### PR TITLE
docs(hermes): add real extraction sandbox report

### DIFF
--- a/docs/0102_session_briefings/DE_HERMES_REAL_EXTRACTION_SANDBOX_PHASE1.md
+++ b/docs/0102_session_briefings/DE_HERMES_REAL_EXTRACTION_SANDBOX_PHASE1.md
@@ -1,0 +1,164 @@
+# DE - Hermes Real Extraction Sandbox Phase 1
+
+## Summary
+- Target: modules/foundups/gotjunk
+- Sandbox path: /o/tmp/de_sandbox/gotjunk_extraction
+- Mode: disposable temp clone + git filter-repo
+- Live working tree mutated: NO
+- GitHub repo created: NO
+- GitHub push: NO
+
+## Command Sequence
+
+```bash
+# Step 1: Create disposable temp clone
+mkdir -p /o/tmp/de_sandbox
+cd /o/tmp/de_sandbox
+rm -rf gotjunk_extraction 2>/dev/null
+git clone --no-hardlinks "o:/Foundups-Agent" gotjunk_extraction
+
+# Step 2: Verify target exists
+ls -la gotjunk_extraction/modules/foundups/gotjunk/
+
+# Step 3: Run git filter-repo extraction
+cd gotjunk_extraction
+git filter-repo --subdirectory-filter modules/foundups/gotjunk --force
+
+# Step 4: Verify extraction
+ls -la
+git rev-list --count HEAD
+git log --oneline -10
+
+# Step 5: Verify live tree unchanged
+cd /o/Foundups-Agent
+git status --short
+```
+
+## Source State
+- Source repo path: o:/Foundups-Agent
+- Source branch: main
+- Source commit: 5c67a5a5e (at clone time, synced to 21271503d by report time)
+- Total commits parsed: 1349
+
+## Extraction Result
+- git filter-repo command: `git filter-repo --subdirectory-filter modules/foundups/gotjunk --force`
+- Runtime: 6.13s
+- Preserved commits: 239
+- Extracted repo size: 2.4M
+- GotJunk root files/directories:
+  - README.md
+  - INTERFACE.md
+  - foundup_manifest.json
+  - module.json
+  - src/
+  - tests/
+  - frontend/
+  - backend/
+  - adapters/
+  - deployment/
+  - docs/
+  - skillz/
+
+## Verification
+
+### Root tree listing
+```
+total 327
+-rw-r--r-- 1 user    73 .firebaserc
+-rw-r--r-- 1 user  6219 ARCHITECTURE_REDESIGN.md
+-rw-r--r-- 1 user  3396 CRITICAL_REQUIREMENTS.md
+-rw-r--r-- 1 user  6859 DAEMON_MONITORING.md
+-rw-r--r-- 1 user  4114 DEPLOYMENT.md
+-rw-r--r-- 1 user  6298 DEPLOYMENT_GUIDE.md
+-rw-r--r-- 1 user  5506 DEPLOY_NOW.md
+-rw-r--r-- 1 user 18388 FIREBASE_AUTH_GAPS_ANALYSIS.md
+-rw-r--r-- 1 user  3029 FORCE_REBUILD.md
+-rw-r--r-- 1 user 11351 GLOBE_VIEW_ARCHITECTURE.md
+-rw-r--r-- 1 user 18887 GOTJUNK_DAEMON_ARCHITECTURE.md
+-rw-r--r-- 1 user  9469 INTERFACE.md
+-rw-r--r-- 1 user 10951 LIBERTY_ALERT_INTEGRATION_PLAN.md
+-rw-r--r-- 1 user  8779 LIBERTY_ALERT_INTEGRATION_STATUS.md
+-rw-r--r-- 1 user 13238 LIBERTY_ALERT_REACT_WEBRTC_ARCHITECTURE.md
+-rw-r--r-- 1 user  5844 LIBERTY_INTEGRATION_WSP_COMPLIANT.md
+-rw-r--r-- 1 user  9079 MAP_ARCHITECTURE.md
+-rw-r--r-- 1 user 70245 ModLog.md
+-rw-r--r-- 1 user  9019 README.md
+-rw-r--r-- 1 user  8056 ROADMAP.md
+-rw-r--r-- 1 user  3753 SECURITY.md
+-rw-r--r-- 1 user  9316 WALLET_ARCHITECTURE.md
+drwxr-xr-x adapters/
+drwxr-xr-x backend/
+-rw-r--r-- 1 user  2277 cloudbuild.yaml
+drwxr-xr-x deployment/
+drwxr-xr-x docs/
+-rw-r--r-- 1 user   155 firebase.json
+-rw-r--r-- 1 user   790 firestore.indexes.json
+-rw-r--r-- 1 user  6410 firestore.rules
+-rw-r--r-- 1 user  1021 foundup_manifest.json
+drwxr-xr-x frontend/
+-rw-r--r-- 1 user  1070 module.json
+drwxr-xr-x skillz/
+drwxr-xr-x src/
+-rw-r--r-- 1 user   410 storage.rules
+drwxr-xr-x tests/
+```
+
+### Git log sample (recent 10 commits)
+```
+922825e Merge pull request #354 from FOUNDUPS/feat/hermes-agent-integration
+563b886 feat(foundups): add gotjunk exfoliation tests and WRE adapter
+ae4441b fix(foundups): unblock gotjunk shell embed (#325)
+0e7c656 Merge pull request #323 from FOUNDUPS/bp/foundup-ai-hooks-daemon-contract
+f57c0da docs(foundups): require ai hooks and daemon output contract
+000f413 Merge pull request #317 from FOUNDUPS/feat/gotjunk-real-app-binding
+1df4ba7 fix(foundups): revert gotjunk entry_url - X-Frame-Options blocks iframe
+5b70162 feat(foundups): bind gotjunk to canonical app mount
+0be1f1e Merge pull request #259 from FOUNDUPS/sync/main-95-commits-20260403-071151
+ee030a8 feat(foundups): harden pfmall manifest readiness metadata
+```
+
+### Live tree status before/after
+Before extraction: clean (only screenshot/news caches untracked)
+After extraction: unchanged - same caches only (at extraction time):
+```
+?? modules/platform_integration/antifafm_broadcaster/skillz/gcc_shipping_tracker/screenshot_cache/gulf_tankers_20260413_102222.png
+?? modules/platform_integration/antifafm_broadcaster/skillz/gcc_shipping_tracker/screenshot_cache/gulf_tankers_20260413_141902.png
+?? modules/platform_integration/antifafm_broadcaster/skillz/news_maps/cache/
+```
+
+Note: After PR #364 merged, the cache paths are now gitignored and `git status --short` on main shows only this report as untracked.
+
+### No remotes added or pushed
+- git filter-repo removed origin remote automatically (expected behavior)
+- No new remotes configured
+- No push commands executed
+
+## What This Proves
+- `git filter-repo --subdirectory-filter modules/foundups/gotjunk` can extract GotJunk with history into a standalone repo.
+- The extracted repo is lightweight (2.4M) and structurally coherent enough for the next gate.
+- 239 commits (17.7% of 1349 parsed) were relevant to gotjunk and preserved.
+- All expected FoundUp artifacts present: manifests, frontend, backend, tests, docs, skillz.
+
+## What This Does Not Prove
+- No production externalization.
+- No remote repository binding.
+- No deploy readiness.
+- No CI portability verification.
+- No secrets/config audit beyond the sandbox checks performed.
+
+## Next Gates
+- Orphaned import scan (verify no dangling cross-module imports).
+- Secrets/config scan (verify no .env or credentials committed).
+- Standalone test run inside extracted repo.
+- Remote binding decision (GitHub org, repo name, visibility).
+- Backup repo strategy.
+- Manifest/catalog update only after remote exists.
+
+## WSP 97 Statement
+This report proves sandbox extraction only. It does not claim external FoundUp production readiness, remote availability, or deployment.
+
+---
+
+**Generated**: 2026-04-17T16:58:00Z  
+**Sandbox**: /o/tmp/de_sandbox/gotjunk_extraction  
+**Agent**: 0102 (Claude Opus 4.5)


### PR DESCRIPTION
## Summary
- DE Phase 1 sandbox proof for GotJunk extraction via `git filter-repo --subdirectory-filter`
- 239 commits preserved (17.7% of 1349 parsed), 2.4M standalone repo
- Live tree: unchanged. No GitHub remote created, no push executed
- Next gates documented: orphaned imports scan, secrets scan, standalone test run, remote binding decision

## Files
- `docs/0102_session_briefings/DE_HERMES_REAL_EXTRACTION_SANDBOX_PHASE1.md` (164 lines, ASCII clean)

## Test plan
- [x] File is ASCII clean (`file` + `git diff --check` pass)
- [x] Only the DE report is included — no stream-resolver or runtime artifacts
- [x] WSP 97 compliant — no overclaiming of deployment readiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)