### PR TITLE
fix(gotjunk): Delete items from IndexedDB when removed from grid

### DIFF
--- a/modules/foundups/gotjunk/frontend/App.tsx
+++ b/modules/foundups/gotjunk/frontend/App.tsx
@@ -483,7 +483,10 @@ const currentReviewItem = myDrafts.length > 0 ? myDrafts[0] : null;
                 setReviewingItem(item);
                 setReviewQueue(remainingItems);
               }}
-              onDelete={(item) => {
+              onDelete={async (item) => {
+                // Delete from storage and update state
+                URL.revokeObjectURL(item.url);
+                await storage.deleteItem(item.id);
                 if (item.status === 'draft') {
                   setMyDrafts(prev => prev.filter(i => i.id !== item.id));
                 } else {


### PR DESCRIPTION
## Summary
Fixed PhotoGrid delete handler to persist deletions to IndexedDB storage, not just React state.

## Problem
When users deleted items from the photo grid, the items would disappear temporarily but reappear after page refresh. This was because the `onDelete` handler only updated React state without removing the item from IndexedDB.

## Root Cause
```typescript
// BEFORE (broken):
onDelete={(item) => {
  if (item.status === 'draft') {
    setMyDrafts(prev => prev.filter(i => i.id !== item.id));
  } else {
    setMyListed(prev => prev.filter(i => i.id !== item.id));
  }
}}
```

Missing operations:
1. ❌ `storage.deleteItem(item.id)` - IndexedDB deletion
2. ❌ `URL.revokeObjectURL(item.url)` - Memory cleanup

## Fix
```typescript
// AFTER (fixed):
onDelete={async (item) => {
  // Delete from storage and update state
  URL.revokeObjectURL(item.url);
  await storage.deleteItem(item.id);
  if (item.status === 'draft') {
    setMyDrafts(prev => prev.filter(i => i.id !== item.id));
  } else {
    setMyListed(prev => prev.filter(i => i.id !== item.id));
  }
}}
```

Now matches the pattern from `handleDeleteMyItem` used in FullscreenGallery.

## Testing
✅ Delete item from grid → item disappears
✅ Refresh page → item stays deleted
✅ No memory leaks (blob URLs revoked)

## Files Changed
- [App.tsx:486-495](modules/foundups/gotjunk/frontend/App.tsx#L486-L495) - Added IndexedDB deletion to PhotoGrid handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)