### PR TITLE
feat(holoindex): HIA3 — experimental TurboQuant ONNX int8 backend

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,89 @@
 # HoloIndex Package ModLog
 
+## [2026-04-23] HIA3 — TurboQuant ONNX int8 Backend (experimental, opt-in) (hia3_turboquant_onnx_backend)
+
+**Agent**: 0102 (W5)
+**WSP References**: WSP 97 (truth distinction), WSP 49 (module structure), WSP 50 (pre-action verification)
+**Status**: COMPLETE (experimental; not default-ready)
+**Depends On**: HIA-TAX1 (taxonomy — this ModLog, entry below)
+**Architect Decision**: 012 — HIA3 ships the safe backend seam only. Quality work (static calibration + real-corpus A/B) deferred to a separate TQ2-STATIC-CALIBRATION slice.
+**Branch**: `feat/hia3-turboquant-onnx-backend`
+**Worktree**: `O:/tmp/w5_hia3_turboquant_onnx` (isolated — dedicated to HIA3 to avoid the parallel-window collision that reverted the first attempt in the primary worktree).
+
+### Context
+
+HIA2 Phase 1 shipped a `TurboQuantEmbedder` stub whose `is_available()` always returned `False` and whose `encode()` raised `NotImplementedError`. HIA-TAX1 corrected the taxonomy so HIA3 could replace the stub with a real backend without overclaiming (retrieval_mode vs embedding_backend are now separate WSP 97 claims).
+
+The TQ1 benchmark (see `holo_index/scripts/benchmarks/tq1_onnx_int8_bench.py`) measured:
+
+- **Performance**: 5.6x cold start, 6.6x load, 8.8x median single-query, 4.0x smaller artifact on MiniLM-L6-v2 (fp32 → int8).
+- **Quality**: 3.65% mean cosine drift vs fp32 (above the 2% same-model threshold) and 76.7% synthetic top-1 retrieval agreement (~23% flip rate).
+
+Per 012 direction: **performance accepted, quality gated**. Ship the safe backend seam as experimental opt-in; promote to default only after static calibration and real-corpus A/B gating in a later slice.
+
+### Changes
+
+1. **`holo_index/core/turboquant_backend.py`** — stub replaced with a real ONNX Runtime int8 embedder:
+   - Optional-import guards for `onnxruntime` (not added to `holo_index/requirements.txt` as a hard dep) and `transformers` (transitively provided by `sentence-transformers>=2.2.0`).
+   - `HOLO_TURBOQUANT_MODEL_DIR` env var (default `E:/HoloIndex/models/tq1_onnx_int8/`).
+   - Tokenizer probe accepts either `tokenizer.json` (fast) or the `vocab.txt`+`tokenizer_config.json` legacy pair.
+   - `is_available()` classmethod — never raises; returns `False` on any missing precondition.
+   - `_ensure_loaded()` raises `RuntimeError` with actionable messages; HoloIndex catches and falls back.
+   - `encode(text, show_progress_bar=False)` — tokenize → ORT forward → attention-mask-weighted mean pool → L2 normalize → 1-D `float32` length 384.
+   - Module constants surface truth claims: `BACKEND_NAME="turboquant_onnx_int8"`, `BACKEND_QUALITY="experimental"`, `QUALITY_GATE="not_default_ready"`.
+
+2. **`holo_index/core/holo_index.py`** — wiring updated:
+   - `embedding_backend` now uses the canonical `BACKEND_NAME` constant (`"turboquant_onnx_int8"`, previously the placeholder `"turboquant"`).
+   - Inner try/except around `embedder._ensure_loaded()` so load failures drop cleanly to the `SentenceTransformer` fallback.
+   - Downstream branch check uses `embedding_backend.startswith("turboquant")` with isinstance guard.
+   - Taxonomy comment block extended with HIA3 note on the `experimental` / `not_default_ready` surface.
+
+3. **`holo_index/core/search_engine.py`** — quality metadata surfaced on every search response:
+   - `_BACKEND_QUALITY` and `_QUALITY_GATE` dicts map `embedding_backend` → claim.
+   - `_backend_quality()` / `_quality_gate()` helpers.
+   - Payload `metadata` dict gains `backend_quality` and `quality_gate` fields alongside the existing `retrieval_mode` / `embedding_backend`.
+
+4. **`holo_index/tests/test_turboquant_backend.py`** — stub tests replaced with a mocked-contract suite (32 tests, 31 run / 1 skipped):
+   - Module constants, duck-type marker, env-var model-dir resolution.
+   - `_tokenizer_files_present` fast / legacy / negative paths.
+   - `is_available()` seven failure-mode branches (+ defensive OSError handling).
+   - `_ensure_loaded()` five failure-mode branches with actionable `RuntimeError` matches.
+   - `encode()` contract tests with `MagicMock` ORT session + tokenizer: dtype/ndim/length, L2 normalization, `show_progress_bar` kwarg compat, input-name filtering.
+   - Construction is side-effect-free (no model I/O in `__init__`).
+   - Optional real-model smoke test gated behind `HOLO_TURBOQUANT_SMOKE=1` + artifact presence.
+
+### Default Unchanged
+
+`HOLO_USE_TURBOQUANT=0` (the default) keeps HoloIndex on the `SentenceTransformer` path, bit-identical to pre-HIA3 behavior. TurboQuant engages only when:
+
+1. `HOLO_USE_TURBOQUANT=1` is set, **and**
+2. `onnxruntime` is importable, **and**
+3. The model artifacts are present on disk at `HOLO_TURBOQUANT_MODEL_DIR`.
+
+Any failure in this chain logs a warning and falls back to `SentenceTransformer`.
+
+### Quality Caveat (WSP 97)
+
+Callers can distinguish this backend from the fp32 baseline without re-checking env vars by reading the `metadata.backend_quality` / `metadata.quality_gate` fields on every search response. A `backend_quality="experimental"` / `quality_gate="not_default_ready"` result means the retrieval is running on the int8 backend and has measured drift vs fp32; downstream consumers should gate automation and ranking decisions accordingly until the calibration slice closes the gap.
+
+### Out of Scope (Explicitly Deferred)
+
+- Static calibration of the int8 quantization scales (TQ2-STATIC-CALIBRATION slice).
+- Real-corpus A/B gating on the live `navigation_code` / `navigation_wsp` collections.
+- Flipping the default to TurboQuant.
+- Full reindex of ChromaDB collections (dim unchanged at 384, so existing collections remain compatible).
+
+### Validation
+
+- `python -m pytest holo_index/tests/test_turboquant_backend.py -v` → **31 passed, 1 skipped**.
+- `python -m pytest holo_index/tests/test_fx1_holoindex_truth.py -v` → **11 passed** (metadata surface unregressed).
+
+### Forensics / Worktree Note
+
+HIA3 attempt #1 in the primary worktree (`O:/Foundups-Agent`) reverted to HEAD before commit — root cause: parallel-window collision (another window checked out a different branch in the same shared worktree within 32 seconds of HIA3 branch creation; reflog confirms 10+ subsequent branch switches). Remediation: HIA3 reapplied in a dedicated isolated worktree at `O:/tmp/w5_hia3_turboquant_onnx`. Worktree stays intact until the PR is merged.
+
+---
+
 ## [2026-04-21] HIA-TAX1 — Retrieval Mode / Embedding Backend Taxonomy Correction (hia_tax1_retrieval_mode_taxonomy_correction)
 
 **Agent**: 0102 (W5)

--- a/holo_index/core/holo_index.py
+++ b/holo_index/core/holo_index.py
@@ -208,9 +208,16 @@ class HoloIndex:
         # retrieval_mode="turboquant" value) overclaims the mode.
         #
         #   retrieval_mode    ∈ {semantic, lexical, failed}
-        #   embedding_backend ∈ {sentence_transformers, turboquant, none}
+        #   embedding_backend ∈ {sentence_transformers, turboquant_onnx_int8, none, unknown}
         #
         # "none" covers both lexical (no embedder) and failed (nothing loaded).
+        # HIA3 (2026-04-23): TurboQuant became a real backend (ORT int8).
+        # Its canonical label is "turboquant_onnx_int8" (see
+        # holo_index.core.turboquant_backend.BACKEND_NAME). HIA3 is an
+        # experimental opt-in — TQ1 benchmark measured 3.65% cosine drift
+        # and 76.7% top-1 agreement; static calibration is required before
+        # default promotion. search_engine.py surfaces this via
+        # backend_quality="experimental" and quality_gate="not_default_ready".
         self.retrieval_mode = "failed"  # Default until proven otherwise
         self.embedding_backend = "none"
 
@@ -226,25 +233,43 @@ class HoloIndex:
             self.retrieval_mode = "lexical"
             self.embedding_backend = "none"
         else:
-            # HIA2 Phase 1 / HIA-TAX1: optional TurboQuant backend (opt-in via
+            # HIA3 / HIA-TAX1: optional TurboQuant ONNX int8 backend (opt-in via
             # HOLO_USE_TURBOQUANT=1). TurboQuant is a *semantic* backend; when
-            # active, retrieval_mode="semantic" and embedding_backend="turboquant".
-            # Phase 1 scaffold is_available() is False, so this path logs and
-            # falls through to the SentenceTransformer backend.
+            # active, retrieval_mode="semantic" and
+            # embedding_backend="turboquant_onnx_int8". Experimental — TQ1
+            # measured 3.65% cosine drift vs fp32 and 76.7% top-1 agreement.
+            # search_engine.py surfaces backend_quality="experimental" and
+            # quality_gate="not_default_ready" on the response metadata.
+            # On any failure (dep missing, artifact missing, load error), we
+            # fall through to the SentenceTransformer backend without raising.
             if _turboquant_enabled():
                 try:
-                    from .turboquant_backend import TurboQuantEmbedder
+                    from .turboquant_backend import (
+                        TurboQuantEmbedder,
+                        BACKEND_NAME as _TQ_BACKEND_NAME,
+                    )
                     if TurboQuantEmbedder.is_available():
                         self._log_agent_action(
-                            "HOLO_USE_TURBOQUANT=1 -> loading TurboQuant backend (semantic)",
+                            "HOLO_USE_TURBOQUANT=1 -> loading TurboQuant backend "
+                            "(semantic, experimental, not_default_ready)",
                             "MODEL",
                         )
-                        self.model = TurboQuantEmbedder()
-                        self.retrieval_mode = "semantic"
-                        self.embedding_backend = "turboquant"
+                        try:
+                            embedder = TurboQuantEmbedder()
+                            embedder._ensure_loaded()
+                            self.model = embedder
+                            self.retrieval_mode = "semantic"
+                            self.embedding_backend = _TQ_BACKEND_NAME
+                        except Exception as load_err:
+                            self._log_agent_action(
+                                f"TurboQuant load failed ({load_err}); "
+                                "falling back to SentenceTransformer",
+                                "WARN",
+                            )
                     else:
                         self._log_agent_action(
-                            "TurboQuant not yet implemented; falling back to SentenceTransformer",
+                            "TurboQuant not available (dep/artifacts missing); "
+                            "falling back to SentenceTransformer",
                             "WARN",
                         )
                 except Exception as e:
@@ -253,7 +278,11 @@ class HoloIndex:
                         "WARN",
                     )
 
-            if getattr(self, "model", None) is not None and self.embedding_backend == "turboquant":
+            if (
+                getattr(self, "model", None) is not None
+                and isinstance(self.embedding_backend, str)
+                and self.embedding_backend.startswith("turboquant")
+            ):
                 # TurboQuant loaded successfully; skip SentenceTransformer path entirely.
                 pass
             else:

--- a/holo_index/core/search_engine.py
+++ b/holo_index/core/search_engine.py
@@ -37,6 +37,43 @@ def _tokenize_query(query: str) -> List[str]:
     return [token for token in re.findall(r"[a-z0-9_]+", query.lower()) if token]
 
 
+# ---------------------------------------------------------------------------
+# HIA3 (2026-04-23): backend quality taxonomy (WSP 97 truth distinction).
+#
+# These dicts map embedding_backend -> quality claim. They are surfaced on
+# every search response's metadata so callers can distinguish a
+# default-ready backend (SentenceTransformer fp32) from an experimental
+# opt-in backend (TurboQuant ONNX int8) without re-checking env vars.
+#
+#   backend_quality ∈ {production, experimental, n/a, unknown}
+#   quality_gate    ∈ {default_ready, not_default_ready, n/a, unknown}
+#
+# "n/a" is used when no embedder is loaded (lexical/failed retrieval).
+# ---------------------------------------------------------------------------
+
+_BACKEND_QUALITY: Dict[str, str] = {
+    "sentence_transformers": "production",
+    "turboquant_onnx_int8": "experimental",
+    "none": "n/a",
+}
+
+_QUALITY_GATE: Dict[str, str] = {
+    "sentence_transformers": "default_ready",
+    "turboquant_onnx_int8": "not_default_ready",
+    "none": "n/a",
+}
+
+
+def _backend_quality(backend: str) -> str:
+    """Return the quality claim for *backend*; 'unknown' if not registered."""
+    return _BACKEND_QUALITY.get(backend, "unknown")
+
+
+def _quality_gate(backend: str) -> str:
+    """Return the default-promotion gate for *backend*; 'unknown' if not registered."""
+    return _QUALITY_GATE.get(backend, "unknown")
+
+
 def _is_symbol_query(query: str) -> bool:
     """Heuristic: detect symbol-like queries (identifiers, paths, function calls)."""
     if not query:
@@ -570,9 +607,20 @@ def execute_search(
                 "cached": False,
                 # FX1-D: Surface retrieval mode in search results.
                 # HIA-TAX1: retrieval_mode describes behavior (semantic/lexical/failed);
-                # embedding_backend describes implementation (sentence_transformers/turboquant/none).
+                # embedding_backend describes implementation
+                # (sentence_transformers / turboquant_onnx_int8 / none).
+                # HIA3: backend_quality + quality_gate describe *truth-level*
+                # claims about that backend (WSP 97). TurboQuant is
+                # experimental / not_default_ready until static calibration
+                # closes the 3.65% cosine-drift gap.
                 "retrieval_mode": getattr(holo, "retrieval_mode", "unknown"),
                 "embedding_backend": getattr(holo, "embedding_backend", "unknown"),
+                "backend_quality": _backend_quality(
+                    getattr(holo, "embedding_backend", "unknown")
+                ),
+                "quality_gate": _quality_gate(
+                    getattr(holo, "embedding_backend", "unknown")
+                ),
             },
         }
 

--- a/holo_index/core/turboquant_backend.py
+++ b/holo_index/core/turboquant_backend.py
@@ -1,68 +1,275 @@
 # -*- coding: utf-8 -*-
-"""TurboQuant Embedding Backend — Scaffold (HIA2 Phase 1).
+"""TurboQuant Embedding Backend — ONNX Runtime int8 (HIA3 beta).
 
 Opt-in int8-quantized embedding backend for HoloIndex. Selected at boot via
-``HOLO_USE_TURBOQUANT=1``. When unavailable (this scaffold always reports
-unavailable until a real backend is wired by a later slice), ``HoloIndex``
-falls back to the ``SentenceTransformer`` path.
+``HOLO_USE_TURBOQUANT=1``. When unavailable (dependency or model artifacts
+missing), ``HoloIndex`` falls back to the ``SentenceTransformer`` path.
 
-Contract the concrete backend MUST satisfy (derived from current call-sites in
-``holo_index/core/holo_index.py`` and ``holo_index/core/search_engine.py``):
+HIA3 status (WSP 97 truth distinction):
+
+  * **Performance accepted** — TQ1 benchmark measured 5.6x cold-start,
+    6.6x load, 8.8x single-query median, 4.0x smaller artifact vs the
+    fp32 ``SentenceTransformer`` baseline on the same MiniLM-L6-v2 model.
+  * **Quality gated** — TQ1 measured 3.65% mean cosine drift vs fp32
+    (above the 2% same-model threshold) and 76.7% synthetic top-1
+    retrieval agreement (~23% flip rate). This backend is therefore
+    marked ``backend_quality="experimental"`` and
+    ``quality_gate="not_default_ready"``. Static calibration and
+    real-corpus A/B gating are TQ2 / HIA-followup slice work; HIA3
+    builds only the safe backend seam.
+  * **Default unchanged** — ``HOLO_USE_TURBOQUANT=0`` (the default)
+    keeps HoloIndex on the ``SentenceTransformer`` path, bit-identical
+    to pre-HIA2 behavior.
+
+Dependencies:
+
+  * ``onnxruntime`` — optional runtime dep. Imported lazily inside
+    ``is_available()`` / ``_ensure_loaded()``; import failure returns
+    ``False`` rather than raising. Not added to
+    ``holo_index/requirements.txt`` as a hard dep in HIA3.
+  * ``transformers`` — already transitively required via
+    ``sentence-transformers>=2.2.0``; used for the MiniLM tokenizer.
+
+Model artifacts:
+
+  * Location: ``HOLO_TURBOQUANT_MODEL_DIR`` (env), default
+    ``E:/HoloIndex/models/tq1_onnx_int8/``.
+  * Required files: ``model_int8.onnx`` plus tokenizer files
+    (``tokenizer.json`` or the ``vocab.txt`` + ``tokenizer_config.json``
+    pair). Missing files -> ``is_available()`` returns ``False``.
+  * Artifacts are NOT committed to the repo. They are produced by
+    ``holo_index/scripts/benchmarks/tq1_onnx_int8_bench.py`` or any
+    equivalent export pipeline.
+
+Contract (must stay consistent with current ``HoloIndex._get_embedding``
+call-site in ``holo_index/core/holo_index.py``):
 
   * ``encode(text: str, show_progress_bar: bool = False) -> numpy.ndarray``
-      Must return a 1-D ``float32`` array with the same dimensionality as the
-      ChromaDB-stored vectors. All collections were populated with
-      ``all-MiniLM-L6-v2`` at **384 dims**; changing the dim requires a full
-      reindex of ``navigation_code``, ``navigation_wsp``, ``navigation_tests``,
-      ``navigation_skills``, and ``navigation_symbols``. This scaffold does
-      not change the dim.
+      Returns a 1-D ``float32`` array of length ``EMBEDDING_DIM`` (384).
+      All ChromaDB collections were populated with ``all-MiniLM-L6-v2``
+      at 384 dims; changing the dim would require a full reindex of
+      ``navigation_code``, ``navigation_wsp``, ``navigation_tests``,
+      ``navigation_skills``, and ``navigation_symbols``. This backend
+      preserves the dim.
 
 B1 (HIA1 finding): 384-dim float32 vector contract is pinned.
 B4 (HIA1 finding): ``HoloIndex`` caches the loaded model in a class-level
-    ``_shared_state``; swapping backends at runtime is not supported. Restart
-    the process or reset ``HoloIndex._initialized`` to switch backends.
+    ``_shared_state``; swapping backends at runtime is not supported.
+    Restart the process or reset ``HoloIndex._initialized`` to switch.
 
-WSP Compliance: WSP 97 (truth distinction), WSP 49 (module structure).
+WSP Compliance: WSP 97 (truth distinction), WSP 49 (module structure),
+WSP 50 (pre-action verification — dependency policy explicit).
 """
 from __future__ import annotations
 
-from typing import Any
+import logging
+import os
+from pathlib import Path
+from typing import Any, Optional
 
 
 EMBEDDING_DIM = 384  # must match ChromaDB-stored vectors; see B1 above
+DEFAULT_MODEL_DIR = "E:/HoloIndex/models/tq1_onnx_int8"
+MODEL_FILENAME = "model_int8.onnx"
+
+# Metadata surfaced through search_engine.py (WSP 97 truth distinction).
+BACKEND_NAME = "turboquant_onnx_int8"
+BACKEND_QUALITY = "experimental"
+QUALITY_GATE = "not_default_ready"
+
+_logger = logging.getLogger(__name__)
+
+
+def _resolve_model_dir() -> Path:
+    """Return the configured model directory.
+
+    Honors ``HOLO_TURBOQUANT_MODEL_DIR`` env var; falls back to
+    ``DEFAULT_MODEL_DIR``. This function does NOT check for existence —
+    call ``_tokenizer_files_present()`` and the ``MODEL_FILENAME`` check
+    separately so ``is_available()`` can return False cleanly.
+    """
+    return Path(os.getenv("HOLO_TURBOQUANT_MODEL_DIR", DEFAULT_MODEL_DIR))
+
+
+def _tokenizer_files_present(model_dir: Path) -> bool:
+    """Check for the tokenizer artifact set the MiniLM tokenizer needs.
+
+    HuggingFace tokenizers can load from either:
+      * a ``tokenizer.json`` fast-tokenizer file, OR
+      * the legacy ``vocab.txt`` + ``tokenizer_config.json`` pair.
+
+    We accept either combination. Missing -> backend unavailable.
+    Defensive: returns False rather than raising on any OSError.
+    """
+    try:
+        fast = (model_dir / "tokenizer.json").exists()
+        legacy = (
+            (model_dir / "vocab.txt").exists()
+            and (model_dir / "tokenizer_config.json").exists()
+        )
+        return fast or legacy
+    except (OSError, ValueError):
+        return False
+
+
+def _onnxruntime_available() -> bool:
+    """Return True if ``onnxruntime`` is importable.
+
+    Optional-import guard. Never raises — missing dependency is a valid
+    state that routes HoloIndex to the SentenceTransformer fallback.
+    """
+    try:
+        import onnxruntime  # noqa: F401
+        return True
+    except Exception:  # pragma: no cover - import-failure surface
+        return False
+
+
+def _transformers_available() -> bool:
+    """Return True if ``transformers`` is importable.
+
+    Transitively required via ``sentence-transformers>=2.2.0`` in
+    ``holo_index/requirements.txt``, but guarded anyway so the backend
+    fails cleanly if the dep graph ever changes.
+    """
+    try:
+        from transformers import AutoTokenizer  # noqa: F401
+        return True
+    except Exception:  # pragma: no cover - import-failure surface
+        return False
 
 
 class TurboQuantEmbedder:
-    """Stub for int8-quantized embedder.
+    """ONNX Runtime int8 embedder for MiniLM-L6-v2.
 
-    This class intentionally raises on ``encode`` until a real backend is
-    wired. ``is_available()`` returns ``False`` so the boot path in
-    ``HoloIndex.__init__`` falls back to ``SentenceTransformer``.
+    Lazy-loads the ONNX session + tokenizer on first ``encode()`` call
+    (or eagerly via ``_ensure_loaded()``). ``is_available()`` is a
+    classmethod that reports readiness without touching module state,
+    so ``HoloIndex`` can probe before constructing.
     """
 
-    # Marker used by ``_determine_retrieval_mode`` to tag the backend without
+    # Marker used by ``HoloIndex.__init__`` to tag the backend without
     # importing this module at the callsite (duck-typed).
     _turboquant_marker: bool = True
 
-    @classmethod
-    def is_available(cls) -> bool:
-        """Return ``True`` only when a real quantized backend is wired.
+    def __init__(self, model_dir: Optional[Path] = None) -> None:
+        self.model_dir: Path = model_dir if model_dir is not None else _resolve_model_dir()
+        self._session = None
+        self._tokenizer = None
+        self._input_names: Optional[set] = None
 
-        Phase 1 scaffold: always ``False``. A later slice (post-W6 research)
-        will import the chosen backend library here, verify model weights
-        are present on disk, and flip this to ``True`` when ready.
+    # -- availability probe --------------------------------------------------
+
+    @classmethod
+    def is_available(cls, model_dir: Optional[Path] = None) -> bool:
+        """Return True iff the full backend stack can load.
+
+        Checks:
+          1. ``onnxruntime`` importable.
+          2. ``transformers`` importable.
+          3. Model dir exists.
+          4. ``model_int8.onnx`` present in model dir.
+          5. Tokenizer artifacts present in model dir.
+
+        Never raises. Missing any precondition -> False.
         """
-        return False
+        try:
+            if not _onnxruntime_available():
+                return False
+            if not _transformers_available():
+                return False
+            mdir = model_dir if model_dir is not None else _resolve_model_dir()
+            if not mdir.exists():
+                return False
+            if not (mdir / MODEL_FILENAME).exists():
+                return False
+            if not _tokenizer_files_present(mdir):
+                return False
+            return True
+        except (OSError, ValueError):
+            return False
+
+    # -- lazy loader ---------------------------------------------------------
+
+    def _ensure_loaded(self) -> None:
+        """Load session + tokenizer on first use.
+
+        Separated from ``__init__`` so ``is_available()`` can be called
+        cheaply and so tests can construct without triggering any model
+        I/O. Raises ``RuntimeError`` with a clear message if any step
+        fails — the caller (HoloIndex) catches and falls back.
+        """
+        if self._session is not None and self._tokenizer is not None:
+            return
+
+        if not _onnxruntime_available():
+            raise RuntimeError(
+                "TurboQuant: onnxruntime is not installed. "
+                "Install via `pip install onnxruntime` or unset HOLO_USE_TURBOQUANT."
+            )
+        if not _transformers_available():
+            raise RuntimeError(
+                "TurboQuant: transformers is not installed. "
+                "Check holo_index/requirements.txt (sentence-transformers pulls it)."
+            )
+        if not self.model_dir.exists():
+            raise RuntimeError(
+                f"TurboQuant: model dir not found: {self.model_dir}. "
+                "Set HOLO_TURBOQUANT_MODEL_DIR or export model artifacts."
+            )
+        model_path = self.model_dir / MODEL_FILENAME
+        if not model_path.exists():
+            raise RuntimeError(
+                f"TurboQuant: model file not found: {model_path}"
+            )
+        if not _tokenizer_files_present(self.model_dir):
+            raise RuntimeError(
+                f"TurboQuant: tokenizer files not found in {self.model_dir}"
+            )
+
+        import onnxruntime as ort
+        from transformers import AutoTokenizer
+
+        self._tokenizer = AutoTokenizer.from_pretrained(str(self.model_dir))
+        self._session = ort.InferenceSession(
+            str(model_path),
+            providers=["CPUExecutionProvider"],
+        )
+        self._input_names = {i.name for i in self._session.get_inputs()}
+
+    # -- encode --------------------------------------------------------------
 
     def encode(self, text: str, show_progress_bar: bool = False) -> Any:  # noqa: ARG002
-        """Return a 384-dim float32 embedding.
+        """Return a 1-D ``float32`` numpy array of length ``EMBEDDING_DIM``.
 
-        Phase 1 scaffold: raises ``NotImplementedError``. The contract is
-        documented here so the future implementer has no ambiguity about
-        shape, dtype, or the ``show_progress_bar`` parameter.
+        Mirrors the fp32 ``SentenceTransformer`` contract used in
+        ``HoloIndex._get_embedding`` so callers do not need branch logic.
+        ``show_progress_bar`` is accepted for signature compatibility
+        but is a no-op here.
+
+        Pipeline: tokenize -> ORT forward -> mean-pool over tokens
+        (attention-mask weighted) -> L2 normalize. L2 normalization
+        matches the normalized output of the MiniLM-L6-v2 pipeline used
+        in the TQ1 baseline benchmark.
         """
-        raise NotImplementedError(
-            "TurboQuant backend not yet implemented. "
-            "HOLO_USE_TURBOQUANT=1 was set, but is_available() is False; "
-            "HoloIndex will fall back to SentenceTransformer."
+        self._ensure_loaded()
+
+        import numpy as np
+
+        enc = self._tokenizer(
+            text,
+            return_tensors="np",
+            padding=True,
+            truncation=True,
+            max_length=256,
         )
+        inputs = {k: v for k, v in enc.items() if k in (self._input_names or set())}
+        outputs = self._session.run(None, inputs)
+        token_embeddings = outputs[0]  # (batch, seq, hidden)
+        mask = enc["attention_mask"][..., None].astype("float32")
+        summed = (token_embeddings * mask).sum(axis=1)
+        counts = mask.sum(axis=1).clip(min=1e-9)
+        pooled = summed / counts
+        norms = np.linalg.norm(pooled, axis=1, keepdims=True).clip(min=1e-12)
+        normalized = (pooled / norms).astype("float32")
+        return normalized[0]

--- a/holo_index/tests/test_turboquant_backend.py
+++ b/holo_index/tests/test_turboquant_backend.py
@@ -1,56 +1,299 @@
 # -*- coding: utf-8 -*-
-"""
-Tests for turboquant_backend.py - TurboQuant Stub Tests
+"""Tests for turboquant_backend.py — HIA3 ONNX Runtime int8 backend.
 
-Tests run in HOLO_SKIP_MODEL=1 mode (no model dependencies).
+All tests run without real model artifacts. The optional real-model
+smoke test is skipped unless ``HOLO_TURBOQUANT_SMOKE=1`` and the
+artifacts are present on disk.
 
 WSP Compliance:
-    WSP 5: Test Coverage
-    WSP 97: Truth Distinction
+    WSP 5  (Test Coverage)
+    WSP 97 (Truth Distinction — backend quality gating)
 """
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
 import pytest
 
+from holo_index.core import turboquant_backend as tq
 from holo_index.core.turboquant_backend import (
+    BACKEND_NAME,
+    BACKEND_QUALITY,
+    DEFAULT_MODEL_DIR,
     EMBEDDING_DIM,
+    MODEL_FILENAME,
+    QUALITY_GATE,
     TurboQuantEmbedder,
+    _resolve_model_dir,
+    _tokenizer_files_present,
 )
 
 
-class TestTurboQuantConstants:
-    """Tests for module constants"""
+# ---------------------------------------------------------------------------
+# Module-level constants (WSP 97 truth distinction surface)
+# ---------------------------------------------------------------------------
 
+class TestTurboQuantConstants:
     def test_embedding_dim_is_384(self):
-        """Embedding dimension matches ChromaDB-stored vectors"""
+        """ChromaDB-stored vectors are 384-dim; dim must not drift."""
         assert EMBEDDING_DIM == 384
 
+    def test_backend_name_is_turboquant_onnx_int8(self):
+        """Surfaced through search_engine.py as the embedding_backend value."""
+        assert BACKEND_NAME == "turboquant_onnx_int8"
 
-class TestTurboQuantEmbedder:
-    """Tests for TurboQuantEmbedder stub class"""
+    def test_backend_quality_is_experimental(self):
+        """HIA3 ships experimental until static calibration closes the drift."""
+        assert BACKEND_QUALITY == "experimental"
 
+    def test_quality_gate_is_not_default_ready(self):
+        """HIA3 is opt-in only; default remains SentenceTransformer."""
+        assert QUALITY_GATE == "not_default_ready"
+
+    def test_default_model_dir_string(self):
+        assert isinstance(DEFAULT_MODEL_DIR, str)
+        assert Path(DEFAULT_MODEL_DIR).name == "tq1_onnx_int8"
+
+    def test_model_filename_is_int8(self):
+        assert MODEL_FILENAME == "model_int8.onnx"
+
+
+# ---------------------------------------------------------------------------
+# Duck-typed marker for HoloIndex branch detection
+# ---------------------------------------------------------------------------
+
+class TestTurboQuantMarker:
     def test_turboquant_marker_exists(self):
-        """Class has _turboquant_marker for duck-typing"""
         assert hasattr(TurboQuantEmbedder, "_turboquant_marker")
         assert TurboQuantEmbedder._turboquant_marker is True
 
-    def test_is_available_returns_false(self):
-        """Stub always reports unavailable"""
+
+# ---------------------------------------------------------------------------
+# Model-dir resolution (env var override)
+# ---------------------------------------------------------------------------
+
+class TestResolveModelDir:
+    def test_defaults_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("HOLO_TURBOQUANT_MODEL_DIR", raising=False)
+        assert _resolve_model_dir() == Path(DEFAULT_MODEL_DIR)
+
+    def test_honors_env_override(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HOLO_TURBOQUANT_MODEL_DIR", str(tmp_path))
+        assert _resolve_model_dir() == tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Tokenizer artifact probe
+# ---------------------------------------------------------------------------
+
+class TestTokenizerFilesPresent:
+    def test_returns_false_on_empty_dir(self, tmp_path):
+        assert _tokenizer_files_present(tmp_path) is False
+
+    def test_returns_true_for_fast_tokenizer(self, tmp_path):
+        (tmp_path / "tokenizer.json").write_text("{}", encoding="utf-8")
+        assert _tokenizer_files_present(tmp_path) is True
+
+    def test_returns_true_for_legacy_pair(self, tmp_path):
+        (tmp_path / "vocab.txt").write_text("", encoding="utf-8")
+        (tmp_path / "tokenizer_config.json").write_text("{}", encoding="utf-8")
+        assert _tokenizer_files_present(tmp_path) is True
+
+    def test_returns_false_when_only_vocab_present(self, tmp_path):
+        (tmp_path / "vocab.txt").write_text("", encoding="utf-8")
+        assert _tokenizer_files_present(tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# is_available() — never raises, returns False on any missing precondition
+# ---------------------------------------------------------------------------
+
+class TestIsAvailable:
+    def test_false_when_onnxruntime_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tq, "_onnxruntime_available", lambda: False)
+        monkeypatch.setattr(tq, "_transformers_available", lambda: True)
+        assert TurboQuantEmbedder.is_available(model_dir=tmp_path) is False
+
+    def test_false_when_transformers_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tq, "_onnxruntime_available", lambda: True)
+        monkeypatch.setattr(tq, "_transformers_available", lambda: False)
+        assert TurboQuantEmbedder.is_available(model_dir=tmp_path) is False
+
+    def test_false_when_model_dir_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tq, "_onnxruntime_available", lambda: True)
+        monkeypatch.setattr(tq, "_transformers_available", lambda: True)
+        missing = tmp_path / "does_not_exist"
+        assert TurboQuantEmbedder.is_available(model_dir=missing) is False
+
+    def test_false_when_model_file_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tq, "_onnxruntime_available", lambda: True)
+        monkeypatch.setattr(tq, "_transformers_available", lambda: True)
+        (tmp_path / "tokenizer.json").write_text("{}", encoding="utf-8")
+        assert TurboQuantEmbedder.is_available(model_dir=tmp_path) is False
+
+    def test_false_when_tokenizer_files_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tq, "_onnxruntime_available", lambda: True)
+        monkeypatch.setattr(tq, "_transformers_available", lambda: True)
+        (tmp_path / MODEL_FILENAME).write_bytes(b"")
+        assert TurboQuantEmbedder.is_available(model_dir=tmp_path) is False
+
+    def test_true_when_all_preconditions_met(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tq, "_onnxruntime_available", lambda: True)
+        monkeypatch.setattr(tq, "_transformers_available", lambda: True)
+        (tmp_path / MODEL_FILENAME).write_bytes(b"")
+        (tmp_path / "tokenizer.json").write_text("{}", encoding="utf-8")
+        assert TurboQuantEmbedder.is_available(model_dir=tmp_path) is True
+
+    def test_never_raises_on_unexpected_state(self, monkeypatch):
+        """Defensive guard: any OSError -> False, not propagated."""
+        def _boom():
+            raise OSError("disk exploded")
+        monkeypatch.setattr(tq, "_onnxruntime_available", _boom)
         assert TurboQuantEmbedder.is_available() is False
 
-    def test_encode_raises_not_implemented(self):
-        """Encode raises NotImplementedError for stub"""
-        embedder = TurboQuantEmbedder()
-        with pytest.raises(NotImplementedError) as exc_info:
-            embedder.encode("test text")
 
-        assert "TurboQuant backend not yet implemented" in str(exc_info.value)
+# ---------------------------------------------------------------------------
+# _ensure_loaded() — actionable RuntimeError per failure mode
+# ---------------------------------------------------------------------------
 
-    def test_encode_accepts_show_progress_bar(self):
-        """Encode method accepts show_progress_bar parameter"""
-        embedder = TurboQuantEmbedder()
-        with pytest.raises(NotImplementedError):
-            embedder.encode("test", show_progress_bar=True)
+class TestEnsureLoadedFailureModes:
+    def test_raises_when_onnxruntime_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tq, "_onnxruntime_available", lambda: False)
+        embedder = TurboQuantEmbedder(model_dir=tmp_path)
+        with pytest.raises(RuntimeError, match="onnxruntime"):
+            embedder._ensure_loaded()
 
-    def test_instance_creation(self):
-        """Can create TurboQuantEmbedder instance"""
+    def test_raises_when_transformers_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tq, "_onnxruntime_available", lambda: True)
+        monkeypatch.setattr(tq, "_transformers_available", lambda: False)
+        embedder = TurboQuantEmbedder(model_dir=tmp_path)
+        with pytest.raises(RuntimeError, match="transformers"):
+            embedder._ensure_loaded()
+
+    def test_raises_when_model_dir_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tq, "_onnxruntime_available", lambda: True)
+        monkeypatch.setattr(tq, "_transformers_available", lambda: True)
+        embedder = TurboQuantEmbedder(model_dir=tmp_path / "nope")
+        with pytest.raises(RuntimeError, match="model dir not found"):
+            embedder._ensure_loaded()
+
+    def test_raises_when_model_file_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tq, "_onnxruntime_available", lambda: True)
+        monkeypatch.setattr(tq, "_transformers_available", lambda: True)
+        embedder = TurboQuantEmbedder(model_dir=tmp_path)
+        with pytest.raises(RuntimeError, match="model file not found"):
+            embedder._ensure_loaded()
+
+    def test_raises_when_tokenizer_files_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tq, "_onnxruntime_available", lambda: True)
+        monkeypatch.setattr(tq, "_transformers_available", lambda: True)
+        (tmp_path / MODEL_FILENAME).write_bytes(b"")
+        embedder = TurboQuantEmbedder(model_dir=tmp_path)
+        with pytest.raises(RuntimeError, match="tokenizer files not found"):
+            embedder._ensure_loaded()
+
+
+# ---------------------------------------------------------------------------
+# encode() contract — 1-D float32, length 384, L2-normalized
+# ---------------------------------------------------------------------------
+
+class TestEncodeContract:
+    def _make_embedder_with_mocks(self):
+        """Pre-populate session + tokenizer so _ensure_loaded short-circuits."""
+        embedder = TurboQuantEmbedder(model_dir=Path("."))
+
+        seq_len = 4
+        hidden = EMBEDDING_DIM
+        token_embeddings = np.ones((1, seq_len, hidden), dtype=np.float32)
+        token_embeddings[:, 2:, :] = 0.0  # last two tokens masked
+
+        session = MagicMock()
+        session.run.return_value = [token_embeddings]
+        session.get_inputs.return_value = [
+            MagicMock(name="input_ids"),
+            MagicMock(name="attention_mask"),
+        ]
+
+        tokenizer_output = {
+            "input_ids": np.array([[1, 2, 3, 4]], dtype=np.int64),
+            "attention_mask": np.array([[1, 1, 0, 0]], dtype=np.int64),
+        }
+        tokenizer = MagicMock(return_value=tokenizer_output)
+
+        embedder._session = session
+        embedder._tokenizer = tokenizer
+        embedder._input_names = {"input_ids", "attention_mask"}
+        return embedder
+
+    def test_encode_returns_1d_float32_vector(self):
+        embedder = self._make_embedder_with_mocks()
+        vec = embedder.encode("hello world")
+        assert isinstance(vec, np.ndarray)
+        assert vec.dtype == np.float32
+        assert vec.ndim == 1
+        assert vec.shape[0] == EMBEDDING_DIM
+
+    def test_encode_is_l2_normalized(self):
+        embedder = self._make_embedder_with_mocks()
+        vec = embedder.encode("hello world")
+        norm = float(np.linalg.norm(vec))
+        assert abs(norm - 1.0) < 1e-5
+
+    def test_encode_accepts_show_progress_bar_kwarg(self):
+        """Signature compatibility with SentenceTransformer.encode."""
+        embedder = self._make_embedder_with_mocks()
+        vec = embedder.encode("hello", show_progress_bar=True)
+        assert vec.shape == (EMBEDDING_DIM,)
+
+    def test_encode_filters_unexpected_input_names(self):
+        """Tokenizer keys the ORT session doesn't expose must be dropped."""
+        embedder = self._make_embedder_with_mocks()
+        embedder._input_names = {"input_ids"}
+        embedder._tokenizer = MagicMock(return_value={
+            "input_ids": np.array([[1, 2]], dtype=np.int64),
+            "attention_mask": np.array([[1, 1]], dtype=np.int64),
+            "token_type_ids": np.array([[0, 0]], dtype=np.int64),
+        })
+        token_embeddings = np.ones((1, 2, EMBEDDING_DIM), dtype=np.float32)
+        embedder._session.run.return_value = [token_embeddings]
+
+        vec = embedder.encode("x")
+        assert vec.shape == (EMBEDDING_DIM,)
+        passed_inputs = embedder._session.run.call_args[0][1]
+        assert set(passed_inputs.keys()) == {"input_ids"}
+
+
+# ---------------------------------------------------------------------------
+# Instance construction — must not touch model I/O
+# ---------------------------------------------------------------------------
+
+class TestConstructionIsSideEffectFree:
+    def test_init_does_not_call_ensure_loaded(self, tmp_path):
+        embedder = TurboQuantEmbedder(model_dir=tmp_path / "unreadable")
+        assert embedder._session is None
+        assert embedder._tokenizer is None
+
+    def test_init_defaults_to_resolved_model_dir(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HOLO_TURBOQUANT_MODEL_DIR", str(tmp_path))
         embedder = TurboQuantEmbedder()
-        assert embedder is not None
+        assert embedder.model_dir == tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Optional real-model smoke test (skipped by default)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    os.getenv("HOLO_TURBOQUANT_SMOKE") != "1" or not TurboQuantEmbedder.is_available(),
+    reason="Real-model smoke test; set HOLO_TURBOQUANT_SMOKE=1 with artifacts on disk.",
+)
+class TestRealModelSmoke:
+    def test_encode_real_model_returns_unit_vector(self):
+        embedder = TurboQuantEmbedder()
+        vec = embedder.encode("the quick brown fox")
+        assert vec.dtype == np.float32
+        assert vec.shape == (EMBEDDING_DIM,)
+        assert abs(float(np.linalg.norm(vec)) - 1.0) < 1e-3


### PR DESCRIPTION
## Summary

- Replaces the HIA2 `TurboQuantEmbedder` stub with a real ONNX Runtime int8 embedder, wired as an **experimental opt-in**. Default behavior is unchanged (`HOLO_USE_TURBOQUANT=0` keeps HoloIndex on the fp32 SentenceTransformer path, bit-identical to pre-HIA3).
- Adds WSP 97 truth surface: `backend_quality="experimental"` / `quality_gate="not_default_ready"` on every search response's `metadata`, so downstream automation can gate ranking decisions without re-checking env vars.
- Deferred work: static calibration + real-corpus A/B gating are out of scope for HIA3 (separate TQ2-STATIC-CALIBRATION slice). This PR ships only the safe backend seam.

## Why Experimental

TQ1 benchmark (`holo_index/scripts/benchmarks/tq1_onnx_int8_bench.py`) vs fp32 MiniLM-L6-v2:

| Dimension | Result | Verdict |
|---|---|---|
| Cold start | 5.6x faster | Accepted |
| Load | 6.6x faster | Accepted |
| Single-query median | 8.8x faster | Accepted |
| Artifact size | 4.0x smaller | Accepted |
| Mean cosine drift | 3.65% (> 2% threshold) | **Gated** |
| Top-1 retrieval agreement | 76.7% (~23% flip rate) | **Gated** |

Per 012 direction: performance accepted, quality gated. Ship now as opt-in; promote to default only after the drift gap closes.

## Changes

- `holo_index/core/turboquant_backend.py` — real backend: optional-import guards for `onnxruntime` / `transformers`, env-var model-dir (`HOLO_TURBOQUANT_MODEL_DIR`), `is_available()` never raises, `_ensure_loaded()` raises actionable `RuntimeError`, `encode()` returns 1-D `float32` length 384 (mean-pool + L2 normalize).
- `holo_index/core/holo_index.py` — wiring uses canonical `BACKEND_NAME` constant, inner try/except around `_ensure_loaded()` for clean fallback, downstream branch uses `startswith("turboquant")` with isinstance guard.
- `holo_index/core/search_engine.py` — `_BACKEND_QUALITY` / `_QUALITY_GATE` dicts + helpers; `metadata` payload extended with `backend_quality` + `quality_gate`.
- `holo_index/tests/test_turboquant_backend.py` — stub tests replaced with mocked-contract suite (31 pass / 1 skip). No real model artifacts needed in CI.
- `holo_index/ModLog.md` — HIA3 entry with quality caveat and deferred-work callout.

## No New Hard Dependencies

- `onnxruntime` stays **optional-import** (not added to `holo_index/requirements.txt`).
- `transformers` is already transitive via `sentence-transformers>=2.2.0`.

If either dep is missing at runtime, `is_available()` returns `False` and HoloIndex falls through to the SentenceTransformer backend without raising.

## Fallback Chain

TurboQuant engages only when **all** of these hold:
1. `HOLO_USE_TURBOQUANT=1`
2. `onnxruntime` importable
3. Model artifacts present at `HOLO_TURBOQUANT_MODEL_DIR` (default `E:/HoloIndex/models/tq1_onnx_int8/`)

Any failure → warning logged → SentenceTransformer.

## Worktree Note

HIA3 attempt #1 in the primary worktree reverted before commit (parallel-window collision — reflog confirmed 10+ branch checkouts by other windows in the shared worktree within 32 seconds of HIA3 branch creation). Remediation: reapplied in the dedicated isolated worktree `O:/tmp/w5_hia3_turboquant_onnx`. Worktree stays intact until this PR is merged.

## Test plan

- [x] `python -m pytest holo_index/tests/test_turboquant_backend.py -v` → **31 passed, 1 skipped** (smoke test gated behind `HOLO_TURBOQUANT_SMOKE=1`)
- [x] `python -m pytest holo_index/tests/test_fx1_holoindex_truth.py -v` → **11 passed** (metadata surface unregressed)
- [ ] Reviewer: confirm default behavior unchanged with `HOLO_USE_TURBOQUANT` unset
- [ ] Reviewer: confirm `backend_quality` / `quality_gate` fields appear in search responses
- [ ] Optional local smoke: export model artifacts, set `HOLO_TURBOQUANT_SMOKE=1` + `HOLO_TURBOQUANT_MODEL_DIR`, rerun test file — the `TestRealModelSmoke` class will un-skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)