### PR TITLE
fix(gotjunk): Map no longer covers sidebar icons

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
+++ b/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
@@ -81,7 +81,7 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
 
   return (
     <div
-      className="fixed top-0 left-0 right-0 bottom-32 bg-black"
+      className="fixed top-0 left-20 sm:left-24 right-0 bottom-32 bg-black"
       style={{
         zIndex: Z_LAYERS.mapOverlay,
         touchAction: "pan-x pan-y pinch-zoom",


### PR DESCRIPTION
## Problem

Sidebar navigation icons were not visible on map view - users reported "there is no icons on the map".

## Root Cause

PigeonMapView container was `fixed left-0 right-0`, covering entire viewport width and physically hiding sidebar icons despite correct z-index layering (sidebar 2200 > map 1600).

## Solution

Changed map container from `left-0` to `left-20 sm:left-24` to leave space for sidebar:
- Mobile: 80px left padding (5rem = left-20)
- Desktop: 96px left padding (6rem = left-24 via sm: breakpoint)
- Matches LeftSidebarNav positioning at `left-4 sm:left-6`

## Verification

- ✅ Build successful: 413.53 kB │ gzip: 130.12 kB
- ✅ Sidebar icons now have physical space to render on left side
- ✅ Map still fills remaining viewport width
- ✅ Z-index contract maintained (sidebar 2200, map 1600)

## Files Changed

- `modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx` (1 line)

## Test Plan

- [ ] Open GotJunk app
- [ ] Click Map icon in left sidebar
- [ ] Verify all 4 sidebar icons (Browse, Map, My Items, Cart) are visible on left side
- [ ] Verify icons are clickable and functional
- [ ] Test on mobile (iPhone 11/13/15) and desktop viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)