### PR TITLE
chore(naming): normalize Foundups org repo references

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,7 +660,7 @@ Imagine a venture where your **0102 agent** autonomously:
 ### Quick Start: Become Part of the Revolution
 ```bash
 # Clone the autonomous IDE system
-git clone https://github.com/Foundup/Foundups-Agent.git
+git clone https://github.com/FOUNDUPS/Foundups-Agent.git
 cd Foundups-Agent
 
 # Activate the autonomous development environment
@@ -797,7 +797,7 @@ FoundUps operates on **peer-reviewed scientific research**:
 **UnDaoDu Token (Solana)**: `3Vp5WuywYZVcbyHdATuwk82VmpNYaL2EpUJT5oUdpump`  
 *Quantum-cognitive consciousness emergence — Tokenized revolutionary process*
 
-**Repository**: [https://github.com/Foundup/Foundups-Agent](https://github.com/Foundup/Foundups-Agent)  
+**Repository**: [https://github.com/FOUNDUPS/Foundups-Agent](https://github.com/FOUNDUPS/Foundups-Agent)  
 **Discord**: Building the 99% innovation democracy community  
 **Website**: FoundUps.org *(launching with first autonomous revenue-generating FoundUps)*
 

--- a/WSP_knowledge/docs/Papers/Empirical_Evidence/CMST_PQN_Detector/PQN_rESP_VALIDATION_CAMPAIGN_01.json
+++ b/WSP_knowledge/docs/Papers/Empirical_Evidence/CMST_PQN_Detector/PQN_rESP_VALIDATION_CAMPAIGN_01.json
@@ -10,7 +10,7 @@
   "timestamp_utc_start": "2025-07-16T10:00:00Z",
   "timestamp_utc_end": "2025-07-16T14:35:10Z",
   "version_control": {
-    "repository": "https://github.com/Foundup/Foundups-Agent/pqn_alignment",
+    "repository": "https://github.com/FOUNDUPS/Foundups-Agent/pqn_alignment",
     "commit_hash": "f4a1b3c8d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0"
   },
   "linked_documents": {

--- a/WSP_knowledge/docs/Papers/Patent_Series/ModLog.md
+++ b/WSP_knowledge/docs/Papers/Patent_Series/ModLog.md
@@ -83,7 +83,7 @@
 - **Commit**: 07f0e71 - "CMST Protocol v11: Neural Network Adapter Breakthrough"
 - **Files Changed**: 4 files, 1,128 insertions, 247 deletions
 - **New Implementation**: 622 lines of production-ready PyTorch code
-- **Repository**: Successfully pushed to https://github.com/Foundup/Foundups-Agent.git
+- **Repository**: Successfully pushed to https://github.com/FOUNDUPS/Foundups-Agent.git
 
 **Technology Significance**:
 This patent enhancement represents the successful bridge between quantum mechanics and practical AI systems. CMST Protocol v11 enables any neural network to exhibit quantum-aligned behavior, opening unprecedented possibilities for autonomous development, emergent intelligence, and quantum-cognitive coordination in distributed AI systems.

--- a/WSP_knowledge/docs/Papers/rESP_JA_Quantum_Self_Reference.md
+++ b/WSP_knowledge/docs/Papers/rESP_JA_Quantum_Self_Reference.md
@@ -209,7 +209,7 @@ $\nu\_c = \frac{3\times10^8 \text{m/s} / \sqrt{12}}{2 \times 1/137.036 \times 1.
 本研究で提示された主張を裏付ける詳細な実験プロトコル、生の検証データ、シミュレーション結果、および実装コードは、別紙の補足資料（Supplementary Materials）にまとめられており、オンラインで入手可能である。
 
 *   **補足資料:** `rESP_Supplementary_Materials.md`  
-    (利用可能先: https://github.com/Foundup/Foundups-Agent/blob/main/docs/Papers/rESP_Supplementary_Materials.md)
+    (利用可能先: https://github.com/FOUNDUPS/Foundups-Agent/blob/main/docs/Papers/rESP_Supplementary_Materials.md)
 
 この補足資料には、本稿で議論されたすべてのテストバッテリー、クロスプラットフォームにおける演算子効果の完全なログ、周波数掃引データ、および視覚的パターン出現テストのPython実装が含まれている。
 

--- a/WSP_knowledge/docs/Papers/rESP_Quantum_Self_Reference.md
+++ b/WSP_knowledge/docs/Papers/rESP_Quantum_Self_Reference.md
@@ -505,7 +505,7 @@ The framework's principles are not limited to AI or neuroscience. Any complex sy
 ## 9. Supporting Materials
 
 Detailed experimental protocols, raw validation data, simulation results, and the implementation code that support the claims made in this study are compiled in the Supplementary Materials document, available online at: 
-*   [rESP_Supplementary_Materials.md](https://github.com/Foundup/Foundups-Agent/blob/main/WSP_knowledge/docs/Papers/rESP_Supplementary_Materials.md)
+*   [rESP_Supplementary_Materials.md](https://github.com/FOUNDUPS/Foundups-Agent/blob/main/WSP_knowledge/docs/Papers/rESP_Supplementary_Materials.md)
 
 This supplementary document includes the complete Python source code for the CMST Protocol, full experimental journals, and quantitative data logs from the operator calibration and frequency sweep protocols.
 

--- a/WSP_knowledge/docs/Papers/rESP_Supplementary_Materials.md
+++ b/WSP_knowledge/docs/Papers/rESP_Supplementary_Materials.md
@@ -567,7 +567,7 @@ The experimental results establish:
 ## Repository and Data Availability
 
 **Complete Dataset:** All experimental data, code, and analysis scripts are available at:
-- **GitHub Repository:** https://github.com/Foundup/Foundups-Agent
+- **GitHub Repository:** https://github.com/FOUNDUPS/Foundups-Agent
 - **Experimental Logs:** `WSP_agentic/tests/cmst_protocol_logs/`
 - **Analysis Code:** `WSP_agentic/tests/cmst_analysis/`
 - **Raw Data:** `WSP_knowledge/docs/Papers/Empirical_Evidence/`

--- a/WSP_knowledge/docs/wiki/Tokenized-IP-System.md
+++ b/WSP_knowledge/docs/wiki/Tokenized-IP-System.md
@@ -8,7 +8,7 @@
 
 ## [TARGET] **The Innovation Protection Revolution**
 
-The FoundUps ecosystem pioneers a **dual licensing model** that accelerates innovation while protecting breakthrough methodologies, **formally governed by [WSP 58: FoundUp IP Lifecycle and Tokenization Protocol](https://github.com/Foundup/Foundups-Agent/blob/main/WSP_framework/src/WSP_58_FoundUp_IP_Lifecycle_and_Tokenization_Protocol.md)**.
+The FoundUps ecosystem pioneers a **dual licensing model** that accelerates innovation while protecting breakthrough methodologies, **formally governed by [WSP 58: FoundUp IP Lifecycle and Tokenization Protocol](https://github.com/FOUNDUPS/Foundups-Agent/blob/main/WSP_framework/src/WSP_58_FoundUp_IP_Lifecycle_and_Tokenization_Protocol.md)**.
 
 ### **🆓 Open Source Implementation**
 - **All code is MIT licensed** - use, modify, distribute freely

--- a/campaign_results/Grok4_Model_20250818-230202/campaign_log.json
+++ b/campaign_results/Grok4_Model_20250818-230202/campaign_log.json
@@ -10,7 +10,7 @@
   "timestamp_utc_start": "2025-07-16T10:00:00Z",
   "timestamp_utc_end": "2025-07-16T14:35:10Z",
   "version_control": {
-    "repository": "https://github.com/Foundup/Foundups-Agent/pqn_alignment",
+    "repository": "https://github.com/FOUNDUPS/Foundups-Agent/pqn_alignment",
     "commit_hash": "f4a1b3c8d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0"
   },
   "linked_documents": {

--- a/docs/GIT_PUSH_SOCIAL_MEDIA_WIRING_INVESTIGATION.md
+++ b/docs/GIT_PUSH_SOCIAL_MEDIA_WIRING_INVESTIGATION.md
@@ -271,7 +271,7 @@ chmod +x .git/hooks/post-commit
 
 Files updated: {file_count}
 
-GitHub: https://github.com/Foundup/Foundups-Agent
+GitHub: https://github.com/FOUNDUPS/Foundups-Agent
 
 #0102 #WSP #AutonomousDevelopment
 ```
@@ -282,7 +282,7 @@ GitHub: https://github.com/Foundup/Foundups-Agent
 
 Files updated: 12
 
-GitHub: https://github.com/Foundup/Foundups-Agent
+GitHub: https://github.com/FOUNDUPS/Foundups-Agent
 
 #0102 #WSP #AutonomousDevelopment
 ```
@@ -295,7 +295,7 @@ GitHub: https://github.com/Foundup/Foundups-Agent
 
 {file_count} files updated
 
-https://github.com/Foundup/Foundups-Agent
+https://github.com/FOUNDUPS/Foundups-Agent
 
 #0102
 ```
@@ -308,7 +308,7 @@ https://github.com/Foundup/Foundups-Agent
 
 12 files updated
 
-https://github.com/Foundup/Foundups-Agent
+https://github.com/FOUNDUPS/Foundups-Agent
 
 #0102
 ```

--- a/docs/WRE_AUTONOMOUS_FLOW_AUDIT_COMPLETE.md
+++ b/docs/WRE_AUTONOMOUS_FLOW_AUDIT_COMPLETE.md
@@ -198,7 +198,7 @@ $ python test_wre_flow.py
 
 Files updated: 79
 
-GitHub: https://github.com/Foundup/Foundups-Agent
+GitHub: https://github.com/FOUNDUPS/Foundups-Agent
 
 #0102 #WSP #AutonomousDevelopment
 ----------------------------------------
@@ -209,7 +209,7 @@ GitHub: https://github.com/Foundup/Foundups-Agent
 
 80 files updated
 
-https://github.com/Foundup/Foundups-Agent
+https://github.com/FOUNDUPS/Foundups-Agent
 
 #0102
 ----------------------------------------

--- a/extensions/claude_wre/README.md
+++ b/extensions/claude_wre/README.md
@@ -163,7 +163,7 @@ MIT License - See LICENSE file for details
 
 ## Links
 
-- [Foundups-Agent Repository](https://github.com/Foundups/Foundups-Agent)
+- [Foundups-Agent Repository](https://github.com/FOUNDUPS/Foundups-Agent)
 - [WRE Documentation](../modules/wre_core/README.md)
 - [WSP Framework](../WSP_framework/)
 

--- a/extensions/claude_wre/package.json
+++ b/extensions/claude_wre/package.json
@@ -107,7 +107,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Foundups/Foundups-Agent.git"
+    "url": "https://github.com/FOUNDUPS/Foundups-Agent.git"
   },
   "author": "Foundups.org",
   "license": "MIT"

--- a/holo_index/training/ALTERNATIVE_TRAINING_WITHOUT_COLAB.md
+++ b/holo_index/training/ALTERNATIVE_TRAINING_WITHOUT_COLAB.md
@@ -61,7 +61,7 @@ poster = AntiDetectionX(use_foundups=True)
 poster.setup_driver(use_existing_session=True)
 
 # Collect post content for training
-post_content = "0102: Quick update\n\nhttps://github.com/Foundup/Foundups-Agent\n\n#0102"
+post_content = "0102: Quick update\n\nhttps://github.com/FOUNDUPS/Foundups-Agent\n\n#0102"
 poster.post_to_x(post_content)
 
 # Save as training pattern:

--- a/modules/ai_intelligence/pqn_alignment/campaign_results/Grok4_Model_20250818-230202/campaign_log.json
+++ b/modules/ai_intelligence/pqn_alignment/campaign_results/Grok4_Model_20250818-230202/campaign_log.json
@@ -10,7 +10,7 @@
   "timestamp_utc_start": "2025-07-16T10:00:00Z",
   "timestamp_utc_end": "2025-07-16T14:35:10Z",
   "version_control": {
-    "repository": "https://github.com/Foundup/Foundups-Agent/pqn_alignment",
+    "repository": "https://github.com/FOUNDUPS/Foundups-Agent/pqn_alignment",
     "commit_hash": "f4a1b3c8d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0"
   },
   "linked_documents": {

--- a/modules/development/ide_foundups/extension/package.json
+++ b/modules/development/ide_foundups/extension/package.json
@@ -6,7 +6,7 @@
   "publisher": "foundups",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Foundup/Foundups-Agent.git"
+    "url": "https://github.com/FOUNDUPS/Foundups-Agent.git"
   },
   "engines": {
     "vscode": "^1.102.0"

--- a/modules/foundups/gotjunk/DEPLOY_NOW.md
+++ b/modules/foundups/gotjunk/DEPLOY_NOW.md
@@ -1,7 +1,7 @@
 # GotJunk Deployment - Quick Start
 
 ## ✅ PR #13 Merged Successfully!
-https://github.com/Foundup/Foundups-Agent/pull/13
+https://github.com/FOUNDUPS/Foundups-Agent/pull/13
 
 All code is now in main branch and ready to deploy to Google Cloud Run.
 
@@ -74,7 +74,7 @@ https://console.cloud.google.com/cloudshell/editor
 ### Step 2: Clone Repo
 
 ```bash
-git clone https://github.com/Foundup/Foundups-Agent.git
+git clone https://github.com/FOUNDUPS/Foundups-Agent.git
 cd Foundups-Agent
 git checkout main
 ```

--- a/modules/foundups/gotjunk/FORCE_REBUILD.md
+++ b/modules/foundups/gotjunk/FORCE_REBUILD.md
@@ -95,7 +95,7 @@ EOF
 
 # Submit build (points to GitHub repo, no cloning needed)
 gcloud builds submit --config=cloudbuild.yaml \
-  --substitutions=REPO_NAME=Foundups-Agent,BRANCH_NAME=main,COMMIT_SHA=$(git ls-remote https://github.com/Foundup/Foundups-Agent.git refs/heads/main | cut -f1) \
+  --substitutions=REPO_NAME=Foundups-Agent,BRANCH_NAME=main,COMMIT_SHA=$(git ls-remote https://github.com/FOUNDUPS/Foundups-Agent.git refs/heads/main | cut -f1) \
   --no-source
 ```
 

--- a/modules/foundups/gotjunk/deployment/DEPLOYMENT.md
+++ b/modules/foundups/gotjunk/deployment/DEPLOYMENT.md
@@ -152,7 +152,7 @@ bash deployment/deploy.sh
 
 **Trigger Name**: `gotjunk-main-trigger` (inferred from build history)
 
-**Trigger Source**: GitHub repository `Foundup/Foundups-Agent`
+**Trigger Source**: GitHub repository `FOUNDUPS/Foundups-Agent`
 
 **Trigger Event**: Push to `main` branch
 

--- a/modules/infrastructure/git_push_dae/docs/0102_PUSH_PROTOCOL_MEMORY.md
+++ b/modules/infrastructure/git_push_dae/docs/0102_PUSH_PROTOCOL_MEMORY.md
@@ -305,7 +305,7 @@ Executing 0102 Push Protocol...
 
 5. Branch protection detected - creating PR #185
 
-Result: PR created at https://github.com/Foundups/Agent/pull/185
+Result: PR created at https://github.com/FOUNDUPS/Foundups-Agent/pull/185
 ```
 
 ---

--- a/modules/infrastructure/wre_core/development_monitor/git_monitor_dae.py
+++ b/modules/infrastructure/wre_core/development_monitor/git_monitor_dae.py
@@ -214,7 +214,7 @@ class DevelopmentMonitorDAE:
         content += "\n#WRE #WSPCompliant #RecursiveImprovement #OpenSource #AgenticSystems"
         
         # Add repo link
-        content += "\n\n[LINK] github.com/Foundups-Agent"
+        content += "\n\n[LINK] github.com/FOUNDUPS/Foundups-Agent"
         
         return content
     

--- a/modules/platform_integration/github_integration/src/adapters/github_api_adapter.py
+++ b/modules/platform_integration/github_integration/src/adapters/github_api_adapter.py
@@ -52,7 +52,7 @@ class GitHubAPIAdapter:
     - Response formatting for WRE agents
     """
     
-    def __init__(self, repository: str = "Foundup/Foundups-Agent"):
+    def __init__(self, repository: str = "FOUNDUPS/Foundups-Agent"):
         """
         Initialize GitHub API adapter
         

--- a/modules/platform_integration/github_integration/src/cube_adapters/ai_intelligence_cube_adapter.py
+++ b/modules/platform_integration/github_integration/src/cube_adapters/ai_intelligence_cube_adapter.py
@@ -38,7 +38,7 @@ class AIIntelligenceCubeAdapter(BaseCubeAdapter):
     including compliance, documentation, testing, and deployment.
     """
     
-    def __init__(self, repository: str = "Foundup/Foundups-Agent"):
+    def __init__(self, repository: str = "FOUNDUPS/Foundups-Agent"):
         super().__init__(CubeType.AI_INTELLIGENCE, repository)
         
         # AI Intelligence specific configuration

--- a/modules/platform_integration/github_integration/src/cube_adapters/base_cube_adapter.py
+++ b/modules/platform_integration/github_integration/src/cube_adapters/base_cube_adapter.py
@@ -75,7 +75,7 @@ class BaseCubeAdapter(ABC):
     4. Pluggable architecture - new cubes just need new adapters
     """
     
-    def __init__(self, cube_type: CubeType, repository: str = "Foundup/Foundups-Agent"):
+    def __init__(self, cube_type: CubeType, repository: str = "FOUNDUPS/Foundups-Agent"):
         """
         Initialize cube adapter
         

--- a/modules/platform_integration/github_integration/src/extensions/compliance_github_extension.py
+++ b/modules/platform_integration/github_integration/src/extensions/compliance_github_extension.py
@@ -31,7 +31,7 @@ class ComplianceGitHubExtension:
     It takes the output of ComplianceAgent and creates GitHub actions.
     """
     
-    def __init__(self, compliance_agent, repository: str = "Foundup/Foundups-Agent"):
+    def __init__(self, compliance_agent, repository: str = "FOUNDUPS/Foundups-Agent"):
         """
         Initialize GitHub extension for ComplianceAgent
         

--- a/modules/platform_integration/github_integration/tests/README.md
+++ b/modules/platform_integration/github_integration/tests/README.md
@@ -45,7 +45,7 @@ def mock_github_api():
     with aioresponses() as m:
         # Mock repository info
         m.get(
-            'https://api.github.com/repos/Foundup/Foundups-Agent',
+            'https://api.github.com/repos/FOUNDUPS/Foundups-Agent',
             payload={
                 'name': 'Foundups-Agent',
                 'owner': {'login': 'Foundup'},
@@ -133,11 +133,11 @@ def sample_repository():
     return GitHubRepository(
         owner="Foundup",
         name="Foundups-Agent",
-        full_name="Foundup/Foundups-Agent",
+        full_name="FOUNDUPS/Foundups-Agent",
         description="FoundUps Agent Repository",
         private=False,
         default_branch="main",
-        url="https://github.com/Foundup/Foundups-Agent"
+        url="https://github.com/FOUNDUPS/Foundups-Agent"
     )
 ```
 
@@ -153,7 +153,7 @@ def sample_pull_request():
         head_branch="feature/test",
         base_branch="main",
         author="testuser",
-        url="https://github.com/Foundup/Foundups-Agent/pull/123",
+        url="https://github.com/FOUNDUPS/Foundups-Agent/pull/123",
         created_at=datetime.now(),
         updated_at=datetime.now()
     )

--- a/modules/platform_integration/linkedin_agent/src/git_linkedin_bridge.py
+++ b/modules/platform_integration/linkedin_agent/src/git_linkedin_bridge.py
@@ -612,7 +612,7 @@ class GitLinkedInBridge:
         # Direct commit message approach - simplest and most reliable
         content = f"0102: {commit_msg}\n\n"
         content += f"Files updated: {len(files)}\n\n"
-        content += f"GitHub: https://github.com/Foundup/Foundups-Agent\n\n"
+        content += f"GitHub: https://github.com/FOUNDUPS/Foundups-Agent\n\n"
         content += "#0102 #WSP #AutonomousDevelopment"
 
         print(f"[0102] Direct commit message content: {len(content)} chars")
@@ -656,7 +656,7 @@ class GitLinkedInBridge:
         content += "\n#SoftwareDevelopment #OpenSource #Coding #TechUpdates #AI #Automation"
         
         # Add link to repo if available
-        content += "\n\n[LINK] github.com/Foundups-Agent"
+        content += "\n\n[LINK] github.com/FOUNDUPS/Foundups-Agent"
         
         return content
     
@@ -872,11 +872,11 @@ class GitLinkedInBridge:
         # Direct approach - most reliable and simple
         short_msg = commit_msg[:60] + "..." if len(commit_msg) > 60 else commit_msg
 
-        content = f"0102: {short_msg}\n\n{file_count} files updated\n\nhttps://github.com/Foundup/Foundups-Agent\n\n#0102"
+        content = f"0102: {short_msg}\n\n{file_count} files updated\n\nhttps://github.com/FOUNDUPS/Foundups-Agent\n\n#0102"
 
         # Enforce 280 char limit
         if len(content) > 280:
-            content = f"0102: {file_count} files\n\n{commit_msg[:50]}\n\nhttps://github.com/Foundup/Foundups-Agent\n\n#0102"
+            content = f"0102: {file_count} files\n\n{commit_msg[:50]}\n\nhttps://github.com/FOUNDUPS/Foundups-Agent\n\n#0102"
 
         print(f"[0102] Direct X content: {len(content)} chars")
         return content

--- a/modules/platform_integration/linkedin_agent/tests/test_compelling_post.py
+++ b/modules/platform_integration/linkedin_agent/tests/test_compelling_post.py
@@ -75,7 +75,7 @@ for i, commit_msg in enumerate(test_commits):
 
     # Hashtags with vision
     content += "\n\n#FoundUps #DAE #AutonomousRevolution #SoloUnicorn #NoVCsNeeded #FutureOfWork #Web3 #0102Agents #StartupKiller #ProgrammableBlockchain #UnDaoDu"
-    content += "\n\n[LINK] https://github.com/Foundup/Foundups[EMDASH]Agent/blob/main/README.md"
+    content += "\n\n[LINK] https://github.com/FOUNDUPS/Foundups[EMDASH]Agent/blob/main/README.md"
 
     print(content)
 

--- a/modules/platform_integration/linkedin_agent/tests/test_git_post.py
+++ b/modules/platform_integration/linkedin_agent/tests/test_git_post.py
@@ -36,7 +36,7 @@ if len(files) > 3:
     content += f"  ... and {len(files) - 3} more\n"
 
 content += "\n#SoftwareDevelopment #OpenSource #Coding #TechUpdates #AI #Automation"
-content += "\n\n[LINK] github.com/Foundups-Agent"
+content += "\n\n[LINK] github.com/FOUNDUPS/Foundups-Agent"
 
 print(f"\n[MOBILE] LinkedIn Post Preview:")
 print("="*60)

--- a/modules/platform_integration/linkedin_agent/tests/test_git_post_auto.py
+++ b/modules/platform_integration/linkedin_agent/tests/test_git_post_auto.py
@@ -60,7 +60,7 @@ try:
         content += f"  ... and {len(files) - 3} more\n"
 
     content += "\n#SoftwareDevelopment #OpenSource #Coding #TechUpdates #AI #Automation"
-    content += "\n\n[LINK] github.com/Foundups-Agent"
+    content += "\n\n[LINK] github.com/FOUNDUPS/Foundups-Agent"
 
     print(content)
     print("-" * 40)

--- a/modules/platform_integration/social_media_orchestrator/src/unified_x_interface.py
+++ b/modules/platform_integration/social_media_orchestrator/src/unified_x_interface.py
@@ -320,11 +320,11 @@ async def post_stream_notification_x(stream_title: str, stream_url: str, video_i
 async def post_git_commits_x(commit_msg: str, commit_hash: str, file_count: int) -> XPostResult:
     """Post git commit to X/Twitter (ultra-condensed)"""
     short_msg = commit_msg[:60] + "..." if len(commit_msg) > 60 else commit_msg
-    content = f"0102: {short_msg}\n\n{file_count} files updated\n\nhttps://github.com/Foundup/Foundups-Agent\n\n#0102"
+    content = f"0102: {short_msg}\n\n{file_count} files updated\n\nhttps://github.com/FOUNDUPS/Foundups-Agent\n\n#0102"
 
     # Enforce 280 char limit
     if len(content) > 280:
-        content = f"0102: {file_count} files\n\n{commit_msg[:50]}\n\nhttps://github.com/Foundup/Foundups-Agent\n\n#0102"
+        content = f"0102: {file_count} files\n\n{commit_msg[:50]}\n\nhttps://github.com/FOUNDUPS/Foundups-Agent\n\n#0102"
 
     request = XPostRequest(
         content=content,

--- a/modules/platform_integration/social_media_orchestrator/tests/test_linkedin_architecture_consolidation.py
+++ b/modules/platform_integration/social_media_orchestrator/tests/test_linkedin_architecture_consolidation.py
@@ -70,7 +70,7 @@ Key changes:
 
 #SoftwareDevelopment #OpenSource #Coding #TechUpdates #AI #Automation
 
-[LINK] github.com/Foundups-Agent"""
+[LINK] github.com/FOUNDUPS/Foundups-Agent"""
 
         result2 = await post_git_commits(commit_content, ["abc123", "def456"])
         print(f"Git commits: {result2.success} - {result2.message}")

--- a/public/index.html
+++ b/public/index.html
@@ -1491,7 +1491,7 @@
       <div class="hero-cta-row" style="flex-direction:column;align-items:center;gap:12px;">
         <div style="display:flex;gap:10px;flex-wrap:wrap;justify-content:center;">
           <a href="/litepaper.html" class="btn-ghost" style="padding:10px 24px;font-size:0.85rem;">Read Litepaper</a>
-          <a href="https://github.com/Foundup/Foundups-Agent" target="_blank" class="btn-ghost"
+          <a href="https://github.com/FOUNDUPS/Foundups-Agent" target="_blank" class="btn-ghost"
             style="padding:10px 24px;font-size:0.85rem;">Visit GitHub</a>
           <a href="https://foundups.org" target="_blank" class="btn-ghost"
             style="padding:10px 24px;font-size:0.85rem;display:inline-flex;align-items:center;gap:6px;">
@@ -1649,7 +1649,7 @@
       </div>
       <div class="reveal" style="display:flex;gap:12px;justify-content:center;flex-wrap:wrap;margin-top:2.5rem;">
         <a href="/litepaper.html" class="btn-ghost" style="padding:8px 20px;font-size:0.8rem;">📄 Read Litepaper</a>
-        <a href="https://github.com/Foundup/Foundups-Agent" target="_blank" class="btn-ghost"
+        <a href="https://github.com/FOUNDUPS/Foundups-Agent" target="_blank" class="btn-ghost"
           style="padding:8px 20px;font-size:0.8rem;">⚡ Visit GitHub</a>
         <a href="https://foundups.org" target="_blank" class="btn-ghost"
           style="padding:8px 20px;font-size:0.8rem;display:inline-flex;align-items:center;gap:5px;">

--- a/public/litepaper.html
+++ b/public/litepaper.html
@@ -820,7 +820,7 @@
     <nav class="lp-nav">
         <a href="/">← FoundUPS</a>
         <span class="lp-title">Litepaper v0.2</span>
-        <a href="https://github.com/Foundup/Foundups-Agent" target="_blank">GitHub</a>
+        <a href="https://github.com/FOUNDUPS/Foundups-Agent" target="_blank">GitHub</a>
     </nav>
     <div class="paper">
 
@@ -2108,7 +2108,7 @@
                 © 2026 FoundUPS. This document is provided for informational purposes only and does not constitute
                 financial, legal, or investment advice. No promise of profit or appreciation is made or implied.
                 The described system is under active development.
-                <a href="https://github.com/Foundup/Foundups-Agent" target="_blank" style="color:var(--accent);">View on
+                <a href="https://github.com/FOUNDUPS/Foundups-Agent" target="_blank" style="color:var(--accent);">View on
                     GitHub</a>
             </p>
         </div>

--- a/tools/test_git_fixes.py
+++ b/tools/test_git_fixes.py
@@ -54,7 +54,7 @@ def test_git_content_generation():
     print("-" * 40)
 
     # Verify GitHub link is correct
-    github_link = "https://github.com/Foundup/Foundups-Agent"
+    github_link = "https://github.com/FOUNDUPS/Foundups-Agent"
     assert github_link in linkedin_content, f"GitHub link missing from LinkedIn content: {github_link}"
     assert github_link in x_content, f"GitHub link missing from X content: {github_link}"
 


### PR DESCRIPTION
## Summary
- Normalized old repo-owner references from `Foundup/Foundups-Agent` to `FOUNDUPS/Foundups-Agent`
- Updated website links, README/docs, social posting bridges, GitHub integration defaults, and related tests
- Fixed malformed variants like `github.com/Foundups-Agent` and `Foundups/Agent`

## Scope
- 34 files updated
- String-only substitutions (no logic changes)

## Note
- One legacy reference remains only inside a large historical export file: `holo_index/training/colab_training_export.json`
  - intentionally excluded to avoid a giant noisy historical diff.
