### PR TITLE
fix(gotjunk): Red delete button now deletes visible filtered item

### DIFF
--- a/modules/foundups/gotjunk/frontend/App.tsx
+++ b/modules/foundups/gotjunk/frontend/App.tsx
@@ -711,8 +711,9 @@ const App: React.FC = () => {
           onToggleCaptureMode={() => setCaptureMode(mode => mode === 'photo' ? 'video' : 'photo')}
           onCapture={handleCapture}
           onReviewAction={(action) => {
-            if (activeTab === 'browse' && browseFeed.length > 0) {
-              handleBrowseSwipe(browseFeed[0], action === 'keep' ? 'right' : 'left');
+            if (activeTab === 'browse' && filteredBrowseFeed.length > 0) {
+              console.log('[GotJunk] Button action:', action, 'on item:', filteredBrowseFeed[0].id);
+              handleBrowseSwipe(filteredBrowseFeed[0], action === 'keep' ? 'right' : 'left');
             } else if (activeTab === 'myitems' && currentReviewItem) {
               handleReviewDecision(currentReviewItem, action);
             }
@@ -721,7 +722,7 @@ const App: React.FC = () => {
           setIsRecording={setIsRecording}
           countdown={countdown}
           setCountdown={setCountdown}
-          hasReviewItems={activeTab === 'browse' ? browseFeed.length > 0 : myDrafts.length > 0}
+          hasReviewItems={activeTab === 'browse' ? filteredBrowseFeed.length > 0 : myDrafts.length > 0}
           onSearchClick={() => {
             console.log('🔍 Search clicked');
             // TODO: Open search modal


### PR DESCRIPTION
## Summary

Fixes critical bug where red delete button deleted **wrong item** when classification filter active.

**Before**:
- User filters for "FREE" items only
- UI shows: Water bottle (FREE)
- User taps red button
- App deletes: Random BID item from unfiltered list ❌

**After**:
- User filters for "FREE" items only
- UI shows: Water bottle (FREE)  
- User taps red button
- App deletes: Water bottle (correct!) ✓

## Root Cause

**Data source mismatch** - Three different data sources:

| Component | Data Source | Correct? |
|-----------|-------------|----------|
| UI render | `filteredBrowseFeed[0]` | ✓ |
| Swipe gesture | `filteredBrowseFeed[0]` | ✓ |
| Button handler | `browseFeed[0]` | ❌ WRONG! |

When filter active:
```typescript
browseFeed = [BID_item, FREE_item, DISCOUNT_item]  // All items
filteredBrowseFeed = [FREE_item]  // Only FREE items visible

// UI shows FREE_item
// Button deletes BID_item ❌
```

## Changes

**[App.tsx:714-716](modules/foundups/gotjunk/frontend/App.tsx#L714-L716)** - Fix button handler:
```diff
- if (activeTab === 'browse' && browseFeed.length > 0) {
-   handleBrowseSwipe(browseFeed[0], action === 'keep' ? 'right' : 'left');
+ if (activeTab === 'browse' && filteredBrowseFeed.length > 0) {
+   console.log('[GotJunk] Button action:', action, 'on item:', filteredBrowseFeed[0].id);
+   handleBrowseSwipe(filteredBrowseFeed[0], action === 'keep' ? 'right' : 'left');
```

**[App.tsx:725](modules/foundups/gotjunk/frontend/App.tsx#L725)** - Fix button disabled state:
```diff
- hasReviewItems={activeTab === 'browse' ? browseFeed.length > 0 : myDrafts.length > 0}
+ hasReviewItems={activeTab === 'browse' ? filteredBrowseFeed.length > 0 : myDrafts.length > 0}
```

## Test Plan

- [ ] No filter → Red button deletes first item in feed
- [ ] Filter = "FREE" → Red button deletes visible FREE item (not random)
- [ ] Filter = "BID" → Red button deletes visible BID item  
- [ ] Filter active but no results → Buttons disabled
- [ ] Swipe and button produce identical behavior
- [ ] Console shows: `[GotJunk] Button action: delete on item: abc123`

## Build Output

```
✓ 424 modules transformed
✓ built in 2.68s
dist/index.html                   1.53 kB │ gzip:   0.70 kB
dist/assets/index-BK78dVSP.css    0.32 kB │ gzip:   0.22 kB
dist/assets/index-D6cXwlGz.js   418.33 kB │ gzip: 131.17 kB
```

## WSP Compliance

- ✓ WSP_00: Zen State (surgical fix)
- ✓ WSP_50: Pre-action verification (HoloIndex + grep)
- ✓ First Principles: Single source of truth

🤖 Generated with [Claude Code](https://claude.com/claude-code)