### PR TITLE
fix(gotjunk): Fullscreen map cleanup - remove pin drop, fix button spacing, hide bottom nav

### DIFF
--- a/modules/foundups/gotjunk/frontend/App.tsx
+++ b/modules/foundups/gotjunk/frontend/App.tsx
@@ -705,7 +705,31 @@ const App: React.FC = () => {
         />
       )}
 
-      {/* Bottom navigation bar */}
+      {/* Bottom navigation bar - hidden when map is open (fullscreen map) */}
+      {!isMapOpen && (
+        <BottomNavBar
+          captureMode={captureMode}
+          onToggleCaptureMode={() => setCaptureMode(mode => mode === 'photo' ? 'video' : 'photo')}
+          onCapture={handleCapture}
+          onReviewAction={(action) => {
+            if (activeTab === 'browse' && browseFeed.length > 0) {
+              handleBrowseSwipe(browseFeed[0], action === 'keep' ? 'right' : 'left');
+            } else if (activeTab === 'myitems' && currentReviewItem) {
+              handleReviewDecision(currentReviewItem, action);
+            }
+          }}
+          isRecording={isRecording}
+          setIsRecording={setIsRecording}
+          countdown={countdown}
+          setCountdown={setCountdown}
+          hasReviewItems={activeTab === 'browse' ? browseFeed.length > 0 : myDrafts.length > 0}
+          onSearchClick={() => {
+            console.log('🔍 Search clicked');
+            // TODO: Open search modal
+          }}
+          showCameraOrb={showCameraOrb}
+        />
+      )}
 
       {/* Re-classification Modal (tap badge) */}
       {reclassifyingItem && (
@@ -725,29 +749,6 @@ const App: React.FC = () => {
           onClose={() => setEditingOptionsItem(null)}
         />
       )}
-
-      <BottomNavBar
-        captureMode={captureMode}
-        onToggleCaptureMode={() => setCaptureMode(mode => mode === 'photo' ? 'video' : 'photo')}
-        onCapture={handleCapture}
-        onReviewAction={(action) => {
-          if (activeTab === 'browse' && browseFeed.length > 0) {
-            handleBrowseSwipe(browseFeed[0], action === 'keep' ? 'right' : 'left');
-          } else if (activeTab === 'myitems' && currentReviewItem) {
-            handleReviewDecision(currentReviewItem, action);
-          }
-        }}
-        isRecording={isRecording}
-        setIsRecording={setIsRecording}
-        countdown={countdown}
-        setCountdown={setCountdown}
-        hasReviewItems={activeTab === 'browse' ? browseFeed.length > 0 : myDrafts.length > 0}
-        onSearchClick={() => {
-          console.log('🔍 Search clicked');
-          // TODO: Open search modal
-        }}
-        showCameraOrb={showCameraOrb}
-      />
 
       {isGalleryOpen && (
         <FullscreenGallery

--- a/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
+++ b/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
@@ -128,18 +128,6 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
         >
           −
         </button>
-        {!isGlobalView && userLocation && (
-          <button
-            onClick={() => {
-              // Center map on user location
-              window.location.reload(); // Simple way to recenter
-            }}
-            className="bg-gray-800 hover:bg-gray-700 text-white text-xl w-12 h-12 rounded-lg shadow-2xl border-2 border-gray-600"
-            title="Center on Me"
-          >
-            📍
-          </button>
-        )}
         {isGlobalView && (
           <button
             onClick={() => setZoom(2)} // Reset to global view
@@ -259,8 +247,8 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
         )}
       </Map>
 
-      {/* Collapsible Legend - Lower position above close button */}
-      <div className="absolute bottom-36 left-4 z-40">
+      {/* Collapsible Legend - Higher position to avoid overlap with close button */}
+      <div className="absolute bottom-48 left-4 z-40">
         {/* Legend Toggle Button */}
         <button
           onClick={() => setLegendExpanded(!legendExpanded)}


### PR DESCRIPTION
## Summary

Three UX improvements for map fullscreen experience on iOS Safari:

1. **Removed pin drop button** - Eliminated redundant user location recenter button (📍)
2. **Fixed left-side button overlap** - Increased spacing between legend (ℹ️) and close (✕) buttons (bottom-48 vs bottom-24)  
3. **Hidden bottom nav bar on map view** - True fullscreen map experience with no bottom nav bar clutter

## Changes

- `PigeonMapView.tsx`: Removed pin drop button, adjusted legend position from bottom-36 to bottom-48
- `App.tsx`: Wrapped BottomNavBar in `{!isMapOpen &&` conditional

## Testing

- Build passed: 418.21 kB (gzipped: 131.14 kB)
- Buttons now have proper spacing (96px gap for 48px buttons)
- Map view shows only essential controls (close, zoom, legend on left; zoom controls on right)