### PR TITLE
fix(gotjunk): Increase sidebar icon size from 12px to 16px

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/LeftSidebarNav.tsx
+++ b/modules/foundups/gotjunk/frontend/components/LeftSidebarNav.tsx
@@ -101,7 +101,7 @@ export const LeftSidebarNav: React.FC<LeftSidebarNavProps> = ({
           height: 'var(--sb-size)',
         }}
       >
-        <GridIcon style={{ width: '12px', height: '12px' }} className="text-white" />
+        <GridIcon style={{ width: '16px', height: '16px' }} className="text-white" />
       </motion.button>
 
       {/* Tab 2: Map - Map Icon */}
@@ -116,7 +116,7 @@ export const LeftSidebarNav: React.FC<LeftSidebarNavProps> = ({
           height: 'var(--sb-size)',
         }}
       >
-        <MapIcon style={{ width: '12px', height: '12px' }} className="text-white" />
+        <MapIcon style={{ width: '16px', height: '16px' }} className="text-white" />
       </motion.button>
 
       {/* Tab 3: My Items - Home Icon */}
@@ -131,7 +131,7 @@ export const LeftSidebarNav: React.FC<LeftSidebarNavProps> = ({
           height: 'var(--sb-size)',
         }}
       >
-        <HomeIcon style={{ width: '12px', height: '12px' }} className="text-white" />
+        <HomeIcon style={{ width: '16px', height: '16px' }} className="text-white" />
       </motion.button>
 
       {/* Tab 4: Cart - Cart Icon */}
@@ -146,7 +146,7 @@ export const LeftSidebarNav: React.FC<LeftSidebarNavProps> = ({
           height: 'var(--sb-size)',
         }}
       >
-        <CartIcon style={{ width: '12px', height: '12px' }} className="text-white" />
+        <CartIcon style={{ width: '16px', height: '16px' }} className="text-white" />
       </motion.button>
     </motion.div>
   );


### PR DESCRIPTION
## User Feedback

User confirmed style prop fix from PR #61 worked, but 12px was too small for thumb accessibility.

## Changes

Increased all sidebar icon sizes from 12px to 16px:
- ✅ GridIcon: 12px → 16px
- ✅ MapIcon: 12px → 16px  
- ✅ HomeIcon: 12px → 16px
- ✅ CartIcon: 12px → 16px

## Result

**Before**: 12px icons with 21px padding per side (too small)  
**After**: 16px icons with 19px padding per side (better visibility, still thumb-accessible)

Buttons remain 54px × 54px as specified by `--sb-size`.

## Testing

- ✅ Build passed (`npm run build`)
- ✅ User-requested size adjustment

🤖 Generated with [Claude Code](https://claude.com/claude-code)