### PR TITLE
feat(youtube-auth): add OAuth operator-assist SKILLz contracts

### DIFF
--- a/modules/platform_integration/youtube_auth/ModLog.md
+++ b/modules/platform_integration/youtube_auth/ModLog.md
@@ -12,6 +12,41 @@ This log tracks changes specific to the **youtube_auth** module in the **platfor
 
 ## MODLOG ENTRIES
 
+### 2026-04-19 - YT-OAUTH-SKILLZ1: OAuth Operator-Assist SKILLz + Script Fixes
+
+**By:** 0102 (Worker CW4, Slice YT-OAUTH-SKILLZ1)
+**WSP References:** WSP 22 (ModLog), WSP 97 (Truth Signaling)
+
+**Problem:**
+1. `authorize_set1.py` told users to use "FoundUps account" but Set 1 should be UnDaoDu
+2. No AI Overseer / Claw / Hermes integration for OAuth health monitoring
+
+**Root Cause:**
+Misleading account guidance in authorize script caused wrong token to be saved.
+Both Set 1 and Set 10 ended up authenticating to the same antifaFM account.
+
+**Changes:**
+- **Fixed** `scripts/authorize_set1.py`:
+  - Now says "UnDaoDu Google account (NOT FoundUps)"
+  - Shows clear set-to-account mapping
+- **Fixed** `scripts/authorize_set10.py`:
+  - Now says "FoundUps Google account (NOT UnDaoDu)"
+  - Consistent guidance with Set 1
+
+**New SKILLz Contracts** (WRE integration):
+- `skillz/oauth_health_check/SKILLz.md` - Read health artifact, classify state (autonomous)
+- `skillz/supervised_reauth/SKILLz.md` - Guide 012 through reauth (requires_012=true)
+- `skillz/identity_verify/SKILLz.md` - Verify set maps to expected channel (autonomous)
+- `skillz/capacity_report/SKILLz.md` - Summarize effective quota capacity (autonomous)
+
+**Supervised Boundary (WSP 97):**
+- No credential inspection by 0102
+- No credential mutation by 0102
+- Browser OAuth requires 012 interaction
+- Claims must be backed by artifacts
+
+---
+
 ### 2026-04-19 - YT2: Set 1 Reauth Operator Runbook
 
 **By:** 0102 (Worker CW4, Slice YT2)

--- a/modules/platform_integration/youtube_auth/scripts/authorize_set1.py
+++ b/modules/platform_integration/youtube_auth/scripts/authorize_set1.py
@@ -74,8 +74,9 @@ def main():
         print("\n[U+1F310] Opening browser for authorization...")
         print(f"   Port: {port}")
         print(f"   Browser: {'Chrome' if browser_name else 'default'}")
-        print("\nIMPORTANT: Use the FoundUps Google account")
-        print("   This gives you access to FoundUps YouTube API quota")
+        print("\nIMPORTANT: Use the UnDaoDu Google account (NOT FoundUps)")
+        print("   Set 1 = UnDaoDu / Move2Japan channels")
+        print("   Set 10 = FoundUps / antifaFM channels (use Edge for Set 10)")
 
         # Run local server on port 8080 for Set 1
         credentials = flow.run_local_server(port=port, browser=browser_name)

--- a/modules/platform_integration/youtube_auth/scripts/authorize_set10.py
+++ b/modules/platform_integration/youtube_auth/scripts/authorize_set10.py
@@ -108,7 +108,9 @@ def main():
             )
         else:
             print(f"   Browser: {'Edge' if browser_name else 'default'}")
-            print("\nIMPORTANT: Use the Google account/channel you actually want on set 10")
+            print("\nIMPORTANT: Use the FoundUps Google account (NOT UnDaoDu)")
+            print("   Set 10 = FoundUps / antifaFM channels")
+            print("   Set 1 = UnDaoDu / Move2Japan channels (use Chrome for Set 1)")
             print("   If Google opens a 400 delegation page, rerun with --manual")
             creds = flow.run_local_server(
                 port=port,

--- a/modules/platform_integration/youtube_auth/skillz/capacity_report/SKILLz.md
+++ b/modules/platform_integration/youtube_auth/skillz/capacity_report/SKILLz.md
@@ -1,0 +1,101 @@
+---
+name: youtube_oauth_capacity_report
+version: "1.0"
+category: capability-uplift
+autonomous: true
+requires_012: false
+evals: []
+retirement_date: null
+---
+
+# youtube_oauth_capacity_report
+
+## Purpose
+
+Summarize effective YouTube API quota capacity after accounting for dead, exhausted, and healthy credential sets. Emit degraded-mode warning if capacity is reduced.
+
+## Supervised Boundary (WSP 97)
+
+- **Autonomous**: YES
+- **Credential inspection**: NO
+- **API calls**: NO (reads artifacts only)
+
+## Input Sources
+
+```
+modules/platform_integration/youtube_auth/reports/oauth_credential_health.json
+modules/platform_integration/youtube_auth/memory/quota_usage.json (if exists)
+```
+
+## Output
+
+```yaml
+report_time: ISO timestamp
+capacity:
+  total_configured_sets: 2
+  operational_sets: [list of set IDs]
+  dead_sets: [list of set IDs]
+  quota_exhausted_today: [list of set IDs]
+  
+quota:
+  daily_limit_per_set: 10000
+  effective_daily_capacity: int  # operational_sets * 10000
+  estimated_remaining_today: int | null  # if quota tracking available
+  
+status: full_capacity | degraded | critical | exhausted
+
+warnings: [list of warning strings]
+
+operator_actions:
+  - action: str
+    set_id: int
+    command: str
+```
+
+## Capacity Status Definitions
+
+| Status | Condition |
+|--------|-----------|
+| full_capacity | All configured sets operational |
+| degraded | 1+ sets dead but some still operational |
+| critical | Only 1 set operational |
+| exhausted | All sets dead or quota exhausted |
+
+## Example Output
+
+```yaml
+capacity:
+  total_configured_sets: 2
+  operational_sets: [10]
+  dead_sets: [1]
+  quota_exhausted_today: []
+  
+quota:
+  daily_limit_per_set: 10000
+  effective_daily_capacity: 10000
+  
+status: degraded
+
+warnings:
+  - "Set 1 is dead (token_expired_or_revoked) - 50% capacity loss"
+  - "Running on single credential set - no failover available"
+
+operator_actions:
+  - action: "Reauthorize Set 1"
+    set_id: 1
+    command: "python modules/platform_integration/youtube_auth/scripts/authorize_set1.py"
+```
+
+## Trigger
+
+- After oauth_health_check detects degraded capacity
+- Scheduled capacity audit (e.g., daily)
+- Manual `/youtube-quota-status` command
+- AI Overseer quota warning threshold
+
+## Integration Points
+
+- **AI Overseer**: Capacity alerts
+- **health_check**: Calls capacity_report for detailed breakdown
+- **WRE**: Pattern memory for capacity degradation trends
+- **DAE Operations**: Degraded mode decisions

--- a/modules/platform_integration/youtube_auth/skillz/identity_verify/SKILLz.md
+++ b/modules/platform_integration/youtube_auth/skillz/identity_verify/SKILLz.md
@@ -1,0 +1,81 @@
+---
+name: youtube_oauth_identity_verify
+version: "1.0"
+category: capability-uplift
+autonomous: true
+requires_012: false
+evals: []
+retirement_date: null
+---
+
+# youtube_oauth_identity_verify
+
+## Purpose
+
+Verify that credential Set N maps to the expected Google account/YouTube channel using safe API metadata or existing artifacts.
+
+## Supervised Boundary (WSP 97)
+
+- **Autonomous**: YES (if token exists and API read approved)
+- **Credential inspection**: NO (uses token, does not read contents)
+- **API calls**: YES (channels.list mine=True, 1 quota unit)
+
+## Input
+
+```yaml
+set_id: 1 | 10
+expected_channels:
+  1: ["UC-LSSlOZwpGIRIYihaz8zCw", "UCfHM9Fw9HD-NwiS0seD_oIA"]  # Move2Japan, UnDaoDu
+  10: ["UCSNTUXjAgpd4sgWYP0xoJgw", "UCVSmg5aOhP4tnQ9KFUg97qA"]  # FoundUps, antifaFM
+```
+
+## Verification Method
+
+1. Load credentials for set_id (via get_authenticated_service)
+2. Call `channels.list(part='snippet', mine=True)`
+3. Extract channel_id from response
+4. Compare to expected_channels[set_id]
+5. Return identity_status
+
+## Output
+
+```yaml
+identity_status: verified | mismatch | not_verified | error
+set_id: int
+observed_channel_id: str | null
+observed_channel_title: str | null
+expected_channel_ids: [list]
+match_found: true | false
+error: str | null
+```
+
+## Allowed Claims
+
+- "Identity verified by channel ID" (when observed matches expected)
+- "Identity mismatch" (when observed does not match expected)
+- "Identity not verified" (when API call fails or no channel found)
+
+## Forbidden Claims
+
+- "Set 1 is UnDaoDu" without channel/account verification
+- Any claim about Google account email
+- Any claim about token contents
+
+## Expected Channel Mapping
+
+| Set | Account | Expected Channels |
+|-----|---------|-------------------|
+| 1 | UnDaoDu | Move2Japan (UC-LSSlOZwpGIRIYihaz8zCw), UnDaoDu (UCfHM9Fw9HD-NwiS0seD_oIA) |
+| 10 | FoundUps | FoundUps (UCSNTUXjAgpd4sgWYP0xoJgw), antifaFM (UCVSmg5aOhP4tnQ9KFUg97qA) |
+
+## Trigger
+
+- After supervised_reauth completes
+- On preflight when token valid but identity unknown
+- Manual `/youtube-oauth-verify {set_id}` command
+
+## Integration Points
+
+- **AI Overseer**: Post-reauth verification
+- **supervised_reauth**: Follow-up skill
+- **health_check**: Identity status in health report

--- a/modules/platform_integration/youtube_auth/skillz/oauth_health_check/SKILLz.md
+++ b/modules/platform_integration/youtube_auth/skillz/oauth_health_check/SKILLz.md
@@ -1,0 +1,75 @@
+---
+name: youtube_oauth_health_check
+version: "1.0"
+category: capability-uplift
+autonomous: true
+requires_012: false
+evals: []
+retirement_date: null
+---
+
+# youtube_oauth_health_check
+
+## Purpose
+
+Read the redacted `oauth_credential_health.json` artifact, classify token/capacity state, and recommend next operator action.
+
+## Supervised Boundary (WSP 97)
+
+- **Autonomous**: YES
+- **Credential inspection**: NO (reads artifact, not tokens)
+- **Credential mutation**: NO
+
+## Input
+
+None required. Reads from:
+```
+modules/platform_integration/youtube_auth/reports/oauth_credential_health.json
+```
+
+## Output
+
+```yaml
+status: healthy | degraded | critical
+sets:
+  operational: [list of set IDs]
+  dead: [list of set IDs]
+  quota_exhausted: [list of set IDs]
+effective_daily_quota: int
+operator_action: null | "reauth required" | "wait for quota reset"
+recommended_skill: null | supervised_reauth | capacity_report
+```
+
+## Allowed Claims
+
+- "Token refresh valid" (if status=healthy in artifact)
+- "Capacity degraded" (if dead sets > 0)
+- "Operator action required" (if reauth_needed)
+
+## Forbidden Claims
+
+- "OAuth fixed" without artifact verification
+- Any claim about token contents
+- Any claim about which Google account owns a set (use identity_verify for that)
+
+## Trigger
+
+- AI Overseer detects oauth preflight fail
+- Scheduled health check
+- Manual `/youtube-oauth-status` command
+
+## Example Invocation
+
+```python
+# AI Overseer hook
+if preflight_failed:
+    result = invoke_skill("youtube_oauth_health_check")
+    if result["status"] == "critical":
+        create_task("supervised_reauth", requires_012=True)
+```
+
+## Integration Points
+
+- **AI Overseer**: Preflight failure hook
+- **Claw/OpenClaw**: Status query
+- **WRE**: Pattern memory for failure trends

--- a/modules/platform_integration/youtube_auth/skillz/supervised_reauth/SKILLz.md
+++ b/modules/platform_integration/youtube_auth/skillz/supervised_reauth/SKILLz.md
@@ -1,0 +1,87 @@
+---
+name: youtube_oauth_supervised_reauth
+version: "1.0"
+category: workflow
+autonomous: false
+requires_012: true
+evals: []
+retirement_date: null
+---
+
+# youtube_oauth_supervised_reauth
+
+## Purpose
+
+Guide 012 through opening the correct authorize script for a credential set. Worker assists but NEVER performs credential entry.
+
+## Supervised Boundary (WSP 97)
+
+- **Autonomous**: PARTIAL (can prepare, cannot execute without 012)
+- **Credential inspection**: NO
+- **Credential mutation**: NO (012 performs OAuth in browser)
+- **Browser control**: NO (script opens browser, 012 interacts)
+
+## Input
+
+```yaml
+set_id: 1 | 10
+reason: "invalid_grant" | "identity_mismatch" | "operator_requested"
+```
+
+## Workflow
+
+1. **Validate set_id** (must be 1 or 10)
+2. **Determine browser**:
+   - Set 1 = Chrome (UnDaoDu / Move2Japan)
+   - Set 10 = Edge (FoundUps / antifaFM)
+3. **Display guidance to 012**:
+   ```
+   Set 1 requires Chrome browser with UnDaoDu Google account
+   Set 10 requires Edge browser with FoundUps Google account
+   ```
+4. **Wait for 012 confirmation**
+5. **Run authorize script** (only when 012 confirms):
+   ```bash
+   python modules/platform_integration/youtube_auth/scripts/authorize_set{N}.py
+   ```
+6. **Observe output** (do not parse tokens)
+7. **Invoke identity_verify** after completion
+8. **Report result**
+
+## Output
+
+```yaml
+action_taken: script_launched | aborted_by_012 | error
+set_id: int
+browser: Chrome | Edge
+identity_verified: true | false | pending
+follow_up_skill: identity_verify
+```
+
+## Allowed Actions
+
+- Open runbook documentation
+- Run authorize script WHEN 012 approves
+- Display account selection guidance
+- Read redacted status after completion
+- Write durable event/artifact
+
+## Forbidden Actions
+
+- Perform credential entry
+- Parse or inspect token file contents
+- Claim "reauth complete" if only browser opened
+- Auto-select Google account
+- Bypass 012 confirmation
+
+## Runbook Reference
+
+```
+modules/platform_integration/youtube_auth/docs/SET1_REAUTH_OPERATOR_RUNBOOK.md
+```
+
+## Integration Points
+
+- **AI Overseer**: Creates supervised_reauth task on invalid_grant
+- **Claw/OpenClaw**: Executes under 012 supervision
+- **WRE**: Records outcome in pattern memory


### PR DESCRIPTION
## Summary
- Add 4 WRE operator-assist skills for AI Overseer / Claw / Hermes integration
- Fix authorize script account guidance (Set 1 = UnDaoDu, Set 10 = FoundUps)

## SKILLz Added

| Skill | Purpose | Autonomous | requires_012 |
|-------|---------|------------|--------------|
| `oauth_health_check` | Read health artifact, classify state | yes | no |
| `supervised_reauth` | Guide 012 through reauth | partial | **yes** |
| `identity_verify` | Verify set maps to expected channel | yes | no |
| `capacity_report` | Summarize effective quota capacity | yes | no |

## WSP 97 Supervised Boundary

**Allowed:**
- Read redacted health artifacts
- Classify token/capacity state
- Run authorize script when 012 approves
- Verify channel identity via API

**Forbidden:**
- Credential inspection
- Credential mutation
- Browser OAuth without 012
- Claims without artifact verification

## Scope (7 files)
- `scripts/authorize_set1.py` — Fixed account guidance
- `scripts/authorize_set10.py` — Fixed account guidance
- `skillz/oauth_health_check/SKILLz.md`
- `skillz/supervised_reauth/SKILLz.md`
- `skillz/identity_verify/SKILLz.md`
- `skillz/capacity_report/SKILLz.md`
- `ModLog.md`

## Test plan
- [ ] Verify no OAuth run or credential reads in this PR
- [ ] Verify WSP 97 boundary documented in each SKILLz.md
- [ ] Review AI Overseer hook flow documented

---

```text
Window: CW4
Slice: YT-OAUTH-SKILLZ1
Lane: YT
Mode: docs/skill contracts only
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)