### PR TITLE
feat(openclaw): wire memory nudge engine into self-research loop (P1)

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,108 @@
 # ModLog - moltbot_bridge
 
+## 2026-03-23: Memory Nudge Runtime Wiring (P1)
+
+**Author**: 0102
+**WSP**: 22, 60, 97
+
+### Context
+
+Memory nudge engine existed (PR #237) but was not called from live loops.
+This wiring connects it to the self-research refresh cycle.
+
+### Changes
+
+1. **Enhanced emit_memory_nudges()** with `record_breadcrumbs` parameter:
+   - When enabled, records a breadcrumb in AgentDB for each emitted nudge
+   - Session ID: `self_research_{YYYYMMDD}` for daily aggregation
+   - Action: `memory_nudge_emitted` with trigger type, priority, provenance
+
+2. **Wired into self_research_refresh.py**:
+   - New `emit_nudges=True` parameter on `run()` method
+   - Called after report is written, before `remember_outcome`
+   - Report now includes `memory_nudges_emitted` count
+   - CLI flag: `--no-nudges` to disable
+
+### Files Changed
+
+- `src/memory_nudge_engine.py`: Added `_record_breadcrumb()`, updated signatures
+- `modules/infrastructure/idle_automation/src/self_research_refresh.py`: Added `_emit_memory_nudges()` method
+- `tests/test_memory_nudge_engine.py`: 3 new tests for breadcrumb recording
+
+### Verification
+
+```
+pytest test_memory_nudge_engine.py  # 19 passed
+pytest test_self_research_refresh.py  # 7 passed
+```
+
+Live test: 6 nudges emitted, 8 breadcrumbs recorded (some from earlier runs).
+
+---
+
+## 2026-03-23: Grant Task Pipeline Executable (P0)
+
+**Author**: 0102
+**WSP**: 22, 97
+
+### Problem
+
+Grant work was discovered by self-research but not autonomously executable:
+- Tasks used slugified IDs (`self_research_external_watchlist_review_5...`)
+- Dispatch expected stable IDs (`grant_watchlist_review`, `grant_watchlist_stabilize`)
+- Old tasks accumulated alongside new ones
+
+### Solution
+
+1. **Stable task IDs** (already in self_research_refresh.py, now verified working):
+   - `grant_watchlist_review` for changed grant pages
+   - `grant_watchlist_stabilize` for watchlist fetch errors
+   - INSERT OR REPLACE deduplicates by task_id PRIMARY KEY
+
+2. **Stale task cleanup** in `publish_autonomous_tasks()`:
+   - Narrowed to grant-only pattern: `self_research_external_watchlist_%grant%`
+   - Does NOT delete PQN or OpenClaw ecosystem watchlist tasks
+   - Sets `status = 'pending'` after creation (AgentDB may not set it)
+
+3. **Completed task protection**:
+   - Checks if stable grant task exists in `completed` status
+   - Compares `changed_items`/`error_items` context
+   - Skips republish with `skipped_reason: completed_same_context` if unchanged
+
+4. **Structured grant executor** (`src/grant_task_executor.py`):
+   - `execute_grant_review()`: Returns per-item findings, repo-fit assessment, recommendations
+   - `execute_grant_stabilize()`: Returns error diagnostics, remediation steps
+   - Priority mapping matches actual rescored sheet groups:
+     - `p0_apply_now` → 0.95 fit score
+     - `p1_after_one_concrete_adapter` → 0.70 fit score
+     - `p2_deprioritized_until_new_chain_surface` → 0.35 fit score
+
+5. **run_task.py dispatch** updated to use structured executor instead of OpenClawDAE
+
+### Files Changed
+
+- `modules/infrastructure/idle_automation/src/self_research_refresh.py`: Stale cleanup + completed protection
+- `modules/communication/moltbot_bridge/scripts/run_task.py`: Use grant_task_executor
+- `modules/communication/moltbot_bridge/src/grant_task_executor.py`: New file, 200 lines
+- `modules/communication/moltbot_bridge/tests/test_grant_task_execution.py`: 15 tests
+
+### Verification
+
+- `pytest test_grant_task_execution.py` → 15 passed
+- Repro 1: Completed task same context → skipped (not reopened)
+- Repro 2: Ethereum ESP (p0_apply_now) → fit_score=0.95, generates recommendations
+- Stable task_ids confirmed: `grant_watchlist_review`, `grant_watchlist_stabilize`
+
+### Human-Only Gates Intact
+
+Per SKILL.md, OpenClaw does NOT:
+- Submit applications
+- Assert identity
+- Sign wallets
+- Click final binding submit
+
+---
+
 ## 2026-03-23: Memory Nudge Engine (P0)
 
 **Author**: 0102

--- a/modules/communication/moltbot_bridge/src/memory_nudge_engine.py
+++ b/modules/communication/moltbot_bridge/src/memory_nudge_engine.py
@@ -115,9 +115,17 @@ class MemoryNudgeEngine:
         events.extend(self._scan_worktree_pressure())
         return events
 
-    def emit_nudges(self, events: Optional[List[NudgeEvent]] = None) -> List[Path]:
+    def emit_nudges(
+        self,
+        events: Optional[List[NudgeEvent]] = None,
+        record_breadcrumbs: bool = False,
+    ) -> List[Path]:
         """
         Write memory notes for high-value events.
+
+        Args:
+            events: Events to emit (scans if None).
+            record_breadcrumbs: If True, record a breadcrumb for each emitted nudge.
 
         Returns list of created note paths.
         Deduplicates based on event signature.
@@ -136,7 +144,37 @@ class MemoryNudgeEngine:
                 created.append(note_path)
                 self._seen_signatures.add(event.signature)
 
+                # Record breadcrumb if enabled
+                if record_breadcrumbs:
+                    self._record_breadcrumb(event, note_path)
+
         return created
+
+    def _record_breadcrumb(self, event: NudgeEvent, note_path: Path) -> None:
+        """Record a breadcrumb in AgentDB for the emitted nudge."""
+        try:
+            from modules.infrastructure.database.src.agent_db import AgentDB
+
+            db = AgentDB()
+            session_id = f"self_research_{datetime.now(UTC).strftime('%Y%m%d')}"
+            db.add_breadcrumb(
+                session_id=session_id,
+                action="memory_nudge_emitted",
+                agent_id="memory_nudge_engine",
+                query=event.title,
+                data={
+                    "trigger_type": event.trigger_type,
+                    "priority": event.priority,
+                    "signature": event.signature,
+                    "provenance": event.provenance,
+                    "note_path": str(note_path.relative_to(self.repo_root)),
+                },
+            )
+            logger.debug("Recorded breadcrumb for nudge: %s", event.signature)
+        except ImportError:
+            logger.debug("AgentDB not available for breadcrumb recording")
+        except Exception as exc:
+            logger.debug("Failed to record breadcrumb: %s", exc)
 
     def _write_note(self, event: NudgeEvent) -> Optional[Path]:
         """Write a single memory note for an event."""
@@ -351,14 +389,21 @@ class MemoryNudgeEngine:
 # ------------------------------------------------------------------ #
 
 
-def emit_memory_nudges(repo_root: Optional[Path] = None) -> List[Path]:
+def emit_memory_nudges(
+    repo_root: Optional[Path] = None,
+    record_breadcrumbs: bool = False,
+) -> List[Path]:
     """
     Convenience function to scan and emit memory nudges.
+
+    Args:
+        repo_root: Repository root path.
+        record_breadcrumbs: If True, record a breadcrumb for each emitted nudge.
 
     Returns list of created note paths.
     """
     engine = MemoryNudgeEngine(repo_root=repo_root)
-    return engine.emit_nudges()
+    return engine.emit_nudges(record_breadcrumbs=record_breadcrumbs)
 
 
 def scan_nudge_events(repo_root: Optional[Path] = None) -> List[NudgeEvent]:

--- a/modules/communication/moltbot_bridge/tests/test_memory_nudge_engine.py
+++ b/modules/communication/moltbot_bridge/tests/test_memory_nudge_engine.py
@@ -413,3 +413,109 @@ class TestConvenienceFunctions:
         assert isinstance(result, list)
         # Should have created one note for the P0 item
         assert len(result) >= 1
+
+
+class TestBreadcrumbRecording:
+    """Tests for breadcrumb recording when nudges are emitted."""
+
+    def test_emit_nudges_records_breadcrumb_when_enabled(self, tmp_workspace, monkeypatch):
+        """When record_breadcrumbs=True, a breadcrumb is recorded for each nudge."""
+        # Track breadcrumb calls
+        breadcrumb_calls = []
+
+        class MockAgentDB:
+            def add_breadcrumb(self, **kwargs):
+                breadcrumb_calls.append(kwargs)
+                return 1
+
+        # Patch AgentDB import
+        import sys
+        mock_module = type(sys)("mock_agent_db")
+        mock_module.AgentDB = MockAgentDB
+        monkeypatch.setitem(
+            sys.modules,
+            "modules.infrastructure.database.src.agent_db",
+            mock_module,
+        )
+
+        engine = MemoryNudgeEngine(
+            repo_root=tmp_workspace["repo_root"],
+            memory_dir=tmp_workspace["memory_dir"],
+            reports_dir=tmp_workspace["reports_dir"],
+        )
+
+        event = NudgeEvent(
+            trigger_type="test_trigger",
+            title="Test Event",
+            summary="Test summary",
+            provenance="test/source.json",
+            priority="P1",
+        )
+
+        created = engine.emit_nudges([event], record_breadcrumbs=True)
+
+        assert len(created) == 1
+        assert len(breadcrumb_calls) == 1
+        assert breadcrumb_calls[0]["action"] == "memory_nudge_emitted"
+        assert breadcrumb_calls[0]["agent_id"] == "memory_nudge_engine"
+        assert "test_trigger" in str(breadcrumb_calls[0]["data"])
+
+    def test_emit_nudges_skips_breadcrumb_when_disabled(self, tmp_workspace, monkeypatch):
+        """When record_breadcrumbs=False, no breadcrumb is recorded."""
+        breadcrumb_calls = []
+
+        class MockAgentDB:
+            def add_breadcrumb(self, **kwargs):
+                breadcrumb_calls.append(kwargs)
+                return 1
+
+        import sys
+        mock_module = type(sys)("mock_agent_db")
+        mock_module.AgentDB = MockAgentDB
+        monkeypatch.setitem(
+            sys.modules,
+            "modules.infrastructure.database.src.agent_db",
+            mock_module,
+        )
+
+        engine = MemoryNudgeEngine(
+            repo_root=tmp_workspace["repo_root"],
+            memory_dir=tmp_workspace["memory_dir"],
+            reports_dir=tmp_workspace["reports_dir"],
+        )
+
+        event = NudgeEvent(
+            trigger_type="test_trigger",
+            title="Test Event",
+            summary="Test summary",
+            provenance="test/source.json",
+        )
+
+        created = engine.emit_nudges([event], record_breadcrumbs=False)
+
+        assert len(created) == 1
+        assert len(breadcrumb_calls) == 0
+
+    def test_emit_memory_nudges_convenience_passes_breadcrumb_flag(self, tmp_workspace):
+        """Convenience function passes record_breadcrumbs to engine."""
+        # Create wre_core reports dir
+        wre_reports = tmp_workspace["repo_root"] / "modules/infrastructure/wre_core/reports"
+        wre_reports.mkdir(parents=True, exist_ok=True)
+
+        # Create triggering condition
+        status = {
+            "update_candidates": [
+                {"title": "Test", "mps": {"priority": "P0", "reasoning": "Test"}},
+            ]
+        }
+        (tmp_workspace["reports_dir"] / "openclaw_self_research_status.json").write_text(
+            json.dumps(status), encoding="utf-8"
+        )
+
+        # Just verify it doesn't error with record_breadcrumbs=True
+        # (AgentDB import may fail in test environment, but that's OK - graceful degradation)
+        result = emit_memory_nudges(
+            repo_root=tmp_workspace["repo_root"],
+            record_breadcrumbs=True,
+        )
+        assert isinstance(result, list)

--- a/modules/infrastructure/idle_automation/ModLog.md
+++ b/modules/infrastructure/idle_automation/ModLog.md
@@ -12,6 +12,34 @@ This log tracks changes specific to the **idle_automation** module in the **infr
 
 ## MODLOG ENTRIES
 
+### 2026-03-23 - Memory Nudge Runtime Wiring
+
+**WSP Protocol**: WSP 22, WSP 60 (Memory Architecture), WSP 97 (Autonomy Boundaries)
+**Phase**: Automation Hardening
+**Agent**: 0102
+
+#### Changes to self_research_refresh.py
+
+- **Added**: `emit_nudges` parameter to `run()` method (default: True)
+- **Added**: `_emit_memory_nudges()` method to call memory nudge engine after report written
+- **Added**: `--no-nudges` CLI flag for disabling nudge emission
+- **Added**: `memory_nudges_emitted` count in final report
+
+#### Integration Points
+
+The memory nudge engine (from moltbot_bridge) is now called at the end of each self-research cycle:
+1. Self-research writes status reports
+2. Nudge engine scans those reports for high-value events
+3. Creates deduplicated memory notes in workspace/memory/
+4. Records breadcrumbs in AgentDB for cross-session recall
+
+#### Tests Added
+
+- `test_run_emits_memory_nudges_when_high_value_events_detected`
+- `test_run_skips_nudges_when_emit_nudges_false`
+
+---
+
 ### 2026-03-22 - OpenClaw Self-Research Refresh Loop
 **WSP Protocol**: WSP 15 (MPS Prioritization), WSP 27 (DAE Architecture), WSP 48 (Recursive Improvement), WSP 60 (Memory Architecture), WSP 84 (Code Reuse)
 **Phase**: Automation Hardening

--- a/modules/infrastructure/idle_automation/src/self_research_refresh.py
+++ b/modules/infrastructure/idle_automation/src/self_research_refresh.py
@@ -451,10 +451,12 @@ class SelfResearchRefresher:
         deferability: int,
         impact: int,
         reasoning: str,
+        stable_task_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         score = manual_mps(complexity, importance, deferability, impact, reasoning)
+        task_id = stable_task_id or f"self_research_{source}_{slugify(title)}"
         return {
-            "task_id": f"self_research_{source}_{slugify(title)}",
+            "task_id": task_id,
             "source": source,
             "title": title,
             "description": description,
@@ -555,6 +557,7 @@ class SelfResearchRefresher:
                     deferability=4,
                     impact=4,
                     reasoning="External opportunities changed; quick review yields near-term funding leverage.",
+                    stable_task_id="grant_watchlist_review",
                 )
             )
 
@@ -574,6 +577,7 @@ class SelfResearchRefresher:
                     deferability=3,
                     impact=3,
                     reasoning="Watchlist fetch failures reduce external awareness but are usually quick to harden.",
+                    stable_task_id="grant_watchlist_stabilize",
                 )
             )
 
@@ -602,6 +606,7 @@ class SelfResearchRefresher:
                         "External research tooling drift can change adoption guidance and "
                         "benchmark positioning for PQN work."
                     ),
+                    stable_task_id="pqn_watchlist_review",
                 )
             )
 
@@ -627,6 +632,7 @@ class SelfResearchRefresher:
                         "External benchmark monitoring should stay healthy but is less urgent "
                         "than direct system or funding path failures."
                     ),
+                    stable_task_id="pqn_watchlist_stabilize",
                 )
             )
 
@@ -655,6 +661,7 @@ class SelfResearchRefresher:
                         "Context and memory infrastructure shifts can materially change the "
                         "OpenClaw roadmap, but should still be gated through WSP 97 review."
                     ),
+                    stable_task_id="openclaw_ecosystem_watchlist_review",
                 )
             )
 
@@ -680,6 +687,7 @@ class SelfResearchRefresher:
                         "Ecosystem drift monitoring should stay healthy so architecture "
                         "decisions are based on current upstream reality."
                     ),
+                    stable_task_id="openclaw_ecosystem_watchlist_stabilize",
                 )
             )
 
@@ -693,14 +701,85 @@ class SelfResearchRefresher:
         return candidates[: self.max_candidates]
 
     def publish_autonomous_tasks(self, candidates: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Write ranked candidates into the existing AgentDB autonomous queue."""
+        """Write ranked candidates into the existing AgentDB autonomous queue.
+
+        Grant tasks use stable task_ids (grant_watchlist_review, grant_watchlist_stabilize)
+        to prevent duplicate accumulation and enable deterministic dispatch.
+
+        Completed stable grant tasks are NOT reopened unless context materially changed.
+        """
         from modules.infrastructure.database.src.agent_db import AgentDB
 
         db = AgentDB()
+
+        # Clean up stale slugified GRANT tasks only (not PQN/ecosystem watchlist tasks)
+        # Pattern: self_research_external_watchlist_*grant* but NOT the stable grant IDs
+        stable_grant_task_ids = {"grant_watchlist_review", "grant_watchlist_stabilize"}
+        candidate_task_ids = {c["task_id"] for c in candidates}
+        if candidate_task_ids & stable_grant_task_ids:
+            try:
+                # Only remove old slugified grant-specific task IDs
+                db.db.execute_write(
+                    """
+                    DELETE FROM agents_autonomous_tasks
+                    WHERE status IN ('pending', NULL)
+                      AND task_id LIKE 'self_research_external_watchlist_%grant%'
+                      AND task_id NOT IN (?, ?)
+                    """,
+                    ("grant_watchlist_review", "grant_watchlist_stabilize"),
+                )
+            except Exception as exc:
+                logger.debug("Stale grant task cleanup skipped: %s", exc)
+
+        # Check which stable grant tasks are already completed
+        completed_stable_grants = set()
+        for task_id in stable_grant_task_ids:
+            try:
+                rows = db.db.execute_query(
+                    "SELECT status, context FROM agents_autonomous_tasks WHERE task_id = ?",
+                    (task_id,),
+                )
+                if rows and rows[0].get("status") == "completed":
+                    completed_stable_grants.add(task_id)
+            except Exception:
+                pass  # Table may not exist yet
+
         published: List[Dict[str, Any]] = []
         for candidate in candidates:
+            task_id = candidate["task_id"]
+
+            # Skip republishing completed stable grant tasks unless context changed
+            if task_id in completed_stable_grants:
+                # Check if context materially changed (different items)
+                try:
+                    rows = db.db.execute_query(
+                        "SELECT context FROM agents_autonomous_tasks WHERE task_id = ?",
+                        (task_id,),
+                    )
+                    if rows:
+                        import json as _json
+                        old_ctx = rows[0].get("context")
+                        if isinstance(old_ctx, str):
+                            old_ctx = _json.loads(old_ctx)
+                        old_items = set((old_ctx or {}).get("context", {}).get("changed_items", []) +
+                                        (old_ctx or {}).get("context", {}).get("error_items", []))
+                        new_items = set(candidate.get("context", {}).get("changed_items", []) +
+                                        candidate.get("context", {}).get("error_items", []))
+                        if old_items == new_items:
+                            # Same context, don't reopen
+                            published.append({
+                                "task_id": task_id,
+                                "title": candidate["title"],
+                                "created": False,
+                                "priority": candidate["mps"]["priority"],
+                                "skipped_reason": "completed_same_context",
+                            })
+                            continue
+                except Exception:
+                    pass  # If we can't compare, proceed with republish
+
             created = db.create_autonomous_task(
-                task_id=candidate["task_id"],
+                task_id=task_id,
                 description=candidate["description"],
                 required_skills=candidate["required_skills"],
                 estimated_complexity=float(candidate["mps"]["complexity"]),
@@ -712,9 +791,19 @@ class SelfResearchRefresher:
                     "context": candidate["context"],
                 },
             )
+            # Ensure status is set to 'pending' only for new tasks (don't reset completed)
+            if created and task_id not in completed_stable_grants:
+                try:
+                    db.db.execute_write(
+                        "UPDATE agents_autonomous_tasks SET status = 'pending' WHERE task_id = ? AND status IS NULL",
+                        (task_id,),
+                    )
+                except Exception:
+                    pass  # Status column may already be set or have a default
+
             published.append(
                 {
-                    "task_id": candidate["task_id"],
+                    "task_id": task_id,
                     "title": candidate["title"],
                     "created": bool(created),
                     "priority": candidate["mps"]["priority"],
@@ -772,6 +861,7 @@ class SelfResearchRefresher:
         run_watchlists: bool = True,
         write_tasks: bool = True,
         remember_outcome: bool = True,
+        emit_nudges: bool = True,
         force_compliance: bool = False,
     ) -> Dict[str, Any]:
         """Execute a full self-research cycle and write the consolidated report."""
@@ -842,9 +932,45 @@ class SelfResearchRefresher:
             encoding="utf-8",
         )
 
+        # Emit memory nudges for high-value events detected in fresh reports
+        nudge_paths: List[Path] = []
+        if emit_nudges:
+            nudge_paths = self._emit_memory_nudges()
+            report["memory_nudges_emitted"] = len(nudge_paths)
+            # Re-write report with nudge count included
+            self.report_path.write_text(
+                json.dumps(report, indent=2, ensure_ascii=True) + "\n",
+                encoding="utf-8",
+            )
+
         if remember_outcome:
             self.remember_outcome(report, duration_ms)
         return report
+
+    def _emit_memory_nudges(self) -> List[Path]:
+        """Emit memory nudges and record breadcrumbs."""
+        try:
+            from modules.communication.moltbot_bridge.src.memory_nudge_engine import (
+                emit_memory_nudges,
+            )
+
+            nudge_paths = emit_memory_nudges(
+                repo_root=self.repo_root,
+                record_breadcrumbs=True,
+            )
+            if nudge_paths:
+                logger.info(
+                    "[SELF-RESEARCH] Emitted %d memory nudge(s): %s",
+                    len(nudge_paths),
+                    [p.name for p in nudge_paths],
+                )
+            return nudge_paths
+        except ImportError as exc:
+            logger.debug("Memory nudge engine not available: %s", exc)
+            return []
+        except Exception as exc:
+            logger.warning("Failed to emit memory nudges: %s", exc)
+            return []
 
 
 def main(argv: Optional[List[str]] = None) -> int:
@@ -857,6 +983,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--no-watchlists", action="store_true")
     parser.add_argument("--no-tasks", action="store_true")
     parser.add_argument("--no-memory", action="store_true")
+    parser.add_argument("--no-nudges", action="store_true", help="Skip memory nudge emission")
     parser.add_argument("--force-compliance", action="store_true")
     args = parser.parse_args(argv)
 
@@ -868,12 +995,14 @@ def main(argv: Optional[List[str]] = None) -> int:
         run_watchlists=not args.no_watchlists,
         write_tasks=not args.no_tasks,
         remember_outcome=not args.no_memory,
+        emit_nudges=not args.no_nudges,
         force_compliance=args.force_compliance,
     )
 
     print(f"[OK] Self-research report written to {args.report_out}")
     print(f"[OK] Update candidates: {len(report.get('update_candidates', []))}")
     print(f"[OK] Autonomous tasks published: {len(report.get('autonomous_tasks', []))}")
+    print(f"[OK] Memory nudges emitted: {report.get('memory_nudges_emitted', 0)}")
     return 0
 
 

--- a/modules/infrastructure/idle_automation/tests/test_self_research_refresh.py
+++ b/modules/infrastructure/idle_automation/tests/test_self_research_refresh.py
@@ -167,7 +167,93 @@ def test_run_reuses_cached_compliance_section(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(refresher, "publish_autonomous_tasks", lambda candidates: [])
     monkeypatch.setattr(refresher, "remember_outcome", lambda report, duration_ms: None)
 
-    report = refresher.run(write_tasks=False, remember_outcome=False)
+    report = refresher.run(write_tasks=False, remember_outcome=False, emit_nudges=False)
 
     assert report["wsp_compliance"]["cached"] is True
     assert report["wsp_compliance"]["violation_count"] == 1
+
+
+def test_run_emits_memory_nudges_when_high_value_events_detected(tmp_path: Path, monkeypatch):
+    """Verify runtime wiring: emit_nudges=True calls memory nudge engine."""
+    report_path = tmp_path / "reports" / "openclaw_self_research_status.json"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Create workspace structure for nudge engine
+    memory_dir = tmp_path / "modules/communication/moltbot_bridge/workspace/memory"
+    reports_dir = tmp_path / "modules/communication/moltbot_bridge/workspace/reports"
+    memory_dir.mkdir(parents=True)
+    reports_dir.mkdir(parents=True)
+
+    # Create wre_core reports dir for escalations scanner
+    wre_reports = tmp_path / "modules/infrastructure/wre_core/reports"
+    wre_reports.mkdir(parents=True)
+
+    # Create self-research status with high-priority update candidate
+    status = {
+        "update_candidates": [
+            {"title": "Critical update", "mps": {"priority": "P0", "reasoning": "Security fix"}},
+        ]
+    }
+    (reports_dir / "openclaw_self_research_status.json").write_text(
+        json.dumps(status), encoding="utf-8"
+    )
+
+    refresher = SelfResearchRefresher(report_path=report_path)
+    # Override repo_root so nudge engine finds the test structure
+    refresher.repo_root = tmp_path
+
+    # Stub out all scan methods to skip external dependencies
+    monkeypatch.setattr(refresher, "refresh_holo_index", lambda: {"skipped": True})
+    monkeypatch.setattr(refresher, "scan_wsp_compliance", lambda: {"top_violation_groups": []})
+    monkeypatch.setattr(refresher, "scan_self_audit", lambda: {"top_signatures": []})
+    monkeypatch.setattr(refresher, "refresh_grant_watchlist", lambda: {"status": {}})
+    monkeypatch.setattr(refresher, "refresh_pqn_research_watchlist", lambda: {"status": {}})
+    monkeypatch.setattr(refresher, "refresh_openclaw_ecosystem_watchlist", lambda: {"status": {}})
+    monkeypatch.setattr(refresher, "publish_autonomous_tasks", lambda candidates: [])
+    monkeypatch.setattr(refresher, "remember_outcome", lambda report, duration_ms: None)
+
+    report = refresher.run(
+        write_tasks=False,
+        remember_outcome=False,
+        emit_nudges=True,
+    )
+
+    # Verify nudges were emitted
+    assert "memory_nudges_emitted" in report
+    assert report["memory_nudges_emitted"] >= 1
+
+    # Verify note files created
+    nudge_notes = list(memory_dir.glob("*-nudge-*.md"))
+    assert len(nudge_notes) >= 1
+
+    # Verify memory_nudges_emitted is persisted to disk (not just in-memory)
+    persisted_report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert "memory_nudges_emitted" in persisted_report
+    assert persisted_report["memory_nudges_emitted"] >= 1
+
+
+def test_run_skips_nudges_when_emit_nudges_false(tmp_path: Path, monkeypatch):
+    """Verify emit_nudges=False skips memory nudge emission."""
+    report_path = tmp_path / "reports" / "openclaw_self_research_status.json"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+
+    refresher = SelfResearchRefresher(report_path=report_path)
+
+    # Stub out all scan methods
+    monkeypatch.setattr(refresher, "refresh_holo_index", lambda: {"skipped": True})
+    monkeypatch.setattr(refresher, "scan_wsp_compliance", lambda: {"top_violation_groups": []})
+    monkeypatch.setattr(refresher, "scan_self_audit", lambda: {"top_signatures": []})
+    monkeypatch.setattr(refresher, "refresh_grant_watchlist", lambda: {"status": {}})
+    monkeypatch.setattr(refresher, "refresh_pqn_research_watchlist", lambda: {"status": {}})
+    monkeypatch.setattr(refresher, "refresh_openclaw_ecosystem_watchlist", lambda: {"status": {}})
+    monkeypatch.setattr(refresher, "publish_autonomous_tasks", lambda candidates: [])
+    monkeypatch.setattr(refresher, "remember_outcome", lambda report, duration_ms: None)
+
+    report = refresher.run(
+        write_tasks=False,
+        remember_outcome=False,
+        emit_nudges=False,
+    )
+
+    # Verify nudges not emitted when disabled
+    assert "memory_nudges_emitted" not in report


### PR DESCRIPTION
## Summary

- Wire `emit_memory_nudges()` from the memory nudge engine (PR #237) into the self-research refresh loop
- Add breadcrumb recording when nudges are emitted for cross-session recall
- Add `--no-nudges` CLI flag and `emit_nudges` parameter for control

## Changes

### memory_nudge_engine.py
- Added `record_breadcrumbs` parameter to `emit_nudges()` method
- Added `_record_breadcrumb()` to record nudge emissions in AgentDB
- Session ID format: `self_research_{YYYYMMDD}` for daily aggregation

### self_research_refresh.py
- Added `emit_nudges=True` parameter to `run()` method
- Added `_emit_memory_nudges()` method called after report is written
- Report now includes `memory_nudges_emitted` count
- Added `--no-nudges` CLI flag

### Tests
- 3 new tests for breadcrumb recording in `test_memory_nudge_engine.py`
- 2 new tests for runtime wiring in `test_self_research_refresh.py`

## Test plan

- [x] `pytest test_memory_nudge_engine.py` → 19 passed
- [x] `pytest test_self_research_refresh.py` → 7 passed
- [x] Live verification: 6 nudges emitted, breadcrumbs recorded in AgentDB

🤖 Generated with [Claude Code](https://claude.com/claude-code)