### PR TITLE
fix(gotjunk): Hide image in selection mode + add voice input overlay

### DIFF
--- a/modules/foundups/gotjunk/frontend/App.tsx
+++ b/modules/foundups/gotjunk/frontend/App.tsx
@@ -20,6 +20,7 @@ import { ItemClassification, MutualAidClassification, AlertClassification } from
 import { MessageThreadPanel } from './components/MessageThreadPanel';
 import { MessageContextRef } from './src/message/types';
 import { PigeonMapView } from './components/PigeonMapView';
+import { VoiceInputOverlay } from './components/VoiceInputOverlay';
 import { useViewport } from './hooks/useViewport';
 import { useViewportHeight } from './hooks/useViewportHeight';
 
@@ -165,6 +166,10 @@ const App: React.FC = () => {
   } | null>(null);
   const [isSelectingLibertyClassification, setIsSelectingLibertyClassification] = useState(false); // True when long-pressing 🗽 badge to select classification
   const [showLibertySelector, setShowLibertySelector] = useState(false); // Controls ActionSheetLibertySelector visibility
+
+  // === VOICE INPUT STATE ===
+  const [voiceInputOpen, setVoiceInputOpen] = useState(false);
+  const [voiceInputText, setVoiceInputText] = useState('');
 
   // === MESSAGE BOARD PANEL STATE ===
   const [messagePanelContext, setMessagePanelContext] = useState<MessageContextRef | null>(null);
@@ -1376,6 +1381,11 @@ const App: React.FC = () => {
           libertyEnabled={libertyEnabled}
           onLongPressLibertyBadge={handleLongPressLibertyBadge}
           lastLibertyClassification={lastLibertyClassification}
+          onVoiceInput={(transcript) => {
+            console.log('[GotJunk] Voice input received:', transcript);
+            setVoiceInputText(transcript);
+            setVoiceInputOpen(true);
+          }}
         />
 
       {/* Re-classification Modal (tap badge) */}
@@ -1469,6 +1479,7 @@ const App: React.FC = () => {
         imageUrl={pendingClassificationItem?.url || ''}
         libertyEnabled={libertyEnabled}
         isMapView={isMapOpen}
+        isSelectionMode={isSelectingClassification}
         onClassify={handleClassify}
       />
 
@@ -1532,6 +1543,22 @@ const App: React.FC = () => {
           onClose={closeMessagePanel}
         />
       )}
+
+      {/* Voice Input Overlay - appears when nav bar mic captures speech */}
+      <VoiceInputOverlay
+        isOpen={voiceInputOpen}
+        initialText={voiceInputText}
+        onSend={(text) => {
+          console.log('[GotJunk] Voice message sent:', text);
+          // TODO: Route to current context (message thread, item note, etc.)
+          // For now, log it - user can wire this up as needed
+        }}
+        onClose={() => {
+          setVoiceInputOpen(false);
+          setVoiceInputText('');
+        }}
+        placeholder="Edit your voice input..."
+      />
 
     </div>
   );

--- a/modules/foundups/gotjunk/frontend/components/ClassificationModal.tsx
+++ b/modules/foundups/gotjunk/frontend/components/ClassificationModal.tsx
@@ -16,6 +16,7 @@ interface ClassificationModalProps {
   imageUrl: string;
   libertyEnabled?: boolean; // Determines which classifications to show
   isMapView?: boolean; // Show all 11 categories on map, only 5 on My Items
+  isSelectionMode?: boolean; // True when selecting preset (long-press toggle) - hides image
   onClassify: (
     classification: ItemClassification,
     discountPercent?: number,
@@ -46,6 +47,7 @@ export const ClassificationModal: React.FC<ClassificationModalProps> = ({
   imageUrl,
   libertyEnabled = false,
   isMapView = false,
+  isSelectionMode = false,
   onClassify,
 }) => {
   // Action sheet state
@@ -209,18 +211,20 @@ export const ClassificationModal: React.FC<ClassificationModalProps> = ({
               userSelect: 'none',
             }}
           >
-            {/* Preview image */}
-            <motion.div
-              initial={{ scale: 0.8, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              className="w-full max-w-sm mb-4 rounded-2xl overflow-hidden shadow-2xl"
-            >
-              <img src={imageUrl} alt="Captured item" className="w-full h-auto" />
-            </motion.div>
+            {/* Preview image - hidden in selection mode */}
+            {!isSelectionMode && imageUrl && (
+              <motion.div
+                initial={{ scale: 0.8, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                className="w-full max-w-sm mb-4 rounded-2xl overflow-hidden shadow-2xl"
+              >
+                <img src={imageUrl} alt="Captured item" className="w-full h-auto" />
+              </motion.div>
+            )}
 
             {/* Title */}
             <h2 className="text-xl font-bold text-white mb-3 text-center">
-              Select Category (11 Types)
+              {isSelectionMode ? 'Choose Default Category' : 'Select Category (11 Types)'}
             </h2>
 
             {/* Classification buttons - All 11 types */}
@@ -472,18 +476,20 @@ export const ClassificationModal: React.FC<ClassificationModalProps> = ({
               userSelect: 'none',
             }}
           >
-            {/* Preview image - 15% smaller */}
-            <motion.div
-              initial={{ scale: 0.8, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              className="w-full max-w-sm mb-4 rounded-2xl overflow-hidden shadow-2xl"
-            >
-              <img src={imageUrl} alt="Captured item" className="w-full h-auto" />
-            </motion.div>
+            {/* Preview image - hidden in selection mode */}
+            {!isSelectionMode && imageUrl && (
+              <motion.div
+                initial={{ scale: 0.8, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                className="w-full max-w-sm mb-4 rounded-2xl overflow-hidden shadow-2xl"
+              >
+                <img src={imageUrl} alt="Captured item" className="w-full h-auto" />
+              </motion.div>
+            )}
 
-            {/* Title - 15% smaller font */}
+            {/* Title */}
             <h2 className="text-xl font-bold text-white mb-3 text-center">
-              How would you like to list this?
+              {isSelectionMode ? 'Choose Default Category' : 'How would you like to list this?'}
             </h2>
 
             {/* Stuff label with LA icon */}
@@ -653,18 +659,20 @@ export const ClassificationModal: React.FC<ClassificationModalProps> = ({
             userSelect: 'none',
           }}
         >
-          {/* Preview image - 15% smaller */}
-          <motion.div
-            initial={{ scale: 0.8, opacity: 0 }}
-            animate={{ scale: 1, opacity: 1 }}
-            className="w-full max-w-sm mb-4 rounded-2xl overflow-hidden shadow-2xl"
-          >
-            <img src={imageUrl} alt="Captured item" className="w-full h-auto" />
-          </motion.div>
+          {/* Preview image - hidden in selection mode */}
+          {!isSelectionMode && imageUrl && (
+            <motion.div
+              initial={{ scale: 0.8, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              className="w-full max-w-sm mb-4 rounded-2xl overflow-hidden shadow-2xl"
+            >
+              <img src={imageUrl} alt="Captured item" className="w-full h-auto" />
+            </motion.div>
+          )}
 
-          {/* Title - 15% smaller */}
+          {/* Title */}
           <h2 className="text-xl font-bold text-white mb-3 text-center">
-            🗽 Liberty Alert - Select Category
+            {isSelectionMode ? '🗽 Choose Default Category' : '🗽 Liberty Alert - Select Category'}
           </h2>
 
           {/* Category Selection */}

--- a/modules/foundups/gotjunk/frontend/components/VoiceInputOverlay.tsx
+++ b/modules/foundups/gotjunk/frontend/components/VoiceInputOverlay.tsx
@@ -1,0 +1,116 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Z_LAYERS } from '../constants/zLayers';
+
+interface VoiceInputOverlayProps {
+  isOpen: boolean;
+  initialText: string;
+  onSend: (text: string) => void;
+  onClose: () => void;
+  placeholder?: string;
+}
+
+/**
+ * VoiceInputOverlay - Floating input bar for voice transcripts
+ *
+ * Appears at bottom of screen when nav bar mic captures speech.
+ * User can edit the transcript and tap Send, or dismiss with X.
+ */
+export const VoiceInputOverlay: React.FC<VoiceInputOverlayProps> = ({
+  isOpen,
+  initialText,
+  onSend,
+  onClose,
+  placeholder = 'Edit your message...',
+}) => {
+  const [text, setText] = useState(initialText);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Update text when initialText changes (new voice input)
+  useEffect(() => {
+    if (isOpen && initialText) {
+      setText(initialText);
+      // Focus input when overlay opens
+      setTimeout(() => inputRef.current?.focus(), 100);
+    }
+  }, [isOpen, initialText]);
+
+  // Clear text when overlay closes
+  useEffect(() => {
+    if (!isOpen) {
+      setText('');
+    }
+  }, [isOpen]);
+
+  const handleSend = () => {
+    if (text.trim()) {
+      onSend(text.trim());
+      setText('');
+      onClose();
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleSend();
+    } else if (e.key === 'Escape') {
+      onClose();
+    }
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          initial={{ y: 100, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: 100, opacity: 0 }}
+          transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+          className="fixed left-0 right-0 px-4 pb-4"
+          style={{
+            bottom: 'calc(96px + env(safe-area-inset-bottom))', // Above nav bar
+            zIndex: Z_LAYERS.modal,
+          }}
+        >
+          <div className="max-w-2xl mx-auto bg-gray-900/95 backdrop-blur-xl rounded-2xl shadow-2xl border border-white/10 p-3">
+            <div className="flex items-center gap-2">
+              {/* Close button */}
+              <button
+                onClick={onClose}
+                className="w-10 h-10 rounded-xl bg-gray-700/80 hover:bg-gray-600/80 flex items-center justify-center transition-colors"
+                aria-label="Dismiss voice input"
+              >
+                <span className="text-white text-lg">×</span>
+              </button>
+
+              {/* Input field */}
+              <input
+                ref={inputRef}
+                type="text"
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder={placeholder}
+                className="flex-1 bg-gray-800/80 text-white rounded-xl px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500/70"
+              />
+
+              {/* Send button */}
+              <button
+                onClick={handleSend}
+                disabled={!text.trim()}
+                className="px-5 h-10 rounded-xl bg-blue-600 hover:bg-blue-500 text-white font-semibold text-sm disabled:opacity-50 disabled:hover:bg-blue-600 transition-colors"
+              >
+                Send
+              </button>
+            </div>
+
+            {/* Hint text */}
+            <p className="text-xs text-gray-500 text-center mt-2">
+              Edit and send, or tap × to dismiss
+            </p>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};


### PR DESCRIPTION
## Summary
Two improvements following Occam's razor principles:

### 1. Classification Modal - Selection Mode
When long-pressing the auto-classify toggle to select a preset:
- **Before**: Showed broken image placeholder (empty phantom item)
- **After**: Hides image, shows "Choose Default Category" title

### 2. Voice Input Overlay (New Component)
When nav bar mic captures speech via STT:
- **Before**: Just logged transcript to console
- **After**: Shows floating input overlay with:
  - Editable text field with transcript
  - Send button
  - Dismiss (X) button
  - Positioned above nav bar

## Files Changed
- `ClassificationModal.tsx` - Added `isSelectionMode` prop, conditional image/title
- `VoiceInputOverlay.tsx` - New component for voice input UI
- `App.tsx` - Wired up voice input state and overlay

## Test Plan

### Selection Mode
- [ ] Long-press auto-classify toggle
- [ ] Modal opens WITHOUT image preview
- [ ] Title shows "Choose Default Category"
- [ ] Select category → enables auto-classify

### Voice Input
- [ ] Tap nav bar mic → STT listens
- [ ] Speak → voice overlay appears with transcript
- [ ] Edit text → tap Send → logs to console
- [ ] Tap X → overlay dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)