### PR TITLE
HOTFIX: Classification modal tap gestures not working

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/ClassificationModal.tsx
+++ b/modules/foundups/gotjunk/frontend/components/ClassificationModal.tsx
@@ -123,11 +123,9 @@ export const ClassificationModal: React.FC<ClassificationModalProps> = ({
             </motion.button>
 
             {/* Discount button - tap or long-press */}
-            <motion.button
-              whileHover={{ scale: 1.03 }}
-              whileTap={{ scale: 0.97 }}
+            <button
               {...discountLongPress}
-              className="w-full flex items-center justify-between p-5 bg-green-500/20 hover:bg-green-500/30 border-2 border-green-400 rounded-2xl transition-all shadow-lg shadow-green-500/20"
+              className="w-full flex items-center justify-between p-5 bg-green-500/20 hover:bg-green-500/30 active:scale-95 border-2 border-green-400 rounded-2xl transition-all shadow-lg shadow-green-500/20"
               style={{
                 touchAction: 'manipulation', // iOS Safari optimization
               }}
@@ -142,14 +140,12 @@ export const ClassificationModal: React.FC<ClassificationModalProps> = ({
                 </div>
               </div>
               <span className="text-lg font-bold text-green-400">{discountPercent}% OFF</span>
-            </motion.button>
+            </button>
 
             {/* Bid button - tap or long-press */}
-            <motion.button
-              whileHover={{ scale: 1.03 }}
-              whileTap={{ scale: 0.97 }}
+            <button
               {...bidLongPress}
-              className="w-full flex items-center justify-between p-5 bg-amber-500/20 hover:bg-amber-500/30 border-2 border-amber-400 rounded-2xl transition-all shadow-lg shadow-amber-500/20"
+              className="w-full flex items-center justify-between p-5 bg-amber-500/20 hover:bg-amber-500/30 active:scale-95 border-2 border-amber-400 rounded-2xl transition-all shadow-lg shadow-amber-500/20"
               style={{
                 touchAction: 'manipulation', // iOS Safari optimization
               }}
@@ -164,7 +160,7 @@ export const ClassificationModal: React.FC<ClassificationModalProps> = ({
                 </div>
               </div>
               <span className="text-lg font-bold text-amber-400">{bidDurationHours}h</span>
-            </motion.button>
+            </button>
           </div>
 
           {/* Helper text */}


### PR DESCRIPTION
## Critical Hotfix for PR #31

**Issue**: Taps on Discount/Bid buttons not registering - users cannot select classification options

**Root Cause**: Framer Motion's `whileTap` gesture handler was consuming tap events before custom `useLongPress` handlers could process them.

**Fix**:
- Changed Discount/Bid buttons from `motion.button` to plain `button`
- Removed `whileTap` and `whileHover` props (gesture handler conflict)
- Added `active:scale-95` CSS class for visual feedback
- Custom pointer event handlers now receive events correctly

**Impact**:
- ✅ Single tap now works: Selects classification immediately
- ✅ Long-press still works: Opens action sheets for customization
- ✅ Visual feedback maintained via CSS transitions

**Testing**:
- Verified buttons respond to tap events
- No more gesture handler conflicts
- Action sheets open on long-press (450ms)

**Priority**: CRITICAL - Classification modal completely broken without this fix

Fixes broken functionality introduced in PR #31
