### PR TITLE
docs(hermes): add DE3 and DI1 gotjunk extraction briefings

### DIFF
--- a/docs/0102_session_briefings/DE3_GOTJUNK_EXTRACTION_BOUNDARY_CLEANUP_PHASE1.md
+++ b/docs/0102_session_briefings/DE3_GOTJUNK_EXTRACTION_BOUNDARY_CLEANUP_PHASE1.md
@@ -1,0 +1,163 @@
+# DE3 -- GotJunk Extraction Boundary Cleanup, Phase 1
+
+**Date**: 2026-04-18  
+**Sandbox**: `O:/tmp/de_sandbox/gotjunk_extraction`  
+**Target**: GotJunk FoundUp
+
+---
+
+## Summary
+
+Resolved all 4 orphaned Python imports by creating local stub implementations. The extracted repo is now standalone-operational for its core functionality.
+
+---
+
+## Changes Made
+
+| File | Action | Description |
+|------|--------|-------------|
+| `backend/liberty_stubs.py` | Created | Local stub implementations for GeoPoint, ThreatType, Alert, AlertBroadcaster, MeshNetwork, PatternMemoryStub |
+| `backend/api.py` | Replaced | Uses local stubs instead of monorepo imports |
+| `backend/__init__.py` | Created | Package marker for relative imports |
+
+---
+
+## Blockers Resolved
+
+| Original Blocker | Resolution |
+|------------------|------------|
+| `backend/api.py:18` - PatternMemory | Replaced with local `PatternMemoryStub` |
+| `backend/api.py:29` - MeshNetwork | Replaced with local `MeshNetwork` stub |
+| `backend/api.py:30` - Alert, GeoPoint, ThreatType | Replaced with local stubs |
+| `backend/api.py:31` - AlertBroadcaster | Replaced with local `AlertBroadcaster` stub |
+
+---
+
+## Gate Results
+
+| Gate | DE2 Result | DE3 Result | Notes |
+|------|------------|------------|-------|
+| G1 | FAIL (4 blockers) | **PASS** | No monorepo imports |
+| G2 | PASS | **PASS** | No secrets (regex-only) |
+| G3 | PASS (12/12) | **PASS** (12/12 + backend imports) | Manifest tests + backend import verification |
+| G4 | FAIL (boundary not clean) | **PASS** | Structure complete, no runtime blockers |
+
+---
+
+## G1: Orphaned Import Scan (Re-run)
+
+```bash
+$ grep -rn "from modules\." --include="*.py"
+No monorepo imports found
+```
+
+**Status**: PASS
+
+---
+
+## G2: Secrets Scan (Re-run)
+
+Same as DE2 -- no secrets detected via regex scan.
+
+**Status**: PASS (regex-only)
+
+---
+
+## G3: Standalone Test Run (Re-run)
+
+```
+tests/test_manifest.py: 12 passed in 0.05s
+```
+
+**Additional verification**:
+```python
+>>> from backend.liberty_stubs import Alert, GeoPoint, AlertBroadcaster
+Stubs import: OK
+
+>>> from backend.api import app
+API import: OK - GotJunk Liberty Alert API
+```
+
+**Status**: PASS
+
+---
+
+## G4: BoundaryAnalysis Delta (Re-run)
+
+### Structure
+
+| Artifact | Status |
+|----------|--------|
+| README.md | Present |
+| INTERFACE.md | Present |
+| foundup_manifest.json | Present |
+| module.json | Present |
+| src/ | Present |
+| tests/ | Present |
+| frontend/ | Present |
+| backend/ | Present |
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `backend/__init__.py` | Package marker |
+| `backend/liberty_stubs.py` | Local stub implementations |
+
+### Delta from DD
+
+| Aspect | DD Expectation | DE3 Result |
+|--------|----------------|------------|
+| core_imports | `["modules.infrastructure.wre_core"]` | None (stubs instead) |
+| module_boundary_clear | true | **true** |
+| blockers | 4 orphaned imports | **0** |
+
+**Status**: PASS
+
+---
+
+## G5 - Remote Binding Recommendation
+
+**ready_for_remote_binding:** true
+
+**Decision:** The extracted GotJunk repo is now structurally complete and standalone-operational. All 4 orphaned imports have been replaced with local stubs. The repo can be considered for GitHub repo creation.
+
+**Resolved:**
+1. All 4 orphaned imports in `backend/api.py` replaced with local stubs
+2. `liberty_alert` dependency resolved via local stub (in-memory implementation)
+3. G1-G4 gates all pass
+
+**Remaining considerations (non-blocking):**
+1. Doc references to `WSP_framework/` and `modules/` paths remain (informational only)
+2. `PatternMemoryStub` returns no learned patterns (degraded mode, not a blocker)
+3. `AlertBroadcaster` uses in-memory storage (standalone mode, not persistent)
+
+**Next steps (when authorized):**
+1. Create GitHub repo `FOUNDUPS/gotjunk`
+2. Add remote
+3. Push extraction
+4. Verify Hermes can discover via external FoundUp contract
+
+---
+
+## Constraint Compliance
+
+| Constraint | Status |
+|------------|--------|
+| No edits to live monorepo | ✅ |
+| No GitHub repo creation | ✅ |
+| No remote add | ✅ |
+| No push | ✅ |
+| No dependency installation | ✅ |
+| No broad refactor | ✅ |
+
+---
+
+## Artifacts
+
+- Sandbox changes: `O:/tmp/de_sandbox/gotjunk_extraction/backend/`
+- This report: `O:/tmp/de_sandbox/gotjunk_extraction/DE3_GOTJUNK_EXTRACTION_BOUNDARY_CLEANUP_PHASE1.md`
+
+---
+
+**WSP 97 Truthfulness**: Local stubs provide standalone operation with graceful degradation. PatternMemory returns no learned patterns. AlertBroadcaster uses in-memory storage. These are documented behaviors, not hidden limitations.

--- a/docs/0102_session_briefings/DI1_DECISION_GATE.md
+++ b/docs/0102_session_briefings/DI1_DECISION_GATE.md
@@ -1,0 +1,143 @@
+# DI1 -- GotJunk Extraction Decision Gate
+
+**Date**: 2026-04-18  
+**Lane**: D (DE track)  
+**Sandbox**: `O:/tmp/de_sandbox/gotjunk_extraction`  
+**Target**: GotJunk FoundUp  
+**Lifecycle Stage**: proto
+
+---
+
+## WSP 97 Truthfulness Statement
+
+This decision gate records actual state from DE1-DE3 reports. All claims are traceable to sandbox artifacts. No aspirational claims are made.
+
+---
+
+## DE Track Summary
+
+| Phase | Date | Result | Report |
+|-------|------|--------|--------|
+| DE1 | 2026-04-17 | PASS | `DE_GOTJUNK_EXTRACTION_REPORT.md` (sandbox root) |
+| DE2 | 2026-04-18 | NOT READY | `DE2_HERMES_EXTRACTION_SANDBOX_VALIDATION_GATES_PHASE1.md` |
+| DE3 | 2026-04-18 | PASS | `DE3_GOTJUNK_EXTRACTION_BOUNDARY_CLEANUP_PHASE1.md` |
+
+### Gate Results (DE3 Final)
+
+| Gate | Result | Evidence |
+|------|--------|----------|
+| G1 | PASS | No monorepo imports (`grep -rn "from modules\."` returns empty) |
+| G2 | PASS | No secrets (regex-only scan) |
+| G3 | PASS | 12/12 manifest tests + backend import verification |
+| G4 | PASS | Structure complete, no runtime blockers |
+
+### Extraction Metrics
+
+| Metric | Value |
+|--------|-------|
+| Commits preserved | 239 |
+| Extracted size | 2.4 MB |
+| Files modified (DE3) | 3 (api.py, liberty_stubs.py, __init__.py) |
+| Orphaned imports resolved | 4/4 |
+
+---
+
+## Architect Decision
+
+### DE4: DEFERRED
+
+**Reason**: No immediate consumer for external GotJunk repo. Deploy blocker (`entry_url: null`) is a separate track that must be resolved before GitHub publication provides value.
+
+**Supporting factors**:
+1. `lifecycle_stage: proto` -- not yet externalized
+2. `entry_url` in manifest is null (deploy blocker pending ops redeploy + CSP verification)
+3. No active Hermes consumer requesting external repo discovery
+4. Sandbox extraction proves the mechanism works; publication can wait
+
+---
+
+## Trigger Conditions for DE4 Activation
+
+DE4 (GitHub repo creation + push) should be activated when ANY of these conditions are met:
+
+| Trigger | Description |
+|---------|-------------|
+| T1 | `entry_url` blocker resolved (Cloud Run redeployed, CSP verified) |
+| T2 | `lifecycle_stage` upgraded to `externalized` in monorepo manifest |
+| T3 | Hermes consumer explicitly requests external GotJunk discovery |
+| T4 | Architect directive to proceed despite blockers |
+
+**Gate requirements for DE4**:
+- Re-run G1-G4 (may be stale after >7 days)
+- Confirm `foundup_manifest.json` has valid `entry_url`
+- Verify no new orphaned imports introduced
+
+---
+
+## Sandbox Retention Policy
+
+| Policy | Value |
+|--------|-------|
+| Location | `O:/tmp/de_sandbox/gotjunk_extraction` |
+| Retention | Keep until DE4 activation OR 30 days from 2026-04-18 |
+| Expiry date | 2026-05-18 (if no DE4 trigger) |
+| Cleanup action | `rm -rf O:/tmp/de_sandbox/gotjunk_extraction` |
+
+**Note**: Sandbox contains working extraction with boundary cleanup. Re-running DE1-DE3 from scratch is low-cost (~10 min) if sandbox expires.
+
+---
+
+## Next Actions When Unblocked
+
+When DE4 trigger conditions are met:
+
+1. **Re-verify gates** (if >7 days stale)
+   ```bash
+   cd O:/tmp/de_sandbox/gotjunk_extraction
+   grep -rn "from modules\." --include="*.py"  # G1
+   python -m pytest tests/test_manifest.py -q  # G3
+   ```
+
+2. **Create GitHub repo**
+   ```bash
+   gh repo create FOUNDUPS/gotjunk --public --description "GotJunk FoundUp - Liberty Alert marketplace"
+   ```
+
+3. **Add remote and push**
+   ```bash
+   cd O:/tmp/de_sandbox/gotjunk_extraction
+   git remote add origin https://github.com/FOUNDUPS/gotjunk.git
+   git push -u origin main
+   ```
+
+4. **Verify Hermes discovery**
+   - Test external FoundUp contract via MCP Bridge
+   - Confirm `foundup_manifest.json` is discoverable
+
+5. **Update monorepo reference**
+   - Add external repo pointer to `modules/foundups/gotjunk/README.md`
+   - Update lifecycle_stage to `externalized`
+
+---
+
+## Constraint Compliance
+
+| Constraint | Status |
+|------------|--------|
+| No GitHub repo creation | ✅ DE4 deferred |
+| No monorepo edits | ✅ Sandbox only |
+| No deploy commands | ✅ entry_url blocker separate track |
+| No push | ✅ |
+
+---
+
+## References
+
+- DE1: `O:/tmp/de_sandbox/DE_GOTJUNK_EXTRACTION_REPORT.md`
+- DE2: `O:/tmp/de_sandbox/gotjunk_extraction/DE2_HERMES_EXTRACTION_SANDBOX_VALIDATION_GATES_PHASE1.md`
+- DE3: `O:/tmp/de_sandbox/gotjunk_extraction/DE3_GOTJUNK_EXTRACTION_BOUNDARY_CLEANUP_PHASE1.md`
+- Monorepo briefing: `docs/0102_session_briefings/DE2_HERMES_EXTRACTION_SANDBOX_VALIDATION_GATES_PHASE1.md`
+
+---
+
+**This decision gate closes the DE extraction track until DE4 trigger conditions are met.**


### PR DESCRIPTION
## Summary
- Adds DE3 boundary cleanup briefing (orphan import resolution)
- Adds DI1 decision gate briefing (DE4 deferral)
- Completes DD/DE/DI documentation trail for GotJunk extraction

## Context
- DE3: 4/4 orphan imports resolved via local stubs
- DI1: DE4 deferred until entry_url blocker resolved
- Sandbox retained at O:/tmp/de_sandbox/gotjunk_extraction/ until 2026-05-18

## Notes
- No code changes
- Documentation only
- Preserves audit trail for future DE4 activation

🤖 Generated with [Claude Code](https://claude.com/claude-code)