### PR TITLE
fix(gotjunk): Add commit hash to load popup

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/InstructionsModal.tsx
+++ b/modules/foundups/gotjunk/frontend/components/InstructionsModal.tsx
@@ -95,6 +95,11 @@ export const InstructionsModal: React.FC<InstructionsModalProps> = ({ isOpen, on
               >
                 Got it! Start Swiping
               </button>
+
+              {/* Version indicator */}
+              <p className="text-[10px] text-gray-500 text-center mt-3 font-mono">
+                Build: {typeof __COMMIT_HASH__ !== 'undefined' ? __COMMIT_HASH__ : 'dev'}
+              </p>
             </div>
           </motion.div>
         </motion.div>


### PR DESCRIPTION
## Summary
Added commit hash display to the InstructionsModal (the welcome popup that shows on every page load).

## Change
Shows "Build: <commit>" at the bottom of the welcome popup, making it easy for users to verify which version is deployed.

![Location: Below "Got it! Start Swiping" button]

## Why
- User feedback: commit hash should be on load screen, not just sidebar
- Easier to verify deployed version without navigating the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)