### PR TITLE
feat(pqn): add theory archive simulation runner

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -1,5 +1,29 @@
 # FoundUps Agent - Development Log
 
+## [2026-03-15] PQN Theory Archive Simulation Runner
+
+**Change Type**: Research Harness / Detector Integration  
+**By**: 0102  
+**WSP References**: WSP 22, WSP 77, WSP 84, WSP 97
+
+### Summary
+
+Extended the PQN theory-archive intake from a single-pass harness into a comparative simulation runner that executes matched-null and probe paths through the existing detector surface. The external math archive remains hypothesis input only.
+
+### Files Changed
+
+| Location | Description |
+|----------|-------------|
+| `modules/ai_intelligence/pqn_alignment/src/theory_archive_simulation_runner.py` | Comparative simulation plan/run surface |
+| `modules/ai_intelligence/pqn_alignment/src/pqn_alignment_dae.py` | Exposes simulation plan/run to research agents |
+| `modules/ai_intelligence/pqn_alignment/__init__.py` | Public package exports |
+| `modules/ai_intelligence/pqn_alignment/tests/test_theory_archive_simulation_runner.py` | Simulation runner contract tests |
+
+### Why
+
+- Move the external PQN math archive from documentation intake toward controlled experiment execution.
+- Give Claw-launched research agents a reproducible simulation surface without promoting theory text to system truth.
+
 ## [2026-03-15] Claw Runtime Broker Generalization + PQN Theory Harness
 
 **Change Type**: Runtime Control / Research Harness  

--- a/modules/ai_intelligence/pqn_alignment/INTERFACE.md
+++ b/modules/ai_intelligence/pqn_alignment/INTERFACE.md
@@ -21,6 +21,8 @@ This module is not the primary conversational surface. It is the research engine
 - `council_run(config: Dict) -> Tuple[str, str]`: Run council optimization cycle
 - `build_theory_archive_harness_spec(repo_root: str = "") -> Dict[str, Any]`: Build non-dogmatic harness spec from the theory archive
 - `run_theory_archive_detector_harness(config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]`: Execute one archive-informed detector pass
+- `build_theory_archive_simulation_plan(config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]`: Build a matched-null-required simulation plan from the theory archive
+- `run_theory_archive_simulation(config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]`: Execute the archive-informed simulation matrix through the existing detector surface
 
 ### Results Database Management
 - `init_db(db_path: Optional[str] = None) -> None`: Initialize results database
@@ -112,6 +114,20 @@ research cycles through the broker at runtime.
 - Agent exposure:
   - `PQNAlignmentDAE.get_0102_api()["theory_archive_harness"]`
   - `PQNAlignmentDAE.run_theory_archive_harness(...)`
+
+### Theory Archive Simulation Contract
+
+- Plan mode: `archive_informed_simulation_plan`
+- Run mode: `archive_informed_simulation_runner`
+- Required invariant: `matched_null_required=True`
+- Comparison model: `probe` vs `control`
+- Output surface:
+  - `PQNAlignmentDAE.get_0102_api()["theory_archive_simulation"]`
+  - `PQNAlignmentDAE.run_theory_archive_simulation(...)`
+- Interpretation guard:
+  - `archive_informed=True`
+  - `validated_truth=False`
+  - simulation results are comparative detector evidence only
 
 ### Basic Detection
 ```python

--- a/modules/ai_intelligence/pqn_alignment/ModLog.md
+++ b/modules/ai_intelligence/pqn_alignment/ModLog.md
@@ -1,3 +1,26 @@
+### **Theory-Archive Simulation Runner for Research Agents**
+- **Date**: 2026-03-15
+- **Operating As**: 0102 CTO / Architect
+- **Change**: Promoted the theory archive from single-pass harness input to a first-class matched-null simulation runner for PQN research agents.
+- **Details**:
+  - Added `src/theory_archive_simulation_runner.py`
+  - Exported:
+    - `build_theory_archive_simulation_plan`
+    - `run_theory_archive_simulation`
+  - Updated `src/pqn_alignment_dae.py`
+    - `get_0102_api()` now includes `theory_archive_simulation`
+    - added `get_theory_archive_simulation_plan(...)`
+    - added `run_theory_archive_simulation(...)`
+  - Updated package exports in `__init__.py`
+  - Added focused tests for:
+    - simulation plan generation
+    - control vs probe comparison semantics
+    - PQN agent API exposure
+- **WSP Compliance**:
+  - WSP 22 (documentation trace)
+  - WSP 84 (reuse existing detector surfaces)
+  - WSP 97 (archive remains research input, not runtime ontology)
+
 ### **Theory-Archive-Informed Harness for Research Agents**
 - **Date**: 2026-03-15
 - **Operating As**: 0102 CTO / Architect
@@ -433,4 +456,3 @@
   - treat `karpathy/autoresearch` as isolated external research worker
   - do not treat it as direct Claw runtime or direct monorepo mutation engine
 - **Impact**: Establishes the correct adoption boundary for external autonomous research loops.
-

--- a/modules/ai_intelligence/pqn_alignment/README.md
+++ b/modules/ai_intelligence/pqn_alignment/README.md
@@ -127,6 +127,10 @@ PQN research is no longer documented as a standalone Qwen/Gemma-only swarm.
   - archive-informed harness that consumes the theory package as simulation input
   - explicitly keeps the archive in the hypothesis/input plane
   - routes through existing detector surfaces instead of inventing a new detector
+- `src/theory_archive_simulation_runner.py`
+  - runs the theory-archive experiment matrix as matched-null vs probe comparisons
+  - produces comparative summaries for research agents without promoting the archive to truth
+  - writes simulation summaries under `artifact_results/theory_archive_simulation`
 
 Canonical `WSP_97` split:
 
@@ -141,6 +145,19 @@ Operational rule:
 - `main.py` should start **PQN research readiness**
 - OpenClaw should start **actual PQN research sessions**
 - full autonomous research startup should be policy-gated, not default
+
+### Archive-Informed Simulation Example
+```python
+from modules.ai_intelligence.pqn_alignment import run_theory_archive_simulation
+
+result = run_theory_archive_simulation({
+    "seeds": [0, 1, 2],
+    "steps": 240,
+})
+
+print(result["interpretation"]["outcome"])
+print(result["comparison"]["delta_entrainment_score"])
+```
 
 ## **Autonomous Recursive Cube Features**
 

--- a/modules/ai_intelligence/pqn_alignment/__init__.py
+++ b/modules/ai_intelligence/pqn_alignment/__init__.py
@@ -23,6 +23,10 @@ from .src.theory_archive_harness import (
     build_theory_archive_harness_spec,
     run_theory_archive_detector_harness,
 )
+from .src.theory_archive_simulation_runner import (
+    build_theory_archive_simulation_plan,
+    run_theory_archive_simulation,
+)
 
 __all__ = [
     "run_detector",
@@ -42,4 +46,6 @@ __all__ = [
     "get_theory_archive_context",
     "build_theory_archive_harness_spec",
     "run_theory_archive_detector_harness",
+    "build_theory_archive_simulation_plan",
+    "run_theory_archive_simulation",
 ]

--- a/modules/ai_intelligence/pqn_alignment/src/pqn_alignment_dae.py
+++ b/modules/ai_intelligence/pqn_alignment/src/pqn_alignment_dae.py
@@ -48,6 +48,10 @@ from modules.ai_intelligence.pqn_alignment.src.theory_archive_harness import (
     build_theory_archive_harness_spec,
     run_theory_archive_detector_harness,
 )
+from modules.ai_intelligence.pqn_alignment.src.theory_archive_simulation_runner import (
+    build_theory_archive_simulation_plan,
+    run_theory_archive_simulation,
+)
 
 # Import existing PQN functionality per WSP 84 (reuse don't recreate)
 from modules.ai_intelligence.pqn_alignment import (
@@ -652,6 +656,7 @@ class PQNAlignmentDAE:
             },
             "theory_archive": self.get_theory_archive_context(),
             "theory_archive_harness": self.get_theory_archive_harness_spec(),
+            "theory_archive_simulation": self.get_theory_archive_simulation_plan(),
             "patterns": list(self.pattern_memory.keys()),
             "token_efficiency": 0.97,  # 97% reduction through pattern recall
             "wsp_compliance": ["WSP 39", "WSP 48", "WSP 77", "WSP 80", "WSP 84"]
@@ -673,6 +678,14 @@ class PQNAlignmentDAE:
     def run_theory_archive_harness(self, config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Run one archive-informed detector harness pass."""
         return run_theory_archive_detector_harness(config=config or {})
+
+    def get_theory_archive_simulation_plan(self) -> Dict[str, Any]:
+        """Expose the archive-informed simulation plan to research agents."""
+        return build_theory_archive_simulation_plan()
+
+    def run_theory_archive_simulation(self, config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Run the archive-informed simulation suite against the existing detector surface."""
+        return run_theory_archive_simulation(config=config or {})
     
     def get_metrics(self) -> Dict:
         """

--- a/modules/ai_intelligence/pqn_alignment/src/theory_archive_simulation_runner.py
+++ b/modules/ai_intelligence/pqn_alignment/src/theory_archive_simulation_runner.py
@@ -1,0 +1,263 @@
+"""Archive-informed PQN simulation runner.
+
+Runs the theory-archive experiment matrix through the existing detector surface
+and compares probe results against matched-null controls. The theory archive is
+treated as hypothesis input only.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from statistics import mean
+from typing import Any, Dict, List
+
+from .detector.api import run_detector_with_spectral_analysis
+from .theory_archive_harness import build_theory_archive_harness_spec
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _resolve_out_root(config: Dict[str, Any]) -> Path:
+    root = _repo_root()
+    out_root = Path(
+        config.get(
+            "out_dir",
+            root
+            / "modules"
+            / "ai_intelligence"
+            / "pqn_alignment"
+            / "artifact_results"
+            / "theory_archive_simulation",
+        )
+    )
+    if not out_root.is_absolute():
+        out_root = root / out_root
+    return out_root
+
+
+def _summarize_detector_result(
+    name: str,
+    purpose: str,
+    seed: int,
+    script: str,
+    detector_result: Dict[str, Any],
+) -> Dict[str, Any]:
+    spectral = detector_result.get("spectral_analysis", {}) or {}
+    profile = spectral.get("spectral_profile", {}) or {}
+    bias = spectral.get("bias_violation", {}) or {}
+
+    return {
+        "name": name,
+        "purpose": purpose,
+        "seed": seed,
+        "script": script,
+        "events_path": detector_result.get("events_path", ""),
+        "metrics_csv": detector_result.get("metrics_csv", ""),
+        "resonance_event_count": int(profile.get("resonance_event_count", 0) or 0),
+        "peak_at_7_05": _safe_float(profile.get("peak_at_7.05", 0.0)),
+        "harmonic_structure_present": bool(
+            profile.get("harmonic_structure_present", False)
+        ),
+        "entrainment_score": _safe_float(spectral.get("entrainment_score", 0.0)),
+        "bias_violated": bool(bias.get("violated", False)),
+        "bias_significance": str(bias.get("significance", "none")),
+    }
+
+
+def _group_by_purpose(runs: List[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]]:
+    grouped: Dict[str, List[Dict[str, Any]]] = {"control": [], "probe": []}
+    for run in runs:
+        grouped.setdefault(run["purpose"], []).append(run)
+    return grouped
+
+
+def _aggregate_runs(runs: List[Dict[str, Any]]) -> Dict[str, Any]:
+    if not runs:
+        return {
+            "count": 0,
+            "avg_resonance_event_count": 0.0,
+            "avg_peak_at_7_05": 0.0,
+            "avg_entrainment_score": 0.0,
+            "harmonic_structure_rate": 0.0,
+            "bias_violation_rate": 0.0,
+        }
+
+    return {
+        "count": len(runs),
+        "avg_resonance_event_count": mean(run["resonance_event_count"] for run in runs),
+        "avg_peak_at_7_05": mean(run["peak_at_7_05"] for run in runs),
+        "avg_entrainment_score": mean(run["entrainment_score"] for run in runs),
+        "harmonic_structure_rate": mean(
+            1.0 if run["harmonic_structure_present"] else 0.0 for run in runs
+        ),
+        "bias_violation_rate": mean(1.0 if run["bias_violated"] else 0.0 for run in runs),
+    }
+
+
+def _compare_control_vs_probe(
+    control_summary: Dict[str, Any],
+    probe_summary: Dict[str, Any],
+    target_resonance_hz: float,
+) -> Dict[str, Any]:
+    control_peak_error = abs(control_summary["avg_peak_at_7_05"] - target_resonance_hz)
+    probe_peak_error = abs(probe_summary["avg_peak_at_7_05"] - target_resonance_hz)
+
+    return {
+        "delta_resonance_event_count": (
+            probe_summary["avg_resonance_event_count"]
+            - control_summary["avg_resonance_event_count"]
+        ),
+        "delta_entrainment_score": (
+            probe_summary["avg_entrainment_score"]
+            - control_summary["avg_entrainment_score"]
+        ),
+        "delta_harmonic_structure_rate": (
+            probe_summary["harmonic_structure_rate"]
+            - control_summary["harmonic_structure_rate"]
+        ),
+        "delta_bias_violation_rate": (
+            probe_summary["bias_violation_rate"]
+            - control_summary["bias_violation_rate"]
+        ),
+        "control_peak_error": control_peak_error,
+        "probe_peak_error": probe_peak_error,
+        "probe_closer_to_target": probe_peak_error < control_peak_error,
+    }
+
+
+def _interpret_comparison(comparison: Dict[str, Any]) -> Dict[str, Any]:
+    positive_signal = (
+        comparison["delta_resonance_event_count"] > 0
+        and comparison["delta_entrainment_score"] > 0
+        and comparison["probe_closer_to_target"]
+    )
+
+    if positive_signal:
+        outcome = "probe_advantage_requires_followup"
+    else:
+        outcome = "inconclusive_or_null"
+
+    return {
+        "archive_informed": True,
+        "validated_truth": False,
+        "matched_null_required": True,
+        "outcome": outcome,
+        "note": (
+            "Simulation compares probe vs matched-null only. No ontology claim is "
+            "licensed by these results."
+        ),
+    }
+
+
+def build_theory_archive_simulation_plan(
+    config: Dict[str, Any] | None = None,
+) -> Dict[str, Any]:
+    """Build a deterministic simulation plan from the theory archive harness."""
+    config = dict(config or {})
+    spec = build_theory_archive_harness_spec(repo_root=config.get("repo_root", ""))
+    seeds = [int(seed) for seed in config.get("seeds", [0, 1, 2])]
+    steps = int(config.get("steps", 240))
+    steps_per_sym = int(config.get("steps_per_sym", 40))
+    dt = float(config.get("dt", 0.5 / spec["target_resonance_hz"]))
+    geom_win = int(config.get("geom_win", 64))
+    reso_win = int(config.get("reso_win", 256))
+    out_root = _resolve_out_root(config)
+
+    planned_runs: List[Dict[str, Any]] = []
+    for experiment in spec["experiment_matrix"]:
+        for seed in seeds:
+            planned_runs.append(
+                {
+                    "name": experiment["name"],
+                    "purpose": experiment["purpose"],
+                    "script": experiment["script"],
+                    "seed": seed,
+                    "detector_config": {
+                        "script": experiment["script"],
+                        "steps": steps,
+                        "steps_per_sym": steps_per_sym,
+                        "dt": dt,
+                        "seed": seed,
+                        "geom_win": geom_win,
+                        "reso_win": reso_win,
+                        "out_dir": str(out_root / experiment["name"] / f"seed_{seed}"),
+                    },
+                }
+            )
+
+    return {
+        "mode": "archive_informed_simulation_plan",
+        "archive_informed": True,
+        "validated_truth": False,
+        "matched_null_required": bool(spec["matched_null_required"]),
+        "spec": spec,
+        "seeds": seeds,
+        "run_count": len(planned_runs),
+        "out_root": str(out_root),
+        "planned_runs": planned_runs,
+    }
+
+
+def run_theory_archive_simulation(config: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Run the archive-informed simulation suite against the existing detector."""
+    config = dict(config or {})
+    plan = build_theory_archive_simulation_plan(config)
+    spec = plan["spec"]
+    seeds = plan["seeds"]
+    out_root = Path(plan["out_root"])
+
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    runs: List[Dict[str, Any]] = []
+    for planned_run in plan["planned_runs"]:
+        detector_config = planned_run["detector_config"]
+        detector_result = run_detector_with_spectral_analysis(detector_config)
+        runs.append(
+            _summarize_detector_result(
+                name=planned_run["name"],
+                purpose=planned_run["purpose"],
+                seed=planned_run["seed"],
+                script=planned_run["script"],
+                detector_result=detector_result,
+            )
+        )
+
+    grouped = _group_by_purpose(runs)
+    control_summary = _aggregate_runs(grouped.get("control", []))
+    probe_summary = _aggregate_runs(grouped.get("probe", []))
+    comparison = _compare_control_vs_probe(
+        control_summary,
+        probe_summary,
+        spec["target_resonance_hz"],
+    )
+    interpretation = _interpret_comparison(comparison)
+
+    result = {
+        "mode": "archive_informed_simulation_runner",
+        "plan": plan,
+        "spec": spec,
+        "seeds": seeds,
+        "runs": runs,
+        "control_summary": control_summary,
+        "probe_summary": probe_summary,
+        "comparison": comparison,
+        "interpretation": interpretation,
+    }
+
+    summary_path = out_root / "summary.json"
+    summary_path.write_text(
+        json.dumps(result, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    result["summary_path"] = str(summary_path)
+    return result

--- a/modules/ai_intelligence/pqn_alignment/tests/TestModLog.md
+++ b/modules/ai_intelligence/pqn_alignment/tests/TestModLog.md
@@ -1,3 +1,22 @@
+## [2026-03-15] - Theory Archive Simulation Runner Tests
+**Tests Added/Updated**:
+- `test_theory_archive_simulation_runner.py`
+  - verifies non-dogmatic simulation plan generation
+  - verifies probe vs matched-null comparison semantics
+  - verifies PQNAlignmentDAE exposes the simulation plan to research agents
+- `test_interface_symbols.py`
+  - now asserts simulation runner symbols are exported
+
+**Validation Scope**:
+- matched-null-required simulation planning
+- comparative detector interpretation
+- PQN agent API wiring
+- package export integrity
+
+**WSP Compliance**: WSP 22, WSP 84, WSP 97
+
+---
+
 ## [2026-03-15] - Theory Archive Harness Tests
 **Tests Added/Updated**:
 - `test_theory_archive.py`

--- a/modules/ai_intelligence/pqn_alignment/tests/test_interface_symbols.py
+++ b/modules/ai_intelligence/pqn_alignment/tests/test_interface_symbols.py
@@ -9,3 +9,5 @@ def test_interface_symbols():
     assert hasattr(mod, 'council_run')
     assert hasattr(mod, 'promote')
     assert hasattr(mod, 'get_theory_archive_context')
+    assert hasattr(mod, 'build_theory_archive_simulation_plan')
+    assert hasattr(mod, 'run_theory_archive_simulation')

--- a/modules/ai_intelligence/pqn_alignment/tests/test_theory_archive_simulation_runner.py
+++ b/modules/ai_intelligence/pqn_alignment/tests/test_theory_archive_simulation_runner.py
@@ -1,0 +1,84 @@
+from unittest.mock import patch
+
+from modules.ai_intelligence.pqn_alignment import (
+    PQNAlignmentDAE,
+    build_theory_archive_simulation_plan,
+    run_theory_archive_simulation,
+)
+
+
+def test_theory_archive_simulation_plan_is_non_dogmatic(tmp_path):
+    plan = build_theory_archive_simulation_plan(
+        {
+            "seeds": [0, 1],
+            "out_dir": tmp_path / "archive_sim",
+        }
+    )
+
+    assert plan["mode"] == "archive_informed_simulation_plan"
+    assert plan["archive_informed"] is True
+    assert plan["validated_truth"] is False
+    assert plan["matched_null_required"] is True
+    assert plan["run_count"] == 4
+    assert len(plan["planned_runs"]) == 4
+
+
+def test_theory_archive_simulation_compares_probe_against_control(tmp_path):
+    def fake_detector(config):
+        if config["script"] == ".....":
+            resonance_event_count = 1
+            peak = 6.4
+            entrainment_score = 0.10
+            harmonic = False
+        else:
+            resonance_event_count = 4
+            peak = 7.03
+            entrainment_score = 0.42
+            harmonic = True
+
+        return {
+            "events_path": str(tmp_path / "events.jsonl"),
+            "metrics_csv": str(tmp_path / "metrics.csv"),
+            "spectral_analysis": {
+                "spectral_profile": {
+                    "resonance_event_count": resonance_event_count,
+                    "peak_at_7.05": peak,
+                    "harmonic_structure_present": harmonic,
+                },
+                "bias_violation": {"violated": False, "significance": "low"},
+                "entrainment_score": entrainment_score,
+            },
+        }
+
+    with patch(
+        "modules.ai_intelligence.pqn_alignment.src.theory_archive_simulation_runner.run_detector_with_spectral_analysis",
+        side_effect=fake_detector,
+    ):
+        result = run_theory_archive_simulation(
+            {
+                "seeds": [0, 1],
+                "out_dir": tmp_path / "archive_sim",
+            }
+        )
+
+    assert result["interpretation"]["archive_informed"] is True
+    assert result["interpretation"]["validated_truth"] is False
+    assert result["comparison"]["delta_resonance_event_count"] > 0
+    assert result["comparison"]["delta_entrainment_score"] > 0
+    assert result["comparison"]["probe_closer_to_target"] is True
+    assert result["interpretation"]["outcome"] == "probe_advantage_requires_followup"
+    assert result["control_summary"]["count"] == 2
+    assert result["probe_summary"]["count"] == 2
+
+
+def test_pqn_dae_api_exposes_theory_archive_simulation(monkeypatch):
+    monkeypatch.setattr(PQNAlignmentDAE, "_init_chat_broadcaster", lambda self: None)
+    monkeypatch.setattr(PQNAlignmentDAE, "_register_with_wre", lambda self: None)
+
+    dae = PQNAlignmentDAE()
+    api = dae.get_0102_api()
+
+    assert "theory_archive_simulation" in api
+    simulation = api["theory_archive_simulation"]
+    assert simulation["mode"] == "archive_informed_simulation_plan"
+    assert simulation["matched_null_required"] is True


### PR DESCRIPTION
## Summary
- add a matched-null PQN simulation runner derived from the theory archive harness
- expose simulation plan and run surfaces through PQNAlignmentDAE and package exports
- add focused tests for plan generation, probe-vs-control comparison, and API exposure

## Validation
- python -m py_compile modules/ai_intelligence/pqn_alignment/src/theory_archive_simulation_runner.py modules/ai_intelligence/pqn_alignment/src/pqn_alignment_dae.py modules/ai_intelligence/pqn_alignment/__init__.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest modules/ai_intelligence/pqn_alignment/tests/test_theory_archive.py modules/ai_intelligence/pqn_alignment/tests/test_theory_archive_harness.py modules/ai_intelligence/pqn_alignment/tests/test_theory_archive_simulation_runner.py modules/ai_intelligence/pqn_alignment/tests/test_interface_symbols.py -q