### PR TITLE
fix(holoindex): distinguish missing dep from timeout in warning

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -76,6 +76,44 @@ WSP 97 applied: metadata now reports truthful connection counts.
 
 ---
 
+## [2026-04-11] Fix: Distinguish missing dependency from timeout in warning messages
+
+**Agent**: 0102 — Worker BZ
+**WSP References**: WSP 97 (Pre-flight Compliance), WSP 91 (Observability)
+**Status**: COMPLETE
+
+### Problem
+
+Warning message conflated missing `sentence_transformers` dependency with actual timeout:
+```
+WARNING:holo_index.core.holo_index:SentenceTransformer import timed out: No module named 'sentence_transformers'
+```
+
+This was confusing because the import didn't time out — the dependency was simply not installed.
+
+### Fix
+
+Enhanced `_run_with_timeout()` in `core/holo_index.py` to distinguish:
+
+1. **Missing dependency** (ImportError/ModuleNotFoundError):
+   `"Missing dependency: No module named 'sentence_transformers'. Fix: pip install sentence-transformers (or use HOLO_SKIP_MODEL=1 for lexical-only)"`
+
+2. **Actual timeout** (FuturesTimeoutError):
+   `"SentenceTransformer import timed out (>5s). Try HOLO_SKIP_MODEL=1 or HOLO_OFFLINE=1"`
+
+### Supported Remediation Paths
+
+- Install: `pip install -r holo_index/requirements.txt`
+- Lexical fallback: `HOLO_SKIP_MODEL=1` or `--offline`
+- Pre-cache model: Ensure `E:/HoloIndex/models/` has model files
+
+### Tests
+
+- All existing HoloIndex tests pass (13 passed, 1 skipped)
+- Manual verification confirms distinct warning messages
+
+---
+
 ## [2026-04-05] External FoundUp — shell backend registration (bridge contract doc only)
 
 **Agent**: 0102 — Worker H  

--- a/holo_index/core/holo_index.py
+++ b/holo_index/core/holo_index.py
@@ -50,24 +50,36 @@ HOLO_ENCODE_TIMEOUT = float(os.getenv("HOLO_ENCODE_TIMEOUT", "3"))              
 HOLO_SEARCH_TIMEOUT = float(os.getenv("HOLO_SEARCH_TIMEOUT", "15"))             # 15s default
 
 
-def _run_with_timeout(func, timeout_sec: float, default=None, error_msg: str = "Operation timed out"):
+def _run_with_timeout(func, timeout_sec: float, default=None, error_msg: str = "Operation timed out",
+                      missing_dep_hint: str = None):
     """
     Execute a function with a hard timeout using ThreadPoolExecutor.
     Returns default value on timeout or exception instead of hanging.
+
+    Distinguishes between:
+    - Actual timeout (FuturesTimeoutError): Log as timeout with remediation hints
+    - Missing dependency (ImportError/ModuleNotFoundError): Log with install hint
+    - Other exceptions: Log with original error message
 
     WSP 97: Prevents indefinite hangs in HoloIndex operations.
     """
     from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 
+    logger = logging.getLogger(__name__)
     with ThreadPoolExecutor(max_workers=1) as executor:
         future = executor.submit(func)
         try:
             return future.result(timeout=timeout_sec)
         except FuturesTimeoutError:
-            logging.getLogger(__name__).warning(f"{error_msg} (>{timeout_sec}s)")
+            logger.warning(f"{error_msg} (>{timeout_sec}s). Try HOLO_SKIP_MODEL=1 or HOLO_OFFLINE=1")
+            return default
+        except (ImportError, ModuleNotFoundError) as e:
+            # Missing dependency - distinct from timeout
+            hint = missing_dep_hint or "pip install -r holo_index/requirements.txt"
+            logger.warning(f"Missing dependency: {e}. Fix: {hint}")
             return default
         except Exception as e:
-            logging.getLogger(__name__).warning(f"{error_msg}: {e}")
+            logger.warning(f"{error_msg}: {e}")
             return default
 
 
@@ -195,7 +207,8 @@ class HoloIndex:
                     _import_sentence_transformers,
                     timeout_sec=HOLO_MODEL_IMPORT_TIMEOUT,
                     default=None,
-                    error_msg="SentenceTransformer import timed out"
+                    error_msg="SentenceTransformer import timed out",
+                    missing_dep_hint="pip install sentence-transformers (or use HOLO_SKIP_MODEL=1 for lexical-only)"
                 )
                 if SentenceTransformer is None:
                     self._log_agent_action("SentenceTransformer unavailable; falling back to lexical search", "WARN")

--- a/holo_index/docs/HOLO_INDEX_REMEDIATION.md
+++ b/holo_index/docs/HOLO_INDEX_REMEDIATION.md
@@ -1,8 +1,26 @@
 # HoloIndex Search Hang Remediation (WSP 97 Compliance)
 
-**Date**: 2026-03-18
+**Date**: 2026-03-18 (updated 2026-04-11)
 **Status**: RESOLVED
 **Issue**: HoloIndex `--search` command hanging indefinitely, blocking WSP 97 pre-flight operations
+
+---
+
+## 2026-04-11 Fix: Distinguish Missing Dependency from Timeout
+
+**Problem**: Warning message conflated missing `sentence_transformers` with actual timeout:
+```
+WARNING:holo_index.core.holo_index:SentenceTransformer import timed out: No module named 'sentence_transformers'
+```
+
+**Fix**: `_run_with_timeout()` now distinguishes:
+- **Missing dependency** (ImportError/ModuleNotFoundError): `"Missing dependency: No module named 'sentence_transformers'. Fix: pip install sentence-transformers (or use HOLO_SKIP_MODEL=1 for lexical-only)"`
+- **Actual timeout** (FuturesTimeoutError): `"SentenceTransformer import timed out (>5s). Try HOLO_SKIP_MODEL=1 or HOLO_OFFLINE=1"`
+
+**Supported Paths**:
+1. **Install dependency**: `pip install -r holo_index/requirements.txt`
+2. **Use lexical fallback**: `HOLO_SKIP_MODEL=1` or `--offline` flag
+3. **Pre-cache model**: Ensure `E:/HoloIndex/models/` has the model files
 
 ---
 


### PR DESCRIPTION
## Summary
- `_run_with_timeout()` now distinguishes ImportError from TimeoutError
- Missing dependency shows actionable install hint instead of confusing "timed out" message
- Updated HOLO_INDEX_REMEDIATION.md and ModLog.md with fix documentation

## Before
```
WARNING:holo_index.core.holo_index:SentenceTransformer import timed out: No module named 'sentence_transformers'
```

## After
```
WARNING:holo_index.core.holo_index:Missing dependency: No module named 'sentence_transformers'. Fix: pip install sentence-transformers (or use HOLO_SKIP_MODEL=1 for lexical-only)
```

## Test plan
- [x] Manual verification: distinct messages for missing dep vs timeout
- [x] Unit tests pass (13 passed, 1 skipped)
- [x] Lexical fallback preserved

🤖 Generated with [Claude Code](https://claude.ai/code)