### PR TITLE
fix(main): OAuth preflight dispatches WARN paths to AI Overseer (DJ2-C)

### DIFF
--- a/main.py
+++ b/main.py
@@ -295,10 +295,79 @@ async def monitor_youtube(disable_lock: bool = False, enable_ai_monitoring: bool
                 print(f"[OK] OAuth healthy: sets {oauth_status['healthy']}")
             else:
                 print("[WARN] No healthy OAuth tokens - running in read-only mode")
+                # DJ2-C: Dispatch OAuth no-healthy-tokens warning (WSP 97 truth distinction)
+                try:
+                    from modules.ai_intelligence.ai_overseer.src.preflight_resolution import (
+                        on_preflight_fail,
+                    )
+                    on_preflight_fail(
+                        component="oauth_youtube",
+                        severity="high",
+                        payload={
+                            "warning": "no_healthy_oauth_tokens",
+                            "auto_reauth": auto_reauth,
+                            "reauth_needed": oauth_status.get('reauth_needed', False),
+                            "expired_sets": oauth_status.get('expired', []),
+                            "source_file": "main.py",
+                            "source_function": "monitor_youtube",
+                            "requires_012": True,
+                            "automation_candidate": False,
+                            "safe_autonomous_actions": ["read_oauth_health_artifact", "capacity_report", "identity_verify_if_token_valid"],
+                            "unsafe_actions": ["credential_entry", "google_account_selection", "consent_approval"],
+                            "remediation": ["read_oauth_credential_health", "run_supervised_reauth_if_012_approves", "verify_identity_after_reauth"],
+                        },
+                        source="main:monitor_youtube",
+                    )
+                except Exception as dispatch_exc:
+                    logger.debug(f"[OAUTH] dispatch skipped: {dispatch_exc}")
         except ImportError as e:
             print(f"[WARN] OAuth preflight check unavailable: {e}")
+            # DJ2-C: Dispatch OAuth import failure (may be intentional in minimal deploys)
+            try:
+                from modules.ai_intelligence.ai_overseer.src.preflight_resolution import (
+                    on_preflight_fail,
+                )
+                on_preflight_fail(
+                    component="oauth_youtube",
+                    severity="medium",
+                    payload={
+                        "error": f"import_error: {e}",
+                        "auto_reauth": auto_reauth,
+                        "source_file": "main.py",
+                        "source_function": "monitor_youtube",
+                        "requires_012": False,
+                        "automation_candidate": False,
+                        "likely_cause": "youtube_auth_module_not_installed_or_minimal_deploy",
+                    },
+                    source="main:monitor_youtube",
+                )
+            except Exception:
+                pass  # Best-effort dispatch
         except Exception as e:
             print(f"[WARN] OAuth preflight check failed: {e}")
+            # DJ2-C: Dispatch OAuth preflight failure (unknown state)
+            try:
+                from modules.ai_intelligence.ai_overseer.src.preflight_resolution import (
+                    on_preflight_fail,
+                )
+                on_preflight_fail(
+                    component="oauth_youtube",
+                    severity="high",
+                    payload={
+                        "error": f"preflight_exception: {e}",
+                        "auto_reauth": auto_reauth,
+                        "source_file": "main.py",
+                        "source_function": "monitor_youtube",
+                        "requires_012": True,
+                        "automation_candidate": False,
+                        "safe_autonomous_actions": ["read_oauth_health_artifact", "capacity_report"],
+                        "unsafe_actions": ["credential_entry", "google_account_selection", "consent_approval"],
+                        "remediation": ["read_oauth_credential_health", "diagnose_preflight_failure", "run_supervised_reauth_if_012_approves"],
+                    },
+                    source="main:monitor_youtube",
+                )
+            except Exception:
+                pass  # Best-effort dispatch
 
         from modules.communication.livechat.src.auto_moderator_dae import AutoModeratorDAE
 

--- a/modules/ai_intelligence/ai_overseer/ModLog.md
+++ b/modules/ai_intelligence/ai_overseer/ModLog.md
@@ -2,7 +2,63 @@
 
 **Module**: `modules/ai_intelligence/ai_overseer/`
 **Status**: Active (Autonomous Code Patching + Daemon Restart + Activity Routing)
-**Version**: 0.10.2
+**Version**: 0.10.3
+
+---
+
+## 2026-04-20 - DJ2-C: OAuth Preflight Dispatch
+
+**Author**: 0102
+**WSP**: 97 (truthful state distinction)
+**Slice**: DJ2-C (second of 6 DJ2 slices from FCA1-AG2 audit)
+
+### Summary
+
+Wires YouTube OAuth preflight WARN paths in `main.py:monitor_youtube()` to dispatch
+via `on_preflight_fail()`. Three dispatch sites:
+1. No healthy OAuth tokens (severity=high, requires_012=true)
+2. ImportError (severity=medium, requires_012=false)
+3. Exception (severity=high, requires_012=true)
+
+### Payload Contract
+
+```json
+{
+  "component": "oauth_youtube",
+  "severity": "high",
+  "warning": "no_healthy_oauth_tokens",
+  "auto_reauth": <bool>,
+  "reauth_needed": <bool>,
+  "expired_sets": [...],
+  "source_file": "main.py",
+  "source_function": "monitor_youtube",
+  "requires_012": true,
+  "automation_candidate": false,
+  "safe_autonomous_actions": ["read_oauth_health_artifact", "capacity_report", "identity_verify_if_token_valid"],
+  "unsafe_actions": ["credential_entry", "google_account_selection", "consent_approval"],
+  "remediation": ["read_oauth_credential_health", "run_supervised_reauth_if_012_approves", "verify_identity_after_reauth"]
+}
+```
+
+### Tests (5 new, 18 total)
+
+- `test_main_py_oauth_no_healthy_tokens_calls_dispatcher`
+- `test_main_py_oauth_import_error_calls_dispatcher`
+- `test_main_py_oauth_exception_calls_dispatcher`
+- `test_main_py_oauth_healthy_does_not_dispatch`
+- `test_main_py_oauth_dispatcher_exception_does_not_block`
+
+### Constraints Respected
+
+- No OAuth browser flow
+- No credential mutation
+- No token inspection
+- No live Google API calls
+- Dispatch is best-effort, never blocks startup
+
+### Next Slice
+
+DJ2-B: IRONCLAW_SKIP_INTENTIONALITY_ASSERTION
 
 ---
 

--- a/modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py
+++ b/modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py
@@ -257,3 +257,169 @@ def test_main_py_wre_dashboard_insufficient_data_calls_dispatcher():
     assert call_kwargs["payload"]["min_samples"] == 25
     assert call_kwargs["payload"]["likely_cause"] == "cold_start_or_telemetry_drop"
     assert call_kwargs["payload"]["automation_candidate"] is True
+
+
+# === DJ2-C OAuth preflight dispatch tests ===
+
+
+def test_main_py_oauth_no_healthy_tokens_calls_dispatcher():
+    """DJ2-C: OAuth dispatches when no healthy tokens (WSP 97 truth distinction)."""
+    import main
+    import asyncio
+
+    with patch(
+        "modules.ai_intelligence.ai_overseer.src.preflight_resolution.on_preflight_fail"
+    ) as mock_dispatch:
+        fake_oauth_status = {
+            "healthy": [],  # No healthy tokens
+            "reauth_needed": False,  # Set False to skip interactive input prompt
+            "expired": ["set1", "set2"],
+        }
+        with patch(
+            "modules.platform_integration.youtube_auth.src.youtube_auth.preflight_oauth_check",
+            return_value=fake_oauth_status,
+        ):
+            with patch(
+                "modules.communication.livechat.src.auto_moderator_dae.AutoModeratorDAE",
+                side_effect=KeyboardInterrupt,
+            ):
+                with patch("builtins.print"):  # Suppress output
+                    try:
+                        asyncio.run(main.monitor_youtube(disable_lock=True, auto_reauth=True))
+                    except (KeyboardInterrupt, SystemExit):
+                        pass
+
+    assert mock_dispatch.called
+    call_kwargs = mock_dispatch.call_args.kwargs
+    assert call_kwargs["component"] == "oauth_youtube"
+    assert call_kwargs["severity"] == "high"
+    assert call_kwargs["payload"]["warning"] == "no_healthy_oauth_tokens"
+    assert call_kwargs["payload"]["requires_012"] is True
+    assert call_kwargs["payload"]["automation_candidate"] is False
+    assert "safe_autonomous_actions" in call_kwargs["payload"]
+    assert "unsafe_actions" in call_kwargs["payload"]
+
+
+def test_main_py_oauth_import_error_calls_dispatcher():
+    """DJ2-C: OAuth dispatches on ImportError (module unavailable)."""
+    import main
+    import asyncio
+
+    with patch(
+        "modules.ai_intelligence.ai_overseer.src.preflight_resolution.on_preflight_fail"
+    ) as mock_dispatch:
+        with patch(
+            "modules.platform_integration.youtube_auth.src.youtube_auth.preflight_oauth_check",
+            side_effect=ImportError("youtube_auth not installed"),
+        ):
+            with patch(
+                "modules.communication.livechat.src.auto_moderator_dae.AutoModeratorDAE",
+                side_effect=KeyboardInterrupt,
+            ):
+                with patch("builtins.print"):
+                    try:
+                        asyncio.run(main.monitor_youtube(disable_lock=True))
+                    except (KeyboardInterrupt, SystemExit):
+                        pass
+
+    assert mock_dispatch.called
+    call_kwargs = mock_dispatch.call_args.kwargs
+    assert call_kwargs["component"] == "oauth_youtube"
+    assert call_kwargs["severity"] == "medium"
+    assert "import_error" in call_kwargs["payload"]["error"]
+    assert call_kwargs["payload"]["requires_012"] is False
+
+
+def test_main_py_oauth_exception_calls_dispatcher():
+    """DJ2-C: OAuth dispatches on preflight exception (unknown state)."""
+    import main
+    import asyncio
+
+    with patch(
+        "modules.ai_intelligence.ai_overseer.src.preflight_resolution.on_preflight_fail"
+    ) as mock_dispatch:
+        with patch(
+            "modules.platform_integration.youtube_auth.src.youtube_auth.preflight_oauth_check",
+            side_effect=RuntimeError("preflight crashed"),
+        ):
+            with patch(
+                "modules.communication.livechat.src.auto_moderator_dae.AutoModeratorDAE",
+                side_effect=KeyboardInterrupt,
+            ):
+                with patch("builtins.print"):
+                    try:
+                        asyncio.run(main.monitor_youtube(disable_lock=True))
+                    except (KeyboardInterrupt, SystemExit):
+                        pass
+
+    assert mock_dispatch.called
+    call_kwargs = mock_dispatch.call_args.kwargs
+    assert call_kwargs["component"] == "oauth_youtube"
+    assert call_kwargs["severity"] == "high"
+    assert "preflight_exception" in call_kwargs["payload"]["error"]
+    assert call_kwargs["payload"]["requires_012"] is True
+
+
+def test_main_py_oauth_healthy_does_not_dispatch():
+    """DJ2-C: Healthy OAuth path does NOT dispatch (no false positives)."""
+    import main
+    import asyncio
+
+    with patch(
+        "modules.ai_intelligence.ai_overseer.src.preflight_resolution.on_preflight_fail"
+    ) as mock_dispatch:
+        fake_oauth_status = {
+            "healthy": ["set1", "set10"],  # Healthy tokens
+            "reauth_needed": False,
+            "expired": [],
+        }
+        with patch(
+            "modules.platform_integration.youtube_auth.src.youtube_auth.preflight_oauth_check",
+            return_value=fake_oauth_status,
+        ):
+            with patch(
+                "modules.communication.livechat.src.auto_moderator_dae.AutoModeratorDAE",
+                side_effect=KeyboardInterrupt,
+            ):
+                with patch("builtins.print"):
+                    try:
+                        asyncio.run(main.monitor_youtube(disable_lock=True))
+                    except (KeyboardInterrupt, SystemExit):
+                        pass
+
+    # Should NOT have dispatched for healthy OAuth
+    assert not mock_dispatch.called
+
+
+def test_main_py_oauth_dispatcher_exception_does_not_block():
+    """DJ2-C: Dispatcher exception does not block existing return behavior."""
+    import main
+    import asyncio
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("dispatcher crashed")
+
+    with patch(
+        "modules.ai_intelligence.ai_overseer.src.preflight_resolution.on_preflight_fail",
+        side_effect=_boom,
+    ):
+        fake_oauth_status = {
+            "healthy": [],
+            "reauth_needed": False,  # Set False to skip interactive input prompt
+            "expired": ["set1"],
+        }
+        with patch(
+            "modules.platform_integration.youtube_auth.src.youtube_auth.preflight_oauth_check",
+            return_value=fake_oauth_status,
+        ):
+            with patch(
+                "modules.communication.livechat.src.auto_moderator_dae.AutoModeratorDAE",
+                side_effect=KeyboardInterrupt,
+            ):
+                with patch("builtins.print"):
+                    # Should not raise even though dispatcher crashes
+                    try:
+                        asyncio.run(main.monitor_youtube(disable_lock=True, auto_reauth=True))
+                    except (KeyboardInterrupt, SystemExit):
+                        pass
+    # If we got here without exception, the test passes


### PR DESCRIPTION
## Summary

Wire YouTube OAuth boot preflight WARN/failure paths in `main.py:monitor_youtube()` to `on_preflight_fail()` via the existing preflight_resolution contract.

## Dispatch Sites (3)

| Site | Condition | Severity | requires_012 |
|------|-----------|----------|--------------|
| Line ~297 | No healthy OAuth tokens | high | true |
| Line ~324 | ImportError (module unavailable) | medium | false |
| Line ~346 | Exception (preflight failed) | high | true |

## Payload Contract

```json
{
  "component": "oauth_youtube",
  "severity": "high",
  "warning": "no_healthy_oauth_tokens",
  "auto_reauth": <bool>,
  "requires_012": true,
  "automation_candidate": false,
  "safe_autonomous_actions": ["read_oauth_health_artifact", "capacity_report", "identity_verify_if_token_valid"],
  "unsafe_actions": ["credential_entry", "google_account_selection", "consent_approval"],
  "remediation": ["read_oauth_credential_health", "run_supervised_reauth_if_012_approves", "verify_identity_after_reauth"]
}
```

## Files Changed (3)

| File | Change |
|------|--------|
| `main.py` | +3 dispatch blocks in OAuth preflight |
| `ai_overseer/ModLog.md` | Version 0.10.3, DJ2-C entry |
| `ai_overseer/tests/test_preflight_resolution.py` | +5 tests (18 total) |

## Tests (5 new)

- `test_main_py_oauth_no_healthy_tokens_calls_dispatcher`
- `test_main_py_oauth_import_error_calls_dispatcher`
- `test_main_py_oauth_exception_calls_dispatcher`
- `test_main_py_oauth_healthy_does_not_dispatch`
- `test_main_py_oauth_dispatcher_exception_does_not_block`

## Constraints Respected

- [x] No OAuth browser flow
- [x] No credential mutation
- [x] No token inspection
- [x] No live Google API calls
- [x] No youtube_auth implementation changes
- [x] No changes to authorize scripts
- [x] No broad refactor of main.py
- [x] Dispatch is best-effort, never blocks startup

## Test Plan

```bash
python -m pytest modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py -v
# Result: 18 passed
```

## FCA1-AG2 Reference

This slice addresses violation #4 from FCA1-AG2 audit:

> OAuth | `monitor_youtube` (~line 299-301) | `[WARN] OAuth preflight...` | failure masked; downstream chat failure is the first signal

## Next Slice

DJ2-B: IRONCLAW_SKIP_INTENTIONALITY_ASSERTION

---

```
Window: CW1
Slice: DJ2-C
Lane: DJ / Boot Observability
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)