### PR TITLE
fix(main): WRE dashboard INSUFFICIENT_DATA now dispatches as WARN (DJ2-A)

### DIFF
--- a/main.py
+++ b/main.py
@@ -813,9 +813,29 @@ def run_wre_dashboard_preflight(repo_root: Path) -> bool:
         if insufficient_data:
             watch_label = "WATCH" if in_watch else "STABLE"
             print(
-                f"[WRE-DASHBOARD] preflight=PASS ({watch_label}, INSUFFICIENT_DATA) "
+                f"[WRE-DASHBOARD] preflight=WARN ({watch_label}, INSUFFICIENT_DATA) "
                 f"samples={total_executions}/{min_samples}"
             )
+            # DJ2-A: Dispatch insufficient_data as warning tier (WSP 97 truth distinction)
+            try:
+                from modules.ai_intelligence.ai_overseer.src.preflight_resolution import (
+                    on_preflight_fail,
+                )
+                on_preflight_fail(
+                    component="wre_dashboard",
+                    severity="medium",
+                    payload={
+                        "samples": total_executions,
+                        "min_samples": min_samples,
+                        "insufficient_data": True,
+                        "likely_cause": "cold_start_or_telemetry_drop",
+                        "in_watch": in_watch,
+                        "automation_candidate": True,
+                    },
+                    source="main:run_wre_dashboard_preflight",
+                )
+            except Exception as dispatch_exc:
+                logger.debug(f"[WRE-DASHBOARD] dispatch skipped: {dispatch_exc}")
             return True
 
         alerts = health.get("alerts", []) if isinstance(health.get("alerts"), list) else []

--- a/modules/ai_intelligence/ai_overseer/ModLog.md
+++ b/modules/ai_intelligence/ai_overseer/ModLog.md
@@ -2,7 +2,48 @@
 
 **Module**: `modules/ai_intelligence/ai_overseer/`
 **Status**: Active (Autonomous Code Patching + Daemon Restart + Activity Routing)
-**Version**: 0.10.1
+**Version**: 0.10.2
+
+---
+
+## 2026-04-19 - DJ2-A: WRE Dashboard Insufficient Data WARN Tier
+
+**Author**: 0102
+**WSP**: 97 (truthful state distinction)
+**Slice**: DJ2-A (first of 6 DJ2 slices from FCA1-AG2 audit)
+
+### Summary
+
+Fixes WSP 97 truth violation where WRE dashboard preflight reported `PASS (INSUFFICIENT_DATA)`
+when samples < 25. Now reports `WARN` and dispatches to AI Overseer for observability.
+
+### Change
+
+- `main.py:run_wre_dashboard_preflight()` - `preflight=PASS` → `preflight=WARN` on insufficient_data
+- Dispatch via `on_preflight_fail()` with severity=medium, automation_candidate=True
+- Startup NOT blocked (still returns True) - warning tier only
+
+### Payload
+
+```json
+{
+  "component": "wre_dashboard",
+  "severity": "medium",
+  "samples": <int>,
+  "min_samples": 25,
+  "insufficient_data": true,
+  "likely_cause": "cold_start_or_telemetry_drop",
+  "automation_candidate": true
+}
+```
+
+### Test
+
+- `test_main_py_wre_dashboard_insufficient_data_calls_dispatcher` - verifies dispatch
+
+### Next slice
+
+DJ2-C: OAUTH_PREFLIGHT_DISPATCH (wire the two WARN sites in monitor_youtube)
 
 ---
 

--- a/modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py
+++ b/modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py
@@ -220,3 +220,40 @@ def test_main_py_wsp_framework_calls_dispatcher():
     assert call_kwargs["component"] == "wsp_framework"
     assert call_kwargs["payload"]["framework_only_count"] == 1
     assert call_kwargs["payload"]["index_issue_count"] == 1
+
+
+def test_main_py_wre_dashboard_insufficient_data_calls_dispatcher():
+    """DJ2-A: WRE dashboard dispatches on INSUFFICIENT_DATA (WSP 97 truth distinction)."""
+    import main
+
+    with patch(
+        "modules.ai_intelligence.ai_overseer.src.preflight_resolution.on_preflight_fail"
+    ) as mock_dispatch:
+        fake_health = {
+            "insufficient_data": True,
+            "total_executions": 3,
+            "min_samples": 25,
+            "healthy": True,
+            "alerts": [],
+        }
+        with patch(
+            "modules.infrastructure.wre_core.src.dashboard_alerts.check_dashboard_health",
+            return_value=fake_health,
+        ):
+            with patch(
+                "modules.infrastructure.wre_core.src.dashboard_alerts.DashboardAlertMonitor"
+            ) as mock_monitor:
+                mock_monitor.return_value.is_in_watch_period.return_value = False
+                with patch.dict("os.environ", {"WRE_DASHBOARD_PREFLIGHT": "1"}, clear=False):
+                    result = main.run_wre_dashboard_preflight(Path("."))
+
+    assert result is True  # Should not block startup
+    assert mock_dispatch.called
+    call_kwargs = mock_dispatch.call_args.kwargs
+    assert call_kwargs["component"] == "wre_dashboard"
+    assert call_kwargs["severity"] == "medium"
+    assert call_kwargs["payload"]["insufficient_data"] is True
+    assert call_kwargs["payload"]["samples"] == 3
+    assert call_kwargs["payload"]["min_samples"] == 25
+    assert call_kwargs["payload"]["likely_cause"] == "cold_start_or_telemetry_drop"
+    assert call_kwargs["payload"]["automation_candidate"] is True


### PR DESCRIPTION
## Summary

- WSP 97 truth violation fix: `preflight=PASS` masked `insufficient_data` state
- Now reports `preflight=WARN` and dispatches to AI Overseer
- First of 6 DJ2 slices from FCA1-AG2 audit
- Startup NOT blocked (returns True) - warning tier only

## DJ2-A Payload

```json
{
  "component": "wre_dashboard",
  "severity": "medium",
  "samples": <int>,
  "min_samples": 25,
  "insufficient_data": true,
  "likely_cause": "cold_start_or_telemetry_drop",
  "automation_candidate": true
}
```

## Files Changed (3)

| File | Change |
|------|--------|
| `main.py` | PASS→WARN + dispatch on insufficient_data |
| `ai_overseer/ModLog.md` | Version 0.10.2, DJ2-A entry |
| `ai_overseer/tests/test_preflight_resolution.py` | +1 test (13 total) |

## Test Plan

- [x] `pytest test_preflight_resolution.py` → 13/13 passed
- [x] New test verifies dispatch called with correct payload

## FCA1-AG2 Reference

This slice addresses violation #1 from [FCA1_AG2_MAIN_DAE_AI_OVERSEER_HOOKS_AUDIT_PHASE1.md](docs/0102_session_briefings/FCA1_AG2_MAIN_DAE_AI_OVERSEER_HOOKS_AUDIT_PHASE1.md):

> WRE-DASHBOARD `INSUFFICIENT_DATA` | `run_wre_dashboard_preflight` (~line 790-796) | Claim: `preflight=PASS (INSUFFICIENT_DATA) samples=0/25` | Actual state: insufficient_data — cannot assert health

## Next Slice

DJ2-C: OAUTH_PREFLIGHT_DISPATCH (wire the two WARN sites in monitor_youtube)

---

```
Window: CW1
Slice: DJ2-A
Lane: DJ2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)