### PR TITLE
feat(gotjunk): Hide sidebar on map + bold X button matching sidebar style

### DIFF
--- a/modules/foundups/gotjunk/frontend/App.tsx
+++ b/modules/foundups/gotjunk/frontend/App.tsx
@@ -586,64 +586,66 @@ const currentReviewItem = myDrafts.length > 0 ? myDrafts[0] : null;
         )}
       </div>
 
-      {/* Left sidebar navigation */}
-      <LeftSidebarNav
-        activeTab={activeTab}
-        onGalleryClick={() => {
-          // Always reset SOS detection and clear timeout (same as Map button)
-          setTapTimes([]);
-          sosDetectionActive.current = false;
-          if (tapTimeoutRef.current) clearTimeout(tapTimeoutRef.current);
-          // Navigate to Browse
-          setActiveTab('browse'); // Tab 1: Browse
-          setMapOpen(false); // Close map when switching to Browse
-        }}
-        onGalleryIconTap={(duration) => {
-          const SHORT_TAP = 200;
-          setTapTimes(prev => {
-            const newTaps = [...prev, duration];
-            if (newTaps.length > 0) {
-              sosDetectionActive.current = true;
-            }
-            if (newTaps.length > 9) newTaps.shift();
-            if (newTaps.length === 9) {
-              const pattern = newTaps.map(d => d < SHORT_TAP ? 'S' : 'L').join('');
-              console.log('🔍 SOS Pattern:', pattern);
-              if (pattern === 'SSSLLLSSS') {
-                console.log('🗽 SOS DETECTED!');
-                setLibertyEnabled(true);
-                alert('🗽 Liberty Alert Unlocked!');
-                sosDetectionActive.current = false;
-                return [];
-              }
-            }
-            return newTaps;
-          });
-          if (tapTimeoutRef.current) clearTimeout(tapTimeoutRef.current);
-          tapTimeoutRef.current = window.setTimeout(() => {
+      {/* Left sidebar navigation - hidden when map is open (map has X button) */}
+      {!isMapOpen && (
+        <LeftSidebarNav
+          activeTab={activeTab}
+          onGalleryClick={() => {
+            // Always reset SOS detection and clear timeout (same as Map button)
             setTapTimes([]);
             sosDetectionActive.current = false;
-          }, 3000);
-        }}
-        onMapClick={() => {
-          setTapTimes([]);
-          sosDetectionActive.current = false;
-          if (tapTimeoutRef.current) clearTimeout(tapTimeoutRef.current);
-          setActiveTab('map'); // Tab 2: Map
-          setMapOpen(true);
-        }}
-        onMyItemsClick={() => {
-          setActiveTab('myitems'); // Tab 3: My Items
-          setMapOpen(false); // Close map when switching to My Items
-          console.log('📦 My Items clicked');
-        }}
-        onCartClick={() => {
-          setActiveTab('cart'); // Tab 4: Cart
-          setMapOpen(false); // Close map when switching to Cart
-          console.log('🛒 Cart clicked');
-        }}
-        libertyEnabled={libertyEnabled}
-      />
+            if (tapTimeoutRef.current) clearTimeout(tapTimeoutRef.current);
+            // Navigate to Browse
+            setActiveTab('browse'); // Tab 1: Browse
+            setMapOpen(false); // Close map when switching to Browse
+          }}
+          onGalleryIconTap={(duration) => {
+            const SHORT_TAP = 200;
+            setTapTimes(prev => {
+              const newTaps = [...prev, duration];
+              if (newTaps.length > 0) {
+                sosDetectionActive.current = true;
+              }
+              if (newTaps.length > 9) newTaps.shift();
+              if (newTaps.length === 9) {
+                const pattern = newTaps.map(d => d < SHORT_TAP ? 'S' : 'L').join('');
+                console.log('🔍 SOS Pattern:', pattern);
+                if (pattern === 'SSSLLLSSS') {
+                  console.log('🗽 SOS DETECTED!');
+                  setLibertyEnabled(true);
+                  alert('🗽 Liberty Alert Unlocked!');
+                  sosDetectionActive.current = false;
+                  return [];
+                }
+              }
+              return newTaps;
+            });
+            if (tapTimeoutRef.current) clearTimeout(tapTimeoutRef.current);
+            tapTimeoutRef.current = window.setTimeout(() => {
+              setTapTimes([]);
+              sosDetectionActive.current = false;
+            }, 3000);
+          }}
+          onMapClick={() => {
+            setTapTimes([]);
+            sosDetectionActive.current = false;
+            if (tapTimeoutRef.current) clearTimeout(tapTimeoutRef.current);
+            setActiveTab('map'); // Tab 2: Map
+            setMapOpen(true);
+          }}
+          onMyItemsClick={() => {
+            setActiveTab('myitems'); // Tab 3: My Items
+            setMapOpen(false); // Close map when switching to My Items
+            console.log('📦 My Items clicked');
+          }}
+          onCartClick={() => {
+            setActiveTab('cart'); // Tab 4: Cart
+            setMapOpen(false); // Close map when switching to Cart
+            console.log('🛒 Cart clicked');
+          }}
+          libertyEnabled={libertyEnabled}
+        />
+      )}
 
       {/* Bottom navigation bar */}
 

--- a/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
+++ b/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
@@ -100,10 +100,14 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
           </h2>
           <button
             onClick={onClose}
-            className="text-white text-3xl hover:text-red-500 transition-colors"
+            className="grid place-items-center rounded-2xl backdrop-blur-md shadow-2xl transition-all bg-black/90 hover:bg-gray-900/90 border-2 border-white shadow-black/80"
+            style={{
+              width: 'var(--sb-size)',
+              height: 'var(--sb-size)',
+            }}
             title="Close Map"
           >
-            ✕
+            <span className="text-white text-2xl font-bold">✕</span>
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Hide LeftSidebarNav when map is open (X button is sufficient)
- Style X button to match sidebar button design (black background, white border, responsive sizing)

## Changes Made
1. **[App.tsx:590](../modules/foundups/gotjunk/frontend/App.tsx#L590)**: Conditional render `{!isMapOpen && <LeftSidebarNav ... />}`
2. **[PigeonMapView.tsx:101-111](../modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx#L101-L111)**: X button now uses:
   - `bg-black/90 hover:bg-gray-900/90` (matches sidebar on map)
   - `border-2 border-white` (white border)
   - `rounded-2xl backdrop-blur-md shadow-2xl` (rounded + shadow)
   - `width/height: var(--sb-size)` (responsive sizing)
   - `text-2xl font-bold` (bolder X icon)

## User Request
> "since the map can be cancelled we can bring the map forward... we do not need the side buttons since the map can be closed with the 'X' we can make more obvious bolder that conforms with the buttons"

## Behavior
**Map View**:
- Sidebar icons: HIDDEN (only X button visible)
- X button: Bold, black background, white border, matches sidebar style

**All Other Views** (Browse, My Items, Cart):
- Sidebar icons: VISIBLE as before

## Test Plan
- [ ] Open map → Sidebar icons hidden ✓
- [ ] Map shows bold X button (black bg, white border) ✓
- [ ] X button closes map ✓
- [ ] Browse/My Items/Cart views show sidebar icons ✓
- [ ] X button responsive sizing works on iPhone 11-16 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)