### PR TITLE
test(holoindex): add docs and knowledge recall coverage

### DIFF
--- a/docs/audits/holoindex_search_quality/HIA_AGENTIC_RAG_DOCS_KNOWLEDGE_RECALL.md
+++ b/docs/audits/holoindex_search_quality/HIA_AGENTIC_RAG_DOCS_KNOWLEDGE_RECALL.md
@@ -1,8 +1,8 @@
 # HIA_AGENTIC_RAG_DOCS_KNOWLEDGE_RECALL_PHASE4
 
 **Date**: 2026-05-06
-**Slice**: HIA_AGENTIC_RAG_DOCS_KNOWLEDGE_RECALL_PHASE4
-**Status**: COMPLETE - PASS (with documented degraded cases)
+**Slice**: HIA_AGENTIC_RAG_DOCS_KNOWLEDGE_RECALL_PHASE4 + PHASE4B (recall repair)
+**Status**: COMPLETE - PASS
 **Author**: 0102 W1
 
 ---
@@ -18,20 +18,20 @@ Prove docs/knowledge recall quality, not just bucket availability. Verify that e
 **Test Run**: 2026-05-06
 **Index**: E:/HoloIndex
 
-### Aggregate Metrics
+### Aggregate Metrics (After Phase 4B Re-index)
 
 | Metric | Value |
 |--------|-------|
 | Total Sentinels | 6 |
-| PASS | 4 (66.7%) |
-| FAIL (Degraded) | 2 (33.3%) |
+| PASS | 6 (100%) |
+| FAIL (Degraded) | 0 (0%) |
 
 ### By Bucket
 
 | Bucket | Total | Pass |
 |--------|-------|------|
 | WSP | 2 | 2 (100%) |
-| Docs | 3 | 1 (33.3%) |
+| Docs | 3 | 3 (100%) |
 | Knowledge | 1 | 1 (100%) |
 
 ---
@@ -45,13 +45,13 @@ Prove docs/knowledge recall quality, not just bucket availability. Verify that e
 | WSP 97 System Execution Prompting Protocol | WSP_97_System_Execution_Prompting_Protocol.md | TOP-1 | PASS |
 | rESP quantum entanglement theoretical foundation WSP 61 | WSP_61_Theoretical_Physics_Foundation_Protocol.md | TOP-1 | PASS |
 
-### Docs Recall (Mixed)
+### Docs Recall (PASS after re-index)
 
-| Query | Expected | Position | Verdict |
-|-------|----------|----------|---------|
-| FOUNDUPS BTC reserve token architecture | FOUNDUPS_BTC_RESERVE_TOKEN_ARCHITECTURE.md | TOP-1 | PASS |
-| HIA Agentic RAG live collection health audit | HIA_AGENTIC_RAG_LIVE_COLLECTION_HEALTH.md | NOT in top 8 | DEGRADED |
-| HoloIndex degraded mode WSP doc retrieval audit | DEGRADED_MODE_WSP_DOC_RETRIEVAL_AUDIT.md | NOT in top 8 | DEGRADED |
+| Query | Expected | Before Re-index | After Re-index | Verdict |
+|-------|----------|-----------------|----------------|---------|
+| FOUNDUPS BTC reserve token architecture | FOUNDUPS_BTC_RESERVE_TOKEN_ARCHITECTURE.md | TOP-1 | TOP-1 | PASS |
+| HIA Agentic RAG live collection health audit | HIA_AGENTIC_RAG_LIVE_COLLECTION_HEALTH.md | NOT in top 8 | TOP-1 | PASS (repaired) |
+| HoloIndex degraded mode WSP doc retrieval audit | DEGRADED_MODE_WSP_DOC_RETRIEVAL_AUDIT.md | NOT in top 8 | TOP-1 | PASS (repaired) |
 
 ### Knowledge Recall (PASS)
 
@@ -61,33 +61,25 @@ Prove docs/knowledge recall quality, not just bucket availability. Verify that e
 
 ---
 
-## Degraded Cases Analysis
+## Degraded Cases Analysis (Phase 4B: REPAIRED)
 
 ### Case 1: HIA_AGENTIC_RAG_LIVE_COLLECTION_HEALTH.md
 
 **Query**: "HIA Agentic RAG live collection health audit"
-**Expected**: `docs/audits/holoindex_search_quality/HIA_AGENTIC_RAG_LIVE_COLLECTION_HEALTH.md`
-**Observed Top 5 Docs**:
-1. HIA8_AGENTIC_RAG_GATE.md
-2. HIA4A_INDEX_REFRESH_REPORT.md
-3. HIA1_HOLOINDEX_ARCHITECTURE_AUDIT.md
-4. HOLO_CLI_FIRST_PRINCIPLES_AUDIT.md
-5. HOLO_COMPREHENSIVE_AUDIT_20251130.md
-
-**Diagnosis**: File exists but not indexed recently. Created 2026-05-05 - may need re-indexing.
+**Before Re-index**: NOT in top 8 (index stale)
+**After Re-index**: **TOP-1** in docs
+**Fix**: `python holo_index.py --index-docs --ssd E:/HoloIndex`
 
 ### Case 2: DEGRADED_MODE_WSP_DOC_RETRIEVAL_AUDIT.md
 
 **Query**: "HoloIndex degraded mode WSP doc retrieval audit"
-**Expected**: `docs/audits/holoindex_search_quality/DEGRADED_MODE_WSP_DOC_RETRIEVAL_AUDIT.md`
-**Observed Top 5 Docs**:
-1. DOCS_AUDIT_CATEGORIZATION.md
-2. CURRENT_STATE_AUDIT.md
-3. HIA1_HOLOINDEX_ARCHITECTURE_AUDIT.md
-4. HIA4A_INDEX_REFRESH_REPORT.md
-5. HOLO_COMPREHENSIVE_AUDIT_20251130.md
+**Before Re-index**: NOT in top 8 (index stale)
+**After Re-index**: **TOP-1** in docs
+**Fix**: `python holo_index.py --index-docs --ssd E:/HoloIndex`
 
-**Diagnosis**: File exists but not indexed recently. Created 2026-05-04 - may need re-indexing.
+### Root Cause
+
+Both files were created 2026-05-04/05 after the last docs index build. Re-indexing docs collection resolved the recall gap immediately.
 
 ---
 
@@ -110,7 +102,7 @@ Prove docs/knowledge recall quality, not just bucket availability. Verify that e
 
 | File | Purpose |
 |------|---------|
-| `holo_index/tests/test_agentic_rag_docs_knowledge_recall.py` | 8 recall quality tests |
+| `holo_index/tests/test_agentic_rag_docs_knowledge_recall.py` | 8 recall quality tests (xfails removed after repair) |
 | `docs/audits/holoindex_search_quality/HIA_AGENTIC_RAG_DOCS_KNOWLEDGE_RECALL.md` | This audit |
 
 ---
@@ -119,7 +111,7 @@ Prove docs/knowledge recall quality, not just bucket availability. Verify that e
 
 | Test Suite | Result |
 |------------|--------|
-| test_agentic_rag_docs_knowledge_recall.py | 6 passed, 2 xfailed |
+| test_agentic_rag_docs_knowledge_recall.py | 8 passed (after Phase 4B repair) |
 | test_agentic_rag_sentinel_sufficiency.py | 11 passed |
 | test_collection_health.py | 18 passed |
 | test_agentic_rag_baseline_gate.py | 24 passed |
@@ -173,13 +165,13 @@ Status: PASS
 
 ## Agentic RAG Docs/Knowledge Verdict
 
-**PASS with degraded cases** - Core recall quality proven:
+**PASS** - Recall quality proven after Phase 4B repair:
 
 1. WSP protocols recalled at TOP-1 with explicit queries
 2. Critical architecture docs recalled at TOP-1
 3. Knowledge papers recalled at TOP-1
-4. Two recent HIA audit docs not in top 8 (index staleness, not ranking failure)
-5. Natural language recall gap documented for future improvement
+4. HIA audit docs recalled at TOP-1 after docs re-index
+5. Natural language WSP recall gap documented for future improvement
 
 ---
 

--- a/docs/audits/holoindex_search_quality/HIA_AGENTIC_RAG_DOCS_KNOWLEDGE_RECALL.md
+++ b/docs/audits/holoindex_search_quality/HIA_AGENTIC_RAG_DOCS_KNOWLEDGE_RECALL.md
@@ -1,0 +1,198 @@
+# HIA_AGENTIC_RAG_DOCS_KNOWLEDGE_RECALL_PHASE4
+
+**Date**: 2026-05-06
+**Slice**: HIA_AGENTIC_RAG_DOCS_KNOWLEDGE_RECALL_PHASE4
+**Status**: COMPLETE - PASS (with documented degraded cases)
+**Author**: 0102 W1
+
+---
+
+## Purpose
+
+Prove docs/knowledge recall quality, not just bucket availability. Verify that expected documents appear in retrieval results at appropriate positions.
+
+---
+
+## Live Recall Results
+
+**Test Run**: 2026-05-06
+**Index**: E:/HoloIndex
+
+### Aggregate Metrics
+
+| Metric | Value |
+|--------|-------|
+| Total Sentinels | 6 |
+| PASS | 4 (66.7%) |
+| FAIL (Degraded) | 2 (33.3%) |
+
+### By Bucket
+
+| Bucket | Total | Pass |
+|--------|-------|------|
+| WSP | 2 | 2 (100%) |
+| Docs | 3 | 1 (33.3%) |
+| Knowledge | 1 | 1 (100%) |
+
+---
+
+## Sentinel Query Results
+
+### WSP Recall (PASS)
+
+| Query | Expected | Position | Verdict |
+|-------|----------|----------|---------|
+| WSP 97 System Execution Prompting Protocol | WSP_97_System_Execution_Prompting_Protocol.md | TOP-1 | PASS |
+| rESP quantum entanglement theoretical foundation WSP 61 | WSP_61_Theoretical_Physics_Foundation_Protocol.md | TOP-1 | PASS |
+
+### Docs Recall (Mixed)
+
+| Query | Expected | Position | Verdict |
+|-------|----------|----------|---------|
+| FOUNDUPS BTC reserve token architecture | FOUNDUPS_BTC_RESERVE_TOKEN_ARCHITECTURE.md | TOP-1 | PASS |
+| HIA Agentic RAG live collection health audit | HIA_AGENTIC_RAG_LIVE_COLLECTION_HEALTH.md | NOT in top 8 | DEGRADED |
+| HoloIndex degraded mode WSP doc retrieval audit | DEGRADED_MODE_WSP_DOC_RETRIEVAL_AUDIT.md | NOT in top 8 | DEGRADED |
+
+### Knowledge Recall (PASS)
+
+| Query | Expected | Position | Verdict |
+|-------|----------|----------|---------|
+| rESP quantum entanglement cross linguistic signatures | rESP_Cross_Linguistic_Quantum_Signatures_2025.md | TOP-1 | PASS |
+
+---
+
+## Degraded Cases Analysis
+
+### Case 1: HIA_AGENTIC_RAG_LIVE_COLLECTION_HEALTH.md
+
+**Query**: "HIA Agentic RAG live collection health audit"
+**Expected**: `docs/audits/holoindex_search_quality/HIA_AGENTIC_RAG_LIVE_COLLECTION_HEALTH.md`
+**Observed Top 5 Docs**:
+1. HIA8_AGENTIC_RAG_GATE.md
+2. HIA4A_INDEX_REFRESH_REPORT.md
+3. HIA1_HOLOINDEX_ARCHITECTURE_AUDIT.md
+4. HOLO_CLI_FIRST_PRINCIPLES_AUDIT.md
+5. HOLO_COMPREHENSIVE_AUDIT_20251130.md
+
+**Diagnosis**: File exists but not indexed recently. Created 2026-05-05 - may need re-indexing.
+
+### Case 2: DEGRADED_MODE_WSP_DOC_RETRIEVAL_AUDIT.md
+
+**Query**: "HoloIndex degraded mode WSP doc retrieval audit"
+**Expected**: `docs/audits/holoindex_search_quality/DEGRADED_MODE_WSP_DOC_RETRIEVAL_AUDIT.md`
+**Observed Top 5 Docs**:
+1. DOCS_AUDIT_CATEGORIZATION.md
+2. CURRENT_STATE_AUDIT.md
+3. HIA1_HOLOINDEX_ARCHITECTURE_AUDIT.md
+4. HIA4A_INDEX_REFRESH_REPORT.md
+5. HOLO_COMPREHENSIVE_AUDIT_20251130.md
+
+**Diagnosis**: File exists but not indexed recently. Created 2026-05-04 - may need re-indexing.
+
+---
+
+## Natural Language Recall Gap
+
+**Finding**: Natural language WSP queries have degraded recall compared to explicit protocol name queries.
+
+| Query Type | Example | WSP 97 Found |
+|------------|---------|--------------|
+| Explicit | "WSP 97 System Execution Prompting Protocol" | TOP-1 |
+| Natural | "WSP 97 retrieve evidence before stating facts" | NOT in top 8 |
+
+**Impact**: Users must use explicit protocol names for reliable WSP recall.
+
+**Recommendation**: Consider semantic expansion or query rewriting to map natural language to protocol names.
+
+---
+
+## Files Added
+
+| File | Purpose |
+|------|---------|
+| `holo_index/tests/test_agentic_rag_docs_knowledge_recall.py` | 8 recall quality tests |
+| `docs/audits/holoindex_search_quality/HIA_AGENTIC_RAG_DOCS_KNOWLEDGE_RECALL.md` | This audit |
+
+---
+
+## Test Results
+
+| Test Suite | Result |
+|------------|--------|
+| test_agentic_rag_docs_knowledge_recall.py | 6 passed, 2 xfailed |
+| test_agentic_rag_sentinel_sufficiency.py | 11 passed |
+| test_collection_health.py | 18 passed |
+| test_agentic_rag_baseline_gate.py | 24 passed |
+| test_search_quality_baseline.py | 10 passed |
+| git diff --check | clean |
+
+---
+
+## CLI Spot Check Results
+
+### WSP 61 Query (PASS)
+```
+Query: "rESP quantum entanglement theoretical foundation WSP 61"
+WSP Top-1: WSP_61_Theoretical_Physics_Foundation_Protocol.md
+Status: PASS
+```
+
+### BTC Architecture Query (PASS)
+```
+Query: "FOUNDUPS BTC reserve token architecture"
+Docs Top-1: FOUNDUPS_BTC_RESERVE_TOKEN_ARCHITECTURE.md
+Status: PASS
+```
+
+---
+
+## WSP 97 Truth Boundaries
+
+| Statement | Status |
+|-----------|--------|
+| Bucket availability is not recall quality | TRUE |
+| Missing expected evidence is documented | TRUE |
+| Degraded cases use xfail, not hidden | TRUE |
+| TurboQuant parity not tested | TRUE |
+| Natural language recall gap documented | TRUE |
+
+---
+
+## Recommended Actions
+
+### Short-term (Index Refresh)
+1. Re-index docs collection to include recent HIA audit files
+2. Verify `navigation_docs` collection includes 2026-05-* files
+
+### Long-term (Ranking Improvement)
+1. Consider query expansion for natural language WSP queries
+2. Add recency boost for recently created audit documents
+3. Evaluate BM25 hybrid scoring for document title matching
+
+---
+
+## Agentic RAG Docs/Knowledge Verdict
+
+**PASS with degraded cases** - Core recall quality proven:
+
+1. WSP protocols recalled at TOP-1 with explicit queries
+2. Critical architecture docs recalled at TOP-1
+3. Knowledge papers recalled at TOP-1
+4. Two recent HIA audit docs not in top 8 (index staleness, not ranking failure)
+5. Natural language recall gap documented for future improvement
+
+---
+
+## Next Action
+
+Since core recall quality is proven (WSP 97, WSP 61, architecture docs, knowledge papers all TOP-1):
+
+**HIA_AGENTIC_RAG_RANKING_QUALITY_PHASE5**
+
+Goal: Measure ranking quality (position distribution) and identify ranking improvements for edge cases.
+
+If degraded recall becomes blocking:
+
+**HIA_AGENTIC_RAG_RECALL_REPAIR_PHASE4B**
+
+Goal: Re-index docs collection and verify recent files are discoverable.

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,10 +1,38 @@
 # HoloIndex Package ModLog
 
+## [2026-05-06] HIA_AGENTIC_RAG_DOCS_RECALL_BRANCH_RECOVERY_AND_REPAIR_PHASE4B
+
+**Agent**: 0102 (W1)
+**WSP References**: WSP 87, WSP 97
+**Status**: COMPLETE - PASS
+
+### Summary
+
+Recovered Phase 4 from main to `feat/hia-agentic-rag-docs-knowledge-recall`.
+Re-indexed docs collection to fix recall staleness for 2026-05 files.
+Both previously degraded docs now TOP-1 after re-index.
+
+### Recall Before/After Re-index
+
+| File | Before | After |
+|------|--------|-------|
+| HIA_AGENTIC_RAG_LIVE_COLLECTION_HEALTH.md | NOT in top 8 | TOP-1 |
+| DEGRADED_MODE_WSP_DOC_RETRIEVAL_AUDIT.md | NOT in top 8 | TOP-1 |
+| WSP 97 (natural language) | NOT in top 8 | Still NOT in top 8 |
+
+### Changes
+
+- Removed xfails from 2 tests (now real assertions)
+- Updated audit doc with repair results
+- Branch recovered from main to feature branch
+
+---
+
 ## [2026-05-06] HIA_AGENTIC_RAG_DOCS_KNOWLEDGE_RECALL_PHASE4 — Recall Quality Tests
 
 **Agent**: 0102 (W1)
 **WSP References**: WSP 87 (Size Limits), WSP 97 (Truth Boundaries)
-**Status**: COMPLETE - PASS (with documented degraded cases)
+**Status**: COMPLETE - PASS
 
 ### Summary
 

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,62 @@
 # HoloIndex Package ModLog
 
+## [2026-05-06] HIA_AGENTIC_RAG_DOCS_KNOWLEDGE_RECALL_PHASE4 — Recall Quality Tests
+
+**Agent**: 0102 (W1)
+**WSP References**: WSP 87 (Size Limits), WSP 97 (Truth Boundaries)
+**Status**: COMPLETE - PASS (with documented degraded cases)
+
+### Summary
+
+Added docs/knowledge recall quality tests. Proves expected documents appear in retrieval results at appropriate positions.
+
+### Recall Results
+
+| Bucket | Total | Pass | Status |
+|--------|-------|------|--------|
+| WSP | 2 | 2 | 100% |
+| Docs | 3 | 1 | 33% (2 degraded) |
+| Knowledge | 1 | 1 | 100% |
+
+### Passing Sentinels (TOP-1)
+
+- WSP 97 System Execution Prompting Protocol
+- WSP 61 Theoretical Physics Foundation
+- FOUNDUPS BTC Reserve Token Architecture
+- rESP Cross Linguistic Quantum Signatures
+
+### Degraded Cases (Index Staleness)
+
+| Query | Expected File | Issue |
+|-------|---------------|-------|
+| HIA live collection health | HIA_AGENTIC_RAG_LIVE_COLLECTION_HEALTH.md | Not in top 8 |
+| Degraded mode audit | DEGRADED_MODE_WSP_DOC_RETRIEVAL_AUDIT.md | Not in top 8 |
+
+**Cause**: Files created 2026-05-04/05 - not yet indexed.
+
+### Natural Language Gap
+
+- Explicit: "WSP 97 System Execution Prompting Protocol" -> TOP-1
+- Natural: "WSP 97 retrieve evidence before stating facts" -> NOT in top 8
+
+### Files Added
+
+| File | Purpose |
+|------|---------|
+| `holo_index/tests/test_agentic_rag_docs_knowledge_recall.py` | 8 recall quality tests |
+| `docs/audits/holoindex_search_quality/HIA_AGENTIC_RAG_DOCS_KNOWLEDGE_RECALL.md` | Audit doc |
+
+### Test Results
+
+- `test_agentic_rag_docs_knowledge_recall.py`: 6 passed, 2 xfailed
+- All other test suites: passing
+
+### Next Slice
+
+HIA_AGENTIC_RAG_RANKING_QUALITY_PHASE5
+
+---
+
 ## [2026-05-06] HIA_AGENTIC_RAG_SENTINEL_SUFFICIENCY_PHASE3 — Live Verdict Tests
 
 **Agent**: 0102 (W1)

--- a/holo_index/tests/test_agentic_rag_docs_knowledge_recall.py
+++ b/holo_index/tests/test_agentic_rag_docs_knowledge_recall.py
@@ -310,43 +310,35 @@ class TestDocsRecallQuality:
     def test_collection_health_audit_recall(self):
         """Collection health query should return HIA audit doc in top 8.
 
-        NOTE: This may be DEGRADED based on preflight observation.
-        If it fails, document in audit report but consider if recall
-        improvement is needed.
+        After docs re-index (Phase 4B), this file is discoverable at TOP-1.
         """
         holo = _get_live_holo()
         sentinel = DOCS_RECALL_SENTINELS[1]  # HIA collection health
 
         result = _run_recall_sentinel(holo, sentinel)
 
-        # This sentinel is known to potentially fail - doc for audit
-        if not result.found:
-            pytest.xfail(
-                f"DEGRADED: HIA collection health audit doc not in top {sentinel.top_n}. "
-                f"Top paths: {result.top_paths}. "
-                f"This is a recall gap to document."
-            )
+        assert result.found, (
+            f"HIA collection health doc not found in top {sentinel.top_n} docs. "
+            f"Top paths: {result.top_paths}. "
+            f"Ensure docs index is fresh: python holo_index.py --index-docs --ssd E:/HoloIndex"
+        )
 
     @SKIP_LIVE
     def test_degraded_mode_audit_recall(self):
         """Degraded mode query should return degraded mode audit doc in top 8.
 
-        NOTE: This may be DEGRADED based on preflight observation.
-        If it fails, document in audit report but consider if recall
-        improvement is needed.
+        After docs re-index (Phase 4B), this file is discoverable at TOP-1.
         """
         holo = _get_live_holo()
         sentinel = DOCS_RECALL_SENTINELS[2]  # Degraded mode audit
 
         result = _run_recall_sentinel(holo, sentinel)
 
-        # This sentinel is known to potentially fail - doc for audit
-        if not result.found:
-            pytest.xfail(
-                f"DEGRADED: Degraded mode audit doc not in top {sentinel.top_n}. "
-                f"Top paths: {result.top_paths}. "
-                f"This is a recall gap to document."
-            )
+        assert result.found, (
+            f"Degraded mode audit doc not found in top {sentinel.top_n} docs. "
+            f"Top paths: {result.top_paths}. "
+            f"Ensure docs index is fresh: python holo_index.py --index-docs --ssd E:/HoloIndex"
+        )
 
 
 # =============================================================================

--- a/holo_index/tests/test_agentic_rag_docs_knowledge_recall.py
+++ b/holo_index/tests/test_agentic_rag_docs_knowledge_recall.py
@@ -1,0 +1,478 @@
+# -*- coding: utf-8 -*-
+"""HIA_AGENTIC_RAG_DOCS_KNOWLEDGE_RECALL_PHASE4: Docs/Knowledge Recall Quality Tests
+
+Tests that verify docs and knowledge recall QUALITY, not just bucket availability.
+Proves that expected documents appear in retrieval results.
+
+WSP 97: These tests measure recall quality. Missing expected evidence is a
+        failure or degraded finding, not a pass. Bucket availability alone
+        is not recall quality.
+
+WSP 87: Keep tests focused on specific expected documents, not broad ranking.
+"""
+
+import os
+import pytest
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from dataclasses import dataclass, asdict
+
+# Verdict imports
+from holo_index.core.agentic_rag_verdict import (
+    RetrievalVerdict,
+    QueryIntent,
+    classify_retrieval_evidence,
+)
+
+
+# =============================================================================
+# Live Index Detection (reused from sentinel tests)
+# =============================================================================
+
+
+def _get_live_holo() -> Optional[Any]:
+    """Get live HoloIndex instance if available."""
+    try:
+        ssd_path = Path("E:/HoloIndex")
+        if not ssd_path.exists():
+            return None
+
+        vectors_path = ssd_path / "vectors"
+        if not vectors_path.exists():
+            return None
+
+        from holo_index.core.holo_index import HoloIndex
+        holo = HoloIndex(quiet=True)
+        return holo
+    except Exception:
+        return None
+
+
+def _is_live_index_available() -> bool:
+    """Check if live HoloIndex is available for testing."""
+    holo = _get_live_holo()
+    if holo is None:
+        return False
+    try:
+        code_count = holo.get_code_entry_count()
+        return code_count > 0
+    except Exception:
+        return False
+
+
+LIVE_INDEX_AVAILABLE = _is_live_index_available()
+SKIP_LIVE = pytest.mark.skipif(
+    not LIVE_INDEX_AVAILABLE,
+    reason="Live HoloIndex not available at E:/HoloIndex"
+)
+
+
+# =============================================================================
+# Recall Sentinel Definitions
+# =============================================================================
+
+
+@dataclass
+class RecallSentinel:
+    """Sentinel for docs/knowledge recall quality testing."""
+    query: str
+    expected_path_contains: str  # Substring that must appear in a result path
+    expected_bucket: str  # docs, wsp, knowledge
+    description: str
+    top_n: int = 8  # Required position (top_n)
+
+
+# WSP/Protocol sentinels - should appear in WSP bucket
+WSP_RECALL_SENTINELS: List[RecallSentinel] = [
+    RecallSentinel(
+        query="WSP 97 System Execution Prompting Protocol",
+        expected_path_contains="WSP_97_System_Execution_Prompting_Protocol",
+        expected_bucket="wsp",
+        description="WSP 97 system execution protocol",
+        top_n=8,
+    ),
+    RecallSentinel(
+        query="rESP quantum entanglement theoretical foundation WSP 61",
+        expected_path_contains="WSP_61_Theoretical_Physics_Foundation_Protocol",
+        expected_bucket="wsp",
+        description="WSP 61 theoretical physics",
+        top_n=8,
+    ),
+]
+
+# NOTE: Natural language WSP queries have degraded recall
+# "WSP 97 retrieve evidence before stating facts" does NOT find WSP_97 in top 8
+# Explicit protocol name queries work; natural language descriptions do not
+# This is a documented ranking gap for future improvement
+
+# Docs sentinels - should appear in docs bucket
+DOCS_RECALL_SENTINELS: List[RecallSentinel] = [
+    RecallSentinel(
+        query="FOUNDUPS BTC reserve token architecture",
+        expected_path_contains="FOUNDUPS_BTC_RESERVE_TOKEN_ARCHITECTURE",
+        expected_bucket="docs",
+        description="BTC reserve architecture doc",
+        top_n=8,
+    ),
+    # NOTE: These are expected to be DEGRADED based on preflight
+    RecallSentinel(
+        query="HIA Agentic RAG live collection health audit",
+        expected_path_contains="HIA_AGENTIC_RAG_LIVE_COLLECTION_HEALTH",
+        expected_bucket="docs",
+        description="Live collection health audit doc",
+        top_n=8,
+    ),
+    RecallSentinel(
+        query="HoloIndex degraded mode WSP doc retrieval audit",
+        expected_path_contains="DEGRADED_MODE_WSP_DOC_RETRIEVAL_AUDIT",
+        expected_bucket="docs",
+        description="Degraded mode audit doc",
+        top_n=8,
+    ),
+]
+
+# Knowledge sentinels - should appear in knowledge bucket
+KNOWLEDGE_RECALL_SENTINELS: List[RecallSentinel] = [
+    RecallSentinel(
+        query="rESP quantum entanglement cross linguistic signatures research",
+        expected_path_contains="rESP_Cross_Linguistic_Quantum_Signatures",
+        expected_bucket="knowledge",
+        description="rESP cross-linguistic paper",
+        top_n=8,
+    ),
+]
+
+ALL_RECALL_SENTINELS = WSP_RECALL_SENTINELS + DOCS_RECALL_SENTINELS + KNOWLEDGE_RECALL_SENTINELS
+
+
+# =============================================================================
+# Relevance Assertion Helpers
+# =============================================================================
+
+
+def _get_bucket_hits(results: Dict[str, Any], bucket: str) -> List[Dict[str, Any]]:
+    """Extract hits from a specific bucket in search results."""
+    bucket_map = {
+        "code": results.get("code", []),
+        "wsp": results.get("wsps", []),
+        "docs": results.get("docs", []),
+        "knowledge": results.get("knowledge", []),
+        "skills": results.get("skills", []),
+    }
+    return bucket_map.get(bucket, [])
+
+
+def _find_path_in_hits(
+    hits: List[Dict[str, Any]],
+    path_contains: str,
+    top_n: int = 8
+) -> Tuple[bool, int, Optional[str]]:
+    """Find if expected path substring appears in top_n hits.
+
+    Returns:
+        Tuple of (found, position, actual_path)
+        - found: True if path_contains substring found in any top_n result
+        - position: 1-indexed position where found, or -1 if not found
+        - actual_path: The full path that matched, or None
+    """
+    for i, hit in enumerate(hits[:top_n]):
+        path = hit.get("path") or hit.get("location") or ""
+        if path_contains.lower() in path.lower():
+            return (True, i + 1, path)
+    return (False, -1, None)
+
+
+def _summarize_top_paths(hits: List[Dict[str, Any]], n: int = 5) -> List[str]:
+    """Get top n paths from hits for reporting."""
+    paths = []
+    for hit in hits[:n]:
+        path = hit.get("path") or hit.get("location") or "unknown"
+        paths.append(path)
+    return paths
+
+
+# =============================================================================
+# Recall Result Dataclass
+# =============================================================================
+
+
+@dataclass
+class RecallResult:
+    """Result of a recall sentinel test."""
+    query: str
+    expected_path_contains: str
+    expected_bucket: str
+    description: str
+    top_n: int
+    found: bool
+    position: int  # 1-indexed, -1 if not found
+    actual_path: Optional[str]
+    bucket_hit_count: int
+    top_paths: List[str]
+    verdict: str
+    measured_at: str
+
+
+def _run_recall_sentinel(holo: Any, sentinel: RecallSentinel) -> RecallResult:
+    """Run a recall sentinel and check if expected path appears."""
+    results = holo.search(sentinel.query, limit=sentinel.top_n)
+
+    # Get bucket hits
+    bucket_hits = _get_bucket_hits(results, sentinel.expected_bucket)
+
+    # Check if expected path is in results
+    found, position, actual_path = _find_path_in_hits(
+        bucket_hits,
+        sentinel.expected_path_contains,
+        sentinel.top_n
+    )
+
+    # Determine verdict
+    if found:
+        verdict = "PASS"
+    else:
+        verdict = "FAIL"
+
+    return RecallResult(
+        query=sentinel.query,
+        expected_path_contains=sentinel.expected_path_contains,
+        expected_bucket=sentinel.expected_bucket,
+        description=sentinel.description,
+        top_n=sentinel.top_n,
+        found=found,
+        position=position,
+        actual_path=actual_path,
+        bucket_hit_count=len(bucket_hits),
+        top_paths=_summarize_top_paths(bucket_hits, 5),
+        verdict=verdict,
+        measured_at=datetime.utcnow().isoformat() + "Z",
+    )
+
+
+# =============================================================================
+# Live Recall Tests - WSP
+# =============================================================================
+
+
+class TestWSPRecallQuality:
+    """Test WSP document recall quality."""
+
+    @SKIP_LIVE
+    def test_wsp_97_recall(self):
+        """WSP 97 query should return WSP_97 protocol in top 8."""
+        holo = _get_live_holo()
+        sentinel = WSP_RECALL_SENTINELS[0]  # WSP 97
+
+        result = _run_recall_sentinel(holo, sentinel)
+
+        assert result.found, (
+            f"WSP 97 not found in top {sentinel.top_n} WSP results. "
+            f"Top paths: {result.top_paths}"
+        )
+
+    @SKIP_LIVE
+    def test_wsp_61_recall(self):
+        """WSP 61 query should return WSP_61 protocol in top 8."""
+        holo = _get_live_holo()
+        sentinel = WSP_RECALL_SENTINELS[1]  # WSP 61
+
+        result = _run_recall_sentinel(holo, sentinel)
+
+        assert result.found, (
+            f"WSP 61 not found in top {sentinel.top_n} WSP results. "
+            f"Top paths: {result.top_paths}"
+        )
+
+
+# =============================================================================
+# Live Recall Tests - Docs
+# =============================================================================
+
+
+class TestDocsRecallQuality:
+    """Test docs recall quality."""
+
+    @SKIP_LIVE
+    def test_btc_reserve_architecture_recall(self):
+        """BTC reserve query should return architecture doc in top 8."""
+        holo = _get_live_holo()
+        sentinel = DOCS_RECALL_SENTINELS[0]  # BTC reserve
+
+        result = _run_recall_sentinel(holo, sentinel)
+
+        assert result.found, (
+            f"BTC reserve architecture doc not found in top {sentinel.top_n} docs. "
+            f"Top paths: {result.top_paths}"
+        )
+
+    @SKIP_LIVE
+    def test_collection_health_audit_recall(self):
+        """Collection health query should return HIA audit doc in top 8.
+
+        NOTE: This may be DEGRADED based on preflight observation.
+        If it fails, document in audit report but consider if recall
+        improvement is needed.
+        """
+        holo = _get_live_holo()
+        sentinel = DOCS_RECALL_SENTINELS[1]  # HIA collection health
+
+        result = _run_recall_sentinel(holo, sentinel)
+
+        # This sentinel is known to potentially fail - doc for audit
+        if not result.found:
+            pytest.xfail(
+                f"DEGRADED: HIA collection health audit doc not in top {sentinel.top_n}. "
+                f"Top paths: {result.top_paths}. "
+                f"This is a recall gap to document."
+            )
+
+    @SKIP_LIVE
+    def test_degraded_mode_audit_recall(self):
+        """Degraded mode query should return degraded mode audit doc in top 8.
+
+        NOTE: This may be DEGRADED based on preflight observation.
+        If it fails, document in audit report but consider if recall
+        improvement is needed.
+        """
+        holo = _get_live_holo()
+        sentinel = DOCS_RECALL_SENTINELS[2]  # Degraded mode audit
+
+        result = _run_recall_sentinel(holo, sentinel)
+
+        # This sentinel is known to potentially fail - doc for audit
+        if not result.found:
+            pytest.xfail(
+                f"DEGRADED: Degraded mode audit doc not in top {sentinel.top_n}. "
+                f"Top paths: {result.top_paths}. "
+                f"This is a recall gap to document."
+            )
+
+
+# =============================================================================
+# Live Recall Tests - Knowledge
+# =============================================================================
+
+
+class TestKnowledgeRecallQuality:
+    """Test knowledge recall quality."""
+
+    @SKIP_LIVE
+    def test_resp_cross_linguistic_recall(self):
+        """rESP research query should return cross-linguistic paper in top 8."""
+        holo = _get_live_holo()
+        sentinel = KNOWLEDGE_RECALL_SENTINELS[0]  # rESP paper
+
+        result = _run_recall_sentinel(holo, sentinel)
+
+        # Knowledge recall may be degraded - use xfail for known gaps
+        if not result.found:
+            pytest.xfail(
+                f"DEGRADED: rESP cross-linguistic paper not in top {sentinel.top_n} knowledge. "
+                f"Top paths: {result.top_paths}. "
+                f"This is a recall gap to document."
+            )
+
+
+# =============================================================================
+# Aggregate Recall Report
+# =============================================================================
+
+
+class TestAggregateRecallQuality:
+    """Aggregate recall quality tests."""
+
+    @SKIP_LIVE
+    def test_wsp_sentinels_all_pass(self):
+        """All WSP recall sentinels should find expected documents."""
+        holo = _get_live_holo()
+        failures = []
+
+        for sentinel in WSP_RECALL_SENTINELS:
+            result = _run_recall_sentinel(holo, sentinel)
+            if not result.found:
+                failures.append(
+                    f"  - {sentinel.description}: expected '{sentinel.expected_path_contains}' "
+                    f"not in top {sentinel.top_n}"
+                )
+
+        if failures:
+            pytest.fail(f"WSP recall failures:\n" + "\n".join(failures))
+
+    @SKIP_LIVE
+    def test_critical_docs_sentinels_pass(self):
+        """Critical docs (like BTC architecture) should be retrievable."""
+        holo = _get_live_holo()
+
+        # Only test the critical doc that must pass
+        critical_sentinel = DOCS_RECALL_SENTINELS[0]  # BTC reserve
+        result = _run_recall_sentinel(holo, critical_sentinel)
+
+        assert result.found, (
+            f"Critical doc recall failure: {critical_sentinel.description}. "
+            f"Top paths: {result.top_paths}"
+        )
+
+
+# =============================================================================
+# Report Generation
+# =============================================================================
+
+
+def generate_recall_quality_report() -> Dict[str, Any]:
+    """Generate a recall quality report for audit documentation."""
+    holo = _get_live_holo()
+    if holo is None:
+        return {
+            "status": "SKIPPED",
+            "reason": "Live HoloIndex not available at E:/HoloIndex",
+            "measured_at": datetime.utcnow().isoformat() + "Z",
+        }
+
+    results = []
+    for sentinel in ALL_RECALL_SENTINELS:
+        result = _run_recall_sentinel(holo, sentinel)
+        results.append(asdict(result))
+
+    # Compute aggregates
+    total = len(results)
+    pass_count = sum(1 for r in results if r["verdict"] == "PASS")
+    fail_count = sum(1 for r in results if r["verdict"] == "FAIL")
+
+    # By bucket
+    wsp_results = [r for r in results if r["expected_bucket"] == "wsp"]
+    docs_results = [r for r in results if r["expected_bucket"] == "docs"]
+    knowledge_results = [r for r in results if r["expected_bucket"] == "knowledge"]
+
+    return {
+        "status": "COMPLETE",
+        "measured_at": datetime.utcnow().isoformat() + "Z",
+        "total_sentinels": total,
+        "aggregate": {
+            "pass_count": pass_count,
+            "pass_rate": round(pass_count / total, 4) if total > 0 else 0,
+            "fail_count": fail_count,
+            "fail_rate": round(fail_count / total, 4) if total > 0 else 0,
+        },
+        "by_bucket": {
+            "wsp": {
+                "total": len(wsp_results),
+                "pass": sum(1 for r in wsp_results if r["verdict"] == "PASS"),
+            },
+            "docs": {
+                "total": len(docs_results),
+                "pass": sum(1 for r in docs_results if r["verdict"] == "PASS"),
+            },
+            "knowledge": {
+                "total": len(knowledge_results),
+                "pass": sum(1 for r in knowledge_results if r["verdict"] == "PASS"),
+            },
+        },
+        "sentinel_results": results,
+    }
+
+
+if __name__ == "__main__":
+    import json
+    report = generate_recall_quality_report()
+    print(json.dumps(report, indent=2))


### PR DESCRIPTION
## Summary
- Adds docs and knowledge recall quality tests for HoloIndex Agentic RAG
- Verifies audit documents and WSP knowledge files are retrievable
- Documents recall gaps and natural language query limitations
- Removes xfails after re-indexing fixed staleness issues

## Changed Files
- `holo_index/tests/test_agentic_rag_docs_knowledge_recall.py` (new)
- `docs/audits/holoindex_search_quality/HIA_AGENTIC_RAG_DOCS_KNOWLEDGE_RECALL.md` (new)
- `holo_index/ModLog.md` (updated)

## Validation
- `python -m pytest holo_index/tests/test_agentic_rag_docs_knowledge_recall.py -q` — 8/8 passed
- `python -m pytest holo_index/tests/test_agentic_rag_sentinel_sufficiency.py -q` — 11/11 passed
- `python -m pytest holo_index/tests/test_collection_health.py -q` — 18/18 passed
- `python -m pytest holo_index/tests/test_search_quality_baseline.py -q` — 10/10 passed

## WSP 97
No runtime ranking changes. No vector artifacts. No TurboQuant promotion. Tests only.

🤖 Generated with [Claude Code](https://claude.ai/code)