### PR TITLE
fix(fam): remove stale help test assertion blocking CI

### DIFF
--- a/modules/foundups/agent_market/tests/test_e2e_integration.py
+++ b/modules/foundups/agent_market/tests/test_e2e_integration.py
@@ -384,7 +384,6 @@ class TestE2EOpenClawIntegration:
         response = handle_fam_intent("what is fam?", "user_1")
 
         assert "launch foundup" in response.lower()
-        assert "create foundup" in response.lower()
 
     def test_fam_adapter_auto_symbol_when_missing_token(self):
         """Launch parser should auto-generate token symbol when none is supplied."""


### PR DESCRIPTION
## Summary
- Remove `assert "create foundup" in response.lower()` — the help text was updated to pAVS terminology with `launch foundup` as the canonical command
- This assertion has been failing on every PR since the pAVS migration

## Test plan
- [x] `test_fam_adapter_handle_intent_help` passes locally
- [ ] CI `test (3.12)` goes green

1 file, 1 line deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)