### PR TITLE
feat(pfmall): lane autoplay and Enter FoundUp button (BL)

### DIFF
--- a/modules/foundups/docs/PFMALL_FOUNDUP_ENTRY_AND_STAKE_GATE_CONTRACT.md
+++ b/modules/foundups/docs/PFMALL_FOUNDUP_ENTRY_AND_STAKE_GATE_CONTRACT.md
@@ -24,33 +24,37 @@ This is the **target architecture**. Current runtime (`foundup.html`) is a trans
 
 ## 2. Entry Gestures
 
-### 2.1 Primary Gesture: Double-Tap / Double-Click
+### 2.1 Primary Gesture: Tap for Lane Autoplay
 
 | Context | Gesture | Result |
 |---------|---------|--------|
-| Mall tile (video playing) | double-tap | Enter FoundUp Welcome |
-| Mall tile (video paused) | double-tap | Play video (first tap = play, second = enter) |
-| Mall tile (desktop) | double-click | Enter FoundUp Welcome |
+| Mall tile | tap | Start lane autoplay through FoundUp's video queue |
+| Lane playing | video ends | Auto-advance to next video (Shorts-style) |
+| Queue end | auto | Loop to start (continuous play) |
 
-**Rationale**: Single-tap controls playback; double-tap signals entry intent.
+**Rationale**: Tap starts video consumption; explicit button signals entry intent. This aligns with Shorts-style UX where content plays continuously.
 
-### 2.2 Visible Fallback: Entry Control
+### 2.2 Explicit Entry: Enter FoundUp Button
 
-A visible button/control on the tile provides explicit entry for:
-- Users unfamiliar with gesture grammar
-- Accessibility (screen readers, switch access)
-- Touch devices where double-tap is unreliable
+A visible "Enter FoundUp" button provides explicit entry:
+- On tile: bottom-left corner, visible during preview
+- In fullscreen: top bar alongside back/share/save controls
+- Routes to `/f/{foundup_id}` (WSP 104 canonical)
 
-Placement: corner overlay on tile (e.g., expand icon or "Enter" label).
+This is the **primary entry mechanism** (not a fallback):
+- Clear user intent (no accidental entry)
+- Accessibility (screen readers, switch access, keyboard Enter)
+- Consistent across tile and fullscreen contexts
 
 ### 2.3 Entry from Fullscreen Player
 
-| Context | Gesture | Result |
+| Context | Control | Result |
 |---------|---------|--------|
+| Fullscreen player | Enter FoundUp button (top bar) | Navigate to `/f/{foundup_id}` |
 | Fullscreen player | swipe-down | Exit to Mall |
-| Fullscreen player | tap "info" or "more" | Show FoundUp info sheet with "Enter FoundUp" action |
+| Fullscreen player | pinch-in | Exit to Mall |
 
-The fullscreen player is a video consumption layer, not an entry surface. Entry requires explicit action from the info sheet.
+The fullscreen player now has explicit entry via the Enter FoundUp button in the top bar, alongside back/share/save controls.
 
 ---
 
@@ -61,7 +65,7 @@ The entry flow progresses through distinct surfaces:
 ```
 Mall Discovery
     │
-    ▼ (double-tap / entry control)
+    ▼ (Enter FoundUp button)
 FoundUp Welcome
     │
     ▼ (public entry → Discord/community)
@@ -88,7 +92,7 @@ Stakeholder Interior
 
 ### 3.2 FoundUp Welcome
 
-**What it is**: The landing surface after entry intent (double-tap or entry control).
+**What it is**: The landing surface after entry intent (Enter FoundUp button on tile or fullscreen).
 
 **Current implementation**: `public/member/foundup.html?id={foundup_id}` — transitional shell-owned surface.
 

--- a/modules/foundups/docs/PFMALL_MALL_NAVIGATION_CONTRACT.md
+++ b/modules/foundups/docs/PFMALL_MALL_NAVIGATION_CONTRACT.md
@@ -94,8 +94,8 @@ X axis = category / cluster / similarity band
 | Gesture | Mall Action | Status |
 |---------|-------------|--------|
 | swipe | Navigate: snapped field motion (default) or glide (override) | RUNTIME |
-| tap tile | Play/pause video in Mall context | RUNTIME |
-| double-tap tile | Enter FoundUp | RUNTIME |
+| tap tile | Start lane autoplay through FoundUp's video queue (Shorts-style) | RUNTIME |
+| Enter button | Navigate to `/f/{foundup_id}` (WSP 104 canonical) | RUNTIME |
 | pinch-out tile | Expand FoundUp into its video field | RUNTIME |
 | pinch-in (expanded) | Collapse back to Mall | RUNTIME |
 | long-press | Reserved (future: quick actions) | RESERVED |
@@ -198,7 +198,7 @@ If user swipes down, they always move toward "nearer/more relevant" in the curre
 |--------|---------|--------|
 | Open account | Swipe-down from top | User identity access |
 | Open concierge | Tap Red Dog | Help/recovery path |
-| Enter FoundUp | Double-tap / Enter | Core navigation |
+| Enter FoundUp | Enter button (tile or fullscreen) | Core navigation |
 | Close overlay | Escape | Universal escape |
 
 ### 6.3 Cannot Be Hidden or Disabled

--- a/public/member/INTERFACE.md
+++ b/public/member/INTERFACE.md
@@ -123,9 +123,11 @@ Video Mall tile grid with field scope projections.
 | Method | Description |
 |--------|-------------|
 | `initialize(config)` | Initialize tile field |
-| `enterFoundUp(index)` | Enter FoundUp view |
+| `navigateToFoundUp(foundupId)` | Navigate to `/f/{foundup_id}` (WSP 104 canonical) |
 | **Video Runtime** | |
-| `togglePlay(index)` | Open fullscreen player from tile (routes to `openFullscreenFromTile`) |
+| `startLanePreview(foundupIndex, videoIndex, muted)` | Start lane autoplay through FoundUp's video queue |
+| `advanceToNextInLane()` | Advance to next video in queue (loops at end) |
+| `togglePlay(index)` | Start lane autoplay on tile (entry point for tap gesture) |
 | `getPlayingIndex()` | Get currently playing tile index |
 | `expandFoundUp(index)` | Expand tile to FoundUp view |
 | `collapseFoundUp()` | Collapse back to Mall |
@@ -306,8 +308,8 @@ interface InviteDoc {
 ### UI Contract
 
 **Mall Context (tile field)**:
-- tap tile: open fullscreen player with FoundUp queue
-- double-tap tile: enter FoundUp view directly
+- tap tile: start lane autoplay through FoundUp's video queue (Shorts-style)
+- Enter FoundUp button: navigate to `/f/{foundup_id}` (WSP 104 canonical)
 - pinch-out on tile: expand into FoundUp's video field
 - swipe: navigate snapped field (default) or glide (override)
 - desktop mouse drag: maps to touch swipe (drag-scroll parity)

--- a/public/member/ModLog.md
+++ b/public/member/ModLog.md
@@ -1,5 +1,62 @@
 # Member Area Module Change Log
 
+## [2026-04-11] Lane Autoplay and FoundUp Entry Phase 1 (Worker BL, WSP 15/97/104)
+
+**Who**: 0102 — Worker BL
+**Slice**: `YOUTUBE_CHANNEL_LANE_AUTOPLAY_AND_FULLSCREEN_ENTRY_PHASE1`
+**What**: Turn pfMALL channel tiles into real lane browsers with Shorts-style autoplay.
+
+**Files Modified**:
+- `public/member/js/mall-tile-field.js` — Lane autoplay state, video end detection, Enter FoundUp navigation
+- `public/member/js/mall-video-player.js` — Fullscreen Enter FoundUp button and handler
+- `public/member/css/mall-tile-field.css` — Enter FoundUp button styling
+- `public/member/css/mall-video-player.css` — Fullscreen Enter button green highlight
+- `public/member/index.html` — Updated guidance text (removed double-tap references)
+- `public/member/INTERFACE.md` — Updated UI Contract for new entry model
+- `public/member/tests/test_video_mall_field_runtime.py` — 25 new/updated tests
+
+**Lane Autoplay Behavior**:
+1. **Tap tile**: Starts lane autoplay through the FoundUp's `videos[]` queue
+2. **Video end**: Auto-advances to next video in queue
+3. **Queue end policy**: **Loop to start** (Shorts-style continuous play)
+4. **State tracking**: `currentLaneFoundupIndex`, `laneVideoIndex`
+
+**Entry Behavior Changes**:
+- **Double-tap removed**: No longer enters FoundUp (was redundant with fullscreen)
+- **Enter FoundUp button**: New button on tiles (bottom-left, visible during preview)
+- **Keyboard Enter**: Now opens fullscreen (was enterFoundUp)
+
+**FoundUp Entry Path**:
+- `navigateToFoundUp(foundupId)` — Uses stable `foundup_id` from `data-foundup-id` attribute
+- Routes to `/f/{foundup_id}` (WSP 104 canonical route)
+- Stops any active preview before navigation
+
+**Video End Detection**:
+- YouTube: `onStateChange` with `event.data === 0` (YT.PlayerState.ENDED)
+- HTML5: `ended` event listener
+- Error handling: Advances to next on playback failure
+
+**Non-Video Tiles**: Unchanged — tap opens quick-view via `mallPlanes.openFoundUpById()`
+
+**WSP 104 Applied**: Enter FoundUp uses stable `foundup_id` identity and routes to canonical `/f/{foundup_id}`.
+
+**WSP 97 Applied**: Boundary respected — no changes to quick-view, PWA, or service worker behavior.
+
+**Test Count**: 182 passed (159 existing + 11 in TestEnterFoundUpButton + 14 in TestLaneAutoplay - 2 overlapped)
+
+**Bug Fixes Applied** (from architect review 2026-04-11):
+1. **Lane state survives preview startup**: Moved `currentLaneFoundupIndex` and `laneVideoIndex` assignment AFTER `stopInlinePreview()` call (was getting cleared immediately)
+2. **Fullscreen Enter FoundUp button**: Added `data-action="enter"` button to `mall-video-player.js` top bar with handler routing to `/f/{foundup_id}`
+3. **Expanded mode parent routing**: Enter FoundUp in expanded mode now resolves parent `foundup_id` from `mallCatalog[expandedFoundUp]` instead of synthetic video tile ID
+
+**Documentation Updates** (from architect review 2026-04-11):
+- `public/member/index.html` — Updated Red Dog guidance and gesture hints (removed double-tap references)
+- `public/member/INTERFACE.md` — Updated UI Contract to reflect tap=lane autoplay, Enter button=entry
+- `modules/foundups/docs/PFMALL_MALL_NAVIGATION_CONTRACT.md` — Updated gesture table
+- `modules/foundups/docs/PFMALL_FOUNDUP_ENTRY_AND_STAKE_GATE_CONTRACT.md` — Rewrote Section 2 (Entry Gestures) for explicit button entry model
+
+---
+
 ## [2026-04-11] Canonical FoundUp App Mount Phase 1 (Worker BN, WSP 15/97/104)
 
 **Who**: 0102 — Worker BN

--- a/public/member/README.md
+++ b/public/member/README.md
@@ -53,8 +53,8 @@ public/member/
 
 ### Mall Navigation
 - swipe or scroll horizontally through FoundUps (desktop: mouse drag on carousel track)
-- tap a tile to play/pause video in Mall context
-- double-tap a tile to enter FoundUp view directly
+- tap a tile to start lane autoplay through its video queue (Shorts-style)
+- Enter FoundUp button to navigate to `/f/{foundup_id}` (tile or fullscreen)
 - pinch-out on tile to expand into FoundUp's video field
 - pinch-in (expanded) to collapse back to Mall
 

--- a/public/member/css/mall-tile-field.css
+++ b/public/member/css/mall-tile-field.css
@@ -539,7 +539,8 @@
 /* Touch devices: always show controls (no hover) */
 @media (hover: none) {
   .mall-tile-expand,
-  .mall-tile-audio {
+  .mall-tile-audio,
+  .mall-tile-enter {
     opacity: 1;
   }
 
@@ -588,11 +589,53 @@
 
 /* Focus states for control buttons (keyboard accessibility) */
 .mall-tile-audio:focus-visible,
-.mall-tile-expand:focus-visible {
+.mall-tile-expand:focus-visible,
+.mall-tile-enter:focus-visible {
   opacity: 1;
   outline: 2px solid rgba(141, 113, 255, 0.8);
   outline-offset: 2px;
   background: rgba(124, 92, 252, 0.6);
+}
+
+/* ─── Enter FoundUp Button (WSP 104 Canonical Route) ─── */
+.mall-tile-enter {
+  position: absolute;
+  bottom: 4px;
+  left: 4px;
+  width: 24px;
+  height: 24px;
+  background: rgba(0, 0, 0, 0.6);
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 150ms ease, background 150ms ease;
+  z-index: 10;
+}
+
+.mall-tile-enter svg {
+  width: 14px;
+  height: 14px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* Enter button visible during preview or hover */
+.mall-tile:hover .mall-tile-enter,
+.mall-tile:focus-within .mall-tile-enter,
+.mall-tile.is-previewing .mall-tile-enter {
+  opacity: 1;
+}
+
+.mall-tile-enter:hover {
+  background: rgba(40, 180, 99, 0.8);
 }
 
 /* Expanded FoundUp video field mode */

--- a/public/member/css/mall-video-player.css
+++ b/public/member/css/mall-video-player.css
@@ -107,6 +107,19 @@
   stroke: #7c5cfc;
 }
 
+/* Enter FoundUp button — distinct green highlight (WSP 104 canonical route) */
+.video-player-enter-btn {
+  background: rgba(40, 180, 99, 0.3);
+}
+
+.video-player-enter-btn:hover {
+  background: rgba(40, 180, 99, 0.5);
+}
+
+.video-player-enter-btn:active {
+  background: rgba(40, 180, 99, 0.7);
+}
+
 .video-player-title {
   color: #fff;
   font-size: 0.9rem;

--- a/public/member/index.html
+++ b/public/member/index.html
@@ -237,7 +237,7 @@
       <div class="account-section-label">Red Dog</div>
       <div class="reddog-concierge-guidance">
         <p class="reddog-guidance-item">Welcome to the p.fMALL. I keep track of your FoundUps and help you find your way around.</p>
-        <p class="reddog-guidance-item">Tap a tile to play. Double-tap to enter a FoundUp. Pinch to expand.</p>
+        <p class="reddog-guidance-item">Tap a tile to play its video queue. Use the Enter button to visit a FoundUp. Pinch to expand.</p>
         <p class="reddog-guidance-item">Swipe down from the top or tap my button to open this panel. Swipe up to close.</p>
       </div>
     </div>
@@ -1116,7 +1116,7 @@
   <div id="gestureHints" class="gesture-hints" style="display:none;">
     <div class="gesture-hint-item"><span class="gesture-hint-icon">&#8596;</span> Swipe sideways to browse FoundUps</div>
     <div class="gesture-hint-item"><span class="gesture-hint-icon">&#8595;</span> Swipe down from top for your account</div>
-    <div class="gesture-hint-item"><span class="gesture-hint-icon">&#8226;</span> Tap to play/pause, double-tap to enter</div>
+    <div class="gesture-hint-item"><span class="gesture-hint-icon">&#8226;</span> Tap to play queue, Enter button to visit</div>
     <p class="gesture-hint-dismiss">Tap anywhere to dismiss</p>
   </div>
 

--- a/public/member/js/mall-tile-field.js
+++ b/public/member/js/mall-tile-field.js
@@ -5,8 +5,8 @@
  * SoftProto mount point: #mallTileField[data-softproto-mount="tile-field"]
  *
  * Gestures (Mall context):
- *   - Tap tile: Play/pause video in Mall context
- *   - Double-tap tile: Enter FoundUp view directly
+ *   - Tap tile: Start lane autoplay through FoundUp's video queue (Shorts-style)
+ *   - Enter button: Navigate to /f/{foundup_id} (WSP 104 canonical)
  *   - Pinch-out on tile: Expand into FoundUp's video field
  *   - Pinch-in (expanded): Collapse back to Mall
  *   - Swipe: Navigate snapped field (default) or glide (override)
@@ -69,6 +69,11 @@
   var previewGeneration = 0;       // Guard against stale callbacks
   var tapGuardActive = false;      // Prevent double-fire on audio button tap
 
+  // Lane autoplay state (Shorts-style queue traversal)
+  var currentLaneFoundupIndex = null;  // Which FoundUp lane is playing (catalog index)
+  var laneVideoIndex = 0;              // Current position in lane's videos[] queue
+  var laneAutoplayEnabled = true;      // Whether to auto-advance on video end
+
   // ========== YouTube IFrame API Helpers ==========
 
   function ensureYouTubeAPI() {
@@ -112,7 +117,148 @@
     var items = expandedFoundUp !== null ? getExpandedVideos() : mallCatalog;
     var item = items[index];
     if (!item) return null;
-    return item.video_data || (item.videos && item.videos[0]) || null;
+    // In expanded mode or single video_data, use direct reference
+    if (item.video_data) return item.video_data;
+    // In lane mode, use current lane video index
+    if (item.videos && item.videos.length) {
+      var vidIdx = (currentLaneFoundupIndex === index) ? laneVideoIndex : 0;
+      return item.videos[vidIdx] || item.videos[0];
+    }
+    return null;
+  }
+
+  /**
+   * Get video from lane queue at specific position
+   * @param {number} foundupIndex - FoundUp index in catalog
+   * @param {number} videoIndex - Position in videos[] queue
+   * @returns {Object|null} Video data object
+   */
+  function getLaneVideo(foundupIndex, videoIndex) {
+    var item = mallCatalog[foundupIndex];
+    if (!item || !item.videos || !item.videos.length) return null;
+    return item.videos[videoIndex] || null;
+  }
+
+  /**
+   * Advance to next video in current lane queue
+   * Policy: Loop to start when queue ends (Shorts-style continuous play)
+   */
+  function advanceToNextInLane() {
+    if (currentLaneFoundupIndex === null || !laneAutoplayEnabled) return;
+    var item = mallCatalog[currentLaneFoundupIndex];
+    if (!item || !item.videos || !item.videos.length) return;
+
+    var nextIndex = laneVideoIndex + 1;
+    // Loop policy: wrap to start when queue ends
+    if (nextIndex >= item.videos.length) {
+      nextIndex = 0;
+    }
+    laneVideoIndex = nextIndex;
+    // Start preview at new position (keep mute state)
+    startLanePreview(currentLaneFoundupIndex, laneVideoIndex, previewMuted);
+  }
+
+  /**
+   * Start lane preview at specific video position
+   * @param {number} foundupIndex - FoundUp catalog index
+   * @param {number} videoIndex - Position in videos[] queue
+   * @param {boolean} muted - Whether to start muted
+   */
+  function startLanePreview(foundupIndex, videoIndex, muted) {
+    var item = mallCatalog[foundupIndex];
+    if (!item || !item.videos || !item.videos.length) return;
+
+    var video = item.videos[videoIndex];
+    if (!video) return;
+
+    // Get the tile element for this FoundUp
+    var tile = getTileElement(foundupIndex);
+    if (!tile) return;
+
+    // Stop any existing preview FIRST (this clears lane state)
+    stopInlinePreview();
+
+    // Set lane state AFTER stopInlinePreview so it survives
+    currentLaneFoundupIndex = foundupIndex;
+    laneVideoIndex = videoIndex;
+
+    var videoUrl = video.embed_url || video.embedUrl || video.source_url || video.sourceUrl || '';
+    if (!videoUrl || typeof videoUrl !== 'string' || videoUrl.length < 5) return;
+
+    var ytId = extractYouTubeVideoId(videoUrl);
+    var stage = tile.querySelector('.mall-tile-preview-stage');
+    if (!stage) return;
+
+    playingIndex = foundupIndex;
+    previewPaused = false;
+    previewMuted = muted !== false;
+    previewGeneration++;
+    var gen = previewGeneration;
+
+    applyTilePreviewState(foundupIndex, { previewing: true, paused: false, muted: previewMuted });
+
+    if (ytId) {
+      ensureYouTubeAPI().then(function() {
+        if (gen !== previewGeneration) return;
+        var hostDiv = document.createElement('div');
+        hostDiv.className = 'mall-tile-preview-host';
+        hostDiv.id = 'yt-preview-' + foundupIndex + '-' + gen;
+        stage.innerHTML = '';
+        stage.appendChild(hostDiv);
+        inlineYTPlayer = new YT.Player(hostDiv.id, {
+          videoId: ytId,
+          playerVars: {
+            autoplay: 1, mute: 1, controls: 0, modestbranding: 1,
+            rel: 0, playsinline: 1
+            // Note: removed loop - we handle advancement manually
+          },
+          events: {
+            onReady: function(event) {
+              if (gen !== previewGeneration) return;
+              if (previewMuted) event.target.mute();
+              else event.target.unMute();
+              event.target.playVideo();
+            },
+            onStateChange: function(event) {
+              if (gen !== previewGeneration) return;
+              // YT.PlayerState.ENDED = 0
+              if (event.data === 0) {
+                advanceToNextInLane();
+              }
+            },
+            onError: function(event) {
+              if (gen !== previewGeneration) return;
+              // Skip to next on error
+              advanceToNextInLane();
+            }
+          }
+        });
+      });
+    } else if (videoUrl) {
+      var videoEl = document.createElement('video');
+      videoEl.className = 'mall-tile-preview-media';
+      videoEl.muted = previewMuted;
+      videoEl.autoplay = true;
+      videoEl.playsInline = true;
+      videoEl.setAttribute('playsinline', '');
+      // Advance on video end
+      videoEl.addEventListener('ended', function() {
+        if (gen !== previewGeneration) return;
+        advanceToNextInLane();
+      });
+      videoEl.onerror = function() {
+        if (gen !== previewGeneration) return;
+        advanceToNextInLane();
+      };
+      stage.innerHTML = '';
+      stage.appendChild(videoEl);
+      inlineHTML5Video = videoEl;
+      videoEl.src = videoUrl;
+      videoEl.play().catch(function() {
+        if (gen !== previewGeneration) return;
+        advanceToNextInLane();
+      });
+    }
   }
 
   // ========== Inline Preview Runtime ==========
@@ -175,6 +321,9 @@
     applyTilePreviewState(null, null);
     playingIndex = null;
     previewPaused = false;
+    // Reset lane state
+    currentLaneFoundupIndex = null;
+    laneVideoIndex = 0;
   }
 
   function pauseInlinePreview() {
@@ -507,6 +656,10 @@
       // Corner expand button for explicit fullscreen entry — video tiles only
       var expandBtn = hasVideos ? '<button class="mall-tile-expand" aria-label="Open fullscreen" title="Fullscreen">&#9654;</button>' : '';
 
+      // Enter FoundUp button (bottom-left, visible during preview) — video tiles only
+      // Uses stable foundup_id for WSP 104 canonical routing
+      var enterFoundupBtn = hasVideos ? '<button class="mall-tile-enter" aria-label="Enter FoundUp" title="Enter FoundUp"><svg viewBox="0 0 24 24"><path d="M15 3h6v6M14 10l6.1-6.1M9 21H3v-6M10 14l-6.1 6.1"/></svg></button>' : '';
+
       // Inline preview container (YouTube iframe or HTML5 video goes here) — video tiles only
       var previewContainer = hasVideos ? '<div class="mall-tile-preview"><div class="mall-tile-preview-stage"></div></div>' : '';
 
@@ -533,6 +686,7 @@
         sourceActionBadge +
         playIndicator +
         audioBtn +
+        enterFoundupBtn +
         expandBtn +
         '<div class="mall-tile-inner">' +
           '<span class="mall-tile-token">' + escapeHtml(item.token_symbol || '') + '</span>' +
@@ -579,30 +733,19 @@
     var tiles = tileField.querySelectorAll('.mall-tile');
 
     tiles.forEach(function(tile) {
-      // Touch/click handling: tap = play/pause, double-tap = enter
+      // Touch/click handling: tap = lane autoplay (no double-tap entry)
+      // FoundUp entry is explicit via fullscreen "Enter FoundUp" button
       tile.addEventListener('click', function(e) {
         // Ignore tap if guard is active (just finished dragging)
         if (tapGuardActive) return;
 
         var index = Number(tile.dataset.index || 0);
-        var now = Date.now();
-
-        // Check for double-tap (second tap within window)
-        if (lastTapTarget === tile && (now - lastTapTime) < DOUBLE_TAP_WINDOW) {
-          // Double-tap: enter FoundUp directly
-          e.preventDefault();
-          lastTapTime = 0;
-          lastTapTarget = null;
-          enterFoundUp(index);
-        } else {
-          // Single tap: play/pause in Mall context
-          lastTapTime = now;
-          lastTapTarget = tile;
-          togglePlay(index);
-        }
+        // Single tap: start/toggle lane autoplay
+        togglePlay(index);
       });
 
       // Keyboard support
+      // Space = lane autoplay, Enter = expand to fullscreen (where Enter FoundUp lives)
       tile.addEventListener('keydown', function(e) {
         var index = Number(tile.dataset.index || 0);
         if (e.key === ' ') {
@@ -610,7 +753,8 @@
           togglePlay(index);
         } else if (e.key === 'Enter') {
           e.preventDefault();
-          enterFoundUp(index);
+          // Open fullscreen context (Enter FoundUp available there)
+          openFullscreenFromTile(index);
         }
       });
 
@@ -661,6 +805,32 @@
       });
     });
 
+    // Enter FoundUp buttons — navigate to canonical /f/{foundup_id} route
+    var enterBtns = tileField.querySelectorAll('.mall-tile-enter');
+    enterBtns.forEach(function(btn) {
+      btn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        if (tapGuardActive) return;
+        var tile = btn.closest('.mall-tile');
+        if (!tile) return;
+        var index = Number(tile.dataset.index || 0);
+
+        // In expanded mode, route to PARENT FoundUp, not synthetic video ID
+        var foundupId;
+        if (expandedFoundUp !== null) {
+          var parentItem = mallCatalog[expandedFoundUp];
+          foundupId = parentItem ? (parentItem.foundup_id || parentItem.id) : null;
+        } else {
+          // In Mall mode, use stable foundup_id from data attribute
+          foundupId = tile.dataset.foundupId;
+        }
+
+        if (foundupId) {
+          navigateToFoundUp(foundupId);
+        }
+      });
+    });
+
     // Global escape handler - collapse expanded view or stop preview
     document.addEventListener('keydown', function(e) {
       if (e.key === 'Escape' && expandedFoundUp !== null) {
@@ -675,6 +845,8 @@
 
   /**
    * Toggle play/pause for a tile
+   * In Mall mode: starts lane autoplay through the FoundUp's videos[] queue
+   * In expanded mode: plays the specific video
    * @param {number} index - Tile index
    */
   function togglePlay(index) {
@@ -709,7 +881,14 @@
       else pauseInlinePreview();
       return;
     }
-    startInlinePreview(index, false);
+
+    // In Mall mode (not expanded): use lane autoplay through videos[] queue
+    if (expandedFoundUp === null && item.videos && item.videos.length) {
+      startLanePreview(index, 0, false);
+    } else {
+      // Expanded mode or single video: use existing preview
+      startInlinePreview(index, false);
+    }
   }
 
   /**
@@ -1031,7 +1210,20 @@
   }
 
   /**
-   * Enter FoundUp view
+   * Navigate to canonical FoundUp landing page
+   * Uses WSP 104 routing: /f/{foundup_id}
+   * @param {string} foundupId - Stable FoundUp identity
+   */
+  function navigateToFoundUp(foundupId) {
+    if (!foundupId) return;
+    // Stop any active preview before navigation
+    stopInlinePreview();
+    // Navigate to canonical route (WSP 104)
+    window.location.href = '/f/' + encodeURIComponent(foundupId);
+  }
+
+  /**
+   * Enter FoundUp view (legacy - opens quick-view plane)
    * @param {number} index - Tile index
    */
   function enterFoundUp(index) {
@@ -1352,6 +1544,7 @@
     // Core
     initialize: initialize,
     enterFoundUp: enterFoundUp,
+    navigateToFoundUp: navigateToFoundUp,
 
     // Video runtime
     togglePlay: togglePlay,
@@ -1360,6 +1553,12 @@
     collapseFoundUp: collapseFoundUp,
     isExpanded: isExpanded,
     getExpandedIndex: getExpandedIndex,
+
+    // Lane autoplay
+    startLanePreview: startLanePreview,
+    advanceToNextInLane: advanceToNextInLane,
+    getLaneVideoIndex: function() { return laneVideoIndex; },
+    getCurrentLaneFoundupIndex: function() { return currentLaneFoundupIndex; },
 
     // Inline preview
     startInlinePreview: startInlinePreview,

--- a/public/member/js/mall-video-player.js
+++ b/public/member/js/mall-video-player.js
@@ -155,6 +155,9 @@
       '    <span class="video-player-title"></span>',
       '  </div>',
       '  <div class="video-player-top-bar-right">',
+      '    <button class="video-player-btn video-player-enter-btn" data-action="enter" aria-label="Enter FoundUp">',
+      '      <svg viewBox="0 0 24 24"><path d="M15 3h6v6M14 10l6.1-6.1M9 21H3v-6M10 14l-6.1 6.1"/></svg>',
+      '    </button>',
       '    <button class="video-player-btn" data-action="save" aria-label="Save">',
       '      <svg viewBox="0 0 24 24"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>',
       '    </button>',
@@ -518,6 +521,13 @@
     switch (action) {
       case 'back':
         close();
+        break;
+      case 'enter':
+        // Enter FoundUp: navigate to canonical /f/{foundup_id} route (WSP 104)
+        if (currentFoundUpId) {
+          close();
+          window.location.href = '/f/' + encodeURIComponent(currentFoundUpId);
+        }
         break;
       case 'save':
         var wasSaved = toggleSave();

--- a/public/member/js/red-dog-concierge.js
+++ b/public/member/js/red-dog-concierge.js
@@ -33,11 +33,11 @@
       q: 'What is the Mall?',
       a: 'The p.fMALL is your invite-gated home inside FoundUPS. '
        + 'Each tile represents a FoundUp \u2014 an autonomous venture in the pAVS ecosystem. '
-       + 'Browse the catalog, check readiness states, and tap a tile to see its full entry page.'
+       + 'Browse the catalog, check readiness states, and tap a tile to play its video queue.'
     },
     {
       q: 'How do I browse?',
-      a: 'Tap any tile to play/pause its video. Double-tap to enter its dedicated page. '
+      a: 'Tap any tile to play its video queue. Use the Enter button to visit its page. '
        + 'On desktop, use keyboard navigation or scroll.'
     },
     {

--- a/public/member/tests/TestModLog.md
+++ b/public/member/tests/TestModLog.md
@@ -4,6 +4,34 @@ Test evolution log for the p.fMALL member shell test suite.
 
 ---
 
+## 2026-04-11 | Lane Autoplay and Enter FoundUp Tests (WSP 15/97/104)
+
+**File**: `test_video_mall_field_runtime.py` (extended)
+**Tests**: 25 new/updated | **Classes**: 2 | **Result**: 182 passed total
+**Worker**: BL
+
+Validates Shorts-style lane autoplay and Enter FoundUp button:
+
+| Class | Count | What it covers |
+|-------|-------|----------------|
+| TestEnterFoundUpButton | 11 | Button in tile HTML, navigateToFoundUp function, stable ID routing, canonical /f/ route, click handler, CSS exists, visible on preview, **fullscreen Enter button**, **fullscreen handler**, **expanded mode parent routing**, **expanded mode ID resolution** |
+| TestLaneAutoplay | 14 | Lane state variables, startLanePreview, advanceToNextInLane, loop policy, YouTube onStateChange, HTML5 ended event, togglePlay uses lane, stop resets state, API exposed, no double-tap entry, keyboard Enter opens fullscreen, **lane state survives preview startup** |
+
+**Key behaviors verified**:
+- Lane autoplay tracks `currentLaneFoundupIndex` and `laneVideoIndex`
+- Video end detected via YouTube `onStateChange` (data === 0) and HTML5 `ended` event
+- Queue end policy: loop to start (Shorts-style)
+- `navigateToFoundUp(foundupId)` uses stable identity from `data-foundup-id`
+- Navigation routes to `/f/{foundup_id}` (WSP 104 canonical)
+- Double-tap entry removed from tile click handler
+- Keyboard Enter opens fullscreen (not enterFoundUp)
+- `stopInlinePreview()` resets lane state
+- **Lane state set AFTER stopInlinePreview** (survives startup)
+- **Fullscreen player has Enter FoundUp button** with `data-action="enter"`
+- **Expanded mode routes to parent FoundUp ID** via `mallCatalog[expandedFoundUp]`
+
+---
+
 ## 2026-04-11 | FoundUp App Mount Tests (WSP 104/97)
 
 **File**: `test_route_contract_bridge.py` (extended)
@@ -408,7 +436,7 @@ Validates entry-page Red Dog alignment with Mall Red Dog:
 
 | File | Tests | Worker | Phase |
 |------|-------|--------|-------|
-| test_video_mall_field_runtime.py | 100 | AK/AP | Animation + Locomotion |
+| test_video_mall_field_runtime.py | 182 | AK/AP/BL | Animation + Locomotion + Lane Autoplay |
 | test_concierge_channel_attachment_phase1.py | 66 | C | Channel attachment |
 | test_reddog_mall_controls_phase1.py | 81 | C | WSP 97 controls |
 | test_reddog_foundup_entry_alignment_phase7.py | 65 | C | Entry alignment |
@@ -416,4 +444,4 @@ Validates entry-page Red Dog alignment with Mall Red Dog:
 | test_reddog_recommended_actions_phase5.py | 63 | C | Recommended actions |
 | test_reddog_context_briefing_phase4.py | 48 | C | Context briefing |
 | (other member tests) | ~446 | B/mixed | Mall shell, tiles, etc. |
-| **Total** | **912** | | |
+| **Total** | **994** | | |

--- a/public/member/tests/test_video_mall_field_runtime.py
+++ b/public/member/tests/test_video_mall_field_runtime.py
@@ -5,11 +5,12 @@ Tests for the video-backed Mall field with:
   - Snapped field motion (default)
   - Glide mode override
   - Poster + queue count tiles
-  - tap = play/pause
-  - double-tap = enter FoundUp
+  - tap = lane autoplay (Shorts-style queue traversal)
   - pinch-out = expand into video field
   - pinch-in = collapse back
   - AI-controlled density presets
+  - Enter FoundUp button for WSP 104 canonical routing
+  - Lane autoplay with video end detection
 """
 import os
 
@@ -86,18 +87,71 @@ class TestVideoBackedTiles:
         assert "background-size: cover" in css
 
 
-class TestDoubleTapEnter:
-    """Test double-tap = enter FoundUp."""
+class TestEnterFoundUpButton:
+    """Test Enter FoundUp button for WSP 104 canonical routing."""
 
-    def test_double_tap_window(self):
-        """Double-tap detection window exists."""
+    def test_enter_button_in_tile_html(self):
+        """Enter FoundUp button included in tile HTML."""
         js = _read("js/mall-tile-field.js")
-        assert "DOUBLE_TAP_WINDOW" in js
+        assert "mall-tile-enter" in js
+        assert "Enter FoundUp" in js
 
-    def test_enter_foundup_on_double_tap(self):
-        """Double-tap calls enterFoundUp."""
+    def test_navigate_to_foundup_function(self):
+        """navigateToFoundUp function exists for WSP 104 routing."""
         js = _read("js/mall-tile-field.js")
-        assert "enterFoundUp(index)" in js
+        assert "function navigateToFoundUp" in js
+
+    def test_navigate_uses_stable_id(self):
+        """Navigation uses foundup_id from data attribute, not index."""
+        js = _read("js/mall-tile-field.js")
+        assert "tile.dataset.foundupId" in js
+
+    def test_navigate_to_canonical_route(self):
+        """Navigation goes to /f/{foundup_id} canonical route."""
+        js = _read("js/mall-tile-field.js")
+        assert "'/f/' + encodeURIComponent(foundupId)" in js
+
+    def test_enter_button_click_handler(self):
+        """Enter button has click handler."""
+        js = _read("js/mall-tile-field.js")
+        assert ".mall-tile-enter" in js
+        assert "navigateToFoundUp(foundupId)" in js
+
+    def test_enter_button_css_exists(self):
+        """Enter button has CSS styling."""
+        css = _read("css/mall-tile-field.css")
+        assert ".mall-tile-enter" in css
+
+    def test_enter_button_visible_on_preview(self):
+        """Enter button visible during preview."""
+        css = _read("css/mall-tile-field.css")
+        assert ".mall-tile.is-previewing .mall-tile-enter" in css
+
+    def test_fullscreen_has_enter_foundup_button(self):
+        """Fullscreen video player has Enter FoundUp button."""
+        js = _read("js/mall-video-player.js")
+        assert 'data-action="enter"' in js
+        assert "Enter FoundUp" in js
+
+    def test_fullscreen_enter_action_handler(self):
+        """Fullscreen Enter action navigates to /f/{foundup_id}."""
+        js = _read("js/mall-video-player.js")
+        assert "case 'enter':" in js
+        assert "'/f/' + encodeURIComponent(currentFoundUpId)" in js
+
+    def test_fullscreen_enter_button_css(self):
+        """Fullscreen Enter button has distinct styling."""
+        css = _read("css/mall-video-player.css")
+        assert ".video-player-enter-btn" in css
+
+    def test_expanded_mode_routes_to_parent(self):
+        """In expanded mode, Enter FoundUp routes to parent FoundUp ID."""
+        js = _read("js/mall-tile-field.js")
+        # Check that expanded mode uses mallCatalog[expandedFoundUp] for ID
+        idx = js.index("// In expanded mode, route to PARENT")
+        section = js[idx:idx+300]
+        assert "mallCatalog[expandedFoundUp]" in section
+        assert "parentItem.foundup_id" in section
 
 
 class TestPinchExpandCollapse:
@@ -1003,3 +1057,98 @@ class TestPreviewResourceHardening:
         js = _read("js/mall-tile-field.js")
         assert "visibilityBound" in js
         assert "if (visibilityBound) return" in js
+
+
+class TestLaneAutoplay:
+    """Test Shorts-style lane autoplay through videos[] queue."""
+
+    def test_lane_video_index_state(self):
+        """Lane video index state variable exists."""
+        js = _read("js/mall-tile-field.js")
+        assert "laneVideoIndex" in js
+
+    def test_current_lane_foundup_index_state(self):
+        """Current lane FoundUp index state variable exists."""
+        js = _read("js/mall-tile-field.js")
+        assert "currentLaneFoundupIndex" in js
+
+    def test_lane_autoplay_enabled_flag(self):
+        """Lane autoplay enabled flag exists."""
+        js = _read("js/mall-tile-field.js")
+        assert "laneAutoplayEnabled" in js
+
+    def test_start_lane_preview_function(self):
+        """startLanePreview function exists for lane autoplay."""
+        js = _read("js/mall-tile-field.js")
+        assert "function startLanePreview" in js
+
+    def test_advance_to_next_in_lane_function(self):
+        """advanceToNextInLane function exists for queue traversal."""
+        js = _read("js/mall-tile-field.js")
+        assert "function advanceToNextInLane" in js
+
+    def test_loop_policy_on_queue_end(self):
+        """Lane autoplay loops to start when queue ends."""
+        js = _read("js/mall-tile-field.js")
+        # Check for loop policy comment and implementation
+        assert "Loop policy" in js or "loop to start" in js
+        assert "nextIndex = 0" in js
+
+    def test_youtube_onstate_change_handler(self):
+        """YouTube player has onStateChange for end detection."""
+        js = _read("js/mall-tile-field.js")
+        assert "onStateChange" in js
+        assert "event.data === 0" in js  # YT.PlayerState.ENDED
+
+    def test_html5_ended_event_handler(self):
+        """HTML5 video has ended event for lane advancement."""
+        js = _read("js/mall-tile-field.js")
+        assert "'ended'" in js
+        assert "advanceToNextInLane()" in js
+
+    def test_toggle_play_uses_lane_preview(self):
+        """togglePlay uses startLanePreview in Mall mode."""
+        js = _read("js/mall-tile-field.js")
+        assert "startLanePreview(index, 0, false)" in js
+
+    def test_stop_preview_resets_lane_state(self):
+        """stopInlinePreview resets lane state."""
+        js = _read("js/mall-tile-field.js")
+        idx = js.index("function stopInlinePreview")
+        section = js[idx:idx+1200]
+        assert "currentLaneFoundupIndex = null" in section
+        assert "laneVideoIndex = 0" in section
+
+    def test_lane_state_survives_preview_startup(self):
+        """Lane state is set AFTER stopInlinePreview in startLanePreview."""
+        js = _read("js/mall-tile-field.js")
+        idx = js.index("function startLanePreview")
+        section = js[idx:idx+600]
+        # stopInlinePreview must come BEFORE setting lane state
+        stop_idx = section.index("stopInlinePreview()")
+        lane_idx = section.index("currentLaneFoundupIndex = foundupIndex")
+        assert stop_idx < lane_idx, "stopInlinePreview must precede lane state assignment"
+
+    def test_lane_api_exposed(self):
+        """Lane autoplay API exposed on window.mallTileField."""
+        js = _read("js/mall-tile-field.js")
+        assert "startLanePreview:" in js
+        assert "advanceToNextInLane:" in js
+        assert "getLaneVideoIndex:" in js
+
+    def test_no_double_tap_entry(self):
+        """Tap handler does not call enterFoundUp on double-tap."""
+        js = _read("js/mall-tile-field.js")
+        # The click handler should NOT have double-tap logic calling enterFoundUp
+        idx = js.index("tile.addEventListener('click'")
+        handler_end = js.index("});", idx)
+        click_handler = js[idx:handler_end]
+        assert "enterFoundUp(index)" not in click_handler
+
+    def test_keyboard_enter_opens_fullscreen(self):
+        """Keyboard Enter opens fullscreen (not enterFoundUp)."""
+        js = _read("js/mall-tile-field.js")
+        # Find the keydown handler
+        idx = js.index("e.key === 'Enter'")
+        section = js[idx:idx+200]
+        assert "openFullscreenFromTile(index)" in section


### PR DESCRIPTION
## Summary
- **Lane autoplay**: Tap tile starts Shorts-style queue playback with auto-advance on video end
- **Enter FoundUp button**: Explicit entry on tiles and fullscreen, routes to `/f/{foundup_id}` (WSP 104)
- **Double-tap removed**: Replaced by explicit button entry

## Files Changed
- `public/member/js/mall-tile-field.js` — Lane state, video end detection, Enter navigation
- `public/member/js/mall-video-player.js` — Fullscreen Enter button and handler
- `public/member/css/mall-{tile-field,video-player}.css` — Button styling
- `public/member/index.html` — Updated guidance text
- `public/member/{INTERFACE,README}.md` — Updated contracts
- `modules/foundups/docs/PFMALL_*.md` — Updated entry/navigation contracts
- `public/member/js/red-dog-concierge.js` — Updated help topics

## Test plan
- [x] `test_video_mall_field_runtime.py`: 182 passed
- [x] `test_mall_tile_field.py`: 76 passed
- [x] `test_tile_keyboard_a11y.py`: 27 passed
- [x] Lane state survives preview startup
- [x] Fullscreen exposes Enter FoundUp button
- [x] Expanded mode routes to parent foundup_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)