### PR TITLE
docs(foundups): add aionui factory architecture

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -1,5 +1,29 @@
 # FoundUps Agent - Development Log
 
+## [2026-03-16] AionUI FoundUp Factory Intake
+
+**Change Type**: Architecture Documentation / Retrieval Anchor  
+**By**: 0102  
+**WSP References**: WSP 11, WSP 22, WSP 73, WSP 97
+
+### Summary
+
+Added a canonical repo-visible architecture note defining `AionUI` as an external orchestration surface over the existing FoundUps factory seam instead of treating it as a new core module.
+
+### Files Changed
+
+| Location | Description |
+|----------|-------------|
+| `modules/foundups/docs/AIONUI_FOUNDUP_FACTORY_WSP97_ARCHITECTURE_2026-03-16.md` | Canonical AionUI intake note |
+| `modules/foundups/README.md` | Added cross-link from active execution references |
+| `modules/foundups/INTERFACE.md` | Added AionUI relationship section |
+| `modules/foundups/ModLog.md` | Recorded architectural decision |
+
+### Why
+
+- HoloIndex cannot retrieve architecture that only exists in chat history.
+- AionUI needed a concrete repo anchor tied to the already-landed `FoundUpSpawner` seam.
+
 ## [2026-03-16] OpenClaw PQN Simulation Runtime + DAEmon Detail Payloads
 
 **Change Type**: Runtime Control / Observability  

--- a/modules/foundups/INTERFACE.md
+++ b/modules/foundups/INTERFACE.md
@@ -402,6 +402,19 @@ GET /api/chat/history?limit=100
 - Process 1000+ platform API requests per minute
 - Maintain performance under 10x load increase
 
+## AionUI External Surface
+
+`AionUI` is an external orchestration surface, not a replacement for
+`FoundUpSpawner`.
+
+Canonical relationship:
+- `FoundUp Seed` = declarative build intent
+- `FoundUpSpawner` = low-level repo/workspace bootstrap primitive
+- `AionUI` = external visual command deck supervising the seed-driven build
+
+Reference:
+- `modules/foundups/docs/AIONUI_FOUNDUP_FACTORY_WSP97_ARCHITECTURE_2026-03-16.md`
+
 ---
 
 **Note**: All interfaces follow WSP 11 standards and are designed for seamless integration with the WRE-built platform modules across all enterprise domains.

--- a/modules/foundups/ModLog.md
+++ b/modules/foundups/ModLog.md
@@ -2,6 +2,33 @@
 
 ## Chronological Change Log
 
+### 2026-03-16 - AionUI FoundUp Factory Intake
+
+**By:** 0102
+**WSP References:** WSP 11, WSP 22, WSP 73, WSP 97
+
+**What changed**
+- Added canonical architecture note:
+  - `modules/foundups/docs/AIONUI_FOUNDUP_FACTORY_WSP97_ARCHITECTURE_2026-03-16.md`
+- Updated FoundUps docs to point at the note:
+  - `modules/foundups/README.md`
+  - `modules/foundups/INTERFACE.md`
+
+**Why**
+- `AionUI` is an external orchestration surface, not a core repo module.
+- It needed a repo-visible definition so HoloIndex can retrieve the relationship between:
+  - `FoundUp Seed`
+  - `FoundUpSpawner`
+  - `OpenClaw`
+  - external AionUI supervision
+
+**Decision**
+- FoundUps core repo remains the factory.
+- Spawned FoundUp sandboxes remain the product.
+- AionUI sits above the existing factory seam; it does not replace it.
+
+---
+
 ### 2026-02-22 - pAVS IronClaw Agent Builder + Digital Twin Roadmap
 
 **By:** 0102

--- a/modules/foundups/README.md
+++ b/modules/foundups/README.md
@@ -6,6 +6,7 @@ For active execution, use these first:
 - `modules/foundups/ROADMAP.md` (domain-level layered roadmap)
 - `modules/foundups/docs/OCCAM_LAYERED_EXECUTION_PLAN.md` (architecture intent)
 - `modules/foundups/docs/CONTINUATION_RUNBOOK.md` (resume/handoff workflow)
+- `modules/foundups/docs/AIONUI_FOUNDUP_FACTORY_WSP97_ARCHITECTURE_2026-03-16.md` (external orchestration surface over FoundUp factory)
 - `modules/foundups/agent_market/ROADMAP.md` (execution ledger roadmap)
 - `modules/foundups/simulator/ROADMAP.md` (simulation and DEX roadmap)
 

--- a/modules/foundups/docs/AIONUI_FOUNDUP_FACTORY_WSP97_ARCHITECTURE_2026-03-16.md
+++ b/modules/foundups/docs/AIONUI_FOUNDUP_FACTORY_WSP97_ARCHITECTURE_2026-03-16.md
@@ -1,0 +1,136 @@
+# AionUI FoundUp Factory Architecture
+
+## Purpose
+
+This note defines how `AionUI` fits into FoundUps under `WSP_97`.
+
+`AionUI` is not part of the current codebase. It is an external orchestration
+surface that can sit on top of the existing FoundUps factory primitives.
+
+It should not be treated as a replacement for:
+- `OpenClaw (0102)` as the control plane
+- `FoundUpSpawner` as the low-level execution primitive
+- WSP governance as the build contract
+
+It should be treated as:
+- a visible command deck
+- a multi-agent supervision surface
+- an external UI for initiating and monitoring FoundUp generation
+
+## Canonical Model
+
+```text
+012
+-> FoundUp Seed
+-> 0102 Charter / Scope Lock
+-> template selection
+-> FoundUpSpawner
+-> isolated repo/workspace bootstrap
+-> builder agents
+-> launch-ready FoundUp
+```
+
+This establishes the correct boundary:
+
+- `FoundUp Seed` = what to build
+- `FoundUp Charter` = 0102-expanded plan
+- `FoundUpSpawner` = how the isolated build environment is created
+- `AionUI` = the external surface for observing and steering that process
+
+## WSP 97 Separation
+
+Core separation must remain intact:
+
+```text
+FoundUps core repo
+= factory
+
+Spawned FoundUp repo/workspace
+= product
+```
+
+That means AionUI must supervise builds into isolated FoundUp sandboxes, not
+encourage direct project-specific buildup inside the FoundUps core repo.
+
+## Current Repo Anchors
+
+Existing implementation anchors already present in the codebase:
+
+- `modules/foundups/src/foundup_spawner.py`
+- `modules/foundups/INTERFACE.md`
+- `modules/foundups/src/README.md`
+
+Current reality:
+- `FoundUpSpawner` exists
+- `FoundUp Seed -> Charter -> Spawner` is only partially formalized
+- `AionUI` is not yet integrated in code
+
+## Architectural Decision
+
+AionUI should integrate as an external surface over the existing FoundUps
+factory, not as a new core orchestration root.
+
+Correct stack:
+
+```text
+012 = principal
+0102 = architect / control plane
+OpenClaw = live command and runtime routing surface
+AionUI = external visual orchestration / cowork surface
+FoundUpSpawner = repo/workspace bootstrap primitive
+spawned FoundUp = isolated output
+```
+
+## Required Contract Before Integration
+
+Before AionUI is wired into runtime control, FoundUps should have a formal seed
+contract:
+
+```yaml
+name:
+category:
+problem:
+target_user:
+core_action:
+mvp_type:
+platform:
+monetization:
+automation_level:
+deployment_target:
+```
+
+From that seed, 0102 should produce a FoundUp charter containing:
+- purpose
+- user flow
+- stack
+- module plan
+- docs plan
+- tests plan
+- launch criteria
+
+## Integration Rule
+
+Do not let AionUI directly mutate the FoundUps core repo as if it were the
+product workspace.
+
+Allowed role:
+- launch and supervise isolated FoundUp builds
+- visualize multi-agent work
+- provide human-visible checkpoints for 012
+
+Disallowed role:
+- replace WSP
+- replace OpenClaw
+- collapse factory and spawned FoundUp into one repo
+
+## Implementation Status
+
+Status on 2026-03-16:
+- documented
+- indexed target for HoloIndex retrieval
+- not yet implemented as runtime integration
+
+Next implementation step:
+- formalize `FoundUp Seed`
+- add `spawn_from_seed(...)` over `FoundUpSpawner`
+- then map AionUI onto that seed-driven pipeline


### PR DESCRIPTION
﻿## Summary
- add a canonical AionUI intake note in the FoundUps domain
- define AionUI as an external orchestration surface over FoundUp Seed -> FoundUpSpawner
- cross-link the note from FoundUps README and interface docs

## Validation
- python holo_index.py --index-wsp
- python holo_index.py --search external orchestration surface over the existing FoundUps factory seam --no-advisor
