### PR TITLE
docs(pfmall): propagate p.fMALL AI interaction space identity

### DIFF
--- a/modules/foundups/ModLog.md
+++ b/modules/foundups/ModLog.md
@@ -150,6 +150,37 @@
 
 ---
 
+### 2026-04-22 - p.fMALL Identity Propagation (W2: PFMALL-IDENTITY-PROPAGATION)
+
+**By:** 0102 (W2) — **Slice:** `PFMALL-IDENTITY-PROPAGATION`
+**WSP References:** WSP 97 (Truth)
+
+**Updated** (12 architecture docs — identity statement added to Section 1 Purpose):
+- `PFMALL_SHELL_CONTRACT.md`
+- `PFMALL_FOUNDUP_MANIFEST_SCHEMA.md`
+- `PFMALL_ROUTING_DISCOVERY_MODEL.md`
+- `PFMALL_DATA_ISOLATION_MODEL.md`
+- `PFMALL_VIDEO_MALL_RUNTIME_FOUNDATION_2026-04-02.md`
+- `PFMALL_MALL_NAVIGATION_CONTRACT.md`
+- `PFMALL_STATE_OVERLAY_CONTRACT.md`
+- `PFMALL_EXTERNAL_FOUNDUP_ROUTE_CONTRACT.md`
+- `PFMALL_MEDIA_DELIVERY_CONTRACT.md`
+- `PFMALL_FOUNDUP_ENTRY_AND_STAKE_GATE_CONTRACT.md`
+- `PFMALL_FULLSCREEN_PLAYER_CONTRACT.md`
+- `PFMALL_VIDEO_MALL_CATALOG_SCHEMA.md`
+
+**Updated** (4 code entry points — identity reference added to module docstrings):
+- `modules/foundups/pfmall/__init__.py`
+- `modules/foundups/pfmall/shell_core.py`
+- `public/member/js/shell-bridge-interceptor.js`
+- `public/member/member-sw.js`
+
+**Identity statement**: "p.fMALL is an AI interaction space — a new way of interacting with AI and the world. Video is the default surface, but the paradigm extends to any content type: documents, community, FoundUps. The same interaction model (pinch, zoom, navigate) works everywhere, with AI mediating all engagement."
+
+**Finding**: No pfmall doc previously defined what p.fMALL IS. All docs described plumbing (shell, routing, isolation, taxonomy). Identity was absent from the entire doc suite and codebase. Now concatenated across all 12 architecture docs and 4 key code entry points.
+
+---
+
 ### 2026-04-21 - PFMALL Routing Discovery Model WSP 97 reconciliation
 
 **By:** 0102 (W3) — **Slice:** `PFMALL-ROUTING-RECON`  

--- a/modules/foundups/docs/PFMALL_DATA_ISOLATION_MODEL.md
+++ b/modules/foundups/docs/PFMALL_DATA_ISOLATION_MODEL.md
@@ -31,7 +31,9 @@
 
 ## 1. Purpose
 
-Define how p.fMALL isolates FoundUp data from each other, encrypts data at rest, and monitors inter-component communication for anomalous patterns.
+p.fMALL is an **AI interaction space** — a new way of interacting with AI and the world. Video is the default surface, but the paradigm extends to any content type: documents, community, FoundUps. The same interaction model (pinch, zoom, navigate) works everywhere, with AI mediating all engagement. Built for FoundUps first, with hooks into all content. Videos are the catalog layer — they tell each FoundUp's story.
+
+This document defines how p.fMALL isolates FoundUp data from each other, encrypts data at rest, and monitors inter-component communication for anomalous patterns.
 
 ---
 

--- a/modules/foundups/docs/PFMALL_EXTERNAL_FOUNDUP_ROUTE_CONTRACT.md
+++ b/modules/foundups/docs/PFMALL_EXTERNAL_FOUNDUP_ROUTE_CONTRACT.md
@@ -8,7 +8,9 @@
 
 ## 1. Purpose
 
-Define the runtime boundary between the installed p.fMALL shell and FoundUps
+p.fMALL is an **AI interaction space** — a new way of interacting with AI and the world. Video is the default surface, but the paradigm extends to any content type: documents, community, FoundUps. The same interaction model (pinch, zoom, navigate) works everywhere, with AI mediating all engagement. Built for FoundUps first, with hooks into all content. Videos are the catalog layer — they tell each FoundUp's story.
+
+This document defines the runtime boundary between the installed p.fMALL shell and FoundUps
 that may live in separate repositories.
 
 This note locks the rule that repo separation does not require a fragmented user

--- a/modules/foundups/docs/PFMALL_FOUNDUP_ENTRY_AND_STAKE_GATE_CONTRACT.md
+++ b/modules/foundups/docs/PFMALL_FOUNDUP_ENTRY_AND_STAKE_GATE_CONTRACT.md
@@ -10,7 +10,9 @@
 
 ## 1. Purpose
 
-Define the entry flow from Mall discovery through gated FoundUp interior access.
+p.fMALL is an **AI interaction space** — a new way of interacting with AI and the world. Video is the default surface, but the paradigm extends to any content type: documents, community, FoundUps. The same interaction model (pinch, zoom, navigate) works everywhere, with AI mediating all engagement. Built for FoundUps first, with hooks into all content. Videos are the catalog layer — they tell each FoundUp's story.
+
+This document defines the entry flow from Mall discovery through gated FoundUp interior access.
 
 This contract specifies:
 - Entry gestures from the Mall

--- a/modules/foundups/docs/PFMALL_FOUNDUP_MANIFEST_SCHEMA.md
+++ b/modules/foundups/docs/PFMALL_FOUNDUP_MANIFEST_SCHEMA.md
@@ -10,6 +10,8 @@
 
 ## 1. Purpose
 
+p.fMALL is an **AI interaction space** — a new way of interacting with AI and the world. Video is the default surface, but the paradigm extends to any content type: documents, community, FoundUps. The same interaction model (pinch, zoom, navigate) works everywhere, with AI mediating all engagement. Built for FoundUps first, with hooks into all content. Videos are the catalog layer — they tell each FoundUp's story.
+
 Every FoundUp that runs inside p.fMALL declares itself through a `foundup_manifest.json`. This manifest is the contract between a FoundUp and the shell. It tells the shell what the FoundUp needs, what it provides, and how to load it.
 
 ### 1.1 Relationship to Video Mall Catalog

--- a/modules/foundups/docs/PFMALL_FULLSCREEN_PLAYER_CONTRACT.md
+++ b/modules/foundups/docs/PFMALL_FULLSCREEN_PLAYER_CONTRACT.md
@@ -9,7 +9,9 @@
 
 ## 1. Purpose
 
-Define the fullscreen video player and queue rail contract for the admitted p.fMALL.
+p.fMALL is an **AI interaction space** — a new way of interacting with AI and the world. Video is the default surface, but the paradigm extends to any content type: documents, community, FoundUps. The same interaction model (pinch, zoom, navigate) works everywhere, with AI mediating all engagement. Built for FoundUps first, with hooks into all content. Videos are the catalog layer — they tell each FoundUp's story.
+
+This document defines the fullscreen video player and queue rail contract for the admitted p.fMALL.
 
 The fullscreen player is a dedicated video viewing layer that:
 - Displays one video at a time from a FoundUp-constrained queue

--- a/modules/foundups/docs/PFMALL_MALL_NAVIGATION_CONTRACT.md
+++ b/modules/foundups/docs/PFMALL_MALL_NAVIGATION_CONTRACT.md
@@ -8,6 +8,8 @@
 
 ## 1. Purpose
 
+p.fMALL is an **AI interaction space** — a new way of interacting with AI and the world. Video is the default surface, but the paradigm extends to any content type: documents, community, FoundUps. The same interaction model (pinch, zoom, navigate) works everywhere, with AI mediating all engagement. Built for FoundUps first, with hooks into all content. Videos are the catalog layer — they tell each FoundUp's story.
+
 This document defines the Mall as **fixed navigation infrastructure**.
 
 The Mall is not a SoftProto customization surface.

--- a/modules/foundups/docs/PFMALL_MEDIA_DELIVERY_CONTRACT.md
+++ b/modules/foundups/docs/PFMALL_MEDIA_DELIVERY_CONTRACT.md
@@ -10,7 +10,9 @@
 
 ## 1. Purpose
 
-Define the runtime rules for media delivery in the Video Mall:
+p.fMALL is an **AI interaction space** — a new way of interacting with AI and the world. Video is the default surface, but the paradigm extends to any content type: documents, community, FoundUps. The same interaction model (pinch, zoom, navigate) works everywhere, with AI mediating all engagement. Built for FoundUps first, with hooks into all content. Videos are the catalog layer — they tell each FoundUp's story.
+
+This document defines the runtime rules for media delivery in the Video Mall:
 - poster images on FoundUp tiles
 - video thumbnails
 - embed sources

--- a/modules/foundups/docs/PFMALL_ROUTING_DISCOVERY_MODEL.md
+++ b/modules/foundups/docs/PFMALL_ROUTING_DISCOVERY_MODEL.md
@@ -34,7 +34,9 @@ This document defines the **target architecture** for p.fMALL routing. Current i
 
 ## 1. Purpose
 
-Define how p.fMALL routes users to FoundUps, how FoundUps are discovered, and how navigation works between the shell and loaded FoundUps.
+p.fMALL is an **AI interaction space** — a new way of interacting with AI and the world. Video is the default surface, but the paradigm extends to any content type: documents, community, FoundUps. The same interaction model (pinch, zoom, navigate) works everywhere, with AI mediating all engagement. Built for FoundUps first, with hooks into all content. Videos are the catalog layer — they tell each FoundUp's story.
+
+This document defines how p.fMALL routes users to FoundUps, how FoundUps are discovered, and how navigation works between the shell and loaded FoundUps.
 
 Companion note:
 - `PFMALL_EXTERNAL_FOUNDUP_ROUTE_CONTRACT.md` clarifies the route/runtime

--- a/modules/foundups/docs/PFMALL_SHELL_CONTRACT.md
+++ b/modules/foundups/docs/PFMALL_SHELL_CONTRACT.md
@@ -9,7 +9,11 @@
 
 ## 1. Purpose
 
-p.fMALL is a PWA shell/gateway that hosts, discovers, and routes into multiple FoundUps. The shell is a **thin platform layer** — it provides discovery, navigation, auth, and shared services. It does NOT own FoundUp business logic, data, or UI.
+p.fMALL is an **AI interaction space** — a new way of interacting with AI and the world. Video is the default surface, but the paradigm extends to any content type: documents, community, FoundUps. The same interaction model (pinch, zoom, navigate) works everywhere, with AI mediating all engagement. Built for FoundUps first, with hooks into all content. Videos are the catalog layer — they tell each FoundUp's story.
+
+The shell is p.fMALL's **thin platform layer** — it provides discovery, navigation, auth, and shared services. It does NOT own FoundUp business logic, data, or UI.
+
+**Registry Boundary**: Canonical FoundUp identity is registry-backed; pFMALL catalogs render and route FoundUps but do not replace the canonical FoundUp registry. See `docs/audits/architecture/FOUNDUP_CANONICAL_REGISTRY_POPULATION_PHASE1.md` for boundary definition.
 
 ---
 

--- a/modules/foundups/docs/PFMALL_STATE_OVERLAY_CONTRACT.md
+++ b/modules/foundups/docs/PFMALL_STATE_OVERLAY_CONTRACT.md
@@ -9,6 +9,8 @@
 
 ## 1. Purpose
 
+p.fMALL is an **AI interaction space** — a new way of interacting with AI and the world. Video is the default surface, but the paradigm extends to any content type: documents, community, FoundUps. The same interaction model (pinch, zoom, navigate) works everywhere, with AI mediating all engagement. Built for FoundUps first, with hooks into all content. Videos are the catalog layer — they tell each FoundUp's story.
+
 The state overlay is the **dynamic layer** that augments `foundup_manifest.json` with live lifecycle, health, economics, and activity data. The manifest is static identity; the overlay is live condition.
 
 ### 1.1 Why the Manifest is Insufficient

--- a/modules/foundups/docs/PFMALL_VIDEO_MALL_CATALOG_SCHEMA.md
+++ b/modules/foundups/docs/PFMALL_VIDEO_MALL_CATALOG_SCHEMA.md
@@ -11,7 +11,9 @@
 
 ## 1. Purpose
 
-This document defines the schema for `mall-video-catalog.json`, the manifest that powers the Video Mall tile field.
+p.fMALL is an **AI interaction space** — a new way of interacting with AI and the world. Video is the default surface, but the paradigm extends to any content type: documents, community, FoundUps. The same interaction model (pinch, zoom, navigate) works everywhere, with AI mediating all engagement. Built for FoundUps first, with hooks into all content. Videos are the catalog layer — they tell each FoundUp's story.
+
+This document defines the schema for `mall-video-catalog.json`, the catalog that powers the Video Mall tile field.
 
 The Video Mall Catalog is **not** the full FoundUp runtime manifest. It is a projection-optimized data structure for:
 

--- a/modules/foundups/docs/PFMALL_VIDEO_MALL_RUNTIME_FOUNDATION_2026-04-02.md
+++ b/modules/foundups/docs/PFMALL_VIDEO_MALL_RUNTIME_FOUNDATION_2026-04-02.md
@@ -9,7 +9,9 @@
 
 ## 1. Purpose
 
-Define the next correct product layer for the admitted FoundUps suite:
+p.fMALL is an **AI interaction space** — a new way of interacting with AI and the world. Video is the default surface, but the paradigm extends to any content type: documents, community, FoundUps. The same interaction model (pinch, zoom, navigate) works everywhere, with AI mediating all engagement. Built for FoundUps first, with hooks into all content. Videos are the catalog layer — they tell each FoundUp's story.
+
+This document defines the next correct product layer for the admitted FoundUps suite:
 
 - `/` = gated front door
 - `/member/` = admitted Mall

--- a/modules/foundups/pfmall/__init__.py
+++ b/modules/foundups/pfmall/__init__.py
@@ -1,6 +1,11 @@
 """
 p.fMALL Shell Core — manifest discovery, catalog, routing, overlay merge.
 
+p.fMALL is an AI interaction space for engaging with everything — video,
+documents, community, FoundUps. Video is the default catalog layer; the same
+interaction paradigm (pinch, zoom, navigate) extends to any content type,
+with AI mediating all engagement.
+
 Public API (shell core):
     create_pfmall_shell(search_paths, state_provider) -> PfmallShell
     load_manifest(source) -> FoundUpManifest | None

--- a/modules/foundups/pfmall/shell_core.py
+++ b/modules/foundups/pfmall/shell_core.py
@@ -3,6 +3,11 @@
 """
 p.fMALL Shell Core Scaffold
 
+p.fMALL is an AI interaction space for engaging with everything — video,
+documents, community, FoundUps. Video is the default catalog layer; the same
+interaction paradigm (pinch, zoom, navigate) extends to any content type,
+with AI mediating all engagement.
+
 Minimal shell runtime providing manifest discovery, catalog assembly,
 route resolution, and manifest+overlay merge. Non-UI scaffold only.
 

--- a/public/member/js/shell-bridge-interceptor.js
+++ b/public/member/js/shell-bridge-interceptor.js
@@ -1,6 +1,11 @@
 /**
  * Shell Bridge Interceptor
  *
+ * p.fMALL is an AI interaction space for engaging with everything — video,
+ * documents, community, FoundUps. Video is the default catalog layer; the same
+ * interaction paradigm (pinch, zoom, navigate) extends to any content type,
+ * with AI mediating all engagement.
+ *
  * p.fMALL shell-side postMessage listener for external FoundUp iframes.
  * Intercepts `agent_request` events and dispatches to backend, then
  * posts `agent_response` back to the origin iframe.

--- a/public/member/member-sw.js
+++ b/public/member/member-sw.js
@@ -1,4 +1,10 @@
 // p.fMALL Member Service Worker
+//
+// p.fMALL is an AI interaction space for engaging with everything — video,
+// documents, community, FoundUps. Video is the default catalog layer; the same
+// interaction paradigm (pinch, zoom, navigate) extends to any content type,
+// with AI mediating all engagement.
+//
 // Caches shell assets for installability and fast reload.
 // Auth flows (Clerk, Firebase) are NEVER cached.
 // Catalog is network-first with cache fallback.


### PR DESCRIPTION
## Summary

- Propagate the p.fMALL identity statement across all architecture docs and key code entry points
- p.fMALL is an **AI interaction space** — a new way of interacting with AI and the world. Video is the default surface, but the paradigm extends to any content type: documents, community, FoundUps. Same interaction model (pinch, zoom, navigate) everywhere, with AI mediating all engagement
- No pfmall doc previously defined what p.fMALL IS — all described plumbing (shell, routing, isolation, taxonomy). This PR fixes that gap.

### Files updated (17)

**12 architecture docs** (identity in Section 1 Purpose):
- PFMALL_SHELL_CONTRACT.md
- PFMALL_FOUNDUP_MANIFEST_SCHEMA.md
- PFMALL_ROUTING_DISCOVERY_MODEL.md
- PFMALL_DATA_ISOLATION_MODEL.md
- PFMALL_VIDEO_MALL_RUNTIME_FOUNDATION_2026-04-02.md
- PFMALL_MALL_NAVIGATION_CONTRACT.md
- PFMALL_STATE_OVERLAY_CONTRACT.md
- PFMALL_EXTERNAL_FOUNDUP_ROUTE_CONTRACT.md
- PFMALL_MEDIA_DELIVERY_CONTRACT.md
- PFMALL_FOUNDUP_ENTRY_AND_STAKE_GATE_CONTRACT.md
- PFMALL_FULLSCREEN_PLAYER_CONTRACT.md
- PFMALL_VIDEO_MALL_CATALOG_SCHEMA.md

**4 code entry points** (identity in module docstrings):
- modules/foundups/pfmall/__init__.py
- modules/foundups/pfmall/shell_core.py
- public/member/js/shell-bridge-interceptor.js
- public/member/member-sw.js

**1 ModLog** (propagation entry)

## Slice

`PFMALL-IDENTITY-PROPAGATION` (W2, 2026-04-22)

## Test plan

- [ ] Verify identity block is consistent across all 12 docs
- [ ] Verify code docstrings don't break imports or tests
- [ ] Doc + docstring only — no behavioral changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)