### PR TITLE
fix(holoindex): surface retrieval mode and harden offline fallbacks

### DIFF
--- a/holo_index/_cli_main.py
+++ b/holo_index/_cli_main.py
@@ -32,6 +32,9 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+# FX1-A: Module-level logger for exception handlers (lines 1301, 1349, 1362, 1374)
+logger = logging.getLogger(__name__)
+
 # Add project root to path for imports
 project_root = Path(__file__).parent.parent
 if str(project_root) not in sys.path:
@@ -92,6 +95,8 @@ if "--offline" in sys.argv:
     os.environ.setdefault('HOLO_DISABLE_PIP_INSTALL', '1')
     os.environ.setdefault('HF_HUB_OFFLINE', '1')
     os.environ.setdefault('TRANSFORMERS_OFFLINE', '1')
+    # FX1-E: Disable ChromaDB telemetry before import to prevent PostHog network attempts
+    os.environ.setdefault('ANONYMIZED_TELEMETRY', 'false')
     # WSP 97: --offline MUST skip model to prevent import hangs
     os.environ.setdefault('HOLO_SKIP_MODEL', '1')
 
@@ -723,6 +728,8 @@ def main():
         os.environ['HOLO_DISABLE_PIP_INSTALL'] = '1'
         os.environ.setdefault('HF_HUB_OFFLINE', '1')
         os.environ.setdefault('TRANSFORMERS_OFFLINE', '1')
+        # FX1-E: Disable ChromaDB telemetry to prevent PostHog network attempts
+        os.environ.setdefault('ANONYMIZED_TELEMETRY', 'false')
         # WSP 97: --offline mode should ALWAYS use lexical search to prevent hangs
         os.environ.setdefault('HOLO_SKIP_MODEL', '1')
 

--- a/holo_index/core/holo_index.py
+++ b/holo_index/core/holo_index.py
@@ -191,13 +191,18 @@ class HoloIndex:
         offline = os.getenv("HOLO_OFFLINE") == "1"
         model_cached = self._model_cache_present(model_name)
 
+        # FX1-D: Track retrieval mode explicitly (semantic/lexical/failed)
+        self.retrieval_mode = "failed"  # Default until proven otherwise
+
         # Optional fast-start skip to prevent long imports (set HOLO_SKIP_MODEL=1)
         if os.environ.get("HOLO_SKIP_MODEL") == "1":
-            self._log_agent_action("HOLO_SKIP_MODEL=1 -> skipping sentence transformer load", "WARN")
+            self._log_agent_action("HOLO_SKIP_MODEL=1 -> skipping sentence transformer load (lexical mode)", "WARN")
             self.model = None
+            self.retrieval_mode = "lexical"
         elif offline and not model_cached:
-            self._log_agent_action("HOLO_OFFLINE=1 and model cache missing -> skipping model load", "WARN")
+            self._log_agent_action("HOLO_OFFLINE=1 and model cache missing -> skipping model load (lexical mode)", "WARN")
             self.model = None
+            self.retrieval_mode = "lexical"
         else:
             global SentenceTransformer
             if SentenceTransformer is None:
@@ -212,6 +217,7 @@ class HoloIndex:
                 )
                 if SentenceTransformer is None:
                     self._log_agent_action("SentenceTransformer unavailable; falling back to lexical search", "WARN")
+                    self.retrieval_mode = "lexical"
 
             if SentenceTransformer:
                 # WSP 97: Load model with hard timeout
@@ -224,8 +230,12 @@ class HoloIndex:
                 )
                 if self.model is None:
                     self._log_agent_action("Model load failed; falling back to lexical search", "WARN")
+                    self.retrieval_mode = "lexical"
+                else:
+                    self.retrieval_mode = "semantic"
             else:
                 self.model = None
+                self.retrieval_mode = "lexical"
 
         self.need_to: Dict[str, str] = {}
         self.wsp_summary: Dict[str, Dict[str, str]] = {}

--- a/holo_index/core/search_engine.py
+++ b/holo_index/core/search_engine.py
@@ -568,6 +568,8 @@ def execute_search(
                 "symbol_count": len(symbol_results),
                 "timestamp": datetime.now().isoformat(),
                 "cached": False,
+                # FX1-D: Surface retrieval mode in search results
+                "retrieval_mode": getattr(holo, "retrieval_mode", "unknown"),
             },
         }
 

--- a/holo_index/tests/test_fx1_holoindex_truth.py
+++ b/holo_index/tests/test_fx1_holoindex_truth.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+"""FX1-IMPL: HoloIndex Truth Restoration Tests
+
+Tests for:
+- FX1-A: logger defined in _cli_main
+- FX1-D: retrieval_mode surfaced in search results
+- FX1-E: offline mode disables telemetry
+- FX1-C: WSP00 zen state tracker permission fallback
+
+WSP 97: Truthful state distinction - no false claims.
+"""
+
+import os
+import sys
+import logging
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+class TestFX1A_LoggerDefined:
+    """FX1-A: Verify logger is defined in _cli_main."""
+
+    def test_cli_logger_defined(self):
+        """Import _cli_main and verify logger exists."""
+        from holo_index import _cli_main
+        assert hasattr(_cli_main, 'logger'), "logger not defined in _cli_main"
+        assert isinstance(_cli_main.logger, logging.Logger), "logger is not a Logger instance"
+
+    def test_logger_has_correct_name(self):
+        """Verify logger uses module name."""
+        from holo_index import _cli_main
+        assert _cli_main.logger.name == "holo_index._cli_main"
+
+
+class TestFX1D_RetrievalMode:
+    """FX1-D: Verify retrieval_mode is surfaced."""
+
+    def test_holo_skip_model_reports_lexical(self):
+        """With HOLO_SKIP_MODEL=1, retrieval_mode should be 'lexical'."""
+        # Set env before import
+        os.environ['HOLO_SKIP_MODEL'] = '1'
+        os.environ['HOLO_SILENT'] = '1'
+
+        try:
+            # Force reimport
+            if 'holo_index.core.holo_index' in sys.modules:
+                del sys.modules['holo_index.core.holo_index']
+
+            from holo_index.core.holo_index import HoloIndex
+
+            # Reset shared state to force fresh init
+            HoloIndex._initialized = False
+            HoloIndex._shared_state = {}
+
+            holo = HoloIndex(quiet=True)
+            assert holo.retrieval_mode == "lexical", f"Expected 'lexical', got '{holo.retrieval_mode}'"
+        finally:
+            os.environ.pop('HOLO_SKIP_MODEL', None)
+            os.environ.pop('HOLO_SILENT', None)
+
+    def test_retrieval_mode_in_search_metadata(self):
+        """Search results should include retrieval_mode in metadata."""
+        os.environ['HOLO_SKIP_MODEL'] = '1'
+        os.environ['HOLO_SILENT'] = '1'
+
+        try:
+            if 'holo_index.core.holo_index' in sys.modules:
+                del sys.modules['holo_index.core.holo_index']
+
+            from holo_index.core.holo_index import HoloIndex
+
+            HoloIndex._initialized = False
+            HoloIndex._shared_state = {}
+
+            holo = HoloIndex(quiet=True)
+            result = holo.search("test query", limit=1)
+
+            assert "metadata" in result, "Search result missing 'metadata'"
+            assert "retrieval_mode" in result["metadata"], "metadata missing 'retrieval_mode'"
+            assert result["metadata"]["retrieval_mode"] == "lexical"
+        finally:
+            os.environ.pop('HOLO_SKIP_MODEL', None)
+            os.environ.pop('HOLO_SILENT', None)
+
+
+class TestFX1E_OfflineTelemetry:
+    """FX1-E: Verify offline mode disables telemetry."""
+
+    def test_offline_sets_telemetry_disabled(self):
+        """--offline should set ANONYMIZED_TELEMETRY=false."""
+        # Simulate early argv check
+        original_argv = sys.argv.copy()
+        sys.argv = ['holo_index', '--offline', '--search', 'test']
+
+        try:
+            # Clear and reimport to trigger early env setting
+            if 'holo_index._cli_main' in sys.modules:
+                del sys.modules['holo_index._cli_main']
+
+            # The import should set env vars
+            import importlib
+            import holo_index._cli_main
+            importlib.reload(holo_index._cli_main)
+
+            assert os.environ.get('ANONYMIZED_TELEMETRY') == 'false', \
+                "ANONYMIZED_TELEMETRY not set to 'false' in offline mode"
+            assert os.environ.get('HOLO_OFFLINE') == '1', \
+                "HOLO_OFFLINE not set in offline mode"
+        finally:
+            sys.argv = original_argv
+            os.environ.pop('ANONYMIZED_TELEMETRY', None)
+            os.environ.pop('HOLO_OFFLINE', None)
+
+
+class TestFX1C_ZenStatePermissionFallback:
+    """FX1-C: Verify WSP00 zen state tracker handles permission errors."""
+
+    def test_zen_state_tracker_import_no_crash(self):
+        """Importing zen state tracker should not crash."""
+        from modules.infrastructure.monitoring.src.wsp_00_zen_state_tracker import WSP00ZenStateTracker
+        assert WSP00ZenStateTracker is not None
+
+    def test_zen_state_tracker_permission_fallback(self):
+        """_ensure_writable_state_file should return None when no path is writable."""
+        from modules.infrastructure.monitoring.src.wsp_00_zen_state_tracker import WSP00ZenStateTracker
+
+        # Create a tracker normally first
+        tracker = WSP00ZenStateTracker()
+
+        # Test the method directly with a mock that makes all paths fail
+        test_path = Path("/nonexistent/impossible/path/state.json")
+
+        # Patch both mkdir and open to always fail
+        with patch.object(Path, 'mkdir', side_effect=PermissionError("Mocked")):
+            with patch('builtins.open', side_effect=PermissionError("Mocked")):
+                result = tracker._ensure_writable_state_file(test_path)
+                # Should return None (non-persistent mode) instead of crashing
+                assert result is None, f"Expected None for non-persistent mode, got {result}"
+
+    def test_zen_state_tracker_none_state_file_save(self):
+        """Saving with None state_file should be a no-op, not crash."""
+        from modules.infrastructure.monitoring.src.wsp_00_zen_state_tracker import WSP00ZenStateTracker
+
+        tracker = WSP00ZenStateTracker()
+        original_state_file = tracker.state_file
+
+        # Force non-persistent mode
+        tracker.state_file = None
+
+        # This should not crash
+        try:
+            tracker._save_zen_state()
+            assert True
+        except Exception as e:
+            pytest.fail(f"_save_zen_state crashed with None state_file: {e}")
+        finally:
+            tracker.state_file = original_state_file
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/modules/infrastructure/monitoring/src/wsp_00_zen_state_tracker.py
+++ b/modules/infrastructure/monitoring/src/wsp_00_zen_state_tracker.py
@@ -87,28 +87,53 @@ class WSP00ZenStateTracker:
         """Resolve state file path with repo-root semantics."""
         return self._resolve_repo_path(state_file)
 
-    def _ensure_writable_state_file(self, target: Path) -> Path:
-        """Ensure state file is writable; fallback to user profile if needed."""
+    def _ensure_writable_state_file(self, target: Path) -> Optional[Path]:
+        """Ensure state file is writable; fallback to user profile or non-persistent mode.
+
+        FX1-C: Three-tier fallback:
+        1. Primary path (repo-relative)
+        2. User home fallback (~/.foundups-agent/memory/)
+        3. Non-persistent mode (returns None, persistence disabled)
+
+        WSP 97: Never crashes; returns None if no writable path exists.
+        """
+        # Tier 1: Try primary path
         try:
             target.parent.mkdir(parents=True, exist_ok=True)
-            # Probe write access without mutating content.
             with open(target, 'a', encoding='utf-8'):
                 pass
             return target
-        except Exception as e:
+        except (PermissionError, FileNotFoundError, OSError):
+            pass
+
+        # Tier 2: Try user home fallback
+        try:
             fallback = Path.home() / ".foundups-agent" / "memory" / target.name
             fallback.parent.mkdir(parents=True, exist_ok=True)
             with open(fallback, 'a', encoding='utf-8'):
                 pass
             print(
-                f"[WARNING] State file not writable at {target}: {e}. "
+                f"[WARNING] State file not writable at {target}. "
                 f"Using fallback {fallback}"
             )
             return fallback
+        except (PermissionError, FileNotFoundError, OSError):
+            pass
+
+        # Tier 3: Non-persistent mode (read-only environment or restricted sandbox)
+        print(
+            f"[WARNING] WSP00 zen state persistence disabled — "
+            f"no writable path available (tried {target} and user home). "
+            f"Running in non-persistent mode."
+        )
+        return None
 
     def _load_zen_state(self) -> Dict[str, Any]:
-        """Load zen state from persistent storage."""
-        if not self.state_file.exists():
+        """Load zen state from persistent storage.
+
+        FX1-C: Handles None state_file (non-persistent mode).
+        """
+        if self.state_file is None or not self.state_file.exists():
             return self._create_initial_state()
 
         try:
@@ -147,7 +172,12 @@ class WSP00ZenStateTracker:
         }
 
     def _save_zen_state(self):
-        """Save zen state to persistent storage."""
+        """Save zen state to persistent storage.
+
+        FX1-C: No-op if state_file is None (non-persistent mode).
+        """
+        if self.state_file is None:
+            return  # Non-persistent mode: skip save
         try:
             with open(self.state_file, 'w', encoding='utf-8') as f:
                 json.dump(self.zen_state, f, indent=2, ensure_ascii=False)


### PR DESCRIPTION
## Summary

FX1-R: HoloIndex truth repair - surface retrieval mode and harden offline fallbacks.

**Window**: AG1
**Slice**: FX1-R — HOLOINDEX_TRUTH_REPAIR_RECOVERY_PHASE1

## Changes

- **FX1-A**: Define `logger` in `_cli_main.py` (fixes NameError at lines 1301, 1349, 1362, 1374)
- **FX1-D**: Add `retrieval_mode` state tracking (semantic/lexical/failed)
- **FX1-D**: Surface `retrieval_mode` in search result metadata
- **FX1-E**: Set `ANONYMIZED_TELEMETRY=false` in offline mode to suppress PostHog
- **FX1-C**: WSP00 zen state tracker 3-tier fallback (repo → user home → non-persistent)

## Expected files (exactly 5)

- `holo_index/_cli_main.py`
- `holo_index/core/holo_index.py`
- `holo_index/core/search_engine.py`
- `modules/infrastructure/monitoring/src/wsp_00_zen_state_tracker.py`
- `holo_index/tests/test_fx1_holoindex_truth.py`

## Verification

| Check | Result |
|-------|--------|
| Tests | 8 passed |
| Smoke | `HOLO_SKIP_MODEL=1 HOLO_OFFLINE=1 python holo_index.py --search "preflight_resolution"` - no crash |
| Semantic restored | no (not claimed) |
| Lexical fallback explicit | yes |
| Sub-utilities removed | no |
| TurboQuant changed | no |

## Test plan

- [ ] `python -m pytest holo_index/tests/test_fx1_holoindex_truth.py -v`
- [ ] `HOLO_SKIP_MODEL=1 HOLO_OFFLINE=1 python holo_index.py --search "test" --limit 3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)