### PR TITLE
fix(gotjunk): Fix browse swipe + layout improvements

### DIFF
--- a/modules/foundups/gotjunk/frontend/App.tsx
+++ b/modules/foundups/gotjunk/frontend/App.tsx
@@ -661,7 +661,7 @@ const App: React.FC = () => {
                 <ItemReviewer
                   key={filteredBrowseFeed[0].id}
                   item={filteredBrowseFeed[0]}
-                  onDecision={(decision) => handleBrowseSwipe(filteredBrowseFeed[0], decision === 'keep' ? 'right' : 'left')}
+                  onDecision={(item, decision) => handleBrowseSwipe(item, decision === 'keep' ? 'right' : 'left')}
                 />
               )}
             </AnimatePresence>

--- a/modules/foundups/gotjunk/frontend/components/BottomNavBar.tsx
+++ b/modules/foundups/gotjunk/frontend/components/BottomNavBar.tsx
@@ -158,15 +158,20 @@ export const BottomNavBar: React.FC<BottomNavBarProps> = ({
       {/* Camera Orb - Floating above nav bar */}
       {showCameraOrb && (
         <div
-          className="absolute left-1/2 -translate-x-1/2 bottom-32 flex flex-row items-center gap-4"
-          style={{ zIndex: Z_LAYERS.cameraOrb }}
+          className="absolute bottom-32 flex flex-row items-center gap-4"
+          style={{
+            zIndex: Z_LAYERS.cameraOrb,
+            left: 'calc(50% - 5px)', // Moved 5px left to re-center
+            transform: 'translateX(-50%)'
+          }}
         >
             {/* Main capture button with live preview - Intelligent scaling: iPhone 11=143px, iPhone 16=149px */}
             <div
               className="p-2 bg-gray-800 rounded-full shadow-2xl cursor-pointer"
               style={{
                 width: 'clamp(147px, 18.4vh, 221px)', // 15% bigger: 128*1.15=147, 192*1.15=221
-                height: 'clamp(147px, 18.4vh, 221px)'
+                height: 'clamp(147px, 18.4vh, 221px)',
+                aspectRatio: '1 / 1' // Ensure perfect circle
               }}
               onMouseDown={handlePressStart}
               onMouseUp={handlePressEnd}
@@ -188,8 +193,12 @@ export const BottomNavBar: React.FC<BottomNavBarProps> = ({
                     : lastClassification?.type === 'bid'
                     ? 'bg-amber-600 text-white'     // Bid = Amber
                     : 'bg-green-600 text-white'     // Fallback = Green
-                  : 'bg-red-600/80 text-white'      // OFF = Red
+                  : 'bg-red-500/60 text-white'      // OFF = Softer red
               }`}
+              style={{
+                marginLeft: '10px',  // 10px right
+                marginTop: '10px'    // 10px down
+              }}
               variants={buttonVariants}
               whileHover="hover"
               whileTap="tap"

--- a/modules/foundups/gotjunk/frontend/components/LeftSidebarNav.tsx
+++ b/modules/foundups/gotjunk/frontend/components/LeftSidebarNav.tsx
@@ -68,7 +68,7 @@ export const LeftSidebarNav: React.FC<LeftSidebarNavProps> = ({
       animate={{ opacity: 1, x: 0 }}
       className="fixed left-4 sm:left-6 flex flex-col items-center pointer-events-auto"
       style={{
-        top: '50%',
+        top: 'calc(50% - 5px)', // Moved up 5px
         transform: 'translateY(-50%)',
         gap: gapValue,
         zIndex: Z_LAYERS.sidebar,


### PR DESCRIPTION
## Browse Swipe Fix + Layout Improvements

Fixes critical browse swipe bug and multiple UX layout adjustments.

### 🐛 Bug Fix: Browse Right Swipe

**Issue**: Right swipe on browse screen was NOT adding items to cart.

**Root Cause**: `onDecision` callback had wrong signature
```typescript
// BEFORE (broken)
onDecision={(decision) => handleBrowseSwipe(filteredBrowseFeed[0], decision === 'keep' ? 'right' : 'left')}

// AFTER (fixed)
onDecision={(item, decision) => handleBrowseSwipe(item, decision === 'keep' ? 'right' : 'left')}
```

**Why it failed**:
- `ItemReviewer` calls `onDecision(item, decision)` with TWO parameters
- Browse tab only accepted ONE parameter (`decision`)
- First parameter (item) was bound to `decision` variable
- Second parameter (actual decision) was ignored
- Result: swipe detection always received wrong data

**Now**: Right swipe properly adds items to cart ✅

### 🎨 Layout Improvements

#### 1. Auto-Classify Toggle Position
- Moved **10px right** (marginLeft)
- Moved **10px down** (marginTop)
- Better separation from camera orb

#### 2. Toggle Color: Softer Red (OFF state)
- **Before**: `bg-red-600/80` (bold, aggressive)
- **After**: `bg-red-500/60` (softer, less distracting)

#### 3. Camera Orb Adjustments
- Moved **5px left** to re-center: `left: calc(50% - 5px)`
- Added `aspectRatio: 1 / 1` to ensure **perfect circle**
- Orb was appearing slightly elliptical

#### 4. Sidebar Buttons Position
- Moved **up 5px**: `top: calc(50% - 5px)`
- Better vertical screen alignment

### Visual Comparison

**Toggle Position**:
```
Before: [ORB] [AUTO]
After:  [ORB]    [AUTO]  (10px right, 10px down)
               ↘
```

**Toggle Color**:
- Before: 🔴 Bold red (bg-red-600/80)
- After: 🟥 Softer red (bg-red-500/60)

### Files Modified
- `App.tsx` - Fixed browse swipe onDecision callback
- `BottomNavBar.tsx` - Toggle position, color, orb centering
- `LeftSidebarNav.tsx` - Sidebar vertical position

### Build Status
✅ TypeScript: **429.80 kB** (gzip: 134.30 kB)

### Testing
- ✅ Browse right swipe adds to cart
- ✅ Toggle positioned 10px right, 10px down
- ✅ Red color softer (less bold)
- ✅ Orb is perfect circle, re-centered
- ✅ Sidebar buttons moved up 5px

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)