### PR TITLE
feat(runtime): add stop hooks for social and git daes

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -55958,3 +55958,8 @@ if cooldown_sets:
 - Added a real `stop_holodae()` hook to `modules/ai_intelligence/holo_dae/scripts/launch.py`.
 - Registered `holodae` with a `stop_callable` in `main.py` so runtime control surfaces can stop HoloDAE honestly instead of returning `stop_unsupported`.
 
+## 2026-03-18: GitPush and Social Media broker stop support
+- Added `stop_git_push_dae()` to `modules/infrastructure/git_push_dae/scripts/launch.py`.
+- Added `stop_social_media_dae()` to `modules/platform_integration/social_media_orchestrator/scripts/launch.py`.
+- Registered both runtimes with real `stop_callable` hooks in `main.py`.
+

--- a/main.py
+++ b/main.py
@@ -150,7 +150,10 @@ from modules.ai_intelligence.holo_dae.scripts.launch import run_holodae, stop_ho
 
 
 # Extracted to modules/platform_integration/social_media_orchestrator/scripts/launch.py per WSP 62
-from modules.platform_integration.social_media_orchestrator.scripts.launch import run_social_media_dae
+from modules.platform_integration.social_media_orchestrator.scripts.launch import (
+    run_social_media_dae,
+    stop_social_media_dae,
+)
 
 from modules.communication.auto_meeting_orchestrator.scripts.launch import run_amo_dae
 from modules.infrastructure.evade_net.scripts.launch import run_evade_net
@@ -167,6 +170,7 @@ from modules.communication.moltbot_bridge.scripts.launch import (
 # Extracted to modules/infrastructure/git_push_dae/scripts/launch.py per WSP 62
 from modules.infrastructure.git_push_dae.scripts.launch import (
     launch_git_push_dae,
+    stop_git_push_dae,
     view_git_post_history,
     check_instance_status,
 )
@@ -911,6 +915,7 @@ def bootstrap_runtime_dae_launches() -> None:
             domain="infrastructure",
             module_path="modules.infrastructure.git_push_dae.scripts.launch",
             start_callable=lambda: launch_git_push_dae(run_once=False),
+            stop_callable=stop_git_push_dae,
             description="Autonomous git push daemon.",
         ),
         DAELaunchSpec(
@@ -919,6 +924,7 @@ def bootstrap_runtime_dae_launches() -> None:
             domain="platform_integration",
             module_path="modules.platform_integration.social_media_orchestrator.scripts.launch",
             start_callable=run_social_media_dae,
+            stop_callable=stop_social_media_dae,
             description="Unified social media orchestration runtime.",
         ),
         DAELaunchSpec(

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -169,7 +169,9 @@ Broker-managed runtime commands are now available through OpenClaw:
 - `status openclaw supervisor live`
 - `status holodae`
 - `stop holodae`
+- `stop git push dae`
 - `launch social media dae`
+- `stop social media dae`
 - `stop training system`
 - `status liberty alert`
 

--- a/modules/infrastructure/git_push_dae/INTERFACE.md
+++ b/modules/infrastructure/git_push_dae/INTERFACE.md
@@ -65,6 +65,22 @@ class HealthStatus:
     recommendations: List[str]
 ```
 
+### Broker-Managed Runtime Hooks
+
+```python
+from modules.infrastructure.git_push_dae.scripts.launch import (
+    launch_git_push_dae,
+    stop_git_push_dae,
+)
+
+launch_git_push_dae(run_once=False)
+stop_git_push_dae()  # -> {"status": "stopping"} | {"status": "not_running"}
+```
+
+Runtime contract:
+- `main.py` registers `git_push_dae` with `stop_callable=stop_git_push_dae`
+- generic DAE runtime commands can now stop the broker-managed GitPushDAE honestly
+
 ## Agentic Parameters
 
 ### Push Decision Criteria (Autonomous)

--- a/modules/infrastructure/git_push_dae/ModLog.md
+++ b/modules/infrastructure/git_push_dae/ModLog.md
@@ -414,3 +414,7 @@ docs/session_backups/
 - [OK] Error handling with context
 - [OK] Health monitoring (vital signs, anomalies)
 - [OK] Semantic conventions (OpenTelemetry alignment)
+## 2026-03-18: Broker-managed stop hook
+- Added broker-visible runtime state to `scripts/launch.py`.
+- Added `stop_git_push_dae()` so the runtime broker can stop GitPushDAE instead of returning `stop_unsupported`.
+- `main.py` now registers `git_push_dae` with a real `stop_callable`.

--- a/modules/infrastructure/git_push_dae/README.md
+++ b/modules/infrastructure/git_push_dae/README.md
@@ -42,6 +42,7 @@ dae.start()
 
 ## Integration Points
 - **Main.py Option 0**: Runs one GitPushDAE cycle and returns to menu
+- **Runtime broker**: `stop git push dae` now routes to `stop_git_push_dae()` through the generic DAE runtime surface
 - **HoloIndex**: Quality assessment for push decisions
 - **Social Media**: LinkedIn/X posting when conditions met
 

--- a/modules/infrastructure/git_push_dae/scripts/launch.py
+++ b/modules/infrastructure/git_push_dae/scripts/launch.py
@@ -26,6 +26,12 @@ Module: git_push_dae
 import sys
 import time
 import traceback
+import threading
+from typing import Any, Dict
+
+_git_push_lock = threading.RLock()
+_git_push_instance: Any = None
+_git_push_status: Dict[str, Any] = {}
 
 # WRE CoT preflight - recursive enforcement after watch period
 try:
@@ -46,6 +52,7 @@ def launch_git_push_dae(run_once: bool = False):
     Args:
         run_once: Run a single monitoring cycle and return to caller (menu-safe).
     """
+    global _git_push_instance
     print("\n" + "="*60)
     print("[MENU] GIT PUSH DAE - AUTONOMOUS DEVELOPMENT")
     print("="*60)
@@ -63,14 +70,22 @@ def launch_git_push_dae(run_once: bool = False):
         print("[DEBUG-MAIN] Creating GitPushDAE instance...")
         dae = GitPushDAE(domain="foundups_development", check_interval=300)  # 5-minute checks
         print("[DEBUG-MAIN] GitPushDAE instance created")
+        with _git_push_lock:
+            _git_push_instance = dae
+            _git_push_status.clear()
+            _git_push_status.update({"status": "starting", "run_once": run_once})
 
         if run_once:
             print("[INFO] Running one GitPushDAE monitoring cycle (run-once mode)...")
             health = dae.run_once()
+            with _git_push_lock:
+                _git_push_status["status"] = health.status
             print(f"[INFO] GitPushDAE run-once complete (health: {health.status})")
         else:
             print("[DEBUG-MAIN] Starting GitPushDAE daemon...")
             dae.start()
+            with _git_push_lock:
+                _git_push_status["status"] = "running"
             print("[DEBUG-MAIN] GitPushDAE daemon started")
 
             print("\n[INFO]GitPushDAE launched successfully!")
@@ -84,18 +99,28 @@ def launch_git_push_dae(run_once: bool = False):
             except KeyboardInterrupt:
                 print("\n[INFO] Stopping GitPushDAE...")
                 dae.stop()
+                with _git_push_lock:
+                    _git_push_status["status"] = "stopped"
 
     except ImportError as e:
+        with _git_push_lock:
+            _git_push_status["status"] = "failed"
         print(f"[ERROR]Failed to import GitPushDAE: {e}")
         print("GitPushDAE module not available")
         traceback.print_exc()
 
     except Exception as e:
+        with _git_push_lock:
+            _git_push_status["status"] = "failed"
         print(f"[ERROR]GitPushDAE failed: {e}")
         traceback.print_exc()
         input("\nPress Enter to continue...")
 
     finally:
+        with _git_push_lock:
+            _git_push_instance = None
+            if "status" not in _git_push_status or _git_push_status["status"] == "running":
+                _git_push_status["status"] = "stopped"
         # Flush stdout/stderr to prevent "lost sys.stderr" errors
         # when returning to menu (WSP 90 UTF-8 enforcement cleanup)
         try:
@@ -140,6 +165,18 @@ def check_instance_status():
             print("[STOPPED] GitPushDAE not running")
     except Exception as e:
         print(f"[UNKNOWN] Could not check status: {e}")
+
+
+def stop_git_push_dae() -> Dict[str, Any]:
+    """Request shutdown for the broker-managed GitPushDAE runtime."""
+    with _git_push_lock:
+        dae = _git_push_instance
+        if dae is None:
+            return {"status": "not_running"}
+
+        dae.stop()
+        _git_push_status["status"] = "stopping"
+        return {"status": "stopping"}
 
 
 if __name__ == "__main__":

--- a/modules/infrastructure/git_push_dae/tests/TestModLog.md
+++ b/modules/infrastructure/git_push_dae/tests/TestModLog.md
@@ -13,3 +13,10 @@
 ### Verification
 - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest modules/infrastructure/git_push_dae/tests/test_post_commit_social_runner.py -q`
 - Result: `3 passed`
+## 2026-03-18: GitPushDAE launch stop-hook coverage
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; python -m pytest modules/infrastructure/git_push_dae/tests/test_launch_runtime.py tests/test_main_runtime_bootstrap.py -q`
+- Status: PASS
+- Coverage:
+  - Confirms `stop_git_push_dae()` returns `not_running` when no broker-managed instance exists.
+  - Confirms the launch wrapper exposes a live GitPushDAE instance that can be stopped through the broker hook.
+  - Confirms `main.bootstrap_runtime_dae_launches()` registers `git_push_dae` with a real `stop_callable`.

--- a/modules/infrastructure/git_push_dae/tests/test_launch_runtime.py
+++ b/modules/infrastructure/git_push_dae/tests/test_launch_runtime.py
@@ -1,0 +1,71 @@
+import builtins
+import threading
+import time
+import types
+
+from modules.infrastructure.git_push_dae.scripts import launch as git_launch
+
+
+def test_stop_git_push_dae_returns_not_running():
+    git_launch._git_push_instance = None
+    git_launch._git_push_status.clear()
+
+    result = git_launch.stop_git_push_dae()
+
+    assert result["status"] == "not_running"
+
+
+def test_launch_git_push_dae_supports_stop_hook(monkeypatch):
+    instances = []
+
+    class FakeGitPushDAE:
+        def __init__(self, domain, check_interval):
+            self.domain = domain
+            self.check_interval = check_interval
+            self.active = False
+            instances.append(self)
+
+        def start(self):
+            self.active = True
+
+        def stop(self):
+            self.active = False
+
+        def run_once(self):
+            return types.SimpleNamespace(status="healthy")
+
+    fake_module = types.ModuleType("git_push_dae")
+    fake_module.GitPushDAE = FakeGitPushDAE
+
+    git_launch._git_push_instance = None
+    git_launch._git_push_status.clear()
+    original_sleep = time.sleep
+    monkeypatch.setattr(git_launch.time, "sleep", lambda _: original_sleep(0.01))
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "modules.infrastructure.git_push_dae.src.git_push_dae":
+            return fake_module
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    thread = threading.Thread(
+        target=git_launch.launch_git_push_dae.__wrapped__,
+        kwargs={"run_once": False},
+        daemon=True,
+    )
+    thread.start()
+
+    deadline = time.time() + 2.0
+    while time.time() < deadline and git_launch._git_push_instance is None:
+        time.sleep(0.01)
+
+    assert git_launch._git_push_instance is not None
+    result = git_launch.stop_git_push_dae()
+    assert result["status"] == "stopping"
+
+    thread.join(timeout=2.0)
+    assert not thread.is_alive()
+    assert instances[0].active is False
+    assert git_launch._git_push_instance is None

--- a/modules/platform_integration/social_media_orchestrator/INTERFACE.md
+++ b/modules/platform_integration/social_media_orchestrator/INTERFACE.md
@@ -29,6 +29,22 @@ async def authenticate_platform(platform: str, credentials: Dict[str, Any]) -> b
 def get_status() -> Dict[str, Any]
 ```
 
+### Broker-Managed Runtime Hooks
+
+```python
+from modules.platform_integration.social_media_orchestrator.scripts.launch import (
+    run_social_media_dae,
+    stop_social_media_dae,
+)
+
+run_social_media_dae()
+stop_social_media_dae()  # -> {"status": "stopping"} | {"status": "not_running"}
+```
+
+Runtime contract:
+- `main.py` registers `social_media` with `stop_callable=stop_social_media_dae`
+- the cadence wait is interruptible, so stop requests do not wait for the full interval
+
 #### Content Operations
 ```python
 async def post_content(content: str, platforms: List[str], options: Optional[Dict] = None) -> Dict[str, Any]

--- a/modules/platform_integration/social_media_orchestrator/ModLog.md
+++ b/modules/platform_integration/social_media_orchestrator/ModLog.md
@@ -1074,3 +1074,7 @@ schedule_id = await orchestrator.schedule_content(
 
 ---
 
+## 2026-03-18: Broker-managed stop hook
+- Replaced the launch wrapper with an ASCII-clean version that exposes broker-visible runtime state.
+- Added `stop_social_media_dae()` so the runtime broker can stop the social cadence loop instead of returning `stop_unsupported`.
+- SocialMediaDAE now uses an interruptible wait so stop requests do not sit behind the full cadence sleep.

--- a/modules/platform_integration/social_media_orchestrator/README.md
+++ b/modules/platform_integration/social_media_orchestrator/README.md
@@ -175,3 +175,8 @@ For detailed technical architecture documentation:
 - **WSP 50**: Pre-action verification in all operations
 - **WSP 72**: Block independence achieved through modularization
 - **WSP 87**: HoloIndex navigation entries for all components
+## Runtime Control (2026-03-18)
+- main.py now registers social_media as a broker-managed runtime with a real stop hook.
+- stop social media dae maps to stop_social_media_dae() instead of returning stop_unsupported.
+- The cadence wait is interruptible, so stop requests do not sit behind the full sleep interval.
+

--- a/modules/platform_integration/social_media_orchestrator/scripts/launch.py
+++ b/modules/platform_integration/social_media_orchestrator/scripts/launch.py
@@ -1,28 +1,30 @@
 #!/usr/bin/env python3
 """
-Social Media DAE Launch Script
-Extracted from main.py per WSP 62 Large File Refactoring Protocol
+Social Media DAE launch script.
 
-Purpose: Launch Social Media DAE (012 Digital Twin)
-Domain: platform_integration
-Module: social_media_orchestrator
-
-WSP Compliance: WSP 27 (DAE Architecture), WSP 46 (WRE Protocol),
-                WSP 77 (Agent Coordination)
+Extracted from `main.py` per WSP 62.
+Purpose: launch the long-running social-domain skill trigger loop and expose
+an honest stop hook for the broker-managed runtime surface.
 """
+
+from __future__ import annotations
 
 import asyncio
 import logging
-import time
+import threading
 import traceback
+from typing import Any, Dict
 
 logger = logging.getLogger(__name__)
 
-# WRE CoT preflight - recursive enforcement after watch period
+_social_media_lock = threading.RLock()
+_social_media_instance: Any = None
+_social_media_status: Dict[str, Any] = {}
+
+
 try:
     from modules.infrastructure.wre_core.src.dae_preflight import preflight_guard
 except ImportError:
-    # Fallback if WRE not available
     def preflight_guard(name, quiet=True):
         def decorator(func):
             return func
@@ -31,25 +33,17 @@ except ImportError:
 
 class SocialMediaDAE:
     """
-    Social Media DAE — fires WRE social skills on a cadence.
-
-    This replaces the previous stub with a real event loop that
-    discovers and executes social-domain skills (LinkedIn, X, etc.)
-    through the full WRE pipeline.
-
-    Per WSP 27: Signal → Knowledge → Protocol → Execution
+    Long-running social-domain DAE that fires WRE social skills on a cadence.
     """
 
     def __init__(self, cadence_minutes: int = 15):
         self.cadence_minutes = cadence_minutes
         self.active = False
+        self._stop_event: asyncio.Event | None = None
 
-        # Compose SkillTriggerMixin functionality
         try:
-            from modules.infrastructure.wre_core.src.skill_trigger import (
-                SkillTriggerMixin,
-            )
-            # Dynamically mix in the trigger methods
+            from modules.infrastructure.wre_core.src.skill_trigger import SkillTriggerMixin
+
             self._trigger_mixin = SkillTriggerMixin()
             self._trigger_mixin.init_skill_triggers(
                 domain="social",
@@ -62,9 +56,9 @@ class SocialMediaDAE:
             self._trigger_available = False
             self._trigger_mixin = None
 
-    async def run(self):
-        """Main DAE event loop — fire social skills on cadence."""
+    async def run(self) -> None:
         self.active = True
+        self._stop_event = asyncio.Event()
         logger.info(
             "[SOCIAL-DAE] Starting social media DAE (cadence=%dm)",
             self.cadence_minutes,
@@ -90,20 +84,24 @@ class SocialMediaDAE:
                         logger.debug("[SOCIAL-DAE] Cycle %d: no skills due", cycle)
                 else:
                     logger.debug("[SOCIAL-DAE] Cycle %d: trigger mixin unavailable", cycle)
-
             except Exception as exc:
                 logger.error("[SOCIAL-DAE] Cycle %d error: %s", cycle, exc)
 
-            # Sleep until next cadence
-            await asyncio.sleep(self.cadence_minutes * 60)
+            try:
+                await asyncio.wait_for(
+                    self._stop_event.wait(),
+                    timeout=self.cadence_minutes * 60,
+                )
+            except asyncio.TimeoutError:
+                pass
 
-    def stop(self):
-        """Stop the DAE loop."""
+    def stop(self) -> None:
         self.active = False
+        if self._stop_event and not self._stop_event.is_set():
+            self._stop_event.set()
         logger.info("[SOCIAL-DAE] Stop requested")
 
-    def get_status(self):
-        """Return DAE status for observability."""
+    def get_status(self) -> Dict[str, Any]:
         status = {"active": self.active, "domain": "social"}
         if self._trigger_available and self._trigger_mixin:
             status["triggers"] = self._trigger_mixin.get_trigger_status()
@@ -111,19 +109,46 @@ class SocialMediaDAE:
 
 
 @preflight_guard("social_media_dae")
-def run_social_media_dae():
-    """Run Social Media DAE (012 Digital Twin)."""
+def run_social_media_dae() -> None:
+    """Run the Social Media DAE as a broker-managed runtime."""
+    global _social_media_instance
     print("[INFO] Starting Social Media DAE (012 Digital Twin)...")
     try:
         dae = SocialMediaDAE(cadence_minutes=15)
+        with _social_media_lock:
+            _social_media_instance = dae
+            _social_media_status.clear()
+            _social_media_status.update({"status": "starting"})
+        with _social_media_lock:
+            _social_media_status["status"] = "running"
         asyncio.run(dae.run())
     except KeyboardInterrupt:
+        with _social_media_lock:
+            _social_media_status["status"] = "stopped"
         print("\n[STOP] Social Media DAE stopped by user")
-    except Exception as e:
-        print(f"[ERROR] Social Media DAE failed: {e}")
+    except Exception as exc:
+        with _social_media_lock:
+            _social_media_status["status"] = "failed"
+        print(f"[ERROR] Social Media DAE failed: {exc}")
         traceback.print_exc()
+    finally:
+        with _social_media_lock:
+            _social_media_instance = None
+            if "status" not in _social_media_status or _social_media_status["status"] == "running":
+                _social_media_status["status"] = "stopped"
+
+
+def stop_social_media_dae() -> Dict[str, Any]:
+    """Request shutdown for the broker-managed Social Media DAE runtime."""
+    with _social_media_lock:
+        dae = _social_media_instance
+        if dae is None:
+            return {"status": "not_running"}
+
+        dae.stop()
+        _social_media_status["status"] = "stopping"
+        return {"status": "stopping"}
 
 
 if __name__ == "__main__":
     run_social_media_dae()
-

--- a/modules/platform_integration/social_media_orchestrator/tests/TestModLog.md
+++ b/modules/platform_integration/social_media_orchestrator/tests/TestModLog.md
@@ -65,3 +65,11 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirna
 ---
 
 *Test log maintained per WSP 34 protocol*
+## 2026-03-18: Social Media DAE launch stop-hook coverage
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; python -m pytest modules/platform_integration/social_media_orchestrator/tests/test_launch_runtime.py tests/test_main_runtime_bootstrap.py -q`
+- Status: PASS
+- Coverage:
+  - Confirms `stop_social_media_dae()` returns `not_running` when no broker-managed instance exists.
+  - Confirms `SocialMediaDAE.stop()` interrupts the cadence wait instead of waiting out the full sleep.
+  - Confirms the launch wrapper exposes a live Social Media DAE instance that can be stopped through the broker hook.
+  - Confirms `main.bootstrap_runtime_dae_launches()` registers `social_media` with a real `stop_callable`.

--- a/modules/platform_integration/social_media_orchestrator/tests/test_launch_runtime.py
+++ b/modules/platform_integration/social_media_orchestrator/tests/test_launch_runtime.py
@@ -1,0 +1,67 @@
+import asyncio
+import threading
+import time
+
+from modules.platform_integration.social_media_orchestrator.scripts import launch as social_launch
+
+
+def test_stop_social_media_dae_returns_not_running():
+    social_launch._social_media_instance = None
+    social_launch._social_media_status.clear()
+
+    result = social_launch.stop_social_media_dae()
+
+    assert result["status"] == "not_running"
+
+
+def test_social_media_dae_stop_interrupts_wait(monkeypatch):
+    dae = social_launch.SocialMediaDAE(cadence_minutes=15)
+    dae._trigger_available = False
+    dae._trigger_mixin = None
+
+    async def runner():
+        task = asyncio.create_task(dae.run())
+        await asyncio.sleep(0.01)
+        dae.stop()
+        await asyncio.wait_for(task, timeout=0.5)
+
+    asyncio.run(runner())
+
+    assert dae.active is False
+
+
+def test_run_social_media_dae_supports_stop_hook(monkeypatch):
+    class FakeSocialMediaDAE:
+        def __init__(self, cadence_minutes=15):
+            self.cadence_minutes = cadence_minutes
+            self.active = False
+
+        async def run(self):
+            self.active = True
+            while self.active:
+                await asyncio.sleep(0.01)
+
+        def stop(self):
+            self.active = False
+
+    social_launch._social_media_instance = None
+    social_launch._social_media_status.clear()
+    monkeypatch.setattr(social_launch, "SocialMediaDAE", FakeSocialMediaDAE)
+
+    thread = threading.Thread(target=social_launch.run_social_media_dae.__wrapped__, daemon=True)
+    thread.start()
+
+    deadline = time.time() + 2.0
+    while time.time() < deadline and social_launch._social_media_instance is None:
+        time.sleep(0.01)
+
+    assert social_launch._social_media_instance is not None
+    while time.time() < deadline and not social_launch._social_media_instance.active:
+        time.sleep(0.01)
+
+    result = social_launch.stop_social_media_dae()
+    assert result["status"] == "stopping"
+
+    thread.join(timeout=2.0)
+    assert not thread.is_alive()
+    assert social_launch._social_media_instance is None

--- a/tests/TestModLog.md
+++ b/tests/TestModLog.md
@@ -41,6 +41,14 @@
 - Notes:
   - Confirms `main.bootstrap_runtime_dae_launches()` registers `holodae` with a real `stop_callable`.
 
+## 2026-03-18: Main bootstrap GitPush and Social Media stop-hook registration
+
+- Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; python -m pytest tests/test_main_runtime_bootstrap.py -q`
+- Status: PASS
+- Notes:
+  - Confirms `main.bootstrap_runtime_dae_launches()` registers `git_push_dae` with a real `stop_callable`.
+  - Confirms `main.bootstrap_runtime_dae_launches()` registers `social_media` with a real `stop_callable`.
+
 ---
 
 ## 2026-03-08: Markdown sanitizer coverage

--- a/tests/test_main_runtime_bootstrap.py
+++ b/tests/test_main_runtime_bootstrap.py
@@ -1,6 +1,12 @@
+import importlib.util
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import main
+_MAIN_PATH = Path(__file__).resolve().parents[1] / "main.py"
+_MAIN_SPEC = importlib.util.spec_from_file_location("foundups_test_main", _MAIN_PATH)
+assert _MAIN_SPEC and _MAIN_SPEC.loader
+main = importlib.util.module_from_spec(_MAIN_SPEC)
+_MAIN_SPEC.loader.exec_module(main)
 
 
 def test_bootstrap_runtime_dae_launches_registers_openclaw(monkeypatch):
@@ -66,6 +72,32 @@ def test_bootstrap_runtime_dae_launches_registers_holodae_stop_hook(monkeypatch)
     holodae_specs = [spec for spec in specs if spec.dae_id == "holodae"]
     assert len(holodae_specs) == 1
     assert holodae_specs[0].stop_callable is main.stop_holodae
+
+
+def test_bootstrap_runtime_dae_launches_registers_git_push_and_social_stop_hooks(monkeypatch):
+    daemon = MagicMock()
+    daemon.running = True
+    broker = MagicMock()
+    broker.list_launchable_daes.return_value = {"git_push_dae": {}, "social_media": {}}
+    broker.get_runtime_status.return_value = {"running": True}
+
+    monkeypatch.setenv("OPENCLAW_RESIDENT_ENABLED", "0")
+    monkeypatch.setenv("OPENCLAW_SUPERVISOR_ENABLED", "0")
+
+    with patch.object(main, "get_central_daemon", return_value=daemon), patch.object(
+        main, "get_dae_launch_broker", return_value=broker
+    ):
+        main.bootstrap_runtime_dae_launches()
+
+    specs = [call.args[0] for call in broker.register_launch_spec.call_args_list]
+    git_specs = [spec for spec in specs if spec.dae_id == "git_push_dae"]
+    social_specs = [spec for spec in specs if spec.dae_id == "social_media"]
+    assert len(git_specs) == 1
+    assert len(social_specs) == 1
+    assert git_specs[0].stop_callable is not None
+    assert social_specs[0].stop_callable is not None
+    assert git_specs[0].stop_callable.__name__ == "stop_git_push_dae"
+    assert social_specs[0].stop_callable.__name__ == "stop_social_media_dae"
 
 
 def test_bootstrap_runtime_dae_launches_registers_and_autostarts_openclaw_supervisor(monkeypatch):


### PR DESCRIPTION
Summary: add real broker stop hooks for GitPushDAE and Social Media DAE; make the social cadence wait interruptible; register both stop callables in main.py; update runtime docs and focused launch/bootstrap tests. Validation: python -m py_compile main.py modules/infrastructure/git_push_dae/scripts/launch.py modules/platform_integration/social_media_orchestrator/scripts/launch.py modules/infrastructure/git_push_dae/tests/test_launch_runtime.py modules/platform_integration/social_media_orchestrator/tests/test_launch_runtime.py tests/test_main_runtime_bootstrap.py ; PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest modules/infrastructure/git_push_dae/tests/test_launch_runtime.py modules/platform_integration/social_media_orchestrator/tests/test_launch_runtime.py tests/test_main_runtime_bootstrap.py -q -s