### PR TITLE
feat(holoindex): TQ3 per-collection backend routing Phase 1 (HOLD_ROUTING)

### DIFF
--- a/docs/audits/holoindex_turboquant/TQ3_PER_COLLECTION_ROUTING.md
+++ b/docs/audits/holoindex_turboquant/TQ3_PER_COLLECTION_ROUTING.md
@@ -1,0 +1,186 @@
+# TQ3 — Per-Collection Backend Routing (Phase 1)
+
+**Slice**: `TQ3_PER_COLLECTION_BACKEND_ROUTING_PHASE1`
+**Date**: 2026-04-23
+**Worker**: CX
+**Decision**: `HOLD_ROUTING` (infrastructure shipped; policy-promotion deferred pending stable-corpus re-audit)
+
+---
+
+## Context
+
+TQ2 (`TQ2_FP32_INT8_REAL_CORPUS_AUDIT.md`, decision `HOLD_INT8`) measured that
+the HIA3 TurboQuant ONNX int8 backend was retrieval-equivalent to fp32 on
+every production navigation collection **except** `navigation_vocabulary`
+(30 docs; top-5 set-agreement 43.3%). Rather than promote int8 globally
+(vocabulary would regress) or hold it off entirely (code / WSP / skills /
+symbols had measured 100% top-1 and 100% top-5 over 23,801 docs), TQ3
+introduces **per-collection routing**: int8 where TQ2 proved equivalence,
+fp32 where it did not.
+
+TQ3 ships the routing surface:
+
+* `holo_index/core/backend_routing.py` — policy module with the canonical
+  collection → backend map.
+* `holo_index/core/holo_index.py` — loads both backends when
+  `HOLO_USE_TURBOQUANT=1`, exposes `routing_active`, `embedders`, and
+  `collection_backend_map`.
+* `holo_index/core/search_engine.py` — resolves the routed embedder per
+  collection on every search and emits `routing_active` +
+  `collection_backend_map` on the response metadata.
+* `holo_index/scripts/benchmarks/tq3_routed_corpus_audit.py` — a TQ2
+  overlay that audits the routed policy vs the pure-fp32 baseline.
+
+## Policy Map (TQ3 Target)
+
+| Collection             | Routed backend             | Evidence source        |
+| ---------------------- | -------------------------- | ---------------------- |
+| `navigation_code`      | `turboquant_onnx_int8`     | TQ2 (evidence drifted) |
+| `navigation_wsp`       | `turboquant_onnx_int8`     | TQ2 (evidence drifted) |
+| `navigation_skills`    | `turboquant_onnx_int8`     | TQ2 + TQ3 both 100%    |
+| `navigation_symbols`   | `turboquant_onnx_int8`     | TQ2 + TQ3 both 100%    |
+| `navigation_vocabulary`| `sentence_transformers`    | TQ2 blocker; TQ3 trivial 100% |
+| `navigation_tests`     | *(unlisted → fp32 default)*| TQ2 could not audit (empty) |
+| *any other*            | *(default → fp32)*         | Safe baseline          |
+
+The map is **declared now** so the routing surface is testable and stable,
+but `HOLD_ROUTING` means no default flips from this slice. Production
+default remains `HOLO_USE_TURBOQUANT=0` (pure fp32). Promotion requires a
+clean re-audit pass (see Blockers).
+
+## Gate Result (TQ3 run, 2026-04-23)
+
+Thresholds (identical to TQ2 for direct comparability):
+
+* overall top-1 agreement ≥ 90%
+* overall top-5 set-agreement ≥ 95%
+* all sentinel queries: top-1 agrees with fp32
+
+Routed-mode result:
+
+| Metric                          | Value  | Gate   | Status |
+| ------------------------------- | ------ | ------ | ------ |
+| overall top-1 agreement         | 95.3%  | ≥ 90%  | PASS   |
+| overall top-5 set-agreement     | 72.7%  | ≥ 95%  | **FAIL** |
+| sentinels passing               | 5 / 6  | 6 / 6  | **FAIL** |
+
+**Decision**: `HOLD_ROUTING`.
+
+### Per-Collection (Routed vs Pure fp32)
+
+| Collection             | Docs (now) | Routed backend | top-1  | top-5  | Notes |
+| ---------------------- | ---------- | -------------- | ------ | ------ | ----- |
+| `navigation_code`      | 296        | int8           | 86.7%  | 46.7%  | Regressed vs TQ2 (was 100% / 100%) |
+| `navigation_wsp`       | 1,916      | int8           | 90.0%  | 16.7%  | Regressed vs TQ2 (was 100% / 100%) |
+| `navigation_skills`    | 59         | int8           | 100.0% | 100.0% | Stable vs TQ2 |
+| `navigation_symbols`   | 20,000     | int8           | 100.0% | 100.0% | Stable vs TQ2 |
+| `navigation_vocabulary`| 30         | fp32           | 100.0% | 100.0% | Trivial (same backend) |
+
+### Failing Sentinel
+
+* `navigation_wsp` / `WSP 97 truth distinction protocol` → fp32 top-1
+  `wsp_201`, routed (int8) top-1 `wsp_108`.
+
+### Divergences (7 total)
+
+| Collection         | Backend | Query                                       |
+| ------------------ | ------- | ------------------------------------------- |
+| `navigation_code`  | int8    | `pfMALL data isolation model`               |
+| `navigation_code`  | int8    | `ai overseer role detection`                |
+| `navigation_code`  | int8    | `embedding_backend search metadata`         |
+| `navigation_code`  | int8    | `token budget for DAE pattern memory`       |
+| `navigation_wsp`   | int8    | `WSP 97 truth distinction protocol`         |
+| `navigation_wsp`   | int8    | `how does 0102 recall patterns from 0201`   |
+| `navigation_wsp`   | int8    | `token budget for DAE pattern memory`       |
+
+Full list: `docs/audits/holoindex_turboquant/tq3_divergent_queries.json`.
+
+## Root-Cause Finding (WSP 97)
+
+**Corpus drift between TQ2 and TQ3 runs.** TQ2 audited `navigation_wsp` at
+3,446 docs; TQ3 saw 1,916 docs in the same Chroma at `E:/HoloIndex/vectors`.
+`navigation_code` was stable at 296 but its 5-NN neighborhoods still
+diverged under int8 more than before, consistent with an underlying
+re-index that also affected code chunk boundaries or payload text.
+
+This does not invalidate the routing **infrastructure** — the routed-mode
+audit correctly used int8 for code/wsp/skills/symbols and fp32 for
+vocabulary. It invalidates the claim that TQ2's equivalence result still
+holds for code/wsp on the present corpus state. Skills and symbols remain
+stable; vocabulary is trivially correct under routing.
+
+## Latency (TQ3 Run)
+
+Routed-mode encode is dominated by int8 (4 of 5 collections) and shows
+the expected improvement over pure fp32:
+
+| Metric              | Routed  | Pure fp32 |
+| ------------------- | ------- | --------- |
+| encode p50 (ms)     | 2.73    | 10.94     |
+| encode p95 (ms)     | 11.40   | 19.91     |
+| query p50 (ms)      | 1.69    | 2.05      |
+| query p95 (ms)      | 2.29    | 2.64      |
+| cold load fp32 (s)  | —       | 11.64     |
+| cold load int8 (s)  | 0.76    | —         |
+
+Latency is not a blocker; the blocker is retrieval equivalence on the
+current corpus.
+
+## Blockers (Must Clear Before Default-Promotion)
+
+1. Re-establish a stable corpus (freeze `E:/HoloIndex/vectors` or rebuild
+   from deterministic source) before any further TQ re-run. Corpus drift
+   between slices makes A/B evidence non-reproducible.
+2. On the frozen corpus, re-run TQ2 (pure-int8 vs fp32) and confirm the
+   code/wsp collections still meet 100% / 100%. If they regress, the
+   int8 lane must shrink to only the collections that pass.
+3. Re-run TQ3 (routed vs fp32) and confirm overall ≥ 90% top-1, ≥ 95%
+   top-5, all sentinels pass.
+
+## What TQ3 Ships Today
+
+* Routing policy module (`backend_routing.py`) — testable, WSP-50 clean.
+* HoloIndex boot loads **both** backends when `HOLO_USE_TURBOQUANT=1`;
+  `routing_active` is `True` only when both load cleanly (no silent
+  degradation).
+* `search_engine.execute_search()` metadata now surfaces:
+  - `routing_active: bool`
+  - `collection_backend_map: {collection: backend}`
+  - `embedding_backend = "routed"` when routing is active (WSP 97 — no
+    single-backend overclaim when behavior is mixed).
+* `backend_quality` / `quality_gate` extended with `"routed" → "mixed"`
+  entries.
+* 14 new focused unit tests (`test_backend_routing.py`) covering the
+  policy map, the resolver, and degraded-load fallbacks.
+* TQ3 audit harness reusing TQ2's frozen query set + sentinels so runs
+  are directly comparable.
+
+## What TQ3 Does NOT Change
+
+* Production default remains `HOLO_USE_TURBOQUANT=0` → pure fp32.
+* No reindex. Chroma still stores fp32-built vectors. Routing only
+  changes the **query** embedder, not the stored vectors.
+* `backend_quality="experimental"` and `quality_gate="not_default_ready"`
+  claims for `turboquant_onnx_int8` stand. The new `"routed"` entry
+  claims `"mixed"` / `"mixed"` — deliberately not `default_ready`.
+
+## Files
+
+* `holo_index/core/backend_routing.py` (new)
+* `holo_index/core/holo_index.py` (modified)
+* `holo_index/core/search_engine.py` (modified)
+* `holo_index/tests/test_backend_routing.py` (new)
+* `holo_index/scripts/benchmarks/tq3_routed_corpus_audit.py` (new)
+* `docs/audits/holoindex_turboquant/tq3_metrics.json`
+* `docs/audits/holoindex_turboquant/tq3_divergent_queries.json`
+* `docs/audits/holoindex_turboquant/TQ3_PER_COLLECTION_ROUTING.md` (this file)
+
+## WSP Compliance
+
+* **WSP 15** (priority): Routing is P1-supporting — unblocks safe
+  per-collection int8 use once corpus stability returns.
+* **WSP 97** (truth distinction): Metadata surfaces the mixed nature of
+  routed retrieval (`embedding_backend="routed"`, per-collection map).
+  The decision `HOLD_ROUTING` reflects measurement, not intent.
+* **WSP 50** (pre-action verification): HoloIndex searched before file
+  creation; all 7 read-first files consulted before design.

--- a/docs/audits/holoindex_turboquant/tq3_divergent_queries.json
+++ b/docs/audits/holoindex_turboquant/tq3_divergent_queries.json
@@ -1,0 +1,152 @@
+{
+  "n_divergent": 7,
+  "divergent": [
+    {
+      "collection": "navigation_code",
+      "routed_backend": "turboquant_onnx_int8",
+      "query": "pfMALL data isolation model",
+      "fp32_top1": "code_295",
+      "routed_top1": "code_108",
+      "fp32_top5": [
+        "code_295",
+        "code_80",
+        "code_189",
+        "code_184",
+        "code_108"
+      ],
+      "routed_top5": [
+        "code_108",
+        "code_184",
+        "code_295",
+        "code_178",
+        "code_155"
+      ]
+    },
+    {
+      "collection": "navigation_code",
+      "routed_backend": "turboquant_onnx_int8",
+      "query": "ai overseer role detection",
+      "fp32_top1": "code_85",
+      "routed_top1": "code_86",
+      "fp32_top5": [
+        "code_85",
+        "code_86",
+        "code_87",
+        "code_67",
+        "code_65"
+      ],
+      "routed_top5": [
+        "code_86",
+        "code_85",
+        "code_87",
+        "code_67",
+        "code_65"
+      ]
+    },
+    {
+      "collection": "navigation_code",
+      "routed_backend": "turboquant_onnx_int8",
+      "query": "embedding_backend search metadata",
+      "fp32_top1": "code_238",
+      "routed_top1": "code_224",
+      "fp32_top5": [
+        "code_238",
+        "code_137",
+        "code_224",
+        "code_194",
+        "code_234"
+      ],
+      "routed_top5": [
+        "code_224",
+        "code_238",
+        "code_137",
+        "code_234",
+        "code_194"
+      ]
+    },
+    {
+      "collection": "navigation_code",
+      "routed_backend": "turboquant_onnx_int8",
+      "query": "token budget for DAE pattern memory",
+      "fp32_top1": "code_102",
+      "routed_top1": "code_108",
+      "fp32_top5": [
+        "code_102",
+        "code_108",
+        "code_113",
+        "code_130",
+        "code_115"
+      ],
+      "routed_top5": [
+        "code_108",
+        "code_102",
+        "code_115",
+        "code_113",
+        "code_130"
+      ]
+    },
+    {
+      "collection": "navigation_wsp",
+      "routed_backend": "turboquant_onnx_int8",
+      "query": "WSP 97 truth distinction protocol",
+      "fp32_top1": "wsp_201",
+      "routed_top1": "wsp_108",
+      "fp32_top5": [
+        "wsp_201",
+        "wsp_245",
+        "wsp_108",
+        "wsp_47",
+        "wsp_1003"
+      ],
+      "routed_top5": [
+        "wsp_108",
+        "wsp_201",
+        "wsp_245",
+        "wsp_16",
+        "wsp_47"
+      ]
+    },
+    {
+      "collection": "navigation_wsp",
+      "routed_backend": "turboquant_onnx_int8",
+      "query": "how does 0102 recall patterns from 0201",
+      "fp32_top1": "wsp_1469",
+      "routed_top1": "wsp_13",
+      "fp32_top5": [
+        "wsp_1469",
+        "wsp_1753",
+        "wsp_13",
+        "wsp_555",
+        "wsp_251"
+      ],
+      "routed_top5": [
+        "wsp_13",
+        "wsp_1753",
+        "wsp_1075",
+        "wsp_251",
+        "wsp_1469"
+      ]
+    },
+    {
+      "collection": "navigation_wsp",
+      "routed_backend": "turboquant_onnx_int8",
+      "query": "token budget for DAE pattern memory",
+      "fp32_top1": "wsp_138",
+      "routed_top1": "wsp_497",
+      "fp32_top5": [
+        "wsp_138",
+        "wsp_497",
+        "wsp_131",
+        "wsp_132",
+        "wsp_1414"
+      ],
+      "routed_top5": [
+        "wsp_497",
+        "wsp_138",
+        "wsp_132",
+        "wsp_131",
+        "wsp_1626"
+      ]
+    }
+  ]
+}

--- a/docs/audits/holoindex_turboquant/tq3_metrics.json
+++ b/docs/audits/holoindex_turboquant/tq3_metrics.json
@@ -1,0 +1,407 @@
+{
+  "slice": "TQ3_PER_COLLECTION_BACKEND_ROUTING_PHASE1",
+  "chroma_path": "E:/HoloIndex/vectors",
+  "collection_counts": {
+    "navigation_code": 296,
+    "navigation_wsp": 1916,
+    "navigation_tests": 0,
+    "navigation_skills": 59,
+    "navigation_symbols": 20000,
+    "navigation_vocabulary": 30
+  },
+  "audited_collections": [
+    "navigation_code",
+    "navigation_wsp",
+    "navigation_skills",
+    "navigation_symbols",
+    "navigation_vocabulary"
+  ],
+  "routing_policy": {
+    "navigation_code": "turboquant_onnx_int8",
+    "navigation_wsp": "turboquant_onnx_int8",
+    "navigation_tests": "sentence_transformers",
+    "navigation_skills": "turboquant_onnx_int8",
+    "navigation_symbols": "turboquant_onnx_int8",
+    "navigation_vocabulary": "sentence_transformers"
+  },
+  "n_queries": 30,
+  "n_sentinels": 6,
+  "gate_thresholds": {
+    "top1_agreement_pct": 90.0,
+    "top5_set_agreement_pct": 95.0,
+    "sentinel_top1_required": "all"
+  },
+  "overall": {
+    "top1_agreement_pct": 95.33333333333333,
+    "top5_set_agreement_pct": 72.66666666666667,
+    "sentinels_pass": false,
+    "sentinel_results": [
+      {
+        "collection": "navigation_code",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "WSP 97 truth distinction protocol",
+        "fp32_top1": "code_98",
+        "routed_top1": "code_98",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_code",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "WSP 87 size limits for modules",
+        "fp32_top1": "code_106",
+        "routed_top1": "code_106",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_code",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "HOLO_USE_TURBOQUANT environment switch",
+        "fp32_top1": "code_152",
+        "routed_top1": "code_152",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_code",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "modules/ai_intelligence/agent_permissions",
+        "fp32_top1": "code_65",
+        "routed_top1": "code_65",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_code",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "AgentPermissionManager.request_permission",
+        "fp32_top1": "code_65",
+        "routed_top1": "code_65",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_code",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "modules/platform_integration/youtube_auth",
+        "fp32_top1": "code_170",
+        "routed_top1": "code_170",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_wsp",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "WSP 97 truth distinction protocol",
+        "fp32_top1": "wsp_201",
+        "routed_top1": "wsp_108",
+        "top1_agree": false
+      },
+      {
+        "collection": "navigation_wsp",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "WSP 87 size limits for modules",
+        "fp32_top1": "wsp_526",
+        "routed_top1": "wsp_526",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_wsp",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "HOLO_USE_TURBOQUANT environment switch",
+        "fp32_top1": "wsp_420",
+        "routed_top1": "wsp_420",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_wsp",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "modules/ai_intelligence/agent_permissions",
+        "fp32_top1": "wsp_566",
+        "routed_top1": "wsp_566",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_wsp",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "AgentPermissionManager.request_permission",
+        "fp32_top1": "wsp_566",
+        "routed_top1": "wsp_566",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_wsp",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "modules/platform_integration/youtube_auth",
+        "fp32_top1": "wsp_1879",
+        "routed_top1": "wsp_1879",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_skills",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "WSP 97 truth distinction protocol",
+        "fp32_top1": "skill_2",
+        "routed_top1": "skill_2",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_skills",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "WSP 87 size limits for modules",
+        "fp32_top1": "skill_2",
+        "routed_top1": "skill_2",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_skills",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "HOLO_USE_TURBOQUANT environment switch",
+        "fp32_top1": "skill_2",
+        "routed_top1": "skill_2",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_skills",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "modules/ai_intelligence/agent_permissions",
+        "fp32_top1": "skill_2",
+        "routed_top1": "skill_2",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_skills",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "AgentPermissionManager.request_permission",
+        "fp32_top1": "skill_2",
+        "routed_top1": "skill_2",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_skills",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "modules/platform_integration/youtube_auth",
+        "fp32_top1": "skill_2",
+        "routed_top1": "skill_2",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_symbols",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "WSP 97 truth distinction protocol",
+        "fp32_top1": "sym_10365",
+        "routed_top1": "sym_10365",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_symbols",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "WSP 87 size limits for modules",
+        "fp32_top1": "sym_10365",
+        "routed_top1": "sym_10365",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_symbols",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "HOLO_USE_TURBOQUANT environment switch",
+        "fp32_top1": "sym_10365",
+        "routed_top1": "sym_10365",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_symbols",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "modules/ai_intelligence/agent_permissions",
+        "fp32_top1": "sym_10365",
+        "routed_top1": "sym_10365",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_symbols",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "AgentPermissionManager.request_permission",
+        "fp32_top1": "sym_10365",
+        "routed_top1": "sym_10365",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_symbols",
+        "routed_backend": "turboquant_onnx_int8",
+        "query": "modules/platform_integration/youtube_auth",
+        "fp32_top1": "sym_10365",
+        "routed_top1": "sym_10365",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_vocabulary",
+        "routed_backend": "sentence_transformers",
+        "query": "WSP 97 truth distinction protocol",
+        "fp32_top1": "vocab_1_10",
+        "routed_top1": "vocab_1_10",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_vocabulary",
+        "routed_backend": "sentence_transformers",
+        "query": "WSP 87 size limits for modules",
+        "fp32_top1": "vocab_1_10",
+        "routed_top1": "vocab_1_10",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_vocabulary",
+        "routed_backend": "sentence_transformers",
+        "query": "HOLO_USE_TURBOQUANT environment switch",
+        "fp32_top1": "vocab_1_13",
+        "routed_top1": "vocab_1_13",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_vocabulary",
+        "routed_backend": "sentence_transformers",
+        "query": "modules/ai_intelligence/agent_permissions",
+        "fp32_top1": "vocab_1_7",
+        "routed_top1": "vocab_1_7",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_vocabulary",
+        "routed_backend": "sentence_transformers",
+        "query": "AgentPermissionManager.request_permission",
+        "fp32_top1": "vocab_1_7",
+        "routed_top1": "vocab_1_7",
+        "top1_agree": true
+      },
+      {
+        "collection": "navigation_vocabulary",
+        "routed_backend": "sentence_transformers",
+        "query": "modules/platform_integration/youtube_auth",
+        "fp32_top1": "vocab_1_7",
+        "routed_top1": "vocab_1_7",
+        "top1_agree": true
+      }
+    ]
+  },
+  "per_collection": {
+    "navigation_code": {
+      "doc_count": 296,
+      "routed_backend": "turboquant_onnx_int8",
+      "queries": 30,
+      "top1_agreement_pct": 86.66666666666667,
+      "top5_set_agreement_pct": 46.666666666666664,
+      "jaccard_mean": {
+        "k=1": 0.8666666666666667,
+        "k=3": 0.78,
+        "k=5": 0.8142857142857143,
+        "k=10": 0.7801087801087802
+      },
+      "jaccard_min": {
+        "k=1": 0.0,
+        "k=3": 0.2,
+        "k=5": 0.42857142857142855,
+        "k=10": 0.5384615384615384
+      },
+      "kendall_tau_mean": 0.7180952380952381,
+      "kendall_tau_min": 0.14285714285714285
+    },
+    "navigation_wsp": {
+      "doc_count": 1916,
+      "routed_backend": "turboquant_onnx_int8",
+      "queries": 30,
+      "top1_agreement_pct": 90.0,
+      "top5_set_agreement_pct": 16.666666666666664,
+      "jaccard_mean": {
+        "k=1": 0.9,
+        "k=3": 0.7733333333333333,
+        "k=5": 0.6607142857142857,
+        "k=10": 0.7123321123321124
+      },
+      "jaccard_min": {
+        "k=1": 0.0,
+        "k=3": 0.2,
+        "k=5": 0.25,
+        "k=10": 0.42857142857142855
+      },
+      "kendall_tau_mean": 0.6378835978835978,
+      "kendall_tau_min": 0.23809523809523808
+    },
+    "navigation_skills": {
+      "doc_count": 59,
+      "routed_backend": "turboquant_onnx_int8",
+      "queries": 30,
+      "top1_agreement_pct": 100.0,
+      "top5_set_agreement_pct": 100.0,
+      "jaccard_mean": {
+        "k=1": 1.0,
+        "k=3": 1.0,
+        "k=5": 1.0,
+        "k=10": 1.0
+      },
+      "jaccard_min": {
+        "k=1": 1.0,
+        "k=3": 1.0,
+        "k=5": 1.0,
+        "k=10": 1.0
+      },
+      "kendall_tau_mean": 1.0,
+      "kendall_tau_min": 1.0
+    },
+    "navigation_symbols": {
+      "doc_count": 20000,
+      "routed_backend": "turboquant_onnx_int8",
+      "queries": 30,
+      "top1_agreement_pct": 100.0,
+      "top5_set_agreement_pct": 100.0,
+      "jaccard_mean": {
+        "k=1": 1.0,
+        "k=3": 1.0,
+        "k=5": 1.0,
+        "k=10": 1.0
+      },
+      "jaccard_min": {
+        "k=1": 1.0,
+        "k=3": 1.0,
+        "k=5": 1.0,
+        "k=10": 1.0
+      },
+      "kendall_tau_mean": 1.0,
+      "kendall_tau_min": 1.0
+    },
+    "navigation_vocabulary": {
+      "doc_count": 30,
+      "routed_backend": "sentence_transformers",
+      "queries": 30,
+      "top1_agreement_pct": 100.0,
+      "top5_set_agreement_pct": 100.0,
+      "jaccard_mean": {
+        "k=1": 1.0,
+        "k=3": 1.0,
+        "k=5": 1.0,
+        "k=10": 1.0
+      },
+      "jaccard_min": {
+        "k=1": 1.0,
+        "k=3": 1.0,
+        "k=5": 1.0,
+        "k=10": 1.0
+      },
+      "kendall_tau_mean": 1.0,
+      "kendall_tau_min": 1.0
+    }
+  },
+  "latency_ms": {
+    "fp32_encode_p50": 10.936950042378157,
+    "fp32_encode_p95": 19.911800028057755,
+    "routed_encode_p50": 2.727749932091683,
+    "routed_encode_p95": 11.403850023634707,
+    "fp32_query_p50": 2.0489500020630658,
+    "fp32_query_p95": 2.6426450349390502,
+    "routed_query_p50": 1.6936000320129097,
+    "routed_query_p95": 2.2869649401400234
+  },
+  "cold_load_sec": {
+    "fp32_sentence_transformer": 11.644695799914189,
+    "int8_turboquant_embedder": 0.7588778999634087
+  },
+  "decision": "HOLD_ROUTING",
+  "blockers": [
+    "overall top-5 set-agreement 72.7% < 95.0%",
+    "1 sentinel query regressions"
+  ]
+}

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,108 @@
 # HoloIndex Package ModLog
 
+## [2026-04-23] TQ3 — Per-Collection Backend Routing Phase 1 (tq3_per_collection_routing)
+
+**Agent**: 0102 (Worker CX)
+**WSP References**: WSP 15 (priority), WSP 97 (truth distinction), WSP 50 (pre-action verification)
+**Status**: INFRASTRUCTURE COMPLETE; policy-promotion HOLD
+**Decision**: `HOLD_ROUTING` (see `docs/audits/holoindex_turboquant/TQ3_PER_COLLECTION_ROUTING.md`)
+**Branch**: `research/tq3-per-collection-routing`
+**Worktree**: `O:/tmp/w_tq3_routing`
+
+### Context
+
+TQ2 (`HOLD_INT8`) proved the int8 backend retrieval-equivalent on every
+navigation collection except `navigation_vocabulary` (30 docs, top-5
+43.3%). TQ3 ships the per-collection routing surface so int8 can serve
+the four equivalent collections while fp32 continues to serve
+vocabulary — without touching the global default or requiring a
+reindex.
+
+### Changes
+
+1. **`holo_index/core/backend_routing.py`** (new) — canonical policy
+   module. `COLLECTION_BACKEND_ROUTING` maps code/wsp/skills/symbols →
+   int8 and vocabulary → fp32. `resolve_backend_for_collection()`
+   honors a `routing_active` flag plus an `available_backends` dict so
+   missing backends degrade truthfully (never silently).
+   `build_collection_backend_map()` emits the full map for search
+   metadata.
+
+2. **`holo_index/core/holo_index.py`** — `__init__` now loads **both**
+   fp32 and int8 when `HOLO_USE_TURBOQUANT=1`. New instance attrs:
+   `self.embedders` (backend_key → embedder), `self.routing_active`
+   (bool; requires both backends loaded), `self.collection_backend_map`
+   (collection → backend_key actually used). `self.model` stays the
+   primary (fp32 preferred) so legacy `_get_embedding` indexing
+   continues to write fp32 vectors — no reindex. When routing is
+   active, `embedding_backend="routed"` (WSP 97 — no single-backend
+   overclaim on mixed behavior).
+
+3. **`holo_index/core/search_engine.py`** — `_search_collection` picks
+   the embedder per-collection via `resolve_backend_for_collection`,
+   falls back to `holo.model` if `embedders` absent (test-mock
+   compatibility). `execute_search` metadata gains
+   `routing_active: bool` and `collection_backend_map: dict`, and the
+   quality-taxonomy dicts gain `"routed" → "mixed"` entries.
+
+4. **`holo_index/tests/test_backend_routing.py`** (new) — 14 focused
+   tests covering the policy map, resolver semantics, and degraded-load
+   fallbacks. No `HoloIndex` instantiation, no Chroma, no model load.
+
+5. **`holo_index/scripts/benchmarks/tq3_routed_corpus_audit.py`** (new)
+   — TQ2 overlay that audits routed-mode retrieval vs pure fp32 on the
+   live corpus using the identical frozen query set and sentinels.
+
+### Test Run
+
+56 focused tests passing, 1 skipped (real-model smoke test, by design):
+
+```
+holo_index/tests/test_backend_routing.py          14 passed
+holo_index/tests/test_turboquant_wiring.py        11 passed
+holo_index/tests/test_turboquant_backend.py       31 passed, 1 skipped
+```
+
+### TQ3 Gate Run (2026-04-23)
+
+```
+overall top-1 = 95.3%  (gate ≥ 90%  -> PASS)
+overall top-5 = 72.7%  (gate ≥ 95%  -> FAIL)
+sentinels     = 5/6    (gate = 6/6  -> FAIL)
+decision      = HOLD_ROUTING
+```
+
+Root cause (WSP 97): Chroma corpus drift between TQ2 and TQ3 runs.
+`navigation_wsp` dropped from 3,446 → 1,916 docs; TQ2's 100%/100%
+result on code/wsp no longer reproduces under the current corpus
+state. `navigation_skills` (59 docs) and `navigation_symbols` (20,000
+docs) remain at 100%/100%. Vocabulary is trivially 100% under routing
+(same backend as baseline).
+
+### What TQ3 Changes in Production
+
+Nothing today. Global default stays `HOLO_USE_TURBOQUANT=0` (pure
+fp32). When an operator sets `HOLO_USE_TURBOQUANT=1`, both backends
+load and routing activates — but `backend_quality="mixed"` and
+`quality_gate="mixed"` keep the experimental surface honest. The
+decision artifact lists the concrete blockers (stable corpus +
+re-pass TQ2 + re-pass TQ3) required for default-promotion.
+
+### Files
+
+```
+holo_index/core/backend_routing.py          (new)
+holo_index/core/holo_index.py               (modified)
+holo_index/core/search_engine.py            (modified)
+holo_index/tests/test_backend_routing.py    (new)
+holo_index/scripts/benchmarks/tq3_routed_corpus_audit.py   (new)
+docs/audits/holoindex_turboquant/TQ3_PER_COLLECTION_ROUTING.md   (new)
+docs/audits/holoindex_turboquant/tq3_metrics.json                (new)
+docs/audits/holoindex_turboquant/tq3_divergent_queries.json      (new)
+```
+
+---
+
 ## [2026-04-23] HIA3 — TurboQuant ONNX int8 Backend (experimental, opt-in) (hia3_turboquant_onnx_backend)
 
 **Agent**: 0102 (W5)

--- a/holo_index/core/backend_routing.py
+++ b/holo_index/core/backend_routing.py
@@ -83,7 +83,15 @@ def resolve_backend_for_collection(
     returned value reflects the actual backend used (fp32 fallback), so
     downstream metadata surfaces the truth.
     """
+    # Even with routing inactive, we must honor available_backends — if only
+    # int8 loaded (degraded mode), return int8 truthfully instead of claiming
+    # fp32 (WSP 97: never lie about the backend that will actually encode).
     if not routing_active:
+        if available_backends is not None and DEFAULT_BACKEND not in available_backends:
+            # Degraded mode: fp32 unavailable. Return whatever IS loaded.
+            for key in (BACKEND_TURBOQUANT,):
+                if key in available_backends:
+                    return key
         return DEFAULT_BACKEND
     requested = COLLECTION_BACKEND_ROUTING.get(collection_name, DEFAULT_BACKEND)
     if available_backends is not None and requested not in available_backends:

--- a/holo_index/core/backend_routing.py
+++ b/holo_index/core/backend_routing.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+"""HoloIndex per-collection embedding backend routing (TQ3 slice).
+
+TQ2 (docs/audits/holoindex_turboquant/TQ2_FP32_INT8_REAL_CORPUS_AUDIT.md)
+measured that the HIA3 TurboQuant ONNX int8 backend is retrieval-equivalent
+to fp32 on every production navigation collection *except*
+``navigation_vocabulary`` (30-doc corpus; top-5 set-agreement 43.3% vs the
+95% gate). Rather than holding int8 off entirely or promoting it globally,
+TQ3 adds per-collection routing: int8 where TQ2 proved equivalence, fp32
+where it did not.
+
+Contract (WSP 97 truth distinction):
+
+  * Routing is **opt-in**: inactive unless ``HOLO_USE_TURBOQUANT=1``.
+  * Routing is **safe**: inactive unless *both* backends loaded cleanly.
+  * The fp32 ``SentenceTransformer`` path is always treated as the
+    authoritative baseline (it built every row currently in ChromaDB).
+  * Collections not listed in the routing map fall back to the fp32
+    baseline. Adding a collection to the int8 lane is a deliberate
+    policy choice that MUST be backed by a gate re-run (see TQ3 report).
+"""
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+# Canonical backend keys. Must match ``embedding_backend`` values the rest
+# of holo_index surfaces (see holo_index.core.search_engine).
+BACKEND_SENTENCE_TRANSFORMERS = "sentence_transformers"
+BACKEND_TURBOQUANT = "turboquant_onnx_int8"
+
+# Per-collection routing policy (TQ3 Phase 1).
+#
+# Every entry here MUST have TQ-series evidence supporting the choice. Today:
+#   * code / wsp / skills / symbols  -> int8 (TQ2 measured 100% top-1 +
+#                                              100% top-5 + Jaccard 1.0 +
+#                                              Kendall tau 1.0 across
+#                                              23,801 docs total).
+#   * vocabulary                     -> fp32 (TQ2 measured 86.7% top-1 and
+#                                              43.3% top-5 on 30 docs;
+#                                              blocker for int8 promotion).
+#
+# ``navigation_tests`` is intentionally omitted because TQ2 could not
+# audit it (empty collection at audit time). It therefore falls through
+# to the safe default via :func:`resolve_backend_for_collection`.
+COLLECTION_BACKEND_ROUTING: Dict[str, str] = {
+    "navigation_code": BACKEND_TURBOQUANT,
+    "navigation_wsp": BACKEND_TURBOQUANT,
+    "navigation_skills": BACKEND_TURBOQUANT,
+    "navigation_symbols": BACKEND_TURBOQUANT,
+    "navigation_vocabulary": BACKEND_SENTENCE_TRANSFORMERS,
+}
+
+# Default backend for collections not explicitly listed above. Stays on
+# fp32 because fp32 is the embedder that built every live collection —
+# any unaudited collection must default to the authoritative baseline.
+DEFAULT_BACKEND: str = BACKEND_SENTENCE_TRANSFORMERS
+
+
+def resolve_backend_for_collection(
+    collection_name: str,
+    routing_active: bool,
+    available_backends: Optional[Dict[str, object]] = None,
+) -> str:
+    """Return the ``embedding_backend`` key to use for *collection_name*.
+
+    Args:
+        collection_name: Name of the Chroma collection being queried.
+        routing_active: True only when ``HOLO_USE_TURBOQUANT=1`` *and*
+            both fp32 and int8 backends loaded cleanly on this
+            HoloIndex instance.
+        available_backends: Optional dict of loaded backends keyed by
+            backend name. If provided, the resolver guarantees it will
+            only return a key that is present — if the routed choice is
+            not loaded, it falls back to whatever single backend IS
+            loaded (or to ``DEFAULT_BACKEND`` as a last resort).
+
+    Returns:
+        One of the ``BACKEND_*`` constants. Caller is responsible for
+        mapping that key to a concrete embedder instance.
+
+    WSP 97: The resolver MUST NOT silently hide a missing backend. If
+    the routing map says ``turboquant`` but int8 is unavailable, the
+    returned value reflects the actual backend used (fp32 fallback), so
+    downstream metadata surfaces the truth.
+    """
+    if not routing_active:
+        return DEFAULT_BACKEND
+    requested = COLLECTION_BACKEND_ROUTING.get(collection_name, DEFAULT_BACKEND)
+    if available_backends is not None and requested not in available_backends:
+        for key in (DEFAULT_BACKEND, BACKEND_TURBOQUANT):
+            if key in available_backends:
+                return key
+        return DEFAULT_BACKEND
+    return requested
+
+
+def build_collection_backend_map(
+    collection_names,
+    routing_active: bool,
+    available_backends: Optional[Dict[str, object]] = None,
+) -> Dict[str, str]:
+    """Return the full ``{collection_name: backend_key}`` map.
+
+    Emitted on every search response so callers can verify per-collection
+    backend truth without re-deriving the routing policy.
+    """
+    return {
+        name: resolve_backend_for_collection(
+            name, routing_active, available_backends
+        )
+        for name in collection_names
+    }

--- a/holo_index/core/holo_index.py
+++ b/holo_index/core/holo_index.py
@@ -201,48 +201,74 @@ class HoloIndex:
         offline = os.getenv("HOLO_OFFLINE") == "1"
         model_cached = self._model_cache_present(model_name)
 
-        # FX1-D: Track retrieval mode explicitly (semantic/lexical/failed).
-        # HIA-TAX1 (2026-04-21): retrieval_mode describes *what* retrieval does;
-        # embedding_backend describes *how* the semantic vectors are produced.
-        # These are separate WSP 97 claims — conflating them (e.g. a
-        # retrieval_mode="turboquant" value) overclaims the mode.
-        #
-        #   retrieval_mode    ∈ {semantic, lexical, failed}
-        #   embedding_backend ∈ {sentence_transformers, turboquant_onnx_int8, none, unknown}
-        #
-        # "none" covers both lexical (no embedder) and failed (nothing loaded).
-        # HIA3 (2026-04-23): TurboQuant became a real backend (ORT int8).
-        # Its canonical label is "turboquant_onnx_int8" (see
-        # holo_index.core.turboquant_backend.BACKEND_NAME). HIA3 is an
-        # experimental opt-in — TQ1 benchmark measured 3.65% cosine drift
-        # and 76.7% top-1 agreement; static calibration is required before
-        # default promotion. search_engine.py surfaces this via
-        # backend_quality="experimental" and quality_gate="not_default_ready".
-        self.retrieval_mode = "failed"  # Default until proven otherwise
+        # FX1-D / HIA-TAX1: retrieval_mode vs embedding_backend taxonomy
+        # (semantic/lexical/failed) x (sentence_transformers/turboquant_onnx_int8/none).
+        # HIA3 introduced the real int8 backend; TQ3 (2026-04-23) adds
+        # per-collection routing so int8 serves only the collections TQ2 proved
+        # equivalent, while fp32 stays authoritative everywhere else.
+        self.retrieval_mode = "failed"
         self.embedding_backend = "none"
 
-        # Optional fast-start skip to prevent long imports (set HOLO_SKIP_MODEL=1)
+        # TQ3: per-collection routing state.
+        #   embedders              : backend_key -> loaded embedder instance
+        #   routing_active         : True only when HOLO_USE_TURBOQUANT=1 AND
+        #                            both backends loaded cleanly (so every
+        #                            collection can be served by its routed
+        #                            choice without silent degradation).
+        #   collection_backend_map : collection_name -> backend_key actually
+        #                            used (truth for search_engine metadata).
+        # When routing is inactive, the map falls back to the loaded primary
+        # (fp32 when available) so callers still see truthful per-collection
+        # backend attribution.
+        from .backend_routing import (
+            build_collection_backend_map,
+            BACKEND_SENTENCE_TRANSFORMERS as _ROUTE_ST,
+            BACKEND_TURBOQUANT as _ROUTE_TQ,
+        )
+        self.embedders: Dict[str, Any] = {}
+        self.routing_active: bool = False
+        self.collection_backend_map: Dict[str, str] = {}
+
+        tq_requested = _turboquant_enabled()
+        st_loaded = False
+        tq_loaded = False
+
         if os.environ.get("HOLO_SKIP_MODEL") == "1":
-            self._log_agent_action("HOLO_SKIP_MODEL=1 -> skipping sentence transformer load (lexical mode)", "WARN")
-            self.model = None
-            self.retrieval_mode = "lexical"
-            self.embedding_backend = "none"
+            self._log_agent_action("HOLO_SKIP_MODEL=1 -> skipping model load (lexical mode)", "WARN")
         elif offline and not model_cached:
             self._log_agent_action("HOLO_OFFLINE=1 and model cache missing -> skipping model load (lexical mode)", "WARN")
-            self.model = None
-            self.retrieval_mode = "lexical"
-            self.embedding_backend = "none"
         else:
-            # HIA3 / HIA-TAX1: optional TurboQuant ONNX int8 backend (opt-in via
-            # HOLO_USE_TURBOQUANT=1). TurboQuant is a *semantic* backend; when
-            # active, retrieval_mode="semantic" and
-            # embedding_backend="turboquant_onnx_int8". Experimental — TQ1
-            # measured 3.65% cosine drift vs fp32 and 76.7% top-1 agreement.
-            # search_engine.py surfaces backend_quality="experimental" and
-            # quality_gate="not_default_ready" on the response metadata.
-            # On any failure (dep missing, artifact missing, load error), we
-            # fall through to the SentenceTransformer backend without raising.
-            if _turboquant_enabled():
+            # Always try fp32 first: it built every live Chroma row and is the
+            # authoritative baseline. Routing only degrades from here.
+            global SentenceTransformer
+            if SentenceTransformer is None:
+                self._log_agent_action(f"Importing SentenceTransformer (timeout={HOLO_MODEL_IMPORT_TIMEOUT}s)...", "MODEL")
+                SentenceTransformer = _run_with_timeout(
+                    _import_sentence_transformers,
+                    timeout_sec=HOLO_MODEL_IMPORT_TIMEOUT,
+                    default=None,
+                    error_msg="SentenceTransformer import timed out",
+                    missing_dep_hint="pip install sentence-transformers (or use HOLO_SKIP_MODEL=1 for lexical-only)",
+                )
+
+            if SentenceTransformer:
+                self._log_agent_action(f"Loading fp32 model '{model_name}' (timeout={HOLO_MODEL_LOAD_TIMEOUT}s)...", "MODEL")
+                st_model = _run_with_timeout(
+                    lambda: _load_model(SentenceTransformer, model_name),
+                    timeout_sec=HOLO_MODEL_LOAD_TIMEOUT,
+                    default=None,
+                    error_msg=f"Model '{model_name}' load timed out",
+                )
+                if st_model is not None:
+                    self.embedders[_ROUTE_ST] = st_model
+                    st_loaded = True
+                else:
+                    self._log_agent_action("fp32 model load failed", "WARN")
+            else:
+                self._log_agent_action("SentenceTransformer unavailable", "WARN")
+
+            # Optionally load TurboQuant int8 alongside fp32 (TQ3 routing).
+            if tq_requested:
                 try:
                     from .turboquant_backend import (
                         TurboQuantEmbedder,
@@ -250,78 +276,71 @@ class HoloIndex:
                     )
                     if TurboQuantEmbedder.is_available():
                         self._log_agent_action(
-                            "HOLO_USE_TURBOQUANT=1 -> loading TurboQuant backend "
-                            "(semantic, experimental, not_default_ready)",
+                            "HOLO_USE_TURBOQUANT=1 -> loading int8 backend alongside fp32 (TQ3 routing)",
                             "MODEL",
                         )
                         try:
-                            embedder = TurboQuantEmbedder()
-                            embedder._ensure_loaded()
-                            self.model = embedder
-                            self.retrieval_mode = "semantic"
-                            self.embedding_backend = _TQ_BACKEND_NAME
+                            tq_embedder = TurboQuantEmbedder()
+                            tq_embedder._ensure_loaded()
+                            self.embedders[_TQ_BACKEND_NAME] = tq_embedder
+                            tq_loaded = True
                         except Exception as load_err:
                             self._log_agent_action(
                                 f"TurboQuant load failed ({load_err}); "
-                                "falling back to SentenceTransformer",
+                                "routing disabled (fp32 only)",
                                 "WARN",
                             )
                     else:
                         self._log_agent_action(
                             "TurboQuant not available (dep/artifacts missing); "
-                            "falling back to SentenceTransformer",
+                            "routing disabled (fp32 only)",
                             "WARN",
                         )
                 except Exception as e:
                     self._log_agent_action(
-                        f"TurboQuant init failed ({e}); falling back to SentenceTransformer",
+                        f"TurboQuant init failed ({e}); routing disabled (fp32 only)",
                         "WARN",
                     )
 
-            if (
-                getattr(self, "model", None) is not None
-                and isinstance(self.embedding_backend, str)
-                and self.embedding_backend.startswith("turboquant")
-            ):
-                # TurboQuant loaded successfully; skip SentenceTransformer path entirely.
-                pass
-            else:
-                global SentenceTransformer
-                if SentenceTransformer is None:
-                    # WSP 97: Import with hard timeout to prevent indefinite hangs
-                    self._log_agent_action(f"Importing SentenceTransformer (timeout={HOLO_MODEL_IMPORT_TIMEOUT}s)...", "MODEL")
-                    SentenceTransformer = _run_with_timeout(
-                        _import_sentence_transformers,
-                        timeout_sec=HOLO_MODEL_IMPORT_TIMEOUT,
-                        default=None,
-                        error_msg="SentenceTransformer import timed out",
-                        missing_dep_hint="pip install sentence-transformers (or use HOLO_SKIP_MODEL=1 for lexical-only)"
-                    )
-                    if SentenceTransformer is None:
-                        self._log_agent_action("SentenceTransformer unavailable; falling back to lexical search", "WARN")
-                        self.retrieval_mode = "lexical"
-                        self.embedding_backend = "none"
+        # Resolve primary embedder and top-level taxonomy from what loaded.
+        if st_loaded:
+            self.model = self.embedders[_ROUTE_ST]
+        elif tq_loaded:
+            # Degraded: only int8 loaded. Routing cannot be active.
+            self.model = self.embedders[_ROUTE_TQ]
+        else:
+            self.model = None
 
-                if SentenceTransformer:
-                    # WSP 97: Load model with hard timeout
-                    self._log_agent_action(f"Loading model '{model_name}' (timeout={HOLO_MODEL_LOAD_TIMEOUT}s)...", "MODEL")
-                    self.model = _run_with_timeout(
-                        lambda: _load_model(SentenceTransformer, model_name),
-                        timeout_sec=HOLO_MODEL_LOAD_TIMEOUT,
-                        default=None,
-                        error_msg=f"Model '{model_name}' load timed out"
-                    )
-                    if self.model is None:
-                        self._log_agent_action("Model load failed; falling back to lexical search", "WARN")
-                        self.retrieval_mode = "lexical"
-                        self.embedding_backend = "none"
-                    else:
-                        self.retrieval_mode = "semantic"
-                        self.embedding_backend = "sentence_transformers"
-                else:
-                    self.model = None
-                    self.retrieval_mode = "lexical"
-                    self.embedding_backend = "none"
+        # Routing requires opt-in AND both backends healthy.
+        self.routing_active = bool(tq_requested and st_loaded and tq_loaded)
+
+        if self.model is not None:
+            self.retrieval_mode = "semantic"
+            if self.routing_active:
+                # Mixed mode: WSP 97 forbids overclaiming a single backend name.
+                self.embedding_backend = "routed"
+            elif tq_loaded and not st_loaded:
+                self.embedding_backend = _ROUTE_TQ
+            else:
+                self.embedding_backend = _ROUTE_ST
+        else:
+            self.retrieval_mode = "lexical"
+            self.embedding_backend = "none"
+
+        # Per-collection backend attribution (always populated for truth).
+        _collection_names = [
+            "navigation_code",
+            "navigation_wsp",
+            "navigation_tests",
+            "navigation_skills",
+            "navigation_symbols",
+            "navigation_vocabulary",
+        ]
+        self.collection_backend_map = build_collection_backend_map(
+            _collection_names,
+            routing_active=self.routing_active,
+            available_backends=self.embedders or None,
+        )
 
         self.need_to: Dict[str, str] = {}
         self.wsp_summary: Dict[str, Dict[str, str]] = {}

--- a/holo_index/core/search_engine.py
+++ b/holo_index/core/search_engine.py
@@ -55,12 +55,17 @@ _BACKEND_QUALITY: Dict[str, str] = {
     "sentence_transformers": "production",
     "turboquant_onnx_int8": "experimental",
     "none": "n/a",
+    # TQ3: when per-collection routing is active, the top-level backend
+    # is "routed" — a mixed claim. Callers needing per-collection truth
+    # read ``collection_backend_map`` on the same metadata block.
+    "routed": "mixed",
 }
 
 _QUALITY_GATE: Dict[str, str] = {
     "sentence_transformers": "default_ready",
     "turboquant_onnx_int8": "not_default_ready",
     "none": "n/a",
+    "routed": "mixed",
 }
 
 
@@ -223,7 +228,25 @@ def _search_collection(
     except Exception:
         return []
 
-    model = getattr(holo, "model", None)
+    # TQ3: select the embedder routed for this specific collection. The
+    # resolver honors ``holo.routing_active`` and the available embedders,
+    # so a missing int8 backend degrades truthfully to fp32 (never silent).
+    from .backend_routing import resolve_backend_for_collection
+
+    embedders = getattr(holo, "embedders", None) or None
+    collection_name = getattr(collection, "name", "") or ""
+    routing_active = bool(getattr(holo, "routing_active", False))
+    backend_key = resolve_backend_for_collection(
+        collection_name,
+        routing_active=routing_active,
+        available_backends=embedders,
+    )
+    model = None
+    if embedders is not None:
+        model = embedders.get(backend_key)
+    if model is None:
+        # Fallback to the legacy single-model attribute (tests monkeypatch it).
+        model = getattr(holo, "model", None)
     if model is None:
         holo._log_agent_action("Embedding model not available - using offline lexical scan", "WARN")
         return _lexical_search_collection(holo, collection, query, limit, kind, doc_type_filter)
@@ -620,6 +643,15 @@ def execute_search(
                 ),
                 "quality_gate": _quality_gate(
                     getattr(holo, "embedding_backend", "unknown")
+                ),
+                # TQ3: per-collection routing truth (WSP 97). When
+                # routing_active=True, embedding_backend="routed" and the
+                # per-collection claim lives in collection_backend_map.
+                # When inactive, the map still reports the single backend
+                # used for every collection (never overclaims).
+                "routing_active": bool(getattr(holo, "routing_active", False)),
+                "collection_backend_map": dict(
+                    getattr(holo, "collection_backend_map", {}) or {}
                 ),
             },
         }

--- a/holo_index/scripts/benchmarks/tq3_routed_corpus_audit.py
+++ b/holo_index/scripts/benchmarks/tq3_routed_corpus_audit.py
@@ -1,0 +1,319 @@
+# -*- coding: utf-8 -*-
+"""TQ3 — routed (per-collection) retrieval audit for HoloIndex.
+
+Purpose:
+    Re-run the TQ2 A/B gate **under per-collection routing**. TQ2 audited
+    pure-int8 vs pure-fp32 and returned ``HOLD_INT8`` because
+    ``navigation_vocabulary`` (30 docs) drove the overall top-5
+    set-agreement to 88.7%, below the 95% gate. Every other collection
+    (code/wsp/skills/symbols) scored 100% / 100% / Jaccard 1.0 / Kendall
+    tau 1.0 on 23,801 docs combined.
+
+    TQ3 introduces ``holo_index.core.backend_routing``: int8 serves the
+    four equivalent collections; fp32 serves ``navigation_vocabulary``.
+    The "routed" side of this audit asks: under that policy, does the
+    overall retrieval behavior match pure-fp32 well enough to promote
+    the routing policy (not the raw int8 backend) to default-ready?
+
+Method (WSP 97 truthful-assessment):
+
+    * fp32 baseline = ``SentenceTransformer('all-MiniLM-L6-v2')``, the
+      production baseline that built every Chroma row.
+    * Routed side = for each collection, use the backend that
+      ``resolve_backend_for_collection`` returns **as if**
+      ``routing_active=True`` with both backends loaded. In practice:
+        - navigation_code / wsp / skills / symbols -> int8
+        - navigation_vocabulary                    -> fp32
+        - navigation_tests                         -> fp32 (unlisted)
+    * Corpus stays fp32-indexed (same ``HOLD_INT8`` constraint as TQ2).
+    * Query set, sentinels, gate, and metric definitions are all frozen
+      identical to TQ2 so the routed number is directly comparable.
+
+Promotion gate (same thresholds as TQ2):
+
+    * overall top-1 agreement >= 90%
+    * overall top-5 set-agreement >= 95%
+    * all sentinel queries: top-1 agrees with fp32
+
+    Emits ``PROMOTE_ROUTING`` or ``HOLD_ROUTING``.
+
+Expected result: PROMOTE_ROUTING. Vocabulary is served by fp32 under
+routing, so its 100% self-agreement replaces the 86.7% / 43.3% score
+that blocked TQ2. No regression is expected on the other collections.
+
+Usage::
+
+    HOLO_USE_TURBOQUANT=1 python holo_index/scripts/benchmarks/tq3_routed_corpus_audit.py
+
+Outputs:
+
+    docs/audits/holoindex_turboquant/tq3_metrics.json
+    docs/audits/holoindex_turboquant/tq3_divergent_queries.json
+
+WSP: WSP 15, WSP 97.
+"""
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import time
+from pathlib import Path
+from typing import Any
+
+# Reuse the frozen query set, sentinels, helpers, and staging logic from TQ2
+# so TQ3 is a policy-overlay on identical evidence (WSP 97: do not drift the
+# measurement tool between slices).
+from holo_index.scripts.benchmarks.tq2_real_corpus_audit import (
+    CHROMA_PATH,
+    SENTINEL_QUERIES,
+    TQ2_QUERIES,
+    _jaccard,
+    _kendall_tau_on_common,
+    _percentile,
+    _stage_int8_with_tokenizer,
+)
+from holo_index.core.backend_routing import (
+    BACKEND_SENTENCE_TRANSFORMERS,
+    BACKEND_TURBOQUANT,
+    resolve_backend_for_collection,
+)
+
+
+def main() -> int:
+    print("[TQ3] preflight - staging int8 + tokenizer")
+    staging = _stage_int8_with_tokenizer()
+    os.environ["HOLO_TURBOQUANT_MODEL_DIR"] = str(staging)
+
+    print("[TQ3] loading fp32 SentenceTransformer (baseline AND vocabulary backend)")
+    t0 = time.perf_counter()
+    from sentence_transformers import SentenceTransformer
+    fp32 = SentenceTransformer("all-MiniLM-L6-v2", cache_folder="E:/HoloIndex/models")
+    fp32_cold = time.perf_counter() - t0
+
+    print("[TQ3] loading int8 TurboQuantEmbedder (routed code/wsp/skills/symbols)")
+    t0 = time.perf_counter()
+    from holo_index.core.turboquant_backend import TurboQuantEmbedder
+    if not TurboQuantEmbedder.is_available():
+        raise SystemExit("TQ3: TurboQuantEmbedder.is_available() False after staging - abort")
+    int8 = TurboQuantEmbedder()
+    int8._ensure_loaded()
+    int8_cold = time.perf_counter() - t0
+
+    # Both backends present -> routing would be active in a real HoloIndex.
+    embedders = {
+        BACKEND_SENTENCE_TRANSFORMERS: fp32,
+        BACKEND_TURBOQUANT: int8,
+    }
+
+    print("[TQ3] opening Chroma client")
+    import chromadb
+    client = chromadb.PersistentClient(path=CHROMA_PATH)
+
+    target_cols = [
+        "navigation_code",
+        "navigation_wsp",
+        "navigation_tests",
+        "navigation_skills",
+        "navigation_symbols",
+        "navigation_vocabulary",
+    ]
+    collections: dict[str, Any] = {}
+    counts: dict[str, int] = {}
+    for name in target_cols:
+        try:
+            col = client.get_collection(name)
+            c = col.count()
+            counts[name] = c
+            if c > 0:
+                collections[name] = col
+        except Exception as e:
+            counts[name] = -1
+            print(f"[TQ3] collection {name}: ERROR {e}")
+
+    # Per-collection backend routing snapshot for this audit (truth surface).
+    collection_backend_map = {
+        name: resolve_backend_for_collection(
+            name, routing_active=True, available_backends=embedders,
+        )
+        for name in target_cols
+    }
+    print(f"[TQ3] collections in audit: {list(collections.keys())}")
+    print(f"[TQ3] counts: {counts}")
+    print(f"[TQ3] routing policy: {collection_backend_map}")
+
+    fp32_encode_times: list[float] = []
+    routed_encode_times: list[float] = []
+    fp32_query_times: list[float] = []
+    routed_query_times: list[float] = []
+
+    per_collection: dict[str, dict[str, Any]] = {}
+    divergent: list[dict[str, Any]] = []
+    sentinel_results: list[dict[str, Any]] = []
+
+    K_VALUES = (1, 3, 5, 10)
+
+    for col_name, col in collections.items():
+        routed_backend_key = collection_backend_map[col_name]
+        routed_embedder = embedders[routed_backend_key]
+        print(f"[TQ3] auditing {col_name} ({counts[col_name]} docs) via {routed_backend_key}")
+
+        top1_matches = 0
+        top5_set_matches = 0
+        jaccards = {k: [] for k in K_VALUES}
+        taus: list[float] = []
+
+        for q in TQ2_QUERIES:
+            t = time.perf_counter()
+            v_fp32 = fp32.encode(q, show_progress_bar=False)
+            fp32_encode_times.append(time.perf_counter() - t)
+
+            t = time.perf_counter()
+            v_routed = routed_embedder.encode(q, show_progress_bar=False)
+            routed_encode_times.append(time.perf_counter() - t)
+
+            t = time.perf_counter()
+            r_fp32 = col.query(query_embeddings=[v_fp32.tolist()], n_results=10)
+            fp32_query_times.append(time.perf_counter() - t)
+
+            t = time.perf_counter()
+            r_routed = col.query(query_embeddings=[v_routed.tolist()], n_results=10)
+            routed_query_times.append(time.perf_counter() - t)
+
+            ids_fp32 = r_fp32["ids"][0]
+            ids_routed = r_routed["ids"][0]
+
+            if ids_fp32 and ids_routed and ids_fp32[0] == ids_routed[0]:
+                top1_matches += 1
+            if set(ids_fp32[:5]) == set(ids_routed[:5]):
+                top5_set_matches += 1
+
+            for k in K_VALUES:
+                jaccards[k].append(_jaccard(ids_fp32[:k], ids_routed[:k]))
+            taus.append(_kendall_tau_on_common(ids_fp32, ids_routed))
+
+            if ids_fp32 and ids_routed and ids_fp32[0] != ids_routed[0]:
+                divergent.append({
+                    "collection": col_name,
+                    "routed_backend": routed_backend_key,
+                    "query": q,
+                    "fp32_top1": ids_fp32[0],
+                    "routed_top1": ids_routed[0],
+                    "fp32_top5": ids_fp32[:5],
+                    "routed_top5": ids_routed[:5],
+                })
+
+            if q in SENTINEL_QUERIES:
+                sentinel_results.append({
+                    "collection": col_name,
+                    "routed_backend": routed_backend_key,
+                    "query": q,
+                    "fp32_top1": ids_fp32[0] if ids_fp32 else None,
+                    "routed_top1": ids_routed[0] if ids_routed else None,
+                    "top1_agree": bool(ids_fp32 and ids_routed and ids_fp32[0] == ids_routed[0]),
+                })
+
+        n = len(TQ2_QUERIES)
+        per_collection[col_name] = {
+            "doc_count": counts[col_name],
+            "routed_backend": routed_backend_key,
+            "queries": n,
+            "top1_agreement_pct": top1_matches / n * 100.0,
+            "top5_set_agreement_pct": top5_set_matches / n * 100.0,
+            "jaccard_mean": {f"k={k}": statistics.mean(jaccards[k]) for k in K_VALUES},
+            "jaccard_min": {f"k={k}": min(jaccards[k]) for k in K_VALUES},
+            "kendall_tau_mean": statistics.mean(taus),
+            "kendall_tau_min": min(taus),
+        }
+
+    n_total = sum(per_collection[c]["queries"] for c in per_collection)
+    overall_top1 = (
+        sum(per_collection[c]["top1_agreement_pct"] * per_collection[c]["queries"]
+            for c in per_collection) / n_total
+        if n_total else 0.0
+    )
+    overall_top5 = (
+        sum(per_collection[c]["top5_set_agreement_pct"] * per_collection[c]["queries"]
+            for c in per_collection) / n_total
+        if n_total else 0.0
+    )
+    sentinels_pass = all(r["top1_agree"] for r in sentinel_results) if sentinel_results else False
+
+    GATE_TOP1 = 90.0
+    GATE_TOP5 = 95.0
+    promote = (
+        overall_top1 >= GATE_TOP1
+        and overall_top5 >= GATE_TOP5
+        and sentinels_pass
+    )
+    decision = "PROMOTE_ROUTING" if promote else "HOLD_ROUTING"
+    blockers: list[str] = []
+    if overall_top1 < GATE_TOP1:
+        blockers.append(f"overall top-1 agreement {overall_top1:.1f}% < {GATE_TOP1}%")
+    if overall_top5 < GATE_TOP5:
+        blockers.append(f"overall top-5 set-agreement {overall_top5:.1f}% < {GATE_TOP5}%")
+    if not sentinels_pass:
+        failed = [r for r in sentinel_results if not r["top1_agree"]]
+        blockers.append(f"{len(failed)} sentinel query regressions")
+
+    metrics = {
+        "slice": "TQ3_PER_COLLECTION_BACKEND_ROUTING_PHASE1",
+        "chroma_path": CHROMA_PATH,
+        "collection_counts": counts,
+        "audited_collections": list(collections.keys()),
+        "routing_policy": collection_backend_map,
+        "n_queries": len(TQ2_QUERIES),
+        "n_sentinels": len(SENTINEL_QUERIES),
+        "gate_thresholds": {
+            "top1_agreement_pct": GATE_TOP1,
+            "top5_set_agreement_pct": GATE_TOP5,
+            "sentinel_top1_required": "all",
+        },
+        "overall": {
+            "top1_agreement_pct": overall_top1,
+            "top5_set_agreement_pct": overall_top5,
+            "sentinels_pass": sentinels_pass,
+            "sentinel_results": sentinel_results,
+        },
+        "per_collection": per_collection,
+        "latency_ms": {
+            "fp32_encode_p50": _percentile(fp32_encode_times, 50) * 1000,
+            "fp32_encode_p95": _percentile(fp32_encode_times, 95) * 1000,
+            "routed_encode_p50": _percentile(routed_encode_times, 50) * 1000,
+            "routed_encode_p95": _percentile(routed_encode_times, 95) * 1000,
+            "fp32_query_p50": _percentile(fp32_query_times, 50) * 1000,
+            "fp32_query_p95": _percentile(fp32_query_times, 95) * 1000,
+            "routed_query_p50": _percentile(routed_query_times, 50) * 1000,
+            "routed_query_p95": _percentile(routed_query_times, 95) * 1000,
+        },
+        "cold_load_sec": {
+            "fp32_sentence_transformer": fp32_cold,
+            "int8_turboquant_embedder": int8_cold,
+        },
+        "decision": decision,
+        "blockers": blockers,
+    }
+
+    repo_root = Path(__file__).resolve().parents[3]
+    audit_dir = repo_root / "docs" / "audits" / "holoindex_turboquant"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+
+    metrics_path = audit_dir / "tq3_metrics.json"
+    div_path = audit_dir / "tq3_divergent_queries.json"
+    metrics_path.write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+    div_path.write_text(json.dumps({
+        "n_divergent": len(divergent),
+        "divergent": divergent,
+    }, indent=2), encoding="utf-8")
+
+    print(f"[TQ3] metrics: {metrics_path}")
+    print(f"[TQ3] divergent: {div_path}")
+    print(f"[TQ3] overall top-1 = {overall_top1:.1f}%  top-5 = {overall_top5:.1f}%  sentinels_pass={sentinels_pass}")
+    print(f"[TQ3] decision = {decision}")
+    if blockers:
+        print(f"[TQ3] blockers: {blockers}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/holo_index/tests/test_backend_routing.py
+++ b/holo_index/tests/test_backend_routing.py
@@ -1,0 +1,208 @@
+# -*- coding: utf-8 -*-
+"""TQ3 backend-routing unit tests.
+
+Covers ``holo_index.core.backend_routing`` — the policy module that decides,
+per collection, whether a query is served by fp32 SentenceTransformer or int8
+TurboQuant.
+
+These tests intentionally avoid instantiating ``HoloIndex`` so they stay fast
+and work without ChromaDB, ONNX, or the MiniLM model on disk. The taxonomy
+contract they lock in:
+
+  * Routing is OFF unless ``routing_active=True``.
+  * Every routed choice must be in ``available_backends`` (when supplied);
+    otherwise the resolver falls through to whatever IS loaded — never
+    silently returns a backend that cannot encode.
+  * ``navigation_vocabulary`` stays fp32 (TQ2 gate blocker).
+  * ``navigation_code / wsp / skills / symbols`` go int8 when routing is on.
+  * Unlisted collections (e.g. ``navigation_tests``) default to fp32 — the
+    corpus-building baseline.
+"""
+from __future__ import annotations
+
+import unittest
+
+from holo_index.core.backend_routing import (
+    BACKEND_SENTENCE_TRANSFORMERS,
+    BACKEND_TURBOQUANT,
+    COLLECTION_BACKEND_ROUTING,
+    DEFAULT_BACKEND,
+    build_collection_backend_map,
+    resolve_backend_for_collection,
+)
+
+
+class _Sentinel:
+    """Stand-in for a loaded embedder — identity is all the resolver checks."""
+
+
+class TestRoutingPolicyMap(unittest.TestCase):
+    """The static policy table is the artifact TQ2 evidence supports."""
+
+    def test_int8_lane_is_code_wsp_skills_symbols(self):
+        int8_lane = {
+            name
+            for name, backend in COLLECTION_BACKEND_ROUTING.items()
+            if backend == BACKEND_TURBOQUANT
+        }
+        self.assertEqual(
+            int8_lane,
+            {
+                "navigation_code",
+                "navigation_wsp",
+                "navigation_skills",
+                "navigation_symbols",
+            },
+        )
+
+    def test_vocabulary_is_fp32(self):
+        """TQ2 gate blocker — 43.3% top-5 agreement on 30 docs."""
+        self.assertEqual(
+            COLLECTION_BACKEND_ROUTING["navigation_vocabulary"],
+            BACKEND_SENTENCE_TRANSFORMERS,
+        )
+
+    def test_navigation_tests_intentionally_omitted(self):
+        """TQ2 could not audit navigation_tests (empty at audit time)."""
+        self.assertNotIn("navigation_tests", COLLECTION_BACKEND_ROUTING)
+
+    def test_default_backend_is_fp32(self):
+        """Default must be the backend that built every live Chroma row."""
+        self.assertEqual(DEFAULT_BACKEND, BACKEND_SENTENCE_TRANSFORMERS)
+
+
+class TestResolveBackendForCollection(unittest.TestCase):
+    """``resolve_backend_for_collection`` — per-query backend selection."""
+
+    def test_inactive_routing_returns_default(self):
+        for name in COLLECTION_BACKEND_ROUTING:
+            self.assertEqual(
+                resolve_backend_for_collection(name, routing_active=False),
+                DEFAULT_BACKEND,
+                msg=f"inactive routing must always return fp32 (got mismatch for {name})",
+            )
+
+    def test_active_routing_sends_int8_lane_to_turboquant(self):
+        both = {
+            BACKEND_SENTENCE_TRANSFORMERS: _Sentinel(),
+            BACKEND_TURBOQUANT: _Sentinel(),
+        }
+        for name in ("navigation_code", "navigation_wsp",
+                     "navigation_skills", "navigation_symbols"):
+            self.assertEqual(
+                resolve_backend_for_collection(
+                    name, routing_active=True, available_backends=both,
+                ),
+                BACKEND_TURBOQUANT,
+                msg=f"{name} must route to int8 under active routing",
+            )
+
+    def test_active_routing_keeps_vocabulary_on_fp32(self):
+        both = {
+            BACKEND_SENTENCE_TRANSFORMERS: _Sentinel(),
+            BACKEND_TURBOQUANT: _Sentinel(),
+        }
+        self.assertEqual(
+            resolve_backend_for_collection(
+                "navigation_vocabulary",
+                routing_active=True,
+                available_backends=both,
+            ),
+            BACKEND_SENTENCE_TRANSFORMERS,
+        )
+
+    def test_unlisted_collection_falls_through_to_default(self):
+        both = {
+            BACKEND_SENTENCE_TRANSFORMERS: _Sentinel(),
+            BACKEND_TURBOQUANT: _Sentinel(),
+        }
+        self.assertEqual(
+            resolve_backend_for_collection(
+                "navigation_tests",
+                routing_active=True,
+                available_backends=both,
+            ),
+            BACKEND_SENTENCE_TRANSFORMERS,
+        )
+
+    def test_missing_int8_degrades_to_fp32_when_available(self):
+        """WSP 97: never return a backend that is not actually loaded."""
+        only_fp32 = {BACKEND_SENTENCE_TRANSFORMERS: _Sentinel()}
+        self.assertEqual(
+            resolve_backend_for_collection(
+                "navigation_code",
+                routing_active=True,
+                available_backends=only_fp32,
+            ),
+            BACKEND_SENTENCE_TRANSFORMERS,
+        )
+
+    def test_missing_fp32_degrades_to_int8_when_available(self):
+        """Symmetric fallback: if the only loaded embedder is int8, use it."""
+        only_tq = {BACKEND_TURBOQUANT: _Sentinel()}
+        # Vocabulary routes to fp32 under policy, but fp32 is not loaded;
+        # the resolver must return the actually-loaded int8 rather than lie.
+        self.assertEqual(
+            resolve_backend_for_collection(
+                "navigation_vocabulary",
+                routing_active=True,
+                available_backends=only_tq,
+            ),
+            BACKEND_TURBOQUANT,
+        )
+
+    def test_no_available_backends_trusts_policy(self):
+        """When the caller does not pass a backends dict (e.g. policy-only
+        inspection) the resolver trusts the static policy map."""
+        self.assertEqual(
+            resolve_backend_for_collection(
+                "navigation_code", routing_active=True,
+            ),
+            BACKEND_TURBOQUANT,
+        )
+
+
+class TestBuildCollectionBackendMap(unittest.TestCase):
+    """``build_collection_backend_map`` — the dict surfaced on search metadata."""
+
+    def test_inactive_routing_all_fp32(self):
+        names = [
+            "navigation_code", "navigation_wsp", "navigation_tests",
+            "navigation_skills", "navigation_symbols", "navigation_vocabulary",
+        ]
+        result = build_collection_backend_map(names, routing_active=False)
+        self.assertEqual(set(result.values()), {BACKEND_SENTENCE_TRANSFORMERS})
+        self.assertEqual(set(result.keys()), set(names))
+
+    def test_active_routing_mixed_map(self):
+        names = [
+            "navigation_code", "navigation_wsp", "navigation_tests",
+            "navigation_skills", "navigation_symbols", "navigation_vocabulary",
+        ]
+        both = {
+            BACKEND_SENTENCE_TRANSFORMERS: _Sentinel(),
+            BACKEND_TURBOQUANT: _Sentinel(),
+        }
+        result = build_collection_backend_map(
+            names, routing_active=True, available_backends=both,
+        )
+        self.assertEqual(result["navigation_code"], BACKEND_TURBOQUANT)
+        self.assertEqual(result["navigation_wsp"], BACKEND_TURBOQUANT)
+        self.assertEqual(result["navigation_skills"], BACKEND_TURBOQUANT)
+        self.assertEqual(result["navigation_symbols"], BACKEND_TURBOQUANT)
+        self.assertEqual(result["navigation_vocabulary"], BACKEND_SENTENCE_TRANSFORMERS)
+        # navigation_tests is not in the routing policy -> default fp32.
+        self.assertEqual(result["navigation_tests"], BACKEND_SENTENCE_TRANSFORMERS)
+
+    def test_degraded_only_fp32_map_is_all_fp32(self):
+        """If int8 failed to load, every collection must truthfully show fp32."""
+        names = list(COLLECTION_BACKEND_ROUTING.keys())
+        only_fp32 = {BACKEND_SENTENCE_TRANSFORMERS: _Sentinel()}
+        result = build_collection_backend_map(
+            names, routing_active=True, available_backends=only_fp32,
+        )
+        self.assertEqual(set(result.values()), {BACKEND_SENTENCE_TRANSFORMERS})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/holo_index/tests/test_backend_routing.py
+++ b/holo_index/tests/test_backend_routing.py
@@ -82,6 +82,33 @@ class TestResolveBackendForCollection(unittest.TestCase):
                 msg=f"inactive routing must always return fp32 (got mismatch for {name})",
             )
 
+    def test_inactive_routing_int8_only_returns_int8(self):
+        """WSP 97 truth-surface: degraded int8-only mode must report int8, not fp32."""
+        only_tq = {BACKEND_TURBOQUANT: _Sentinel()}
+        for name in COLLECTION_BACKEND_ROUTING:
+            self.assertEqual(
+                resolve_backend_for_collection(
+                    name, routing_active=False, available_backends=only_tq
+                ),
+                BACKEND_TURBOQUANT,
+                msg=f"inactive routing with only int8 must return int8 for {name}",
+            )
+
+    def test_inactive_routing_both_backends_returns_fp32(self):
+        """When routing is inactive but both backends are loaded, fp32 (default) wins."""
+        both = {
+            BACKEND_SENTENCE_TRANSFORMERS: _Sentinel(),
+            BACKEND_TURBOQUANT: _Sentinel(),
+        }
+        for name in COLLECTION_BACKEND_ROUTING:
+            self.assertEqual(
+                resolve_backend_for_collection(
+                    name, routing_active=False, available_backends=both
+                ),
+                BACKEND_SENTENCE_TRANSFORMERS,
+                msg=f"inactive routing with both backends must return fp32 for {name}",
+            )
+
     def test_active_routing_sends_int8_lane_to_turboquant(self):
         both = {
             BACKEND_SENTENCE_TRANSFORMERS: _Sentinel(),
@@ -202,6 +229,22 @@ class TestBuildCollectionBackendMap(unittest.TestCase):
             names, routing_active=True, available_backends=only_fp32,
         )
         self.assertEqual(set(result.values()), {BACKEND_SENTENCE_TRANSFORMERS})
+
+    def test_inactive_routing_int8_only_map_is_all_int8(self):
+        """WSP 97 truth-surface: degraded int8-only with inactive routing must report int8."""
+        names = [
+            "navigation_code", "navigation_wsp", "navigation_tests",
+            "navigation_skills", "navigation_symbols", "navigation_vocabulary",
+        ]
+        only_tq = {BACKEND_TURBOQUANT: _Sentinel()}
+        result = build_collection_backend_map(
+            names, routing_active=False, available_backends=only_tq,
+        )
+        self.assertEqual(
+            set(result.values()),
+            {BACKEND_TURBOQUANT},
+            msg="inactive routing with only int8 must truthfully report int8 for all collections",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Ship TQ3 per-collection embedding-backend routing: int8 TurboQuant for code/wsp/skills/symbols, fp32 for navigation_vocabulary, truthful degraded-load fallback.
- Global default unchanged (`HOLO_USE_TURBOQUANT=0` → pure fp32). No reindex.
- Routed-mode gate returned **`HOLD_ROUTING`** due to Chroma corpus drift between TQ2 (wsp=3,446 docs) and TQ3 (wsp=1,916 docs) runs. Infrastructure is sound; policy-promotion gated on stable-corpus re-audit.

## What's new

| Path | Kind |
| ---- | ---- |
| `holo_index/core/backend_routing.py` | policy module (new) |
| `holo_index/core/holo_index.py` | loads both backends when opted in; exposes `embedders`, `routing_active`, `collection_backend_map` |
| `holo_index/core/search_engine.py` | per-collection embedder resolution; metadata gains `routing_active` + `collection_backend_map`; `embedding_backend="routed"` when active (WSP 97) |
| `holo_index/tests/test_backend_routing.py` | 14 focused tests |
| `holo_index/scripts/benchmarks/tq3_routed_corpus_audit.py` | TQ2 overlay audit |
| `docs/audits/holoindex_turboquant/TQ3_PER_COLLECTION_ROUTING.md` | decision artifact |
| `docs/audits/holoindex_turboquant/tq3_metrics.json` | raw metrics |
| `docs/audits/holoindex_turboquant/tq3_divergent_queries.json` | divergences |

## Gate Result

| Metric | Value | Gate | Status |
| --- | --- | --- | --- |
| overall top-1 agreement | 95.3% | ≥ 90% | PASS |
| overall top-5 set-agreement | 72.7% | ≥ 95% | **FAIL** |
| sentinels passing | 5/6 | 6/6 | **FAIL** |

**Decision**: `HOLD_ROUTING`. Root cause (WSP 97): Chroma corpus drift between TQ2 and TQ3 — `navigation_wsp` dropped from 3,446 → 1,916 docs. TQ2's 100%/100% result on code/wsp does not reproduce on current corpus. `navigation_skills` (59 docs) and `navigation_symbols` (20,000 docs) remain stable at 100%/100%. Vocabulary is trivially 100% under routing (same backend as baseline).

## Production impact

**None today.** Default stays `HOLO_USE_TURBOQUANT=0`. When an operator flips `HOLO_USE_TURBOQUANT=1`, routing activates — but `backend_quality="mixed"` / `quality_gate="mixed"` keep the experimental surface honest. Blockers for default-promotion are enumerated in the decision artifact.

## Test plan

- [x] `test_backend_routing.py` — 14 focused tests (policy map, resolver, degraded-load fallback)
- [x] `test_turboquant_wiring.py` — 11 tests (unchanged)
- [x] `test_turboquant_backend.py` — 31 tests + 1 skip (unchanged)
- [x] `test_web_asset_indexing.py` — 3 tests (indexing surface unchanged; `_get_embedding` still fp32)
- [x] TQ3 gate run on live Chroma at `E:/HoloIndex/vectors`

WSP: WSP 15 (priority), WSP 97 (truth distinction), WSP 50 (pre-action verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)