### PR TITLE
feat(foundups): restore kosei entry_url after iframe verification

### DIFF
--- a/modules/foundups/kosei/ModLog.md
+++ b/modules/foundups/kosei/ModLog.md
@@ -1,5 +1,36 @@
 # Kosei AI Systems — ModLog
 
+## 2026-04-13 — Restore entry_url After Iframe Verification
+
+**Worker**: BX5
+**Slice**: `KOSEI_RESTORE_ENTRY_URL_PHASE1`
+
+### Changes
+
+Restored Kosei's `entry_url` now that BX4 (PR #337) verified iframe embeddability.
+
+| Field | Before | After |
+|-------|--------|-------|
+| `entry_url` | `null` | `https://foundupscom.web.app/kosei/app/` |
+| `launch_readiness` | `discoverable_only` | `ready` |
+
+### Files Updated
+
+- `modules/foundups/kosei/foundup_manifest.json` — restored `entry_url`, changed `launch_readiness`
+- `public/member/mall-video-catalog.json` — matching catalog update
+- `public/member/tests/test_route_contract_bridge.py` — tests now verify `entry_url` presence
+
+### Result
+
+Kosei is now **ready**. The shell at `/f/kosei/app` will embed the deployed app instead of showing "App Not Ready".
+
+### WSP References
+
+- WSP 97: Truthful metadata — `entry_url` set only after browser verification
+- WSP 104: Route namespace `/f/kosei` → `/f/kosei/app` is canonical
+
+---
+
 ## 2026-04-13 — In-Browser Iframe Embed Verification
 
 **Worker**: BX4

--- a/modules/foundups/kosei/README.md
+++ b/modules/foundups/kosei/README.md
@@ -81,11 +81,11 @@ Canonical contract: `modules/foundups/docs/FOUNDUP_AI_HOOKS_AND_DAEMON_SURFACE_C
 
 Shell contract: **`/f/kosei/app`**. App bundle deployed at `https://foundupscom.web.app/kosei/app/`.
 
-**Embedding status** (verified 2026-04-13): **VERIFIED EMBEDDABLE**
+**Embedding status** (verified 2026-04-13): **APP READY**
 
 In-browser iframe test confirmed: Kosei app successfully renders inside the FoundUps shell iframe. CSP `frame-ancestors` takes precedence over `X-Frame-Options: DENY` in modern browsers as per W3C CSP3 spec.
 
-**Next step**: `BX5` — tiny metadata slice to restore `entry_url` in manifest/catalog.
+**entry_url**: `https://foundupscom.web.app/kosei/app/` (restored in BX5)
 
 **Remaining blockers** (P2):
 - Landing page (`/kosei/`) not deployed — source needs cleanup

--- a/modules/foundups/kosei/foundup_manifest.json
+++ b/modules/foundups/kosei/foundup_manifest.json
@@ -7,12 +7,17 @@
   "tagline": "AI content automation for businesses",
   "tier": "F0_DAE",
   "lifecycle_stage": "incubating",
-  "entry_url": null,
+  "entry_url": "https://foundupscom.web.app/kosei/app/",
   "routing_prefix": "/f/kosei",
   "icon_url": null,
   "required_subscription_tier": "free",
   "is_invite_only": true,
-  "capabilities": ["audit_funnel", "onboarding", "service_orchestration", "client_workspace"],
+  "capabilities": [
+    "audit_funnel",
+    "onboarding",
+    "service_orchestration",
+    "client_workspace"
+  ],
   "agent_routes": [],
   "holo_collections": [],
   "data_namespace": "idb_kosei",
@@ -24,7 +29,7 @@
   "owner_id": "012",
   "token_symbol": "KOSEI",
   "category": "media",
-  "launch_readiness": "discoverable_only",
+  "launch_readiness": "ready",
   "created_at": "2026-04-06T00:00:00Z",
   "signature": ""
 }

--- a/public/member/ModLog.md
+++ b/public/member/ModLog.md
@@ -1,5 +1,28 @@
 # Member Area Module Change Log
 
+## [2026-04-13] Kosei entry_url Restored (Worker BX5, WSP 97/104)
+
+**Who**: 0102 - Worker BX5
+**Slice**: `KOSEI_RESTORE_ENTRY_URL_PHASE1`
+**What**: Restored Kosei `entry_url` after BX4 verified iframe embeddability.
+
+**Files Modified**:
+- `public/member/mall-video-catalog.json` - Added `entry_url`, changed `launch_readiness` to `ready`
+- `public/member/tests/test_route_contract_bridge.py` - Updated Kosei tests to verify entry_url presence
+
+**Binding Truth (After BX5)**:
+- Landing: `/f/kosei` resolves through canonical shell contract
+- App mount: `/f/kosei/app` embeds deployed app (verified in BX4)
+- `entry_url`: `https://foundupscom.web.app/kosei/app/`
+- `launch_readiness`: `ready`
+
+**WSP 104 Applied**: Route family `/f/kosei` and `/f/kosei/app` unchanged.
+**WSP 97 Applied**: Truthful metadata — entry_url set only after browser verification.
+
+**Test Results**: 45 passed
+
+---
+
 ## [2026-04-12] Kosei Shell Route Binding (Worker BU, WSP 15/97/104)
 
 **Who**: 0102 - Worker BU

--- a/public/member/mall-video-catalog.json
+++ b/public/member/mall-video-catalog.json
@@ -11119,13 +11119,14 @@
     "description": "Kosei AI Systems — AI content automation service for businesses. Internal service FoundUp with planned production domain.",
     "tier": "F0_DAE",
     "lifecycle_stage": "incubating",
-    "launch_readiness": "discoverable_only",
+    "launch_readiness": "ready",
     "routing_prefix": "/f/kosei",
     "data_namespace": "idb_kosei",
     "token_symbol": "KOSEI",
     "poster_url": "/media/posters/kosei.jpg",
     "video_count": 0,
-    "videos": []
+    "videos": [],
+    "entry_url": "https://foundupscom.web.app/kosei/app/"
   },
   {
     "foundup_id": "gotjunk_001",

--- a/public/member/tests/TestModLog.md
+++ b/public/member/tests/TestModLog.md
@@ -4,6 +4,23 @@ Test evolution log for the p.fMALL member shell test suite.
 
 ---
 
+## 2026-04-13 | Kosei entry_url Restored (WSP 104/97)
+
+**File**: `test_route_contract_bridge.py` (modified)
+**Tests**: 2 updated | **Class**: `TestKoseiTenantBinding` | **Result**: 45 passed
+**Worker**: BX5
+
+Updated tests after BX4 verified iframe embeddability:
+
+| Test | What it checks |
+|------|----------------|
+| `test_kosei_has_entry_url` | entry_url is set to deployed app URL |
+| `test_kosei_launch_readiness_is_ready` | Kosei is ready |
+
+**Key context**: BX4 (PR #337) verified Kosei app renders inside FoundUps shell iframe. entry_url now truthfully set.
+
+---
+
 ## 2026-04-12 | Kosei Tenant Binding Tests (WSP 104/97)
 
 **File**: `test_route_contract_bridge.py` (extended)
@@ -17,10 +34,10 @@ Validates Kosei as second canonical shell-bound FoundUp:
 | `test_kosei_in_catalog` | Kosei exists in mall-video-catalog.json |
 | `test_kosei_has_routing_prefix` | Catalog has `/f/kosei` routing |
 | `test_kosei_has_data_namespace` | Catalog has `idb_kosei` namespace |
-| `test_kosei_no_entry_url_truthfully` | No fake entry_url (no embeddable app yet) |
-| `test_kosei_launch_readiness_is_discoverable_only` | Kosei is discoverable_only |
+| `test_kosei_has_entry_url` | entry_url is set (after BX5) |
+| `test_kosei_launch_readiness_is_ready` | Kosei is ready (after BX5) |
 
-**Key context**: Kosei is bound to canonical shell routes but has no embeddable runtime yet. Landing exists at `/f/kosei`, app mount shows "App Not Ready" truthfully.
+**Key context**: Kosei is bound to canonical shell routes with verified embeddable runtime. Landing at `/f/kosei`, app mount at `/f/kosei/app` embeds the deployed app.
 
 ---
 

--- a/public/member/tests/test_route_contract_bridge.py
+++ b/public/member/tests/test_route_contract_bridge.py
@@ -369,12 +369,11 @@ class TestKoseiTenantBinding:
         catalog = _read("mall-video-catalog.json")
         assert '"idb_kosei"' in catalog
 
-    def test_kosei_no_entry_url_truthfully(self):
-        """Kosei has no entry_url because no embeddable app exists yet.
+    def test_kosei_has_entry_url(self):
+        """Kosei has entry_url after BX4 iframe verification confirmed embeddability.
 
-        Kosei is discoverable_only - users can see the landing page at /f/kosei
-        but /f/kosei/app will show "App Not Ready" because there's no runtime
-        URL to embed. This is truthful: no fake URLs, no promises we can't keep.
+        BX4 (PR #337) verified the Kosei app renders inside the FoundUps shell iframe.
+        entry_url is now truthfully set to the deployed app URL.
         """
         catalog = _read("mall-video-catalog.json")
         idx = catalog.find('"foundup_id": "kosei"')
@@ -383,11 +382,11 @@ class TestKoseiTenantBinding:
         if next_entry < 0:
             next_entry = len(catalog)
         kosei_entry = catalog[idx:next_entry]
-        # entry_url should not appear in kosei's catalog entry
-        assert '"entry_url"' not in kosei_entry
+        # entry_url should be present after iframe verification
+        assert '"entry_url": "https://foundupscom.web.app/kosei/app/"' in kosei_entry
 
-    def test_kosei_launch_readiness_is_discoverable_only(self):
-        """Kosei is discoverable_only - landing exists but app is not ready."""
+    def test_kosei_launch_readiness_is_ready(self):
+        """Kosei is ready after iframe embed verification (BX4)."""
         catalog = _read("mall-video-catalog.json")
         idx = catalog.find('"foundup_id": "kosei"')
         assert idx > 0
@@ -395,7 +394,7 @@ class TestKoseiTenantBinding:
         if next_entry < 0:
             next_entry = len(catalog)
         kosei_entry = catalog[idx:next_entry]
-        assert '"discoverable_only"' in kosei_entry
+        assert '"ready"' in kosei_entry
 
 
 class TestCatalogArrayHandling:


### PR DESCRIPTION
## Summary

- Restored Kosei `entry_url` to `https://foundupscom.web.app/kosei/app/`
- Changed `launch_readiness` from `discoverable_only` to `ready`
- Updated `foundup_manifest.json` and `mall-video-catalog.json` to match
- Updated tests to verify `entry_url` presence

## Context

BX4 (PR #337) verified the Kosei app successfully renders inside the FoundUps shell iframe. This slice is the tiny metadata closeout that makes Kosei truthfully app-ready.

**Note**: Uses `ready` (not `app_ready`) as `app_ready` is not supported by shell readiness maps.

## Files Changed

| File | Change |
|------|--------|
| `modules/foundups/kosei/foundup_manifest.json` | Set `entry_url`, changed `launch_readiness` to `ready` |
| `public/member/mall-video-catalog.json` | Matching catalog update |
| `public/member/tests/test_route_contract_bridge.py` | Tests verify entry_url presence |
| `modules/foundups/kosei/ModLog.md` | BX5 entry |
| `public/member/ModLog.md` | BX5 entry |
| `public/member/tests/TestModLog.md` | Test log update |

## Test plan

- [x] `pytest public/member/tests/test_route_contract_bridge.py -q` — 45 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)