### PR TITLE
feat(ai-overseer): dispatch core preflight failures

### DIFF
--- a/docs/0102_session_briefings/DJ_AI_RESOLUTION_HOOK_CONTRACT_PHASE1.md
+++ b/docs/0102_session_briefings/DJ_AI_RESOLUTION_HOOK_CONTRACT_PHASE1.md
@@ -1,0 +1,117 @@
+# DJ — AI_RESOLUTION_HOOK_CONTRACT_PHASE1 (Completion Report)
+
+**Date**: 2026-04-19
+**Worker**: DJ
+**WSP**: 97 (truthful state distinction), 77 (agent coordination)
+**Scope**: Option A (from architect) — dispatch contract + DEP-SECURITY + WSP-FRAMEWORK only.
+**Deferred**: DJ-OBS (AntifaFM OBS-start emitter) until AF1 read-only audit completes.
+
+---
+
+## Goal
+
+Add one structured AI-resolution dispatch contract for preflight failures that today log and continue. AI Overseer is initialized at boot (visible in logs) but nothing was handed off to it.
+
+## Problem (from boot log, 2026-04-19 06:44)
+
+```
+[DEP-SECURITY] preflight=FAIL (fresh) critical=4 high=4 unknown=3 tool_failures=0
+[WSP-FRAMEWORK] preflight=FAIL (fresh) drift=0 framework_only=1 knowledge_only=0 index_issues=1
+```
+
+Both emit to console, both set the process return code, neither route to the
+`[AI-OVERSEER] ... initialized` daemon that could triage them.
+
+## Architecture
+
+```
+preflight emitter  --on_preflight_fail(component, severity, payload)-->  ai_overseer
+                                             |
+                                             +-- pattern recall (wre_core/pattern_memory, graceful fallback)
+                                             +-- AI proposal     (qwen/gemma,           graceful fallback)
+                                             +-- durable artifact (alerts/preflight/*.json)
+                                             +-- escalate if severity in {critical, high} or requires_012
+```
+
+Single entry point. Never raises. LLM-unavailable path returns a valid event
+with `state="skipped"`.
+
+## Files
+
+| File | Change |
+|---|---|
+| `modules/ai_intelligence/ai_overseer/src/preflight_resolution.py` | new, dispatch contract + event dataclass |
+| `modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py` | new, 12 tests |
+| `modules/ai_intelligence/ai_overseer/tests/conftest.py` | allowlist += `test_preflight_resolution.py` |
+| `modules/ai_intelligence/ai_overseer/ModLog.md` | DJ phase entry prepended |
+| `main.py` | DEP-SECURITY + WSP-FRAMEWORK emitters wired (try/except import, non-fatal) |
+
+## Boot-log signal → dispatch mapping
+
+| Boot-log signal | Source | Component key | Severity rule | Escalation |
+|---|---|---|---|---|
+| `[DEP-SECURITY] preflight=FAIL ... critical=N high=M` | `main.run_dependency_security_preflight` | `dep_security` | `critical` if N>0, else `high` if M>0, else `medium` | auto-escalate on critical/high |
+| `[WSP-FRAMEWORK] preflight=FAIL ... drift=D framework_only=F index_issues=I` | `main.run_wsp_framework_preflight` | `wsp_framework` | `high` if D+F+I > 0 else `medium` | auto-escalate on high |
+
+## WSP 97 state machine
+
+```
+detected     - emitter observed failure
+dispatched   - event artifact written
+proposed     - AI proposed remediation (never applied)
+escalated    - severity or payload flag requires 012
+skipped      - LLM/PatternMemory unavailable; deterministic event only
+```
+
+Each `alerts/preflight/<component>_<UTC>.json` reflects the final state.
+The report strictly distinguishes **proposed** from **applied** — nothing is
+applied in Phase 1.
+
+## Acceptance
+
+| Criterion | Status |
+|---|---|
+| DEP-SECURITY failure emits AI resolution event | ✅ wired in `main.py`, test asserts dispatcher call |
+| WSP-FRAMEWORK failure emits AI resolution event | ✅ wired in `main.py`, test asserts dispatcher call |
+| OBS-start emitter (requires_012 / automation_candidate) | ⏸ **deferred to DJ-OBS**, reason below |
+| Existing logs remain | ✅ no `print`/`logger` lines removed; dispatch is additive |
+| Durable artifact `alerts/preflight/*.json` | ✅ written on each dispatch |
+| Tests mock each emitter and assert dispatch | ✅ `test_main_py_dep_security_calls_dispatcher`, `test_main_py_wsp_framework_calls_dispatcher` |
+| Tests prove no fix applied | ✅ `test_no_fix_is_auto_applied` |
+| LLM-unavailable path still works | ✅ `test_ai_unavailable_path_returns_valid_event` |
+| Dispatch never raises | ✅ `test_dispatch_never_raises_even_on_internal_error` |
+
+## Deferral note — DJ-OBS
+
+**OBS-start emitter deferred to DJ-OBS after AF1 read-only AntifaFM readiness audit.**
+
+Rationale: AF1 is a read-only audit of `modules/platform_integration/antifafm_broadcaster/`.
+Wiring a dispatch call into `obs_controller.py` during DJ would contaminate that
+audit surface. The dispatch contract is fully proven with 2 emitters; the OBS
+branch can adopt it verbatim once AF1 confirms AntifaFM boundary stability.
+
+## Out of scope (future slices)
+
+- Chrome 9222 auto-start (DJ2)
+- `google.generativeai` deprecation migration hook (DJ2)
+- WRE dashboard WARN tier for `samples=0/25` (DJ2)
+- IRONCLAW `preflight=SKIP` intentional-skip validation (DJ2)
+- Actual OBS modal-click automation (DJ-OBS or Hermes)
+- Orphan process reaper (unregistered python.exe survives heartbeat) — DJ3 candidate
+
+## Verification
+
+```
+pytest modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py -v
+============================= 12 passed in 4.18s ==============================
+```
+
+No other tests touched. No runtime mutation introduced. Dispatch activates on
+next `main.py` restart — current running `main.py` (PID 87616) keeps its
+loaded bytecode and is unaffected.
+
+## Next slice gates
+
+- **AF1** — read-only AntifaFM internal-operational-readiness audit
+- **DJ-OBS** — gated on AF1, wires the OBS-start emitter using the now-proven contract
+- **DJ2** — other detection-without-resolution emitters from WSP 97 sweep

--- a/main.py
+++ b/main.py
@@ -527,6 +527,29 @@ def run_dependency_security_preflight(repo_root: Path) -> bool:
         f"critical={critical} high={high} unknown={unknown} tool_failures={tool_failures}"
     )
 
+    if not passed:
+        try:
+            from modules.ai_intelligence.ai_overseer.src.preflight_resolution import (
+                on_preflight_fail,
+            )
+
+            severity = "critical" if critical > 0 else ("high" if high > 0 else "medium")
+            on_preflight_fail(
+                component="dep_security",
+                severity=severity,
+                payload={
+                    "critical": critical,
+                    "high": high,
+                    "unknown": unknown,
+                    "tool_failures": tool_failures,
+                    "cache_state": cache_state,
+                    "enforced": enforced,
+                },
+                source="main.py:run_dep_security_preflight",
+            )
+        except Exception as exc:
+            logger.debug(f"[DEP-SECURITY] preflight dispatch failed: {exc}")
+
     if not passed and enforced:
         print("[DEP-SECURITY] Startup blocked by OPENCLAW_DEP_SECURITY_PREFLIGHT_ENFORCED=1")
         return False
@@ -872,6 +895,33 @@ def run_wsp_framework_preflight(repo_root: Path, overseer: Any | None = None) ->
         f"drift={drift_count} framework_only={framework_only_count} "
         f"knowledge_only={knowledge_only_count} index_issues={index_issue_count}"
     )
+
+    if canonical_fail:
+        try:
+            from modules.ai_intelligence.ai_overseer.src.preflight_resolution import (
+                on_preflight_fail,
+            )
+
+            severity = (
+                "high" if (drift_count > 0 or framework_only_count > 0 or index_issue_count > 0) else "medium"
+            )
+            on_preflight_fail(
+                component="wsp_framework",
+                severity=severity,
+                payload={
+                    "available": available,
+                    "drift_count": drift_count,
+                    "framework_only_count": framework_only_count,
+                    "knowledge_only_count": knowledge_only_count,
+                    "index_issue_count": index_issue_count,
+                    "cache_state": cache_state,
+                    "enforced": enforced,
+                    "allow_backup_only": allow_backup_only,
+                },
+                source="main.py:run_wsp_framework_preflight",
+            )
+        except Exception as exc:
+            logger.debug(f"[WSP-FRAMEWORK] preflight dispatch failed: {exc}")
 
     if canonical_fail and enforced:
         print("[WSP-FRAMEWORK] Startup blocked by WSP_FRAMEWORK_PREFLIGHT_ENFORCED=1")

--- a/modules/ai_intelligence/ai_overseer/ModLog.md
+++ b/modules/ai_intelligence/ai_overseer/ModLog.md
@@ -6,6 +6,57 @@
 
 ---
 
+## 2026-04-19 - DJ: Preflight Resolution Dispatch Contract (Phase 1)
+
+**Author**: 0102
+**WSP**: 97 (truthful state distinction), 77 (agent coordination)
+**Phase**: DJ - AI_RESOLUTION_HOOK_CONTRACT_PHASE1
+
+### Summary
+
+Adds a single structured hook (`on_preflight_fail`) that converts log-and-continue
+preflight failures into durable, AI-routable events. Wires DEP-SECURITY and
+WSP-FRAMEWORK emitters in `main.py`. OBS-start emitter deferred to DJ-OBS after
+AF1 read-only AntifaFM readiness audit.
+
+### Files
+
+- `src/preflight_resolution.py` (new) - dispatch contract + event dataclass
+- `tests/test_preflight_resolution.py` (new) - 12 tests, all passing
+- `tests/conftest.py` - allowlist includes new test file
+- `main.py` (monorepo root) - 2 emitter wires (DEP-SECURITY, WSP-FRAMEWORK)
+
+### Truthful state model (WSP 97)
+
+- `detected`   - emitter observed a preflight failure
+- `dispatched` - structured event recorded on disk
+- `proposed`   - AI proposed a remediation (not applied)
+- `escalated`  - event requires 012 review
+- `skipped`    - LLM/PatternMemory unavailable; deterministic event only
+
+### Hard constraints respected
+
+- No auto-remediation, no fix application, no process mutation.
+- AI proposal path wrapped in try/except; LLM-unavailable returns valid skipped event.
+- PatternMemory recall wrapped in try/except; absent memory returns `None`.
+- `alerts/preflight/*.json` per-event artifacts; never overwrites sources.
+- Dispatcher function never raises.
+
+### Deferred scope
+
+- DJ-OBS (AntifaFM `obs_controller.py` emitter) - gated on AF1 audit completion.
+- DJ2 (Chrome 9222 auto-start, VEO deprecation hook, WRE dashboard WARN tier,
+  IRONCLAW SKIP validation) - post-proof expansion.
+
+### Verification
+
+```
+pytest modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py -v
+12 passed in 4.18s
+```
+
+---
+
 ## 2026-04-19 - CF3M: m2m_SKILLz.md Semantic Cleanup
 
 **Author**: 0102  

--- a/modules/ai_intelligence/ai_overseer/src/preflight_resolution.py
+++ b/modules/ai_intelligence/ai_overseer/src/preflight_resolution.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Preflight Resolution Dispatch Contract.
+
+DJ - AI_RESOLUTION_HOOK_CONTRACT_PHASE1
+
+Provides on_preflight_fail() as the single structured hook for preflight
+failures that today only log-and-continue. Writes a durable event artifact
+under alerts/preflight/ and attempts best-effort proposal routing via
+PatternMemory / Qwen / Gemma when those are available. Never auto-applies
+fixes.
+
+WSP 97 state distinction:
+    detected     - emitter observed a preflight failure
+    dispatched   - structured event recorded on disk
+    proposed     - AI proposed a remediation (not applied)
+    escalated    - event requires 012 review (severity/confidence)
+    skipped      - LLM unavailable; deterministic event only
+
+Hard constraints (Phase 1):
+    - No auto-remediation
+    - No fix application
+    - No process mutation
+    - LLM-unavailable path returns a valid dispatched event
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Optional
+
+logger = logging.getLogger(__name__)
+
+
+PreflightResolutionState = Literal[
+    "detected",
+    "dispatched",
+    "proposed",
+    "escalated",
+    "skipped",
+]
+
+
+Severity = Literal["critical", "high", "medium", "low", "info"]
+
+
+_SEVERITY_ESCALATE = {"critical", "high"}
+
+_SAFE_COMPONENT = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+def _utc_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _safe_component(component: str) -> str:
+    cleaned = _SAFE_COMPONENT.sub("_", component.strip()) or "unknown"
+    return cleaned[:64]
+
+
+@dataclass
+class PreflightFailureEvent:
+    """Structured preflight-failure event routed to ai_overseer."""
+
+    component: str
+    severity: Severity
+    payload: Dict[str, Any]
+    source: str = ""
+    detected_at: str = ""
+    state: PreflightResolutionState = "detected"
+    requires_012: bool = False
+    automation_candidate: bool = False
+    pattern_recall: Optional[Dict[str, Any]] = None
+    proposal: Optional[Dict[str, Any]] = None
+    notes: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def _default_alerts_root(repo_root: Optional[Path] = None) -> Path:
+    root = repo_root or Path(os.getenv("FOUNDUPS_REPO_ROOT", ".")).resolve()
+    return root / "alerts" / "preflight"
+
+
+def _try_pattern_recall(event: PreflightFailureEvent) -> Optional[Dict[str, Any]]:
+    try:
+        from modules.infrastructure.wre_core.src.pattern_memory import (
+            SQLitePatternMemory,
+        )
+
+        memory = SQLitePatternMemory()
+        patterns = memory.recall_successful_patterns(
+            skill_name=f"preflight_{event.component}",
+            min_fidelity=0.70,
+        )
+        if not patterns:
+            return None
+        first = patterns[0]
+        return {
+            "pattern_id": getattr(first, "pattern_id", None),
+            "fidelity": getattr(first, "fidelity", None),
+            "skill_name": getattr(first, "skill_name", None),
+        }
+    except Exception as exc:
+        logger.debug(f"[PREFLIGHT-DISPATCH] PatternMemory unavailable: {exc}")
+        return None
+
+
+def _try_ai_proposal(event: PreflightFailureEvent) -> Optional[Dict[str, Any]]:
+    try:
+        from holo_index.qwen_advisor.orchestration.autonomous_refactoring import (
+            AutonomousRefactoringOrchestrator,
+        )
+
+        orchestrator = AutonomousRefactoringOrchestrator(Path("."))
+        if not hasattr(orchestrator, "propose_preflight_fix"):
+            return {
+                "engine": "qwen",
+                "available": False,
+                "reason": "propose_preflight_fix method not implemented",
+            }
+        return orchestrator.propose_preflight_fix(event.to_dict())
+    except Exception as exc:
+        logger.debug(f"[PREFLIGHT-DISPATCH] AI proposal unavailable: {exc}")
+        return None
+
+
+def _write_event_artifact(
+    event: PreflightFailureEvent,
+    alerts_root: Optional[Path] = None,
+) -> Path:
+    root = alerts_root or _default_alerts_root()
+    root.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    path = root / f"{_safe_component(event.component)}_{timestamp}.json"
+    path.write_text(json.dumps(event.to_dict(), indent=2), encoding="utf-8")
+    return path
+
+
+def on_preflight_fail(
+    component: str,
+    severity: Severity,
+    payload: Dict[str, Any],
+    source: str = "",
+    *,
+    alerts_root: Optional[Path] = None,
+    skip_ai: bool = False,
+) -> Dict[str, Any]:
+    """
+    Single structured entry point for preflight failures.
+
+    Args:
+        component: Short identifier (e.g. "dep_security", "wsp_framework").
+        severity: One of critical / high / medium / low / info.
+        payload: Free-form dict of emitter-provided context.
+        source: Emitter identifier (module:function or file:line).
+        alerts_root: Override artifact directory (test hook).
+        skip_ai: Skip AI proposal path (test hook).
+
+    Returns:
+        Dict describing the event and its resolution state. Never raises.
+    """
+    try:
+        event = PreflightFailureEvent(
+            component=component or "unknown",
+            severity=severity if severity in {"critical", "high", "medium", "low", "info"} else "medium",
+            payload=payload or {},
+            source=source or "",
+            detected_at=_utc_iso(),
+            state="detected",
+        )
+
+        event.requires_012 = bool(payload.get("requires_012")) or (
+            event.severity in _SEVERITY_ESCALATE
+        )
+        event.automation_candidate = bool(payload.get("automation_candidate", False))
+
+        event.pattern_recall = _try_pattern_recall(event)
+        if event.pattern_recall:
+            event.notes.append(f"pattern_recall_hit={event.pattern_recall.get('pattern_id')}")
+
+        if skip_ai:
+            event.state = "skipped"
+            event.notes.append("ai_proposal_skipped_by_caller")
+        else:
+            proposal = _try_ai_proposal(event)
+            if proposal and proposal.get("available", True):
+                event.proposal = proposal
+                event.state = "proposed"
+            else:
+                event.state = "skipped"
+                event.notes.append(
+                    "ai_proposal_unavailable"
+                    if proposal is None
+                    else f"ai_proposal_not_implemented:{proposal.get('reason', '')}"
+                )
+
+        if event.requires_012:
+            event.state = "escalated"
+
+        artifact_path = _write_event_artifact(event, alerts_root=alerts_root)
+        if event.state == "detected":
+            event.state = "dispatched"
+
+        logger.info(
+            f"[PREFLIGHT-DISPATCH] component={event.component} severity={event.severity} "
+            f"state={event.state} artifact={artifact_path}"
+        )
+
+        result = event.to_dict()
+        result["artifact_path"] = str(artifact_path)
+        return result
+
+    except Exception as exc:
+        logger.error(f"[PREFLIGHT-DISPATCH] dispatch failed: {exc}")
+        return {
+            "component": component,
+            "severity": severity,
+            "state": "detected",
+            "error": str(exc),
+            "notes": ["dispatch_internal_error"],
+        }

--- a/modules/ai_intelligence/ai_overseer/tests/conftest.py
+++ b/modules/ai_intelligence/ai_overseer/tests/conftest.py
@@ -25,6 +25,7 @@ _ALLOWLIST = {
     "test_ai_overseer_ironclaw_runtime.py",
     "test_wsp49_interface_gap_scanner.py",
     "test_vulnerability_scan_policy.py",
+    "test_preflight_resolution.py",
 }
 
 _HEAVY_TARGETS = [

--- a/modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py
+++ b/modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py
@@ -1,0 +1,222 @@
+"""
+Tests for preflight_resolution dispatch contract (DJ Phase 1).
+
+Acceptance:
+- on_preflight_fail() returns a structured dispatched/escalated event.
+- Artifact written to alerts_root provided by caller (no repo pollution).
+- AI-unavailable path still returns a valid event (skipped state).
+- No fix is auto-applied.
+- Two main.py emitters (DEP-SECURITY, WSP-FRAMEWORK) call the dispatcher.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from modules.ai_intelligence.ai_overseer.src import preflight_resolution as pr
+
+
+def test_dispatch_returns_structured_event(tmp_path):
+    result = pr.on_preflight_fail(
+        component="dep_security",
+        severity="critical",
+        payload={"critical": 4, "high": 4, "unknown": 3},
+        source="test",
+        alerts_root=tmp_path,
+        skip_ai=True,
+    )
+
+    assert result["component"] == "dep_security"
+    assert result["severity"] == "critical"
+    assert result["state"] in {"escalated", "dispatched", "skipped"}
+    assert result["requires_012"] is True
+    assert "artifact_path" in result
+
+
+def test_critical_severity_escalates_to_012(tmp_path):
+    result = pr.on_preflight_fail(
+        component="dep_security",
+        severity="critical",
+        payload={"critical": 1},
+        alerts_root=tmp_path,
+        skip_ai=True,
+    )
+    assert result["requires_012"] is True
+    assert result["state"] == "escalated"
+
+
+def test_medium_severity_does_not_auto_escalate(tmp_path):
+    result = pr.on_preflight_fail(
+        component="wsp_framework",
+        severity="medium",
+        payload={"drift_count": 0, "framework_only_count": 0},
+        alerts_root=tmp_path,
+        skip_ai=True,
+    )
+    assert result["requires_012"] is False
+    assert result["state"] == "skipped"
+
+
+def test_automation_candidate_flag_passes_through(tmp_path):
+    result = pr.on_preflight_fail(
+        component="obs_start",
+        severity="high",
+        payload={"automation_candidate": True, "requires_012": True},
+        alerts_root=tmp_path,
+        skip_ai=True,
+    )
+    assert result["automation_candidate"] is True
+    assert result["requires_012"] is True
+
+
+def test_artifact_written_to_alerts_root(tmp_path):
+    result = pr.on_preflight_fail(
+        component="dep_security",
+        severity="high",
+        payload={"high": 4},
+        alerts_root=tmp_path,
+        skip_ai=True,
+    )
+    path = Path(result["artifact_path"])
+    assert path.exists()
+    assert path.parent == tmp_path
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["component"] == "dep_security"
+    assert data["severity"] == "high"
+
+
+def test_ai_unavailable_path_returns_valid_event(tmp_path):
+    with patch.object(pr, "_try_ai_proposal", return_value=None):
+        result = pr.on_preflight_fail(
+            component="dep_security",
+            severity="high",
+            payload={"high": 4},
+            alerts_root=tmp_path,
+        )
+    assert result["state"] in {"escalated", "skipped", "dispatched"}
+    assert result["proposal"] is None
+    assert any("ai_proposal_unavailable" in n for n in result["notes"])
+
+
+def test_pattern_memory_unavailable_path_is_graceful(tmp_path):
+    with patch.object(pr, "_try_pattern_recall", return_value=None):
+        result = pr.on_preflight_fail(
+            component="dep_security",
+            severity="high",
+            payload={"high": 4},
+            alerts_root=tmp_path,
+            skip_ai=True,
+        )
+    assert result["pattern_recall"] is None
+
+
+def test_dispatch_never_raises_even_on_internal_error(tmp_path, monkeypatch):
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated artifact write failure")
+
+    monkeypatch.setattr(pr, "_write_event_artifact", _boom)
+
+    result = pr.on_preflight_fail(
+        component="dep_security",
+        severity="high",
+        payload={},
+        alerts_root=tmp_path,
+        skip_ai=True,
+    )
+    assert result["state"] == "detected"
+    assert "dispatch_internal_error" in result.get("notes", [])
+
+
+def test_no_fix_is_auto_applied(tmp_path, monkeypatch):
+    side_effects = {"called": False}
+
+    def _spy_proposal(event):
+        side_effects["called"] = True
+        return {"engine": "qwen", "proposal": "upgrade foo==2.0.0", "available": True}
+
+    monkeypatch.setattr(pr, "_try_ai_proposal", _spy_proposal)
+
+    result = pr.on_preflight_fail(
+        component="dep_security",
+        severity="high",
+        payload={"high": 4},
+        alerts_root=tmp_path,
+    )
+
+    assert side_effects["called"] is True
+    assert result["state"] in {"proposed", "escalated"}
+    assert result["proposal"]["proposal"] == "upgrade foo==2.0.0"
+    data = json.loads(Path(result["artifact_path"]).read_text(encoding="utf-8"))
+    assert "applied" not in data
+    assert "fixed" not in data
+
+
+def test_component_name_is_sanitised(tmp_path):
+    result = pr.on_preflight_fail(
+        component="dep security / critical",
+        severity="high",
+        payload={},
+        alerts_root=tmp_path,
+        skip_ai=True,
+    )
+    path = Path(result["artifact_path"])
+    assert "/" not in path.name
+    assert " " not in path.name
+
+
+def test_main_py_dep_security_calls_dispatcher():
+    import main
+
+    with patch(
+        "modules.ai_intelligence.ai_overseer.src.preflight_resolution.on_preflight_fail"
+    ) as mock_dispatch:
+        fake_status = {
+            "totals": {"critical": 4, "high": 4, "unknown": 3},
+            "tool_failures": 0,
+            "cached": False,
+            "passed": False,
+        }
+        with patch(
+            "modules.infrastructure.wre_core.src.dependency_security_preflight.run_dependency_security_preflight",
+            return_value=fake_status,
+        ):
+            with patch.dict("os.environ", {"OPENCLAW_DEP_SECURITY_PREFLIGHT": "1",
+                                           "OPENCLAW_DEP_SECURITY_PREFLIGHT_ENFORCED": "0",
+                                           "OPENCLAW_24X7": "0"}, clear=False):
+                main.run_dependency_security_preflight(Path("."))
+
+    assert mock_dispatch.called
+    call_kwargs = mock_dispatch.call_args.kwargs
+    assert call_kwargs["component"] == "dep_security"
+    assert call_kwargs["severity"] in {"critical", "high", "medium"}
+    assert call_kwargs["payload"]["critical"] == 4
+
+
+def test_main_py_wsp_framework_calls_dispatcher():
+    import main
+
+    class _FakeOverseer:
+        def monitor_wsp_framework(self, force=False, emit_alert=False):
+            return {
+                "available": True,
+                "drift_count": 0,
+                "framework_only": ["WSP_XX"],
+                "knowledge_only": [],
+                "index_issues": ["dup"],
+                "cached": False,
+            }
+
+    with patch(
+        "modules.ai_intelligence.ai_overseer.src.preflight_resolution.on_preflight_fail"
+    ) as mock_dispatch:
+        with patch.dict("os.environ", {"WSP_FRAMEWORK_PREFLIGHT": "1",
+                                       "WSP_FRAMEWORK_PREFLIGHT_ENFORCED": "0"}, clear=False):
+            main.run_wsp_framework_preflight(Path("."), overseer=_FakeOverseer())
+
+    assert mock_dispatch.called
+    call_kwargs = mock_dispatch.call_args.kwargs
+    assert call_kwargs["component"] == "wsp_framework"
+    assert call_kwargs["payload"]["framework_only_count"] == 1
+    assert call_kwargs["payload"]["index_issue_count"] == 1


### PR DESCRIPTION
## Summary

DJ Phase 1 (Option A scope) — adds one structured AI-resolution dispatch contract for preflight failures that today log-and-continue.

- Wires **DEP-SECURITY** and **WSP-FRAMEWORK** preflight-fail emitters only.
- OBS emitter intentionally **deferred to DJ-OBS** after AF1 read-only AntifaFM readiness audit.
- **No auto-remediation** — events are durable/proposal/dispatch only.
- Main.py changes take effect on **next restart** (no hot-reload).

## Boot-log signal → dispatch mapping

| Signal | Component | Severity rule |
|---|---|---|
| `[DEP-SECURITY] preflight=FAIL critical=N high=M` | `dep_security` | `critical` if N>0, else `high` if M>0, else `medium` |
| `[WSP-FRAMEWORK] preflight=FAIL drift=D framework_only=F index_issues=I` | `wsp_framework` | `high` if any>0, else `medium` |

## WSP 97 state machine
```
detected → dispatched → proposed → escalated
                                 ↘ skipped (LLM unavailable)
```
Each dispatch writes `alerts/preflight/<component>_<UTC>.json`. Proposed is strictly distinguished from applied — nothing is applied.

## Files
- NEW `modules/ai_intelligence/ai_overseer/src/preflight_resolution.py` — dispatch contract
- NEW `modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py` — 12 tests
- MOD `modules/ai_intelligence/ai_overseer/tests/conftest.py` — allowlist
- MOD `main.py` — DEP-SECURITY + WSP-FRAMEWORK emitters (try/except, non-fatal)
- MOD `modules/ai_intelligence/ai_overseer/ModLog.md` — DJ Phase 1 entry
- NEW `docs/0102_session_briefings/DJ_AI_RESOLUTION_HOOK_CONTRACT_PHASE1.md` — completion report

## Acceptance

| Criterion | Status |
|---|---|
| DEP-SECURITY failure emits AI resolution event | ✅ |
| WSP-FRAMEWORK failure emits AI resolution event | ✅ |
| OBS-start emitter | ⏸ deferred to DJ-OBS (post-AF1) |
| Existing logs remain | ✅ additive only |
| Durable artifact written | ✅ |
| No fix auto-applied | ✅ |
| LLM-unavailable path works | ✅ returns skipped event |
| Dispatch never raises | ✅ |

## Deferred to later slices

- **DJ-OBS** — AntifaFM OBS-start emitter, gated on AF1 read-only audit
- **DJ2** — Chrome 9222 auto-start, WRE dashboard WARN tier, IRONCLAW SKIP validation, orphan process reaper, google.generativeai migration hook

## Test plan

- [x] `pytest modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py -v` → 12 passed in 4.18s
- [x] No other tests touched
- [x] No runtime mutation — dispatch activates on next main.py restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)