### PR TITLE
feat(gotjunk): Add swipe gestures for continuous item browsing

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/ItemReviewer.tsx
+++ b/modules/foundups/gotjunk/frontend/components/ItemReviewer.tsx
@@ -50,6 +50,13 @@ export const ItemReviewer: React.FC<ItemReviewerProps> = ({
       return;
     }
 
+    // Check for vertical swipe DOWN to skip to next item
+    if (info.offset.y > swipeThreshold || info.velocity.y > velocityThreshold) {
+      console.log('[ItemReviewer] Swipe down detected - skipping to next item');
+      setSwipeDecision('delete'); // Skip = delete in browse context
+      return;
+    }
+
     // Horizontal swipe for keep/delete
     let decision: 'keep' | 'delete' | null = null;
 
@@ -87,7 +94,7 @@ export const ItemReviewer: React.FC<ItemReviewerProps> = ({
       role="dialog"
       aria-modal="true"
       drag
-      dragConstraints={{ left: -150, right: 150, top: -200, bottom: 50 }}
+      dragConstraints={{ left: -150, right: 150, top: -200, bottom: 150 }}
       dragElastic={0.2}
       onDragEnd={handleDragEnd}
       onClick={handleTap}

--- a/modules/foundups/gotjunk/frontend/components/PhotoCard.tsx
+++ b/modules/foundups/gotjunk/frontend/components/PhotoCard.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { motion } from 'framer-motion';
+import { motion, PanInfo } from 'framer-motion';
 import { CapturedItem } from '../types';
 import { TrashIcon } from './icons/TrashIcon';
 import { PlayIcon } from './icons/PlayIcon';
@@ -37,8 +37,28 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({ item, onClick, onDelete, o
 
   const isVideo = item.blob.type.startsWith('video/');
 
+  // Swipe-down gesture to open fullscreen
+  const handleDragEnd = (event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
+    const swipeThreshold = 80;  // pixels
+    const velocityThreshold = 200;  // pixels/second
+
+    // Swipe DOWN = open fullscreen
+    if (info.offset.y > swipeThreshold || info.velocity.y > velocityThreshold) {
+      console.log('[PhotoCard] Swipe down detected - opening fullscreen');
+      onClick(item);
+    }
+  };
+
   return (
-    <div className="relative group aspect-square w-full rounded-lg overflow-hidden bg-gray-800 shadow-md cursor-pointer" onClick={handleCardClick}>
+    <motion.div
+      className="relative group aspect-square w-full rounded-lg overflow-hidden bg-gray-800 shadow-md cursor-pointer"
+      onClick={handleCardClick}
+      drag="y"
+      dragConstraints={{ top: 0, bottom: 0 }}
+      dragElastic={0.3}
+      onDragEnd={handleDragEnd}
+      whileDrag={{ scale: 1.02, zIndex: 10 }}
+    >
       {isVideo ? (
          <video
             src={item.url}
@@ -103,6 +123,6 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({ item, onClick, onDelete, o
       >
         <PlusIcon className="w-4 h-4" />
       </button>
-    </div>
+    </motion.div>
   );
 };


### PR DESCRIPTION
## Summary
Add swipe-down gestures for faster item browsing without lifting finger.

## Changes

### PhotoCard (Thumbnails)
- **Swipe DOWN** → Open item in fullscreen
- Threshold: 80px offset or 200px/s velocity
- Visual feedback: scale 1.02x while dragging

### ItemReviewer (Fullscreen)
- **Swipe DOWN** → Skip to next item (same as swipe left)
- Increased bottom drag constraint (50→150px) for better detection

## Gesture Summary

| Location | Gesture | Action |
|----------|---------|--------|
| Thumbnail | Swipe DOWN | Open fullscreen |
| Fullscreen | Swipe UP | Close/collapse |
| Fullscreen | Swipe DOWN | Skip to next |
| Fullscreen | Swipe LEFT | Delete/skip |
| Fullscreen | Swipe RIGHT | Keep/add to cart |

## UX Flow
```
[Grid View]
    ↓ swipe down on thumbnail
[Fullscreen View]
    ↓ swipe down to skip
[Next Item Fullscreen]
    ↓ swipe right to keep
[Next Item Fullscreen]
    ... continue browsing
```

## Test Plan
- [ ] In grid view, swipe down on thumbnail → opens fullscreen
- [ ] In fullscreen, swipe down → skips to next item
- [ ] In fullscreen, swipe up → closes fullscreen
- [ ] In fullscreen, swipe left/right → delete/keep
- [ ] Double-tap still works as alternative

🤖 Generated with [Claude Code](https://claude.com/claude-code)