### PR TITLE
debug(gotjunk): Add video capture logging

### DIFF
--- a/modules/foundups/gotjunk/frontend/services/storage.ts
+++ b/modules/foundups/gotjunk/frontend/services/storage.ts
@@ -23,8 +23,18 @@ type StorableItem = Omit<CapturedItem, 'url'>;
 
 export const saveItem = async (item: CapturedItem): Promise<void> => {
     const { url, ...storableItem } = item;
+    const mediaType = item.blob.type.startsWith('video/') ? 'VIDEO' : 'PHOTO';
+    console.log(`[Storage] Saving ${mediaType}:`, {
+        id: item.id,
+        blobSize: item.blob.size,
+        blobType: item.blob.type,
+        classification: item.classification,
+        status: item.status
+    });
+
     // Layer 1: Save to IndexedDB (immediate, offline-first)
     await localforage.setItem(item.id, storableItem);
+    console.log(`[Storage] ✅ ${mediaType} saved to IndexedDB:`, item.id);
 
     // Layer 2: Sync to Cloud (Legacy/Hybrid)
     syncItemToCloud(item).catch(err =>


### PR DESCRIPTION
## Summary
Adds comprehensive console logging to diagnose why videos aren't appearing in My Items list.

## Logging Added

### 1. handleCapture (App.tsx)
```
[GotJunk] VIDEO captured - size: 1234567 bytes, type: video/webm
[GotJunk] VIDEO capturedItem created: { hasBlob, blobSize, blobType, hasUrl, hasLocation }
[GotJunk] VIDEO captured - opening classification modal
```

### 2. handleClassify (App.tsx)
```
[GotJunk] Saving new VIDEO: { id, classification, blobType, blobSize, libertyAlert }
[GotJunk] ✅ VIDEO added to myDrafts (5 total items)
[GotJunk] ✅ VIDEO successfully saved and added to drafts
```

### 3. storage.saveItem (storage.ts)
```
[Storage] Saving VIDEO: { id, blobSize, blobType, classification, status }
[Storage] ✅ VIDEO saved to IndexedDB: item-1234567890
```

## Diagnosis Steps
With these logs, we can identify:
1. ✅ Video blob created → Check "VIDEO captured" log
2. ✅ Classification modal opened → Check "opening classification modal"
3. ✅ Classification selected → Check "Saving new VIDEO"
4. ✅ IndexedDB persisted → Check "VIDEO saved to IndexedDB"
5. ✅ State updated → Check "VIDEO added to myDrafts"

## Test Plan
1. Record video (hold camera button)
2. Classify video (e.g., ICE alert)
3. Open browser console → search for "VIDEO"
4. Verify all 5 checkpoints logged
5. Check My Items tab for video

🤖 Generated with [Claude Code](https://claude.com/claude-code)