### PR TITLE
feat(mall): add channel avatars and density policy hardening

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -1,5 +1,39 @@
 # FoundUps Agent - Development Log
 
+## [2026-04-17] p.fMALL Tile Field Display Improvements
+
+**Change Type**: Feature / UI
+**By**: 0102
+**WSP References**: WSP 22, WSP 50
+
+### Summary
+
+Fixed Mall tile display: channel avatars, proper scaling, video counts, and catalog refresh tooling.
+
+### What Changed
+
+- `public/member/css/mall-tile-field.css`:
+  - Changed `background-size: cover` to `contain` for proper logo scaling
+  - Added `!important` to prevent inline style overrides
+- `public/member/js/mall-tile-field.js`:
+  - Prioritize `channel_avatar_url` over `poster_url` for tile backgrounds
+  - Use `true_video_count` for accurate video counts
+- `modules/communication/youtube_channel_pull/src/channel_puller.py`:
+  - Added `fetch_channel_info()` for avatars and channel stats
+- `scripts/refresh_mall_catalog.py` (NEW):
+  - Quota-efficient catalog refresh (--info-only, --delta, --full modes)
+  - Fetches channel avatars and true video counts
+- `public/member/mall-video-catalog.json`:
+  - Updated with channel_avatar_url and true_video_count for 4 YouTube channels
+
+### Result
+
+- Mall tiles display channel logos that scale with density
+- Accurate video counts (3416, 4208, 1588, 105 vs old 44)
+- Efficient refresh tooling (~13 quota units for info-only mode)
+
+---
+
 ## [2026-04-01] SoftProto Audit Prompt Batch
 
 **Change Type**: Architecture / Coordination

--- a/ModLog.md
+++ b/ModLog.md
@@ -1,5 +1,43 @@
 # FoundUps Agent - Development Log
 
+## [2026-04-18] p.fMALL Device Policy Hardening
+
+**Change Type**: Security / Hardening
+**By**: 0102
+**WSP References**: WSP 22, WSP 50, WSP 64
+
+### Summary
+
+Added device policy enforcement for density controls and refresh script safety.
+
+### What Changed
+
+- `public/member/js/mall-tile-field.js`:
+  - Added `getDeviceInfo()` and `getDevicePolicy()` for device classification
+  - Added `requestDensity(preset, options)` as safe public API with policy enforcement
+  - Phone (coarse + short side < 600): only 3x4, 3x5 allowed
+  - Tablet (coarse + short side >= 600): up to 4x6, 5x8
+  - Desktop (fine pointer): all densities allowed
+  - Added `data-tile-type` attribute (avatar/video) for CSS targeting
+- `public/member/css/mall-tile-field.css`:
+  - Avatar tiles use `background-size: contain` (show full logo)
+  - Video tiles use `background-size: cover` (fill thumbnail)
+- `public/member/js/account-concierge.js`:
+  - RedDog now uses `requestDensity()` with policy validation
+  - Rejected densities logged and emitted as `density_rejected` event
+- `scripts/refresh_mall_catalog.py`:
+  - Dry-run by default, requires `--apply` to write changes
+  - Creates backup before writing
+- Tests added for all hardening (26 new tests)
+
+### Result
+
+- AI/RedDog cannot force desktop densities on phones
+- Channel logos scale correctly, video thumbnails fill tiles
+- Catalog refresh is safe by default (no accidental mutations)
+
+---
+
 ## [2026-04-17] p.fMALL Tile Field Display Improvements
 
 **Change Type**: Feature / UI

--- a/modules/communication/youtube_channel_pull/ModLog.md
+++ b/modules/communication/youtube_channel_pull/ModLog.md
@@ -1,0 +1,27 @@
+# YouTube Channel Pull - Development Log
+
+## [2026-04-17] Channel Info Fetch & Avatar Support
+
+**Change Type**: Feature
+**By**: 0102
+**WSP References**: WSP 22, WSP 50
+
+### Summary
+
+Added `fetch_channel_info()` function to retrieve channel avatars, subscriber counts, and true video counts from YouTube Data API.
+
+### What Changed
+
+- Added `fetch_channel_info()` in `src/channel_puller.py`:
+  - Returns avatar_url (high > medium > default thumbnail)
+  - Returns true video_count from channel statistics
+  - Returns subscriber_count
+  - Uses channels.list API (1 quota unit per call)
+
+### Result
+
+- Mall tiles can now display channel logos instead of random video thumbnails
+- True video counts available (e.g., 3416 instead of 44)
+- Enables catalog refresh script to populate channel_avatar_url field
+
+---

--- a/modules/communication/youtube_channel_pull/src/channel_puller.py
+++ b/modules/communication/youtube_channel_pull/src/channel_puller.py
@@ -18,10 +18,66 @@ from typing import Any, Dict, List, Optional
 logger = logging.getLogger(__name__)
 
 
+def fetch_channel_info(
+    youtube_service,
+    channel_id: str,
+) -> Optional[Dict[str, Any]]:
+    """
+    Fetch channel info including avatar/logo URL.
+
+    Args:
+        youtube_service: Authenticated googleapiclient YouTube service
+        channel_id: YouTube channel ID (e.g., "UC-LSSlOZwpGIRIYihaz8zCw")
+
+    Returns:
+        Dict with: channel_id, title, avatar_url, subscriber_count, video_count
+    """
+    if not youtube_service or not channel_id:
+        return None
+
+    try:
+        request = youtube_service.channels().list(
+            part="snippet,statistics",
+            id=channel_id,
+        )
+        response = request.execute()
+
+        items = response.get("items", [])
+        if not items:
+            return None
+
+        channel = items[0]
+        snippet = channel.get("snippet", {})
+        stats = channel.get("statistics", {})
+        thumbnails = snippet.get("thumbnails", {})
+
+        # Get best avatar (high > medium > default)
+        avatar_url = (
+            thumbnails.get("high", {}).get("url")
+            or thumbnails.get("medium", {}).get("url")
+            or thumbnails.get("default", {}).get("url")
+        )
+
+        return {
+            "channel_id": channel_id,
+            "title": snippet.get("title", ""),
+            "description": snippet.get("description", ""),
+            "avatar_url": avatar_url,
+            "subscriber_count": int(stats.get("subscriberCount", 0)),
+            "video_count": int(stats.get("videoCount", 0)),
+            "custom_url": snippet.get("customUrl", ""),
+        }
+
+    except Exception as e:
+        logger.error(f"[PULL] Error fetching channel info for {channel_id}: {e}")
+        return None
+
+
 def fetch_channel_videos(
     youtube_service,
     channel_id: str,
     max_results: int = 50,
+    fetch_all: bool = False,
 ) -> List[Dict[str, Any]]:
     """
     Fetch latest videos from a YouTube channel via Data API.
@@ -30,6 +86,7 @@ def fetch_channel_videos(
         youtube_service: Authenticated googleapiclient YouTube service
         channel_id: YouTube channel ID (e.g., "UC-LSSlOZwpGIRIYihaz8zCw")
         max_results: Maximum videos to fetch (default 50, max 50 per request)
+        fetch_all: If True, paginate to fetch ALL videos (can be slow/quota-heavy)
 
     Returns:
         List of video dicts with: video_id, title, thumbnail_url, embed_url, published_at
@@ -42,46 +99,63 @@ def fetch_channel_videos(
         return []
 
     videos: List[Dict[str, Any]] = []
+    next_page_token = None
+    total_fetched = 0
 
     try:
-        # Search for videos from this channel (ordered by date, newest first)
-        request = youtube_service.search().list(
-            part="snippet",
-            channelId=channel_id,
-            type="video",
-            order="date",
-            maxResults=min(max_results, 50),
-        )
-        response = request.execute()
-
-        for item in response.get("items", []):
-            video_id = item.get("id", {}).get("videoId")
-            if not video_id:
-                continue
-
-            snippet = item.get("snippet", {})
-            published_at = snippet.get("publishedAt", "")
-
-            # Get best available thumbnail
-            thumbnails = snippet.get("thumbnails", {})
-            thumbnail_url = (
-                thumbnails.get("high", {}).get("url")
-                or thumbnails.get("medium", {}).get("url")
-                or thumbnails.get("default", {}).get("url")
-                or f"https://i.ytimg.com/vi/{video_id}/hqdefault.jpg"
+        while True:
+            # Search for videos from this channel (ordered by date, newest first)
+            request = youtube_service.search().list(
+                part="snippet",
+                channelId=channel_id,
+                type="video",
+                order="date",
+                maxResults=50,  # Always fetch max per request
+                pageToken=next_page_token,
             )
+            response = request.execute()
 
-            videos.append({
-                "video_id": video_id,
-                "title": snippet.get("title", ""),
-                "thumbnail_url": thumbnail_url,
-                "embed_url": f"https://www.youtube.com/embed/{video_id}",
-                "source_url": f"https://www.youtube.com/watch?v={video_id}",
-                "published_at": published_at,
-                "channel_id": channel_id,
-            })
+            for item in response.get("items", []):
+                video_id = item.get("id", {}).get("videoId")
+                if not video_id:
+                    continue
 
-        logger.info(f"[PULL] Fetched {len(videos)} videos from channel {channel_id}")
+                snippet = item.get("snippet", {})
+                published_at = snippet.get("publishedAt", "")
+
+                # Get best available thumbnail
+                thumbnails = snippet.get("thumbnails", {})
+                thumbnail_url = (
+                    thumbnails.get("high", {}).get("url")
+                    or thumbnails.get("medium", {}).get("url")
+                    or thumbnails.get("default", {}).get("url")
+                    or f"https://i.ytimg.com/vi/{video_id}/hqdefault.jpg"
+                )
+
+                videos.append({
+                    "video_id": video_id,
+                    "title": snippet.get("title", ""),
+                    "thumbnail_url": thumbnail_url,
+                    "embed_url": f"https://www.youtube.com/embed/{video_id}",
+                    "source_url": f"https://www.youtube.com/watch?v={video_id}",
+                    "published_at": published_at,
+                    "channel_id": channel_id,
+                })
+
+                total_fetched += 1
+                if not fetch_all and total_fetched >= max_results:
+                    break
+
+            # Check if we should continue pagination
+            next_page_token = response.get("nextPageToken")
+            if not fetch_all or not next_page_token:
+                break
+            if not fetch_all and total_fetched >= max_results:
+                break
+
+            logger.info(f"[PULL] Fetched {total_fetched} videos so far, continuing...")
+
+        logger.info(f"[PULL] Fetched {len(videos)} total videos from channel {channel_id}")
 
     except Exception as e:
         logger.error(f"[PULL] API error for channel {channel_id}: {e}")

--- a/public/member/css/mall-tile-field.css
+++ b/public/member/css/mall-tile-field.css
@@ -23,8 +23,66 @@
 .mall-projection {
   display: flex;
   gap: 0.4rem;
+  padding: 0 0 0.5rem;
+  flex-wrap: wrap;
+}
+
+/* ========== Density Controls ========== */
+
+.mall-density-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
   padding: 0 0 0.75rem;
   flex-wrap: wrap;
+}
+
+.mall-density-label {
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.4);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin-right: 0.25rem;
+}
+
+.mall-density-btn {
+  min-width: 32px;
+  min-height: 32px;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.12s ease;
+}
+
+.mall-density-btn:hover {
+  border-color: rgba(255, 255, 255, 0.25);
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.mall-density-btn.active {
+  border-color: rgba(141, 113, 255, 0.5);
+  background: rgba(141, 113, 255, 0.15);
+  color: #fff;
+}
+
+.mall-density-slider {
+  width: 80px;
+  height: 4px;
+  margin-left: 0.5rem;
+  accent-color: rgba(141, 113, 255, 0.8);
+  cursor: pointer;
+}
+
+@media (max-width: 600px) {
+  .mall-density-controls {
+    display: none; /* Hide on mobile - auto-density is better */
+  }
 }
 
 .mall-projection-chip {
@@ -141,6 +199,7 @@
   display: grid;
   grid-template-columns: repeat(var(--field-columns, 3), 1fr);
   grid-auto-rows: auto;
+  grid-auto-flow: row;
   gap: var(--tile-gap, 0.2rem);
   padding: 0;
   min-height: 100%;
@@ -177,12 +236,86 @@
   --tile-radius: 0.25rem;
   --tile-gap: 0.1rem;
 }
-/* Desktop-optimized: wide landscape with 6 columns, 3 rows */
+/* Desktop-optimized: wide landscape with 6 columns */
 .mall-tile-field[data-density="6x3"] {
   --field-columns: 6;
   --field-rows: 3;
   --tile-radius: 0.5rem;
   --tile-gap: 0.35rem;
+}
+
+.mall-tile-field[data-density="6x3"] .mall-tile {
+  aspect-ratio: 3 / 4;
+}
+
+/* Desktop dense wall presets — shorter aspect ratio for more rows */
+.mall-tile-field[data-density="8x5"] {
+  --field-columns: 8;
+  --field-rows: 5;
+  --tile-radius: 0.35rem;
+  --tile-gap: 0.2rem;
+}
+
+.mall-tile-field[data-density="8x5"] .mall-tile {
+  aspect-ratio: 3 / 4;
+}
+
+.mall-tile-field[data-density="10x6"] {
+  --field-columns: 10;
+  --field-rows: 6;
+  --tile-radius: 0.3rem;
+  --tile-gap: 0.15rem;
+}
+
+.mall-tile-field[data-density="10x6"] .mall-tile {
+  aspect-ratio: 4 / 5;
+}
+
+.mall-tile-field[data-density="12x8"] {
+  --field-columns: 12;
+  --field-rows: 8;
+  --tile-radius: 0.25rem;
+  --tile-gap: 0.1rem;
+}
+
+.mall-tile-field[data-density="12x8"] .mall-tile {
+  aspect-ratio: 1 / 1;
+}
+
+/* Ultra-wide desktop: 12 columns × 3 rows with landscape tiles */
+.mall-tile-field[data-density="12x3"] {
+  --field-columns: 12;
+  --field-rows: 3;
+  --tile-radius: 0.3rem;
+  --tile-gap: 0.2rem;
+}
+
+.mall-tile-field[data-density="12x3"] .mall-tile {
+  aspect-ratio: 4 / 3;
+}
+
+/* Maximum density: 15 columns for large screens */
+.mall-tile-field[data-density="15x4"] {
+  --field-columns: 15;
+  --field-rows: 4;
+  --tile-radius: 0.2rem;
+  --tile-gap: 0.1rem;
+}
+
+.mall-tile-field[data-density="15x4"] .mall-tile {
+  aspect-ratio: 1 / 1;
+}
+
+/* Wide landscape: 8 columns × 2 rows */
+.mall-tile-field[data-density="8x2"] {
+  --field-columns: 8;
+  --field-rows: 2;
+  --tile-radius: 0.4rem;
+  --tile-gap: 0.25rem;
+}
+
+.mall-tile-field[data-density="8x2"] .mall-tile {
+  aspect-ratio: 16 / 9;
 }
 
 @media (min-width: 600px) {
@@ -204,10 +337,44 @@
   aspect-ratio: 9 / 16;
   border-radius: var(--tile-radius, 0.4rem);
   border: 1px solid rgba(255, 255, 255, 0.06);
-  background: var(--surface);
-  background-size: cover;
-  background-position: center;
+  background-color: var(--surface);
+  background-size: contain !important;
+  background-position: center !important;
+  background-repeat: no-repeat !important;
   overflow: hidden;
+}
+
+/* Loading shimmer while thumbnail loads */
+.mall-tile::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    110deg,
+    transparent 20%,
+    rgba(255, 255, 255, 0.04) 40%,
+    rgba(255, 255, 255, 0.08) 50%,
+    rgba(255, 255, 255, 0.04) 60%,
+    transparent 80%
+  );
+  background-size: 200% 100%;
+  animation: tile-shimmer 1.5s ease-in-out infinite;
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.3s ease;
+  z-index: 0;
+}
+
+.mall-tile.thumb-loaded::after {
+  opacity: 0;
+}
+
+@keyframes tile-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.mall-tile {
   cursor: pointer;
   /* Snappy transitions for phone feel */
   transition: transform 100ms ease-out, border-color 100ms ease-out, box-shadow 100ms ease-out;
@@ -453,9 +620,13 @@
   border: none;
 }
 
-/* Active preview: show the preview layer */
+/* Active preview: show the preview layer and hide thumbnail background */
 .mall-tile.is-previewing .mall-tile-preview {
   opacity: 1;
+}
+
+.mall-tile.is-previewing {
+  background-image: none !important;
 }
 
 /* Hide play indicator during active preview */

--- a/public/member/css/mall-tile-field.css
+++ b/public/member/css/mall-tile-field.css
@@ -338,10 +338,19 @@
   border-radius: var(--tile-radius, 0.4rem);
   border: 1px solid rgba(255, 255, 255, 0.06);
   background-color: var(--surface);
-  background-size: contain !important;
-  background-position: center !important;
-  background-repeat: no-repeat !important;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
   overflow: hidden;
+}
+
+/* Channel avatar tiles: contain to show full logo, cover for video thumbnails */
+.mall-tile[data-tile-type="avatar"] {
+  background-size: contain;
+}
+
+.mall-tile[data-tile-type="video"] {
+  background-size: cover;
 }
 
 /* Loading shimmer while thumbnail loads */

--- a/public/member/js/account-concierge.js
+++ b/public/member/js/account-concierge.js
@@ -467,10 +467,15 @@
   ];
 
   var DENSITY_PRESETS = [
-    { id: '3x4' },
-    { id: '3x5' },
-    { id: '4x6' },
-    { id: '5x8' }
+    { id: '3x4', label: '3×4' },
+    { id: '3x5', label: '3×5' },
+    { id: '4x6', label: '4×6' },
+    { id: '5x8', label: '5×8' },
+    { id: '6x3', label: '6×3' },
+    { id: '8x2', label: '8w' },
+    { id: '10x6', label: '10' },
+    { id: '12x3', label: '12' },
+    { id: '15x4', label: '15' }
   ];
 
   function emitRedDogCommand(command, detail) {
@@ -568,11 +573,11 @@
     // Density presets
     html += '<div class="reddog-tools-group">';
     html += '<div class="reddog-tools-label">Density</div>';
-    html += '<div class="reddog-tools-row">';
+    html += '<div class="reddog-tools-row reddog-tools-row-wrap">';
     for (var j = 0; j < DENSITY_PRESETS.length; j++) {
       var d = DENSITY_PRESETS[j];
       html += '<button class="reddog-tool-pill reddog-density-pill' + (d.id === currentDensity ? ' active' : '') + '"'
-            + ' data-reddog-density="' + d.id + '" type="button">' + d.id + '</button>';
+            + ' data-reddog-density="' + d.id + '" type="button">' + (d.label || d.id) + '</button>';
     }
     html += '</div></div>';
 

--- a/public/member/js/account-concierge.js
+++ b/public/member/js/account-concierge.js
@@ -502,8 +502,18 @@
   }
 
   function setDensity(presetId) {
-    currentDensity = presetId;
-    if (window.mallTileField && typeof window.mallTileField.setDensity === 'function') {
+    // Use requestDensity for device policy enforcement
+    if (window.mallTileField && typeof window.mallTileField.requestDensity === 'function') {
+      var result = window.mallTileField.requestDensity(presetId, { source: 'reddog' });
+      if (!result.applied) {
+        console.warn('[RedDog] Density rejected:', result.reason);
+        emitRedDogCommand('density_rejected', { preset: presetId, reason: result.reason });
+        return;
+      }
+      currentDensity = presetId;
+    } else if (window.mallTileField && typeof window.mallTileField.setDensity === 'function') {
+      // Fallback for older API
+      currentDensity = presetId;
       window.mallTileField.setDensity(presetId);
     }
     emitRedDogCommand('set_density', { preset: presetId });

--- a/public/member/js/mall-tile-field.js
+++ b/public/member/js/mall-tile-field.js
@@ -646,8 +646,11 @@
       var badgeClass = readiness === 'ready' ? 'ready' : (readiness === 'conditional' ? 'conditional' : '');
 
       // Video-backed: use channel_avatar_url (preferred) or poster_url as background
+      // Track tile type for CSS background-size: avatar uses contain, video uses cover
+      var isAvatarTile = !!item.channel_avatar_url && !item.video_data;
       var posterUrl = item.channel_avatar_url || item.poster_url || '';
       var posterStyle = posterUrl ? 'background-image: url(' + escapeAttr(posterUrl) + ')' : '';
+      var tileType = isAvatarTile ? 'avatar' : 'video';
 
       // Determine if tile has videos (includes expanded video tiles with video_data)
       var hasVideos = (item.videos && item.videos.length) || item.video_count || item.video_data;
@@ -685,7 +688,7 @@
       // Non-video tile class modifier
       var tileClass = 'mall-tile theme-' + theme + (hasVideos ? '' : ' non-video');
 
-      return '<article class="' + tileClass + '" data-index="' + index + '" data-foundup-id="' + escapeAttr(item.foundup_id || item.id || '') + '" tabindex="0" aria-label="' + escapeAttr(item.name || item.title || '') + '" style="' + posterStyle + '">' +
+      return '<article class="' + tileClass + '" data-index="' + index + '" data-foundup-id="' + escapeAttr(item.foundup_id || item.id || '') + '" data-tile-type="' + tileType + '" tabindex="0" aria-label="' + escapeAttr(item.name || item.title || '') + '" style="' + posterStyle + '">' +
         previewContainer +
         '<span class="mall-tile-badge ' + badgeClass + '">' + escapeHtml(readiness.replace('_', ' ')) + '</span>' +
         queueBadge +
@@ -1184,14 +1187,111 @@
 
   // ========== Density Control ==========
 
+  // All valid density presets
+  var ALL_DENSITIES = ['3x4', '3x5', '4x6', '5x8', '6x3', '8x2', '8x5', '10x6', '12x3', '12x8', '15x4'];
+
+  // Density tiers by device class
+  var DENSITY_TIERS = {
+    phone: ['3x4', '3x5'],
+    tablet: ['3x4', '3x5', '4x6', '5x8'],
+    desktop: ALL_DENSITIES
+  };
+
   /**
-   * Set field density preset
-   * @param {string} density - '3x4' | '3x5' | '4x6' | '5x8' | '6x3'
+   * Get device class based on pointer type and viewport
+   * @returns {{ deviceClass: string, shortSide: number, isCoarse: boolean, isLandscape: boolean }}
+   */
+  function getDeviceInfo() {
+    var width = window.innerWidth;
+    var height = window.innerHeight;
+    var isCoarsePointer = window.matchMedia && window.matchMedia('(pointer: coarse)').matches;
+    var isLandscape = width > height;
+    var shortSide = Math.min(width, height);
+
+    var deviceClass;
+    if (!isCoarsePointer) {
+      deviceClass = 'desktop';
+    } else if (shortSide < 600) {
+      deviceClass = 'phone';
+    } else {
+      deviceClass = 'tablet';
+    }
+
+    return {
+      deviceClass: deviceClass,
+      shortSide: shortSide,
+      isCoarse: isCoarsePointer,
+      isLandscape: isLandscape,
+      width: width,
+      height: height
+    };
+  }
+
+  /**
+   * Get allowed density presets for current device
+   * @returns {{ allowed: string[], deviceClass: string, reason: string }}
+   */
+  function getDevicePolicy() {
+    var info = getDeviceInfo();
+    var allowed = DENSITY_TIERS[info.deviceClass] || DENSITY_TIERS.phone;
+
+    return {
+      allowed: allowed,
+      deviceClass: info.deviceClass,
+      reason: info.deviceClass === 'phone'
+        ? 'Phone (coarse pointer, short side < 600px)'
+        : info.deviceClass === 'tablet'
+          ? 'Tablet (coarse pointer, short side >= 600px)'
+          : 'Desktop (fine pointer)'
+    };
+  }
+
+  /**
+   * Safe public API for density changes from AI/RedDog
+   * Validates against device policy before applying
+   * @param {string} preset - Requested density preset
+   * @param {{ source?: string }} [options] - Options with source identifier
+   * @returns {{ applied: boolean, preset: string, reason?: string }}
+   */
+  function requestDensity(preset, options) {
+    options = options || {};
+    var source = options.source || 'unknown';
+    var policy = getDevicePolicy();
+
+    if (!ALL_DENSITIES.includes(preset)) {
+      return {
+        applied: false,
+        preset: preset,
+        reason: 'Invalid density preset: ' + preset
+      };
+    }
+
+    if (!policy.allowed.includes(preset)) {
+      return {
+        applied: false,
+        preset: preset,
+        reason: 'Density ' + preset + ' not allowed for ' + policy.deviceClass + '. Allowed: ' + policy.allowed.join(', ')
+      };
+    }
+
+    setDensity(preset, true);
+    return {
+      applied: true,
+      preset: preset,
+      source: source,
+      deviceClass: policy.deviceClass
+    };
+  }
+
+  /**
+   * Set field density preset (internal/low-level)
+   * External callers should use requestDensity() for policy enforcement
+   * @param {string} density - Density preset
    * @param {boolean} [isManual=true] - Whether this is a manual user override
+   * @private
    */
   function setDensity(density, isManual) {
-    var validDensities = ['3x4', '3x5', '4x6', '5x8', '6x3', '8x2', '8x5', '10x6', '12x3', '12x8', '15x4'];
-    if (!validDensities.includes(density)) {
+    if (!ALL_DENSITIES.includes(density)) {
       density = '3x5';
     }
     currentDensity = density;
@@ -1216,31 +1316,27 @@
 
   /**
    * Detect viewport class and return optimal density
-   * Desktop/fine-pointer wide viewports get 6x3
-   * Mobile/tablet/coarse-pointer get appropriate portrait densities
+   * Uses device policy to ensure returned density is always allowed
    * @returns {string} Optimal density preset
    */
   function detectOptimalDensity() {
-    var width = window.innerWidth;
-    var height = window.innerHeight;
-    var isCoarsePointer = window.matchMedia && window.matchMedia('(pointer: coarse)').matches;
-    var isLandscape = width > height;
+    var info = getDeviceInfo();
+    var policy = getDevicePolicy();
 
     // Desktop: fine pointer + wide viewport + landscape
-    // Use denser presets for larger screens
-    if (!isCoarsePointer && isLandscape) {
-      if (width >= 2560) return '12x3';  // 4K/ultrawide = maximum density
-      if (width >= 1920) return '10x6';  // Full HD+ = dense wall
-      if (width >= 1440) return '8x5';   // QHD = medium wall
-      if (width >= 1024) return '6x3';   // HD = standard
+    if (info.deviceClass === 'desktop' && info.isLandscape) {
+      if (info.width >= 2560) return '12x3';
+      if (info.width >= 1920) return '10x6';
+      if (info.width >= 1440) return '8x5';
+      if (info.width >= 1024) return '6x3';
     }
 
-    // Tablet landscape: coarse pointer but wide
-    if (isCoarsePointer && width >= 768 && isLandscape) {
+    // Tablet landscape: coarse pointer but wide enough
+    if (info.deviceClass === 'tablet' && info.isLandscape) {
       return '4x6';
     }
 
-    // Default mobile-first
+    // Phone or portrait: safe mobile default
     return '3x5';
   }
 
@@ -1656,7 +1752,9 @@
     setMotionMode: setMotionMode,
     getMotionMode: getMotionMode,
 
-    // Density
+    // Density (use requestDensity for AI/RedDog, setDensity is low-level)
+    requestDensity: requestDensity,
+    getDevicePolicy: getDevicePolicy,
     setDensity: setDensity,
     getDensity: getDensity,
     detectOptimalDensity: detectOptimalDensity,

--- a/public/member/js/mall-tile-field.js
+++ b/public/member/js/mall-tile-field.js
@@ -645,14 +645,15 @@
       var readiness = item.launch_readiness || item.status || 'discoverable_only';
       var badgeClass = readiness === 'ready' ? 'ready' : (readiness === 'conditional' ? 'conditional' : '');
 
-      // Video-backed: use poster_url as background
-      var posterStyle = item.poster_url ? 'background-image: url(' + escapeAttr(item.poster_url) + ')' : '';
+      // Video-backed: use channel_avatar_url (preferred) or poster_url as background
+      var posterUrl = item.channel_avatar_url || item.poster_url || '';
+      var posterStyle = posterUrl ? 'background-image: url(' + escapeAttr(posterUrl) + ')' : '';
 
       // Determine if tile has videos (includes expanded video tiles with video_data)
       var hasVideos = (item.videos && item.videos.length) || item.video_count || item.video_data;
 
-      // Queue count (video_count or videos array length) — video tiles only
-      var queueCount = item.video_count || (item.videos ? item.videos.length : 0);
+      // Queue count (true_video_count preferred, then video_count, then videos array length)
+      var queueCount = item.true_video_count || item.video_count || (item.videos ? item.videos.length : 0);
       var queueBadge = queueCount > 0 ? '<span class="mall-tile-queue-count">' + queueCount + ' videos</span>' : '';
 
       // Play indicator — video tiles only
@@ -703,6 +704,25 @@
 
     // Update expanded mode class
     tileField.classList.toggle('expanded-mode', expandedFoundUp !== null);
+
+    // Detect thumbnail load and remove shimmer
+    var tiles = tileField.querySelectorAll('.mall-tile');
+    tiles.forEach(function(tile) {
+      var bgImage = tile.style.backgroundImage;
+      if (bgImage && bgImage !== 'none') {
+        var urlMatch = bgImage.match(/url\(["']?([^"')]+)["']?\)/);
+        if (urlMatch && urlMatch[1]) {
+          var img = new Image();
+          img.onload = function() { tile.classList.add('thumb-loaded'); };
+          img.onerror = function() { tile.classList.add('thumb-loaded'); }; // Stop shimmer on error too
+          img.src = urlMatch[1];
+        } else {
+          tile.classList.add('thumb-loaded');
+        }
+      } else {
+        tile.classList.add('thumb-loaded'); // No image = no shimmer needed
+      }
+    });
   }
 
   /**
@@ -1170,7 +1190,7 @@
    * @param {boolean} [isManual=true] - Whether this is a manual user override
    */
   function setDensity(density, isManual) {
-    var validDensities = ['3x4', '3x5', '4x6', '5x8', '6x3'];
+    var validDensities = ['3x4', '3x5', '4x6', '5x8', '6x3', '8x2', '8x5', '10x6', '12x3', '12x8', '15x4'];
     if (!validDensities.includes(density)) {
       density = '3x5';
     }
@@ -1206,9 +1226,13 @@
     var isCoarsePointer = window.matchMedia && window.matchMedia('(pointer: coarse)').matches;
     var isLandscape = width > height;
 
-    // Desktop: fine pointer + wide viewport (1024px+) + landscape
-    if (!isCoarsePointer && width >= 1024 && isLandscape) {
-      return '6x3';
+    // Desktop: fine pointer + wide viewport + landscape
+    // Use denser presets for larger screens
+    if (!isCoarsePointer && isLandscape) {
+      if (width >= 2560) return '12x3';  // 4K/ultrawide = maximum density
+      if (width >= 1920) return '10x6';  // Full HD+ = dense wall
+      if (width >= 1440) return '8x5';   // QHD = medium wall
+      if (width >= 1024) return '6x3';   // HD = standard
     }
 
     // Tablet landscape: coarse pointer but wide
@@ -1651,7 +1675,22 @@
     getFieldScope: getFieldScope,
     searchByCreator: searchByCreator,
     filterByCategory: filterByCategory,
-    filterByTag: filterByTag
+    filterByTag: filterByTag,
+
+    // Debug helpers
+    debugTiles: function() {
+      var items = expandedFoundUp !== null ? getExpandedVideos() : mallCatalog;
+      console.table(items.map(function(item, i) {
+        return {
+          index: i,
+          foundup_id: item.foundup_id,
+          name: (item.name || item.title || '').substring(0, 30),
+          poster_url: (item.poster_url || '').substring(0, 50)
+        };
+      }));
+      console.log('Total tiles:', items.length, '| Density:', currentDensity, '| Expanded:', expandedFoundUp);
+    },
+    getCatalog: function() { return mallCatalog; }
   };
 
 })();

--- a/public/member/mall-video-catalog.json
+++ b/public/member/mall-video-catalog.json
@@ -5381,7 +5381,10 @@
     "lifecycle_stage": "active",
     "tier": "F0_DAE",
     "description": "012 documents life in rural Japan — relocation, culture, and political activism through the FFCPLN movement. 573 videos spanning daily life, resistance music, and community building.",
-    "launch_readiness": "discoverable_only"
+    "launch_readiness": "discoverable_only",
+    "channel_avatar_url": "https://yt3.ggpht.com/AoHPQuFo-j-2isTEcEBNrSvzFTUkW59JFmcutvJe9PW4-faopoLNpVki7JfPousHObJNc2m7iw=s800-c-k-c0x00ffffff-no-rj",
+    "true_video_count": 3416,
+    "subscriber_count": 10200
   },
   {
     "foundup_id": "undaodu",
@@ -10031,7 +10034,10 @@
     "lifecycle_stage": "active",
     "tier": "F0_DAE",
     "description": "012 personal channel covering music production, political commentary, and creative experiments. The longest-running content lane in the FoundUPS ecosystem.",
-    "launch_readiness": "discoverable_only"
+    "launch_readiness": "discoverable_only",
+    "channel_avatar_url": "https://yt3.ggpht.com/H1V5ZWWpU2WOAlEUzhYGtYBW77BRW9sgORhjNkltbwYRRilk4oegh0g8TZ96wY0cK5riBl1fIQ=s800-c-k-c0x00ffffff-no-rj",
+    "true_video_count": 4208,
+    "subscriber_count": 3640
   },
   {
     "foundup_id": "foundups_main",
@@ -10467,7 +10473,10 @@
     "lifecycle_stage": "active",
     "tier": "F0_DAE",
     "description": "Official FoundUPS YouTube presence. Product updates, ecosystem explainers, and development milestones.",
-    "launch_readiness": "discoverable_only"
+    "launch_readiness": "discoverable_only",
+    "channel_avatar_url": "https://yt3.ggpht.com/iTgFX0cdfkYbRq7w900ZUg_6aHIYtdgFDDLq9HqCXPtJx564HDjPyzKDSSkCr44KxL6aFJSAtA=s800-c-k-c0x00ffffff-no-rj",
+    "true_video_count": 1588,
+    "subscriber_count": 4500
   },
   {
     "foundup_id": "antifafm",
@@ -10813,7 +10822,10 @@
     "lifecycle_stage": "proto",
     "tier": "F0_DAE",
     "description": "24/7 headless radio broadcaster with visual layers. Bridges Icecast to YouTube Live via FFmpeg. The broadcast stack is real.",
-    "launch_readiness": "discoverable_only"
+    "launch_readiness": "discoverable_only",
+    "channel_avatar_url": "https://yt3.ggpht.com/yOwK3KmYnGNJn1Z8xB5QLVk9wKfcgXR0rWFKJ_-5mvcbZ89Oc06FZDykUXDkWTtfF7XI5_Sjtg=s800-c-k-c0x00ffffff-no-rj",
+    "true_video_count": 105,
+    "subscriber_count": 71
   },
   {
     "foundup_id": "linkedin_012",

--- a/public/member/tests/test_mall_tile_field.py
+++ b/public/member/tests/test_mall_tile_field.py
@@ -452,3 +452,93 @@ class TestExpandedVideoTilesPreserved:
     def test_get_expanded_videos_sets_video_data(self, tile_field_js):
         """getExpandedVideos() sets video_data on mapped items."""
         assert 'video_data:' in tile_field_js or 'video_data: video' in tile_field_js
+
+
+# ═══════════════════════════════════════════════
+# Device Policy Hardening (PR tile-field-hardening)
+# ═══════════════════════════════════════════════
+
+class TestDevicePolicyStructure:
+    """Device policy restricts density presets by device class."""
+
+    def test_density_tiers_defined(self, tile_field_js):
+        """DENSITY_TIERS object defines phone/tablet/desktop tiers."""
+        assert 'DENSITY_TIERS' in tile_field_js
+
+    def test_phone_tier_restricted(self, tile_field_js):
+        """Phone tier only allows 3x4, 3x5."""
+        assert "phone: ['3x4', '3x5']" in tile_field_js or 'phone: ["3x4", "3x5"]' in tile_field_js
+
+    def test_tablet_tier_allows_medium(self, tile_field_js):
+        """Tablet tier allows up to 4x6, 5x8."""
+        assert "'4x6'" in tile_field_js and "'5x8'" in tile_field_js
+
+    def test_get_device_info_function(self, tile_field_js):
+        """getDeviceInfo function exists."""
+        assert 'function getDeviceInfo()' in tile_field_js
+
+    def test_get_device_policy_function(self, tile_field_js):
+        """getDevicePolicy function exists."""
+        assert 'function getDevicePolicy()' in tile_field_js
+
+    def test_short_side_check(self, tile_field_js):
+        """Device detection checks short side for phone classification."""
+        assert 'shortSide' in tile_field_js
+        assert '< 600' in tile_field_js
+
+
+class TestRequestDensityAPI:
+    """requestDensity API validates against device policy."""
+
+    def test_request_density_function(self, tile_field_js):
+        """requestDensity function exists."""
+        assert 'function requestDensity(' in tile_field_js
+
+    def test_request_density_returns_applied(self, tile_field_js):
+        """requestDensity returns applied boolean."""
+        assert 'applied: true' in tile_field_js or 'applied: false' in tile_field_js
+
+    def test_request_density_returns_reason(self, tile_field_js):
+        """requestDensity returns reason on rejection."""
+        assert 'reason:' in tile_field_js
+
+    def test_request_density_exposed_in_api(self, tile_field_js):
+        """requestDensity is exposed in public API."""
+        assert 'requestDensity: requestDensity' in tile_field_js
+
+    def test_get_device_policy_exposed_in_api(self, tile_field_js):
+        """getDevicePolicy is exposed in public API."""
+        assert 'getDevicePolicy: getDevicePolicy' in tile_field_js
+
+
+class TestTileTypeAttribute:
+    """Tiles have data-tile-type for CSS targeting."""
+
+    def test_tile_type_attribute_added(self, tile_field_js):
+        """data-tile-type attribute is added to tiles."""
+        assert 'data-tile-type' in tile_field_js
+
+    def test_avatar_tile_type(self, tile_field_js):
+        """Avatar tiles get type='avatar'."""
+        assert "tileType = isAvatarTile ? 'avatar'" in tile_field_js or 'tileType = isAvatarTile ?' in tile_field_js
+
+    def test_is_avatar_tile_check(self, tile_field_js):
+        """isAvatarTile checks for channel_avatar_url."""
+        assert 'isAvatarTile' in tile_field_js
+        assert 'channel_avatar_url' in tile_field_js
+
+
+class TestTileTypeCSS:
+    """CSS scopes background-size by tile type."""
+
+    def test_avatar_tile_uses_contain(self, tile_field_css):
+        """Avatar tiles use background-size: contain."""
+        assert '.mall-tile[data-tile-type="avatar"]' in tile_field_css
+        # Check contain is associated with avatar type
+        assert 'contain' in tile_field_css
+
+    def test_video_tile_uses_cover(self, tile_field_css):
+        """Video tiles use background-size: cover."""
+        assert '.mall-tile[data-tile-type="video"]' in tile_field_css
+        # Check cover is associated with video type
+        assert 'cover' in tile_field_css

--- a/public/member/tests/test_reddog_mall_controls_phase1.py
+++ b/public/member/tests/test_reddog_mall_controls_phase1.py
@@ -466,3 +466,41 @@ class TestNoRegression:
     def test_css_desktop_query_preserved(self):
         content = CONCIERGE_CSS.read_text(encoding="utf-8")
         assert "min-width: 640px" in content
+
+
+# ═══════════════════════════════════════════════
+# RedDog Density Policy Enforcement (Hardening)
+# ═══════════════════════════════════════════════
+
+class TestRedDogDensityPolicyEnforcement:
+    """RedDog uses requestDensity for device policy enforcement."""
+
+    def test_set_density_uses_request_density(self):
+        """setDensity function uses mallTileField.requestDensity."""
+        content = CONCIERGE_JS.read_text(encoding="utf-8")
+        assert "mallTileField.requestDensity" in content
+
+    def test_request_density_source_reddog(self):
+        """requestDensity is called with source: 'reddog'."""
+        content = CONCIERGE_JS.read_text(encoding="utf-8")
+        assert "source: 'reddog'" in content or 'source: "reddog"' in content
+
+    def test_density_rejection_handled(self):
+        """Rejected density requests are handled."""
+        content = CONCIERGE_JS.read_text(encoding="utf-8")
+        assert "result.applied" in content or "!result.applied" in content
+
+    def test_density_rejection_logged(self):
+        """Rejected density requests are logged."""
+        content = CONCIERGE_JS.read_text(encoding="utf-8")
+        assert "Density rejected" in content
+
+    def test_density_rejected_command_emitted(self):
+        """density_rejected command is emitted on rejection."""
+        content = CONCIERGE_JS.read_text(encoding="utf-8")
+        assert "density_rejected" in content
+
+    def test_fallback_to_set_density(self):
+        """Falls back to setDensity if requestDensity unavailable."""
+        content = CONCIERGE_JS.read_text(encoding="utf-8")
+        assert "mallTileField.setDensity" in content

--- a/public/member/tests/test_refresh_catalog_safety.py
+++ b/public/member/tests/test_refresh_catalog_safety.py
@@ -1,0 +1,75 @@
+"""
+Tests for Mall Catalog Refresh Script Safety
+
+Verifies dry-run default, --apply requirement, and backup behavior.
+"""
+import pytest
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "refresh_mall_catalog.py"
+
+
+@pytest.fixture
+def script_content():
+    """Load the refresh script."""
+    return SCRIPT_PATH.read_text(encoding="utf-8")
+
+
+class TestRefreshScriptSafety:
+    """Refresh script defaults to dry-run for safety."""
+
+    def test_script_exists(self):
+        """Refresh script exists."""
+        assert SCRIPT_PATH.exists()
+
+    def test_dry_run_documented(self, script_content):
+        """Dry-run behavior is documented in docstring."""
+        assert "DRY-RUN" in script_content or "dry-run" in script_content
+
+    def test_apply_flag_defined(self, script_content):
+        """--apply flag is defined."""
+        assert "--apply" in script_content
+
+    def test_dry_run_default_true(self, script_content):
+        """dry_run defaults to True (not args.apply)."""
+        assert "dry_run = not args.apply" in script_content
+
+    def test_save_catalog_accepts_dry_run(self, script_content):
+        """save_catalog function accepts dry_run parameter."""
+        assert "def save_catalog(catalog" in script_content
+        assert "dry_run" in script_content
+
+    def test_backup_created_on_write(self, script_content):
+        """Backup is created before writing."""
+        assert ".bak" in script_content or "backup" in script_content.lower()
+
+    def test_dry_run_skips_write(self, script_content):
+        """Dry-run mode skips file write."""
+        assert "[DRY-RUN]" in script_content
+
+    def test_refresh_catalog_accepts_dry_run(self, script_content):
+        """refresh_catalog function accepts dry_run parameter."""
+        assert "dry_run: bool = True" in script_content or "dry_run=True" in script_content
+
+
+class TestRefreshScriptModes:
+    """Refresh script supports multiple quota-efficient modes."""
+
+    def test_info_only_mode(self, script_content):
+        """--info-only mode exists."""
+        assert "--info-only" in script_content
+
+    def test_delta_mode(self, script_content):
+        """--delta mode exists."""
+        assert "--delta" in script_content
+
+    def test_full_mode(self, script_content):
+        """--full mode exists."""
+        assert "--full" in script_content
+
+    def test_quota_estimates_documented(self, script_content):
+        """Quota estimates are documented."""
+        assert "quota" in script_content.lower()
+        assert "units" in script_content.lower()

--- a/scripts/refresh_mall_catalog.py
+++ b/scripts/refresh_mall_catalog.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+Refresh Mall Video Catalog - Update channel avatars and video counts.
+
+Usage:
+    python scripts/refresh_mall_catalog.py --info-only  # Avatars + counts (13 units) - RUN ONCE
+    python scripts/refresh_mall_catalog.py --delta      # Only NEW videos since last fetch (~100 units)
+    python scripts/refresh_mall_catalog.py              # 50 latest videos per channel (1300 units)
+    python scripts/refresh_mall_catalog.py --full       # ALL videos (quota heavy!) - RARELY NEEDED
+
+Recommended workflow:
+    1. Run --info-only ONCE to get avatars (they don't change)
+    2. Run --delta periodically to get new videos only
+"""
+
+import json
+import logging
+import sys
+from pathlib import Path
+from datetime import datetime
+
+# Add repo root to path
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from modules.platform_integration.youtube_auth.src.youtube_auth import get_authenticated_service
+from modules.communication.youtube_channel_pull.src.channel_puller import (
+    fetch_channel_info,
+    fetch_channel_videos,
+)
+
+logging.basicConfig(level=logging.INFO, format='%(message)s')
+logger = logging.getLogger(__name__)
+
+CATALOG_PATH = REPO_ROOT / "public" / "member" / "mall-video-catalog.json"
+
+
+def load_catalog() -> list:
+    """Load existing catalog."""
+    if not CATALOG_PATH.exists():
+        logger.error(f"Catalog not found: {CATALOG_PATH}")
+        return []
+    with open(CATALOG_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_catalog(catalog: list) -> None:
+    """Save catalog back to JSON."""
+    with open(CATALOG_PATH, "w", encoding="utf-8") as f:
+        json.dump(catalog, f, indent=2, ensure_ascii=False)
+    logger.info(f"Saved catalog to {CATALOG_PATH}")
+
+
+def refresh_catalog(fetch_videos: bool = True, fetch_all: bool = False, delta_only: bool = False) -> None:
+    """
+    Refresh catalog with channel info and optionally videos.
+
+    Args:
+        fetch_videos: If True, fetch latest videos for each channel
+        fetch_all: If True and fetch_videos, fetch ALL videos (quota heavy)
+        delta_only: If True, only fetch videos newer than most recent in catalog
+    """
+    catalog = load_catalog()
+    if not catalog:
+        return
+
+    logger.info(f"Loaded {len(catalog)} entries from catalog")
+
+    # Get YouTube service
+    try:
+        youtube = get_authenticated_service()
+        if not youtube:
+            logger.error("Failed to get YouTube service")
+            return
+    except Exception as e:
+        logger.error(f"YouTube auth error: {e}")
+        return
+
+    updated = 0
+    for entry in catalog:
+        source_type = entry.get("source_type", "")
+        if source_type != "youtube_channel":
+            logger.info(f"  Skipping {entry.get('foundup_id')} (not a YouTube channel)")
+            continue
+
+        channel_id = entry.get("source_id", "")
+        if not channel_id or not channel_id.startswith("UC"):
+            logger.warning(f"  Invalid channel_id for {entry.get('foundup_id')}")
+            continue
+
+        foundup_id = entry.get("foundup_id", "unknown")
+        logger.info(f"\n[{foundup_id}] Fetching channel info...")
+
+        # Fetch channel info (avatar, true video count)
+        info = fetch_channel_info(youtube, channel_id)
+        if info:
+            entry["channel_avatar_url"] = info.get("avatar_url", "")
+            entry["true_video_count"] = info.get("video_count", 0)
+            entry["subscriber_count"] = info.get("subscriber_count", 0)
+            logger.info(f"  Avatar: {info.get('avatar_url', 'N/A')[:50]}...")
+            logger.info(f"  True video count: {info.get('video_count', 0)}")
+            logger.info(f"  Subscribers: {info.get('subscriber_count', 0)}")
+
+        # Fetch videos
+        if fetch_videos:
+            existing_videos = entry.get("videos", [])
+
+            if delta_only and existing_videos:
+                # Delta mode: only fetch 50 latest, filter to new ones
+                logger.info(f"  Delta mode: checking for new videos...")
+                latest_ids = {v.get("video_id") for v in existing_videos[:100]}
+
+                new_videos = fetch_channel_videos(youtube, channel_id, max_results=50)
+                new_videos = [v for v in new_videos if v.get("video_id") not in latest_ids]
+
+                if new_videos:
+                    entry["videos"] = new_videos + existing_videos
+                    entry["video_count"] = len(entry["videos"])
+                    logger.info(f"  Found {len(new_videos)} NEW videos")
+                else:
+                    logger.info(f"  No new videos")
+            else:
+                # Full fetch mode
+                max_vids = None if fetch_all else 50
+                logger.info(f"  Fetching videos (max={max_vids or 'ALL'})...")
+
+                videos = fetch_channel_videos(
+                    youtube,
+                    channel_id,
+                    max_results=max_vids or 500,
+                    fetch_all=fetch_all
+                )
+
+                if videos:
+                    entry["videos"] = videos
+                    entry["video_count"] = len(videos)
+                    logger.info(f"  Fetched {len(videos)} videos")
+
+        updated += 1
+
+    logger.info(f"\nUpdated {updated} entries")
+
+    # Add refresh timestamp
+    save_catalog(catalog)
+    logger.info(f"Catalog refreshed at {datetime.now().isoformat()}")
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Refresh Mall Video Catalog")
+    parser.add_argument("--full", action="store_true", help="Fetch ALL videos (quota heavy)")
+    parser.add_argument("--info-only", action="store_true", help="Only fetch channel info (cheap) - RUN ONCE")
+    parser.add_argument("--delta", action="store_true", help="Only fetch NEW videos since last run (efficient)")
+    args = parser.parse_args()
+
+    if args.info_only:
+        logger.info("Mode: Info only (avatars + counts) - ~13 quota units")
+        refresh_catalog(fetch_videos=False)
+    elif args.delta:
+        logger.info("Mode: Delta (new videos only) - ~1300 quota units max")
+        refresh_catalog(fetch_videos=True, delta_only=True)
+    elif args.full:
+        logger.info("Mode: Full refresh (ALL videos - quota heavy!)")
+        response = input("This will use significant quota. Continue? [y/N] ")
+        if response.lower() == 'y':
+            refresh_catalog(fetch_videos=True, fetch_all=True)
+        else:
+            logger.info("Aborted")
+    else:
+        logger.info("Mode: Standard refresh (50 latest videos per channel)")
+        refresh_catalog(fetch_videos=True, fetch_all=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/refresh_mall_catalog.py
+++ b/scripts/refresh_mall_catalog.py
@@ -2,15 +2,20 @@
 """
 Refresh Mall Video Catalog - Update channel avatars and video counts.
 
+SAFETY: Dry-run by default. Use --apply to actually write changes.
+
 Usage:
-    python scripts/refresh_mall_catalog.py --info-only  # Avatars + counts (13 units) - RUN ONCE
-    python scripts/refresh_mall_catalog.py --delta      # Only NEW videos since last fetch (~100 units)
-    python scripts/refresh_mall_catalog.py              # 50 latest videos per channel (1300 units)
-    python scripts/refresh_mall_catalog.py --full       # ALL videos (quota heavy!) - RARELY NEEDED
+    python scripts/refresh_mall_catalog.py --info-only          # Preview: avatars + counts (13 units)
+    python scripts/refresh_mall_catalog.py --info-only --apply  # Apply: avatars + counts
+    python scripts/refresh_mall_catalog.py --delta              # Preview: new videos only (~100 units)
+    python scripts/refresh_mall_catalog.py --delta --apply      # Apply: new videos only
+    python scripts/refresh_mall_catalog.py --apply              # Apply: 50 latest per channel (1300 units)
+    python scripts/refresh_mall_catalog.py --full --apply       # Apply: ALL videos (quota heavy!)
 
 Recommended workflow:
-    1. Run --info-only ONCE to get avatars (they don't change)
-    2. Run --delta periodically to get new videos only
+    1. Run --info-only (dry-run) to preview what will change
+    2. Run --info-only --apply to save avatars
+    3. Run --delta --apply periodically to get new videos
 """
 
 import json
@@ -44,14 +49,31 @@ def load_catalog() -> list:
         return json.load(f)
 
 
-def save_catalog(catalog: list) -> None:
-    """Save catalog back to JSON."""
+def save_catalog(catalog: list, dry_run: bool = True) -> None:
+    """Save catalog back to JSON (or preview in dry-run mode)."""
+    if dry_run:
+        logger.info(f"[DRY-RUN] Would save catalog to {CATALOG_PATH}")
+        logger.info(f"[DRY-RUN] Use --apply to actually write changes")
+        return
+
+    # Create backup before writing
+    backup_path = CATALOG_PATH.with_suffix(".json.bak")
+    if CATALOG_PATH.exists():
+        import shutil
+        shutil.copy2(CATALOG_PATH, backup_path)
+        logger.info(f"Backup saved to {backup_path}")
+
     with open(CATALOG_PATH, "w", encoding="utf-8") as f:
         json.dump(catalog, f, indent=2, ensure_ascii=False)
     logger.info(f"Saved catalog to {CATALOG_PATH}")
 
 
-def refresh_catalog(fetch_videos: bool = True, fetch_all: bool = False, delta_only: bool = False) -> None:
+def refresh_catalog(
+    fetch_videos: bool = True,
+    fetch_all: bool = False,
+    delta_only: bool = False,
+    dry_run: bool = True
+) -> None:
     """
     Refresh catalog with channel info and optionally videos.
 
@@ -59,6 +81,7 @@ def refresh_catalog(fetch_videos: bool = True, fetch_all: bool = False, delta_on
         fetch_videos: If True, fetch latest videos for each channel
         fetch_all: If True and fetch_videos, fetch ALL videos (quota heavy)
         delta_only: If True, only fetch videos newer than most recent in catalog
+        dry_run: If True (default), only preview changes without writing
     """
     catalog = load_catalog()
     if not catalog:
@@ -141,8 +164,9 @@ def refresh_catalog(fetch_videos: bool = True, fetch_all: bool = False, delta_on
     logger.info(f"\nUpdated {updated} entries")
 
     # Add refresh timestamp
-    save_catalog(catalog)
-    logger.info(f"Catalog refreshed at {datetime.now().isoformat()}")
+    save_catalog(catalog, dry_run=dry_run)
+    if not dry_run:
+        logger.info(f"Catalog refreshed at {datetime.now().isoformat()}")
 
 
 def main():
@@ -151,24 +175,31 @@ def main():
     parser.add_argument("--full", action="store_true", help="Fetch ALL videos (quota heavy)")
     parser.add_argument("--info-only", action="store_true", help="Only fetch channel info (cheap) - RUN ONCE")
     parser.add_argument("--delta", action="store_true", help="Only fetch NEW videos since last run (efficient)")
+    parser.add_argument("--apply", action="store_true", help="Actually write changes (default is dry-run)")
     args = parser.parse_args()
 
+    dry_run = not args.apply
+    mode_suffix = "" if args.apply else " [DRY-RUN]"
+
     if args.info_only:
-        logger.info("Mode: Info only (avatars + counts) - ~13 quota units")
-        refresh_catalog(fetch_videos=False)
+        logger.info(f"Mode: Info only (avatars + counts) - ~13 quota units{mode_suffix}")
+        refresh_catalog(fetch_videos=False, dry_run=dry_run)
     elif args.delta:
-        logger.info("Mode: Delta (new videos only) - ~1300 quota units max")
-        refresh_catalog(fetch_videos=True, delta_only=True)
+        logger.info(f"Mode: Delta (new videos only) - ~1300 quota units max{mode_suffix}")
+        refresh_catalog(fetch_videos=True, delta_only=True, dry_run=dry_run)
     elif args.full:
-        logger.info("Mode: Full refresh (ALL videos - quota heavy!)")
-        response = input("This will use significant quota. Continue? [y/N] ")
-        if response.lower() == 'y':
-            refresh_catalog(fetch_videos=True, fetch_all=True)
+        logger.info(f"Mode: Full refresh (ALL videos - quota heavy!){mode_suffix}")
+        if dry_run:
+            logger.info("[DRY-RUN] Would fetch all videos. Use --apply to execute.")
         else:
-            logger.info("Aborted")
+            response = input("This will use significant quota. Continue? [y/N] ")
+            if response.lower() == 'y':
+                refresh_catalog(fetch_videos=True, fetch_all=True, dry_run=dry_run)
+            else:
+                logger.info("Aborted")
     else:
-        logger.info("Mode: Standard refresh (50 latest videos per channel)")
-        refresh_catalog(fetch_videos=True, fetch_all=False)
+        logger.info(f"Mode: Standard refresh (50 latest videos per channel){mode_suffix}")
+        refresh_catalog(fetch_videos=True, fetch_all=False, dry_run=dry_run)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Adds channel-logo-backed pfMALL tiles, true YouTube channel counts, and safety hardening for density controls.

## Scope
- Fetches YouTube channel avatars and true video counts via Data API helper
- Prioritizes channel_avatar_url for FoundUp tiles
- Keeps channel logos contained while preserving cover behavior for video thumbnails
- Adds quota-aware catalog refresh tooling
- Hardens density controls with device policy gates so AI/RedDog cannot force desktop presets on phones
- Makes catalog refresh dry-run by default and requires explicit apply for mutation

## Safety
- Phone/coarse-pointer layouts remain mobile-safe
- Desktop presets only apply on eligible desktop/fine-pointer viewports
- Rejected density requests return an explicit reason
- /kosei and other non-video surfaces are not part of this change

## Test plan
- [x] 373 tests passed
- [x] `python -m pytest public/member/tests/test_video_mall_field_runtime.py public/member/tests/test_mall_tile_field.py public/member/tests/test_reddog_mall_controls_phase1.py -q`

🤖 Generated with [Claude Code](https://claude.ai/code)