### PR TITLE
feat(wre): add FoundUpJob consumer seam

### DIFF
--- a/modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py
@@ -790,5 +790,5 @@ def _handle_build_intent(intent: Any) -> str:
         f"  status: {job.status.value}\n"
         f"  requested_action: {requested_action}\n"
         f"  foundup_id: {foundup_str}\n"
-        f"  next: Hermes/WRE pending"
+        f"  next: FoundUpJobConsumer can drain queued jobs"
     )

--- a/modules/communication/moltbot_bridge/src/receipt_emitter.py
+++ b/modules/communication/moltbot_bridge/src/receipt_emitter.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+"""
+Receipt Emitter — Terminal Job to pAVS Receipt Pipeline
+
+Wraps the receipt creation and pAVS verification for terminal FoundUpJobs.
+Only terminal jobs (SUCCEEDED, FAILED, BLOCKED) can have receipts emitted.
+
+Architecture:
+  Terminal FoundUpJob -> create_receipt_from_job() -> ProofOfComputeReceipt
+                      -> verify_receipt() -> PAVSVerificationResult
+
+WSP Compliance:
+  WSP 11  : Interface contract (typed receipt pipeline)
+  WSP 97  : System Execution Prompting (only terminal jobs, truthful status)
+
+Truth Boundaries (WSP 97):
+  - Only terminal jobs can emit receipts
+  - cabr_ready = False (no CABR consensus exists)
+  - payout_ready = False (no payout engine exists)
+  - verification_complete = False (only accepted for review)
+
+NAVIGATION:
+  -> Uses: proof_of_compute_receipt.py (create_receipt_from_job)
+  -> Uses: pavs_verification_seam.py (verify_receipt)
+  -> Called by: FoundUpJobConsumer after terminal state
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from .proof_of_compute_receipt import (
+    ProofOfComputeReceipt,
+    ReceiptResult,
+    create_receipt_from_job,
+)
+from .pavs_verification_seam import (
+    PAVSVerificationResult,
+    verify_receipt,
+)
+
+logger = logging.getLogger("receipt_emitter")
+
+
+# ---------------------------------------------------------------------------
+# Emission Result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ReceiptEmissionResult:
+    """
+    Result of receipt emission for a terminal job.
+
+    Contains both the receipt and the pAVS verification result,
+    or error information if emission failed.
+    """
+
+    success: bool
+    """True if receipt was created and verified."""
+
+    job_id: str
+    """Source job identifier."""
+
+    receipt: Optional[ProofOfComputeReceipt] = None
+    """Created receipt (if successful)."""
+
+    verification: Optional[PAVSVerificationResult] = None
+    """pAVS verification result (if receipt created)."""
+
+    error: Optional[str] = None
+    """Error message if emission failed."""
+
+
+# ---------------------------------------------------------------------------
+# Terminal Status Check
+# ---------------------------------------------------------------------------
+
+
+def _is_terminal_job(job: Any) -> bool:
+    """
+    Check if job is in terminal state.
+
+    Terminal states: SUCCEEDED, FAILED, BLOCKED.
+    Non-terminal: QUEUED, RUNNING.
+
+    Args:
+        job: FoundUpJob or duck-typed object with status attribute.
+
+    Returns:
+        True if job is in terminal state.
+    """
+    try:
+        # Import here to avoid circular deps
+        from modules.communication.moltbot_bridge.src.foundup_job_contract import (
+            is_terminal_status,
+        )
+
+        status = getattr(job, "status", None)
+        if status is None:
+            return False
+        return is_terminal_status(status)
+    except ImportError:
+        # Fallback: check by status value
+        status = getattr(job, "status", None)
+        if status is None:
+            return False
+        status_str = status.value if hasattr(status, "value") else str(status)
+        return status_str.lower() in ("succeeded", "failed", "blocked")
+
+
+# ---------------------------------------------------------------------------
+# Receipt Emission
+# ---------------------------------------------------------------------------
+
+
+def emit_receipt_for_terminal_job(job: Any) -> ReceiptEmissionResult:
+    """
+    Emit receipt for a terminal FoundUpJob.
+
+    Only terminal jobs (SUCCEEDED, FAILED, BLOCKED) can have receipts.
+    Non-terminal jobs are rejected truthfully.
+
+    Steps:
+      1. Validate job is terminal
+      2. Create receipt via create_receipt_from_job()
+      3. Verify receipt via verify_receipt()
+      4. Return combined result
+
+    Args:
+        job: FoundUpJob instance in terminal state.
+
+    Returns:
+        ReceiptEmissionResult with receipt and verification (if successful).
+
+    WSP 97 truth boundaries:
+      - Non-terminal jobs rejected with error
+      - cabr_ready = False in verification result
+      - payout_ready = False in verification result
+      - verification_complete = False in verification result
+    """
+    job_id = getattr(job, "job_id", "") or ""
+
+    # Step 1: Validate terminal status
+    if not _is_terminal_job(job):
+        status = getattr(job, "status", None)
+        status_str = status.value if hasattr(status, "value") else str(status or "unknown")
+        error = f"Job {job_id} is not terminal (status={status_str}); receipt emission rejected"
+        logger.warning("[RECEIPT-EMITTER] %s", error)
+        return ReceiptEmissionResult(
+            success=False,
+            job_id=job_id,
+            error=error,
+        )
+
+    # Step 2: Create receipt
+    try:
+        receipt_result: ReceiptResult = create_receipt_from_job(job)
+
+        if not receipt_result.success:
+            error = f"Receipt creation failed: {receipt_result.error}"
+            logger.warning("[RECEIPT-EMITTER] %s", error)
+            return ReceiptEmissionResult(
+                success=False,
+                job_id=job_id,
+                error=error,
+            )
+
+        receipt = receipt_result.receipt
+
+    except Exception as e:
+        logger.exception("[RECEIPT-EMITTER] Receipt creation exception for job %s", job_id)
+        return ReceiptEmissionResult(
+            success=False,
+            job_id=job_id,
+            error=f"Receipt creation exception: {e}",
+        )
+
+    # Step 3: Verify receipt
+    try:
+        verification: PAVSVerificationResult = verify_receipt(receipt)
+
+        logger.info(
+            "[RECEIPT-EMITTER] Receipt emitted for job %s: decision=%s",
+            job_id,
+            verification.decision.value,
+        )
+
+        return ReceiptEmissionResult(
+            success=True,
+            job_id=job_id,
+            receipt=receipt,
+            verification=verification,
+        )
+
+    except Exception as e:
+        logger.exception("[RECEIPT-EMITTER] Verification exception for job %s", job_id)
+        return ReceiptEmissionResult(
+            success=True,  # Receipt was created, just verification failed
+            job_id=job_id,
+            receipt=receipt,
+            error=f"Verification exception: {e}",
+        )

--- a/modules/infrastructure/wre_core/src/foundup_job_consumer.py
+++ b/modules/infrastructure/wre_core/src/foundup_job_consumer.py
@@ -1,0 +1,341 @@
+# -*- coding: utf-8 -*-
+"""
+WRE FoundUpJob Consumer — Phase 1A Consumer Seam
+
+Drains FoundUpJobs through the WRE routing pipeline without making
+OpenClaw call Hermes directly. All dispatch goes through RouteEnvelope.
+
+Architecture:
+  OpenClaw -> FoundUpJob (QUEUED) -> WRE Router -> RouteEnvelope
+           -> This Consumer -> Hermes Executor (if routed)
+           -> Terminal Job -> Receipt Emitter
+
+This is Phase 1A: synchronous drain only, no daemon loop.
+
+WSP Compliance:
+  WSP 11  : Interface contract (typed dispatch)
+  WSP 50  : Pre-Action Verification (route_foundup_job validates first)
+  WSP 77  : Agent Coordination (WRE controls dispatch, not OpenClaw)
+  WSP 97  : System Execution Prompting (dry_run=True default, no overclaims)
+
+NAVIGATION:
+  -> Uses: foundup_job_router.py (route_foundup_job, RouteEnvelope)
+  -> Uses: hermes_foundup_job_executor.py (execute_foundup_job)
+  -> Uses: openclaw_foundup_orchestrator.py (get_job_queue, clear_job_queue)
+  -> Called by: WRE gateway, manual drain commands
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional
+
+from .foundup_job_router import (
+    RouteEnvelope,
+    RouteStatus,
+    TargetBackend,
+    route_foundup_job,
+)
+
+logger = logging.getLogger("wre_foundup_job_consumer")
+
+
+def _utc_now() -> datetime:
+    """Return current UTC timestamp."""
+    return datetime.now(timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Consumer Result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ConsumerResult:
+    """
+    Result container for a single job consumption.
+
+    Wraps the HermesJobExecutionResult (if dispatched) or records
+    why the job was not dispatched.
+    """
+
+    job_id: str
+    """Job identifier."""
+
+    dispatched: bool
+    """True if job was dispatched to Hermes."""
+
+    route_status: RouteStatus
+    """Routing decision status."""
+
+    target_backend: TargetBackend
+    """Target backend from routing."""
+
+    reason: str
+    """Human-readable reason for result."""
+
+    hermes_result: Optional[Any] = None
+    """HermesJobExecutionResult if dispatched, else None."""
+
+    envelope: Optional[RouteEnvelope] = None
+    """RouteEnvelope from routing decision."""
+
+    consumed_at: datetime = field(default_factory=_utc_now)
+    """Timestamp when consumption completed."""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dict for logging/JSON."""
+        return {
+            "job_id": self.job_id,
+            "dispatched": self.dispatched,
+            "route_status": self.route_status.value,
+            "target_backend": self.target_backend.value,
+            "reason": self.reason,
+            "consumed_at": self.consumed_at.isoformat(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# FoundUpJob Consumer
+# ---------------------------------------------------------------------------
+
+
+class FoundUpJobConsumer:
+    """
+    WRE-controlled consumer for FoundUpJobs.
+
+    Drains jobs through the typed pipeline:
+      1. route_foundup_job(job) -> RouteEnvelope
+      2. Dispatch based on target_backend (only if ROUTED)
+      3. Return result with execution outcome
+
+    This is Phase 1A: synchronous operations only, no daemon loop.
+
+    WSP 97 truth boundaries:
+      - dry_run=True by default (no production execution)
+      - Only ROUTED jobs dispatch to Hermes
+      - QUEUED/BLOCKED/UNSUPPORTED do not execute
+
+    Attributes:
+        dry_run: If True, force dry-run mode for all Hermes dispatches.
+    """
+
+    def __init__(self, dry_run: bool = True):
+        """
+        Initialize consumer.
+
+        Args:
+            dry_run: Force dry-run mode for Hermes dispatches. Default True.
+        """
+        self.dry_run = dry_run
+
+    def consume_one(self, job: Any) -> ConsumerResult:
+        """
+        Consume a single FoundUpJob through the pipeline.
+
+        Steps:
+          1. Route via route_foundup_job(job)
+          2. If ROUTED to HERMES_*, dispatch to execute_foundup_job
+          3. Return ConsumerResult with outcome
+
+        Args:
+            job: FoundUpJob instance to consume.
+
+        Returns:
+            ConsumerResult with dispatch outcome.
+        """
+        job_id = getattr(job, "job_id", "") or ""
+
+        # Step 1: Route
+        try:
+            envelope = route_foundup_job(job)
+        except Exception as e:
+            logger.exception("[CONSUMER] Routing failed for job %s: %s", job_id, e)
+            return ConsumerResult(
+                job_id=job_id,
+                dispatched=False,
+                route_status=RouteStatus.FAILED,
+                target_backend=TargetBackend.NONE,
+                reason=f"Routing exception: {e}",
+            )
+
+        # Step 2: Dispatch based on target_backend
+        if envelope.route_status == RouteStatus.ROUTED:
+            if envelope.target_backend in (
+                TargetBackend.HERMES_BUILDER,
+                TargetBackend.HERMES_VALIDATOR,
+            ):
+                return self._dispatch_to_hermes(job, envelope)
+
+        # Step 3: Not dispatched (QUEUED, BLOCKED, UNSUPPORTED, FAILED, etc.)
+        logger.info(
+            "[CONSUMER] Job %s not dispatched: status=%s backend=%s",
+            job_id,
+            envelope.route_status.value,
+            envelope.target_backend.value,
+        )
+        return ConsumerResult(
+            job_id=job_id,
+            dispatched=False,
+            route_status=envelope.route_status,
+            target_backend=envelope.target_backend,
+            reason=envelope.reason_human,
+            envelope=envelope,
+        )
+
+    def _dispatch_to_hermes(
+        self, job: Any, envelope: RouteEnvelope
+    ) -> ConsumerResult:
+        """
+        Dispatch job to Hermes executor.
+
+        Args:
+            job: FoundUpJob to execute.
+            envelope: RouteEnvelope from routing.
+
+        Returns:
+            ConsumerResult with Hermes execution outcome.
+        """
+        job_id = envelope.job_id
+
+        try:
+            # Import here to avoid circular deps at module load
+            from modules.foundups.agent.src.hermes_foundup_job_executor import (
+                execute_foundup_job,
+                HermesJobExecutionResult,
+            )
+
+            logger.info(
+                "[CONSUMER] Dispatching job %s to %s (dry_run=%s)",
+                job_id,
+                envelope.target_backend.value,
+                self.dry_run,
+            )
+
+            hermes_result: HermesJobExecutionResult = execute_foundup_job(
+                job, force_dry_run=self.dry_run
+            )
+
+            dispatched = True
+            reason = (
+                f"Dispatched to {envelope.target_backend.value}; "
+                f"job_status={hermes_result.job.status.value}"
+            )
+
+            logger.info(
+                "[CONSUMER] Job %s completed: status=%s",
+                job_id,
+                hermes_result.job.status.value,
+            )
+
+            return ConsumerResult(
+                job_id=job_id,
+                dispatched=dispatched,
+                route_status=envelope.route_status,
+                target_backend=envelope.target_backend,
+                reason=reason,
+                hermes_result=hermes_result,
+                envelope=envelope,
+            )
+
+        except ImportError as e:
+            logger.error("[CONSUMER] Hermes executor not available: %s", e)
+            return ConsumerResult(
+                job_id=job_id,
+                dispatched=False,
+                route_status=envelope.route_status,
+                target_backend=envelope.target_backend,
+                reason=f"Hermes executor import failed: {e}",
+                envelope=envelope,
+            )
+
+        except Exception as e:
+            logger.exception("[CONSUMER] Hermes dispatch failed for job %s: %s", job_id, e)
+            return ConsumerResult(
+                job_id=job_id,
+                dispatched=False,
+                route_status=envelope.route_status,
+                target_backend=envelope.target_backend,
+                reason=f"Hermes dispatch exception: {e}",
+                envelope=envelope,
+            )
+
+    def drain_jobs(self, jobs: Iterable[Any]) -> List[ConsumerResult]:
+        """
+        Drain multiple jobs through the pipeline.
+
+        Args:
+            jobs: Iterable of FoundUpJob instances.
+
+        Returns:
+            List of ConsumerResult for each job.
+        """
+        results = []
+        for job in jobs:
+            result = self.consume_one(job)
+            results.append(result)
+        return results
+
+    def drain_openclaw_queue_once(self, clear: bool = True) -> List[ConsumerResult]:
+        """
+        Drain the OpenClaw FoundUpJob queue once.
+
+        Imports the queue from openclaw_foundup_orchestrator, processes all
+        jobs, and optionally clears the queue after successful processing.
+
+        Args:
+            clear: If True, clear the queue after draining. Default True.
+
+        Returns:
+            List of ConsumerResult for each job in the queue.
+
+        Note:
+            This is a synchronous operation. No daemon loop.
+        """
+        try:
+            from modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator import (
+                get_job_queue,
+                clear_job_queue,
+            )
+        except ImportError as e:
+            logger.error("[CONSUMER] OpenClaw orchestrator not available: %s", e)
+            return []
+
+        queue = get_job_queue()
+        job_count = len(queue)
+
+        if job_count == 0:
+            logger.info("[CONSUMER] Queue empty, nothing to drain")
+            return []
+
+        logger.info("[CONSUMER] Draining %d job(s) from OpenClaw queue", job_count)
+
+        # Drain all jobs
+        results = self.drain_jobs(queue)
+
+        # Clear queue only after successful drain (if requested)
+        if clear:
+            clear_job_queue()
+            logger.info("[CONSUMER] Cleared OpenClaw queue after drain")
+
+        return results
+
+
+# ---------------------------------------------------------------------------
+# Convenience: Get Consumer Instance
+# ---------------------------------------------------------------------------
+
+
+def get_consumer(dry_run: bool = True) -> FoundUpJobConsumer:
+    """
+    Get a FoundUpJobConsumer instance.
+
+    Args:
+        dry_run: Force dry-run mode for Hermes dispatches. Default True.
+
+    Returns:
+        Configured FoundUpJobConsumer.
+    """
+    return FoundUpJobConsumer(dry_run=dry_run)

--- a/modules/infrastructure/wre_core/tests/test_foundup_job_consumer.py
+++ b/modules/infrastructure/wre_core/tests/test_foundup_job_consumer.py
@@ -1,0 +1,541 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for WRE FoundUpJob Consumer — Phase 1A Consumer Seam
+
+W2/OC5 Test Coverage:
+  - consume_one calls route_foundup_job before Hermes dispatch
+  - HERMES_BUILDER routed job calls execute_foundup_job with dry_run=True
+  - HERMES_VALIDATOR routed job calls execute_foundup_job with dry_run=True
+  - unsupported/blocked route does not call Hermes
+  - drain_jobs consumes multiple jobs
+  - drain_openclaw_queue_once clears queue only after successful drain
+  - terminal job receipt wrapper rejects non-terminal jobs truthfully
+
+WSP Compliance:
+  WSP 11  : Interface contract verified
+  WSP 50  : Pre-action validation (route_foundup_job called first)
+  WSP 77  : Agent coordination (WRE controls dispatch)
+  WSP 97  : Truthful status (dry_run default, no overclaims)
+"""
+
+import pytest
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Dict, Any
+from unittest.mock import MagicMock, patch
+
+from modules.infrastructure.wre_core.src.foundup_job_consumer import (
+    FoundUpJobConsumer,
+    ConsumerResult,
+    get_consumer,
+)
+from modules.infrastructure.wre_core.src.foundup_job_router import (
+    RouteStatus,
+    TargetBackend,
+)
+
+
+# ---------------------------------------------------------------------------
+# Mock Job Classes (duck-typed to match FoundUpJob contract)
+# ---------------------------------------------------------------------------
+
+
+class MockJobStatus(str, Enum):
+    """Mock status enum matching FoundUpJob contract."""
+
+    QUEUED = "queued"
+    RUNNING = "running"
+    BLOCKED = "blocked"
+    FAILED = "failed"
+    SUCCEEDED = "succeeded"
+
+
+@dataclass
+class MockPolicyFlags:
+    """Mock policy flags matching FoundUpJob contract."""
+
+    security_gate_checked: bool = False
+    security_gate_passed: bool = False
+    dry_run_mode: bool = True
+
+    def to_dict(self) -> Dict[str, bool]:
+        return {
+            "security_gate_checked": self.security_gate_checked,
+            "security_gate_passed": self.security_gate_passed,
+            "dry_run_mode": self.dry_run_mode,
+        }
+
+
+@dataclass
+class MockFoundUpJob:
+    """Mock FoundUpJob for testing consumer."""
+
+    job_id: str
+    tenant_id: str
+    requested_action: str
+    status: MockJobStatus = MockJobStatus.QUEUED
+    foundup_id: Optional[str] = None
+    policy_flags: Optional[MockPolicyFlags] = None
+    payload: Optional[Dict[str, Any]] = None
+    evidence_refs: list = None
+
+    def __post_init__(self):
+        if self.evidence_refs is None:
+            self.evidence_refs = []
+        if self.policy_flags is None:
+            self.policy_flags = MockPolicyFlags()
+
+
+# ---------------------------------------------------------------------------
+# Test: consume_one calls route_foundup_job before Hermes
+# ---------------------------------------------------------------------------
+
+
+class TestConsumeOneRoutesFirst:
+    """Test that consume_one calls route_foundup_job before dispatching."""
+
+    @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
+    def test_consume_one_calls_route_first(self, mock_route):
+        """consume_one must call route_foundup_job before any dispatch."""
+        # Setup mock to return blocked (so no Hermes dispatch)
+        mock_envelope = MagicMock()
+        mock_envelope.route_status = RouteStatus.BLOCKED
+        mock_envelope.target_backend = TargetBackend.NONE
+        mock_envelope.reason_human = "Blocked for test"
+        mock_envelope.job_id = "job_001"
+        mock_route.return_value = mock_envelope
+
+        job = MockFoundUpJob(
+            job_id="job_001",
+            tenant_id="tenant_test",
+            requested_action="build_foundup",
+        )
+
+        consumer = FoundUpJobConsumer(dry_run=True)
+        result = consumer.consume_one(job)
+
+        # route_foundup_job must have been called
+        mock_route.assert_called_once_with(job)
+        # Result should not be dispatched (blocked)
+        assert result.dispatched is False
+        assert result.route_status == RouteStatus.BLOCKED
+
+
+# ---------------------------------------------------------------------------
+# Test: HERMES_BUILDER/VALIDATOR routed jobs call execute_foundup_job
+# ---------------------------------------------------------------------------
+
+
+class TestHermesDispatch:
+    """Test that routed jobs dispatch to Hermes with correct dry_run."""
+
+    @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
+    @patch(
+        "modules.foundups.agent.src.hermes_foundup_job_executor.execute_foundup_job"
+    )
+    def test_hermes_builder_dispatches_with_dry_run_true(
+        self, mock_execute, mock_route
+    ):
+        """HERMES_BUILDER routed job dispatches with dry_run=True."""
+        # Setup mock route envelope
+        mock_envelope = MagicMock()
+        mock_envelope.route_status = RouteStatus.ROUTED
+        mock_envelope.target_backend = TargetBackend.HERMES_BUILDER
+        mock_envelope.reason_human = "Routed to hermes_builder"
+        mock_envelope.job_id = "job_builder"
+        mock_route.return_value = mock_envelope
+
+        # Setup mock Hermes result
+        mock_hermes_result = MagicMock()
+        mock_hermes_result.job.status.value = "succeeded"
+        mock_execute.return_value = mock_hermes_result
+
+        job = MockFoundUpJob(
+            job_id="job_builder",
+            tenant_id="tenant_test",
+            requested_action="build_foundup",
+        )
+
+        consumer = FoundUpJobConsumer(dry_run=True)
+        result = consumer.consume_one(job)
+
+        # execute_foundup_job must be called with force_dry_run=True
+        mock_execute.assert_called_once_with(job, force_dry_run=True)
+        assert result.dispatched is True
+        assert result.target_backend == TargetBackend.HERMES_BUILDER
+
+    @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
+    @patch(
+        "modules.foundups.agent.src.hermes_foundup_job_executor.execute_foundup_job"
+    )
+    def test_hermes_validator_dispatches_with_dry_run_true(
+        self, mock_execute, mock_route
+    ):
+        """HERMES_VALIDATOR routed job dispatches with dry_run=True."""
+        mock_envelope = MagicMock()
+        mock_envelope.route_status = RouteStatus.ROUTED
+        mock_envelope.target_backend = TargetBackend.HERMES_VALIDATOR
+        mock_envelope.reason_human = "Routed to hermes_validator"
+        mock_envelope.job_id = "job_validator"
+        mock_route.return_value = mock_envelope
+
+        mock_hermes_result = MagicMock()
+        mock_hermes_result.job.status.value = "succeeded"
+        mock_execute.return_value = mock_hermes_result
+
+        job = MockFoundUpJob(
+            job_id="job_validator",
+            tenant_id="tenant_test",
+            requested_action="validate_foundup",
+        )
+
+        consumer = FoundUpJobConsumer(dry_run=True)
+        result = consumer.consume_one(job)
+
+        mock_execute.assert_called_once_with(job, force_dry_run=True)
+        assert result.dispatched is True
+        assert result.target_backend == TargetBackend.HERMES_VALIDATOR
+
+    @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
+    @patch(
+        "modules.foundups.agent.src.hermes_foundup_job_executor.execute_foundup_job"
+    )
+    def test_consumer_dry_run_false_passes_to_hermes(self, mock_execute, mock_route):
+        """Consumer with dry_run=False passes force_dry_run=False to Hermes."""
+        mock_envelope = MagicMock()
+        mock_envelope.route_status = RouteStatus.ROUTED
+        mock_envelope.target_backend = TargetBackend.HERMES_BUILDER
+        mock_envelope.reason_human = "Routed"
+        mock_envelope.job_id = "job_real"
+        mock_route.return_value = mock_envelope
+
+        mock_hermes_result = MagicMock()
+        mock_hermes_result.job.status.value = "succeeded"
+        mock_execute.return_value = mock_hermes_result
+
+        job = MockFoundUpJob(
+            job_id="job_real",
+            tenant_id="tenant_test",
+            requested_action="build_foundup",
+        )
+
+        consumer = FoundUpJobConsumer(dry_run=False)
+        result = consumer.consume_one(job)
+
+        # force_dry_run should be False
+        mock_execute.assert_called_once_with(job, force_dry_run=False)
+        assert result.dispatched is True
+
+
+# ---------------------------------------------------------------------------
+# Test: Unsupported/blocked routes do not call Hermes
+# ---------------------------------------------------------------------------
+
+
+class TestNoHermesForBlockedRoutes:
+    """Test that blocked/unsupported routes do not dispatch to Hermes."""
+
+    @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
+    @patch(
+        "modules.foundups.agent.src.hermes_foundup_job_executor.execute_foundup_job"
+    )
+    def test_unsupported_action_no_hermes_dispatch(self, mock_execute, mock_route):
+        """Unsupported action does not call execute_foundup_job."""
+        mock_envelope = MagicMock()
+        mock_envelope.route_status = RouteStatus.UNSUPPORTED
+        mock_envelope.target_backend = TargetBackend.NONE
+        mock_envelope.reason_human = "Action not supported"
+        mock_envelope.job_id = "job_unsupported"
+        mock_route.return_value = mock_envelope
+
+        job = MockFoundUpJob(
+            job_id="job_unsupported",
+            tenant_id="tenant_test",
+            requested_action="delete_foundup",  # Not supported
+        )
+
+        consumer = FoundUpJobConsumer(dry_run=True)
+        result = consumer.consume_one(job)
+
+        # execute_foundup_job must NOT be called
+        mock_execute.assert_not_called()
+        assert result.dispatched is False
+        assert result.route_status == RouteStatus.UNSUPPORTED
+
+    @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
+    @patch(
+        "modules.foundups.agent.src.hermes_foundup_job_executor.execute_foundup_job"
+    )
+    def test_blocked_route_no_hermes_dispatch(self, mock_execute, mock_route):
+        """Blocked route does not call execute_foundup_job."""
+        mock_envelope = MagicMock()
+        mock_envelope.route_status = RouteStatus.BLOCKED
+        mock_envelope.target_backend = TargetBackend.NONE
+        mock_envelope.reason_human = "Security gate failed"
+        mock_envelope.job_id = "job_blocked"
+        mock_route.return_value = mock_envelope
+
+        job = MockFoundUpJob(
+            job_id="job_blocked",
+            tenant_id="tenant_test",
+            requested_action="build_foundup",
+            policy_flags=MockPolicyFlags(
+                security_gate_checked=True, security_gate_passed=False
+            ),
+        )
+
+        consumer = FoundUpJobConsumer(dry_run=True)
+        result = consumer.consume_one(job)
+
+        mock_execute.assert_not_called()
+        assert result.dispatched is False
+        assert result.route_status == RouteStatus.BLOCKED
+
+    @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
+    @patch(
+        "modules.foundups.agent.src.hermes_foundup_job_executor.execute_foundup_job"
+    )
+    def test_queued_route_status_no_hermes_dispatch(self, mock_execute, mock_route):
+        """QUEUED route status (queue_foundup_job) does not call Hermes."""
+        mock_envelope = MagicMock()
+        mock_envelope.route_status = RouteStatus.QUEUED
+        mock_envelope.target_backend = TargetBackend.OPENCLAW_QUEUE
+        mock_envelope.reason_human = "Job queued"
+        mock_envelope.job_id = "job_queued"
+        mock_route.return_value = mock_envelope
+
+        job = MockFoundUpJob(
+            job_id="job_queued",
+            tenant_id="tenant_test",
+            requested_action="queue_foundup_job",
+        )
+
+        consumer = FoundUpJobConsumer(dry_run=True)
+        result = consumer.consume_one(job)
+
+        mock_execute.assert_not_called()
+        assert result.dispatched is False
+        assert result.route_status == RouteStatus.QUEUED
+
+
+# ---------------------------------------------------------------------------
+# Test: drain_jobs consumes multiple jobs
+# ---------------------------------------------------------------------------
+
+
+class TestDrainJobs:
+    """Test drain_jobs processes multiple jobs."""
+
+    @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
+    def test_drain_jobs_processes_all_jobs(self, mock_route):
+        """drain_jobs processes all jobs in iterable."""
+        # All jobs blocked (no Hermes dispatch needed)
+        mock_envelope = MagicMock()
+        mock_envelope.route_status = RouteStatus.BLOCKED
+        mock_envelope.target_backend = TargetBackend.NONE
+        mock_envelope.reason_human = "Blocked"
+        mock_envelope.job_id = "job_x"
+        mock_route.return_value = mock_envelope
+
+        jobs = [
+            MockFoundUpJob(
+                job_id=f"job_{i}",
+                tenant_id="tenant_test",
+                requested_action="build_foundup",
+            )
+            for i in range(5)
+        ]
+
+        consumer = FoundUpJobConsumer(dry_run=True)
+        results = consumer.drain_jobs(jobs)
+
+        assert len(results) == 5
+        assert mock_route.call_count == 5
+        for result in results:
+            assert isinstance(result, ConsumerResult)
+
+
+# ---------------------------------------------------------------------------
+# Test: drain_openclaw_queue_once clears queue after drain
+# ---------------------------------------------------------------------------
+
+
+class TestDrainOpenClawQueue:
+    """Test drain_openclaw_queue_once behavior."""
+
+    @patch(
+        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.clear_job_queue"
+    )
+    @patch(
+        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.get_job_queue"
+    )
+    @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
+    def test_drain_clears_queue_after_success(
+        self, mock_route, mock_get_queue, mock_clear_queue
+    ):
+        """drain_openclaw_queue_once clears queue after successful drain."""
+        mock_envelope = MagicMock()
+        mock_envelope.route_status = RouteStatus.BLOCKED
+        mock_envelope.target_backend = TargetBackend.NONE
+        mock_envelope.reason_human = "Blocked"
+        mock_envelope.job_id = "job_q"
+        mock_route.return_value = mock_envelope
+
+        mock_get_queue.return_value = [
+            MockFoundUpJob(
+                job_id="job_q1",
+                tenant_id="tenant_test",
+                requested_action="build_foundup",
+            ),
+            MockFoundUpJob(
+                job_id="job_q2",
+                tenant_id="tenant_test",
+                requested_action="validate_foundup",
+            ),
+        ]
+
+        consumer = FoundUpJobConsumer(dry_run=True)
+        results = consumer.drain_openclaw_queue_once(clear=True)
+
+        assert len(results) == 2
+        mock_clear_queue.assert_called_once()
+
+    @patch(
+        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.clear_job_queue"
+    )
+    @patch(
+        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.get_job_queue"
+    )
+    @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
+    def test_drain_does_not_clear_if_clear_false(
+        self, mock_route, mock_get_queue, mock_clear_queue
+    ):
+        """drain_openclaw_queue_once with clear=False does not clear queue."""
+        mock_envelope = MagicMock()
+        mock_envelope.route_status = RouteStatus.BLOCKED
+        mock_envelope.target_backend = TargetBackend.NONE
+        mock_envelope.reason_human = "Blocked"
+        mock_envelope.job_id = "job_q"
+        mock_route.return_value = mock_envelope
+
+        mock_get_queue.return_value = [
+            MockFoundUpJob(
+                job_id="job_q1",
+                tenant_id="tenant_test",
+                requested_action="build_foundup",
+            ),
+        ]
+
+        consumer = FoundUpJobConsumer(dry_run=True)
+        results = consumer.drain_openclaw_queue_once(clear=False)
+
+        assert len(results) == 1
+        mock_clear_queue.assert_not_called()
+
+    @patch(
+        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.get_job_queue"
+    )
+    def test_drain_empty_queue_returns_empty_list(self, mock_get_queue):
+        """drain_openclaw_queue_once on empty queue returns empty list."""
+        mock_get_queue.return_value = []
+
+        consumer = FoundUpJobConsumer(dry_run=True)
+        results = consumer.drain_openclaw_queue_once()
+
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Test: Receipt emitter rejects non-terminal jobs
+# ---------------------------------------------------------------------------
+
+
+class TestReceiptEmitterTerminalCheck:
+    """Test receipt emitter rejects non-terminal jobs."""
+
+    def test_non_terminal_job_rejected(self):
+        """Non-terminal job receipt emission is rejected."""
+        from modules.communication.moltbot_bridge.src.receipt_emitter import (
+            emit_receipt_for_terminal_job,
+        )
+
+        job = MockFoundUpJob(
+            job_id="job_queued",
+            tenant_id="tenant_test",
+            requested_action="build_foundup",
+            status=MockJobStatus.QUEUED,  # Not terminal
+        )
+
+        result = emit_receipt_for_terminal_job(job)
+
+        assert result.success is False
+        assert "not terminal" in result.error.lower()
+
+    def test_running_job_rejected(self):
+        """Running job receipt emission is rejected."""
+        from modules.communication.moltbot_bridge.src.receipt_emitter import (
+            emit_receipt_for_terminal_job,
+        )
+
+        job = MockFoundUpJob(
+            job_id="job_running",
+            tenant_id="tenant_test",
+            requested_action="build_foundup",
+            status=MockJobStatus.RUNNING,  # Not terminal
+        )
+
+        result = emit_receipt_for_terminal_job(job)
+
+        assert result.success is False
+        assert "not terminal" in result.error.lower()
+
+    def test_terminal_succeeded_job_accepted(self):
+        """Terminal SUCCEEDED job can emit receipt."""
+        from modules.communication.moltbot_bridge.src.receipt_emitter import (
+            emit_receipt_for_terminal_job,
+        )
+        from modules.communication.moltbot_bridge.src.foundup_job_contract import (
+            create_job,
+            JobStatus,
+            StatusReasonCode,
+        )
+
+        # Use real FoundUpJob for proper terminal check
+        job = create_job(
+            tenant_id="tenant_test",
+            requested_action="build_foundup",
+            payload={"test": True},
+        )
+        # Manually set to terminal state
+        job.status = JobStatus.SUCCEEDED
+        job.status_reason_code = StatusReasonCode.OK_COMPLETED
+        job.evidence_refs = ["test_evidence.json"]
+
+        result = emit_receipt_for_terminal_job(job)
+
+        assert result.success is True
+        assert result.receipt is not None
+        assert result.verification is not None
+        # WSP 97 truth boundaries
+        assert result.verification.cabr_ready is False
+        assert result.verification.payout_ready is False
+
+
+# ---------------------------------------------------------------------------
+# Test: get_consumer factory
+# ---------------------------------------------------------------------------
+
+
+class TestGetConsumer:
+    """Test get_consumer factory function."""
+
+    def test_get_consumer_returns_instance(self):
+        """get_consumer returns FoundUpJobConsumer instance."""
+        consumer = get_consumer()
+        assert isinstance(consumer, FoundUpJobConsumer)
+        assert consumer.dry_run is True
+
+    def test_get_consumer_dry_run_false(self):
+        """get_consumer with dry_run=False."""
+        consumer = get_consumer(dry_run=False)
+        assert consumer.dry_run is False


### PR DESCRIPTION
## Summary
Adds FoundUpJobConsumer in WRE layer to drain OpenClaw queued FoundUpJobs.

## Changes
- **FoundUpJobConsumer** — Drains queued jobs without direct OpenClaw→Hermes bypass
- **Route-first pattern** — Every job goes through `route_foundup_job()` first
- **Action dispatch** — `HERMES_BUILDER`/`HERMES_VALIDATOR` dispatch to `execute_foundup_job()` with `dry_run=True` default
- **Receipt emitter** — Wrapper for terminal jobs only
- **Orchestrator update** — Message truthfully states consumer can drain queued jobs

## Tests
```
test_foundup_job_consumer.py: 16 passed
test_e2e_foundup_job_seam.py: 11 passed
test_foundup_job_router.py: 17 passed
Total: 44 passed
```

## WSP_97 Truth Boundaries
- **DOES NOT** implement daemon loop
- **DOES NOT** implement persistent queue
- **DOES NOT** mutate live production by default (`dry_run=True`)
- **DOES NOT** claim CABR/payout/reward mechanics
- **pAVS** remains accept-for-review only

🤖 Generated with [Claude Code](https://claude.com/claude-code)