### PR TITLE
feat(git-push-dae): run-once mode for menu

### DIFF
--- a/main.py
+++ b/main.py
@@ -776,7 +776,8 @@ def main():
             if choice == "0":
                 # Launch GitPushDAE daemon (WSP 91 compliant)
                 print("[DEBUG-MAIN] Calling launch_git_push_dae()...")
-                launch_git_push_dae()
+                # Run-once so the interactive menu is not blocked by a long-running daemon.
+                launch_git_push_dae(run_once=True)
                 print("[DEBUG-MAIN] Returned from launch_git_push_dae()")
                 # Will return to menu after completion
 

--- a/modules/infrastructure/git_push_dae/ModLog.md
+++ b/modules/infrastructure/git_push_dae/ModLog.md
@@ -9,12 +9,14 @@
 **Type**: Bug Fix / Test Reliability
 
 **Changes Made**:
-1. `_is_appropriate_time()` now treats **23:00–06:00** as sleep hours to reduce late-night notification spam.
-2. `tests/test_git_push_dae.py` uses an isolated daemon fixture for agentic helper-method tests so unit tests do **not** load persistent state or local LLMs (Qwen).
+1. `_is_appropriate_time()` now treats **23:00-06:00** as sleep hours to reduce late-night notification spam.
+2. Added `GitPushDAE.run_once()` and `launch_git_push_dae(run_once=True)` so the interactive main menu can execute one cycle and return (no "hung" menu).
+3. `tests/test_git_push_dae.py` uses an isolated daemon fixture for agentic helper-method tests so unit tests do **not** load persistent state or local LLMs (Qwen).
 
 **Impact**:
 - Deterministic, fast unit tests on Windows environments.
 - Push gating aligns with test expectations and reduces overnight noise.
+- Main menu option `0` returns after completion (run-once mode).
 
 ## Context-Aware Commit Messages (ModLog-Driven)
 **WSP References**: WSP 22 (ModLog), WSP 50 (Pre-action verification), WSP 3 (Module organization)

--- a/modules/infrastructure/git_push_dae/README.md
+++ b/modules/infrastructure/git_push_dae/README.md
@@ -24,7 +24,12 @@ Fully autonomous git push daemon that monitors code changes and publishes develo
 ```python
 from modules.infrastructure.git_push_dae.src.git_push_dae import GitPushDAE
 
-# Launch autonomous daemon
+# Run one autonomous cycle (menu-safe)
+dae = GitPushDAE(domain="foundups_development", check_interval=300)
+health = dae.run_once()
+print(health.status)
+
+# Launch autonomous daemon (long-running)
 dae = GitPushDAE(domain="foundups_development", check_interval=300)
 dae.start()
 
@@ -35,7 +40,7 @@ dae.start()
 ```
 
 ## Integration Points
-- **Main.py Option 0**: Launches the GitPushDAE daemon
+- **Main.py Option 0**: Runs one GitPushDAE cycle and returns to menu
 - **HoloIndex**: Quality assessment for push decisions
 - **Social Media**: LinkedIn/X posting when conditions met
 

--- a/modules/infrastructure/git_push_dae/scripts/launch.py
+++ b/modules/infrastructure/git_push_dae/scripts/launch.py
@@ -28,10 +28,13 @@ import time
 import traceback
 
 
-def launch_git_push_dae():
+def launch_git_push_dae(run_once: bool = False):
     """
     Launch GitPushDAE daemon with WSP 91 full observability.
     Transforms git push from human-triggered action to autonomous DAE.
+
+    Args:
+        run_once: Run a single monitoring cycle and return to caller (menu-safe).
     """
     print("\n" + "="*60)
     print("[MENU] GIT PUSH DAE - AUTONOMOUS DEVELOPMENT")
@@ -49,21 +52,28 @@ def launch_git_push_dae():
         # Create and start the daemon
         print("[DEBUG-MAIN] Creating GitPushDAE instance...")
         dae = GitPushDAE(domain="foundups_development", check_interval=300)  # 5-minute checks
-        print("[DEBUG-MAIN] GitPushDAE instance created, starting daemon...")
-        dae.start()
-        print("[DEBUG-MAIN] GitPushDAE daemon started")
+        print("[DEBUG-MAIN] GitPushDAE instance created")
 
-        print("\n[INFO]GitPushDAE launched successfully!")
-        print("[INFO] Monitor logs at: logs/git_push_dae.log")
-        print("[INFO] Press Ctrl+C to stop the daemon")
+        if run_once:
+            print("[INFO] Running one GitPushDAE monitoring cycle (run-once mode)...")
+            health = dae.run_once()
+            print(f"[INFO] GitPushDAE run-once complete (health: {health.status})")
+        else:
+            print("[DEBUG-MAIN] Starting GitPushDAE daemon...")
+            dae.start()
+            print("[DEBUG-MAIN] GitPushDAE daemon started")
 
-        try:
-            # Keep running until interrupted
-            while dae.active:
-                time.sleep(1)
-        except KeyboardInterrupt:
-            print("\n[INFO] Stopping GitPushDAE...")
-            dae.stop()
+            print("\n[INFO]GitPushDAE launched successfully!")
+            print("[INFO] Monitor logs at: logs/git_push_dae.log")
+            print("[INFO] Press Ctrl+C to stop the daemon")
+
+            try:
+                # Keep running until interrupted
+                while dae.active:
+                    time.sleep(1)
+            except KeyboardInterrupt:
+                print("\n[INFO] Stopping GitPushDAE...")
+                dae.stop()
 
     except ImportError as e:
         print(f"[ERROR]Failed to import GitPushDAE: {e}")

--- a/modules/infrastructure/git_push_dae/tests/test_git_push_dae.py
+++ b/modules/infrastructure/git_push_dae/tests/test_git_push_dae.py
@@ -105,7 +105,11 @@ class TestGitPushDAE:
             change_summary={"modified": 3, "added": 1}
         )
 
-        decision = daemon.make_push_decision(context)
+        # Ensure this test is deterministic regardless of the local clock.
+        # The time window gate should pass in a typical daytime hour.
+        with patch('modules.infrastructure.git_push_dae.src.git_push_dae.datetime') as mock_dt:
+            mock_dt.now.return_value = datetime(2025, 1, 1, 14, 0, 0)
+            decision = daemon.make_push_decision(context)
 
         # Should decide to push with high confidence
         assert decision.should_push


### PR DESCRIPTION
- Add GitPushDAE.run_once() and wire menu option 0 to use it\n- Update launcher to support un_once so interactive menu returns immediately\n- Update docs + keep unit tests deterministic\n\nWSP: 3, 34, 91\n