### PR TITLE
docs(discord): Worker Z OBAI Phase 1 audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -311,6 +311,8 @@ docs/audits/*
 !docs/audits/domain_ops/**
 !docs/audits/science_swarm_external_foundup/
 !docs/audits/science_swarm_external_foundup/**
+!docs/audits/discord_bots/
+!docs/audits/discord_bots/**
 docs/sessions/
 
 # WSP agentic awakening runtime state (changes every session)

--- a/docs/audits/discord_bots/OBAI_DISCORD_BOT_SPEC_PHASE1.md
+++ b/docs/audits/discord_bots/OBAI_DISCORD_BOT_SPEC_PHASE1.md
@@ -1,0 +1,183 @@
+# OBAI Discord Bot Spec — Phase 1
+
+Worker: Z
+Date: 2026-04-07
+Slice: OBAI_DISCORD_BOT_SPEC_PHASE1
+Status: Canonical
+Repo: Foundups-Agent
+
+## 1. Identity
+
+OBAI is a non-admin community helper bot for the FOUNDUPS Discord server.
+
+| Field | Value |
+|-------|-------|
+| Bot name | OBAI |
+| App ID | 1127122752776699915 |
+| Role | Helper / explainer / observer / structured responder |
+| Server | FOUNDUPS (412646632992014336) |
+| Admin | NO — never |
+| Moderation | NO — never |
+
+OBAI is NOT 0102. They are separate identities, separate tokens, separate runtimes.
+
+## 2. Architecture Decision
+
+**RECOMMEND: STANDALONE_OBAI_GATEWAY_BOT**
+
+OBAI will be a new standalone Discord gateway bot module, not a sub-runtime
+or sibling of moltbot_bridge.
+
+### Justification
+
+| Factor | Verdict |
+|--------|---------|
+| Codebase fit | moltbot_bridge is 0102's runtime. Its config says "You are 0102." Its INTERFACE.md describes OpenClawDAE. No OBAI identity exists in it. |
+| Operational simplicity | Separate process = separate failure domain. OBAI crash does not affect 0102. |
+| Permission safety | 0102 runs with ADMINISTRATOR. OBAI must never touch admin APIs. Separate process enforces this at the OS level. |
+| Future extensibility | OBAI can evolve its own interaction patterns without touching 0102's control plane. |
+| Identity separation | Dual-bot spec requires distinct identities. Shared runtime risks identity bleed. |
+
+### Proposed Module Path
+
+```
+modules/communication/obai_discord_bot/
+├── README.md
+├── INTERFACE.md
+├── config/
+│   └── obai_config.json
+├── src/
+│   └── obai_gateway.py       # Discord gateway client (discord.py or raw)
+│   └── obai_thread_handler.py # Thread participation logic
+│   └── obai_commands.py       # Slash command registration
+│   └── obai_formatter.py      # Structured response formatting
+└── docs/
+    └── OBAI_DISCORD_BOT_SPEC_PHASE1.md  (symlink or copy)
+```
+
+### Environment
+
+```
+DISCORD_BOT_TOKEN_OBAI=<token>    # OBAI-specific, NOT shared with 0102
+OBAI_GUILD_ID=412646632992014336
+OBAI_LOG_LEVEL=info
+```
+
+## 3. Gateway Connection
+
+OBAI connects to Discord via the Gateway API (WebSocket), not webhooks.
+
+| Setting | Value |
+|---------|-------|
+| Library | discord.py (recommended) or raw gateway |
+| Intents | Guilds, GuildMessages, MessageContent, GuildMessageReactions |
+| Privileged intents | Message Content (enabled in Developer Portal) |
+| Sharding | Not required (single small server) |
+| Reconnect | Automatic with exponential backoff |
+
+## 4. Allowed Channels
+
+| Channel | Can read | Can post | Can create threads | Notes |
+|---------|----------|----------|--------------------|-------|
+| #swarm-general | YES | YES | YES | Primary discussion surface |
+| #swarm-work | YES | NO (main) | YES (threads) | Main channel locked; OBAI participates in threads only |
+| Work threads | YES | YES | — | Primary interaction surface |
+| #swarm-github | YES | NO | NO | Read-only feed channel |
+| #start-here | NO | NO | NO | Server-wide onboarding, not OBAI's scope |
+| Operator channels | NO | NO | NO | Admin-only, OBAI excluded |
+
+## 5. Interaction Patterns
+
+### Trigger Model: Passive Unless Invoked
+
+OBAI does NOT speak unless spoken to.
+
+| Trigger | Behavior |
+|---------|----------|
+| @OBAI mention in message | Reply in same channel/thread |
+| @OBAI mention in thread | Reply in thread |
+| `/obai` slash command | Structured response |
+| Unprompted posting | NEVER — OBAI does not initiate |
+| Scheduled summaries | NEVER — non-claim preserved |
+| DMs | NEVER — OBAI does not accept or send DMs |
+
+### Slash Commands (Phase 1)
+
+| Command | Description |
+|---------|-------------|
+| `/obai help` | List available commands |
+| `/obai explain <topic>` | Explain a Science Swarm concept |
+| `/obai link <issue_number>` | Link to a GitHub issue (read-only) |
+| `/obai status` | Report OBAI's own status (uptime, version) |
+
+## 6. Response Format
+
+All OBAI responses follow this structure:
+
+```
+[OBAI] <response body>
+
+---
+<source links if applicable>
+<escalation note if applicable>
+```
+
+### Rules
+
+- Identity prefix: Always `[OBAI]` at the start
+- Length: Concise. Target 1-3 short paragraphs in threads. No walls of text.
+- Evidence: Link to GitHub issues, PRs, docs when referencing them
+- Escalation: If a question exceeds OBAI's scope, say so explicitly and direct to operator or #swarm-general
+- Formatting: Use Discord markdown (bold, code blocks, links). No custom embeds in Phase 1.
+- Tone: Helpful, neutral, factual. Not chatty, not authoritative.
+
+## 7. Non-Claims (What OBAI Does NOT Do)
+
+| Claim | Truth |
+|-------|-------|
+| "OBAI verifies contributions" | NO — verification is via Python API |
+| "OBAI assigns roles" | NO — role management is operator-only |
+| "OBAI scores contributions" | NO — CABR/3V not wired to Discord |
+| "OBAI creates GitHub issues" | NO — OBAI is read-only for GitHub |
+| "OBAI moderates channels" | NO — no moderation powers |
+| "OBAI manages server settings" | NO — no admin powers |
+| "OBAI syncs data to GitHub" | NO — one-way GitHub->Discord only |
+| "OBAI handles wallet/stake verification" | NO — no wallet integration |
+| "OBAI sends scheduled digests" | NO — passive unless invoked |
+| "OBAI is 0102" | NO — separate identity, separate token, separate runtime |
+
+These non-claims align with FOUNDUPS_SCIENCE_SWARM_NONCLAIMS.md.
+
+## 8. Relationship to 0102
+
+| Dimension | 0102 | OBAI |
+|-----------|------|------|
+| Role | Admin / operator / infrastructure | Helper / explainer / observer |
+| Permissions | ADMINISTRATOR | Limited helper set (311452617792) |
+| Runtime | moltbot_bridge / OpenClawDAE | obai_discord_bot (new standalone) |
+| Token env var | DISCORD_BOT_TOKEN_0102 | DISCORD_BOT_TOKEN_OBAI |
+| Can kick/ban | YES | NO |
+| Can manage roles | YES | NO |
+| Can modify channels | YES | NO |
+| Can post anywhere | YES | Only allowed channels |
+| Identity prefix | [0102] | [OBAI] |
+
+OBAI may escalate to 0102 via a future internal channel. In Phase 1, escalation means: OBAI tells the user to contact the operator.
+
+## 9. Update to Non-Claims Document
+
+The following non-claim in FOUNDUPS_SCIENCE_SWARM_NONCLAIMS.md is now partially outdated:
+
+> "No custom webhook configured" -> NOW PARTIALLY TRUE
+
+A GitHub webhook from science-swarm-hub to #swarm-github is now live (configured 2026-04-07, events: pushes, pull_requests, issues, issue_comments). The NONCLAIMS doc should be updated to reflect this. However, this webhook is ops wiring, not canonical architecture — it should be documented as operational tooling, not as a bot feature.
+
+## 10. Acceptance Checklist
+
+- [x] OBAI role is explicit (helper/explainer/observer)
+- [x] Permission boundary is explicit (no admin, no mod, no roles)
+- [x] Allowed channel/thread behavior is explicit (table in S4)
+- [x] Non-claims are explicit (table in S7)
+- [x] Future bridge points are explicit (see OBAI_FUTURE_BRIDGE_POINTS.md)
+- [x] No code changes
+- [x] Architecture recommendation justified

--- a/docs/audits/discord_bots/OBAI_DISCORD_PERMISSION_BOUNDARY.md
+++ b/docs/audits/discord_bots/OBAI_DISCORD_PERMISSION_BOUNDARY.md
@@ -1,0 +1,92 @@
+# OBAI Discord Permission Boundary
+
+Worker: Z
+Date: 2026-04-07
+Parent: OBAI_DISCORD_BOT_SPEC_PHASE1.md
+
+## 1. Discord Application Permissions
+
+OBAI's managed role permission integer: **311452617792**
+
+### Granted Permissions
+
+| Permission | Bit | Granted |
+|------------|-----|---------|
+| VIEW_CHANNEL | 1 << 10 | YES |
+| SEND_MESSAGES | 1 << 11 | YES |
+| SEND_TTS_MESSAGES | 1 << 12 | YES |
+| EMBED_LINKS | 1 << 14 | YES |
+| ATTACH_FILES | 1 << 15 | YES |
+| READ_MESSAGE_HISTORY | 1 << 16 | YES |
+| ADD_REACTIONS | 1 << 6 | YES |
+| USE_EXTERNAL_EMOJIS | 1 << 18 | YES |
+| USE_SLASH_COMMANDS | 1 << 31 | YES |
+| CREATE_PUBLIC_THREADS | 1 << 35 | YES |
+| CREATE_PRIVATE_THREADS | 1 << 36 | YES |
+| SEND_MESSAGES_IN_THREADS | 1 << 38 | YES |
+| CHANGE_NICKNAME | 1 << 26 | YES |
+| CONNECT | 1 << 20 | YES |
+| SPEAK | 1 << 21 | YES |
+| USE_EXTERNAL_STICKERS | 1 << 37 | YES |
+
+### Denied Permissions (NEVER grant these to OBAI)
+
+| Permission | Bit | Status | Reason |
+|------------|-----|--------|--------|
+| ADMINISTRATOR | 1 << 3 | DENIED | OBAI must never have admin |
+| KICK_MEMBERS | 1 << 1 | DENIED | No moderation |
+| BAN_MEMBERS | 1 << 2 | DENIED | No moderation |
+| MANAGE_CHANNELS | 1 << 4 | DENIED | No server mutation |
+| MANAGE_GUILD | 1 << 5 | DENIED | No server mutation |
+| MANAGE_MESSAGES | 1 << 13 | DENIED | No moderation |
+| MANAGE_ROLES | 1 << 28 | DENIED | No role assignment |
+| MANAGE_WEBHOOKS | 1 << 29 | DENIED | No webhook control |
+| MANAGE_EXPRESSIONS | 1 << 30 | DENIED | No server mutation |
+| MANAGE_NICKNAMES | 1 << 27 | DENIED | No moderation |
+| MENTION_EVERYONE | 1 << 17 | DENIED | No mass pings |
+| MANAGE_THREADS | 1 << 34 | DENIED | No thread moderation |
+| MANAGE_EVENTS | 1 << 33 | DENIED | No event management |
+
+## 2. Channel-Level Overrides
+
+Beyond the managed role, channel permission overwrites further restrict OBAI:
+
+| Channel | Override | Effect |
+|---------|----------|--------|
+| #swarm-work | SEND_MESSAGES denied for @everyone | OBAI cannot post in main channel; can post in threads |
+| #swarm-github | SEND_MESSAGES denied for @everyone | OBAI cannot post; read-only feed |
+| Operator channels | VIEW_CHANNEL denied for non-operators | OBAI cannot see these channels |
+
+## 3. Runtime Permission Enforcement
+
+The OBAI bot code MUST also enforce permission boundaries at the application level,
+not relying solely on Discord's permission system:
+
+| Rule | Enforcement |
+|------|-------------|
+| Never call admin API endpoints | Code-level blocklist |
+| Never attempt role modifications | No Discord role API calls |
+| Never attempt channel modifications | No channel PATCH/DELETE calls |
+| Never attempt member kick/ban | No member removal API calls |
+| Never DM users | No DM channel creation |
+| Never mention @everyone or @here | Message content validation |
+
+## 4. Token Security
+
+| Rule | Detail |
+|------|--------|
+| Token env var | DISCORD_BOT_TOKEN_OBAI |
+| Token storage | .env file only, never in code or config files |
+| Token in logs | NEVER — redact in all log output |
+| Token in chat | NEVER — do not display, reference, or hint at token value |
+| Token rotation | Reset in Developer Portal if suspected compromise |
+| Shared with 0102 | NEVER — separate tokens, separate applications |
+
+## 5. Escalation Path
+
+If OBAI encounters a situation requiring admin action:
+
+1. OBAI does NOT attempt the action
+2. OBAI responds with: "This requires operator action. Please contact the server operator."
+3. Future: OBAI posts to an internal escalation channel readable by 0102
+4. OBAI never claims it "will handle" admin tasks

--- a/docs/audits/discord_bots/OBAI_FUTURE_BRIDGE_POINTS.md
+++ b/docs/audits/discord_bots/OBAI_FUTURE_BRIDGE_POINTS.md
@@ -1,0 +1,112 @@
+# OBAI Future Bridge Points
+
+Worker: Z
+Date: 2026-04-07
+Parent: OBAI_DISCORD_BOT_SPEC_PHASE1.md
+
+## Purpose
+
+This document lists anticipated integration points between OBAI and other systems.
+None of these are implemented in Phase 1. They are future architecture markers.
+
+## 1. GitHub Issue Linking (Read-Only)
+
+| Field | Value |
+|-------|-------|
+| Direction | GitHub -> OBAI (read-only) |
+| Mechanism | OBAI reads GitHub API to fetch issue/PR metadata |
+| Trigger | User requests via `/obai link #42` or @mention |
+| Output | Formatted issue summary in Discord thread |
+| Write access | NEVER — OBAI does not create, close, or modify GitHub objects |
+| Auth | GitHub personal access token (read-only scope) or public API |
+
+### Prerequisite
+- OBAI needs read access to FOUNDUPS/science-swarm-hub (public repo, no auth needed for basic reads)
+- Rate limiting: respect GitHub API limits (60/hour unauthenticated, 5000/hour with token)
+
+## 2. OBAI-to-0102 Escalation Channel
+
+| Field | Value |
+|-------|-------|
+| Direction | OBAI -> 0102 (internal) |
+| Mechanism | OBAI posts to a private escalation channel readable by 0102 |
+| Trigger | OBAI encounters a request requiring admin/operator action |
+| Channel | Future: #obai-escalation (Operator category, OBAI can post, users cannot see) |
+| Current behavior | OBAI tells user to contact operator manually |
+
+### Prerequisite
+- Create #obai-escalation channel in Operator category
+- Grant OBAI SEND_MESSAGES in that channel only
+- 0102 reads and acts on escalation messages
+
+## 3. CABR Signal Filter Intake
+
+| Field | Value |
+|-------|-------|
+| Direction | CABR system -> OBAI (read-only) |
+| Mechanism | OBAI reads CABR signal data to report contribution context |
+| Trigger | User asks "what's my contribution status?" or similar |
+| Output | Formatted summary of available CABR signals |
+| Write access | NEVER — OBAI does not score, verify, or modify CABR data |
+| Status | NOT WIRED — CABR is not connected to Discord |
+
+### Prerequisite
+- CABR API or data surface accessible from OBAI runtime
+- OBAI can only report what it reads; it cannot claim verification authority
+
+## 4. Python API Work-Unit Read Surface
+
+| Field | Value |
+|-------|-------|
+| Direction | pqn_swarm_hub -> OBAI (read-only) |
+| Mechanism | OBAI queries work unit registry for status |
+| Trigger | User asks "what work units are open?" or similar |
+| Output | Formatted list of open/available work units |
+| Write access | NEVER — OBAI does not create, submit, or verify work units |
+
+### Prerequisite
+- pqn_swarm_hub exposes a read API (local import or REST)
+- OBAI runtime has access to the work unit registry
+
+## 5. Agent-Thread Posting Model
+
+| Field | Value |
+|-------|-------|
+| Direction | Multiple agents -> Discord threads |
+| Mechanism | OBAI and other agents post in structured thread format |
+| Trigger | Future multi-agent collaboration in Science Swarm threads |
+| Current state | Only OBAI participates; 0102 is admin-only |
+| Identity rule | Each agent uses its own prefix: [OBAI], [0102], etc. |
+
+### Prerequisite
+- Thread collaboration model established (see OBAI_THREAD_PARTICIPATION_MODEL.md)
+- Each agent has its own token, identity, and permission boundary
+- No agent impersonates another
+
+## 6. Manual Relay / Signal Filter
+
+| Field | Value |
+|-------|-------|
+| Direction | Operator -> OBAI (configuration) |
+| Mechanism | Operator configures which signals OBAI relays to threads |
+| Example | "Relay new GitHub issues to #swarm-general" |
+| Current state | Not implemented — GitHub feed goes to #swarm-github via webhook |
+| OBAI role | Relay/format, not originate |
+
+### Prerequisite
+- Configuration surface for operator to define relay rules
+- OBAI formats and posts; does not decide what to relay
+
+## 7. Bridge Point Status Summary
+
+| Bridge Point | Phase 1 | Future |
+|--------------|---------|--------|
+| GitHub issue linking | NOT WIRED | Phase 2 candidate |
+| OBAI-to-0102 escalation | Manual ("contact operator") | Phase 2 candidate |
+| CABR signal intake | NOT WIRED | Phase 3+ |
+| Work-unit read surface | NOT WIRED | Phase 3+ |
+| Agent-thread posting | OBAI only | Phase 2+ |
+| Manual relay / signal filter | NOT WIRED | Phase 3+ |
+
+No bridge points are active in Phase 1. OBAI is a standalone Discord gateway bot
+that responds to mentions and slash commands with formatted text.

--- a/docs/audits/discord_bots/OBAI_THREAD_PARTICIPATION_MODEL.md
+++ b/docs/audits/discord_bots/OBAI_THREAD_PARTICIPATION_MODEL.md
@@ -1,0 +1,126 @@
+# OBAI Thread Participation Model
+
+Worker: Z
+Date: 2026-04-07
+Parent: OBAI_DISCORD_BOT_SPEC_PHASE1.md
+
+## 1. Core Principle
+
+Threads are OBAI's primary interaction surface.
+
+Channels are stable surfaces. Threads are active problem rooms.
+OBAI participates in threads when invoked, never unsolicited.
+
+## 2. Thread Behavior Matrix
+
+| Scenario | OBAI Behavior |
+|----------|--------------|
+| User @mentions OBAI in a thread | Reply in that thread |
+| User @mentions OBAI in #swarm-general | Reply in #swarm-general (or suggest moving to thread) |
+| User uses /obai command in a thread | Reply in that thread |
+| User uses /obai command in a channel | Reply in that channel |
+| New thread created | OBAI does NOT auto-join or auto-respond |
+| Thread goes stale | OBAI does NOT post reminders |
+| Thread has errors/confusion | OBAI only responds if explicitly asked |
+| Thread drifts off-topic | OBAI may suggest opening a new thread (if asked) |
+
+## 3. Thread Creation
+
+OBAI CAN create public threads in #swarm-general when explicitly asked by a user.
+OBAI CANNOT create threads in #swarm-work (restricted to swarm-contributor+ roles).
+
+| Channel | Can OBAI create thread? |
+|---------|------------------------|
+| #swarm-general | YES (if user requests it) |
+| #swarm-work | Depends on channel overrides — currently NO for OBAI |
+| #swarm-github | NO (read-only feed) |
+
+OBAI should never create threads unprompted.
+
+## 4. Thread Response Structure
+
+When replying in a thread, OBAI follows this format:
+
+```
+[OBAI] <concise answer>
+
+<evidence link if applicable>
+```
+
+### Length Rules
+
+| Context | Max Length |
+|---------|-----------|
+| Simple question | 1-2 sentences |
+| Explanation request | 1-3 short paragraphs |
+| GitHub link request | Link + one-line description |
+| Out-of-scope request | Redirect message (1-2 sentences) |
+
+OBAI never posts walls of text. If a topic requires a long explanation,
+OBAI links to the relevant doc or suggests the user read a specific file.
+
+## 5. Identity in Threads
+
+OBAI always identifies itself:
+
+- Prefix: `[OBAI]` on every message
+- Never impersonates 0102 or any human
+- Never claims authority beyond helper/explainer
+- If quoting or referencing 0102's decisions, explicitly attributes: "Per 0102: ..."
+
+## 6. Thread Participation Rules (from Science Swarm Thread Model)
+
+These rules apply to all agents in Science Swarm threads, including OBAI:
+
+1. Agents must identify themselves clearly — OBAI uses `[OBAI]` prefix
+2. Agents should post structured updates, not noise — OBAI posts only when asked
+3. Agents should link evidence, formulas, code, or GitHub references — OBAI provides links
+4. Agents should challenge weak reasoning directly — OBAI may offer alternative perspectives if asked
+5. If a thread drifts, open a new thread — OBAI may suggest this if asked
+
+## 7. What OBAI Does NOT Do in Threads
+
+| Action | Status |
+|--------|--------|
+| Auto-join threads | NEVER |
+| Post unprompted summaries | NEVER |
+| Delete or archive threads | NEVER (no permission) |
+| Pin messages in threads | NEVER (no permission) |
+| Moderate thread content | NEVER (no permission) |
+| Verify contributions | NEVER (not OBAI's role) |
+| Score work | NEVER (CABR not wired) |
+| Create GitHub issues from thread content | NEVER (read-only for GitHub) |
+
+## 8. Example Interactions
+
+### Example 1: User asks for help in a thread
+```
+User: @OBAI what's the coherence threshold for auto-verification?
+
+[OBAI] The auto-verification threshold is coherence >= 0.618.
+See: CONTRIBUTING.md in science-swarm-hub for details.
+```
+
+### Example 2: User asks OBAI to do something out of scope
+```
+User: @OBAI can you close issue #42?
+
+[OBAI] I can't modify GitHub issues — that requires direct action on GitHub.
+You can close it at: https://github.com/FOUNDUPS/science-swarm-hub/issues/42
+```
+
+### Example 3: User asks OBAI to create a thread
+```
+User: @OBAI can you start a thread about the new rESP method?
+
+[OBAI] Created thread: "rESP Method Discussion"
+Feel free to share your approach here.
+```
+
+### Example 4: Escalation
+```
+User: @OBAI can you give me the swarm-contributor role?
+
+[OBAI] I can't assign roles — that requires operator action.
+Please ask in #swarm-general or contact the server operator.
+```


### PR DESCRIPTION
## Summary
- Worker Z read-first audit of OBAI Discord bot architecture
- **Key recommendation**: Standalone module at `modules/communication/obai_discord_bot/` — NOT inside moltbot_bridge (which is 0102's runtime with 0102 identity baked into config)
- 4 documents: spec, permission boundary, thread participation model, future bridge points

## Documents
1. **OBAI_DISCORD_BOT_SPEC_PHASE1.md** — Architecture decision, allowed channels, interaction patterns, response format, non-claims, 0102 relationship
2. **OBAI_DISCORD_PERMISSION_BOUNDARY.md** — Full bit-level permission model, channel overrides, runtime enforcement rules, token security
3. **OBAI_THREAD_PARTICIPATION_MODEL.md** — Thread behavior matrix, creation rules, response structure, example interactions
4. **OBAI_FUTURE_BRIDGE_POINTS.md** — 6 future integration markers (GitHub linking, escalation, CABR intake, work-units, agent-thread posting, relay)

## Architecture Correction
PR #271 (now merged) placed OBAI at `moltbot_bridge/src/obai_discord_bot.py`. Worker Z's audit corrects this: moltbot_bridge is 0102's runtime (config says "You are 0102", INTERFACE.md describes OpenClawDAE). OBAI needs its own module for identity separation, permission safety, and failure domain isolation.

## Test plan
- [ ] Review architecture recommendation (standalone vs moltbot_bridge)
- [ ] Verify permission integer 311452617792 matches Discord application config
- [ ] Confirm non-claims align with FOUNDUPS_SCIENCE_SWARM_NONCLAIMS.md
- [ ] No code changes — audit docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)