### PR TITLE
feat(pfmall): tile keyboard accessibility phase 1 (BC)

### DIFF
--- a/public/member/ModLog.md
+++ b/public/member/ModLog.md
@@ -32,6 +32,36 @@
 
 ---
 
+## [2026-04-09] Tile Keyboard Accessibility Phase 1 (Worker BC, WSP 15/97)
+
+**Who**: 0102 — Worker BC
+**Slice**: `PFMALL_TILE_A11Y_AND_KEYBOARD_PARITY_PHASE1`
+**What**: Add WCAG 2.1 Level AA keyboard accessibility to pfMALL tiles.
+
+**Files Modified**:
+- `public/member/css/mall-tile-field.css` — Distinct `:focus-visible` ring, control button focus styles
+- `public/member/css/mall-planes.css` — Close button, CTA, secondary link focus-visible styles
+- `public/member/js/mall-planes.js` — Focus return by stable `foundup_id` (survives projection changes)
+- `public/member/tests/test_tile_keyboard_a11y.py` — New test suite (27 tests)
+
+**A11y Improvements**:
+1. **Focus visibility**: Tiles now have clear purple focus ring (`box-shadow: 0 0 0 3px rgba(141, 113, 255, 0.35)`) separate from hover
+2. **Control focus**: Audio/expand buttons have `:focus-visible` outline
+3. **Focus return by stable ID**: When closing quick-view, focus returns to originating tile by `data-foundup-id` (not `data-index`)
+4. **Focus on open**: Close button receives focus when plane opens for immediate keyboard control
+5. **Navigation tracking**: Arrow key navigation updates `returnFocusId` to navigated item's identity
+
+**Projection-safe focus return**: Uses `returnFocusId` (foundup_id) and queries `[data-foundup-id="..."]` on close, so focus return works correctly even if Mall projection/filter changes while plane is open.
+
+**Keyboard Behavior** (unchanged, now tested):
+- **Space**: togglePlay (video tiles play/pause, non-video opens quick-view)
+- **Enter**: enterFoundUp (opens quick-view plane)
+- **Escape**: Close expanded view or stop preview
+
+**Test Count**: 27 passed (tile keyboard accessibility suite)
+
+---
+
 ## [2026-04-09] Non-Video Quick-View Action Surface Phase 2 (Worker BB, WSP 15/97)
 
 **Who**: 0102 — Worker BB

--- a/public/member/css/mall-planes.css
+++ b/public/member/css/mall-planes.css
@@ -69,6 +69,11 @@
 .fv-close-btn:hover {
   color: rgba(255, 255, 255, 0.8);
 }
+.fv-close-btn:focus-visible {
+  outline: 2px solid rgba(141, 113, 255, 0.8);
+  outline-offset: 2px;
+  color: rgba(255, 255, 255, 0.9);
+}
 
 /* ---- View content ---- */
 .fv-hero {
@@ -163,6 +168,11 @@
 .fv-primary-cta:active {
   transform: scale(0.98);
 }
+.fv-primary-cta:focus-visible {
+  outline: 2px solid rgba(0, 212, 170, 0.8);
+  outline-offset: 2px;
+  background: rgba(0, 212, 170, 0.25);
+}
 
 /* Secondary actions container */
 .fv-secondary-actions {
@@ -183,6 +193,11 @@
 .fv-secondary-link:hover {
   color: var(--text-dim, rgba(243, 241, 248, 0.7));
   text-decoration: underline;
+}
+.fv-secondary-link:focus-visible {
+  outline: 2px solid rgba(141, 113, 255, 0.6);
+  outline-offset: 2px;
+  color: var(--text-dim, rgba(243, 241, 248, 0.7));
 }
 
 /* Legacy classes (kept for backwards compatibility) */

--- a/public/member/css/mall-tile-field.css
+++ b/public/member/css/mall-tile-field.css
@@ -222,11 +222,17 @@
   pointer-events: none;
 }
 
-.mall-tile:hover,
-.mall-tile:focus-visible {
+.mall-tile:hover {
   transform: scale(1.02);
   border-color: rgba(255, 255, 255, 0.18);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.24);
+}
+
+/* Keyboard focus: clear visible ring for accessibility */
+.mall-tile:focus-visible {
+  transform: scale(1.02);
+  border-color: rgba(141, 113, 255, 0.6);
+  box-shadow: 0 0 0 3px rgba(141, 113, 255, 0.35), 0 8px 32px rgba(0, 0, 0, 0.24);
   outline: none;
 }
 
@@ -578,6 +584,15 @@
 
 .mall-tile-expand:hover {
   background: rgba(124, 92, 252, 0.8);
+}
+
+/* Focus states for control buttons (keyboard accessibility) */
+.mall-tile-audio:focus-visible,
+.mall-tile-expand:focus-visible {
+  opacity: 1;
+  outline: 2px solid rgba(141, 113, 255, 0.8);
+  outline-offset: 2px;
+  background: rgba(124, 92, 252, 0.6);
 }
 
 /* Expanded FoundUp video field mode */

--- a/public/member/js/mall-planes.js
+++ b/public/member/js/mall-planes.js
@@ -30,6 +30,7 @@
   var activeIndex = -1;
   var isOpen = false;
   var gestureRef = null;
+  var returnFocusId = null;  // foundup_id for focus return (stable across projections)
 
   var READINESS_LABELS = {
     ready: 'Ready',
@@ -47,13 +48,18 @@
   // ---- open / close ----
   function openFoundUp(index) {
     if (index < 0 || index >= catalog.length) return;
+    // Save focus return ID (stable across projection/filter changes)
+    var item = catalog[index];
+    returnFocusId = item.foundup_id || item.id || null;
     activeIndex = index;
-    renderView(catalog[index]);
+    renderView(item);
     plane.classList.add('open');
     if (scrim) scrim.classList.add('open');
     document.body.classList.add('surface-open');
     isOpen = true;
     attachGestures();
+    // Move focus to close button for keyboard users
+    if (closeBtn) closeBtn.focus();
   }
 
   function closeView() {
@@ -63,6 +69,15 @@
     document.body.classList.remove('surface-open');
     isOpen = false;
     if (gestureRef) { gestureRef.destroy(); gestureRef = null; }
+    // Return focus to originating tile by stable ID (survives projection changes)
+    if (returnFocusId) {
+      var tileField = document.getElementById('mallTileField');
+      if (tileField) {
+        var tile = tileField.querySelector('.mall-tile[data-foundup-id="' + returnFocusId + '"]');
+        if (tile && typeof tile.focus === 'function') tile.focus();
+      }
+      returnFocusId = null;
+    }
   }
 
   function navigateFoundUp(delta) {
@@ -70,6 +85,9 @@
     if (next < 0 || next >= catalog.length) return;
     activeIndex = next;
     renderView(catalog[next]);
+    // Update return focus ID to navigated item (stable identity)
+    var navItem = catalog[next];
+    returnFocusId = navItem.foundup_id || navItem.id || null;
     // Sync Mall carousel position
     if (window.mallPlanesSync) window.mallPlanesSync(next);
   }

--- a/public/member/tests/TestModLog.md
+++ b/public/member/tests/TestModLog.md
@@ -33,6 +33,32 @@ Validates inline preview resource discipline for mobile/PWA:
 
 ---
 
+## 2026-04-09 | Tile Keyboard Accessibility Tests (WSP 15/97)
+
+**File**: `test_tile_keyboard_a11y.py` (new)
+**Tests**: 27 | **Classes**: 6 | **Result**: 27 passed
+**Worker**: BC
+
+Validates WCAG 2.1 Level AA keyboard accessibility for Mall tiles:
+
+| Class | Count | What it covers |
+|-------|-------|----------------|
+| TestTileFocusVisibility | 5 | tabindex, aria-label, focus-visible ring, hover/focus separation |
+| TestKeyboardActivation | 4 | keydown handler, Space/Enter/Escape key behavior |
+| TestControlAccessibility | 7 | Audio/expand button aria-labels, titles, focus-visible CSS |
+| TestFocusReturn | 5 | returnFocusId tracking, focus restore by stable identity |
+| TestMallPlanesFocusStyles | 4 | Close button, CTA, secondary link focus styles |
+| TestARIASemantics | 2 | Article element, mall-planes keyboard handler |
+
+**Key A11y improvements verified**:
+- Tiles have visible purple focus ring (`box-shadow: 0 0 0 3px rgba(141, 113, 255, 0.35)`)
+- Keyboard Enter/Space parity with pointer interactions
+- Focus returns to originating tile by `foundup_id` (stable across projection/filter changes)
+- Control buttons (audio/expand) focusable with proper labels
+- `test_focus_return_uses_stable_identity` validates closeView queries by `data-foundup-id`, not `data-index`
+
+---
+
 ## 2026-04-09 | Non-Video Action Surface Phase 2 Tests (WSP 15/97)
 
 **File**: `test_non_video_quickview_actions.py` (extended)

--- a/public/member/tests/test_tile_keyboard_a11y.py
+++ b/public/member/tests/test_tile_keyboard_a11y.py
@@ -1,0 +1,223 @@
+"""
+Tile Keyboard Accessibility Tests — pfMALL A11y Phase 1
+
+Tests keyboard navigation and focus management for Mall tiles.
+Validates WCAG 2.1 Level AA compliance for:
+  - Focus visibility: Clear visual indicator for keyboard focus
+  - Keyboard activation: Enter/Space parity with pointer
+  - Control accessibility: Audio/expand buttons focusable with labels
+  - Focus return: Surface exit returns focus to originating tile
+"""
+import pytest
+from pathlib import Path
+
+
+@pytest.fixture
+def tile_field_css():
+    """Load the tile field CSS file."""
+    path = Path(__file__).parent.parent / 'css' / 'mall-tile-field.css'
+    return path.read_text(encoding='utf-8')
+
+
+@pytest.fixture
+def tile_field_js():
+    """Load the tile field JS file."""
+    path = Path(__file__).parent.parent / 'js' / 'mall-tile-field.js'
+    return path.read_text(encoding='utf-8')
+
+
+@pytest.fixture
+def mall_planes_css():
+    """Load the mall-planes CSS file."""
+    path = Path(__file__).parent.parent / 'css' / 'mall-planes.css'
+    return path.read_text(encoding='utf-8')
+
+
+@pytest.fixture
+def mall_planes_js():
+    """Load the mall-planes JS file."""
+    path = Path(__file__).parent.parent / 'js' / 'mall-planes.js'
+    return path.read_text(encoding='utf-8')
+
+
+# ========== Focus Visibility ==========
+
+class TestTileFocusVisibility:
+    """Test visible focus indicators on tiles."""
+
+    def test_tile_has_tabindex(self, tile_field_js):
+        """Tiles are keyboard focusable via tabindex."""
+        assert 'tabindex="0"' in tile_field_js
+
+    def test_tile_has_aria_label(self, tile_field_js):
+        """Tiles have aria-label for screen readers."""
+        assert 'aria-label="' in tile_field_js
+
+    def test_tile_focus_visible_separate_from_hover(self, tile_field_css):
+        """Focus-visible is separate from hover (distinct styling)."""
+        # Must NOT be combined: .mall-tile:hover, .mall-tile:focus-visible
+        # Should have separate rule for :focus-visible
+        lines = tile_field_css.split('\n')
+        focus_visible_lines = [l for l in lines if ':focus-visible' in l and '.mall-tile' in l]
+        # At least one line should have ONLY :focus-visible (not combined with :hover)
+        standalone_focus = any(
+            ':focus-visible' in l and ':hover' not in l
+            for l in focus_visible_lines
+        )
+        assert standalone_focus, "Tile :focus-visible should be a standalone rule"
+
+    def test_tile_focus_has_visible_ring(self, tile_field_css):
+        """Focus-visible has a clear visible ring (box-shadow or outline)."""
+        # Look for focus indicator styles after :focus-visible
+        assert '141, 113, 255' in tile_field_css  # Purple focus ring color
+        # Check for either outline or box-shadow with focus ring
+        assert 'box-shadow: 0 0 0 3px' in tile_field_css or 'outline: 2px solid' in tile_field_css
+
+    def test_tile_hover_no_outline_none(self, tile_field_css):
+        """Hover state should not have outline: none that breaks focus."""
+        # Split into rules and check hover doesn't have outline: none
+        # Focus-visible CAN have outline: none if using box-shadow instead
+        css_text = tile_field_css
+        # Find the hover rule
+        hover_match = '.mall-tile:hover {'
+        if hover_match in css_text:
+            hover_start = css_text.index(hover_match)
+            hover_end = css_text.index('}', hover_start)
+            hover_rule = css_text[hover_start:hover_end]
+            assert 'outline: none' not in hover_rule
+
+
+# ========== Keyboard Activation ==========
+
+class TestKeyboardActivation:
+    """Test keyboard activation parity with pointer."""
+
+    def test_tile_keydown_handler_exists(self, tile_field_js):
+        """Tiles have keydown event handler."""
+        assert "addEventListener('keydown'" in tile_field_js
+
+    def test_space_triggers_toggle_play(self, tile_field_js):
+        """Spacebar triggers togglePlay (same as tap)."""
+        # Space key check exists
+        assert "e.key === ' '" in tile_field_js
+        # And calls togglePlay
+        assert 'togglePlay(index)' in tile_field_js
+
+    def test_enter_triggers_enter_foundup(self, tile_field_js):
+        """Enter key triggers enterFoundUp."""
+        assert "e.key === 'Enter'" in tile_field_js
+        assert 'enterFoundUp(index)' in tile_field_js
+
+    def test_escape_closes_expanded_or_preview(self, tile_field_js):
+        """Escape key closes expanded view or stops preview."""
+        assert "e.key === 'Escape'" in tile_field_js
+        assert 'collapseFoundUp()' in tile_field_js or 'stopInlinePreview()' in tile_field_js
+
+
+# ========== Control Accessibility ==========
+
+class TestControlAccessibility:
+    """Test audio and expand button accessibility."""
+
+    def test_audio_button_has_aria_label(self, tile_field_js):
+        """Audio button has aria-label."""
+        assert 'aria-label=' in tile_field_js
+        assert 'Unmute preview' in tile_field_js or 'Mute preview' in tile_field_js
+
+    def test_audio_button_has_title(self, tile_field_js):
+        """Audio button has title for tooltip."""
+        assert '.title =' in tile_field_js
+
+    def test_expand_button_has_aria_label(self, tile_field_js):
+        """Expand button has aria-label."""
+        assert 'aria-label="Open fullscreen"' in tile_field_js
+
+    def test_expand_button_has_title(self, tile_field_js):
+        """Expand button has title attribute."""
+        assert 'title="Fullscreen"' in tile_field_js
+
+    def test_audio_button_focus_visible_css(self, tile_field_css):
+        """Audio button has focus-visible styling."""
+        assert '.mall-tile-audio:focus-visible' in tile_field_css
+
+    def test_expand_button_focus_visible_css(self, tile_field_css):
+        """Expand button has focus-visible styling."""
+        assert '.mall-tile-expand:focus-visible' in tile_field_css
+
+    def test_control_buttons_focusable_in_tile(self, tile_field_css):
+        """Control buttons become visible when tile has focus-within."""
+        assert ':focus-within .mall-tile-expand' in tile_field_css
+        assert ':focus-within .mall-tile-audio' in tile_field_css
+
+
+# ========== Focus Return ==========
+
+class TestFocusReturn:
+    """Test focus management when closing surfaces."""
+
+    def test_return_focus_id_tracked(self, mall_planes_js):
+        """Return focus ID is tracked on open (stable identity)."""
+        assert 'returnFocusId' in mall_planes_js
+
+    def test_focus_returned_by_foundup_id(self, mall_planes_js):
+        """Focus is returned by querying data-foundup-id (stable across projections)."""
+        assert 'data-foundup-id="' in mall_planes_js
+        assert 'tile.focus()' in mall_planes_js
+
+    def test_close_button_focused_on_open(self, mall_planes_js):
+        """Close button receives focus when plane opens."""
+        assert 'closeBtn.focus()' in mall_planes_js
+
+    def test_navigate_updates_return_id(self, mall_planes_js):
+        """Arrow navigation updates return focus ID to navigated item."""
+        # Check that navigateFoundUp updates returnFocusId from item identity
+        assert 'navItem.foundup_id || navItem.id' in mall_planes_js or 'item.foundup_id || item.id' in mall_planes_js
+
+    def test_focus_return_uses_stable_identity(self, mall_planes_js):
+        """Focus return uses foundup_id, not data-index (survives projection changes)."""
+        # Must NOT query by data-index for focus return
+        # The closeView function should query by data-foundup-id
+        close_view_section = mall_planes_js[mall_planes_js.find('function closeView'):]
+        close_view_section = close_view_section[:close_view_section.find('function ', 10)]
+        assert 'data-foundup-id' in close_view_section
+        assert 'data-index' not in close_view_section
+
+
+# ========== Mall Planes Focus Styles ==========
+
+class TestMallPlanesFocusStyles:
+    """Test focus styles for mall planes UI elements."""
+
+    def test_close_button_focus_visible(self, mall_planes_css):
+        """Close button has focus-visible styling."""
+        assert '.fv-close-btn:focus-visible' in mall_planes_css
+
+    def test_primary_cta_focus_visible(self, mall_planes_css):
+        """Primary CTA has focus-visible styling."""
+        assert '.fv-primary-cta:focus-visible' in mall_planes_css
+
+    def test_secondary_link_focus_visible(self, mall_planes_css):
+        """Secondary link has focus-visible styling."""
+        assert '.fv-secondary-link:focus-visible' in mall_planes_css
+
+    def test_focus_uses_outline_not_just_color(self, mall_planes_css):
+        """Focus styles use outline for visibility."""
+        # Must have outline property in focus-visible rules
+        assert 'outline: 2px solid' in mall_planes_css
+
+
+# ========== ARIA Semantics ==========
+
+class TestARIASemantics:
+    """Test ARIA roles and semantics."""
+
+    def test_tile_rendered_as_article(self, tile_field_js):
+        """Tiles are rendered as article elements."""
+        assert '<article class="' in tile_field_js
+
+    def test_mall_planes_keyboard_handler(self, mall_planes_js):
+        """Mall planes has keyboard handler for navigation."""
+        assert "addEventListener('keydown'" in mall_planes_js
+        assert "e.key === 'Escape'" in mall_planes_js
+        assert "e.key === 'ArrowLeft'" in mall_planes_js
+        assert "e.key === 'ArrowRight'" in mall_planes_js


### PR DESCRIPTION
## Summary
- Add WCAG 2.1 Level AA keyboard accessibility to pfMALL tiles
- Focus visibility: distinct purple ring for `:focus-visible` (separate from hover)
- Focus return by stable `foundup_id` (survives projection/filter changes)
- Control buttons (audio/expand) now keyboard-focusable with visible styles

## Key Changes
- `mall-tile-field.css`: Separate `:focus-visible` rule with `box-shadow: 0 0 0 3px rgba(141, 113, 255, 0.35)`
- `mall-planes.css`: Focus styles for close button, primary CTA, secondary link
- `mall-planes.js`: `returnFocusId` tracks by `foundup_id`, queries by `data-foundup-id` on close

## Test plan
- [x] `test_tile_keyboard_a11y.py`: 27 passed
- [x] Full member suite: 1214 passed (4 pre-existing unrelated failures)
- [ ] Manual: Tab through tiles, verify purple focus ring visible
- [ ] Manual: Open quick-view with Enter, close with Escape, verify focus returns to tile
- [ ] Manual: Change projection while plane is open, close, verify focus still returns correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)