### PR TITLE
fix(pfmall): harden inline preview resource lifecycle

### DIFF
--- a/public/member/ModLog.md
+++ b/public/member/ModLog.md
@@ -1,5 +1,37 @@
 # Member Area Module Change Log
 
+## [2026-04-10] Inline Preview Resource Hardening Phase 1 (Worker BD, WSP 15/97)
+
+**Who**: 0102 — Worker BD
+**Slice**: `PFMALL_PREVIEW_RESOURCE_HARDENING_PHASE1`
+**What**: Harden pfMALL inline preview resource behavior for mobile/PWA reality.
+
+**Files Modified**:
+- `public/member/js/mall-tile-field.js` — Teardown hygiene, visibility handler, error fail-safes
+- `public/member/tests/test_video_mall_field_runtime.py` — 13 new tests for resource hardening
+
+**Lifecycle/Resource Safeguards Added**:
+1. **Stale callback guard**: `previewGeneration` incremented FIRST in `stopInlinePreview()` to invalidate pending async callbacks
+2. **HTML5 video teardown hygiene**:
+   - `onerror` handler cleared before teardown
+   - `video.load()` called to release media buffers
+   - DOM node removed from parent
+3. **Page visibility handler**: `visibilitychange` pauses preview when tab/page is hidden (battery discipline)
+4. **Invalid URL fail-safe**: Validates URL length before attempting preview
+5. **YouTube error callback**: `onError` handler guards against generation and cleans up
+6. **HTML5 error handler**: `onerror` fails quietly without poisoning state
+7. **Autoplay failure cleanup**: `.catch()` on `video.play()` calls `stopInlinePreview()`
+
+**Cleanup Paths Improved**:
+- `stopInlinePreview()`: Now increments generation first, clears error handlers, calls `load()`, removes DOM node
+- `startInlinePreview()`: Defensive cleanup (always stops previous), URL validation, error handlers on both YT and HTML5
+
+**WSP 97 Applied**: Runtime boundary respected — no changes to UX semantics, service worker, or PWA caching.
+
+**Test Count**: 154 passed (141 existing + 13 new resource hardening tests)
+
+---
+
 ## [2026-04-09] Non-Video Quick-View Action Surface Phase 2 (Worker BB, WSP 15/97)
 
 **Who**: 0102 — Worker BB

--- a/public/member/js/mall-tile-field.js
+++ b/public/member/js/mall-tile-field.js
@@ -151,10 +151,20 @@
 
   function stopInlinePreview() {
     if (playingIndex === null) return;
+    // Increment generation FIRST to invalidate any pending async callbacks
+    previewGeneration++;
     destroyInlineYTPlayer();
     if (inlineHTML5Video) {
+      // Remove error handler to prevent stale callback
+      inlineHTML5Video.onerror = null;
       inlineHTML5Video.pause();
       inlineHTML5Video.src = '';
+      // Call load() to release media buffers (mobile resource discipline)
+      try { inlineHTML5Video.load(); } catch (e) { /* ignore */ }
+      // Remove from DOM to ensure cleanup
+      if (inlineHTML5Video.parentNode) {
+        inlineHTML5Video.parentNode.removeChild(inlineHTML5Video);
+      }
       inlineHTML5Video = null;
     }
     var tile = getTileElement(playingIndex);
@@ -188,15 +198,17 @@
   }
 
   function startInlinePreview(index, muted) {
-    if (playingIndex !== null && playingIndex !== index) {
-      stopInlinePreview();
-    } else {
-      stopInlinePreview();
-    }
+    // Defensive cleanup: always stop previous preview first
+    stopInlinePreview();
+
     var videoData = getTilePreviewVideo(index);
     if (!videoData) return;
 
     var videoUrl = videoData.embed_url || videoData.embedUrl || videoData.source_url || videoData.sourceUrl || '';
+    // Invalid URL fail-safe: don't attempt preview with empty/malformed URLs
+    if (!videoUrl || typeof videoUrl !== 'string' || videoUrl.length < 5) {
+      return;
+    }
     var ytId = extractYouTubeVideoId(videoUrl);
     var tile = getTileElement(index);
     if (!tile) return;
@@ -231,6 +243,11 @@
               if (previewMuted) event.target.mute();
               else event.target.unMute();
               event.target.playVideo();
+            },
+            onError: function(event) {
+              // YouTube player error: fail quietly, clean up state
+              if (gen !== previewGeneration) return;
+              stopInlinePreview();
             }
           }
         });
@@ -238,16 +255,25 @@
     } else if (videoUrl) {
       var video = document.createElement('video');
       video.className = 'mall-tile-preview-media';
-      video.src = videoUrl;
       video.muted = previewMuted;
       video.autoplay = true;
       video.loop = true;
       video.playsInline = true;
       video.setAttribute('playsinline', '');
+      // Error handler: fail quietly without poisoning state
+      video.onerror = function() {
+        if (gen !== previewGeneration) return;
+        stopInlinePreview();
+      };
       stage.innerHTML = '';
       stage.appendChild(video);
       inlineHTML5Video = video;
-      video.play().catch(function() { /* autoplay may be blocked */ });
+      video.src = videoUrl;
+      video.play().catch(function() {
+        // Autoplay may be blocked — fail quietly, stop preview state
+        if (gen !== previewGeneration) return;
+        stopInlinePreview();
+      });
     }
   }
 
@@ -272,6 +298,28 @@
       }
     }
     applyTilePreviewState(playingIndex, { previewing: true, paused: previewPaused, muted: previewMuted });
+  }
+
+  // ========== Page Visibility Resource Discipline ==========
+
+  var visibilityBound = false;
+
+  /**
+   * Bind page visibility handler - pause preview when tab/page is hidden
+   * to avoid burning resources offscreen (mobile battery discipline)
+   */
+  function bindVisibilityHandler() {
+    if (visibilityBound) return;
+    visibilityBound = true;
+
+    document.addEventListener('visibilitychange', function() {
+      if (document.hidden && playingIndex !== null) {
+        // Page hidden: pause preview to save resources
+        pauseInlinePreview();
+      }
+      // Note: we do NOT auto-resume on visible - user taps to resume
+      // This is intentional: prevents unexpected audio/video playback
+    });
   }
 
   // Locomotion state
@@ -315,6 +363,9 @@
 
     // Track scroll state for edge shadows
     bindScrollState();
+
+    // Bind page visibility handler for resource discipline
+    bindVisibilityHandler();
 
     renderTiles();
     bindInteractions();

--- a/public/member/tests/TestModLog.md
+++ b/public/member/tests/TestModLog.md
@@ -4,6 +4,35 @@ Test evolution log for the p.fMALL member shell test suite.
 
 ---
 
+## 2026-04-10 | Preview Resource Hardening Tests (WSP 15/97)
+
+**File**: `test_video_mall_field_runtime.py` (extended)
+**Tests**: 13 new | **Class**: `TestPreviewResourceHardening` | **Result**: 154 passed total
+**Worker**: BD
+
+Validates inline preview resource discipline for mobile/PWA:
+
+| Test | What it covers |
+|------|----------------|
+| test_stale_callback_guard_increment_first | `previewGeneration++` happens FIRST in teardown |
+| test_html5_video_load_called | `video.load()` releases media buffers |
+| test_html5_video_removed_from_dom | Video element removed from parent on teardown |
+| test_html5_video_onerror_cleared | `onerror` handler cleared to prevent stale callback |
+| test_visibility_handler_bound | `bindVisibilityHandler()` exists and called |
+| test_visibility_change_pauses_preview | `visibilitychange` pauses preview when hidden |
+| test_invalid_url_failsafe | URL validated before preview attempt |
+| test_youtube_error_callback_guarded | YT `onError` checks generation guard |
+| test_html5_video_error_handler | `video.onerror` fails quietly |
+| test_fullscreen_handoff_cleanup | `openFullscreenFromTile` stops preview first |
+| test_expand_cleanup | `expandFoundUp` stops preview first |
+| test_collapse_cleanup | `collapseFoundUp` stops preview first |
+| test_visibility_bound_guard | Handler has double-bind guard |
+
+**Updated test**:
+- `test_one_active_preview_rule`: Updated to check for defensive cleanup comment
+
+---
+
 ## 2026-04-09 | Non-Video Action Surface Phase 2 Tests (WSP 15/97)
 
 **File**: `test_non_video_quickview_actions.py` (extended)

--- a/public/member/tests/test_video_mall_field_runtime.py
+++ b/public/member/tests/test_video_mall_field_runtime.py
@@ -526,9 +526,10 @@ class TestTapInlinePreviewAR:
         assert "function stopInlinePreview" in js
 
     def test_one_active_preview_rule(self):
-        """Starting a new preview stops the previous one."""
+        """Starting a new preview stops the previous one (defensive cleanup)."""
         js = _read("js/mall-tile-field.js")
-        assert "playingIndex !== null && playingIndex !== index" in js
+        # Defensive cleanup: always stop previous preview first
+        assert "// Defensive cleanup: always stop previous preview first" in js
         assert "stopInlinePreview()" in js
 
     def test_toggle_play_starts_inline(self):
@@ -890,3 +891,84 @@ class TestMallLocomotionAndGestures:
         assert "scrollStartY" in js
         assert "scrollLeft" in js
         assert "scrollTop" in js
+
+
+class TestPreviewResourceHardening:
+    """Test inline preview resource hardening (BD slice)."""
+
+    def test_stale_callback_guard_increment_first(self):
+        """stopInlinePreview increments generation FIRST to invalidate callbacks."""
+        js = _read("js/mall-tile-field.js")
+        assert "// Increment generation FIRST" in js
+        assert "previewGeneration++" in js
+
+    def test_html5_video_load_called(self):
+        """HTML5 video.load() called to release media buffers."""
+        js = _read("js/mall-tile-field.js")
+        assert "inlineHTML5Video.load()" in js
+
+    def test_html5_video_removed_from_dom(self):
+        """HTML5 video removed from DOM on teardown."""
+        js = _read("js/mall-tile-field.js")
+        assert "inlineHTML5Video.parentNode.removeChild(inlineHTML5Video)" in js
+
+    def test_html5_video_onerror_cleared(self):
+        """HTML5 video onerror handler cleared on teardown."""
+        js = _read("js/mall-tile-field.js")
+        assert "inlineHTML5Video.onerror = null" in js
+
+    def test_visibility_handler_bound(self):
+        """bindVisibilityHandler exists and is called on init."""
+        js = _read("js/mall-tile-field.js")
+        assert "function bindVisibilityHandler" in js
+        assert "bindVisibilityHandler()" in js
+
+    def test_visibility_change_pauses_preview(self):
+        """visibilitychange pauses preview when page is hidden."""
+        js = _read("js/mall-tile-field.js")
+        assert "document.addEventListener('visibilitychange'" in js
+        assert "document.hidden" in js
+        assert "pauseInlinePreview()" in js
+
+    def test_invalid_url_failsafe(self):
+        """startInlinePreview validates URL before attempting preview."""
+        js = _read("js/mall-tile-field.js")
+        assert "videoUrl.length < 5" in js
+
+    def test_youtube_error_callback_guarded(self):
+        """YouTube player onError callback checks generation."""
+        js = _read("js/mall-tile-field.js")
+        assert "onError: function(event)" in js
+
+    def test_html5_video_error_handler(self):
+        """HTML5 video has onerror handler that fails quietly."""
+        js = _read("js/mall-tile-field.js")
+        assert "video.onerror = function()" in js
+
+    def test_fullscreen_handoff_cleanup(self):
+        """openFullscreenFromTile stops inline preview first."""
+        js = _read("js/mall-tile-field.js")
+        assert "function openFullscreenFromTile" in js
+        idx_func = js.index("function openFullscreenFromTile")
+        idx_stop = js.index("stopInlinePreview();", idx_func)
+        assert idx_stop - idx_func < 100
+
+    def test_expand_cleanup(self):
+        """expandFoundUp stops inline preview first."""
+        js = _read("js/mall-tile-field.js")
+        idx_func = js.index("function expandFoundUp")
+        idx_stop = js.index("stopInlinePreview();", idx_func)
+        assert idx_stop - idx_func < 200
+
+    def test_collapse_cleanup(self):
+        """collapseFoundUp stops inline preview first."""
+        js = _read("js/mall-tile-field.js")
+        idx_func = js.index("function collapseFoundUp")
+        idx_stop = js.index("stopInlinePreview();", idx_func)
+        assert idx_stop - idx_func < 200
+
+    def test_visibility_bound_guard(self):
+        """Visibility handler has guard against double-binding."""
+        js = _read("js/mall-tile-field.js")
+        assert "visibilityBound" in js
+        assert "if (visibilityBound) return" in js


### PR DESCRIPTION
## Summary
- Hardens pfMALL inline preview resource behavior for mobile/PWA reality
- Adds stale callback guard, teardown hygiene, page visibility handler, error fail-safes
- 13 new tests covering resource hardening scenarios

## Changes
- **mall-tile-field.js**: Teardown hygiene, visibility handler, error fail-safes (+65 lines)
- **test_video_mall_field_runtime.py**: 13 new tests in `TestPreviewResourceHardening` class
- **ModLog.md**: Phase 1 entry
- **TestModLog.md**: Test entry

## Lifecycle/Resource Safeguards
1. `previewGeneration++` moved to FIRST in `stopInlinePreview()` to invalidate callbacks
2. HTML5 video teardown: clear `onerror`, call `load()`, remove from DOM
3. Page visibility handler: pause preview when tab/page is hidden
4. Invalid URL fail-safe: validate URL before attempting preview
5. YouTube `onError` handler guards against generation
6. HTML5 `onerror` fails quietly without poisoning state
7. Autoplay failure cleanup in `.catch()`

## Test plan
- [x] 154 tests pass (141 existing + 13 new resource hardening)
- [ ] Manual: verify preview stops when switching tabs
- [ ] Manual: verify invalid URLs don't poison state

---
Worker BD — PFMALL_PREVIEW_RESOURCE_HARDENING_PHASE1

🤖 Generated with [Claude Code](https://claude.com/claude-code)