### PR TITLE
feat(foundups): bind gotjunk metadata + document iframe blocker

### DIFF
--- a/modules/foundups/ModLog.md
+++ b/modules/foundups/ModLog.md
@@ -2,6 +2,50 @@
 
 ## Chronological Change Log
 
+### 2026-04-11 - Namespace Guardrail Validator (WSP 104 Enforcement)
+
+**By:** 0102 (Worker BQ) · **Slice:** `FOUNDUP_NAMESPACE_GUARDRAIL_PHASE1`  
+**WSP References:** WSP 15, WSP 97, WSP 104  
+
+**Added**
+
+- `modules/foundups/tests/test_namespace_guardrail.py` — 16 tests enforcing WSP 104 namespace rules:
+  - **Namespace uniqueness**: No duplicate `foundup_id`, `routing_prefix`, or `data_namespace` across catalog/manifests
+  - **Canonical route shape**: `routing_prefix` must match `/f/{foundup_id}`, `data_namespace` must match `idb_{foundup_id}`
+  - **Catalog/manifest consistency**: Values must match when both sources define the same field
+  - **No root sprawl**: Rejects reserved paths (`/member`, `/foundups`, `/api`, etc.) and root-level routes
+  - **Manifest structure**: Required fields validation (`foundup_id`, `routing_prefix`, `data_namespace`)
+  - **GotJunk first tenant**: Verifies first bound tenant compliance
+
+**Notes**
+
+- Guardrail designed to prevent collision at scale (100+ FoundUps)
+- All 16 tests pass against current catalog (13 entries) and manifest (1 file)
+- HoloIndex top hit: `modules\development\cursor_multi_agent_bridge\src\wsp_validator.py`
+
+---
+
+### 2026-04-11 - FoundUp AI hooks + DAEmon surface contract (Phase 1)
+
+**By:** 0102 (Worker BP) · **Slice:** `FOUNDUP_AI_HOOKS_AND_DAEMON_DOC_CONTRACT_PHASE1`  
+**WSP References:** WSP 15, WSP 91, WSP 97, WSP 104  
+
+**Added**
+
+- Canonical contract: `modules/foundups/docs/FOUNDUP_AI_HOOKS_AND_DAEMON_SURFACE_CONTRACT.md` (FoundUp-local; backs onto WSP 91 + WSP 104 without duplicating full protocol text).
+- `FOUNDUP_TEMPLATE.md` v1.1.0 — required README section block + copy-paste + compliance test pointer.
+- Compliance tests: `modules/foundups/tests/test_foundup_ai_hooks_daemon_contract_compliance.py` (discovers `module.json` / `foundup_manifest.json` FoundUps; validates README headings, WSP 91/104 literals, contract filename).
+
+**Updated**
+
+- README surface sections for FoundUps under `modules/foundups/` that declare `module.json` or `foundup_manifest.json` (route, app mount, AI hooks, DAEmon outputs, data namespace, WSP refs).
+
+**Notes**
+
+- No new WSP. Runtime pfMALL / tenant features out of scope for this slice.
+
+---
+
 ### 2026-04-07 - pfMALL Catalog Schema Expansion
 
 **By:** 0102 (Worker AG) · **Slice:** `PFMALL_CATALOG_SCHEMA_EXPANSION_PHASE1`

--- a/modules/foundups/gotjunk/INTERFACE.md
+++ b/modules/foundups/gotjunk/INTERFACE.md
@@ -8,7 +8,7 @@
 
 ### Deployment Endpoints
 
-**Production URL**: [To be added after deployment]
+**Production URL**: https://gotjunk-56566376153.us-west1.run.app/
 **AI Studio Editor**: https://ai.studio/apps/drive/1R_lBYHwMJHOxWjI_HAAx5DU9fqePG9nA
 
 ### Redeployment Process
@@ -329,5 +329,5 @@ const apiKey = "<DO_NOT_HARDCODE_API_KEYS>"  # NEVER commit this!
 ---
 
 **Deployment Status**: POC Complete, ready for Prototype phase
-**Last Synced**: [To be updated on deployment]
-**Cloud Run URL**: [To be added after deployment]
+**Last Synced**: 2026-04-11
+**Cloud Run URL**: https://gotjunk-56566376153.us-west1.run.app/

--- a/modules/foundups/gotjunk/foundup_manifest.json
+++ b/modules/foundups/gotjunk/foundup_manifest.json
@@ -7,7 +7,7 @@
   "tagline": "Turn your junk into someone's treasure",
   "tier": "F0_DAE",
   "lifecycle_stage": "proto",
-  "entry_url": "frontend/index.html",
+  "entry_url": "https://gotjunk-56566376153.us-west1.run.app/",
   "routing_prefix": "/f/gotjunk_001",
   "icon_url": "frontend/public/icon-192.svg",
   "required_subscription_tier": "free",

--- a/modules/foundups/gotjunk/foundup_manifest.json
+++ b/modules/foundups/gotjunk/foundup_manifest.json
@@ -7,7 +7,7 @@
   "tagline": "Turn your junk into someone's treasure",
   "tier": "F0_DAE",
   "lifecycle_stage": "proto",
-  "entry_url": "https://gotjunk-56566376153.us-west1.run.app/",
+  "entry_url": null,
   "routing_prefix": "/f/gotjunk_001",
   "icon_url": "frontend/public/icon-192.svg",
   "required_subscription_tier": "free",

--- a/modules/foundups/tests/test_namespace_guardrail.py
+++ b/modules/foundups/tests/test_namespace_guardrail.py
@@ -1,0 +1,282 @@
+"""
+Namespace Guardrail Validator - WSP 104 Enforcement
+
+Validates FoundUp namespace rules to ensure safe scaling to 100+ tenants:
+1. Namespace uniqueness (foundup_id, routing_prefix, data_namespace)
+2. Canonical route shape (/f/{foundup_id})
+3. Catalog/manifest consistency
+4. No root sprawl rejection
+
+WSP 104: FoundUp Route Namespace and Tenant Isolation Protocol
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Canonical route pattern: /f/{foundup_id}
+CANONICAL_ROUTE_PATTERN = re.compile(r"^/f/[a-z0-9_]+$")
+
+# Data namespace pattern: idb_{foundup_id}
+DATA_NAMESPACE_PATTERN = re.compile(r"^idb_[a-z0-9_]+$")
+
+# Reserved root paths that FoundUps must NOT claim
+RESERVED_ROOT_PATHS = frozenset({
+    "/member", "/foundups", "/media", "/f", "/api", "/admin",
+    "/assets", "/static", "/js", "/css", "/images", "/public"
+})
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _foundups_root() -> Path:
+    return _repo_root() / "modules" / "foundups"
+
+
+def _load_catalog() -> list[dict[str, Any]]:
+    """Load mall-video-catalog.json as array."""
+    catalog_path = _repo_root() / "public" / "member" / "mall-video-catalog.json"
+    if not catalog_path.exists():
+        return []
+    with open(catalog_path, encoding="utf-8") as f:
+        data = json.load(f)
+    return data if isinstance(data, list) else data.get("items", [])
+
+
+def _load_manifests() -> dict[str, dict[str, Any]]:
+    """Load all foundup_manifest.json files keyed by foundup_id."""
+    manifests: dict[str, dict[str, Any]] = {}
+    for d in _foundups_root().iterdir():
+        if not d.is_dir():
+            continue
+        manifest_path = d / "foundup_manifest.json"
+        if manifest_path.exists():
+            with open(manifest_path, encoding="utf-8") as f:
+                data = json.load(f)
+            fid = data.get("foundup_id")
+            if fid:
+                manifests[fid] = data
+    return manifests
+
+
+def _get_catalog_entries_with_routing() -> list[dict[str, Any]]:
+    """Return catalog entries that have routing_prefix set."""
+    catalog = _load_catalog()
+    return [e for e in catalog if e.get("routing_prefix")]
+
+
+class TestNamespaceUniqueness:
+    """Enforce globally unique namespaces across all FoundUps."""
+
+    def test_foundup_ids_unique_in_catalog(self):
+        """No duplicate foundup_id values in catalog."""
+        catalog = _load_catalog()
+        ids = [e.get("foundup_id") for e in catalog if e.get("foundup_id")]
+        duplicates = [fid for fid in ids if ids.count(fid) > 1]
+        assert not duplicates, f"Duplicate foundup_ids in catalog: {set(duplicates)}"
+
+    def test_routing_prefixes_unique_in_catalog(self):
+        """No duplicate routing_prefix values in catalog."""
+        entries = _get_catalog_entries_with_routing()
+        prefixes = [e["routing_prefix"] for e in entries]
+        duplicates = [p for p in prefixes if prefixes.count(p) > 1]
+        assert not duplicates, f"Duplicate routing_prefixes: {set(duplicates)}"
+
+    def test_data_namespaces_unique_in_catalog(self):
+        """No duplicate data_namespace values in catalog."""
+        catalog = _load_catalog()
+        namespaces = [e.get("data_namespace") for e in catalog if e.get("data_namespace")]
+        duplicates = [ns for ns in namespaces if namespaces.count(ns) > 1]
+        assert not duplicates, f"Duplicate data_namespaces: {set(duplicates)}"
+
+    def test_foundup_ids_unique_in_manifests(self):
+        """No duplicate foundup_id across manifest files."""
+        manifests = _load_manifests()
+        # Manifests are keyed by foundup_id, so duplicates would overwrite.
+        # Check by scanning all manifest files directly.
+        seen: dict[str, Path] = {}
+        for d in _foundups_root().iterdir():
+            if not d.is_dir():
+                continue
+            manifest_path = d / "foundup_manifest.json"
+            if manifest_path.exists():
+                with open(manifest_path, encoding="utf-8") as f:
+                    data = json.load(f)
+                fid = data.get("foundup_id")
+                if fid:
+                    if fid in seen:
+                        pytest.fail(f"Duplicate foundup_id '{fid}' in {manifest_path} and {seen[fid]}")
+                    seen[fid] = manifest_path
+
+
+class TestCanonicalRouteShape:
+    """Enforce /f/{foundup_id} canonical route structure."""
+
+    def test_routing_prefix_matches_canonical_pattern(self):
+        """All routing_prefix values must match /f/{foundup_id} pattern."""
+        entries = _get_catalog_entries_with_routing()
+        violations = []
+        for e in entries:
+            prefix = e["routing_prefix"]
+            if not CANONICAL_ROUTE_PATTERN.match(prefix):
+                violations.append(f"{e.get('foundup_id')}: {prefix}")
+        assert not violations, f"Non-canonical routing_prefix: {violations}"
+
+    def test_routing_prefix_contains_foundup_id(self):
+        """routing_prefix must contain the foundup_id."""
+        entries = _get_catalog_entries_with_routing()
+        violations = []
+        for e in entries:
+            fid = e.get("foundup_id", "")
+            prefix = e["routing_prefix"]
+            expected = f"/f/{fid}"
+            if prefix != expected:
+                violations.append(f"{fid}: got {prefix}, expected {expected}")
+        assert not violations, f"routing_prefix does not match foundup_id: {violations}"
+
+    def test_data_namespace_matches_pattern(self):
+        """data_namespace must match idb_{foundup_id} pattern."""
+        catalog = _load_catalog()
+        violations = []
+        for e in catalog:
+            ns = e.get("data_namespace")
+            if ns and not DATA_NAMESPACE_PATTERN.match(ns):
+                violations.append(f"{e.get('foundup_id')}: {ns}")
+        assert not violations, f"Non-canonical data_namespace: {violations}"
+
+    def test_data_namespace_contains_foundup_id(self):
+        """data_namespace must contain the foundup_id."""
+        catalog = _load_catalog()
+        violations = []
+        for e in catalog:
+            fid = e.get("foundup_id", "")
+            ns = e.get("data_namespace")
+            if ns:
+                expected = f"idb_{fid}"
+                if ns != expected:
+                    violations.append(f"{fid}: got {ns}, expected {expected}")
+        assert not violations, f"data_namespace does not match foundup_id: {violations}"
+
+
+class TestCatalogManifestConsistency:
+    """Ensure catalog entries and manifest files are consistent."""
+
+    def test_manifest_foundup_id_matches_catalog(self):
+        """Manifest foundup_id must match corresponding catalog entry."""
+        manifests = _load_manifests()
+        catalog = _load_catalog()
+        catalog_ids = {e.get("foundup_id") for e in catalog}
+
+        for fid, manifest in manifests.items():
+            if fid in catalog_ids:
+                # Manifest exists and is in catalog - check consistency
+                catalog_entry = next(e for e in catalog if e.get("foundup_id") == fid)
+
+                # Check routing_prefix consistency
+                manifest_prefix = manifest.get("routing_prefix")
+                catalog_prefix = catalog_entry.get("routing_prefix")
+                if manifest_prefix and catalog_prefix:
+                    assert manifest_prefix == catalog_prefix, \
+                        f"{fid}: manifest routing_prefix '{manifest_prefix}' != catalog '{catalog_prefix}'"
+
+                # Check data_namespace consistency
+                manifest_ns = manifest.get("data_namespace")
+                catalog_ns = catalog_entry.get("data_namespace")
+                if manifest_ns and catalog_ns:
+                    assert manifest_ns == catalog_ns, \
+                        f"{fid}: manifest data_namespace '{manifest_ns}' != catalog '{catalog_ns}'"
+
+    def test_manifest_entry_url_matches_catalog(self):
+        """Manifest entry_url must match catalog entry_url when both exist."""
+        manifests = _load_manifests()
+        catalog = _load_catalog()
+
+        for fid, manifest in manifests.items():
+            catalog_entry = next((e for e in catalog if e.get("foundup_id") == fid), None)
+            if catalog_entry:
+                manifest_url = manifest.get("entry_url")
+                catalog_url = catalog_entry.get("entry_url")
+                if manifest_url and catalog_url:
+                    assert manifest_url == catalog_url, \
+                        f"{fid}: manifest entry_url '{manifest_url}' != catalog '{catalog_url}'"
+
+
+class TestNoRootSprawl:
+    """Prevent FoundUps from claiming reserved root paths."""
+
+    def test_routing_prefix_not_reserved_root(self):
+        """routing_prefix must not be a reserved root path."""
+        entries = _get_catalog_entries_with_routing()
+        violations = []
+        for e in entries:
+            prefix = e["routing_prefix"]
+            # Check if prefix is or starts with a reserved path
+            for reserved in RESERVED_ROOT_PATHS:
+                if prefix == reserved or (prefix.startswith(reserved + "/") and reserved != "/f"):
+                    violations.append(f"{e.get('foundup_id')}: {prefix} conflicts with {reserved}")
+        assert not violations, f"Root sprawl violations: {violations}"
+
+    def test_no_root_level_routing_prefix(self):
+        """routing_prefix must not be a single segment (root level)."""
+        entries = _get_catalog_entries_with_routing()
+        violations = []
+        for e in entries:
+            prefix = e["routing_prefix"]
+            # Valid: /f/gotjunk_001 (3+ segments), Invalid: /gotjunk (2 segments)
+            segments = [s for s in prefix.split("/") if s]
+            if len(segments) < 2:
+                violations.append(f"{e.get('foundup_id')}: {prefix} is root-level (needs /f/ prefix)")
+        assert not violations, f"Root-level routing violations: {violations}"
+
+
+class TestManifestStructure:
+    """Validate manifest files have required WSP 104 fields."""
+
+    def test_manifest_has_required_fields(self):
+        """Manifest must have foundup_id, routing_prefix, data_namespace."""
+        manifests = _load_manifests()
+        violations = []
+        for fid, manifest in manifests.items():
+            missing = []
+            if not manifest.get("foundup_id"):
+                missing.append("foundup_id")
+            if not manifest.get("routing_prefix"):
+                missing.append("routing_prefix")
+            if not manifest.get("data_namespace"):
+                missing.append("data_namespace")
+            if missing:
+                violations.append(f"{fid}: missing {missing}")
+        assert not violations, f"Manifest missing required fields: {violations}"
+
+
+class TestGotJunkFirstTenant:
+    """GotJunk is the first bound tenant - verify WSP 104 compliance."""
+
+    def test_gotjunk_manifest_exists(self):
+        """GotJunk manifest exists at expected location."""
+        manifest_path = _foundups_root() / "gotjunk" / "foundup_manifest.json"
+        assert manifest_path.exists(), "gotjunk/foundup_manifest.json must exist"
+
+    def test_gotjunk_canonical_routing(self):
+        """GotJunk has canonical /f/gotjunk_001 routing."""
+        manifests = _load_manifests()
+        assert "gotjunk_001" in manifests, "gotjunk_001 manifest must exist"
+
+        manifest = manifests["gotjunk_001"]
+        assert manifest.get("routing_prefix") == "/f/gotjunk_001"
+        assert manifest.get("data_namespace") == "idb_gotjunk_001"
+
+    def test_gotjunk_in_catalog(self):
+        """GotJunk appears in mall-video-catalog with consistent routing."""
+        catalog = _load_catalog()
+        gotjunk = next((e for e in catalog if e.get("foundup_id") == "gotjunk_001"), None)
+        assert gotjunk is not None, "gotjunk_001 must be in catalog"
+        assert gotjunk.get("routing_prefix") == "/f/gotjunk_001"
+        assert gotjunk.get("data_namespace") == "idb_gotjunk_001"

--- a/public/member/ModLog.md
+++ b/public/member/ModLog.md
@@ -1,5 +1,40 @@
 # Member Area Module Change Log
 
+## [2026-04-11] GotJunk Real App Binding Phase 1 (Worker BS, WSP 15/97/104)
+
+**Who**: 0102 - Worker BS
+**Slice**: `GOTJUNK_REAL_APP_BINDING_PHASE1`
+**What**: Bind `gotjunk_001` to real Cloud Run deployment so `/f/gotjunk_001/app` loads actual tenant app.
+
+**Files Modified**:
+- `public/member/mall-video-catalog.json` - Added `entry_url` for gotjunk_001
+- `modules/foundups/gotjunk/foundup_manifest.json` - Updated `entry_url` to production Cloud Run URL
+- `modules/foundups/gotjunk/INTERFACE.md` - Added production URL, last sync date
+- `public/member/tests/test_route_contract_bridge.py` - Updated test to verify real entry_url
+
+**Runtime Source**:
+- **Cloud Run URL**: `https://gotjunk-56566376153.us-west1.run.app/`
+- **Auto-deploy**: Triggered by merge to `main` branch
+- **Build**: Vite + nginx (via Dockerfile)
+
+**Catalog/Manifest Agreement**:
+- `entry_url`: `https://gotjunk-56566376153.us-west1.run.app/`
+- `routing_prefix`: `/f/gotjunk_001`
+- `data_namespace`: `idb_gotjunk_001`
+
+**Behavior Change**:
+| Route | Before | After |
+|-------|--------|-------|
+| `/f/gotjunk_001/app` | "App Not Ready" | Loads GotJunk PWA in iframe |
+| Landing "Launch App" CTA | Not shown | Shows and navigates to `/f/gotjunk_001/app` |
+
+**WSP 104 Applied**: Tenant app loads at `/f/gotjunk_001/app` via shell-owned mount; no root sprawl.
+**WSP 97 Applied**: entry_url reflects real deployed runtime; truthful readiness.
+
+**Test Results**: 40 passed
+
+---
+
 ## [2026-04-11] Lane Autoplay and FoundUp Entry Phase 1 (Worker BL, WSP 15/97/104)
 
 **Who**: 0102 — Worker BL

--- a/public/member/ModLog.md
+++ b/public/member/ModLog.md
@@ -1,35 +1,33 @@
 # Member Area Module Change Log
 
-## [2026-04-11] GotJunk Real App Binding Phase 1 (Worker BS, WSP 15/97/104)
+## [2026-04-11] GotJunk App Binding Attempted + X-Frame-Options Blocker (Worker BS, WSP 15/97/104)
 
 **Who**: 0102 - Worker BS
 **Slice**: `GOTJUNK_REAL_APP_BINDING_PHASE1`
-**What**: Bind `gotjunk_001` to real Cloud Run deployment so `/f/gotjunk_001/app` loads actual tenant app.
+**What**: Attempted to bind `gotjunk_001` to Cloud Run deployment. Reverted due to iframe blocker.
+
+**BLOCKER**: Cloud Run returns `X-Frame-Options: SAMEORIGIN` which prevents iframe embed at `/f/gotjunk_001/app`. The shell app mount uses an `<iframe>` to load tenant apps.
 
 **Files Modified**:
-- `public/member/mall-video-catalog.json` - Added `entry_url` for gotjunk_001
-- `modules/foundups/gotjunk/foundup_manifest.json` - Updated `entry_url` to production Cloud Run URL
-- `modules/foundups/gotjunk/INTERFACE.md` - Added production URL, last sync date
-- `public/member/tests/test_route_contract_bridge.py` - Updated test to verify real entry_url
+- `modules/foundups/gotjunk/foundup_manifest.json` - Set `entry_url` to null (was `frontend/index.html`)
+- `modules/foundups/gotjunk/INTERFACE.md` - Documented production URL
+- `public/member/tests/test_route_contract_bridge.py` - Test guards against premature entry_url
 
-**Runtime Source**:
-- **Cloud Run URL**: `https://gotjunk-56566376153.us-west1.run.app/`
-- **Auto-deploy**: Triggered by merge to `main` branch
-- **Build**: Vite + nginx (via Dockerfile)
+**What Stays True**:
+- Cloud Run deployment exists: `https://gotjunk-56566376153.us-west1.run.app/`
+- Auto-deploy works (Cloud Build trigger on main)
+- Manifest and catalog agree: no entry_url until frame-compatible
 
-**Catalog/Manifest Agreement**:
-- `entry_url`: `https://gotjunk-56566376153.us-west1.run.app/`
-- `routing_prefix`: `/f/gotjunk_001`
-- `data_namespace`: `idb_gotjunk_001`
+**Unblock Path**:
+Configure nginx in `modules/foundups/gotjunk/frontend/Dockerfile` or nginx config to:
+1. Remove `X-Frame-Options: SAMEORIGIN`, OR
+2. Set `X-Frame-Options: ALLOWALL`, OR
+3. Use `Content-Security-Policy: frame-ancestors` with shell origin
 
-**Behavior Change**:
-| Route | Before | After |
-|-------|--------|-------|
-| `/f/gotjunk_001/app` | "App Not Ready" | Loads GotJunk PWA in iframe |
-| Landing "Launch App" CTA | Not shown | Shows and navigates to `/f/gotjunk_001/app` |
+Then re-add `entry_url` to catalog and manifest.
 
-**WSP 104 Applied**: Tenant app loads at `/f/gotjunk_001/app` via shell-owned mount; no root sprawl.
-**WSP 97 Applied**: entry_url reflects real deployed runtime; truthful readiness.
+**WSP 104 Applied**: No root sprawl; app mount route ready but waiting for frame-compatible headers.
+**WSP 97 Applied**: Truthful readiness - "App Not Ready" shown because it genuinely isn't embeddable yet.
 
 **Test Results**: 40 passed
 

--- a/public/member/mall-video-catalog.json
+++ b/public/member/mall-video-catalog.json
@@ -11152,7 +11152,6 @@
     "launch_readiness": "conditional",
     "routing_prefix": "/f/gotjunk_001",
     "data_namespace": "idb_gotjunk_001",
-    "entry_url": "https://gotjunk-56566376153.us-west1.run.app/",
     "token_symbol": "JUNK",
     "poster_url": "/media/posters/gotjunk.jpg",
     "video_count": 0,

--- a/public/member/mall-video-catalog.json
+++ b/public/member/mall-video-catalog.json
@@ -11152,6 +11152,7 @@
     "launch_readiness": "conditional",
     "routing_prefix": "/f/gotjunk_001",
     "data_namespace": "idb_gotjunk_001",
+    "entry_url": "https://gotjunk-56566376153.us-west1.run.app/",
     "token_symbol": "JUNK",
     "poster_url": "/media/posters/gotjunk.jpg",
     "video_count": 0,

--- a/public/member/tests/TestModLog.md
+++ b/public/member/tests/TestModLog.md
@@ -4,6 +4,27 @@ Test evolution log for the p.fMALL member shell test suite.
 
 ---
 
+## 2026-04-11 | GotJunk Tenant Binding Test (WSP 104/97)
+
+**File**: `test_route_contract_bridge.py` (modified)
+**Tests**: 1 updated | **Class**: `TestGotJunkTenantBinding` | **Result**: 40 passed
+**Worker**: BS
+
+Updated test to verify GotJunk now has real Cloud Run `entry_url`:
+
+| Test | Before | After |
+|------|--------|-------|
+| `test_gotjunk_no_entry_url_yet` | Verified entry_url missing | `test_gotjunk_has_entry_url` - verifies Cloud Run URL present |
+
+**Key verifications**:
+- `entry_url` field exists in gotjunk_001 catalog entry
+- URL contains `gotjunk-` (Cloud Run service name)
+- URL contains `.run.app` (Cloud Run domain)
+
+**Test rationale**: GotJunk is now bound to real Cloud Run deployment at `https://gotjunk-56566376153.us-west1.run.app/`, so test must verify the binding rather than assert missing.
+
+---
+
 ## 2026-04-11 | Lane Autoplay and Enter FoundUp Tests (WSP 15/97/104)
 
 **File**: `test_video_mall_field_runtime.py` (extended)

--- a/public/member/tests/TestModLog.md
+++ b/public/member/tests/TestModLog.md
@@ -4,24 +4,19 @@ Test evolution log for the p.fMALL member shell test suite.
 
 ---
 
-## 2026-04-11 | GotJunk Tenant Binding Test (WSP 104/97)
+## 2026-04-11 | GotJunk Frame-Compatibility Guard Test (WSP 104/97)
 
 **File**: `test_route_contract_bridge.py` (modified)
 **Tests**: 1 updated | **Class**: `TestGotJunkTenantBinding` | **Result**: 40 passed
 **Worker**: BS
 
-Updated test to verify GotJunk now has real Cloud Run `entry_url`:
+Updated test to guard against premature `entry_url` binding:
 
-| Test | Before | After |
-|------|--------|-------|
-| `test_gotjunk_no_entry_url_yet` | Verified entry_url missing | `test_gotjunk_has_entry_url` - verifies Cloud Run URL present |
+| Test | What it checks |
+|------|----------------|
+| `test_gotjunk_no_entry_url_until_frame_compatible` | entry_url absent until Cloud Run X-Frame-Options fixed |
 
-**Key verifications**:
-- `entry_url` field exists in gotjunk_001 catalog entry
-- URL contains `gotjunk-` (Cloud Run service name)
-- URL contains `.run.app` (Cloud Run domain)
-
-**Test rationale**: GotJunk is now bound to real Cloud Run deployment at `https://gotjunk-56566376153.us-west1.run.app/`, so test must verify the binding rather than assert missing.
+**Key context**: Cloud Run returns `X-Frame-Options: SAMEORIGIN` which blocks iframe embed. Test enforces truthful readiness by asserting no entry_url until deployment allows framing.
 
 ---
 

--- a/public/member/tests/test_route_contract_bridge.py
+++ b/public/member/tests/test_route_contract_bridge.py
@@ -326,15 +326,14 @@ class TestGotJunkTenantBinding:
         catalog = _read("mall-video-catalog.json")
         assert '"idb_gotjunk_001"' in catalog
 
-    def test_gotjunk_no_entry_url_yet(self):
-        """GotJunk has no entry_url until production deployment exists.
+    def test_gotjunk_has_entry_url(self):
+        """GotJunk has entry_url pointing to Cloud Run deployment.
 
-        Current state: GotJunk is deployed to Cloud Run via AI Studio,
-        but production URL is not yet configured in catalog.
-        App mount will show "App Not Ready" which is truthful.
+        GotJunk is deployed to Cloud Run via AI Studio with auto-deploy.
+        The catalog entry_url must point to the real production URL.
         """
         catalog = _read("mall-video-catalog.json")
-        # Find gotjunk_001 entry and verify no entry_url
+        # Find gotjunk_001 entry and verify entry_url exists
         idx = catalog.find('"foundup_id": "gotjunk_001"')
         assert idx > 0
         # Look for next foundup_id or end of file to bound the entry
@@ -342,7 +341,10 @@ class TestGotJunkTenantBinding:
         if next_entry < 0:
             next_entry = len(catalog)
         gotjunk_entry = catalog[idx:next_entry]
-        assert '"entry_url"' not in gotjunk_entry
+        assert '"entry_url"' in gotjunk_entry
+        # Verify it's a real Cloud Run URL
+        assert "gotjunk-" in gotjunk_entry
+        assert ".run.app" in gotjunk_entry
 
 
 class TestCatalogArrayHandling:

--- a/public/member/tests/test_route_contract_bridge.py
+++ b/public/member/tests/test_route_contract_bridge.py
@@ -326,25 +326,25 @@ class TestGotJunkTenantBinding:
         catalog = _read("mall-video-catalog.json")
         assert '"idb_gotjunk_001"' in catalog
 
-    def test_gotjunk_has_entry_url(self):
-        """GotJunk has entry_url pointing to Cloud Run deployment.
+    def test_gotjunk_no_entry_url_until_frame_compatible(self):
+        """GotJunk has no entry_url until Cloud Run headers allow iframe embed.
 
-        GotJunk is deployed to Cloud Run via AI Studio with auto-deploy.
-        The catalog entry_url must point to the real production URL.
+        BLOCKER: Cloud Run returns X-Frame-Options: SAMEORIGIN which blocks
+        the shell iframe mount at /f/gotjunk_001/app. entry_url must remain
+        absent until the deployment is configured with frame-compatible headers.
+
+        Unblock by: adding X-Frame-Options: ALLOWALL or removing the header
+        and setting Content-Security-Policy frame-ancestors to include the
+        shell origin, then re-adding entry_url to catalog and manifest.
         """
         catalog = _read("mall-video-catalog.json")
-        # Find gotjunk_001 entry and verify entry_url exists
         idx = catalog.find('"foundup_id": "gotjunk_001"')
         assert idx > 0
-        # Look for next foundup_id or end of file to bound the entry
         next_entry = catalog.find('"foundup_id":', idx + 30)
         if next_entry < 0:
             next_entry = len(catalog)
         gotjunk_entry = catalog[idx:next_entry]
-        assert '"entry_url"' in gotjunk_entry
-        # Verify it's a real Cloud Run URL
-        assert "gotjunk-" in gotjunk_entry
-        assert ".run.app" in gotjunk_entry
+        assert '"entry_url"' not in gotjunk_entry
 
 
 class TestCatalogArrayHandling:


### PR DESCRIPTION
## Summary
- Synchronize `gotjunk_001` metadata across manifest, catalog, and INTERFACE docs
- Document `X-Frame-Options: SAMEORIGIN` blocker preventing iframe embed
- Guard against premature `entry_url` binding until Cloud Run headers are fixed
- Set manifest `entry_url` to `null` (was stale `frontend/index.html`)

## Blocker: X-Frame-Options

Cloud Run returns `X-Frame-Options: SAMEORIGIN` which prevents the shell iframe mount at `/f/gotjunk_001/app` from loading the tenant PWA. The app mount correctly shows "App Not Ready" until this is resolved.

**Unblock path**: configure nginx in GotJunk Dockerfile to remove `X-Frame-Options` or set `Content-Security-Policy: frame-ancestors` for the shell origin.

## Files Changed
- `modules/foundups/gotjunk/foundup_manifest.json` — Set `entry_url` to null
- `modules/foundups/gotjunk/INTERFACE.md` — Documented production URL and sync date
- `public/member/tests/test_route_contract_bridge.py` — Guard test for premature entry_url
- `public/member/ModLog.md` — Session entry with blocker documentation
- `public/member/tests/TestModLog.md` — Test entry

## Behavior

| Route | Before | After |
|-------|--------|-------|
| `/f/gotjunk_001/app` | "App Not Ready" | "App Not Ready" (truthful) |
| manifest `entry_url` | `frontend/index.html` (stale) | `null` (correct) |

## WSP Applied
- **WSP 104**: Canonical route metadata preserved; no root sprawl
- **WSP 97**: Truthful readiness — no false Launch App CTA

## Test plan
- [x] 40 route contract tests pass
- [x] Test guards against premature entry_url until iframe blocker resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)