### PR TITLE
fix(gotjunk): Lower map controls for better thumb reach

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
+++ b/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
@@ -99,10 +99,10 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
         </h2>
       </div>
 
-      {/* Close Button - Moved to bottom-left thumb zone */}
+      {/* Close Button - Lower position for better thumb reach */}
       <button
         onClick={onClose}
-        className="absolute bottom-36 left-4 z-40 grid place-items-center rounded-2xl backdrop-blur-md shadow-2xl transition-all bg-black/90 hover:bg-gray-900/90 border-2 border-white shadow-black/80"
+        className="absolute bottom-24 left-4 z-40 grid place-items-center rounded-2xl backdrop-blur-md shadow-2xl transition-all bg-black/90 hover:bg-gray-900/90 border-2 border-white shadow-black/80"
         style={{
           width: 'var(--sb-size)',
           height: 'var(--sb-size)',
@@ -112,8 +112,8 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
         <span className="text-white text-2xl font-bold">✕</span>
       </button>
 
-      {/* Zoom Controls - Moved to bottom-right thumb zone */}
-      <div className="absolute bottom-36 right-4 z-40 flex flex-col gap-2">
+      {/* Zoom Controls - Lower position for better thumb reach */}
+      <div className="absolute bottom-24 right-4 z-40 flex flex-col gap-2">
         <button
           onClick={() => setZoom(Math.min(zoom + 1, 18))}
           className="bg-gray-800 hover:bg-gray-700 text-white text-2xl w-12 h-12 rounded-lg shadow-2xl border-2 border-gray-600 font-bold"
@@ -259,8 +259,8 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
         )}
       </Map>
 
-      {/* Collapsible Legend - Moved to bottom-left above close button */}
-      <div className="absolute bottom-52 left-4 z-40">
+      {/* Collapsible Legend - Lower position above close button */}
+      <div className="absolute bottom-36 left-4 z-40">
         {/* Legend Toggle Button */}
         <button
           onClick={() => setLegendExpanded(!legendExpanded)}


### PR DESCRIPTION
## Summary
Lowered all map controls closer to bottom nav bar for easier one-handed thumb operation.

## Changes

### Control Positions (Before → After)

**Info Button (ℹ️)**:
- Before:  (208px from bottom) ❌ Too high
- After:  (144px from bottom) ✓ Better reach

**Close Button (×)**:
- Before:  (144px from bottom) ❌ Too high
- After:  (96px from bottom) ✓ Thumb-accessible

**Zoom Controls (+/−/📍)**:
- Before:  (144px from bottom) ❌ Too high
- After:  (96px from bottom) ✓ Thumb-accessible

### New Layout

```
Bottom-left:           Bottom-right:
  [ℹ️]  144px            [+]  96px
  ↓ 48px gap             [−]  stacked
  [×]  96px              [📍] stacked
  ↓ 96px to nav          ↓ 96px to nav
```

## User Feedback
"see how thay are riding high? they need to be lower"

## Build Status
- ✅ Build: 417.53 KB (gzipped: 131.01 kB)
- ✅ Time: 3.06s
- ✅ TypeScript compilation passed

## Files Modified
- [PigeonMapView.tsx](modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)