### PR TITLE
fix(livechat): add session recovery for account rotation

### DIFF
--- a/modules/communication/livechat/ModLog.md
+++ b/modules/communication/livechat/ModLog.md
@@ -10,6 +10,31 @@ This log tracks changes specific to the **livechat** module in the **communicati
 
 ---
 
+## 2026-03-18 - Session Recovery for Account Rotation
+
+**By:** 0102
+**WSP References:** WSP 22 (ModLog), WSP 91 (Observability)
+
+### Problem
+
+Chrome/Edge browser sessions can die (timeout, crash, disconnect) causing "invalid session id" errors. The account rotation code would log the error but not attempt recovery, blocking video indexing (Chrome-only) and comment engagement rotation.
+
+### Fix
+
+Added session recovery logic to `auto_moderator_dae.py` (lines 799-818):
+1. Detect session errors using `_is_session_error()`
+2. Reset switcher driver to None (force reconnect)
+3. Call `_connect_to_chrome()` to establish new session
+4. Retry the account switch operation
+
+### Impact
+
+- Video indexing can resume after browser session dies
+- Account rotation recovers automatically without restart
+- Follows same pattern as `multi_channel_coordinator.py` session recovery
+
+---
+
 ## 2026-03-11 - DAEmon Orchestration Switches + LinkedIn Phase 4
 
 **By:** 0102

--- a/modules/communication/livechat/src/auto_moderator_dae.py
+++ b/modules/communication/livechat/src/auto_moderator_dae.py
@@ -793,8 +793,31 @@ class AutoModeratorDAE:
                             logger.warning(f"[ROTATE] ⚠️ Account switch failed: {switch_result.get('error')}")
 
                 except Exception as e:
-                    logger.error(f"[ROTATE] ❌ Account rotation error: {e}")
-        
+                    error_str = str(e)
+                    logger.error(f"[ROTATE] ❌ Account rotation error: {error_str}")
+
+                    # Session recovery: if session died, reset driver and retry once
+                    if _is_session_error(error_str):
+                        logger.warning("[ROTATE] Session error detected - attempting recovery...")
+                        try:
+                            from modules.infrastructure.foundups_vision.src.studio_account_switcher import get_account_switcher
+                            # Reset the switcher's driver to force reconnect
+                            switcher = get_account_switcher()
+                            switcher.driver = None
+
+                            # Attempt reconnect
+                            if switcher._connect_to_chrome():
+                                logger.info("[ROTATE] Chrome reconnected - retrying account switch")
+                                switch_result = await switcher.switch_to_account(target_account)
+                                if switch_result.get("success"):
+                                    logger.info(f"[ROTATE] ✅ Recovery successful - switched to {target_account}")
+                                else:
+                                    logger.warning(f"[ROTATE] Recovery switch failed: {switch_result.get('error')}")
+                            else:
+                                logger.error("[ROTATE] Chrome reconnect failed - session unrecoverable")
+                        except Exception as recovery_err:
+                            logger.error(f"[ROTATE] Recovery attempt failed: {recovery_err}")
+
         # Normalize result into dict (resolve_stream can return a tuple in some branches)
         if isinstance(result, tuple):
             # Tuple format: (video_id, chat_id)


### PR DESCRIPTION
## Problem

Browser sessions can die (timeout, crash, disconnect) causing "invalid session id" errors:
```
[ROTATE] ❌ Account rotation error: Message: invalid session id
```

Account rotation would log the error but not attempt recovery, blocking:
- Video indexing (Chrome-only)
- Comment engagement rotation

## Fix

Added session recovery logic to `auto_moderator_dae.py`:
1. Detect session errors using `_is_session_error()`
2. Reset switcher driver to None (force reconnect)
3. Call `_connect_to_chrome()` to establish new session
4. Retry the account switch operation

## Impact

- Video indexing can resume after browser session dies
- Account rotation recovers automatically without restart
- Follows same pattern as `multi_channel_coordinator.py` session recovery

Generated with [Claude Code](https://claude.com/claude-code)