### PR TITLE
feat(gotjunk): Hide camera orb on map view for clean UI

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -30,6 +30,21 @@
 - Tutorial remains fully visible under all safe-area cutouts (dynamic island/notch) and never overlaps the camera orb or floating controls.
 - Z-index contract stays synchronized across code + docs to prevent future layering regressions.
 - Users get the same glow/animation styling while regaining unobstructed swipe instructions that satisfy WSP UX guardrails.
+- Follow-up tweak (2025-11-10 2nd pass): constrained popup height with safe-area-aware `maxHeight`, tightened typography, and enabled auto-scroll so it never intersects the capture orb even on smaller iPhones.
+
+## [2025-11-10] GotJunk Map Camera Orb Visibility Fix
+
+**Change Type**: UI conditional rendering  
+**Architect**: Codex (0102)  
+**WSP References**: WSP 3 (module boundaries), WSP 7 (pre-commit validation), WSP 22 (ModLog), WSP 57 (UI documentation consistency)
+
+### What Changed
+- Added a `showCameraOrb` prop to `BottomNavBar` so the capture orb can be toggled off per view.
+- Updated `App.tsx` to disable the orb when the map overlay is open or when the user is in the map tab, preventing UI overlap on the GotJunk Map screen.
+
+### Impact
+- Map view now shows only map controls (zoom/info/pins) while camera and list views still get the orb immediately.
+- WSP 87 navigation guidance preserved: no camera controls rendered during non-camera contexts, avoiding accidental capture actions.
 
 ## [2025-11-03] MCP Server First Principles Optimization - 78% Reduction
 

--- a/modules/foundups/gotjunk/frontend/App.tsx
+++ b/modules/foundups/gotjunk/frontend/App.tsx
@@ -490,6 +490,7 @@ const App: React.FC = () => {
     : browseFeed.filter(item => item.classification === classificationFilter);
 
   const currentReviewItem = myDrafts.length > 0 ? myDrafts[0] : null;
+  const showCameraOrb = !(isMapOpen || activeTab === 'map');
 
   // Handle instructions modal close
   const handleInstructionsClose = () => {
@@ -743,6 +744,7 @@ const App: React.FC = () => {
           console.log('🔍 Search clicked');
           // TODO: Open search modal
         }}
+        showCameraOrb={showCameraOrb}
       />
 
       {isGalleryOpen && (

--- a/modules/foundups/gotjunk/frontend/components/BottomNavBar.tsx
+++ b/modules/foundups/gotjunk/frontend/components/BottomNavBar.tsx
@@ -18,6 +18,7 @@ interface BottomNavBarProps {
   setCountdown: React.Dispatch<React.SetStateAction<number>>;
   hasReviewItems: boolean;
   onSearchClick?: () => void; // Search functionality
+  showCameraOrb?: boolean;
 }
 
 const buttonVariants = {
@@ -35,6 +36,7 @@ export const BottomNavBar: React.FC<BottomNavBarProps> = ({
   setCountdown,
   hasReviewItems,
   onSearchClick = () => console.log('🔍 Search clicked'),
+  showCameraOrb = true,
 }) => {
   const cameraRef = useRef<CameraHandle>(null);
   const pressTimerRef = useRef<number | null>(null);
@@ -118,25 +120,27 @@ export const BottomNavBar: React.FC<BottomNavBarProps> = ({
         transition={{ type: 'spring', stiffness: 300, damping: 30 }}
     >
       {/* Camera Orb - Floating above nav bar */}
-      <div
-        className="absolute left-1/2 -translate-x-1/2 bottom-32 flex flex-col items-center"
-        style={{ zIndex: Z_LAYERS.cameraOrb }}
-      >
-          {/* Main capture button with live preview - Intelligent scaling: iPhone 11=143px, iPhone 16=149px */}
-          <div
-            className="p-2 bg-gray-800 rounded-full shadow-2xl cursor-pointer"
-            style={{
-              width: 'clamp(128px, 16vh, 192px)',
-              height: 'clamp(128px, 16vh, 192px)'
-            }}
-            onMouseDown={handlePressStart}
-            onMouseUp={handlePressEnd}
-            onTouchStart={handlePressStart}
-            onTouchEnd={handlePressEnd}
-          >
-               <Camera ref={cameraRef} onCapture={onCapture} captureMode={captureMode} />
-          </div>
-      </div>
+      {showCameraOrb && (
+        <div
+          className="absolute left-1/2 -translate-x-1/2 bottom-32 flex flex-col items-center"
+          style={{ zIndex: Z_LAYERS.cameraOrb }}
+        >
+            {/* Main capture button with live preview - Intelligent scaling: iPhone 11=143px, iPhone 16=149px */}
+            <div
+              className="p-2 bg-gray-800 rounded-full shadow-2xl cursor-pointer"
+              style={{
+                width: 'clamp(128px, 16vh, 192px)',
+                height: 'clamp(128px, 16vh, 192px)'
+              }}
+              onMouseDown={handlePressStart}
+              onMouseUp={handlePressEnd}
+              onTouchStart={handlePressStart}
+              onTouchEnd={handlePressEnd}
+            >
+                 <Camera ref={cameraRef} onCapture={onCapture} captureMode={captureMode} />
+            </div>
+        </div>
+      )}
 
       {/* Main Nav Bar */}
       <div


### PR DESCRIPTION
## Summary
Camera orb now hides whenever the GotJunk map overlay is open, keeping the map UI clean and preventing visual clutter.

## Changes

### BottomNavBar Component
- Added optional `showCameraOrb?: boolean` prop (default: `true`)
- Conditionally renders camera orb only when `showCameraOrb` is true
- Preserves all camera orb functionality when visible

### App Component
- Derives `showCameraOrb = !(isMapOpen || activeTab === 'map')` 
- Passes prop to BottomNavBar
- Camera orb hidden when:
  - Map overlay is open (`isMapOpen`)
  - Active tab is map (`activeTab === 'map'`)
- Camera orb visible in all other views (browse, myItems, cart)

### Implementation Details
```typescript
// App.tsx:493
const showCameraOrb = !(isMapOpen || activeTab === 'map');

// App.tsx:747
<BottomNavBar showCameraOrb={showCameraOrb} ... />

// BottomNavBar.tsx:21, 39, 123
interface BottomNavBarProps {
  showCameraOrb?: boolean;
}
showCameraOrb = true,
{showCameraOrb && ( /* camera orb rendering */ )}
```

## Impact
- **Map view**: Only map controls visible (zoom, info, pins) ✓
- **Browse/MyItems/Cart**: Camera orb appears instantly ✓
- **No layout shifts**: Conditional rendering (not CSS hiding) ✓
- **WSP 87 compliance**: No camera controls in non-camera contexts ✓

## WSP Compliance
- **WSP 3**: Module boundaries preserved
- **WSP 7**: Pre-commit validation
- **WSP 22**: ModLog documentation ([ModLog.md:35-47](../../../ModLog.md#L35-L47))
- **WSP 57**: UI documentation consistency
- **WSP 87**: Navigation guidance (no camera in map context)

## Testing
- ✅ Build successful: 417.81 KB (gzipped: 131.10 kB) in 2.88s
- ✅ TypeScript compilation passed
- Manual testing required: Verify camera orb hides on map view and reappears on other tabs

## Files Modified
- [App.tsx:493,747](../modules/foundups/gotjunk/frontend/App.tsx#L493)
- [BottomNavBar.tsx:21,39,123](../modules/foundups/gotjunk/frontend/components/BottomNavBar.tsx#L21)
- [ModLog.md:35-47](../../../ModLog.md#L35-L47)

🤖 Generated with [Claude Code](https://claude.com/claude-code)