### PR TITLE
feat(sim): adoption-tied entry guards for F_i orderbook

### DIFF
--- a/modules/foundups/simulator/economics/__init__.py
+++ b/modules/foundups/simulator/economics/__init__.py
@@ -120,6 +120,7 @@ from .btc_reserve import (
 from .fi_orderbook import (
     OrderSide,
     OrderStatus,
+    EntryProtectionConfig,
     Order,
     Trade,
     FiOrderBook,
@@ -415,6 +416,7 @@ __all__ = [
     # F_i Order Book (buy/sell FoundUp tokens)
     "OrderSide",
     "OrderStatus",
+    "EntryProtectionConfig",
     "Order",
     "Trade",
     "FiOrderBook",

--- a/modules/foundups/simulator/mesa_model.py
+++ b/modules/foundups/simulator/mesa_model.py
@@ -792,6 +792,11 @@ class FoundUpsModel:
         sell_price = max(0.01, base_price - spread * random.uniform(0.2, 1.0))
         buy_price = base_price + spread * random.uniform(0.2, 1.2)
         quantity = round(random.uniform(3.0, 20.0), 2)
+        adoption_rate = min(
+            1.0,
+            float(tile.customer_count) / float(max(1, self._config.num_user_agents)),
+        )
+        liquidity_hint_ups = float(max(0, tile.total_staked))
 
         seller_id = random.choice(user_ids)
         buyer_pool = [uid for uid in user_ids if uid != seller_id]
@@ -804,12 +809,16 @@ class FoundUpsModel:
             human_id=seller_id,
             price=round(sell_price, 4),
             quantity=quantity,
+            adoption_rate=adoption_rate,
+            liquidity_hint_ups=liquidity_hint_ups,
         )
         buy_order, trades = self._orderbook.place_buy(
             foundup_id=foundup_id,
             human_id=buyer_id,
             price=round(buy_price, 4),
             quantity=quantity,
+            adoption_rate=adoption_rate,
+            liquidity_hint_ups=liquidity_hint_ups,
         )
         daemon = self._fam_bridge.get_daemon()
         book = self._orderbook.get_or_create_book(foundup_id)

--- a/modules/foundups/simulator/tests/test_fi_orderbook_entry_guards.py
+++ b/modules/foundups/simulator/tests/test_fi_orderbook_entry_guards.py
@@ -1,0 +1,85 @@
+"""Entry-side anti-manipulation tests for F_i order books."""
+
+from __future__ import annotations
+
+from modules.foundups.simulator.economics.fi_orderbook import (
+    EntryProtectionConfig,
+    FiOrderBook,
+    OrderStatus,
+)
+
+
+def test_buy_rejected_when_notional_exceeds_low_adoption_cap() -> None:
+    config = EntryProtectionConfig(
+        base_max_order_btc=0.001,  # 100k sats baseline
+        max_liquidity_boost=0.0,  # keep cap deterministic for test
+    )
+    book = FiOrderBook(foundup_id="f_low_adoption", entry_protection_config=config)
+    book.update_market_context(adoption_rate=0.05, liquidity_hint_ups=0.0)
+
+    # 100k UPS order notional vs 50k UPS cap at 5% adoption (0.5x scale).
+    order, trades = book.place_buy_order(
+        human_id="buyer_1",
+        price=1000.0,
+        quantity=100.0,
+    )
+
+    assert order.status == OrderStatus.CANCELLED
+    assert order.rejection_reason is not None
+    assert order.rejection_reason.startswith("entry_notional_limit_exceeded")
+    assert trades == []
+    assert book.rejected_buy_orders == 1
+    assert len(book.buy_orders) == 0
+
+
+def test_buy_allowed_when_adoption_matures() -> None:
+    config = EntryProtectionConfig(
+        base_max_order_btc=0.001,  # 100k sats baseline
+        max_liquidity_boost=0.0,
+    )
+    book = FiOrderBook(foundup_id="f_mature", entry_protection_config=config)
+    book.update_market_context(adoption_rate=0.95, liquidity_hint_ups=0.0)
+
+    # Same 100k UPS notional should pass at high adoption (9.5x scale).
+    order, trades = book.place_buy_order(
+        human_id="buyer_1",
+        price=1000.0,
+        quantity=100.0,
+    )
+
+    assert order.status == OrderStatus.OPEN
+    assert order.rejection_reason is None
+    assert trades == []
+    assert book.rejected_buy_orders == 0
+    assert len(book.buy_orders) == 1
+
+
+def test_depth_impact_guard_blocks_single_order_whale_sweep() -> None:
+    config = EntryProtectionConfig(
+        base_max_order_btc=10.0,  # disable notional cap as limiting factor
+        min_depth_for_impact_guard_ups=100.0,
+        max_single_order_share_of_opposing_depth=0.25,
+    )
+    book = FiOrderBook(foundup_id="f_depth_guard", entry_protection_config=config)
+    book.update_market_context(adoption_rate=1.0, liquidity_hint_ups=0.0)
+
+    # Seed opposing depth: 1000 UPS total ask side.
+    sell_order, _ = book.place_sell_order(
+        human_id="seller_1",
+        price=10.0,
+        quantity=100.0,
+    )
+    assert sell_order.status == OrderStatus.OPEN
+
+    # 400 UPS buy order exceeds 25% of opposing depth (cap = 250 UPS).
+    whale_buy, trades = book.place_buy_order(
+        human_id="buyer_whale",
+        price=10.0,
+        quantity=40.0,
+    )
+
+    assert whale_buy.status == OrderStatus.CANCELLED
+    assert whale_buy.rejection_reason is not None
+    assert whale_buy.rejection_reason.startswith("depth_impact_limit_exceeded")
+    assert trades == []
+    assert book.rejected_buy_orders == 1


### PR DESCRIPTION
## Why\nCurrent protections focus on EXIT stress (death-spiral control), but ENTRY-side manipulation remained under-constrained in thin early books.\n\n## What changed\n- add EntryProtectionConfig to i_orderbook.py\n- enforce BUY notional cap scaled by adoption + observed liquidity\n- enforce depth-impact whale guard (both sides) when opposing depth is meaningful\n- reject violating orders as CANCELLED with explicit ejection_reason\n- wire market context from mesa_model.py (doption_rate, liquidity_hint_ups)\n- add tests: 	est_fi_orderbook_entry_guards.py\n\n## Validation\n- python -m pytest modules/foundups/simulator/tests/test_fi_orderbook_entry_guards.py -q\n- python -m pytest modules/foundups/simulator/tests/test_scenario_runner_determinism.py -q\n\nBoth pass in this environment (with existing non-blocking pytest config warnings).\n