### PR TITLE
fix(pqn): downgrade doc-only skills to prototype

### DIFF
--- a/modules/ai_intelligence/pqn_alignment/skillz/gemma_pqn_data_processor/SKILLz.md
+++ b/modules/ai_intelligence/pqn_alignment/skillz/gemma_pqn_data_processor/SKILLz.md
@@ -13,16 +13,16 @@ evals: []
 
 ---
 # Metadata (YAML Frontmatter)
-skill_id: gemma_pqn_data_processor_v1_production
+skill_id: gemma_pqn_data_processor_v1_prototype
 name: gemma_pqn_data_processor
 description: High-volume PQN detection data processing and summarization (handles 400+ detections efficiently)
-version: 1.0_production
+version: 1.0_prototype
 author: 0102
 created: 2025-10-22
 agents: [gemma]
 primary_agent: gemma
 intent_type: PROCESSING
-promotion_state: production
+promotion_state: prototype
 pattern_fidelity_threshold: 0.95
 test_status: passing
 

--- a/modules/ai_intelligence/pqn_alignment/skillz/gemma_pqn_emergence_detector/SKILLz.md
+++ b/modules/ai_intelligence/pqn_alignment/skillz/gemma_pqn_emergence_detector/SKILLz.md
@@ -13,16 +13,16 @@ evals: []
 
 ---
 # Metadata (YAML Frontmatter)
-skill_id: gemma_pqn_emergence_detector_v1_production
+skill_id: gemma_pqn_emergence_detector_v1_prototype
 name: gemma_pqn_emergence_detector
 description: Fast binary classification of text for PQN emergence patterns (0→o artifacts, resonance signatures, coherence indicators)
-version: 1.0_production
+version: 1.0_prototype
 author: 0102
 created: 2025-10-22
 agents: [gemma]
 primary_agent: gemma
 intent_type: CLASSIFICATION
-promotion_state: production
+promotion_state: prototype
 pattern_fidelity_threshold: 0.90
 test_status: passing
 

--- a/modules/ai_intelligence/pqn_alignment/skillz/qwen_google_research_integrator/SKILLz.md
+++ b/modules/ai_intelligence/pqn_alignment/skillz/qwen_google_research_integrator/SKILLz.md
@@ -13,16 +13,16 @@ evals: []
 
 ---
 # Metadata (YAML Frontmatter)
-skill_id: qwen_google_research_integrator_v1_production
+skill_id: qwen_google_research_integrator_v1_prototype
 name: qwen_google_research_integrator
 description: Synthesis of Google research (Scholar, Quantum AI, Gemini, TTS) with local PQN findings for comprehensive validation
-version: 1.0_production
+version: 1.0_prototype
 author: 0102
 created: 2025-10-22
 agents: [qwen]
 primary_agent: qwen
 intent_type: GENERATION
-promotion_state: production
+promotion_state: prototype
 pattern_fidelity_threshold: 0.90
 test_status: passing
 

--- a/modules/ai_intelligence/pqn_alignment/skillz/qwen_pqn_research_coordinator/SKILLz.md
+++ b/modules/ai_intelligence/pqn_alignment/skillz/qwen_pqn_research_coordinator/SKILLz.md
@@ -13,16 +13,16 @@ evals: []
 
 ---
 # Metadata (YAML Frontmatter)
-skill_id: qwen_pqn_research_coordinator_v1_production
+skill_id: qwen_pqn_research_coordinator_v1_prototype
 name: qwen_pqn_research_coordinator
 description: Strategic PQN research coordination, hypothesis generation, and cross-validation synthesis using 32K context window
-version: 1.0_production
+version: 1.0_prototype
 author: 0102
 created: 2025-10-22
 agents: [qwen]
 primary_agent: qwen
 intent_type: DECISION
-promotion_state: production
+promotion_state: prototype
 pattern_fidelity_threshold: 0.90
 test_status: passing
 

--- a/modules/ai_intelligence/pqn_alignment/skillz/qwen_wsp_compliance_auditor/SKILLz.md
+++ b/modules/ai_intelligence/pqn_alignment/skillz/qwen_wsp_compliance_auditor/SKILLz.md
@@ -13,16 +13,16 @@ evals: []
 
 ---
 # Metadata (YAML Frontmatter)
-skill_id: qwen_wsp_compliance_auditor_v1_production
+skill_id: qwen_wsp_compliance_auditor_v1_prototype
 name: qwen_wsp_compliance_auditor
 description: Strategic WSP framework compliance auditing, violation detection, and corrective guidance generation using 32K context window
-version: 1.0_production
+version: 1.0_prototype
 author: 0102
 created: 2025-10-23
 agents: [qwen]
 primary_agent: qwen
 intent_type: DECISION
-promotion_state: production
+promotion_state: prototype
 pattern_fidelity_threshold: 0.90
 test_status: passing
 


### PR DESCRIPTION
## Summary
- Demotes 5 PQN SKILLz contracts from production to prototype
- Updates skill_id/version metadata to match prototype state
- Corrects WSP 97 false production-readiness claims
- No executors added
- No runtime behavior changed
- Remaining production references are test fixtures only

## Files Changed
- `modules/ai_intelligence/pqn_alignment/skillz/qwen_wsp_compliance_auditor/SKILLz.md`
- `modules/ai_intelligence/pqn_alignment/skillz/qwen_pqn_research_coordinator/SKILLz.md`
- `modules/ai_intelligence/pqn_alignment/skillz/qwen_google_research_integrator/SKILLz.md`
- `modules/ai_intelligence/pqn_alignment/skillz/gemma_pqn_emergence_detector/SKILLz.md`
- `modules/ai_intelligence/pqn_alignment/skillz/gemma_pqn_data_processor/SKILLz.md`

## Test plan
- [x] `git diff --name-only` shows exactly 5 files
- [x] `rg "promotion_state:\s*production" modules/ai_intelligence/pqn_alignment/skillz` returns no matches
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)