### PR TITLE
fix(gotjunk): Close camera when sidebar icons clicked

### DIFF
--- a/modules/foundups/gotjunk/frontend/App.tsx
+++ b/modules/foundups/gotjunk/frontend/App.tsx
@@ -1275,6 +1275,7 @@ const App: React.FC = () => {
             // Navigate to Browse
             setActiveTab('browse'); // Tab 1: Browse
             setMapOpen(false); // Close map when switching to Browse
+            setIsFullscreenCameraOpen(false); // Close camera when switching tabs
           }}
           onGalleryIconTap={(duration) => {
             const SHORT_TAP = 200;
@@ -1308,15 +1309,18 @@ const App: React.FC = () => {
             sosDetectionActive.current = false;
             if (tapTimeoutRef.current) clearTimeout(tapTimeoutRef.current);
             setMapOpen(true); // Open map as overlay
+            setIsFullscreenCameraOpen(false); // Close camera when opening map
           }}
           onMyItemsClick={() => {
             setActiveTab('myitems'); // Tab 3: My Items
             setMapOpen(false); // Close map when switching to My Items
+            setIsFullscreenCameraOpen(false); // Close camera when switching tabs
             console.log('📦 My Items clicked');
           }}
           onCartClick={() => {
             setActiveTab('cart'); // Tab 4: Cart
             setMapOpen(false); // Close map when switching to Cart
+            setIsFullscreenCameraOpen(false); // Close camera when switching tabs
             console.log('🛒 Cart clicked');
           }}
           libertyEnabled={libertyEnabled}


### PR DESCRIPTION
## Summary
Camera now closes when any left sidebar icon is clicked.

## Problem
When the fullscreen camera was open and user tapped a sidebar icon (Browse, Map, My Items, Cart), the camera remained open instead of closing.

## Solution (Occam's Razor)
Added `setIsFullscreenCameraOpen(false)` to all sidebar click handlers:
- `onGalleryClick` - Browse tab
- `onMapClick` - Map overlay
- `onMyItemsClick` - My Items tab
- `onCartClick` - Cart tab

**Principle**: Sidebar tap = context switch = close camera.

## Test Plan
- [ ] Open fullscreen camera
- [ ] Tap Browse icon → camera closes
- [ ] Open camera again → tap Map icon → camera closes
- [ ] Open camera again → tap My Items icon → camera closes
- [ ] Open camera again → tap Cart icon → camera closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)