### PR TITLE
fix(pfmall): align quickview link class styling

### DIFF
--- a/public/member/css/mall-planes.css
+++ b/public/member/css/mall-planes.css
@@ -156,7 +156,7 @@
   background: rgba(0, 212, 170, 0.18);
 }
 
-.fv-detail-link {
+.fv-open-link {
   display: inline-flex;
   align-items: center;
   padding: 0.6rem 1.2rem;
@@ -169,7 +169,7 @@
   font-weight: 500;
   transition: background 0.15s;
 }
-.fv-detail-link:hover {
+.fv-open-link:hover {
   background: rgba(124, 92, 252, 0.18);
 }
 

--- a/public/member/tests/test_navigation_planes.py
+++ b/public/member/tests/test_navigation_planes.py
@@ -125,6 +125,12 @@ class TestFoundUpHandoff:
         js = _read("js/mall-planes.js")
         assert "routing_prefix" in js
 
+    def test_open_link_css_class_matches_js(self):
+        """CSS targets .fv-open-link (not stale .fv-detail-link)."""
+        css = _read("css/mall-planes.css")
+        assert ".fv-open-link" in css
+        assert ".fv-detail-link" not in css
+
     def test_no_stale_save_semantics(self):
         """Save/favorite semantics removed from view plane."""
         js = _read("js/mall-planes.js")


### PR DESCRIPTION
## Summary

- Rename `.fv-detail-link` to `.fv-open-link` in `mall-planes.css` to match the class rendered by `mall-planes.js`
- The JS was updated in a prior slice but the CSS was missed, leaving the quickview "Open FoundUp" link unstyled
- Add focused test asserting CSS targets `.fv-open-link` and stale `.fv-detail-link` is gone

## Test plan

- [x] 42/42 navigation_planes tests pass (2 pre-existing failures unrelated — missing gesture-hints.js)
- [x] 51/51 non-video quickview/action tests pass
- [x] No `fv-detail-link` remains in source (only in ModLog history + negative test assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)