### PR TITLE
test(holoindex): expand search quality sentinel baseline to 38 queries

### DIFF
--- a/docs/audits/holoindex_search_quality/HIA7B_PRIORITY_ROOT_INDEXING_FIX_REPORT.md
+++ b/docs/audits/holoindex_search_quality/HIA7B_PRIORITY_ROOT_INDEXING_FIX_REPORT.md
@@ -1,0 +1,151 @@
+# HIA7B: Priority Root Indexing Gap Fix Report
+
+**Date**: 2026-05-02
+**Status**: COMPLETE
+**Branch**: feat/hia7-sentinel-expansion-gate
+
+## Summary
+
+Added priority indexing roots to ensure target files are indexed. Files are now
+indexed and discoverable, but semantic drift causes ranking issues that require
+separate tuning (HIA8).
+
+## Changes Made
+
+Added 3 priority roots to `indexing_engine.py`:
+
+```python
+roots = roots or [
+    holo.project_root / "holo_index" / "core",                      # P1: existing
+    holo.project_root / "modules" / "infrastructure" / "wre_core" / "src",  # P1: existing
+    holo.project_root / "holo_index" / "qwen_advisor",              # P1: HIA7B NEW
+    holo.project_root / "modules" / "development" / "ide_foundups" / "src",  # P1: HIA7B NEW
+    holo.project_root / "modules" / "foundups" / "agent" / "src",   # P1: HIA7B NEW
+    holo.project_root / "modules",                                  # P2: bulk
+    # ...
+]
+```
+
+## Indexing Verification
+
+All target files are now indexed and discoverable:
+
+| Target File | Direct Query | Top-1 Result | Similarity |
+|-------------|--------------|--------------|------------|
+| wre_bridge.py | "wre_bridge" | wre_bridge.py | 57.2% |
+| build_plan.py | "build_plan" | build_plan.py | 55.9% |
+| orphan_batch_analyzer.py | "orphan batch analyzer" | orphan_batch_analyzer.py | 66.4% |
+
+**Indexing gap: FIXED**
+
+## Baseline Results
+
+| Metric | HIA7 (Before) | HIA7B (After) | Delta |
+|--------|---------------|---------------|-------|
+| Top-1 Pass Rate | 86.8% (33/38) | 84.2% (32/38) | -2.6% |
+| Top-5 Pass Rate | 92.1% (35/38) | 92.1% (35/38) | 0.0% |
+
+Note: Top-1 decreased by 1 query due to index rebalancing affecting "WRE master orchestrator"
+query (performance_orchestrator.py now ranked higher than wre_master_orchestrator.py).
+
+## Failure Analysis (Post-Fix)
+
+### Top-1 Failures (6 queries)
+
+| Query | Got | Expected | Root Cause |
+|-------|-----|----------|------------|
+| backend routing turboquant embedding | turboquant_backend.py | backend_routing | Semantic drift |
+| WRE master orchestrator coordination | performance_orchestrator.py | wre_master_orchestrator | Semantic drift (new) |
+| WRE bridge integration cursor | integrate_with_wre.py | wre_bridge | Semantic drift: "integration" boosts wrong file |
+| build plan generator hermes | hermes_adapter.py | build_plan | Semantic drift: "hermes" boosts wrong file |
+| pfmall catalog verification | test file | pfmall_catalog | Test file ranked higher |
+| orphan capability scanner detection | security_scanner.py | orphan | Semantic drift: "scanner" boosts wrong file |
+
+### Top-5 Failures (3 queries)
+
+| Query | Root Cause |
+|-------|------------|
+| WRE master orchestrator coordination | File exists but semantic drift |
+| WRE bridge integration cursor | File exists but semantic drift |
+| build plan generator hermes | File exists but semantic drift |
+
+### Root Cause Distribution
+
+| Root Cause | HIA7 Count | HIA7B Count | Status |
+|------------|------------|-------------|--------|
+| Indexing gap | 3 | 0 | **FIXED** |
+| Semantic drift | 2 | 6 | **Increased** (more visible now) |
+
+## Key Insight
+
+The indexing fix was successful: target files are now indexed and appear in top-5
+results for direct queries. However, the sentinel queries use natural language
+that causes semantic drift:
+
+- Query "WRE bridge integration cursor" → "integration" matches integrate_with_wre.py better
+- Query "build plan generator hermes" → "hermes" matches hermes_adapter.py better
+- Query "orphan capability scanner detection" → "scanner" matches security_scanner.py better
+
+This is **not an indexing problem** but a **semantic ranking problem** that requires:
+1. Query-specific keyword boosting, or
+2. LLM-based reranking (HIA8), or
+3. Adjusting evidence rules to accept semantic equivalents
+
+## Gate Evaluation
+
+**Gate Criteria**: Top-5 >= 95% AND Top-1 >= 85%
+
+| Metric | Required | Actual | Status |
+|--------|----------|--------|--------|
+| Top-1 Pass Rate | >= 85% | 84.2% | **FAIL** |
+| Top-5 Pass Rate | >= 95% | 92.1% | **FAIL** |
+
+**Gate Result**: NOT PASSED
+
+## Files Changed
+
+1. `holo_index/core/indexing_engine.py`:
+   - Added 3 priority roots for HIA7B sentinel coverage
+
+2. `docs/audits/holoindex_search_quality/hia3_baseline_metrics.json`:
+   - Regenerated with 38-query baseline after re-indexing
+
+3. `docs/audits/holoindex_search_quality/HIA7B_PRIORITY_ROOT_INDEXING_FIX_REPORT.md`:
+   - This report
+
+## Recommendations
+
+### Option A: Proceed to HIA8 (LLM Reranking)
+
+Accept that deterministic ranking has limits. Use Gemma/LLM to rerank top-10
+results based on intent matching. This is the recommended path per the HIA series.
+
+### Option B: Keyword Boosting Tuning
+
+Add query-specific keyword detection to boost exact file name matches:
+- Query contains "wre_bridge" → boost files with "wre_bridge" in path
+- Query contains "build_plan" → boost files with "build_plan" in path
+
+This is deterministic but requires maintaining keyword mappings.
+
+### Option C: Evidence Rule Relaxation
+
+Accept semantic equivalents in evidence rules:
+- "wre_bridge" OR "integrate_with_wre" (same module)
+- "build_plan" OR "hermes" (same domain)
+
+Not recommended: weakens quality signal.
+
+## Next Steps
+
+1. **HIA8**: Evaluate LLM reranking for semantic drift correction
+2. Consider whether 84.2%/92.1% is acceptable baseline before LLM layer
+3. If LLM reranking is deferred, tune keyword boosting for high-value queries
+
+## WSP 97 Compliance
+
+Results reported truthfully:
+- Indexing gap fixed (verified with direct queries)
+- Semantic drift identified as separate root cause
+- Gate not passed, documented why
+- No overclaiming - improvements are incremental

--- a/docs/audits/holoindex_search_quality/HIA7B_PRIORITY_ROOT_INDEXING_FIX_REPORT.md
+++ b/docs/audits/holoindex_search_quality/HIA7B_PRIORITY_ROOT_INDEXING_FIX_REPORT.md
@@ -1,151 +1,99 @@
 # HIA7B: Priority Root Indexing Gap Fix Report
 
 **Date**: 2026-05-02
-**Status**: COMPLETE
+**Status**: COMPLETE - NOT PROMOTED
 **Branch**: feat/hia7-sentinel-expansion-gate
+**Decision**: Path A - Code reverted, audit preserved
 
 ## Summary
 
-Added priority indexing roots to ensure target files are indexed. Files are now
-indexed and discoverable, but semantic drift causes ranking issues that require
-separate tuning (HIA8).
+Investigated adding priority indexing roots to fix indexing gaps identified in HIA7.
+The change improved direct file discoverability but caused a regression in sentinel
+query pass rates. **Code reverted. Change not promoted.**
 
-## Changes Made
+## Experiment
 
-Added 3 priority roots to `indexing_engine.py`:
+### Hypothesis
 
-```python
-roots = roots or [
-    holo.project_root / "holo_index" / "core",                      # P1: existing
-    holo.project_root / "modules" / "infrastructure" / "wre_core" / "src",  # P1: existing
-    holo.project_root / "holo_index" / "qwen_advisor",              # P1: HIA7B NEW
-    holo.project_root / "modules" / "development" / "ide_foundups" / "src",  # P1: HIA7B NEW
-    holo.project_root / "modules" / "foundups" / "agent" / "src",   # P1: HIA7B NEW
-    holo.project_root / "modules",                                  # P2: bulk
-    # ...
-]
-```
+Adding priority roots for missing files would improve sentinel query pass rates:
+- `holo_index/qwen_advisor/` (orphan analyzers)
+- `modules/development/ide_foundups/src/` (wre_bridge.py)
+- `modules/foundups/agent/src/` (build_plan.py)
 
-## Indexing Verification
-
-All target files are now indexed and discoverable:
-
-| Target File | Direct Query | Top-1 Result | Similarity |
-|-------------|--------------|--------------|------------|
-| wre_bridge.py | "wre_bridge" | wre_bridge.py | 57.2% |
-| build_plan.py | "build_plan" | build_plan.py | 55.9% |
-| orphan_batch_analyzer.py | "orphan batch analyzer" | orphan_batch_analyzer.py | 66.4% |
-
-**Indexing gap: FIXED**
-
-## Baseline Results
+### Results
 
 | Metric | HIA7 (Before) | HIA7B (After) | Delta |
 |--------|---------------|---------------|-------|
-| Top-1 Pass Rate | 86.8% (33/38) | 84.2% (32/38) | -2.6% |
+| Top-1 Pass Rate | 86.8% (33/38) | 84.2% (32/38) | **-2.6%** |
 | Top-5 Pass Rate | 92.1% (35/38) | 92.1% (35/38) | 0.0% |
 
-Note: Top-1 decreased by 1 query due to index rebalancing affecting "WRE master orchestrator"
-query (performance_orchestrator.py now ranked higher than wre_master_orchestrator.py).
+**Outcome**: Top-1 REGRESSED. Gate NOT passed in either case.
 
-## Failure Analysis (Post-Fix)
+### Direct Query Verification
 
-### Top-1 Failures (6 queries)
+Target files became discoverable via direct queries:
 
-| Query | Got | Expected | Root Cause |
-|-------|-----|----------|------------|
-| backend routing turboquant embedding | turboquant_backend.py | backend_routing | Semantic drift |
-| WRE master orchestrator coordination | performance_orchestrator.py | wre_master_orchestrator | Semantic drift (new) |
-| WRE bridge integration cursor | integrate_with_wre.py | wre_bridge | Semantic drift: "integration" boosts wrong file |
-| build plan generator hermes | hermes_adapter.py | build_plan | Semantic drift: "hermes" boosts wrong file |
-| pfmall catalog verification | test file | pfmall_catalog | Test file ranked higher |
-| orphan capability scanner detection | security_scanner.py | orphan | Semantic drift: "scanner" boosts wrong file |
+| Target File | Direct Query | Rank | Similarity |
+|-------------|--------------|------|------------|
+| wre_bridge.py | "wre_bridge" | #1 | 57.2% |
+| build_plan.py | "build_plan" | #1 | 55.9% |
+| orphan_batch_analyzer.py | "orphan batch analyzer" | #1 | 66.4% |
 
-### Top-5 Failures (3 queries)
+However, sentinel queries use natural language and continue to exhibit semantic drift.
 
-| Query | Root Cause |
-|-------|------------|
-| WRE master orchestrator coordination | File exists but semantic drift |
-| WRE bridge integration cursor | File exists but semantic drift |
-| build plan generator hermes | File exists but semantic drift |
+## Decision: Path A - Revert
 
-### Root Cause Distribution
+### Rationale
 
-| Root Cause | HIA7 Count | HIA7B Count | Status |
-|------------|------------|-------------|--------|
-| Indexing gap | 3 | 0 | **FIXED** |
-| Semantic drift | 2 | 6 | **Increased** (more visible now) |
+1. **Regression**: Top-1 pass rate decreased from 86.8% to 84.2%
+2. **Gate not passed**: Neither before (86.8%/92.1%) nor after (84.2%/92.1%) met the
+   gate criteria (top-1 >= 85%, top-5 >= 95%)
+3. **WSP 97 compliance**: Cannot claim improvement when metrics regressed
+4. **Direct discoverability not in gate**: The benefit (files findable via direct
+   queries) is not part of the sentinel gate criteria
 
-## Key Insight
+### Action Taken
 
-The indexing fix was successful: target files are now indexed and appear in top-5
-results for direct queries. However, the sentinel queries use natural language
-that causes semantic drift:
+- `indexing_engine.py`: Reverted to HIA7 state (no priority root additions)
+- `hia3_baseline_metrics.json`: Restored to HIA7 state (86.8%/92.1%)
+- This report: Updated to document experiment and decision
 
+## Root Cause Analysis
+
+The priority root change caused index rebalancing that affected unrelated queries:
+- "WRE master orchestrator coordination" regressed (new failure)
+- Adding more P1 roots shifted which files appeared in the 20K symbol limit
+
+The remaining failures are **semantic drift**, not indexing gaps:
 - Query "WRE bridge integration cursor" → "integration" matches integrate_with_wre.py better
 - Query "build plan generator hermes" → "hermes" matches hermes_adapter.py better
 - Query "orphan capability scanner detection" → "scanner" matches security_scanner.py better
 
-This is **not an indexing problem** but a **semantic ranking problem** that requires:
-1. Query-specific keyword boosting, or
-2. LLM-based reranking (HIA8), or
-3. Adjusting evidence rules to accept semantic equivalents
+## Final State
 
-## Gate Evaluation
+| Metric | Value | Gate Requirement | Status |
+|--------|-------|------------------|--------|
+| Top-1 Pass Rate | 86.8% (33/38) | >= 85% | PASS |
+| Top-5 Pass Rate | 92.1% (35/38) | >= 95% | FAIL |
 
-**Gate Criteria**: Top-5 >= 95% AND Top-1 >= 85%
-
-| Metric | Required | Actual | Status |
-|--------|----------|--------|--------|
-| Top-1 Pass Rate | >= 85% | 84.2% | **FAIL** |
-| Top-5 Pass Rate | >= 95% | 92.1% | **FAIL** |
-
-**Gate Result**: NOT PASSED
-
-## Files Changed
-
-1. `holo_index/core/indexing_engine.py`:
-   - Added 3 priority roots for HIA7B sentinel coverage
-
-2. `docs/audits/holoindex_search_quality/hia3_baseline_metrics.json`:
-   - Regenerated with 38-query baseline after re-indexing
-
-3. `docs/audits/holoindex_search_quality/HIA7B_PRIORITY_ROOT_INDEXING_FIX_REPORT.md`:
-   - This report
+**Code**: Unchanged from HIA7 (no priority root additions)
+**Baseline**: 86.8% top-1, 92.1% top-5 (38 queries)
 
 ## Recommendations
 
-### Option A: Proceed to HIA8 (LLM Reranking)
+### Optional: HIA8 (LLM Reranking)
 
-Accept that deterministic ranking has limits. Use Gemma/LLM to rerank top-10
-results based on intent matching. This is the recommended path per the HIA series.
+If top-5 >= 95% is required, consider LLM reranking for semantic drift correction.
+This is not mandatory; current 92.1% may be acceptable baseline.
 
-### Option B: Keyword Boosting Tuning
+### Not Recommended
 
-Add query-specific keyword detection to boost exact file name matches:
-- Query contains "wre_bridge" → boost files with "wre_bridge" in path
-- Query contains "build_plan" → boost files with "build_plan" in path
-
-This is deterministic but requires maintaining keyword mappings.
-
-### Option C: Evidence Rule Relaxation
-
-Accept semantic equivalents in evidence rules:
-- "wre_bridge" OR "integrate_with_wre" (same module)
-- "build_plan" OR "hermes" (same domain)
-
-Not recommended: weakens quality signal.
-
-## Next Steps
-
-1. **HIA8**: Evaluate LLM reranking for semantic drift correction
-2. Consider whether 84.2%/92.1% is acceptable baseline before LLM layer
-3. If LLM reranking is deferred, tune keyword boosting for high-value queries
+- Do not add priority roots without regression testing
+- Do not claim indexing fixes improve quality without sentinel verification
 
 ## WSP 97 Compliance
 
-Results reported truthfully:
-- Indexing gap fixed (verified with direct queries)
-- Semantic drift identified as separate root cause
-- Gate not passed, documented why
-- No overclaiming - improvements are incremental
+- No "gate passed" claim (gate not passed)
+- No "quality improved" claim (top-1 regressed)
+- Experiment documented truthfully
+- Decision rationale transparent

--- a/docs/audits/holoindex_search_quality/HIA7_SENTINEL_EXPANSION_REPORT.md
+++ b/docs/audits/holoindex_search_quality/HIA7_SENTINEL_EXPANSION_REPORT.md
@@ -1,0 +1,152 @@
+# HIA7: Sentinel Query Expansion Report
+
+**Date**: 2026-05-01
+**Status**: COMPLETE
+**Branch**: feat/hia7-sentinel-expansion-gate
+
+## Summary
+
+Expanded sentinel query set from 11 to 38 queries across 10 categories to validate
+search quality before adding LLM reranking. Results show indexing and ranking gaps
+that must be addressed before proceeding.
+
+## Expanded Baseline Metrics
+
+| Metric | HIA6B (11 queries) | HIA7 (38 queries) | Delta |
+|--------|-------------------|-------------------|-------|
+| Top-1 Pass Rate | 100.0% (11/11) | 86.8% (33/38) | -13.2% |
+| Top-5 Pass Rate | 100.0% (11/11) | 92.1% (35/38) | -7.9% |
+| Confidence Min | 0.68 | 0.655 | -0.025 |
+| Confidence Avg | 0.852 | 0.885 | +0.033 |
+| Latency p50 | 90ms | 102ms | +12ms |
+| Latency p95 | 382ms | 155ms | -227ms |
+
+## Query Categories (38 total)
+
+| Category | Count | Top-1 Pass | Top-5 Pass |
+|----------|-------|------------|------------|
+| HoloIndex Core | 5 | 4/5 (80%) | 5/5 (100%) |
+| WSP Protocols | 6 | 6/6 (100%) | 6/6 (100%) |
+| OpenClaw/FoundUpJob | 5 | 5/5 (100%) | 5/5 (100%) |
+| WRE Queue/Worker | 4 | 3/4 (75%) | 3/4 (75%) |
+| BuildPlan/Swarm | 3 | 2/3 (67%) | 2/3 (67%) |
+| pfMALL | 3 | 2/3 (67%) | 3/3 (100%) |
+| YouTube/Video | 3 | 3/3 (100%) | 3/3 (100%) |
+| Skills/Scanner | 3 | 2/3 (67%) | 2/3 (67%) |
+| Code/Symbol | 4 | 4/4 (100%) | 4/4 (100%) |
+| Docs/Knowledge | 2 | 2/2 (100%) | 2/2 (100%) |
+
+## Failure Analysis
+
+### Top-1 Failures (5 queries)
+
+| Query | Expected | Got | Root Cause |
+|-------|----------|-----|------------|
+| backend routing turboquant embedding | `backend_routing` | `turboquant_backend.py` | Semantic drift - "turboquant" in query matches file better |
+| WRE bridge integration cursor | `wre_bridge` | `integrate_with_wre.py` | Indexing gap - wre_bridge.py in development/ not indexed |
+| build plan generator hermes | `build_plan` | `hermes_adapter.py` | Semantic drift - "hermes" keyword boosts wrong file |
+| pfmall catalog verification | `pfmall_catalog` | test file | Ranking - test file ranked above src file |
+| orphan capability scanner detection | `orphan` | `security_scanner.py` | Indexing gap - orphan*.py files not in priority roots |
+
+### Top-5 Failures (3 queries)
+
+| Query | Evidence Rule | Files Exist? | Root Cause |
+|-------|--------------|--------------|------------|
+| WRE bridge integration cursor | `wre_bridge` | Yes | `modules/development/` not in indexed roots |
+| build plan generator hermes | `build_plan` | Yes | `modules/foundups/agent/src/` not in priority roots |
+| orphan capability scanner detection | `orphan` | Yes | `holo_index/qwen_advisor/` not in priority roots |
+
+### Root Cause Distribution
+
+| Root Cause | Count | % of Failures |
+|------------|-------|---------------|
+| Indexing gap (file not indexed) | 3 | 60% |
+| Semantic drift (wrong file ranked higher) | 2 | 40% |
+| Ranking issue (test > src) | 1 | 20% |
+
+Note: Some queries have multiple root causes.
+
+## Target File Verification
+
+All failing queries have target files that exist:
+
+```
+holo_index/core/backend_routing.py                           EXISTS
+modules/development/ide_foundups/src/wre_bridge.py           EXISTS
+modules/foundups/agent/src/build_plan.py                     EXISTS
+modules/foundups/agent/src/build_plan_generator.py           EXISTS
+modules/communication/moltbot_bridge/src/pfmall_catalog.py   EXISTS
+holo_index/qwen_advisor/orphan_batch_analyzer.py             EXISTS
+modules/infrastructure/code_quality/tools/orphan_analyzer.py EXISTS
+```
+
+## Gate Evaluation
+
+**Gate Criteria**: Top-5 >= 95% AND Top-1 >= 85%
+
+| Metric | Required | Actual | Status |
+|--------|----------|--------|--------|
+| Top-1 Pass Rate | >= 85% | 86.8% | PASS |
+| Top-5 Pass Rate | >= 95% | 92.1% | **FAIL** |
+
+**Gate Result**: NOT PASSED
+
+## Recommendations
+
+### Option A: Fix Indexing Gaps (Recommended)
+
+Add missing directories to priority roots in `indexing_engine.py`:
+
+```python
+roots = [
+    holo.project_root / "holo_index" / "core",           # P1: search infrastructure
+    holo.project_root / "holo_index" / "qwen_advisor",   # P1: add for orphan analyzers
+    holo.project_root / "modules" / "infrastructure" / "wre_core" / "src",
+    holo.project_root / "modules" / "development" / "ide_foundups" / "src",  # P1: add for wre_bridge
+    holo.project_root / "modules" / "foundups" / "agent" / "src",            # P1: add for build_plan
+    holo.project_root / "modules",
+    # ... rest
+]
+```
+
+Expected impact: Fixes 3/5 top-1 failures, likely achieves 95%+ top-5.
+
+### Option B: Relax Evidence Rules
+
+For semantic drift failures, use broader evidence:
+- `backend_routing` -> also accept `turboquant_backend` (related)
+- `build_plan` -> also accept `hermes` (same domain)
+
+Not recommended: Loosens quality bar rather than fixing root cause.
+
+### Option C: Proceed to HIA8
+
+Accept 92.1% top-5 as acceptable baseline, proceed with LLM reranking.
+
+Not recommended until indexing gaps are closed.
+
+## Next Steps
+
+1. **HIA7B**: Fix indexing priority roots for failing categories
+2. Re-run baseline after indexing fix
+3. If gate passes (top-5 >= 95%), proceed to HIA8 (LLM reranking evaluation)
+
+## Files Changed
+
+1. `holo_index/tests/test_search_quality_baseline.py`:
+   - Expanded SENTINEL_QUERIES from 11 to 38 queries
+   - Added 10 category coverage
+
+2. `docs/audits/holoindex_search_quality/hia3_baseline_metrics.json`:
+   - Regenerated with 38-query baseline
+
+3. `docs/audits/holoindex_search_quality/HIA7_SENTINEL_EXPANSION_REPORT.md`:
+   - This report
+
+## WSP 97 Compliance
+
+Results reported truthfully:
+- Pass rates reflect actual search performance
+- Failures documented with root cause analysis
+- No overclaiming - gate not passed, documented why
+- Evidence rules validated against existing files

--- a/docs/audits/holoindex_search_quality/hia3_baseline_metrics.json
+++ b/docs/audits/holoindex_search_quality/hia3_baseline_metrics.json
@@ -1,22 +1,22 @@
 {
-  "generated_at_utc": "2026-05-01T13:51:54.006701Z",
+  "generated_at_utc": "2026-05-01T23:32:37.602718Z",
   "holo_use_turboquant": "0",
   "holo_emit_confidence": "1",
   "corpus_doc_count": 20413,
   "sentinel_query_count": 38,
   "aggregate": {
     "total_queries": 38,
-    "top_1_pass_count": 33,
-    "top_1_pass_rate": 0.8684,
+    "top_1_pass_count": 32,
+    "top_1_pass_rate": 0.8421,
     "top_5_pass_count": 35,
     "top_5_pass_rate": 0.9211,
     "confidence_min": 0.655,
-    "confidence_avg": 0.8845,
+    "confidence_avg": 0.8786,
     "confidence_max": 1.0,
-    "latency_min_ms": 82,
-    "latency_p50_ms": 102,
-    "latency_p95_ms": 155,
-    "latency_max_ms": 414
+    "latency_min_ms": 79,
+    "latency_p50_ms": 91,
+    "latency_p95_ms": 141,
+    "latency_max_ms": 495
   },
   "query_results": [
     {
@@ -33,7 +33,7 @@
       "top_1_confidence": 0.7663490526361794,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 414,
+      "latency_ms": 495,
       "error": null
     },
     {
@@ -50,7 +50,7 @@
       "top_1_confidence": 0.7770940305244378,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 100,
+      "latency_ms": 104,
       "error": null
     },
     {
@@ -67,7 +67,7 @@
       "top_1_confidence": 0.7851966968481987,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 128,
+      "latency_ms": 98,
       "error": null
     },
     {
@@ -84,7 +84,7 @@
       "top_1_confidence": 0.728173514128496,
       "top_1_passes": false,
       "top_5_passes": true,
-      "latency_ms": 137,
+      "latency_ms": 106,
       "error": null
     },
     {
@@ -101,7 +101,7 @@
       "top_1_confidence": 0.8289897182247203,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 95,
+      "latency_ms": 101,
       "error": null
     },
     {
@@ -118,7 +118,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 95,
+      "latency_ms": 91,
       "error": null
     },
     {
@@ -152,7 +152,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 95,
+      "latency_ms": 97,
       "error": null
     },
     {
@@ -169,7 +169,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 117,
+      "latency_ms": 91,
       "error": null
     },
     {
@@ -186,7 +186,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 118,
+      "latency_ms": 92,
       "error": null
     },
     {
@@ -203,7 +203,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 114,
+      "latency_ms": 91,
       "error": null
     },
     {
@@ -220,7 +220,7 @@
       "top_1_confidence": 0.9191263915507275,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 119,
+      "latency_ms": 105,
       "error": null
     },
     {
@@ -237,7 +237,7 @@
       "top_1_confidence": 0.9704019725548232,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 109,
+      "latency_ms": 127,
       "error": null
     },
     {
@@ -254,7 +254,7 @@
       "top_1_confidence": 0.7900913216225764,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 155,
+      "latency_ms": 141,
       "error": null
     },
     {
@@ -271,7 +271,7 @@
       "top_1_confidence": 0.8581582473518456,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 117,
+      "latency_ms": 89,
       "error": null
     },
     {
@@ -288,7 +288,7 @@
       "top_1_confidence": 0.9119717346963487,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 110,
+      "latency_ms": 86,
       "error": null
     },
     {
@@ -298,14 +298,14 @@
       "evidence_rule": {
         "path_contains": "wre_master_orchestrator"
       },
-      "top_1_path": "O:\\Foundups-Agent\\modules\\infrastructure\\wre_core\\wre_master_orchestrator\\src\\wre_master_orchestrator.py",
+      "top_1_path": "O:\\Foundups-Agent\\holo_index\\qwen_advisor\\performance_orchestrator.py",
       "top_1_title": null,
       "top_1_type": "symbol",
-      "top_1_similarity": "56.9%",
-      "top_1_confidence": 0.9191301949041437,
-      "top_1_passes": true,
-      "top_5_passes": true,
-      "latency_ms": 107,
+      "top_1_similarity": "54.4%",
+      "top_1_confidence": 0.6942394085374256,
+      "top_1_passes": false,
+      "top_5_passes": false,
+      "latency_ms": 89,
       "error": null
     },
     {
@@ -322,7 +322,7 @@
       "top_1_confidence": 0.9820283762282334,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 100,
+      "latency_ms": 79,
       "error": null
     },
     {
@@ -339,7 +339,7 @@
       "top_1_confidence": 0.9497865435186601,
       "top_1_passes": false,
       "top_5_passes": false,
-      "latency_ms": 114,
+      "latency_ms": 80,
       "error": null
     },
     {
@@ -356,7 +356,7 @@
       "top_1_confidence": 0.8404882046598658,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 115,
+      "latency_ms": 82,
       "error": null
     },
     {
@@ -373,7 +373,7 @@
       "top_1_confidence": 0.6550419102325375,
       "top_1_passes": false,
       "top_5_passes": false,
-      "latency_ms": 102,
+      "latency_ms": 98,
       "error": null
     },
     {
@@ -390,7 +390,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 125,
+      "latency_ms": 81,
       "error": null
     },
     {
@@ -407,7 +407,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 123,
+      "latency_ms": 93,
       "error": null
     },
     {
@@ -424,7 +424,7 @@
       "top_1_confidence": 0.8796568835519014,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 101,
+      "latency_ms": 87,
       "error": null
     },
     {
@@ -441,7 +441,7 @@
       "top_1_confidence": 0.7653613297766888,
       "top_1_passes": false,
       "top_5_passes": true,
-      "latency_ms": 103,
+      "latency_ms": 89,
       "error": null
     },
     {
@@ -458,7 +458,7 @@
       "top_1_confidence": 0.8083764464477199,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 104,
+      "latency_ms": 82,
       "error": null
     },
     {
@@ -475,7 +475,7 @@
       "top_1_confidence": 0.9981861992399124,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 88,
+      "latency_ms": 87,
       "error": null
     },
     {
@@ -492,7 +492,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 87,
+      "latency_ms": 98,
       "error": null
     },
     {
@@ -509,7 +509,7 @@
       "top_1_confidence": 0.9420379142169739,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 95,
+      "latency_ms": 94,
       "error": null
     },
     {
@@ -519,14 +519,14 @@
       "evidence_rule": {
         "type_equals": "skillz"
       },
-      "top_1_path": "O:\\Foundups-Agent\\modules\\ai_intelligence\\video_indexer\\skillz\\transcript_ask\\SKILLz.md",
+      "top_1_path": "O:\\Foundups-Agent\\modules\\communication\\livechat\\skillz\\gemma_telemetry_retention_detector\\SKILLz.md",
       "top_1_title": null,
       "top_1_type": "skillz",
       "top_1_similarity": "50.0%",
       "top_1_confidence": 0.6799999999999999,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 86,
+      "latency_ms": 84,
       "error": null
     },
     {
@@ -536,14 +536,14 @@
       "evidence_rule": {
         "type_equals": "skillz"
       },
-      "top_1_path": "O:\\Foundups-Agent\\modules\\ai_intelligence\\video_indexer\\skillz\\transcript_ask\\SKILLz.md",
+      "top_1_path": "O:\\Foundups-Agent\\modules\\communication\\livechat\\skillz\\gemma_telemetry_retention_detector\\SKILLz.md",
       "top_1_title": null,
       "top_1_type": "skillz",
       "top_1_similarity": "50.0%",
       "top_1_confidence": 0.6800000447034875,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 82,
+      "latency_ms": 89,
       "error": null
     },
     {
@@ -559,8 +559,8 @@
       "top_1_similarity": "53.1%",
       "top_1_confidence": 0.681414332627324,
       "top_1_passes": false,
-      "top_5_passes": false,
-      "latency_ms": 100,
+      "top_5_passes": true,
+      "latency_ms": 93,
       "error": null
     },
     {
@@ -577,7 +577,7 @@
       "top_1_confidence": 0.8659627158461345,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 91,
+      "latency_ms": 89,
       "error": null
     },
     {
@@ -594,7 +594,7 @@
       "top_1_confidence": 0.845680281770153,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 87,
+      "latency_ms": 83,
       "error": null
     },
     {
@@ -611,7 +611,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 89,
+      "latency_ms": 86,
       "error": null
     },
     {
@@ -628,7 +628,7 @@
       "top_1_confidence": 0.7832634911351688,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 94,
+      "latency_ms": 84,
       "error": null
     },
     {
@@ -645,7 +645,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 95,
+      "latency_ms": 107,
       "error": null
     },
     {
@@ -662,7 +662,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 97,
+      "latency_ms": 131,
       "error": null
     }
   ]

--- a/docs/audits/holoindex_search_quality/hia3_baseline_metrics.json
+++ b/docs/audits/holoindex_search_quality/hia3_baseline_metrics.json
@@ -1,22 +1,22 @@
 {
-  "generated_at_utc": "2026-05-01T23:32:37.602718Z",
+  "generated_at_utc": "2026-05-01T13:51:54.006701Z",
   "holo_use_turboquant": "0",
   "holo_emit_confidence": "1",
   "corpus_doc_count": 20413,
   "sentinel_query_count": 38,
   "aggregate": {
     "total_queries": 38,
-    "top_1_pass_count": 32,
-    "top_1_pass_rate": 0.8421,
+    "top_1_pass_count": 33,
+    "top_1_pass_rate": 0.8684,
     "top_5_pass_count": 35,
     "top_5_pass_rate": 0.9211,
     "confidence_min": 0.655,
-    "confidence_avg": 0.8786,
+    "confidence_avg": 0.8845,
     "confidence_max": 1.0,
-    "latency_min_ms": 79,
-    "latency_p50_ms": 91,
-    "latency_p95_ms": 141,
-    "latency_max_ms": 495
+    "latency_min_ms": 82,
+    "latency_p50_ms": 102,
+    "latency_p95_ms": 155,
+    "latency_max_ms": 414
   },
   "query_results": [
     {
@@ -33,7 +33,7 @@
       "top_1_confidence": 0.7663490526361794,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 495,
+      "latency_ms": 414,
       "error": null
     },
     {
@@ -50,7 +50,7 @@
       "top_1_confidence": 0.7770940305244378,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 104,
+      "latency_ms": 100,
       "error": null
     },
     {
@@ -67,7 +67,7 @@
       "top_1_confidence": 0.7851966968481987,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 98,
+      "latency_ms": 128,
       "error": null
     },
     {
@@ -84,7 +84,7 @@
       "top_1_confidence": 0.728173514128496,
       "top_1_passes": false,
       "top_5_passes": true,
-      "latency_ms": 106,
+      "latency_ms": 137,
       "error": null
     },
     {
@@ -101,7 +101,7 @@
       "top_1_confidence": 0.8289897182247203,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 101,
+      "latency_ms": 95,
       "error": null
     },
     {
@@ -118,7 +118,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 91,
+      "latency_ms": 95,
       "error": null
     },
     {
@@ -152,7 +152,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 97,
+      "latency_ms": 95,
       "error": null
     },
     {
@@ -169,7 +169,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 91,
+      "latency_ms": 117,
       "error": null
     },
     {
@@ -186,7 +186,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 92,
+      "latency_ms": 118,
       "error": null
     },
     {
@@ -203,7 +203,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 91,
+      "latency_ms": 114,
       "error": null
     },
     {
@@ -220,7 +220,7 @@
       "top_1_confidence": 0.9191263915507275,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 105,
+      "latency_ms": 119,
       "error": null
     },
     {
@@ -237,7 +237,7 @@
       "top_1_confidence": 0.9704019725548232,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 127,
+      "latency_ms": 109,
       "error": null
     },
     {
@@ -254,7 +254,7 @@
       "top_1_confidence": 0.7900913216225764,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 141,
+      "latency_ms": 155,
       "error": null
     },
     {
@@ -271,7 +271,7 @@
       "top_1_confidence": 0.8581582473518456,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 89,
+      "latency_ms": 117,
       "error": null
     },
     {
@@ -288,7 +288,7 @@
       "top_1_confidence": 0.9119717346963487,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 86,
+      "latency_ms": 110,
       "error": null
     },
     {
@@ -298,14 +298,14 @@
       "evidence_rule": {
         "path_contains": "wre_master_orchestrator"
       },
-      "top_1_path": "O:\\Foundups-Agent\\holo_index\\qwen_advisor\\performance_orchestrator.py",
+      "top_1_path": "O:\\Foundups-Agent\\modules\\infrastructure\\wre_core\\wre_master_orchestrator\\src\\wre_master_orchestrator.py",
       "top_1_title": null,
       "top_1_type": "symbol",
-      "top_1_similarity": "54.4%",
-      "top_1_confidence": 0.6942394085374256,
-      "top_1_passes": false,
-      "top_5_passes": false,
-      "latency_ms": 89,
+      "top_1_similarity": "56.9%",
+      "top_1_confidence": 0.9191301949041437,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 107,
       "error": null
     },
     {
@@ -322,7 +322,7 @@
       "top_1_confidence": 0.9820283762282334,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 79,
+      "latency_ms": 100,
       "error": null
     },
     {
@@ -339,7 +339,7 @@
       "top_1_confidence": 0.9497865435186601,
       "top_1_passes": false,
       "top_5_passes": false,
-      "latency_ms": 80,
+      "latency_ms": 114,
       "error": null
     },
     {
@@ -356,7 +356,7 @@
       "top_1_confidence": 0.8404882046598658,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 82,
+      "latency_ms": 115,
       "error": null
     },
     {
@@ -373,7 +373,7 @@
       "top_1_confidence": 0.6550419102325375,
       "top_1_passes": false,
       "top_5_passes": false,
-      "latency_ms": 98,
+      "latency_ms": 102,
       "error": null
     },
     {
@@ -390,7 +390,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 81,
+      "latency_ms": 125,
       "error": null
     },
     {
@@ -407,7 +407,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 93,
+      "latency_ms": 123,
       "error": null
     },
     {
@@ -424,7 +424,7 @@
       "top_1_confidence": 0.8796568835519014,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 87,
+      "latency_ms": 101,
       "error": null
     },
     {
@@ -441,7 +441,7 @@
       "top_1_confidence": 0.7653613297766888,
       "top_1_passes": false,
       "top_5_passes": true,
-      "latency_ms": 89,
+      "latency_ms": 103,
       "error": null
     },
     {
@@ -458,7 +458,7 @@
       "top_1_confidence": 0.8083764464477199,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 82,
+      "latency_ms": 104,
       "error": null
     },
     {
@@ -475,7 +475,7 @@
       "top_1_confidence": 0.9981861992399124,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 87,
+      "latency_ms": 88,
       "error": null
     },
     {
@@ -492,7 +492,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 98,
+      "latency_ms": 87,
       "error": null
     },
     {
@@ -509,7 +509,7 @@
       "top_1_confidence": 0.9420379142169739,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 94,
+      "latency_ms": 95,
       "error": null
     },
     {
@@ -519,14 +519,14 @@
       "evidence_rule": {
         "type_equals": "skillz"
       },
-      "top_1_path": "O:\\Foundups-Agent\\modules\\communication\\livechat\\skillz\\gemma_telemetry_retention_detector\\SKILLz.md",
+      "top_1_path": "O:\\Foundups-Agent\\modules\\ai_intelligence\\video_indexer\\skillz\\transcript_ask\\SKILLz.md",
       "top_1_title": null,
       "top_1_type": "skillz",
       "top_1_similarity": "50.0%",
       "top_1_confidence": 0.6799999999999999,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 84,
+      "latency_ms": 86,
       "error": null
     },
     {
@@ -536,14 +536,14 @@
       "evidence_rule": {
         "type_equals": "skillz"
       },
-      "top_1_path": "O:\\Foundups-Agent\\modules\\communication\\livechat\\skillz\\gemma_telemetry_retention_detector\\SKILLz.md",
+      "top_1_path": "O:\\Foundups-Agent\\modules\\ai_intelligence\\video_indexer\\skillz\\transcript_ask\\SKILLz.md",
       "top_1_title": null,
       "top_1_type": "skillz",
       "top_1_similarity": "50.0%",
       "top_1_confidence": 0.6800000447034875,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 89,
+      "latency_ms": 82,
       "error": null
     },
     {
@@ -559,8 +559,8 @@
       "top_1_similarity": "53.1%",
       "top_1_confidence": 0.681414332627324,
       "top_1_passes": false,
-      "top_5_passes": true,
-      "latency_ms": 93,
+      "top_5_passes": false,
+      "latency_ms": 100,
       "error": null
     },
     {
@@ -577,7 +577,7 @@
       "top_1_confidence": 0.8659627158461345,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 89,
+      "latency_ms": 91,
       "error": null
     },
     {
@@ -594,7 +594,7 @@
       "top_1_confidence": 0.845680281770153,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 83,
+      "latency_ms": 87,
       "error": null
     },
     {
@@ -611,7 +611,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 86,
+      "latency_ms": 89,
       "error": null
     },
     {
@@ -628,7 +628,7 @@
       "top_1_confidence": 0.7832634911351688,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 84,
+      "latency_ms": 94,
       "error": null
     },
     {
@@ -645,7 +645,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 107,
+      "latency_ms": 95,
       "error": null
     },
     {
@@ -662,7 +662,7 @@
       "top_1_confidence": 1.0,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 131,
+      "latency_ms": 97,
       "error": null
     }
   ]

--- a/docs/audits/holoindex_search_quality/hia3_baseline_metrics.json
+++ b/docs/audits/holoindex_search_quality/hia3_baseline_metrics.json
@@ -1,132 +1,30 @@
 {
-  "generated_at_utc": "2026-05-01T12:14:12.582575Z",
+  "generated_at_utc": "2026-05-01T13:51:54.006701Z",
   "holo_use_turboquant": "0",
   "holo_emit_confidence": "1",
   "corpus_doc_count": 20413,
-  "sentinel_query_count": 11,
+  "sentinel_query_count": 38,
   "aggregate": {
-    "total_queries": 11,
-    "top_1_pass_count": 11,
-    "top_1_pass_rate": 1.0,
-    "top_5_pass_count": 11,
-    "top_5_pass_rate": 1.0,
-    "confidence_min": 0.68,
-    "confidence_avg": 0.8518,
+    "total_queries": 38,
+    "top_1_pass_count": 33,
+    "top_1_pass_rate": 0.8684,
+    "top_5_pass_count": 35,
+    "top_5_pass_rate": 0.9211,
+    "confidence_min": 0.655,
+    "confidence_avg": 0.8845,
     "confidence_max": 1.0,
-    "latency_min_ms": 78,
-    "latency_p50_ms": 90,
-    "latency_p95_ms": 382,
-    "latency_max_ms": 382
+    "latency_min_ms": 82,
+    "latency_p50_ms": 102,
+    "latency_p95_ms": 155,
+    "latency_max_ms": 414
   },
   "query_results": [
     {
-      "query": "YouTube channel registry",
-      "category": "code",
-      "description": "Find the YouTube channel registry module",
-      "evidence_rule": {
-        "path_contains": "youtube_channel_registry"
-      },
-      "top_1_path": "O:\\Foundups-Agent\\modules\\infrastructure\\shared_utilities\\youtube_channel_registry.py",
-      "top_1_title": null,
-      "top_1_type": "symbol",
-      "top_1_similarity": "64.8%",
-      "top_1_confidence": 0.9981861992399124,
-      "top_1_passes": true,
-      "top_5_passes": true,
-      "latency_ms": 382,
-      "error": null
-    },
-    {
-      "query": "demurrage economics simulator",
-      "category": "code",
-      "description": "Find the demurrage economics module",
-      "evidence_rule": {
-        "path_contains": "demurrage"
-      },
-      "top_1_path": "O:\\Foundups-Agent\\modules\\foundups\\simulator\\economics\\demurrage.py",
-      "top_1_title": null,
-      "top_1_type": "symbol",
-      "top_1_similarity": "51.6%",
-      "top_1_confidence": 0.8659627158461345,
-      "top_1_passes": true,
-      "top_5_passes": true,
-      "latency_ms": 86,
-      "error": null
-    },
-    {
-      "query": "browser automation selenium",
-      "category": "code",
-      "description": "Find Selenium browser automation code",
-      "evidence_rule": {
-        "path_contains": "selenium"
-      },
-      "top_1_path": "O:\\Foundups-Agent\\modules\\infrastructure\\foundups_selenium\\src\\undetected_browser.py",
-      "top_1_title": null,
-      "top_1_type": "symbol",
-      "top_1_similarity": "59.6%",
-      "top_1_confidence": 0.845680281770153,
-      "top_1_passes": true,
-      "top_5_passes": true,
-      "latency_ms": 86,
-      "error": null
-    },
-    {
-      "query": "WSP 97 system execution prompting",
-      "category": "wsp",
-      "description": "Find WSP 97 system execution protocol",
-      "evidence_rule": {
-        "path_contains": "WSP_97"
-      },
-      "top_1_path": "O:\\Foundups-Agent\\WSP_framework\\src\\WSP_97_System_Execution_Prompting_Protocol.md",
-      "top_1_title": "WSP 97: System Execution Prompting Protocol",
-      "top_1_type": "wsp_protocol",
-      "top_1_similarity": "74.9%",
-      "top_1_confidence": 1.0,
-      "top_1_passes": true,
-      "top_5_passes": true,
-      "latency_ms": 78,
-      "error": null
-    },
-    {
-      "query": "WSP 00 zen state attainment",
-      "category": "wsp",
-      "description": "Find WSP 00 zen state protocol",
-      "evidence_rule": {
-        "path_contains": "WSP_00"
-      },
-      "top_1_path": "O:\\Foundups-Agent\\WSP_framework\\src\\WSP_00_Zen_State_Attainment_Protocol.md",
-      "top_1_title": "WSP_00: Zen State Attainment Protocol - Absolute Foundation",
-      "top_1_type": "wsp_protocol",
-      "top_1_similarity": "57.1%",
-      "top_1_confidence": 1.0,
-      "top_1_passes": true,
-      "top_5_passes": true,
-      "latency_ms": 90,
-      "error": null
-    },
-    {
-      "query": "module organization domains",
-      "category": "wsp",
-      "description": "Find module organization WSP",
-      "evidence_rule": {
-        "path_contains": "WSP"
-      },
-      "top_1_path": "O:\\Foundups-Agent\\WSP_framework\\src\\WSP_3_Enterprise_Domain_Organization.md",
-      "top_1_title": "WSP 3: Enterprise Domain Organization",
-      "top_1_type": "wsp_protocol",
-      "top_1_similarity": "56.6%",
-      "top_1_confidence": 0.9661010363122635,
-      "top_1_passes": true,
-      "top_5_passes": true,
-      "latency_ms": 93,
-      "error": null
-    },
-    {
       "query": "search engine query execution",
       "category": "symbol",
-      "description": "Find search engine module (known gap: search_engine.py not indexed)",
+      "description": "Find search engine module",
       "evidence_rule": {
-        "path_contains": "search"
+        "path_contains": "search_engine"
       },
       "top_1_path": "O:\\Foundups-Agent\\holo_index\\core\\search_engine.py",
       "top_1_title": null,
@@ -135,7 +33,7 @@
       "top_1_confidence": 0.7663490526361794,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 91,
+      "latency_ms": 414,
       "error": null
     },
     {
@@ -152,7 +50,194 @@
       "top_1_confidence": 0.7770940305244378,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 83,
+      "latency_ms": 100,
+      "error": null
+    },
+    {
+      "query": "indexing engine symbol extraction",
+      "category": "symbol",
+      "description": "Find indexing engine for symbol extraction",
+      "evidence_rule": {
+        "path_contains": "indexing_engine"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\holo_index\\core\\indexing_engine.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "53.5%",
+      "top_1_confidence": 0.7851966968481987,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 128,
+      "error": null
+    },
+    {
+      "query": "backend routing turboquant embedding",
+      "category": "symbol",
+      "description": "Find TurboQuant backend routing logic",
+      "evidence_rule": {
+        "path_contains": "backend_routing"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\holo_index\\core\\turboquant_backend.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "47.8%",
+      "top_1_confidence": 0.728173514128496,
+      "top_1_passes": false,
+      "top_5_passes": true,
+      "latency_ms": 137,
+      "error": null
+    },
+    {
+      "query": "search cache retrieval optimization",
+      "category": "symbol",
+      "description": "Find search cache implementation",
+      "evidence_rule": {
+        "path_contains": "search_cache"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\holo_index\\core\\search_cache.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "57.9%",
+      "top_1_confidence": 0.8289897182247203,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 95,
+      "error": null
+    },
+    {
+      "query": "WSP 97 system execution prompting",
+      "category": "wsp",
+      "description": "Find WSP 97 system execution protocol",
+      "evidence_rule": {
+        "path_contains": "WSP_97"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\WSP_framework\\src\\WSP_97_System_Execution_Prompting_Protocol.md",
+      "top_1_title": "WSP 97: System Execution Prompting Protocol",
+      "top_1_type": "wsp_protocol",
+      "top_1_similarity": "74.9%",
+      "top_1_confidence": 1.0,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 95,
+      "error": null
+    },
+    {
+      "query": "WSP 00 zen state attainment",
+      "category": "wsp",
+      "description": "Find WSP 00 zen state protocol",
+      "evidence_rule": {
+        "path_contains": "WSP_00"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\WSP_framework\\src\\WSP_00_Zen_State_Attainment_Protocol.md",
+      "top_1_title": "WSP_00: Zen State Attainment Protocol - Absolute Foundation",
+      "top_1_type": "wsp_protocol",
+      "top_1_similarity": "57.1%",
+      "top_1_confidence": 1.0,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 91,
+      "error": null
+    },
+    {
+      "query": "WSP 11 WRE standard command",
+      "category": "wsp",
+      "description": "Find WSP 11 WRE command protocol",
+      "evidence_rule": {
+        "path_contains": "WSP_11"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\WSP_framework\\src\\WSP_11_WRE_Standard_Command_Protocol.md",
+      "top_1_title": "WSP 11: WRE Standard Command Protocol",
+      "top_1_type": "wsp_protocol",
+      "top_1_similarity": "68.0%",
+      "top_1_confidence": 1.0,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 95,
+      "error": null
+    },
+    {
+      "query": "WSP 22 ModLog documentation updates",
+      "category": "wsp",
+      "description": "Find WSP 22 ModLog protocol",
+      "evidence_rule": {
+        "path_contains": "WSP_22"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\WSP_framework\\src\\WSP_22a_Module_ModLog_and_Roadmap.md",
+      "top_1_title": "WSP 22: ModLog and Roadmap Protocol",
+      "top_1_type": "wsp_protocol",
+      "top_1_similarity": "65.7%",
+      "top_1_confidence": 1.0,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 117,
+      "error": null
+    },
+    {
+      "query": "WSP 50 pre-action verification",
+      "category": "wsp",
+      "description": "Find WSP 50 verification protocol",
+      "evidence_rule": {
+        "path_contains": "WSP_50"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\WSP_framework\\src\\WSP_50_Pre_Action_Verification_Protocol.md",
+      "top_1_title": "WSP 50: Pre-Action Verification Protocol",
+      "top_1_type": "wsp_protocol",
+      "top_1_similarity": "66.2%",
+      "top_1_confidence": 1.0,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 118,
+      "error": null
+    },
+    {
+      "query": "WSP 72 block independence isolation",
+      "category": "wsp",
+      "description": "Find WSP 72 independence protocol",
+      "evidence_rule": {
+        "path_contains": "WSP_72"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\WSP_framework\\src\\WSP_72_Block_Independence_Interactive_Protocol.md",
+      "top_1_title": "WSP 72: Block Independence Autonomous Protocol",
+      "top_1_type": "wsp_protocol",
+      "top_1_similarity": "57.2%",
+      "top_1_confidence": 1.0,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 114,
+      "error": null
+    },
+    {
+      "query": "openclaw intent planner routing",
+      "category": "symbol",
+      "description": "Find OpenClaw intent planner",
+      "evidence_rule": {
+        "path_contains": "openclaw_intent"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\communication\\moltbot_bridge\\src\\openclaw_intent_planner.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "56.9%",
+      "top_1_confidence": 0.9191263915507275,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 119,
+      "error": null
+    },
+    {
+      "query": "openclaw codebase agent navigation",
+      "category": "symbol",
+      "description": "Find OpenClaw codebase agent",
+      "evidence_rule": {
+        "path_contains": "openclaw_codebase"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\ai_intelligence\\ai_gateway\\src\\openclaw_codebase_agent.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "62.0%",
+      "top_1_confidence": 0.9704019725548232,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 109,
       "error": null
     },
     {
@@ -169,7 +254,262 @@
       "top_1_confidence": 0.7900913216225764,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 120,
+      "latency_ms": 155,
+      "error": null
+    },
+    {
+      "query": "foundup job contract lifecycle",
+      "category": "symbol",
+      "description": "Find FoundUp job contract model",
+      "evidence_rule": {
+        "path_contains": "foundup_job_contract"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\communication\\moltbot_bridge\\src\\foundup_job_contract.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "50.8%",
+      "top_1_confidence": 0.8581582473518456,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 117,
+      "error": null
+    },
+    {
+      "query": "openclaw action ledger persistence",
+      "category": "symbol",
+      "description": "Find OpenClaw action ledger",
+      "evidence_rule": {
+        "path_contains": "openclaw_action_ledger"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\communication\\moltbot_bridge\\src\\openclaw_action_ledger.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "56.2%",
+      "top_1_confidence": 0.9119717346963487,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 110,
+      "error": null
+    },
+    {
+      "query": "WRE master orchestrator coordination",
+      "category": "symbol",
+      "description": "Find WRE master orchestrator",
+      "evidence_rule": {
+        "path_contains": "wre_master_orchestrator"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\infrastructure\\wre_core\\wre_master_orchestrator\\src\\wre_master_orchestrator.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "56.9%",
+      "top_1_confidence": 0.9191301949041437,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 107,
+      "error": null
+    },
+    {
+      "query": "WRE skills loader registry",
+      "category": "symbol",
+      "description": "Find WRE skills loader",
+      "evidence_rule": {
+        "path_contains": "wre_skills_loader"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\infrastructure\\wre_core\\skillz\\wre_skills_loader.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "63.2%",
+      "top_1_confidence": 0.9820283762282334,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 100,
+      "error": null
+    },
+    {
+      "query": "WRE bridge integration cursor",
+      "category": "symbol",
+      "description": "Find WRE bridge integration",
+      "evidence_rule": {
+        "path_contains": "wre_bridge"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\development\\cursor_multi_agent_bridge\\integrate_with_wre.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "60.0%",
+      "top_1_confidence": 0.9497865435186601,
+      "top_1_passes": false,
+      "top_5_passes": false,
+      "latency_ms": 114,
+      "error": null
+    },
+    {
+      "query": "pattern memory skill outcomes",
+      "category": "symbol",
+      "description": "Find pattern memory for skill outcomes",
+      "evidence_rule": {
+        "path_contains": "pattern_memory"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\infrastructure\\wre_core\\src\\pattern_memory.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "59.0%",
+      "top_1_confidence": 0.8404882046598658,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 115,
+      "error": null
+    },
+    {
+      "query": "build plan generator hermes",
+      "category": "symbol",
+      "description": "Find build plan generator",
+      "evidence_rule": {
+        "path_contains": "build_plan"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\foundups\\agent\\src\\hermes_adapter.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "50.5%",
+      "top_1_confidence": 0.6550419102325375,
+      "top_1_passes": false,
+      "top_5_passes": false,
+      "latency_ms": 102,
+      "error": null
+    },
+    {
+      "query": "swarm dispatch queue integration",
+      "category": "symbol",
+      "description": "Find swarm dispatch integration",
+      "evidence_rule": {
+        "path_contains": "swarm"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\foundups\\agent\\src\\swarm_dispatch_integration.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "67.2%",
+      "top_1_confidence": 1.0,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 125,
+      "error": null
+    },
+    {
+      "query": "hermes foundup job executor",
+      "category": "symbol",
+      "description": "Find Hermes FoundUp job executor",
+      "evidence_rule": {
+        "path_contains": "hermes_foundup"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\foundups\\agent\\src\\hermes_foundup_job_executor.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "72.3%",
+      "top_1_confidence": 1.0,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 123,
+      "error": null
+    },
+    {
+      "query": "pfmall discovery youtube matching",
+      "category": "symbol",
+      "description": "Find pfMALL discovery module",
+      "evidence_rule": {
+        "path_contains": "pfmall_discovery"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\ai_intelligence\\pfmall_discovery\\src\\youtube_discovery.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "53.0%",
+      "top_1_confidence": 0.8796568835519014,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 101,
+      "error": null
+    },
+    {
+      "query": "pfmall catalog verification",
+      "category": "symbol",
+      "description": "Find pfMALL catalog",
+      "evidence_rule": {
+        "path_contains": "pfmall_catalog"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\foundups\\pfmall\\tests\\test_catalog_foundup_truth_gate.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "51.5%",
+      "top_1_confidence": 0.7653613297766888,
+      "top_1_passes": false,
+      "top_5_passes": true,
+      "latency_ms": 103,
+      "error": null
+    },
+    {
+      "query": "pfmall shell core grid loading",
+      "category": "symbol",
+      "description": "Find pfMALL shell core",
+      "evidence_rule": {
+        "path_contains": "pfmall"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\foundups\\pfmall\\shell_core.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "45.8%",
+      "top_1_confidence": 0.8083764464477199,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 104,
+      "error": null
+    },
+    {
+      "query": "YouTube channel registry",
+      "category": "code",
+      "description": "Find the YouTube channel registry module",
+      "evidence_rule": {
+        "path_contains": "youtube_channel_registry"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\infrastructure\\shared_utilities\\youtube_channel_registry.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "64.8%",
+      "top_1_confidence": 0.9981861992399124,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 88,
+      "error": null
+    },
+    {
+      "query": "youtube transcript scraper video indexer",
+      "category": "symbol",
+      "description": "Find YouTube transcript scraper",
+      "evidence_rule": {
+        "path_contains": "youtube_transcript"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\ai_intelligence\\video_indexer\\src\\youtube_transcript_scraper.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "72.9%",
+      "top_1_confidence": 1.0,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 87,
+      "error": null
+    },
+    {
+      "query": "video comment engagement automation",
+      "category": "symbol",
+      "description": "Find video comment engagement module",
+      "evidence_rule": {
+        "path_contains": "video_comment"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\communication\\video_comments\\skillz\\qwen_studio_engage\\autonomous_engagement.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "59.2%",
+      "top_1_confidence": 0.9420379142169739,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 95,
       "error": null
     },
     {
@@ -179,14 +519,14 @@
       "evidence_rule": {
         "type_equals": "skillz"
       },
-      "top_1_path": "O:\\Foundups-Agent\\modules\\ai_intelligence\\ai_overseer\\skillz\\antifafm_dj\\SKILLz.md",
+      "top_1_path": "O:\\Foundups-Agent\\modules\\ai_intelligence\\video_indexer\\skillz\\transcript_ask\\SKILLz.md",
       "top_1_title": null,
       "top_1_type": "skillz",
       "top_1_similarity": "50.0%",
       "top_1_confidence": 0.6799999999999999,
       "top_1_passes": true,
       "top_5_passes": true,
-      "latency_ms": 97,
+      "latency_ms": 86,
       "error": null
     },
     {
@@ -196,7 +536,7 @@
       "evidence_rule": {
         "type_equals": "skillz"
       },
-      "top_1_path": "O:\\Foundups-Agent\\modules\\ai_intelligence\\ai_overseer\\skillz\\antifafm_dj\\SKILLz.md",
+      "top_1_path": "O:\\Foundups-Agent\\modules\\ai_intelligence\\video_indexer\\skillz\\transcript_ask\\SKILLz.md",
       "top_1_title": null,
       "top_1_type": "skillz",
       "top_1_similarity": "50.0%",
@@ -204,6 +544,125 @@
       "top_1_passes": true,
       "top_5_passes": true,
       "latency_ms": 82,
+      "error": null
+    },
+    {
+      "query": "orphan capability scanner detection",
+      "category": "symbol",
+      "description": "Find orphan capability scanner",
+      "evidence_rule": {
+        "path_contains": "orphan"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\infrastructure\\security_scanner\\src\\security_scanner.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "53.1%",
+      "top_1_confidence": 0.681414332627324,
+      "top_1_passes": false,
+      "top_5_passes": false,
+      "latency_ms": 100,
+      "error": null
+    },
+    {
+      "query": "demurrage economics simulator",
+      "category": "code",
+      "description": "Find the demurrage economics module",
+      "evidence_rule": {
+        "path_contains": "demurrage"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\foundups\\simulator\\economics\\demurrage.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "51.6%",
+      "top_1_confidence": 0.8659627158461345,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 91,
+      "error": null
+    },
+    {
+      "query": "browser automation selenium",
+      "category": "code",
+      "description": "Find Selenium browser automation code",
+      "evidence_rule": {
+        "path_contains": "selenium"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\infrastructure\\foundups_selenium\\src\\undetected_browser.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "59.6%",
+      "top_1_confidence": 0.845680281770153,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 87,
+      "error": null
+    },
+    {
+      "query": "agent permission manager confidence",
+      "category": "symbol",
+      "description": "Find agent permission manager",
+      "evidence_rule": {
+        "path_contains": "agent_permission"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\ai_intelligence\\agent_permissions\\src\\agent_permission_manager.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "67.9%",
+      "top_1_confidence": 1.0,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 89,
+      "error": null
+    },
+    {
+      "query": "FAM daemon persistence jsonl",
+      "category": "symbol",
+      "description": "Find FAM daemon persistence layer",
+      "evidence_rule": {
+        "path_contains": "fam_daemon"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\foundups\\agent_market\\src\\fam_daemon.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "53.3%",
+      "top_1_confidence": 0.7832634911351688,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 94,
+      "error": null
+    },
+    {
+      "query": "module organization enterprise domains",
+      "category": "wsp",
+      "description": "Find module organization WSP",
+      "evidence_rule": {
+        "path_contains": "WSP"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\WSP_framework\\src\\WSP_3_Enterprise_Domain_Organization.md",
+      "top_1_title": "WSP 3: Enterprise Domain Organization",
+      "top_1_type": "wsp_protocol",
+      "top_1_similarity": "54.5%",
+      "top_1_confidence": 1.0,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 95,
+      "error": null
+    },
+    {
+      "query": "gemma intent classifier binary",
+      "category": "symbol",
+      "description": "Find Gemma intent classifier",
+      "evidence_rule": {
+        "path_contains": "gemma_intent"
+      },
+      "top_1_path": "O:\\Foundups-Agent\\modules\\communication\\moltbot_bridge\\src\\gemma_intent_classifier.py",
+      "top_1_title": null,
+      "top_1_type": "symbol",
+      "top_1_similarity": "65.8%",
+      "top_1_confidence": 1.0,
+      "top_1_passes": true,
+      "top_5_passes": true,
+      "latency_ms": 97,
       "error": null
     }
   ]

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,48 @@
 # HoloIndex Package ModLog
 
+## [2026-05-02] HIA7B — Priority Root Indexing Gap Fix (hia7b_priority_root_fix)
+
+**Agent**: 0102 (Worker W2)
+**WSP References**: WSP 97 (truth distinction), WSP 50 (pre-action verification), WSP 22 (ModLog)
+**Status**: COMPLETE
+**Gate Result**: NOT PASSED (top-1 84.2% < 85%, top-5 92.1% < 95%)
+
+### Context
+
+HIA7 revealed 3 indexing gaps where target files were not indexed. Added priority
+roots to ensure these files are indexed before the 20K limit is reached.
+
+### Changes
+
+Added 3 priority roots to `indexing_engine.py`:
+- `holo_index/qwen_advisor/` (orphan analyzers)
+- `modules/development/ide_foundups/src/` (wre_bridge.py)
+- `modules/foundups/agent/src/` (build_plan.py)
+
+### Results
+
+| Metric | HIA7 (Before) | HIA7B (After) | Delta |
+|--------|---------------|---------------|-------|
+| Top-1 Pass Rate | 86.8% | 84.2% | -2.6% |
+| Top-5 Pass Rate | 92.1% | 92.1% | 0.0% |
+
+**Indexing gap: FIXED** - All target files now discoverable via direct queries.
+**Semantic drift: REMAINS** - General queries still rank wrong files higher due to
+keyword overlap ("integration" → integrate_with_wre.py, "hermes" → hermes_adapter.py).
+
+### Key Insight
+
+The remaining failures are not indexing issues but semantic ranking issues.
+Recommend proceeding to HIA8 (LLM reranking) to address semantic drift.
+
+### Files
+
+- `holo_index/core/indexing_engine.py` — Added 3 priority roots
+- `docs/audits/holoindex_search_quality/HIA7B_PRIORITY_ROOT_INDEXING_FIX_REPORT.md` (new)
+- `docs/audits/holoindex_search_quality/hia3_baseline_metrics.json` — Updated
+
+---
+
 ## [2026-05-01] HIA7 — Sentinel Query Expansion (hia7_sentinel_expansion_gate)
 
 **Agent**: 0102 (Worker W2)

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -4,42 +4,40 @@
 
 **Agent**: 0102 (Worker W2)
 **WSP References**: WSP 97 (truth distinction), WSP 50 (pre-action verification), WSP 22 (ModLog)
-**Status**: COMPLETE
-**Gate Result**: NOT PASSED (top-1 84.2% < 85%, top-5 92.1% < 95%)
+**Status**: COMPLETE - NOT PROMOTED
+**Decision**: Path A - Code reverted, audit preserved
 
 ### Context
 
-HIA7 revealed 3 indexing gaps where target files were not indexed. Added priority
-roots to ensure these files are indexed before the 20K limit is reached.
+Investigated adding priority roots to fix indexing gaps identified in HIA7. The change
+improved direct file discoverability but caused a regression in sentinel query pass rates.
 
-### Changes
-
-Added 3 priority roots to `indexing_engine.py`:
-- `holo_index/qwen_advisor/` (orphan analyzers)
-- `modules/development/ide_foundups/src/` (wre_bridge.py)
-- `modules/foundups/agent/src/` (build_plan.py)
-
-### Results
+### Experiment Results
 
 | Metric | HIA7 (Before) | HIA7B (After) | Delta |
 |--------|---------------|---------------|-------|
-| Top-1 Pass Rate | 86.8% | 84.2% | -2.6% |
+| Top-1 Pass Rate | 86.8% | 84.2% | **-2.6%** |
 | Top-5 Pass Rate | 92.1% | 92.1% | 0.0% |
 
-**Indexing gap: FIXED** - All target files now discoverable via direct queries.
-**Semantic drift: REMAINS** - General queries still rank wrong files higher due to
-keyword overlap ("integration" → integrate_with_wre.py, "hermes" → hermes_adapter.py).
+**Outcome**: Top-1 REGRESSED. Gate NOT passed in either case.
 
-### Key Insight
+### Decision Rationale
 
-The remaining failures are not indexing issues but semantic ranking issues.
-Recommend proceeding to HIA8 (LLM reranking) to address semantic drift.
+1. Top-1 regressed from 86.8% to 84.2% (not an improvement)
+2. Gate not passed before or after (top-5 92.1% < 95%)
+3. WSP 97: Cannot claim improvement when metrics regressed
+4. Direct discoverability benefit not part of sentinel gate criteria
+
+### Action Taken
+
+- `indexing_engine.py`: Reverted to HIA7 state (no code change)
+- `hia3_baseline_metrics.json`: Restored to HIA7 state (86.8%/92.1%)
+- Report updated to document experiment and decision
 
 ### Files
 
-- `holo_index/core/indexing_engine.py` — Added 3 priority roots
-- `docs/audits/holoindex_search_quality/HIA7B_PRIORITY_ROOT_INDEXING_FIX_REPORT.md` (new)
-- `docs/audits/holoindex_search_quality/hia3_baseline_metrics.json` — Updated
+- `docs/audits/holoindex_search_quality/HIA7B_PRIORITY_ROOT_INDEXING_FIX_REPORT.md` — Audit only
+- No code changes promoted
 
 ---
 

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,49 @@
 # HoloIndex Package ModLog
 
+## [2026-05-01] HIA7 — Sentinel Query Expansion (hia7_sentinel_expansion_gate)
+
+**Agent**: 0102 (Worker W2)
+**WSP References**: WSP 97 (truth distinction), WSP 50 (pre-action verification), WSP 22 (ModLog)
+**Status**: COMPLETE
+**Gate Result**: NOT PASSED (top-5 92.1% < 95% threshold)
+
+### Context
+
+After HIA6B achieved 100% pass rates on 11 sentinel queries, expanded the test set
+to 38 queries across 10 categories to validate quality before adding LLM reranking.
+
+### Expanded Baseline Results
+
+| Metric | HIA6B (11 queries) | HIA7 (38 queries) | Delta |
+|--------|-------------------|-------------------|-------|
+| Top-1 Pass Rate | 100.0% | 86.8% (33/38) | -13.2% |
+| Top-5 Pass Rate | 100.0% | 92.1% (35/38) | -7.9% |
+
+### Failure Root Causes
+
+| Root Cause | Count | Examples |
+|------------|-------|----------|
+| Indexing gap | 3 | wre_bridge.py, build_plan.py, orphan*.py not indexed |
+| Semantic drift | 2 | "hermes" boosts hermes_adapter.py over build_plan.py |
+
+### Gate Evaluation
+
+- Top-1 >= 85%: 86.8% PASS
+- Top-5 >= 95%: 92.1% FAIL
+
+### Recommendation
+
+Fix indexing gaps (HIA7B) by adding missing directories to priority roots, then
+re-evaluate gate before proceeding to HIA8 (LLM reranking).
+
+### Files
+
+- `holo_index/tests/test_search_quality_baseline.py` — Expanded from 11 to 38 queries
+- `docs/audits/holoindex_search_quality/HIA7_SENTINEL_EXPANSION_REPORT.md` (new)
+- `docs/audits/holoindex_search_quality/hia3_baseline_metrics.json` — Updated with 38-query baseline
+
+---
+
 ## [2026-05-01] HIA6B — Path Title Boost Tuning (hia6b_path_title_boost_tuning)
 
 **Agent**: 0102 (Worker W2)

--- a/holo_index/core/indexing_engine.py
+++ b/holo_index/core/indexing_engine.py
@@ -272,20 +272,13 @@ def index_symbol_entries(holo: "HoloIndex", roots: Optional[List[Path]] = None) 
     if env_roots:
         roots = [holo.project_root / Path(r.strip()) for r in env_roots.split(";") if r.strip()]
     else:
-        # HIA6A/HIA7B: Priority ordering ensures critical files are indexed first:
+        # HIA6A: Priority ordering ensures critical files are indexed first:
         # - holo_index/core: search_engine.py (core search infrastructure)
         # - wre_core/src: foundup_job_router.py (job routing)
-        # - HIA7B additions for expanded sentinel coverage:
-        #   - ide_foundups/src: wre_bridge.py
-        #   - foundups/agent/src: build_plan*.py
-        #   - holo_index/qwen_advisor: orphan*.py analyzers
         # - Then bulk directories fill remaining slots
         roots = roots or [
             holo.project_root / "holo_index" / "core",                      # P1: search infrastructure
             holo.project_root / "modules" / "infrastructure" / "wre_core" / "src",  # P1: job routing
-            holo.project_root / "holo_index" / "qwen_advisor",              # P1: HIA7B orphan analyzers
-            holo.project_root / "modules" / "development" / "ide_foundups" / "src",  # P1: HIA7B wre_bridge
-            holo.project_root / "modules" / "foundups" / "agent" / "src",   # P1: HIA7B build_plan
             holo.project_root / "modules",                                  # P2: bulk modules
             holo.project_root / "scripts",                                  # P3: scripts
             holo.project_root / "holo_index",                               # P3: remaining holo_index

--- a/holo_index/core/indexing_engine.py
+++ b/holo_index/core/indexing_engine.py
@@ -272,13 +272,20 @@ def index_symbol_entries(holo: "HoloIndex", roots: Optional[List[Path]] = None) 
     if env_roots:
         roots = [holo.project_root / Path(r.strip()) for r in env_roots.split(";") if r.strip()]
     else:
-        # HIA6A: Priority ordering ensures critical files are indexed first:
+        # HIA6A/HIA7B: Priority ordering ensures critical files are indexed first:
         # - holo_index/core: search_engine.py (core search infrastructure)
         # - wre_core/src: foundup_job_router.py (job routing)
+        # - HIA7B additions for expanded sentinel coverage:
+        #   - ide_foundups/src: wre_bridge.py
+        #   - foundups/agent/src: build_plan*.py
+        #   - holo_index/qwen_advisor: orphan*.py analyzers
         # - Then bulk directories fill remaining slots
         roots = roots or [
             holo.project_root / "holo_index" / "core",                      # P1: search infrastructure
             holo.project_root / "modules" / "infrastructure" / "wre_core" / "src",  # P1: job routing
+            holo.project_root / "holo_index" / "qwen_advisor",              # P1: HIA7B orphan analyzers
+            holo.project_root / "modules" / "development" / "ide_foundups" / "src",  # P1: HIA7B wre_bridge
+            holo.project_root / "modules" / "foundups" / "agent" / "src",   # P1: HIA7B build_plan
             holo.project_root / "modules",                                  # P2: bulk modules
             holo.project_root / "scripts",                                  # P3: scripts
             holo.project_root / "holo_index",                               # P3: remaining holo_index

--- a/holo_index/tests/test_search_quality_baseline.py
+++ b/holo_index/tests/test_search_quality_baseline.py
@@ -28,12 +28,219 @@ class SentinelQuery:
 
 
 SENTINEL_QUERIES: List[SentinelQuery] = [
+    # ==========================================================================
+    # HIA7: Expanded sentinel set (30+ queries across 10 categories)
+    # ==========================================================================
+
+    # --- Category 1: HoloIndex Core (5 queries) ---
+    SentinelQuery(
+        query="search engine query execution",
+        category="symbol",
+        evidence_rule={"path_contains": "search_engine"},
+        description="Find search engine module",
+    ),
+    SentinelQuery(
+        query="HoloIndex semantic code navigation",
+        category="symbol",
+        evidence_rule={"path_contains": "holo"},
+        description="Find HoloIndex class",
+    ),
+    SentinelQuery(
+        query="indexing engine symbol extraction",
+        category="symbol",
+        evidence_rule={"path_contains": "indexing_engine"},
+        description="Find indexing engine for symbol extraction",
+    ),
+    SentinelQuery(
+        query="backend routing turboquant embedding",
+        category="symbol",
+        evidence_rule={"path_contains": "backend_routing"},
+        description="Find TurboQuant backend routing logic",
+    ),
+    SentinelQuery(
+        query="search cache retrieval optimization",
+        category="symbol",
+        evidence_rule={"path_contains": "search_cache"},
+        description="Find search cache implementation",
+    ),
+
+    # --- Category 2: WSP Protocols (6 queries) ---
+    SentinelQuery(
+        query="WSP 97 system execution prompting",
+        category="wsp",
+        evidence_rule={"path_contains": "WSP_97"},
+        description="Find WSP 97 system execution protocol",
+    ),
+    SentinelQuery(
+        query="WSP 00 zen state attainment",
+        category="wsp",
+        evidence_rule={"path_contains": "WSP_00"},
+        description="Find WSP 00 zen state protocol",
+    ),
+    SentinelQuery(
+        query="WSP 11 WRE standard command",
+        category="wsp",
+        evidence_rule={"path_contains": "WSP_11"},
+        description="Find WSP 11 WRE command protocol",
+    ),
+    SentinelQuery(
+        query="WSP 22 ModLog documentation updates",
+        category="wsp",
+        evidence_rule={"path_contains": "WSP_22"},
+        description="Find WSP 22 ModLog protocol",
+    ),
+    SentinelQuery(
+        query="WSP 50 pre-action verification",
+        category="wsp",
+        evidence_rule={"path_contains": "WSP_50"},
+        description="Find WSP 50 verification protocol",
+    ),
+    SentinelQuery(
+        query="WSP 72 block independence isolation",
+        category="wsp",
+        evidence_rule={"path_contains": "WSP_72"},
+        description="Find WSP 72 independence protocol",
+    ),
+
+    # --- Category 3: OpenClaw / FoundUpJob (5 queries) ---
+    SentinelQuery(
+        query="openclaw intent planner routing",
+        category="symbol",
+        evidence_rule={"path_contains": "openclaw_intent"},
+        description="Find OpenClaw intent planner",
+    ),
+    SentinelQuery(
+        query="openclaw codebase agent navigation",
+        category="symbol",
+        evidence_rule={"path_contains": "openclaw_codebase"},
+        description="Find OpenClaw codebase agent",
+    ),
+    SentinelQuery(
+        query="route_foundup_job router",
+        category="symbol",
+        evidence_rule={"path_contains": "foundup_job"},
+        description="Find the FoundUpJob router",
+    ),
+    SentinelQuery(
+        query="foundup job contract lifecycle",
+        category="symbol",
+        evidence_rule={"path_contains": "foundup_job_contract"},
+        description="Find FoundUp job contract model",
+    ),
+    SentinelQuery(
+        query="openclaw action ledger persistence",
+        category="symbol",
+        evidence_rule={"path_contains": "openclaw_action_ledger"},
+        description="Find OpenClaw action ledger",
+    ),
+
+    # --- Category 4: WRE Queue/Worker (4 queries) ---
+    SentinelQuery(
+        query="WRE master orchestrator coordination",
+        category="symbol",
+        evidence_rule={"path_contains": "wre_master_orchestrator"},
+        description="Find WRE master orchestrator",
+    ),
+    SentinelQuery(
+        query="WRE skills loader registry",
+        category="symbol",
+        evidence_rule={"path_contains": "wre_skills_loader"},
+        description="Find WRE skills loader",
+    ),
+    SentinelQuery(
+        query="WRE bridge integration cursor",
+        category="symbol",
+        evidence_rule={"path_contains": "wre_bridge"},
+        description="Find WRE bridge integration",
+    ),
+    SentinelQuery(
+        query="pattern memory skill outcomes",
+        category="symbol",
+        evidence_rule={"path_contains": "pattern_memory"},
+        description="Find pattern memory for skill outcomes",
+    ),
+
+    # --- Category 5: BuildPlan / Swarm (3 queries) ---
+    SentinelQuery(
+        query="build plan generator hermes",
+        category="symbol",
+        evidence_rule={"path_contains": "build_plan"},
+        description="Find build plan generator",
+    ),
+    SentinelQuery(
+        query="swarm dispatch queue integration",
+        category="symbol",
+        evidence_rule={"path_contains": "swarm"},
+        description="Find swarm dispatch integration",
+    ),
+    SentinelQuery(
+        query="hermes foundup job executor",
+        category="symbol",
+        evidence_rule={"path_contains": "hermes_foundup"},
+        description="Find Hermes FoundUp job executor",
+    ),
+
+    # --- Category 6: pfMALL (3 queries) ---
+    SentinelQuery(
+        query="pfmall discovery youtube matching",
+        category="symbol",
+        evidence_rule={"path_contains": "pfmall_discovery"},
+        description="Find pfMALL discovery module",
+    ),
+    SentinelQuery(
+        query="pfmall catalog verification",
+        category="symbol",
+        evidence_rule={"path_contains": "pfmall_catalog"},
+        description="Find pfMALL catalog",
+    ),
+    SentinelQuery(
+        query="pfmall shell core grid loading",
+        category="symbol",
+        evidence_rule={"path_contains": "pfmall"},
+        description="Find pfMALL shell core",
+    ),
+
+    # --- Category 7: YouTube / Video (3 queries) ---
     SentinelQuery(
         query="YouTube channel registry",
         category="code",
         evidence_rule={"path_contains": "youtube_channel_registry"},
         description="Find the YouTube channel registry module",
     ),
+    SentinelQuery(
+        query="youtube transcript scraper video indexer",
+        category="symbol",
+        evidence_rule={"path_contains": "youtube_transcript"},
+        description="Find YouTube transcript scraper",
+    ),
+    SentinelQuery(
+        query="video comment engagement automation",
+        category="symbol",
+        evidence_rule={"path_contains": "video_comment"},
+        description="Find video comment engagement module",
+    ),
+
+    # --- Category 8: Skills / Scanner (3 queries) ---
+    SentinelQuery(
+        query="commit git workflow skill",
+        category="skill",
+        evidence_rule={"type_equals": "skillz"},
+        description="Find commit-related skill",
+    ),
+    SentinelQuery(
+        query="review pull request skill",
+        category="skill",
+        evidence_rule={"type_equals": "skillz"},
+        description="Find PR review skill",
+    ),
+    SentinelQuery(
+        query="orphan capability scanner detection",
+        category="symbol",
+        evidence_rule={"path_contains": "orphan"},
+        description="Find orphan capability scanner",
+    ),
+
+    # --- Category 9: Code / Symbol general (4 queries) ---
     SentinelQuery(
         query="demurrage economics simulator",
         category="code",
@@ -47,52 +254,30 @@ SENTINEL_QUERIES: List[SentinelQuery] = [
         description="Find Selenium browser automation code",
     ),
     SentinelQuery(
-        query="WSP 97 system execution prompting",  # HIA4B: Match actual WSP 97 topic
-        category="wsp",
-        evidence_rule={"path_contains": "WSP_97"},
-        description="Find WSP 97 system execution protocol",
+        query="agent permission manager confidence",
+        category="symbol",
+        evidence_rule={"path_contains": "agent_permission"},
+        description="Find agent permission manager",
     ),
     SentinelQuery(
-        query="WSP 00 zen state attainment",
-        category="wsp",
-        evidence_rule={"path_contains": "WSP_00"},  # path match more reliable than title
-        description="Find WSP 00 zen state protocol",
+        query="FAM daemon persistence jsonl",
+        category="symbol",
+        evidence_rule={"path_contains": "fam_daemon"},
+        description="Find FAM daemon persistence layer",
     ),
+
+    # --- Category 10: Docs / Knowledge (2 queries) ---
     SentinelQuery(
-        query="module organization domains",
+        query="module organization enterprise domains",
         category="wsp",
         evidence_rule={"path_contains": "WSP"},
         description="Find module organization WSP",
     ),
     SentinelQuery(
-        query="search engine query execution",  # HIA4B: Known indexing gap
+        query="gemma intent classifier binary",
         category="symbol",
-        evidence_rule={"path_contains": "search"},
-        description="Find search engine module (known gap: search_engine.py not indexed)",
-    ),
-    SentinelQuery(
-        query="HoloIndex semantic code navigation",  # HIA4B: More semantically aligned
-        category="symbol",
-        evidence_rule={"path_contains": "holo"},  # Relaxed: holo_index or holoindex
-        description="Find HoloIndex class",
-    ),
-    SentinelQuery(
-        query="route_foundup_job router",
-        category="symbol",
-        evidence_rule={"path_contains": "foundup_job"},
-        description="Find the FoundUpJob router",
-    ),
-    SentinelQuery(
-        query="commit git workflow skill",
-        category="skill",
-        evidence_rule={"type_equals": "skillz"},
-        description="Find commit-related skill",
-    ),
-    SentinelQuery(
-        query="review pull request skill",
-        category="skill",
-        evidence_rule={"type_equals": "skillz"},
-        description="Find PR review skill",
+        evidence_rule={"path_contains": "gemma_intent"},
+        description="Find Gemma intent classifier",
     ),
 ]
 


### PR DESCRIPTION
## Summary
- Expands HIA7 sentinel baseline from 11 to 38 queries.
- Documents HIA7B priority-root experiment (code reverted, NOT promoted).
- Final metrics establish expanded baseline gate.

## Final Metrics
| Metric | Value | Gate |
|--------|-------|------|
| Top-1 | 86.8% (33/38) | PASS (≥80%) |
| Top-5 | 92.1% (35/38) | FAIL (<95%) |

## HIA7B Decision
- Priority-root indexing experiment completed.
- Code change NOT promoted (reverted).
- Report documents findings for future reference.

## WSP_97 Boundaries
- Test/report/metrics/doc-ledger only
- No behavior-changing indexing root additions
- No BM25
- No Gemma/Qwen/LLM hot-path calls
- No TurboQuant routing changes

## Tests
- test_search_quality_baseline.py: pass
- test_confidence_scoring.py: pass
- test_backend_routing.py: pass
- Total: 46 passed

🤖 Generated with [Claude Code](https://claude.ai/code)