### PR TITLE
docs(kosei): record iframe embed verification result - VERIFIED

### DIFF
--- a/modules/foundups/kosei/ModLog.md
+++ b/modules/foundups/kosei/ModLog.md
@@ -1,5 +1,65 @@
 # Kosei AI Systems — ModLog
 
+## 2026-04-13 — In-Browser Iframe Embed Verification
+
+**Worker**: BX4
+**Slice**: `KOSEI_IN_BROWSER_IFRAME_EMBED_VERIFICATION_PHASE1`
+
+### Verification Performed
+
+Tested actual iframe embedding in a modern browser (Chrome) against the FoundUps shell domain.
+
+**Browser path used**: `https://foundupscom.web.app/f/kosei`
+**Iframe source**: `https://foundupscom.web.app/kosei/app/`
+**Method**: Injected iframe via JavaScript on the shell page
+
+### Result: VERIFIED EMBEDDABLE
+
+The Kosei app **successfully renders** inside an iframe on the FoundUps shell domain.
+
+**Screenshot evidence**: Kosei auth gate fully visible inside iframe:
+- Kosei logo and title
+- "Sign in to your workspace" text
+- "Sign in with Google" button
+- Email/Password input fields
+- "Sign in with Email" button
+
+### Finding: CSP Takes Precedence
+
+Per W3C CSP3 spec, modern browsers ignore `X-Frame-Options` when `Content-Security-Policy: frame-ancestors` is present. This is now **confirmed** in practice:
+- Headers still show both `frame-ancestors` and `X-Frame-Options: DENY`
+- Chrome correctly ignores `X-Frame-Options` and allows embedding
+- The iframe renders without any frame policy errors
+
+### Current State (WSP 97)
+
+- **Iframe embedding**: VERIFIED ✓
+- **CSP frame-ancestors**: Working correctly ✓
+- **entry_url**: Remains `null` pending tiny metadata restore slice
+- **App renders**: Auth gate fully functional in iframe
+
+### Next Step
+
+**`BX5 — KOSEI_RESTORE_ENTRY_URL_PHASE1`**: Tiny metadata update to:
+1. Set `entry_url` to `/f/kosei/app` in `foundup_manifest.json`
+2. Update `mall-video-catalog.json` if needed
+3. Kosei will then appear as embeddable in the shell instead of "DISCOVERABLE ONLY"
+
+### Remaining Blockers (P2)
+
+| Blocker | Severity | Notes |
+|---------|----------|-------|
+| Landing page not deployed | P2 | Source needs cleanup before deploy |
+| Firebase API keys empty | P2 | Runtime uses `/__/firebase/init.json` auto-config |
+
+### WSP References
+
+- WSP 15: Browser verification only, no fake readiness
+- WSP 97: entry_url stays null until metadata slice (verification complete, metadata pending)
+- WSP 104: Verified on `/f/kosei` shell route embedding `/kosei/app/`
+
+---
+
 ## 2026-04-12 — Deploy-Time Header Verification
 
 **Worker**: BX3

--- a/modules/foundups/kosei/README.md
+++ b/modules/foundups/kosei/README.md
@@ -81,15 +81,14 @@ Canonical contract: `modules/foundups/docs/FOUNDUP_AI_HOOKS_AND_DAEMON_SURFACE_C
 
 Shell contract: **`/f/kosei/app`**. App bundle deployed at `https://foundupscom.web.app/kosei/app/`.
 
-**Header state** (verified 2026-04-12):
-- `Content-Security-Policy: frame-ancestors ...` ✓ (correctly set)
-- `X-Frame-Options: DENY` still present (Firebase cannot clear inherited headers)
+**Embedding status** (verified 2026-04-13): **VERIFIED EMBEDDABLE**
 
-**Per W3C CSP3 spec**: Modern browsers should ignore X-Frame-Options when frame-ancestors is present. Embeddability requires in-browser iframe test to confirm.
+In-browser iframe test confirmed: Kosei app successfully renders inside the FoundUps shell iframe. CSP `frame-ancestors` takes precedence over `X-Frame-Options: DENY` in modern browsers as per W3C CSP3 spec.
 
-**Blockers before shell embedding**:
-1. **P1**: In-browser iframe test needed — CSP should take precedence, but needs browser confirmation
-2. **P2**: Landing page (`/kosei/`) not deployed — source needs cleanup
+**Next step**: `BX5` — tiny metadata slice to restore `entry_url` in manifest/catalog.
+
+**Remaining blockers** (P2):
+- Landing page (`/kosei/`) not deployed — source needs cleanup
 
 ---
 


### PR DESCRIPTION
## Summary

- In-browser iframe test confirmed: Kosei app successfully renders inside the FoundUps shell iframe
- CSP `frame-ancestors` takes precedence over `X-Frame-Options: DENY` as per W3C CSP3 spec
- `entry_url` remains `null` pending tiny metadata restore slice

## Verification Evidence

**Browser path**: `https://foundupscom.web.app/f/kosei`
**Iframe source**: `https://foundupscom.web.app/kosei/app/`
**Method**: JavaScript iframe injection on shell page

**Result**: Kosei auth gate fully visible inside iframe:
- Kosei logo and title
- "Sign in to your workspace" text
- "Sign in with Google" button
- Email/Password input fields
- "Sign in with Email" button

## Finding

Per W3C CSP3 spec, modern browsers ignore `X-Frame-Options` when `Content-Security-Policy: frame-ancestors` is present. This is now **confirmed** in practice - Chrome correctly allows embedding despite `X-Frame-Options: DENY` header.

## Next Step

**`BX5 — KOSEI_RESTORE_ENTRY_URL_PHASE1`**: Tiny metadata update to set `entry_url` in manifest/catalog. Kosei will then appear as embeddable instead of "DISCOVERABLE ONLY".

## Test plan

- [x] In-browser iframe test: Kosei renders successfully
- [x] Route tests: `python -m pytest public/member/tests/test_route_contract_bridge.py -q` → 45 passed
- [ ] BX5 metadata restore (next slice)

## WSP References

- WSP 15: Browser verification only
- WSP 97: entry_url stays null until metadata slice
- WSP 104: Verified on `/f/kosei` shell route

🤖 Generated with [Claude Code](https://claude.com/claude-code)