### PR TITLE
fix(message-board): Top-drop UI with voice input and z-index fix

### DIFF
--- a/modules/foundups/gotjunk/frontend/constants/zLayers.ts
+++ b/modules/foundups/gotjunk/frontend/constants/zLayers.ts
@@ -11,6 +11,7 @@ export const Z_LAYERS = {
   floatingControls: 2050,
   cameraOrb: 2100,
   sidebar: 2150,
+  messagePanel: 2200, // Message panel - above sidebar, below modals (drops from top)
   modal: 2300, // Classification, Options - above all controls
   PURCHASE_MODAL: 2350, // Purchase confirmation - above regular modals
   tutorialPopup: 2400,


### PR DESCRIPTION
## Summary
- Fixed z-index conflict where nav bar (2050) obscured message panel (was 1600)
- Changed message panel from bottom-slide to **top-drop** animation
- Added voice input via Web Speech API with mic button

## Changes

### Z-Index Fix (Critical)
Added `messagePanel: 2200` to zLayers.ts - now properly stacks above sidebar (2150) but below modals (2300). Previously used `fullscreen + 200` which was 1600, below nav bar's 2050.

### Top-Drop Animation
| Before | After |
|--------|-------|
| Bottom-slide (y: 100% → 0) | Top-drop (y: -100% → 0) |
| Rounded top corners | Rounded bottom corners |
| Obscured by nav bar | Clear of nav bar |

### Voice Input (Web Speech API)
- Mic button (🎤) in input area
- Toggles red when listening
- Transcript appends to input text
- Error handling for unsupported browsers

### Safe Area Insets (iOS)
- `paddingTop: max(16px, env(safe-area-inset-top))` for notch/Dynamic Island
- `paddingBottom: max(16px, env(safe-area-inset-bottom))` for home indicator

## Files Changed
- `frontend/constants/zLayers.ts` - Added messagePanel: 2200
- `frontend/components/MessageThreadPanel.tsx` - Top-drop + voice input

## Testing Checklist
- [ ] Message panel drops from top (not bottom)
- [ ] Panel does not overlap with bottom nav bar
- [ ] Mic button toggles listening state
- [ ] Voice transcript appends to input
- [ ] Escape key closes panel
- [ ] Works on iOS with notch

## WSP Compliance
- WSP 50: Verified existing z-index system before modification
- WSP 83: ModLog will be updated post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)