### PR TITLE
feat(dae): add live supervision surface for claw and pqn

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -55844,3 +55844,11 @@ if cooldown_sets:
 - Added regression coverage in `modules/infrastructure/database/tests/test_agent_db_schema_compatibility.py`.
 - Fixed `holo_index/adaptive_learning/breadcrumb_tracer.py` runtime ID generation to use collision-resistant IDs for contracts, autonomous tasks, and coordination events.
 - Verified repeated `python holo_index.py --search "AionUI" --limit 5 --no-advisor` runs complete without adaptive-learning database errors.
+
+## 2026-03-17: DAEmon live-tail/status surface for Claw and PQN
+- Added `modules/infrastructure/dae_daemon/src/dae_observer.py` as the read-side observer over the central event ledger.
+- Extended `modules/infrastructure/dae_daemon/src/event_store.py` with recent-window querying.
+- Extended `modules/communication/moltbot_bridge/src/dae_runtime_adapter.py` with read-only supervision commands:
+  - `tail <dae>`
+  - `status <dae> live`
+- Added `openclaw` / `claw` / `0102` daemon aliases so 012 can supervise Claw directly through OpenClaw.

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -338,3 +338,15 @@ This is the canonical internal layout for future work:
 Refactor status:
 - `openclaw_dae.py` now stays below the large-file threshold at `1342` lines
 - execution-plane resolution now matches `WSP_97`: resolve intent -> gate -> plan -> route -> validate -> remember
+
+## Runtime Supervision Commands
+
+OpenClaw can now read the DAEmon live ledger for itself and broker-managed DAEs:
+
+- `tail openclaw`
+- `status openclaw live`
+- `tail pqn research`
+- `status pqn research live`
+- `tail holodae`
+
+These commands are read-only. They use the central DAEmon observer surface and do not mutate runtime state.

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -982,3 +982,170 @@ openclaw onboard
   - Read-safe by default
   - No external model drift
   - Mutating intents auto-contained before execution planning
+
+## 2026-03-15: PQN runtime broker control from OpenClaw
+
+**Author**: 0102  
+**WSP**: 11, 72, 73, 84, 97
+
+### Changes
+- Updated `src/pqn_research_adapter.py` to recognize broker-managed runtime commands:
+  - `launch pqn research`
+  - `status pqn research`
+  - `stop pqn research`
+  - `launch pqn architect`
+  - `status pqn architect`
+- Runtime control now routes through the central `DAELaunchBroker` instead of trying to re-enter the menu layer.
+- Updated `INTERFACE.md` to document the new runtime control contract.
+
+### Outcome
+- 012 can ask 0102 to launch PQN research inside an already running system.
+- OpenClaw stays the conversational/control-plane front door while DAEmon remains the lifecycle ledger.
+## 2026-03-10: LinkedIn mission-control routing + WSP 97 context pack
+
+**Author**: 0102  
+**WSP**: 15, 50, 77, 84, 97
+
+### Changes
+- Added `src/linkedin_loop_adapter.py` as a conversational control surface for the durable LinkedIn orchestration loop.
+- Updated `src/openclaw_dae.py` to:
+  - route mission phrases such as `let's work on LN` through the loop adapter before low-level LinkedIn actions
+  - load `WSP_97_System_Execution_Prompting_Protocol.md` into the default OpenClaw platform context pack
+  - prioritize code-change language over health vocabulary during agentic model selection so edit work routes to the coder model
+
+### Outcome
+- OpenClaw can now steer LinkedIn loop phases conversationally while preserving deterministic action commands.
+- WSP 97 is part of default OpenClaw context, so `follow wsp` resolves through the execution-prompting protocol by default.
+- Mixed prompts like `fix the failing test in main.py` now route to `local/qwen-coder-7b` instead of `local/gemma-270m`.
+
+## 2026-03-10: Deterministic "follow wsp" command route
+
+**Author**: 0102  
+**WSP**: 50, 77, 84, 97
+
+### Changes
+- Added explicit `follow wsp` interception in `src/openclaw_dae.py` command routing.
+- The canonical WSP 97 operator now routes through `modules/infrastructure/wsp_orchestrator/src/wsp_orchestrator.py` instead of falling through generic WRE command handling.
+
+### Outcome
+- `follow wsp ...` now has a real execution plane in OpenClaw:
+  - detect operator
+  - call WSP orchestrator
+  - return deterministic execution summary
+
+## 2026-03-11: OpenClaw control-plane refactor - intent planner + result memory
+
+**Author**: 0102  
+**WSP**: 22, 50, 73, 84, 97
+
+### Changes
+- Added `src/openclaw_intent_planner.py` for intent classification, WSP preflight, and execution-plan construction.
+- Added `src/openclaw_result_memory.py` for output validation and WRE pattern-memory storage.
+- Reduced `src/openclaw_dae.py` by replacing inline classify/preflight/plan/finalize blocks with facade wrappers.
+
+### Outcome
+- OpenClaw intent resolution and result finalization are now isolated control-plane seams instead of monolith internals.
+- `openclaw_dae.py` dropped from `2638` lines to `2262` lines in this slice.
+
+## 2026-03-11: OpenClaw control-plane refactor - permission and safety policy
+
+**Author**: 0102  
+**WSP**: 22, 50, 71, 73, 84, 95, 97
+
+### Changes
+- Added `src/openclaw_permission_policy.py` for autonomy-tier resolution, source-write gating, AI Overseer emission, containment checks, and cached skill-safety scanning.
+- Replaced the inline permission/security block in `src/openclaw_dae.py` with facade wrappers.
+
+### Outcome
+- Permission, containment, and skill-safety policy are now centralized and auditable as one control-plane module.
+- `openclaw_dae.py` dropped from `2262` lines to `2086` lines in this slice.
+
+## 2026-03-11: OpenClaw control-plane refactor - execution routes
+
+**Author**: 0102  
+**WSP**: 22, 50, 73, 84, 97
+
+### Changes
+- Added `src/openclaw_execution_routes.py` for post-plan route execution:
+  - query
+  - command + follow-wsp
+  - monitor
+  - schedule
+  - system
+  - automation
+  - foundup
+  - research
+- Replaced the inline route layer in `src/openclaw_dae.py` with facade wrappers.
+
+### Outcome
+- Execution-plane routing now lives in a dedicated module after plan resolution, aligned to WSP 97 plane separation.
+- `openclaw_dae.py` dropped from `2086` lines to `1678` lines in this slice.
+
+## 2026-03-11: OpenClaw control-plane refactor - telemetry and turn state
+
+**Author**: 0102  
+**WSP**: 22, 73, 84, 91, 97
+
+### Changes
+- Added `src/openclaw_turn_state.py` for:
+  - conversation-engine markers
+  - preferred-external status markers
+  - token telemetry
+  - cooperative turn cancellation
+- Replaced the inline runtime bookkeeping block in `src/openclaw_dae.py` with facade wrappers.
+
+### Outcome
+- Runtime bookkeeping is now isolated from the OpenClaw control-plane facade.
+- `openclaw_dae.py` dropped from `1678` lines to `1603` lines in this slice.
+
+## 2026-03-11: OpenClaw control-plane refactor - status surface + process loop
+
+**Author**: 0102  
+**WSP**: 22, 50, 73, 84, 91, 97
+
+### Changes
+- Added `src/openclaw_status_surface.py` for:
+  - `connect_wre` readiness/status synthesis
+  - Discord/AI Overseer status push dispatch
+- Added `src/openclaw_process_loop.py` for the full autonomy loop:
+  - honeypot intercept
+  - containment gate
+  - intent -> preflight -> permission -> plan -> execute -> validate pipeline
+  - DAEmon in/out and action reporting
+- Replaced the inline status/process bodies in `src/openclaw_dae.py` with facade delegation.
+
+### Outcome
+- `OpenClawDAE` now behaves as a true orchestration facade instead of carrying the full autonomy implementation.
+- `openclaw_dae.py` dropped from `1603` lines to `1342` lines in this final extraction slice.
+
+## 2026-03-15: OpenClaw docs updated for WSP 97 module split
+
+**Author**: 0102  
+**WSP**: 22, 73, 84, 97
+
+### Changes
+- Appended canonical control-plane module map to `README.md`.
+- Appended internal module-boundary map to `INTERFACE.md`.
+
+### Outcome
+- Repo-local documentation now matches the post-refactor OpenClaw runtime layout.
+- The next 0102 session can re-enter OpenClaw using the actual module graph instead of the old monolith assumption.
+
+## 2026-03-17: OpenClaw runtime supervision surface
+
+**Author**: 0102  
+**WSP**: 22, 73, 91, 97
+
+### Changes
+- Extended `src/dae_runtime_adapter.py` with read-only supervision commands:
+  - `tail <dae>`
+  - `status <dae> live`
+- Added OpenClaw aliases for its own daemon identity:
+  - `openclaw`
+  - `claw`
+  - `0102`
+- Updated `INTERFACE.md` to document the new live-tail command surface.
+
+### Outcome
+- 012 can inspect the DAEmon ledger through OpenClaw instead of reading raw logs.
+- Claw and PQN runtime activity now has a real supervision surface, not just event persistence.

--- a/modules/communication/moltbot_bridge/src/dae_runtime_adapter.py
+++ b/modules/communication/moltbot_bridge/src/dae_runtime_adapter.py
@@ -11,12 +11,16 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 logger = logging.getLogger("dae_runtime_adapter")
 
 
 _DAE_ALIASES: Dict[str, str] = {
+    "openclaw dae": "openclaw",
+    "openclaw": "openclaw",
+    "claw": "openclaw",
+    "0102": "openclaw",
     "holodae": "holodae",
     "holo dae": "holodae",
     "git push dae": "git_push_dae",
@@ -37,6 +41,7 @@ _DAE_ALIASES: Dict[str, str] = {
 
 _MUTATING_VERBS = ("launch", "start", "stop")
 _STATUS_VERBS = ("status", "show")
+_TAIL_VERBS = ("tail", "watch")
 _LIST_PATTERNS = (
     "list daes",
     "list launchable daes",
@@ -66,6 +71,16 @@ def _get_launch_broker():
         return None
 
 
+def _get_dae_observer():
+    try:
+        from modules.infrastructure.dae_daemon.src.dae_observer import get_dae_observer
+
+        return get_dae_observer()
+    except Exception as exc:
+        logger.debug("[DAE-RUNTIME] DAE observer unavailable: %s", exc)
+        return None
+
+
 def parse_dae_runtime_request(message: str) -> Optional[Dict[str, str]]:
     """Return normalized runtime request or None."""
     msg = _normalize(message)
@@ -82,8 +97,10 @@ def parse_dae_runtime_request(message: str) -> Optional[Dict[str, str]]:
             if msg.startswith(f"{verb} ") or f" {verb} " in msg:
                 action = verb
                 break
+    elif any(msg.startswith(f"{verb} ") or f" {verb} " in msg for verb in _TAIL_VERBS):
+        action = "tail"
     elif any(msg.startswith(f"{verb} ") or f" {verb} " in msg for verb in _STATUS_VERBS):
-        action = "status"
+        action = "live_status" if " live" in msg or msg.startswith("live ") else "status"
 
     if not action:
         return None
@@ -105,9 +122,65 @@ def classify_dae_runtime_category(message: str) -> Optional[str]:
     request = parse_dae_runtime_request(message)
     if not request:
         return None
-    if request["action"] in {"status", "list"}:
+    if request["action"] in {"status", "live_status", "tail", "list"}:
         return "monitor"
     return "system"
+
+
+def _format_event_line(event: Dict[str, Any]) -> str:
+    payload = event.get("payload", {}) or {}
+    base = f"#{event.get('sequence_id')} {event.get('event_type')}"
+    if event.get("event_type") == "action_performed":
+        action = payload.get("action_type", "action")
+        target = payload.get("target") or payload.get("details", {}).get("target") or payload.get("action_target")
+        result = payload.get("result", "")
+        parts = [base, f"action={action}"]
+        if target:
+            parts.append(f"target={target}")
+        if result:
+            parts.append(f"result={str(result)[:80]}")
+        return " | ".join(parts)
+    if event.get("event_type") == "dae_state_changed":
+        return (
+            f"{base} | {payload.get('old_state', 'unknown')} -> "
+            f"{payload.get('new_state', 'unknown')} | reason={payload.get('reason', 'none')}"
+        )
+    if event.get("event_type") == "message_in":
+        return f"{base} | from={payload.get('source', 'unknown')} | {payload.get('summary', '')[:80]}"
+    if event.get("event_type") == "message_out":
+        return f"{base} | to={payload.get('dest', 'unknown')} | {payload.get('summary', '')[:80]}"
+    return base
+
+
+def _format_live_status(snapshot: Dict[str, Any]) -> str:
+    runtime = snapshot.get("runtime", {}) or {}
+    lines = [
+        f"DAE live status `{snapshot.get('dae_id')}`",
+        f"state={snapshot.get('state')}",
+        f"enabled={snapshot.get('enabled')}",
+        f"registered={snapshot.get('registered')}",
+    ]
+    if snapshot.get("domain"):
+        lines.append(f"domain={snapshot.get('domain')}")
+    if snapshot.get("pid"):
+        lines.append(f"pid={snapshot.get('pid')}")
+    if snapshot.get("last_heartbeat_age_sec") is not None:
+        lines.append(f"last_heartbeat_age_sec={snapshot.get('last_heartbeat_age_sec')}")
+    if runtime:
+        if "running" in runtime:
+            lines.append(f"running={runtime.get('running')}")
+        if "run_count" in runtime:
+            lines.append(f"run_count={runtime.get('run_count')}")
+        if runtime.get("last_error"):
+            lines.append(f"last_error={runtime.get('last_error')}")
+        elif runtime.get("last_result_summary"):
+            lines.append(f"last_result={runtime.get('last_result_summary')}")
+
+    recent_events = snapshot.get("recent_events", [])
+    if recent_events:
+        lines.append("recent_events:")
+        lines.extend(f"- {_format_event_line(event)}" for event in recent_events)
+    return "\n".join(lines)
 
 
 def handle_dae_runtime_intent(
@@ -121,17 +194,18 @@ def handle_dae_runtime_intent(
     if not request:
         return ""
 
-    broker = _get_launch_broker()
-    if broker is None:
-        return (
-            "DAE runtime broker is not available. Start the system through `python main.py` "
-            "so 0102 can bootstrap runtime launches."
-        )
-
     action = request["action"]
     dae_id = request["dae_id"]
 
+    observer = _get_dae_observer()
+    broker = _get_launch_broker()
+
     if action == "list":
+        if broker is None:
+            return (
+                "DAE runtime broker is not available. Start the system through `python main.py` "
+                "so 0102 can bootstrap runtime launches."
+            )
         launchable = broker.list_launchable_daes()
         if not launchable:
             return "No launchable DAEs are currently registered."
@@ -150,7 +224,30 @@ def handle_dae_runtime_intent(
             "launch/status/stop by the known runtime name."
         )
 
+    if action == "tail":
+        if observer is None:
+            return "DAE observer is not available yet."
+        events = observer.tail_events(dae_id=dae_id, limit=8)
+        if not events:
+            return f"No recent daemon events for `{dae_id}`."
+        lines = [f"DAE event tail `{dae_id}`"]
+        lines.extend(f"- {_format_event_line(event)}" for event in events)
+        return "\n".join(lines)
+
+    if action == "live_status":
+        if observer is None:
+            return "DAE observer is not available yet."
+        snapshot = observer.get_live_status(dae_id, limit=8)
+        if not snapshot.get("registered"):
+            return f"DAE runtime `{dae_id}` is not registered."
+        return _format_live_status(snapshot)
+
     if action == "status":
+        if broker is None:
+            return (
+                "DAE runtime broker is not available. Start the system through `python main.py` "
+                "so 0102 can bootstrap runtime launches."
+            )
         result = broker.get_runtime_status(dae_id)
         if not result.get("registered"):
             return f"DAE runtime `{dae_id}` is not registered."
@@ -167,6 +264,12 @@ def handle_dae_runtime_intent(
         return (
             "Runtime launch and stop commands require 012 authorization. "
             "Use `status <dae>` or `list launchable daes` for read-only inspection."
+        )
+
+    if broker is None:
+        return (
+            "DAE runtime broker is not available. Start the system through `python main.py` "
+            "so 0102 can bootstrap runtime launches."
         )
 
     if action in {"launch", "start"}:

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -306,3 +306,11 @@
 - Result: `4 passed, 92 deselected, 2 warnings`
 - Notes:
   - Confirms extracted status/telemetry surfaces still drive token usage, cancellation, monitor, and follow-wsp behavior correctly.
+
+## 2026-03-17: Runtime supervision adapter coverage
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; python -m pytest modules/communication/moltbot_bridge/tests/test_dae_runtime_adapter.py modules/communication/moltbot_bridge/tests/test_openclaw_dae_runtime_commands.py -q`
+- Status: PASS
+- Result: `11 passed`
+- Notes:
+  - Confirms `tail <dae>` and `status <dae> live` classify as monitor intents.
+  - Confirms OpenClaw runtime supervision for `openclaw` routes through the new DAEmon observer path.

--- a/modules/communication/moltbot_bridge/tests/test_dae_runtime_adapter.py
+++ b/modules/communication/moltbot_bridge/tests/test_dae_runtime_adapter.py
@@ -18,6 +18,7 @@ def test_parse_launch_social_media_dae():
 def test_classify_status_as_monitor():
     assert classify_dae_runtime_category("status holodae") == "monitor"
     assert classify_dae_runtime_category("list launchable daes") == "monitor"
+    assert classify_dae_runtime_category("tail openclaw") == "monitor"
 
 
 def test_handle_list_launchable_daes():
@@ -86,3 +87,84 @@ def test_status_holodae_uses_broker():
     broker.get_runtime_status.assert_called_once_with("holodae")
     assert "state=running" in result
     assert "run_count=3" in result
+
+
+def test_parse_tail_openclaw_request():
+    request = parse_dae_runtime_request("tail openclaw")
+
+    assert request is not None
+    assert request["action"] == "tail"
+    assert request["dae_id"] == "openclaw"
+
+
+def test_live_status_openclaw_uses_observer():
+    observer = MagicMock()
+    observer.get_live_status.return_value = {
+        "registered": True,
+        "dae_id": "openclaw",
+        "state": "running",
+        "enabled": True,
+        "domain": "communication",
+        "pid": 123,
+        "last_heartbeat_age_sec": 2.0,
+        "runtime": {"running": True, "run_count": 1, "last_error": ""},
+        "recent_events": [
+            {
+                "sequence_id": 44,
+                "event_type": "action_performed",
+                "payload": {
+                    "action_type": "pqn_simulation",
+                    "target": "pqn_theory_archive",
+                    "result": "started",
+                },
+            }
+        ],
+    }
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.dae_runtime_adapter._get_dae_observer",
+        return_value=observer,
+    ):
+        result = handle_dae_runtime_intent(
+            "status openclaw live",
+            "012",
+            allow_mutation=False,
+        )
+
+    observer.get_live_status.assert_called_once_with("openclaw", limit=8)
+    assert "DAE live status `openclaw`" in result
+    assert "recent_events:" in result
+
+
+def test_tail_openclaw_uses_observer():
+    observer = MagicMock()
+    observer.tail_events.return_value = [
+        {
+            "sequence_id": 41,
+            "event_type": "message_in",
+            "payload": {"source": "012", "summary": "tail openclaw"},
+        },
+        {
+            "sequence_id": 42,
+            "event_type": "action_performed",
+            "payload": {
+                "action_type": "pqn_simulation",
+                "target": "pqn_theory_archive",
+                "result": "started",
+            },
+        },
+    ]
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.dae_runtime_adapter._get_dae_observer",
+        return_value=observer,
+    ):
+        result = handle_dae_runtime_intent(
+            "tail openclaw",
+            "012",
+            allow_mutation=False,
+        )
+
+    observer.tail_events.assert_called_once_with(dae_id="openclaw", limit=8)
+    assert "DAE event tail `openclaw`" in result
+    assert "pqn_simulation" in result

--- a/modules/infrastructure/dae_daemon/ModLog.md
+++ b/modules/infrastructure/dae_daemon/ModLog.md
@@ -91,3 +91,19 @@
 - `main.py` can register launchable DAEs during bootstrap.
 - OpenClaw and other control surfaces can activate DAEs after startup.
 - Runtime DAE launch no longer depends on fake menu input or restarting `main.py`.
+
+## V1.3.0 - DAEmon Observer Read Surface (2026-03-17)
+
+**What**: Added a read-side supervision layer over the central event store so OpenClaw and other controllers can tail recent events and request live runtime snapshots.
+
+**Changes**:
+- Added `src/dae_observer.py` with:
+  - `tail_events(...)`
+  - `get_live_status(...)`
+  - `get_system_live_status(...)`
+- Extended `src/event_store.py` with `query_recent(...)` for recent-window event reads.
+- Updated `README.md` to document the observer as the canonical live supervision seam.
+
+**Impact**:
+- DAEmon is now both the write ledger and the read-side runtime surface.
+- OpenClaw can expose real-time Claw/PQN supervision without scraping logs or bypassing the daemon.

--- a/modules/infrastructure/dae_daemon/README.md
+++ b/modules/infrastructure/dae_daemon/README.md
@@ -65,6 +65,20 @@ Runtime intent:
 - OpenClaw or another controller asks broker to `start/status/stop`
 - Central DAEmon remains the canonical lifecycle ledger
 
+### For live supervision:
+```python
+from modules.infrastructure.dae_daemon.src.dae_observer import get_dae_observer
+
+observer = get_dae_observer()
+tail = observer.tail_events(dae_id="openclaw", limit=8)
+snapshot = observer.get_live_status("pqn_research", limit=8)
+```
+
+Runtime supervision intent:
+- `tail <dae>` -> recent DAEmon event stream for that DAE
+- `status <dae> live` -> registry state + runtime status + recent event tail
+- The event store remains the source of truth; the observer is read-only
+
 ## Security Killswitch
 
 - 1 CRITICAL event = immediate detach
@@ -83,6 +97,7 @@ Runtime intent:
 | `src/dae_daemon.py` | 4 | Singleton daemon (composes 1-3) |
 | `src/dae_adapter.py` | 5 | Non-invasive adapter for DAEs |
 | `src/dae_launch_broker.py` | 5 | Runtime launch broker for on-demand DAE activation |
+| `src/dae_observer.py` | 5 | Read-side observer for live status and event tails |
 
 ## WSP Compliance
 

--- a/modules/infrastructure/dae_daemon/src/dae_observer.py
+++ b/modules/infrastructure/dae_daemon/src/dae_observer.py
@@ -1,0 +1,112 @@
+"""Read-side DAEmon observer helpers for live status and event tails."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+_observer_lock = threading.Lock()
+_dae_observer: Optional["DAEObserver"] = None
+
+
+class DAEObserver:
+    """Read-only observer over the central DAEmon state and recent events."""
+
+    def __init__(self, daemon=None) -> None:
+        if daemon is None:
+            from modules.infrastructure.dae_daemon.src.dae_daemon import get_central_daemon
+
+            daemon = get_central_daemon()
+        self._daemon = daemon
+
+    def tail_events(
+        self,
+        *,
+        dae_id: Optional[str] = None,
+        event_type: Optional[str] = None,
+        limit: int = 12,
+    ) -> List[Dict[str, Any]]:
+        events = self._daemon.event_store.query_recent(
+            dae_id=dae_id,
+            event_type=event_type,
+            limit=limit,
+        )
+        return [self._event_to_dict(event) for event in events]
+
+    def get_live_status(self, dae_id: str, *, limit: int = 8) -> Dict[str, Any]:
+        reg = self._daemon.registry.get(dae_id)
+        recent_events = self.tail_events(dae_id=dae_id, limit=limit)
+        runtime = self._get_runtime_status(dae_id)
+        last_event = recent_events[-1] if recent_events else None
+        last_action = None
+        for event in reversed(recent_events):
+            if event["event_type"] == "action_performed":
+                last_action = event
+                break
+
+        heartbeat_age_sec = None
+        if reg and reg.last_heartbeat:
+            heartbeat_age_sec = round(max(0.0, time.time() - reg.last_heartbeat), 1)
+
+        return {
+            "registered": reg is not None or runtime.get("registered", False),
+            "dae_id": dae_id,
+            "dae_name": reg.dae_name if reg else runtime.get("dae_name", dae_id),
+            "domain": reg.domain if reg else "",
+            "state": reg.state.value if reg else runtime.get("state", "unknown"),
+            "enabled": reg.enabled if reg else runtime.get("enabled", False),
+            "pid": reg.pid if reg else None,
+            "heartbeat_interval_sec": reg.heartbeat_interval_sec if reg else None,
+            "last_heartbeat_age_sec": heartbeat_age_sec,
+            "runtime": runtime,
+            "recent_events": recent_events,
+            "last_event": last_event,
+            "last_action": last_action,
+        }
+
+    def get_system_live_status(self, *, limit: int = 12) -> Dict[str, Any]:
+        return {
+            "dashboard": self._daemon.get_dashboard(),
+            "recent_events": self.tail_events(limit=limit),
+        }
+
+    def _get_runtime_status(self, dae_id: str) -> Dict[str, Any]:
+        try:
+            from modules.infrastructure.dae_daemon.src.dae_launch_broker import get_dae_launch_broker
+
+            broker = get_dae_launch_broker()
+        except Exception:
+            return {}
+
+        try:
+            return broker.get_runtime_status(dae_id)
+        except Exception:
+            return {}
+
+    @staticmethod
+    def _event_to_dict(event: Any) -> Dict[str, Any]:
+        payload = dict(event.payload or {})
+        return {
+            "sequence_id": event.sequence_id,
+            "event_id": event.event_id,
+            "event_type": event.event_type.value,
+            "dae_id": event.dae_id,
+            "actor_id": event.actor_id,
+            "timestamp": event.timestamp,
+            "payload": payload,
+        }
+
+
+def get_dae_observer(daemon=None) -> DAEObserver:
+    global _dae_observer
+    with _observer_lock:
+        if _dae_observer is None:
+            _dae_observer = DAEObserver(daemon=daemon)
+        return _dae_observer
+
+
+def reset_dae_observer() -> None:
+    global _dae_observer
+    with _observer_lock:
+        _dae_observer = None

--- a/modules/infrastructure/dae_daemon/src/event_store.py
+++ b/modules/infrastructure/dae_daemon/src/event_store.py
@@ -230,6 +230,54 @@ class DAEEventStore:
             )
         return events
 
+    def query_recent(
+        self,
+        event_type: Optional[str] = None,
+        dae_id: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[DAEEvent]:
+        """Return the most recent events, ordered oldest->newest within the window."""
+        conditions = ["1=1"]
+        params: List[Any] = []
+
+        if event_type:
+            conditions.append("event_type = ?")
+            params.append(event_type)
+        if dae_id:
+            conditions.append("dae_id = ?")
+            params.append(dae_id)
+
+        where_clause = " AND ".join(conditions)
+        params.append(limit)
+
+        with self._connect() as conn:
+            cursor = conn.execute(
+                f"""
+                SELECT * FROM dae_events
+                WHERE {where_clause}
+                ORDER BY sequence_id DESC
+                LIMIT ?
+                """,
+                tuple(params),
+            )
+            rows = list(reversed(cursor.fetchall()))
+
+        events = []
+        for row in rows:
+            events.append(
+                DAEEvent(
+                    event_id=row["event_id"],
+                    sequence_id=row["sequence_id"],
+                    dedupe_key=row["dedupe_key"],
+                    event_type=DAEEventType(row["event_type"]),
+                    dae_id=row["dae_id"],
+                    actor_id=row["actor_id"] or "system",
+                    payload=json.loads(row["payload_json"] or "{}"),
+                    timestamp=row["timestamp"],
+                )
+            )
+        return events
+
     # ------------------------------------------------------------------
     # Stats / Parity
     # ------------------------------------------------------------------

--- a/modules/infrastructure/dae_daemon/tests/TestModLog.md
+++ b/modules/infrastructure/dae_daemon/tests/TestModLog.md
@@ -42,3 +42,15 @@ MessageBoxW mocked to no-op in test environment.
 
 **Result**:
 - `3 passed`
+
+## V1.3.0 - DAEmon Observer Tests (2026-03-17)
+
+**Created**: `test_dae_observer.py`
+- validates recent event tail retrieval for a registered DAE
+- validates live status snapshots combine registry state and recent event history
+
+**Run**:
+- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest modules/infrastructure/dae_daemon/tests/test_dae_observer.py -q`
+
+**Result**:
+- `2 passed`

--- a/modules/infrastructure/dae_daemon/tests/test_dae_observer.py
+++ b/modules/infrastructure/dae_daemon/tests/test_dae_observer.py
@@ -1,0 +1,76 @@
+"""DAE observer read-surface tests."""
+
+from modules.infrastructure.dae_daemon.src.dae_daemon import (
+    get_central_daemon,
+    reset_central_daemon,
+)
+from modules.infrastructure.dae_daemon.src.dae_launch_broker import (
+    get_dae_launch_broker,
+    reset_dae_launch_broker,
+)
+from modules.infrastructure.dae_daemon.src.dae_observer import (
+    get_dae_observer,
+    reset_dae_observer,
+)
+from modules.infrastructure.dae_daemon.src.schemas import DAERegistration, DAEEventType
+
+
+class TestDAEObserver:
+    def setup_method(self):
+        reset_dae_observer()
+        reset_dae_launch_broker()
+        reset_central_daemon()
+
+    def teardown_method(self):
+        reset_dae_observer()
+        reset_dae_launch_broker()
+        reset_central_daemon()
+
+    def test_tail_events_returns_recent_activity(self, tmp_path):
+        daemon = get_central_daemon(data_dir=tmp_path / "dae_daemon")
+        daemon.start()
+        daemon.register_dae(
+            DAERegistration(
+                dae_id="openclaw",
+                dae_name="OpenClaw DAE",
+                domain="communication",
+            )
+        )
+        daemon.registry.report_event(
+            "openclaw",
+            DAEEventType.ACTION_PERFORMED,
+            {"action_type": "pqn_simulation", "target": "pqn_theory_archive", "result": "started"},
+        )
+
+        observer = get_dae_observer(daemon=daemon)
+        events = observer.tail_events(dae_id="openclaw", limit=5)
+
+        assert events
+        assert events[-1]["event_type"] == "action_performed"
+        assert events[-1]["payload"]["action_type"] == "pqn_simulation"
+
+    def test_live_status_combines_registry_and_recent_events(self, tmp_path):
+        daemon = get_central_daemon(data_dir=tmp_path / "dae_daemon")
+        daemon.start()
+        daemon.register_dae(
+            DAERegistration(
+                dae_id="openclaw",
+                dae_name="OpenClaw DAE",
+                domain="communication",
+            )
+        )
+        daemon.registry.report_heartbeat("openclaw", {"healthy": True})
+        daemon.registry.report_event(
+            "openclaw",
+            DAEEventType.MESSAGE_IN,
+            {"source": "012", "summary": "tail openclaw"},
+        )
+
+        observer = get_dae_observer(daemon=daemon)
+        snapshot = observer.get_live_status("openclaw", limit=5)
+
+        assert snapshot["registered"] is True
+        assert snapshot["dae_id"] == "openclaw"
+        assert snapshot["state"] in {"registered", "running"}
+        assert snapshot["recent_events"]
+        assert snapshot["last_event"]["event_type"] == "message_in"


### PR DESCRIPTION
## Summary
- add a DAEmon observer read surface for recent event tails and live runtime snapshots
- expose `tail <dae>` and `status <dae> live` through the OpenClaw runtime adapter
- document the new supervision commands and add focused daemon/runtime tests

## Validation
- python -m py_compile modules/infrastructure/dae_daemon/src/event_store.py modules/infrastructure/dae_daemon/src/dae_observer.py modules/infrastructure/dae_daemon/tests/test_dae_observer.py modules/communication/moltbot_bridge/src/dae_runtime_adapter.py modules/communication/moltbot_bridge/tests/test_dae_runtime_adapter.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest modules/infrastructure/dae_daemon/tests/test_dae_observer.py modules/communication/moltbot_bridge/tests/test_dae_runtime_adapter.py modules/communication/moltbot_bridge/tests/test_openclaw_dae_runtime_commands.py -q