### PR TITLE
fix(gotjunk): Switch to My Items after photo capture

### DIFF
--- a/modules/foundups/gotjunk/frontend/App.tsx
+++ b/modules/foundups/gotjunk/frontend/App.tsx
@@ -681,6 +681,10 @@ const App: React.FC = () => {
         return [newItem, ...current];
       });
 
+      // Close camera and switch to My Items tab so user sees their new item
+      setIsFullscreenCameraOpen(false);
+      setActiveTab('myitems');
+
       console.log('[GotJunk] Item successfully created and added to drafts');
     } finally {
       // Always reset processing flag, even if there's an error


### PR DESCRIPTION
## Summary
After capturing a photo, automatically switch to My Items tab so user sees their new item.

## Problem
When user took a photo from Browse tab, the photo was correctly saved to My Items (`myDrafts`), but user stayed on Browse tab. They had to manually navigate to My Items to see their captured photo.

## Solution (Occam's Razor)
After successful classification:
1. Close fullscreen camera (`setIsFullscreenCameraOpen(false)`)
2. Switch to My Items tab (`setActiveTab('myitems')`)

**Principle**: Capture → See result immediately.

## Test Plan
- [ ] Open camera from Browse tab
- [ ] Take photo → classify
- [ ] Verify: Camera closes + switches to My Items tab
- [ ] Verify: New photo visible in My Items

🤖 Generated with [Claude Code](https://claude.com/claude-code)