### PR TITLE
feat(openclaw): supervisor memory nudge wiring (P1)

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,63 @@
 # ModLog - moltbot_bridge
 
+## 2026-03-23: Supervisor Memory Nudge Wiring (P1)
+
+**Author**: 0102
+**WSP**: 22, 60, 97
+
+### Context
+
+Supervisor already stores PatternMemory outcomes in `_remember()` but did not emit
+dedicated nudges for high-value VERIFY/ESCALATE failures. This wiring adds targeted
+nudge emission without creating noise.
+
+### Changes
+
+1. **Added `_emit_supervisor_nudge()` helper** to `openclaw_supervisor.py`:
+   - Constructs explicit `NudgeEvent` objects
+   - Calls `MemoryNudgeEngine.emit_nudges([event], record_breadcrumbs=True)`
+   - Returns True if nudge was emitted (not deduplicated)
+
+2. **VERIFY failure path now emits nudge**:
+   - Trigger type: `supervisor_verify_failure`
+   - Priority: P1
+   - Includes: plan_action, plan_reason, verify_error, task_id, fidelity
+
+3. **ESCALATE path now emits nudge for high-value reasons**:
+   - `resident_openclaw_restart_budget_exhausted` → P0
+   - `broker_or_observer_unavailable` → P1
+   - `openclaw_runtime_not_registered` → P1
+
+4. **Signature identity for VERIFY failures**:
+   - Title includes `task_id` and `verify_error` to distinguish different failures
+   - Format: `Task verify failed: <action> [<task_id>] (<error>)`
+   - Prevents over-deduplication of materially different failures
+
+5. **Deduplication**: Identical escalations are deduplicated by nudge engine
+   (signature-based matching on trigger_type + title + provenance).
+
+### Files Changed
+
+- `src/openclaw_supervisor.py`: Added `_emit_supervisor_nudge()` method, calls in run_cycle
+- `tests/test_openclaw_supervisor.py`: 7 new tests for nudge emission
+
+### Verification
+
+```
+pytest test_openclaw_supervisor.py       # 14 passed
+pytest test_openclaw_supervisor_p0.py    # 1 passed
+pytest test_memory_nudge_engine.py       # 19 passed
+pytest test_self_research_refresh.py     # 7 passed
+```
+
+### Not Changed
+
+- Self-research nudge logic (already working from PR #238)
+- Grant execution files (completed in PR #239)
+- Gateway continuity layer (future slice)
+
+---
+
 ## 2026-03-23: Memory Nudge Runtime Wiring (P1)
 
 **Author**: 0102

--- a/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
@@ -189,6 +189,29 @@ class OpenClawSupervisor:
             self._transition(SupervisorState.ESCALATE, triage["reason"])
             verify = {"ok": False, "error": triage["reason"]}
             self._remember(observation, triage, {}, verify)
+            # Emit nudge for high-value escalation reasons
+            escalation_reason = triage["reason"]
+            high_value_reasons = {
+                "resident_openclaw_restart_budget_exhausted",
+                "broker_or_observer_unavailable",
+                "openclaw_runtime_not_registered",
+            }
+            if escalation_reason in high_value_reasons:
+                self._emit_supervisor_nudge(
+                    trigger_type="supervisor_escalation",
+                    title=f"Supervisor escalation: {escalation_reason}",
+                    summary=(
+                        f"Supervisor reached ESCALATE state due to: {escalation_reason}. "
+                        f"Restart budget: {triage.get('restart_budget', {})}. "
+                        f"Manual intervention may be required."
+                    ),
+                    priority="P0" if "budget_exhausted" in escalation_reason else "P1",
+                    details={
+                        "escalation_reason": escalation_reason,
+                        "restart_budget": triage.get("restart_budget"),
+                        "observation_keys": list(observation.keys()),
+                    },
+                )
             self.last_cycle = {
                 "state": self.current_state.value,
                 "triage": triage,
@@ -209,6 +232,28 @@ class OpenClawSupervisor:
         if not verify["ok"]:
             self._transition(SupervisorState.ESCALATE, verify.get("error", "verify_failed"))
             self._remember(observation, plan, action_result, verify)
+            # Emit nudge for verify failure (high-value event)
+            # Include task_id and error in title to distinguish different failures
+            task_id = plan.get("task", {}).get("task_id") if plan.get("task") else None
+            verify_error = verify.get("error", "unknown")
+            title_suffix = f" [{task_id}]" if task_id else ""
+            title_suffix += f" ({verify_error})" if verify_error != "unknown" else ""
+            self._emit_supervisor_nudge(
+                trigger_type="supervisor_verify_failure",
+                title=f"Task verify failed: {plan.get('action', 'unknown')}{title_suffix}",
+                summary=(
+                    f"Execution of {plan.get('action')} completed but verification failed. "
+                    f"Error: {verify_error}. Reason: {plan.get('reason', '')}"
+                ),
+                priority="P1",
+                details={
+                    "plan_action": plan.get("action"),
+                    "plan_reason": plan.get("reason"),
+                    "verify_error": verify_error,
+                    "task_id": task_id,
+                    "fidelity": verify.get("fidelity"),
+                },
+            )
         else:
             self._transition(SupervisorState.REMEMBER, plan["action"])
             self._remember(observation, plan, action_result, verify)
@@ -736,3 +781,63 @@ class OpenClawSupervisor:
         cutoff = now - self.restart_window_sec
         while self._restart_attempts and self._restart_attempts[0] < cutoff:
             self._restart_attempts.popleft()
+
+    # ------------------------------------------------------------------ #
+    #  Memory Nudge Emission                                              #
+    # ------------------------------------------------------------------ #
+
+    def _emit_supervisor_nudge(
+        self,
+        trigger_type: str,
+        title: str,
+        summary: str,
+        priority: str,
+        details: Dict[str, Any],
+    ) -> bool:
+        """
+        Emit a memory nudge for high-value supervisor events.
+
+        Emits nudges for:
+        - supervisor_verify_failure: Task execution verification failed
+        - supervisor_escalation: Budget exhausted, broker unavailable, etc.
+
+        Returns True if nudge was emitted (not deduplicated).
+        """
+        try:
+            from modules.communication.moltbot_bridge.src.memory_nudge_engine import (
+                MemoryNudgeEngine,
+                NudgeEvent,
+            )
+
+            event = NudgeEvent(
+                trigger_type=trigger_type,
+                title=title,
+                summary=summary,
+                provenance="openclaw_supervisor",
+                priority=priority,
+                details=details,
+            )
+
+            engine = MemoryNudgeEngine(repo_root=self.repo_root)
+            created = engine.emit_nudges([event], record_breadcrumbs=True)
+
+            if created:
+                logger.info(
+                    "[SUPERVISOR] Emitted memory nudge: %s (%s)",
+                    title[:50],
+                    trigger_type,
+                )
+                return True
+            else:
+                logger.debug(
+                    "[SUPERVISOR] Nudge deduplicated: %s",
+                    event.signature,
+                )
+                return False
+
+        except ImportError:
+            logger.debug("[SUPERVISOR] MemoryNudgeEngine not available")
+            return False
+        except Exception as exc:
+            logger.debug("[SUPERVISOR] Failed to emit nudge: %s", exc)
+            return False

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,18 @@
+## 2026-03-23: Supervisor Memory Nudge Tests (P1)
+- Command: `pytest modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py -q`
+- Status: PASS
+- Result: `14 passed` (7 existing + 7 new nudge tests)
+- Coverage:
+  - VERIFY failure emits nudge: trigger_type=supervisor_verify_failure, priority=P1
+  - Budget exhausted escalation emits P0 nudge
+  - Broker unavailable escalation emits P1 nudge
+  - Identical escalations deduplicate cleanly (signature-based)
+  - **Different task failures produce different signatures** (task_id + error in title)
+  - Successful cycles do NOT emit nudges
+  - Breadcrumb recording invoked with record_breadcrumbs=True
+
+---
+
 ## 2026-03-23: Grant Task Pipeline Tests (P0)
 - Command: `pytest modules/communication/moltbot_bridge/tests/test_grant_task_execution.py modules/communication/moltbot_bridge/tests/test_hardening_tranche.py -k grant -q`
 - Status: PASS

--- a/modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -314,3 +314,405 @@ def test_plan_ai_analysis_exception_stores_error(tmp_path):
     assert "Holo unavailable" in ai_analysis["error"]
     # Plan should still complete even with AI analysis error
     assert result["plan"]["action"] == "execute_autonomous_task"
+
+
+# --------------------------------------------------------------------------- #
+#  Supervisor Memory Nudge Tests                                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_verify_failure_emits_nudge(tmp_path):
+    """Verify failure emits a memory nudge with breadcrumb recording."""
+    nudge_calls = []
+
+    class MockNudgeEngine:
+        def __init__(self, repo_root=None, **kwargs):
+            self.repo_root = repo_root
+
+        def emit_nudges(self, events, record_breadcrumbs=False):
+            nudge_calls.append({
+                "events": events,
+                "record_breadcrumbs": record_breadcrumbs,
+            })
+            # Simulate note creation
+            return [tmp_path / "mock_note.md"]
+
+    broker = MagicMock()
+    # Always return stopped to force start attempt, then verify failure
+    broker.get_runtime_status.return_value = {
+        "registered": True,
+        "running": False,
+        "state": "stopped",
+        "last_error": "still down",
+        "enabled": True,
+    }
+    broker.start_dae.return_value = {"status": "starting"}
+
+    observer = MagicMock()
+    observer.get_live_status.return_value = {"registered": True}
+    observer.follow_events.return_value = {
+        "events": [],
+        "next_cursor": 0,
+        "latest_sequence_id": 0,
+    }
+
+    supervisor = OpenClawSupervisor(
+        repo_root=tmp_path,
+        broker=broker,
+        observer=observer,
+        action_reporter=lambda a, r, d: None,
+        self_audit_factory=lambda repo_root: MagicMock(),
+    )
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.memory_nudge_engine.MemoryNudgeEngine",
+        MockNudgeEngine,
+    ):
+        result = supervisor.run_cycle()
+
+        # Verify failure should have occurred
+        assert result["verify"]["ok"] is False
+        assert supervisor.current_state == SupervisorState.ESCALATE
+
+        # Should have emitted a nudge
+        assert len(nudge_calls) == 1
+        assert nudge_calls[0]["record_breadcrumbs"] is True
+        event = nudge_calls[0]["events"][0]
+        assert event.trigger_type == "supervisor_verify_failure"
+        assert "verify failed" in event.title.lower()
+        assert event.priority == "P1"
+
+
+def test_escalate_budget_exhausted_emits_nudge(tmp_path, monkeypatch):
+    """Restart budget exhausted escalation emits a P0 nudge."""
+    monkeypatch.setenv("OPENCLAW_SUPERVISOR_MAX_RESTARTS", "2")
+    monkeypatch.setenv("OPENCLAW_SUPERVISOR_RESTART_WINDOW_SEC", "600")
+
+    nudge_calls = []
+
+    class MockNudgeEngine:
+        def __init__(self, repo_root=None, **kwargs):
+            pass
+
+        def emit_nudges(self, events, record_breadcrumbs=False):
+            nudge_calls.append({
+                "events": events,
+                "record_breadcrumbs": record_breadcrumbs,
+            })
+            return [tmp_path / "mock_note.md"]
+
+    broker = MagicMock()
+    broker.get_runtime_status.return_value = {
+        "registered": True,
+        "running": False,
+        "state": "stopped",
+        "last_error": "crashed",
+        "enabled": True,
+    }
+    observer = MagicMock()
+    observer.get_live_status.return_value = {"registered": True}
+    observer.follow_events.return_value = {
+        "events": [],
+        "next_cursor": 0,
+        "latest_sequence_id": 0,
+    }
+
+    supervisor = OpenClawSupervisor(
+        repo_root=tmp_path,
+        broker=broker,
+        observer=observer,
+        action_reporter=lambda a, r, d: None,
+        self_audit_factory=lambda repo_root: MagicMock(),
+    )
+    # Exhaust restart budget
+    supervisor._restart_attempts.extend([100.0, 200.0])
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.openclaw_supervisor.time.time",
+        return_value=250.0,
+    ), patch(
+        "modules.communication.moltbot_bridge.src.memory_nudge_engine.MemoryNudgeEngine",
+        MockNudgeEngine,
+    ):
+        result = supervisor.run_cycle()
+
+        assert result["verify"]["error"] == "resident_openclaw_restart_budget_exhausted"
+        assert supervisor.current_state == SupervisorState.ESCALATE
+
+        # Should have emitted a P0 nudge
+        assert len(nudge_calls) == 1
+        event = nudge_calls[0]["events"][0]
+        assert event.trigger_type == "supervisor_escalation"
+        assert "budget_exhausted" in event.title
+        assert event.priority == "P0"
+
+
+def test_escalate_broker_unavailable_emits_nudge(tmp_path):
+    """Broker unavailable escalation emits a P1 nudge."""
+    nudge_calls = []
+
+    class MockNudgeEngine:
+        def __init__(self, repo_root=None, **kwargs):
+            pass
+
+        def emit_nudges(self, events, record_breadcrumbs=False):
+            nudge_calls.append({
+                "events": events,
+                "record_breadcrumbs": record_breadcrumbs,
+            })
+            return [tmp_path / "mock_note.md"]
+
+    supervisor = OpenClawSupervisor(
+        repo_root=tmp_path,
+        broker=MagicMock(),  # Will be overridden
+        observer=MagicMock(),
+        action_reporter=lambda a, r, d: None,
+        self_audit_factory=lambda repo_root: MagicMock(),
+    )
+    # Skip normal broker initialization and force broker/observer to None
+    supervisor._bootstrapped = True
+    supervisor._broker = None
+    supervisor._observer = None
+
+    # Mock _get_broker and _get_observer to return None (prevents lazy init)
+    supervisor._get_broker = lambda: None
+    supervisor._get_observer = lambda: None
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.memory_nudge_engine.MemoryNudgeEngine",
+        MockNudgeEngine,
+    ):
+        result = supervisor.run_cycle()
+
+        assert result["verify"]["error"] == "broker_or_observer_unavailable"
+        assert supervisor.current_state == SupervisorState.ESCALATE
+
+        # Should have emitted a P1 nudge
+        assert len(nudge_calls) == 1
+        event = nudge_calls[0]["events"][0]
+        assert event.trigger_type == "supervisor_escalation"
+        assert "broker_or_observer" in event.title
+        assert event.priority == "P1"
+
+
+def test_identical_escalation_dedupes(tmp_path):
+    """Repeated identical escalations are deduplicated by nudge engine."""
+    nudge_calls = []
+    seen_signatures = set()
+
+    class MockNudgeEngine:
+        def __init__(self, repo_root=None, **kwargs):
+            pass
+
+        def emit_nudges(self, events, record_breadcrumbs=False):
+            created = []
+            for event in events:
+                if event.signature not in seen_signatures:
+                    seen_signatures.add(event.signature)
+                    created.append(tmp_path / f"note_{event.signature}.md")
+            nudge_calls.append({
+                "events": events,
+                "created": created,
+            })
+            return created
+
+    supervisor = OpenClawSupervisor(
+        repo_root=tmp_path,
+        broker=MagicMock(),
+        observer=MagicMock(),
+        action_reporter=lambda a, r, d: None,
+        self_audit_factory=lambda repo_root: MagicMock(),
+    )
+    supervisor._bootstrapped = True
+    # Force broker/observer unavailable escalation
+    supervisor._get_broker = lambda: None
+    supervisor._get_observer = lambda: None
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.memory_nudge_engine.MemoryNudgeEngine",
+        MockNudgeEngine,
+    ):
+        # Run multiple cycles with same escalation
+        supervisor.run_cycle()
+        supervisor.run_cycle()
+        supervisor.run_cycle()
+
+        # Should have called emit_nudges 3 times, but only first creates note
+        assert len(nudge_calls) == 3
+        assert len(nudge_calls[0]["created"]) == 1  # First creates
+        assert len(nudge_calls[1]["created"]) == 0  # Second dedups
+        assert len(nudge_calls[2]["created"]) == 0  # Third dedups
+
+
+def test_different_task_failures_produce_different_signatures(tmp_path):
+    """Different task failures produce different nudge signatures (not over-deduplicated)."""
+    emitted_events = []
+
+    class MockNudgeEngine:
+        def __init__(self, repo_root=None, **kwargs):
+            pass
+
+        def emit_nudges(self, events, record_breadcrumbs=False):
+            emitted_events.extend(events)
+            return [tmp_path / f"note_{len(emitted_events)}.md"]
+
+    broker = MagicMock()
+    broker.get_runtime_status.return_value = {
+        "registered": True,
+        "running": True,
+        "state": "running",
+        "last_error": "",
+        "enabled": True,
+    }
+    observer = MagicMock()
+    observer.get_live_status.return_value = {"registered": True}
+    observer.follow_events.return_value = {
+        "events": [],
+        "next_cursor": 0,
+        "latest_sequence_id": 0,
+    }
+
+    supervisor = OpenClawSupervisor(
+        repo_root=tmp_path,
+        broker=broker,
+        observer=observer,
+        action_reporter=lambda a, r, d: None,
+        self_audit_factory=lambda repo_root: MagicMock(),
+    )
+    supervisor._bootstrapped = True
+
+    # Create two different task failures
+    task1 = {"task_id": "grant_watchlist_review", "description": "Review grants"}
+    task2 = {"task_id": "pqn_watchlist_review", "description": "Review PQN"}
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.memory_nudge_engine.MemoryNudgeEngine",
+        MockNudgeEngine,
+    ), patch("modules.infrastructure.database.src.agent_db.AgentDB") as mock_db:
+        # First cycle: task1 fails
+        mock_db.return_value.get_autonomous_tasks.side_effect = [
+            [task1],  # pending
+            [],  # completed (task not there = failure)
+        ]
+        mock_db.return_value.assign_autonomous_task.return_value = True
+
+        # Mock execute_task to return failure
+        with patch(
+            "modules.communication.moltbot_bridge.scripts.run_task.execute_task",
+            return_value={"ok": False, "error": "task_failed"},
+        ):
+            supervisor.run_cycle()
+
+        # Second cycle: task2 fails with different error
+        mock_db.return_value.get_autonomous_tasks.side_effect = [
+            [task2],  # pending
+            [],  # completed (task not there = failure)
+        ]
+
+        with patch(
+            "modules.communication.moltbot_bridge.scripts.run_task.execute_task",
+            return_value={"ok": False, "error": "timeout"},
+        ):
+            supervisor.run_cycle()
+
+        # Both failures should have emitted events
+        assert len(emitted_events) == 2
+
+        # Signatures should be DIFFERENT (task_id and error in title)
+        sig1 = emitted_events[0].signature
+        sig2 = emitted_events[1].signature
+        assert sig1 != sig2, (
+            f"Different task failures should have different signatures: "
+            f"{emitted_events[0].title} vs {emitted_events[1].title}"
+        )
+
+        # Titles should include task_id
+        assert "grant_watchlist_review" in emitted_events[0].title
+        assert "pqn_watchlist_review" in emitted_events[1].title
+
+
+def test_successful_cycle_does_not_emit_nudge(tmp_path):
+    """Successful execution cycle does not emit any nudge."""
+    nudge_calls = []
+
+    class MockNudgeEngine:
+        def __init__(self, repo_root=None, **kwargs):
+            pass
+
+        def emit_nudges(self, events, record_breadcrumbs=False):
+            nudge_calls.append(events)
+            return []
+
+    broker = MagicMock()
+    broker.get_runtime_status.return_value = {
+        "registered": True,
+        "running": True,
+        "state": "running",
+        "last_error": "",
+        "enabled": True,
+    }
+    observer = MagicMock()
+    observer.get_live_status.return_value = {"registered": True}
+    observer.follow_events.return_value = {
+        "events": [],
+        "next_cursor": 0,
+        "latest_sequence_id": 0,
+    }
+
+    supervisor = OpenClawSupervisor(
+        repo_root=tmp_path,
+        broker=broker,
+        observer=observer,
+        action_reporter=lambda a, r, d: None,
+        self_audit_factory=lambda repo_root: MagicMock(),
+    )
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.memory_nudge_engine.MemoryNudgeEngine",
+        MockNudgeEngine,
+    ), patch("modules.infrastructure.database.src.agent_db.AgentDB") as mock_db:
+        mock_db.return_value.get_autonomous_tasks.return_value = []
+        result = supervisor.run_cycle()
+
+        # Should be idle (healthy runtime, no pending tasks)
+        assert result["triage"]["kind"] == "idle"
+        assert supervisor.current_state == SupervisorState.IDLE_WATCH
+
+        # Should NOT have emitted any nudge
+        assert len(nudge_calls) == 0
+
+
+def test_breadcrumb_recording_invoked_on_nudge(tmp_path):
+    """Breadcrumb recording is invoked when nudge is emitted."""
+    breadcrumb_recorded = []
+
+    class MockNudgeEngine:
+        def __init__(self, repo_root=None, **kwargs):
+            pass
+
+        def emit_nudges(self, events, record_breadcrumbs=False):
+            if record_breadcrumbs:
+                breadcrumb_recorded.append(True)
+            return [tmp_path / "note.md"]
+
+    supervisor = OpenClawSupervisor(
+        repo_root=tmp_path,
+        broker=MagicMock(),
+        observer=MagicMock(),
+        action_reporter=lambda a, r, d: None,
+        self_audit_factory=lambda repo_root: MagicMock(),
+    )
+    supervisor._bootstrapped = True
+    # Force broker/observer unavailable escalation
+    supervisor._get_broker = lambda: None
+    supervisor._get_observer = lambda: None
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.memory_nudge_engine.MemoryNudgeEngine",
+        MockNudgeEngine,
+    ):
+        supervisor.run_cycle()
+
+        # Should have recorded breadcrumb
+        assert len(breadcrumb_recorded) == 1
+        assert breadcrumb_recorded[0] is True


### PR DESCRIPTION
## Summary

- Wire memory nudge emission into supervisor VERIFY/ESCALATE paths
- Add `_emit_supervisor_nudge()` helper to `openclaw_supervisor.py`
- VERIFY failure emits nudge with `task_id` and `error` in title for distinct signatures
- ESCALATE path emits P0/P1 nudges for high-value reasons:
  - `resident_openclaw_restart_budget_exhausted` (P0)
  - `broker_or_observer_unavailable` (P1)
  - `openclaw_runtime_not_registered` (P1)
- Breadcrumb recording enabled for all supervisor nudges
- 7 new tests covering nudge emission, deduplication, and signature identity

## Test plan

- [x] `pytest test_openclaw_supervisor.py -q` → 14 passed
- [x] `pytest test_openclaw_supervisor_p0.py -q` → 1 passed
- [x] `pytest test_memory_nudge_engine.py -q` → 19 passed
- [x] `pytest test_self_research_refresh.py -q` → 7 passed
- [x] Different task failures produce different signatures (verified with direct signature check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)