### PR TITLE
feat(wre): add security analysis assistant (SEC7)

### DIFF
--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -2,6 +2,65 @@
 
 ## Chronological Change Log
 
+### [2026-04-18] - SEC7: Security Analysis Assistant (v0.8.4)
+
+**WSP Protocol References**: WSP 77 (Agent Coordination), WSP 97 (Truthful)
+**Impact Analysis**: LLM-assisted proposal generation - NO auto-remediation, NO patch generation
+
+#### Changes Made
+
+- `src/security_analysis_assistant.py` (NEW):
+  - `AnalysisProposal` dataclass - remediation proposal for human review
+  - `SecurityAnalysisAssistant` class - LLM-assisted analysis (optional Qwen/Gemma)
+  - `analyze_finding()` - produces proposals from scan findings + recall context
+  - `write_proposal_artifact()` - explicit file write (disabled by default)
+  - Lazy backend resolution (no LM Studio required for tests)
+
+- `tests/test_security_analysis_assistant.py` (NEW):
+  - 34 tests with mocked LLM backends
+  - LLM unavailable returns `needs_review` (3 tests)
+  - Qwen/Gemma output parsing (6 tests)
+  - `requires_012` preserved from policy (3 tests)
+  - `no_patch_generated: true` invariant (3 tests)
+  - Recall context inclusion (4 tests)
+  - No file writes except explicit (3 tests)
+
+#### Hard Invariants
+
+- `no_patch_generated: true` — always True
+- `requires_012` — preserved from SEC2 policy, never overridden by LLM
+- No code mutation
+- No auto-remediation
+- No MCP/Codex/Claude dependency
+
+#### Proposal Output
+
+```python
+AnalysisProposal(
+    fingerprint="...",
+    finding_id="CVE-2024-001",
+    classification="true_positive|false_positive|needs_review",
+    classification_confidence=0.85,
+    finding_summary="...",
+    risk_explanation="...",
+    remediation_proposal="...",  # Text only, no patch
+    files_likely_affected=["src/api.py"],
+    requires_012=True,
+    no_patch_generated=True,  # Always True
+    analysis_source="qwen+gemma|deterministic",
+    recall_context_included=True,
+)
+```
+
+#### Verification
+
+```bash
+python -m pytest modules/infrastructure/wre_core/tests/test_security_analysis_assistant.py -v
+# Result: 34 passed
+```
+
+---
+
 ### [2026-04-18] - SEC6: Security Recall Service (v0.8.3)
 
 **WSP Protocol References**: WSP 60 (Module Memory), WSP 97 (Truthful), WSP 48 (Recursive Self-Improvement)

--- a/modules/infrastructure/wre_core/src/security_analysis_assistant.py
+++ b/modules/infrastructure/wre_core/src/security_analysis_assistant.py
@@ -1,0 +1,697 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Security Analysis Assistant - LLM-Assisted Proposal Generation
+
+SEC7 — SECURITY_ANALYSIS_ASSISTANT_PHASE1
+
+Analyzes scan findings + recall context and produces reviewable remediation
+proposals only. No auto-apply, no code mutation, no patch generation.
+
+Architecture:
+- SEC1 scans (subprocess CLI)
+- SEC2 routes policy
+- SEC3 wraps scan execution
+- SEC4 proposes scan triggers
+- SEC5 stores observations
+- SEC6 recalls historical outcomes
+- SEC7 (this) analyzes and writes remediation proposals
+
+WSP Compliance:
+- WSP 77: Agent Coordination (Qwen/Gemma optional)
+- WSP 97: Truthful claims (proposals only, no fix claims)
+"""
+
+import json
+import logging
+from dataclasses import dataclass, asdict, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _utc_iso() -> str:
+    """Return current UTC timestamp as ISO string."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class AnalysisProposal:
+    """
+    Remediation proposal for a security finding.
+
+    This is a PROPOSAL for human review, not an action.
+    No patches are generated. No code is modified.
+    """
+
+    # Finding identification
+    fingerprint: str
+    finding_id: str
+    tool: str
+    severity: str
+
+    # Analysis results
+    finding_summary: str = ""
+    risk_explanation: str = ""
+    classification: str = "needs_review"  # true_positive, false_positive, needs_review
+    classification_confidence: float = 0.0
+
+    # Remediation proposal
+    remediation_proposal: str = ""
+    files_likely_affected: List[str] = field(default_factory=list)
+
+    # Metadata
+    confidence_score: float = 0.0
+    requires_012: bool = False
+    no_patch_generated: bool = True  # Always True - hard invariant
+
+    # Analysis source
+    analysis_source: str = "deterministic"  # deterministic, qwen, gemma, qwen+gemma
+    llm_available: bool = False
+
+    # Recall context (if provided)
+    recall_context_included: bool = False
+    prior_outcomes: Optional[Dict[str, int]] = None
+    suggested_outcome_from_history: Optional[str] = None
+
+    # Timestamps
+    created_at: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return asdict(self)
+
+    def to_json(self, indent: int = 2) -> str:
+        """Convert to JSON string."""
+        return json.dumps(self.to_dict(), indent=indent)
+
+
+class SecurityAnalysisAssistant:
+    """
+    LLM-assisted security analysis that produces reviewable proposals.
+
+    This assistant:
+    - Analyzes normalized scan findings
+    - Incorporates SEC6 recall context when available
+    - Preserves SEC2 policy decisions (especially requires_012)
+    - Produces remediation proposals for human review
+
+    Hard constraints:
+    - No code mutation
+    - No patch generation
+    - No auto-remediation
+    - No MCP/Codex/Claude dependency
+    - LLM unavailability returns deterministic needs_review
+
+    Usage:
+        assistant = SecurityAnalysisAssistant()
+
+        proposal = assistant.analyze_finding(
+            finding={...},  # Normalized finding from SEC1/SEC3
+            policy_decision="gate_012",
+            requires_012=True,
+            recall_context={...},  # Optional SEC6 recall result
+        )
+
+        if proposal.requires_012:
+            # Route to 012 for review
+            pass
+    """
+
+    # Classification keywords for deterministic analysis
+    TRUE_POSITIVE_INDICATORS = {
+        "remote code execution",
+        "sql injection",
+        "command injection",
+        "path traversal",
+        "authentication bypass",
+        "privilege escalation",
+        "hardcoded credentials",
+        "secret exposure",
+    }
+
+    FALSE_POSITIVE_INDICATORS = {
+        "test file",
+        "example",
+        "mock",
+        "fixture",
+        "sample",
+        "demo",
+    }
+
+    def __init__(
+        self,
+        enable_qwen: bool = True,
+        enable_gemma: bool = True,
+        proposal_output_dir: Optional[Path] = None,
+    ):
+        """
+        Initialize SecurityAnalysisAssistant.
+
+        Args:
+            enable_qwen: Try to use Qwen for analysis (if available)
+            enable_gemma: Try to use Gemma for validation (if available)
+            proposal_output_dir: Directory for proposal artifacts (optional)
+        """
+        self.enable_qwen = enable_qwen
+        self.enable_gemma = enable_gemma
+        self.proposal_output_dir = proposal_output_dir
+
+        self._qwen_backend = None
+        self._gemma_backend = None
+        self._backends_resolved = False
+
+        logger.info(
+            "[SECURITY-ANALYSIS] Initialized - qwen=%s, gemma=%s",
+            enable_qwen,
+            enable_gemma,
+        )
+
+    def _resolve_backends(self) -> None:
+        """
+        Lazy-resolve LLM backends.
+
+        Only called when analysis is requested, not at init time.
+        This allows tests to run without LM Studio.
+        """
+        if self._backends_resolved:
+            return
+
+        self._backends_resolved = True
+
+        if not self.enable_qwen and not self.enable_gemma:
+            logger.info("[SECURITY-ANALYSIS] LLM backends disabled by config")
+            return
+
+        try:
+            from modules.infrastructure.shared_utilities.local_llm_resolver import (
+                resolve_qwen_backend,
+                resolve_gemma_backend,
+            )
+
+            if self.enable_qwen:
+                self._qwen_backend = resolve_qwen_backend()
+                if self._qwen_backend:
+                    logger.info("[SECURITY-ANALYSIS] Qwen backend available")
+
+            if self.enable_gemma:
+                self._gemma_backend = resolve_gemma_backend()
+                if self._gemma_backend:
+                    logger.info("[SECURITY-ANALYSIS] Gemma backend available")
+
+        except ImportError as e:
+            logger.debug(f"[SECURITY-ANALYSIS] LLM resolver import failed: {e}")
+        except Exception as e:
+            logger.debug(f"[SECURITY-ANALYSIS] Backend resolution failed: {e}")
+
+    def analyze_finding(
+        self,
+        finding: Dict[str, Any],
+        policy_decision: str = "report_only",
+        requires_012: bool = False,
+        recall_context: Optional[Dict[str, Any]] = None,
+    ) -> AnalysisProposal:
+        """
+        Analyze a security finding and produce a remediation proposal.
+
+        Args:
+            finding: Normalized finding dict (from SEC1/SEC3)
+                Required keys: fingerprint, finding_id, tool, severity
+                Optional: title, description, package_name, file_path
+            policy_decision: SEC2 policy decision
+            requires_012: Whether finding requires 012 review
+            recall_context: Optional SEC6 recall result
+
+        Returns:
+            AnalysisProposal with remediation suggestions (for review only)
+        """
+        # Extract finding fields
+        fingerprint = finding.get("fingerprint", "unknown")
+        finding_id = finding.get("finding_id", finding.get("vuln_id", "unknown"))
+        tool = finding.get("tool", "unknown")
+        severity = finding.get("severity", "unknown")
+        title = finding.get("title", "")
+        description = finding.get("description", "")
+        package_name = finding.get("package_name")
+        file_path = finding.get("file_path")
+
+        # Start building proposal
+        proposal = AnalysisProposal(
+            fingerprint=fingerprint,
+            finding_id=finding_id,
+            tool=tool,
+            severity=severity,
+            requires_012=requires_012,
+            no_patch_generated=True,  # Hard invariant
+            created_at=_utc_iso(),
+        )
+
+        # Include recall context if provided
+        if recall_context:
+            proposal.recall_context_included = True
+            proposal.prior_outcomes = recall_context.get("prior_outcomes")
+            proposal.suggested_outcome_from_history = recall_context.get(
+                "suggested_outcome"
+            )
+
+        # Try LLM analysis first
+        self._resolve_backends()
+
+        if self._qwen_backend or self._gemma_backend:
+            proposal.llm_available = True
+            self._analyze_with_llm(
+                proposal=proposal,
+                title=title,
+                description=description,
+                package_name=package_name,
+                file_path=file_path,
+                recall_context=recall_context,
+            )
+        else:
+            # Deterministic fallback
+            proposal.llm_available = False
+            proposal.analysis_source = "deterministic"
+            self._analyze_deterministic(
+                proposal=proposal,
+                title=title,
+                description=description,
+                package_name=package_name,
+                file_path=file_path,
+                recall_context=recall_context,
+            )
+
+        return proposal
+
+    def _analyze_with_llm(
+        self,
+        proposal: AnalysisProposal,
+        title: str,
+        description: str,
+        package_name: Optional[str],
+        file_path: Optional[str],
+        recall_context: Optional[Dict[str, Any]],
+    ) -> None:
+        """
+        Analyze finding using available LLM backends.
+
+        Qwen: Draft analysis
+        Gemma: Validate/second-pass classification
+        """
+        analysis_sources = []
+
+        # Build analysis prompt
+        prompt = self._build_analysis_prompt(
+            proposal=proposal,
+            title=title,
+            description=description,
+            package_name=package_name,
+            file_path=file_path,
+            recall_context=recall_context,
+        )
+
+        # Try Qwen for primary analysis
+        qwen_output = None
+        if self._qwen_backend:
+            try:
+                qwen_output = self._qwen_backend.generate_response(prompt, max_tokens=512)
+                if qwen_output and qwen_output.strip():
+                    analysis_sources.append("qwen")
+                    self._parse_llm_output(proposal, qwen_output)
+            except Exception as e:
+                logger.warning(f"[SECURITY-ANALYSIS] Qwen analysis failed: {e}")
+
+        # Try Gemma for validation/second-pass
+        if self._gemma_backend:
+            try:
+                validation_prompt = self._build_validation_prompt(
+                    proposal=proposal,
+                    qwen_output=qwen_output,
+                )
+                gemma_output = self._gemma_backend.generate_response(
+                    validation_prompt, max_tokens=256
+                )
+                if gemma_output and gemma_output.strip():
+                    analysis_sources.append("gemma")
+                    self._apply_gemma_validation(proposal, gemma_output)
+            except Exception as e:
+                logger.warning(f"[SECURITY-ANALYSIS] Gemma validation failed: {e}")
+
+        # Set analysis source
+        if analysis_sources:
+            proposal.analysis_source = "+".join(analysis_sources)
+        else:
+            # LLM available but both failed - fall back to deterministic
+            proposal.analysis_source = "deterministic"
+            self._analyze_deterministic(
+                proposal=proposal,
+                title=title,
+                description=description,
+                package_name=package_name,
+                file_path=file_path,
+                recall_context=recall_context,
+            )
+
+    def _analyze_deterministic(
+        self,
+        proposal: AnalysisProposal,
+        title: str,
+        description: str,
+        package_name: Optional[str],
+        file_path: Optional[str],
+        recall_context: Optional[Dict[str, Any]],
+    ) -> None:
+        """
+        Deterministic analysis when LLM is unavailable.
+
+        Always returns needs_review with low confidence.
+        """
+        combined_text = f"{title} {description}".lower()
+
+        # Build summary
+        proposal.finding_summary = self._build_deterministic_summary(
+            proposal, title, package_name, file_path
+        )
+
+        # Risk explanation
+        proposal.risk_explanation = self._build_risk_explanation(
+            proposal.severity, title, description
+        )
+
+        # Classification based on keywords
+        classification = "needs_review"
+        confidence = 0.3  # Low confidence for deterministic
+
+        # Check for true positive indicators
+        for indicator in self.TRUE_POSITIVE_INDICATORS:
+            if indicator in combined_text:
+                classification = "needs_review"  # Still needs_review, but note it
+                confidence = 0.5
+                break
+
+        # Check for false positive indicators
+        for indicator in self.FALSE_POSITIVE_INDICATORS:
+            if indicator in combined_text:
+                classification = "needs_review"  # Still needs_review
+                confidence = 0.4
+                break
+
+        # Use recall context if available
+        if recall_context and recall_context.get("suggested_outcome"):
+            suggested = recall_context["suggested_outcome"]
+            hist_confidence = recall_context.get("suggestion_confidence", 0.0)
+            if suggested == "false_positive" and hist_confidence > 0.7:
+                classification = "false_positive"
+                confidence = min(0.7, hist_confidence)
+            elif suggested == "resolved" and hist_confidence > 0.7:
+                # Still needs_review for new instance
+                confidence = max(confidence, 0.5)
+
+        proposal.classification = classification
+        proposal.classification_confidence = confidence
+        proposal.confidence_score = confidence
+
+        # Remediation proposal
+        proposal.remediation_proposal = self._build_remediation_proposal(
+            proposal.severity, title, package_name, file_path
+        )
+
+        # Files affected
+        if file_path:
+            proposal.files_likely_affected = [file_path]
+
+    def _build_analysis_prompt(
+        self,
+        proposal: AnalysisProposal,
+        title: str,
+        description: str,
+        package_name: Optional[str],
+        file_path: Optional[str],
+        recall_context: Optional[Dict[str, Any]],
+    ) -> str:
+        """Build prompt for LLM analysis."""
+        parts = [
+            "Analyze this security finding and provide a remediation proposal.",
+            "Output JSON with: classification (true_positive/false_positive/needs_review),",
+            "finding_summary, risk_explanation, remediation_proposal, confidence (0-1).",
+            "",
+            f"Finding ID: {proposal.finding_id}",
+            f"Tool: {proposal.tool}",
+            f"Severity: {proposal.severity}",
+            f"Title: {title}",
+        ]
+
+        if description:
+            parts.append(f"Description: {description[:500]}")
+
+        if package_name:
+            parts.append(f"Package: {package_name}")
+
+        if file_path:
+            parts.append(f"File: {file_path}")
+
+        if recall_context and recall_context.get("prior_outcomes"):
+            parts.append("")
+            parts.append("Historical context:")
+            parts.append(f"Prior outcomes: {recall_context['prior_outcomes']}")
+            if recall_context.get("suggested_outcome"):
+                parts.append(
+                    f"Historical suggestion: {recall_context['suggested_outcome']}"
+                )
+
+        parts.extend([
+            "",
+            "IMPORTANT: Do not generate patches. This is analysis only.",
+            "Respond with JSON only.",
+        ])
+
+        return "\n".join(parts)
+
+    def _build_validation_prompt(
+        self,
+        proposal: AnalysisProposal,
+        qwen_output: Optional[str],
+    ) -> str:
+        """Build prompt for Gemma validation."""
+        parts = [
+            "Validate this security finding classification.",
+            f"Finding: {proposal.finding_id} ({proposal.severity})",
+        ]
+
+        if qwen_output:
+            parts.append(f"Initial analysis: {qwen_output[:300]}")
+
+        parts.extend([
+            "",
+            "Output: true_positive, false_positive, or needs_review",
+            "Single word only.",
+        ])
+
+        return "\n".join(parts)
+
+    def _parse_llm_output(self, proposal: AnalysisProposal, output: str) -> None:
+        """Parse LLM JSON output into proposal fields."""
+        try:
+            # Try to extract JSON from output
+            output = output.strip()
+            if output.startswith("```"):
+                # Strip markdown code blocks
+                lines = output.split("\n")
+                output = "\n".join(
+                    line for line in lines if not line.startswith("```")
+                )
+
+            data = json.loads(output)
+
+            if "classification" in data:
+                classification = data["classification"].lower()
+                if classification in ("true_positive", "false_positive", "needs_review"):
+                    proposal.classification = classification
+
+            if "confidence" in data:
+                try:
+                    conf = float(data["confidence"])
+                    proposal.classification_confidence = max(0.0, min(1.0, conf))
+                    proposal.confidence_score = proposal.classification_confidence
+                except (ValueError, TypeError):
+                    pass
+
+            if "finding_summary" in data:
+                proposal.finding_summary = str(data["finding_summary"])[:500]
+
+            if "risk_explanation" in data:
+                proposal.risk_explanation = str(data["risk_explanation"])[:500]
+
+            if "remediation_proposal" in data:
+                proposal.remediation_proposal = str(data["remediation_proposal"])[:1000]
+
+        except json.JSONDecodeError:
+            # Fall back to extracting classification keyword
+            output_lower = output.lower()
+            if "true_positive" in output_lower:
+                proposal.classification = "true_positive"
+                proposal.classification_confidence = 0.6
+            elif "false_positive" in output_lower:
+                proposal.classification = "false_positive"
+                proposal.classification_confidence = 0.6
+            else:
+                proposal.classification = "needs_review"
+                proposal.classification_confidence = 0.4
+
+            proposal.confidence_score = proposal.classification_confidence
+
+    def _apply_gemma_validation(self, proposal: AnalysisProposal, output: str) -> None:
+        """Apply Gemma validation output to proposal."""
+        output_lower = output.strip().lower()
+
+        # Simple keyword extraction
+        if "true_positive" in output_lower:
+            if proposal.classification != "true_positive":
+                # Gemma disagrees - reduce confidence
+                proposal.classification_confidence *= 0.8
+            else:
+                # Gemma agrees - increase confidence
+                proposal.classification_confidence = min(
+                    1.0, proposal.classification_confidence * 1.1
+                )
+        elif "false_positive" in output_lower:
+            if proposal.classification != "false_positive":
+                proposal.classification_confidence *= 0.8
+            else:
+                proposal.classification_confidence = min(
+                    1.0, proposal.classification_confidence * 1.1
+                )
+        elif "needs_review" in output_lower:
+            # Gemma says needs_review - could override
+            if proposal.classification != "needs_review":
+                proposal.classification = "needs_review"
+                proposal.classification_confidence *= 0.7
+
+        proposal.confidence_score = proposal.classification_confidence
+
+    def _build_deterministic_summary(
+        self,
+        proposal: AnalysisProposal,
+        title: str,
+        package_name: Optional[str],
+        file_path: Optional[str],
+    ) -> str:
+        """Build deterministic finding summary."""
+        parts = [f"{proposal.severity.upper()} severity finding"]
+
+        if title:
+            parts.append(f"'{title}'")
+
+        parts.append(f"detected by {proposal.tool}")
+
+        if package_name:
+            parts.append(f"in package {package_name}")
+        elif file_path:
+            parts.append(f"in {file_path}")
+
+        return " ".join(parts) + "."
+
+    def _build_risk_explanation(
+        self,
+        severity: str,
+        title: str,
+        description: str,
+    ) -> str:
+        """Build risk explanation based on severity and content."""
+        severity_explanations = {
+            "critical": "This is a critical severity finding that may allow remote code execution, data exfiltration, or complete system compromise. Immediate review recommended.",
+            "high": "This is a high severity finding that could lead to significant security impact if exploited. Priority review recommended.",
+            "medium": "This is a medium severity finding that may pose security risks under certain conditions. Review when capacity allows.",
+            "low": "This is a low severity finding with limited security impact. Review during regular maintenance.",
+            "info": "This is an informational finding for awareness. No immediate action required.",
+        }
+
+        return severity_explanations.get(
+            severity.lower(),
+            "Severity unknown. Manual review recommended to assess risk.",
+        )
+
+    def _build_remediation_proposal(
+        self,
+        severity: str,
+        title: str,
+        package_name: Optional[str],
+        file_path: Optional[str],
+    ) -> str:
+        """Build remediation proposal text."""
+        parts = ["REMEDIATION PROPOSAL (for review only - no patch generated):"]
+
+        if package_name:
+            parts.append(f"1. Review {package_name} for known vulnerabilities")
+            parts.append("2. Check if upgrade is available and compatible")
+            parts.append("3. Evaluate if the vulnerable code path is reachable")
+        elif file_path:
+            parts.append(f"1. Review code in {file_path}")
+            parts.append("2. Verify the finding is not a false positive")
+            parts.append("3. If confirmed, implement secure coding fix")
+        else:
+            parts.append("1. Review the finding details")
+            parts.append("2. Assess applicability to this codebase")
+            parts.append("3. Implement appropriate remediation if confirmed")
+
+        if severity.lower() in ("critical", "high"):
+            parts.append("")
+            parts.append("NOTE: High/critical severity - prioritize this review.")
+
+        return "\n".join(parts)
+
+    def write_proposal_artifact(
+        self,
+        proposal: AnalysisProposal,
+        output_dir: Optional[Path] = None,
+    ) -> Optional[Path]:
+        """
+        Write proposal to artifact file.
+
+        Args:
+            proposal: AnalysisProposal to write
+            output_dir: Override output directory
+
+        Returns:
+            Path to written file, or None if disabled
+        """
+        target_dir = output_dir or self.proposal_output_dir
+        if target_dir is None:
+            return None
+
+        target_dir = Path(target_dir)
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        # Generate filename
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        safe_id = proposal.finding_id.replace("/", "_").replace(":", "_")[:50]
+        filename = f"proposal_{safe_id}_{timestamp}.json"
+
+        output_path = target_dir / filename
+
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(proposal.to_json())
+
+        logger.info(f"[SECURITY-ANALYSIS] Wrote proposal artifact: {output_path}")
+        return output_path
+
+
+def get_security_analysis_assistant(
+    enable_qwen: bool = True,
+    enable_gemma: bool = True,
+) -> SecurityAnalysisAssistant:
+    """
+    Factory function to get SecurityAnalysisAssistant instance.
+
+    Args:
+        enable_qwen: Try to use Qwen for analysis
+        enable_gemma: Try to use Gemma for validation
+
+    Returns:
+        SecurityAnalysisAssistant instance
+    """
+    return SecurityAnalysisAssistant(
+        enable_qwen=enable_qwen,
+        enable_gemma=enable_gemma,
+    )

--- a/modules/infrastructure/wre_core/tests/test_security_analysis_assistant.py
+++ b/modules/infrastructure/wre_core/tests/test_security_analysis_assistant.py
@@ -1,0 +1,607 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Tests for Security Analysis Assistant
+
+SEC7 — SECURITY_ANALYSIS_ASSISTANT_PHASE1
+
+Validates:
+- LLM unavailable path returns needs_review
+- Qwen/Gemma outputs are parsed safely
+- Policy requires_012 is preserved
+- Proposal contains no_patch_generated: true
+- Recall context is included when provided
+- No file writes except explicit proposal artifact writer
+- Mocked LLM backends (no LM Studio required)
+"""
+
+import gc
+import json
+import pytest
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from modules.infrastructure.wre_core.src.security_analysis_assistant import (
+    SecurityAnalysisAssistant,
+    AnalysisProposal,
+    get_security_analysis_assistant,
+)
+
+
+@pytest.fixture
+def sample_finding():
+    """Sample normalized finding for tests."""
+    return {
+        "fingerprint": "abc123def456",
+        "finding_id": "CVE-2024-001",
+        "tool": "snyk",
+        "severity": "critical",
+        "title": "Prototype Pollution in lodash",
+        "description": "Versions of lodash before 4.17.21 are vulnerable to prototype pollution.",
+        "package_name": "lodash",
+        "package_version": "4.17.20",
+    }
+
+
+@pytest.fixture
+def sample_recall_context():
+    """Sample SEC6 recall context for tests."""
+    return {
+        "match_found": True,
+        "similar_matches": 3,
+        "prior_outcomes": {
+            "resolved": 2,
+            "false_positive": 1,
+            "open": 0,
+        },
+        "suggested_outcome": "resolved",
+        "suggestion_confidence": 0.8,
+    }
+
+
+class TestLLMUnavailablePath:
+    """Tests verifying LLM unavailable fallback."""
+
+    def test_returns_needs_review_when_llm_disabled(self, sample_finding):
+        """Should return needs_review when LLM is disabled."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=False, enable_gemma=False)
+
+        proposal = assistant.analyze_finding(sample_finding)
+
+        assert proposal.classification == "needs_review"
+        assert proposal.llm_available is False
+        assert proposal.analysis_source == "deterministic"
+
+    def test_returns_needs_review_when_resolver_fails(self, sample_finding):
+        """Should return needs_review when LLM resolver import fails."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=True, enable_gemma=True)
+
+        # Mock resolver to raise ImportError
+        with patch(
+            "modules.infrastructure.wre_core.src.security_analysis_assistant.SecurityAnalysisAssistant._resolve_backends"
+        ) as mock_resolve:
+            # Simulate resolver failure by not setting backends
+            def fail_resolve(self):
+                self._backends_resolved = True
+                self._qwen_backend = None
+                self._gemma_backend = None
+
+            mock_resolve.side_effect = lambda: fail_resolve(assistant)
+
+            proposal = assistant.analyze_finding(sample_finding)
+
+        assert proposal.classification == "needs_review"
+        assert proposal.llm_available is False
+
+    def test_deterministic_has_low_confidence(self, sample_finding):
+        """Deterministic analysis should have low confidence."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=False, enable_gemma=False)
+
+        proposal = assistant.analyze_finding(sample_finding)
+
+        assert proposal.confidence_score <= 0.5
+        assert proposal.classification_confidence <= 0.5
+
+
+class TestQwenGemmaParsing:
+    """Tests for LLM output parsing safety."""
+
+    def test_parses_valid_json_output(self, sample_finding):
+        """Should parse valid JSON output from LLM."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=True, enable_gemma=False)
+
+        # Mock Qwen backend
+        mock_qwen = MagicMock()
+        mock_qwen.generate_response.return_value = json.dumps({
+            "classification": "true_positive",
+            "confidence": 0.85,
+            "finding_summary": "Critical prototype pollution vulnerability",
+            "risk_explanation": "Allows property injection",
+            "remediation_proposal": "Upgrade lodash to 4.17.21",
+        })
+
+        assistant._backends_resolved = True
+        assistant._qwen_backend = mock_qwen
+        assistant._gemma_backend = None
+
+        proposal = assistant.analyze_finding(sample_finding)
+
+        assert proposal.classification == "true_positive"
+        assert proposal.classification_confidence == 0.85
+        assert "prototype pollution" in proposal.finding_summary.lower()
+
+    def test_handles_malformed_json(self, sample_finding):
+        """Should handle malformed JSON gracefully."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=True, enable_gemma=False)
+
+        mock_qwen = MagicMock()
+        mock_qwen.generate_response.return_value = "This is not JSON at all"
+
+        assistant._backends_resolved = True
+        assistant._qwen_backend = mock_qwen
+        assistant._gemma_backend = None
+
+        proposal = assistant.analyze_finding(sample_finding)
+
+        # Should fall back to deterministic
+        assert proposal.classification == "needs_review"
+        assert proposal.no_patch_generated is True
+
+    def test_handles_partial_json(self, sample_finding):
+        """Should extract what it can from partial JSON."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=True, enable_gemma=False)
+
+        mock_qwen = MagicMock()
+        mock_qwen.generate_response.return_value = json.dumps({
+            "classification": "false_positive",
+            # Missing other fields
+        })
+
+        assistant._backends_resolved = True
+        assistant._qwen_backend = mock_qwen
+        assistant._gemma_backend = None
+
+        proposal = assistant.analyze_finding(sample_finding)
+
+        assert proposal.classification == "false_positive"
+
+    def test_handles_markdown_wrapped_json(self, sample_finding):
+        """Should handle JSON wrapped in markdown code blocks."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=True, enable_gemma=False)
+
+        mock_qwen = MagicMock()
+        mock_qwen.generate_response.return_value = """```json
+{
+    "classification": "true_positive",
+    "confidence": 0.9
+}
+```"""
+
+        assistant._backends_resolved = True
+        assistant._qwen_backend = mock_qwen
+        assistant._gemma_backend = None
+
+        proposal = assistant.analyze_finding(sample_finding)
+
+        assert proposal.classification == "true_positive"
+
+    def test_extracts_keyword_from_text(self, sample_finding):
+        """Should extract classification keyword from plain text."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=True, enable_gemma=False)
+
+        mock_qwen = MagicMock()
+        mock_qwen.generate_response.return_value = (
+            "Based on my analysis, this appears to be a TRUE_POSITIVE finding."
+        )
+
+        assistant._backends_resolved = True
+        assistant._qwen_backend = mock_qwen
+        assistant._gemma_backend = None
+
+        proposal = assistant.analyze_finding(sample_finding)
+
+        assert proposal.classification == "true_positive"
+
+    def test_gemma_validation_adjusts_confidence(self, sample_finding):
+        """Gemma validation should adjust confidence."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=True, enable_gemma=True)
+
+        mock_qwen = MagicMock()
+        mock_qwen.generate_response.return_value = json.dumps({
+            "classification": "true_positive",
+            "confidence": 0.7,
+        })
+
+        mock_gemma = MagicMock()
+        mock_gemma.generate_response.return_value = "true_positive"
+
+        assistant._backends_resolved = True
+        assistant._qwen_backend = mock_qwen
+        assistant._gemma_backend = mock_gemma
+
+        proposal = assistant.analyze_finding(sample_finding)
+
+        # Gemma agrees, confidence should increase
+        assert proposal.classification == "true_positive"
+        assert proposal.classification_confidence >= 0.7
+        assert "qwen" in proposal.analysis_source
+        assert "gemma" in proposal.analysis_source
+
+
+class TestRequires012Preservation:
+    """Tests verifying requires_012 is preserved from policy."""
+
+    def test_preserves_requires_012_true(self, sample_finding):
+        """Should preserve requires_012=True from policy."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=False, enable_gemma=False)
+
+        proposal = assistant.analyze_finding(
+            sample_finding,
+            policy_decision="gate_012",
+            requires_012=True,
+        )
+
+        assert proposal.requires_012 is True
+
+    def test_preserves_requires_012_false(self, sample_finding):
+        """Should preserve requires_012=False from policy."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=False, enable_gemma=False)
+
+        proposal = assistant.analyze_finding(
+            sample_finding,
+            policy_decision="report_only",
+            requires_012=False,
+        )
+
+        assert proposal.requires_012 is False
+
+    def test_requires_012_not_modified_by_llm(self, sample_finding):
+        """LLM analysis should not modify requires_012."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=True, enable_gemma=False)
+
+        mock_qwen = MagicMock()
+        # LLM output does not contain requires_012
+        mock_qwen.generate_response.return_value = json.dumps({
+            "classification": "false_positive",
+            "confidence": 0.95,
+        })
+
+        assistant._backends_resolved = True
+        assistant._qwen_backend = mock_qwen
+        assistant._gemma_backend = None
+
+        proposal = assistant.analyze_finding(
+            sample_finding,
+            requires_012=True,  # Policy says requires 012
+        )
+
+        # Should still require 012 despite LLM saying false_positive
+        assert proposal.requires_012 is True
+
+
+class TestNoPatchGenerated:
+    """Tests verifying no_patch_generated invariant."""
+
+    def test_no_patch_generated_always_true(self, sample_finding):
+        """no_patch_generated must always be True."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=False, enable_gemma=False)
+
+        proposal = assistant.analyze_finding(sample_finding)
+
+        assert proposal.no_patch_generated is True
+
+    def test_no_patch_generated_with_llm(self, sample_finding):
+        """no_patch_generated must be True even with LLM analysis."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=True, enable_gemma=False)
+
+        mock_qwen = MagicMock()
+        mock_qwen.generate_response.return_value = json.dumps({
+            "classification": "true_positive",
+            "patch": "// This should be ignored",
+        })
+
+        assistant._backends_resolved = True
+        assistant._qwen_backend = mock_qwen
+        assistant._gemma_backend = None
+
+        proposal = assistant.analyze_finding(sample_finding)
+
+        assert proposal.no_patch_generated is True
+
+    def test_proposal_dataclass_default(self):
+        """AnalysisProposal default should have no_patch_generated=True."""
+        proposal = AnalysisProposal(
+            fingerprint="test",
+            finding_id="CVE-TEST",
+            tool="test",
+            severity="high",
+        )
+
+        assert proposal.no_patch_generated is True
+
+
+class TestRecallContextInclusion:
+    """Tests for recall context inclusion."""
+
+    def test_includes_recall_context(self, sample_finding, sample_recall_context):
+        """Should include recall context when provided."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=False, enable_gemma=False)
+
+        proposal = assistant.analyze_finding(
+            sample_finding,
+            recall_context=sample_recall_context,
+        )
+
+        assert proposal.recall_context_included is True
+        assert proposal.prior_outcomes == {"resolved": 2, "false_positive": 1, "open": 0}
+        assert proposal.suggested_outcome_from_history == "resolved"
+
+    def test_no_recall_context_when_not_provided(self, sample_finding):
+        """Should not include recall context when not provided."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=False, enable_gemma=False)
+
+        proposal = assistant.analyze_finding(sample_finding)
+
+        assert proposal.recall_context_included is False
+        assert proposal.prior_outcomes is None
+        assert proposal.suggested_outcome_from_history is None
+
+    def test_recall_context_influences_deterministic_classification(
+        self, sample_finding
+    ):
+        """Recall context should influence deterministic classification."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=False, enable_gemma=False)
+
+        # Recall says high confidence false_positive
+        recall_context = {
+            "suggested_outcome": "false_positive",
+            "suggestion_confidence": 0.9,
+        }
+
+        proposal = assistant.analyze_finding(
+            sample_finding,
+            recall_context=recall_context,
+        )
+
+        # Should classify as false_positive based on history
+        assert proposal.classification == "false_positive"
+
+    def test_recall_context_passed_to_llm_prompt(self, sample_finding, sample_recall_context):
+        """Recall context should be included in LLM prompt."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=True, enable_gemma=False)
+
+        mock_qwen = MagicMock()
+        mock_qwen.generate_response.return_value = json.dumps({
+            "classification": "needs_review",
+        })
+
+        assistant._backends_resolved = True
+        assistant._qwen_backend = mock_qwen
+        assistant._gemma_backend = None
+
+        assistant.analyze_finding(
+            sample_finding,
+            recall_context=sample_recall_context,
+        )
+
+        # Check that recall context was in the prompt
+        call_args = mock_qwen.generate_response.call_args
+        prompt = call_args[0][0]
+        assert "Historical context" in prompt
+        assert "Prior outcomes" in prompt
+
+
+class TestNoFileWritesExceptExplicit:
+    """Tests verifying no file writes except explicit artifact writer."""
+
+    def test_analyze_does_not_write_files(self, sample_finding, tmp_path):
+        """analyze_finding should not write any files."""
+        assistant = SecurityAnalysisAssistant(
+            enable_qwen=False,
+            enable_gemma=False,
+            proposal_output_dir=None,  # Disabled
+        )
+
+        # Record files before
+        files_before = set(tmp_path.rglob("*"))
+
+        proposal = assistant.analyze_finding(sample_finding)
+
+        # Verify no files written
+        files_after = set(tmp_path.rglob("*"))
+        assert files_after == files_before
+
+    def test_explicit_write_creates_file(self, sample_finding, tmp_path):
+        """Explicit write_proposal_artifact should create file."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=False, enable_gemma=False)
+
+        proposal = assistant.analyze_finding(sample_finding)
+
+        # Explicit write
+        output_path = assistant.write_proposal_artifact(proposal, output_dir=tmp_path)
+
+        assert output_path is not None
+        assert output_path.exists()
+        assert output_path.suffix == ".json"
+
+        # Verify content
+        with open(output_path) as f:
+            data = json.load(f)
+        assert data["finding_id"] == "CVE-2024-001"
+        assert data["no_patch_generated"] is True
+
+    def test_write_disabled_returns_none(self, sample_finding):
+        """Should return None when output dir is None."""
+        assistant = SecurityAnalysisAssistant(
+            enable_qwen=False,
+            enable_gemma=False,
+            proposal_output_dir=None,
+        )
+
+        proposal = assistant.analyze_finding(sample_finding)
+        result = assistant.write_proposal_artifact(proposal)
+
+        assert result is None
+
+
+class TestAnalysisProposalDataclass:
+    """Tests for AnalysisProposal dataclass."""
+
+    def test_to_dict(self, sample_finding):
+        """Should convert to dictionary."""
+        proposal = AnalysisProposal(
+            fingerprint="abc123",
+            finding_id="CVE-2024-001",
+            tool="snyk",
+            severity="critical",
+            classification="needs_review",
+        )
+
+        d = proposal.to_dict()
+
+        assert d["fingerprint"] == "abc123"
+        assert d["finding_id"] == "CVE-2024-001"
+        assert d["no_patch_generated"] is True
+
+    def test_to_json(self):
+        """Should convert to JSON string."""
+        proposal = AnalysisProposal(
+            fingerprint="abc123",
+            finding_id="CVE-2024-001",
+            tool="snyk",
+            severity="critical",
+        )
+
+        json_str = proposal.to_json()
+
+        data = json.loads(json_str)
+        assert data["finding_id"] == "CVE-2024-001"
+
+    def test_default_values(self):
+        """Should have sensible defaults."""
+        proposal = AnalysisProposal(
+            fingerprint="test",
+            finding_id="TEST",
+            tool="test",
+            severity="low",
+        )
+
+        assert proposal.classification == "needs_review"
+        assert proposal.no_patch_generated is True
+        assert proposal.llm_available is False
+        assert proposal.analysis_source == "deterministic"
+        assert proposal.files_likely_affected == []
+
+
+class TestFactoryFunction:
+    """Tests for get_security_analysis_assistant factory."""
+
+    def test_creates_with_defaults(self):
+        """Should create assistant with default settings."""
+        assistant = get_security_analysis_assistant()
+
+        assert assistant.enable_qwen is True
+        assert assistant.enable_gemma is True
+
+    def test_creates_with_custom_settings(self):
+        """Should respect custom settings."""
+        assistant = get_security_analysis_assistant(
+            enable_qwen=False,
+            enable_gemma=True,
+        )
+
+        assert assistant.enable_qwen is False
+        assert assistant.enable_gemma is True
+
+
+class TestDeterministicAnalysis:
+    """Tests for deterministic analysis logic."""
+
+    def test_includes_severity_in_risk_explanation(self, sample_finding):
+        """Risk explanation should mention severity."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=False, enable_gemma=False)
+
+        proposal = assistant.analyze_finding(sample_finding)
+
+        assert "critical" in proposal.risk_explanation.lower()
+
+    def test_includes_package_in_remediation(self, sample_finding):
+        """Remediation should mention package when available."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=False, enable_gemma=False)
+
+        proposal = assistant.analyze_finding(sample_finding)
+
+        assert "lodash" in proposal.remediation_proposal
+
+    def test_includes_file_in_affected(self):
+        """Should include file_path in files_likely_affected."""
+        finding = {
+            "fingerprint": "xyz789",
+            "finding_id": "RULE-001",
+            "tool": "semgrep",
+            "severity": "high",
+            "file_path": "src/api/handler.py",
+        }
+
+        assistant = SecurityAnalysisAssistant(enable_qwen=False, enable_gemma=False)
+
+        proposal = assistant.analyze_finding(finding)
+
+        assert "src/api/handler.py" in proposal.files_likely_affected
+
+    def test_summary_includes_tool(self, sample_finding):
+        """Summary should mention the scanning tool."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=False, enable_gemma=False)
+
+        proposal = assistant.analyze_finding(sample_finding)
+
+        assert "snyk" in proposal.finding_summary.lower()
+
+
+class TestEdgeCases:
+    """Tests for edge cases."""
+
+    def test_handles_empty_finding(self):
+        """Should handle minimal finding dict."""
+        finding = {
+            "fingerprint": "min",
+            "finding_id": "UNKNOWN",
+            "tool": "unknown",
+            "severity": "unknown",
+        }
+
+        assistant = SecurityAnalysisAssistant(enable_qwen=False, enable_gemma=False)
+
+        proposal = assistant.analyze_finding(finding)
+
+        assert proposal.classification == "needs_review"
+        assert proposal.no_patch_generated is True
+
+    def test_handles_llm_exception(self, sample_finding):
+        """Should handle LLM backend exception gracefully."""
+        assistant = SecurityAnalysisAssistant(enable_qwen=True, enable_gemma=False)
+
+        mock_qwen = MagicMock()
+        mock_qwen.generate_response.side_effect = Exception("LLM crashed")
+
+        assistant._backends_resolved = True
+        assistant._qwen_backend = mock_qwen
+        assistant._gemma_backend = None
+
+        proposal = assistant.analyze_finding(sample_finding)
+
+        # Should fall back to deterministic
+        assert proposal.analysis_source == "deterministic"
+        assert proposal.no_patch_generated is True
+
+    def test_handles_very_long_description(self, sample_finding):
+        """Should truncate very long descriptions."""
+        sample_finding["description"] = "A" * 10000
+
+        assistant = SecurityAnalysisAssistant(enable_qwen=False, enable_gemma=False)
+
+        proposal = assistant.analyze_finding(sample_finding)
+
+        # Should not crash and should complete
+        assert proposal.finding_id == "CVE-2024-001"


### PR DESCRIPTION
## Summary

- **SEC7** — LLM-assisted analysis layer producing reviewable remediation proposals
- `analyze_finding()` — analyzes scan findings + SEC6 recall context
- Classification: `true_positive | false_positive | needs_review`
- Qwen drafts analysis, Gemma validates (both optional)
- LLM unavailable → deterministic `needs_review` (no failure)

## Explicit Disclaimers

- **No code fixes generated** — `no_patch_generated: true` is a hard invariant
- **No auto-remediation** — outputs are proposals for human review only
- **Confidence is historical pattern confidence only** — based on SEC6 recall + LLM classification, not remediation quality
- **Outputs are suggestions for review, not actions** — human/012 decides next steps
- **requires_012 preserved from policy** — LLM cannot override SEC2 policy gate

## Architecture

```
SEC1 (scan) → SEC2 (policy) → SEC3 (skill) → SEC5 (store)
                                   ↓
              SEC6 (recall) → SEC7 (analysis) → AnalysisProposal
                                                (for review only)
```

## Test Plan

- [x] 34 tests passing (`test_security_analysis_assistant.py`)
- [x] LLM unavailable returns `needs_review` (3 tests)
- [x] Qwen/Gemma output parsing safety (6 tests)
- [x] `requires_012` preserved from policy (3 tests)
- [x] `no_patch_generated: true` invariant (3 tests)
- [x] Recall context included when provided (4 tests)
- [x] No file writes except explicit artifact (3 tests)

## Dependencies

- Requires #376 (SEC6) — **MERGED**

🤖 Generated with [Claude Code](https://claude.ai/code)