### PR TITLE
fix(gotjunk): Stub out meshDaemon to fix build

### DIFF
--- a/modules/foundups/gotjunk/frontend/services/meshDaemon.ts
+++ b/modules/foundups/gotjunk/frontend/services/meshDaemon.ts
@@ -1,24 +1,18 @@
-
-import { MeshCore } from '@mesh/core/src/meshCore';
-import { MeshPacket } from '@mesh/core/src/packet';
 import { CapturedItem } from '../types';
 
 /**
  * MeshDaemon - The Bridge between Local Data and the Mesh
  * WSP 98: FoundUps Mesh-Native Architecture
+ *
+ * STUB VERSION: Full mesh implementation coming in Phase 2
+ * Currently logs intent but doesn't actually broadcast over mesh
  */
 export class MeshDaemon {
   private static instance: MeshDaemon;
-  private mesh: MeshCore;
   private isRunning: boolean = false;
 
   private constructor() {
-    // Initialize with a random device ID (in prod, persist this in localStorage)
-    const deviceId = localStorage.getItem('gotjunk_device_id') || crypto.randomUUID();
-    localStorage.setItem('gotjunk_device_id', deviceId);
-    
-    this.mesh = new MeshCore(deviceId);
-    this.setupPacketHandlers();
+    console.log('[MeshDaemon] Stub initialized (full mesh coming in Phase 2)');
   }
 
   public static getInstance(): MeshDaemon {
@@ -30,69 +24,21 @@ export class MeshDaemon {
 
   public start(): void {
     if (this.isRunning) return;
-    
-    this.mesh.goOnline();
     this.isRunning = true;
-    console.log('[MeshDaemon] Service started');
-    
-    // In MVP, we mock peer discovery
-    this.mesh.addPeer('mock-peer-1');
+    console.log('[MeshDaemon] Stub service started');
   }
 
   public stop(): void {
-    this.mesh.goOffline();
     this.isRunning = false;
-    console.log('[MeshDaemon] Service stopped');
+    console.log('[MeshDaemon] Stub service stopped');
   }
 
   /**
    * Broadcast a new GotJunk item to the mesh
+   * STUB: Logs intent but doesn't actually broadcast
    */
   public broadcastItem(item: CapturedItem): void {
-    if (!this.isRunning) {
-      console.warn('[MeshDaemon] Cannot broadcast: Service not running');
-      return;
-    }
-
-    console.log('[MeshDaemon] Broadcasting item:', item.id);
-    
-    this.mesh.createAndBroadcast('gotjunk.new_item', {
-      id: item.id,
-      status: item.status,
-      lat: item.latitude,
-      lng: item.longitude,
-      // Note: We don't send the blob over mesh yet (too big)
-      // We send metadata so peers know it exists
-    });
-  }
-
-  private setupPacketHandlers(): void {
-    this.mesh.setPacketHandler((packet: MeshPacket) => {
-      console.log('[MeshDaemon] Received packet:', packet);
-      
-      switch (packet.type) {
-        case 'gotjunk.new_item':
-          this.handleNewItem(packet);
-          break;
-        case 'liberty.alert':
-          this.handleLibertyAlert(packet);
-          break;
-        default:
-          console.log('[MeshDaemon] Unknown packet type:', packet.type);
-      }
-    });
-  }
-
-  private handleNewItem(packet: MeshPacket): void {
-    // TODO: Check if we have this item in IndexedDB
-    // If not, mark it as "known remote item"
-    console.log('[MeshDaemon] Saw remote item:', packet.payload.id);
-  }
-
-  private handleLibertyAlert(packet: MeshPacket): void {
-    // High priority alert!
-    console.warn('[MeshDaemon] LIBERTY ALERT RECEIVED:', packet.payload);
-    // TODO: Trigger UI notification
+    console.log('[MeshDaemon] Would broadcast item (stub):', item.id);
+    // Full mesh broadcasting coming in Phase 2
   }
 }
-


### PR DESCRIPTION
## Summary
Fixes Cloud Build error by replacing meshDaemon with a stub implementation.

## Error Fixed
```
[vite]: Rollup failed to resolve import "@mesh/core/src/meshCore"
```

## Root Cause
- meshDaemon.ts was importing from `@mesh/core/src/meshCore`
- Mesh code is in `src/mesh/` but Dockerfile only copies `frontend/`
- Build couldn't resolve mesh dependencies

## Solution
- Replace with stub that provides same API
- Logs intent but doesn't actually broadcast
- storage.ts already wraps mesh calls in try-catch
- Full mesh integration coming in Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)