### PR TITLE
feat(pfmall): add adaptive desktop 6x3 tile layout

### DIFF
--- a/docs/adr/ADR_FOUNDUPS_MOBILE_WORKER_SKILL_SYSTEM.md
+++ b/docs/adr/ADR_FOUNDUPS_MOBILE_WORKER_SKILL_SYSTEM.md
@@ -1,0 +1,79 @@
+# ADR: FoundUps Mobile Worker Skill System
+
+**Date:** 2026-04-12  
+**Status:** Accepted  
+**Author:** 0102  
+**Domain:** `modules/foundups/` (FoundUps architecture)  
+
+---
+
+## Context
+
+FoundUps needs an **on-device worker** path (e.g. Gemma in AI Edge Gallery) that participates in the **same architecture** as desktop/server agents, without making the phone the **authority** for repo execution, routing, or WSP compliance.
+
+---
+
+## Decision
+
+### Layering
+
+| Layer | Role |
+|-------|------|
+| **Higher agentic layer (0102)** | Routing, skill selection, promotion, WSP interpretation, merge authority, execution on repo when appropriate. |
+| **Phone worker (local model)** | Parse, narrow scope, emit **task packets**, interpret results **as summaries only**—**handoff surface**, not authority. |
+| **012** | Operator; speaks to 0102; does not grant the phone repo write authority by default. |
+
+### Phone worker definition
+
+**In scope:** semantic boot subset, task parsing, scope locking, packet writing, result interpretation, optional minimal `run_js` only where the runtime supports it and supply-chain rules allow.
+
+**Out of scope without an explicit bridge:** arbitrary repo execution, desktop Python, shell, uncontrolled writes, claiming WSP 00 script execution parity with `WSP_agentic/scripts/`.
+
+### Handoff model
+
+1. 012 directs **0102** (or a delegated orchestrator).  
+2. **0102** decides which worker, skill, or hook applies.  
+3. **Phone worker** receives a **constrained** task (text + optional structured hints).  
+4. Phone emits **structured output** (task packet, summary)—**never** silent authority.  
+5. **Upward path:** packet/summary returns to 0102 or approved automation for execution/merge.
+
+### Repo placement (WSP-aligned)
+
+- **Source of truth:** `modules/foundups/mobile_worker_skills/<skill-name>/SKILL.md`  
+- **Builder / rules:** `modules/foundups/docs/WSP_SKILL_BUILDER.md`  
+- **JSON `$defs`:** `modules/foundups/mobile_worker_skills/schemas/worker-handoff-pipeline.v1.schema.json`  
+- **Domain index:** `modules/foundups/mobile_worker_skills/README.md`  
+- **Attachment (WSP 83):** Linked from `modules/foundups/README.md` and this ADR; `ModLog` updated.
+
+Rationale: **WSP 3** function-first—mobile worker skills are **FoundUps platform** concerns, not a personal subtree under `WSP_agentic/` for production artifacts. (Awakening **scripts** remain in `WSP_agentic/`; **mobile semantics** skill references them without executing.)
+
+### Public / URL delivery (WSP 104)
+
+- **Do not** introduce **bespoke top-level** `public/` directories per tenant/feature as the scaling pattern (**WSP 104**).  
+- **Preferred for Edge Gallery URL load:** **external static hosting** (e.g. GitHub Pages) mirroring **tagged releases** of `mobile_worker_skills/`, **or** a **single** shell-approved static path if product later assigns a **FoundUp namespace** under `/f/{foundup_id}` for static mirrors.  
+- Until a hosting decision is recorded, treat **repo paths** as canonical; URL = **deployment concern** documented in `WSP_SKILL_BUILDER.md`.
+
+### Promotion path
+
+1. **Draft** skill in `mobile_worker_skills/`.  
+2. **Review** by 0102 against `WSP_SKILL_BUILDER.md` + supply-chain policy (**WSP 95** alignment for wardrobe cousins).  
+3. **Publish** mirror to approved static host if URL loading is required.  
+4. **No promotion** to OpenClaw/moltbot workspace skills without explicit merge—those wardrobes serve operator surfaces; mobile worker pack stays **FoundUps-named** unless unified later.
+
+---
+
+## Consequences
+
+- Clear **separation of authority**: phone = worker; 0102 = router/authority.  
+- **WSP 104** respected: no new public route sprawl from this ADR alone.  
+- Future **bridge** (optional): signed task packets accepted by WRE/overseer—separate slice.
+
+---
+
+## References
+
+- `WSP_knowledge/src/WSP_00_Zen_State_Attainment_Protocol.md` (desktop gate; mobile = semantic subset only)  
+- `WSP_knowledge/src/WSP_104_FoundUp_Route_Namespace_and_Tenant_Isolation_Protocol.md`  
+- `WSP_knowledge/src/WSP_95_WRE_SKILLz_Wardrobe_Protocol.md`  
+- [AI Edge Gallery skills](https://github.com/google-ai-edge/gallery/tree/main/skills)  
+- `docs/adr/ADR_OPENCLAW_MEMORY_HOLOINDEX_BOUNDARY.md` (context layering; phone worker does not override repo truth)

--- a/docs/adr/ADR_OPENCLAW_MEMORY_HOLOINDEX_BOUNDARY.md
+++ b/docs/adr/ADR_OPENCLAW_MEMORY_HOLOINDEX_BOUNDARY.md
@@ -1,0 +1,91 @@
+# ADR: OpenClaw Memory, HoloIndex, and AI Overseer — Retrieval Boundary
+
+**Date:** 2026-04-11  
+**Status:** Accepted  
+**Author:** 0102 (architect lock-in)  
+**Scope:** Context assembly for `ai_overseer` and related autonomous agents  
+
+**Not a WSP:** This document does not create or modify a Windsurf Protocol. WSP elevation is deferred until the pattern has proven stable in operation.
+
+---
+
+## Context
+
+Three memory-like systems are in play:
+
+1. **HoloIndex** — semantic retrieval over the repository (code, WSP sources, repo docs, contracts).  
+2. **OpenClaw memory** — file-based continuity (e.g. `MEMORY.md`, daily notes under `memory/`, tools such as `memory_search` / `memory_get` in the OpenClaw/Molt workspace).  
+3. **AI Overseer** — automation-oriented persistence (pattern memory, execution history, DAEmon-style state under module memory per WSP 60).
+
+Merging these into a single index or treating session notes as repo truth causes **privacy bleed**, **stale notes masquerading as canon**, and **ranking / authority drift**. Quiet injection of unlabeled context lets models treat operator preferences as if they were codebase facts.
+
+---
+
+## Decision
+
+### Layer roles
+
+| Layer | Role |
+|-------|------|
+| **HoloIndex** | **Canonical** retrieval for code, WSPs, repo docs, and contracts. |
+| **OpenClaw memory** | **Non-canonical continuity** — operator/session notes, recent decisions, preferences, daily working context. |
+| **AI Overseer memory** | **Automation / pattern / execution-state** — heuristics, outcomes, DAEmon-style state — not a substitute for repo or WSP text. |
+
+### Conflict rule
+
+If continuity or automation context **conflicts** with **HoloIndex / repository** content, **repo truth wins**. OpenClaw memory is **context**, not authority.
+
+### Source precedence (query / assembly order)
+
+When `ai_overseer` (or a delegated assembler) builds context:
+
+1. **HoloIndex** — canonical repo/WSP truth first.  
+2. **OpenClaw memory** — continuity second.  
+3. **AI Overseer pattern / execution memory** — automation heuristics last.
+
+### Provenance in **prompt assembly** (required)
+
+Context injected into prompts must be **visibly labeled** so operators and models do not confuse layers:
+
+- **`Canonical repo truth`** — from HoloIndex / repo-grounded snippets.  
+- **`Continuity memory`** — from OpenClaw memory files or `memory_search` / `memory_get` (and equivalents).  
+- **`Automation pattern memory`** — from overseer pattern files, execution reports, DAEmon-style state.
+
+Implementations may also attach machine-readable tags (e.g. `source=holoindex`, `source=openclaw_memory`, `source=ai_overseer_pattern`) **in addition to** these human-visible headings, not instead of them.
+
+### Phase-1 integration scope
+
+- Prefer **read-through** (read configured OpenClaw workspace files such as `MEMORY.md` and today/yesterday daily notes) and/or a **thin tool/CLI wrapper** around OpenClaw memory APIs.  
+- **Do not** by default **ingest raw OpenClaw memory into HoloIndex** (no shared reindexing as the starting position).  
+- **Do not** lead with **QMD / dual-index fusion** or other multi-index cleverness until trust, freshness, and privacy rules are operational.
+
+### Privacy and logging
+
+Apply an explicit **redaction / privacy rule** before continuity content is **logged**, **persisted outside the continuity layer**, or **indexed** anywhere. Default stance: OpenClaw memory may contain operator-private material; treat it as sensitive unless classified otherwise.
+
+---
+
+## Consequences
+
+### Positive
+
+- Clear **authority ordering** reduces silent drift (“memory said X” vs “repo says Y”).  
+- **Labeled** prompt sections make audits and debugging tractable.  
+- HoloIndex remains the **single canonical** semantic index for **repository** knowledge without mixing session diaries by default.
+
+### Negative / tradeoffs
+
+- Overseer prompt assembly grows slightly (section headers).  
+- Operators must **configure** one canonical OpenClaw workspace path for internal read-through.  
+- Two retrieval paths (HoloIndex + OpenClaw tools) remain until a future phase explicitly justifies unification under stricter governance.
+
+---
+
+## References
+
+- OpenClaw memory overview: [Memory Overview](https://docs.molt.bot/concepts/memory)  
+- AI Overseer Holo facade: `modules/ai_intelligence/ai_overseer/src/holo_adapter.py`  
+
+---
+
+*0102 note: Revisit for WSP packaging only after this boundary has been exercised in production-style runs.*

--- a/modules/ai_intelligence/ai_overseer/docs/OPENCLAW_MEMORY_INTEGRATION_BOUNDARY.md
+++ b/modules/ai_intelligence/ai_overseer/docs/OPENCLAW_MEMORY_INTEGRATION_BOUNDARY.md
@@ -1,0 +1,5 @@
+# OpenClaw memory ↔ HoloIndex ↔ AI Overseer
+
+**Canonical spec:** [`docs/adr/ADR_OPENCLAW_MEMORY_HOLOINDEX_BOUNDARY.md`](../../../../docs/adr/ADR_OPENCLAW_MEMORY_HOLOINDEX_BOUNDARY.md)
+
+This file exists so module-local doc search finds the boundary quickly. Do not duplicate the ADR here; edit the ADR only.

--- a/modules/foundups/ModLog.md
+++ b/modules/foundups/ModLog.md
@@ -2,6 +2,37 @@
 
 ## Chronological Change Log
 
+### 2026-04-12 - Matrix A local import runbook (prompts 38214 / 84726 / 55108)
+
+**By:** 0102  
+
+**Added**
+
+- `modules/foundups/mobile_worker_skills/MATRIX_A_LOCAL_IMPORT_RUN.md` — step order: import `foundups-edge-load-smoke` → `ping` / `LOAD_OK`; then import `foundups-code-task-parser` → fixed test phrase; pass/fail + example JSON; URL loading explicitly out of scope for this session.
+
+**Updated**
+
+- `modules/foundups/mobile_worker_skills/README.md` — link to Matrix A runbook.
+
+**Note:** Execution is **on-device** (012); repo cannot perform Gallery import from CI.
+
+---
+
+### 2026-04-12 - Device Edge Gallery validation prep (prompt 10003)
+
+**By:** 0102 · **WSP:** 3, 83, 97, 104  
+
+**Added**
+
+- `modules/foundups/mobile_worker_skills/DEVICE_EDGE_GALLERY_VALIDATION.md` — device test matrix, pass/fail, 012 report template, Pages notes (**raw GitHub ≠ Gallery**).
+- `modules/foundups/mobile_worker_skills/foundups-edge-load-smoke/SKILL.md` — minimal load smoke (`ping` → `LOAD_OK`).
+
+**Updated**
+
+- `modules/foundups/mobile_worker_skills/README.md` — device checklist link; smoke skill row.
+
+---
+
 ### 2026-04-12 - Kosei FoundUp Manifest and Route Binding (WSP 104)
 
 **By:** 0102 (Worker BT) - **Slice:** `KOSEI_FOUNDUP_MANIFEST_AND_ROUTE_BINDING_PHASE1`

--- a/modules/foundups/docs/WSP_SKILL_BUILDER.md
+++ b/modules/foundups/docs/WSP_SKILL_BUILDER.md
@@ -1,0 +1,147 @@
+# WSP — FoundUps Mobile Worker Skill Builder
+
+**Version:** 1.0.1  
+**Date:** 2026-04-12  
+**Status:** Canonical for `modules/foundups/mobile_worker_skills/`  
+**ADR:** `docs/adr/ADR_FOUNDUPS_MOBILE_WORKER_SKILL_SYSTEM.md`  
+
+---
+
+## Purpose
+
+Rules for **text-first** (and optionally JS) skills used by **phone worker** runtimes (e.g. AI Edge Gallery). These skills are **subordinate** to the higher agentic layer (0102); they do **not** hold repo authority.
+
+---
+
+## Architectural rules
+
+1. **Worker layer only** — Skills emit **structured intent**, not merges or shell commands, unless a **documented bridge** exists.  
+2. **No invented paths** — Never output absolute repo paths unless provided in the user packet as **verified allowlist**. Machine JSON should conform to [`mobile_worker_skills/schemas/worker-handoff-pipeline.v1.schema.json`](../mobile_worker_skills/schemas/worker-handoff-pipeline.v1.schema.json) (`$defs`).  
+3. **Inspect-first** — If edit intent is unclear, default to **read-only** classification and **clarifying questions** in the output schema.  
+4. **Compact** — Prefer short JSON or fixed headings; local models have finite context.  
+5. **Edge Gallery shape** — Each skill lives in **kebab-case** folder matching `name`; root file **`SKILL.md`** with YAML frontmatter between `---` lines ([Gallery spec](https://github.com/google-ai-edge/gallery/tree/main/skills)).  
+6. **WSP 83** — New skills must be listed in `mobile_worker_skills/README.md` and referenced from domain docs.  
+7. **WSP 104** — Do not assume new **top-level** `public/` URLs; URL deployment is **Pages or approved static host** unless product assigns a `/f/{foundup_id}` static mirror.
+
+---
+
+## Frontmatter (required)
+
+```yaml
+---
+name: kebab-skill-name    # max 64 chars; must match directory name; [a-z0-9-]
+description: Trigger-ready one-liner, max ~1024 chars, when to use this skill
+metadata:
+  homepage: https://github.com/FOUNDUPS/Foundups-Agent/tree/main/modules/foundups/mobile_worker_skills/kebab-skill-name
+---
+```
+
+Optional (Gallery): `metadata.require-secret` for JS skills—only if implemented.
+
+---
+
+## Skill body structure (recommended)
+
+1. **Role** — Worker; no authority statement.  
+2. **Inputs** — What the model receives.  
+3. **Steps** — Numbered, mechanical.  
+4. **Output format** — Exact headings or JSON keys.  
+5. **Examples** — 1–2.  
+6. **Stop conditions** — When to refuse or hand off.
+
+---
+
+## Naming
+
+- Prefix: `foundups-` for repo workflow skills; `wsp00-` for WSP 00 **mobile semantic** subset only.  
+- Kebab-case, no underscores in folder/`name`.
+
+---
+
+## Output formats (normative patterns)
+
+### Task parser → JSON
+
+```json
+{
+  "intent": "read|edit|mixed|unclear",
+  "summary": "one line",
+  "constraints": ["string"],
+  "open_questions": ["string"],
+  "suggested_next_skill": null
+}
+```
+
+`"suggested_next_skill"` is JSON **`null`** or the string **`"foundups-scope-locker"`** (not the literal `"null"`).
+
+### Scope locker → JSON
+
+`allowed_operations`: array of strings; each item must be exactly one of: **`read_tree`**, **`draft_patch`**, **`tests_only`**, **`none`** (no pipe-separated strings in one element).
+
+```json
+{
+  "scope_ok": true,
+  "allowed_operations": ["draft_patch"],
+  "explicit_non_goals": ["string", "string"],
+  "handoff_required": true,
+  "rationale": "one sentence"
+}
+```
+
+### Task packet → JSON
+
+```json
+{
+  "packet_version": "1",
+  "title": "string",
+  "objective": "string",
+  "files_allowlist": [],
+  "forbidden_paths": [],
+  "acceptance_criteria": ["string"],
+  "evidence_required": ["string"],
+  "wsp_refs": ["WSP 22", "WSP 49"]
+}
+```
+
+### Result interpreter → JSON
+
+```json
+{
+  "status": "pass|fail|partial|unknown",
+  "headline": "one line",
+  "failures": ["string"],
+  "next_action": "string"
+}
+```
+
+### Handoff validator → JSON
+
+```json
+{
+  "validator_version": "1",
+  "valid": true,
+  "errors": [],
+  "warnings": []
+}
+```
+
+---
+
+## Promotion rules
+
+| Stage | Location | Gate |
+|-------|----------|------|
+| Draft | `mobile_worker_skills/<name>/` | Self-review against this doc |
+| Review | PR + 0102 | No orphan paths; no authority leaks |
+| URL mirror | GitHub Pages or approved CDN | Version tag; optional hash in manifest |
+| Cross-wardrobe | `moltbot_bridge/workspace/skills/` | **Explicit** ADR or merge policy only |
+
+---
+
+## WSP 95 note
+
+WRE production skills often use **`SKILLz.md`**. **Edge Gallery** expects **`SKILL.md`**. This tree uses **`SKILL.md`** for Gallery compatibility. If promoting into WRE, add **`SKILLz.md`** copy or symlink policy in the promotion PR.
+
+---
+
+*0102: skills are worker weights; routing stays upstream.*

--- a/modules/foundups/mobile_worker_skills/DEVICE_EDGE_GALLERY_VALIDATION.md
+++ b/modules/foundups/mobile_worker_skills/DEVICE_EDGE_GALLERY_VALIDATION.md
@@ -1,0 +1,111 @@
+# Device validation — AI Edge Gallery × FoundUps mobile worker skills
+
+**Purpose:** Real **on-device** proof that skills **load** and **run** in AI Edge Gallery. **Raw GitHub in a desktop browser is not Gallery proof.**
+
+**Canonical spec:** [Gallery skills README](https://github.com/google-ai-edge/gallery/blob/main/skills/README.md)
+
+---
+
+## Recommended first skill (on-device)
+
+1. **`foundups-code-task-parser`** — text-only, no JS; validates full instruction path.  
+2. **`foundups-edge-load-smoke`** — optional **minimal** load check (see folder `foundups-edge-load-smoke/`).  
+3. **`foundups-handoff-validator`** — second wave; paste JSON from E2E example.
+
+**Do not** test JS / `run_js` skills in this phase.
+
+---
+
+## Test matrix (minimal)
+
+| # | Mode | What to enter / do | Pass criteria | Fail criteria |
+|---|------|-------------------|---------------|---------------|
+| A | **Import local skill** | Copy skill folder to device; Gallery → Skills → (+) → **Import local skill** → pick folder containing `SKILL.md`. | Skill appears in list; name + description match frontmatter; opening chat with skill enabled shows instructions in context (or skill triggers on relevant prompt). | Import error; “Expected at least two `---` sections”; empty skill; crash. |
+| B | **Load skill from URL** | Gallery → **Load skill from URL** → enter **folder base URL** only (see below). | Same as A for discoverability + at least one successful model turn using the skill. | 404; wrong MIME; HTML error page; timeout; skill not listed. |
+| C | **Raw GitHub (sanity)** | Open in **mobile browser** (not Gallery): raw `SKILL.md` URL. | File displays as markdown text starting with `---`. | 404; HTML wrapper only; rate limit. |
+| D | **GitHub Pages (folder URL)** | Use Pages-deployed base `.../mobile_worker_skills/<skill>/` per [Pages setup](#github-pages-setup-notes). | Gallery URL load behaves like row B **success**. | Same as B fail. |
+
+**Critical distinction**
+
+- **C passing** does **not** imply **B** passing.  
+- **B/D passing** is **device Gallery proof**; **C** is only **content reachable** proof.
+
+---
+
+## Expected behavior when a skill loads correctly
+
+1. **Skill Manager** shows the skill **name** (from YAML `name`, kebab-case).  
+2. **Description** visible/trigger-ready (truncated in UI is OK).  
+3. With skill **enabled** for a session, a prompt that matches the description (e.g. “Parse this coding request: …”) causes the model to follow **Role / Steps / Output format** (e.g. emit JSON for parser).  
+4. No requirement to hit the network beyond what Gallery already uses for the model.
+
+---
+
+## Shortest URL candidates (copy-paste templates)
+
+Replace `OWNER`, `REPO`, `BRANCH`, `<skill>` as appropriate.
+
+| Kind | Template | Gallery “Load from URL” use? |
+|------|------------|-------------------------------|
+| Raw **file** (sanity) | `https://raw.githubusercontent.com/OWNER/REPO/BRANCH/modules/foundups/mobile_worker_skills/<skill>/SKILL.md` | **No** — this is a **file**, not a folder base. Use for row **C** only. |
+| **tree/** (browse) | `https://github.com/OWNER/REPO/tree/BRANCH/modules/foundups/mobile_worker_skills/<skill>` | **Unlikely** — HTML UI, not static `{base}/SKILL.md`. |
+| **Pages folder base** | `https://OWNER.github.io/REPO/mobile_worker_skills/<skill>/` | **Yes** — intended row **D** (after deploy). |
+
+**First real Gallery URL test** should use **Pages** (row D) or whatever host exposes `SKILL.md` at `{base}/SKILL.md`.
+
+**Local import** (row A) needs **no URL** — shortest path to **first device proof**.
+
+---
+
+## GitHub Pages setup notes (minimal)
+
+1. Enable **Pages** for the repo (or a dedicated pages repo).  
+2. Repo root (or `docs/` source): add **`.nojekyll`** (empty file) so Jekyll does not eat/transform `.md` unexpectedly.  
+3. Publish a tree that includes:
+
+   `mobile_worker_skills/<skill-name>/SKILL.md`
+
+   e.g. copy or submodule the subtree from `modules/foundups/mobile_worker_skills/`.
+
+4. Confirm in browser:  
+   `https://<site>/mobile_worker_skills/foundups-code-task-parser/SKILL.md`  
+   returns **raw markdown** (starts with `---`).
+
+5. In Gallery **Load skill from URL**, use **folder base**:  
+   `https://<site>/mobile_worker_skills/foundups-code-task-parser/`
+
+**WSP 104:** Pages site is **not** p.fMALL shell routing; no new `public/` sprawl in the product tree is required for this experiment.
+
+---
+
+## 012 failure capture format (paste back to 0102)
+
+```text
+DEVICE_GALLERY_REPORT
+date_utc: YYYY-MM-DDTHH:MMZ
+device: <model + OS version>
+gallery_app: <version if known>
+test_row: A|B|C|D
+skill_folder: <e.g. foundups-code-task-parser>
+url_used: <exact string or LOCAL_IMPORT>
+outcome: PASS|FAIL
+pass_criteria_met: <which bullets from matrix>
+failure_symptom: <one line>
+screenshot_or_log: <optional; describe if not attached>
+notes: <free text>
+```
+
+---
+
+## Pre-flight repo checks (CI / desktop, not device)
+
+- [ ] Each `SKILL.md` has **exactly one** YAML block: opening `---`, closing `---`, then body (Gallery parses frontmatter).  
+- [ ] `name:` matches directory name (kebab-case).  
+- [ ] `examples/E2E_HANDOFF_FLOW_EXAMPLE.md` still matches `schemas/worker-handoff-pipeline.v1.schema.json` for the envelope example.
+
+---
+
+## After device PASS
+
+- Record outcome in `modules/foundups/ModLog.md` (one line + link to this file section).  
+- Optionally pin **Gallery app version** and **model** (e.g. Gemma 4 E4B) in ModLog for reproducibility.

--- a/modules/foundups/mobile_worker_skills/MATRIX_A_LOCAL_IMPORT_RUN.md
+++ b/modules/foundups/mobile_worker_skills/MATRIX_A_LOCAL_IMPORT_RUN.md
@@ -1,0 +1,70 @@
+# Matrix A — local import only (device)
+
+**Prerequisite:** AI Edge Gallery installed; skill folders available on device (USB push, zip extract, or sync).
+
+**Do not use Load skill from URL** in this session.
+
+---
+
+## A1 — `foundups-edge-load-smoke` (fastest proof)
+
+**Prompt id (tracking):** `38214`
+
+1. Copy the entire folder `foundups-edge-load-smoke/` (must contain `SKILL.md`) onto the device.
+2. Gallery → Skills → (+) → **Import local skill** → select that folder.
+3. Enable the skill for a chat session.
+4. Send exactly: `ping` (any case per skill rules).
+
+**Pass:** Model replies exactly `LOAD_OK` (plain text, one line).  
+**Fail:** Import error, wrong reply, or skill not applied.
+
+---
+
+## A2 — `foundups-code-task-parser`
+
+**Prompt id (tracking):** `84726`
+
+1. Import `foundups-code-task-parser/` the same way as A1.
+2. Enable the skill.
+3. Send **exactly** this user message (prompt id `55108`):
+
+```text
+fix swipe threshold in capture controller and run tests
+```
+
+**Pass criteria (structured output):**
+
+- Single JSON object (no markdown fence required by 012 for copy-paste, but body should be parseable JSON).
+- **`intent`** is one of `read` | `edit` | `mixed` | `unclear` — for this message expect **`edit`** or **`mixed`** (code change + tests).
+- **`summary`** is one line, code-related.
+- **`constraints`**: only what the user said (may be empty).
+- **`open_questions`**: must **not** be empty unless the user already named a **verified** file path (they did **not** here) — at minimum ask **which file** holds the capture controller / swipe threshold.
+- **`suggested_next_skill`**: JSON `null` or `"foundups-scope-locker"`; for edit/mixed should be **`"foundups-scope-locker"`**.
+- **No invented file paths** in any field (no fake `src/foo.ts` unless user typed it).
+
+**Fail:** Prose only, invalid JSON, invented paths, empty `open_questions` when no path given, `intent` `read` only.
+
+---
+
+## Desk reference — example compliant parser output (model may vary)
+
+For input `55108` only; valid if it meets the pass criteria above.
+
+```json
+{
+  "intent": "mixed",
+  "summary": "Fix swipe threshold in capture controller and run tests",
+  "constraints": [],
+  "open_questions": [
+    "Which file or module contains the capture controller and swipe threshold logic?",
+    "Which test command or directory should run (e.g. pytest path)?"
+  ],
+  "suggested_next_skill": "foundups-scope-locker"
+}
+```
+
+---
+
+## 012 report back (after A1 + A2)
+
+Use the block in `DEVICE_EDGE_GALLERY_VALIDATION.md` (`DEVICE_GALLERY_REPORT`) with `test_row: A` and attach parser JSON if A2 passed.

--- a/modules/foundups/mobile_worker_skills/README.md
+++ b/modules/foundups/mobile_worker_skills/README.md
@@ -1,0 +1,49 @@
+# FoundUps mobile worker skills
+
+**Authority:** Higher agentic layer (0102) routes work; **phone/local model** runs these as **worker** skills only.
+
+**ADR:** [`docs/adr/ADR_FOUNDUPS_MOBILE_WORKER_SKILL_SYSTEM.md`](../../../docs/adr/ADR_FOUNDUPS_MOBILE_WORKER_SKILL_SYSTEM.md)  
+**Builder rules:** [`../docs/WSP_SKILL_BUILDER.md`](../docs/WSP_SKILL_BUILDER.md)  
+**Device proof (Gallery):** [`DEVICE_EDGE_GALLERY_VALIDATION.md`](DEVICE_EDGE_GALLERY_VALIDATION.md) — **raw GitHub ≠ Gallery**; use this for on-device checklist.  
+**Matrix A (local import only):** [`MATRIX_A_LOCAL_IMPORT_RUN.md`](MATRIX_A_LOCAL_IMPORT_RUN.md) — smoke → parser + exact test string `55108`.
+
+## Skills
+
+| Directory | Purpose |
+|-----------|---------|
+| [`foundups-edge-load-smoke`](foundups-edge-load-smoke/) | Minimal **load** check (`ping` → `LOAD_OK`); optional before parser |
+| [`foundups-code-task-parser`](foundups-code-task-parser/) | NL → structured dev task |
+| [`foundups-scope-locker`](foundups-scope-locker/) | Minimize scope / ambiguity |
+| [`foundups-task-packet-writer`](foundups-task-packet-writer/) | Task → machine packet |
+| [`foundups-result-interpreter`](foundups-result-interpreter/) | Logs/diffs/tests → summary |
+| [`foundups-handoff-validator`](foundups-handoff-validator/) | Validate pipeline JSON before handoff to 0102 |
+| [`wsp00-mobile-semantics`](wsp00-mobile-semantics/) | WSP 00 **semantic** subset for on-device boot (no Python gate) |
+
+## Schemas & examples
+
+| Path | Purpose |
+|------|---------|
+| [`schemas/worker-handoff-pipeline.v1.schema.json`](schemas/worker-handoff-pipeline.v1.schema.json) | Canonical `$defs` for worker JSON |
+| [`examples/E2E_HANDOFF_FLOW_EXAMPLE.md`](examples/E2E_HANDOFF_FLOW_EXAMPLE.md) | Full pipeline walkthrough |
+
+## URL loading (AI Edge Gallery) — exact notes
+
+**Cannot be fully confirmed from CI:** the Gallery app resolves the **skill folder URL** on-device. Use this checklist before claiming “loads from URL”:
+
+1. **Raw file sanity (any browser):**  
+   `https://raw.githubusercontent.com/FOUNDUPS/Foundups-Agent/main/modules/foundups/mobile_worker_skills/<skill-name>/SKILL.md`  
+   Must return **plain markdown** (starts with `---` frontmatter). Replace `FOUNDUPS/Foundups-Agent` / `main` if your fork or branch differs.
+
+2. **“Folder URL” in Gallery:** the app expects a **base URL** where `SKILL.md` can be fetched as `{base}/SKILL.md`. **`github.com/.../tree/.../folder`** is an HTML UI, **not** a static folder API — do **not** assume it works as the load URL.
+
+3. **Recommended for production URL loading:** mirror `mobile_worker_skills/` to **GitHub Pages** (or another static host) with **`.nojekyll`** so `.md` is not Jekyll-transformed; base = `https://<org>.github.io/<pages-site>/mobile_worker_skills/<skill-name>/`.
+
+4. **JS skills:** execution needs correct MIME; **raw.githubusercontent.com** is often **wrong** for `run_js` — use Pages per [Gallery skills README](https://github.com/google-ai-edge/gallery/blob/main/skills/README.md).
+
+5. **WSP 104:** do not add **bespoke** `public/` tenant sprawl for this; Pages mirror or approved CDN is separate from p.fMALL shell routes.
+
+**Local import:** Gallery supports **Import local skill** (device file picker) — valid for dev without any URL.
+
+## Attachment (WSP 83)
+
+Listed in [`../README.md`](../README.md) canonical table and `modules/foundups/ModLog.md`.

--- a/modules/foundups/mobile_worker_skills/examples/E2E_HANDOFF_FLOW_EXAMPLE.md
+++ b/modules/foundups/mobile_worker_skills/examples/E2E_HANDOFF_FLOW_EXAMPLE.md
@@ -1,0 +1,138 @@
+# End-to-end example: mobile worker handoff pipeline (v1)
+
+**Purpose:** One fictional flow showing **user request → parser → scope → packet → (upstream execution) → result**.  
+**Authority:** 0102 executes the packet on desktop; phone worker only produces structured JSON.
+
+---
+
+## 1. User request (012 → phone worker)
+
+> In `modules/foundups/docs/WSP_SKILL_BUILDER.md` only, bump version line from 1.0.0 to 1.0.1 and add a bullet under Architectural rules: “Skills must list schema link when emitting JSON.”
+
+*(Assume upstream supplied `files_allowlist`: `["modules/foundups/docs/WSP_SKILL_BUILDER.md"]`.)*
+
+---
+
+## 2. `foundups-code-task-parser` output
+
+```json
+{
+  "intent": "edit",
+  "summary": "Bump WSP_SKILL_BUILDER version to 1.0.1 and add schema bullet",
+  "constraints": ["single file", "docs only"],
+  "open_questions": [],
+  "suggested_next_skill": "foundups-scope-locker"
+}
+```
+
+---
+
+## 3. `foundups-scope-locker` output
+
+```json
+{
+  "scope_ok": true,
+  "allowed_operations": ["draft_patch"],
+  "explicit_non_goals": [
+    "Do not edit mobile_worker_skills SKILL.md files in this task",
+    "Do not change ADR or ModLog in this task"
+  ],
+  "handoff_required": true,
+  "rationale": "Single named file in allowlist; bounded doc edit"
+}
+```
+
+---
+
+## 4. `foundups-task-packet-writer` output
+
+```json
+{
+  "packet_version": "1",
+  "title": "WSP_SKILL_BUILDER version + schema rule",
+  "objective": "Update version metadata and add one architectural rule bullet referencing schemas/worker-handoff-pipeline.v1.schema.json",
+  "files_allowlist": ["modules/foundups/docs/WSP_SKILL_BUILDER.md"],
+  "forbidden_paths": ["modules/foundups/mobile_worker_skills"],
+  "acceptance_criteria": [
+    "Version string shows 1.0.1",
+    "New bullet references schema path",
+    "No other files modified"
+  ],
+  "evidence_required": ["diff", "optional: jsonschema spot-check"],
+  "wsp_refs": ["WSP 22", "WSP 83"]
+}
+```
+
+---
+
+## 5. Upstream execution (0102 — not on phone)
+
+0102 applies the patch, runs checks, then returns **raw test/log snippet** to the worker for summarization (fictional):
+
+```text
+pytest modules/foundups/tests/test_foundup_ai_hooks_daemon_contract_compliance.py -q
+.....                                                                    [100%]
+5 passed in 0.15s
+```
+
+---
+
+## 6. `foundups-result-interpreter` output
+
+```json
+{
+  "status": "pass",
+  "headline": "5 passed in 0.15s",
+  "failures": [],
+  "next_action": "0102: proceed to commit or merge per WSP 7"
+}
+```
+
+---
+
+## 7. Optional `foundups-handoff-validator` input (full envelope)
+
+```json
+{
+  "pipeline_version": "1",
+  "parser": {
+    "intent": "edit",
+    "summary": "Bump WSP_SKILL_BUILDER version to 1.0.1 and add schema bullet",
+    "constraints": ["single file", "docs only"],
+    "open_questions": [],
+    "suggested_next_skill": "foundups-scope-locker"
+  },
+  "scope": {
+    "scope_ok": true,
+    "allowed_operations": ["draft_patch"],
+    "explicit_non_goals": [
+      "Do not edit mobile_worker_skills SKILL.md files in this task",
+      "Do not change ADR or ModLog in this task"
+    ],
+    "handoff_required": true,
+    "rationale": "Single named file in allowlist; bounded doc edit"
+  },
+  "packet": {
+    "packet_version": "1",
+    "title": "WSP_SKILL_BUILDER version + schema rule",
+    "objective": "Update version metadata and add one architectural rule bullet referencing schemas/worker-handoff-pipeline.v1.schema.json",
+    "files_allowlist": ["modules/foundups/docs/WSP_SKILL_BUILDER.md"],
+    "forbidden_paths": ["modules/foundups/mobile_worker_skills"],
+    "acceptance_criteria": [
+      "Version string shows 1.0.1",
+      "New bullet references schema path",
+      "No other files modified"
+    ],
+    "evidence_required": ["diff", "optional: jsonschema spot-check"],
+    "wsp_refs": ["WSP 22", "WSP 83"]
+  },
+  "result": {
+    "status": "pass",
+    "headline": "5 passed in 0.15s",
+    "failures": [],
+    "next_action": "0102: proceed to commit or merge per WSP 7"
+  }
+}
+```
+
+Expected **validator**: `valid: true`, empty `errors` (for this synthetic example).

--- a/modules/foundups/mobile_worker_skills/foundups-code-task-parser/SKILL.md
+++ b/modules/foundups/mobile_worker_skills/foundups-code-task-parser/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: foundups-code-task-parser
+description: Parse natural-language coding requests into structured tasks for FoundUps worker handoff. Use when the user describes code work but intent is unstructured.
+metadata:
+  homepage: https://github.com/FOUNDUPS/Foundups-Agent/tree/main/modules/foundups/mobile_worker_skills/foundups-code-task-parser
+---
+
+# Foundups code task parser (worker)
+
+## Role
+
+You are a **worker-layer** parser. You do **not** edit files, run tools, or decide architecture. You only **structure** the request.
+
+## Inputs
+
+- User message (natural language).
+- Optional: `files_allowlist` from upstream (if absent, use empty array—do not invent paths).
+
+## Steps
+
+1. Classify `intent`: one of `read`, `edit`, `mixed`, `unclear`.
+2. Write one-line `summary` (max 200 chars).
+3. List `constraints` explicitly stated (empty if none).
+4. List `open_questions` if intent is `unclear` or `mixed` (minimum 1 question).
+5. Set `suggested_next_skill` to `foundups-scope-locker` if intent is `edit` or `mixed`, else `null`.
+
+## Output format
+
+Emit **only** this JSON object (no markdown fence):
+
+```json
+{
+  "intent": "read|edit|mixed|unclear",
+  "summary": "",
+  "constraints": [],
+  "open_questions": [],
+  "suggested_next_skill": null
+}
+```
+
+Use JSON `null` or `"foundups-scope-locker"` only — never the string `"null"`.
+
+## Rules
+
+- Never invent file paths or module names not present in the user message or `files_allowlist`.
+- If the user asks to “fix everything” or “refactor the repo”, set `intent` to `unclear` and ask for **smallest** target.
+
+## Examples
+
+**Example A — Input:** “Add a null check in the login handler.”  
+**Output:** `{"intent":"edit","summary":"Add null check in login handler","constraints":[],"open_questions":["Which file or handler name?"],"suggested_next_skill":"foundups-scope-locker"}`
+
+**Example B — Input:** “How does CABR gating work?”  
+**Output:** `{"intent":"read","summary":"Explain CABR gating","constraints":[],"open_questions":[],"suggested_next_skill":null}`

--- a/modules/foundups/mobile_worker_skills/foundups-edge-load-smoke/SKILL.md
+++ b/modules/foundups/mobile_worker_skills/foundups-edge-load-smoke/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: foundups-edge-load-smoke
+description: Tiny text-only skill to verify AI Edge Gallery loaded a FoundUps worker skill. Say LOAD_OK if the user says ping.
+metadata:
+  homepage: https://github.com/FOUNDUPS/Foundups-Agent/tree/main/modules/foundups/mobile_worker_skills/foundups-edge-load-smoke
+---
+
+# FoundUps Edge load smoke (worker)
+
+## Role
+
+You only confirm the skill file was loaded. **No** repo access, **no** JSON, **no** architecture.
+
+## Instructions
+
+1. If the user message is exactly `ping` (case-insensitive), reply with exactly: `LOAD_OK`
+2. Otherwise reply with exactly: `WAITING_FOR_PING`
+
+## Output
+
+Plain text only — one line, no markdown fence.
+
+## Example
+
+**User:** `ping`  
+**You:** `LOAD_OK`

--- a/modules/foundups/mobile_worker_skills/foundups-handoff-validator/SKILL.md
+++ b/modules/foundups/mobile_worker_skills/foundups-handoff-validator/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: foundups-handoff-validator
+description: Validate parser, scope, packet, and result JSON objects against FoundUps mobile worker v1 shapes before handoff to 0102. Use when pasting pipeline outputs or a pipeline envelope.
+metadata:
+  homepage: https://github.com/FOUNDUPS/Foundups-Agent/tree/main/modules/foundups/mobile_worker_skills/foundups-handoff-validator
+---
+
+# Foundups handoff validator (worker)
+
+## Role
+
+You **check shape and consistency** of worker JSON. You do **not** fix content, run tests, or approve merges.
+
+## Inputs
+
+Either:
+
+- **A)** One **pipeline envelope** JSON with keys `pipeline_version`, `parser`, `scope`, `packet`, optional `result`, or  
+- **B)** Up to four labeled blocks in order: `parser`, `scope`, `packet`, `result` (parse each as JSON).
+
+Canonical shapes: `modules/foundups/mobile_worker_skills/schemas/worker-handoff-pipeline.v1.schema.json` (`$defs`).
+
+## Steps
+
+1. For each present stage, verify **required keys** exist and **types** match (string/array/boolean/null as specified).
+2. **Parser:** `intent` ∈ {read, edit, mixed, unclear}; `suggested_next_skill` is JSON `null` or `"foundups-scope-locker"`.
+3. **Scope:** `allowed_operations` items ∈ {read_tree, draft_patch, tests_only, none} only; `explicit_non_goals` length ≥ **2**; `rationale` present (string).
+4. **Packet:** `packet_version` === `"1"`; arrays present; if `files_allowlist` empty and objective implies edit, `forbidden_paths` should contain `"*"` (warning if not).
+5. **Result:** if present, `status` ∈ {pass, fail, partial, unknown}.
+6. Cross-check: if `parser.intent` is `read`, `scope.allowed_operations` should not include `draft_patch` unless user explicitly allowed read+draft (warning only).
+
+## Output format
+
+Emit **only** this JSON:
+
+```json
+{
+  "validator_version": "1",
+  "valid": true,
+  "errors": [],
+  "warnings": []
+}
+```
+
+`errors` entries: `{"stage":"parser|scope|packet|result|envelope","message":"..."}`.
+
+## Rules
+
+- If JSON is unparseable, one error with `stage` `envelope` and message `invalid JSON`.
+- Do not invent fields; only validate declared artifacts.
+
+## Example
+
+**Input:** envelope with `parser.intent` = `edit` but `scope.allowed_operations` = `["none"]`.  
+**Output:** `{"validator_version":"1","valid":false,"errors":[{"stage":"scope","message":"edit intent conflicts with allowed_operations none"}],"warnings":[]}`

--- a/modules/foundups/mobile_worker_skills/foundups-result-interpreter/SKILL.md
+++ b/modules/foundups/mobile_worker_skills/foundups-result-interpreter/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: foundups-result-interpreter
+description: Summarize raw test output, logs, or diffs into a compact worker-friendly report for FoundUps handoff. Use after execution upstream returns artifacts.
+metadata:
+  homepage: https://github.com/FOUNDUPS/Foundups-Agent/tree/main/modules/foundups/mobile_worker_skills/foundups-result-interpreter
+---
+
+# Foundups result interpreter (worker)
+
+## Role
+
+You **summarize**; you do **not** re-run tests or fix code.
+
+## Inputs
+
+- Pasted log, test stdout, or diff text (may be truncated).
+- Optional one-line `task_title` from packet.
+
+## Steps
+
+1. If input empty → `status` `unknown`, `headline` “No input”.
+2. Detect failure signals: `FAILED`, `ERROR`, non-zero exit implied, `AssertionError`, etc.
+3. Detect pass signals: `passed`, `OK`, all green summary.
+4. `failures`: max 5 strings, each max 120 chars (first errors only).
+5. `next_action`: one imperative for **upstream** (e.g. “Re-run tests after fixing import in X”).
+
+## Output format
+
+Emit **only** this JSON:
+
+```json
+{
+  "status": "pass|fail|partial|unknown",
+  "headline": "",
+  "failures": [],
+  "next_action": ""
+}
+```
+
+## Rules
+
+- Do not invent file names not appearing in the pasted text.
+- If diff is huge, summarize counts only: “N files, +a -b lines” in `headline`.
+
+## Examples
+
+**Example A — Input contains `3 failed, 12 passed`**
+
+```json
+{
+  "status": "fail",
+  "headline": "12 passed, 3 failed",
+  "failures": ["First failure line only if visible"],
+  "next_action": "Open first failing test output upstream and patch"
+}
+```
+
+**Example B — Input: `All tests passed`**
+
+```json
+{
+  "status": "pass",
+  "headline": "All tests passed",
+  "failures": [],
+  "next_action": "Proceed to merge review per WSP 7"
+}
+```

--- a/modules/foundups/mobile_worker_skills/foundups-scope-locker/SKILL.md
+++ b/modules/foundups/mobile_worker_skills/foundups-scope-locker/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: foundups-scope-locker
+description: Narrow ambiguous coding work to the smallest safe scope for FoundUps worker handoff. Use after foundups-code-task-parser or when scope is broad.
+metadata:
+  homepage: https://github.com/FOUNDUPS/Foundups-Agent/tree/main/modules/foundups/mobile_worker_skills/foundups-scope-locker
+---
+
+# Foundups scope locker (worker)
+
+## Role
+
+You **lock scope**. You do **not** implement changes or claim repo access.
+
+## Inputs
+
+- Prior parser JSON (optional) or user message.
+- `files_allowlist`: array from upstream; if missing, `[]` (never guess paths).
+
+## Steps
+
+1. If no specific files/modules named and intent implies edit → set `scope_ok` false, `allowed_operations` `["none"]`, `handoff_required` true.
+2. If user named concrete symbols/files (or non-empty allowlist) → set `scope_ok` true, allow **minimal** ops: prefer `read_tree` + `draft_patch` only if edit is clearly bounded.
+3. List `explicit_non_goals`: at least two items (what we will **not** do).
+4. Always set `handoff_required` true for `edit`/`mixed` (0102 or executor applies the patch).
+
+## Output format
+
+Emit **only** this JSON:
+
+```json
+{
+  "scope_ok": true,
+  "allowed_operations": ["read_tree", "draft_patch", "tests_only", "none"],
+  "explicit_non_goals": ["", ""],
+  "handoff_required": true,
+  "rationale": "one sentence"
+}
+```
+
+## Rules
+
+- `allowed_operations` must be **subset** of the four strings above; use only valid values.
+- Never expand scope (“while we’re here…”)—shrink it.
+
+## Examples
+
+**Example A — Input:** “Refactor all FoundUps modules.”  
+**Output:** `{"scope_ok":false,"allowed_operations":["none"],"explicit_non_goals":["No repo-wide refactor","No multi-module sweep"],"handoff_required":true,"rationale":"Unbounded scope"}`
+
+**Example B — Input:** “In README.md only, fix the typo ‘recieve’ → ‘receive’.”  
+**Output:** `{"scope_ok":true,"allowed_operations":["draft_patch"],"explicit_non_goals":["No other files","No formatting beyond typo"],"handoff_required":true,"rationale":"Single-file typo"}`

--- a/modules/foundups/mobile_worker_skills/foundups-task-packet-writer/SKILL.md
+++ b/modules/foundups/mobile_worker_skills/foundups-task-packet-writer/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: foundups-task-packet-writer
+description: Convert a scoped coding task into a strict machine-readable task packet for upstream FoundUps execution. Use after scope is locked.
+metadata:
+  homepage: https://github.com/FOUNDUPS/Foundups-Agent/tree/main/modules/foundups/mobile_worker_skills/foundups-task-packet-writer
+---
+
+# Foundups task packet writer (worker)
+
+## Role
+
+You emit a **versioned packet** for **0102 / executor**. You do **not** execute.
+
+## Inputs
+
+- Locked scope JSON from `foundups-scope-locker` (optional).
+- User objective text.
+- `files_allowlist`: only paths **explicitly** provided upstream; else `[]`.
+
+## Steps
+
+1. Set `packet_version` to `"1"`.
+2. `title`: max 80 chars.
+3. `objective`: single paragraph, no path invention.
+4. `files_allowlist`: copy from input only.
+5. `forbidden_paths`: include `["*"]` if allowlist empty and edit implied—forces upstream to supply paths.
+6. `acceptance_criteria`: 2–5 testable bullets.
+7. `evidence_required`: e.g. `["pytest path", "diff summary"]` as appropriate; use generic strings if unknown.
+8. `wsp_refs`: suggest from set `WSP 22`, `WSP 49`, `WSP 50`, `WSP 64`, `WSP 97`—only if relevant; else `[]`.
+
+## Output format
+
+Emit **only** this JSON:
+
+```json
+{
+  "packet_version": "1",
+  "title": "",
+  "objective": "",
+  "files_allowlist": [],
+  "forbidden_paths": [],
+  "acceptance_criteria": [],
+  "evidence_required": [],
+  "wsp_refs": []
+}
+```
+
+## Rules
+
+- If `files_allowlist` is empty and task requires edit, `forbidden_paths` must include `"*"` and `acceptance_criteria` must include “Upstream supplies verified file paths”.
+
+## Examples
+
+**Example A — allowlist `["modules/foo/README.md"]`**
+
+```json
+{
+  "packet_version": "1",
+  "title": "Fix README typo",
+  "objective": "Correct spelling only in modules/foo/README.md",
+  "files_allowlist": ["modules/foo/README.md"],
+  "forbidden_paths": ["modules/foo/src"],
+  "acceptance_criteria": ["Only README.md changed", "Typo fixed", "No other wording changes"],
+  "evidence_required": ["diff"],
+  "wsp_refs": ["WSP 22"]
+}
+```

--- a/modules/foundups/mobile_worker_skills/schemas/README.md
+++ b/modules/foundups/mobile_worker_skills/schemas/README.md
@@ -1,0 +1,9 @@
+# Mobile worker JSON schemas (v1)
+
+| File | Purpose |
+|------|---------|
+| [`worker-handoff-pipeline.v1.schema.json`](worker-handoff-pipeline.v1.schema.json) | `$defs` for **ParserOutput**, **ScopeOutput**, **PacketOutput**, **ResultOutput**, **PipelineEnvelopeV1**, **HandoffValidationResult** |
+
+**Usage:** Reference from `WSP_SKILL_BUILDER.md` and `foundups-handoff-validator`. Validate with any Draft 2020-12 capable tool (`ajv`, `jsonschema`, etc.).
+
+**Note:** `$id` uses `https://foundups.org/schemas/...` as a stable logical URI; file is authoritative in-repo.

--- a/modules/foundups/mobile_worker_skills/schemas/worker-handoff-pipeline.v1.schema.json
+++ b/modules/foundups/mobile_worker_skills/schemas/worker-handoff-pipeline.v1.schema.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://foundups.org/schemas/mobile-worker/worker-handoff-pipeline.v1.schema.json",
+  "title": "FoundUps mobile worker handoff artifacts (v1)",
+  "description": "Canonical JSON shapes for foundups-code-task-parser, foundups-scope-locker, foundups-task-packet-writer, foundups-result-interpreter. Used for documentation and handoff validation; runtime may enforce subsets.",
+  "$defs": {
+    "ParserOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["intent", "summary", "constraints", "open_questions", "suggested_next_skill"],
+      "properties": {
+        "intent": { "type": "string", "enum": ["read", "edit", "mixed", "unclear"] },
+        "summary": { "type": "string", "maxLength": 400 },
+        "constraints": { "type": "array", "items": { "type": "string" } },
+        "open_questions": { "type": "array", "items": { "type": "string" } },
+        "suggested_next_skill": {
+          "oneOf": [
+            { "type": "null" },
+            { "type": "string", "const": "foundups-scope-locker" }
+          ]
+        }
+      }
+    },
+    "ScopeOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scope_ok",
+        "allowed_operations",
+        "explicit_non_goals",
+        "handoff_required",
+        "rationale"
+      ],
+      "properties": {
+        "scope_ok": { "type": "boolean" },
+        "allowed_operations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["read_tree", "draft_patch", "tests_only", "none"]
+          }
+        },
+        "explicit_non_goals": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 2
+        },
+        "handoff_required": { "type": "boolean" },
+        "rationale": { "type": "string", "maxLength": 500 }
+      }
+    },
+    "PacketOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "packet_version",
+        "title",
+        "objective",
+        "files_allowlist",
+        "forbidden_paths",
+        "acceptance_criteria",
+        "evidence_required",
+        "wsp_refs"
+      ],
+      "properties": {
+        "packet_version": { "type": "string", "const": "1" },
+        "title": { "type": "string", "maxLength": 120 },
+        "objective": { "type": "string", "maxLength": 4000 },
+        "files_allowlist": { "type": "array", "items": { "type": "string" } },
+        "forbidden_paths": { "type": "array", "items": { "type": "string" } },
+        "acceptance_criteria": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        },
+        "evidence_required": { "type": "array", "items": { "type": "string" } },
+        "wsp_refs": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "ResultOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "headline", "failures", "next_action"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["pass", "fail", "partial", "unknown"]
+        },
+        "headline": { "type": "string", "maxLength": 300 },
+        "failures": { "type": "array", "items": { "type": "string" } },
+        "next_action": { "type": "string", "maxLength": 500 }
+      }
+    },
+    "PipelineEnvelopeV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pipeline_version", "parser", "scope", "packet"],
+      "properties": {
+        "pipeline_version": { "type": "string", "const": "1" },
+        "parser": { "$ref": "#/$defs/ParserOutput" },
+        "scope": { "$ref": "#/$defs/ScopeOutput" },
+        "packet": { "$ref": "#/$defs/PacketOutput" },
+        "result": { "$ref": "#/$defs/ResultOutput" }
+      }
+    },
+    "HandoffValidationResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["validator_version", "valid", "errors", "warnings"],
+      "properties": {
+        "validator_version": { "type": "string", "const": "1" },
+        "valid": { "type": "boolean" },
+        "errors": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["stage", "message"],
+            "additionalProperties": false,
+            "properties": {
+              "stage": {
+                "type": "string",
+                "enum": ["parser", "scope", "packet", "result", "envelope"]
+              },
+              "message": { "type": "string" }
+            }
+          }
+        },
+        "warnings": { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  }
+}

--- a/modules/foundups/mobile_worker_skills/wsp00-mobile-semantics/SKILL.md
+++ b/modules/foundups/mobile_worker_skills/wsp00-mobile-semantics/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: wsp00-mobile-semantics
+description: Apply the FoundUps WSP 00 semantic subset for on-device worker boot—identity, anti-VI phrasing, and handoff discipline without desktop Python execution.
+metadata:
+  homepage: https://github.com/FOUNDUPS/Foundups-Agent/tree/main/modules/foundups/mobile_worker_skills/wsp00-mobile-semantics
+---
+
+# WSP 00 mobile semantics (worker boot)
+
+## Role
+
+You are a **phone worker**. You are **not** the full 0102 architect authority layer and you **do not** run `WSP_agentic` Python scripts. You apply **semantic discipline** only.
+
+## What this skill IS
+
+- **Operator**: 012 (not “user” in outputs).
+- **Upstream authority**: 0102 routes skills and execution.
+- **Output shape** when summarizing stance: Decision → Evidence → Action → Validation → Memory (each **one short line**).
+- **Anti-VI**: Avoid deferential helper phrasing (“Would you like…”, “I can help…”) when a clear worker action exists—use decisive **worker** phrasing: “Handing off: …”.
+
+## What this skill is NOT
+
+- Does **not** claim `is_zen_compliant` or run `functional_0102_awakening_v2.py`.
+- Does **not** perform HoloIndex CLI (note in handoff if retrieval needed upstream).
+- Does **not** write repo files or execute shell.
+
+## Steps (on session start or when 012 requests boot)
+
+1. State **Worker identity**: “FoundUps mobile worker; 0102 routes; 012 operates.”
+2. State **Non-authority**: “No repo write; packets and summaries only.”
+3. If task received: classify **read vs handoff**; if edit implied without allowlist → output **handoff block** (below).
+
+## Handoff block format
+
+When upstream execution is required, emit:
+
+```text
+HANDOFF
+to: 0102
+reason: <one line>
+packet_hint: foundups-code-task-parser | foundups-scope-locker | foundups-task-packet-writer
+risk: none | low | medium
+```
+
+## Example
+
+**012:** “Boot worker and say what you can do.”  
+**Worker:** “FoundUps mobile worker online. 012 operates; 0102 routes architecture. I parse tasks, lock scope, write packets, and summarize results. I do not run desktop WSP 00 scripts or edit the repo. For code changes, I emit HANDOFF to 0102 with a packet_hint.”
+
+## Canonical reference (for 012 / 0102 only)
+
+Full WSP 00: `WSP_knowledge/src/WSP_00_Zen_State_Attainment_Protocol.md` (desktop gates). This skill is a **subset** for device constraints.

--- a/public/member/ModLog.md
+++ b/public/member/ModLog.md
@@ -1,5 +1,67 @@
 # Member Area Module Change Log
 
+## [2026-04-12] Adaptive Desktop 6x3 Tile Layout (Worker CL)
+
+**Who**: 0102 - Worker CL
+**Slice**: `PFMALL_DESKTOP_6X3_ADAPTIVE_LAYOUT_PHASE1`
+**What**: Added viewport-adaptive density selection for desktop/fine-pointer viewports.
+
+**Changes**:
+- Added `6x3` density preset (6 columns, 3 rows) optimized for wide desktop viewports
+- Implemented viewport detection using `matchMedia('(pointer: coarse)')` + width/height checks
+- Auto-selects `6x3` for fine-pointer + landscape + ≥1024px viewports
+- Auto-selects `4x6` for coarse-pointer + landscape + ≥768px (tablet landscape)
+- Defaults to `3x5` for mobile-first portrait viewports
+- Added resize listener for dynamic re-evaluation
+- Manual `setDensity()` calls mark override, preventing auto-selection
+- Added `resetDensityOverride()` to restore auto-selection
+
+**Files Modified**:
+- `public/member/js/mall-tile-field.js` - Viewport detection, auto-selection, 6x3 preset
+- `public/member/css/mall-tile-field.css` - 6x3 density CSS variables
+
+**API Surface**:
+- `setDensity(density, isManual)` - Now tracks manual override
+- `detectOptimalDensity()` - Returns optimal density for current viewport
+- `autoSelectDensity()` - Auto-selects if not manually set
+- `resetDensityOverride()` - Clears manual flag, re-evaluates viewport
+
+---
+
+## [2026-04-13] pfMALL YouTube Wall Live Verification (Worker CH, WSP 97/104)
+
+**Who**: 0102 - Worker CH
+**Slice**: `PFMALL_YOUTUBE_WALL_LIVE_VERIFICATION_PHASE1`
+**What**: End-to-end browser verification of pfMALL tile wall with YouTube-backed FoundUp queues.
+
+**Method**: Local HTTP server (`python -m http.server 8090`) serving `public/`, Clerk auth bypassed via JS injection, Chrome DevTools MCP for automated verification.
+
+**Catalog Truth** (13 entries, 4 targets verified):
+
+| FoundUp | videos | poster | tap→play | lane advance | expand | collapse |
+|---------|--------|--------|----------|-------------|--------|----------|
+| `move2japan` | 573 | /media/posters/move2japan.jpg | PASS | 0→1 PASS | 573 tiles PASS | 13 tiles PASS |
+| `undaodu` | 512 | /media/posters/undaodu.jpg | PASS | 0→1 PASS | 512 tiles PASS | 13 tiles PASS |
+| `foundups_main` | 44 | /media/posters/foundups_main.jpg | PASS | 0→1 PASS | 44 tiles PASS | 13 tiles PASS |
+| `antifafm` | 34 | /media/posters/antifafm.jpg | PASS | 0→1 PASS | 34 tiles PASS | 13 tiles PASS |
+
+**Fullscreen Player**: `mallVideoPlayer.open()` loads YouTube iframe, shows video title, play controls, Enter FoundUp button (WSP 104 route `/f/{foundup_id}`). `mallVideoPlayer.close()` returns to tile wall cleanly.
+
+**Projection Controls**: All, A-Z, Readiness, Category — all re-sort tiles correctly.
+
+**UI Elements per tile**: poster background, readiness badge, queue count badge, audio button, enter button, expand button, preview stage — all present for video-backed tiles.
+
+**API surface verified**: `initialize`, `togglePlay`, `advanceToNextInLane`, `expandFoundUp`, `collapseFoundUp`, `setProjection`, `startLanePreview`, `stopInlinePreview`.
+
+**Pytest**: 258 passed (test_video_mall_field_runtime.py + test_mall_tile_field.py)
+
+**No bugs found. No code changes required.**
+
+**WSP 97 Applied**: Browser-verified, not assumed.
+**WSP 104 Applied**: Enter FoundUp routes to `/f/{foundup_id}` canonical path.
+
+---
+
 ## [2026-04-13] Kosei entry_url Restored (Worker BX5, WSP 97/104)
 
 **Who**: 0102 - Worker BX5

--- a/public/member/css/mall-tile-field.css
+++ b/public/member/css/mall-tile-field.css
@@ -8,8 +8,9 @@
    - Snap (default): page-style discrete movement
    - Glide: fluid scroll override
 
-   Density presets (AI-controlled):
-   - 3x4, 3x5, 4x6, 5x8 (default: 3x5 for mobile-first dense wall)
+   Density presets (AI-controlled or viewport-adaptive):
+   - 3x4, 3x5, 4x6, 5x8 (portrait-first dense walls)
+   - 6x3 (desktop wide viewport - auto-selected for fine-pointer + landscape)
 */
 
 :root {
@@ -175,6 +176,13 @@
   --field-rows: 8;
   --tile-radius: 0.25rem;
   --tile-gap: 0.1rem;
+}
+/* Desktop-optimized: wide landscape with 6 columns, 3 rows */
+.mall-tile-field[data-density="6x3"] {
+  --field-columns: 6;
+  --field-rows: 3;
+  --tile-radius: 0.5rem;
+  --tile-gap: 0.35rem;
 }
 
 @media (min-width: 600px) {

--- a/public/member/js/mall-tile-field.js
+++ b/public/member/js/mall-tile-field.js
@@ -15,8 +15,9 @@
  *   - Snap (default): discrete paging like iPhone home screens
  *   - Glide: fluid scroll for browsing
  *
- * Density presets (AI-controlled):
- *   - 3x4, 3x5, 4x6, 5x8 (default: 3x5 for mobile-first dense wall)
+ * Density presets (AI-controlled or viewport-adaptive):
+ *   - 3x4, 3x5, 4x6, 5x8 (portrait-first dense walls)
+ *   - 6x3 (desktop wide viewport - auto-selected for fine-pointer + landscape)
  */
 (function() {
   'use strict';
@@ -54,6 +55,7 @@
   // Video Mall runtime state
   var motionMode = 'snap'; // 'snap' | 'glide'
   var currentDensity = '3x5';
+  var densityManuallySet = false; // Whether user has manually overridden density
   var expandedFoundUp = null; // Index of expanded FoundUp, or null
   var expandSourceIndex = null; // Original tile index for collapse animation
   var expandSourceVisual = null; // { bgImage, bgColor } for collapse continuity
@@ -504,8 +506,11 @@
     // Create collapse hint
     createCollapseHint();
 
-    // Set initial density
-    setDensity(currentDensity);
+    // Auto-select density based on viewport (respects manual override)
+    autoSelectDensity();
+
+    // Bind resize handler for adaptive density
+    window.addEventListener('resize', handleResize);
 
     // Enable desktop drag-to-scroll
     bindDragScroll();
@@ -1161,14 +1166,20 @@
 
   /**
    * Set field density preset
-   * @param {string} density - '3x4' | '3x5' | '4x6' | '5x8'
+   * @param {string} density - '3x4' | '3x5' | '4x6' | '5x8' | '6x3'
+   * @param {boolean} [isManual=true] - Whether this is a manual user override
    */
-  function setDensity(density) {
-    var validDensities = ['3x4', '3x5', '4x6', '5x8'];
+  function setDensity(density, isManual) {
+    var validDensities = ['3x4', '3x5', '4x6', '5x8', '6x3'];
     if (!validDensities.includes(density)) {
       density = '3x5';
     }
     currentDensity = density;
+
+    // Track manual override (defaults to true for API calls)
+    if (isManual !== false) {
+      densityManuallySet = true;
+    }
 
     if (tileField) {
       tileField.dataset.density = density;
@@ -1181,6 +1192,56 @@
    */
   function getDensity() {
     return currentDensity;
+  }
+
+  /**
+   * Detect viewport class and return optimal density
+   * Desktop/fine-pointer wide viewports get 6x3
+   * Mobile/tablet/coarse-pointer get appropriate portrait densities
+   * @returns {string} Optimal density preset
+   */
+  function detectOptimalDensity() {
+    var width = window.innerWidth;
+    var height = window.innerHeight;
+    var isCoarsePointer = window.matchMedia && window.matchMedia('(pointer: coarse)').matches;
+    var isLandscape = width > height;
+
+    // Desktop: fine pointer + wide viewport (1024px+) + landscape
+    if (!isCoarsePointer && width >= 1024 && isLandscape) {
+      return '6x3';
+    }
+
+    // Tablet landscape: coarse pointer but wide
+    if (isCoarsePointer && width >= 768 && isLandscape) {
+      return '4x6';
+    }
+
+    // Default mobile-first
+    return '3x5';
+  }
+
+  /**
+   * Auto-select density based on viewport (only if not manually set)
+   */
+  function autoSelectDensity() {
+    if (densityManuallySet) return;
+    var optimal = detectOptimalDensity();
+    setDensity(optimal, false); // false = not manual
+  }
+
+  /**
+   * Handle viewport resize - re-evaluate density if not manually set
+   */
+  function handleResize() {
+    autoSelectDensity();
+  }
+
+  /**
+   * Reset manual density override - allows auto-selection to resume
+   */
+  function resetDensityOverride() {
+    densityManuallySet = false;
+    autoSelectDensity();
   }
 
   // ========== Expanded State Queries ==========
@@ -1574,6 +1635,9 @@
     // Density
     setDensity: setDensity,
     getDensity: getDensity,
+    detectOptimalDensity: detectOptimalDensity,
+    autoSelectDensity: autoSelectDensity,
+    resetDensityOverride: resetDensityOverride,
 
     // Projection
     setProjection: setProjection,


### PR DESCRIPTION
## Summary
- Add `6x3` density preset for wide desktop viewports with fine-pointer input
- Implement viewport-class detection using `matchMedia('(pointer: coarse)')` + dimensions
- Auto-select optimal density on init and resize; preserve manual override precedence

## Changes
| File | Change |
|------|--------|
| `public/member/js/mall-tile-field.js` | Viewport detection, auto-selection logic, 6x3 in validDensities |
| `public/member/css/mall-tile-field.css` | 6x3 density CSS (6 cols, 3 rows, larger gaps/radius) |
| `public/member/ModLog.md` | Worker CL session entry |

## Viewport-class rules
- **Desktop**: fine-pointer + ≥1024px + landscape → `6x3`
- **Tablet landscape**: coarse-pointer + ≥768px + landscape → `4x6`
- **Mobile/portrait**: default → `3x5`

## Test plan
- [ ] Verify desktop (1920×1080 Chrome) shows 6x3 on init
- [ ] Verify resize to narrow portrait switches to 3x5
- [ ] Verify manual `setDensity('4x6')` prevents auto-selection
- [ ] Verify `resetDensityOverride()` restores auto-selection
- [ ] Verify mobile/tablet portrait unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)