### PR TITLE
test(stream-resolver): restore collection after dependency/import drift

### DIFF
--- a/modules/platform_integration/stream_resolver/requirements.txt
+++ b/modules/platform_integration/stream_resolver/requirements.txt
@@ -8,6 +8,9 @@ google-auth-oauthlib>=1.0.0
 # Environment variables
 python-dotenv>=1.0.0
 
+# Timezone handling (required by stream_config.py)
+pytz>=2023.3
+
 # Standard library dependencies (listed for clarity)
 # time
 # random

--- a/modules/platform_integration/stream_resolver/tests/test_stream_resolver.py
+++ b/modules/platform_integration/stream_resolver/tests/test_stream_resolver.py
@@ -6,15 +6,15 @@ import os
 import sys
 import pytest
 import googleapiclient.errors
-from modules.platform_integration.stream_resolver.src.stream_resolver import (
+from modules.platform_integration.stream_resolver.src import (
     calculate_dynamic_delay,
     mask_sensitive_id,
     check_video_details,
     search_livestreams,
     get_active_livestream_video_id,
     QuotaExceededError,
-    FORCE_DEV_DELAY
 )
+from modules.platform_integration.stream_resolver.src.stream_config import FORCE_DEV_DELAY
 
 class TestCalculateDynamicDelay(unittest.TestCase):
     """Test suite for the calculate_dynamic_delay function."""
@@ -22,21 +22,21 @@ class TestCalculateDynamicDelay(unittest.TestCase):
     def setUp(self):
         # Store original value
         self.original_force_dev_delay = getattr(
-            __import__('modules.platform_integration.stream_resolver.src.stream_resolver', 
-                     fromlist=['FORCE_DEV_DELAY']), 
+            __import__('modules.platform_integration.stream_resolver.src.stream_config',
+                     fromlist=['FORCE_DEV_DELAY']),
             'FORCE_DEV_DELAY'
         )
-        
+
     def tearDown(self):
         # Restore original value
         setattr(
-            __import__('modules.platform_integration.stream_resolver.src.stream_resolver', 
-                     fromlist=['FORCE_DEV_DELAY']), 
+            __import__('modules.platform_integration.stream_resolver.src.stream_config',
+                     fromlist=['FORCE_DEV_DELAY']),
             'FORCE_DEV_DELAY',
             self.original_force_dev_delay
         )
 
-    @patch('modules.platform_integration.stream_resolver.src.stream_resolver.FORCE_DEV_DELAY', False)
+    @patch('modules.platform_integration.stream_resolver.src.stream_config.FORCE_DEV_DELAY', False)
     def test_calculate_dynamic_delay_with_high_activity(self):
         """Test delay calculation with high chat activity."""
 
@@ -46,7 +46,7 @@ class TestCalculateDynamicDelay(unittest.TestCase):
         self.assertGreaterEqual(delay, 5.0)  
         self.assertLessEqual(delay, 7.0)  # With jitter
 
-    @patch('modules.platform_integration.stream_resolver.src.stream_resolver.FORCE_DEV_DELAY', False)
+    @patch('modules.platform_integration.stream_resolver.src.stream_config.FORCE_DEV_DELAY', False)
     def test_calculate_dynamic_delay_with_low_activity(self):
         """Test delay calculation with low chat activity."""
         delay = calculate_dynamic_delay(active_users=5)
@@ -54,21 +54,21 @@ class TestCalculateDynamicDelay(unittest.TestCase):
         self.assertGreaterEqual(delay, 48.0)  
         self.assertLessEqual(delay, 60.0)  # With upper bound
 
-    @patch('modules.platform_integration.stream_resolver.src.stream_resolver.FORCE_DEV_DELAY', False)
+    @patch('modules.platform_integration.stream_resolver.src.stream_config.FORCE_DEV_DELAY', False)
     def test_calculate_dynamic_delay_with_failures(self):
         """Test delay increase with consecutive failures."""
         base_delay = calculate_dynamic_delay(active_users=100)
         increased_delay = calculate_dynamic_delay(active_users=100, consecutive_failures=3)
         self.assertGreater(increased_delay, base_delay)
 
-    @patch('modules.platform_integration.stream_resolver.src.stream_resolver.FORCE_DEV_DELAY', True)
+    @patch('modules.platform_integration.stream_resolver.src.stream_config.FORCE_DEV_DELAY', True)
     def test_calculate_dynamic_delay_dev_mode(self):
         """Test that dev mode forces a 1-second delay."""
         delay = calculate_dynamic_delay(active_users=1000)
         self.assertEqual(delay, 1.0)
 
-    @patch('modules.platform_integration.stream_resolver.src.stream_resolver.FORCE_DEV_DELAY', False)
-    @patch('modules.platform_integration.stream_resolver.src.stream_resolver.random.uniform')
+    @patch('modules.platform_integration.stream_resolver.src.stream_config.FORCE_DEV_DELAY', False)
+    @patch('random.uniform')
     def test_calculate_dynamic_delay_with_previous_delay(self, mock_uniform):
         """Test that previous delay is used for smoothing."""
         mock_uniform.return_value = 0  # No randomness for testing
@@ -78,8 +78,8 @@ class TestCalculateDynamicDelay(unittest.TestCase):
         self.assertGreater(current, 10.0)  # Medium activity base
         self.assertLess(current, 30.0)  # Previous delay
 
-    @patch('modules.platform_integration.stream_resolver.src.stream_resolver.FORCE_DEV_DELAY', False)
-    @patch('modules.platform_integration.stream_resolver.src.stream_resolver.random.uniform')
+    @patch('modules.platform_integration.stream_resolver.src.stream_config.FORCE_DEV_DELAY', False)
+    @patch('random.uniform')
     def test_calculate_dynamic_delay_without_dev_mode(self, mock_uniform):
         """Test calculate_dynamic_delay with FORCE_DEV_DELAY set to False."""
         mock_uniform.return_value = 1.0  # Consistent random value for testing

--- a/modules/platform_integration/stream_resolver/tests/test_video.py
+++ b/modules/platform_integration/stream_resolver/tests/test_video.py
@@ -14,7 +14,7 @@ if __name__ == '__main__' and sys.platform.startswith('win'):
 import logging
 from utils.logging_config import setup_logging
 from modules.platform_integration.youtube_auth.src.youtube_auth import get_authenticated_service
-from modules.platform_integration.stream_resolver.src.stream_resolver import check_video_details
+from modules.platform_integration.stream_resolver.src import check_video_details
 from utils.env_loader import get_env_variable
 
 # Setup logging


### PR DESCRIPTION
## Summary
- 42 tests now collect (was: ImportError on collection)
- 30/42 pass
- 12 remaining failures deferred to YT-CLEANUP2 due to old API-contract assertions
- No live YouTube/API/OAuth calls

## Changes
- Added pytz>=2023.3 to requirements.txt
- Fixed imports to use package-level re-exports
- Fixed patch decorator targets (stream_config vs stream_resolver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)