### PR TITLE
feat(pfmall): inline preview with audio controls (AR slice)

### DIFF
--- a/public/member/ModLog.md
+++ b/public/member/ModLog.md
@@ -1,5 +1,25 @@
 # Member Area Module Change Log
 
+## [2026-04-09] Inline Preview Audio & Controls Polish Phase 2 (Worker AR, WSP 97)
+
+**Who**: 0102 — Worker AR
+**Slice**: `PFMALL_INLINE_PREVIEW_AUDIO_AND_CONTROLS_POLISH_PHASE2`
+**What**: Inline grid preview for video-backed tiles. Tap plays video inside the tile (not fullscreen). Audio button with 4 CSS states. Expand button routes to fullscreen player.
+
+**Files Modified**:
+- `public/member/js/mall-tile-field.js` — `startInlinePreview()`, `stopInlinePreview()`, `pauseInlinePreview()`, `resumeInlinePreview()`, `togglePreviewMute()`, `applyTilePreviewState()`, `ensureYouTubeAPI()`, `extractYouTubeVideoId()`, session-guarded callbacks via `previewGeneration`
+- `public/member/css/mall-tile-field.css` — `.mall-tile-preview`, `.mall-tile-audio` (4 states: `.is-active`, `:not(.is-muted)`, `.is-muted`, `.is-paused`), `.is-previewing`, touch override `(hover: none)`
+- `public/member/tests/test_video_mall_field_runtime.py` — 6 new AR test classes replacing `TestTapPlayPause`
+
+**Key Decisions**:
+- Media fields use canonical `embed_url` / `source_url` (matching `PFMALL_VIDEO_MALL_CATALOG_SCHEMA.md` and `mall-video-player.js`)
+- Audio button `aria-label` and `title` update per mute state ("Unmute preview" / "Mute preview")
+- Old `TestTapPlayPause` removed (was asserting stale fullscreen-on-tap behavior)
+
+**Test Count**: 118 passed (was 82 pre-AR)
+
+---
+
 ## [2026-04-08] Expanded Video Field Animation Phase 1 (Worker AK, WSP 97)
 
 **Who**: 0102 — Worker AK

--- a/public/member/css/mall-tile-field.css
+++ b/public/member/css/mall-tile-field.css
@@ -507,6 +507,11 @@
   .mall-tile-audio {
     opacity: 1;
   }
+
+  /* Video-backed tiles need control padding when controls are always visible */
+  .mall-tile:has(.mall-tile-audio) .mall-tile-inner {
+    padding-top: 2.4rem;
+  }
 }
 
 /* ─── Expand Button (Fullscreen Entry on Tile) ─── */

--- a/public/member/css/mall-tile-field.css
+++ b/public/member/css/mall-tile-field.css
@@ -86,6 +86,49 @@
   -webkit-overflow-scrolling: touch;
   /* Smooth deceleration for phone-native feel */
   scroll-padding: 0;
+  /* Desktop drag affordance */
+  cursor: grab;
+  /* Touch gesture clarity */
+  touch-action: pan-x pan-y;
+  /* For scroll shadow pseudo-elements */
+  position: relative;
+}
+
+/* Active drag state */
+.mall-tile-field-wrapper.is-dragging {
+  cursor: grabbing;
+  scroll-snap-type: none;
+  scroll-behavior: auto;
+  user-select: none;
+}
+
+/* Scroll edge shadows for spatial awareness */
+.mall-tile-field-wrapper::before,
+.mall-tile-field-wrapper::after {
+  content: '';
+  position: sticky;
+  left: 0;
+  right: 0;
+  height: 24px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 150ms ease-out;
+  z-index: 10;
+}
+
+.mall-tile-field-wrapper::before {
+  top: 0;
+  background: linear-gradient(to bottom, rgba(0,0,0,0.15), transparent);
+}
+
+.mall-tile-field-wrapper::after {
+  bottom: 0;
+  background: linear-gradient(to top, rgba(0,0,0,0.15), transparent);
+}
+
+.mall-tile-field-wrapper.can-scroll-up::before,
+.mall-tile-field-wrapper.can-scroll-down::after {
+  opacity: 1;
 }
 
 /* Glide mode: remove snap for fluid scrolling */
@@ -331,6 +374,141 @@
   margin-left: 0;
 }
 
+/* ========== Inline Preview Layer ========== */
+
+.mall-tile-preview {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transition: opacity 120ms ease-out;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.mall-tile-preview::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, rgba(0,0,0,0.15) 0%, transparent 30%, transparent 70%, rgba(0,0,0,0.25) 100%);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.mall-tile-preview-stage {
+  width: 100%;
+  height: 100%;
+}
+
+.mall-tile-preview-host,
+.mall-tile-preview-media,
+.mall-tile-preview-stage iframe,
+.mall-tile-preview-stage video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border: none;
+}
+
+/* Active preview: show the preview layer */
+.mall-tile.is-previewing .mall-tile-preview {
+  opacity: 1;
+}
+
+/* Hide play indicator during active preview */
+.mall-tile.is-previewing .mall-tile-play-indicator {
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(0.8);
+}
+
+/* Paused preview: show pause bars in play indicator */
+.mall-tile.is-previewing.is-paused .mall-tile-play-indicator {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.mall-tile.is-previewing.is-paused .mall-tile-play-indicator::before {
+  /* Pause bars */
+  border: none;
+  width: 0.6rem;
+  height: 0.9rem;
+  background: linear-gradient(to right, #fff 35%, transparent 35%, transparent 65%, #fff 65%);
+  margin-left: 0;
+}
+
+/* Paused preview dims the preview layer slightly */
+.mall-tile.is-paused .mall-tile-preview {
+  opacity: 0.75;
+}
+
+/* Video-control tiles get extra top padding for controls */
+.mall-tile.has-video-controls .mall-tile-inner {
+  padding-top: 2.4rem;
+}
+
+/* ========== Audio Button (Inline Preview Mute Toggle) ========== */
+
+.mall-tile-audio {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  width: 32px;
+  height: 32px;
+  background: rgba(0, 0, 0, 0.6);
+  border: none;
+  border-radius: 6px;
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 150ms ease, background 150ms ease;
+  z-index: 10;
+}
+
+.mall-tile-audio svg,
+.mall-tile-expand svg {
+  width: 18px;
+  height: 18px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* Audio button state: active (preview is playing for this tile) */
+.mall-tile-audio.is-active {
+  background: rgba(66, 160, 255, 0.45);
+}
+
+/* Audio button state: active and unmuted (sound is on) */
+.mall-tile-audio.is-active:not(.is-muted) {
+  background: rgba(66, 160, 255, 0.55);
+  color: #fff;
+}
+
+/* Audio button state: active and muted (sound is off) */
+.mall-tile-audio.is-active.is-muted {
+  background: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.55);
+}
+
+/* Audio button state: paused preview */
+.mall-tile.is-paused .mall-tile-audio.is-active {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* Touch devices: always show controls (no hover) */
+@media (hover: none) {
+  .mall-tile-expand,
+  .mall-tile-audio {
+    opacity: 1;
+  }
+}
+
 /* ─── Expand Button (Fullscreen Entry on Tile) ─── */
 .mall-tile-expand {
   position: absolute;
@@ -353,7 +531,14 @@
 }
 
 .mall-tile:hover .mall-tile-expand,
-.mall-tile:focus-within .mall-tile-expand {
+.mall-tile:focus-within .mall-tile-expand,
+.mall-tile.is-previewing .mall-tile-expand {
+  opacity: 1;
+}
+
+.mall-tile:hover .mall-tile-audio,
+.mall-tile:focus-within .mall-tile-audio,
+.mall-tile.is-previewing .mall-tile-audio {
   opacity: 1;
 }
 

--- a/public/member/js/mall-tile-field.js
+++ b/public/member/js/mall-tile-field.js
@@ -59,6 +59,217 @@
   var expandSourceVisual = null; // { bgImage, bgColor } for collapse continuity
   var playingIndex = null; // Index of currently playing tile
 
+  // Inline preview state
+  var previewPaused = false;       // Whether current preview is paused
+  var previewMuted = true;         // Whether current preview audio is muted
+  var inlineYTPlayer = null;       // YouTube IFrame API player instance
+  var inlineHTML5Video = null;     // HTML5 <video> element reference
+  var ytAPIReady = false;          // Whether YouTube IFrame API is loaded
+  var ytAPILoading = false;        // Prevent duplicate script injection
+  var previewGeneration = 0;       // Guard against stale callbacks
+  var tapGuardActive = false;      // Prevent double-fire on audio button tap
+
+  // ========== YouTube IFrame API Helpers ==========
+
+  function ensureYouTubeAPI() {
+    if (ytAPIReady) return Promise.resolve();
+    if (ytAPILoading) {
+      return new Promise(function(resolve) {
+        var check = setInterval(function() {
+          if (ytAPIReady) { clearInterval(check); resolve(); }
+        }, 100);
+      });
+    }
+    ytAPILoading = true;
+    return new Promise(function(resolve) {
+      var prev = window.onYouTubeIframeAPIReady;
+      window.onYouTubeIframeAPIReady = function() {
+        ytAPIReady = true;
+        ytAPILoading = false;
+        if (prev) prev();
+        resolve();
+      };
+      var tag = document.createElement('script');
+      tag.src = 'https://www.youtube.com/iframe_api';
+      document.head.appendChild(tag);
+    });
+  }
+
+  function extractYouTubeVideoId(url) {
+    if (!url) return null;
+    var m = url.match(/(?:youtu\.be\/|youtube\.com\/(?:watch\?.*v=|embed\/|v\/))([A-Za-z0-9_-]{11})/);
+    return m ? m[1] : null;
+  }
+
+  function destroyInlineYTPlayer() {
+    if (inlineYTPlayer) {
+      try { inlineYTPlayer.destroy(); } catch (e) { /* ignore */ }
+      inlineYTPlayer = null;
+    }
+  }
+
+  function getTilePreviewVideo(index) {
+    var items = expandedFoundUp !== null ? getExpandedVideos() : mallCatalog;
+    var item = items[index];
+    if (!item) return null;
+    return item.video_data || (item.videos && item.videos[0]) || null;
+  }
+
+  // ========== Inline Preview Runtime ==========
+
+  function applyTilePreviewState(index, state) {
+    if (!tileField) return;
+    var allTiles = tileField.querySelectorAll('.mall-tile');
+    allTiles.forEach(function(t) {
+      t.classList.remove('is-previewing', 'is-paused', 'has-video-controls');
+      var btn = t.querySelector('.mall-tile-audio');
+      if (btn) btn.classList.remove('is-active', 'is-muted');
+    });
+    if (index === null || index === undefined || !state) return;
+    var tile = allTiles[index];
+    if (!tile) return;
+    if (state.previewing) {
+      tile.classList.add('is-previewing', 'has-video-controls');
+      if (state.paused) tile.classList.add('is-paused');
+    }
+    var audioBtn = tile.querySelector('.mall-tile-audio');
+    if (audioBtn && state.previewing) {
+      audioBtn.classList.add('is-active');
+      if (state.muted) audioBtn.classList.add('is-muted');
+      // Update SVG icon
+      if (state.muted) {
+        audioBtn.innerHTML = '<svg viewBox="0 0 24 24"><path d="M11 5L6 9H2v6h4l5 4V5z"/><line x1="23" y1="9" x2="17" y2="15"/><line x1="17" y1="9" x2="23" y2="15"/></svg>';
+      } else {
+        audioBtn.innerHTML = '<svg viewBox="0 0 24 24"><path d="M11 5L6 9H2v6h4l5 4V5z"/><path d="M19.07 4.93a10 10 0 010 14.14"/><path d="M15.54 8.46a5 5 0 010 7.07"/></svg>';
+      }
+    }
+  }
+
+  function stopInlinePreview() {
+    if (playingIndex === null) return;
+    destroyInlineYTPlayer();
+    if (inlineHTML5Video) {
+      inlineHTML5Video.pause();
+      inlineHTML5Video.src = '';
+      inlineHTML5Video = null;
+    }
+    var tile = getTileElement(playingIndex);
+    if (tile) {
+      var stage = tile.querySelector('.mall-tile-preview-stage');
+      if (stage) stage.innerHTML = '';
+    }
+    applyTilePreviewState(null, null);
+    playingIndex = null;
+    previewPaused = false;
+  }
+
+  function pauseInlinePreview() {
+    if (playingIndex === null) return;
+    if (inlineYTPlayer && typeof inlineYTPlayer.pauseVideo === 'function') {
+      inlineYTPlayer.pauseVideo();
+    }
+    if (inlineHTML5Video) inlineHTML5Video.pause();
+    previewPaused = true;
+    applyTilePreviewState(playingIndex, { previewing: true, paused: true, muted: previewMuted });
+  }
+
+  function resumeInlinePreview() {
+    if (playingIndex === null) return;
+    if (inlineYTPlayer && typeof inlineYTPlayer.playVideo === 'function') {
+      inlineYTPlayer.playVideo();
+    }
+    if (inlineHTML5Video) inlineHTML5Video.play();
+    previewPaused = false;
+    applyTilePreviewState(playingIndex, { previewing: true, paused: false, muted: previewMuted });
+  }
+
+  function startInlinePreview(index, muted) {
+    if (playingIndex !== null && playingIndex !== index) {
+      stopInlinePreview();
+    } else {
+      stopInlinePreview();
+    }
+    var videoData = getTilePreviewVideo(index);
+    if (!videoData) return;
+
+    var videoUrl = videoData.url || videoData.video_url || '';
+    var ytId = extractYouTubeVideoId(videoUrl);
+    var tile = getTileElement(index);
+    if (!tile) return;
+    var stage = tile.querySelector('.mall-tile-preview-stage');
+    if (!stage) return;
+
+    playingIndex = index;
+    previewPaused = false;
+    previewMuted = muted !== false;
+    previewGeneration++;
+    var gen = previewGeneration;
+
+    applyTilePreviewState(index, { previewing: true, paused: false, muted: previewMuted });
+
+    if (ytId) {
+      ensureYouTubeAPI().then(function() {
+        if (gen !== previewGeneration) return;
+        var hostDiv = document.createElement('div');
+        hostDiv.className = 'mall-tile-preview-host';
+        hostDiv.id = 'yt-preview-' + index + '-' + gen;
+        stage.innerHTML = '';
+        stage.appendChild(hostDiv);
+        inlineYTPlayer = new YT.Player(hostDiv.id, {
+          videoId: ytId,
+          playerVars: {
+            autoplay: 1, mute: 1, controls: 0, modestbranding: 1,
+            rel: 0, playsinline: 1, loop: 1, playlist: ytId
+          },
+          events: {
+            onReady: function(event) {
+              if (gen !== previewGeneration) return;
+              if (previewMuted) event.target.mute();
+              else event.target.unMute();
+              event.target.playVideo();
+            }
+          }
+        });
+      });
+    } else if (videoUrl) {
+      var video = document.createElement('video');
+      video.className = 'mall-tile-preview-media';
+      video.src = videoUrl;
+      video.muted = previewMuted;
+      video.autoplay = true;
+      video.loop = true;
+      video.playsInline = true;
+      video.setAttribute('playsinline', '');
+      stage.innerHTML = '';
+      stage.appendChild(video);
+      inlineHTML5Video = video;
+      video.play().catch(function() { /* autoplay may be blocked */ });
+    }
+  }
+
+  function togglePreviewMute() {
+    if (playingIndex === null) return;
+    previewMuted = !previewMuted;
+    if (inlineYTPlayer) {
+      if (previewMuted) { if (typeof inlineYTPlayer.mute === 'function') inlineYTPlayer.mute(); }
+      else { if (typeof inlineYTPlayer.unMute === 'function') inlineYTPlayer.unMute(); }
+    }
+    if (inlineHTML5Video) inlineHTML5Video.muted = previewMuted;
+
+    var tile = getTileElement(playingIndex);
+    if (tile) {
+      var audioBtn = tile.querySelector('.mall-tile-audio');
+      if (audioBtn) {
+        if (previewMuted) {
+          audioBtn.innerHTML = '<svg viewBox="0 0 24 24"><path d="M11 5L6 9H2v6h4l5 4V5z"/><line x1="23" y1="9" x2="17" y2="15"/><line x1="17" y1="9" x2="23" y2="15"/></svg>';
+        } else {
+          audioBtn.innerHTML = '<svg viewBox="0 0 24 24"><path d="M11 5L6 9H2v6h4l5 4V5z"/><path d="M19.07 4.93a10 10 0 010 14.14"/><path d="M15.54 8.46a5 5 0 010 7.07"/></svg>';
+        }
+      }
+    }
+    applyTilePreviewState(playingIndex, { previewing: true, paused: previewPaused, muted: previewMuted });
+  }
+
   /**
    * Initialize tile field with catalog data
    * @param {Array} catalog - Array of FoundUp objects (with video data)
@@ -138,10 +349,19 @@
       var hasVideos = (item.videos && item.videos.length) || item.video_count;
       var expandBtn = hasVideos ? '<button class="mall-tile-expand" aria-label="Open fullscreen" title="Fullscreen">&#9654;</button>' : '';
 
+      // Inline preview container (YouTube iframe or HTML5 video goes here)
+      var previewContainer = hasVideos ? '<div class="mall-tile-preview"><div class="mall-tile-preview-stage"></div></div>' : '';
+
+      // Speaker button for mute/unmute (top-left, video-backed only)
+      var speakerSvg = '<svg viewBox="0 0 24 24"><path d="M11 5L6 9H2v6h4l5 4V5z"/><line x1="23" y1="9" x2="17" y2="15"/><line x1="17" y1="9" x2="23" y2="15"/></svg>';
+      var audioBtn = hasVideos ? '<button class="mall-tile-audio" aria-label="Toggle audio" title="Toggle audio">' + speakerSvg + '</button>' : '';
+
       return '<article class="mall-tile theme-' + theme + '" data-index="' + index + '" data-foundup-id="' + escapeAttr(item.foundup_id || item.id || '') + '" tabindex="0" aria-label="' + escapeAttr(item.name || item.title || '') + '" style="' + posterStyle + '">' +
+        previewContainer +
         '<span class="mall-tile-badge ' + badgeClass + '">' + escapeHtml(readiness.replace('_', ' ')) + '</span>' +
         queueBadge +
         playIndicator +
+        audioBtn +
         expandBtn +
         '<div class="mall-tile-inner">' +
           '<span class="mall-tile-token">' + escapeHtml(item.token_symbol || '') + '</span>' +
@@ -248,11 +468,31 @@
       });
     });
 
-    // Global escape handler - collapse expanded view
+    // Audio buttons — toggle mute or start muted preview
+    var audioBtns = tileField.querySelectorAll('.mall-tile-audio');
+    audioBtns.forEach(function(btn) {
+      btn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        if (tapGuardActive) return;
+        var tile = btn.closest('.mall-tile');
+        if (!tile) return;
+        var index = Number(tile.dataset.index || 0);
+        if (playingIndex === index) {
+          togglePreviewMute();
+        } else {
+          startInlinePreview(index, true);
+        }
+      });
+    });
+
+    // Global escape handler - collapse expanded view or stop preview
     document.addEventListener('keydown', function(e) {
       if (e.key === 'Escape' && expandedFoundUp !== null) {
         e.stopPropagation();
         collapseFoundUp();
+      } else if (e.key === 'Escape' && playingIndex !== null) {
+        e.stopPropagation();
+        stopInlinePreview();
       }
     });
   }
@@ -273,8 +513,13 @@
       targetTile.classList.add('tap-pulse');
     }
 
-    // Open fullscreen player with real playback
-    openFullscreenFromTile(index);
+    // Inline preview: tap same tile = pause/resume, tap different = start new
+    if (playingIndex === index) {
+      if (previewPaused) resumeInlinePreview();
+      else pauseInlinePreview();
+      return;
+    }
+    startInlinePreview(index, false);
   }
 
   /**
@@ -285,6 +530,8 @@
    */
   function openFullscreenFromTile(index) {
     if (!window.mallVideoPlayer) return;
+
+    stopInlinePreview();
 
     if (expandedFoundUp !== null) {
       // Expanded mode: tiles are individual videos from one FoundUp
@@ -361,6 +608,7 @@
    */
   function expandFoundUp(index) {
     if (expandedFoundUp === index) return; // Already expanded
+    stopInlinePreview();
 
     var item = mallCatalog[index];
     if (!item || !item.videos || !item.videos.length) {
@@ -438,6 +686,7 @@
    */
   function collapseFoundUp() {
     if (expandedFoundUp === null) return;
+    stopInlinePreview();
 
     // Hide collapse hint first
     if (collapseHint) {
@@ -691,6 +940,7 @@
    * @param {string} projection - Projection name: default, alpha, readiness, category
    */
   function setProjection(projection) {
+    stopInlinePreview();
     if (!['default', 'alpha', 'readiness', 'category'].includes(projection)) {
       projection = 'default';
     }
@@ -889,6 +1139,7 @@
    */
   function clearFieldScope() {
     if (currentFieldScope === null) return;
+    stopInlinePreview();
     currentFieldScope = null;
     mallCatalog = fullCatalog.slice();
     originalOrder = mallCatalog.slice();
@@ -919,6 +1170,13 @@
     collapseFoundUp: collapseFoundUp,
     isExpanded: isExpanded,
     getExpandedIndex: getExpandedIndex,
+
+    // Inline preview
+    startInlinePreview: startInlinePreview,
+    stopInlinePreview: stopInlinePreview,
+    pauseInlinePreview: pauseInlinePreview,
+    resumeInlinePreview: resumeInlinePreview,
+    togglePreviewMute: togglePreviewMute,
 
     // Motion mode
     setMotionMode: setMotionMode,

--- a/public/member/js/mall-tile-field.js
+++ b/public/member/js/mall-tile-field.js
@@ -358,7 +358,7 @@
 
       // Speaker button for mute/unmute (top-left, video-backed only)
       var speakerSvg = '<svg viewBox="0 0 24 24"><path d="M11 5L6 9H2v6h4l5 4V5z"/><line x1="23" y1="9" x2="17" y2="15"/><line x1="17" y1="9" x2="23" y2="15"/></svg>';
-      var audioBtn = hasVideos ? '<button class="mall-tile-audio" aria-label="Toggle audio" title="Toggle audio">' + speakerSvg + '</button>' : '';
+      var audioBtn = hasVideos ? '<button class="mall-tile-audio" aria-label="Start muted preview" title="Start muted preview">' + speakerSvg + '</button>' : '';
 
       return '<article class="mall-tile theme-' + theme + '" data-index="' + index + '" data-foundup-id="' + escapeAttr(item.foundup_id || item.id || '') + '" tabindex="0" aria-label="' + escapeAttr(item.name || item.title || '') + '" style="' + posterStyle + '">' +
         previewContainer +

--- a/public/member/js/mall-tile-field.js
+++ b/public/member/js/mall-tile-field.js
@@ -136,11 +136,15 @@
     if (audioBtn && state.previewing) {
       audioBtn.classList.add('is-active');
       if (state.muted) audioBtn.classList.add('is-muted');
-      // Update SVG icon
+      // Update SVG icon and accessibility text
       if (state.muted) {
         audioBtn.innerHTML = '<svg viewBox="0 0 24 24"><path d="M11 5L6 9H2v6h4l5 4V5z"/><line x1="23" y1="9" x2="17" y2="15"/><line x1="17" y1="9" x2="23" y2="15"/></svg>';
+        audioBtn.setAttribute('aria-label', 'Unmute preview');
+        audioBtn.title = 'Unmute preview';
       } else {
         audioBtn.innerHTML = '<svg viewBox="0 0 24 24"><path d="M11 5L6 9H2v6h4l5 4V5z"/><path d="M19.07 4.93a10 10 0 010 14.14"/><path d="M15.54 8.46a5 5 0 010 7.07"/></svg>';
+        audioBtn.setAttribute('aria-label', 'Mute preview');
+        audioBtn.title = 'Mute preview';
       }
     }
   }
@@ -192,7 +196,7 @@
     var videoData = getTilePreviewVideo(index);
     if (!videoData) return;
 
-    var videoUrl = videoData.url || videoData.video_url || '';
+    var videoUrl = videoData.embed_url || videoData.embedUrl || videoData.source_url || videoData.sourceUrl || '';
     var ytId = extractYouTubeVideoId(videoUrl);
     var tile = getTileElement(index);
     if (!tile) return;

--- a/public/member/tests/TestModLog.md
+++ b/public/member/tests/TestModLog.md
@@ -4,6 +4,26 @@ Test evolution log for the p.fMALL member shell test suite.
 
 ---
 
+## 2026-04-09 | Inline Preview AR Tests (WSP 97)
+
+**File**: `test_video_mall_field_runtime.py` (extended)
+**Tests**: +40 new, -4 removed | **Result**: 118 passed total
+**Worker**: AR
+
+Removed `TestTapPlayPause` (4 tests — asserted stale fullscreen-on-tap behavior).
+Added 6 AR test classes:
+
+| Class | Tests | Covers |
+|-------|-------|--------|
+| TestTapInlinePreviewAR | 12 | Preview lifecycle, generation guard, YouTube/HTML5 paths |
+| TestPreviewControlsAR | 7 | Audio/expand buttons, public API exposure |
+| TestInlinePreviewAudioStatesAR | 8 | 4 CSS states, SVG paths, innerHTML swap |
+| TestPausedPreviewIndicatorAR | 4 | Paused state visibility, touch override |
+| TestMediaFieldMappingAR | 5 | `embed_url`/`source_url` canonical fields, priority order |
+| TestAudioButtonAccessibilityAR | 4 | `aria-label`/`title` update per mute state |
+
+---
+
 ## 2026-04-08 | Expanded Video Field Animation Tests (WSP 97)
 
 **File**: `test_video_mall_field_runtime.py` (extended)

--- a/public/member/tests/test_video_mall_field_runtime.py
+++ b/public/member/tests/test_video_mall_field_runtime.py
@@ -578,7 +578,7 @@ class TestPreviewControlsAR:
         """Audio button rendered with mall-tile-audio class."""
         js = _read("js/mall-tile-field.js")
         assert "mall-tile-audio" in js
-        assert "Toggle audio" in js
+        assert "Start muted preview" in js
 
     def test_audio_button_css(self):
         """Audio button CSS exists."""
@@ -745,3 +745,47 @@ class TestAudioButtonAccessibilityAR:
         """title property updated alongside aria-label."""
         js = _read("js/mall-tile-field.js")
         assert "audioBtn.title = " in js
+
+    def test_initial_label_matches_inactive_action(self):
+        """Inactive audio button says 'Start muted preview', not 'Toggle audio'."""
+        js = _read("js/mall-tile-field.js")
+        assert 'aria-label="Start muted preview"' in js
+        assert 'title="Start muted preview"' in js
+        assert 'aria-label="Toggle audio"' not in js
+
+    def test_three_label_states(self):
+        """Three distinct label states: initial, muted-active, unmuted-active."""
+        js = _read("js/mall-tile-field.js")
+        assert "Start muted preview" in js
+        assert "Unmute preview" in js
+        assert "Mute preview" in js
+
+
+class TestTouchModePaddingAR:
+    """Test touch-mode video tiles get control padding even when inactive."""
+
+    def test_touch_has_selector_padding(self):
+        """Touch media query adds padding for tiles with audio button via :has()."""
+        css = _read("css/mall-tile-field.css")
+        assert ".mall-tile:has(.mall-tile-audio) .mall-tile-inner" in css
+
+    def test_touch_padding_inside_hover_none(self):
+        """The :has() padding rule is inside the (hover: none) media query."""
+        css = _read("css/mall-tile-field.css")
+        # Find the hover:none block and confirm it contains the :has rule
+        in_hover_none = False
+        found = False
+        for line in css.splitlines():
+            if "hover: none" in line:
+                in_hover_none = True
+            if in_hover_none and ".mall-tile:has(.mall-tile-audio)" in line:
+                found = True
+                break
+        assert found, ":has(.mall-tile-audio) padding must be inside @media (hover: none)"
+
+    def test_touch_padding_value(self):
+        """Touch padding matches the has-video-controls padding (2.4rem)."""
+        css = _read("css/mall-tile-field.css")
+        # Both rules should use 2.4rem
+        lines_with_padding = [l for l in css.splitlines() if "padding-top: 2.4rem" in l]
+        assert len(lines_with_padding) >= 2, "Expected 2.4rem padding in both .has-video-controls and :has(.mall-tile-audio) rules"

--- a/public/member/tests/test_video_mall_field_runtime.py
+++ b/public/member/tests/test_video_mall_field_runtime.py
@@ -524,3 +524,187 @@ class TestSearchMallProjection:
         js = _read("js/mall-tile-field.js")
         assert "options.type" in js
         assert "scope.query" in js
+
+
+class TestTapInlinePreviewAR:
+    """Test tap = inline preview play/pause behavior (AR slice)."""
+
+    def test_start_inline_preview_function(self):
+        """startInlinePreview function exists for inline playback."""
+        js = _read("js/mall-tile-field.js")
+        assert "function startInlinePreview" in js
+
+    def test_pause_inline_preview_function(self):
+        """pauseInlinePreview function exists."""
+        js = _read("js/mall-tile-field.js")
+        assert "function pauseInlinePreview" in js
+
+    def test_resume_inline_preview_function(self):
+        """resumeInlinePreview function exists."""
+        js = _read("js/mall-tile-field.js")
+        assert "function resumeInlinePreview" in js
+
+    def test_stop_inline_preview_function(self):
+        """stopInlinePreview function exists."""
+        js = _read("js/mall-tile-field.js")
+        assert "function stopInlinePreview" in js
+
+    def test_one_active_preview_rule(self):
+        """Starting a new preview stops the previous one."""
+        js = _read("js/mall-tile-field.js")
+        assert "playingIndex !== null && playingIndex !== index" in js
+        assert "stopInlinePreview()" in js
+
+    def test_toggle_play_starts_inline(self):
+        """togglePlay calls startInlinePreview for new tile."""
+        js = _read("js/mall-tile-field.js")
+        assert "startInlinePreview(index, false)" in js
+
+    def test_toggle_play_pauses_active(self):
+        """togglePlay pauses active inline preview."""
+        js = _read("js/mall-tile-field.js")
+        assert "pauseInlinePreview()" in js
+        assert "previewPaused" in js
+
+    def test_toggle_play_resumes_paused(self):
+        """togglePlay resumes a paused inline preview."""
+        js = _read("js/mall-tile-field.js")
+        assert "resumeInlinePreview()" in js
+
+    def test_preview_generation_guard(self):
+        """previewGeneration prevents stale async callbacks."""
+        js = _read("js/mall-tile-field.js")
+        assert "previewGeneration" in js
+        assert "gen !== previewGeneration" in js
+
+    def test_youtube_api_loader(self):
+        """ensureYouTubeAPI function lazy-loads IFrame API."""
+        js = _read("js/mall-tile-field.js")
+        assert "function ensureYouTubeAPI" in js
+        assert "iframe_api" in js
+
+    def test_youtube_video_id_extractor(self):
+        """extractYouTubeVideoId parses YouTube URLs."""
+        js = _read("js/mall-tile-field.js")
+        assert "function extractYouTubeVideoId" in js
+
+    def test_html5_video_fallback(self):
+        """HTML5 video element created for non-YouTube sources."""
+        js = _read("js/mall-tile-field.js")
+        assert "mall-tile-preview-media" in js
+        assert "video.playsInline" in js
+
+
+class TestPreviewControlsAR:
+    """Test audio button and expand button for inline preview."""
+
+    def test_audio_button_markup(self):
+        """Audio button rendered with mall-tile-audio class."""
+        js = _read("js/mall-tile-field.js")
+        assert "mall-tile-audio" in js
+        assert "Toggle audio" in js
+
+    def test_audio_button_css(self):
+        """Audio button CSS exists."""
+        css = _read("css/mall-tile-field.css")
+        assert ".mall-tile-audio" in css
+
+    def test_toggle_preview_mute_function(self):
+        """togglePreviewMute function handles audio toggle."""
+        js = _read("js/mall-tile-field.js")
+        assert "function togglePreviewMute" in js
+
+    def test_expand_button_fullscreen_path(self):
+        """Expand button calls openFullscreenFromTile."""
+        js = _read("js/mall-tile-field.js")
+        assert "openFullscreenFromTile(index)" in js
+
+    def test_fullscreen_stops_preview(self):
+        """openFullscreenFromTile stops inline preview first."""
+        js = _read("js/mall-tile-field.js")
+        assert "function openFullscreenFromTile" in js
+        assert "stopInlinePreview();" in js
+
+    def test_preview_container_markup(self):
+        """Preview container and stage rendered for video tiles."""
+        js = _read("js/mall-tile-field.js")
+        assert "mall-tile-preview" in js
+        assert "mall-tile-preview-stage" in js
+
+    def test_public_api_exposes_preview(self):
+        """Public API exposes inline preview methods."""
+        js = _read("js/mall-tile-field.js")
+        assert "startInlinePreview:" in js
+        assert "stopInlinePreview:" in js
+        assert "pauseInlinePreview:" in js
+        assert "resumeInlinePreview:" in js
+        assert "togglePreviewMute:" in js
+
+
+class TestInlinePreviewAudioStatesAR:
+    """Test audio button visual state clarity (AR slice)."""
+
+    def test_audio_active_css(self):
+        """Audio button has is-active state CSS."""
+        css = _read("css/mall-tile-field.css")
+        assert ".mall-tile-audio.is-active" in css
+
+    def test_audio_unmuted_css(self):
+        """Active unmuted state has distinct background."""
+        css = _read("css/mall-tile-field.css")
+        assert ".mall-tile-audio.is-active:not(.is-muted)" in css
+
+    def test_audio_muted_css(self):
+        """Active muted state has distinct background."""
+        css = _read("css/mall-tile-field.css")
+        assert ".mall-tile-audio.is-active.is-muted" in css
+
+    def test_audio_paused_css(self):
+        """Paused preview audio state has dimmed background."""
+        css = _read("css/mall-tile-field.css")
+        assert ".mall-tile.is-paused .mall-tile-audio.is-active" in css
+
+    def test_svg_muted_icon(self):
+        """Muted SVG uses speaker body + X lines."""
+        js = _read("js/mall-tile-field.js")
+        assert 'x1="23" y1="9" x2="17" y2="15"' in js
+
+    def test_svg_waves_icon(self):
+        """Unmuted SVG uses speaker+waves path."""
+        js = _read("js/mall-tile-field.js")
+        assert "M15.54 8.46a5 5 0 010 7.07" in js
+
+    def test_svg_body_path(self):
+        """Speaker body path exists in SVG markup."""
+        js = _read("js/mall-tile-field.js")
+        assert "M11 5L6 9H2v6h4l5 4V5z" in js
+
+    def test_audio_btn_innerHTML_updated(self):
+        """Audio button innerHTML is updated on state change."""
+        js = _read("js/mall-tile-field.js")
+        assert "audioBtn.innerHTML" in js
+
+
+class TestPausedPreviewIndicatorAR:
+    """Test paused preview shows visible play indicator (AR slice)."""
+
+    def test_paused_preview_visible_css(self):
+        """Paused preview shows play indicator."""
+        css = _read("css/mall-tile-field.css")
+        assert ".mall-tile.is-previewing.is-paused .mall-tile-play-indicator" in css
+
+    def test_inline_preview_layer_css(self):
+        """Inline preview layer CSS exists for in-grid playback."""
+        css = _read("css/mall-tile-field.css")
+        assert ".mall-tile-preview" in css
+        assert ".mall-tile.is-previewing .mall-tile-preview" in css
+
+    def test_preview_stage_css(self):
+        """Preview stage CSS exists."""
+        css = _read("css/mall-tile-field.css")
+        assert ".mall-tile-preview-stage" in css
+
+    def test_touch_devices_show_controls(self):
+        """Touch devices always show audio and expand buttons."""
+        css = _read("css/mall-tile-field.css")
+        assert "hover: none" in css

--- a/public/member/tests/test_video_mall_field_runtime.py
+++ b/public/member/tests/test_video_mall_field_runtime.py
@@ -86,30 +86,6 @@ class TestVideoBackedTiles:
         assert "background-size: cover" in css
 
 
-class TestTapPlayPause:
-    """Test tap = play/pause behavior."""
-
-    def test_toggle_play_function(self):
-        """togglePlay function exists."""
-        js = _read("js/mall-tile-field.js")
-        assert "function togglePlay" in js
-
-    def test_playing_index_tracked(self):
-        """Playing index is tracked."""
-        js = _read("js/mall-tile-field.js")
-        assert "playingIndex" in js
-
-    def test_toggle_play_opens_fullscreen(self):
-        """togglePlay routes to fullscreen player via openFullscreenFromTile."""
-        js = _read("js/mall-tile-field.js")
-        assert "openFullscreenFromTile(index)" in js
-
-    def test_play_indicator_css(self):
-        """Play indicator CSS exists."""
-        css = _read("css/mall-tile-field.css")
-        assert ".mall-tile-play-indicator" in css
-
-
 class TestDoubleTapEnter:
     """Test double-tap = enter FoundUp."""
 
@@ -708,3 +684,64 @@ class TestPausedPreviewIndicatorAR:
         """Touch devices always show audio and expand buttons."""
         css = _read("css/mall-tile-field.css")
         assert "hover: none" in css
+
+
+class TestMediaFieldMappingAR:
+    """Test inline preview reads canonical pfMALL video fields."""
+
+    def test_embed_url_field(self):
+        """startInlinePreview reads embed_url (schema-canonical)."""
+        js = _read("js/mall-tile-field.js")
+        assert "videoData.embed_url" in js
+
+    def test_source_url_field(self):
+        """startInlinePreview reads source_url (schema-canonical)."""
+        js = _read("js/mall-tile-field.js")
+        assert "videoData.source_url" in js
+
+    def test_camelcase_fallbacks(self):
+        """Camel-case aliases embedUrl/sourceUrl accepted."""
+        js = _read("js/mall-tile-field.js")
+        assert "videoData.embedUrl" in js
+        assert "videoData.sourceUrl" in js
+
+    def test_no_stale_url_field(self):
+        """Old .url / .video_url fields are NOT used."""
+        js = _read("js/mall-tile-field.js")
+        # The media-field line should not contain videoData.url or videoData.video_url
+        for line in js.splitlines():
+            if "embed_url" in line and "source_url" in line:
+                assert "videoData.url " not in line
+                assert "videoData.video_url" not in line
+
+    def test_field_priority_matches_player(self):
+        """Field priority: embed_url > source_url (same as mall-video-player.js)."""
+        js = _read("js/mall-tile-field.js")
+        # embed_url must appear before source_url in the fallback chain
+        idx_embed = js.index("videoData.embed_url")
+        idx_source = js.index("videoData.source_url")
+        assert idx_embed < idx_source
+
+
+class TestAudioButtonAccessibilityAR:
+    """Test audio button aria-label and title update by state."""
+
+    def test_muted_label(self):
+        """Muted state sets aria-label to 'Unmute preview'."""
+        js = _read("js/mall-tile-field.js")
+        assert "Unmute preview" in js
+
+    def test_unmuted_label(self):
+        """Unmuted state sets aria-label to 'Mute preview'."""
+        js = _read("js/mall-tile-field.js")
+        assert "Mute preview" in js
+
+    def test_aria_label_updated(self):
+        """aria-label is set via setAttribute in applyTilePreviewState."""
+        js = _read("js/mall-tile-field.js")
+        assert "setAttribute('aria-label'" in js
+
+    def test_title_updated(self):
+        """title property updated alongside aria-label."""
+        js = _read("js/mall-tile-field.js")
+        assert "audioBtn.title = " in js


### PR DESCRIPTION
## Summary

- **Inline preview**: tap plays video inside the tile grid (YouTube IFrame API + HTML5 fallback), not fullscreen
- **Audio control**: 3-state labeling (Start muted preview → Unmute preview → Mute preview), 4 CSS visual states, SVG icon swap
- **Touch-mode padding**: `:has(.mall-tile-audio)` ensures video-backed tiles get control spacing on touch devices even when inactive
- **Media field alignment**: reads `embed_url` / `source_url` matching catalog schema and `mall-video-player.js`
- **Test story**: removed stale `TestTapPlayPause`, added 6 AR test classes — 123 passed

## Files (5)

- `public/member/js/mall-tile-field.js`
- `public/member/css/mall-tile-field.css`
- `public/member/tests/test_video_mall_field_runtime.py`
- `public/member/ModLog.md`
- `public/member/tests/TestModLog.md`

## Test plan

- [x] `python -m pytest public/member/tests/test_video_mall_field_runtime.py -v` — 123 passed
- [ ] Manual: tap video tile on mobile — plays inline, not fullscreen
- [ ] Manual: speaker button shows correct label per state
- [ ] Manual: expand button opens fullscreen player

🤖 Generated with [Claude Code](https://claude.com/claude-code)