### PR TITLE
feat(foundups): add worker queue observability scaffold

### DIFF
--- a/modules/foundups/agent/INTERFACE.md
+++ b/modules/foundups/agent/INTERFACE.md
@@ -266,6 +266,59 @@ DispatchCycleStatus     # SUCCESS | NO_QUEUED_ENTRIES | NO_CAPABILITY_MATCH | ..
 
 ---
 
+## Worker Queue Observability (OC20)
+
+### WorkerQueueObservability
+
+```python
+# modules/foundups/agent/src/worker_queue_observability.py
+class WorkerQueueObservability:
+    """Observability system for SwarmWorkerQueue telemetry."""
+    
+    def emit_event(self, event: WorkerQueueEvent) -> WorkerQueueEvent: ...
+    def emit_heartbeat(self, worker_id: str, entry_id: str | None) -> WorkerQueueEvent: ...
+    def emit_lease_expired(self, entry_id: str, worker_id: str, reason: str) -> WorkerQueueEvent: ...
+    def emit_worker_available(self, worker_id: str, capabilities: list[str]) -> WorkerQueueEvent: ...
+    def emit_worker_unavailable(self, worker_id: str, reason: str) -> WorkerQueueEvent: ...
+    def snapshot_queue_health(self, queue: SwarmWorkerQueue) -> QueueHealthSnapshot: ...
+    def get_events(self, worker_id: str | None) -> list[WorkerQueueEvent]: ...
+```
+
+### Observability Dataclasses
+
+```python
+WorkerQueueEvent        # Base event with timestamp, worker_id, entry_id, evidence_refs
+WorkerHeartbeatSnapshot # Heartbeat state with consecutive count
+LeaseExpirySignal       # Lease expiration details
+WorkerAvailabilitySnapshot  # Worker availability state
+QueueHealthSnapshot     # Queue health with entry counts
+```
+
+### Observability Enums
+
+```python
+WorkerQueueEventType    # HEARTBEAT | LEASE_EXPIRED | WORKER_AVAILABLE | ...
+WorkerAvailabilityStatus # AVAILABLE | BUSY | OFFLINE | TERMINATED
+QueueHealthStatus       # HEALTHY | DEGRADED | UNHEALTHY
+```
+
+### WSP 91 Compliance
+
+| Pillar | Implementation |
+|--------|----------------|
+| Logs | emit_* methods create discrete events |
+| Traces | Not implemented (Phase 2) |
+| Metrics | snapshot_* methods for aggregated state |
+
+### Observability WSP 97 Truth Fields
+
+- Events are in-memory only (Phase 1)
+- Events are append-only
+- No real_execution_performed field exists
+- No CABR/reward/payout/token fields
+
+---
+
 ## Event Schemas
 
 ### agent_joins

--- a/modules/foundups/agent/ModLog.md
+++ b/modules/foundups/agent/ModLog.md
@@ -1,5 +1,58 @@
 # Agent Module ModLog
 
+## 2026-05-01 - Worker Queue Observability Scaffold (v0.14.0)
+
+**Author**: 0102 (W4)
+**Slice**: OC20_WRE_WORKER_QUEUE_OBSERVABILITY_EVENTS_PHASE1
+**WSP References**: WSP 11, WSP 50, WSP 91, WSP 97
+
+### Added
+
+- **worker_queue_observability.py** - WorkerQueueObservability
+  - `WorkerQueueObservability` class for queue telemetry
+  - `emit_event()` - Emit observability event (append-only)
+  - `emit_heartbeat()` - Emit heartbeat with consecutive tracking
+  - `emit_lease_expired()` - Emit lease expiry signal
+  - `emit_worker_available()` - Emit worker availability event
+  - `emit_worker_unavailable()` - Emit worker unavailability event
+  - `snapshot_queue_health()` - Queue health snapshot with counts
+
+### Enums and Dataclasses
+
+| Type | Purpose |
+|------|---------|
+| `WorkerQueueEventType` | HEARTBEAT, LEASE_EXPIRED, WORKER_AVAILABLE, etc. |
+| `WorkerAvailabilityStatus` | AVAILABLE, BUSY, OFFLINE, TERMINATED |
+| `QueueHealthStatus` | HEALTHY, DEGRADED, UNHEALTHY |
+| `WorkerQueueEvent` | Base event with timestamp, worker_id, entry_id, evidence_refs |
+| `WorkerHeartbeatSnapshot` | Heartbeat state with consecutive count |
+| `LeaseExpirySignal` | Lease expiration details |
+| `WorkerAvailabilitySnapshot` | Worker availability state |
+| `QueueHealthSnapshot` | Queue health with entry counts |
+
+### WSP 91 Three Pillars
+
+| Pillar | Implementation |
+|--------|----------------|
+| Logs | emit_* methods create discrete events with timestamps |
+| Traces | Not implemented (Phase 2) |
+| Metrics | snapshot_* methods for aggregated state |
+
+### WSP 97 Truth Boundary
+
+- Events are in-memory only (Phase 1)
+- Events are append-only
+- No real_execution_performed field exists
+- No CABR/reward/payout/token fields exist
+- No external telemetry sink yet
+- No RedDog/pfMALL event emission yet
+
+### Tests
+
+- `test_worker_queue_observability.py` - 28 tests covering all 10 requirements
+
+---
+
 ## 2026-04-30 - Swarm Dispatch Integration (v0.13.0)
 
 **Author**: 0102 (W4)

--- a/modules/foundups/agent/src/worker_queue_observability.py
+++ b/modules/foundups/agent/src/worker_queue_observability.py
@@ -1,0 +1,625 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Worker Queue Observability — Event Scaffolding for Queue Telemetry
+
+Implements observability/status event scaffolding for SwarmWorkerQueue
+and worker assignment flow per WSP 91 (DAEMON Observability Protocol).
+
+This is observability scaffold only.
+- Events are in-memory only (Phase 1)
+- Events are append-only
+- No external telemetry sink yet
+- No RedDog/pfMALL event emission yet
+- No real worker process starts
+
+WSP 91 Three Pillars:
+  - Logs: Event emission with timestamps
+  - Traces: Not implemented (Phase 2)
+  - Metrics: Snapshot methods for aggregated state
+
+WSP 97 TRUTH BOUNDARIES:
+  - All events are observability only
+  - No real processes are represented
+  - No files are edited
+  - No CABR/reward/payout/token fields
+  - real_execution_performed does not exist
+
+WSP Compliance:
+  WSP 11  : Interface contract (typed API)
+  WSP 50  : Pre-action validation (event validation)
+  WSP 91  : DAEMON Observability Protocol
+  WSP 97  : Truth boundaries (no execution claims)
+
+NAVIGATION:
+  -> Uses: build_plan_swarm_queue.py (SwarmWorkerQueue, QueueEntryStatus)
+  -> Spec: WSP_framework/src/WSP_91_DAEMON_Observability_Protocol.md
+  -> Called by: Future WRE observability integration
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("worker_queue_observability")
+
+
+def utc_now() -> datetime:
+    """Return current UTC timestamp."""
+    return datetime.now(timezone.utc)
+
+
+def utc_iso(dt: Optional[datetime]) -> Optional[str]:
+    """Convert datetime to ISO string or None."""
+    return dt.isoformat() if dt else None
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class WorkerQueueEventType(str, Enum):
+    """Types of worker queue events."""
+
+    HEARTBEAT = "heartbeat"
+    """Worker sent heartbeat."""
+
+    LEASE_EXPIRED = "lease_expired"
+    """Assignment lease expired."""
+
+    WORKER_AVAILABLE = "worker_available"
+    """Worker became available for assignments."""
+
+    WORKER_UNAVAILABLE = "worker_unavailable"
+    """Worker became unavailable."""
+
+    ASSIGNMENT_ENQUEUED = "assignment_enqueued"
+    """Assignment was enqueued."""
+
+    ASSIGNMENT_DEQUEUED = "assignment_dequeued"
+    """Assignment was dequeued by worker."""
+
+    ASSIGNMENT_COMPLETED = "assignment_completed"
+    """Assignment was completed."""
+
+    QUEUE_STATUS_CHANGE = "queue_status_change"
+    """Queue status changed."""
+
+
+class WorkerAvailabilityStatus(str, Enum):
+    """Worker availability status for telemetry."""
+
+    AVAILABLE = "available"
+    """Worker is available for new assignments."""
+
+    BUSY = "busy"
+    """Worker is processing an assignment."""
+
+    OFFLINE = "offline"
+    """Worker is not responding."""
+
+    TERMINATED = "terminated"
+    """Worker was deregistered."""
+
+
+class QueueHealthStatus(str, Enum):
+    """Queue health status for telemetry."""
+
+    HEALTHY = "healthy"
+    """Queue operating normally."""
+
+    DEGRADED = "degraded"
+    """Queue has pending issues (expired entries, etc.)."""
+
+    UNHEALTHY = "unhealthy"
+    """Queue has critical issues."""
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WorkerQueueEvent:
+    """
+    Base event for worker queue observability.
+
+    WSP 91: Implements Pillar 1 (Logs) - discrete events with timestamps.
+    WSP 97: No execution claims, no CABR/payout fields.
+    """
+
+    event_id: str
+    """Unique event identifier."""
+
+    event_type: WorkerQueueEventType
+    """Type of event."""
+
+    created_at: datetime = field(default_factory=utc_now)
+    """When event was created."""
+
+    worker_id: Optional[str] = None
+    """Worker involved in event (if applicable)."""
+
+    entry_id: Optional[str] = None
+    """Queue entry involved (if applicable)."""
+
+    evidence_refs: List[str] = field(default_factory=list)
+    """Evidence references (if applicable)."""
+
+    payload: Dict[str, Any] = field(default_factory=dict)
+    """Additional event payload."""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "event_id": self.event_id,
+            "event_type": self.event_type.value,
+            "created_at": utc_iso(self.created_at),
+            "worker_id": self.worker_id,
+            "entry_id": self.entry_id,
+            "evidence_refs": self.evidence_refs,
+            "payload": self.payload,
+        }
+
+
+@dataclass
+class WorkerHeartbeatSnapshot:
+    """
+    Snapshot of worker heartbeat state.
+
+    WSP 91: Metrics pillar - aggregated measurements.
+    """
+
+    worker_id: str
+    """Worker that sent heartbeat."""
+
+    heartbeat_at: datetime = field(default_factory=utc_now)
+    """When heartbeat was sent."""
+
+    entry_id: Optional[str] = None
+    """Entry being processed (if any)."""
+
+    lease_remaining_seconds: Optional[int] = None
+    """Seconds remaining on lease."""
+
+    consecutive_heartbeats: int = 0
+    """Consecutive heartbeats without failure."""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "worker_id": self.worker_id,
+            "heartbeat_at": utc_iso(self.heartbeat_at),
+            "entry_id": self.entry_id,
+            "lease_remaining_seconds": self.lease_remaining_seconds,
+            "consecutive_heartbeats": self.consecutive_heartbeats,
+        }
+
+
+@dataclass
+class LeaseExpirySignal:
+    """
+    Signal that a lease has expired.
+
+    WSP 91: Logs pillar - lease lifecycle event.
+    """
+
+    entry_id: str
+    """Queue entry whose lease expired."""
+
+    worker_id: str
+    """Worker that held the lease."""
+
+    expired_at: datetime = field(default_factory=utc_now)
+    """When expiration was detected."""
+
+    reason: str = ""
+    """Reason for expiration."""
+
+    was_requeued: bool = False
+    """True if entry was requeued for retry."""
+
+    retry_count: int = 0
+    """Current retry count."""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "entry_id": self.entry_id,
+            "worker_id": self.worker_id,
+            "expired_at": utc_iso(self.expired_at),
+            "reason": self.reason,
+            "was_requeued": self.was_requeued,
+            "retry_count": self.retry_count,
+        }
+
+
+@dataclass
+class WorkerAvailabilitySnapshot:
+    """
+    Snapshot of worker availability state.
+
+    WSP 91: Metrics pillar - worker health telemetry.
+    """
+
+    worker_id: str
+    """Worker identifier."""
+
+    status: WorkerAvailabilityStatus
+    """Availability status."""
+
+    capabilities: List[str] = field(default_factory=list)
+    """Worker capabilities."""
+
+    last_heartbeat_at: Optional[datetime] = None
+    """Last heartbeat timestamp."""
+
+    current_assignment_id: Optional[str] = None
+    """Current assignment (if busy)."""
+
+    snapshot_at: datetime = field(default_factory=utc_now)
+    """When snapshot was taken."""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "worker_id": self.worker_id,
+            "status": self.status.value,
+            "capabilities": self.capabilities,
+            "last_heartbeat_at": utc_iso(self.last_heartbeat_at),
+            "current_assignment_id": self.current_assignment_id,
+            "snapshot_at": utc_iso(self.snapshot_at),
+        }
+
+
+@dataclass
+class QueueHealthSnapshot:
+    """
+    Snapshot of queue health state.
+
+    WSP 91: Metrics pillar - queue health telemetry.
+    """
+
+    status: QueueHealthStatus
+    """Overall queue health status."""
+
+    total_queued: int = 0
+    """Entries waiting for pickup."""
+
+    total_processing: int = 0
+    """Entries being processed."""
+
+    total_completed: int = 0
+    """Entries completed."""
+
+    total_failed: int = 0
+    """Entries failed."""
+
+    total_expired: int = 0
+    """Entries expired."""
+
+    oldest_queued_seconds: Optional[int] = None
+    """Age of oldest queued entry in seconds."""
+
+    snapshot_at: datetime = field(default_factory=utc_now)
+    """When snapshot was taken."""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "status": self.status.value,
+            "total_queued": self.total_queued,
+            "total_processing": self.total_processing,
+            "total_completed": self.total_completed,
+            "total_failed": self.total_failed,
+            "total_expired": self.total_expired,
+            "oldest_queued_seconds": self.oldest_queued_seconds,
+            "snapshot_at": utc_iso(self.snapshot_at),
+        }
+
+
+# ---------------------------------------------------------------------------
+# WorkerQueueObservability
+# ---------------------------------------------------------------------------
+
+
+class WorkerQueueObservability:
+    """
+    Observability system for SwarmWorkerQueue telemetry.
+
+    Implements WSP 91 (DAEMON Observability Protocol) Pillar 1 (Logs)
+    and basic Pillar 3 (Metrics) via snapshot methods.
+
+    WSP 97 Truth Boundaries:
+      - All events are observability only
+      - No real processes are represented
+      - No execution claims
+      - No CABR/reward/payout fields
+    """
+
+    def __init__(self) -> None:
+        """Initialize the observability system."""
+        # In-memory event storage (Phase 1)
+        self._events: List[WorkerQueueEvent] = []
+
+        # Worker heartbeat tracking
+        self._worker_heartbeats: Dict[str, WorkerHeartbeatSnapshot] = {}
+
+    # ------------------------------------------------------------------
+    # Event Emission
+    # ------------------------------------------------------------------
+
+    def emit_event(self, event: WorkerQueueEvent) -> WorkerQueueEvent:
+        """
+        Emit an observability event.
+
+        Events are stored in-memory and append-only.
+
+        Args:
+            event: WorkerQueueEvent to emit.
+
+        Returns:
+            The emitted event.
+        """
+        self._events.append(event)
+
+        logger.info(
+            "[OBSERVABILITY] Event %s: %s (worker=%s, entry=%s)",
+            event.event_id,
+            event.event_type.value,
+            event.worker_id,
+            event.entry_id,
+        )
+
+        return event
+
+    def emit_heartbeat(
+        self,
+        worker_id: str,
+        entry_id: Optional[str] = None,
+    ) -> WorkerQueueEvent:
+        """
+        Emit a heartbeat event for a worker.
+
+        Args:
+            worker_id: Worker sending heartbeat.
+            entry_id: Entry being processed (optional).
+
+        Returns:
+            The emitted heartbeat event.
+        """
+        event_id = f"evt_{secrets.token_hex(6)}"
+
+        event = WorkerQueueEvent(
+            event_id=event_id,
+            event_type=WorkerQueueEventType.HEARTBEAT,
+            worker_id=worker_id,
+            entry_id=entry_id,
+            payload={"source": "worker_queue_observability"},
+        )
+
+        # Update heartbeat tracking
+        existing = self._worker_heartbeats.get(worker_id)
+        consecutive = (existing.consecutive_heartbeats + 1) if existing else 1
+
+        self._worker_heartbeats[worker_id] = WorkerHeartbeatSnapshot(
+            worker_id=worker_id,
+            heartbeat_at=event.created_at,
+            entry_id=entry_id,
+            consecutive_heartbeats=consecutive,
+        )
+
+        return self.emit_event(event)
+
+    def emit_lease_expired(
+        self,
+        entry_id: str,
+        worker_id: str,
+        reason: str,
+    ) -> WorkerQueueEvent:
+        """
+        Emit a lease expiry event.
+
+        Args:
+            entry_id: Queue entry whose lease expired.
+            worker_id: Worker that held the lease.
+            reason: Reason for expiration.
+
+        Returns:
+            The emitted lease expiry event.
+        """
+        event_id = f"evt_{secrets.token_hex(6)}"
+
+        signal = LeaseExpirySignal(
+            entry_id=entry_id,
+            worker_id=worker_id,
+            reason=reason,
+        )
+
+        event = WorkerQueueEvent(
+            event_id=event_id,
+            event_type=WorkerQueueEventType.LEASE_EXPIRED,
+            worker_id=worker_id,
+            entry_id=entry_id,
+            payload=signal.to_dict(),
+        )
+
+        return self.emit_event(event)
+
+    def emit_worker_available(
+        self,
+        worker_id: str,
+        capabilities: List[str],
+    ) -> WorkerQueueEvent:
+        """
+        Emit a worker available event.
+
+        Args:
+            worker_id: Worker that became available.
+            capabilities: Worker capabilities.
+
+        Returns:
+            The emitted availability event.
+        """
+        event_id = f"evt_{secrets.token_hex(6)}"
+
+        snapshot = WorkerAvailabilitySnapshot(
+            worker_id=worker_id,
+            status=WorkerAvailabilityStatus.AVAILABLE,
+            capabilities=capabilities,
+        )
+
+        event = WorkerQueueEvent(
+            event_id=event_id,
+            event_type=WorkerQueueEventType.WORKER_AVAILABLE,
+            worker_id=worker_id,
+            payload=snapshot.to_dict(),
+        )
+
+        return self.emit_event(event)
+
+    def emit_worker_unavailable(
+        self,
+        worker_id: str,
+        reason: str,
+    ) -> WorkerQueueEvent:
+        """
+        Emit a worker unavailable event.
+
+        Args:
+            worker_id: Worker that became unavailable.
+            reason: Reason for unavailability.
+
+        Returns:
+            The emitted unavailability event.
+        """
+        event_id = f"evt_{secrets.token_hex(6)}"
+
+        event = WorkerQueueEvent(
+            event_id=event_id,
+            event_type=WorkerQueueEventType.WORKER_UNAVAILABLE,
+            worker_id=worker_id,
+            payload={
+                "status": WorkerAvailabilityStatus.OFFLINE.value,
+                "reason": reason,
+            },
+        )
+
+        return self.emit_event(event)
+
+    # ------------------------------------------------------------------
+    # Snapshots
+    # ------------------------------------------------------------------
+
+    def snapshot_queue_health(
+        self,
+        queue: "SwarmWorkerQueue",  # noqa: F821
+    ) -> QueueHealthSnapshot:
+        """
+        Take a health snapshot of the queue.
+
+        Args:
+            queue: SwarmWorkerQueue to snapshot.
+
+        Returns:
+            QueueHealthSnapshot with current state.
+        """
+        # Import here to avoid circular import
+        from .build_plan_swarm_queue import QueueEntryStatus
+
+        counts = queue.count_by_status()
+
+        total_queued = counts.get(QueueEntryStatus.QUEUED, 0)
+        total_processing = counts.get(QueueEntryStatus.PROCESSING, 0)
+        total_completed = counts.get(QueueEntryStatus.COMPLETED, 0)
+        total_failed = counts.get(QueueEntryStatus.FAILED, 0)
+        total_expired = counts.get(QueueEntryStatus.EXPIRED, 0)
+
+        # Calculate oldest queued entry age
+        queued_entries = queue.list_entries(status=QueueEntryStatus.QUEUED)
+        oldest_queued_seconds = None
+        if queued_entries:
+            now = utc_now()
+            oldest = min(e.queued_at for e in queued_entries)
+            oldest_queued_seconds = int((now - oldest).total_seconds())
+
+        # Determine health status
+        if total_failed > 0 or total_expired > 0:
+            status = QueueHealthStatus.DEGRADED
+        elif total_processing > 10 or (oldest_queued_seconds and oldest_queued_seconds > 300):
+            status = QueueHealthStatus.DEGRADED
+        else:
+            status = QueueHealthStatus.HEALTHY
+
+        return QueueHealthSnapshot(
+            status=status,
+            total_queued=total_queued,
+            total_processing=total_processing,
+            total_completed=total_completed,
+            total_failed=total_failed,
+            total_expired=total_expired,
+            oldest_queued_seconds=oldest_queued_seconds,
+        )
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    def get_events(
+        self,
+        worker_id: Optional[str] = None,
+    ) -> List[WorkerQueueEvent]:
+        """
+        Get events, optionally filtered by worker_id.
+
+        Args:
+            worker_id: Filter by worker ID (optional).
+
+        Returns:
+            List of matching events.
+        """
+        if worker_id is None:
+            return list(self._events)
+
+        return [e for e in self._events if e.worker_id == worker_id]
+
+    def get_heartbeat_snapshot(
+        self,
+        worker_id: str,
+    ) -> Optional[WorkerHeartbeatSnapshot]:
+        """Get latest heartbeat snapshot for a worker."""
+        return self._worker_heartbeats.get(worker_id)
+
+    def clear_events(self) -> int:
+        """
+        Clear all events (for testing/cleanup).
+
+        Returns:
+            Number of events cleared.
+        """
+        count = len(self._events)
+        self._events.clear()
+        self._worker_heartbeats.clear()
+        return count
+
+
+# ---------------------------------------------------------------------------
+# Factory Function
+# ---------------------------------------------------------------------------
+
+
+def create_worker_queue_observability() -> WorkerQueueObservability:
+    """
+    Create a WorkerQueueObservability instance.
+
+    Returns:
+        WorkerQueueObservability instance.
+    """
+    return WorkerQueueObservability()

--- a/modules/foundups/agent/tests/README.md
+++ b/modules/foundups/agent/tests/README.md
@@ -9,6 +9,21 @@ Tests cover two surfaces:
 
 ## Implemented Test Coverage
 
+### Worker Queue Observability
+
+`test_worker_queue_observability.py` verifies:
+
+1. emit_event stores append-only event
+2. emit_heartbeat creates heartbeat event with consecutive tracking
+3. emit_lease_expired creates lease expiry signal
+4. worker availability/unavailability events are recorded
+5. snapshot_queue_health reports queued/processing/completed/expired counts
+6. get_events filters by worker_id
+7. event fields preserve evidence_refs
+8. all observability is in-memory only
+9. no real worker/process fields imply execution
+10. no CABR/reward/payout/token fields exist
+
 ### Swarm Dispatch Integration
 
 `test_swarm_dispatch_integration.py` verifies:

--- a/modules/foundups/agent/tests/TestModLog.md
+++ b/modules/foundups/agent/tests/TestModLog.md
@@ -1,5 +1,38 @@
 # Agent Module TestModLog
 
+## 2026-05-01 - Worker Queue Observability Tests (OC20)
+
+**Command**:
+
+```bash
+python -m pytest modules/foundups/agent/tests/test_worker_queue_observability.py -q
+```
+
+**Result**: PASS
+
+**Summary**: 28 passed in 1.04s.
+
+**Coverage**:
+1. emit_event stores append-only event
+2. emit_heartbeat creates heartbeat event with consecutive tracking
+3. emit_lease_expired creates lease expiry signal
+4. worker availability/unavailability events are recorded
+5. snapshot_queue_health reports queued/processing/completed/expired counts
+6. get_events filters by worker_id
+7. event fields preserve evidence_refs
+8. all observability is in-memory only
+9. no real worker/process fields imply execution
+10. no CABR/reward/payout/token fields exist
+
+**Notes**:
+- Implements WSP 91 (DAEMON Observability Protocol) Pillar 1 (Logs) and partial Pillar 3 (Metrics)
+- All 32 agent queue tests still passing (no regressions)
+- All 33 VoteBallot PoC tests still passing (no regressions)
+
+**WSP References**: WSP 11, WSP 50, WSP 91, WSP 97.
+
+---
+
 ## 2026-04-30 - Full VoteBallot Dispatch PoC Integration (OC19)
 
 **Command**:

--- a/modules/foundups/agent/tests/test_worker_queue_observability.py
+++ b/modules/foundups/agent/tests/test_worker_queue_observability.py
@@ -1,0 +1,611 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Worker Queue Observability Tests
+
+Tests for worker queue observability event scaffolding per WSP 91.
+
+WSP 97 TRUTH BOUNDARIES:
+  - All events are observability only
+  - No real processes are represented
+  - No CABR/reward/payout/token fields
+
+Test Coverage:
+  1. emit_event stores append-only event
+  2. emit_heartbeat creates heartbeat event
+  3. emit_lease_expired creates lease expiry signal
+  4. worker availability/unavailability events are recorded
+  5. snapshot_queue_health reports queued/dequeued/completed/expired counts
+  6. get_events filters by worker_id
+  7. event fields preserve evidence_refs
+  8. all observability is in-memory only
+  9. no real worker/process fields imply execution
+  10. no CABR/reward/payout/token fields exist
+
+WSP References: WSP 11, WSP 50, WSP 91, WSP 97.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from modules.foundups.agent.src.worker_queue_observability import (
+    LeaseExpirySignal,
+    QueueHealthSnapshot,
+    QueueHealthStatus,
+    WorkerAvailabilitySnapshot,
+    WorkerAvailabilityStatus,
+    WorkerHeartbeatSnapshot,
+    WorkerQueueEvent,
+    WorkerQueueEventType,
+    WorkerQueueObservability,
+    create_worker_queue_observability,
+)
+
+from modules.foundups.agent.src.build_plan_swarm_queue import (
+    QueueEntryStatus,
+    QueuePriority,
+    SwarmWorkerQueue,
+    create_swarm_worker_queue,
+)
+
+from modules.foundups.agent.src.build_plan_swarm import (
+    StepAssignment,
+)
+
+from modules.foundups.agent.src.build_plan import (
+    BuildStepAction,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def observability() -> WorkerQueueObservability:
+    """Create a WorkerQueueObservability instance."""
+    return create_worker_queue_observability()
+
+
+@pytest.fixture
+def queue() -> SwarmWorkerQueue:
+    """Create a SwarmWorkerQueue instance."""
+    return create_swarm_worker_queue()
+
+
+@pytest.fixture
+def sample_assignment() -> StepAssignment:
+    """Create a sample StepAssignment."""
+    return StepAssignment(
+        assignment_id="assign_obs_001",
+        step_id="step_validate_001",
+        worker_id="obs_worker_001",
+        owned_files=["modules/test/README.md"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: emit_event stores append-only event
+# ---------------------------------------------------------------------------
+
+
+class TestEmitEvent:
+    """Test emit_event functionality."""
+
+    def test_emit_event_stores_event(
+        self, observability: WorkerQueueObservability
+    ) -> None:
+        """emit_event stores event in append-only list."""
+        event = WorkerQueueEvent(
+            event_id="evt_test_001",
+            event_type=WorkerQueueEventType.HEARTBEAT,
+            worker_id="worker_001",
+        )
+
+        result = observability.emit_event(event)
+
+        assert result.event_id == "evt_test_001"
+        assert len(observability.get_events()) == 1
+        assert observability.get_events()[0].event_id == "evt_test_001"
+
+    def test_emit_event_is_append_only(
+        self, observability: WorkerQueueObservability
+    ) -> None:
+        """Events are append-only."""
+        event1 = WorkerQueueEvent(
+            event_id="evt_001",
+            event_type=WorkerQueueEventType.HEARTBEAT,
+        )
+        event2 = WorkerQueueEvent(
+            event_id="evt_002",
+            event_type=WorkerQueueEventType.LEASE_EXPIRED,
+        )
+
+        observability.emit_event(event1)
+        observability.emit_event(event2)
+
+        events = observability.get_events()
+        assert len(events) == 2
+        assert events[0].event_id == "evt_001"
+        assert events[1].event_id == "evt_002"
+
+    def test_emit_event_preserves_all_fields(
+        self, observability: WorkerQueueObservability
+    ) -> None:
+        """All event fields are preserved."""
+        event = WorkerQueueEvent(
+            event_id="evt_full_001",
+            event_type=WorkerQueueEventType.ASSIGNMENT_COMPLETED,
+            worker_id="worker_full",
+            entry_id="entry_full",
+            evidence_refs=["evidence/ref1", "evidence/ref2"],
+            payload={"custom_key": "custom_value"},
+        )
+
+        observability.emit_event(event)
+        stored = observability.get_events()[0]
+
+        assert stored.worker_id == "worker_full"
+        assert stored.entry_id == "entry_full"
+        assert len(stored.evidence_refs) == 2
+        assert "evidence/ref1" in stored.evidence_refs
+        assert stored.payload["custom_key"] == "custom_value"
+
+
+# ---------------------------------------------------------------------------
+# Test: emit_heartbeat creates heartbeat event
+# ---------------------------------------------------------------------------
+
+
+class TestEmitHeartbeat:
+    """Test emit_heartbeat functionality."""
+
+    def test_emit_heartbeat_creates_event(
+        self, observability: WorkerQueueObservability
+    ) -> None:
+        """emit_heartbeat creates heartbeat event."""
+        event = observability.emit_heartbeat(
+            worker_id="hb_worker_001",
+            entry_id="hb_entry_001",
+        )
+
+        assert event.event_type == WorkerQueueEventType.HEARTBEAT
+        assert event.worker_id == "hb_worker_001"
+        assert event.entry_id == "hb_entry_001"
+        assert event.event_id.startswith("evt_")
+
+    def test_emit_heartbeat_tracks_consecutive(
+        self, observability: WorkerQueueObservability
+    ) -> None:
+        """Consecutive heartbeats are tracked."""
+        worker_id = "consecutive_worker"
+
+        observability.emit_heartbeat(worker_id)
+        observability.emit_heartbeat(worker_id)
+        observability.emit_heartbeat(worker_id)
+
+        snapshot = observability.get_heartbeat_snapshot(worker_id)
+        assert snapshot is not None
+        assert snapshot.consecutive_heartbeats == 3
+
+    def test_emit_heartbeat_without_entry(
+        self, observability: WorkerQueueObservability
+    ) -> None:
+        """Heartbeat without entry_id is valid."""
+        event = observability.emit_heartbeat(worker_id="idle_worker")
+
+        assert event.entry_id is None
+        assert event.worker_id == "idle_worker"
+
+
+# ---------------------------------------------------------------------------
+# Test: emit_lease_expired creates lease expiry signal
+# ---------------------------------------------------------------------------
+
+
+class TestEmitLeaseExpired:
+    """Test emit_lease_expired functionality."""
+
+    def test_emit_lease_expired_creates_event(
+        self, observability: WorkerQueueObservability
+    ) -> None:
+        """emit_lease_expired creates lease expiry event."""
+        event = observability.emit_lease_expired(
+            entry_id="expired_entry_001",
+            worker_id="expired_worker_001",
+            reason="Lease timeout",
+        )
+
+        assert event.event_type == WorkerQueueEventType.LEASE_EXPIRED
+        assert event.entry_id == "expired_entry_001"
+        assert event.worker_id == "expired_worker_001"
+
+        # Payload contains LeaseExpirySignal data
+        assert event.payload["reason"] == "Lease timeout"
+        assert event.payload["entry_id"] == "expired_entry_001"
+
+    def test_lease_expiry_signal_serialization(self) -> None:
+        """LeaseExpirySignal serializes correctly."""
+        signal = LeaseExpirySignal(
+            entry_id="sig_entry_001",
+            worker_id="sig_worker_001",
+            reason="Test reason",
+            was_requeued=True,
+            retry_count=2,
+        )
+
+        data = signal.to_dict()
+
+        assert data["entry_id"] == "sig_entry_001"
+        assert data["worker_id"] == "sig_worker_001"
+        assert data["reason"] == "Test reason"
+        assert data["was_requeued"] is True
+        assert data["retry_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Test: Worker availability events
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerAvailabilityEvents:
+    """Test worker availability/unavailability events."""
+
+    def test_emit_worker_available(
+        self, observability: WorkerQueueObservability
+    ) -> None:
+        """emit_worker_available creates availability event."""
+        event = observability.emit_worker_available(
+            worker_id="avail_worker_001",
+            capabilities=["validate", "build"],
+        )
+
+        assert event.event_type == WorkerQueueEventType.WORKER_AVAILABLE
+        assert event.worker_id == "avail_worker_001"
+        assert event.payload["status"] == WorkerAvailabilityStatus.AVAILABLE.value
+        assert "validate" in event.payload["capabilities"]
+        assert "build" in event.payload["capabilities"]
+
+    def test_emit_worker_unavailable(
+        self, observability: WorkerQueueObservability
+    ) -> None:
+        """emit_worker_unavailable creates unavailability event."""
+        event = observability.emit_worker_unavailable(
+            worker_id="unavail_worker_001",
+            reason="Connection lost",
+        )
+
+        assert event.event_type == WorkerQueueEventType.WORKER_UNAVAILABLE
+        assert event.worker_id == "unavail_worker_001"
+        assert event.payload["reason"] == "Connection lost"
+        assert event.payload["status"] == WorkerAvailabilityStatus.OFFLINE.value
+
+    def test_availability_snapshot_serialization(self) -> None:
+        """WorkerAvailabilitySnapshot serializes correctly."""
+        snapshot = WorkerAvailabilitySnapshot(
+            worker_id="snap_worker_001",
+            status=WorkerAvailabilityStatus.BUSY,
+            capabilities=["test"],
+            current_assignment_id="assign_001",
+        )
+
+        data = snapshot.to_dict()
+
+        assert data["worker_id"] == "snap_worker_001"
+        assert data["status"] == "busy"
+        assert data["current_assignment_id"] == "assign_001"
+
+
+# ---------------------------------------------------------------------------
+# Test: snapshot_queue_health reports counts
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotQueueHealth:
+    """Test snapshot_queue_health functionality."""
+
+    def test_snapshot_empty_queue(
+        self,
+        observability: WorkerQueueObservability,
+        queue: SwarmWorkerQueue,
+    ) -> None:
+        """Snapshot of empty queue reports zeros."""
+        snapshot = observability.snapshot_queue_health(queue)
+
+        assert snapshot.total_queued == 0
+        assert snapshot.total_processing == 0
+        assert snapshot.total_completed == 0
+        assert snapshot.total_failed == 0
+        assert snapshot.total_expired == 0
+        assert snapshot.status == QueueHealthStatus.HEALTHY
+
+    def test_snapshot_with_queued_entries(
+        self,
+        observability: WorkerQueueObservability,
+        queue: SwarmWorkerQueue,
+        sample_assignment: StepAssignment,
+    ) -> None:
+        """Snapshot reports queued entry counts."""
+        # Enqueue some entries
+        queue.enqueue_assignment(
+            assignment=sample_assignment,
+            step_action=BuildStepAction.VALIDATE_GENESIS,
+        )
+
+        snapshot = observability.snapshot_queue_health(queue)
+
+        assert snapshot.total_queued == 1
+        assert snapshot.oldest_queued_seconds is not None
+        assert snapshot.oldest_queued_seconds >= 0
+
+    def test_snapshot_health_status_degraded(
+        self,
+        observability: WorkerQueueObservability,
+        queue: SwarmWorkerQueue,
+    ) -> None:
+        """Queue with failed entries is DEGRADED."""
+        # Create a mock entry directly (simulating failed state)
+        from modules.foundups.agent.src.build_plan_swarm_queue import (
+            SwarmWorkerQueueEntry,
+        )
+
+        failed_entry = SwarmWorkerQueueEntry(
+            entry_id="failed_001",
+            assignment_id="assign_failed",
+            step_id="step_failed",
+            step_action=BuildStepAction.RUN_TESTS,
+            required_capability="test",
+            status=QueueEntryStatus.FAILED,
+        )
+        queue._entries[failed_entry.entry_id] = failed_entry
+
+        snapshot = observability.snapshot_queue_health(queue)
+
+        assert snapshot.total_failed == 1
+        assert snapshot.status == QueueHealthStatus.DEGRADED
+
+    def test_snapshot_serialization(
+        self,
+        observability: WorkerQueueObservability,
+        queue: SwarmWorkerQueue,
+    ) -> None:
+        """QueueHealthSnapshot serializes correctly."""
+        snapshot = observability.snapshot_queue_health(queue)
+        data = snapshot.to_dict()
+
+        assert "status" in data
+        assert "total_queued" in data
+        assert "total_processing" in data
+        assert "total_completed" in data
+        assert "total_failed" in data
+        assert "total_expired" in data
+        assert "snapshot_at" in data
+
+
+# ---------------------------------------------------------------------------
+# Test: get_events filters by worker_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetEventsFiltering:
+    """Test get_events filtering functionality."""
+
+    def test_get_events_all(
+        self, observability: WorkerQueueObservability
+    ) -> None:
+        """get_events() without filter returns all events."""
+        observability.emit_heartbeat("worker_a")
+        observability.emit_heartbeat("worker_b")
+        observability.emit_heartbeat("worker_c")
+
+        events = observability.get_events()
+
+        assert len(events) == 3
+
+    def test_get_events_by_worker_id(
+        self, observability: WorkerQueueObservability
+    ) -> None:
+        """get_events(worker_id) filters correctly."""
+        observability.emit_heartbeat("filter_worker_001")
+        observability.emit_heartbeat("filter_worker_002")
+        observability.emit_heartbeat("filter_worker_001")
+        observability.emit_heartbeat("filter_worker_003")
+
+        events = observability.get_events(worker_id="filter_worker_001")
+
+        assert len(events) == 2
+        assert all(e.worker_id == "filter_worker_001" for e in events)
+
+    def test_get_events_no_match(
+        self, observability: WorkerQueueObservability
+    ) -> None:
+        """get_events with no matching worker returns empty list."""
+        observability.emit_heartbeat("existing_worker")
+
+        events = observability.get_events(worker_id="nonexistent_worker")
+
+        assert len(events) == 0
+
+
+# ---------------------------------------------------------------------------
+# Test: Evidence refs preservation
+# ---------------------------------------------------------------------------
+
+
+class TestEvidenceRefsPreservation:
+    """Test that evidence_refs are preserved in events."""
+
+    def test_event_preserves_evidence_refs(
+        self, observability: WorkerQueueObservability
+    ) -> None:
+        """Event evidence_refs are preserved."""
+        evidence = [
+            "evidence/queue/heartbeat_001",
+            "evidence/queue/lease_renewal",
+        ]
+
+        event = WorkerQueueEvent(
+            event_id="evt_evidence_001",
+            event_type=WorkerQueueEventType.ASSIGNMENT_COMPLETED,
+            evidence_refs=evidence,
+        )
+
+        observability.emit_event(event)
+        stored = observability.get_events()[0]
+
+        assert len(stored.evidence_refs) == 2
+        assert "evidence/queue/heartbeat_001" in stored.evidence_refs
+        assert "evidence/queue/lease_renewal" in stored.evidence_refs
+
+    def test_to_dict_includes_evidence_refs(
+        self, observability: WorkerQueueObservability
+    ) -> None:
+        """Event serialization includes evidence_refs."""
+        event = WorkerQueueEvent(
+            event_id="evt_serial_001",
+            event_type=WorkerQueueEventType.HEARTBEAT,
+            evidence_refs=["ref1", "ref2"],
+        )
+
+        data = event.to_dict()
+
+        assert "evidence_refs" in data
+        assert len(data["evidence_refs"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Test: In-memory only observability
+# ---------------------------------------------------------------------------
+
+
+class TestInMemoryObservability:
+    """Test that observability is in-memory only."""
+
+    def test_observability_is_in_memory(
+        self, observability: WorkerQueueObservability
+    ) -> None:
+        """Events are stored in memory only."""
+        observability.emit_heartbeat("memory_worker")
+
+        # Check internal state
+        assert len(observability._events) == 1
+        assert len(observability._worker_heartbeats) == 1
+
+    def test_clear_events_removes_all(
+        self, observability: WorkerQueueObservability
+    ) -> None:
+        """clear_events removes all events."""
+        observability.emit_heartbeat("clear_worker_1")
+        observability.emit_heartbeat("clear_worker_2")
+        observability.emit_heartbeat("clear_worker_3")
+
+        cleared = observability.clear_events()
+
+        assert cleared == 3
+        assert len(observability.get_events()) == 0
+        assert len(observability._worker_heartbeats) == 0
+
+
+# ---------------------------------------------------------------------------
+# Test: No real execution fields
+# ---------------------------------------------------------------------------
+
+
+class TestNoRealExecutionFields:
+    """Test that no real execution fields exist."""
+
+    def test_event_has_no_real_execution_fields(self) -> None:
+        """WorkerQueueEvent has no real_execution_performed field."""
+        event = WorkerQueueEvent(
+            event_id="evt_noexec_001",
+            event_type=WorkerQueueEventType.HEARTBEAT,
+        )
+
+        assert not hasattr(event, "real_execution_performed")
+        assert not hasattr(event, "real_process_started")
+
+        data = event.to_dict()
+        assert "real_execution_performed" not in data
+        assert "real_process_started" not in data
+
+    def test_snapshot_has_no_real_execution_fields(self) -> None:
+        """Snapshots have no real execution fields."""
+        heartbeat = WorkerHeartbeatSnapshot(worker_id="snap_worker")
+        availability = WorkerAvailabilitySnapshot(
+            worker_id="avail_worker",
+            status=WorkerAvailabilityStatus.AVAILABLE,
+        )
+        health = QueueHealthSnapshot(status=QueueHealthStatus.HEALTHY)
+
+        for snapshot in [heartbeat, availability, health]:
+            assert not hasattr(snapshot, "real_execution_performed")
+            data = snapshot.to_dict()
+            assert "real_execution_performed" not in data
+
+
+# ---------------------------------------------------------------------------
+# Test: No CABR/reward/payout/token fields
+# ---------------------------------------------------------------------------
+
+
+class TestNoCABRFields:
+    """Test that no CABR/reward/payout/token fields exist."""
+
+    def test_event_has_no_cabr_fields(self) -> None:
+        """WorkerQueueEvent has no CABR/payout fields."""
+        event = WorkerQueueEvent(
+            event_id="evt_nocabr_001",
+            event_type=WorkerQueueEventType.ASSIGNMENT_COMPLETED,
+        )
+
+        data = event.to_dict()
+
+        assert "cabr_ready" not in data
+        assert "payout_ready" not in data
+        assert "reward" not in data
+        assert "tokens" not in data
+        assert "payout_amount" not in data
+
+    def test_snapshot_has_no_cabr_fields(self) -> None:
+        """Snapshots have no CABR/payout fields."""
+        health = QueueHealthSnapshot(status=QueueHealthStatus.HEALTHY)
+
+        data = health.to_dict()
+
+        assert "cabr_ready" not in data
+        assert "payout_ready" not in data
+        assert "reward" not in data
+        assert "tokens" not in data
+
+    def test_heartbeat_snapshot_has_no_cabr_fields(self) -> None:
+        """WorkerHeartbeatSnapshot has no CABR/payout fields."""
+        snapshot = WorkerHeartbeatSnapshot(worker_id="hb_nocabr")
+
+        data = snapshot.to_dict()
+
+        assert "cabr_ready" not in data
+        assert "payout_ready" not in data
+        assert "reward" not in data
+        assert "tokens" not in data
+
+
+# ---------------------------------------------------------------------------
+# Test: Factory function
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryFunction:
+    """Test factory function."""
+
+    def test_create_worker_queue_observability(self) -> None:
+        """Factory creates valid instance."""
+        obs = create_worker_queue_observability()
+
+        assert isinstance(obs, WorkerQueueObservability)
+        assert len(obs.get_events()) == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Adds WorkerQueueObservability scaffold.
- Adds worker queue event types for heartbeat, lease expiry, worker availability, and queue health.
- Adds in-memory append-only event store for Phase 1.
- Adds queue health snapshots for WSP 91 observability.
- No external telemetry sink yet.
- No RedDog/pfMALL event emission yet.
- Updates INTERFACE.md, ModLog.md, tests/README.md, and tests/TestModLog.md.

## WSP_91 Observability
- logs/events implemented ✓
- metrics snapshots implemented ✓
- traces deferred

## WSP_97 Boundaries
- events are in-memory only
- no real worker process starts
- no real execution performed
- no CABR/reward/payout/token fields
- no external telemetry sink

## Tests
- 28 + 32 + 33 = 93 passed locally

🤖 Generated with [Claude Code](https://claude.ai/code)