### PR TITLE
fix(gotjunk): Relocate + button, smaller icons, category at top

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/ItemReviewer.tsx
+++ b/modules/foundups/gotjunk/frontend/components/ItemReviewer.tsx
@@ -163,9 +163,9 @@ export const ItemReviewer: React.FC<ItemReviewerProps> = ({
         )}
       </div>
 
-      {/* Classification details overlay */}
+      {/* Classification details overlay - TOP center (above nav bar) */}
       {item.classification && (
-        <div className="absolute bottom-28 left-1/2 -translate-x-1/2 z-10">
+        <div className="absolute top-20 left-1/2 -translate-x-1/2 z-10">
           <div className="px-5 py-2 bg-black/65 rounded-full text-white text-sm font-semibold flex items-center gap-2 shadow-lg">
             <span>{classificationLabel}</span>
             {classificationMeta && <span className="text-white/70 text-xs">{classificationMeta}</span>}
@@ -173,17 +173,17 @@ export const ItemReviewer: React.FC<ItemReviewerProps> = ({
         </div>
       )}
 
-      {/* Interaction stack - bottom right */}
-      <div className="absolute bottom-6 right-6 flex flex-col items-end gap-3 z-10">
+      {/* Interaction stack - bottom right (10% smaller buttons) */}
+      <div className="absolute bottom-6 right-6 flex flex-col items-end gap-2.5 z-10">
         <button
           onClick={(e) => {
             e.stopPropagation();
             onMessageBoard(item);
           }}
-          className="w-16 h-16 rounded-full bg-white flex items-center justify-center shadow-2xl hover:scale-105 transition-all"
+          className="w-14 h-14 rounded-full bg-white flex items-center justify-center shadow-2xl hover:scale-105 transition-all"
           aria-label="Open message board"
         >
-          <MessageBoardIcon className="w-7 h-7 text-gray-900" />
+          <MessageBoardIcon className="w-6 h-6 text-gray-900" />
         </button>
 
         <button
@@ -191,10 +191,10 @@ export const ItemReviewer: React.FC<ItemReviewerProps> = ({
             e.stopPropagation();
             onJoinAction(item);
           }}
-          className="w-16 h-16 rounded-full bg-white flex items-center justify-center shadow-2xl hover:scale-105 transition-all"
+          className="w-14 h-14 rounded-full bg-white flex items-center justify-center shadow-2xl hover:scale-105 transition-all"
           aria-label="Join / Request action"
         >
-          <CartIcon className="w-7 h-7 text-gray-900" />
+          <CartIcon className="w-6 h-6 text-gray-900" />
         </button>
 
         {onClose && (
@@ -203,26 +203,26 @@ export const ItemReviewer: React.FC<ItemReviewerProps> = ({
               e.stopPropagation();
               onClose();
             }}
-            className="w-16 h-16 rounded-full bg-white flex items-center justify-center shadow-2xl hover:scale-105 transition-all"
+            className="w-14 h-14 rounded-full bg-white flex items-center justify-center shadow-2xl hover:scale-105 transition-all"
             aria-label="Collapse to thumbnails"
           >
-            <span className="text-3xl text-gray-900 leading-none">−</span>
+            <span className="text-2xl text-gray-900 leading-none">−</span>
           </button>
         )}
       </div>
 
-      {/* Forward button (>) - Bottom left corner (for cart purchase) */}
+      {/* Forward button (>) - Bottom left corner (10% smaller) */}
       {showForwardButton && (
         <button
           onClick={(e) => {
             e.stopPropagation(); // Prevent double-tap detection
             onDecision(item, 'keep'); // Trigger purchase
           }}
-          className="absolute bottom-8 left-8 w-14 h-14 bg-green-600/90 hover:bg-green-500/90 active:scale-95 rounded-full flex items-center justify-center shadow-2xl border-2 border-green-400 transition-all z-10"
+          className="absolute bottom-8 left-8 w-12 h-12 bg-green-600/90 hover:bg-green-500/90 active:scale-95 rounded-full flex items-center justify-center shadow-2xl border-2 border-green-400 transition-all z-10"
           aria-label="Purchase Item"
         >
           <svg
-            className="w-8 h-8 text-white"
+            className="w-7 h-7 text-white"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"

--- a/modules/foundups/gotjunk/frontend/components/PhotoCard.tsx
+++ b/modules/foundups/gotjunk/frontend/components/PhotoCard.tsx
@@ -82,13 +82,13 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({ item, onClick, onDelete, o
       )}
       <button
         onClick={handleDeleteClick}
-        className="absolute top-1 right-1 z-10 w-7 h-7 bg-red-600 rounded-full flex items-center justify-center text-white opacity-0 group-hover:opacity-100 scale-50 group-hover:scale-100 transition-all duration-200 hover:bg-red-500"
+        className="absolute top-1 right-1 z-10 w-6 h-6 bg-red-600 rounded-full flex items-center justify-center text-white opacity-0 group-hover:opacity-100 scale-50 group-hover:scale-100 transition-all duration-200 hover:bg-red-500"
         aria-label="Delete item"
       >
-        <TrashIcon className="w-4 h-4" />
+        <TrashIcon className="w-3.5 h-3.5" />
       </button>
 
-      {/* Manual expand button (alternative to double tap) */}
+      {/* Manual expand button - bottom LEFT corner (10% smaller) */}
       <button
         onClick={(e) => {
           e.stopPropagation();
@@ -98,10 +98,10 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({ item, onClick, onDelete, o
             onClick(item);
           }
         }}
-        className="absolute bottom-2 right-2 z-10 w-10 h-10 bg-white text-gray-800 rounded-full flex items-center justify-center shadow-lg opacity-0 group-hover:opacity-100 translate-y-2 group-hover:translate-y-0 transition-all duration-200"
+        className="absolute bottom-2 left-2 z-10 w-9 h-9 bg-white text-gray-800 rounded-full flex items-center justify-center shadow-lg opacity-0 group-hover:opacity-100 translate-y-2 group-hover:translate-y-0 transition-all duration-200"
         aria-label="Expand item"
       >
-        <PlusIcon className="w-5 h-5" />
+        <PlusIcon className="w-4 h-4" />
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
- Moved + expand button to bottom-left corner (was under trash)
- Reduced all icons by ~10%
- Moved category overlay to top (not hidden by nav bar)

## Changes

### PhotoCard (Thumbnail View)
| Element | Before | After |
|---------|--------|-------|
| Trash button | w-7 h-7 | w-6 h-6 |
| + button position | bottom-right | **bottom-left** |
| + button size | w-10 h-10 | w-9 h-9 |
| Icon sizes | w-4/w-5 | w-3.5/w-4 |

### ItemReviewer (Fullscreen View)
| Element | Before | After |
|---------|--------|-------|
| Category overlay | bottom-28 | **top-20** |
| Interaction buttons | w-16 h-16 | w-14 h-14 |
| Button gap | gap-3 | gap-2.5 |
| Forward button | w-14 h-14 | w-12 h-12 |

## Visual Impact
- + button no longer overlaps with trash icon area
- Category label visible without nav bar overlap
- More thumb-friendly spacing on smaller screens

## Files Changed
- `PhotoCard.tsx` - + button relocation, smaller icons
- `ItemReviewer.tsx` - category at top, smaller buttons

## Testing Checklist
- [ ] + button appears in bottom-left of thumbnail
- [ ] Trash button still in top-right
- [ ] Category overlay visible at top in fullscreen
- [ ] All buttons tappable on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)