### PR TITLE
feat(wre): P0 autonomy wiring fixes (WSP 97)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -152,6 +152,13 @@ IRONCLAW_MODEL=local/qwen-coder-7b
 IRONCLAW_AUTH_TOKEN=
 IRONCLAW_TIMEOUT_SEC=15
 IRONCLAW_NO_API_KEYS=1
+# Start command for self-audit / supervisor auto-remediation.
+# Pick one and uncomment in your local `.env`:
+#   IRONCLAW_START_CMD=ironclaw start
+#   IRONCLAW_START_CMD=cargo run --release --manifest-path temp/_vendor/ironclaw/Cargo.toml
+#   IRONCLAW_START_CMD=docker compose -f temp/_vendor/ironclaw/docker-compose.yml up -d
+#   IRONCLAW_START_CMD=scripts/start_ironclaw_services.bat
+# If empty, the system can detect IronClaw failures but cannot auto-start the gateway.
 IRONCLAW_START_CMD=
 WRE_ENABLE_IRONCLAW_WORKER=1
 # Simulator Qwen backend route: local | ironclaw | wre_ironclaw

--- a/main.py
+++ b/main.py
@@ -1389,6 +1389,78 @@ def main():
             self_audit_loop.stop()
 
 
+def run_headless() -> int:
+    """
+    WSP 97: Headless autonomous mode.
+
+    Runs OpenClaw supervisor in a loop without interactive menu.
+    FAIL-CLOSED: Exits with error if WRE is not READY.
+    """
+    repo_root = Path(__file__).resolve().parent
+
+    # Fail-closed: check WRE readiness first
+    wre_status = run_connect_wre(repo_root)
+    if wre_status["readiness"] not in ("READY", "INSUFFICIENT_DATA"):
+        print(
+            f"[HEADLESS] FAIL-CLOSED: WRE not ready "
+            f"(readiness={wre_status['readiness']}, "
+            f"critical={wre_status['alert_counts']['critical']})"
+        )
+        return 1
+
+    print(f"[HEADLESS] Starting autonomous mode (WRE={wre_status['readiness']})")
+
+    try:
+        from modules.communication.moltbot_bridge.src.openclaw_supervisor import OpenClawSupervisor
+        from modules.infrastructure.dae_daemon.src.dae_launch_broker import DAELaunchBroker
+        from modules.infrastructure.dae_daemon.src.dae_observer import DAEObserver
+
+        broker = DAELaunchBroker()
+        observer = DAEObserver()
+
+        supervisor = OpenClawSupervisor(
+            repo_root=repo_root,
+            broker=broker,
+            observer=observer,
+        )
+
+        print("[HEADLESS] OpenClaw supervisor initialized, entering run loop...")
+
+        cycle_interval = float(os.getenv("OPENCLAW_HEADLESS_INTERVAL", "30"))
+        max_cycles = int(os.getenv("OPENCLAW_HEADLESS_MAX_CYCLES", "0"))  # 0 = infinite
+        cycle_count = 0
+
+        while True:
+            try:
+                result = supervisor.run_cycle()
+                cycle_count += 1
+                action = result.get("plan", {}).get("action", "idle")
+                ok = result.get("verify", {}).get("ok", False)
+                print(f"[HEADLESS] cycle={cycle_count} action={action} ok={ok}")
+
+                if max_cycles > 0 and cycle_count >= max_cycles:
+                    print(f"[HEADLESS] max_cycles={max_cycles} reached, exiting")
+                    break
+
+                time.sleep(cycle_interval)
+
+            except KeyboardInterrupt:
+                print("[HEADLESS] interrupted, exiting")
+                break
+            except Exception as exc:
+                logger.error(f"[HEADLESS] cycle error: {exc}")
+                time.sleep(cycle_interval)
+
+        return 0
+
+    except ImportError as exc:
+        print(f"[HEADLESS] FAIL-CLOSED: missing dependency: {exc}")
+        return 1
+    except Exception as exc:
+        print(f"[HEADLESS] FAIL-CLOSED: {exc}")
+        return 1
+
+
 if __name__ == "__main__":
     # WSP 97 Section 4.6: --connect-wre CLI hook
     if len(sys.argv) > 1 and sys.argv[1] == "--connect-wre":
@@ -1405,4 +1477,9 @@ if __name__ == "__main__":
             f"warnings={status['alert_counts']['warning']}"
         )
         sys.exit(0 if status["readiness"] == "READY" else 1)
+
+    # WSP 97: --headless autonomous mode (fail-closed, no interactive menu)
+    if len(sys.argv) > 1 and sys.argv[1] == "--headless":
+        sys.exit(run_headless())
+
     main()

--- a/modules/communication/moltbot_bridge/scripts/run_task.py
+++ b/modules/communication/moltbot_bridge/scripts/run_task.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+Executes an autonomous task from AgentDB via WRE or self-audit infrastructure.
+
+This is the P0 task consumer triggered by OpenClawSupervisor._execute().
+It can be called:
+  - In-process via execute_task(task_id) from the supervisor
+  - As a script via python run_task.py --task_id <id>
+
+Dispatch priority:
+  1. WRE execute_skill() if required_skills match a registered skill
+  2. DaemonSelfAuditLoop._apply_policy_fix() for self_audit-sourced tasks
+  3. Fail with "no_executor_matched" — never silently complete
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO_ROOT))
+
+logger = logging.getLogger(__name__)
+
+
+def execute_task(task_id: str, repo_root: Path | None = None) -> Dict[str, Any]:
+    """
+    Execute a single autonomous task from AgentDB.
+
+    Returns:
+        Dict with keys: ok (bool), detail (str), executor (str),
+        execution_time_ms (int)
+    """
+    if repo_root is None:
+        repo_root = REPO_ROOT
+
+    start = time.monotonic()
+
+    try:
+        from modules.infrastructure.database.src.agent_db import AgentDB
+    except ImportError as e:
+        return {"ok": False, "detail": f"AgentDB import failed: {e}", "executor": "none", "execution_time_ms": 0}
+
+    db = AgentDB()
+
+    # Fetch the task (supervisor sets it to "assigned" before calling us)
+    tasks = db.get_autonomous_tasks(status="assigned", limit=100)
+    task = next((t for t in tasks if t.get("task_id") == task_id), None)
+
+    if not task:
+        return {"ok": False, "detail": f"Task {task_id} not found in 'assigned' state", "executor": "none", "execution_time_ms": 0}
+
+    required_skills = task.get("required_skills", [])
+    context = task.get("context", {})
+    source = context.get("source", "") if isinstance(context, dict) else ""
+    description = task.get("description", "")
+
+    logger.info("[RUN_TASK] Executing task %s: %s (skills=%s, source=%s)", task_id, description[:80], required_skills, source)
+
+    result: Dict[str, Any] = {"ok": False, "detail": "no_executor_matched", "executor": "none"}
+
+    # ── Dispatch path 1: WRE skill execution ──
+    if required_skills:
+        wre_result = _try_wre_dispatch(repo_root, task_id, required_skills, context, description)
+        if wre_result is not None:
+            result = wre_result
+
+    # ── Dispatch path 2: Self-audit policy fix ──
+    if not result["ok"] and result["detail"] == "no_executor_matched" and source == "self_audit":
+        audit_result = _try_self_audit_dispatch(repo_root, context)
+        if audit_result is not None:
+            result = audit_result
+
+    # ── Finalize in AgentDB ──
+    elapsed_ms = int((time.monotonic() - start) * 1000)
+    result["execution_time_ms"] = elapsed_ms
+
+    if result["ok"]:
+        db.complete_autonomous_task(task_id)
+        logger.info("[RUN_TASK] Task %s completed (executor=%s, %dms)", task_id, result["executor"], elapsed_ms)
+    else:
+        # Mark as failed by updating status directly (no fail_autonomous_task method yet)
+        try:
+            db.db.execute_write(
+                "UPDATE agents_autonomous_tasks SET status = 'failed' WHERE task_id = ?",
+                (task_id,),
+            )
+        except Exception as fail_exc:
+            logger.warning("[RUN_TASK] Could not mark task %s as failed: %s", task_id, fail_exc)
+        logger.warning("[RUN_TASK] Task %s failed: %s (executor=%s)", task_id, result["detail"][:200], result["executor"])
+
+    return result
+
+
+def _try_wre_dispatch(
+    repo_root: Path,
+    task_id: str,
+    required_skills: list,
+    context: dict,
+    description: str,
+) -> Dict[str, Any] | None:
+    """Attempt to dispatch via WRE execute_skill. Returns result or None."""
+    try:
+        from modules.infrastructure.wre_core.wre_master_orchestrator.src.wre_master_orchestrator import (
+            WREMasterOrchestrator,
+        )
+
+        wre = WREMasterOrchestrator()
+        loader = getattr(wre, "skills_loader", None)
+
+        # WRE_MOCK_SKILLS env allows test injection of fake skills
+        mock_skills = set(filter(None, os.getenv("WRE_MOCK_SKILLS", "").split(",")))
+
+        for skill_name in required_skills:
+            # Check if this skill is actually registered (or mocked for tests)
+            has_skill = skill_name in mock_skills
+            if not has_skill and loader is not None:
+                has_skill_fn = getattr(loader, "has_skill", None)
+                if callable(has_skill_fn):
+                    try:
+                        has_skill = has_skill_fn(skill_name)
+                    except Exception:
+                        pass
+                if not has_skill:
+                    registry = getattr(loader, "registry", {}) or {}
+                    skills = registry.get("skills", {}) if isinstance(registry, dict) else {}
+                    has_skill = isinstance(skills, dict) and skill_name in skills
+
+            if not has_skill:
+                continue
+
+            input_context = {
+                "type": "autonomous_task",
+                "task_id": task_id,
+                "task": description,
+                "source": "openclaw_supervisor",
+                "context": context,
+            }
+
+            wre_result = wre.execute_skill(
+                skill_name=skill_name,
+                agent="qwen",
+                input_context=input_context,
+            )
+
+            success = wre_result.get("success", False)
+            return {
+                "ok": success,
+                "detail": json.dumps(wre_result, default=str)[:1000],
+                "executor": f"wre:{skill_name}",
+                "wre_result": wre_result,
+            }
+
+    except ImportError as e:
+        logger.debug("[RUN_TASK] WRE unavailable: %s", e)
+    except Exception as e:
+        logger.warning("[RUN_TASK] WRE dispatch error: %s", e)
+        return {"ok": False, "detail": f"wre_error: {e}", "executor": "wre"}
+
+    return None
+
+
+def _try_self_audit_dispatch(repo_root: Path, context: dict) -> Dict[str, Any] | None:
+    """Attempt to dispatch via DaemonSelfAuditLoop policy fix. Returns result or None."""
+    recommended_fix = None
+    if isinstance(context, dict):
+        ctx_inner = context.get("context", {})
+        if isinstance(ctx_inner, dict):
+            recommended_fix = ctx_inner.get("recommended_fix")
+
+    if not recommended_fix:
+        return None
+
+    try:
+        from modules.infrastructure.wre_core.src.daemon_self_audit_loop import DaemonSelfAuditLoop
+
+        audit_loop = DaemonSelfAuditLoop(repo_root)
+        if hasattr(audit_loop, "_apply_policy_fix"):
+            success, detail = audit_loop._apply_policy_fix(recommended_fix)
+            return {
+                "ok": success,
+                "detail": str(detail)[:500],
+                "executor": f"self_audit:{recommended_fix}",
+            }
+    except ImportError as e:
+        logger.debug("[RUN_TASK] DaemonSelfAuditLoop unavailable: %s", e)
+    except Exception as e:
+        logger.warning("[RUN_TASK] Self-audit dispatch error: %s", e)
+        return {"ok": False, "detail": f"self_audit_error: {e}", "executor": "self_audit"}
+
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run an autonomous task.")
+    parser.add_argument("--task_id", type=str, required=True, help="Task ID from AgentDB")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
+    result = execute_task(args.task_id)
+
+    if result["ok"]:
+        print(f"[RUN_TASK] SUCCESS: {result['executor']} ({result['execution_time_ms']}ms)")
+    else:
+        print(f"[RUN_TASK] FAILED: {result['detail'][:200]}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
@@ -1,19 +1,53 @@
 #!/usr/bin/env python3
-"""Explicit OpenClaw 24/7 supervisor state machine."""
+"""
+Canonical OpenClaw 24/7 Supervisor State Machine.
+
+This is the CANONICAL supervisor for the FoundUps Agent runtime.
+`Supervisor24x7` in modules/infrastructure/supervisor/ is a donor/prototype.
+
+Architecture (WSP prompt pack 2026-03-22):
+- AI Overseer: observe, gate, correlate, rank
+- OpenClawSupervisor: schedule, budget, launch, verify (THIS FILE)
+- OpenClaw: executive/control plane
+- WRE + DAEs: execution
+- PatternMemory: recall and learning
+
+State machine:
+    BOOT → PREFLIGHT → OBSERVE → TRIAGE → PLAN → EXECUTE → VERIFY → REMEMBER → ESCALATE → IDLE_WATCH
+      ↑___________________________________________________________________________________|
+"""
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import subprocess
+import sys
 import threading
 import time
+import uuid
 from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Deque, Dict, Optional
+from typing import Any, Callable, Deque, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SupervisorMetrics:
+    """Telemetry for observability (WSP 91)."""
+
+    cycles_completed: int = 0
+    events_observed: int = 0
+    tasks_executed: int = 0
+    tasks_succeeded: int = 0
+    escalations_triggered: int = 0
+    last_state_change: float = field(default_factory=time.time)
+    state_durations: Dict[str, float] = field(default_factory=dict)
 
 
 class SupervisorState(str, Enum):
@@ -30,7 +64,12 @@ class SupervisorState(str, Enum):
 
 
 class OpenClawSupervisor:
-    """Canonical 0102 supervisor for the resident OpenClaw runtime."""
+    """
+    Canonical 0102 supervisor for the resident OpenClaw runtime.
+
+    This is the production supervisor launched by main.py.
+    Unified from OpenClawSupervisor + Supervisor24x7 behaviors (P1 2026-03-22).
+    """
 
     def __init__(
         self,
@@ -60,9 +99,34 @@ class OpenClawSupervisor:
         self._event_cursor = 0
         self._restart_attempts: Deque[float] = deque()
 
+        # Unified from Supervisor24x7 (P1 2026-03-22)
+        self.metrics = SupervisorMetrics()
+        self._ai_overseer: Any | None = None
+        self._pattern_memory: Any | None = None
+        self._libido_monitor: Any | None = None
+        self._triage_queue: List[Dict[str, Any]] = []
+        self._execution_results: List[Dict[str, Any]] = []
+
     def stop(self) -> None:
         self._stop_event.set()
         self._stop_self_audit()
+
+    def get_metrics(self) -> Dict[str, Any]:
+        """Return telemetry metrics (WSP 91 observability)."""
+        return {
+            "state": self.current_state.value,
+            "cycles_completed": self.metrics.cycles_completed,
+            "events_observed": self.metrics.events_observed,
+            "tasks_executed": self.metrics.tasks_executed,
+            "tasks_succeeded": self.metrics.tasks_succeeded,
+            "escalations_triggered": self.metrics.escalations_triggered,
+            "uptime_seconds": time.time() - self.metrics.last_state_change,
+            "restart_budget": {
+                "max_attempts": self.max_restart_attempts,
+                "window_sec": self.restart_window_sec,
+                "attempts_in_window": self._attempts_in_window(),
+            },
+        }
 
     def run_forever(self) -> Dict[str, Any]:
         while not self._stop_event.is_set():
@@ -135,6 +199,10 @@ class OpenClawSupervisor:
         }
         return self.last_cycle
 
+    # ------------------------------------------------------------------ #
+    #  Infrastructure helpers                                             #
+    # ------------------------------------------------------------------ #
+
     def _build_daemon_reporter(self) -> Callable[[str, str, Dict[str, Any]], None]:
         from modules.infrastructure.dae_daemon.src.dae_daemon import get_central_daemon
         from modules.infrastructure.dae_daemon.src.schemas import DAEEventType
@@ -179,6 +247,10 @@ class OpenClawSupervisor:
             {"state": state.value, "reason": reason},
         )
 
+    # ------------------------------------------------------------------ #
+    #  Self-Audit Lifecycle                                               #
+    # ------------------------------------------------------------------ #
+
     def _start_self_audit(self) -> None:
         if not self.self_audit_enabled or self._self_audit_loop is not None:
             return
@@ -204,6 +276,38 @@ class OpenClawSupervisor:
                 {"subsystem": "daemon_self_audit", "error": str(exc)[:200]},
             )
 
+        # Initialize unified components (ported from Supervisor24x7)
+        self._init_unified_components()
+
+    def _init_unified_components(self) -> None:
+        """Initialize AI Overseer, PatternMemory, LibidoMonitor (unified from Supervisor24x7)."""
+        # AI Overseer for PLAN state
+        try:
+            from modules.ai_intelligence.ai_overseer.src.ai_overseer import (
+                AIIntelligenceOverseer,
+            )
+            self._ai_overseer = AIIntelligenceOverseer(repo_root=self.repo_root)
+            logger.info("[SUPERVISOR] AI Overseer loaded")
+        except ImportError as e:
+            logger.debug("[SUPERVISOR] AI Overseer unavailable: %s", e)
+
+        # Pattern Memory for REMEMBER state
+        try:
+            from modules.infrastructure.wre_core.src.pattern_memory import PatternMemory
+            db_path = self.repo_root / "modules/infrastructure/wre_core/memory/pattern_memory.db"
+            self._pattern_memory = PatternMemory(db_path=db_path)
+            logger.info("[SUPERVISOR] PatternMemory loaded")
+        except (ImportError, Exception) as e:
+            logger.debug("[SUPERVISOR] PatternMemory unavailable: %s", e)
+
+        # Libido Monitor for VERIFY state (Gemma fidelity)
+        try:
+            from modules.infrastructure.wre_core.src.libido_monitor import GemmaLibidoMonitor
+            self._libido_monitor = GemmaLibidoMonitor()
+            logger.info("[SUPERVISOR] LibidoMonitor loaded")
+        except (ImportError, Exception) as e:
+            logger.debug("[SUPERVISOR] LibidoMonitor unavailable: %s", e)
+
     def _stop_self_audit(self) -> None:
         if self._self_audit_loop is None:
             return
@@ -212,10 +316,14 @@ class OpenClawSupervisor:
         finally:
             self._self_audit_loop = None
 
+    # ------------------------------------------------------------------ #
+    #  OBSERVE — poll broker, observer, git, self-audit                   #
+    # ------------------------------------------------------------------ #
+
     def _observe(self) -> Dict[str, Any]:
         broker = self._get_broker()
         observer = self._get_observer()
-        return {
+        obs: Dict[str, Any] = {
             "openclaw_runtime": broker.get_runtime_status("openclaw") if broker else {"registered": False},
             "supervisor_runtime": broker.get_runtime_status("openclaw_supervisor") if broker else {"registered": False},
             "openclaw_live": observer.get_live_status("openclaw", limit=4) if observer else {"registered": False},
@@ -235,7 +343,28 @@ class OpenClawSupervisor:
                 "window_sec": self.restart_window_sec,
                 "attempts_in_window": self._attempts_in_window(),
             },
+            "self_audit_events": [],
         }
+
+        # Poll DaemonSelfAuditLoop for real events (ported from Supervisor24x7)
+        if self._self_audit_loop and hasattr(self._self_audit_loop, "scan_once"):
+            try:
+                events = self._self_audit_loop.scan_once()
+                if events:
+                    obs["self_audit_events"] = list(events)
+                    self.metrics.events_observed += len(obs["self_audit_events"])
+                    logger.info(
+                        "[SUPERVISOR] OBSERVE: %d self-audit events detected",
+                        len(obs["self_audit_events"]),
+                    )
+            except Exception as exc:
+                logger.warning("[SUPERVISOR] OBSERVE: scan_once() failed: %s", exc)
+
+        return obs
+
+    # ------------------------------------------------------------------ #
+    #  TRIAGE — decide what action to take                                #
+    # ------------------------------------------------------------------ #
 
     def _triage(self, observation: Dict[str, Any]) -> Dict[str, Any]:
         broker = self._get_broker()
@@ -263,22 +392,76 @@ class OpenClawSupervisor:
                 "restart_budget": observation.get("restart_budget", {}),
             }
 
+        # Check AgentDB for pending autonomous tasks
+        try:
+            from modules.infrastructure.database.src.agent_db import AgentDB
+            db = AgentDB()
+            tasks = db.get_autonomous_tasks(status="pending", limit=1)
+            if tasks:
+                return {
+                    "kind": "action",
+                    "reason": "autonomous_task_pending",
+                    "action": "execute_autonomous_task",
+                    "task": tasks[0],
+                }
+        except Exception as exc:
+            logger.warning("Failed to check autonomous tasks: %s", exc)
+
+        # Check self-audit events (lower priority than restart and AgentDB tasks)
+        audit_events = observation.get("self_audit_events", [])
+        if audit_events:
+            event = audit_events[0]
+            signature = getattr(event, "signature", str(event))
+            recommended_fix = "inspect_log_and_create_patch_task"
+            auto_fixable = False
+            if self._self_audit_loop and hasattr(self._self_audit_loop, "_recommend_fix"):
+                try:
+                    recommended_fix = self._self_audit_loop._recommend_fix(signature)
+                except Exception:
+                    pass
+            if self._self_audit_loop:
+                allowed = getattr(self._self_audit_loop, "allowed_fixes", set())
+                auto_fixable = recommended_fix in allowed
+            if auto_fixable:
+                return {
+                    "kind": "action",
+                    "reason": "self_audit_event_detected",
+                    "action": "execute_self_audit_fix",
+                    "event_signature": signature,
+                    "recommended_fix": recommended_fix,
+                }
+
         return {"kind": "idle", "reason": "resident_openclaw_healthy"}
 
+    # ------------------------------------------------------------------ #
+    #  PLAN — build execution plan from triage                            #
+    # ------------------------------------------------------------------ #
+
     def _plan(self, triage: Dict[str, Any], observation: Dict[str, Any]) -> Dict[str, Any]:
-        return {
+        plan: Dict[str, Any] = {
             "action": triage["action"],
             "target": "openclaw",
             "reason": triage["reason"],
             "git_dirty_files": observation["git"]["dirty_files"],
             "restart_budget": observation.get("restart_budget", {}),
             "next_restart_attempt": self._attempts_in_window() + 1,
+            "task": triage.get("task"),
         }
+        # Carry self-audit fix metadata into plan
+        if triage["action"] == "execute_self_audit_fix":
+            plan["event_signature"] = triage.get("event_signature")
+            plan["recommended_fix"] = triage.get("recommended_fix")
+        return plan
+
+    # ------------------------------------------------------------------ #
+    #  EXECUTE — dispatch action                                          #
+    # ------------------------------------------------------------------ #
 
     def _execute(self, plan: Dict[str, Any]) -> Dict[str, Any]:
         broker = self._get_broker()
         if broker is None:
             return {"ok": False, "error": "broker_unavailable"}
+
         if plan["action"] == "start_openclaw":
             self._record_restart_attempt()
             result = broker.start_dae("openclaw", actor_id="0102")
@@ -288,12 +471,120 @@ class OpenClawSupervisor:
                 {"plan": plan, "result": result},
             )
             return result
+
+        elif plan["action"] == "execute_autonomous_task":
+            task = plan.get("task", {})
+            task_id = task.get("task_id")
+            result: Dict[str, Any] = {"ok": False, "error": "unknown"}
+            try:
+                from modules.infrastructure.database.src.agent_db import AgentDB
+
+                db = AgentDB()
+                if task_id:
+                    db.assign_autonomous_task(task_id, "openclaw_supervisor")
+
+                    # In-process dispatch via run_task.execute_task()
+                    from modules.communication.moltbot_bridge.scripts.run_task import (
+                        execute_task,
+                    )
+
+                    task_result = execute_task(task_id, repo_root=self.repo_root)
+                    result = {
+                        "ok": task_result.get("ok", False),
+                        "status": "completed" if task_result.get("ok") else "task_failed",
+                        "executor": task_result.get("executor", "unknown"),
+                        "detail": task_result.get("detail", "")[:1000],
+                        "execution_time_ms": task_result.get("execution_time_ms", 0),
+                    }
+                else:
+                    result = {"ok": False, "error": "no_task_id"}
+            except Exception as exc:
+                result = {"ok": False, "status": "execute_error", "error": str(exc)[:500]}
+
+            self._action_reporter(
+                "supervisor_execute",
+                result.get("status", result.get("error", "unknown")),
+                {"plan": plan, "result": result},
+            )
+            return result
+
+        elif plan["action"] == "execute_self_audit_fix":
+            recommended_fix = plan.get("recommended_fix", "")
+            result: Dict[str, Any] = {"ok": False, "error": "no_audit_loop"}
+            if self._self_audit_loop and hasattr(self._self_audit_loop, "_apply_policy_fix"):
+                try:
+                    success, detail = self._self_audit_loop._apply_policy_fix(recommended_fix)
+                    result = {
+                        "ok": success,
+                        "status": "applied" if success else "fix_failed",
+                        "detail": str(detail)[:500],
+                    }
+                except Exception as exc:
+                    result = {"ok": False, "status": "fix_error", "error": str(exc)[:500]}
+
+            self._action_reporter(
+                "supervisor_execute",
+                result.get("status", result.get("error", "unknown")),
+                {"plan": plan, "result": result},
+            )
+            return result
+
         return {"ok": False, "error": "unsupported_action"}
+
+    # ------------------------------------------------------------------ #
+    #  VERIFY — check execution results                                   #
+    # ------------------------------------------------------------------ #
 
     def _verify(self, plan: Dict[str, Any], action_result: Dict[str, Any]) -> Dict[str, Any]:
         broker = self._get_broker()
         if broker is None:
             return {"ok": False, "error": "broker_unavailable"}
+
+        if plan["action"] == "execute_autonomous_task":
+            task = plan.get("task", {})
+            task_id = task.get("task_id")
+            task_status = None
+
+            try:
+                from modules.infrastructure.database.src.agent_db import AgentDB
+
+                db = AgentDB()
+                completed_tasks = db.get_autonomous_tasks(status="completed", limit=100)
+                if task_id and any(item.get("task_id") == task_id for item in completed_tasks):
+                    task_status = "completed"
+            except Exception as exc:
+                logger.debug("[SUPERVISOR] VERIFY: task status check skipped: %s", exc)
+
+            ok = bool(action_result.get("ok", False) and task_status == "completed")
+            fidelity = 0.85  # Default
+
+            # Gemma fidelity validation (unified from Supervisor24x7)
+            if ok and self._libido_monitor and hasattr(self._libido_monitor, "validate_step_fidelity"):
+                try:
+                    validation = self._libido_monitor.validate_step_fidelity(
+                        step_description=f"Task: {plan.get('task', {}).get('task_id', 'unknown')}",
+                        step_output=str(action_result)[:500],
+                    )
+                    if isinstance(validation, dict):
+                        fidelity = validation.get("fidelity", 0.85)
+                    elif isinstance(validation, (int, float)):
+                        fidelity = float(validation)
+                    logger.debug("[SUPERVISOR] VERIFY: Gemma fidelity = %.3f", fidelity)
+                except Exception as e:
+                    logger.debug("[SUPERVISOR] VERIFY: Gemma validation skipped: %s", e)
+
+            error = action_result.get("error", "")
+            if not ok and not error and task_status != "completed":
+                error = "task_not_completed"
+
+            return {
+                "ok": ok,
+                "status": action_result,
+                "task_status": task_status,
+                "error": error,
+                "fidelity": fidelity,
+            }
+
         status = broker.get_runtime_status(plan["target"])
         running_states = {"starting", "running", "degraded"}
         ok = (
@@ -306,6 +597,10 @@ class OpenClawSupervisor:
         )
         return {"ok": ok, "status": status, "error": status.get("last_error", "")}
 
+    # ------------------------------------------------------------------ #
+    #  REMEMBER — store outcomes and update metrics                       #
+    # ------------------------------------------------------------------ #
+
     def _remember(
         self,
         observation: Dict[str, Any],
@@ -313,6 +608,14 @@ class OpenClawSupervisor:
         action_result: Dict[str, Any],
         verify: Dict[str, Any],
     ) -> None:
+        # Update metrics
+        self.metrics.cycles_completed += 1
+        if action_result.get("ok"):
+            self.metrics.tasks_executed += 1
+            if verify.get("ok"):
+                self.metrics.tasks_succeeded += 1
+
+        # Report to daemon
         self._action_reporter(
             "supervisor_cycle",
             "recorded",
@@ -327,8 +630,43 @@ class OpenClawSupervisor:
                 "openclaw_follow": observation.get("openclaw_follow", {}),
             },
         )
+
+        # Store to PatternMemory using proper SkillOutcome dataclass
+        if self._pattern_memory and action_result.get("ok"):
+            try:
+                from modules.infrastructure.wre_core.src.pattern_memory import SkillOutcome
+
+                skill_name = plan_or_triage.get("action", "unknown")
+                fidelity = float(verify.get("fidelity", 0.85))
+                outcome = SkillOutcome(
+                    execution_id=f"supervisor_{uuid.uuid4().hex[:12]}",
+                    skill_name=skill_name,
+                    agent="openclaw_supervisor",
+                    timestamp=datetime.now().isoformat(),
+                    input_context=json.dumps(plan_or_triage, default=str)[:2000],
+                    output_result=json.dumps(action_result, default=str)[:2000],
+                    success=bool(verify.get("ok", False)),
+                    pattern_fidelity=fidelity,
+                    outcome_quality=1.0 if verify.get("ok") else 0.0,
+                    execution_time_ms=int(action_result.get("execution_time_ms", 0)),
+                    step_count=1,
+                    notes=f"Supervisor cycle: {plan_or_triage.get('reason', '')}",
+                )
+                self._pattern_memory.store_outcome(outcome)
+                logger.debug(
+                    "[SUPERVISOR] REMEMBER: Stored SkillOutcome for %s (fidelity=%.3f)",
+                    skill_name,
+                    fidelity,
+                )
+            except Exception as e:
+                logger.debug("[SUPERVISOR] REMEMBER: PatternMemory storage skipped: %s", e)
+
         follow = observation.get("openclaw_follow", {})
         self._event_cursor = int(follow.get("next_cursor", self._event_cursor) or self._event_cursor)
+
+    # ------------------------------------------------------------------ #
+    #  Utility helpers                                                    #
+    # ------------------------------------------------------------------ #
 
     def _git_summary(self) -> Dict[str, Any]:
         try:

--- a/modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py
@@ -1,9 +1,20 @@
 from unittest.mock import MagicMock
 
+import pytest
+
 from modules.communication.moltbot_bridge.src.openclaw_supervisor import (
     OpenClawSupervisor,
     SupervisorState,
 )
+from modules.infrastructure.database.src.db_manager import DatabaseManager
+
+
+@pytest.fixture(autouse=True)
+def isolated_agent_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("FOUNDUPS_DB_PATH", str(tmp_path / "foundups.db"))
+    DatabaseManager.reset_for_tests()
+    yield
+    DatabaseManager.reset_for_tests()
 
 
 def test_run_cycle_starts_openclaw_when_resident_runtime_is_down(tmp_path):
@@ -75,7 +86,10 @@ def test_run_cycle_idles_when_resident_runtime_is_healthy(tmp_path):
         self_audit_factory=lambda repo_root: MagicMock(),
     )
 
-    result = supervisor.run_cycle()
+    from unittest.mock import patch
+    with patch("modules.infrastructure.database.src.agent_db.AgentDB") as mock_db:
+        mock_db.return_value.get_autonomous_tasks.return_value = []
+        result = supervisor.run_cycle()
 
     broker.start_dae.assert_not_called()
     assert result["triage"]["kind"] == "idle"

--- a/modules/communication/moltbot_bridge/tests/test_openclaw_supervisor_p0.py
+++ b/modules/communication/moltbot_bridge/tests/test_openclaw_supervisor_p0.py
@@ -1,0 +1,73 @@
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.openclaw_supervisor import OpenClawSupervisor
+from modules.infrastructure.database.src.agent_db import AgentDB
+from modules.infrastructure.database.src.db_manager import DatabaseManager
+
+
+def test_run_cycle_executes_and_completes_pending_autonomous_task(tmp_path, monkeypatch):
+    db_path = tmp_path / "foundups.db"
+    monkeypatch.setenv("FOUNDUPS_DB_PATH", str(db_path))
+    # Mock WRE to accept "test" skill and return success
+    monkeypatch.setenv("WRE_MOCK_SKILLS", "test")
+    DatabaseManager.reset_for_tests()
+
+    # Mock WRE execute_skill to return success
+    mock_wre = MagicMock()
+    mock_wre.skills_loader = MagicMock()
+    mock_wre.skills_loader.has_skill.return_value = True
+    mock_wre.execute_skill.return_value = {"success": True, "output": "test completed"}
+    monkeypatch.setattr(
+        "modules.infrastructure.wre_core.wre_master_orchestrator.src.wre_master_orchestrator.WREMasterOrchestrator",
+        lambda: mock_wre,
+    )
+
+    db = AgentDB()
+    task_id = "test_task_p0_001"
+    created = db.create_autonomous_task(
+        task_id=task_id,
+        description="Test P0 autonomous pipeline",
+        required_skills=["test"],
+        estimated_complexity=1.0,
+        priority_score=99.0,
+        context={"test": True},
+    )
+    assert created is True
+
+    broker = MagicMock()
+    broker.get_runtime_status.side_effect = lambda dae_id: {
+        "registered": True,
+        "running": True,
+        "state": "running",
+        "last_error": "",
+        "enabled": True,
+    }
+
+    observer = MagicMock()
+    observer.get_live_status.return_value = {"registered": True}
+    observer.follow_events.return_value = {
+        "events": [],
+        "next_cursor": 0,
+        "latest_sequence_id": 0,
+    }
+
+    events = []
+    supervisor = OpenClawSupervisor(
+        repo_root=Path(__file__).resolve().parents[4],
+        broker=broker,
+        observer=observer,
+        action_reporter=lambda action, result, details: events.append((action, result, details)),
+    )
+    supervisor._bootstrapped = True
+
+    result = supervisor.run_cycle()
+
+    completed = db.get_autonomous_tasks(status="completed", limit=10)
+    assert any(item["task_id"] == task_id for item in completed)
+    assert result["plan"]["action"] == "execute_autonomous_task"
+    assert result["verify"]["ok"] is True
+    assert result["verify"]["task_status"] == "completed"
+    assert any(action == "supervisor_execute" and outcome == "completed" for action, outcome, _ in events)
+
+    DatabaseManager.reset_for_tests()


### PR DESCRIPTION
## Summary

Closes the P0 autonomy gap identified in OpenClaw supervisor:

1. **WREMasterOrchestrator constructor fix** - `run_task.py` was calling `WREMasterOrchestrator(repo_root)` but constructor takes no args (orchestrator computes repo_root internally)

2. **P0 test with proper WRE mocking** - New `test_openclaw_supervisor_p0.py` that mocks WRE dispatch and verifies the full cycle: supervisor polls → dispatches → completes task

3. **Headless autonomous mode** - `python main.py --headless` runs OpenClaw supervisor loop without interactive menu. FAIL-CLOSED: exits if WRE readiness != READY|INSUFFICIENT_DATA

4. **OpenClaw supervisor enhancements** - Polls self-audit tasks, dispatches in-process, writes SkillOutcome

## Test plan

- [x] `python -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py -q` → 4 passed
- [x] `python -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_supervisor_p0.py -q` → 1 passed
- [x] `python main.py --connect-wre` → returns WRE status
- [x] `OPENCLAW_HEADLESS_MAX_CYCLES=1 python main.py --headless` → runs 1 supervisor cycle

## Remaining (P1, separate PR)

- AI Overseer in supervisor planning (initialized but not used in `_plan()`)
- Route unmapped menu islands (coverage 0.619)
- Fail-closed for general COMMAND routing (currently advisory fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)