### PR TITLE
fix(map): Camera orb appears only after SOS activation

### DIFF
--- a/modules/foundups/gotjunk/frontend/App.tsx
+++ b/modules/foundups/gotjunk/frontend/App.tsx
@@ -839,7 +839,7 @@ const App: React.FC = () => {
     : browseFeed.filter(item => !item.libertyAlert && item.latitude && item.longitude);
 
   const currentReviewItem = myDrafts.length > 0 ? myDrafts[0] : null;
-  const showCameraOrb = isMapOpen || activeTab === 'myitems'; // Camera visible on map (for Liberty Alerts) + My Items tab
+  const showCameraOrb = (isMapOpen && libertyEnabled) || activeTab === 'myitems'; // Camera orb appears on map AFTER SOS activation + always on My Items tab
 
   // Handle instructions modal close
   const handleInstructionsClose = () => {


### PR DESCRIPTION
## Summary
Fixed camera orb visibility logic - now only appears on map **after** SOS morse code activation, not before.

## Changes

**File Modified**: [App.tsx:842](modules/foundups/gotjunk/frontend/App.tsx#L842)

```typescript
// BEFORE
const showCameraOrb = isMapOpen || activeTab === 'myitems';

// AFTER  
const showCameraOrb = (isMapOpen && libertyEnabled) || activeTab === 'myitems';
```

## User Flow

### Map View
1. **Open map** → No camera orb visible ❌
2. **Tap SOS morse code** (`...___...`) → Camera orb appears ✅
3. **Capture Liberty Alerts** → Orb with 🗽 badge ready

### My Items Tab
- Camera orb **always visible** (unchanged behavior) ✅

## Technical Details

**Visibility Logic**:
- Map view: `isMapOpen && libertyEnabled` (requires SOS activation)
- My Items: `activeTab === 'myitems'` (always visible)

**State Management**:
- SOS detection in [PigeonMapView.tsx:183-187](modules/foundups/gotjunk/frontend/components/PigeonMapView.tsx#L183-L187)
- Triggers `setLibertyEnabled(true)` → Camera orb appears
- Liberty badge (🗽) renders on orb when `libertyEnabled=true`

## Build Results
- **Status**: ✅ Success
- **Time**: 2.90s
- **Size**: 468.15 kB
- **Gzip**: 140.96 kB

## Testing Checklist
- [ ] Open map → Verify no camera orb visible
- [ ] Perform SOS morse code → Verify camera orb appears
- [ ] Verify Liberty badge (🗽) on orb
- [ ] Switch to My Items → Verify camera orb visible
- [ ] Capture photo on My Items → Verify works
- [ ] Capture Liberty Alert on map → Verify classification modal

## WSP Compliance
- ✅ WSP 50: Occam's Razor (1-line change, existing logic)
- ✅ WSP 87: Clear component hierarchy (no new components)
- ✅ WSP 22: ModLog will be updated post-merge

## Related PRs
- Fixes behavior from PR #117 (originally made orb always visible on map)
- Builds on PR #118 (11-category auto-classify)
- Builds on PR #119 (missing ActionSheet components)

🤖 Generated with [Claude Code](https://claude.com/claude-code)