### PR TITLE
feat(foundups): add BuildPlanExecutor interface stub

### DIFF
--- a/modules/foundups/agent/INTERFACE.md
+++ b/modules/foundups/agent/INTERFACE.md
@@ -1,6 +1,59 @@
 # Agent Module Interface
 
-Public API and schema contracts for agent lifecycle management.
+Public API and schema contracts for agent lifecycle management, BuildPlan generation, and controlled execution.
+
+## BuildPlan Pipeline (OC8/OC9/OC12)
+
+### Core Dataclasses
+
+```python
+# modules/foundups/agent/src/build_plan.py
+BuildPlan        # Multi-step orchestration contract
+BuildTarget      # Target paths and scope
+BuildStep        # Step definition with action enum
+BuildGate        # Gate checkpoints (genesis, dry_run, human_approval)
+BuildEvidence    # Evidence reference with verification status
+```
+
+### BuildPlan Generator
+
+```python
+# modules/foundups/agent/src/build_plan_generator.py
+def create_build_plan_from_job(job: FoundUpJob) -> BuildPlan:
+    """Generate BuildPlan from FoundUpJob. Always produces dry_run=True plans."""
+
+def can_generate_build_plan(job: FoundUpJob) -> bool:
+    """Check if job can generate a BuildPlan."""
+```
+
+### BuildPlan Executor (Interface Stub)
+
+```python
+# modules/foundups/agent/src/build_plan_executor.py
+class BuildPlanExecutor:
+    """Controlled step execution. Real execution NOT implemented."""
+    
+    def __init__(self, dry_run: bool = True): ...
+    def validate_plan(self, plan: BuildPlan) -> ValidationResult: ...
+    def evaluate_gate(self, plan: BuildPlan, gate_type: GateType) -> GateEvaluationResult: ...
+    def simulate_step(self, plan: BuildPlan, step: BuildStep) -> StepExecutionResult: ...
+    def execute_step(self, plan: BuildPlan, step: BuildStep) -> StepExecutionResult: ...
+    def create_execution_receipt(self, plan: BuildPlan, results: List[StepExecutionResult]) -> ExecutionReceipt: ...
+
+# Execution Result Types
+StepExecutionStatus  # SUCCEEDED | FAILED | BLOCKED | SKIPPED | SIMULATED
+ExecutionReceipt     # Terminal receipt with WSP 97 truth fields
+```
+
+### WSP 97 Truth Fields
+
+ExecutionReceipt enforces these fields as False always:
+- `verification_complete = False`
+- `cabr_ready = False`
+- `payout_ready = False`
+- `real_execution_performed = False`
+
+---
 
 ## Event Schemas
 

--- a/modules/foundups/agent/ModLog.md
+++ b/modules/foundups/agent/ModLog.md
@@ -1,5 +1,109 @@
 # Agent Module ModLog
 
+## 2026-04-29 - BuildPlanExecutor Interface Stub (v0.9.0)
+
+**Author**: 0102 (W4)
+**Slice**: OC12_BUILD_PLAN_EXECUTOR_INTERFACE_STUB_PHASE1
+**WSP References**: WSP 11, WSP 50, WSP 77, WSP 97
+
+### Added
+
+- **build_plan_executor.py** - BuildPlanExecutor interface stub
+  - `BuildPlanExecutor` class with dry_run=True default
+  - `validate_plan()` - Plan validation with gate checks
+  - `evaluate_gate()` - Gate evaluation (genesis, dry_run, human_approval)
+  - `simulate_step()` - Step simulation returning SIMULATED status
+  - `execute_step()` - Delegates to simulation; real execution returns BLOCKED
+  - `create_execution_receipt()` - Creates receipt with WSP 97 truth fields
+
+### Enums and Dataclasses
+
+| Type | Purpose |
+|------|---------|
+| `StepExecutionStatus` | SUCCEEDED, FAILED, BLOCKED, SKIPPED, SIMULATED |
+| `ExecutionMode` | DRY_RUN, REAL |
+| `ExecutionBlockReason` | Block reasons (REAL_EXECUTION_NOT_IMPLEMENTED, etc.) |
+| `StepExecutionResult` | Step execution outcome with evidence |
+| `GateEvaluationResult` | Gate evaluation outcome |
+| `ExecutionReceipt` | Terminal receipt with WSP 97 truth fields |
+
+### WSP 97 Truth Boundary
+
+- `verification_complete = False` (always)
+- `cabr_ready = False` (always)
+- `payout_ready = False` (always)
+- `real_execution_performed = False` (stub)
+- No CABR/reward/payout/token fields exist
+
+### Tests
+
+- `test_build_plan_executor.py` - 39 tests covering all 9 requirements
+
+---
+
+## 2026-04-29 - BuildPlan Generator (v0.8.0)
+
+**Author**: 0102 (W4)
+**Slice**: OC9_BUILD_PLAN_GENERATOR_PHASE1
+**WSP References**: WSP 11, WSP 50, WSP 77, WSP 97
+
+### Added
+
+- **build_plan_generator.py** - BuildPlan generation from FoundUpJob
+  - `create_build_plan_from_job()` - Main entry point
+  - `validate_job_for_build_plan()` - Pre-validation
+  - `infer_build_scope()` - Scope inference from action
+  - `build_target_from_job()` - Target construction
+  - `KNOWN_FOUNDUP_PATHS` - Path inference for known FoundUps
+
+### Scope Inference
+
+| Action | Inferred Scope |
+|--------|----------------|
+| `validate_foundup` | GENESIS_ONLY |
+| `build_foundup` | FULL_BUILD |
+| `extract_foundup` | FULL_BUILD |
+
+### Tests
+
+- `test_build_plan_generator.py` - 20 tests
+
+---
+
+## 2026-04-29 - BuildPlan Dataclass (v0.7.0)
+
+**Author**: 0102 (W4)
+**Slice**: OC8_BUILD_PLAN_DATACLASS_PHASE1
+**WSP References**: WSP 11, WSP 50, WSP 77, WSP 97
+
+### Added
+
+- **build_plan.py** - BuildPlan typed interface
+  - `BuildPlan` - Multi-step orchestration contract
+  - `BuildTarget` - Target paths and scope
+  - `BuildStep` - Step definition with action enum
+  - `BuildGate` - Gate checkpoints
+  - `BuildEvidence` - Evidence with verification status
+  - `create_standard_build_steps()` - Standard step factory
+
+### Enums
+
+| Enum | Values |
+|------|--------|
+| `BuildPlanStatus` | DRAFT, READY, IN_PROGRESS, COMPLETED, FAILED, CANCELLED |
+| `BuildMode` | DRY_RUN, REAL, PARTIAL |
+| `BuildScope` | GENESIS_ONLY, FULL_BUILD, INCREMENTAL |
+| `BuildStepAction` | VALIDATE_*, CREATE_*, UPDATE_*, RUN_TESTS, etc. |
+| `GateType` | genesis_gate, dry_run_gate, test_gate, human_approval_gate |
+
+### WSP 97 Truth Boundary
+
+- `is_real_build_allowed()` checks all gates before real execution
+- `dry_run=True` default enforced
+- No CABR/payout/reward/token fields
+
+---
+
 ## 2026-04-26 - Hermes FoundUpJob Executor (v0.6.0)
 
 **Author**: 0102 (W4)

--- a/modules/foundups/agent/src/build_plan_executor.py
+++ b/modules/foundups/agent/src/build_plan_executor.py
@@ -1,0 +1,758 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+BuildPlan Executor — Interface Stub for Controlled Step Execution
+
+Implements the BuildPlanExecutor interface from BUILD_PLAN_EXECUTION_ADAPTER_CONTRACT.md.
+This is an interface stub only. Real execution is NOT implemented.
+
+WSP 97 TRUTH BOUNDARIES:
+  - dry_run=True by default
+  - Real execution (dry_run=False) returns BLOCKED
+  - verification_complete=False always
+  - cabr_ready=False always
+  - payout_ready=False always
+  - No actual file operations performed
+
+Architecture:
+  BuildPlan -> BuildPlanExecutor -> StepExecutionResult
+           -> ExecutionReceipt (with WSP 97 truth fields)
+
+WSP Compliance:
+  WSP 11  : Interface contract (typed API)
+  WSP 50  : Pre-action validation (validate_plan)
+  WSP 77  : Agent coordination (gate evaluation)
+  WSP 97  : Truth boundaries (no real execution)
+
+NAVIGATION:
+  -> Spec: modules/foundups/docs/BUILD_PLAN_EXECUTION_ADAPTER_CONTRACT.md
+  -> Uses: build_plan.py (BuildPlan, BuildStep, GateType)
+  -> Called by: Future orchestration (not implemented)
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from .build_plan import (
+    BuildMode,
+    BuildPlan,
+    BuildPlanStatus,
+    BuildStep,
+    BuildStepAction,
+    GateType,
+    GateStatus,
+    StepStatus,
+)
+
+logger = logging.getLogger("build_plan_executor")
+
+
+def utc_now() -> datetime:
+    """Return current UTC timestamp."""
+    return datetime.now(timezone.utc)
+
+
+def utc_iso(dt: Optional[datetime]) -> Optional[str]:
+    """Convert datetime to ISO string or None."""
+    return dt.isoformat() if dt else None
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class StepExecutionStatus(str, Enum):
+    """Step execution outcome status."""
+
+    SUCCEEDED = "succeeded"
+    """Step completed successfully (simulation or execution)."""
+
+    FAILED = "failed"
+    """Step failed during execution."""
+
+    BLOCKED = "blocked"
+    """Step blocked by gate, scope, or policy."""
+
+    SKIPPED = "skipped"
+    """Step skipped (optional or condition not met)."""
+
+    SIMULATED = "simulated"
+    """Step was simulated (dry-run), not executed."""
+
+
+class ExecutionMode(str, Enum):
+    """Execution mode for the executor."""
+
+    DRY_RUN = "dry_run"
+    """Simulate steps, no real changes."""
+
+    REAL = "real"
+    """Real execution (NOT IMPLEMENTED)."""
+
+
+class ExecutionBlockReason(str, Enum):
+    """Reasons why execution may be blocked."""
+
+    REAL_EXECUTION_NOT_IMPLEMENTED = "real_execution_not_implemented"
+    """Real execution is not implemented in this stub."""
+
+    MUTATING_ACTION_IN_STUB = "mutating_action_in_stub"
+    """Mutating actions are blocked in stub implementation."""
+
+    GATE_FAILED = "gate_failed"
+    """A required gate did not pass."""
+
+    HUMAN_APPROVAL_REQUIRED = "human_approval_required"
+    """Human approval gate required but not passed."""
+
+    SCOPE_VIOLATION = "scope_violation"
+    """Operation outside allowed scope."""
+
+    PLAN_NOT_VALID = "plan_not_valid"
+    """Plan failed validation."""
+
+    MODE_REAL_NOT_ALLOWED = "mode_real_not_allowed"
+    """Plan has mode=REAL but approval not granted."""
+
+
+# ---------------------------------------------------------------------------
+# Actions that can be safely simulated
+# ---------------------------------------------------------------------------
+
+# Actions that only validate/read, do not mutate
+SAFE_SIMULATION_ACTIONS: frozenset[BuildStepAction] = frozenset({
+    BuildStepAction.VALIDATE_GENESIS,
+    BuildStepAction.VALIDATE_MANIFEST,
+    BuildStepAction.VALIDATE_STRUCTURE,
+    BuildStepAction.RUN_TESTS,  # Tests can run in dry-run
+})
+
+# Actions that require file mutation (blocked in stub)
+MUTATING_ACTIONS: frozenset[BuildStepAction] = frozenset({
+    BuildStepAction.CREATE_SPEC,
+    BuildStepAction.CREATE_TEST,
+    BuildStepAction.CREATE_MODULE,
+    BuildStepAction.CREATE_ADAPTERS,
+    BuildStepAction.UPDATE_MANIFEST,
+    BuildStepAction.UPDATE_MODLOG,
+    BuildStepAction.UPDATE_TESTMODLOG,
+})
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DiffSummary:
+    """Summary of file changes (planned or actual)."""
+
+    files_created: int = 0
+    files_modified: int = 0
+    files_deleted: int = 0
+    lines_added: int = 0
+    lines_removed: int = 0
+
+    def to_dict(self) -> Dict[str, int]:
+        """Serialize to dictionary."""
+        return {
+            "files_created": self.files_created,
+            "files_modified": self.files_modified,
+            "files_deleted": self.files_deleted,
+            "lines_added": self.lines_added,
+            "lines_removed": self.lines_removed,
+        }
+
+
+@dataclass
+class StepExecutionContext:
+    """Context for step execution."""
+
+    plan: BuildPlan
+    step: BuildStep
+    step_index: int
+    dry_run: bool = True
+    target_files: List[str] = field(default_factory=list)
+    started_at: datetime = field(default_factory=utc_now)
+    timeout_ms: int = 60000
+    worker_id: str = "build_plan_executor"
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "plan_id": self.plan.build_plan_id,
+            "step_id": self.step.step_id,
+            "step_index": self.step_index,
+            "dry_run": self.dry_run,
+            "target_files": self.target_files,
+            "started_at": utc_iso(self.started_at),
+            "timeout_ms": self.timeout_ms,
+            "worker_id": self.worker_id,
+        }
+
+
+@dataclass
+class StepExecutionResult:
+    """Result of step execution."""
+
+    # Identity
+    step_id: str
+    step_name: str
+    action: BuildStepAction
+
+    # Outcome
+    status: StepExecutionStatus
+
+    # Mode
+    dry_run: bool = True
+    simulated: bool = True
+
+    # Evidence
+    planned_diff: Optional[DiffSummary] = None
+    actual_diff: Optional[DiffSummary] = None  # Always None in stub
+    evidence_refs: List[str] = field(default_factory=list)
+
+    # Timing
+    started_at: datetime = field(default_factory=utc_now)
+    completed_at: Optional[datetime] = None
+    duration_ms: int = 0
+
+    # Error
+    error_code: Optional[str] = None
+    error_message: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "step_id": self.step_id,
+            "step_name": self.step_name,
+            "action": self.action.value,
+            "status": self.status.value,
+            "dry_run": self.dry_run,
+            "simulated": self.simulated,
+            "planned_diff": self.planned_diff.to_dict() if self.planned_diff else None,
+            "actual_diff": self.actual_diff.to_dict() if self.actual_diff else None,
+            "evidence_refs": self.evidence_refs,
+            "started_at": utc_iso(self.started_at),
+            "completed_at": utc_iso(self.completed_at),
+            "duration_ms": self.duration_ms,
+            "error_code": self.error_code,
+            "error_message": self.error_message,
+        }
+
+
+@dataclass
+class GateEvaluationResult:
+    """Result of gate evaluation."""
+
+    gate_id: str
+    gate_type: GateType
+    passed: bool
+    reason: str
+    checked_at: datetime = field(default_factory=utc_now)
+    checked_by: str = "system"
+    blocks_execution: bool = False
+    requires_human: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "gate_id": self.gate_id,
+            "gate_type": self.gate_type.value,
+            "passed": self.passed,
+            "reason": self.reason,
+            "checked_at": utc_iso(self.checked_at),
+            "checked_by": self.checked_by,
+            "blocks_execution": self.blocks_execution,
+            "requires_human": self.requires_human,
+        }
+
+
+@dataclass
+class ValidationResult:
+    """Result of plan validation."""
+
+    valid: bool
+    error_code: Optional[str] = None
+    error_message: Optional[str] = None
+    warnings: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "valid": self.valid,
+            "error_code": self.error_code,
+            "error_message": self.error_message,
+            "warnings": self.warnings,
+        }
+
+
+@dataclass
+class ExecutionReceipt:
+    """
+    Receipt for BuildPlan execution.
+
+    WSP 97 Truth Fields:
+      - verification_complete = False (always)
+      - cabr_ready = False (always)
+      - payout_ready = False (always)
+      - real_execution_performed = False (stub)
+    """
+
+    # Identity
+    receipt_id: str
+    plan_id: str
+    source_job_id: Optional[str] = None
+
+    # Correlation
+    foundup_id: str = ""
+    tenant_id: str = ""
+
+    # Execution Summary
+    mode: ExecutionMode = ExecutionMode.DRY_RUN
+    total_steps: int = 0
+    steps_succeeded: int = 0
+    steps_failed: int = 0
+    steps_blocked: int = 0
+    steps_skipped: int = 0
+
+    # Gates
+    all_gates_passed: bool = False
+    gates_evaluated: List[GateEvaluationResult] = field(default_factory=list)
+
+    # Evidence
+    step_results: List[StepExecutionResult] = field(default_factory=list)
+    evidence_refs: List[str] = field(default_factory=list)
+
+    # Timestamps
+    started_at: datetime = field(default_factory=utc_now)
+    completed_at: Optional[datetime] = None
+
+    # WSP 97 Truth Fields (ALWAYS these values)
+    verification_complete: bool = False
+    cabr_ready: bool = False
+    payout_ready: bool = False
+    real_execution_performed: bool = False
+
+    def __post_init__(self) -> None:
+        """Enforce WSP 97 truth fields."""
+        # These MUST be False - cannot be overridden
+        self.verification_complete = False
+        self.cabr_ready = False
+        self.payout_ready = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "receipt_id": self.receipt_id,
+            "plan_id": self.plan_id,
+            "source_job_id": self.source_job_id,
+            "foundup_id": self.foundup_id,
+            "tenant_id": self.tenant_id,
+            "mode": self.mode.value,
+            "total_steps": self.total_steps,
+            "steps_succeeded": self.steps_succeeded,
+            "steps_failed": self.steps_failed,
+            "steps_blocked": self.steps_blocked,
+            "steps_skipped": self.steps_skipped,
+            "all_gates_passed": self.all_gates_passed,
+            "gates_evaluated": [g.to_dict() for g in self.gates_evaluated],
+            "step_results": [r.to_dict() for r in self.step_results],
+            "evidence_refs": self.evidence_refs,
+            "started_at": utc_iso(self.started_at),
+            "completed_at": utc_iso(self.completed_at),
+            # WSP 97 truth fields
+            "verification_complete": self.verification_complete,
+            "cabr_ready": self.cabr_ready,
+            "payout_ready": self.payout_ready,
+            "real_execution_performed": self.real_execution_performed,
+        }
+
+
+# ---------------------------------------------------------------------------
+# BuildPlanExecutor
+# ---------------------------------------------------------------------------
+
+
+class BuildPlanExecutor:
+    """
+    BuildPlan Executor — Interface Stub.
+
+    Translates BuildPlan steps into bounded operations.
+    This is a stub: real execution is NOT implemented.
+
+    WSP 97 Truth Boundaries:
+      - dry_run=True by default
+      - execute_step with dry_run=False returns BLOCKED
+      - No actual file operations performed
+      - No CABR/payout/reward fields
+    """
+
+    def __init__(self, dry_run: bool = True):
+        """
+        Initialize executor.
+
+        Args:
+            dry_run: Force dry-run mode. Default True.
+        """
+        self.dry_run = dry_run
+        self._execution_id = f"exec_{secrets.token_hex(4)}"
+
+    def is_dry_run(self) -> bool:
+        """Check if executor is in dry-run mode."""
+        return self.dry_run
+
+    # ------------------------------------------------------------------
+    # Plan Validation
+    # ------------------------------------------------------------------
+
+    def validate_plan(self, plan: BuildPlan) -> ValidationResult:
+        """
+        Validate a BuildPlan before execution.
+
+        Checks:
+          - Plan has required identity fields
+          - Plan has target
+          - mode=REAL requires human_approval_gate
+          - Steps exist
+
+        Args:
+            plan: BuildPlan to validate.
+
+        Returns:
+            ValidationResult with validation outcome.
+        """
+        warnings = []
+
+        # Check identity
+        if not plan.build_plan_id:
+            return ValidationResult(
+                valid=False,
+                error_code="MISSING_PLAN_ID",
+                error_message="BuildPlan.build_plan_id is required",
+            )
+
+        if not plan.foundup_id:
+            return ValidationResult(
+                valid=False,
+                error_code="MISSING_FOUNDUP_ID",
+                error_message="BuildPlan.foundup_id is required",
+            )
+
+        # Check target
+        if not plan.target:
+            return ValidationResult(
+                valid=False,
+                error_code="MISSING_TARGET",
+                error_message="BuildPlan.target is required",
+            )
+
+        # Check mode=REAL requires approval
+        if plan.mode == BuildMode.REAL:
+            human_gate = plan.get_gate(GateType.HUMAN_APPROVAL_GATE)
+            if not human_gate or not human_gate.passed:
+                return ValidationResult(
+                    valid=False,
+                    error_code="MODE_REAL_NO_APPROVAL",
+                    error_message="mode=REAL requires human_approval_gate to be passed",
+                )
+
+        # Check steps exist
+        if not plan.steps:
+            warnings.append("Plan has no steps")
+
+        # Warn about real execution
+        if not plan.dry_run:
+            warnings.append("Plan has dry_run=False but real execution is not implemented")
+
+        return ValidationResult(
+            valid=True,
+            warnings=warnings,
+        )
+
+    # ------------------------------------------------------------------
+    # Gate Evaluation
+    # ------------------------------------------------------------------
+
+    def evaluate_gate(
+        self, plan: BuildPlan, gate_type: GateType
+    ) -> GateEvaluationResult:
+        """
+        Evaluate a gate for the plan.
+
+        Args:
+            plan: BuildPlan being executed.
+            gate_type: Type of gate to evaluate.
+
+        Returns:
+            GateEvaluationResult with evaluation outcome.
+        """
+        gate = plan.get_gate(gate_type)
+        gate_id = gate.gate_id if gate else f"{gate_type.value}_auto"
+
+        # Check if gate already passed in plan
+        if gate and gate.passed:
+            return GateEvaluationResult(
+                gate_id=gate_id,
+                gate_type=gate_type,
+                passed=True,
+                reason="Gate already passed in plan",
+                checked_by="system",
+            )
+
+        # Evaluate based on gate type
+        if gate_type == GateType.GENESIS_GATE:
+            # Check target has module_path
+            passed = plan.target is not None and bool(plan.target.module_path)
+            reason = "Genesis validation: target exists" if passed else "No target defined"
+
+        elif gate_type == GateType.DRY_RUN_GATE:
+            # Dry-run gate passes if plan is dry-run
+            passed = plan.dry_run
+            reason = "Dry-run mode active" if passed else "Plan is not dry-run"
+
+        elif gate_type == GateType.HUMAN_APPROVAL_GATE:
+            # Human approval must be explicitly set
+            passed = gate is not None and gate.passed
+            reason = "Human approval granted" if passed else "Human approval required"
+            return GateEvaluationResult(
+                gate_id=gate_id,
+                gate_type=gate_type,
+                passed=passed,
+                reason=reason,
+                checked_by="system",
+                blocks_execution=not passed,
+                requires_human=True,
+            )
+
+        else:
+            # Default: pass in stub (no real validation)
+            passed = True
+            reason = f"Gate {gate_type.value} auto-passed in stub"
+
+        return GateEvaluationResult(
+            gate_id=gate_id,
+            gate_type=gate_type,
+            passed=passed,
+            reason=reason,
+            checked_by="system",
+            blocks_execution=gate.required if gate else False,
+        )
+
+    # ------------------------------------------------------------------
+    # Step Simulation
+    # ------------------------------------------------------------------
+
+    def simulate_step(
+        self, plan: BuildPlan, step: BuildStep
+    ) -> StepExecutionResult:
+        """
+        Simulate a step without making changes.
+
+        Args:
+            plan: BuildPlan containing the step.
+            step: BuildStep to simulate.
+
+        Returns:
+            StepExecutionResult with simulation outcome.
+        """
+        started_at = utc_now()
+
+        # Check if action is safe to simulate
+        if step.action in SAFE_SIMULATION_ACTIONS:
+            # Safe actions: validation, tests
+            status = StepExecutionStatus.SIMULATED
+            planned_diff = DiffSummary()  # No changes
+            error_code = None
+            error_message = None
+
+        elif step.action in MUTATING_ACTIONS:
+            # Mutating actions: return simulated with planned_diff
+            status = StepExecutionStatus.SIMULATED
+            planned_diff = DiffSummary(
+                files_created=len(step.target_files) if step.target_files else 1,
+                lines_added=100,  # Placeholder estimate
+            )
+            error_code = None
+            error_message = None
+
+        else:
+            # Other actions: simulate as pass
+            status = StepExecutionStatus.SIMULATED
+            planned_diff = DiffSummary()
+            error_code = None
+            error_message = None
+
+        completed_at = utc_now()
+        duration_ms = int((completed_at - started_at).total_seconds() * 1000)
+
+        return StepExecutionResult(
+            step_id=step.step_id,
+            step_name=step.step_name,
+            action=step.action,
+            status=status,
+            dry_run=True,
+            simulated=True,
+            planned_diff=planned_diff,
+            actual_diff=None,
+            evidence_refs=[f"simulation/{plan.build_plan_id}/{step.step_id}"],
+            started_at=started_at,
+            completed_at=completed_at,
+            duration_ms=duration_ms,
+            error_code=error_code,
+            error_message=error_message,
+        )
+
+    # ------------------------------------------------------------------
+    # Step Execution
+    # ------------------------------------------------------------------
+
+    def execute_step(
+        self, plan: BuildPlan, step: BuildStep
+    ) -> StepExecutionResult:
+        """
+        Execute a step.
+
+        WSP 97: Real execution is NOT implemented.
+          - If dry_run=True: delegates to simulate_step
+          - If dry_run=False: returns BLOCKED
+
+        Args:
+            plan: BuildPlan containing the step.
+            step: BuildStep to execute.
+
+        Returns:
+            StepExecutionResult with execution outcome.
+        """
+        started_at = utc_now()
+
+        # Dry-run mode: delegate to simulation
+        if self.dry_run:
+            return self.simulate_step(plan, step)
+
+        # Real execution: BLOCKED (not implemented)
+        completed_at = utc_now()
+        duration_ms = int((completed_at - started_at).total_seconds() * 1000)
+
+        logger.warning(
+            "[EXECUTOR] Real execution blocked for step %s: not implemented",
+            step.step_id,
+        )
+
+        return StepExecutionResult(
+            step_id=step.step_id,
+            step_name=step.step_name,
+            action=step.action,
+            status=StepExecutionStatus.BLOCKED,
+            dry_run=False,
+            simulated=False,
+            planned_diff=None,
+            actual_diff=None,
+            evidence_refs=[],
+            started_at=started_at,
+            completed_at=completed_at,
+            duration_ms=duration_ms,
+            error_code=ExecutionBlockReason.REAL_EXECUTION_NOT_IMPLEMENTED.value,
+            error_message="Real execution is not implemented. Use dry_run=True.",
+        )
+
+    # ------------------------------------------------------------------
+    # Execution Receipt
+    # ------------------------------------------------------------------
+
+    def create_execution_receipt(
+        self,
+        plan: BuildPlan,
+        results: List[StepExecutionResult],
+    ) -> ExecutionReceipt:
+        """
+        Create an ExecutionReceipt from plan and step results.
+
+        WSP 97 Truth Fields:
+          - verification_complete = False (always)
+          - cabr_ready = False (always)
+          - payout_ready = False (always)
+          - real_execution_performed = False (stub)
+
+        Args:
+            plan: BuildPlan that was executed.
+            results: List of StepExecutionResult from execution.
+
+        Returns:
+            ExecutionReceipt with all truth fields False.
+        """
+        receipt_id = f"rcpt_{plan.build_plan_id}_{secrets.token_hex(4)}"
+
+        # Count step outcomes
+        succeeded = sum(1 for r in results if r.status == StepExecutionStatus.SUCCEEDED)
+        simulated = sum(1 for r in results if r.status == StepExecutionStatus.SIMULATED)
+        failed = sum(1 for r in results if r.status == StepExecutionStatus.FAILED)
+        blocked = sum(1 for r in results if r.status == StepExecutionStatus.BLOCKED)
+        skipped = sum(1 for r in results if r.status == StepExecutionStatus.SKIPPED)
+
+        # Simulated counts as succeeded for summary
+        steps_succeeded = succeeded + simulated
+
+        # Collect evidence refs
+        evidence_refs = []
+        for result in results:
+            evidence_refs.extend(result.evidence_refs)
+
+        # Evaluate gates for receipt
+        gates_evaluated = []
+        all_gates_passed = True
+        for gate in plan.gates:
+            gate_result = self.evaluate_gate(plan, gate.gate_type)
+            gates_evaluated.append(gate_result)
+            if gate.required and not gate_result.passed:
+                all_gates_passed = False
+
+        return ExecutionReceipt(
+            receipt_id=receipt_id,
+            plan_id=plan.build_plan_id,
+            source_job_id=plan.source_job_id,
+            foundup_id=plan.foundup_id,
+            tenant_id=plan.tenant_id,
+            mode=ExecutionMode.DRY_RUN if self.dry_run else ExecutionMode.REAL,
+            total_steps=len(results),
+            steps_succeeded=steps_succeeded,
+            steps_failed=failed,
+            steps_blocked=blocked,
+            steps_skipped=skipped,
+            all_gates_passed=all_gates_passed,
+            gates_evaluated=gates_evaluated,
+            step_results=results,
+            evidence_refs=evidence_refs,
+            completed_at=utc_now(),
+            # WSP 97: These are ALWAYS False
+            verification_complete=False,
+            cabr_ready=False,
+            payout_ready=False,
+            real_execution_performed=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Factory Function
+# ---------------------------------------------------------------------------
+
+
+def get_executor(dry_run: bool = True) -> BuildPlanExecutor:
+    """
+    Get a BuildPlanExecutor instance.
+
+    Args:
+        dry_run: Force dry-run mode. Default True.
+
+    Returns:
+        BuildPlanExecutor configured for dry-run.
+    """
+    return BuildPlanExecutor(dry_run=dry_run)

--- a/modules/foundups/agent/tests/TestModLog.md
+++ b/modules/foundups/agent/tests/TestModLog.md
@@ -1,5 +1,51 @@
 # Agent Module TestModLog
 
+## 2026-04-29 - BuildPlanExecutor Interface Stub Tests
+
+**Command**:
+
+```bash
+python -m pytest modules/foundups/agent/tests/test_build_plan_executor.py -v
+```
+
+**Result**: PASS
+
+**Summary**: 39 passed in 0.71s.
+
+**Coverage**:
+1. Executor instantiation with dry_run=True
+2. validate_plan rejects mode=REAL without approval
+3. simulate_step returns StepExecutionResult with SIMULATED
+4. execute_step dry_run delegates to simulation
+5. execute_step real returns BLOCKED
+6. Mutating actions identified correctly
+7. ExecutionReceipt WSP 97 truth fields all False
+8. No CABR/reward/payout/token fields exist
+9. VoteBallot generated BuildPlan validates and simulates
+
+**WSP References**: WSP 11, WSP 50, WSP 77, WSP 97.
+
+---
+
+## 2026-04-29 - Full Agent Module Test Suite
+
+**Command**:
+
+```bash
+python -m pytest modules/foundups/agent/tests/ -v
+```
+
+**Result**: PASS
+
+**Summary**: 160 passed in 7.67s.
+
+**Notes**:
+- All BuildPlan pipeline tests (OC8/OC9/OC12) passing
+- Hermes tests passing
+- No regressions
+
+---
+
 ## 2026-04-25 - Hermes Deploy Surface Detector Alignment
 
 **Command**:

--- a/modules/foundups/agent/tests/test_build_plan_executor.py
+++ b/modules/foundups/agent/tests/test_build_plan_executor.py
@@ -1,0 +1,604 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Test suite for BuildPlanExecutor interface stub.
+
+WSP 97 Truth Boundary Tests:
+  - dry_run=True default
+  - Real execution returns BLOCKED
+  - ExecutionReceipt has truth fields False
+  - No CABR/reward/payout/token fields
+
+Test Coverage:
+  1. Executor can be instantiated with dry_run=True
+  2. validate_plan rejects mode=REAL plans without approval gates
+  3. simulate_step returns StepExecutionResult
+  4. execute_step with dry_run=True delegates to simulation
+  5. execute_step with dry_run=False is blocked
+  6. mutating actions are blocked in stub
+  7. ExecutionReceipt has WSP_97 truth fields false
+  8. No CABR/reward/payout/token fields exist
+  9. VoteBallot generated BuildPlan can be validated and simulated without real execution
+"""
+
+import pytest
+from pathlib import Path
+
+from modules.foundups.agent.src.build_plan import (
+    BuildMode,
+    BuildPlan,
+    BuildPlanStatus,
+    BuildScope,
+    BuildStep,
+    BuildStepAction,
+    BuildTarget,
+    BuildGate,
+    GateType,
+    GateStatus,
+    StepStatus,
+    create_standard_build_steps,
+)
+from modules.foundups.agent.src.build_plan_executor import (
+    BuildPlanExecutor,
+    DiffSummary,
+    ExecutionBlockReason,
+    ExecutionMode,
+    ExecutionReceipt,
+    GateEvaluationResult,
+    StepExecutionContext,
+    StepExecutionResult,
+    StepExecutionStatus,
+    ValidationResult,
+    MUTATING_ACTIONS,
+    SAFE_SIMULATION_ACTIONS,
+    get_executor,
+)
+from modules.foundups.agent.src.build_plan_generator import (
+    create_build_plan_from_job,
+)
+from modules.communication.moltbot_bridge.src.foundup_job_contract import (
+    FoundUpJob,
+    JobStatus,
+    create_job,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_target() -> BuildTarget:
+    """Create a sample BuildTarget for testing."""
+    return BuildTarget(
+        module_path="modules/foundups/voteballots",
+        pwa_surface_path="public/member/foundups/voteballots/",
+    )
+
+
+@pytest.fixture
+def sample_plan(sample_target: BuildTarget) -> BuildPlan:
+    """Create a sample BuildPlan for testing."""
+    plan = BuildPlan(
+        build_plan_id="bp_test_001",
+        foundup_id="voteballots",
+        tenant_id="foundups",
+        mode=BuildMode.DRY_RUN,
+        dry_run=True,
+        status=BuildPlanStatus.DRAFT,
+        target=sample_target,
+    )
+    plan.steps = create_standard_build_steps("modules/foundups/voteballots")
+    return plan
+
+
+@pytest.fixture
+def sample_step() -> BuildStep:
+    """Create a sample BuildStep for testing."""
+    return BuildStep(
+        step_id="step_test_001",
+        step_name="Test Step",
+        action=BuildStepAction.VALIDATE_GENESIS,
+        status=StepStatus.PENDING,
+        evidence_required=True,
+    )
+
+
+@pytest.fixture
+def executor() -> BuildPlanExecutor:
+    """Create a BuildPlanExecutor in dry-run mode."""
+    return BuildPlanExecutor(dry_run=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Executor can be instantiated with dry_run=True
+# ---------------------------------------------------------------------------
+
+
+class TestExecutorInstantiation:
+    """Test BuildPlanExecutor instantiation."""
+
+    def test_instantiate_with_dry_run_true(self):
+        """Executor can be instantiated with dry_run=True."""
+        executor = BuildPlanExecutor(dry_run=True)
+        assert executor.dry_run is True
+        assert executor.is_dry_run() is True
+
+    def test_default_is_dry_run(self):
+        """Executor defaults to dry_run=True."""
+        executor = BuildPlanExecutor()
+        assert executor.dry_run is True
+
+    def test_factory_function_dry_run(self):
+        """get_executor factory returns dry-run executor."""
+        executor = get_executor()
+        assert executor.dry_run is True
+        assert isinstance(executor, BuildPlanExecutor)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: validate_plan rejects mode=REAL plans without approval gates
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePlan:
+    """Test plan validation."""
+
+    def test_validate_plan_rejects_real_without_approval(self, sample_target):
+        """validate_plan rejects mode=REAL plans without approval gates."""
+        plan = BuildPlan(
+            build_plan_id="bp_real_001",
+            foundup_id="voteballots",
+            tenant_id="foundups",
+            mode=BuildMode.REAL,
+            dry_run=False,
+            target=sample_target,
+        )
+        executor = BuildPlanExecutor()
+        result = executor.validate_plan(plan)
+
+        assert result.valid is False
+        assert result.error_code == "MODE_REAL_NO_APPROVAL"
+        assert "human_approval_gate" in result.error_message.lower()
+
+    def test_validate_plan_accepts_dry_run(self, sample_plan, executor):
+        """validate_plan accepts dry_run plans."""
+        result = executor.validate_plan(sample_plan)
+        assert result.valid is True
+
+    def test_validate_plan_requires_plan_id(self, sample_target, executor):
+        """BuildPlan itself requires build_plan_id (dataclass validation)."""
+        # BuildPlan.__post_init__ raises ValueError for empty build_plan_id
+        with pytest.raises(ValueError, match="build_plan_id is required"):
+            BuildPlan(
+                build_plan_id="",
+                foundup_id="voteballots",
+                tenant_id="foundups",
+                target=sample_target,
+            )
+
+    def test_validate_plan_requires_foundup_id(self, sample_target, executor):
+        """BuildPlan itself requires foundup_id (dataclass validation)."""
+        # BuildPlan.__post_init__ raises ValueError for empty foundup_id
+        with pytest.raises(ValueError, match="foundup_id is required"):
+            BuildPlan(
+                build_plan_id="bp_test_001",
+                foundup_id="",
+                tenant_id="foundups",
+                target=sample_target,
+            )
+
+    def test_validate_plan_requires_target(self, executor):
+        """validate_plan requires target."""
+        plan = BuildPlan(
+            build_plan_id="bp_test_001",
+            foundup_id="voteballots",
+            tenant_id="foundups",
+            target=None,
+        )
+        result = executor.validate_plan(plan)
+        assert result.valid is False
+        assert result.error_code == "MISSING_TARGET"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: simulate_step returns StepExecutionResult
+# ---------------------------------------------------------------------------
+
+
+class TestSimulateStep:
+    """Test step simulation."""
+
+    def test_simulate_step_returns_result(self, sample_plan, sample_step, executor):
+        """simulate_step returns StepExecutionResult."""
+        result = executor.simulate_step(sample_plan, sample_step)
+
+        assert isinstance(result, StepExecutionResult)
+        assert result.step_id == sample_step.step_id
+        assert result.step_name == sample_step.step_name
+        assert result.action == sample_step.action
+
+    def test_simulate_step_status_simulated(self, sample_plan, sample_step, executor):
+        """simulate_step returns SIMULATED status."""
+        result = executor.simulate_step(sample_plan, sample_step)
+
+        assert result.status == StepExecutionStatus.SIMULATED
+        assert result.simulated is True
+        assert result.dry_run is True
+
+    def test_simulate_step_has_evidence_refs(self, sample_plan, sample_step, executor):
+        """simulate_step includes evidence_refs."""
+        result = executor.simulate_step(sample_plan, sample_step)
+
+        assert len(result.evidence_refs) > 0
+        assert "simulation" in result.evidence_refs[0]
+
+    def test_simulate_mutating_action_returns_planned_diff(self, sample_plan, executor):
+        """simulate_step for mutating actions returns planned_diff."""
+        mutating_step = BuildStep(
+            step_id="step_create",
+            step_name="Create Module",
+            action=BuildStepAction.CREATE_MODULE,
+            status=StepStatus.PENDING,
+        )
+        result = executor.simulate_step(sample_plan, mutating_step)
+
+        assert result.status == StepExecutionStatus.SIMULATED
+        assert result.planned_diff is not None
+        assert isinstance(result.planned_diff, DiffSummary)
+
+
+# ---------------------------------------------------------------------------
+# Test 4: execute_step with dry_run=True delegates to simulation
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteStepDryRun:
+    """Test execute_step in dry-run mode."""
+
+    def test_execute_step_dry_run_delegates_to_simulation(
+        self, sample_plan, sample_step, executor
+    ):
+        """execute_step with dry_run=True delegates to simulate_step."""
+        result = executor.execute_step(sample_plan, sample_step)
+
+        assert result.status == StepExecutionStatus.SIMULATED
+        assert result.dry_run is True
+        assert result.simulated is True
+
+    def test_execute_step_dry_run_no_actual_diff(
+        self, sample_plan, sample_step, executor
+    ):
+        """execute_step in dry-run never produces actual_diff."""
+        result = executor.execute_step(sample_plan, sample_step)
+
+        assert result.actual_diff is None
+
+
+# ---------------------------------------------------------------------------
+# Test 5: execute_step with dry_run=False is blocked
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteStepRealBlocked:
+    """Test execute_step blocks real execution."""
+
+    def test_execute_step_real_is_blocked(self, sample_plan, sample_step):
+        """execute_step with dry_run=False returns BLOCKED."""
+        executor = BuildPlanExecutor(dry_run=False)
+        result = executor.execute_step(sample_plan, sample_step)
+
+        assert result.status == StepExecutionStatus.BLOCKED
+        assert result.dry_run is False
+        assert result.simulated is False
+
+    def test_execute_step_real_error_code(self, sample_plan, sample_step):
+        """execute_step with dry_run=False has correct error code."""
+        executor = BuildPlanExecutor(dry_run=False)
+        result = executor.execute_step(sample_plan, sample_step)
+
+        assert result.error_code == ExecutionBlockReason.REAL_EXECUTION_NOT_IMPLEMENTED.value
+        assert "not implemented" in result.error_message.lower()
+
+
+# ---------------------------------------------------------------------------
+# Test 6: mutating actions are blocked in stub
+# ---------------------------------------------------------------------------
+
+
+class TestMutatingActionsBlocked:
+    """Test mutating actions are identified correctly."""
+
+    def test_mutating_actions_constant_exists(self):
+        """MUTATING_ACTIONS constant is defined."""
+        assert isinstance(MUTATING_ACTIONS, frozenset)
+        assert len(MUTATING_ACTIONS) > 0
+
+    def test_safe_actions_constant_exists(self):
+        """SAFE_SIMULATION_ACTIONS constant is defined."""
+        assert isinstance(SAFE_SIMULATION_ACTIONS, frozenset)
+        assert len(SAFE_SIMULATION_ACTIONS) > 0
+
+    def test_create_actions_are_mutating(self):
+        """CREATE_* actions are in MUTATING_ACTIONS."""
+        assert BuildStepAction.CREATE_MODULE in MUTATING_ACTIONS
+        assert BuildStepAction.CREATE_SPEC in MUTATING_ACTIONS
+        assert BuildStepAction.CREATE_TEST in MUTATING_ACTIONS
+
+    def test_validate_actions_are_safe(self):
+        """VALIDATE_* actions are in SAFE_SIMULATION_ACTIONS."""
+        assert BuildStepAction.VALIDATE_GENESIS in SAFE_SIMULATION_ACTIONS
+        assert BuildStepAction.VALIDATE_MANIFEST in SAFE_SIMULATION_ACTIONS
+
+    def test_dry_run_executor_simulates_mutating_actions(self, sample_plan, executor):
+        """dry_run executor simulates mutating actions without blocking."""
+        mutating_step = BuildStep(
+            step_id="step_mut",
+            step_name="Create Module",
+            action=BuildStepAction.CREATE_MODULE,
+            status=StepStatus.PENDING,
+        )
+        result = executor.execute_step(sample_plan, mutating_step)
+
+        # In dry-run mode, mutating actions are simulated (not blocked)
+        assert result.status == StepExecutionStatus.SIMULATED
+        assert result.planned_diff is not None
+
+
+# ---------------------------------------------------------------------------
+# Test 7: ExecutionReceipt has WSP_97 truth fields false
+# ---------------------------------------------------------------------------
+
+
+class TestExecutionReceiptTruthFields:
+    """Test ExecutionReceipt WSP 97 truth fields."""
+
+    def test_receipt_verification_complete_false(self, sample_plan, executor):
+        """ExecutionReceipt.verification_complete is always False."""
+        results = []
+        receipt = executor.create_execution_receipt(sample_plan, results)
+
+        assert receipt.verification_complete is False
+
+    def test_receipt_cabr_ready_false(self, sample_plan, executor):
+        """ExecutionReceipt.cabr_ready is always False."""
+        results = []
+        receipt = executor.create_execution_receipt(sample_plan, results)
+
+        assert receipt.cabr_ready is False
+
+    def test_receipt_payout_ready_false(self, sample_plan, executor):
+        """ExecutionReceipt.payout_ready is always False."""
+        results = []
+        receipt = executor.create_execution_receipt(sample_plan, results)
+
+        assert receipt.payout_ready is False
+
+    def test_receipt_real_execution_performed_false(self, sample_plan, executor):
+        """ExecutionReceipt.real_execution_performed is False in stub."""
+        results = []
+        receipt = executor.create_execution_receipt(sample_plan, results)
+
+        assert receipt.real_execution_performed is False
+
+    def test_receipt_post_init_enforces_truth_fields(self):
+        """ExecutionReceipt.__post_init__ enforces truth fields."""
+        # Even if we try to set True, __post_init__ resets to False
+        receipt = ExecutionReceipt(
+            receipt_id="rcpt_test",
+            plan_id="bp_test",
+            verification_complete=True,  # Will be overridden
+            cabr_ready=True,  # Will be overridden
+            payout_ready=True,  # Will be overridden
+        )
+        assert receipt.verification_complete is False
+        assert receipt.cabr_ready is False
+        assert receipt.payout_ready is False
+
+
+# ---------------------------------------------------------------------------
+# Test 8: No CABR/reward/payout/token fields exist
+# ---------------------------------------------------------------------------
+
+
+class TestNoCABRFields:
+    """Test that no CABR/reward/payout/token fields exist."""
+
+    def test_step_execution_result_no_cabr_fields(self):
+        """StepExecutionResult has no CABR/reward/payout fields."""
+        import inspect
+
+        sig = inspect.signature(StepExecutionResult)
+        param_names = set(sig.parameters.keys())
+
+        forbidden_patterns = ["cabr", "reward", "payout", "token", "ups", "f_i"]
+        for pattern in forbidden_patterns:
+            for name in param_names:
+                assert pattern not in name.lower(), f"Found forbidden field: {name}"
+
+    def test_execution_receipt_no_reward_fields(self):
+        """ExecutionReceipt has no reward/UPS/F_i fields."""
+        import inspect
+
+        sig = inspect.signature(ExecutionReceipt)
+        param_names = set(sig.parameters.keys())
+
+        forbidden_patterns = ["reward", "ups", "f_i", "token_amount", "token_type"]
+        for pattern in forbidden_patterns:
+            for name in param_names:
+                assert pattern not in name.lower(), f"Found forbidden field: {name}"
+
+    def test_receipt_dict_no_cabr_keys(self, sample_plan, executor):
+        """ExecutionReceipt.to_dict() has no CABR keys."""
+        results = []
+        receipt = executor.create_execution_receipt(sample_plan, results)
+        receipt_dict = receipt.to_dict()
+
+        forbidden_keys = ["cabr_score", "reward_amount", "ups_amount", "token_type"]
+        for key in forbidden_keys:
+            assert key not in receipt_dict, f"Found forbidden key: {key}"
+
+
+# ---------------------------------------------------------------------------
+# Test 9: VoteBallot generated BuildPlan can be validated and simulated
+# ---------------------------------------------------------------------------
+
+
+class TestVoteBallotIntegration:
+    """Test VoteBallot BuildPlan can be validated and simulated."""
+
+    def test_voteballot_job_generates_valid_plan(self):
+        """VoteBallot job generates a valid BuildPlan."""
+        job = create_job(
+            tenant_id="foundups",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            intent_id="test_intent",
+        )
+        plan = create_build_plan_from_job(job)
+
+        assert plan is not None
+        assert plan.foundup_id == "voteballots"
+        assert plan.dry_run is True
+        assert plan.mode == BuildMode.DRY_RUN
+
+    def test_voteballot_plan_validates(self):
+        """VoteBallot generated plan passes validation."""
+        job = create_job(
+            tenant_id="foundups",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            intent_id="test_intent",
+        )
+        plan = create_build_plan_from_job(job)
+
+        executor = BuildPlanExecutor(dry_run=True)
+        validation = executor.validate_plan(plan)
+
+        assert validation.valid is True
+
+    def test_voteballot_plan_steps_can_simulate(self):
+        """VoteBallot plan steps can be simulated."""
+        job = create_job(
+            tenant_id="foundups",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            intent_id="test_intent",
+        )
+        plan = create_build_plan_from_job(job)
+
+        executor = BuildPlanExecutor(dry_run=True)
+        results = []
+
+        for step in plan.steps:
+            result = executor.execute_step(plan, step)
+            results.append(result)
+
+        assert len(results) == len(plan.steps)
+        for result in results:
+            assert result.status == StepExecutionStatus.SIMULATED
+
+    def test_voteballot_plan_receipt_has_truth_fields(self):
+        """VoteBallot plan execution receipt has WSP 97 truth fields False."""
+        job = create_job(
+            tenant_id="foundups",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            intent_id="test_intent",
+        )
+        plan = create_build_plan_from_job(job)
+
+        executor = BuildPlanExecutor(dry_run=True)
+        results = [executor.execute_step(plan, step) for step in plan.steps]
+        receipt = executor.create_execution_receipt(plan, results)
+
+        assert receipt.verification_complete is False
+        assert receipt.cabr_ready is False
+        assert receipt.payout_ready is False
+        assert receipt.real_execution_performed is False
+
+    def test_voteballot_plan_no_real_execution(self):
+        """VoteBallot plan cannot execute with dry_run=False."""
+        job = create_job(
+            tenant_id="foundups",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            intent_id="test_intent",
+        )
+        plan = create_build_plan_from_job(job)
+
+        # Force dry_run=False
+        executor = BuildPlanExecutor(dry_run=False)
+        step = plan.steps[0] if plan.steps else None
+
+        if step:
+            result = executor.execute_step(plan, step)
+            assert result.status == StepExecutionStatus.BLOCKED
+            assert result.error_code == ExecutionBlockReason.REAL_EXECUTION_NOT_IMPLEMENTED.value
+
+
+# ---------------------------------------------------------------------------
+# Additional Coverage Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGateEvaluation:
+    """Test gate evaluation."""
+
+    def test_evaluate_genesis_gate(self, sample_plan, executor):
+        """evaluate_gate returns result for genesis_gate."""
+        result = executor.evaluate_gate(sample_plan, GateType.GENESIS_GATE)
+
+        assert isinstance(result, GateEvaluationResult)
+        assert result.gate_type == GateType.GENESIS_GATE
+        assert result.passed is True  # Has target
+
+    def test_evaluate_dry_run_gate(self, sample_plan, executor):
+        """evaluate_gate returns result for dry_run_gate."""
+        result = executor.evaluate_gate(sample_plan, GateType.DRY_RUN_GATE)
+
+        assert result.gate_type == GateType.DRY_RUN_GATE
+        assert result.passed is True  # Plan is dry_run
+
+    def test_evaluate_human_approval_gate_requires_human(self, sample_plan, executor):
+        """Human approval gate requires human."""
+        result = executor.evaluate_gate(sample_plan, GateType.HUMAN_APPROVAL_GATE)
+
+        assert result.requires_human is True
+        assert result.passed is False  # Not pre-approved
+
+
+class TestStepExecutionContext:
+    """Test StepExecutionContext dataclass."""
+
+    def test_context_to_dict(self, sample_plan, sample_step):
+        """StepExecutionContext.to_dict() works."""
+        context = StepExecutionContext(
+            plan=sample_plan,
+            step=sample_step,
+            step_index=0,
+            dry_run=True,
+        )
+        d = context.to_dict()
+
+        assert d["plan_id"] == sample_plan.build_plan_id
+        assert d["step_id"] == sample_step.step_id
+        assert d["dry_run"] is True
+
+
+class TestDiffSummary:
+    """Test DiffSummary dataclass."""
+
+    def test_diff_summary_to_dict(self):
+        """DiffSummary.to_dict() works."""
+        diff = DiffSummary(
+            files_created=2,
+            files_modified=1,
+            lines_added=50,
+        )
+        d = diff.to_dict()
+
+        assert d["files_created"] == 2
+        assert d["files_modified"] == 1
+        assert d["lines_added"] == 50


### PR DESCRIPTION
## Summary

- Adds BuildPlanExecutor interface stub
- Adds StepExecutionContext, StepExecutionResult, GateEvaluationResult, ExecutionReceipt, ValidationResult
- `execute_step()` is simulation-only in dry_run mode
- `dry_run=False` is blocked with `REAL_EXECUTION_NOT_IMPLEMENTED`
- ExecutionReceipt forces:
  - `verification_complete=False`
  - `cabr_ready=False`
  - `payout_ready=False`
  - `real_execution_performed=False`
- Updates module INTERFACE.md, ModLog.md, and tests/TestModLog.md
- Includes retroactive ModLog catch-up for OC8/OC9

## WSP_97 Boundaries

- No real step execution
- No `mode=REAL` enablement
- No Hermes real execution wiring
- No CABR/reward/payout/token claims

## Test Plan

- [x] 39 BuildPlanExecutor tests passed
- [x] 46 BuildPlan generator tests passed (regression)
- [x] 35 BuildPlan tests passed (regression)
- [x] Lint/security CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)