### PR TITLE
feat(foundups): bind kosei to canonical shell routes (WSP 104)

### DIFF
--- a/public/member/ModLog.md
+++ b/public/member/ModLog.md
@@ -1,5 +1,31 @@
 # Member Area Module Change Log
 
+## [2026-04-12] Kosei Shell Route Binding (Worker BU, WSP 15/97/104)
+
+**Who**: 0102 - Worker BU
+**Slice**: `KOSEI_LANDING_AND_APP_BINDING_PHASE1`
+**What**: Codify Kosei as second canonical shell-bound FoundUp after GotJunk.
+
+**Files Modified**:
+- `public/member/tests/test_route_contract_bridge.py` - Added `TestKoseiTenantBinding` (5 tests)
+
+**Binding Truth**:
+- Landing: `/f/kosei` resolves through canonical shell contract
+- App mount: `/f/kosei/app` shows "App Not Ready" (truthful - no embeddable runtime yet)
+- `entry_url`: omitted (no fake URL)
+- `launch_readiness`: `discoverable_only`
+
+**Pre-existing Truth** (no changes needed):
+- `modules/foundups/kosei/foundup_manifest.json` - Already has `routing_prefix: /f/kosei`, `data_namespace: idb_kosei`, `entry_url: null`
+- `public/member/mall-video-catalog.json` - Already has matching routing fields, no entry_url
+
+**WSP 104 Applied**: No root sprawl; route family is `/f/kosei` and `/f/kosei/app`.
+**WSP 97 Applied**: Truthful readiness - "discoverable_only" state, no fake URLs.
+
+**Test Results**: 45 passed (was 40)
+
+---
+
 ## [2026-04-11] GotJunk App Binding Attempted + X-Frame-Options Blocker (Worker BS, WSP 15/97/104)
 
 **Who**: 0102 - Worker BS

--- a/public/member/tests/TestModLog.md
+++ b/public/member/tests/TestModLog.md
@@ -4,6 +4,26 @@ Test evolution log for the p.fMALL member shell test suite.
 
 ---
 
+## 2026-04-12 | Kosei Tenant Binding Tests (WSP 104/97)
+
+**File**: `test_route_contract_bridge.py` (extended)
+**Tests**: 5 added | **Class**: `TestKoseiTenantBinding` | **Result**: 45 passed
+**Worker**: BU
+
+Validates Kosei as second canonical shell-bound FoundUp:
+
+| Test | What it checks |
+|------|----------------|
+| `test_kosei_in_catalog` | Kosei exists in mall-video-catalog.json |
+| `test_kosei_has_routing_prefix` | Catalog has `/f/kosei` routing |
+| `test_kosei_has_data_namespace` | Catalog has `idb_kosei` namespace |
+| `test_kosei_no_entry_url_truthfully` | No fake entry_url (no embeddable app yet) |
+| `test_kosei_launch_readiness_is_discoverable_only` | Kosei is discoverable_only |
+
+**Key context**: Kosei is bound to canonical shell routes but has no embeddable runtime yet. Landing exists at `/f/kosei`, app mount shows "App Not Ready" truthfully.
+
+---
+
 ## 2026-04-11 | GotJunk Frame-Compatibility Guard Test (WSP 104/97)
 
 **File**: `test_route_contract_bridge.py` (modified)

--- a/public/member/tests/test_route_contract_bridge.py
+++ b/public/member/tests/test_route_contract_bridge.py
@@ -347,6 +347,57 @@ class TestGotJunkTenantBinding:
         assert '"entry_url"' not in gotjunk_entry
 
 
+class TestKoseiTenantBinding:
+    """Test Kosei as second bound tenant (WSP 104).
+
+    Kosei is bound to the canonical shell route family after GotJunk.
+    Unlike GotJunk, Kosei has no embeddable runtime yet (discoverable_only).
+    """
+
+    def test_kosei_in_catalog(self):
+        """Kosei exists in mall-video-catalog.json."""
+        catalog = _read("mall-video-catalog.json")
+        assert '"foundup_id": "kosei"' in catalog
+
+    def test_kosei_has_routing_prefix(self):
+        """Kosei catalog entry has correct routing_prefix."""
+        catalog = _read("mall-video-catalog.json")
+        assert '"/f/kosei"' in catalog
+
+    def test_kosei_has_data_namespace(self):
+        """Kosei catalog entry has data_namespace."""
+        catalog = _read("mall-video-catalog.json")
+        assert '"idb_kosei"' in catalog
+
+    def test_kosei_no_entry_url_truthfully(self):
+        """Kosei has no entry_url because no embeddable app exists yet.
+
+        Kosei is discoverable_only - users can see the landing page at /f/kosei
+        but /f/kosei/app will show "App Not Ready" because there's no runtime
+        URL to embed. This is truthful: no fake URLs, no promises we can't keep.
+        """
+        catalog = _read("mall-video-catalog.json")
+        idx = catalog.find('"foundup_id": "kosei"')
+        assert idx > 0
+        next_entry = catalog.find('"foundup_id":', idx + 20)
+        if next_entry < 0:
+            next_entry = len(catalog)
+        kosei_entry = catalog[idx:next_entry]
+        # entry_url should not appear in kosei's catalog entry
+        assert '"entry_url"' not in kosei_entry
+
+    def test_kosei_launch_readiness_is_discoverable_only(self):
+        """Kosei is discoverable_only - landing exists but app is not ready."""
+        catalog = _read("mall-video-catalog.json")
+        idx = catalog.find('"foundup_id": "kosei"')
+        assert idx > 0
+        next_entry = catalog.find('"foundup_id":', idx + 20)
+        if next_entry < 0:
+            next_entry = len(catalog)
+        kosei_entry = catalog[idx:next_entry]
+        assert '"discoverable_only"' in kosei_entry
+
+
 class TestCatalogArrayHandling:
     """Test catalog array format handling."""
 


### PR DESCRIPTION
## Summary
- Codify Kosei as second canonical shell-bound FoundUp after GotJunk
- Add `TestKoseiTenantBinding` class with 5 tests
- Verify truthful routing state (no fake entry_url)

## Binding Truth
| Field | Value |
|-------|-------|
| Landing | `/f/kosei` |
| App mount | `/f/kosei/app` (shows "App Not Ready") |
| `entry_url` | omitted (truthful - no embeddable app) |
| `launch_readiness` | `discoverable_only` |

## Pre-existing Truth (no changes needed)
- `modules/foundups/kosei/foundup_manifest.json` already configured
- `public/member/mall-video-catalog.json` already matches

## Test plan
- [x] `python -m pytest public/member/tests/test_route_contract_bridge.py -q` — 45 passed
- [x] `python -m pytest modules/foundups/tests/test_namespace_guardrail.py -q` — 23 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)