### PR TITLE
Revert to PR #43 state - adaptive indigo sidebar on map

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/LeftSidebarNav.tsx
+++ b/modules/foundups/gotjunk/frontend/components/LeftSidebarNav.tsx
@@ -50,14 +50,18 @@ export const LeftSidebarNav: React.FC<LeftSidebarNavProps> = ({
     onGalleryClick();
   };
 
-  // Consistent icon styling across all views (home, map, etc)
+  // Adaptive icon styling for map view visibility
+  // Map tiles vary (white streets, dark parks, blue water) - inactive icons need high contrast
+  const isMapView = activeTab === 'map';
   const getButtonStyle = (isActive: boolean) => {
     if (isActive) {
-      // Active state: bright blue with ring
+      // Active state: bright blue with ring (always visible)
       return 'bg-blue-500/70 ring-2 ring-blue-400 shadow-blue-500/50 border-2 border-blue-300';
     }
-    // Inactive state: dark gray background (same for all views)
-    return 'bg-gray-800/90 hover:bg-gray-700/90 border-2 border-gray-600 shadow-2xl';
+    // Inactive state: high-contrast for map view, subtle for other views
+    return isMapView
+      ? 'bg-indigo-600/85 hover:bg-indigo-500/90 border-2 border-indigo-400 shadow-2xl shadow-indigo-900/60'
+      : 'bg-gray-800/90 hover:bg-gray-700/90 border-2 border-gray-600 shadow-2xl';
   };
 
   return (

--- a/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
+++ b/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
@@ -81,7 +81,7 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
 
   return (
     <div
-      className="fixed top-0 left-20 sm:left-24 right-0 bottom-32 bg-black"
+      className="fixed top-0 left-0 right-0 bottom-32 bg-black"
       style={{
         zIndex: Z_LAYERS.mapOverlay,
         touchAction: "pan-x pan-y pinch-zoom",


### PR DESCRIPTION
## User Request

"revert to that one" - pointing to commit 54ab367e (PR #43 deployment from 11/9/25 at 2:06 AM)

## Reverted Changes

### LeftSidebarNav
- ✅ Restored adaptive styling with `isMapView` logic
- Map view: inactive icons use bright indigo (`bg-indigo-600/85`)
- Other views: inactive icons use dark gray (`bg-gray-800/90`)

### PigeonMapView
- ✅ Reverted map container to `left-0` (full width, no padding)

## Files Restored from 54ab367e

- `modules/foundups/gotjunk/frontend/components/LeftSidebarNav.tsx`
- `modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx`

## Build

✅ 413.51 kB │ gzip: 130.11 kB

## Test Plan

- [ ] Open GotJunk app
- [ ] Click Map icon
- [ ] Verify sidebar icons have bright indigo backgrounds on map view
- [ ] Verify icons are visible and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)