### PR TITLE
fix(gotjunk): Remove IPFS chunk configuration

### DIFF
--- a/modules/foundups/gotjunk/frontend/vite.config.ts
+++ b/modules/foundups/gotjunk/frontend/vite.config.ts
@@ -24,19 +24,11 @@ export default defineConfig(({ mode }) => {
         }
       },
       optimizeDeps: {
-        include: ['leaflet', 'react-leaflet', 'helia', '@helia/unixfs', '@helia/strings', 'blockstore-idb', 'multiformats']
+        include: ['leaflet', 'react-leaflet']
       },
       build: {
         commonjsOptions: {
           transformMixedEsModules: true
-        },
-        rollupOptions: {
-          external: [],
-          output: {
-            manualChunks: {
-              'ipfs': ['helia', '@helia/unixfs', '@helia/strings', 'blockstore-idb', 'multiformats']
-            }
-          }
         }
       }
     };


### PR DESCRIPTION
Removes IPFS packages from vite build config since IPFS is disabled. Fixes 'Could not resolve entry module helia' error.