### PR TITLE
fix(stream-resolver): harden YouTube truth signaling

### DIFF
--- a/modules/platform_integration/stream_resolver/INTERFACE.md
+++ b/modules/platform_integration/stream_resolver/INTERFACE.md
@@ -98,6 +98,66 @@ except QuotaExceededError:
     print("YouTube API quota exceeded")
 ```
 
+## Service Caching (WSP 97 Truth Signal Hardening)
+
+### StreamResolver Service Cache
+The `StreamResolver` class caches authenticated YouTube API services per credential set to avoid rebuilding services on every verification call.
+
+**Methods:**
+- `_get_cached_authenticated_service(credential_set=None)`: Returns cached service or builds and caches a new one
+- `_invalidate_cached_authenticated_service(service=None)`: Drops cached services after quota/auth failures
+
+**Behavior:**
+- First call builds and caches the service
+- Subsequent calls return cached service (DEBUG log: "Reusing cached YouTube service")
+- On quota/auth error, cache is invalidated to allow rotation
+
+### NoQuotaStreamChecker Service Cache
+The `NoQuotaStreamChecker` class also caches its authenticated YouTube service.
+
+**Methods:**
+- `_get_authenticated_youtube_service()`: Returns cached service or builds and caches a new one
+- `_invalidate_youtube_service_cache(service=None)`: Drops cached services after quota/auth failures
+
+## Request Timeout Configuration
+
+**Environment Variable:** `YT_STREAM_REQUEST_TIMEOUT_SEC`
+- **Default:** 30 seconds
+- **Minimum:** 5 seconds (clamped)
+- **Maximum:** 120 seconds (clamped)
+- **Fallback:** Malformed, zero, or negative values fall back to 30
+
+**Parsing:** `NoQuotaStreamChecker._parse_timeout_env()` validates and clamps the value safely.
+
+## Stale Indicator Handling
+
+When live-looking DOM indicators are found but no verified live stream exists, a structured `stale_indicator` result is returned:
+
+```python
+{
+    "live": False,
+    "status": "stale_indicator",
+    "confidence": 0.3,
+    "source": "no_quota_live_page" | "no_quota_streams_page",
+    "channel_id": "...",
+    "channel_name": "...",
+    "indicator_count": N
+}
+```
+
+**Behavior:**
+- `/live` page with stale indicators returns immediately (does not fall through to `/streams`)
+- This is intentional: if `/live` shows stale indicators, `/streams` likely has the same issue
+- Callers can check `result.get("status") == "stale_indicator"` to distinguish from verified non-live
+
+## Channel Mismatch (Recommended Content)
+
+When a video's channel ID doesn't match the target channel, it's treated as expected recommended content:
+- Logged at DEBUG level with `[RECOMMENDED]` prefix
+- Not logged as warning/error
+- Skipped in verification loop
+- Evidence preserved in `source`, `target_channel_id`, `observed_channel_id` fields
+
 ## Dependencies
 - googleapiclient.discovery
 - googleapiclient.errors

--- a/modules/platform_integration/stream_resolver/ModLog.md
+++ b/modules/platform_integration/stream_resolver/ModLog.md
@@ -12,6 +12,55 @@ This log tracks changes specific to the **stream_resolver** module in the **plat
 
 ## MODLOG ENTRIES
 
+### 2026-04-18 - Truth Signal Hardening (Worker SR1)
+
+**By:** 0102 - Worker SR1
+**WSP References:** WSP 97 (Truthful Guarantees), WSP 91 (Observability), WSP 22 (ModLog)
+
+**Problem:** Stream resolver had poor truth signaling:
+- YouTube services rebuilt repeatedly per verification call
+- Channel mismatch logged as warning (but recommended content is expected)
+- Live-looking DOM indicators could be stale
+- Request timeout not configurable
+- Some tests hit real auth/network paths
+
+**Changes:**
+
+1. **Service Caching (StreamResolver + NoQuotaStreamChecker)**
+   - `_get_cached_authenticated_service()` / `_get_authenticated_youtube_service()`
+   - `_invalidate_cached_authenticated_service()` / `_invalidate_youtube_service_cache()`
+   - Cache by credential set, invalidate on quota/auth failure
+
+2. **Timeout Configuration**
+   - Env: `YT_STREAM_REQUEST_TIMEOUT_SEC` (default 30, clamped 5-120)
+   - `_parse_timeout_env()` handles malformed, zero, negative values safely
+
+3. **Stale Indicator Handling**
+   - `_live_indicator_result()` returns structured non-live result
+   - `{live: false, status: "stale_indicator", confidence: 0.3, ...}`
+   - `/live` stale does NOT fall through to `/streams` (intentional: same issue likely)
+
+4. **Channel Mismatch Reclassified**
+   - Recommended streams from other channels logged at DEBUG with `[RECOMMENDED]`
+   - Not warning/error (this is expected behavior)
+   - Evidence preserved in result metadata
+
+5. **Progress Visibility**
+   - Log before channel/video scraping starts with timeout
+   - Log elapsed time for slow requests (>=8s)
+
+**Tests Added:**
+- `test_api_verification_reuses_cached_service`
+- `test_channel_mismatch_is_recommended_debug_not_warning`
+- `test_stale_indicator_returned_when_live_dom_has_no_verified_stream`
+- `test_timeout_env_parsing_invalid_falls_back`
+- `test_timeout_env_parsing_negative_falls_back`
+- `test_timeout_env_parsing_clamps_to_max`
+
+**Test Results:** 36/36 passed (23 no_quota_stream_checker + 13 anti_rate_limit)
+
+---
+
 ### 2026-02-06 - Vision Refactored to Verification-Only (Architecture Fix)
 
 **By:** 0102

--- a/modules/platform_integration/stream_resolver/src/no_quota_stream_checker.py
+++ b/modules/platform_integration/stream_resolver/src/no_quota_stream_checker.py
@@ -87,6 +87,8 @@ class NoQuotaStreamChecker:
 
         self.channel_cooldowns = {}
         self.last_rate_limit = None
+        self.request_timeout_sec = self._parse_timeout_env()
+        self._youtube_service_cache = {}
         
         # CAPTCHA defense: Global cooldown mode
         self.captcha_cooldown_until = None
@@ -94,6 +96,31 @@ class NoQuotaStreamChecker:
         self.max_videos_to_check = 3  # Dynamically reduced on CAPTCHA
 
         logger.info("[INFO] NO-QUOTA stream checker initialized")
+
+    @staticmethod
+    def _parse_timeout_env() -> float:
+        """Parse YT_STREAM_REQUEST_TIMEOUT_SEC safely with fallback and clamping."""
+        default = 30.0
+        min_timeout = 5.0
+        max_timeout = 120.0
+        raw = os.getenv("YT_STREAM_REQUEST_TIMEOUT_SEC", "")
+        if not raw:
+            return default
+        try:
+            val = float(raw)
+            if val <= 0:
+                logger.warning("[CONFIG] YT_STREAM_REQUEST_TIMEOUT_SEC=%s is non-positive; using default %.0f", raw, default)
+                return default
+            if val < min_timeout:
+                logger.warning("[CONFIG] YT_STREAM_REQUEST_TIMEOUT_SEC=%.0f below minimum; clamping to %.0f", val, min_timeout)
+                return min_timeout
+            if val > max_timeout:
+                logger.warning("[CONFIG] YT_STREAM_REQUEST_TIMEOUT_SEC=%.0f above maximum; clamping to %.0f", val, max_timeout)
+                return max_timeout
+            return val
+        except ValueError:
+            logger.warning("[CONFIG] YT_STREAM_REQUEST_TIMEOUT_SEC=%s is invalid; using default %.0f", raw, default)
+            return default
 
     def _get_live_verifier(self):
         """Lazy-load LiveStatusVerifier to avoid circular dependency during initialization"""
@@ -138,7 +165,7 @@ class NoQuotaStreamChecker:
 
     @staticmethod
     def _looks_like_captcha(text: str) -> bool:
-        if not text:
+        if not text or not isinstance(text, str):
             return False
         lowered = text.lower()
         return ("google.com/sorry" in lowered) or ("www.google.com/sorry" in lowered)
@@ -166,10 +193,10 @@ class NoQuotaStreamChecker:
         # Increased default delays from 8-15s to 10-18s to reduce CAPTCHA triggers
         base_delay = random.uniform(min_delay, max_delay)
         delay = min(base_delay * max(multiplier, 1.0), 60.0)
-        if _env_truthy("STREAM_VERBOSE_LOGS", "false"):
-            logger.info(f"[RATE-LIMIT] Backoff delay: {delay:.1f}s")
+        if _env_truthy("STREAM_VERBOSE_LOGS", "false") or delay >= 8.0:
+            logger.info(f"[NO-QUOTA] Scrape backoff delay: {delay:.1f}s")
         else:
-            logger.debug(f"[RATE-LIMIT] Backoff delay: {delay:.1f}s")
+            logger.debug(f"[NO-QUOTA] Scrape backoff delay: {delay:.1f}s")
         time.sleep(delay)
 
     def _is_channel_rate_limited(self, channel_id: str):
@@ -246,6 +273,48 @@ class NoQuotaStreamChecker:
                 self.max_videos_to_check = 3  # Fully restore
                 logger.info("[CAPTCHA] Backoff state reset after successful requests")
 
+    def _get_authenticated_youtube_service(self):
+        """Return a cached YouTube service for this checker process."""
+        cached = self._youtube_service_cache.get("auto")
+        if cached is not None:
+            credential_set = getattr(cached, "_credential_set", "auto")
+            logger.debug("[API] Reusing cached YouTube service for credential set %s", credential_set)
+            return cached
+
+        from modules.platform_integration.youtube_auth.src.youtube_auth import get_authenticated_service
+
+        service = get_authenticated_service()
+        if service is not None:
+            credential_set = getattr(service, "_credential_set", "auto")
+            self._youtube_service_cache["auto"] = service
+            self._youtube_service_cache[credential_set] = service
+            logger.info("[API] Cached YouTube service for credential set %s", credential_set)
+        return service
+
+    def _invalidate_youtube_service_cache(self, service=None) -> None:
+        """Drop cached API services after quota/auth failures so rotation can retry."""
+        if service is None:
+            self._youtube_service_cache.clear()
+            return
+
+        for key, cached in list(self._youtube_service_cache.items()):
+            if cached is service:
+                self._youtube_service_cache.pop(key, None)
+
+    @staticmethod
+    def _live_indicator_result(channel_id: str, channel_name: Optional[str], source: str, indicator_count: int) -> Dict[str, Any]:
+        """Truthful result for live-looking DOM state without a verified live stream."""
+        display_name = channel_name or channel_id
+        return {
+            "live": False,
+            "status": "stale_indicator",
+            "confidence": 0.3,
+            "source": source,
+            "channel_id": channel_id,
+            "channel_name": display_name,
+            "indicator_count": indicator_count,
+        }
+
     def check_video_is_live(self, video_id: str, channel_name: str = None, scraping_prefilter: bool = True) -> Dict[str, Any]:
         """
         Efficient hybrid verification: Scraping first, API only for confirmation
@@ -292,7 +361,16 @@ class NoQuotaStreamChecker:
                 headers = self._get_random_headers()
 
                 # Use session to enable retry strategy with exponential backoff
-                response = self.session.get(url, headers=headers, timeout=15)
+                logger.info(
+                    "[NO-QUOTA] Checking video %s... (scraping, timeout=%.0fs)",
+                    video_id,
+                    self.request_timeout_sec,
+                )
+                request_start = time.time()
+                response = self.session.get(url, headers=headers, timeout=self.request_timeout_sec)
+                elapsed = time.time() - request_start
+                if elapsed >= 8.0:
+                    logger.info("[NO-QUOTA] Video scrape completed after %.1fs for %s", elapsed, video_id)
 
                 # Detect CAPTCHA redirect to Google sorry page
                 captcha_hit = False
@@ -380,9 +458,7 @@ class NoQuotaStreamChecker:
 
         try:
             # Direct API call without going through LiveStatusVerifier to avoid circular dependency
-            from modules.platform_integration.youtube_auth.src.youtube_auth import get_authenticated_service
-
-            youtube_service = get_authenticated_service()
+            youtube_service = self._get_authenticated_youtube_service()
             request = youtube_service.videos().list(
                 part="snippet,liveStreamingDetails",
                 id=video_id
@@ -414,6 +490,7 @@ class NoQuotaStreamChecker:
             if any(phrase in error_str for phrase in ['quota', 'limit exceeded', 'daily limit', 'rate limit']):
                 logger.warning(f"[U+26A0] API quota exhausted during verification: {e}")
                 logger.info(f"[QUOTA] Returning rate_limited status to trigger rotation upstream")
+                self._invalidate_youtube_service_cache(locals().get("youtube_service"))
                 return {"live": False, "rate_limited": True, "method": "api", "error": str(e)}
             else:
                 if scraping_indicated_live:
@@ -439,7 +516,16 @@ class NoQuotaStreamChecker:
             headers = self._get_random_headers()
 
             # Use session to enable retry strategy with exponential backoff
-            response = self.session.get(url, headers=headers, timeout=15)
+            logger.info(
+                "[NO-QUOTA] Checking video %s with comprehensive scrape... (timeout=%.0fs)",
+                video_id,
+                self.request_timeout_sec,
+            )
+            request_start = time.time()
+            response = self.session.get(url, headers=headers, timeout=self.request_timeout_sec)
+            elapsed = time.time() - request_start
+            if elapsed >= 8.0:
+                logger.info("[NO-QUOTA] Comprehensive scrape completed after %.1fs for %s", elapsed, video_id)
 
             # Detect CAPTCHA redirect to Google sorry page
             if 'google.com/sorry' in response.url or 'www.google.com/sorry' in response.url:
@@ -824,6 +910,12 @@ class NoQuotaStreamChecker:
                 logger.info("[SEARCH] NO-QUOTA CHANNEL CHECK")
                 logger.info(f"  - Channel ID: {channel_id}")
                 logger.info(f"  - Trying URL: {live_url}")
+                display_name = channel_name or channel_id
+                logger.info(
+                    "[NO-QUOTA] Checking %s... (scraping, timeout=%.0fs)",
+                    display_name,
+                    self.request_timeout_sec,
+                )
 
                 # Anti-detection measures for channel check
                 self._anti_detection_delay()
@@ -831,7 +923,11 @@ class NoQuotaStreamChecker:
 
                 # Use session with retry strategy for better rate limit handling
                 # Important: do NOT follow redirects to watch pages (high CAPTCHA risk).
-                response = self.session.get(live_url, headers=headers, timeout=15, allow_redirects=False)
+                request_start = time.time()
+                response = self.session.get(live_url, headers=headers, timeout=self.request_timeout_sec, allow_redirects=False)
+                elapsed = time.time() - request_start
+                if elapsed >= 8.0:
+                    logger.info("[NO-QUOTA] Channel scrape completed after %.1fs for %s", elapsed, display_name)
 
                 if response.status_code == 429:
                     cooldown = self._register_rate_limit(channel_id, channel_name)
@@ -872,6 +968,17 @@ class NoQuotaStreamChecker:
                     logger.info(f"  - Status Code: {response.status_code}")
                 else:
                     logger.debug(f"[SEARCH] response_url={response.url} status={response.status_code}")
+
+                response_video_id = self._extract_video_id(getattr(response, "url", ""))
+                if response_video_id:
+                    display_name = channel_name or channel_id
+                    logger.info(f"[VIDEO] /live resolved to video for {display_name}: {response_video_id}")
+                    result = self.check_video_is_live(response_video_id, channel_name, scraping_prefilter=False)
+                    if isinstance(result, dict) and result.get("rate_limited"):
+                        return result
+                    if result and result.get("live"):
+                        return result
+                    continue
 
                 # Check if we're on the channel page
                 if response.status_code == 200:
@@ -1007,8 +1114,14 @@ class NoQuotaStreamChecker:
                                     found_cid = result.get('channel_id')
                                     if found_cid and channel_id.startswith('UC') and len(channel_id) == 24:
                                         if found_cid != channel_id:
-                                            logger.warning(f"[MISMATCH] Found live stream but channel ID mismatch: {found_cid} != {channel_id}")
-                                            logger.info(f"[MISMATCH] This is likely a recommended stream from another channel. Skipping.")
+                                            result["source"] = "recommended"
+                                            result["target_channel_id"] = channel_id
+                                            result["observed_channel_id"] = found_cid
+                                            logger.debug(
+                                                "[RECOMMENDED] Live candidate from %s while checking %s; skipping expected recommendation",
+                                                found_cid,
+                                                channel_id,
+                                            )
                                             continue
                                             
                                     logger.info(f"[SUCCESS] Video {video_id} is LIVE!")
@@ -1046,7 +1159,13 @@ class NoQuotaStreamChecker:
 
                             # No videos verified and no CAPTCHA trust possible
                             logger.info(f"[SKIP] Found video IDs but none verified as actually live")
-                            logger.info(f"[INFO] Page had live indicators but videos are not live (stale page?)")
+                            logger.info(f"[STALE] Page had live indicators but no verified live stream")
+                            return self._live_indicator_result(
+                                channel_id,
+                                channel_name,
+                                "no_quota_live_page",
+                                indicator_count,
+                            )
 
             except Exception as e:
                 logger.error(f"Error checking URL {live_url}: {e}")
@@ -1065,7 +1184,17 @@ class NoQuotaStreamChecker:
                 headers = self._get_random_headers()
 
                 # Use session with retry strategy for better rate limit handling
-                response = self.session.get(streams_url, headers=headers, timeout=15, allow_redirects=False)
+                display_name = channel_name or channel_id
+                logger.info(
+                    "[NO-QUOTA] Checking %s streams tab... (scraping, timeout=%.0fs)",
+                    display_name,
+                    self.request_timeout_sec,
+                )
+                request_start = time.time()
+                response = self.session.get(streams_url, headers=headers, timeout=self.request_timeout_sec, allow_redirects=False)
+                elapsed = time.time() - request_start
+                if elapsed >= 8.0:
+                    logger.info("[NO-QUOTA] Streams scrape completed after %.1fs for %s", elapsed, display_name)
 
                 if response.status_code == 429:
                     cooldown = self._register_rate_limit(channel_id, channel_name)
@@ -1152,6 +1281,14 @@ class NoQuotaStreamChecker:
                             logger.info("  - No videos found on streams page")
                         else:
                             logger.debug("[STREAMS] No videos found on streams page")
+                        indicator_count = sum([has_is_live_now, has_live_badge, has_watching, has_live_text])
+                        logger.info("[STALE] Streams tab had live indicators but no video IDs")
+                        return self._live_indicator_result(
+                            channel_id,
+                            channel_name,
+                            "no_quota_streams_page",
+                            indicator_count,
+                        )
 
                     if skip_api and videos_to_check:
                         display_name = channel_name or channel_id
@@ -1199,8 +1336,14 @@ class NoQuotaStreamChecker:
                             found_cid = result.get('channel_id')
                             if found_cid and channel_id.startswith('UC') and len(channel_id) == 24:
                                 if found_cid != channel_id:
-                                    logger.warning(f"[MISMATCH] Found live stream but channel ID mismatch: {found_cid} != {channel_id}")
-                                    logger.info(f"[MISMATCH] This is likely a recommended stream from another channel. Skipping.")
+                                    result["source"] = "recommended"
+                                    result["target_channel_id"] = channel_id
+                                    result["observed_channel_id"] = found_cid
+                                    logger.debug(
+                                        "[RECOMMENDED] Live candidate from %s while checking %s; skipping expected recommendation",
+                                        found_cid,
+                                        channel_id,
+                                    )
                                     continue
                                     
                             # Add channel name to result for better logging
@@ -1224,6 +1367,16 @@ class NoQuotaStreamChecker:
                             "source": "api_failure_trust",
                             "indicator_count": indicator_count,
                         }
+
+                    if videos_to_check:
+                        indicator_count = sum([has_is_live_now, has_live_badge, has_watching, has_live_text])
+                        logger.info("[STALE] Streams tab had live indicators but no verified live stream")
+                        return self._live_indicator_result(
+                            channel_id,
+                            channel_name,
+                            "no_quota_streams_page",
+                            indicator_count,
+                        )
 
             except Exception as e:
                 error_text = str(e)

--- a/modules/platform_integration/stream_resolver/src/stream_resolver.py
+++ b/modules/platform_integration/stream_resolver/src/stream_resolver.py
@@ -181,6 +181,7 @@ class StreamResolver:
         self._quota_tester = QuotaTester() if QuotaTester and use_intelligent_sorting else None
         self._tested_credentials = set()
         self._cache = {}
+        self._api_service_cache = {}
         self._last_stream_check = {}
 
         # QWEN Intelligence - Use existing superior implementation (lazy import to avoid circular dependency)
@@ -333,13 +334,14 @@ class StreamResolver:
                 continue  # Skip already tested in this session
                 
             try:
+                cached_service = self._api_service_cache.get(cred_set)
+                if cached_service is not None:
+                    self.logger.debug("[API] Reusing cached YouTube service for credential set %s", cred_set)
+                    self._tested_credentials.add(cred_set)
+                    return cached_service, cred_set
+
                 self.logger.info(f"Testing credential set {cred_set}...")
-                from modules.platform_integration.youtube_auth.src.youtube_auth import get_authenticated_service
-                
-                service, actual_set = get_authenticated_service(
-                    force_credential_set=cred_set,
-                    skip_validation=False
-                )
+                service, actual_set = self._get_cached_authenticated_service(cred_set)
                 
                 if service:
                     self.logger.info(f"[SUCCESS] Using credential set {cred_set} with available quota")
@@ -353,6 +355,53 @@ class StreamResolver:
         
         self.logger.error("[ERROR] All recommended credentials failed")
         return None, None
+
+    def _normalize_authenticated_service_result(self, auth_result, requested_set=None):
+        """Normalize auth helpers that return either service or tuple variants."""
+        if isinstance(auth_result, tuple):
+            service = auth_result[0] if auth_result else None
+            actual_set = auth_result[1] if len(auth_result) > 1 else requested_set
+        else:
+            service = auth_result
+            actual_set = getattr(service, "_credential_set", requested_set) if service is not None else requested_set
+        return service, actual_set
+
+    def _get_cached_authenticated_service(self, credential_set=None):
+        """Return a cached authenticated service by credential set or auto-rotation."""
+        cache_key = credential_set if credential_set is not None else "auto"
+        cached = self._api_service_cache.get(cache_key)
+        if cached is not None:
+            actual_set = getattr(cached, "_credential_set", credential_set)
+            self.logger.debug("[API] Reusing cached YouTube service for credential set %s", actual_set or cache_key)
+            return cached, actual_set
+
+        from modules.platform_integration.youtube_auth.src.youtube_auth import get_authenticated_service
+
+        if credential_set is None:
+            auth_result = get_authenticated_service()
+        else:
+            auth_result = get_authenticated_service(token_index=credential_set)
+        service, actual_set = self._normalize_authenticated_service_result(auth_result, credential_set)
+
+        if service is not None:
+            actual_key = actual_set if actual_set is not None else getattr(service, "_credential_set", cache_key)
+            try:
+                service._credential_set = actual_key
+            except Exception:
+                pass
+            self._api_service_cache[cache_key] = service
+            self._api_service_cache[actual_key] = service
+            self.logger.info("[API] Cached YouTube service for credential set %s", actual_key)
+        return service, actual_set
+
+    def _invalidate_cached_authenticated_service(self, service=None) -> None:
+        """Drop cached API services after quota/auth failures so rotation can retry."""
+        if service is None:
+            self._api_service_cache.clear()
+            return
+        for key, cached in list(self._api_service_cache.items()):
+            if cached is service:
+                self._api_service_cache.pop(key, None)
     
     def _load_session_cache(self):
         """Load cached session data using SessionUtils from infrastructure."""
@@ -402,15 +451,14 @@ class StreamResolver:
         self.logger.info("="*60)
         
         # Try up to 3 credential sets (auto-rotation built into get_authenticated_service)
-        from modules.platform_integration.youtube_auth.src.youtube_auth import get_authenticated_service
-
         for attempt in range(3):
+            youtube_service = None
             try:
                 # Get fresh credentials via rotation (auto-rotates through available sets)
                 if attempt > 0:
                     self.logger.info(f"[CHAT-ID] Attempt {attempt + 1}: Retrying with credential rotation...")
 
-                youtube_service = get_authenticated_service()
+                youtube_service, _ = self._get_cached_authenticated_service()
                 if not youtube_service:
                     self.logger.warning(f"[CHAT-ID] Attempt {attempt + 1}: No credentials available")
                     continue
@@ -446,6 +494,7 @@ class StreamResolver:
                 error_str = str(e).lower()
                 if 'quota' in error_str or '403' in error_str or 'exceeded' in error_str:
                     self.logger.warning(f"[CHAT-ID] Quota exhausted on attempt {attempt + 1}, rotating...")
+                    self._invalidate_cached_authenticated_service(youtube_service)
                     continue
                 else:
                     self.logger.error(f"[CHAT-ID] Error fetching chat ID: {e}")

--- a/modules/platform_integration/stream_resolver/tests/TestModLog.md
+++ b/modules/platform_integration/stream_resolver/tests/TestModLog.md
@@ -1,6 +1,40 @@
 # Testing Evolution Log - Stream Resolver
 
-## LATEST UPDATE - 2025-12-22 No-API Stream Detection Coverage [OK]
+## LATEST UPDATE - 2026-04-18 Truth Signal Hardening (Worker SR1) [OK]
+
+### Test Run
+```bash
+python -m pytest modules/platform_integration/stream_resolver/tests/test_no_quota_stream_checker.py modules/platform_integration/stream_resolver/tests/test_no_quota_anti_rate_limit.py -v
+```
+
+### Results
+- `test_no_quota_stream_checker.py`: **23 passed** in 69s
+- `test_no_quota_anti_rate_limit.py`: **13 passed** in 10s
+- **Total: 36 passed**
+
+### New Tests Added
+| Test | Purpose |
+|------|---------|
+| `test_api_verification_reuses_cached_service` | Service cache hit on second API call |
+| `test_channel_mismatch_is_recommended_debug_not_warning` | Recommended streams log at DEBUG |
+| `test_stale_indicator_returned_when_live_dom_has_no_verified_stream` | Live DOM without verified stream → stale_indicator |
+| `test_timeout_env_parsing_invalid_falls_back` | Malformed env → default 30 |
+| `test_timeout_env_parsing_negative_falls_back` | Negative env → default 30 |
+| `test_timeout_env_parsing_clamps_to_max` | Excessive env → clamp to 120 |
+
+### Files Updated
+- `test_no_quota_stream_checker.py`: Added 6 new tests, fixed import paths
+- `test_no_quota_anti_rate_limit.py`: Updated mocks to avoid real auth/network
+
+### WSP 97 Coverage
+- Service cache reuse verified (no redundant builds)
+- Timeout parsing safety verified (fallback + clamp)
+- Stale indicator structure verified
+- Channel mismatch log level verified
+
+---
+
+## PREVIOUS UPDATE - 2025-12-22 No-API Stream Detection Coverage [OK]
 
 ### Test Additions
 - Added no-API indicator trust coverage for /live pages.

--- a/modules/platform_integration/stream_resolver/tests/test_no_quota_anti_rate_limit.py
+++ b/modules/platform_integration/stream_resolver/tests/test_no_quota_anti_rate_limit.py
@@ -154,16 +154,16 @@ class TestAntiRateLimiting(unittest.TestCase):
         channel_response = Mock()
         channel_response.status_code = 302
         channel_response.url = 'https://www.youtube.com/channel/test_channel_id/live'
-        channel_response.headers = {"Location": "/watch?v=live123"}
+        channel_response.headers = {"Location": "/watch?v=dQw4w9WgXcQ"}
         mock_get.return_value = channel_response
 
         with patch.object(self.checker, '_anti_detection_delay'), patch.object(self.checker, 'check_video_is_live') as mock_check_video:
-            mock_check_video.return_value = {"live": True, "video_id": "live123", "method": "api"}
+            mock_check_video.return_value = {"live": True, "video_id": "dQw4w9WgXcQ", "method": "api"}
             result = self.checker.check_channel_for_live('test_channel_id')
 
         self.assertIsNotNone(result)
         self.assertTrue(result.get("live"))
-        self.assertEqual(result.get("video_id"), "live123")
+        self.assertEqual(result.get("video_id"), "dQw4w9WgXcQ")
         self.assertFalse(mock_get.call_args[1].get("allow_redirects", True))
 
     def test_cookie_persistence(self):
@@ -185,9 +185,9 @@ class TestAntiRateLimiting(unittest.TestCase):
             with patch.object(self.checker, '_anti_detection_delay'):
                 self.checker.check_video_is_live('test_id')
 
-                # Check timeout is 15 seconds
+                # Check timeout matches the explicit channel/video request timeout
                 call_args = mock_get.call_args
-                self.assertEqual(call_args[1]['timeout'], 15)
+                self.assertEqual(call_args[1]['timeout'], self.checker.request_timeout_sec)
 
     @patch('requests.Session.get')
     def test_exponential_backoff_on_errors(self, mock_get):
@@ -217,7 +217,8 @@ class TestLiveStreamDetection(unittest.TestCase):
         self.checker = NoQuotaStreamChecker()
 
     @patch('requests.Session.get')
-    def test_live_stream_detection(self, mock_get):
+    @patch('modules.platform_integration.youtube_auth.src.youtube_auth.get_authenticated_service')
+    def test_live_stream_detection(self, mock_auth, mock_get):
         """Test detection of actually live streams"""
         # Mock response with live indicators
         mock_response = Mock()
@@ -234,7 +235,10 @@ class TestLiveStreamDetection(unittest.TestCase):
                 </script>
             </html>
         '''
+        mock_response.url = 'https://www.youtube.com/watch?v=live_video_id'
+        mock_response.headers = {}
         mock_get.return_value = mock_response
+        mock_auth.side_effect = RuntimeError("auth unavailable in unit test")
 
         with patch.object(self.checker, '_anti_detection_delay'):
             result = self.checker.check_video_is_live('live_video_id')
@@ -271,18 +275,22 @@ class TestIntegration(unittest.TestCase):
     """Integration tests for the complete system"""
 
     @patch('requests.Session.get')
-    def test_full_stream_check_workflow(self, mock_get):
+    @patch('modules.platform_integration.youtube_auth.src.youtube_auth.get_authenticated_service')
+    def test_full_stream_check_workflow(self, mock_auth, mock_get):
         """Test complete workflow from channel to live detection"""
         checker = NoQuotaStreamChecker()
 
         # Mock channel redirects to live video
         channel_response = Mock()
         channel_response.status_code = 200
-        channel_response.url = 'https://www.youtube.com/watch?v=live123'
+        channel_response.url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+        channel_response.headers = {}
 
         # Mock live video response
         video_response = Mock()
         video_response.status_code = 200
+        video_response.url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+        video_response.headers = {}
         video_response.text = '''
             <html>
                 <title>LIVE - Stream - YouTube</title>
@@ -295,6 +303,20 @@ class TestIntegration(unittest.TestCase):
         '''
 
         mock_get.side_effect = [channel_response, video_response]
+        mock_service = MagicMock()
+        mock_service._credential_set = 1
+        mock_service.videos.return_value.list.return_value.execute.return_value = {
+            "items": [
+                {
+                    "snippet": {
+                        "channelId": "test_channel",
+                        "liveBroadcastContent": "live",
+                    },
+                    "liveStreamingDetails": {},
+                }
+            ]
+        }
+        mock_auth.return_value = mock_service
 
         with patch.object(checker, '_anti_detection_delay'):
             result = checker.check_channel_for_live('test_channel')
@@ -302,7 +324,7 @@ class TestIntegration(unittest.TestCase):
             # Should find live stream
             self.assertIsNotNone(result)
             self.assertTrue(result['live'])
-            self.assertEqual(result['video_id'], 'live123')
+            self.assertEqual(result['video_id'], 'dQw4w9WgXcQ')
 
 
 def run_tests():

--- a/modules/platform_integration/stream_resolver/tests/test_no_quota_stream_checker.py
+++ b/modules/platform_integration/stream_resolver/tests/test_no_quota_stream_checker.py
@@ -13,10 +13,7 @@ import time
 import sys
 import os
 
-# Add src directory to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
-
-from no_quota_stream_checker import NoQuotaStreamChecker
+from modules.platform_integration.stream_resolver.src.no_quota_stream_checker import NoQuotaStreamChecker
 
 
 class TestNoQuotaStreamChecker(unittest.TestCase):
@@ -172,7 +169,7 @@ class TestNoQuotaStreamChecker(unittest.TestCase):
         is_limited, _ = self.checker._is_channel_rate_limited(self.test_channel_id)
         self.assertTrue(is_limited)
 
-    @patch('no_quota_stream_checker.LIVE_STATUS_VERIFIER_AVAILABLE', False)
+    @patch('modules.platform_integration.stream_resolver.src.no_quota_stream_checker.LIVE_STATUS_VERIFIER_AVAILABLE', False)
     @patch('requests.Session.get')
     def test_fallback_behavior(self, mock_get):
         """Test fallback behavior when LiveStatusVerifier is unavailable."""
@@ -201,6 +198,79 @@ class TestNoQuotaStreamChecker(unittest.TestCase):
         self.assertIsInstance(result, dict)
         self.assertFalse(result.get('live', True))
 
+    @patch('modules.platform_integration.youtube_auth.src.youtube_auth.get_authenticated_service')
+    def test_api_verification_reuses_cached_service(self, mock_auth):
+        """API verification should not rebuild the YouTube service per video check."""
+        mock_service = MagicMock()
+        mock_service._credential_set = 10
+        mock_service.videos.return_value.list.return_value.execute.return_value = {
+            "items": [
+                {
+                    "snippet": {
+                        "channelId": self.test_channel_id,
+                        "liveBroadcastContent": "none",
+                    },
+                    "liveStreamingDetails": {},
+                }
+            ]
+        }
+        mock_auth.return_value = mock_service
+
+        first = self.checker.check_video_is_live(self.test_video_id, scraping_prefilter=False)
+        second = self.checker.check_video_is_live("abc123def45", scraping_prefilter=False)
+
+        self.assertFalse(first.get("live"))
+        self.assertFalse(second.get("live"))
+        mock_auth.assert_called_once()
+
+    @patch('requests.Session.get')
+    @patch.object(NoQuotaStreamChecker, "_anti_detection_delay")
+    @patch.object(NoQuotaStreamChecker, "check_video_is_live")
+    def test_channel_mismatch_is_recommended_debug_not_warning(self, mock_check_video, mock_delay, mock_get):
+        """Recommended streams from other channels are expected, not warnings."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.url = f"https://www.youtube.com/channel/{self.test_channel_id}/live"
+        mock_response.headers = {}
+        mock_response.text = '"BADGE_STYLE_TYPE_LIVE_NOW" "videoId":"dQw4w9WgXcQ"'
+        mock_get.return_value = mock_response
+        mock_check_video.return_value = {
+            "live": True,
+            "video_id": self.test_video_id,
+            "method": "api",
+            "channel_id": "UCOTHERCHANNEL1234567890",
+        }
+
+        with patch('modules.platform_integration.stream_resolver.src.no_quota_stream_checker.logger.warning') as mock_warning, \
+             patch('modules.platform_integration.stream_resolver.src.no_quota_stream_checker.logger.debug') as mock_debug:
+            result = self.checker.check_channel_for_live(self.test_channel_id)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result.get("status"), "stale_indicator")
+        mock_warning.assert_not_called()
+        self.assertTrue(any("[RECOMMENDED]" in str(call) for call in mock_debug.call_args_list))
+
+    @patch('requests.Session.get')
+    @patch.object(NoQuotaStreamChecker, "_anti_detection_delay")
+    @patch.object(NoQuotaStreamChecker, "check_video_is_live")
+    def test_stale_indicator_returned_when_live_dom_has_no_verified_stream(self, mock_check_video, mock_delay, mock_get):
+        """Live-looking DOM without verified live videos is reported as stale, not live."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.url = f"https://www.youtube.com/channel/{self.test_channel_id}/live"
+        mock_response.headers = {}
+        mock_response.text = '"isLiveNow":true "BADGE_STYLE_TYPE_LIVE_NOW" "videoId":"dQw4w9WgXcQ"'
+        mock_get.return_value = mock_response
+        mock_check_video.return_value = {"live": False, "method": "api", "status": "none"}
+
+        result = self.checker.check_channel_for_live(self.test_channel_id)
+
+        self.assertIsInstance(result, dict)
+        self.assertFalse(result.get("live"))
+        self.assertEqual(result.get("status"), "stale_indicator")
+        self.assertEqual(result.get("confidence"), 0.3)
+        self.assertEqual(result.get("source"), "no_quota_live_page")
+
     def test_session_configuration(self):
         """Test that session is properly configured."""
         self.assertIsNotNone(self.checker.session)
@@ -222,6 +292,48 @@ class TestNoQuotaStreamChecker(unittest.TestCase):
 
         # Should be the same object (cached)
         self.assertIs(verifier1, verifier2)
+
+    def test_timeout_env_parsing_invalid_falls_back(self):
+        """Malformed YT_STREAM_REQUEST_TIMEOUT_SEC falls back to 30."""
+        import os
+        old_val = os.environ.get("YT_STREAM_REQUEST_TIMEOUT_SEC")
+        try:
+            os.environ["YT_STREAM_REQUEST_TIMEOUT_SEC"] = "not_a_number"
+            result = NoQuotaStreamChecker._parse_timeout_env()
+            self.assertEqual(result, 30.0)
+        finally:
+            if old_val is None:
+                os.environ.pop("YT_STREAM_REQUEST_TIMEOUT_SEC", None)
+            else:
+                os.environ["YT_STREAM_REQUEST_TIMEOUT_SEC"] = old_val
+
+    def test_timeout_env_parsing_negative_falls_back(self):
+        """Negative YT_STREAM_REQUEST_TIMEOUT_SEC falls back to 30."""
+        import os
+        old_val = os.environ.get("YT_STREAM_REQUEST_TIMEOUT_SEC")
+        try:
+            os.environ["YT_STREAM_REQUEST_TIMEOUT_SEC"] = "-5"
+            result = NoQuotaStreamChecker._parse_timeout_env()
+            self.assertEqual(result, 30.0)
+        finally:
+            if old_val is None:
+                os.environ.pop("YT_STREAM_REQUEST_TIMEOUT_SEC", None)
+            else:
+                os.environ["YT_STREAM_REQUEST_TIMEOUT_SEC"] = old_val
+
+    def test_timeout_env_parsing_clamps_to_max(self):
+        """Excessive YT_STREAM_REQUEST_TIMEOUT_SEC is clamped to 120."""
+        import os
+        old_val = os.environ.get("YT_STREAM_REQUEST_TIMEOUT_SEC")
+        try:
+            os.environ["YT_STREAM_REQUEST_TIMEOUT_SEC"] = "999"
+            result = NoQuotaStreamChecker._parse_timeout_env()
+            self.assertEqual(result, 120.0)
+        finally:
+            if old_val is None:
+                os.environ.pop("YT_STREAM_REQUEST_TIMEOUT_SEC", None)
+            else:
+                os.environ["YT_STREAM_REQUEST_TIMEOUT_SEC"] = old_val
 
 
 class TestNoQuotaStreamCheckerIntegration(unittest.TestCase):

--- a/modules/platform_integration/stream_resolver/tests/test_quota_intelligence.py
+++ b/modules/platform_integration/stream_resolver/tests/test_quota_intelligence.py
@@ -235,6 +235,22 @@ class TestQuotaIntelligence(unittest.TestCase):
             self.assertIs(service, self.mock_youtube_service)
             self.assertEqual(cred_set, 2)
 
+    def test_authenticated_service_cache_reuses_credential_set(self):
+        """Credential-specific services should be built once per resolver process."""
+        resolver = StreamResolver(self.mock_youtube_service, use_intelligent_sorting=False)
+
+        with patch('modules.platform_integration.youtube_auth.src.youtube_auth.get_authenticated_service') as mock_auth:
+            mock_auth.return_value = (self.mock_youtube_service, 2)
+
+            first, first_set = resolver._get_cached_authenticated_service(2)
+            second, second_set = resolver._get_cached_authenticated_service(2)
+
+        self.assertIs(first, self.mock_youtube_service)
+        self.assertIs(second, self.mock_youtube_service)
+        self.assertEqual(first_set, 2)
+        self.assertEqual(second_set, 2)
+        mock_auth.assert_called_once_with(token_index=2)
+
 
 class TestStreamTimingIntelligence(unittest.TestCase):
     """Test intelligent stream timing and scheduling"""


### PR DESCRIPTION
## Summary
- Cache authenticated YouTube services per credential set (invalidate on quota/auth failures)
- Safe timeout parsing with `YT_STREAM_REQUEST_TIMEOUT_SEC` env (default 30, clamp 5-120)
- Stale indicator handling: live DOM without verified stream -> `{live: false, status: "stale_indicator"}`
- Channel mismatch reclassified as DEBUG (recommended streams are expected, not errors)
- Progress visibility: log before scrape with timeout, log elapsed time for slow requests

## Known tradeoff
Stale `/live` DOM returns `stale_indicator` without probing `/streams`. Accepted for Phase 1 to avoid extra scrape latency; revisit if false negatives appear.

## Test plan
- [x] `python -m pytest modules/platform_integration/stream_resolver/tests/test_no_quota_stream_checker.py modules/platform_integration/stream_resolver/tests/test_no_quota_anti_rate_limit.py -q` -> 36 passed
- [x] Service cache reuse verified
- [x] Timeout parsing edge cases verified (invalid, negative, excessive)
- [x] Stale indicator structure verified
- [x] Channel mismatch log level verified (DEBUG, not warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)