### PR TITLE
fix(gotjunk): Shift tutorial popup 50px left from center

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/InstructionsModal.tsx
+++ b/modules/foundups/gotjunk/frontend/components/InstructionsModal.tsx
@@ -23,8 +23,10 @@ export const InstructionsModal: React.FC<InstructionsModalProps> = ({ isOpen, on
           initial={{ opacity: 0, y: -20 }}
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: -20 }}
-          className="fixed left-1/2 -translate-x-1/2 w-[min(92vw,360px)]"
+          className="fixed w-[min(92vw,360px)]"
           style={{
+            left: 'calc(50% - 50px)',
+            transform: 'translateX(-50%)',
             top: 'calc(env(safe-area-inset-top, 20px) + 16px)',
             zIndex: Z_LAYERS.tutorialPopup
           }}


### PR DESCRIPTION
## Change
Shifted InstructionsModal tutorial popup 50 pixels to the left from center position.

## Technical Implementation
**Before**:
```tsx
className="fixed left-1/2 -translate-x-1/2 w-[min(92vw,360px)]"
```

**After**:
```tsx
className="fixed w-[min(92vw,360px)]"
style={{
  left: 'calc(50% - 50px)',
  transform: 'translateX(-50%)',
  ...
}}
```

## Result
- Popup now appears 50px to the left of screen center
- Better visual balance with left sidebar icons
- Still respects iOS safe-area-inset-top for notch/dynamic island
- Maintains responsive width: `min(92vw, 360px)`

## Testing
- ✅ Build passes: `vite build` (no TypeScript errors)
- ✅ Bundle size: 417.51 KB (gzipped: 130.99 KB)

## Files Modified
- [InstructionsModal.tsx](modules/foundups/gotjunk/frontend/components/InstructionsModal.tsx#L26-L32)

🤖 Generated with [Claude Code](https://claude.com/claude-code)