### PR TITLE
fix(wre): validate FoundUpJob model routing policy

### DIFF
--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -2,6 +2,52 @@
 
 ## Chronological Change Log
 
+### [2026-05-02] - WRE_MODEL_ROUTING_POLICY_VALIDATION_PHASE1 (v0.8.14)
+
+**WSP Protocol References**: WSP 11 (Interface), WSP 97 (Truthful - policy validation only)
+**Impact Analysis**: Validate tier/preference compatibility for FoundUpJob model routing
+
+#### Changes Made
+
+- `src/foundup_job_router.py`:
+  - Added `EnvelopeValidationCode.MODEL_PREFERENCE_NOT_ALLOWED_FOR_TIER`
+  - Added `TIER_ALLOWED_PREFERENCES` map:
+    - freemium: auto, free only
+    - basic: auto, free, standard
+    - enterprise: auto, free, standard, premium
+  - Added `EnvelopeValidationResult` fields: model_routing_policy_validated, model_routing_policy_reason
+  - Added tier/preference compatibility check in `_validate_compute_budget()`
+
+- `tests/test_foundup_job_envelope_validation.py`:
+  - Added 18 new tests for model routing policy validation
+  - Updated 2 existing tests to use compatible tiers
+
+#### Policy Rules
+
+| Tier | Allowed Preferences |
+|------|---------------------|
+| freemium | auto, free |
+| basic | auto, free, standard |
+| enterprise | auto, free, standard, premium |
+
+#### WSP 97 Truth Boundaries
+
+- Policy validation is structural only - no model selected
+- No inference executed, no compute consumed
+- verification_complete=False, cabr_ready=False, payout_ready=False
+
+#### Verification
+
+```bash
+python -m pytest modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py -q
+# 111 passed
+
+python -m pytest modules/infrastructure/wre_core/tests -q --ignore=modules/infrastructure/wre_core/tests/test_production_gates.py
+# 517 passed
+```
+
+---
+
 ### [2026-05-02] - WRE_COMPUTE_BUDGET_VALIDATION_PHASE1 (v0.8.13)
 
 **WSP Protocol References**: WSP 11 (Interface), WSP 97 (Truthful - structural validation only)

--- a/modules/infrastructure/wre_core/src/foundup_job_router.py
+++ b/modules/infrastructure/wre_core/src/foundup_job_router.py
@@ -176,6 +176,9 @@ class EnvelopeValidationCode(str, Enum):
     INVALID_COMPUTE_TIER = "INVALID_COMPUTE_TIER"
     INVALID_MODEL_PREFERENCE = "INVALID_MODEL_PREFERENCE"
 
+    # Invalid - Model Routing Policy
+    MODEL_PREFERENCE_NOT_ALLOWED_FOR_TIER = "MODEL_PREFERENCE_NOT_ALLOWED_FOR_TIER"
+
 
 @dataclass
 class EnvelopeValidationResult:
@@ -243,6 +246,13 @@ class EnvelopeValidationResult:
     model_preference_value: str = ""
     """Model preference from envelope."""
 
+    # === Model Routing Policy Validation ===
+    model_routing_policy_validated: bool = False
+    """True if tier/preference compatibility passed validation."""
+
+    model_routing_policy_reason: str = ""
+    """Explanation of routing policy validation result."""
+
     # === WSP 97 Truth Fields (ALWAYS False at validation time) ===
     verification_complete: bool = False
     """WSP 97: Always False. Evidence presence does NOT imply verification."""
@@ -276,6 +286,9 @@ class EnvelopeValidationResult:
             "compute_used_value": self.compute_used_value,
             "compute_tier_value": self.compute_tier_value,
             "model_preference_value": self.model_preference_value,
+            # Model routing policy
+            "model_routing_policy_validated": self.model_routing_policy_validated,
+            "model_routing_policy_reason": self.model_routing_policy_reason,
             # WSP 97 Truth: Always False at validation time
             "verification_complete": self.verification_complete,
             "cabr_ready": self.cabr_ready,
@@ -492,6 +505,8 @@ def validate_foundup_job_envelope(envelope: Dict[str, Any]) -> EnvelopeValidatio
             compute_used_value=compute_result.get("used", 0),
             compute_tier_value=compute_result.get("tier", ""),
             model_preference_value=compute_result.get("model_preference", ""),
+            model_routing_policy_validated=compute_result.get("routing_policy_validated", False),
+            model_routing_policy_reason=compute_result.get("routing_policy_reason", ""),
         )
 
     # Valid FoundUpJob envelope
@@ -521,6 +536,9 @@ def validate_foundup_job_envelope(envelope: Dict[str, Any]) -> EnvelopeValidatio
         compute_used_value=compute_result.get("used", 0),
         compute_tier_value=compute_result.get("tier", "freemium"),
         model_preference_value=compute_result.get("model_preference", "auto"),
+        # Model routing policy (WSP 97: policy validation, no model selected)
+        model_routing_policy_validated=compute_result.get("routing_policy_validated", True),
+        model_routing_policy_reason=compute_result.get("routing_policy_reason", ""),
         # WSP 97 Truth: Always False at validation time
         verification_complete=False,
         cabr_ready=False,
@@ -740,6 +758,17 @@ ALLOWED_MODEL_PREFERENCES: frozenset[str] = frozenset({
     "premium",
 })
 
+# Tier -> allowed model preferences (conservative routing policy)
+# - auto is always allowed (runtime selects based on tier)
+# - freemium: free models only (no paid inference)
+# - basic: free + standard models
+# - enterprise: all models including premium
+TIER_ALLOWED_PREFERENCES: Dict[str, frozenset[str]] = {
+    "freemium": frozenset({"auto", "free"}),
+    "basic": frozenset({"auto", "free", "standard"}),
+    "enterprise": frozenset({"auto", "free", "standard", "premium"}),
+}
+
 
 def _validate_compute_budget(
     envelope: Dict[str, Any],
@@ -872,9 +901,27 @@ def _validate_compute_budget(
             "used": compute_used,
             "tier": compute_tier,
             "model_preference": model_preference,
+            "routing_policy_validated": False,
+            "routing_policy_reason": "model_preference validation failed",
+        }
+
+    # === Tier/preference compatibility check ===
+    allowed_for_tier = TIER_ALLOWED_PREFERENCES.get(compute_tier, frozenset())
+    if model_preference not in allowed_for_tier:
+        return {
+            "valid": False,
+            "code": EnvelopeValidationCode.MODEL_PREFERENCE_NOT_ALLOWED_FOR_TIER,
+            "message": f"model_preference '{model_preference}' not allowed for compute_tier '{compute_tier}' (allowed: {sorted(allowed_for_tier)})",
+            "budget": compute_budget,
+            "used": compute_used,
+            "tier": compute_tier,
+            "model_preference": model_preference,
+            "routing_policy_validated": False,
+            "routing_policy_reason": f"tier '{compute_tier}' does not allow preference '{model_preference}'",
         }
 
     # All checks passed
+    routing_reason = f"tier '{compute_tier}' allows preference '{model_preference}'"
     return {
         "valid": True,
         "code": EnvelopeValidationCode.VALID,
@@ -883,6 +930,8 @@ def _validate_compute_budget(
         "used": compute_used,
         "tier": compute_tier,
         "model_preference": model_preference,
+        "routing_policy_validated": True,
+        "routing_policy_reason": routing_reason,
     }
 
 

--- a/modules/infrastructure/wre_core/tests/TestModLog.md
+++ b/modules/infrastructure/wre_core/tests/TestModLog.md
@@ -1,5 +1,25 @@
 # TestModLog - wre_core/tests
 
+## 2026-05-02: Model routing policy validation tests
+
+- Command: `python -m pytest modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py -q`
+- Status: PASS
+- Result: `111 passed`
+- Notes:
+  - Added `TestFreemiumTierModelRouting` (4 tests) - freemium allows auto/free only
+  - Added `TestBasicTierModelRouting` (4 tests) - basic allows auto/free/standard
+  - Added `TestEnterpriseTierModelRouting` (4 tests) - enterprise allows all
+  - Added `TestAutoPreferenceAllTiers` (3 tests) - auto valid for all tiers
+  - Added `TestModelRoutingPolicyWSP97Truth` (2 tests) - policy validation is structural
+  - Added `TestGenericDAERoutingPolicyIgnored` (1 test) - generic DAE skips routing
+  - Updated 2 existing model preference tests to include compatible tiers
+  - Added EnvelopeValidationCode.MODEL_PREFERENCE_NOT_ALLOWED_FOR_TIER
+  - Added TIER_ALLOWED_PREFERENCES map in foundup_job_router.py
+  - Added model_routing_policy_validated/model_routing_policy_reason fields
+  - Full suite: 517 passed (excluding production_gates)
+
+---
+
 ## 2026-05-02: Compute budget validation tests
 
 - Command: `python -m pytest modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py -q`

--- a/modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py
+++ b/modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py
@@ -1642,12 +1642,13 @@ class TestModelPreferenceValidation:
         assert result.model_preference_value == "free"
 
     def test_model_preference_standard_passes(self):
-        """model_preference='standard' passes."""
+        """model_preference='standard' passes (with compatible tier)."""
         envelope = {
             "job_id": "job_budget_029",
             "foundup_id": "social_twin",
             "tenant_id": "tenant_cara",
             "requested_action": "build_foundup",
+            "compute_tier": "basic",  # basic tier allows standard
             "model_preference": "standard",
         }
 
@@ -1657,12 +1658,13 @@ class TestModelPreferenceValidation:
         assert result.model_preference_value == "standard"
 
     def test_model_preference_premium_passes(self):
-        """model_preference='premium' passes."""
+        """model_preference='premium' passes (with compatible tier)."""
         envelope = {
             "job_id": "job_budget_030",
             "foundup_id": "pqn_portal",
             "tenant_id": "tenant_dan",
             "requested_action": "validate_foundup",
+            "compute_tier": "enterprise",  # enterprise tier allows premium
             "model_preference": "premium",
         }
 
@@ -1754,6 +1756,342 @@ class TestGenericDAEComputeIgnored:
         assert result.valid is True
         assert result.envelope_type == EnvelopeType.GENERIC_DAE
         assert result.compute_budget_validated is False
+
+
+# ---------------------------------------------------------------------------
+# Test: Model Routing Policy Validation (WRE_MODEL_ROUTING_POLICY_VALIDATION_PHASE1)
+# ---------------------------------------------------------------------------
+
+
+class TestFreemiumTierModelRouting:
+    """Test freemium tier model preference restrictions."""
+
+    def test_freemium_with_free_passes(self):
+        """freemium tier with free preference passes."""
+        envelope = {
+            "job_id": "job_policy_001",
+            "foundup_id": "gotjunk",
+            "tenant_id": "tenant_alice",
+            "requested_action": "build_foundup",
+            "compute_tier": "freemium",
+            "model_preference": "free",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.model_routing_policy_validated is True
+        assert "freemium" in result.model_routing_policy_reason
+        assert "free" in result.model_routing_policy_reason
+
+    def test_freemium_with_auto_passes(self):
+        """freemium tier with auto preference passes (auto always allowed)."""
+        envelope = {
+            "job_id": "job_policy_002",
+            "foundup_id": "kosei",
+            "tenant_id": "tenant_bob",
+            "requested_action": "validate_foundup",
+            "compute_tier": "freemium",
+            "model_preference": "auto",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.model_routing_policy_validated is True
+
+    def test_freemium_with_standard_fails(self):
+        """freemium tier with standard preference fails."""
+        envelope = {
+            "job_id": "job_policy_003",
+            "foundup_id": "move2japan",
+            "tenant_id": "tenant_carol",
+            "requested_action": "extract_foundup",
+            "compute_tier": "freemium",
+            "model_preference": "standard",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.MODEL_PREFERENCE_NOT_ALLOWED_FOR_TIER
+        assert "standard" in result.validation_message
+        assert "freemium" in result.validation_message
+        assert result.model_routing_policy_validated is False
+
+    def test_freemium_with_premium_fails(self):
+        """freemium tier with premium preference fails."""
+        envelope = {
+            "job_id": "job_policy_004",
+            "foundup_id": "social_twin",
+            "tenant_id": "tenant_dave",
+            "requested_action": "build_foundup",
+            "compute_tier": "freemium",
+            "model_preference": "premium",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.MODEL_PREFERENCE_NOT_ALLOWED_FOR_TIER
+        assert "premium" in result.validation_message
+        assert result.model_routing_policy_validated is False
+
+
+class TestBasicTierModelRouting:
+    """Test basic tier model preference restrictions."""
+
+    def test_basic_with_free_passes(self):
+        """basic tier with free preference passes."""
+        envelope = {
+            "job_id": "job_policy_005",
+            "foundup_id": "pqn_portal",
+            "tenant_id": "tenant_eve",
+            "requested_action": "validate_foundup",
+            "compute_tier": "basic",
+            "model_preference": "free",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.model_routing_policy_validated is True
+
+    def test_basic_with_standard_passes(self):
+        """basic tier with standard preference passes."""
+        envelope = {
+            "job_id": "job_policy_006",
+            "foundup_id": "gotjunk",
+            "tenant_id": "tenant_frank",
+            "requested_action": "build_foundup",
+            "compute_tier": "basic",
+            "model_preference": "standard",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.model_routing_policy_validated is True
+        assert "basic" in result.model_routing_policy_reason
+        assert "standard" in result.model_routing_policy_reason
+
+    def test_basic_with_auto_passes(self):
+        """basic tier with auto preference passes."""
+        envelope = {
+            "job_id": "job_policy_007",
+            "foundup_id": "kosei",
+            "tenant_id": "tenant_grace",
+            "requested_action": "extract_foundup",
+            "compute_tier": "basic",
+            "model_preference": "auto",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.model_routing_policy_validated is True
+
+    def test_basic_with_premium_fails(self):
+        """basic tier with premium preference fails."""
+        envelope = {
+            "job_id": "job_policy_008",
+            "foundup_id": "move2japan",
+            "tenant_id": "tenant_hank",
+            "requested_action": "validate_foundup",
+            "compute_tier": "basic",
+            "model_preference": "premium",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.validation_code == EnvelopeValidationCode.MODEL_PREFERENCE_NOT_ALLOWED_FOR_TIER
+        assert "premium" in result.validation_message
+        assert "basic" in result.validation_message
+        assert result.model_routing_policy_validated is False
+
+
+class TestEnterpriseTierModelRouting:
+    """Test enterprise tier allows all model preferences."""
+
+    def test_enterprise_with_free_passes(self):
+        """enterprise tier with free preference passes."""
+        envelope = {
+            "job_id": "job_policy_009",
+            "foundup_id": "social_twin",
+            "tenant_id": "tenant_ivan",
+            "requested_action": "build_foundup",
+            "compute_tier": "enterprise",
+            "model_preference": "free",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.model_routing_policy_validated is True
+
+    def test_enterprise_with_standard_passes(self):
+        """enterprise tier with standard preference passes."""
+        envelope = {
+            "job_id": "job_policy_010",
+            "foundup_id": "pqn_portal",
+            "tenant_id": "tenant_judy",
+            "requested_action": "validate_foundup",
+            "compute_tier": "enterprise",
+            "model_preference": "standard",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.model_routing_policy_validated is True
+
+    def test_enterprise_with_premium_passes(self):
+        """enterprise tier with premium preference passes."""
+        envelope = {
+            "job_id": "job_policy_011",
+            "foundup_id": "gotjunk",
+            "tenant_id": "tenant_kevin",
+            "requested_action": "extract_foundup",
+            "compute_tier": "enterprise",
+            "model_preference": "premium",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.model_routing_policy_validated is True
+        assert "enterprise" in result.model_routing_policy_reason
+        assert "premium" in result.model_routing_policy_reason
+
+    def test_enterprise_with_auto_passes(self):
+        """enterprise tier with auto preference passes."""
+        envelope = {
+            "job_id": "job_policy_012",
+            "foundup_id": "kosei",
+            "tenant_id": "tenant_larry",
+            "requested_action": "build_foundup",
+            "compute_tier": "enterprise",
+            "model_preference": "auto",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.model_routing_policy_validated is True
+
+
+class TestAutoPreferenceAllTiers:
+    """Test auto preference is valid for all tiers."""
+
+    def test_auto_with_freemium_passes(self):
+        """auto preference with freemium tier passes."""
+        envelope = {
+            "job_id": "job_policy_013",
+            "foundup_id": "move2japan",
+            "tenant_id": "tenant_mary",
+            "requested_action": "validate_foundup",
+            "compute_tier": "freemium",
+            "model_preference": "auto",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.model_routing_policy_validated is True
+
+    def test_auto_with_basic_passes(self):
+        """auto preference with basic tier passes."""
+        envelope = {
+            "job_id": "job_policy_014",
+            "foundup_id": "social_twin",
+            "tenant_id": "tenant_nancy",
+            "requested_action": "extract_foundup",
+            "compute_tier": "basic",
+            "model_preference": "auto",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.model_routing_policy_validated is True
+
+    def test_auto_with_enterprise_passes(self):
+        """auto preference with enterprise tier passes."""
+        envelope = {
+            "job_id": "job_policy_015",
+            "foundup_id": "pqn_portal",
+            "tenant_id": "tenant_oscar",
+            "requested_action": "build_foundup",
+            "compute_tier": "enterprise",
+            "model_preference": "auto",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.model_routing_policy_validated is True
+
+
+class TestModelRoutingPolicyWSP97Truth:
+    """Test model routing policy validation does not claim execution."""
+
+    def test_routing_policy_does_not_claim_verification(self):
+        """Policy validation does NOT set verification_complete=True."""
+        envelope = {
+            "job_id": "job_policy_016",
+            "foundup_id": "gotjunk",
+            "tenant_id": "tenant_paul",
+            "requested_action": "validate_foundup",
+            "compute_tier": "enterprise",
+            "model_preference": "premium",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.model_routing_policy_validated is True
+        # WSP 97: Policy validation is structural only
+        assert result.verification_complete is False
+        assert result.cabr_ready is False
+        assert result.payout_ready is False
+
+    def test_routing_policy_fields_in_serialized_result(self):
+        """Model routing policy fields appear in to_dict() output."""
+        envelope = {
+            "job_id": "job_policy_017",
+            "foundup_id": "kosei",
+            "tenant_id": "tenant_quinn",
+            "requested_action": "build_foundup",
+            "compute_tier": "basic",
+            "model_preference": "standard",
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+        result_dict = result.to_dict()
+
+        assert "model_routing_policy_validated" in result_dict
+        assert "model_routing_policy_reason" in result_dict
+        assert result_dict["model_routing_policy_validated"] is True
+        assert "basic" in result_dict["model_routing_policy_reason"]
+
+
+class TestGenericDAERoutingPolicyIgnored:
+    """Test generic DAE envelope ignores routing policy."""
+
+    def test_generic_dae_ignores_routing_policy(self):
+        """Generic DAE envelope does not validate tier/preference compatibility."""
+        envelope = {
+            "objective": "Do something generic",
+            "compute_tier": "freemium",
+            "model_preference": "premium",  # Would fail for FoundUpJob
+        }
+
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.envelope_type == EnvelopeType.GENERIC_DAE
+        assert result.model_routing_policy_validated is False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds model routing tier/preference compatibility validation
- Rules:
  - freemium: auto, free
  - basic: auto, free, standard
  - enterprise: auto, free, standard, premium
- Adds `MODEL_PREFERENCE_NOT_ALLOWED_FOR_TIER` validation code
- Adds validation metadata to EnvelopeValidationResult
- Structural validation only; no provider/model selected

## WSP 97 Truth Boundaries
- No model selected
- No inference executed
- No compute consumed
- verification_complete=False, cabr_ready=False, payout_ready=False
- No CABR/reward/payout/token claims

## Test plan
- [x] 111 model routing validation tests pass
- [x] Full WRE core suite: 517 passed (excluding production_gates)
- [ ] CI verification pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)