### PR TITLE
fix(openclaw): forward-port ironclaw retry and x actions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -160,6 +160,11 @@ IRONCLAW_NO_API_KEYS=1
 #   IRONCLAW_START_CMD=scripts/start_ironclaw_services.bat
 # If empty, the system can detect IronClaw failures but cannot auto-start the gateway.
 IRONCLAW_START_CMD=
+# Auto-recovery retry budget after IRONCLAW_START_CMD is dispatched.
+# daemon_self_audit_loop polls IRONCLAW_BASE_URL/health up to RETRY_COUNT times,
+# waiting RETRY_DELAY_SEC between polls. Failure after budget => fix reported failed.
+IRONCLAW_START_RETRY_COUNT=3
+IRONCLAW_START_RETRY_DELAY_SEC=5
 WRE_ENABLE_IRONCLAW_WORKER=1
 # Simulator Qwen backend route: local | ironclaw | wre_ironclaw
 SIM_QWEN_BACKEND=local

--- a/modules/communication/moltbot_bridge/src/x_social_adapter.py
+++ b/modules/communication/moltbot_bridge/src/x_social_adapter.py
@@ -9,6 +9,10 @@ Examples:
   x action post content="foundups: roi -> roc"
   x action read_timeline max_tweets=5
   x action engagement_session duration_minutes=10 max_engagements=3
+  x action like_tweet tweet_id=1234567890
+  x action retweet tweet_id=1234567890
+  x action reply_to_tweet tweet_id=1234567890 reply_text="agreed"
+  x action like_and_reply tweet_id=1234567890 reply_text="agreed"
 """
 
 from __future__ import annotations
@@ -23,6 +27,10 @@ SUPPORTED_ACTIONS = {
     "post",
     "read_timeline",
     "engagement_session",
+    "like_tweet",
+    "retweet",
+    "reply_to_tweet",
+    "like_and_reply",
 }
 
 ACTION_ALIASES = {
@@ -33,6 +41,13 @@ ACTION_ALIASES = {
     "timeline": "read_timeline",
     "engage": "engagement_session",
     "session": "engagement_session",
+    "like": "like_tweet",
+    "heart": "like_tweet",
+    "rt": "retweet",
+    "repost": "retweet",
+    "reply": "reply_to_tweet",
+    "respond": "reply_to_tweet",
+    "like_reply": "like_and_reply",
 }
 
 
@@ -176,6 +191,44 @@ async def execute_x_action(action: str, params: Dict[str, str]) -> Dict[str, Any
                 duration_minutes=duration_minutes,
                 max_engagements=max_engagements,
             )
+            return {"success": bool(result.success), "action": action, "result": _to_jsonable(result)}
+        finally:
+            x.close()
+
+    if action in {"like_tweet", "retweet", "reply_to_tweet", "like_and_reply"}:
+        tweet_id = params.get("tweet_id", params.get("id", "")).strip()
+        if not tweet_id:
+            return {"success": False, "action": action, "error": "missing tweet_id"}
+
+        needs_reply = action in {"reply_to_tweet", "like_and_reply"}
+        reply_text = params.get("reply_text", params.get("text", params.get("content", ""))).strip()
+        if needs_reply and not reply_text:
+            return {"success": False, "action": action, "error": "missing reply_text"}
+
+        if dry_run:
+            preview: Dict[str, Any] = {
+                "success": True,
+                "action": action,
+                "dry_run": True,
+                "profile": profile,
+                "tweet_id": tweet_id,
+            }
+            if needs_reply:
+                preview["reply_preview"] = reply_text[:280]
+            return preview
+
+        from modules.infrastructure.browser_actions.src.x_actions import XActions
+
+        x = XActions(profile=profile, ai_provider=ai_provider)
+        try:
+            if action == "like_tweet":
+                result = await x.like_tweet(tweet_id=tweet_id)
+            elif action == "retweet":
+                result = await x.retweet(tweet_id=tweet_id)
+            elif action == "reply_to_tweet":
+                result = await x.reply_to_tweet(tweet_id=tweet_id, reply_text=reply_text)
+            else:  # like_and_reply
+                result = await x.like_and_reply(tweet_id=tweet_id, reply_text=reply_text)
             return {"success": bool(result.success), "action": action, "result": _to_jsonable(result)}
         finally:
             x.close()

--- a/modules/infrastructure/wre_core/src/daemon_self_audit_loop.py
+++ b/modules/infrastructure/wre_core/src/daemon_self_audit_loop.py
@@ -83,6 +83,12 @@ class DaemonSelfAuditLoop:
         self.allow_shell_start_cmd = os.getenv(
             "OPENCLAW_SELF_AUDIT_ALLOW_SHELL_START_CMD", "0"
         ).strip() == "1"
+        self.ironclaw_start_retry_count = max(
+            0, int(os.getenv("IRONCLAW_START_RETRY_COUNT", "3"))
+        )
+        self.ironclaw_start_retry_delay_sec = max(
+            0.0, float(os.getenv("IRONCLAW_START_RETRY_DELAY_SEC", "5"))
+        )
         self.enable_telemetry = os.getenv("OPENCLAW_SELF_AUDIT_TELEMETRY", "1").strip() == "1"
         self.escalate_after = int(os.getenv("OPENCLAW_SELF_AUDIT_ESCALATE_AFTER", "3"))
         self.escalation_window_sec = int(
@@ -398,7 +404,7 @@ class DaemonSelfAuditLoop:
             cmd = os.getenv("IRONCLAW_START_CMD", "").strip()
             if not cmd:
                 return False, "IRONCLAW_START_CMD not set"
-            return self._dispatch_start_command(cmd)
+            return self._dispatch_start_command_with_retry(cmd)
         if fix_name == "diagnose_microphone_device":
             return self._diagnose_microphone_device()
         if fix_name == "verify_dae_event_store":
@@ -430,6 +436,50 @@ class DaemonSelfAuditLoop:
             return True, "start_command_dispatched"
         except Exception as exc:
             return False, str(exc)
+
+    def _dispatch_start_command_with_retry(self, cmd: str) -> Tuple[bool, str]:
+        # Dispatch once; daemon start is fire-and-forget (Popen).
+        dispatched, detail = self._dispatch_start_command(cmd)
+        if not dispatched:
+            return False, f"dispatch_failed:{detail}"
+
+        # Dispatch succeeded → fix was attempted. Health polling annotates
+        # the result string but does not flip the "attempted" flag.
+        if self.ironclaw_start_retry_count <= 0:
+            return True, detail
+
+        last_health_detail = "no_health_attempt"
+        for attempt in range(1, self.ironclaw_start_retry_count + 1):
+            time.sleep(self.ironclaw_start_retry_delay_sec)
+            healthy, last_health_detail = self._verify_ironclaw_health()
+            if healthy:
+                return True, f"healthy_after_{attempt}_attempt(s):{detail}"
+        # Dispatch ran but health never came up. "attempted=True"; the
+        # result string omits the dispatch success marker so
+        # _is_successful_fix_result classifies this as a failure.
+        return True, (
+            f"attempted_but_unhealthy_after_{self.ironclaw_start_retry_count}_attempt(s):"
+            f"{last_health_detail}"
+        )
+
+    def _verify_ironclaw_health(self) -> Tuple[bool, str]:
+        base = os.getenv("IRONCLAW_BASE_URL", "http://127.0.0.1:3000").strip().rstrip("/")
+        if not base:
+            return False, "no_base_url"
+        timeout = max(1.0, float(os.getenv("IRONCLAW_TIMEOUT_SEC", "5")))
+        url = f"{base}/health"
+        try:
+            from urllib.request import Request, urlopen
+
+            req = Request(url, method="GET")
+            with urlopen(req, timeout=timeout) as resp:
+                status = int(getattr(resp, "status", 200))
+                if 200 <= status < 300:
+                    return True, f"health_ok:{status}"
+                # 3xx/4xx/5xx: reachable but not reporting healthy.
+                return False, f"health_bad_status:{status}"
+        except Exception as exc:
+            return False, f"health_error:{exc.__class__.__name__}"
 
     def _diagnose_microphone_device(self) -> Tuple[bool, str]:
         report_path = (

--- a/modules/infrastructure/wre_core/tests/test_daemon_self_audit_loop.py
+++ b/modules/infrastructure/wre_core/tests/test_daemon_self_audit_loop.py
@@ -58,6 +58,9 @@ def test_self_audit_policy_fix_dispatches_gateway_start(tmp_path: Path, monkeypa
     monkeypatch.setenv("OPENCLAW_SELF_AUDIT_AUTO_FIX", "1")
     monkeypatch.setenv("OPENCLAW_SELF_AUDIT_ALLOWED_FIXES", "start_ironclaw_gateway")
     monkeypatch.setenv("IRONCLAW_START_CMD", "echo start")
+    # This test only exercises dispatch; bypass the health-poll retry loop
+    # added by IRONCLAW_START_RETRY_COUNT (covered by a dedicated test).
+    monkeypatch.setenv("IRONCLAW_START_RETRY_COUNT", "0")
 
     loop = DaemonSelfAuditLoop(repo_root=tmp_path)
     with patch("modules.infrastructure.wre_core.src.daemon_self_audit_loop.subprocess.Popen") as mock_popen:
@@ -68,6 +71,69 @@ def test_self_audit_policy_fix_dispatches_gateway_start(tmp_path: Path, monkeypa
     rows = _read_jsonl(loop.task_log_path)
     assert rows[0]["auto_fix_attempted"] is True
     assert rows[0]["auto_fix_result"] == "start_command_dispatched"
+
+
+def test_ironclaw_retry_reports_attempted_but_unhealthy(tmp_path: Path, monkeypatch):
+    """Dispatch succeeds, health polling never does → attempted=True, result flags unhealthy."""
+    logs = tmp_path / "logs"
+    logs.mkdir(parents=True)
+    log_file = logs / "daemon.log"
+    log_file.write_text(
+        "IronClaw runtime is unavailable, health endpoint unavailable\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("OPENCLAW_SELF_AUDIT_LOG_GLOBS", "logs/**/*.log")
+    monkeypatch.setenv("OPENCLAW_SELF_AUDIT_AUTO_FIX", "1")
+    monkeypatch.setenv("OPENCLAW_SELF_AUDIT_ALLOWED_FIXES", "start_ironclaw_gateway")
+    monkeypatch.setenv("IRONCLAW_START_CMD", "echo start")
+    monkeypatch.setenv("IRONCLAW_START_RETRY_COUNT", "2")
+    monkeypatch.setenv("IRONCLAW_START_RETRY_DELAY_SEC", "0")
+
+    loop = DaemonSelfAuditLoop(repo_root=tmp_path)
+    with patch("modules.infrastructure.wre_core.src.daemon_self_audit_loop.subprocess.Popen") as mock_popen, \
+         patch.object(DaemonSelfAuditLoop, "_verify_ironclaw_health", return_value=(False, "health_error:URLError")):
+        events = loop.scan_once()
+
+    assert events == 1
+    assert mock_popen.call_count == 1
+    rows = _read_jsonl(loop.task_log_path)
+    # Dispatch ran → attempted=True, even though health never came up.
+    assert rows[0]["auto_fix_attempted"] is True
+    result = rows[0]["auto_fix_result"]
+    assert result.startswith("attempted_but_unhealthy_after_2_attempt(s):")
+    assert "start_command_dispatched" not in result  # classified as failure
+
+
+def test_ironclaw_retry_reports_healthy_when_health_endpoint_responds(tmp_path: Path, monkeypatch):
+    """Dispatch succeeds; health passes on first poll → attempted=True, result contains dispatch marker."""
+    logs = tmp_path / "logs"
+    logs.mkdir(parents=True)
+    log_file = logs / "daemon.log"
+    log_file.write_text(
+        "IronClaw runtime is unavailable, health endpoint unavailable\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("OPENCLAW_SELF_AUDIT_LOG_GLOBS", "logs/**/*.log")
+    monkeypatch.setenv("OPENCLAW_SELF_AUDIT_AUTO_FIX", "1")
+    monkeypatch.setenv("OPENCLAW_SELF_AUDIT_ALLOWED_FIXES", "start_ironclaw_gateway")
+    monkeypatch.setenv("IRONCLAW_START_CMD", "echo start")
+    monkeypatch.setenv("IRONCLAW_START_RETRY_COUNT", "3")
+    monkeypatch.setenv("IRONCLAW_START_RETRY_DELAY_SEC", "0")
+
+    loop = DaemonSelfAuditLoop(repo_root=tmp_path)
+    with patch("modules.infrastructure.wre_core.src.daemon_self_audit_loop.subprocess.Popen") as mock_popen, \
+         patch.object(DaemonSelfAuditLoop, "_verify_ironclaw_health", return_value=(True, "health_ok:200")):
+        events = loop.scan_once()
+
+    assert events == 1
+    assert mock_popen.call_count == 1
+    rows = _read_jsonl(loop.task_log_path)
+    assert rows[0]["auto_fix_attempted"] is True
+    result = rows[0]["auto_fix_result"]
+    assert result.startswith("healthy_after_1_attempt(s):")
+    assert "start_command_dispatched" in result  # classified as success
 
 
 def test_self_audit_verifies_event_store_when_sequence_error_seen(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Summary

Forward-port of runtime capabilities that had reverted from the canonical OpenClaw path. Two independent surfaces:

- **IronClaw auto-recovery**: `start_ironclaw_gateway` policy fix now dispatches the start command, then polls `IRONCLAW_BASE_URL/health` up to `IRONCLAW_START_RETRY_COUNT` times (default 3) with `IRONCLAW_START_RETRY_DELAY_SEC` between polls (default 5). Dispatch success → `attempted=True` regardless of health; result string carries health state (`healthy_after_N_attempt(s):...`, `attempted_but_unhealthy_after_N_attempt(s):...`, or `dispatch_failed:...`). Only 2xx counts as healthy — 3xx/4xx/5xx reported as `health_bad_status:<code>`, exceptions as `health_error:<Exc>`.
- **X direct actions**: `x_social_adapter` now exposes `like_tweet`, `retweet`, `reply_to_tweet`, `like_and_reply` plus aliases (`like`, `heart`, `rt`, `repost`, `reply`, `respond`, `like_reply`). Pass-through over existing `XActions` methods — no new reliability claims. `engagement_session` untouched.

**Deferred (inspect-and-defer)**: Container isolation wiring. OpenClaw EXECUTE seam runs only policy-bound known workloads (broker tasks, audit-loop fixes); no untrusted payloads. `modules/infrastructure/container_isolation/` stays reserved for a future EXECUTE path that actually runs agent-produced code.

**Not touched**: `supervisor_24x7.py` (deprecated donor); Layer 2 patterns already unified into canonical OpenClawSupervisor.

## Test plan

- [x] `pytest modules/infrastructure/wre_core/tests -k audit -q` → 10/10 passed
- [x] `pytest modules/communication/moltbot_bridge/tests/test_x_social_adapter.py -q` → 5/5 passed
- [x] New tests added for retry/health paths (`test_ironclaw_retry_reports_attempted_but_unhealthy`, `test_ironclaw_retry_reports_healthy_when_health_endpoint_responds`) with mocked `_verify_ironclaw_health` and `RETRY_DELAY_SEC=0` for CI speed
- [ ] Manual smoke: set `IRONCLAW_START_CMD=<local starter>` and confirm self-audit dispatches + health-verifies

## Files

- `.env.example` — `IRONCLAW_START_RETRY_COUNT=3`, `IRONCLAW_START_RETRY_DELAY_SEC=5`
- `modules/infrastructure/wre_core/src/daemon_self_audit_loop.py` — retry env vars, `_dispatch_start_command_with_retry`, `_verify_ironclaw_health`
- `modules/infrastructure/wre_core/tests/test_daemon_self_audit_loop.py` — existing dispatch test monkeypatched to skip retry; 2 new tests
- `modules/communication/moltbot_bridge/src/x_social_adapter.py` — 4 direct actions + aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)