### PR TITLE
fix(gotjunk): Raise sidebar z-index to stay above fullscreen images

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/LeftSidebarNav.tsx
+++ b/modules/foundups/gotjunk/frontend/components/LeftSidebarNav.tsx
@@ -53,7 +53,7 @@ export const LeftSidebarNav: React.FC<LeftSidebarNavProps> = ({
     <motion.div
       initial={{ opacity: 0, x: -50 }}
       animate={{ opacity: 1, x: 0 }}
-      className="fixed left-6 z-40 flex flex-col items-center space-y-6"
+      className="fixed left-6 z-60 flex flex-col items-center space-y-6"
       style={{ top: 'calc(50% - 150px)', transform: 'translateY(-50%)' }}
     >
       {/* Liberty Alert - Top of sidebar */}


### PR DESCRIPTION
## Summary
Fixed sidebar navigation icons rendering underneath expanded/zoomed images by raising z-index from 40 to 60.

## Problem
User reported: "When an image expands (full or zoomed), the sidebar + control icons render underneath the image instead of staying on top."

**Visual bug**:
- Expand an image to fullscreen
- Left sidebar icons (🏠📍📦🛒) disappear behind the image
- Bottom nav bar stays visible (correct behavior)

## Root Cause

**Z-index conflict:**
```typescript
LeftSidebarNav: z-40    ← SAME as fullscreen!
FullscreenGallery: z-40  ← Covers sidebar
BottomNavBar: z-50      ← Stays on top (correct)
```

When two elements have the same z-index, browser renders in DOM order:
1. Sidebar renders first
2. Fullscreen renders second → covers sidebar

## Solution

Raised sidebar z-index to stay above fullscreen images:

```diff
- className="fixed left-6 z-40 flex flex-col..."
+ className="fixed left-6 z-60 flex flex-col..."
```

## New Z-Index Hierarchy

```
OptionsModal: z-[300]          ← Top layer (modals)
ActionSheets: z-[250]          
ClassificationModal: z-[200]   
LeftSidebarNav: z-60           ← Fixed! Always visible
BottomNavBar: z-50             ← Always visible
FullscreenGallery: z-40        ← Background
```

## Testing

Before fix:
- [ ] Expand image → sidebar disappears ❌

After fix:
- [ ] Expand image → sidebar stays visible ✅
- [ ] Bottom nav stays visible ✅
- [ ] Modals still appear on top ✅

## Files Changed

- [LeftSidebarNav.tsx:56](modules/foundups/gotjunk/frontend/components/LeftSidebarNav.tsx#L56) - Changed z-40 → z-60

🤖 Generated with [Claude Code](https://claude.com/claude-code)