### PR TITLE
fix(wre): gate live FoundUpJob envelopes on evidence policy

### DIFF
--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -2,6 +2,65 @@
 
 ## Chronological Change Log
 
+### [2026-05-02] - WRE_LIVE_MODE_EVIDENCE_POLICY_GATE_PHASE1 (v0.8.12)
+
+**WSP Protocol References**: WSP 11 (Interface), WSP 97 (Truthful - live mode blocked without gates)
+**Impact Analysis**: Block non-dry-run FoundUpJob envelopes unless strict policy gates present
+
+#### Changes Made
+
+- `src/foundup_job_router.py`:
+  - Added `EnvelopeValidationCode` values:
+    - `LIVE_MODE_NOT_ENABLED`
+    - `LIVE_MODE_REQUIRES_HUMAN_APPROVAL`
+    - `LIVE_MODE_REQUIRES_EVIDENCE`
+    - `LIVE_MODE_REQUIRES_SECURITY_GATE`
+  - Added `EnvelopeValidationResult` fields:
+    - `is_live_mode`: True if explicit dry_run_mode=False
+    - `live_mode_gates_passed`: True if all required gates passed
+    - `missing_live_gates`: List of missing policy gates
+  - Added `_validate_live_mode_gates()` function
+  - Updated `validate_foundup_job_envelope()` to apply live mode gates
+
+- `tests/test_foundup_job_envelope_validation.py`:
+  - Added 17 new tests for live mode policy gates
+  - TestDryRunWithPendingEvidenceStillPasses (2 tests)
+  - TestLiveModeWithoutApprovalFails (2 tests)
+  - TestLiveModeWithoutEvidenceFails (2 tests)
+  - TestLiveModeWithMalformedEvidenceFails (2 tests)
+  - TestLiveModeWithApprovalAndEvidenceNoVerification (3 tests)
+  - TestLiveModeSecurityGate (2 tests)
+  - TestLiveModeValidationErrorDetails (4 tests)
+  - Updated 2 existing tests for live mode approval
+
+#### Live Mode Policy Gates (Phase 1)
+
+| Gate | Requirement | Validation Code if Missing |
+|------|-------------|----------------------------|
+| human_approval OR permission_gate_passed | True | LIVE_MODE_REQUIRES_HUMAN_APPROVAL |
+| security_gate_passed (if security_gate_checked) | True | LIVE_MODE_REQUIRES_SECURITY_GATE |
+| evidence_refs | Non-empty, not pending | LIVE_MODE_REQUIRES_EVIDENCE |
+
+#### WSP 97 Truth Boundaries
+
+- Live mode gates do NOT imply `verification_complete=True`
+- Live mode gates do NOT enable CABR claims (`cabr_ready=False`)
+- Live mode gates do NOT enable payout claims (`payout_ready=False`)
+- This is validation only - no actual execution path created
+- Dry-run behavior unchanged (evidence_pending allowed)
+
+#### Verification
+
+```bash
+python -m pytest modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py -q
+# 59 passed
+
+python -m pytest modules/infrastructure/wre_core/tests -q --ignore=modules/infrastructure/wre_core/tests/test_production_gates.py
+# 465 passed
+```
+
+---
+
 ### [2026-05-02] - WRE_EVIDENCE_REFS_VALIDATION_PHASE1 (v0.8.11)
 
 **WSP Protocol References**: WSP 11 (Interface), WSP 97 (Truthful - evidence traceability only)

--- a/modules/infrastructure/wre_core/src/foundup_job_router.py
+++ b/modules/infrastructure/wre_core/src/foundup_job_router.py
@@ -160,6 +160,12 @@ class EnvelopeValidationCode(str, Enum):
     INVALID_EVIDENCE_REFS_TYPE = "INVALID_EVIDENCE_REFS_TYPE"
     INVALID_EVIDENCE_REF_ENTRY = "INVALID_EVIDENCE_REF_ENTRY"
 
+    # Invalid - Live Mode Policy Gates
+    LIVE_MODE_NOT_ENABLED = "LIVE_MODE_NOT_ENABLED"
+    LIVE_MODE_REQUIRES_HUMAN_APPROVAL = "LIVE_MODE_REQUIRES_HUMAN_APPROVAL"
+    LIVE_MODE_REQUIRES_EVIDENCE = "LIVE_MODE_REQUIRES_EVIDENCE"
+    LIVE_MODE_REQUIRES_SECURITY_GATE = "LIVE_MODE_REQUIRES_SECURITY_GATE"
+
 
 @dataclass
 class EnvelopeValidationResult:
@@ -201,6 +207,16 @@ class EnvelopeValidationResult:
     evidence_pending: bool = False
     """True if evidence is pending (empty in dry-run mode)."""
 
+    # === Live Mode Policy Gates ===
+    is_live_mode: bool = False
+    """True if dry_run_mode=False (explicit live execution requested)."""
+
+    live_mode_gates_passed: bool = False
+    """True if all required live mode gates passed."""
+
+    missing_live_gates: List[str] = field(default_factory=list)
+    """List of missing live mode policy gates."""
+
     # === WSP 97 Truth Fields (ALWAYS False at validation time) ===
     verification_complete: bool = False
     """WSP 97: Always False. Evidence presence does NOT imply verification."""
@@ -224,6 +240,10 @@ class EnvelopeValidationResult:
             "evidence_refs_validated": self.evidence_refs_validated,
             "evidence_refs_count": self.evidence_refs_count,
             "evidence_pending": self.evidence_pending,
+            # Live mode gates
+            "is_live_mode": self.is_live_mode,
+            "live_mode_gates_passed": self.live_mode_gates_passed,
+            "missing_live_gates": self.missing_live_gates,
             # WSP 97 Truth: Always False at validation time
             "verification_complete": self.verification_complete,
             "cabr_ready": self.cabr_ready,
@@ -366,10 +386,13 @@ def validate_foundup_job_envelope(envelope: Dict[str, Any]) -> EnvelopeValidatio
             dry_run_defaulted = True
             policy_snapshot["dry_run_mode"] = True
 
+    # Determine if this is live mode (explicit dry_run_mode=False)
+    is_live_mode = policy_snapshot.get("dry_run_mode") is False and not dry_run_defaulted
+
     # Evidence refs validation (WSP 97: validate shape, not verification)
     evidence_result = _validate_evidence_refs(
         envelope.get("evidence_refs"),
-        is_dry_run=policy_snapshot.get("dry_run_mode", True),
+        is_dry_run=not is_live_mode,  # Dry-run if not explicitly live mode
     )
 
     if not evidence_result["valid"]:
@@ -384,11 +407,38 @@ def validate_foundup_job_envelope(envelope: Dict[str, Any]) -> EnvelopeValidatio
             evidence_refs_validated=False,
             evidence_refs_count=evidence_result.get("count", 0),
             evidence_pending=False,
+            is_live_mode=is_live_mode,
         )
 
-    # Valid FoundUpJob envelope
     evidence_pending = evidence_result.get("pending", False)
+    evidence_count = evidence_result.get("count", 0)
 
+    # Live mode policy gate validation
+    if is_live_mode:
+        live_gate_result = _validate_live_mode_gates(
+            policy_snapshot=policy_snapshot,
+            evidence_count=evidence_count,
+            evidence_pending=evidence_pending,
+        )
+
+        if not live_gate_result["valid"]:
+            return EnvelopeValidationResult(
+                valid=False,
+                envelope_type=EnvelopeType.FOUNDUP_JOB,
+                validation_code=live_gate_result["code"],
+                missing_fields=[],
+                validation_message=live_gate_result["message"],
+                dry_run_defaulted=dry_run_defaulted,
+                policy_flags_snapshot=policy_snapshot,
+                evidence_refs_validated=True,
+                evidence_refs_count=evidence_count,
+                evidence_pending=evidence_pending,
+                is_live_mode=True,
+                live_mode_gates_passed=False,
+                missing_live_gates=live_gate_result.get("missing_gates", []),
+            )
+
+    # Valid FoundUpJob envelope
     # Determine validation code
     if evidence_pending:
         validation_code = EnvelopeValidationCode.VALID_EVIDENCE_PENDING
@@ -405,13 +455,93 @@ def validate_foundup_job_envelope(envelope: Dict[str, Any]) -> EnvelopeValidatio
         dry_run_defaulted=dry_run_defaulted,
         policy_flags_snapshot=policy_snapshot,
         evidence_refs_validated=True,
-        evidence_refs_count=evidence_result.get("count", 0),
+        evidence_refs_count=evidence_count,
         evidence_pending=evidence_pending,
+        is_live_mode=is_live_mode,
+        live_mode_gates_passed=is_live_mode,  # True only if live mode and passed gates
         # WSP 97 Truth: Always False at validation time
         verification_complete=False,
         cabr_ready=False,
         payout_ready=False,
     )
+
+
+def _validate_live_mode_gates(
+    policy_snapshot: Dict[str, bool],
+    evidence_count: int,
+    evidence_pending: bool,
+) -> Dict[str, Any]:
+    """
+    Validate live mode policy gates for FoundUpJob execution.
+
+    Live mode (dry_run_mode=False) requires explicit approval and evidence
+    before any non-dry-run execution can proceed.
+
+    WSP 97 Truth Boundaries:
+      - Live mode gates do NOT imply verification_complete=True
+      - Live mode gates do NOT enable CABR or payout claims
+      - This is validation only - no actual execution occurs
+
+    Required gates for Phase 1:
+      - human_approval=True OR permission_gate_passed=True
+      - security_gate_passed=True (if security_gate_checked=True)
+      - Non-empty evidence_refs (evidence_pending=False)
+
+    Args:
+        policy_snapshot: Policy flags at validation time
+        evidence_count: Number of evidence refs in envelope
+        evidence_pending: Whether evidence is pending
+
+    Returns:
+        Dict with: valid, code, message, missing_gates
+    """
+    missing_gates: List[str] = []
+
+    # Gate 1: Human approval OR permission gate passed
+    human_approval = policy_snapshot.get("human_approval", False)
+    permission_gate_passed = policy_snapshot.get("permission_gate_passed", False)
+
+    if not human_approval and not permission_gate_passed:
+        missing_gates.append("human_approval")
+
+    # Gate 2: Security gate (if checked, must pass)
+    security_gate_checked = policy_snapshot.get("security_gate_checked", False)
+    security_gate_passed = policy_snapshot.get("security_gate_passed", False)
+
+    if security_gate_checked and not security_gate_passed:
+        missing_gates.append("security_gate_passed")
+
+    # Gate 3: Evidence must be present (not pending)
+    if evidence_pending or evidence_count == 0:
+        missing_gates.append("evidence_refs")
+
+    # Determine result
+    if missing_gates:
+        # Determine primary failure code
+        if "human_approval" in missing_gates:
+            code = EnvelopeValidationCode.LIVE_MODE_REQUIRES_HUMAN_APPROVAL
+        elif "security_gate_passed" in missing_gates:
+            code = EnvelopeValidationCode.LIVE_MODE_REQUIRES_SECURITY_GATE
+        elif "evidence_refs" in missing_gates:
+            code = EnvelopeValidationCode.LIVE_MODE_REQUIRES_EVIDENCE
+        else:
+            code = EnvelopeValidationCode.LIVE_MODE_NOT_ENABLED
+
+        return {
+            "valid": False,
+            "code": code,
+            "message": f"Live mode requires gates: {missing_gates}",
+            "missing_gates": missing_gates,
+        }
+
+    # All gates passed
+    logger.info("[WSP97] Live mode gates passed - validation only, no execution")
+    return {
+        "valid": True,
+        "code": EnvelopeValidationCode.VALID,
+        "message": "Live mode gates passed (validation only)",
+        "missing_gates": [],
+    }
 
 
 def _validate_evidence_refs(

--- a/modules/infrastructure/wre_core/tests/TestModLog.md
+++ b/modules/infrastructure/wre_core/tests/TestModLog.md
@@ -1,5 +1,23 @@
 # TestModLog - wre_core/tests
 
+## 2026-05-02: Live mode policy gate tests
+
+- Command: `python -m pytest modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py -q`
+- Status: PASS
+- Result: `59 passed`
+- Notes:
+  - Added `TestDryRunWithPendingEvidenceStillPasses` (2 tests) - dry-run behavior unchanged
+  - Added `TestLiveModeWithoutApprovalFails` (2 tests) - human_approval required
+  - Added `TestLiveModeWithoutEvidenceFails` (2 tests) - evidence required in live mode
+  - Added `TestLiveModeWithMalformedEvidenceFails` (2 tests) - evidence must be valid
+  - Added `TestLiveModeWithApprovalAndEvidenceNoVerification` (3 tests) - WSP 97 truth
+  - Added `TestLiveModeSecurityGate` (2 tests) - security gate validation
+  - Added `TestLiveModeValidationErrorDetails` (4 tests) - error details include missing gates
+  - Updated 2 existing tests to include live mode approval
+  - Full suite: 465 passed (excluding production_gates)
+
+---
+
 ## 2026-05-02: Evidence refs validation tests
 
 - Command: `python -m pytest modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py -q`

--- a/modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py
+++ b/modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py
@@ -208,12 +208,15 @@ class TestFoundUpJobDryRunDefault:
             "requested_action": "extract_foundup",
             "policy_flags": {
                 "dry_run_mode": False,  # Explicit live mode
+                "human_approval": True,  # Required for live mode
             },
+            "evidence_refs": ["manifest.json"],  # Required for live mode
         }
 
         result = validate_foundup_job_envelope(envelope)
 
         assert result.valid is True
+        assert result.is_live_mode is True
         # Note: dry_run_defaulted logic checks if dry_run_mode is missing or falsy
         # When explicitly set to False, we still default to True for safety per WSP 97
         # This is the safety-first approach
@@ -689,7 +692,10 @@ class TestEvidenceRefsWSP97TruthFields:
             "foundup_id": "kosei",
             "tenant_id": "tenant_quinn",
             "requested_action": "validate_foundup",
-            "policy_flags": {"dry_run_mode": False},
+            "policy_flags": {
+                "dry_run_mode": False,
+                "human_approval": True,  # Required for live mode
+            },
             "evidence_refs": ["manifest.json", "proof_abc123"],
         }
 
@@ -776,6 +782,373 @@ class TestGenericDAEEvidenceBehavior:
 
         assert result.valid is True
         assert result.envelope_type == EnvelopeType.GENERIC_DAE
+
+
+# ---------------------------------------------------------------------------
+# Test: Live Mode Policy Gates (WRE_LIVE_MODE_EVIDENCE_POLICY_GATE_PHASE1)
+# ---------------------------------------------------------------------------
+
+
+class TestDryRunWithPendingEvidenceStillPasses:
+    """Test dry-run envelope with pending evidence still passes."""
+
+    def test_dry_run_with_no_evidence_passes_as_pending(self):
+        """Dry-run envelope without evidence passes with pending status."""
+        envelope = {
+            "job_id": "job_live_001",
+            "foundup_id": "gotjunk",
+            "tenant_id": "tenant_alice",
+            "requested_action": "build_foundup",
+            "policy_flags": {"dry_run_mode": True},
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.evidence_pending is True
+        assert result.is_live_mode is False
+
+    def test_dry_run_defaulted_with_no_evidence_passes(self):
+        """Envelope with no policy_flags defaults to dry-run and passes."""
+        envelope = {
+            "job_id": "job_live_002",
+            "foundup_id": "kosei",
+            "tenant_id": "tenant_bob",
+            "requested_action": "validate_foundup",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.dry_run_defaulted is True
+        assert result.evidence_pending is True
+        assert result.is_live_mode is False
+
+
+class TestLiveModeWithoutApprovalFails:
+    """Test live-mode envelope without approval fails."""
+
+    def test_live_mode_without_human_approval_fails(self):
+        """Live mode without human_approval or permission_gate_passed fails."""
+        envelope = {
+            "job_id": "job_live_003",
+            "foundup_id": "move2japan",
+            "tenant_id": "tenant_carol",
+            "requested_action": "extract_foundup",
+            "policy_flags": {
+                "dry_run_mode": False,  # Explicit live mode
+                "human_approval": False,
+                "permission_gate_passed": False,
+            },
+            "evidence_refs": ["manifest.json"],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.LIVE_MODE_REQUIRES_HUMAN_APPROVAL
+        assert result.is_live_mode is True
+        assert "human_approval" in result.missing_live_gates
+
+    def test_live_mode_without_any_approval_flag_fails(self):
+        """Live mode with no approval flags at all fails."""
+        envelope = {
+            "job_id": "job_live_004",
+            "foundup_id": "social_twin",
+            "tenant_id": "tenant_dave",
+            "requested_action": "build_foundup",
+            "policy_flags": {
+                "dry_run_mode": False,
+            },
+            "evidence_refs": ["evidence.json"],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.LIVE_MODE_REQUIRES_HUMAN_APPROVAL
+        assert "human_approval" in result.missing_live_gates
+
+
+class TestLiveModeWithoutEvidenceFails:
+    """Test live-mode envelope without evidence fails."""
+
+    def test_live_mode_with_empty_evidence_fails(self):
+        """Live mode with empty evidence_refs fails."""
+        envelope = {
+            "job_id": "job_live_005",
+            "foundup_id": "pqn_portal",
+            "tenant_id": "tenant_eve",
+            "requested_action": "validate_foundup",
+            "policy_flags": {
+                "dry_run_mode": False,
+                "human_approval": True,
+            },
+            "evidence_refs": [],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.LIVE_MODE_REQUIRES_EVIDENCE
+        assert "evidence_refs" in result.missing_live_gates
+
+    def test_live_mode_with_no_evidence_field_fails(self):
+        """Live mode without evidence_refs field fails."""
+        envelope = {
+            "job_id": "job_live_006",
+            "foundup_id": "gotjunk",
+            "tenant_id": "tenant_frank",
+            "requested_action": "build_foundup",
+            "policy_flags": {
+                "dry_run_mode": False,
+                "human_approval": True,
+            },
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.LIVE_MODE_REQUIRES_EVIDENCE
+        assert "evidence_refs" in result.missing_live_gates
+
+
+class TestLiveModeWithMalformedEvidenceFails:
+    """Test live-mode envelope with malformed evidence fails."""
+
+    def test_live_mode_with_invalid_evidence_type_fails(self):
+        """Live mode with wrong evidence_refs type fails."""
+        envelope = {
+            "job_id": "job_live_007",
+            "foundup_id": "kosei",
+            "tenant_id": "tenant_grace",
+            "requested_action": "validate_foundup",
+            "policy_flags": {
+                "dry_run_mode": False,
+                "human_approval": True,
+            },
+            "evidence_refs": "not_a_list",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.INVALID_EVIDENCE_REFS_TYPE
+
+    def test_live_mode_with_empty_string_evidence_fails(self):
+        """Live mode with empty string in evidence fails."""
+        envelope = {
+            "job_id": "job_live_008",
+            "foundup_id": "move2japan",
+            "tenant_id": "tenant_hank",
+            "requested_action": "extract_foundup",
+            "policy_flags": {
+                "dry_run_mode": False,
+                "human_approval": True,
+            },
+            "evidence_refs": ["valid.json", "", "also_valid.json"],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.INVALID_EVIDENCE_REF_ENTRY
+
+
+class TestLiveModeWithApprovalAndEvidenceNoVerification:
+    """Test live-mode envelope with approval and evidence does not claim verification."""
+
+    def test_live_mode_valid_does_not_set_verification_complete(self):
+        """Valid live mode envelope does NOT set verification_complete."""
+        envelope = {
+            "job_id": "job_live_009",
+            "foundup_id": "social_twin",
+            "tenant_id": "tenant_ivan",
+            "requested_action": "build_foundup",
+            "policy_flags": {
+                "dry_run_mode": False,
+                "human_approval": True,
+            },
+            "evidence_refs": ["manifest.json", "proof.json"],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.is_live_mode is True
+        assert result.live_mode_gates_passed is True
+        assert result.verification_complete is False  # WSP 97
+
+    def test_live_mode_valid_does_not_set_cabr_ready(self):
+        """Valid live mode envelope does NOT set cabr_ready."""
+        envelope = {
+            "job_id": "job_live_010",
+            "foundup_id": "pqn_portal",
+            "tenant_id": "tenant_judy",
+            "requested_action": "validate_foundup",
+            "policy_flags": {
+                "dry_run_mode": False,
+                "permission_gate_passed": True,  # Alternative approval
+            },
+            "evidence_refs": ["cabr_evidence.json"],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.cabr_ready is False  # WSP 97
+
+    def test_live_mode_valid_does_not_set_payout_ready(self):
+        """Valid live mode envelope does NOT set payout_ready."""
+        envelope = {
+            "job_id": "job_live_011",
+            "foundup_id": "gotjunk",
+            "tenant_id": "tenant_kevin",
+            "requested_action": "extract_foundup",
+            "policy_flags": {
+                "dry_run_mode": False,
+                "human_approval": True,
+                "security_gate_checked": True,
+                "security_gate_passed": True,
+            },
+            "evidence_refs": ["payout_ready_evidence.json"],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.payout_ready is False  # WSP 97
+
+
+class TestLiveModeSecurityGate:
+    """Test live mode security gate validation."""
+
+    def test_live_mode_security_gate_checked_but_not_passed_fails(self):
+        """Live mode with security_gate_checked=True but security_gate_passed=False fails."""
+        envelope = {
+            "job_id": "job_live_012",
+            "foundup_id": "kosei",
+            "tenant_id": "tenant_larry",
+            "requested_action": "build_foundup",
+            "policy_flags": {
+                "dry_run_mode": False,
+                "human_approval": True,
+                "security_gate_checked": True,
+                "security_gate_passed": False,
+            },
+            "evidence_refs": ["manifest.json"],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.LIVE_MODE_REQUIRES_SECURITY_GATE
+        assert "security_gate_passed" in result.missing_live_gates
+
+    def test_live_mode_security_gate_not_checked_passes(self):
+        """Live mode without security_gate_checked passes (gate not required if not checked)."""
+        envelope = {
+            "job_id": "job_live_013",
+            "foundup_id": "move2japan",
+            "tenant_id": "tenant_mary",
+            "requested_action": "validate_foundup",
+            "policy_flags": {
+                "dry_run_mode": False,
+                "human_approval": True,
+                "security_gate_checked": False,  # Not checked, so not required
+            },
+            "evidence_refs": ["evidence.json"],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.live_mode_gates_passed is True
+
+
+class TestLiveModeValidationErrorDetails:
+    """Test validation error includes explicit reason and missing gates."""
+
+    def test_missing_gates_list_in_result(self):
+        """Validation result includes missing_live_gates list."""
+        envelope = {
+            "job_id": "job_live_014",
+            "foundup_id": "social_twin",
+            "tenant_id": "tenant_nancy",
+            "requested_action": "build_foundup",
+            "policy_flags": {
+                "dry_run_mode": False,
+                # Missing: human_approval, evidence
+            },
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert len(result.missing_live_gates) >= 1
+        assert "human_approval" in result.missing_live_gates
+
+    def test_multiple_missing_gates_all_listed(self):
+        """Multiple missing gates are all listed."""
+        envelope = {
+            "job_id": "job_live_015",
+            "foundup_id": "pqn_portal",
+            "tenant_id": "tenant_oscar",
+            "requested_action": "extract_foundup",
+            "policy_flags": {
+                "dry_run_mode": False,
+                "security_gate_checked": True,
+                "security_gate_passed": False,
+                # Missing: human_approval, security_gate_passed, evidence
+            },
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert "human_approval" in result.missing_live_gates
+        assert "security_gate_passed" in result.missing_live_gates
+        assert "evidence_refs" in result.missing_live_gates
+
+    def test_validation_message_mentions_missing_gates(self):
+        """Validation message mentions the missing gates."""
+        envelope = {
+            "job_id": "job_live_016",
+            "foundup_id": "gotjunk",
+            "tenant_id": "tenant_paul",
+            "requested_action": "validate_foundup",
+            "policy_flags": {
+                "dry_run_mode": False,
+            },
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert "human_approval" in result.validation_message or "gates" in result.validation_message
+
+    def test_live_mode_fields_in_serialized_result(self):
+        """Live mode fields appear in to_dict() output."""
+        envelope = {
+            "job_id": "job_live_017",
+            "foundup_id": "kosei",
+            "tenant_id": "tenant_quinn",
+            "requested_action": "build_foundup",
+            "policy_flags": {
+                "dry_run_mode": False,
+                "human_approval": True,
+            },
+            "evidence_refs": ["complete_evidence.json"],
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+        result_dict = result.to_dict()
+
+        assert "is_live_mode" in result_dict
+        assert "live_mode_gates_passed" in result_dict
+        assert "missing_live_gates" in result_dict
+        assert result_dict["is_live_mode"] is True
+        assert result_dict["live_mode_gates_passed"] is True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds validation gate for live/non-dry-run FoundUpJob envelopes
- Live mode requires:
  - human_approval or permission_gate_passed
  - non-empty valid evidence_refs
  - security_gate_passed when security_gate_checked is set
- Dry-run behavior unchanged
- No live execution path created
- WSP 97 fields remain false

## WSP 97 Truth Boundaries
- Validation only - no live execution backend
- verification_complete remains False
- cabr_ready remains False
- payout_ready remains False
- No CABR/reward/payout/token claims

## Deferred (intentional)
- rollback policy gate not modeled in PolicyFlags yet
- external audit gate deferred
- compute budget validation deferred

## Test plan
- [x] 59 policy gate validation tests pass
- [x] Full WRE core suite: 465 passed (excluding production_gates)
- [ ] CI verification pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)