### PR TITLE
fix(holoindex): add live collection health gate

### DIFF
--- a/docs/audits/holoindex_search_quality/HIA_AGENTIC_RAG_LIVE_COLLECTION_HEALTH.md
+++ b/docs/audits/holoindex_search_quality/HIA_AGENTIC_RAG_LIVE_COLLECTION_HEALTH.md
@@ -1,0 +1,134 @@
+# HIA_AGENTIC_RAG_LIVE_COLLECTION_HEALTH_PHASE2
+
+**Date**: 2026-05-05
+**Slice**: HIA_AGENTIC_RAG_LIVE_COLLECTION_HEALTH_PHASE2
+**Status**: COMPLETE - PASS (Ready with minor degradation)
+**Author**: 0102 W1
+
+---
+
+## Live Collection Health Results
+
+**Command**: `python holo_index.py --collection-health --ssd E:/HoloIndex`
+
+```
+============================================================
+HoloIndex Collection Health Report
+============================================================
+Vector Path: E:\HoloIndex\vectors
+Overall Status: DEGRADED
+Agentic RAG Ready: YES
+Degraded: YES
+
+Collections:
+----------------------------------------
+  [OK] navigation_code: 296 docs (REQUIRED)
+  [OK] navigation_wsp: 116 docs (REQUIRED)
+  [OK] navigation_symbols: 20000 docs (REQUIRED)
+  [OK] navigation_docs: 3143 docs
+  [OK] navigation_knowledge: 47 docs
+  [EMPTY] navigation_tests: 0 docs
+  [OK] navigation_skills: 64 docs
+
+Reasons:
+----------------------------------------
+  - Optional collection 'navigation_tests' is empty
+============================================================
+```
+
+---
+
+## Collection Counts Observed
+
+| Collection | Count | Status | Required |
+|------------|-------|--------|----------|
+| navigation_code | 296 | HEALTHY | YES |
+| navigation_wsp | 116 | HEALTHY | YES |
+| navigation_symbols | 20,000 | HEALTHY | YES |
+| navigation_docs | 3,143 | HEALTHY | NO |
+| navigation_knowledge | 47 | HEALTHY | NO |
+| navigation_tests | 0 | EMPTY | NO |
+| navigation_skills | 64 | HEALTHY | NO |
+
+**Total Indexed Documents**: 23,666
+
+---
+
+## Agentic RAG Readiness
+
+| Criterion | Status |
+|-----------|--------|
+| All required collections present | YES |
+| Required collections have counts > 0 | YES |
+| navigation_code | 296 docs |
+| navigation_wsp | 116 docs |
+| navigation_symbols | 20,000 docs |
+
+**Verdict**: **AGENTIC_RAG_READY = TRUE**
+
+---
+
+## Degradation Analysis
+
+| Issue | Severity | Impact |
+|-------|----------|--------|
+| navigation_tests empty | LOW | Test file search unavailable |
+
+The degradation is minor - test collection indexing is optional and doesn't affect core Agentic RAG functionality (code/WSP/docs/knowledge search).
+
+---
+
+## Files Added/Modified
+
+| File | Change |
+|------|--------|
+| `holo_index/core/collection_health.py` | NEW - Collection health helper |
+| `holo_index/tests/test_collection_health.py` | NEW - 18 tests |
+| `holo_index/_cli_main.py` | MODIFIED - Added `--collection-health` flags |
+| `docs/audits/holoindex_search_quality/HIA_AGENTIC_RAG_LIVE_COLLECTION_HEALTH.md` | NEW - This audit |
+
+---
+
+## CLI Usage
+
+```bash
+# Human-readable report
+python holo_index.py --collection-health --ssd E:/HoloIndex
+
+# JSON output (for automation)
+python holo_index.py --collection-health-json --ssd E:/HoloIndex
+```
+
+---
+
+## WSP 97 Truth Boundaries
+
+| Statement | Status |
+|-----------|--------|
+| Unit tests use mocks (stated in docstring) | TRUE |
+| Live counts reported separately | TRUE |
+| Empty navigation_tests is optional | TRUE |
+| Agentic RAG ready based on required collections only | TRUE |
+| Degraded status reflects optional collection gaps | TRUE |
+
+---
+
+## Next Action
+
+**navigation_tests is empty** - If test file search is desired, run:
+
+```bash
+python holo_index.py --index-tests --ssd E:/HoloIndex
+```
+
+However, this is **optional** for Agentic RAG readiness.
+
+---
+
+## Next Slice
+
+Since Agentic RAG is ready (all required collections healthy):
+
+**HIA_AGENTIC_RAG_SENTINEL_SUFFICIENCY_PHASE3**
+
+Goal: Wire verdict helper into sentinel query tests to verify that WSP-intent queries actually return WSP hits (not just code hits).

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,58 @@
 # HoloIndex Package ModLog
 
+## [2026-05-05] HIA_AGENTIC_RAG_LIVE_COLLECTION_HEALTH_PHASE2 — Collection Health CLI
+
+**Agent**: 0102 (W1)
+**WSP References**: WSP 87 (Size Limits), WSP 97 (Truth Boundaries)
+**Status**: COMPLETE - PASS (Ready with minor degradation)
+
+### Summary
+
+Added collection health inspection to verify Agentic RAG readiness before federation or TurboQuant work.
+
+### Live Collection Counts (E:/HoloIndex)
+
+| Collection | Count | Status |
+|------------|-------|--------|
+| navigation_code | 296 | HEALTHY |
+| navigation_wsp | 116 | HEALTHY |
+| navigation_symbols | 20,000 | HEALTHY |
+| navigation_docs | 3,143 | HEALTHY |
+| navigation_knowledge | 47 | HEALTHY |
+| navigation_tests | 0 | EMPTY |
+| navigation_skills | 64 | HEALTHY |
+
+**Agentic RAG Ready**: YES (all required collections healthy)
+**Degraded**: YES (navigation_tests empty - optional)
+
+### Files Added
+
+| File | Purpose |
+|------|---------|
+| `holo_index/core/collection_health.py` | Collection health helper |
+| `holo_index/tests/test_collection_health.py` | 18 tests |
+| `docs/audits/holoindex_search_quality/HIA_AGENTIC_RAG_LIVE_COLLECTION_HEALTH.md` | Live audit |
+
+### CLI Flags Added
+
+```bash
+python holo_index.py --collection-health --ssd E:/HoloIndex       # Human-readable
+python holo_index.py --collection-health-json --ssd E:/HoloIndex  # JSON
+```
+
+### Test Results
+
+- `test_collection_health.py`: 18/18 passed
+- `test_agentic_rag_baseline_gate.py`: 24/24 passed
+- `test_search_quality_baseline.py`: 10/10 passed
+- `git diff --check`: clean
+
+### Next Slice
+
+HIA_AGENTIC_RAG_SENTINEL_SUFFICIENCY_PHASE3
+
+---
+
 ## [2026-05-05] HIA_AGENTIC_RAG_BASELINE_GATE_PHASE1 — Verdict Helper Added
 
 **Agent**: 0102 (W1)

--- a/holo_index/_cli_main.py
+++ b/holo_index/_cli_main.py
@@ -678,6 +678,10 @@ def main():
     parser.add_argument('--monitor-work', action='store_true', help='Monitor work completion for auto-publish (ai_intelligence/work_completion_publisher)')
     parser.add_argument('--organize-docs', action='store_true', help='Allow DocDAE to reorganize docs during auto-refresh')
 
+    # Agentic RAG collection health (HIA_AGENTIC_RAG_LIVE_COLLECTION_HEALTH_PHASE2)
+    parser.add_argument('--collection-health', action='store_true', help='Inspect collection health for Agentic RAG readiness')
+    parser.add_argument('--collection-health-json', action='store_true', help='Output collection health as JSON')
+
     args = parser.parse_args()
 
     # --- Bundle JSON (extracted to holo_index/cli/commands/bundle_json.py) ---
@@ -1509,6 +1513,19 @@ def main():
     if args.benchmark:
         holo.benchmark_ssd()
 
+    # --- Collection Health (HIA_AGENTIC_RAG_LIVE_COLLECTION_HEALTH_PHASE2) ---
+    if args.collection_health or args.collection_health_json:
+        from holo_index.core.collection_health import (
+            inspect_holoindex_collection_health,
+            format_health_report,
+        )
+        report = inspect_holoindex_collection_health(holo)
+        if args.collection_health_json:
+            safe_print(report.to_json())
+        else:
+            safe_print(format_health_report(report))
+        return
+
     # --- HoloDAE features (extracted to holo_index/cli/commands/holodae.py) ---
     from holo_index.cli.commands.holodae import handle_holodae_features
     if handle_holodae_features(args, safe_print, project_root):
@@ -1516,7 +1533,8 @@ def main():
 
     if not any([index_code, index_wsp, args.search, args.benchmark, args.start_holodae, args.stop_holodae, args.holodae_status, args.link_modules,
                 args.pattern_coach, args.module_analysis, args.health_check, args.performance_metrics, args.system_check, args.slow_mode,
-                args.pattern_memory, args.mcp_hooks, args.mcp_log, args.thought_log, args.monitor_work, args.memory_feedback]):
+                args.pattern_memory, args.mcp_hooks, args.mcp_log, args.thought_log, args.monitor_work, args.memory_feedback,
+                args.collection_health, args.collection_health_json]):
         safe_print("\n[USAGE] Usage:")
         safe_print("  python holo_index.py --index-all             # Index NAVIGATION + WSP")
         safe_print("  python holo_index.py --index-code            # Index NAVIGATION only")

--- a/holo_index/core/collection_health.py
+++ b/holo_index/core/collection_health.py
@@ -1,0 +1,302 @@
+# -*- coding: utf-8 -*-
+"""Collection Health Helper — HIA_AGENTIC_RAG_LIVE_COLLECTION_HEALTH_PHASE2
+
+Inspects HoloIndex collection health to determine Agentic RAG readiness.
+
+WSP 97: Reports truthfully. Missing/empty collections are reported as-is.
+If collection access fails, report UNKNOWN rather than assume healthy.
+
+WSP 87: Keep helper small. Do not refactor indexing engine.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, asdict
+from enum import Enum
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .holo_index import HoloIndex
+
+
+class CollectionHealthStatus(Enum):
+    """Health status for a single collection."""
+
+    HEALTHY = "healthy"
+    """Collection exists and has documents."""
+
+    EMPTY = "empty"
+    """Collection exists but has no documents."""
+
+    MISSING = "missing"
+    """Collection does not exist."""
+
+    DEGRADED = "degraded"
+    """Collection exists but may have issues (low count, stale, etc.)."""
+
+    UNKNOWN = "unknown"
+    """Could not determine collection status (access error)."""
+
+
+@dataclass
+class CollectionHealth:
+    """Health status for a single collection."""
+
+    name: str
+    count: int = 0
+    status: CollectionHealthStatus = CollectionHealthStatus.UNKNOWN
+    required_for_agentic_rag: bool = False
+    reason: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to JSON-serializable dict."""
+        return {
+            "name": self.name,
+            "count": self.count,
+            "status": self.status.value,
+            "required_for_agentic_rag": self.required_for_agentic_rag,
+            "reason": self.reason,
+        }
+
+
+@dataclass
+class HoloIndexHealthReport:
+    """Overall HoloIndex health report for Agentic RAG readiness."""
+
+    vector_path: str
+    collections: List[CollectionHealth] = field(default_factory=list)
+    overall_status: CollectionHealthStatus = CollectionHealthStatus.UNKNOWN
+    agentic_rag_ready: bool = False
+    degraded: bool = False
+    reasons: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to JSON-serializable dict."""
+        return {
+            "vector_path": self.vector_path,
+            "collections": [c.to_dict() for c in self.collections],
+            "overall_status": self.overall_status.value,
+            "agentic_rag_ready": self.agentic_rag_ready,
+            "degraded": self.degraded,
+            "reasons": self.reasons,
+        }
+
+    def to_json(self, indent: int = 2) -> str:
+        """Convert to JSON string."""
+        return json.dumps(self.to_dict(), indent=indent)
+
+
+# Collection requirements for Agentic RAG
+# WSP 97: These are the truth boundaries for readiness
+REQUIRED_COLLECTIONS = {
+    "navigation_code": True,      # Required for code search
+    "navigation_wsp": True,       # Required for WSP retrieval
+    "navigation_symbols": True,   # Required for symbol lookup
+}
+
+OPTIONAL_COLLECTIONS = {
+    "navigation_docs": False,       # Optional but recommended
+    "navigation_knowledge": False,  # Optional but recommended
+    "navigation_tests": False,      # Optional
+    "navigation_skills": False,     # Optional
+}
+
+ALL_EXPECTED_COLLECTIONS = {**REQUIRED_COLLECTIONS, **OPTIONAL_COLLECTIONS}
+
+
+def _get_collection_count(holo: "HoloIndex", collection_name: str) -> tuple[int, CollectionHealthStatus, str]:
+    """Get count for a collection, returning (count, status, reason).
+
+    Returns:
+        Tuple of (count, status, reason).
+        - count: Document count or 0 if unavailable
+        - status: CollectionHealthStatus
+        - reason: Human-readable explanation
+    """
+    try:
+        # Try to get collection from holo instance
+        collection = None
+
+        # Map collection names to attributes
+        attr_map = {
+            "navigation_code": "code_collection",
+            "navigation_wsp": "wsp_collection",
+            "navigation_tests": "test_collection",
+            "navigation_skills": "skill_collection",
+            "navigation_symbols": "symbol_collection",
+            "navigation_docs": "docs_collection",
+            "navigation_knowledge": "knowledge_collection",
+        }
+
+        attr_name = attr_map.get(collection_name)
+        if attr_name:
+            collection = getattr(holo, attr_name, None)
+
+        if collection is None:
+            # Collection attribute is None - try direct client access
+            client = getattr(holo, "client", None)
+            if client:
+                try:
+                    collection = client.get_collection(collection_name)
+                except Exception:
+                    return (0, CollectionHealthStatus.MISSING, f"Collection '{collection_name}' not found")
+            else:
+                # No client available - treat as missing (not unknown)
+                return (0, CollectionHealthStatus.MISSING, f"Collection '{collection_name}' not available")
+
+        count = collection.count()
+
+        if count == 0:
+            return (0, CollectionHealthStatus.EMPTY, f"Collection '{collection_name}' is empty")
+        elif count < 10:
+            return (count, CollectionHealthStatus.DEGRADED, f"Collection '{collection_name}' has low count ({count})")
+        else:
+            return (count, CollectionHealthStatus.HEALTHY, f"Collection '{collection_name}' healthy ({count} docs)")
+
+    except Exception as e:
+        return (0, CollectionHealthStatus.UNKNOWN, f"Error accessing '{collection_name}': {str(e)}")
+
+
+def inspect_holoindex_collection_health(holo: "HoloIndex") -> HoloIndexHealthReport:
+    """Inspect HoloIndex collection health for Agentic RAG readiness.
+
+    Args:
+        holo: HoloIndex instance to inspect
+
+    Returns:
+        HoloIndexHealthReport with collection statuses and overall assessment.
+
+    WSP 97 Rules:
+    - Missing or empty navigation_wsp => agentic_rag_ready=False
+    - Missing or empty navigation_code => DEGRADED, not ready for full RAG
+    - Missing docs/knowledge may be DEGRADED depending on use case
+    - All required collections with counts > 0 => agentic_rag_ready=True
+    - Never classify UNKNOWN as ready
+    """
+    vector_path = str(getattr(holo, "vector_path", "unknown"))
+
+    report = HoloIndexHealthReport(
+        vector_path=vector_path,
+        collections=[],
+        overall_status=CollectionHealthStatus.UNKNOWN,
+        agentic_rag_ready=False,
+        degraded=False,
+        reasons=[],
+    )
+
+    all_healthy = True
+    has_required = True
+    has_degraded = False
+
+    # Check all expected collections
+    for collection_name, required in ALL_EXPECTED_COLLECTIONS.items():
+        count, status, reason = _get_collection_count(holo, collection_name)
+
+        health = CollectionHealth(
+            name=collection_name,
+            count=count,
+            status=status,
+            required_for_agentic_rag=required,
+            reason=reason,
+        )
+        report.collections.append(health)
+
+        # Track overall status
+        if status == CollectionHealthStatus.UNKNOWN:
+            all_healthy = False
+            if required:
+                has_required = False
+                report.reasons.append(f"Required collection '{collection_name}' status unknown")
+
+        elif status == CollectionHealthStatus.MISSING:
+            all_healthy = False
+            if required:
+                has_required = False
+                report.reasons.append(f"Required collection '{collection_name}' is missing")
+            else:
+                has_degraded = True
+                report.reasons.append(f"Optional collection '{collection_name}' is missing")
+
+        elif status == CollectionHealthStatus.EMPTY:
+            all_healthy = False
+            if required:
+                has_required = False
+                report.reasons.append(f"Required collection '{collection_name}' is empty")
+            else:
+                has_degraded = True
+                report.reasons.append(f"Optional collection '{collection_name}' is empty")
+
+        elif status == CollectionHealthStatus.DEGRADED:
+            has_degraded = True
+            if required:
+                report.reasons.append(f"Required collection '{collection_name}' is degraded")
+
+    # Determine overall status
+    if all_healthy and has_required:
+        report.overall_status = CollectionHealthStatus.HEALTHY
+        report.agentic_rag_ready = True
+        if has_degraded:
+            report.degraded = True
+    elif has_required:
+        if has_degraded:
+            report.overall_status = CollectionHealthStatus.DEGRADED
+            report.agentic_rag_ready = True  # Can still operate but degraded
+            report.degraded = True
+        else:
+            report.overall_status = CollectionHealthStatus.HEALTHY
+            report.agentic_rag_ready = True
+    else:
+        report.overall_status = CollectionHealthStatus.DEGRADED
+        report.agentic_rag_ready = False
+        report.degraded = True
+
+    return report
+
+
+def format_health_report(report: HoloIndexHealthReport) -> str:
+    """Format health report for human-readable output.
+
+    Args:
+        report: HoloIndexHealthReport to format
+
+    Returns:
+        Formatted string suitable for CLI output.
+    """
+    lines = [
+        "=" * 60,
+        "HoloIndex Collection Health Report",
+        "=" * 60,
+        f"Vector Path: {report.vector_path}",
+        f"Overall Status: {report.overall_status.value.upper()}",
+        f"Agentic RAG Ready: {'YES' if report.agentic_rag_ready else 'NO'}",
+        f"Degraded: {'YES' if report.degraded else 'NO'}",
+        "",
+        "Collections:",
+        "-" * 40,
+    ]
+
+    for collection in report.collections:
+        status_icon = {
+            CollectionHealthStatus.HEALTHY: "[OK]",
+            CollectionHealthStatus.EMPTY: "[EMPTY]",
+            CollectionHealthStatus.MISSING: "[MISSING]",
+            CollectionHealthStatus.DEGRADED: "[WARN]",
+            CollectionHealthStatus.UNKNOWN: "[?]",
+        }.get(collection.status, "[?]")
+
+        required_tag = " (REQUIRED)" if collection.required_for_agentic_rag else ""
+        lines.append(f"  {status_icon} {collection.name}: {collection.count} docs{required_tag}")
+
+    if report.reasons:
+        lines.extend([
+            "",
+            "Reasons:",
+            "-" * 40,
+        ])
+        for reason in report.reasons:
+            lines.append(f"  - {reason}")
+
+    lines.append("=" * 60)
+
+    return "\n".join(lines)

--- a/holo_index/tests/test_collection_health.py
+++ b/holo_index/tests/test_collection_health.py
@@ -1,0 +1,337 @@
+# -*- coding: utf-8 -*-
+"""HIA_AGENTIC_RAG_LIVE_COLLECTION_HEALTH_PHASE2: Collection Health Tests
+
+Tests for collection health inspection and Agentic RAG readiness classification.
+
+WSP 97: These tests use mock collection objects, not live ChromaDB.
+Live collection health is tested via CLI command separately.
+"""
+
+import json
+import pytest
+from unittest.mock import MagicMock, PropertyMock
+
+from holo_index.core.collection_health import (
+    CollectionHealthStatus,
+    CollectionHealth,
+    HoloIndexHealthReport,
+    inspect_holoindex_collection_health,
+    format_health_report,
+    REQUIRED_COLLECTIONS,
+    OPTIONAL_COLLECTIONS,
+)
+
+
+# =============================================================================
+# Mock Fixtures
+# =============================================================================
+
+
+def create_mock_holo(collection_counts: dict) -> MagicMock:
+    """Create a mock HoloIndex with specified collection counts.
+
+    Args:
+        collection_counts: Dict mapping collection names to counts.
+            Special values:
+            - -1: Collection raises exception (access error)
+            - None: Collection doesn't exist
+    """
+    mock_holo = MagicMock()
+    mock_holo.vector_path = "/test/vectors"
+
+    # Map collection names to attributes
+    attr_map = {
+        "navigation_code": "code_collection",
+        "navigation_wsp": "wsp_collection",
+        "navigation_tests": "test_collection",
+        "navigation_skills": "skill_collection",
+        "navigation_symbols": "symbol_collection",
+        "navigation_docs": "docs_collection",
+        "navigation_knowledge": "knowledge_collection",
+    }
+
+    # Set up collection mocks
+    for collection_name, attr_name in attr_map.items():
+        count = collection_counts.get(collection_name)
+
+        if count is None:
+            setattr(mock_holo, attr_name, None)
+        elif count == -1:
+            mock_collection = MagicMock()
+            mock_collection.count.side_effect = Exception("Access error")
+            setattr(mock_holo, attr_name, mock_collection)
+        else:
+            mock_collection = MagicMock()
+            mock_collection.count.return_value = count
+            setattr(mock_holo, attr_name, mock_collection)
+
+    # Mock client for fallback (not used in tests but needed)
+    mock_holo.client = None
+
+    return mock_holo
+
+
+# =============================================================================
+# CollectionHealth Dataclass Tests
+# =============================================================================
+
+
+class TestCollectionHealth:
+    """Test CollectionHealth dataclass."""
+
+    def test_to_dict(self):
+        """CollectionHealth converts to JSON-serializable dict."""
+        health = CollectionHealth(
+            name="navigation_wsp",
+            count=117,
+            status=CollectionHealthStatus.HEALTHY,
+            required_for_agentic_rag=True,
+            reason="Collection healthy",
+        )
+        d = health.to_dict()
+        assert d["name"] == "navigation_wsp"
+        assert d["count"] == 117
+        assert d["status"] == "healthy"
+        assert d["required_for_agentic_rag"] is True
+
+    def test_default_values(self):
+        """CollectionHealth has sensible defaults."""
+        health = CollectionHealth(name="test")
+        assert health.count == 0
+        assert health.status == CollectionHealthStatus.UNKNOWN
+        assert health.required_for_agentic_rag is False
+
+
+# =============================================================================
+# HoloIndexHealthReport Dataclass Tests
+# =============================================================================
+
+
+class TestHoloIndexHealthReport:
+    """Test HoloIndexHealthReport dataclass."""
+
+    def test_to_json(self):
+        """Report converts to valid JSON."""
+        report = HoloIndexHealthReport(
+            vector_path="/test",
+            collections=[
+                CollectionHealth(
+                    name="navigation_wsp",
+                    count=100,
+                    status=CollectionHealthStatus.HEALTHY,
+                    required_for_agentic_rag=True,
+                )
+            ],
+            overall_status=CollectionHealthStatus.HEALTHY,
+            agentic_rag_ready=True,
+            degraded=False,
+            reasons=[],
+        )
+        json_str = report.to_json()
+        parsed = json.loads(json_str)
+        assert parsed["vector_path"] == "/test"
+        assert parsed["agentic_rag_ready"] is True
+        assert len(parsed["collections"]) == 1
+
+
+# =============================================================================
+# Agentic RAG Readiness Tests
+# =============================================================================
+
+
+class TestAgenticRagReadiness:
+    """Test Agentic RAG readiness classification."""
+
+    def test_all_required_present_ready(self):
+        """All required collections with counts > 0 => ready."""
+        mock_holo = create_mock_holo({
+            "navigation_code": 500,
+            "navigation_wsp": 117,
+            "navigation_symbols": 20000,
+            "navigation_docs": 100,
+            "navigation_knowledge": 50,
+            "navigation_tests": 30,
+            "navigation_skills": 20,
+        })
+        report = inspect_holoindex_collection_health(mock_holo)
+        assert report.agentic_rag_ready is True
+        assert report.overall_status == CollectionHealthStatus.HEALTHY
+
+    def test_missing_wsp_not_ready(self):
+        """Missing WSP collection => not ready."""
+        mock_holo = create_mock_holo({
+            "navigation_code": 500,
+            "navigation_wsp": None,  # Missing
+            "navigation_symbols": 20000,
+            "navigation_docs": 100,
+            "navigation_knowledge": 50,
+            "navigation_tests": 30,
+            "navigation_skills": 20,
+        })
+        report = inspect_holoindex_collection_health(mock_holo)
+        assert report.agentic_rag_ready is False
+        assert any("navigation_wsp" in r and "missing" in r.lower() for r in report.reasons)
+
+    def test_empty_wsp_not_ready(self):
+        """Empty WSP collection => not ready."""
+        mock_holo = create_mock_holo({
+            "navigation_code": 500,
+            "navigation_wsp": 0,  # Empty
+            "navigation_symbols": 20000,
+            "navigation_docs": 100,
+            "navigation_knowledge": 50,
+            "navigation_tests": 30,
+            "navigation_skills": 20,
+        })
+        report = inspect_holoindex_collection_health(mock_holo)
+        assert report.agentic_rag_ready is False
+        assert any("navigation_wsp" in r and "empty" in r.lower() for r in report.reasons)
+
+    def test_missing_code_not_ready(self):
+        """Missing code collection => not ready."""
+        mock_holo = create_mock_holo({
+            "navigation_code": None,  # Missing
+            "navigation_wsp": 117,
+            "navigation_symbols": 20000,
+            "navigation_docs": 100,
+            "navigation_knowledge": 50,
+            "navigation_tests": 30,
+            "navigation_skills": 20,
+        })
+        report = inspect_holoindex_collection_health(mock_holo)
+        assert report.agentic_rag_ready is False
+
+    def test_missing_optional_degraded_but_ready(self):
+        """Missing optional collections => degraded but still ready."""
+        mock_holo = create_mock_holo({
+            "navigation_code": 500,
+            "navigation_wsp": 117,
+            "navigation_symbols": 20000,
+            "navigation_docs": None,  # Optional missing
+            "navigation_knowledge": None,  # Optional missing
+            "navigation_tests": None,  # Optional missing
+            "navigation_skills": None,  # Optional missing
+        })
+        report = inspect_holoindex_collection_health(mock_holo)
+        assert report.agentic_rag_ready is True
+        assert report.degraded is True
+        assert len(report.reasons) > 0  # Should have reasons for missing optional
+
+    def test_access_error_unknown_not_ready(self):
+        """Collection access error => unknown, not ready."""
+        mock_holo = create_mock_holo({
+            "navigation_code": 500,
+            "navigation_wsp": -1,  # Access error
+            "navigation_symbols": 20000,
+            "navigation_docs": 100,
+            "navigation_knowledge": 50,
+            "navigation_tests": 30,
+            "navigation_skills": 20,
+        })
+        report = inspect_holoindex_collection_health(mock_holo)
+        assert report.agentic_rag_ready is False
+
+        # Find WSP collection in report
+        wsp_health = next(c for c in report.collections if c.name == "navigation_wsp")
+        assert wsp_health.status == CollectionHealthStatus.UNKNOWN
+
+    def test_low_count_degraded(self):
+        """Low count (< 10) => degraded status."""
+        mock_holo = create_mock_holo({
+            "navigation_code": 5,  # Low count
+            "navigation_wsp": 117,
+            "navigation_symbols": 20000,
+            "navigation_docs": 100,
+            "navigation_knowledge": 50,
+            "navigation_tests": 30,
+            "navigation_skills": 20,
+        })
+        report = inspect_holoindex_collection_health(mock_holo)
+
+        code_health = next(c for c in report.collections if c.name == "navigation_code")
+        assert code_health.status == CollectionHealthStatus.DEGRADED
+
+
+# =============================================================================
+# Format Tests
+# =============================================================================
+
+
+class TestFormatHealthReport:
+    """Test health report formatting."""
+
+    def test_format_healthy_report(self):
+        """Healthy report formats with [OK] markers."""
+        mock_holo = create_mock_holo({
+            "navigation_code": 500,
+            "navigation_wsp": 117,
+            "navigation_symbols": 20000,
+            "navigation_docs": 100,
+            "navigation_knowledge": 50,
+            "navigation_tests": 30,
+            "navigation_skills": 20,
+        })
+        report = inspect_holoindex_collection_health(mock_holo)
+        output = format_health_report(report)
+
+        assert "HEALTHY" in output
+        assert "Agentic RAG Ready: YES" in output
+        assert "[OK]" in output
+
+    def test_format_unhealthy_report(self):
+        """Unhealthy report formats with warnings."""
+        mock_holo = create_mock_holo({
+            "navigation_code": 500,
+            "navigation_wsp": 0,  # Empty
+            "navigation_symbols": 20000,
+            "navigation_docs": 100,
+            "navigation_knowledge": 50,
+            "navigation_tests": 30,
+            "navigation_skills": 20,
+        })
+        report = inspect_holoindex_collection_health(mock_holo)
+        output = format_health_report(report)
+
+        assert "Agentic RAG Ready: NO" in output
+        assert "[EMPTY]" in output or "[MISSING]" in output
+
+    def test_format_contains_vector_path(self):
+        """Report output includes vector path."""
+        mock_holo = create_mock_holo({
+            "navigation_code": 500,
+            "navigation_wsp": 117,
+            "navigation_symbols": 20000,
+        })
+        report = inspect_holoindex_collection_health(mock_holo)
+        output = format_health_report(report)
+
+        assert "/test/vectors" in output
+
+
+# =============================================================================
+# Required Collections Tests
+# =============================================================================
+
+
+class TestRequiredCollections:
+    """Test required collection configuration."""
+
+    def test_wsp_is_required(self):
+        """navigation_wsp is marked required."""
+        assert REQUIRED_COLLECTIONS.get("navigation_wsp") is True
+
+    def test_code_is_required(self):
+        """navigation_code is marked required."""
+        assert REQUIRED_COLLECTIONS.get("navigation_code") is True
+
+    def test_symbols_is_required(self):
+        """navigation_symbols is marked required."""
+        assert REQUIRED_COLLECTIONS.get("navigation_symbols") is True
+
+    def test_docs_is_optional(self):
+        """navigation_docs is optional."""
+        assert OPTIONAL_COLLECTIONS.get("navigation_docs") is False
+
+    def test_knowledge_is_optional(self):
+        """navigation_knowledge is optional."""
+        assert OPTIONAL_COLLECTIONS.get("navigation_knowledge") is False


### PR DESCRIPTION
## Summary
- Adds live HoloIndex collection health helper/reporting
- Verifies required Agentic RAG collections are present and non-empty
- Documents live collection health for code, WSP, symbols, docs, knowledge, tests, and skills

## Validation
- `python -m pytest holo_index/tests/test_collection_health.py -q` — 18/18 passed
- `python -m pytest holo_index/tests/test_agentic_rag_baseline_gate.py -q` — 24/24 passed
- `python -m pytest holo_index/tests/test_search_quality_baseline.py -q` — 10/10 passed
- `git diff --check` — clean

## WSP 97
No federation, pAVS MCP, external FoundUp integration, or TurboQuant default promotion. Live collection readiness only.

🤖 Generated with [Claude Code](https://claude.ai/code)