### PR TITLE
fix(gotjunk): Prevent white screen crash from missing URL/blob in Browse

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/ItemReviewer.tsx
+++ b/modules/foundups/gotjunk/frontend/components/ItemReviewer.tsx
@@ -87,6 +87,33 @@ export const ItemReviewer: React.FC<ItemReviewerProps> = ({
 
   const isVideo = item.blob?.type?.startsWith('video/') ?? false;
 
+  // Check if item has valid URL/blob for rendering
+  if (!item.url || !item.blob) {
+    console.warn('[ItemReviewer] Item missing URL or blob:', item.id);
+    return (
+      <motion.div
+        className="fixed inset-0 flex items-center justify-center p-4 pb-28 bg-black/80 backdrop-blur-sm"
+        style={{ zIndex: Z_LAYERS.fullscreen }}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+      >
+        <div className="text-center">
+          <p className="text-white text-xl mb-2">Media unavailable</p>
+          <p className="text-gray-400 text-sm">This item cannot be displayed</p>
+          {onClose && (
+            <button
+              onClick={onClose}
+              className="mt-4 px-4 py-2 bg-gray-700 text-white rounded-lg"
+            >
+              Close
+            </button>
+          )}
+        </div>
+      </motion.div>
+    );
+  }
+
   return (
     <motion.div
       className="fixed inset-0 flex items-center justify-center p-4 pb-28 bg-black/80 backdrop-blur-sm"

--- a/modules/foundups/gotjunk/frontend/components/PhotoCard.tsx
+++ b/modules/foundups/gotjunk/frontend/components/PhotoCard.tsx
@@ -49,6 +49,16 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({ item, onClick, onDelete, o
     }
   };
 
+  // Check if item has valid URL/blob for rendering
+  if (!item.url || !item.blob) {
+    console.warn('[PhotoCard] Item missing URL or blob:', item.id);
+    return (
+      <div className="relative aspect-square w-full rounded-lg bg-gray-800 flex items-center justify-center">
+        <p className="text-gray-500 text-xs text-center px-2">Media unavailable</p>
+      </div>
+    );
+  }
+
   return (
     <motion.div
       className="relative group aspect-square w-full rounded-lg overflow-hidden bg-gray-800 shadow-md cursor-pointer"


### PR DESCRIPTION
## Summary
Fixes white screen crash when swiping up (grid mode) or right (keep) on Browse tab

## Root Cause
Items without valid `item.url` or `item.blob` crashed when rendered:
- **Grid mode** (swipe up → PhotoGrid → PhotoCard)
- **Full screen swipe** (right/left → ItemReviewer)

Crash occurred when:
- Item synced from Firestore without blob
- `URL.createObjectURL()` fails
- IndexedDB corrupted/missing blob data
- Storage encounters invalid items

## Changes

### PhotoCard.tsx
```typescript
// Check if item has valid URL/blob before rendering
if (!item.url || !item.blob) {
  console.warn('[PhotoCard] Item missing URL or blob:', item.id);
  return (
    <div className="relative aspect-square w-full rounded-lg bg-gray-800 flex items-center justify-center">
      <p className="text-gray-500 text-xs text-center px-2">Media unavailable</p>
    </div>
  );
}
```

### ItemReviewer.tsx
```typescript
// Check if item has valid URL/blob before rendering
if (!item.url || !item.blob) {
  console.warn('[ItemReviewer] Item missing URL or blob:', item.id);
  return (
    <motion.div>
      <p className="text-white text-xl mb-2">Media unavailable</p>
      <p className="text-gray-400 text-sm">This item cannot be displayed</p>
      <button onClick={onClose}>Close</button>
    </motion.div>
  );
}
```

## Defensive Rendering
- **PhotoCard**: Gray box with "Media unavailable" text
- **ItemReviewer**: Fullscreen overlay with error message + Close button
- Console warnings for debugging

## Testing
- [ ] Swipe up on Browse tab → grid mode loads without crash
- [ ] Grid shows "Media unavailable" for corrupted items
- [ ] Swipe right on item → item moves to cart without crash
- [ ] Full screen shows fallback UI for invalid items
- [ ] Console shows warning with item ID for debugging

## Related
- PR #161: Initial blob null checks (fixed Community tab crash)
- This PR: Extends protection to Browse tab swipe actions

## WSP Compliance
- WSP 22: ModLog update pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)