### PR TITLE
fix(gotjunk): Fix white map - variable reference before declaration

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
+++ b/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
@@ -52,6 +52,10 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
   onLibertyActivate,
   onLibertyCapture,
 }) => {
+  // Liberty Global View Toggle (MUST be declared before use in center calculation)
+  const [isGlobalLiberty, setIsGlobalLiberty] = useState(false);
+  const [selectedRegion, setSelectedRegion] = useState<{ latitude: number; longitude: number } | null>(null);
+
   // Global view for Liberty Alerts (world map), local view for GotJunk items
   const isGlobalView = showLibertyAlerts && isGlobalLiberty;
 
@@ -76,10 +80,6 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
   // Liberty Alert Camera (for capturing alerts on map)
   const libertyCameraRef = useRef<CameraHandle>(null);
   const [isCameraOpen, setIsCameraOpen] = useState(false);
-
-  // Liberty Global View Toggle
-  const [isGlobalLiberty, setIsGlobalLiberty] = useState(false);
-  const [selectedRegion, setSelectedRegion] = useState<{ latitude: number; longitude: number } | null>(null);
 
   // Swipe gesture detection
   const touchStartY = useRef<number>(0);


### PR DESCRIPTION
## Critical Bug Fix

Fixes white map crash caused by variable reference before declaration.

## Root Cause

**Lines affected**:
- Line 56: `const isGlobalView = showLibertyAlerts && isGlobalLiberty;` ❌ (used before declaration)
- Line 81: `const [isGlobalLiberty, setIsGlobalLiberty] = useState(false);` (declared too late)

**JavaScript ReferenceError**: Cannot access lexical declaration 'isGlobalLiberty' before initialization

This caused the Map component to crash during initialization, resulting in a white screen.

## Fix

✅ **Moved state declarations to top**:
- `isGlobalLiberty` now declared at line 56 (before use at line 60)
- `selectedRegion` moved with it (line 57)
- Added comment: "MUST be declared before use in center calculation"

## Testing

**Before fix**:
- White map screen on app load
- Component crash (ReferenceError)
- Non-functional map view

**After fix**:
- Map renders correctly
- Default zoom level 12
- User location marker visible
- No JavaScript errors

## Files Changed

- [components/PigeonMapView.tsx](modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx): Reordered state declarations (4 lines)

## Impact

- ✅ Fixes production white map issue
- ✅ Restores map functionality
- ✅ Critical deployment blocker resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)