### PR TITLE
feat(openclaw): classify codebase improvement intents

### DIFF
--- a/modules/communication/moltbot_bridge/src/openclaw_dae.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_dae.py
@@ -177,6 +177,7 @@ class IntentCategory(Enum):
     FOUNDUP = "foundup"             # FoundUp launch and management
     RESEARCH = "research"           # PQN detection, Duism, Oracle teaching
     TRAINING = "training"           # Corpus training: status, start, progress
+    IMPROVEMENT = "improvement"     # Codebase self-improvement: WSP violations, repairs
 
 
 class AutonomyTier(Enum):
@@ -599,6 +600,12 @@ class OpenClawDAE:
             "training status", "start training", "is training due",
             "training progress", "pattern memory", "batch training",
         ],
+        IntentCategory.IMPROVEMENT: [
+            "fix violation", "wsp violation", "repair module", "remediate",
+            "fix drift", "codebase improvement", "duplicate module",
+            "stale test", "run fmas repair", "self improvement",
+            "fix wsp", "code hygiene", "module cleanup", "fmas scan",
+        ],
     }
 
     # Domain routing map: intent category -> target domain/DAE
@@ -614,6 +621,7 @@ class OpenClawDAE:
         IntentCategory.FOUNDUP: "fam_adapter",
         IntentCategory.RESEARCH: "pqn_research_adapter",
         IntentCategory.TRAINING: "training_controller",
+        IntentCategory.IMPROVEMENT: "improvement_router",
     }
 
     # Runtime profiles (OpenClaw/IronClaw/ZeroClaw) and aliases.

--- a/modules/communication/moltbot_bridge/src/openclaw_execution_routes.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_execution_routes.py
@@ -47,6 +47,8 @@ async def execute_plan(dae: Any, plan: Any) -> str:
         return execute_research(dae, intent)
     if route == "training_controller":
         return execute_training(dae, intent)
+    if route == "improvement_router":
+        return execute_improvement(dae, intent)
 
     social_control = await dae._try_conversation_social_control(intent)
     if social_control:
@@ -860,7 +862,58 @@ def _start_training_batch() -> str:
         return f"**Training Batch: ERROR**\n\nCould not start: {exc}"
 
 
-def _try_memory_query(dae: Any, raw_message: str) -> Optional[str]:
+def execute_improvement(dae: Any, intent: Any) -> str:
+    """Route IMPROVEMENT intent (codebase self-improvement requests).
+
+    WSP 97 Truth Boundary:
+      - Classifies the improvement request
+      - Returns advisory acknowledgment
+      - Does NOT execute autonomous repairs (not implemented)
+      - Does NOT claim repair capability exists
+
+    Supported improvement types (classification only):
+      - WSP violations (fix violation, fix wsp, wsp violation)
+      - Module repairs (repair module, duplicate module, module cleanup)
+      - Test hygiene (stale test)
+      - Code drift (fix drift, codebase improvement)
+      - FMAS scans (run fmas repair, fmas scan)
+    """
+    msg_lower = (intent.raw_message or "").lower().strip()
+
+    # Classify improvement sub-type for routing hints
+    # Order matters: check specific keywords before generic ones
+    improvement_type = "general"
+    if "fmas" in msg_lower:
+        improvement_type = "fmas_scan"
+    elif "drift" in msg_lower:
+        improvement_type = "drift_correction"
+    elif "wsp" in msg_lower or "violation" in msg_lower:
+        improvement_type = "wsp_violation"
+    elif "test" in msg_lower or "stale" in msg_lower:
+        improvement_type = "test_hygiene"
+    elif "repair" in msg_lower or "module" in msg_lower or "cleanup" in msg_lower:
+        improvement_type = "module_repair"
+
+    logger.info(
+        "[OPENCLAW-DAE] [IMPROVEMENT] Intent recognized: type=%s task=%s sender=%s",
+        improvement_type,
+        (intent.extracted_task or "")[:50],
+        intent.sender,
+    )
+
+    # WSP 97: Truthful advisory response - no repair execution claims
+    return (
+        f"**Improvement Intent Recognized**\n\n"
+        f"- **Type**: `{improvement_type}`\n"
+        f"- **Request**: {intent.extracted_task or intent.raw_message}\n\n"
+        f"**Status**: Classified but not executed.\n\n"
+        f"Autonomous codebase repair is not yet implemented. "
+        f"This intent was recognized and logged for future FMAS integration.\n\n"
+        f"_WSP 97: AI surfaces improvement needs. Humans decide execution._"
+    )
+
+
+
     """
     Detect and handle deterministic memory queries.
 

--- a/modules/communication/moltbot_bridge/src/openclaw_intent_planner.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_intent_planner.py
@@ -403,6 +403,12 @@ def plan_execution(dae: Any, intent: Any, tier: Any) -> Any:
             {"action": "fam_or_genesis_route"},
         ]
         est_tokens = 100
+    elif intent.category == dae.IntentCategory.IMPROVEMENT:
+        steps = [
+            {"action": "improvement_classify", "input": intent.extracted_task},
+            {"action": "improvement_route_stub"},
+        ]
+        est_tokens = 80
     else:
         steps = [{"action": "digital_twin_response", "context": intent.raw_message}]
         est_tokens = 60

--- a/modules/communication/moltbot_bridge/tests/test_openclaw_improvement_intent.py
+++ b/modules/communication/moltbot_bridge/tests/test_openclaw_improvement_intent.py
@@ -1,0 +1,252 @@
+"""Focused tests for OpenClaw IMPROVEMENT intent classification and routing.
+
+Tests:
+- IMPROVEMENT IntentCategory exists
+- IMPROVEMENT keywords defined in INTENT_KEYWORDS
+- IMPROVEMENT route defined in DOMAIN_ROUTES
+- execute_improvement returns advisory (not execution claim)
+- WSP 97 truth boundary: no repair capability claims
+
+WSP 97 Truth Boundary:
+  - These tests verify classification, NOT execution
+  - These tests verify advisory messages, NOT repair actions
+  - These tests verify truthful disclaimers exist
+"""
+
+from dataclasses import dataclass
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and Helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MockIntent:
+    """Mock OpenClawIntent for testing."""
+
+    raw_message: str
+    is_authorized_commander: bool = True
+    extracted_task: str = ""
+    sender: str = "test_sender"
+
+
+class MockDAE:
+    """Mock OpenClawDAE for testing."""
+
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Intent Classification Tests
+# ---------------------------------------------------------------------------
+
+
+class TestImprovementIntentClassification:
+    """Test IMPROVEMENT IntentCategory classification."""
+
+    def test_improvement_category_exists(self):
+        """IMPROVEMENT IntentCategory is defined."""
+        from modules.communication.moltbot_bridge.src.openclaw_dae import IntentCategory
+
+        assert hasattr(IntentCategory, "IMPROVEMENT")
+        assert IntentCategory.IMPROVEMENT.value == "improvement"
+
+    def test_improvement_keywords_defined(self):
+        """Improvement keywords are defined in INTENT_KEYWORDS."""
+        from modules.communication.moltbot_bridge.src.openclaw_dae import (
+            IntentCategory,
+            OpenClawDAE,
+        )
+
+        keywords = OpenClawDAE.INTENT_KEYWORDS.get(IntentCategory.IMPROVEMENT, [])
+        assert len(keywords) > 0
+        assert "fix violation" in keywords
+        assert "wsp violation" in keywords
+        assert "repair module" in keywords
+        assert "remediate" in keywords
+
+    def test_improvement_route_defined(self):
+        """Improvement route is defined in DOMAIN_ROUTES."""
+        from modules.communication.moltbot_bridge.src.openclaw_dae import (
+            IntentCategory,
+            OpenClawDAE,
+        )
+
+        route = OpenClawDAE.DOMAIN_ROUTES.get(IntentCategory.IMPROVEMENT)
+        assert route == "improvement_router"
+
+
+# ---------------------------------------------------------------------------
+# Improvement Route Tests
+# ---------------------------------------------------------------------------
+
+
+class TestImprovementRoute:
+    """Test execute_improvement returns truthful advisory."""
+
+    def test_improvement_returns_advisory(self):
+        """execute_improvement returns advisory, not execution claim."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+        )
+
+        intent = MockIntent(
+            raw_message="fix wsp violation in holo_index",
+            extracted_task="fix wsp violation in holo_index",
+        )
+        result = execute_improvement(MockDAE(), intent)
+
+        # Must acknowledge intent was recognized
+        assert "Improvement Intent Recognized" in result
+        assert "wsp_violation" in result
+
+    def test_improvement_no_execution_claim(self):
+        """WSP 97: execute_improvement must NOT claim repair was executed."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+        )
+
+        intent = MockIntent(
+            raw_message="repair module agent_permissions",
+            extracted_task="repair module agent_permissions",
+        )
+        result = execute_improvement(MockDAE(), intent)
+
+        # Must NOT claim execution
+        assert "not executed" in result.lower() or "not yet implemented" in result.lower()
+        # Must acknowledge advisory status
+        assert "WSP 97" in result
+
+    def test_improvement_classifies_wsp_violation(self):
+        """WSP violation keywords classify as wsp_violation type."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+        )
+
+        intent = MockIntent(
+            raw_message="fix wsp violation wsp 49",
+            extracted_task="fix wsp violation wsp 49",
+        )
+        result = execute_improvement(MockDAE(), intent)
+
+        assert "wsp_violation" in result
+
+    def test_improvement_classifies_module_repair(self):
+        """Module repair keywords classify as module_repair type."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+        )
+
+        intent = MockIntent(
+            raw_message="repair module wre_core",
+            extracted_task="repair module wre_core",
+        )
+        result = execute_improvement(MockDAE(), intent)
+
+        assert "module_repair" in result
+
+    def test_improvement_classifies_test_hygiene(self):
+        """Test hygiene keywords classify as test_hygiene type."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+        )
+
+        intent = MockIntent(
+            raw_message="fix stale test in ai_overseer",
+            extracted_task="fix stale test in ai_overseer",
+        )
+        result = execute_improvement(MockDAE(), intent)
+
+        assert "test_hygiene" in result
+
+    def test_improvement_classifies_drift_correction(self):
+        """Drift keywords classify as drift_correction type."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+        )
+
+        intent = MockIntent(
+            raw_message="fix drift in navigation module",
+            extracted_task="fix drift in navigation module",
+        )
+        result = execute_improvement(MockDAE(), intent)
+
+        assert "drift_correction" in result
+
+    def test_improvement_classifies_fmas_scan(self):
+        """FMAS keywords classify as fmas_scan type."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+        )
+
+        intent = MockIntent(
+            raw_message="run fmas repair on communication",
+            extracted_task="run fmas repair on communication",
+        )
+        result = execute_improvement(MockDAE(), intent)
+
+        assert "fmas_scan" in result
+
+
+# ---------------------------------------------------------------------------
+# Intent Planner Tests
+# ---------------------------------------------------------------------------
+
+
+class TestImprovementPlanExecution:
+    """Test IMPROVEMENT category in plan_execution."""
+
+    def test_improvement_plan_has_stub_steps(self):
+        """IMPROVEMENT plan includes improvement_route_stub action."""
+        from dataclasses import dataclass, field
+        from typing import List, Dict, Any
+
+        from modules.communication.moltbot_bridge.src.openclaw_intent_planner import (
+            plan_execution,
+        )
+        from modules.communication.moltbot_bridge.src.openclaw_dae import (
+            IntentCategory,
+            AutonomyTier,
+        )
+
+        # Create ExecutionPlan dataclass mimic
+        @dataclass
+        class ExecutionPlan:
+            intent: Any
+            route: str
+            permission_level: Any
+            wsp_preflight_passed: bool
+            steps: List[Dict[str, Any]] = field(default_factory=list)
+            estimated_tokens: int = 0
+
+        # Create minimal mock DAE with required attributes
+        mock_dae = type(
+            "MockDAE",
+            (),
+            {
+                "IntentCategory": IntentCategory,
+                "ExecutionPlan": ExecutionPlan,
+            },
+        )()
+
+        # Create minimal mock intent
+        mock_intent = type(
+            "MockIntent",
+            (),
+            {
+                "category": IntentCategory.IMPROVEMENT,
+                "extracted_task": "fix wsp violation",
+                "raw_message": "fix wsp violation",
+                "target_domain": "improvement_router",
+            },
+        )()
+
+        plan = plan_execution(mock_dae, mock_intent, AutonomyTier.ADVISORY)
+
+        # Plan should have improvement steps
+        step_actions = [s.get("action") for s in plan.steps]
+        assert "improvement_classify" in step_actions
+        assert "improvement_route_stub" in step_actions


### PR DESCRIPTION
## Summary

- Add `IMPROVEMENT` IntentCategory for codebase self-improvement requests
- Add keywords: fix violation, wsp violation, repair module, remediate, fix drift, codebase improvement, stale test, fmas scan, etc.
- Add `improvement_router` domain route
- Add `execute_improvement()` stub returning advisory acknowledgment
- Add plan steps: `improvement_classify`, `improvement_route_stub`
- 11 tests (all passing) covering classification and WSP 97 truth boundaries

## WSP 97 Truth Boundary

The route returns an advisory acknowledgment only. Autonomous repair execution is NOT implemented - the response includes a truthful disclaimer:

> "Autonomous codebase repair is not yet implemented. This intent was recognized and logged for future FMAS integration."

## Test plan

- [x] Run `pytest modules/communication/moltbot_bridge/tests/test_openclaw_improvement_intent.py -v` (11/11 pass)
- [x] Verify IMPROVEMENT category exists in IntentCategory enum
- [x] Verify keywords include fix violation, wsp violation, repair module
- [x] Verify route maps to improvement_router
- [x] Verify execute_improvement classifies sub-types (wsp_violation, module_repair, test_hygiene, drift_correction, fmas_scan)
- [x] Verify no execution claims in response (WSP 97)

🤖 Generated with [Claude Code](https://claude.com/claude-code)