### PR TITLE
fix(gotjunk): Fix icon visibility on map with dark backgrounds

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/LeftSidebarNav.tsx
+++ b/modules/foundups/gotjunk/frontend/components/LeftSidebarNav.tsx
@@ -79,7 +79,7 @@ export const LeftSidebarNav: React.FC<LeftSidebarNavProps> = ({
         className={`p-4 rounded-2xl backdrop-blur-md shadow-xl transition-all ${
           activeTab === 'browse'
             ? 'bg-blue-500/70 ring-2 ring-blue-400 shadow-blue-500/50 border-2 border-blue-300'
-            : 'bg-white/90 hover:bg-white border-2 border-gray-300 shadow-2xl'
+            : 'bg-gray-800/90 hover:bg-gray-700/90 border-2 border-gray-600 shadow-2xl'
         }`}
       >
         <GridIcon className="w-8 h-8 text-white" />
@@ -94,7 +94,7 @@ export const LeftSidebarNav: React.FC<LeftSidebarNavProps> = ({
         className={`p-4 rounded-2xl backdrop-blur-md shadow-xl transition-all ${
           activeTab === 'map'
             ? 'bg-blue-500/70 ring-2 ring-blue-400 shadow-blue-500/50 border-2 border-blue-300'
-            : 'bg-white/90 hover:bg-white border-2 border-gray-300 shadow-2xl'
+            : 'bg-gray-800/90 hover:bg-gray-700/90 border-2 border-gray-600 shadow-2xl'
         }`}
       >
         <MapIcon className="w-8 h-8 text-white" />
@@ -109,7 +109,7 @@ export const LeftSidebarNav: React.FC<LeftSidebarNavProps> = ({
         className={`p-4 rounded-2xl backdrop-blur-md shadow-xl transition-all ${
           activeTab === 'myitems'
             ? 'bg-blue-500/70 ring-2 ring-blue-400 shadow-blue-500/50 border-2 border-blue-300'
-            : 'bg-white/90 hover:bg-white border-2 border-gray-300 shadow-2xl'
+            : 'bg-gray-800/90 hover:bg-gray-700/90 border-2 border-gray-600 shadow-2xl'
         }`}
       >
         <HomeIcon className="w-8 h-8 text-white" />
@@ -124,7 +124,7 @@ export const LeftSidebarNav: React.FC<LeftSidebarNavProps> = ({
         className={`p-4 rounded-2xl backdrop-blur-md shadow-xl transition-all ${
           activeTab === 'cart'
             ? 'bg-blue-500/70 ring-2 ring-blue-400 shadow-blue-500/50 border-2 border-blue-300'
-            : 'bg-white/90 hover:bg-white border-2 border-gray-300 shadow-2xl'
+            : 'bg-gray-800/90 hover:bg-gray-700/90 border-2 border-gray-600 shadow-2xl'
         }`}
       >
         <CartIcon className="w-8 h-8 text-white" />

--- a/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
+++ b/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
@@ -92,14 +92,14 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
       <div className="absolute top-24 right-4 z-40 flex flex-col gap-2">
         <button
           onClick={() => setZoom(Math.min(zoom + 1, 18))}
-          className="bg-white hover:bg-gray-50 text-black text-2xl w-10 h-10 rounded-lg shadow-2xl border-2 border-gray-300 font-bold"
+          className="bg-gray-800 hover:bg-gray-700 text-white text-2xl w-10 h-10 rounded-lg shadow-2xl border-2 border-gray-600 font-bold"
           title="Zoom In"
         >
           +
         </button>
         <button
           onClick={() => setZoom(Math.max(zoom - 1, 1))}
-          className="bg-white hover:bg-gray-50 text-black text-2xl w-10 h-10 rounded-lg shadow-2xl border-2 border-gray-300 font-bold"
+          className="bg-gray-800 hover:bg-gray-700 text-white text-2xl w-10 h-10 rounded-lg shadow-2xl border-2 border-gray-600 font-bold"
           title="Zoom Out"
         >
           −
@@ -110,7 +110,7 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
               // Center map on user location
               window.location.reload(); // Simple way to recenter
             }}
-            className="bg-white hover:bg-gray-50 text-black text-xl w-10 h-10 rounded-lg shadow-2xl border-2 border-gray-300"
+            className="bg-gray-800 hover:bg-gray-700 text-white text-xl w-10 h-10 rounded-lg shadow-2xl border-2 border-gray-600"
             title="Center on Me"
           >
             📍
@@ -119,7 +119,7 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
         {isGlobalView && (
           <button
             onClick={() => setZoom(2)} // Reset to global view
-            className="bg-white hover:bg-gray-50 text-black text-xl w-10 h-10 rounded-lg shadow-2xl border-2 border-gray-300"
+            className="bg-gray-800 hover:bg-gray-700 text-white text-xl w-10 h-10 rounded-lg shadow-2xl border-2 border-gray-600"
             title="Reset Global View"
           >
             🌍
@@ -240,7 +240,7 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
         {/* Legend Toggle Button */}
         <button
           onClick={() => setLegendExpanded(!legendExpanded)}
-          className="bg-white hover:bg-gray-50 backdrop-blur rounded-full w-12 h-12 shadow-2xl border-2 border-gray-300 flex items-center justify-center transition-all"
+          className="bg-gray-800 hover:bg-gray-700 backdrop-blur rounded-full w-12 h-12 shadow-2xl border-2 border-gray-600 flex items-center justify-center transition-all"
           title="Toggle Legend"
         >
           <span className="text-2xl">{legendExpanded ? '✕' : 'ℹ️'}</span>


### PR DESCRIPTION
## Summary
Fixed white-on-white visibility issue where navigation and map control icons were invisible against light map backgrounds.

## Changes
- **LeftSidebarNav.tsx**: Changed all 4 navigation buttons from `bg-white/90` to `bg-gray-800/90`
- **PigeonMapView.tsx**: Changed all 5 control buttons (zoom, center, legend) from `bg-white` to `bg-gray-800`
- White icons now clearly visible on dark gray backgrounds
- Dark backgrounds provide strong contrast against light map tile areas

## User Feedback Addressed
> "1st is the new the 2nd the better old version... also the icon no longer display on the map view... maybe we need the icons to be another color other than white? need a lite color background and not white on white"

## Test Plan
- ✅ Icons visible on map view
- ✅ Dark gray backgrounds provide contrast against light map tiles
- ✅ Hover states work properly (bg-gray-700)
- ✅ Active state (blue) still distinguishable from inactive (gray)

🤖 Generated with [Claude Code](https://claude.com/claude-code)