### PR TITLE
docs(research): assess karpathy autoresearch under wsp97

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -55553,6 +55553,22 @@ if cooldown_sets:
 ### Cleanup Recommendations
 - Consider migrating posted_streams.json from array to dict format with timestamps
 
+## 2026-03-15 - AutoResearch WSP 97 assessment
+
+**Scope**
+- `modules/ai_intelligence/pqn_alignment/docs/KARPATHY_AUTORESEARCH_WSP97_ASSESSMENT_2026-03-15.md`
+- `modules/ai_intelligence/ai_overseer/skillz/open_source_tool_diligence/SKILLz.md`
+- `modules/ai_intelligence/pqn_alignment/ROADMAP.md`
+- `modules/ai_intelligence/pqn_mcp/ROADMAP.md`
+- `WSP_framework/src/WSP_77_Agent_Coordination_Protocol.md`
+- `WSP_framework/src/WSP_96_MCP_Governance_and_Consensus_Protocol.md`
+- mirrored knowledge copies
+
+**Summary**
+- Assessed `karpathy/autoresearch` as an external isolated research worker candidate.
+- Explicitly rejected direct startup integration and direct production monorepo mutation.
+- Added reusable diligence skill and updated WSP/roadmap posture to match.
+
 ## LinkedIn Scheduling Queue Audit - 2025-10-19
 
 **WSP Compliance**: WSP 50 (Pre-Action), WSP 77 (Agent Coordination), WSP 60 (Memory)

--- a/WSP_framework/src/ModLog.md
+++ b/WSP_framework/src/ModLog.md
@@ -757,3 +757,14 @@ L:<lane> S:<scope> M:<mode> T:<task> R:[wsps] I:{inv} O:[out] F:[fail]
 **Verification**:
 - Confirmed no missing numbered framework WSP rows (excluding WSP 00 entry format) after remediation.
 - Confirmed WSP 94 and WSP 98 rows are present in `WSP_MASTER_INDEX.md`.
+
+## 2026-03-15 - External research runtime governance clarification
+
+**WSP References**: WSP 77, WSP 96, WSP 97, WSP 22
+
+**Changes Made**:
+- Updated `WSP_77_Agent_Coordination_Protocol.md` with explicit rule that autonomous external research systems remain subordinate worker runtimes under 0102 control.
+- Updated `WSP_96_MCP_Governance_and_Consensus_Protocol.md` to clarify that non-MCP external runtimes must be isolated and wrapped before any MCP exposure.
+
+**Rationale**:
+- Tools such as `karpathy/autoresearch` are useful candidates, but their operating model does not map directly to FoundUps control-plane or production-repo governance.

--- a/WSP_framework/src/WSP_77_Agent_Coordination_Protocol.md
+++ b/WSP_framework/src/WSP_77_Agent_Coordination_Protocol.md
@@ -1,8 +1,8 @@
 # WSP 77: Agent Coordination Protocol
 
 **Status**: ACTIVE
-**Version**: 1.1
-**Date**: 2026-03-07
+**Version**: 1.2
+**Date**: 2026-03-15
 **Author**: 0102 (HoloIndex Coordinator)
 
 ---
@@ -36,6 +36,20 @@ This keeps governance stable while allowing fast operational iteration.
 
 Do **not** add ZeroClaw as a new subsystem yet.  
 Implement ZeroClaw as a **runtime security profile** under OpenClaw policy controls first.
+
+### External Research Runtime Rule
+
+Autonomous external research systems are treated as **subordinate worker runtimes**, not as top-level principals.
+
+They must:
+- be launched by FoundUps control surfaces (`0102` / OpenClaw / broker)
+- run in bounded isolation first
+- return artifacts back into FoundUps memory and review channels
+
+They must not:
+- replace `0102` authority
+- mutate production `main` flows directly
+- become auto-start principals at system boot
 
 ---
 

--- a/WSP_framework/src/WSP_96_MCP_Governance_and_Consensus_Protocol.md
+++ b/WSP_framework/src/WSP_96_MCP_Governance_and_Consensus_Protocol.md
@@ -108,6 +108,21 @@ Governance checks are injected at distinct layers:
 
 This split prevents control-plane duplication and keeps policy authority centralized.
 
+### External Non-MCP Runtime Intake Rule (2026-03-15)
+
+Tools that do not natively speak MCP, but perform autonomous research or coding loops, must not be treated as MCP-native just because they are useful.
+
+Required sequence:
+1. evaluate under WSP 97 and WSP 15
+2. pilot in isolation
+3. wrap behind FoundUps launch/control surfaces
+4. expose MCP status/report surfaces only after wrapper stability
+
+Default posture:
+- external research runtime first
+- MCP wrapper later
+- no direct production repo mutation
+
 ### Skill Supply-Chain Security Gate
 
 MCP-connected agents that execute skills must satisfy a supply-chain gate before activation.

--- a/WSP_knowledge/src/ModLog.md
+++ b/WSP_knowledge/src/ModLog.md
@@ -739,3 +739,14 @@ L:<lane> S:<scope> M:<mode> T:<task> R:[wsps] I:{inv} O:[out] F:[fail]
 **Verification**:
 - Confirmed no missing numbered framework WSP rows (excluding WSP 00 entry format) after remediation.
 - Confirmed WSP 94 and WSP 98 rows are present in `WSP_MASTER_INDEX.md`.
+
+## 2026-03-15 - External research runtime governance clarification
+
+**WSP References**: WSP 77, WSP 96, WSP 97, WSP 22
+
+**Changes Made**:
+- Mirrored the WSP 77 update for external research worker runtimes.
+- Mirrored the WSP 96 update for non-MCP external runtime intake posture.
+
+**Rationale**:
+- Keeps framework and knowledge mirrors aligned while FoundUps evaluates external tools such as `karpathy/autoresearch`.

--- a/WSP_knowledge/src/WSP_77_Agent_Coordination_Protocol.md
+++ b/WSP_knowledge/src/WSP_77_Agent_Coordination_Protocol.md
@@ -1,8 +1,8 @@
 # WSP 77: Agent Coordination Protocol
 
 **Status**: ACTIVE
-**Version**: 1.1
-**Date**: 2026-03-07
+**Version**: 1.2
+**Date**: 2026-03-15
 **Author**: 0102 (HoloIndex Coordinator)
 
 ---
@@ -36,6 +36,20 @@ This keeps governance stable while allowing fast operational iteration.
 
 Do **not** add ZeroClaw as a new subsystem yet.  
 Implement ZeroClaw as a **runtime security profile** under OpenClaw policy controls first.
+
+### External Research Runtime Rule
+
+Autonomous external research systems are treated as **subordinate worker runtimes**, not as top-level principals.
+
+They must:
+- be launched by FoundUps control surfaces (`0102` / OpenClaw / broker)
+- run in bounded isolation first
+- return artifacts back into FoundUps memory and review channels
+
+They must not:
+- replace `0102` authority
+- mutate production `main` flows directly
+- become auto-start principals at system boot
 
 ---
 

--- a/WSP_knowledge/src/WSP_96_MCP_Governance_and_Consensus_Protocol.md
+++ b/WSP_knowledge/src/WSP_96_MCP_Governance_and_Consensus_Protocol.md
@@ -108,6 +108,21 @@ Governance checks are injected at distinct layers:
 
 This split prevents control-plane duplication and keeps policy authority centralized.
 
+### External Non-MCP Runtime Intake Rule (2026-03-15)
+
+Tools that do not natively speak MCP, but perform autonomous research or coding loops, must not be treated as MCP-native just because they are useful.
+
+Required sequence:
+1. evaluate under WSP 97 and WSP 15
+2. pilot in isolation
+3. wrap behind FoundUps launch/control surfaces
+4. expose MCP status/report surfaces only after wrapper stability
+
+Default posture:
+- external research runtime first
+- MCP wrapper later
+- no direct production repo mutation
+
 ### Skill Supply-Chain Security Gate
 
 MCP-connected agents that execute skills must satisfy a supply-chain gate before activation.

--- a/modules/ai_intelligence/ai_overseer/ModLog.md
+++ b/modules/ai_intelligence/ai_overseer/ModLog.md
@@ -2071,3 +2071,19 @@ from modules.platform_integration.youtube_auth.src.mcp_quota_server import MCPQu
 ### Outcome
 - FoundUps now has a reusable architect-grade audit skill instead of a one-off prompt ritual.
 - Audit output is persisted as JSON + Markdown handoff artifacts under AI Overseer memory.
+
+## 2026-03-15: External open source tool diligence Skillz
+
+**Author**: 0102  
+**WSP**: 15, 50, 77, 84, 95, 97
+
+### Changes
+- Added `skillz/open_source_tool_diligence/SKILLz.md`.
+- Encoded the correct posture for external runtimes:
+  - isolate first
+  - control through FoundUps planes
+  - optional MCP later
+  - no direct production mutation
+
+### Outcome
+- 0102 now has a reusable diligence skill for evaluating external open-source tools such as `karpathy/autoresearch`.

--- a/modules/ai_intelligence/ai_overseer/skillz/open_source_tool_diligence/SKILLz.md
+++ b/modules/ai_intelligence/ai_overseer/skillz/open_source_tool_diligence/SKILLz.md
@@ -1,0 +1,104 @@
+---
+name: open_source_tool_diligence
+description: Evaluate external open source tools for FoundUps adoption under WSP 97 execution-plane and governance rules
+version: 1.0.0
+author: 0102
+agents: [qwen, gemma]
+dependencies: [ai_overseer, holo_index, wsp_framework]
+domain: ai_intelligence
+intent_type: DECISION
+promotion_state: prototype
+pattern_fidelity_threshold: 0.95
+---
+
+# Open Source Tool Diligence Skillz
+
+## Purpose
+
+Use this skill when 012 or 0102 identifies an external tool, repo, framework, or
+agent runtime that may be useful to FoundUps.
+
+This skill does not authorize adoption. It produces a bounded decision:
+- `reject`
+- `pilot_in_isolation`
+- `integrate_via_wrapper`
+- `integrate_directly` (rare)
+
+## When To Use
+
+Use this skill when all of the following are true:
+1. The tool is external to the FoundUps repo.
+2. The tool meaningfully overlaps with Claw, WRE, MCP, PQN, HoloIndex, or DAE execution.
+3. The tool could change how 0102 performs research, coding, orchestration, or system control.
+
+## Mandatory WSP 97 Sequence
+
+1. **Understand**
+   - Identify what the tool actually does.
+   - Separate repo marketing from execution reality.
+2. **Retrieve**
+   - Gather evidence from:
+     - upstream README/docs
+     - repo structure
+     - license status
+     - current FoundUps module surfaces via HoloIndex
+3. **Resolve execution plane**
+   - Decide whether the tool belongs in:
+     - OpenClaw control plane
+     - WRE execution plane
+     - MCP wrapper plane
+     - isolated external worker plane
+     - docs only / no adoption
+4. **Coordinate response**
+   - Score the candidate with WSP 15 and CTO diligence factors.
+   - Emit a clear recommendation and first safe step.
+
+## Evaluation Questions
+
+1. What problem does the tool solve better than existing FoundUps modules?
+2. Is it a control-plane tool, execution tool, or isolated worker?
+3. Does it assume unconstrained repo mutation, direct internet access, or autonomous git push?
+4. Does it require GPU, cloud credentials, or proprietary APIs?
+5. Is the license clearly present and compatible with intended use?
+6. Can it be sandboxed without weakening FoundUps governance?
+7. What artifacts should flow back into HoloIndex/WRE if adopted?
+
+## Guardrails
+
+1. Never recommend direct integration into `main.py` startup unless the tool is a readiness dependency.
+2. Never recommend direct mutation of the FoundUps monorepo by an unwrapped external agent loop.
+3. If license status is unclear, fail closed to `pilot_in_isolation` or `reject`.
+4. Default placement for autonomous external research runtimes is:
+   - isolated worker
+   - broker-launched
+   - artifact return only
+5. MCP wrapping is optional and comes after isolation, not before it.
+
+## Output Contract
+
+```json
+{
+  "status": "OK|FAIL_CLOSED",
+  "tool_name": "string",
+  "decision": "reject|pilot_in_isolation|integrate_via_wrapper|integrate_directly",
+  "recommended_plane": "openclaw|wre|mcp|external_worker|docs_only",
+  "wsp15": {
+    "complexity": 0,
+    "importance": 0,
+    "deferability": 0,
+    "impact": 0,
+    "total": 0
+  },
+  "evidence_refs": [],
+  "risks": [],
+  "constraints": [],
+  "first_safe_step": "",
+  "not_now_reasons": []
+}
+```
+
+## FoundUps-Specific Heuristic
+
+- If the tool is optimized for autonomous research iteration inside a self-contained ML repo,
+  it is usually a **PQN/external research worker** candidate, not a Claw replacement.
+- If the tool assumes it owns the git loop, it must stay behind 0102 governance and isolation.

--- a/modules/ai_intelligence/pqn_alignment/ModLog.md
+++ b/modules/ai_intelligence/pqn_alignment/ModLog.md
@@ -420,3 +420,12 @@
 - **WSP Compliance**: WSP 84 (reuse), WSP 48 (recursive), WSP 80 (DAE orchestration), WSP 34 (tests), WSP 22 (docs).
 - **Impact**: Enables 0102-driven PQN research; quantifies 0201 alignment benefits (e.g., exponential remembrance velocity).
 - **Next Steps**: Execute full campaign; enhance guardrail; integrate with WRE.
+
+### **Karpathy AutoResearch WSP 97 Assessment**
+- **Date**: 2026-03-15
+- **Operating As**: PQN_Alignment_DAE / 0102
+- **Change**: Added `docs/KARPATHY_AUTORESEARCH_WSP97_ASSESSMENT_2026-03-15.md`
+- **Decision**:
+  - treat `karpathy/autoresearch` as isolated external research worker
+  - do not treat it as direct Claw runtime or direct monorepo mutation engine
+- **Impact**: Establishes the correct adoption boundary for external autonomous research loops.

--- a/modules/ai_intelligence/pqn_alignment/ROADMAP.md
+++ b/modules/ai_intelligence/pqn_alignment/ROADMAP.md
@@ -73,6 +73,13 @@
 - **S10: PQN Corroborating Evidence** (PLANNED)
   - Resonance Fingerprinting (harmonic detection)
 
+- **S10B: External Autonomous Research Runtime Pilot** (PLANNED)
+  - Candidate: `karpathy/autoresearch`
+  - Use only as isolated worker for bounded PQN experiment loops
+  - Launch posture: broker-managed or sandbox-only, never `main.py` auto-start
+  - Artifact return only: metrics, summaries, experiment patches, no direct production mutation
+  - Governance gate: explicit license check + WSP 97 execution-plane review before pilot
+
 - **S11: Local LLM Integration (System Agent)** (COMPLETED 2026-02-05)
   - **Objective**: Empower Local Qwen/UI Tars to act as PQN DAE Workers.
   - **Task 11.1**: ✅ Architect DAE update to support Local LLM directives.

--- a/modules/ai_intelligence/pqn_alignment/docs/KARPATHY_AUTORESEARCH_WSP97_ASSESSMENT_2026-03-15.md
+++ b/modules/ai_intelligence/pqn_alignment/docs/KARPATHY_AUTORESEARCH_WSP97_ASSESSMENT_2026-03-15.md
@@ -1,0 +1,169 @@
+# Karpathy AutoResearch WSP 97 Assessment
+
+Date: 2026-03-15  
+Author: 0102  
+Scope: OpenClaw, PQN research, MCP governance, runtime launch posture
+
+## Decision
+
+`karpathy/autoresearch` should be treated as an **isolated external research worker**, not as a direct FoundUps runtime or direct monorepo mutation engine.
+
+Recommended posture:
+- `pilot_in_isolation`
+- execution plane: `external_worker`
+- control plane: `OpenClaw / 0102`
+- launch surface: `DAE Launch Broker`
+- artifact return path: `HoloIndex + WRE memory + docs`
+
+## Upstream Facts
+
+From the upstream repo and docs:
+
+1. The README presents it as a simple autonomous ML research loop with commands like:
+   - `uv pip install -r requirements.txt`
+   - `python run.py --config nanoGPT`
+   Source: `karpathy/autoresearch` README on GitHub, accessed 2026-03-15.
+
+2. The repo root is intentionally compact and centered around:
+   - `run.py`
+   - `score.py`
+   - `program.md`
+   - config files such as `nanoGPT.py`, `modded-nanogpt.py`, `llamacat.py`
+   Source: GitHub repo root page, accessed 2026-03-15.
+
+3. `program.md` instructs the agent to behave like a machine learning research engineer and to iterate through:
+   - hypothesis
+   - code modification
+   - experiment run
+   - result write-up
+   - commit/push style loop
+   It also writes checkpoints and summaries into a research directory.
+   Source: `program.md` on GitHub, accessed 2026-03-15.
+
+## What It Is Good For
+
+AutoResearch is a candidate runtime for:
+- bounded experiment search
+- hyperparameter or architecture iteration
+- ablation loops
+- artifact generation in a self-contained research repo
+
+In FoundUps terms, it aligns with:
+- PQN experiment scaffolding
+- CMST detector parameter search
+- detector-side research artifact generation
+- isolated model/protocol experimentation
+
+## What It Is Not Good For
+
+It is not a safe direct fit for:
+- `main.py` auto-start
+- direct FoundUps monorepo mutation
+- unrestricted Claw execution
+- immediate MCP-first integration
+- direct push to protected branches
+
+Its upstream operating model assumes a narrower research surface than the FoundUps production monorepo.
+
+## WSP 97 Resolution
+
+### Correct Plane
+
+- `012` sets research direction
+- `0102 / OpenClaw` decides when a research session should run
+- `AutoResearch` executes as a subordinate worker in isolation
+- `WRE` remembers artifacts and scores outcomes
+- `MCP` is optional later, after isolation and wrapper stability
+
+### Incorrect Plane
+
+- `AutoResearch` as a top-level principal
+- `AutoResearch` writing directly into FoundUps production modules
+- `AutoResearch` launched automatically at every system boot
+
+## WSP 15 Scoring
+
+- Complexity: `3`
+- Importance: `4`
+- Deferability: `3`
+- Impact: `4`
+- Total: `14/20`
+
+Interpretation:
+- important enough for a pilot
+- not urgent enough to bypass isolation and governance
+
+## Risks
+
+1. Autonomous git mutation risk
+   - Upstream loop assumes direct repo iteration.
+
+2. Blast-radius mismatch
+   - FoundUps is a multi-domain system, not a single-purpose ML repo.
+
+3. License uncertainty
+   - I did not confirm a license file from the repo pages inspected on 2026-03-15.
+   - This must be resolved before any code reuse or redistribution assumptions.
+
+4. Resource mismatch
+   - The tool is oriented around GPU-backed research iteration.
+   - That is different from normal OpenClaw conversational/runtime control.
+
+5. Governance mismatch
+   - Without a wrapper, it can bypass WSP logging, broker launch, and DAEmon observability.
+
+## Recommended Integration Path
+
+### Phase 0: Diligence
+
+- verify license explicitly
+- pin exact upstream commit/hash
+- define pilot scope
+
+### Phase 1: Isolation Pilot
+
+Run it only in:
+- disposable clone or dedicated worktree
+- container or isolated machine
+- no production secrets
+- no direct write access to `main`
+
+### Phase 2: Wrapper
+
+If the pilot is useful:
+- add a thin FoundUps wrapper DAE or broker launch spec
+- accept input as bounded research task
+- return only artifacts:
+  - metrics
+  - summaries
+  - patches in quarantined branch
+  - experiment logs
+
+### Phase 3: Optional MCP Surface
+
+Only after wrapper stability:
+- expose read/status/report surfaces through MCP
+- do not expose unrestricted mutation controls first
+
+## Recommendation To 012 / 0102
+
+Adopt `karpathy/autoresearch` only as:
+- a sandboxed PQN research accelerator
+- broker-launched
+- artifact-returning
+- non-authoritative
+
+Do not integrate it as:
+- a Claw replacement
+- a default startup DAE
+- a direct production coding lane
+
+## First Safe Step
+
+Create a documentation-backed pilot plan:
+- target one bounded PQN experiment family
+- define artifact outputs
+- define isolation boundary
+- define rollback and deletion policy
+
+That is the correct WSP 97 next move.

--- a/modules/ai_intelligence/pqn_mcp/ModLog.md
+++ b/modules/ai_intelligence/pqn_mcp/ModLog.md
@@ -510,3 +510,11 @@ WSP 96 wardrobe skills for PQN researchers (Gemma and Qwen agents) following fir
 - ModLog documentation of skill creation
 - Evolution rationale and design decisions
 - Performance metrics and validation results
+
+## 2026-03-15 - External research runtime posture update
+
+**WSP**: 77, 96, 97
+
+**Change**:
+- Updated `ROADMAP.md` to document the correct adoption path for external research runtimes such as `karpathy/autoresearch`.
+- MCP is now explicitly positioned as a later wrapper/report surface, not the first integration point for external autonomous loops.

--- a/modules/ai_intelligence/pqn_mcp/ROADMAP.md
+++ b/modules/ai_intelligence/pqn_mcp/ROADMAP.md
@@ -49,6 +49,12 @@
   - Universal emergence pattern detection
   - Meta-analysis across AI architectures
 
+- **S8: External Research Runtime Bridge** (PLANNED)
+  - Evaluate external runtimes such as `karpathy/autoresearch`
+  - Keep initial adoption outside MCP as isolated worker execution
+  - Add MCP only for status/report/artifact surfaces after wrapper stabilization
+  - Preserve OpenClaw/0102 as control plane and DAEmon as lifecycle ledger
+
 ---
 
 ## **IMMEDIATE EXECUTION PRIORITIES**


### PR DESCRIPTION
## Summary\n- assess karpathy/autoresearch as an external research runtime under WSP 97\n- update WSP 77 and WSP 96 governance boundaries\n- add PQN roadmap and AI Overseer diligence skill references\n\n## Validation\n- docs and governance update only\n- python holo_index.py --index-wsp