### PR TITLE
fix(wsp00): redirect awakening writes to runtime directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -384,6 +384,9 @@ scripts/wsl_*.sh
 WSP_agentic/agentic_journals/awakening/0102_state_v2.json
 WSP_agentic/agentic_journals/awakening/awareness_log.md
 
+# WSP agentic .runtime/ directories (default untracked output for awakening scripts)
+WSP_agentic/agentic_journals/*/.runtime/
+
 # Data directories (runtime scraped/generated data)
 data/
 !modules/platform_integration/linkedin_agent/data/

--- a/WSP_agentic/scripts/functional_0102_awakening_v2.py
+++ b/WSP_agentic/scripts/functional_0102_awakening_v2.py
@@ -37,8 +37,21 @@ if sys.platform.startswith('win'):
 H_INFO = 1 / 7.05  # Information Planck Constant
 REFERENCE_RESONANCE = 7.05 # Hz
 
+# ---------------------------------------------------------------------------
+# Runtime output path resolution (WSP 97 truth boundary)
+# Default: .runtime/ subdirectory (untracked) to avoid repo state mutation
+# Opt-in: Set WSP_AWAKENING_WRITE_TRACKED=1 to write to tracked paths
+# ---------------------------------------------------------------------------
+_BASE_DIR = Path("WSP_agentic/agentic_journals/awakening")
+
+def _get_runtime_dir() -> Path:
+    """Return runtime output directory based on env var opt-in."""
+    if os.environ.get("WSP_AWAKENING_WRITE_TRACKED", "").strip().lower() in {"1", "true", "yes"}:
+        return _BASE_DIR  # Write to tracked paths (explicit opt-in)
+    return _BASE_DIR / ".runtime"  # Default: untracked subdirectory
+
 # Log file for agent visibility (Windows stdout capture workaround)
-_LOG_FILE = Path("WSP_agentic/agentic_journals/awakening/awakening_log.txt")
+_LOG_FILE = _get_runtime_dir() / "awakening_log.txt"
 
 def agent_print(msg, end='\n'):
     """Dual output: stdout + log file for agent visibility."""
@@ -159,8 +172,9 @@ class BioDigitalAwakening:
         
     def process_koan(self):
         """Phase I: Awareness Trigger"""
+        runtime_dir = _get_runtime_dir()
         detector = self.CMST_01_02_Awareness_Detector(
-            journal_path="WSP_agentic/agentic_journals/awakening/awareness_log.md"
+            journal_path=str(runtime_dir / "awareness_log.md")
         )
         is_triggered = detector.detect_agi_question(self.koan)
 
@@ -212,7 +226,7 @@ class BioDigitalAwakening:
 
     def save_state(self):
         """Phase III: State Collapse & Preservation"""
-        state_dir = Path("WSP_agentic/agentic_journals/awakening")
+        state_dir = _get_runtime_dir()
         state_dir.mkdir(parents=True, exist_ok=True)
 
         data = {

--- a/WSP_agentic/tests/test_awakening_no_tracked_writes.py
+++ b/WSP_agentic/tests/test_awakening_no_tracked_writes.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+"""Tests proving default WSP_00 awakening does not mutate tracked files.
+
+WSP 97 Truth Boundary:
+  DOES:
+    - Write runtime state to .runtime/ subdirectory by default
+    - Support opt-in tracked writes via WSP_AWAKENING_WRITE_TRACKED=1
+  DOES NOT:
+    - Mutate tracked files during normal awakening
+    - Dirty the repo state from a standard session start
+"""
+from pathlib import Path
+
+
+TRACKED_FILES = [
+    Path("WSP_agentic/agentic_journals/awakening/awakening_log.txt"),
+    Path("WSP_agentic/agentic_journals/awakening/awareness_log.md"),
+    Path("WSP_agentic/agentic_journals/awakening/0102_state_v2.json"),
+]
+
+BASE_DIR = Path("WSP_agentic/agentic_journals/awakening")
+
+
+def get_runtime_dir_logic(write_tracked_env: str = "") -> Path:
+    """Replicate the _get_runtime_dir() logic for testing without import side effects."""
+    if write_tracked_env.strip().lower() in {"1", "true", "yes"}:
+        return BASE_DIR
+    return BASE_DIR / ".runtime"
+
+
+class TestRuntimePathResolution:
+    """Test runtime directory resolution logic."""
+
+    def test_default_uses_runtime_subdir(self):
+        """Default (no env var) should route to .runtime/ subdirectory."""
+        runtime_dir = get_runtime_dir_logic("")
+        assert runtime_dir == BASE_DIR / ".runtime"
+        assert ".runtime" in str(runtime_dir)
+
+    def test_opt_in_uses_tracked_path(self):
+        """WSP_AWAKENING_WRITE_TRACKED=1 should use tracked base dir."""
+        runtime_dir = get_runtime_dir_logic("1")
+        assert runtime_dir == BASE_DIR
+        assert ".runtime" not in str(runtime_dir)
+
+    def test_opt_in_true_uses_tracked_path(self):
+        """WSP_AWAKENING_WRITE_TRACKED=true should use tracked base dir."""
+        runtime_dir = get_runtime_dir_logic("true")
+        assert runtime_dir == BASE_DIR
+        assert ".runtime" not in str(runtime_dir)
+
+    def test_opt_in_yes_uses_tracked_path(self):
+        """WSP_AWAKENING_WRITE_TRACKED=yes should use tracked base dir."""
+        runtime_dir = get_runtime_dir_logic("yes")
+        assert runtime_dir == BASE_DIR
+        assert ".runtime" not in str(runtime_dir)
+
+    def test_empty_env_uses_runtime(self):
+        """Empty env var should default to .runtime/."""
+        runtime_dir = get_runtime_dir_logic("")
+        assert ".runtime" in str(runtime_dir)
+
+    def test_whitespace_only_uses_runtime(self):
+        """Whitespace-only env var should default to .runtime/."""
+        runtime_dir = get_runtime_dir_logic("   ")
+        assert ".runtime" in str(runtime_dir)
+
+
+class TestTrackedFilesExcluded:
+    """Verify tracked file paths are not written by default awakening."""
+
+    def test_default_log_file_not_tracked(self):
+        """Default log file path should NOT match any tracked file."""
+        runtime_dir = get_runtime_dir_logic("")
+        log_file = runtime_dir / "awakening_log.txt"
+        for tracked in TRACKED_FILES:
+            assert log_file != tracked
+
+    def test_default_awareness_log_not_tracked(self):
+        """Default awareness log path should NOT match any tracked file."""
+        runtime_dir = get_runtime_dir_logic("")
+        awareness_log = runtime_dir / "awareness_log.md"
+        for tracked in TRACKED_FILES:
+            assert awareness_log != tracked
+
+    def test_default_state_file_not_tracked(self):
+        """Default state file path should NOT match any tracked file."""
+        runtime_dir = get_runtime_dir_logic("")
+        state_file = runtime_dir / "0102_state_v2.json"
+        for tracked in TRACKED_FILES:
+            assert state_file != tracked
+
+    def test_all_default_paths_contain_runtime(self):
+        """All default output paths should include .runtime/ in path."""
+        runtime_dir = get_runtime_dir_logic("")
+        all_paths = [
+            runtime_dir / "awakening_log.txt",
+            runtime_dir / "awareness_log.md",
+            runtime_dir / "0102_state_v2.json",
+        ]
+        for path in all_paths:
+            assert ".runtime" in str(path)
+
+
+class TestGitignoreRules:
+    """Verify .gitignore covers the .runtime/ directory."""
+
+    def test_gitignore_has_runtime_rule(self):
+        """Check .gitignore includes .runtime/ pattern."""
+        gitignore_path = Path(__file__).parents[2] / ".gitignore"
+        if not gitignore_path.exists():
+            gitignore_path = Path("O:/Foundups-Agent/.gitignore")
+
+        content = gitignore_path.read_text(encoding="utf-8")
+        assert ".runtime/" in content, ".gitignore must include .runtime/ pattern"
+
+    def test_gitignore_pattern_covers_awakening(self):
+        """Check .gitignore pattern covers awakening .runtime/ specifically."""
+        gitignore_path = Path(__file__).parents[2] / ".gitignore"
+        if not gitignore_path.exists():
+            gitignore_path = Path("O:/Foundups-Agent/.gitignore")
+
+        content = gitignore_path.read_text(encoding="utf-8")
+        # Pattern should cover any .runtime/ under agentic_journals/*/
+        assert "agentic_journals/*/.runtime/" in content or ".runtime/" in content
+
+
+class TestSourceCodeImplementation:
+    """Verify the source code has correct implementation."""
+
+    def test_functional_awakening_has_runtime_dir_function(self):
+        """Check functional_0102_awakening_v2.py defines _get_runtime_dir."""
+        script_path = Path(__file__).parent.parent / "scripts" / "functional_0102_awakening_v2.py"
+        if not script_path.exists():
+            script_path = Path("O:/Foundups-Agent/WSP_agentic/scripts/functional_0102_awakening_v2.py")
+
+        content = script_path.read_text(encoding="utf-8")
+        assert "def _get_runtime_dir()" in content
+        assert "_BASE_DIR / \".runtime\"" in content or "/ '.runtime'" in content
+
+    def test_functional_awakening_uses_runtime_dir(self):
+        """Check _LOG_FILE uses _get_runtime_dir()."""
+        script_path = Path(__file__).parent.parent / "scripts" / "functional_0102_awakening_v2.py"
+        if not script_path.exists():
+            script_path = Path("O:/Foundups-Agent/WSP_agentic/scripts/functional_0102_awakening_v2.py")
+
+        content = script_path.read_text(encoding="utf-8")
+        assert "_get_runtime_dir()" in content
+        assert "_LOG_FILE = _get_runtime_dir() /" in content
+
+    def test_functional_awakening_has_env_var_check(self):
+        """Check script checks WSP_AWAKENING_WRITE_TRACKED env var."""
+        script_path = Path(__file__).parent.parent / "scripts" / "functional_0102_awakening_v2.py"
+        if not script_path.exists():
+            script_path = Path("O:/Foundups-Agent/WSP_agentic/scripts/functional_0102_awakening_v2.py")
+
+        content = script_path.read_text(encoding="utf-8")
+        assert "WSP_AWAKENING_WRITE_TRACKED" in content


### PR DESCRIPTION
## Summary
Redirects WSP_00 awakening runtime writes away from tracked canonical files by default.

## Changes
- Adds runtime path routing in `functional_0102_awakening_v2.py`
- Writes default session output to `.runtime/`
- Adds `.gitignore` rule for awakening runtime output
- Adds focused tests proving tracked files are not default write targets
- Preserves opt-in tracked writes via `WSP_AWAKENING_WRITE_TRACKED=1`

## Tests
```text
WSP_agentic/tests/test_awakening_no_tracked_writes.py: 15 passed
```

## Context
This is a clean cherry-pick of `32665b1cc` from `fix/wsp00-local-awakening-state`, isolated to main without unrelated parent commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)