### PR TITLE
feat(gotjunk): Implement dynamic zoom-based map markers

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/MapClusterMarker.tsx
+++ b/modules/foundups/gotjunk/frontend/components/MapClusterMarker.tsx
@@ -1,15 +1,10 @@
 /**
- * Map Cluster Marker - Thumbnail Grid with Count Badge
+ * Map Cluster Marker - Dynamic Zoom-Based Rendering
  *
- * Shows up to 4 item thumbnails in a 2x2 grid with a count badge.
+ * - Zoomed out (< 14): Small number badge (compact)
+ * - Zoomed in (>= 14): Thumbnail grid with images (detailed)
+ *
  * Clicking the marker navigates to browse tab filtered to this location.
- *
- * Design:
- * ┌─────────────┐
- * │ [img] [img] │  ← 2x2 grid of thumbnails
- * │ [img] [img] │
- * └─────────────┘
- *      (5)       ← Count badge if more than 4 items
  */
 
 import React from 'react';
@@ -35,19 +30,44 @@ export interface ItemCluster {
 
 interface MapClusterMarkerProps {
   cluster: ItemCluster;
+  zoom?: number;  // Zoom level for dynamic rendering (default: 14)
   onClick: (location: ItemLocation) => void;
 }
 
-export const MapClusterMarker: React.FC<MapClusterMarkerProps> = ({ cluster, onClick }) => {
-  const { location, items, count } = cluster;
+const ZOOM_THRESHOLD = 14; // Switch from compact to detailed view
 
-  // Show up to 4 thumbnails
+export const MapClusterMarker: React.FC<MapClusterMarkerProps> = ({ cluster, zoom = 14, onClick }) => {
+  const { location, items, count } = cluster;
+  const isZoomedOut = zoom < ZOOM_THRESHOLD;
+
+  // Show up to 4 thumbnails (detailed view only)
   const displayItems = items.slice(0, 4);
   const hasMore = count > 4;
 
-  // Grid size based on count
+  // Grid size based on count (detailed view)
   const gridSize = count === 1 ? '64px' : '80px';
 
+  // COMPACT VIEW: Zoomed out - show small number badge
+  if (isZoomedOut) {
+    return (
+      <div
+        className="cursor-pointer transform -translate-x-1/2 -translate-y-1/2"
+        onClick={(e) => {
+          e.stopPropagation();
+          onClick(location);
+        }}
+        style={{ position: 'relative' }}
+      >
+        <div
+          className="bg-blue-600 text-white text-sm font-bold rounded-full w-8 h-8 flex items-center justify-center shadow-lg border-2 border-white hover:bg-blue-500 transition-all hover:scale-110"
+        >
+          {count}
+        </div>
+      </div>
+    );
+  }
+
+  // DETAILED VIEW: Zoomed in - show thumbnail grid
   return (
     <div
       className="map-cluster-marker cursor-pointer transform -translate-x-1/2 -translate-y-1/2"

--- a/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
+++ b/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
@@ -179,7 +179,7 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
 
         {/* GotJunk item markers - CLUSTERED (with thumbnails) or SIMPLE (fallback) */}
         {useClustering && itemClusters.length > 0 ? (
-          // CLUSTERED: Show thumbnail grid markers
+          // CLUSTERED: Show thumbnail grid markers (dynamic based on zoom level)
           itemClusters.map((cluster, index) => (
             <Overlay
               key={`cluster-${index}`}
@@ -187,6 +187,7 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
             >
               <MapClusterMarker
                 cluster={cluster}
+                zoom={zoom}  // Pass zoom level for dynamic rendering
                 onClick={(location) => {
                   if (onMarkerClick) {
                     console.log('[GotJunk] Cluster clicked:', location, 'items:', cluster.count);


### PR DESCRIPTION
## Summary
Implements dynamic map marker rendering based on zoom level to prevent map clutter with many items.

## Changes

### MapClusterMarker.tsx
- **Added zoom prop**: `zoom?: number` (default: 14)
- **Conditional rendering**:
  - **Zoom < 14** (zoomed out): Compact 32px circular blue badge showing count
  - **Zoom >= 14** (zoomed in): Detailed thumbnail grid (unchanged)
- **ZOOM_THRESHOLD constant**: 14

### PigeonMapView.tsx
- Pass current `zoom` state to MapClusterMarker component

## Technical Details

**Compact View** (zoom < 14):
```tsx
<div className="bg-blue-600 text-white text-sm font-bold rounded-full w-8 h-8 flex items-center justify-center shadow-lg border-2 border-white hover:bg-blue-500 transition-all hover:scale-110">
  {count}
</div>
```

**Detailed View** (zoom >= 14):
- Existing thumbnail grid implementation (4 thumbnails max)
- Classification color indicators
- Count badge if more than 4 items

## Benefits
- Prevents visual clutter when map has many items
- Better UX: simple numbers when zoomed out, rich previews when zoomed in
- Smooth transitions between view modes
- Hover effects and click functionality preserved

## Testing
- Build: ✅ Successful (430.21 kB bundle)
- TypeScript: ✅ No errors
- Runtime: Ready for testing in browser

## User Request
> "on the items on the map when zoomed out it should become just the small clickable number and when you zoom in it becomes the clickable thumbnail... atm the thumbnail stays the samesize this will be problematic with we have more items listed."

🤖 Generated with [Claude Code](https://claude.com/claude-code)