### PR TITLE
fix(gotjunk): Update tab labels and hide LA Alerts

### DIFF
--- a/modules/foundups/gotjunk/frontend/App.tsx
+++ b/modules/foundups/gotjunk/frontend/App.tsx
@@ -144,8 +144,9 @@ const App: React.FC = () => {
   // === CLASSIFICATION FILTER ===
   const [classificationFilter, setClassificationFilter] = useState<'all' | ItemClassification>('all');
 
-  // === MY ITEMS SECTION FILTER (3 compartments) ===
-  type MyItemsSection = 'commerce' | 'share' | 'community';
+  // === MY ITEMS SECTION FILTER (2-3 compartments) ===
+  // LA (Liberty Alerts) tab only visible when Liberty unlocked
+  type MyItemsSection = 'commerce' | 'share' | 'la';
   const [myItemsSection, setMyItemsSection] = useState<MyItemsSection>('commerce');
 
   // === MY ITEMS MEDIA FILTER (photos/videos/all) ===
@@ -397,6 +398,14 @@ const App: React.FC = () => {
     };
     initializeApp();
   }, []);
+
+  // Reset LA tab selection if Liberty disabled while on LA tab
+  useEffect(() => {
+    if (!libertyEnabled && myItemsSection === 'la') {
+      setMyItemsSection('commerce');
+      console.log('[GotJunk] Liberty disabled - resetting to Commerce tab');
+    }
+  }, [libertyEnabled, myItemsSection]);
 
   // Reset map navigation when opening map or changing Liberty mode
   useEffect(() => {
@@ -1087,7 +1096,7 @@ const App: React.FC = () => {
                       : 'text-gray-400 hover:text-white'
                   }`}
                 >
-                  Commerce
+                  Stuff
                 </button>
                 {/* Share Economy */}
                 <button
@@ -1098,19 +1107,21 @@ const App: React.FC = () => {
                       : 'text-gray-400 hover:text-white'
                   }`}
                 >
-                  Share
+                  Wanted
                 </button>
-                {/* Community Aid + Alerts */}
-                <button
-                  onClick={() => setMyItemsSection('community')}
-                  className={`flex-1 px-4 py-2 rounded-lg text-sm font-semibold transition-all ${
-                    myItemsSection === 'community'
-                      ? 'bg-orange-500 text-white shadow-lg'
-                      : 'text-gray-400 hover:text-white'
-                  }`}
-                >
-                  Community
-                </button>
+                {/* Liberty Alerts - Only visible when unlocked */}
+                {libertyEnabled && (
+                  <button
+                    onClick={() => setMyItemsSection('la')}
+                    className={`flex-1 px-4 py-2 rounded-lg text-sm font-semibold transition-all ${
+                      myItemsSection === 'la'
+                        ? 'bg-orange-500 text-white shadow-lg'
+                        : 'text-gray-400 hover:text-white'
+                    }`}
+                  >
+                    LA Alerts
+                  </button>
+                )}
               </div>
 
               {/* Media Type Filter Row */}
@@ -1166,8 +1177,8 @@ const App: React.FC = () => {
                       item.classification === 'share' ||
                       item.classification === 'wanted'
                     );
-                  } else {
-                    // community: mutual aid + alerts (including food subcategories)
+                  } else if (myItemsSection === 'la') {
+                    // LA (Liberty Alerts): mutual aid + emergency alerts
                     filtered = filtered.filter(item =>
                       item.classification === 'food' ||
                       item.classification === 'soup_kitchen' ||


### PR DESCRIPTION
## Summary
Updates My Items tab labels for clarity and hides LA Alerts tab until Liberty mode is unlocked.

## Changes

### 1. Tab Label Updates
| Old | New |
|-----|-----|
| Commerce | **Stuff** |
| Share | **Wanted** |
| Community | **LA Alerts** |

### 2. LA Alerts Visibility
- Only shows when `libertyEnabled` is true
- Hidden by default (requires SOS unlock)
- Auto-resets to Stuff tab if Liberty disabled while viewing LA

### 3. Tab Filters
- **Stuff**: free, discount, bid
- **Wanted**: share, wanted
- **LA Alerts**: mutual aid + emergency alerts
  - Food: soup_kitchen, bbq, dry_food, pick, garden
  - Shelter: couch, camping, housing
  - Alerts: ice, police

## Test Plan
- [ ] Check tabs show "Stuff / Wanted" by default
- [ ] Unlock Liberty → "LA Alerts" tab appears
- [ ] Switch to LA Alerts → see Liberty items only
- [ ] Toggle Liberty OFF → auto-switch back to Stuff tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)