### PR TITLE
feat(gotjunk): Responsive camera orb for iPhone 11/16

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/BottomNavBar.tsx
+++ b/modules/foundups/gotjunk/frontend/components/BottomNavBar.tsx
@@ -118,9 +118,13 @@ export const BottomNavBar: React.FC<BottomNavBarProps> = ({
     >
       {/* Camera Orb - Floating above nav bar */}
       <div className="absolute left-1/2 -translate-x-1/2 bottom-32 flex flex-col items-center z-[100]">
-          {/* Main capture button with live preview - 2.5x bigger (260px) */}
+          {/* Main capture button with live preview - Intelligent scaling: iPhone 11=197px, iPhone 16=205px */}
           <div
-            className="w-[260px] h-[260px] p-2 bg-gray-800 rounded-full shadow-2xl cursor-pointer"
+            className="p-2 bg-gray-800 rounded-full shadow-2xl cursor-pointer"
+            style={{
+              width: 'clamp(180px, 22vh, 260px)',
+              height: 'clamp(180px, 22vh, 260px)'
+            }}
             onMouseDown={handlePressStart}
             onMouseUp={handlePressEnd}
             onTouchStart={handlePressStart}


### PR DESCRIPTION
## Summary
Fixed camera orb being too large on iPhone 11. Now intelligently scales based on viewport height.

## Problem
Camera orb was fixed at 260px, which took up ~29% of iPhone 11 screen (too large).

## Solution
Use CSS `clamp()` for responsive sizing:
```css
width: clamp(180px, 22vh, 260px)
height: clamp(180px, 22vh, 260px)
```

## Results

**iPhone 11** (896px height):
- Before: 260px (29% of screen)
- After: ~197px (22% of screen) ✅

**iPhone 16 Pro Max** (932px height):
- After: ~205px (22% of screen) ✅

**Desktop/Tablets**:
- Capped at 260px max

## Testing
- [x] Local dev server builds successfully  
- [x] No TypeScript errors
- [x] Camera orb responsive on all screen sizes
- [ ] Test on iPhone 11 after deployment
- [ ] Test on iPhone 16 after deployment

## Note
Filter buttons (All/Photos/Videos) will be added in next PR - keeping this focused on the critical responsive sizing fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)