### PR TITLE
fix(gotjunk): Revert classification modal vibecoding - restore quick-select

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/ClassificationModal.tsx
+++ b/modules/foundups/gotjunk/frontend/components/ClassificationModal.tsx
@@ -49,7 +49,8 @@ export const ClassificationModal: React.FC<ClassificationModalProps> = ({
       setDiscountSheetOpen(true);
     },
     onTap: () => {
-      setDiscountSheetOpen(true); // Always show sheet - prevents accidental quick-tap bypass
+      // Quick-select with current default (power user feature)
+      onClassify('discount', discountPercent, undefined);
     },
     threshold: 450,
   });
@@ -60,7 +61,8 @@ export const ClassificationModal: React.FC<ClassificationModalProps> = ({
       setBidSheetOpen(true);
     },
     onTap: () => {
-      setBidSheetOpen(true); // Always show sheet - prevents accidental quick-tap bypass
+      // Quick-select with current default (power user feature)
+      onClassify('bid', undefined, bidDurationHours);
     },
     threshold: 450,
   });


### PR DESCRIPTION
## Summary
Reverts vibecoded changes from PR #84 that broke the documented quick-select behavior for Discount/Bid options.

## Problem (PR #84 Introduced)
- Changed `onTap` to **always** open action sheet for Discount/Bid
- Removed power-user quick-select feature
- **Contradicted documentation**:
  - JSDoc: "Single tap: Select classification with defaults"
  - Helper text: "Tap to select • Long-press to edit"

## Root Cause
Misinterpreted user complaint about "choice bypass":
- Thought quick-tap was the problem
- Actually removed useful power-user shortcut
- User's feedback emphasized: "you do not change the default unless long press"

## Solution
**Restored original intent**:
- **Tap** DISCOUNT → Instant select with current default (75%)
- **Long-press** DISCOUNT → Open action sheet to customize
- **Tap** BID → Instant select with current default (48h)
- **Long-press** BID → Open action sheet to customize
- FREE → Always instant select (unchanged)

## Behavior Timeline
| Stage | Tap Behavior | Long-press Behavior | Status |
|-------|--------------|---------------------|--------|
| Before PR #84 | Instant select | Open sheet to edit | ✓ Correct |
| After PR #84 | Open sheet | Open sheet | ✗ Vibecoded |
| **This PR** | **Instant select** | **Open sheet to edit** | **✓ Restored** |

## Files Changed
- [ClassificationModal.tsx:51-66](modules/foundups/gotjunk/frontend/components/ClassificationModal.tsx#L51-L66)

## Testing
1. Take photo with camera orb
2. Classification modal appears
3. **Tap** Discount → Should instantly classify as "discount 75%" and close modal
4. Take another photo
5. **Long-press** Discount → Should open action sheet with 25%/50%/75% options
6. Select 50% → Should save as new default

🤖 Generated with [Claude Code](https://claude.com/claude-code)