### PR TITLE
fix(wre): validate FoundUpJob evidence references

### DIFF
--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -2,6 +2,65 @@
 
 ## Chronological Change Log
 
+### [2026-05-02] - WRE_EVIDENCE_REFS_VALIDATION_PHASE1 (v0.8.11)
+
+**WSP Protocol References**: WSP 11 (Interface), WSP 97 (Truthful - evidence traceability only)
+**Impact Analysis**: Add evidence reference validation for FoundUpJob execution envelopes
+
+#### Changes Made
+
+- `src/foundup_job_router.py`:
+  - Added `EnvelopeValidationCode.VALID_EVIDENCE_PENDING` for dry-run pending state
+  - Added `EnvelopeValidationCode.INVALID_EVIDENCE_REFS_TYPE` for wrong type
+  - Added `EnvelopeValidationCode.INVALID_EVIDENCE_REF_ENTRY` for malformed entries
+  - Added `EnvelopeValidationResult` fields: evidence_refs_validated, evidence_refs_count, evidence_pending
+  - Added WSP 97 truth fields: verification_complete=False, cabr_ready=False, payout_ready=False (always False)
+  - Added `_validate_evidence_refs()` helper function
+  - Updated `validate_foundup_job_envelope()` to validate evidence shape
+
+- `tests/test_foundup_job_envelope_validation.py`:
+  - Added 22 new tests for evidence validation
+  - TestEvidenceRefsListOfStrings (2 tests)
+  - TestEvidenceRefsEmptyWithDryRun (3 tests)
+  - TestEvidenceRefsWrongType (3 tests)
+  - TestEvidenceRefsEmptyString (2 tests)
+  - TestEvidenceRefsMalformedDict (6 tests)
+  - TestEvidenceRefsWSP97TruthFields (4 tests)
+  - TestGenericDAEEvidenceBehavior (2 tests)
+
+#### Evidence Validation Rules
+
+| Condition | Result | Code |
+|-----------|--------|------|
+| List of non-empty strings | Valid | VALID |
+| Empty list in dry-run | Valid (pending) | VALID_EVIDENCE_PENDING |
+| No evidence_refs in dry-run | Valid (pending) | VALID_EVIDENCE_PENDING |
+| Dict with path/id/ref field | Valid | VALID |
+| Not a list | Invalid | INVALID_EVIDENCE_REFS_TYPE |
+| Empty string in list | Invalid | INVALID_EVIDENCE_REF_ENTRY |
+| Dict without path/id/ref | Invalid | INVALID_EVIDENCE_REF_ENTRY |
+| Non-string/dict in list | Invalid | INVALID_EVIDENCE_REF_ENTRY |
+
+#### WSP 97 Truth Boundaries
+
+- `verification_complete`: Always False (evidence proves traceability only)
+- `cabr_ready`: Always False (evidence does NOT enable CABR claims)
+- `payout_ready`: Always False (evidence does NOT enable payout claims)
+- `evidence_refs_validated`: True if evidence shape is valid
+- `evidence_pending`: True if dry-run mode with no/empty evidence
+
+#### Verification
+
+```bash
+python -m pytest modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py -q
+# 42 passed
+
+python -m pytest modules/infrastructure/wre_core/tests -q --ignore=modules/infrastructure/wre_core/tests/test_production_gates.py
+# 448 passed
+```
+
+---
+
 ### [2026-05-02] - WRE_ENVELOPE_VALIDATION_FOUNDUPJOB_PHASE1 (v0.8.10)
 
 **WSP Protocol References**: WSP 11 (Interface), WSP 50 (Pre-Action Verification), WSP 97 (Truthful)

--- a/modules/infrastructure/wre_core/src/foundup_job_router.py
+++ b/modules/infrastructure/wre_core/src/foundup_job_router.py
@@ -144,6 +144,7 @@ class EnvelopeValidationCode(str, Enum):
     # Valid
     VALID = "VALID"
     VALID_DRY_RUN_DEFAULTED = "VALID_DRY_RUN_DEFAULTED"
+    VALID_EVIDENCE_PENDING = "VALID_EVIDENCE_PENDING"
 
     # Invalid - Missing Fields
     MISSING_JOB_ID = "MISSING_JOB_ID"
@@ -155,6 +156,10 @@ class EnvelopeValidationCode(str, Enum):
     # Invalid - Policy
     DRY_RUN_NOT_SET = "DRY_RUN_NOT_SET"
 
+    # Invalid - Evidence
+    INVALID_EVIDENCE_REFS_TYPE = "INVALID_EVIDENCE_REFS_TYPE"
+    INVALID_EVIDENCE_REF_ENTRY = "INVALID_EVIDENCE_REF_ENTRY"
+
 
 @dataclass
 class EnvelopeValidationResult:
@@ -162,6 +167,7 @@ class EnvelopeValidationResult:
     Result of FoundUpJob envelope validation.
 
     WSP 97 Truth: Returns explicit validation status with missing field list.
+    Evidence validation does NOT imply verification_complete, cabr_ready, or payout_ready.
     """
 
     valid: bool
@@ -185,6 +191,26 @@ class EnvelopeValidationResult:
     policy_flags_snapshot: Dict[str, bool] = field(default_factory=dict)
     """Policy flags at validation time (if present)."""
 
+    # === Evidence Validation (WSP 97 Truth) ===
+    evidence_refs_validated: bool = False
+    """True if evidence_refs passed validation."""
+
+    evidence_refs_count: int = 0
+    """Number of evidence refs in envelope."""
+
+    evidence_pending: bool = False
+    """True if evidence is pending (empty in dry-run mode)."""
+
+    # === WSP 97 Truth Fields (ALWAYS False at validation time) ===
+    verification_complete: bool = False
+    """WSP 97: Always False. Evidence presence does NOT imply verification."""
+
+    cabr_ready: bool = False
+    """WSP 97: Always False. Evidence does NOT enable CABR claims."""
+
+    payout_ready: bool = False
+    """WSP 97: Always False. Evidence does NOT enable payout claims."""
+
     def to_dict(self) -> Dict[str, Any]:
         """Serialize for logging/API response."""
         return {
@@ -195,6 +221,13 @@ class EnvelopeValidationResult:
             "validation_message": self.validation_message,
             "dry_run_defaulted": self.dry_run_defaulted,
             "policy_flags_snapshot": self.policy_flags_snapshot,
+            "evidence_refs_validated": self.evidence_refs_validated,
+            "evidence_refs_count": self.evidence_refs_count,
+            "evidence_pending": self.evidence_pending,
+            # WSP 97 Truth: Always False at validation time
+            "verification_complete": self.verification_complete,
+            "cabr_ready": self.cabr_ready,
+            "payout_ready": self.payout_ready,
         }
 
 
@@ -333,12 +366,36 @@ def validate_foundup_job_envelope(envelope: Dict[str, Any]) -> EnvelopeValidatio
             dry_run_defaulted = True
             policy_snapshot["dry_run_mode"] = True
 
-    # Valid FoundUpJob envelope
-    validation_code = (
-        EnvelopeValidationCode.VALID_DRY_RUN_DEFAULTED
-        if dry_run_defaulted
-        else EnvelopeValidationCode.VALID
+    # Evidence refs validation (WSP 97: validate shape, not verification)
+    evidence_result = _validate_evidence_refs(
+        envelope.get("evidence_refs"),
+        is_dry_run=policy_snapshot.get("dry_run_mode", True),
     )
+
+    if not evidence_result["valid"]:
+        return EnvelopeValidationResult(
+            valid=False,
+            envelope_type=EnvelopeType.FOUNDUP_JOB,
+            validation_code=evidence_result["code"],
+            missing_fields=[],
+            validation_message=evidence_result["message"],
+            dry_run_defaulted=dry_run_defaulted,
+            policy_flags_snapshot=policy_snapshot,
+            evidence_refs_validated=False,
+            evidence_refs_count=evidence_result.get("count", 0),
+            evidence_pending=False,
+        )
+
+    # Valid FoundUpJob envelope
+    evidence_pending = evidence_result.get("pending", False)
+
+    # Determine validation code
+    if evidence_pending:
+        validation_code = EnvelopeValidationCode.VALID_EVIDENCE_PENDING
+    elif dry_run_defaulted:
+        validation_code = EnvelopeValidationCode.VALID_DRY_RUN_DEFAULTED
+    else:
+        validation_code = EnvelopeValidationCode.VALID
 
     return EnvelopeValidationResult(
         valid=True,
@@ -347,7 +404,129 @@ def validate_foundup_job_envelope(envelope: Dict[str, Any]) -> EnvelopeValidatio
         validation_message="FoundUpJob envelope validated successfully",
         dry_run_defaulted=dry_run_defaulted,
         policy_flags_snapshot=policy_snapshot,
+        evidence_refs_validated=True,
+        evidence_refs_count=evidence_result.get("count", 0),
+        evidence_pending=evidence_pending,
+        # WSP 97 Truth: Always False at validation time
+        verification_complete=False,
+        cabr_ready=False,
+        payout_ready=False,
     )
+
+
+def _validate_evidence_refs(
+    evidence_refs: Any,
+    is_dry_run: bool = True,
+) -> Dict[str, Any]:
+    """
+    Validate evidence_refs shape for FoundUpJob envelope.
+
+    WSP 97 Truth Boundaries:
+      - Evidence validation proves traceability shape only
+      - Evidence does NOT imply verification_complete=True
+      - Evidence does NOT enable CABR or payout claims
+      - Empty evidence_refs accepted in dry-run mode (pending)
+
+    Args:
+        evidence_refs: Evidence refs from envelope (may be None, list, or invalid)
+        is_dry_run: Whether dry_run_mode is True (allows empty evidence)
+
+    Returns:
+        Dict with: valid, code, message, count, pending
+    """
+    # No evidence_refs field: allowed (pending if dry-run)
+    if evidence_refs is None:
+        if is_dry_run:
+            return {
+                "valid": True,
+                "code": EnvelopeValidationCode.VALID_EVIDENCE_PENDING,
+                "message": "Evidence refs pending (dry-run mode)",
+                "count": 0,
+                "pending": True,
+            }
+        else:
+            # Live mode without evidence: still valid but flagged
+            logger.warning(
+                "[WSP97] FoundUpJob envelope has no evidence_refs in live mode"
+            )
+            return {
+                "valid": True,
+                "code": EnvelopeValidationCode.VALID,
+                "message": "Evidence refs not provided (live mode)",
+                "count": 0,
+                "pending": False,
+            }
+
+    # Must be a list
+    if not isinstance(evidence_refs, list):
+        return {
+            "valid": False,
+            "code": EnvelopeValidationCode.INVALID_EVIDENCE_REFS_TYPE,
+            "message": f"evidence_refs must be a list, got {type(evidence_refs).__name__}",
+            "count": 0,
+            "pending": False,
+        }
+
+    # Empty list: allowed in dry-run mode
+    if len(evidence_refs) == 0:
+        if is_dry_run:
+            return {
+                "valid": True,
+                "code": EnvelopeValidationCode.VALID_EVIDENCE_PENDING,
+                "message": "Evidence refs empty (dry-run mode, pending)",
+                "count": 0,
+                "pending": True,
+            }
+        else:
+            # Live mode with empty list: still valid
+            return {
+                "valid": True,
+                "code": EnvelopeValidationCode.VALID,
+                "message": "Evidence refs empty (live mode)",
+                "count": 0,
+                "pending": False,
+            }
+
+    # Validate each entry
+    for idx, ref in enumerate(evidence_refs):
+        if isinstance(ref, str):
+            # String refs must be non-empty
+            if not ref.strip():
+                return {
+                    "valid": False,
+                    "code": EnvelopeValidationCode.INVALID_EVIDENCE_REF_ENTRY,
+                    "message": f"evidence_refs[{idx}] is empty string",
+                    "count": len(evidence_refs),
+                    "pending": False,
+                }
+        elif isinstance(ref, dict):
+            # Dict refs must have at least 'path' or 'id' field
+            if not ref.get("path") and not ref.get("id") and not ref.get("ref"):
+                return {
+                    "valid": False,
+                    "code": EnvelopeValidationCode.INVALID_EVIDENCE_REF_ENTRY,
+                    "message": f"evidence_refs[{idx}] dict missing 'path', 'id', or 'ref' field",
+                    "count": len(evidence_refs),
+                    "pending": False,
+                }
+        else:
+            # Invalid type
+            return {
+                "valid": False,
+                "code": EnvelopeValidationCode.INVALID_EVIDENCE_REF_ENTRY,
+                "message": f"evidence_refs[{idx}] must be string or dict, got {type(ref).__name__}",
+                "count": len(evidence_refs),
+                "pending": False,
+            }
+
+    # All entries valid
+    return {
+        "valid": True,
+        "code": EnvelopeValidationCode.VALID,
+        "message": f"Evidence refs validated ({len(evidence_refs)} entries)",
+        "count": len(evidence_refs),
+        "pending": False,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/modules/infrastructure/wre_core/tests/TestModLog.md
+++ b/modules/infrastructure/wre_core/tests/TestModLog.md
@@ -1,5 +1,23 @@
 # TestModLog - wre_core/tests
 
+## 2026-05-02: Evidence refs validation tests
+
+- Command: `python -m pytest modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py -q`
+- Status: PASS
+- Result: `42 passed`
+- Notes:
+  - Added `TestEvidenceRefsListOfStrings` (2 tests) - list of strings passes
+  - Added `TestEvidenceRefsEmptyWithDryRun` (3 tests) - empty evidence in dry-run pending
+  - Added `TestEvidenceRefsWrongType` (3 tests) - wrong type fails
+  - Added `TestEvidenceRefsEmptyString` (2 tests) - empty string fails
+  - Added `TestEvidenceRefsMalformedDict` (6 tests) - dict validation
+  - Added `TestEvidenceRefsWSP97TruthFields` (4 tests) - verification/cabr/payout always False
+  - Added `TestGenericDAEEvidenceBehavior` (2 tests) - generic DAE ignores evidence
+  - Updated existing tests for evidence_pending validation code
+  - Full suite: 448 passed (excluding production_gates)
+
+---
+
 ## 2026-05-02: FoundUpJob envelope validation tests
 
 - Command: `python -m pytest modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py -v`

--- a/modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py
+++ b/modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py
@@ -173,7 +173,11 @@ class TestFoundUpJobDryRunDefault:
 
         assert result.valid is True
         assert result.dry_run_defaulted is True
-        assert result.validation_code == EnvelopeValidationCode.VALID_DRY_RUN_DEFAULTED
+        # Evidence pending takes precedence over dry_run_defaulted in code
+        assert result.validation_code in (
+            EnvelopeValidationCode.VALID_DRY_RUN_DEFAULTED,
+            EnvelopeValidationCode.VALID_EVIDENCE_PENDING,
+        )
         assert result.policy_flags_snapshot.get("dry_run_mode") is True
 
     def test_foundup_envelope_with_policy_flags_no_dry_run_defaults(self):
@@ -235,6 +239,7 @@ class TestValidDryRunFoundUpJob:
                 "security_gate_checked": False,
                 "security_gate_passed": False,
             },
+            "evidence_refs": ["manifest.json"],  # Provide evidence to get VALID code
         }
 
         result = validate_foundup_job_envelope(envelope)
@@ -244,6 +249,7 @@ class TestValidDryRunFoundUpJob:
         assert result.validation_code == EnvelopeValidationCode.VALID
         assert result.dry_run_defaulted is False
         assert result.missing_fields == []
+        assert result.evidence_refs_validated is True
 
     def test_valid_envelope_with_all_fields_passes(self):
         """Complete FoundUpJob envelope with all optional fields passes."""
@@ -387,6 +393,389 @@ class TestEnvelopeTypeDetection:
         envelope_type = detect_envelope_type(envelope)
 
         assert envelope_type == EnvelopeType.GENERIC_DAE
+
+
+# ---------------------------------------------------------------------------
+# Test: Evidence Refs Validation (WRE_EVIDENCE_REFS_VALIDATION_PHASE1)
+# ---------------------------------------------------------------------------
+
+
+class TestEvidenceRefsListOfStrings:
+    """Test evidence_refs list of strings passes validation."""
+
+    def test_evidence_refs_list_of_strings_passes(self):
+        """evidence_refs as list of non-empty strings passes."""
+        envelope = {
+            "job_id": "job_001",
+            "foundup_id": "gotjunk",
+            "tenant_id": "tenant_alice",
+            "requested_action": "build_foundup",
+            "policy_flags": {"dry_run_mode": True},
+            "evidence_refs": ["manifest.json", "readme.md", "proof_abc123"],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.evidence_refs_validated is True
+        assert result.evidence_refs_count == 3
+        assert result.evidence_pending is False
+
+    def test_evidence_refs_single_string_passes(self):
+        """evidence_refs with single string entry passes."""
+        envelope = {
+            "job_id": "job_002",
+            "foundup_id": "kosei",
+            "tenant_id": "tenant_bob",
+            "requested_action": "validate_foundup",
+            "evidence_refs": ["foundup_manifest.json"],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.evidence_refs_count == 1
+
+
+class TestEvidenceRefsEmptyWithDryRun:
+    """Test evidence_refs empty with dry-run/pending policy passes."""
+
+    def test_empty_evidence_refs_in_dry_run_passes_as_pending(self):
+        """Empty evidence_refs with dry_run_mode=True passes as pending."""
+        envelope = {
+            "job_id": "job_003",
+            "foundup_id": "move2japan",
+            "tenant_id": "tenant_carol",
+            "requested_action": "extract_foundup",
+            "policy_flags": {"dry_run_mode": True},
+            "evidence_refs": [],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.evidence_pending is True
+        assert result.validation_code == EnvelopeValidationCode.VALID_EVIDENCE_PENDING
+        assert result.evidence_refs_count == 0
+
+    def test_no_evidence_refs_in_dry_run_passes_as_pending(self):
+        """No evidence_refs field with dry_run_mode=True passes as pending."""
+        envelope = {
+            "job_id": "job_004",
+            "foundup_id": "social_twin",
+            "tenant_id": "tenant_dave",
+            "requested_action": "build_foundup",
+            "policy_flags": {"dry_run_mode": True},
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.evidence_pending is True
+
+    def test_no_evidence_refs_defaults_dry_run_and_pending(self):
+        """No evidence_refs and no policy_flags defaults to dry-run pending."""
+        envelope = {
+            "job_id": "job_005",
+            "foundup_id": "pqn_portal",
+            "tenant_id": "tenant_eve",
+            "requested_action": "validate_foundup",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.dry_run_defaulted is True
+        assert result.evidence_pending is True
+
+
+class TestEvidenceRefsWrongType:
+    """Test evidence_refs wrong type fails validation."""
+
+    def test_evidence_refs_string_instead_of_list_fails(self):
+        """evidence_refs as string instead of list fails."""
+        envelope = {
+            "job_id": "job_006",
+            "foundup_id": "gotjunk",
+            "tenant_id": "tenant_frank",
+            "requested_action": "build_foundup",
+            "evidence_refs": "manifest.json",  # Should be list
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.INVALID_EVIDENCE_REFS_TYPE
+        assert "list" in result.validation_message.lower()
+
+    def test_evidence_refs_dict_instead_of_list_fails(self):
+        """evidence_refs as dict instead of list fails."""
+        envelope = {
+            "job_id": "job_007",
+            "foundup_id": "kosei",
+            "tenant_id": "tenant_grace",
+            "requested_action": "validate_foundup",
+            "evidence_refs": {"path": "manifest.json"},  # Should be list
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.INVALID_EVIDENCE_REFS_TYPE
+
+    def test_evidence_refs_int_fails(self):
+        """evidence_refs as int fails."""
+        envelope = {
+            "job_id": "job_008",
+            "foundup_id": "move2japan",
+            "tenant_id": "tenant_hank",
+            "requested_action": "extract_foundup",
+            "evidence_refs": 123,
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.INVALID_EVIDENCE_REFS_TYPE
+
+
+class TestEvidenceRefsEmptyString:
+    """Test evidence_refs with empty string fails validation."""
+
+    def test_evidence_refs_with_empty_string_fails(self):
+        """evidence_refs containing empty string fails."""
+        envelope = {
+            "job_id": "job_009",
+            "foundup_id": "social_twin",
+            "tenant_id": "tenant_ivan",
+            "requested_action": "build_foundup",
+            "evidence_refs": ["manifest.json", "", "readme.md"],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.INVALID_EVIDENCE_REF_ENTRY
+        assert "empty string" in result.validation_message.lower()
+
+    def test_evidence_refs_with_whitespace_only_fails(self):
+        """evidence_refs containing whitespace-only string fails."""
+        envelope = {
+            "job_id": "job_010",
+            "foundup_id": "pqn_portal",
+            "tenant_id": "tenant_judy",
+            "requested_action": "validate_foundup",
+            "evidence_refs": ["   ", "manifest.json"],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.INVALID_EVIDENCE_REF_ENTRY
+
+
+class TestEvidenceRefsMalformedDict:
+    """Test evidence_refs malformed dict fails unless matching accepted schema."""
+
+    def test_evidence_refs_dict_without_required_fields_fails(self):
+        """evidence_refs dict entry without path/id/ref fails."""
+        envelope = {
+            "job_id": "job_011",
+            "foundup_id": "gotjunk",
+            "tenant_id": "tenant_kevin",
+            "requested_action": "build_foundup",
+            "evidence_refs": [
+                {"type": "manifest", "status": "verified"},  # Missing path/id/ref
+            ],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.INVALID_EVIDENCE_REF_ENTRY
+        assert "path" in result.validation_message or "id" in result.validation_message
+
+    def test_evidence_refs_dict_with_path_passes(self):
+        """evidence_refs dict entry with 'path' field passes."""
+        envelope = {
+            "job_id": "job_012",
+            "foundup_id": "kosei",
+            "tenant_id": "tenant_larry",
+            "requested_action": "validate_foundup",
+            "evidence_refs": [
+                {"path": "modules/foundups/gotjunk/manifest.json", "type": "manifest"},
+            ],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.evidence_refs_count == 1
+
+    def test_evidence_refs_dict_with_id_passes(self):
+        """evidence_refs dict entry with 'id' field passes."""
+        envelope = {
+            "job_id": "job_013",
+            "foundup_id": "move2japan",
+            "tenant_id": "tenant_mary",
+            "requested_action": "extract_foundup",
+            "evidence_refs": [
+                {"id": "proof_abc123", "type": "verification"},
+            ],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+
+    def test_evidence_refs_dict_with_ref_passes(self):
+        """evidence_refs dict entry with 'ref' field passes."""
+        envelope = {
+            "job_id": "job_014",
+            "foundup_id": "social_twin",
+            "tenant_id": "tenant_nancy",
+            "requested_action": "build_foundup",
+            "evidence_refs": [
+                {"ref": "commit:abc123def", "type": "git"},
+            ],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+
+    def test_evidence_refs_mixed_string_and_valid_dict_passes(self):
+        """evidence_refs with mixed strings and valid dicts passes."""
+        envelope = {
+            "job_id": "job_015",
+            "foundup_id": "pqn_portal",
+            "tenant_id": "tenant_oscar",
+            "requested_action": "validate_foundup",
+            "evidence_refs": [
+                "manifest.json",
+                {"path": "readme.md", "type": "doc"},
+                "proof_xyz789",
+            ],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.evidence_refs_count == 3
+
+    def test_evidence_refs_invalid_type_in_list_fails(self):
+        """evidence_refs with invalid type (int) in list fails."""
+        envelope = {
+            "job_id": "job_016",
+            "foundup_id": "gotjunk",
+            "tenant_id": "tenant_paul",
+            "requested_action": "build_foundup",
+            "evidence_refs": ["manifest.json", 123, "readme.md"],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.INVALID_EVIDENCE_REF_ENTRY
+
+
+class TestEvidenceRefsWSP97TruthFields:
+    """Test evidence_refs do not change WSP 97 truth fields."""
+
+    def test_valid_evidence_does_not_set_verification_complete(self):
+        """Valid evidence_refs does NOT set verification_complete=True."""
+        envelope = {
+            "job_id": "job_017",
+            "foundup_id": "kosei",
+            "tenant_id": "tenant_quinn",
+            "requested_action": "validate_foundup",
+            "policy_flags": {"dry_run_mode": False},
+            "evidence_refs": ["manifest.json", "proof_abc123"],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.verification_complete is False  # WSP 97: Always False
+
+    def test_valid_evidence_does_not_set_cabr_ready(self):
+        """Valid evidence_refs does NOT set cabr_ready=True."""
+        envelope = {
+            "job_id": "job_018",
+            "foundup_id": "move2japan",
+            "tenant_id": "tenant_rachel",
+            "requested_action": "build_foundup",
+            "evidence_refs": ["manifest.json", "readme.md", "cabr_proof.json"],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.cabr_ready is False  # WSP 97: Always False
+
+    def test_valid_evidence_does_not_set_payout_ready(self):
+        """Valid evidence_refs does NOT set payout_ready=True."""
+        envelope = {
+            "job_id": "job_019",
+            "foundup_id": "social_twin",
+            "tenant_id": "tenant_steve",
+            "requested_action": "extract_foundup",
+            "evidence_refs": ["payout_evidence.json", "verification_proof.json"],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.payout_ready is False  # WSP 97: Always False
+
+    def test_wsp97_truth_fields_in_serialized_result(self):
+        """WSP 97 truth fields appear in to_dict() output as False."""
+        envelope = {
+            "job_id": "job_020",
+            "foundup_id": "pqn_portal",
+            "tenant_id": "tenant_tina",
+            "requested_action": "validate_foundup",
+            "evidence_refs": ["full_evidence.json"],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+        result_dict = result.to_dict()
+
+        assert result_dict["verification_complete"] is False
+        assert result_dict["cabr_ready"] is False
+        assert result_dict["payout_ready"] is False
+        assert result_dict["evidence_refs_validated"] is True
+
+
+class TestGenericDAEEvidenceBehavior:
+    """Test generic DAE envelope evidence behavior unchanged."""
+
+    def test_generic_dae_ignores_evidence_refs(self):
+        """Generic DAE envelope validation ignores evidence_refs."""
+        envelope = {
+            "objective": "Do something generic",
+            "evidence_refs": ["some_evidence.json"],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.envelope_type == EnvelopeType.GENERIC_DAE
+        # Evidence fields should be defaults (not validated for generic DAE)
+        assert result.evidence_refs_validated is False
+        assert result.evidence_refs_count == 0
+
+    def test_generic_dae_with_malformed_evidence_still_passes(self):
+        """Generic DAE envelope passes even with malformed evidence_refs."""
+        envelope = {
+            "objective": "Do something else",
+            "evidence_refs": "not_a_list",  # Invalid type but ignored for generic DAE
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.envelope_type == EnvelopeType.GENERIC_DAE
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Validates FoundUpJob `evidence_refs` shape in foundup_job_router.py
- Allows dry-run missing/empty evidence as pending
- Accepts list of non-empty strings
- Accepts typed dict entries with path/id/ref field
- Rejects wrong type, empty string, malformed dict, unsupported entry types
- Adds evidence validation fields to serializable validation result

## WSP 97 Truth Boundaries
- evidence_refs prove traceability only
- verification_complete remains False
- cabr_ready remains False
- payout_ready remains False
- No CABR/reward/payout/token claims
- No real evidence content verification yet
- No signature/hash provenance validation yet

## Test plan
- [x] 42 evidence validation tests pass
- [x] Full WRE core suite: 448 passed (excluding production_gates)
- [ ] CI verification pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)