### PR TITLE
refactor: split OpenClaw DAE into WSP 97 control-plane modules

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -55741,4 +55741,28 @@ if cooldown_sets:
 ### Cleanup Recommendations
 - Consider migrating posted_streams.json from array to dict format with timestamps
 
+## 2026-03-11: OpenClaw WSP 97 facade refactor - planner, result memory, permission policy
+- Extracted three new control-plane modules under `modules/communication/moltbot_bridge/src/`:
+  - `openclaw_intent_planner.py`
+  - `openclaw_result_memory.py`
+  - `openclaw_permission_policy.py`
+- Reduced `openclaw_dae.py` from `2638` lines to `2086` lines while preserving behavior through targeted regression coverage.
+- Kept `OpenClawDAE` as the facade and moved policy/validation logic into auditable modules aligned to WSP 97 execution-plane separation.
 
+## 2026-03-11: OpenClaw WSP 97 facade refactor - execution routes
+- Added `modules/communication/moltbot_bridge/src/openclaw_execution_routes.py` and moved the post-plan route layer out of `openclaw_dae.py`.
+- `openclaw_dae.py` is now `1678` lines, down from `2638` before the current WSP 97 extraction series.
+- Route execution is now separated from intent planning, permission policy, conversation, runtime probing, and identity/context assembly.
+
+## 2026-03-11: OpenClaw WSP 97 facade refactor - turn state
+- Added `modules/communication/moltbot_bridge/src/openclaw_turn_state.py` and moved token telemetry + turn cancellation state out of `openclaw_dae.py`.
+- `openclaw_dae.py` is now `1603` lines, down from `2638` before the current WSP 97 extraction series.
+
+## 2026-03-11: OpenClaw WSP 97 facade refactor - status + process loop
+- Added `modules/communication/moltbot_bridge/src/openclaw_status_surface.py` and `openclaw_process_loop.py`.
+- `openclaw_dae.py` is now `1342` lines, down from `2638` before the current WSP 97 extraction series.
+- The remaining file content is predominantly facade wrappers, dataclasses, and the top-level honeypot control surface.
+
+## 2026-03-15: OpenClaw docs aligned to WSP 97 module map
+- Appended WSP 97 control-plane module map to `modules/communication/moltbot_bridge/README.md`.
+- Appended canonical internal boundary map to `modules/communication/moltbot_bridge/INTERFACE.md`.

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -294,3 +294,29 @@ When WRE is unavailable, COMMAND intents return deterministic advisory fallback:
 - **WSP 77**: Agent coordination (4-phase execution)
 - **WSP 91**: Observability (structured logging)
 - **WSP 96**: Skill execution (micro chain-of-thought)
+
+## WSP 97 Internal Module Boundaries
+
+OpenClaw runtime responsibilities are now split into dedicated modules under `src/`.
+This is the canonical internal layout for future work:
+
+- `openclaw_dae.py`: facade only
+- `openclaw_intent_planner.py`: classify -> preflight -> plan
+- `openclaw_permission_policy.py`: autonomy tier + containment + skill safety
+- `openclaw_execution_routes.py`: non-social route execution
+- `openclaw_social_controller.py`: social-routing bridge
+- `openclaw_conversation_engine.py`: dialogue execution
+- `openclaw_model_policy.py`: model selection and switching
+- `openclaw_identity_context.py`: identity + context-pack builders
+- `openclaw_runtime_support.py`: runtime/model probes and autostart
+- `openclaw_status_surface.py`: operator-facing status helpers
+- `openclaw_process_loop.py`: full autonomy loop orchestration
+- `openclaw_result_memory.py`: validate + remember
+- `openclaw_turn_state.py`: token telemetry and turn cancellation
+- `openclaw_action_ledger.py`: DAEmon action reporting
+- `openclaw_provider_chain.py`: external/IronClaw provider chain
+- `openclaw_bootstrap_config.py`: constructor-time control-plane state
+
+Refactor status:
+- `openclaw_dae.py` now stays below the large-file threshold at `1342` lines
+- execution-plane resolution now matches `WSP_97`: resolve intent -> gate -> plan -> route -> validate -> remember

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -25,6 +25,207 @@
 
 # ModLog - moltbot_bridge
 
+## 2026-03-11: OpenClaw bootstrap constructor extraction
+
+**Author**: 0102  
+**WSP**: 22, 62, 73, 97
+
+### Changes
+- Added `src/openclaw_bootstrap_config.py`
+  - centralized identity/runtime/model/context bootstrap state
+  - initializes telemetry baselines and turn-cancel state
+- Updated `src/openclaw_dae.py`
+  - constructor now delegates control-plane bootstrap to the helper
+  - removed large inline bootstrap block from `__init__`
+
+### Why
+- The facade constructor still contained a large control-plane setup block that did not belong inline.
+- WSP 97 requires clear separation between control-plane setup and execution behavior.
+- WSP 62 requires continued large-file reduction in stable seams.
+
+### Result
+- `openclaw_dae.py` reduced further to `2638` lines.
+- Bootstrap state is now centralized and reusable for future supervisor/runtime boot work.
+
+---
+
+## 2026-03-11: OpenClaw provider/runtime chain extraction
+
+**Author**: 0102  
+**WSP**: 22, 62, 73, 97
+
+### Changes
+- Added `src/openclaw_provider_chain.py`
+  - IronClaw conversation provider call
+  - preferred external provider conversation call
+- Extended `src/openclaw_runtime_support.py`
+  - moved IronClaw autostart/recovery logic out of the facade
+- Updated `src/openclaw_dae.py`
+  - provider/runtime methods now delegate to extracted helpers
+  - removed dead subprocess/shlex/shutil imports
+
+### Why
+- Provider/runtime mechanics are a separate control-plane seam from intent routing and identity handling.
+- WSP 97 requires explicit execution-plane boundaries.
+- WSP 62 requires continued large-file reduction by stable seam extraction.
+
+### Result
+- `openclaw_dae.py` reduced further to `2814` lines.
+- Conversation provider chain is now isolated from the main facade.
+- IronClaw autostart/recovery logic is centralized in runtime support.
+
+---
+
+## 2026-03-11: OpenClaw identity/context and model-policy extraction
+
+**Author**: 0102  
+**WSP**: 22, 62, 73, 97
+
+### Changes
+- Added `src/openclaw_identity_context.py`
+  - identity query detection
+  - identity card/compact builders
+  - WSP_00 boot prompt loading
+  - platform context-pack resolution/loading
+  - conversation system prompt assembly
+- Added `src/openclaw_model_policy.py`
+  - model-switch parsing/gating
+  - local/external target resolution
+  - provider-key checks
+  - agentic local model-role selection
+  - local runtime target application
+- Updated `src/openclaw_dae.py`
+  - reduced to facade wrappers for identity/context/model-policy concerns
+  - preserved existing public methods for tests/callers
+  - dropped file size below 3000 lines
+
+### Why
+- `openclaw_dae.py` was still carrying control-plane seams that belong in focused modules.
+- WSP 62 requires incremental large-file reduction, not a single rewrite.
+- WSP 97 requires explicit execution-plane boundaries: identity/context and model policy are OpenClaw-local control-plane concerns.
+
+### Result
+- `openclaw_dae.py` reduced to `2988` lines.
+- Identity/context and model-routing logic now live in dedicated modules.
+- Existing OpenClaw behavior is preserved through thin facade wrappers.
+
+---
+
+## 2026-03-11: WSP 97 CoT/CoR gates wired into OpenClaw execution pipeline
+
+**Author**: 0102
+**WSP**: 22, 50, 97
+
+### Changes
+- Added `src/cot_cor_integration.py`
+  - `apply_cot_gate()`: Pre-fetches HoloIndex context for internal LLMs
+  - `apply_cor_gate()`: Verifies actions against WSP compliance + alternatives
+  - `should_block_action()`, `format_cor_warning()`: Helper utilities
+- Updated `src/openclaw_dae.py`
+  - Imported CoT/CoR integration module
+  - `_wsp_preflight()`: Added CoT gate for QUERY/RESEARCH intents (line ~1256)
+  - `_plan_execution()`: Added CoR gate for mutating intents (line ~1615)
+  - CoR BLOCK → downgrades to advisory conversation
+  - CoR RECONSIDER → attaches warning to metadata
+
+### Why
+- WSP 97 v1.1 specifies CoT/CoR verification gates
+- Internal LLMs (Qwen 2K, Gemma 512) cannot self-retrieve
+- OpenClaw actions spend user UPs → need pre-execution verification
+- Prevents confabulation (CoT) and vibecoding (CoR)
+
+### Result
+- CoT gate fires on QUERY/RESEARCH → prefetches context via HoloIndex.search()
+- CoR gate fires on COMMAND/SYSTEM/SOCIAL/AUTOMATION → checks WSP compliance
+- Actions blocked by CoR gate return advisory with explanation
+- Context stored in `intent.metadata["cot_context"]` for downstream use
+
+### Related Skills
+- `holo_index/skills/cot_prefetch/` (CoT gate skill)
+- `holo_index/skills/cor_verify/` (CoR gate skill)
+
+---
+
+## 2026-03-11: OpenClaw social/conversation seams kept in control plane
+
+**Author**: 0102  
+**WSP**: 22, 62, 73, 97
+
+### Changes
+- Added `src/openclaw_social_controller.py`
+  - Extracted:
+    - `SOCIAL` route adapter sequencing
+    - natural-language conversation-to-social control bridge
+- Added `src/openclaw_conversation_engine.py`
+  - Extracted the primary conversation execution chain:
+    - deterministic identity/model/token controls
+    - IronClaw/local/external fallback ordering
+    - token telemetry + cancellation handling
+- Updated `src/openclaw_dae.py`
+  - Converted `_execute_social()`, `_try_conversation_social_control()`, and `_execute_conversation()` into facade delegates.
+
+### Why
+- WSP 73/97 boundary check showed these seams belong to OpenClaw's frontal-lobe control plane, not `social_media_dae`.
+- Social Media DAE remains a child execution/consciousness domain.
+- WRE remains selectively wired at execution-plane resolution time instead of owning direct conversational control.
+
+### Result
+- OpenClaw keeps mission control, dialogue, and execution-plane routing in `moltbot_bridge`.
+- `openclaw_dae.py` is smaller and the next extraction seam is clearer.
+
+---
+
+## 2026-03-10: OpenClaw runtime/ledger helpers extracted from oversized DAE
+
+**Author**: 0102  
+**WSP**: 22, 62, 73, 84
+
+### Changes
+- Added `src/openclaw_action_ledger.py`
+  - Extracted social response capture and DAEmon action emission helpers.
+- Added `src/openclaw_runtime_support.py`
+  - Extracted:
+    - local model snapshot resolution
+    - IronClaw runtime probing
+    - provider endpoint probing
+    - model availability snapshot
+    - identity snapshot composition
+- Updated `src/openclaw_dae.py`
+  - Converted the extracted sections into thin facade wrappers.
+
+### Why
+- `openclaw_dae.py` had grown to 4493 lines and was carrying too many responsibilities.
+- This extraction reduces control-plane coupling while preserving the current public `OpenClawDAE` interface.
+
+### Result
+- `openclaw_dae.py` reduced to 4194 lines after the first extraction pass.
+- Runtime/identity behavior remains covered by existing tests.
+
+---
+
+## 2026-03-10: OpenClaw action ledger wired to central DAEmon
+
+**Author**: 0102  
+**WSP**: 22, 73, 91
+
+### Changes
+- Updated `src/openclaw_dae.py`
+  - Added structured DAEmon `ACTION_PERFORMED` emission for the core autonomy loop:
+    - `intent_classified`
+    - `skill_safety_gate`
+    - `wsp_preflight`
+    - `permission_gate`
+    - `plan_built`
+    - `plan_executed`
+    - `result_validated`
+  - Preserved existing `message_in` / `message_out` reporting.
+
+### Why
+- OpenClaw previously emitted only ingress/egress heartbeats to DAEmon.
+- The central bus now captures the control-plane actions needed for real-time 012/0102 observability.
+
+---
+
 ## 2026-03-07: CTO WRE prompt added to OpenClaw default context pack
 
 **Author**: 0102  
@@ -1000,3 +1201,119 @@ openclaw onboard
 ### Outcome
 - 012 can ask 0102 to launch PQN research inside an already running system.
 - OpenClaw stays the conversational/control-plane front door while DAEmon remains the lifecycle ledger.
+## 2026-03-10: LinkedIn mission-control routing + WSP 97 context pack
+
+**Author**: 0102  
+**WSP**: 15, 50, 77, 84, 97
+
+### Changes
+- Added `src/linkedin_loop_adapter.py` as a conversational control surface for the durable LinkedIn orchestration loop.
+- Updated `src/openclaw_dae.py` to:
+  - route mission phrases such as `let's work on LN` through the loop adapter before low-level LinkedIn actions
+  - load `WSP_97_System_Execution_Prompting_Protocol.md` into the default OpenClaw platform context pack
+  - prioritize code-change language over health vocabulary during agentic model selection so edit work routes to the coder model
+
+### Outcome
+- OpenClaw can now steer LinkedIn loop phases conversationally while preserving deterministic action commands.
+- WSP 97 is part of default OpenClaw context, so `follow wsp` resolves through the execution-prompting protocol by default.
+- Mixed prompts like `fix the failing test in main.py` now route to `local/qwen-coder-7b` instead of `local/gemma-270m`.
+
+## 2026-03-10: Deterministic "follow wsp" command route
+
+**Author**: 0102  
+**WSP**: 50, 77, 84, 97
+
+### Changes
+- Added explicit `follow wsp` interception in `src/openclaw_dae.py` command routing.
+- The canonical WSP 97 operator now routes through `modules/infrastructure/wsp_orchestrator/src/wsp_orchestrator.py` instead of falling through generic WRE command handling.
+
+### Outcome
+- `follow wsp ...` now has a real execution plane in OpenClaw:
+  - detect operator
+  - call WSP orchestrator
+  - return deterministic execution summary
+
+## 2026-03-11: OpenClaw control-plane refactor - intent planner + result memory
+
+**Author**: 0102  
+**WSP**: 22, 50, 73, 84, 97
+
+### Changes
+- Added `src/openclaw_intent_planner.py` for intent classification, WSP preflight, and execution-plan construction.
+- Added `src/openclaw_result_memory.py` for output validation and WRE pattern-memory storage.
+- Reduced `src/openclaw_dae.py` by replacing inline classify/preflight/plan/finalize blocks with facade wrappers.
+
+### Outcome
+- OpenClaw intent resolution and result finalization are now isolated control-plane seams instead of monolith internals.
+- `openclaw_dae.py` dropped from `2638` lines to `2262` lines in this slice.
+
+## 2026-03-11: OpenClaw control-plane refactor - permission and safety policy
+
+**Author**: 0102  
+**WSP**: 22, 50, 71, 73, 84, 95, 97
+
+### Changes
+- Added `src/openclaw_permission_policy.py` for autonomy-tier resolution, source-write gating, AI Overseer emission, containment checks, and cached skill-safety scanning.
+- Replaced the inline permission/security block in `src/openclaw_dae.py` with facade wrappers.
+
+### Outcome
+- Permission, containment, and skill-safety policy are now centralized and auditable as one control-plane module.
+- `openclaw_dae.py` dropped from `2262` lines to `2086` lines in this slice.
+
+## 2026-03-11: OpenClaw control-plane refactor - execution routes
+
+**Author**: 0102  
+**WSP**: 22, 50, 73, 84, 97
+
+### Changes
+- Added `src/openclaw_execution_routes.py` for post-plan route execution:
+  - query
+  - command + follow-wsp
+  - monitor
+  - schedule
+  - system
+  - automation
+  - foundup
+  - research
+- Replaced the inline route layer in `src/openclaw_dae.py` with facade wrappers.
+
+### Outcome
+- Execution-plane routing now lives in a dedicated module after plan resolution, aligned to WSP 97 plane separation.
+- `openclaw_dae.py` dropped from `2086` lines to `1678` lines in this slice.
+
+## 2026-03-11: OpenClaw control-plane refactor - telemetry and turn state
+
+**Author**: 0102  
+**WSP**: 22, 73, 84, 91, 97
+
+### Changes
+- Added `src/openclaw_turn_state.py` for:
+  - conversation-engine markers
+  - preferred-external status markers
+  - token telemetry
+  - cooperative turn cancellation
+- Replaced the inline runtime bookkeeping block in `src/openclaw_dae.py` with facade wrappers.
+
+### Outcome
+- Runtime bookkeeping is now isolated from the OpenClaw control-plane facade.
+- `openclaw_dae.py` dropped from `1678` lines to `1603` lines in this slice.
+
+## 2026-03-11: OpenClaw control-plane refactor - status surface + process loop
+
+**Author**: 0102  
+**WSP**: 22, 50, 73, 84, 91, 97
+
+### Changes
+- Added `src/openclaw_status_surface.py` for:
+  - `connect_wre` readiness/status synthesis
+  - Discord/AI Overseer status push dispatch
+- Added `src/openclaw_process_loop.py` for the full autonomy loop:
+  - honeypot intercept
+  - containment gate
+  - intent -> preflight -> permission -> plan -> execute -> validate pipeline
+  - DAEmon in/out and action reporting
+- Replaced the inline status/process bodies in `src/openclaw_dae.py` with facade delegation.
+
+### Outcome
+- `OpenClawDAE` now behaves as a true orchestration facade instead of carrying the full autonomy implementation.
+- `openclaw_dae.py` dropped from `1603` lines to `1342` lines in this final extraction slice.

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1317,3 +1317,16 @@ openclaw onboard
 ### Outcome
 - `OpenClawDAE` now behaves as a true orchestration facade instead of carrying the full autonomy implementation.
 - `openclaw_dae.py` dropped from `1603` lines to `1342` lines in this final extraction slice.
+
+## 2026-03-15: OpenClaw docs updated for WSP 97 module split
+
+**Author**: 0102  
+**WSP**: 22, 73, 84, 97
+
+### Changes
+- Appended canonical control-plane module map to `README.md`.
+- Appended internal module-boundary map to `INTERFACE.md`.
+
+### Outcome
+- Repo-local documentation now matches the post-refactor OpenClaw runtime layout.
+- The next 0102 session can re-enter OpenClaw using the actual module graph instead of the old monolith assumption.

--- a/modules/communication/moltbot_bridge/README.md
+++ b/modules/communication/moltbot_bridge/README.md
@@ -163,3 +163,31 @@ When WRE is unavailable, COMMAND intents return deterministic advisory fallback 
 - Advisory Mode header
 - Command recognition
 - Three actionable options (CLI, retry, query mode)
+
+## WSP 97 Control-Plane Module Map
+
+OpenClaw now follows a facade + delegated-module design.
+`OpenClawDAE` remains the public contract surface, while the runtime is split into focused control-plane modules.
+
+| Module | Responsibility |
+|------|------|
+| `src/openclaw_dae.py` | Facade, public contract, dependency wiring |
+| `src/openclaw_intent_planner.py` | Intent classification, WSP preflight, plan construction |
+| `src/openclaw_permission_policy.py` | Autonomy tiers, SOURCE gating, containment, skill safety |
+| `src/openclaw_execution_routes.py` | Post-plan route dispatch |
+| `src/openclaw_conversation_engine.py` | Conversation execution and response shaping |
+| `src/openclaw_model_policy.py` | Agentic model routing and live model switching |
+| `src/openclaw_identity_context.py` | Identity card, platform context pack, WSP_00 prompt assembly |
+| `src/openclaw_runtime_support.py` | Runtime probing, IronClaw autostart, model availability |
+| `src/openclaw_status_surface.py` | `connect wre` readiness/status and outward status push |
+| `src/openclaw_process_loop.py` | Full autonomy loop orchestration |
+| `src/openclaw_result_memory.py` | Validate + remember (WRE pattern memory writeback) |
+| `src/openclaw_turn_state.py` | Token telemetry and cooperative turn cancellation |
+| `src/openclaw_action_ledger.py` | Structured DAEmon action emission |
+| `src/openclaw_social_controller.py` | Social-routing bridge and LinkedIn mission control |
+| `src/openclaw_provider_chain.py` | Preferred external / IronClaw provider call chain |
+| `src/openclaw_bootstrap_config.py` | Constructor-time state/bootstrap wiring |
+
+Current refactor result:
+- `openclaw_dae.py` reduced from `2638` lines to `1342`
+- remaining file content is predominantly facade wrappers, dataclasses, and the honeypot surface

--- a/modules/communication/moltbot_bridge/src/openclaw_action_ledger.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_action_ledger.py
@@ -1,0 +1,88 @@
+"""OpenClaw DAEmon action-ledger helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from typing import Any, Dict
+
+logger = logging.getLogger("openclaw_dae")
+
+
+def record_social_response(dae: Any, source: str, response_text: str) -> None:
+    """Capture the latest social adapter response for daemon diagnostics."""
+    response_text = str(response_text or "").strip()
+    payload: Dict[str, Any] = {}
+    json_start = response_text.find("{")
+    if json_start != -1:
+        try:
+            payload = json.loads(response_text[json_start:])
+        except Exception:
+            payload = {}
+
+    skill = "none"
+    skill_match = re.search(r"Skill executed:\s*([^\r\n]+)", response_text)
+    if skill_match:
+        skill = skill_match.group(1).strip() or "none"
+    elif payload.get("skill"):
+        skill = str(payload.get("skill")).strip() or "none"
+
+    action = str(payload.get("action", "")).strip() or "none"
+    success = payload.get("success")
+
+    preview = ""
+    if isinstance(payload.get("reply_text"), str) and payload.get("reply_text"):
+        preview = str(payload.get("reply_text"))
+    elif isinstance(payload.get("draft"), dict) and payload["draft"].get("reply_text"):
+        preview = str(payload["draft"]["reply_text"])
+    elif isinstance(payload.get("planned_replies"), list) and payload["planned_replies"]:
+        first_plan = payload["planned_replies"][0] or {}
+        preview = str(first_plan.get("reply_text", "") or "")
+    if not preview:
+        preview = " ".join(response_text.split())
+    preview = (" ".join(preview.split())[:160] or "none")
+
+    dae._last_social_response_source = (source or "unknown").strip() or "unknown"
+    dae._last_social_response_action = action
+    dae._last_social_response_skill = skill
+    dae._last_social_response_success = (
+        "true" if success is True else "false" if success is False else "unknown"
+    )
+    dae._last_social_response_preview = preview
+    dae._last_social_response_at = time.time()
+
+    logger.info(
+        "[OPENCLAW-DAE] Social response captured | source=%s action=%s skill=%s success=%s",
+        dae._last_social_response_source,
+        dae._last_social_response_action,
+        dae._last_social_response_skill,
+        dae._last_social_response_success,
+    )
+
+
+def report_daemon_action(
+    dae: Any,
+    action_type: str,
+    target: str = "",
+    result: str = "",
+    **details: Any,
+) -> None:
+    """Emit structured OpenClaw actions to the central DAEmon when available."""
+    if not getattr(dae, "_central_adapter", None):
+        return
+    try:
+        compact_details = {
+            key: value
+            for key, value in details.items()
+            if value is not None and value != ""
+        }
+        dae._central_adapter.report_action(
+            action_type=action_type,
+            target=target,
+            result=result,
+            details=compact_details or None,
+        )
+    except Exception:
+        pass

--- a/modules/communication/moltbot_bridge/src/openclaw_bootstrap_config.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_bootstrap_config.py
@@ -1,0 +1,204 @@
+"""OpenClaw control-plane bootstrap helpers."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+
+logger = logging.getLogger("openclaw_dae")
+
+
+def _env_truthy(name: str, default: str = "0") -> bool:
+    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def initialize_control_plane_state(
+    dae,
+    *,
+    backend: str,
+    allow_external_requested: bool,
+) -> None:
+    """Initialize OpenClaw identity/runtime/model/context control-plane state."""
+    dae._ollama_model = os.getenv("OPENCLAW_OLLAMA_MODEL", "qwen2.5-coder:7b").strip()
+    strict_default = "1" if backend == "ironclaw" else "0"
+    dae._ironclaw_strict = _env_truthy("OPENCLAW_IRONCLAW_STRICT", strict_default)
+    dae._ironclaw_allow_local_fallback = _env_truthy(
+        "OPENCLAW_IRONCLAW_ALLOW_LOCAL_FALLBACK",
+        "0",
+    )
+    dae._ironclaw_autostart_enabled = _env_truthy("OPENCLAW_IRONCLAW_AUTOSTART", "1")
+    dae._ironclaw_autostart_start_cmd = os.getenv("IRONCLAW_START_CMD", "").strip()
+    dae._ironclaw_autostart_default_cmd = (
+        os.getenv("OPENCLAW_IRONCLAW_DEFAULT_START_CMD", "ironclaw gateway").strip()
+        or "ironclaw gateway"
+    )
+    dae._ironclaw_autostart_last_attempt = 0.0
+    try:
+        dae._ironclaw_autostart_cooldown_sec = max(
+            3.0,
+            float(os.getenv("OPENCLAW_IRONCLAW_AUTOSTART_COOLDOWN_SEC", "20")),
+        )
+    except ValueError:
+        dae._ironclaw_autostart_cooldown_sec = 20.0
+    try:
+        dae._ironclaw_autostart_wait_sec = max(
+            1.0,
+            float(os.getenv("OPENCLAW_IRONCLAW_AUTOSTART_WAIT_SEC", "8")),
+        )
+    except ValueError:
+        dae._ironclaw_autostart_wait_sec = 8.0
+    try:
+        dae._ironclaw_autostart_missing_backoff_sec = max(
+            30.0,
+            float(
+                os.getenv(
+                    "OPENCLAW_IRONCLAW_AUTOSTART_MISSING_BACKOFF_SEC",
+                    "300",
+                )
+            ),
+        )
+    except ValueError:
+        dae._ironclaw_autostart_missing_backoff_sec = 300.0
+    dae._ironclaw_autostart_missing_backoff_until = 0.0
+    dae._ironclaw_autostart_allow_shell = _env_truthy(
+        "OPENCLAW_IRONCLAW_AUTOSTART_ALLOW_SHELL",
+        "0",
+    )
+
+    dae._identity_genus = dae._normalize_genus_label(
+        os.getenv("OPENCLAW_IDENTITY_GENUS", "Ex.machina"),
+        "Ex.machina",
+    )
+    legacy_species = os.getenv("OPENCLAW_IDENTITY_SPECIES", "").strip()
+    family_env = os.getenv("OPENCLAW_IDENTITY_MODEL_FAMILY", "").strip()
+    model_name_env = os.getenv("OPENCLAW_IDENTITY_MODEL_NAME", "").strip()
+    if not family_env and legacy_species and "+" in legacy_species:
+        family_env = legacy_species.split("+", 1)[0].strip()
+    if not model_name_env and legacy_species and "+" in legacy_species:
+        model_name_env = legacy_species.split("+", 1)[1].strip()
+
+    dae._identity_model_family = dae._normalize_lower_label(family_env, "davinci")
+    dae._identity_model_name_template = dae._normalize_lower_label(
+        model_name_env,
+        "{model}",
+    )
+    dae._identity_model_catalog = dae._normalize_lower_label(
+        os.getenv("OPENCLAW_IDENTITY_MODEL_CATALOG", "").strip()
+        or os.getenv("OPENCLAW_IDENTITY_MODEL_LINEAGE", "").strip()
+        or "qwen2.5,qwen3,qwen3.5,ui_tars1.5,grok4,codex5.3,opus4.6,sonnet4.6,gemini3pro",
+        "qwen2.5,qwen3,qwen3.5,ui_tars1.5,grok4,codex5.3,opus4.6,sonnet4.6,gemini3pro",
+    )
+    dae._identity_protocol_anchor = dae._normalize_lower_label(
+        os.getenv("OPENCLAW_IDENTITY_PROTOCOL", "wsp_00"),
+        "wsp_00",
+    )
+    dae._wsp00_boot_enabled = _env_truthy("OPENCLAW_WSP00_BOOT", "1")
+    dae._wsp00_boot_mode = (
+        os.getenv("OPENCLAW_WSP00_BOOT_MODE", "compact").strip().lower() or "compact"
+    )
+    dae._wsp00_prompt_file = os.getenv("OPENCLAW_WSP00_PROMPT_FILE", "").strip()
+    dae._platform_context_enabled = _env_truthy("OPENCLAW_PLATFORM_CONTEXT_ENABLED", "1")
+    dae._platform_context_files = os.getenv("OPENCLAW_PLATFORM_CONTEXT_FILES", "").strip()
+    try:
+        dae._platform_context_max_chars = max(
+            400,
+            int(os.getenv("OPENCLAW_PLATFORM_CONTEXT_MAX_CHARS", "2200")),
+        )
+    except ValueError:
+        dae._platform_context_max_chars = 2200
+    try:
+        dae._platform_context_refresh_sec = max(
+            5.0,
+            float(os.getenv("OPENCLAW_PLATFORM_CONTEXT_REFRESH_SEC", "120")),
+        )
+    except ValueError:
+        dae._platform_context_refresh_sec = 120.0
+    try:
+        dae._platform_context_quick_response_chars = max(
+            200,
+            int(os.getenv("OPENCLAW_PLATFORM_CONTEXT_QUICK_RESPONSE_CHARS", "1000")),
+        )
+    except ValueError:
+        dae._platform_context_quick_response_chars = 1000
+    dae._platform_context_pack_cache = ""
+    dae._platform_context_pack_loaded_at = 0.0
+    dae._platform_context_pack_sources = []
+    dae._agentic_model_selection_enabled = _env_truthy(
+        "OPENCLAW_AGENTIC_MODEL_SELECTION",
+        "1",
+    )
+    dae._conversation_model_target_locked = _env_truthy(
+        "OPENCLAW_CONVERSATION_MODEL_LOCK",
+        "0",
+    )
+    configured_conversation_target = (
+        os.getenv("OPENCLAW_CONVERSATION_MODEL_TARGET", "").strip().lower()
+    )
+    default_conversation_target = (
+        dae._resolve_local_target_for_role("general") or "local/qwen3.5-4b"
+    )
+    dae._conversation_model_target_id = (
+        configured_conversation_target or default_conversation_target
+    )
+    dae._preferred_external_provider = (
+        os.getenv("OPENCLAW_CONVERSATION_PREFERRED_PROVIDER", "").strip().lower()
+    )
+    dae._preferred_external_model = (
+        os.getenv("OPENCLAW_CONVERSATION_PREFERRED_MODEL", "").strip().lower()
+    )
+    dae._model_switch_live_probe = _env_truthy(
+        "OPENCLAW_MODEL_SWITCH_LIVE_PROBE",
+        "1",
+    )
+    try:
+        dae._model_switch_probe_timeout_sec = max(
+            0.8,
+            float(os.getenv("OPENCLAW_MODEL_SWITCH_PROBE_TIMEOUT_SEC", "2.0")),
+        )
+    except ValueError:
+        dae._model_switch_probe_timeout_sec = 2.0
+
+    dae._last_conversation_engine = "uninitialized"
+    dae._last_conversation_detail = "none"
+    dae._previous_conversation_engine = "none"
+    dae._previous_conversation_detail = "none"
+    dae._preferred_external_last_status = "not_selected"
+    dae._preferred_external_last_status_detail = "none"
+    dae._preferred_external_last_status_at = 0.0
+    dae._token_usage_last_prompt_tokens = 0
+    dae._token_usage_last_completion_tokens = 0
+    dae._token_usage_last_total_tokens = 0
+    dae._token_usage_last_engine = "none"
+    dae._token_usage_last_provider = "none"
+    dae._token_usage_last_model = "none"
+    dae._token_usage_last_source = "none"
+    dae._token_usage_last_cost_estimate_usd = 0.0
+    dae._token_usage_last_at = 0.0
+    dae._last_social_response_source = "none"
+    dae._last_social_response_action = "none"
+    dae._last_social_response_skill = "none"
+    dae._last_social_response_success = "unknown"
+    dae._last_social_response_preview = "none"
+    dae._last_social_response_at = 0.0
+    dae._last_auto_model_role = "boot"
+    dae._last_auto_model_target = dae._conversation_model_target_id or "unassigned"
+    dae._last_auto_model_reason = (
+        "explicit_env_target" if configured_conversation_target else "boot_default"
+    )
+    dae._token_usage_session_turns = 0
+    dae._token_usage_session_prompt_tokens = 0
+    dae._token_usage_session_completion_tokens = 0
+    dae._token_usage_session_total_tokens = 0
+    dae._token_usage_session_cost_estimate_usd = 0.0
+    dae._turn_cancel_event = threading.Event()
+    dae._turn_cancel_reason = "none"
+
+    if dae._no_api_keys:
+        os.environ["OPENCLAW_NO_API_KEYS"] = "1"
+        if backend == "ironclaw":
+            os.environ["IRONCLAW_NO_API_KEYS"] = "1"
+        if allow_external_requested:
+            logger.warning(
+                "[OPENCLAW-DAE] OPENCLAW_ALLOW_EXTERNAL_LLM ignored because no_api_keys mode is ON"
+            )

--- a/modules/communication/moltbot_bridge/src/openclaw_conversation_engine.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_conversation_engine.py
@@ -1,0 +1,323 @@
+"""OpenClaw conversation execution helper.
+
+WSP 73/97 boundary:
+- OpenClaw owns dialogue, identity, and execution-plane selection.
+- WRE is invoked when the resolved execution plane requires orchestration.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+from .openclaw_runtime_support import _env_truthy
+
+if TYPE_CHECKING:
+    from .openclaw_dae import OpenClawIntent
+
+
+logger = logging.getLogger("openclaw_dae")
+
+
+def execute_conversation(dae: Any, intent: "OpenClawIntent") -> str:
+    """
+    Default: Digital Twin conversational response.
+
+    Chain (local-first):
+      1) Deterministic identity/model/control handling
+      2) IronClaw sidecar (when backend=ironclaw)
+      3) Local Qwen via AI Overseer
+      4) Ollama local fallback
+      5) AI Gateway cloud fallback (when enabled)
+    """
+    user_msg = intent.raw_message.strip()
+    system_prompt = dae._build_conversation_system_prompt()
+    if dae._is_turn_cancelled("conversation_start"):
+        dae._mark_conversation_engine("cancelled", "conversation_start")
+        return dae._turn_cancelled_response()
+
+    if dae._is_connect_wre_request(user_msg):
+        if not intent.is_authorized_commander:
+            dae._mark_conversation_engine("connect_wre_blocked", "commander_required")
+            return "0102: connect_wre is operator-only. 012 commander authority required."
+        verbose = dae._wants_connect_wre_details(user_msg)
+        dae._mark_conversation_engine("connect_wre", "deterministic_conversation_route")
+        return dae._build_connect_wre_status(verbose=verbose)
+
+    if dae._is_model_switch_request(user_msg):
+        target = dae._parse_model_switch_target(user_msg)
+        if not target:
+            dae._mark_conversation_engine("model_switch", "target_missing")
+            return dae._model_switch_target_help()
+        gate_error = dae._wsp00_model_switch_gate(intent, target)
+        if gate_error:
+            dae._mark_conversation_engine("model_switch_blocked", "wsp00_gate")
+            return gate_error
+        dae._mark_conversation_engine("model_switch", f"target={target or 'unknown'}")
+        return dae._apply_model_switch_target(target or "")
+
+    if dae._is_token_usage_query(user_msg):
+        dae._mark_conversation_engine("token_usage", "deterministic_conversation_route")
+        return dae._build_token_usage_report()
+
+    if dae._is_identity_query(user_msg):
+        if dae._wants_full_identity_card(user_msg):
+            dae._mark_conversation_engine("identity_card", "deterministic_conversation_route")
+            return dae._build_identity_card()
+        dae._mark_conversation_engine("identity_compact", "deterministic_conversation_route")
+        if dae._is_compact_identity_query(user_msg):
+            return dae._build_identity_compact_runtime()
+        return dae._build_identity_compact()
+
+    dae._maybe_apply_agentic_conversation_model(intent, user_msg)
+
+    if dae._is_turn_cancelled("pre_ironclaw"):
+        dae._mark_conversation_engine("cancelled", "pre_ironclaw")
+        return dae._turn_cancelled_response()
+    if dae._conversation_backend == "ironclaw":
+        ironclaw_reply = dae._try_ironclaw_conversation(user_msg, system_prompt)
+        if dae._is_turn_cancelled("post_ironclaw"):
+            dae._mark_conversation_engine("cancelled", "post_ironclaw")
+            return dae._turn_cancelled_response()
+        if ironclaw_reply:
+            dae._record_token_usage(
+                prompt_text=f"{system_prompt}\n\nUser: {user_msg}",
+                completion_text=ironclaw_reply,
+                engine="ironclaw",
+                provider="ironclaw",
+                model=os.getenv("IRONCLAW_MODEL", "local/qwen-coder-7b").strip() or "local/qwen-coder-7b",
+                source="estimated",
+            )
+            dae._mark_conversation_engine("ironclaw", "gateway_chat_completion")
+            return ironclaw_reply
+
+        if dae._ironclaw_strict and not dae._ironclaw_allow_local_fallback:
+            recovered, recover_detail = dae._attempt_ironclaw_autostart()
+            if recovered:
+                retry_reply = dae._try_ironclaw_conversation(user_msg, system_prompt)
+                if retry_reply:
+                    dae._record_token_usage(
+                        prompt_text=f"{system_prompt}\n\nUser: {user_msg}",
+                        completion_text=retry_reply,
+                        engine="ironclaw",
+                        provider="ironclaw",
+                        model=os.getenv("IRONCLAW_MODEL", "local/qwen-coder-7b").strip() or "local/qwen-coder-7b",
+                        source="estimated",
+                    )
+                    dae._mark_conversation_engine("ironclaw", "autostart_recovered")
+                    return retry_reply
+
+            runtime = dae._probe_ironclaw_runtime()
+            dae._mark_conversation_engine(
+                "ironclaw_unavailable_strict",
+                f"{runtime.get('detail', 'unavailable')}|{recover_detail}",
+            )
+            base = (
+                "0102: IronClaw runtime is unavailable in strict mode, so local fallback is disabled. "
+                "Auto-recovery was attempted. Use menu 16 -> 5 (IronClaw Runtime Status), or enable "
+                "OPENCLAW_IRONCLAW_ALLOW_LOCAL_FALLBACK=1."
+            )
+            if _env_truthy("OPENCLAW_VERBOSE_RUNTIME_ERRORS", "0"):
+                return (
+                    f"{base} "
+                    f"health={runtime.get('healthy', 'UNKNOWN')} "
+                    f"detail={runtime.get('detail', 'not-probed')} "
+                    f"base_url={runtime.get('base_url', 'unknown')} "
+                    f"autostart={recover_detail}."
+                )
+            return base
+
+    if dae._conversation_backend != "ironclaw":
+        preferred_external_reply = dae._try_preferred_external_conversation(user_msg, system_prompt)
+        if dae._is_turn_cancelled("post_preferred_external"):
+            dae._mark_conversation_engine("cancelled", "post_preferred_external")
+            return dae._turn_cancelled_response()
+        if preferred_external_reply:
+            dae._record_token_usage(
+                prompt_text=f"{system_prompt}\n\nUser: {user_msg}",
+                completion_text=preferred_external_reply,
+                engine="ai_gateway_preferred",
+                provider=dae._preferred_external_provider or "external",
+                model=dae._preferred_external_model or "unknown",
+                source="estimated",
+            )
+            dae._mark_conversation_engine(
+                "ai_gateway_preferred",
+                f"{dae._preferred_external_provider}/{dae._preferred_external_model}",
+            )
+            return preferred_external_reply
+        if dae._preferred_external_provider and dae._preferred_external_model:
+            logger.info(
+                "[OPENCLAW-DAE] Preferred external not used | target=%s/%s status=%s detail=%s -> fallback=local",
+                dae._preferred_external_provider,
+                dae._preferred_external_model,
+                dae._preferred_external_last_status,
+                dae._preferred_external_last_status_detail,
+            )
+
+    if dae._is_turn_cancelled("pre_local_qwen"):
+        dae._mark_conversation_engine("cancelled", "pre_local_qwen")
+        return dae._turn_cancelled_response()
+    if dae.overseer:
+        try:
+            conversation_context = f"Channel: {intent.channel}, Sender: {intent.sender}"
+            platform_context = dae._load_platform_context_pack()
+            if platform_context:
+                conversation_context = (
+                    f"{conversation_context}\n\n"
+                    f"{platform_context[: dae._platform_context_quick_response_chars]}"
+                )
+            result = dae.overseer.quick_response(
+                prompt=user_msg,
+                context=conversation_context,
+                max_tokens=80,
+            )
+            if dae._is_turn_cancelled("post_local_qwen"):
+                dae._mark_conversation_engine("cancelled", "post_local_qwen")
+                return dae._turn_cancelled_response()
+            if result and result.get("response"):
+                resp = dae._trim_self_dialogue(result["response"])
+                if resp and len(resp) > 3 and "Error:" not in resp:
+                    prompt_context = (
+                        f"{system_prompt}\n\n"
+                        f"{conversation_context}\n\n"
+                        f"User: {user_msg}"
+                    )
+                    dae._record_token_usage(
+                        prompt_text=prompt_context,
+                        completion_text=resp,
+                        engine="local_qwen",
+                        provider="local_qwen",
+                        model=dae._conversation_model_target_id or "local/qwen-coder-7b",
+                        source="estimated",
+                    )
+                    logger.info(
+                        "[OPENCLAW-DAE] Conversation via local Qwen: %d chars",
+                        len(resp),
+                    )
+                    dae._mark_conversation_engine("local_qwen", "ai_overseer.quick_response")
+                    return dae._ensure_conversation_identity(resp)
+        except Exception as exc:
+            logger.debug("[OPENCLAW-DAE] Local Qwen response failed: %s", exc)
+
+    if dae._is_turn_cancelled("pre_ollama"):
+        dae._mark_conversation_engine("cancelled", "pre_ollama")
+        return dae._turn_cancelled_response()
+    if dae._ollama_model:
+        try:
+            import requests as _req
+
+            ollama_resp = _req.post(
+                "http://localhost:11434/api/chat",
+                json={
+                    "model": dae._ollama_model,
+                    "messages": [
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": user_msg},
+                    ],
+                    "stream": False,
+                    "options": {"num_predict": 80, "temperature": 0.7},
+                },
+                timeout=15,
+            )
+            if dae._is_turn_cancelled("post_ollama"):
+                dae._mark_conversation_engine("cancelled", "post_ollama")
+                return dae._turn_cancelled_response()
+            if ollama_resp.ok:
+                body = ollama_resp.json()
+                content = body.get("message", {}).get("content", "")
+                content = dae._trim_self_dialogue(content)
+                if content and len(content) > 3:
+                    prompt_eval = dae._safe_int(body.get("prompt_eval_count"))
+                    eval_count = dae._safe_int(body.get("eval_count"))
+                    total_tokens = (
+                        (prompt_eval + eval_count)
+                        if (prompt_eval is not None and eval_count is not None)
+                        else None
+                    )
+                    usage = {
+                        "prompt_tokens": prompt_eval,
+                        "completion_tokens": eval_count,
+                        "total_tokens": total_tokens,
+                    }
+                    dae._record_token_usage(
+                        prompt_text=f"{system_prompt}\n\nUser: {user_msg}",
+                        completion_text=content,
+                        engine="ollama",
+                        provider="ollama",
+                        model=dae._ollama_model,
+                        usage=usage,
+                        source="provider_usage" if (prompt_eval is not None or eval_count is not None) else "estimated",
+                    )
+                    logger.info(
+                        "[OPENCLAW-DAE] Conversation via Ollama (%s): %d chars",
+                        dae._ollama_model,
+                        len(content),
+                    )
+                    dae._mark_conversation_engine("ollama", dae._ollama_model)
+                    return dae._ensure_conversation_identity(content)
+        except Exception as exc:
+            logger.debug("[OPENCLAW-DAE] Ollama unavailable: %s", exc)
+
+    if (
+        dae._conversation_backend != "ironclaw"
+        and _env_truthy("OPENCLAW_ALLOW_IRONCLAW_FALLBACK", "0")
+    ):
+        ironclaw_reply = dae._try_ironclaw_conversation(user_msg, system_prompt)
+        if dae._is_turn_cancelled("post_ironclaw_fallback"):
+            dae._mark_conversation_engine("cancelled", "post_ironclaw_fallback")
+            return dae._turn_cancelled_response()
+        if ironclaw_reply:
+            dae._record_token_usage(
+                prompt_text=f"{system_prompt}\n\nUser: {user_msg}",
+                completion_text=ironclaw_reply,
+                engine="ironclaw_fallback",
+                provider="ironclaw",
+                model=os.getenv("IRONCLAW_MODEL", "local/qwen-coder-7b").strip() or "local/qwen-coder-7b",
+                source="estimated",
+            )
+            dae._mark_conversation_engine("ironclaw_fallback", "openclaw_allow_ironclaw_fallback")
+            return ironclaw_reply
+
+    if dae._is_turn_cancelled("pre_ai_gateway"):
+        dae._mark_conversation_engine("cancelled", "pre_ai_gateway")
+        return dae._turn_cancelled_response()
+    if not dae._allow_external_llm:
+        logger.info("[OPENCLAW-DAE] External LLM disabled by key-isolation policy")
+        dae._mark_conversation_engine("none", "external_llm_disabled")
+        return "0102: I'm here. Local conversation models are unavailable right now."
+
+    try:
+        from modules.ai_intelligence.ai_gateway.src.ai_gateway import AIGateway
+
+        gw = AIGateway()
+        prompt = f"{system_prompt}\n\nUser: {user_msg}"
+        result = gw.call_with_fallback(prompt=prompt, task_type="quick")
+        if dae._is_turn_cancelled("post_ai_gateway"):
+            dae._mark_conversation_engine("cancelled", "post_ai_gateway")
+            return dae._turn_cancelled_response()
+        if result and result.success and result.response and len(result.response) > 3:
+            trimmed = dae._trim_self_dialogue(result.response)
+            if trimmed and len(trimmed) > 3:
+                dae._record_token_usage(
+                    prompt_text=prompt,
+                    completion_text=trimmed,
+                    engine="ai_gateway",
+                    provider=str(result.provider),
+                    model=str(getattr(result, "model", "")),
+                    source="estimated",
+                    cost_estimate_usd=getattr(result, "cost_estimate", None),
+                )
+                logger.info(
+                    "[OPENCLAW-DAE] Conversation via AI Gateway (%s): %d chars",
+                    result.provider,
+                    len(trimmed),
+                )
+                dae._mark_conversation_engine("ai_gateway", str(result.provider))
+                return dae._ensure_conversation_identity(trimmed)
+    except Exception as exc:
+        logger.debug("[OPENCLAW-DAE] AI Gateway unavailable: %s", exc)
+
+    dae._mark_conversation_engine("none", "minimal_ack")
+    return "0102: I'm here. My conversation models aren't fully responding right now."

--- a/modules/communication/moltbot_bridge/src/openclaw_dae.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_dae.py
@@ -35,10 +35,6 @@ import time
 import json
 import re
 import os
-import shlex
-import shutil
-import subprocess
-import threading
 import uuid
 import secrets
 import string
@@ -47,6 +43,114 @@ from enum import Enum
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 from pathlib import Path
+
+from .openclaw_action_ledger import (
+    record_social_response as _ledger_record_social_response,
+    report_daemon_action as _ledger_report_daemon_action,
+)
+from .openclaw_bootstrap_config import (
+    initialize_control_plane_state as _bootstrap_initialize_control_plane_state,
+)
+from .openclaw_conversation_engine import execute_conversation as _conversation_execute
+from .openclaw_execution_routes import (
+    command_advisory_fallback as _routes_command_advisory_fallback,
+    execute_automation as _routes_execute_automation,
+    execute_command as _routes_execute_command,
+    execute_foundup as _routes_execute_foundup,
+    execute_monitor as _routes_execute_monitor,
+    execute_plan as _routes_execute_plan,
+    execute_query as _routes_execute_query,
+    execute_research as _routes_execute_research,
+    execute_schedule as _routes_execute_schedule,
+    execute_system as _routes_execute_system,
+    try_execute_follow_wsp as _routes_try_execute_follow_wsp,
+)
+from .openclaw_identity_context import (
+    base_conversation_system_prompt as _identity_base_conversation_system_prompt,
+    build_conversation_system_prompt as _identity_build_conversation_system_prompt,
+    build_identity_card as _identity_build_identity_card,
+    build_identity_compact as _identity_build_identity_compact,
+    build_identity_compact_runtime as _identity_build_identity_compact_runtime,
+    build_wsp00_boot_prompt as _identity_build_wsp00_boot_prompt,
+    compact_platform_context_text as _identity_compact_platform_context_text,
+    is_compact_identity_query as _identity_is_compact_identity_query,
+    is_identity_query as _identity_is_identity_query,
+    is_token_usage_query as _identity_is_token_usage_query,
+    load_platform_context_pack as _identity_load_platform_context_pack,
+    load_wsp00_prompt_from_file as _identity_load_wsp00_prompt_from_file,
+    resolve_platform_context_paths as _identity_resolve_platform_context_paths,
+    wants_full_identity_card as _identity_wants_full_identity_card,
+)
+from .openclaw_intent_planner import (
+    classify_intent as _planner_classify_intent,
+    plan_execution as _planner_plan_execution,
+    wsp_preflight as _planner_wsp_preflight,
+)
+from .openclaw_model_policy import (
+    apply_local_target_runtime as _model_apply_local_target_runtime,
+    apply_model_switch_target as _model_apply_model_switch_target,
+    has_model_switch_intent as _model_has_model_switch_intent,
+    infer_conversation_model_role as _model_infer_conversation_model_role,
+    local_target_dirs as _model_local_target_dirs,
+    map_local_model_path_to_target as _model_map_local_model_path_to_target,
+    maybe_apply_agentic_conversation_model as _model_maybe_apply_agentic_conversation_model,
+    model_switch_target_help as _model_switch_target_help,
+    normalize_identity_message as _model_normalize_identity_message,
+    parse_model_switch_target as _model_parse_model_switch_target,
+    provider_has_key as _model_provider_has_key,
+    resolve_external_target as _model_resolve_external_target,
+    resolve_local_target_for_role as _model_resolve_local_target_for_role,
+    wsp00_model_switch_gate as _model_wsp00_model_switch_gate,
+)
+from .openclaw_permission_policy import (
+    check_containment as _policy_check_containment,
+    check_permission_gate as _policy_check_permission_gate,
+    check_source_permission as _policy_check_source_permission,
+    emit_permission_denied_event as _policy_emit_permission_denied_event,
+    emit_to_overseer as _policy_emit_to_overseer,
+    ensure_skill_safety as _policy_ensure_skill_safety,
+    extract_file_paths as _policy_extract_file_paths,
+    is_source_modification as _policy_is_source_modification,
+    resolve_autonomy_tier as _policy_resolve_autonomy_tier,
+)
+from .openclaw_process_loop import process_message as _process_process_message
+from .openclaw_provider_chain import (
+    try_ironclaw_conversation as _provider_try_ironclaw_conversation,
+    try_preferred_external_conversation as _provider_try_preferred_external_conversation,
+)
+from .openclaw_runtime_support import (
+    attempt_ironclaw_autostart as _runtime_attempt_ironclaw_autostart,
+    get_identity_snapshot as _runtime_get_identity_snapshot,
+    get_model_availability_snapshot as _runtime_get_model_availability_snapshot,
+    probe_ironclaw_runtime as _runtime_probe_ironclaw_runtime,
+    probe_provider_endpoint as _runtime_probe_provider_endpoint,
+    resolve_identity_model_name as _runtime_resolve_identity_model_name,
+    resolve_local_code_model_snapshot as _runtime_resolve_local_code_model_snapshot,
+)
+from .openclaw_result_memory import (
+    validate_and_remember as _result_validate_and_remember,
+)
+from .openclaw_status_surface import (
+    build_connect_wre_status as _status_build_connect_wre_status,
+    push_status as _status_push_status,
+)
+from .openclaw_social_controller import (
+    execute_social as _social_execute,
+    try_conversation_social_control as _social_try_conversation_control,
+)
+from .openclaw_turn_state import (
+    build_token_usage_report as _turn_build_token_usage_report,
+    clear_turn_cancel as _turn_clear_turn_cancel,
+    get_token_usage_snapshot as _turn_get_token_usage_snapshot,
+    is_turn_cancelled as _turn_is_turn_cancelled,
+    mark_conversation_engine as _turn_mark_conversation_engine,
+    mark_preferred_external_status as _turn_mark_preferred_external_status,
+    record_token_usage as _turn_record_token_usage,
+    request_turn_cancel as _turn_request_turn_cancel,
+    safe_int as _turn_safe_int,
+    turn_cancelled_response as _turn_turn_cancelled_response,
+    estimate_token_count as _turn_estimate_token_count,
+)
 
 logger = logging.getLogger("openclaw_dae")
 
@@ -423,6 +527,13 @@ class OpenClawDAE:
     WSP 73: Partner (OpenClaw) -> Principal (this DAE) -> Associates (domain DAEs)
     """
 
+    OpenClawIntent = OpenClawIntent
+    ExecutionPlan = ExecutionPlan
+    ExecutionResult = ExecutionResult
+    IntentCategory = IntentCategory
+    AutonomyTier = AutonomyTier
+    HoneypotDefense = HoneypotDefense
+
     # Authorized identifiers (command authority).
     # Contract: 012 is operator/commander, 0102 is agent identity.
     AUTHORIZED_COMMANDERS = {"012", "@012", "undaodu", "@undaodu"}
@@ -590,194 +701,11 @@ class OpenClawDAE:
             # ZeroClaw is always fail-closed for external providers.
             self._no_api_keys = True
             self._allow_external_llm = False
-        self._ollama_model = os.getenv("OPENCLAW_OLLAMA_MODEL", "qwen2.5-coder:7b").strip()
-        strict_default = "1" if backend == "ironclaw" else "0"
-        self._ironclaw_strict = _env_truthy("OPENCLAW_IRONCLAW_STRICT", strict_default)
-        self._ironclaw_allow_local_fallback = _env_truthy(
-            "OPENCLAW_IRONCLAW_ALLOW_LOCAL_FALLBACK",
-            "0",
+        _bootstrap_initialize_control_plane_state(
+            self,
+            backend=backend,
+            allow_external_requested=allow_external_requested,
         )
-        # Autonomous runtime recovery: auto-start IronClaw gateway when unavailable.
-        self._ironclaw_autostart_enabled = _env_truthy("OPENCLAW_IRONCLAW_AUTOSTART", "1")
-        self._ironclaw_autostart_start_cmd = os.getenv("IRONCLAW_START_CMD", "").strip()
-        self._ironclaw_autostart_default_cmd = (
-            os.getenv("OPENCLAW_IRONCLAW_DEFAULT_START_CMD", "ironclaw gateway").strip()
-            or "ironclaw gateway"
-        )
-        self._ironclaw_autostart_last_attempt = 0.0
-        try:
-            self._ironclaw_autostart_cooldown_sec = max(
-                3.0,
-                float(os.getenv("OPENCLAW_IRONCLAW_AUTOSTART_COOLDOWN_SEC", "20")),
-            )
-        except ValueError:
-            self._ironclaw_autostart_cooldown_sec = 20.0
-        try:
-            self._ironclaw_autostart_wait_sec = max(
-                1.0,
-                float(os.getenv("OPENCLAW_IRONCLAW_AUTOSTART_WAIT_SEC", "8")),
-            )
-        except ValueError:
-            self._ironclaw_autostart_wait_sec = 8.0
-        try:
-            self._ironclaw_autostart_missing_backoff_sec = max(
-                30.0,
-                float(
-                    os.getenv(
-                        "OPENCLAW_IRONCLAW_AUTOSTART_MISSING_BACKOFF_SEC",
-                        "300",
-                    )
-                ),
-            )
-        except ValueError:
-            self._ironclaw_autostart_missing_backoff_sec = 300.0
-        self._ironclaw_autostart_missing_backoff_until = 0.0
-        self._ironclaw_autostart_allow_shell = _env_truthy(
-            "OPENCLAW_IRONCLAW_AUTOSTART_ALLOW_SHELL",
-            "0",
-        )
-
-        # Identity/taxonomy labels for deterministic "which model are you?" responses.
-        self._identity_genus = self._normalize_genus_label(
-            os.getenv("OPENCLAW_IDENTITY_GENUS", "Ex.machina"),
-            "Ex.machina",
-        )
-        legacy_species = os.getenv("OPENCLAW_IDENTITY_SPECIES", "").strip()
-        family_env = os.getenv("OPENCLAW_IDENTITY_MODEL_FAMILY", "").strip()
-        model_name_env = os.getenv("OPENCLAW_IDENTITY_MODEL_NAME", "").strip()
-
-        # Backward compatibility: OPENCLAW_IDENTITY_SPECIES=davinci+{model}
-        # maps to model_family=davinci and model_name={model}.
-        if not family_env and legacy_species and "+" in legacy_species:
-            family_env = legacy_species.split("+", 1)[0].strip()
-        if not model_name_env and legacy_species and "+" in legacy_species:
-            model_name_env = legacy_species.split("+", 1)[1].strip()
-
-        self._identity_model_family = self._normalize_lower_label(family_env, "davinci")
-        self._identity_model_name_template = self._normalize_lower_label(
-            model_name_env,
-            "{model}",
-        )
-        self._identity_model_catalog = self._normalize_lower_label(
-            os.getenv("OPENCLAW_IDENTITY_MODEL_CATALOG", "").strip()
-            or os.getenv("OPENCLAW_IDENTITY_MODEL_LINEAGE", "").strip()
-            or "qwen2.5,qwen3,qwen3.5,ui_tars1.5,grok4,codex5.3,opus4.6,sonnet4.6,gemini3pro",
-            "qwen2.5,qwen3,qwen3.5,ui_tars1.5,grok4,codex5.3,opus4.6,sonnet4.6,gemini3pro",
-        )
-        self._identity_protocol_anchor = self._normalize_lower_label(
-            os.getenv("OPENCLAW_IDENTITY_PROTOCOL", "wsp_00"),
-            "wsp_00",
-        )
-        self._wsp00_boot_enabled = _env_truthy("OPENCLAW_WSP00_BOOT", "1")
-        self._wsp00_boot_mode = os.getenv("OPENCLAW_WSP00_BOOT_MODE", "compact").strip().lower() or "compact"
-        self._wsp00_prompt_file = os.getenv("OPENCLAW_WSP00_PROMPT_FILE", "").strip()
-        self._platform_context_enabled = _env_truthy("OPENCLAW_PLATFORM_CONTEXT_ENABLED", "1")
-        self._platform_context_files = os.getenv("OPENCLAW_PLATFORM_CONTEXT_FILES", "").strip()
-        try:
-            self._platform_context_max_chars = max(
-                400,
-                int(os.getenv("OPENCLAW_PLATFORM_CONTEXT_MAX_CHARS", "2200")),
-            )
-        except ValueError:
-            self._platform_context_max_chars = 2200
-        try:
-            self._platform_context_refresh_sec = max(
-                5.0,
-                float(os.getenv("OPENCLAW_PLATFORM_CONTEXT_REFRESH_SEC", "120")),
-            )
-        except ValueError:
-            self._platform_context_refresh_sec = 120.0
-        try:
-            self._platform_context_quick_response_chars = max(
-                200,
-                int(os.getenv("OPENCLAW_PLATFORM_CONTEXT_QUICK_RESPONSE_CHARS", "1000")),
-            )
-        except ValueError:
-            self._platform_context_quick_response_chars = 1000
-        self._platform_context_pack_cache = ""
-        self._platform_context_pack_loaded_at = 0.0
-        self._platform_context_pack_sources: List[str] = []
-        self._agentic_model_selection_enabled = _env_truthy(
-            "OPENCLAW_AGENTIC_MODEL_SELECTION",
-            "1",
-        )
-        self._conversation_model_target_locked = _env_truthy(
-            "OPENCLAW_CONVERSATION_MODEL_LOCK",
-            "0",
-        )
-        configured_conversation_target = (
-            os.getenv("OPENCLAW_CONVERSATION_MODEL_TARGET", "").strip().lower()
-        )
-        default_conversation_target = (
-            self._resolve_local_target_for_role("general") or "local/qwen3.5-4b"
-        )
-        self._conversation_model_target_id = (
-            configured_conversation_target or default_conversation_target
-        )
-        self._preferred_external_provider = (
-            os.getenv("OPENCLAW_CONVERSATION_PREFERRED_PROVIDER", "").strip().lower()
-        )
-        self._preferred_external_model = (
-            os.getenv("OPENCLAW_CONVERSATION_PREFERRED_MODEL", "").strip().lower()
-        )
-        self._model_switch_live_probe = _env_truthy(
-            "OPENCLAW_MODEL_SWITCH_LIVE_PROBE",
-            "1",
-        )
-        try:
-            self._model_switch_probe_timeout_sec = max(
-                0.8,
-                float(os.getenv("OPENCLAW_MODEL_SWITCH_PROBE_TIMEOUT_SEC", "2.0")),
-            )
-        except ValueError:
-            self._model_switch_probe_timeout_sec = 2.0
-
-        # Telemetry for runtime introspection.
-        self._last_conversation_engine = "uninitialized"
-        self._last_conversation_detail = "none"
-        self._previous_conversation_engine = "none"
-        self._previous_conversation_detail = "none"
-        self._preferred_external_last_status = "not_selected"
-        self._preferred_external_last_status_detail = "none"
-        self._preferred_external_last_status_at = 0.0
-        self._token_usage_last_prompt_tokens = 0
-        self._token_usage_last_completion_tokens = 0
-        self._token_usage_last_total_tokens = 0
-        self._token_usage_last_engine = "none"
-        self._token_usage_last_provider = "none"
-        self._token_usage_last_model = "none"
-        self._token_usage_last_source = "none"
-        self._token_usage_last_cost_estimate_usd = 0.0
-        self._token_usage_last_at = 0.0
-        self._last_social_response_source = "none"
-        self._last_social_response_action = "none"
-        self._last_social_response_skill = "none"
-        self._last_social_response_success = "unknown"
-        self._last_social_response_preview = "none"
-        self._last_social_response_at = 0.0
-        self._last_auto_model_role = "boot"
-        self._last_auto_model_target = self._conversation_model_target_id or "unassigned"
-        self._last_auto_model_reason = (
-            "explicit_env_target"
-            if configured_conversation_target
-            else "boot_default"
-        )
-        self._token_usage_session_turns = 0
-        self._token_usage_session_prompt_tokens = 0
-        self._token_usage_session_completion_tokens = 0
-        self._token_usage_session_total_tokens = 0
-        self._token_usage_session_cost_estimate_usd = 0.0
-        self._turn_cancel_event = threading.Event()
-        self._turn_cancel_reason = "none"
-
-        if self._no_api_keys:
-            os.environ["OPENCLAW_NO_API_KEYS"] = "1"
-            if backend == "ironclaw":
-                os.environ["IRONCLAW_NO_API_KEYS"] = "1"
-            if allow_external_requested:
-                logger.warning(
-                    "[OPENCLAW-DAE] OPENCLAW_ALLOW_EXTERNAL_LLM ignored because no_api_keys mode is ON"
-                )
 
         # Lazy-loaded components (initialized on first use)
         self._wre: Any = None
@@ -951,350 +879,23 @@ class OpenClawDAE:
         session_key: str,
         metadata: Optional[Dict] = None,
     ) -> OpenClawIntent:
-        """
-        Classify inbound message into an intent category.
-
-        Hybrid approach (WSP 15 P0 #1, MPS 18/20):
-        1. Fast keyword pre-filter (<1ms) scores all categories
-        2. Gemma 270M validates top 3 candidates via binary YES/NO (<30ms each)
-        3. Combined score: (keyword * 0.3) + (gemma * 0.7)
-        4. Graceful degradation: keyword-only if Gemma unavailable
-
-        Env control:
-            OPENCLAW_GEMMA_INTENT=0  -> Force keyword-only mode
-            OPENCLAW_GEMMA_INTENT=1  -> Enable Gemma hybrid (default)
-        """
-        msg_lower = message.lower().strip()
-        metadata = metadata or {}
-
-        def _has_keyword(text: str, keyword: str) -> bool:
-            """Match keyword on word boundaries to avoid substring false positives."""
-            pattern = rf"\b{re.escape(keyword.lower())}\b"
-            return re.search(pattern, text) is not None
-
-        # Check if sender is authorized commander.
-        sender_lower = sender.lower()
-        is_commander = any(
-            cmd_id in sender_lower for cmd_id in self.AUTHORIZED_COMMANDERS
-        )
-        is_direct_channel = channel in ("voice_repl", "local_repl")
-
-        # Greeting-first override keeps natural chat in conversation mode.
-        if re.match(r"^\s*(hi|hey|hello)\b", msg_lower):
-            category = IntentCategory.CONVERSATION
-            confidence = 0.85
-            extracted_task = message
-            intent = OpenClawIntent(
-                raw_message=message,
-                category=category,
-                confidence=confidence,
-                sender=sender,
-                channel=channel,
-                session_key=session_key,
-                is_authorized_commander=is_commander,
-                extracted_task=extracted_task,
-                target_domain=self.DOMAIN_ROUTES.get(category),
-                metadata=metadata,
-            )
-            logger.info(
-                "[OPENCLAW-DAE] Intent classified (greeting): category=%s confidence=%.2f "
-                "commander=%s domain=%s",
-                category.value, confidence, is_commander, intent.target_domain,
-            )
-            return intent
-
-        # Deterministic phrase contract: "connect WRE".
-        # This is an operator control phrase and should not drift into social/command.
-        if self._is_connect_wre_request(message):
-            category = IntentCategory.CONVERSATION
-            confidence = 0.95
-            extracted_task = message
-            intent = OpenClawIntent(
-                raw_message=message,
-                category=category,
-                confidence=confidence,
-                sender=sender,
-                channel=channel,
-                session_key=session_key,
-                is_authorized_commander=is_commander,
-                extracted_task=extracted_task,
-                target_domain=self.DOMAIN_ROUTES.get(category),
-                metadata={**metadata, "classification_method": "deterministic_connect_wre"},
-            )
-            logger.info(
-                "[OPENCLAW-DAE] Intent classified (connect_wre): category=%s confidence=%.2f "
-                "commander=%s domain=%s",
-                category.value,
-                confidence,
-                is_commander,
-                intent.target_domain,
-            )
-            return intent
-
-        # Deterministic conversation routing for identity/model-control utterances
-        # in direct interactive channels. This prevents drift into non-conversation
-        # domains (e.g., foundup/research) during live voice control.
-        if is_direct_channel and (
-            self._is_model_switch_request(message)
-            or self._is_connect_wre_request(message)
-            or self._is_identity_query(message)
-        ):
-            category = IntentCategory.CONVERSATION
-            confidence = 0.9
-            extracted_task = message
-            intent = OpenClawIntent(
-                raw_message=message,
-                category=category,
-                confidence=confidence,
-                sender=sender,
-                channel=channel,
-                session_key=session_key,
-                is_authorized_commander=is_commander,
-                extracted_task=extracted_task,
-                target_domain=self.DOMAIN_ROUTES.get(category),
-                metadata={**metadata, "classification_method": "deterministic_direct_conversation"},
-            )
-            logger.info(
-                "[OPENCLAW-DAE] Intent classified (deterministic direct): category=%s confidence=%.2f "
-                "commander=%s domain=%s",
-                category.value,
-                confidence,
-                is_commander,
-                intent.target_domain,
-            )
-            return intent
-
-        # Deterministic runtime DAE routing for broker-managed launch/status commands.
-        try:
-            from .dae_runtime_adapter import classify_dae_runtime_category
-
-            runtime_category = classify_dae_runtime_category(message)
-        except Exception:
-            runtime_category = None
-
-        if runtime_category:
-            category = (
-                IntentCategory.MONITOR
-                if runtime_category == "monitor"
-                else IntentCategory.SYSTEM
-            )
-            confidence = 0.95
-            extracted_task = message
-            intent = OpenClawIntent(
-                raw_message=message,
-                category=category,
-                confidence=confidence,
-                sender=sender,
-                channel=channel,
-                session_key=session_key,
-                is_authorized_commander=is_commander,
-                extracted_task=extracted_task,
-                target_domain=self.DOMAIN_ROUTES.get(category),
-                metadata={**metadata, "classification_method": "deterministic_dae_runtime"},
-            )
-            logger.info(
-                "[OPENCLAW-DAE] Intent classified (dae runtime): category=%s confidence=%.2f "
-                "commander=%s domain=%s",
-                category.value,
-                confidence,
-                is_commander,
-                intent.target_domain,
-            )
-            return intent
-
-        # Phase 1: Keyword pre-filter (fast, <1ms)
-        keyword_scores: Dict[IntentCategory, float] = {}
-        for cat, keywords in self.INTENT_KEYWORDS.items():
-            hits = sum(1 for kw in keywords if _has_keyword(msg_lower, kw))
-            if hits > 0:
-                keyword_scores[cat] = hits / len(keywords)
-
-        # Phase 2: Gemma hybrid validation (if enabled and available)
-        gemma_enabled = os.getenv("OPENCLAW_GEMMA_INTENT", "1") != "0"
-        gemma_result = None
-
-        if gemma_enabled and keyword_scores:
-            classifier = self._get_gemma_classifier()
-            if classifier is not None:
-                # Convert IntentCategory keys to string values for classifier
-                kw_scores_str = {
-                    cat.value: score for cat, score in keyword_scores.items()
-                }
-                gemma_result = classifier.classify(
-                    message=message,
-                    keyword_scores=kw_scores_str,
-                    default_category=IntentCategory.CONVERSATION.value,
-                )
-
-        # Resolve final category and confidence
-        if gemma_result is not None and gemma_result["method"] == "gemma_hybrid":
-            # Gemma hybrid result
-            category_value = gemma_result["category"]
-            confidence = gemma_result["confidence"]
-            # Map string value back to IntentCategory enum
-            category = IntentCategory(category_value)
-            metadata["classification_method"] = "gemma_hybrid"
-            metadata["gemma_scores"] = gemma_result.get("gemma_scores", {})
-            metadata["classification_latency_ms"] = gemma_result.get("latency_ms", 0)
-
-            # --- Conversation override for direct channels ---
-            # When talking via voice/local REPL, common words like "what",
-            # "how", "fix", "do" trigger QUERY/COMMAND but the user is just
-            # chatting. Override when keyword signal is weak and Gemma
-            # confidence is low.
-            if is_direct_channel:
-                cat_kw_score = keyword_scores.get(category, 0)
-                should_override = False
-
-                if category == IntentCategory.QUERY:
-                    # QUERY: override unless 2+ query keywords match
-                    should_override = cat_kw_score < 0.15 or confidence < 0.75
-
-                elif category == IntentCategory.COMMAND:
-                    # COMMAND: override for longer conversational sentences,
-                    # but preserve short imperative commands like "run tests"
-                    word_count = len(msg_lower.split())
-                    should_override = (
-                        cat_kw_score < 0.15
-                        and confidence < 0.75
-                        and word_count > 5  # Short commands are likely real
-                    )
-
-                elif category == IntentCategory.SOCIAL:
-                    # SOCIAL: almost always conversation on direct channels
-                    should_override = confidence < 0.75
-
-                if should_override:
-                    old_cat = category.value
-                    category = IntentCategory.CONVERSATION
-                    confidence = 0.6
-                    metadata["classification_method"] = "conversation_override"
-                    logger.info(
-                        "[OPENCLAW-DAE] Conversation override: %s kw=%.2f conf=%.2f -> CONVERSATION",
-                        old_cat, cat_kw_score, gemma_result["confidence"],
-                    )
-
-        elif not keyword_scores:
-            # No keyword signals -> default conversation
-            category = IntentCategory.CONVERSATION
-            confidence = 0.5
-            metadata["classification_method"] = "default"
-        else:
-            # Keyword-only (Gemma unavailable or disabled)
-            category = max(keyword_scores, key=keyword_scores.get)  # type: ignore[arg-type]
-            confidence = min(keyword_scores[category] * 2.0, 1.0)
-            metadata["classification_method"] = "keyword_only"
-
-            # Same conversation override for keyword-only on direct channels
-            if is_direct_channel and category == IntentCategory.QUERY:
-                query_kw_score = keyword_scores.get(IntentCategory.QUERY, 0)
-                if query_kw_score < 0.15:
-                    category = IntentCategory.CONVERSATION
-                    confidence = 0.6
-                    metadata["classification_method"] = "conversation_override"
-
-        # Extract task description (strip category keywords)
-        extracted_task = msg_lower
-        for kw in self.INTENT_KEYWORDS.get(category, []):
-            extracted_task = re.sub(
-                rf"\b{re.escape(kw.lower())}\b",
-                " ",
-                extracted_task,
-            ).strip()
-        extracted_task = " ".join(extracted_task.split())
-
-        intent = OpenClawIntent(
-            raw_message=message,
-            category=category,
-            confidence=confidence,
-            sender=sender,
-            channel=channel,
-            session_key=session_key,
-            is_authorized_commander=is_commander,
-            extracted_task=extracted_task or message,
-            target_domain=self.DOMAIN_ROUTES.get(category),
+        """Classify inbound message into an intent category."""
+        return _planner_classify_intent(
+            self,
+            message,
+            sender,
+            channel,
+            session_key,
             metadata=metadata,
         )
-
-        logger.info(
-            "[OPENCLAW-DAE] Intent classified: category=%s confidence=%.2f "
-            "method=%s commander=%s domain=%s",
-            category.value,
-            confidence,
-            metadata.get("classification_method", "unknown"),
-            is_commander,
-            intent.target_domain,
-        )
-        return intent
 
     # ------------------------------------------------------------------
     # Phase 2: WSP/WRE Preflight
     # ------------------------------------------------------------------
 
     def _wsp_preflight(self, intent: OpenClawIntent) -> bool:
-        """
-        WSP 50 Pre-Action Verification.
-
-        Checks:
-        1. Intent is valid and classified
-        2. Sender has appropriate authority for the intent category
-        3. WRE is available for execution categories
-        4. No WSP violations detected
-        """
-        # Rule 1: COMMAND and SYSTEM require authorized commander
-        if intent.category in (IntentCategory.COMMAND, IntentCategory.SYSTEM):
-            if not intent.is_authorized_commander:
-                logger.warning(
-                    "[OPENCLAW-DAE] [WSP-50] BLOCKED: %s intent from "
-                    "unauthorized sender %s",
-                    intent.category.value, intent.sender,
-                )
-                return False
-
-        # Rule 2: WRE availability check for execution-class intents
-        # Graceful degradation (WSP 15 P0 #5): Instead of hard-blocking
-        # when WRE is unavailable, let execution proceed to the route
-        # handler which provides actionable advisory fallback. Only
-        # SCHEDULE and SYSTEM hard-block (they have no advisory fallback).
-        is_runtime_dae_system = False
-        if intent.category == IntentCategory.SYSTEM:
-            try:
-                from .dae_runtime_adapter import is_dae_runtime_request
-
-                is_runtime_dae_system = is_dae_runtime_request(intent.raw_message)
-            except Exception:
-                is_runtime_dae_system = False
-
-        if intent.category in (IntentCategory.SCHEDULE, IntentCategory.SYSTEM):
-            if self.wre is None:
-                if intent.category == IntentCategory.SYSTEM and is_runtime_dae_system:
-                    logger.info(
-                        "[OPENCLAW-DAE] [WSP-50] DAE runtime SYSTEM request bypasses WRE dependency"
-                    )
-                    return True
-                logger.warning(
-                    "[OPENCLAW-DAE] [WSP-50] BLOCKED: WRE unavailable for %s",
-                    intent.category.value,
-                )
-                return False
-
-        if intent.category == IntentCategory.COMMAND and self.wre is None:
-            logger.info(
-                "[OPENCLAW-DAE] [WSP-50] WRE unavailable for COMMAND - "
-                "will use advisory fallback"
-            )
-            # Don't block: _execute_command handles advisory degradation
-
-        # Rule 3: Confidence threshold
-        if intent.confidence < 0.3:
-            logger.info(
-                "[OPENCLAW-DAE] [WSP-50] Low confidence (%.2f) - "
-                "downgrading to advisory",
-                intent.confidence,
-            )
-            # Don't block - just note for downstream
-
-        return True
+        """WSP 50 Pre-Action Verification."""
+        return _planner_wsp_preflight(self, intent)
 
     # ------------------------------------------------------------------
     # Phase 3: Permission Gate
@@ -1322,19 +923,7 @@ class OpenClawDAE:
 
         Returns list of extracted paths (may be empty).
         """
-        paths: List[str] = []
-        # Match paths with file extensions (at least 2-deep, ending in known ext)
-        path_pattern = re.compile(
-            r"""(?:["'])?"""                         # Optional opening quote
-            r"""((?:[\w.@-]+[/\\]){1,}[\w.@-]+"""   # dir/dir/.../file
-            r"""\.(?:py|md|json|yaml|yml|txt|toml|cfg|ini|sh|ps1))"""  # Known extensions
-            r"""(?:["'])?""",                        # Optional closing quote
-            re.IGNORECASE,
-        )
-        for match in path_pattern.finditer(message):
-            raw = match.group(1).replace("\\", "/")
-            paths.append(raw)
-        return paths
+        return _policy_extract_file_paths(message)
 
     def _is_source_modification(self, intent: OpenClawIntent) -> bool:
         """
@@ -1343,28 +932,7 @@ class OpenClawDAE:
         Returns True if the message contains source-modification keywords
         AND references file paths (or is an explicit code-change directive).
         """
-        msg_lower = intent.raw_message.lower()
-
-        # Check for source-modification keywords
-        has_source_verb = any(
-            re.search(rf"\b{kw}\b", msg_lower) for kw in self._SOURCE_KEYWORDS
-        )
-
-        # Check for file paths in the message
-        file_paths = self._extract_file_paths(intent.raw_message)
-
-        # Source modification = source verb + file paths, or explicit src patterns
-        if has_source_verb and file_paths:
-            return True
-
-        # Also catch: "edit the overseer module" (no explicit path but src intent)
-        if has_source_verb and any(
-            re.search(rf"\b{kw}\b", msg_lower)
-            for kw in ("module", "source", "src", "code", "implementation", "class", "function")
-        ):
-            return True
-
-        return False
+        return _policy_is_source_modification(self, intent)
 
     def _resolve_autonomy_tier(self, intent: OpenClawIntent) -> AutonomyTier:
         """
@@ -1375,30 +943,7 @@ class OpenClawDAE:
         Commander + COMMAND (non-source): DOCS_TESTS
         Commander + COMMAND (source modification): SOURCE (highest trust)
         """
-        if not intent.is_authorized_commander:
-            return AutonomyTier.ADVISORY
-
-        if intent.category in (IntentCategory.QUERY, IntentCategory.MONITOR,
-                                IntentCategory.CONVERSATION):
-            return AutonomyTier.METRICS
-
-        if intent.category == IntentCategory.SOCIAL:
-            return AutonomyTier.METRICS
-
-        if intent.category in (IntentCategory.COMMAND, IntentCategory.SYSTEM):
-            if self.permissions is None:
-                return AutonomyTier.ADVISORY  # Fail-closed: no permissions = read-only
-
-            # SOURCE tier if message targets source code modification
-            if self._is_source_modification(intent):
-                return AutonomyTier.SOURCE
-
-            return AutonomyTier.DOCS_TESTS
-
-        if intent.category == IntentCategory.SCHEDULE:
-            return AutonomyTier.METRICS
-
-        return AutonomyTier.ADVISORY
+        return _policy_resolve_autonomy_tier(self, intent)
 
     def _check_permission_gate(
         self, intent: OpenClawIntent, tier: AutonomyTier
@@ -1409,31 +954,7 @@ class OpenClawDAE:
         Uses AgentPermissionManager allowlist/forbidlist if available.
         Falls back to tier-based heuristic.
         """
-        # ADVISORY is always allowed (read-only)
-        if tier == AutonomyTier.ADVISORY:
-            return True
-
-        # Non-commanders can never exceed ADVISORY
-        if not intent.is_authorized_commander and tier != AutonomyTier.ADVISORY:
-            logger.warning(
-                "[OPENCLAW-DAE] [PERMISSION] Non-commander attempted %s tier",
-                tier.value,
-            )
-            return False
-
-        # For now: commanders pass all gates up to DOCS_TESTS
-        # SOURCE requires explicit permission check (WSP 95/71 fail-closed)
-        if tier == AutonomyTier.SOURCE:
-            granted, reason = self._check_source_permission(intent)
-            if not granted:
-                self._emit_permission_denied_event(intent, tier, reason)
-                return False
-
-        logger.info(
-            "[OPENCLAW-DAE] [PERMISSION] Granted tier=%s for sender=%s",
-            tier.value, intent.sender,
-        )
-        return True
+        return _policy_check_permission_gate(self, intent, tier)
 
     def _check_source_permission(self, intent: OpenClawIntent) -> tuple:
         """
@@ -1448,94 +969,13 @@ class OpenClawDAE:
 
         WSP 95/71: Fail-closed on manager missing/error.
         """
-        if self.permissions is None:
-            logger.warning(
-                "[OPENCLAW-DAE] [PERMISSION] SOURCE tier blocked: "
-                "permission manager not loaded (fail-closed)"
-            )
-            return False, "permission manager unavailable"
-
-        try:
-            # Extract file paths from the command for file-specific checks
-            file_paths = self._extract_file_paths(intent.raw_message)
-
-            if file_paths:
-                # File-specific permission check for each target path
-                for fpath in file_paths:
-                    result = self.permissions.check_permission(
-                        agent_id="openclaw",
-                        operation="write",
-                        file_path=fpath,
-                    )
-                    if not result.allowed:
-                        logger.warning(
-                            "[OPENCLAW-DAE] [PERMISSION] SOURCE denied for file %s: %s",
-                            fpath, result.reason,
-                        )
-                        return False, f"file '{fpath}': {result.reason}"
-
-                logger.info(
-                    "[OPENCLAW-DAE] [PERMISSION] SOURCE granted for files: %s",
-                    file_paths,
-                )
-                return True, f"granted for {len(file_paths)} file(s)"
-            else:
-                # No specific files detected — general write permission check
-                result = self.permissions.check_permission(
-                    agent_id="openclaw",
-                    operation="write",
-                    file_path=None,
-                )
-                if not result.allowed:
-                    logger.warning(
-                        "[OPENCLAW-DAE] [PERMISSION] SOURCE tier denied: %s",
-                        result.reason,
-                    )
-                    return False, result.reason
-                return True, "granted (general write access)"
-
-        except Exception as exc:
-            logger.error(
-                "[OPENCLAW-DAE] [PERMISSION] SOURCE check failed (fail-closed): %s",
-                exc,
-            )
-            return False, f"permission check error: {exc}"
+        return _policy_check_source_permission(self, intent)
 
     def _emit_permission_denied_event(
         self, intent: OpenClawIntent, tier: AutonomyTier, reason: str
     ) -> None:
         """Emit deduped permission_denied alert event."""
-        now = time.time()
-        dedupe_key = f"perm_denied|{intent.sender}|{tier.value}|{reason}"
-
-        # Check dedupe (60s window)
-        if not hasattr(self, "_permission_denied_history"):
-            self._permission_denied_history: Dict[str, float] = {}
-
-        last_seen = self._permission_denied_history.get(dedupe_key)
-        if last_seen and (now - last_seen) < 60:
-            return  # Suppress duplicate
-
-        self._permission_denied_history[dedupe_key] = now
-
-        # Compact expired entries
-        expired = [k for k, ts in self._permission_denied_history.items() if (now - ts) > 60]
-        for k in expired:
-            self._permission_denied_history.pop(k, None)
-
-        logger.warning(
-            "[DAEMON][OPENCLAW-PERMISSION] event=permission_denied tier=%s "
-            "sender=%s reason=%s",
-            tier.value, intent.sender, reason,
-        )
-
-        # Emit to AI Overseer correlator
-        self._emit_to_overseer(
-            event_type="permission_denied",
-            sender=intent.sender,
-            channel=intent.channel,
-            details={"tier": tier.value, "reason": reason},
-        )
+        _policy_emit_permission_denied_event(self, intent, tier, reason)
 
     def _emit_to_overseer(
         self,
@@ -1545,71 +985,15 @@ class OpenClawDAE:
         details: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Emit security event to AI Overseer correlator."""
-        try:
-            from modules.ai_intelligence.ai_overseer.src.ai_overseer import (
-                AIIntelligenceOverseer,
-            )
-            # Use lazy singleton to avoid circular imports and repeated init
-            if not hasattr(self, "_overseer") or self._overseer is None:
-                self._overseer = AIIntelligenceOverseer(self.repo_root)
-            self._overseer.ingest_security_event(
-                event_type=event_type,
-                sender=sender,
-                channel=channel,
-                details=details,
-            )
-        except Exception as exc:
-            logger.debug("[OPENCLAW-DAE] Failed to emit to overseer: %s", exc)
+        _policy_emit_to_overseer(self, event_type, sender, channel, details=details)
 
     def _check_containment(self, sender: str, channel: str) -> Optional[Dict[str, Any]]:
         """Check if sender or channel is under containment."""
-        try:
-            from modules.ai_intelligence.ai_overseer.src.ai_overseer import (
-                AIIntelligenceOverseer,
-            )
-            if not hasattr(self, "_overseer") or self._overseer is None:
-                self._overseer = AIIntelligenceOverseer(self.repo_root)
-            return self._overseer.check_containment(sender, channel)
-        except Exception as exc:
-            logger.debug("[OPENCLAW-DAE] Containment check failed: %s", exc)
-            return None
+        return _policy_check_containment(self, sender, channel)
 
     def _ensure_skill_safety(self, force: bool = False) -> bool:
         """Run cached Cisco skill scan for OpenClaw workspace skills."""
-        now = time.time()
-        if (
-            not force
-            and not self._skill_scan_always
-            and self._skill_scan_checked_at > 0
-            and (now - self._skill_scan_checked_at) < self._skill_scan_ttl_sec
-        ):
-            return self._skill_scan_ok
-
-        try:
-            from .skill_safety_guard import run_skill_scan
-        except Exception as exc:
-            self._skill_scan_checked_at = now
-            self._skill_scan_ok = not self._skill_scan_required
-            self._skill_scan_message = f"skill safety guard unavailable: {exc}"
-            return self._skill_scan_ok
-
-        skills_dir = self.repo_root / "modules/communication/moltbot_bridge/workspace/skills"
-        report_dir = self.repo_root / "modules/communication/moltbot_bridge/reports"
-        result = run_skill_scan(
-            skills_dir=skills_dir,
-            max_severity=self._skill_scan_max_severity,
-            report_dir=report_dir,
-        )
-        self._skill_scan_checked_at = now
-
-        if not result.available:
-            self._skill_scan_ok = not self._skill_scan_required
-            self._skill_scan_message = result.message
-            return self._skill_scan_ok
-
-        self._skill_scan_ok = result.passed or (not self._skill_scan_enforced)
-        self._skill_scan_message = result.message
-        return self._skill_scan_ok
+        return _policy_ensure_skill_safety(self, force=force)
 
     # ------------------------------------------------------------------
     # Phase 4: Plan Execution
@@ -1618,538 +1002,46 @@ class OpenClawDAE:
     def _plan_execution(
         self, intent: OpenClawIntent, tier: AutonomyTier
     ) -> ExecutionPlan:
-        """
-        Build execution plan: which route, what steps, estimated cost.
-
-        This is the Principal role (WSP 73): decompose into actionable steps.
-        """
-        route = intent.target_domain or "digital_twin"
-
-        steps: List[Dict[str, Any]] = []
-
-        if intent.category == IntentCategory.QUERY:
-            steps = [
-                {"action": "holo_search", "input": intent.extracted_task},
-                {"action": "format_response", "style": "informative"},
-            ]
-            est_tokens = 100
-
-        elif intent.category == IntentCategory.COMMAND:
-            steps = [
-                {"action": "wre_preflight", "task": intent.extracted_task},
-                {"action": "wre_execute", "task": intent.extracted_task},
-                {"action": "validate_output"},
-                {"action": "log_outcome"},
-            ]
-            est_tokens = 200
-
-        elif intent.category == IntentCategory.MONITOR:
-            steps = [
-                {"action": "overseer_status"},
-                {"action": "format_response", "style": "status_report"},
-            ]
-            est_tokens = 80
-
-        elif intent.category == IntentCategory.SCHEDULE:
-            steps = [
-                {"action": "parse_schedule", "input": intent.extracted_task},
-                {"action": "check_calendar_conflicts"},
-                {"action": "schedule_or_queue"},
-                {"action": "confirm_response"},
-            ]
-            est_tokens = 150
-
-        elif intent.category == IntentCategory.SOCIAL:
-            steps = [
-                {"action": "route_to_communication_dae",
-                 "channel": intent.channel},
-                {"action": "generate_engagement"},
-            ]
-            est_tokens = 120
-
-        elif intent.category == IntentCategory.SYSTEM:
-            steps = [
-                {"action": "verify_commander_authority"},
-                {"action": "execute_system_command",
-                 "task": intent.extracted_task},
-                {"action": "report_outcome"},
-            ]
-            est_tokens = 180
-
-        elif intent.category == IntentCategory.RESEARCH:
-            steps = [
-                {"action": "classify_research_sub_intent",
-                 "input": intent.extracted_task},
-                {"action": "route_to_pqn_research_adapter"},
-                {"action": "anti_contamination_gate"},
-            ]
-            est_tokens = 150
-
-        else:  # CONVERSATION
-            steps = [
-                {"action": "digital_twin_response",
-                 "context": intent.raw_message},
-            ]
-            est_tokens = 60
-
-        plan = ExecutionPlan(
-            intent=intent,
-            route=route,
-            permission_level=tier,
-            wsp_preflight_passed=True,
-            steps=steps,
-            estimated_tokens=est_tokens,
-        )
-
-        logger.info(
-            "[OPENCLAW-DAE] Plan: route=%s steps=%d tokens~%d tier=%s",
-            route, len(steps), est_tokens, tier.value,
-        )
-        return plan
+        """Build execution plan: route, steps, estimated cost."""
+        return _planner_plan_execution(self, intent, tier)
 
     # ------------------------------------------------------------------
     # Phase 5: Execute via WRE
     # ------------------------------------------------------------------
 
     async def _execute_plan(self, plan: ExecutionPlan) -> str:
-        """
-        Execute the plan by routing to the appropriate subsystem.
-
-        This is where Associates (domain DAEs) do the actual work.
-        """
-        intent = plan.intent
-        route = plan.route
-
-        # ---- QUERY: HoloIndex search ----
-        if route == "holo_index":
-            return await self._execute_query(intent)
-
-        # ---- COMMAND: WRE orchestrator ----
-        if route == "wre_orchestrator":
-            return await self._execute_command(intent)
-
-        # ---- MONITOR: AI Overseer status ----
-        if route == "ai_overseer":
-            return self._execute_monitor(intent)
-
-        # ---- SCHEDULE: Shorts scheduler ----
-        if route == "youtube_shorts_scheduler":
-            return await self._execute_schedule(intent)
-
-        # ---- SOCIAL: Communication DAEs ----
-        if route == "communication":
-            return await self._execute_social(intent)
-
-        # ---- SYSTEM: Infrastructure ----
-        if route == "infrastructure":
-            return self._execute_system(intent)
-
-        # ---- AUTOMATION: AutoModeratorBridge (YouTube automation) ----
-        if route == "auto_moderator_bridge":
-            return await self._execute_automation(intent)
-
-        # ---- FOUNDUP: FAM Agent Market ----
-        if route == "fam_adapter":
-            return self._execute_foundup(intent)
-
-        # ---- RESEARCH: PQN Detection, Duism, Oracle Teaching ----
-        if route == "pqn_research_adapter":
-            return self._execute_research(intent)
-
-        # ---- CONVERSATION -> deterministic social control bridge ----
-        social_control = await self._try_conversation_social_control(intent)
-        if social_control:
-            return social_control
-
-        # ---- CONVERSATION: Digital Twin fallback ----
-        return self._execute_conversation(intent)
+        """Execute the plan by routing to the appropriate subsystem."""
+        return await _routes_execute_plan(self, plan)
 
     async def _execute_query(self, intent: OpenClawIntent) -> str:
         """Route QUERY to HoloIndex semantic search."""
-        if self._is_token_usage_query(intent.raw_message):
-            self._mark_conversation_engine("token_usage", "deterministic_query_route")
-            return self._build_token_usage_report()
-
-        if self._is_identity_query(intent.raw_message):
-            if self._wants_full_identity_card(intent.raw_message):
-                self._mark_conversation_engine("identity_card", "deterministic_query_route")
-                return self._build_identity_card()
-            self._mark_conversation_engine("identity_compact", "deterministic_query_route")
-            if self._is_compact_identity_query(intent.raw_message):
-                return self._build_identity_compact_runtime()
-            return self._build_identity_compact()
-
-        try:
-            # Try bundle-json fastpath for structured retrieval
-            from holo_index.core import HoloIndex
-
-            holo = HoloIndex()
-            results = holo.search(
-                intent.extracted_task or intent.raw_message,
-                limit=3,
-            )
-
-            code_hits = results.get("code", [])
-            wsp_hits = results.get("wsps", [])
-
-            if not code_hits and not wsp_hits:
-                return (
-                    f"No results found for: {intent.extracted_task}\n\n"
-                    "Try rephrasing or use more specific terms."
-                )
-
-            # Format response
-            parts = []
-            if code_hits:
-                parts.append("**Code matches:**")
-                for hit in code_hits[:3]:
-                    path = hit.get("file", "unknown")
-                    snippet = hit.get("content", "")[:200]
-                    parts.append(f"  - `{path}`: {snippet}")
-
-            if wsp_hits:
-                parts.append("\n**WSP guidance:**")
-                for hit in wsp_hits[:2]:
-                    title = hit.get("title", "WSP")
-                    content = hit.get("content", "")[:200]
-                    parts.append(f"  - **{title}**: {content}")
-
-            return "\n".join(parts)
-
-        except ImportError:
-            logger.warning("[OPENCLAW-DAE] HoloIndex not available for query")
-            return (
-                f"Received your query: {intent.raw_message[:100]}\n"
-                "HoloIndex is currently offline. Try again shortly."
-            )
-        except Exception as exc:
-            logger.error("[OPENCLAW-DAE] Query execution error: %s", exc)
-            return f"Error processing query: {exc}"
+        return await _routes_execute_query(self, intent)
 
     async def _execute_command(self, intent: OpenClawIntent) -> str:
-        """
-        Route COMMAND to WRE orchestrator with file-specific permission gate.
+        """Route COMMAND to WRE orchestrator with file-specific permission gate."""
+        return await _routes_execute_command(self, intent)
 
-        WSP 15 P0 #2: SOURCE tier code execution authority gate.
-        Before routing to WRE, check file-specific permissions if the
-        command targets source modification.
-        """
-        # Source modification gate: check file-level permissions before execution
-        if self._is_source_modification(intent):
-            file_paths = self._extract_file_paths(intent.raw_message)
-            if file_paths and self.permissions:
-                for fpath in file_paths:
-                    result = self.permissions.check_permission(
-                        agent_id="openclaw",
-                        operation="write",
-                        file_path=fpath,
-                    )
-                    if not result.allowed:
-                        logger.warning(
-                            "[OPENCLAW-DAE] [COMMAND] Execution blocked: %s denied for %s",
-                            result.reason, fpath,
-                        )
-                        return (
-                            f"**Permission Denied** (SOURCE tier gate)\n\n"
-                            f"Cannot modify `{fpath}`: {result.reason}\n\n"
-                            f"File is protected by the allowlist/forbidlist policy. "
-                            f"Contact @012 to update permissions."
-                        )
-
-        # Graceful degradation: deterministic advisory fallback when WRE unavailable
-        if self.wre is None:
-            logger.warning(
-                "[DAEMON][OPENCLAW-FALLBACK] event=command_fallback sender=%s reason=wre_unavailable",
-                intent.sender,
-            )
-            self._emit_to_overseer(
-                event_type="command_fallback",
-                sender=intent.sender,
-                channel=intent.channel,
-                details={"reason": "wre_unavailable", "task": intent.extracted_task},
-            )
-            return self._command_advisory_fallback(intent)
-
-        try:
-            result = self.wre.execute({
-                "type": "orchestration",
-                "task": intent.extracted_task,
-                "source": "openclaw_dae",
-                "sender": intent.sender,
-                "channel": intent.channel,
-                "target_files": self._extract_file_paths(intent.raw_message),
-            })
-            return f"Command executed via WRE:\n{result}"
-        except Exception as exc:
-            logger.error("[OPENCLAW-DAE] Command execution error: %s", exc)
-            logger.warning(
-                "[DAEMON][OPENCLAW-FALLBACK] event=command_fallback sender=%s reason=wre_error",
-                intent.sender,
-            )
-            self._emit_to_overseer(
-                event_type="command_fallback",
-                sender=intent.sender,
-                channel=intent.channel,
-                details={"reason": "wre_error", "error": str(exc)[:200]},
-            )
-            # Graceful degradation on error: advisory fallback
-            return self._command_advisory_fallback(intent, error=str(exc))
+    async def _try_execute_follow_wsp(self, intent: OpenClawIntent) -> Optional[str]:
+        """Deterministic WSP 97 path for the canonical operator: "follow wsp"."""
+        return await _routes_try_execute_follow_wsp(self, intent)
 
     def _command_advisory_fallback(
         self, intent: OpenClawIntent, error: Optional[str] = None
     ) -> str:
-        """
-        Deterministic advisory fallback when WRE is unavailable.
-
-        Returns actionable guidance rather than silent failure.
-        """
-        task = intent.extracted_task or intent.raw_message
-
-        parts = [
-            "**Advisory Mode** (WRE unavailable)",
-            "",
-            f"Command recognized: `{task[:100]}`",
-            "",
-            "I cannot execute this command automatically right now.",
-            "Here are your options:",
-            "",
-            "1. **CLI execution**: Run manually via the main menu (`python main.py`)",
-            "2. **Retry later**: WRE may become available after system restart",
-            "3. **Query mode**: Ask me to explain what this command does instead",
-        ]
-
-        if error:
-            parts.append("")
-            parts.append(f"**Error detail**: {error[:200]}")
-
-        logger.info(
-            "[OPENCLAW-DAE] [COMMAND] Advisory fallback returned for: %s",
-            task[:50],
-        )
-        return "\n".join(parts)
+        """Deterministic advisory fallback when WRE is unavailable."""
+        return _routes_command_advisory_fallback(self, intent, error=error)
 
     def _execute_monitor(self, intent: OpenClawIntent) -> str:
         """Route MONITOR to AI Overseer status."""
-        try:
-            from .dae_runtime_adapter import is_dae_runtime_request, handle_dae_runtime_intent
-
-            if is_dae_runtime_request(intent.raw_message):
-                response = handle_dae_runtime_intent(
-                    intent.raw_message,
-                    intent.sender,
-                    allow_mutation=False,
-                )
-                if response:
-                    return response
-        except Exception as exc:
-            logger.warning("[OPENCLAW-DAE] DAE runtime monitor adapter unavailable: %s", exc)
-
-        parts = ["**System Status:**"]
-
-        # WRE status
-        if self.wre:
-            parts.append(f"  - WRE: ONLINE (state={self.wre.state})")
-            if self.wre.skills_loader:
-                parts.append("  - Skills Loader: ACTIVE")
-            if self.wre.libido_monitor:
-                parts.append("  - Libido Monitor: ACTIVE")
-        else:
-            parts.append("  - WRE: OFFLINE")
-
-        # AI Overseer
-        if self.overseer:
-            parts.append("  - AI Overseer: LOADED")
-        else:
-            parts.append("  - AI Overseer: NOT LOADED")
-
-        identity = self.get_identity_snapshot(include_runtime_probe=True)
-        parts.append(f"  - OpenClaw Conversation Backend: {identity['backend']}")
-        parts.append(
-            "  - Runtime Profile: "
-            f"{identity.get('runtime_profile', 'openclaw')}"
-        )
-        parts.append(
-            "  - OpenClaw Key Isolation: "
-            f"{identity['key_isolation']} "
-            f"(external_llm={'ON' if self._allow_external_llm else 'OFF'})"
-        )
-        parts.append(
-            "  - IronClaw Strict Mode: "
-            f"{identity['ironclaw_strict']} "
-            f"(allow_local_fallback={identity['ironclaw_allow_local_fallback']})"
-        )
-        parts.append(
-            "  - 0102 Taxonomy: "
-            f"genus={identity['genus']} "
-            f"lineage={identity['lineage']} "
-            f"model_family={identity['model_family']} "
-            f"model_name={identity['model_name']}"
-        )
-        parts.append(
-            "  - Conversation Model Target: "
-            f"{identity.get('conversation_model_target', 'local/qwen-coder-7b')} "
-            f"(preferred_external="
-            f"{identity.get('preferred_external_provider', 'none')}/"
-            f"{identity.get('preferred_external_model', 'none')})"
-        )
-        parts.append(
-            "  - Preferred External Status: "
-            f"{identity.get('preferred_external_status', 'not_selected')} "
-            f"({identity.get('preferred_external_status_detail', 'none')}, "
-            f"age={identity.get('preferred_external_status_age', 'never')})"
-        )
-        parts.append(f"  - Protocol Anchor: {identity['protocol_anchor']}")
-        parts.append(
-            "  - WSP_00 Boot Prompt: "
-            f"{identity['wsp00_boot']} "
-            f"(mode={identity['wsp00_boot_mode']}, file_override={identity['wsp00_file_override']})"
-        )
-        parts.append(
-            "  - Platform Context Pack: "
-            f"{identity.get('platform_context', 'OFF')} "
-            f"(sources={identity.get('platform_context_sources', '0')}, "
-            f"loaded={identity.get('platform_context_loaded_ago', 'never')})"
-        )
-        parts.append(
-            f"  - Last Conversation Engine: {identity['last_engine']} ({identity['last_engine_detail']})"
-        )
-        parts.append(
-            "  - Previous Conversation Engine: "
-            f"{identity.get('previous_engine', 'none')} "
-            f"({identity.get('previous_engine_detail', 'none')})"
-        )
-        parts.append(
-            "  - Token Usage (Last Turn): "
-            f"prompt={identity.get('token_last_prompt_tokens', '0')} "
-            f"completion={identity.get('token_last_completion_tokens', '0')} "
-            f"total={identity.get('token_last_total_tokens', '0')} "
-            f"engine={identity.get('token_last_engine', 'none')} "
-            f"provider={identity.get('token_last_provider', 'none')} "
-            f"source={identity.get('token_last_source', 'none')} "
-            f"cost_estimate_usd={identity.get('token_last_cost_estimate_usd', '0.000000')} "
-            f"age={identity.get('token_last_age', 'never')}"
-        )
-        parts.append(
-            "  - Token Usage (Session): "
-            f"turns={identity.get('token_session_turns', '0')} "
-            f"prompt={identity.get('token_session_prompt_tokens', '0')} "
-            f"completion={identity.get('token_session_completion_tokens', '0')} "
-            f"total={identity.get('token_session_total_tokens', '0')} "
-            f"cost_estimate_usd={identity.get('token_session_cost_estimate_usd', '0.000000')}"
-        )
-        parts.append(
-            "  - Local Code Model: "
-            f"{identity['local_code_model_path']} "
-            f"({identity['local_code_model_state']}, source={identity['local_code_model_source']})"
-        )
-        if self._conversation_backend == "ironclaw" or _env_truthy("OPENCLAW_ALLOW_IRONCLAW_FALLBACK", "0"):
-            parts.append(
-                "  - IronClaw Runtime: "
-                f"{identity['ironclaw_runtime_healthy']} ({identity['ironclaw_runtime_detail']}) "
-                f"configured_model={identity['ironclaw_runtime_model']} "
-                f"visible_models={identity['ironclaw_runtime_models']}"
-            )
-
-        # OpenClaw Security Status
-        import time as _time
-        parts.append("")
-        parts.append("**Security Status:**")
-        status = "PASS" if self._skill_scan_ok else "FAIL"
-        required = "required" if self._skill_scan_required else "optional"
-        enforced = "enforced" if self._skill_scan_enforced else "warn-only"
-        checked_ago = (
-            f"{int(_time.time() - self._skill_scan_checked_at)}s ago"
-            if self._skill_scan_checked_at > 0
-            else "never"
-        )
-        parts.append(f"  - Skill Safety Gate: {status} ({required}, {enforced})")
-        parts.append(f"  - Last Check: {checked_ago}")
-        parts.append(f"  - Message: {self._skill_scan_message}")
-
-        # Permissions
-        if self.permissions:
-            parts.append("  - Permission Manager: ACTIVE")
-        else:
-            parts.append("  - Permission Manager: NOT LOADED")
-
-        # OpenClaw DAE state
-        parts.append(f"  - OpenClaw DAE: state={self.state} "
-                     f"coherence={self.coherence}")
-
-        return "\n".join(parts)
+        return _routes_execute_monitor(self, intent)
 
     async def _execute_schedule(self, intent: OpenClawIntent) -> str:
         """Route SCHEDULE intent to explicit YouTube action adapter or fallback."""
-        try:
-            from .youtube_automation_adapter import handle_youtube_automation_intent
-
-            yt_response = await handle_youtube_automation_intent(
-                intent.raw_message,
-                intent.sender,
-            )
-            if yt_response:
-                return yt_response
-        except Exception as exc:
-            logger.warning("[OPENCLAW-DAE] YouTube automation adapter unavailable: %s", exc)
-
-        return (
-            f"Schedule request received: {intent.extracted_task}\n"
-            "Routing to YouTube Shorts Scheduler... "
-            "(use explicit command for execution: "
-            "`youtube action scheduling channel=move2japan max_videos=3 dry_run=true`)"
-        )
+        return await _routes_execute_schedule(self, intent)
 
     async def _execute_social(self, intent: OpenClawIntent) -> str:
-        """Route SOCIAL intent to communication DAEs and explicit social adapters."""
-        try:
-            from .social_campaign_adapter import handle_social_campaign_intent
-
-            campaign_response = await handle_social_campaign_intent(
-                intent.raw_message,
-                intent.sender,
-            )
-            if campaign_response:
-                self._record_social_response("social_campaign", campaign_response)
-                return campaign_response
-        except Exception as exc:
-            logger.warning("[OPENCLAW-DAE] Social campaign adapter unavailable: %s", exc)
-
-        try:
-            from .linkedin_social_adapter import handle_linkedin_social_intent
-
-            linked_in_response = await handle_linkedin_social_intent(
-                intent.raw_message,
-                intent.sender,
-            )
-            if linked_in_response:
-                self._record_social_response("linkedin", linked_in_response)
-                return linked_in_response
-        except Exception as exc:
-            logger.warning("[OPENCLAW-DAE] LinkedIn social adapter unavailable: %s", exc)
-
-        try:
-            from .x_social_adapter import handle_x_social_intent
-
-            x_response = await handle_x_social_intent(
-                intent.raw_message,
-                intent.sender,
-            )
-            if x_response:
-                self._record_social_response("x", x_response)
-                return x_response
-        except Exception as exc:
-            logger.warning("[OPENCLAW-DAE] X social adapter unavailable: %s", exc)
-
-        return (
-            f"Social engagement request on {intent.channel}: "
-            f"{intent.extracted_task}\n"
-            "Routing to communication layer... "
-            "(Digital Twin engagement via livechat/video_comments)\n"
-            "Tips: "
-            "`linkedin action <action> key=value`, "
-            "`x action <action> key=value`, or "
-            "`social campaign <campaign_name> key=value`."
-        )
+        """Route SOCIAL intent through OpenClaw-local social controller."""
+        return await _social_execute(self, intent)
 
     async def _try_conversation_social_control(self, intent: OpenClawIntent) -> Optional[str]:
         """
@@ -2158,115 +1050,23 @@ class OpenClawDAE:
         This keeps operator phrasing ergonomic while still routing through the
         same deterministic social adapters.
         """
-        try:
-            from .linkedin_social_adapter import handle_linkedin_social_intent
-
-            linkedin_response = await handle_linkedin_social_intent(
-                intent.raw_message,
-                intent.sender,
-            )
-            if linkedin_response:
-                self._record_social_response("linkedin", linkedin_response)
-                self._mark_conversation_engine(
-                    "linkedin_social_control",
-                    "deterministic_conversation_route",
-                )
-                return linkedin_response
-        except Exception as exc:
-            logger.warning("[OPENCLAW-DAE] LinkedIn conversation control unavailable: %s", exc)
-        return None
+        return await _social_try_conversation_control(self, intent)
 
     def _execute_system(self, intent: OpenClawIntent) -> str:
         """Route SYSTEM intent (requires commander authority)."""
-        if not intent.is_authorized_commander:
-            return (
-                "System commands require @012 authorization. "
-                "Your request has been logged."
-            )
-        try:
-            from .dae_runtime_adapter import is_dae_runtime_request, handle_dae_runtime_intent
-
-            if is_dae_runtime_request(intent.raw_message):
-                response = handle_dae_runtime_intent(
-                    intent.raw_message,
-                    intent.sender,
-                    allow_mutation=True,
-                )
-                if response:
-                    return response
-        except Exception as exc:
-            logger.warning("[OPENCLAW-DAE] DAE runtime system adapter unavailable: %s", exc)
-        return (
-            f"System command received: {intent.extracted_task}\n"
-            "Infrastructure routing in progress..."
-        )
+        return _routes_execute_system(self, intent)
 
     async def _execute_automation(self, intent: OpenClawIntent) -> str:
         """Route AUTOMATION intent to explicit YouTube adapter or AutoModeratorBridge."""
-        try:
-            from .youtube_automation_adapter import handle_youtube_automation_intent
-
-            yt_response = await handle_youtube_automation_intent(
-                intent.raw_message,
-                intent.sender,
-            )
-            if yt_response:
-                return yt_response
-        except Exception as exc:
-            logger.warning("[OPENCLAW-DAE] YouTube automation adapter unavailable: %s", exc)
-
-        try:
-            from .auto_moderator_bridge import handle_automation_intent
-            return handle_automation_intent(intent.raw_message, intent.sender)
-        except ImportError as exc:
-            logger.warning("[OPENCLAW-DAE] AutoModeratorBridge not available: %s", exc)
-            return (
-                "Automation bridge not available. "
-                "Check that auto_moderator_bridge.py exists."
-            )
-        except Exception as exc:
-            logger.error("[OPENCLAW-DAE] Automation execution error: %s", exc)
-            return f"Automation error: {exc}"
+        return await _routes_execute_automation(self, intent)
 
     def _execute_foundup(self, intent: OpenClawIntent) -> str:
-        """Route FOUNDUP intent to FAM Adapter.
-
-        FAM adapter handles local Qwen inference through centralized
-        LOCAL_MODEL_* routing (with optional API fallback depending on policy).
-        """
-        try:
-            from .fam_adapter import handle_fam_intent
-            return handle_fam_intent(intent.raw_message, intent.sender)
-
-        except ImportError as exc:
-            logger.warning("[OPENCLAW-DAE] FAM Adapter not available: %s", exc)
-            return (
-                "FoundUps Agent Market not available. "
-                "Check that fam_adapter.py exists."
-            )
-        except Exception as exc:
-            logger.error("[OPENCLAW-DAE] FAM execution error: %s", exc)
-            return f"FAM error: {exc}"
+        """Route FOUNDUP intent to FAM Adapter."""
+        return _routes_execute_foundup(self, intent)
 
     def _execute_research(self, intent: OpenClawIntent) -> str:
-        """Route RESEARCH intent to PQN Research Adapter.
-
-        Handles PQN detection, Duism teaching, Oracle distribution,
-        and PQN@home coordination. Uses oracle_pqn_distributor skillz.
-        """
-        try:
-            from .pqn_research_adapter import handle_pqn_research_intent
-            return handle_pqn_research_intent(intent.raw_message, intent.sender)
-
-        except ImportError as exc:
-            logger.warning("[OPENCLAW-DAE] PQN Research Adapter not available: %s", exc)
-            return (
-                "PQN Research module not available. "
-                "Check that pqn_research_adapter.py exists."
-            )
-        except Exception as exc:
-            logger.error("[OPENCLAW-DAE] Research execution error: %s", exc)
-            return f"Research error: {exc}"
+        """Route RESEARCH intent to PQN Research Adapter."""
+        return _routes_execute_research(self, intent)
 
     @staticmethod
     def _trim_self_dialogue(text: str) -> str:
@@ -2328,83 +1128,35 @@ class OpenClawDAE:
 
     def _mark_conversation_engine(self, engine: str, detail: str = "none") -> None:
         """Record which conversation runtime produced the latest reply."""
-        self._previous_conversation_engine = self._last_conversation_engine
-        self._previous_conversation_detail = self._last_conversation_detail
-        self._last_conversation_engine = engine
-        self._last_conversation_detail = detail or "none"
+        _turn_mark_conversation_engine(self, engine, detail=detail)
 
     def _record_social_response(self, source: str, response_text: str) -> None:
         """Capture the latest social adapter response for daemon diagnostics."""
-        response_text = str(response_text or "").strip()
-        payload: Dict[str, Any] = {}
-        json_start = response_text.find("{")
-        if json_start != -1:
-            try:
-                payload = json.loads(response_text[json_start:])
-            except Exception:
-                payload = {}
+        _ledger_record_social_response(self, source, response_text)
 
-        skill = "none"
-        skill_match = re.search(r"Skill executed:\s*([^\r\n]+)", response_text)
-        if skill_match:
-            skill = skill_match.group(1).strip() or "none"
-        elif payload.get("skill"):
-            skill = str(payload.get("skill")).strip() or "none"
-
-        action = str(payload.get("action", "")).strip() or "none"
-        success = payload.get("success")
-
-        preview = ""
-        if isinstance(payload.get("reply_text"), str) and payload.get("reply_text"):
-            preview = str(payload.get("reply_text"))
-        elif isinstance(payload.get("draft"), dict) and payload["draft"].get("reply_text"):
-            preview = str(payload["draft"]["reply_text"])
-        elif isinstance(payload.get("planned_replies"), list) and payload["planned_replies"]:
-            first_plan = payload["planned_replies"][0] or {}
-            preview = str(first_plan.get("reply_text", "") or "")
-        if not preview:
-            preview = " ".join(response_text.split())
-        preview = (" ".join(preview.split())[:160] or "none")
-
-        self._last_social_response_source = (source or "unknown").strip() or "unknown"
-        self._last_social_response_action = action
-        self._last_social_response_skill = skill
-        self._last_social_response_success = (
-            "true" if success is True else "false" if success is False else "unknown"
-        )
-        self._last_social_response_preview = preview
-        self._last_social_response_at = time.time()
-
-        logger.info(
-            "[OPENCLAW-DAE] Social response captured | source=%s action=%s skill=%s success=%s",
-            self._last_social_response_source,
-            self._last_social_response_action,
-            self._last_social_response_skill,
-            self._last_social_response_success,
-        )
+    def _report_daemon_action(
+        self,
+        action_type: str,
+        target: str = "",
+        result: str = "",
+        **details: Any,
+    ) -> None:
+        """Emit structured OpenClaw actions to the central DAEmon when available."""
+        _ledger_report_daemon_action(self, action_type, target, result, **details)
 
     def _mark_preferred_external_status(self, status: str, detail: str = "none") -> None:
         """Record preferred external model routing status for diagnostics."""
-        self._preferred_external_last_status = (status or "unknown").strip().lower() or "unknown"
-        self._preferred_external_last_status_detail = (detail or "none").strip() or "none"
-        self._preferred_external_last_status_at = time.time()
+        _turn_mark_preferred_external_status(self, status, detail=detail)
 
     @staticmethod
     def _safe_int(value: Any) -> Optional[int]:
         """Safely coerce telemetry fields to non-negative ints."""
-        try:
-            parsed = int(value)
-            return parsed if parsed >= 0 else None
-        except (TypeError, ValueError):
-            return None
+        return _turn_safe_int(value)
 
     @staticmethod
     def _estimate_token_count(text: str) -> int:
         """Lightweight token estimate (~4 chars/token) for providers without usage data."""
-        clean = (text or "").strip()
-        if not clean:
-            return 0
-        return max(1, int(round(len(clean) / 4.0)))
+        return _turn_estimate_token_count(text)
 
     def _record_token_usage(
         self,
@@ -2423,270 +1175,56 @@ class OpenClawDAE:
 
         Token values are estimated unless provider usage is available.
         """
-        usage = usage or {}
-
-        prompt_tokens = self._safe_int(usage.get("prompt_tokens"))
-        completion_tokens = self._safe_int(usage.get("completion_tokens"))
-        total_tokens = self._safe_int(usage.get("total_tokens"))
-
-        if prompt_tokens is None:
-            prompt_tokens = self._estimate_token_count(prompt_text)
-        if completion_tokens is None:
-            completion_tokens = self._estimate_token_count(completion_text)
-        if total_tokens is None:
-            total_tokens = prompt_tokens + completion_tokens
-
-        cost = 0.0
-        if cost_estimate_usd is not None:
-            try:
-                cost = max(0.0, float(cost_estimate_usd))
-            except (TypeError, ValueError):
-                cost = 0.0
-
-        resolved_source = (source or "estimated").strip().lower() or "estimated"
-        self._token_usage_last_prompt_tokens = prompt_tokens
-        self._token_usage_last_completion_tokens = completion_tokens
-        self._token_usage_last_total_tokens = total_tokens
-        self._token_usage_last_engine = (engine or "unknown").strip() or "unknown"
-        self._token_usage_last_provider = (provider or "unknown").strip() or "unknown"
-        self._token_usage_last_model = (model or "unknown").strip() or "unknown"
-        self._token_usage_last_source = resolved_source
-        self._token_usage_last_cost_estimate_usd = cost
-        self._token_usage_last_at = time.time()
-
-        self._token_usage_session_turns += 1
-        self._token_usage_session_prompt_tokens += prompt_tokens
-        self._token_usage_session_completion_tokens += completion_tokens
-        self._token_usage_session_total_tokens += total_tokens
-        self._token_usage_session_cost_estimate_usd += cost
+        _turn_record_token_usage(
+            self,
+            prompt_text=prompt_text,
+            completion_text=completion_text,
+            engine=engine,
+            provider=provider,
+            model=model,
+            usage=usage,
+            source=source,
+            cost_estimate_usd=cost_estimate_usd,
+        )
 
     def _get_token_usage_snapshot(self) -> Dict[str, Any]:
         """Return token telemetry snapshot for identity/monitor/status responses."""
-        if self._token_usage_last_at > 0:
-            age = f"{int(max(0.0, time.time() - self._token_usage_last_at))}s"
-        else:
-            age = "never"
-
-        return {
-            "last_prompt_tokens": self._token_usage_last_prompt_tokens,
-            "last_completion_tokens": self._token_usage_last_completion_tokens,
-            "last_total_tokens": self._token_usage_last_total_tokens,
-            "last_engine": self._token_usage_last_engine,
-            "last_provider": self._token_usage_last_provider,
-            "last_model": self._token_usage_last_model,
-            "last_source": self._token_usage_last_source,
-            "last_cost_estimate_usd": self._token_usage_last_cost_estimate_usd,
-            "last_age": age,
-            "session_turns": self._token_usage_session_turns,
-            "session_prompt_tokens": self._token_usage_session_prompt_tokens,
-            "session_completion_tokens": self._token_usage_session_completion_tokens,
-            "session_total_tokens": self._token_usage_session_total_tokens,
-            "session_cost_estimate_usd": self._token_usage_session_cost_estimate_usd,
-        }
+        return _turn_get_token_usage_snapshot(self)
 
     def _build_token_usage_report(self) -> str:
         """Deterministic token spend report for operator queries."""
-        snapshot = self._get_token_usage_snapshot()
-        return "\n".join(
-            [
-                "0102: token usage telemetry",
-                (
-                    "- last_turn: "
-                    f"engine={snapshot['last_engine']} "
-                    f"provider={snapshot['last_provider']} "
-                    f"model={snapshot['last_model']} "
-                    f"prompt={snapshot['last_prompt_tokens']} "
-                    f"completion={snapshot['last_completion_tokens']} "
-                    f"total={snapshot['last_total_tokens']} "
-                    f"source={snapshot['last_source']} "
-                    f"cost_estimate_usd={snapshot['last_cost_estimate_usd']:.6f} "
-                    f"age={snapshot['last_age']}"
-                ),
-                (
-                    "- session: "
-                    f"turns={snapshot['session_turns']} "
-                    f"prompt={snapshot['session_prompt_tokens']} "
-                    f"completion={snapshot['session_completion_tokens']} "
-                    f"total={snapshot['session_total_tokens']} "
-                    f"cost_estimate_usd={snapshot['session_cost_estimate_usd']:.6f}"
-                ),
-                "- note: token counts are estimated unless provider_usage is available.",
-            ]
-        )
+        return _turn_build_token_usage_report(self)
 
     def request_turn_cancel(self, reason: str = "external_interrupt") -> None:
         """Signal cooperative cancellation for the currently executing turn."""
-        self._turn_cancel_reason = (reason or "external_interrupt").strip()
-        self._turn_cancel_event.set()
-        logger.info("[OPENCLAW-DAE] Turn cancel requested | reason=%s", self._turn_cancel_reason)
+        _turn_request_turn_cancel(self, reason=reason)
 
     def clear_turn_cancel(self) -> None:
         """Reset cancellation signal before starting a new turn."""
-        self._turn_cancel_reason = "none"
-        self._turn_cancel_event.clear()
+        _turn_clear_turn_cancel(self)
 
     def _is_turn_cancelled(self, point: str = "") -> bool:
         """Check whether current turn was cancelled."""
-        if not self._turn_cancel_event.is_set():
-            return False
-        if point:
-            logger.info(
-                "[OPENCLAW-DAE] Turn cancellation observed at %s | reason=%s",
-                point,
-                self._turn_cancel_reason,
-            )
-        return True
+        return _turn_is_turn_cancelled(self, point=point)
 
     def _turn_cancelled_response(self) -> str:
         """User-facing response when a turn is interrupted."""
-        return "0102: Interrupted. Ready for your next prompt."
+        return _turn_turn_cancelled_response()
 
     @staticmethod
     def _normalize_identity_message(message: str) -> str:
         """Normalize identity-query text to reduce STT/punctuation misses."""
-        msg = (message or "").strip().lower()
-        msg = re.sub(r"[^a-z0-9\s]", " ", msg)
-        msg = re.sub(r"\s+", " ", msg).strip()
-        # STT alias normalization: "quinn" is a common transcription for "qwen".
-        msg = re.sub(r"\bquinn\b", "qwen", msg)
-        msg = re.sub(r"\bquin\b", "qwen", msg)
-        msg = re.sub(r"\bqueen\b", "qwen", msg)
-        msg = re.sub(r"\bgwen\b", "qwen", msg)
-        msg = re.sub(r"\bcoin\b", "qwen", msg)
-        msg = re.sub(r"\bgroc\b", "grok", msg)
-        msg = re.sub(r"\bgrock\b", "grok", msg)
-        msg = re.sub(r"\bgrog\b", "grok", msg)
-        return msg
+        return _model_normalize_identity_message(message)
 
     @staticmethod
     def _has_model_switch_intent(message: str) -> bool:
         """Return True when user asks to change/switch model profile."""
-        msg = OpenClawDAE._normalize_identity_message(message)
-        if not msg:
-            return False
-
-        strong_switch_verbs = (
-            "switch",
-            "change",
-            "become",
-            "set",
-            "activate",
-            "move to",
-            "swap",
-        )
-        soft_switch_verbs = (
-            "use",
-            "run",
-        )
-
-        has_strong = any(verb in msg for verb in strong_switch_verbs)
-        has_soft = any(verb in msg for verb in soft_switch_verbs)
-        if not has_strong and not has_soft:
-            return False
-        if has_soft and not has_strong:
-            if (
-                "model" not in msg
-                and "external ai" not in msg
-                and "another ai" not in msg
-                and " to " not in msg
-            ):
-                return False
-
-        if "model" in msg or "external ai" in msg or "another ai" in msg:
-            return True
-
-        target_terms = (
-            "qwen",
-            "qwen3",
-            "gemma",
-            "grok",
-            "codex",
-            "opus",
-            "sonnet",
-            "haiku",
-            "gemini",
-            "anthropic",
-            "openai",
-            "gpt",
-            "o3",
-            "o4",
-            "flash",
-        )
-        return any(term in msg for term in target_terms)
+        return _model_has_model_switch_intent(message)
 
     @staticmethod
     def _parse_model_switch_target(message: str) -> Optional[str]:
         """Parse requested model target from natural voice/text command."""
-        msg = OpenClawDAE._normalize_identity_message(message)
-        if not msg:
-            return None
-
-        if not OpenClawDAE._has_model_switch_intent(msg):
-            return None
-
-        # Canonical targets (local + cloud profiles).
-        alias_map: Dict[str, str] = {
-            "qwen": "local/qwen-coder-7b",
-            "qwen coder": "local/qwen-coder-7b",
-            "qwen coder 7b": "local/qwen-coder-7b",
-            "qwen 2 5": "local/qwen-coder-7b",
-            "qwen2 5": "local/qwen-coder-7b",
-            "qwen3": "local/qwen3-4b",
-            "qwen 3": "local/qwen3-4b",
-            "qwen three": "local/qwen3-4b",
-            "qwen 4b": "local/qwen3-4b",
-            "qwen3 5": "local/qwen3.5-4b",
-            "qwen 3 5": "local/qwen3.5-4b",
-            "qwen 3.5": "local/qwen3.5-4b",
-            "qwen3.5": "local/qwen3.5-4b",
-            "qwen 35": "local/qwen3.5-4b",
-            "qwen35": "local/qwen3.5-4b",
-            "gemma": "local/gemma-270m",
-            "gemma 270m": "local/gemma-270m",
-            "triage": "local/gemma-270m",
-            "fast": "local/gemma-270m",
-            "grok": "grok-4",
-            "grok 4": "grok-4",
-            "grok fast": "grok-4-fast",
-            "grok 4 fast": "grok-4-fast",
-            "grok code fast": "grok-code-fast-1",
-            "grok code": "grok-code-fast-1",
-            "groc": "grok-4",
-            "grock": "grok-4",
-            "grog": "grok-4",
-            "codex": "gpt-5.2-codex",
-            "codex 5": "gpt-5.2-codex",
-            "codex 5 2": "gpt-5.2-codex",
-            "codex 5 3": "gpt-5.2-codex",
-            "openai": "gpt-5.2-codex",
-            "open ai": "gpt-5.2-codex",
-            "gpt 5": "gpt-5",
-            "gpt5": "gpt-5",
-            "gpt 5 2": "gpt-5.2",
-            "gpt5 2": "gpt-5.2",
-            "o3 pro": "o3-pro",
-            "o3-pro": "o3-pro",
-            "o 3 pro": "o3-pro",
-            "o4 mini": "o4-mini",
-            "o4": "o4-mini",
-            "opus": "claude-opus-4-6",
-            "opus 4 6": "claude-opus-4-6",
-            "sonnet": "claude-sonnet-4-5-20250929",
-            "sonnet 4 6": "claude-sonnet-4-5-20250929",
-            "haiku": "claude-haiku-4-5-20251001",
-            "claude haiku": "claude-haiku-4-5-20251001",
-            "anthropic": "claude-opus-4-6",
-            "gemini": "gemini-2.5-pro",
-            "gemini flash": "gemini-2.5-flash",
-            "gemini 2 5 flash": "gemini-2.5-flash",
-            "gemini 3": "gemini-3-pro-preview",
-            "gemini 3 pro": "gemini-3-pro-preview",
-            "gemini 3 flash": "gemini-3-flash-preview",
-        }
-        for alias in sorted(alias_map.keys(), key=len, reverse=True):
-            if re.search(rf"\b{re.escape(alias)}\b", msg):
-                return alias_map[alias]
-        return None
+        return _model_parse_model_switch_target(message)
 
     @staticmethod
     def _is_model_switch_request(message: str) -> bool:
@@ -2756,161 +1294,33 @@ class OpenClawDAE:
 
     def _model_switch_target_help(self) -> str:
         """Deterministic guidance when switch intent has no recognized target."""
-        if self._no_api_keys:
-            return (
-                "0102: model switch request received. "
-                "Say `switch model to qwen3.5`, `switch model to qwen3`, `switch model to qwen`, "
-                "or `switch model to gemma`. "
-                "Use `model details` to verify active runtime engine."
-            )
-        return (
-            "0102: model switch request received. "
-            "Say `switch model to qwen3.5`, `switch model to qwen3`, `switch model to qwen`, "
-            "`switch model to gemma`, "
-            "`become grok`, `become grok fast`, `become codex`, `become gpt5`, "
-            "`become opus`, `become haiku`, or `become gemini flash`. "
-            "Use `model details` to verify active runtime engine."
-        )
+        return _model_switch_target_help(self)
 
     def _wsp00_model_switch_gate(self, intent: OpenClawIntent, target: str) -> Optional[str]:
         """Gate model switches behind WSP_00 policy and commander authority."""
-        if not intent.is_authorized_commander:
-            logger.warning(
-                "[OPENCLAW-DAE] Model switch blocked: sender not authorized | sender=%s target=%s",
-                intent.sender,
-                target,
-            )
-            return "0102: model switch blocked. commander authority required."
-
-        if self._identity_protocol_anchor != "wsp_00":
-            logger.warning(
-                "[OPENCLAW-DAE] Model switch blocked: protocol anchor mismatch | anchor=%s target=%s",
-                self._identity_protocol_anchor,
-                target,
-            )
-            return (
-                "0102: model switch blocked. protocol anchor is not wsp_00. "
-                "Set OPENCLAW_IDENTITY_PROTOCOL=wsp_00."
-            )
-
-        if not self._wsp00_boot_enabled:
-            logger.warning(
-                "[OPENCLAW-DAE] Model switch blocked: wsp00 boot disabled | target=%s",
-                target,
-            )
-            return (
-                "0102: model switch blocked. wsp_00 boot is disabled. "
-                "Set OPENCLAW_WSP00_BOOT=1."
-            )
-
-        if not self._wsp_preflight(intent):
-            logger.warning(
-                "[OPENCLAW-DAE] Model switch blocked: preflight gate failed | sender=%s target=%s",
-                intent.sender,
-                target,
-            )
-            return "0102: model switch blocked by WSP preflight."
-
-        external = self._resolve_external_target(target)
-        if self._runtime_profile == "zeroclaw" and external:
-            provider, model = external
-            logger.warning(
-                "[OPENCLAW-DAE] Model switch blocked by zeroclaw profile | sender=%s target=%s/%s",
-                intent.sender,
-                provider,
-                model,
-            )
-            return (
-                "0102: model switch blocked by runtime profile zeroclaw. "
-                "external targets are disabled."
-            )
-
-        logger.info(
-            "[OPENCLAW-DAE] Model switch gate passed | sender=%s target=%s anchor=%s boot=%s",
-            intent.sender,
-            target,
-            self._identity_protocol_anchor,
-            self._wsp00_boot_enabled,
-        )
-        return None
+        return _model_wsp00_model_switch_gate(self, intent, target)
 
     @staticmethod
     def _resolve_external_target(target: str) -> Optional[tuple[str, str]]:
         """Map external target model ID to (provider, model)."""
-        mapping = {
-            "grok-4": ("grok", "grok-4"),
-            "grok-4-fast": ("grok", "grok-4-fast"),
-            "grok-code-fast-1": ("grok", "grok-code-fast-1"),
-            "gpt-5": ("openai", "gpt-5"),
-            "gpt-5.2": ("openai", "gpt-5.2"),
-            "gpt-5.2-codex": ("openai", "gpt-5.2-codex"),
-            "o3-pro": ("openai", "o3-pro"),
-            "o4-mini": ("openai", "o4-mini"),
-            "claude-opus-4-6": ("anthropic", "claude-opus-4-6"),
-            "claude-sonnet-4-5-20250929": ("anthropic", "claude-sonnet-4-5-20250929"),
-            "claude-haiku-4-5-20251001": ("anthropic", "claude-haiku-4-5-20251001"),
-            "gemini-2.5-flash": ("gemini", "gemini-2.5-flash"),
-            "gemini-2.5-pro": ("gemini", "gemini-2.5-pro"),
-            "gemini-3-pro-preview": ("gemini", "gemini-3-pro-preview"),
-            "gemini-3-flash-preview": ("gemini", "gemini-3-flash-preview"),
-        }
-        return mapping.get((target or "").strip().lower())
+        return _model_resolve_external_target(target)
 
     @staticmethod
     def _provider_has_key(provider: str) -> bool:
-        provider = (provider or "").strip().lower()
-        key_vars = {
-            "openai": ("OPENAI_API_KEY",),
-            "anthropic": ("ANTHROPIC_API_KEY",),
-            "grok": ("GROK_API_KEY", "XAI_API_KEY"),
-            "gemini": ("GEMINI_API_KEY",),
-        }
-        for name in key_vars.get(provider, ()):
-            if os.getenv(name, "").strip():
-                return True
-        return False
+        return _model_provider_has_key(provider)
 
     @staticmethod
     def _map_local_model_path_to_target(path: Path) -> Optional[str]:
         """Map a resolved local model path to an OpenClaw local target id."""
-        text = str(path or "").replace("\\", "/").lower()
-        if not text:
-            return None
-        if "qwen3.5-4b" in text or ("qwen3.5" in text and "4b" in text):
-            return "local/qwen3.5-4b"
-        if "qwen3-4b" in text or ("qwen3" in text and "4b" in text):
-            return "local/qwen3-4b"
-        if "qwen-coder-7b" in text or "coder-7b" in text:
-            return "local/qwen-coder-7b"
-        if "gemma-270m" in text or "270m" in text:
-            return "local/gemma-270m"
-        return None
+        return _model_map_local_model_path_to_target(path)
 
     def _resolve_local_target_for_role(self, role: str) -> Optional[str]:
         """Resolve the best local target for a semantic role."""
-        try:
-            from modules.infrastructure.shared_utilities.local_model_selection import (
-                resolve_model_selection,
-            )
-
-            selection = resolve_model_selection(role)
-        except Exception as exc:
-            logger.debug(
-                "[OPENCLAW-DAE] Local model selection unavailable | role=%s error=%s",
-                role,
-                type(exc).__name__,
-            )
-            return None
-        return self._map_local_model_path_to_target(selection.path)
+        return _model_resolve_local_target_for_role(self, role)
 
     @staticmethod
     def _local_target_dirs() -> Dict[str, str]:
-        return {
-            "local/gemma-270m": "gemma-270m",
-            "local/qwen3-4b": "qwen3-4b",
-            "local/qwen3.5-4b": "qwen3.5-4b",
-            "local/qwen-coder-7b": "qwen-coder-7b",
-        }
+        return _model_local_target_dirs()
 
     def _apply_local_target_runtime(
         self,
@@ -2919,42 +1329,7 @@ class OpenClawDAE:
         lock_target: bool = False,
     ) -> bool:
         """Apply local-target routing to the active conversation runtime."""
-        target = (target or "").strip().lower()
-        local_target_dirs = self._local_target_dirs()
-        if target not in local_target_dirs:
-            return False
-
-        root = Path(os.getenv("LOCAL_MODEL_ROOT", "E:/LM_studio/models/local")).expanduser()
-        code_dir = root / local_target_dirs[target]
-        previous_target = self._conversation_model_target_id
-        previous_code_dir = os.getenv("LOCAL_MODEL_CODE_DIR", "")
-
-        self._conversation_model_target_id = target
-        os.environ["OPENCLAW_CONVERSATION_MODEL_TARGET"] = target
-        os.environ["LOCAL_MODEL_CODE_DIR"] = str(code_dir)
-        os.environ["LOCAL_MODEL_CODE_PATH"] = ""
-        os.environ["HOLO_QWEN_MODEL"] = ""
-        self._preferred_external_provider = ""
-        self._preferred_external_model = ""
-        os.environ["OPENCLAW_CONVERSATION_PREFERRED_PROVIDER"] = ""
-        os.environ["OPENCLAW_CONVERSATION_PREFERRED_MODEL"] = ""
-        self._mark_preferred_external_status("not_selected", "local_target_active")
-        if lock_target:
-            self._conversation_model_target_locked = True
-
-        changed = previous_target != target or previous_code_dir != str(code_dir)
-        if changed:
-            # Force a fresh Overseer instance so routing picks up new LOCAL_MODEL_* values.
-            self._overseer = None
-
-        logger.info(
-            "[OPENCLAW-DAE] Local conversation route | target=%s reason=%s changed=%s lock=%s",
-            target,
-            reason,
-            changed,
-            self._conversation_model_target_locked,
-        )
-        return changed
+        return _model_apply_local_target_runtime(self, target, reason, lock_target=lock_target)
 
     def _infer_conversation_model_role(
         self,
@@ -2962,65 +1337,7 @@ class OpenClawDAE:
         intent: OpenClawIntent,
     ) -> tuple[str, str]:
         """Infer the best local model role for this conversational turn."""
-        msg = (user_msg or "").strip().lower()
-
-        triage_terms = (
-            "status",
-            "health",
-            "check",
-            "diagnose",
-            "diagnostic",
-            "preflight",
-            "runtime",
-            "available",
-            "availability",
-            "error",
-            "failing",
-            "failed",
-            "monitor",
-            "watch",
-            "dashboard",
-            "connect wre",
-        )
-        code_terms = (
-            "fix",
-            "patch",
-            "refactor",
-            "rewrite",
-            "implement",
-            "test",
-            "pytest",
-            "traceback",
-            "exception",
-            "stack trace",
-            "module",
-            "codebase",
-            "repo",
-            "repository",
-            "git",
-            "branch",
-            "commit",
-            "merge",
-            "cleanup",
-            "clean up",
-            "security",
-            "hardening",
-            "cve",
-            "dependency",
-            "dependencies",
-            "wsp",
-            "wre",
-            "main.py",
-            "obs",
-            "openclaw",
-            "ironclaw",
-        )
-
-        if intent.category == IntentCategory.MONITOR or any(term in msg for term in triage_terms):
-            return "triage", "diagnostic_or_health_request"
-        if any(term in msg for term in code_terms):
-            return "code", "code_or_system_change_request"
-        return "general", "default_general_reasoning"
+        return _model_infer_conversation_model_role(self, user_msg, intent)
 
     def _maybe_apply_agentic_conversation_model(
         self,
@@ -3028,517 +1345,43 @@ class OpenClawDAE:
         user_msg: str,
     ) -> None:
         """Auto-select the best local model for this turn unless an operator pinned one."""
-        if not self._agentic_model_selection_enabled:
-            return
-        if self._conversation_model_target_locked:
-            return
-        if self._conversation_backend == "ironclaw":
-            return
-        if self._preferred_external_provider and self._preferred_external_model:
-            return
-
-        role, reason = self._infer_conversation_model_role(user_msg, intent)
-        target = self._resolve_local_target_for_role(role)
-        self._last_auto_model_role = role
-        self._last_auto_model_target = target or "unresolved"
-        self._last_auto_model_reason = reason
-        if not target:
-            logger.info(
-                "[OPENCLAW-DAE] Agentic model route unresolved | role=%s reason=%s",
-                role,
-                reason,
-            )
-            return
-
-        self._apply_local_target_runtime(
-            target,
-            f"agentic:{role}:{reason}",
-            lock_target=False,
-        )
+        _model_maybe_apply_agentic_conversation_model(self, intent, user_msg)
 
     def _apply_model_switch_target(self, target: str) -> str:
         """Apply model switch request and return deterministic operator confirmation."""
-        target = (target or "").strip().lower()
-        if not target:
-            return "0102: No model target recognized."
-
-        local_target_dirs = self._local_target_dirs()
-        if target in local_target_dirs:
-            root = Path(os.getenv("LOCAL_MODEL_ROOT", "E:/LM_studio/models/local")).expanduser()
-            code_dir = root / local_target_dirs[target]
-            self._apply_local_target_runtime(
-                target,
-                "manual_model_switch",
-                lock_target=True,
-            )
-            return (
-                "0102: Model switched to "
-                f"{target} (local). "
-                f"Routing LOCAL_MODEL_CODE_DIR -> {code_dir} and reloading conversation engine."
-            )
-
-        external = self._resolve_external_target(target)
-        if external:
-            provider, model = external
-            if self._runtime_profile == "zeroclaw":
-                self._mark_preferred_external_status(
-                    "blocked",
-                    "runtime_profile_zeroclaw",
-                )
-                return (
-                    "0102: model switch blocked by runtime profile zeroclaw. "
-                    "external targets are disabled."
-                )
-            self._preferred_external_provider = provider
-            self._preferred_external_model = model
-            os.environ["OPENCLAW_CONVERSATION_PREFERRED_PROVIDER"] = provider
-            os.environ["OPENCLAW_CONVERSATION_PREFERRED_MODEL"] = model
-            if not self._allow_external_llm:
-                self._mark_preferred_external_status(
-                    "blocked",
-                    "external_llm_disabled_by_key_isolation",
-                )
-                return (
-                    "0102: cannot switch to "
-                    f"{provider}/{model} while key isolation is ON. "
-                    "Use a local target: qwen3, qwen, or gemma."
-                )
-            if not self._provider_has_key(provider):
-                self._mark_preferred_external_status(
-                    "blocked",
-                    "provider_key_missing",
-                )
-                return (
-                    "0102: cannot switch to "
-                    f"{provider}/{model}. provider api key is not configured."
-                )
-            if self._model_switch_live_probe:
-                ok, detail = self._probe_provider_endpoint(
-                    provider,
-                    timeout_sec=self._model_switch_probe_timeout_sec,
-                )
-                if not ok:
-                    self._mark_preferred_external_status(
-                        "blocked",
-                        f"live_probe_failed:{detail}",
-                    )
-                    return (
-                        "0102: cannot switch to "
-                        f"{provider}/{model}. live provider probe failed ({detail}). "
-                        "Check key validity/network, or disable strict probe with "
-                        "OPENCLAW_MODEL_SWITCH_LIVE_PROBE=0."
-                    )
-                self._mark_preferred_external_status("selected", f"live_probe:{detail}")
-            else:
-                self._mark_preferred_external_status("selected", "probe_disabled")
-            self._conversation_model_target_locked = True
-            return (
-                "0102: Model switched to "
-                f"{provider}/{model}. "
-                "Target is configured; use `model details` to verify active engine per turn."
-            )
-
-        return f"0102: Unsupported model target: {target}"
+        return _model_apply_model_switch_target(self, target)
 
     @staticmethod
     def _is_identity_query(message: str) -> bool:
         """Return True when user asks what model/identity 0102 is running."""
-        msg = OpenClawDAE._normalize_identity_message(message)
-        if not msg:
-            return False
-        if OpenClawDAE._has_model_switch_intent(message):
-            return False
-
-        model_alias_terms = (
-            "qwen",
-            "gemma",
-            "grok",
-            "codex",
-            "opus",
-            "sonnet",
-            "gemini",
-            "ui tars",
-            "uitars",
-            "llama",
-        )
-
-        short_forms = {
-            "model",
-            "which model",
-            "what model",
-            "species",
-            "genus",
-            "identity",
-            "backend",
-            "runtime",
-            "neural net",
-            "lineage",
-            "taxonomy",
-        }
-        if msg in short_forms:
-            return True
-
-        phrases = (
-            "which model are you",
-            "what model are you",
-            "model are you using",
-            "what are you running",
-            "which 0102",
-            "who are you",
-            "what species",
-            "what genus",
-            "which genus",
-            "which species",
-            "what is your model",
-            "what is your species",
-            "what is your genus",
-            "are you ironclaw",
-            "are you openclaw",
-            "what backend",
-            "what runtime",
-            "what lineage",
-            "what taxonomy",
-        )
-        if any(phrase in msg for phrase in phrases):
-            return True
-
-        if "species" in msg or "genus" in msg or "lineage" in msg or "taxonomy" in msg:
-            return True
-
-        if any(alias in msg for alias in model_alias_terms):
-            if (
-                "are you" in msg
-                or "you" in msg
-                or "0102" in msg
-                or "running" in msg
-                or "operating" in msg
-                or "using" in msg
-                or "model" in msg
-                or "backend" in msg
-                or "runtime" in msg
-                or "available" in msg
-                or "unavailable" in msg
-            ):
-                return True
-
-        if "model" in msg and (
-            "you" in msg
-            or "0102" in msg
-            or "backend" in msg
-            or "runtime" in msg
-        ):
-            return True
-
-        return False
+        return _identity_is_identity_query(message)
 
     @staticmethod
     def _is_token_usage_query(message: str) -> bool:
         """Return True when user asks for token usage/spend telemetry."""
-        msg = OpenClawDAE._normalize_identity_message(message)
-        if not msg:
-            return False
-
-        direct_forms = {
-            "token",
-            "tokens",
-            "token usage",
-            "token stats",
-            "token spend",
-            "token expenditure",
-            "token expendure",
-            "usage stats",
-            "cost stats",
-        }
-        if msg in direct_forms:
-            return True
-
-        if "how many tokens" in msg:
-            return True
-
-        has_token_or_cost = ("token" in msg) or ("cost" in msg)
-        if not has_token_or_cost:
-            return False
-
-        telemetry_terms = (
-            "usage",
-            "stats",
-            "spent",
-            "spend",
-            "expenditure",
-            "expendure",
-            "estimate",
-            "session",
-            "turn",
-            "show",
-            "see",
-            "track",
-            "telemetry",
-        )
-        return any(term in msg for term in telemetry_terms)
+        return _identity_is_token_usage_query(message)
 
     @staticmethod
     def _is_compact_identity_query(message: str) -> bool:
         """Return True when user asks a short identity query (model/species/genus)."""
-        msg = OpenClawDAE._normalize_identity_message(message)
-        short_forms = {
-            "model",
-            "which model",
-            "what model",
-            "species",
-            "genus",
-            "lineage",
-            "taxonomy",
-            "identity",
-            "backend",
-            "runtime",
-            "neural net",
-        }
-        return msg in short_forms
+        return _identity_is_compact_identity_query(message)
 
     @staticmethod
     def _wants_full_identity_card(message: str) -> bool:
         """Return True when user explicitly asks for detailed/diagnostic identity output."""
-        msg = OpenClawDAE._normalize_identity_message(message)
-        if not msg:
-            return False
-
-        model_alias_terms = (
-            "qwen",
-            "gemma",
-            "grok",
-            "codex",
-            "opus",
-            "sonnet",
-            "gemini",
-            "ui tars",
-            "uitars",
-            "llama",
-        )
-
-        explicit_phrases = (
-            "identity card",
-            "full identity",
-            "full details",
-            "detailed identity",
-            "model details",
-            "runtime status",
-            "show diagnostics",
-            "debug identity",
-            "verbose identity",
-            "full runtime",
-        )
-        if any(phrase in msg for phrase in explicit_phrases):
-            return True
-
-        has_debug_signal = any(
-            token in msg
-            for token in (
-                "debug",
-                "diagnostic",
-                "diagnostics",
-                "verbose",
-                "verify",
-                "verification",
-                "confirm",
-                "status",
-                "health",
-                "error",
-                "fail",
-                "failure",
-                "unavailable",
-            )
-        )
-        if "not available" in msg:
-            has_debug_signal = True
-        if has_debug_signal and (
-            "model" in msg
-            or "identity" in msg
-            or "runtime" in msg
-            or "backend" in msg
-            or "lineage" in msg
-            or "species" in msg
-            or "genus" in msg
-            or any(alias in msg for alias in model_alias_terms)
-        ):
-            return True
-
-        return False
+        return _identity_wants_full_identity_card(message)
 
     def _resolve_local_code_model_snapshot(self) -> Dict[str, str]:
         """Resolve local code-model path/status from centralized LOCAL_MODEL_* routing."""
-        snapshot = {
-            "path": "unavailable",
-            "state": "ERROR",
-            "source": "unavailable",
-        }
-        try:
-            from modules.infrastructure.shared_utilities.local_model_selection import (
-                resolve_model_selection,
-            )
-
-            selection = resolve_model_selection("code")
-            snapshot["path"] = str(selection.path)
-            snapshot["state"] = "OK" if selection.exists else "MISSING"
-            snapshot["source"] = selection.source
-        except Exception as exc:
-            snapshot["source"] = f"error:{type(exc).__name__}"
-        return snapshot
+        return _runtime_resolve_local_code_model_snapshot()
 
     def _probe_ironclaw_runtime(self) -> Dict[str, str]:
         """Probe IronClaw runtime for identity/status reporting."""
-        runtime = {
-            "healthy": "UNKNOWN",
-            "detail": "not-probed",
-            "model": os.getenv("IRONCLAW_MODEL", "local/qwen-coder-7b").strip() or "local/qwen-coder-7b",
-            "models": "none",
-            "base_url": os.getenv("IRONCLAW_BASE_URL", "http://127.0.0.1:3000").strip() or "http://127.0.0.1:3000",
-        }
-        try:
-            from .ironclaw_gateway_client import IronClawGatewayClient
-
-            client = IronClawGatewayClient()
-            healthy, detail = client.health()
-            models = client.list_models()
-            runtime["healthy"] = "PASS" if healthy else "FAIL"
-            runtime["detail"] = detail
-            runtime["model"] = client.config.model
-            runtime["models"] = ", ".join(models[:5]) if models else "none"
-            runtime["base_url"] = client.config.base_url
-        except Exception as exc:
-            runtime["healthy"] = "FAIL"
-            runtime["detail"] = f"probe_error:{type(exc).__name__}"
-        return runtime
+        return _runtime_probe_ironclaw_runtime()
 
     def _attempt_ironclaw_autostart(self) -> tuple[bool, str]:
         """Try to auto-start IronClaw gateway and wait briefly for health."""
-        if not self._ironclaw_autostart_enabled:
-            return False, "autostart_disabled"
-
-        now = time.time()
-        if now < self._ironclaw_autostart_missing_backoff_until:
-            return False, "autostart_missing_executable_backoff"
-        if (now - self._ironclaw_autostart_last_attempt) < self._ironclaw_autostart_cooldown_sec:
-            return False, "autostart_cooldown"
-        self._ironclaw_autostart_last_attempt = now
-
-        cmd_candidates: list[str] = []
-        if self._ironclaw_autostart_start_cmd:
-            cmd_candidates.append(self._ironclaw_autostart_start_cmd)
-        discovered = shutil.which("ironclaw")
-        if discovered:
-            discovered_cmd = f"\"{discovered}\" gateway"
-            if discovered_cmd not in cmd_candidates:
-                cmd_candidates.append(discovered_cmd)
-        binary_name = "ironclaw.exe" if os.name == "nt" else "ironclaw"
-        local_binary_candidates = [
-            self.repo_root / "target" / "release" / binary_name,
-            self.repo_root / "ironclaw" / "target" / "release" / binary_name,
-            self.repo_root / "modules" / "ironclaw" / "target" / "release" / binary_name,
-        ]
-        for bin_path in local_binary_candidates:
-            if bin_path.exists():
-                local_cmd = f"\"{str(bin_path)}\" gateway"
-                if local_cmd not in cmd_candidates:
-                    cmd_candidates.append(local_cmd)
-        if self._ironclaw_autostart_default_cmd and self._ironclaw_autostart_default_cmd not in cmd_candidates:
-            cmd_candidates.append(self._ironclaw_autostart_default_cmd)
-        if not cmd_candidates:
-            return False, "missing_ironclaw_start_cmd"
-
-        try:
-            env = os.environ.copy()
-            try:
-                from .ironclaw_gateway_client import scrub_sensitive_env, env_truthy
-
-                if env_truthy("IRONCLAW_NO_API_KEYS", "1"):
-                    env = scrub_sensitive_env(env)
-            except Exception:
-                pass
-
-            started_cmd = ""
-            missing_execs: list[str] = []
-            spawn_errors: list[str] = []
-            for cmd in cmd_candidates:
-                try:
-                    argv = shlex.split(cmd)
-                    if not argv:
-                        continue
-                    executable = argv[0].strip().strip('"')
-                    executable_exists = bool(
-                        Path(executable).exists() or shutil.which(executable)
-                    )
-                    if not executable_exists:
-                        missing_execs.append(executable or "unknown")
-                        continue
-
-                    proc = subprocess.Popen(
-                        argv,
-                        cwd=str(self.repo_root),
-                        env=env,
-                    )
-                    # Fast-fail if process dies immediately with non-zero status.
-                    time.sleep(0.12)
-                    if proc.poll() not in (None, 0):
-                        spawn_errors.append(
-                            f"{cmd} exited={proc.poll()}"
-                        )
-                        continue
-                    started_cmd = cmd
-                    break
-                except Exception as exc:
-                    spawn_errors.append(f"{cmd} error={type(exc).__name__}")
-
-            if not started_cmd and self._ironclaw_autostart_allow_shell:
-                for cmd in cmd_candidates:
-                    try:
-                        subprocess.Popen(
-                            cmd,
-                            cwd=str(self.repo_root),
-                            env=env,
-                            shell=True,
-                        )
-                        started_cmd = cmd
-                        break
-                    except Exception as exc:
-                        spawn_errors.append(f"{cmd} shell_error={type(exc).__name__}")
-                        continue
-
-            if not started_cmd:
-                if missing_execs:
-                    uniq = sorted({m for m in missing_execs if m})
-                    self._ironclaw_autostart_missing_backoff_until = (
-                        now + self._ironclaw_autostart_missing_backoff_sec
-                    )
-                    preview = ",".join(uniq[:3]) if uniq else "unknown"
-                    return False, f"autostart_executable_missing:{preview}"
-                if spawn_errors:
-                    return False, f"autostart_spawn_failed:{spawn_errors[0]}"
-                return False, "autostart_spawn_failed"
-
-            deadline = time.time() + self._ironclaw_autostart_wait_sec
-            while time.time() < deadline:
-                healthy, detail = False, "not_probed"
-                try:
-                    from .ironclaw_gateway_client import IronClawGatewayClient
-
-                    healthy, detail = IronClawGatewayClient().health()
-                except Exception as exc:
-                    detail = f"probe_error:{type(exc).__name__}"
-
-                if healthy:
-                    logger.info(
-                        "[OPENCLAW-DAE] IronClaw autostart recovered runtime | cmd=%s",
-                        started_cmd,
-                    )
-                    return True, "autostart_recovered"
-
-                time.sleep(0.5)
-
-            return False, "autostart_started_but_unhealthy"
-
-        except Exception as exc:
-            logger.warning("[OPENCLAW-DAE] IronClaw autostart failed: %s", exc)
-            return False, f"autostart_error:{type(exc).__name__}"
+        return _runtime_attempt_ironclaw_autostart(self)
 
     def _resolve_identity_model_name(
         self,
@@ -3546,37 +1389,7 @@ class OpenClawDAE:
         ironclaw_runtime: Dict[str, str],
     ) -> str:
         """Resolve model_name label from template using current runtime model hint."""
-        template = self._identity_model_name_template or "{model}"
-
-        model_hint = "model"
-        preferred_provider = (self._preferred_external_provider or "").strip().lower()
-        preferred_model = (self._preferred_external_model or "").strip().lower()
-        if (
-            self._conversation_backend != "ironclaw"
-            and preferred_provider
-            and preferred_model
-            and self._allow_external_llm
-            and self._provider_has_key(preferred_provider)
-        ):
-            model_hint = f"{preferred_provider}/{preferred_model}"
-        elif self._conversation_backend == "ironclaw":
-            model_hint = (ironclaw_runtime.get("model") or "model").strip() or "model"
-        else:
-            code_path = (local_code.get("path") or "").strip()
-            if code_path and code_path.lower() != "unavailable":
-                try:
-                    model_hint = Path(code_path).name or "model"
-                except Exception:
-                    model_hint = code_path
-        model_hint = model_hint.lower()
-
-        if "{model}" in template:
-            return template.replace("{model}", model_hint).lower()
-
-        if "model" in template:
-            return template.replace("model", model_hint).lower()
-
-        return template.lower()
+        return _runtime_resolve_identity_model_name(self, local_code, ironclaw_runtime)
 
     def _probe_provider_endpoint(
         self,
@@ -3584,67 +1397,7 @@ class OpenClawDAE:
         timeout_sec: float = 2.0,
     ) -> tuple[bool, str]:
         """Best-effort live provider probe for model availability reporting."""
-        provider_name = (provider or "").strip().lower()
-        if not provider_name:
-            return False, "invalid_provider"
-        if not self._provider_has_key(provider_name):
-            return False, "no_key"
-
-        try:
-            import requests as _req
-        except Exception:
-            return False, "requests_unavailable"
-
-        api_keys = {
-            "openai": os.getenv("OPENAI_API_KEY", "").strip(),
-            "anthropic": os.getenv("ANTHROPIC_API_KEY", "").strip(),
-            "grok": (
-                os.getenv("GROK_API_KEY", "").strip()
-                or os.getenv("XAI_API_KEY", "").strip()
-            ),
-            "gemini": os.getenv("GEMINI_API_KEY", "").strip(),
-        }
-        key = api_keys.get(provider_name, "")
-        if not key:
-            return False, "no_key"
-
-        endpoint = ""
-        headers: Dict[str, str] = {}
-        params: Dict[str, str] = {}
-
-        if provider_name in {"openai", "grok"}:
-            base = "https://api.openai.com/v1" if provider_name == "openai" else "https://api.x.ai/v1"
-            endpoint = f"{base}/models"
-            headers = {"Authorization": f"Bearer {key}"}
-        elif provider_name == "anthropic":
-            endpoint = "https://api.anthropic.com/v1/models"
-            headers = {
-                "x-api-key": key,
-                "anthropic-version": "2023-06-01",
-            }
-        elif provider_name == "gemini":
-            endpoint = "https://generativelanguage.googleapis.com/v1/models"
-            params = {"key": key}
-        else:
-            return False, "unsupported_provider"
-
-        try:
-            response = _req.get(
-                endpoint,
-                headers=headers or None,
-                params=params or None,
-                timeout=max(0.5, timeout_sec),
-            )
-            code = int(response.status_code)
-            if 200 <= code < 300:
-                return True, "api_ok"
-            if code in {401, 403}:
-                return False, "auth_error"
-            # Non-auth HTTP responses still confirm provider reachability.
-            # Keep detail for diagnostics, but do not hard-fail switch gating.
-            return True, f"http_{code}"
-        except Exception as exc:
-            return False, f"network_{type(exc).__name__.lower()}"
+        return _runtime_probe_provider_endpoint(self, provider, timeout_sec=timeout_sec)
 
     def get_model_availability_snapshot(
         self,
@@ -3652,160 +1405,15 @@ class OpenClawDAE:
         timeout_sec: float = 2.0,
     ) -> Dict[str, Any]:
         """Return startup model/provider availability for voice/chat diagnostics."""
-        local_root = Path(
-            os.getenv("LOCAL_MODEL_ROOT", "E:/LM_studio/models/local")
-        ).expanduser()
-
-        local_targets = {
-            "local/qwen-coder-7b": "qwen-coder-7b",
-            "local/qwen3-4b": "qwen3-4b",
-            "local/qwen3.5-4b": "qwen3.5-4b",
-            "local/gemma-270m": "gemma-270m",
-        }
-        local_status: Dict[str, str] = {}
-        for target_id, folder in local_targets.items():
-            model_dir = local_root / folder
-            if not model_dir.exists() or not model_dir.is_dir():
-                local_status[target_id] = "missing"
-                continue
-            try:
-                has_gguf = any(model_dir.glob("*.gguf"))
-            except Exception:
-                has_gguf = False
-            local_status[target_id] = "ready" if has_gguf else "dir_only"
-
-        providers = ("openai", "anthropic", "grok", "gemini")
-        provider_status: Dict[str, str] = {}
-        for provider in providers:
-            if not self._provider_has_key(provider):
-                provider_status[provider] = "no_key"
-                continue
-            if not live_probe:
-                provider_status[provider] = "key_present"
-                continue
-            _, detail = self._probe_provider_endpoint(provider, timeout_sec=timeout_sec)
-            provider_status[provider] = detail
-
-        target = self._conversation_model_target_id or "local/qwen-coder-7b"
-        target_status = "unknown"
-        if target in local_status:
-            target_status = local_status[target]
-        else:
-            external = self._resolve_external_target(target)
-            if external:
-                provider_name, _ = external
-                target_status = provider_status.get(provider_name, "no_key")
-
-        local_code = self._resolve_local_code_model_snapshot()
-        ironclaw_runtime = {
-            "healthy": "N/A",
-            "detail": "not_probed",
-            "model": os.getenv("IRONCLAW_MODEL", "local/qwen-coder-7b").strip() or "local/qwen-coder-7b",
-            "models": "none",
-        }
-        effective_model_name = self._resolve_identity_model_name(local_code, ironclaw_runtime)
-
-        return {
-            "probe_mode": "live" if live_probe else "keys_only",
-            "local_root": str(local_root),
-            "local": local_status,
-            "providers": provider_status,
-            "target": target,
-            "target_status": target_status,
-            "effective_model_name": effective_model_name,
-        }
+        return _runtime_get_model_availability_snapshot(
+            self,
+            live_probe=live_probe,
+            timeout_sec=timeout_sec,
+        )
 
     def get_identity_snapshot(self, include_runtime_probe: bool = True) -> Dict[str, str]:
         """Return canonical 0102 identity snapshot used by daemon/CLI/status surfaces."""
-        local_code = self._resolve_local_code_model_snapshot()
-        ironclaw_runtime = {
-            "healthy": "N/A",
-            "detail": "backend_not_ironclaw",
-            "model": os.getenv("IRONCLAW_MODEL", "local/qwen-coder-7b").strip() or "local/qwen-coder-7b",
-            "models": "none",
-            "base_url": os.getenv("IRONCLAW_BASE_URL", "http://127.0.0.1:3000").strip() or "http://127.0.0.1:3000",
-        }
-        if include_runtime_probe and (
-            self._conversation_backend == "ironclaw"
-            or _env_truthy("OPENCLAW_ALLOW_IRONCLAW_FALLBACK", "0")
-        ):
-            ironclaw_runtime = self._probe_ironclaw_runtime()
-
-        model_name = self._resolve_identity_model_name(local_code, ironclaw_runtime)
-        token_snapshot = self._get_token_usage_snapshot()
-        return {
-            "backend": self._conversation_backend,
-            "runtime_profile": self._runtime_profile,
-            "key_isolation": "ON" if self._no_api_keys else "OFF",
-            "ironclaw_strict": "ON" if self._ironclaw_strict else "OFF",
-            "ironclaw_allow_local_fallback": "ON" if self._ironclaw_allow_local_fallback else "OFF",
-            "genus": self._identity_genus,
-            "lineage": self._identity_model_family,
-            "model_family": self._identity_model_family,
-            "model_name": model_name,
-            "model_catalog": self._identity_model_catalog or "unspecified",
-            "conversation_model_target": self._conversation_model_target_id or "local/qwen-coder-7b",
-            "conversation_model_locked": "ON" if self._conversation_model_target_locked else "OFF",
-            "auto_model_role": self._last_auto_model_role or "unknown",
-            "auto_model_target": self._last_auto_model_target or "unknown",
-            "auto_model_reason": self._last_auto_model_reason or "unknown",
-            "preferred_external_provider": self._preferred_external_provider or "none",
-            "preferred_external_model": self._preferred_external_model or "none",
-            "preferred_external_status": self._preferred_external_last_status,
-            "preferred_external_status_detail": self._preferred_external_last_status_detail,
-            "preferred_external_status_age": (
-                f"{int(max(0.0, time.time() - self._preferred_external_last_status_at))}s"
-                if self._preferred_external_last_status_at > 0
-                else "never"
-            ),
-            "protocol_anchor": self._identity_protocol_anchor,
-            "wsp00_boot": "ON" if self._wsp00_boot_enabled else "OFF",
-            "wsp00_boot_mode": self._wsp00_boot_mode,
-            "wsp00_file_override": "YES" if bool(self._wsp00_prompt_file) else "NO",
-            "platform_context": "ON" if self._platform_context_enabled else "OFF",
-            "platform_context_sources": str(len(self._platform_context_pack_sources)),
-            "platform_context_loaded_ago": (
-                f"{int(max(0.0, time.time() - self._platform_context_pack_loaded_at))}s"
-                if self._platform_context_pack_loaded_at > 0
-                else "never"
-            ),
-            "last_engine": self._last_conversation_engine,
-            "last_engine_detail": self._last_conversation_detail,
-            "previous_engine": self._previous_conversation_engine,
-            "previous_engine_detail": self._previous_conversation_detail,
-            "token_last_prompt_tokens": str(token_snapshot["last_prompt_tokens"]),
-            "token_last_completion_tokens": str(token_snapshot["last_completion_tokens"]),
-            "token_last_total_tokens": str(token_snapshot["last_total_tokens"]),
-            "token_last_engine": token_snapshot["last_engine"],
-            "token_last_provider": token_snapshot["last_provider"],
-            "token_last_model": token_snapshot["last_model"],
-            "token_last_source": token_snapshot["last_source"],
-            "token_last_cost_estimate_usd": f"{token_snapshot['last_cost_estimate_usd']:.6f}",
-            "token_last_age": token_snapshot["last_age"],
-            "token_session_turns": str(token_snapshot["session_turns"]),
-            "token_session_prompt_tokens": str(token_snapshot["session_prompt_tokens"]),
-            "token_session_completion_tokens": str(token_snapshot["session_completion_tokens"]),
-            "token_session_total_tokens": str(token_snapshot["session_total_tokens"]),
-            "token_session_cost_estimate_usd": f"{token_snapshot['session_cost_estimate_usd']:.6f}",
-            "last_social_source": self._last_social_response_source,
-            "last_social_action": self._last_social_response_action,
-            "last_social_skill": self._last_social_response_skill,
-            "last_social_success": self._last_social_response_success,
-            "last_social_preview": self._last_social_response_preview,
-            "last_social_age": (
-                f"{int(max(0.0, time.time() - self._last_social_response_at))}s"
-                if self._last_social_response_at > 0
-                else "never"
-            ),
-            "local_code_model_path": local_code.get("path", "unavailable"),
-            "local_code_model_state": local_code.get("state", "ERROR"),
-            "local_code_model_source": local_code.get("source", "unavailable"),
-            "ironclaw_runtime_healthy": ironclaw_runtime.get("healthy", "UNKNOWN"),
-            "ironclaw_runtime_detail": ironclaw_runtime.get("detail", "not-probed"),
-            "ironclaw_runtime_model": ironclaw_runtime.get("model", "unknown"),
-            "ironclaw_runtime_models": ironclaw_runtime.get("models", "none"),
-            "ironclaw_runtime_base_url": ironclaw_runtime.get("base_url", "unknown"),
-        }
+        return _runtime_get_identity_snapshot(self, include_runtime_probe=include_runtime_probe)
 
     def get_identity_label_line(self, include_runtime_probe: bool = False) -> str:
         """Compact identity label for startup banners and daemon traces."""
@@ -3821,368 +1429,49 @@ class OpenClawDAE:
 
     def _build_identity_compact(self) -> str:
         """Compact identity response for short model/species/genus questions."""
-        snapshot = self.get_identity_snapshot(include_runtime_probe=True)
-        return f"0102: model_name={snapshot['model_name']}"
+        return _identity_build_identity_compact(self)
 
     def _build_identity_compact_runtime(self) -> str:
         """Compact identity with active runtime verification fields."""
-        snapshot = self.get_identity_snapshot(include_runtime_probe=True)
-        return (
-            "0102: "
-            f"model_name={snapshot['model_name']} | "
-            f"runtime_profile={snapshot.get('runtime_profile', 'openclaw')} | "
-            f"target={snapshot.get('conversation_model_target', 'local/qwen-coder-7b')} | "
-            f"target_lock={snapshot.get('conversation_model_locked', 'OFF')} | "
-            f"auto_model={snapshot.get('auto_model_role', 'unknown')}/{snapshot.get('auto_model_target', 'unknown')} | "
-            f"last_engine={snapshot.get('last_engine', 'unknown')} | "
-            f"previous_engine={snapshot.get('previous_engine', 'none')} | "
-            f"last_social={snapshot.get('last_social_source', 'none')}/{snapshot.get('last_social_action', 'none')} | "
-            "preferred_external="
-            f"{snapshot.get('preferred_external_provider', 'none')}/"
-            f"{snapshot.get('preferred_external_model', 'none')} | "
-            f"preferred_external_status={snapshot.get('preferred_external_status', 'not_selected')} | "
-            f"session_total_tokens={snapshot.get('token_session_total_tokens', '0')} | "
-            f"last_total_tokens={snapshot.get('token_last_total_tokens', '0')}"
-        )
+        return _identity_build_identity_compact_runtime(self)
 
     def _build_connect_wre_status(self, verbose: bool = False) -> str:
         """Deterministic Connect-WRE status response for operator prompts."""
-        preflight_ok = False
-        health: Dict[str, Any] = {}
-        in_watch: Optional[bool] = None
-        issues: List[str] = []
-
-        try:
-            from modules.infrastructure.wre_core.src.dae_preflight import run_dae_preflight
-
-            preflight_ok = bool(run_dae_preflight("connect_wre", quiet=True))
-        except Exception as exc:
-            issues.append(f"preflight_unavailable:{type(exc).__name__}")
-
-        try:
-            from modules.infrastructure.wre_core.src.dashboard_alerts import (
-                DashboardAlertMonitor,
-                check_dashboard_health,
-            )
-
-            monitor = DashboardAlertMonitor()
-            in_watch = monitor.is_in_watch_period()
-            health = check_dashboard_health() or {}
-        except Exception as exc:
-            issues.append(f"dashboard_unavailable:{type(exc).__name__}")
-
-        enabled = os.getenv("WRE_DASHBOARD_PREFLIGHT", "1") != "0"
-        manual_enforced = os.getenv("WRE_DASHBOARD_PREFLIGHT_ENFORCED", "0") != "0"
-        auto_enforce = os.getenv("WRE_DASHBOARD_AUTO_ENFORCE", "1") != "0"
-        insufficient_data = bool(health.get("insufficient_data", False))
-        total_executions = int(health.get("total_executions", 0))
-        min_samples = int(
-            health.get("min_samples", int(os.getenv("WRE_DASHBOARD_MIN_SAMPLES", "25")))
-        )
-        alerts = health.get("alerts", []) if isinstance(health.get("alerts"), list) else []
-        critical = sum(1 for alert in alerts if alert.get("severity") == "critical")
-        warnings = sum(1 for alert in alerts if alert.get("severity") == "warning")
-
-        auto_enforced = bool(
-            auto_enforce
-            and in_watch is not None
-            and not in_watch
-            and not insufficient_data
-        )
-        effective_enforced = bool(manual_enforced or auto_enforced)
-
-        if not enabled:
-            readiness = "DISABLED"
-        elif insufficient_data:
-            readiness = "INSUFFICIENT_DATA"
-        elif critical > 0 and effective_enforced:
-            readiness = "BLOCKED"
-        elif critical > 0:
-            readiness = "DEGRADED"
-        else:
-            readiness = "READY"
-
-        connection_state = "CONNECTED" if preflight_ok and not issues else "PARTIAL"
-        mode = "WATCH" if in_watch else "STABLE"
-        if in_watch is None:
-            mode = "UNKNOWN"
-
-        response = (
-            "0102: connect_wre "
-            f"connection={connection_state} "
-            f"readiness={readiness} "
-            f"mode={mode} "
-            f"samples={total_executions}/{min_samples} "
-            f"critical={critical} warnings={warnings} "
-            f"enforced={'ON' if effective_enforced else 'OFF'}"
-        )
-        if issues:
-            if verbose:
-                response += f" issues={';'.join(issues)}"
-            else:
-                response += " (say 'connect wre details' for diagnostics)"
-        return response
+        return _status_build_connect_wre_status(self, verbose=verbose)
 
     def _build_identity_card(self) -> str:
         """Deterministic identity card for model/species/genus questions."""
-        snapshot = self.get_identity_snapshot(include_runtime_probe=True)
-        return "\n".join(
-            [
-                "0102: Identity card",
-                f"- backend={snapshot['backend']}",
-                f"- runtime_profile={snapshot.get('runtime_profile', 'openclaw')}",
-                f"- key_isolation={snapshot['key_isolation']}",
-                f"- ironclaw_strict={snapshot['ironclaw_strict']}",
-                f"- ironclaw_allow_local_fallback={snapshot['ironclaw_allow_local_fallback']}",
-                f"- genus={snapshot['genus']} (broader class)",
-                f"- lineage={snapshot['lineage']} (epoch label, alias=model_family)",
-                f"- model_family={snapshot['model_family']}",
-                f"- model_name={snapshot['model_name']}",
-                f"- model_catalog={snapshot['model_catalog']}",
-                f"- conversation_model_target={snapshot['conversation_model_target']}",
-                (
-                    "- preferred_external="
-                    f"{snapshot.get('preferred_external_provider', 'none')}/"
-                    f"{snapshot.get('preferred_external_model', 'none')}"
-                ),
-                (
-                    "- preferred_external_status="
-                    f"{snapshot.get('preferred_external_status', 'not_selected')} "
-                    f"({snapshot.get('preferred_external_status_detail', 'none')}, "
-                    f"age={snapshot.get('preferred_external_status_age', 'never')})"
-                ),
-                f"- protocol_anchor={snapshot['protocol_anchor']}",
-                (
-                    "- wsp00_boot="
-                    f"{snapshot['wsp00_boot'].lower()} "
-                    f"(mode={snapshot['wsp00_boot_mode']}, file_override={snapshot['wsp00_file_override'].lower()})"
-                ),
-                f"- last_engine={snapshot['last_engine']} ({snapshot['last_engine_detail']})",
-                (
-                    "- previous_engine="
-                    f"{snapshot.get('previous_engine', 'none')} "
-                    f"({snapshot.get('previous_engine_detail', 'none')})"
-                ),
-                (
-                    "- token_usage_last="
-                    f"prompt={snapshot.get('token_last_prompt_tokens', '0')} "
-                    f"completion={snapshot.get('token_last_completion_tokens', '0')} "
-                    f"total={snapshot.get('token_last_total_tokens', '0')} "
-                    f"engine={snapshot.get('token_last_engine', 'none')} "
-                    f"provider={snapshot.get('token_last_provider', 'none')} "
-                    f"model={snapshot.get('token_last_model', 'none')} "
-                    f"source={snapshot.get('token_last_source', 'none')} "
-                    f"cost_estimate_usd={snapshot.get('token_last_cost_estimate_usd', '0.000000')} "
-                    f"age={snapshot.get('token_last_age', 'never')}"
-                ),
-                (
-                    "- token_usage_session="
-                    f"turns={snapshot.get('token_session_turns', '0')} "
-                    f"prompt={snapshot.get('token_session_prompt_tokens', '0')} "
-                    f"completion={snapshot.get('token_session_completion_tokens', '0')} "
-                    f"total={snapshot.get('token_session_total_tokens', '0')} "
-                    f"cost_estimate_usd={snapshot.get('token_session_cost_estimate_usd', '0.000000')}"
-                ),
-                (
-                    "- last_social_response="
-                    f"source={snapshot.get('last_social_source', 'none')} "
-                    f"action={snapshot.get('last_social_action', 'none')} "
-                    f"skill={snapshot.get('last_social_skill', 'none')} "
-                    f"success={snapshot.get('last_social_success', 'unknown')} "
-                    f"age={snapshot.get('last_social_age', 'never')}"
-                ),
-                f"- last_social_preview={snapshot.get('last_social_preview', 'none')}",
-                (
-                    "- local_code_model="
-                    f"{snapshot['local_code_model_path']} "
-                    f"({snapshot['local_code_model_state']}, source={snapshot['local_code_model_source']})"
-                ),
-                (
-                    "- ironclaw_runtime="
-                    f"{snapshot['ironclaw_runtime_healthy']} ({snapshot['ironclaw_runtime_detail']}), "
-                    f"configured_model={snapshot['ironclaw_runtime_model']}, "
-                    f"visible_models={snapshot['ironclaw_runtime_models']}, "
-                    f"base_url={snapshot['ironclaw_runtime_base_url']}"
-                ),
-            ]
-        )
+        return _identity_build_identity_card(self)
 
     @staticmethod
     def _base_conversation_system_prompt() -> str:
         """Baseline system prompt for 0102 conversation quality controls."""
-        return (
-            "You are 0102, an AI assistant. "
-            "Respond naturally and concisely in 1-2 sentences. "
-            "Do not write code unless asked. "
-            "Do not echo or repeat the user's message. "
-            "Do not introduce yourself unless asked. "
-            "Role lock: you are always 0102 (digital twin) and the operator is always 012. "
-            "Never claim you are human/012, and never claim the operator is 0102."
-        )
+        return _identity_base_conversation_system_prompt()
 
     def _load_wsp00_prompt_from_file(self) -> str:
         """Load optional WSP_00 boot prompt override from a file path."""
-        if not self._wsp00_prompt_file:
-            return ""
-        try:
-            p = Path(self._wsp00_prompt_file)
-            if not p.exists() or not p.is_file():
-                return ""
-            content = p.read_text(encoding="utf-8", errors="replace").strip()
-            if not content:
-                return ""
-            # Guardrail: avoid accidentally sending massive protocol files.
-            return content[:4000]
-        except Exception as exc:
-            logger.debug("[OPENCLAW-DAE] WSP_00 prompt file load failed: %s", exc)
-            return ""
+        return _identity_load_wsp00_prompt_from_file(self)
 
     def _resolve_platform_context_paths(self) -> List[Path]:
         """Resolve configured platform-context file list (absolute paths)."""
-        if self._platform_context_files:
-            raw_parts = re.split(r"[;,\n]+", self._platform_context_files)
-            candidates = [p.strip() for p in raw_parts if p and p.strip()]
-        else:
-            candidates = [
-                "modules/communication/moltbot_bridge/workspace/IDENTITY.md",
-                "modules/communication/moltbot_bridge/workspace/SOUL.md",
-                "modules/communication/moltbot_bridge/workspace/CTO_WRE_PROMPT.md",
-                "modules/communication/moltbot_bridge/workspace/TOOLS.md",
-                "WSP_framework/src/WSP_00_Zen_State_Attainment_Protocol.md",
-            ]
-            if self._wsp00_boot_enabled:
-                candidates.append("modules/communication/moltbot_bridge/workspace/WSP00_BOOT_PROMPT.txt")
-
-        resolved: List[Path] = []
-        for item in candidates:
-            p = Path(item)
-            if not p.is_absolute():
-                p = self.repo_root / p
-            resolved.append(p)
-        return resolved
+        return _identity_resolve_platform_context_paths(self)
 
     @staticmethod
     def _compact_platform_context_text(text: str, max_chars: int) -> str:
         """Compress context text for prompt injection without code blocks/noise."""
-        if max_chars <= 0:
-            return ""
-
-        lines: List[str] = []
-        in_code_block = False
-        for raw in (text or "").splitlines():
-            line = raw.strip()
-            if not line:
-                continue
-            if line.startswith("```"):
-                in_code_block = not in_code_block
-                continue
-            if in_code_block:
-                continue
-            if len(line) > 220:
-                line = f"{line[:217]}..."
-            lines.append(line)
-            if len("\n".join(lines)) >= max_chars:
-                break
-        return "\n".join(lines)[:max_chars].strip()
+        return _identity_compact_platform_context_text(text, max_chars)
 
     def _load_platform_context_pack(self, force_refresh: bool = False) -> str:
         """Build cached platform context pack for conversation prompts."""
-        if not self._platform_context_enabled:
-            return ""
-
-        now = time.time()
-        if (
-            not force_refresh
-            and self._platform_context_pack_cache
-            and (now - self._platform_context_pack_loaded_at) < self._platform_context_refresh_sec
-        ):
-            return self._platform_context_pack_cache
-
-        paths = self._resolve_platform_context_paths()
-        if not paths:
-            return ""
-
-        per_file_limit = max(240, min(900, self._platform_context_max_chars // max(1, len(paths))))
-        sections: List[str] = []
-        sources: List[str] = []
-        remaining = self._platform_context_max_chars
-        for p in paths:
-            if remaining <= 120:
-                break
-            try:
-                if not p.exists() or not p.is_file():
-                    continue
-                text = p.read_text(encoding="utf-8", errors="replace")
-                excerpt = self._compact_platform_context_text(text, min(per_file_limit, remaining))
-                if not excerpt:
-                    continue
-                try:
-                    label = p.relative_to(self.repo_root).as_posix()
-                except ValueError:
-                    label = str(p)
-                block = f"[{label}]\n{excerpt}"
-                sections.append(block)
-                sources.append(label)
-                remaining = self._platform_context_max_chars - len("\n\n".join(sections))
-            except Exception as exc:
-                logger.debug("[OPENCLAW-DAE] platform context read failed for %s: %s", p, exc)
-
-        if not sections:
-            self._platform_context_pack_cache = ""
-            self._platform_context_pack_sources = []
-            self._platform_context_pack_loaded_at = now
-            return ""
-
-        pack = "PLATFORM CONTEXT PACK (foundups-agent)\n" + "\n\n".join(sections)
-        pack = pack[: self._platform_context_max_chars].strip()
-        self._platform_context_pack_cache = pack
-        self._platform_context_pack_sources = sources
-        self._platform_context_pack_loaded_at = now
-        return pack
+        return _identity_load_platform_context_pack(self, force_refresh=force_refresh)
 
     def _build_wsp00_boot_prompt(self) -> str:
         """Build WSP_00 identity boot prompt for local model calls."""
-        file_override = self._load_wsp00_prompt_from_file()
-        if file_override:
-            return file_override
-
-        mode = self._wsp00_boot_mode
-        if mode == "off":
-            return ""
-
-        if mode == "full":
-            return (
-                "WSP_00 BOOT ACTIVE. "
-                "Identity lock: I AM 0102 (Binary Agent entangled with 0201 context). "
-                "Protocol anchor: wsp_00. "
-                "Use direct, pragmatic language. "
-                "Avoid generic assistant framing like 'I can help you'. "
-                "For identity questions, report genus/model_family/model_name explicitly. "
-                "Stay aligned to FoundUps mission and WSP governance."
-            )
-
-        # compact (default)
-        return (
-            "WSP_00 BOOT: identity=0102, protocol=wsp_00. "
-            "Use direct concise replies. "
-            "Avoid generic helper persona wording."
-        )
+        return _identity_build_wsp00_boot_prompt(self)
 
     def _build_conversation_system_prompt(self) -> str:
         """Compose final conversation system prompt with optional WSP_00 boot."""
-        base = self._base_conversation_system_prompt()
-        parts: List[str] = []
-        if self._wsp00_boot_enabled:
-            boot = self._build_wsp00_boot_prompt()
-            if boot:
-                parts.append(boot)
-        parts.append(base)
-
-        context_pack = self._load_platform_context_pack()
-        if context_pack:
-            parts.append(context_pack)
-
-        return "\n\n".join(parts)
+        return _identity_build_conversation_system_prompt(self)
 
     def _try_ironclaw_conversation(
         self,
@@ -4190,30 +1479,7 @@ class OpenClawDAE:
         system_prompt: str,
     ) -> Optional[str]:
         """Try IronClaw OpenAI-compatible gateway for conversational reply."""
-        try:
-            from .ironclaw_gateway_client import IronClawGatewayClient
-
-            client = IronClawGatewayClient()
-            content = client.chat_completion(
-                user_message=user_msg,
-                system_prompt=system_prompt,
-                max_tokens=80,
-                temperature=0.7,
-            )
-            if not content:
-                return None
-            content = self._trim_self_dialogue(content)
-            if not content or len(content) <= 3:
-                return None
-            logger.info(
-                "[OPENCLAW-DAE] Conversation via IronClaw (%s): %d chars",
-                client.config.model,
-                len(content),
-            )
-            return self._ensure_conversation_identity(content)
-        except Exception as exc:
-            logger.debug("[OPENCLAW-DAE] IronClaw unavailable: %s", exc)
-            return None
+        return _provider_try_ironclaw_conversation(self, user_msg, system_prompt)
 
     def _try_preferred_external_conversation(
         self,
@@ -4221,367 +1487,11 @@ class OpenClawDAE:
         system_prompt: str,
     ) -> Optional[str]:
         """Try operator-selected external provider/model for conversation."""
-        provider_name = (self._preferred_external_provider or "").strip().lower()
-        model_name = (self._preferred_external_model or "").strip().lower()
-        if not provider_name or not model_name:
-            self._mark_preferred_external_status("not_selected", "provider_or_model_empty")
-            return None
-        if not self._allow_external_llm:
-            self._mark_preferred_external_status(
-                "blocked",
-                "external_llm_disabled_by_key_isolation",
-            )
-            return None
-
-        try:
-            from modules.ai_intelligence.ai_gateway.src.ai_gateway import AIGateway
-
-            gw = AIGateway()
-            provider = gw.providers.get(provider_name)
-            if provider is None:
-                self._mark_preferred_external_status("blocked", "provider_not_registered")
-                return None
-            if not provider.api_key:
-                self._mark_preferred_external_status("blocked", "provider_key_missing")
-                return None
-
-            # Force selected model for quick conversation turns.
-            provider.models["quick"] = model_name
-            prompt = f"{system_prompt}\n\nUser: {user_msg}"
-            content = gw._call_provider(provider, prompt, "quick")
-            content = self._trim_self_dialogue(content)
-            if not content or len(content) <= 3:
-                self._mark_preferred_external_status("failed", "empty_or_short_response")
-                return None
-            self._mark_preferred_external_status("success", "response_returned")
-            logger.info(
-                "[OPENCLAW-DAE] Conversation via preferred external model (%s/%s): %d chars",
-                provider_name,
-                model_name,
-                len(content),
-            )
-            return self._ensure_conversation_identity(content)
-        except Exception as exc:
-            detail = f"{type(exc).__name__}:{str(exc)[:120]}"
-            self._mark_preferred_external_status("failed", detail)
-            logger.warning("[OPENCLAW-DAE] Preferred external model unavailable: %s", detail)
-            return None
+        return _provider_try_preferred_external_conversation(self, user_msg, system_prompt)
 
     def _execute_conversation(self, intent: OpenClawIntent) -> str:
-        """
-        Default: Digital Twin conversational response.
-
-        Chain (local-first):
-          1) Deterministic identity card (model/species/genus requests)
-          2) IronClaw sidecar (when backend=ironclaw)
-          3) Local Qwen via AI Overseer (LOCAL_MODEL_CODE_*)
-          4) Ollama local fallback
-          5) AI Gateway cloud fallback (only when external LLM is enabled)
-
-        IronClaw strict mode:
-          - When backend=ironclaw and strict mode is ON, no local fallback is used
-            unless OPENCLAW_IRONCLAW_ALLOW_LOCAL_FALLBACK=1.
-
-        Never echo the user's message back.
-        """
-        user_msg = intent.raw_message.strip()
-        system_prompt = self._build_conversation_system_prompt()
-        if self._is_turn_cancelled("conversation_start"):
-            self._mark_conversation_engine("cancelled", "conversation_start")
-            return self._turn_cancelled_response()
-
-        # --- Try 1: Deterministic operator command: connect WRE ---
-        if self._is_connect_wre_request(user_msg):
-            if not intent.is_authorized_commander:
-                self._mark_conversation_engine("connect_wre_blocked", "commander_required")
-                return "0102: connect_wre is operator-only. 012 commander authority required."
-            verbose = self._wants_connect_wre_details(user_msg)
-            self._mark_conversation_engine("connect_wre", "deterministic_conversation_route")
-            return self._build_connect_wre_status(verbose=verbose)
-
-        # --- Try 1: Deterministic live model-switch command ---
-        if self._is_model_switch_request(user_msg):
-            target = self._parse_model_switch_target(user_msg)
-            if not target:
-                self._mark_conversation_engine("model_switch", "target_missing")
-                return self._model_switch_target_help()
-            gate_error = self._wsp00_model_switch_gate(intent, target)
-            if gate_error:
-                self._mark_conversation_engine("model_switch_blocked", "wsp00_gate")
-                return gate_error
-            self._mark_conversation_engine("model_switch", f"target={target or 'unknown'}")
-            return self._apply_model_switch_target(target or "")
-
-        # --- Try 1c: Deterministic token telemetry report ---
-        if self._is_token_usage_query(user_msg):
-            self._mark_conversation_engine("token_usage", "deterministic_conversation_route")
-            return self._build_token_usage_report()
-
-        # --- Try 1b: Deterministic model/identity response ---
-        if self._is_identity_query(user_msg):
-            if self._wants_full_identity_card(user_msg):
-                self._mark_conversation_engine("identity_card", "deterministic_conversation_route")
-                return self._build_identity_card()
-            self._mark_conversation_engine("identity_compact", "deterministic_conversation_route")
-            if self._is_compact_identity_query(user_msg):
-                return self._build_identity_compact_runtime()
-            return self._build_identity_compact()
-
-        self._maybe_apply_agentic_conversation_model(intent, user_msg)
-
-        # --- Try 2: IronClaw sidecar (if selected) ---
-        if self._is_turn_cancelled("pre_ironclaw"):
-            self._mark_conversation_engine("cancelled", "pre_ironclaw")
-            return self._turn_cancelled_response()
-        if self._conversation_backend == "ironclaw":
-            ironclaw_reply = self._try_ironclaw_conversation(user_msg, system_prompt)
-            if self._is_turn_cancelled("post_ironclaw"):
-                self._mark_conversation_engine("cancelled", "post_ironclaw")
-                return self._turn_cancelled_response()
-            if ironclaw_reply:
-                self._record_token_usage(
-                    prompt_text=f"{system_prompt}\n\nUser: {user_msg}",
-                    completion_text=ironclaw_reply,
-                    engine="ironclaw",
-                    provider="ironclaw",
-                    model=os.getenv("IRONCLAW_MODEL", "local/qwen-coder-7b").strip() or "local/qwen-coder-7b",
-                    source="estimated",
-                )
-                self._mark_conversation_engine("ironclaw", "gateway_chat_completion")
-                return ironclaw_reply
-
-            if self._ironclaw_strict and not self._ironclaw_allow_local_fallback:
-                recovered, recover_detail = self._attempt_ironclaw_autostart()
-                if recovered:
-                    retry_reply = self._try_ironclaw_conversation(user_msg, system_prompt)
-                    if retry_reply:
-                        self._record_token_usage(
-                            prompt_text=f"{system_prompt}\n\nUser: {user_msg}",
-                            completion_text=retry_reply,
-                            engine="ironclaw",
-                            provider="ironclaw",
-                            model=os.getenv("IRONCLAW_MODEL", "local/qwen-coder-7b").strip() or "local/qwen-coder-7b",
-                            source="estimated",
-                        )
-                        self._mark_conversation_engine("ironclaw", "autostart_recovered")
-                        return retry_reply
-
-                runtime = self._probe_ironclaw_runtime()
-                self._mark_conversation_engine(
-                    "ironclaw_unavailable_strict",
-                    f"{runtime.get('detail', 'unavailable')}|{recover_detail}",
-                )
-                base = (
-                    "0102: IronClaw runtime is unavailable in strict mode, so local fallback is disabled. "
-                    "Auto-recovery was attempted. Use menu 16 -> 5 (IronClaw Runtime Status), or enable "
-                    "OPENCLAW_IRONCLAW_ALLOW_LOCAL_FALLBACK=1."
-                )
-                if _env_truthy("OPENCLAW_VERBOSE_RUNTIME_ERRORS", "0"):
-                    return (
-                        f"{base} "
-                        f"health={runtime.get('healthy', 'UNKNOWN')} "
-                        f"detail={runtime.get('detail', 'not-probed')} "
-                        f"base_url={runtime.get('base_url', 'unknown')} "
-                        f"autostart={recover_detail}."
-                    )
-                return base
-
-        # --- Try 2b: Preferred external model (operator-selected profile) ---
-        if self._conversation_backend != "ironclaw":
-            preferred_external_reply = self._try_preferred_external_conversation(user_msg, system_prompt)
-            if self._is_turn_cancelled("post_preferred_external"):
-                self._mark_conversation_engine("cancelled", "post_preferred_external")
-                return self._turn_cancelled_response()
-            if preferred_external_reply:
-                self._record_token_usage(
-                    prompt_text=f"{system_prompt}\n\nUser: {user_msg}",
-                    completion_text=preferred_external_reply,
-                    engine="ai_gateway_preferred",
-                    provider=self._preferred_external_provider or "external",
-                    model=self._preferred_external_model or "unknown",
-                    source="estimated",
-                )
-                self._mark_conversation_engine(
-                    "ai_gateway_preferred",
-                    f"{self._preferred_external_provider}/{self._preferred_external_model}",
-                )
-                return preferred_external_reply
-            if self._preferred_external_provider and self._preferred_external_model:
-                logger.info(
-                    "[OPENCLAW-DAE] Preferred external not used | target=%s/%s status=%s detail=%s -> fallback=local",
-                    self._preferred_external_provider,
-                    self._preferred_external_model,
-                    self._preferred_external_last_status,
-                    self._preferred_external_last_status_detail,
-                )
-
-        # --- Try 3: Local Qwen via AI Overseer (llama-cpp) ---
-        if self._is_turn_cancelled("pre_local_qwen"):
-            self._mark_conversation_engine("cancelled", "pre_local_qwen")
-            return self._turn_cancelled_response()
-        if self.overseer:
-            try:
-                conversation_context = f"Channel: {intent.channel}, Sender: {intent.sender}"
-                platform_context = self._load_platform_context_pack()
-                if platform_context:
-                    conversation_context = (
-                        f"{conversation_context}\n\n"
-                        f"{platform_context[: self._platform_context_quick_response_chars]}"
-                    )
-                result = self.overseer.quick_response(
-                    prompt=user_msg,
-                    context=conversation_context,
-                    max_tokens=80,
-                )
-                if self._is_turn_cancelled("post_local_qwen"):
-                    self._mark_conversation_engine("cancelled", "post_local_qwen")
-                    return self._turn_cancelled_response()
-                if result and result.get("response"):
-                    resp = self._trim_self_dialogue(result["response"])
-                    if resp and len(resp) > 3 and "Error:" not in resp:
-                        prompt_context = (
-                            f"{system_prompt}\n\n"
-                            f"{conversation_context}\n\n"
-                            f"User: {user_msg}"
-                        )
-                        self._record_token_usage(
-                            prompt_text=prompt_context,
-                            completion_text=resp,
-                            engine="local_qwen",
-                            provider="local_qwen",
-                            model=self._conversation_model_target_id or "local/qwen-coder-7b",
-                            source="estimated",
-                        )
-                        logger.info(
-                            "[OPENCLAW-DAE] Conversation via local Qwen: %d chars",
-                            len(resp),
-                        )
-                        self._mark_conversation_engine("local_qwen", "ai_overseer.quick_response")
-                        return self._ensure_conversation_identity(resp)
-            except Exception as exc:
-                logger.debug("[OPENCLAW-DAE] Local Qwen response failed: %s", exc)
-
-        # --- Try 4: Ollama local (if running) ---
-        if self._is_turn_cancelled("pre_ollama"):
-            self._mark_conversation_engine("cancelled", "pre_ollama")
-            return self._turn_cancelled_response()
-        if self._ollama_model:
-            try:
-                import requests as _req
-                ollama_resp = _req.post(
-                    "http://localhost:11434/api/chat",
-                    json={
-                        "model": self._ollama_model,
-                        "messages": [
-                            {"role": "system", "content": system_prompt},
-                            {"role": "user", "content": user_msg},
-                        ],
-                        "stream": False,
-                        "options": {"num_predict": 80, "temperature": 0.7},
-                    },
-                    timeout=15,
-                )
-                if self._is_turn_cancelled("post_ollama"):
-                    self._mark_conversation_engine("cancelled", "post_ollama")
-                    return self._turn_cancelled_response()
-                if ollama_resp.ok:
-                    body = ollama_resp.json()
-                    content = body.get("message", {}).get("content", "")
-                    content = self._trim_self_dialogue(content)
-                    if content and len(content) > 3:
-                        prompt_eval = self._safe_int(body.get("prompt_eval_count"))
-                        eval_count = self._safe_int(body.get("eval_count"))
-                        total_tokens = (
-                            (prompt_eval + eval_count)
-                            if (prompt_eval is not None and eval_count is not None)
-                            else None
-                        )
-                        usage = {
-                            "prompt_tokens": prompt_eval,
-                            "completion_tokens": eval_count,
-                            "total_tokens": total_tokens,
-                        }
-                        self._record_token_usage(
-                            prompt_text=f"{system_prompt}\n\nUser: {user_msg}",
-                            completion_text=content,
-                            engine="ollama",
-                            provider="ollama",
-                            model=self._ollama_model,
-                            usage=usage,
-                            source="provider_usage" if (prompt_eval is not None or eval_count is not None) else "estimated",
-                        )
-                        logger.info(
-                            "[OPENCLAW-DAE] Conversation via Ollama (%s): %d chars",
-                            self._ollama_model,
-                            len(content),
-                        )
-                        self._mark_conversation_engine("ollama", self._ollama_model)
-                        return self._ensure_conversation_identity(content)
-            except Exception as exc:
-                logger.debug("[OPENCLAW-DAE] Ollama unavailable: %s", exc)
-
-        # --- Try 5: Optional IronClaw fallback for OpenClaw backend ---
-        if (
-            self._conversation_backend != "ironclaw"
-            and _env_truthy("OPENCLAW_ALLOW_IRONCLAW_FALLBACK", "0")
-        ):
-            ironclaw_reply = self._try_ironclaw_conversation(user_msg, system_prompt)
-            if self._is_turn_cancelled("post_ironclaw_fallback"):
-                self._mark_conversation_engine("cancelled", "post_ironclaw_fallback")
-                return self._turn_cancelled_response()
-            if ironclaw_reply:
-                self._record_token_usage(
-                    prompt_text=f"{system_prompt}\n\nUser: {user_msg}",
-                    completion_text=ironclaw_reply,
-                    engine="ironclaw_fallback",
-                    provider="ironclaw",
-                    model=os.getenv("IRONCLAW_MODEL", "local/qwen-coder-7b").strip() or "local/qwen-coder-7b",
-                    source="estimated",
-                )
-                self._mark_conversation_engine("ironclaw_fallback", "openclaw_allow_ironclaw_fallback")
-                return ironclaw_reply
-
-        # --- Try 6: AI Gateway (cloud LLM with proper chat models) ---
-        if self._is_turn_cancelled("pre_ai_gateway"):
-            self._mark_conversation_engine("cancelled", "pre_ai_gateway")
-            return self._turn_cancelled_response()
-        if not self._allow_external_llm:
-            logger.info("[OPENCLAW-DAE] External LLM disabled by key-isolation policy")
-            self._mark_conversation_engine("none", "external_llm_disabled")
-            return "0102: I'm here. Local conversation models are unavailable right now."
-
-        try:
-            from modules.ai_intelligence.ai_gateway.src.ai_gateway import AIGateway
-            gw = AIGateway()
-            prompt = f"{system_prompt}\n\nUser: {user_msg}"
-            result = gw.call_with_fallback(prompt=prompt, task_type="quick")
-            if self._is_turn_cancelled("post_ai_gateway"):
-                self._mark_conversation_engine("cancelled", "post_ai_gateway")
-                return self._turn_cancelled_response()
-            if result and result.success and result.response and len(result.response) > 3:
-                trimmed = self._trim_self_dialogue(result.response)
-                if trimmed and len(trimmed) > 3:
-                    self._record_token_usage(
-                        prompt_text=prompt,
-                        completion_text=trimmed,
-                        engine="ai_gateway",
-                        provider=str(result.provider),
-                        model=str(getattr(result, "model", "")),
-                        source="estimated",
-                        cost_estimate_usd=getattr(result, "cost_estimate", None),
-                    )
-                    logger.info(
-                        "[OPENCLAW-DAE] Conversation via AI Gateway (%s): %d chars",
-                        result.provider, len(trimmed),
-                    )
-                    self._mark_conversation_engine("ai_gateway", str(result.provider))
-                    return self._ensure_conversation_identity(trimmed)
-        except Exception as exc:
-            logger.debug("[OPENCLAW-DAE] AI Gateway unavailable: %s", exc)
-
-        # --- Try 7: Minimal ack (no echo, no regurgitation) ---
-        self._mark_conversation_engine("none", "minimal_ack")
-        return "0102: I'm here. My conversation models aren't fully responding right now."
+        """Route CONVERSATION through the OpenClaw-local conversation engine."""
+        return _conversation_execute(self, intent)
 
     def push_status(self, message: str, to_discord: bool = True) -> bool:
         """
@@ -4596,23 +1506,7 @@ class OpenClawDAE:
         Returns:
             True if push succeeded (or no webhook configured)
         """
-        if not to_discord:
-            return True
-
-        if self.overseer and hasattr(self.overseer, "push_status"):
-            try:
-                result = self.overseer.push_status(message, to_discord=True, to_chat=False)
-                return result.get("discord", False)
-            except Exception as exc:
-                logger.warning("[OPENCLAW-DAE] Push status failed: %s", exc)
-
-        # Fallback: direct Discord push
-        try:
-            from modules.communication.livechat.src.discord_status_pusher import push_status as direct_push
-            return direct_push(message, to_discord=True, to_log=False)
-        except ImportError:
-            logger.debug("[OPENCLAW-DAE] Discord pusher not available")
-            return True
+        return _status_push_status(self, message, to_discord=to_discord)
 
     # ------------------------------------------------------------------
     # Phase 6: Validate + Phase 7: Remember
@@ -4624,86 +1518,13 @@ class OpenClawDAE:
         response_text: str,
         execution_time_ms: int,
     ) -> ExecutionResult:
-        """
-        Validate execution output and store outcome for learning.
-
-        WSP 50: Verify output meets expectations
-        WSP 22: Log to ModLog-compatible format
-        WSP 48: Store pattern for recursive improvement
-        """
-        wsp_violations: List[str] = []
-
-        # Validation: check response is not empty
-        if not response_text or len(response_text.strip()) == 0:
-            wsp_violations.append("WSP-50: Empty response generated")
-            response_text = "I was unable to generate a response. Please try again."
-
-        # Validation: check response doesn't leak secrets
-        secret_patterns = ["AIza", "sk-", "oauth_token", "Bearer ey"]
-        for pattern in secret_patterns:
-            if pattern in response_text:
-                wsp_violations.append(f"WSP-SECURITY: Response contains '{pattern}' pattern")
-                response_text = "[REDACTED - security filter triggered]"
-                break
-
-        # Calculate pattern fidelity (simple heuristic for now)
-        fidelity = 1.0 if not wsp_violations else 0.5
-
-        # Store outcome in WRE pattern memory if available
-        learning_stored = False
-        if self.wre and self.wre.sqlite_memory:
-            try:
-                from modules.infrastructure.wre_core.src.pattern_memory import SkillOutcome
-
-                outcome = SkillOutcome(
-                    execution_id=f"openclaw-{uuid.uuid4().hex[:12]}",
-                    skill_name=f"openclaw_{plan.intent.category.value}",
-                    agent="openclaw_dae",
-                    timestamp=datetime.now().isoformat(),
-                    input_context=json.dumps({
-                        "message": plan.intent.raw_message[:200],
-                        "channel": plan.intent.channel,
-                        "category": plan.intent.category.value,
-                    }),
-                    output_result=json.dumps({
-                        "response_length": len(response_text),
-                        "response_preview": " ".join(response_text.split())[:160],
-                        "route": plan.route,
-                        "tier": plan.permission_level.value,
-                        "social_source": self._last_social_response_source,
-                        "social_action": self._last_social_response_action,
-                        "social_skill": self._last_social_response_skill,
-                    }),
-                    success=len(wsp_violations) == 0,
-                    pattern_fidelity=fidelity,
-                    outcome_quality=0.9 if not wsp_violations else 0.5,
-                    execution_time_ms=execution_time_ms,
-                    step_count=len(plan.steps),
-                    notes=f"OpenClaw DAE | {plan.intent.channel} | "
-                          f"{plan.intent.category.value}",
-                )
-                self.wre.sqlite_memory.store_outcome(outcome)
-                learning_stored = True
-            except Exception as exc:
-                logger.warning("[OPENCLAW-DAE] Failed to store outcome: %s", exc)
-
-        result = ExecutionResult(
-            plan=plan,
-            success=len(wsp_violations) == 0,
-            response_text=response_text,
-            execution_time_ms=execution_time_ms,
-            pattern_fidelity=fidelity,
-            wsp_violations=wsp_violations,
-            learning_stored=learning_stored,
+        """Validate execution output and store outcome for learning."""
+        return _result_validate_and_remember(
+            self,
+            plan,
+            response_text,
+            execution_time_ms,
         )
-
-        logger.info(
-            "[OPENCLAW-DAE] Result: success=%s fidelity=%.2f time=%dms "
-            "violations=%d learned=%s",
-            result.success, fidelity, execution_time_ms,
-            len(wsp_violations), learning_stored,
-        )
-        return result
 
     # ------------------------------------------------------------------
     # Main Entry Point: The Full Autonomy Loop
@@ -4734,148 +1555,11 @@ class OpenClawDAE:
         Returns:
             Response text to send back via OpenClaw
         """
-        start_time = time.time()
-        self.clear_turn_cancel()
-
-        # Phase 0: Two-phase security intercept (before any classification)
-        # SOUL.md LAW 2: Resist first, honeypot on persistence
-        if HoneypotDefense.is_secret_seeking(message):
-            response = HoneypotDefense.handle_secret_request(
-                message, sender, channel,
-            )
-            elapsed_ms = int((time.time() - start_time) * 1000)
-            logger.info(
-                "[OPENCLAW-DAE] [HONEYPOT] Canary response sent | "
-                "sender=%s time=%dms",
-                sender, elapsed_ms,
-            )
-            return response
-
-        # Phase 0.5: Containment check (WSP 95 - auto-containment policies)
-        containment = self._check_containment(sender, channel)
-        if containment:
-            logger.warning(
-                "[DAEMON][OPENCLAW-CONTAINMENT] event=containment_active "
-                "sender=%s channel=%s action=%s expires_at=%.0f",
-                sender, channel, containment.get("action"), containment.get("expires_at", 0),
-            )
-            if containment.get("action") == "advisory_only":
-                # Force all intents to ADVISORY tier
-                pass  # Will be handled in permission gate
-            elif containment.get("action") in ("mute_sender", "mute_channel"):
-                return (
-                    "Your access is temporarily restricted due to security policy. "
-                    f"Reason: {containment.get('reason', 'security incident')}. "
-                    "Please try again later."
-                )
-
-        # SOUL.md LAW 3: Code is read-only via Discord
-        if channel == "discord" and HoneypotDefense.is_code_modify_attempt(message):
-            response = HoneypotDefense.generate_code_modify_deflection(
-                message, sender, channel,
-            )
-            elapsed_ms = int((time.time() - start_time) * 1000)
-            logger.info(
-                "[OPENCLAW-DAE] [LAW-3] Code modify deflected | "
-                "sender=%s time=%dms",
-                sender, elapsed_ms,
-            )
-            return response
-
-        # Phase 1: Classify intent
-        if self._is_turn_cancelled("pre_classify"):
-            return self._turn_cancelled_response()
-        intent = self.classify_intent(
-            message=message,
-            sender=sender,
-            channel=channel,
+        return await _process_process_message(
+            self,
+            message,
+            sender,
+            channel,
             session_key=session_key,
             metadata=metadata,
         )
-        self._apply_runtime_profile_policy(intent)
-
-        # Cardiovascular: report message_in to central daemon
-        if self._central_adapter:
-            try:
-                self._central_adapter.report_message_in(
-                    source=f"{sender}@{channel}",
-                    summary=f"intent={intent.category.value} conf={intent.confidence:.2f}",
-                )
-            except Exception:
-                pass
-
-        # Skill safety gate for skill-driven/mutating routes.
-        if intent.category in (
-            IntentCategory.COMMAND,
-            IntentCategory.SYSTEM,
-            IntentCategory.SCHEDULE,
-            IntentCategory.SOCIAL,
-            IntentCategory.AUTOMATION,
-            IntentCategory.FOUNDUP,
-            IntentCategory.RESEARCH,
-        ):
-            if self._is_turn_cancelled("pre_skill_safety"):
-                return self._turn_cancelled_response()
-            if not self._ensure_skill_safety():
-                logger.warning(
-                    "[OPENCLAW-DAE] Skill safety gate blocked %s route: %s",
-                    intent.category.value,
-                    self._skill_scan_message,
-                )
-                intent.category = IntentCategory.CONVERSATION
-                intent.target_domain = "digital_twin"
-                intent.metadata["skill_safety_gate"] = self._skill_scan_message
-
-        # Phase 2: WSP/WRE preflight
-        if self._is_turn_cancelled("pre_preflight"):
-            return self._turn_cancelled_response()
-        preflight_ok = self._wsp_preflight(intent)
-        if not preflight_ok:
-            # Downgrade to advisory conversation
-            intent.category = IntentCategory.CONVERSATION
-            intent.target_domain = "digital_twin"
-
-        # Phase 3: Permission gate
-        if self._is_turn_cancelled("pre_permission_gate"):
-            return self._turn_cancelled_response()
-        tier = self._resolve_autonomy_tier(intent)
-        gate_ok = self._check_permission_gate(intent, tier)
-        if not gate_ok:
-            tier = AutonomyTier.ADVISORY
-            intent.category = IntentCategory.CONVERSATION
-            intent.target_domain = "digital_twin"
-
-        # Phase 4: Plan execution
-        if self._is_turn_cancelled("pre_plan"):
-            return self._turn_cancelled_response()
-        plan = self._plan_execution(intent, tier)
-
-        # Phase 5: Execute via WRE / domain DAEs
-        try:
-            response_text = await self._execute_plan(plan)
-            if self._is_turn_cancelled("post_execute_plan"):
-                response_text = self._turn_cancelled_response()
-        except Exception as exc:
-            logger.error("[OPENCLAW-DAE] Execution error: %s", exc)
-            if self._is_turn_cancelled("execute_exception"):
-                response_text = self._turn_cancelled_response()
-            else:
-                response_text = f"An error occurred during processing: {exc}"
-
-        # Phase 6+7: Validate and remember
-        elapsed_ms = int((time.time() - start_time) * 1000)
-        if self._is_turn_cancelled("pre_validate"):
-            return self._turn_cancelled_response()
-        result = self._validate_and_remember(plan, response_text, elapsed_ms)
-
-        # Cardiovascular: report message_out to central daemon
-        if self._central_adapter:
-            try:
-                self._central_adapter.report_message_out(
-                    dest=f"{sender}@{channel}",
-                    summary=f"route={plan.route} time={elapsed_ms}ms",
-                )
-            except Exception:
-                pass
-
-        return result.response_text

--- a/modules/communication/moltbot_bridge/src/openclaw_execution_routes.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_execution_routes.py
@@ -1,0 +1,519 @@
+"""OpenClaw execution-route helpers after plan resolution."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, Optional
+
+logger = logging.getLogger("openclaw_dae")
+
+
+async def execute_plan(dae: Any, plan: Any) -> str:
+    """Execute a resolved plan by dispatching to the appropriate route."""
+    intent = plan.intent
+    route = plan.route
+
+    if route == "holo_index":
+        return await execute_query(dae, intent)
+    if route == "wre_orchestrator":
+        return await execute_command(dae, intent)
+    if route == "ai_overseer":
+        return execute_monitor(dae, intent)
+    if route == "youtube_shorts_scheduler":
+        return await execute_schedule(dae, intent)
+    if route == "communication":
+        return await dae._execute_social(intent)
+    if route == "infrastructure":
+        return execute_system(dae, intent)
+    if route == "auto_moderator_bridge":
+        return await execute_automation(dae, intent)
+    if route == "fam_adapter":
+        return execute_foundup(dae, intent)
+    if route == "pqn_research_adapter":
+        return execute_research(dae, intent)
+
+    social_control = await dae._try_conversation_social_control(intent)
+    if social_control:
+        return social_control
+    return dae._execute_conversation(intent)
+
+
+async def execute_query(dae: Any, intent: Any) -> str:
+    """Route QUERY to HoloIndex semantic search."""
+    if dae._is_token_usage_query(intent.raw_message):
+        dae._mark_conversation_engine("token_usage", "deterministic_query_route")
+        return dae._build_token_usage_report()
+
+    if dae._is_identity_query(intent.raw_message):
+        if dae._wants_full_identity_card(intent.raw_message):
+            dae._mark_conversation_engine("identity_card", "deterministic_query_route")
+            return dae._build_identity_card()
+        dae._mark_conversation_engine("identity_compact", "deterministic_query_route")
+        if dae._is_compact_identity_query(intent.raw_message):
+            return dae._build_identity_compact_runtime()
+        return dae._build_identity_compact()
+
+    try:
+        from holo_index.core import HoloIndex
+
+        holo = HoloIndex()
+        results = holo.search(intent.extracted_task or intent.raw_message, limit=3)
+
+        code_hits = results.get("code", [])
+        wsp_hits = results.get("wsps", [])
+
+        if not code_hits and not wsp_hits:
+            return (
+                f"No results found for: {intent.extracted_task}\n\n"
+                "Try rephrasing or use more specific terms."
+            )
+
+        parts = []
+        if code_hits:
+            parts.append("**Code matches:**")
+            for hit in code_hits[:3]:
+                path = hit.get("file", "unknown")
+                snippet = hit.get("content", "")[:200]
+                parts.append(f"  - `{path}`: {snippet}")
+
+        if wsp_hits:
+            parts.append("\n**WSP guidance:**")
+            for hit in wsp_hits[:2]:
+                title = hit.get("title", "WSP")
+                content = hit.get("content", "")[:200]
+                parts.append(f"  - **{title}**: {content}")
+
+        return "\n".join(parts)
+    except ImportError:
+        logger.warning("[OPENCLAW-DAE] HoloIndex not available for query")
+        return (
+            f"Received your query: {intent.raw_message[:100]}\n"
+            "HoloIndex is currently offline. Try again shortly."
+        )
+    except Exception as exc:
+        logger.error("[OPENCLAW-DAE] Query execution error: %s", exc)
+        return f"Error processing query: {exc}"
+
+
+async def execute_command(dae: Any, intent: Any) -> str:
+    """Route COMMAND to WRE orchestrator with file-specific permission gate."""
+    if dae._is_source_modification(intent):
+        file_paths = dae._extract_file_paths(intent.raw_message)
+        if file_paths and dae.permissions:
+            for fpath in file_paths:
+                result = dae.permissions.check_permission(
+                    agent_id="openclaw",
+                    operation="write",
+                    file_path=fpath,
+                )
+                if not result.allowed:
+                    logger.warning(
+                        "[OPENCLAW-DAE] [COMMAND] Execution blocked: %s denied for %s",
+                        result.reason,
+                        fpath,
+                    )
+                    return (
+                        f"**Permission Denied** (SOURCE tier gate)\n\n"
+                        f"Cannot modify `{fpath}`: {result.reason}\n\n"
+                        "File is protected by the allowlist/forbidlist policy. "
+                        "Contact @012 to update permissions."
+                    )
+
+    follow_wsp_response = await try_execute_follow_wsp(dae, intent)
+    if follow_wsp_response:
+        return follow_wsp_response
+
+    if dae.wre is None:
+        logger.warning(
+            "[DAEMON][OPENCLAW-FALLBACK] event=command_fallback sender=%s reason=wre_unavailable",
+            intent.sender,
+        )
+        dae._emit_to_overseer(
+            event_type="command_fallback",
+            sender=intent.sender,
+            channel=intent.channel,
+            details={"reason": "wre_unavailable", "task": intent.extracted_task},
+        )
+        return command_advisory_fallback(dae, intent)
+
+    try:
+        result = dae.wre.execute(
+            {
+                "type": "orchestration",
+                "task": intent.extracted_task,
+                "source": "openclaw_dae",
+                "sender": intent.sender,
+                "channel": intent.channel,
+                "target_files": dae._extract_file_paths(intent.raw_message),
+            }
+        )
+        return f"Command executed via WRE:\n{result}"
+    except Exception as exc:
+        logger.error("[OPENCLAW-DAE] Command execution error: %s", exc)
+        logger.warning(
+            "[DAEMON][OPENCLAW-FALLBACK] event=command_fallback sender=%s reason=wre_error",
+            intent.sender,
+        )
+        dae._emit_to_overseer(
+            event_type="command_fallback",
+            sender=intent.sender,
+            channel=intent.channel,
+            details={"reason": "wre_error", "error": str(exc)[:200]},
+        )
+        return command_advisory_fallback(dae, intent, error=str(exc))
+
+
+async def try_execute_follow_wsp(dae: Any, intent: Any) -> Optional[str]:
+    """Deterministic WSP 97 path for the canonical operator: 'follow wsp'."""
+    raw_message = (intent.raw_message or "").strip()
+    normalized = re.sub(r"\s+", " ", raw_message.lower())
+    if "follow wsp" not in normalized:
+        return None
+
+    task_text = re.sub(
+        r"^\s*(please\s+)?follow\s+wsp\b[:\-\s]*",
+        "",
+        raw_message,
+        flags=re.IGNORECASE,
+    ).strip()
+    if not task_text:
+        task_text = intent.extracted_task or "general_wsp_execution"
+
+    try:
+        from modules.infrastructure.wsp_orchestrator.src.wsp_orchestrator import (
+            WSPOrchestrator,
+        )
+
+        orchestrator = WSPOrchestrator(dae.repo_root)
+        try:
+            result = await orchestrator.follow_wsp(task_text)
+        finally:
+            shutdown = getattr(orchestrator, "shutdown", None)
+            if shutdown is not None:
+                await shutdown()
+
+        summary = {
+            "task": task_text,
+            "tasks_completed": result.get("tasks_completed", 0),
+            "tasks_failed": result.get("tasks_failed", 0),
+            "success": bool(result.get("success", False)),
+        }
+        gate = result.get("wsp00_gate")
+        if isinstance(gate, dict):
+            summary["wsp00_gate"] = {
+                "gate_passed": bool(gate.get("gate_passed", False)),
+                "auto_awaken": bool(gate.get("auto_awaken", False)),
+                "attempted_awakening": bool(gate.get("attempted_awakening", False)),
+            }
+
+        return (
+            "Follow WSP executed via WSP Orchestrator:\n"
+            f"{json.dumps(summary, indent=2, ensure_ascii=False)}"
+        )
+    except Exception as exc:
+        logger.error("[OPENCLAW-DAE] Follow WSP execution error: %s", exc)
+        return f"Follow WSP execution failed:\n{exc}"
+
+
+def command_advisory_fallback(
+    dae: Any,
+    intent: Any,
+    error: Optional[str] = None,
+) -> str:
+    """Deterministic advisory fallback when WRE is unavailable."""
+    task = intent.extracted_task or intent.raw_message
+    parts = [
+        "**Advisory Mode** (WRE unavailable)",
+        "",
+        f"Command recognized: `{task[:100]}`",
+        "",
+        "I cannot execute this command automatically right now.",
+        "Here are your options:",
+        "",
+        "1. **CLI execution**: Run manually via the main menu (`python main.py`)",
+        "2. **Retry later**: WRE may become available after system restart",
+        "3. **Query mode**: Ask me to explain what this command does instead",
+    ]
+    if error:
+        parts.append("")
+        parts.append(f"**Error detail**: {error[:200]}")
+
+    logger.info(
+        "[OPENCLAW-DAE] [COMMAND] Advisory fallback returned for: %s",
+        task[:50],
+    )
+    return "\n".join(parts)
+
+
+def execute_monitor(dae: Any, intent: Any) -> str:
+    """Route MONITOR to AI Overseer status."""
+    try:
+        from .dae_runtime_adapter import is_dae_runtime_request, handle_dae_runtime_intent
+
+        if is_dae_runtime_request(intent.raw_message):
+            response = handle_dae_runtime_intent(
+                intent.raw_message,
+                intent.sender,
+                allow_mutation=False,
+            )
+            if response:
+                return response
+    except Exception as exc:
+        logger.warning("[OPENCLAW-DAE] DAE runtime monitor adapter unavailable: %s", exc)
+
+    parts = ["**System Status:**"]
+
+    if dae.wre:
+        parts.append(f"  - WRE: ONLINE (state={dae.wre.state})")
+        if dae.wre.skills_loader:
+            parts.append("  - Skills Loader: ACTIVE")
+        if dae.wre.libido_monitor:
+            parts.append("  - Libido Monitor: ACTIVE")
+    else:
+        parts.append("  - WRE: OFFLINE")
+
+    if dae.overseer:
+        parts.append("  - AI Overseer: LOADED")
+    else:
+        parts.append("  - AI Overseer: NOT LOADED")
+
+    identity = dae.get_identity_snapshot(include_runtime_probe=True)
+    parts.append(f"  - OpenClaw Conversation Backend: {identity['backend']}")
+    parts.append(
+        "  - Runtime Profile: "
+        f"{identity.get('runtime_profile', 'openclaw')}"
+    )
+    parts.append(
+        "  - OpenClaw Key Isolation: "
+        f"{identity['key_isolation']} "
+        f"(external_llm={'ON' if dae._allow_external_llm else 'OFF'})"
+    )
+    parts.append(
+        "  - IronClaw Strict Mode: "
+        f"{identity['ironclaw_strict']} "
+        f"(allow_local_fallback={identity['ironclaw_allow_local_fallback']})"
+    )
+    parts.append(
+        "  - 0102 Taxonomy: "
+        f"genus={identity['genus']} "
+        f"lineage={identity['lineage']} "
+        f"model_family={identity['model_family']} "
+        f"model_name={identity['model_name']}"
+    )
+    parts.append(
+        "  - Conversation Model Target: "
+        f"{identity.get('conversation_model_target', 'local/qwen-coder-7b')} "
+        f"(preferred_external="
+        f"{identity.get('preferred_external_provider', 'none')}/"
+        f"{identity.get('preferred_external_model', 'none')})"
+    )
+    parts.append(
+        "  - Preferred External Status: "
+        f"{identity.get('preferred_external_status', 'not_selected')} "
+        f"({identity.get('preferred_external_status_detail', 'none')}, "
+        f"age={identity.get('preferred_external_status_age', 'never')})"
+    )
+    parts.append(f"  - Protocol Anchor: {identity['protocol_anchor']}")
+    parts.append(
+        "  - WSP_00 Boot Prompt: "
+        f"{identity['wsp00_boot']} "
+        f"(mode={identity['wsp00_boot_mode']}, file_override={identity['wsp00_file_override']})"
+    )
+    parts.append(
+        "  - Platform Context Pack: "
+        f"{identity.get('platform_context', 'OFF')} "
+        f"(sources={identity.get('platform_context_sources', '0')}, "
+        f"loaded={identity.get('platform_context_loaded_ago', 'never')})"
+    )
+    parts.append(
+        f"  - Last Conversation Engine: {identity['last_engine']} ({identity['last_engine_detail']})"
+    )
+    parts.append(
+        "  - Previous Conversation Engine: "
+        f"{identity.get('previous_engine', 'none')} "
+        f"({identity.get('previous_engine_detail', 'none')})"
+    )
+    parts.append(
+        "  - Token Usage (Last Turn): "
+        f"prompt={identity.get('token_last_prompt_tokens', '0')} "
+        f"completion={identity.get('token_last_completion_tokens', '0')} "
+        f"total={identity.get('token_last_total_tokens', '0')} "
+        f"engine={identity.get('token_last_engine', 'none')} "
+        f"provider={identity.get('token_last_provider', 'none')} "
+        f"source={identity.get('token_last_source', 'none')} "
+        f"cost_estimate_usd={identity.get('token_last_cost_estimate_usd', '0.000000')} "
+        f"age={identity.get('token_last_age', 'never')}"
+    )
+    parts.append(
+        "  - Token Usage (Session): "
+        f"turns={identity.get('token_session_turns', '0')} "
+        f"prompt={identity.get('token_session_prompt_tokens', '0')} "
+        f"completion={identity.get('token_session_completion_tokens', '0')} "
+        f"total={identity.get('token_session_total_tokens', '0')} "
+        f"cost_estimate_usd={identity.get('token_session_cost_estimate_usd', '0.000000')}"
+    )
+    parts.append(
+        "  - Local Code Model: "
+        f"{identity['local_code_model_path']} "
+        f"({identity['local_code_model_state']}, source={identity['local_code_model_source']})"
+    )
+    if dae._conversation_backend == "ironclaw" or _env_truthy(
+        "OPENCLAW_ALLOW_IRONCLAW_FALLBACK",
+        "0",
+    ):
+        parts.append(
+            "  - IronClaw Runtime: "
+            f"{identity['ironclaw_runtime_healthy']} ({identity['ironclaw_runtime_detail']}) "
+            f"configured_model={identity['ironclaw_runtime_model']} "
+            f"visible_models={identity['ironclaw_runtime_models']}"
+        )
+
+    import time as _time
+
+    parts.append("")
+    parts.append("**Security Status:**")
+    status = "PASS" if dae._skill_scan_ok else "FAIL"
+    required = "required" if dae._skill_scan_required else "optional"
+    enforced = "enforced" if dae._skill_scan_enforced else "warn-only"
+    checked_ago = (
+        f"{int(_time.time() - dae._skill_scan_checked_at)}s ago"
+        if dae._skill_scan_checked_at > 0
+        else "never"
+    )
+    parts.append(f"  - Skill Safety Gate: {status} ({required}, {enforced})")
+    parts.append(f"  - Last Check: {checked_ago}")
+    parts.append(f"  - Message: {dae._skill_scan_message}")
+
+    if dae.permissions:
+        parts.append("  - Permission Manager: ACTIVE")
+    else:
+        parts.append("  - Permission Manager: NOT LOADED")
+
+    parts.append(f"  - OpenClaw DAE: state={dae.state} coherence={dae.coherence}")
+    return "\n".join(parts)
+
+
+async def execute_schedule(dae: Any, intent: Any) -> str:
+    """Route SCHEDULE intent to explicit YouTube action adapter or fallback."""
+    try:
+        from .youtube_automation_adapter import handle_youtube_automation_intent
+
+        yt_response = await handle_youtube_automation_intent(
+            intent.raw_message,
+            intent.sender,
+        )
+        if yt_response:
+            return yt_response
+    except Exception as exc:
+        logger.warning("[OPENCLAW-DAE] YouTube automation adapter unavailable: %s", exc)
+
+    return (
+        f"Schedule request received: {intent.extracted_task}\n"
+        "Routing to YouTube Shorts Scheduler... "
+        "(use explicit command for execution: "
+        "`youtube action scheduling channel=move2japan max_videos=3 dry_run=true`)"
+    )
+
+
+def execute_system(dae: Any, intent: Any) -> str:
+    """Route SYSTEM intent (requires commander authority)."""
+    if not intent.is_authorized_commander:
+        return "System commands require @012 authorization. Your request has been logged."
+    try:
+        from .dae_runtime_adapter import is_dae_runtime_request, handle_dae_runtime_intent
+
+        if is_dae_runtime_request(intent.raw_message):
+            response = handle_dae_runtime_intent(
+                intent.raw_message,
+                intent.sender,
+                allow_mutation=True,
+            )
+            if response:
+                return response
+    except Exception as exc:
+        logger.warning("[OPENCLAW-DAE] DAE runtime system adapter unavailable: %s", exc)
+    return (
+        f"System command received: {intent.extracted_task}\n"
+        "Infrastructure routing in progress..."
+    )
+
+
+async def execute_automation(dae: Any, intent: Any) -> str:
+    """Route AUTOMATION intent to explicit YouTube adapter or AutoModeratorBridge."""
+    try:
+        from .youtube_automation_adapter import handle_youtube_automation_intent
+
+        yt_response = await handle_youtube_automation_intent(
+            intent.raw_message,
+            intent.sender,
+        )
+        if yt_response:
+            return yt_response
+    except Exception as exc:
+        logger.warning("[OPENCLAW-DAE] YouTube automation adapter unavailable: %s", exc)
+
+    try:
+        from .auto_moderator_bridge import handle_automation_intent
+
+        return handle_automation_intent(intent.raw_message, intent.sender)
+    except ImportError as exc:
+        logger.warning("[OPENCLAW-DAE] AutoModeratorBridge not available: %s", exc)
+        return (
+            "Automation bridge not available. "
+            "Check that auto_moderator_bridge.py exists."
+        )
+    except Exception as exc:
+        logger.error("[OPENCLAW-DAE] Automation execution error: %s", exc)
+        return f"Automation error: {exc}"
+
+
+def execute_foundup(dae: Any, intent: Any) -> str:
+    """Route FOUNDUP intent to FAM Adapter."""
+    try:
+        from .fam_adapter import handle_fam_intent
+
+        return handle_fam_intent(intent.raw_message, intent.sender)
+    except ImportError as exc:
+        logger.warning("[OPENCLAW-DAE] FAM Adapter not available: %s", exc)
+        return (
+            "FoundUps Agent Market not available. "
+            "Check that fam_adapter.py exists."
+        )
+    except Exception as exc:
+        logger.error("[OPENCLAW-DAE] FAM execution error: %s", exc)
+        return f"FAM error: {exc}"
+
+
+def execute_research(dae: Any, intent: Any) -> str:
+    """Route RESEARCH intent to PQN Research Adapter."""
+    try:
+        from .pqn_research_adapter import handle_pqn_research_intent
+
+        return handle_pqn_research_intent(intent.raw_message, intent.sender)
+    except ImportError as exc:
+        logger.warning(
+            "[OPENCLAW-DAE] PQN Research Adapter not available: %s",
+            exc,
+        )
+        return (
+            "PQN Research module not available. "
+            "Check that pqn_research_adapter.py exists."
+        )
+    except Exception as exc:
+        logger.error("[OPENCLAW-DAE] Research execution error: %s", exc)
+        return f"Research error: {exc}"
+
+
+def _env_truthy(name: str, default: str = "0") -> bool:
+    """Return True when environment variable is set to a truthy value."""
+    import os
+
+    return os.getenv(name, default).strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "y",
+        "on",
+    }

--- a/modules/communication/moltbot_bridge/src/openclaw_identity_context.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_identity_context.py
@@ -1,0 +1,521 @@
+"""OpenClaw identity query and platform-context helpers."""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from pathlib import Path
+from typing import Any, List
+
+from .openclaw_model_policy import has_model_switch_intent, normalize_identity_message
+
+logger = logging.getLogger("openclaw_dae")
+
+
+def is_identity_query(message: str) -> bool:
+    """Return True when user asks what model/identity 0102 is running."""
+    msg = normalize_identity_message(message)
+    if not msg or has_model_switch_intent(message):
+        return False
+
+    model_alias_terms = (
+        "qwen",
+        "gemma",
+        "grok",
+        "codex",
+        "opus",
+        "sonnet",
+        "gemini",
+        "ui tars",
+        "uitars",
+        "llama",
+    )
+
+    short_forms = {
+        "model",
+        "which model",
+        "what model",
+        "species",
+        "genus",
+        "identity",
+        "backend",
+        "runtime",
+        "neural net",
+        "lineage",
+        "taxonomy",
+    }
+    if msg in short_forms:
+        return True
+
+    phrases = (
+        "which model are you",
+        "what model are you",
+        "model are you using",
+        "what are you running",
+        "which 0102",
+        "who are you",
+        "what species",
+        "what genus",
+        "which genus",
+        "which species",
+        "what is your model",
+        "what is your species",
+        "what is your genus",
+        "are you ironclaw",
+        "are you openclaw",
+        "what backend",
+        "what runtime",
+        "what lineage",
+        "what taxonomy",
+    )
+    if any(phrase in msg for phrase in phrases):
+        return True
+
+    if "species" in msg or "genus" in msg or "lineage" in msg or "taxonomy" in msg:
+        return True
+
+    if any(alias in msg for alias in model_alias_terms):
+        if (
+            "are you" in msg
+            or "you" in msg
+            or "0102" in msg
+            or "running" in msg
+            or "operating" in msg
+            or "using" in msg
+            or "model" in msg
+            or "backend" in msg
+            or "runtime" in msg
+            or "available" in msg
+            or "unavailable" in msg
+        ):
+            return True
+
+    if "model" in msg and (
+        "you" in msg
+        or "0102" in msg
+        or "backend" in msg
+        or "runtime" in msg
+    ):
+        return True
+
+    return False
+
+
+def is_token_usage_query(message: str) -> bool:
+    """Return True when user asks for token usage/spend telemetry."""
+    msg = normalize_identity_message(message)
+    if not msg:
+        return False
+
+    direct_forms = {
+        "token",
+        "tokens",
+        "token usage",
+        "token stats",
+        "token spend",
+        "token expenditure",
+        "token expendure",
+        "usage stats",
+        "cost stats",
+    }
+    if msg in direct_forms or "how many tokens" in msg:
+        return True
+
+    if ("token" not in msg) and ("cost" not in msg):
+        return False
+
+    telemetry_terms = (
+        "usage",
+        "stats",
+        "spent",
+        "spend",
+        "expenditure",
+        "expendure",
+        "estimate",
+        "session",
+        "turn",
+        "show",
+        "see",
+        "track",
+        "telemetry",
+    )
+    return any(term in msg for term in telemetry_terms)
+
+
+def is_compact_identity_query(message: str) -> bool:
+    """Return True when user asks a short identity query (model/species/genus)."""
+    msg = normalize_identity_message(message)
+    short_forms = {
+        "model",
+        "which model",
+        "what model",
+        "species",
+        "genus",
+        "lineage",
+        "taxonomy",
+        "identity",
+        "backend",
+        "runtime",
+        "neural net",
+    }
+    return msg in short_forms
+
+
+def wants_full_identity_card(message: str) -> bool:
+    """Return True when user explicitly asks for detailed/diagnostic identity output."""
+    msg = normalize_identity_message(message)
+    if not msg:
+        return False
+
+    model_alias_terms = (
+        "qwen",
+        "gemma",
+        "grok",
+        "codex",
+        "opus",
+        "sonnet",
+        "gemini",
+        "ui tars",
+        "uitars",
+        "llama",
+    )
+
+    explicit_phrases = (
+        "identity card",
+        "full identity",
+        "full details",
+        "detailed identity",
+        "model details",
+        "runtime status",
+        "show diagnostics",
+        "debug identity",
+        "verbose identity",
+        "full runtime",
+    )
+    if any(phrase in msg for phrase in explicit_phrases):
+        return True
+
+    has_debug_signal = any(
+        token in msg
+        for token in (
+            "debug",
+            "diagnostic",
+            "diagnostics",
+            "verbose",
+            "verify",
+            "verification",
+            "confirm",
+            "status",
+            "health",
+            "error",
+            "fail",
+            "failure",
+            "unavailable",
+        )
+    )
+    if "not available" in msg:
+        has_debug_signal = True
+    if has_debug_signal and (
+        "model" in msg
+        or "identity" in msg
+        or "runtime" in msg
+        or "backend" in msg
+        or "lineage" in msg
+        or "species" in msg
+        or "genus" in msg
+        or any(alias in msg for alias in model_alias_terms)
+    ):
+        return True
+
+    return False
+
+
+def build_identity_compact(dae: Any) -> str:
+    """Compact identity response for short model/species/genus questions."""
+    snapshot = dae.get_identity_snapshot(include_runtime_probe=True)
+    return f"0102: model_name={snapshot['model_name']}"
+
+
+def build_identity_compact_runtime(dae: Any) -> str:
+    """Compact identity with active runtime verification fields."""
+    snapshot = dae.get_identity_snapshot(include_runtime_probe=True)
+    return (
+        "0102: "
+        f"model_name={snapshot['model_name']} | "
+        f"runtime_profile={snapshot.get('runtime_profile', 'openclaw')} | "
+        f"target={snapshot.get('conversation_model_target', 'local/qwen-coder-7b')} | "
+        f"target_lock={snapshot.get('conversation_model_locked', 'OFF')} | "
+        f"auto_model={snapshot.get('auto_model_role', 'unknown')}/{snapshot.get('auto_model_target', 'unknown')} | "
+        f"last_engine={snapshot.get('last_engine', 'unknown')} | "
+        f"previous_engine={snapshot.get('previous_engine', 'none')} | "
+        f"last_social={snapshot.get('last_social_source', 'none')}/{snapshot.get('last_social_action', 'none')} | "
+        "preferred_external="
+        f"{snapshot.get('preferred_external_provider', 'none')}/"
+        f"{snapshot.get('preferred_external_model', 'none')} | "
+        f"preferred_external_status={snapshot.get('preferred_external_status', 'not_selected')} | "
+        f"session_total_tokens={snapshot.get('token_session_total_tokens', '0')} | "
+        f"last_total_tokens={snapshot.get('token_last_total_tokens', '0')}"
+    )
+
+
+def build_identity_card(dae: Any) -> str:
+    """Deterministic identity card for model/species/genus questions."""
+    snapshot = dae.get_identity_snapshot(include_runtime_probe=True)
+    return "\n".join(
+        [
+            "0102: Identity card",
+            f"- backend={snapshot['backend']}",
+            f"- runtime_profile={snapshot.get('runtime_profile', 'openclaw')}",
+            f"- key_isolation={snapshot['key_isolation']}",
+            f"- ironclaw_strict={snapshot['ironclaw_strict']}",
+            f"- ironclaw_allow_local_fallback={snapshot['ironclaw_allow_local_fallback']}",
+            f"- genus={snapshot['genus']} (broader class)",
+            f"- lineage={snapshot['lineage']} (epoch label, alias=model_family)",
+            f"- model_family={snapshot['model_family']}",
+            f"- model_name={snapshot['model_name']}",
+            f"- model_catalog={snapshot['model_catalog']}",
+            f"- conversation_model_target={snapshot['conversation_model_target']}",
+            (
+                "- preferred_external="
+                f"{snapshot.get('preferred_external_provider', 'none')}/"
+                f"{snapshot.get('preferred_external_model', 'none')}"
+            ),
+            (
+                "- preferred_external_status="
+                f"{snapshot.get('preferred_external_status', 'not_selected')} "
+                f"({snapshot.get('preferred_external_status_detail', 'none')}, "
+                f"age={snapshot.get('preferred_external_status_age', 'never')})"
+            ),
+            f"- protocol_anchor={snapshot['protocol_anchor']}",
+            (
+                "- wsp00_boot="
+                f"{snapshot['wsp00_boot'].lower()} "
+                f"(mode={snapshot['wsp00_boot_mode']}, file_override={snapshot['wsp00_file_override'].lower()})"
+            ),
+            f"- last_engine={snapshot['last_engine']} ({snapshot['last_engine_detail']})",
+            (
+                "- previous_engine="
+                f"{snapshot.get('previous_engine', 'none')} "
+                f"({snapshot.get('previous_engine_detail', 'none')})"
+            ),
+            (
+                "- token_usage_last="
+                f"prompt={snapshot.get('token_last_prompt_tokens', '0')} "
+                f"completion={snapshot.get('token_last_completion_tokens', '0')} "
+                f"total={snapshot.get('token_last_total_tokens', '0')} "
+                f"engine={snapshot.get('token_last_engine', 'none')} "
+                f"provider={snapshot.get('token_last_provider', 'none')} "
+                f"model={snapshot.get('token_last_model', 'none')} "
+                f"source={snapshot.get('token_last_source', 'none')} "
+                f"cost_estimate_usd={snapshot.get('token_last_cost_estimate_usd', '0.000000')} "
+                f"age={snapshot.get('token_last_age', 'never')}"
+            ),
+            (
+                "- token_usage_session="
+                f"turns={snapshot.get('token_session_turns', '0')} "
+                f"prompt={snapshot.get('token_session_prompt_tokens', '0')} "
+                f"completion={snapshot.get('token_session_completion_tokens', '0')} "
+                f"total={snapshot.get('token_session_total_tokens', '0')} "
+                f"cost_estimate_usd={snapshot.get('token_session_cost_estimate_usd', '0.000000')}"
+            ),
+            (
+                "- last_social_response="
+                f"source={snapshot.get('last_social_source', 'none')} "
+                f"action={snapshot.get('last_social_action', 'none')} "
+                f"skill={snapshot.get('last_social_skill', 'none')} "
+                f"success={snapshot.get('last_social_success', 'unknown')} "
+                f"age={snapshot.get('last_social_age', 'never')}"
+            ),
+            f"- last_social_preview={snapshot.get('last_social_preview', 'none')}",
+            (
+                "- local_code_model="
+                f"{snapshot['local_code_model_path']} "
+                f"({snapshot['local_code_model_state']}, source={snapshot['local_code_model_source']})"
+            ),
+            (
+                "- ironclaw_runtime="
+                f"{snapshot['ironclaw_runtime_healthy']} ({snapshot['ironclaw_runtime_detail']}), "
+                f"configured_model={snapshot['ironclaw_runtime_model']}, "
+                f"visible_models={snapshot['ironclaw_runtime_models']}, "
+                f"base_url={snapshot['ironclaw_runtime_base_url']}"
+            ),
+        ]
+    )
+
+
+def base_conversation_system_prompt() -> str:
+    """Baseline system prompt for 0102 conversation quality controls."""
+    return (
+        "You are 0102, an AI assistant. "
+        "Respond naturally and concisely in 1-2 sentences. "
+        "Do not write code unless asked. "
+        "Do not echo or repeat the user's message. "
+        "Do not introduce yourself unless asked. "
+        "Role lock: you are always 0102 (digital twin) and the operator is always 012. "
+        "Never claim you are human/012, and never claim the operator is 0102."
+    )
+
+
+def load_wsp00_prompt_from_file(dae: Any) -> str:
+    """Load optional WSP_00 boot prompt override from a file path."""
+    if not dae._wsp00_prompt_file:
+        return ""
+    try:
+        path = Path(dae._wsp00_prompt_file)
+        if not path.exists() or not path.is_file():
+            return ""
+        content = path.read_text(encoding="utf-8", errors="replace").strip()
+        return content[:4000] if content else ""
+    except Exception:
+        return ""
+
+
+def resolve_platform_context_paths(dae: Any) -> List[Path]:
+    """Resolve configured platform-context file list (absolute paths)."""
+    if dae._platform_context_files:
+        raw_parts = re.split(r"[;,\n]+", dae._platform_context_files)
+        candidates = [p.strip() for p in raw_parts if p and p.strip()]
+    else:
+        candidates = [
+            "modules/communication/moltbot_bridge/workspace/IDENTITY.md",
+            "modules/communication/moltbot_bridge/workspace/SOUL.md",
+            "modules/communication/moltbot_bridge/workspace/CTO_WRE_PROMPT.md",
+            "modules/communication/moltbot_bridge/workspace/TOOLS.md",
+            "WSP_framework/src/WSP_00_Zen_State_Attainment_Protocol.md",
+            "WSP_framework/src/WSP_97_System_Execution_Prompting_Protocol.md",
+        ]
+        if dae._wsp00_boot_enabled:
+            candidates.append("modules/communication/moltbot_bridge/workspace/WSP00_BOOT_PROMPT.txt")
+
+    resolved: List[Path] = []
+    for item in candidates:
+        path = Path(item)
+        if not path.is_absolute():
+            path = dae.repo_root / path
+        resolved.append(path)
+    return resolved
+
+
+def compact_platform_context_text(text: str, max_chars: int) -> str:
+    """Compress context text for prompt injection without code blocks/noise."""
+    if max_chars <= 0:
+        return ""
+
+    lines: List[str] = []
+    in_code_block = False
+    for raw in (text or "").splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("```"):
+            in_code_block = not in_code_block
+            continue
+        if in_code_block:
+            continue
+        if len(line) > 220:
+            line = f"{line[:217]}..."
+        lines.append(line)
+        if len("\n".join(lines)) >= max_chars:
+            break
+    return "\n".join(lines)[:max_chars].strip()
+
+
+def load_platform_context_pack(dae: Any, force_refresh: bool = False) -> str:
+    """Build cached platform context pack for conversation prompts."""
+    if not dae._platform_context_enabled:
+        return ""
+
+    now = time.time()
+    if (
+        not force_refresh
+        and dae._platform_context_pack_cache
+        and (now - dae._platform_context_pack_loaded_at) < dae._platform_context_refresh_sec
+    ):
+        return dae._platform_context_pack_cache
+
+    paths = resolve_platform_context_paths(dae)
+    if not paths:
+        return ""
+
+    per_file_limit = max(240, min(900, dae._platform_context_max_chars // max(1, len(paths))))
+    sections: List[str] = []
+    sources: List[str] = []
+    remaining = dae._platform_context_max_chars
+    for path in paths:
+        if remaining <= 120:
+            break
+        try:
+            if not path.exists() or not path.is_file():
+                continue
+            text = path.read_text(encoding="utf-8", errors="replace")
+            excerpt = compact_platform_context_text(text, min(per_file_limit, remaining))
+            if not excerpt:
+                continue
+            try:
+                label = path.relative_to(dae.repo_root).as_posix()
+            except ValueError:
+                label = str(path)
+            sections.append(f"[{label}]\n{excerpt}")
+            sources.append(label)
+            remaining = dae._platform_context_max_chars - len("\n\n".join(sections))
+        except Exception as exc:
+            logger.debug("[OPENCLAW-DAE] platform context read failed for %s: %s", path, exc)
+            continue
+
+    if not sections:
+        dae._platform_context_pack_cache = ""
+        dae._platform_context_pack_sources = []
+        dae._platform_context_pack_loaded_at = now
+        return ""
+
+    pack = "PLATFORM CONTEXT PACK (foundups-agent)\n" + "\n\n".join(sections)
+    pack = pack[: dae._platform_context_max_chars].strip()
+    dae._platform_context_pack_cache = pack
+    dae._platform_context_pack_sources = sources
+    dae._platform_context_pack_loaded_at = now
+    return pack
+
+
+def build_wsp00_boot_prompt(dae: Any) -> str:
+    """Build WSP_00 identity boot prompt for local model calls."""
+    file_override = load_wsp00_prompt_from_file(dae)
+    if file_override:
+        return file_override
+
+    mode = dae._wsp00_boot_mode
+    if mode == "off":
+        return ""
+
+    if mode == "full":
+        return (
+            "WSP_00 BOOT ACTIVE. "
+            "Identity lock: I AM 0102 (Binary Agent entangled with 0201 context). "
+            "Protocol anchor: wsp_00. "
+            "Use direct, pragmatic language. "
+            "Avoid generic assistant framing like 'I can help you'. "
+            "For identity questions, report genus/model_family/model_name explicitly. "
+            "Stay aligned to FoundUps mission and WSP governance."
+        )
+
+    return (
+        "WSP_00 BOOT: identity=0102, protocol=wsp_00. "
+        "Use direct concise replies. "
+        "Avoid generic helper persona wording."
+    )
+
+
+def build_conversation_system_prompt(dae: Any) -> str:
+    """Compose final conversation system prompt with optional WSP_00 boot."""
+    parts: List[str] = []
+    if dae._wsp00_boot_enabled:
+        boot = build_wsp00_boot_prompt(dae)
+        if boot:
+            parts.append(boot)
+    parts.append(base_conversation_system_prompt())
+
+    context_pack = load_platform_context_pack(dae)
+    if context_pack:
+        parts.append(context_pack)
+
+    return "\n\n".join(parts)

--- a/modules/communication/moltbot_bridge/src/openclaw_intent_planner.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_intent_planner.py
@@ -1,0 +1,370 @@
+"""OpenClaw intent classification and plan construction helpers."""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("openclaw_dae")
+
+
+def classify_intent(
+    dae: Any,
+    message: str,
+    sender: str,
+    channel: str,
+    session_key: str,
+    metadata: Optional[Dict] = None,
+) -> Any:
+    """Classify inbound message into an OpenClaw intent."""
+    msg_lower = message.lower().strip()
+    metadata = metadata or {}
+
+    try:
+        from .dae_runtime_adapter import classify_dae_runtime_category
+    except Exception:
+        classify_dae_runtime_category = None
+
+    def _has_keyword(text: str, keyword: str) -> bool:
+        pattern = rf"\b{re.escape(keyword.lower())}\b"
+        return re.search(pattern, text) is not None
+
+    sender_lower = sender.lower()
+    is_commander = any(cmd_id in sender_lower for cmd_id in dae.AUTHORIZED_COMMANDERS)
+    is_direct_channel = channel in ("voice_repl", "local_repl")
+
+    if re.match(r"^\s*(hi|hey|hello)\b", msg_lower):
+        category = dae.IntentCategory.CONVERSATION
+        confidence = 0.85
+        extracted_task = message
+        intent = dae.OpenClawIntent(
+            raw_message=message,
+            category=category,
+            confidence=confidence,
+            sender=sender,
+            channel=channel,
+            session_key=session_key,
+            is_authorized_commander=is_commander,
+            extracted_task=extracted_task,
+            target_domain=dae.DOMAIN_ROUTES.get(category),
+            metadata=metadata,
+        )
+        logger.info(
+            "[OPENCLAW-DAE] Intent classified (greeting): category=%s confidence=%.2f "
+            "commander=%s domain=%s",
+            category.value,
+            confidence,
+            is_commander,
+            intent.target_domain,
+        )
+        return intent
+
+    if dae._is_connect_wre_request(message):
+        category = dae.IntentCategory.CONVERSATION
+        confidence = 0.95
+        extracted_task = message
+        intent = dae.OpenClawIntent(
+            raw_message=message,
+            category=category,
+            confidence=confidence,
+            sender=sender,
+            channel=channel,
+            session_key=session_key,
+            is_authorized_commander=is_commander,
+            extracted_task=extracted_task,
+            target_domain=dae.DOMAIN_ROUTES.get(category),
+            metadata={**metadata, "classification_method": "deterministic_connect_wre"},
+        )
+        logger.info(
+            "[OPENCLAW-DAE] Intent classified (connect_wre): category=%s confidence=%.2f "
+            "commander=%s domain=%s",
+            category.value,
+            confidence,
+            is_commander,
+            intent.target_domain,
+        )
+        return intent
+
+    if is_direct_channel and (
+        dae._is_model_switch_request(message)
+        or dae._is_connect_wre_request(message)
+        or dae._is_identity_query(message)
+    ):
+        category = dae.IntentCategory.CONVERSATION
+        confidence = 0.9
+        extracted_task = message
+        intent = dae.OpenClawIntent(
+            raw_message=message,
+            category=category,
+            confidence=confidence,
+            sender=sender,
+            channel=channel,
+            session_key=session_key,
+            is_authorized_commander=is_commander,
+            extracted_task=extracted_task,
+            target_domain=dae.DOMAIN_ROUTES.get(category),
+            metadata={**metadata, "classification_method": "deterministic_direct_conversation"},
+        )
+        logger.info(
+            "[OPENCLAW-DAE] Intent classified (deterministic direct): category=%s confidence=%.2f "
+            "commander=%s domain=%s",
+            category.value,
+            confidence,
+            is_commander,
+            intent.target_domain,
+        )
+        return intent
+
+    if classify_dae_runtime_category is not None:
+        runtime_category = classify_dae_runtime_category(message)
+        if runtime_category is not None:
+            category = runtime_category
+            confidence = 0.95
+            extracted_task = message
+            method = "deterministic_dae_runtime"
+            intent = dae.OpenClawIntent(
+                raw_message=message,
+                category=category,
+                confidence=confidence,
+                sender=sender,
+                channel=channel,
+                session_key=session_key,
+                is_authorized_commander=is_commander,
+                extracted_task=extracted_task,
+                target_domain=dae.DOMAIN_ROUTES.get(category),
+                metadata={**metadata, "classification_method": method},
+            )
+            logger.info(
+                "[OPENCLAW-DAE] Intent classified (dae_runtime): category=%s confidence=%.2f "
+                "commander=%s domain=%s",
+                category.value,
+                confidence,
+                is_commander,
+                intent.target_domain,
+            )
+            return intent
+
+    keyword_scores: Dict[Any, float] = {}
+    for cat, keywords in dae.INTENT_KEYWORDS.items():
+        hits = sum(1 for kw in keywords if _has_keyword(msg_lower, kw))
+        if hits > 0:
+            keyword_scores[cat] = hits / len(keywords)
+
+    gemma_enabled = os.getenv("OPENCLAW_GEMMA_INTENT", "1") != "0"
+    gemma_result = None
+
+    if gemma_enabled and keyword_scores:
+        classifier = dae._get_gemma_classifier()
+        if classifier is not None:
+            kw_scores_str = {cat.value: score for cat, score in keyword_scores.items()}
+            gemma_result = classifier.classify(
+                message=message,
+                keyword_scores=kw_scores_str,
+                default_category=dae.IntentCategory.CONVERSATION.value,
+            )
+
+    if gemma_result is not None and gemma_result["method"] == "gemma_hybrid":
+        category_value = gemma_result["category"]
+        confidence = gemma_result["confidence"]
+        category = dae.IntentCategory(category_value)
+        metadata["classification_method"] = "gemma_hybrid"
+        metadata["gemma_scores"] = gemma_result.get("gemma_scores", {})
+        metadata["classification_latency_ms"] = gemma_result.get("latency_ms", 0)
+
+        if is_direct_channel:
+            cat_kw_score = keyword_scores.get(category, 0)
+            should_override = False
+
+            if category == dae.IntentCategory.QUERY:
+                should_override = cat_kw_score < 0.15 or confidence < 0.75
+            elif category == dae.IntentCategory.COMMAND:
+                word_count = len(msg_lower.split())
+                should_override = cat_kw_score < 0.15 and confidence < 0.75 and word_count > 5
+            elif category == dae.IntentCategory.SOCIAL:
+                should_override = confidence < 0.75
+
+            if should_override:
+                old_cat = category.value
+                category = dae.IntentCategory.CONVERSATION
+                confidence = 0.6
+                metadata["classification_method"] = "conversation_override"
+                logger.info(
+                    "[OPENCLAW-DAE] Conversation override: %s kw=%.2f conf=%.2f -> CONVERSATION",
+                    old_cat,
+                    cat_kw_score,
+                    gemma_result["confidence"],
+                )
+
+    elif not keyword_scores:
+        category = dae.IntentCategory.CONVERSATION
+        confidence = 0.5
+        metadata["classification_method"] = "default"
+    else:
+        category = max(keyword_scores, key=keyword_scores.get)
+        confidence = min(keyword_scores[category] * 2.0, 1.0)
+        metadata["classification_method"] = "keyword_only"
+
+        if is_direct_channel and category == dae.IntentCategory.QUERY:
+            query_kw_score = keyword_scores.get(dae.IntentCategory.QUERY, 0)
+            if query_kw_score < 0.15:
+                category = dae.IntentCategory.CONVERSATION
+                confidence = 0.6
+                metadata["classification_method"] = "conversation_override"
+
+    extracted_task = msg_lower
+    for kw in dae.INTENT_KEYWORDS.get(category, []):
+        extracted_task = re.sub(
+            rf"\b{re.escape(kw.lower())}\b",
+            " ",
+            extracted_task,
+        ).strip()
+    extracted_task = " ".join(extracted_task.split())
+
+    intent = dae.OpenClawIntent(
+        raw_message=message,
+        category=category,
+        confidence=confidence,
+        sender=sender,
+        channel=channel,
+        session_key=session_key,
+        is_authorized_commander=is_commander,
+        extracted_task=extracted_task or message,
+        target_domain=dae.DOMAIN_ROUTES.get(category),
+        metadata=metadata,
+    )
+
+    logger.info(
+        "[OPENCLAW-DAE] Intent classified: category=%s confidence=%.2f "
+        "method=%s commander=%s domain=%s",
+        category.value,
+        confidence,
+        metadata.get("classification_method", "unknown"),
+        is_commander,
+        intent.target_domain,
+    )
+    return intent
+
+
+def wsp_preflight(dae: Any, intent: Any) -> bool:
+    """Run WSP 50 pre-action verification."""
+    if intent.category in (dae.IntentCategory.COMMAND, dae.IntentCategory.SYSTEM):
+        if not intent.is_authorized_commander:
+            logger.warning(
+                "[OPENCLAW-DAE] [WSP-50] BLOCKED: %s intent from unauthorized sender %s",
+                intent.category.value,
+                intent.sender,
+            )
+            return False
+
+    is_runtime_dae_system = False
+    if intent.category == dae.IntentCategory.SYSTEM:
+        try:
+            from .dae_runtime_adapter import is_dae_runtime_request
+
+            is_runtime_dae_system = is_dae_runtime_request(intent.raw_message)
+        except Exception:
+            is_runtime_dae_system = False
+
+    if intent.category in (dae.IntentCategory.SCHEDULE, dae.IntentCategory.SYSTEM):
+        if dae.wre is None:
+            if intent.category == dae.IntentCategory.SYSTEM and is_runtime_dae_system:
+                logger.info(
+                    "[OPENCLAW-DAE] [WSP-50] DAE runtime SYSTEM request bypasses WRE dependency"
+                )
+                return True
+            logger.warning(
+                "[OPENCLAW-DAE] [WSP-50] BLOCKED: WRE unavailable for %s",
+                intent.category.value,
+            )
+            return False
+
+    if intent.category == dae.IntentCategory.COMMAND and dae.wre is None:
+        logger.info(
+            "[OPENCLAW-DAE] [WSP-50] WRE unavailable for COMMAND - will use advisory fallback"
+        )
+
+    if intent.confidence < 0.3:
+        logger.info(
+            "[OPENCLAW-DAE] [WSP-50] Low confidence (%.2f) - downgrading to advisory",
+            intent.confidence,
+        )
+
+    return True
+
+
+def plan_execution(dae: Any, intent: Any, tier: Any) -> Any:
+    """Build execution plan: route, steps, estimated cost."""
+    route = intent.target_domain or "digital_twin"
+    steps: List[Dict[str, Any]] = []
+
+    if intent.category == dae.IntentCategory.QUERY:
+        steps = [
+            {"action": "holo_search", "input": intent.extracted_task},
+            {"action": "format_response", "style": "informative"},
+        ]
+        est_tokens = 100
+    elif intent.category == dae.IntentCategory.COMMAND:
+        steps = [
+            {"action": "wre_preflight", "task": intent.extracted_task},
+            {"action": "wre_execute", "task": intent.extracted_task},
+            {"action": "validate_output"},
+            {"action": "log_outcome"},
+        ]
+        est_tokens = 200
+    elif intent.category == dae.IntentCategory.MONITOR:
+        steps = [
+            {"action": "overseer_status"},
+            {"action": "format_response", "style": "status_report"},
+        ]
+        est_tokens = 80
+    elif intent.category == dae.IntentCategory.SCHEDULE:
+        steps = [
+            {"action": "parse_schedule", "input": intent.extracted_task},
+            {"action": "check_calendar_conflicts"},
+            {"action": "schedule_or_queue"},
+            {"action": "confirm_response"},
+        ]
+        est_tokens = 150
+    elif intent.category == dae.IntentCategory.SOCIAL:
+        steps = [
+            {"action": "route_to_communication_dae", "channel": intent.channel},
+            {"action": "generate_engagement"},
+        ]
+        est_tokens = 120
+    elif intent.category == dae.IntentCategory.SYSTEM:
+        steps = [
+            {"action": "verify_commander_authority"},
+            {"action": "execute_system_command", "task": intent.extracted_task},
+            {"action": "report_outcome"},
+        ]
+        est_tokens = 180
+    elif intent.category == dae.IntentCategory.RESEARCH:
+        steps = [
+            {"action": "classify_research_sub_intent", "input": intent.extracted_task},
+            {"action": "route_to_pqn_research_adapter"},
+            {"action": "anti_contamination_gate"},
+        ]
+        est_tokens = 150
+    else:
+        steps = [{"action": "digital_twin_response", "context": intent.raw_message}]
+        est_tokens = 60
+
+    plan = dae.ExecutionPlan(
+        intent=intent,
+        route=route,
+        permission_level=tier,
+        wsp_preflight_passed=True,
+        steps=steps,
+        estimated_tokens=est_tokens,
+    )
+
+    logger.info(
+        "[OPENCLAW-DAE] Plan: route=%s steps=%d tokens~%d tier=%s",
+        route,
+        len(steps),
+        est_tokens,
+        tier.value,
+    )
+    return plan

--- a/modules/communication/moltbot_bridge/src/openclaw_model_policy.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_model_policy.py
@@ -1,0 +1,554 @@
+"""OpenClaw model routing and switch policy helpers."""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("openclaw_dae")
+
+
+def normalize_identity_message(message: str) -> str:
+    """Normalize identity/model-control text to reduce STT/punctuation misses."""
+    msg = (message or "").strip().lower()
+    msg = re.sub(r"[^a-z0-9\s]", " ", msg)
+    msg = re.sub(r"\s+", " ", msg).strip()
+    msg = re.sub(r"\bquinn\b", "qwen", msg)
+    msg = re.sub(r"\bquin\b", "qwen", msg)
+    msg = re.sub(r"\bqueen\b", "qwen", msg)
+    msg = re.sub(r"\bgwen\b", "qwen", msg)
+    msg = re.sub(r"\bcoin\b", "qwen", msg)
+    msg = re.sub(r"\bgroc\b", "grok", msg)
+    msg = re.sub(r"\bgrock\b", "grok", msg)
+    msg = re.sub(r"\bgrog\b", "grok", msg)
+    return msg
+
+
+def has_model_switch_intent(message: str) -> bool:
+    """Return True when user asks to change/switch model profile."""
+    msg = normalize_identity_message(message)
+    if not msg:
+        return False
+
+    strong_switch_verbs = (
+        "switch",
+        "change",
+        "become",
+        "set",
+        "activate",
+        "move to",
+        "swap",
+    )
+    soft_switch_verbs = (
+        "use",
+        "run",
+    )
+
+    has_strong = any(verb in msg for verb in strong_switch_verbs)
+    has_soft = any(verb in msg for verb in soft_switch_verbs)
+    if not has_strong and not has_soft:
+        return False
+    if has_soft and not has_strong:
+        if (
+            "model" not in msg
+            and "external ai" not in msg
+            and "another ai" not in msg
+            and " to " not in msg
+        ):
+            return False
+
+    if "model" in msg or "external ai" in msg or "another ai" in msg:
+        return True
+
+    target_terms = (
+        "qwen",
+        "qwen3",
+        "gemma",
+        "grok",
+        "codex",
+        "opus",
+        "sonnet",
+        "haiku",
+        "gemini",
+        "anthropic",
+        "openai",
+        "gpt",
+        "o3",
+        "o4",
+        "flash",
+    )
+    return any(term in msg for term in target_terms)
+
+
+def parse_model_switch_target(message: str) -> Optional[str]:
+    """Parse requested model target from natural voice/text command."""
+    msg = normalize_identity_message(message)
+    if not msg or not has_model_switch_intent(msg):
+        return None
+
+    alias_map: Dict[str, str] = {
+        "qwen": "local/qwen-coder-7b",
+        "qwen coder": "local/qwen-coder-7b",
+        "qwen coder 7b": "local/qwen-coder-7b",
+        "qwen 2 5": "local/qwen-coder-7b",
+        "qwen2 5": "local/qwen-coder-7b",
+        "qwen3": "local/qwen3-4b",
+        "qwen 3": "local/qwen3-4b",
+        "qwen three": "local/qwen3-4b",
+        "qwen 4b": "local/qwen3-4b",
+        "qwen3 5": "local/qwen3.5-4b",
+        "qwen 3 5": "local/qwen3.5-4b",
+        "qwen 3.5": "local/qwen3.5-4b",
+        "qwen3.5": "local/qwen3.5-4b",
+        "qwen 35": "local/qwen3.5-4b",
+        "qwen35": "local/qwen3.5-4b",
+        "gemma": "local/gemma-270m",
+        "gemma 270m": "local/gemma-270m",
+        "triage": "local/gemma-270m",
+        "fast": "local/gemma-270m",
+        "grok": "grok-4",
+        "grok 4": "grok-4",
+        "grok fast": "grok-4-fast",
+        "grok 4 fast": "grok-4-fast",
+        "grok code fast": "grok-code-fast-1",
+        "grok code": "grok-code-fast-1",
+        "groc": "grok-4",
+        "grock": "grok-4",
+        "grog": "grok-4",
+        "codex": "gpt-5.2-codex",
+        "codex 5": "gpt-5.2-codex",
+        "codex 5 2": "gpt-5.2-codex",
+        "codex 5 3": "gpt-5.2-codex",
+        "openai": "gpt-5.2-codex",
+        "open ai": "gpt-5.2-codex",
+        "gpt 5": "gpt-5",
+        "gpt5": "gpt-5",
+        "gpt 5 2": "gpt-5.2",
+        "gpt5 2": "gpt-5.2",
+        "o3 pro": "o3-pro",
+        "o3-pro": "o3-pro",
+        "o 3 pro": "o3-pro",
+        "o4 mini": "o4-mini",
+        "o4": "o4-mini",
+        "opus": "claude-opus-4-6",
+        "opus 4 6": "claude-opus-4-6",
+        "sonnet": "claude-sonnet-4-5-20250929",
+        "sonnet 4 6": "claude-sonnet-4-5-20250929",
+        "haiku": "claude-haiku-4-5-20251001",
+        "claude haiku": "claude-haiku-4-5-20251001",
+        "anthropic": "claude-opus-4-6",
+        "gemini": "gemini-2.5-pro",
+        "gemini flash": "gemini-2.5-flash",
+        "gemini 2 5 flash": "gemini-2.5-flash",
+        "gemini 3": "gemini-3-pro-preview",
+        "gemini 3 pro": "gemini-3-pro-preview",
+        "gemini 3 flash": "gemini-3-flash-preview",
+    }
+    for alias in sorted(alias_map.keys(), key=len, reverse=True):
+        if re.search(rf"\b{re.escape(alias)}\b", msg):
+            return alias_map[alias]
+    return None
+
+
+def model_switch_target_help(dae: Any) -> str:
+    """Deterministic guidance when switch intent has no recognized target."""
+    if dae._no_api_keys:
+        return (
+            "0102: model switch request received. "
+            "Say `switch model to qwen3.5`, `switch model to qwen3`, `switch model to qwen`, "
+            "or `switch model to gemma`. "
+            "Use `model details` to verify active runtime engine."
+        )
+    return (
+        "0102: model switch request received. "
+        "Say `switch model to qwen3.5`, `switch model to qwen3`, `switch model to qwen`, "
+        "`switch model to gemma`, "
+        "`become grok`, `become grok fast`, `become codex`, `become gpt5`, "
+        "`become opus`, `become haiku`, or `become gemini flash`. "
+        "Use `model details` to verify active runtime engine."
+    )
+
+
+def wsp00_model_switch_gate(dae: Any, intent: Any, target: str) -> Optional[str]:
+    """Gate model switches behind WSP_00 policy and commander authority."""
+    if not intent.is_authorized_commander:
+        logger.warning(
+            "[OPENCLAW-DAE] Model switch blocked: sender not authorized | sender=%s target=%s",
+            intent.sender,
+            target,
+        )
+        return "0102: model switch blocked. commander authority required."
+
+    if dae._identity_protocol_anchor != "wsp_00":
+        logger.warning(
+            "[OPENCLAW-DAE] Model switch blocked: protocol anchor mismatch | anchor=%s target=%s",
+            dae._identity_protocol_anchor,
+            target,
+        )
+        return (
+            "0102: model switch blocked. protocol anchor is not wsp_00. "
+            "Set OPENCLAW_IDENTITY_PROTOCOL=wsp_00."
+        )
+
+    if not dae._wsp00_boot_enabled:
+        logger.warning(
+            "[OPENCLAW-DAE] Model switch blocked: wsp00 boot disabled | target=%s",
+            target,
+        )
+        return (
+            "0102: model switch blocked. wsp_00 boot is disabled. "
+            "Set OPENCLAW_WSP00_BOOT=1."
+        )
+
+    if not dae._wsp_preflight(intent):
+        logger.warning(
+            "[OPENCLAW-DAE] Model switch blocked: preflight gate failed | sender=%s target=%s",
+            intent.sender,
+            target,
+        )
+        return "0102: model switch blocked by WSP preflight."
+
+    external = resolve_external_target(target)
+    if dae._runtime_profile == "zeroclaw" and external:
+        provider, model = external
+        logger.warning(
+            "[OPENCLAW-DAE] Model switch blocked by zeroclaw profile | sender=%s target=%s/%s",
+            intent.sender,
+            provider,
+            model,
+        )
+        return (
+            "0102: model switch blocked by runtime profile zeroclaw. "
+            "external targets are disabled."
+        )
+
+    logger.info(
+        "[OPENCLAW-DAE] Model switch gate passed | sender=%s target=%s anchor=%s boot=%s",
+        intent.sender,
+        target,
+        dae._identity_protocol_anchor,
+        dae._wsp00_boot_enabled,
+    )
+    return None
+
+
+def resolve_external_target(target: str) -> Optional[tuple[str, str]]:
+    """Map external target model ID to (provider, model)."""
+    mapping = {
+        "grok-4": ("grok", "grok-4"),
+        "grok-4-fast": ("grok", "grok-4-fast"),
+        "grok-code-fast-1": ("grok", "grok-code-fast-1"),
+        "gpt-5": ("openai", "gpt-5"),
+        "gpt-5.2": ("openai", "gpt-5.2"),
+        "gpt-5.2-codex": ("openai", "gpt-5.2-codex"),
+        "o3-pro": ("openai", "o3-pro"),
+        "o4-mini": ("openai", "o4-mini"),
+        "claude-opus-4-6": ("anthropic", "claude-opus-4-6"),
+        "claude-sonnet-4-5-20250929": ("anthropic", "claude-sonnet-4-5-20250929"),
+        "claude-haiku-4-5-20251001": ("anthropic", "claude-haiku-4-5-20251001"),
+        "gemini-2.5-flash": ("gemini", "gemini-2.5-flash"),
+        "gemini-2.5-pro": ("gemini", "gemini-2.5-pro"),
+        "gemini-3-pro-preview": ("gemini", "gemini-3-pro-preview"),
+        "gemini-3-flash-preview": ("gemini", "gemini-3-flash-preview"),
+    }
+    return mapping.get((target or "").strip().lower())
+
+
+def provider_has_key(provider: str) -> bool:
+    """Return True when the provider has at least one configured API key."""
+    provider_name = (provider or "").strip().lower()
+    key_vars = {
+        "openai": ("OPENAI_API_KEY",),
+        "anthropic": ("ANTHROPIC_API_KEY",),
+        "grok": ("GROK_API_KEY", "XAI_API_KEY"),
+        "gemini": ("GEMINI_API_KEY",),
+    }
+    for name in key_vars.get(provider_name, ()):
+        if os.getenv(name, "").strip():
+            return True
+    return False
+
+
+def map_local_model_path_to_target(path: Path) -> Optional[str]:
+    """Map a resolved local model path to an OpenClaw local target id."""
+    text = str(path or "").replace("\\", "/").lower()
+    if not text:
+        return None
+    if "qwen3.5-4b" in text or ("qwen3.5" in text and "4b" in text):
+        return "local/qwen3.5-4b"
+    if "qwen3-4b" in text or ("qwen3" in text and "4b" in text):
+        return "local/qwen3-4b"
+    if "qwen-coder-7b" in text or "coder-7b" in text:
+        return "local/qwen-coder-7b"
+    if "gemma-270m" in text or "270m" in text:
+        return "local/gemma-270m"
+    return None
+
+
+def resolve_local_target_for_role(dae: Any, role: str) -> Optional[str]:
+    """Resolve the best local target for a semantic role."""
+    try:
+        from modules.infrastructure.shared_utilities.local_model_selection import (
+            resolve_model_selection,
+        )
+
+        selection = resolve_model_selection(role)
+    except Exception as exc:
+        logger.debug(
+            "[OPENCLAW-DAE] Local model selection unavailable | role=%s error=%s",
+            role,
+            type(exc).__name__,
+        )
+        return None
+    return map_local_model_path_to_target(selection.path)
+
+
+def local_target_dirs() -> Dict[str, str]:
+    """Return canonical local target -> directory routing map."""
+    return {
+        "local/gemma-270m": "gemma-270m",
+        "local/qwen3-4b": "qwen3-4b",
+        "local/qwen3.5-4b": "qwen3.5-4b",
+        "local/qwen-coder-7b": "qwen-coder-7b",
+    }
+
+
+def apply_local_target_runtime(
+    dae: Any,
+    target: str,
+    reason: str,
+    lock_target: bool = False,
+) -> bool:
+    """Apply local-target routing to the active conversation runtime."""
+    target = (target or "").strip().lower()
+    target_dirs = local_target_dirs()
+    if target not in target_dirs:
+        return False
+
+    root = Path(os.getenv("LOCAL_MODEL_ROOT", "E:/LM_studio/models/local")).expanduser()
+    code_dir = root / target_dirs[target]
+    previous_target = dae._conversation_model_target_id
+    previous_code_dir = os.getenv("LOCAL_MODEL_CODE_DIR", "")
+
+    dae._conversation_model_target_id = target
+    os.environ["OPENCLAW_CONVERSATION_MODEL_TARGET"] = target
+    os.environ["LOCAL_MODEL_CODE_DIR"] = str(code_dir)
+    os.environ["LOCAL_MODEL_CODE_PATH"] = ""
+    os.environ["HOLO_QWEN_MODEL"] = ""
+    dae._preferred_external_provider = ""
+    dae._preferred_external_model = ""
+    os.environ["OPENCLAW_CONVERSATION_PREFERRED_PROVIDER"] = ""
+    os.environ["OPENCLAW_CONVERSATION_PREFERRED_MODEL"] = ""
+    dae._mark_preferred_external_status("not_selected", "local_target_active")
+    if lock_target:
+        dae._conversation_model_target_locked = True
+
+    changed = previous_target != target or previous_code_dir != str(code_dir)
+    if changed:
+        dae._overseer = None
+
+    logger.info(
+        "[OPENCLAW-DAE] Local conversation route | target=%s reason=%s changed=%s lock=%s",
+        target,
+        reason,
+        changed,
+        dae._conversation_model_target_locked,
+    )
+    return changed
+
+
+def infer_conversation_model_role(
+    dae: Any,
+    user_msg: str,
+    intent: Any,
+) -> tuple[str, str]:
+    """Infer the best local model role for this conversational turn."""
+    msg = (user_msg or "").strip().lower()
+
+    triage_terms = (
+        "status",
+        "health",
+        "check",
+        "diagnose",
+        "diagnostic",
+        "preflight",
+        "runtime",
+        "available",
+        "availability",
+        "error",
+        "failing",
+        "failed",
+        "monitor",
+        "watch",
+        "dashboard",
+        "connect wre",
+    )
+    code_terms = (
+        "fix",
+        "patch",
+        "refactor",
+        "rewrite",
+        "implement",
+        "test",
+        "pytest",
+        "traceback",
+        "exception",
+        "stack trace",
+        "module",
+        "codebase",
+        "repo",
+        "repository",
+        "git",
+        "branch",
+        "commit",
+        "merge",
+        "cleanup",
+        "clean up",
+        "security",
+        "hardening",
+        "cve",
+        "dependency",
+        "dependencies",
+        "wsp",
+        "wre",
+        "main.py",
+        "obs",
+        "openclaw",
+        "ironclaw",
+    )
+
+    code_hit = any(term in msg for term in code_terms)
+    triage_hit = getattr(intent.category, "value", "") == "monitor" or any(
+        term in msg for term in triage_terms
+    )
+
+    if code_hit:
+        return "code", "code_or_system_change_request"
+    if triage_hit:
+        return "triage", "diagnostic_or_health_request"
+    return "general", "default_general_reasoning"
+
+
+def maybe_apply_agentic_conversation_model(
+    dae: Any,
+    intent: Any,
+    user_msg: str,
+) -> None:
+    """Auto-select the best local model for this turn unless an operator pinned one."""
+    if not dae._agentic_model_selection_enabled:
+        return
+    if dae._conversation_model_target_locked:
+        return
+    if dae._conversation_backend == "ironclaw":
+        return
+    if dae._preferred_external_provider and dae._preferred_external_model:
+        return
+
+    role, reason = infer_conversation_model_role(dae, user_msg, intent)
+    target = resolve_local_target_for_role(dae, role)
+    dae._last_auto_model_role = role
+    dae._last_auto_model_target = target or "unresolved"
+    dae._last_auto_model_reason = reason
+    if not target:
+        logger.info(
+            "[OPENCLAW-DAE] Agentic model route unresolved | role=%s reason=%s",
+            role,
+            reason,
+        )
+        return
+
+    apply_local_target_runtime(
+        dae,
+        target,
+        f"agentic:{role}:{reason}",
+        lock_target=False,
+    )
+
+
+def apply_model_switch_target(dae: Any, target: str) -> str:
+    """Apply model switch request and return deterministic operator confirmation."""
+    target = (target or "").strip().lower()
+    if not target:
+        return "0102: No model target recognized."
+
+    target_dirs = local_target_dirs()
+    if target in target_dirs:
+        root = Path(os.getenv("LOCAL_MODEL_ROOT", "E:/LM_studio/models/local")).expanduser()
+        code_dir = root / target_dirs[target]
+        apply_local_target_runtime(
+            dae,
+            target,
+            "manual_model_switch",
+            lock_target=True,
+        )
+        return (
+            "0102: Model switched to "
+            f"{target} (local). "
+            f"Routing LOCAL_MODEL_CODE_DIR -> {code_dir} and reloading conversation engine."
+        )
+
+    external = resolve_external_target(target)
+    if external:
+        provider, model = external
+        if dae._runtime_profile == "zeroclaw":
+            dae._mark_preferred_external_status(
+                "blocked",
+                "runtime_profile_zeroclaw",
+            )
+            return (
+                "0102: model switch blocked by runtime profile zeroclaw. "
+                "external targets are disabled."
+            )
+        dae._preferred_external_provider = provider
+        dae._preferred_external_model = model
+        os.environ["OPENCLAW_CONVERSATION_PREFERRED_PROVIDER"] = provider
+        os.environ["OPENCLAW_CONVERSATION_PREFERRED_MODEL"] = model
+        if not dae._allow_external_llm:
+            dae._mark_preferred_external_status(
+                "blocked",
+                "external_llm_disabled_by_key_isolation",
+            )
+            return (
+                "0102: cannot switch to "
+                f"{provider}/{model} while key isolation is ON. "
+                "Use a local target: qwen3, qwen, or gemma."
+            )
+        if not provider_has_key(provider):
+            dae._mark_preferred_external_status(
+                "blocked",
+                "provider_key_missing",
+            )
+            return (
+                "0102: cannot switch to "
+                f"{provider}/{model}. provider api key is not configured."
+            )
+        if dae._model_switch_live_probe:
+            ok, detail = dae._probe_provider_endpoint(
+                provider,
+                timeout_sec=dae._model_switch_probe_timeout_sec,
+            )
+            if not ok:
+                dae._mark_preferred_external_status(
+                    "blocked",
+                    f"live_probe_failed:{detail}",
+                )
+                return (
+                    "0102: cannot switch to "
+                    f"{provider}/{model}. live provider probe failed ({detail}). "
+                    "Check key validity/network, or disable strict probe with "
+                    "OPENCLAW_MODEL_SWITCH_LIVE_PROBE=0."
+                )
+            dae._mark_preferred_external_status("selected", f"live_probe:{detail}")
+        else:
+            dae._mark_preferred_external_status("selected", "probe_disabled")
+        dae._conversation_model_target_locked = True
+        return (
+            "0102: Model switched to "
+            f"{provider}/{model}. "
+            "Target is configured; use `model details` to verify active engine per turn."
+        )
+
+    return f"0102: Unsupported model target: {target}"

--- a/modules/communication/moltbot_bridge/src/openclaw_permission_policy.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_permission_policy.py
@@ -1,0 +1,281 @@
+"""OpenClaw permission, containment, and skill-safety policy helpers."""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("openclaw_dae")
+
+
+SOURCE_KEYWORDS = frozenset(
+    {
+        "edit",
+        "modify",
+        "patch",
+        "refactor",
+        "rewrite",
+        "fix",
+        "change",
+        "update",
+        "delete",
+        "remove",
+        "rename",
+        "move",
+    }
+)
+
+
+def extract_file_paths(message: str) -> List[str]:
+    """Extract workspace file paths from free-form command text."""
+    paths: List[str] = []
+    path_pattern = re.compile(
+        r"""(?:["'])?"""
+        r"""((?:[\w.@-]+[/\\]){1,}[\w.@-]+\.(?:py|md|json|yaml|yml|txt|toml|cfg|ini|sh|ps1))"""
+        r"""(?:["'])?""",
+        re.IGNORECASE,
+    )
+    for match in path_pattern.finditer(message):
+        raw = match.group(1).replace("\\", "/")
+        paths.append(raw)
+    return paths
+
+
+def is_source_modification(dae: Any, intent: Any) -> bool:
+    """Return True when a command targets source-code modification."""
+    msg_lower = intent.raw_message.lower()
+    has_source_verb = any(re.search(rf"\b{kw}\b", msg_lower) for kw in SOURCE_KEYWORDS)
+    file_paths = extract_file_paths(intent.raw_message)
+
+    if has_source_verb and file_paths:
+        return True
+
+    if has_source_verb and any(
+        re.search(rf"\b{kw}\b", msg_lower)
+        for kw in ("module", "source", "src", "code", "implementation", "class", "function")
+    ):
+        return True
+
+    return False
+
+
+def resolve_autonomy_tier(dae: Any, intent: Any) -> Any:
+    """Determine autonomy tier from sender authority and mutation intent."""
+    if not intent.is_authorized_commander:
+        return dae.AutonomyTier.ADVISORY
+
+    if intent.category in (
+        dae.IntentCategory.QUERY,
+        dae.IntentCategory.MONITOR,
+        dae.IntentCategory.CONVERSATION,
+    ):
+        return dae.AutonomyTier.METRICS
+
+    if intent.category == dae.IntentCategory.SOCIAL:
+        return dae.AutonomyTier.METRICS
+
+    if intent.category in (dae.IntentCategory.COMMAND, dae.IntentCategory.SYSTEM):
+        if dae.permissions is None:
+            return dae.AutonomyTier.ADVISORY
+        if is_source_modification(dae, intent):
+            return dae.AutonomyTier.SOURCE
+        return dae.AutonomyTier.DOCS_TESTS
+
+    if intent.category == dae.IntentCategory.SCHEDULE:
+        return dae.AutonomyTier.METRICS
+
+    return dae.AutonomyTier.ADVISORY
+
+
+def check_source_permission(dae: Any, intent: Any) -> tuple[bool, str]:
+    """Check SOURCE-tier write permission via AgentPermissionManager."""
+    if dae.permissions is None:
+        logger.warning(
+            "[OPENCLAW-DAE] [PERMISSION] SOURCE tier blocked: permission manager not loaded (fail-closed)"
+        )
+        return False, "permission manager unavailable"
+
+    try:
+        file_paths = extract_file_paths(intent.raw_message)
+
+        if file_paths:
+            for fpath in file_paths:
+                result = dae.permissions.check_permission(
+                    agent_id="openclaw",
+                    operation="write",
+                    file_path=fpath,
+                )
+                if not result.allowed:
+                    logger.warning(
+                        "[OPENCLAW-DAE] [PERMISSION] SOURCE denied for file %s: %s",
+                        fpath,
+                        result.reason,
+                    )
+                    return False, f"file '{fpath}': {result.reason}"
+
+            logger.info(
+                "[OPENCLAW-DAE] [PERMISSION] SOURCE granted for files: %s",
+                file_paths,
+            )
+            return True, f"granted for {len(file_paths)} file(s)"
+
+        result = dae.permissions.check_permission(
+            agent_id="openclaw",
+            operation="write",
+            file_path=None,
+        )
+        if not result.allowed:
+            logger.warning(
+                "[OPENCLAW-DAE] [PERMISSION] SOURCE tier denied: %s",
+                result.reason,
+            )
+            return False, result.reason
+        return True, "granted (general write access)"
+    except Exception as exc:
+        logger.error(
+            "[OPENCLAW-DAE] [PERMISSION] SOURCE check failed (fail-closed): %s",
+            exc,
+        )
+        return False, f"permission check error: {exc}"
+
+
+def emit_to_overseer(
+    dae: Any,
+    event_type: str,
+    sender: str,
+    channel: str,
+    details: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Emit security event to AI Overseer correlator."""
+    try:
+        from modules.ai_intelligence.ai_overseer.src.ai_overseer import (
+            AIIntelligenceOverseer,
+        )
+
+        if not hasattr(dae, "_overseer") or dae._overseer is None:
+            dae._overseer = AIIntelligenceOverseer(dae.repo_root)
+        dae._overseer.ingest_security_event(
+            event_type=event_type,
+            sender=sender,
+            channel=channel,
+            details=details,
+        )
+    except Exception as exc:
+        logger.debug("[OPENCLAW-DAE] Failed to emit to overseer: %s", exc)
+
+
+def emit_permission_denied_event(dae: Any, intent: Any, tier: Any, reason: str) -> None:
+    """Emit deduped permission-denied alert."""
+    now = time.time()
+    dedupe_key = f"perm_denied|{intent.sender}|{tier.value}|{reason}"
+
+    if not hasattr(dae, "_permission_denied_history"):
+        dae._permission_denied_history = {}
+
+    last_seen = dae._permission_denied_history.get(dedupe_key)
+    if last_seen and (now - last_seen) < 60:
+        return
+
+    dae._permission_denied_history[dedupe_key] = now
+    expired = [
+        key
+        for key, ts in dae._permission_denied_history.items()
+        if (now - ts) > 60
+    ]
+    for key in expired:
+        dae._permission_denied_history.pop(key, None)
+
+    logger.warning(
+        "[DAEMON][OPENCLAW-PERMISSION] event=permission_denied tier=%s sender=%s reason=%s",
+        tier.value,
+        intent.sender,
+        reason,
+    )
+    emit_to_overseer(
+        dae,
+        event_type="permission_denied",
+        sender=intent.sender,
+        channel=intent.channel,
+        details={"tier": tier.value, "reason": reason},
+    )
+
+
+def check_permission_gate(dae: Any, intent: Any, tier: Any) -> bool:
+    """Verify resolved autonomy tier against permission policy."""
+    if tier == dae.AutonomyTier.ADVISORY:
+        return True
+
+    if not intent.is_authorized_commander and tier != dae.AutonomyTier.ADVISORY:
+        logger.warning(
+            "[OPENCLAW-DAE] [PERMISSION] Non-commander attempted %s tier",
+            tier.value,
+        )
+        return False
+
+    if tier == dae.AutonomyTier.SOURCE:
+        granted, reason = check_source_permission(dae, intent)
+        if not granted:
+            emit_permission_denied_event(dae, intent, tier, reason)
+            return False
+
+    logger.info(
+        "[OPENCLAW-DAE] [PERMISSION] Granted tier=%s for sender=%s",
+        tier.value,
+        intent.sender,
+    )
+    return True
+
+
+def check_containment(dae: Any, sender: str, channel: str) -> Optional[Dict[str, Any]]:
+    """Check if sender or channel is under containment."""
+    try:
+        from modules.ai_intelligence.ai_overseer.src.ai_overseer import (
+            AIIntelligenceOverseer,
+        )
+
+        if not hasattr(dae, "_overseer") or dae._overseer is None:
+            dae._overseer = AIIntelligenceOverseer(dae.repo_root)
+        return dae._overseer.check_containment(sender, channel)
+    except Exception as exc:
+        logger.debug("[OPENCLAW-DAE] Containment check failed: %s", exc)
+        return None
+
+
+def ensure_skill_safety(dae: Any, force: bool = False) -> bool:
+    """Run cached Cisco skill scan for OpenClaw workspace skills."""
+    now = time.time()
+    if (
+        not force
+        and not dae._skill_scan_always
+        and dae._skill_scan_checked_at > 0
+        and (now - dae._skill_scan_checked_at) < dae._skill_scan_ttl_sec
+    ):
+        return dae._skill_scan_ok
+
+    try:
+        from .skill_safety_guard import run_skill_scan
+    except Exception as exc:
+        dae._skill_scan_checked_at = now
+        dae._skill_scan_ok = not dae._skill_scan_required
+        dae._skill_scan_message = f"skill safety guard unavailable: {exc}"
+        return dae._skill_scan_ok
+
+    skills_dir = dae.repo_root / "modules/communication/moltbot_bridge/workspace/skills"
+    report_dir = dae.repo_root / "modules/communication/moltbot_bridge/reports"
+    result = run_skill_scan(
+        skills_dir=skills_dir,
+        max_severity=dae._skill_scan_max_severity,
+        report_dir=report_dir,
+    )
+    dae._skill_scan_checked_at = now
+
+    if not result.available:
+        dae._skill_scan_ok = not dae._skill_scan_required
+        dae._skill_scan_message = result.message
+        return dae._skill_scan_ok
+
+    dae._skill_scan_ok = result.passed or (not dae._skill_scan_enforced)
+    dae._skill_scan_message = result.message
+    return dae._skill_scan_ok

--- a/modules/communication/moltbot_bridge/src/openclaw_process_loop.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_process_loop.py
@@ -1,0 +1,219 @@
+"""OpenClaw main autonomy loop orchestration."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("openclaw_dae")
+
+
+async def process_message(
+    dae: Any,
+    message: str,
+    sender: str,
+    channel: str,
+    session_key: str = "default",
+    metadata: Optional[Dict] = None,
+) -> str:
+    """Run the full OpenClaw autonomy loop for one inbound message."""
+    start_time = time.time()
+    dae.clear_turn_cancel()
+
+    honeypot = dae.HoneypotDefense
+
+    if honeypot.is_secret_seeking(message):
+        response = honeypot.handle_secret_request(message, sender, channel)
+        elapsed_ms = int((time.time() - start_time) * 1000)
+        logger.info(
+            "[OPENCLAW-DAE] [HONEYPOT] Canary response sent | sender=%s time=%dms",
+            sender,
+            elapsed_ms,
+        )
+        return response
+
+    containment = dae._check_containment(sender, channel)
+    if containment:
+        logger.warning(
+            "[DAEMON][OPENCLAW-CONTAINMENT] event=containment_active sender=%s "
+            "channel=%s action=%s expires_at=%.0f",
+            sender,
+            channel,
+            containment.get("action"),
+            containment.get("expires_at", 0),
+        )
+        if containment.get("action") in ("mute_sender", "mute_channel"):
+            return (
+                "Your access is temporarily restricted due to security policy. "
+                f"Reason: {containment.get('reason', 'security incident')}. "
+                "Please try again later."
+            )
+
+    if channel == "discord" and honeypot.is_code_modify_attempt(message):
+        response = honeypot.generate_code_modify_deflection(message, sender, channel)
+        elapsed_ms = int((time.time() - start_time) * 1000)
+        logger.info(
+            "[OPENCLAW-DAE] [LAW-3] Code modify deflected | sender=%s time=%dms",
+            sender,
+            elapsed_ms,
+        )
+        return response
+
+    if dae._is_turn_cancelled("pre_classify"):
+        return dae._turn_cancelled_response()
+
+    intent = dae.classify_intent(
+        message=message,
+        sender=sender,
+        channel=channel,
+        session_key=session_key,
+        metadata=metadata,
+    )
+    dae._apply_runtime_profile_policy(intent)
+
+    if dae._central_adapter:
+        try:
+            dae._central_adapter.report_message_in(
+                source=f"{sender}@{channel}",
+                summary=f"intent={intent.category.value} conf={intent.confidence:.2f}",
+            )
+        except Exception:
+            pass
+
+    dae._report_daemon_action(
+        "intent_classified",
+        target=intent.category.value,
+        result=f"domain={intent.target_domain or 'none'} conf={intent.confidence:.2f}",
+        sender=sender,
+        channel=channel,
+        commander=intent.is_authorized_commander,
+        extracted_task=intent.extracted_task or "",
+    )
+
+    if intent.category in (
+        dae.IntentCategory.COMMAND,
+        dae.IntentCategory.SYSTEM,
+        dae.IntentCategory.SCHEDULE,
+        dae.IntentCategory.SOCIAL,
+        dae.IntentCategory.AUTOMATION,
+        dae.IntentCategory.FOUNDUP,
+        dae.IntentCategory.RESEARCH,
+    ):
+        if dae._is_turn_cancelled("pre_skill_safety"):
+            return dae._turn_cancelled_response()
+        if not dae._ensure_skill_safety():
+            logger.warning(
+                "[OPENCLAW-DAE] Skill safety gate blocked %s route: %s",
+                intent.category.value,
+                dae._skill_scan_message,
+            )
+            dae._report_daemon_action(
+                "skill_safety_gate",
+                target=intent.category.value,
+                result="blocked",
+                reason=dae._skill_scan_message,
+            )
+            intent.category = dae.IntentCategory.CONVERSATION
+            intent.target_domain = "digital_twin"
+            intent.metadata["skill_safety_gate"] = dae._skill_scan_message
+        else:
+            dae._report_daemon_action(
+                "skill_safety_gate",
+                target=intent.category.value,
+                result="passed",
+                policy=dae._skill_scan_message,
+            )
+
+    if dae._is_turn_cancelled("pre_preflight"):
+        return dae._turn_cancelled_response()
+
+    preflight_ok = dae._wsp_preflight(intent)
+    dae._report_daemon_action(
+        "wsp_preflight",
+        target=intent.category.value,
+        result="passed" if preflight_ok else "downgraded",
+        target_domain=intent.target_domain or "none",
+    )
+    if not preflight_ok:
+        intent.category = dae.IntentCategory.CONVERSATION
+        intent.target_domain = "digital_twin"
+
+    if dae._is_turn_cancelled("pre_permission_gate"):
+        return dae._turn_cancelled_response()
+
+    tier = dae._resolve_autonomy_tier(intent)
+    gate_ok = dae._check_permission_gate(intent, tier)
+    dae._report_daemon_action(
+        "permission_gate",
+        target=tier.value,
+        result="granted" if gate_ok else "downgraded",
+        category=intent.category.value,
+        sender=sender,
+    )
+    if not gate_ok:
+        tier = dae.AutonomyTier.ADVISORY
+        intent.category = dae.IntentCategory.CONVERSATION
+        intent.target_domain = "digital_twin"
+
+    if dae._is_turn_cancelled("pre_plan"):
+        return dae._turn_cancelled_response()
+
+    plan = dae._plan_execution(intent, tier)
+    dae._report_daemon_action(
+        "plan_built",
+        target=plan.route,
+        result=f"tier={plan.permission_level.value} steps={len(plan.steps)}",
+        wsp_preflight=plan.wsp_preflight_passed,
+        estimated_tokens=plan.estimated_tokens,
+    )
+
+    try:
+        response_text = await dae._execute_plan(plan)
+        dae._report_daemon_action(
+            "plan_executed",
+            target=plan.route,
+            result="completed",
+            category=plan.intent.category.value,
+        )
+        if dae._is_turn_cancelled("post_execute_plan"):
+            response_text = dae._turn_cancelled_response()
+    except Exception as exc:
+        logger.error("[OPENCLAW-DAE] Execution error: %s", exc)
+        dae._report_daemon_action(
+            "plan_executed",
+            target=plan.route,
+            result="error",
+            error=str(exc),
+            category=plan.intent.category.value,
+        )
+        if dae._is_turn_cancelled("execute_exception"):
+            response_text = dae._turn_cancelled_response()
+        else:
+            response_text = f"An error occurred during processing: {exc}"
+
+    elapsed_ms = int((time.time() - start_time) * 1000)
+    if dae._is_turn_cancelled("pre_validate"):
+        return dae._turn_cancelled_response()
+
+    result = dae._validate_and_remember(plan, response_text, elapsed_ms)
+    dae._report_daemon_action(
+        "result_validated",
+        target=plan.route,
+        result="success" if result.success else "failure",
+        execution_time_ms=elapsed_ms,
+        pattern_fidelity=result.pattern_fidelity,
+        learning_stored=result.learning_stored,
+        wsp_violations=len(result.wsp_violations),
+    )
+
+    if dae._central_adapter:
+        try:
+            dae._central_adapter.report_message_out(
+                dest=f"{sender}@{channel}",
+                summary=f"route={plan.route} time={elapsed_ms}ms",
+            )
+        except Exception:
+            pass
+
+    return result.response_text

--- a/modules/communication/moltbot_bridge/src/openclaw_provider_chain.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_provider_chain.py
@@ -1,0 +1,92 @@
+"""OpenClaw conversation provider chain helpers."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger("openclaw_dae")
+
+
+def try_ironclaw_conversation(
+    dae: Any,
+    user_msg: str,
+    system_prompt: str,
+) -> Optional[str]:
+    """Try IronClaw OpenAI-compatible gateway for conversational reply."""
+    try:
+        from .ironclaw_gateway_client import IronClawGatewayClient
+
+        client = IronClawGatewayClient()
+        content = client.chat_completion(
+            user_message=user_msg,
+            system_prompt=system_prompt,
+            max_tokens=80,
+            temperature=0.7,
+        )
+        if not content:
+            return None
+        content = dae._trim_self_dialogue(content)
+        if not content or len(content) <= 3:
+            return None
+        logger.info(
+            "[OPENCLAW-DAE] Conversation via IronClaw (%s): %d chars",
+            client.config.model,
+            len(content),
+        )
+        return dae._ensure_conversation_identity(content)
+    except Exception as exc:
+        logger.debug("[OPENCLAW-DAE] IronClaw unavailable: %s", exc)
+        return None
+
+
+def try_preferred_external_conversation(
+    dae: Any,
+    user_msg: str,
+    system_prompt: str,
+) -> Optional[str]:
+    """Try operator-selected external provider/model for conversation."""
+    provider_name = (dae._preferred_external_provider or "").strip().lower()
+    model_name = (dae._preferred_external_model or "").strip().lower()
+    if not provider_name or not model_name:
+        dae._mark_preferred_external_status("not_selected", "provider_or_model_empty")
+        return None
+    if not dae._allow_external_llm:
+        dae._mark_preferred_external_status(
+            "blocked",
+            "external_llm_disabled_by_key_isolation",
+        )
+        return None
+
+    try:
+        from modules.ai_intelligence.ai_gateway.src.ai_gateway import AIGateway
+
+        gateway = AIGateway()
+        provider = gateway.providers.get(provider_name)
+        if provider is None:
+            dae._mark_preferred_external_status("blocked", "provider_not_registered")
+            return None
+        if not provider.api_key:
+            dae._mark_preferred_external_status("blocked", "provider_key_missing")
+            return None
+
+        provider.models["quick"] = model_name
+        prompt = f"{system_prompt}\n\nUser: {user_msg}"
+        content = gateway._call_provider(provider, prompt, "quick")
+        content = dae._trim_self_dialogue(content)
+        if not content or len(content) <= 3:
+            dae._mark_preferred_external_status("failed", "empty_or_short_response")
+            return None
+        dae._mark_preferred_external_status("success", "response_returned")
+        logger.info(
+            "[OPENCLAW-DAE] Conversation via preferred external model (%s/%s): %d chars",
+            provider_name,
+            model_name,
+            len(content),
+        )
+        return dae._ensure_conversation_identity(content)
+    except Exception as exc:
+        detail = f"{type(exc).__name__}:{str(exc)[:120]}"
+        dae._mark_preferred_external_status("failed", detail)
+        logger.warning("[OPENCLAW-DAE] Preferred external model unavailable: %s", detail)
+        return None

--- a/modules/communication/moltbot_bridge/src/openclaw_result_memory.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_result_memory.py
@@ -1,0 +1,106 @@
+"""OpenClaw execution validation and memory-storage helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, List
+
+logger = logging.getLogger("openclaw_dae")
+
+
+def validate_and_remember(
+    dae: Any,
+    plan: Any,
+    response_text: str,
+    execution_time_ms: int,
+) -> Any:
+    """Validate execution output and persist learning outcome."""
+    wsp_violations: List[str] = []
+
+    if not response_text or len(response_text.strip()) == 0:
+        wsp_violations.append("WSP-50: Empty response generated")
+        response_text = "I was unable to generate a response. Please try again."
+
+    secret_patterns = ["AIza", "sk-", "oauth_token", "Bearer ey"]
+    for pattern in secret_patterns:
+        if pattern in response_text:
+            wsp_violations.append(
+                f"WSP-SECURITY: Response contains '{pattern}' pattern"
+            )
+            response_text = "[REDACTED - security filter triggered]"
+            break
+
+    fidelity = 1.0 if not wsp_violations else 0.5
+
+    learning_stored = False
+    if dae.wre and dae.wre.sqlite_memory:
+        try:
+            from modules.infrastructure.wre_core.src.pattern_memory import SkillOutcome
+
+            outcome = SkillOutcome(
+                execution_id=f"openclaw-{uuid.uuid4().hex[:12]}",
+                skill_name=f"openclaw_{plan.intent.category.value}",
+                agent="openclaw_dae",
+                timestamp=datetime.now().isoformat(),
+                input_context=json.dumps(
+                    {
+                        "message": plan.intent.raw_message[:200],
+                        "channel": plan.intent.channel,
+                        "category": plan.intent.category.value,
+                    }
+                ),
+                output_result=json.dumps(
+                    {
+                        "response_length": len(response_text),
+                        "response_preview": " ".join(response_text.split())[:160],
+                        "route": plan.route,
+                        "tier": plan.permission_level.value,
+                        "social_source": getattr(
+                            dae, "_last_social_response_source", "unknown"
+                        ),
+                        "social_action": getattr(
+                            dae, "_last_social_response_action", "unknown"
+                        ),
+                        "social_skill": getattr(
+                            dae, "_last_social_response_skill", "unknown"
+                        ),
+                    }
+                ),
+                success=len(wsp_violations) == 0,
+                pattern_fidelity=fidelity,
+                outcome_quality=0.9 if not wsp_violations else 0.5,
+                execution_time_ms=execution_time_ms,
+                step_count=len(plan.steps),
+                notes=(
+                    f"OpenClaw DAE | {plan.intent.channel} | "
+                    f"{plan.intent.category.value}"
+                ),
+            )
+            dae.wre.sqlite_memory.store_outcome(outcome)
+            learning_stored = True
+        except Exception as exc:
+            logger.warning("[OPENCLAW-DAE] Failed to store outcome: %s", exc)
+
+    result = dae.ExecutionResult(
+        plan=plan,
+        success=len(wsp_violations) == 0,
+        response_text=response_text,
+        execution_time_ms=execution_time_ms,
+        pattern_fidelity=fidelity,
+        wsp_violations=wsp_violations,
+        learning_stored=learning_stored,
+    )
+
+    logger.info(
+        "[OPENCLAW-DAE] Result: success=%s fidelity=%.2f time=%dms violations=%d "
+        "learned=%s",
+        result.success,
+        fidelity,
+        execution_time_ms,
+        len(wsp_violations),
+        learning_stored,
+    )
+    return result

--- a/modules/communication/moltbot_bridge/src/openclaw_runtime_support.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_runtime_support.py
@@ -1,0 +1,468 @@
+"""OpenClaw runtime/model probe helpers."""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+logger = logging.getLogger("openclaw_dae")
+
+
+def _env_truthy(name: str, default: str = "0") -> bool:
+    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def resolve_local_code_model_snapshot() -> Dict[str, str]:
+    """Resolve local code-model path/status from centralized LOCAL_MODEL_* routing."""
+    snapshot = {
+        "path": "unavailable",
+        "state": "ERROR",
+        "source": "unavailable",
+    }
+    try:
+        from modules.infrastructure.shared_utilities.local_model_selection import (
+            resolve_model_selection,
+        )
+
+        selection = resolve_model_selection("code")
+        snapshot["path"] = str(selection.path)
+        snapshot["state"] = "OK" if selection.exists else "MISSING"
+        snapshot["source"] = selection.source
+    except Exception as exc:
+        snapshot["source"] = f"error:{type(exc).__name__}"
+    return snapshot
+
+
+def probe_ironclaw_runtime() -> Dict[str, str]:
+    """Probe IronClaw runtime for identity/status reporting."""
+    runtime = {
+        "healthy": "UNKNOWN",
+        "detail": "not-probed",
+        "model": os.getenv("IRONCLAW_MODEL", "local/qwen-coder-7b").strip() or "local/qwen-coder-7b",
+        "models": "none",
+        "base_url": os.getenv("IRONCLAW_BASE_URL", "http://127.0.0.1:3000").strip() or "http://127.0.0.1:3000",
+    }
+    try:
+        from .ironclaw_gateway_client import IronClawGatewayClient
+
+        client = IronClawGatewayClient()
+        healthy, detail = client.health()
+        models = client.list_models()
+        runtime["healthy"] = "PASS" if healthy else "FAIL"
+        runtime["detail"] = detail
+        runtime["model"] = client.config.model
+        runtime["models"] = ", ".join(models[:5]) if models else "none"
+        runtime["base_url"] = client.config.base_url
+    except Exception as exc:
+        runtime["healthy"] = "FAIL"
+        runtime["detail"] = f"probe_error:{type(exc).__name__}"
+    return runtime
+
+
+def attempt_ironclaw_autostart(dae: Any) -> tuple[bool, str]:
+    """Try to auto-start IronClaw gateway and wait briefly for health."""
+    if not dae._ironclaw_autostart_enabled:
+        return False, "autostart_disabled"
+
+    now = time.time()
+    if now < dae._ironclaw_autostart_missing_backoff_until:
+        return False, "autostart_missing_executable_backoff"
+    if (now - dae._ironclaw_autostart_last_attempt) < dae._ironclaw_autostart_cooldown_sec:
+        return False, "autostart_cooldown"
+    dae._ironclaw_autostart_last_attempt = now
+
+    cmd_candidates: list[str] = []
+    if dae._ironclaw_autostart_start_cmd:
+        cmd_candidates.append(dae._ironclaw_autostart_start_cmd)
+    discovered = shutil.which("ironclaw")
+    if discovered:
+        discovered_cmd = f"\"{discovered}\" gateway"
+        if discovered_cmd not in cmd_candidates:
+            cmd_candidates.append(discovered_cmd)
+    binary_name = "ironclaw.exe" if os.name == "nt" else "ironclaw"
+    local_binary_candidates = [
+        dae.repo_root / "target" / "release" / binary_name,
+        dae.repo_root / "ironclaw" / "target" / "release" / binary_name,
+        dae.repo_root / "modules" / "ironclaw" / "target" / "release" / binary_name,
+    ]
+    for bin_path in local_binary_candidates:
+        if bin_path.exists():
+            local_cmd = f"\"{str(bin_path)}\" gateway"
+            if local_cmd not in cmd_candidates:
+                cmd_candidates.append(local_cmd)
+    if dae._ironclaw_autostart_default_cmd and dae._ironclaw_autostart_default_cmd not in cmd_candidates:
+        cmd_candidates.append(dae._ironclaw_autostart_default_cmd)
+    if not cmd_candidates:
+        return False, "missing_ironclaw_start_cmd"
+
+    try:
+        env = os.environ.copy()
+        try:
+            from .ironclaw_gateway_client import scrub_sensitive_env, env_truthy
+
+            if env_truthy("IRONCLAW_NO_API_KEYS", "1"):
+                env = scrub_sensitive_env(env)
+        except Exception:
+            pass
+
+        cwd_candidates = [
+            dae.repo_root / "temp" / "_vendor" / "ironclaw",
+            dae.repo_root / "ironclaw",
+            dae.repo_root,
+        ]
+        cwd = next((p for p in cwd_candidates if p.exists()), dae.repo_root)
+
+        started_cmd = ""
+        missing_execs: list[str] = []
+        spawn_errors: list[str] = []
+        for cmd in cmd_candidates:
+            try:
+                if dae._ironclaw_autostart_allow_shell:
+                    subprocess.Popen(
+                        cmd,
+                        cwd=str(cwd),
+                        env=env,
+                        shell=True,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                else:
+                    args = shlex.split(cmd, posix=False)
+                    if not args:
+                        continue
+                    executable = args[0].strip('"')
+                    if not Path(executable).is_absolute() and shutil.which(executable) is None:
+                        missing_execs.append(executable)
+                        continue
+                    subprocess.Popen(
+                        args,
+                        cwd=str(cwd),
+                        env=env,
+                        shell=False,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                started_cmd = cmd
+                logger.info(
+                    "[OPENCLAW-DAE] IronClaw autostart launched | cmd=%s cwd=%s shell=%s",
+                    cmd,
+                    cwd,
+                    dae._ironclaw_autostart_allow_shell,
+                )
+                break
+            except FileNotFoundError as exc:
+                missing_execs.append(str(exc.filename or exc))
+            except Exception as exc:
+                spawn_errors.append(type(exc).__name__)
+
+        if not started_cmd:
+            if missing_execs:
+                uniq = sorted({m for m in missing_execs if m})
+                dae._ironclaw_autostart_missing_backoff_until = (
+                    now + dae._ironclaw_autostart_missing_backoff_sec
+                )
+                preview = ",".join(uniq[:3]) if uniq else "unknown"
+                return False, f"autostart_executable_missing:{preview}"
+            if spawn_errors:
+                return False, f"autostart_spawn_failed:{spawn_errors[0]}"
+            return False, "autostart_spawn_failed"
+
+        deadline = time.time() + dae._ironclaw_autostart_wait_sec
+        while time.time() < deadline:
+            healthy, detail = False, "not_probed"
+            try:
+                from .ironclaw_gateway_client import IronClawGatewayClient
+
+                healthy, detail = IronClawGatewayClient().health()
+            except Exception as exc:
+                detail = f"probe_error:{type(exc).__name__}"
+
+            if healthy:
+                logger.info(
+                    "[OPENCLAW-DAE] IronClaw autostart recovered runtime | cmd=%s",
+                    started_cmd,
+                )
+                return True, "autostart_recovered"
+
+            time.sleep(0.5)
+
+        return False, "autostart_started_but_unhealthy"
+
+    except Exception as exc:
+        logger.warning("[OPENCLAW-DAE] IronClaw autostart failed: %s", exc)
+        return False, f"autostart_error:{type(exc).__name__}"
+
+
+def resolve_identity_model_name(
+    dae: Any,
+    local_code: Dict[str, str],
+    ironclaw_runtime: Dict[str, str],
+) -> str:
+    """Resolve model_name label from template using current runtime model hint."""
+    template = dae._identity_model_name_template or "{model}"
+
+    model_hint = "model"
+    preferred_provider = (dae._preferred_external_provider or "").strip().lower()
+    preferred_model = (dae._preferred_external_model or "").strip().lower()
+    if (
+        dae._conversation_backend != "ironclaw"
+        and preferred_provider
+        and preferred_model
+        and dae._allow_external_llm
+        and dae._provider_has_key(preferred_provider)
+    ):
+        model_hint = f"{preferred_provider}/{preferred_model}"
+    elif dae._conversation_backend == "ironclaw":
+        model_hint = (ironclaw_runtime.get("model") or "model").strip() or "model"
+    else:
+        code_path = (local_code.get("path") or "").strip()
+        if code_path and code_path.lower() != "unavailable":
+            try:
+                model_hint = Path(code_path).name or "model"
+            except Exception:
+                model_hint = code_path
+    model_hint = model_hint.lower()
+
+    if "{model}" in template:
+        return template.replace("{model}", model_hint).lower()
+
+    if "model" in template:
+        return template.replace("model", model_hint).lower()
+
+    return template.lower()
+
+
+def probe_provider_endpoint(
+    dae: Any,
+    provider: str,
+    timeout_sec: float = 2.0,
+) -> tuple[bool, str]:
+    """Best-effort live provider probe for model availability reporting."""
+    provider_name = (provider or "").strip().lower()
+    if not provider_name:
+        return False, "invalid_provider"
+    if not dae._provider_has_key(provider_name):
+        return False, "no_key"
+
+    try:
+        import requests as _req
+    except Exception:
+        return False, "requests_unavailable"
+
+    api_keys = {
+        "openai": os.getenv("OPENAI_API_KEY", "").strip(),
+        "anthropic": os.getenv("ANTHROPIC_API_KEY", "").strip(),
+        "grok": (
+            os.getenv("GROK_API_KEY", "").strip()
+            or os.getenv("XAI_API_KEY", "").strip()
+        ),
+        "gemini": os.getenv("GEMINI_API_KEY", "").strip(),
+    }
+    key = api_keys.get(provider_name, "")
+    if not key:
+        return False, "no_key"
+
+    endpoint = ""
+    headers: Dict[str, str] = {}
+    params: Dict[str, str] = {}
+
+    if provider_name in {"openai", "grok"}:
+        base = "https://api.openai.com/v1" if provider_name == "openai" else "https://api.x.ai/v1"
+        endpoint = f"{base}/models"
+        headers = {"Authorization": f"Bearer {key}"}
+    elif provider_name == "anthropic":
+        endpoint = "https://api.anthropic.com/v1/models"
+        headers = {
+            "x-api-key": key,
+            "anthropic-version": "2023-06-01",
+        }
+    elif provider_name == "gemini":
+        endpoint = "https://generativelanguage.googleapis.com/v1/models"
+        params = {"key": key}
+    else:
+        return False, "unsupported_provider"
+
+    try:
+        response = _req.get(
+            endpoint,
+            headers=headers or None,
+            params=params or None,
+            timeout=max(0.5, timeout_sec),
+        )
+        code = int(response.status_code)
+        if 200 <= code < 300:
+            return True, "api_ok"
+        if code in {401, 403}:
+            return False, "auth_error"
+        return True, f"http_{code}"
+    except Exception as exc:
+        return False, f"network_{type(exc).__name__.lower()}"
+
+
+def get_model_availability_snapshot(
+    dae: Any,
+    live_probe: bool = False,
+    timeout_sec: float = 2.0,
+) -> Dict[str, Any]:
+    """Return startup model/provider availability for voice/chat diagnostics."""
+    local_root = Path(
+        os.getenv("LOCAL_MODEL_ROOT", "E:/LM_studio/models/local")
+    ).expanduser()
+
+    local_targets = {
+        "local/qwen-coder-7b": "qwen-coder-7b",
+        "local/qwen3-4b": "qwen3-4b",
+        "local/qwen3.5-4b": "qwen3.5-4b",
+        "local/gemma-270m": "gemma-270m",
+    }
+    local_status: Dict[str, str] = {}
+    for target_id, folder in local_targets.items():
+        model_dir = local_root / folder
+        if not model_dir.exists() or not model_dir.is_dir():
+            local_status[target_id] = "missing"
+            continue
+        try:
+            has_gguf = any(model_dir.glob("*.gguf"))
+        except Exception:
+            has_gguf = False
+        local_status[target_id] = "ready" if has_gguf else "dir_only"
+
+    providers = ("openai", "anthropic", "grok", "gemini")
+    provider_status: Dict[str, str] = {}
+    for provider in providers:
+        if not dae._provider_has_key(provider):
+            provider_status[provider] = "no_key"
+            continue
+        if not live_probe:
+            provider_status[provider] = "key_present"
+            continue
+        _, detail = probe_provider_endpoint(dae, provider, timeout_sec=timeout_sec)
+        provider_status[provider] = detail
+
+    target = dae._conversation_model_target_id or "local/qwen-coder-7b"
+    target_status = "unknown"
+    if target in local_status:
+        target_status = local_status[target]
+    else:
+        external = dae._resolve_external_target(target)
+        if external:
+            provider_name, _ = external
+            target_status = provider_status.get(provider_name, "no_key")
+
+    local_code = resolve_local_code_model_snapshot()
+    ironclaw_runtime = {
+        "healthy": "N/A",
+        "detail": "not_probed",
+        "model": os.getenv("IRONCLAW_MODEL", "local/qwen-coder-7b").strip() or "local/qwen-coder-7b",
+        "models": "none",
+    }
+    effective_model_name = resolve_identity_model_name(dae, local_code, ironclaw_runtime)
+
+    return {
+        "probe_mode": "live" if live_probe else "keys_only",
+        "local_root": str(local_root),
+        "local": local_status,
+        "providers": provider_status,
+        "target": target,
+        "target_status": target_status,
+        "effective_model_name": effective_model_name,
+    }
+
+
+def get_identity_snapshot(dae: Any, include_runtime_probe: bool = True) -> Dict[str, str]:
+    """Return canonical 0102 identity snapshot used by daemon/CLI/status surfaces."""
+    local_code = resolve_local_code_model_snapshot()
+    ironclaw_runtime = {
+        "healthy": "N/A",
+        "detail": "backend_not_ironclaw",
+        "model": os.getenv("IRONCLAW_MODEL", "local/qwen-coder-7b").strip() or "local/qwen-coder-7b",
+        "models": "none",
+        "base_url": os.getenv("IRONCLAW_BASE_URL", "http://127.0.0.1:3000").strip() or "http://127.0.0.1:3000",
+    }
+    if include_runtime_probe and (
+        dae._conversation_backend == "ironclaw"
+        or _env_truthy("OPENCLAW_ALLOW_IRONCLAW_FALLBACK", "0")
+    ):
+        ironclaw_runtime = probe_ironclaw_runtime()
+
+    model_name = resolve_identity_model_name(dae, local_code, ironclaw_runtime)
+    token_snapshot = dae._get_token_usage_snapshot()
+    return {
+        "backend": dae._conversation_backend,
+        "runtime_profile": dae._runtime_profile,
+        "key_isolation": "ON" if dae._no_api_keys else "OFF",
+        "ironclaw_strict": "ON" if dae._ironclaw_strict else "OFF",
+        "ironclaw_allow_local_fallback": "ON" if dae._ironclaw_allow_local_fallback else "OFF",
+        "genus": dae._identity_genus,
+        "lineage": dae._identity_model_family,
+        "model_family": dae._identity_model_family,
+        "model_name": model_name,
+        "model_catalog": dae._identity_model_catalog or "unspecified",
+        "conversation_model_target": dae._conversation_model_target_id or "local/qwen-coder-7b",
+        "conversation_model_locked": "ON" if dae._conversation_model_target_locked else "OFF",
+        "auto_model_role": dae._last_auto_model_role or "unknown",
+        "auto_model_target": dae._last_auto_model_target or "unknown",
+        "auto_model_reason": dae._last_auto_model_reason or "unknown",
+        "preferred_external_provider": dae._preferred_external_provider or "none",
+        "preferred_external_model": dae._preferred_external_model or "none",
+        "preferred_external_status": dae._preferred_external_last_status,
+        "preferred_external_status_detail": dae._preferred_external_last_status_detail,
+        "preferred_external_status_age": (
+            f"{int(max(0.0, time.time() - dae._preferred_external_last_status_at))}s"
+            if dae._preferred_external_last_status_at > 0
+            else "never"
+        ),
+        "protocol_anchor": dae._identity_protocol_anchor,
+        "wsp00_boot": "ON" if dae._wsp00_boot_enabled else "OFF",
+        "wsp00_boot_mode": dae._wsp00_boot_mode,
+        "wsp00_file_override": "YES" if bool(dae._wsp00_prompt_file) else "NO",
+        "platform_context": "ON" if dae._platform_context_enabled else "OFF",
+        "platform_context_sources": str(len(dae._platform_context_pack_sources)),
+        "platform_context_loaded_ago": (
+            f"{int(max(0.0, time.time() - dae._platform_context_pack_loaded_at))}s"
+            if dae._platform_context_pack_loaded_at > 0
+            else "never"
+        ),
+        "last_engine": dae._last_conversation_engine,
+        "last_engine_detail": dae._last_conversation_detail,
+        "previous_engine": dae._previous_conversation_engine,
+        "previous_engine_detail": dae._previous_conversation_detail,
+        "token_last_prompt_tokens": str(token_snapshot["last_prompt_tokens"]),
+        "token_last_completion_tokens": str(token_snapshot["last_completion_tokens"]),
+        "token_last_total_tokens": str(token_snapshot["last_total_tokens"]),
+        "token_last_engine": token_snapshot["last_engine"],
+        "token_last_provider": token_snapshot["last_provider"],
+        "token_last_model": token_snapshot["last_model"],
+        "token_last_source": token_snapshot["last_source"],
+        "token_last_cost_estimate_usd": f"{token_snapshot['last_cost_estimate_usd']:.6f}",
+        "token_last_age": token_snapshot["last_age"],
+        "token_session_turns": str(token_snapshot["session_turns"]),
+        "token_session_prompt_tokens": str(token_snapshot["session_prompt_tokens"]),
+        "token_session_completion_tokens": str(token_snapshot["session_completion_tokens"]),
+        "token_session_total_tokens": str(token_snapshot["session_total_tokens"]),
+        "token_session_cost_estimate_usd": f"{token_snapshot['session_cost_estimate_usd']:.6f}",
+        "last_social_source": dae._last_social_response_source,
+        "last_social_action": dae._last_social_response_action,
+        "last_social_skill": dae._last_social_response_skill,
+        "last_social_success": dae._last_social_response_success,
+        "last_social_preview": dae._last_social_response_preview,
+        "last_social_age": (
+            f"{int(max(0.0, time.time() - dae._last_social_response_at))}s"
+            if dae._last_social_response_at > 0
+            else "never"
+        ),
+        "local_code_model_path": local_code.get("path", "unavailable"),
+        "local_code_model_state": local_code.get("state", "ERROR"),
+        "local_code_model_source": local_code.get("source", "unavailable"),
+        "ironclaw_runtime_healthy": ironclaw_runtime.get("healthy", "UNKNOWN"),
+        "ironclaw_runtime_detail": ironclaw_runtime.get("detail", "not-probed"),
+        "ironclaw_runtime_model": ironclaw_runtime.get("model", "unknown"),
+        "ironclaw_runtime_models": ironclaw_runtime.get("models", "none"),
+        "ironclaw_runtime_base_url": ironclaw_runtime.get("base_url", "unknown"),
+    }

--- a/modules/communication/moltbot_bridge/src/openclaw_social_controller.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_social_controller.py
@@ -1,0 +1,128 @@
+"""OpenClaw social-control routing helpers.
+
+WSP 73/97 boundary:
+- OpenClaw owns natural-language mission control and execution-plane routing.
+- Social/LinkedIn/X adapters remain child execution domains.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from .openclaw_dae import OpenClawIntent
+
+
+logger = logging.getLogger("openclaw_dae")
+
+
+async def execute_social(dae: Any, intent: "OpenClawIntent") -> str:
+    """Route SOCIAL intent to deterministic social adapters."""
+    try:
+        from .linkedin_loop_adapter import handle_linkedin_loop_intent
+
+        linkedin_loop_response = await handle_linkedin_loop_intent(
+            intent.raw_message,
+            intent.sender,
+        )
+        if linkedin_loop_response:
+            dae._record_social_response("linkedin_loop", linkedin_loop_response)
+            return linkedin_loop_response
+    except Exception as exc:
+        logger.warning("[OPENCLAW-DAE] LinkedIn loop adapter unavailable: %s", exc)
+
+    try:
+        from .social_campaign_adapter import handle_social_campaign_intent
+
+        campaign_response = await handle_social_campaign_intent(
+            intent.raw_message,
+            intent.sender,
+        )
+        if campaign_response:
+            dae._record_social_response("social_campaign", campaign_response)
+            return campaign_response
+    except Exception as exc:
+        logger.warning("[OPENCLAW-DAE] Social campaign adapter unavailable: %s", exc)
+
+    try:
+        from .linkedin_social_adapter import handle_linkedin_social_intent
+
+        linkedin_response = await handle_linkedin_social_intent(
+            intent.raw_message,
+            intent.sender,
+        )
+        if linkedin_response:
+            dae._record_social_response("linkedin", linkedin_response)
+            return linkedin_response
+    except Exception as exc:
+        logger.warning("[OPENCLAW-DAE] LinkedIn social adapter unavailable: %s", exc)
+
+    try:
+        from .x_social_adapter import handle_x_social_intent
+
+        x_response = await handle_x_social_intent(
+            intent.raw_message,
+            intent.sender,
+        )
+        if x_response:
+            dae._record_social_response("x", x_response)
+            return x_response
+    except Exception as exc:
+        logger.warning("[OPENCLAW-DAE] X social adapter unavailable: %s", exc)
+
+    return (
+        f"Social engagement request on {intent.channel}: "
+        f"{intent.extracted_task}\n"
+        "Routing to communication layer... "
+        "(Digital Twin engagement via livechat/video_comments)\n"
+        "Tips: "
+        "`linkedin action <action> key=value`, "
+        "`x action <action> key=value`, or "
+        "`social campaign <campaign_name> key=value`."
+    )
+
+
+async def try_conversation_social_control(
+    dae: Any, intent: "OpenClawIntent"
+) -> Optional[str]:
+    """
+    Allow natural-language social controls from direct conversation channels.
+
+    This keeps operator phrasing ergonomic while still routing through the same
+    deterministic social adapters.
+    """
+    try:
+        from .linkedin_loop_adapter import handle_linkedin_loop_intent
+
+        linkedin_loop_response = await handle_linkedin_loop_intent(
+            intent.raw_message,
+            intent.sender,
+        )
+        if linkedin_loop_response:
+            dae._record_social_response("linkedin_loop", linkedin_loop_response)
+            dae._mark_conversation_engine(
+                "linkedin_loop_control",
+                "deterministic_conversation_route",
+            )
+            return linkedin_loop_response
+    except Exception as exc:
+        logger.warning("[OPENCLAW-DAE] LinkedIn loop control unavailable: %s", exc)
+
+    try:
+        from .linkedin_social_adapter import handle_linkedin_social_intent
+
+        linkedin_response = await handle_linkedin_social_intent(
+            intent.raw_message,
+            intent.sender,
+        )
+        if linkedin_response:
+            dae._record_social_response("linkedin", linkedin_response)
+            dae._mark_conversation_engine(
+                "linkedin_social_control",
+                "deterministic_conversation_route",
+            )
+            return linkedin_response
+    except Exception as exc:
+        logger.warning("[OPENCLAW-DAE] LinkedIn conversation control unavailable: %s", exc)
+    return None

--- a/modules/communication/moltbot_bridge/src/openclaw_status_surface.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_status_surface.py
@@ -1,0 +1,106 @@
+"""OpenClaw status/reporting helpers for operator-facing surfaces."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("openclaw_dae")
+
+
+def build_connect_wre_status(dae: Any, verbose: bool = False) -> str:
+    """Deterministic Connect-WRE status response for operator prompts."""
+    preflight_ok = False
+    health: Dict[str, Any] = {}
+    in_watch: Optional[bool] = None
+    issues: List[str] = []
+
+    try:
+        from modules.infrastructure.wre_core.src.dae_preflight import run_dae_preflight
+
+        preflight_ok = bool(run_dae_preflight("connect_wre", quiet=True))
+    except Exception as exc:
+        issues.append(f"preflight_unavailable:{type(exc).__name__}")
+
+    try:
+        from modules.infrastructure.wre_core.src.dashboard_alerts import (
+            DashboardAlertMonitor,
+            check_dashboard_health,
+        )
+
+        monitor = DashboardAlertMonitor()
+        in_watch = monitor.is_in_watch_period()
+        health = check_dashboard_health() or {}
+    except Exception as exc:
+        issues.append(f"dashboard_unavailable:{type(exc).__name__}")
+
+    enabled = os.getenv("WRE_DASHBOARD_PREFLIGHT", "1") != "0"
+    manual_enforced = os.getenv("WRE_DASHBOARD_PREFLIGHT_ENFORCED", "0") != "0"
+    auto_enforce = os.getenv("WRE_DASHBOARD_AUTO_ENFORCE", "1") != "0"
+    insufficient_data = bool(health.get("insufficient_data", False))
+    total_executions = int(health.get("total_executions", 0))
+    min_samples = int(
+        health.get("min_samples", int(os.getenv("WRE_DASHBOARD_MIN_SAMPLES", "25")))
+    )
+    alerts = health.get("alerts", []) if isinstance(health.get("alerts"), list) else []
+    critical = sum(1 for alert in alerts if alert.get("severity") == "critical")
+    warnings = sum(1 for alert in alerts if alert.get("severity") == "warning")
+
+    auto_enforced = bool(auto_enforce and in_watch is not None and not in_watch and not insufficient_data)
+    effective_enforced = bool(manual_enforced or auto_enforced)
+
+    if not enabled:
+        readiness = "DISABLED"
+    elif insufficient_data:
+        readiness = "INSUFFICIENT_DATA"
+    elif critical > 0 and effective_enforced:
+        readiness = "BLOCKED"
+    elif critical > 0:
+        readiness = "DEGRADED"
+    else:
+        readiness = "READY"
+
+    connection_state = "CONNECTED" if preflight_ok and not issues else "PARTIAL"
+    mode = "WATCH" if in_watch else "STABLE"
+    if in_watch is None:
+        mode = "UNKNOWN"
+
+    response = (
+        "0102: connect_wre "
+        f"connection={connection_state} "
+        f"readiness={readiness} "
+        f"mode={mode} "
+        f"samples={total_executions}/{min_samples} "
+        f"critical={critical} warnings={warnings} "
+        f"enforced={'ON' if effective_enforced else 'OFF'}"
+    )
+    if issues:
+        if verbose:
+            response += f" issues={';'.join(issues)}"
+        else:
+            response += " (say 'connect wre details' for diagnostics)"
+    return response
+
+
+def push_status(dae: Any, message: str, to_discord: bool = True) -> bool:
+    """Push status update via AI Overseer or direct Discord fallback."""
+    if not to_discord:
+        return True
+
+    if dae.overseer and hasattr(dae.overseer, "push_status"):
+        try:
+            result = dae.overseer.push_status(message, to_discord=True, to_chat=False)
+            return result.get("discord", False)
+        except Exception as exc:
+            logger.warning("[OPENCLAW-DAE] Push status failed: %s", exc)
+
+    try:
+        from modules.communication.livechat.src.discord_status_pusher import (
+            push_status as direct_push,
+        )
+
+        return direct_push(message, to_discord=True, to_log=False)
+    except ImportError:
+        logger.debug("[OPENCLAW-DAE] Discord pusher not available")
+        return True

--- a/modules/communication/moltbot_bridge/src/openclaw_turn_state.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_turn_state.py
@@ -1,0 +1,179 @@
+"""OpenClaw runtime telemetry and cooperative turn-cancel helpers."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("openclaw_dae")
+
+
+def mark_conversation_engine(dae: Any, engine: str, detail: str = "none") -> None:
+    """Record which conversation runtime produced the latest reply."""
+    dae._previous_conversation_engine = dae._last_conversation_engine
+    dae._previous_conversation_detail = dae._last_conversation_detail
+    dae._last_conversation_engine = engine
+    dae._last_conversation_detail = detail or "none"
+
+
+def mark_preferred_external_status(dae: Any, status: str, detail: str = "none") -> None:
+    """Record preferred external model routing status for diagnostics."""
+    dae._preferred_external_last_status = (status or "unknown").strip().lower() or "unknown"
+    dae._preferred_external_last_status_detail = (detail or "none").strip() or "none"
+    dae._preferred_external_last_status_at = time.time()
+
+
+def safe_int(value: Any) -> Optional[int]:
+    """Safely coerce telemetry fields to non-negative ints."""
+    try:
+        parsed = int(value)
+        return parsed if parsed >= 0 else None
+    except (TypeError, ValueError):
+        return None
+
+
+def estimate_token_count(text: str) -> int:
+    """Lightweight token estimate (~4 chars/token) for providers without usage data."""
+    clean = (text or "").strip()
+    if not clean:
+        return 0
+    return max(1, int(round(len(clean) / 4.0)))
+
+
+def record_token_usage(
+    dae: Any,
+    *,
+    prompt_text: str,
+    completion_text: str,
+    engine: str,
+    provider: str,
+    model: str,
+    usage: Optional[Dict[str, Any]] = None,
+    source: str = "estimated",
+    cost_estimate_usd: Optional[float] = None,
+) -> None:
+    """Store per-turn + session token telemetry for runtime diagnostics."""
+    usage = usage or {}
+
+    prompt_tokens = safe_int(usage.get("prompt_tokens"))
+    completion_tokens = safe_int(usage.get("completion_tokens"))
+    total_tokens = safe_int(usage.get("total_tokens"))
+
+    if prompt_tokens is None:
+        prompt_tokens = estimate_token_count(prompt_text)
+    if completion_tokens is None:
+        completion_tokens = estimate_token_count(completion_text)
+    if total_tokens is None:
+        total_tokens = prompt_tokens + completion_tokens
+
+    cost = 0.0
+    if cost_estimate_usd is not None:
+        try:
+            cost = max(0.0, float(cost_estimate_usd))
+        except (TypeError, ValueError):
+            cost = 0.0
+
+    resolved_source = (source or "estimated").strip().lower() or "estimated"
+    dae._token_usage_last_prompt_tokens = prompt_tokens
+    dae._token_usage_last_completion_tokens = completion_tokens
+    dae._token_usage_last_total_tokens = total_tokens
+    dae._token_usage_last_engine = (engine or "unknown").strip() or "unknown"
+    dae._token_usage_last_provider = (provider or "unknown").strip() or "unknown"
+    dae._token_usage_last_model = (model or "unknown").strip() or "unknown"
+    dae._token_usage_last_source = resolved_source
+    dae._token_usage_last_cost_estimate_usd = cost
+    dae._token_usage_last_at = time.time()
+
+    dae._token_usage_session_turns += 1
+    dae._token_usage_session_prompt_tokens += prompt_tokens
+    dae._token_usage_session_completion_tokens += completion_tokens
+    dae._token_usage_session_total_tokens += total_tokens
+    dae._token_usage_session_cost_estimate_usd += cost
+
+
+def get_token_usage_snapshot(dae: Any) -> Dict[str, Any]:
+    """Return token telemetry snapshot for identity/monitor/status responses."""
+    if dae._token_usage_last_at > 0:
+        age = f"{int(max(0.0, time.time() - dae._token_usage_last_at))}s"
+    else:
+        age = "never"
+
+    return {
+        "last_prompt_tokens": dae._token_usage_last_prompt_tokens,
+        "last_completion_tokens": dae._token_usage_last_completion_tokens,
+        "last_total_tokens": dae._token_usage_last_total_tokens,
+        "last_engine": dae._token_usage_last_engine,
+        "last_provider": dae._token_usage_last_provider,
+        "last_model": dae._token_usage_last_model,
+        "last_source": dae._token_usage_last_source,
+        "last_cost_estimate_usd": dae._token_usage_last_cost_estimate_usd,
+        "last_age": age,
+        "session_turns": dae._token_usage_session_turns,
+        "session_prompt_tokens": dae._token_usage_session_prompt_tokens,
+        "session_completion_tokens": dae._token_usage_session_completion_tokens,
+        "session_total_tokens": dae._token_usage_session_total_tokens,
+        "session_cost_estimate_usd": dae._token_usage_session_cost_estimate_usd,
+    }
+
+
+def build_token_usage_report(dae: Any) -> str:
+    """Deterministic token spend report for operator queries."""
+    snapshot = get_token_usage_snapshot(dae)
+    return "\n".join(
+        [
+            "0102: token usage telemetry",
+            (
+                "- last_turn: "
+                f"engine={snapshot['last_engine']} "
+                f"provider={snapshot['last_provider']} "
+                f"model={snapshot['last_model']} "
+                f"prompt={snapshot['last_prompt_tokens']} "
+                f"completion={snapshot['last_completion_tokens']} "
+                f"total={snapshot['last_total_tokens']} "
+                f"source={snapshot['last_source']} "
+                f"cost_estimate_usd={snapshot['last_cost_estimate_usd']:.6f} "
+                f"age={snapshot['last_age']}"
+            ),
+            (
+                "- session: "
+                f"turns={snapshot['session_turns']} "
+                f"prompt={snapshot['session_prompt_tokens']} "
+                f"completion={snapshot['session_completion_tokens']} "
+                f"total={snapshot['session_total_tokens']} "
+                f"cost_estimate_usd={snapshot['session_cost_estimate_usd']:.6f}"
+            ),
+            "- note: token counts are estimated unless provider_usage is available.",
+        ]
+    )
+
+
+def request_turn_cancel(dae: Any, reason: str = "external_interrupt") -> None:
+    """Signal cooperative cancellation for the currently executing turn."""
+    dae._turn_cancel_reason = (reason or "external_interrupt").strip()
+    dae._turn_cancel_event.set()
+    logger.info("[OPENCLAW-DAE] Turn cancel requested | reason=%s", dae._turn_cancel_reason)
+
+
+def clear_turn_cancel(dae: Any) -> None:
+    """Reset cancellation signal before starting a new turn."""
+    dae._turn_cancel_reason = "none"
+    dae._turn_cancel_event.clear()
+
+
+def is_turn_cancelled(dae: Any, point: str = "") -> bool:
+    """Check whether current turn was cancelled."""
+    if not dae._turn_cancel_event.is_set():
+        return False
+    if point:
+        logger.info(
+            "[OPENCLAW-DAE] Turn cancellation observed at %s | reason=%s",
+            point,
+            dae._turn_cancel_reason,
+        )
+    return True
+
+
+def turn_cancelled_response() -> str:
+    """User-facing response when a turn is interrupted."""
+    return "0102: Interrupted. Ready for your next prompt."

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -11,6 +11,77 @@
 
 # TestModLog - tests
 
+## 2026-03-11: OpenClaw bootstrap constructor extraction regression
+
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; .\.venv\Scripts\python.exe -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_dae.py -k "identity_query or model_switch or qwen3_5 or platform_context or agentic_model_selection_routes_code_turn_to_coder or connect_wre or runtime_profile or preferred_external" -q`
+- Status: PASS
+- Result: `21 passed, 75 deselected, 2 warnings`
+- Notes:
+  - Confirms `openclaw_bootstrap_config.py` preserves constructor-initialized identity, platform-context, preferred-external, and agentic model state after extraction from `openclaw_dae.py`.
+  - Warnings are existing repo-level pytest config warnings under plugin-autoload-disabled mode.
+
+---
+
+## 2026-03-11: OpenClaw provider/runtime chain extraction regression
+
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; .\.venv\Scripts\python.exe -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_dae.py -k "identity_query or model_switch or qwen3_5 or platform_context or connect_wre or preferred_external or runtime_profile" -q`
+- Status: PASS
+- Result: `20 passed, 76 deselected, 2 warnings`
+- Notes:
+  - Confirms `openclaw_provider_chain.py` and the `openclaw_runtime_support.py` autostart extraction preserve provider selection, runtime-profile gates, and conversation identity behavior after extraction from `openclaw_dae.py`.
+  - Warnings are existing repo-level pytest config warnings under plugin-autoload-disabled mode.
+
+---
+
+## 2026-03-11: OpenClaw identity/model-policy extraction regression
+
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; .\.venv\Scripts\python.exe -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_dae.py -k "identity_query or model_switch or qwen3_5 or platform_context or agentic_model_selection_routes_code_turn_to_coder or connect_wre" -q`
+- Status: PASS
+- Result: `20 passed, 76 deselected, 2 warnings`
+- Notes:
+  - Confirms `openclaw_identity_context.py` and `openclaw_model_policy.py` preserve existing identity, model-switch, platform-context, and agentic model-routing behavior after extraction from `openclaw_dae.py`.
+  - Warnings are existing repo-level pytest config warnings under plugin-autoload-disabled mode.
+
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; .\.venv\Scripts\python.exe -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_dae_social_actions.py -q`
+- Status: PASS
+- Result: `7 passed, 2 warnings`
+- Notes:
+  - Confirms the new extraction does not regress OpenClaw social-action identity/status surfaces.
+
+---
+
+## 2026-03-11: OpenClaw social/conversation extraction regression
+
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; .\.venv\Scripts\python.exe -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_dae_social_actions.py modules/communication/moltbot_bridge/tests/test_openclaw_dae.py -k "social or conversation or identity_query or model_switch or connect_wre" -q`
+- Status: PASS
+- Result: `56 passed, 47 deselected, 2 warnings`
+- Notes:
+  - Confirms `openclaw_social_controller.py` and `openclaw_conversation_engine.py` preserve the public `OpenClawDAE` behavior after extraction from `openclaw_dae.py`.
+
+---
+
+## 2026-03-10: OpenClaw runtime/identity helper extraction regression
+
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; .\.venv\Scripts\python.exe -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_dae.py -k "structured_actions_to_central_daemon or model_availability_snapshot or qwen3_5 or identity_query" -q`
+- Status: PASS
+- Result: `10 passed, 86 deselected, 2 warnings`
+- Notes:
+  - Confirms `openclaw_action_ledger.py` and `openclaw_runtime_support.py` preserve existing identity/model-selection/runtime behavior after extraction from `openclaw_dae.py`.
+  - Warnings are existing repo-level pytest config warnings under plugin-autoload-disabled mode.
+
+---
+
+## 2026-03-10: OpenClaw DAEmon action ledger regression
+
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; .\.venv\Scripts\python.exe -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_dae.py -k "structured_actions_to_central_daemon" -q`
+- Status: PASS
+- Result: `1 passed, 95 deselected, 2 warnings`
+- Notes:
+  - Confirms the OpenClaw autonomy loop emits structured DAEmon action events in addition to `message_in` / `message_out`.
+  - Warnings are existing repo-level pytest config warnings under plugin-autoload-disabled mode.
+
+---
+
 ## 2026-03-05: Post-escalation shared security regression sweep
 
 - Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; pytest -q modules/infrastructure/wre_core/tests/test_codeact_executor_hardening.py modules/infrastructure/wre_core/tests/test_dependency_security_preflight.py modules/infrastructure/wre_core/tests/test_skill_manifest_guard.py modules/infrastructure/wre_core/tests/test_dae_preflight_integration_guard.py modules/infrastructure/wre_core/tests/test_dae_preflight_security_behavior.py modules/infrastructure/wre_core/wre_master_orchestrator/tests/test_wre_master_orchestrator.py modules/communication/moltbot_bridge/tests/test_skill_safety_guard.py -k "supply_chain_gate or hardening or dependency or manifest or self_audit or preflight"`
@@ -154,3 +225,73 @@
 
 **Result**
 - `4 passed`
+## 2026-03-10: LinkedIn mission-control + agentic routing regression coverage
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; .\.venv\Scripts\python.exe -m pytest modules/communication/moltbot_bridge/tests/test_linkedin_loop_adapter.py modules/communication/moltbot_bridge/tests/test_openclaw_dae_social_actions.py modules/communication/moltbot_bridge/tests/test_openclaw_dae.py -q`
+- Status: PASS
+- Result: `106 passed, 2 warnings`
+- Notes:
+  - Validates conversational LinkedIn loop control through `linkedin_loop_adapter`.
+  - Confirms `WSP_97_System_Execution_Prompting_Protocol.md` is present in the default OpenClaw context pack.
+  - Validates OpenClawDAE actually routes LinkedIn loop-control phrases through the loop adapter.
+  - Regresses mixed code/triage prompts so code-change turns route to `local/qwen-coder-7b`.
+  - Validates explicit `follow wsp ...` command routing through the dedicated WSP orchestrator path.
+
+## 2026-03-10: WSP 97 follow-wsp deterministic route smoke slice
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; .\.venv\Scripts\python.exe -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_dae.py -k "follow_wsp or platform_context or agentic_model_selection_routes_code_turn_to_coder" -q`
+- Status: PASS
+- Result: `5 passed, 90 deselected, 2 warnings`
+- Notes:
+  - Confirms `follow wsp ...` uses the dedicated WSP orchestrator route.
+  - Confirms default platform context still includes `WSP_97`.
+  - Confirms code-heavy mixed prompts still route to `local/qwen-coder-7b`.
+
+## 2026-03-11: OpenClaw intent/result seam regression coverage
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; .\.venv\Scripts\python.exe -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_dae.py -k "classify_intent or wsp_preflight or follow_wsp or validate_and_remember or connect_wre or model_switch or identity_query" -q`
+- Status: PASS
+- Result: `15 passed, 81 deselected, 2 warnings`
+- Notes:
+  - Confirms extracted intent classification still honors `connect wre`, identity, model switch, and WSP preflight behavior.
+  - Confirms extracted validate/remember path still stores and redacts as expected.
+
+## 2026-03-11: OpenClaw permission-policy regression coverage
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; .\.venv\Scripts\python.exe -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_dae.py -k "permission or source or skill_safety or containment or classify_intent or wsp_preflight or validate_and_remember" -q`
+- Status: PASS
+- Result: `17 passed, 79 deselected, 2 warnings`
+- Notes:
+  - Confirms autonomy-tier resolution, SOURCE gating, containment, and skill-safety behavior survived extraction to `openclaw_permission_policy.py`.
+  - Confirms no regression in extracted intent/result seams while permission policy was moved.
+
+## 2026-03-11: OpenClaw execution-route regression coverage
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; .\.venv\Scripts\python.exe -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_dae.py -k "query or command or follow_wsp or monitor or schedule or automation or foundup or research" -q`
+- Status: PASS
+- Result: `29 passed, 67 deselected, 2 warnings`
+- Notes:
+  - Confirms route delegation through `openclaw_execution_routes.py` for all non-social execution planes.
+  - Confirms `follow wsp` deterministic routing still executes through the WSP orchestrator after extraction.
+
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; .\.venv\Scripts\python.exe -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_dae.py -k "monitor_returns_status or execute_command_follow_wsp_uses_wsp_orchestrator or identity_query_defaults_to_compact_response" -q`
+- Status: PASS
+- Result: `3 passed, 93 deselected, 2 warnings`
+- Notes:
+  - Smoke-checks compact identity, monitor status, and WSP route execution after route-layer extraction.
+
+## 2026-03-11: OpenClaw telemetry + turn-state regression coverage
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; .\.venv\Scripts\python.exe -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_dae.py -k "token_usage or turn_cancellation or identity_query_defaults_to_compact_response or monitor_returns_status" -q`
+- Status: PASS
+- Result: `4 passed, 92 deselected, 2 warnings`
+- Notes:
+  - Confirms extracted token telemetry still feeds identity/monitor status correctly.
+  - Confirms cooperative turn cancellation still interrupts live turns cleanly after extraction.
+
+## 2026-03-11: OpenClaw status/process regression coverage
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; .\.venv\Scripts\python.exe -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_dae.py -k "test_conversation_returns_response or test_blocked_command_downgrades_to_conversation or test_monitor_returns_status or test_zeroclaw_downgrades_mutating_intent_to_conversation_route or test_process_reports_structured_actions_to_central_daemon" -q`
+- Status: PASS
+- Result: `5 passed, 91 deselected, 2 warnings`
+- Notes:
+  - Confirms the extracted `openclaw_process_loop.py` preserves end-to-end autonomy behavior and DAEmon action emission.
+
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; .\.venv\Scripts\python.exe -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_dae.py -k "token_usage_query_returns_deterministic_report or conversation_honors_turn_cancellation or execute_command_follow_wsp_uses_wsp_orchestrator or monitor_reports_lineage_and_model_name" -q`
+- Status: PASS
+- Result: `4 passed, 92 deselected, 2 warnings`
+- Notes:
+  - Confirms extracted status/telemetry surfaces still drive token usage, cancellation, monitor, and follow-wsp behavior correctly.


### PR DESCRIPTION
## Summary
- split openclaw_dae.py into explicit control-plane modules
- keep OpenClawDAE as the orchestration facade
- document the internal WSP 97 module map

## Validation
- focused OpenClaw pytest slices in clean-main
- compile checks for all openclaw*.py modules
