### PR TITLE
feat(wre): add CLI security scanner proof

### DIFF
--- a/modules/infrastructure/security_scanner/INTERFACE.md
+++ b/modules/infrastructure/security_scanner/INTERFACE.md
@@ -1,0 +1,169 @@
+# Security Scanner Interface
+
+## Public API
+
+### SecurityScanner
+
+Main scanner class wrapping CLI tools.
+
+```python
+from modules.infrastructure.security_scanner import SecurityScanner
+
+scanner = SecurityScanner(timeout_seconds: int = 300)
+```
+
+#### Methods
+
+| Method | Args | Returns | Description |
+|--------|------|---------|-------------|
+| `check_tool_availability` | `force_refresh: bool = False` | `ToolAvailability` | Check which CLI tools are installed |
+| `scan_snyk` | `path: str = "."` | `ScanResult` | Run Snyk SAST/SCA scan |
+| `scan_trivy` | `target: str = ".", scan_type: str = "fs"` | `ScanResult` | Run Trivy scan (fs/image/repo) |
+| `scan_semgrep` | `path: str = ".", config: str = "auto"` | `ScanResult` | Run Semgrep SAST scan |
+| `scan_all_available` | `path: str = "."` | `Dict[str, ScanResult]` | Run all installed scanners |
+| `generate_capability_report` | none | `Dict[str, Any]` | Generate availability report |
+
+### ToolAvailability
+
+Status of installed CLI tools.
+
+```python
+@dataclass
+class ToolAvailability:
+    snyk_available: bool
+    snyk_version: Optional[str]
+    snyk_path: Optional[str]
+    
+    trivy_available: bool
+    trivy_version: Optional[str]
+    trivy_path: Optional[str]
+    
+    semgrep_available: bool
+    semgrep_version: Optional[str]
+    semgrep_path: Optional[str]
+    
+    @property
+    def any_available(self) -> bool
+    
+    @property
+    def all_available(self) -> bool
+    
+    def to_dict(self) -> Dict[str, Any]
+```
+
+### ScanResult
+
+Result of a scan attempt.
+
+```python
+@dataclass
+class ScanResult:
+    tool: str                              # snyk, trivy, semgrep
+    success: bool                          # Did scan complete?
+    available: bool                        # Is tool installed?
+    report: Optional[VulnerabilityReport]  # Normalized report
+    raw_output: Optional[str]              # Raw stdout
+    error_output: Optional[str]            # Raw stderr
+    error_message: Optional[str]           # Human-readable error
+    exit_code: Optional[int]               # Process exit code
+    duration_ms: int                       # Execution time
+    
+    def to_dict(self) -> Dict[str, Any]
+```
+
+### VulnerabilityReport
+
+Normalized scan report.
+
+```python
+@dataclass
+class VulnerabilityReport:
+    scan_id: str
+    scanner: str
+    scan_target: str
+    scan_timestamp: str
+    scan_duration_ms: int
+    findings: List[VulnerabilityFinding]
+    total_findings: int
+    critical_count: int
+    high_count: int
+    medium_count: int
+    low_count: int
+    scan_success: bool
+    error_message: Optional[str]
+    
+    @property
+    def max_severity(self) -> SeverityLevel
+    
+    def to_dict(self) -> Dict[str, Any]
+    def to_json(self, indent: int = 2) -> str
+```
+
+### VulnerabilityFinding
+
+Single vulnerability.
+
+```python
+@dataclass
+class VulnerabilityFinding:
+    vuln_id: str                           # CVE-XXXX or rule ID
+    title: str
+    severity: SeverityLevel
+    file_path: Optional[str]
+    line_number: Optional[int]
+    package_name: Optional[str]
+    package_version: Optional[str]
+    description: str
+    fix_available: bool
+    fix_version: Optional[str]
+    scanner: str
+    raw_data: Dict[str, Any]
+    
+    def to_dict(self) -> Dict[str, Any]
+```
+
+### SeverityLevel
+
+Normalized severity enum.
+
+```python
+class SeverityLevel(Enum):
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    INFO = "info"
+    UNKNOWN = "unknown"
+    
+    @classmethod
+    def from_snyk(cls, severity: str) -> SeverityLevel
+    
+    @classmethod
+    def from_trivy(cls, severity: str) -> SeverityLevel
+    
+    @classmethod
+    def from_semgrep(cls, severity: str) -> SeverityLevel
+```
+
+## Normalization Functions
+
+```python
+def normalize_snyk_output(raw_json: Dict, scan_id: str, target: str) -> VulnerabilityReport
+def normalize_trivy_output(raw_json: Dict, scan_id: str, target: str) -> VulnerabilityReport
+def normalize_semgrep_output(raw_json: Dict, scan_id: str, target: str) -> VulnerabilityReport
+```
+
+## Execution Boundary
+
+| Component | Execution | Notes |
+|-----------|-----------|-------|
+| SecurityScanner | `subprocess.run()` | Autonomous CLI execution |
+| Qwen/Gemma | NOT HERE | Analyze results after scanning |
+| MCP plugins | NOT HERE | Operator tools only |
+
+## Integration Points
+
+- **SecuritySentinel** (AI Overseer): Owns policy, thresholds, escalation
+- **PatternMemory**: Stores scan outcomes for learning
+- **HoloDAE**: Triggers scans on cadence
+- **WRE Skills**: Wraps scanner as executable skill

--- a/modules/infrastructure/security_scanner/ModLog.md
+++ b/modules/infrastructure/security_scanner/ModLog.md
@@ -1,0 +1,53 @@
+# Security Scanner ModLog
+
+## V0.1.0 - SEC1 CLI Proof (2026-04-17)
+
+**Phase**: SEC1 — SECURITY_SCANNER_CLI_PROOF_PHASE1
+
+**Objective**: Prove autonomous CLI-based security scanning without MCP/LLM dependencies.
+
+### Created
+
+- `src/security_scanner.py` - Main scanner class
+  - `SecurityScanner` with subprocess-based scan execution
+  - `ToolAvailability` dataclass for CLI tool detection
+  - `ScanResult` dataclass for scan outcomes
+  - `check_tool_availability()` with caching
+  - `scan_snyk()`, `scan_trivy()`, `scan_semgrep()` methods
+  - `scan_all_available()` for multi-tool scanning
+  - `generate_capability_report()` for truthful availability
+
+- `src/schemas.py` - Normalized output schemas
+  - `SeverityLevel` enum with per-scanner mappers
+  - `VulnerabilityFinding` dataclass
+  - `VulnerabilityReport` dataclass with summary calculation
+  - `normalize_snyk_output()`, `normalize_trivy_output()`, `normalize_semgrep_output()`
+
+- `tests/test_security_scanner.py` - Mocked tests (no CLI tools required)
+  - `TestToolAvailability` - detection and caching
+  - `TestSnykScanner`, `TestTrivyScanner`, `TestSemgrepScanner` - scan execution
+  - `TestSchemas` - normalization and serialization
+  - `TestCapabilityReport` - truthful reporting
+  - `TestExecutionBoundary` - verifies subprocess.run, no LLM imports
+
+### Execution Boundary (CRITICAL)
+
+```
+CLI subprocess executes scans
+Qwen/Gemma analyze results AFTER this module returns
+MCP plugins are OPERATOR tools, NOT autonomous runtime
+```
+
+### WSP References
+
+- WSP 49: Module structure
+- WSP 77: Agent coordination
+- WSP 97: Execution discipline
+
+### Roadmap
+
+- SEC2: Policy layer (severity thresholds, escalation rules)
+- SEC3: WRE skills (wrap scanner as executable skills)
+- SEC4: Triggers (HoloDAE cadence integration)
+- SEC5: Memory (PatternMemory outcome storage)
+- SEC6: MCP eval (evaluate Codex plugin integration)

--- a/modules/infrastructure/security_scanner/README.md
+++ b/modules/infrastructure/security_scanner/README.md
@@ -1,0 +1,158 @@
+# Security Scanner
+
+Autonomous CLI-based vulnerability scanning via snyk, trivy, and semgrep.
+
+## Execution Boundary (CRITICAL)
+
+```
+CLI subprocess executes scans (snyk, trivy, semgrep)
+Qwen/Gemma analyze results AFTER this module returns
+Codex/Claude MCP plugins are operator tools, NOT autonomous runtime dependencies
+```
+
+This module is the **autonomous 0102 scanning path**. No LLM, no MCP, no human in loop for scan execution.
+
+## WSP References
+
+- WSP 49: Module structure
+- WSP 77: Agent coordination (SecuritySentinel integration)
+- WSP 97: Execution discipline
+
+## Installation
+
+```bash
+# Module has no Python dependencies beyond stdlib
+# CLI tools must be installed separately:
+
+# Snyk (npm)
+npm install -g snyk
+snyk auth  # One-time authentication
+
+# Trivy (various methods)
+brew install trivy        # macOS
+choco install trivy       # Windows
+apt-get install trivy     # Debian/Ubuntu
+
+# Semgrep (pip)
+pip install semgrep
+```
+
+## Usage
+
+```python
+from modules.infrastructure.security_scanner import SecurityScanner
+
+scanner = SecurityScanner()
+
+# Check what tools are available
+availability = scanner.check_tool_availability()
+print(f"Snyk: {availability.snyk_available}")
+print(f"Trivy: {availability.trivy_available}")
+print(f"Semgrep: {availability.semgrep_available}")
+
+# Run individual scans
+if availability.snyk_available:
+    result = scanner.scan_snyk(".")
+    if result.success:
+        print(f"Found {result.report.total_findings} vulnerabilities")
+        print(result.report.to_json())
+
+# Run all available scanners
+results = scanner.scan_all_available(".")
+for tool, result in results.items():
+    if result.success:
+        print(f"{tool}: {result.report.total_findings} findings")
+
+# Generate capability report (truthful availability)
+report = scanner.generate_capability_report()
+print(json.dumps(report, indent=2))
+```
+
+## Architecture
+
+```
+                    +-------------------+
+                    |  SecurityScanner  |
+                    |  (subprocess.run) |
+                    +--------+----------+
+                             |
+         +-------------------+-------------------+
+         |                   |                   |
+    +----v----+        +-----v-----+       +-----v-----+
+    |  snyk   |        |   trivy   |       |  semgrep  |
+    |  CLI    |        |    CLI    |       |    CLI    |
+    +----+----+        +-----+-----+       +-----+-----+
+         |                   |                   |
+         v                   v                   v
+    +----------+        +----------+        +----------+
+    | Raw JSON |        | Raw JSON |        | Raw JSON |
+    +----+-----+        +-----+----+        +-----+----+
+         |                   |                   |
+         +-------------------+-------------------+
+                             |
+                    +--------v---------+
+                    |  schemas.py      |
+                    |  (normalize)     |
+                    +--------+---------+
+                             |
+                    +--------v---------+
+                    | VulnerabilityReport |
+                    | (unified format)    |
+                    +---------------------+
+                             |
+              +--------------+--------------+
+              |                             |
+     +--------v--------+           +--------v--------+
+     | Qwen (analyze)  |           | PatternMemory   |
+     | Gemma (validate)|           | (store/recall)  |
+     +-----------------+           +-----------------+
+```
+
+## Normalized Output
+
+All scanners produce `VulnerabilityReport` with:
+
+```python
+{
+    "scan_id": "snyk-a1b2c3d4",
+    "scanner": "snyk",
+    "scan_target": ".",
+    "scan_timestamp": "2026-04-17T12:00:00Z",
+    "findings": [
+        {
+            "vuln_id": "CVE-2021-44228",
+            "title": "Log4Shell",
+            "severity": "critical",
+            "package_name": "log4j",
+            "package_version": "2.14.0",
+            "fix_available": true,
+            "fix_version": "2.17.0"
+        }
+    ],
+    "summary": {
+        "total": 1,
+        "critical": 1,
+        "high": 0,
+        "medium": 0,
+        "low": 0
+    }
+}
+```
+
+## Testing
+
+All tests use mocked subprocess calls - no CLI tools required:
+
+```bash
+cd modules/infrastructure/security_scanner
+pytest tests/ -v
+```
+
+## Roadmap
+
+- **SEC1** (current): CLI proof - subprocess execution, mocked tests
+- **SEC2**: Policy layer - severity thresholds, escalation rules
+- **SEC3**: WRE skills - wrap scanner as executable skills
+- **SEC4**: Triggers - HoloDAE cadence integration
+- **SEC5**: Memory - PatternMemory outcome storage
+- **SEC6**: MCP eval - evaluate Codex plugin integration for 012 workflows

--- a/modules/infrastructure/security_scanner/requirements.txt
+++ b/modules/infrastructure/security_scanner/requirements.txt
@@ -1,0 +1,8 @@
+# Security Scanner - Python Dependencies
+#
+# This module uses ONLY stdlib for core functionality.
+# CLI tools (snyk, trivy, semgrep) must be installed separately.
+#
+# Test dependencies:
+pytest>=7.0.0
+pytest-asyncio>=0.23.0

--- a/modules/infrastructure/security_scanner/src/__init__.py
+++ b/modules/infrastructure/security_scanner/src/__init__.py
@@ -1,0 +1,33 @@
+"""
+Security Scanner Module
+
+Autonomous security scanning via CLI tools (snyk, trivy, semgrep).
+Subprocess-based execution - no MCP or LLM required for scanning.
+
+WSP References:
+- WSP 49: Module structure
+- WSP 77: Agent coordination (SecuritySentinel integration)
+- WSP 97: Execution discipline
+"""
+
+from .security_scanner import SecurityScanner, ScanResult, ToolAvailability
+from .schemas import (
+    VulnerabilityReport,
+    VulnerabilityFinding,
+    SeverityLevel,
+    normalize_snyk_output,
+    normalize_trivy_output,
+    normalize_semgrep_output,
+)
+
+__all__ = [
+    "SecurityScanner",
+    "ScanResult",
+    "ToolAvailability",
+    "VulnerabilityReport",
+    "VulnerabilityFinding",
+    "SeverityLevel",
+    "normalize_snyk_output",
+    "normalize_trivy_output",
+    "normalize_semgrep_output",
+]

--- a/modules/infrastructure/security_scanner/src/schemas.py
+++ b/modules/infrastructure/security_scanner/src/schemas.py
@@ -1,0 +1,326 @@
+"""
+Normalized Security Scan Output Schemas
+
+All scanner outputs (snyk, trivy, semgrep) normalize to these structures.
+This enables consistent processing regardless of which tool ran the scan.
+
+Execution Boundary:
+- CLI subprocess executes scans (produces raw JSON)
+- This module normalizes raw JSON to standard schema
+- Qwen/Gemma analyze normalized results LATER (not here)
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+import json
+
+
+class SeverityLevel(Enum):
+    """Normalized severity levels across all scanners."""
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    INFO = "info"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def from_snyk(cls, severity: str) -> "SeverityLevel":
+        """Map Snyk severity to normalized level."""
+        mapping = {
+            "critical": cls.CRITICAL,
+            "high": cls.HIGH,
+            "medium": cls.MEDIUM,
+            "low": cls.LOW,
+        }
+        return mapping.get(severity.lower(), cls.UNKNOWN)
+
+    @classmethod
+    def from_trivy(cls, severity: str) -> "SeverityLevel":
+        """Map Trivy severity to normalized level."""
+        mapping = {
+            "CRITICAL": cls.CRITICAL,
+            "HIGH": cls.HIGH,
+            "MEDIUM": cls.MEDIUM,
+            "LOW": cls.LOW,
+            "UNKNOWN": cls.UNKNOWN,
+        }
+        return mapping.get(severity.upper(), cls.UNKNOWN)
+
+    @classmethod
+    def from_semgrep(cls, severity: str) -> "SeverityLevel":
+        """Map Semgrep severity to normalized level."""
+        mapping = {
+            "ERROR": cls.HIGH,
+            "WARNING": cls.MEDIUM,
+            "INFO": cls.INFO,
+        }
+        return mapping.get(severity.upper(), cls.UNKNOWN)
+
+
+@dataclass
+class VulnerabilityFinding:
+    """Single vulnerability finding normalized across scanners."""
+
+    # Identification
+    vuln_id: str                          # CVE-2026-XXXX or rule ID
+    title: str                            # Human-readable title
+    severity: SeverityLevel               # Normalized severity
+
+    # Location
+    file_path: Optional[str] = None       # Affected file
+    line_number: Optional[int] = None     # Line number if applicable
+    package_name: Optional[str] = None    # Affected package/dependency
+    package_version: Optional[str] = None # Current version
+
+    # Details
+    description: str = ""                 # Vulnerability description
+    fix_available: bool = False           # Is a fix available?
+    fix_version: Optional[str] = None     # Version that fixes it
+
+    # Metadata
+    scanner: str = ""                     # snyk, trivy, or semgrep
+    raw_data: Dict[str, Any] = field(default_factory=dict)  # Original scanner output
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "vuln_id": self.vuln_id,
+            "title": self.title,
+            "severity": self.severity.value,
+            "file_path": self.file_path,
+            "line_number": self.line_number,
+            "package_name": self.package_name,
+            "package_version": self.package_version,
+            "description": self.description,
+            "fix_available": self.fix_available,
+            "fix_version": self.fix_version,
+            "scanner": self.scanner,
+        }
+
+
+@dataclass
+class VulnerabilityReport:
+    """Complete vulnerability scan report."""
+
+    # Metadata
+    scan_id: str                          # Unique scan identifier
+    scanner: str                          # snyk, trivy, or semgrep
+    scan_target: str                      # What was scanned (path, image, etc.)
+    scan_timestamp: str                   # ISO format timestamp
+    scan_duration_ms: int = 0             # How long the scan took
+
+    # Results
+    findings: List[VulnerabilityFinding] = field(default_factory=list)
+
+    # Summary
+    total_findings: int = 0
+    critical_count: int = 0
+    high_count: int = 0
+    medium_count: int = 0
+    low_count: int = 0
+
+    # Status
+    scan_success: bool = True
+    error_message: Optional[str] = None
+
+    def __post_init__(self):
+        """Calculate summary counts from findings."""
+        if self.findings and self.total_findings == 0:
+            self.total_findings = len(self.findings)
+            self.critical_count = sum(1 for f in self.findings if f.severity == SeverityLevel.CRITICAL)
+            self.high_count = sum(1 for f in self.findings if f.severity == SeverityLevel.HIGH)
+            self.medium_count = sum(1 for f in self.findings if f.severity == SeverityLevel.MEDIUM)
+            self.low_count = sum(1 for f in self.findings if f.severity == SeverityLevel.LOW)
+
+    @property
+    def max_severity(self) -> SeverityLevel:
+        """Return the highest severity found."""
+        if self.critical_count > 0:
+            return SeverityLevel.CRITICAL
+        if self.high_count > 0:
+            return SeverityLevel.HIGH
+        if self.medium_count > 0:
+            return SeverityLevel.MEDIUM
+        if self.low_count > 0:
+            return SeverityLevel.LOW
+        return SeverityLevel.INFO
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "scan_id": self.scan_id,
+            "scanner": self.scanner,
+            "scan_target": self.scan_target,
+            "scan_timestamp": self.scan_timestamp,
+            "scan_duration_ms": self.scan_duration_ms,
+            "findings": [f.to_dict() for f in self.findings],
+            "summary": {
+                "total": self.total_findings,
+                "critical": self.critical_count,
+                "high": self.high_count,
+                "medium": self.medium_count,
+                "low": self.low_count,
+                "max_severity": self.max_severity.value,
+            },
+            "scan_success": self.scan_success,
+            "error_message": self.error_message,
+        }
+
+    def to_json(self, indent: int = 2) -> str:
+        """Serialize to JSON string."""
+        return json.dumps(self.to_dict(), indent=indent)
+
+
+def normalize_snyk_output(raw_json: Dict[str, Any], scan_id: str, target: str) -> VulnerabilityReport:
+    """
+    Normalize Snyk JSON output to VulnerabilityReport.
+
+    Snyk output structure (simplified):
+    {
+        "vulnerabilities": [
+            {
+                "id": "SNYK-JS-LODASH-1234",
+                "title": "Prototype Pollution",
+                "severity": "high",
+                "packageName": "lodash",
+                "version": "4.17.15",
+                "fixedIn": ["4.17.21"],
+                "description": "..."
+            }
+        ]
+    }
+    """
+    findings = []
+    vulnerabilities = raw_json.get("vulnerabilities", [])
+
+    for vuln in vulnerabilities:
+        fixed_versions = vuln.get("fixedIn", [])
+        finding = VulnerabilityFinding(
+            vuln_id=vuln.get("id", "UNKNOWN"),
+            title=vuln.get("title", "Unknown vulnerability"),
+            severity=SeverityLevel.from_snyk(vuln.get("severity", "unknown")),
+            package_name=vuln.get("packageName"),
+            package_version=vuln.get("version"),
+            description=vuln.get("description", ""),
+            fix_available=len(fixed_versions) > 0,
+            fix_version=fixed_versions[0] if fixed_versions else None,
+            scanner="snyk",
+            raw_data=vuln,
+        )
+        findings.append(finding)
+
+    return VulnerabilityReport(
+        scan_id=scan_id,
+        scanner="snyk",
+        scan_target=target,
+        scan_timestamp=datetime.utcnow().isoformat() + "Z",
+        findings=findings,
+    )
+
+
+def normalize_trivy_output(raw_json: Dict[str, Any], scan_id: str, target: str) -> VulnerabilityReport:
+    """
+    Normalize Trivy JSON output to VulnerabilityReport.
+
+    Trivy output structure (simplified):
+    {
+        "Results": [
+            {
+                "Target": "package-lock.json",
+                "Vulnerabilities": [
+                    {
+                        "VulnerabilityID": "CVE-2021-44228",
+                        "PkgName": "log4j",
+                        "InstalledVersion": "2.14.0",
+                        "FixedVersion": "2.17.0",
+                        "Severity": "CRITICAL",
+                        "Title": "Log4Shell",
+                        "Description": "..."
+                    }
+                ]
+            }
+        ]
+    }
+    """
+    findings = []
+    results = raw_json.get("Results", [])
+
+    for result in results:
+        target_file = result.get("Target", "")
+        vulnerabilities = result.get("Vulnerabilities") or []
+
+        for vuln in vulnerabilities:
+            fixed_version = vuln.get("FixedVersion")
+            finding = VulnerabilityFinding(
+                vuln_id=vuln.get("VulnerabilityID", "UNKNOWN"),
+                title=vuln.get("Title", "Unknown vulnerability"),
+                severity=SeverityLevel.from_trivy(vuln.get("Severity", "UNKNOWN")),
+                file_path=target_file,
+                package_name=vuln.get("PkgName"),
+                package_version=vuln.get("InstalledVersion"),
+                description=vuln.get("Description", ""),
+                fix_available=bool(fixed_version),
+                fix_version=fixed_version,
+                scanner="trivy",
+                raw_data=vuln,
+            )
+            findings.append(finding)
+
+    return VulnerabilityReport(
+        scan_id=scan_id,
+        scanner="trivy",
+        scan_target=target,
+        scan_timestamp=datetime.utcnow().isoformat() + "Z",
+        findings=findings,
+    )
+
+
+def normalize_semgrep_output(raw_json: Dict[str, Any], scan_id: str, target: str) -> VulnerabilityReport:
+    """
+    Normalize Semgrep JSON output to VulnerabilityReport.
+
+    Semgrep output structure (simplified):
+    {
+        "results": [
+            {
+                "check_id": "python.lang.security.audit.dangerous-exec",
+                "path": "src/main.py",
+                "start": {"line": 42},
+                "extra": {
+                    "severity": "ERROR",
+                    "message": "Dangerous use of exec()"
+                }
+            }
+        ]
+    }
+    """
+    findings = []
+    results = raw_json.get("results", [])
+
+    for result in results:
+        extra = result.get("extra", {})
+        start = result.get("start", {})
+
+        finding = VulnerabilityFinding(
+            vuln_id=result.get("check_id", "UNKNOWN"),
+            title=extra.get("message", "Security finding"),
+            severity=SeverityLevel.from_semgrep(extra.get("severity", "INFO")),
+            file_path=result.get("path"),
+            line_number=start.get("line"),
+            description=extra.get("message", ""),
+            fix_available=False,  # Semgrep doesn't provide fix versions
+            scanner="semgrep",
+            raw_data=result,
+        )
+        findings.append(finding)
+
+    return VulnerabilityReport(
+        scan_id=scan_id,
+        scanner="semgrep",
+        scan_target=target,
+        scan_timestamp=datetime.utcnow().isoformat() + "Z",
+        findings=findings,
+    )

--- a/modules/infrastructure/security_scanner/src/security_scanner.py
+++ b/modules/infrastructure/security_scanner/src/security_scanner.py
@@ -1,0 +1,531 @@
+"""
+Security Scanner - Autonomous CLI-based vulnerability scanning.
+
+Execution Boundary (CRITICAL):
+- CLI subprocess executes scans (snyk, trivy, semgrep)
+- Qwen/Gemma are NOT involved in scan execution
+- Qwen/Gemma analyze results AFTER this module returns
+- Codex/Claude MCP plugins are operator tools, NOT autonomous runtime dependencies
+
+This module is the autonomous 0102 scanning path.
+No LLM, no MCP, no human in loop for scan execution.
+
+WSP References:
+- WSP 49: Module structure
+- WSP 77: Agent coordination
+- WSP 97: Execution discipline
+"""
+
+import json
+import logging
+import shutil
+import subprocess
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from .schemas import (
+    VulnerabilityReport,
+    normalize_snyk_output,
+    normalize_trivy_output,
+    normalize_semgrep_output,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ToolAvailability:
+    """Status of security scanning CLI tools."""
+
+    snyk_available: bool = False
+    snyk_version: Optional[str] = None
+    snyk_path: Optional[str] = None
+
+    trivy_available: bool = False
+    trivy_version: Optional[str] = None
+    trivy_path: Optional[str] = None
+
+    semgrep_available: bool = False
+    semgrep_version: Optional[str] = None
+    semgrep_path: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for reporting."""
+        return {
+            "snyk": {
+                "available": self.snyk_available,
+                "version": self.snyk_version,
+                "path": self.snyk_path,
+            },
+            "trivy": {
+                "available": self.trivy_available,
+                "version": self.trivy_version,
+                "path": self.trivy_path,
+            },
+            "semgrep": {
+                "available": self.semgrep_available,
+                "version": self.semgrep_version,
+                "path": self.semgrep_path,
+            },
+            "any_available": self.any_available,
+            "all_available": self.all_available,
+        }
+
+    @property
+    def any_available(self) -> bool:
+        """True if at least one tool is available."""
+        return self.snyk_available or self.trivy_available or self.semgrep_available
+
+    @property
+    def all_available(self) -> bool:
+        """True if all tools are available."""
+        return self.snyk_available and self.trivy_available and self.semgrep_available
+
+
+@dataclass
+class ScanResult:
+    """Result of a security scan attempt."""
+
+    tool: str                             # snyk, trivy, or semgrep
+    success: bool                         # Did the scan complete?
+    available: bool                       # Is the tool installed?
+    report: Optional[VulnerabilityReport] = None  # Normalized report if successful
+    raw_output: Optional[str] = None      # Raw stdout
+    error_output: Optional[str] = None    # Raw stderr
+    error_message: Optional[str] = None   # Human-readable error
+    exit_code: Optional[int] = None       # Process exit code
+    duration_ms: int = 0                  # Execution time
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for reporting."""
+        return {
+            "tool": self.tool,
+            "success": self.success,
+            "available": self.available,
+            "report": self.report.to_dict() if self.report else None,
+            "error_message": self.error_message,
+            "exit_code": self.exit_code,
+            "duration_ms": self.duration_ms,
+        }
+
+
+class SecurityScanner:
+    """
+    Autonomous security scanner using CLI tools.
+
+    This class wraps snyk, trivy, and semgrep CLI tools for
+    read-only vulnerability scanning. No mutations, no auto-fixes.
+
+    Usage:
+        scanner = SecurityScanner()
+        availability = scanner.check_tool_availability()
+
+        if availability.snyk_available:
+            result = scanner.scan_snyk(".")
+            if result.success:
+                print(result.report.to_json())
+
+    Execution Boundary:
+        - subprocess.run() executes CLI tools
+        - No LLM involved in execution
+        - Results are normalized JSON for later Qwen/Gemma analysis
+    """
+
+    def __init__(self, timeout_seconds: int = 300):
+        """
+        Initialize SecurityScanner.
+
+        Args:
+            timeout_seconds: Maximum time for each scan (default 5 minutes)
+        """
+        self.timeout_seconds = timeout_seconds
+        self._availability: Optional[ToolAvailability] = None
+
+    def check_tool_availability(self, force_refresh: bool = False) -> ToolAvailability:
+        """
+        Check which security scanning tools are installed.
+
+        Args:
+            force_refresh: Re-check even if cached
+
+        Returns:
+            ToolAvailability with status of each tool
+        """
+        if self._availability is not None and not force_refresh:
+            return self._availability
+
+        availability = ToolAvailability()
+
+        # Check snyk
+        snyk_path = shutil.which("snyk")
+        if snyk_path:
+            availability.snyk_path = snyk_path
+            availability.snyk_available = True
+            availability.snyk_version = self._get_version("snyk", ["snyk", "--version"])
+
+        # Check trivy
+        trivy_path = shutil.which("trivy")
+        if trivy_path:
+            availability.trivy_path = trivy_path
+            availability.trivy_available = True
+            availability.trivy_version = self._get_version("trivy", ["trivy", "--version"])
+
+        # Check semgrep
+        semgrep_path = shutil.which("semgrep")
+        if semgrep_path:
+            availability.semgrep_path = semgrep_path
+            availability.semgrep_available = True
+            availability.semgrep_version = self._get_version("semgrep", ["semgrep", "--version"])
+
+        self._availability = availability
+        return availability
+
+    def _get_version(self, tool: str, cmd: List[str]) -> Optional[str]:
+        """Get version string for a tool."""
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode == 0:
+                # Take first line, strip whitespace
+                return result.stdout.strip().split("\n")[0]
+        except Exception as e:
+            logger.debug(f"Failed to get {tool} version: {e}")
+        return None
+
+    def _run_command(
+        self,
+        cmd: List[str],
+        tool: str,
+    ) -> Tuple[bool, Optional[str], Optional[str], int, int]:
+        """
+        Run a subprocess command and return results.
+
+        Returns:
+            Tuple of (success, stdout, stderr, exit_code, duration_ms)
+        """
+        start_time = datetime.now()
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+            )
+            duration_ms = int((datetime.now() - start_time).total_seconds() * 1000)
+
+            # Note: Some tools return non-zero when vulnerabilities found
+            # This is not a failure - it means scan completed with findings
+            return (
+                True,
+                result.stdout,
+                result.stderr,
+                result.returncode,
+                duration_ms,
+            )
+
+        except subprocess.TimeoutExpired:
+            duration_ms = int((datetime.now() - start_time).total_seconds() * 1000)
+            logger.warning(f"{tool} scan timed out after {self.timeout_seconds}s")
+            return (False, None, f"Timeout after {self.timeout_seconds}s", -1, duration_ms)
+
+        except Exception as e:
+            duration_ms = int((datetime.now() - start_time).total_seconds() * 1000)
+            logger.error(f"{tool} scan failed: {e}")
+            return (False, None, str(e), -1, duration_ms)
+
+    def scan_snyk(self, path: str = ".") -> ScanResult:
+        """
+        Run Snyk SAST/SCA scan.
+
+        Args:
+            path: Path to scan (default: current directory)
+
+        Returns:
+            ScanResult with normalized report or error
+        """
+        availability = self.check_tool_availability()
+
+        if not availability.snyk_available:
+            return ScanResult(
+                tool="snyk",
+                success=False,
+                available=False,
+                error_message="snyk CLI not installed",
+            )
+
+        scan_id = f"snyk-{uuid.uuid4().hex[:8]}"
+
+        # Snyk test with JSON output (read-only, no fix)
+        cmd = ["snyk", "test", "--json", path]
+
+        success, stdout, stderr, exit_code, duration_ms = self._run_command(cmd, "snyk")
+
+        if not success or stdout is None:
+            return ScanResult(
+                tool="snyk",
+                success=False,
+                available=True,
+                error_output=stderr,
+                error_message=stderr or "Scan failed",
+                exit_code=exit_code,
+                duration_ms=duration_ms,
+            )
+
+        # Parse JSON output
+        try:
+            raw_json = json.loads(stdout)
+            report = normalize_snyk_output(raw_json, scan_id, path)
+            report.scan_duration_ms = duration_ms
+
+            return ScanResult(
+                tool="snyk",
+                success=True,
+                available=True,
+                report=report,
+                raw_output=stdout,
+                exit_code=exit_code,
+                duration_ms=duration_ms,
+            )
+
+        except json.JSONDecodeError as e:
+            return ScanResult(
+                tool="snyk",
+                success=False,
+                available=True,
+                raw_output=stdout,
+                error_output=stderr,
+                error_message=f"Failed to parse JSON output: {e}",
+                exit_code=exit_code,
+                duration_ms=duration_ms,
+            )
+
+    def scan_trivy(self, target: str = ".", scan_type: str = "fs") -> ScanResult:
+        """
+        Run Trivy scan.
+
+        Args:
+            target: Path or image to scan
+            scan_type: Type of scan - "fs" (filesystem), "image", or "repo"
+
+        Returns:
+            ScanResult with normalized report or error
+        """
+        availability = self.check_tool_availability()
+
+        if not availability.trivy_available:
+            return ScanResult(
+                tool="trivy",
+                success=False,
+                available=False,
+                error_message="trivy CLI not installed",
+            )
+
+        scan_id = f"trivy-{uuid.uuid4().hex[:8]}"
+
+        # Trivy scan with JSON output (read-only)
+        cmd = ["trivy", scan_type, "--format", "json", target]
+
+        success, stdout, stderr, exit_code, duration_ms = self._run_command(cmd, "trivy")
+
+        if not success or stdout is None:
+            return ScanResult(
+                tool="trivy",
+                success=False,
+                available=True,
+                error_output=stderr,
+                error_message=stderr or "Scan failed",
+                exit_code=exit_code,
+                duration_ms=duration_ms,
+            )
+
+        # Parse JSON output
+        try:
+            raw_json = json.loads(stdout)
+            report = normalize_trivy_output(raw_json, scan_id, target)
+            report.scan_duration_ms = duration_ms
+
+            return ScanResult(
+                tool="trivy",
+                success=True,
+                available=True,
+                report=report,
+                raw_output=stdout,
+                exit_code=exit_code,
+                duration_ms=duration_ms,
+            )
+
+        except json.JSONDecodeError as e:
+            return ScanResult(
+                tool="trivy",
+                success=False,
+                available=True,
+                raw_output=stdout,
+                error_output=stderr,
+                error_message=f"Failed to parse JSON output: {e}",
+                exit_code=exit_code,
+                duration_ms=duration_ms,
+            )
+
+    def scan_semgrep(self, path: str = ".", config: str = "auto") -> ScanResult:
+        """
+        Run Semgrep SAST scan.
+
+        Args:
+            path: Path to scan
+            config: Semgrep config - "auto" for default rules
+
+        Returns:
+            ScanResult with normalized report or error
+        """
+        availability = self.check_tool_availability()
+
+        if not availability.semgrep_available:
+            return ScanResult(
+                tool="semgrep",
+                success=False,
+                available=False,
+                error_message="semgrep CLI not installed",
+            )
+
+        scan_id = f"semgrep-{uuid.uuid4().hex[:8]}"
+
+        # Semgrep scan with JSON output (read-only)
+        cmd = ["semgrep", "--config", config, "--json", path]
+
+        success, stdout, stderr, exit_code, duration_ms = self._run_command(cmd, "semgrep")
+
+        if not success or stdout is None:
+            return ScanResult(
+                tool="semgrep",
+                success=False,
+                available=True,
+                error_output=stderr,
+                error_message=stderr or "Scan failed",
+                exit_code=exit_code,
+                duration_ms=duration_ms,
+            )
+
+        # Parse JSON output
+        try:
+            raw_json = json.loads(stdout)
+            report = normalize_semgrep_output(raw_json, scan_id, path)
+            report.scan_duration_ms = duration_ms
+
+            return ScanResult(
+                tool="semgrep",
+                success=True,
+                available=True,
+                report=report,
+                raw_output=stdout,
+                exit_code=exit_code,
+                duration_ms=duration_ms,
+            )
+
+        except json.JSONDecodeError as e:
+            return ScanResult(
+                tool="semgrep",
+                success=False,
+                available=True,
+                raw_output=stdout,
+                error_output=stderr,
+                error_message=f"Failed to parse JSON output: {e}",
+                exit_code=exit_code,
+                duration_ms=duration_ms,
+            )
+
+    def scan_all_available(self, path: str = ".") -> Dict[str, ScanResult]:
+        """
+        Run all available scanners on a path.
+
+        Args:
+            path: Path to scan
+
+        Returns:
+            Dict mapping tool name to ScanResult
+        """
+        results = {}
+
+        availability = self.check_tool_availability()
+
+        if availability.snyk_available:
+            results["snyk"] = self.scan_snyk(path)
+        else:
+            results["snyk"] = ScanResult(
+                tool="snyk",
+                success=False,
+                available=False,
+                error_message="snyk CLI not installed",
+            )
+
+        if availability.trivy_available:
+            results["trivy"] = self.scan_trivy(path)
+        else:
+            results["trivy"] = ScanResult(
+                tool="trivy",
+                success=False,
+                available=False,
+                error_message="trivy CLI not installed",
+            )
+
+        if availability.semgrep_available:
+            results["semgrep"] = self.scan_semgrep(path)
+        else:
+            results["semgrep"] = ScanResult(
+                tool="semgrep",
+                success=False,
+                available=False,
+                error_message="semgrep CLI not installed",
+            )
+
+        return results
+
+    def generate_capability_report(self) -> Dict[str, Any]:
+        """
+        Generate a report of tool availability and capabilities.
+
+        Returns:
+            Dict suitable for JSON serialization
+        """
+        availability = self.check_tool_availability()
+
+        return {
+            "report_type": "security_scanner_capability",
+            "generated_at": datetime.utcnow().isoformat() + "Z",
+            "tools": availability.to_dict(),
+            "execution_boundary": {
+                "scanner_execution": "subprocess (CLI tools)",
+                "llm_involvement": "NONE - Qwen/Gemma analyze results AFTER scanning",
+                "mcp_dependency": "NONE - Codex/Claude MCP are operator tools only",
+                "autonomous": True,
+            },
+            "recommendations": self._generate_recommendations(availability),
+        }
+
+    def _generate_recommendations(self, availability: ToolAvailability) -> List[str]:
+        """Generate recommendations based on tool availability."""
+        recommendations = []
+
+        if not availability.snyk_available:
+            recommendations.append("Install snyk: npm install -g snyk")
+
+        if not availability.trivy_available:
+            recommendations.append("Install trivy: brew install trivy (or apt/choco)")
+
+        if not availability.semgrep_available:
+            recommendations.append("Install semgrep: pip install semgrep")
+
+        if availability.all_available:
+            recommendations.append("All tools available - full security scanning ready")
+
+        if not availability.any_available:
+            recommendations.append("No security scanning tools installed - scans will report unavailable")
+
+        return recommendations

--- a/modules/infrastructure/security_scanner/tests/__init__.py
+++ b/modules/infrastructure/security_scanner/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Security Scanner Tests."""

--- a/modules/infrastructure/security_scanner/tests/test_security_scanner.py
+++ b/modules/infrastructure/security_scanner/tests/test_security_scanner.py
@@ -1,0 +1,500 @@
+"""
+Security Scanner Tests
+
+All tests use mocked subprocess calls - no actual CLI tools required.
+Tests verify the execution boundary: CLI subprocess executes, Qwen/Gemma not involved.
+
+WSP References:
+- WSP 5: Test coverage
+- WSP 72: Module independence (no external dependencies in tests)
+"""
+
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+
+from modules.infrastructure.security_scanner.src.security_scanner import (
+    SecurityScanner,
+    ScanResult,
+    ToolAvailability,
+)
+from modules.infrastructure.security_scanner.src.schemas import (
+    VulnerabilityReport,
+    VulnerabilityFinding,
+    SeverityLevel,
+    normalize_snyk_output,
+    normalize_trivy_output,
+    normalize_semgrep_output,
+)
+
+
+# =============================================================================
+# Mock Data
+# =============================================================================
+
+MOCK_SNYK_OUTPUT = {
+    "vulnerabilities": [
+        {
+            "id": "SNYK-JS-LODASH-1234",
+            "title": "Prototype Pollution",
+            "severity": "high",
+            "packageName": "lodash",
+            "version": "4.17.15",
+            "fixedIn": ["4.17.21"],
+            "description": "Prototype pollution vulnerability in lodash",
+        },
+        {
+            "id": "SNYK-JS-AXIOS-5678",
+            "title": "SSRF Vulnerability",
+            "severity": "critical",
+            "packageName": "axios",
+            "version": "0.21.0",
+            "fixedIn": ["0.21.1"],
+            "description": "Server-side request forgery",
+        },
+    ]
+}
+
+MOCK_TRIVY_OUTPUT = {
+    "Results": [
+        {
+            "Target": "package-lock.json",
+            "Vulnerabilities": [
+                {
+                    "VulnerabilityID": "CVE-2021-44228",
+                    "PkgName": "log4j",
+                    "InstalledVersion": "2.14.0",
+                    "FixedVersion": "2.17.0",
+                    "Severity": "CRITICAL",
+                    "Title": "Log4Shell",
+                    "Description": "Remote code execution via JNDI lookup",
+                },
+            ],
+        }
+    ]
+}
+
+MOCK_SEMGREP_OUTPUT = {
+    "results": [
+        {
+            "check_id": "python.lang.security.audit.dangerous-exec",
+            "path": "src/main.py",
+            "start": {"line": 42},
+            "extra": {
+                "severity": "ERROR",
+                "message": "Dangerous use of exec()",
+            },
+        },
+    ]
+}
+
+
+# =============================================================================
+# Tool Availability Tests
+# =============================================================================
+
+class TestToolAvailability:
+    """Tests for tool availability detection."""
+
+    def test_no_tools_available(self):
+        """Test when no tools are installed."""
+        with patch("shutil.which", return_value=None):
+            scanner = SecurityScanner()
+            availability = scanner.check_tool_availability()
+
+            assert not availability.snyk_available
+            assert not availability.trivy_available
+            assert not availability.semgrep_available
+            assert not availability.any_available
+            assert not availability.all_available
+
+    def test_snyk_available(self):
+        """Test snyk detection."""
+        def mock_which(cmd):
+            return "/usr/bin/snyk" if cmd == "snyk" else None
+
+        with patch("shutil.which", side_effect=mock_which):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(
+                    returncode=0,
+                    stdout="1.1000.0",
+                )
+                scanner = SecurityScanner()
+                availability = scanner.check_tool_availability()
+
+                assert availability.snyk_available
+                assert availability.snyk_version == "1.1000.0"
+                assert availability.snyk_path == "/usr/bin/snyk"
+                assert not availability.trivy_available
+                assert not availability.semgrep_available
+                assert availability.any_available
+                assert not availability.all_available
+
+    def test_all_tools_available(self):
+        """Test when all tools are installed."""
+        def mock_which(cmd):
+            paths = {
+                "snyk": "/usr/bin/snyk",
+                "trivy": "/usr/bin/trivy",
+                "semgrep": "/usr/bin/semgrep",
+            }
+            return paths.get(cmd)
+
+        with patch("shutil.which", side_effect=mock_which):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(
+                    returncode=0,
+                    stdout="1.0.0",
+                )
+                scanner = SecurityScanner()
+                availability = scanner.check_tool_availability()
+
+                assert availability.snyk_available
+                assert availability.trivy_available
+                assert availability.semgrep_available
+                assert availability.any_available
+                assert availability.all_available
+
+    def test_availability_caching(self):
+        """Test that availability is cached."""
+        with patch("shutil.which", return_value=None) as mock_which:
+            scanner = SecurityScanner()
+
+            # First call
+            scanner.check_tool_availability()
+            call_count_1 = mock_which.call_count
+
+            # Second call (should use cache)
+            scanner.check_tool_availability()
+            call_count_2 = mock_which.call_count
+
+            assert call_count_1 == call_count_2  # No additional calls
+
+            # Force refresh
+            scanner.check_tool_availability(force_refresh=True)
+            assert mock_which.call_count > call_count_2
+
+
+# =============================================================================
+# Scan Execution Tests
+# =============================================================================
+
+class TestSnykScanner:
+    """Tests for Snyk scanning."""
+
+    def test_snyk_unavailable(self):
+        """Test scan when snyk not installed."""
+        with patch("shutil.which", return_value=None):
+            scanner = SecurityScanner()
+            result = scanner.scan_snyk(".")
+
+            assert not result.success
+            assert not result.available
+            assert result.tool == "snyk"
+            assert "not installed" in result.error_message
+
+    def test_snyk_scan_success(self):
+        """Test successful snyk scan with mocked output."""
+        def mock_which(cmd):
+            return "/usr/bin/snyk" if cmd == "snyk" else None
+
+        with patch("shutil.which", side_effect=mock_which):
+            with patch("subprocess.run") as mock_run:
+                # Version check
+                mock_run.return_value = MagicMock(
+                    returncode=0,
+                    stdout=json.dumps(MOCK_SNYK_OUTPUT),
+                    stderr="",
+                )
+
+                scanner = SecurityScanner()
+                scanner._availability = ToolAvailability(snyk_available=True)
+                result = scanner.scan_snyk(".")
+
+                assert result.success
+                assert result.available
+                assert result.report is not None
+                assert result.report.scanner == "snyk"
+                assert len(result.report.findings) == 2
+                assert result.report.critical_count == 1
+                assert result.report.high_count == 1
+
+    def test_snyk_scan_with_vulnerabilities(self):
+        """Test snyk correctly parses vulnerability details."""
+        with patch("shutil.which", return_value="/usr/bin/snyk"):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(
+                    returncode=1,  # Non-zero = vulns found
+                    stdout=json.dumps(MOCK_SNYK_OUTPUT),
+                    stderr="",
+                )
+
+                scanner = SecurityScanner()
+                scanner._availability = ToolAvailability(snyk_available=True)
+                result = scanner.scan_snyk(".")
+
+                assert result.success  # Vulns found is still success
+                finding = result.report.findings[0]
+                assert finding.vuln_id == "SNYK-JS-LODASH-1234"
+                assert finding.package_name == "lodash"
+                assert finding.severity == SeverityLevel.HIGH
+                assert finding.fix_available
+                assert finding.fix_version == "4.17.21"
+
+
+class TestTrivyScanner:
+    """Tests for Trivy scanning."""
+
+    def test_trivy_unavailable(self):
+        """Test scan when trivy not installed."""
+        with patch("shutil.which", return_value=None):
+            scanner = SecurityScanner()
+            result = scanner.scan_trivy(".")
+
+            assert not result.success
+            assert not result.available
+            assert result.tool == "trivy"
+            assert "not installed" in result.error_message
+
+    def test_trivy_scan_success(self):
+        """Test successful trivy scan with mocked output."""
+        with patch("shutil.which", return_value="/usr/bin/trivy"):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(
+                    returncode=0,
+                    stdout=json.dumps(MOCK_TRIVY_OUTPUT),
+                    stderr="",
+                )
+
+                scanner = SecurityScanner()
+                scanner._availability = ToolAvailability(trivy_available=True)
+                result = scanner.scan_trivy(".")
+
+                assert result.success
+                assert result.available
+                assert result.report is not None
+                assert result.report.scanner == "trivy"
+                assert len(result.report.findings) == 1
+                assert result.report.critical_count == 1
+
+                finding = result.report.findings[0]
+                assert finding.vuln_id == "CVE-2021-44228"
+                assert finding.severity == SeverityLevel.CRITICAL
+
+
+class TestSemgrepScanner:
+    """Tests for Semgrep scanning."""
+
+    def test_semgrep_unavailable(self):
+        """Test scan when semgrep not installed."""
+        with patch("shutil.which", return_value=None):
+            scanner = SecurityScanner()
+            result = scanner.scan_semgrep(".")
+
+            assert not result.success
+            assert not result.available
+            assert result.tool == "semgrep"
+            assert "not installed" in result.error_message
+
+    def test_semgrep_scan_success(self):
+        """Test successful semgrep scan with mocked output."""
+        with patch("shutil.which", return_value="/usr/bin/semgrep"):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(
+                    returncode=0,
+                    stdout=json.dumps(MOCK_SEMGREP_OUTPUT),
+                    stderr="",
+                )
+
+                scanner = SecurityScanner()
+                scanner._availability = ToolAvailability(semgrep_available=True)
+                result = scanner.scan_semgrep(".")
+
+                assert result.success
+                assert result.available
+                assert result.report is not None
+                assert result.report.scanner == "semgrep"
+                assert len(result.report.findings) == 1
+
+                finding = result.report.findings[0]
+                assert finding.file_path == "src/main.py"
+                assert finding.line_number == 42
+                assert finding.severity == SeverityLevel.HIGH
+
+
+# =============================================================================
+# Schema Normalization Tests
+# =============================================================================
+
+class TestSchemas:
+    """Tests for output normalization schemas."""
+
+    def test_severity_mapping_snyk(self):
+        """Test Snyk severity mapping."""
+        assert SeverityLevel.from_snyk("critical") == SeverityLevel.CRITICAL
+        assert SeverityLevel.from_snyk("high") == SeverityLevel.HIGH
+        assert SeverityLevel.from_snyk("medium") == SeverityLevel.MEDIUM
+        assert SeverityLevel.from_snyk("low") == SeverityLevel.LOW
+        assert SeverityLevel.from_snyk("unknown") == SeverityLevel.UNKNOWN
+
+    def test_severity_mapping_trivy(self):
+        """Test Trivy severity mapping."""
+        assert SeverityLevel.from_trivy("CRITICAL") == SeverityLevel.CRITICAL
+        assert SeverityLevel.from_trivy("HIGH") == SeverityLevel.HIGH
+        assert SeverityLevel.from_trivy("MEDIUM") == SeverityLevel.MEDIUM
+        assert SeverityLevel.from_trivy("LOW") == SeverityLevel.LOW
+        assert SeverityLevel.from_trivy("UNKNOWN") == SeverityLevel.UNKNOWN
+
+    def test_severity_mapping_semgrep(self):
+        """Test Semgrep severity mapping."""
+        assert SeverityLevel.from_semgrep("ERROR") == SeverityLevel.HIGH
+        assert SeverityLevel.from_semgrep("WARNING") == SeverityLevel.MEDIUM
+        assert SeverityLevel.from_semgrep("INFO") == SeverityLevel.INFO
+
+    def test_vulnerability_report_summary(self):
+        """Test VulnerabilityReport calculates summary correctly."""
+        findings = [
+            VulnerabilityFinding(
+                vuln_id="CVE-1", title="Test 1", severity=SeverityLevel.CRITICAL, scanner="test"
+            ),
+            VulnerabilityFinding(
+                vuln_id="CVE-2", title="Test 2", severity=SeverityLevel.HIGH, scanner="test"
+            ),
+            VulnerabilityFinding(
+                vuln_id="CVE-3", title="Test 3", severity=SeverityLevel.HIGH, scanner="test"
+            ),
+            VulnerabilityFinding(
+                vuln_id="CVE-4", title="Test 4", severity=SeverityLevel.MEDIUM, scanner="test"
+            ),
+        ]
+
+        report = VulnerabilityReport(
+            scan_id="test-123",
+            scanner="test",
+            scan_target=".",
+            scan_timestamp="2026-04-18T00:00:00Z",
+            findings=findings,
+        )
+
+        assert report.total_findings == 4
+        assert report.critical_count == 1
+        assert report.high_count == 2
+        assert report.medium_count == 1
+        assert report.low_count == 0
+        assert report.max_severity == SeverityLevel.CRITICAL
+
+    def test_report_to_json(self):
+        """Test report serialization to JSON."""
+        report = VulnerabilityReport(
+            scan_id="test-123",
+            scanner="snyk",
+            scan_target=".",
+            scan_timestamp="2026-04-18T00:00:00Z",
+            findings=[],
+        )
+
+        json_str = report.to_json()
+        parsed = json.loads(json_str)
+
+        assert parsed["scan_id"] == "test-123"
+        assert parsed["scanner"] == "snyk"
+        assert "summary" in parsed
+
+
+# =============================================================================
+# Capability Report Tests
+# =============================================================================
+
+class TestCapabilityReport:
+    """Tests for capability reporting."""
+
+    def test_capability_report_no_tools(self):
+        """Test capability report when no tools installed."""
+        with patch("shutil.which", return_value=None):
+            scanner = SecurityScanner()
+            report = scanner.generate_capability_report()
+
+            assert report["report_type"] == "security_scanner_capability"
+            assert not report["tools"]["any_available"]
+            assert report["execution_boundary"]["autonomous"] is True
+            assert "NONE" in report["execution_boundary"]["llm_involvement"]
+            assert "NONE" in report["execution_boundary"]["mcp_dependency"]
+            # Check that one of the recommendations mentions no tools
+            assert any("No security scanning tools" in r for r in report["recommendations"])
+
+    def test_capability_report_all_tools(self):
+        """Test capability report when all tools installed."""
+        def mock_which(cmd):
+            return f"/usr/bin/{cmd}"
+
+        with patch("shutil.which", side_effect=mock_which):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout="1.0.0")
+
+                scanner = SecurityScanner()
+                report = scanner.generate_capability_report()
+
+                assert report["tools"]["all_available"]
+                assert "All tools available" in str(report["recommendations"])
+
+
+# =============================================================================
+# Execution Boundary Tests
+# =============================================================================
+
+class TestExecutionBoundary:
+    """Tests verifying the execution boundary is correct."""
+
+    def test_subprocess_is_execution_mechanism(self):
+        """Verify subprocess.run is used for execution."""
+        with patch("shutil.which", return_value="/usr/bin/snyk"):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(
+                    returncode=0,
+                    stdout="{}",
+                    stderr="",
+                )
+
+                scanner = SecurityScanner()
+                scanner._availability = ToolAvailability(snyk_available=True)
+                scanner.scan_snyk(".")
+
+                # Verify subprocess.run was called
+                mock_run.assert_called()
+
+                # Verify it was called with snyk command
+                call_args = mock_run.call_args[0][0]
+                assert "snyk" in call_args
+
+    def test_no_llm_in_scan_path(self):
+        """Verify no LLM/Qwen/Gemma imports in scanner (comments documenting boundary are OK)."""
+        # This test verifies by inspection that the scanner module
+        # does not IMPORT any LLM-related modules
+        import modules.infrastructure.security_scanner.src.security_scanner as scanner_module
+
+        module_source = scanner_module.__file__
+
+        with open(module_source, "r") as f:
+            source_code = f.read()
+
+        # Check for actual imports - these would violate execution boundary
+        # (Comments explaining the boundary are allowed)
+        forbidden_imports = [
+            "from llm_engine",
+            "import llm_engine",
+            "from mcp__",
+            "import mcp__",
+            "from anthropic",
+            "import anthropic",
+            "from openai",
+            "import openai",
+            "from qwen",
+            "import qwen",
+            "from gemma",
+            "import gemma",
+        ]
+
+        for pattern in forbidden_imports:
+            assert pattern.lower() not in source_code.lower(), \
+                f"Scanner should not import '{pattern}' - execution boundary violation"

--- a/modules/platform_integration/youtube_auth/INTERFACE.md
+++ b/modules/platform_integration/youtube_auth/INTERFACE.md
@@ -69,4 +69,61 @@ except Exception as e:
 
 ## Internal Functions
 The module contains internal helper functions not part of the public interface:
-- `get_credentials_for_index(index)`: Helper function to retrieve credential paths for a specific index 
+- `get_credentials_for_index(index)`: Helper function to retrieve credential paths for a specific index
+
+---
+
+## OAuth Credential Health Reporting (`oauth_health.py`)
+
+WSP 97 truth signaling for credential capacity visibility.
+
+### Status Vocabulary
+| Status | Meaning |
+|--------|---------|
+| `healthy` | Refresh token valid, quota available |
+| `token_revoked` | User revoked grant in Google account UI |
+| `token_expired_or_revoked` | `invalid_grant` but cause not distinguishable |
+| `refresh_failed` | Network or non-auth exception during refresh |
+| `credential_set_unconfigured` | Env or token/secret file missing |
+| `no_refresh_token` | Credential loaded but lacks refresh_token |
+| `quota_exhausted` | Exhausted this cycle, not an auth failure |
+
+### Key Functions
+
+#### `classify_refresh_error(error_msg: str) -> Tuple[str, str]`
+Maps a Google OAuth refresh exception to `(status, reason)`. Only claims `token_revoked` when message explicitly contains "revoked".
+
+#### `write_health_report(per_set, output_path=None) -> Path`
+Persists JSON artifact to `reports/oauth_credential_health.json`:
+```json
+{
+  "generated_at": "<iso8601>",
+  "credential_sets": {
+    "total_configured": 2,
+    "operational": [10],
+    "dead": [1],
+    "quota_exhausted_today": [],
+    "effective_daily_quota_estimate": 10000
+  },
+  "per_set": [
+    {
+      "set_id": 1,
+      "status": "token_expired_or_revoked",
+      "operator_action": "python modules/platform_integration/youtube_auth/scripts/authorize_set1.py",
+      ...
+    }
+  ]
+}
+```
+
+#### `format_capacity_log(capacity) -> str`
+Returns a one-line log message surfacing dead sets and action required.
+
+#### `emit_critical_reauth(set_id, status, reason)`
+Emits CRITICAL log with exact reauth command.
+
+### Operator Visibility
+When Set 1 is dead and Set 10 is healthy:
+- Artifact: `dead=[1]`, `operational=[10]`, `effective_daily_quota_estimate=10000`
+- Log: `"1/2 sets operational; dead=[1]; action_required=python .../authorize_set1.py"`
+- CRITICAL: `"operator must run: python modules/.../authorize_set1.py (use Chrome)"` 

--- a/modules/platform_integration/youtube_auth/ModLog.md
+++ b/modules/platform_integration/youtube_auth/ModLog.md
@@ -12,6 +12,96 @@ This log tracks changes specific to the **youtube_auth** module in the **platfor
 
 ## MODLOG ENTRIES
 
+### 2026-04-18 - YT1: invalid_grant visibility + oauth_credential_health.json artifact
+
+**By:** 0102 (Worker YT1)
+**WSP References:** WSP 22 (ModLog), WSP 50 (Pre-Action Verification), WSP 97 (Truth Signaling)
+
+**Problem:**
+Set 1 (UnDaoDu/Chrome) refresh token expired ~April 2026. `get_authenticated_service()`
+did log the failure and add the set to `exhausted_sets`, but downstream stream resolver
+/ quota selection logs only said "Set 10 exhausted". Operators could not see that
+effective quota capacity had halved (from 2 sets to 1). No persistent artifact existed
+to make this truthfully observable.
+
+**Scope:**
+Truth signaling only. Does NOT perform OAuth re-auth flow. Set 1 still requires manual
+re-authorization: `python modules/platform_integration/youtube_auth/scripts/authorize_set1.py`.
+
+**Changes:**
+- **New** `src/oauth_health.py`:
+  - Status literals: `healthy`, `token_revoked`, `token_expired_or_revoked`,
+    `refresh_failed`, `credential_set_unconfigured`, `no_refresh_token`, `quota_exhausted`.
+  - `classify_refresh_error(msg)` — only claims `token_revoked` when Google's message
+    literally contains "revoked"; otherwise returns `token_expired_or_revoked` (Google
+    does not reliably distinguish the two).
+  - `build_set_entry`, `compute_effective_capacity`, `write_health_report`,
+    `format_capacity_log`, `emit_critical_reauth`.
+  - Per-set metadata (account label, browser hint) for Set 1 and Set 10.
+- **Modified** `src/youtube_auth.py`:
+  - `get_authenticated_service()`: in the `invalid_grant` branch, call the classifier,
+    emit CRITICAL with the exact reauth command, persist health snapshot.
+  - After resolving rotation targets, emit a truthful one-line capacity log via
+    `format_capacity_log()` — surfaces dead sets alongside quota-exhausted sets.
+  - `preflight_oauth_check()`: classify every set (healthy / unconfigured / no_refresh_token
+    / token_revoked / token_expired_or_revoked / refresh_failed) and persist the artifact
+    before returning.
+  - Warning lines now use `oauth_health.reauth_command_for(idx)` — one source of truth
+    for the reauth command string.
+- **New artifact** `reports/oauth_credential_health.json`:
+  ```json
+  {
+    "generated_at": "...",
+    "credential_sets": {
+      "total_configured": 2, "operational": [10], "dead": [1],
+      "quota_exhausted_today": [], "effective_daily_quota_estimate": 10000
+    },
+    "per_set": [
+      { "set_id": 1, "account_label": "UnDaoDu / Move2Japan", "browser_hint": "Chrome",
+        "status": "token_expired_or_revoked", "reason": "...",
+        "operator_action": "python .../authorize_set1.py", "last_checked": "..." },
+      { "set_id": 10, "status": "healthy", "operator_action": null, ... }
+    ]
+  }
+  ```
+- **New tests** `tests/test_oauth_credential_health.py` (16 tests, all passing, no network):
+  - Classifier: revoked, expired-or-revoked, non-oauth, empty.
+  - `build_set_entry`: healthy has no action; dead carries exact reauth command.
+  - `compute_effective_capacity`: only healthy count toward quota; quota_exhausted is
+    not dead; all-dead yields zero quota.
+  - `format_capacity_log`: dead sets surface `action_required`; quota-only does not.
+  - `write_health_report`: schema fields present; JSON roundtrip intact.
+  - `emit_critical_reauth`: CRITICAL log contains the exact command.
+  - `preflight_oauth_check` end-to-end: simulated invalid_grant on Set 1 while Set 10
+    healthy → artifact reports `dead=[1]`, `operational=[10]`, quota=10000, capacity log
+    says "1/2 sets operational; dead=[1]". Regression guard against the original
+    misleading "only Set 10 exhausted" logging.
+
+**Verification:**
+- `pytest modules/platform_integration/youtube_auth/tests/test_oauth_credential_health.py`
+  → 16 passed.
+- Full youtube_auth suite before my changes: 15 failing, 21 passing (pre-existing).
+  After my changes: 15 failing, 43 passing. Same 15 failures, +22 new passes — zero
+  regressions introduced.
+
+**Out of scope (not done here):**
+- Manual Set 1 browser OAuth — 012 must run `authorize_set1.py` when ready.
+- Stream resolver call sites still log their own messages; the new capacity log is
+  emitted from `get_authenticated_service()` on rotation and from
+  `preflight_oauth_check()` at startup, which is where 012's brief specified truthful
+  logging should land. Stream resolver paths inherit it through those call sites.
+
+**Files Changed:**
+- `modules/platform_integration/youtube_auth/src/oauth_health.py` (new, 219 lines)
+- `modules/platform_integration/youtube_auth/src/youtube_auth.py` (classifier
+  integration + capacity log + persisted artifact)
+- `modules/platform_integration/youtube_auth/tests/test_oauth_credential_health.py`
+  (new, 16 tests, no network)
+- `modules/platform_integration/youtube_auth/reports/oauth_credential_health.json`
+  (new example artifact)
+
+---
+
 ### 2026-01-27 - Fix OAuth Browser Selection in get_authenticated_service()
 
 **By:** 0102

--- a/modules/platform_integration/youtube_auth/src/oauth_health.py
+++ b/modules/platform_integration/youtube_auth/src/oauth_health.py
@@ -1,0 +1,222 @@
+"""
+YouTube OAuth Credential Health Reporting (WSP 97 truth signaling)
+
+Classifies OAuth refresh failures beyond "expired vs missing" and persists an
+operator-visible artifact describing per-set status and effective daily quota
+capacity. Stream resolver / quota selection paths can read the same classifier
+so operator logs reflect real capacity, not just in-memory rotation state.
+
+Status vocabulary (literals, not an Enum to keep JSON-friendly):
+    - healthy
+    - token_revoked                (user revoked grant in Google account UI)
+    - token_expired_or_revoked     (invalid_grant, cause not distinguishable)
+    - refresh_failed               (network / non-auth exception during refresh)
+    - credential_set_unconfigured  (env or token/secret file missing)
+    - no_refresh_token             (cred loaded but lacks refresh_token)
+    - quota_exhausted              (exhausted this cycle, not an auth failure)
+
+The artifact schema is documented in the generate_report() docstring.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+STATUS_HEALTHY = "healthy"
+STATUS_TOKEN_REVOKED = "token_revoked"
+STATUS_TOKEN_EXPIRED_OR_REVOKED = "token_expired_or_revoked"
+STATUS_REFRESH_FAILED = "refresh_failed"
+STATUS_UNCONFIGURED = "credential_set_unconfigured"
+STATUS_NO_REFRESH_TOKEN = "no_refresh_token"
+STATUS_QUOTA_EXHAUSTED = "quota_exhausted"
+
+DEAD_STATUSES = frozenset({
+    STATUS_TOKEN_REVOKED,
+    STATUS_TOKEN_EXPIRED_OR_REVOKED,
+    STATUS_REFRESH_FAILED,
+    STATUS_UNCONFIGURED,
+    STATUS_NO_REFRESH_TOKEN,
+})
+
+DAILY_QUOTA_PER_SET = 10000
+
+SET_METADATA: Dict[int, Dict[str, str]] = {
+    1: {
+        "account_label": "UnDaoDu / Move2Japan",
+        "browser_hint": "Chrome",
+    },
+    10: {
+        "account_label": "FoundUps / antifaFM",
+        "browser_hint": "Edge",
+    },
+}
+
+_DEFAULT_REPORT_PATH = (
+    Path(__file__).resolve().parent.parent / "reports" / "oauth_credential_health.json"
+)
+
+
+def reauth_command_for(set_id: int) -> str:
+    """Exact command an operator must run to re-authorize a credential set."""
+    return f"python modules/platform_integration/youtube_auth/scripts/authorize_set{set_id}.py"
+
+
+def classify_refresh_error(error_msg: str) -> Tuple[str, str]:
+    """
+    Map a Google OAuth refresh exception message to a (status, reason) tuple.
+
+    Google returns invalid_grant for both expired AND revoked refresh tokens
+    and does not reliably distinguish the two in the error body. We classify
+    as token_revoked only when the message explicitly contains 'revoked';
+    otherwise we return token_expired_or_revoked so operators are told the
+    truth ("we cannot tell which") rather than guessing.
+    """
+    msg = error_msg or ""
+    lowered = msg.lower()
+    if "invalid_grant" in msg:
+        if "revoked" in lowered:
+            return STATUS_TOKEN_REVOKED, "Refresh token revoked by user or Google"
+        return (
+            STATUS_TOKEN_EXPIRED_OR_REVOKED,
+            "Refresh token expired or revoked (Google does not distinguish)",
+        )
+    return STATUS_REFRESH_FAILED, f"Refresh failed: {msg[:200]}"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def build_set_entry(
+    set_id: int,
+    status: str,
+    reason: Optional[str] = None,
+    last_checked: Optional[str] = None,
+) -> Dict[str, object]:
+    """Build one per-set entry for the health report."""
+    meta = SET_METADATA.get(set_id, {})
+    operator_action = (
+        reauth_command_for(set_id) if status in DEAD_STATUSES else None
+    )
+    return {
+        "set_id": set_id,
+        "account_label": meta.get("account_label", f"Set {set_id}"),
+        "browser_hint": meta.get("browser_hint", "default"),
+        "status": status,
+        "reason": reason,
+        "operator_action": operator_action,
+        "last_checked": last_checked or _now_iso(),
+    }
+
+
+def compute_effective_capacity(
+    per_set: Iterable[Dict[str, object]],
+) -> Dict[str, object]:
+    """
+    Summarize per-set entries into operational/dead counts and daily quota.
+
+    Only sets with status == healthy count toward the effective daily quota;
+    everything in DEAD_STATUSES is treated as dead. quota_exhausted is neither
+    healthy nor permanently dead — it reduces "currently usable" capacity, but
+    the set is expected to return after daily reset, so we count it separately.
+    """
+    per_set = list(per_set)
+    total = len(per_set)
+    operational: List[int] = []
+    dead: List[int] = []
+    exhausted: List[int] = []
+    for entry in per_set:
+        status = entry.get("status")
+        set_id = entry.get("set_id")
+        if status == STATUS_HEALTHY:
+            operational.append(set_id)
+        elif status == STATUS_QUOTA_EXHAUSTED:
+            exhausted.append(set_id)
+        elif status in DEAD_STATUSES:
+            dead.append(set_id)
+    return {
+        "total_configured": total,
+        "operational": operational,
+        "dead": dead,
+        "quota_exhausted_today": exhausted,
+        "effective_daily_quota_estimate": len(operational) * DAILY_QUOTA_PER_SET,
+    }
+
+
+def write_health_report(
+    per_set: Iterable[Dict[str, object]],
+    output_path: Optional[Path] = None,
+) -> Path:
+    """
+    Persist the health report to JSON. Returns the path that was written.
+
+    Report schema:
+    {
+      "generated_at": "<iso8601 utc>",
+      "credential_sets": {
+        "total_configured": int,
+        "operational": [set_id, ...],
+        "dead": [set_id, ...],
+        "quota_exhausted_today": [set_id, ...],
+        "effective_daily_quota_estimate": int
+      },
+      "per_set": [ <build_set_entry output>, ... ]
+    }
+    """
+    per_set_list = list(per_set)
+    report = {
+        "generated_at": _now_iso(),
+        "credential_sets": compute_effective_capacity(per_set_list),
+        "per_set": per_set_list,
+    }
+
+    path = output_path or _DEFAULT_REPORT_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2, sort_keys=False)
+    logger.info(f"[OAUTH-HEALTH] Wrote credential health report to {path}")
+    return path
+
+
+def format_capacity_log(capacity: Dict[str, object]) -> str:
+    """
+    Render a truthful one-line capacity message for operator logs.
+
+    Example:
+        "Effective credential capacity: 1/2 sets operational; dead=[1]; "
+        "action_required=python modules/.../authorize_set1.py"
+    """
+    total = capacity.get("total_configured", 0)
+    operational = capacity.get("operational", []) or []
+    dead = capacity.get("dead", []) or []
+    exhausted = capacity.get("quota_exhausted_today", []) or []
+
+    parts = [
+        f"Effective credential capacity: {len(operational)}/{total} sets operational"
+    ]
+    if dead:
+        parts.append(f"dead={dead}")
+    if exhausted:
+        parts.append(f"quota_exhausted_today={exhausted}")
+    if dead:
+        actions = "; ".join(reauth_command_for(s) for s in dead)
+        parts.append(f"action_required={actions}")
+    return "; ".join(parts)
+
+
+def emit_critical_reauth(set_id: int, status: str, reason: Optional[str]) -> None:
+    """Emit a CRITICAL log telling the operator exactly how to reauthorize."""
+    cmd = reauth_command_for(set_id)
+    meta = SET_METADATA.get(set_id, {})
+    label = meta.get("account_label", f"Set {set_id}")
+    browser = meta.get("browser_hint", "default browser")
+    logger.critical(
+        f"[OAUTH-HEALTH] CRITICAL: credential set {set_id} ({label}) status={status} "
+        f"reason={reason!r} -- operator must run: {cmd} (use {browser})"
+    )

--- a/modules/platform_integration/youtube_auth/src/youtube_auth.py
+++ b/modules/platform_integration/youtube_auth/src/youtube_auth.py
@@ -7,6 +7,7 @@ from googleapiclient.discovery import build
 from google.auth.transport.requests import Request
 from googleapiclient.errors import HttpError
 from modules.platform_integration.youtube_auth.src.quota_monitor import QuotaMonitor
+from modules.platform_integration.youtube_auth.src import oauth_health
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +39,40 @@ def get_credentials_for_index(index):
         return None
         
     return client_secrets, token_file
+
+def _persist_health_snapshot(failing_set=None, failing_status=None, failing_reason=None):
+    """
+    Write modules/platform_integration/youtube_auth/reports/oauth_credential_health.json
+    summarizing the current rotation state. Called whenever we classify an
+    invalid_grant or preflight completes so operators see real capacity.
+
+    Healthy sets = configured sets not marked exhausted/dead.
+    The caller may pass a specific failing set to override its status in the
+    snapshot (used when marking a fresh invalid_grant before it appears in
+    exhausted_sets downstream).
+    """
+    from modules.platform_integration.youtube_auth.src.quota_monitor import get_available_credential_sets
+
+    configured = get_available_credential_sets()
+    exhausted = getattr(get_authenticated_service, 'exhausted_sets', set())
+
+    per_set = []
+    for set_id in configured:
+        if set_id == failing_set and failing_status:
+            entry = oauth_health.build_set_entry(set_id, failing_status, failing_reason)
+        elif set_id in exhausted:
+            # exhausted_sets is ambiguous (quota OR auth failure); caller path
+            # supplies classification for auth failures. Default to quota.
+            entry = oauth_health.build_set_entry(set_id, oauth_health.STATUS_QUOTA_EXHAUSTED)
+        else:
+            entry = oauth_health.build_set_entry(set_id, oauth_health.STATUS_HEALTHY)
+        per_set.append(entry)
+
+    try:
+        oauth_health.write_health_report(per_set)
+    except Exception as write_e:
+        logger.warning(f"[OAUTH-HEALTH] Failed to persist health report: {write_e}")
+
 
 def get_authenticated_service(token_index=None):
     """
@@ -94,6 +129,19 @@ def get_authenticated_service(token_index=None):
         
         indices_to_try = available_sets
         logger.info(f"[REFRESH] Auto-rotating through sets: {indices_to_try} (Exhausted: {get_authenticated_service.exhausted_sets})")
+
+        # WSP 97: emit truthful effective-capacity log so operators see that
+        # exhausted / dead sets reduce real quota, not just rotation targets.
+        capacity_snapshot = oauth_health.compute_effective_capacity([
+            oauth_health.build_set_entry(
+                s,
+                oauth_health.STATUS_QUOTA_EXHAUSTED
+                if s in get_authenticated_service.exhausted_sets
+                else oauth_health.STATUS_HEALTHY,
+            )
+            for s in all_sets
+        ])
+        logger.info(f"[OAUTH-HEALTH] {oauth_health.format_capacity_log(capacity_snapshot)}")
     
     for index in indices_to_try:
         logger.info(f"[U+1F511] Attempting authentication with credential set {index}")
@@ -155,22 +203,17 @@ def get_authenticated_service(token_index=None):
                         logger.info(f"[U+1F4C5] New token expires at: {creds.expiry} (valid for ~1 hour)")
                 except Exception as e:
                     error_msg = str(e)
-                    # Better error distinction
+                    status, reason = oauth_health.classify_refresh_error(error_msg)
                     if 'invalid_grant' in error_msg:
-                        if 'Token has been expired or revoked' in error_msg:
-                            # Try to distinguish between expired and revoked
-                            if 'revoked' in error_msg.lower():
-                                logger.error(f"[FORBIDDEN] Token has been REVOKED for set {index} - user action required")
-                                logger.info(f"ℹ️ To fix: Run 'python modules/platform_integration/youtube_auth/scripts/authorize_set{index}.py'")
-                            else:
-                                logger.error(f"⏰ Refresh token EXPIRED for set {index} (tokens last 6 months if unused)")
-                                logger.info(f"ℹ️ To fix: Run 'python modules/platform_integration/youtube_auth/scripts/authorize_set{index}.py'")
-                        else:
-                            logger.error(f"[FAIL] Invalid grant error for set {index}: {error_msg}")
+                        # CRITICAL log with exact reauth command per WSP 97
+                        oauth_health.emit_critical_reauth(index, status, reason)
                         # Mark this set offline for this process to avoid repeated retries during fallback flows
                         get_authenticated_service.exhausted_sets.add(index)
                     else:
                         logger.error(f"[FAIL] Failed to refresh token for set {index}: {e}")
+
+                    # Persist operator-visible health artifact for this failure
+                    _persist_health_snapshot(failing_set=index, failing_status=status, failing_reason=reason)
 
                     # Continue to next credential set instead of trying OAuth flow
                     continue
@@ -445,6 +488,8 @@ def preflight_oauth_check(auto_reauth: bool = False, credential_sets=None) -> di
         'missing': [],
         'reauth_needed': False
     }
+    # Classified per-set entries for the health report (WSP 97)
+    per_set_classified = {}
 
     scopes_str = os.getenv('YOUTUBE_SCOPES', '').strip()
     if not scopes_str:
@@ -459,6 +504,10 @@ def preflight_oauth_check(auto_reauth: bool = False, credential_sets=None) -> di
         creds_data = get_credentials_for_index(index)
         if not creds_data:
             result['missing'].append(index)
+            per_set_classified[index] = oauth_health.build_set_entry(
+                index, oauth_health.STATUS_UNCONFIGURED,
+                "Client secrets or token file path not configured in .env"
+            )
             continue
 
         client_secrets_file, token_file = creds_data
@@ -466,6 +515,10 @@ def preflight_oauth_check(auto_reauth: bool = False, credential_sets=None) -> di
         if not os.path.exists(token_file):
             logger.warning(f"[PREFLIGHT] Token file missing for set {index}")
             result['missing'].append(index)
+            per_set_classified[index] = oauth_health.build_set_entry(
+                index, oauth_health.STATUS_UNCONFIGURED,
+                f"Token file missing at {token_file}"
+            )
             continue
 
         try:
@@ -481,20 +534,34 @@ def preflight_oauth_check(auto_reauth: bool = False, credential_sets=None) -> di
                     f.write(creds.to_json())
                 logger.info(f"[PREFLIGHT] Set {index} refreshed successfully")
                 result['healthy'].append(index)
+                per_set_classified[index] = oauth_health.build_set_entry(
+                    index, oauth_health.STATUS_HEALTHY
+                )
 
             elif creds.valid:
                 logger.info(f"[PREFLIGHT] Set {index} is valid")
                 result['healthy'].append(index)
+                per_set_classified[index] = oauth_health.build_set_entry(
+                    index, oauth_health.STATUS_HEALTHY
+                )
             else:
                 logger.warning(f"[PREFLIGHT] Set {index} invalid (no refresh token)")
                 result['expired'].append(index)
+                per_set_classified[index] = oauth_health.build_set_entry(
+                    index, oauth_health.STATUS_NO_REFRESH_TOKEN,
+                    "Credential loaded but has no refresh_token"
+                )
 
         except Exception as e:
             error_msg = str(e)
             if 'invalid_grant' in error_msg:
-                logger.error(f"[PREFLIGHT] Set {index} has INVALID_GRANT - token expired/revoked")
+                status, reason = oauth_health.classify_refresh_error(error_msg)
+                oauth_health.emit_critical_reauth(index, status, reason)
                 result['expired'].append(index)
                 result['reauth_needed'] = True
+                per_set_classified[index] = oauth_health.build_set_entry(
+                    index, status, reason
+                )
 
                 if auto_reauth:
                     # Determine correct browser based on credential set
@@ -553,6 +620,9 @@ def preflight_oauth_check(auto_reauth: bool = False, credential_sets=None) -> di
             else:
                 logger.error(f"[PREFLIGHT] Set {index} error: {error_msg}")
                 result['expired'].append(index)
+                per_set_classified[index] = oauth_health.build_set_entry(
+                    index, oauth_health.STATUS_REFRESH_FAILED, error_msg[:200]
+                )
 
     # Summary
     if result['healthy']:
@@ -560,8 +630,17 @@ def preflight_oauth_check(auto_reauth: bool = False, credential_sets=None) -> di
     if result['expired']:
         logger.warning(f"[PREFLIGHT] Expired/invalid sets: {result['expired']}")
         for idx in result['expired']:
-            logger.warning(f"  -> Fix set {idx}: python -m modules.platform_integration.youtube_auth.src.youtube_auth --reauth --set {idx}")
+            logger.warning(f"  -> Fix set {idx}: {oauth_health.reauth_command_for(idx)}")
     if result['missing']:
         logger.warning(f"[PREFLIGHT] Missing sets: {result['missing']}")
+
+    # WSP 97: persist operator-visible health artifact + capacity log
+    per_set_list = [per_set_classified[i] for i in sorted(per_set_classified)]
+    try:
+        oauth_health.write_health_report(per_set_list)
+    except Exception as write_e:
+        logger.warning(f"[OAUTH-HEALTH] Failed to persist health report: {write_e}")
+    capacity = oauth_health.compute_effective_capacity(per_set_list)
+    logger.info(f"[OAUTH-HEALTH] {oauth_health.format_capacity_log(capacity)}")
 
     return result

--- a/modules/platform_integration/youtube_auth/tests/TestModLog.md
+++ b/modules/platform_integration/youtube_auth/tests/TestModLog.md
@@ -1,6 +1,35 @@
 # Testing Evolution Log - YouTube Auth
 
-## 🆕 **LATEST UPDATE - WSP COMPLIANCE FOUNDATION ESTABLISHED** [OK]
+## LATEST UPDATE - 2026-04-18 OAuth Credential Health Tests (Worker YT1) [OK]
+
+### Test Run
+```bash
+python -m pytest modules/platform_integration/youtube_auth/tests/test_oauth_credential_health.py -v
+```
+
+### Results
+- **16 passed** in 3.03s
+
+### Test Coverage
+| Class | Tests | Purpose |
+|-------|-------|---------|
+| TestClassifyRefreshError | 4 | invalid_grant -> status mapping |
+| TestBuildSetEntry | 3 | operator_action = exact reauth command |
+| TestComputeEffectiveCapacity | 3 | only healthy sets count toward quota |
+| TestFormatCapacityLog | 2 | dead sets surface action_required |
+| TestWriteHealthReport | 1 | artifact schema and roundtrip |
+| TestEmitCriticalReauth | 1 | CRITICAL log with exact command |
+| TestPreflightWritesArtifact | 2 | end-to-end preflight mocking |
+
+### WSP 97 Coverage
+- `invalid_grant` classified as `token_revoked` or `token_expired_or_revoked`
+- Dead sets surfaced in capacity log (not hidden behind quota_exhausted)
+- Exact operator command in artifact: `python modules/platform_integration/youtube_auth/scripts/authorize_set1.py`
+- No browser OAuth or live Google API calls in tests
+
+---
+
+## **PREVIOUS UPDATE - WSP COMPLIANCE FOUNDATION ESTABLISHED** [OK]
 
 ### **WSP Framework Compliance Achievement**
 - **Current Status**: Tests directory structure created per WSP 49

--- a/modules/platform_integration/youtube_auth/tests/test_oauth_credential_health.py
+++ b/modules/platform_integration/youtube_auth/tests/test_oauth_credential_health.py
@@ -1,0 +1,291 @@
+"""
+No-network unit tests for OAuth credential health reporting (WSP 97).
+
+Covers:
+    - invalid_grant classifier maps error messages to the right status literals
+    - preflight failure writes the health artifact with correct schema
+    - operator_action contains the exact reauth command
+    - effective_daily_quota_estimate reflects dead sets (not just exhausted)
+    - rotation capacity log surfaces dead sets, not only quota-exhausted ones
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from modules.platform_integration.youtube_auth.src import oauth_health
+
+
+# -- classify_refresh_error ---------------------------------------------------
+
+class TestClassifyRefreshError:
+    def test_revoked_token_maps_to_token_revoked(self):
+        msg = "('invalid_grant: Token has been expired or revoked.', ...)"
+        status, reason = oauth_health.classify_refresh_error(msg)
+        assert status == oauth_health.STATUS_TOKEN_REVOKED
+        assert "revoked" in reason.lower()
+
+    def test_expired_invalid_grant_maps_to_expired_or_revoked(self):
+        # Google's actual response for a long-unused refresh token.
+        msg = "invalid_grant: Token has been expired or refresh token missing"
+        status, _ = oauth_health.classify_refresh_error(msg)
+        assert status == oauth_health.STATUS_TOKEN_EXPIRED_OR_REVOKED
+
+    def test_non_oauth_error_maps_to_refresh_failed(self):
+        status, reason = oauth_health.classify_refresh_error("Connection reset by peer")
+        assert status == oauth_health.STATUS_REFRESH_FAILED
+        assert "Connection reset" in reason
+
+    def test_empty_message_is_safe(self):
+        status, _ = oauth_health.classify_refresh_error("")
+        assert status == oauth_health.STATUS_REFRESH_FAILED
+
+
+# -- build_set_entry + operator_action ---------------------------------------
+
+class TestBuildSetEntry:
+    def test_healthy_set_has_no_operator_action(self):
+        entry = oauth_health.build_set_entry(1, oauth_health.STATUS_HEALTHY)
+        assert entry["operator_action"] is None
+        assert entry["status"] == oauth_health.STATUS_HEALTHY
+        assert entry["account_label"] == "UnDaoDu / Move2Japan"
+        assert entry["browser_hint"] == "Chrome"
+
+    def test_dead_set_has_exact_reauth_command(self):
+        entry = oauth_health.build_set_entry(
+            1, oauth_health.STATUS_TOKEN_EXPIRED_OR_REVOKED, "Refresh token expired or revoked"
+        )
+        assert entry["operator_action"] == (
+            "python modules/platform_integration/youtube_auth/scripts/authorize_set1.py"
+        )
+
+    def test_set_10_metadata(self):
+        entry = oauth_health.build_set_entry(10, oauth_health.STATUS_HEALTHY)
+        assert entry["account_label"] == "FoundUps / antifaFM"
+        assert entry["browser_hint"] == "Edge"
+
+
+# -- compute_effective_capacity ----------------------------------------------
+
+class TestComputeEffectiveCapacity:
+    def test_only_healthy_sets_count_toward_quota(self):
+        entries = [
+            oauth_health.build_set_entry(1, oauth_health.STATUS_TOKEN_EXPIRED_OR_REVOKED, "r"),
+            oauth_health.build_set_entry(10, oauth_health.STATUS_HEALTHY),
+        ]
+        cap = oauth_health.compute_effective_capacity(entries)
+        assert cap["total_configured"] == 2
+        assert cap["operational"] == [10]
+        assert cap["dead"] == [1]
+        assert cap["effective_daily_quota_estimate"] == oauth_health.DAILY_QUOTA_PER_SET
+
+    def test_quota_exhausted_is_not_dead(self):
+        entries = [
+            oauth_health.build_set_entry(1, oauth_health.STATUS_HEALTHY),
+            oauth_health.build_set_entry(10, oauth_health.STATUS_QUOTA_EXHAUSTED),
+        ]
+        cap = oauth_health.compute_effective_capacity(entries)
+        assert cap["dead"] == []
+        assert cap["quota_exhausted_today"] == [10]
+        # Healthy=1 means 1 set's worth of daily quota is currently operational.
+        assert cap["effective_daily_quota_estimate"] == oauth_health.DAILY_QUOTA_PER_SET
+
+    def test_all_dead_means_zero_quota(self):
+        entries = [
+            oauth_health.build_set_entry(1, oauth_health.STATUS_TOKEN_REVOKED, "r"),
+            oauth_health.build_set_entry(10, oauth_health.STATUS_UNCONFIGURED, "m"),
+        ]
+        cap = oauth_health.compute_effective_capacity(entries)
+        assert cap["operational"] == []
+        assert cap["effective_daily_quota_estimate"] == 0
+
+
+# -- format_capacity_log ------------------------------------------------------
+
+class TestFormatCapacityLog:
+    def test_dead_sets_surface_action_required(self):
+        entries = [
+            oauth_health.build_set_entry(1, oauth_health.STATUS_TOKEN_EXPIRED_OR_REVOKED, "r"),
+            oauth_health.build_set_entry(10, oauth_health.STATUS_HEALTHY),
+        ]
+        cap = oauth_health.compute_effective_capacity(entries)
+        msg = oauth_health.format_capacity_log(cap)
+
+        assert "1/2 sets operational" in msg
+        assert "dead=[1]" in msg
+        assert "action_required=" in msg
+        assert "authorize_set1.py" in msg
+
+    def test_quota_exhausted_only_does_not_claim_action_required(self):
+        # Stream resolver's current log says "Set X exhausted" even if the
+        # real problem is auth. This asserts that when ONLY quota is the
+        # issue (no dead sets), we do NOT falsely ask for reauthorization.
+        entries = [
+            oauth_health.build_set_entry(1, oauth_health.STATUS_HEALTHY),
+            oauth_health.build_set_entry(10, oauth_health.STATUS_QUOTA_EXHAUSTED),
+        ]
+        cap = oauth_health.compute_effective_capacity(entries)
+        msg = oauth_health.format_capacity_log(cap)
+        assert "action_required" not in msg
+        assert "quota_exhausted_today=[10]" in msg
+
+
+# -- write_health_report ------------------------------------------------------
+
+class TestWriteHealthReport:
+    def test_schema_fields_and_roundtrip(self, tmp_path: Path):
+        entries = [
+            oauth_health.build_set_entry(1, oauth_health.STATUS_TOKEN_EXPIRED_OR_REVOKED, "r"),
+            oauth_health.build_set_entry(10, oauth_health.STATUS_HEALTHY),
+        ]
+        out = tmp_path / "reports" / "oauth_credential_health.json"
+        path = oauth_health.write_health_report(entries, output_path=out)
+
+        assert path == out
+        report = json.loads(out.read_text(encoding="utf-8"))
+        assert "generated_at" in report
+        assert set(report["credential_sets"].keys()) == {
+            "total_configured", "operational", "dead",
+            "quota_exhausted_today", "effective_daily_quota_estimate",
+        }
+        assert report["credential_sets"]["dead"] == [1]
+        assert report["credential_sets"]["effective_daily_quota_estimate"] == (
+            oauth_health.DAILY_QUOTA_PER_SET
+        )
+
+        set_1 = next(e for e in report["per_set"] if e["set_id"] == 1)
+        assert set_1["operator_action"].endswith("authorize_set1.py")
+        assert set_1["reason"] is not None
+
+
+# -- emit_critical_reauth emits CRITICAL with exact command -------------------
+
+class TestEmitCriticalReauth:
+    def test_critical_log_contains_exact_command(self, caplog):
+        caplog.set_level(logging.CRITICAL, logger="modules.platform_integration.youtube_auth.src.oauth_health")
+        oauth_health.emit_critical_reauth(
+            1, oauth_health.STATUS_TOKEN_EXPIRED_OR_REVOKED, "Refresh token expired or revoked"
+        )
+        messages = [r.getMessage() for r in caplog.records if r.levelno == logging.CRITICAL]
+        assert any("authorize_set1.py" in m for m in messages)
+        assert any("CRITICAL" in m for m in messages)
+
+
+# -- preflight_oauth_check end-to-end (no network) ----------------------------
+
+class TestPreflightWritesArtifact:
+    """
+    Simulates the exact condition described in the Worker YT1 brief:
+    Set 1 refresh_token expired, Set 10 still healthy. The artifact must
+    report dead=[1], operational=[10], effective_quota=10,000, and the
+    capacity log must not falsely claim "only quota exhaustion".
+    """
+
+    def _run_preflight_with_mocks(self, tmp_path, set1_behavior, set10_behavior):
+        from modules.platform_integration.youtube_auth.src import youtube_auth as ya
+
+        report_path = tmp_path / "oauth_credential_health.json"
+
+        # Redirect the module's default report path so write_health_report()
+        # runs unchanged but writes under tmp_path.
+        default_path_patch = patch.object(
+            oauth_health, "_DEFAULT_REPORT_PATH", report_path
+        )
+
+        with default_path_patch, \
+             patch.object(ya, 'get_credentials_for_index') as mock_creds, \
+             patch.object(ya.os.path, 'exists', return_value=True), \
+             patch.object(ya.google.oauth2.credentials.Credentials, 'from_authorized_user_file') as mock_from_file, \
+             patch.dict(ya.os.environ, {'YOUTUBE_SCOPES': 'https://www.googleapis.com/auth/youtube.readonly'}, clear=False):
+
+            mock_creds.side_effect = lambda index: (
+                f"/fake/secrets_{index}.json", f"/fake/token_for_set_{index}.json"
+            )
+
+            def make_creds(behavior):
+                m = MagicMock()
+                m.expired = behavior["expired"]
+                m.refresh_token = behavior["refresh_token"]
+                m.valid = behavior["valid"]
+                if behavior.get("refresh_raises"):
+                    m.refresh.side_effect = Exception(behavior["refresh_raises"])
+                else:
+                    m.refresh.return_value = None
+                    m.to_json.return_value = "{}"
+                return m
+
+            def from_file(token_file, scopes):
+                # Use exact suffix match — "token_1" would also match "token_10".
+                if token_file.endswith("_set_1.json"):
+                    return make_creds(set1_behavior)
+                if token_file.endswith("_set_10.json"):
+                    return make_creds(set10_behavior)
+                raise AssertionError(f"unexpected token_file: {token_file}")
+
+            mock_from_file.side_effect = from_file
+
+            # Patch file write so refreshed token doesn't try to hit disk.
+            # Don't patch builtins.open globally — oauth_health needs it to
+            # write the report artifact.
+            with patch.object(ya, "open", new_callable=MagicMock, create=True):
+                result = ya.preflight_oauth_check(
+                    auto_reauth=False, credential_sets=[1, 10]
+                )
+
+        return result, report_path
+
+    def test_invalid_grant_on_set1_writes_truthful_artifact(self, tmp_path):
+        set1 = {
+            "expired": True, "refresh_token": "rt", "valid": False,
+            "refresh_raises": "invalid_grant: Token has been expired or revoked.",
+        }
+        set10 = {"expired": False, "refresh_token": "rt", "valid": True}
+        result, report_path = self._run_preflight_with_mocks(tmp_path, set1, set10)
+
+        assert 1 in result['expired']
+        assert 10 in result['healthy']
+        assert result['reauth_needed'] is True
+
+        assert report_path.exists(), "health artifact must be persisted"
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+
+        assert report["credential_sets"]["dead"] == [1]
+        assert report["credential_sets"]["operational"] == [10]
+        assert report["credential_sets"]["effective_daily_quota_estimate"] == (
+            oauth_health.DAILY_QUOTA_PER_SET
+        )
+
+        set_1 = next(e for e in report["per_set"] if e["set_id"] == 1)
+        assert set_1["status"] == oauth_health.STATUS_TOKEN_REVOKED
+        assert set_1["operator_action"].endswith("authorize_set1.py")
+
+    def test_capacity_log_does_not_report_only_set10_exhaustion(self, tmp_path, caplog):
+        """
+        Regression guard for the WSP 97 gap in the brief: stream resolver /
+        rotation logs were showing 'Set 10 exhausted' only, hiding that Set 1
+        was actually dead from invalid_grant. The capacity log must surface
+        dead=[1] as well.
+        """
+        set1 = {
+            "expired": True, "refresh_token": "rt", "valid": False,
+            "refresh_raises": "invalid_grant: Token has been expired or revoked.",
+        }
+        set10 = {"expired": False, "refresh_token": "rt", "valid": True}
+
+        caplog.set_level(logging.INFO, logger="modules.platform_integration.youtube_auth.src.youtube_auth")
+        self._run_preflight_with_mocks(tmp_path, set1, set10)
+
+        capacity_msgs = [r.getMessage() for r in caplog.records if "OAUTH-HEALTH" in r.getMessage()]
+        assert capacity_msgs, "capacity log line must be emitted"
+        joined = " | ".join(capacity_msgs)
+        assert "dead=[1]" in joined
+        assert "1/2 sets operational" in joined
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- SEC1 — SECURITY_SCANNER_CLI_PROOF_PHASE1
- Autonomous CLI-based vulnerability scanning via snyk, trivy, semgrep
- Subprocess-based execution - no MCP or LLM required for scan execution

## Test Results

- **20 passed** in 0.19s
- All tests use mocked subprocess calls - no CLI tools required

## Tool Availability (Truthful)

| Tool | Status |
|------|--------|
| snyk | unavailable |
| trivy | unavailable |
| semgrep | unavailable |

- No installs performed
- No scans fabricated

## Execution Boundary

```
subprocess -> normalized JSON -> later Qwen/Gemma analysis
```

- CLI subprocess executes scans
- Qwen/Gemma analyze results AFTER this module returns
- Codex/Claude MCP plugins are operator tools, NOT autonomous runtime dependencies

## Files

- `src/security_scanner.py` - Main scanner class (532 lines)
- `src/schemas.py` - Normalized output schemas (327 lines)
- `tests/test_security_scanner.py` - Mocked tests (494 lines)
- `README.md`, `INTERFACE.md`, `ModLog.md`, `requirements.txt`

## Next Slice

SEC2 — SECURITY_SENTINEL_POLICY_PHASE1 (policy layer, no scans)

🤖 Generated with [Claude Code](https://claude.com/claude-code)