### PR TITLE
fix(gotjunk): Show instructions modal on Browse tab only (landing page)

### DIFF
--- a/modules/foundups/gotjunk/frontend/App.tsx
+++ b/modules/foundups/gotjunk/frontend/App.tsx
@@ -775,9 +775,9 @@ const App: React.FC = () => {
         onClassify={handleClassify}
       />
 
-      {/* Instructions Modal (shows on every page load) */}
+      {/* Instructions Modal (shows on Browse tab only - landing page) */}
       <InstructionsModal
-        isOpen={showInstructions}
+        isOpen={showInstructions && activeTab === 'browse'}
         onClose={handleInstructionsClose}
       />
 


### PR DESCRIPTION
## Root Cause

InstructionsModal was appearing on **ALL tabs** (Browse, Map, My Items, Cart) instead of just the landing page (Browse).

**Bug**: `isOpen` condition only checked `showInstructions` state, not which tab was active.

```tsx
// BEFORE - Shows on all tabs ❌
<InstructionsModal
  isOpen={showInstructions}
  onClose={handleInstructionsClose}
/>
```

## Fix

Added `activeTab === 'browse'` condition to only show modal on landing page:

```tsx
// AFTER - Shows only on Browse tab (landing page) ✅
<InstructionsModal
  isOpen={showInstructions && activeTab === 'browse'}
  onClose={handleInstructionsClose}
/>
```

## Result

✅ Modal appears on **Browse tab only** (GridIcon - the landing page)  
✅ Does NOT appear on Map, My Items, or Cart tabs  
✅ Prevents confusion when user navigates away from Browse on first load  
✅ User sees tutorial exactly once, on the correct screen

## Testing

- ✅ Build passed (`npm run build`)
- ✅ Conditional rendering based on activeTab state
- ✅ Works with existing showInstructions close logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)