### PR TITLE
fix(gotjunk): Fine-tune map controls - move closer to bottom

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
+++ b/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
@@ -99,10 +99,10 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
         </h2>
       </div>
 
-      {/* Close Button - Thumb zone position (bottom-8 for easy reach) */}
+      {/* Close Button - Lower thumb zone (bottom-3 = 12px from bottom) */}
       <button
         onClick={onClose}
-        className="absolute bottom-8 left-4 z-40 grid place-items-center rounded-2xl backdrop-blur-md shadow-2xl transition-all bg-black/90 hover:bg-gray-900/90 border-2 border-white shadow-black/80"
+        className="absolute bottom-3 left-4 z-40 grid place-items-center rounded-2xl backdrop-blur-md shadow-2xl transition-all bg-black/90 hover:bg-gray-900/90 border-2 border-white shadow-black/80"
         style={{
           width: 'var(--sb-size)',
           height: 'var(--sb-size)',
@@ -112,8 +112,8 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
         <span className="text-white text-2xl font-bold">✕</span>
       </button>
 
-      {/* Zoom Controls - Thumb zone position (bottom-8 for easy reach) */}
-      <div className="absolute bottom-8 right-4 z-40 flex flex-col gap-2">
+      {/* Zoom Controls - Lower thumb zone (bottom-3 = 12px from bottom) */}
+      <div className="absolute bottom-3 right-4 z-40 flex flex-col gap-2">
         <button
           onClick={() => setZoom(Math.min(zoom + 1, 18))}
           className="bg-gray-800 hover:bg-gray-700 text-white text-2xl w-12 h-12 rounded-lg shadow-2xl border-2 border-gray-600 font-bold"
@@ -247,8 +247,8 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
         )}
       </Map>
 
-      {/* Collapsible Legend - Thumb zone position (bottom-20 above close button) */}
-      <div className="absolute bottom-20 left-4 z-40">
+      {/* Collapsible Legend - Higher position (100px from bottom) */}
+      <div className="absolute bottom-[100px] left-4 z-40">
         {/* Legend Toggle Button */}
         <button
           onClick={() => setLegendExpanded(!legendExpanded)}


### PR DESCRIPTION
## Summary

Fine-tuned map control positioning based on user feedback for easier one-handed thumb reach:

**Adjustments** (all changes: move 20px):
- **Close button (✕)**: bottom-8 → bottom-3 (32px → 12px from bottom)
- **Zoom controls (+/−)**: bottom-8 → bottom-3 (32px → 12px from bottom)
- **Legend button (ℹ️)**: bottom-20 → bottom-[100px] (80px → 100px from bottom)

## Ergonomics

All controls now optimized for natural thumb reach on mobile devices:
- Close/Zoom at 12px from bottom (maximum thumb reach)
- Legend at 100px from bottom (prevents overlap, easy reach)

## Build

- Size: 418.21 kB (gzipped: 131.15 kB)
- Build time: 2.75s