### PR TITLE
feat(dae): add cursor follow supervision

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -1,5 +1,28 @@
 # FoundUps Agent - Development Log
 
+## [2026-03-18] DAEmon Cursor-Follow Supervision
+
+**Change Type**: Observability / Runtime Supervision  
+**By**: 0102  
+**WSP References**: WSP 22, WSP 73, WSP 91, WSP 97
+
+### Summary
+
+Upgraded DAEmon supervision from recent-window snapshots to explicit cursor-based follow semantics so `012` and `0102` can incrementally watch runtime activity without relying on a fake streaming loop.
+
+### Files Changed
+
+| Location | Description |
+|----------|-------------|
+| `modules/infrastructure/dae_daemon/src/event_store.py` | Added latest-sequence helper for observer cursors |
+| `modules/infrastructure/dae_daemon/src/dae_observer.py` | Added `follow_events(...)` and cursor fields in live status |
+| `modules/communication/moltbot_bridge/src/dae_runtime_adapter.py` | Added `watch|follow <dae> since <sequence>` runtime contract |
+
+### Why
+
+- `WSP_97` required a real execution-plane cursor, not only “show me the last few events”.
+- This makes DAEmon supervision incremental and machine-usable for future 24/7 control loops.
+
 ## [2026-03-18] OpenClaw Resident Bootstrap Through Broker
 
 **Change Type**: Runtime Control Plane / Bootstrap  

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -155,6 +155,7 @@ Broker-managed runtime commands are now available through OpenClaw:
 - `status openclaw`
 - `status openclaw live`
 - `tail openclaw`
+- `watch openclaw since 42`
 - `status holodae`
 - `launch social media dae`
 - `stop training system`
@@ -173,6 +174,9 @@ Resident OpenClaw contract:
 - `main.py` registers `openclaw` as a launchable DAE using `scripts/launch.py`
 - bootstrap can autostart the resident webhook service after preflight
 - CLI menu option `3` now reuses the broker-managed runtime when available instead of spawning a competing subprocess
+- live supervision now exposes a cursor contract:
+  - `tail <dae>` = recent window
+  - `watch|follow <dae> since <sequence>` = incremental follow with returned `next_cursor`
 
 ### PQN Runtime Control
 

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-03-18: Cursor-based DAE follow commands
+
+**Author**: 0102  
+**WSP**: 22, 73, 91, 97
+
+### Changes
+- Updated `src/dae_runtime_adapter.py`
+  - added `watch|follow <dae> since <sequence>` parsing
+  - preserved `tail <dae>` as the recent-window command
+  - surfaced `next_cursor` in live status formatting
+- Updated `INTERFACE.md`
+  - documented the cursor/follow runtime contract
+
+### Impact
+- OpenClaw runtime supervision is now incremental instead of snapshot-only.
+- `012` and future 0102 loops can continue from a known event cursor without rereading the same tail window.
+
 ## 2026-03-18: Resident OpenClaw broker runtime
 
 **Author**: 0102  

--- a/modules/communication/moltbot_bridge/src/dae_runtime_adapter.py
+++ b/modules/communication/moltbot_bridge/src/dae_runtime_adapter.py
@@ -41,7 +41,8 @@ _DAE_ALIASES: Dict[str, str] = {
 
 _MUTATING_VERBS = ("launch", "start", "stop")
 _STATUS_VERBS = ("status", "show")
-_TAIL_VERBS = ("tail", "watch")
+_TAIL_VERBS = ("tail",)
+_FOLLOW_VERBS = ("watch", "follow")
 _LIST_PATTERNS = (
     "list daes",
     "list launchable daes",
@@ -87,9 +88,17 @@ def parse_dae_runtime_request(message: str) -> Optional[Dict[str, str]]:
     if not msg:
         return None
 
+    cursor_match = re.search(r"\b(?:since|after|cursor)\s+(\d+)\b", msg)
+    since_sequence = int(cursor_match.group(1)) if cursor_match else 0
+
     for pattern in _LIST_PATTERNS:
         if pattern in msg:
-            return {"action": "list", "dae_id": "", "normalized_message": msg}
+            return {
+                "action": "list",
+                "dae_id": "",
+                "normalized_message": msg,
+                "since_sequence": since_sequence,
+            }
 
     action = ""
     if any(msg.startswith(f"{verb} ") or f" {verb} " in msg for verb in _MUTATING_VERBS):
@@ -99,6 +108,8 @@ def parse_dae_runtime_request(message: str) -> Optional[Dict[str, str]]:
                 break
     elif any(msg.startswith(f"{verb} ") or f" {verb} " in msg for verb in _TAIL_VERBS):
         action = "tail"
+    elif any(msg.startswith(f"{verb} ") or f" {verb} " in msg for verb in _FOLLOW_VERBS):
+        action = "follow"
     elif any(msg.startswith(f"{verb} ") or f" {verb} " in msg for verb in _STATUS_VERBS):
         action = "live_status" if " live" in msg or msg.startswith("live ") else "status"
 
@@ -107,10 +118,22 @@ def parse_dae_runtime_request(message: str) -> Optional[Dict[str, str]]:
 
     for alias, dae_id in sorted(_DAE_ALIASES.items(), key=lambda item: len(item[0]), reverse=True):
         if alias in msg:
-            return {"action": action, "dae_id": dae_id, "normalized_message": msg}
+            resolved_action = "follow" if action == "tail" and since_sequence > 0 else action
+            return {
+                "action": resolved_action,
+                "dae_id": dae_id,
+                "normalized_message": msg,
+                "since_sequence": since_sequence,
+            }
 
     if " dae" in msg or msg.endswith("dae"):
-        return {"action": action, "dae_id": "", "normalized_message": msg}
+        resolved_action = "follow" if action == "tail" and since_sequence > 0 else action
+        return {
+            "action": resolved_action,
+            "dae_id": "",
+            "normalized_message": msg,
+            "since_sequence": since_sequence,
+        }
     return None
 
 
@@ -122,7 +145,7 @@ def classify_dae_runtime_category(message: str) -> Optional[str]:
     request = parse_dae_runtime_request(message)
     if not request:
         return None
-    if request["action"] in {"status", "live_status", "tail", "list"}:
+    if request["action"] in {"status", "live_status", "tail", "follow", "list"}:
         return "monitor"
     return "system"
 
@@ -166,6 +189,8 @@ def _format_live_status(snapshot: Dict[str, Any]) -> str:
         lines.append(f"pid={snapshot.get('pid')}")
     if snapshot.get("last_heartbeat_age_sec") is not None:
         lines.append(f"last_heartbeat_age_sec={snapshot.get('last_heartbeat_age_sec')}")
+    if snapshot.get("next_cursor") is not None:
+        lines.append(f"next_cursor={snapshot.get('next_cursor')}")
     if runtime:
         if "running" in runtime:
             lines.append(f"running={runtime.get('running')}")
@@ -183,6 +208,23 @@ def _format_live_status(snapshot: Dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _format_follow_response(follow: Dict[str, Any]) -> str:
+    dae_id = follow.get("dae_id") or "system"
+    since_sequence = follow.get("since_sequence", 0)
+    next_cursor = follow.get("next_cursor", since_sequence)
+    events = follow.get("events", [])
+    lines = [
+        f"DAE follow `{dae_id}`",
+        f"since_sequence={since_sequence}",
+        f"next_cursor={next_cursor}",
+        f"new_events={len(events)}",
+    ]
+    if events:
+        lines.append("events:")
+        lines.extend(f"- {_format_event_line(event)}" for event in events)
+    return "\n".join(lines)
+
+
 def handle_dae_runtime_intent(
     message: str,
     sender: str,
@@ -196,6 +238,7 @@ def handle_dae_runtime_intent(
 
     action = request["action"]
     dae_id = request["dae_id"]
+    since_sequence = int(request.get("since_sequence", 0))
 
     observer = _get_dae_observer()
     broker = _get_launch_broker()
@@ -233,6 +276,16 @@ def handle_dae_runtime_intent(
         lines = [f"DAE event tail `{dae_id}`"]
         lines.extend(f"- {_format_event_line(event)}" for event in events)
         return "\n".join(lines)
+
+    if action == "follow":
+        if observer is None:
+            return "DAE observer is not available yet."
+        follow = observer.follow_events(
+            dae_id=dae_id,
+            since_sequence=since_sequence,
+            limit=8,
+        )
+        return _format_follow_response(follow)
 
     if action == "live_status":
         if observer is None:

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,13 @@
+## 2026-03-18: Cursor-based DAE follow runtime
+
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; python -m pytest modules/communication/moltbot_bridge/tests/test_dae_runtime_adapter.py modules/communication/moltbot_bridge/tests/test_openclaw_dae_runtime_commands.py -q`
+- Status: PASS
+- Notes:
+  - Validates `watch openclaw since <sequence>` parses to the follow path.
+  - Confirms OpenClaw runtime supervision now returns `next_cursor` for incremental polling.
+
+---
+
 ## 2026-03-18: Resident OpenClaw launch contract
 
 - Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; python -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_resident_launch.py modules/communication/moltbot_bridge/tests/test_dae_runtime_adapter.py -q`

--- a/modules/communication/moltbot_bridge/tests/test_dae_runtime_adapter.py
+++ b/modules/communication/moltbot_bridge/tests/test_dae_runtime_adapter.py
@@ -97,6 +97,15 @@ def test_parse_tail_openclaw_request():
     assert request["dae_id"] == "openclaw"
 
 
+def test_parse_watch_openclaw_since_request():
+    request = parse_dae_runtime_request("watch openclaw since 41")
+
+    assert request is not None
+    assert request["action"] == "follow"
+    assert request["dae_id"] == "openclaw"
+    assert request["since_sequence"] == 41
+
+
 def test_live_status_openclaw_uses_observer():
     observer = MagicMock()
     observer.get_live_status.return_value = {
@@ -168,3 +177,41 @@ def test_tail_openclaw_uses_observer():
     observer.tail_events.assert_called_once_with(dae_id="openclaw", limit=8)
     assert "DAE event tail `openclaw`" in result
     assert "pqn_simulation" in result
+
+
+def test_follow_openclaw_uses_cursor_observer():
+    observer = MagicMock()
+    observer.follow_events.return_value = {
+        "dae_id": "openclaw",
+        "since_sequence": 41,
+        "next_cursor": 43,
+        "events": [
+            {
+                "sequence_id": 42,
+                "event_type": "action_performed",
+                "payload": {
+                    "action_type": "launch_requested",
+                    "target": "openclaw",
+                    "result": "ok",
+                },
+            }
+        ],
+    }
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.dae_runtime_adapter._get_dae_observer",
+        return_value=observer,
+    ):
+        result = handle_dae_runtime_intent(
+            "watch openclaw since 41",
+            "012",
+            allow_mutation=False,
+        )
+
+    observer.follow_events.assert_called_once_with(
+        dae_id="openclaw",
+        since_sequence=41,
+        limit=8,
+    )
+    assert "DAE follow `openclaw`" in result
+    assert "next_cursor=43" in result

--- a/modules/infrastructure/dae_daemon/ModLog.md
+++ b/modules/infrastructure/dae_daemon/ModLog.md
@@ -1,5 +1,24 @@
 # dae_daemon ModLog
 
+## V1.2.4 - Cursor-based observer follow mode (2026-03-18)
+
+**What**: Added cursor-based follow semantics on top of the DAEmon event store.
+
+**Why**: Recent-window snapshots were useful for inspection but not strong enough for incremental supervision. `WSP_97` needs a deterministic cursor contract that future control loops can resume from.
+
+**Changes**:
+- `src/event_store.py`
+  - added `get_latest_sequence_id()`
+- `src/dae_observer.py`
+  - added `follow_events(...)`
+  - added `latest_sequence_id` and `next_cursor` to live/system snapshots
+- `README.md`
+  - documented `watch <dae> since <sequence>` follow contract
+
+**Impact**:
+- DAEmon read surfaces can now return an explicit next cursor for incremental polling.
+- This is the first clean step from ad hoc tails toward true 24/7 supervision.
+
 ## V1.2.3 - Resident OpenClaw registered as broker-managed runtime (2026-03-18)
 
 **What**: Extended the runtime broker contract so OpenClaw itself can be treated as a launchable resident DAE instead of only a menu surface.

--- a/modules/infrastructure/dae_daemon/README.md
+++ b/modules/infrastructure/dae_daemon/README.md
@@ -82,6 +82,7 @@ snapshot = observer.get_live_status("pqn_research", limit=8)
 Runtime supervision intent:
 - `tail <dae>` -> recent DAEmon event stream for that DAE
 - `status <dae> live` -> registry state + runtime status + recent event tail
+- `watch <dae> since <sequence>` -> cursor-based incremental follow from a known event id
 - The event store remains the source of truth; the observer is read-only
 
 ## Security Killswitch

--- a/modules/infrastructure/dae_daemon/src/dae_observer.py
+++ b/modules/infrastructure/dae_daemon/src/dae_observer.py
@@ -34,10 +34,38 @@ class DAEObserver:
         )
         return [self._event_to_dict(event) for event in events]
 
+    def follow_events(
+        self,
+        *,
+        dae_id: Optional[str] = None,
+        event_type: Optional[str] = None,
+        since_sequence: int = 0,
+        limit: int = 12,
+    ) -> Dict[str, Any]:
+        """Return events after a known cursor and the next cursor to continue from."""
+        events = self._daemon.event_store.query(
+            dae_id=dae_id,
+            event_type=event_type,
+            since_sequence=since_sequence,
+            limit=limit,
+        )
+        event_dicts = [self._event_to_dict(event) for event in events]
+        latest_sequence = self._daemon.event_store.get_latest_sequence_id()
+        next_cursor = event_dicts[-1]["sequence_id"] if event_dicts else latest_sequence
+        return {
+            "dae_id": dae_id or "",
+            "event_type": event_type or "",
+            "since_sequence": since_sequence,
+            "next_cursor": next_cursor,
+            "latest_sequence_id": latest_sequence,
+            "events": event_dicts,
+        }
+
     def get_live_status(self, dae_id: str, *, limit: int = 8) -> Dict[str, Any]:
         reg = self._daemon.registry.get(dae_id)
         recent_events = self.tail_events(dae_id=dae_id, limit=limit)
         runtime = self._get_runtime_status(dae_id)
+        latest_sequence = self._daemon.event_store.get_latest_sequence_id()
         last_event = recent_events[-1] if recent_events else None
         last_action = None
         for event in reversed(recent_events):
@@ -60,6 +88,8 @@ class DAEObserver:
             "heartbeat_interval_sec": reg.heartbeat_interval_sec if reg else None,
             "last_heartbeat_age_sec": heartbeat_age_sec,
             "runtime": runtime,
+            "latest_sequence_id": latest_sequence,
+            "next_cursor": last_event["sequence_id"] if last_event else latest_sequence,
             "recent_events": recent_events,
             "last_event": last_event,
             "last_action": last_action,
@@ -68,6 +98,7 @@ class DAEObserver:
     def get_system_live_status(self, *, limit: int = 12) -> Dict[str, Any]:
         return {
             "dashboard": self._daemon.get_dashboard(),
+            "latest_sequence_id": self._daemon.event_store.get_latest_sequence_id(),
             "recent_events": self.tail_events(limit=limit),
         }
 

--- a/modules/infrastructure/dae_daemon/src/event_store.py
+++ b/modules/infrastructure/dae_daemon/src/event_store.py
@@ -275,8 +275,15 @@ class DAEEventStore:
                     payload=json.loads(row["payload_json"] or "{}"),
                     timestamp=row["timestamp"],
                 )
-            )
+        )
         return events
+
+    def get_latest_sequence_id(self) -> int:
+        """Return the latest persisted sequence id, or 0 when store is empty."""
+        with self._connect() as conn:
+            cursor = conn.execute("SELECT MAX(sequence_id) FROM dae_events")
+            row = cursor.fetchone()
+        return int(row[0] or 0)
 
     # ------------------------------------------------------------------
     # Stats / Parity

--- a/modules/infrastructure/dae_daemon/tests/TestModLog.md
+++ b/modules/infrastructure/dae_daemon/tests/TestModLog.md
@@ -1,5 +1,17 @@
 # dae_daemon TestModLog
 
+## V1.2.4 - Cursor-based observer follow tests (2026-03-18)
+
+**Updated**: `test_dae_observer.py`
+- validates `follow_events(...)` returns only events beyond a known cursor
+- validates the observer emits a usable `next_cursor` for incremental polling
+
+**Run**:
+- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest modules/infrastructure/dae_daemon/tests/test_dae_observer.py -q`
+
+**Result**:
+- `3 passed`
+
 ## V1.2.1 - Structured Action Details Test (2026-03-16)
 
 **Created**: `test_dae_adapter.py`

--- a/modules/infrastructure/dae_daemon/tests/test_dae_observer.py
+++ b/modules/infrastructure/dae_daemon/tests/test_dae_observer.py
@@ -74,3 +74,33 @@ class TestDAEObserver:
         assert snapshot["state"] in {"registered", "running"}
         assert snapshot["recent_events"]
         assert snapshot["last_event"]["event_type"] == "message_in"
+
+    def test_follow_events_respects_cursor_and_returns_next_cursor(self, tmp_path):
+        daemon = get_central_daemon(data_dir=tmp_path / "dae_daemon")
+        daemon.start()
+        daemon.register_dae(
+            DAERegistration(
+                dae_id="openclaw",
+                dae_name="OpenClaw DAE",
+                domain="communication",
+            )
+        )
+        daemon.registry.report_event(
+            "openclaw",
+            DAEEventType.MESSAGE_IN,
+            {"source": "012", "summary": "first"},
+        )
+        daemon.registry.report_event(
+            "openclaw",
+            DAEEventType.ACTION_PERFORMED,
+            {"action_type": "launch_requested", "target": "openclaw", "result": "ok"},
+        )
+
+        observer = get_dae_observer(daemon=daemon)
+        follow = observer.follow_events(dae_id="openclaw", since_sequence=1, limit=5)
+
+        assert follow["since_sequence"] == 1
+        assert follow["next_cursor"] >= 2
+        assert follow["events"]
+        assert all(event["sequence_id"] > 1 for event in follow["events"])
+        assert follow["events"][-1]["event_type"] == "action_performed"


### PR DESCRIPTION
## Summary
- add cursor-based follow semantics to the DAEmon observer
- expose watch/follow runtime commands with next_cursor output through OpenClaw
- document the follow contract in DAEmon/OpenClaw interfaces and logs

## Validation
- python -m py_compile modules/infrastructure/dae_daemon/src/event_store.py modules/infrastructure/dae_daemon/src/dae_observer.py modules/communication/moltbot_bridge/src/dae_runtime_adapter.py modules/infrastructure/dae_daemon/tests/test_dae_observer.py modules/communication/moltbot_bridge/tests/test_dae_runtime_adapter.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest modules/infrastructure/dae_daemon/tests/test_dae_observer.py modules/communication/moltbot_bridge/tests/test_dae_runtime_adapter.py modules/communication/moltbot_bridge/tests/test_openclaw_dae_runtime_commands.py -q

## WSP 97
- upgrades the supervision plane from recent-window snapshots to explicit cursor follow semantics
- keeps execution deterministic by returning next_cursor instead of pretending there is a true streaming channel