### PR TITLE
feat(foundups): generate BuildPlan from FoundUpJob

### DIFF
--- a/modules/foundups/agent/src/build_plan_generator.py
+++ b/modules/foundups/agent/src/build_plan_generator.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+BuildPlan Generator — Generate BuildPlan from FoundUpJob
+
+Creates a BuildPlan from a FoundUpJob, bridging job-based orchestration
+to plan-based build control without enabling real execution.
+
+WSP 97 TRUTH BOUNDARIES:
+  - Generator produces dry_run=True plans only
+  - Generator does not execute BuildPlan steps
+  - Generator does not wire real Hermes execution
+  - No CABR/payout/reward/token fields
+
+Architecture:
+  FoundUpJob (OpenClaw) -> Generator -> BuildPlan -> (Future: Executor)
+
+WSP Compliance:
+  WSP 11  : Interface contract (typed API)
+  WSP 50  : Pre-action validation (validate_job_for_build_plan)
+  WSP 77  : Agent coordination (job->plan translation)
+  WSP 97  : Truth boundaries (dry_run=True, no real execution)
+
+NAVIGATION:
+  -> Uses: build_plan.py (BuildPlan, BuildTarget, BuildScope)
+  -> Uses: foundup_job_contract.py (FoundUpJob, CANONICAL_ACTIONS)
+  -> Spec: modules/foundups/docs/FOUNDUP_BUILD_PLAN_CONTRACT.md
+  -> Called by: Internal VoteBallot PoC (future integration)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+from modules.communication.moltbot_bridge.src.foundup_job_contract import (
+    CANONICAL_ACTIONS,
+    FoundUpJob,
+    is_supported_action,
+)
+
+from .build_plan import (
+    BuildMode,
+    BuildPlan,
+    BuildPlanStatus,
+    BuildScope,
+    BuildTarget,
+    create_standard_build_steps,
+    generate_build_plan_id,
+)
+
+logger = logging.getLogger("build_plan_generator")
+
+
+# ---------------------------------------------------------------------------
+# Supported Actions for BuildPlan Generation
+# ---------------------------------------------------------------------------
+
+# Actions that can generate BuildPlans (not queue_foundup_job)
+BUILDPLAN_SUPPORTED_ACTIONS: frozenset[str] = frozenset({
+    "build_foundup",
+    "extract_foundup",
+    "validate_foundup",
+})
+
+# Actions that should NOT generate BuildPlans
+BUILDPLAN_UNSUPPORTED_ACTIONS: frozenset[str] = frozenset({
+    "queue_foundup_job",  # Meta-action, not executable
+})
+
+
+# ---------------------------------------------------------------------------
+# Known FoundUp Module Paths (repo evidence)
+# ---------------------------------------------------------------------------
+
+# Known FoundUp IDs with proven module paths in the repo
+# Used for module_path inference when payload doesn't specify
+KNOWN_FOUNDUP_PATHS: Dict[str, str] = {
+    "voteballots": "modules/foundups/voteballots",
+    "gotjunk": "modules/foundups/gotjunk",
+    "kosei": "modules/foundups/kosei",
+    "pqn_portal": "modules/foundups/pqn_portal",
+    "social_twin": "modules/foundups/social_twin",
+    "move2japan": "modules/foundups/move2japan",
+}
+
+
+def get_known_foundup_path(foundup_id: str) -> Optional[str]:
+    """
+    Get known module path for a FoundUp ID.
+
+    Returns None if not a known FoundUp with repo evidence.
+    """
+    return KNOWN_FOUNDUP_PATHS.get(foundup_id.lower())
+
+
+# ---------------------------------------------------------------------------
+# Validation Result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GenerationValidationResult:
+    """Result of job validation for BuildPlan generation."""
+
+    valid: bool
+    """True if job can generate a BuildPlan."""
+
+    error_code: Optional[str] = None
+    """Machine-readable error code if invalid."""
+
+    error_message: Optional[str] = None
+    """Human-readable error message if invalid."""
+
+    inferred_module_path: Optional[str] = None
+    """Module path inferred from foundup_id if not in payload."""
+
+
+# ---------------------------------------------------------------------------
+# Validation Functions
+# ---------------------------------------------------------------------------
+
+
+def validate_job_for_build_plan(job: FoundUpJob) -> GenerationValidationResult:
+    """
+    Validate that a FoundUpJob can generate a BuildPlan.
+
+    Checks:
+      1. foundup_id is present
+      2. requested_action is supported
+      3. module_path can be determined (from payload or inference)
+      4. Path is within allowed scope
+
+    Returns:
+        GenerationValidationResult with validation outcome.
+    """
+    # Check foundup_id
+    if not job.foundup_id:
+        return GenerationValidationResult(
+            valid=False,
+            error_code="MISSING_FOUNDUP_ID",
+            error_message="FoundUpJob.foundup_id is required for BuildPlan generation",
+        )
+
+    # Check requested_action is supported
+    action = job.requested_action
+    if action in BUILDPLAN_UNSUPPORTED_ACTIONS:
+        return GenerationValidationResult(
+            valid=False,
+            error_code="UNSUPPORTED_ACTION",
+            error_message=f"Action '{action}' cannot generate a BuildPlan. "
+            f"Use one of: {', '.join(sorted(BUILDPLAN_SUPPORTED_ACTIONS))}",
+        )
+
+    if action not in BUILDPLAN_SUPPORTED_ACTIONS:
+        return GenerationValidationResult(
+            valid=False,
+            error_code="UNKNOWN_ACTION",
+            error_message=f"Unknown action '{action}'. "
+            f"Supported actions: {', '.join(sorted(BUILDPLAN_SUPPORTED_ACTIONS))}",
+        )
+
+    # Determine module_path
+    payload = job.payload or {}
+    module_path = payload.get("module_path") or payload.get("source_module")
+
+    # Try to infer from foundup_id if not provided
+    inferred_path = None
+    if not module_path:
+        inferred_path = get_known_foundup_path(job.foundup_id)
+        if inferred_path:
+            module_path = inferred_path
+        else:
+            return GenerationValidationResult(
+                valid=False,
+                error_code="MISSING_MODULE_PATH",
+                error_message=(
+                    f"Cannot determine module_path for FoundUp '{job.foundup_id}'. "
+                    f"Provide payload.module_path or use a known FoundUp ID: "
+                    f"{', '.join(sorted(KNOWN_FOUNDUP_PATHS.keys()))}"
+                ),
+            )
+
+    # Validate path is within allowed scope
+    if not _is_valid_foundup_path(module_path):
+        return GenerationValidationResult(
+            valid=False,
+            error_code="INVALID_MODULE_PATH",
+            error_message=(
+                f"Module path '{module_path}' is outside allowed scope. "
+                f"Must be under modules/foundups/ or a recognized target path."
+            ),
+        )
+
+    return GenerationValidationResult(
+        valid=True,
+        inferred_module_path=inferred_path,
+    )
+
+
+def _is_valid_foundup_path(path: str) -> bool:
+    """
+    Check if path is a valid FoundUp module path.
+
+    Valid paths:
+      - modules/foundups/<foundup_id>/...
+      - public/member/foundups/<foundup_id>/... (PWA surface)
+    """
+    normalized = path.replace("\\", "/").lower()
+
+    # Must be under foundups module or surface
+    valid_prefixes = [
+        "modules/foundups/",
+        "public/member/foundups/",
+    ]
+
+    for prefix in valid_prefixes:
+        if normalized.startswith(prefix):
+            return True
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Scope Inference
+# ---------------------------------------------------------------------------
+
+
+def infer_build_scope(job: FoundUpJob) -> BuildScope:
+    """
+    Infer BuildScope from job action and payload.
+
+    Mapping:
+      validate_foundup -> GENESIS_ONLY
+      build_foundup -> FULL_BUILD
+      extract_foundup -> FULL_BUILD
+    """
+    action = job.requested_action
+    payload = job.payload or {}
+
+    # Check payload for explicit scope
+    explicit_scope = payload.get("build_scope")
+    if explicit_scope:
+        try:
+            return BuildScope(explicit_scope)
+        except ValueError:
+            pass  # Fall through to inference
+
+    # Infer from action
+    if action == "validate_foundup":
+        return BuildScope.GENESIS_ONLY
+
+    if action in ("build_foundup", "extract_foundup"):
+        return BuildScope.FULL_BUILD
+
+    # Default to genesis only for unknown
+    return BuildScope.GENESIS_ONLY
+
+
+# ---------------------------------------------------------------------------
+# BuildTarget Generation
+# ---------------------------------------------------------------------------
+
+
+def build_target_from_job(job: FoundUpJob) -> BuildTarget:
+    """
+    Generate BuildTarget from FoundUpJob payload.
+
+    Maps job.payload fields to BuildTarget fields.
+    """
+    payload = job.payload or {}
+
+    # Determine module_path (validated before this is called)
+    module_path = payload.get("module_path") or payload.get("source_module")
+    if not module_path and job.foundup_id:
+        module_path = get_known_foundup_path(job.foundup_id)
+
+    if not module_path:
+        # Should not reach here if validation passed
+        module_path = f"modules/foundups/{job.foundup_id}"
+
+    # Extract optional paths from payload
+    pwa_surface_path = payload.get("pwa_surface_path")
+    if not pwa_surface_path and job.foundup_id:
+        # Default PWA surface path
+        pwa_surface_path = f"public/member/foundups/{job.foundup_id}/"
+
+    return BuildTarget(
+        module_path=module_path,
+        foundup_manifest_path=payload.get("foundup_manifest_path"),
+        pwa_surface_path=pwa_surface_path,
+        tests_path=payload.get("tests_path"),
+        docs_path=payload.get("docs_path"),
+        modlog_path=payload.get("modlog_path"),
+        testmodlog_path=payload.get("testmodlog_path"),
+        readme_path=payload.get("readme_path"),
+        interface_path=payload.get("interface_path"),
+        allowed_paths=payload.get("allowed_paths", []),
+        blocked_paths=payload.get("blocked_paths", []),
+    )
+
+
+# ---------------------------------------------------------------------------
+# BuildPlan Generation
+# ---------------------------------------------------------------------------
+
+
+def create_build_plan_from_job(job: FoundUpJob) -> BuildPlan:
+    """
+    Generate a BuildPlan from a FoundUpJob.
+
+    Maps job identity, payload, and action to a BuildPlan structure.
+    Always produces dry_run=True plans (WSP 97).
+
+    Args:
+        job: FoundUpJob to generate plan from.
+
+    Returns:
+        BuildPlan with job identity, target, and standard steps.
+
+    Raises:
+        ValueError: If job fails validation.
+
+    WSP 97: This function ONLY generates plans with dry_run=True.
+    It does NOT execute steps or enable real builds.
+    """
+    # Validate job
+    validation = validate_job_for_build_plan(job)
+    if not validation.valid:
+        raise ValueError(
+            f"[{validation.error_code}] {validation.error_message}"
+        )
+
+    # Generate plan ID
+    plan_id = generate_build_plan_id(job.foundup_id)
+
+    # Build target from job
+    target = build_target_from_job(job)
+
+    # Determine dry_run mode
+    payload = job.payload or {}
+    dry_run = True  # WSP 97: Always default to True
+
+    # Check if job explicitly sets dry_run (still default True)
+    if payload.get("dry_run") is False:
+        # Log warning but keep dry_run=True for generator
+        logger.warning(
+            "[GENERATOR] Job %s requested dry_run=False, "
+            "but generator always produces dry_run=True plans",
+            job.job_id,
+        )
+
+    # Also check policy_flags
+    if job.policy_flags and job.policy_flags.dry_run_mode is False:
+        logger.warning(
+            "[GENERATOR] Job %s has policy_flags.dry_run_mode=False, "
+            "but generator always produces dry_run=True plans",
+            job.job_id,
+        )
+
+    # Infer build scope
+    scope = infer_build_scope(job)
+
+    # Create plan
+    plan = BuildPlan(
+        build_plan_id=plan_id,
+        foundup_id=job.foundup_id,
+        tenant_id=job.tenant_id,
+        intent_id=job.intent_id,
+        source_job_id=job.job_id,
+        requested_action=job.requested_action,
+        mode=BuildMode.DRY_RUN,  # WSP 97: Always DRY_RUN
+        dry_run=dry_run,  # WSP 97: Always True
+        status=BuildPlanStatus.DRAFT,
+        target=target,
+    )
+
+    # Add standard steps based on scope
+    if scope in (BuildScope.FULL_BUILD, BuildScope.INCREMENTAL):
+        plan.steps = create_standard_build_steps(target.module_path)
+    elif scope == BuildScope.GENESIS_ONLY:
+        # Genesis-only: first 2 validation steps
+        all_steps = create_standard_build_steps(target.module_path)
+        plan.steps = all_steps[:2]
+
+    logger.info(
+        "[GENERATOR] Created BuildPlan %s for job %s (foundup=%s, scope=%s)",
+        plan.build_plan_id,
+        job.job_id,
+        job.foundup_id,
+        scope.value,
+    )
+
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# Convenience: Check if Job Can Generate Plan
+# ---------------------------------------------------------------------------
+
+
+def can_generate_build_plan(job: FoundUpJob) -> bool:
+    """
+    Check if a FoundUpJob can generate a BuildPlan.
+
+    Args:
+        job: FoundUpJob to check.
+
+    Returns:
+        True if job can generate a BuildPlan, False otherwise.
+    """
+    validation = validate_job_for_build_plan(job)
+    return validation.valid
+
+
+def get_generation_error(job: FoundUpJob) -> Optional[str]:
+    """
+    Get the generation error for a job, if any.
+
+    Args:
+        job: FoundUpJob to check.
+
+    Returns:
+        Error message if job cannot generate a BuildPlan, None otherwise.
+    """
+    validation = validate_job_for_build_plan(job)
+    if validation.valid:
+        return None
+    return f"[{validation.error_code}] {validation.error_message}"

--- a/modules/foundups/agent/tests/test_build_plan_generator.py
+++ b/modules/foundups/agent/tests/test_build_plan_generator.py
@@ -1,0 +1,727 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+BuildPlan Generator Tests
+
+Verifies BuildPlan generation from FoundUpJob.
+
+WSP 97 TRUTH BOUNDARIES:
+  - Generator produces dry_run=True plans only
+  - Generator does not execute steps
+  - Generator validates job before generation
+  - No CABR/payout/reward/token fields
+
+Test Coverage:
+  1. VoteBallot FoundUpJob generates valid BuildPlan
+  2. Plan inherits job identity
+  3. Plan preserves dry_run=True
+  4. Plan mode is DRY_RUN by default
+  5. module_path maps to BuildTarget
+  6. standard steps are populated
+  7. queue_foundup_job is rejected
+  8. missing foundup_id fails truthfully
+  9. missing module_path can infer VoteBallot path
+  10. outside-scope module_path is rejected
+  11. no CABR/reward/payout/token fields
+  12. generated plan is not real-build allowed
+
+NAVIGATION:
+  -> Tests: modules/foundups/agent/src/build_plan_generator.py
+  -> Uses: build_plan.py, foundup_job_contract.py
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.foundup_job_contract import (
+    FoundUpJob,
+    JobStatus,
+    PolicyFlags,
+    create_job,
+)
+
+from modules.foundups.agent.src.build_plan import (
+    BuildMode,
+    BuildPlan,
+    BuildPlanStatus,
+    BuildScope,
+    BuildStepAction,
+    GateType,
+)
+
+from modules.foundups.agent.src.build_plan_generator import (
+    BUILDPLAN_SUPPORTED_ACTIONS,
+    BUILDPLAN_UNSUPPORTED_ACTIONS,
+    KNOWN_FOUNDUP_PATHS,
+    build_target_from_job,
+    can_generate_build_plan,
+    create_build_plan_from_job,
+    get_generation_error,
+    get_known_foundup_path,
+    infer_build_scope,
+    validate_job_for_build_plan,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def voteballot_job() -> FoundUpJob:
+    """Create a VoteBallot build_foundup job."""
+    return create_job(
+        tenant_id="012",
+        requested_action="build_foundup",
+        foundup_id="voteballots",
+        intent_id="internal_poc_voteballot_build",
+        payload={
+            "module_path": "modules/foundups/voteballots",
+            "target_org": "FOUNDUPS",
+            "build_goal": "internal dry-run PoC for VoteBallot",
+            "dry_run": True,
+        },
+    )
+
+
+@pytest.fixture
+def voteballot_job_no_module_path() -> FoundUpJob:
+    """Create a VoteBallot job without explicit module_path."""
+    return create_job(
+        tenant_id="012",
+        requested_action="build_foundup",
+        foundup_id="voteballots",
+        intent_id="internal_poc_voteballot_build",
+        payload={
+            "target_org": "FOUNDUPS",
+            "dry_run": True,
+        },
+    )
+
+
+@pytest.fixture
+def queue_job() -> FoundUpJob:
+    """Create a queue_foundup_job action job."""
+    return create_job(
+        tenant_id="012",
+        requested_action="queue_foundup_job",
+        foundup_id="voteballots",
+        payload={
+            "module_path": "modules/foundups/voteballots",
+        },
+    )
+
+
+@pytest.fixture
+def unknown_foundup_job() -> FoundUpJob:
+    """Create a job for unknown FoundUp without module_path."""
+    return create_job(
+        tenant_id="012",
+        requested_action="build_foundup",
+        foundup_id="unknown_foundup_xyz",
+        payload={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: VoteBallot FoundUpJob Generates Valid BuildPlan
+# ---------------------------------------------------------------------------
+
+
+class TestVoteBallotPlanGeneration:
+    """Test VoteBallot job generates valid plan."""
+
+    def test_voteballot_generates_valid_plan(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """VoteBallot job generates a valid BuildPlan."""
+        plan = create_build_plan_from_job(voteballot_job)
+
+        assert plan is not None
+        assert isinstance(plan, BuildPlan)
+        assert plan.build_plan_id.startswith("bp_voteballots_")
+        assert plan.foundup_id == "voteballots"
+
+    def test_voteballot_plan_has_target(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """Generated plan has BuildTarget."""
+        plan = create_build_plan_from_job(voteballot_job)
+
+        assert plan.target is not None
+        assert plan.target.module_path == "modules/foundups/voteballots"
+
+    def test_voteballot_plan_has_steps(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """Generated plan has standard build steps."""
+        plan = create_build_plan_from_job(voteballot_job)
+
+        # Full build has 12 steps
+        assert len(plan.steps) == 12
+        assert plan.steps[0].action == BuildStepAction.VALIDATE_GENESIS
+        assert plan.steps[-1].action == BuildStepAction.REQUEST_APPROVAL
+
+    def test_voteballot_plan_has_gates(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """Generated plan has default gates."""
+        plan = create_build_plan_from_job(voteballot_job)
+
+        assert len(plan.gates) == 8
+        gate_types = {g.gate_type for g in plan.gates}
+        assert GateType.HUMAN_APPROVAL_GATE in gate_types
+        assert GateType.DRY_RUN_GATE in gate_types
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Plan Inherits Job Identity
+# ---------------------------------------------------------------------------
+
+
+class TestPlanInheritsJobIdentity:
+    """Test plan inherits job identity fields."""
+
+    def test_plan_inherits_foundup_id(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """Plan inherits foundup_id from job."""
+        plan = create_build_plan_from_job(voteballot_job)
+        assert plan.foundup_id == voteballot_job.foundup_id
+
+    def test_plan_inherits_tenant_id(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """Plan inherits tenant_id from job."""
+        plan = create_build_plan_from_job(voteballot_job)
+        assert plan.tenant_id == voteballot_job.tenant_id
+
+    def test_plan_inherits_intent_id(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """Plan inherits intent_id from job."""
+        plan = create_build_plan_from_job(voteballot_job)
+        assert plan.intent_id == voteballot_job.intent_id
+
+    def test_plan_has_source_job_id(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """Plan has source_job_id linking to originating job."""
+        plan = create_build_plan_from_job(voteballot_job)
+        assert plan.source_job_id == voteballot_job.job_id
+
+    def test_plan_inherits_requested_action(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """Plan inherits requested_action from job."""
+        plan = create_build_plan_from_job(voteballot_job)
+        assert plan.requested_action == "build_foundup"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Plan Preserves dry_run=True
+# ---------------------------------------------------------------------------
+
+
+class TestPlanPreservesDryRun:
+    """Test plan preserves dry_run=True."""
+
+    def test_plan_has_dry_run_true(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """Generated plan has dry_run=True."""
+        plan = create_build_plan_from_job(voteballot_job)
+        assert plan.dry_run is True
+
+    def test_plan_ignores_dry_run_false_in_payload(self) -> None:
+        """Generator ignores dry_run=False in payload (WSP 97)."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            payload={
+                "module_path": "modules/foundups/voteballots",
+                "dry_run": False,  # Request dry_run=False
+            },
+        )
+
+        plan = create_build_plan_from_job(job)
+
+        # Generator ALWAYS produces dry_run=True
+        assert plan.dry_run is True
+
+    def test_plan_ignores_policy_flags_dry_run_false(self) -> None:
+        """Generator ignores policy_flags.dry_run_mode=False (WSP 97)."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            payload={
+                "module_path": "modules/foundups/voteballots",
+            },
+        )
+        job.policy_flags.dry_run_mode = False  # Set to False
+
+        plan = create_build_plan_from_job(job)
+
+        # Generator ALWAYS produces dry_run=True
+        assert plan.dry_run is True
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Plan Mode is DRY_RUN by Default
+# ---------------------------------------------------------------------------
+
+
+class TestPlanModeDefault:
+    """Test plan mode defaults to DRY_RUN."""
+
+    def test_plan_mode_is_dry_run(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """Generated plan has mode=DRY_RUN."""
+        plan = create_build_plan_from_job(voteballot_job)
+        assert plan.mode == BuildMode.DRY_RUN
+
+    def test_plan_status_is_draft(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """Generated plan has status=DRAFT."""
+        plan = create_build_plan_from_job(voteballot_job)
+        assert plan.status == BuildPlanStatus.DRAFT
+
+
+# ---------------------------------------------------------------------------
+# Test 5: module_path Maps to BuildTarget
+# ---------------------------------------------------------------------------
+
+
+class TestModulePathMapping:
+    """Test module_path maps to BuildTarget."""
+
+    def test_module_path_from_payload(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """BuildTarget.module_path from payload.module_path."""
+        plan = create_build_plan_from_job(voteballot_job)
+        assert plan.target.module_path == "modules/foundups/voteballots"
+
+    def test_manifest_path_auto_generated(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """BuildTarget auto-generates manifest path."""
+        plan = create_build_plan_from_job(voteballot_job)
+        assert plan.target.foundup_manifest_path == (
+            "modules/foundups/voteballots/foundup_manifest.json"
+        )
+
+    def test_tests_path_auto_generated(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """BuildTarget auto-generates tests path."""
+        plan = create_build_plan_from_job(voteballot_job)
+        assert plan.target.tests_path == "modules/foundups/voteballots/tests/"
+
+    def test_explicit_paths_override_defaults(self) -> None:
+        """Explicit paths in payload override defaults."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            payload={
+                "module_path": "modules/foundups/voteballots",
+                "tests_path": "custom/tests/",
+                "docs_path": "custom/docs/",
+            },
+        )
+
+        plan = create_build_plan_from_job(job)
+
+        assert plan.target.tests_path == "custom/tests/"
+        assert plan.target.docs_path == "custom/docs/"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Standard Steps are Populated
+# ---------------------------------------------------------------------------
+
+
+class TestStandardStepsPopulated:
+    """Test standard steps are populated."""
+
+    def test_full_build_has_12_steps(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """Full build scope has 12 standard steps."""
+        plan = create_build_plan_from_job(voteballot_job)
+
+        assert len(plan.steps) == 12
+        actions = [s.action for s in plan.steps]
+        assert BuildStepAction.VALIDATE_GENESIS in actions
+        assert BuildStepAction.RUN_TESTS in actions
+        assert BuildStepAction.SUBMIT_RECEIPT in actions
+
+    def test_validate_foundup_has_genesis_steps_only(self) -> None:
+        """validate_foundup action has genesis steps only."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="validate_foundup",
+            foundup_id="voteballots",
+            payload={
+                "module_path": "modules/foundups/voteballots",
+            },
+        )
+
+        plan = create_build_plan_from_job(job)
+
+        # Genesis only = first 2 steps
+        assert len(plan.steps) == 2
+        assert plan.steps[0].action == BuildStepAction.VALIDATE_GENESIS
+        assert plan.steps[1].action == BuildStepAction.VALIDATE_MANIFEST
+
+    def test_extract_foundup_has_full_steps(self) -> None:
+        """extract_foundup action has full build steps."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="voteballots",
+            payload={
+                "module_path": "modules/foundups/voteballots",
+            },
+        )
+
+        plan = create_build_plan_from_job(job)
+
+        assert len(plan.steps) == 12
+
+
+# ---------------------------------------------------------------------------
+# Test 7: queue_foundup_job is Rejected
+# ---------------------------------------------------------------------------
+
+
+class TestQueueActionRejected:
+    """Test queue_foundup_job is rejected for BuildPlan generation."""
+
+    def test_queue_foundup_job_is_unsupported(self) -> None:
+        """queue_foundup_job is in unsupported actions set."""
+        assert "queue_foundup_job" in BUILDPLAN_UNSUPPORTED_ACTIONS
+        assert "queue_foundup_job" not in BUILDPLAN_SUPPORTED_ACTIONS
+
+    def test_queue_job_fails_validation(
+        self, queue_job: FoundUpJob
+    ) -> None:
+        """queue_foundup_job fails validation."""
+        result = validate_job_for_build_plan(queue_job)
+
+        assert result.valid is False
+        assert result.error_code == "UNSUPPORTED_ACTION"
+        assert "queue_foundup_job" in result.error_message
+
+    def test_queue_job_cannot_generate_plan(
+        self, queue_job: FoundUpJob
+    ) -> None:
+        """queue_foundup_job cannot generate plan."""
+        assert can_generate_build_plan(queue_job) is False
+
+    def test_queue_job_raises_on_generate(
+        self, queue_job: FoundUpJob
+    ) -> None:
+        """queue_foundup_job raises ValueError on generation."""
+        with pytest.raises(ValueError, match="UNSUPPORTED_ACTION"):
+            create_build_plan_from_job(queue_job)
+
+
+# ---------------------------------------------------------------------------
+# Test 8: Missing foundup_id Fails Truthfully
+# ---------------------------------------------------------------------------
+
+
+class TestMissingFoundupIdFails:
+    """Test missing foundup_id fails truthfully."""
+
+    def test_missing_foundup_id_fails_validation(self) -> None:
+        """Job without foundup_id fails validation."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id=None,  # type: ignore
+            payload={
+                "module_path": "modules/foundups/test",
+            },
+        )
+        # Manually clear foundup_id (create_job might set it)
+        job.foundup_id = None
+
+        result = validate_job_for_build_plan(job)
+
+        assert result.valid is False
+        assert result.error_code == "MISSING_FOUNDUP_ID"
+
+    def test_empty_foundup_id_fails_validation(self) -> None:
+        """Job with empty foundup_id fails validation."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="",
+            payload={
+                "module_path": "modules/foundups/test",
+            },
+        )
+        job.foundup_id = ""
+
+        result = validate_job_for_build_plan(job)
+
+        assert result.valid is False
+        assert result.error_code == "MISSING_FOUNDUP_ID"
+
+
+# ---------------------------------------------------------------------------
+# Test 9: Missing module_path Can Infer VoteBallot Path
+# ---------------------------------------------------------------------------
+
+
+class TestModulePathInference:
+    """Test module_path inference from foundup_id."""
+
+    def test_known_foundup_paths_include_voteballots(self) -> None:
+        """KNOWN_FOUNDUP_PATHS includes voteballots."""
+        assert "voteballots" in KNOWN_FOUNDUP_PATHS
+        assert KNOWN_FOUNDUP_PATHS["voteballots"] == "modules/foundups/voteballots"
+
+    def test_get_known_foundup_path_returns_voteballots(self) -> None:
+        """get_known_foundup_path returns VoteBallots path."""
+        path = get_known_foundup_path("voteballots")
+        assert path == "modules/foundups/voteballots"
+
+    def test_infer_module_path_for_voteballots(
+        self, voteballot_job_no_module_path: FoundUpJob
+    ) -> None:
+        """Can infer module_path for VoteBallots."""
+        result = validate_job_for_build_plan(voteballot_job_no_module_path)
+
+        assert result.valid is True
+        assert result.inferred_module_path == "modules/foundups/voteballots"
+
+    def test_generate_plan_with_inferred_path(
+        self, voteballot_job_no_module_path: FoundUpJob
+    ) -> None:
+        """Can generate plan with inferred module_path."""
+        plan = create_build_plan_from_job(voteballot_job_no_module_path)
+
+        assert plan.target.module_path == "modules/foundups/voteballots"
+
+    def test_unknown_foundup_without_module_path_fails(
+        self, unknown_foundup_job: FoundUpJob
+    ) -> None:
+        """Unknown FoundUp without module_path fails."""
+        result = validate_job_for_build_plan(unknown_foundup_job)
+
+        assert result.valid is False
+        assert result.error_code == "MISSING_MODULE_PATH"
+        assert "unknown_foundup_xyz" in result.error_message
+
+
+# ---------------------------------------------------------------------------
+# Test 10: Outside-Scope module_path is Rejected
+# ---------------------------------------------------------------------------
+
+
+class TestOutsideScopeRejected:
+    """Test outside-scope module_path is rejected."""
+
+    def test_infrastructure_path_rejected(self) -> None:
+        """Infrastructure module path is rejected."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="test",
+            payload={
+                "module_path": "modules/infrastructure/wre_core",
+            },
+        )
+
+        result = validate_job_for_build_plan(job)
+
+        assert result.valid is False
+        assert result.error_code == "INVALID_MODULE_PATH"
+
+    def test_root_path_rejected(self) -> None:
+        """Root path is rejected."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="test",
+            payload={
+                "module_path": "/etc/passwd",
+            },
+        )
+
+        result = validate_job_for_build_plan(job)
+
+        assert result.valid is False
+        assert result.error_code == "INVALID_MODULE_PATH"
+
+    def test_ai_intelligence_path_rejected(self) -> None:
+        """AI intelligence module path is rejected."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="test",
+            payload={
+                "module_path": "modules/ai_intelligence/agent_permissions",
+            },
+        )
+
+        result = validate_job_for_build_plan(job)
+
+        assert result.valid is False
+        assert result.error_code == "INVALID_MODULE_PATH"
+
+
+# ---------------------------------------------------------------------------
+# Test 11: No CABR/Reward/Payout/Token Fields
+# ---------------------------------------------------------------------------
+
+
+class TestNoCABRFields:
+    """Test no CABR/reward/payout/token fields exist."""
+
+    def test_plan_dict_has_no_cabr_fields(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """Generated plan dict has no CABR fields."""
+        plan = create_build_plan_from_job(voteballot_job)
+        d = plan.to_dict()
+
+        assert "cabr_ready" not in d
+        assert "payout_ready" not in d
+        assert "reward" not in d
+        assert "tokens" not in d
+        assert "tokens_issued" not in d
+        assert "payout_amount" not in d
+        assert "verification_complete" not in d
+
+    def test_plan_has_no_cabr_attributes(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """Generated plan has no CABR attributes."""
+        plan = create_build_plan_from_job(voteballot_job)
+
+        assert not hasattr(plan, "cabr_ready")
+        assert not hasattr(plan, "payout_ready")
+        assert not hasattr(plan, "tokens_issued")
+        assert not hasattr(plan, "reward")
+
+
+# ---------------------------------------------------------------------------
+# Test 12: Generated Plan is Not Real-Build Allowed
+# ---------------------------------------------------------------------------
+
+
+class TestNotRealBuildAllowed:
+    """Test generated plan is not real-build allowed."""
+
+    def test_generated_plan_not_real_build_allowed(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """Generated plan cannot do real build."""
+        plan = create_build_plan_from_job(voteballot_job)
+
+        # WSP 97: Generated plans are always dry-run
+        assert plan.is_real_build_allowed() is False
+
+    def test_plan_requires_human_approval_for_real(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """Real build would require human approval gate."""
+        plan = create_build_plan_from_job(voteballot_job)
+
+        # Get human approval gate
+        human_gate = plan.get_gate(GateType.HUMAN_APPROVAL_GATE)
+        assert human_gate is not None
+        assert human_gate.passed is False
+
+
+# ---------------------------------------------------------------------------
+# Test: BuildScope Inference
+# ---------------------------------------------------------------------------
+
+
+class TestBuildScopeInference:
+    """Test BuildScope inference from job."""
+
+    def test_build_foundup_infers_full_build(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """build_foundup infers FULL_BUILD scope."""
+        scope = infer_build_scope(voteballot_job)
+        assert scope == BuildScope.FULL_BUILD
+
+    def test_validate_foundup_infers_genesis_only(self) -> None:
+        """validate_foundup infers GENESIS_ONLY scope."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="validate_foundup",
+            foundup_id="voteballots",
+            payload={"module_path": "modules/foundups/voteballots"},
+        )
+
+        scope = infer_build_scope(job)
+        assert scope == BuildScope.GENESIS_ONLY
+
+    def test_explicit_scope_in_payload(self) -> None:
+        """Explicit build_scope in payload is used."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            payload={
+                "module_path": "modules/foundups/voteballots",
+                "build_scope": "incremental",
+            },
+        )
+
+        scope = infer_build_scope(job)
+        assert scope == BuildScope.INCREMENTAL
+
+
+# ---------------------------------------------------------------------------
+# Test: Convenience Functions
+# ---------------------------------------------------------------------------
+
+
+class TestConvenienceFunctions:
+    """Test convenience functions."""
+
+    def test_can_generate_build_plan_true(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """can_generate_build_plan returns True for valid job."""
+        assert can_generate_build_plan(voteballot_job) is True
+
+    def test_can_generate_build_plan_false(
+        self, queue_job: FoundUpJob
+    ) -> None:
+        """can_generate_build_plan returns False for invalid job."""
+        assert can_generate_build_plan(queue_job) is False
+
+    def test_get_generation_error_none(
+        self, voteballot_job: FoundUpJob
+    ) -> None:
+        """get_generation_error returns None for valid job."""
+        assert get_generation_error(voteballot_job) is None
+
+    def test_get_generation_error_message(
+        self, queue_job: FoundUpJob
+    ) -> None:
+        """get_generation_error returns error for invalid job."""
+        error = get_generation_error(queue_job)
+        assert error is not None
+        assert "UNSUPPORTED_ACTION" in error
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Adds BuildPlan generation from FoundUpJob
- Supports `build_foundup`, `extract_foundup`, `validate_foundup` actions
- Rejects `queue_foundup_job` for executable BuildPlan generation
- Maps FoundUpJob identity into BuildPlan identity
- Maps payload paths into BuildTarget
- Infers known FoundUp module paths when repo evidence supports it
- Always enforces `dry_run=True` and `BuildMode.DRY_RUN`
- Does not execute BuildPlan steps
- Does not enable real builds
- No CABR/reward/payout/token fields

## WSP_97 Boundaries

- `dry_run=True` enforced in all generated plans
- `BuildMode.DRY_RUN` enforced
- No step execution implemented
- No real build enablement

## Test Plan

- [x] 46 generator tests passed
- [x] 35 BuildPlan tests passed (regression)
- [x] 13 VoteBallot PoC tests passed (regression)
- [x] Lint/security CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)