### PR TITLE
feat(tools): add PR scope guard to prevent mixed-scope PRs

### DIFF
--- a/docs/0102_session_briefings/BH2_BRANCH_HYGIENE_SCOPE_GUARD_PHASE1.md
+++ b/docs/0102_session_briefings/BH2_BRANCH_HYGIENE_SCOPE_GUARD_PHASE1.md
@@ -1,0 +1,181 @@
+# BH2 - Branch Hygiene Scope Guard Phase 1
+
+```text
+Window: AG5
+Slice: BH2
+Lane: Process / Git Truth
+Branch: feat/bh2-pr-scope-guard
+Mode: implementation
+Status: complete
+```
+
+## Summary
+
+Implements a PR scope guard to prevent mixed-scope PRs from merging. Compares expected files declared in PR body against actual changed files and fails if files outside the declared scope appear.
+
+## Motivation: PR #384 Incident
+
+On 2026-04-19, PR #384 ("docs(rolodex): regenerate artifacts after CF4 file-specific binding") was merged with 11 files, but only 2-3 were actually rolodex-related. The remaining files were DJ-OBS work that entered main via branch contamination.
+
+### What Happened
+
+1. DJ-OBS commits (`fde9d64a4`, `1c0ee3f01`) were created on local main without a branch
+2. CF lane worker created `cf/rolodex-artifact-regen-cf4` from that dirty local main
+3. PR #384 was pushed and merged, carrying the unrelated DJ commits
+4. DJ-OBS work bypassed its own review gate
+
+### Evidence
+
+| Check | Expected | Actual |
+|-------|----------|--------|
+| PR title | rolodex artifact regen | rolodex artifact regen |
+| Expected files | 2-3 rolodex artifacts | 11 files |
+| DJ files included | NO | YES |
+| DJ-OBS files included | NO | YES |
+
+### Contaminated Files in PR #384
+
+```text
+docs/0102_session_briefings/DJ_AI_RESOLUTION_HOOK_CONTRACT_PHASE1.md  <- DJ
+holo_index/docs/AGENT_CLI_CATALOG.md                                  <- CF5 (expected)
+holo_index/docs/command_rolodex.json                                  <- CF5 (expected)
+main.py                                                               <- DJ
+modules/ai_intelligence/ai_overseer/ModLog.md                         <- DJ
+modules/ai_intelligence/ai_overseer/src/preflight_resolution.py       <- DJ
+modules/ai_intelligence/ai_overseer/tests/conftest.py                 <- DJ
+modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py <- DJ
+modules/platform_integration/antifafm_broadcaster/ModLog.md           <- DJ-OBS
+modules/platform_integration/antifafm_broadcaster/src/obs_controller.py <- DJ-OBS
+modules/platform_integration/antifafm_broadcaster/tests/test_obs_controller_startup.py <- DJ-OBS
+```
+
+## Solution
+
+### 1. PR Scope Guard Script
+
+Location: `tools/pr_scope_guard/pr_scope_guard.py`
+
+Usage:
+```bash
+# Check a PR by number (fetches from GitHub API)
+python tools/pr_scope_guard/pr_scope_guard.py --pr-number 384
+
+# Check with explicit inputs
+python tools/pr_scope_guard/pr_scope_guard.py \
+  --pr-body "Window: AG5\nSlice: BH2\nExpected files:\n- file1.py" \
+  --changed-files file1.py file2.py
+```
+
+Exit codes:
+- `0` - All changed files are within declared scope
+- `1` - Scope violation detected (unexpected files)
+- `2` - Missing required PR body fields
+- `3` - Parse error or invalid input
+
+### 2. Required PR Body Format
+
+Every PR must include:
+
+```text
+Window: [assigned window ID]
+Slice: [slice ID]
+Lane: [lane name]
+Expected files:
+- path/to/file1.py
+- path/to/file2.py
+- path/to/file3.md
+```
+
+### 3. Policy (Effective Immediately)
+
+No PR is merge-approved unless:
+
+1. **Branch created from origin/main**
+   ```bash
+   git fetch origin main
+   git checkout -b feat/xyz origin/main
+   ```
+
+2. **Scope verified before push**
+   ```bash
+   git diff --name-only origin/main...HEAD
+   # Must match expected files only
+   ```
+
+3. **PR body declares expected files**
+   - Window, Slice, Lane, Expected files sections required
+
+4. **Actual PR files match expected files**
+   - Scope guard validates on PR open/update
+
+## Example: How PR #384 Would Have Failed
+
+If scope guard had been in place:
+
+```text
+============================================================
+PR SCOPE GUARD REPORT
+============================================================
+PR: #384
+Window: NOT DECLARED
+Slice: NOT DECLARED
+Lane: NOT DECLARED
+
+PARSE ERRORS:
+  - Missing 'Window:' field in PR body
+  - Missing 'Slice:' field in PR body
+  - Missing 'Expected files:' section in PR body
+
+============================================================
+RESULT: FAIL - Missing required PR body fields
+============================================================
+```
+
+Even if the CF5 worker had declared expected files:
+
+```text
+Expected files:
+- holo_index/docs/AGENT_CLI_CATALOG.md
+- holo_index/docs/command_rolodex.json
+```
+
+The guard would have caught:
+
+```text
+OUT OF SCOPE (VIOLATION):
+  - docs/0102_session_briefings/DJ_AI_RESOLUTION_HOOK_CONTRACT_PHASE1.md
+  - main.py
+  - modules/ai_intelligence/ai_overseer/ModLog.md
+  - modules/ai_intelligence/ai_overseer/src/preflight_resolution.py
+  - modules/ai_intelligence/ai_overseer/tests/conftest.py
+  - modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py
+  - modules/platform_integration/antifafm_broadcaster/ModLog.md
+  - modules/platform_integration/antifafm_broadcaster/src/obs_controller.py
+  - modules/platform_integration/antifafm_broadcaster/tests/test_obs_controller_startup.py
+
+============================================================
+RESULT: FAIL - Scope violation detected
+============================================================
+```
+
+## Files Changed
+
+| File | Purpose |
+|------|---------|
+| `tools/pr_scope_guard/pr_scope_guard.py` | Scope guard script |
+| `docs/0102_session_briefings/BH2_BRANCH_HYGIENE_SCOPE_GUARD_PHASE1.md` | This documentation |
+
+## Next Steps
+
+### BH3 - CI Integration (P1)
+Add scope guard as a required CI check on pull_request events.
+
+### BH4 - Pre-push Hook (P2)
+Add local pre-push hook that warns when branching from dirty main.
+
+---
+
+**Generated**: 2026-04-20
+**Window**: AG5
+**Slice**: BH2
+**Forensics source**: BH1 - BRANCH_HYGIENE_FORENSICS_PHASE1

--- a/tools/pr_scope_guard/pr_scope_guard.py
+++ b/tools/pr_scope_guard/pr_scope_guard.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""
+PR Scope Guard - Prevents mixed-scope PRs from merging.
+
+Compares expected files declared in PR body against actual changed files.
+Fails if files outside the declared scope appear.
+
+Motivation: PR #384 incident where DJ-OBS commits entered main through
+a rolodex PR via branch contamination. See BH1 forensics report.
+
+Usage:
+    python pr_scope_guard.py --pr-body "..." --changed-files file1.py file2.py
+    python pr_scope_guard.py --pr-number 123  # Fetches from GitHub API
+
+Required PR body format:
+    Window: AG5
+    Slice: BH2
+    Lane: Process
+    Expected files:
+    - path/to/file1.py
+    - path/to/file2.py
+
+Exit codes:
+    0 - All changed files are within declared scope
+    1 - Scope violation detected (unexpected files)
+    2 - Missing required PR body fields
+    3 - Parse error or invalid input
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from typing import Optional
+
+
+def parse_pr_body(body: str) -> dict:
+    """Extract Window, Slice, Lane, and Expected files from PR body."""
+    result = {
+        "window": None,
+        "slice": None,
+        "lane": None,
+        "expected_files": [],
+        "errors": [],
+    }
+
+    lines = body.split("\n")
+
+    for line in lines:
+        line_stripped = line.strip()
+
+        if line_stripped.lower().startswith("window:"):
+            result["window"] = line_stripped.split(":", 1)[1].strip()
+        elif line_stripped.lower().startswith("slice:"):
+            result["slice"] = line_stripped.split(":", 1)[1].strip()
+        elif line_stripped.lower().startswith("lane:"):
+            result["lane"] = line_stripped.split(":", 1)[1].strip()
+
+    expected_section = re.search(
+        r"expected files:\s*\n((?:\s*[-*]\s*.+\n?)+)",
+        body,
+        re.IGNORECASE | re.MULTILINE,
+    )
+
+    if expected_section:
+        file_lines = expected_section.group(1)
+        for line in file_lines.split("\n"):
+            match = re.match(r"\s*[-*]\s*(.+)", line)
+            if match:
+                filepath = match.group(1).strip().strip("`")
+                if filepath:
+                    result["expected_files"].append(filepath)
+
+    if not result["window"]:
+        result["errors"].append("Missing 'Window:' field in PR body")
+    if not result["slice"]:
+        result["errors"].append("Missing 'Slice:' field in PR body")
+    if not result["expected_files"]:
+        result["errors"].append("Missing 'Expected files:' section in PR body")
+
+    return result
+
+
+def check_scope(expected_files: list[str], changed_files: list[str]) -> dict:
+    """Compare expected files against changed files."""
+    expected_set = set(expected_files)
+    changed_set = set(changed_files)
+
+    in_scope = changed_set & expected_set
+    out_of_scope = changed_set - expected_set
+    missing = expected_set - changed_set
+
+    return {
+        "pass": len(out_of_scope) == 0,
+        "in_scope": sorted(in_scope),
+        "out_of_scope": sorted(out_of_scope),
+        "missing": sorted(missing),
+        "expected_count": len(expected_set),
+        "changed_count": len(changed_set),
+    }
+
+
+def fetch_pr_info(pr_number: int) -> tuple[str, list[str]]:
+    """Fetch PR body and changed files from GitHub API."""
+    try:
+        body_result = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--json", "body"],
+            capture_output=True,
+            check=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        body_data = json.loads(body_result.stdout)
+        body = body_data.get("body", "")
+
+        files_result = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--json", "files"],
+            capture_output=True,
+            check=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        files_data = json.loads(files_result.stdout)
+        changed_files = [f["path"] for f in files_data.get("files", [])]
+
+        return body, changed_files
+    except subprocess.CalledProcessError as e:
+        print(f"Error fetching PR #{pr_number}: {e.stderr}", file=sys.stderr)
+        sys.exit(3)
+    except json.JSONDecodeError as e:
+        print(f"Error parsing GitHub response: {e}", file=sys.stderr)
+        sys.exit(3)
+
+
+def format_report(parsed: dict, scope_result: dict, pr_number: Optional[int] = None) -> str:
+    """Format the scope check report."""
+    lines = []
+    lines.append("=" * 60)
+    lines.append("PR SCOPE GUARD REPORT")
+    lines.append("=" * 60)
+
+    if pr_number:
+        lines.append(f"PR: #{pr_number}")
+    lines.append(f"Window: {parsed['window'] or 'NOT DECLARED'}")
+    lines.append(f"Slice: {parsed['slice'] or 'NOT DECLARED'}")
+    lines.append(f"Lane: {parsed['lane'] or 'NOT DECLARED'}")
+    lines.append("")
+
+    if parsed["errors"]:
+        lines.append("PARSE ERRORS:")
+        for err in parsed["errors"]:
+            lines.append(f"  - {err}")
+        lines.append("")
+
+    lines.append(f"Expected files: {scope_result['expected_count']}")
+    lines.append(f"Changed files: {scope_result['changed_count']}")
+    lines.append("")
+
+    if scope_result["out_of_scope"]:
+        lines.append("OUT OF SCOPE (VIOLATION):")
+        for f in scope_result["out_of_scope"]:
+            lines.append(f"  - {f}")
+        lines.append("")
+
+    if scope_result["in_scope"]:
+        lines.append("IN SCOPE:")
+        for f in scope_result["in_scope"]:
+            lines.append(f"  + {f}")
+        lines.append("")
+
+    if scope_result["missing"]:
+        lines.append("EXPECTED BUT NOT CHANGED:")
+        for f in scope_result["missing"]:
+            lines.append(f"  ? {f}")
+        lines.append("")
+
+    lines.append("=" * 60)
+    if scope_result["pass"] and not parsed["errors"]:
+        lines.append("RESULT: PASS - All files within declared scope")
+    elif parsed["errors"]:
+        lines.append("RESULT: FAIL - Missing required PR body fields")
+    else:
+        lines.append("RESULT: FAIL - Scope violation detected")
+    lines.append("=" * 60)
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="PR Scope Guard - Prevents mixed-scope PRs"
+    )
+    parser.add_argument(
+        "--pr-number",
+        type=int,
+        help="GitHub PR number (fetches body and files via gh CLI)",
+    )
+    parser.add_argument(
+        "--pr-body",
+        type=str,
+        help="PR body text (alternative to --pr-number)",
+    )
+    parser.add_argument(
+        "--changed-files",
+        nargs="*",
+        help="List of changed files (alternative to --pr-number)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON instead of text report",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Also fail if expected files are missing from changes",
+    )
+
+    args = parser.parse_args()
+
+    if args.pr_number:
+        body, changed_files = fetch_pr_info(args.pr_number)
+    elif args.pr_body and args.changed_files:
+        body = args.pr_body
+        changed_files = args.changed_files
+    else:
+        parser.error("Either --pr-number or both --pr-body and --changed-files required")
+        return
+
+    parsed = parse_pr_body(body)
+
+    if parsed["errors"]:
+        if args.json:
+            print(json.dumps({"pass": False, "errors": parsed["errors"]}, indent=2))
+        else:
+            print(format_report(parsed, {"pass": False, "expected_count": 0,
+                  "changed_count": len(changed_files), "in_scope": [],
+                  "out_of_scope": changed_files, "missing": []}, args.pr_number))
+        sys.exit(2)
+
+    scope_result = check_scope(parsed["expected_files"], changed_files)
+
+    if args.strict and scope_result["missing"]:
+        scope_result["pass"] = False
+
+    if args.json:
+        output = {
+            "pass": scope_result["pass"],
+            "window": parsed["window"],
+            "slice": parsed["slice"],
+            "lane": parsed["lane"],
+            **scope_result,
+        }
+        print(json.dumps(output, indent=2))
+    else:
+        print(format_report(parsed, scope_result, args.pr_number))
+
+    sys.exit(0 if scope_result["pass"] else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a PR scope guard to prevent mixed-scope PRs from merging. Compares expected files declared in PR body against actual changed files and fails if files outside the declared scope appear.

## Motivation

PR #384 incident: DJ-OBS commits entered main through a rolodex PR via branch contamination. See BH1 forensics report.

## Window: AG5
## Slice: BH2
## Lane: Process / Git Truth

## Expected files:
- tools/pr_scope_guard/pr_scope_guard.py
- docs/0102_session_briefings/BH2_BRANCH_HYGIENE_SCOPE_GUARD_PHASE1.md

## Usage

```bash
# Check a PR by number
python tools/pr_scope_guard/pr_scope_guard.py --pr-number 384

# Example output for PR #384 (would have failed):
# RESULT: FAIL - Missing required PR body fields
# OUT OF SCOPE (VIOLATION): 9 unexpected files
```

## Policy (effective immediately)

No PR is merge-approved unless:
1. Branch created from origin/main
2. PR body declares Window, Slice, Lane, Expected files
3. Actual PR files match expected files

🤖 Generated with [Claude Code](https://claude.ai/code)