### PR TITLE
fix(gotjunk): Fix classification bypass + double-capture race condition

### DIFF
--- a/HOLO_INDEX_IMPROVEMENT_LOG.md
+++ b/HOLO_INDEX_IMPROVEMENT_LOG.md
@@ -1,0 +1,105 @@
+# HoloIndex Improvement Log - 2025-11-10
+
+## Session: GotJunk Double-Capture Investigation
+
+### Issue 1: Empty Code Previews
+
+**Query**:
+```
+"camera capture button double tap duplicate race condition onClick onTouchEnd handleCapture"
+```
+
+**Results**:
+- ✓ Found 10 results (5 code, 5 WSP)
+- ✗ All previews empty: `Preview: ` (no content)
+- ✓ File paths returned correctly
+
+**Expected Behavior**:
+Should return actual code snippets showing:
+- Event handler implementations
+- Race condition guards
+- State management patterns
+
+**Impact**: Medium
+- Forces fallback to manual file reading
+- Loses semantic context of "why" these files match
+- Cannot quickly assess relevance without opening files
+
+---
+
+### Issue 2: Generic Match Scores
+
+**Query**:
+```
+"BottomNavBar Camera takePhoto handlePressStart handlePressEnd onTouchStart onTouchEnd"
+```
+
+**Results**:
+- All matches show: `Match: 0.0%`
+- Expected: Semantic similarity scores (0-100%)
+
+**Impact**: Low
+- Unclear which results are most relevant
+- Cannot prioritize reading order
+
+---
+
+## Recommendations for Another 0102
+
+### Fix 1: Code Preview Extraction
+
+**File**: `holo_index/cli/holo_request.py` (likely)
+**Root Cause Hypothesis**: TSX/JSX parsing may not extract function bodies correctly
+
+**Suggested Investigation**:
+1. Check if previews work for `.py` files vs `.tsx` files
+2. Verify regex/AST extraction for TypeScript event handlers
+3. Add fallback: if preview empty, return first 3 lines of matched function
+
+### Fix 2: Match Score Calculation
+
+**File**: `holo_index/core/search_engine.py` (likely)
+**Root Cause Hypothesis**: Cosine similarity not being returned or formatted
+
+**Suggested Investigation**:
+1. Verify `distance` field from ChromaDB is converted to percentage
+2. Check if score is lost during result aggregation
+3. Add debug logging: `[HOLO-SCORE] file=X score=Y`
+
+---
+
+## Workaround Used This Session
+
+Fallback strategy:
+1. Use HoloIndex to identify relevant files ✓
+2. Use `Read` tool to examine files directly ✓
+3. Use `Grep` for precise pattern matching ✓
+
+**Efficiency Loss**: ~30% (extra tool calls needed)
+
+---
+
+## Test Case for Validation
+
+After fixes, re-run:
+```bash
+python holo_index.py --search "handlePressStart handlePressEnd onClick onTouchEnd" --verbose
+```
+
+**Expected Output**:
+```
+[CODE RESULTS] Top implementations:
+  1. modules/foundups/gotjunk/frontend/components/BottomNavBar.tsx:handlePressEnd
+     Match: 87.3% | Preview: const handlePressEnd = () => {
+       if (pressTimerRef.current) {
+         clearTimeout(pressTimerRef.current);
+         pressTimerRef.current = null;
+       }
+       ...
+     }
+```
+
+---
+
+*Log created by 0102 during surgical investigation of GotJunk double-capture bug*
+*Timestamp: 2025-11-10 07:25 UTC*

--- a/modules/foundups/gotjunk/frontend/components/BottomNavBar.tsx
+++ b/modules/foundups/gotjunk/frontend/components/BottomNavBar.tsx
@@ -43,6 +43,7 @@ export const BottomNavBar: React.FC<BottomNavBarProps> = ({
   const countdownIntervalRef = useRef<number | null>(null);
   const stopTimeoutRef = useRef<number | null>(null);
   const momentaryRecordingRef = useRef<boolean>(false);
+  const captureLockRef = useRef<boolean>(false); // Prevents double-capture from touch+mouse events
 
   const stopRecording = () => {
     if (countdownIntervalRef.current) {
@@ -103,11 +104,24 @@ export const BottomNavBar: React.FC<BottomNavBarProps> = ({
     if (momentaryRecordingRef.current) {
         stopRecording();
     } else if (!isRecording) {
+        // Capture lock prevents double-fire from touch+mouse events
+        if (captureLockRef.current) {
+          console.log('[GotJunk] Capture blocked - lock active');
+          return;
+        }
+
+        captureLockRef.current = true;
+
         if (captureMode === 'photo') {
             cameraRef.current?.takePhoto();
         } else if (captureMode === 'video') {
             startRecording(false);
         }
+
+        // Release lock after 500ms to allow next capture
+        setTimeout(() => {
+          captureLockRef.current = false;
+        }, 500);
     }
   };
 

--- a/modules/foundups/gotjunk/frontend/components/ClassificationModal.tsx
+++ b/modules/foundups/gotjunk/frontend/components/ClassificationModal.tsx
@@ -49,7 +49,7 @@ export const ClassificationModal: React.FC<ClassificationModalProps> = ({
       setDiscountSheetOpen(true);
     },
     onTap: () => {
-      onClassify('discount', discountPercent, undefined);
+      setDiscountSheetOpen(true); // Always show sheet - prevents accidental quick-tap bypass
     },
     threshold: 450,
   });
@@ -60,7 +60,7 @@ export const ClassificationModal: React.FC<ClassificationModalProps> = ({
       setBidSheetOpen(true);
     },
     onTap: () => {
-      onClassify('bid', undefined, bidDurationHours);
+      setBidSheetOpen(true); // Always show sheet - prevents accidental quick-tap bypass
     },
     threshold: 450,
   });


### PR DESCRIPTION
## Summary

Fixes two critical UX bugs:
1. **Classification modal bypass** - Quick tap on Discount/Bid bypassed options menu
2. **Double-picture capture** - Touch+mouse events fired simultaneously, creating duplicates

## Problem 1: Classification Modal Quick-Tap Bypass

**Before**:
- User takes picture → Tap "Discount" → Modal closes instantly with 75% default ❌
- User perception: "The choice was bypassed!"

**After**:
- User takes picture → Tap "Discount" → Action sheet opens → User selects 25%/50%/75% ✓
- Predictable, no surprises

**Root Cause**:
```tsx
// BEFORE (ClassificationModal.tsx:52)
onTap: () => onClassify('discount', discountPercent)  // ❌ Instant save

// AFTER
onTap: () => setDiscountSheetOpen(true)  // ✓ Always show options
```

## Problem 2: Double-Picture Capture

**Before**:
- User taps camera → Two identical pictures appear (Bid 48h, $25) ❌
- Screenshot evidence: Two identical glass cups with same badge

**After**:
- User taps camera → ONE picture captured ✓
- Capture lock prevents race condition

**Root Cause**:
```tsx
// Camera button had BOTH event types
<div
  onMouseDown={handlePressStart}   // Desktop
  onMouseUp={handlePressEnd}       // Desktop
  onTouchStart={handlePressStart}  // Mobile
  onTouchEnd={handlePressEnd}      // Mobile - BOTH fire on iPhone!
>
```

On mobile browsers, both touch AND mouse events fire → `takePhoto()` called twice.

**Fix**:
```tsx
// Added capture lock (BottomNavBar.tsx:46)
const captureLockRef = useRef<boolean>(false);

// Lock mechanism (lines 107-124)
if (captureLockRef.current) {
  console.log('[GotJunk] Capture blocked - lock active');
  return;  // Prevent duplicate
}

captureLockRef.current = true;
cameraRef.current?.takePhoto();  // Only fires once

setTimeout(() => {
  captureLockRef.current = false;  // Release after 500ms
}, 500);
```

## Changes

**[ClassificationModal.tsx](modules/foundups/gotjunk/frontend/components/ClassificationModal.tsx)**:
- Line 52: Discount `onTap` → always open sheet
- Line 63: Bid `onTap` → always open sheet

**[BottomNavBar.tsx](modules/foundups/gotjunk/frontend/components/BottomNavBar.tsx)**:
- Line 46: Added `captureLockRef`
- Lines 107-124: Capture lock with 500ms cooldown

**[HOLO_INDEX_IMPROVEMENT_LOG.md](HOLO_INDEX_IMPROVEMENT_LOG.md)**:
- Documented HoloIndex empty preview issue
- Actionable recommendations for another 0102 to fix

## Investigation Method

1. Used **HoloIndex** (agentic search) to identify relevant files
2. Created **improvement log** when HoloIndex returned empty previews
3. Surgical code reading to find exact root cause
4. Applied **Occam's Razor** - simplest lock mechanism (useRef, not state)

## Test Plan

- [ ] Take picture → Tap Discount → Verify action sheet opens (not bypass)
- [ ] Take picture → Tap Bid → Verify action sheet opens (not bypass)
- [ ] Select 50% discount → Verify saves correctly
- [ ] Rapid tap camera → Verify only ONE picture captured
- [ ] Check console logs: `[GotJunk] Capture blocked` on duplicate attempts

## Build Output

```
✓ 424 modules transformed
✓ built in 2.52s
dist/index.html                   1.53 kB │ gzip:   0.70 kB
dist/assets/index-BK78dVSP.css    0.32 kB │ gzip:   0.22 kB
dist/assets/index-Dan9UgKC.js   418.27 kB │ gzip: 131.16 kB
```

## WSP Compliance

- ✓ WSP_00: Zen State Protocol (surgical fixes, no vibecoding)
- ✓ WSP_50: Pre-action verification (HoloIndex search first)
- ✓ First Principles: Occam's Razor (minimal lock mechanism)

🤖 Generated with [Claude Code](https://claude.com/claude-code)