### PR TITLE
fix(gotjunk): Temporarily disable IPFS to fix Cloud Build

### DIFF
--- a/modules/foundups/gotjunk/frontend/App.tsx
+++ b/modules/foundups/gotjunk/frontend/App.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { CapturedItem, ItemStatus } from './types';
 import * as storage from './services/storage';
-import * as ipfs from './services/ipfsService';
+// import * as ipfs from './services/ipfsService';
 import { ItemReviewer } from './components/ItemReviewer';
 import { FullscreenGallery } from './components/FullscreenGallery';
 import { BottomNavBar } from './components/BottomNavBar';
@@ -88,13 +88,13 @@ const App: React.FC = () => {
 
   useEffect(() => {
     const initializeApp = async () => {
-      // Initialize IPFS (Helia) for decentralized storage
-      try {
-        await ipfs.initHelia();
-        console.log('[GotJunk] IPFS initialized - decentralized storage ready');
-      } catch (error) {
-        console.error('[GotJunk] IPFS initialization failed:', error);
-      }
+//       // Initialize IPFS (Helia) for decentralized storage
+//       try {
+//         await ipfs.initHelia();
+//         console.log('[GotJunk] IPFS initialized - decentralized storage ready');
+//       } catch (error) {
+//         console.error('[GotJunk] IPFS initialization failed:', error);
+//       }
 
       const allItems = await storage.getAllItems();
 
@@ -260,23 +260,23 @@ const App: React.FC = () => {
         ownership: 'mine' // Ensure ownership is set
       };
 
-      // Upload to IPFS in background for decentralized storage
-      try {
-        console.log('[GotJunk] Uploading to IPFS...');
-        const ipfsCid = await ipfs.uploadToIPFS(item.blob);
-        console.log('[GotJunk] IPFS upload successful:', ipfsCid);
-
-        // Update item with IPFS CID
-        listedItem.ipfsCid = ipfsCid;
-        await storage.updateItemStatus(item.id, 'listed');
-
-        // TODO: Pin item for storage rewards (WSP 98 mesh network)
-        // await ipfs.pinItem(ipfsCid);
-      } catch (error) {
-        console.error('[GotJunk] IPFS upload failed:', error);
-        // Continue with local storage only
-        await storage.updateItemStatus(item.id, 'listed');
-      }
+//       // Upload to IPFS in background for decentralized storage
+//       try {
+//         console.log('[GotJunk] Uploading to IPFS...');
+//         const ipfsCid = await ipfs.uploadToIPFS(item.blob);
+//         console.log('[GotJunk] IPFS upload successful:', ipfsCid);
+// 
+//         // Update item with IPFS CID
+//         listedItem.ipfsCid = ipfsCid;
+//         await storage.updateItemStatus(item.id, 'listed');
+// 
+//         // TODO: Pin item for storage rewards (WSP 98 mesh network)
+//         // await ipfs.pinItem(ipfsCid);
+//       } catch (error) {
+//         console.error('[GotJunk] IPFS upload failed:', error);
+//         // Continue with local storage only
+//         await storage.updateItemStatus(item.id, 'listed');
+//       }
 
       setMyListed(current => [listedItem, ...current]);
     } else {


### PR DESCRIPTION
## Summary
Temporarily disables IPFS (Helia) imports to fix Vite production build in Cloud Build.

## Root Cause
Helia uses Node.js-specific dependencies that Rollup/Vite cannot bundle for browser without polyfills. The `optimizeDeps` config only affects dev mode, not production builds.

## Solution
**Temporary**: Comment out all IPFS usage in App.tsx
- Import statement
- initHelia() initialization  
- uploadToIPFS() calls

## What Works Now
- ✅ Camera capture (photo/video)
- ✅ 4-tab navigation with highlighting
- ✅ Geolocation 50km filtering
- ✅ Local IndexedDB storage
- ✅ Vite production build succeeds

## What's Disabled
- ❌ IPFS decentralized storage
- ❌ Item pinning for storage rewards

## Next Steps (Future PR)
1. Install `vite-plugin-node-polyfills`
2. Configure for browser-compatible Node.js APIs
3. Uncomment IPFS code
4. Test IPFS upload/download

## Test Plan
- [ ] Cloud Build completes successfully
- [ ] App deploys to https://gotjunk.foundups.com/
- [ ] Test on iPhone Safari: camera, tabs, geolocation
- [ ] Verify no console errors related to IPFS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>