### PR TITLE
feat(wre): add security recall service (SEC6)

### DIFF
--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -2,6 +2,54 @@
 
 ## Chronological Change Log
 
+### [2026-04-18] - SEC6: Security Recall Service (v0.8.3)
+
+**WSP Protocol References**: WSP 60 (Module Memory), WSP 97 (Truthful), WSP 48 (Recursive Self-Improvement)
+**Impact Analysis**: Read-only recall layer for historical vulnerability lookup - NO remediation
+
+#### Changes Made
+
+- `src/security_recall.py` (NEW):
+  - `RecallResult` dataclass - query result with historical context and suggestion
+  - `SecurityRecall` class - read-only recall service over SecurityPatternMemory
+  - `recall_by_fingerprint()` - exact fingerprint lookup
+  - `recall_by_finding_id()` - CVE/rule-id pattern lookup (aggregates all matches)
+  - `recall_by_type()` - filter by tool/category/severity
+  - `get_historical_summary()` - comprehensive timeline and statistics
+  - `_suggest_outcome_from_patterns()` - suggests outcome based on historical majority
+
+- `tests/test_security_recall.py` (NEW):
+  - 33 tests covering all recall methods
+  - Outcome suggestion logic (exact match, majority, mixed)
+  - Historical summary generation
+  - Read-only invariant verification (recall does not mutate)
+
+#### Read-Only Invariants
+
+- Recall does NOT modify findings
+- Recall does NOT increment times_seen
+- Recall does NOT update timestamps
+- Recall does NOT add new findings
+- Future SEC7+ may add Qwen/Gemma analysis (NOT in this phase)
+
+#### Architecture
+
+```
+SEC5 (storage) <---- SEC6 (recall) ----> suggested outcome
+                         ^
+                         |
+            fingerprint/finding_id/type query
+```
+
+#### Verification
+
+```bash
+python -m pytest modules/infrastructure/wre_core/tests/test_security_recall.py -v
+# Result: 33 passed
+```
+
+---
+
 ### [2026-04-18] - SEC5: Security Pattern Memory (v0.8.2)
 
 **WSP Protocol References**: WSP 60 (Module Memory), WSP 97 (Truthful), WSP 48 (Recursive Self-Improvement)

--- a/modules/infrastructure/wre_core/src/security_recall.py
+++ b/modules/infrastructure/wre_core/src/security_recall.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Security Recall - Read-Only Historical Finding Lookup
+
+SEC6 — SECURITY_REMEDIATION_RECALL_READONLY_PHASE1
+
+Given a fingerprint/type, look up prior resolved/false-positive records.
+Return historical context and suggested prior outcome.
+
+This is READ-ONLY:
+- No code changes
+- No auto-fix
+- No Qwen/Gemma generation
+
+WSP Compliance:
+- WSP 60: Module Memory Architecture (recall patterns)
+- WSP 97: Truthful claims (observations only)
+
+Architecture:
+- SEC5 stores findings (SecurityPatternMemory)
+- SEC6 (this) recalls historical context + suggests outcomes
+- Future SEC7+ may add Qwen/Gemma analysis (NOT in this phase)
+"""
+
+import logging
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, List, Optional
+
+from .security_pattern_memory import SecurityPatternMemory, SecurityFinding
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RecallResult:
+    """
+    Result of a historical finding recall.
+
+    Contains historical context and suggested outcome based on patterns.
+    """
+
+    # Query info
+    query_fingerprint: Optional[str] = None
+    query_finding_id: Optional[str] = None
+    query_type: Optional[str] = None
+
+    # Match info
+    match_found: bool = False
+    exact_match: bool = False
+    similar_matches: int = 0
+
+    # Historical context
+    finding: Optional[Dict[str, Any]] = None
+    first_seen: Optional[str] = None
+    last_seen: Optional[str] = None
+    times_seen: int = 0
+
+    # Prior outcomes (for similar findings)
+    prior_outcomes: Optional[Dict[str, int]] = None  # {"resolved": N, "false_positive": M, ...}
+    total_similar: int = 0
+
+    # Suggested outcome
+    suggested_outcome: Optional[str] = None
+    suggestion_confidence: float = 0.0
+    suggestion_rationale: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return asdict(self)
+
+
+class SecurityRecall:
+    """
+    Security Recall - Read-only historical finding lookup.
+
+    Provides recall of prior vulnerability findings and suggests outcomes
+    based on historical patterns. Does NOT perform any remediation.
+
+    Usage:
+        memory = SecurityPatternMemory()
+        recall = SecurityRecall(memory)
+
+        # Recall by fingerprint
+        result = recall.recall_by_fingerprint("abc123...")
+        if result.match_found:
+            print(f"First seen: {result.first_seen}")
+            print(f"Suggested: {result.suggested_outcome}")
+
+        # Recall by finding ID (CVE)
+        result = recall.recall_by_finding_id("CVE-2024-001")
+
+        # Recall by type pattern
+        result = recall.recall_by_type("snyk", "sql-injection")
+    """
+
+    def __init__(self, memory: SecurityPatternMemory):
+        """
+        Initialize SecurityRecall.
+
+        Args:
+            memory: SecurityPatternMemory instance for querying
+        """
+        self.memory = memory
+        logger.info("[SECURITY-RECALL] Initialized - read-only recall service")
+
+    def recall_by_fingerprint(self, fingerprint: str) -> RecallResult:
+        """
+        Recall finding by exact fingerprint match.
+
+        Args:
+            fingerprint: SHA256 fingerprint from SecurityFinding
+
+        Returns:
+            RecallResult with historical context and suggested outcome
+        """
+        result = RecallResult(query_fingerprint=fingerprint)
+
+        finding = self.memory.get_finding_by_fingerprint(fingerprint)
+
+        if not finding:
+            logger.debug(
+                "[SECURITY-RECALL] No match for fingerprint=%s",
+                fingerprint[:8] if fingerprint else "None",
+            )
+            return result
+
+        result.match_found = True
+        result.exact_match = True
+        result.finding = finding.to_dict()
+        result.first_seen = finding.first_seen
+        result.last_seen = finding.last_seen
+        result.times_seen = finding.times_seen
+
+        # Get similar findings by finding_id for outcome patterns
+        similar = self._get_similar_by_finding_id(finding.finding_id)
+        result.similar_matches = len(similar)
+        result.total_similar = len(similar)
+        result.prior_outcomes = self._compute_outcome_distribution(similar)
+
+        # Suggest outcome
+        suggestion = self._suggest_outcome_from_patterns(
+            exact_finding=finding,
+            similar_findings=similar,
+        )
+        result.suggested_outcome = suggestion["outcome"]
+        result.suggestion_confidence = suggestion["confidence"]
+        result.suggestion_rationale = suggestion["rationale"]
+
+        logger.info(
+            "[SECURITY-RECALL] Recalled fingerprint=%s, suggested=%s (%.2f)",
+            fingerprint[:8],
+            result.suggested_outcome,
+            result.suggestion_confidence,
+        )
+
+        return result
+
+    def recall_by_finding_id(self, finding_id: str) -> RecallResult:
+        """
+        Recall findings by finding ID (CVE, SNYK-XXX, rule-id).
+
+        Returns aggregated historical context from all matching findings.
+
+        Args:
+            finding_id: CVE-XXXX, SNYK-XXX, or other finding identifier
+
+        Returns:
+            RecallResult with aggregated history and suggested outcome
+        """
+        result = RecallResult(query_finding_id=finding_id)
+
+        similar = self._get_similar_by_finding_id(finding_id)
+
+        if not similar:
+            logger.debug(
+                "[SECURITY-RECALL] No matches for finding_id=%s",
+                finding_id,
+            )
+            return result
+
+        result.match_found = True
+        result.exact_match = False  # Multiple matches possible
+        result.similar_matches = len(similar)
+        result.total_similar = len(similar)
+
+        # Use most recent as primary finding
+        most_recent = max(similar, key=lambda f: f.last_seen)
+        result.finding = most_recent.to_dict()
+        result.first_seen = min(f.first_seen for f in similar)
+        result.last_seen = max(f.last_seen for f in similar)
+        result.times_seen = sum(f.times_seen for f in similar)
+
+        result.prior_outcomes = self._compute_outcome_distribution(similar)
+
+        # Suggest outcome
+        suggestion = self._suggest_outcome_from_patterns(
+            exact_finding=None,
+            similar_findings=similar,
+        )
+        result.suggested_outcome = suggestion["outcome"]
+        result.suggestion_confidence = suggestion["confidence"]
+        result.suggestion_rationale = suggestion["rationale"]
+
+        logger.info(
+            "[SECURITY-RECALL] Recalled finding_id=%s, matches=%d, suggested=%s (%.2f)",
+            finding_id,
+            len(similar),
+            result.suggested_outcome,
+            result.suggestion_confidence,
+        )
+
+        return result
+
+    def recall_by_type(
+        self,
+        tool: Optional[str] = None,
+        category: Optional[str] = None,
+        severity: Optional[str] = None,
+    ) -> RecallResult:
+        """
+        Recall findings by type pattern.
+
+        Looks up similar findings matching tool, category, or severity patterns.
+
+        Args:
+            tool: Scanner tool (snyk, trivy, semgrep)
+            category: Finding category (from title/description keywords)
+            severity: Severity level
+
+        Returns:
+            RecallResult with aggregated patterns
+        """
+        result = RecallResult(query_type=f"{tool or '*'}:{category or '*'}:{severity or '*'}")
+
+        similar = self._get_similar_by_type(tool, category, severity)
+
+        if not similar:
+            logger.debug(
+                "[SECURITY-RECALL] No matches for type pattern tool=%s, category=%s, severity=%s",
+                tool,
+                category,
+                severity,
+            )
+            return result
+
+        result.match_found = True
+        result.exact_match = False
+        result.similar_matches = len(similar)
+        result.total_similar = len(similar)
+
+        # Use most recent as primary finding
+        most_recent = max(similar, key=lambda f: f.last_seen)
+        result.finding = most_recent.to_dict()
+        result.first_seen = min(f.first_seen for f in similar)
+        result.last_seen = max(f.last_seen for f in similar)
+        result.times_seen = sum(f.times_seen for f in similar)
+
+        result.prior_outcomes = self._compute_outcome_distribution(similar)
+
+        # Suggest outcome
+        suggestion = self._suggest_outcome_from_patterns(
+            exact_finding=None,
+            similar_findings=similar,
+        )
+        result.suggested_outcome = suggestion["outcome"]
+        result.suggestion_confidence = suggestion["confidence"]
+        result.suggestion_rationale = suggestion["rationale"]
+
+        logger.info(
+            "[SECURITY-RECALL] Recalled type=%s, matches=%d, suggested=%s (%.2f)",
+            result.query_type,
+            len(similar),
+            result.suggested_outcome,
+            result.suggestion_confidence,
+        )
+
+        return result
+
+    def get_historical_summary(
+        self,
+        finding_id: Optional[str] = None,
+        fingerprint: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Get comprehensive historical summary for a finding.
+
+        Args:
+            finding_id: CVE or finding ID
+            fingerprint: Exact fingerprint
+
+        Returns:
+            Dict with historical timeline, outcomes, and statistics
+        """
+        findings: List[SecurityFinding] = []
+
+        if fingerprint:
+            finding = self.memory.get_finding_by_fingerprint(fingerprint)
+            if finding:
+                findings.append(finding)
+                # Also get similar by finding_id
+                similar = self._get_similar_by_finding_id(finding.finding_id)
+                findings.extend([f for f in similar if f.fingerprint != fingerprint])
+
+        elif finding_id:
+            findings = self._get_similar_by_finding_id(finding_id)
+
+        if not findings:
+            return {
+                "found": False,
+                "query": {"finding_id": finding_id, "fingerprint": fingerprint},
+            }
+
+        # Build timeline
+        timeline = []
+        for f in sorted(findings, key=lambda x: x.first_seen):
+            timeline.append({
+                "fingerprint": f.fingerprint[:16],
+                "target": f.target,
+                "first_seen": f.first_seen,
+                "last_seen": f.last_seen,
+                "times_seen": f.times_seen,
+                "status": f.status,
+            })
+
+        # Compute statistics
+        outcomes = self._compute_outcome_distribution(findings)
+        total = sum(outcomes.values())
+
+        return {
+            "found": True,
+            "finding_id": findings[0].finding_id,
+            "tool": findings[0].tool,
+            "severity": findings[0].severity,
+            "total_occurrences": len(findings),
+            "total_times_seen": sum(f.times_seen for f in findings),
+            "first_seen_ever": min(f.first_seen for f in findings),
+            "last_seen_ever": max(f.last_seen for f in findings),
+            "outcome_distribution": outcomes,
+            "resolution_rate": (
+                (outcomes.get("resolved", 0) + outcomes.get("false_positive", 0)) / total
+                if total > 0
+                else 0.0
+            ),
+            "timeline": timeline,
+        }
+
+    def _get_similar_by_finding_id(self, finding_id: str) -> List[SecurityFinding]:
+        """Get all findings with matching finding_id."""
+        cursor = self.memory.conn.cursor()
+        cursor.execute(
+            "SELECT * FROM security_findings WHERE finding_id = ?",
+            (finding_id,)
+        )
+        return [self.memory._row_to_finding(row) for row in cursor.fetchall()]
+
+    def _get_similar_by_type(
+        self,
+        tool: Optional[str],
+        category: Optional[str],
+        severity: Optional[str],
+    ) -> List[SecurityFinding]:
+        """Get findings matching type pattern."""
+        cursor = self.memory.conn.cursor()
+
+        query = "SELECT * FROM security_findings WHERE 1=1"
+        params: List[Any] = []
+
+        if tool:
+            query += " AND tool = ?"
+            params.append(tool.lower())
+
+        if severity:
+            query += " AND severity = ?"
+            params.append(severity.lower())
+
+        if category:
+            # Search in title and description
+            query += " AND (title LIKE ? OR description LIKE ?)"
+            pattern = f"%{category}%"
+            params.extend([pattern, pattern])
+
+        cursor.execute(query, params)
+        return [self.memory._row_to_finding(row) for row in cursor.fetchall()]
+
+    def _compute_outcome_distribution(
+        self,
+        findings: List[SecurityFinding],
+    ) -> Dict[str, int]:
+        """Compute outcome distribution from findings."""
+        outcomes: Dict[str, int] = {
+            "open": 0,
+            "resolved": 0,
+            "false_positive": 0,
+            "ignored": 0,
+        }
+
+        for f in findings:
+            status = f.status.lower()
+            if status in outcomes:
+                outcomes[status] += 1
+            else:
+                outcomes[status] = 1
+
+        return outcomes
+
+    def _suggest_outcome_from_patterns(
+        self,
+        exact_finding: Optional[SecurityFinding],
+        similar_findings: List[SecurityFinding],
+    ) -> Dict[str, Any]:
+        """
+        Suggest outcome based on historical patterns.
+
+        Decision logic:
+        1. If exact match has status != open, suggest that status
+        2. If majority of similar have same non-open status, suggest that
+        3. Otherwise, suggest keeping open with low confidence
+
+        Returns:
+            Dict with outcome, confidence, rationale
+        """
+        # Case 1: Exact match with non-open status
+        if exact_finding and exact_finding.status != "open":
+            return {
+                "outcome": exact_finding.status,
+                "confidence": 0.95,
+                "rationale": f"Exact fingerprint previously marked as {exact_finding.status}",
+            }
+
+        # Case 2: Analyze similar findings
+        if not similar_findings:
+            return {
+                "outcome": None,
+                "confidence": 0.0,
+                "rationale": "No historical data available",
+            }
+
+        outcomes = self._compute_outcome_distribution(similar_findings)
+        total = sum(outcomes.values())
+
+        if total == 0:
+            return {
+                "outcome": None,
+                "confidence": 0.0,
+                "rationale": "No historical data available",
+            }
+
+        # Find majority outcome (excluding open)
+        non_open = {k: v for k, v in outcomes.items() if k != "open" and v > 0}
+
+        if not non_open:
+            # All similar are still open
+            return {
+                "outcome": "open",
+                "confidence": 0.5,
+                "rationale": f"All {total} similar findings still open",
+            }
+
+        # Get most common non-open outcome
+        best_outcome = max(non_open, key=lambda k: non_open[k])
+        best_count = non_open[best_outcome]
+        confidence = best_count / total
+
+        # Require at least 60% for suggestion
+        if confidence < 0.6:
+            return {
+                "outcome": best_outcome,
+                "confidence": confidence,
+                "rationale": f"Mixed outcomes: {outcomes}. Weak suggestion based on {best_count}/{total}",
+            }
+
+        return {
+            "outcome": best_outcome,
+            "confidence": confidence,
+            "rationale": f"{best_count}/{total} similar findings were {best_outcome}",
+        }
+
+
+def get_security_recall(memory: Optional[SecurityPatternMemory] = None) -> SecurityRecall:
+    """
+    Factory function to get SecurityRecall instance.
+
+    Args:
+        memory: Optional SecurityPatternMemory instance.
+                If None, creates new memory with default path.
+
+    Returns:
+        SecurityRecall instance
+    """
+    if memory is None:
+        memory = SecurityPatternMemory()
+    return SecurityRecall(memory)

--- a/modules/infrastructure/wre_core/tests/test_security_recall.py
+++ b/modules/infrastructure/wre_core/tests/test_security_recall.py
@@ -1,0 +1,578 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Tests for Security Recall Service
+
+SEC6 — SECURITY_REMEDIATION_RECALL_READONLY_PHASE1
+
+Validates:
+- Recall by fingerprint (exact match)
+- Recall by finding ID (CVE pattern)
+- Recall by type (tool/category/severity)
+- Historical summary generation
+- Outcome suggestion logic
+- Read-only invariant (no mutations from recall)
+"""
+
+import gc
+import pytest
+import tempfile
+from pathlib import Path
+
+from modules.infrastructure.wre_core.src.security_pattern_memory import (
+    SecurityPatternMemory,
+    SecurityFinding,
+)
+from modules.infrastructure.wre_core.src.security_recall import (
+    SecurityRecall,
+    RecallResult,
+    get_security_recall,
+)
+
+
+@pytest.fixture
+def temp_db():
+    """Create temporary database for tests."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = Path(f.name)
+
+    memory = SecurityPatternMemory(db_path=db_path)
+    yield memory
+
+    memory.close()
+    gc.collect()  # Windows file lock workaround
+    try:
+        db_path.unlink()
+    except PermissionError:
+        pass  # Ignore on Windows
+
+
+@pytest.fixture
+def populated_db(temp_db):
+    """Create database with test findings."""
+    # Finding 1: Critical CVE, resolved
+    f1 = SecurityFinding(
+        fingerprint=SecurityFinding.compute_fingerprint(
+            "snyk", "CVE-2024-001", ".", "lodash"
+        ),
+        finding_id="CVE-2024-001",
+        tool="snyk",
+        target=".",
+        package_name="lodash",
+        severity="critical",
+        title="Prototype Pollution in lodash",
+        status="resolved",
+        first_seen="2024-01-01T00:00:00Z",
+        last_seen="2024-01-15T00:00:00Z",
+        times_seen=3,
+    )
+    temp_db.store_finding(f1)
+
+    # Finding 2: Same CVE, different target, false_positive
+    f2 = SecurityFinding(
+        fingerprint=SecurityFinding.compute_fingerprint(
+            "snyk", "CVE-2024-001", "./sub", "lodash"
+        ),
+        finding_id="CVE-2024-001",
+        tool="snyk",
+        target="./sub",
+        package_name="lodash",
+        severity="critical",
+        title="Prototype Pollution in lodash",
+        status="false_positive",
+        first_seen="2024-02-01T00:00:00Z",
+        last_seen="2024-02-10T00:00:00Z",
+        times_seen=2,
+    )
+    temp_db.store_finding(f2)
+
+    # Finding 3: Different CVE, open
+    f3 = SecurityFinding(
+        fingerprint=SecurityFinding.compute_fingerprint(
+            "trivy", "CVE-2024-002", ".", "express"
+        ),
+        finding_id="CVE-2024-002",
+        tool="trivy",
+        target=".",
+        package_name="express",
+        severity="high",
+        title="XSS vulnerability in express",
+        description="Cross-site scripting vulnerability",
+        status="open",
+        first_seen="2024-03-01T00:00:00Z",
+        last_seen="2024-03-05T00:00:00Z",
+        times_seen=1,
+    )
+    temp_db.store_finding(f3)
+
+    # Finding 4: Semgrep rule, ignored
+    f4 = SecurityFinding(
+        fingerprint=SecurityFinding.compute_fingerprint(
+            "semgrep", "python.lang.security.injection.sql", "./app.py", None
+        ),
+        finding_id="python.lang.security.injection.sql",
+        tool="semgrep",
+        target="./app.py",
+        file_path="app.py",
+        line_number=42,
+        severity="high",
+        title="SQL Injection vulnerability",
+        description="Possible SQL injection",
+        status="ignored",
+        first_seen="2024-04-01T00:00:00Z",
+        last_seen="2024-04-01T00:00:00Z",
+        times_seen=1,
+    )
+    temp_db.store_finding(f4)
+
+    # Finding 5: Another SQL injection instance, resolved
+    f5 = SecurityFinding(
+        fingerprint=SecurityFinding.compute_fingerprint(
+            "semgrep", "python.lang.security.injection.sql", "./api.py", None
+        ),
+        finding_id="python.lang.security.injection.sql",
+        tool="semgrep",
+        target="./api.py",
+        file_path="api.py",
+        line_number=100,
+        severity="high",
+        title="SQL Injection vulnerability",
+        description="Possible SQL injection in API",
+        status="resolved",
+        first_seen="2024-04-10T00:00:00Z",
+        last_seen="2024-04-15T00:00:00Z",
+        times_seen=2,
+    )
+    temp_db.store_finding(f5)
+
+    return temp_db
+
+
+class TestRecallByFingerprint:
+    """Tests for recall_by_fingerprint."""
+
+    def test_exact_match_found(self, populated_db):
+        """Should find exact fingerprint match."""
+        recall = SecurityRecall(populated_db)
+        fingerprint = SecurityFinding.compute_fingerprint(
+            "snyk", "CVE-2024-001", ".", "lodash"
+        )
+
+        result = recall.recall_by_fingerprint(fingerprint)
+
+        assert result.match_found is True
+        assert result.exact_match is True
+        assert result.finding is not None
+        assert result.finding["finding_id"] == "CVE-2024-001"
+
+    def test_historical_context_populated(self, populated_db):
+        """Should populate historical context fields."""
+        recall = SecurityRecall(populated_db)
+        fingerprint = SecurityFinding.compute_fingerprint(
+            "snyk", "CVE-2024-001", ".", "lodash"
+        )
+
+        result = recall.recall_by_fingerprint(fingerprint)
+
+        assert result.first_seen == "2024-01-01T00:00:00Z"
+        assert result.last_seen == "2024-01-15T00:00:00Z"
+        assert result.times_seen == 3
+
+    def test_similar_findings_counted(self, populated_db):
+        """Should count similar findings by finding_id."""
+        recall = SecurityRecall(populated_db)
+        fingerprint = SecurityFinding.compute_fingerprint(
+            "snyk", "CVE-2024-001", ".", "lodash"
+        )
+
+        result = recall.recall_by_fingerprint(fingerprint)
+
+        # CVE-2024-001 has 2 findings (. and ./sub)
+        assert result.similar_matches == 2
+        assert result.total_similar == 2
+
+    def test_suggests_resolved_for_resolved_finding(self, populated_db):
+        """Should suggest resolved for previously resolved finding."""
+        recall = SecurityRecall(populated_db)
+        fingerprint = SecurityFinding.compute_fingerprint(
+            "snyk", "CVE-2024-001", ".", "lodash"
+        )
+
+        result = recall.recall_by_fingerprint(fingerprint)
+
+        assert result.suggested_outcome == "resolved"
+        assert result.suggestion_confidence >= 0.9
+
+    def test_no_match_returns_empty_result(self, populated_db):
+        """Should return empty result for unknown fingerprint."""
+        recall = SecurityRecall(populated_db)
+
+        result = recall.recall_by_fingerprint("nonexistent-fingerprint")
+
+        assert result.match_found is False
+        assert result.exact_match is False
+        assert result.finding is None
+        assert result.suggested_outcome is None
+
+
+class TestRecallByFindingId:
+    """Tests for recall_by_finding_id."""
+
+    def test_finds_all_matching_cve(self, populated_db):
+        """Should find all findings with same CVE."""
+        recall = SecurityRecall(populated_db)
+
+        result = recall.recall_by_finding_id("CVE-2024-001")
+
+        assert result.match_found is True
+        assert result.similar_matches == 2
+        # Total times seen = 3 + 2 = 5
+        assert result.times_seen == 5
+
+    def test_aggregates_time_span(self, populated_db):
+        """Should show earliest first_seen and latest last_seen."""
+        recall = SecurityRecall(populated_db)
+
+        result = recall.recall_by_finding_id("CVE-2024-001")
+
+        assert result.first_seen == "2024-01-01T00:00:00Z"
+        assert result.last_seen == "2024-02-10T00:00:00Z"
+
+    def test_prior_outcomes_computed(self, populated_db):
+        """Should compute prior outcome distribution."""
+        recall = SecurityRecall(populated_db)
+
+        result = recall.recall_by_finding_id("CVE-2024-001")
+
+        assert result.prior_outcomes is not None
+        assert result.prior_outcomes["resolved"] == 1
+        assert result.prior_outcomes["false_positive"] == 1
+
+    def test_no_match_for_unknown_cve(self, populated_db):
+        """Should return no match for unknown CVE."""
+        recall = SecurityRecall(populated_db)
+
+        result = recall.recall_by_finding_id("CVE-9999-999")
+
+        assert result.match_found is False
+        assert result.similar_matches == 0
+
+
+class TestRecallByType:
+    """Tests for recall_by_type."""
+
+    def test_filter_by_tool(self, populated_db):
+        """Should filter by tool."""
+        recall = SecurityRecall(populated_db)
+
+        result = recall.recall_by_type(tool="semgrep")
+
+        assert result.match_found is True
+        assert result.similar_matches == 2  # Two semgrep findings
+
+    def test_filter_by_severity(self, populated_db):
+        """Should filter by severity."""
+        recall = SecurityRecall(populated_db)
+
+        result = recall.recall_by_type(severity="critical")
+
+        assert result.match_found is True
+        assert result.similar_matches == 2  # Two critical findings
+
+    def test_filter_by_category(self, populated_db):
+        """Should filter by category keyword in title/description."""
+        recall = SecurityRecall(populated_db)
+
+        result = recall.recall_by_type(category="SQL")
+
+        assert result.match_found is True
+        assert result.similar_matches == 2  # Two SQL injection findings
+
+    def test_combined_filters(self, populated_db):
+        """Should apply multiple filters."""
+        recall = SecurityRecall(populated_db)
+
+        result = recall.recall_by_type(tool="semgrep", severity="high")
+
+        assert result.match_found is True
+        assert result.similar_matches == 2
+
+    def test_no_match_for_unknown_type(self, populated_db):
+        """Should return no match for unknown type."""
+        recall = SecurityRecall(populated_db)
+
+        result = recall.recall_by_type(tool="unknown-tool")
+
+        assert result.match_found is False
+
+
+class TestOutcomeSuggestion:
+    """Tests for outcome suggestion logic."""
+
+    def test_suggests_existing_status_for_exact_match(self, populated_db):
+        """Exact match with non-open status should suggest that status."""
+        recall = SecurityRecall(populated_db)
+        fingerprint = SecurityFinding.compute_fingerprint(
+            "semgrep", "python.lang.security.injection.sql", "./app.py", None
+        )
+
+        result = recall.recall_by_fingerprint(fingerprint)
+
+        assert result.suggested_outcome == "ignored"
+        assert result.suggestion_confidence >= 0.9
+
+    def test_mixed_outcomes_lower_confidence(self, populated_db):
+        """Mixed outcomes should have lower confidence."""
+        recall = SecurityRecall(populated_db)
+
+        result = recall.recall_by_finding_id("CVE-2024-001")
+
+        # 50% resolved, 50% false_positive
+        assert result.suggestion_confidence < 0.8
+
+    def test_majority_outcome_suggested(self, populated_db):
+        """Should suggest majority outcome from similar findings."""
+        recall = SecurityRecall(populated_db)
+
+        # SQL injection: 1 ignored, 1 resolved
+        result = recall.recall_by_finding_id("python.lang.security.injection.sql")
+
+        # Both are non-open, should pick one
+        assert result.suggested_outcome in ["ignored", "resolved"]
+
+    def test_open_findings_suggest_open(self, populated_db):
+        """All open findings should suggest keeping open."""
+        recall = SecurityRecall(populated_db)
+
+        result = recall.recall_by_finding_id("CVE-2024-002")
+
+        # Only one finding, still open
+        assert result.suggested_outcome == "open"
+        assert result.suggestion_confidence <= 0.5
+
+    def test_suggestion_rationale_provided(self, populated_db):
+        """Should provide rationale for suggestion."""
+        recall = SecurityRecall(populated_db)
+        fingerprint = SecurityFinding.compute_fingerprint(
+            "snyk", "CVE-2024-001", ".", "lodash"
+        )
+
+        result = recall.recall_by_fingerprint(fingerprint)
+
+        assert result.suggestion_rationale is not None
+        assert len(result.suggestion_rationale) > 0
+
+
+class TestHistoricalSummary:
+    """Tests for get_historical_summary."""
+
+    def test_summary_by_finding_id(self, populated_db):
+        """Should generate summary for finding ID."""
+        recall = SecurityRecall(populated_db)
+
+        summary = recall.get_historical_summary(finding_id="CVE-2024-001")
+
+        assert summary["found"] is True
+        assert summary["finding_id"] == "CVE-2024-001"
+        assert summary["total_occurrences"] == 2
+        assert summary["total_times_seen"] == 5
+
+    def test_summary_by_fingerprint(self, populated_db):
+        """Should generate summary for fingerprint."""
+        recall = SecurityRecall(populated_db)
+        fingerprint = SecurityFinding.compute_fingerprint(
+            "snyk", "CVE-2024-001", ".", "lodash"
+        )
+
+        summary = recall.get_historical_summary(fingerprint=fingerprint)
+
+        assert summary["found"] is True
+        # Includes similar findings by finding_id
+        assert summary["total_occurrences"] == 2
+
+    def test_timeline_included(self, populated_db):
+        """Should include timeline in summary."""
+        recall = SecurityRecall(populated_db)
+
+        summary = recall.get_historical_summary(finding_id="CVE-2024-001")
+
+        assert "timeline" in summary
+        assert len(summary["timeline"]) == 2
+
+    def test_resolution_rate_computed(self, populated_db):
+        """Should compute resolution rate."""
+        recall = SecurityRecall(populated_db)
+
+        summary = recall.get_historical_summary(finding_id="CVE-2024-001")
+
+        # 1 resolved + 1 false_positive = 2/2 = 100%
+        assert summary["resolution_rate"] == 1.0
+
+    def test_not_found_returns_marker(self, populated_db):
+        """Should return found=False for unknown."""
+        recall = SecurityRecall(populated_db)
+
+        summary = recall.get_historical_summary(finding_id="UNKNOWN-CVE")
+
+        assert summary["found"] is False
+
+
+class TestReadOnlyInvariant:
+    """Tests verifying recall is read-only."""
+
+    def test_recall_does_not_modify_finding(self, populated_db):
+        """Recall should not modify the finding."""
+        recall = SecurityRecall(populated_db)
+        fingerprint = SecurityFinding.compute_fingerprint(
+            "snyk", "CVE-2024-001", ".", "lodash"
+        )
+
+        # Get original state
+        original = populated_db.get_finding_by_fingerprint(fingerprint)
+        original_times_seen = original.times_seen
+        original_status = original.status
+
+        # Perform recall
+        recall.recall_by_fingerprint(fingerprint)
+        recall.recall_by_fingerprint(fingerprint)
+        recall.recall_by_fingerprint(fingerprint)
+
+        # Verify unchanged
+        after = populated_db.get_finding_by_fingerprint(fingerprint)
+        assert after.times_seen == original_times_seen
+        assert after.status == original_status
+
+    def test_recall_does_not_add_findings(self, populated_db):
+        """Recall should not add new findings."""
+        recall = SecurityRecall(populated_db)
+
+        # Count before
+        summary_before = populated_db.summarize_findings()
+        count_before = summary_before["total_findings"]
+
+        # Perform various recalls
+        recall.recall_by_fingerprint("nonexistent")
+        recall.recall_by_finding_id("UNKNOWN-CVE")
+        recall.recall_by_type(tool="unknown")
+
+        # Count after
+        summary_after = populated_db.summarize_findings()
+        count_after = summary_after["total_findings"]
+
+        assert count_after == count_before
+
+    def test_recall_does_not_update_timestamps(self, populated_db):
+        """Recall should not update last_seen timestamps."""
+        recall = SecurityRecall(populated_db)
+        fingerprint = SecurityFinding.compute_fingerprint(
+            "snyk", "CVE-2024-001", ".", "lodash"
+        )
+
+        original = populated_db.get_finding_by_fingerprint(fingerprint)
+        original_last_seen = original.last_seen
+
+        recall.recall_by_fingerprint(fingerprint)
+
+        after = populated_db.get_finding_by_fingerprint(fingerprint)
+        assert after.last_seen == original_last_seen
+
+
+class TestRecallResult:
+    """Tests for RecallResult dataclass."""
+
+    def test_to_dict(self):
+        """Should convert to dictionary."""
+        result = RecallResult(
+            query_fingerprint="abc123",
+            match_found=True,
+            suggested_outcome="resolved",
+        )
+
+        d = result.to_dict()
+
+        assert d["query_fingerprint"] == "abc123"
+        assert d["match_found"] is True
+        assert d["suggested_outcome"] == "resolved"
+
+    def test_default_values(self):
+        """Should have sensible defaults."""
+        result = RecallResult()
+
+        assert result.match_found is False
+        assert result.exact_match is False
+        assert result.similar_matches == 0
+        assert result.times_seen == 0
+        assert result.suggestion_confidence == 0.0
+
+
+class TestFactoryFunction:
+    """Tests for get_security_recall factory."""
+
+    def test_creates_with_provided_memory(self, temp_db):
+        """Should use provided memory instance."""
+        recall = get_security_recall(temp_db)
+
+        assert recall.memory is temp_db
+
+    def test_creates_default_memory(self):
+        """Should create default memory if none provided."""
+        recall = get_security_recall()
+
+        assert recall.memory is not None
+        assert isinstance(recall.memory, SecurityPatternMemory)
+
+        recall.memory.close()
+
+
+class TestIntegrationWithPatternMemory:
+    """Integration tests with SEC5 pattern memory."""
+
+    def test_store_then_recall(self, temp_db):
+        """Should recall findings stored via pattern memory."""
+        # Store via SEC5
+        finding = SecurityFinding(
+            fingerprint=SecurityFinding.compute_fingerprint(
+                "trivy", "CVE-2025-NEW", ".", "newpkg"
+            ),
+            finding_id="CVE-2025-NEW",
+            tool="trivy",
+            target=".",
+            package_name="newpkg",
+            severity="medium",
+            status="open",
+        )
+        temp_db.store_finding(finding)
+
+        # Recall via SEC6
+        recall = SecurityRecall(temp_db)
+        result = recall.recall_by_fingerprint(finding.fingerprint)
+
+        assert result.match_found is True
+        assert result.finding["finding_id"] == "CVE-2025-NEW"
+
+    def test_status_update_reflected_in_recall(self, temp_db):
+        """Should reflect status updates in recall."""
+        # Store open finding
+        fingerprint = SecurityFinding.compute_fingerprint(
+            "snyk", "CVE-2025-STATUS", ".", "pkg"
+        )
+        finding = SecurityFinding(
+            fingerprint=fingerprint,
+            finding_id="CVE-2025-STATUS",
+            tool="snyk",
+            target=".",
+            package_name="pkg",
+            severity="high",
+            status="open",
+        )
+        temp_db.store_finding(finding)
+
+        # Update status
+        temp_db.update_status(fingerprint, "resolved")
+
+        # Recall should reflect new status
+        recall = SecurityRecall(temp_db)
+        result = recall.recall_by_fingerprint(fingerprint)
+
+        assert result.suggested_outcome == "resolved"
+        assert result.suggestion_confidence >= 0.9


### PR DESCRIPTION
## Summary

- **SEC6** — Read-only recall layer over SecurityPatternMemory (SEC5)
- `recall_by_fingerprint()` — exact lookup with suggested outcome
- `recall_by_finding_id()` — CVE/rule-id aggregation across targets
- `recall_by_type()` — filter by tool/category/severity
- `get_historical_summary()` — timeline, resolution rate, outcome distribution

## Read-Only Invariants

- Recall does NOT modify findings
- Recall does NOT increment times_seen
- Recall does NOT update timestamps
- Recall does NOT add new findings

## Explicit Disclaimers

- **No code fixes generated** — this service does not produce patches or fixes
- **No auto-remediation** — outputs are never applied automatically
- **Confidence is historical pattern confidence only** — based on prior outcomes (resolved/false_positive/ignored), not remediation quality
- **Outputs are suggestions for review, not actions** — human/012 must decide next steps

## Architecture

```
SEC5 (storage) <---- SEC6 (recall) ----> suggested outcome (for review)
                         ^
                         |
            fingerprint/finding_id/type query
```

## Test Plan

- [x] 33 tests passing (`test_security_recall.py`)
- [x] Recall by fingerprint (exact match)
- [x] Recall by finding_id (CVE aggregation)
- [x] Recall by type (tool/category/severity filter)
- [x] Outcome suggestion logic (exact > majority > open)
- [x] Read-only invariant verification

## Dependencies

- Requires #375 (SEC5) — **MERGED**

🤖 Generated with [Claude Code](https://claude.ai/code)