### PR TITLE
docs(kosei): record deploy-time header verification result

### DIFF
--- a/modules/foundups/kosei/ModLog.md
+++ b/modules/foundups/kosei/ModLog.md
@@ -1,5 +1,62 @@
 # Kosei AI Systems — ModLog
 
+## 2026-04-12 — Deploy-Time Header Verification
+
+**Worker**: BX3
+**Slice**: `KOSEI_DEPLOY_TIME_HEADER_VERIFICATION_PHASE1`
+
+### Verification Performed
+
+Deployed Firebase Hosting with path-specific header config and checked live headers.
+
+**Deploy method**: `firebase deploy --only hosting --project gen-lang-client-0061781628`
+**Live URL checked**: `https://foundupscom.web.app/kosei/app/`
+
+### Live Headers Observed
+
+```
+HTTP/1.1 200 OK
+Content-Security-Policy: frame-ancestors https://foundups.com https://*.foundups.com https://foundupscom.web.app https://foundupscom.firebaseapp.com http://localhost:* https://localhost:*
+X-Frame-Options: DENY
+```
+
+### Finding: Firebase Cannot Clear Inherited Headers
+
+Setting `X-Frame-Options: ""` does NOT clear the inherited global `X-Frame-Options: DENY`. Firebase Hosting's header rules are **additive** — path-specific rules add headers but cannot remove headers set by broader rules.
+
+### Embeddability Assessment
+
+**Per W3C CSP3 spec** (https://www.w3.org/TR/CSP3/):
+> If a Content-Security-Policy header that contains the frame-ancestors directive is delivered with the resource, the X-Frame-Options header MUST be ignored.
+
+This means:
+- **Modern browsers** (Chrome 40+, Firefox 35+, Safari 10+, Edge 15+) should ignore `X-Frame-Options` and use `frame-ancestors`
+- **Legacy browsers** would still honor `X-Frame-Options: DENY` and block embedding
+- **Actual embeddability requires in-browser iframe test**
+
+### Current State (WSP 97)
+
+- **CSP frame-ancestors**: Live and correct ✓
+- **X-Frame-Options**: Still present (cannot be cleared via Firebase config)
+- **entry_url**: Remains `null` — truthful state until in-browser test confirms embedding
+- **Next step**: In-browser iframe test to confirm CSP precedence
+
+### Remaining Blockers
+
+| Blocker | Severity | Notes |
+|---------|----------|-------|
+| In-browser iframe test needed | P1 | CSP should take precedence, but needs browser confirmation |
+| Landing page not deployed | P2 | Source needs cleanup before deploy |
+| Firebase API keys empty | P2 | Runtime uses `/__/firebase/init.json` auto-config |
+
+### WSP References
+
+- WSP 15: Verification only, no fake readiness
+- WSP 97: entry_url null until browser test confirms embedding
+- WSP 104: Verified on `/kosei/app/` path
+
+---
+
 ## 2026-04-12 — Firebase Hosting Deploy Phase 1
 
 **Worker**: BX2

--- a/modules/foundups/kosei/README.md
+++ b/modules/foundups/kosei/README.md
@@ -79,17 +79,17 @@ Canonical contract: `modules/foundups/docs/FOUNDUP_AI_HOOKS_AND_DAEMON_SURFACE_C
 
 ## App Mount
 
-Shell contract: **`/f/kosei/app`**. App bundle staged at `public/kosei/app/`.
+Shell contract: **`/f/kosei/app`**. App bundle deployed at `https://foundupscom.web.app/kosei/app/`.
+
+**Header state** (verified 2026-04-12):
+- `Content-Security-Policy: frame-ancestors ...` ✓ (correctly set)
+- `X-Frame-Options: DENY` still present (Firebase cannot clear inherited headers)
+
+**Per W3C CSP3 spec**: Modern browsers should ignore X-Frame-Options when frame-ancestors is present. Embeddability requires in-browser iframe test to confirm.
 
 **Blockers before shell embedding**:
-1. **P1 UNVERIFIED**: Iframe header fix — whether `X-Frame-Options: ""` clears inherited global `DENY` is untested. See ModLog for proposed config.
-2. **P2**: Landing page (`/kosei/`) not deployed — source needs cleanup.
-
-**Deploy + verify**:
-```bash
-firebase deploy --only hosting
-curl -sI https://foundupscom.web.app/kosei/app/ | grep -iE "(x-frame|content-security)"
-```
+1. **P1**: In-browser iframe test needed — CSP should take precedence, but needs browser confirmation
+2. **P2**: Landing page (`/kosei/`) not deployed — source needs cleanup
 
 ---
 


### PR DESCRIPTION
## Summary

- Deployed Firebase Hosting with path-specific header config
- Verified live headers at `https://foundupscom.web.app/kosei/app/`
- Documented finding: Firebase cannot clear inherited headers

## Live Headers Observed

```
Content-Security-Policy: frame-ancestors https://foundups.com https://*.foundups.com https://foundupscom.web.app https://foundupscom.firebaseapp.com http://localhost:* https://localhost:*
X-Frame-Options: DENY
```

## Finding

Firebase Hosting's header rules are **additive** — path-specific rules add headers but cannot remove headers set by broader rules. Setting `X-Frame-Options: ""` does NOT clear the inherited global DENY.

## Embeddability Assessment

Per W3C CSP3 spec, modern browsers should ignore X-Frame-Options when frame-ancestors is present. Next step is in-browser iframe test to confirm.

## Test plan

- [x] Deploy: `firebase deploy --only hosting` — succeeded
- [x] Header check: `curl -sI https://foundupscom.web.app/kosei/app/` — both headers present
- [x] Route tests: `python -m pytest public/member/tests/test_route_contract_bridge.py -q` → 45 passed
- [ ] In-browser iframe test (next slice)

## WSP References

- WSP 15: Verification only, no fake readiness
- WSP 97: entry_url remains null until browser test confirms embedding
- WSP 104: Verified on `/kosei/app/` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)