### PR TITLE
fix(gotjunk): Fix cart purchase > button and cancel behavior

### DIFF
--- a/modules/foundups/gotjunk/frontend/App.tsx
+++ b/modules/foundups/gotjunk/frontend/App.tsx
@@ -802,6 +802,7 @@ const App: React.FC = () => {
                 <ItemReviewer
                   key={reviewingCartItem.id}
                   item={reviewingCartItem}
+                  showForwardButton={true}  // Show > button for purchase
                   onDecision={(item, decision) => {
                     if (decision === 'keep') {
                       // Right swipe in cart → Purchase confirmation
@@ -1043,7 +1044,9 @@ const App: React.FC = () => {
         onCancel={() => {
           console.log('[GotJunk] Purchase cancelled');
           setPurchasingItem(null);
-          // Keep reviewingCartItem and queue - user can try again or swipe to other items
+          // Return to cart thumbnails view (close fullscreen)
+          setReviewingCartItem(null);
+          setCartReviewQueue([]);
         }}
       />
 

--- a/modules/foundups/gotjunk/frontend/components/ItemReviewer.tsx
+++ b/modules/foundups/gotjunk/frontend/components/ItemReviewer.tsx
@@ -8,9 +8,10 @@ interface ItemReviewerProps {
   item: CapturedItem;
   onDecision: (item: CapturedItem, decision: 'keep' | 'delete') => void;
   onClose?: () => void; // Optional: close fullscreen without making a decision
+  showForwardButton?: boolean; // Optional: show > button for cart purchase
 }
 
-export const ItemReviewer: React.FC<ItemReviewerProps> = ({ item, onDecision, onClose }) => {
+export const ItemReviewer: React.FC<ItemReviewerProps> = ({ item, onDecision, onClose, showForwardButton = false }) => {
   const [swipeDecision, setSwipeDecision] = useState<'keep' | 'delete' | null>(null);
   const lastTapRef = useRef<number>(0);
 
@@ -130,6 +131,32 @@ export const ItemReviewer: React.FC<ItemReviewerProps> = ({ item, onDecision, on
               strokeLinejoin="round"
               strokeWidth={3}
               d="M20 12H4"
+            />
+          </svg>
+        </button>
+      )}
+
+      {/* Forward button (>) - Bottom left corner (for cart purchase) */}
+      {showForwardButton && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation(); // Prevent double-tap detection
+            onDecision(item, 'keep'); // Trigger purchase
+          }}
+          className="absolute bottom-8 left-8 w-14 h-14 bg-green-600/90 hover:bg-green-500/90 active:scale-95 rounded-full flex items-center justify-center shadow-2xl border-2 border-green-400 transition-all z-10"
+          aria-label="Purchase Item"
+        >
+          <svg
+            className="w-8 h-8 text-white"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={3}
+              d="M9 5l7 7-7 7"
             />
           </svg>
         </button>


### PR DESCRIPTION
## Summary
Fixes two user-reported bugs in the cart purchase flow: missing > button for purchase and broken cancel button behavior.

## User-Reported Bugs

1. **> Button Not Working**:
   > "the purchase swipe works but the > button does not"

2. **Cancel Button Does Nothing**:
   > "on the purchase item screen the 'cancel' does nothing it should return to the my cart thumbnails view"

## Changes

### 1. ItemReviewer.tsx - Added Forward Button (>)

**New Prop**:
```typescript
showForwardButton?: boolean  // Show > button for purchase
```

**Button Implementation**:
```tsx
{showForwardButton && (
  <button
    onClick={() => onDecision(item, 'keep')}
    className="absolute bottom-8 left-8 w-14 h-14 bg-green-600/90 ..."
  >
    <svg>  {/* Chevron-right icon */}
      <path d="M9 5l7 7-7 7" />
    </svg>
  </button>
)}
```

**Button Design**:
- **Position**: Bottom-left corner (opposite collapse button)
- **Color**: Green (purchase action color)
- **Size**: 56px × 56px (matches collapse button)
- **Icon**: Chevron-right (>)
- **Action**: Triggers `onDecision('keep')` → opens purchase modal

### 2. App.tsx - Enable Forward Button for Cart

**Cart ItemReviewer**:
```tsx
<ItemReviewer
  item={reviewingCartItem}
  showForwardButton={true}  // NEW: Enable > button
  onDecision={(item, decision) => {
    if (decision === 'keep') {
      setPurchasingItem(item);  // Open purchase modal
    }
  }}
/>
```

### 3. App.tsx - Fix Cancel Button Behavior

**Before** (broken):
```typescript
onCancel={() => {
  setPurchasingItem(null);  // Only closes modal
  // Fullscreen stays open (confusing)
}}
```

**After** (fixed):
```typescript
onCancel={() => {
  setPurchasingItem(null);      // Close modal
  setReviewingCartItem(null);   // Close fullscreen
  setCartReviewQueue([]);       // Clear queue
  // Returns to cart thumbnails ✓
}}
```

## User Flows

### Purchase with > Button (Fixed)
1. Double-tap cart item → fullscreen
2. **Click > button** (NEW)
3. Purchase modal opens ✓

### Purchase with Swipe (Already Working)
1. Double-tap cart item → fullscreen
2. Swipe right
3. Purchase modal opens ✓

### Cancel Purchase (Fixed)
1. Purchase modal open
2. **Click Cancel** button
3. Returns to cart thumbnail grid ✓
4. Can select another item or exit

### Confirm Purchase (Already Working)
1. Purchase modal open
2. Click Confirm
3. Item removed from cart
4. Next item or return to thumbnails

## UI Layout

**Cart Fullscreen View**:
```
┌─────────────────────────┐
│     [Item Image]        │
│                         │
│                         │
│                         │
│                         │
│   [>]           [-]     │  ← Bottom buttons
└─────────────────────────┘
 Green          Gray
 Purchase       Collapse
```

**Button Positions**:
- **>** (green): `bottom-8 left-8` - Purchase action
- **-** (gray): `bottom-8 right-8` - Collapse to thumbnails

## Testing

- **Build**: ✅ Successful (431.98 kB bundle)
- **TypeScript**: ✅ No errors
- **Forward Button**: ✅ Triggers purchase modal
- **Cancel Button**: ✅ Returns to cart thumbnails
- **Swipe Still Works**: ✅ Both methods functional

## Benefits

✅ **> Button Works** - Users can purchase with button OR swipe  
✅ **Cancel Returns to Cart** - Expected behavior restored  
✅ **Visual Consistency** - Green = purchase, gray = close  
✅ **Better Accessibility** - Button option for non-swipe users  
✅ **Clear Actions** - Intuitive button placement and colors  

## Before/After

**Before**:
- ❌ No > button available for purchase
- ❌ Cancel button leaves fullscreen open (confusing)
- Users forced to use swipe gestures

**After**:
- ✅ > button triggers purchase modal
- ✅ Cancel button returns to cart thumbnails
- Users can choose button OR swipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)