### PR TITLE
feat(map): Add arrow navigation for map items (Liberty + regular)

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
+++ b/modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx
@@ -35,6 +35,7 @@ interface PigeonMapViewProps {
   showLibertyAlerts?: boolean;
   useClustering?: boolean;  // Enable/disable clustering (default: true)
   onLibertyActivate?: () => void;  // NEW: Callback when SOS morse code detected
+  navigationCenter?: { latitude: number; longitude: number } | null;  // NEW: Center map on this location (for arrow navigation)
 }
 
 export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
@@ -47,6 +48,7 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
   showLibertyAlerts = false,
   useClustering = true,
   onLibertyActivate,
+  navigationCenter = null,
 }) => {
   // Liberty Global View Toggle (MUST be declared before use in center calculation)
   const [isGlobalLiberty, setIsGlobalLiberty] = useState(false);
@@ -57,6 +59,8 @@ export const PigeonMapView: React.FC<PigeonMapViewProps> = ({
 
   const center: [number, number] = isGlobalView
     ? [20, 0] // World center (shows entire globe with all continents)
+    : navigationCenter
+    ? [navigationCenter.latitude, navigationCenter.longitude] // Arrow navigation center (priority)
     : selectedRegion
     ? [selectedRegion.latitude, selectedRegion.longitude] // Zoomed to selected 🗽 region
     : userLocation


### PR DESCRIPTION
## Summary
Implements map-specific navigation using < and > arrows without breaking existing Browse/My Items delete/keep functionality. Arrows now navigate between items on the map, with automatic centering and Liberty/regular item separation.

## Problem

**Before**:
- < and > arrows unusable on map view (BottomNavBar was hidden)
- No way to navigate between map items
- Liberty items and regular items mixed together
- Couldn't scroll through items without closing map

**User Request**: "can the red < and green > on map used to navigate map items and flags? for example if on liberty map then it toggles LibertyAlertFlags if on map CapturedItem? currently the < and > will delete items on the map... we want it to have that behavior on brose and my items but on map view it becomes a scroll"

## Solution

### Architecture Changes

**Added Map Navigation State**:
- `currentMapItemIndex` - Track current item in navigation
- `mapNavigationCenter` - Location to center map on during navigation
- `mapNavigableItems` - Computed array based on Liberty mode

**Liberty-Aware Navigation**:
```typescript
// Liberty mode: navigate only Liberty items (🧊)
const mapNavigableItems = libertyEnabled
  ? browseFeed.filter(item => item.libertyAlert && item.latitude && item.longitude)
  : browseFeed.filter(item => !item.libertyAlert && item.latitude && item.longitude);
```

### Implementation Details

#### 1. Conditional Arrow Behavior ([App.tsx:1048-1064](modules/foundups/gotjunk/frontend/App.tsx#L1048-L1064))

```typescript
onReviewAction={(action) => {
  // MAP VIEW: Use arrows for navigation (not delete/keep)
  if (isMapOpen) {
    if (action === 'delete') {
      handleMapNavigatePrevious(); // Left arrow = previous item
    } else {
      handleMapNavigateNext(); // Right arrow = next item
    }
  }
  // BROWSE/MY ITEMS: Use arrows for delete/keep (existing behavior - UNCHANGED)
  else if (activeTab === 'browse' && filteredBrowseFeed.length > 0) {
    handleBrowseSwipe(filteredBrowseFeed[0], action === 'keep' ? 'right' : 'left');
  } else if (activeTab === 'myitems' && currentReviewItem) {
    handleReviewDecision(currentReviewItem, action);
  }
}}
```

#### 2. Navigation Handlers ([App.tsx:691-716](modules/foundups/gotjunk/frontend/App.tsx#L691-L716))

```typescript
const handleMapNavigateNext = () => {
  if (mapNavigableItems.length === 0) return;
  const nextIndex = (currentMapItemIndex + 1) % mapNavigableItems.length; // Wrap around
  setCurrentMapItemIndex(nextIndex);
  const nextItem = mapNavigableItems[nextIndex];
  setMapNavigationCenter({ latitude: nextItem.latitude, longitude: nextItem.longitude });
};

const handleMapNavigatePrevious = () => {
  if (mapNavigableItems.length === 0) return;
  const prevIndex = currentMapItemIndex === 0 ? mapNavigableItems.length - 1 : currentMapItemIndex - 1;
  setCurrentMapItemIndex(prevIndex);
  const prevItem = mapNavigableItems[prevIndex];
  setMapNavigationCenter({ latitude: prevItem.latitude, longitude: prevItem.longitude });
};
```

#### 3. Map Centering ([PigeonMapView.tsx:60-68](modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx#L60-L68))

```typescript
const center: [number, number] = isGlobalView
  ? [20, 0] // World center (Liberty global view)
  : navigationCenter
  ? [navigationCenter.latitude, navigationCenter.longitude] // PRIORITY: Arrow navigation
  : selectedRegion
  ? [selectedRegion.latitude, selectedRegion.longitude] // Clicked 🗽 region
  : userLocation
  ? [userLocation.latitude, userLocation.longitude] // User's location
  : [37.7749, -122.4194]; // Default: San Francisco
```

#### 4. Reset Logic ([App.tsx:305-317](modules/foundups/gotjunk/frontend/App.tsx#L305-L317))

```typescript
useEffect(() => {
  if (isMapOpen) {
    setCurrentMapItemIndex(0); // Reset to first item
    if (mapNavigableItems.length > 0) {
      const firstItem = mapNavigableItems[0];
      setMapNavigationCenter({ latitude: firstItem.latitude, longitude: firstItem.longitude });
    }
  }
}, [isMapOpen, libertyEnabled]); // Reset when map opens or Liberty mode changes
```

## User Flow

### Regular Map Navigation
1. Open map view
2. Map auto-centers on first regular item (without `libertyAlert` flag)
3. Press **> (right green arrow)** → navigate to next regular item, map centers
4. Press **< (left red arrow)** → navigate to previous regular item, map centers
5. Navigation wraps around (last → first, first → last)

### Liberty Map Navigation
1. Unlock Liberty mode (SOS morse code: `...___...`)
2. Open map view
3. Map auto-centers on first Liberty item (`libertyAlert: true`, shown as 🧊)
4. Press **>** → navigate to next Liberty item, map centers on 🧊 marker
5. Press **<** → navigate to previous Liberty item, map centers on 🧊 marker
6. Only Liberty items in navigation rotation (regular items excluded)

### Browse/My Items (UNCHANGED)
1. On Browse tab: **<** deletes/skips item, **>** adds to cart
2. On My Items tab: **<** deletes item, **>** keeps item
3. Existing behavior fully preserved ✅

## Benefits

- ✅ **Map navigation** without breaking existing functionality
- ✅ **Liberty-aware** separation (navigate only Liberty items when enabled)
- ✅ **Auto-centering** on current item during navigation
- ✅ **Arrows visible** and functional on map
- ✅ **Proper reset** when switching modes or closing map
- ✅ **Wrapping navigation** (seamless looping)
- ✅ **Zero impact** on Browse/My Items behavior

## Technical Details

**Files Modified**: 2
- [App.tsx](modules/foundups/gotjunk/frontend/App.tsx) (+60 lines)
  - Added navigation state and handlers
  - Modified `onReviewAction` conditional logic
  - Added reset `useEffect`
  - Made BottomNavBar visible on map
  - Updated `hasReviewItems` for map
  
- [PigeonMapView.tsx](modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx) (+3 lines)
  - Added `navigationCenter` prop to interface
  - Updated `center` calculation to prioritize `navigationCenter`

**Net Change**: +63 lines (navigation logic + state management)

**Module Size**: Similar to previous build (~435 kB)

## Testing Checklist

### Regular Map
- [ ] Open map view
- [ ] Verify map centers on first regular item
- [ ] Press > arrow → verify navigation to next item
- [ ] Verify map centers on new item
- [ ] Press < arrow → verify navigation to previous item
- [ ] Navigate to last item, press > → verify wraps to first
- [ ] Navigate to first item, press < → verify wraps to last

### Liberty Map
- [ ] Unlock Liberty mode via SOS morse code
- [ ] Capture photo with Liberty flag
- [ ] Open map view
- [ ] Verify map centers on first Liberty item (🧊)
- [ ] Press > arrow → verify navigation only through Liberty items
- [ ] Press < arrow → verify previous Liberty item
- [ ] Verify regular items excluded from navigation

### Browse/My Items (Regression)
- [ ] Switch to Browse tab
- [ ] Press < arrow → verify item deleted/skipped
- [ ] Press > arrow → verify item added to cart
- [ ] Switch to My Items tab
- [ ] Press < arrow → verify item deleted
- [ ] Press > arrow → verify item kept

## WSP Compliance

- ✅ **WSP 50**: Reused existing navigation logic patterns
- ✅ **WSP 87**: Clear separation of concerns (map vs browse/myitems)
- ✅ **WSP 22**: ModLog will be updated post-merge

## Dependencies

None - This is a pure enhancement of existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)