### PR TITLE
fix(holoindex): render docs and knowledge hits in CLI search summary

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,49 @@
 # HoloIndex Package ModLog
 
+## [2026-05-03] HOLOINDEX_CLI_DOCS_DISPLAY_FIX_PHASE1 — CLI Docs/Knowledge Display
+
+**Agent**: 0102 W1
+**WSP References**: WSP 22 (ModLog), WSP 50 (Pre-Action), WSP 97 (Truth)
+**Status**: COMPLETE
+
+### Summary
+
+Fixed HoloIndex CLI output to display [DOCS] and [KNOWLEDGE] search hits alongside [CODE] and [WSP].
+
+### Root Cause
+
+Three separate rendering paths needed updating:
+1. `_render_fast_search_summary()` in `_cli_main.py` - fast search mode
+2. `display_results()` and `render_prioritized_output()` in `agentic_output_throttler.py` - throttled mode
+3. `orchestrate_holoindex_request()` in `qwen_orchestrator.py` - QwenOrchestrator mode
+
+### Changes
+
+| File | Change |
+|------|--------|
+| `_cli_main.py` | Added docs_hits/knowledge_hits rendering in `_render_fast_search_summary()` |
+| `output/agentic_output_throttler.py` | Added docs/knowledge counts in summary, display sections in `display_results()` |
+| `qwen_advisor/orchestration/qwen_orchestrator.py` | Added [DOCS] and [KNOWLEDGE] to search results output |
+| `tests/test_cli_docs_display.py` | 7 tests for docs/knowledge rendering |
+
+### Verification
+
+```bash
+python holo_index.py --search "WRE Gateway Adapter" --ssd E:/HoloIndex
+# Output now shows:
+#   [DOCS] docs/architecture/WRE_GATEWAY_ADAPTER_DESIGN.md
+#   [KNOWLEDGE] WSP_knowledge/docs/Papers/...
+```
+
+### WSP 97 Compliance
+
+- No indexing behavior changed
+- No search ranking changed
+- No TurboQuant defaults changed
+- Display-only fix
+
+---
+
 ## [2026-05-03] HOLOINDEX_INDEX_REFRESH_REPAIR_PHASE1 — Docs Index Repair
 
 **Agent**: 0102

--- a/holo_index/_cli_main.py
+++ b/holo_index/_cli_main.py
@@ -258,9 +258,11 @@ def _render_fast_search_summary(results: Dict[str, Any], limit: int = 5) -> None
     """Compact fast-mode output compatible with existing CLI usage."""
     code_hits = results.get("code", []) or []
     wsp_hits = results.get("wsps", []) or []
-    total_hits = len(code_hits) + len(wsp_hits)
+    docs_hits = results.get("docs", []) or []
+    knowledge_hits = results.get("knowledge", []) or []
+    total_hits = len(code_hits) + len(wsp_hits) + len(docs_hits) + len(knowledge_hits)
 
-    safe_print(f"[OK] Analysis complete: {total_hits} hits (code={len(code_hits)}, wsp={len(wsp_hits)}), no critical issues found")
+    safe_print(f"[OK] Analysis complete: {total_hits} hits (code={len(code_hits)}, wsp={len(wsp_hits)}, docs={len(docs_hits)}, knowledge={len(knowledge_hits)}), no critical issues found")
     safe_print("[RESULTS] Top matches")
 
     shown = 0
@@ -275,6 +277,20 @@ def _render_fast_search_summary(results: Dict[str, Any], limit: int = 5) -> None
         title = hit.get("title") or "unknown"
         path = hit.get("path") or "unknown"
         safe_print(f"  [WSP] {path if path != 'unknown' else title}")
+        shown += 1
+        if shown >= limit:
+            return
+
+    for hit in docs_hits:
+        path = hit.get("path") or hit.get("title") or "unknown"
+        safe_print(f"  [DOCS] {path}")
+        shown += 1
+        if shown >= limit:
+            return
+
+    for hit in knowledge_hits:
+        path = hit.get("path") or hit.get("title") or "unknown"
+        safe_print(f"  [KNOWLEDGE] {path}")
         shown += 1
         if shown >= limit:
             return

--- a/holo_index/output/agentic_output_throttler.py
+++ b/holo_index/output/agentic_output_throttler.py
@@ -855,6 +855,8 @@ class AgenticOutputThrottler:
         """Display search results using the throttler's prioritized output system."""
         code_hits = result.get('code', [])
         wsp_hits = result.get('wsps', [])
+        docs_hits = result.get('docs', [])
+        knowledge_hits = result.get('knowledge', [])
         warnings = result.get('warnings', [])
         reminders = result.get('reminders', [])
 
@@ -904,6 +906,28 @@ class AgenticOutputThrottler:
                 self.add_section('guidance', "[WSP] No module-specific WSP guidance found", priority=4, tags=['wsp', 'empty'])
         else:
             self.add_section('guidance', "[WSP] No relevant WSP protocols found", priority=4, tags=['wsp', 'empty'])
+
+        # Docs results - module/root documentation
+        if docs_hits:
+            docs_content = "[DOCS] Documentation:"
+            for idx, hit in enumerate(docs_hits[:5], start=1):
+                path = hit.get('path', 'unknown')
+                title = hit.get('title', '')
+                docs_content += f"\n  {idx}. {path}"
+                if title:
+                    docs_content += f" - {title}"
+            self.add_section('docs', docs_content, priority=2, tags=['docs', 'documentation'])
+
+        # Knowledge results - papers/research
+        if knowledge_hits:
+            knowledge_content = "[KNOWLEDGE] Research/Papers:"
+            for idx, hit in enumerate(knowledge_hits[:3], start=1):
+                path = hit.get('path', 'unknown')
+                title = hit.get('title', '')
+                knowledge_content += f"\n  {idx}. {path}"
+                if title:
+                    knowledge_content += f" - {title}"
+            self.add_section('knowledge', knowledge_content, priority=3, tags=['knowledge', 'research'])
 
         # Warnings - critical priority
         if warnings:
@@ -1123,10 +1147,12 @@ class AgenticOutputThrottler:
             if hasattr(self, "_search_results") and self._search_results:
                 code_count = len(self._search_results.get('code', []) or [])
                 wsp_count = len(self._search_results.get('wsps', []) or [])
-                total_hits = code_count + wsp_count
+                docs_count = len(self._search_results.get('docs', []) or [])
+                knowledge_count = len(self._search_results.get('knowledge', []) or [])
+                total_hits = code_count + wsp_count + docs_count + knowledge_count
                 if total_hits > 0:
                     summary_parts.append(
-                        f"[OK] Analysis complete: {total_hits} hits (code={code_count}, wsp={wsp_count}), no critical issues found"
+                        f"[OK] Analysis complete: {total_hits} hits (code={code_count}, wsp={wsp_count}, docs={docs_count}, knowledge={knowledge_count}), no critical issues found"
                     )
                 else:
                     summary_parts.append(f"[OK] Analysis complete: {total_files} files checked, no critical issues found")

--- a/holo_index/qwen_advisor/orchestration/qwen_orchestrator.py
+++ b/holo_index/qwen_advisor/orchestration/qwen_orchestrator.py
@@ -482,7 +482,9 @@ class QwenOrchestrator:
             if search_results:
                 code_hits = search_results.get('code', []) or []
                 wsp_hits = search_results.get('wsps', []) or []
-                if code_hits or wsp_hits:
+                docs_hits = search_results.get('docs', []) or []
+                knowledge_hits = search_results.get('knowledge', []) or []
+                if code_hits or wsp_hits or docs_hits or knowledge_hits:
                     result_lines = ["[RESULTS] Top matches"]
                     for item in code_hits[:3]:
                         path = item.get('path') or item.get('id') or item.get('title') or 'unknown'
@@ -490,6 +492,12 @@ class QwenOrchestrator:
                     for item in wsp_hits[:3]:
                         path = item.get('path') or item.get('id') or item.get('title') or 'unknown'
                         result_lines.append(f"  [WSP] {path}")
+                    for item in docs_hits[:3]:
+                        path = item.get('path') or item.get('id') or item.get('title') or 'unknown'
+                        result_lines.append(f"  [DOCS] {path}")
+                    for item in knowledge_hits[:2]:
+                        path = item.get('path') or item.get('id') or item.get('title') or 'unknown'
+                        result_lines.append(f"  [KNOWLEDGE] {path}")
                     concise_summary = concise_summary.rstrip() + "\n" + "\n".join(result_lines)
 
             return concise_summary

--- a/holo_index/tests/test_cli_docs_display.py
+++ b/holo_index/tests/test_cli_docs_display.py
@@ -1,0 +1,154 @@
+"""Tests for CLI docs/knowledge display rendering.
+
+HOLOINDEX_CLI_DOCS_DISPLAY_FIX_PHASE1: Verify _render_fast_search_summary
+displays DOCS and KNOWLEDGE hits in addition to CODE and WSP.
+"""
+
+import pytest
+from io import StringIO
+from unittest.mock import patch
+
+
+class TestCliDocsDisplay:
+    """Test _render_fast_search_summary renders docs/knowledge hits."""
+
+    def test_fast_summary_renders_docs_hits(self):
+        """Fast summary should render docs_hits with [DOCS] prefix."""
+        from holo_index._cli_main import _render_fast_search_summary
+
+        results = {
+            "code": [],
+            "wsps": [],
+            "docs": [
+                {"path": "docs/architecture/WRE_GATEWAY_ADAPTER_DESIGN.md", "title": "WRE Gateway"},
+                {"path": "docs/architecture/FOUNDUPS_AGENT_WORKSPACE_FORK_PLAN.md", "title": "Fork Plan"},
+            ],
+            "knowledge": [],
+        }
+
+        with patch("holo_index._cli_main.safe_print") as mock_print:
+            _render_fast_search_summary(results, limit=5)
+
+        calls = [str(c) for c in mock_print.call_args_list]
+        call_str = " ".join(calls)
+
+        assert "[DOCS]" in call_str
+        assert "WRE_GATEWAY_ADAPTER_DESIGN.md" in call_str
+
+    def test_fast_summary_renders_knowledge_hits(self):
+        """Fast summary should render knowledge_hits with [KNOWLEDGE] prefix."""
+        from holo_index._cli_main import _render_fast_search_summary
+
+        results = {
+            "code": [],
+            "wsps": [],
+            "docs": [],
+            "knowledge": [
+                {"path": "WSP_knowledge/docs/Papers/some_paper.md", "title": "Research Paper"},
+            ],
+        }
+
+        with patch("holo_index._cli_main.safe_print") as mock_print:
+            _render_fast_search_summary(results, limit=5)
+
+        calls = [str(c) for c in mock_print.call_args_list]
+        call_str = " ".join(calls)
+
+        assert "[KNOWLEDGE]" in call_str
+        assert "some_paper.md" in call_str
+
+    def test_existing_code_wsp_rendering_unchanged(self):
+        """Existing code_hits and wsp_hits rendering should still work."""
+        from holo_index._cli_main import _render_fast_search_summary
+
+        results = {
+            "code": [
+                {"location": "modules/wre_core/src/router.py"},
+            ],
+            "wsps": [
+                {"path": "WSP_framework/src/WSP_106.md", "title": "WSP 106"},
+            ],
+            "docs": [],
+            "knowledge": [],
+        }
+
+        with patch("holo_index._cli_main.safe_print") as mock_print:
+            _render_fast_search_summary(results, limit=5)
+
+        calls = [str(c) for c in mock_print.call_args_list]
+        call_str = " ".join(calls)
+
+        assert "[CODE]" in call_str
+        assert "router.py" in call_str
+        assert "[WSP]" in call_str
+        assert "WSP_106.md" in call_str
+
+    def test_empty_docs_knowledge_does_not_error(self):
+        """Empty docs/knowledge lists should not cause errors."""
+        from holo_index._cli_main import _render_fast_search_summary
+
+        results = {
+            "code": [{"location": "some/path.py"}],
+            "wsps": [],
+            "docs": [],
+            "knowledge": [],
+        }
+
+        # Should not raise
+        with patch("holo_index._cli_main.safe_print"):
+            _render_fast_search_summary(results, limit=5)
+
+    def test_none_docs_knowledge_does_not_error(self):
+        """None docs/knowledge values should not cause errors."""
+        from holo_index._cli_main import _render_fast_search_summary
+
+        results = {
+            "code": [{"location": "some/path.py"}],
+            "wsps": [],
+            "docs": None,
+            "knowledge": None,
+        }
+
+        # Should not raise
+        with patch("holo_index._cli_main.safe_print"):
+            _render_fast_search_summary(results, limit=5)
+
+    def test_total_hits_includes_docs_knowledge(self):
+        """Total hits count should include docs and knowledge."""
+        from holo_index._cli_main import _render_fast_search_summary
+
+        results = {
+            "code": [{"location": "a.py"}],
+            "wsps": [{"path": "WSP_1.md"}],
+            "docs": [{"path": "doc1.md"}, {"path": "doc2.md"}],
+            "knowledge": [{"path": "paper1.md"}],
+        }
+
+        with patch("holo_index._cli_main.safe_print") as mock_print:
+            _render_fast_search_summary(results, limit=10)
+
+        # First call should contain total hits summary
+        first_call = str(mock_print.call_args_list[0])
+        assert "5 hits" in first_call
+        assert "code=1" in first_call
+        assert "wsp=1" in first_call
+        assert "docs=2" in first_call
+        assert "knowledge=1" in first_call
+
+    def test_limit_applies_across_all_categories(self):
+        """Limit should apply across all hit categories."""
+        from holo_index._cli_main import _render_fast_search_summary
+
+        results = {
+            "code": [{"location": f"code{i}.py"} for i in range(3)],
+            "wsps": [{"path": f"wsp{i}.md"} for i in range(3)],
+            "docs": [{"path": f"doc{i}.md"} for i in range(3)],
+            "knowledge": [{"path": f"paper{i}.md"} for i in range(3)],
+        }
+
+        with patch("holo_index._cli_main.safe_print") as mock_print:
+            _render_fast_search_summary(results, limit=5)
+
+        # Count actual result lines (excluding header lines)
+        result_calls = [c for c in mock_print.call_args_list if "[CODE]" in str(c) or "[WSP]" in str(c) or "[DOCS]" in str(c) or "[KNOWLEDGE]" in str(c)]
+        assert len(result_calls) == 5


### PR DESCRIPTION
## Summary
- Renders `[DOCS]` and `[KNOWLEDGE]` categories in CLI search output
- Enables discoverability of architecture docs via standard search
- No search ranking or indexing behavior changes

## Changed Files
- `holo_index/_cli_main.py` - CLI output formatting
- `holo_index/output/agentic_output_throttler.py` - Output category handling
- `holo_index/qwen_advisor/orchestration/qwen_orchestrator.py` - Orchestrator integration
- `holo_index/tests/test_cli_docs_display.py` - New test file
- `holo_index/ModLog.md` - WSP 22 entry

## Manual Verification Results
| Query | Docs Found |
|-------|------------|
| WRE Gateway Adapter | `WRE_GATEWAY_ADAPTER_DESIGN.md` ✅ |
| FoundUps Agent Workspace | `FOUNDUPS_AGENT_WORKSPACE_FORK_PLAN.md` ✅ |
| Destructive action guard | `WRE_DESTRUCTIVE_ACTION_GUARD.md` ✅ |

## WSP 97 Truth Boundary
| Check | Status |
|-------|--------|
| Display-only change | ✅ |
| No search ranking changes | ✅ |
| No indexing behavior changes | ✅ |
| No TurboQuant default changes | ✅ |
| No Gemma/Qwen reranker changes | ✅ |
| No execution/deletion claims | ✅ |

## Test Results
- `test_cli_docs_display.py` - 7 passed
- `test_search_quality_baseline.py` - 10 passed
- `test_backend_routing.py` - 19 passed

## Test plan
- [x] Local tests pass (36 total)
- [x] Manual CLI verification shows [DOCS]/[KNOWLEDGE] hits
- [ ] CI passes (test/lint/security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)