### PR TITLE
feat(pfmall): add youtube channel pull delta generator

### DIFF
--- a/modules/communication/youtube_channel_pull/INTERFACE.md
+++ b/modules/communication/youtube_channel_pull/INTERFACE.md
@@ -1,0 +1,102 @@
+# YouTube Channel Pull Interface
+
+## Public API
+
+### channel_puller.py
+
+#### `fetch_channel_videos(youtube_service, channel_id, max_results=50)`
+
+Fetch latest videos from a YouTube channel.
+
+**Parameters:**
+- `youtube_service`: Authenticated googleapiclient YouTube service
+- `channel_id`: YouTube channel ID (e.g., "UC-LSSlOZwpGIRIYihaz8zCw")
+- `max_results`: Maximum videos to fetch (default 50)
+
+**Returns:** `List[Dict]` with keys:
+- `video_id`: YouTube video ID
+- `title`: Video title
+- `thumbnail_url`: Thumbnail URL
+- `embed_url`: Embeddable URL
+- `source_url`: Watch URL
+- `published_at`: ISO timestamp
+- `channel_id`: Channel ID
+
+#### `get_channel_ids_from_catalog(catalog)`
+
+Extract YouTube channel IDs from catalog.
+
+**Parameters:**
+- `catalog`: List of catalog entries
+
+**Returns:** `Dict[str, str]` mapping foundup_id → channel_id
+
+### catalog_delta.py
+
+#### `generate_full_delta(catalog, pulled_by_foundup)`
+
+Generate delta report for all FoundUps.
+
+**Parameters:**
+- `catalog`: Full mall-video-catalog.json content
+- `pulled_by_foundup`: Dict mapping foundup_id → pulled videos list
+
+**Returns:** Delta report dict:
+```python
+{
+    "generated_at": "2026-04-13T...",
+    "summary": {
+        "foundups_checked": 10,
+        "total_new_videos": 25,
+        "total_skipped": 150,
+    },
+    "deltas": [
+        {
+            "foundup_id": "move2japan",
+            "existing_count": 573,
+            "pulled_count": 50,
+            "new_count": 3,
+            "skipped_count": 47,
+            "new_videos": [...],
+            "skipped_ids": [...]
+        }
+    ]
+}
+```
+
+#### `write_delta_artifact(delta, output_path)`
+
+Write delta to JSON file.
+
+**Parameters:**
+- `delta`: Delta report dict
+- `output_path`: Path to write
+
+**Returns:** Path written to
+
+#### `format_delta_summary(delta)`
+
+Format delta for terminal display.
+
+**Parameters:**
+- `delta`: Delta report dict
+
+**Returns:** Formatted string
+
+## CLI Interface
+
+```bash
+python -m modules.communication.youtube_channel_pull.src.pull_cli [OPTIONS]
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--dry-run` | flag | True | No catalog mutation |
+| `--foundup` | str | all | Filter to one FoundUp |
+| `--max-results` | int | 50 | Videos per channel |
+| `--output` | path | auto | Delta output path |
+
+## Dependencies
+
+- `youtube_auth`: For `get_authenticated_service()`
+- `googleapiclient`: YouTube Data API v3

--- a/modules/communication/youtube_channel_pull/README.md
+++ b/modules/communication/youtube_channel_pull/README.md
@@ -1,0 +1,139 @@
+# YouTube Channel Pull
+
+Fetch latest videos from YouTube channels and generate reviewable delta artifacts.
+
+## Purpose
+
+This module provides the first truthful YouTube-to-catalog ingest path for pfMALL. Instead of blind catalog mutation, it:
+
+1. Reads channel identity from existing `source_id` fields in `mall-video-catalog.json`
+2. Fetches latest N videos per channel via YouTube Data API
+3. Compares against current catalog entries
+4. Emits a reviewable delta artifact
+5. Leaves actual catalog merge as a human-reviewed follow-up
+
+## Usage
+
+### Basic Pull (Dry-Run)
+
+```bash
+python -m modules.communication.youtube_channel_pull.src.pull_cli
+```
+
+This generates a delta artifact at:
+```
+docs/audits/pfmall_youtube_ingest/youtube_channel_pull_delta.json
+```
+
+### Pull Specific FoundUp
+
+```bash
+python -m modules.communication.youtube_channel_pull.src.pull_cli --foundup move2japan
+```
+
+### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--dry-run` | `True` | Generate delta without mutation |
+| `--foundup ID` | all | Pull only specified FoundUp |
+| `--max-results N` | 50 | Max videos per channel |
+| `--output PATH` | auto | Output path for delta JSON |
+
+## Operator Workflow
+
+### 1. Run the Pull
+
+```bash
+cd O:\Foundups-Agent
+python -m modules.communication.youtube_channel_pull.src.pull_cli
+```
+
+### 2. Inspect the Delta
+
+Open the generated delta file:
+```
+docs/audits/pfmall_youtube_ingest/youtube_channel_pull_delta.json
+```
+
+Review:
+- `new_videos`: Candidates to add
+- `skipped_ids`: Already present (no action needed)
+- Video metadata: title, thumbnail_url, published_at
+
+### 3. Decide What to Merge
+
+For each FoundUp with new videos:
+1. Review video titles for relevance
+2. Check publish dates
+3. Decide which videos to include
+
+### 4. Manual Merge (Current Process)
+
+Edit `public/member/mall-video-catalog.json`:
+1. Find the FoundUp entry
+2. Add new videos to the `videos` array
+3. Update `video_count` field
+4. Commit and deploy
+
+### 5. Future: Merge Command (Not in Phase 1)
+
+A future `--apply` mode may automate the merge step with review prompts.
+
+## Prerequisites
+
+### YouTube Data API Credentials
+
+This module reuses the existing `youtube_auth` credential system:
+
+1. Ensure `.env` has `YOUTUBE_SCOPES` configured
+2. Ensure OAuth tokens exist for at least one credential set
+3. Test with: `python -m modules.platform_integration.youtube_auth.src.quota_tester`
+
+If credentials are missing, the CLI will:
+- Report the blocker explicitly
+- Generate an empty delta to verify workflow
+
+### Quota Costs
+
+Per YouTube Data API v3:
+- `search.list`: ~100 units per request
+- Default quota: 10,000 units/day per credential set
+
+With 50 videos × 10 FoundUps = ~1,000 units per full pull.
+
+## Module Structure
+
+```
+youtube_channel_pull/
+├── src/
+│   ├── __init__.py
+│   ├── channel_puller.py    # Fetch videos from channel
+│   ├── catalog_delta.py     # Compare and generate delta
+│   └── pull_cli.py          # CLI entry point
+├── tests/
+│   └── test_catalog_delta.py
+├── README.md
+├── INTERFACE.md
+└── requirements.txt
+```
+
+## WSP References
+
+- **WSP 3**: Communication domain placement
+- **WSP 97**: Truthful verification (no fake data)
+- **WSP 49**: Module structure compliance
+
+## Limitations (Phase 1)
+
+- No scheduled/cron automation
+- No auto-commit or PR creation
+- No thumbnail caching
+- No cross-platform (YouTube only)
+- Manual merge step required
+
+## Related Modules
+
+- `youtube_auth`: OAuth credential management
+- `youtube_api_operations`: Enhanced API operations
+- `youtube_channel_registry`: Channel metadata registry

--- a/modules/communication/youtube_channel_pull/__init__.py
+++ b/modules/communication/youtube_channel_pull/__init__.py
@@ -1,0 +1,1 @@
+"""YouTube Channel Pull module."""

--- a/modules/communication/youtube_channel_pull/requirements.txt
+++ b/modules/communication/youtube_channel_pull/requirements.txt
@@ -1,0 +1,5 @@
+# YouTube Channel Pull dependencies
+# Core YouTube API (shared with youtube_auth)
+google-api-python-client>=2.0.0
+google-auth>=2.0.0
+google-auth-oauthlib>=1.0.0

--- a/modules/communication/youtube_channel_pull/src/__init__.py
+++ b/modules/communication/youtube_channel_pull/src/__init__.py
@@ -1,0 +1,25 @@
+"""YouTube Channel Pull - Fetch videos and generate reviewable deltas."""
+
+from .channel_puller import (
+    fetch_channel_videos,
+    get_channel_id_from_catalog,
+    get_channel_ids_from_catalog,
+)
+from .catalog_delta import (
+    compute_delta,
+    generate_full_delta,
+    get_existing_video_ids,
+    write_delta_artifact,
+    format_delta_summary,
+)
+
+__all__ = [
+    "fetch_channel_videos",
+    "get_channel_id_from_catalog",
+    "get_channel_ids_from_catalog",
+    "compute_delta",
+    "generate_full_delta",
+    "get_existing_video_ids",
+    "write_delta_artifact",
+    "format_delta_summary",
+]

--- a/modules/communication/youtube_channel_pull/src/catalog_delta.py
+++ b/modules/communication/youtube_channel_pull/src/catalog_delta.py
@@ -1,0 +1,172 @@
+"""
+Catalog Delta Generator - Compare pulled videos against existing catalog.
+
+Produces a reviewable delta artifact showing:
+- Videos already present (skipped)
+- New candidate videos (to review)
+- Duplicates detected
+
+WSP References:
+- WSP 3: Communication domain
+- WSP 97: Truthful output (no blind mutation)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Set
+
+logger = logging.getLogger(__name__)
+
+
+def get_existing_video_ids(catalog_entry: Dict[str, Any]) -> Set[str]:
+    """
+    Extract all video_id values from a catalog entry's videos array.
+
+    Args:
+        catalog_entry: Single entry from mall-video-catalog.json
+
+    Returns:
+        Set of video_id strings
+    """
+    videos = catalog_entry.get("videos", [])
+    return {v.get("video_id", "") for v in videos if v.get("video_id")}
+
+
+def compute_delta(
+    foundup_id: str,
+    existing_video_ids: Set[str],
+    pulled_videos: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """
+    Compute delta between pulled videos and existing catalog.
+
+    Args:
+        foundup_id: FoundUp identifier
+        existing_video_ids: Set of video IDs already in catalog
+        pulled_videos: List of video dicts from API pull
+
+    Returns:
+        Delta dict with new_videos, existing_count, skipped_count
+    """
+    new_videos = []
+    skipped_ids = []
+
+    for video in pulled_videos:
+        video_id = video.get("video_id", "")
+        if video_id in existing_video_ids:
+            skipped_ids.append(video_id)
+        else:
+            new_videos.append(video)
+
+    return {
+        "foundup_id": foundup_id,
+        "existing_count": len(existing_video_ids),
+        "pulled_count": len(pulled_videos),
+        "new_count": len(new_videos),
+        "skipped_count": len(skipped_ids),
+        "new_videos": new_videos,
+        "skipped_ids": skipped_ids,
+    }
+
+
+def generate_full_delta(
+    catalog: List[Dict[str, Any]],
+    pulled_by_foundup: Dict[str, List[Dict[str, Any]]],
+) -> Dict[str, Any]:
+    """
+    Generate full delta report across all FoundUps.
+
+    Args:
+        catalog: Full mall-video-catalog.json content
+        pulled_by_foundup: Dict mapping foundup_id -> pulled videos list
+
+    Returns:
+        Full delta report
+    """
+    # Build lookup of existing videos by foundup_id
+    catalog_by_id = {entry.get("foundup_id", ""): entry for entry in catalog}
+
+    deltas = []
+    total_new = 0
+    total_skipped = 0
+
+    for foundup_id, pulled_videos in pulled_by_foundup.items():
+        catalog_entry = catalog_by_id.get(foundup_id, {})
+        existing_ids = get_existing_video_ids(catalog_entry)
+
+        delta = compute_delta(foundup_id, existing_ids, pulled_videos)
+        deltas.append(delta)
+        total_new += delta["new_count"]
+        total_skipped += delta["skipped_count"]
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "summary": {
+            "foundups_checked": len(deltas),
+            "total_new_videos": total_new,
+            "total_skipped": total_skipped,
+        },
+        "deltas": deltas,
+    }
+
+
+def write_delta_artifact(
+    delta: Dict[str, Any],
+    output_path: Path,
+) -> Path:
+    """
+    Write delta artifact to JSON file.
+
+    Args:
+        delta: Delta report dict
+        output_path: Path to write JSON
+
+    Returns:
+        Path written to
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(delta, indent=2, ensure_ascii=False), encoding="utf-8")
+    logger.info(f"[DELTA] Wrote delta artifact to {output_path}")
+    return output_path
+
+
+def format_delta_summary(delta: Dict[str, Any]) -> str:
+    """
+    Format delta for human review in terminal.
+
+    Args:
+        delta: Full delta report
+
+    Returns:
+        Formatted string
+    """
+    lines = [
+        "=" * 60,
+        "YOUTUBE CHANNEL PULL DELTA REPORT",
+        f"Generated: {delta.get('generated_at', 'unknown')}",
+        "=" * 60,
+        "",
+        f"FoundUps checked: {delta['summary']['foundups_checked']}",
+        f"Total new videos:  {delta['summary']['total_new_videos']}",
+        f"Total skipped:     {delta['summary']['total_skipped']}",
+        "",
+    ]
+
+    for d in delta.get("deltas", []):
+        lines.append(f"--- {d['foundup_id']} ---")
+        lines.append(f"  Existing: {d['existing_count']} | Pulled: {d['pulled_count']}")
+        lines.append(f"  New: {d['new_count']} | Skipped: {d['skipped_count']}")
+        if d["new_videos"]:
+            lines.append("  New videos:")
+            for v in d["new_videos"][:5]:  # Show first 5
+                lines.append(f"    - {v['video_id']}: {v['title'][:50]}...")
+            if len(d["new_videos"]) > 5:
+                lines.append(f"    ... and {len(d['new_videos']) - 5} more")
+        lines.append("")
+
+    lines.append("=" * 60)
+    return "\n".join(lines)

--- a/modules/communication/youtube_channel_pull/src/channel_puller.py
+++ b/modules/communication/youtube_channel_pull/src/channel_puller.py
@@ -1,0 +1,128 @@
+"""
+YouTube Channel Puller - Fetch latest videos from a YouTube channel.
+
+Reads channel identity from catalog source_id or youtube_channel_registry,
+fetches latest N videos via YouTube Data API, returns structured video list.
+
+WSP References:
+- WSP 3: Communication domain
+- WSP 97: Browser-verified (truthful API response, no fake data)
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_channel_videos(
+    youtube_service,
+    channel_id: str,
+    max_results: int = 50,
+) -> List[Dict[str, Any]]:
+    """
+    Fetch latest videos from a YouTube channel via Data API.
+
+    Args:
+        youtube_service: Authenticated googleapiclient YouTube service
+        channel_id: YouTube channel ID (e.g., "UC-LSSlOZwpGIRIYihaz8zCw")
+        max_results: Maximum videos to fetch (default 50, max 50 per request)
+
+    Returns:
+        List of video dicts with: video_id, title, thumbnail_url, embed_url, published_at
+    """
+    if not youtube_service:
+        logger.error("[PULL] No YouTube service provided")
+        return []
+    if not channel_id or not channel_id.startswith("UC"):
+        logger.error(f"[PULL] Invalid channel_id: {channel_id}")
+        return []
+
+    videos: List[Dict[str, Any]] = []
+
+    try:
+        # Search for videos from this channel (ordered by date, newest first)
+        request = youtube_service.search().list(
+            part="snippet",
+            channelId=channel_id,
+            type="video",
+            order="date",
+            maxResults=min(max_results, 50),
+        )
+        response = request.execute()
+
+        for item in response.get("items", []):
+            video_id = item.get("id", {}).get("videoId")
+            if not video_id:
+                continue
+
+            snippet = item.get("snippet", {})
+            published_at = snippet.get("publishedAt", "")
+
+            # Get best available thumbnail
+            thumbnails = snippet.get("thumbnails", {})
+            thumbnail_url = (
+                thumbnails.get("high", {}).get("url")
+                or thumbnails.get("medium", {}).get("url")
+                or thumbnails.get("default", {}).get("url")
+                or f"https://i.ytimg.com/vi/{video_id}/hqdefault.jpg"
+            )
+
+            videos.append({
+                "video_id": video_id,
+                "title": snippet.get("title", ""),
+                "thumbnail_url": thumbnail_url,
+                "embed_url": f"https://www.youtube.com/embed/{video_id}",
+                "source_url": f"https://www.youtube.com/watch?v={video_id}",
+                "published_at": published_at,
+                "channel_id": channel_id,
+            })
+
+        logger.info(f"[PULL] Fetched {len(videos)} videos from channel {channel_id}")
+
+    except Exception as e:
+        logger.error(f"[PULL] API error for channel {channel_id}: {e}")
+
+    return videos
+
+
+def get_channel_id_from_catalog(catalog_entry: Dict[str, Any]) -> Optional[str]:
+    """
+    Extract YouTube channel ID from a catalog entry.
+
+    Looks for source_id field where source_type is 'youtube_channel'.
+
+    Args:
+        catalog_entry: Single entry from mall-video-catalog.json
+
+    Returns:
+        Channel ID string or None
+    """
+    source_type = catalog_entry.get("source_type", "")
+    if source_type != "youtube_channel":
+        return None
+
+    source_id = catalog_entry.get("source_id", "")
+    if source_id and source_id.startswith("UC"):
+        return source_id
+
+    return None
+
+
+def get_channel_ids_from_catalog(catalog: List[Dict[str, Any]]) -> Dict[str, str]:
+    """
+    Extract all YouTube channel IDs from catalog.
+
+    Returns:
+        Dict mapping foundup_id -> channel_id
+    """
+    mapping = {}
+    for entry in catalog:
+        foundup_id = entry.get("foundup_id", "")
+        channel_id = get_channel_id_from_catalog(entry)
+        if foundup_id and channel_id:
+            mapping[foundup_id] = channel_id
+    return mapping

--- a/modules/communication/youtube_channel_pull/src/pull_cli.py
+++ b/modules/communication/youtube_channel_pull/src/pull_cli.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+YouTube Channel Pull CLI - Fetch latest videos and generate reviewable delta.
+
+Usage:
+    python -m modules.communication.youtube_channel_pull.src.pull_cli [--dry-run] [--foundup FOUNDUP_ID]
+
+Options:
+    --dry-run       Default mode. Generate delta without catalog mutation.
+    --foundup ID    Pull only specified FoundUp (by foundup_id)
+    --max-results N Max videos per channel (default: 50)
+    --output PATH   Output path for delta JSON
+
+WSP References:
+- WSP 3: Communication domain
+- WSP 97: Truthful verification
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+# Setup logging before imports
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+# Project paths
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
+CATALOG_PATH = REPO_ROOT / "public" / "member" / "mall-video-catalog.json"
+DEFAULT_DELTA_PATH = REPO_ROOT / "docs" / "audits" / "pfmall_youtube_ingest" / "youtube_channel_pull_delta.json"
+
+
+def load_catalog() -> list:
+    """Load mall-video-catalog.json."""
+    if not CATALOG_PATH.exists():
+        logger.error(f"[PULL] Catalog not found: {CATALOG_PATH}")
+        return []
+    return json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+
+
+def get_youtube_service():
+    """
+    Get authenticated YouTube API service.
+
+    Returns None if credentials are not available.
+    """
+    try:
+        from modules.platform_integration.youtube_auth.src.youtube_auth import (
+            get_authenticated_service,
+        )
+        return get_authenticated_service()
+    except Exception as e:
+        logger.warning(f"[PULL] YouTube auth unavailable: {e}")
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="YouTube Channel Pull - Fetch latest videos, generate reviewable delta"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="Generate delta without catalog mutation (default: True)",
+    )
+    parser.add_argument(
+        "--foundup",
+        type=str,
+        default=None,
+        help="Pull only specified FoundUp by foundup_id",
+    )
+    parser.add_argument(
+        "--max-results",
+        type=int,
+        default=50,
+        help="Max videos per channel (default: 50)",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help=f"Output path for delta JSON (default: {DEFAULT_DELTA_PATH})",
+    )
+    args = parser.parse_args()
+
+    output_path = Path(args.output) if args.output else DEFAULT_DELTA_PATH
+
+    # Load catalog
+    logger.info(f"[PULL] Loading catalog from {CATALOG_PATH}")
+    catalog = load_catalog()
+    if not catalog:
+        logger.error("[PULL] Empty or missing catalog. Exiting.")
+        sys.exit(1)
+
+    # Import after path setup
+    from modules.communication.youtube_channel_pull.src.channel_puller import (
+        fetch_channel_videos,
+        get_channel_ids_from_catalog,
+    )
+    from modules.communication.youtube_channel_pull.src.catalog_delta import (
+        generate_full_delta,
+        write_delta_artifact,
+        format_delta_summary,
+    )
+
+    # Get channel mappings from catalog
+    channel_map = get_channel_ids_from_catalog(catalog)
+    logger.info(f"[PULL] Found {len(channel_map)} YouTube-backed FoundUps in catalog")
+
+    # Filter to specific FoundUp if requested
+    if args.foundup:
+        if args.foundup not in channel_map:
+            logger.error(f"[PULL] FoundUp '{args.foundup}' not found or not YouTube-backed")
+            sys.exit(1)
+        channel_map = {args.foundup: channel_map[args.foundup]}
+        logger.info(f"[PULL] Filtering to single FoundUp: {args.foundup}")
+
+    # Get YouTube service
+    youtube = get_youtube_service()
+    if not youtube:
+        logger.warning("[PULL] YouTube API unavailable - generating fixture-based delta")
+        logger.warning("[PULL] To enable live API: configure YOUTUBE_SCOPES and OAuth tokens in .env")
+        # Generate empty delta to show the workflow works
+        pulled_by_foundup = {fid: [] for fid in channel_map.keys()}
+    else:
+        # Fetch videos from each channel
+        pulled_by_foundup = {}
+        for foundup_id, channel_id in channel_map.items():
+            logger.info(f"[PULL] Fetching videos for {foundup_id} (channel: {channel_id})")
+            videos = fetch_channel_videos(youtube, channel_id, max_results=args.max_results)
+            pulled_by_foundup[foundup_id] = videos
+
+    # Generate delta
+    delta = generate_full_delta(catalog, pulled_by_foundup)
+
+    # Write artifact
+    write_delta_artifact(delta, output_path)
+
+    # Print summary (handle Windows console encoding)
+    try:
+        print(format_delta_summary(delta))
+    except UnicodeEncodeError:
+        # Fallback for Windows consoles that can't handle emojis
+        summary = format_delta_summary(delta)
+        print(summary.encode("ascii", errors="replace").decode("ascii"))
+
+    logger.info(f"[PULL] Delta artifact written to: {output_path}")
+    logger.info("[PULL] Review the delta, then manually merge approved videos into catalog.")
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/communication/youtube_channel_pull/tests/__init__.py
+++ b/modules/communication/youtube_channel_pull/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for YouTube Channel Pull module."""

--- a/modules/communication/youtube_channel_pull/tests/test_catalog_delta.py
+++ b/modules/communication/youtube_channel_pull/tests/test_catalog_delta.py
@@ -1,0 +1,233 @@
+"""
+Tests for YouTube Channel Pull catalog delta generation.
+
+Tests channel identity extraction, duplicate detection, and delta generation
+using fixture data (no live API required).
+"""
+
+import pytest
+from modules.communication.youtube_channel_pull.src.channel_puller import (
+    get_channel_id_from_catalog,
+    get_channel_ids_from_catalog,
+)
+from modules.communication.youtube_channel_pull.src.catalog_delta import (
+    get_existing_video_ids,
+    compute_delta,
+    generate_full_delta,
+    format_delta_summary,
+)
+
+
+# ==================== Fixtures ====================
+
+
+@pytest.fixture
+def sample_catalog_entry():
+    """Single YouTube-backed catalog entry."""
+    return {
+        "foundup_id": "move2japan",
+        "title": "Move to Japan",
+        "source_type": "youtube_channel",
+        "source_id": "UC-LSSlOZwpGIRIYihaz8zCw",
+        "videos": [
+            {"video_id": "abc123", "title": "Video 1"},
+            {"video_id": "def456", "title": "Video 2"},
+            {"video_id": "ghi789", "title": "Video 3"},
+        ],
+    }
+
+
+@pytest.fixture
+def sample_catalog():
+    """Multi-entry catalog."""
+    return [
+        {
+            "foundup_id": "move2japan",
+            "source_type": "youtube_channel",
+            "source_id": "UC-LSSlOZwpGIRIYihaz8zCw",
+            "videos": [
+                {"video_id": "abc123", "title": "Video 1"},
+                {"video_id": "def456", "title": "Video 2"},
+            ],
+        },
+        {
+            "foundup_id": "antifafm",
+            "source_type": "youtube_channel",
+            "source_id": "UCVSmg5aOhP4tnQ9KFUg97qA",
+            "videos": [
+                {"video_id": "xyz999", "title": "Existing"},
+            ],
+        },
+        {
+            "foundup_id": "gotjunk",
+            "source_type": "web_app",
+            "source_id": None,
+            "videos": [],
+        },
+    ]
+
+
+@pytest.fixture
+def sample_pulled_videos():
+    """Simulated API response."""
+    return [
+        {"video_id": "abc123", "title": "Video 1 (exists)"},
+        {"video_id": "new001", "title": "New Video 1"},
+        {"video_id": "new002", "title": "New Video 2"},
+    ]
+
+
+# ==================== Channel Identity Tests ====================
+
+
+class TestChannelIdentityExtraction:
+    """Test channel ID extraction from catalog."""
+
+    def test_extract_channel_id_youtube_type(self, sample_catalog_entry):
+        """YouTube channel entry returns source_id."""
+        channel_id = get_channel_id_from_catalog(sample_catalog_entry)
+        assert channel_id == "UC-LSSlOZwpGIRIYihaz8zCw"
+
+    def test_extract_channel_id_non_youtube_type(self):
+        """Non-YouTube entry returns None."""
+        entry = {"source_type": "web_app", "source_id": "some-id"}
+        assert get_channel_id_from_catalog(entry) is None
+
+    def test_extract_channel_id_missing_source(self):
+        """Missing source_id returns None."""
+        entry = {"source_type": "youtube_channel"}
+        assert get_channel_id_from_catalog(entry) is None
+
+    def test_extract_channel_id_invalid_format(self):
+        """Non-UC prefix returns None."""
+        entry = {"source_type": "youtube_channel", "source_id": "invalid"}
+        assert get_channel_id_from_catalog(entry) is None
+
+    def test_extract_all_channel_ids(self, sample_catalog):
+        """Extract all YouTube-backed FoundUps."""
+        mapping = get_channel_ids_from_catalog(sample_catalog)
+        assert len(mapping) == 2
+        assert mapping["move2japan"] == "UC-LSSlOZwpGIRIYihaz8zCw"
+        assert mapping["antifafm"] == "UCVSmg5aOhP4tnQ9KFUg97qA"
+        assert "gotjunk" not in mapping  # web_app, not youtube
+
+
+# ==================== Duplicate Detection Tests ====================
+
+
+class TestDuplicateDetection:
+    """Test existing video ID extraction."""
+
+    def test_get_existing_video_ids(self, sample_catalog_entry):
+        """Extract video IDs from entry."""
+        ids = get_existing_video_ids(sample_catalog_entry)
+        assert ids == {"abc123", "def456", "ghi789"}
+
+    def test_get_existing_video_ids_empty(self):
+        """Empty videos returns empty set."""
+        entry = {"videos": []}
+        assert get_existing_video_ids(entry) == set()
+
+    def test_get_existing_video_ids_missing_field(self):
+        """Missing video_id field handled."""
+        entry = {"videos": [{"title": "No ID"}, {"video_id": "abc"}]}
+        assert get_existing_video_ids(entry) == {"abc"}
+
+
+# ==================== Delta Generation Tests ====================
+
+
+class TestDeltaGeneration:
+    """Test delta computation."""
+
+    def test_compute_delta_with_new_and_existing(self, sample_pulled_videos):
+        """Delta correctly identifies new vs existing."""
+        existing_ids = {"abc123", "def456"}
+        delta = compute_delta("move2japan", existing_ids, sample_pulled_videos)
+
+        assert delta["foundup_id"] == "move2japan"
+        assert delta["existing_count"] == 2
+        assert delta["pulled_count"] == 3
+        assert delta["new_count"] == 2
+        assert delta["skipped_count"] == 1
+
+        new_ids = [v["video_id"] for v in delta["new_videos"]]
+        assert "new001" in new_ids
+        assert "new002" in new_ids
+        assert "abc123" not in new_ids
+
+        assert "abc123" in delta["skipped_ids"]
+
+    def test_compute_delta_all_new(self):
+        """All videos are new."""
+        pulled = [{"video_id": "x"}, {"video_id": "y"}]
+        delta = compute_delta("test", set(), pulled)
+
+        assert delta["new_count"] == 2
+        assert delta["skipped_count"] == 0
+
+    def test_compute_delta_all_existing(self):
+        """All videos already exist."""
+        pulled = [{"video_id": "x"}, {"video_id": "y"}]
+        delta = compute_delta("test", {"x", "y"}, pulled)
+
+        assert delta["new_count"] == 0
+        assert delta["skipped_count"] == 2
+
+    def test_generate_full_delta(self, sample_catalog):
+        """Full delta across multiple FoundUps."""
+        pulled = {
+            "move2japan": [
+                {"video_id": "abc123"},  # exists
+                {"video_id": "new001"},  # new
+            ],
+            "antifafm": [
+                {"video_id": "xyz999"},  # exists
+                {"video_id": "new002"},  # new
+                {"video_id": "new003"},  # new
+            ],
+        }
+
+        delta = generate_full_delta(sample_catalog, pulled)
+
+        assert "generated_at" in delta
+        assert delta["summary"]["foundups_checked"] == 2
+        assert delta["summary"]["total_new_videos"] == 3
+        assert delta["summary"]["total_skipped"] == 2
+
+
+# ==================== Formatting Tests ====================
+
+
+class TestDeltaFormatting:
+    """Test human-readable delta output."""
+
+    def test_format_delta_summary(self):
+        """Format produces readable output."""
+        delta = {
+            "generated_at": "2026-04-13T12:00:00Z",
+            "summary": {
+                "foundups_checked": 2,
+                "total_new_videos": 5,
+                "total_skipped": 10,
+            },
+            "deltas": [
+                {
+                    "foundup_id": "move2japan",
+                    "existing_count": 573,
+                    "pulled_count": 50,
+                    "new_count": 3,
+                    "skipped_count": 47,
+                    "new_videos": [
+                        {"video_id": "x", "title": "New Video Title Here"},
+                    ],
+                    "skipped_ids": [],
+                }
+            ],
+        }
+
+        output = format_delta_summary(delta)
+        assert "YOUTUBE CHANNEL PULL DELTA REPORT" in output
+        assert "move2japan" in output
+        assert "New: 3" in output
+        assert "New Video Title Here" in output

--- a/public/member/ModLog.md
+++ b/public/member/ModLog.md
@@ -1,5 +1,59 @@
 # Member Area Module Change Log
 
+## [2026-04-13] YouTube Channel Pull Delta Generator (Worker CM)
+
+**Who**: 0102 - Worker CM
+**Slice**: `YOUTUBE_CHANNEL_PULL_PHASE1`
+**What**: First truthful YouTube-to-catalog ingest path for pfMALL.
+
+**Implementation**:
+- New module: `modules/communication/youtube_channel_pull/`
+- Reads channel IDs from existing `source_id` fields in `mall-video-catalog.json`
+- Fetches latest videos via YouTube Data API (reuses `youtube_auth` credentials)
+- Generates reviewable delta artifact (no blind catalog mutation)
+- Default dry-run mode; manual merge step for human review
+
+**Live API Test Result**:
+- Channel: `move2japan` (UC-LSSlOZwpGIRIYihaz8zCw)
+- Pulled: 19 videos from API
+- New: 19 (not yet in catalog)
+- Delta artifact: `docs/audits/pfmall_youtube_ingest/youtube_channel_pull_delta.json`
+
+**Operator Workflow**:
+1. `python -m modules.communication.youtube_channel_pull.src.pull_cli`
+2. Inspect delta artifact
+3. Manually merge approved videos into catalog
+
+**Tests**: 13/13 passed (channel identity, duplicate detection, delta generation)
+
+**WSP 97 Applied**: Live API verification confirmed pull path is truthful.
+
+---
+
+## [2026-04-13] pfMALL YouTube Ingest Audit (Worker CI)
+
+**Who**: 0102 - Worker CI
+**Slice**: `PFMALL_YOUTUBE_SEARCH_AND_INGEST_AUDIT_PHASE1`
+**What**: Audit how YouTube videos populate pfMALL to determine if search/ingest path exists.
+
+**Findings**:
+- `mall-video-catalog.json` is MANUALLY MAINTAINED (no automated pipeline)
+- No YouTube Data API integration exists
+- `member_catalog_export.py` exports catalog metadata, does NOT generate video entries
+- `video_indexer/` is for Digital Twin learning, not catalog population
+- `youtube_ingest_resolver.py` is for RTMPS live streaming, not catalog
+
+**Answer**: No search or ingest path exists. Catalog is hand-edited JSON.
+
+**Recommended Next Slice**: `YOUTUBE_CHANNEL_PULL_PHASE1`
+- Fetch videos from channel IDs via YouTube Data API
+- Output delta JSON for human review
+- Module location: `modules/communication/youtube_channel_pull/`
+
+**Artifact**: [docs/audits/pfmall_youtube_ingest/PFMALL_YOUTUBE_INGEST_AUDIT.md](../../docs/audits/pfmall_youtube_ingest/PFMALL_YOUTUBE_INGEST_AUDIT.md)
+
+---
+
 ## [2026-04-12] Adaptive Desktop 6x3 Tile Layout (Worker CL)
 
 **Who**: 0102 - Worker CL


### PR DESCRIPTION
## Summary
- Add `youtube_channel_pull` module for truthful YouTube-to-catalog ingest
- Reads channel IDs from existing `source_id` fields in `mall-video-catalog.json`
- Fetches latest videos via YouTube Data API (reuses `youtube_auth` credentials)
- Generates reviewable delta artifact (no blind catalog mutation)

## Live API Verification
```
Channel: move2japan (UC-LSSlOZwpGIRIYihaz8zCw)
Pulled: 19 videos
New: 19 (not in existing catalog)
```

## Files
| File | Purpose |
|------|---------|
| `channel_puller.py` | Fetch videos from channel via search.list |
| `catalog_delta.py` | Compare with existing, generate delta |
| `pull_cli.py` | CLI with --dry-run default |
| `test_catalog_delta.py` | 13 tests for identity, dedup, delta |

## Operator Workflow
```bash
# 1. Run pull
python -m modules.communication.youtube_channel_pull.src.pull_cli

# 2. Inspect delta (gitignored, not committed)
cat docs/audits/pfmall_youtube_ingest/youtube_channel_pull_delta.json

# 3. Manually merge approved videos into catalog
```

## Test plan
- [x] 13 unit tests passed (channel identity, duplicate detection, delta generation)
- [x] Live API pull verified (move2japan: 19 videos)
- [x] Delta artifact generated correctly
- [ ] Verify quota consumption acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)