### PR TITLE
feat(wre): add retention-aware queue drain semantics

### DIFF
--- a/modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py
@@ -129,6 +129,27 @@ def clear_job_queue() -> None:
     _FOUNDUP_JOB_QUEUE.clear()
 
 
+def remove_jobs_by_id(job_ids: List[str]) -> int:
+    """
+    Remove specific jobs from the queue by job_id.
+
+    Args:
+        job_ids: List of job_id values to remove.
+
+    Returns:
+        Number of jobs removed.
+
+    WSP 97: Only removes explicitly specified jobs; retains others.
+    """
+    global _FOUNDUP_JOB_QUEUE
+    original_count = len(_FOUNDUP_JOB_QUEUE)
+    job_id_set = set(job_ids)
+    _FOUNDUP_JOB_QUEUE = [j for j in _FOUNDUP_JOB_QUEUE if j.job_id not in job_id_set]
+    removed = original_count - len(_FOUNDUP_JOB_QUEUE)
+    logger.info("[ORCHESTRATOR] Removed %d job(s) from queue; %d retained", removed, len(_FOUNDUP_JOB_QUEUE))
+    return removed
+
+
 # -----------------------------------------------------------------------------
 # Failure Reason Codes (WSP 97 explicit)
 # -----------------------------------------------------------------------------

--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -2,6 +2,63 @@
 
 ## Chronological Change Log
 
+### [2026-05-02] - WRE_QUEUE_RETENTION_SEMANTICS_PHASE1 (v0.8.9)
+
+**WSP Protocol References**: WSP 11 (Interface), WSP 97 (Truthful - no silent failures)
+**Impact Analysis**: Harden queue draining with retention-aware clearing
+
+#### Changes Made
+
+- `src/foundup_job_consumer.py`:
+  - Added `DrainResult` dataclass for retention metadata
+  - Added `ConsumerResult.should_clear` property - True only for terminal successful jobs with receipts
+  - Added `ConsumerResult.retention_reason` property - explicit reason for retained jobs
+  - Added `drain_openclaw_queue_with_retention()` method - selective job removal
+  - Updated `drain_openclaw_queue_once()` to use retention semantics
+  - Updated `drain_openclaw_queue_dry_run()` to return retention metadata
+
+- `modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py`:
+  - Added `remove_jobs_by_id()` function for selective queue removal
+
+- `tests/test_foundup_job_consumer.py`:
+  - Added `TestRetentionSemantics` class (4 tests)
+  - Updated existing tests for retention-aware behavior
+
+#### Retention Semantics
+
+| Condition | Action | Reason Code |
+|-----------|--------|-------------|
+| Terminal + receipt success | Clear | - |
+| Routing FAILED | Retain | `routing_failed` |
+| Routing BLOCKED | Retain | `routing_blocked` |
+| Action UNSUPPORTED | Retain | `action_unsupported` |
+| Not dispatched | Retain | `not_dispatched` |
+| Not terminal | Retain | `not_terminal` |
+| Receipt emission failed | Retain | `receipt_emission_failed` |
+
+#### Example Output
+
+```json
+{
+  "job_count": 3,
+  "cleared_job_ids": ["job_success"],
+  "retained_job_ids": ["job_fail1", "job_fail2"],
+  "retention_reasons": {"job_fail1": "routing_failed", "job_fail2": "routing_blocked"},
+  "cleared_count": 1,
+  "retained_count": 2,
+  "summary": {"verification_complete": false, "cabr_ready": false, "payout_ready": false}
+}
+```
+
+#### Verification
+
+```bash
+python -m pytest modules/infrastructure/wre_core/tests/test_foundup_job_consumer.py -q
+# 29 passed
+```
+
+---
+
 ### [2026-05-02] - WRE_CLOSED_LOOP_DRY_RUN_COMMAND_PHASE1 (v0.8.8)
 
 **WSP Protocol References**: WSP 11 (Interface), WSP 97 (Truthful)

--- a/modules/infrastructure/wre_core/src/foundup_job_consumer.py
+++ b/modules/infrastructure/wre_core/src/foundup_job_consumer.py
@@ -52,6 +52,52 @@ if TYPE_CHECKING:
 logger = logging.getLogger("wre_foundup_job_consumer")
 
 
+# ---------------------------------------------------------------------------
+# Drain Result with Retention Metadata
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DrainResult:
+    """
+    Result of draining the FoundUpJob queue with retention semantics.
+
+    WSP 97 truth:
+      - Only successful terminal jobs with receipts are cleared
+      - Failed/incomplete jobs are retained with explicit reasons
+      - No silent dropping of failures
+    """
+
+    results: List["ConsumerResult"]
+    """All ConsumerResults from the drain operation."""
+
+    cleared_job_ids: List[str]
+    """Job IDs that were cleared (successful terminal with receipt)."""
+
+    retained_job_ids: List[str]
+    """Job IDs that were retained (failed/incomplete)."""
+
+    retention_reasons: Dict[str, str]
+    """Map of retained job_id -> retention reason."""
+
+    cleared_count: int = 0
+    """Number of jobs cleared."""
+
+    retained_count: int = 0
+    """Number of jobs retained."""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dict for logging/JSON."""
+        return {
+            "results": [r.to_dict() for r in self.results],
+            "cleared_job_ids": self.cleared_job_ids,
+            "retained_job_ids": self.retained_job_ids,
+            "retention_reasons": self.retention_reasons,
+            "cleared_count": self.cleared_count,
+            "retained_count": self.retained_count,
+        }
+
+
 def _utc_now() -> datetime:
     """Return current UTC timestamp."""
     return datetime.now(timezone.utc)
@@ -153,6 +199,44 @@ class ConsumerResult:
     def has_receipt(self) -> bool:
         """True if receipt was emitted."""
         return self.receipt_emission is not None and self.receipt_emission.success
+
+    @property
+    def should_clear(self) -> bool:
+        """
+        True if job completed successfully and should be cleared from queue.
+
+        Criteria for clearing (all must be true):
+          - Dispatched to Hermes
+          - Reached terminal state (succeeded/failed/blocked)
+          - Receipt emitted successfully
+
+        Jobs that fail routing, Hermes dispatch, or receipt emission
+        are retained for retry or manual inspection.
+        """
+        return self.dispatched and self.is_terminal and self.has_receipt
+
+    @property
+    def retention_reason(self) -> Optional[str]:
+        """
+        Why this job should be retained (not cleared).
+
+        Returns None if job should be cleared.
+        """
+        if self.should_clear:
+            return None
+        if not self.dispatched:
+            if self.route_status == RouteStatus.FAILED:
+                return "routing_failed"
+            if self.route_status == RouteStatus.BLOCKED:
+                return "routing_blocked"
+            if self.route_status == RouteStatus.UNSUPPORTED:
+                return "action_unsupported"
+            return "not_dispatched"
+        if not self.is_terminal:
+            return "not_terminal"
+        if not self.has_receipt:
+            return "receipt_emission_failed"
+        return "unknown"
 
     @property
     def verification_complete(self) -> bool:
@@ -436,45 +520,115 @@ class FoundUpJobConsumer:
         """
         Drain the OpenClaw FoundUpJob queue once.
 
-        Imports the queue from openclaw_foundup_orchestrator, processes all
-        jobs, and optionally clears the queue after successful processing.
-
         Args:
-            clear: If True, clear the queue after draining. Default True.
+            clear: If True, clear successful jobs after draining. Default True.
+                   Uses retention-aware clearing: only clears jobs that
+                   completed successfully with receipt emission.
 
         Returns:
             List of ConsumerResult for each job in the queue.
 
         Note:
             This is a synchronous operation. No daemon loop.
+            Failed/incomplete jobs are retained in the queue.
+        """
+        drain_result = self.drain_openclaw_queue_with_retention(clear=clear)
+        return drain_result.results
+
+    def drain_openclaw_queue_with_retention(self, clear: bool = True) -> DrainResult:
+        """
+        Drain the OpenClaw FoundUpJob queue with retention semantics.
+
+        Only clears jobs that:
+          - Were dispatched to Hermes
+          - Reached terminal state (succeeded/failed/blocked)
+          - Had receipt emitted successfully
+
+        Jobs that fail routing, Hermes dispatch, or receipt emission
+        are retained in the queue for retry or manual inspection.
+
+        Args:
+            clear: If True, clear successful jobs. Default True.
+                   Failed jobs are always retained.
+
+        Returns:
+            DrainResult with full retention metadata.
+
+        WSP 97 truth:
+          - No silent dropping of failures
+          - Explicit retention reasons for each retained job
         """
         try:
             from modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator import (
                 get_job_queue,
-                clear_job_queue,
+                remove_jobs_by_id,
             )
         except ImportError as e:
             logger.error("[CONSUMER] OpenClaw orchestrator not available: %s", e)
-            return []
+            return DrainResult(
+                results=[],
+                cleared_job_ids=[],
+                retained_job_ids=[],
+                retention_reasons={},
+                cleared_count=0,
+                retained_count=0,
+            )
 
         queue = get_job_queue()
         job_count = len(queue)
 
         if job_count == 0:
             logger.info("[CONSUMER] Queue empty, nothing to drain")
-            return []
+            return DrainResult(
+                results=[],
+                cleared_job_ids=[],
+                retained_job_ids=[],
+                retention_reasons={},
+                cleared_count=0,
+                retained_count=0,
+            )
 
         logger.info("[CONSUMER] Draining %d job(s) from OpenClaw queue", job_count)
 
         # Drain all jobs
         results = self.drain_jobs(queue)
 
-        # Clear queue only after successful drain (if requested)
-        if clear:
-            clear_job_queue()
-            logger.info("[CONSUMER] Cleared OpenClaw queue after drain")
+        # Classify results for retention
+        cleared_job_ids: List[str] = []
+        retained_job_ids: List[str] = []
+        retention_reasons: Dict[str, str] = {}
 
-        return results
+        for result in results:
+            if result.should_clear:
+                cleared_job_ids.append(result.job_id)
+            else:
+                retained_job_ids.append(result.job_id)
+                retention_reasons[result.job_id] = result.retention_reason or "unknown"
+
+        # Remove only successful jobs if clear=True
+        if clear and cleared_job_ids:
+            removed = remove_jobs_by_id(cleared_job_ids)
+            logger.info(
+                "[CONSUMER] Cleared %d successful job(s); %d retained",
+                removed,
+                len(retained_job_ids),
+            )
+
+        if retained_job_ids:
+            logger.warning(
+                "[CONSUMER] Retained %d job(s) in queue: %s",
+                len(retained_job_ids),
+                {jid: retention_reasons[jid] for jid in retained_job_ids},
+            )
+
+        return DrainResult(
+            results=results,
+            cleared_job_ids=cleared_job_ids,
+            retained_job_ids=retained_job_ids,
+            retention_reasons=retention_reasons,
+            cleared_count=len(cleared_job_ids),
+            retained_count=len(retained_job_ids),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -501,38 +655,51 @@ def drain_openclaw_queue_dry_run(clear: bool = True) -> Dict[str, Any]:
 
     Convenience function that:
       1. Creates a FoundUpJobConsumer(dry_run=True)
-      2. Drains the OpenClaw queue once
-      3. Returns structured evidence for each job
+      2. Drains the OpenClaw queue with retention semantics
+      3. Returns structured evidence including retention metadata
 
     Args:
-        clear: If True, clear the queue after draining. Default True.
+        clear: If True, clear successful jobs after draining. Default True.
+               Failed jobs are always retained.
 
     Returns:
         Dict containing:
           - job_count: Number of jobs drained
           - results: List of ConsumerResult.to_dict() for each job
           - dry_run: True (always)
-          - summary: Aggregated stats (dispatched, receipts, terminals)
+          - cleared_job_ids: Jobs that were cleared
+          - retained_job_ids: Jobs that were retained
+          - retention_reasons: Map of retained job_id -> reason
+          - summary: Aggregated stats
 
     WSP 97 truth boundaries:
       - dry_run=True always
       - verification_complete=False always
       - cabr_ready=False always
       - payout_ready=False always
+      - No silent dropping of failures
     """
     consumer = FoundUpJobConsumer(dry_run=True)
-    results = consumer.drain_openclaw_queue_once(clear=clear)
+    drain_result = consumer.drain_openclaw_queue_with_retention(clear=clear)
 
-    # Aggregate stats (Phase 1A - no receipt binding yet)
-    dispatched_count = sum(1 for r in results if r.dispatched)
+    # Aggregate stats
+    dispatched_count = sum(1 for r in drain_result.results if r.dispatched)
+    receipt_count = sum(1 for r in drain_result.results if r.has_receipt)
+    terminal_count = sum(1 for r in drain_result.results if r.is_terminal)
 
     return {
-        "job_count": len(results),
-        "results": [r.to_dict() for r in results],
+        "job_count": len(drain_result.results),
+        "results": [r.to_dict() for r in drain_result.results],
         "dry_run": True,
-        "queue_cleared": clear,
+        "cleared_job_ids": drain_result.cleared_job_ids,
+        "retained_job_ids": drain_result.retained_job_ids,
+        "retention_reasons": drain_result.retention_reasons,
+        "cleared_count": drain_result.cleared_count,
+        "retained_count": drain_result.retained_count,
         "summary": {
             "dispatched": dispatched_count,
+            "receipts_emitted": receipt_count,
+            "terminal_jobs": terminal_count,
             "verification_complete": False,
             "cabr_ready": False,
             "payout_ready": False,

--- a/modules/infrastructure/wre_core/tests/TestModLog.md
+++ b/modules/infrastructure/wre_core/tests/TestModLog.md
@@ -1,5 +1,18 @@
 # TestModLog - wre_core/tests
 
+## 2026-05-02: Queue retention semantics + retention-aware drain
+
+- Command: `python -m pytest modules/infrastructure/wre_core/tests/test_foundup_job_consumer.py -v`
+- Status: PASS
+- Result: `29 passed`
+- Notes:
+  - Added `TestRetentionSemantics` class with 4 tests
+  - Tests routing_failure, routing_blocked, empty queue, should_clear properties
+  - Updated TestDrainOpenClawQueue for retention-aware behavior
+  - Updated TestDrainOpenClawQueueDryRun for retention metadata output
+
+---
+
 ## 2026-05-02: drain_openclaw_queue_dry_run convenience function + CLI command
 
 - Command: `python -m pytest modules/infrastructure/wre_core/tests/test_foundup_job_consumer.py -v`

--- a/modules/infrastructure/wre_core/tests/TestModLog.md
+++ b/modules/infrastructure/wre_core/tests/TestModLog.md
@@ -1,5 +1,18 @@
 # TestModLog - wre_core/tests
 
+## 2026-05-02: Success clearing proof for retention semantics
+
+- Command: `python -m pytest modules/infrastructure/wre_core/tests/test_foundup_job_consumer.py -q`
+- Status: PASS
+- Result: `30 passed`
+- Notes:
+  - Added `test_successful_terminal_job_cleared` to TestRetentionSemantics
+  - Proves terminal + receipt success -> job cleared from queue
+  - Asserts job_id in cleared_job_ids, not in retained_job_ids
+  - Confirms WSP 97 truth fields remain false
+
+---
+
 ## 2026-05-02: Queue retention semantics + retention-aware drain
 
 - Command: `python -m pytest modules/infrastructure/wre_core/tests/test_foundup_job_consumer.py -v`

--- a/modules/infrastructure/wre_core/tests/test_foundup_job_consumer.py
+++ b/modules/infrastructure/wre_core/tests/test_foundup_job_consumer.py
@@ -570,6 +570,87 @@ class TestRetentionSemantics:
         assert unsupported_result.should_clear is False
         assert unsupported_result.retention_reason == "action_unsupported"
 
+    @patch(
+        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.remove_jobs_by_id"
+    )
+    @patch(
+        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.get_job_queue"
+    )
+    @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
+    @patch("modules.foundups.agent.src.hermes_adapter.HermesFoundUpBuilder")
+    def test_successful_terminal_job_cleared(
+        self, mock_builder_class, mock_route, mock_get_queue, mock_remove
+    ):
+        """
+        Successful terminal dry-run job is cleared from queue.
+
+        Proves:
+          - Terminal + receipt success -> job_id in cleared_job_ids
+          - Not in retained_job_ids
+          - cleared_count == 1, retained_count == 0
+          - WSP 97 fields remain false
+        """
+        from modules.communication.moltbot_bridge.src.foundup_job_contract import (
+            create_job,
+        )
+
+        # Setup routing to HERMES_BUILDER
+        mock_envelope = MagicMock()
+        mock_envelope.route_status = RouteStatus.ROUTED
+        mock_envelope.target_backend = TargetBackend.HERMES_BUILDER
+        mock_envelope.reason_human = "Routed to hermes_builder"
+        mock_envelope.job_id = "job_success_clear"
+        mock_route.return_value = mock_envelope
+
+        # Setup Hermes to return successful terminal result
+        mock_builder = MagicMock()
+        mock_builder.dry_run = True
+        mock_builder.extract_foundup.return_value = {
+            "success": True,
+            "source_module": "modules/foundups/success_test",
+            "target_repo": "FOUNDUPS/success_test",
+            "exfoliation_gate": {"passed": True, "checks": {}},
+            "dry_run": True,
+        }
+        mock_builder_class.return_value = mock_builder
+
+        # Create real job with proper payload
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="success_test",
+            payload={"module_path": "modules/foundups/success_test"},
+        )
+        # Override job_id to match envelope
+        job.job_id = "job_success_clear"
+
+        mock_get_queue.return_value = [job]
+        mock_remove.return_value = 1  # 1 job removed
+
+        consumer = FoundUpJobConsumer(dry_run=True)
+        drain_result = consumer.drain_openclaw_queue_with_retention(clear=True)
+
+        # Assert job is cleared, not retained
+        assert drain_result.cleared_count == 1
+        assert drain_result.retained_count == 0
+        assert "job_success_clear" in drain_result.cleared_job_ids
+        assert "job_success_clear" not in drain_result.retained_job_ids
+        assert drain_result.retention_reasons == {}
+
+        # Assert remove_jobs_by_id was called with the successful job
+        mock_remove.assert_called_once_with(["job_success_clear"])
+
+        # Assert WSP 97 truth fields in summary (via dry_run helper)
+        result = drain_result.results[0]
+        assert result.verification_complete is False
+        assert result.cabr_ready is False
+        assert result.payout_ready is False
+
+        # Verify it was actually terminal with receipt
+        assert result.is_terminal is True
+        assert result.has_receipt is True
+        assert result.should_clear is True
+
 
 # ---------------------------------------------------------------------------
 # Test: Receipt emitter rejects non-terminal jobs

--- a/modules/infrastructure/wre_core/tests/test_foundup_job_consumer.py
+++ b/modules/infrastructure/wre_core/tests/test_foundup_job_consumer.py
@@ -362,19 +362,19 @@ class TestDrainJobs:
 
 
 class TestDrainOpenClawQueue:
-    """Test drain_openclaw_queue_once behavior."""
+    """Test drain_openclaw_queue_once behavior with retention semantics."""
 
     @patch(
-        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.clear_job_queue"
+        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.remove_jobs_by_id"
     )
     @patch(
         "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.get_job_queue"
     )
     @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
-    def test_drain_clears_queue_after_success(
-        self, mock_route, mock_get_queue, mock_clear_queue
+    def test_drain_retains_blocked_jobs(
+        self, mock_route, mock_get_queue, mock_remove
     ):
-        """drain_openclaw_queue_once clears queue after successful drain."""
+        """Blocked jobs are retained, not cleared (retention semantics)."""
         mock_envelope = MagicMock()
         mock_envelope.route_status = RouteStatus.BLOCKED
         mock_envelope.target_backend = TargetBackend.NONE
@@ -398,20 +398,22 @@ class TestDrainOpenClawQueue:
         consumer = FoundUpJobConsumer(dry_run=True)
         results = consumer.drain_openclaw_queue_once(clear=True)
 
+        # Jobs were processed
         assert len(results) == 2
-        mock_clear_queue.assert_called_once()
+        # But blocked jobs should not be removed (retained)
+        mock_remove.assert_not_called()
 
     @patch(
-        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.clear_job_queue"
+        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.remove_jobs_by_id"
     )
     @patch(
         "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.get_job_queue"
     )
     @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
     def test_drain_does_not_clear_if_clear_false(
-        self, mock_route, mock_get_queue, mock_clear_queue
+        self, mock_route, mock_get_queue, mock_remove
     ):
-        """drain_openclaw_queue_once with clear=False does not clear queue."""
+        """drain_openclaw_queue_once with clear=False does not remove jobs."""
         mock_envelope = MagicMock()
         mock_envelope.route_status = RouteStatus.BLOCKED
         mock_envelope.target_backend = TargetBackend.NONE
@@ -431,7 +433,7 @@ class TestDrainOpenClawQueue:
         results = consumer.drain_openclaw_queue_once(clear=False)
 
         assert len(results) == 1
-        mock_clear_queue.assert_not_called()
+        mock_remove.assert_not_called()
 
     @patch(
         "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.get_job_queue"
@@ -444,6 +446,129 @@ class TestDrainOpenClawQueue:
         results = consumer.drain_openclaw_queue_once()
 
         assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Test: Retention Semantics
+# ---------------------------------------------------------------------------
+
+
+class TestRetentionSemantics:
+    """Test retention-aware drain behavior."""
+
+    @patch(
+        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.remove_jobs_by_id"
+    )
+    @patch(
+        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.get_job_queue"
+    )
+    @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
+    def test_routing_failure_retained(self, mock_route, mock_get_queue, mock_remove):
+        """Jobs with routing failure are retained with reason."""
+        mock_envelope = MagicMock()
+        mock_envelope.route_status = RouteStatus.FAILED
+        mock_envelope.target_backend = TargetBackend.NONE
+        mock_envelope.reason_human = "Routing failed"
+        mock_envelope.job_id = "job_fail"
+        mock_route.return_value = mock_envelope
+
+        mock_get_queue.return_value = [
+            MockFoundUpJob(
+                job_id="job_fail",
+                tenant_id="tenant_test",
+                requested_action="build_foundup",
+            ),
+        ]
+
+        consumer = FoundUpJobConsumer(dry_run=True)
+        drain_result = consumer.drain_openclaw_queue_with_retention(clear=True)
+
+        assert drain_result.retained_count == 1
+        assert drain_result.cleared_count == 0
+        assert "job_fail" in drain_result.retained_job_ids
+        assert drain_result.retention_reasons["job_fail"] == "routing_failed"
+        mock_remove.assert_not_called()
+
+    @patch(
+        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.remove_jobs_by_id"
+    )
+    @patch(
+        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.get_job_queue"
+    )
+    @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
+    def test_routing_blocked_retained(self, mock_route, mock_get_queue, mock_remove):
+        """Jobs blocked by security gate are retained."""
+        mock_envelope = MagicMock()
+        mock_envelope.route_status = RouteStatus.BLOCKED
+        mock_envelope.target_backend = TargetBackend.NONE
+        mock_envelope.reason_human = "Security gate failed"
+        mock_envelope.job_id = "job_blocked"
+        mock_route.return_value = mock_envelope
+
+        mock_get_queue.return_value = [
+            MockFoundUpJob(
+                job_id="job_blocked",
+                tenant_id="tenant_test",
+                requested_action="build_foundup",
+            ),
+        ]
+
+        consumer = FoundUpJobConsumer(dry_run=True)
+        drain_result = consumer.drain_openclaw_queue_with_retention(clear=True)
+
+        assert drain_result.retained_count == 1
+        assert drain_result.retention_reasons["job_blocked"] == "routing_blocked"
+
+    @patch(
+        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.get_job_queue"
+    )
+    def test_empty_queue_no_retained_consumed(self, mock_get_queue):
+        """Empty queue returns no retained or consumed jobs."""
+        mock_get_queue.return_value = []
+
+        consumer = FoundUpJobConsumer(dry_run=True)
+        drain_result = consumer.drain_openclaw_queue_with_retention(clear=True)
+
+        assert drain_result.cleared_count == 0
+        assert drain_result.retained_count == 0
+        assert drain_result.cleared_job_ids == []
+        assert drain_result.retained_job_ids == []
+        assert drain_result.retention_reasons == {}
+
+    def test_consumer_result_should_clear_properties(self):
+        """ConsumerResult has should_clear and retention_reason properties."""
+        # Blocked route - should retain
+        blocked_result = ConsumerResult(
+            job_id="blocked_job",
+            dispatched=False,
+            route_status=RouteStatus.BLOCKED,
+            target_backend=TargetBackend.NONE,
+            reason="Blocked",
+        )
+        assert blocked_result.should_clear is False
+        assert blocked_result.retention_reason == "routing_blocked"
+
+        # Failed route - should retain
+        failed_result = ConsumerResult(
+            job_id="failed_job",
+            dispatched=False,
+            route_status=RouteStatus.FAILED,
+            target_backend=TargetBackend.NONE,
+            reason="Failed",
+        )
+        assert failed_result.should_clear is False
+        assert failed_result.retention_reason == "routing_failed"
+
+        # Unsupported action - should retain
+        unsupported_result = ConsumerResult(
+            job_id="unsupported_job",
+            dispatched=False,
+            route_status=RouteStatus.UNSUPPORTED,
+            target_backend=TargetBackend.NONE,
+            reason="Unsupported",
+        )
+        assert unsupported_result.should_clear is False
+        assert unsupported_result.retention_reason == "action_unsupported"
 
 
 # ---------------------------------------------------------------------------
@@ -869,19 +994,19 @@ class TestConsumerResultReceiptBinding:
 
 
 class TestDrainOpenClawQueueDryRun:
-    """Test drain_openclaw_queue_dry_run convenience function."""
+    """Test drain_openclaw_queue_dry_run convenience function with retention."""
 
     @patch(
-        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.clear_job_queue"
+        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.remove_jobs_by_id"
     )
     @patch(
         "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.get_job_queue"
     )
     @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
-    def test_drain_dry_run_returns_structured_evidence(
-        self, mock_route, mock_get_queue, mock_clear_queue
+    def test_drain_dry_run_returns_retention_metadata(
+        self, mock_route, mock_get_queue, mock_remove
     ):
-        """drain_openclaw_queue_dry_run returns structured evidence dict."""
+        """drain_openclaw_queue_dry_run returns retention metadata."""
         mock_envelope = MagicMock()
         mock_envelope.route_status = RouteStatus.BLOCKED
         mock_envelope.target_backend = TargetBackend.NONE
@@ -904,28 +1029,35 @@ class TestDrainOpenClawQueueDryRun:
 
         summary = drain_openclaw_queue_dry_run(clear=True)
 
-        # Verify structure
+        # Verify structure with retention fields
         assert "job_count" in summary
         assert "results" in summary
         assert "dry_run" in summary
-        assert "queue_cleared" in summary
+        assert "cleared_job_ids" in summary
+        assert "retained_job_ids" in summary
+        assert "retention_reasons" in summary
+        assert "cleared_count" in summary
+        assert "retained_count" in summary
         assert "summary" in summary
 
-        # Verify values
+        # Verify values - blocked jobs are retained
         assert summary["job_count"] == 2
         assert summary["dry_run"] is True
-        assert summary["queue_cleared"] is True
         assert len(summary["results"]) == 2
+        assert summary["retained_count"] == 2
+        assert summary["cleared_count"] == 0
+        assert "job_dry1" in summary["retained_job_ids"]
+        assert "job_dry2" in summary["retained_job_ids"]
 
     @patch(
-        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.clear_job_queue"
+        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.remove_jobs_by_id"
     )
     @patch(
         "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.get_job_queue"
     )
     @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
     def test_drain_dry_run_wsp97_truth_fields(
-        self, mock_route, mock_get_queue, mock_clear_queue
+        self, mock_route, mock_get_queue, mock_remove
     ):
         """drain_openclaw_queue_dry_run enforces WSP 97 truth boundaries."""
         mock_envelope = MagicMock()
@@ -954,7 +1086,7 @@ class TestDrainOpenClawQueueDryRun:
         "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.get_job_queue"
     )
     def test_drain_dry_run_empty_queue(self, mock_get_queue):
-        """drain_openclaw_queue_dry_run with empty queue returns empty results."""
+        """drain_openclaw_queue_dry_run with empty queue returns no retained/consumed."""
         mock_get_queue.return_value = []
 
         summary = drain_openclaw_queue_dry_run()
@@ -962,19 +1094,24 @@ class TestDrainOpenClawQueueDryRun:
         assert summary["job_count"] == 0
         assert summary["results"] == []
         assert summary["dry_run"] is True
+        assert summary["cleared_count"] == 0
+        assert summary["retained_count"] == 0
+        assert summary["cleared_job_ids"] == []
+        assert summary["retained_job_ids"] == []
+        assert summary["retention_reasons"] == {}
         assert summary["summary"]["dispatched"] == 0
 
     @patch(
-        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.clear_job_queue"
+        "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.remove_jobs_by_id"
     )
     @patch(
         "modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator.get_job_queue"
     )
     @patch("modules.infrastructure.wre_core.src.foundup_job_consumer.route_foundup_job")
-    def test_drain_dry_run_no_clear_flag(
-        self, mock_route, mock_get_queue, mock_clear_queue
+    def test_drain_dry_run_includes_retention_reasons(
+        self, mock_route, mock_get_queue, mock_remove
     ):
-        """drain_openclaw_queue_dry_run with clear=False does not clear."""
+        """drain_openclaw_queue_dry_run includes retention reasons for each job."""
         mock_envelope = MagicMock()
         mock_envelope.route_status = RouteStatus.BLOCKED
         mock_envelope.target_backend = TargetBackend.NONE
@@ -990,7 +1127,11 @@ class TestDrainOpenClawQueueDryRun:
             ),
         ]
 
-        summary = drain_openclaw_queue_dry_run(clear=False)
+        summary = drain_openclaw_queue_dry_run(clear=True)
 
-        assert summary["queue_cleared"] is False
-        mock_clear_queue.assert_not_called()
+        # Blocked job should have retention reason
+        assert summary["retained_count"] == 1
+        assert "job_nc1" in summary["retention_reasons"]
+        assert summary["retention_reasons"]["job_nc1"] == "routing_blocked"
+        # No jobs removed since all were blocked
+        mock_remove.assert_not_called()


### PR DESCRIPTION
## Summary
- Adds retention-aware drain semantics for FoundUpJob queue.
- Adds `remove_jobs_by_id()` for selective queue removal.
- Clears successful terminal jobs with receipt success.
- Retains routing failures, blocked jobs, unsupported actions, and receipt emission failures.
- Output includes cleared/retained IDs and retention reasons.

## Retention Logic
| Condition | Action |
|-----------|--------|
| Terminal + receipt success | CLEAR |
| Routing failure | RETAIN |
| Blocked job | RETAIN |
| Unsupported action | RETAIN |
| Receipt emission failure | RETAIN |

## WSP_97 Boundaries
- verification_complete=False
- cabr_ready=False
- payout_ready=False
- No daemon loop
- No persistent queue
- No real build mutation
- No CABR/reward/payout/token claims

## Tests
- test_foundup_job_consumer.py: 30 passed
- test_internal_voteballot_build_poc.py: 33 passed
- Total: 63 passed

🤖 Generated with [Claude Code](https://claude.ai/code)