### PR TITLE
feat(pfmall): add lane autoplay and fullscreen foundup entry

### DIFF
--- a/public/member/ModLog.md
+++ b/public/member/ModLog.md
@@ -1,5 +1,49 @@
 # Member Area Module Change Log
 
+## [2026-04-10] Lane Autoplay & Fullscreen FoundUp Entry Phase 1 (Worker BL, WSP 15/97)
+
+**Who**: 0102 — Worker BL
+**Slice**: `YOUTUBE_CHANNEL_LANE_AUTOPLAY_AND_FULLSCREEN_ENTRY_PHASE1`
+**What**: Turn pfMALL channel tiles into real lane browsers with autoplay and explicit fullscreen FoundUp entry.
+
+**Files Modified**:
+- `public/member/js/mall-tile-field.js` — Lane autoplay state, `advanceLaneAutoplay()`, `startLaneVideoAtIndex()`
+- `public/member/js/mall-video-player.js` — Added `handleVideoEnded()`, "Enter FoundUp" button, `enterFoundUp()`
+- `public/member/css/mall-video-player.css` — `.video-player-btn-entry` styling
+- `public/member/tests/test_lane_autoplay_fullscreen_entry.py` — 31 new tests
+
+**Lane Autoplay Behavior**:
+1. **Tap on video-backed tile** → Starts lane autoplay (not single video)
+2. **Auto-advance** → When current video ends, advances to next in lane's `videos[]`
+3. **Queue constraint** → Autoplay stays within the lane, never drifts to other FoundUps
+4. **Loop policy** → At queue end, loops back to first video (`AUTOPLAY_LOOP_POLICY = 'loop'`)
+5. **Mall mode only** → Expanded mode uses legacy single-video preview
+
+**Lane Autoplay State**:
+```javascript
+autoplayLaneIndex = null;    // FoundUp index for current lane
+autoplayVideoIndex = 0;      // Position within lane's videos[]
+AUTOPLAY_LOOP_POLICY = 'loop'; // Queue-end behavior
+```
+
+**Fullscreen "Enter FoundUp" Button**:
+- **Location**: Top bar, between Share and More buttons
+- **Style**: Prominent pill with icon + "Enter FoundUp" label
+- **Routing**: `/member/foundup.html?id={currentFoundUpId}` — stable identity
+- **No PWA launch**: Routes to landing page, not direct PWA
+
+**Fixed Bug**: `handleVideoEnded` was called but never defined in `mall-video-player.js` — now properly advances queue.
+
+**Non-Video Truth**: Non-video tiles (github_repo, external_app, internal_service) retain their quick-view path, no fake autoplay semantics.
+
+**Expanded Mode**: Pinch-out/pinch-in behavior unchanged — expanded inventory view still works.
+
+**WSP 97 Applied**: Autoplay constrained to lane truth, explicit entry surface, stable identity routing.
+
+**Test Count**: 31 new focused tests, all passing.
+
+---
+
 ## [2026-04-10] Explicit FoundUp Entry Trigger Phase 1 (Worker BK, WSP 15/97)
 
 **Who**: 0102 — Worker BK

--- a/public/member/ModLog.md
+++ b/public/member/ModLog.md
@@ -1,5 +1,55 @@
 # Member Area Module Change Log
 
+## [2026-04-10] Explicit FoundUp Entry Trigger Phase 1 (Worker BK, WSP 15/97)
+
+**Who**: 0102 — Worker BK
+**Slice**: `PFMALL_FOUNDUP_ENTRY_TRIGGER_PHASE1`
+**What**: Add explicit truthful entry path to FoundUp landing on all pfMALL tiles.
+
+**Files Modified**:
+- `public/member/js/mall-tile-field.js` — Entry button rendering in `renderTiles()`, click handler in `bindInteractions()`
+- `public/member/css/mall-tile-field.css` — `.mall-tile-entry` button styles, visibility rules
+- `public/member/tests/test_video_mall_field_runtime.py` — 11 new tests for entry trigger behavior
+
+**Entry Trigger Behavior**:
+1. **Button placement**: Bottom-left corner, 24px info icon (circle with i)
+2. **Routing**: Uses stable `data-foundup-id` attribute, calls `mallPlanes.openFoundUpById(foundupId)`
+3. **Tap guard**: Respects `tapGuardActive` to prevent accidental activation during drag
+4. **Event isolation**: `e.stopPropagation()` prevents tile tap handler interference
+
+**Visual Treatment**:
+- **Default**: Hidden (not polluting browse wall)
+- **Hover**: Visible on `.mall-tile:hover`
+- **Focus**: Visible on `.mall-tile:focus-within` and `.mall-tile-entry:focus-visible`
+- **Preview**: Visible when `.inline-preview-active`
+- **Touch**: Always visible on `@media (hover: none)` for touch-only devices
+
+**CSS Styles**:
+```css
+.mall-tile-entry {
+  position: absolute;
+  bottom: 4px;
+  left: 4px;
+  width: 24px;
+  height: 24px;
+  background: rgba(0, 0, 0, 0.6);
+  border-radius: 4px;
+  opacity: 0;
+  transition: opacity 0.15s, background 0.15s;
+}
+.mall-tile-entry:hover { background: rgba(0, 212, 170, 0.8); }
+```
+
+**Stable Identity Routing**: Entry button queries `tile.dataset.foundupId` (not raw index), ensuring correct routing survives projection/filter changes.
+
+**No PWA Direct Launch**: Entry trigger does NOT launch PWA directly — routes through `mallPlanes.openFoundUpById()` for truthful handoff.
+
+**WSP 97 Applied**: Minimal surface addition — one button, stable identity, existing API handoff.
+
+**Test Count**: 170 passed (159 existing + 11 new entry trigger tests)
+
+---
+
 ## [2026-04-10] Portrait-First Video Wall Layout Phase 1 (Worker BJ, WSP 15/97)
 
 **Who**: 0102 — Worker BJ

--- a/public/member/css/mall-tile-field.css
+++ b/public/member/css/mall-tile-field.css
@@ -539,7 +539,8 @@
 /* Touch devices: always show controls (no hover) */
 @media (hover: none) {
   .mall-tile-expand,
-  .mall-tile-audio {
+  .mall-tile-audio,
+  .mall-tile-entry {
     opacity: 1;
   }
 
@@ -586,9 +587,50 @@
   background: rgba(124, 92, 252, 0.8);
 }
 
+/* ─── Entry Button (FoundUp Landing Entry on Tile) ─── */
+.mall-tile-entry {
+  position: absolute;
+  bottom: 4px;
+  left: 4px;
+  width: 24px;
+  height: 24px;
+  background: rgba(0, 0, 0, 0.6);
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 150ms ease, background 150ms ease;
+  z-index: 10;
+}
+
+.mall-tile-entry svg {
+  width: 14px;
+  height: 14px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.mall-tile:hover .mall-tile-entry,
+.mall-tile:focus-within .mall-tile-entry,
+.mall-tile.is-previewing .mall-tile-entry {
+  opacity: 1;
+}
+
+.mall-tile-entry:hover {
+  background: rgba(0, 212, 170, 0.8);
+}
+
 /* Focus states for control buttons (keyboard accessibility) */
 .mall-tile-audio:focus-visible,
-.mall-tile-expand:focus-visible {
+.mall-tile-expand:focus-visible,
+.mall-tile-entry:focus-visible {
   opacity: 1;
   outline: 2px solid rgba(141, 113, 255, 0.8);
   outline-offset: 2px;

--- a/public/member/css/mall-video-player.css
+++ b/public/member/css/mall-video-player.css
@@ -107,6 +107,33 @@
   stroke: #7c5cfc;
 }
 
+/* Enter FoundUp button — prominent entry action */
+.video-player-btn-entry {
+  width: auto;
+  padding: 0 0.75rem;
+  border-radius: 20px;
+  gap: 0.4rem;
+  background: rgba(124, 92, 252, 0.3);
+  border: 1px solid rgba(124, 92, 252, 0.5);
+}
+
+.video-player-btn-entry:hover {
+  background: rgba(124, 92, 252, 0.5);
+}
+
+.video-player-btn-entry svg {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.video-player-btn-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
 .video-player-title {
   color: #fff;
   font-size: 0.9rem;

--- a/public/member/js/mall-tile-field.js
+++ b/public/member/js/mall-tile-field.js
@@ -507,6 +507,10 @@
       // Corner expand button for explicit fullscreen entry — video tiles only
       var expandBtn = hasVideos ? '<button class="mall-tile-expand" aria-label="Open fullscreen" title="Fullscreen">&#9654;</button>' : '';
 
+      // FoundUp entry button (bottom-left) — all tiles, explicit entry path
+      var entryBtnSvg = '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>';
+      var entryBtn = '<button class="mall-tile-entry" aria-label="About ' + escapeAttr(item.name || item.title || 'this FoundUp') + '" title="About">' + entryBtnSvg + '</button>';
+
       // Inline preview container (YouTube iframe or HTML5 video goes here) — video tiles only
       var previewContainer = hasVideos ? '<div class="mall-tile-preview"><div class="mall-tile-preview-stage"></div></div>' : '';
 
@@ -534,6 +538,7 @@
         playIndicator +
         audioBtn +
         expandBtn +
+        entryBtn +
         '<div class="mall-tile-inner">' +
           '<span class="mall-tile-token">' + escapeHtml(item.token_symbol || '') + '</span>' +
           '<span class="mall-tile-hero">' + escapeHtml(item.hero_label || '') + '</span>' +
@@ -657,6 +662,21 @@
           togglePreviewMute();
         } else {
           startInlinePreview(index, true);
+        }
+      });
+    });
+
+    // Entry buttons — explicit FoundUp landing entry using stable identity
+    var entryBtns = tileField.querySelectorAll('.mall-tile-entry');
+    entryBtns.forEach(function(btn) {
+      btn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        if (tapGuardActive) return;
+        var tile = btn.closest('.mall-tile');
+        if (!tile) return;
+        var foundupId = tile.dataset.foundupId;
+        if (foundupId && window.mallPlanes && typeof window.mallPlanes.openFoundUpById === 'function') {
+          window.mallPlanes.openFoundUpById(foundupId);
         }
       });
     });

--- a/public/member/js/mall-tile-field.js
+++ b/public/member/js/mall-tile-field.js
@@ -69,6 +69,11 @@
   var previewGeneration = 0;       // Guard against stale callbacks
   var tapGuardActive = false;      // Prevent double-fire on audio button tap
 
+  // Lane autoplay state
+  var autoplayLaneIndex = null;    // FoundUp index for current lane autoplay (Mall mode only)
+  var autoplayVideoIndex = 0;      // Current video index within lane's videos[] array
+  var AUTOPLAY_LOOP_POLICY = 'loop'; // 'loop' = restart at 0, 'stop' = halt on last
+
   // ========== YouTube IFrame API Helpers ==========
 
   function ensureYouTubeAPI() {
@@ -175,6 +180,9 @@
     applyTilePreviewState(null, null);
     playingIndex = null;
     previewPaused = false;
+    // Clear lane autoplay state
+    autoplayLaneIndex = null;
+    autoplayVideoIndex = 0;
   }
 
   function pauseInlinePreview() {
@@ -257,7 +265,7 @@
       video.className = 'mall-tile-preview-media';
       video.muted = previewMuted;
       video.autoplay = true;
-      video.loop = true;
+      video.loop = false; // No loop — lane autoplay handles advancement
       video.playsInline = true;
       video.setAttribute('playsinline', '');
       // Error handler: fail quietly without poisoning state
@@ -265,12 +273,155 @@
         if (gen !== previewGeneration) return;
         stopInlinePreview();
       };
+      // Lane autoplay: advance to next video when current ends
+      video.onended = function() {
+        if (gen !== previewGeneration) return;
+        advanceLaneAutoplay();
+      };
       stage.innerHTML = '';
       stage.appendChild(video);
       inlineHTML5Video = video;
       video.src = videoUrl;
       video.play().catch(function() {
         // Autoplay may be blocked — fail quietly, stop preview state
+        if (gen !== previewGeneration) return;
+        stopInlinePreview();
+      });
+    }
+  }
+
+  /**
+   * Advance lane autoplay to next video in the lane's queue.
+   * Called when inline preview video ends.
+   */
+  function advanceLaneAutoplay() {
+    // Only advance in Mall mode (not expanded mode)
+    if (expandedFoundUp !== null) return;
+    if (autoplayLaneIndex === null) return;
+
+    var lane = mallCatalog[autoplayLaneIndex];
+    if (!lane || !lane.videos || !lane.videos.length) {
+      stopInlinePreview();
+      return;
+    }
+
+    var nextVideoIdx = autoplayVideoIndex + 1;
+
+    // Queue end policy
+    if (nextVideoIdx >= lane.videos.length) {
+      if (AUTOPLAY_LOOP_POLICY === 'loop') {
+        nextVideoIdx = 0;
+      } else {
+        // 'stop' policy: halt on last video
+        stopInlinePreview();
+        return;
+      }
+    }
+
+    autoplayVideoIndex = nextVideoIdx;
+    startLaneVideoAtIndex(autoplayLaneIndex, nextVideoIdx);
+  }
+
+  /**
+   * Start inline preview for a specific video within a lane.
+   * @param {number} laneIndex - Index of the FoundUp in mallCatalog
+   * @param {number} videoIdx - Index within the lane's videos[] array
+   */
+  function startLaneVideoAtIndex(laneIndex, videoIdx) {
+    var lane = mallCatalog[laneIndex];
+    if (!lane || !lane.videos || !lane.videos[videoIdx]) return;
+
+    var video = lane.videos[videoIdx];
+    var tile = getTileElement(laneIndex);
+    if (!tile) return;
+    var stage = tile.querySelector('.mall-tile-preview-stage');
+    if (!stage) return;
+
+    // Update playing state (tile index stays the same, it's the lane)
+    playingIndex = laneIndex;
+    previewPaused = false;
+    previewGeneration++;
+    var gen = previewGeneration;
+
+    applyTilePreviewState(laneIndex, { previewing: true, paused: false, muted: previewMuted });
+
+    var videoUrl = video.embed_url || video.embedUrl || video.source_url || video.sourceUrl || '';
+    if (!videoUrl || typeof videoUrl !== 'string' || videoUrl.length < 5) {
+      stopInlinePreview();
+      return;
+    }
+
+    var ytId = extractYouTubeVideoId(videoUrl);
+
+    if (ytId) {
+      ensureYouTubeAPI().then(function() {
+        if (gen !== previewGeneration) return;
+        destroyInlineYTPlayer();
+        var hostDiv = document.createElement('div');
+        hostDiv.className = 'mall-tile-preview-host';
+        hostDiv.id = 'yt-preview-' + laneIndex + '-' + gen;
+        stage.innerHTML = '';
+        stage.appendChild(hostDiv);
+        inlineYTPlayer = new YT.Player(hostDiv.id, {
+          videoId: ytId,
+          playerVars: {
+            autoplay: 1, mute: previewMuted ? 1 : 0, controls: 0, modestbranding: 1,
+            rel: 0, playsinline: 1, loop: 0
+          },
+          events: {
+            onReady: function(event) {
+              if (gen !== previewGeneration) return;
+              if (previewMuted) event.target.mute();
+              else event.target.unMute();
+              event.target.playVideo();
+            },
+            onStateChange: function(event) {
+              if (gen !== previewGeneration) return;
+              // YT.PlayerState.ENDED = 0
+              if (event.data === 0) {
+                advanceLaneAutoplay();
+              }
+            },
+            onError: function() {
+              if (gen !== previewGeneration) return;
+              stopInlinePreview();
+            }
+          }
+        });
+      });
+    } else {
+      // HTML5 video
+      destroyInlineYTPlayer();
+      if (inlineHTML5Video) {
+        inlineHTML5Video.onerror = null;
+        inlineHTML5Video.onended = null;
+        inlineHTML5Video.pause();
+        inlineHTML5Video.src = '';
+        try { inlineHTML5Video.load(); } catch (e) {}
+        if (inlineHTML5Video.parentNode) inlineHTML5Video.parentNode.removeChild(inlineHTML5Video);
+        inlineHTML5Video = null;
+      }
+
+      var vid = document.createElement('video');
+      vid.className = 'mall-tile-preview-media';
+      vid.muted = previewMuted;
+      vid.autoplay = true;
+      vid.loop = false;
+      vid.playsInline = true;
+      vid.setAttribute('playsinline', '');
+      vid.onerror = function() {
+        if (gen !== previewGeneration) return;
+        stopInlinePreview();
+      };
+      vid.onended = function() {
+        if (gen !== previewGeneration) return;
+        advanceLaneAutoplay();
+      };
+      stage.innerHTML = '';
+      stage.appendChild(vid);
+      inlineHTML5Video = vid;
+      vid.src = videoUrl;
+      vid.play().catch(function() {
         if (gen !== previewGeneration) return;
         stopInlinePreview();
       });
@@ -729,7 +880,18 @@
       else pauseInlinePreview();
       return;
     }
-    startInlinePreview(index, false);
+
+    // Initialize lane autoplay state (Mall mode only)
+    if (expandedFoundUp === null && item.videos && item.videos.length) {
+      autoplayLaneIndex = index;
+      autoplayVideoIndex = 0;
+      startLaneVideoAtIndex(index, 0);
+    } else {
+      // Expanded mode or single video: use legacy single-video preview
+      autoplayLaneIndex = null;
+      autoplayVideoIndex = 0;
+      startInlinePreview(index, false);
+    }
   }
 
   /**

--- a/public/member/js/mall-video-player.js
+++ b/public/member/js/mall-video-player.js
@@ -161,6 +161,10 @@
       '    <button class="video-player-btn" data-action="share" aria-label="Share">',
       '      <svg viewBox="0 0 24 24"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><path d="M8.59 13.51l6.83 3.98M15.41 6.51l-6.82 3.98"/></svg>',
       '    </button>',
+      '    <button class="video-player-btn video-player-btn-entry" data-action="enter" aria-label="Enter FoundUp">',
+      '      <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>',
+      '      <span class="video-player-btn-label">Enter FoundUp</span>',
+      '    </button>',
       '    <button class="video-player-btn" data-action="more" aria-label="More options">',
       '      <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>',
       '    </button>',
@@ -297,6 +301,19 @@
     if (currentIndex > 0) {
       goToVideo(currentIndex - 1);
       showHint('Previous');
+    }
+  }
+
+  /**
+   * Handle video ended event — auto-advance to next in queue.
+   * Called by YouTube onStateChange(ENDED) and HTML5 video 'ended' event.
+   */
+  function handleVideoEnded() {
+    if (currentIndex < currentQueue.length - 1) {
+      goToVideo(currentIndex + 1);
+    } else {
+      // End of queue: loop back to start (consistent with lane autoplay policy)
+      goToVideo(0);
     }
   }
 
@@ -534,7 +551,23 @@
       case 'more':
         showHint('More options');
         break;
+      case 'enter':
+        enterFoundUp();
+        break;
     }
+  }
+
+  /**
+   * Navigate to the FoundUp landing page using stable identity.
+   */
+  function enterFoundUp() {
+    if (!currentFoundUpId) {
+      showHint('No FoundUp');
+      return;
+    }
+    // Navigate to FoundUp entry page using stable foundup_id
+    var entryUrl = '/member/foundup.html?id=' + encodeURIComponent(currentFoundUpId);
+    window.location.href = entryUrl;
   }
 
   function handleRailClick(e) {

--- a/public/member/tests/TestModLog.md
+++ b/public/member/tests/TestModLog.md
@@ -4,6 +4,36 @@ Test evolution log for the p.fMALL member shell test suite.
 
 ---
 
+## 2026-04-10 | Lane Autoplay & Fullscreen Entry Tests (WSP 15/97)
+
+**File**: `test_lane_autoplay_fullscreen_entry.py` (new)
+**Tests**: 31 | **Classes**: 10 | **Result**: 31 passed
+**Worker**: BL
+
+Validates channel lane autoplay and fullscreen FoundUp entry:
+
+| Test Class | Tests | What it covers |
+|------------|-------|----------------|
+| TestLaneAutoplayState | 3 | `autoplayLaneIndex`, `autoplayVideoIndex`, `AUTOPLAY_LOOP_POLICY` vars |
+| TestLaneAutoplayBehavior | 5 | `advanceLaneAutoplay()`, `startLaneVideoAtIndex()`, ended handlers |
+| TestLaneAutoplayQueueConstraint | 3 | Mall mode only, checks `lane.videos`, stops if no videos |
+| TestTogglePlayLaneInit | 3 | `togglePlay` sets lane index, video index 0, calls `startLaneVideoAtIndex` |
+| TestStopInlinePreviewClearsLane | 2 | `stopInlinePreview` resets lane state |
+| TestFullscreenEnterFoundUp | 5 | Enter button, action handler, `enterFoundUp()`, stable routing |
+| TestFullscreenEnterFoundUpCSS | 2 | `.video-player-btn-entry`, `.video-player-btn-label` styles |
+| TestFullscreenVideoEnded | 3 | `handleVideoEnded()` exists, advances queue, loops at end |
+| TestNonVideoTruth | 2 | Non-video opens quick-view, `hasVideos` check |
+| TestExpandedModeUnaffected | 3 | Expanded mode class, pinch-out/pinch-in still work |
+
+**Key implementation verified**:
+- Lane autoplay advances through `videos[]` array, constrained to single lane
+- Loop policy resets to video 0 at queue end
+- Fullscreen "Enter FoundUp" button uses stable `currentFoundUpId`
+- Non-video tiles retain truthful quick-view path
+- `handleVideoEnded()` now defined (was missing, caused runtime error)
+
+---
+
 ## 2026-04-10 | FoundUp Entry Trigger Tests (WSP 15/97)
 
 **File**: `test_video_mall_field_runtime.py` (extended)

--- a/public/member/tests/TestModLog.md
+++ b/public/member/tests/TestModLog.md
@@ -4,6 +4,36 @@ Test evolution log for the p.fMALL member shell test suite.
 
 ---
 
+## 2026-04-10 | FoundUp Entry Trigger Tests (WSP 15/97)
+
+**File**: `test_video_mall_field_runtime.py` (extended)
+**Tests**: 11 new | **Class**: `TestFoundUpEntryTrigger` | **Result**: 170 passed total
+**Worker**: BK
+
+Validates explicit FoundUp entry trigger on all pfMALL tiles:
+
+| Test | What it covers |
+|------|----------------|
+| test_entry_button_rendered | `.mall-tile-entry` button exists in tile markup |
+| test_entry_button_svg_icon | Info icon SVG (circle + i paths) |
+| test_entry_button_aria_label | Accessible label "About {name}" |
+| test_entry_button_click_handler | Click handler bound in `bindInteractions()` |
+| test_entry_uses_stable_foundup_id | Queries `tile.dataset.foundupId`, not raw index |
+| test_entry_calls_open_foundup_by_id | Calls `mallPlanes.openFoundUpById(foundupId)` |
+| test_entry_stops_propagation | `e.stopPropagation()` prevents tile tap |
+| test_entry_respects_tap_guard | Checks `tapGuardActive` before routing |
+| test_entry_visible_on_hover | CSS shows button on `.mall-tile:hover` |
+| test_entry_visible_on_touch_devices | `@media (hover: none)` always-visible rule |
+| test_no_pwa_direct_launch | No `navigator.standalone` or `window.open` in handler |
+
+**Key implementation verified**:
+- Stable identity routing via `data-foundup-id` (survives projection/filter changes)
+- Visual restraint: button hidden by default, visible on hover/focus/preview/touch
+- Tap guard integration prevents accidental activation during drag-to-scroll
+- No PWA direct launch — routes through existing `mallPlanes.openFoundUpById()` API
+
+---
+
 ## 2026-04-10 | Portrait Tile Geometry Tests (WSP 15/97)
 
 **File**: `test_video_mall_field_runtime.py` (extended)

--- a/public/member/tests/test_lane_autoplay_fullscreen_entry.py
+++ b/public/member/tests/test_lane_autoplay_fullscreen_entry.py
@@ -1,0 +1,230 @@
+"""
+Lane Autoplay & Fullscreen Entry Tests
+
+Tests for:
+  - Tap starts lane autoplay (video-backed tiles in Mall mode)
+  - Lane autoplay stays inside the lane's videos[] queue
+  - Autoplay policy: loop to start when queue ends
+  - Pinch-out expanded behavior remains intact
+  - Fullscreen exposes "Enter FoundUp" button
+  - FoundUp entry uses stable identity (foundup_id)
+  - Non-video tiles remain truthful (no fake autoplay)
+"""
+import os
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _read(relpath):
+    with open(os.path.join(ROOT, relpath), encoding="utf-8") as f:
+        return f.read()
+
+
+class TestLaneAutoplayState:
+    """Test lane autoplay state management."""
+
+    def test_autoplay_lane_index_var_exists(self):
+        """autoplayLaneIndex variable tracks current lane."""
+        js = _read("js/mall-tile-field.js")
+        assert "autoplayLaneIndex" in js
+
+    def test_autoplay_video_index_var_exists(self):
+        """autoplayVideoIndex tracks position in lane queue."""
+        js = _read("js/mall-tile-field.js")
+        assert "autoplayVideoIndex" in js
+
+    def test_autoplay_loop_policy_defined(self):
+        """AUTOPLAY_LOOP_POLICY defines queue-end behavior."""
+        js = _read("js/mall-tile-field.js")
+        assert "AUTOPLAY_LOOP_POLICY" in js
+        assert "'loop'" in js  # Loop policy chosen
+
+
+class TestLaneAutoplayBehavior:
+    """Test lane autoplay advancement logic."""
+
+    def test_advance_lane_autoplay_function_exists(self):
+        """advanceLaneAutoplay function handles video ended event."""
+        js = _read("js/mall-tile-field.js")
+        assert "function advanceLaneAutoplay()" in js
+
+    def test_start_lane_video_at_index_exists(self):
+        """startLaneVideoAtIndex plays specific video in lane."""
+        js = _read("js/mall-tile-field.js")
+        assert "function startLaneVideoAtIndex(" in js
+
+    def test_html5_video_ended_calls_advance(self):
+        """HTML5 video ended event triggers advanceLaneAutoplay."""
+        js = _read("js/mall-tile-field.js")
+        # Both inline preview and lane preview should have ended handler
+        assert "video.onended" in js or "vid.onended" in js
+        assert "advanceLaneAutoplay()" in js
+
+    def test_youtube_ended_calls_advance(self):
+        """YouTube player ended state triggers advanceLaneAutoplay."""
+        js = _read("js/mall-tile-field.js")
+        # YT.PlayerState.ENDED = 0
+        assert "event.data === 0" in js
+        assert "advanceLaneAutoplay()" in js
+
+    def test_loop_policy_resets_to_zero(self):
+        """Loop policy resets autoplayVideoIndex to 0 at queue end."""
+        js = _read("js/mall-tile-field.js")
+        assert "nextVideoIdx = 0" in js
+
+
+class TestLaneAutoplayQueueConstraint:
+    """Test that autoplay stays within the lane queue."""
+
+    def test_only_advances_in_mall_mode(self):
+        """Autoplay only advances when expandedFoundUp is null."""
+        js = _read("js/mall-tile-field.js")
+        assert "if (expandedFoundUp !== null) return" in js
+
+    def test_checks_lane_videos_array(self):
+        """Autoplay checks lane.videos exists before advancing."""
+        js = _read("js/mall-tile-field.js")
+        assert "!lane.videos" in js
+
+    def test_stops_if_no_videos(self):
+        """Stops preview if lane has no videos."""
+        js = _read("js/mall-tile-field.js")
+        # Should call stopInlinePreview when no videos
+        assert "stopInlinePreview()" in js
+
+
+class TestTogglePlayLaneInit:
+    """Test togglePlay initializes lane autoplay correctly."""
+
+    def test_toggle_play_sets_autoplay_lane_index(self):
+        """togglePlay sets autoplayLaneIndex for video-backed tiles."""
+        js = _read("js/mall-tile-field.js")
+        assert "autoplayLaneIndex = index" in js
+
+    def test_toggle_play_sets_video_index_zero(self):
+        """togglePlay starts at video index 0."""
+        js = _read("js/mall-tile-field.js")
+        assert "autoplayVideoIndex = 0" in js
+
+    def test_toggle_play_calls_start_lane_video(self):
+        """togglePlay calls startLaneVideoAtIndex for lane autoplay."""
+        js = _read("js/mall-tile-field.js")
+        assert "startLaneVideoAtIndex(index, 0)" in js
+
+
+class TestStopInlinePreviewClearsLane:
+    """Test stopInlinePreview clears lane state."""
+
+    def test_stop_clears_autoplay_lane_index(self):
+        """stopInlinePreview resets autoplayLaneIndex to null."""
+        js = _read("js/mall-tile-field.js")
+        assert "autoplayLaneIndex = null" in js
+
+    def test_stop_clears_autoplay_video_index(self):
+        """stopInlinePreview resets autoplayVideoIndex to 0."""
+        js = _read("js/mall-tile-field.js")
+        # Should reset to 0 in stopInlinePreview
+        assert "autoplayVideoIndex = 0" in js
+
+
+class TestFullscreenEnterFoundUp:
+    """Test fullscreen player Enter FoundUp button."""
+
+    def test_enter_button_in_top_bar(self):
+        """Enter FoundUp button exists in fullscreen top bar."""
+        js = _read("js/mall-video-player.js")
+        assert 'data-action="enter"' in js
+        assert "Enter FoundUp" in js
+
+    def test_enter_action_handler_exists(self):
+        """handleTopBarClick handles 'enter' action."""
+        js = _read("js/mall-video-player.js")
+        assert "case 'enter':" in js
+        assert "enterFoundUp()" in js
+
+    def test_enter_foundup_function_exists(self):
+        """enterFoundUp function navigates to FoundUp page."""
+        js = _read("js/mall-video-player.js")
+        assert "function enterFoundUp()" in js
+
+    def test_uses_stable_foundup_id(self):
+        """Entry URL uses currentFoundUpId (stable identity)."""
+        js = _read("js/mall-video-player.js")
+        assert "currentFoundUpId" in js
+        assert "encodeURIComponent(currentFoundUpId)" in js
+
+    def test_navigates_to_foundup_html(self):
+        """Navigates to /member/foundup.html with id param."""
+        js = _read("js/mall-video-player.js")
+        assert "/member/foundup.html?id=" in js
+
+
+class TestFullscreenEnterFoundUpCSS:
+    """Test Enter FoundUp button styling."""
+
+    def test_entry_button_class_exists(self):
+        """Entry button has dedicated CSS class."""
+        css = _read("css/mall-video-player.css")
+        assert ".video-player-btn-entry" in css
+
+    def test_entry_button_has_label(self):
+        """Entry button has visible label."""
+        css = _read("css/mall-video-player.css")
+        assert ".video-player-btn-label" in css
+
+
+class TestFullscreenVideoEnded:
+    """Test fullscreen player video ended handler."""
+
+    def test_handle_video_ended_exists(self):
+        """handleVideoEnded function is defined."""
+        js = _read("js/mall-video-player.js")
+        assert "function handleVideoEnded()" in js
+
+    def test_handle_video_ended_advances_queue(self):
+        """handleVideoEnded calls goToVideo to advance."""
+        js = _read("js/mall-video-player.js")
+        # Check it advances to next video
+        assert "goToVideo(currentIndex + 1)" in js
+
+    def test_handle_video_ended_loops_at_end(self):
+        """handleVideoEnded loops to start at queue end."""
+        js = _read("js/mall-video-player.js")
+        assert "goToVideo(0)" in js
+
+
+class TestNonVideoTruth:
+    """Test non-video tiles retain truthful behavior."""
+
+    def test_non_video_opens_quickview(self):
+        """Non-video tiles open quick-view, not fake autoplay."""
+        js = _read("js/mall-tile-field.js")
+        # Non-video tiles should use openFoundUpById
+        assert "openFoundUpById(foundupId)" in js
+
+    def test_non_video_check_before_autoplay(self):
+        """hasVideos check prevents non-video autoplay."""
+        js = _read("js/mall-tile-field.js")
+        assert "if (!hasVideos)" in js
+
+
+class TestExpandedModeUnaffected:
+    """Test pinch-out expanded mode remains intact."""
+
+    def test_expanded_mode_class_toggle(self):
+        """Expanded mode class still toggles correctly."""
+        js = _read("js/mall-tile-field.js")
+        assert "expandedFoundUp !== null" in js
+        assert "expanded-mode" in js
+
+    def test_pinch_out_expand_still_works(self):
+        """Pinch-out gesture still expands to video field."""
+        js = _read("js/mall-tile-field.js")
+        assert "onPinchOut:" in js
+        assert "expandFoundUp(index)" in js
+
+    def test_pinch_in_collapse_still_works(self):
+        """Pinch-in gesture still collapses back to Mall."""
+        js = _read("js/mall-tile-field.js")
+        assert "onPinchIn:" in js
+        assert "collapseFoundUp()" in js

--- a/public/member/tests/test_video_mall_field_runtime.py
+++ b/public/member/tests/test_video_mall_field_runtime.py
@@ -1003,3 +1003,84 @@ class TestPreviewResourceHardening:
         js = _read("js/mall-tile-field.js")
         assert "visibilityBound" in js
         assert "if (visibilityBound) return" in js
+
+
+class TestFoundUpEntryTrigger:
+    """Test explicit FoundUp entry trigger on tiles."""
+
+    def test_entry_button_rendered_on_tiles(self):
+        """Entry button is rendered in tile HTML."""
+        js = _read("js/mall-tile-field.js")
+        assert "mall-tile-entry" in js
+        assert "entryBtn" in js
+
+    def test_entry_button_has_aria_label(self):
+        """Entry button has aria-label for accessibility."""
+        js = _read("js/mall-tile-field.js")
+        assert 'aria-label="About ' in js
+
+    def test_entry_button_uses_stable_identity(self):
+        """Entry button uses foundup_id from data attribute, not raw index."""
+        js = _read("js/mall-tile-field.js")
+        # Handler should get foundupId from tile dataset, not index
+        assert "tile.dataset.foundupId" in js
+        assert "openFoundUpById(foundupId)" in js
+
+    def test_entry_button_stops_propagation(self):
+        """Entry button click stops propagation to prevent tile tap."""
+        js = _read("js/mall-tile-field.js")
+        # Find entry button handler and verify stopPropagation
+        idx_entry = js.index("entryBtns.forEach")
+        idx_stop = js.index("e.stopPropagation()", idx_entry)
+        assert idx_stop - idx_entry < 200
+
+    def test_entry_button_css_exists(self):
+        """Entry button has CSS styling."""
+        css = _read("css/mall-tile-field.css")
+        assert ".mall-tile-entry" in css
+        assert "bottom: 4px" in css
+        assert "left: 4px" in css
+
+    def test_entry_button_visible_on_hover(self):
+        """Entry button becomes visible on tile hover."""
+        css = _read("css/mall-tile-field.css")
+        assert ".mall-tile:hover .mall-tile-entry" in css
+
+    def test_entry_button_visible_on_preview(self):
+        """Entry button visible when tile is previewing."""
+        css = _read("css/mall-tile-field.css")
+        assert ".mall-tile.is-previewing .mall-tile-entry" in css
+
+    def test_entry_button_focus_visible(self):
+        """Entry button has focus-visible styling."""
+        css = _read("css/mall-tile-field.css")
+        assert ".mall-tile-entry:focus-visible" in css
+
+    def test_entry_button_touch_visible(self):
+        """Entry button always visible on touch devices."""
+        css = _read("css/mall-tile-field.css")
+        # Check touch media query includes entry button
+        idx_touch = css.index("@media (hover: none)")
+        idx_end = css.index("}", idx_touch + 20)
+        touch_block = css[idx_touch:idx_end]
+        assert ".mall-tile-entry" in touch_block
+
+    def test_video_tap_semantics_unchanged(self):
+        """Video tile tap still triggers preview, not entry."""
+        js = _read("js/mall-tile-field.js")
+        # togglePlay should still be called on single tap
+        assert "togglePlay(index)" in js
+        # and togglePlay starts preview for video tiles
+        assert "startInlinePreview(index" in js
+
+    def test_no_direct_pwa_launch(self):
+        """Entry does not launch PWA directly from wall."""
+        js = _read("js/mall-tile-field.js")
+        # Entry button handler should use mallPlanes, not direct PWA launch
+        idx_entry = js.index("entryBtns.forEach")
+        idx_end = js.index("});", idx_entry + 50)
+        entry_handler = js[idx_entry:idx_end]
+        assert "mallPlanes.openFoundUpById" in entry_handler
+        # Should NOT have direct window.open or location navigation
+        assert "window.open" not in entry_handler
+        assert "location.href" not in entry_handler


### PR DESCRIPTION
## Summary

- **Lane autoplay**: Tap on video-backed tile starts autoplay through that lane's `videos[]` queue (not single video)
- **Auto-advance**: When current video ends, advances to next in lane; loops to start at queue end
- **Fullscreen "Enter FoundUp"**: Prominent button in fullscreen top bar navigates to `/member/foundup.html?id={foundupId}`
- **Fixed bug**: `handleVideoEnded` was called but never defined in `mall-video-player.js`
- **Stable routing**: Entry uses `currentFoundUpId` (not raw index), survives projection/filter changes
- **Non-video truth**: Non-video tiles retain quick-view path, no fake autoplay semantics

## Autoplay Policy

**Chosen policy**: Loop to start (`AUTOPLAY_LOOP_POLICY = 'loop'`)

When lane queue ends, autoplay resets to video index 0 and continues. This matches TikTok/Shorts behavior.

## Fullscreen Entry Behavior

- **Button location**: Top bar, between Share and More buttons
- **Style**: Pill button with info icon + "Enter FoundUp" label
- **Action**: `window.location.href = '/member/foundup.html?id=' + encodeURIComponent(currentFoundUpId)`

## Test plan

- [x] 31 focused tests in `test_lane_autoplay_fullscreen_entry.py`
- [x] Lane autoplay state management tests
- [x] Auto-advance behavior tests
- [x] Queue constraint tests (stays in lane)
- [x] Fullscreen entry button tests
- [x] Non-video truth tests
- [x] Expanded mode unaffected tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)