### PR TITLE
feat(idle_automation): startup maintenance gate with real executors

### DIFF
--- a/modules/communication/moltbot_bridge/scripts/run_task.py
+++ b/modules/communication/moltbot_bridge/scripts/run_task.py
@@ -84,6 +84,12 @@ def execute_task(task_id: str, repo_root: Path | None = None) -> Dict[str, Any]:
             if grant_result is not None:
                 result = grant_result
 
+    # ── Dispatch path 4: Startup maintenance tasks ──
+    if not result["ok"] and result["detail"] == "no_executor_matched" and source == "startup_maintenance_gate":
+        startup_result = _try_startup_maintenance_dispatch(repo_root, task_id, context)
+        if startup_result is not None:
+            result = startup_result
+
     # ── Finalize in AgentDB ──
     elapsed_ms = int((time.monotonic() - start) * 1000)
     result["execution_time_ms"] = elapsed_ms
@@ -254,6 +260,121 @@ def _try_grant_dispatch(
 
     else:
         # Not a recognized grant task pattern
+        return None
+
+
+def _try_startup_maintenance_dispatch(
+    repo_root: Path, task_id: str, context: dict
+) -> Dict[str, Any] | None:
+    """
+    Execute startup maintenance tasks queued by startup_maintenance_gate.
+
+    Handles:
+      - startup_refresh_self_research: Run self-research refresh
+      - startup_refresh_holo_index: Run HoloIndex refresh
+      - startup_refresh_model_status: Run model status refresh
+      - startup_training_batch: Run training batch (if training system available)
+
+    Returns structured result or None if not a recognized startup task.
+    """
+    try:
+        from modules.infrastructure.idle_automation.src.self_research_refresh import (
+            SelfResearchRefresher,
+        )
+    except ImportError as e:
+        logger.debug("[RUN_TASK] SelfResearchRefresher unavailable: %s", e)
+        return None
+
+    refresher = SelfResearchRefresher(repo_root=repo_root)
+
+    if task_id == "startup_refresh_self_research":
+        logger.info("[RUN_TASK] Startup dispatch: self-research refresh")
+        try:
+            # Use actual SelfResearchRefresher.run() signature
+            result = refresher.run(
+                run_holo_refresh=False,
+                run_compliance=True,
+                run_self_audit=True,
+                run_watchlists=True,
+                write_tasks=True,
+                emit_nudges=True,
+            )
+            # Success = report dict with generated_on (means refresh completed)
+            success = isinstance(result, dict) and "generated_on" in result
+            return {
+                "ok": success,
+                "detail": json.dumps(result, default=str)[:1000],
+                "executor": "startup:self_research",
+                "structured_result": result,
+            }
+        except Exception as e:
+            return {"ok": False, "detail": f"self_research_error: {e}", "executor": "startup:self_research"}
+
+    elif task_id == "startup_refresh_holo_index":
+        logger.info("[RUN_TASK] Startup dispatch: HoloIndex refresh")
+        try:
+            result = refresher.refresh_holo_index()
+            success = result.get("refresh_success", False) or not result.get("code_stale", True)
+            return {
+                "ok": success,
+                "detail": json.dumps(result, default=str)[:1000],
+                "executor": "startup:holo_index",
+                "structured_result": result,
+            }
+        except Exception as e:
+            return {"ok": False, "detail": f"holo_index_error: {e}", "executor": "startup:holo_index"}
+
+    elif task_id == "startup_refresh_model_status":
+        logger.info("[RUN_TASK] Startup dispatch: model status refresh")
+        try:
+            from modules.infrastructure.dependency_launcher.src.dae_dependencies import (
+                get_dependency_status,
+            )
+            from datetime import datetime, UTC
+
+            status = get_dependency_status()
+            result = {
+                "checked_on": datetime.now(UTC).isoformat(),
+                "lm_studio_running": status.get("lm_studio", False),
+                "dependencies": status,
+            }
+            # Write status to reports dir for freshness tracking
+            reports_dir = repo_root / "modules" / "communication" / "moltbot_bridge" / "workspace" / "reports"
+            reports_dir.mkdir(parents=True, exist_ok=True)
+            status_path = reports_dir / "local_model_status.json"
+            status_path.write_text(json.dumps(result, indent=2, default=str), encoding="utf-8")
+
+            return {
+                "ok": True,
+                "detail": json.dumps(result, default=str)[:1000],
+                "executor": "startup:model_status",
+                "structured_result": result,
+            }
+        except Exception as e:
+            return {"ok": False, "detail": f"model_status_error: {e}", "executor": "startup:model_status"}
+
+    elif task_id == "startup_training_batch":
+        logger.info("[RUN_TASK] Startup dispatch: training batch")
+        try:
+            import asyncio
+            from modules.infrastructure.idle_automation.src.idle_automation_dae import (
+                IdleAutomationDAE,
+            )
+
+            dae = IdleAutomationDAE()
+            result = asyncio.run(dae._execute_pattern_training())
+            success = result.get("success", False)
+            return {
+                "ok": success,
+                "detail": json.dumps(result, default=str)[:1000],
+                "executor": "startup:training_batch",
+                "structured_result": result,
+            }
+        except Exception as e:
+            return {"ok": False, "detail": f"training_error: {e}", "executor": "startup:training_batch"}
+
+    else:
+        # Not a recognized startup task pattern
         return None
 
 

--- a/modules/infrastructure/idle_automation/ModLog.md
+++ b/modules/infrastructure/idle_automation/ModLog.md
@@ -12,6 +12,128 @@ This log tracks changes specific to the **idle_automation** module in the **infr
 
 ## MODLOG ENTRIES
 
+### 2026-03-26 - Startup Maintenance Gate Execution Path Fix (P0)
+
+**WSP Protocol**: WSP 22, WSP 27 (DAE Architecture)
+**Phase**: Fix dead work gap
+**Agent**: 0102
+
+#### Problem (Round 1)
+
+Startup maintenance gate queued tasks with phantom skill names (`openclaw-monitor`, `holo-search`, `training-system`) that had no executors in `run_task.py`. Result: gate queued dead work that would always fail with `no_executor_matched`.
+
+#### Problem (Round 2)
+
+Initial fix used incorrect kwargs for `SelfResearchRefresher.run()` and routed training to wrong executor:
+- `run_training_refresh`, `run_compliance_scan`, `run_update_candidates` don't exist
+- Training was calling `SelfResearchRefresher.run()` instead of `IdleAutomationDAE._execute_pattern_training()`
+
+#### Solution
+
+Added dispatch path 4 in `run_task.py` for startup maintenance tasks:
+
+1. Detects `source == "startup_maintenance_gate"` tasks
+2. Dispatches by task_id to real executors:
+   - `startup_refresh_self_research` → `SelfResearchRefresher.run(run_compliance=True, run_self_audit=True, ...)`
+   - `startup_refresh_holo_index` → `SelfResearchRefresher.refresh_holo_index()`
+   - `startup_refresh_model_status` → `get_dependency_status()` + write JSON
+   - `startup_training_batch` → `IdleAutomationDAE()._execute_pattern_training()` via asyncio.run()
+
+#### Integration Tests (Live Dispatch)
+
+5 tests proving executability without mocking the critical paths:
+- `test_model_status_task_executes`: Proves model status has executor
+- `test_holo_index_task_executes`: Proves HoloIndex has executor (mocked to avoid 30s index)
+- `test_self_research_task_executes_live`: **LIVE** - proves kwargs are correct
+- `test_training_batch_task_executes_live`: **LIVE** - proves IdleAutomationDAE routing
+- `test_unknown_task_returns_none`: Proves unknown tasks fall through
+
+#### Files Modified
+
+- `modules/communication/moltbot_bridge/scripts/run_task.py`: +95 lines (dispatch path 4 with correct routing)
+- `tests/test_startup_maintenance_gate.py`: +90 lines (live dispatch integration tests)
+
+#### Round 3: Success Classification Fix
+
+**Problem**: `startup_refresh_self_research` returned `ok=False` even on success because success detection checked `result.get("status") == "completed"` but `SelfResearchRefresher.run()` returns a report dict with `generated_on`, not a `status` field.
+
+**Fix**: Changed success detection to `isinstance(result, dict) and "generated_on" in result`
+
+**Regression test**: `test_self_research_task_executes_live` now asserts `ok=True`
+
+#### Test Results
+
+18 tests pass (13 existing + 5 integration tests)
+
+#### Final Verification
+
+```
+startup_refresh_model_status:    ok=True
+startup_refresh_holo_index:      ok=True
+startup_refresh_self_research:   ok=True
+startup_training_batch:          ok=False (expected - training already complete)
+```
+
+---
+
+### 2026-03-24 - Startup Maintenance Gate (P0)
+
+**WSP Protocol**: WSP 22, WSP 27 (DAE Architecture)
+**Phase**: Compute-conserving startup
+**Agent**: 0102
+
+#### Problem
+
+Heavy work like training, HoloIndex refresh, and doc generation was potentially blocking startup.
+The system needed a way to detect staleness cheaply and queue maintenance for later execution.
+
+#### Solution
+
+Created `startup_maintenance_gate.py` that implements a compute-conserving startup pattern:
+
+1. **Detect** staleness without heavy execution:
+   - Self-research status (max 6h)
+   - HoloIndex freshness (max 12h)
+   - Training readiness (max 24h)
+   - Model routing status (max 24h)
+
+2. **Queue** maintenance tasks to AgentDB:
+   - `startup_refresh_self_research`
+   - `startup_refresh_holo_index`
+   - `startup_training_batch` (only if explicitly due)
+   - `startup_refresh_model_status`
+
+3. **Return quickly** without blocking startup
+
+#### Integration
+
+Added call in `main.py` after preflights pass, before `bootstrap_runtime_dae_launches()`.
+
+#### Constraints Enforced
+
+- Preflight may inspect timestamps/hashes
+- Preflight must NOT run model training
+- Preflight must NOT run full HoloIndex indexing
+- Preflight must NOT rewrite narrative docs
+- Heavy work belongs in queued/background execution
+
+#### Files Added
+
+- `src/startup_maintenance_gate.py`: 300 lines, StartupMaintenanceGate class
+- `tests/test_startup_maintenance_gate.py`: 13 tests
+
+#### Files Changed
+
+- `main.py`: Added startup maintenance gate call after preflights
+
+#### Verification
+
+- `pytest test_startup_maintenance_gate.py` → 13 passed
+- In-process: Detects 3 stale artifacts, prints `[STARTUP-MAINT] preflight=PASS stale=3`
+- No heavy compute inline (tests verify < 5s execution)
+
+---
+
 ### 2026-03-24 - Scheduled Natural Language Automations
 
 **WSP Protocol**: WSP 22, WSP 27 (DAE Architecture), WSP 60 (Memory Architecture)

--- a/modules/infrastructure/idle_automation/src/startup_maintenance_gate.py
+++ b/modules/infrastructure/idle_automation/src/startup_maintenance_gate.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""
+Startup Maintenance Gate - Compute-conserving startup maintenance detection.
+
+At startup, detects stale generated documentation / model policy / training readiness /
+index freshness, then queues maintenance work for later execution instead of doing
+heavy work inline.
+
+Does NOT:
+- Run model training
+- Run full HoloIndex indexing
+- Rewrite narrative docs
+- Block startup with heavy compute
+
+DOES:
+- Inspect timestamps/hashes cheaply
+- Queue maintenance tasks to AgentDB
+- Return quickly without blocking
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+REPORTS_DIR = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "workspace"
+    / "reports"
+)
+
+
+def utc_now() -> datetime:
+    """Return current UTC datetime."""
+    return datetime.now(UTC)
+
+
+def utc_now_iso() -> str:
+    """Return current UTC timestamp in ISO format."""
+    return utc_now().isoformat()
+
+
+def _load_json_safe(path: Path) -> Optional[Dict[str, Any]]:
+    """Load JSON file safely, returning None on error."""
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _artifact_age_hours(artifact: Optional[Dict[str, Any]], key: str = "generated_on") -> Optional[float]:
+    """Return age in hours of a generated artifact, or None if unavailable."""
+    if not artifact:
+        return None
+    ts = artifact.get(key) or artifact.get("checked_on")
+    if not ts:
+        return None
+    try:
+        checked = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+        if checked.tzinfo is None:
+            checked = checked.replace(tzinfo=UTC)
+        return (utc_now() - checked).total_seconds() / 3600
+    except Exception:
+        return None
+
+
+class StartupMaintenanceGate:
+    """Lightweight startup maintenance detector and task queuer."""
+
+    def __init__(
+        self,
+        repo_root: Optional[Path] = None,
+        max_self_research_age_hours: float = 6.0,
+        max_holo_index_age_hours: float = 12.0,
+        max_training_status_age_hours: float = 24.0,
+        max_model_status_age_hours: float = 24.0,
+    ):
+        self.repo_root = Path(repo_root or REPO_ROOT).resolve()
+        self.reports_dir = REPORTS_DIR
+        self.max_self_research_age_hours = max_self_research_age_hours
+        self.max_holo_index_age_hours = max_holo_index_age_hours
+        self.max_training_status_age_hours = max_training_status_age_hours
+        self.max_model_status_age_hours = max_model_status_age_hours
+
+    def check_self_research_status(self) -> Dict[str, Any]:
+        """Check if self-research status is stale."""
+        path = self.reports_dir / "openclaw_self_research_status.json"
+        status = _load_json_safe(path)
+        age = _artifact_age_hours(status)
+
+        return {
+            "artifact": "self_research_status",
+            "path": str(path),
+            "exists": status is not None,
+            "age_hours": age,
+            "max_age_hours": self.max_self_research_age_hours,
+            "stale": age is None or age > self.max_self_research_age_hours,
+        }
+
+    def check_holo_index_freshness(self) -> Dict[str, Any]:
+        """Check if HoloIndex is stale using AgentDB."""
+        try:
+            from modules.infrastructure.database.src.agent_db import AgentDB
+
+            db = AgentDB()
+            code_stale = db.should_refresh_index("code", max_age_hours=self.max_holo_index_age_hours)
+            wsp_stale = db.should_refresh_index("wsp", max_age_hours=self.max_holo_index_age_hours)
+            stale = code_stale or wsp_stale
+        except Exception as exc:
+            logger.debug("HoloIndex freshness check failed: %s", exc)
+            code_stale = None
+            wsp_stale = None
+            stale = True  # Assume stale if we can't check
+
+        return {
+            "artifact": "holo_index",
+            "code_stale": code_stale,
+            "wsp_stale": wsp_stale,
+            "max_age_hours": self.max_holo_index_age_hours,
+            "stale": stale,
+        }
+
+    def check_training_readiness(self) -> Dict[str, Any]:
+        """Check training readiness without running training."""
+        path = self.reports_dir / "training_readiness_status.json"
+        status = _load_json_safe(path)
+        age = _artifact_age_hours(status)
+
+        # Also check PatternMemory stats if available
+        training_due = False
+        checkpoint_line = None
+        try:
+            from holo_index.qwen_advisor.pattern_memory import PatternMemory
+
+            mem = PatternMemory()
+            stats = mem.get_stats()
+            if stats:
+                checkpoint_line = stats.get("checkpoint_line", 0)
+                # Training is due if less than 50% complete
+                training_due = checkpoint_line < 14000  # ~50% of 28K lines
+        except Exception:
+            pass
+
+        return {
+            "artifact": "training_readiness",
+            "path": str(path),
+            "exists": status is not None,
+            "age_hours": age,
+            "max_age_hours": self.max_training_status_age_hours,
+            "stale": age is None or age > self.max_training_status_age_hours,
+            "checkpoint_line": checkpoint_line,
+            "training_due": training_due,
+        }
+
+    def check_model_routing_status(self) -> Dict[str, Any]:
+        """Check local model routing status freshness."""
+        path = self.reports_dir / "local_model_status.json"
+        status = _load_json_safe(path)
+        age = _artifact_age_hours(status)
+
+        return {
+            "artifact": "model_routing_status",
+            "path": str(path),
+            "exists": status is not None,
+            "age_hours": age,
+            "max_age_hours": self.max_model_status_age_hours,
+            "stale": age is None or age > self.max_model_status_age_hours,
+        }
+
+    def detect_maintenance_needs(self) -> Dict[str, Any]:
+        """Detect all maintenance needs without running heavy work."""
+        checks = {
+            "self_research": self.check_self_research_status(),
+            "holo_index": self.check_holo_index_freshness(),
+            "training": self.check_training_readiness(),
+            "model_routing": self.check_model_routing_status(),
+        }
+
+        stale_count = sum(1 for c in checks.values() if c.get("stale"))
+        training_due = checks["training"].get("training_due", False)
+
+        return {
+            "checked_at": utc_now_iso(),
+            "checks": checks,
+            "stale_count": stale_count,
+            "training_due": training_due,
+            "maintenance_needed": stale_count > 0 or training_due,
+        }
+
+    def queue_maintenance_tasks(self, detection: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Queue maintenance tasks to AgentDB for later execution.
+
+        Does NOT execute tasks - only queues them for idle automation / supervisor.
+        """
+        try:
+            from modules.infrastructure.database.src.agent_db import AgentDB
+        except ImportError:
+            logger.warning("[STARTUP_MAINT] AgentDB unavailable - cannot queue tasks")
+            return []
+
+        db = AgentDB()
+        queued = []
+        checks = detection.get("checks", {})
+
+        # Queue self-research refresh if stale
+        if checks.get("self_research", {}).get("stale"):
+            task_id = "startup_refresh_self_research"
+            created = db.create_autonomous_task(
+                task_id=task_id,
+                description="Refresh self-research status (startup maintenance gate detected staleness)",
+                required_skills=["openclaw-monitor"],
+                estimated_complexity=2.0,
+                priority_score=12.0,
+                context={
+                    "source": "startup_maintenance_gate",
+                    "trigger": "stale_self_research",
+                    "age_hours": checks["self_research"].get("age_hours"),
+                },
+            )
+            if created:
+                try:
+                    db.db.execute_write(
+                        "UPDATE agents_autonomous_tasks SET status = 'pending' WHERE task_id = ? AND status IS NULL",
+                        (task_id,),
+                    )
+                except Exception:
+                    pass
+            queued.append({"task_id": task_id, "created": created, "type": "self_research_refresh"})
+
+        # Queue HoloIndex refresh if stale
+        if checks.get("holo_index", {}).get("stale"):
+            task_id = "startup_refresh_holo_index"
+            created = db.create_autonomous_task(
+                task_id=task_id,
+                description="Refresh HoloIndex (startup maintenance gate detected staleness)",
+                required_skills=["holo-search"],
+                estimated_complexity=3.0,
+                priority_score=11.0,
+                context={
+                    "source": "startup_maintenance_gate",
+                    "trigger": "stale_holo_index",
+                    "code_stale": checks["holo_index"].get("code_stale"),
+                    "wsp_stale": checks["holo_index"].get("wsp_stale"),
+                },
+            )
+            if created:
+                try:
+                    db.db.execute_write(
+                        "UPDATE agents_autonomous_tasks SET status = 'pending' WHERE task_id = ? AND status IS NULL",
+                        (task_id,),
+                    )
+                except Exception:
+                    pass
+            queued.append({"task_id": task_id, "created": created, "type": "holo_index_refresh"})
+
+        # Queue training batch only if explicitly due AND status is stale
+        training = checks.get("training", {})
+        if training.get("training_due") and training.get("stale"):
+            task_id = "startup_training_batch"
+            created = db.create_autonomous_task(
+                task_id=task_id,
+                description="Run training batch (startup detected training is due)",
+                required_skills=["training-system"],
+                estimated_complexity=4.0,
+                priority_score=10.0,
+                context={
+                    "source": "startup_maintenance_gate",
+                    "trigger": "training_due",
+                    "checkpoint_line": training.get("checkpoint_line"),
+                },
+            )
+            if created:
+                try:
+                    db.db.execute_write(
+                        "UPDATE agents_autonomous_tasks SET status = 'pending' WHERE task_id = ? AND status IS NULL",
+                        (task_id,),
+                    )
+                except Exception:
+                    pass
+            queued.append({"task_id": task_id, "created": created, "type": "training_batch"})
+
+        # Queue model status refresh if stale
+        if checks.get("model_routing", {}).get("stale"):
+            task_id = "startup_refresh_model_status"
+            created = db.create_autonomous_task(
+                task_id=task_id,
+                description="Refresh local model routing status",
+                required_skills=["openclaw-monitor"],
+                estimated_complexity=1.0,
+                priority_score=8.0,
+                context={
+                    "source": "startup_maintenance_gate",
+                    "trigger": "stale_model_status",
+                    "age_hours": checks["model_routing"].get("age_hours"),
+                },
+            )
+            if created:
+                try:
+                    db.db.execute_write(
+                        "UPDATE agents_autonomous_tasks SET status = 'pending' WHERE task_id = ? AND status IS NULL",
+                        (task_id,),
+                    )
+                except Exception:
+                    pass
+            queued.append({"task_id": task_id, "created": created, "type": "model_status_refresh"})
+
+        return queued
+
+    def run(self, queue_tasks: bool = True) -> Dict[str, Any]:
+        """Run startup maintenance detection and optionally queue tasks.
+
+        Returns quickly - does NOT run heavy work.
+        """
+        detection = self.detect_maintenance_needs()
+        queued = []
+
+        if queue_tasks and detection.get("maintenance_needed"):
+            queued = self.queue_maintenance_tasks(detection)
+
+        return {
+            "detection": detection,
+            "queued_tasks": queued,
+            "queue_enabled": queue_tasks,
+        }
+
+
+def run_startup_maintenance_gate(repo_root: Optional[Path] = None, queue_tasks: bool = True) -> bool:
+    """Run the startup maintenance gate.
+
+    This is the entry point called from main.py.
+    Returns True always (non-blocking) but logs maintenance needs.
+    """
+    try:
+        gate = StartupMaintenanceGate(repo_root=repo_root)
+        result = gate.run(queue_tasks=queue_tasks)
+
+        detection = result.get("detection", {})
+        stale_count = detection.get("stale_count", 0)
+        training_due = detection.get("training_due", False)
+        queued = result.get("queued_tasks", [])
+
+        if stale_count > 0 or training_due:
+            parts = []
+            if stale_count > 0:
+                parts.append(f"stale={stale_count}")
+            if training_due:
+                parts.append("training_due=yes")
+            if queued:
+                parts.append(f"queued={len(queued)}")
+
+            print(f"[STARTUP-MAINT] preflight=PASS {' '.join(parts)}")
+        else:
+            print("[STARTUP-MAINT] preflight=PASS fresh")
+
+        return True  # Never blocks startup
+
+    except Exception as exc:
+        logger.debug("[STARTUP-MAINT] Detection failed: %s", exc)
+        print(f"[STARTUP-MAINT] preflight=WARN error={type(exc).__name__}")
+        return True  # Non-blocking even on error
+
+
+if __name__ == "__main__":
+    import sys
+
+    queue = "--no-queue" not in sys.argv
+    run_startup_maintenance_gate(queue_tasks=queue)

--- a/modules/infrastructure/idle_automation/tests/test_startup_maintenance_gate.py
+++ b/modules/infrastructure/idle_automation/tests/test_startup_maintenance_gate.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""
+Tests for startup maintenance gate.
+
+Verifies:
+1. Stale detection works without heavy execution
+2. Task queuing behavior
+3. Never blocks startup
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO_ROOT))
+
+
+class TestStartupMaintenanceDetection:
+    """Tests for maintenance detection logic."""
+
+    def test_detects_stale_self_research(self, tmp_path):
+        """Detects stale self-research status."""
+        from modules.infrastructure.idle_automation.src.startup_maintenance_gate import (
+            StartupMaintenanceGate,
+        )
+
+        gate = StartupMaintenanceGate(repo_root=REPO_ROOT)
+        check = gate.check_self_research_status()
+
+        # Should have expected structure
+        assert "artifact" in check
+        assert "stale" in check
+        assert check["artifact"] == "self_research_status"
+        assert isinstance(check["stale"], bool)
+
+    def test_detects_stale_holo_index(self):
+        """Detects stale HoloIndex."""
+        from modules.infrastructure.idle_automation.src.startup_maintenance_gate import (
+            StartupMaintenanceGate,
+        )
+
+        gate = StartupMaintenanceGate(repo_root=REPO_ROOT)
+        check = gate.check_holo_index_freshness()
+
+        assert "artifact" in check
+        assert check["artifact"] == "holo_index"
+        assert "stale" in check
+
+    def test_detects_training_readiness(self):
+        """Detects training readiness without running training."""
+        from modules.infrastructure.idle_automation.src.startup_maintenance_gate import (
+            StartupMaintenanceGate,
+        )
+
+        gate = StartupMaintenanceGate(repo_root=REPO_ROOT)
+        check = gate.check_training_readiness()
+
+        assert "artifact" in check
+        assert check["artifact"] == "training_readiness"
+        assert "training_due" in check
+        assert "stale" in check
+
+    def test_detects_model_routing_status(self):
+        """Detects model routing status staleness."""
+        from modules.infrastructure.idle_automation.src.startup_maintenance_gate import (
+            StartupMaintenanceGate,
+        )
+
+        gate = StartupMaintenanceGate(repo_root=REPO_ROOT)
+        check = gate.check_model_routing_status()
+
+        assert "artifact" in check
+        assert check["artifact"] == "model_routing_status"
+        assert "stale" in check
+
+    def test_detect_maintenance_needs_returns_summary(self):
+        """detect_maintenance_needs returns complete summary."""
+        from modules.infrastructure.idle_automation.src.startup_maintenance_gate import (
+            StartupMaintenanceGate,
+        )
+
+        gate = StartupMaintenanceGate(repo_root=REPO_ROOT)
+        result = gate.detect_maintenance_needs()
+
+        assert "checked_at" in result
+        assert "checks" in result
+        assert "stale_count" in result
+        assert "training_due" in result
+        assert "maintenance_needed" in result
+
+        # Checks should have all 4 artifacts
+        assert "self_research" in result["checks"]
+        assert "holo_index" in result["checks"]
+        assert "training" in result["checks"]
+        assert "model_routing" in result["checks"]
+
+
+class TestStartupMaintenanceQueueing:
+    """Tests for task queueing behavior."""
+
+    def test_queues_tasks_when_stale(self):
+        """Queues maintenance tasks when artifacts are stale."""
+        from modules.infrastructure.idle_automation.src.startup_maintenance_gate import (
+            StartupMaintenanceGate,
+        )
+
+        # Mock detection with stale artifacts
+        detection = {
+            "checked_at": "2026-03-24T00:00:00+00:00",
+            "checks": {
+                "self_research": {"stale": True, "age_hours": 24.0},
+                "holo_index": {"stale": True, "code_stale": True, "wsp_stale": False},
+                "training": {"stale": True, "training_due": False},
+                "model_routing": {"stale": False},
+            },
+            "stale_count": 3,
+            "training_due": False,
+            "maintenance_needed": True,
+        }
+
+        gate = StartupMaintenanceGate(repo_root=REPO_ROOT)
+
+        # Mock AgentDB
+        mock_db = MagicMock()
+        mock_db.create_autonomous_task.return_value = True
+        mock_db.db.execute_write.return_value = 1
+
+        with patch("modules.infrastructure.database.src.agent_db.AgentDB", return_value=mock_db):
+            queued = gate.queue_maintenance_tasks(detection)
+
+        # Should queue self_research and holo_index (both stale)
+        # Training is stale but training_due=False, so not queued
+        queued_types = [q["type"] for q in queued]
+        assert "self_research_refresh" in queued_types
+        assert "holo_index_refresh" in queued_types
+        assert "training_batch" not in queued_types  # training_due=False
+
+    def test_does_not_queue_training_unless_due(self):
+        """Training batch only queued when explicitly due."""
+        from modules.infrastructure.idle_automation.src.startup_maintenance_gate import (
+            StartupMaintenanceGate,
+        )
+
+        # Mock detection: training stale but NOT due
+        detection = {
+            "checked_at": "2026-03-24T00:00:00+00:00",
+            "checks": {
+                "self_research": {"stale": False},
+                "holo_index": {"stale": False},
+                "training": {"stale": True, "training_due": False},  # Stale but not due
+                "model_routing": {"stale": False},
+            },
+            "stale_count": 1,
+            "training_due": False,
+            "maintenance_needed": True,
+        }
+
+        gate = StartupMaintenanceGate(repo_root=REPO_ROOT)
+
+        mock_db = MagicMock()
+        mock_db.create_autonomous_task.return_value = True
+
+        with patch("modules.infrastructure.database.src.agent_db.AgentDB", return_value=mock_db):
+            queued = gate.queue_maintenance_tasks(detection)
+
+        # Training should NOT be queued (not due)
+        queued_types = [q["type"] for q in queued]
+        assert "training_batch" not in queued_types
+
+    def test_queues_training_when_due_and_stale(self):
+        """Training batch queued when both due AND stale."""
+        from modules.infrastructure.idle_automation.src.startup_maintenance_gate import (
+            StartupMaintenanceGate,
+        )
+
+        # Mock detection: training is BOTH stale AND due
+        detection = {
+            "checked_at": "2026-03-24T00:00:00+00:00",
+            "checks": {
+                "self_research": {"stale": False},
+                "holo_index": {"stale": False},
+                "training": {"stale": True, "training_due": True, "checkpoint_line": 5000},
+                "model_routing": {"stale": False},
+            },
+            "stale_count": 1,
+            "training_due": True,
+            "maintenance_needed": True,
+        }
+
+        gate = StartupMaintenanceGate(repo_root=REPO_ROOT)
+
+        mock_db = MagicMock()
+        mock_db.create_autonomous_task.return_value = True
+        mock_db.db.execute_write.return_value = 1
+
+        with patch("modules.infrastructure.database.src.agent_db.AgentDB", return_value=mock_db):
+            queued = gate.queue_maintenance_tasks(detection)
+
+        # Training SHOULD be queued (both stale AND due)
+        queued_types = [q["type"] for q in queued]
+        assert "training_batch" in queued_types
+
+
+class TestStartupMaintenanceNonBlocking:
+    """Tests that startup is never blocked."""
+
+    def test_run_always_returns_true(self):
+        """run_startup_maintenance_gate always returns True (non-blocking)."""
+        from modules.infrastructure.idle_automation.src.startup_maintenance_gate import (
+            run_startup_maintenance_gate,
+        )
+
+        # Should return True even if everything is stale
+        result = run_startup_maintenance_gate(repo_root=REPO_ROOT, queue_tasks=False)
+        assert result is True
+
+    def test_returns_true_on_import_error(self):
+        """Returns True even if dependencies fail to import."""
+        from modules.infrastructure.idle_automation.src.startup_maintenance_gate import (
+            run_startup_maintenance_gate,
+        )
+
+        # Patch to simulate import error
+        with patch(
+            "modules.infrastructure.idle_automation.src.startup_maintenance_gate.StartupMaintenanceGate",
+            side_effect=ImportError("test"),
+        ):
+            # Should still return True (non-blocking)
+            result = run_startup_maintenance_gate(repo_root=REPO_ROOT)
+            # Note: The function catches ImportError internally
+            assert result is True
+
+    def test_returns_true_on_exception(self):
+        """Returns True even on unexpected exceptions."""
+        from modules.infrastructure.idle_automation.src.startup_maintenance_gate import (
+            run_startup_maintenance_gate,
+        )
+
+        # Patch to simulate exception
+        with patch(
+            "modules.infrastructure.idle_automation.src.startup_maintenance_gate.StartupMaintenanceGate.detect_maintenance_needs",
+            side_effect=RuntimeError("test exception"),
+        ):
+            result = run_startup_maintenance_gate(repo_root=REPO_ROOT)
+            assert result is True
+
+
+class TestStartupMaintenanceNoHeavyWork:
+    """Tests that no heavy work is done inline."""
+
+    def test_does_not_run_holo_index_refresh_inline(self):
+        """HoloIndex refresh is queued, not run inline."""
+        from modules.infrastructure.idle_automation.src.startup_maintenance_gate import (
+            StartupMaintenanceGate,
+        )
+
+        gate = StartupMaintenanceGate(repo_root=REPO_ROOT)
+
+        # Run detection - should be fast
+        import time
+
+        start = time.monotonic()
+        result = gate.detect_maintenance_needs()
+        elapsed = time.monotonic() - start
+
+        # Detection should be fast (< 5 seconds)
+        # HoloIndex refresh takes 15-30 seconds - if it ran, this would fail
+        assert elapsed < 5.0, f"Detection took {elapsed:.1f}s - too slow, may be doing heavy work"
+
+    def test_does_not_run_training_inline(self):
+        """Training is queued, not run inline."""
+        from modules.infrastructure.idle_automation.src.startup_maintenance_gate import (
+            StartupMaintenanceGate,
+        )
+
+        gate = StartupMaintenanceGate(repo_root=REPO_ROOT)
+
+        # Run full gate including queueing
+        import time
+
+        start = time.monotonic()
+
+        mock_db = MagicMock()
+        mock_db.create_autonomous_task.return_value = True
+        mock_db.db.execute_write.return_value = 1
+
+        with patch("modules.infrastructure.database.src.agent_db.AgentDB", return_value=mock_db):
+            result = gate.run(queue_tasks=True)
+
+        elapsed = time.monotonic() - start
+
+        # Full run should still be fast (< 5 seconds)
+        # Training takes 30+ seconds - if it ran, this would fail
+        assert elapsed < 5.0, f"Full run took {elapsed:.1f}s - too slow, may be doing heavy work"
+
+
+class TestStartupTaskExecution:
+    """Integration tests proving queued tasks are executable through run_task.py."""
+
+    def test_model_status_task_executes(self, tmp_path):
+        """startup_refresh_model_status task executes through dispatch path."""
+        from modules.communication.moltbot_bridge.scripts.run_task import (
+            _try_startup_maintenance_dispatch,
+        )
+
+        result = _try_startup_maintenance_dispatch(
+            repo_root=REPO_ROOT,
+            task_id="startup_refresh_model_status",
+            context={"source": "startup_maintenance_gate"},
+        )
+
+        assert result is not None, "Model status task should have an executor"
+        assert result["executor"] == "startup:model_status"
+        # ok can be True or False depending on LM Studio state, but should not error
+        assert "detail" in result
+
+    def test_holo_index_task_executes(self):
+        """startup_refresh_holo_index task executes through dispatch path."""
+        from modules.communication.moltbot_bridge.scripts.run_task import (
+            _try_startup_maintenance_dispatch,
+        )
+
+        # Use short timeout to avoid actual indexing
+        with patch(
+            "modules.infrastructure.idle_automation.src.self_research_refresh.SelfResearchRefresher.refresh_holo_index"
+        ) as mock_refresh:
+            mock_refresh.return_value = {
+                "code_stale": False,
+                "wsp_stale": False,
+                "refresh_success": True,
+            }
+
+            result = _try_startup_maintenance_dispatch(
+                repo_root=REPO_ROOT,
+                task_id="startup_refresh_holo_index",
+                context={"source": "startup_maintenance_gate"},
+            )
+
+        assert result is not None, "HoloIndex task should have an executor"
+        assert result["executor"] == "startup:holo_index"
+        assert result["ok"] is True
+
+    def test_self_research_task_executes_live(self):
+        """startup_refresh_self_research executes through live dispatch (no mocking)."""
+        from modules.communication.moltbot_bridge.scripts.run_task import (
+            _try_startup_maintenance_dispatch,
+        )
+
+        # Live dispatch - verifies correct SelfResearchRefresher.run() kwargs
+        result = _try_startup_maintenance_dispatch(
+            repo_root=REPO_ROOT,
+            task_id="startup_refresh_self_research",
+            context={"source": "startup_maintenance_gate"},
+        )
+
+        assert result is not None, "Self research task should have an executor"
+        assert result["executor"] == "startup:self_research"
+        # Critical: no "unexpected keyword argument" in detail
+        assert "unexpected keyword" not in result.get("detail", "").lower()
+        # Regression: success detection uses generated_on, not status field
+        assert result["ok"] is True, "Self research should return ok=True when report has generated_on"
+
+    def test_training_batch_task_executes_live(self):
+        """startup_training_batch executes through live dispatch (IdleAutomationDAE)."""
+        from modules.communication.moltbot_bridge.scripts.run_task import (
+            _try_startup_maintenance_dispatch,
+        )
+
+        # Live dispatch - verifies correct IdleAutomationDAE._execute_pattern_training() call
+        result = _try_startup_maintenance_dispatch(
+            repo_root=REPO_ROOT,
+            task_id="startup_training_batch",
+            context={"source": "startup_maintenance_gate"},
+        )
+
+        assert result is not None, "Training batch task should have an executor"
+        assert result["executor"] == "startup:training_batch"
+        # ok may be True or False depending on training state, but should not error
+        assert "detail" in result
+        # Critical: no "unexpected keyword argument" in detail
+        assert "unexpected keyword" not in result.get("detail", "").lower()
+        # Should have structured training result
+        structured = result.get("structured_result", {})
+        assert "task" in structured or "error" in result.get("detail", "")
+
+    def test_unknown_task_returns_none(self):
+        """Unknown startup task returns None (falls through to no_executor_matched)."""
+        from modules.communication.moltbot_bridge.scripts.run_task import (
+            _try_startup_maintenance_dispatch,
+        )
+
+        result = _try_startup_maintenance_dispatch(
+            repo_root=REPO_ROOT,
+            task_id="startup_unknown_task",
+            context={"source": "startup_maintenance_gate"},
+        )
+
+        assert result is None, "Unknown task should return None"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Non-blocking startup maintenance detection that queues tasks for later execution
- Detects stale artifacts (self-research, HoloIndex, training, model status)
- Dispatch path 4 in `run_task.py` routes startup tasks to real executors
- 18 tests including live dispatch integration tests

## Changes

| File | Lines | Purpose |
|------|-------|---------|
| `startup_maintenance_gate.py` | +379 | Startup detection and task queueing |
| `test_startup_maintenance_gate.py` | +406 | 18 tests including live dispatch |
| `run_task.py` | +121 | Dispatch path 4 for startup tasks |
| `ModLog.md` | +122 | Documentation |

## Executor Mapping

- `startup_refresh_self_research` → `SelfResearchRefresher.run()`
- `startup_refresh_holo_index` → `SelfResearchRefresher.refresh_holo_index()`
- `startup_refresh_model_status` → `get_dependency_status()` + write JSON
- `startup_training_batch` → `IdleAutomationDAE._execute_pattern_training()`

## Test plan

- [x] `python -m pytest modules/infrastructure/idle_automation/tests/test_startup_maintenance_gate.py -q` → 18 passed
- [x] Direct repro: `startup_refresh_self_research` → `ok=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)