### PR TITLE
feat(openclaw): create ImprovementJob from IMPROVEMENT intent

### DIFF
--- a/modules/communication/moltbot_bridge/src/openclaw_execution_routes.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_execution_routes.py
@@ -2,10 +2,21 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
+
+# ImprovementJob contract imports (OC_IMP3)
+from modules.infrastructure.wre_core.src.improvement_job_contract import (
+    ImprovementJob,
+    ImprovementRiskLevel,
+    ImprovementScope,
+    ImprovementType,
+    WSP15Priority,
+    create_improvement_job,
+)
 
 from .openclaw_memory_queries import (
     normalize_time_qualifier,
@@ -862,53 +873,226 @@ def _start_training_batch() -> str:
         return f"**Training Batch: ERROR**\n\nCould not start: {exc}"
 
 
+# ---------------------------------------------------------------------------
+# ImprovementJob Inspection Hook (OC_IMP3)
+# ---------------------------------------------------------------------------
+# Module-level storage for test inspection ONLY.
+# Not a production queue - just allows tests to verify job creation.
+_LAST_IMPROVEMENT_JOB: Optional[ImprovementJob] = None
+
+
+def get_last_improvement_job() -> Optional[ImprovementJob]:
+    """Return the last created ImprovementJob for test inspection.
+
+    WSP 97: This is a test hook only. Not a production queue.
+    """
+    return _LAST_IMPROVEMENT_JOB
+
+
+def clear_improvement_job_hook() -> None:
+    """Clear the inspection hook. For test cleanup."""
+    global _LAST_IMPROVEMENT_JOB
+    _LAST_IMPROVEMENT_JOB = None
+
+
+# ---------------------------------------------------------------------------
+# Improvement Type Classification
+# ---------------------------------------------------------------------------
+
+# Map string improvement types to ImprovementType enum
+_IMPROVEMENT_TYPE_MAP: Dict[str, ImprovementType] = {
+    "fmas_scan": ImprovementType.FMAS_SCAN,
+    "drift_correction": ImprovementType.DRIFT_CORRECTION,
+    "wsp_violation": ImprovementType.WSP_VIOLATION,
+    "test_hygiene": ImprovementType.TEST_HYGIENE,
+    "module_repair": ImprovementType.MODULE_REPAIR,
+    "orphan_connection": ImprovementType.ORPHAN_CONNECTION,
+    "doc_ledger_hygiene": ImprovementType.DOC_LEDGER_HYGIENE,
+    "general": ImprovementType.FMAS_SCAN,  # Default fallback
+}
+
+
+def _classify_improvement_type(msg_lower: str) -> str:
+    """Classify improvement sub-type from message text.
+
+    Returns string key for _IMPROVEMENT_TYPE_MAP.
+
+    Order matters: check specific keywords before generic ones.
+    Priority: fmas > drift > wsp > doc artifacts > test > orphan > module > doc.
+    Doc artifacts (modlog/readme/roadmap) must come before "test" and "module".
+    """
+    if "fmas" in msg_lower:
+        return "fmas_scan"
+    elif "drift" in msg_lower:
+        return "drift_correction"
+    elif "wsp" in msg_lower or "violation" in msg_lower:
+        return "wsp_violation"
+    # Doc artifacts (modlog/readme/roadmap) must come BEFORE "test" and "module"
+    # "update modlog for test module" is doc_ledger_hygiene, not test_hygiene
+    elif "modlog" in msg_lower or "readme" in msg_lower or "roadmap" in msg_lower:
+        return "doc_ledger_hygiene"
+    elif "test" in msg_lower or "stale" in msg_lower:
+        return "test_hygiene"
+    elif "orphan" in msg_lower:
+        return "orphan_connection"
+    elif "repair" in msg_lower or "module" in msg_lower or "cleanup" in msg_lower:
+        return "module_repair"
+    elif "doc" in msg_lower:
+        return "doc_ledger_hygiene"
+    return "general"
+
+
+def _extract_module_path(message: str) -> str:
+    """Extract module path from improvement message if present.
+
+    Looks for patterns like:
+      - modules/domain/module_name
+      - in holo_index
+      - in wre_core
+    """
+    # Try to find explicit module path
+    module_match = re.search(
+        r"(?:modules/[a-z_]+/[a-z_]+|in\s+([a-z_]+))",
+        message.lower(),
+    )
+    if module_match:
+        if module_match.group(0).startswith("modules/"):
+            return module_match.group(0)
+        elif module_match.group(1):
+            # "in module_name" -> try to construct path
+            module_name = module_match.group(1)
+            # Common module locations
+            for domain in ["infrastructure", "communication", "ai_intelligence", "foundups"]:
+                return f"modules/{domain}/{module_name}"
+    return ""
+
+
+def _extract_wsp_refs(message: str) -> List[str]:
+    """Extract WSP references from improvement message."""
+    wsp_refs = []
+    # Match patterns like "WSP 49", "wsp49", "WSP-49"
+    wsp_matches = re.findall(r"wsp[-_\s]?(\d+)", message.lower())
+    for num in wsp_matches:
+        wsp_refs.append(f"WSP {num}")
+    return wsp_refs
+
+
+def _derive_risk_level(improvement_type_str: str, msg_lower: str) -> ImprovementRiskLevel:
+    """Derive risk level from improvement type and message content."""
+    # Security-related keywords -> HIGH
+    if any(kw in msg_lower for kw in ["security", "secret", "credential", "vulnerability"]):
+        return ImprovementRiskLevel.HIGH
+
+    # Documentation-only changes -> LOW
+    if improvement_type_str in ("doc_ledger_hygiene",):
+        return ImprovementRiskLevel.LOW
+
+    # Test hygiene with "stale" -> LOW (just updating tests)
+    if improvement_type_str == "test_hygiene" and "stale" in msg_lower:
+        return ImprovementRiskLevel.LOW
+
+    # Default to MEDIUM for most repairs
+    return ImprovementRiskLevel.MEDIUM
+
+
+def _generate_finding_id(message: str, sender: str) -> str:
+    """Generate deterministic finding ID from message content."""
+    hash_input = f"improvement:{sender}:{message}"
+    return f"imp_intent_{hashlib.sha256(hash_input.encode()).hexdigest()[:12]}"
+
+
 def execute_improvement(dae: Any, intent: Any) -> str:
     """Route IMPROVEMENT intent (codebase self-improvement requests).
 
+    Creates an ImprovementJob with dry_run=True and returns advisory.
+
     WSP 97 Truth Boundary:
       - Classifies the improvement request
-      - Returns advisory acknowledgment
-      - Does NOT execute autonomous repairs (not implemented)
+      - Creates ImprovementJob (dry_run=True, not executed)
+      - Returns advisory with job_id
+      - Does NOT execute autonomous repairs
+      - Does NOT queue for worker dispatch
       - Does NOT claim repair capability exists
 
-    Supported improvement types (classification only):
+    Supported improvement types:
       - WSP violations (fix violation, fix wsp, wsp violation)
       - Module repairs (repair module, duplicate module, module cleanup)
       - Test hygiene (stale test)
       - Code drift (fix drift, codebase improvement)
       - FMAS scans (run fmas repair, fmas scan)
+      - Orphan connections (orphan capability)
+      - Documentation hygiene (modlog, readme)
     """
-    msg_lower = (intent.raw_message or "").lower().strip()
+    global _LAST_IMPROVEMENT_JOB
 
-    # Classify improvement sub-type for routing hints
-    # Order matters: check specific keywords before generic ones
-    improvement_type = "general"
-    if "fmas" in msg_lower:
-        improvement_type = "fmas_scan"
-    elif "drift" in msg_lower:
-        improvement_type = "drift_correction"
-    elif "wsp" in msg_lower or "violation" in msg_lower:
-        improvement_type = "wsp_violation"
-    elif "test" in msg_lower or "stale" in msg_lower:
-        improvement_type = "test_hygiene"
-    elif "repair" in msg_lower or "module" in msg_lower or "cleanup" in msg_lower:
-        improvement_type = "module_repair"
+    msg = intent.raw_message or ""
+    msg_lower = msg.lower().strip()
+    sender = getattr(intent, "sender", "unknown")
+
+    # Classify improvement sub-type
+    improvement_type_str = _classify_improvement_type(msg_lower)
+    improvement_type_enum = _IMPROVEMENT_TYPE_MAP.get(
+        improvement_type_str, ImprovementType.FMAS_SCAN
+    )
+
+    # Extract scope information from message
+    module_path = _extract_module_path(msg)
+    wsp_refs = _extract_wsp_refs(msg)
+
+    # Build scope
+    scope = ImprovementScope(
+        module_path=module_path,
+        wsp_refs=wsp_refs,
+    )
+
+    # Derive risk level
+    risk_level = _derive_risk_level(improvement_type_str, msg_lower)
+
+    # Generate finding ID
+    finding_id = _generate_finding_id(msg, sender)
+
+    # Create ImprovementJob (always dry_run=True)
+    job = create_improvement_job(
+        finding_id=finding_id,
+        improvement_type=improvement_type_enum,
+        scope=scope,
+        risk_level=risk_level,
+        requested_by=sender,
+        payload={
+            "raw_message": msg,
+            "extracted_task": getattr(intent, "extracted_task", ""),
+            "source": "openclaw_improvement_intent",
+        },
+    )
+
+    # Store for test inspection (NOT a production queue)
+    _LAST_IMPROVEMENT_JOB = job
 
     logger.info(
-        "[OPENCLAW-DAE] [IMPROVEMENT] Intent recognized: type=%s task=%s sender=%s",
-        improvement_type,
-        (intent.extracted_task or "")[:50],
-        intent.sender,
+        "[OPENCLAW-DAE] [IMPROVEMENT] ImprovementJob created: "
+        "job_id=%s type=%s risk=%s dry_run=%s sender=%s",
+        job.job_id,
+        improvement_type_enum.value,
+        risk_level.value,
+        job.dry_run,
+        sender,
     )
 
     # WSP 97: Truthful advisory response - no repair execution claims
     return (
         f"**Improvement Intent Recognized**\n\n"
-        f"- **Type**: `{improvement_type}`\n"
+        f"- **Type**: `{improvement_type_str}`\n"
         f"- **Request**: {intent.extracted_task or intent.raw_message}\n\n"
-        f"**Status**: Classified but not executed.\n\n"
-        f"Autonomous codebase repair is not yet implemented. "
-        f"This intent was recognized and logged for future FMAS integration.\n\n"
+        f"**ImprovementJob Created**\n\n"
+        f"- **Job ID**: `{job.job_id}`\n"
+        f"- **Improvement Type**: `{improvement_type_enum.value}`\n"
+        f"- **Risk Level**: `{risk_level.value}`\n"
+        f"- **Dry Run**: `True`\n"
+        f"- **Status**: `{job.status.value}` (created, not executed)\n\n"
+        f"**WSP 97 Truth Boundary**\n\n"
+        f"This job was created but NOT executed. Autonomous codebase repair "
+        f"and worker dispatch are not implemented in this slice. "
+        f"The job exists for future FMAS integration.\n\n"
         f"_WSP 97: AI surfaces improvement needs. Humans decide execution._"
     )
 

--- a/modules/communication/moltbot_bridge/tests/test_openclaw_improvement_intent.py
+++ b/modules/communication/moltbot_bridge/tests/test_openclaw_improvement_intent.py
@@ -250,3 +250,281 @@ class TestImprovementPlanExecution:
         step_actions = [s.get("action") for s in plan.steps]
         assert "improvement_classify" in step_actions
         assert "improvement_route_stub" in step_actions
+
+
+# ---------------------------------------------------------------------------
+# ImprovementJob Creation Tests (OC_IMP3)
+# ---------------------------------------------------------------------------
+
+
+class TestImprovementJobCreation:
+    """Test that execute_improvement creates ImprovementJob."""
+
+    def setup_method(self):
+        """Clear inspection hook before each test."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            clear_improvement_job_hook,
+        )
+        clear_improvement_job_hook()
+
+    def test_improvement_creates_job(self):
+        """execute_improvement creates an ImprovementJob."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+            get_last_improvement_job,
+        )
+
+        intent = MockIntent(
+            raw_message="fix wsp violation in holo_index",
+            extracted_task="fix wsp violation in holo_index",
+            sender="test_user",
+        )
+        execute_improvement(MockDAE(), intent)
+
+        job = get_last_improvement_job()
+        assert job is not None
+        assert job.job_id.startswith("imp_")
+
+    def test_job_has_dry_run_true(self):
+        """Created ImprovementJob always has dry_run=True."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+            get_last_improvement_job,
+        )
+
+        intent = MockIntent(
+            raw_message="repair module wre_core",
+            extracted_task="repair module wre_core",
+        )
+        execute_improvement(MockDAE(), intent)
+
+        job = get_last_improvement_job()
+        assert job is not None
+        assert job.dry_run is True
+
+    def test_job_improvement_type_matches_classification(self):
+        """ImprovementJob.improvement_type matches classification."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+            get_last_improvement_job,
+        )
+        from modules.infrastructure.wre_core.src.improvement_job_contract import (
+            ImprovementType,
+        )
+
+        # Test WSP violation
+        intent = MockIntent(raw_message="fix wsp violation")
+        execute_improvement(MockDAE(), intent)
+        job = get_last_improvement_job()
+        assert job.improvement_type == ImprovementType.WSP_VIOLATION
+
+    def test_job_improvement_type_test_hygiene(self):
+        """Test hygiene keyword creates TEST_HYGIENE job."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+            get_last_improvement_job,
+        )
+        from modules.infrastructure.wre_core.src.improvement_job_contract import (
+            ImprovementType,
+        )
+
+        intent = MockIntent(raw_message="fix stale test in ai_overseer")
+        execute_improvement(MockDAE(), intent)
+        job = get_last_improvement_job()
+        assert job.improvement_type == ImprovementType.TEST_HYGIENE
+
+    def test_job_improvement_type_fmas_scan(self):
+        """FMAS keyword creates FMAS_SCAN job."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+            get_last_improvement_job,
+        )
+        from modules.infrastructure.wre_core.src.improvement_job_contract import (
+            ImprovementType,
+        )
+
+        intent = MockIntent(raw_message="run fmas repair on communication")
+        execute_improvement(MockDAE(), intent)
+        job = get_last_improvement_job()
+        assert job.improvement_type == ImprovementType.FMAS_SCAN
+
+    def test_response_includes_job_id(self):
+        """Response text includes the job_id."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+            get_last_improvement_job,
+        )
+
+        intent = MockIntent(raw_message="fix drift in navigation")
+        result = execute_improvement(MockDAE(), intent)
+
+        job = get_last_improvement_job()
+        assert job is not None
+        assert job.job_id in result
+
+    def test_response_includes_dry_run_true(self):
+        """Response text includes dry_run status."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+        )
+
+        intent = MockIntent(raw_message="repair module test")
+        result = execute_improvement(MockDAE(), intent)
+
+        assert "Dry Run" in result
+        assert "True" in result
+
+    def test_response_includes_wsp97_disclaimer(self):
+        """Response includes WSP 97 truth boundary disclaimer."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+        )
+
+        intent = MockIntent(raw_message="fix wsp violation")
+        result = execute_improvement(MockDAE(), intent)
+
+        assert "WSP 97" in result
+        assert "not executed" in result.lower() or "NOT executed" in result
+
+    def test_no_execution_occurs(self):
+        """Job is created but not executed - status is PENDING."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+            get_last_improvement_job,
+        )
+        from modules.infrastructure.wre_core.src.improvement_job_contract import (
+            ImprovementStatus,
+        )
+
+        intent = MockIntent(raw_message="repair module test")
+        execute_improvement(MockDAE(), intent)
+
+        job = get_last_improvement_job()
+        assert job is not None
+        assert job.status == ImprovementStatus.PENDING
+        assert job.completed_at is None
+        assert job.assigned_worker is None
+
+
+class TestImprovementJobScopeExtraction:
+    """Test scope extraction from improvement messages."""
+
+    def setup_method(self):
+        """Clear inspection hook before each test."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            clear_improvement_job_hook,
+        )
+        clear_improvement_job_hook()
+
+    def test_extracts_wsp_refs(self):
+        """WSP references are extracted to scope.wsp_refs."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+            get_last_improvement_job,
+        )
+
+        intent = MockIntent(raw_message="fix wsp 49 violation in module")
+        execute_improvement(MockDAE(), intent)
+
+        job = get_last_improvement_job()
+        assert "WSP 49" in job.scope.wsp_refs
+
+    def test_extracts_module_path(self):
+        """Module path is extracted from message."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+            get_last_improvement_job,
+        )
+
+        intent = MockIntent(raw_message="repair modules/infrastructure/wre_core")
+        execute_improvement(MockDAE(), intent)
+
+        job = get_last_improvement_job()
+        assert "modules/infrastructure/wre_core" in job.scope.module_path
+
+
+class TestImprovementJobRiskLevel:
+    """Test risk level derivation."""
+
+    def setup_method(self):
+        """Clear inspection hook before each test."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            clear_improvement_job_hook,
+        )
+        clear_improvement_job_hook()
+
+    def test_security_keyword_high_risk(self):
+        """Security-related keywords result in HIGH risk."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+            get_last_improvement_job,
+        )
+        from modules.infrastructure.wre_core.src.improvement_job_contract import (
+            ImprovementRiskLevel,
+        )
+
+        intent = MockIntent(raw_message="fix security vulnerability")
+        execute_improvement(MockDAE(), intent)
+
+        job = get_last_improvement_job()
+        assert job.risk_level == ImprovementRiskLevel.HIGH
+
+    def test_doc_hygiene_low_risk(self):
+        """Documentation hygiene is LOW risk."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+            get_last_improvement_job,
+        )
+        from modules.infrastructure.wre_core.src.improvement_job_contract import (
+            ImprovementRiskLevel,
+        )
+
+        intent = MockIntent(raw_message="update modlog for test module")
+        execute_improvement(MockDAE(), intent)
+
+        job = get_last_improvement_job()
+        assert job.risk_level == ImprovementRiskLevel.LOW
+
+
+class TestImprovementAdvisoryTextWSP97:
+    """Test WSP 97 compliance in advisory text."""
+
+    def test_advisory_no_execution_claim(self):
+        """Advisory does not claim repair was executed."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+        )
+
+        intent = MockIntent(raw_message="repair module test")
+        result = execute_improvement(MockDAE(), intent)
+
+        # Should NOT contain claims of execution
+        assert "executed repair" not in result.lower()
+        assert "fixed" not in result.lower()
+        assert "repaired" not in result.lower()
+
+        # Should contain disclaimer
+        assert "not implemented" in result.lower() or "NOT executed" in result
+
+    def test_advisory_states_job_created(self):
+        """Advisory states job was created."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+        )
+
+        intent = MockIntent(raw_message="fix wsp violation")
+        result = execute_improvement(MockDAE(), intent)
+
+        assert "ImprovementJob Created" in result
+        assert "Job ID" in result
+
+    def test_advisory_includes_status_pending(self):
+        """Advisory shows status as created/pending."""
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            execute_improvement,
+        )
+
+        intent = MockIntent(raw_message="repair module")
+        result = execute_improvement(MockDAE(), intent)
+
+        assert "pending" in result.lower() or "created" in result.lower()


### PR DESCRIPTION
## Summary
- Adds ImprovementJob creation from IMPROVEMENT intent in OpenClaw execution routes.
- Wires to ImprovementJobContract and FMASImprovementBridge infrastructure (OC_IMP1, OC_IMP2).
- dry_run=True default - no real execution.

## WSP_97 Boundaries
- ImprovementJob creation only
- No repair execution
- No worker dispatch
- No production queue
- No CABR/reward/payout/token fields

## Tests
- test_openclaw_improvement_intent.py: 27 passed
- test_fmas_improvement_bridge.py: 32 passed
- test_improvement_job_contract.py: 36 passed
- Total: 95 passed

🤖 Generated with [Claude Code](https://claude.ai/code)