### PR TITLE
fix(gotjunk): Prevent camera zoom from affecting UI modal

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/FullscreenCamera.tsx
+++ b/modules/foundups/gotjunk/frontend/components/FullscreenCamera.tsx
@@ -74,7 +74,10 @@ export const FullscreenCamera: React.FC<FullscreenCameraProps> = ({
       {isOpen && (
         <motion.div
           className="fixed inset-0 bg-black"
-          style={{ zIndex: Z_LAYERS.fullscreenCamera }}
+          style={{
+            zIndex: Z_LAYERS.fullscreenCamera,
+            touchAction: 'manipulation', // Prevent pinch-to-zoom affecting UI
+          }}
           initial={{ opacity: 0, scale: 0.5 }}
           animate={{ opacity: 1, scale: 1 }}
           exit={{ opacity: 0, scale: 0.5 }}

--- a/modules/foundups/gotjunk/frontend/index.html
+++ b/modules/foundups/gotjunk/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <title>GotJUNK?</title>
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#111827" />


### PR DESCRIPTION
## Problem
When user pinch-zoomed on camera to frame a shot, the classification modal also got zoomed - making category selection difficult.

## Solution
1. **Disable browser zoom** - viewport meta: maximum-scale=1.0, user-scalable=no
2. **Touch-action restriction** - Added touch-action: manipulation to FullscreenCamera

## Files Changed
- index.html - viewport meta tag
- FullscreenCamera.tsx - touch-action style

## Result
Classification modal always appears at normal size after photo capture.

Generated with Claude Code