### PR TITLE
docs(pfmall): add youtube pipeline status summary

### DIFF
--- a/modules/communication/youtube_channel_pull/INTERFACE.md
+++ b/modules/communication/youtube_channel_pull/INTERFACE.md
@@ -143,7 +143,57 @@ python -m modules.communication.youtube_channel_pull.src.refresh_scheduler [OPTI
 | Delta | `docs/audits/pfmall_youtube_ingest/youtube_channel_pull_delta.json` | New videos for review |
 | Refresh Log | `docs/audits/pfmall_youtube_ingest/refresh_log.json` | Scheduler run history |
 
+### status_summary.py
+
+Read-only status summary generator. Aggregates catalog, delta, refresh log,
+discovery proposals, and the latest discovery review into a single operator
+artifact. Performs no catalog mutation and requires no live API access.
+
+#### `generate_status_summary(repo_root=REPO_ROOT) -> Dict`
+
+Return a status summary dict with fields:
+- `generated_at`, `read_only`
+- `sources`: relative paths to each parsed artifact (or `null` if missing)
+- `catalog`: foundup counts, declared-vs-actual totals, mismatches, per-entry rows
+- `delta`: latest known-channel refresh (generated_at, per-foundup deltas)
+- `refresh_log`: run count + last run, or `{available: False, note: ...}` if missing
+- `proposals`: latest discovery proposals metadata
+- `review`: latest discovery review result (auto-selects most recent `youtube_discovery_review_result_*.json` by sorted order)
+- `blockers`: list of strings
+- `next_actions`: list of strings
+
+#### `render_markdown(summary: Dict) -> str`
+
+Render the summary dict as operator-facing markdown. Safe on fully-missing
+artifact sets (reports absences honestly).
+
+#### `write_status_summary(summary, markdown_path, json_path) -> Dict[str, Path]`
+
+Write markdown and JSON artifacts. Only writes to the provided output paths;
+never mutates source artifacts.
+
+#### CLI
+
+```bash
+python -m modules.communication.youtube_channel_pull.src.status_summary [OPTIONS]
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--repo-root` | path | inferred | Repo root to scan for artifacts |
+| `--markdown-out` | path | `docs/audits/pfmall_youtube_ingest/pipeline_status_summary.md` | Markdown output |
+| `--json-out` | path | `docs/audits/pfmall_youtube_ingest/pipeline_status_summary.json` | JSON output |
+| `--stdout` | flag | false | Print markdown to stdout instead of writing files |
+
+#### Output Artifacts
+
+| Artifact | Path | Purpose |
+|----------|------|---------|
+| Status Summary (MD) | `docs/audits/pfmall_youtube_ingest/pipeline_status_summary.md` | Operator-facing status view |
+| Status Summary (JSON) | `docs/audits/pfmall_youtube_ingest/pipeline_status_summary.json` | Machine-readable status contract |
+
 ## Dependencies
 
 - `youtube_auth`: For `get_authenticated_service()`
 - `googleapiclient`: YouTube Data API v3
+- `status_summary`: standard library only (json, pathlib, datetime, argparse)

--- a/modules/communication/youtube_channel_pull/src/status_summary.py
+++ b/modules/communication/youtube_channel_pull/src/status_summary.py
@@ -1,0 +1,525 @@
+#!/usr/bin/env python3
+"""
+YouTube Pipeline Status Summary Generator (Read-Only).
+
+Parses existing artifacts and emits an operator-facing status summary so
+humans can see what ran, what changed, and what needs review without
+manually inspecting multiple JSON files.
+
+Artifact sources (read-only):
+- public/member/mall-video-catalog.json
+- docs/audits/pfmall_youtube_ingest/youtube_channel_pull_delta.json
+- docs/audits/pfmall_youtube_ingest/refresh_log.json            (optional)
+- docs/audits/pfmall_youtube_ingest/youtube_discovery_proposals.json
+- docs/audits/pfmall_youtube_ingest/youtube_discovery_review_result_*.json
+
+Outputs (generated):
+- docs/audits/pfmall_youtube_ingest/pipeline_status_summary.md
+- docs/audits/pfmall_youtube_ingest/pipeline_status_summary.json
+
+This module performs NO catalog mutation and requires NO live API access.
+
+WSP References:
+- WSP 3: Communication domain
+- WSP 49: Module structure
+- WSP 97: Truthful verification (report missing artifacts honestly)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
+CATALOG_PATH = REPO_ROOT / "public" / "member" / "mall-video-catalog.json"
+AUDIT_DIR = REPO_ROOT / "docs" / "audits" / "pfmall_youtube_ingest"
+DELTA_PATH = AUDIT_DIR / "youtube_channel_pull_delta.json"
+REFRESH_LOG_PATH = AUDIT_DIR / "refresh_log.json"
+PROPOSALS_PATH = AUDIT_DIR / "youtube_discovery_proposals.json"
+SUMMARY_MD_PATH = AUDIT_DIR / "pipeline_status_summary.md"
+SUMMARY_JSON_PATH = AUDIT_DIR / "pipeline_status_summary.json"
+REVIEW_RESULT_GLOB = "youtube_discovery_review_result_*.json"
+
+
+def _load_json(path: Path) -> Optional[Any]:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return {"_parse_error": str(exc)}
+
+
+def _find_latest_review_result(audit_dir: Path) -> Optional[Path]:
+    candidates = sorted(audit_dir.glob(REVIEW_RESULT_GLOB))
+    if not candidates:
+        return None
+    return candidates[-1]
+
+
+def _catalog_counts(catalog: Optional[List[Dict[str, Any]]]) -> Dict[str, Any]:
+    if not isinstance(catalog, list):
+        return {"available": False, "error": "catalog missing or not a list"}
+
+    entries: List[Dict[str, Any]] = []
+    total_declared = 0
+    total_actual = 0
+    mismatches: List[Dict[str, Any]] = []
+    for entry in catalog:
+        fid = entry.get("foundup_id", "?")
+        declared = int(entry.get("video_count", 0) or 0)
+        videos = entry.get("videos", []) or []
+        actual = len(videos)
+        total_declared += declared
+        total_actual += actual
+        entries.append(
+            {
+                "foundup_id": fid,
+                "title": entry.get("title", ""),
+                "source_type": entry.get("source_type", ""),
+                "source_id": entry.get("source_id", ""),
+                "declared_video_count": declared,
+                "actual_video_count": actual,
+            }
+        )
+        if declared != actual:
+            mismatches.append(
+                {"foundup_id": fid, "declared": declared, "actual": actual}
+            )
+
+    return {
+        "available": True,
+        "foundup_count": len(entries),
+        "total_declared_videos": total_declared,
+        "total_actual_videos": total_actual,
+        "count_mismatches": mismatches,
+        "entries": entries,
+    }
+
+
+def _delta_status(delta: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not isinstance(delta, dict):
+        return {"available": False}
+    if "_parse_error" in delta:
+        return {"available": False, "error": delta["_parse_error"]}
+
+    summary = delta.get("summary", {}) or {}
+    deltas = delta.get("deltas", []) or []
+    per_foundup = [
+        {
+            "foundup_id": d.get("foundup_id"),
+            "existing_count": d.get("existing_count"),
+            "pulled_count": d.get("pulled_count"),
+            "new_count": d.get("new_count"),
+            "skipped_count": d.get("skipped_count"),
+        }
+        for d in deltas
+    ]
+    return {
+        "available": True,
+        "generated_at": delta.get("generated_at"),
+        "foundups_checked": summary.get("foundups_checked"),
+        "total_new_videos": summary.get("total_new_videos"),
+        "total_skipped": summary.get("total_skipped"),
+        "per_foundup": per_foundup,
+    }
+
+
+def _refresh_log_status(log: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not isinstance(log, dict):
+        return {
+            "available": False,
+            "note": (
+                "refresh_log.json not present; refresh_scheduler has not run "
+                "in logged mode yet, or all runs used --no-log."
+            ),
+        }
+    runs = log.get("runs", []) or []
+    if not runs:
+        return {"available": True, "run_count": 0, "last_run": None}
+    last = runs[-1]
+    return {
+        "available": True,
+        "run_count": len(runs),
+        "last_run": {
+            "triggered_at": last.get("triggered_at"),
+            "trigger_mode": last.get("trigger_mode"),
+            "success": last.get("success"),
+            "foundups_checked": last.get("foundups_checked"),
+            "new_videos_found": last.get("new_videos_found"),
+            "error": last.get("error"),
+        },
+    }
+
+
+def _proposals_status(proposals: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not isinstance(proposals, dict):
+        return {"available": False}
+    if "_parse_error" in proposals:
+        return {"available": False, "error": proposals["_parse_error"]}
+
+    summary = proposals.get("summary", {}) or {}
+    return {
+        "available": True,
+        "generated_at": proposals.get("generated_at"),
+        "query": proposals.get("query"),
+        "search_type": proposals.get("search_type"),
+        "total_proposals": summary.get("total_proposals"),
+        "matched_to_foundup": summary.get("matched_to_foundup"),
+        "unmatched": summary.get("unmatched"),
+        "catalog_targets": summary.get("catalog_targets"),
+    }
+
+
+def _review_status(review: Optional[Dict[str, Any]], source: Optional[Path]) -> Dict[str, Any]:
+    if not isinstance(review, dict):
+        return {"available": False}
+    if "_parse_error" in review:
+        return {"available": False, "error": review["_parse_error"]}
+
+    rs = review.get("review_summary", {}) or {}
+    cu = review.get("catalog_update", {}) or {}
+    return {
+        "available": True,
+        "source_file": source.name if source else None,
+        "reviewed_at": review.get("reviewed_at"),
+        "reviewer": review.get("reviewer"),
+        "proposal_artifact": review.get("proposal_artifact"),
+        "total_proposals": review.get("total_proposals"),
+        "approved": rs.get("approved"),
+        "skipped_duplicate": rs.get("skipped_duplicate"),
+        "skipped_ambiguous": rs.get("skipped_ambiguous"),
+        "skipped_low_confidence": rs.get("skipped_low_confidence"),
+        "rejected": rs.get("rejected"),
+        "catalog_update": {
+            "target_foundup": cu.get("target_foundup"),
+            "video_count_before": cu.get("video_count_before"),
+            "video_count_after": cu.get("video_count_after"),
+        },
+    }
+
+
+def _determine_blockers_and_next_action(summary: Dict[str, Any]) -> Dict[str, Any]:
+    blockers: List[str] = []
+    next_actions: List[str] = []
+
+    if not summary["catalog"]["available"]:
+        blockers.append("Catalog missing or unreadable.")
+        next_actions.append("Restore public/member/mall-video-catalog.json.")
+
+    if not summary["delta"]["available"]:
+        blockers.append("Known-channel delta artifact missing.")
+        next_actions.append(
+            "Run: python -m modules.communication.youtube_channel_pull.src.refresh_scheduler"
+        )
+    else:
+        total_new = summary["delta"].get("total_new_videos") or 0
+        if total_new > 0:
+            next_actions.append(
+                f"Review {total_new} new known-channel candidate(s) in "
+                "youtube_channel_pull_delta.json and apply if relevant."
+            )
+        else:
+            next_actions.append(
+                "Known-channel delta shows 0 new videos - no action required."
+            )
+
+    if not summary["refresh_log"]["available"]:
+        next_actions.append(
+            "Run refresh_scheduler at least once with logging enabled to "
+            "populate refresh_log.json (drop --no-log)."
+        )
+
+    if summary["proposals"]["available"]:
+        total_prop = summary["proposals"].get("total_proposals") or 0
+        reviewed = summary["review"].get("total_proposals") if summary["review"]["available"] else None
+        proposals_gen = summary["proposals"].get("generated_at")
+        review_gen = summary["review"].get("reviewed_at") if summary["review"]["available"] else None
+        if not summary["review"]["available"]:
+            next_actions.append(
+                f"{total_prop} discovery proposal(s) exist with no review artifact - operator review required."
+            )
+        elif reviewed != total_prop:
+            next_actions.append(
+                f"Latest review covers {reviewed}/{total_prop} proposals - verify pending items."
+            )
+        elif proposals_gen and review_gen and review_gen < proposals_gen:
+            next_actions.append(
+                "Latest review predates latest proposals - re-review required."
+            )
+
+    mismatches = summary["catalog"].get("count_mismatches") if summary["catalog"]["available"] else []
+    if mismatches:
+        blockers.append(
+            f"{len(mismatches)} FoundUp(s) have declared video_count != actual videos[] length."
+        )
+        next_actions.append("Reconcile declared vs actual video counts in catalog.")
+
+    return {"blockers": blockers, "next_actions": next_actions}
+
+
+def generate_status_summary(repo_root: Path = REPO_ROOT) -> Dict[str, Any]:
+    """Build the pipeline status summary dict from existing artifacts only.
+
+    Read-only. No catalog mutation. No live API calls.
+    """
+    catalog_path = repo_root / "public" / "member" / "mall-video-catalog.json"
+    audit_dir = repo_root / "docs" / "audits" / "pfmall_youtube_ingest"
+    delta_path = audit_dir / "youtube_channel_pull_delta.json"
+    refresh_log_path = audit_dir / "refresh_log.json"
+    proposals_path = audit_dir / "youtube_discovery_proposals.json"
+
+    catalog = _load_json(catalog_path)
+    delta = _load_json(delta_path)
+    refresh_log = _load_json(refresh_log_path)
+    proposals = _load_json(proposals_path)
+    latest_review_path = _find_latest_review_result(audit_dir)
+    review = _load_json(latest_review_path) if latest_review_path else None
+
+    summary: Dict[str, Any] = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generator": "status_summary.generate_status_summary",
+        "read_only": True,
+        "sources": {
+            "catalog": str(catalog_path.relative_to(repo_root)) if catalog_path.exists() else None,
+            "delta": str(delta_path.relative_to(repo_root)) if delta_path.exists() else None,
+            "refresh_log": str(refresh_log_path.relative_to(repo_root)) if refresh_log_path.exists() else None,
+            "proposals": str(proposals_path.relative_to(repo_root)) if proposals_path.exists() else None,
+            "latest_review": str(latest_review_path.relative_to(repo_root)) if latest_review_path else None,
+        },
+        "catalog": _catalog_counts(catalog),
+        "delta": _delta_status(delta),
+        "refresh_log": _refresh_log_status(refresh_log),
+        "proposals": _proposals_status(proposals),
+        "review": _review_status(review, latest_review_path),
+    }
+    summary.update(_determine_blockers_and_next_action(summary))
+    return summary
+
+
+def render_markdown(summary: Dict[str, Any]) -> str:
+    """Render the summary dict as an operator-facing markdown document."""
+    lines: List[str] = []
+    lines.append("# pfMALL YouTube Pipeline - Status Summary")
+    lines.append("")
+    lines.append(f"- Generated: `{summary['generated_at']}`")
+    lines.append("- Read-only: yes (no catalog mutation, no live API calls)")
+    lines.append("- Generator: `modules/communication/youtube_channel_pull/src/status_summary.py`")
+    lines.append("")
+
+    # Sources
+    lines.append("## Sources")
+    lines.append("")
+    lines.append("| Artifact | Path |")
+    lines.append("|---|---|")
+    for label, key in [
+        ("Catalog", "catalog"),
+        ("Known-channel delta", "delta"),
+        ("Refresh log", "refresh_log"),
+        ("Discovery proposals", "proposals"),
+        ("Latest discovery review", "latest_review"),
+    ]:
+        path = summary["sources"].get(key)
+        shown = f"`{path}`" if path else "_missing_"
+        lines.append(f"| {label} | {shown} |")
+    lines.append("")
+
+    # Catalog
+    lines.append("## 1. Catalog State")
+    lines.append("")
+    cat = summary["catalog"]
+    if not cat["available"]:
+        lines.append(f"Catalog unavailable: {cat.get('error', 'unknown error')}")
+    else:
+        lines.append(f"- FoundUps: **{cat['foundup_count']}**")
+        lines.append(f"- Total declared videos: **{cat['total_declared_videos']}**")
+        lines.append(f"- Total actual videos (sum of `videos[]`): **{cat['total_actual_videos']}**")
+        if cat["count_mismatches"]:
+            lines.append(
+                f"- Count mismatches: **{len(cat['count_mismatches'])}** (declared != actual)"
+            )
+        else:
+            lines.append("- Count mismatches: none")
+        lines.append("")
+        lines.append("| foundup_id | title | source_type | declared | actual |")
+        lines.append("|---|---|---|---:|---:|")
+        for e in cat["entries"]:
+            lines.append(
+                f"| {e['foundup_id']} | {e['title']} | {e['source_type']} | "
+                f"{e['declared_video_count']} | {e['actual_video_count']} |"
+            )
+    lines.append("")
+
+    # Delta
+    lines.append("## 2. Latest Known-Channel Refresh (Delta)")
+    lines.append("")
+    delta = summary["delta"]
+    if not delta["available"]:
+        lines.append("Delta artifact not present - run `refresh_scheduler` to generate one.")
+    else:
+        lines.append(f"- Generated: `{delta.get('generated_at', 'unknown')}`")
+        lines.append(f"- FoundUps checked: **{delta.get('foundups_checked', 0)}**")
+        lines.append(f"- New videos: **{delta.get('total_new_videos', 0)}**")
+        lines.append(f"- Skipped (already in catalog): **{delta.get('total_skipped', 0)}**")
+        lines.append("")
+        if delta.get("per_foundup"):
+            lines.append("| foundup_id | existing | pulled | new | skipped |")
+            lines.append("|---|---:|---:|---:|---:|")
+            for row in delta["per_foundup"]:
+                lines.append(
+                    f"| {row.get('foundup_id')} | {row.get('existing_count')} | "
+                    f"{row.get('pulled_count')} | {row.get('new_count')} | "
+                    f"{row.get('skipped_count')} |"
+                )
+    lines.append("")
+
+    # Refresh log
+    lines.append("## 3. Refresh Scheduler Log")
+    lines.append("")
+    rl = summary["refresh_log"]
+    if not rl["available"]:
+        lines.append(f"_{rl.get('note', 'refresh_log.json not present')}_")
+    else:
+        lines.append(f"- Total logged runs: **{rl.get('run_count', 0)}**")
+        last = rl.get("last_run")
+        if last:
+            lines.append(f"- Last run at: `{last.get('triggered_at')}`")
+            lines.append(f"- Trigger mode: `{last.get('trigger_mode')}`")
+            lines.append(f"- Success: `{last.get('success')}`")
+            lines.append(f"- FoundUps checked: {last.get('foundups_checked')}")
+            lines.append(f"- New videos found: {last.get('new_videos_found')}")
+            if last.get("error"):
+                lines.append(f"- Error: `{last['error']}`")
+    lines.append("")
+
+    # Proposals
+    lines.append("## 4. Discovery Proposals")
+    lines.append("")
+    prop = summary["proposals"]
+    if not prop["available"]:
+        lines.append("No discovery proposals artifact present.")
+    else:
+        lines.append(f"- Generated: `{prop.get('generated_at', 'unknown')}`")
+        lines.append(f"- Query: `{prop.get('query')}`")
+        lines.append(f"- Search type: `{prop.get('search_type')}`")
+        lines.append(f"- Total proposals: **{prop.get('total_proposals', 0)}**")
+        lines.append(f"- Matched to a FoundUp: **{prop.get('matched_to_foundup', 0)}**")
+        lines.append(f"- Unmatched: **{prop.get('unmatched', 0)}**")
+        lines.append(f"- Distinct catalog targets: **{prop.get('catalog_targets', 0)}**")
+    lines.append("")
+
+    # Review
+    lines.append("## 5. Latest Discovery Review")
+    lines.append("")
+    rev = summary["review"]
+    if not rev["available"]:
+        lines.append("No discovery review artifact found.")
+    else:
+        lines.append(f"- Source: `{rev.get('source_file')}`")
+        lines.append(f"- Reviewed at: `{rev.get('reviewed_at')}`")
+        lines.append(f"- Reviewer: `{rev.get('reviewer')}`")
+        lines.append(f"- Proposal artifact reviewed: `{rev.get('proposal_artifact')}`")
+        lines.append(f"- Total proposals covered: **{rev.get('total_proposals', 0)}**")
+        lines.append(f"- Approved / applied: **{rev.get('approved', 0)}**")
+        lines.append(f"- Skipped (duplicate): **{rev.get('skipped_duplicate', 0)}**")
+        lines.append(f"- Skipped (ambiguous): **{rev.get('skipped_ambiguous', 0)}**")
+        lines.append(f"- Skipped (low confidence): **{rev.get('skipped_low_confidence', 0)}**")
+        lines.append(f"- Rejected: **{rev.get('rejected', 0)}**")
+        cu = rev.get("catalog_update") or {}
+        if cu.get("target_foundup") is not None:
+            lines.append(
+                f"- Catalog update: `{cu.get('target_foundup')}` "
+                f"{cu.get('video_count_before')} -> {cu.get('video_count_after')}"
+            )
+    lines.append("")
+
+    # Blockers & next actions
+    lines.append("## 6. Blockers")
+    lines.append("")
+    if summary["blockers"]:
+        for b in summary["blockers"]:
+            lines.append(f"- {b}")
+    else:
+        lines.append("- None detected from artifacts.")
+    lines.append("")
+
+    lines.append("## 7. Operator Next Action")
+    lines.append("")
+    if summary["next_actions"]:
+        for a in summary["next_actions"]:
+            lines.append(f"- {a}")
+    else:
+        lines.append("- No action required.")
+    lines.append("")
+
+    lines.append("---")
+    lines.append("")
+    lines.append(
+        "_Summary is artifact-grounded. Missing artifacts are reported honestly; "
+        "no fields are inferred from sources that do not exist._"
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_status_summary(
+    summary: Dict[str, Any],
+    markdown_path: Path = SUMMARY_MD_PATH,
+    json_path: Path = SUMMARY_JSON_PATH,
+) -> Dict[str, Path]:
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.write_text(render_markdown(summary), encoding="utf-8")
+    json_path.write_text(
+        json.dumps(summary, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return {"markdown": markdown_path, "json": json_path}
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate read-only status summary for the pfMALL YouTube pipeline."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Repository root (defaults to inferred path).",
+    )
+    parser.add_argument(
+        "--markdown-out",
+        type=Path,
+        default=SUMMARY_MD_PATH,
+        help="Path for markdown summary output.",
+    )
+    parser.add_argument(
+        "--json-out",
+        type=Path,
+        default=SUMMARY_JSON_PATH,
+        help="Path for JSON summary output.",
+    )
+    parser.add_argument(
+        "--stdout",
+        action="store_true",
+        help="Print markdown to stdout instead of writing files.",
+    )
+    args = parser.parse_args(argv)
+
+    summary = generate_status_summary(args.repo_root)
+
+    if args.stdout:
+        sys.stdout.write(render_markdown(summary))
+        return 0
+
+    written = write_status_summary(summary, args.markdown_out, args.json_out)
+    print(f"[OK] Wrote markdown: {written['markdown']}")
+    print(f"[OK] Wrote JSON:     {written['json']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/modules/communication/youtube_channel_pull/tests/test_status_summary.py
+++ b/modules/communication/youtube_channel_pull/tests/test_status_summary.py
@@ -1,0 +1,225 @@
+"""
+Focused tests for status_summary generator.
+
+Tests:
+- Parsing of complete artifact set (happy path)
+- Missing-artifact behavior (refresh_log absent, catalog absent, etc.)
+- Markdown renders without crashing for both cases
+- Read-only guarantee: never writes to catalog/audit source paths
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from modules.communication.youtube_channel_pull.src import status_summary
+
+
+def _write_json(path: Path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _scaffold_repo(tmp_path: Path, *, include_catalog=True, include_delta=True,
+                   include_proposals=True, include_review=True, include_refresh_log=False):
+    catalog_path = tmp_path / "public" / "member" / "mall-video-catalog.json"
+    audit_dir = tmp_path / "docs" / "audits" / "pfmall_youtube_ingest"
+
+    if include_catalog:
+        _write_json(
+            catalog_path,
+            [
+                {
+                    "foundup_id": "move2japan",
+                    "title": "Move to Japan",
+                    "source_type": "youtube_channel",
+                    "source_id": "UC-TEST",
+                    "video_count": 2,
+                    "videos": [{"video_id": "a"}, {"video_id": "b"}],
+                },
+                {
+                    "foundup_id": "eduit",
+                    "title": "EDUIT",
+                    "source_type": "youtube_channel",
+                    "source_id": "UC-EDU",
+                    "video_count": 1,
+                    "videos": [],  # mismatch: declared 1, actual 0
+                },
+            ],
+        )
+
+    if include_delta:
+        _write_json(
+            audit_dir / "youtube_channel_pull_delta.json",
+            {
+                "generated_at": "2026-04-13T07:17:28Z",
+                "summary": {
+                    "foundups_checked": 1,
+                    "total_new_videos": 0,
+                    "total_skipped": 19,
+                },
+                "deltas": [
+                    {
+                        "foundup_id": "move2japan",
+                        "existing_count": 594,
+                        "pulled_count": 19,
+                        "new_count": 0,
+                        "skipped_count": 19,
+                        "new_videos": [],
+                        "skipped_ids": [],
+                    }
+                ],
+            },
+        )
+
+    if include_proposals:
+        _write_json(
+            audit_dir / "youtube_discovery_proposals.json",
+            {
+                "generated_at": "2026-04-13T07:06:16Z",
+                "query": "FFCPLN music",
+                "search_type": "video",
+                "summary": {
+                    "total_proposals": 10,
+                    "matched_to_foundup": 10,
+                    "unmatched": 0,
+                    "catalog_targets": 4,
+                },
+                "proposals": [],
+            },
+        )
+
+    if include_review:
+        _write_json(
+            audit_dir / "youtube_discovery_review_result_20260413.json",
+            {
+                "reviewed_at": "2026-04-13T07:30:00Z",
+                "reviewer": "test",
+                "proposal_artifact": "youtube_discovery_proposals.json",
+                "total_proposals": 10,
+                "review_summary": {
+                    "approved": 2,
+                    "skipped_duplicate": 8,
+                    "skipped_ambiguous": 0,
+                    "skipped_low_confidence": 0,
+                    "rejected": 0,
+                },
+                "applied": [],
+                "skipped": [],
+                "catalog_update": {
+                    "target_foundup": "move2japan",
+                    "video_count_before": 592,
+                    "video_count_after": 594,
+                },
+            },
+        )
+
+    if include_refresh_log:
+        _write_json(
+            audit_dir / "refresh_log.json",
+            {
+                "runs": [
+                    {
+                        "success": True,
+                        "foundups_checked": 1,
+                        "new_videos_found": 0,
+                        "delta_path": "docs/audits/pfmall_youtube_ingest/youtube_channel_pull_delta.json",
+                        "error": None,
+                        "triggered_at": "2026-04-13T07:17:28Z",
+                        "trigger_mode": "manual",
+                    }
+                ]
+            },
+        )
+
+    return tmp_path
+
+
+def test_full_artifact_set_parses(tmp_path):
+    repo = _scaffold_repo(tmp_path, include_refresh_log=True)
+    summary = status_summary.generate_status_summary(repo)
+
+    assert summary["catalog"]["available"] is True
+    assert summary["catalog"]["foundup_count"] == 2
+    assert summary["catalog"]["total_declared_videos"] == 3
+    assert summary["catalog"]["total_actual_videos"] == 2
+    assert len(summary["catalog"]["count_mismatches"]) == 1
+    assert summary["catalog"]["count_mismatches"][0]["foundup_id"] == "eduit"
+
+    assert summary["delta"]["available"] is True
+    assert summary["delta"]["total_new_videos"] == 0
+    assert summary["delta"]["total_skipped"] == 19
+
+    assert summary["refresh_log"]["available"] is True
+    assert summary["refresh_log"]["run_count"] == 1
+    assert summary["refresh_log"]["last_run"]["trigger_mode"] == "manual"
+
+    assert summary["proposals"]["available"] is True
+    assert summary["proposals"]["total_proposals"] == 10
+
+    assert summary["review"]["available"] is True
+    assert summary["review"]["approved"] == 2
+    assert summary["review"]["catalog_update"]["video_count_after"] == 594
+
+
+def test_missing_refresh_log_is_reported_honestly(tmp_path):
+    repo = _scaffold_repo(tmp_path, include_refresh_log=False)
+    summary = status_summary.generate_status_summary(repo)
+
+    assert summary["refresh_log"]["available"] is False
+    assert "refresh_log.json not present" in summary["refresh_log"]["note"]
+    # Other artifacts still parse fine
+    assert summary["catalog"]["available"] is True
+    assert summary["delta"]["available"] is True
+
+
+def test_all_artifacts_missing_emits_blockers(tmp_path):
+    summary = status_summary.generate_status_summary(tmp_path)
+
+    assert summary["catalog"]["available"] is False
+    assert summary["delta"]["available"] is False
+    assert summary["refresh_log"]["available"] is False
+    assert summary["proposals"]["available"] is False
+    assert summary["review"]["available"] is False
+
+    # Blockers list should flag the critical absences
+    blocker_text = " ".join(summary["blockers"])
+    assert "Catalog" in blocker_text
+    assert "delta" in blocker_text.lower()
+
+
+def test_markdown_render_does_not_raise_for_full_and_empty(tmp_path):
+    # Full
+    repo_full = _scaffold_repo(tmp_path / "full", include_refresh_log=True)
+    summary_full = status_summary.generate_status_summary(repo_full)
+    md_full = status_summary.render_markdown(summary_full)
+    assert "pfMALL YouTube Pipeline" in md_full
+    assert "move2japan" in md_full
+
+    # Empty (no artifacts)
+    summary_empty = status_summary.generate_status_summary(tmp_path / "empty")
+    md_empty = status_summary.render_markdown(summary_empty)
+    assert "pfMALL YouTube Pipeline" in md_empty
+    assert "not present" in md_empty.lower() or "missing" in md_empty.lower()
+
+
+def test_write_status_summary_is_read_only_vs_sources(tmp_path):
+    repo = _scaffold_repo(tmp_path, include_refresh_log=True)
+    summary = status_summary.generate_status_summary(repo)
+
+    md_out = tmp_path / "out" / "summary.md"
+    json_out = tmp_path / "out" / "summary.json"
+    written = status_summary.write_status_summary(summary, md_out, json_out)
+
+    assert written["markdown"].exists()
+    assert written["json"].exists()
+
+    # Ensure no source artifact was mutated (mtime not changed is expensive to
+    # verify cross-platform; instead verify content is still intact).
+    catalog = json.loads(
+        (repo / "public" / "member" / "mall-video-catalog.json").read_text(encoding="utf-8")
+    )
+    assert len(catalog) == 2  # same as scaffolded

--- a/public/member/ModLog.md
+++ b/public/member/ModLog.md
@@ -1,5 +1,70 @@
 # Member Area Module Change Log
 
+## [2026-04-17] pfMALL YouTube Pipeline Status Summary (Worker CW)
+
+**Who**: 0102 - Worker CW
+**Slice**: `PFMALL_YOUTUBE_PIPELINE_STATUS_SUMMARY_PHASE1`
+**What**: Read-only operator status summary for the pfMALL YouTube pipeline.
+
+**Rationale**: Pipeline state was previously spread across the catalog, delta,
+review, and proposal artifacts. Operators had to manually inspect multiple
+JSON files to know what ran and what still needs review. This slice defines
+the status contract (not a UI) so a later surface can consume it cleanly.
+
+**Files Added**:
+- `modules/communication/youtube_channel_pull/src/status_summary.py` - generator (read-only).
+- `modules/communication/youtube_channel_pull/tests/test_status_summary.py` - 5 focused tests.
+- `docs/audits/pfmall_youtube_ingest/pipeline_status_summary.md` - rendered summary.
+- `docs/audits/pfmall_youtube_ingest/pipeline_status_summary.json` - machine-readable summary.
+
+**Status Contract (fields reported)**:
+| Field | Source | Notes |
+|---|---|---|
+| Catalog foundup count / declared-vs-actual video totals | `mall-video-catalog.json` | Reports mismatches honestly |
+| Latest known-channel refresh timestamp / counts / per-foundup rows | `youtube_channel_pull_delta.json` | Existing vs pulled vs new vs skipped |
+| Refresh scheduler run history | `refresh_log.json` | Missing artifact reported, not faked |
+| Discovery proposals (query, totals, matched/unmatched) | `youtube_discovery_proposals.json` | |
+| Latest discovery review (approved / applied / skipped / rejected) | `youtube_discovery_review_result_*.json` | Latest file auto-selected |
+| Blockers & operator next-action | derived | Grounded only in observed artifacts |
+
+**Current Catalog State (this run)**:
+- FoundUps: 13
+- Total declared videos: 1205 (matches actual `videos[]` length)
+- Active YouTube channels: move2japan (594), undaodu (512), foundups_main (44), antifafm (34), eduit (21)
+
+**Known-Channel Refresh** (latest delta 2026-04-13T07:17:28Z):
+- FoundUps checked: 1 (move2japan)
+- New videos: 0 - all 19 pulled were duplicates
+- No action required on delta
+
+**Discovery**:
+- Proposals artifact (2026-04-13T07:06:16Z): 10 FFCPLN-music proposals, all matched to move2japan by channel_id
+- Latest review (2026-04-13T07:30:00Z): 2 approved/applied, 8 duplicate-skipped - catalog 592 -> 594
+
+**Missing Artifacts (honestly reported)**:
+- `refresh_log.json` - not yet present. Scheduler has not run in logged mode, or has only run with `--no-log`. Summary flags this as a next-action, not a blocker.
+
+**Key Boundary Preserved**:
+- Read-only: no catalog mutation, no scheduler mutation, no live API calls.
+- Missing artifacts reported as missing; no values are fabricated.
+- Status contract defined here is reusable by any later UI/API surface.
+
+**Tests**: 5/5 passing
+- `test_full_artifact_set_parses`
+- `test_missing_refresh_log_is_reported_honestly`
+- `test_all_artifacts_missing_emits_blockers`
+- `test_markdown_render_does_not_raise_for_full_and_empty`
+- `test_write_status_summary_is_read_only_vs_sources`
+
+**HoloIndex**:
+- Command: `python holo_index.py --search "pfmall youtube pipeline status summary refresh delta discovery review artifact" --limit 3`
+- Top hit: `modules/ai_intelligence/pfmall_discovery/README.md` (adjacent module; confirmed no existing summary generator to reuse).
+
+**WSP 15 Applied**: P1 task - operator-facing observability for an active pipeline; low complexity, high deferability cost (manual multi-file inspection every run).
+**WSP 97 Applied**: CoT (evidence retrieved before facts stated), CoR (dialectic sweep chose smallest generator + JSON contract over larger UI surface), missing artifacts reported truthfully instead of inferred.
+
+---
+
 ## [2026-04-13] YouTube Discovery Proposal Review and Apply (Worker CT)
 
 **Who**: 0102 - Worker CT


### PR DESCRIPTION
Adds a read-only pfMALL YouTube pipeline status summary generator.

Scope:
- Adds status_summary.py for catalog/delta/discovery-review status reporting
- Adds focused tests for full, missing, and empty artifact states
- Documents the public API in youtube_channel_pull INTERFACE.md
- Records the slice in public/member ModLog

Generated summary snapshots remain uncommitted because docs/audits/pfmall_youtube_ingest is intentionally gitignored as per-session/runtime output.

Verification:
- python -m pytest modules/communication/youtube_channel_pull/tests/test_status_summary.py -q
- 5 passed