### PR TITLE
feat(registry): WSP01 signature routing and posting directives

### DIFF
--- a/modules/infrastructure/shared_utilities/linkedin_account_registry.py
+++ b/modules/infrastructure/shared_utilities/linkedin_account_registry.py
@@ -69,10 +69,9 @@ class LinkedInCompany:
     EDUIT = "eduit"
 
 
-# Default fallback if env not set
-_DEFAULT_ACCOUNTS: Dict[str, str] = {
-    "foundups": "1263645",
-}
+# Default fallback if env not set (minimal - use LINKEDIN_ACCOUNTS_JSON env var)
+# Format: LINKEDIN_ACCOUNTS_JSON='{"foundups":"1263645","undaodu":"156137799","move2japan":"104834798"}'
+_DEFAULT_ACCOUNTS: Dict[str, str] = {}
 
 # Aliases for fuzzy matching (lowercase -> canonical name)
 ACCOUNT_ALIASES: Dict[str, str] = {
@@ -167,8 +166,9 @@ def get_default_company() -> str:
     if canonical and canonical in accounts:
         return accounts[canonical]
 
-    # Fallback to FOUNDUPS
-    return accounts.get("foundups", "1263645")
+    # No fallback - env var must be set
+    logger.error("[LINKEDIN] LINKEDIN_ACCOUNTS_JSON env var not set or missing accounts")
+    return ""
 
 
 def _resolve_account_name(name: str) -> Optional[str]:

--- a/modules/infrastructure/shared_utilities/youtube_channel_registry.py
+++ b/modules/infrastructure/shared_utilities/youtube_channel_registry.py
@@ -52,7 +52,7 @@ def _default_channels() -> List[Dict[str, Any]]:
                 "account_section": 0,
             },
             "shorts": {"time_slots": _DEFAULT_TIME_SLOTS, "max_per_day": 8, "description_template": "ffcpln"},
-            "social": {"linkedin_company": "move2japan", "x_account": "geozai", "enabled": True},
+            "social": {"linkedin_company": "move2japan", "x_account": "geozai", "enabled": True, "signature": "0102🦞"},
         },
         {
             "key": "undaodu",
@@ -69,7 +69,7 @@ def _default_channels() -> List[Dict[str, Any]]:
                 "account_section": 0,
             },
             "shorts": {"time_slots": _DEFAULT_TIME_SLOTS, "max_per_day": 8, "description_template": "undaodu"},
-            "social": {"linkedin_company": "undaodu", "x_account": "undaodu", "enabled": True},
+            "social": {"linkedin_company": "undaodu", "x_account": "undaodu", "enabled": True, "signature": "0102🦞012🖐️"},  # wsp01: 012 co-signs
         },
         {
             "key": "foundups",
@@ -86,7 +86,7 @@ def _default_channels() -> List[Dict[str, Any]]:
                 "account_section": 1,
             },
             "shorts": {"time_slots": _DEFAULT_TIME_SLOTS, "max_per_day": 8, "description_template": "foundups"},
-            "social": {"linkedin_company": "foundups", "x_account": "foundups", "enabled": True},
+            "social": {"linkedin_company": "foundups", "x_account": "foundups", "enabled": True, "signature": "0102🦞"},
         },
         {
             "key": "antifafm",
@@ -103,7 +103,7 @@ def _default_channels() -> List[Dict[str, Any]]:
                 "account_section": 1,
             },
             "shorts": {"time_slots": _DEFAULT_TIME_SLOTS, "max_per_day": 8, "description_template": "ffcpln"},
-            "social": {"linkedin_company": "foundups", "x_account": "antifafm", "enabled": True},
+            "social": {"linkedin_company": "move2japan", "x_account": "antifafm", "enabled": True, "signature": "0102🦞"},  # wsp01: antifaFM posts to move2japan
         },
     ]
 
@@ -161,6 +161,7 @@ def _normalize_channel(channel: Dict[str, Any]) -> Dict[str, Any]:
         "linkedin_page_id": linkedin_page_id,
         "x_account": str(social.get("x_account", "")),
         "enabled": bool(social.get("enabled", False)),
+        "signature": str(social.get("signature", "0102🦞")),  # default lobster, 012 co-signs on undaodu
     }
 
     return normalized


### PR DESCRIPTION
## Summary
- Add signature field to youtube_channel_registry (`0102🦞` default, `0102🦞012🖐️` for undaodu)
- Route antifaFM LinkedIn posts to move2japan per WSP01 XV.2
- Remove hardcoded LinkedIn IDs (env-only via LINKEDIN_ACCOUNTS_JSON)

## Test plan
- [ ] DAEmon restart picks up new routing
- [ ] antifaFM posts go to move2japan LinkedIn
- [ ] undaodu posts include 012 signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)