### PR TITLE
fix(gotjunk): Show instructions modal on every load + move sidebar up 10px

### DIFF
--- a/modules/foundups/gotjunk/frontend/App.tsx
+++ b/modules/foundups/gotjunk/frontend/App.tsx
@@ -83,11 +83,8 @@ const App: React.FC = () => {
   const [countdown, setCountdown] = useState(10);
   const [userLocation, setUserLocation] = useState<{ latitude: number; longitude: number } | undefined>();
 
-  // === INSTRUCTIONS MODAL (shows once on first visit) ===
-  const [showInstructions, setShowInstructions] = useState(() => {
-    const hasSeenInstructions = localStorage.getItem('gotjunk_instructions_seen');
-    return !hasSeenInstructions;
-  });
+  // === INSTRUCTIONS MODAL (shows on every page load) ===
+  const [showInstructions, setShowInstructions] = useState(true);
 
   // === CLASSIFICATION FILTER ===
   const [classificationFilter, setClassificationFilter] = useState<'all' | ItemClassification>('all');
@@ -486,7 +483,6 @@ const App: React.FC = () => {
   // Handle instructions modal close
   const handleInstructionsClose = () => {
     setShowInstructions(false);
-    localStorage.setItem('gotjunk_instructions_seen', 'true');
   };
 
   return (
@@ -779,7 +775,7 @@ const App: React.FC = () => {
         onClassify={handleClassify}
       />
 
-      {/* Instructions Modal (shows once on first visit) */}
+      {/* Instructions Modal (shows on every page load) */}
       <InstructionsModal
         isOpen={showInstructions}
         onClose={handleInstructionsClose}

--- a/modules/foundups/gotjunk/frontend/components/InstructionsModal.tsx
+++ b/modules/foundups/gotjunk/frontend/components/InstructionsModal.tsx
@@ -1,6 +1,6 @@
 /**
  * InstructionsModal - Dismissible welcome modal with swipe instructions
- * Shows once on first visit, stores state in localStorage
+ * Shows on every page load
  */
 
 import React from 'react';

--- a/modules/foundups/gotjunk/frontend/index.css
+++ b/modules/foundups/gotjunk/frontend/index.css
@@ -13,7 +13,7 @@
   --sb-top: calc(max(env(safe-area-inset-top, 0px) + 64px, 88px));
 
   /* Keep off the bottom toolbar */
-  --sb-bottom-safe: calc(env(safe-area-inset-bottom, 0px) + 120px);
+  --sb-bottom-safe: calc(env(safe-area-inset-bottom, 0px) + 130px);
 
   /* Image preview responsive sizing */
   --preview-size: clamp(200px, 50vw, 380px);


### PR DESCRIPTION
## User Feedback

1. **Instructions modal disappeared** - User expected it to show on every page refresh, not just once
2. **Sidebar icons too low** - Requested moving left sidebar icons up by 10 pixels

## Changes

### 1. Instructions Modal - Show on Every Page Load

**Before**: Modal showed once on first visit, then never again (localStorage persistence)  
**After**: Modal shows on every page load/refresh

- ✅ Removed localStorage check from initialization ([App.tsx:87](modules/foundups/gotjunk/frontend/App.tsx#L87))
- ✅ Removed localStorage.setItem from close handler ([App.tsx:484](modules/foundups/gotjunk/frontend/App.tsx#L484))
- ✅ Updated comments in App.tsx and InstructionsModal.tsx

### 2. Left Sidebar Position - Move Up 10px

**Before**: `--sb-bottom-safe: 120px`  
**After**: `--sb-bottom-safe: 130px`

- ✅ Increased bottom offset by 10px ([index.css:16](modules/foundups/gotjunk/frontend/index.css#L16))
- ✅ Applies to all 4 navigation icons (Browse, Map, Home, Cart)

## Testing

- ✅ Build passed (`npm run build`)
- ✅ User-requested behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)