### PR TITLE
feat(wre): add checkpoint protocol and evidence collection to Hermes executor

### DIFF
--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -2,6 +2,54 @@
 
 ## Chronological Change Log
 
+### [2026-05-03] - HERMES_EVIDENCE_COLLECTION_PHASE1 (v0.8.18)
+
+**WSP Protocol References**: WSP 11 (Interface), WSP 97 (Truthful)
+**Impact Analysis**: Add evidence file collection for auditable job artifacts
+
+#### Changes Made
+
+- `src/hermes_job_executor.py`:
+  - Added `evidence_path: Optional[str]` to `HermesDelegationResult`
+  - Added `_write_evidence()` method to `HermesJobExecutor`:
+    - Creates `.hermes_evidence/{job_id}/` directory
+    - Writes `metadata.json` with job identity, workspace binding, timing
+    - Writes `checkpoint.json` with checkpoint state and execution details
+    - Returns evidence path or None on error (silent failure)
+  - Integrated evidence collection into `execute()` for all valid job paths
+  - Evidence NOT written for validation failures (no valid job to document)
+  - Added `json` to top-level imports
+
+- `tests/test_hermes_job_executor.py`:
+  - 10 new tests (94 total) for evidence collection
+  - TestEvidenceCollection: directory creation, metadata/checkpoint JSON
+  - TestEvidencePathField: default value, to_dict serialization
+
+#### Evidence Directory Structure
+
+```
+.hermes_evidence/{job_id}/
+├── metadata.json    # Job identity, workspace binding, timing
+└── checkpoint.json  # Checkpoint state, files_changed, commands_run
+```
+
+#### WSP 97 Truth Boundaries
+
+- Evidence files are observability artifacts ONLY
+- They prove job was processed through WRE, not that real work occurred
+- `real_execution_performed` = False (always in Phase 1)
+- `verification_complete` = False (evidence is NOT verification)
+- Evidence enables future CABR verification to have artifacts to score
+
+#### Verification
+
+```bash
+python -m pytest modules/infrastructure/wre_core/tests/test_hermes_job_executor.py -v
+# 94 passed
+```
+
+---
+
 ### [2026-05-03] - HERMES_CHECKPOINT_PROTOCOL_PHASE1 (v0.8.17)
 
 **WSP Protocol References**: WSP 11 (Interface), WSP 97 (Truthful)

--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -2,6 +2,47 @@
 
 ## Chronological Change Log
 
+### [2026-05-03] - HERMES_CHECKPOINT_PROTOCOL_PHASE1 (v0.8.17)
+
+**WSP Protocol References**: WSP 11 (Interface), WSP 97 (Truthful)
+**Impact Analysis**: Add checkpoint protocol fields for structured Hermes swarm evidence
+
+#### Changes Made
+
+- `src/hermes_job_executor.py`:
+  - Added checkpoint protocol fields to `HermesDelegationResult`:
+    - `checkpoint_state`: DONE|BLOCKED|NEEDS_INPUT|HANDOFF|SIMULATED (default: SIMULATED)
+    - `checkpoint_result`: Summary of work completed (Optional[str])
+    - `checkpoint_blocker`: Description of blocker if BLOCKED (Optional[str])
+    - `checkpoint_next_action`: Suggested next step (Optional[str])
+    - `files_changed`: List of files modified (List[str])
+    - `commands_run`: List of commands executed (List[str])
+  - Updated `to_dict()` to serialize all checkpoint fields
+
+- `tests/test_hermes_job_executor.py`:
+  - 20 new tests (84 total) for checkpoint protocol
+  - TestCheckpointProtocolFields: default values
+  - TestCheckpointInResult: to_dict serialization
+  - TestCheckpointStateSimulated: dry_run behavior
+  - TestCheckpointWSP97: truth field isolation
+
+#### WSP 97 Truth Boundaries
+
+- `checkpoint_state` = "SIMULATED" when dry_run=True or flag disabled
+- `real_execution_performed` = False (always in Phase 1)
+- `verification_complete` = False (checkpoint fields do NOT imply verification)
+- `cabr_ready` = False
+- `payout_ready` = False
+
+#### Verification
+
+```bash
+python -m pytest modules/infrastructure/wre_core/tests/test_hermes_job_executor.py -v
+# 84 passed
+```
+
+---
+
 ### [2026-05-02] - HERMES_WORKSPACE_BINDING_CONTRACT_PHASE1 (v0.8.16)
 
 **WSP Protocol References**: WSP 11 (Interface), WSP 50 (Pre-Action), WSP 97 (Truthful)

--- a/modules/infrastructure/wre_core/src/hermes_job_executor.py
+++ b/modules/infrastructure/wre_core/src/hermes_job_executor.py
@@ -30,6 +30,7 @@ Slice: HERMES_JOB_EXECUTOR_ADAPTER_PHASE1
 from __future__ import annotations
 
 import fnmatch
+import json
 import logging
 import os
 from dataclasses import dataclass, field
@@ -367,6 +368,9 @@ class HermesDelegationResult:
         files_changed: List of files modified during execution
         commands_run: List of commands executed
 
+        Evidence Collection Fields:
+        evidence_path: Path to evidence directory (.hermes_evidence/{job_id}/)
+
         WSP 97 Truth Fields:
         real_execution_performed: True ONLY if delegate_task was called
         verification_complete: Always False (no CABR verification yet)
@@ -396,6 +400,9 @@ class HermesDelegationResult:
     files_changed: List[str] = field(default_factory=list)
     commands_run: List[str] = field(default_factory=list)
 
+    # Evidence Collection Fields
+    evidence_path: Optional[str] = None
+
     # WSP 97 Truth Fields - NEVER set to True in this adapter
     real_execution_performed: bool = False
     verification_complete: bool = False
@@ -422,6 +429,8 @@ class HermesDelegationResult:
             "checkpoint_next_action": self.checkpoint_next_action,
             "files_changed": self.files_changed,
             "commands_run": self.commands_run,
+            # Evidence Collection Fields
+            "evidence_path": self.evidence_path,
             # WSP 97 Truth Fields
             "real_execution_performed": self.real_execution_performed,
             "verification_complete": self.verification_complete,
@@ -700,7 +709,7 @@ class HermesJobExecutor:
                 "[HERMES-EXEC] Feature disabled, simulating job %s",
                 job.job_id,
             )
-            return HermesDelegationResult(
+            result = HermesDelegationResult(
                 status=HermesExecutionStatus.SIMULATED,
                 status_reason=(
                     f"Hermes delegation disabled ({_HERMES_DELEGATE_ENABLED_KEY}=0). "
@@ -713,6 +722,8 @@ class HermesJobExecutor:
                 cabr_ready=False,
                 payout_ready=False,
             )
+            result.evidence_path = self._write_evidence(job, request, result)
+            return result
 
         # Step 4: Feature enabled - check dry_run
         if self.dry_run:
@@ -720,7 +731,7 @@ class HermesJobExecutor:
                 "[HERMES-EXEC] dry_run=True, simulating job %s",
                 job.job_id,
             )
-            return HermesDelegationResult(
+            result = HermesDelegationResult(
                 status=HermesExecutionStatus.SIMULATED,
                 status_reason=(
                     f"dry_run=True, job {job.job_id} simulated. "
@@ -733,10 +744,12 @@ class HermesJobExecutor:
                 cabr_ready=False,
                 payout_ready=False,
             )
+            result.evidence_path = self._write_evidence(job, request, result)
+            return result
 
         # Step 5: Check import availability
         if not self._lazy_import_delegate_task():
-            return HermesDelegationResult(
+            result = HermesDelegationResult(
                 status=HermesExecutionStatus.BLOCKED_IMPORT_UNAVAILABLE,
                 status_reason=(
                     f"Cannot import Hermes delegate_task: {self._import_error}. "
@@ -746,13 +759,15 @@ class HermesJobExecutor:
                 duration_seconds=time.monotonic() - start_time,
                 real_execution_performed=False,
             )
+            result.evidence_path = self._write_evidence(job, request, result)
+            return result
 
         # Step 6: Real execution blocked in Phase 1
         logger.warning(
             "[HERMES-EXEC] Real delegation NOT IMPLEMENTED, blocking job %s",
             job.job_id,
         )
-        return HermesDelegationResult(
+        result = HermesDelegationResult(
             status=HermesExecutionStatus.BLOCKED_REAL_DELEGATION_NOT_IMPLEMENTED,
             status_reason=(
                 f"Real Hermes delegation not implemented in Phase 1. "
@@ -765,6 +780,8 @@ class HermesJobExecutor:
             cabr_ready=False,
             payout_ready=False,
         )
+        result.evidence_path = self._write_evidence(job, request, result)
+        return result
 
     def _validate_job(self, job: "FoundUpJob") -> Optional[str]:
         """
@@ -786,6 +803,87 @@ class HermesJobExecutor:
             return "Job missing requested_action"
 
         return None
+
+    def _write_evidence(
+        self,
+        job: "FoundUpJob",
+        request: HermesDelegationRequest,
+        result: HermesDelegationResult,
+    ) -> Optional[str]:
+        """
+        Write evidence files for job execution.
+
+        Creates .hermes_evidence/{job_id}/ directory with:
+          - metadata.json: Job identity, workspace binding, timing
+          - checkpoint.json: Checkpoint state and execution details
+
+        Evidence files are observability artifacts only (WSP 97).
+        They prove the job was processed, not that real work occurred.
+
+        Args:
+            job: Source FoundUpJob
+            request: HermesDelegationRequest that was built
+            result: HermesDelegationResult with execution outcome
+
+        Returns:
+            Absolute path to evidence directory, or None on error
+        """
+        try:
+            # Get evidence output path from workspace binding
+            evidence_dir = request.workspace_binding.evidence_output_path
+
+            # Create evidence directory
+            os.makedirs(evidence_dir, exist_ok=True)
+
+            # Build metadata.json contents
+            metadata = {
+                "job_id": job.job_id,
+                "foundup_id": job.foundup_id,
+                "tenant_id": job.tenant_id,
+                "requested_action": job.requested_action,
+                "intent_id": job.intent_id,
+                "workspace_binding": request.workspace_binding.to_dict(),
+                "started_at": request.created_at.isoformat(),
+                "completed_at": result.completed_at.isoformat(),
+                "dry_run": request.dry_run,
+                "execution_status": result.status.value,
+            }
+
+            # Write metadata.json
+            metadata_path = os.path.join(evidence_dir, "metadata.json")
+            with open(metadata_path, "w", encoding="utf-8") as f:
+                json.dump(metadata, f, indent=2, default=str)
+
+            # Build checkpoint.json contents
+            checkpoint = {
+                "state": result.checkpoint_state,
+                "result": result.checkpoint_result,
+                "blocker": result.checkpoint_blocker,
+                "next_action": result.checkpoint_next_action,
+                "files_changed": result.files_changed,
+                "commands_run": result.commands_run,
+                "exit_reason": result.status_reason,
+            }
+
+            # Write checkpoint.json
+            checkpoint_path = os.path.join(evidence_dir, "checkpoint.json")
+            with open(checkpoint_path, "w", encoding="utf-8") as f:
+                json.dump(checkpoint, f, indent=2, default=str)
+
+            logger.info(
+                "[HERMES-EXEC] Evidence written to %s",
+                evidence_dir,
+            )
+            return evidence_dir
+
+        except Exception as exc:
+            # Evidence failure must not fail job (WSP 97 observability)
+            logger.warning(
+                "[HERMES-EXEC] Failed to write evidence for job %s: %s",
+                job.job_id,
+                exc,
+            )
+            return None
 
 
 # ---------------------------------------------------------------------------

--- a/modules/infrastructure/wre_core/src/hermes_job_executor.py
+++ b/modules/infrastructure/wre_core/src/hermes_job_executor.py
@@ -359,6 +359,14 @@ class HermesDelegationResult:
         duration_seconds: Wall clock time
         api_calls: Number of Hermes API calls (0 if simulated)
 
+        Checkpoint Protocol Fields (Hermes swarm format):
+        checkpoint_state: DONE|BLOCKED|NEEDS_INPUT|HANDOFF|SIMULATED
+        checkpoint_result: Summary of work completed (if any)
+        checkpoint_blocker: Description of blocker (if BLOCKED)
+        checkpoint_next_action: Suggested next step
+        files_changed: List of files modified during execution
+        commands_run: List of commands executed
+
         WSP 97 Truth Fields:
         real_execution_performed: True ONLY if delegate_task was called
         verification_complete: Always False (no CABR verification yet)
@@ -380,6 +388,14 @@ class HermesDelegationResult:
     duration_seconds: float = 0.0
     api_calls: int = 0
 
+    # Checkpoint Protocol Fields (Hermes swarm format)
+    checkpoint_state: str = "SIMULATED"
+    checkpoint_result: Optional[str] = None
+    checkpoint_blocker: Optional[str] = None
+    checkpoint_next_action: Optional[str] = None
+    files_changed: List[str] = field(default_factory=list)
+    commands_run: List[str] = field(default_factory=list)
+
     # WSP 97 Truth Fields - NEVER set to True in this adapter
     real_execution_performed: bool = False
     verification_complete: bool = False
@@ -399,6 +415,14 @@ class HermesDelegationResult:
             "delegate_response": self.delegate_response,
             "duration_seconds": self.duration_seconds,
             "api_calls": self.api_calls,
+            # Checkpoint Protocol Fields
+            "checkpoint_state": self.checkpoint_state,
+            "checkpoint_result": self.checkpoint_result,
+            "checkpoint_blocker": self.checkpoint_blocker,
+            "checkpoint_next_action": self.checkpoint_next_action,
+            "files_changed": self.files_changed,
+            "commands_run": self.commands_run,
+            # WSP 97 Truth Fields
             "real_execution_performed": self.real_execution_performed,
             "verification_complete": self.verification_complete,
             "cabr_ready": self.cabr_ready,

--- a/modules/infrastructure/wre_core/tests/TestModLog.md
+++ b/modules/infrastructure/wre_core/tests/TestModLog.md
@@ -1,5 +1,23 @@
 # TestModLog - wre_core/tests
 
+## 2026-05-03: Hermes checkpoint protocol tests
+
+- Command: `python -m pytest modules/infrastructure/wre_core/tests/test_hermes_job_executor.py -v`
+- Status: PASS
+- Result: `84 passed`
+- Notes:
+  - Added `TestCheckpointProtocolFields` (6 tests) - checkpoint field defaults
+  - Added `TestCheckpointInResult` (6 tests) - to_dict checkpoint serialization
+  - Added `TestCheckpointStateSimulated` (4 tests) - dry_run checkpoint behavior
+  - Added `TestCheckpointWSP97` (4 tests) - truth field isolation with checkpoint
+- WSP 97 Coverage:
+  - checkpoint_state="SIMULATED" when dry_run or flag disabled
+  - checkpoint fields do NOT imply real_execution_performed
+  - checkpoint fields do NOT imply verification_complete
+  - Checkpoint protocol is structural, not proof of execution
+
+---
+
 ## 2026-05-02: Hermes workspace binding contract tests
 
 - Command: `python -m pytest modules/infrastructure/wre_core/tests/test_hermes_job_executor.py -v`

--- a/modules/infrastructure/wre_core/tests/test_hermes_job_executor.py
+++ b/modules/infrastructure/wre_core/tests/test_hermes_job_executor.py
@@ -1091,5 +1091,198 @@ class TestCheckpointWSP97(unittest.TestCase):
         self.assertFalse(result.payout_ready)
 
 
+# ---------------------------------------------------------------------------
+# Evidence Collection Tests (HERMES_EVIDENCE_COLLECTION_PHASE1)
+# ---------------------------------------------------------------------------
+
+
+class TestEvidenceCollection(unittest.TestCase):
+    """Test evidence file collection."""
+
+    def setUp(self):
+        """Create temp directory for evidence tests."""
+        import tempfile
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        """Clean up temp directory."""
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_evidence_directory_created(self):
+        """Evidence directory is created during execution."""
+        with patch.dict(os.environ, {"HERMES_DELEGATE_ENABLED": "0"}):
+            executor = HermesJobExecutor(workspace_root=self.temp_dir)
+            job = create_job(tenant_id="t1", requested_action="build_foundup")
+            result = executor.execute(job)
+
+            # Evidence directory should exist
+            expected_dir = os.path.join(self.temp_dir, ".hermes_evidence", job.job_id)
+            self.assertTrue(os.path.isdir(expected_dir))
+
+    def test_evidence_metadata_json_written(self):
+        """metadata.json is written to evidence directory."""
+        import json
+
+        with patch.dict(os.environ, {"HERMES_DELEGATE_ENABLED": "0"}):
+            executor = HermesJobExecutor(workspace_root=self.temp_dir)
+            job = create_job(tenant_id="t1", requested_action="build_foundup")
+            result = executor.execute(job)
+
+            metadata_path = os.path.join(
+                self.temp_dir, ".hermes_evidence", job.job_id, "metadata.json"
+            )
+            self.assertTrue(os.path.isfile(metadata_path))
+
+            with open(metadata_path, "r") as f:
+                metadata = json.load(f)
+
+            self.assertIsInstance(metadata, dict)
+
+    def test_evidence_metadata_contains_job_fields(self):
+        """metadata.json contains required job fields."""
+        import json
+
+        with patch.dict(os.environ, {"HERMES_DELEGATE_ENABLED": "0"}):
+            executor = HermesJobExecutor(workspace_root=self.temp_dir)
+            job = create_job(
+                tenant_id="tenant_abc",
+                requested_action="validate_foundup",
+                foundup_id="gotjunk",
+                intent_id="intent_xyz",
+            )
+            result = executor.execute(job)
+
+            metadata_path = os.path.join(
+                self.temp_dir, ".hermes_evidence", job.job_id, "metadata.json"
+            )
+            with open(metadata_path, "r") as f:
+                metadata = json.load(f)
+
+            self.assertEqual(metadata["job_id"], job.job_id)
+            self.assertEqual(metadata["foundup_id"], "gotjunk")
+            self.assertEqual(metadata["tenant_id"], "tenant_abc")
+            self.assertEqual(metadata["requested_action"], "validate_foundup")
+            self.assertEqual(metadata["intent_id"], "intent_xyz")
+            self.assertIn("workspace_binding", metadata)
+            self.assertIn("started_at", metadata)
+            self.assertIn("completed_at", metadata)
+            self.assertIn("dry_run", metadata)
+            self.assertEqual(metadata["execution_status"], "SIMULATED")
+
+    def test_evidence_checkpoint_json_written(self):
+        """checkpoint.json is written to evidence directory."""
+        import json
+
+        with patch.dict(os.environ, {"HERMES_DELEGATE_ENABLED": "0"}):
+            executor = HermesJobExecutor(workspace_root=self.temp_dir)
+            job = create_job(tenant_id="t1", requested_action="build_foundup")
+            result = executor.execute(job)
+
+            checkpoint_path = os.path.join(
+                self.temp_dir, ".hermes_evidence", job.job_id, "checkpoint.json"
+            )
+            self.assertTrue(os.path.isfile(checkpoint_path))
+
+            with open(checkpoint_path, "r") as f:
+                checkpoint = json.load(f)
+
+            self.assertIsInstance(checkpoint, dict)
+
+    def test_evidence_checkpoint_contains_state(self):
+        """checkpoint.json contains checkpoint state fields."""
+        import json
+
+        with patch.dict(os.environ, {"HERMES_DELEGATE_ENABLED": "0"}):
+            executor = HermesJobExecutor(workspace_root=self.temp_dir)
+            job = create_job(tenant_id="t1", requested_action="build_foundup")
+            result = executor.execute(job)
+
+            checkpoint_path = os.path.join(
+                self.temp_dir, ".hermes_evidence", job.job_id, "checkpoint.json"
+            )
+            with open(checkpoint_path, "r") as f:
+                checkpoint = json.load(f)
+
+            self.assertEqual(checkpoint["state"], "SIMULATED")
+            self.assertIn("result", checkpoint)
+            self.assertIn("blocker", checkpoint)
+            self.assertIn("next_action", checkpoint)
+            self.assertIn("files_changed", checkpoint)
+            self.assertIn("commands_run", checkpoint)
+            self.assertIn("exit_reason", checkpoint)
+
+    def test_evidence_path_in_result(self):
+        """evidence_path is set in result."""
+        with patch.dict(os.environ, {"HERMES_DELEGATE_ENABLED": "0"}):
+            executor = HermesJobExecutor(workspace_root=self.temp_dir)
+            job = create_job(tenant_id="t1", requested_action="build_foundup")
+            result = executor.execute(job)
+
+            self.assertIsNotNone(result.evidence_path)
+            expected_path = os.path.join(self.temp_dir, ".hermes_evidence", job.job_id)
+            self.assertEqual(result.evidence_path, expected_path)
+
+    def test_evidence_write_failure_does_not_fail_job(self):
+        """Evidence write failure does not fail job execution."""
+        with patch.dict(os.environ, {"HERMES_DELEGATE_ENABLED": "0"}):
+            executor = HermesJobExecutor(workspace_root=self.temp_dir)
+            job = create_job(tenant_id="t1", requested_action="build_foundup")
+
+            # Mock os.makedirs to raise an exception
+            with patch("os.makedirs", side_effect=PermissionError("Access denied")):
+                # Should not raise - evidence failure is silent
+                result = executor.execute(job)
+
+            # Job still completes
+            self.assertEqual(result.status, HermesExecutionStatus.SIMULATED)
+            # But evidence_path is None (write failed)
+            self.assertIsNone(result.evidence_path)
+
+    def test_evidence_not_written_when_validation_fails(self):
+        """Evidence is NOT written when job validation fails."""
+        with patch.dict(os.environ, {"HERMES_DELEGATE_ENABLED": "0"}):
+            executor = HermesJobExecutor(workspace_root=self.temp_dir)
+
+            # Create invalid job (missing job_id)
+            job = create_job(tenant_id="t1", requested_action="build_foundup")
+            job.job_id = ""
+
+            result = executor.execute(job)
+
+            # Result is blocked
+            self.assertEqual(result.status, HermesExecutionStatus.BLOCKED_INVALID_JOB)
+
+            # No evidence directory created (no valid job_id to use)
+            evidence_base = os.path.join(self.temp_dir, ".hermes_evidence")
+            if os.path.exists(evidence_base):
+                # Should be empty or not exist
+                self.assertEqual(os.listdir(evidence_base), [])
+
+
+class TestEvidencePathField(unittest.TestCase):
+    """Test evidence_path field in HermesDelegationResult."""
+
+    def test_evidence_path_default_none(self):
+        """evidence_path defaults to None."""
+        result = HermesDelegationResult(
+            status=HermesExecutionStatus.SIMULATED,
+            status_reason="Test",
+        )
+        self.assertIsNone(result.evidence_path)
+
+    def test_to_dict_includes_evidence_path(self):
+        """to_dict includes evidence_path."""
+        result = HermesDelegationResult(
+            status=HermesExecutionStatus.SIMULATED,
+            status_reason="Test",
+            evidence_path="/path/to/.hermes_evidence/j_123",
+        )
+        d = result.to_dict()
+
+        self.assertIn("evidence_path", d)
+        self.assertEqual(d["evidence_path"], "/path/to/.hermes_evidence/j_123")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/modules/infrastructure/wre_core/tests/test_hermes_job_executor.py
+++ b/modules/infrastructure/wre_core/tests/test_hermes_job_executor.py
@@ -875,5 +875,221 @@ class TestNoRealExecutionWithWorkspaceBinding(unittest.TestCase):
         self.assertEqual(d["workspace_binding"]["workspace_root"], "/test/repo")
 
 
+# ---------------------------------------------------------------------------
+# Checkpoint Protocol Tests (HERMES_CHECKPOINT_PROTOCOL_PHASE1)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckpointProtocolFields(unittest.TestCase):
+    """Test checkpoint protocol fields exist with defaults."""
+
+    def test_checkpoint_state_default_simulated(self):
+        """checkpoint_state defaults to SIMULATED."""
+        result = HermesDelegationResult(
+            status=HermesExecutionStatus.SIMULATED,
+            status_reason="Test",
+        )
+        self.assertEqual(result.checkpoint_state, "SIMULATED")
+
+    def test_checkpoint_result_default_none(self):
+        """checkpoint_result defaults to None."""
+        result = HermesDelegationResult(
+            status=HermesExecutionStatus.SIMULATED,
+            status_reason="Test",
+        )
+        self.assertIsNone(result.checkpoint_result)
+
+    def test_checkpoint_blocker_default_none(self):
+        """checkpoint_blocker defaults to None."""
+        result = HermesDelegationResult(
+            status=HermesExecutionStatus.SIMULATED,
+            status_reason="Test",
+        )
+        self.assertIsNone(result.checkpoint_blocker)
+
+    def test_checkpoint_next_action_default_none(self):
+        """checkpoint_next_action defaults to None."""
+        result = HermesDelegationResult(
+            status=HermesExecutionStatus.SIMULATED,
+            status_reason="Test",
+        )
+        self.assertIsNone(result.checkpoint_next_action)
+
+    def test_files_changed_default_empty_list(self):
+        """files_changed defaults to empty list."""
+        result = HermesDelegationResult(
+            status=HermesExecutionStatus.SIMULATED,
+            status_reason="Test",
+        )
+        self.assertEqual(result.files_changed, [])
+
+    def test_commands_run_default_empty_list(self):
+        """commands_run defaults to empty list."""
+        result = HermesDelegationResult(
+            status=HermesExecutionStatus.SIMULATED,
+            status_reason="Test",
+        )
+        self.assertEqual(result.commands_run, [])
+
+
+class TestCheckpointInResult(unittest.TestCase):
+    """Test to_dict() includes all checkpoint fields."""
+
+    def test_to_dict_includes_checkpoint_state(self):
+        """to_dict includes checkpoint_state."""
+        result = HermesDelegationResult(
+            status=HermesExecutionStatus.SIMULATED,
+            status_reason="Test",
+        )
+        d = result.to_dict()
+        self.assertIn("checkpoint_state", d)
+        self.assertEqual(d["checkpoint_state"], "SIMULATED")
+
+    def test_to_dict_includes_checkpoint_result(self):
+        """to_dict includes checkpoint_result."""
+        result = HermesDelegationResult(
+            status=HermesExecutionStatus.SIMULATED,
+            status_reason="Test",
+            checkpoint_result="Work completed successfully",
+        )
+        d = result.to_dict()
+        self.assertIn("checkpoint_result", d)
+        self.assertEqual(d["checkpoint_result"], "Work completed successfully")
+
+    def test_to_dict_includes_checkpoint_blocker(self):
+        """to_dict includes checkpoint_blocker."""
+        result = HermesDelegationResult(
+            status=HermesExecutionStatus.BLOCKED_FEATURE_DISABLED,
+            status_reason="Test",
+            checkpoint_state="BLOCKED",
+            checkpoint_blocker="Feature flag disabled",
+        )
+        d = result.to_dict()
+        self.assertIn("checkpoint_blocker", d)
+        self.assertEqual(d["checkpoint_blocker"], "Feature flag disabled")
+
+    def test_to_dict_includes_checkpoint_next_action(self):
+        """to_dict includes checkpoint_next_action."""
+        result = HermesDelegationResult(
+            status=HermesExecutionStatus.SIMULATED,
+            status_reason="Test",
+            checkpoint_next_action="Enable HERMES_DELEGATE_ENABLED=1",
+        )
+        d = result.to_dict()
+        self.assertIn("checkpoint_next_action", d)
+        self.assertEqual(d["checkpoint_next_action"], "Enable HERMES_DELEGATE_ENABLED=1")
+
+    def test_to_dict_includes_files_changed(self):
+        """to_dict includes files_changed."""
+        result = HermesDelegationResult(
+            status=HermesExecutionStatus.SIMULATED,
+            status_reason="Test",
+            files_changed=["src/main.py", "tests/test_main.py"],
+        )
+        d = result.to_dict()
+        self.assertIn("files_changed", d)
+        self.assertEqual(d["files_changed"], ["src/main.py", "tests/test_main.py"])
+
+    def test_to_dict_includes_commands_run(self):
+        """to_dict includes commands_run."""
+        result = HermesDelegationResult(
+            status=HermesExecutionStatus.SIMULATED,
+            status_reason="Test",
+            commands_run=["git status", "pytest -v"],
+        )
+        d = result.to_dict()
+        self.assertIn("commands_run", d)
+        self.assertEqual(d["commands_run"], ["git status", "pytest -v"])
+
+
+class TestCheckpointStateSimulated(unittest.TestCase):
+    """Test dry_run=True yields SIMULATED checkpoint state."""
+
+    def test_dry_run_true_checkpoint_simulated(self):
+        """dry_run=True produces checkpoint_state=SIMULATED."""
+        with patch.dict(os.environ, {"HERMES_DELEGATE_ENABLED": "0"}):
+            executor = HermesJobExecutor(dry_run=True)
+            job = create_job(tenant_id="t1", requested_action="build_foundup")
+            result = executor.execute(job)
+
+            self.assertEqual(result.checkpoint_state, "SIMULATED")
+
+    def test_feature_disabled_checkpoint_simulated(self):
+        """Feature disabled produces checkpoint_state=SIMULATED."""
+        with patch.dict(os.environ, {"HERMES_DELEGATE_ENABLED": "0"}):
+            executor = HermesJobExecutor()
+            job = create_job(tenant_id="t1", requested_action="build_foundup")
+            result = executor.execute(job)
+
+            self.assertEqual(result.checkpoint_state, "SIMULATED")
+
+    def test_checkpoint_files_changed_empty_in_simulation(self):
+        """files_changed is empty in simulation mode."""
+        with patch.dict(os.environ, {"HERMES_DELEGATE_ENABLED": "0"}):
+            executor = HermesJobExecutor()
+            job = create_job(tenant_id="t1", requested_action="build_foundup")
+            result = executor.execute(job)
+
+            self.assertEqual(result.files_changed, [])
+
+    def test_checkpoint_commands_run_empty_in_simulation(self):
+        """commands_run is empty in simulation mode."""
+        with patch.dict(os.environ, {"HERMES_DELEGATE_ENABLED": "0"}):
+            executor = HermesJobExecutor()
+            job = create_job(tenant_id="t1", requested_action="build_foundup")
+            result = executor.execute(job)
+
+            self.assertEqual(result.commands_run, [])
+
+
+class TestCheckpointWSP97(unittest.TestCase):
+    """Test WSP 97 truth fields remain false with checkpoint fields."""
+
+    def test_checkpoint_does_not_enable_real_execution(self):
+        """Checkpoint fields do not imply real_execution_performed=True."""
+        result = HermesDelegationResult(
+            status=HermesExecutionStatus.SIMULATED,
+            status_reason="Test",
+            checkpoint_state="DONE",  # Even if DONE...
+            checkpoint_result="Work completed",
+            files_changed=["file.py"],
+            commands_run=["pytest"],
+        )
+
+        # ...real_execution_performed still False
+        self.assertFalse(result.real_execution_performed)
+
+    def test_checkpoint_does_not_enable_verification(self):
+        """Checkpoint fields do not imply verification_complete=True."""
+        result = HermesDelegationResult(
+            status=HermesExecutionStatus.SIMULATED,
+            status_reason="Test",
+            checkpoint_state="DONE",
+            checkpoint_result="All tests passed",
+        )
+
+        self.assertFalse(result.verification_complete)
+
+    def test_checkpoint_does_not_enable_cabr(self):
+        """Checkpoint fields do not imply cabr_ready=True."""
+        result = HermesDelegationResult(
+            status=HermesExecutionStatus.SIMULATED,
+            status_reason="Test",
+            checkpoint_state="DONE",
+        )
+
+        self.assertFalse(result.cabr_ready)
+
+    def test_checkpoint_does_not_enable_payout(self):
+        """Checkpoint fields do not imply payout_ready=True."""
+        result = HermesDelegationResult(
+            status=HermesExecutionStatus.SIMULATED,
+            status_reason="Test",
+            checkpoint_state="DONE",
+        )
+
+        self.assertFalse(result.payout_ready)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Adds checkpoint protocol fields and evidence file collection to HermesDelegationResult.

### Checkpoint Protocol (v0.8.17)
- `checkpoint_state`: DONE|BLOCKED|NEEDS_INPUT|HANDOFF|SIMULATED (default: SIMULATED)
- `checkpoint_result`: Summary of work completed
- `checkpoint_blocker`: Description of blocker (if BLOCKED)
- `checkpoint_next_action`: Suggested next step
- `files_changed`: List of files modified
- `commands_run`: List of commands executed

### Evidence Collection (v0.8.18)
- Creates `.hermes_evidence/{job_id}/` directory
- Writes `metadata.json` with job identity, workspace binding, timing
- Writes `checkpoint.json` with checkpoint state and execution details
- `evidence_path` field in HermesDelegationResult

## WSP 97 Truth Boundaries
- `checkpoint_state` = "SIMULATED" when dry_run=True or flag disabled
- `real_execution_performed` = False (always in Phase 1)
- `verification_complete` = False (checkpoint/evidence NOT verification)
- Evidence proves job processed through WRE, not that real work occurred

## Test plan
- [x] 94 Hermes executor tests pass
- [x] 611 WRE core tests pass (excluding production_gates)
- [ ] CI verification pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)