### PR TITLE
feat(pqn): broker-manage theory simulation runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,4 @@ youtube_foundups/
 modules/platform_integration/antifafm_broadcaster/assets/backgrounds/*.mp4
 campaign_results/
 tools/gitleaks/
+modules/ai_intelligence/pqn_alignment/artifact_results/theory_archive_simulation/

--- a/ModLog.md
+++ b/ModLog.md
@@ -55900,3 +55900,11 @@ if cooldown_sets:
   - `tail <dae>`
   - `status <dae> live`
 - Added `openclaw` / `claw` / `0102` daemon aliases so 012 can supervise Claw directly through OpenClaw.
+
+## 2026-03-18: PQN simulation moved into broker-managed runtime lane
+- Added `run_pqn_simulation_once()` in `modules/ai_intelligence/pqn/scripts/launch.py` as the broker-facing one-shot launch hook.
+- Registered `pqn_simulation` in `main.bootstrap_runtime_dae_launches()` so the runtime becomes visible to Claw and DAEmon like the other launchable DAEs.
+- Updated `modules/communication/moltbot_bridge/src/pqn_research_adapter.py` so:
+  - `show pqn simulation plan` stays a read-only research query
+  - `run|launch|status|stop pqn simulation` routes through the broker-managed runtime lane
+- Extended `dae_runtime_adapter.py` aliases so generic runtime commands can supervise `pqn_simulation`.

--- a/main.py
+++ b/main.py
@@ -183,6 +183,7 @@ from modules.ai_intelligence.pqn.scripts.launch import (
     run_pqn_dae,
     run_pqn_research_session,
     run_pqn_architect_once,
+    run_pqn_simulation_once,
 )
 
 # Extracted to modules/platform_integration/youtube_shorts_scheduler/scripts/launch.py per WSP 62
@@ -823,6 +824,15 @@ def bootstrap_runtime_dae_launches() -> None:
             start_callable=run_pqn_architect_once,
             heartbeat_interval_sec=15.0,
             description="Non-interactive PQN architect cycle.",
+        ),
+        DAELaunchSpec(
+            dae_id="pqn_simulation",
+            dae_name="PQN Theory-Archive Simulation",
+            domain="ai_intelligence",
+            module_path="modules.ai_intelligence.pqn.scripts.launch",
+            start_callable=run_pqn_simulation_once,
+            heartbeat_interval_sec=15.0,
+            description="Broker-managed PQN simulation against the theory archive.",
         ),
     ])
     for spec in specs:

--- a/modules/ai_intelligence/pqn/scripts/launch.py
+++ b/modules/ai_intelligence/pqn/scripts/launch.py
@@ -317,5 +317,26 @@ def run_pqn_research_session(
         "results_path": str(output_path) if output_path else "",
     }
 
+
+def run_pqn_simulation_once(config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Run one broker-managed PQN theory-archive simulation cycle."""
+    from modules.ai_intelligence.pqn_alignment.src.pqn_alignment_dae import (
+        PQNAlignmentDAE,
+    )
+
+    dae = PQNAlignmentDAE()
+    result = dae.run_theory_archive_simulation(config=config or {})
+    comparison = result.get("comparison", {})
+    interpretation = result.get("interpretation", {})
+
+    return {
+        "status": interpretation.get("outcome", "completed"),
+        "summary_path": result.get("summary_path", ""),
+        "run_count": len(result.get("runs", [])),
+        "probe_closer_to_target": comparison.get("probe_closer_to_target", False),
+        "validated_truth": interpretation.get("validated_truth", False),
+        "archive_informed": interpretation.get("archive_informed", True),
+    }
+
 if __name__ == "__main__":
     run_pqn_dae()

--- a/modules/ai_intelligence/pqn/tests/TestModLog.md
+++ b/modules/ai_intelligence/pqn/tests/TestModLog.md
@@ -1,0 +1,10 @@
+# TestModLog - PQN runtime launch tests
+
+## 2026-03-18: PQN simulation launch hook coverage
+
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; python -m pytest modules/ai_intelligence/pqn/tests/test_launch_runtime.py -q`
+- Status: PASS
+- Result: `1 passed`
+- Notes:
+  - Confirms `run_pqn_simulation_once()` returns a broker-friendly summary payload.
+  - Confirms the launch hook preserves comparative simulation semantics (`validated_truth=False`).

--- a/modules/ai_intelligence/pqn/tests/test_launch_runtime.py
+++ b/modules/ai_intelligence/pqn/tests/test_launch_runtime.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+
+from modules.ai_intelligence.pqn.scripts.launch import run_pqn_simulation_once
+
+
+def test_run_pqn_simulation_once_returns_broker_friendly_summary():
+    fake_result = {
+        "runs": [{}, {}, {}],
+        "summary_path": "modules/ai_intelligence/pqn_alignment/artifact_results/theory_archive_simulation/summary.json",
+        "comparison": {
+            "probe_closer_to_target": True,
+        },
+        "interpretation": {
+            "outcome": "probe_advantage_requires_followup",
+            "validated_truth": False,
+            "archive_informed": True,
+        },
+    }
+
+    with patch(
+        "modules.ai_intelligence.pqn_alignment.src.pqn_alignment_dae.PQNAlignmentDAE",
+    ) as dae_cls:
+        dae_cls.return_value.run_theory_archive_simulation.return_value = fake_result
+        result = run_pqn_simulation_once()
+
+    assert result["status"] == "probe_advantage_requires_followup"
+    assert result["run_count"] == 3
+    assert result["probe_closer_to_target"] is True
+    assert result["validated_truth"] is False

--- a/modules/ai_intelligence/pqn_alignment/INTERFACE.md
+++ b/modules/ai_intelligence/pqn_alignment/INTERFACE.md
@@ -102,6 +102,7 @@ Non-interactive runtime entrypoints used by the central DAE launch broker live i
 Broker-facing entrypoints:
 - `run_pqn_research_session(selected_agents=None, session_name="PQN_Research", save_results=True)`
 - `run_pqn_architect_once()`
+- `run_pqn_simulation_once(config: Optional[Dict[str, Any]] = None)`
 
 This keeps `main.py` responsible for readiness/bootstrap while `0102` launches
 research cycles through the broker at runtime.

--- a/modules/ai_intelligence/pqn_alignment/ModLog.md
+++ b/modules/ai_intelligence/pqn_alignment/ModLog.md
@@ -441,3 +441,14 @@
 - **WSP Compliance**: WSP 84 (reuse), WSP 48 (recursive), WSP 80 (DAE orchestration), WSP 34 (tests), WSP 22 (docs).
 - **Impact**: Enables 0102-driven PQN research; quantifies 0201 alignment benefits (e.g., exponential remembrance velocity).
 - **Next Steps**: Execute full campaign; enhance guardrail; integrate with WRE.
+
+### **PQN Simulation Runtime Broker Alignment**
+- **Date**: 2026-03-18
+- **Operating As**: 0102 / PQN runtime control-plane integration
+- **Change**: Moved theory-archive simulation execution into the broker-managed DAE runtime lane.
+- **Details**:
+  - Added `run_pqn_simulation_once()` as a one-shot launch hook in `modules/ai_intelligence/pqn/scripts/launch.py`
+  - Registered `pqn_simulation` during `main.py` runtime bootstrap
+  - Preserved `show pqn simulation plan` as a read-only archive/planning query
+- **WSP Compliance**: WSP 22 (documentation), WSP 84 (reuse existing detector/simulation surface), WSP 97 (separate planning from execution)
+- **Impact**: PQN simulation now participates in the same launch/status/supervision model as the other resident runtime lanes.

--- a/modules/ai_intelligence/pqn_alignment/README.md
+++ b/modules/ai_intelligence/pqn_alignment/README.md
@@ -133,6 +133,8 @@ Operational rule:
 - `main.py` should start **PQN research readiness**
 - OpenClaw should start **actual PQN research sessions**
 - full autonomous research startup should be policy-gated, not default
+- `pqn_simulation` is now a broker-managed one-shot runtime lane
+- `show pqn simulation plan` remains a read-only research/planning query
 
 ## **2026-03 Evidence Intake**
 

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -198,15 +198,27 @@ PQN simulation can now be triggered directly through research intent phrases:
 - `run pqn simulation`
 - `launch pqn simulation`
 - `status pqn simulation`
+- `stop pqn simulation`
+- `tail pqn simulation`
+- `watch pqn simulation since 42`
 - `show pqn simulation plan`
 
 Routing contract:
-- OpenClaw -> `pqn_research_adapter.py`
-- `pqn_research_adapter.py` -> `PQNAlignmentDAE.run_theory_archive_simulation(...)`
-- PQN simulation lifecycle -> OpenClaw DAEmon action ledger
+- `run|launch|status|stop pqn simulation`:
+  - OpenClaw deterministic runtime classification or `pqn_research_adapter.py`
+  - `DAELaunchBroker`
+  - `modules/ai_intelligence/pqn/scripts/launch.py:run_pqn_simulation_once()`
+- `show pqn simulation plan`:
+  - OpenClaw RESEARCH route
+  - `pqn_research_adapter.py`
+  - `PQNAlignmentDAE.get_theory_archive_simulation_plan(...)`
+- supervision:
+  - generic DAE runtime observer surface
+  - `tail|watch pqn simulation ...`
 
 Operational rule:
-- simulation is a research action, not a broker-managed DAE
+- simulation execution is a broker-managed runtime lane
+- simulation planning remains a read-only research query
 - archive remains hypothesis input only
 - returned interpretation remains comparative, not ontological
 

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1183,3 +1183,19 @@ openclaw onboard
 ### Outcome
 - 012 can inspect the DAEmon ledger through OpenClaw instead of reading raw logs.
 - Claw and PQN runtime activity now has a real supervision surface, not just event persistence.
+
+## 2026-03-18: PQN simulation broker/runtime alignment
+
+**Author**: 0102  
+**WSP**: 22, 73, 84, 97
+
+### Changes
+- Extended `src/dae_runtime_adapter.py` aliases and parsing so `pqn_simulation` is a first-class runtime target.
+- Added deterministic separation:
+  - `show pqn simulation plan` stays on the RESEARCH/read path
+  - `run|launch|status|stop pqn simulation` routes to runtime control
+- Updated `src/pqn_research_adapter.py` to delegate simulation execution/status/stop to the central broker instead of instantiating `PQNAlignmentDAE` inline.
+
+### Outcome
+- PQN simulation now behaves like the rest of the launchable runtime system instead of bypassing it.
+- Claw, DAEmon, and the broker now share one execution ledger for PQN simulation lifecycle events.

--- a/modules/communication/moltbot_bridge/README.md
+++ b/modules/communication/moltbot_bridge/README.md
@@ -116,6 +116,12 @@ Runtime examples:
 - `tail openclaw`
 - `stop openclaw`
 
+PQN runtime examples:
+- `run pqn simulation`
+- `status pqn simulation`
+- `tail pqn simulation`
+- `show pqn simulation plan`
+
 ### Memory Writeback (WSP 60 / WSP 48)
 
 Standalone action runs are now persisted into WRE PatternMemory as `skill_outcomes`

--- a/modules/communication/moltbot_bridge/src/dae_runtime_adapter.py
+++ b/modules/communication/moltbot_bridge/src/dae_runtime_adapter.py
@@ -37,9 +37,11 @@ _DAE_ALIASES: Dict[str, str] = {
     "training dae": "training_system",
     "pqn research": "pqn_research",
     "pqn architect": "pqn_architect",
+    "pqn simulation": "pqn_simulation",
+    "theory archive simulation": "pqn_simulation",
 }
 
-_MUTATING_VERBS = ("launch", "start", "stop")
+_MUTATING_VERBS = ("launch", "start", "run", "stop")
 _STATUS_VERBS = ("status", "show")
 _TAIL_VERBS = ("tail",)
 _FOLLOW_VERBS = ("watch", "follow")
@@ -88,6 +90,9 @@ def parse_dae_runtime_request(message: str) -> Optional[Dict[str, str]]:
     if not msg:
         return None
 
+    if "simulation plan" in msg:
+        return None
+
     cursor_match = re.search(r"\b(?:since|after|cursor)\s+(\d+)\b", msg)
     since_sequence = int(cursor_match.group(1)) if cursor_match else 0
 
@@ -104,7 +109,7 @@ def parse_dae_runtime_request(message: str) -> Optional[Dict[str, str]]:
     if any(msg.startswith(f"{verb} ") or f" {verb} " in msg for verb in _MUTATING_VERBS):
         for verb in _MUTATING_VERBS:
             if msg.startswith(f"{verb} ") or f" {verb} " in msg:
-                action = verb
+                action = "launch" if verb == "run" else verb
                 break
     elif any(msg.startswith(f"{verb} ") or f" {verb} " in msg for verb in _TAIL_VERBS):
         action = "tail"

--- a/modules/communication/moltbot_bridge/src/openclaw_intent_planner.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_intent_planner.py
@@ -117,6 +117,32 @@ def classify_intent(
         )
         return intent
 
+    if "pqn simulation plan" in msg_lower or "theory archive simulation plan" in msg_lower:
+        category = dae.IntentCategory.RESEARCH
+        confidence = 0.95
+        extracted_task = message
+        intent = dae.OpenClawIntent(
+            raw_message=message,
+            category=category,
+            confidence=confidence,
+            sender=sender,
+            channel=channel,
+            session_key=session_key,
+            is_authorized_commander=is_commander,
+            extracted_task=extracted_task,
+            target_domain=dae.DOMAIN_ROUTES.get(category),
+            metadata={**metadata, "classification_method": "deterministic_pqn_simulation_plan"},
+        )
+        logger.info(
+            "[OPENCLAW-DAE] Intent classified (pqn_simulation_plan): category=%s confidence=%.2f "
+            "commander=%s domain=%s",
+            category.value,
+            confidence,
+            is_commander,
+            intent.target_domain,
+        )
+        return intent
+
     if classify_dae_runtime_category is not None:
         runtime_category = classify_dae_runtime_category(message)
         if runtime_category is not None:

--- a/modules/communication/moltbot_bridge/src/pqn_research_adapter.py
+++ b/modules/communication/moltbot_bridge/src/pqn_research_adapter.py
@@ -46,11 +46,15 @@ _SIMULATION_KEYWORDS = [
     "run pqn simulation",
     "launch pqn simulation",
     "start pqn simulation",
+    "stop pqn simulation",
     "status pqn simulation",
     "show pqn simulation",
     "show pqn simulation plan",
     "show theory archive simulation",
     "run theory archive simulation",
+    "launch theory archive simulation",
+    "start theory archive simulation",
+    "stop theory archive simulation",
     "status theory archive simulation",
 ]
 
@@ -225,13 +229,13 @@ def _handle_simulation(
     sender: str,
     report_action: Optional[Callable[..., None]] = None,
 ) -> str:
-    """Run or inspect the theory-archive simulation through PQNAlignmentDAE."""
-    from modules.ai_intelligence.pqn_alignment import PQNAlignmentDAE
-
+    """Run or inspect the theory-archive simulation through the runtime broker."""
     msg_lower = message.lower()
-    dae = PQNAlignmentDAE()
 
-    if "status " in msg_lower or "show " in msg_lower or " plan" in msg_lower:
+    if " plan" in msg_lower:
+        from modules.ai_intelligence.pqn_alignment import PQNAlignmentDAE
+
+        dae = PQNAlignmentDAE()
         plan = dae.get_theory_archive_simulation_plan()
         _emit_action(
             report_action,
@@ -251,47 +255,80 @@ def _handle_simulation(
             f"out_root={plan.get('out_root', 'unknown')}"
         )
 
-    _emit_action(
-        report_action,
-        "pqn_simulation",
-        "pqn_theory_archive",
-        "started",
-        sender=sender,
-    )
-    try:
-        result = dae.run_theory_archive_simulation()
-    except Exception as exc:
+    broker = _get_launch_broker()
+    if broker is None:
         _emit_action(
             report_action,
             "pqn_simulation",
             "pqn_theory_archive",
-            "error",
+            "broker_unavailable",
             sender=sender,
-            error=str(exc)[:200],
         )
-        raise
+        return (
+            "PQN runtime broker is not available. Start the system through `python main.py` "
+            "so 0102 can bootstrap broker-managed simulation runs."
+        )
 
-    interpretation = result.get("interpretation", {})
-    comparison = result.get("comparison", {})
+    dae_id = "pqn_simulation"
+
+    if "launch " in msg_lower or "start " in msg_lower or "run " in msg_lower:
+        result = broker.start_dae(dae_id, actor_id=sender)
+        _emit_action(
+            report_action,
+            "pqn_simulation_runtime",
+            dae_id,
+            result.get("status", result.get("error", "unknown")),
+            action="launch",
+            sender=sender,
+        )
+        if result.get("error") == "not_registered":
+            return (
+                "PQN simulation runtime is not registered yet. "
+                "Launch through `python main.py` so 0102 can bootstrap launchable DAEs."
+            )
+        status = result.get("status", result.get("error", "unknown"))
+        return (
+            f"PQN simulation launch `{dae_id}` -> {status}.\n"
+            f"started_at={result.get('started_at', 0)}"
+        )
+
+    if "stop " in msg_lower:
+        result = broker.stop_dae(dae_id, actor_id=sender)
+        _emit_action(
+            report_action,
+            "pqn_simulation_runtime",
+            dae_id,
+            result.get("status", result.get("error", "unknown")),
+            action="stop",
+            sender=sender,
+        )
+        status = result.get("status", result.get("error", "unknown"))
+        if result.get("error") == "not_running":
+            return f"PQN simulation runtime `{dae_id}` is not running."
+        return f"PQN simulation stop `{dae_id}` -> {status}."
+
+    result = broker.get_runtime_status(dae_id)
     _emit_action(
         report_action,
-        "pqn_simulation",
-        "pqn_theory_archive",
-        "completed",
+        "pqn_simulation_runtime",
+        dae_id,
+        result.get("state", "unknown"),
+        action="status",
         sender=sender,
-        outcome=interpretation.get("outcome", "unknown"),
-        run_count=len(result.get("runs", [])),
-        summary_path=result.get("summary_path", ""),
-        delta_entrainment_score=comparison.get("delta_entrainment_score", 0.0),
-        delta_resonance_event_count=comparison.get("delta_resonance_event_count", 0.0),
+        running=result.get("running", False),
     )
+    if not result.get("registered"):
+        return (
+            "PQN simulation runtime is not registered yet. "
+            "Launch through `python main.py` so 0102 can bootstrap launchable DAEs."
+        )
     return (
-        "**PQN Theory-Archive Simulation Complete**\n\n"
-        f"outcome={interpretation.get('outcome', 'unknown')}\n"
-        f"delta_entrainment_score={comparison.get('delta_entrainment_score', 0.0):.3f}\n"
-        f"delta_resonance_event_count={comparison.get('delta_resonance_event_count', 0.0):.3f}\n"
-        f"probe_closer_to_target={comparison.get('probe_closer_to_target', False)}\n"
-        f"summary_path={result.get('summary_path', 'unknown')}"
+        f"PQN simulation status `{dae_id}`\n"
+        f"state={result.get('state')}\n"
+        f"running={result.get('running')}\n"
+        f"enabled={result.get('enabled')}\n"
+        f"run_count={result.get('run_count')}\n"
+        f"last_error={result.get('last_error') or 'none'}"
     )
 
 

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -334,3 +334,12 @@
 - Notes:
   - Confirms `tail <dae>` and `status <dae> live` classify as monitor intents.
   - Confirms OpenClaw runtime supervision for `openclaw` routes through the new DAEmon observer path.
+
+## 2026-03-18: PQN simulation runtime alignment coverage
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; python -m pytest modules/communication/moltbot_bridge/tests/test_pqn_research_adapter.py modules/communication/moltbot_bridge/tests/test_dae_runtime_adapter.py modules/communication/moltbot_bridge/tests/test_openclaw_dae_runtime_commands.py -q`
+- Status: PASS
+- Result: `25 passed`
+- Notes:
+  - Confirms `run pqn simulation` is now classified as broker/runtime control instead of inline research execution.
+  - Confirms `show pqn simulation plan` stays on the RESEARCH read path.
+  - Confirms `pqn_simulation` is visible to generic DAE runtime supervision commands.

--- a/modules/communication/moltbot_bridge/tests/test_dae_runtime_adapter.py
+++ b/modules/communication/moltbot_bridge/tests/test_dae_runtime_adapter.py
@@ -15,6 +15,20 @@ def test_parse_launch_social_media_dae():
     assert request["dae_id"] == "social_media"
 
 
+def test_parse_launch_pqn_simulation_runtime():
+    request = parse_dae_runtime_request("run pqn simulation")
+
+    assert request is not None
+    assert request["action"] == "launch"
+    assert request["dae_id"] == "pqn_simulation"
+
+
+def test_parse_show_pqn_simulation_plan_stays_out_of_runtime_adapter():
+    request = parse_dae_runtime_request("show pqn simulation plan")
+
+    assert request is None
+
+
 def test_classify_status_as_monitor():
     assert classify_dae_runtime_category("status holodae") == "monitor"
     assert classify_dae_runtime_category("list launchable daes") == "monitor"

--- a/modules/communication/moltbot_bridge/tests/test_openclaw_dae_runtime_commands.py
+++ b/modules/communication/moltbot_bridge/tests/test_openclaw_dae_runtime_commands.py
@@ -76,21 +76,56 @@ def test_execute_monitor_routes_to_dae_runtime_adapter():
     assert "Launchable DAEs" in response
 
 
-def test_execute_research_passes_daemon_reporter():
+def test_classify_run_pqn_simulation_as_system_runtime():
+    dae = OpenClawDAE(repo_root=PROJECT_ROOT)
+
+    intent = dae.classify_intent(
+        message="run pqn simulation",
+        sender="012",
+        channel="discord",
+        session_key="runtime-5a",
+    )
+
+    assert intent.category == IntentCategory.SYSTEM
+    assert intent.metadata["classification_method"] == "deterministic_dae_runtime"
+
+
+def test_execute_system_routes_pqn_simulation_to_dae_runtime_adapter():
     dae = OpenClawDAE(repo_root=PROJECT_ROOT)
     intent = dae.classify_intent(
         message="run pqn simulation",
         sender="012",
         channel="discord",
-        session_key="runtime-5",
+        session_key="runtime-5b",
     )
 
     with patch(
+        "modules.communication.moltbot_bridge.src.dae_runtime_adapter.handle_dae_runtime_intent",
+        return_value="PQN simulation launch `pqn_simulation` -> starting.",
+    ) as mocked:
+        response = dae._execute_system(intent)
+
+    mocked.assert_called_once()
+    assert "pqn_simulation" in response
+
+
+def test_show_pqn_simulation_plan_stays_on_research_route():
+    dae = OpenClawDAE(repo_root=PROJECT_ROOT)
+    intent = dae.classify_intent(
+        message="show pqn simulation plan",
+        sender="012",
+        channel="discord",
+        session_key="runtime-5c",
+    )
+
+    assert intent.category == IntentCategory.RESEARCH
+
+    with patch(
         "modules.communication.moltbot_bridge.src.pqn_research_adapter.handle_pqn_research_intent",
-        return_value="**PQN Theory-Archive Simulation Complete**",
+        return_value="**PQN Theory-Archive Simulation Plan**",
     ) as mocked:
         response = dae._execute_research(intent)
 
     mocked.assert_called_once()
     assert mocked.call_args.kwargs["report_action"] == dae._report_daemon_action
-    assert "Simulation Complete" in response
+    assert "Simulation Plan" in response

--- a/modules/communication/moltbot_bridge/tests/test_pqn_research_adapter.py
+++ b/modules/communication/moltbot_bridge/tests/test_pqn_research_adapter.py
@@ -65,7 +65,7 @@ class TestPQNResearchAdapterRuntimeControl:
 
         assert "runtime broker is not available" in result.lower()
 
-    def test_status_pqn_simulation_returns_plan(self):
+    def test_show_pqn_simulation_plan_returns_plan(self):
         reporter = MagicMock()
         fake_plan = {
             "run_count": 6,
@@ -82,7 +82,7 @@ class TestPQNResearchAdapterRuntimeControl:
         ) as dae_cls:
             dae_cls.return_value.get_theory_archive_simulation_plan.return_value = fake_plan
             result = handle_pqn_research_intent(
-                "status pqn simulation",
+                "show pqn simulation plan",
                 "012",
                 report_action=reporter,
             )
@@ -92,34 +92,26 @@ class TestPQNResearchAdapterRuntimeControl:
         reporter.assert_called_once()
         assert reporter.call_args.args[0] == "pqn_simulation_plan"
 
-    def test_run_pqn_simulation_reports_completion(self):
+    def test_run_pqn_simulation_uses_broker_runtime(self):
         reporter = MagicMock()
-        fake_result = {
-            "runs": [{}, {}, {}],
-            "summary_path": "modules/ai_intelligence/pqn_alignment/artifact_results/theory_archive_simulation/summary.json",
-            "comparison": {
-                "delta_entrainment_score": 0.21,
-                "delta_resonance_event_count": 2.0,
-                "probe_closer_to_target": True,
-            },
-            "interpretation": {
-                "outcome": "probe_advantage_requires_followup",
-            },
+        broker = MagicMock()
+        broker.start_dae.return_value = {
+            "status": "starting",
+            "started_at": 456.0,
         }
 
         with patch(
-            "modules.ai_intelligence.pqn_alignment.PQNAlignmentDAE",
-        ) as dae_cls:
-            dae_cls.return_value.run_theory_archive_simulation.return_value = fake_result
+            "modules.communication.moltbot_bridge.src.pqn_research_adapter._get_launch_broker",
+            return_value=broker,
+        ):
             result = handle_pqn_research_intent(
                 "run pqn simulation",
                 "012",
                 report_action=reporter,
             )
 
-        assert "PQN Theory-Archive Simulation Complete" in result
-        assert "probe_advantage_requires_followup" in result
-        assert reporter.call_count == 2
-        assert reporter.call_args_list[0].args[0] == "pqn_simulation"
-        assert reporter.call_args_list[0].args[2] == "started"
-        assert reporter.call_args_list[1].args[2] == "completed"
+        broker.start_dae.assert_called_once_with("pqn_simulation", actor_id="012")
+        assert "PQN simulation launch `pqn_simulation` -> starting." in result
+        reporter.assert_called_once()
+        assert reporter.call_args.args[0] == "pqn_simulation_runtime"
+        assert reporter.call_args.args[2] == "starting"

--- a/modules/infrastructure/dae_daemon/README.md
+++ b/modules/infrastructure/dae_daemon/README.md
@@ -60,6 +60,11 @@ broker.register_launch_spec(
 broker.start_dae("pqn_research", actor_id="012")
 ```
 
+Broker-managed one-shot runtimes can also expose analysis lanes such as:
+- `pqn_research`
+- `pqn_architect`
+- `pqn_simulation`
+
 Runtime intent:
 - `main.py` bootstraps launchable specs
 - OpenClaw or another controller asks broker to `start/status/stop`

--- a/tests/TestModLog.md
+++ b/tests/TestModLog.md
@@ -8,6 +8,14 @@
   - Confirms `main.bootstrap_runtime_dae_launches()` registers `openclaw` as a broker-managed launch spec.
   - Confirms resident OpenClaw autostart requests the broker path instead of remaining menu-only.
 
+## 2026-03-18: Main bootstrap PQN simulation registration
+
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; python -m pytest tests/test_main_runtime_bootstrap.py -q`
+- Status: PASS
+- Notes:
+  - Confirms `main.bootstrap_runtime_dae_launches()` registers `pqn_simulation` as a launchable broker spec.
+  - Confirms the simulation lane is bootstrapped alongside the other PQN runtime entrypoints.
+
 ---
 
 ## 2026-03-08: Markdown sanitizer coverage

--- a/tests/test_main_runtime_bootstrap.py
+++ b/tests/test_main_runtime_bootstrap.py
@@ -23,3 +23,24 @@ def test_bootstrap_runtime_dae_launches_registers_openclaw(monkeypatch):
     assert len(openclaw_specs) == 1
     assert openclaw_specs[0].stop_callable is not None
     broker.start_dae.assert_called_once_with("openclaw", actor_id="0102")
+
+
+def test_bootstrap_runtime_dae_launches_registers_pqn_simulation(monkeypatch):
+    daemon = MagicMock()
+    daemon.running = True
+    broker = MagicMock()
+    broker.list_launchable_daes.return_value = {"openclaw": {}, "pqn_simulation": {}}
+    broker.get_runtime_status.return_value = {"running": True}
+
+    monkeypatch.setenv("OPENCLAW_RESIDENT_ENABLED", "1")
+    monkeypatch.setenv("OPENCLAW_RESIDENT_AUTOSTART", "1")
+
+    with patch.object(main, "get_central_daemon", return_value=daemon), patch.object(
+        main, "get_dae_launch_broker", return_value=broker
+    ):
+        main.bootstrap_runtime_dae_launches()
+
+    specs = [call.args[0] for call in broker.register_launch_spec.call_args_list]
+    simulation_specs = [spec for spec in specs if spec.dae_id == "pqn_simulation"]
+    assert len(simulation_specs) == 1
+    assert simulation_specs[0].start_callable is main.run_pqn_simulation_once


### PR DESCRIPTION
## Summary
- add broker-managed pqn_simulation runtime entrypoint and startup registration
- route PQN simulation launch/status/stop through the runtime control plane while keeping show pqn simulation plan read-only
- add targeted runtime, adapter, and bootstrap regression coverage

## Validation
- python -m py_compile main.py modules/ai_intelligence/pqn/scripts/launch.py modules/communication/moltbot_bridge/src/dae_runtime_adapter.py modules/communication/moltbot_bridge/src/pqn_research_adapter.py modules/communication/moltbot_bridge/src/openclaw_intent_planner.py modules/ai_intelligence/pqn/tests/test_launch_runtime.py modules/communication/moltbot_bridge/tests/test_pqn_research_adapter.py modules/communication/moltbot_bridge/tests/test_dae_runtime_adapter.py modules/communication/moltbot_bridge/tests/test_openclaw_dae_runtime_commands.py tests/test_main_runtime_bootstrap.py
- ='1'; python -m pytest modules/ai_intelligence/pqn/tests/test_launch_runtime.py modules/communication/moltbot_bridge/tests/test_pqn_research_adapter.py modules/communication/moltbot_bridge/tests/test_dae_runtime_adapter.py modules/communication/moltbot_bridge/tests/test_openclaw_dae_runtime_commands.py tests/test_main_runtime_bootstrap.py -q