### PR TITLE
fix(gotjunk): Bump service worker cache to v3

### DIFF
--- a/modules/foundups/gotjunk/frontend/service-worker.js
+++ b/modules/foundups/gotjunk/frontend/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'vision-ai-pwa-v2'; // Bumped version to invalidate old cache
+const CACHE_NAME = 'vision-ai-pwa-v3'; // Bumped version to invalidate old cache (2024-11-22)
 const URLS_TO_CACHE = [
   '/',
   '/index.html'


### PR DESCRIPTION
## Summary
Force cache invalidation after UI updates from PRs #135, #136, #137.

## Problem
Users seeing old cached version on phones due to service worker caching.

## Fix
Bump `CACHE_NAME` from `v2` → `v3` which triggers:
1. New SW installs with `skipWaiting()`
2. Old caches deleted on `activate` event
3. Fresh assets served

## Testing
After deploy, phone should show:
- Message panel drops from TOP (not bottom)
- Arrows hidden on phone (visible on tablet)
- + button in bottom-left of thumbnails
- Category at top in fullscreen view

🤖 Generated with [Claude Code](https://claude.com/claude-code)