### PR TITLE
fix(pfmall): style reddog watch history continue badge

### DIFF
--- a/public/member/css/account-concierge.css
+++ b/public/member/css/account-concierge.css
@@ -1071,3 +1071,16 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+.reddog-history-continue-badge {
+  display: inline-block;
+  margin-top: 0.25rem;
+  padding: 0.15rem 0.4rem;
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #00d4aa;
+  background: rgba(0, 212, 170, 0.15);
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary

Add missing `.reddog-history-continue-badge` CSS styling for Red Dog watch-history cards.

## CSS Added

```css
.reddog-history-continue-badge {
  display: inline-block;
  margin-top: 0.25rem;
  padding: 0.15rem 0.4rem;
  font-size: 0.6rem;
  font-weight: 600;
  text-transform: uppercase;
  letter-spacing: 0.04em;
  color: #00d4aa;
  background: rgba(0, 212, 170, 0.15);
  border-radius: 4px;
}
```

## Test plan

- [x] 142/142 account_concierge tests pass (was failing `test_continue_badge_styles`)
- [x] No JS changes needed — markup contract already correct

## Files changed

| File | Change |
|------|--------|
| `public/member/css/account-concierge.css` | +13 lines |

🤖 Generated with [Claude Code](https://claude.com/claude-code)