### PR TITLE
fix(classification): Use defaults on tap, fix bid duration, fix delete

### DIFF
--- a/modules/foundups/gotjunk/frontend/App.tsx
+++ b/modules/foundups/gotjunk/frontend/App.tsx
@@ -570,7 +570,7 @@ const App: React.FC = () => {
 
       // Use provided values or defaults
       const finalDiscountPercent = discountPercent || 75;
-      const finalBidDurationHours = bidDurationHours || 48;
+      const finalBidDurationHours = bidDurationHours || 72;
 
       if (classification === 'free') {
         price = 0;
@@ -681,6 +681,8 @@ const App: React.FC = () => {
     URL.revokeObjectURL(itemToDelete.url);
     await storage.deleteItem(itemToDelete.id);
     setMyListed(current => current.filter(item => item.id !== itemToDelete.id));
+    setMyDrafts(current => current.filter(item => item.id !== itemToDelete.id));
+    setBrowseFeed(current => current.filter(item => item.id !== itemToDelete.id));
   };
 
   // BROWSE FEED: Handle swipe actions on other people's items

--- a/modules/foundups/gotjunk/frontend/components/ClassificationModal.tsx
+++ b/modules/foundups/gotjunk/frontend/components/ClassificationModal.tsx
@@ -63,7 +63,7 @@ export const ClassificationModal: React.FC<ClassificationModalProps> = ({
   });
   const [bidDurationHours, setBidDurationHours] = useState(() => {
     const saved = localStorage.getItem('gotjunk_default_bid_duration');
-    return saved ? parseInt(saved, 10) : 48;
+    return saved ? parseInt(saved, 10) : 72;
   });
 
   // ============================================================================
@@ -72,13 +72,13 @@ export const ClassificationModal: React.FC<ClassificationModalProps> = ({
 
   const discountLongPress = useLongPress({
     onLongPress: () => setDiscountSheetOpen(true),
-    onTap: () => setDiscountSheetOpen(true), // Always open action sheet
+    onTap: () => onClassify('discount', discountPercent), // Tap = use default 75% off
     threshold: 450,
   });
 
   const bidLongPress = useLongPress({
     onLongPress: () => setBidSheetOpen(true),
-    onTap: () => setBidSheetOpen(true), // Always open action sheet
+    onTap: () => onClassify('bid', undefined, bidDurationHours), // Tap = use default 72h
     threshold: 450,
   });
 


### PR DESCRIPTION
## Summary
Fixes classification UX to use defaults on tap (long-press to customize) + changes bid default to 72h + fixes delete to remove items from all UI locations.

## Problem
User reported multiple classification issues:
1. Discount asks for percentage selection - should default to 75% off (only long-press allows changing)
2. Bid asks for duration - should default to 72 hours (only long-press allows changing)  
3. Deleted items from user inventory not removed from browse feed/map
4. Current bid default was 48h instead of 72h

## Changes

### 1. Discount/Bid Tap Behavior

**Before**:
- Tap Discount → Always open action sheet (forces user to select)
- Tap Bid → Always open action sheet (forces user to select)

**After**:
- **Tap** Discount → Immediately classify with 75% off default ✅
- **Long-press** Discount → Open action sheet to customize percentage
- **Tap** Bid → Immediately classify with 72h default ✅
- **Long-press** Bid → Open action sheet to customize duration

**[ClassificationModal.tsx:73-83](modules/foundups/gotjunk/frontend/components/ClassificationModal.tsx#L73-L83)**:
```typescript
const discountLongPress = useLongPress({
  onLongPress: () => setDiscountSheetOpen(true),
  onTap: () => onClassify('discount', discountPercent), // ✅ Use default
  threshold: 450,
});

const bidLongPress = useLongPress({
  onLongPress: () => setBidSheetOpen(true),
  onTap: () => onClassify('bid', undefined, bidDurationHours), // ✅ Use default
  threshold: 450,
});
```

### 2. Bid Default Duration: 48h → 72h

**[ClassificationModal.tsx:66](modules/foundups/gotjunk/frontend/components/ClassificationModal.tsx#L66)**:
```typescript
const [bidDurationHours, setBidDurationHours] = useState(() => {
  const saved = localStorage.getItem('gotjunk_default_bid_duration');
  return saved ? parseInt(saved, 10) : 72; // Was 48
});
```

**[App.tsx:573](modules/foundups/gotjunk/frontend/App.tsx#L573)**:
```typescript
const finalBidDurationHours = bidDurationHours || 72; // Was 48
```

### 3. Delete Removes Items from All Locations

**Before**:
```typescript
const handleDeleteMyItem = async (itemToDelete: CapturedItem) => {
  URL.revokeObjectURL(itemToDelete.url);
  await storage.deleteItem(itemToDelete.id);
  setMyListed(current => current.filter(item => item.id !== itemToDelete.id));
  // ❌ Missing: browseFeed, myDrafts
};
```

**After** **[App.tsx:680-686](modules/foundups/gotjunk/frontend/App.tsx#L680-L686)**:
```typescript
const handleDeleteMyItem = async (itemToDelete: CapturedItem) => {
  URL.revokeObjectURL(itemToDelete.url);
  await storage.deleteItem(itemToDelete.id);
  setMyListed(current => current.filter(item => item.id !== itemToDelete.id));
  setMyDrafts(current => current.filter(item => item.id !== itemToDelete.id)); // ✅ Added
  setBrowseFeed(current => current.filter(item => item.id !== itemToDelete.id)); // ✅ Added
};
```

## User Flow Changes

### Before This Fix
1. User captures photo
2. Taps "Discount" → Action sheet appears → Must select 75%/50%/25% → Item created
3. Taps "Bid" → Action sheet appears → Must select 72h/48h/24h → Item created
4. User deletes item from "My Items" → Item removed from myListed, but still visible on map/browse feed

### After This Fix
1. User captures photo
2. **Taps "Discount"** → Item immediately created with 75% off default ✅
3. **Long-press "Discount"** → Action sheet appears → Can customize percentage
4. **Taps "Bid"** → Item immediately created with 72h default ✅
5. **Long-press "Bid"** → Action sheet appears → Can customize duration
6. User deletes item → Removed from myListed, myDrafts, AND browseFeed (no orphans) ✅

## Testing Plan

### Discount Default
1. Capture photo on Home tab
2. **Tap** "Discount" button (short tap < 450ms)
3. ✅ Verify: Item immediately appears in "My Items" with 75% OFF badge
4. ✅ Verify: No action sheet appeared

### Discount Customize
1. Capture photo on Home tab
2. **Long-press** "Discount" button (hold > 450ms)
3. ✅ Verify: Action sheet appears with 75%/50%/25% options
4. Select 50% → Verify item created with 50% OFF badge

### Bid Default
1. Capture photo on Home tab
2. **Tap** "Bid" button (short tap)
3. ✅ Verify: Item appears with "72h" badge
4. ✅ Verify: No action sheet appeared

### Bid Customize
1. Capture photo on Home tab
2. **Long-press** "Bid" button
3. ✅ Verify: Action sheet appears with 72h/48h/24h options
4. Select 48h → Verify item created with "48h" badge

### Delete Removes from All Locations
1. Capture photo on Home tab
2. Classify as Free → Item appears in "My Items"
3. Review item → Swipe right (keep) → Item moves to "My Items" (listed)
4. Item should appear in Browse feed/map (for testing)
5. Delete item from "My Items"
6. ✅ Verify: Item removed from "My Items"
7. ✅ Verify: Item removed from Browse feed
8. ✅ Verify: Item removed from Map view

## Module Size
- Before: 469.05 kB
- After: 469.18 kB
- Increase: +0.13 kB

## Related Issues
- User report: "discount asks for select discount... it should default to 75% off only a long press allows user to change the default"
- User report: "same with bid... asks for auction duration, should be set to 72 hr default"
- User report: "deleted ANY item in the users inv should remove it off the browse items map"

🤖 Generated with [Claude Code](https://claude.com/claude-code)