### PR TITLE
test(holoindex): verify external bridge contract

### DIFF
--- a/docs/0102_session_briefings/CY2_HOLOINDEX_CONNECTOR_INTERCEPTOR_RESPONSE_HANDSHAKE_FIX.md
+++ b/docs/0102_session_briefings/CY2_HOLOINDEX_CONNECTOR_INTERCEPTOR_RESPONSE_HANDSHAKE_FIX.md
@@ -1,0 +1,165 @@
+# CY2 — HoloIndex Connector/Interceptor Response Handshake Fix
+
+**Worker**: CY2
+**Date**: 2026-04-17
+**Slice**: `HOLOINDEX_CONNECTOR_INTERCEPTOR_RESPONSE_HANDSHAKE_FIX`
+**WSP Lock**: WSP 15 (pre-read), WSP 97 (no overclaiming)
+**Depends On**: CY — HOLOINDEX_EXTERNAL_BRIDGE_CONTRACT_VERIFICATION_PHASE1
+
+---
+
+## 1. Problem Statement
+
+CY documented two handshake mismatches preventing the HoloIndex iframe scaffold from receiving responses:
+
+| Mismatch | Connector expects | Interceptor sends |
+|----------|-------------------|-------------------|
+| **Service field** | `event.data.service === 'holoindex'` | No `service` field |
+| **Data field** | `event.data.payload` | `event.data.data` |
+
+Both mismatches mean the connector's `message` event listener **never fires** for interceptor responses.
+
+---
+
+## 2. Convention Decision
+
+**Service field**: Add `service: 'holoindex'` to interceptor responses for the `openclaw_search` route. This matches the connector's existing check and allows multiple FoundUp iframes to filter for their own responses.
+
+**Data field**: Fix connector to read `event.data.data` (matching contract Section 3.1 and interceptor implementation). The connector was the outlier.
+
+---
+
+## 3. Changes
+
+### 3.1 `shell-bridge-interceptor.js`
+
+Added `ROUTE_SERVICE_MAP` (route-to-service lookup) and modified `dispatchRequest` callback to inject `response.service` before posting to the source iframe.
+
+```javascript
+var ROUTE_SERVICE_MAP = {
+    'openclaw_search': 'holoindex'
+};
+
+// In dispatchRequest callback:
+if (ROUTE_SERVICE_MAP[route]) {
+    response.service = ROUTE_SERVICE_MAP[route];
+}
+```
+
+**Why a map, not hardcoded**: When future FoundUps register routes, they add one line to `ROUTE_SERVICE_MAP`. The injection point in `dispatchRequest` stays unchanged.
+
+### 3.2 `connector.js`
+
+Fixed response data access path:
+
+```javascript
+// Before (wrong — "payload" is not a field in the response):
+resultsPanel.textContent = JSON.stringify(event.data.payload, null, 2);
+
+// After (correct — per contract Section 3.1):
+resultsPanel.textContent = JSON.stringify(event.data.data, null, 2);
+```
+
+### 3.3 `EXTERNAL_FOUNDUP_BRIDGE_CONTRACT.md`
+
+Updated Section 3.1 response shape to include `service` field:
+
+```json
+{
+  "type": "agent_response",
+  "service": "holoindex",
+  "status": "success",
+  "data": { ... }
+}
+```
+
+---
+
+## 4. Tests Added
+
+### `test_bridge_contract.py` — 8 new tests (38 → 46)
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_contract_response_has_service_field` | Contract doc defines `"service": "holoindex"` |
+| `test_interceptor_has_route_service_map` | `ROUTE_SERVICE_MAP` exists in interceptor |
+| `test_interceptor_injects_service_in_response` | `response.service` assignment in dispatch |
+| `test_interceptor_maps_openclaw_to_holoindex` | `openclaw_search` → `holoindex` mapping |
+| `test_connector_checks_service_holoindex` | Connector filters by `service` |
+| `test_connector_checks_agent_response_type` | Connector filters by `agent_response` type |
+| `test_interceptor_and_connector_agree_on_service_name` | Both reference `holoindex` |
+| `test_connector_reads_data_from_response` | Connector reads `event.data.data` (not `.payload`) |
+
+### `test_shell_bridge_interceptor.py` — 2 new tests (42 → 44)
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_response_has_service_field` | `ROUTE_SERVICE_MAP` and `holoindex` in source |
+| `test_service_injected_in_dispatch` | `response.service` in source |
+
+### `shell_bridge_interceptor_vm.mjs` — 2 new assertions
+
+| Assertion | Where |
+|-----------|-------|
+| `resolved.service === 'holoindex'` | Stub search response |
+| `resolved.service === 'holoindex'` | Registered backend search response |
+
+---
+
+## 5. Full Test Results
+
+| Suite | Count | Result |
+|-------|-------|--------|
+| `test_bridge_contract.py` | 46 | PASS |
+| `test_shell_bridge_interceptor.py` | 44 | PASS |
+| `test_route_contract_bridge.py` | 45 | PASS |
+| **Total** | **135** | **135 PASS** |
+
+---
+
+## 6. Response Flow (After Fix)
+
+```
+1. Connector sends:
+   window.parent.postMessage({
+     type: 'agent_request',
+     route: 'openclaw_search',
+     payload: { action: 'semantic_search', query: '...' }
+   }, '*');
+
+2. Interceptor receives agent_request, dispatches to openclaw_search handler
+
+3. Handler builds response:
+   { type: 'agent_response', status: 'success', data: { results: [...], stub: true } }
+
+4. dispatchRequest injects service from ROUTE_SERVICE_MAP:
+   response.service = 'holoindex'
+
+5. Interceptor posts back to iframe:
+   sourceWindow.postMessage(response, origin)
+
+6. Connector receives, filters:
+   event.data.type === 'agent_response' && event.data.service === 'holoindex'
+   → resultsPanel.textContent = JSON.stringify(event.data.data, null, 2)
+```
+
+**End-to-end stub response path is now wired.** No backend needed — the iframe will display stub results with `stub: true`.
+
+---
+
+## 7. What Was NOT Changed
+
+- `launch_readiness` remains `discoverable_only`
+- No real HoloIndex backend wired
+- `bridge_stub.py` untouched (Python adapter — browser path only)
+- No `entry_url` added to catalog
+
+---
+
+## 8. WSP 97 Statement
+
+No readiness promotion. Bridge remains stub-only. The handshake fix enables the UI scaffold to **display** stub responses, not to claim live search capability. `launch_readiness: discoverable_only` is still truthful.
+
+---
+
+*CY2 complete. Connector/interceptor response handshake is wired. 135 tests pass. Iframe scaffold can now receive and display stub responses end-to-end.*

--- a/docs/0102_session_briefings/CY_HOLOINDEX_EXTERNAL_BRIDGE_CONTRACT_VERIFICATION_PHASE1.md
+++ b/docs/0102_session_briefings/CY_HOLOINDEX_EXTERNAL_BRIDGE_CONTRACT_VERIFICATION_PHASE1.md
@@ -1,0 +1,178 @@
+# CY — HoloIndex External Bridge Contract Verification Phase 1
+
+**Worker**: CY
+**Date**: 2026-04-17
+**Slice**: `HOLOINDEX_EXTERNAL_BRIDGE_CONTRACT_VERIFICATION_PHASE1`
+**WSP Lock**: WSP 15 (pre-read), WSP 97 (no overclaiming)
+
+---
+
+## 1. Repo-Real File Table
+
+| File | Tracked | Status |
+|------|---------|--------|
+| `holo_index/docs/EXTERNAL_FOUNDUP_BRIDGE_CONTRACT.md` | YES | Contract spec — defines inbound/outbound message shapes |
+| `holo_index/foundup_manifest.json` | YES | FoundUp identity manifest |
+| `holo_index/foundup_adapter/bridge_stub.py` | YES | Python stub adapter (simulated responses) |
+| `public/f/holoindex_prod_01/index.html` | YES | UI scaffold — search input + results panel |
+| `public/f/holoindex_prod_01/js/connector.js` | YES | Browser-side postMessage sender |
+| `public/f/holoindex_prod_01/css/style.css` | YES | Minimal dark-theme CSS |
+| `public/member/js/shell-bridge-interceptor.js` | YES | Shell-side message dispatcher |
+| `public/member/mall-catalog.json` | YES | Shell catalog with HoloIndex entry |
+
+**All 8 files are repo-tracked.** The BY audit's critical finding ("most of it is workspace-local, not repo truth") is now stale.
+
+---
+
+## 2. Stale BY Audit Reconciliation
+
+| BY Audit Claim | Current Truth |
+|----------------|---------------|
+| "Bridge adapter is UNTRACKED" | **STALE** — `bridge_stub.py` is tracked |
+| "FoundUp manifest is UNTRACKED" | **STALE** — `foundup_manifest.json` is tracked |
+| "UI scaffold is UNTRACKED" | **STALE** — `public/f/holoindex_prod_01/` is tracked |
+| "Manifest entry_url points to untracked path — double dishonesty" | **STALE** — both are tracked |
+| "No bridge tests" | **STALE** — 38 tests added by CY, plus existing 42 interceptor + 45 route tests |
+| "No catalog entry" | **STALE** — `mall-catalog.json` has `holoindex_prod_01` |
+| "Shell interceptor is TRACKED" | STILL ACCURATE |
+| "Bridge contract doc is TRACKED" | STILL ACCURATE |
+
+**BY audit verdict**: Superseded by CY on tracking/catalog/test claims. The architectural analysis (bridge flow, contract shape) remains accurate.
+
+---
+
+## 3. Manifest / Catalog / Path Alignment
+
+### Manifest (`foundup_manifest.json`)
+
+| Field | Value | Alignment |
+|-------|-------|-----------|
+| `foundup_id` | `holoindex_prod_01` | Matches catalog |
+| `routing_prefix` | `/f/holoindex_prod_01` | Matches catalog |
+| `data_namespace` | `idb_holoindex_prod_01` | Present (catalog doesn't carry this) |
+| `entry_point` | `public/f/holoindex_prod_01/index.html` | File EXISTS at this path |
+| `capabilities` | `["semantic_search", "wsp_lookup"]` | Matches contract Section 2 |
+| `capabilities_adapter` | `holo_index.foundup_adapter.bridge_stub` | File EXISTS |
+
+**Note**: Manifest uses `entry_point` (repo-relative path to HTML). Catalog does NOT have `entry_url` (correctly absent — no deployed external URL while stub-only). These are different fields serving different purposes: `entry_point` = where the file is in the repo, `entry_url` = where the app is deployed for iframe embed. No conflict.
+
+### Catalog (`mall-catalog.json`)
+
+| Field | Value | Correct? |
+|-------|-------|----------|
+| `foundup_id` | `holoindex_prod_01` | YES |
+| `launch_readiness` | `discoverable_only` | YES (stub-only) |
+| `routing_prefix` | `/f/holoindex_prod_01` | YES |
+| `entry_url` | ABSENT | CORRECT — no deployed app to embed |
+
+---
+
+## 4. Bridge Contract Test Results
+
+### Tests Added: `holo_index/foundup_adapter/tests/test_bridge_contract.py`
+
+| Test Class | Count | Result |
+|-----------|-------|--------|
+| TestBridgeStubSemanticSearch | 4 | PASS |
+| TestBridgeStubUnknownRoute | 2 | PASS |
+| TestManifestTruth | 5 | PASS |
+| TestCatalogBinding | 5 | PASS |
+| TestConnectorContract | 5 | PASS |
+| TestContractDocAlignment | 9 | PASS |
+| TestRepoTracking | 8 | PASS |
+| **Total** | **38** | **38 PASS** |
+
+### Existing Tests (confirmed still passing)
+
+| Test File | Count | Result |
+|-----------|-------|--------|
+| `test_shell_bridge_interceptor.py` | 42 | PASS |
+| `test_route_contract_bridge.py` | 45 | PASS |
+| **Total suite** | **125** | **125 PASS** |
+
+---
+
+## 5. Bridge Status: Stub-Only, Not Backend-Connected
+
+The bridge is **stub-only**. No live HoloIndex semantic search backend is wired.
+
+| Component | Mode | Evidence |
+|-----------|------|----------|
+| `bridge_stub.py` | Simulated | Returns hardcoded results with `stub: True` (fixed from `False`) |
+| `shell-bridge-interceptor.js` | Stub by default | `getShellBridgeBackendStatus()` returns `{ mode: 'stub' }` |
+| Backend registration | Available but unused | `registerShellBridgeBackend()` API exists, no caller |
+
+**How it works today**:
+1. UI connector sends `agent_request` via `postMessage` to parent shell
+2. Shell interceptor receives, dispatches to `openclaw_search` handler
+3. No backend registered → interceptor returns stub response with `stub: true`
+4. Response posted back to iframe
+
+**What would make it live**:
+- A registered backend calling `window.shellBridgeInterceptor.registerShellBridgeBackend(backend)` where `backend.search()` calls the real HoloIndex Python core
+- This would require a local relay server or WebSocket bridge — not implemented
+
+---
+
+## 6. Fixes Applied
+
+| Fix | File | Before | After | Why |
+|-----|------|--------|-------|-----|
+| Stub marker truthfulness | `bridge_stub.py:30` | `"stub": False` | `"stub": True` | Simulated stub must not claim live backend |
+| JSON syntax | `mall-catalog.json:47` | Trailing comma after last property | Removed | Invalid JSON — `json.load()` fails |
+
+---
+
+## 7. Connector Response Handler Issue (Documented, Not Fixed)
+
+`connector.js` line 30 checks:
+```javascript
+event.data.service === 'holoindex'
+```
+
+But the shell interceptor sends responses with `type: 'agent_response'` and does NOT set a `service` field. This means the connector **will never see responses from the interceptor** in an actual iframe embed.
+
+**Not fixed in this slice** because:
+- The UI scaffold is marked "(Stub)" in its own header
+- No live iframe embed exists yet
+- Fixing this requires deciding the service field convention (add to interceptor? change connector?)
+- This is a future implementation concern, not a contract-truth issue
+
+**Recommended fix when needed**: Either add `service: 'holoindex'` to interceptor responses for the HoloIndex route, or change connector to check `event.data.type === 'agent_response'` only.
+
+---
+
+## 8. Readiness Verdict
+
+| Question | Answer |
+|----------|--------|
+| Is the HoloIndex external FoundUp bundle repo-real? | **YES** — all 8 files tracked |
+| Does the manifest match the public shell path and catalog route? | **YES** — `routing_prefix` aligned, `entry_point` resolves to existing file |
+| Does the bridge stub honor the documented request/response contract? | **YES** — after fixing `stub: True` |
+| Does the browser connector send the correct payload? | **YES** — `type: agent_request`, `route: openclaw_search`, `payload.action: semantic_search` |
+| Does the shell interceptor route or stub consistently? | **YES** — stub mode with `stub: true` marker, backend registration API available |
+| Is any field overclaiming readiness? | **NO** (after fix) — `stub: True`, `launch_readiness: discoverable_only`, no `entry_url` |
+| Is `launch_readiness: discoverable_only` still truthful? | **YES** — bridge is stub-only, no live backend |
+
+---
+
+## 9. HoloIndex Search
+
+**Command**:
+```bash
+python holo_index.py --search "HoloIndex external FoundUp bridge contract shell interceptor manifest catalog" --limit 3
+```
+
+**Result**: 6 hits (3 code, 3 WSP)
+**Top hit**: `public/member/js/shell-bridge-interceptor.js` [CODE]
+**Note**: `WARNING: Missing dependency: No module named 'sentence_transformers'` — lexical-only mode used, semantic search unavailable.
+
+---
+
+## 10. WSP 97 Statement
+
+No claim of live backend. Bridge is verified as stub-only. All response shapes marked `stub: true`. `launch_readiness` remains `discoverable_only`. The BY audit's "untracked" findings are superseded by current git state, not by overclaiming deployment readiness.
+
+---
+
+*CY complete. HoloIndex external FoundUp bundle is repo-real, contract-aligned, and truthfully stub-only. 125 tests pass.*

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,78 @@
 # HoloIndex Package ModLog
 
+## [2026-04-17] HoloIndex Connector/Interceptor Response Handshake Fix (Worker CY2)
+
+**Worker**: CY2
+**Slice**: `HOLOINDEX_CONNECTOR_INTERCEPTOR_RESPONSE_HANDSHAKE_FIX`
+**WSP References**: WSP 11, WSP 22, WSP 97
+**Depends On**: CY — `HOLOINDEX_EXTERNAL_BRIDGE_CONTRACT_VERIFICATION_PHASE1`
+**Briefing**: [docs/0102_session_briefings/CY2_HOLOINDEX_CONNECTOR_INTERCEPTOR_RESPONSE_HANDSHAKE_FIX.md](../docs/0102_session_briefings/CY2_HOLOINDEX_CONNECTOR_INTERCEPTOR_RESPONSE_HANDSHAKE_FIX.md)
+
+### Fixed
+
+- `shell-bridge-interceptor.js` — Added `ROUTE_SERVICE_MAP` (`openclaw_search` → `holoindex`). `dispatchRequest` now injects `response.service` before posting to iframe.
+- `connector.js` — `event.data.payload` → `event.data.data`. Was reading wrong field per contract Section 3.1.
+- `EXTERNAL_FOUNDUP_BRIDGE_CONTRACT.md` Section 3.1 — Added `service` field to response shape.
+
+### Added
+
+- 8 new tests in `test_bridge_contract.py` (38 → 46): contract service field, ROUTE_SERVICE_MAP, dispatch injection, connector/interceptor agreement.
+- 2 new tests in `test_shell_bridge_interceptor.py` (42 → 44): service field presence, dispatch injection.
+- 2 new assertions in `shell_bridge_interceptor_vm.mjs`: `service: 'holoindex'` on stub and registered responses.
+
+### Verification
+
+- `pytest holo_index/foundup_adapter/tests/test_bridge_contract.py -q` → **46 passed**.
+- `pytest public/member/tests/test_shell_bridge_interceptor.py -q` → **44 passed**.
+- `pytest public/member/tests/test_route_contract_bridge.py -q` → **45 passed**.
+- `node public/member/tests/shell_bridge_interceptor_vm.mjs` → **all checks passed**.
+- Total: **135 tests, 0 failures, 0 regressions**.
+
+### WSP 97
+
+No readiness promotion. `launch_readiness: discoverable_only` unchanged. Bridge remains stub-only. The handshake fix enables the UI scaffold to display stub responses, not to claim live search capability.
+
+---
+
+## [2026-04-17] HoloIndex External Bridge Contract Verification Phase 1 (Worker CY)
+
+**Worker**: CY
+**Slice**: `HOLOINDEX_EXTERNAL_BRIDGE_CONTRACT_VERIFICATION_PHASE1`
+**WSP References**: WSP 11, WSP 15, WSP 97, WSP 104
+**Briefing**: [docs/0102_session_briefings/CY_HOLOINDEX_EXTERNAL_BRIDGE_CONTRACT_VERIFICATION_PHASE1.md](../docs/0102_session_briefings/CY_HOLOINDEX_EXTERNAL_BRIDGE_CONTRACT_VERIFICATION_PHASE1.md)
+
+### Verified
+
+- All 8 external-FoundUp bundle files are **repo-tracked** (supersedes the BY 2026-04-12 audit, which claimed most were workspace-local).
+- `foundup_manifest.json` aligns with `public/member/mall-catalog.json` on `foundup_id`, `routing_prefix`; `entry_point` resolves to an existing file.
+- Catalog entry for `holoindex_prod_01` has `launch_readiness: discoverable_only`, no `entry_url` — truthful while bridge is stub-only.
+
+### Fixed (contract-truth only)
+
+- `holo_index/foundup_adapter/bridge_stub.py` — `"stub": False → True`. Simulated responses must not overclaim backend connectivity.
+- `public/member/mall-catalog.json` — removed trailing comma (invalid JSON, `json.load()` would fail).
+
+### Added
+
+- `holo_index/foundup_adapter/tests/test_bridge_contract.py` — 38 tests, all PASS. Covers `BridgeStub.sendMessage`, manifest/catalog alignment, connector outbound payload, contract-doc vs interceptor alignment, and repo-tracking of the full bundle.
+
+### Documented, Not Fixed (deferred to CY2)
+
+- `public/f/holoindex_prod_01/js/connector.js:30` filters responses on `event.data.service === 'holoindex'`, but the contract does not promise that field and the shell interceptor never sets it. In a live iframe embed, all responses would silently drop. Scaffold is explicitly labelled "(Stub)"; no live embed exists yet. Fix is a convention decision (add `service` to interceptor OR drop the filter in connector). Tracked as **CY2 — Connector/Interceptor Response Handshake Fix**.
+
+### Verification
+
+- `pytest holo_index/foundup_adapter/tests/test_bridge_contract.py -q` → **38 passed**.
+- `pytest public/member/tests -k "bridge or catalog or route or holoindex" -q` → 111 passed, 2 unrelated pre-existing `devMall` route-bridge failures in `test_localhost_dev_harness.py` (outside CY scope).
+- `json.load()` on `holo_index/foundup_manifest.json` and `public/member/mall-catalog.json` → both valid.
+- `holo_index.py --search "HoloIndex external FoundUp bridge contract shell interceptor manifest catalog" --limit 3` → 6 hits, top hit `public/member/js/shell-bridge-interceptor.js`; lexical-only mode (sentence_transformers unavailable).
+
+### WSP 97
+
+No claim of live backend. Bridge verified as stub-only. No external repo mutation. No GitHub push. Only contract-truth fixes applied.
+
+---
+
 ## [2026-04-13] Rolodex false-positive exclusion and classification
 
 **Worker**: CF2

--- a/holo_index/docs/EXTERNAL_FOUNDUP_BRIDGE_CONTRACT.md
+++ b/holo_index/docs/EXTERNAL_FOUNDUP_BRIDGE_CONTRACT.md
@@ -60,6 +60,7 @@ The Python stub handles the specific intents, converts them into FastMCP calls o
 ```json
 {
   "type": "agent_response",
+  "service": "holoindex",
   "status": "success",
   "data": {
     "results": [

--- a/holo_index/docs/ModLog.md
+++ b/holo_index/docs/ModLog.md
@@ -2,6 +2,39 @@
 **WSP Compliance**: WSP 22 (Module ModLog and Roadmap Protocol)
 
 ====================================================================
+## MODLOG - [2026-04-17] [+CY2-CONNECTOR-INTERCEPTOR-RESPONSE-HANDSHAKE]
+- Summary: Fixed connector/interceptor response handshake so iframe scaffold can receive stub responses end-to-end.
+- Worker: CY2
+- Slice: `HOLOINDEX_CONNECTOR_INTERCEPTOR_RESPONSE_HANDSHAKE_FIX`
+- Changes:
+  - Added `ROUTE_SERVICE_MAP` to `shell-bridge-interceptor.js` — maps `openclaw_search` → `holoindex`
+  - Interceptor `dispatchRequest` now injects `response.service` from map before posting to iframe
+  - Fixed `connector.js`: `event.data.payload` → `event.data.data` (was reading wrong field per contract Section 3.1)
+  - Updated `EXTERNAL_FOUNDUP_BRIDGE_CONTRACT.md` Section 3.1 to include `service` field in response shape
+  - Added 8 new tests (4 contract alignment + 4 connector response path) — total bridge contract tests: 46
+  - Added 2 new tests to interceptor suite (service field + dispatch injection) — total: 44
+  - Added 2 `service` assertions to VM runtime tests
+  - No readiness promotion — `launch_readiness` remains `discoverable_only`
+- Test totals: 135 pass (46 + 44 + 45), zero regressions
+- WSP References: WSP 11, WSP 22, WSP 97
+====================================================================
+
+====================================================================
+## MODLOG - [2026-04-17] [+CY-BRIDGE-CONTRACT-VERIFICATION]
+- Summary: External FoundUp bridge contract verified end-to-end. All bundle files confirmed repo-tracked. Overclaiming fixed.
+- Worker: CY
+- Slice: `HOLOINDEX_EXTERNAL_BRIDGE_CONTRACT_VERIFICATION_PHASE1`
+- Changes:
+  - Fixed `bridge_stub.py`: `stub: False` → `stub: True` (was overclaiming backend connectivity)
+  - Fixed `mall-catalog.json`: trailing comma syntax error
+  - Added `holo_index/foundup_adapter/tests/test_bridge_contract.py` (38 tests)
+  - Verified: manifest, catalog, connector, interceptor, bridge stub all align with contract doc
+  - BY audit finding "untracked files" is now stale — all 5 files are tracked
+- Briefing: `docs/0102_session_briefings/CY_HOLOINDEX_EXTERNAL_BRIDGE_CONTRACT_VERIFICATION_PHASE1.md`
+- WSP References: WSP 11, WSP 22, WSP 97
+====================================================================
+
+====================================================================
 ## MODLOG - [2026-02-18] [+MACHINE-CONTRACT]
 - Summary: Added canonical machine-language spec and rewrote INTERFACE contract to match runtime behavior.
 - Notes:

--- a/holo_index/foundup_adapter/bridge_stub.py
+++ b/holo_index/foundup_adapter/bridge_stub.py
@@ -27,7 +27,7 @@ class BridgeStub:
                     }
                 ],
                 "quantum_coherence": 0.95,
-                "stub": False,
+                "stub": True,
                 "source": "python_bridge_stub"
             })
             

--- a/holo_index/foundup_adapter/tests/test_bridge_contract.py
+++ b/holo_index/foundup_adapter/tests/test_bridge_contract.py
@@ -1,0 +1,414 @@
+"""
+HoloIndex External FoundUp Bridge Contract Verification Tests
+
+Verifies bridge_stub.py, foundup_manifest.json, mall-catalog.json,
+connector.js, and shell-bridge-interceptor.js against
+EXTERNAL_FOUNDUP_BRIDGE_CONTRACT.md.
+
+Worker: CY
+Slice: HOLOINDEX_EXTERNAL_BRIDGE_CONTRACT_VERIFICATION_PHASE1
+WSP References: WSP 11 (Interface), WSP 97 (Execution Discipline)
+"""
+import json
+import os
+import sys
+
+import pytest
+
+# Paths
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+ADAPTER_DIR = os.path.join(REPO_ROOT, "holo_index", "foundup_adapter")
+MANIFEST_PATH = os.path.join(REPO_ROOT, "holo_index", "foundup_manifest.json")
+CATALOG_PATH = os.path.join(REPO_ROOT, "public", "member", "mall-catalog.json")
+UI_DIR = os.path.join(REPO_ROOT, "public", "f", "holoindex_prod_01")
+CONNECTOR_PATH = os.path.join(UI_DIR, "js", "connector.js")
+CONTRACT_PATH = os.path.join(
+    REPO_ROOT, "holo_index", "docs", "EXTERNAL_FOUNDUP_BRIDGE_CONTRACT.md"
+)
+INTERCEPTOR_PATH = os.path.join(
+    REPO_ROOT, "public", "member", "js", "shell-bridge-interceptor.js"
+)
+
+sys.path.insert(0, ADAPTER_DIR)
+sys.path.insert(0, os.path.join(ADAPTER_DIR))
+# bridge_stub.py lives in holo_index/foundup_adapter/
+_stub_path = os.path.join(ADAPTER_DIR, "bridge_stub.py")
+import importlib.util
+_spec = importlib.util.spec_from_file_location("bridge_stub", _stub_path)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+BridgeStub = _mod.BridgeStub
+
+
+# ---------------------------------------------------------------------------
+# BridgeStub sendMessage Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBridgeStubSemanticSearch:
+    """BridgeStub.sendMessage() with semantic_search action."""
+
+    def test_semantic_search_returns_results(self):
+        stub = BridgeStub()
+        resp = json.loads(
+            stub.sendMessage(
+                json.dumps(
+                    {
+                        "route": "openclaw_search",
+                        "payload": {
+                            "action": "semantic_search",
+                            "query": "WSP 97",
+                            "limit": 3,
+                        },
+                    }
+                )
+            )
+        )
+        assert "results" in resp
+        assert isinstance(resp["results"], list)
+        assert len(resp["results"]) > 0
+
+    def test_semantic_search_has_quantum_coherence(self):
+        stub = BridgeStub()
+        resp = json.loads(
+            stub.sendMessage(
+                json.dumps(
+                    {
+                        "route": "openclaw_search",
+                        "payload": {"action": "semantic_search", "query": "test"},
+                    }
+                )
+            )
+        )
+        assert "quantum_coherence" in resp
+        assert isinstance(resp["quantum_coherence"], (int, float))
+
+    def test_semantic_search_has_truthful_stub_marker(self):
+        """stub field MUST be True when response is simulated."""
+        stub = BridgeStub()
+        resp = json.loads(
+            stub.sendMessage(
+                json.dumps(
+                    {
+                        "route": "openclaw_search",
+                        "payload": {"action": "semantic_search", "query": "test"},
+                    }
+                )
+            )
+        )
+        assert resp.get("stub") is True, (
+            "BridgeStub must return stub: true (not false) — simulated responses "
+            "must not overclaim backend connectivity"
+        )
+
+    def test_semantic_search_result_has_content_path_relevance(self):
+        stub = BridgeStub()
+        resp = json.loads(
+            stub.sendMessage(
+                json.dumps(
+                    {
+                        "route": "openclaw_search",
+                        "payload": {"action": "semantic_search", "query": "test"},
+                    }
+                )
+            )
+        )
+        result = resp["results"][0]
+        assert "content" in result
+        assert "path" in result
+        assert "relevance" in result
+
+
+class TestBridgeStubUnknownRoute:
+    """Unknown route/action returns error envelope."""
+
+    def test_unknown_route_returns_error(self):
+        stub = BridgeStub()
+        resp = json.loads(
+            stub.sendMessage(
+                json.dumps(
+                    {
+                        "route": "nonexistent_route",
+                        "payload": {"action": "foo"},
+                    }
+                )
+            )
+        )
+        assert "error" in resp
+
+    def test_unknown_action_returns_error(self):
+        stub = BridgeStub()
+        resp = json.loads(
+            stub.sendMessage(
+                json.dumps(
+                    {
+                        "route": "openclaw_search",
+                        "payload": {"action": "nonexistent_action"},
+                    }
+                )
+            )
+        )
+        assert "error" in resp
+
+
+# ---------------------------------------------------------------------------
+# Manifest Tests
+# ---------------------------------------------------------------------------
+
+
+class TestManifestTruth:
+    """foundup_manifest.json points to tracked UI scaffold."""
+
+    def test_manifest_valid_json(self):
+        with open(MANIFEST_PATH, encoding="utf-8") as f:
+            manifest = json.load(f)
+        assert isinstance(manifest, dict)
+
+    def test_manifest_has_foundup_id(self):
+        with open(MANIFEST_PATH, encoding="utf-8") as f:
+            manifest = json.load(f)
+        assert manifest["foundup_id"] == "holoindex_prod_01"
+
+    def test_manifest_entry_point_exists(self):
+        """Manifest entry_point points to a file that exists in the repo."""
+        with open(MANIFEST_PATH, encoding="utf-8") as f:
+            manifest = json.load(f)
+        entry = manifest.get("entry_point", "")
+        entry_path = os.path.join(REPO_ROOT, entry)
+        assert os.path.isfile(entry_path), (
+            f"Manifest entry_point '{entry}' does not exist at {entry_path}"
+        )
+
+    def test_manifest_routing_prefix_matches_catalog(self):
+        with open(MANIFEST_PATH, encoding="utf-8") as f:
+            manifest = json.load(f)
+        with open(CATALOG_PATH, encoding="utf-8") as f:
+            catalog = json.load(f)
+        holo_entry = next(
+            (e for e in catalog if e["foundup_id"] == "holoindex_prod_01"), None
+        )
+        assert holo_entry is not None, "holoindex_prod_01 must be in mall-catalog.json"
+        assert manifest["routing_prefix"] == holo_entry["routing_prefix"]
+
+    def test_manifest_capabilities_match_contract(self):
+        """Manifest capabilities match contract Section 2 actions."""
+        with open(MANIFEST_PATH, encoding="utf-8") as f:
+            manifest = json.load(f)
+        caps = manifest.get("capabilities", [])
+        assert "semantic_search" in caps
+        assert "wsp_lookup" in caps
+
+
+# ---------------------------------------------------------------------------
+# Catalog Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCatalogBinding:
+    """mall-catalog.json contains holoindex_prod_01 with correct fields."""
+
+    def test_catalog_valid_json(self):
+        with open(CATALOG_PATH, encoding="utf-8") as f:
+            catalog = json.load(f)
+        assert isinstance(catalog, list)
+
+    def test_holoindex_in_catalog(self):
+        with open(CATALOG_PATH, encoding="utf-8") as f:
+            catalog = json.load(f)
+        ids = [e["foundup_id"] for e in catalog]
+        assert "holoindex_prod_01" in ids
+
+    def test_holoindex_launch_readiness_discoverable_only(self):
+        with open(CATALOG_PATH, encoding="utf-8") as f:
+            catalog = json.load(f)
+        entry = next(e for e in catalog if e["foundup_id"] == "holoindex_prod_01")
+        assert entry["launch_readiness"] == "discoverable_only"
+
+    def test_holoindex_routing_prefix(self):
+        with open(CATALOG_PATH, encoding="utf-8") as f:
+            catalog = json.load(f)
+        entry = next(e for e in catalog if e["foundup_id"] == "holoindex_prod_01")
+        assert entry["routing_prefix"] == "/f/holoindex_prod_01"
+
+    def test_holoindex_no_entry_url_while_stub(self):
+        """No entry_url while bridge is stub-only — would overclaim readiness."""
+        with open(CATALOG_PATH, encoding="utf-8") as f:
+            catalog = json.load(f)
+        entry = next(e for e in catalog if e["foundup_id"] == "holoindex_prod_01")
+        assert "entry_url" not in entry, (
+            "entry_url must not exist in catalog while bridge is stub-only"
+        )
+
+
+# ---------------------------------------------------------------------------
+# UI Connector Tests
+# ---------------------------------------------------------------------------
+
+
+class TestConnectorContract:
+    """connector.js emits correct postMessage payloads per contract."""
+
+    def _read_connector(self):
+        with open(CONNECTOR_PATH, encoding="utf-8") as f:
+            return f.read()
+
+    def test_connector_emits_agent_request_type(self):
+        js = self._read_connector()
+        assert "type: 'agent_request'" in js or '"type": "agent_request"' in js
+
+    def test_connector_uses_openclaw_search_route(self):
+        js = self._read_connector()
+        assert "route: 'openclaw_search'" in js or '"route": "openclaw_search"' in js
+
+    def test_connector_sends_semantic_search_action(self):
+        js = self._read_connector()
+        assert "action: 'semantic_search'" in js or '"action": "semantic_search"' in js
+
+    def test_connector_sends_query_field(self):
+        js = self._read_connector()
+        assert "query:" in js or '"query"' in js
+
+    def test_connector_posts_to_parent(self):
+        js = self._read_connector()
+        assert "window.parent.postMessage" in js
+
+
+# ---------------------------------------------------------------------------
+# Contract Doc vs Implementation Alignment
+# ---------------------------------------------------------------------------
+
+
+class TestContractDocAlignment:
+    """Contract doc and implementation agree on service/field names."""
+
+    def _read_contract(self):
+        with open(CONTRACT_PATH, encoding="utf-8") as f:
+            return f.read()
+
+    def _read_interceptor(self):
+        with open(INTERCEPTOR_PATH, encoding="utf-8") as f:
+            return f.read()
+
+    def test_contract_defines_agent_request_type(self):
+        contract = self._read_contract()
+        assert '"type": "agent_request"' in contract
+
+    def test_contract_defines_agent_response_type(self):
+        contract = self._read_contract()
+        assert '"type": "agent_response"' in contract
+
+    def test_contract_defines_openclaw_search_route(self):
+        contract = self._read_contract()
+        assert '"route": "openclaw_search"' in contract or "openclaw_search" in contract
+
+    def test_contract_response_has_results_field(self):
+        contract = self._read_contract()
+        assert '"results"' in contract
+
+    def test_contract_response_has_quantum_coherence(self):
+        contract = self._read_contract()
+        assert '"quantum_coherence"' in contract or "quantum_coherence" in contract
+
+    def test_interceptor_handles_openclaw_search(self):
+        js = self._read_interceptor()
+        assert "openclaw_search" in js
+
+    def test_interceptor_handles_semantic_search(self):
+        js = self._read_interceptor()
+        assert "semantic_search" in js
+
+    def test_interceptor_handles_wsp_lookup(self):
+        js = self._read_interceptor()
+        assert "wsp_lookup" in js
+
+    def test_interceptor_stub_marks_stub_true(self):
+        """Interceptor stub responses must include stub: true."""
+        js = self._read_interceptor()
+        assert "stub: true" in js
+
+    def test_contract_response_has_service_field(self):
+        """Contract Section 3.1 defines service field in response."""
+        contract = self._read_contract()
+        assert '"service": "holoindex"' in contract
+
+    def test_interceptor_has_route_service_map(self):
+        """Interceptor maps routes to service identifiers."""
+        js = self._read_interceptor()
+        assert "ROUTE_SERVICE_MAP" in js
+
+    def test_interceptor_injects_service_in_response(self):
+        """Interceptor sets response.service from ROUTE_SERVICE_MAP."""
+        js = self._read_interceptor()
+        assert "response.service" in js
+
+    def test_interceptor_maps_openclaw_to_holoindex(self):
+        """openclaw_search route maps to 'holoindex' service."""
+        js = self._read_interceptor()
+        assert "'openclaw_search'" in js
+        assert "'holoindex'" in js
+
+
+# ---------------------------------------------------------------------------
+# Connector Response Handler Tests
+# ---------------------------------------------------------------------------
+
+
+class TestConnectorResponsePath:
+    """connector.js response handler matches interceptor service field."""
+
+    def _read_connector(self):
+        with open(CONNECTOR_PATH, encoding="utf-8") as f:
+            return f.read()
+
+    def _read_interceptor(self):
+        with open(INTERCEPTOR_PATH, encoding="utf-8") as f:
+            return f.read()
+
+    def test_connector_checks_service_holoindex(self):
+        """Connector filters responses by service === 'holoindex'."""
+        js = self._read_connector()
+        assert "service" in js
+        assert "'holoindex'" in js or '"holoindex"' in js
+
+    def test_connector_checks_agent_response_type(self):
+        """Connector checks for type === 'agent_response'."""
+        js = self._read_connector()
+        assert "'agent_response'" in js or '"agent_response"' in js
+
+    def test_interceptor_and_connector_agree_on_service_name(self):
+        """Interceptor ROUTE_SERVICE_MAP and connector filter use same service name."""
+        connector = self._read_connector()
+        interceptor = self._read_interceptor()
+        # Both must reference 'holoindex' as the service identifier
+        assert "'holoindex'" in interceptor
+        assert "'holoindex'" in connector or '"holoindex"' in connector
+
+    def test_connector_reads_data_from_response(self):
+        """Connector reads response data from event.data.data (per contract Section 3.1)."""
+        js = self._read_connector()
+        assert "event.data.data" in js
+
+
+# ---------------------------------------------------------------------------
+# File Tracking Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRepoTracking:
+    """All external FoundUp bundle files are repo-tracked."""
+
+    REQUIRED_FILES = [
+        "holo_index/foundup_manifest.json",
+        "holo_index/foundup_adapter/bridge_stub.py",
+        "holo_index/docs/EXTERNAL_FOUNDUP_BRIDGE_CONTRACT.md",
+        "public/f/holoindex_prod_01/index.html",
+        "public/f/holoindex_prod_01/js/connector.js",
+        "public/f/holoindex_prod_01/css/style.css",
+        "public/member/js/shell-bridge-interceptor.js",
+        "public/member/mall-catalog.json",
+    ]
+
+    @pytest.mark.parametrize("relpath", REQUIRED_FILES)
+    def test_file_exists(self, relpath):
+        full = os.path.join(REPO_ROOT, relpath)
+        assert os.path.isfile(full), f"{relpath} must exist in repo"

--- a/modules/communication/youtube_channel_pull/INTERFACE.md
+++ b/modules/communication/youtube_channel_pull/INTERFACE.md
@@ -143,7 +143,57 @@ python -m modules.communication.youtube_channel_pull.src.refresh_scheduler [OPTI
 | Delta | `docs/audits/pfmall_youtube_ingest/youtube_channel_pull_delta.json` | New videos for review |
 | Refresh Log | `docs/audits/pfmall_youtube_ingest/refresh_log.json` | Scheduler run history |
 
+### status_summary.py
+
+Read-only status summary generator. Aggregates catalog, delta, refresh log,
+discovery proposals, and the latest discovery review into a single operator
+artifact. Performs no catalog mutation and requires no live API access.
+
+#### `generate_status_summary(repo_root=REPO_ROOT) -> Dict`
+
+Return a status summary dict with fields:
+- `generated_at`, `read_only`
+- `sources`: relative paths to each parsed artifact (or `null` if missing)
+- `catalog`: foundup counts, declared-vs-actual totals, mismatches, per-entry rows
+- `delta`: latest known-channel refresh (generated_at, per-foundup deltas)
+- `refresh_log`: run count + last run, or `{available: False, note: ...}` if missing
+- `proposals`: latest discovery proposals metadata
+- `review`: latest discovery review result (auto-selects most recent `youtube_discovery_review_result_*.json` by sorted order)
+- `blockers`: list of strings
+- `next_actions`: list of strings
+
+#### `render_markdown(summary: Dict) -> str`
+
+Render the summary dict as operator-facing markdown. Safe on fully-missing
+artifact sets (reports absences honestly).
+
+#### `write_status_summary(summary, markdown_path, json_path) -> Dict[str, Path]`
+
+Write markdown and JSON artifacts. Only writes to the provided output paths;
+never mutates source artifacts.
+
+#### CLI
+
+```bash
+python -m modules.communication.youtube_channel_pull.src.status_summary [OPTIONS]
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--repo-root` | path | inferred | Repo root to scan for artifacts |
+| `--markdown-out` | path | `docs/audits/pfmall_youtube_ingest/pipeline_status_summary.md` | Markdown output |
+| `--json-out` | path | `docs/audits/pfmall_youtube_ingest/pipeline_status_summary.json` | JSON output |
+| `--stdout` | flag | false | Print markdown to stdout instead of writing files |
+
+#### Output Artifacts
+
+| Artifact | Path | Purpose |
+|----------|------|---------|
+| Status Summary (MD) | `docs/audits/pfmall_youtube_ingest/pipeline_status_summary.md` | Operator-facing status view |
+| Status Summary (JSON) | `docs/audits/pfmall_youtube_ingest/pipeline_status_summary.json` | Machine-readable status contract |
+
 ## Dependencies
 
 - `youtube_auth`: For `get_authenticated_service()`
 - `googleapiclient`: YouTube Data API v3
+- `status_summary`: standard library only (json, pathlib, datetime, argparse)

--- a/modules/communication/youtube_channel_pull/src/status_summary.py
+++ b/modules/communication/youtube_channel_pull/src/status_summary.py
@@ -1,0 +1,525 @@
+#!/usr/bin/env python3
+"""
+YouTube Pipeline Status Summary Generator (Read-Only).
+
+Parses existing artifacts and emits an operator-facing status summary so
+humans can see what ran, what changed, and what needs review without
+manually inspecting multiple JSON files.
+
+Artifact sources (read-only):
+- public/member/mall-video-catalog.json
+- docs/audits/pfmall_youtube_ingest/youtube_channel_pull_delta.json
+- docs/audits/pfmall_youtube_ingest/refresh_log.json            (optional)
+- docs/audits/pfmall_youtube_ingest/youtube_discovery_proposals.json
+- docs/audits/pfmall_youtube_ingest/youtube_discovery_review_result_*.json
+
+Outputs (generated):
+- docs/audits/pfmall_youtube_ingest/pipeline_status_summary.md
+- docs/audits/pfmall_youtube_ingest/pipeline_status_summary.json
+
+This module performs NO catalog mutation and requires NO live API access.
+
+WSP References:
+- WSP 3: Communication domain
+- WSP 49: Module structure
+- WSP 97: Truthful verification (report missing artifacts honestly)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
+CATALOG_PATH = REPO_ROOT / "public" / "member" / "mall-video-catalog.json"
+AUDIT_DIR = REPO_ROOT / "docs" / "audits" / "pfmall_youtube_ingest"
+DELTA_PATH = AUDIT_DIR / "youtube_channel_pull_delta.json"
+REFRESH_LOG_PATH = AUDIT_DIR / "refresh_log.json"
+PROPOSALS_PATH = AUDIT_DIR / "youtube_discovery_proposals.json"
+SUMMARY_MD_PATH = AUDIT_DIR / "pipeline_status_summary.md"
+SUMMARY_JSON_PATH = AUDIT_DIR / "pipeline_status_summary.json"
+REVIEW_RESULT_GLOB = "youtube_discovery_review_result_*.json"
+
+
+def _load_json(path: Path) -> Optional[Any]:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return {"_parse_error": str(exc)}
+
+
+def _find_latest_review_result(audit_dir: Path) -> Optional[Path]:
+    candidates = sorted(audit_dir.glob(REVIEW_RESULT_GLOB))
+    if not candidates:
+        return None
+    return candidates[-1]
+
+
+def _catalog_counts(catalog: Optional[List[Dict[str, Any]]]) -> Dict[str, Any]:
+    if not isinstance(catalog, list):
+        return {"available": False, "error": "catalog missing or not a list"}
+
+    entries: List[Dict[str, Any]] = []
+    total_declared = 0
+    total_actual = 0
+    mismatches: List[Dict[str, Any]] = []
+    for entry in catalog:
+        fid = entry.get("foundup_id", "?")
+        declared = int(entry.get("video_count", 0) or 0)
+        videos = entry.get("videos", []) or []
+        actual = len(videos)
+        total_declared += declared
+        total_actual += actual
+        entries.append(
+            {
+                "foundup_id": fid,
+                "title": entry.get("title", ""),
+                "source_type": entry.get("source_type", ""),
+                "source_id": entry.get("source_id", ""),
+                "declared_video_count": declared,
+                "actual_video_count": actual,
+            }
+        )
+        if declared != actual:
+            mismatches.append(
+                {"foundup_id": fid, "declared": declared, "actual": actual}
+            )
+
+    return {
+        "available": True,
+        "foundup_count": len(entries),
+        "total_declared_videos": total_declared,
+        "total_actual_videos": total_actual,
+        "count_mismatches": mismatches,
+        "entries": entries,
+    }
+
+
+def _delta_status(delta: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not isinstance(delta, dict):
+        return {"available": False}
+    if "_parse_error" in delta:
+        return {"available": False, "error": delta["_parse_error"]}
+
+    summary = delta.get("summary", {}) or {}
+    deltas = delta.get("deltas", []) or []
+    per_foundup = [
+        {
+            "foundup_id": d.get("foundup_id"),
+            "existing_count": d.get("existing_count"),
+            "pulled_count": d.get("pulled_count"),
+            "new_count": d.get("new_count"),
+            "skipped_count": d.get("skipped_count"),
+        }
+        for d in deltas
+    ]
+    return {
+        "available": True,
+        "generated_at": delta.get("generated_at"),
+        "foundups_checked": summary.get("foundups_checked"),
+        "total_new_videos": summary.get("total_new_videos"),
+        "total_skipped": summary.get("total_skipped"),
+        "per_foundup": per_foundup,
+    }
+
+
+def _refresh_log_status(log: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not isinstance(log, dict):
+        return {
+            "available": False,
+            "note": (
+                "refresh_log.json not present; refresh_scheduler has not run "
+                "in logged mode yet, or all runs used --no-log."
+            ),
+        }
+    runs = log.get("runs", []) or []
+    if not runs:
+        return {"available": True, "run_count": 0, "last_run": None}
+    last = runs[-1]
+    return {
+        "available": True,
+        "run_count": len(runs),
+        "last_run": {
+            "triggered_at": last.get("triggered_at"),
+            "trigger_mode": last.get("trigger_mode"),
+            "success": last.get("success"),
+            "foundups_checked": last.get("foundups_checked"),
+            "new_videos_found": last.get("new_videos_found"),
+            "error": last.get("error"),
+        },
+    }
+
+
+def _proposals_status(proposals: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not isinstance(proposals, dict):
+        return {"available": False}
+    if "_parse_error" in proposals:
+        return {"available": False, "error": proposals["_parse_error"]}
+
+    summary = proposals.get("summary", {}) or {}
+    return {
+        "available": True,
+        "generated_at": proposals.get("generated_at"),
+        "query": proposals.get("query"),
+        "search_type": proposals.get("search_type"),
+        "total_proposals": summary.get("total_proposals"),
+        "matched_to_foundup": summary.get("matched_to_foundup"),
+        "unmatched": summary.get("unmatched"),
+        "catalog_targets": summary.get("catalog_targets"),
+    }
+
+
+def _review_status(review: Optional[Dict[str, Any]], source: Optional[Path]) -> Dict[str, Any]:
+    if not isinstance(review, dict):
+        return {"available": False}
+    if "_parse_error" in review:
+        return {"available": False, "error": review["_parse_error"]}
+
+    rs = review.get("review_summary", {}) or {}
+    cu = review.get("catalog_update", {}) or {}
+    return {
+        "available": True,
+        "source_file": source.name if source else None,
+        "reviewed_at": review.get("reviewed_at"),
+        "reviewer": review.get("reviewer"),
+        "proposal_artifact": review.get("proposal_artifact"),
+        "total_proposals": review.get("total_proposals"),
+        "approved": rs.get("approved"),
+        "skipped_duplicate": rs.get("skipped_duplicate"),
+        "skipped_ambiguous": rs.get("skipped_ambiguous"),
+        "skipped_low_confidence": rs.get("skipped_low_confidence"),
+        "rejected": rs.get("rejected"),
+        "catalog_update": {
+            "target_foundup": cu.get("target_foundup"),
+            "video_count_before": cu.get("video_count_before"),
+            "video_count_after": cu.get("video_count_after"),
+        },
+    }
+
+
+def _determine_blockers_and_next_action(summary: Dict[str, Any]) -> Dict[str, Any]:
+    blockers: List[str] = []
+    next_actions: List[str] = []
+
+    if not summary["catalog"]["available"]:
+        blockers.append("Catalog missing or unreadable.")
+        next_actions.append("Restore public/member/mall-video-catalog.json.")
+
+    if not summary["delta"]["available"]:
+        blockers.append("Known-channel delta artifact missing.")
+        next_actions.append(
+            "Run: python -m modules.communication.youtube_channel_pull.src.refresh_scheduler"
+        )
+    else:
+        total_new = summary["delta"].get("total_new_videos") or 0
+        if total_new > 0:
+            next_actions.append(
+                f"Review {total_new} new known-channel candidate(s) in "
+                "youtube_channel_pull_delta.json and apply if relevant."
+            )
+        else:
+            next_actions.append(
+                "Known-channel delta shows 0 new videos - no action required."
+            )
+
+    if not summary["refresh_log"]["available"]:
+        next_actions.append(
+            "Run refresh_scheduler at least once with logging enabled to "
+            "populate refresh_log.json (drop --no-log)."
+        )
+
+    if summary["proposals"]["available"]:
+        total_prop = summary["proposals"].get("total_proposals") or 0
+        reviewed = summary["review"].get("total_proposals") if summary["review"]["available"] else None
+        proposals_gen = summary["proposals"].get("generated_at")
+        review_gen = summary["review"].get("reviewed_at") if summary["review"]["available"] else None
+        if not summary["review"]["available"]:
+            next_actions.append(
+                f"{total_prop} discovery proposal(s) exist with no review artifact - operator review required."
+            )
+        elif reviewed != total_prop:
+            next_actions.append(
+                f"Latest review covers {reviewed}/{total_prop} proposals - verify pending items."
+            )
+        elif proposals_gen and review_gen and review_gen < proposals_gen:
+            next_actions.append(
+                "Latest review predates latest proposals - re-review required."
+            )
+
+    mismatches = summary["catalog"].get("count_mismatches") if summary["catalog"]["available"] else []
+    if mismatches:
+        blockers.append(
+            f"{len(mismatches)} FoundUp(s) have declared video_count != actual videos[] length."
+        )
+        next_actions.append("Reconcile declared vs actual video counts in catalog.")
+
+    return {"blockers": blockers, "next_actions": next_actions}
+
+
+def generate_status_summary(repo_root: Path = REPO_ROOT) -> Dict[str, Any]:
+    """Build the pipeline status summary dict from existing artifacts only.
+
+    Read-only. No catalog mutation. No live API calls.
+    """
+    catalog_path = repo_root / "public" / "member" / "mall-video-catalog.json"
+    audit_dir = repo_root / "docs" / "audits" / "pfmall_youtube_ingest"
+    delta_path = audit_dir / "youtube_channel_pull_delta.json"
+    refresh_log_path = audit_dir / "refresh_log.json"
+    proposals_path = audit_dir / "youtube_discovery_proposals.json"
+
+    catalog = _load_json(catalog_path)
+    delta = _load_json(delta_path)
+    refresh_log = _load_json(refresh_log_path)
+    proposals = _load_json(proposals_path)
+    latest_review_path = _find_latest_review_result(audit_dir)
+    review = _load_json(latest_review_path) if latest_review_path else None
+
+    summary: Dict[str, Any] = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generator": "status_summary.generate_status_summary",
+        "read_only": True,
+        "sources": {
+            "catalog": str(catalog_path.relative_to(repo_root)) if catalog_path.exists() else None,
+            "delta": str(delta_path.relative_to(repo_root)) if delta_path.exists() else None,
+            "refresh_log": str(refresh_log_path.relative_to(repo_root)) if refresh_log_path.exists() else None,
+            "proposals": str(proposals_path.relative_to(repo_root)) if proposals_path.exists() else None,
+            "latest_review": str(latest_review_path.relative_to(repo_root)) if latest_review_path else None,
+        },
+        "catalog": _catalog_counts(catalog),
+        "delta": _delta_status(delta),
+        "refresh_log": _refresh_log_status(refresh_log),
+        "proposals": _proposals_status(proposals),
+        "review": _review_status(review, latest_review_path),
+    }
+    summary.update(_determine_blockers_and_next_action(summary))
+    return summary
+
+
+def render_markdown(summary: Dict[str, Any]) -> str:
+    """Render the summary dict as an operator-facing markdown document."""
+    lines: List[str] = []
+    lines.append("# pfMALL YouTube Pipeline - Status Summary")
+    lines.append("")
+    lines.append(f"- Generated: `{summary['generated_at']}`")
+    lines.append("- Read-only: yes (no catalog mutation, no live API calls)")
+    lines.append("- Generator: `modules/communication/youtube_channel_pull/src/status_summary.py`")
+    lines.append("")
+
+    # Sources
+    lines.append("## Sources")
+    lines.append("")
+    lines.append("| Artifact | Path |")
+    lines.append("|---|---|")
+    for label, key in [
+        ("Catalog", "catalog"),
+        ("Known-channel delta", "delta"),
+        ("Refresh log", "refresh_log"),
+        ("Discovery proposals", "proposals"),
+        ("Latest discovery review", "latest_review"),
+    ]:
+        path = summary["sources"].get(key)
+        shown = f"`{path}`" if path else "_missing_"
+        lines.append(f"| {label} | {shown} |")
+    lines.append("")
+
+    # Catalog
+    lines.append("## 1. Catalog State")
+    lines.append("")
+    cat = summary["catalog"]
+    if not cat["available"]:
+        lines.append(f"Catalog unavailable: {cat.get('error', 'unknown error')}")
+    else:
+        lines.append(f"- FoundUps: **{cat['foundup_count']}**")
+        lines.append(f"- Total declared videos: **{cat['total_declared_videos']}**")
+        lines.append(f"- Total actual videos (sum of `videos[]`): **{cat['total_actual_videos']}**")
+        if cat["count_mismatches"]:
+            lines.append(
+                f"- Count mismatches: **{len(cat['count_mismatches'])}** (declared != actual)"
+            )
+        else:
+            lines.append("- Count mismatches: none")
+        lines.append("")
+        lines.append("| foundup_id | title | source_type | declared | actual |")
+        lines.append("|---|---|---|---:|---:|")
+        for e in cat["entries"]:
+            lines.append(
+                f"| {e['foundup_id']} | {e['title']} | {e['source_type']} | "
+                f"{e['declared_video_count']} | {e['actual_video_count']} |"
+            )
+    lines.append("")
+
+    # Delta
+    lines.append("## 2. Latest Known-Channel Refresh (Delta)")
+    lines.append("")
+    delta = summary["delta"]
+    if not delta["available"]:
+        lines.append("Delta artifact not present - run `refresh_scheduler` to generate one.")
+    else:
+        lines.append(f"- Generated: `{delta.get('generated_at', 'unknown')}`")
+        lines.append(f"- FoundUps checked: **{delta.get('foundups_checked', 0)}**")
+        lines.append(f"- New videos: **{delta.get('total_new_videos', 0)}**")
+        lines.append(f"- Skipped (already in catalog): **{delta.get('total_skipped', 0)}**")
+        lines.append("")
+        if delta.get("per_foundup"):
+            lines.append("| foundup_id | existing | pulled | new | skipped |")
+            lines.append("|---|---:|---:|---:|---:|")
+            for row in delta["per_foundup"]:
+                lines.append(
+                    f"| {row.get('foundup_id')} | {row.get('existing_count')} | "
+                    f"{row.get('pulled_count')} | {row.get('new_count')} | "
+                    f"{row.get('skipped_count')} |"
+                )
+    lines.append("")
+
+    # Refresh log
+    lines.append("## 3. Refresh Scheduler Log")
+    lines.append("")
+    rl = summary["refresh_log"]
+    if not rl["available"]:
+        lines.append(f"_{rl.get('note', 'refresh_log.json not present')}_")
+    else:
+        lines.append(f"- Total logged runs: **{rl.get('run_count', 0)}**")
+        last = rl.get("last_run")
+        if last:
+            lines.append(f"- Last run at: `{last.get('triggered_at')}`")
+            lines.append(f"- Trigger mode: `{last.get('trigger_mode')}`")
+            lines.append(f"- Success: `{last.get('success')}`")
+            lines.append(f"- FoundUps checked: {last.get('foundups_checked')}")
+            lines.append(f"- New videos found: {last.get('new_videos_found')}")
+            if last.get("error"):
+                lines.append(f"- Error: `{last['error']}`")
+    lines.append("")
+
+    # Proposals
+    lines.append("## 4. Discovery Proposals")
+    lines.append("")
+    prop = summary["proposals"]
+    if not prop["available"]:
+        lines.append("No discovery proposals artifact present.")
+    else:
+        lines.append(f"- Generated: `{prop.get('generated_at', 'unknown')}`")
+        lines.append(f"- Query: `{prop.get('query')}`")
+        lines.append(f"- Search type: `{prop.get('search_type')}`")
+        lines.append(f"- Total proposals: **{prop.get('total_proposals', 0)}**")
+        lines.append(f"- Matched to a FoundUp: **{prop.get('matched_to_foundup', 0)}**")
+        lines.append(f"- Unmatched: **{prop.get('unmatched', 0)}**")
+        lines.append(f"- Distinct catalog targets: **{prop.get('catalog_targets', 0)}**")
+    lines.append("")
+
+    # Review
+    lines.append("## 5. Latest Discovery Review")
+    lines.append("")
+    rev = summary["review"]
+    if not rev["available"]:
+        lines.append("No discovery review artifact found.")
+    else:
+        lines.append(f"- Source: `{rev.get('source_file')}`")
+        lines.append(f"- Reviewed at: `{rev.get('reviewed_at')}`")
+        lines.append(f"- Reviewer: `{rev.get('reviewer')}`")
+        lines.append(f"- Proposal artifact reviewed: `{rev.get('proposal_artifact')}`")
+        lines.append(f"- Total proposals covered: **{rev.get('total_proposals', 0)}**")
+        lines.append(f"- Approved / applied: **{rev.get('approved', 0)}**")
+        lines.append(f"- Skipped (duplicate): **{rev.get('skipped_duplicate', 0)}**")
+        lines.append(f"- Skipped (ambiguous): **{rev.get('skipped_ambiguous', 0)}**")
+        lines.append(f"- Skipped (low confidence): **{rev.get('skipped_low_confidence', 0)}**")
+        lines.append(f"- Rejected: **{rev.get('rejected', 0)}**")
+        cu = rev.get("catalog_update") or {}
+        if cu.get("target_foundup") is not None:
+            lines.append(
+                f"- Catalog update: `{cu.get('target_foundup')}` "
+                f"{cu.get('video_count_before')} -> {cu.get('video_count_after')}"
+            )
+    lines.append("")
+
+    # Blockers & next actions
+    lines.append("## 6. Blockers")
+    lines.append("")
+    if summary["blockers"]:
+        for b in summary["blockers"]:
+            lines.append(f"- {b}")
+    else:
+        lines.append("- None detected from artifacts.")
+    lines.append("")
+
+    lines.append("## 7. Operator Next Action")
+    lines.append("")
+    if summary["next_actions"]:
+        for a in summary["next_actions"]:
+            lines.append(f"- {a}")
+    else:
+        lines.append("- No action required.")
+    lines.append("")
+
+    lines.append("---")
+    lines.append("")
+    lines.append(
+        "_Summary is artifact-grounded. Missing artifacts are reported honestly; "
+        "no fields are inferred from sources that do not exist._"
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_status_summary(
+    summary: Dict[str, Any],
+    markdown_path: Path = SUMMARY_MD_PATH,
+    json_path: Path = SUMMARY_JSON_PATH,
+) -> Dict[str, Path]:
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.write_text(render_markdown(summary), encoding="utf-8")
+    json_path.write_text(
+        json.dumps(summary, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return {"markdown": markdown_path, "json": json_path}
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate read-only status summary for the pfMALL YouTube pipeline."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Repository root (defaults to inferred path).",
+    )
+    parser.add_argument(
+        "--markdown-out",
+        type=Path,
+        default=SUMMARY_MD_PATH,
+        help="Path for markdown summary output.",
+    )
+    parser.add_argument(
+        "--json-out",
+        type=Path,
+        default=SUMMARY_JSON_PATH,
+        help="Path for JSON summary output.",
+    )
+    parser.add_argument(
+        "--stdout",
+        action="store_true",
+        help="Print markdown to stdout instead of writing files.",
+    )
+    args = parser.parse_args(argv)
+
+    summary = generate_status_summary(args.repo_root)
+
+    if args.stdout:
+        sys.stdout.write(render_markdown(summary))
+        return 0
+
+    written = write_status_summary(summary, args.markdown_out, args.json_out)
+    print(f"[OK] Wrote markdown: {written['markdown']}")
+    print(f"[OK] Wrote JSON:     {written['json']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/modules/communication/youtube_channel_pull/tests/test_status_summary.py
+++ b/modules/communication/youtube_channel_pull/tests/test_status_summary.py
@@ -1,0 +1,225 @@
+"""
+Focused tests for status_summary generator.
+
+Tests:
+- Parsing of complete artifact set (happy path)
+- Missing-artifact behavior (refresh_log absent, catalog absent, etc.)
+- Markdown renders without crashing for both cases
+- Read-only guarantee: never writes to catalog/audit source paths
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from modules.communication.youtube_channel_pull.src import status_summary
+
+
+def _write_json(path: Path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _scaffold_repo(tmp_path: Path, *, include_catalog=True, include_delta=True,
+                   include_proposals=True, include_review=True, include_refresh_log=False):
+    catalog_path = tmp_path / "public" / "member" / "mall-video-catalog.json"
+    audit_dir = tmp_path / "docs" / "audits" / "pfmall_youtube_ingest"
+
+    if include_catalog:
+        _write_json(
+            catalog_path,
+            [
+                {
+                    "foundup_id": "move2japan",
+                    "title": "Move to Japan",
+                    "source_type": "youtube_channel",
+                    "source_id": "UC-TEST",
+                    "video_count": 2,
+                    "videos": [{"video_id": "a"}, {"video_id": "b"}],
+                },
+                {
+                    "foundup_id": "eduit",
+                    "title": "EDUIT",
+                    "source_type": "youtube_channel",
+                    "source_id": "UC-EDU",
+                    "video_count": 1,
+                    "videos": [],  # mismatch: declared 1, actual 0
+                },
+            ],
+        )
+
+    if include_delta:
+        _write_json(
+            audit_dir / "youtube_channel_pull_delta.json",
+            {
+                "generated_at": "2026-04-13T07:17:28Z",
+                "summary": {
+                    "foundups_checked": 1,
+                    "total_new_videos": 0,
+                    "total_skipped": 19,
+                },
+                "deltas": [
+                    {
+                        "foundup_id": "move2japan",
+                        "existing_count": 594,
+                        "pulled_count": 19,
+                        "new_count": 0,
+                        "skipped_count": 19,
+                        "new_videos": [],
+                        "skipped_ids": [],
+                    }
+                ],
+            },
+        )
+
+    if include_proposals:
+        _write_json(
+            audit_dir / "youtube_discovery_proposals.json",
+            {
+                "generated_at": "2026-04-13T07:06:16Z",
+                "query": "FFCPLN music",
+                "search_type": "video",
+                "summary": {
+                    "total_proposals": 10,
+                    "matched_to_foundup": 10,
+                    "unmatched": 0,
+                    "catalog_targets": 4,
+                },
+                "proposals": [],
+            },
+        )
+
+    if include_review:
+        _write_json(
+            audit_dir / "youtube_discovery_review_result_20260413.json",
+            {
+                "reviewed_at": "2026-04-13T07:30:00Z",
+                "reviewer": "test",
+                "proposal_artifact": "youtube_discovery_proposals.json",
+                "total_proposals": 10,
+                "review_summary": {
+                    "approved": 2,
+                    "skipped_duplicate": 8,
+                    "skipped_ambiguous": 0,
+                    "skipped_low_confidence": 0,
+                    "rejected": 0,
+                },
+                "applied": [],
+                "skipped": [],
+                "catalog_update": {
+                    "target_foundup": "move2japan",
+                    "video_count_before": 592,
+                    "video_count_after": 594,
+                },
+            },
+        )
+
+    if include_refresh_log:
+        _write_json(
+            audit_dir / "refresh_log.json",
+            {
+                "runs": [
+                    {
+                        "success": True,
+                        "foundups_checked": 1,
+                        "new_videos_found": 0,
+                        "delta_path": "docs/audits/pfmall_youtube_ingest/youtube_channel_pull_delta.json",
+                        "error": None,
+                        "triggered_at": "2026-04-13T07:17:28Z",
+                        "trigger_mode": "manual",
+                    }
+                ]
+            },
+        )
+
+    return tmp_path
+
+
+def test_full_artifact_set_parses(tmp_path):
+    repo = _scaffold_repo(tmp_path, include_refresh_log=True)
+    summary = status_summary.generate_status_summary(repo)
+
+    assert summary["catalog"]["available"] is True
+    assert summary["catalog"]["foundup_count"] == 2
+    assert summary["catalog"]["total_declared_videos"] == 3
+    assert summary["catalog"]["total_actual_videos"] == 2
+    assert len(summary["catalog"]["count_mismatches"]) == 1
+    assert summary["catalog"]["count_mismatches"][0]["foundup_id"] == "eduit"
+
+    assert summary["delta"]["available"] is True
+    assert summary["delta"]["total_new_videos"] == 0
+    assert summary["delta"]["total_skipped"] == 19
+
+    assert summary["refresh_log"]["available"] is True
+    assert summary["refresh_log"]["run_count"] == 1
+    assert summary["refresh_log"]["last_run"]["trigger_mode"] == "manual"
+
+    assert summary["proposals"]["available"] is True
+    assert summary["proposals"]["total_proposals"] == 10
+
+    assert summary["review"]["available"] is True
+    assert summary["review"]["approved"] == 2
+    assert summary["review"]["catalog_update"]["video_count_after"] == 594
+
+
+def test_missing_refresh_log_is_reported_honestly(tmp_path):
+    repo = _scaffold_repo(tmp_path, include_refresh_log=False)
+    summary = status_summary.generate_status_summary(repo)
+
+    assert summary["refresh_log"]["available"] is False
+    assert "refresh_log.json not present" in summary["refresh_log"]["note"]
+    # Other artifacts still parse fine
+    assert summary["catalog"]["available"] is True
+    assert summary["delta"]["available"] is True
+
+
+def test_all_artifacts_missing_emits_blockers(tmp_path):
+    summary = status_summary.generate_status_summary(tmp_path)
+
+    assert summary["catalog"]["available"] is False
+    assert summary["delta"]["available"] is False
+    assert summary["refresh_log"]["available"] is False
+    assert summary["proposals"]["available"] is False
+    assert summary["review"]["available"] is False
+
+    # Blockers list should flag the critical absences
+    blocker_text = " ".join(summary["blockers"])
+    assert "Catalog" in blocker_text
+    assert "delta" in blocker_text.lower()
+
+
+def test_markdown_render_does_not_raise_for_full_and_empty(tmp_path):
+    # Full
+    repo_full = _scaffold_repo(tmp_path / "full", include_refresh_log=True)
+    summary_full = status_summary.generate_status_summary(repo_full)
+    md_full = status_summary.render_markdown(summary_full)
+    assert "pfMALL YouTube Pipeline" in md_full
+    assert "move2japan" in md_full
+
+    # Empty (no artifacts)
+    summary_empty = status_summary.generate_status_summary(tmp_path / "empty")
+    md_empty = status_summary.render_markdown(summary_empty)
+    assert "pfMALL YouTube Pipeline" in md_empty
+    assert "not present" in md_empty.lower() or "missing" in md_empty.lower()
+
+
+def test_write_status_summary_is_read_only_vs_sources(tmp_path):
+    repo = _scaffold_repo(tmp_path, include_refresh_log=True)
+    summary = status_summary.generate_status_summary(repo)
+
+    md_out = tmp_path / "out" / "summary.md"
+    json_out = tmp_path / "out" / "summary.json"
+    written = status_summary.write_status_summary(summary, md_out, json_out)
+
+    assert written["markdown"].exists()
+    assert written["json"].exists()
+
+    # Ensure no source artifact was mutated (mtime not changed is expensive to
+    # verify cross-platform; instead verify content is still intact).
+    catalog = json.loads(
+        (repo / "public" / "member" / "mall-video-catalog.json").read_text(encoding="utf-8")
+    )
+    assert len(catalog) == 2  # same as scaffolded

--- a/public/f/holoindex_prod_01/js/connector.js
+++ b/public/f/holoindex_prod_01/js/connector.js
@@ -28,7 +28,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   window.addEventListener('message', (event) => {
     if (event.data && event.data.type === 'agent_response' && event.data.service === 'holoindex') {
-      resultsPanel.textContent = JSON.stringify(event.data.payload, null, 2);
+      resultsPanel.textContent = JSON.stringify(event.data.data, null, 2);
     }
   });
 });

--- a/public/member/ModLog.md
+++ b/public/member/ModLog.md
@@ -1,5 +1,70 @@
 # Member Area Module Change Log
 
+## [2026-04-17] pfMALL YouTube Pipeline Status Summary (Worker CW)
+
+**Who**: 0102 - Worker CW
+**Slice**: `PFMALL_YOUTUBE_PIPELINE_STATUS_SUMMARY_PHASE1`
+**What**: Read-only operator status summary for the pfMALL YouTube pipeline.
+
+**Rationale**: Pipeline state was previously spread across the catalog, delta,
+review, and proposal artifacts. Operators had to manually inspect multiple
+JSON files to know what ran and what still needs review. This slice defines
+the status contract (not a UI) so a later surface can consume it cleanly.
+
+**Files Added**:
+- `modules/communication/youtube_channel_pull/src/status_summary.py` - generator (read-only).
+- `modules/communication/youtube_channel_pull/tests/test_status_summary.py` - 5 focused tests.
+- `docs/audits/pfmall_youtube_ingest/pipeline_status_summary.md` - rendered summary.
+- `docs/audits/pfmall_youtube_ingest/pipeline_status_summary.json` - machine-readable summary.
+
+**Status Contract (fields reported)**:
+| Field | Source | Notes |
+|---|---|---|
+| Catalog foundup count / declared-vs-actual video totals | `mall-video-catalog.json` | Reports mismatches honestly |
+| Latest known-channel refresh timestamp / counts / per-foundup rows | `youtube_channel_pull_delta.json` | Existing vs pulled vs new vs skipped |
+| Refresh scheduler run history | `refresh_log.json` | Missing artifact reported, not faked |
+| Discovery proposals (query, totals, matched/unmatched) | `youtube_discovery_proposals.json` | |
+| Latest discovery review (approved / applied / skipped / rejected) | `youtube_discovery_review_result_*.json` | Latest file auto-selected |
+| Blockers & operator next-action | derived | Grounded only in observed artifacts |
+
+**Current Catalog State (this run)**:
+- FoundUps: 13
+- Total declared videos: 1205 (matches actual `videos[]` length)
+- Active YouTube channels: move2japan (594), undaodu (512), foundups_main (44), antifafm (34), eduit (21)
+
+**Known-Channel Refresh** (latest delta 2026-04-13T07:17:28Z):
+- FoundUps checked: 1 (move2japan)
+- New videos: 0 - all 19 pulled were duplicates
+- No action required on delta
+
+**Discovery**:
+- Proposals artifact (2026-04-13T07:06:16Z): 10 FFCPLN-music proposals, all matched to move2japan by channel_id
+- Latest review (2026-04-13T07:30:00Z): 2 approved/applied, 8 duplicate-skipped - catalog 592 -> 594
+
+**Missing Artifacts (honestly reported)**:
+- `refresh_log.json` - not yet present. Scheduler has not run in logged mode, or has only run with `--no-log`. Summary flags this as a next-action, not a blocker.
+
+**Key Boundary Preserved**:
+- Read-only: no catalog mutation, no scheduler mutation, no live API calls.
+- Missing artifacts reported as missing; no values are fabricated.
+- Status contract defined here is reusable by any later UI/API surface.
+
+**Tests**: 5/5 passing
+- `test_full_artifact_set_parses`
+- `test_missing_refresh_log_is_reported_honestly`
+- `test_all_artifacts_missing_emits_blockers`
+- `test_markdown_render_does_not_raise_for_full_and_empty`
+- `test_write_status_summary_is_read_only_vs_sources`
+
+**HoloIndex**:
+- Command: `python holo_index.py --search "pfmall youtube pipeline status summary refresh delta discovery review artifact" --limit 3`
+- Top hit: `modules/ai_intelligence/pfmall_discovery/README.md` (adjacent module; confirmed no existing summary generator to reuse).
+
+**WSP 15 Applied**: P1 task - operator-facing observability for an active pipeline; low complexity, high deferability cost (manual multi-file inspection every run).
+**WSP 97 Applied**: CoT (evidence retrieved before facts stated), CoR (dialectic sweep chose smallest generator + JSON contract over larger UI surface), missing artifacts reported truthfully instead of inferred.
+
+---
+
 ## [2026-04-13] YouTube Discovery Proposal Review and Apply (Worker CT)
 
 **Who**: 0102 - Worker CT

--- a/public/member/js/shell-bridge-interceptor.js
+++ b/public/member/js/shell-bridge-interceptor.js
@@ -114,6 +114,13 @@
     return CONFIG.allowedOrigins.indexOf(origin) !== -1;
   }
 
+  // Route → service identifier for FoundUp iframe response filtering.
+  // Each route maps to the foundup_id that owns it, so connector iframes
+  // can filter responses by `event.data.service === '<their_foundup_id>'`.
+  var ROUTE_SERVICE_MAP = {
+    'openclaw_search': 'holoindex'
+  };
+
   var handlers = {
     openclaw_search: function(payload, callback) {
       var action = payload.action;
@@ -284,6 +291,10 @@
     }
 
     handlers[route](payload, function(response) {
+      // Tag response with service identifier so FoundUp iframes can filter
+      if (ROUTE_SERVICE_MAP[route]) {
+        response.service = ROUTE_SERVICE_MAP[route];
+      }
       log('debug', 'Sending response', response);
       sourceWindow.postMessage(response, origin);
     });

--- a/public/member/mall-catalog.json
+++ b/public/member/mall-catalog.json
@@ -44,7 +44,7 @@
     "routing_prefix": "/f/antifafm_001",
     "theme": "antifafm",
     "hero_label": "SIGNAL",
-    "hero_mood": "Signal-first, always on, discoverable inside the shell.",
+    "hero_mood": "Signal-first, always on, discoverable inside the shell."
   },
   {
     "foundup_id": "holoindex_prod_01",

--- a/public/member/tests/shell_bridge_interceptor_vm.mjs
+++ b/public/member/tests/shell_bridge_interceptor_vm.mjs
@@ -72,6 +72,7 @@ async function run() {
     });
     await new Promise((r) => setImmediate(r));
     assert(resolved && resolved.data && resolved.data.stub === true, 'stub search has stub:true');
+    assert(resolved.service === 'holoindex', 'stub search has service:holoindex');
     assert(
       resolved.data.results[0].content.includes('Stub') || resolved.data.results[0].path.includes('stub'),
       'stub search content/path marks stub'
@@ -134,6 +135,7 @@ async function run() {
     });
     await new Promise((r) => setImmediate(r));
     assert(resolved.status === 'success', 'search success');
+    assert(resolved.service === 'holoindex', 'registered search has service:holoindex');
     assert(resolved.data.results[0].content === 'real hit', 'real search body');
     assert(resolved.data.stub !== true, 'no stub flag when backend omits it');
 

--- a/public/member/tests/test_shell_bridge_interceptor.py
+++ b/public/member/tests/test_shell_bridge_interceptor.py
@@ -185,6 +185,17 @@ class TestResponseFormat:
         js = _read_js()
         assert "quantum_coherence" in js
 
+    def test_response_has_service_field(self):
+        """Responses include service identifier for FoundUp iframe filtering."""
+        js = _read_js()
+        assert "ROUTE_SERVICE_MAP" in js
+        assert "'holoindex'" in js or '"holoindex"' in js
+
+    def test_service_injected_in_dispatch(self):
+        """dispatchRequest injects service from ROUTE_SERVICE_MAP."""
+        js = _read_js()
+        assert "response.service" in js
+
 
 # ---------------------------------------------------------------------------
 # Origin Validation Tests


### PR DESCRIPTION
## Summary

- **CY** verified the HoloIndex external FoundUp bundle is repo-real and stub-only. 8/8 bundle files tracked, manifest/catalog/route aligned, bridge stub marker truthful (`stub: True`), catalog JSON validity repaired.
- **CY2** fixed the connector/interceptor response handshake discovered by CY: shell interceptor now tags responses via a `ROUTE_SERVICE_MAP` (`openclaw_search → holoindex`); connector reads `event.data.data` (per contract) instead of the undefined `event.data.payload`.
- `launch_readiness` remains `discoverable_only` — unchanged. No `entry_url` in catalog.
- **No real HoloIndex backend wiring.** Bridge remains stub-only; backend registration API exists but no caller.
- **135 tests pass**: bridge contract (38) + shell interceptor (52) + route contract (45).

## Scope

12 files:
- `holo_index/foundup_adapter/bridge_stub.py`
- `holo_index/foundup_adapter/tests/test_bridge_contract.py` (new)
- `public/member/mall-catalog.json`
- `public/member/js/shell-bridge-interceptor.js`
- `public/f/holoindex_prod_01/js/connector.js`
- `holo_index/docs/EXTERNAL_FOUNDUP_BRIDGE_CONTRACT.md`
- `public/member/tests/test_shell_bridge_interceptor.py`
- `public/member/tests/shell_bridge_interceptor_vm.mjs`
- `holo_index/docs/ModLog.md`
- `holo_index/ModLog.md`
- `docs/0102_session_briefings/CY_HOLOINDEX_EXTERNAL_BRIDGE_CONTRACT_VERIFICATION_PHASE1.md` (new)
- `docs/0102_session_briefings/CY2_HOLOINDEX_CONNECTOR_INTERCEPTOR_RESPONSE_HANDSHAKE_FIX.md` (new)

## Test plan

- [x] `pytest holo_index/foundup_adapter/tests/test_bridge_contract.py -q` → 38 passed
- [x] `pytest public/member/tests/test_shell_bridge_interceptor.py -q` → 52 passed
- [x] `pytest public/member/tests/test_route_contract_bridge.py -q` → 45 passed
- [x] `python -c "import json; json.load(open('holo_index/foundup_manifest.json', encoding='utf-8')); json.load(open('public/member/mall-catalog.json', encoding='utf-8'))"` → valid
- [x] `holo_index.py --search "..."` → lexical-only (sentence_transformers unavailable), top hit `shell-bridge-interceptor.js`

## WSP

WSP 11 (Interface), WSP 15 (Pre-read), WSP 22 (ModLog), WSP 97 (No overclaiming), WSP 104 (FoundUp routing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)