### PR TITLE
feat(pfmall): expand catalog schema for non-video FoundUps

### DIFF
--- a/modules/foundups/ModLog.md
+++ b/modules/foundups/ModLog.md
@@ -2,6 +2,28 @@
 
 ## Chronological Change Log
 
+### 2026-04-07 - pfMALL Catalog Schema Expansion
+
+**By:** 0102 (Worker AG) · **Slice:** `PFMALL_CATALOG_SCHEMA_EXPANSION_PHASE1`
+**WSP References:** WSP 15, WSP 22, WSP 97
+
+**Added**
+- 3 new source_types: `github_repo`, `external_app`, `internal_service`
+- 3 new catalog entries: `science_swarm`, `autopost`, `kosei`
+- Conditional field: `external_url` (required for non-video types)
+- Derived lane fields: `parent_channels`, `derivation_method` (eduit updated)
+- New category: `science`
+- New topic families: `science`, `media`
+- 5 new tests (TestNonVideoFoundUps: 2, TestDerivedLanes: 3)
+- 2 existing validation tests expanded for new types
+
+**Notes**
+- Zero runtime code changes
+- Zero breaking changes
+- Catalog: 9 → 12 lanes, 3 → 6 source_types
+
+---
+
 ### 2026-04-06 - AutoPost external alignment
 
 **By:** 0102 (Worker G) · **Slice:** `AUTOPOST_EXTERNAL_ALIGNMENT_PHASE1`

--- a/modules/foundups/docs/PFMALL_VIDEO_MALL_CATALOG_SCHEMA.md
+++ b/modules/foundups/docs/PFMALL_VIDEO_MALL_CATALOG_SCHEMA.md
@@ -60,7 +60,7 @@ mall-video-catalog.json
   "creator_id": "string",
   "creator_display": "string",
   "entity": "string",
-  "source_type": "youtube_channel | linkedin_profile | x_profile | tiktok_profile | instagram_profile | derived",
+  "source_type": "youtube_channel | linkedin_profile | x_profile | tiktok_profile | instagram_profile | derived | github_repo | external_app | internal_service",
   "source_id": "string | null",
   "source_handle": "string | null",
   "category": "string",
@@ -106,6 +106,9 @@ mall-video-catalog.json
 | `source_type` | enum | YES | Platform type. See Section 4. |
 | `source_id` | string | NO | Platform-specific ID (e.g., YouTube channel ID). |
 | `source_handle` | string | NO | Platform handle (e.g., "@MOVE2JAPAN"). |
+| `external_url` | string | NO | External URL. Present when `source_type` is `external_app`, `github_repo`, or `internal_service`. See Section 4. |
+| `parent_channels` | string[] | NO | Parent lane references. Required when `source_type` is `derived`. See Section 4. |
+| `derivation_method` | string | NO | How content was classified. Required when `source_type` is `derived`. See Section 4. |
 
 #### Classification Fields
 
@@ -156,6 +159,9 @@ These fields enrich the entry page (`foundup.html`) when present. They are optio
 | `tiktok_profile` | TikTok | Account ID |
 | `instagram_profile` | Instagram | Account ID |
 | `derived` | Content classified from a parent channel | Parent channel ID (e.g., `UCfHM9Fw9HD-NwiS0seD_oIA`) |
+| `github_repo` | Repo-backed FoundUp (code/research) | `"org/repo-name"` (e.g., `"FOUNDUPS/science-swarm-hub"`) |
+| `external_app` | Externalized product FoundUp (own deploy) | `"org/repo-name"` (e.g., `"FOUNDUPS/autopost"`) |
+| `internal_service` | Monorepo-internal service FoundUp | Module path (e.g., `"modules/foundups/kosei"`) |
 
 ### Derived Lanes
 
@@ -165,6 +171,31 @@ A `derived` lane has no source channel of its own. Its videos are a topic-classi
 - Videos are copied from the parent lane at catalog build time, not moved
 - The same video may appear in both the parent lane and derived lane(s)
 - Parent lane's `related_lanes` should include the derived lane's `foundup_id`
+
+Required conditional fields for `source_type: "derived"`:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `parent_channels` | string[] | YES | Array of `foundup_id` references whose content feeds this lane. |
+| `derivation_method` | string | YES | How content was classified: `manual_curation`, `topic_tag`, `ai_classification`. |
+
+### Non-Video FoundUps (`github_repo`, `external_app`, `internal_service`)
+
+These source types represent FoundUps whose value is in code, tools, or services rather than media content. They have `videos: []` with `video_count: 0`, which is explicitly valid. LinkedIn profile lanes already prove this pattern works across all pfMALL surfaces.
+
+Conditional field for non-video FoundUps:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `external_url` | string (URL) | YES | URL to external deploy, repository, or planned production domain. |
+
+Resolution rules:
+
+| source_type | `external_url` resolves to |
+|-------------|---------------------------|
+| `github_repo` | GitHub repo URL or project site |
+| `external_app` | Production app URL |
+| `internal_service` | Planned production domain (may not be live yet) |
 
 ---
 
@@ -181,6 +212,7 @@ Current active categories:
 | `thought-leadership` | Articles, essays, long-form |
 | `ai-education` | AI learning, education |
 | `ai-research` | AI research, technical |
+| `science` | Science, research, multi-agent |
 
 Categories are projection axes for Red Dog filtering.
 
@@ -195,6 +227,8 @@ Categories are projection axes for Red Dog filtering.
 | `startup` | Ventures, founders, pAVS | foundups_main, linkedin_foundups |
 | `resistance` | Activism, anti-fascist | antifafm |
 | `ai-education` | AI learning, autonomous education | eduit |
+| `science` | Science, research coordination | science_swarm |
+| `media` | Content automation, tools | autopost, kosei |
 
 Topic families enable cross-category projection (e.g., "show all detector signature content").
 
@@ -355,23 +389,30 @@ Builder tool: `holo_index/skillz/video_catalog_builder/` (planned)
 
 ## 13. Current Catalog Stats
 
-As of 2026-04-05:
+As of 2026-04-07:
 
 | Metric | Value |
 |--------|-------|
-| Total lanes | 9 |
+| Total lanes | 12 |
 | YouTube lanes | 4 |
 | LinkedIn lanes | 4 |
 | Derived lanes | 1 |
+| GitHub repo lanes | 1 |
+| External app lanes | 1 |
+| Internal service lanes | 1 |
 | Total videos | 1,184 (21 shared with undaodu via derived lane) |
+| Source types in use | 6 (youtube_channel, linkedin_profile, derived, github_repo, external_app, internal_service) |
 
 Lane breakdown:
-- move2japan: 573 videos
-- undaodu: 512 videos
-- foundups_main: 44 videos
-- antifafm: 34 videos
+- move2japan: 573 videos (youtube_channel)
+- undaodu: 512 videos (youtube_channel)
+- foundups_main: 44 videos (youtube_channel)
+- antifafm: 34 videos (youtube_channel)
 - eduit: 21 videos (derived from undaodu)
-- linkedin_012: 0 (profile lane)
-- linkedin_esingularity: 0 (profile lane)
-- linkedin_tsingularity: 0 (profile lane)
-- linkedin_foundups: 0 (profile lane)
+- linkedin_012: 0 (linkedin_profile)
+- linkedin_esingularity: 0 (linkedin_profile)
+- linkedin_tsingularity: 0 (linkedin_profile)
+- linkedin_foundups: 0 (linkedin_profile)
+- science_swarm: 0 (github_repo)
+- autopost: 0 (external_app)
+- kosei: 0 (internal_service)

--- a/modules/foundups/pfmall/tests/test_mall_video_catalog.py
+++ b/modules/foundups/pfmall/tests/test_mall_video_catalog.py
@@ -75,7 +75,11 @@ class TestFoundUpEntryShape:
             assert fid == fid.lower().replace(" ", "_"), f"foundup_id should be lowercase snake_case: {fid}"
 
     def test_source_type_values(self, catalog: list[dict]):
-        valid_types = {"youtube_channel", "linkedin_profile", "x_profile", "tiktok_profile", "instagram_profile", "derived"}
+        valid_types = {
+            "youtube_channel", "linkedin_profile", "x_profile",
+            "tiktok_profile", "instagram_profile", "derived",
+            "github_repo", "external_app", "internal_service",
+        }
         for entry in catalog:
             assert entry["source_type"] in valid_types, f"Invalid source_type: {entry['source_type']}"
 
@@ -210,7 +214,10 @@ class TestProjectionMetadata:
 
     def test_topic_family_values(self, catalog: list[dict]):
         """topic_family must be one of defined values."""
-        valid_families = {"life", "consciousness", "startup", "resistance", "ai-education"}
+        valid_families = {
+            "life", "consciousness", "startup", "resistance",
+            "ai-education", "science", "media",
+        }
         for entry in catalog:
             assert entry["topic_family"] in valid_families, (
                 f"Invalid topic_family '{entry['topic_family']}' in {entry['foundup_id']}"
@@ -243,3 +250,68 @@ class TestProjectionMetadata:
             assert "012-lane" in entry["tags"], (
                 f"Missing '012-lane' tag in {entry['foundup_id']}"
             )
+
+
+class TestNonVideoFoundUps:
+    """Test non-video FoundUp types (github_repo, external_app, internal_service)."""
+
+    NON_VIDEO_SOURCE_TYPES = {"github_repo", "external_app", "internal_service"}
+
+    def test_external_url_present_for_non_video_types(self, catalog: list[dict]):
+        """Non-video source types must have external_url."""
+        for entry in catalog:
+            if entry["source_type"] in self.NON_VIDEO_SOURCE_TYPES:
+                assert "external_url" in entry and entry["external_url"], (
+                    f"Missing external_url in {entry['foundup_id']} "
+                    f"(source_type={entry['source_type']})"
+                )
+
+    def test_external_url_is_https(self, catalog: list[dict]):
+        """external_url must be a valid https URL."""
+        for entry in catalog:
+            url = entry.get("external_url")
+            if url:
+                assert url.startswith("https://"), (
+                    f"external_url must be https in {entry['foundup_id']}: {url}"
+                )
+
+
+class TestDerivedLanes:
+    """Test derived lane conditional fields."""
+
+    def test_derived_lanes_have_parent_channels(self, catalog: list[dict]):
+        """Derived lanes must declare parent_channels."""
+        for entry in catalog:
+            if entry["source_type"] == "derived":
+                assert "parent_channels" in entry, (
+                    f"Missing parent_channels in derived lane {entry['foundup_id']}"
+                )
+                assert isinstance(entry["parent_channels"], list), (
+                    f"parent_channels must be a list in {entry['foundup_id']}"
+                )
+                assert len(entry["parent_channels"]) > 0, (
+                    f"parent_channels must not be empty in {entry['foundup_id']}"
+                )
+
+    def test_derived_lanes_have_derivation_method(self, catalog: list[dict]):
+        """Derived lanes must declare derivation_method."""
+        valid_methods = {"manual_curation", "topic_tag", "ai_classification"}
+        for entry in catalog:
+            if entry["source_type"] == "derived":
+                assert "derivation_method" in entry, (
+                    f"Missing derivation_method in derived lane {entry['foundup_id']}"
+                )
+                assert entry["derivation_method"] in valid_methods, (
+                    f"Invalid derivation_method '{entry['derivation_method']}' "
+                    f"in {entry['foundup_id']}"
+                )
+
+    def test_parent_channels_reference_valid_lanes(self, catalog: list[dict]):
+        """parent_channels must reference existing foundup_ids."""
+        all_ids = {entry["foundup_id"] for entry in catalog}
+        for entry in catalog:
+            if entry["source_type"] == "derived" and "parent_channels" in entry:
+                for ref in entry["parent_channels"]:
+                    assert ref in all_ids, (
+                        f"Invalid parent_channel '{ref}' in {entry['foundup_id']}"
+                    )

--- a/public/member/mall-video-catalog.json
+++ b/public/member/mall-video-catalog.json
@@ -11006,6 +11006,122 @@
         "timestamp": "2026-01-12T17:12:16Z",
         "duration_seconds": 54
       }
-    ]
+    ],
+    "parent_channels": [
+      "undaodu"
+    ],
+    "derivation_method": "manual_curation"
+  },
+  {
+    "foundup_id": "science_swarm",
+    "title": "Science Swarm Hub",
+    "creator": "012",
+    "creator_id": "012",
+    "creator_display": "012",
+    "entity": "Science Swarm Hub",
+    "source_type": "github_repo",
+    "source_id": "FOUNDUPS/science-swarm-hub",
+    "source_handle": "science-swarm-hub",
+    "external_url": "https://github.com/FOUNDUPS/science-swarm-hub",
+    "category": "science",
+    "tags": [
+      "012-lane",
+      "multi-agent",
+      "pqn",
+      "research",
+      "science",
+      "swarm"
+    ],
+    "topic_family": "science",
+    "geo": "Global",
+    "status": "active",
+    "display_order": 10,
+    "related_lanes": [
+      "foundups_main",
+      "linkedin_esingularity"
+    ],
+    "tagline": "Multi-agent research coordination",
+    "description": "Science Swarm Hub — multi-agent research coordination platform for PQN alignment and scientific inquiry.",
+    "tier": "F0_DAE",
+    "lifecycle_stage": "externalized",
+    "launch_readiness": "discoverable_only",
+    "poster_url": "/media/posters/science_swarm.jpg",
+    "video_count": 0,
+    "videos": []
+  },
+  {
+    "foundup_id": "autopost",
+    "title": "AutoPost",
+    "creator": "012",
+    "creator_id": "012",
+    "creator_display": "012",
+    "entity": "AutoPost",
+    "source_type": "external_app",
+    "source_id": "FOUNDUPS/autopost",
+    "source_handle": "autopost",
+    "external_url": "https://autopost.foundups.com",
+    "category": "media",
+    "tags": [
+      "012-lane",
+      "ai",
+      "automation",
+      "camera-to-post",
+      "content",
+      "media",
+      "social"
+    ],
+    "topic_family": "media",
+    "geo": "Global",
+    "status": "active",
+    "display_order": 11,
+    "related_lanes": [
+      "foundups_main"
+    ],
+    "tagline": "Camera-to-post AI content engine",
+    "description": "AutoPost — AI-powered camera-to-post content engine. Externalized product FoundUp with own repo and domain.",
+    "tier": "F0_DAE",
+    "lifecycle_stage": "externalized",
+    "launch_readiness": "discoverable_only",
+    "poster_url": "/media/posters/autopost.jpg",
+    "video_count": 0,
+    "videos": []
+  },
+  {
+    "foundup_id": "kosei",
+    "title": "Kosei AI Systems",
+    "creator": "012",
+    "creator_id": "012",
+    "creator_display": "012",
+    "entity": "Kosei AI Systems",
+    "source_type": "internal_service",
+    "source_id": "modules/foundups/kosei",
+    "source_handle": "kosei",
+    "external_url": "https://kosei.ai",
+    "category": "media",
+    "tags": [
+      "012-lane",
+      "ai",
+      "automation",
+      "b2b",
+      "content",
+      "kosei",
+      "service"
+    ],
+    "topic_family": "media",
+    "geo": "Global",
+    "status": "active",
+    "display_order": 12,
+    "related_lanes": [
+      "foundups_main",
+      "autopost"
+    ],
+    "tagline": "AI content automation for businesses",
+    "description": "Kosei AI Systems — AI content automation service for businesses. Internal service FoundUp with planned production domain.",
+    "tier": "F0_DAE",
+    "lifecycle_stage": "incubating",
+    "launch_readiness": "discoverable_only",
+    "poster_url": "/media/posters/kosei.jpg",
+    "video_count": 0,
+    "videos": []
   }
 ]


### PR DESCRIPTION
## Summary
- Add 3 new `source_type` values: `github_repo`, `external_app`, `internal_service` — enabling non-video FoundUps in the pfMALL catalog
- Add 3 new catalog entries: Science Swarm Hub (`github_repo`), AutoPost (`external_app`), Kosei AI Systems (`internal_service`)
- Add `external_url` conditional field for non-video source types, `parent_channels` + `derivation_method` for derived lanes
- Add `science` category, `science` and `media` topic families
- Update EDUIT derived lane with `parent_channels: ["undaodu"]` and `derivation_method: "manual_curation"`
- 5 new tests + 2 expanded validations = 30 total passing

## What changed

| File | Change |
|------|--------|
| `modules/foundups/ModLog.md` | WSP 22 entry for Worker AG slice |
| `PFMALL_VIDEO_MALL_CATALOG_SCHEMA.md` | Schema: 3 source_types, external_url field, derived fields, science category, topic families, updated stats |
| `test_mall_video_catalog.py` | Tests: expanded source_type/topic_family sets, +TestNonVideoFoundUps (2 tests), +TestDerivedLanes (3 tests) |
| `mall-video-catalog.json` | Data: 3 new entries (science_swarm, autopost, kosei), EDUIT gains parent_channels/derivation_method |

## Non-goals
- No runtime JS changes (zero-video fallbacks already proven by LinkedIn lanes)
- No UI changes (entry page "Open App" / "View Repo" buttons are future slice)
- No poster assets (placeholder paths; asset creation is separate task)

## Test plan
- [x] `pytest modules/foundups/pfmall/tests/test_mall_video_catalog.py -v` — 30/30 pass
- [ ] Visual: verify 12 tiles render in Mall (3 new tiles show "0 videos" gracefully)
- [ ] Verify existing 9 lanes unchanged (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)