### PR TITLE
fix(wre): validate FoundUpJob compute budget policy

### DIFF
--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -2,6 +2,44 @@
 
 ## Chronological Change Log
 
+### [2026-05-02] - WRE_COMPUTE_BUDGET_VALIDATION_PHASE1 (v0.8.13)
+
+**WSP Protocol References**: WSP 11 (Interface), WSP 97 (Truthful - structural validation only)
+**Impact Analysis**: Add compute budget policy validation for FoundUpJob envelopes
+
+#### Changes Made
+
+- `src/foundup_job_router.py`:
+  - Added `EnvelopeValidationCode` values for compute validation errors
+  - Added `EnvelopeValidationResult` fields: compute_budget_validated, compute_tier, model_preference
+  - Added `_validate_compute_budget()` helper function
+  - Validates: compute_budget/compute_used types, non-negative values, budget limits
+  - Validates: compute_tier (freemium|basic|enterprise), model_preference (auto|free|standard|premium)
+  - Live mode requires explicit compute_budget
+
+- `tests/test_foundup_job_envelope_validation.py`:
+  - Added 34 new tests for compute budget validation
+  - Covers type validation, negative values, budget overflow, tier/preference validation
+
+#### WSP 97 Truth Boundaries
+
+- Structural validation only - does not verify actual metering accuracy
+- Does not prove resource consumption tracking
+- Does not enable billing claims
+- verification_complete=False, cabr_ready=False, payout_ready=False
+
+#### Verification
+
+```bash
+python -m pytest modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py -q
+# 93 passed
+
+python -m pytest modules/infrastructure/wre_core/tests -q --ignore=modules/infrastructure/wre_core/tests/test_production_gates.py
+# 499 passed
+```
+
+---
+
 ### [2026-05-02] - WRE_LIVE_MODE_EVIDENCE_POLICY_GATE_PHASE1 (v0.8.12)
 
 **WSP Protocol References**: WSP 11 (Interface), WSP 97 (Truthful - live mode blocked without gates)

--- a/modules/infrastructure/wre_core/src/foundup_job_router.py
+++ b/modules/infrastructure/wre_core/src/foundup_job_router.py
@@ -166,6 +166,16 @@ class EnvelopeValidationCode(str, Enum):
     LIVE_MODE_REQUIRES_EVIDENCE = "LIVE_MODE_REQUIRES_EVIDENCE"
     LIVE_MODE_REQUIRES_SECURITY_GATE = "LIVE_MODE_REQUIRES_SECURITY_GATE"
 
+    # Invalid - Compute Budget
+    INVALID_COMPUTE_BUDGET_TYPE = "INVALID_COMPUTE_BUDGET_TYPE"
+    INVALID_COMPUTE_BUDGET_NEGATIVE = "INVALID_COMPUTE_BUDGET_NEGATIVE"
+    INVALID_COMPUTE_USED_TYPE = "INVALID_COMPUTE_USED_TYPE"
+    INVALID_COMPUTE_USED_NEGATIVE = "INVALID_COMPUTE_USED_NEGATIVE"
+    COMPUTE_USED_EXCEEDS_BUDGET = "COMPUTE_USED_EXCEEDS_BUDGET"
+    LIVE_MODE_REQUIRES_COMPUTE_BUDGET = "LIVE_MODE_REQUIRES_COMPUTE_BUDGET"
+    INVALID_COMPUTE_TIER = "INVALID_COMPUTE_TIER"
+    INVALID_MODEL_PREFERENCE = "INVALID_MODEL_PREFERENCE"
+
 
 @dataclass
 class EnvelopeValidationResult:
@@ -217,6 +227,22 @@ class EnvelopeValidationResult:
     missing_live_gates: List[str] = field(default_factory=list)
     """List of missing live mode policy gates."""
 
+    # === Compute Budget Validation ===
+    compute_budget_validated: bool = False
+    """True if compute budget fields passed validation."""
+
+    compute_budget_value: Optional[int] = None
+    """Compute budget from envelope (None = unlimited/not set)."""
+
+    compute_used_value: int = 0
+    """Compute used from envelope."""
+
+    compute_tier_value: str = ""
+    """Compute tier from envelope."""
+
+    model_preference_value: str = ""
+    """Model preference from envelope."""
+
     # === WSP 97 Truth Fields (ALWAYS False at validation time) ===
     verification_complete: bool = False
     """WSP 97: Always False. Evidence presence does NOT imply verification."""
@@ -244,6 +270,12 @@ class EnvelopeValidationResult:
             "is_live_mode": self.is_live_mode,
             "live_mode_gates_passed": self.live_mode_gates_passed,
             "missing_live_gates": self.missing_live_gates,
+            # Compute budget
+            "compute_budget_validated": self.compute_budget_validated,
+            "compute_budget_value": self.compute_budget_value,
+            "compute_used_value": self.compute_used_value,
+            "compute_tier_value": self.compute_tier_value,
+            "model_preference_value": self.model_preference_value,
             # WSP 97 Truth: Always False at validation time
             "verification_complete": self.verification_complete,
             "cabr_ready": self.cabr_ready,
@@ -438,6 +470,30 @@ def validate_foundup_job_envelope(envelope: Dict[str, Any]) -> EnvelopeValidatio
                 missing_live_gates=live_gate_result.get("missing_gates", []),
             )
 
+    # Compute budget validation (WSP 97: structural only, no metering claims)
+    compute_result = _validate_compute_budget(envelope, is_live_mode=is_live_mode)
+
+    if not compute_result["valid"]:
+        return EnvelopeValidationResult(
+            valid=False,
+            envelope_type=EnvelopeType.FOUNDUP_JOB,
+            validation_code=compute_result["code"],
+            missing_fields=[],
+            validation_message=compute_result["message"],
+            dry_run_defaulted=dry_run_defaulted,
+            policy_flags_snapshot=policy_snapshot,
+            evidence_refs_validated=True,
+            evidence_refs_count=evidence_count,
+            evidence_pending=evidence_pending,
+            is_live_mode=is_live_mode,
+            live_mode_gates_passed=is_live_mode,
+            compute_budget_validated=False,
+            compute_budget_value=compute_result.get("budget"),
+            compute_used_value=compute_result.get("used", 0),
+            compute_tier_value=compute_result.get("tier", ""),
+            model_preference_value=compute_result.get("model_preference", ""),
+        )
+
     # Valid FoundUpJob envelope
     # Determine validation code
     if evidence_pending:
@@ -459,6 +515,12 @@ def validate_foundup_job_envelope(envelope: Dict[str, Any]) -> EnvelopeValidatio
         evidence_pending=evidence_pending,
         is_live_mode=is_live_mode,
         live_mode_gates_passed=is_live_mode,  # True only if live mode and passed gates
+        # Compute budget (WSP 97: structural validation, no metering claims)
+        compute_budget_validated=True,
+        compute_budget_value=compute_result.get("budget"),
+        compute_used_value=compute_result.get("used", 0),
+        compute_tier_value=compute_result.get("tier", "freemium"),
+        model_preference_value=compute_result.get("model_preference", "auto"),
         # WSP 97 Truth: Always False at validation time
         verification_complete=False,
         cabr_ready=False,
@@ -656,6 +718,171 @@ def _validate_evidence_refs(
         "message": f"Evidence refs validated ({len(evidence_refs)} entries)",
         "count": len(evidence_refs),
         "pending": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Compute Budget Validation (WSP 97: Structural validation only)
+# ---------------------------------------------------------------------------
+
+# Allowed compute tiers (from FoundUpJob contract)
+ALLOWED_COMPUTE_TIERS: frozenset[str] = frozenset({
+    "freemium",
+    "basic",
+    "enterprise",
+})
+
+# Allowed model preferences (from FoundUpJob contract)
+ALLOWED_MODEL_PREFERENCES: frozenset[str] = frozenset({
+    "auto",
+    "free",
+    "standard",
+    "premium",
+})
+
+
+def _validate_compute_budget(
+    envelope: Dict[str, Any],
+    is_live_mode: bool = False,
+) -> Dict[str, Any]:
+    """
+    Validate compute budget fields for FoundUpJob envelope.
+
+    WSP 97 Truth Boundaries:
+      - Compute validation proves structural correctness only
+      - Does NOT verify actual metering accuracy
+      - Does NOT prove resource consumption tracking
+      - Does NOT enable billing claims
+
+    Validates:
+      - compute_budget: Optional[int] (None or non-negative integer)
+      - compute_used: int (non-negative integer)
+      - compute_tier: str (must be in ALLOWED_COMPUTE_TIERS)
+      - model_preference: str (must be in ALLOWED_MODEL_PREFERENCES)
+      - compute_used <= compute_budget (when budget is set)
+      - live mode requires explicit compute_budget
+
+    Args:
+        envelope: FoundUpJob envelope dict
+        is_live_mode: Whether dry_run_mode=False (live execution)
+
+    Returns:
+        Dict with: valid, code, message, budget, used, tier, model_preference
+    """
+    # Extract fields with defaults matching FoundUpJob contract
+    compute_budget = envelope.get("compute_budget")  # None = unlimited
+    compute_used = envelope.get("compute_used", 0)
+    compute_tier = envelope.get("compute_tier", "freemium")
+    model_preference = envelope.get("model_preference", "auto")
+
+    # === compute_budget type validation ===
+    # Contract: Optional[int] - None or int only (no floats)
+    if compute_budget is not None:
+        if not isinstance(compute_budget, int) or isinstance(compute_budget, bool):
+            return {
+                "valid": False,
+                "code": EnvelopeValidationCode.INVALID_COMPUTE_BUDGET_TYPE,
+                "message": f"compute_budget must be int or None, got {type(compute_budget).__name__}",
+                "budget": None,
+                "used": compute_used if isinstance(compute_used, int) else 0,
+                "tier": compute_tier,
+                "model_preference": model_preference,
+            }
+
+        # Non-negative check
+        if compute_budget < 0:
+            return {
+                "valid": False,
+                "code": EnvelopeValidationCode.INVALID_COMPUTE_BUDGET_NEGATIVE,
+                "message": f"compute_budget must be non-negative, got {compute_budget}",
+                "budget": compute_budget,
+                "used": compute_used if isinstance(compute_used, int) else 0,
+                "tier": compute_tier,
+                "model_preference": model_preference,
+            }
+
+    # === compute_used type validation ===
+    # Contract: int only (no floats)
+    if not isinstance(compute_used, int) or isinstance(compute_used, bool):
+        return {
+            "valid": False,
+            "code": EnvelopeValidationCode.INVALID_COMPUTE_USED_TYPE,
+            "message": f"compute_used must be int, got {type(compute_used).__name__}",
+            "budget": compute_budget,
+            "used": 0,
+            "tier": compute_tier,
+            "model_preference": model_preference,
+        }
+
+    # Non-negative check
+    if compute_used < 0:
+        return {
+            "valid": False,
+            "code": EnvelopeValidationCode.INVALID_COMPUTE_USED_NEGATIVE,
+            "message": f"compute_used must be non-negative, got {compute_used}",
+            "budget": compute_budget,
+            "used": compute_used,
+            "tier": compute_tier,
+            "model_preference": model_preference,
+        }
+
+    # === Budget exhaustion check ===
+    if compute_budget is not None and compute_used > compute_budget:
+        return {
+            "valid": False,
+            "code": EnvelopeValidationCode.COMPUTE_USED_EXCEEDS_BUDGET,
+            "message": f"compute_used ({compute_used}) exceeds compute_budget ({compute_budget})",
+            "budget": compute_budget,
+            "used": compute_used,
+            "tier": compute_tier,
+            "model_preference": model_preference,
+        }
+
+    # === Live mode requires explicit budget ===
+    if is_live_mode and compute_budget is None:
+        return {
+            "valid": False,
+            "code": EnvelopeValidationCode.LIVE_MODE_REQUIRES_COMPUTE_BUDGET,
+            "message": "Live mode requires explicit compute_budget",
+            "budget": None,
+            "used": compute_used,
+            "tier": compute_tier,
+            "model_preference": model_preference,
+        }
+
+    # === compute_tier validation ===
+    if compute_tier not in ALLOWED_COMPUTE_TIERS:
+        return {
+            "valid": False,
+            "code": EnvelopeValidationCode.INVALID_COMPUTE_TIER,
+            "message": f"compute_tier must be one of {sorted(ALLOWED_COMPUTE_TIERS)}, got '{compute_tier}'",
+            "budget": compute_budget,
+            "used": compute_used,
+            "tier": compute_tier,
+            "model_preference": model_preference,
+        }
+
+    # === model_preference validation ===
+    if model_preference not in ALLOWED_MODEL_PREFERENCES:
+        return {
+            "valid": False,
+            "code": EnvelopeValidationCode.INVALID_MODEL_PREFERENCE,
+            "message": f"model_preference must be one of {sorted(ALLOWED_MODEL_PREFERENCES)}, got '{model_preference}'",
+            "budget": compute_budget,
+            "used": compute_used,
+            "tier": compute_tier,
+            "model_preference": model_preference,
+        }
+
+    # All checks passed
+    return {
+        "valid": True,
+        "code": EnvelopeValidationCode.VALID,
+        "message": "Compute budget validated",
+        "budget": compute_budget,
+        "used": compute_used,
+        "tier": compute_tier,
+        "model_preference": model_preference,
     }
 
 

--- a/modules/infrastructure/wre_core/tests/TestModLog.md
+++ b/modules/infrastructure/wre_core/tests/TestModLog.md
@@ -1,5 +1,26 @@
 # TestModLog - wre_core/tests
 
+## 2026-05-02: Compute budget validation tests
+
+- Command: `python -m pytest modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py -q`
+- Status: PASS
+- Result: `93 passed`
+- Notes:
+  - Added `TestComputeBudgetTypeValidation` (5 tests) - int/None valid, float/str/bool fail
+  - Added `TestComputeBudgetNegativeValidation` (3 tests) - 0 and positive pass, negative fails
+  - Added `TestComputeUsedTypeValidation` (4 tests) - int valid, float/str/bool fail
+  - Added `TestComputeUsedNegativeValidation` (3 tests) - 0 and positive pass, negative fails
+  - Added `TestComputeUsedExceedsBudget` (4 tests) - used <= budget or None budget
+  - Added `TestLiveModeRequiresComputeBudget` (3 tests) - live mode needs explicit budget
+  - Added `TestComputeTierValidation` (4 tests) - freemium/basic/enterprise only
+  - Added `TestModelPreferenceValidation` (5 tests) - auto/free/standard/premium only
+  - Added `TestComputeBudgetWSP97Truth` (2 tests) - no metering accuracy claims
+  - Added `TestGenericDAEComputeIgnored` (1 test) - generic DAE skips compute validation
+  - Updated 7 existing live mode tests to include compute_budget
+  - Full suite: 499 passed (excluding production_gates)
+
+---
+
 ## 2026-05-02: Live mode policy gate tests
 
 - Command: `python -m pytest modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py -q`

--- a/modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py
+++ b/modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py
@@ -211,6 +211,7 @@ class TestFoundUpJobDryRunDefault:
                 "human_approval": True,  # Required for live mode
             },
             "evidence_refs": ["manifest.json"],  # Required for live mode
+            "compute_budget": 5000,  # Required for live mode
         }
 
         result = validate_foundup_job_envelope(envelope)
@@ -697,6 +698,7 @@ class TestEvidenceRefsWSP97TruthFields:
                 "human_approval": True,  # Required for live mode
             },
             "evidence_refs": ["manifest.json", "proof_abc123"],
+            "compute_budget": 5000,  # Required for live mode
         }
 
         result = validate_foundup_job_envelope(envelope)
@@ -970,6 +972,7 @@ class TestLiveModeWithApprovalAndEvidenceNoVerification:
                 "human_approval": True,
             },
             "evidence_refs": ["manifest.json", "proof.json"],
+            "compute_budget": 5000,  # Required for live mode
         }
 
         result = validate_foundup_job_envelope(envelope)
@@ -991,6 +994,7 @@ class TestLiveModeWithApprovalAndEvidenceNoVerification:
                 "permission_gate_passed": True,  # Alternative approval
             },
             "evidence_refs": ["cabr_evidence.json"],
+            "compute_budget": 5000,  # Required for live mode
         }
 
         result = validate_foundup_job_envelope(envelope)
@@ -1012,6 +1016,7 @@ class TestLiveModeWithApprovalAndEvidenceNoVerification:
                 "security_gate_passed": True,
             },
             "evidence_refs": ["payout_ready_evidence.json"],
+            "compute_budget": 5000,  # Required for live mode
         }
 
         result = validate_foundup_job_envelope(envelope)
@@ -1058,6 +1063,7 @@ class TestLiveModeSecurityGate:
                 "security_gate_checked": False,  # Not checked, so not required
             },
             "evidence_refs": ["evidence.json"],
+            "compute_budget": 5000,  # Required for live mode
         }
 
         result = validate_foundup_job_envelope(envelope)
@@ -1139,6 +1145,7 @@ class TestLiveModeValidationErrorDetails:
                 "human_approval": True,
             },
             "evidence_refs": ["complete_evidence.json"],
+            "compute_budget": 5000,  # Required for live mode
         }
 
         result = validate_foundup_job_envelope(envelope)
@@ -1149,6 +1156,604 @@ class TestLiveModeValidationErrorDetails:
         assert "missing_live_gates" in result_dict
         assert result_dict["is_live_mode"] is True
         assert result_dict["live_mode_gates_passed"] is True
+
+
+# ---------------------------------------------------------------------------
+# Test: Compute Budget Validation (WRE_COMPUTE_BUDGET_VALIDATION_PHASE1)
+# ---------------------------------------------------------------------------
+
+
+class TestComputeBudgetTypeValidation:
+    """Test compute_budget type validation (int only per contract)."""
+
+    def test_compute_budget_none_is_valid(self):
+        """compute_budget=None (unlimited) is valid."""
+        envelope = {
+            "job_id": "job_budget_001",
+            "foundup_id": "gotjunk",
+            "tenant_id": "tenant_alice",
+            "requested_action": "build_foundup",
+            "compute_budget": None,
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.compute_budget_validated is True
+        assert result.compute_budget_value is None
+
+    def test_compute_budget_int_is_valid(self):
+        """compute_budget as int is valid."""
+        envelope = {
+            "job_id": "job_budget_002",
+            "foundup_id": "kosei",
+            "tenant_id": "tenant_bob",
+            "requested_action": "validate_foundup",
+            "compute_budget": 1000,
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.compute_budget_validated is True
+        assert result.compute_budget_value == 1000
+
+    def test_compute_budget_float_fails(self):
+        """compute_budget as float fails (contract is int only)."""
+        envelope = {
+            "job_id": "job_budget_003",
+            "foundup_id": "move2japan",
+            "tenant_id": "tenant_carol",
+            "requested_action": "extract_foundup",
+            "compute_budget": 100.5,
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.INVALID_COMPUTE_BUDGET_TYPE
+        assert "int" in result.validation_message
+
+    def test_compute_budget_string_fails(self):
+        """compute_budget as string fails."""
+        envelope = {
+            "job_id": "job_budget_004",
+            "foundup_id": "social_twin",
+            "tenant_id": "tenant_dave",
+            "requested_action": "build_foundup",
+            "compute_budget": "1000",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.INVALID_COMPUTE_BUDGET_TYPE
+
+    def test_compute_budget_bool_fails(self):
+        """compute_budget as bool fails (bool is subclass of int in Python)."""
+        envelope = {
+            "job_id": "job_budget_005",
+            "foundup_id": "pqn_portal",
+            "tenant_id": "tenant_eve",
+            "requested_action": "validate_foundup",
+            "compute_budget": True,  # bool is subclass of int, must be rejected
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.INVALID_COMPUTE_BUDGET_TYPE
+
+
+class TestComputeBudgetNegativeValidation:
+    """Test compute_budget non-negative validation."""
+
+    def test_compute_budget_zero_is_valid(self):
+        """compute_budget=0 is valid (exhausted but not negative)."""
+        envelope = {
+            "job_id": "job_budget_006",
+            "foundup_id": "gotjunk",
+            "tenant_id": "tenant_frank",
+            "requested_action": "build_foundup",
+            "compute_budget": 0,
+            "compute_used": 0,
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.compute_budget_value == 0
+
+    def test_compute_budget_positive_is_valid(self):
+        """compute_budget > 0 is valid."""
+        envelope = {
+            "job_id": "job_budget_007",
+            "foundup_id": "kosei",
+            "tenant_id": "tenant_grace",
+            "requested_action": "validate_foundup",
+            "compute_budget": 5000,
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.compute_budget_value == 5000
+
+    def test_compute_budget_negative_fails(self):
+        """compute_budget < 0 fails."""
+        envelope = {
+            "job_id": "job_budget_008",
+            "foundup_id": "move2japan",
+            "tenant_id": "tenant_hank",
+            "requested_action": "extract_foundup",
+            "compute_budget": -100,
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.INVALID_COMPUTE_BUDGET_NEGATIVE
+        assert "non-negative" in result.validation_message
+
+
+class TestComputeUsedTypeValidation:
+    """Test compute_used type validation (int only per contract)."""
+
+    def test_compute_used_int_is_valid(self):
+        """compute_used as int is valid."""
+        envelope = {
+            "job_id": "job_budget_009",
+            "foundup_id": "social_twin",
+            "tenant_id": "tenant_ivan",
+            "requested_action": "build_foundup",
+            "compute_used": 500,
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.compute_used_value == 500
+
+    def test_compute_used_float_fails(self):
+        """compute_used as float fails."""
+        envelope = {
+            "job_id": "job_budget_010",
+            "foundup_id": "pqn_portal",
+            "tenant_id": "tenant_judy",
+            "requested_action": "validate_foundup",
+            "compute_used": 100.5,
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.INVALID_COMPUTE_USED_TYPE
+
+    def test_compute_used_string_fails(self):
+        """compute_used as string fails."""
+        envelope = {
+            "job_id": "job_budget_011",
+            "foundup_id": "gotjunk",
+            "tenant_id": "tenant_kevin",
+            "requested_action": "extract_foundup",
+            "compute_used": "500",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.INVALID_COMPUTE_USED_TYPE
+
+    def test_compute_used_bool_fails(self):
+        """compute_used as bool fails."""
+        envelope = {
+            "job_id": "job_budget_012",
+            "foundup_id": "kosei",
+            "tenant_id": "tenant_larry",
+            "requested_action": "build_foundup",
+            "compute_used": False,
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.INVALID_COMPUTE_USED_TYPE
+
+
+class TestComputeUsedNegativeValidation:
+    """Test compute_used non-negative validation."""
+
+    def test_compute_used_zero_is_valid(self):
+        """compute_used=0 is valid."""
+        envelope = {
+            "job_id": "job_budget_013",
+            "foundup_id": "move2japan",
+            "tenant_id": "tenant_mary",
+            "requested_action": "validate_foundup",
+            "compute_used": 0,
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.compute_used_value == 0
+
+    def test_compute_used_positive_is_valid(self):
+        """compute_used > 0 is valid."""
+        envelope = {
+            "job_id": "job_budget_014",
+            "foundup_id": "social_twin",
+            "tenant_id": "tenant_nancy",
+            "requested_action": "build_foundup",
+            "compute_used": 250,
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.compute_used_value == 250
+
+    def test_compute_used_negative_fails(self):
+        """compute_used < 0 fails."""
+        envelope = {
+            "job_id": "job_budget_015",
+            "foundup_id": "pqn_portal",
+            "tenant_id": "tenant_oscar",
+            "requested_action": "extract_foundup",
+            "compute_used": -50,
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.INVALID_COMPUTE_USED_NEGATIVE
+
+
+class TestComputeUsedExceedsBudget:
+    """Test compute_used cannot exceed compute_budget."""
+
+    def test_compute_used_less_than_budget_passes(self):
+        """compute_used < compute_budget passes."""
+        envelope = {
+            "job_id": "job_budget_016",
+            "foundup_id": "gotjunk",
+            "tenant_id": "tenant_paul",
+            "requested_action": "build_foundup",
+            "compute_budget": 1000,
+            "compute_used": 500,
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.compute_budget_value == 1000
+        assert result.compute_used_value == 500
+
+    def test_compute_used_equals_budget_passes(self):
+        """compute_used == compute_budget passes (fully consumed)."""
+        envelope = {
+            "job_id": "job_budget_017",
+            "foundup_id": "kosei",
+            "tenant_id": "tenant_quinn",
+            "requested_action": "validate_foundup",
+            "compute_budget": 1000,
+            "compute_used": 1000,
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.compute_used_value == result.compute_budget_value
+
+    def test_compute_used_exceeds_budget_fails(self):
+        """compute_used > compute_budget fails."""
+        envelope = {
+            "job_id": "job_budget_018",
+            "foundup_id": "move2japan",
+            "tenant_id": "tenant_rachel",
+            "requested_action": "extract_foundup",
+            "compute_budget": 1000,
+            "compute_used": 1001,
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.COMPUTE_USED_EXCEEDS_BUDGET
+        assert "exceeds" in result.validation_message
+
+    def test_compute_used_with_none_budget_passes(self):
+        """compute_used with compute_budget=None passes (unlimited)."""
+        envelope = {
+            "job_id": "job_budget_019",
+            "foundup_id": "social_twin",
+            "tenant_id": "tenant_steve",
+            "requested_action": "build_foundup",
+            "compute_budget": None,
+            "compute_used": 999999,
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.compute_budget_value is None
+        assert result.compute_used_value == 999999
+
+
+class TestLiveModeRequiresComputeBudget:
+    """Test live mode requires explicit compute_budget."""
+
+    def test_live_mode_with_budget_passes(self):
+        """Live mode with explicit compute_budget passes."""
+        envelope = {
+            "job_id": "job_budget_020",
+            "foundup_id": "pqn_portal",
+            "tenant_id": "tenant_tina",
+            "requested_action": "validate_foundup",
+            "policy_flags": {
+                "dry_run_mode": False,
+                "human_approval": True,
+            },
+            "evidence_refs": ["manifest.json"],
+            "compute_budget": 5000,
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.is_live_mode is True
+        assert result.compute_budget_value == 5000
+
+    def test_live_mode_without_budget_fails(self):
+        """Live mode without compute_budget fails."""
+        envelope = {
+            "job_id": "job_budget_021",
+            "foundup_id": "gotjunk",
+            "tenant_id": "tenant_uma",
+            "requested_action": "build_foundup",
+            "policy_flags": {
+                "dry_run_mode": False,
+                "human_approval": True,
+            },
+            "evidence_refs": ["evidence.json"],
+            "compute_budget": None,
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.LIVE_MODE_REQUIRES_COMPUTE_BUDGET
+        assert result.is_live_mode is True
+
+    def test_dry_run_without_budget_passes(self):
+        """Dry-run mode without compute_budget passes (allowed for dry-run)."""
+        envelope = {
+            "job_id": "job_budget_022",
+            "foundup_id": "kosei",
+            "tenant_id": "tenant_victor",
+            "requested_action": "validate_foundup",
+            "policy_flags": {"dry_run_mode": True},
+            "compute_budget": None,
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.is_live_mode is False
+        assert result.compute_budget_value is None
+
+
+class TestComputeTierValidation:
+    """Test compute_tier validation against allowed values."""
+
+    def test_compute_tier_freemium_passes(self):
+        """compute_tier='freemium' passes."""
+        envelope = {
+            "job_id": "job_budget_023",
+            "foundup_id": "move2japan",
+            "tenant_id": "tenant_wendy",
+            "requested_action": "extract_foundup",
+            "compute_tier": "freemium",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.compute_tier_value == "freemium"
+
+    def test_compute_tier_basic_passes(self):
+        """compute_tier='basic' passes."""
+        envelope = {
+            "job_id": "job_budget_024",
+            "foundup_id": "social_twin",
+            "tenant_id": "tenant_xander",
+            "requested_action": "build_foundup",
+            "compute_tier": "basic",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.compute_tier_value == "basic"
+
+    def test_compute_tier_enterprise_passes(self):
+        """compute_tier='enterprise' passes."""
+        envelope = {
+            "job_id": "job_budget_025",
+            "foundup_id": "pqn_portal",
+            "tenant_id": "tenant_yolanda",
+            "requested_action": "validate_foundup",
+            "compute_tier": "enterprise",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.compute_tier_value == "enterprise"
+
+    def test_compute_tier_unknown_fails(self):
+        """compute_tier with unknown value fails."""
+        envelope = {
+            "job_id": "job_budget_026",
+            "foundup_id": "gotjunk",
+            "tenant_id": "tenant_zach",
+            "requested_action": "build_foundup",
+            "compute_tier": "premium_plus",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.INVALID_COMPUTE_TIER
+        assert "premium_plus" in result.validation_message
+
+
+class TestModelPreferenceValidation:
+    """Test model_preference validation against allowed values."""
+
+    def test_model_preference_auto_passes(self):
+        """model_preference='auto' passes."""
+        envelope = {
+            "job_id": "job_budget_027",
+            "foundup_id": "kosei",
+            "tenant_id": "tenant_amy",
+            "requested_action": "validate_foundup",
+            "model_preference": "auto",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.model_preference_value == "auto"
+
+    def test_model_preference_free_passes(self):
+        """model_preference='free' passes."""
+        envelope = {
+            "job_id": "job_budget_028",
+            "foundup_id": "move2japan",
+            "tenant_id": "tenant_bill",
+            "requested_action": "extract_foundup",
+            "model_preference": "free",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.model_preference_value == "free"
+
+    def test_model_preference_standard_passes(self):
+        """model_preference='standard' passes."""
+        envelope = {
+            "job_id": "job_budget_029",
+            "foundup_id": "social_twin",
+            "tenant_id": "tenant_cara",
+            "requested_action": "build_foundup",
+            "model_preference": "standard",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.model_preference_value == "standard"
+
+    def test_model_preference_premium_passes(self):
+        """model_preference='premium' passes."""
+        envelope = {
+            "job_id": "job_budget_030",
+            "foundup_id": "pqn_portal",
+            "tenant_id": "tenant_dan",
+            "requested_action": "validate_foundup",
+            "model_preference": "premium",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.model_preference_value == "premium"
+
+    def test_model_preference_unknown_fails(self):
+        """model_preference with unknown value fails."""
+        envelope = {
+            "job_id": "job_budget_031",
+            "foundup_id": "gotjunk",
+            "tenant_id": "tenant_emma",
+            "requested_action": "build_foundup",
+            "model_preference": "opus",  # Not in allowed list
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.INVALID_MODEL_PREFERENCE
+        assert "opus" in result.validation_message
+
+
+class TestComputeBudgetWSP97Truth:
+    """Test compute budget validation does not claim metering accuracy."""
+
+    def test_compute_validation_does_not_claim_verification(self):
+        """Compute validation does NOT set verification_complete=True."""
+        envelope = {
+            "job_id": "job_budget_032",
+            "foundup_id": "kosei",
+            "tenant_id": "tenant_frank",
+            "requested_action": "validate_foundup",
+            "compute_budget": 5000,
+            "compute_used": 1000,
+            "compute_tier": "enterprise",
+            "model_preference": "premium",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.compute_budget_validated is True
+        # WSP 97: Compute validation is structural only
+        assert result.verification_complete is False
+        assert result.cabr_ready is False
+        assert result.payout_ready is False
+
+    def test_compute_fields_in_serialized_result(self):
+        """Compute budget fields appear in to_dict() output."""
+        envelope = {
+            "job_id": "job_budget_033",
+            "foundup_id": "move2japan",
+            "tenant_id": "tenant_gina",
+            "requested_action": "extract_foundup",
+            "compute_budget": 2000,
+            "compute_used": 500,
+            "compute_tier": "basic",
+            "model_preference": "free",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+        result_dict = result.to_dict()
+
+        assert "compute_budget_validated" in result_dict
+        assert "compute_budget_value" in result_dict
+        assert "compute_used_value" in result_dict
+        assert "compute_tier_value" in result_dict
+        assert "model_preference_value" in result_dict
+        assert result_dict["compute_budget_validated"] is True
+        assert result_dict["compute_budget_value"] == 2000
+        assert result_dict["compute_used_value"] == 500
+
+
+class TestGenericDAEComputeIgnored:
+    """Test generic DAE envelope ignores compute fields."""
+
+    def test_generic_dae_ignores_compute_budget(self):
+        """Generic DAE envelope does not validate compute_budget."""
+        envelope = {
+            "objective": "Do something generic",
+            "compute_budget": "invalid_string",  # Would fail for FoundUpJob
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.envelope_type == EnvelopeType.GENERIC_DAE
+        assert result.compute_budget_validated is False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds structural compute budget validation for FoundUpJob envelopes
- Validates:
  - compute_budget type and non-negative value
  - compute_used type and non-negative value
  - compute_used <= compute_budget when budget present
  - live mode requires explicit compute_budget
  - compute_tier: freemium | basic | enterprise
  - model_preference: auto | free | standard | premium
- Adds compute validation metadata to EnvelopeValidationResult
- Generic DAE compute fields remain ignored/permissive

## Contract Alignment
```python
compute_budget: Optional[int]
compute_used: int
compute_tier: freemium | basic | enterprise
model_preference: auto | free | standard | premium
```

## WSP 97 Truth Boundaries
- Structural validation only
- Does not verify actual metering accuracy
- Does not prove resource consumption tracking
- Does not enable billing claims
- verification_complete=False, cabr_ready=False, payout_ready=False
- No CABR/reward/payout/token claims

## Test plan
- [x] 93 compute budget validation tests pass
- [x] Full WRE core suite: 499 passed (excluding production_gates)
- [ ] CI verification pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)