### PR TITLE
fix(pfmall): restore one-time gesture hints script

### DIFF
--- a/public/member/index.html
+++ b/public/member/index.html
@@ -1100,6 +1100,7 @@
   </div>
 
   <script src="js/gesture-engine.js"></script>
+  <script src="js/gesture-hints.js"></script>
   <script src="js/shell-bridge-interceptor.js"></script>
   <script src="js/mall-planes.js"></script>
   <script src="js/mall-tile-field.js"></script>

--- a/public/member/js/gesture-hints.js
+++ b/public/member/js/gesture-hints.js
@@ -1,0 +1,65 @@
+/**
+ * Gesture Hints — One-time dismissible discovery overlay
+ *
+ * Shows gesture hints on first visit, dismisses on tap or after 6 seconds.
+ * Uses localStorage to remember dismissal.
+ */
+(function() {
+  'use strict';
+
+  var STORAGE_KEY = 'pfmall_hints_dismissed';
+  var AUTO_DISMISS_MS = 6000;
+
+  function init() {
+    var hints = document.getElementById('gestureHints');
+    if (!hints) return;
+
+    // Check if already dismissed
+    try {
+      if (localStorage.getItem(STORAGE_KEY) === 'true') {
+        return; // Don't show again
+      }
+    } catch (e) {
+      // localStorage unavailable, fail quietly
+      return;
+    }
+
+    // Show hints overlay
+    hints.style.display = 'flex';
+
+    var dismissed = false;
+
+    function dismiss() {
+      if (dismissed) return;
+      dismissed = true;
+
+      // Fade out via CSS class
+      hints.classList.add('hint-dismiss');
+
+      // Store dismissal
+      try {
+        localStorage.setItem(STORAGE_KEY, 'true');
+      } catch (e) {
+        // Fail quietly
+      }
+
+      // Hide after transition completes
+      setTimeout(function() {
+        hints.style.display = 'none';
+      }, 350);
+    }
+
+    // Tap/click anywhere to dismiss
+    hints.addEventListener('click', dismiss);
+
+    // Auto-dismiss after 6 seconds
+    setTimeout(dismiss, 6000);
+  }
+
+  // Run after DOM ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary

- Create `gesture-hints.js` with one-time dismissible overlay behavior
- Wire script include in `index.html` after gesture-engine.js

## Behavior

| Aspect | Implementation |
|--------|---------------|
| localStorage key | `pfmall_hints_dismissed` |
| First visit | Show overlay (`display:flex`) |
| Dismiss | Tap anywhere adds `.hint-dismiss` class, sets localStorage |
| Auto-dismiss | `setTimeout(dismiss, 6000)` |
| Failure mode | Quiet — no errors on localStorage unavailable or missing DOM |

## Test plan

- [x] 44/44 navigation_planes tests pass (was 42/44 before — 2 fixed)
- [x] 192/192 total member tests pass (non-video + video runtime included)
- [x] No regressions

## Files changed

| File | Change |
|------|--------|
| `public/member/js/gesture-hints.js` | +65 lines (new) |
| `public/member/index.html` | +1 line (script include) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)