### PR TITLE
feat(wre): bind receipt and pAVS evidence into FoundUpJobConsumer

### DIFF
--- a/modules/communication/moltbot_bridge/src/receipt_emitter.py
+++ b/modules/communication/moltbot_bridge/src/receipt_emitter.py
@@ -96,12 +96,15 @@ def _is_terminal_job(job: Any) -> bool:
         # Import here to avoid circular deps
         from modules.communication.moltbot_bridge.src.foundup_job_contract import (
             is_terminal_status,
+            JobStatus,
         )
 
         status = getattr(job, "status", None)
         if status is None:
             return False
-        return is_terminal_status(status)
+        # is_terminal_status only includes SUCCEEDED/FAILED
+        # BLOCKED is also terminal for receipt emission purposes
+        return is_terminal_status(status) or status == JobStatus.BLOCKED
     except ImportError:
         # Fallback: check by status value
         status = getattr(job, "status", None)

--- a/modules/infrastructure/wre_core/src/foundup_job_consumer.py
+++ b/modules/infrastructure/wre_core/src/foundup_job_consumer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-WRE FoundUpJob Consumer — Phase 1A Consumer Seam
+WRE FoundUpJob Consumer — Phase 1B Consumer Seam with Receipt Binding
 
 Drains FoundUpJobs through the WRE routing pipeline without making
 OpenClaw call Hermes directly. All dispatch goes through RouteEnvelope.
@@ -8,9 +8,13 @@ OpenClaw call Hermes directly. All dispatch goes through RouteEnvelope.
 Architecture:
   OpenClaw -> FoundUpJob (QUEUED) -> WRE Router -> RouteEnvelope
            -> This Consumer -> Hermes Executor (if routed)
-           -> Terminal Job -> Receipt Emitter
+           -> Terminal Job -> Receipt Emitter -> pAVS Verification
+           -> ConsumerResult (contains entire closed-loop evidence)
 
-This is Phase 1A: synchronous drain only, no daemon loop.
+Phase 1B Enhancement:
+  - ConsumerResult now carries receipt emission and pAVS verification
+  - One ConsumerResult contains the complete closed-loop evidence chain
+  - No need for callers to manually call receipt/pAVS APIs
 
 WSP Compliance:
   WSP 11  : Interface contract (typed dispatch)
@@ -21,6 +25,7 @@ WSP Compliance:
 NAVIGATION:
   -> Uses: foundup_job_router.py (route_foundup_job, RouteEnvelope)
   -> Uses: hermes_foundup_job_executor.py (execute_foundup_job)
+  -> Uses: receipt_emitter.py (emit_receipt_for_terminal_job)
   -> Uses: openclaw_foundup_orchestrator.py (get_job_queue, clear_job_queue)
   -> Called by: WRE gateway, manual drain commands
 """
@@ -30,7 +35,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterable, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
 
 from .foundup_job_router import (
     RouteEnvelope,
@@ -38,6 +43,11 @@ from .foundup_job_router import (
     TargetBackend,
     route_foundup_job,
 )
+
+if TYPE_CHECKING:
+    from modules.communication.moltbot_bridge.src.receipt_emitter import (
+        ReceiptEmissionResult,
+    )
 
 logger = logging.getLogger("wre_foundup_job_consumer")
 
@@ -57,8 +67,19 @@ class ConsumerResult:
     """
     Result container for a single job consumption.
 
-    Wraps the HermesJobExecutionResult (if dispatched) or records
-    why the job was not dispatched.
+    Phase 1B: Contains the complete closed-loop evidence chain:
+      - Routing decision (envelope)
+      - Hermes execution result (if dispatched)
+      - Receipt emission result (if terminal)
+      - pAVS verification result (via emission result)
+
+    One ConsumerResult contains everything needed to audit the
+    entire dry-run closed loop without manual API calls.
+
+    WSP 97 Truth Boundaries:
+      - receipt_emission.verification.verification_complete = False
+      - receipt_emission.verification.cabr_ready = False
+      - receipt_emission.verification.payout_ready = False
     """
 
     job_id: str
@@ -82,19 +103,77 @@ class ConsumerResult:
     envelope: Optional[RouteEnvelope] = None
     """RouteEnvelope from routing decision."""
 
+    receipt_emission: Optional["ReceiptEmissionResult"] = None
+    """
+    Receipt emission result (if job reached terminal state).
+
+    Contains:
+      - receipt: ProofOfComputeReceipt with evidence_refs
+      - verification: PAVSVerificationResult with truth fields
+
+    None if job did not reach terminal state or was not dispatched.
+    """
+
     consumed_at: datetime = field(default_factory=_utc_now)
     """Timestamp when consumption completed."""
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize to dict for logging/JSON."""
-        return {
+        result = {
             "job_id": self.job_id,
             "dispatched": self.dispatched,
             "route_status": self.route_status.value,
             "target_backend": self.target_backend.value,
             "reason": self.reason,
             "consumed_at": self.consumed_at.isoformat(),
+            "receipt_emitted": self.receipt_emission is not None and self.receipt_emission.success,
         }
+        # Include pAVS truth fields if available
+        if self.receipt_emission and self.receipt_emission.verification:
+            v = self.receipt_emission.verification
+            result["verification_complete"] = v.verification_complete
+            result["cabr_ready"] = v.cabr_ready
+            result["payout_ready"] = v.payout_ready
+        return result
+
+    @property
+    def is_terminal(self) -> bool:
+        """True if job reached terminal state."""
+        if self.hermes_result is None:
+            return False
+        job = getattr(self.hermes_result, "job", None)
+        if job is None:
+            return False
+        status = getattr(job, "status", None)
+        if status is None:
+            return False
+        return status.value in ("succeeded", "failed", "blocked")
+
+    @property
+    def has_receipt(self) -> bool:
+        """True if receipt was emitted."""
+        return self.receipt_emission is not None and self.receipt_emission.success
+
+    @property
+    def verification_complete(self) -> bool:
+        """WSP 97: Always False - never claim final verification."""
+        if self.receipt_emission and self.receipt_emission.verification:
+            return self.receipt_emission.verification.verification_complete
+        return False
+
+    @property
+    def cabr_ready(self) -> bool:
+        """WSP 97: Always False - no CABR consensus exists."""
+        if self.receipt_emission and self.receipt_emission.verification:
+            return self.receipt_emission.verification.cabr_ready
+        return False
+
+    @property
+    def payout_ready(self) -> bool:
+        """WSP 97: Always False - no payout engine exists."""
+        if self.receipt_emission and self.receipt_emission.verification:
+            return self.receipt_emission.verification.payout_ready
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -219,16 +298,25 @@ class FoundUpJobConsumer:
             )
 
             dispatched = True
+            job_status = hermes_result.job.status.value
             reason = (
                 f"Dispatched to {envelope.target_backend.value}; "
-                f"job_status={hermes_result.job.status.value}"
+                f"job_status={job_status}"
             )
 
             logger.info(
                 "[CONSUMER] Job %s completed: status=%s",
                 job_id,
-                hermes_result.job.status.value,
+                job_status,
             )
+
+            # Phase 1B: Emit receipt if job is terminal
+            receipt_emission = self._emit_receipt_if_terminal(hermes_result.job, job_id)
+            if receipt_emission:
+                if receipt_emission.success:
+                    reason += f"; receipt={receipt_emission.receipt.receipt_id}"
+                else:
+                    reason += f"; receipt_error={receipt_emission.error}"
 
             return ConsumerResult(
                 job_id=job_id,
@@ -238,6 +326,7 @@ class FoundUpJobConsumer:
                 reason=reason,
                 hermes_result=hermes_result,
                 envelope=envelope,
+                receipt_emission=receipt_emission,
             )
 
         except ImportError as e:
@@ -261,6 +350,71 @@ class FoundUpJobConsumer:
                 reason=f"Hermes dispatch exception: {e}",
                 envelope=envelope,
             )
+
+    def _emit_receipt_if_terminal(
+        self, job: Any, job_id: str
+    ) -> Optional["ReceiptEmissionResult"]:
+        """
+        Emit receipt and run pAVS verification if job is terminal.
+
+        Args:
+            job: The FoundUpJob after Hermes execution.
+            job_id: Job identifier for logging.
+
+        Returns:
+            ReceiptEmissionResult if job is terminal, None otherwise.
+
+        WSP 97 truth:
+            - Only terminal jobs emit receipts
+            - verification_complete=False always
+            - cabr_ready=False always
+            - payout_ready=False always
+        """
+        # Check if job is terminal
+        status = getattr(job, "status", None)
+        if status is None:
+            return None
+
+        status_value = status.value if hasattr(status, "value") else str(status)
+        if status_value.lower() not in ("succeeded", "failed", "blocked"):
+            logger.debug("[CONSUMER] Job %s not terminal (%s), skipping receipt", job_id, status_value)
+            return None
+
+        # Import receipt emitter
+        try:
+            from modules.communication.moltbot_bridge.src.receipt_emitter import (
+                emit_receipt_for_terminal_job,
+                ReceiptEmissionResult,
+            )
+        except ImportError as e:
+            logger.error("[CONSUMER] Receipt emitter not available: %s", e)
+            # Return a failure result without importing the class
+            return None
+
+        # Emit receipt (includes pAVS verification)
+        try:
+            emission_result = emit_receipt_for_terminal_job(job)
+
+            if emission_result.success:
+                logger.info(
+                    "[CONSUMER] Receipt emitted for job %s: receipt=%s decision=%s",
+                    job_id,
+                    emission_result.receipt.receipt_id,
+                    emission_result.verification.decision.value if emission_result.verification else "N/A",
+                )
+            else:
+                logger.warning(
+                    "[CONSUMER] Receipt emission failed for job %s: %s",
+                    job_id,
+                    emission_result.error,
+                )
+
+            return emission_result
+
+        except Exception as e:
+            logger.exception("[CONSUMER] Receipt emission exception for job %s: %s", job_id, e)
+            # Return None rather than constructing a partial result
+            return None
 
     def drain_jobs(self, jobs: Iterable[Any]) -> List[ConsumerResult]:
         """

--- a/modules/infrastructure/wre_core/tests/test_foundup_job_consumer.py
+++ b/modules/infrastructure/wre_core/tests/test_foundup_job_consumer.py
@@ -539,3 +539,324 @@ class TestGetConsumer:
         """get_consumer with dry_run=False."""
         consumer = get_consumer(dry_run=False)
         assert consumer.dry_run is False
+
+
+# ---------------------------------------------------------------------------
+# Test: Phase 1B Receipt/pAVS Binding in ConsumerResult
+# ---------------------------------------------------------------------------
+
+
+class TestConsumerResultReceiptBinding:
+    """
+    Test Phase 1B: ConsumerResult carries receipt and pAVS evidence.
+
+    Proves:
+      - One ConsumerResult contains complete closed-loop evidence
+      - No need to manually call receipt/pAVS APIs
+      - WSP 97 truth fields preserved
+    """
+
+    @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
+    @patch("modules.foundups.agent.src.hermes_adapter.HermesFoundUpBuilder")
+    def test_terminal_job_emits_receipt_in_consumer_result(
+        self, mock_builder_class, mock_route
+    ):
+        """
+        Terminal job includes receipt_emission in ConsumerResult.
+
+        Proves:
+          - ConsumerResult.receipt_emission is populated
+          - No manual create_receipt_from_job() or verify_receipt() calls
+          - Receipt contains job correlation
+        """
+        from modules.communication.moltbot_bridge.src.foundup_job_contract import (
+            create_job,
+        )
+
+        # Setup routing
+        mock_envelope = MagicMock()
+        mock_envelope.route_status = RouteStatus.ROUTED
+        mock_envelope.target_backend = TargetBackend.HERMES_BUILDER
+        mock_envelope.reason_human = "Routed to hermes_builder"
+        mock_envelope.job_id = "job_terminal_receipt"
+        mock_route.return_value = mock_envelope
+
+        # Setup Hermes success result
+        mock_builder = MagicMock()
+        mock_builder.dry_run = True
+        mock_builder.extract_foundup.return_value = {
+            "success": True,
+            "source_module": "modules/foundups/test_module",
+            "target_repo": "FOUNDUPS/test_module",
+            "exfoliation_gate": {"passed": True, "checks": {}},
+            "dry_run": True,
+        }
+        mock_builder_class.return_value = mock_builder
+
+        # Create job with proper payload
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="test_module",
+            payload={"module_path": "modules/foundups/test_module"},
+        )
+
+        consumer = FoundUpJobConsumer(dry_run=True)
+        result = consumer.consume_one(job)
+
+        # Verify dispatch succeeded
+        assert result.dispatched is True
+        assert result.is_terminal is True
+
+        # Verify receipt is bound in ConsumerResult
+        assert result.receipt_emission is not None
+        assert result.receipt_emission.success is True
+        assert result.has_receipt is True
+
+        # Verify receipt correlates to job
+        receipt = result.receipt_emission.receipt
+        assert receipt is not None
+        assert receipt.job_id == job.job_id
+        assert receipt.tenant_id == job.tenant_id
+
+        # Verify pAVS verification is included
+        verification = result.receipt_emission.verification
+        assert verification is not None
+        assert verification.job_id == job.job_id
+
+    @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
+    @patch("modules.foundups.agent.src.hermes_adapter.HermesFoundUpBuilder")
+    def test_consumer_result_contains_wsp97_truth_fields(
+        self, mock_builder_class, mock_route
+    ):
+        """
+        ConsumerResult exposes WSP 97 truth fields.
+
+        Proves:
+          - verification_complete=False
+          - cabr_ready=False
+          - payout_ready=False
+        """
+        from modules.communication.moltbot_bridge.src.foundup_job_contract import (
+            create_job,
+        )
+
+        mock_envelope = MagicMock()
+        mock_envelope.route_status = RouteStatus.ROUTED
+        mock_envelope.target_backend = TargetBackend.HERMES_BUILDER
+        mock_envelope.reason_human = "Routed"
+        mock_envelope.job_id = "job_wsp97"
+        mock_route.return_value = mock_envelope
+
+        mock_builder = MagicMock()
+        mock_builder.dry_run = True
+        mock_builder.extract_foundup.return_value = {
+            "success": True,
+            "source_module": "modules/foundups/wsp97_test",
+            "exfoliation_gate": {"passed": True, "checks": {}},
+            "dry_run": True,
+        }
+        mock_builder_class.return_value = mock_builder
+
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            payload={"module_path": "modules/foundups/wsp97_test"},
+        )
+
+        consumer = FoundUpJobConsumer(dry_run=True)
+        result = consumer.consume_one(job)
+
+        # WSP 97 truth fields via ConsumerResult properties
+        assert result.verification_complete is False
+        assert result.cabr_ready is False
+        assert result.payout_ready is False
+
+        # WSP 97 truth fields in to_dict()
+        result_dict = result.to_dict()
+        assert result_dict["verification_complete"] is False
+        assert result_dict["cabr_ready"] is False
+        assert result_dict["payout_ready"] is False
+        assert result_dict["receipt_emitted"] is True
+
+    @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
+    def test_non_terminal_job_no_receipt_emission(self, mock_route):
+        """
+        Non-terminal job does not emit receipt.
+
+        Proves:
+          - Blocked route -> no Hermes dispatch -> no receipt
+          - ConsumerResult.receipt_emission is None
+        """
+        mock_envelope = MagicMock()
+        mock_envelope.route_status = RouteStatus.BLOCKED
+        mock_envelope.target_backend = TargetBackend.NONE
+        mock_envelope.reason_human = "Blocked by security gate"
+        mock_envelope.job_id = "job_blocked_no_receipt"
+        mock_route.return_value = mock_envelope
+
+        job = MockFoundUpJob(
+            job_id="job_blocked_no_receipt",
+            tenant_id="tenant_test",
+            requested_action="build_foundup",
+        )
+
+        consumer = FoundUpJobConsumer(dry_run=True)
+        result = consumer.consume_one(job)
+
+        # Not dispatched, no receipt
+        assert result.dispatched is False
+        assert result.receipt_emission is None
+        assert result.has_receipt is False
+        assert result.is_terminal is False
+
+    @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
+    @patch("modules.foundups.agent.src.hermes_adapter.HermesFoundUpBuilder")
+    def test_closed_loop_dry_run_proof_single_result(
+        self, mock_builder_class, mock_route
+    ):
+        """
+        One ConsumerResult proves closed-loop dry-run execution.
+
+        Proves:
+          - Route -> Hermes -> Receipt -> pAVS all in one result
+          - Test body does NOT manually call create_receipt_from_job()
+          - Test body does NOT manually call verify_receipt()
+          - All evidence accessible from ConsumerResult
+        """
+        from modules.communication.moltbot_bridge.src.foundup_job_contract import (
+            create_job,
+        )
+
+        # Setup full pipeline
+        mock_envelope = MagicMock()
+        mock_envelope.route_status = RouteStatus.ROUTED
+        mock_envelope.target_backend = TargetBackend.HERMES_BUILDER
+        mock_envelope.reason_human = "Routed to hermes_builder"
+        mock_envelope.job_id = "job_closed_loop"
+        mock_route.return_value = mock_envelope
+
+        mock_builder = MagicMock()
+        mock_builder.dry_run = True
+        mock_builder.extract_foundup.return_value = {
+            "success": True,
+            "source_module": "modules/foundups/closed_loop_test",
+            "target_repo": "FOUNDUPS/closed_loop_test",
+            "exfoliation_gate": {"passed": True, "checks": {}},
+            "adapters": {"adapters_created": ["adapter.py"]},
+            "dry_run": True,
+        }
+        mock_builder_class.return_value = mock_builder
+
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="closed_loop_test",
+            payload={"module_path": "modules/foundups/closed_loop_test"},
+        )
+
+        consumer = FoundUpJobConsumer(dry_run=True)
+        result = consumer.consume_one(job)
+
+        # === Closed-loop evidence in ONE ConsumerResult ===
+
+        # 1. Route evidence
+        assert result.route_status == RouteStatus.ROUTED
+        assert result.target_backend == TargetBackend.HERMES_BUILDER
+        assert result.envelope is not None
+
+        # 2. Hermes evidence
+        assert result.dispatched is True
+        assert result.hermes_result is not None
+        assert result.hermes_result.job.status.value == "succeeded"
+        assert result.hermes_result.job.policy_flags.dry_run_mode is True
+
+        # 3. Receipt evidence (NOT manually calling create_receipt_from_job)
+        assert result.has_receipt is True
+        assert result.receipt_emission.success is True
+        receipt = result.receipt_emission.receipt
+        assert receipt.job_id == job.job_id
+        assert receipt.foundup_id == "closed_loop_test"
+        assert len(receipt.evidence_refs) > 0
+
+        # 4. pAVS evidence (NOT manually calling verify_receipt)
+        verification = result.receipt_emission.verification
+        assert verification is not None
+        assert verification.receipt_id == receipt.receipt_id
+        assert verification.job_id == job.job_id
+
+        # 5. WSP 97 truth boundaries
+        assert result.verification_complete is False
+        assert result.cabr_ready is False
+        assert result.payout_ready is False
+
+    @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
+    @patch("modules.foundups.agent.src.hermes_adapter.HermesFoundUpBuilder")
+    def test_blocked_hermes_result_still_emits_receipt(
+        self, mock_builder_class, mock_route
+    ):
+        """
+        Blocked Hermes result (terminal) still emits receipt.
+
+        Proves:
+          - BLOCKED job is terminal
+          - Receipt is emitted with BLOCKED status
+          - pAVS decision is BLOCKED_UPSTREAM
+        """
+        from modules.communication.moltbot_bridge.src.foundup_job_contract import (
+            create_job,
+        )
+        from modules.communication.moltbot_bridge.src.pavs_verification_seam import (
+            PAVSDecision,
+        )
+        from modules.communication.moltbot_bridge.src.proof_of_compute_receipt import (
+            VerificationStatus,
+        )
+
+        mock_envelope = MagicMock()
+        mock_envelope.route_status = RouteStatus.ROUTED
+        mock_envelope.target_backend = TargetBackend.HERMES_BUILDER
+        mock_envelope.reason_human = "Routed"
+        mock_envelope.job_id = "job_hermes_blocked"
+        mock_route.return_value = mock_envelope
+
+        mock_builder = MagicMock()
+        mock_builder.dry_run = True
+        mock_builder.extract_foundup.return_value = {
+            "success": False,
+            "error": "exfoliation_gate_failed",
+            "source_module": "modules/foundups/blocked_test",
+            "exfoliation_gate": {
+                "passed": False,
+                "checks": {"contracts_explicit": False},
+            },
+            "dry_run": True,
+        }
+        mock_builder_class.return_value = mock_builder
+
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            payload={"module_path": "modules/foundups/blocked_test"},
+        )
+
+        consumer = FoundUpJobConsumer(dry_run=True)
+        result = consumer.consume_one(job)
+
+        # BLOCKED is terminal
+        assert result.is_terminal is True
+        assert result.hermes_result.job.status.value == "blocked"
+
+        # Receipt emitted for blocked job
+        assert result.has_receipt is True
+        receipt = result.receipt_emission.receipt
+        assert receipt.verification_status == VerificationStatus.BLOCKED
+
+        # pAVS reflects blocked upstream
+        verification = result.receipt_emission.verification
+        assert verification.decision == PAVSDecision.BLOCKED_UPSTREAM
+
+        # WSP 97 still enforced
+        assert result.verification_complete is False
+        assert result.cabr_ready is False
+        assert result.payout_ready is False


### PR DESCRIPTION
## Summary
- ConsumerResult now carries receipt_emission field.
- ConsumerResult exposes WSP_97 truth properties:
  - verification_complete=False
  - cabr_ready=False
  - payout_ready=False
- FoundUpJobConsumer emits receipt/pAVS evidence for terminal jobs.
- Tests prove Route → Hermes → Receipt → pAVS in one ConsumerResult.

## WSP_97 Boundaries
- No HoloIndex files
- No CLI/command entrypoint
- No daemon loop
- No real worker swarm
- No real build mutation
- No RedDog/pfMALL changes
- No CABR/reward/payout/token claims

## Tests
- test_foundup_job_consumer.py: 21 passed
- test_e2e_foundup_job_seam.py: 11 passed
- test_internal_voteballot_build_poc.py: 33 passed
- Total: 65 passed

🤖 Generated with [Claude Code](https://claude.ai/code)