### PR TITLE
feat(gotjunk): Double-tap fullscreen, classification system, UI fixes

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/PhotoCard.tsx
+++ b/modules/foundups/gotjunk/frontend/components/PhotoCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { motion } from 'framer-motion';
 import { CapturedItem } from '../types';
 import { TrashIcon } from './icons/TrashIcon';
@@ -17,10 +17,24 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({ item, onClick, onDelete })
     onDelete(item);
   };
   
+  // Double-tap detection for fullscreen
+  const lastTapRef = useRef<number>(0);
+
+  const handleCardClick = () => {
+    const now = Date.now();
+    const DOUBLE_TAP_DELAY = 300; // ms
+
+    if (now - lastTapRef.current < DOUBLE_TAP_DELAY) {
+      // Double tap detected - open fullscreen
+      onClick(item);
+    }
+    lastTapRef.current = now;
+  };
+
   const isVideo = item.blob.type.startsWith('video/');
 
   return (
-    <div className="relative group aspect-square w-full rounded-lg overflow-hidden bg-gray-800 shadow-md cursor-pointer" onClick={() => onClick(item)}>
+    <div className="relative group aspect-square w-full rounded-lg overflow-hidden bg-gray-800 shadow-md cursor-pointer" onClick={handleCardClick}>
       {isVideo ? (
          <video
             src={item.url}


### PR DESCRIPTION
## Summary
Complete GotJunk UX improvements for iPhone 11 and classification workflow:

### UI Fixes
- Move landing text to top-8 (32px from top) to prevent sidebar overlap
- Camera orb sized for iPhone 11 compatibility (20% smaller via responsive clamp)
- Left sidebar moved up 50px to prevent search bar overlap

### Classification System (Modular Architecture)
**New Components**:
- `FreeIcon.tsx` - Gift box SVG (blue, minimal stroke style)
- `DiscountIcon.tsx` - Price tag SVG (green)
- `BidIcon.tsx` - Gavel SVG (amber)
- `ClassificationModal.tsx` - Post-capture popup with 3 classification buttons
- `ClassificationBadge.tsx` - Grid thumbnail overlay showing classification + price

**Features**:
- Post-capture modal blocks save until user selects classification
- Auto-pricing: Free=$0, Discount=75% OFF, Bid=50% OFF
- Badge overlays on My Items grid thumbnails
- Icons match existing minimal stroke-based style

### Double-Tap Fullscreen
- Added double-tap detection to PhotoCard (300ms window)
- Double-tap on My Items thumbnail opens fullscreen view
- Reuses existing ItemReviewer component per Occam's Razor

## WSP Compliance
- ✅ WSP 50: HoloIndex search before implementation
- ✅ WSP 3: Modular component architecture
- ✅ First principles: Reused ItemReviewer instead of building new component
- ✅ Occam's Razor: Simplest solution for fullscreen (double-tap + existing component)

## Test Plan
- [ ] Verify landing text visible at top of screen (no sidebar overlap)
- [ ] Test camera orb size on iPhone 11 (should be ~143px)
- [ ] Capture photo → classification modal appears
- [ ] Select Free/Discount/Bid → item saves with correct price
- [ ] View My Items grid → badges show on thumbnails
- [ ] Double-tap thumbnail → opens fullscreen view
- [ ] Verify Cloud Run deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>