### PR TITLE
feat(holodae): add broker stop hook

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -55954,3 +55954,7 @@ if cooldown_sets:
 - Added restart-budget enforcement to modules/communication/moltbot_bridge/src/openclaw_supervisor.py.
 - Supervisor now advances a DAEmon follow cursor each cycle and escalates when restart attempts exceed policy instead of retrying indefinitely.
 
+## 2026-03-18: HoloDAE broker stop support
+- Added a real `stop_holodae()` hook to `modules/ai_intelligence/holo_dae/scripts/launch.py`.
+- Registered `holodae` with a `stop_callable` in `main.py` so runtime control surfaces can stop HoloDAE honestly instead of returning `stop_unsupported`.
+

--- a/main.py
+++ b/main.py
@@ -146,7 +146,7 @@ logger = logging.getLogger(__name__)
 import time
 
 # Extracted to modules/ai_intelligence/holo_dae/scripts/launch.py per WSP 62
-from modules.ai_intelligence.holo_dae.scripts.launch import run_holodae
+from modules.ai_intelligence.holo_dae.scripts.launch import run_holodae, stop_holodae
 
 
 # Extracted to modules/platform_integration/social_media_orchestrator/scripts/launch.py per WSP 62
@@ -902,6 +902,7 @@ def bootstrap_runtime_dae_launches() -> None:
             domain="ai_intelligence",
             module_path="modules.ai_intelligence.holo_dae.scripts.launch",
             start_callable=run_holodae,
+            stop_callable=stop_holodae,
             description="Code intelligence and search runtime.",
         ),
         DAELaunchSpec(

--- a/modules/ai_intelligence/holo_dae/ModLog.md
+++ b/modules/ai_intelligence/holo_dae/ModLog.md
@@ -1,0 +1,4 @@
+## 2026-03-18: Broker-managed HoloDAE stop hook
+- Added broker-visible lifecycle state to `scripts/launch.py`.
+- Added `stop_holodae()` so the runtime broker can stop HoloDAE instead of returning `stop_unsupported`.
+- HoloDAE shutdown now clears the tracked instance after releasing the module lock.

--- a/modules/ai_intelligence/holo_dae/scripts/launch.py
+++ b/modules/ai_intelligence/holo_dae/scripts/launch.py
@@ -11,8 +11,14 @@ Module: holo_dae
 import sys
 import time
 import logging
+import threading
+from typing import Any, Dict
 
 logger = logging.getLogger(__name__)
+
+_holodae_lock = threading.RLock()
+_holodae_instance: Any = None
+_holodae_status: Dict[str, Any] = {}
 
 # WRE CoT preflight - recursive enforcement after watch period
 try:
@@ -27,6 +33,7 @@ except ImportError:
 @preflight_guard("holo_dae")
 def run_holodae():
     """Run HoloDAE (Code Intelligence & Monitoring)."""
+    global _holodae_instance
     print("[HOLODAE] Starting HoloDAE - Code Intelligence & Monitoring System...")
 
     # HOLO-DAE INSTANCE LOCKING (First Principles: Resource Protection & Consistency)
@@ -57,6 +64,10 @@ def run_holodae():
     try:
         from holo_index.qwen_advisor.autonomous_holodae import AutonomousHoloDAE
         holodae = AutonomousHoloDAE()
+        with _holodae_lock:
+            _holodae_instance = holodae
+            _holodae_status.clear()
+            _holodae_status.update({"status": "starting"})
 
         # Log successful instance acquisition
         instance_summary = lock.get_instance_summary()
@@ -78,6 +89,8 @@ def run_holodae():
             logger.debug(f"[WRE-TRIGGER] Skill triggers unavailable: {trigger_exc}")
 
         holodae.start_autonomous_monitoring()
+        with _holodae_lock:
+            _holodae_status.update({"status": "running"})
 
         print("[HOLODAE] Autonomous monitoring active. Press Ctrl+C to stop.")
 
@@ -97,14 +110,33 @@ def run_holodae():
             print("[HOLODAE] HoloDAE stopped successfully")
 
     except Exception as e:
+        with _holodae_lock:
+            _holodae_status["status"] = "failed"
         print(f"[HOLODAE-ERROR] Failed to start: {e}")
         import traceback
         traceback.print_exc()
 
     finally:
+        with _holodae_lock:
+            if _holodae_instance is not None:
+                _holodae_instance = None
+            if "status" not in _holodae_status or _holodae_status["status"] == "running":
+                _holodae_status["status"] = "stopped"
         # Release the instance lock when done
         lock.release()
         logger.info("[LOCK] HoloDAE monitor instance lock released")
+
+
+def stop_holodae() -> Dict[str, Any]:
+    """Request shutdown for the broker-managed HoloDAE runtime."""
+    with _holodae_lock:
+        holodae = _holodae_instance
+        if holodae is None:
+            return {"status": "not_running"}
+
+        holodae.stop_autonomous_monitoring()
+        _holodae_status["status"] = "stopping"
+        return {"status": "stopping"}
 
 
 if __name__ == "__main__":

--- a/modules/ai_intelligence/holo_dae/tests/TestModLog.md
+++ b/modules/ai_intelligence/holo_dae/tests/TestModLog.md
@@ -1,0 +1,7 @@
+## 2026-03-18: HoloDAE launch stop-hook coverage
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; python -m pytest modules/ai_intelligence/holo_dae/tests/test_launch.py tests/test_main_runtime_bootstrap.py -q`
+- Status: PASS
+- Coverage:
+  - Confirms `stop_holodae()` returns `not_running` when no broker-managed instance exists.
+  - Confirms `run_holodae()` exposes a live instance that can be stopped through the broker hook.
+  - Confirms `main.bootstrap_runtime_dae_launches()` registers `holodae` with a real `stop_callable`.

--- a/modules/ai_intelligence/holo_dae/tests/test_launch.py
+++ b/modules/ai_intelligence/holo_dae/tests/test_launch.py
@@ -1,0 +1,92 @@
+import threading
+import time
+import types
+import builtins
+
+from modules.ai_intelligence.holo_dae.scripts import launch as holo_launch
+
+
+class _FakeLock:
+    def __init__(self):
+        self.released = False
+
+    def check_duplicates(self):
+        return []
+
+    def acquire(self):
+        return True
+
+    def release(self):
+        self.released = True
+
+    def get_instance_summary(self):
+        return {"total_instances": 1, "current_pid": 1234}
+
+
+def test_stop_holodae_returns_not_running():
+    holo_launch._holodae_instance = None
+    holo_launch._holodae_status.clear()
+
+    result = holo_launch.stop_holodae()
+
+    assert result["status"] == "not_running"
+
+
+def test_run_holodae_supports_stop_hook(monkeypatch):
+    fake_lock = _FakeLock()
+    instances = []
+
+    class FakeHoloDAE:
+        def __init__(self):
+            self.active = False
+            self.stop_calls = 0
+            instances.append(self)
+
+        def start_autonomous_monitoring(self):
+            self.active = True
+
+        def stop_autonomous_monitoring(self):
+            self.stop_calls += 1
+            self.active = False
+
+    instance_module = types.ModuleType("instance_manager")
+    instance_module.get_instance_lock = lambda name: fake_lock
+
+    autonomous_module = types.ModuleType("autonomous_holodae")
+    autonomous_module.AutonomousHoloDAE = FakeHoloDAE
+
+    holo_launch._holodae_instance = None
+    holo_launch._holodae_status.clear()
+    original_sleep = time.sleep
+    monkeypatch.setattr(holo_launch.time, "sleep", lambda _: original_sleep(0.01))
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "modules.infrastructure.instance_lock.src.instance_manager":
+            return instance_module
+        if name == "holo_index.qwen_advisor.autonomous_holodae":
+            return autonomous_module
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    try:
+        thread = threading.Thread(target=holo_launch.run_holodae, daemon=True)
+        thread.start()
+
+        deadline = time.time() + 2.0
+        while time.time() < deadline and holo_launch._holodae_instance is None:
+            time.sleep(0.01)
+
+        assert holo_launch._holodae_instance is not None
+        result = holo_launch.stop_holodae()
+        assert result["status"] == "stopping"
+
+        thread.join(timeout=2.0)
+        assert not thread.is_alive()
+        assert instances[0].stop_calls == 1
+        assert fake_lock.released is True
+        assert holo_launch._holodae_instance is None
+    finally:
+        holo_launch._holodae_instance = None
+        holo_launch._holodae_status.clear()

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -168,6 +168,7 @@ Broker-managed runtime commands are now available through OpenClaw:
 - `watch openclaw since 42`
 - `status openclaw supervisor live`
 - `status holodae`
+- `stop holodae`
 - `launch social media dae`
 - `stop training system`
 - `status liberty alert`

--- a/tests/TestModLog.md
+++ b/tests/TestModLog.md
@@ -34,6 +34,13 @@
   - Confirms startup blocks when IronClaw is the active backend and readiness fails without fallback.
   - Confirms startup warns but allows boot when local fallback policy is enabled.
 
+## 2026-03-18: Main bootstrap HoloDAE stop-hook registration
+
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; python -m pytest tests/test_main_runtime_bootstrap.py -q`
+- Status: PASS
+- Notes:
+  - Confirms `main.bootstrap_runtime_dae_launches()` registers `holodae` with a real `stop_callable`.
+
 ---
 
 ## 2026-03-08: Markdown sanitizer coverage

--- a/tests/test_main_runtime_bootstrap.py
+++ b/tests/test_main_runtime_bootstrap.py
@@ -47,6 +47,27 @@ def test_bootstrap_runtime_dae_launches_registers_pqn_simulation(monkeypatch):
     assert simulation_specs[0].start_callable is main.run_pqn_simulation_once
 
 
+def test_bootstrap_runtime_dae_launches_registers_holodae_stop_hook(monkeypatch):
+    daemon = MagicMock()
+    daemon.running = True
+    broker = MagicMock()
+    broker.list_launchable_daes.return_value = {"holodae": {}}
+    broker.get_runtime_status.return_value = {"running": True}
+
+    monkeypatch.setenv("OPENCLAW_RESIDENT_ENABLED", "0")
+    monkeypatch.setenv("OPENCLAW_SUPERVISOR_ENABLED", "0")
+
+    with patch.object(main, "get_central_daemon", return_value=daemon), patch.object(
+        main, "get_dae_launch_broker", return_value=broker
+    ):
+        main.bootstrap_runtime_dae_launches()
+
+    specs = [call.args[0] for call in broker.register_launch_spec.call_args_list]
+    holodae_specs = [spec for spec in specs if spec.dae_id == "holodae"]
+    assert len(holodae_specs) == 1
+    assert holodae_specs[0].stop_callable is main.stop_holodae
+
+
 def test_bootstrap_runtime_dae_launches_registers_and_autostarts_openclaw_supervisor(monkeypatch):
     daemon = MagicMock()
     daemon.running = True


### PR DESCRIPTION
Summary: add a real stop_holodae() runtime hook; register holodae with a broker stop_callable in main.py; document the runtime control surface and cover the launcher plus bootstrap path with tests. Validation: python -m py_compile modules/ai_intelligence/holo_dae/scripts/launch.py modules/ai_intelligence/holo_dae/tests/test_launch.py tests/test_main_runtime_bootstrap.py main.py ; PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest modules/ai_intelligence/holo_dae/tests/test_launch.py tests/test_main_runtime_bootstrap.py -q