### PR TITLE
feat(foundups): add real worker assignment protocol scaffold

### DIFF
--- a/modules/foundups/agent/INTERFACE.md
+++ b/modules/foundups/agent/INTERFACE.md
@@ -179,6 +179,54 @@ Enqueue → QUEUED → Dequeue → PROCESSING → Complete → COMPLETED
 
 ---
 
+## Worker Assignment Protocol (OC17)
+
+### AssignmentDispatcher
+
+```python
+# modules/foundups/agent/src/worker_assignment_protocol.py
+class AssignmentDispatcher:
+    """Dispatches SwarmWorkerQueue assignments to worker processes."""
+    
+    def register_worker(self, registration: WorkerRegistration) -> WorkerProcess: ...
+    def deregister_worker(self, worker_id: str) -> WorkerDeregistration: ...
+    def dispatch_assignment(self, request: AssignmentDispatchRequest) -> AssignmentDispatchResult: ...
+    def receive_heartbeat(self, event: WorkerHeartbeatEvent) -> WorkerProcess: ...
+    def receive_completion(self, event: WorkerCompletionEvent) -> AssignmentDispatchResult: ...
+    def list_workers(self, status: WorkerProcessStatus | None) -> list[WorkerProcess]: ...
+```
+
+### Protocol Dataclasses
+
+```python
+WorkerProcess           # Registered worker with status, capabilities
+WorkerRegistration      # Worker registration request
+WorkerDeregistration    # Deregistration result
+AssignmentDispatchRequest   # Dispatch request with step details
+AssignmentDispatchResult    # Dispatch result (simulated)
+WorkerHeartbeatEvent    # Heartbeat from worker
+WorkerCompletionEvent   # Completion report with evidence
+```
+
+### Protocol Enums
+
+```python
+WorkerProcessStatus      # IDLE | ASSIGNED | PROCESSING | FAILED | TERMINATED
+WorkerRuntimeType        # OPENCLAW | HERMES | CLAUDE_0102 | QWEN | GEMMA | GENERIC
+AssignmentDispatchStatus # SIMULATED_DISPATCH | SPECIFIED_NOT_IMPLEMENTED | WORKER_NOT_FOUND | ...
+WorkerTrustLevel         # UNTRUSTED | VERIFIED | TRUSTED | SYSTEM
+```
+
+### Protocol WSP 97 Truth Fields
+
+- `WorkerProcess.simulated = True` (always)
+- `AssignmentDispatchResult.simulated = True` (always)
+- `AssignmentDispatchResult.real_process_started = False` (always)
+- `WorkerCompletionEvent.simulated = True` (always)
+- No CABR/reward/payout/token fields
+
+---
+
 ## Event Schemas
 
 ### agent_joins

--- a/modules/foundups/agent/ModLog.md
+++ b/modules/foundups/agent/ModLog.md
@@ -1,5 +1,65 @@
 # Agent Module ModLog
 
+## 2026-04-30 - Real Worker Assignment Protocol Scaffold (v0.12.0)
+
+**Author**: 0102 (W4)
+**Slice**: OC17_REAL_WORKER_ASSIGNMENT_PROTOCOL_DESIGN_PHASE1
+**WSP References**: WSP 11, WSP 50, WSP 77, WSP 97
+
+### Added
+
+- **worker_assignment_protocol.py** - AssignmentDispatcher scaffold
+  - `AssignmentDispatcher` class for worker dispatch
+  - `register_worker()` - Register worker with capabilities
+  - `deregister_worker()` - Release worker and assignments
+  - `dispatch_assignment()` - Simulated dispatch (no real process)
+  - `receive_heartbeat()` - Update worker last_seen
+  - `receive_completion()` - Record evidence from completion
+
+- **REAL_WORKER_ASSIGNMENT_PROTOCOL.md** - Architecture spec
+
+### Enums and Dataclasses
+
+| Type | Purpose |
+|------|---------|
+| `WorkerProcessStatus` | IDLE, ASSIGNED, PROCESSING, FAILED, TERMINATED |
+| `WorkerRuntimeType` | OPENCLAW, HERMES, CLAUDE_0102, QWEN, GEMMA, GENERIC |
+| `AssignmentDispatchStatus` | SIMULATED_DISPATCH, SPECIFIED_NOT_IMPLEMENTED, etc. |
+| `WorkerTrustLevel` | UNTRUSTED, VERIFIED, TRUSTED, SYSTEM |
+| `WorkerProcess` | Registered worker with status, capabilities |
+| `WorkerRegistration` | Worker registration request |
+| `WorkerDeregistration` | Deregistration result |
+| `AssignmentDispatchRequest` | Dispatch request with step details |
+| `AssignmentDispatchResult` | Dispatch result (simulated) |
+| `WorkerHeartbeatEvent` | Heartbeat from worker |
+| `WorkerCompletionEvent` | Completion report with evidence |
+
+### Protocol Rules
+
+| Rule | Description |
+|------|-------------|
+| R1 | Dispatch is simulated only |
+| R2 | No real processes are started |
+| R3 | No Claude/OpenClaw/Hermes invocation |
+| R4 | Identity verification is simulated |
+| R5 | Completion can carry evidence_refs |
+| R6 | No CABR/payout/reward fields exist |
+
+### WSP 97 Truth Boundary
+
+- `WorkerProcess.simulated = True` (always)
+- `AssignmentDispatchResult.simulated = True` (always)
+- `AssignmentDispatchResult.real_process_started = False` (always)
+- `WorkerCompletionEvent.simulated = True` (always)
+- `real_execution_performed` does not exist
+- No CABR/reward/payout/token fields exist
+
+### Tests
+
+- `test_worker_assignment_protocol.py` - 25 tests covering all 9 requirements
+
+---
+
 ## 2026-04-30 - BuildPlan Swarm WRE Queue Contract (v0.11.0)
 
 **Author**: 0102 (W4)

--- a/modules/foundups/agent/src/worker_assignment_protocol.py
+++ b/modules/foundups/agent/src/worker_assignment_protocol.py
@@ -1,0 +1,795 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Worker Assignment Protocol — Real Worker Dispatch Scaffold
+
+Defines typed interfaces for dispatching SwarmWorkerQueue assignments to
+actual worker processes (OpenClaw, Hermes, Claude 0102, Qwen, Gemma).
+
+This is a scaffold only. No real worker processes are started.
+
+WSP 97 TRUTH BOUNDARIES:
+  - All dispatch is simulated only
+  - No real processes are started
+  - No Claude/OpenClaw/Hermes invocation
+  - No files are edited
+  - No CABR/reward/payout/token fields
+  - real_execution_performed does not exist (cannot become True)
+
+Architecture:
+  SwarmWorkerQueue.dequeue_for_worker()
+      │
+      ▼
+  AssignmentDispatcher.dispatch_assignment()
+      │
+      ├─> WorkerProcess registration
+      ├─> Assignment dispatch (SIMULATED)
+      ├─> Heartbeat monitoring
+      └─> Completion reporting
+
+WSP Compliance:
+  WSP 11  : Interface contract (typed API)
+  WSP 50  : Pre-action validation (identity verification)
+  WSP 77  : Agent coordination (worker dispatch)
+  WSP 97  : Truth boundaries (simulation only)
+
+NAVIGATION:
+  -> Spec: modules/foundups/docs/REAL_WORKER_ASSIGNMENT_PROTOCOL.md
+  -> Uses: build_plan_swarm_queue.py (SwarmWorkerQueueEntry)
+  -> Uses: build_plan_swarm.py (StepAssignment)
+  -> Uses: build_plan.py (BuildStepAction)
+  -> Called by: Future WRE worker integration (not implemented)
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from .build_plan import BuildStepAction
+
+logger = logging.getLogger("worker_assignment_protocol")
+
+
+def utc_now() -> datetime:
+    """Return current UTC timestamp."""
+    return datetime.now(timezone.utc)
+
+
+def utc_iso(dt: Optional[datetime]) -> Optional[str]:
+    """Convert datetime to ISO string or None."""
+    return dt.isoformat() if dt else None
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class WorkerProcessStatus(str, Enum):
+    """Worker process lifecycle status."""
+
+    IDLE = "idle"
+    """Registered, awaiting assignment."""
+
+    ASSIGNED = "assigned"
+    """Assignment dispatched."""
+
+    PROCESSING = "processing"
+    """Actively processing assignment."""
+
+    FAILED = "failed"
+    """Failed/error state."""
+
+    TERMINATED = "terminated"
+    """Deregistered."""
+
+
+class WorkerRuntimeType(str, Enum):
+    """Worker runtime type."""
+
+    OPENCLAW = "openclaw"
+    """OpenClaw agent."""
+
+    HERMES = "hermes"
+    """Hermes FoundUp builder."""
+
+    CLAUDE_0102 = "claude_0102"
+    """Claude 0102 agent."""
+
+    QWEN = "qwen"
+    """Qwen local model."""
+
+    GEMMA = "gemma"
+    """Gemma local model."""
+
+    GENERIC = "generic"
+    """Generic/unknown worker."""
+
+
+class AssignmentDispatchStatus(str, Enum):
+    """Assignment dispatch result status."""
+
+    SIMULATED_DISPATCH = "simulated_dispatch"
+    """Dispatch simulated (no real process)."""
+
+    SPECIFIED_NOT_IMPLEMENTED = "specified_not_implemented"
+    """Interface specified but not implemented."""
+
+    WORKER_NOT_FOUND = "worker_not_found"
+    """Worker not registered."""
+
+    WORKER_BUSY = "worker_busy"
+    """Worker already has assignment."""
+
+    CAPABILITY_MISMATCH = "capability_mismatch"
+    """Worker lacks required capability."""
+
+    DISPATCH_FAILED = "dispatch_failed"
+    """Dispatch failed for other reason."""
+
+
+class WorkerTrustLevel(str, Enum):
+    """Worker trust level."""
+
+    UNTRUSTED = "untrusted"
+    """New/unknown worker."""
+
+    VERIFIED = "verified"
+    """Identity confirmed."""
+
+    TRUSTED = "trusted"
+    """Track record established."""
+
+    SYSTEM = "system"
+    """System-level worker."""
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WorkerProcess:
+    """
+    Registered worker process.
+
+    WSP 97: simulated is always True. No real process is represented.
+    """
+
+    worker_id: str
+    """Unique worker identifier."""
+
+    runtime_type: WorkerRuntimeType
+    """Worker runtime type."""
+
+    capabilities: List[str] = field(default_factory=list)
+    """Worker capabilities (validate, build, test, etc.)."""
+
+    trust_level: WorkerTrustLevel = WorkerTrustLevel.UNTRUSTED
+    """Worker trust level."""
+
+    status: WorkerProcessStatus = WorkerProcessStatus.IDLE
+    """Worker lifecycle status."""
+
+    registered_at: datetime = field(default_factory=utc_now)
+    """When worker was registered."""
+
+    last_seen_at: Optional[datetime] = None
+    """Last heartbeat time."""
+
+    current_assignment_id: Optional[str] = None
+    """Current assignment ID if any."""
+
+    # Identity verification (simulated)
+    identity_verified: bool = False
+    """True if identity was verified (simulated)."""
+
+    identity_method: Optional[str] = None
+    """Verification method: api_key, jwt, mtls, internal, none."""
+
+    # WSP 97 Truth Fields
+    simulated: bool = True
+    """Always True in scaffold."""
+
+    def __post_init__(self) -> None:
+        """Enforce WSP 97: simulated is always True."""
+        self.simulated = True
+
+    def has_capability(self, capability: str) -> bool:
+        """Check if worker has a capability."""
+        return capability in self.capabilities or "all" in self.capabilities
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "worker_id": self.worker_id,
+            "runtime_type": self.runtime_type.value,
+            "capabilities": self.capabilities,
+            "trust_level": self.trust_level.value,
+            "status": self.status.value,
+            "registered_at": utc_iso(self.registered_at),
+            "last_seen_at": utc_iso(self.last_seen_at),
+            "current_assignment_id": self.current_assignment_id,
+            "identity_verified": self.identity_verified,
+            "identity_method": self.identity_method,
+            "simulated": self.simulated,
+        }
+
+
+@dataclass
+class WorkerRegistration:
+    """Request to register a worker process."""
+
+    worker_id: str
+    """Proposed worker ID."""
+
+    runtime_type: WorkerRuntimeType
+    """Worker runtime type."""
+
+    capabilities: List[str] = field(default_factory=list)
+    """Worker capabilities."""
+
+    identity_claim: Optional[str] = None
+    """Identity claim (API key, JWT, etc.) — simulated."""
+
+    requested_trust_level: WorkerTrustLevel = WorkerTrustLevel.UNTRUSTED
+    """Requested trust level."""
+
+
+@dataclass
+class WorkerDeregistration:
+    """Result of worker deregistration."""
+
+    worker_id: str
+    """Worker that was deregistered."""
+
+    deregistered_at: datetime = field(default_factory=utc_now)
+    """When deregistration occurred."""
+
+    reason: str = ""
+    """Reason for deregistration."""
+
+    assignments_released: List[str] = field(default_factory=list)
+    """Assignment IDs that were released."""
+
+    success: bool = True
+    """True if deregistration succeeded."""
+
+
+@dataclass
+class AssignmentDispatchRequest:
+    """Request to dispatch an assignment to a worker."""
+
+    assignment_id: str
+    """From StepAssignment."""
+
+    entry_id: str
+    """From SwarmWorkerQueueEntry."""
+
+    worker_id: str
+    """Target worker."""
+
+    step_id: str
+    """BuildStep ID."""
+
+    step_action: BuildStepAction
+    """Action to perform."""
+
+    owned_files: List[str] = field(default_factory=list)
+    """Files to work on."""
+
+    timeout_seconds: int = 300
+    """Assignment timeout."""
+
+
+@dataclass
+class AssignmentDispatchResult:
+    """
+    Result of assignment dispatch.
+
+    WSP 97: simulated is always True, real_process_started is always False.
+    """
+
+    success: bool
+    """True if dispatch succeeded."""
+
+    dispatch_status: AssignmentDispatchStatus
+    """Dispatch status."""
+
+    assignment_id: str = ""
+    """Assignment ID."""
+
+    worker_id: str = ""
+    """Worker ID."""
+
+    reason: str = ""
+    """Human-readable reason."""
+
+    dispatched_at: Optional[datetime] = None
+    """When dispatch occurred."""
+
+    # WSP 97 Truth Fields
+    simulated: bool = True
+    """Always True in scaffold."""
+
+    real_process_started: bool = False
+    """Always False in scaffold."""
+
+    def __post_init__(self) -> None:
+        """Enforce WSP 97: simulated=True, real_process_started=False."""
+        self.simulated = True
+        self.real_process_started = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "success": self.success,
+            "dispatch_status": self.dispatch_status.value,
+            "assignment_id": self.assignment_id,
+            "worker_id": self.worker_id,
+            "reason": self.reason,
+            "dispatched_at": utc_iso(self.dispatched_at),
+            "simulated": self.simulated,
+            "real_process_started": self.real_process_started,
+        }
+
+
+@dataclass
+class WorkerHeartbeatEvent:
+    """Heartbeat event from worker."""
+
+    worker_id: str
+    """Worker sending heartbeat."""
+
+    assignment_id: Optional[str] = None
+    """Current assignment if any."""
+
+    heartbeat_at: datetime = field(default_factory=utc_now)
+    """When heartbeat was sent."""
+
+    status: WorkerProcessStatus = WorkerProcessStatus.PROCESSING
+    """Worker status."""
+
+    progress_percent: Optional[int] = None
+    """Progress 0-100 if applicable."""
+
+
+@dataclass
+class WorkerCompletionEvent:
+    """
+    Completion event from worker.
+
+    WSP 97: simulated is always True. Cannot set real_execution_performed.
+    """
+
+    worker_id: str
+    """Worker reporting completion."""
+
+    assignment_id: str
+    """Assignment that was completed."""
+
+    completed_at: datetime = field(default_factory=utc_now)
+    """When completion occurred."""
+
+    success: bool = True
+    """True if assignment succeeded."""
+
+    evidence_refs: List[str] = field(default_factory=list)
+    """Evidence from execution."""
+
+    error_message: Optional[str] = None
+    """Error message if failed."""
+
+    # WSP 97 Truth Fields
+    simulated: bool = True
+    """Always True in scaffold."""
+
+    def __post_init__(self) -> None:
+        """Enforce WSP 97: simulated is always True."""
+        self.simulated = True
+
+
+# ---------------------------------------------------------------------------
+# AssignmentDispatcher
+# ---------------------------------------------------------------------------
+
+
+class AssignmentDispatcher:
+    """
+    Dispatches SwarmWorkerQueue assignments to worker processes.
+
+    WSP 97 Truth Boundaries:
+      - All dispatch is simulated only
+      - No real processes are started
+      - No Claude/OpenClaw/Hermes invocation
+      - No files are edited
+      - No CABR/reward/payout fields
+    """
+
+    def __init__(self) -> None:
+        """Initialize the dispatcher."""
+        # In-memory worker registry (Phase 1)
+        self._workers: Dict[str, WorkerProcess] = {}
+
+        # Assignment tracking
+        self._assignments: Dict[str, str] = {}  # assignment_id -> worker_id
+
+        # Event log (for audit trail)
+        self._events: List[Dict[str, Any]] = []
+
+    # ------------------------------------------------------------------
+    # Worker Registration
+    # ------------------------------------------------------------------
+
+    def register_worker(
+        self,
+        registration: WorkerRegistration,
+    ) -> WorkerProcess:
+        """
+        Register a worker process with capabilities.
+
+        Args:
+            registration: WorkerRegistration with worker details.
+
+        Returns:
+            WorkerProcess representing the registered worker.
+
+        Raises:
+            ValueError: If worker ID already registered.
+        """
+        if registration.worker_id in self._workers:
+            raise ValueError(
+                f"Worker {registration.worker_id} already registered"
+            )
+
+        # Verify identity (simulated)
+        identity_verified = self._verify_identity(registration)
+
+        # Determine trust level
+        trust_level = (
+            registration.requested_trust_level
+            if identity_verified
+            else WorkerTrustLevel.UNTRUSTED
+        )
+
+        # Create worker process
+        worker = WorkerProcess(
+            worker_id=registration.worker_id,
+            runtime_type=registration.runtime_type,
+            capabilities=list(registration.capabilities),
+            trust_level=trust_level,
+            status=WorkerProcessStatus.IDLE,
+            identity_verified=identity_verified,
+            identity_method="simulated" if identity_verified else None,
+        )
+
+        self._workers[worker.worker_id] = worker
+
+        # Log event
+        self._log_event("worker_registered", {
+            "worker_id": worker.worker_id,
+            "runtime_type": worker.runtime_type.value,
+            "capabilities": worker.capabilities,
+        })
+
+        logger.info(
+            "[DISPATCHER] Registered worker %s (%s) with capabilities %s",
+            worker.worker_id,
+            worker.runtime_type.value,
+            worker.capabilities,
+        )
+
+        return worker
+
+    def _verify_identity(self, registration: WorkerRegistration) -> bool:
+        """
+        Verify worker identity claim.
+
+        WSP 97: Always returns True in scaffold. Real verification NOT IMPLEMENTED.
+
+        Args:
+            registration: Worker registration with identity claim.
+
+        Returns:
+            True (simulated verification).
+        """
+        # Simulated verification — always passes
+        return True
+
+    # ------------------------------------------------------------------
+    # Worker Deregistration
+    # ------------------------------------------------------------------
+
+    def deregister_worker(
+        self,
+        worker_id: str,
+    ) -> WorkerDeregistration:
+        """
+        Deregister a worker, releasing any assignments.
+
+        Args:
+            worker_id: Worker to deregister.
+
+        Returns:
+            WorkerDeregistration with result.
+        """
+        worker = self._workers.get(worker_id)
+
+        if not worker:
+            return WorkerDeregistration(
+                worker_id=worker_id,
+                reason=f"Worker {worker_id} not found",
+                success=False,
+            )
+
+        # Release any assignments
+        released_assignments = []
+        for assignment_id, assigned_worker in list(self._assignments.items()):
+            if assigned_worker == worker_id:
+                del self._assignments[assignment_id]
+                released_assignments.append(assignment_id)
+
+        # Update worker status
+        worker.status = WorkerProcessStatus.TERMINATED
+        worker.current_assignment_id = None
+
+        # Log event
+        self._log_event("worker_deregistered", {
+            "worker_id": worker_id,
+            "assignments_released": released_assignments,
+        })
+
+        logger.info(
+            "[DISPATCHER] Deregistered worker %s, released %d assignments",
+            worker_id,
+            len(released_assignments),
+        )
+
+        return WorkerDeregistration(
+            worker_id=worker_id,
+            reason="Worker deregistered",
+            assignments_released=released_assignments,
+            success=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Assignment Dispatch
+    # ------------------------------------------------------------------
+
+    def dispatch_assignment(
+        self,
+        request: AssignmentDispatchRequest,
+    ) -> AssignmentDispatchResult:
+        """
+        Dispatch an assignment to a registered worker.
+
+        WSP 97: Returns SIMULATED_DISPATCH or SPECIFIED_NOT_IMPLEMENTED.
+        Does NOT start a real process.
+
+        Args:
+            request: AssignmentDispatchRequest with assignment details.
+
+        Returns:
+            AssignmentDispatchResult with dispatch status.
+        """
+        worker = self._workers.get(request.worker_id)
+
+        # Check worker exists
+        if not worker:
+            return AssignmentDispatchResult(
+                success=False,
+                dispatch_status=AssignmentDispatchStatus.WORKER_NOT_FOUND,
+                assignment_id=request.assignment_id,
+                worker_id=request.worker_id,
+                reason=f"Worker {request.worker_id} not found",
+            )
+
+        # Check worker is available
+        if worker.status not in [WorkerProcessStatus.IDLE]:
+            return AssignmentDispatchResult(
+                success=False,
+                dispatch_status=AssignmentDispatchStatus.WORKER_BUSY,
+                assignment_id=request.assignment_id,
+                worker_id=request.worker_id,
+                reason=f"Worker {request.worker_id} is {worker.status.value}",
+            )
+
+        # Check capability (simplified — real implementation would use action mapping)
+        # For now, any registered worker can receive any assignment (simulated)
+
+        # Simulate dispatch (no real process started)
+        worker.status = WorkerProcessStatus.ASSIGNED
+        worker.current_assignment_id = request.assignment_id
+        self._assignments[request.assignment_id] = request.worker_id
+
+        # Log event
+        self._log_event("assignment_dispatched", {
+            "assignment_id": request.assignment_id,
+            "worker_id": request.worker_id,
+            "step_id": request.step_id,
+            "step_action": request.step_action.value,
+        })
+
+        logger.info(
+            "[DISPATCHER] Dispatched assignment %s to worker %s (SIMULATED)",
+            request.assignment_id,
+            request.worker_id,
+        )
+
+        return AssignmentDispatchResult(
+            success=True,
+            dispatch_status=AssignmentDispatchStatus.SIMULATED_DISPATCH,
+            assignment_id=request.assignment_id,
+            worker_id=request.worker_id,
+            reason="Assignment dispatched (simulated)",
+            dispatched_at=utc_now(),
+        )
+
+    # ------------------------------------------------------------------
+    # Heartbeat
+    # ------------------------------------------------------------------
+
+    def receive_heartbeat(
+        self,
+        event: WorkerHeartbeatEvent,
+    ) -> WorkerProcess:
+        """
+        Receive heartbeat from worker, update last_seen.
+
+        Args:
+            event: WorkerHeartbeatEvent from worker.
+
+        Returns:
+            Updated WorkerProcess.
+
+        Raises:
+            ValueError: If worker not found.
+        """
+        worker = self._workers.get(event.worker_id)
+
+        if not worker:
+            raise ValueError(f"Worker {event.worker_id} not found")
+
+        # Update last seen
+        worker.last_seen_at = event.heartbeat_at
+
+        # Update status if processing
+        if event.status == WorkerProcessStatus.PROCESSING:
+            worker.status = WorkerProcessStatus.PROCESSING
+
+        # Log event (debug level to avoid spam)
+        logger.debug(
+            "[DISPATCHER] Heartbeat from worker %s (progress=%s)",
+            event.worker_id,
+            event.progress_percent,
+        )
+
+        return worker
+
+    # ------------------------------------------------------------------
+    # Completion
+    # ------------------------------------------------------------------
+
+    def receive_completion(
+        self,
+        event: WorkerCompletionEvent,
+    ) -> AssignmentDispatchResult:
+        """
+        Receive completion report from worker.
+
+        WSP 97: Cannot set real_execution_performed=True.
+
+        Args:
+            event: WorkerCompletionEvent from worker.
+
+        Returns:
+            AssignmentDispatchResult with completion status.
+        """
+        worker = self._workers.get(event.worker_id)
+
+        if not worker:
+            return AssignmentDispatchResult(
+                success=False,
+                dispatch_status=AssignmentDispatchStatus.WORKER_NOT_FOUND,
+                assignment_id=event.assignment_id,
+                worker_id=event.worker_id,
+                reason=f"Worker {event.worker_id} not found",
+            )
+
+        # Clear assignment
+        if event.assignment_id in self._assignments:
+            del self._assignments[event.assignment_id]
+
+        # Update worker status
+        worker.status = WorkerProcessStatus.IDLE
+        worker.current_assignment_id = None
+        worker.last_seen_at = event.completed_at
+
+        # Log event
+        self._log_event("completion_received", {
+            "assignment_id": event.assignment_id,
+            "worker_id": event.worker_id,
+            "success": event.success,
+            "evidence_refs": event.evidence_refs,
+            "error_message": event.error_message,
+        })
+
+        logger.info(
+            "[DISPATCHER] Completion from worker %s for assignment %s (success=%s, evidence=%d)",
+            event.worker_id,
+            event.assignment_id,
+            event.success,
+            len(event.evidence_refs),
+        )
+
+        return AssignmentDispatchResult(
+            success=event.success,
+            dispatch_status=AssignmentDispatchStatus.SIMULATED_DISPATCH,
+            assignment_id=event.assignment_id,
+            worker_id=event.worker_id,
+            reason="Completion received" if event.success else event.error_message or "Failed",
+            dispatched_at=event.completed_at,
+        )
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    def list_workers(
+        self,
+        status: Optional[WorkerProcessStatus] = None,
+    ) -> List[WorkerProcess]:
+        """
+        List registered workers, optionally filtered by status.
+
+        Args:
+            status: Filter by status (optional).
+
+        Returns:
+            List of matching workers.
+        """
+        if status is None:
+            return list(self._workers.values())
+
+        return [w for w in self._workers.values() if w.status == status]
+
+    def get_worker(self, worker_id: str) -> Optional[WorkerProcess]:
+        """Get a worker by ID."""
+        return self._workers.get(worker_id)
+
+    def get_events(self) -> List[Dict[str, Any]]:
+        """Get audit event log."""
+        return list(self._events)
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _log_event(self, event_type: str, data: Dict[str, Any]) -> None:
+        """Log an audit event."""
+        self._events.append({
+            "event_type": event_type,
+            "timestamp": utc_now().isoformat(),
+            **data,
+        })
+
+
+# ---------------------------------------------------------------------------
+# Factory Function
+# ---------------------------------------------------------------------------
+
+
+def create_assignment_dispatcher() -> AssignmentDispatcher:
+    """
+    Create an AssignmentDispatcher instance.
+
+    Returns:
+        AssignmentDispatcher instance.
+    """
+    return AssignmentDispatcher()

--- a/modules/foundups/agent/tests/README.md
+++ b/modules/foundups/agent/tests/README.md
@@ -9,6 +9,20 @@ Tests cover two surfaces:
 
 ## Implemented Test Coverage
 
+### Worker Assignment Protocol
+
+`test_worker_assignment_protocol.py` verifies:
+
+1. register_worker creates tracked worker process
+2. register_worker records runtime type and capabilities
+3. dispatch_assignment returns simulated/not-implemented status
+4. dispatch_assignment does not start process
+5. heartbeat updates worker last_seen
+6. completion event records evidence_refs
+7. deregistration changes status
+8. no CABR/reward/payout/token fields exist
+9. all WSP_97 truth fields remain false/simulated
+
 ### Swarm WRE Queue
 
 `test_build_plan_swarm_queue.py` verifies:

--- a/modules/foundups/agent/tests/TestModLog.md
+++ b/modules/foundups/agent/tests/TestModLog.md
@@ -1,5 +1,51 @@
 # Agent Module TestModLog
 
+## 2026-04-30 - Worker Assignment Protocol Tests
+
+**Command**:
+
+```bash
+python -m pytest modules/foundups/agent/tests/test_worker_assignment_protocol.py -q
+```
+
+**Result**: PASS
+
+**Summary**: 25 passed in 0.26s.
+
+**Coverage**:
+1. register_worker creates tracked worker process
+2. register_worker records runtime type and capabilities
+3. dispatch_assignment returns simulated/not-implemented status
+4. dispatch_assignment does not start process
+5. heartbeat updates worker last_seen
+6. completion event records evidence_refs
+7. deregistration changes status
+8. no CABR/reward/payout/token fields exist
+9. all WSP_97 truth fields remain false/simulated
+
+**WSP References**: WSP 11, WSP 50, WSP 77, WSP 97.
+
+---
+
+## 2026-04-30 - Full Agent Module Test Suite (OC17)
+
+**Command**:
+
+```bash
+python -m pytest modules/foundups/agent/tests/test_worker_assignment_protocol.py modules/foundups/agent/tests/test_build_plan_swarm_queue.py -q
+```
+
+**Result**: PASS
+
+**Summary**: 45 passed.
+
+**Notes**:
+- All worker assignment protocol tests (25) passing
+- All queue tests (20) still passing
+- No regressions
+
+---
+
 ## 2026-04-30 - BuildPlan Swarm WRE Queue Tests
 
 **Command**:

--- a/modules/foundups/agent/tests/test_worker_assignment_protocol.py
+++ b/modules/foundups/agent/tests/test_worker_assignment_protocol.py
@@ -1,0 +1,667 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Test suite for Worker Assignment Protocol scaffold.
+
+WSP 97 Truth Boundary Tests:
+  - All dispatch is simulated only
+  - No real processes are started
+  - real_process_started=False always
+  - simulated=True always
+  - No CABR/reward/payout/token fields
+
+Test Coverage:
+  1. register_worker creates tracked worker process
+  2. register_worker records runtime type and capabilities
+  3. dispatch_assignment returns simulated/not-implemented status
+  4. dispatch_assignment does not start process
+  5. heartbeat updates worker last_seen
+  6. completion event records evidence_refs
+  7. deregistration changes status
+  8. no CABR/reward/payout/token fields exist
+  9. all WSP_97 truth fields remain false/simulated
+"""
+
+import pytest
+from datetime import datetime, timezone
+
+from modules.foundups.agent.src.build_plan import BuildStepAction
+from modules.foundups.agent.src.worker_assignment_protocol import (
+    AssignmentDispatcher,
+    AssignmentDispatchRequest,
+    AssignmentDispatchResult,
+    AssignmentDispatchStatus,
+    WorkerCompletionEvent,
+    WorkerDeregistration,
+    WorkerHeartbeatEvent,
+    WorkerProcess,
+    WorkerProcessStatus,
+    WorkerRegistration,
+    WorkerRuntimeType,
+    WorkerTrustLevel,
+    create_assignment_dispatcher,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dispatcher() -> AssignmentDispatcher:
+    """Create an AssignmentDispatcher for testing."""
+    return create_assignment_dispatcher()
+
+
+@pytest.fixture
+def hermes_registration() -> WorkerRegistration:
+    """Create a Hermes worker registration."""
+    return WorkerRegistration(
+        worker_id="hermes_test_001",
+        runtime_type=WorkerRuntimeType.HERMES,
+        capabilities=["build", "extract"],
+        identity_claim="test_api_key_hermes",
+        requested_trust_level=WorkerTrustLevel.VERIFIED,
+    )
+
+
+@pytest.fixture
+def openclaw_registration() -> WorkerRegistration:
+    """Create an OpenClaw worker registration."""
+    return WorkerRegistration(
+        worker_id="openclaw_test_001",
+        runtime_type=WorkerRuntimeType.OPENCLAW,
+        capabilities=["validate", "orchestrate"],
+        identity_claim="test_api_key_openclaw",
+        requested_trust_level=WorkerTrustLevel.TRUSTED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: register_worker creates tracked worker process
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerRegistration:
+    """Test worker registration functionality."""
+
+    def test_register_worker_creates_process(
+        self,
+        dispatcher: AssignmentDispatcher,
+        hermes_registration: WorkerRegistration,
+    ) -> None:
+        """Test that register_worker creates a tracked worker process."""
+        worker = dispatcher.register_worker(hermes_registration)
+
+        assert worker is not None
+        assert worker.worker_id == "hermes_test_001"
+        assert worker.status == WorkerProcessStatus.IDLE
+        assert worker.simulated is True
+
+        # Worker is tracked
+        workers = dispatcher.list_workers()
+        assert len(workers) == 1
+        assert workers[0].worker_id == "hermes_test_001"
+
+    def test_register_worker_duplicate_fails(
+        self,
+        dispatcher: AssignmentDispatcher,
+        hermes_registration: WorkerRegistration,
+    ) -> None:
+        """Test that duplicate registration fails."""
+        dispatcher.register_worker(hermes_registration)
+
+        with pytest.raises(ValueError, match="already registered"):
+            dispatcher.register_worker(hermes_registration)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: register_worker records runtime type and capabilities
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerCapabilities:
+    """Test worker runtime type and capabilities."""
+
+    def test_register_records_runtime_type(
+        self,
+        dispatcher: AssignmentDispatcher,
+        hermes_registration: WorkerRegistration,
+    ) -> None:
+        """Test that registration records runtime type."""
+        worker = dispatcher.register_worker(hermes_registration)
+
+        assert worker.runtime_type == WorkerRuntimeType.HERMES
+
+    def test_register_records_capabilities(
+        self,
+        dispatcher: AssignmentDispatcher,
+        hermes_registration: WorkerRegistration,
+    ) -> None:
+        """Test that registration records capabilities."""
+        worker = dispatcher.register_worker(hermes_registration)
+
+        assert "build" in worker.capabilities
+        assert "extract" in worker.capabilities
+        assert worker.has_capability("build") is True
+        assert worker.has_capability("validate") is False
+
+    def test_multiple_workers_different_types(
+        self,
+        dispatcher: AssignmentDispatcher,
+        hermes_registration: WorkerRegistration,
+        openclaw_registration: WorkerRegistration,
+    ) -> None:
+        """Test registering multiple workers with different types."""
+        hermes = dispatcher.register_worker(hermes_registration)
+        openclaw = dispatcher.register_worker(openclaw_registration)
+
+        assert hermes.runtime_type == WorkerRuntimeType.HERMES
+        assert openclaw.runtime_type == WorkerRuntimeType.OPENCLAW
+
+        workers = dispatcher.list_workers()
+        assert len(workers) == 2
+
+
+# ---------------------------------------------------------------------------
+# Test 3: dispatch_assignment returns simulated/not-implemented status
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchStatus:
+    """Test dispatch assignment status."""
+
+    def test_dispatch_returns_simulated_status(
+        self,
+        dispatcher: AssignmentDispatcher,
+        hermes_registration: WorkerRegistration,
+    ) -> None:
+        """Test that dispatch returns SIMULATED_DISPATCH status."""
+        worker = dispatcher.register_worker(hermes_registration)
+
+        request = AssignmentDispatchRequest(
+            assignment_id="assign_001",
+            entry_id="qe_001",
+            worker_id=worker.worker_id,
+            step_id="step_create_module",
+            step_action=BuildStepAction.CREATE_MODULE,
+            owned_files=["modules/test/src/"],
+        )
+
+        result = dispatcher.dispatch_assignment(request)
+
+        assert result.success is True
+        assert result.dispatch_status == AssignmentDispatchStatus.SIMULATED_DISPATCH
+        assert result.simulated is True
+
+    def test_dispatch_worker_not_found(
+        self,
+        dispatcher: AssignmentDispatcher,
+    ) -> None:
+        """Test dispatch fails if worker not found."""
+        request = AssignmentDispatchRequest(
+            assignment_id="assign_001",
+            entry_id="qe_001",
+            worker_id="nonexistent_worker",
+            step_id="step_001",
+            step_action=BuildStepAction.VALIDATE_GENESIS,
+            owned_files=[],
+        )
+
+        result = dispatcher.dispatch_assignment(request)
+
+        assert result.success is False
+        assert result.dispatch_status == AssignmentDispatchStatus.WORKER_NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# Test 4: dispatch_assignment does not start process
+# ---------------------------------------------------------------------------
+
+
+class TestNoRealProcess:
+    """Test that no real process is started."""
+
+    def test_dispatch_does_not_start_process(
+        self,
+        dispatcher: AssignmentDispatcher,
+        hermes_registration: WorkerRegistration,
+    ) -> None:
+        """Test that dispatch does not start a real process."""
+        worker = dispatcher.register_worker(hermes_registration)
+
+        request = AssignmentDispatchRequest(
+            assignment_id="assign_001",
+            entry_id="qe_001",
+            worker_id=worker.worker_id,
+            step_id="step_001",
+            step_action=BuildStepAction.CREATE_MODULE,
+            owned_files=["modules/test/"],
+        )
+
+        result = dispatcher.dispatch_assignment(request)
+
+        # WSP 97: real_process_started is always False
+        assert result.real_process_started is False
+        assert result.simulated is True
+
+    def test_result_post_init_enforces_no_real_process(self) -> None:
+        """Test that __post_init__ enforces real_process_started=False."""
+        result = AssignmentDispatchResult(
+            success=True,
+            dispatch_status=AssignmentDispatchStatus.SIMULATED_DISPATCH,
+            real_process_started=True,  # Try to set True
+        )
+
+        # __post_init__ should enforce False
+        assert result.real_process_started is False
+        assert result.simulated is True
+
+
+# ---------------------------------------------------------------------------
+# Test 5: heartbeat updates worker last_seen
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeat:
+    """Test heartbeat functionality."""
+
+    def test_heartbeat_updates_last_seen(
+        self,
+        dispatcher: AssignmentDispatcher,
+        hermes_registration: WorkerRegistration,
+    ) -> None:
+        """Test that heartbeat updates worker last_seen."""
+        worker = dispatcher.register_worker(hermes_registration)
+        original_last_seen = worker.last_seen_at
+
+        # Dispatch assignment first
+        request = AssignmentDispatchRequest(
+            assignment_id="assign_001",
+            entry_id="qe_001",
+            worker_id=worker.worker_id,
+            step_id="step_001",
+            step_action=BuildStepAction.CREATE_MODULE,
+            owned_files=[],
+        )
+        dispatcher.dispatch_assignment(request)
+
+        # Send heartbeat
+        heartbeat = WorkerHeartbeatEvent(
+            worker_id=worker.worker_id,
+            assignment_id="assign_001",
+            status=WorkerProcessStatus.PROCESSING,
+            progress_percent=50,
+        )
+        updated_worker = dispatcher.receive_heartbeat(heartbeat)
+
+        assert updated_worker.last_seen_at is not None
+        assert updated_worker.last_seen_at != original_last_seen
+
+    def test_heartbeat_updates_status(
+        self,
+        dispatcher: AssignmentDispatcher,
+        hermes_registration: WorkerRegistration,
+    ) -> None:
+        """Test that heartbeat can update worker status."""
+        worker = dispatcher.register_worker(hermes_registration)
+
+        # Dispatch first
+        request = AssignmentDispatchRequest(
+            assignment_id="assign_001",
+            entry_id="qe_001",
+            worker_id=worker.worker_id,
+            step_id="step_001",
+            step_action=BuildStepAction.VALIDATE_GENESIS,
+            owned_files=[],
+        )
+        dispatcher.dispatch_assignment(request)
+
+        # Heartbeat with PROCESSING status
+        heartbeat = WorkerHeartbeatEvent(
+            worker_id=worker.worker_id,
+            assignment_id="assign_001",
+            status=WorkerProcessStatus.PROCESSING,
+        )
+        updated_worker = dispatcher.receive_heartbeat(heartbeat)
+
+        assert updated_worker.status == WorkerProcessStatus.PROCESSING
+
+
+# ---------------------------------------------------------------------------
+# Test 6: completion event records evidence_refs
+# ---------------------------------------------------------------------------
+
+
+class TestCompletion:
+    """Test completion event functionality."""
+
+    def test_completion_records_evidence(
+        self,
+        dispatcher: AssignmentDispatcher,
+        hermes_registration: WorkerRegistration,
+    ) -> None:
+        """Test that completion event records evidence_refs."""
+        worker = dispatcher.register_worker(hermes_registration)
+
+        # Dispatch
+        request = AssignmentDispatchRequest(
+            assignment_id="assign_001",
+            entry_id="qe_001",
+            worker_id=worker.worker_id,
+            step_id="step_001",
+            step_action=BuildStepAction.CREATE_MODULE,
+            owned_files=[],
+        )
+        dispatcher.dispatch_assignment(request)
+
+        # Complete with evidence
+        completion = WorkerCompletionEvent(
+            worker_id=worker.worker_id,
+            assignment_id="assign_001",
+            success=True,
+            evidence_refs=[
+                "evidence/step_001/module_created",
+                "evidence/step_001/tests_passed",
+            ],
+        )
+        result = dispatcher.receive_completion(completion)
+
+        assert result.success is True
+
+        # Check event log
+        events = dispatcher.get_events()
+        completion_events = [e for e in events if e["event_type"] == "completion_received"]
+        assert len(completion_events) == 1
+        assert completion_events[0]["evidence_refs"] == [
+            "evidence/step_001/module_created",
+            "evidence/step_001/tests_passed",
+        ]
+
+    def test_completion_returns_worker_to_idle(
+        self,
+        dispatcher: AssignmentDispatcher,
+        hermes_registration: WorkerRegistration,
+    ) -> None:
+        """Test that completion returns worker to IDLE status."""
+        worker = dispatcher.register_worker(hermes_registration)
+
+        # Dispatch
+        request = AssignmentDispatchRequest(
+            assignment_id="assign_001",
+            entry_id="qe_001",
+            worker_id=worker.worker_id,
+            step_id="step_001",
+            step_action=BuildStepAction.VALIDATE_GENESIS,
+            owned_files=[],
+        )
+        dispatcher.dispatch_assignment(request)
+
+        assert worker.status == WorkerProcessStatus.ASSIGNED
+
+        # Complete
+        completion = WorkerCompletionEvent(
+            worker_id=worker.worker_id,
+            assignment_id="assign_001",
+            success=True,
+            evidence_refs=[],
+        )
+        dispatcher.receive_completion(completion)
+
+        # Worker should be IDLE again
+        updated_worker = dispatcher.get_worker(worker.worker_id)
+        assert updated_worker.status == WorkerProcessStatus.IDLE
+
+
+# ---------------------------------------------------------------------------
+# Test 7: deregistration changes status
+# ---------------------------------------------------------------------------
+
+
+class TestDeregistration:
+    """Test worker deregistration."""
+
+    def test_deregistration_changes_status(
+        self,
+        dispatcher: AssignmentDispatcher,
+        hermes_registration: WorkerRegistration,
+    ) -> None:
+        """Test that deregistration changes worker status to TERMINATED."""
+        worker = dispatcher.register_worker(hermes_registration)
+        assert worker.status == WorkerProcessStatus.IDLE
+
+        result = dispatcher.deregister_worker(worker.worker_id)
+
+        assert result.success is True
+        assert result.worker_id == worker.worker_id
+
+        # Worker status should be TERMINATED
+        updated_worker = dispatcher.get_worker(worker.worker_id)
+        assert updated_worker.status == WorkerProcessStatus.TERMINATED
+
+    def test_deregistration_releases_assignments(
+        self,
+        dispatcher: AssignmentDispatcher,
+        hermes_registration: WorkerRegistration,
+    ) -> None:
+        """Test that deregistration releases any assignments."""
+        worker = dispatcher.register_worker(hermes_registration)
+
+        # Dispatch
+        request = AssignmentDispatchRequest(
+            assignment_id="assign_001",
+            entry_id="qe_001",
+            worker_id=worker.worker_id,
+            step_id="step_001",
+            step_action=BuildStepAction.CREATE_MODULE,
+            owned_files=[],
+        )
+        dispatcher.dispatch_assignment(request)
+
+        # Deregister
+        result = dispatcher.deregister_worker(worker.worker_id)
+
+        assert result.success is True
+        assert "assign_001" in result.assignments_released
+
+
+# ---------------------------------------------------------------------------
+# Test 8: no CABR/reward/payout/token fields exist
+# ---------------------------------------------------------------------------
+
+
+class TestNoCABRFields:
+    """Test that no CABR/reward/payout/token fields exist."""
+
+    def test_worker_no_cabr_fields(
+        self,
+        dispatcher: AssignmentDispatcher,
+        hermes_registration: WorkerRegistration,
+    ) -> None:
+        """Test WorkerProcess has no CABR fields."""
+        worker = dispatcher.register_worker(hermes_registration)
+
+        forbidden_fields = [
+            "cabr_ready",
+            "payout_ready",
+            "reward",
+            "payout",
+            "tokens",
+            "token_balance",
+        ]
+
+        for field in forbidden_fields:
+            assert not hasattr(worker, field), f"Worker should not have {field}"
+
+        # Also check to_dict()
+        worker_dict = worker.to_dict()
+        for field in forbidden_fields:
+            assert field not in worker_dict, f"Worker dict should not have {field}"
+
+    def test_result_no_cabr_fields(
+        self,
+        dispatcher: AssignmentDispatcher,
+        hermes_registration: WorkerRegistration,
+    ) -> None:
+        """Test AssignmentDispatchResult has no CABR fields."""
+        worker = dispatcher.register_worker(hermes_registration)
+
+        request = AssignmentDispatchRequest(
+            assignment_id="assign_001",
+            entry_id="qe_001",
+            worker_id=worker.worker_id,
+            step_id="step_001",
+            step_action=BuildStepAction.VALIDATE_GENESIS,
+            owned_files=[],
+        )
+        result = dispatcher.dispatch_assignment(request)
+
+        forbidden_fields = [
+            "cabr_ready",
+            "payout_ready",
+            "reward",
+            "payout",
+            "tokens",
+        ]
+
+        for field in forbidden_fields:
+            assert not hasattr(result, field), f"Result should not have {field}"
+
+        result_dict = result.to_dict()
+        for field in forbidden_fields:
+            assert field not in result_dict, f"Result dict should not have {field}"
+
+
+# ---------------------------------------------------------------------------
+# Test 9: all WSP_97 truth fields remain false/simulated
+# ---------------------------------------------------------------------------
+
+
+class TestWSP97TruthFields:
+    """Test WSP 97 truth field enforcement."""
+
+    def test_worker_simulated_always_true(
+        self,
+        dispatcher: AssignmentDispatcher,
+        hermes_registration: WorkerRegistration,
+    ) -> None:
+        """Test that WorkerProcess.simulated is always True."""
+        worker = dispatcher.register_worker(hermes_registration)
+        assert worker.simulated is True
+
+        # Try to set False via new instance
+        new_worker = WorkerProcess(
+            worker_id="test_worker",
+            runtime_type=WorkerRuntimeType.GENERIC,
+            simulated=False,  # Try to set False
+        )
+        # __post_init__ should enforce True
+        assert new_worker.simulated is True
+
+    def test_result_simulated_always_true(self) -> None:
+        """Test that AssignmentDispatchResult.simulated is always True."""
+        result = AssignmentDispatchResult(
+            success=True,
+            dispatch_status=AssignmentDispatchStatus.SIMULATED_DISPATCH,
+            simulated=False,  # Try to set False
+        )
+        # __post_init__ should enforce True
+        assert result.simulated is True
+
+    def test_result_real_process_started_always_false(self) -> None:
+        """Test that real_process_started is always False."""
+        result = AssignmentDispatchResult(
+            success=True,
+            dispatch_status=AssignmentDispatchStatus.SIMULATED_DISPATCH,
+            real_process_started=True,  # Try to set True
+        )
+        # __post_init__ should enforce False
+        assert result.real_process_started is False
+
+    def test_completion_event_simulated_always_true(self) -> None:
+        """Test that WorkerCompletionEvent.simulated is always True."""
+        completion = WorkerCompletionEvent(
+            worker_id="test_worker",
+            assignment_id="assign_001",
+            success=True,
+            simulated=False,  # Try to set False
+        )
+        # __post_init__ should enforce True
+        assert completion.simulated is True
+
+    def test_no_real_execution_performed_field(
+        self,
+        dispatcher: AssignmentDispatcher,
+        hermes_registration: WorkerRegistration,
+    ) -> None:
+        """Test that no real_execution_performed field exists."""
+        worker = dispatcher.register_worker(hermes_registration)
+
+        # Worker has no real_execution_performed
+        assert not hasattr(worker, "real_execution_performed")
+
+        # Completion event has no real_execution_performed
+        completion = WorkerCompletionEvent(
+            worker_id=worker.worker_id,
+            assignment_id="assign_001",
+            success=True,
+        )
+        assert not hasattr(completion, "real_execution_performed")
+
+
+# ---------------------------------------------------------------------------
+# Additional Tests
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryFunction:
+    """Test factory function."""
+
+    def test_create_assignment_dispatcher(self) -> None:
+        """Test create_assignment_dispatcher factory."""
+        dispatcher = create_assignment_dispatcher()
+
+        assert dispatcher is not None
+        assert isinstance(dispatcher, AssignmentDispatcher)
+        assert len(dispatcher.list_workers()) == 0
+
+
+class TestAuditEvents:
+    """Test audit event logging."""
+
+    def test_registration_logs_event(
+        self,
+        dispatcher: AssignmentDispatcher,
+        hermes_registration: WorkerRegistration,
+    ) -> None:
+        """Test that registration logs an event."""
+        dispatcher.register_worker(hermes_registration)
+
+        events = dispatcher.get_events()
+        assert len(events) == 1
+        assert events[0]["event_type"] == "worker_registered"
+        assert events[0]["worker_id"] == "hermes_test_001"
+
+    def test_dispatch_logs_event(
+        self,
+        dispatcher: AssignmentDispatcher,
+        hermes_registration: WorkerRegistration,
+    ) -> None:
+        """Test that dispatch logs an event."""
+        worker = dispatcher.register_worker(hermes_registration)
+
+        request = AssignmentDispatchRequest(
+            assignment_id="assign_001",
+            entry_id="qe_001",
+            worker_id=worker.worker_id,
+            step_id="step_001",
+            step_action=BuildStepAction.VALIDATE_GENESIS,
+            owned_files=[],
+        )
+        dispatcher.dispatch_assignment(request)
+
+        events = dispatcher.get_events()
+        dispatch_events = [e for e in events if e["event_type"] == "assignment_dispatched"]
+        assert len(dispatch_events) == 1
+        assert dispatch_events[0]["assignment_id"] == "assign_001"

--- a/modules/foundups/docs/REAL_WORKER_ASSIGNMENT_PROTOCOL.md
+++ b/modules/foundups/docs/REAL_WORKER_ASSIGNMENT_PROTOCOL.md
@@ -1,0 +1,645 @@
+# Real Worker Assignment Protocol
+
+**Status**: Architecture Specification (ADR)
+**Owner**: 0102
+**Slice**: `OC17_REAL_WORKER_ASSIGNMENT_PROTOCOL_DESIGN_PHASE1`
+**WSP References**: WSP 11 (Interface Protocol), WSP 50 (Pre-Action Verification), WSP 77 (Agent Coordination), WSP 97 (Truth Boundaries)
+
+---
+
+## WSP 97 Truthfulness Statement
+
+This document is an **architecture specification only**. No real worker processes are started.
+
+| Claim | Status |
+|-------|--------|
+| AssignmentDispatcher interface defined | `SPECIFIED_SCAFFOLD_ONLY` |
+| Worker registration | `SCAFFOLD_SIMULATED` |
+| Worker deregistration | `SCAFFOLD_SIMULATED` |
+| Assignment dispatch | `SCAFFOLD_NOT_IMPLEMENTED` |
+| Heartbeat tracking | `SCAFFOLD_SIMULATED` |
+| Completion reporting | `SCAFFOLD_SIMULATED` |
+| Worker identity verification | `SCAFFOLD_SIMULATED` |
+| Real process start | `NOT_IMPLEMENTED` |
+| Real Claude/OpenClaw/Hermes invocation | `NOT_IMPLEMENTED` |
+| CABR/payout/reward | `NOT_IMPLEMENTED` |
+
+**Canonical Rule**: Worker assignment is simulated. No real workers are started.
+
+---
+
+## 1. Purpose
+
+The Real Worker Assignment Protocol defines how SwarmWorkerQueue entries are dispatched to actual worker processes (OpenClaw, Hermes, 0102 agents) when the system transitions from simulation to real execution.
+
+**Architecture Position**:
+```
+SwarmWorkerQueue.dequeue_for_worker()
+    │
+    ▼
+AssignmentDispatcher.dispatch_assignment()
+    │
+    ├─> WorkerProcess registration
+    │       │
+    │       ├─> Identity verification
+    │       ├─> Capability check
+    │       └─> Trust level assignment
+    │
+    ├─> Assignment dispatch (SIMULATED)
+    │       │
+    │       ├─> Lease acquisition
+    │       ├─> Heartbeat monitoring
+    │       └─> Completion tracking
+    │
+    └─> Evidence collection
+            │
+            └─> SwarmCoordinator.complete_assignment()
+```
+
+**PoC Goal**: Define typed interfaces for worker assignment lifecycle.
+**MVP Goal**: Real workers can register, receive assignments, and report completion.
+
+---
+
+## 2. Worker Process Model
+
+### 2.1 Worker Types
+
+| Type | Description | Capabilities |
+|------|-------------|--------------|
+| `OPENCLAW` | OpenClaw agent instance | validate, orchestrate |
+| `HERMES` | Hermes FoundUp builder | build, extract |
+| `CLAUDE_0102` | Claude agent (0102) | all |
+| `QWEN` | Qwen local model | validate, triage |
+| `GEMMA` | Gemma local model | validate, classify |
+
+### 2.2 Worker Lifecycle
+
+```
+                    ┌──────────────┐
+                    │  UNREGISTERED │
+                    └──────┬───────┘
+                           │ register_worker()
+                           ▼
+                    ┌──────────────┐
+           ┌────────│   IDLE       │◄────────┐
+           │        └──────┬───────┘         │
+           │               │ dispatch()      │ complete()
+           │               ▼                 │
+           │        ┌──────────────┐         │
+           │        │   ASSIGNED   │─────────┤
+           │        └──────┬───────┘         │
+           │               │ heartbeat()     │
+           │               ▼                 │
+           │        ┌──────────────┐         │
+           │        │  PROCESSING  │─────────┘
+           │        └──────┬───────┘
+           │               │ timeout/error
+           │               ▼
+           │        ┌──────────────┐
+           └────────│   FAILED     │
+                    └──────┬───────┘
+                           │ deregister()
+                           ▼
+                    ┌──────────────┐
+                    │  TERMINATED  │
+                    └──────────────┘
+```
+
+### 2.3 Trust Levels
+
+| Level | Description | Allowed Actions |
+|-------|-------------|-----------------|
+| `UNTRUSTED` | New/unknown worker | Read-only operations |
+| `VERIFIED` | Identity confirmed | Validation, analysis |
+| `TRUSTED` | Track record established | Build, modify |
+| `SYSTEM` | System-level worker | All operations |
+
+---
+
+## 3. Core Interfaces
+
+### 3.1 AssignmentDispatcher
+
+```python
+class AssignmentDispatcher:
+    """
+    Dispatches SwarmWorkerQueue assignments to worker processes.
+    
+    WSP 97: All dispatch is simulated. No real processes are started.
+    """
+    
+    def register_worker(
+        self,
+        registration: WorkerRegistration,
+    ) -> WorkerProcess:
+        """Register a worker process with capabilities."""
+    
+    def deregister_worker(
+        self,
+        worker_id: str,
+    ) -> WorkerDeregistration:
+        """Deregister a worker, releasing any assignments."""
+    
+    def dispatch_assignment(
+        self,
+        request: AssignmentDispatchRequest,
+    ) -> AssignmentDispatchResult:
+        """
+        Dispatch an assignment to a registered worker.
+        
+        WSP 97: Returns SIMULATED_DISPATCH or SPECIFIED_NOT_IMPLEMENTED.
+        Does NOT start a real process.
+        """
+    
+    def receive_heartbeat(
+        self,
+        event: WorkerHeartbeatEvent,
+    ) -> WorkerProcess:
+        """Receive heartbeat from worker, update last_seen."""
+    
+    def receive_completion(
+        self,
+        event: WorkerCompletionEvent,
+    ) -> AssignmentDispatchResult:
+        """
+        Receive completion report from worker.
+        
+        WSP 97: Cannot set real_execution_performed=True.
+        """
+    
+    def list_workers(
+        self,
+        status: WorkerProcessStatus | None = None,
+    ) -> list[WorkerProcess]:
+        """List registered workers, optionally filtered by status."""
+```
+
+### 3.2 WorkerProcess
+
+```python
+@dataclass
+class WorkerProcess:
+    worker_id: str                    # Unique worker identifier
+    runtime_type: WorkerRuntimeType   # OPENCLAW, HERMES, CLAUDE_0102, etc.
+    capabilities: list[str]           # ["validate", "build", "test"]
+    trust_level: WorkerTrustLevel     # UNTRUSTED, VERIFIED, TRUSTED, SYSTEM
+    status: WorkerProcessStatus       # IDLE, ASSIGNED, PROCESSING, FAILED, TERMINATED
+    
+    registered_at: datetime
+    last_seen_at: Optional[datetime]
+    current_assignment_id: Optional[str]
+    
+    # Identity verification (simulated)
+    identity_verified: bool = False
+    identity_method: Optional[str] = None  # "api_key", "jwt", "mtls", etc.
+    
+    # WSP 97 Truth Fields
+    simulated: bool = True            # Always True in scaffold
+    # No real_execution_performed field exists
+```
+
+### 3.3 WorkerRegistration
+
+```python
+@dataclass
+class WorkerRegistration:
+    worker_id: str                    # Proposed worker ID
+    runtime_type: WorkerRuntimeType   # Worker runtime type
+    capabilities: list[str]           # Capabilities
+    identity_claim: Optional[str]     # Identity claim (API key, JWT, etc.)
+    requested_trust_level: WorkerTrustLevel  # Requested trust level
+```
+
+### 3.4 WorkerDeregistration
+
+```python
+@dataclass
+class WorkerDeregistration:
+    worker_id: str
+    deregistered_at: datetime
+    reason: str
+    assignments_released: list[str]   # Assignment IDs released
+    success: bool
+```
+
+### 3.5 AssignmentDispatchRequest
+
+```python
+@dataclass
+class AssignmentDispatchRequest:
+    assignment_id: str                # From StepAssignment
+    entry_id: str                     # From SwarmWorkerQueueEntry
+    worker_id: str                    # Target worker
+    step_id: str                      # BuildStep ID
+    step_action: BuildStepAction      # Action to perform
+    owned_files: list[str]            # Files to work on
+    timeout_seconds: int = 300        # Assignment timeout
+```
+
+### 3.6 AssignmentDispatchResult
+
+```python
+@dataclass
+class AssignmentDispatchResult:
+    success: bool
+    dispatch_status: AssignmentDispatchStatus  # SIMULATED_DISPATCH, NOT_IMPLEMENTED, etc.
+    assignment_id: str
+    worker_id: str
+    reason: str
+    dispatched_at: Optional[datetime]
+    
+    # WSP 97 Truth Fields
+    simulated: bool = True            # Always True in scaffold
+    real_process_started: bool = False  # Always False in scaffold
+```
+
+### 3.7 WorkerHeartbeatEvent
+
+```python
+@dataclass
+class WorkerHeartbeatEvent:
+    worker_id: str
+    assignment_id: Optional[str]
+    heartbeat_at: datetime
+    status: WorkerProcessStatus
+    progress_percent: Optional[int]   # 0-100 if applicable
+```
+
+### 3.8 WorkerCompletionEvent
+
+```python
+@dataclass
+class WorkerCompletionEvent:
+    worker_id: str
+    assignment_id: str
+    completed_at: datetime
+    success: bool
+    evidence_refs: list[str]
+    error_message: Optional[str]
+    
+    # WSP 97 Truth Fields
+    simulated: bool = True            # Always True in scaffold
+    # Cannot set real_execution_performed=True
+```
+
+---
+
+## 4. Enums
+
+### 4.1 WorkerProcessStatus
+
+```python
+class WorkerProcessStatus(str, Enum):
+    IDLE = "idle"              # Registered, awaiting assignment
+    ASSIGNED = "assigned"      # Assignment dispatched
+    PROCESSING = "processing"  # Actively processing
+    FAILED = "failed"          # Failed/error state
+    TERMINATED = "terminated"  # Deregistered
+```
+
+### 4.2 WorkerRuntimeType
+
+```python
+class WorkerRuntimeType(str, Enum):
+    OPENCLAW = "openclaw"      # OpenClaw agent
+    HERMES = "hermes"          # Hermes builder
+    CLAUDE_0102 = "claude_0102"  # Claude 0102 agent
+    QWEN = "qwen"              # Qwen local model
+    GEMMA = "gemma"            # Gemma local model
+    GENERIC = "generic"        # Generic/unknown
+```
+
+### 4.3 AssignmentDispatchStatus
+
+```python
+class AssignmentDispatchStatus(str, Enum):
+    SIMULATED_DISPATCH = "simulated_dispatch"   # Dispatch simulated
+    SPECIFIED_NOT_IMPLEMENTED = "specified_not_implemented"  # Interface only
+    WORKER_NOT_FOUND = "worker_not_found"
+    WORKER_BUSY = "worker_busy"
+    CAPABILITY_MISMATCH = "capability_mismatch"
+    DISPATCH_FAILED = "dispatch_failed"
+```
+
+### 4.4 WorkerTrustLevel
+
+```python
+class WorkerTrustLevel(str, Enum):
+    UNTRUSTED = "untrusted"    # New/unknown
+    VERIFIED = "verified"      # Identity confirmed
+    TRUSTED = "trusted"        # Track record
+    SYSTEM = "system"          # System-level
+```
+
+---
+
+## 5. Dispatch Protocol
+
+### 5.1 Polling Model (Phase 1)
+
+Workers poll for assignments:
+
+```
+Worker                          AssignmentDispatcher
+   │                                    │
+   │──── register_worker() ────────────>│
+   │<─── WorkerProcess (IDLE) ──────────│
+   │                                    │
+   │──── poll for assignment ──────────>│ (via SwarmWorkerQueue)
+   │<─── AssignmentDispatchRequest ─────│
+   │                                    │
+   │──── heartbeat() ──────────────────>│
+   │<─── WorkerProcess (PROCESSING) ────│
+   │                                    │
+   │──── complete() ───────────────────>│
+   │<─── AssignmentDispatchResult ──────│
+   │                                    │
+```
+
+### 5.2 Push Model (Future)
+
+Dispatcher pushes assignments to workers:
+
+```
+AssignmentDispatcher            Worker
+   │                               │
+   │──── dispatch_assignment() ───>│
+   │<─── ACK ──────────────────────│
+   │                               │
+   │<─── heartbeat() ──────────────│
+   │──── ACK ─────────────────────>│
+   │                               │
+   │<─── complete() ───────────────│
+   │──── AssignmentDispatchResult ─│
+   │                               │
+```
+
+### 5.3 Heartbeat Protocol
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| Heartbeat Interval | 30s | Worker sends heartbeat |
+| Heartbeat Timeout | 90s | Missed heartbeats = failure |
+| Max Missed | 3 | Consecutive misses before failure |
+
+---
+
+## 6. Identity Verification
+
+### 6.1 Verification Methods (Simulated)
+
+| Method | Description | Trust Level |
+|--------|-------------|-------------|
+| `api_key` | API key validation | VERIFIED |
+| `jwt` | JWT token validation | VERIFIED |
+| `mtls` | Mutual TLS certificate | TRUSTED |
+| `internal` | Internal system process | SYSTEM |
+| `none` | No verification | UNTRUSTED |
+
+### 6.2 Verification Flow
+
+```python
+# Simulated verification (scaffold only)
+def verify_worker_identity(registration: WorkerRegistration) -> bool:
+    """
+    Verify worker identity claim.
+    
+    WSP 97: Always returns True in scaffold.
+    Real verification NOT IMPLEMENTED.
+    """
+    return True  # Simulated
+```
+
+---
+
+## 7. Failure Handling
+
+### 7.1 Failure Types
+
+| Failure | Response |
+|---------|----------|
+| Worker timeout | Release assignment, mark failed |
+| Heartbeat miss | Warning → retry → failure |
+| Completion error | Record error, mark failed |
+| Worker crash | Detect via heartbeat, requeue |
+
+### 7.2 Retry Semantics
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| Max Retries | 3 | Per assignment |
+| Retry Delay | 30s | Before retry |
+| Backoff Multiplier | 2.0 | Exponential backoff |
+
+---
+
+## 8. Audit Trail
+
+### 8.1 Events Recorded
+
+| Event | Data |
+|-------|------|
+| `worker_registered` | worker_id, runtime_type, capabilities |
+| `worker_deregistered` | worker_id, reason |
+| `assignment_dispatched` | assignment_id, worker_id, step_id |
+| `heartbeat_received` | worker_id, assignment_id, progress |
+| `completion_received` | assignment_id, success, evidence_refs |
+| `worker_failed` | worker_id, reason |
+
+### 8.2 Evidence Chain
+
+```
+WorkerCompletionEvent.evidence_refs
+    │
+    ▼
+AssignmentDispatchResult (recorded)
+    │
+    ▼
+SwarmWorkerQueueEntry.evidence_refs
+    │
+    ▼
+StepAssignment.evidence_refs
+    │
+    ▼
+EvidenceBundle (aggregated)
+```
+
+---
+
+## 9. Security Boundaries
+
+### 9.1 Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Worker → Dispatcher | Worker must register with valid identity |
+| Dispatcher → Queue | Dispatcher validates assignment ownership |
+| Assignment → Files | File access limited to owned_files |
+
+### 9.2 No Raw Chat Execution
+
+**Critical**: Workers receive typed `AssignmentDispatchRequest`, NOT raw chat.
+
+```python
+# CORRECT
+request = AssignmentDispatchRequest(
+    assignment_id="a_001",
+    step_action=BuildStepAction.VALIDATE_GENESIS,
+    owned_files=["modules/foundups/voteballots/README.md"],
+)
+
+# FORBIDDEN - No raw chat
+# request.raw_instruction = "Please validate the genesis..."
+```
+
+---
+
+## 10. WSP 97 Truth Boundaries
+
+This scaffold enforces the following truth fields:
+
+| Field | Value | Location |
+|-------|-------|----------|
+| `WorkerProcess.simulated` | True | Always |
+| `AssignmentDispatchResult.simulated` | True | Always |
+| `AssignmentDispatchResult.real_process_started` | False | Always |
+| `WorkerCompletionEvent.simulated` | True | Always |
+| `real_execution_performed` | N/A | Field does not exist |
+| `cabr_ready` | N/A | Field does not exist |
+| `payout_ready` | N/A | Field does not exist |
+
+**No CABR/reward/payout/token fields exist in this contract.**
+
+---
+
+## 11. Integration Points
+
+### 11.1 SwarmWorkerQueue Integration
+
+```python
+# Queue entry dequeued
+entry = queue.dequeue_for_worker(request)
+
+# Create dispatch request
+dispatch_request = AssignmentDispatchRequest(
+    assignment_id=entry.assignment_id,
+    entry_id=entry.entry_id,
+    worker_id=entry.worker_id,
+    step_id=entry.step_id,
+    step_action=entry.step_action,
+    owned_files=entry.owned_files,
+)
+
+# Dispatch (simulated)
+result = dispatcher.dispatch_assignment(dispatch_request)
+
+# Result is SIMULATED_DISPATCH (no real process)
+assert result.dispatch_status == AssignmentDispatchStatus.SIMULATED_DISPATCH
+assert result.real_process_started is False
+```
+
+### 11.2 BuildPlanExecutor Integration
+
+```python
+# Worker completes, reports back
+completion = WorkerCompletionEvent(
+    worker_id="hermes_001",
+    assignment_id="a_001",
+    success=True,
+    evidence_refs=["evidence/step1/validated"],
+)
+
+# Dispatcher receives completion
+result = dispatcher.receive_completion(completion)
+
+# Flow to SwarmCoordinator
+coordinator.complete_assignment(
+    completion.assignment_id,
+    completion.evidence_refs,
+)
+```
+
+---
+
+## 12. Example (SPEC_EXAMPLE_NOT_EXECUTED)
+
+```python
+# Full worker assignment lifecycle (simulated)
+
+from modules.foundups.agent.src.worker_assignment_protocol import (
+    AssignmentDispatcher, WorkerRegistration, WorkerRuntimeType,
+    WorkerTrustLevel, AssignmentDispatchRequest, WorkerHeartbeatEvent,
+    WorkerCompletionEvent, AssignmentDispatchStatus
+)
+from modules.foundups.agent.src.build_plan import BuildStepAction
+
+# Create dispatcher
+dispatcher = AssignmentDispatcher()
+
+# Register worker
+registration = WorkerRegistration(
+    worker_id="hermes_vb_001",
+    runtime_type=WorkerRuntimeType.HERMES,
+    capabilities=["build", "extract"],
+    identity_claim="api_key_hermes_001",
+    requested_trust_level=WorkerTrustLevel.VERIFIED,
+)
+worker = dispatcher.register_worker(registration)
+assert worker.status == WorkerProcessStatus.IDLE
+assert worker.simulated is True
+
+# Dispatch assignment (simulated)
+request = AssignmentDispatchRequest(
+    assignment_id="a_vb_001",
+    entry_id="qe_vb_001",
+    worker_id="hermes_vb_001",
+    step_id="step_create_module",
+    step_action=BuildStepAction.CREATE_MODULE,
+    owned_files=["modules/foundups/voteballots/src/"],
+)
+result = dispatcher.dispatch_assignment(request)
+assert result.dispatch_status == AssignmentDispatchStatus.SIMULATED_DISPATCH
+assert result.real_process_started is False
+
+# Heartbeat
+heartbeat = WorkerHeartbeatEvent(
+    worker_id="hermes_vb_001",
+    assignment_id="a_vb_001",
+    heartbeat_at=datetime.now(timezone.utc),
+    status=WorkerProcessStatus.PROCESSING,
+    progress_percent=50,
+)
+worker = dispatcher.receive_heartbeat(heartbeat)
+assert worker.status == WorkerProcessStatus.PROCESSING
+
+# Completion
+completion = WorkerCompletionEvent(
+    worker_id="hermes_vb_001",
+    assignment_id="a_vb_001",
+    completed_at=datetime.now(timezone.utc),
+    success=True,
+    evidence_refs=["evidence/voteballots/module_created"],
+)
+result = dispatcher.receive_completion(completion)
+assert result.success is True
+assert result.simulated is True
+```
+
+**NOTE**: This example is specification only. No real execution occurs.
+
+---
+
+## 13. Future Extensions (Out of Scope)
+
+The following are explicitly out of scope for OC17:
+
+- Real process start (subprocess, API call)
+- Real Claude/OpenClaw/Hermes invocation
+- Real identity verification (cryptographic)
+- Cross-machine worker coordination
+- Worker health monitoring daemon
+- RedDog/pfMALL UI integration
+- CABR/rewards/payouts
+
+These will be addressed in future OC slices.


### PR DESCRIPTION
## Summary

- Adds real worker assignment protocol ADR/spec
- Adds AssignmentDispatcher scaffold
- Adds worker process registration/deregistration, heartbeat, dispatch request/result, completion event
- Models worker identity verification as simulated/scaffold only
- Dispatch never starts real worker processes
- Completion carries evidence_refs only
- Updates INTERFACE.md, ModLog.md, tests/README.md, and tests/TestModLog.md

## WSP_97 Boundaries

- All workers simulated
- No real process starts
- No real execution performed
- No raw chat execution
- No CABR/reward/payout/token fields

## Test Plan

- [x] 25 worker assignment protocol tests passed
- [x] 20 BuildPlan swarm queue tests passed (regression)
- [x] Lint/security CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)