### PR TITLE
fix(gotjunk): Browse button now always responsive (remove SOS block)

### DIFF
--- a/modules/foundups/gotjunk/frontend/App.tsx
+++ b/modules/foundups/gotjunk/frontend/App.tsx
@@ -585,10 +585,13 @@ const currentReviewItem = myDrafts.length > 0 ? myDrafts[0] : null;
       <LeftSidebarNav
         activeTab={activeTab}
         onGalleryClick={() => {
-          if (!sosDetectionActive.current) {
-            setActiveTab('browse'); // Tab 1: Browse
-            setMapOpen(false); // Close map when switching to Browse
-          }
+          // Always reset SOS detection and clear timeout (same as Map button)
+          setTapTimes([]);
+          sosDetectionActive.current = false;
+          if (tapTimeoutRef.current) clearTimeout(tapTimeoutRef.current);
+          // Navigate to Browse
+          setActiveTab('browse'); // Tab 1: Browse
+          setMapOpen(false); // Close map when switching to Browse
         }}
         onGalleryIconTap={(duration) => {
           const SHORT_TAP = 200;


### PR DESCRIPTION
## Problem

User reported: **"landing page button from maps doesnt always work"** - clicking Browse icon after rapid navigation caused button to hang/not respond. Issue confirmed to only affect Browse/Landing Page icon, not My Items or Cart.

## Root Cause

The Browse button had a guard clause blocking clicks during SOS detection:

```tsx
onGalleryClick={() => {
  if (!sosDetectionActive.current) { // ❌ Blocks clicks!
    setActiveTab('browse');
    setMapOpen(false);
  }
}}
```

**What caused the hang**:
1. Tap Browse icon → `onGalleryIconTap` handler sets `sosDetectionActive.current = true` (line 598)
2. sosDetectionActive stays true for **3 seconds** (timeout on line 615-618)
3. Any Browse clicks within 3 seconds were **BLOCKED** by guard clause on line 588
4. My Items/Cart buttons worked fine (no guard clause)

## Solution

Removed guard clause and added immediate SOS detection reset - same pattern used by Map button:

```tsx
onGalleryClick={() => {
  // Always reset SOS detection (same as Map button)
  setTapTimes([]);
  sosDetectionActive.current = false;
  if (tapTimeoutRef.current) clearTimeout(tapTimeoutRef.current);
  // Navigate to Browse
  setActiveTab('browse');
  setMapOpen(false);
}}
```

## Behavior Now

✅ **Browse button ALWAYS responds immediately**
✅ **No 3-second hang/delay** when clicking back and forth
✅ **SOS detection properly reset** when user navigates away
✅ **Consistent behavior** with Map/MyItems/Cart buttons

## Files Changed

- `modules/foundups/gotjunk/frontend/App.tsx` (lines 587-595 - Browse button handler)

## Build

✅ 413.55 kB │ gzip: 130.09 kB

## Test Plan

- [ ] Open GotJunk app
- [ ] Click Map icon → map opens
- [ ] Click Browse icon rapidly 5+ times → verify it ALWAYS closes map and switches to Browse
- [ ] No delays or hanging
- [ ] Works immediately every time

🤖 Generated with [Claude Code](https://claude.com/claude-code)