### PR TITLE
Promote HoloIndex machine contract + paper blueprint to main

### DIFF
--- a/holo_index/CLI_REFERENCE.md
+++ b/holo_index/CLI_REFERENCE.md
@@ -2,6 +2,11 @@
 
 0102 cheat sheet for HoloIndex + HoloDAE. Qwen leads orchestration, Gemma validates patterns, and this map keeps every CLI skill tied to the module that powers it. Because `holo_index/cli.py` enforces WSP 90 UTF-8 at the entry point, documentation can surface mnemonic tags for fast scanning without contaminating machine-to-machine output.
 
+Contract note:
+- This file is a menu-focused operations atlas, not an exhaustive CLI flag list.
+- Canonical interface contracts live in `holo_index/INTERFACE.md`.
+- Canonical machine schema lives in `holo_index/docs/HOLO_INDEX_MACHINE_LANGUAGE_SPEC_0102.json`.
+
 ## Menu Snapshot (0102 Ops)
 ```
 ============================================================

--- a/holo_index/INTERFACE.md
+++ b/holo_index/INTERFACE.md
@@ -1,287 +1,155 @@
 # HoloIndex Public Interface
 
-## Overview
-HoloIndex has evolved into an autonomous intelligence foundation with HoloDAE - the "green foundation board agent" that comes with every LEGO set. Every search now triggers automatic intelligence analysis.
+## Scope
+This document is the stable public contract for consuming HoloIndex programmatically and via CLI.
+For exhaustive machine-level semantics, use:
+- `holo_index/docs/HOLO_INDEX_MACHINE_LANGUAGE_SPEC_0102.md`
+- `holo_index/docs/HOLO_INDEX_MACHINE_LANGUAGE_SPEC_0102.json`
 
-## Module API
+Source-of-truth policy:
+- Authoritative machine contract: `holo_index/docs/HOLO_INDEX_MACHINE_LANGUAGE_SPEC_0102.json`
+- Human-facing interface contract: this file
+- Menu/operator atlas: `holo_index/CLI_REFERENCE.md` (non-normative)
 
-### Core Search Interface (Now with HoloDAE Intelligence)
+## Programmatic API
 
+### Core Retrieval
 ```python
-from holo_index.cli import HoloIndex
+from holo_index.core.holo_index import HoloIndex
 
-# Initialize
-holo = HoloIndex(ssd_path="E:/HoloIndex")
+holo = HoloIndex(ssd_path="E:/HoloIndex", quiet=True)
+results = holo.search("send chat message", limit=5, doc_type_filter="all")
+```
 
-# Search for code and WSP guidance
-results = holo.search(
-    query="send chat message",
-    limit=5  # Results per category
-)
-
-# Results structure
+Search response contract:
+```python
 {
-    'code': [
-        {
-            'score': float,  # Similarity score
-            'module': str,   # Module path
-            'function': str, # Function/class name
-            'content': str,  # Code snippet
-            'file': str,     # Source file
-            'cube': str      # Optional cube tag
-        }
-    ],
-    'wsps': [
-        {
-            'score': float,
-            'wsp': str,      # WSP identifier
-            'title': str,    # WSP title
-            'content': str,  # Relevant section
-            'file': str      # Source document
-        }
-    ],
-    'health_notices': [...],  # Module health warnings
-    'adaptive_learning': {...}  # Learning metrics
-}
-```
-
-### Indexing Interface
-
-```python
-# Index code entries
-holo.index_code_entries()
-
-# Index WSP documents
-holo.index_wsp_entries(paths=[Path("WSP_framework/")])
-
-# Index everything
-holo.index_all()
-```
-
-### HoloDAE Autonomous Intelligence Interface
-
-```python
-from holo_index.qwen_advisor.autonomous_holodae import autonomous_holodae
-
-# Start autonomous monitoring (like YouTube DAE)
-autonomous_holodae.start_autonomous_monitoring()
-
-# Get status report
-status = autonomous_holodae.get_status_report()
-# Returns: {
-#     'active': bool,
-#     'uptime_minutes': int,
-#     'files_watched': int,
-#     'current_module': str,
-#     'task_pattern': str,
-#     'session_actions': int,
-#     'last_activity': str
-# }
-
-# Stop monitoring
-autonomous_holodae.stop_autonomous_monitoring()
-
-# Manual request handling (automatic via CLI)
-report = autonomous_holodae.handle_holoindex_request(query, search_results)
-```
-
-### AI Advisor Interface
-
-```python
-from holo_index.qwen_advisor.advisor import QwenAdvisor, AdvisorContext
-
-# Initialize advisor
-advisor = QwenAdvisor()
-
-# Create context
-context = AdvisorContext(
-    query="create new module",
-    code_hits=[...],  # From search results
-    wsp_hits=[...]    # From search results
-)
-
-# Get guidance
-result = advisor.generate_guidance(context)
-
-# Result structure
-{
-    'guidance': str,        # Primary guidance text
-    'reminders': List[str], # WSP reminders
-    'todos': List[str],     # Action items
-    'metadata': {
-        'risk_level': str,
-        'intent': str,
-        'violations': List[str],
-        'llm_used': bool,
-        'wsp_analysis': {...}
+  "code_hits": [
+    {
+      "need": str,
+      "location": str,
+      "similarity": "85.1%",
+      "type": str,
+      "priority": int,
+      "path": str | None,
+      "line": int | None,
+      "preview": str | None,
+      "cube": str | None,
     }
+  ],
+  "wsp_hits": [
+    {
+      "wsp": str,
+      "title": str,
+      "summary": str,
+      "path": str,
+      "similarity": "82.3%",
+      "type": str,
+      "priority": int,
+      "cube": str | None,
+    }
+  ],
+  "test_hits": list,
+
+  # Backward-compatible aliases
+  "code": list,
+  "wsps": list,
+  "tests": list,
+
+  "skills": list,
+  "skill_hits": list,
+  "symbol_hits": list,
+  "metadata": {
+    "query": str,
+    "code_count": int,
+    "wsp_count": int,
+    "test_count": int,
+    "skill_count": int,
+    "symbol_count": int,
+    "timestamp": str,
+    "cached": bool,
+  }
 }
 ```
 
-### Pattern Coach Interface
-
+### Indexing Methods
 ```python
-from holo_index.qwen_advisor.pattern_coach import PatternCoach
-
-# Initialize coach
-coach = PatternCoach()
-
-# Analyze and get coaching
-coaching = coach.analyze_and_coach(
-    query="test the system",
-    search_results=[...],
-    health_warnings=[...]
-)
-
-# Record outcome for learning
-coach.record_coaching_outcome(
-    coaching=coaching,
-    followed=True,
-    reward_earned=5
-)
-
-# Get statistics
-stats = coach.get_coaching_stats()
+holo.index_code_entries()
+holo.index_symbol_entries()
+holo.index_wsp_entries()
+holo.index_test_registry()
+holo.index_skillz_entries()
 ```
 
-### DAE Cube Organizer Interface
-
+### Module Compliance Helper
 ```python
-from holo_index.dae_cube_organizer.dae_cube_organizer import DAECubeOrganizer
-
-# Initialize organizer
-organizer = DAECubeOrganizer()
-
-# Get DAE context
-context = organizer.initialize_dae_context("YouTube Live")
-
-# Context structure
-{
-    'dae_identity': {
-        'name': str,
-        'emoji': str,
-        'description': str,
-        'orchestrator': str,
-        'main_py_reference': str
-    },
-    'module_map': {
-        'ascii_map': str,
-        'modules': List[Dict]
-    },
-    'orchestration_flow': {
-        'phases': List[str],
-        'loop_type': str
-    },
-    'quick_reference': {...},
-    'rampup_guidance': {...}
-}
+status = holo.check_module_exists("modules/communication/livechat")
 ```
 
-### Violation Tracking Interface
+Returns:
+- `exists`, `path`, `module_name`
+- doc/test presence booleans
+- `wsp_compliance`, `compliance_score`, `health_warnings`, `recommendation`
 
+### HoloDAE Coordinator API
 ```python
-from holo_index.violation_tracker import ViolationTracker
+from holo_index.qwen_advisor import start_holodae, stop_holodae, get_holodae_status
 
-# Initialize tracker
-tracker = ViolationTracker()
-
-# Record violation
-tracker.record_violation(
-    wsp="WSP 49",
-    module="holo_index",
-    severity="MEDIUM",
-    description="Missing required structure",
-    agent="0102"
-)
-
-# Query violations
-violations = tracker.get_violations_by_module("holo_index")
-summary = tracker.get_summary()
+start_holodae()
+status = get_holodae_status()
+stop_holodae()
 ```
 
-## CLI Commands
+## CLI API
 
-### Search
+### Retrieval
 ```bash
-python holo_index.py --search "query" [options]
-  --limit N           # Results per category (default: 5)
-  --llm-advisor      # Enable AI advisor
-  --no-advisor       # Disable advisor
+python holo_index.py --search "query" --limit 5
+python holo_index.py --search "query" --doc-type code
+python holo_index.py --search "query" --fast-search
 ```
 
 ### Indexing
 ```bash
-python holo_index.py --index-all     # Index everything
-python holo_index.py --index-code    # Index code only
-python holo_index.py --index-wsp     # Index WSP only
+python holo_index.py --index-all
+python holo_index.py --index-code
+python holo_index.py --index-wsp
+python holo_index.py --index-symbols --symbol-roots modules/foundups
+python holo_index.py --index-skillz
 ```
 
-### HoloDAE Autonomous Monitoring
+### Machine Bundle Output
 ```bash
-python holo_index.py --start-holodae  # Start autonomous monitoring
-python holo_index.py --stop-holodae   # Stop monitoring
-python holo_index.py --holodae-status # Get status report
-
-# Or via main.py:
-python main.py --holo                  # Start HoloDAE monitoring
+python holo_index.py --bundle-json --search "task" --bundle-module-hint modules/foundups/agent_market
 ```
 
-### DAE Initialization
+Bundle schema ID: `wsp_memory_bundle_v1`
+
+### Monitoring / Orchestration
 ```bash
-python holo_index.py --init-dae [DAE_NAME]
-  # Examples:
-  --init-dae                    # Auto-detect DAE
-  --init-dae "YouTube Live"     # YouTube DAE
-  --init-dae "AMO"             # Meeting orchestration
+python holo_index.py --start-holodae
+python holo_index.py --stop-holodae
+python holo_index.py --holodae-status
 ```
 
-### Feedback
+### Compliance / Diagnostics
 ```bash
-python holo_index.py --advisor-rating useful|needs_more
-python holo_index.py --ack-reminders  # Acknowledge reminders
+python holo_index.py --check-module "livechat"
+python holo_index.py --check-wsp-docs
+python holo_index.py --fix-ascii --check-wsp-docs
+python holo_index.py --system-check
+python holo_index.py --health-check
 ```
 
-## Integration Points
+## Environment Controls (Selected)
+- `HOLO_OFFLINE=1`: disable model downloads/auto-install.
+- `HOLO_SKIP_MODEL=1`: force lexical retrieval path.
+- `HOLO_MIN_SIMILARITY=0.35`: vector hit floor.
+- `HOLO_FAST_SEARCH=1`: retrieval-only fast path.
+- `HOLO_INDEX_WEB=1`: include web assets during `--index-code`.
+- `HOLO_SYMBOL_AUTO=1`: auto symbol indexing during `--index-code`.
 
-### With NAVIGATION.py
-```python
-# HoloIndex automatically loads NAVIGATION.py mappings
-from NAVIGATION import NEED_TO
-# These are integrated into search results
-```
-
-### With main.py
-```python
-# DAE Cube Organizer understands main.py structure
-# Provides menu option mappings and orchestrator references
-```
-
-### With WSP Framework
-```python
-# WSP Master loads all protocols from WSP_framework/
-# Provides intelligent protocol selection and guidance
-```
-
-## Error Handling
-
-All methods may raise:
-- `FileNotFoundError`: Missing required files
-- `ImportError`: Missing dependencies
-- `ValueError`: Invalid parameters
-- `RuntimeError`: Initialization failures
-
-## Performance Considerations
-
-- **First Load**: ~2-3 seconds (model loading)
-- **Subsequent Searches**: <200ms
-- **Memory Usage**: ~1GB with all models
-- **SSD Required**: For ChromaDB performance
-- **Cache**: Results cached for 15 minutes
-
-## WSP Compliance
-
-This interface follows:
-- **WSP 11**: Complete interface documentation
-- **WSP 49**: Module structure standards
-- **WSP 87**: Code navigation protocol
-- **WSP 84**: Code memory verification
+## Compatibility Notes
+- `code` / `wsps` keys remain present for backward compatibility.
+- `search()` degrades to lexical mode when embedding model is unavailable.
+- `CLI_REFERENCE.md` is a menu snapshot; use this file + machine spec JSON for exhaustive contracts.

--- a/holo_index/README.md
+++ b/holo_index/README.md
@@ -85,6 +85,9 @@ HoloIndex + **HoloDAE** = Complete autonomous code intelligence system:
 
 ## Operational Documentation
 - **[CLI_REFERENCE.md](CLI_REFERENCE.md)** — Verbatim menu snapshot and CLI command mappings (for 0102_gpt parsing)
+- **[INTERFACE.md](INTERFACE.md)** — Public runtime interface contract (programmatic + CLI)
+- **[Machine Spec (JSON)](docs/HOLO_INDEX_MACHINE_LANGUAGE_SPEC_0102.json)** — Canonical machine-readable architecture/spec contract
+- **[Machine Spec (Markdown)](docs/HOLO_INDEX_MACHINE_LANGUAGE_SPEC_0102.md)** — Human-readable first-principles architecture analysis
 - [Operational Playbook](docs/OPERATIONAL_PLAYBOOK.md) — step-by-step pre-code checklist, TODO workflow, and doc compliance rules for 0102.
 - [Telemetry & Breadcrumb Guide](docs/MULTI_AGENT_BREADCRUMB_EXAMPLE.md) — how to follow the live JSONL stream (`holo_index/logs/telemetry/`) and coordinate hand-offs between sessions.
 - [CLI Refactoring Plan](docs/CLI_REFACTORING_PLAN.md) — deeper design notes for the search/CLI pipeline.

--- a/holo_index/docs/HOLO_INDEX_MACHINE_LANGUAGE_SPEC_0102.json
+++ b/holo_index/docs/HOLO_INDEX_MACHINE_LANGUAGE_SPEC_0102.json
@@ -1,0 +1,263 @@
+{
+  "spec_id": "holo_index.machine_language.v1",
+  "version": "2026-02-18",
+  "scope": "runtime architecture, contracts, and scoring semantics",
+  "source_of_truth_policy": {
+    "authoritative_machine_contract": "holo_index/docs/HOLO_INDEX_MACHINE_LANGUAGE_SPEC_0102.json",
+    "human_interface_contract": "holo_index/INTERFACE.md",
+    "operator_menu_atlas_non_normative": "holo_index/CLI_REFERENCE.md"
+  },
+  "entrypoints": {
+    "cli_module": "holo_index/cli.py::main",
+    "core_class": "holo_index/core/holo_index.py::HoloIndex",
+    "python_package_entry": "holo_index/__init__.py::main",
+    "legacy_wrapper": "holo_index.py"
+  },
+  "runtime_layers": [
+    {
+      "name": "retrieval_core",
+      "responsibility": "indexing and querying code, WSP docs, tests, and skillz",
+      "primary_file": "holo_index/core/holo_index.py"
+    },
+    {
+      "name": "cli_orchestration",
+      "responsibility": "command routing, index refresh, output rendering, bundle export",
+      "primary_file": "holo_index/cli.py"
+    },
+    {
+      "name": "intent_orchestration",
+      "responsibility": "intent classification, component routing, output composition",
+      "primary_files": [
+        "holo_index/intent_classifier.py",
+        "holo_index/qwen_advisor/orchestration/qwen_orchestrator.py",
+        "holo_index/output_composer.py"
+      ]
+    },
+    {
+      "name": "adaptive_memory",
+      "responsibility": "feedback learning, breadcrumb tracing, history telemetry",
+      "primary_files": [
+        "holo_index/feedback_learner.py",
+        "holo_index/adaptive_learning/breadcrumb_tracer.py",
+        "holo_index/output/agentic_output_throttler.py"
+      ]
+    }
+  ],
+  "state_machine": {
+    "states": [
+      "BOOTSTRAP",
+      "INDEX_READY",
+      "SEARCH_EXECUTING",
+      "RESULT_FOUND",
+      "RESULT_MISSING",
+      "ERROR"
+    ],
+    "transitions": [
+      {
+        "from": "BOOTSTRAP",
+        "event": "init_success",
+        "to": "INDEX_READY"
+      },
+      {
+        "from": "INDEX_READY",
+        "event": "search(query)",
+        "to": "SEARCH_EXECUTING"
+      },
+      {
+        "from": "SEARCH_EXECUTING",
+        "event": "hits_total > 0",
+        "to": "RESULT_FOUND"
+      },
+      {
+        "from": "SEARCH_EXECUTING",
+        "event": "hits_total == 0",
+        "to": "RESULT_MISSING"
+      },
+      {
+        "from": "SEARCH_EXECUTING",
+        "event": "exception",
+        "to": "ERROR"
+      }
+    ]
+  },
+  "collections": [
+    {
+      "name": "navigation_code",
+      "source_domains": [
+        "NAVIGATION.py NEED_TO map",
+        "web assets from HOLO_WEB_INDEX_ROOTS"
+      ],
+      "key_metadata": [
+        "need",
+        "type",
+        "source",
+        "path",
+        "keywords",
+        "priority",
+        "cube"
+      ]
+    },
+    {
+      "name": "navigation_symbols",
+      "source_domains": [
+        "python AST function/class extraction"
+      ],
+      "key_metadata": [
+        "symbol",
+        "path",
+        "line",
+        "type"
+      ]
+    },
+    {
+      "name": "navigation_wsp",
+      "source_domains": [
+        "WSP_framework and configured markdown/yaml corpora"
+      ],
+      "key_metadata": [
+        "wsp",
+        "title",
+        "path",
+        "summary",
+        "type",
+        "priority",
+        "cube"
+      ]
+    },
+    {
+      "name": "navigation_tests",
+      "source_domains": [
+        "WSP_knowledge/WSP_Test_Registry.json"
+      ],
+      "key_metadata": [
+        "test_id",
+        "path",
+        "description",
+        "capabilities",
+        "priority"
+      ]
+    },
+    {
+      "name": "navigation_skills",
+      "source_domains": [
+        "SKILLz.md frontmatter and content"
+      ],
+      "key_metadata": [
+        "skill_name",
+        "primary_agent",
+        "intent_type",
+        "promotion_state",
+        "path",
+        "priority"
+      ]
+    }
+  ],
+  "search_math": {
+    "embedding_distance_to_similarity": "similarity = 1 / (1 + distance)",
+    "vector_similarity_floor_env": "HOLO_MIN_SIMILARITY (default 0.35)",
+    "hybrid_rank_formula": "rank = 0.5*priority + 0.3*similarity + 0.2*keyword_score",
+    "skill_rank_formula": "rank = 0.6*priority + 0.3*similarity + 0.1*keyword_score",
+    "lexical_similarity_formula": "similarity = min(1.0, keyword_score / (max(1, token_count * 2.5)))",
+    "symbol_fallbacks": [
+      "symbol collection semantic query",
+      "collection lexical scan",
+      "ripgrep exact fallback via _rg_symbol_search"
+    ]
+  },
+  "contracts": {
+    "search_request": {
+      "query": "string",
+      "limit": "integer",
+      "doc_type_filter": "all|code|test|wsp_protocol|module_readme|interface|documentation|roadmap|modlog"
+    },
+    "search_response_required_keys": [
+      "code_hits",
+      "wsp_hits",
+      "test_hits",
+      "code",
+      "wsps",
+      "tests",
+      "skills",
+      "skill_hits",
+      "metadata"
+    ],
+    "search_metadata_keys": [
+      "query",
+      "code_count",
+      "wsp_count",
+      "test_count",
+      "skill_count",
+      "symbol_count",
+      "timestamp",
+      "cached"
+    ],
+    "bundle_json_schema_id": "wsp_memory_bundle_v1",
+    "bundle_json_top_keys": [
+      "schema_version",
+      "generated_at",
+      "ok",
+      "task",
+      "module_hint",
+      "module_path",
+      "structured_memory",
+      "task_retrieval"
+    ]
+  },
+  "orchestration": {
+    "intent_types": [
+      "doc_lookup",
+      "code_location",
+      "module_health",
+      "research",
+      "general"
+    ],
+    "component_execution_surface": [
+      "health_analysis",
+      "vibecoding_analysis",
+      "file_size_monitor",
+      "module_analysis",
+      "pattern_coach",
+      "orphan_analysis",
+      "wsp_documentation_guardian"
+    ],
+    "mcp_research_gate": "MCP tools are invoked only when intent == research"
+  },
+  "durability": {
+    "vector_store_default": "E:/HoloIndex/vectors (or custom --ssd path)",
+    "wsp_summary_cache": "E:/HoloIndex/indexes/wsp_summary.json",
+    "output_history_default": "holo_index/output/holo_output_history.jsonl",
+    "agent_activity_log": "holo_index/logs/agent_activity.log"
+  },
+  "invariants": [
+    "search() always returns legacy keys code/wsps for compatibility",
+    "if embedding model is unavailable, retrieval falls back to lexical scan",
+    "default output path is tri-state: ERROR | FOUND | MISSING",
+    "symbol queries must attempt exact-fallback search to reduce NAVIGATION blind spots"
+  ],
+  "current_drift_and_status": [
+    {
+      "id": "DRIFT-001",
+      "area": "OutputComposer API compatibility",
+      "status": "resolved",
+      "resolution": "compose() now accepts intent_classification and legacy intent argument"
+    },
+    {
+      "id": "DRIFT-002",
+      "area": "Intent-router component names vs executable stubs",
+      "status": "resolved",
+      "resolution": "component_router now returns component names implemented by orchestrator stub execution"
+    },
+    {
+      "id": "DRIFT-003",
+      "area": "search() robustness under partial initialization",
+      "status": "resolved",
+      "resolution": "search() and _search_collection() now guard missing attrs/collections"
+    },
+    {
+      "id": "DRIFT-004",
+      "area": "docs-to-cli command parity",
+      "status": "open",
+      "resolution_target": "keep CLI_REFERENCE as menu snapshot; maintain exhaustive machine contract in this spec"
+    }
+  ]
+}

--- a/holo_index/docs/HOLO_INDEX_MACHINE_LANGUAGE_SPEC_0102.md
+++ b/holo_index/docs/HOLO_INDEX_MACHINE_LANGUAGE_SPEC_0102.md
@@ -1,0 +1,111 @@
+# HoloIndex Machine-Language Specification (0102)
+
+## 1) First-Principles Definition
+HoloIndex is a deterministic retrieval-and-orchestration machine:
+
+`(query, context, configuration) -> (ranked memory hits, protocol guidance, action surface)`
+
+It is not only a search utility. It is a policy-bearing retrieval system with:
+- memory indexing,
+- intent routing,
+- compliance framing,
+- agent-specific output compression.
+
+## 2) Canonical Runtime Topology
+- Retrieval core: `holo_index/core/holo_index.py` (`HoloIndex`)
+- CLI command router: `holo_index/cli.py`
+- Intent and composition:
+  - `holo_index/intent_classifier.py`
+  - `holo_index/qwen_advisor/orchestration/qwen_orchestrator.py`
+  - `holo_index/output_composer.py`
+- Output contract + memory cards: `holo_index/output/agentic_output_throttler.py`
+- Adaptive learning:
+  - `holo_index/feedback_learner.py`
+  - `holo_index/adaptive_learning/breadcrumb_tracer.py`
+
+## 3) State Machine
+- `BOOTSTRAP`: initialize model, Chroma collections, cached WSP summary/navigation.
+- `INDEX_READY`: accepts index/search commands.
+- `SEARCH_EXECUTING`: dual retrieval (code + WSP + optional tests/skills/symbols).
+- `RESULT_FOUND`: at least one hit.
+- `RESULT_MISSING`: no hit, creation guidance path.
+- `ERROR`: exception path with structured fallback payload.
+
+Transition truth is encoded in `holo_index/core/holo_index.py:1014` and `holo_index/output/agentic_output_throttler.py:427`.
+
+## 4) Scoring Math (Current)
+- Vector distance conversion:
+  - `similarity = 1 / (1 + distance)`
+- Similarity floor:
+  - `HOLO_MIN_SIMILARITY` (default `0.35`)
+- Hybrid rank:
+  - `score = 0.5*priority + 0.3*similarity + 0.2*keyword_score`
+- Skill rank variant:
+  - `score = 0.6*priority + 0.3*similarity + 0.1*keyword_score`
+- Lexical fallback similarity:
+  - `similarity = min(1.0, keyword_score / (max(1, token_count * 2.5)))`
+
+## 5) Retrieval Contract (Machine Surface)
+`search(query, limit, doc_type_filter)` returns keys:
+- `code_hits`, `wsp_hits`, `test_hits`
+- `code`, `wsps`, `tests` (legacy compatibility)
+- `skills`, `skill_hits`
+- `metadata` with counts and timestamp
+
+`--bundle-json` returns schema `wsp_memory_bundle_v1`:
+- `schema_version`, `generated_at`, `ok`
+- `task`, `module_hint`, `module_path`
+- `structured_memory`, `task_retrieval`
+
+## 6) Intent-Orchestration Contract
+Intent classes:
+- `doc_lookup`
+- `code_location`
+- `module_health`
+- `research`
+- `general`
+
+Execution components:
+- `health_analysis`
+- `vibecoding_analysis`
+- `file_size_monitor`
+- `module_analysis`
+- `pattern_coach`
+- `orphan_analysis`
+- `wsp_documentation_guardian`
+
+MCP research is intent-gated (`research` only).
+
+## 7) CTO Consistency Audit (Docs vs Runtime)
+Validated on 2026-02-18 with tests:
+- `holo_index/tests/test_intent_classifier.py`
+- `holo_index/tests/test_output_composer.py`
+- `holo_index/tests/test_memory_output_contract.py`
+- `holo_index/tests/test_doc_type_filtering.py`
+
+Result: `45 passed`.
+
+Resolved drifts:
+- `OutputComposer` accepted only `intent_classification`; now supports legacy `intent` callers.
+- Router returned non-executable component names (`code_index_search`, `mcp_integration`); now aligned to executable component surface.
+- `HoloIndex.search()` now handles partial initialization without collapsing into exception fallback.
+- Intent classification and alert grouping now match expected behavioral contract.
+
+Open drift:
+- `CLI_REFERENCE.md` is a menu snapshot, not an exhaustive flag contract. This file + JSON spec are now the canonical machine contract.
+
+## 8) Economic/System Interpretation
+At system level, HoloIndex optimizes:
+- recall of existing implementations,
+- policy adherence (WSP constraints),
+- token efficiency under agent context limits.
+
+It behaves as a constrained optimizer:
+- maximize relevance and protocol utility,
+- subject to output and latency constraints.
+
+## 9) Canonical Source of Truth
+- Machine contract (authoritative, executable-facing): `holo_index/docs/HOLO_INDEX_MACHINE_LANGUAGE_SPEC_0102.json`
+- Human-readable explanation: this document
+- Public interface summary: `holo_index/INTERFACE.md`
+- Operator/menu atlas (non-normative): `holo_index/CLI_REFERENCE.md`

--- a/holo_index/docs/ModLog.md
+++ b/holo_index/docs/ModLog.md
@@ -2,6 +2,20 @@
 **WSP Compliance**: WSP 22 (Module ModLog and Roadmap Protocol)
 
 ====================================================================
+## MODLOG - [2026-02-18] [+MACHINE-CONTRACT]
+- Summary: Added canonical machine-language spec and rewrote INTERFACE contract to match runtime behavior.
+- Notes:
+  - Added `HOLO_INDEX_MACHINE_LANGUAGE_SPEC_0102.json` (machine-readable source of truth).
+  - Added `HOLO_INDEX_MACHINE_LANGUAGE_SPEC_0102.md` (human-readable first-principles analysis).
+  - Updated `holo_index/INTERFACE.md` and linked contract docs from `README.md`.
+  - Locked governance with test coverage in `holo_index/tests/test_machine_spec_contract.py`.
+- WSP References:
+  - WSP 22
+  - WSP 50
+  - WSP 87
+====================================================================
+
+====================================================================
 ## MODLOG - [+DOC-EXEMPT]
 - Summary: Added documentation-only exemption so HoloIndex health skips runtime requirements for this bundle.
 - Notes: Updated HoloDAE coordinator to recognize docs directories while preserving WSP 22 scaffolding.
@@ -17,4 +31,3 @@
   - WSP 22
   - WSP 50
 ====================================================================
-

--- a/holo_index/docs/README.md
+++ b/holo_index/docs/README.md
@@ -7,6 +7,8 @@ HoloIndex is a sophisticated semantic search system designed to prevent vibecodi
 ## Key Documentation
 
 **Active Documentation** (current reference):
+- [Machine Spec (JSON)](HOLO_INDEX_MACHINE_LANGUAGE_SPEC_0102.json) — Canonical machine-readable runtime contract
+- [Machine Spec (Markdown)](HOLO_INDEX_MACHINE_LANGUAGE_SPEC_0102.md) — First-principles architecture and consistency analysis
 - [Operational Playbook](OPERATIONAL_PLAYBOOK.md) — Primary runbook for 0102 (checklists, workflows)
 - [ModLog.md](ModLog.md) — Change history and updates
 - [Holo Command Interface](Holo_Command_Interface.md) — CLI reference guide

--- a/holo_index/intent_classifier.py
+++ b/holo_index/intent_classifier.py
@@ -73,10 +73,10 @@ class IntentClassification:
         """Get context-aware output formatting rules for this intent"""
         rules_map = {
             IntentType.DOC_LOOKUP: OutputFormattingRules(
-                priority_sections=['results', 'guidance', 'compliance'],
+                priority_sections=['results', 'guidance', 'compliance', 'alerts'],
                 verbosity_level='minimal',
                 focus_description='Direct answers to documentation questions',
-                suppress_sections=['orchestrator', 'alerts']
+                suppress_sections=['orchestrator']
             ),
             IntentType.CODE_LOCATION: OutputFormattingRules(
                 priority_sections=['results', 'context', 'health'],
@@ -134,7 +134,7 @@ class IntentClassifier:
             r'(?:wsp|protocol) (?:definition|explanation)',
         ],
         IntentType.CODE_LOCATION: [
-            r'where (?:is|does|can i find)',
+            r'where (?:is|are|does|can i find)',
             r'find (?:the )?(?:class|function|method|file)',
             r'locate (?:the )?(?:code|implementation|definition)',
             r'(?:which|what) file (?:contains|has|defines)',
@@ -151,6 +151,7 @@ class IntentClassifier:
             r'(?:is|are) (?:there )?(?:any )?(?:issues|problems|errors|violations)',
             r'(?:wsp|compliance) (?:violations|issues|problems)',
             r'(?:module|system|code) status',
+            r'(?:module|system) health',
             r'(?:show|list) (?:module |system )?(?:issues|problems|violations)',
             # Enhanced patterns for health checking
             r'(?:test|lint|coverage) (?:status|results?)',

--- a/holo_index/qwen_advisor/orchestration/services/component_router.py
+++ b/holo_index/qwen_advisor/orchestration/services/component_router.py
@@ -8,11 +8,11 @@ from enum import Enum
 COMPONENT_META = {
     'health_analysis': ('[PILL][OK]', 'Health & WSP Compliance'),
     'vibecoding_analysis': ('[AI]', 'Vibecoding Analysis'),
+    'file_size_monitor': ('[RULER]', 'File Size Monitor'),
+    'pattern_coach': ('[IDEA]', 'Pattern Coach'),
     'orphan_analysis': ('[GHOST]', 'Orphan Analysis'),
     'wsp_documentation_guardian': ('[BOOKS]', 'WSP Documentation Guardian'),
     'module_analysis': ('[LINK]', 'Module Analysis'),
-    'code_index_search': ('[SEARCH]', 'Code Index Search'),
-    'mcp_integration': ('[MCP]', 'MCP Integration'),
 }
 
 class ComponentRouter:
@@ -28,15 +28,15 @@ class ComponentRouter:
                 'module_analysis'              # Secondary - module context
             ],
             'code_location': [
-                'code_index_search',           # Primary - Find code
-                'module_analysis'              # Secondary - Verify location
+                'module_analysis',             # Primary - Verify module + location context
+                'file_size_monitor'            # Secondary - Surface large-file hotspots
             ],
             'fix_error': [
                 'health_analysis',             # Primary - Check for errors
-                'code_index_search'            # Secondary - Find context
+                'module_analysis'              # Secondary - Find local module context
             ],
             'research': [
-                'mcp_integration',             # Primary - External research
+                'pattern_coach',               # Primary - Explain architecture/patterns
                 'wsp_documentation_guardian'   # Secondary - Internal docs
             ],
             'general': [

--- a/holo_index/tests/TESTModLog.md
+++ b/holo_index/tests/TESTModLog.md
@@ -1,4 +1,91 @@
-﻿# HoloIndex Test Suite TESTModLog
+# HoloIndex Test Suite TESTModLog
+## [2026-02-18] Machine Contract Governance Lock
+**WSP Protocol**: WSP 5 (Testing Standards), WSP 6 (Audit Coverage), WSP 22 (Documentation)
+
+### Summary
+- Added `test_machine_spec_contract.py` to enforce source-of-truth governance:
+  - machine JSON spec remains authoritative
+  - `INTERFACE.md` declares policy
+  - `CLI_REFERENCE.md` remains explicitly non-normative
+
+### Verification
+- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest holo_index/tests/test_machine_spec_contract.py -q`
+
+## [2026-02-18] Contract Drift Hardening Regression
+**WSP Protocol**: WSP 5 (Testing Standards), WSP 6 (Audit Coverage), WSP 22 (Documentation)
+
+### Summary
+- Re-ran targeted contract suite after runtime/interface hardening:
+  - intent classification
+  - output composition compatibility
+  - memory output contract
+  - doc-type filtering behavior
+- Verified that previously drifting contracts now align.
+
+### Verification
+- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest holo_index/tests/test_intent_classifier.py holo_index/tests/test_output_composer.py holo_index/tests/test_memory_output_contract.py holo_index/tests/test_doc_type_filtering.py -q`
+- Result: `45 passed` (2 pytest config warnings in this environment)
+
+## [2026-02-12] 012 Scratchpad Source Resolver Coverage
+**WSP Protocol**: WSP 5 (Testing Standards), WSP 6 (Audit Coverage), WSP 22 (Documentation)
+
+### Summary
+- Added `test_ingest_012_corpus.py` to validate deterministic source resolution for 012 corpus ingest.
+- Covers:
+  - Auto mode prefers root `012.txt` scratchpad.
+  - Explicit relative path resolution works for docs mirror path.
+
+### Verification
+- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest holo_index/tests/test_ingest_012_corpus.py -q`
+
+## [2026-02-11] Holo System Check WSP Sentinel Coverage
+**WSP Protocol**: WSP 5 (Testing Standards), WSP 6 (Audit Coverage), WSP 22 (Documentation)
+
+### Summary
+- Added `test_holo_system_check.py` to validate WSP framework sentinel integration in system-check output.
+- Covers:
+  - `run_system_check(...)` includes `wsp_framework_health` payload.
+  - `write_system_check_report(...)` renders `WSP Framework Health` section.
+
+### Verification
+- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest holo_index/tests/test_holo_system_check.py -q`
+
+## [2026-02-11] Web Asset Indexing Coverage
+**WSP Protocol**: WSP 5 (Testing Standards), WSP 6 (Audit Coverage), WSP 22 (Documentation)
+
+### Summary
+- Added `test_web_asset_indexing.py` to validate semantic ingestion of `public` HTML/JS assets.
+- Covers enabled path, disabled toggle path, and merged indexing with NAVIGATION entries.
+- Locks retrieval behavior needed for FoundUP cube animation artifacts.
+
+### Verification
+- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest holo_index/tests/test_web_asset_indexing.py -q`
+
+## [2026-02-08] Windows Decode Hardening Verification
+**WSP Protocol**: WSP 5 (Testing Standards), WSP 6 (Audit Coverage), WSP 22 (Documentation)
+
+### Summary
+- Verified search cache hit path with repeated-query timing + cache stats.
+- Validated CLI search no longer emits Windows cp932 decode thread noise under current repro commands.
+- Covered runtime subprocess hardening paths with UTF-8 decode settings.
+
+### Verification
+- `python - <<script>>` timing harness for repeated `HoloIndex.search()` (cache hit/miss stats).
+- `python holo_index.py --offline --fast-search --search "persistence" --limit 6 --quiet-root-alerts`
+- `python holo_index.py --offline --search "persistence" --limit 6 --quiet-root-alerts`
+- `Measure-Command { python holo_index.py --offline --fast-search --search "persistence" --limit 6 --quiet-root-alerts | Out-Null }`
+
+## [2026-02-08] Fast Search Mode Coverage
+**WSP Protocol**: WSP 5 (Testing Standards), WSP 6 (Audit Coverage), WSP 22 (Documentation)
+
+### Summary
+- Added `test_fast_search_mode.py` to validate retrieval fast-path controls.
+- Covers activation via `--fast-search` and `HOLO_FAST_SEARCH=1`.
+- Verifies compact fast-path summary output format.
+
+### Verification
+- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest holo_index/tests/test_fast_search_mode.py -q`
+
 ## ++ CodeIndex Circulation Monitor Coverage
 **WSP Protocol**: WSP 93 (CodeIndex), WSP 35 (HoloIndex Qwen Advisor Plan), WSP 5 (Testing Standards), WSP 6 (Audit Coverage), WSP 22 (Documentation)
 
@@ -34,6 +121,49 @@
 - Added tests for HoloOutputFormatter summary/TODO structure and telemetry JSONL logging.
 - Existing coordinator tests now validate structured response still includes arbitration/execution details.
 - Pending: module map + doc consumption tests once coordinator integration lands.
+
+## [2026-02-06] Holo vs grep Integration Test Refresh
+**WSP Protocol**: WSP 5 (Testing Standards), WSP 6 (Audit Coverage), WSP 22 (Documentation)
+
+### Summary
+- Updated `test_holo_vs_grep.py` assertions to reflect current CLI output formatting.
+- Added UTF-8 safe subprocess decoding for HoloIndex and rg outputs.
+- Reframed TSX preview test to semantic-result availability when literal rg fails.
+- Documented SWOT comparison in `holo_index/tests/TEST_SUITE_DOCUMENTATION.md`.
+
+### Verification
+- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest holo_index/tests/test_holo_vs_grep.py -q`
+
+## [2026-02-06] Video Search Health Probe Tests
+**WSP Protocol**: WSP 5 (Testing Standards), WSP 34 (Test Documentation), WSP 22 (Documentation)
+
+### Summary
+- Added `test_video_search_healthcheck.py` to validate video index health probe toggles.
+- Covers disable flag, healthcheck disable path, and failure blocking.
+
+### Verification
+- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest holo_index/tests/test_video_search_healthcheck.py -q`
+
+## [2026-02-06] Video Search SQLite Metadata Index Tests
+**WSP Protocol**: WSP 5 (Testing Standards), WSP 34 (Test Documentation), WSP 22 (Documentation)
+
+### Summary
+- Added `test_video_search_metadata_db.py` to verify SQLite audit index writes.
+- Uses a manual instance (no ChromaDB init) to keep tests isolated.
+
+### Verification
+- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest holo_index/tests/test_video_search_metadata_db.py -q`
+
+## [2026-02-06] Benchmark Runner Controls
+**WSP Protocol**: WSP 5 (Testing Standards), WSP 22 (Documentation)
+
+### Summary
+- Added BENCH_* env timeouts and BENCH_MAX_QUERIES to keep benchmark runs bounded.
+- Forced UTF-8 subprocess decoding and ASCII-only report markers to avoid Windows encoding crashes.
+
+### Verification
+- `BENCH_MAX_QUERIES=4 python holo_index/tests/benchmark_holo_vs_tools.py`
+  - Bounded run executed with `BENCH_MAX_QUERIES=2` (literal queries only).
 
 
 ## Purpose (Read Before Writing Tests)
@@ -303,4 +433,3 @@
 - **Script Dependencies**: Python standard library + HoloIndex components
 - **Error Handling**: Comprehensive exception catching with diagnostic output
 - **Performance**: Optimized for fast execution in CI/CD pipelines
-

--- a/holo_index/tests/test_machine_spec_contract.py
+++ b/holo_index/tests/test_machine_spec_contract.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Contract tests for HoloIndex machine-language governance."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPEC_JSON = REPO_ROOT / "holo_index" / "docs" / "HOLO_INDEX_MACHINE_LANGUAGE_SPEC_0102.json"
+INTERFACE_MD = REPO_ROOT / "holo_index" / "INTERFACE.md"
+CLI_REFERENCE_MD = REPO_ROOT / "holo_index" / "CLI_REFERENCE.md"
+
+
+def test_machine_spec_json_is_valid_and_authoritative() -> None:
+    assert SPEC_JSON.exists(), f"missing spec file: {SPEC_JSON}"
+    payload = json.loads(SPEC_JSON.read_text(encoding="utf-8"))
+
+    assert payload.get("spec_id") == "holo_index.machine_language.v1"
+    assert payload.get("source_of_truth_policy"), "missing source_of_truth_policy section"
+
+    policy = payload["source_of_truth_policy"]
+    assert policy.get("authoritative_machine_contract") == "holo_index/docs/HOLO_INDEX_MACHINE_LANGUAGE_SPEC_0102.json"
+    assert policy.get("human_interface_contract") == "holo_index/INTERFACE.md"
+    assert policy.get("operator_menu_atlas_non_normative") == "holo_index/CLI_REFERENCE.md"
+
+
+def test_interface_declares_source_of_truth_policy() -> None:
+    assert INTERFACE_MD.exists(), f"missing interface file: {INTERFACE_MD}"
+    text = INTERFACE_MD.read_text(encoding="utf-8")
+
+    assert "Source-of-truth policy:" in text
+    assert "Authoritative machine contract" in text
+    assert "non-normative" in text
+
+
+def test_cli_reference_declares_non_normative_status() -> None:
+    assert CLI_REFERENCE_MD.exists(), f"missing cli reference: {CLI_REFERENCE_MD}"
+    text = CLI_REFERENCE_MD.read_text(encoding="utf-8")
+
+    assert "not an exhaustive CLI flag list" in text
+    assert "Canonical machine schema lives in `holo_index/docs/HOLO_INDEX_MACHINE_LANGUAGE_SPEC_0102.json`." in text
+

--- a/modules/foundups/simulator/docs/FOUNDUPS_SELF_SUSTAINING_ECON_MODEL_PAPER_OUTLINE.md
+++ b/modules/foundups/simulator/docs/FOUNDUPS_SELF_SUSTAINING_ECON_MODEL_PAPER_OUTLINE.md
@@ -1,0 +1,182 @@
+﻿# FoundUps Self-Sustaining Economic Model: Academic Paper Outline + 0102 Execution Prompts
+
+## Purpose
+Define a publication-grade paper architecture for the FoundUps economic system, with executable prompts for delegated 0102 workers and a strict CTO review loop.
+
+## Working Title
+"A Self-Sustaining Economic Model for FoundUps: Bitcoin-Reserve Anchoring, Agentic Production, and Regenerative Value Circulation"
+
+## Central Thesis
+FoundUps can sustain long-run growth without requiring perpetual external capital by coupling:
+- productive agent/user activity,
+- explicit fee/revenue flows,
+- reserve-aware treasury accounting (Bitcoin as reserve reference), and
+- bounded issuance/deflation controls,
+into a measurable closed-loop economic system.
+
+## Research Questions
+1. Under what conditions does FoundUps become cashflow-self-sustaining?
+2. Which fee/revenue channels dominate sustainability in early vs mature phases?
+3. How sensitive is sustainability to adoption velocity, churn, and market stress?
+4. How does Bitcoin-reserve anchoring change treasury resilience and unit economics?
+
+## Paper Structure
+
+### 0. Abstract + Contribution Statement
+- Goal: 200-300 word abstract with 3 concrete contributions.
+- Output required:
+  - problem statement,
+  - method summary,
+  - primary quantitative result,
+  - implication for economic system design.
+- Prompt for delegated 0102:
+  - "Write an abstract for a quantitative economics/systems paper on FoundUps. Explicitly state (a) the failure mode of legacy capital allocation this model addresses, (b) the formal mechanism used in FoundUps, (c) one measurable sustainability result from simulator outputs, and (d) one falsifiable prediction. Keep claims bounded to available model evidence."
+
+### 1. Introduction and Motivation
+- Goal: Establish why this model is needed and what makes it novel.
+- Must include:
+  - contrast with ad-funded/extractive platform economics,
+  - explicit non-utopian framing (testable model, not ideology-only claims),
+  - scope and boundaries.
+- Prompt for delegated 0102:
+  - "Draft the introduction with first-principles framing: define the resource constraints, incentive distortions in current systems, and the design requirements for a replacement model. End with an explicit bullet list of what this paper does and does not claim."
+
+### 2. Formal Economic Architecture
+- Goal: Define primitives and state variables.
+- Must include formal notation:
+  - agents, FoundUps, treasury, reserves,
+  - flows: creation fees, transaction fees, exits, compute spend, distribution,
+  - stock variables: reserve balance, treasury balance, liabilities, active supply.
+- Prompt for delegated 0102:
+  - "Produce a notation table and state-transition definitions for the FoundUps economy. Include dimensions/units for every variable, and ensure all equations are dimensionally consistent."
+
+### 3. Accounting Identities and Conservation Laws
+- Goal: Make hidden assumptions explicit via accounting identities.
+- Required equations:
+  - flow-of-funds identity per tick,
+  - treasury balance update,
+  - reserve coverage ratio,
+  - sustainability condition as inequality.
+- Prompt for delegated 0102:
+  - "Derive core accounting identities from simulator economics modules. Include a proof sketch that no value is created by notation error (double-counting, unit mismatch, or truncation artifacts)."
+
+### 4. Incentive Design and Mechanism Logic
+- Goal: Show why participants act in ways that stabilize the system.
+- Required analysis:
+  - founder incentives,
+  - user/participant incentives,
+  - platform/treasury incentives,
+  - anti-extractive constraints and failure modes.
+- Prompt for delegated 0102:
+  - "Map each participant class to utility drivers and constraints. Show where incentives align and where moral hazard can emerge. Include at least three mechanism-level safeguards and their tradeoffs."
+
+### 5. Simulator Methodology and Calibration
+- Goal: Translate architecture into reproducible simulation method.
+- Must include:
+  - scenario definitions (baseline/high adoption/stress),
+  - parameter sets and rationale,
+  - determinism and reproducibility controls,
+  - known model limitations.
+- Prompt for delegated 0102:
+  - "Write the methods section using the existing simulator scenario stack. Include exact scenario names, key parameters, random seed policy, and validation tests used to ensure deterministic output."
+
+### 6. Results: Sustainability Envelope
+- Goal: Present core results and conditions for self-sustainability.
+- Required outputs:
+  - break-even horizon estimates,
+  - sensitivity plots/tables,
+  - downside/base/upside scenario interpretation,
+  - reserve drawdown and recovery behavior.
+- Prompt for delegated 0102:
+  - "Generate a results narrative anchored in measured metrics (not aspiration language). Quantify sustainability thresholds and identify the smallest parameter shifts that move the system from sustainable to unsustainable."
+
+### 7. Stress Tests and Adversarial Conditions
+- Goal: Evaluate robustness under shocks.
+- Must include tests for:
+  - demand shock,
+  - fee compression,
+  - high churn,
+  - symbol/resource collisions,
+  - low-volume fee quantization edge cases.
+- Prompt for delegated 0102:
+  - "Write a robustness section with adversarial scenarios. For each shock, report which invariants hold, which fail, and what policy/control changes restore stability."
+
+### 8. Comparative Framing
+- Goal: Position model against incumbent systems and adjacent token systems.
+- Must include:
+  - apples-to-apples metric mapping,
+  - unit economics comparison,
+  - limits of comparability.
+- Prompt for delegated 0102:
+  - "Provide comparative analysis against at least two reference economic structures (e.g., platform ad model, transaction-fee token model). Use normalized metrics and clearly mark where assumptions differ."
+
+### 9. Governance, Policy, and Legal Boundaries
+- Goal: Separate economics from legal overreach.
+- Must include:
+  - governance control surface,
+  - what is utility vs investment-like behavior,
+  - explicit compliance caveats and non-claims.
+- Prompt for delegated 0102:
+  - "Draft governance/legal boundaries section focused on risk containment. Do not provide legal advice; instead define model boundaries, disclosure requirements, and unresolved legal questions requiring counsel."
+
+### 10. Discussion, Limitations, and Future Work
+- Goal: Credibility via explicit limits.
+- Must include:
+  - model risk inventory,
+  - unmodeled externalities,
+  - future empirical validation roadmap.
+- Prompt for delegated 0102:
+  - "Write limitations and future work as a falsifiability roadmap. List assumptions likely to break first in production and design experiments to test each assumption."
+
+### 11. Conclusion
+- Goal: Crisp statement of what is proven vs hypothesized.
+- Prompt for delegated 0102:
+  - "Write a conclusion with two parts: (A) what the current model evidence supports now, (B) what remains hypothesis pending further data."
+
+## Standard Deliverable Package per Section
+Each delegated 0102 must return:
+1. Section draft (markdown, publication style)
+2. Equation list (if section has math)
+3. Evidence table (source metric/file reference)
+4. Assumption register (explicit assumptions + risk level)
+5. Open questions for reviewer
+
+## CTO Review Protocol (for your review pass)
+Use this review rubric for every section:
+
+### Pass/Fail Gates
+1. Mathematical consistency:
+- Units and dimensions are consistent.
+- No hidden conversions or untracked truncation/rounding assumptions.
+
+2. Evidence discipline:
+- Every quantitative claim references a metric, scenario, or formula.
+- No unsupported absolute language ("always", "guaranteed", "proven") unless formally shown.
+
+3. Incentive coherence:
+- Actor incentives are explicit and non-contradictory.
+- Failure modes are acknowledged, not suppressed.
+
+4. Reproducibility:
+- Another 0102 can rerun methods from text and recover claims.
+
+5. Boundary control:
+- No policy/legal overclaims.
+- Clear distinction between model insight and normative aspiration.
+
+### Reviewer Prompt (CTO)
+Use this after each section arrives:
+- "Review this section as a hostile but fair referee. Identify: (1) any mathematical inconsistency, (2) unsupported claims, (3) missing edge-case analysis, and (4) required revisions before publication quality. Return a prioritized revision list with severity labels: Critical, Major, Minor."
+
+## Assembly Plan
+1. Draft sections in parallel by delegated 0102 workers.
+2. Run CTO rubric on each section.
+3. Merge accepted sections into full manuscript.
+4. Perform final coherence pass (notation, claims, references, tone).
+5. Produce submission-ready paper + appendix.
+
+## Immediate Next Task Queue
+1. Execute Section 2 prompt (formal architecture) first.
+2. Execute Section 3 prompt (accounting identities) second.
+3. Execute Section 5 prompt (methods/calibration) third.
+4. Do first CTO review cycle before writing comparative narrative sections.


### PR DESCRIPTION
## Summary\n- Promote the audited HoloIndex machine-contract hardening from feature branch to main\n- Add machine spec artifacts (.md + .json) and governance contract test\n- Align interface/router/classifier/composer behavior with runtime contracts\n- Add FoundUps self-sustaining economic model paper outline scaffold\n\n## Validation\n- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest holo_index/tests/test_machine_spec_contract.py holo_index/tests/test_intent_classifier.py holo_index/tests/test_output_composer.py holo_index/tests/test_memory_output_contract.py holo_index/tests/test_doc_type_filtering.py -q\n- python -m py_compile holo_index/core/holo_index.py holo_index/output_composer.py holo_index/intent_classifier.py holo_index/qwen_advisor/orchestration/services/component_router.py holo_index/tests/test_machine_spec_contract.py\n\n## Security\n- Scoped secret-pattern scan returned no hits in changed files\n- Manual risky-call scan found only existing safe uses (st.literal_eval, subprocess.run without shell=True)