### PR TITLE
fix(gotjunk): Close map on item click + black sidebar backgrounds

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/LeftSidebarNav.tsx
+++ b/modules/foundups/gotjunk/frontend/components/LeftSidebarNav.tsx
@@ -58,9 +58,9 @@ export const LeftSidebarNav: React.FC<LeftSidebarNavProps> = ({
       // Active state: bright blue with ring (always visible)
       return 'bg-blue-500/70 ring-2 ring-blue-400 shadow-blue-500/50 border-2 border-blue-300';
     }
-    // Inactive state: high-contrast for map view, subtle for other views
+    // Inactive state: black background for map view, dark gray for other views
     return isMapView
-      ? 'bg-indigo-600/85 hover:bg-indigo-500/90 border-2 border-indigo-400 shadow-2xl shadow-indigo-900/60'
+      ? 'bg-black/90 hover:bg-gray-900/90 border-2 border-white shadow-2xl shadow-black/80'
       : 'bg-gray-800/90 hover:bg-gray-700/90 border-2 border-gray-600 shadow-2xl';
   };
 

--- a/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
+++ b/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
@@ -172,7 +172,7 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
             width={30}
             anchor={[item.location.latitude, item.location.longitude]}
             color={getMarkerColor(item.status)}
-            onClick={() => setSelectedItem(item)}
+            onClick={onClose}
           />
         ))}
 


### PR DESCRIPTION
## User Requests

1. "when i select the item the map should close atm the map is staying open"
2. "on the map make the background black not indigo... all should be black background on the sidebar"

## Changes

### 1. Map closes immediately when item clicked ✅
- Changed GotJunk item marker onClick from `setSelectedItem(item)` to `onClose`
- **Before**: Click item → popup overlay shows → map stays open
- **After**: Click item → map closes immediately

### 2. Black sidebar backgrounds on map view ✅
- Changed inactive button styling on map from indigo to black
- **Before**: `bg-indigo-600/85` (purple/indigo)
- **After**: `bg-black/90` with white borders (high contrast black)

## Files Changed

- `modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx` (line 175 - item onClick handler)
- `modules/foundups/gotjunk/frontend/components/LeftSidebarNav.tsx` (line 63 - black backgrounds)

## Build

✅ 413.49 kB │ gzip: 130.10 kB

## Test Plan

- [ ] Open GotJunk app
- [ ] Click Map icon in sidebar
- [ ] Verify sidebar buttons have black backgrounds (not indigo)
- [ ] Click any GotJunk item marker on map
- [ ] Verify map closes immediately (not popup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)