### PR TITLE
fix(gotjunk): Fix camera orb visibility - correct activeTab case mismatch

### DIFF
--- a/modules/foundups/gotjunk/frontend/App.tsx
+++ b/modules/foundups/gotjunk/frontend/App.tsx
@@ -503,7 +503,7 @@ const App: React.FC = () => {
   }
 
   const currentReviewItem = myDrafts.length > 0 ? myDrafts[0] : null;
-  const showCameraOrb = !isMapOpen && activeTab === 'myItems';
+  const showCameraOrb = !isMapOpen && activeTab === 'myitems';
 
   // Handle instructions modal close
   const handleInstructionsClose = () => {


### PR DESCRIPTION
## Summary

Fixes camera orb visibility bug caused by activeTab case mismatch.

## Bug

Camera orb was never showing on My Items tab because:
- `useState` type uses **lowercase**: `'myitems'` 
- Visibility check used **camelCase**: `'myItems'` ❌

Result: Condition `activeTab === 'myItems'` never matched, so orb never appeared.

## Fix

Changed [App.tsx:506](modules/foundups/gotjunk/frontend/App.tsx#L506):
```tsx
// Before (wrong)
const showCameraOrb = !isMapOpen && activeTab === 'myItems';

// After (correct)
const showCameraOrb = !isMapOpen && activeTab === 'myitems';
```

## Verification

All other references correctly use lowercase `'myitems'`:
- Line 77: `useState<'browse' | 'myitems' | 'cart'>` ✓
- Line 573: `activeTab === 'myitems'` (tab section) ✓
- Line 705: `setActiveTab('myitems')` (navigation) ✓
- Line 728: `activeTab === 'myitems'` (button actions) ✓

## Result

Camera orb now correctly visible **ONLY** on My Items tab and hidden everywhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)