### PR TITLE
feat(foundups): add Trade internal FoundUp seed

### DIFF
--- a/modules/foundups/trade/INTERFACE.md
+++ b/modules/foundups/trade/INTERFACE.md
@@ -1,0 +1,350 @@
+# Trade FoundUp - Interface Contract
+
+**Version**: 0.1.0  
+**Status**: Incubating (Phase 0)  
+**WSP References**: WSP 11 (Interface), WSP 97 (Truth), WSP 104 (Namespace)
+
+---
+
+## 1. Adapter Contract Boundaries
+
+### 1.1 MarketAdapterSpec
+
+Market adapters abstract blockchain or exchange-specific details.
+
+```python
+@dataclass
+class MarketAdapterSpec:
+    adapter_id: str           # Unique adapter identifier
+    chain_or_exchange: str    # e.g., "solana", "ethereum", "binance"
+    display_name: str         # Human-readable name
+    status: AdapterStatus     # PLANNED | INTERFACE_ONLY | SIMULATION | PAPER_TRADING
+    
+    # Capabilities
+    supports_token_events: bool
+    supports_wallet_events: bool
+    supports_ohlcv: bool
+    supports_order_book: bool
+    supports_social_signals: bool
+    
+    # Truth boundary
+    live_execution_enabled: bool = False  # MUST be False in Phase 0
+```
+
+**Planned Adapters:**
+
+| Adapter ID | Chain/Exchange | Priority |
+|------------|----------------|----------|
+| `solana` | Solana | P1 |
+| `ethereum` | Ethereum | P2 |
+| `base` | Base | P2 |
+| `bnb` | BNB Chain | P2 |
+| `tron` | Tron | P3 |
+| `cardano` | Cardano | P3 |
+
+### 1.2 LaunchpadAdapterSpec
+
+Launchpad adapters abstract token launch platform mechanics.
+
+```python
+@dataclass
+class LaunchpadAdapterSpec:
+    adapter_id: str           # Unique adapter identifier
+    platform_name: str        # e.g., "pump.fun", "sunpump"
+    chain: str                # Underlying chain
+    display_name: str         # Human-readable name
+    status: AdapterStatus     # PLANNED | INTERFACE_ONLY | SIMULATION
+    
+    # Capabilities
+    supports_launch_detection: bool
+    supports_bonding_curve: bool
+    supports_migration_tracking: bool
+    supports_top_traders: bool
+    supports_holder_distribution: bool
+    
+    # Truth boundary
+    live_execution_enabled: bool = False  # MUST be False in Phase 0
+```
+
+**Planned Adapters:**
+
+| Adapter ID | Platform | Chain | Data Source |
+|------------|----------|-------|-------------|
+| `pumpfun` | Pump.fun | Solana | Bitquery |
+| `pumpswap` | PumpSwap | Solana | Bitquery |
+| `raydium_launchlab` | Raydium LaunchLab | Solana | Direct RPC |
+| `moonshot` | Moonshot | Solana | TBD |
+| `letsbonk` | LetsBONK | Solana | TBD |
+| `four_meme` | Four.Meme | BNB | TBD |
+| `sunpump` | SunPump | Tron | TBD |
+| `zora` | Zora | Base/ETH | TBD |
+| `snekfun` | Snek.fun | Cardano | TBD |
+
+---
+
+## 2. Universal Event Schema
+
+All events normalize to these schemas:
+
+### 2.1 MarketEvent
+
+```python
+@dataclass
+class MarketEvent:
+    event_id: str
+    event_type: str           # price_update, volume_spike, liquidity_change
+    adapter_id: str
+    chain: str
+    timestamp: datetime
+    symbol: Optional[str]
+    price_usd: Optional[float]
+    volume_24h: Optional[float]
+    market_cap: Optional[float]
+    liquidity_usd: Optional[float]
+    raw_data: Dict[str, Any]
+```
+
+### 2.2 TokenEvent
+
+```python
+@dataclass
+class TokenEvent:
+    event_id: str
+    event_type: str           # token_created, migrated_to_dex, metadata_update
+    adapter_id: str
+    chain: str
+    timestamp: datetime
+    token_address: Optional[str]
+    token_symbol: Optional[str]
+    token_name: Optional[str]
+    creator_address: Optional[str]
+    launchpad: Optional[str]
+    bonding_curve_progress: Optional[float]  # 0.0 - 1.0
+    raw_data: Dict[str, Any]
+```
+
+### 2.3 WalletEvent
+
+```python
+@dataclass
+class WalletEvent:
+    event_id: str
+    event_type: str           # buy, sell, transfer, holder_change
+    adapter_id: str
+    chain: str
+    timestamp: datetime
+    wallet_cluster_id: Optional[str]  # Hashed, not raw PII
+    is_known_entity: bool
+    entity_label: Optional[str]       # whale, insider, bot
+    token_address: Optional[str]
+    action: Optional[str]
+    amount_tokens: Optional[float]
+    amount_usd: Optional[float]
+    raw_data: Dict[str, Any]
+```
+
+### 2.4 SocialEvent
+
+```python
+@dataclass
+class SocialEvent:
+    event_id: str
+    event_type: str           # mention, sentiment_shift, influencer_post
+    source: str               # twitter, telegram, discord
+    timestamp: datetime
+    token_address: Optional[str]
+    token_symbol: Optional[str]
+    sentiment_score: Optional[float]  # -1.0 to 1.0
+    mention_count: Optional[int]
+    engagement_score: Optional[float]
+    bot_activity_detected: bool
+    coordinated_activity_detected: bool
+    raw_data: Dict[str, Any]
+```
+
+### 2.5 RiskEvent
+
+```python
+@dataclass
+class RiskEvent:
+    event_id: str
+    event_type: str           # honeypot_detected, rug_risk, exit_blocked
+    timestamp: datetime
+    token_address: Optional[str]
+    chain: Optional[str]
+    overall_risk_score: float       # 0.0 = safe, 1.0 = max risk
+    honeypot_score: float
+    rug_pull_score: float
+    no_exit_score: float
+    insider_concentration_score: float
+    is_honeypot: bool
+    is_exit_blocked: bool
+    has_suspicious_holders: bool
+    risk_factors: List[str]
+    confidence: float               # 0.0 - 1.0
+```
+
+---
+
+## 3. WRE Task Adapter Plan
+
+Future WRE integration:
+
+| Task Type | WRE Action | Trade Handler |
+|-----------|------------|---------------|
+| `trade_analyze` | Analysis job | Risk engine |
+| `trade_simulate` | Simulation job | Paper trade engine |
+| `trade_score` | Scoring job | Proof metrics |
+| `trade_report` | Reporting job | Audit logger |
+
+**FoundUpJob Fields:**
+
+```python
+{
+    "foundup_id": "trade",
+    "tenant_id": "...",
+    "requested_action": "trade_analyze",
+    "payload": {
+        "token_address": "...",
+        "chain": "solana",
+        "analysis_type": "risk_score"
+    }
+}
+```
+
+---
+
+## 4. FAM Event Plan
+
+FAM event emission patterns:
+
+| Event Type | Trigger | Data |
+|------------|---------|------|
+| `trade.risk_scored` | Risk analysis complete | Risk event summary |
+| `trade.simulation_complete` | Paper trade finished | Simulation result |
+| `trade.signal_generated` | Trade/exit signal | Signal data |
+| `trade.adapter_status_change` | Adapter health change | Adapter status |
+
+---
+
+## 5. pAVS Registration Plan
+
+pAVS verification seam integration:
+
+| Capability | pAVS Role |
+|------------|-----------|
+| `market_intelligence` | Provide market analysis |
+| `risk_scoring` | Provide risk assessments |
+| `simulation` | Provide paper trading |
+| `proof_metrics` | Provide performance metrics |
+
+**Registration (future):**
+
+```python
+pavs_register(
+    foundup_id="trade",
+    capabilities=["market_intelligence", "risk_scoring", "simulation"],
+    proof_receipt_types=["risk_score", "simulation_result"]
+)
+```
+
+---
+
+## 6. Proof Metric Plan
+
+Performance tracking without real capital:
+
+| Metric Category | Metrics |
+|-----------------|---------|
+| **Latency** | Detection latency, adapter latency, model latency |
+| **Accuracy** | Honeypot detection, no-exit detection, soft-rug prediction, false positives, false negatives |
+| **Performance** | Simulated expectancy, simulated max drawdown, win rate, Sharpe ratio |
+| **Reliability** | Valid JSON rate, rate-limit reliability, adapter uptime |
+| **Cost** | Model cost per analysis, API cost per request |
+
+---
+
+## 7. Explicit Unsupported Operations
+
+**Phase 0 blocks all execution operations:**
+
+| Operation | Status | Reason |
+|-----------|--------|--------|
+| Real trades | BLOCKED | No-money mode |
+| Wallet signing | BLOCKED | No private key access |
+| Private key access | BLOCKED | Security boundary |
+| Order placement | BLOCKED | No exchange integration |
+| Wash trading | BLOCKED | Illegal activity |
+| Market manipulation | BLOCKED | Illegal activity |
+| Bot concealment | BLOCKED | Ethical violation |
+| Fake volume | BLOCKED | Market manipulation |
+| Autonomous capital deployment | BLOCKED | No-money mode |
+
+**Enforcement:**
+
+```python
+from contracts import ExecutionGuardPolicy, UnsupportedOperationError
+
+guard = ExecutionGuardPolicy()
+guard.assert_operation_allowed("real_trade")  # Raises UnsupportedOperationError
+```
+
+---
+
+## 8. Truth Fields Contract
+
+All Trade operations must respect WSP 97 truth fields:
+
+```python
+@dataclass
+class TruthFields:
+    dry_run_mode: bool = True           # MUST be True in Phase 0
+    no_money_mode: bool = True          # MUST be True in Phase 0
+    real_execution_performed: bool = False
+    verification_complete: bool = False
+    cabr_ready: bool = False
+    payout_ready: bool = False
+```
+
+---
+
+## 9. Public API (Phase 0)
+
+**Contracts module:**
+
+```python
+from modules.foundups.trade.src.contracts import (
+    # Adapter specs
+    MarketAdapterSpec,
+    LaunchpadAdapterSpec,
+    AdapterStatus,
+    
+    # Event schemas
+    MarketEvent,
+    TokenEvent,
+    WalletEvent,
+    SocialEvent,
+    RiskEvent,
+    
+    # Signal schemas
+    TradeSignal,
+    ExitSignal,
+    
+    # Proof schemas
+    ProofMetric,
+    SimulationResult,
+    
+    # Guard
+    ExecutionGuardPolicy,
+    UnsupportedOperationError,
+    
+    # Truth
+    TruthFields,
+    DEFAULT_TRUTH_FIELDS,
+    DEFAULT_EXECUTION_GUARD,
+)
+```
+
+---
+
+*All schemas serialize to dict/JSON via `.to_dict()` method.*

--- a/modules/foundups/trade/ModLog.md
+++ b/modules/foundups/trade/ModLog.md
@@ -1,0 +1,78 @@
+# Trade FoundUp - ModLog
+
+## Chronological Change Log
+
+### [2026-05-04] - TRADE_FOUNDUP_INTERNAL_SEED_PHASE1 (v0.1.0)
+
+**WSP Protocol References**: WSP 97 (Truth), WSP 103 (Federation), WSP 104 (Namespace)  
+**Impact Analysis**: Initial internal seed for Trade FoundUp
+
+#### Changes Made
+
+- Created module structure per WSP 49:
+  - `README.md` — FoundUp overview with all required sections
+  - `INTERFACE.md` — Contract boundaries and API surface
+  - `ROADMAP.md` — Phase 0-9 development plan
+  - `ModLog.md` — Change log (this file)
+  - `module.json` — Module metadata
+  - `foundup_manifest.json` — pfMALL shell contract
+  - `src/__init__.py` — Package exports
+  - `src/contracts.py` — Typed contracts (12 dataclasses)
+  - `tests/__init__.py` — Test package
+  - `tests/test_manifest_contract.py` — Manifest validation
+  - `tests/test_trade_contracts.py` — Contract serialization
+  - `tests/TestModLog.md` — Test change log
+
+#### Contracts Defined
+
+| Contract | Purpose |
+|----------|---------|
+| `TruthFields` | WSP 97 truth boundary fields |
+| `MarketAdapterSpec` | Chain/exchange abstraction |
+| `LaunchpadAdapterSpec` | Launch platform abstraction |
+| `MarketEvent` | Universal market data event |
+| `TokenEvent` | Token lifecycle event |
+| `WalletEvent` | Wallet activity event |
+| `SocialEvent` | Social signal event |
+| `RiskEvent` | Risk assessment event |
+| `TradeSignal` | Entry signal (simulation only) |
+| `ExitSignal` | Exit signal (simulation only) |
+| `ProofMetric` | Performance measurement |
+| `SimulationResult` | Paper trading outcome |
+| `ExecutionGuardPolicy` | Execution blocker |
+
+#### Manifest Summary
+
+```json
+{
+  "foundup_id": "trade",
+  "routing_prefix": "/f/trade",
+  "data_namespace": "idb_trade",
+  "lifecycle_stage": "incubating",
+  "tier": "F0_DAE",
+  "launch_readiness": "discoverable_only"
+}
+```
+
+#### WSP 97 Truth Boundaries
+
+All Phase 0 operations respect:
+- `dry_run_mode: True`
+- `no_money_mode: True`
+- `real_execution_performed: False`
+- `verification_complete: False`
+- `cabr_ready: False`
+- `payout_ready: False`
+
+#### Verification
+
+```bash
+python -m pytest modules/foundups/trade/tests -q
+python -m pytest modules/foundups/tests/test_namespace_guardrail.py -q
+```
+
+---
+
+## Future Entries
+
+Next slice: `TRADE_FOUNDUP_ADAPTER_CONTRACTS_PHASE2`

--- a/modules/foundups/trade/README.md
+++ b/modules/foundups/trade/README.md
@@ -1,0 +1,250 @@
+# Trade FoundUp
+
+**Autonomous trading intelligence and execution FoundUp.**
+
+**Version**: 0.1.0  
+**Status**: Incubating (Phase 0)  
+**Type**: F0_DAE  
+**Owner**: 012  
+
+---
+
+## One-Line Thesis
+
+Trade is the autonomous FoundUp that turns compute into market intelligence, proves edge in hostile meme-launch markets, then expands into ubiquitous autonomous trading.
+
+---
+
+## Core Principle
+
+**Trade is ubiquitous.**
+
+- Must NOT be chain-specific
+- Must NOT be launchpad-specific
+- Must NOT be meme-specific
+- Must BE market-adapter driven
+
+The meme-coin launchpad PoC is just the fastest hostile environment to test the system.
+
+---
+
+## WSP 97 Truth Boundary
+
+**Phase 0 constraints (NO EXCEPTIONS):**
+
+| Field | Value | Meaning |
+|-------|-------|---------|
+| `no_money_mode` | `True` | No real capital deployment |
+| `dry_run_mode` | `True` | All operations are simulated |
+| `real_execution_performed` | `False` | No actual trades executed |
+| `verification_complete` | `False` | No CABR verification |
+| `cabr_ready` | `False` | No V3 scoring |
+| `payout_ready` | `False` | No blockchain payouts |
+
+**Unsupported Operations (Phase 0):**
+
+- No real trades
+- No wallet signing
+- No private keys
+- No order placement
+- No wash trading
+- No market manipulation
+- No bot concealment
+- No fake volume
+- No autonomous capital deployment
+
+---
+
+## Route Namespace
+
+Canonical contract: `modules/foundups/docs/FOUNDUP_AI_HOOKS_AND_DAEMON_SURFACE_CONTRACT.md`  
+Routing follows **WSP 104** (`/f/{foundup_id}`).
+
+| Field | Value |
+|-------|-------|
+| `foundup_id` | `trade` |
+| `routing_prefix` | `/f/trade` |
+| Landing route | `/f/trade` |
+| App mount | `/f/trade/app` |
+
+---
+
+## App Mount
+
+Shell contract: **`/f/trade/app`**
+
+**Current status**: Not deployed. Internal prototype only.
+
+---
+
+## AI Capability Hooks
+
+Contract surface (implementation staged):
+
+| Hook | Status | Intent |
+|------|--------|--------|
+| `get_status` | Planned | Short operational snapshot |
+| `get_context` | Planned | Bounded context for trading decision |
+| `navigate` | Planned | Change surface within tenant bounds |
+| `launch_capability` | Planned | Invoke intelligence/simulation capability |
+| Shell handoff/return | Planned | Delegate to shell or return from tool |
+
+---
+
+## DAEmon Outputs
+
+Per **WSP 91** (when DAEMON workers attach):
+
+| Output | Status | Notes |
+|--------|--------|-------|
+| Health status | Planned | healthy / degraded / critical |
+| Last action | Planned | Last simulation or analysis |
+| Error state | Planned | Active error or "none" |
+| Recommended next action | Planned | Operator/agent hint |
+| Queue / work state | Planned | Simulation queue state |
+| Telemetry namespace | Defined | `idb_trade` |
+
+---
+
+## Data / Telemetry Namespace
+
+| Field | Value |
+|-------|-------|
+| `foundup_id` | `trade` |
+| `data_namespace` | `idb_trade` |
+| Tenant bounds | Cache, storage, telemetry stay tenant-scoped per WSP 104 |
+
+---
+
+## Architecture
+
+Trade is adapter-driven:
+
+```
+Trade/
+├── market_adapters/       # Chain/exchange abstraction (solana, ethereum, cex, etc.)
+├── launchpad_adapters/    # Launch platform abstraction (pumpfun, sunpump, zora, etc.)
+├── intelligence/          # Risk engine, honeypot detector, entity graph, game theory
+├── orchestration/         # WRE task adapter, model router, swarm dispatcher
+├── simulation/            # Paper trade, backtest, shadow execution, proof metrics
+├── execution/             # No-money mode, micro-wallet mode (future), execution guard
+└── audit/                 # Decision log, violations, proof of performance
+```
+
+---
+
+## Universal Event Schema
+
+All market data normalized to universal schemas:
+
+| Schema | Purpose |
+|--------|---------|
+| `MarketEvent` | Price, volume, liquidity changes |
+| `TokenEvent` | Token creation, migration, metadata |
+| `WalletEvent` | Wallet transactions and holdings |
+| `SocialEvent` | Social signals, sentiment, manipulation |
+| `RiskEvent` | Risk scores, honeypot detection |
+| `TradeSignal` | Entry signals (simulation only) |
+| `ExitSignal` | Exit signals (simulation only) |
+| `ProofMetric` | Performance measurement |
+| `SimulationResult` | Paper trading outcomes |
+
+---
+
+## PoC Market: Meme Launchpads
+
+First proving ground: meme-coin launch markets (high-signal, high-risk, adversarial).
+
+**Target launchpad adapters (priority order):**
+
+| Platform | Chain | Data Source | Status |
+|----------|-------|-------------|--------|
+| Pump.fun | Solana | Bitquery API | Planned |
+| PumpSwap | Solana | Bitquery API | Planned |
+| Raydium LaunchLab | Solana | Direct RPC | Planned |
+| Moonshot | Solana | TBD | Planned |
+| LetsBONK | Solana | TBD | Planned |
+| Four.Meme | BNB Chain | TBD | Planned |
+| SunPump | Tron | TBD | Planned |
+| Zora | Base/Ethereum | TBD | Planned |
+| Snek.fun | Cardano | TBD | Planned |
+
+**Data sources (verified):**
+- Bitquery: Token launches, live trades, OHLCV, bonding curves, top traders, holder distribution, migration tracking ([docs](https://docs.bitquery.io/docs/blockchain/Solana/Pumpfun/Pump-Fun-API/))
+
+---
+
+## Proof Metrics (Phase 0)
+
+Track without real capital:
+
+| Metric | Category |
+|--------|----------|
+| Detection latency | Latency |
+| Adapter latency | Latency |
+| Honeypot detection accuracy | Accuracy |
+| No-exit detection accuracy | Accuracy |
+| Soft-rug prediction accuracy | Accuracy |
+| False positives | Accuracy |
+| False negatives | Accuracy |
+| Simulated expectancy | Performance |
+| Simulated max drawdown | Performance |
+| Model latency | Latency |
+| Valid JSON rate | Reliability |
+| Model cost | Cost |
+| Rate-limit reliability | Reliability |
+| Cross-market generalization | Performance |
+
+---
+
+## WRE Integration Plan
+
+Future integration with WRE orchestration:
+
+1. **FoundUpJob**: Jobs with `foundup_id="trade"` route to Trade adapters
+2. **FAM Events**: Trade emits `fam_emit` events for proof tracking
+3. **pAVS Registration**: Trade registers as pAVS-verifiable FoundUp
+4. **Hermes Delegation**: WRE can delegate simulation tasks to Trade workers
+
+---
+
+## WSP References
+
+- **WSP 97** — Truthful Agent Contract (truth boundaries)
+- **WSP 91** — DAEMON Observability Protocol
+- **WSP 103** — FoundUp Federation Protocol
+- **WSP 104** — FoundUp Route Namespace and Tenant Isolation Protocol
+- **WSP 29** — CABR Engine (V1/V2/V3 validation)
+
+---
+
+## Lifecycle Phases
+
+| Phase | Description | Capital |
+|-------|-------------|---------|
+| **Phase 0** (current) | Internal seed, contracts, simulation | None |
+| Phase 1 | Adapter layer, multi-launchpad | None |
+| Phase 2 | Universal market schema normalization | None |
+| Phase 3 | Simulation + proof metrics | None |
+| Phase 4 | WRE swarm integration | None |
+| Phase 5 | Prototype hardening | None |
+| Phase 6 | External FoundUp generation | None |
+| Phase 7 | Community compute registry | None |
+| Phase 8 | Bounded micro-wallet execution | Micro |
+| Phase 9 | Universal trading expansion | Scaled |
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `foundup_manifest.json` | FoundUp identity and shell contract |
+| `module.json` | Module metadata |
+| `src/contracts.py` | Typed contracts and event schemas |
+| `tests/test_manifest_contract.py` | Manifest validation tests |
+| `tests/test_trade_contracts.py` | Contract serialization tests |
+
+---
+
+*Trade is the autonomous FoundUp that turns compute into market intelligence.*

--- a/modules/foundups/trade/ROADMAP.md
+++ b/modules/foundups/trade/ROADMAP.md
@@ -1,0 +1,169 @@
+# Trade FoundUp - Roadmap
+
+**Version**: 0.1.0  
+**Status**: Incubating  
+**Last Updated**: 2026-05-04
+
+---
+
+## Phase 0: Internal Seed (Current)
+
+**Objective**: Establish contracts and architecture without capital.
+
+| Task | Status | Notes |
+|------|--------|-------|
+| Create module structure | DONE | WSP 49 compliant |
+| Define foundup_manifest.json | DONE | WSP 104 compliant |
+| Define universal event schemas | DONE | 9 contract types |
+| Define adapter specs | DONE | Market + Launchpad |
+| Define execution guard | DONE | Blocks all execution |
+| Define truth fields | DONE | WSP 97 compliant |
+| Create manifest tests | DONE | Validates namespace |
+| Create contract tests | DONE | Validates serialization |
+
+**Next Slice**: `TRADE_FOUNDUP_ADAPTER_CONTRACTS_PHASE2`
+
+---
+
+## Phase 1: Adapter Layer
+
+**Objective**: Build adapter interfaces for multiple launchpads.
+
+| Task | Status | Priority |
+|------|--------|----------|
+| Pump.fun adapter interface | Planned | P1 |
+| PumpSwap adapter interface | Planned | P1 |
+| Raydium LaunchLab adapter interface | Planned | P2 |
+| Moonshot adapter interface | Planned | P2 |
+| Four.Meme adapter interface | Planned | P3 |
+| SunPump adapter interface | Planned | P3 |
+| Bitquery integration layer | Planned | P1 |
+
+---
+
+## Phase 2: Universal Market Schema
+
+**Objective**: Normalize all market data to universal format.
+
+| Task | Status |
+|------|--------|
+| Event normalization pipeline | Planned |
+| Cross-adapter event routing | Planned |
+| Event validation layer | Planned |
+| Event persistence (simulation) | Planned |
+
+---
+
+## Phase 3: Simulation + Proof
+
+**Objective**: Paper trading and performance measurement.
+
+| Task | Status |
+|------|--------|
+| Paper trade engine | Planned |
+| Backtest framework | Planned |
+| Shadow execution mode | Planned |
+| Proof metric collection | Planned |
+| Performance dashboard | Planned |
+
+---
+
+## Phase 4: WRE Swarm Integration
+
+**Objective**: Integrate with WRE orchestration layer.
+
+| Task | Status |
+|------|--------|
+| WRE task adapter | Planned |
+| Model router benchmark | Planned |
+| Swarm dispatcher | Planned |
+| Latency profiler | Planned |
+
+---
+
+## Phase 5: Prototype Hardening
+
+**Objective**: Production-quality internal prototype.
+
+| Task | Status |
+|------|--------|
+| Full test coverage | Planned |
+| Error handling hardening | Planned |
+| Rate limit handling | Planned |
+| Observability integration | Planned |
+
+---
+
+## Phase 6: External FoundUp Generation
+
+**Objective**: Export as autonomous FoundUp MVP.
+
+| Task | Status |
+|------|--------|
+| FoundUp export manifest | Planned |
+| External repo generation | Planned |
+| Documentation export | Planned |
+
+---
+
+## Phase 7: Community Compute
+
+**Objective**: Enable community compute contribution.
+
+| Task | Status |
+|------|--------|
+| Compute registry | Planned |
+| Contributor tracking | Planned |
+| Proof-of-compute receipts | Planned |
+
+---
+
+## Phase 8: Bounded Execution (Future)
+
+**Objective**: Controlled micro-wallet execution.
+
+| Task | Status |
+|------|--------|
+| Micro-wallet mode | Future |
+| Risk caps | Future |
+| Treasury guard | Future |
+| Profit sweep | Future |
+
+---
+
+## Phase 9: Universal Trading (Future)
+
+**Objective**: Expand beyond meme launches.
+
+| Task | Status |
+|------|--------|
+| DEX trading adapters | Future |
+| CEX trading adapters | Future |
+| Prediction markets | Future |
+| Yield routing | Future |
+
+---
+
+## Dependencies
+
+| Dependency | Status | Required For |
+|------------|--------|--------------|
+| Bitquery API access | Not started | Phase 1 |
+| WRE orchestration | Available | Phase 4 |
+| FAM daemon | Available | Phase 4 |
+| pAVS MCP | Available | Phase 6 |
+
+---
+
+## Risk Log
+
+| Risk | Mitigation | Phase |
+|------|------------|-------|
+| API rate limits | Caching, request batching | 1 |
+| Data quality variance | Multi-source validation | 2 |
+| Model latency | Pre-scoring, caching | 3 |
+| False positive rate | Ensemble scoring | 3 |
+
+---
+
+*Roadmap updated per slice completion. No execution until Phase 8.*

--- a/modules/foundups/trade/foundup_manifest.json
+++ b/modules/foundups/trade/foundup_manifest.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://foundups.org/schemas/foundup-manifest/v1.json",
+  "foundup_id": "trade",
+  "name": "Trade",
+  "version": "0.1.0",
+  "description": "Autonomous trading intelligence and execution FoundUp. Market-adapter driven, chain-agnostic.",
+  "tagline": "Compute into market intelligence",
+  "tier": "F0_DAE",
+  "lifecycle_stage": "incubating",
+  "entry_url": null,
+  "routing_prefix": "/f/trade",
+  "icon_url": null,
+  "required_subscription_tier": "free",
+  "is_invite_only": true,
+  "capabilities": [
+    "market_intelligence",
+    "risk_scoring",
+    "simulation",
+    "proof_metrics",
+    "offline"
+  ],
+  "agent_routes": [
+    "openclaw_query"
+  ],
+  "holo_collections": [],
+  "data_namespace": "idb_trade",
+  "cabr_contract": {
+    "v1_gate": "default",
+    "v2_proof": "default",
+    "v3_score_min": 0.5
+  },
+  "owner_id": "012",
+  "token_symbol": "TRADE",
+  "category": "trading",
+  "launch_readiness": "discoverable_only",
+  "created_at": "2026-05-04T00:00:00Z",
+  "signature": ""
+}

--- a/modules/foundups/trade/module.json
+++ b/modules/foundups/trade/module.json
@@ -1,0 +1,15 @@
+{
+  "name": "trade",
+  "version": "0.1.0",
+  "type": "foundup",
+  "description": "Autonomous trading intelligence and execution FoundUp",
+  "domain": "foundups",
+  "wsp_compliance": ["WSP_97", "WSP_103", "WSP_104"],
+  "entry_points": {
+    "contracts": "src/contracts.py"
+  },
+  "dependencies": [],
+  "lifecycle_stage": "incubating",
+  "no_money_mode": true,
+  "dry_run_mode": true
+}

--- a/modules/foundups/trade/src/__init__.py
+++ b/modules/foundups/trade/src/__init__.py
@@ -1,0 +1,49 @@
+"""Trade FoundUp - Autonomous Trading Intelligence
+
+Autonomous trading intelligence and execution FoundUp.
+Market-adapter driven, chain-agnostic.
+
+WSP References:
+- WSP 97: Truth Boundaries (no false execution claims)
+- WSP 103: FoundUp Federation Protocol
+- WSP 104: FoundUp Route Namespace
+
+Phase 0 Status:
+- no_money_mode: True
+- dry_run_mode: True
+- real_execution_performed: False
+"""
+
+from .contracts import (
+    MarketAdapterSpec,
+    LaunchpadAdapterSpec,
+    MarketEvent,
+    TokenEvent,
+    WalletEvent,
+    SocialEvent,
+    RiskEvent,
+    TradeSignal,
+    ExitSignal,
+    ProofMetric,
+    SimulationResult,
+    ExecutionGuardPolicy,
+    TruthFields,
+)
+
+__all__ = [
+    "MarketAdapterSpec",
+    "LaunchpadAdapterSpec",
+    "MarketEvent",
+    "TokenEvent",
+    "WalletEvent",
+    "SocialEvent",
+    "RiskEvent",
+    "TradeSignal",
+    "ExitSignal",
+    "ProofMetric",
+    "SimulationResult",
+    "ExecutionGuardPolicy",
+    "TruthFields",
+]
+
+__version__ = "0.1.0"

--- a/modules/foundups/trade/src/contracts.py
+++ b/modules/foundups/trade/src/contracts.py
@@ -1,0 +1,695 @@
+"""Trade FoundUp Contracts
+
+Typed contracts for autonomous trading intelligence.
+All contracts are market-adapter driven and chain-agnostic.
+
+WSP References:
+- WSP 97: Truth Boundaries (no false execution claims)
+- WSP 103: FoundUp Federation Protocol
+- WSP 104: FoundUp Route Namespace
+
+Phase 0 Constraints:
+- no_money_mode: True (always)
+- dry_run_mode: True (always)
+- real_execution_performed: False (always)
+- No wallet signing
+- No private keys
+- No order placement
+- No autonomous capital deployment
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, List, Literal, Optional
+
+
+# ---------------------------------------------------------------------------
+# WSP 97 Truth Fields
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TruthFields:
+    """WSP 97 truth boundary fields.
+
+    Phase 0: All execution fields are False.
+    These fields MUST NOT be set to True without actual execution.
+    """
+
+    dry_run_mode: bool = True
+    no_money_mode: bool = True
+    real_execution_performed: bool = False
+    verification_complete: bool = False
+    cabr_ready: bool = False
+    payout_ready: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "dry_run_mode": self.dry_run_mode,
+            "no_money_mode": self.no_money_mode,
+            "real_execution_performed": self.real_execution_performed,
+            "verification_complete": self.verification_complete,
+            "cabr_ready": self.cabr_ready,
+            "payout_ready": self.payout_ready,
+        }
+
+    def assert_no_execution(self) -> None:
+        """Verify no execution claims are made."""
+        assert self.dry_run_mode is True, "dry_run_mode must be True in Phase 0"
+        assert self.no_money_mode is True, "no_money_mode must be True in Phase 0"
+        assert self.real_execution_performed is False, "real_execution_performed must be False"
+        assert self.verification_complete is False, "verification_complete must be False"
+        assert self.cabr_ready is False, "cabr_ready must be False"
+        assert self.payout_ready is False, "payout_ready must be False"
+
+
+# ---------------------------------------------------------------------------
+# Adapter Specifications
+# ---------------------------------------------------------------------------
+
+
+class AdapterStatus(str, Enum):
+    """Adapter implementation status."""
+
+    PLANNED = "planned"
+    INTERFACE_ONLY = "interface_only"
+    SIMULATION = "simulation"
+    PAPER_TRADING = "paper_trading"
+    LIVE = "live"  # Not allowed in Phase 0
+
+
+@dataclass
+class MarketAdapterSpec:
+    """Market adapter specification (chain/exchange abstraction).
+
+    Market adapters abstract blockchain or exchange-specific details.
+    Examples: solana, ethereum, base, bnb, tron, cardano, cex
+
+    Phase 0: Interface specification only.
+    """
+
+    adapter_id: str
+    chain_or_exchange: str
+    display_name: str
+    status: AdapterStatus = AdapterStatus.PLANNED
+
+    # Capabilities (what this adapter can provide)
+    supports_token_events: bool = False
+    supports_wallet_events: bool = False
+    supports_ohlcv: bool = False
+    supports_order_book: bool = False
+    supports_social_signals: bool = False
+
+    # Truth boundary
+    live_execution_enabled: bool = False  # MUST be False in Phase 0
+
+    # Metadata
+    documentation_url: Optional[str] = None
+    data_sources: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "adapter_id": self.adapter_id,
+            "chain_or_exchange": self.chain_or_exchange,
+            "display_name": self.display_name,
+            "status": self.status.value,
+            "supports_token_events": self.supports_token_events,
+            "supports_wallet_events": self.supports_wallet_events,
+            "supports_ohlcv": self.supports_ohlcv,
+            "supports_order_book": self.supports_order_book,
+            "supports_social_signals": self.supports_social_signals,
+            "live_execution_enabled": self.live_execution_enabled,
+            "documentation_url": self.documentation_url,
+            "data_sources": self.data_sources,
+        }
+
+
+@dataclass
+class LaunchpadAdapterSpec:
+    """Launchpad adapter specification (token launch platform abstraction).
+
+    Launchpad adapters abstract platform-specific launch mechanics.
+    Examples: pumpfun, pumpswap, letsbonk, raydium_launchlab, sunpump, zora
+
+    Phase 0: Interface specification only.
+    """
+
+    adapter_id: str
+    platform_name: str
+    chain: str
+    display_name: str
+    status: AdapterStatus = AdapterStatus.PLANNED
+
+    # Capabilities
+    supports_launch_detection: bool = False
+    supports_bonding_curve: bool = False
+    supports_migration_tracking: bool = False
+    supports_top_traders: bool = False
+    supports_holder_distribution: bool = False
+
+    # Truth boundary
+    live_execution_enabled: bool = False  # MUST be False in Phase 0
+
+    # Metadata
+    documentation_url: Optional[str] = None
+    api_type: Optional[str] = None  # e.g., "bitquery", "direct_rpc", "websocket"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "adapter_id": self.adapter_id,
+            "platform_name": self.platform_name,
+            "chain": self.chain,
+            "display_name": self.display_name,
+            "status": self.status.value,
+            "supports_launch_detection": self.supports_launch_detection,
+            "supports_bonding_curve": self.supports_bonding_curve,
+            "supports_migration_tracking": self.supports_migration_tracking,
+            "supports_top_traders": self.supports_top_traders,
+            "supports_holder_distribution": self.supports_holder_distribution,
+            "live_execution_enabled": self.live_execution_enabled,
+            "documentation_url": self.documentation_url,
+            "api_type": self.api_type,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Universal Event Schemas
+# ---------------------------------------------------------------------------
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass
+class MarketEvent:
+    """Universal market event schema.
+
+    Normalized market data event from any adapter.
+    """
+
+    event_id: str
+    event_type: str  # e.g., "price_update", "volume_spike", "liquidity_change"
+    adapter_id: str
+    chain: str
+    timestamp: datetime = field(default_factory=_utc_now)
+
+    # Market data
+    symbol: Optional[str] = None
+    price_usd: Optional[float] = None
+    volume_24h: Optional[float] = None
+    market_cap: Optional[float] = None
+    liquidity_usd: Optional[float] = None
+
+    # Raw data passthrough
+    raw_data: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "event_id": self.event_id,
+            "event_type": self.event_type,
+            "adapter_id": self.adapter_id,
+            "chain": self.chain,
+            "timestamp": self.timestamp.isoformat(),
+            "symbol": self.symbol,
+            "price_usd": self.price_usd,
+            "volume_24h": self.volume_24h,
+            "market_cap": self.market_cap,
+            "liquidity_usd": self.liquidity_usd,
+            "raw_data": self.raw_data,
+        }
+
+
+@dataclass
+class TokenEvent:
+    """Token lifecycle event schema.
+
+    Token creation, migration, or metadata change events.
+    """
+
+    event_id: str
+    event_type: str  # e.g., "token_created", "migrated_to_dex", "metadata_update"
+    adapter_id: str
+    chain: str
+    timestamp: datetime = field(default_factory=_utc_now)
+
+    # Token identity
+    token_address: Optional[str] = None
+    token_symbol: Optional[str] = None
+    token_name: Optional[str] = None
+
+    # Launch metadata
+    creator_address: Optional[str] = None
+    launchpad: Optional[str] = None
+    bonding_curve_progress: Optional[float] = None  # 0.0 - 1.0
+
+    # Raw data
+    raw_data: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "event_id": self.event_id,
+            "event_type": self.event_type,
+            "adapter_id": self.adapter_id,
+            "chain": self.chain,
+            "timestamp": self.timestamp.isoformat(),
+            "token_address": self.token_address,
+            "token_symbol": self.token_symbol,
+            "token_name": self.token_name,
+            "creator_address": self.creator_address,
+            "launchpad": self.launchpad,
+            "bonding_curve_progress": self.bonding_curve_progress,
+            "raw_data": self.raw_data,
+        }
+
+
+@dataclass
+class WalletEvent:
+    """Wallet activity event schema.
+
+    Wallet-level transaction and holding events.
+    """
+
+    event_id: str
+    event_type: str  # e.g., "buy", "sell", "transfer", "holder_change"
+    adapter_id: str
+    chain: str
+    timestamp: datetime = field(default_factory=_utc_now)
+
+    # Wallet identity (hashed or clustered, not raw PII)
+    wallet_cluster_id: Optional[str] = None
+    is_known_entity: bool = False
+    entity_label: Optional[str] = None  # e.g., "whale", "insider", "bot"
+
+    # Transaction data
+    token_address: Optional[str] = None
+    action: Optional[str] = None
+    amount_tokens: Optional[float] = None
+    amount_usd: Optional[float] = None
+
+    # Raw data
+    raw_data: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "event_id": self.event_id,
+            "event_type": self.event_type,
+            "adapter_id": self.adapter_id,
+            "chain": self.chain,
+            "timestamp": self.timestamp.isoformat(),
+            "wallet_cluster_id": self.wallet_cluster_id,
+            "is_known_entity": self.is_known_entity,
+            "entity_label": self.entity_label,
+            "token_address": self.token_address,
+            "action": self.action,
+            "amount_tokens": self.amount_tokens,
+            "amount_usd": self.amount_usd,
+            "raw_data": self.raw_data,
+        }
+
+
+@dataclass
+class SocialEvent:
+    """Social signal event schema.
+
+    Social media, sentiment, and community activity events.
+    """
+
+    event_id: str
+    event_type: str  # e.g., "mention", "sentiment_shift", "influencer_post"
+    source: str  # e.g., "twitter", "telegram", "discord"
+    timestamp: datetime = field(default_factory=_utc_now)
+
+    # Signal data
+    token_address: Optional[str] = None
+    token_symbol: Optional[str] = None
+    sentiment_score: Optional[float] = None  # -1.0 to 1.0
+    mention_count: Optional[int] = None
+    engagement_score: Optional[float] = None
+
+    # Manipulation indicators
+    bot_activity_detected: bool = False
+    coordinated_activity_detected: bool = False
+
+    # Raw data
+    raw_data: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "event_id": self.event_id,
+            "event_type": self.event_type,
+            "source": self.source,
+            "timestamp": self.timestamp.isoformat(),
+            "token_address": self.token_address,
+            "token_symbol": self.token_symbol,
+            "sentiment_score": self.sentiment_score,
+            "mention_count": self.mention_count,
+            "engagement_score": self.engagement_score,
+            "bot_activity_detected": self.bot_activity_detected,
+            "coordinated_activity_detected": self.coordinated_activity_detected,
+            "raw_data": self.raw_data,
+        }
+
+
+@dataclass
+class RiskEvent:
+    """Risk assessment event schema.
+
+    Risk engine output for a token or market condition.
+    """
+
+    event_id: str
+    event_type: str  # e.g., "honeypot_detected", "rug_risk", "exit_blocked"
+    timestamp: datetime = field(default_factory=_utc_now)
+
+    # Target
+    token_address: Optional[str] = None
+    chain: Optional[str] = None
+
+    # Risk scores (0.0 = safe, 1.0 = maximum risk)
+    overall_risk_score: float = 0.0
+    honeypot_score: float = 0.0
+    rug_pull_score: float = 0.0
+    no_exit_score: float = 0.0
+    insider_concentration_score: float = 0.0
+
+    # Flags
+    is_honeypot: bool = False
+    is_exit_blocked: bool = False
+    has_suspicious_holders: bool = False
+
+    # Reasoning
+    risk_factors: List[str] = field(default_factory=list)
+    confidence: float = 0.0  # 0.0 - 1.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "event_id": self.event_id,
+            "event_type": self.event_type,
+            "timestamp": self.timestamp.isoformat(),
+            "token_address": self.token_address,
+            "chain": self.chain,
+            "overall_risk_score": self.overall_risk_score,
+            "honeypot_score": self.honeypot_score,
+            "rug_pull_score": self.rug_pull_score,
+            "no_exit_score": self.no_exit_score,
+            "insider_concentration_score": self.insider_concentration_score,
+            "is_honeypot": self.is_honeypot,
+            "is_exit_blocked": self.is_exit_blocked,
+            "has_suspicious_holders": self.has_suspicious_holders,
+            "risk_factors": self.risk_factors,
+            "confidence": self.confidence,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Signal Schemas
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TradeSignal:
+    """Trade signal schema.
+
+    Entry signal from intelligence layer. Does NOT execute trades.
+    """
+
+    signal_id: str
+    signal_type: Literal["entry", "scale_in", "hold"]
+    timestamp: datetime = field(default_factory=_utc_now)
+
+    # Target
+    token_address: Optional[str] = None
+    chain: Optional[str] = None
+
+    # Signal strength
+    confidence: float = 0.0  # 0.0 - 1.0
+    expected_upside: Optional[float] = None  # Percentage
+    expected_timeframe_seconds: Optional[int] = None
+
+    # Risk-adjusted
+    risk_score: float = 0.0
+    risk_reward_ratio: Optional[float] = None
+
+    # Reasoning
+    signal_factors: List[str] = field(default_factory=list)
+    model_id: Optional[str] = None
+
+    # Truth boundary
+    is_simulation: bool = True  # MUST be True in Phase 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "signal_id": self.signal_id,
+            "signal_type": self.signal_type,
+            "timestamp": self.timestamp.isoformat(),
+            "token_address": self.token_address,
+            "chain": self.chain,
+            "confidence": self.confidence,
+            "expected_upside": self.expected_upside,
+            "expected_timeframe_seconds": self.expected_timeframe_seconds,
+            "risk_score": self.risk_score,
+            "risk_reward_ratio": self.risk_reward_ratio,
+            "signal_factors": self.signal_factors,
+            "model_id": self.model_id,
+            "is_simulation": self.is_simulation,
+        }
+
+
+@dataclass
+class ExitSignal:
+    """Exit signal schema.
+
+    Exit signal from intelligence layer. Does NOT execute trades.
+    """
+
+    signal_id: str
+    signal_type: Literal["exit", "scale_out", "stop_loss", "take_profit"]
+    timestamp: datetime = field(default_factory=_utc_now)
+
+    # Target
+    token_address: Optional[str] = None
+    chain: Optional[str] = None
+
+    # Signal data
+    urgency: Literal["low", "medium", "high", "critical"] = "medium"
+    confidence: float = 0.0
+
+    # Exit reasoning
+    exit_factors: List[str] = field(default_factory=list)
+
+    # Performance context (if from simulation)
+    simulated_pnl_percent: Optional[float] = None
+    hold_duration_seconds: Optional[int] = None
+
+    # Truth boundary
+    is_simulation: bool = True  # MUST be True in Phase 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "signal_id": self.signal_id,
+            "signal_type": self.signal_type,
+            "timestamp": self.timestamp.isoformat(),
+            "token_address": self.token_address,
+            "chain": self.chain,
+            "urgency": self.urgency,
+            "confidence": self.confidence,
+            "exit_factors": self.exit_factors,
+            "simulated_pnl_percent": self.simulated_pnl_percent,
+            "hold_duration_seconds": self.hold_duration_seconds,
+            "is_simulation": self.is_simulation,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Proof and Simulation Schemas
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ProofMetric:
+    """Proof metric for simulation performance tracking.
+
+    Measures system performance without real capital.
+    """
+
+    metric_id: str
+    metric_type: str
+    timestamp: datetime = field(default_factory=_utc_now)
+
+    # Metric value
+    value: float = 0.0
+    unit: str = ""
+
+    # Context
+    adapter_id: Optional[str] = None
+    model_id: Optional[str] = None
+    timeframe_seconds: Optional[int] = None
+    sample_size: Optional[int] = None
+
+    # Classification
+    category: Literal[
+        "latency", "accuracy", "performance", "reliability", "cost"
+    ] = "performance"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "metric_id": self.metric_id,
+            "metric_type": self.metric_type,
+            "timestamp": self.timestamp.isoformat(),
+            "value": self.value,
+            "unit": self.unit,
+            "adapter_id": self.adapter_id,
+            "model_id": self.model_id,
+            "timeframe_seconds": self.timeframe_seconds,
+            "sample_size": self.sample_size,
+            "category": self.category,
+        }
+
+
+@dataclass
+class SimulationResult:
+    """Simulation/paper trading result.
+
+    Tracks hypothetical performance without real capital.
+    """
+
+    simulation_id: str
+    timestamp: datetime = field(default_factory=_utc_now)
+
+    # Simulation period
+    start_time: Optional[datetime] = None
+    end_time: Optional[datetime] = None
+
+    # Performance
+    total_trades: int = 0
+    winning_trades: int = 0
+    losing_trades: int = 0
+    win_rate: float = 0.0
+
+    # Returns (simulated)
+    simulated_pnl_percent: float = 0.0
+    simulated_max_drawdown_percent: float = 0.0
+    simulated_sharpe_ratio: Optional[float] = None
+
+    # Risk metrics
+    average_risk_score: float = 0.0
+    honeypot_avoidance_rate: float = 0.0
+    false_positive_rate: float = 0.0
+
+    # Model performance
+    model_id: Optional[str] = None
+    model_latency_ms: Optional[float] = None
+    valid_json_rate: float = 1.0
+
+    # Truth boundary
+    is_simulation: bool = True  # MUST be True
+    real_capital_used: bool = False  # MUST be False in Phase 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "simulation_id": self.simulation_id,
+            "timestamp": self.timestamp.isoformat(),
+            "start_time": self.start_time.isoformat() if self.start_time else None,
+            "end_time": self.end_time.isoformat() if self.end_time else None,
+            "total_trades": self.total_trades,
+            "winning_trades": self.winning_trades,
+            "losing_trades": self.losing_trades,
+            "win_rate": self.win_rate,
+            "simulated_pnl_percent": self.simulated_pnl_percent,
+            "simulated_max_drawdown_percent": self.simulated_max_drawdown_percent,
+            "simulated_sharpe_ratio": self.simulated_sharpe_ratio,
+            "average_risk_score": self.average_risk_score,
+            "honeypot_avoidance_rate": self.honeypot_avoidance_rate,
+            "false_positive_rate": self.false_positive_rate,
+            "model_id": self.model_id,
+            "model_latency_ms": self.model_latency_ms,
+            "valid_json_rate": self.valid_json_rate,
+            "is_simulation": self.is_simulation,
+            "real_capital_used": self.real_capital_used,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Execution Guard
+# ---------------------------------------------------------------------------
+
+
+class UnsupportedOperationError(Exception):
+    """Raised when an unsupported operation is attempted."""
+    pass
+
+
+@dataclass
+class ExecutionGuardPolicy:
+    """Execution guard policy for Phase 0.
+
+    Defines what operations are blocked in no-money mode.
+    """
+
+    policy_id: str = "phase0_no_money"
+
+    # Global flags
+    no_money_mode: bool = True  # MUST be True
+    dry_run_mode: bool = True  # MUST be True
+
+    # Blocked operations (all True = blocked)
+    block_real_trades: bool = True
+    block_wallet_signing: bool = True
+    block_private_keys: bool = True
+    block_order_placement: bool = True
+    block_capital_deployment: bool = True
+    block_wash_trading: bool = True
+    block_market_manipulation: bool = True
+    block_bot_concealment: bool = True
+    block_fake_volume: bool = True
+
+    def assert_operation_allowed(self, operation: str) -> None:
+        """Raise UnsupportedOperationError if operation is blocked."""
+        blocked_operations = {
+            "real_trade": self.block_real_trades,
+            "wallet_sign": self.block_wallet_signing,
+            "private_key_access": self.block_private_keys,
+            "order_place": self.block_order_placement,
+            "capital_deploy": self.block_capital_deployment,
+            "wash_trade": self.block_wash_trading,
+            "market_manipulate": self.block_market_manipulation,
+            "conceal_bot": self.block_bot_concealment,
+            "fake_volume": self.block_fake_volume,
+        }
+
+        if operation in blocked_operations and blocked_operations[operation]:
+            raise UnsupportedOperationError(
+                f"Operation '{operation}' is blocked in {self.policy_id} mode. "
+                "Trade FoundUp Phase 0 does not support execution operations."
+            )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "policy_id": self.policy_id,
+            "no_money_mode": self.no_money_mode,
+            "dry_run_mode": self.dry_run_mode,
+            "block_real_trades": self.block_real_trades,
+            "block_wallet_signing": self.block_wallet_signing,
+            "block_private_keys": self.block_private_keys,
+            "block_order_placement": self.block_order_placement,
+            "block_capital_deployment": self.block_capital_deployment,
+            "block_wash_trading": self.block_wash_trading,
+            "block_market_manipulation": self.block_market_manipulation,
+            "block_bot_concealment": self.block_bot_concealment,
+            "block_fake_volume": self.block_fake_volume,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Default Instances
+# ---------------------------------------------------------------------------
+
+# Default execution guard for Phase 0
+DEFAULT_EXECUTION_GUARD = ExecutionGuardPolicy()
+
+# Default truth fields for Phase 0
+DEFAULT_TRUTH_FIELDS = TruthFields()

--- a/modules/foundups/trade/tests/TestModLog.md
+++ b/modules/foundups/trade/tests/TestModLog.md
@@ -1,0 +1,41 @@
+# Trade FoundUp - Test ModLog
+
+## Test Change Log
+
+### [2026-05-04] - TRADE_FOUNDUP_INTERNAL_SEED_PHASE1 (v0.1.0)
+
+**WSP Protocol References**: WSP 97 (Truth), WSP 104 (Namespace)
+
+#### Tests Added
+
+**test_manifest_contract.py** — Manifest validation (15 tests):
+- TestTradeManifestExists: file exists, valid JSON
+- TestTradeManifestFields: foundup_id, routing_prefix, data_namespace, lifecycle_stage, tier, launch_readiness, is_invite_only, entry_url, subscription_tier, cabr_contract
+- TestTradeManifestCapabilities: capabilities present, no execution capabilities
+- TestTradeManifestAgentRoutes: query-only routes
+
+**test_trade_contracts.py** — Contract serialization (40+ tests):
+- TestTruthFields: all defaults False/True, assert_no_execution, to_dict
+- TestExecutionGuardPolicy: all 9 blocked operations, unknown passes, to_dict
+- TestAdapterSpecs: MarketAdapterSpec, LaunchpadAdapterSpec, live_execution_enabled
+- TestEventSchemas: MarketEvent, TokenEvent, WalletEvent, SocialEvent, RiskEvent
+- TestSignalSchemas: TradeSignal, ExitSignal simulation defaults
+- TestProofSchemas: ProofMetric, SimulationResult no real capital
+- TestJsonSerialization: all contracts serialize to valid JSON
+- TestDefaultInstances: DEFAULT_TRUTH_FIELDS, DEFAULT_EXECUTION_GUARD
+
+#### Verification
+
+```bash
+python -m pytest modules/foundups/trade/tests -q
+# Expected: 55+ passed
+
+python -m pytest modules/foundups/tests/test_namespace_guardrail.py -q
+# Verifies trade namespace integration
+```
+
+---
+
+## Future Entries
+
+Next slice: `TRADE_FOUNDUP_ADAPTER_CONTRACTS_PHASE2`

--- a/modules/foundups/trade/tests/__init__.py
+++ b/modules/foundups/trade/tests/__init__.py
@@ -1,0 +1,6 @@
+"""Trade FoundUp Tests
+
+WSP References:
+- WSP 97: Truth Boundaries
+- WSP 104: FoundUp Route Namespace
+"""

--- a/modules/foundups/trade/tests/test_manifest_contract.py
+++ b/modules/foundups/trade/tests/test_manifest_contract.py
@@ -1,0 +1,154 @@
+"""Trade FoundUp Manifest Contract Tests
+
+Validates that Trade's foundup_manifest.json meets the canonical pfMALL
+FoundUp contract requirements for shell integration.
+
+WSP References:
+- WSP 97: System Execution Prompting Protocol (truth boundaries)
+- WSP 104: FoundUp Route Namespace and Tenant Isolation Protocol
+
+Contract: modules/foundups/docs/FOUNDUP_AI_HOOKS_AND_DAEMON_SURFACE_CONTRACT.md
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+MODULE_ROOT = Path(__file__).parent.parent
+MANIFEST_PATH = MODULE_ROOT / "foundup_manifest.json"
+
+
+class TestTradeManifestExists:
+    """Trade must have a valid foundup_manifest.json."""
+
+    def test_trade_manifest_exists(self):
+        """foundup_manifest.json exists at module root."""
+        assert MANIFEST_PATH.is_file(), f"Expected {MANIFEST_PATH} to exist"
+
+    def test_trade_manifest_valid_json(self):
+        """foundup_manifest.json is valid JSON."""
+        with open(MANIFEST_PATH, encoding="utf-8") as f:
+            data = json.load(f)
+        assert isinstance(data, dict), "Manifest must be a JSON object"
+
+
+class TestTradeManifestFields:
+    """Trade manifest must have required fields for pfMALL integration."""
+
+    @pytest.fixture
+    def manifest(self):
+        """Load the Trade manifest."""
+        with open(MANIFEST_PATH, encoding="utf-8") as f:
+            return json.load(f)
+
+    def test_trade_foundup_id(self, manifest):
+        """foundup_id must be 'trade'."""
+        assert manifest.get("foundup_id") == "trade"
+
+    def test_trade_routing_prefix_canonical(self, manifest):
+        """routing_prefix must follow WSP 104 canonical format.
+
+        WSP 104: /f/{foundup_id} is the canonical FoundUp landing namespace.
+        """
+        routing_prefix = manifest.get("routing_prefix")
+        assert routing_prefix == "/f/trade", (
+            f"routing_prefix must be '/f/trade', got '{routing_prefix}'"
+        )
+
+    def test_trade_data_namespace_valid(self, manifest):
+        """data_namespace must follow idb_{foundup_id} convention.
+
+        WSP 104: Tenant isolation requires scoped IndexedDB namespace.
+        """
+        data_namespace = manifest.get("data_namespace")
+        assert data_namespace == "idb_trade", (
+            f"data_namespace must be 'idb_trade', got '{data_namespace}'"
+        )
+
+    def test_trade_lifecycle_stage_incubating(self, manifest):
+        """lifecycle_stage must be 'incubating' for Phase 0."""
+        assert manifest.get("lifecycle_stage") == "incubating"
+
+    def test_trade_tier_f0_dae(self, manifest):
+        """tier must be 'F0_DAE' for internal seed."""
+        assert manifest.get("tier") == "F0_DAE"
+
+    def test_trade_launch_readiness_discoverable_only(self, manifest):
+        """launch_readiness must be 'discoverable_only' for Phase 0."""
+        assert manifest.get("launch_readiness") == "discoverable_only"
+
+    def test_trade_is_invite_only(self, manifest):
+        """is_invite_only must be true for F0_DAE."""
+        assert manifest.get("is_invite_only") is True
+
+    def test_trade_entry_url_null(self, manifest):
+        """entry_url should be null for incubating FoundUp.
+
+        WSP 97 truth boundary: No deployed app yet.
+        """
+        assert manifest.get("entry_url") is None
+
+    def test_trade_required_subscription_tier_free(self, manifest):
+        """required_subscription_tier should be 'free' for incubating."""
+        assert manifest.get("required_subscription_tier") == "free"
+
+    def test_trade_cabr_contract_default(self, manifest):
+        """cabr_contract should have default values."""
+        cabr = manifest.get("cabr_contract", {})
+        assert cabr.get("v1_gate") == "default"
+        assert cabr.get("v2_proof") == "default"
+        assert cabr.get("v3_score_min") == 0.5
+
+
+class TestTradeManifestCapabilities:
+    """Trade capabilities should be intelligence/simulation focused."""
+
+    @pytest.fixture
+    def manifest(self):
+        """Load the Trade manifest."""
+        with open(MANIFEST_PATH, encoding="utf-8") as f:
+            return json.load(f)
+
+    def test_trade_capabilities_present(self, manifest):
+        """capabilities must be present and non-empty."""
+        capabilities = manifest.get("capabilities")
+        assert capabilities is not None
+        assert isinstance(capabilities, list)
+        assert len(capabilities) > 0
+
+    def test_trade_no_execution_capabilities(self, manifest):
+        """capabilities must NOT include execution-related terms.
+
+        WSP 97 truth boundary: No real trading capabilities in Phase 0.
+        """
+        capabilities = manifest.get("capabilities", [])
+        execution_terms = [
+            "execution", "trading", "order", "wallet", "signing",
+            "deposit", "withdraw", "swap"
+        ]
+        for cap in capabilities:
+            for term in execution_terms:
+                assert term not in cap.lower(), (
+                    f"Capability '{cap}' implies execution (contains '{term}')"
+                )
+
+
+class TestTradeManifestAgentRoutes:
+    """Trade agent_routes should be query-only in Phase 0."""
+
+    @pytest.fixture
+    def manifest(self):
+        """Load the Trade manifest."""
+        with open(MANIFEST_PATH, encoding="utf-8") as f:
+            return json.load(f)
+
+    def test_trade_agent_routes_query_only(self, manifest):
+        """agent_routes should only include query routes in Phase 0."""
+        routes = manifest.get("agent_routes", [])
+        # Query routes are safe
+        safe_routes = ["openclaw_query", "openclaw_search"]
+
+        for route in routes:
+            assert route in safe_routes, (
+                f"Route '{route}' may imply execution capability"
+            )

--- a/modules/foundups/trade/tests/test_trade_contracts.py
+++ b/modules/foundups/trade/tests/test_trade_contracts.py
@@ -1,0 +1,415 @@
+"""Trade FoundUp Contract Tests
+
+Tests for typed contracts in src/contracts.py.
+
+WSP References:
+- WSP 97: Truth Boundaries (all execution fields False)
+- WSP 11: Interface Protocol (contracts serialize correctly)
+"""
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+import sys
+from pathlib import Path
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from contracts import (
+    TruthFields,
+    MarketAdapterSpec,
+    LaunchpadAdapterSpec,
+    AdapterStatus,
+    MarketEvent,
+    TokenEvent,
+    WalletEvent,
+    SocialEvent,
+    RiskEvent,
+    TradeSignal,
+    ExitSignal,
+    ProofMetric,
+    SimulationResult,
+    ExecutionGuardPolicy,
+    UnsupportedOperationError,
+    DEFAULT_TRUTH_FIELDS,
+    DEFAULT_EXECUTION_GUARD,
+)
+
+
+class TestTruthFields:
+    """WSP 97 truth fields must default to no-execution state."""
+
+    def test_default_dry_run_mode_true(self):
+        """dry_run_mode defaults to True."""
+        tf = TruthFields()
+        assert tf.dry_run_mode is True
+
+    def test_default_no_money_mode_true(self):
+        """no_money_mode defaults to True."""
+        tf = TruthFields()
+        assert tf.no_money_mode is True
+
+    def test_default_real_execution_performed_false(self):
+        """real_execution_performed defaults to False."""
+        tf = TruthFields()
+        assert tf.real_execution_performed is False
+
+    def test_default_verification_complete_false(self):
+        """verification_complete defaults to False."""
+        tf = TruthFields()
+        assert tf.verification_complete is False
+
+    def test_default_cabr_ready_false(self):
+        """cabr_ready defaults to False."""
+        tf = TruthFields()
+        assert tf.cabr_ready is False
+
+    def test_default_payout_ready_false(self):
+        """payout_ready defaults to False."""
+        tf = TruthFields()
+        assert tf.payout_ready is False
+
+    def test_assert_no_execution_passes_on_defaults(self):
+        """assert_no_execution passes with default values."""
+        tf = TruthFields()
+        # Should not raise
+        tf.assert_no_execution()
+
+    def test_assert_no_execution_fails_on_real_execution(self):
+        """assert_no_execution fails if real_execution_performed is True."""
+        tf = TruthFields(real_execution_performed=True)
+        with pytest.raises(AssertionError):
+            tf.assert_no_execution()
+
+    def test_to_dict_serializes_all_fields(self):
+        """to_dict includes all truth fields."""
+        tf = TruthFields()
+        d = tf.to_dict()
+        assert "dry_run_mode" in d
+        assert "no_money_mode" in d
+        assert "real_execution_performed" in d
+        assert "verification_complete" in d
+        assert "cabr_ready" in d
+        assert "payout_ready" in d
+
+
+class TestExecutionGuardPolicy:
+    """Execution guard must block all execution operations."""
+
+    def test_default_no_money_mode_true(self):
+        """no_money_mode defaults to True."""
+        guard = ExecutionGuardPolicy()
+        assert guard.no_money_mode is True
+
+    def test_default_dry_run_mode_true(self):
+        """dry_run_mode defaults to True."""
+        guard = ExecutionGuardPolicy()
+        assert guard.dry_run_mode is True
+
+    def test_block_real_trades(self):
+        """Real trades are blocked."""
+        guard = ExecutionGuardPolicy()
+        with pytest.raises(UnsupportedOperationError):
+            guard.assert_operation_allowed("real_trade")
+
+    def test_block_wallet_signing(self):
+        """Wallet signing is blocked."""
+        guard = ExecutionGuardPolicy()
+        with pytest.raises(UnsupportedOperationError):
+            guard.assert_operation_allowed("wallet_sign")
+
+    def test_block_private_key_access(self):
+        """Private key access is blocked."""
+        guard = ExecutionGuardPolicy()
+        with pytest.raises(UnsupportedOperationError):
+            guard.assert_operation_allowed("private_key_access")
+
+    def test_block_order_placement(self):
+        """Order placement is blocked."""
+        guard = ExecutionGuardPolicy()
+        with pytest.raises(UnsupportedOperationError):
+            guard.assert_operation_allowed("order_place")
+
+    def test_block_capital_deployment(self):
+        """Capital deployment is blocked."""
+        guard = ExecutionGuardPolicy()
+        with pytest.raises(UnsupportedOperationError):
+            guard.assert_operation_allowed("capital_deploy")
+
+    def test_block_wash_trading(self):
+        """Wash trading is blocked."""
+        guard = ExecutionGuardPolicy()
+        with pytest.raises(UnsupportedOperationError):
+            guard.assert_operation_allowed("wash_trade")
+
+    def test_block_market_manipulation(self):
+        """Market manipulation is blocked."""
+        guard = ExecutionGuardPolicy()
+        with pytest.raises(UnsupportedOperationError):
+            guard.assert_operation_allowed("market_manipulate")
+
+    def test_block_bot_concealment(self):
+        """Bot concealment is blocked."""
+        guard = ExecutionGuardPolicy()
+        with pytest.raises(UnsupportedOperationError):
+            guard.assert_operation_allowed("conceal_bot")
+
+    def test_block_fake_volume(self):
+        """Fake volume is blocked."""
+        guard = ExecutionGuardPolicy()
+        with pytest.raises(UnsupportedOperationError):
+            guard.assert_operation_allowed("fake_volume")
+
+    def test_unknown_operation_passes(self):
+        """Unknown operations pass (not in block list)."""
+        guard = ExecutionGuardPolicy()
+        # Should not raise
+        guard.assert_operation_allowed("unknown_operation")
+
+    def test_to_dict_serializes(self):
+        """to_dict serializes all fields."""
+        guard = ExecutionGuardPolicy()
+        d = guard.to_dict()
+        assert d["no_money_mode"] is True
+        assert d["dry_run_mode"] is True
+        assert d["block_real_trades"] is True
+
+
+class TestAdapterSpecs:
+    """Adapter specs must serialize correctly."""
+
+    def test_market_adapter_spec_to_dict(self):
+        """MarketAdapterSpec serializes to dict."""
+        spec = MarketAdapterSpec(
+            adapter_id="solana",
+            chain_or_exchange="solana",
+            display_name="Solana",
+            status=AdapterStatus.PLANNED,
+        )
+        d = spec.to_dict()
+        assert d["adapter_id"] == "solana"
+        assert d["status"] == "planned"
+        assert d["live_execution_enabled"] is False
+
+    def test_launchpad_adapter_spec_to_dict(self):
+        """LaunchpadAdapterSpec serializes to dict."""
+        spec = LaunchpadAdapterSpec(
+            adapter_id="pumpfun",
+            platform_name="pump.fun",
+            chain="solana",
+            display_name="Pump.fun",
+            status=AdapterStatus.PLANNED,
+        )
+        d = spec.to_dict()
+        assert d["adapter_id"] == "pumpfun"
+        assert d["platform_name"] == "pump.fun"
+        assert d["live_execution_enabled"] is False
+
+    def test_adapter_live_execution_default_false(self):
+        """live_execution_enabled defaults to False."""
+        market = MarketAdapterSpec(
+            adapter_id="test",
+            chain_or_exchange="test",
+            display_name="Test",
+        )
+        launchpad = LaunchpadAdapterSpec(
+            adapter_id="test",
+            platform_name="test",
+            chain="test",
+            display_name="Test",
+        )
+        assert market.live_execution_enabled is False
+        assert launchpad.live_execution_enabled is False
+
+
+class TestEventSchemas:
+    """Event schemas must serialize to dict/JSON."""
+
+    def test_market_event_to_dict(self):
+        """MarketEvent serializes to dict."""
+        event = MarketEvent(
+            event_id="evt_123",
+            event_type="price_update",
+            adapter_id="solana",
+            chain="solana",
+            price_usd=0.001,
+        )
+        d = event.to_dict()
+        assert d["event_id"] == "evt_123"
+        assert d["price_usd"] == 0.001
+        assert "timestamp" in d
+
+    def test_token_event_to_dict(self):
+        """TokenEvent serializes to dict."""
+        event = TokenEvent(
+            event_id="evt_456",
+            event_type="token_created",
+            adapter_id="pumpfun",
+            chain="solana",
+            token_symbol="MEME",
+        )
+        d = event.to_dict()
+        assert d["token_symbol"] == "MEME"
+
+    def test_wallet_event_to_dict(self):
+        """WalletEvent serializes to dict."""
+        event = WalletEvent(
+            event_id="evt_789",
+            event_type="buy",
+            adapter_id="solana",
+            chain="solana",
+            wallet_cluster_id="cluster_abc",
+        )
+        d = event.to_dict()
+        assert d["wallet_cluster_id"] == "cluster_abc"
+
+    def test_social_event_to_dict(self):
+        """SocialEvent serializes to dict."""
+        event = SocialEvent(
+            event_id="evt_social",
+            event_type="mention",
+            source="twitter",
+            sentiment_score=0.8,
+        )
+        d = event.to_dict()
+        assert d["sentiment_score"] == 0.8
+
+    def test_risk_event_to_dict(self):
+        """RiskEvent serializes to dict."""
+        event = RiskEvent(
+            event_id="evt_risk",
+            event_type="honeypot_detected",
+            overall_risk_score=0.95,
+            is_honeypot=True,
+        )
+        d = event.to_dict()
+        assert d["overall_risk_score"] == 0.95
+        assert d["is_honeypot"] is True
+
+
+class TestSignalSchemas:
+    """Signal schemas must default to simulation mode."""
+
+    def test_trade_signal_is_simulation_default_true(self):
+        """TradeSignal.is_simulation defaults to True."""
+        signal = TradeSignal(
+            signal_id="sig_123",
+            signal_type="entry",
+        )
+        assert signal.is_simulation is True
+
+    def test_exit_signal_is_simulation_default_true(self):
+        """ExitSignal.is_simulation defaults to True."""
+        signal = ExitSignal(
+            signal_id="sig_456",
+            signal_type="exit",
+        )
+        assert signal.is_simulation is True
+
+    def test_trade_signal_to_dict(self):
+        """TradeSignal serializes to dict."""
+        signal = TradeSignal(
+            signal_id="sig_123",
+            signal_type="entry",
+            confidence=0.85,
+        )
+        d = signal.to_dict()
+        assert d["confidence"] == 0.85
+        assert d["is_simulation"] is True
+
+    def test_exit_signal_to_dict(self):
+        """ExitSignal serializes to dict."""
+        signal = ExitSignal(
+            signal_id="sig_456",
+            signal_type="stop_loss",
+            urgency="critical",
+        )
+        d = signal.to_dict()
+        assert d["urgency"] == "critical"
+
+
+class TestProofSchemas:
+    """Proof schemas must serialize correctly."""
+
+    def test_proof_metric_to_dict(self):
+        """ProofMetric serializes to dict."""
+        metric = ProofMetric(
+            metric_id="metric_123",
+            metric_type="detection_latency",
+            value=150.0,
+            unit="ms",
+            category="latency",
+        )
+        d = metric.to_dict()
+        assert d["value"] == 150.0
+        assert d["unit"] == "ms"
+
+    def test_simulation_result_default_no_real_capital(self):
+        """SimulationResult.real_capital_used defaults to False."""
+        result = SimulationResult(
+            simulation_id="sim_123",
+        )
+        assert result.real_capital_used is False
+        assert result.is_simulation is True
+
+    def test_simulation_result_to_dict(self):
+        """SimulationResult serializes to dict."""
+        result = SimulationResult(
+            simulation_id="sim_123",
+            total_trades=100,
+            win_rate=0.55,
+            simulated_pnl_percent=25.0,
+        )
+        d = result.to_dict()
+        assert d["win_rate"] == 0.55
+        assert d["real_capital_used"] is False
+
+
+class TestJsonSerialization:
+    """All contracts must serialize to valid JSON."""
+
+    def test_truth_fields_json(self):
+        """TruthFields serializes to valid JSON."""
+        tf = TruthFields()
+        json_str = json.dumps(tf.to_dict())
+        assert json.loads(json_str)
+
+    def test_execution_guard_json(self):
+        """ExecutionGuardPolicy serializes to valid JSON."""
+        guard = ExecutionGuardPolicy()
+        json_str = json.dumps(guard.to_dict())
+        assert json.loads(json_str)
+
+    def test_market_event_json(self):
+        """MarketEvent serializes to valid JSON."""
+        event = MarketEvent(
+            event_id="test",
+            event_type="test",
+            adapter_id="test",
+            chain="test",
+        )
+        json_str = json.dumps(event.to_dict())
+        assert json.loads(json_str)
+
+    def test_simulation_result_json(self):
+        """SimulationResult serializes to valid JSON."""
+        result = SimulationResult(simulation_id="test")
+        json_str = json.dumps(result.to_dict())
+        assert json.loads(json_str)
+
+
+class TestDefaultInstances:
+    """Default instances must have correct values."""
+
+    def test_default_truth_fields(self):
+        """DEFAULT_TRUTH_FIELDS has correct values."""
+        assert DEFAULT_TRUTH_FIELDS.dry_run_mode is True
+        assert DEFAULT_TRUTH_FIELDS.no_money_mode is True
+        assert DEFAULT_TRUTH_FIELDS.real_execution_performed is False
+
+    def test_default_execution_guard(self):
+        """DEFAULT_EXECUTION_GUARD blocks execution."""
+        with pytest.raises(UnsupportedOperationError):
+            DEFAULT_EXECUTION_GUARD.assert_operation_allowed("real_trade")


### PR DESCRIPTION
## Summary
- Add Trade FoundUp internal seed under modules/foundups/trade/
- 12 files: manifest, module.json, README, INTERFACE, ROADMAP, ModLog, contracts, tests
- WSP_97 truth boundaries enforced (dry_run=True, no_money_mode=True, all execution flags False)

## Test plan
- [x] Local tests: 58 passed (trade module)
- [x] Local tests: 23 passed (namespace guardrail)
- [ ] CI: test (3.12)
- [ ] CI: lint
- [ ] CI: security

## WSP_97 Truth Verdict
- no_money_mode: True ✓
- dry_run_mode: True ✓
- real_execution_performed: False ✓
- verification_complete: False ✓
- cabr_ready: False ✓
- payout_ready: False ✓

🤖 Generated with [Claude Code](https://claude.ai/code)