### PR TITLE
feat(gotjunk): Consistent sidebar icon styling across all views

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/LeftSidebarNav.tsx
+++ b/modules/foundups/gotjunk/frontend/components/LeftSidebarNav.tsx
@@ -50,18 +50,14 @@ export const LeftSidebarNav: React.FC<LeftSidebarNavProps> = ({
     onGalleryClick();
   };
 
-  // Adaptive icon styling for map view visibility
-  // Map tiles vary (white streets, dark parks, blue water) - inactive icons need high contrast
-  const isMapView = activeTab === 'map';
+  // Consistent icon styling across all views (home, map, etc)
   const getButtonStyle = (isActive: boolean) => {
     if (isActive) {
-      // Active state: bright blue with ring (always visible)
+      // Active state: bright blue with ring
       return 'bg-blue-500/70 ring-2 ring-blue-400 shadow-blue-500/50 border-2 border-blue-300';
     }
-    // Inactive state: high-contrast for map view, subtle for other views
-    return isMapView
-      ? 'bg-indigo-600/85 hover:bg-indigo-500/90 border-2 border-indigo-400 shadow-2xl shadow-indigo-900/60'
-      : 'bg-gray-800/90 hover:bg-gray-700/90 border-2 border-gray-600 shadow-2xl';
+    // Inactive state: dark gray background (same for all views)
+    return 'bg-gray-800/90 hover:bg-gray-700/90 border-2 border-gray-600 shadow-2xl';
   };
 
   return (


### PR DESCRIPTION
## User Request

"use the same buttons on the map as on the home"

## Change

Removed adaptive styling that changed icon backgrounds on map view. All views now use consistent dark gray backgrounds for inactive icons.

## Before

- Home/Browse: `bg-gray-800/90` (dark gray)
- Map: `bg-indigo-600/85` (indigo) - different color

## After

- All views: `bg-gray-800/90` (dark gray) - consistent styling

## Files Changed

- `modules/foundups/gotjunk/frontend/components/LeftSidebarNav.tsx` (simplified getButtonStyle function)

## Build

✅ 413.41 kB │ gzip: 130.08 kB

## Test Plan

- [ ] Open GotJunk app
- [ ] Note sidebar icon styling on home/browse view
- [ ] Click Map icon
- [ ] Verify sidebar icons have SAME styling on map view (not different colors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)