### PR TITLE
docs(foundups): activate GotJunk entry_url after Cloud Run CSP verification

### DIFF
--- a/docs/0102_session_briefings/DE4_GOTJUNK_ENTRY_URL_ACTIVATION.md
+++ b/docs/0102_session_briefings/DE4_GOTJUNK_ENTRY_URL_ACTIVATION.md
@@ -1,0 +1,90 @@
+# DE4 — GotJunk Entry URL Activation
+
+**Date**: 2026-04-19  
+**Slice**: DE4-GOTJUNK-ENTRY_URL-ACTIVATION  
+**Lane**: D / DE  
+**Window**: CW3
+
+---
+
+## Verdict: PASS
+
+All required evidence verified. GotJunk `entry_url` restored and discoverable.
+
+---
+
+## Evidence Collected
+
+| Requirement | Status | Evidence |
+|-------------|--------|----------|
+| GitHub Actions run 24640086239 | **PASS** | `status: completed, conclusion: success` |
+| Cloud Run URL returns 2xx | **PASS** | `HTTP/1.1 200 OK` |
+| CSP header captured | **PASS** | `content-security-policy: frame-ancestors https://foundups.com https://*.foundups.com https://foundupscom.web.app https://foundupscom.firebaseapp.com http://localhost:* https://localhost:*` |
+| frame-ancestors allows shell embedding | **PASS** | Includes `foundups.com`, `*.foundups.com`, `localhost:*` |
+| X-Frame-Options not blocking | **PASS** | `ABSENT` (no blocking header) |
+| Manifest entry_url non-null | **PASS** | `https://gotjunk-56566376153.us-west1.run.app/` |
+| HoloIndex/Hermes discovery | **PASS** | Manifest found at `modules/foundups/gotjunk/foundup_manifest.json` with valid URL |
+
+---
+
+## Changes Made (This Slice)
+
+| File | Change |
+|------|--------|
+| `modules/foundups/gotjunk/foundup_manifest.json` | `entry_url: null` → `entry_url: "https://gotjunk-56566376153.us-west1.run.app/"` |
+
+---
+
+## Autonomous Pipeline Created (Prior Slice)
+
+| File | Purpose |
+|------|---------|
+| `.github/workflows/deploy-gotjunk.yml` | Autonomous GotJunk deployment to Cloud Run |
+
+Triggers:
+- Push to `modules/foundups/gotjunk/**`
+- Manual `workflow_dispatch`
+
+---
+
+## What This Unlocks
+
+1. **Hermes Discovery**: GotJunk now has valid `entry_url` for external FoundUp contract
+2. **p.fMALL Shell**: Can iframe GotJunk with proper CSP
+3. **No 012-in-the-loop**: Future deploys trigger automatically on code push
+
+---
+
+## What Remains Blocked
+
+| Item | Status | Reason |
+|------|--------|--------|
+| GitHub repo creation (FOUNDUPS/gotjunk) | **BLOCKED** | Architect directive required per DI1 |
+| Remote binding | **BLOCKED** | Depends on repo creation |
+| `lifecycle_stage: externalized` | **PENDING** | Follows successful extraction push |
+
+---
+
+## DE Track Summary
+
+| Phase | Date | Status |
+|-------|------|--------|
+| DE1 | 2026-04-17 | PASS |
+| DE2 | 2026-04-18 | PASS (after cleanup) |
+| DE3 | 2026-04-18 | PASS |
+| DI1 | 2026-04-18 | T1 MET (entry_url resolved) |
+| DE4 | 2026-04-19 | **PASS** (entry_url activated) |
+
+---
+
+## WSP 97 Truthfulness Statement
+
+This briefing records actual verification results. The deployment succeeded, CSP headers are correctly configured, and `entry_url` is restored. No claims about iframe smoke test (not performed) or external repo status (still blocked per architect directive).
+
+---
+
+## References
+
+- Workflow run: https://github.com/FOUNDUPS/Foundups-Agent/actions/runs/24640086239
+- Live URL: https://gotjunk-56566376153.us-west1.run.app/
+- Manifest: `modules/foundups/gotjunk/foundup_manifest.json`

--- a/modules/foundups/gotjunk/foundup_manifest.json
+++ b/modules/foundups/gotjunk/foundup_manifest.json
@@ -7,7 +7,7 @@
   "tagline": "Turn your junk into someone's treasure",
   "tier": "F0_DAE",
   "lifecycle_stage": "proto",
-  "entry_url": null,
+  "entry_url": "https://gotjunk-56566376153.us-west1.run.app/",
   "routing_prefix": "/f/gotjunk_001",
   "icon_url": "frontend/public/icon-192.svg",
   "required_subscription_tier": "free",


### PR DESCRIPTION
## Summary

- **Window**: CW3
- **Slice**: DE4-GOTJUNK-ENTRY_URL-ACTIVATION
- **Lane**: D / DE

Activates GotJunk `entry_url` after successful Cloud Run deployment and CSP header verification.

## Files Changed (exactly 2)

- `modules/foundups/gotjunk/foundup_manifest.json` — `entry_url: null` → `entry_url: "https://gotjunk-56566376153.us-west1.run.app/"`
- `docs/0102_session_briefings/DE4_GOTJUNK_ENTRY_URL_ACTIVATION.md` — Evidence briefing

## Evidence

| Check | Result |
|-------|--------|
| GitHub Actions run | [24640086239](https://github.com/FOUNDUPS/Foundups-Agent/actions/runs/24640086239) — `completed/success` |
| Cloud Run URL | `HTTP/1.1 200 OK` |
| CSP header | `frame-ancestors https://foundups.com https://*.foundups.com https://foundupscom.web.app https://foundupscom.firebaseapp.com http://localhost:* https://localhost:*` |
| X-Frame-Options | `absent` (not blocking iframe embedding) |

## What This Does NOT Include

- No FX1/HoloIndex files
- No `lifecycle_stage` change (remains `proto`)
- No GitHub repo creation (FOUNDUPS/gotjunk)
- No remote binding

## Test Plan

- [x] Verify manifest `entry_url` is valid URL
- [x] Verify CSP allows p.fMALL shell embedding
- [x] Verify only 2 files in diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)