### PR TITLE
refactor(gotjunk): Extend useLongPress hook for video recording

### DIFF
--- a/modules/foundups/gotjunk/frontend/hooks/useLongPress.ts
+++ b/modules/foundups/gotjunk/frontend/hooks/useLongPress.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef } from 'react';
 
 interface UseLongPressOptions {
   onLongPress: (event: PointerEvent | TouchEvent | MouseEvent) => void;
+  onLongPressRelease?: (event: PointerEvent | TouchEvent | MouseEvent) => void; // Called when finger lifts after long-press (for video recording)
   onTap?: (event: PointerEvent | TouchEvent | MouseEvent) => void;
   threshold?: number; // ms before long-press fires (default 450ms)
   moveThreshold?: number; // px movement to cancel long-press (default 10px)
@@ -35,6 +36,7 @@ interface UseLongPressReturn {
  */
 export function useLongPress({
   onLongPress,
+  onLongPressRelease,
   onTap,
   threshold = 450,
   moveThreshold = 10,
@@ -100,6 +102,14 @@ export function useLongPress({
   const handleEnd = useCallback((event: PointerEvent | TouchEvent | MouseEvent) => {
     clear();
 
+    // If long-press was triggered, fire release callback (for video recording stop)
+    if (longPressTriggeredRef.current && onLongPressRelease) {
+      onLongPressRelease(event);
+      longPressTriggeredRef.current = false;
+      startPosRef.current = null;
+      return;
+    }
+
     // Fire tap only if long-press wasn't triggered
     if (!longPressTriggeredRef.current && onTap) {
       const now = Date.now();
@@ -117,7 +127,7 @@ export function useLongPress({
     }
 
     startPosRef.current = null;
-  }, [onTap, clear]);
+  }, [onTap, onLongPressRelease, clear]);
 
   const handleCancel = useCallback(() => {
     clear();


### PR DESCRIPTION
## Summary
Anti-vibecode fix: Extended existing `useLongPress` hook instead of duplicating long-press detection logic.

**Depends on PR #156** (merge that first)

## Changes

### hooks/useLongPress.ts
Added `onLongPressRelease` callback to support video recording use case:
```typescript
interface UseLongPressOptions {
  onLongPress: (event) => void;
  onLongPressRelease?: (event) => void; // NEW - fires when finger lifts after long-press
  onTap?: (event) => void;
  threshold?: number;
  moveThreshold?: number;
}
```

### FullscreenCamera.tsx
Refactored to use the extended hook:
- Removed inline pointer handlers (handlePressStart, handlePressEnd, handlePressCancel)
- Removed redundant refs (longPressTimerRef, isLongPressActiveRef)
- Uses `{...longPressHandlers}` spread for cleaner JSX
- **-14% code reduction** (279 → 239 lines)

## Why This Matters
- **WSP 50 compliance**: Reuse existing modules instead of duplicating
- **Maintainability**: One hook to maintain instead of two implementations
- **Consistency**: Same long-press behavior across all components

## Testing
- [ ] Tap camera → photo captured
- [ ] Hold camera 450ms+ → recording starts
- [ ] Release finger → recording stops
- [ ] Wait 10s → auto-stop works
- [ ] Existing long-press in ClassificationModal still works
- [ ] Existing long-press in BottomNavBar still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)