### PR TITLE
fix(gotjunk): Fix duplicate images and add fullscreen exit options

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/ItemReviewer.tsx
+++ b/modules/foundups/gotjunk/frontend/components/ItemReviewer.tsx
@@ -33,6 +33,14 @@ export const ItemReviewer: React.FC<ItemReviewerProps> = ({ item, onDecision, on
     const swipeThreshold = 50;
     const velocityThreshold = 200;
 
+    // Check for vertical swipe UP to close (collapse back to thumbnails)
+    if (onClose && (info.offset.y < -swipeThreshold || info.velocity.y < -velocityThreshold)) {
+      console.log('[ItemReviewer] Swipe up detected - closing fullscreen');
+      onClose();
+      return;
+    }
+
+    // Horizontal swipe for keep/delete
     let decision: 'keep' | 'delete' | null = null;
 
     if (info.offset.x > swipeThreshold || info.velocity.x > velocityThreshold) {
@@ -68,8 +76,8 @@ export const ItemReviewer: React.FC<ItemReviewerProps> = ({ item, onDecision, on
       style={{ zIndex: Z_LAYERS.fullscreen }}
       role="dialog"
       aria-modal="true"
-      drag="x"
-      dragConstraints={{ left: -150, right: 150 }}
+      drag
+      dragConstraints={{ left: -150, right: 150, top: -200, bottom: 50 }}
       dragElastic={0.2}
       onDragEnd={handleDragEnd}
       onClick={handleTap}
@@ -100,6 +108,32 @@ export const ItemReviewer: React.FC<ItemReviewerProps> = ({ item, onDecision, on
           />
         )}
       </div>
+
+      {/* Collapse button (-) - Bottom right corner */}
+      {onClose && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation(); // Prevent double-tap detection
+            onClose();
+          }}
+          className="absolute bottom-8 right-8 w-14 h-14 bg-gray-800/90 hover:bg-gray-700/90 active:scale-95 rounded-full flex items-center justify-center shadow-2xl border-2 border-gray-600 transition-all z-10"
+          aria-label="Collapse to thumbnails"
+        >
+          <svg
+            className="w-8 h-8 text-white"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={3}
+              d="M20 12H4"
+            />
+          </svg>
+        </button>
+      )}
     </motion.div>
   );
 };

--- a/modules/foundups/gotjunk/frontend/hooks/useLongPress.ts
+++ b/modules/foundups/gotjunk/frontend/hooks/useLongPress.ts
@@ -43,6 +43,7 @@ export function useLongPress({
   const longPressTriggeredRef = useRef(false);
   const startPosRef = useRef<{ x: number; y: number } | null>(null);
   const lastLongPressTimeRef = useRef<number>(0);
+  const lastTapTimeRef = useRef<number>(0); // Prevent double-tap from touch+mouse events
 
   const clear = useCallback(() => {
     if (timerRef.current) {
@@ -101,6 +102,17 @@ export function useLongPress({
 
     // Fire tap only if long-press wasn't triggered
     if (!longPressTriggeredRef.current && onTap) {
+      const now = Date.now();
+
+      // Prevent double-tap from touch+mouse events (mobile browsers fire both)
+      // Skip if onTap was called within 300ms (debounce)
+      if (now - lastTapTimeRef.current < 300) {
+        console.log('[useLongPress] Skipping duplicate tap event (touch+mouse collision)');
+        startPosRef.current = null;
+        return;
+      }
+
+      lastTapTimeRef.current = now;
       onTap(event);
     }
 


### PR DESCRIPTION
## Summary

Fixes two critical UX bugs reported by user testing:
1. **Duplicate images** when selecting "bid" classification
2. **No way to exit fullscreen** item view

## Bug #1: Duplicate Image Creation

**Problem**: Tapping "bid" classification created 2 duplicate images instead of 1

**Root Cause**: Touch+Mouse event collision on mobile browsers
- `onTouchEnd` → calls `onTap` → creates image #1
- Browser fires synthetic `onMouseUp` → calls `onTap` AGAIN → creates image #2

**Solution**: Added 300ms debounce in [useLongPress.ts](modules/foundups/gotjunk/frontend/hooks/useLongPress.ts)
```tsx
// Track last tap time to prevent duplicates
const lastTapTimeRef = useRef<number>(0);

// In handleEnd():
if (now - lastTapTimeRef.current < 300) {
  console.log('[useLongPress] Skipping duplicate tap event');
  return;
}
lastTapTimeRef.current = now;
onTap(event);
```

## Bug #2: Fullscreen Exit Options

**Problem**: After double-tapping thumbnail to open fullscreen, no way to return to thumbnail view

**Solutions Implemented**:

### 1. Swipe-up Gesture
[ItemReviewer.tsx:36-41](modules/foundups/gotjunk/frontend/components/ItemReviewer.tsx#L36-L41)
```tsx
// Check for vertical swipe UP to close
if (onClose && (info.offset.y < -swipeThreshold || info.velocity.y < -velocityThreshold)) {
  onClose();
  return;
}
```

### 2. Collapse Button ("-" icon)
[ItemReviewer.tsx:112-136](modules/foundups/gotjunk/frontend/components/ItemReviewer.tsx#L112-L136)
- Circular button with minus icon
- Bottom-right corner (bottom-8 right-8)
- Easy thumb access on mobile
- Gray background with hover effects

## Files Changed

1. **useLongPress.ts**: Added tap debouncing (300ms window)
2. **ItemReviewer.tsx**: 
   - Added swipe-up detection
   - Enabled vertical dragging
   - Added collapse button UI

## Testing

- ✅ Tap "bid" → Creates 1 image (not 2)
- ✅ Double-tap thumbnail → Opens fullscreen
- ✅ Swipe up → Collapses to thumbnails
- ✅ Click "-" button → Collapses to thumbnails
- ✅ Swipe left/right → Keep/delete still works

## User Experience Improvements

**Before**:
- Selecting "bid" = 2 duplicate images (confusing!)
- Fullscreen opens but no obvious way to close (user stuck!)

**After**:
- Selecting "bid" = 1 image (correct!)
- Fullscreen has 2 exit options: swipe up OR tap "-" button (intuitive!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)