### PR TITLE
fix(gotjunk): Add Secret Manager integration for Firebase build secrets

### DIFF
--- a/modules/foundups/gotjunk/cloudbuild.yaml
+++ b/modules/foundups/gotjunk/cloudbuild.yaml
@@ -2,17 +2,24 @@
 # Deploys from modules/foundups/gotjunk/frontend/ to Cloud Run
 
 steps:
-  # Step 1: Build Docker image
+  # Step 1: Build Docker image with Firebase secrets
   - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
     args:
-      - 'build'
-      - '-t'
-      - 'gcr.io/$PROJECT_ID/gotjunk:$COMMIT_SHA'
-      - '-t'
-      - 'gcr.io/$PROJECT_ID/gotjunk:latest'
-      - '-f'
-      - 'modules/foundups/gotjunk/frontend/Dockerfile'
-      - 'modules/foundups/gotjunk/frontend'
+      - '-c'
+      - |
+        docker build \
+          --build-arg VITE_FIREBASE_API_KEY=$$VITE_FIREBASE_API_KEY \
+          --build-arg VITE_FIREBASE_APP_ID=$$VITE_FIREBASE_APP_ID \
+          --build-arg VITE_FIREBASE_SENDER_ID=$$VITE_FIREBASE_SENDER_ID \
+          -t gcr.io/$PROJECT_ID/gotjunk:$COMMIT_SHA \
+          -t gcr.io/$PROJECT_ID/gotjunk:latest \
+          -f modules/foundups/gotjunk/frontend/Dockerfile \
+          modules/foundups/gotjunk/frontend
+    secretEnv:
+      - 'VITE_FIREBASE_API_KEY'
+      - 'VITE_FIREBASE_APP_ID'
+      - 'VITE_FIREBASE_SENDER_ID'
 
   # Step 2: Push Docker image to Container Registry
   - name: 'gcr.io/cloud-builders/docker'
@@ -44,7 +51,17 @@ images:
   - 'gcr.io/$PROJECT_ID/gotjunk:$COMMIT_SHA'
   - 'gcr.io/$PROJECT_ID/gotjunk:latest'
 
-# Only trigger on changes to gotjunk module
+# Access secrets from Secret Manager
+availableSecrets:
+  secretManager:
+    - versionName: projects/$PROJECT_ID/secrets/VITE_FIREBASE_API_KEY/versions/latest
+      env: 'VITE_FIREBASE_API_KEY'
+    - versionName: projects/$PROJECT_ID/secrets/VITE_FIREBASE_APP_ID/versions/latest
+      env: 'VITE_FIREBASE_APP_ID'
+    - versionName: projects/$PROJECT_ID/secrets/VITE_FIREBASE_SENDER_ID/versions/latest
+      env: 'VITE_FIREBASE_SENDER_ID'
+
+# Build options
 options:
   logging: CLOUD_LOGGING_ONLY
 

--- a/modules/foundups/gotjunk/frontend/Dockerfile
+++ b/modules/foundups/gotjunk/frontend/Dockerfile
@@ -4,6 +4,16 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
+# Build-time arguments for Vite environment variables
+ARG VITE_FIREBASE_API_KEY
+ARG VITE_FIREBASE_APP_ID
+ARG VITE_FIREBASE_SENDER_ID
+
+# Set as environment variables for Vite build
+ENV VITE_FIREBASE_API_KEY=$VITE_FIREBASE_API_KEY
+ENV VITE_FIREBASE_APP_ID=$VITE_FIREBASE_APP_ID
+ENV VITE_FIREBASE_SENDER_ID=$VITE_FIREBASE_SENDER_ID
+
 # Copy package files
 COPY package.json package-lock.json* ./
 
@@ -13,7 +23,7 @@ RUN npm ci
 # Copy source code
 COPY . .
 
-# Build for production
+# Build for production (Vite embeds VITE_* vars at build time)
 RUN npm run build
 
 # Stage 2: Serve with nginx


### PR DESCRIPTION
## Summary
Updates Cloud Build to use Secret Manager for Firebase environment variables needed at Vite build time.

## Changes
- **Dockerfile**: Added `ARG`/`ENV` for `VITE_FIREBASE_*` variables
- **cloudbuild.yaml**: Added `availableSecrets` section for Secret Manager integration
- Build step now passes secrets as `--build-arg` to Docker

## Setup Required (One-Time)

### 1. Create Secrets in Secret Manager

Go to: https://console.cloud.google.com/security/secret-manager

Or run:
```bash
# Create the 3 Firebase secrets
gcloud secrets create VITE_FIREBASE_API_KEY --replication-policy="automatic"
gcloud secrets create VITE_FIREBASE_APP_ID --replication-policy="automatic"
gcloud secrets create VITE_FIREBASE_SENDER_ID --replication-policy="automatic"

# Add the values (replace with actual values)
echo -n "YOUR_API_KEY" | gcloud secrets versions add VITE_FIREBASE_API_KEY --data-file=-
echo -n "YOUR_APP_ID" | gcloud secrets versions add VITE_FIREBASE_APP_ID --data-file=-
echo -n "YOUR_SENDER_ID" | gcloud secrets versions add VITE_FIREBASE_SENDER_ID --data-file=-
```

### 2. Grant Cloud Build Access

```bash
PROJECT_NUMBER=$(gcloud projects describe $(gcloud config get-value project) --format='value(projectNumber)')

gcloud secrets add-iam-policy-binding VITE_FIREBASE_API_KEY \
  --member="serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
  --role="roles/secretmanager.secretAccessor"

gcloud secrets add-iam-policy-binding VITE_FIREBASE_APP_ID \
  --member="serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
  --role="roles/secretmanager.secretAccessor"

gcloud secrets add-iam-policy-binding VITE_FIREBASE_SENDER_ID \
  --member="serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
  --role="roles/secretmanager.secretAccessor"
```

## Test Plan
- [ ] Create secrets in Secret Manager
- [ ] Grant Cloud Build access
- [ ] Merge PR and verify Cloud Build succeeds
- [ ] Verify app loads Firebase correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)