### PR TITLE
docs: update ModLog/TestModLog for grant pipeline (#239)

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -60,8 +60,9 @@ Grant work was discovered by self-research but not autonomously executable:
    - INSERT OR REPLACE deduplicates by task_id PRIMARY KEY
 
 2. **Stale task cleanup** in `publish_autonomous_tasks()`:
-   - Narrowed to grant-only pattern: `self_research_external_watchlist_%grant%`
-   - Does NOT delete PQN or OpenClaw ecosystem watchlist tasks
+   - Combined filter: `task_id LIKE 'self_research_external_watchlist_%'` + `required_skills LIKE '%openclaw-grants%'`
+   - Does NOT delete PQN or OpenClaw ecosystem watchlist tasks (different skill tags)
+   - Preserves stable IDs via `NOT IN (?, ?)` clause
    - Sets `status = 'pending'` after creation (AgentDB may not set it)
 
 3. **Completed task protection**:
@@ -84,11 +85,14 @@ Grant work was discovered by self-research but not autonomously executable:
 - `modules/infrastructure/idle_automation/src/self_research_refresh.py`: Stale cleanup + completed protection
 - `modules/communication/moltbot_bridge/scripts/run_task.py`: Use grant_task_executor
 - `modules/communication/moltbot_bridge/src/grant_task_executor.py`: New file, 200 lines
-- `modules/communication/moltbot_bridge/tests/test_grant_task_execution.py`: 15 tests
+- `modules/communication/moltbot_bridge/tests/test_grant_task_execution.py`: 21 tests
+- `modules/communication/moltbot_bridge/tests/test_hardening_tranche.py`: 7 grant tests + 1 regression
 
 ### Verification
 
-- `pytest test_grant_task_execution.py` → 15 passed
+- `pytest test_grant_task_execution.py` → 21 passed
+- `pytest test_hardening_tranche.py -k grant` → 8 passed (7 grant + 1 stale cleanup regression)
+- Regression test: Seeds old slugified rows + PQN/ecosystem rows, verifies only old grant rows deleted
 - Repro 1: Completed task same context → skipped (not reopened)
 - Repro 2: Ethereum ESP (p0_apply_now) → fit_score=0.95, generates recommendations
 - Stable task_ids confirmed: `grant_watchlist_review`, `grant_watchlist_stabilize`

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,17 @@
+## 2026-03-23: Grant Task Pipeline Tests (P0)
+- Command: `pytest modules/communication/moltbot_bridge/tests/test_grant_task_execution.py modules/communication/moltbot_bridge/tests/test_hardening_tranche.py -k grant -q`
+- Status: PASS
+- Result: `29 passed` (21 + 8)
+- Coverage:
+  - Grant executor: review returns structured findings, stabilize categorizes errors
+  - Dispatch: recognizes grant_watchlist_review/stabilize, fails closed on unknown
+  - Stable IDs: deduplication via INSERT OR REPLACE
+  - Completed protection: same-context skip, changed-context reopens
+  - Stale cleanup: combined filter (task_id LIKE + skill tag), preserves PQN/ecosystem
+  - Regression: real-DB test seeds old slugified + PQN + ecosystem rows, asserts correct deletions
+
+---
+
 ## 2026-03-23: Memory Nudge Engine (P0)
 - Command: `pytest modules/communication/moltbot_bridge/tests/test_memory_nudge_engine.py -q`
 - Status: PASS

--- a/modules/infrastructure/idle_automation/ModLog.md
+++ b/modules/infrastructure/idle_automation/ModLog.md
@@ -12,6 +12,34 @@ This log tracks changes specific to the **idle_automation** module in the **infr
 
 ## MODLOG ENTRIES
 
+### 2026-03-23 - Grant Task Stable IDs and Stale Cleanup
+
+**WSP Protocol**: WSP 22, WSP 97 (Autonomy Boundaries)
+**Phase**: Automation Hardening
+**Agent**: 0102
+
+#### Changes to self_research_refresh.py
+
+- **Added**: `stable_task_id` parameter to `_build_manual_candidate()` for explicit task IDs
+- **Added**: Stable IDs for all watchlist tasks:
+  - `grant_watchlist_review`, `grant_watchlist_stabilize`
+  - `pqn_watchlist_review`, `pqn_watchlist_stabilize`
+  - `openclaw_ecosystem_watchlist_review`, `openclaw_ecosystem_watchlist_stabilize`
+- **Added**: Stale task cleanup in `publish_autonomous_tasks()`:
+  - Combined filter: `task_id LIKE 'self_research_external_watchlist_%'` + `required_skills LIKE '%openclaw-grants%'`
+  - Preserves stable IDs via `NOT IN` clause
+  - Only triggers when stable grant tasks are in candidates
+- **Added**: Completed task protection - skips republish if same `changed_items`/`error_items`
+
+#### Tests
+
+Regression test in `test_hardening_tranche.py::test_stale_grant_task_cleanup_preserves_pqn_and_ecosystem`:
+- Seeds old slugified grant rows, PQN rows, ecosystem rows
+- Publishes stable grant tasks
+- Asserts only old grant rows deleted, PQN/ecosystem preserved
+
+---
+
 ### 2026-03-23 - Memory Nudge Runtime Wiring
 
 **WSP Protocol**: WSP 22, WSP 60 (Memory Architecture), WSP 97 (Autonomy Boundaries)

--- a/modules/infrastructure/idle_automation/tests/TestModLog.md
+++ b/modules/infrastructure/idle_automation/tests/TestModLog.md
@@ -54,6 +54,19 @@
 - `mock_git_repo` - Fake git repository with test commits
 - `mock_linkedin_api` - Simulated LinkedIn posting responses
 
+### 2026-03-23: Grant Task Cleanup Regression Test
+
+- **Location**: `modules/communication/moltbot_bridge/tests/test_hardening_tranche.py`
+- **Test**: `test_stale_grant_task_cleanup_preserves_pqn_and_ecosystem`
+- **Status**: PASS
+- **Coverage**:
+  - Seeds old slugified grant rows, PQN rows, ecosystem rows in real temp DB
+  - Calls `SelfResearchRefresher.publish_autonomous_tasks()` with stable grant IDs
+  - Asserts: old grant rows deleted, PQN/ecosystem rows preserved, stable grant rows created
+  - Uses `DatabaseManager.reset_for_tests()` pattern for singleton isolation
+
+---
+
 ### Current Test Status: NOT IMPLEMENTED
 
 **Reason**: Module is in MVP phase with safety-disabled social media posting. Full test implementation requires:


### PR DESCRIPTION
## Summary

- Fix test counts (29 total: 21 + 8)
- Correct stale cleanup filter description (combined LIKE + skill tag)
- Add regression test entry for stale cleanup

## Test plan

- [x] Doc-only changes, no code modified
- [x] Descriptions match actual implementation in merged #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)