### PR TITLE
fix(gotjunk): Move auto-classify toggle right of orb, increase orb 15%

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/BottomNavBar.tsx
+++ b/modules/foundups/gotjunk/frontend/components/BottomNavBar.tsx
@@ -158,15 +158,15 @@ export const BottomNavBar: React.FC<BottomNavBarProps> = ({
       {/* Camera Orb - Floating above nav bar */}
       {showCameraOrb && (
         <div
-          className="absolute left-1/2 -translate-x-1/2 bottom-32 flex flex-col items-center gap-3"
+          className="absolute left-1/2 -translate-x-1/2 bottom-32 flex flex-row items-center gap-4"
           style={{ zIndex: Z_LAYERS.cameraOrb }}
         >
             {/* Main capture button with live preview - Intelligent scaling: iPhone 11=143px, iPhone 16=149px */}
             <div
               className="p-2 bg-gray-800 rounded-full shadow-2xl cursor-pointer"
               style={{
-                width: 'clamp(128px, 16vh, 192px)',
-                height: 'clamp(128px, 16vh, 192px)'
+                width: 'clamp(147px, 18.4vh, 221px)', // 15% bigger: 128*1.15=147, 192*1.15=221
+                height: 'clamp(147px, 18.4vh, 221px)'
               }}
               onMouseDown={handlePressStart}
               onMouseUp={handlePressEnd}
@@ -176,7 +176,7 @@ export const BottomNavBar: React.FC<BottomNavBarProps> = ({
                  <Camera ref={cameraRef} onCapture={onCapture} captureMode={captureMode} />
             </div>
 
-            {/* Auto-Classify Toggle Button - Tap to toggle ON/OFF, Long-press to select classification */}
+            {/* Auto-Classify Toggle Button - Moved to RIGHT of orb to prevent accidental triggers */}
             <motion.button
               {...autoClassifyLongPress}
               className={`px-4 py-2 rounded-full shadow-lg font-semibold text-sm transition-all ${


### PR DESCRIPTION
## Orb Layout UX Improvement

Moves auto-classify toggle to the right of the camera orb to prevent accidental triggers when taking pictures.

### Changes

#### 1. Toggle Repositioned
- **Before**: Toggle below orb (vertical layout)
- **After**: Toggle to **right** of orb (horizontal layout)
- Changed from `flex-col` → `flex-row`
- Gap: 4 units (gap-4) between orb and toggle

#### 2. Camera Orb 15% Bigger
- **Old size**: `clamp(128px, 16vh, 192px)`
- **New size**: `clamp(147px, 18.4vh, 221px)`
  - Min: 128 × 1.15 = **147px**
  - Responsive: 16vh × 1.15 = **18.4vh**
  - Max: 192 × 1.15 = **221px**
- Kept center placement (`left-1/2 -translate-x-1/2`)

### Visual Layout

**Before**:
```
  [ORB]
  [AUTO]  ← Below orb (accidental triggers)
```

**After**:
```
  [ORB] [AUTO]  ← Right of orb (safer)
   ↑
  15% bigger
```

### UX Benefit
- **No accidental toggle triggers** when tapping orb to take pictures
- **Bigger orb** = easier to tap for photo capture
- **Horizontal layout** = better use of screen real estate

### Build Status
✅ TypeScript compilation succeeded (429.70 kB)

### Files Modified
- `BottomNavBar.tsx` - Layout and orb size

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)