### PR TITLE
feat(autoagent): rescue target surface io layer (Layer 3)

### DIFF
--- a/modules/infrastructure/autoagent_lab/INTERFACE.md
+++ b/modules/infrastructure/autoagent_lab/INTERFACE.md
@@ -136,6 +136,64 @@ context = pattern_memory_adapter.get_context("skill_name")
 result = eval_skill_config(path, context)
 ```
 
+## Target Surface IO (Layer 3)
+
+```python
+from modules.infrastructure.autoagent_lab.src.target_surface import (
+    SkillSurface,
+    load_skill_surface,
+    create_workspace_copy,
+    write_candidate_surface,
+    get_candidate_path,
+    TargetSurfaceError,
+)
+
+# Load a production skill (read-only)
+surface = load_skill_surface("path/to/SKILL.md")
+print(surface.skill_id)           # Derived from 'name' or filename
+print(surface.mutable_fields)     # {agents, domains, tokens_budget, ...}
+print(surface.immutable_fields)   # {name, version, description, ...}
+
+# Create isolated workspace copy
+workspace = Path("modules/infrastructure/autoagent_lab/workspace")
+surface = create_workspace_copy(surface, workspace_root=workspace)
+print(surface.workspace_path)  # Now set
+
+# Write candidate with updated mutable fields
+candidate_path = write_candidate_surface(
+    surface,
+    updated_mutable_fields={"agents": ["haiku"], "tokens_budget": 1000},
+)
+```
+
+### SkillSurface
+
+```python
+@dataclass
+class SkillSurface:
+    source_path: Path               # Original production file (read-only)
+    workspace_path: Optional[Path]  # Workspace copy (if created)
+    skill_id: str                   # From 'name' field or filename
+    immutable_fields: dict          # Cannot be changed by experiments
+    mutable_fields: dict            # Can be mutated
+    body_content: str               # Markdown body after frontmatter
+```
+
+### Mutable vs Immutable Fields
+
+| Mutable (can change) | Immutable (preserved) |
+|---------------------|----------------------|
+| agents | name |
+| wsp_chain | version |
+| domains | description |
+| tokens_budget | author |
+| prompt | category, dependencies, etc. |
+
+### Production Read-Only
+
+The original `SKILL.md` file is NEVER modified. All mutations happen in
+isolated workspace copies under `workspace/exp_{hash}/`.
+
 ## WSP Compliance
 
 - WSP 49: Standard module structure

--- a/modules/infrastructure/autoagent_lab/ModLog.md
+++ b/modules/infrastructure/autoagent_lab/ModLog.md
@@ -1,5 +1,49 @@
 # AutoAgent Lab — ModLog
 
+## V0.3.0 — Layer 3: Target Surface IO (2026-04-08)
+
+**Worker**: AJ
+**Slice**: AUTOAGENT_LAB_LAYER3_TARGET_SURFACE_IO_IMPLEMENTATION
+
+### Added
+- `src/target_surface.py` — Skill config read/copy/write
+  - `SkillSurface` dataclass: source_path, workspace_path, skill_id, mutable/immutable fields, body
+  - `load_skill_surface(path)` — Parse production SKILL.md (read-only)
+  - `create_workspace_copy(surface, workspace_root, experiment_id)` — Isolated copy
+  - `write_candidate_surface(surface, updated_mutable_fields)` — Write candidate
+  - `get_candidate_path(surface)` — Deterministic candidate path
+  - `TargetSurfaceError` exception class
+- `tests/test_target_surface.py` — 33 focused tests
+  - Load valid/invalid skills
+  - Mutable/immutable field separation
+  - Workspace copy creation
+  - Candidate write with field updates
+  - Production file never modified
+  - Workspace isolation enforcement
+
+### Mutable Fields (from experiment_config.py)
+- `agents`, `wsp_chain`, `domains`, `tokens_budget`, `prompt`
+
+### Immutable Fields (preserved exactly)
+- `name`, `version`, `description`, `author`, `category`, etc.
+
+### Design Decisions
+- **Production read-only**: Original SKILL.md files never modified
+- **Workspace isolation**: All mutations under `workspace/exp_{hash}/`
+- **Deterministic pathing**: Same source path produces same experiment_id hash
+- **Reuses safety gates**: Uses `validate_workspace_path` from safety_gates.py
+
+### What Is NOT Implemented (Layer 4+)
+- Experiment loop / keep-discard runner
+- Mutation generation
+- Auto-apply to production
+
+### WSP Compliance
+- WSP 15: Read-first (all specs verified before implementation)
+- WSP 97: Internal boundaries (production files read-only)
+
+---
+
 ## V0.2.0 — Layer 2: Deterministic Eval Harness (2026-04-07)
 
 **Worker**: AE

--- a/modules/infrastructure/autoagent_lab/README.md
+++ b/modules/infrastructure/autoagent_lab/README.md
@@ -52,6 +52,31 @@ Score components:
 - `historical_fidelity` (0.3) — From context (PatternMemory adapter future)
 - `historical_quality` (0.3) — From context (PatternMemory adapter future)
 
+## Target Surface IO (Layer 3)
+
+```python
+from modules.infrastructure.autoagent_lab.src.target_surface import (
+    load_skill_surface,
+    create_workspace_copy,
+    write_candidate_surface,
+)
+
+# Load production skill (read-only)
+surface = load_skill_surface("path/to/SKILL.md")
+
+# Create isolated workspace copy
+surface = create_workspace_copy(surface)
+
+# Write candidate with updated mutable fields
+candidate = write_candidate_surface(
+    surface,
+    {"agents": ["haiku"], "tokens_budget": 1000},
+)
+```
+
+Mutable fields: `agents`, `wsp_chain`, `domains`, `tokens_budget`, `prompt`
+Immutable fields: `name`, `version`, `description`, etc. (preserved exactly)
+
 ## What This Does NOT Do
 
 - No production WRE mutation

--- a/modules/infrastructure/autoagent_lab/src/target_surface.py
+++ b/modules/infrastructure/autoagent_lab/src/target_surface.py
@@ -1,0 +1,314 @@
+"""Target surface IO for AutoAgent Lab experiments.
+
+Read production skill configs, create isolated workspace copies,
+and write candidate mutations. Production files are NEVER modified.
+
+Mutable fields (from experiment_config.py):
+- agents, wsp_chain, domains, tokens_budget, prompt
+
+Immutable fields (preserved exactly):
+- name, version, description, author, dependencies, skill_id, category, etc.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+from .experiment_config import VALID_MUTABLE_FIELDS
+from .safety_gates import SafetyViolation, validate_workspace_path
+
+logger = logging.getLogger("autoagent_lab.target_surface")
+
+# Default workspace root relative to module
+DEFAULT_WORKSPACE_ROOT = Path(__file__).parent.parent / "workspace"
+
+
+class TargetSurfaceError(Exception):
+    """Raised when target surface operations fail."""
+
+
+@dataclass
+class SkillSurface:
+    """Represents a skill config surface for experimentation.
+
+    Separates mutable fields (can be changed by experiments) from
+    immutable fields (preserved exactly).
+    """
+
+    source_path: Path  # Original production file (read-only)
+    workspace_path: Optional[Path]  # Workspace copy (if created)
+    skill_id: str  # Derived from 'name' field or filename
+    immutable_fields: dict[str, Any]  # Fields that cannot change
+    mutable_fields: dict[str, Any]  # Fields that can be mutated
+    body_content: str  # Markdown body after frontmatter
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for serialization."""
+        return {
+            "source_path": str(self.source_path),
+            "workspace_path": str(self.workspace_path) if self.workspace_path else None,
+            "skill_id": self.skill_id,
+            "immutable_fields": dict(self.immutable_fields),
+            "mutable_fields": dict(self.mutable_fields),
+            "body_content_length": len(self.body_content),
+        }
+
+
+def load_skill_surface(skill_path: Path | str) -> SkillSurface:
+    """Load a skill config from a production file.
+
+    Args:
+        skill_path: Path to the SKILL.md file.
+
+    Returns:
+        SkillSurface with parsed mutable/immutable fields.
+
+    Raises:
+        TargetSurfaceError: If the file cannot be read or parsed.
+    """
+    skill_path = Path(skill_path)
+
+    if not skill_path.exists():
+        raise TargetSurfaceError(f"Skill file not found: {skill_path}")
+
+    try:
+        content = skill_path.read_text(encoding="utf-8")
+    except Exception as e:
+        raise TargetSurfaceError(f"Failed to read skill file: {e}")
+
+    # Parse frontmatter and body
+    frontmatter_str, body_content = _split_frontmatter(content)
+    if frontmatter_str is None:
+        raise TargetSurfaceError(f"No YAML frontmatter found in: {skill_path}")
+
+    try:
+        frontmatter = yaml.safe_load(frontmatter_str)
+    except yaml.YAMLError as e:
+        raise TargetSurfaceError(f"Invalid YAML frontmatter: {e}")
+
+    if not isinstance(frontmatter, dict):
+        raise TargetSurfaceError(f"Frontmatter must be a mapping, got {type(frontmatter).__name__}")
+
+    # Separate mutable and immutable fields
+    mutable_fields = {}
+    immutable_fields = {}
+
+    for key, value in frontmatter.items():
+        if key in VALID_MUTABLE_FIELDS:
+            mutable_fields[key] = value
+        else:
+            immutable_fields[key] = value
+
+    # Derive skill_id from 'name' field or filename
+    skill_id = immutable_fields.get("name") or skill_path.stem
+
+    logger.debug(
+        f"Loaded skill surface: {skill_id} "
+        f"(mutable: {list(mutable_fields.keys())}, "
+        f"immutable: {list(immutable_fields.keys())})"
+    )
+
+    return SkillSurface(
+        source_path=skill_path.resolve(),
+        workspace_path=None,
+        skill_id=skill_id,
+        immutable_fields=immutable_fields,
+        mutable_fields=mutable_fields,
+        body_content=body_content,
+    )
+
+
+def create_workspace_copy(
+    surface: SkillSurface,
+    workspace_root: Optional[Path] = None,
+    experiment_id: Optional[str] = None,
+) -> SkillSurface:
+    """Create an isolated workspace copy of a skill surface.
+
+    Args:
+        surface: The skill surface to copy.
+        workspace_root: Root directory for workspace copies.
+            Defaults to module workspace/ directory.
+        experiment_id: Optional experiment identifier for the subdirectory.
+            If not provided, uses a hash of the source path.
+
+    Returns:
+        New SkillSurface with workspace_path set.
+
+    Raises:
+        SafetyViolation: If the workspace path escapes isolation.
+        TargetSurfaceError: If the copy fails.
+    """
+    workspace_root = workspace_root or DEFAULT_WORKSPACE_ROOT
+    workspace_root = Path(workspace_root).resolve()
+
+    # Generate experiment subdirectory
+    if experiment_id is None:
+        # Deterministic: hash of source path
+        path_hash = hashlib.sha256(str(surface.source_path).encode()).hexdigest()[:12]
+        experiment_id = f"exp_{path_hash}"
+
+    experiment_dir = workspace_root / experiment_id
+    workspace_path = experiment_dir / "SKILL.md"
+
+    # Validate workspace isolation (fail-closed)
+    validate_workspace_path(workspace_root, workspace_path)
+
+    # Create directory
+    try:
+        experiment_dir.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        raise TargetSurfaceError(f"Failed to create workspace directory: {e}")
+
+    # Write the skill content to workspace
+    content = _render_skill_content(surface)
+    try:
+        workspace_path.write_text(content, encoding="utf-8")
+    except Exception as e:
+        raise TargetSurfaceError(f"Failed to write workspace copy: {e}")
+
+    logger.info(f"Created workspace copy: {workspace_path}")
+
+    # Return new surface with workspace_path set
+    return SkillSurface(
+        source_path=surface.source_path,
+        workspace_path=workspace_path,
+        skill_id=surface.skill_id,
+        immutable_fields=dict(surface.immutable_fields),
+        mutable_fields=dict(surface.mutable_fields),
+        body_content=surface.body_content,
+    )
+
+
+def write_candidate_surface(
+    surface: SkillSurface,
+    updated_mutable_fields: dict[str, Any],
+    candidate_suffix: str = "_candidate",
+) -> Path:
+    """Write a candidate skill config with updated mutable fields.
+
+    Immutable fields are preserved exactly. Only mutable fields
+    from updated_mutable_fields are applied.
+
+    Args:
+        surface: The skill surface (must have workspace_path set).
+        updated_mutable_fields: New values for mutable fields.
+            Keys not in VALID_MUTABLE_FIELDS are ignored with a warning.
+        candidate_suffix: Suffix for the candidate filename.
+
+    Returns:
+        Path to the written candidate file.
+
+    Raises:
+        TargetSurfaceError: If no workspace_path or write fails.
+        SafetyViolation: If candidate path escapes workspace.
+    """
+    if surface.workspace_path is None:
+        raise TargetSurfaceError(
+            "Cannot write candidate: no workspace_path set. "
+            "Call create_workspace_copy() first."
+        )
+
+    workspace_dir = surface.workspace_path.parent
+    candidate_path = workspace_dir / f"SKILL{candidate_suffix}.md"
+
+    # Validate workspace isolation
+    validate_workspace_path(workspace_dir.parent, candidate_path)
+
+    # Merge mutable fields (only valid mutable keys)
+    new_mutable = dict(surface.mutable_fields)
+    for key, value in updated_mutable_fields.items():
+        if key in VALID_MUTABLE_FIELDS:
+            new_mutable[key] = value
+        else:
+            logger.warning(f"Ignoring non-mutable field in update: {key}")
+
+    # Create temporary surface with updated mutable fields
+    candidate_surface = SkillSurface(
+        source_path=surface.source_path,
+        workspace_path=candidate_path,
+        skill_id=surface.skill_id,
+        immutable_fields=surface.immutable_fields,
+        mutable_fields=new_mutable,
+        body_content=surface.body_content,
+    )
+
+    # Render and write
+    content = _render_skill_content(candidate_surface)
+    try:
+        candidate_path.write_text(content, encoding="utf-8")
+    except Exception as e:
+        raise TargetSurfaceError(f"Failed to write candidate: {e}")
+
+    logger.info(f"Wrote candidate: {candidate_path}")
+    return candidate_path
+
+
+def get_candidate_path(surface: SkillSurface, candidate_suffix: str = "_candidate") -> Path:
+    """Get the deterministic path for a candidate file.
+
+    Args:
+        surface: The skill surface (must have workspace_path set).
+        candidate_suffix: Suffix for the candidate filename.
+
+    Returns:
+        Path where candidate would be written.
+
+    Raises:
+        TargetSurfaceError: If no workspace_path set.
+    """
+    if surface.workspace_path is None:
+        raise TargetSurfaceError("No workspace_path set")
+
+    return surface.workspace_path.parent / f"SKILL{candidate_suffix}.md"
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _split_frontmatter(content: str) -> tuple[Optional[str], str]:
+    """Split content into frontmatter and body.
+
+    Returns:
+        (frontmatter_str, body_content)
+        frontmatter_str is None if no frontmatter found.
+    """
+    lines = content.split("\n")
+    if not lines or lines[0].strip() != "---":
+        return None, content
+
+    # Find closing ---
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            frontmatter = "\n".join(lines[1:i])
+            body = "\n".join(lines[i + 1 :])
+            return frontmatter, body
+
+    return None, content
+
+
+def _render_skill_content(surface: SkillSurface) -> str:
+    """Render a SkillSurface back to SKILL.md format.
+
+    Combines immutable and mutable fields into frontmatter,
+    preserving field order (immutable first, then mutable).
+    """
+    # Combine fields: immutable first, then mutable
+    combined = {}
+    combined.update(surface.immutable_fields)
+    combined.update(surface.mutable_fields)
+
+    # Render frontmatter
+    frontmatter = yaml.dump(combined, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+    # Combine with body
+    return f"---\n{frontmatter}---{surface.body_content}"

--- a/modules/infrastructure/autoagent_lab/tests/test_target_surface.py
+++ b/modules/infrastructure/autoagent_lab/tests/test_target_surface.py
@@ -1,0 +1,437 @@
+"""Tests for target surface IO — skill config read/copy/write.
+
+Covers:
+- Load valid skill surface
+- Preserve immutable fields
+- Extract mutable fields correctly
+- Create isolated workspace copy
+- Writing candidate does not mutate production file
+- Invalid skill path fails cleanly
+- Candidate path stays inside workspace root
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
+
+from modules.infrastructure.autoagent_lab.src.experiment_config import VALID_MUTABLE_FIELDS
+from modules.infrastructure.autoagent_lab.src.safety_gates import SafetyViolation
+from modules.infrastructure.autoagent_lab.src.target_surface import (
+    DEFAULT_WORKSPACE_ROOT,
+    SkillSurface,
+    TargetSurfaceError,
+    _render_skill_content,
+    _split_frontmatter,
+    create_workspace_copy,
+    get_candidate_path,
+    load_skill_surface,
+    write_candidate_surface,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def valid_skill_content():
+    """Full valid SKILL.md content with mutable and immutable fields."""
+    return """---
+name: test_skill
+description: A test skill for experiments
+version: 1.0.0
+author: test_team
+category: workflow
+agents: [qwen, gemma]
+domains: [testing]
+tokens_budget: 500
+---
+# Test Skill
+
+This is the body content.
+
+## WSP Compliance
+References WSP 49 and WSP 97.
+"""
+
+
+@pytest.fixture
+def minimal_skill_content():
+    """Minimal SKILL.md with only immutable fields."""
+    return """---
+name: minimal_skill
+description: Minimal skill
+---
+# Minimal
+"""
+
+
+@pytest.fixture
+def temp_workspace(tmp_path):
+    """Create a temporary workspace directory."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    return workspace
+
+
+def _write_temp_skill(content: str, tmp_path: Path, name: str = "SKILL.md") -> Path:
+    """Write skill content to a temp file."""
+    skill_path = tmp_path / name
+    skill_path.write_text(content, encoding="utf-8")
+    return skill_path
+
+
+# ---------------------------------------------------------------------------
+# SkillSurface dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestSkillSurface:
+
+    def test_to_dict(self, valid_skill_content, tmp_path):
+        path = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(path)
+        d = surface.to_dict()
+        assert "source_path" in d
+        assert "skill_id" in d
+        assert "immutable_fields" in d
+        assert "mutable_fields" in d
+        assert "body_content_length" in d
+
+    def test_workspace_path_none_initially(self, valid_skill_content, tmp_path):
+        path = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(path)
+        assert surface.workspace_path is None
+
+
+# ---------------------------------------------------------------------------
+# load_skill_surface
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSkillSurface:
+
+    def test_load_valid_skill(self, valid_skill_content, tmp_path):
+        path = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(path)
+        assert surface.skill_id == "test_skill"
+        assert surface.source_path == path.resolve()
+
+    def test_extracts_mutable_fields(self, valid_skill_content, tmp_path):
+        path = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(path)
+        # Mutable fields present in the fixture
+        assert "agents" in surface.mutable_fields
+        assert "domains" in surface.mutable_fields
+        assert "tokens_budget" in surface.mutable_fields
+        assert surface.mutable_fields["agents"] == ["qwen", "gemma"]
+
+    def test_extracts_immutable_fields(self, valid_skill_content, tmp_path):
+        path = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(path)
+        # Immutable fields
+        assert "name" in surface.immutable_fields
+        assert "description" in surface.immutable_fields
+        assert "version" in surface.immutable_fields
+        assert "author" in surface.immutable_fields
+        assert surface.immutable_fields["name"] == "test_skill"
+
+    def test_immutable_not_in_mutable(self, valid_skill_content, tmp_path):
+        path = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(path)
+        # name, version, etc. should NOT be in mutable
+        assert "name" not in surface.mutable_fields
+        assert "version" not in surface.mutable_fields
+        assert "description" not in surface.mutable_fields
+
+    def test_mutable_not_in_immutable(self, valid_skill_content, tmp_path):
+        path = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(path)
+        # agents, domains, etc. should NOT be in immutable
+        assert "agents" not in surface.immutable_fields
+        assert "domains" not in surface.immutable_fields
+
+    def test_preserves_body_content(self, valid_skill_content, tmp_path):
+        path = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(path)
+        assert "# Test Skill" in surface.body_content
+        assert "WSP 49" in surface.body_content
+
+    def test_file_not_found_raises(self):
+        with pytest.raises(TargetSurfaceError) as exc:
+            load_skill_surface(Path("/nonexistent/SKILL.md"))
+        assert "not found" in str(exc.value)
+
+    def test_no_frontmatter_raises(self, tmp_path):
+        content = "# Just markdown\nNo frontmatter here."
+        path = _write_temp_skill(content, tmp_path)
+        with pytest.raises(TargetSurfaceError) as exc:
+            load_skill_surface(path)
+        assert "frontmatter" in str(exc.value).lower()
+
+    def test_invalid_yaml_raises(self, tmp_path):
+        content = "---\nname: [unclosed\n---\n# Body"
+        path = _write_temp_skill(content, tmp_path)
+        with pytest.raises(TargetSurfaceError) as exc:
+            load_skill_surface(path)
+        assert "YAML" in str(exc.value)
+
+    def test_skill_id_from_name(self, valid_skill_content, tmp_path):
+        path = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(path)
+        assert surface.skill_id == "test_skill"
+
+    def test_skill_id_from_filename_if_no_name(self, tmp_path):
+        content = """---
+description: No name field
+---
+# Body
+"""
+        path = _write_temp_skill(content, tmp_path, "my_skill.md")
+        surface = load_skill_surface(path)
+        assert surface.skill_id == "my_skill"
+
+
+# ---------------------------------------------------------------------------
+# create_workspace_copy
+# ---------------------------------------------------------------------------
+
+
+class TestCreateWorkspaceCopy:
+
+    def test_creates_workspace_copy(self, valid_skill_content, tmp_path, temp_workspace):
+        source = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(source)
+        copied = create_workspace_copy(surface, workspace_root=temp_workspace)
+
+        assert copied.workspace_path is not None
+        assert copied.workspace_path.exists()
+        assert "workspace" in str(copied.workspace_path)
+
+    def test_preserves_source_path(self, valid_skill_content, tmp_path, temp_workspace):
+        source = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(source)
+        copied = create_workspace_copy(surface, workspace_root=temp_workspace)
+
+        # Source path is preserved
+        assert copied.source_path == surface.source_path
+
+    def test_workspace_content_matches(self, valid_skill_content, tmp_path, temp_workspace):
+        source = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(source)
+        copied = create_workspace_copy(surface, workspace_root=temp_workspace)
+
+        # Read workspace file
+        workspace_content = copied.workspace_path.read_text(encoding="utf-8")
+        assert "test_skill" in workspace_content
+        assert "# Test Skill" in workspace_content
+
+    def test_deterministic_experiment_id(self, valid_skill_content, tmp_path, temp_workspace):
+        source = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(source)
+
+        # Same source path should produce same experiment_id
+        copy1 = create_workspace_copy(surface, workspace_root=temp_workspace)
+        # Note: calling again will use same dir since it's deterministic from path hash
+        assert copy1.workspace_path.parent.name.startswith("exp_")
+
+    def test_custom_experiment_id(self, valid_skill_content, tmp_path, temp_workspace):
+        source = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(source)
+        copied = create_workspace_copy(
+            surface, workspace_root=temp_workspace, experiment_id="my_experiment"
+        )
+
+        assert "my_experiment" in str(copied.workspace_path)
+
+    def test_does_not_modify_production(self, valid_skill_content, tmp_path, temp_workspace):
+        source = _write_temp_skill(valid_skill_content, tmp_path)
+        original_content = source.read_text()
+        surface = load_skill_surface(source)
+        create_workspace_copy(surface, workspace_root=temp_workspace)
+
+        # Production file unchanged
+        assert source.read_text() == original_content
+
+
+# ---------------------------------------------------------------------------
+# write_candidate_surface
+# ---------------------------------------------------------------------------
+
+
+class TestWriteCandidateSurface:
+
+    def test_writes_candidate_file(self, valid_skill_content, tmp_path, temp_workspace):
+        source = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(source)
+        surface = create_workspace_copy(surface, workspace_root=temp_workspace)
+
+        candidate_path = write_candidate_surface(surface, {"agents": ["qwen"]})
+        assert candidate_path.exists()
+        assert "candidate" in candidate_path.name
+
+    def test_updates_mutable_fields(self, valid_skill_content, tmp_path, temp_workspace):
+        source = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(source)
+        surface = create_workspace_copy(surface, workspace_root=temp_workspace)
+
+        candidate_path = write_candidate_surface(
+            surface, {"agents": ["haiku"], "tokens_budget": 1000}
+        )
+        content = candidate_path.read_text()
+        assert "haiku" in content
+        assert "1000" in content
+
+    def test_preserves_immutable_fields(self, valid_skill_content, tmp_path, temp_workspace):
+        source = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(source)
+        surface = create_workspace_copy(surface, workspace_root=temp_workspace)
+
+        candidate_path = write_candidate_surface(surface, {"agents": ["haiku"]})
+        content = candidate_path.read_text()
+        # Immutable fields still present
+        assert "test_skill" in content  # name
+        assert "1.0.0" in content  # version
+        assert "test_team" in content  # author
+
+    def test_ignores_non_mutable_fields(self, valid_skill_content, tmp_path, temp_workspace):
+        source = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(source)
+        surface = create_workspace_copy(surface, workspace_root=temp_workspace)
+
+        # Try to update an immutable field
+        candidate_path = write_candidate_surface(
+            surface, {"name": "hacked_name", "agents": ["haiku"]}
+        )
+        content = candidate_path.read_text()
+        # name should NOT be changed
+        assert "hacked_name" not in content
+        assert "test_skill" in content  # Original name preserved
+
+    def test_requires_workspace_path(self, valid_skill_content, tmp_path):
+        source = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(source)
+
+        # No workspace_path set
+        with pytest.raises(TargetSurfaceError) as exc:
+            write_candidate_surface(surface, {"agents": ["qwen"]})
+        assert "workspace_path" in str(exc.value)
+
+    def test_candidate_path_deterministic(self, valid_skill_content, tmp_path, temp_workspace):
+        source = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(source)
+        surface = create_workspace_copy(surface, workspace_root=temp_workspace)
+
+        path1 = get_candidate_path(surface)
+        path2 = get_candidate_path(surface)
+        assert path1 == path2
+
+    def test_production_file_unchanged(self, valid_skill_content, tmp_path, temp_workspace):
+        source = _write_temp_skill(valid_skill_content, tmp_path)
+        original_content = source.read_text()
+        surface = load_skill_surface(source)
+        surface = create_workspace_copy(surface, workspace_root=temp_workspace)
+        write_candidate_surface(surface, {"agents": ["opus"]})
+
+        # Production file still has original content
+        assert source.read_text() == original_content
+        assert "qwen" in original_content  # Original agents
+        assert "opus" not in original_content  # Changed agents not in production
+
+
+# ---------------------------------------------------------------------------
+# Workspace isolation
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceIsolation:
+
+    def test_candidate_inside_workspace(self, valid_skill_content, tmp_path, temp_workspace):
+        source = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(source)
+        surface = create_workspace_copy(surface, workspace_root=temp_workspace)
+        candidate_path = write_candidate_surface(surface, {"agents": ["qwen"]})
+
+        # Candidate is inside workspace
+        assert str(temp_workspace) in str(candidate_path)
+
+
+# ---------------------------------------------------------------------------
+# Mutable fields boundary
+# ---------------------------------------------------------------------------
+
+
+class TestMutableFieldsBoundary:
+
+    def test_valid_mutable_fields_match_config(self):
+        """Verify our mutable fields match experiment_config.py."""
+        expected = {"agents", "wsp_chain", "domains", "tokens_budget", "prompt"}
+        assert VALID_MUTABLE_FIELDS == expected
+
+    def test_all_mutable_fields_extracted(self, tmp_path):
+        """Test skill with all possible mutable fields."""
+        content = """---
+name: full_mutable
+description: Has all mutable fields
+agents: [qwen]
+wsp_chain: [50, 97]
+domains: [testing]
+tokens_budget: 1000
+prompt: "Custom prompt text"
+---
+# Body
+"""
+        path = _write_temp_skill(content, tmp_path)
+        surface = load_skill_surface(path)
+
+        assert "agents" in surface.mutable_fields
+        assert "wsp_chain" in surface.mutable_fields
+        assert "domains" in surface.mutable_fields
+        assert "tokens_budget" in surface.mutable_fields
+        assert "prompt" in surface.mutable_fields
+        assert len(surface.mutable_fields) == 5
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSplitFrontmatter:
+
+    def test_splits_valid(self):
+        content = "---\nname: test\n---\n# Body"
+        fm, body = _split_frontmatter(content)
+        assert fm == "name: test"
+        assert "# Body" in body
+
+    def test_no_frontmatter(self):
+        content = "# Just markdown"
+        fm, body = _split_frontmatter(content)
+        assert fm is None
+        assert body == content
+
+    def test_unclosed_frontmatter(self):
+        content = "---\nname: test\n# No closing"
+        fm, body = _split_frontmatter(content)
+        assert fm is None
+
+
+class TestRenderSkillContent:
+
+    def test_renders_complete_skill(self, valid_skill_content, tmp_path):
+        source = _write_temp_skill(valid_skill_content, tmp_path)
+        surface = load_skill_surface(source)
+        rendered = _render_skill_content(surface)
+
+        assert rendered.startswith("---\n")
+        assert "name: test_skill" in rendered
+        assert "# Test Skill" in rendered


### PR DESCRIPTION
## Summary
Rescue AutoAgent Lab Layer 3 target-surface I/O from accumulated branch.

## Origin
- Source: feat/pfmall-pwa-hardening (ACCUMULATED_SLICES)
- Commit: d0de6ef37
- Original author: Worker AJ

## Files
- modules/infrastructure/autoagent_lab/src/target_surface.py (314 lines)
- modules/infrastructure/autoagent_lab/tests/test_target_surface.py (437 lines)
- INTERFACE.md, ModLog.md, README.md updates

## Tests
33 passed

## Purpose
Read production skill configs, create isolated workspace copies, write candidate mutations. Production files NEVER modified.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>