### PR TITLE
feat(openclaw): add pqn simulation runtime control

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -1,5 +1,29 @@
 # FoundUps Agent - Development Log
 
+## [2026-03-16] OpenClaw PQN Simulation Runtime + DAEmon Detail Payloads
+
+**Change Type**: Runtime Control / Observability  
+**By**: 0102  
+**WSP References**: WSP 22, WSP 73, WSP 77, WSP 91, WSP 97
+
+### Summary
+
+Extended OpenClaw so `012` can launch the PQN theory-archive simulation directly from live chat and made the DAEmon action ledger carry structured research details for those runs.
+
+### Files Changed
+
+| Location | Description |
+|----------|-------------|
+| `modules/communication/moltbot_bridge/src/pqn_research_adapter.py` | Added PQN simulation command handling |
+| `modules/communication/moltbot_bridge/src/openclaw_execution_routes.py` | Passed DAEmon action reporter into research adapter |
+| `modules/infrastructure/dae_daemon/src/dae_adapter.py` | Added structured `details` payload support for action events |
+| `modules/infrastructure/dae_daemon/tests/test_dae_adapter.py` | Added adapter payload regression tests |
+
+### Why
+
+- Move PQN simulation out of “Python-only” operator paths and into the live Claw control plane.
+- Make research actions visible in DAEmon with machine-readable detail instead of only plain-text responses.
+
 ## [2026-03-15] PQN Theory Archive Simulation Runner
 
 **Change Type**: Research Harness / Detector Integration  

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -175,6 +175,24 @@ Routing contract:
 - `pqn_research_adapter.py` -> central `DAELaunchBroker`
 - `DAELaunchBroker` -> broker-managed PQN runtime entrypoints in `modules/ai_intelligence/pqn/scripts/launch.py`
 
+### PQN Theory-Archive Simulation Control
+
+PQN simulation can now be triggered directly through research intent phrases:
+- `run pqn simulation`
+- `launch pqn simulation`
+- `status pqn simulation`
+- `show pqn simulation plan`
+
+Routing contract:
+- OpenClaw -> `pqn_research_adapter.py`
+- `pqn_research_adapter.py` -> `PQNAlignmentDAE.run_theory_archive_simulation(...)`
+- PQN simulation lifecycle -> OpenClaw DAEmon action ledger
+
+Operational rule:
+- simulation is a research action, not a broker-managed DAE
+- archive remains hypothesis input only
+- returned interpretation remains comparative, not ontological
+
 ### FOUNDUP Route Contract (FAM Adapter)
 
 - Launch command examples:

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,3 +1,26 @@
+## 2026-03-16: PQN simulation runtime control + DAEmon research ledger
+
+**Author**: 0102  
+**WSP**: 22, 73, 77, 91, 97
+
+### Changes
+- Updated `src/pqn_research_adapter.py`
+  - added theory-archive simulation commands:
+    - `run pqn simulation`
+    - `launch pqn simulation`
+    - `status pqn simulation`
+    - `show pqn simulation plan`
+  - simulation commands now call `PQNAlignmentDAE` directly
+  - broker-managed PQN runtime commands now emit action-ledger events
+- Updated `src/openclaw_execution_routes.py`
+  - RESEARCH route now passes OpenClaw's DAEmon action reporter into the PQN adapter
+- Updated `INTERFACE.md`
+  - documented the simulation control path and its non-broker nature
+
+### Impact
+- 012 can run the theory-archive simulation from a live OpenClaw session without dropping to Python or the CLI menu.
+- PQN research actions now surface in the DAEmon ledger with structured start/completion details instead of disappearing into plain text replies.
+
 ## 2026-03-15: Generic DAE runtime commands through OpenClaw
 
 **Author**: 0102  

--- a/modules/communication/moltbot_bridge/src/openclaw_execution_routes.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_execution_routes.py
@@ -491,7 +491,11 @@ def execute_research(dae: Any, intent: Any) -> str:
     try:
         from .pqn_research_adapter import handle_pqn_research_intent
 
-        return handle_pqn_research_intent(intent.raw_message, intent.sender)
+        return handle_pqn_research_intent(
+            intent.raw_message,
+            intent.sender,
+            report_action=dae._report_daemon_action,
+        )
     except ImportError as exc:
         logger.warning(
             "[OPENCLAW-DAE] PQN Research Adapter not available: %s",

--- a/modules/communication/moltbot_bridge/src/openclaw_intent_planner.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_intent_planner.py
@@ -120,7 +120,11 @@ def classify_intent(
     if classify_dae_runtime_category is not None:
         runtime_category = classify_dae_runtime_category(message)
         if runtime_category is not None:
-            category = runtime_category
+            category = (
+                dae.IntentCategory(runtime_category)
+                if isinstance(runtime_category, str)
+                else runtime_category
+            )
             confidence = 0.95
             extracted_task = message
             method = "deterministic_dae_runtime"

--- a/modules/communication/moltbot_bridge/src/pqn_research_adapter.py
+++ b/modules/communication/moltbot_bridge/src/pqn_research_adapter.py
@@ -23,7 +23,7 @@ NAVIGATION:
 """
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 logger = logging.getLogger("pqn_research_adapter")
 
@@ -40,6 +40,18 @@ _TEACH_KEYWORDS = [
 _DEMO_KEYWORDS = [
     "awaken", "demo", "detect", "run detector", "run pqn",
     "detection demo", "run detection",
+]
+
+_SIMULATION_KEYWORDS = [
+    "run pqn simulation",
+    "launch pqn simulation",
+    "start pqn simulation",
+    "status pqn simulation",
+    "show pqn simulation",
+    "show pqn simulation plan",
+    "show theory archive simulation",
+    "run theory archive simulation",
+    "status theory archive simulation",
 ]
 
 _PUBLISH_KEYWORDS = [
@@ -71,6 +83,10 @@ def _classify_sub_intent(message: str) -> str:
         if kw in msg_lower:
             return "runtime_control"
 
+    for kw in _SIMULATION_KEYWORDS:
+        if kw in msg_lower:
+            return "simulation"
+
     for kw in _DEMO_KEYWORDS:
         if kw in msg_lower:
             return "demo"
@@ -91,6 +107,22 @@ def _classify_sub_intent(message: str) -> str:
     return "knowledge"
 
 
+def _emit_action(
+    report_action: Optional[Callable[..., None]],
+    action_type: str,
+    target: str,
+    result: str,
+    **details: Any,
+) -> None:
+    """Best-effort action emission into the OpenClaw DAEmon ledger."""
+    if report_action is None:
+        return
+    try:
+        report_action(action_type, target, result, **details)
+    except Exception as exc:
+        logger.debug("[PQN-RESEARCH] action emit failed: %s", exc)
+
+
 def _get_launch_broker():
     """Load the runtime DAE broker if available."""
     try:
@@ -104,10 +136,21 @@ def _get_launch_broker():
         return None
 
 
-def _handle_runtime_control(message: str, sender: str) -> str:
+def _handle_runtime_control(
+    message: str,
+    sender: str,
+    report_action: Optional[Callable[..., None]] = None,
+) -> str:
     """Launch/status/stop runtime PQN DAEs through the central broker."""
     broker = _get_launch_broker()
     if broker is None:
+        _emit_action(
+            report_action,
+            "pqn_runtime_control",
+            "broker",
+            "unavailable",
+            sender=sender,
+        )
         return (
             "PQN runtime broker is not available. Start the system through `python main.py` "
             "so 0102 can bootstrap broker-managed DAE launches."
@@ -118,6 +161,14 @@ def _handle_runtime_control(message: str, sender: str) -> str:
 
     if "launch " in msg_lower or "start " in msg_lower:
         result = broker.start_dae(dae_id, actor_id=sender)
+        _emit_action(
+            report_action,
+            "pqn_runtime_control",
+            dae_id,
+            result.get("status", result.get("error", "unknown")),
+            action="launch",
+            sender=sender,
+        )
         if result.get("error") == "not_registered":
             return (
                 f"PQN runtime `{dae_id}` is not registered yet. "
@@ -131,12 +182,29 @@ def _handle_runtime_control(message: str, sender: str) -> str:
 
     if "stop " in msg_lower:
         result = broker.stop_dae(dae_id, actor_id=sender)
+        _emit_action(
+            report_action,
+            "pqn_runtime_control",
+            dae_id,
+            result.get("status", result.get("error", "unknown")),
+            action="stop",
+            sender=sender,
+        )
         if result.get("error") == "not_running":
             return f"PQN runtime `{dae_id}` is not running."
         status = result.get("status", result.get("error", "unknown"))
         return f"PQN runtime stop `{dae_id}` -> {status}."
 
     result = broker.get_runtime_status(dae_id)
+    _emit_action(
+        report_action,
+        "pqn_runtime_control",
+        dae_id,
+        result.get("state", "unknown"),
+        action="status",
+        sender=sender,
+        running=result.get("running", False),
+    )
     if not result.get("registered"):
         return (
             f"PQN runtime `{dae_id}` is not registered yet. "
@@ -149,6 +217,81 @@ def _handle_runtime_control(message: str, sender: str) -> str:
         f"enabled={result.get('enabled')}\n"
         f"run_count={result.get('run_count')}\n"
         f"last_error={result.get('last_error') or 'none'}"
+    )
+
+
+def _handle_simulation(
+    message: str,
+    sender: str,
+    report_action: Optional[Callable[..., None]] = None,
+) -> str:
+    """Run or inspect the theory-archive simulation through PQNAlignmentDAE."""
+    from modules.ai_intelligence.pqn_alignment import PQNAlignmentDAE
+
+    msg_lower = message.lower()
+    dae = PQNAlignmentDAE()
+
+    if "status " in msg_lower or "show " in msg_lower or " plan" in msg_lower:
+        plan = dae.get_theory_archive_simulation_plan()
+        _emit_action(
+            report_action,
+            "pqn_simulation_plan",
+            "pqn_theory_archive",
+            "inspected",
+            sender=sender,
+            run_count=plan.get("run_count", 0),
+            target_resonance_hz=plan["spec"].get("target_resonance_hz", 0.0),
+        )
+        return (
+            "**PQN Theory-Archive Simulation Plan**\n\n"
+            f"run_count={plan.get('run_count', 0)}\n"
+            f"matched_null_required={plan.get('matched_null_required')}\n"
+            f"target_resonance_hz={plan['spec'].get('target_resonance_hz', 0.0)}\n"
+            f"observables={', '.join(plan['spec'].get('observables', [])) or 'none'}\n"
+            f"out_root={plan.get('out_root', 'unknown')}"
+        )
+
+    _emit_action(
+        report_action,
+        "pqn_simulation",
+        "pqn_theory_archive",
+        "started",
+        sender=sender,
+    )
+    try:
+        result = dae.run_theory_archive_simulation()
+    except Exception as exc:
+        _emit_action(
+            report_action,
+            "pqn_simulation",
+            "pqn_theory_archive",
+            "error",
+            sender=sender,
+            error=str(exc)[:200],
+        )
+        raise
+
+    interpretation = result.get("interpretation", {})
+    comparison = result.get("comparison", {})
+    _emit_action(
+        report_action,
+        "pqn_simulation",
+        "pqn_theory_archive",
+        "completed",
+        sender=sender,
+        outcome=interpretation.get("outcome", "unknown"),
+        run_count=len(result.get("runs", [])),
+        summary_path=result.get("summary_path", ""),
+        delta_entrainment_score=comparison.get("delta_entrainment_score", 0.0),
+        delta_resonance_event_count=comparison.get("delta_resonance_event_count", 0.0),
+    )
+    return (
+        "**PQN Theory-Archive Simulation Complete**\n\n"
+        f"outcome={interpretation.get('outcome', 'unknown')}\n"
+        f"delta_entrainment_score={comparison.get('delta_entrainment_score', 0.0):.3f}\n"
+        f"delta_resonance_event_count={comparison.get('delta_resonance_event_count', 0.0):.3f}\n"
+        f"probe_closer_to_target={comparison.get('probe_closer_to_target', False)}\n"
+        f"summary_path={result.get('summary_path', 'unknown')}"
     )
 
 
@@ -351,7 +494,11 @@ def _handle_knowledge(message: str) -> str:
 
 # --- Entry point (called by openclaw_dae.py) ---
 
-def handle_pqn_research_intent(message: str, sender: str) -> str:
+def handle_pqn_research_intent(
+    message: str,
+    sender: str,
+    report_action: Optional[Callable[..., None]] = None,
+) -> str:
     """
     Handle RESEARCH intent from OpenClaw.
 
@@ -366,7 +513,9 @@ def handle_pqn_research_intent(message: str, sender: str) -> str:
     )
 
     if sub_intent == "runtime_control":
-        return _handle_runtime_control(message, sender)
+        return _handle_runtime_control(message, sender, report_action=report_action)
+    elif sub_intent == "simulation":
+        return _handle_simulation(message, sender, report_action=report_action)
     elif sub_intent == "teach":
         return _handle_teach(message)
     elif sub_intent == "demo":

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,14 @@
+## 2026-03-16: PQN simulation runtime command routing
+
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; python -m pytest modules/communication/moltbot_bridge/tests/test_pqn_research_adapter.py modules/communication/moltbot_bridge/tests/test_openclaw_dae_runtime_commands.py modules/infrastructure/dae_daemon/tests/test_dae_adapter.py -q`
+- Status: PASS
+- Notes:
+  - Validates `run/status pqn simulation` routing through the PQN research adapter.
+  - Confirms OpenClaw RESEARCH route passes the DAEmon action reporter into the adapter.
+  - Confirms structured `details` payloads are preserved in DAEmon action events.
+
+---
+
 ## 2026-03-15: Generic DAE runtime command routing
 
 - Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; python -m pytest modules/communication/moltbot_bridge/tests/test_dae_runtime_adapter.py modules/communication/moltbot_bridge/tests/test_openclaw_dae_runtime_commands.py modules/communication/moltbot_bridge/tests/test_pqn_research_adapter.py modules/infrastructure/dae_daemon/tests/test_dae_launch_broker.py -q`

--- a/modules/communication/moltbot_bridge/tests/test_openclaw_dae_runtime_commands.py
+++ b/modules/communication/moltbot_bridge/tests/test_openclaw_dae_runtime_commands.py
@@ -74,3 +74,23 @@ def test_execute_monitor_routes_to_dae_runtime_adapter():
 
     mocked.assert_called_once()
     assert "Launchable DAEs" in response
+
+
+def test_execute_research_passes_daemon_reporter():
+    dae = OpenClawDAE(repo_root=PROJECT_ROOT)
+    intent = dae.classify_intent(
+        message="run pqn simulation",
+        sender="012",
+        channel="discord",
+        session_key="runtime-5",
+    )
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.pqn_research_adapter.handle_pqn_research_intent",
+        return_value="**PQN Theory-Archive Simulation Complete**",
+    ) as mocked:
+        response = dae._execute_research(intent)
+
+    mocked.assert_called_once()
+    assert mocked.call_args.kwargs["report_action"] == dae._report_daemon_action
+    assert "Simulation Complete" in response

--- a/modules/communication/moltbot_bridge/tests/test_pqn_research_adapter.py
+++ b/modules/communication/moltbot_bridge/tests/test_pqn_research_adapter.py
@@ -64,3 +64,62 @@ class TestPQNResearchAdapterRuntimeControl:
             result = handle_pqn_research_intent("launch pqn research", "012")
 
         assert "runtime broker is not available" in result.lower()
+
+    def test_status_pqn_simulation_returns_plan(self):
+        reporter = MagicMock()
+        fake_plan = {
+            "run_count": 6,
+            "matched_null_required": True,
+            "out_root": "modules/ai_intelligence/pqn_alignment/artifact_results/theory_archive_simulation",
+            "spec": {
+                "target_resonance_hz": 7.05,
+                "observables": ["spectral_gap_ratio", "detection_signal_eta"],
+            },
+        }
+
+        with patch(
+            "modules.ai_intelligence.pqn_alignment.PQNAlignmentDAE",
+        ) as dae_cls:
+            dae_cls.return_value.get_theory_archive_simulation_plan.return_value = fake_plan
+            result = handle_pqn_research_intent(
+                "status pqn simulation",
+                "012",
+                report_action=reporter,
+            )
+
+        assert "PQN Theory-Archive Simulation Plan" in result
+        assert "run_count=6" in result
+        reporter.assert_called_once()
+        assert reporter.call_args.args[0] == "pqn_simulation_plan"
+
+    def test_run_pqn_simulation_reports_completion(self):
+        reporter = MagicMock()
+        fake_result = {
+            "runs": [{}, {}, {}],
+            "summary_path": "modules/ai_intelligence/pqn_alignment/artifact_results/theory_archive_simulation/summary.json",
+            "comparison": {
+                "delta_entrainment_score": 0.21,
+                "delta_resonance_event_count": 2.0,
+                "probe_closer_to_target": True,
+            },
+            "interpretation": {
+                "outcome": "probe_advantage_requires_followup",
+            },
+        }
+
+        with patch(
+            "modules.ai_intelligence.pqn_alignment.PQNAlignmentDAE",
+        ) as dae_cls:
+            dae_cls.return_value.run_theory_archive_simulation.return_value = fake_result
+            result = handle_pqn_research_intent(
+                "run pqn simulation",
+                "012",
+                report_action=reporter,
+            )
+
+        assert "PQN Theory-Archive Simulation Complete" in result
+        assert "probe_advantage_requires_followup" in result
+        assert reporter.call_count == 2
+        assert reporter.call_args_list[0].args[0] == "pqn_simulation"
+        assert reporter.call_args_list[0].args[2] == "started"
+        assert reporter.call_args_list[1].args[2] == "completed"

--- a/modules/infrastructure/dae_daemon/ModLog.md
+++ b/modules/infrastructure/dae_daemon/ModLog.md
@@ -1,5 +1,20 @@
 # dae_daemon ModLog
 
+## V1.2.1 - Structured Action Details for Live Research Events (2026-03-16)
+
+**What**: Extended the non-invasive `CentralDAEAdapter` so action events can carry structured details payloads.
+
+**Why**: OpenClaw was already trying to emit structured research/runtime details through the action ledger, but the adapter signature still dropped them. That broke the intended real-time observability contract for PQN simulation runs.
+
+**Changes**:
+- Updated `src/dae_adapter.py`
+  - `report_action(...)` now accepts optional `details`
+  - preserves `details` inside the emitted `ACTION_PERFORMED` payload
+
+**Impact**:
+- OpenClaw research/runtime events can now carry machine-readable context into DAEmon.
+- PQN simulation start/completion signals are visible as structured events rather than only flat text summaries.
+
 ## V1.0.0 - Centralized DAEmon (Cardiovascular System) (2026-02-17)
 
 **What**: Created 8-layer centralized DAEmon module for monitoring and controlling all DAEs.

--- a/modules/infrastructure/dae_daemon/src/dae_adapter.py
+++ b/modules/infrastructure/dae_daemon/src/dae_adapter.py
@@ -170,14 +170,27 @@ class CentralDAEAdapter:
             {"dest": dest, "summary": summary[:200]},
         )
 
-    def report_action(self, action_type: str, target: str = "", result: str = "") -> None:
+    def report_action(
+        self,
+        action_type: str,
+        target: str = "",
+        result: str = "",
+        details: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """Report an action performed by this DAE."""
         if not self._daemon:
             return
+        payload = {
+            "action_type": action_type,
+            "target": target,
+            "result": result[:200],
+        }
+        if details:
+            payload["details"] = details
         self._daemon.registry.report_event(
             self._dae_id,
             DAEEventType.ACTION_PERFORMED,
-            {"action_type": action_type, "target": target, "result": result[:200]},
+            payload,
         )
 
     def report_security_event(self, reason: str, severity: str = "warning") -> None:

--- a/modules/infrastructure/dae_daemon/tests/TestModLog.md
+++ b/modules/infrastructure/dae_daemon/tests/TestModLog.md
@@ -1,5 +1,17 @@
 # dae_daemon TestModLog
 
+## V1.2.1 - Structured Action Details Test (2026-03-16)
+
+**Created**: `test_dae_adapter.py`
+- validates `CentralDAEAdapter.report_action(...)` preserves structured `details`
+- validates the adapter still no-ops cleanly when DAEmon is absent
+
+**Run**:
+- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest modules/infrastructure/dae_daemon/tests/test_dae_adapter.py -q`
+
+**Result**:
+- `2 passed`
+
 ## V1.0.0 - Initial Test Suite (2026-02-17)
 
 **Created**: `test_schemas.py` — Layer 0 formal pytest tests (50+ assertions)

--- a/modules/infrastructure/dae_daemon/tests/test_dae_adapter.py
+++ b/modules/infrastructure/dae_daemon/tests/test_dae_adapter.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+
+from modules.infrastructure.dae_daemon.src.dae_adapter import CentralDAEAdapter
+from modules.infrastructure.dae_daemon.src.schemas import DAEEventType
+
+
+class _FakeRegistry:
+    def __init__(self):
+        self.calls = []
+
+    def report_event(self, dae_id, event_type, payload):
+        self.calls.append((dae_id, event_type, payload))
+
+
+def test_report_action_preserves_structured_details():
+    adapter = CentralDAEAdapter("openclaw", "OpenClaw", "communication")
+    fake_registry = _FakeRegistry()
+    adapter._daemon = SimpleNamespace(registry=fake_registry)
+
+    adapter.report_action(
+        "research_simulation",
+        target="pqn_theory_archive",
+        result="completed",
+        details={"outcome": "probe_advantage_requires_followup", "run_count": 6},
+    )
+
+    assert len(fake_registry.calls) == 1
+    dae_id, event_type, payload = fake_registry.calls[0]
+    assert dae_id == "openclaw"
+    assert event_type == DAEEventType.ACTION_PERFORMED
+    assert payload["action_type"] == "research_simulation"
+    assert payload["target"] == "pqn_theory_archive"
+    assert payload["result"] == "completed"
+    assert payload["details"]["run_count"] == 6
+
+
+def test_report_action_noops_without_daemon():
+    adapter = CentralDAEAdapter("openclaw", "OpenClaw", "communication")
+
+    adapter.report_action("intent_classified", target="research", result="ok")


### PR DESCRIPTION
## Summary
- add PQN theory-archive simulation commands to the research adapter
- emit structured research/runtime details into the DAEmon action ledger
- fix deterministic DAE runtime category coercion in OpenClaw intent planning
- extend the DAE adapter to preserve structured action details

## Validation
- python -m py_compile modules/communication/moltbot_bridge/src/pqn_research_adapter.py modules/communication/moltbot_bridge/src/openclaw_execution_routes.py modules/communication/moltbot_bridge/src/openclaw_intent_planner.py modules/infrastructure/dae_daemon/src/dae_adapter.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest modules/communication/moltbot_bridge/tests/test_pqn_research_adapter.py modules/communication/moltbot_bridge/tests/test_openclaw_dae_runtime_commands.py modules/infrastructure/dae_daemon/tests/test_dae_adapter.py -q