### PR TITLE
fix(gotjunk): Add purple color and label for Wanted/Share auto-toggle

### DIFF
--- a/modules/foundups/gotjunk/frontend/components/BottomNavBar.tsx
+++ b/modules/foundups/gotjunk/frontend/components/BottomNavBar.tsx
@@ -238,6 +238,10 @@ export const BottomNavBar: React.FC<BottomNavBarProps> = ({
                  ? 'bg-green-600 text-white'     // Discount = Green
                  : lastClassification?.type === 'bid'
                  ? 'bg-amber-600 text-white'     // Bid = Amber
+                 : lastClassification?.type === 'share'
+                 ? 'bg-purple-600 text-white'    // Share = Purple
+                 : lastClassification?.type === 'wanted'
+                 ? 'bg-purple-600 text-white'    // Wanted = Purple
                  : 'bg-green-600 text-white'     // Fallback = Green
                : 'bg-red-500/60 text-white'      // OFF = Softer red
            }`}
@@ -257,6 +261,8 @@ export const BottomNavBar: React.FC<BottomNavBarProps> = ({
                {lastClassification.type === 'discount' && `${lastClassification.discountPercent || 75}%`}
                {lastClassification.type === 'bid' && `${lastClassification.bidDurationHours || 48}h`}
                {lastClassification.type === 'free' && 'FREE'}
+               {lastClassification.type === 'share' && 'SHARE'}
+               {lastClassification.type === 'wanted' && 'WANTED'}
              </div>
            )}
          </motion.button>


### PR DESCRIPTION
## Summary
Fixes auto-classify toggle to show purple color and display category name for Wanted/Share classifications

## Problem
User feedback: "wanted... the toggle should turn to purple -- wanted color and show the category on the toggle"

Auto-classify toggle wasn't handling Wanted/Share classifications - it fell back to green default without showing the category name.

## Changes

### Auto-Classify Toggle Color (BottomNavBar.tsx)
**Before**: Wanted/Share → green fallback
**After**: Wanted/Share → purple (bg-purple-600)

```typescript
lastClassification?.type === 'share'
  ? 'bg-purple-600 text-white'    // Share = Purple
  : lastClassification?.type === 'wanted'
  ? 'bg-purple-600 text-white'    // Wanted = Purple
```

### Category Label Display
**Before**: No label for Wanted/Share
**After**: Shows "SHARE" or "WANTED" below ON toggle

```typescript
{lastClassification.type === 'share' && 'SHARE'}
{lastClassification.type === 'wanted' && 'WANTED'}
```

## Color Scheme (Complete)
- **Free**: Blue (bg-blue-600) + "FREE"
- **Discount**: Green (bg-green-600) + "75%"
- **Bid**: Amber (bg-amber-600) + "48h"
- **Share**: Purple (bg-purple-600) + "SHARE" ✨
- **Wanted**: Purple (bg-purple-600) + "WANTED" ✨

## Testing
- [ ] Long-press auto-toggle → select "Wanted" → toggle turns purple
- [ ] Toggle label shows "WANTED" text below "ON"
- [ ] Long-press auto-toggle → select "Share" → toggle turns purple
- [ ] Toggle label shows "SHARE" text below "ON"
- [ ] All other categories still show correct colors

## WSP Compliance
- WSP 22: ModLog update pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)