### PR TITLE
fix(gotjunk): CRITICAL - Fix Cloud Build secret configuration error

### DIFF
--- a/modules/foundups/gotjunk/cloudbuild.yaml
+++ b/modules/foundups/gotjunk/cloudbuild.yaml
@@ -14,7 +14,7 @@ steps:
     entrypoint: 'npm'
     args: ['run', 'build']
 
-  # Step 3: Deploy to Cloud Run
+  # Step 3: Deploy to Cloud Run with Secret Manager integration
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     dir: 'modules/foundups/gotjunk/frontend'
     entrypoint: 'gcloud'
@@ -26,14 +26,10 @@ steps:
       - '--region=us-west1'
       - '--platform=managed'
       - '--allow-unauthenticated'
-      - '--set-env-vars=GEMINI_API_KEY_GotJunk=$$GEMINI_API_KEY'
+      - '--update-secrets=GEMINI_API_KEY_GotJunk=GEMINI_API_KEY_GOTJUNK:latest'
 
-# Secret Manager integration
-# API key is loaded from Secret Manager and available as $GEMINI_API_KEY
-availableSecrets:
-  secretManager:
-    - versionName: projects/gen-lang-client-0061781628/secrets/GEMINI_API_KEY_GOTJUNK/versions/latest
-      env: 'GEMINI_API_KEY'
+# Cloud Run mounts secrets directly from Secret Manager
+# No availableSecrets/secretEnv needed - Cloud Run accesses Secret Manager directly
 
 # Only trigger on changes to gotjunk module
 options:


### PR DESCRIPTION
## 🔥 CRITICAL BUG FIX

**Error Blocking ALL Deployments**: `secretEnv 'GEMINI_API_KEY' is defined without being used`

## Root Cause
Cloud Build's `secretEnv` + `availableSecrets` is for secrets used **WITHIN build steps**.  
Cloud Run environment variables need `--update-secrets` to mount from Secret Manager directly.

## Fix Applied
```diff
- --set-env-vars=GEMINI_API_KEY_GotJunk=$$GEMINI_API_KEY
- secretEnv: ['GEMINI_API_KEY']  
- availableSecrets:
-   secretManager:
-     - versionName: projects/.../GEMINI_API_KEY_GOTJUNK/versions/latest
-       env: 'GEMINI_API_KEY'

+ --update-secrets=GEMINI_API_KEY_GotJunk=GEMINI_API_KEY_GOTJUNK:latest
```

## How It Works  
Cloud Run mounts the secret **directly from Secret Manager** at runtime.  
No Cloud Build environment variables or `availableSecrets` needed.

## Files Changed
- **modules/foundups/gotjunk/cloudbuild.yaml** (-8 lines, +4 lines): Fixed secret configuration
- **modules/foundups/gotjunk/frontend/App.tsx** (2 lines): Welcome message update

## Testing Plan
1. ✅ Merge PR → Cloud Build trigger activates  
2. ✅ Build should SUCCESS (no more secret error)  
3. ✅ Deployment completes to https://gotjunk-56566376153.us-west1.run.app  
4. ✅ Verify new welcome message appears

## Priority
**P0 - CRITICAL**: Blocks all automatic deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)