### PR TITLE
fix(holoindex): self-heal adaptive learning db drift

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -55838,3 +55838,9 @@ if cooldown_sets:
 ## 2026-03-15: OpenClaw docs aligned to WSP 97 module map
 - Appended WSP 97 control-plane module map to `modules/communication/moltbot_bridge/README.md`.
 - Appended canonical internal boundary map to `modules/communication/moltbot_bridge/INTERFACE.md`.
+
+## 2026-03-16: HoloIndex adaptive-learning DB drift and event-collision fix
+- Fixed `modules/infrastructure/database/src/agent_db.py` so legacy `agents_autonomous_tasks` tables self-heal missing `status` and `completed_at` columns.
+- Added regression coverage in `modules/infrastructure/database/tests/test_agent_db_schema_compatibility.py`.
+- Fixed `holo_index/adaptive_learning/breadcrumb_tracer.py` runtime ID generation to use collision-resistant IDs for contracts, autonomous tasks, and coordination events.
+- Verified repeated `python holo_index.py --search "AionUI" --limit 5 --no-advisor` runs complete without adaptive-learning database errors.

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -5649,3 +5649,8 @@ The complete DAE Memory System has been implemented:
   - Downloaded `Qwen3.5-4B-Q4_K_M.gguf`
   - Hardlinked to `E:/LM_studio/models/local/qwen3.5-4b`
   - LM Studio reported loaded model id `qwen3.5-4b`
+
+## [2026-03-16] - Adaptive-learning search path stabilized
+- Fixed the `AgentDB` schema/runtime mismatch that was breaking adaptive-learning startup on older databases (`agents_autonomous_tasks` missing `status`).
+- Fixed coordination-event ID collisions in `holo_index/adaptive_learning/breadcrumb_tracer.py` by replacing second-resolution IDs with UUID-backed runtime IDs.
+- Verified live HoloIndex searches no longer emit database errors on repeated generic queries such as `AionUI`.

--- a/holo_index/adaptive_learning/breadcrumb_tracer.py
+++ b/holo_index/adaptive_learning/breadcrumb_tracer.py
@@ -38,6 +38,7 @@ import logging
 import os
 import threading
 import time
+import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Any
@@ -54,6 +55,11 @@ except ImportError:
 from modules.infrastructure.database.src.agent_db import AgentDB
 
 logger = logging.getLogger(__name__)
+
+
+def _new_runtime_id(prefix: str) -> str:
+    """Create a collision-resistant runtime identifier for adaptive-learning records."""
+    return f"{prefix}_{datetime.now().strftime('%Y%m%d_%H%M%S_%f')}_{uuid.uuid4().hex[:8]}"
 
 
 def _breadcrumb_enabled() -> bool:
@@ -456,7 +462,7 @@ class BreadcrumbTracer:
                                estimated_minutes: int, priority: str = "medium",
                                dependencies: List[str] = None, deliverables: List[str] = None) -> str:
         """Create a handoff contract for multi-agent task assignment."""
-        contract_id = f"contract_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{hash(task_description) % 1000}"
+        contract_id = _new_runtime_id("contract")
 
         # Add deadline if high priority
         deadline = None
@@ -652,7 +658,7 @@ class BreadcrumbTracer:
 
     def discover_autonomous_task(self, task_description: str, context: Dict[str, Any] = None) -> str:
         """Autonomously discover and register a task that needs to be done."""
-        task_id = f"auto_task_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{hash(task_description) % 1000}"
+        task_id = _new_runtime_id("auto_task")
 
         # Analyze task to determine requirements
         required_skills = self._analyze_task_requirements(task_description)
@@ -946,7 +952,7 @@ class BreadcrumbTracer:
     def _create_coordination_event(self, event_type: str, initiator: str,
                                  targets: List[str], payload: Dict[str, Any]) -> None:
         """Create a coordination event for inter-agent communication."""
-        event_id = f"coord_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{hash(str(payload)) % 1000}"
+        event_id = _new_runtime_id("coord")
 
         # Create coordination event in database (WSP 78)
         success = self.db.create_coordination_event(

--- a/holo_index/tests/test_breadcrumb_tracer_ids.py
+++ b/holo_index/tests/test_breadcrumb_tracer_ids.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Regression coverage for adaptive-learning runtime identifiers."""
+
+from holo_index.adaptive_learning.breadcrumb_tracer import _new_runtime_id
+
+
+def test_new_runtime_id_is_collision_resistant() -> None:
+    seen = {_new_runtime_id("coord") for _ in range(50)}
+    assert len(seen) == 50
+    assert all(identifier.startswith("coord_") for identifier in seen)

--- a/modules/infrastructure/database/ModLog.md
+++ b/modules/infrastructure/database/ModLog.md
@@ -92,3 +92,18 @@
 - Stronger integrity guarantees for relational writes.
 - More resilient concurrent event-store writes.
 - Shared architecture language for SIM + CABR + blockchain settlement boundary.
+
+## Entry: 2026-03-16 - AgentDB legacy autonomous-task schema self-heal
+**What Changed**:
+- Added backward-compatible migration logic in `src/agent_db.py` for legacy `agents_autonomous_tasks` tables.
+- Self-heals missing `status` and `completed_at` columns on startup instead of assuming a fresh schema.
+- Backfills null task statuses to `pending` and adds indexes on `status` and `assigned_to`.
+- Corrected `get_recent_breadcrumb_agents()` to query through `DatabaseManager` and normalize breadcrumb timestamps in UTC.
+
+**Why**:
+- HoloIndex adaptive-learning search paths were failing against older databases with `no such column: status`.
+- Recent-agent discovery also had a latent bug from mixed timestamp formats and a wrong method call.
+
+**Impact**:
+- Existing `foundups.db` instances can run adaptive-learning task discovery without manual DB surgery.
+- Breadcrumb-based recent-agent lookups now work reliably across SQLite timestamp formats.

--- a/modules/infrastructure/database/src/agent_db.py
+++ b/modules/infrastructure/database/src/agent_db.py
@@ -22,7 +22,7 @@ Shared agent memory and state management.
 
 import json
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Any
 from .db_manager import DatabaseManager
 
@@ -284,6 +284,55 @@ class AgentDB:
             conn.execute('CREATE INDEX IF NOT EXISTS idx_transactions_status ON agents_transactions(status)')
             conn.execute('CREATE INDEX IF NOT EXISTS idx_transactions_currency ON agents_transactions(currency)')
 
+        self._migrate_legacy_tables()
+
+    def _get_table_columns(self, table_name: str) -> set[str]:
+        """Return normalized column names for a table across supported backends."""
+        columns = set()
+        for row in self.db.get_table_info(table_name):
+            column_name = row.get("name") or row.get("column_name")
+            if column_name:
+                columns.add(str(column_name))
+        return columns
+
+    def _ensure_table_columns(self, table_name: str, column_definitions: Dict[str, str]) -> None:
+        """Add missing columns to legacy tables in a backward-compatible way."""
+        existing_columns = self._get_table_columns(table_name)
+        missing_columns = {
+            column_name: definition
+            for column_name, definition in column_definitions.items()
+            if column_name not in existing_columns
+        }
+        if not missing_columns:
+            return
+
+        with self.db.get_connection() as conn:
+            for column_name, definition in missing_columns.items():
+                conn.execute(f"ALTER TABLE {table_name} ADD COLUMN {column_name} {definition}")
+
+    def _migrate_legacy_tables(self) -> None:
+        """Backfill columns expected by current AgentDB methods."""
+        self._ensure_table_columns(
+            "agents_autonomous_tasks",
+            {
+                "status": "TEXT DEFAULT 'pending'",
+                "completed_at": "DATETIME",
+            },
+        )
+
+        with self.db.get_connection() as conn:
+            conn.execute("""
+                UPDATE agents_autonomous_tasks
+                SET status = 'pending'
+                WHERE status IS NULL OR status = ''
+            """)
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_autonomous_tasks_status ON agents_autonomous_tasks(status)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_autonomous_tasks_assigned_to ON agents_autonomous_tasks(assigned_to)"
+            )
+
     def record_awakening(self, agent_id: str, consciousness_level: str, koan: str = None) -> None:
         """Record agent awakening state."""
         with self.db.get_connection() as conn:
@@ -412,18 +461,35 @@ class AgentDB:
 
     def get_recent_breadcrumb_agents(self, minutes: int = 120, limit: int = 5) -> List[str]:
         """Get distinct breadcrumb agent IDs within the time window."""
-        cutoff = datetime.now() - timedelta(minutes=minutes)
-        rows = self.execute_query(
+        cutoff = (datetime.now(timezone.utc) - timedelta(minutes=minutes)).replace(tzinfo=None)
+        rows = self.db.execute_query(
             """
-            SELECT DISTINCT agent_id
+            SELECT agent_id, MAX(timestamp) AS last_seen
             FROM agents_breadcrumbs
-            WHERE agent_id IS NOT NULL AND agent_id != '' AND timestamp >= ?
-            ORDER BY timestamp DESC
+            WHERE agent_id IS NOT NULL AND agent_id != ''
+            GROUP BY agent_id
+            ORDER BY last_seen DESC
             LIMIT ?
             """,
-            (cutoff.isoformat(), limit)
+            (max(limit * 5, limit),)
         )
-        return [row['agent_id'] for row in rows]
+
+        recent_agents: List[str] = []
+        for row in rows:
+            last_seen = row.get("last_seen")
+            if not last_seen:
+                continue
+            if isinstance(last_seen, str):
+                parsed_last_seen = datetime.fromisoformat(last_seen.replace("Z", "+00:00"))
+            else:
+                parsed_last_seen = last_seen
+            if getattr(parsed_last_seen, "tzinfo", None) is not None:
+                parsed_last_seen = parsed_last_seen.astimezone(timezone.utc).replace(tzinfo=None)
+            if parsed_last_seen >= cutoff:
+                recent_agents.append(row["agent_id"])
+            if len(recent_agents) >= limit:
+                break
+        return recent_agents
 
     # ============================================================================
     # HANDOFF CONTRACTS (Multi-Agent Task Assignment)

--- a/modules/infrastructure/database/tests/TestModLog.md
+++ b/modules/infrastructure/database/tests/TestModLog.md
@@ -126,3 +126,15 @@ python -m pytest --cov=modules.infrastructure.database.src --cov-report=html mod
 **Rationale**:
 - Protects against regressions where SQLite pragmas are only set at file-init time.
 - Ensures audit tooling remains deterministic and CI-friendly.
+
+## Entry: 2026-03-16 - AgentDB schema compatibility regression coverage
+**Added Tests**:
+- `test_agent_db_schema_compatibility.py`
+  - verifies legacy `agents_autonomous_tasks` tables are migrated with `status` and `completed_at`
+  - verifies legacy rows are backfilled to `pending`
+  - verifies autonomous task assignment/completion works after migration
+  - verifies recent breadcrumb agent discovery works against live DB timestamps
+
+**Validation**:
+- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest modules/infrastructure/database/tests/test_agent_db_schema_compatibility.py -q`
+- Result: `2 passed`

--- a/modules/infrastructure/database/tests/test_agent_db_schema_compatibility.py
+++ b/modules/infrastructure/database/tests/test_agent_db_schema_compatibility.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Regression tests for AgentDB schema compatibility migrations."""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import tempfile
+from pathlib import Path
+
+from modules.infrastructure.database.src.agent_db import AgentDB
+from modules.infrastructure.database.src.db_manager import DatabaseManager
+
+
+def _reset_database(db_path: Path) -> None:
+    DatabaseManager.reset_for_tests()
+    DatabaseManager._db_path = str(db_path)
+
+
+def test_agent_db_migrates_legacy_autonomous_task_schema() -> None:
+    temp_dir = Path(tempfile.mkdtemp())
+    db_path = temp_dir / "legacy_foundups.db"
+    try:
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            """
+            CREATE TABLE agents_autonomous_tasks (
+                task_id TEXT PRIMARY KEY,
+                description TEXT,
+                required_skills JSON,
+                estimated_complexity REAL,
+                priority_score REAL,
+                discovered_by TEXT DEFAULT 'autonomous_discovery',
+                discovered_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                context JSON,
+                assigned_to TEXT,
+                assigned_at DATETIME
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO agents_autonomous_tasks (
+                task_id, description, required_skills, estimated_complexity, priority_score
+            ) VALUES ('legacy-task', 'legacy description', '[]', 0.1, 0.5)
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        _reset_database(db_path)
+        agent_db = AgentDB()
+
+        columns = {row["name"] for row in agent_db.db.get_table_info("agents_autonomous_tasks")}
+        assert "status" in columns
+        assert "completed_at" in columns
+
+        tasks = agent_db.get_autonomous_tasks()
+        assert len(tasks) == 1
+        assert tasks[0]["task_id"] == "legacy-task"
+        assert tasks[0]["status"] == "pending"
+
+        assert agent_db.assign_autonomous_task("legacy-task", "0102")
+        assigned_rows = agent_db.db.execute_query(
+            "SELECT status, assigned_to FROM agents_autonomous_tasks WHERE task_id = ?",
+            ("legacy-task",),
+        )
+        assert assigned_rows[0]["status"] == "assigned"
+        assert assigned_rows[0]["assigned_to"] == "0102"
+
+        assert agent_db.complete_autonomous_task("legacy-task")
+        completed_rows = agent_db.db.execute_query(
+            "SELECT status, completed_at FROM agents_autonomous_tasks WHERE task_id = ?",
+            ("legacy-task",),
+        )
+        assert completed_rows[0]["status"] == "completed"
+        assert completed_rows[0]["completed_at"] is not None
+    finally:
+        DatabaseManager.reset_for_tests()
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def test_agent_db_returns_recent_breadcrumb_agents() -> None:
+    temp_dir = Path(tempfile.mkdtemp())
+    db_path = temp_dir / "breadcrumbs_foundups.db"
+    try:
+        _reset_database(db_path)
+        agent_db = AgentDB()
+        agent_db.add_breadcrumb(session_id="session-a", action="search", agent_id="0102")
+        agent_db.add_breadcrumb(session_id="session-b", action="search", agent_id="0201")
+
+        recent_agents = agent_db.get_recent_breadcrumb_agents(minutes=60, limit=10)
+
+        assert "0102" in recent_agents
+        assert "0201" in recent_agents
+    finally:
+        DatabaseManager.reset_for_tests()
+        shutil.rmtree(temp_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary
- self-heal legacy agents_autonomous_tasks schemas by adding missing status/completed_at columns
- fix recent breadcrumb agent discovery and switch runtime adaptive-learning IDs to UUID-backed generation
- add regression coverage for legacy schema migration and runtime ID uniqueness

## Validation
- python -m py_compile modules/infrastructure/database/src/agent_db.py modules/infrastructure/database/tests/test_agent_db_schema_compatibility.py holo_index/adaptive_learning/breadcrumb_tracer.py holo_index/tests/test_breadcrumb_tracer_ids.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest modules/infrastructure/database/tests/test_agent_db_schema_compatibility.py holo_index/tests/test_breadcrumb_tracer_ids.py -q
- python holo_index.py --search AionUI --limit 5 --no-advisor