### PR TITLE
docs(wsp): add HoloIndex and WSP 97 to WSP 50

### DIFF
--- a/WSP_framework/src/ModLog.md
+++ b/WSP_framework/src/ModLog.md
@@ -11,6 +11,25 @@
 
 ---
 
+## 2026-04-18 - WSP 50 HoloIndex + WSP 97 Integration
+
+**WSP References**: WSP 22, WSP 50, WSP 97
+
+**Changes Made**:
+- Updated `WSP_50_Pre_Action_Verification_Protocol.md`:
+  - Section 3 (Required Sequence): Added HoloIndex as primary semantic search tool, grep as secondary
+  - Section 4.3 (Bloat Prevention): Replaced generic `codebase_search()`/`file_search()` with HoloIndex + grep
+  - Section 5 (Integration): Added WSP 97 cross-reference for truthful verification claims
+  - Added WSP 97 truthfulness notes to search result handling
+- Synced changes to `WSP_knowledge/src/WSP_50_Pre_Action_Verification_Protocol.md`
+
+**Rationale**:
+- WSP 50 predated HoloIndex and referenced generic/placeholder search tools
+- HoloIndex semantic search finds architecturally similar implementations that grep may miss
+- WSP 97 integration ensures search results are reported truthfully (no fabrication if no results)
+
+---
+
 ## 2026-03-10 - WSP 97 Canonical Compression Clarified (Resolve Execution Plane?)
 
 **WSP References**: WSP 22, WSP 46, WSP 97, WSP 99

--- a/WSP_framework/src/WSP_50_Pre_Action_Verification_Protocol.md
+++ b/WSP_framework/src/WSP_50_Pre_Action_Verification_Protocol.md
@@ -30,11 +30,20 @@ Agents MUST verify file existence, paths, and content before taking actions or m
 ## 3. Required Sequence
 
 ```
-1. file_search() or codebase_search()
-2. Verify results match expectations  
-3. read_file() with confirmed path
-4. Process actual content
+1. HoloIndex semantic search (primary):
+   python holo_index.py --search "[task or pattern]"
+   
+2. Pattern search (secondary):
+   grep -r "pattern" modules/
+   
+3. Verify results match expectations  
+
+4. read_file() with confirmed path
+
+5. Process actual content
 ```
+
+**WSP 97 Integration**: All search results and file claims must be truthful and verifiable. If a search returns no results, state that explicitly — do not assume or fabricate.
 
 ## 4. Error Prevention Checklist
 
@@ -165,11 +174,15 @@ Agents MUST verify file existence, paths, and content before taking actions or m
    ```
 
 2. **Search for Existing Functionality**:
+   ```bash
+   # HoloIndex semantic search (primary - finds architecturally similar code)
+   python holo_index.py --search "similar functionality or purpose"
+   
+   # Pattern search (secondary)
+   grep -r "existing implementations" modules/
    ```
-   codebase_search("similar functionality or purpose")
-   file_search("potential duplicate files")
-   grep_search("existing implementations")
-   ```
+   
+   **WSP 97**: Report search results truthfully. If HoloIndex finds similar implementations, evaluate before creating new files.
 
 3. **Validate Necessity**:
    - Is this functionality already tested/implemented?
@@ -238,6 +251,7 @@ When an action proposes deletion, consolidation, or major refactoring that can r
 
 Proceed only when all checks are satisfied and artifacts are linked in the ModLog (WSP 22).
 
+- **WSP 97 (Truthful Claims)**: All verification results must be truthful and browser-verifiable
 - **WSP 54 (ComplianceAgent)**: Monitor for WSP 50 violations
 - **WSP 48 (WRE)**: Incorporate verification in enhancement cycles
 - **WSP 56 (Coherence)**: Prevent cross-state assumption errors

--- a/WSP_knowledge/src/ModLog.md
+++ b/WSP_knowledge/src/ModLog.md
@@ -1,5 +1,20 @@
 # WSP Framework Change Log
 
+## 2026-04-18 - WSP 50 HoloIndex + WSP 97 Integration
+
+**WSP References**: WSP 22, WSP 50, WSP 97
+
+**Changes Made**:
+- Updated `WSP_50_Pre_Action_Verification_Protocol.md`:
+  - Added HoloIndex as primary semantic search tool
+  - Added WSP 97 cross-reference for truthful verification claims
+- Synced from `WSP_framework/src/`
+
+**Rationale**:
+- WSP 50 predated HoloIndex — now canonical semantic search integrated
+
+---
+
 ## 2026-04-11 - Anchored FoundUp Namespace Guardrails in WSP 104
 
 **WSP References**: WSP 104, WSP 98, WSP 103, WSP 22, WSP 97

--- a/WSP_knowledge/src/WSP_50_Pre_Action_Verification_Protocol.md
+++ b/WSP_knowledge/src/WSP_50_Pre_Action_Verification_Protocol.md
@@ -30,11 +30,20 @@ Agents MUST verify file existence, paths, and content before taking actions or m
 ## 3. Required Sequence
 
 ```
-1. file_search() or codebase_search()
-2. Verify results match expectations  
-3. read_file() with confirmed path
-4. Process actual content
+1. HoloIndex semantic search (primary):
+   python holo_index.py --search "[task or pattern]"
+   
+2. Pattern search (secondary):
+   grep -r "pattern" modules/
+   
+3. Verify results match expectations  
+
+4. read_file() with confirmed path
+
+5. Process actual content
 ```
+
+**WSP 97 Integration**: All search results and file claims must be truthful and verifiable. If a search returns no results, state that explicitly — do not assume or fabricate.
 
 ## 4. Error Prevention Checklist
 
@@ -165,11 +174,15 @@ Agents MUST verify file existence, paths, and content before taking actions or m
    ```
 
 2. **Search for Existing Functionality**:
+   ```bash
+   # HoloIndex semantic search (primary - finds architecturally similar code)
+   python holo_index.py --search "similar functionality or purpose"
+   
+   # Pattern search (secondary)
+   grep -r "existing implementations" modules/
    ```
-   codebase_search("similar functionality or purpose")
-   file_search("potential duplicate files")
-   grep_search("existing implementations")
-   ```
+   
+   **WSP 97**: Report search results truthfully. If HoloIndex finds similar implementations, evaluate before creating new files.
 
 3. **Validate Necessity**:
    - Is this functionality already tested/implemented?
@@ -238,6 +251,7 @@ When an action proposes deletion, consolidation, or major refactoring that can r
 
 Proceed only when all checks are satisfied and artifacts are linked in the ModLog (WSP 22).
 
+- **WSP 97 (Truthful Claims)**: All verification results must be truthful and browser-verifiable
 - **WSP 54 (ComplianceAgent)**: Monitor for WSP 50 violations
 - **WSP 48 (WRE)**: Incorporate verification in enhancement cycles
 - **WSP 56 (Coherence)**: Prevent cross-state assumption errors


### PR DESCRIPTION
## Summary
- Add HoloIndex as primary semantic search tool in WSP 50 required sequence
- Add WSP 97 cross-reference for truthful verification claims
- WSP 50 predated HoloIndex — this patch integrates canonical semantic search

## Changes
- `WSP_framework/src/WSP_50_Pre_Action_Verification_Protocol.md`
- `WSP_knowledge/src/WSP_50_Pre_Action_Verification_Protocol.md`
- ModLogs updated in both locations

## Test plan
- [x] Docs-only change, no code impact
- [x] ModLogs follow WSP 22 format

🤖 Generated with [Claude Code](https://claude.ai/code)