### PR TITLE
chore(audits): allowlist MCP and OpenClaw-Hermes audit directories for indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -340,6 +340,8 @@ docs/audits/*
 !docs/audits/holoindex_search_quality/**
 !docs/audits/openclaw_hermes/
 !docs/audits/openclaw_hermes/**
+!docs/audits/mcp_system/
+!docs/audits/mcp_system/**
 docs/sessions/
 
 # WSP agentic awakening runtime state (changes every session)

--- a/.gitignore
+++ b/.gitignore
@@ -338,6 +338,8 @@ docs/audits/*
 !docs/audits/holoindex_ascii_guardian/**
 !docs/audits/holoindex_search_quality/
 !docs/audits/holoindex_search_quality/**
+!docs/audits/openclaw_hermes/
+!docs/audits/openclaw_hermes/**
 docs/sessions/
 
 # WSP agentic awakening runtime state (changes every session)

--- a/docs/audits/mcp_system/MCPA1_MCP_SURFACE_AUTHORITY_AUDIT.md
+++ b/docs/audits/mcp_system/MCPA1_MCP_SURFACE_AUTHORITY_AUDIT.md
@@ -1,0 +1,305 @@
+# MCPA1 — MCP Surface Authority Audit (Phase 1)
+
+**Slice**: `MCPA1_MCP_SURFACE_AUTHORITY_AUDIT_PHASE1`
+**Worker**: W1
+**Date**: 2026-05-08
+**Mode**: Audit only — no runtime fixes, no commits, no flag flips
+**WSP Lock**: WSP_00 → WSP_50 → WSP_97
+**Companion audits**: `docs/audits/openclaw_hermes/HXA1_*.md`, `HXA2_*.md`
+
+---
+
+## HoloIndex Research
+
+```bash
+python holo_index.py --search "MCP holo_index server foundups_mcp_bridge pavs_mcp mcp_manager holo_search authority routing auth scope" --limit 6
+```
+
+**Top CODE hit**: `modules/infrastructure/pavs_mcp/src/server.py`
+**Top WSP hit**: `WSP_framework/src/WSP_96_MCP_Governance_and_Consensus_Protocol.md`
+**Top DOCS hit**: `modules/infrastructure/pavs_mcp/INTERFACE.md`
+
+---
+
+## 1. Surface Inventory
+
+### Status legend
+
+- **`RUNTIME_LIVE`** — real, exercised path that calls actual backends.
+- **`RUNTIME_INTERNAL_ONLY`** — real backend access, but not exposed over MCP transport (Python-class CLI only).
+- **`PLACEHOLDER_STUB`** — file exists but every tool returns hardcoded data; `# TODO: Connect to actual <X>` markers in code.
+- **`MANAGER_ONLY`** — orchestration helper, not itself an MCP surface.
+
+| # | Surface | Path | Transport | Status | Intended Consumers |
+|---|---------|------|-----------|--------|---------------------|
+| S1 | HoloIndex MCP Server (P1) | `foundups-mcp-p1/servers/holo_index/server.py` | FastMCP (stdio/sse) | **RUNTIME_LIVE** | External AI clients (Cursor, Windsurf, ChatGPT) via FastMCP transport |
+| S2 | FoundUps Private MCP Bridge | `modules/infrastructure/foundups_mcp_bridge/src/bridge_server.py` | Python class + CLI (no MCP wire transport) | **RUNTIME_INTERNAL_ONLY** | Internal 0102 / AI architect via direct Python calls or `python -m ... --call <tool>` CLI |
+| S3 | pAVS MCP Server | `modules/infrastructure/pavs_mcp/src/server.py` | None (asyncio sleep loop, no actual server) | **PLACEHOLDER_STUB** | (Claimed) Federated FoundUp repos (autopost, gotjunk, move2japan); (actual) nobody — server doesn't bind a port |
+| S4 | MCP Manager | `modules/infrastructure/mcp_manager/src/mcp_manager.py` | None (subprocess orchestrator) | **MANAGER_ONLY** | Local main.py menu — discovers and starts S1-class servers |
+
+### Status evidence
+
+- **S1 — RUNTIME_LIVE**: `foundups-mcp-p1/servers/holo_index/server.py:1` imports `FastMCP`. Line 17: `app = FastMCP("Foundups HoloIndex MCP Server")`. Line 21: `self.holo_index = HoloIndex()` instantiates the real engine. Line 28: `self.holo_index.search(query, limit=limit)` is a real call. File is 557 lines.
+- **S2 — RUNTIME_INTERNAL_ONLY**: `bridge_server.py:54-74` defines a `FoundUpsMCPBridge` Python class. Tools registered at lines 79-131. Real backend access via `holo_tools._get_holoindex` (`holo_tools.py:40-72`). CLI entry at lines 232-289 (`--call <tool>`). **No MCP transport** — nothing in this file binds stdio, sse, websocket, or HTTP. The README claims "MCP Bridge" but the code is a Python class with a CLI shim.
+- **S3 — PLACEHOLDER_STUB**: Every tool body has `# TODO: Connect to actual <X>` with hardcoded return:
+  - `cabr_validate` (`pavs_mcp/src/server.py:79-91`): hardcoded `score=0.85, passed=True`. TODO at line 79.
+  - `gemma_classify` (lines 108-116): hardcoded confidence `0.92`.
+  - `qwen_plan` (lines 133-147): hardcoded 3-step plan.
+  - `fam_emit` (lines 166-181): TODO at line 166; computes a hash but does not emit to FAM DAEmon.
+  - `pattern_recall` (lines 198-213): TODO at line 198; returns a hardcoded fake pattern `ptn_001`.
+  - `pattern_store` (lines 230-241): TODO at line 230; computes a hash, no persistence.
+  - `holo_search` (lines 259-273): TODO at line 260; returns a hardcoded match for `modules/foundups/agent_market/src/example.py`.
+  - `handle_tool_call` (line 329): `# TODO: Implement proper auth`. The `api_key` parameter is accepted but never validated.
+  - `start` (lines 352-363): `# TODO: Implement actual WebSocket server`. Does not bind. Just `await asyncio.sleep(60)` in a loop.
+- **S4 — MANAGER_ONLY**: `mcp_manager.py:122-138` `_discover_mcp_servers` scans only `foundups-mcp-p1/servers/`. It does NOT discover S2 or S3.
+
+---
+
+## 2. Authority Matrix
+
+For each capability, identify the canonical owner surface and any duplicates/conflicts.
+
+### 2.1 `holo_search` (semantic search)
+
+| Surface | Tool name | Real backend? | Schema | Auth | Notes |
+|---------|-----------|---------------|--------|------|-------|
+| **S1** | `semantic_code_search` (`server.py:24-75`) | **YES** — `self.holo_index.search(query, limit)` | quantum-coherence-decorated | None at app layer (FastMCP transport only) | **Canonical external owner** |
+| **S2** | `holo_search` (`holo_tools.py:80-199`) | **YES** — `holo.search(query, limit, doc_type_filter)` via lazy `_get_holoindex` | `ok_response`-wrapped `{hits[], hit_count, metadata}` | None | **Canonical internal owner** (perception layer); has ripgrep fallback at lines 167-198 |
+| **S3** | `holo_search` (`pavs_mcp/src/server.py:243-273`) | **NO** — hardcoded match | `{matches[]}` flat | None (api_key TODO) | **Duplication conflict** — claims to be federation surface but contains zero real logic |
+
+**Duplication conflict**: S1, S2, and S3 all expose a `holo_search`-shaped capability. S1 and S2 both call the real `holo_index.core.holo_index.HoloIndex.search`. S3 lies about doing so.
+
+**Canonical recommendation** (anchored to the real backend at `holo_index/core/holo_index.py:178-198` and `search_engine.py:execute_search`): one canonical engine (the `HoloIndex` class) with two intentional adapters — S1 for external MCP clients, S2 for internal Python/CLI callers. S3 must either delegate to S1/S2 or be removed.
+
+### 2.2 Auth (api key validation, tenant identity)
+
+| Surface | Auth mechanism | Evidence | Status |
+|---------|----------------|----------|--------|
+| S1 | None at app layer; relies on FastMCP transport (no `api_key`/`tenant_id` checks in tool bodies) | grep `api_key|auth|tenant|scope|authorize` in `server.py`: 0 hits | UNENFORCED |
+| S2 | None | grep same patterns in `bridge_server.py`: 0 hits (the only `api_key` refs are for Google AI Studio at `holo_tools.py`-adjacent files, not MCP auth) | UNENFORCED |
+| S3 | Stub: `handle_tool_call` accepts `api_key` parameter but never validates it (`pavs_mcp/src/server.py:329` — `# TODO: Implement proper auth`) | Confirmed; the `foundup_register` method generates `api_keys` but no surface checks them | UNENFORCED |
+| S4 | N/A (manager, not gateway) | — | N/A |
+
+**Canonical owner**: NONE today. The README at `pavs_mcp/README.md:117` claims "WSP 71: Security - API key auth, encrypted transport"; this claim has no enforcement code behind it.
+
+### 2.3 Tenant scope / `foundup_id` ownership
+
+| Surface | Mechanism | Evidence | Status |
+|---------|-----------|----------|--------|
+| S1 | None | No `foundup_id` parameter on any tool in `server.py` | NOT ENFORCED |
+| S2 | None | Tools accept paths/queries; no caller-foundup binding | NOT ENFORCED |
+| S3 | `FoundUpRegistration` dataclass exists (`pavs_mcp/src/server.py:21-28`); registration generates `api_key` mapping to `foundup_id` (`foundup_register` lines 275-310). But the registry is never consulted by any tool. Tools accept `foundup_id` as a request parameter (e.g. `fam_emit`) and trust it without verifying it matches the caller's `api_key` | Cross-tenant risk: any `api_key` can pass any `foundup_id` to `fam_emit`/`pattern_store` and the surface accepts it | NOT ENFORCED |
+
+### 2.4 Registration
+
+| Surface | Mechanism | Authority |
+|---------|-----------|-----------|
+| S1 | Implicit — FastMCP picks up tools via `@app.tool()` decorators (`server.py:23, 77, 112, ...`) | Within S1 only |
+| S2 | Explicit in `bridge_server._register_tools` (`bridge_server.py:76-131`) | Within S2 only |
+| S3 | `FoundUpRegistration` dataclass + `foundup_register` tool (`pavs_mcp/src/server.py:21-28, 275-310`) | Claims to be a system-wide registry but persistence is in-memory `self.registrations: dict[str, FoundUpRegistration]` (line 48) — lost on restart, never read by any other surface |
+| S4 | Subprocess discovery in `_discover_mcp_servers` (`mcp_manager.py:122-138`) | Discovers S1-class servers only; ignores S2 and S3 |
+
+**Canonical owner**: There is no shared FoundUp registration authority. S3's in-memory dict is the only "registry" claim and it neither persists nor cross-references with any other surface.
+
+### 2.5 Tool dispatch
+
+| Surface | Mechanism | Evidence |
+|---------|-----------|----------|
+| S1 | FastMCP `@app.tool()` decorator → FastMCP routes via stdio/sse | `server.py:23, 77, 112, ...` |
+| S2 | `_tools: Dict[str, Callable]` registry + `call_tool(name, **kwargs)` (`bridge_server.py:171-194`) | Direct Python dispatch; no transport |
+| S3 | `_tools: dict[str, callable]` + `handle_tool_call` (`pavs_mcp/src/server.py:51-62, 312-350`) | Same pattern as S2 but dispatch is wired to placeholder bodies |
+
+**Drift**: S2 and S3 use lookalike but incompatible dispatch surfaces (different return wrappers, different error envelopes — see §4).
+
+---
+
+## 3. Routing Matrix
+
+### Ingress points → which MCP surface is actually called
+
+| Ingress | Caller | Reaches | Bypass risk |
+|---------|--------|---------|-------------|
+| FastMCP client (Cursor, Windsurf, external IDE) | External AI tool | **S1** (via stdio/sse) | None (transport-locked); no app auth gate, but transport pairing is local-only |
+| `python -m modules.infrastructure.foundups_mcp_bridge.src.bridge_server --call <tool>` | Local 0102/operator | **S2** (Python class) | None — direct local invocation |
+| `from modules.infrastructure.foundups_mcp_bridge.src import FoundUpsMCPBridge` | Internal Python code | **S2** | None — direct import |
+| (Documented) `wss://pavs.foundups.com/mcp` | (Claimed) federated FoundUps via TS/Python SDK | **NOWHERE** — S3 does not bind a port (`server.py:354` is a TODO; `start` just sleeps) | Endpoint is fictional; clients written against `pavs_mcp/README.md:108` ("PAVS_ENDPOINT=wss://pavs.foundups.com/mcp") will fail to connect |
+| `python main.py --mcp` (menu option 14) | Local operator | **S4 → S1** (manager auto-starts S1-class servers from `foundups-mcp-p1/servers/`) | S4 cannot start S2 or S3 (auto-discovery only scans the p1 dir) |
+
+### Bypass-of-policy paths
+
+1. **No app-layer auth on S1 or S2**: any caller reaching the transport (FastMCP local pairing for S1, local Python import for S2) can call any tool. Policy intent (per `pavs_mcp/README.md:117` and `WSP 96`) is never executed because S3 — the only surface that even tried — is a stub.
+2. **`mcp_manager` does not orchestrate S2 or S3**: a local operator running `python main.py --mcp` will start S1 but will not expose, monitor, or even know about S2 and S3.
+3. **S3 silent failure**: clients written against the documented `wss://pavs.foundups.com/mcp` will hang — the server starts but never accepts connections. There is no error surfacing to the operator.
+4. **`FoundUp federation` claim has no enforcement**: a federated FoundUp could try to pass any `foundup_id` to `fam_emit` (S3 line 149-181) and the surface would happily accept it (if S3 were running). Not a live exploit because S3 isn't running, but the design is fail-open.
+
+---
+
+## 4. Response Contract Drift
+
+`holo_search` result schemas across the three surfaces:
+
+### S1 (foundups-mcp-p1) — `semantic_code_search` (server.py:53-66)
+
+```json
+{
+  "query": "<query>",
+  "code_results": [
+    {"content": "...", "path": "...", "function": "...", "line": 0,
+     "relevance": 1.0, "snippet": "..."}
+  ],
+  "wsp_results": [
+    {"content": "...", "path": "...", "protocol": "...",
+     "relevance": 1.0, "snippet": "..."}
+  ],
+  "total_results": 0,
+  "quantum_coherence": <float>,
+  "bell_state_alignment": <bool>,
+  "timestamp": <float>,
+  "search_metadata": {"limit": 5, "file_types": [], "execution_time": 0}
+}
+```
+
+### S2 (foundups_mcp_bridge) — `holo_search` (holo_tools.py:149-160)
+
+```json
+{
+  "status": "ok",
+  "data": {
+    "query": "<query>",
+    "scope": "all|code|wsp|test|skill",
+    "hits": [
+      {"type": "code|wsp|test|skill", "path": "...", "relevance": 0.0,
+       "preview": "...", "title": "...", "summary": "..."}
+    ],
+    "hit_count": 0,
+    "metadata": {...}
+  },
+  "meta": {"timestamp": "...", "source": "holoindex|fallback", "tool": "holo_search", "confidence": 0.8}
+}
+```
+
+### S3 (pavs_mcp) — `holo_search` (server.py:264-273)
+
+```json
+{
+  "matches": [
+    {"file": "...", "line": 42, "content": "...", "score": 0.95}
+  ]
+}
+```
+
+### Compatibility verdict
+
+| Pair | Compatible? | Why |
+|------|-------------|-----|
+| S1 vs S2 | **INCOMPATIBLE** | Different envelopes (S1 flat; S2 status/data/meta), different hit collection names (`code_results`+`wsp_results` vs unified `hits[]` with `type`), different relevance scaling (S1: HoloIndex distance, S2: parsed similarity 0-1), S1 adds quantum/bell-state fields that S2 omits |
+| S1 vs S3 | **INCOMPATIBLE + STALE** | S3 has no `code_results`/`wsp_results` split, no quantum/bell fields; S3's `matches[]` schema does not match anything S1 returns. Stale: S3 was written before S1 stabilized and has not been reconciled |
+| S2 vs S3 | **INCOMPATIBLE + STALE** | S2 wraps in `ok_response`; S3 returns flat dict. S3's `matches[]` is closer to S2's `hits[]` shape but uses different keys (`file`/`line`/`content`/`score` vs `path`/`preview`/`relevance`) |
+
+**No common contract exists.** A client cannot today be written against a single `holo_search` schema.
+
+---
+
+## 5. Auth & Scope Enforcement Audit
+
+### Surface-by-surface enforcement reality
+
+| Surface | API key check | `foundup_id` ownership check | Cross-tenant risk |
+|---------|---------------|------------------------------|--------------------|
+| S1 (P1 holo_index server) | Not implemented; relies on FastMCP transport pairing | No `foundup_id` field on any tool | **MEDIUM** — transport binds locally; risk is operator-side leakage, not cross-tenant |
+| S2 (foundups_mcp_bridge) | Not implemented | No `foundup_id` field on any tool | **LOW** — internal-only, no remote ingress |
+| S3 (pavs_mcp) | Stub (`# TODO: Implement proper auth` at line 329) | Stub (`FoundUpRegistration` defined but never consulted) | **N/A** (server isn't running) but **CRITICAL** the moment it is — design is fail-open |
+
+### Severity-ranked risks
+
+| ID | Risk | Severity | Surface | Evidence |
+|----|------|----------|---------|----------|
+| R1 | S3 documented as a federation auth boundary but has zero enforcement; if started without remediation, any caller can register any `foundup_id` and call any tool against any other tenant's data | **CRITICAL** | S3 | `pavs_mcp/src/server.py:329` (auth TODO), `:312-350` (handler ignores `api_key`), `pavs_mcp/README.md:117` (claim) |
+| R2 | S3 documented client endpoint (`wss://pavs.foundups.com/mcp`) does not exist — S3 does not bind any port | **CRITICAL** (silent failure for any consumer) | S3 | `pavs_mcp/src/server.py:354` (TODO), `:362` (sleep loop), `pavs_mcp/README.md:108` (endpoint claim) |
+| R3 | Three divergent `holo_search` result schemas; clients cannot interop | **HIGH** | S1, S2, S3 | §4 above |
+| R4 | `mcp_manager` only discovers S1-class servers; S2 and S3 are invisible to the gateway | **HIGH** | S4 | `mcp_manager.py:122-138` |
+| R5 | S1 and S2 do not enforce app-layer auth; any local pairing/import can call all tools | **MEDIUM** | S1, S2 | Empty grep results for `auth`/`tenant`/`api_key` on tool surfaces |
+| R6 | S3's in-memory `registrations` dict is the only registration "registry" — does not persist across restarts and is not read by any other surface | **MEDIUM** | S3 | `pavs_mcp/src/server.py:48, 275-310` |
+| R7 | Three separate "holo_search" implementations create maintenance drift; future fixes to the `HoloIndex` engine must be re-validated against three callers (or two, since S3 doesn't actually call the engine) | **MEDIUM** | All | §2.1 |
+| R8 | Bridge README and pAVS README both describe themselves as "MCP" surfaces but neither speaks any MCP wire protocol (S2 = Python CLI; S3 = nothing) | **MEDIUM** | S2, S3 | `foundups_mcp_bridge/README.md:5` ("MCP bridge"), `pavs_mcp/README.md:1` ("MCP Server") |
+
+**Risk count**: Critical = 2; High = 2; Medium = 4.
+
+---
+
+## 6. Canonicalization Decision
+
+### **MULTI_SURFACE_DRIFT_BLOCKING**
+
+Three surfaces claim `holo_search`. Only two implement it; one (S3) is a placeholder. The two real ones return incompatible schemas. None enforce app-layer auth. The MCP Manager only knows about one of them. The pAVS README documents an endpoint that does not exist.
+
+Until the drift is resolved, **further MCP feature prompts must NOT add new tools to S3 or assume any of the three surfaces is the canonical authority**. Any feature added to one surface today will need to be re-implemented on the other two — which is exactly the failure pattern WSP 96 (MCP Governance) is meant to prevent.
+
+---
+
+## 7. Minimum Remediation Plan
+
+Six atomic slices, ordered by risk. **Slice 1 is the trunk blocker.**
+
+### Slice 1 (Trunk) — `MCP_HOLO_SEARCH_CANONICAL_CONTRACT_PHASE1`
+
+- **Objective**: Define the canonical `holo_search` request/response contract (one envelope, one hit shape) and document it in `WSP_framework/src/WSP_96_*` or a new `MCP_CONTRACTS.md`. No code changes; contract artifact only.
+- **Files**: `docs/mcp/MCP_HOLO_SEARCH_CONTRACT.md` (NEW). Optional ModLog entry.
+- **Acceptance**: Single document defines the response envelope (status/data/meta), the hit object (type/path/relevance/preview/...), and the relevance scale (0-1). Document is referenced from S1, S2, and S3 docstrings in subsequent slices.
+
+### Slice 2 — `MCP_PAVS_HONESTY_PHASE1` (de-overclaim)
+
+- **Objective**: Stop the false-compliance pattern in S3. Either (a) clearly mark S3 as `STATUS=PROTOTYPE_NOT_RUNNING` in README and replace `wss://pavs.foundups.com/mcp` with `<not yet deployed>`, or (b) remove S3 entirely. Decision in this slice; execution in slice 5.
+- **Files**: `modules/infrastructure/pavs_mcp/README.md` (MODIFY — status banner), `modules/infrastructure/pavs_mcp/src/server.py` (MODIFY — startup banner clarifying placeholder status if kept). No business logic change.
+- **Acceptance**: Operator running `python -m modules.infrastructure.pavs_mcp.src.server` sees an explicit "PLACEHOLDER — TOOLS RETURN HARDCODED DATA — NO AUTH — DO NOT USE FOR REAL TENANTS" banner. README endpoint claim is removed or marked `(planned)`.
+
+### Slice 3 — `MCP_MANAGER_DISCOVERY_EXPANSION_PHASE1`
+
+- **Objective**: Extend `MCPServerManager._discover_mcp_servers` to also surface S2 and S3 as known surfaces (with explicit status: live/internal-only/placeholder), so the gateway report does not lie about what exists.
+- **Files**: `modules/infrastructure/mcp_manager/src/mcp_manager.py:122-138`. Plus tests in `modules/infrastructure/mcp_manager/tests/`.
+- **Acceptance**: `python main.py --mcp` lists three rows (HoloIndex P1 server, foundups_mcp_bridge, pavs_mcp) with truthful status flags. No transport changes.
+
+### Slice 4 — `MCP_HOLO_SEARCH_DELEGATION_PHASE1`
+
+- **Objective**: Make S3's `holo_search` either (a) delegate to S2's `holo_search` (so behavior is real), or (b) return `{"status": "not_implemented", "error": "pavs_mcp.holo_search is a placeholder"}` instead of fake data. Choose path (b) until the federation auth/scope layer (Slice 6) lands.
+- **Files**: `modules/infrastructure/pavs_mcp/src/server.py:243-273`.
+- **Acceptance**: S3's `holo_search` no longer returns hardcoded matches; returns explicit `not_implemented` until federation is real.
+
+### Slice 5 — `MCP_AUTH_BASELINE_PHASE1`
+
+- **Objective**: Add the simplest credible app-layer auth on S2 (the surface that's actually used). Single shared-secret env var (`FOUNDUPS_MCP_BRIDGE_TOKEN`) checked on `call_tool`. Not federation-grade — just closes the "any local Python import can run anything" gap if/when the bridge is exposed beyond direct internal use.
+- **Files**: `modules/infrastructure/foundups_mcp_bridge/src/bridge_server.py:171-194`. Tests.
+- **Acceptance**: With the env var set, calls without the matching token are rejected with `error_response("auth required")`. With the var unset (current default), behavior is unchanged (back-compat).
+
+### Slice 6 — `MCP_FEDERATION_AUTH_AND_SCOPE_PHASE1`
+
+- **Objective**: Real federation auth/scope on S3 (the surface that claims to need it). API-key → `foundup_id` mapping, persistent registry, per-tool scope enforcement. Only proceeds after Slice 1 (canonical contract) and Slice 4 (no fake data) so the new auth doesn't cement a broken contract.
+- **Files**: `modules/infrastructure/pavs_mcp/src/server.py` (full rewrite of `handle_tool_call` and `foundup_register`); persistent registry adapter (likely SQLite via existing `agent_market` patterns); transport layer.
+- **Acceptance**: S3's `handle_tool_call` rejects calls without a registered API key. `foundup_id` arguments on tools are verified against the registered identity. Cross-tenant attempts fail with explicit error.
+
+---
+
+## Acceptance Criteria Verification
+
+- ✓ Every claim tied to file:line (sections 1-5).
+- ✓ No speculative claims — distinguished `RUNTIME_LIVE` vs `RUNTIME_INTERNAL_ONLY` vs `PLACEHOLDER_STUB` with specific TODO line numbers.
+- ✓ Clear canonical owner recommendation for `holo_search`: `holo_index/core/holo_index.py` is the engine; S1 is the canonical external MCP adapter; S2 is the canonical internal Python adapter; S3 must delegate or stand down.
+- ✓ Clear no-go for further MCP feature prompts until Slice 1 (canonical contract) lands.
+
+---
+
+## WSP 97 Applied
+
+- **CoT (retrieve before stating)**: HoloIndex run before any conclusion; canonical WSP 96 reference surfaced as top WSP hit and confirms the governance lens used here.
+- **CoR (dialectic sweep before committing)**: considered one-server consolidation (collapse S1+S2+S3 into one) vs. canonical-owner-with-adapters; chose `MULTI_SURFACE_DRIFT_BLOCKING` because the S1/S2 split has legitimate transport reasons (external MCP vs internal Python) and only S3 is the actual drift hazard. The remediation plan reflects this — S1 and S2 keep their roles; S3 must stand down or be rebuilt to a real spec.
+- **Truth distinction**: avoided the trap of treating S3 as "an MCP server with a TODO" — it is a placeholder with `# TODO` markers and an `asyncio.sleep(60)` body that does not bind a port. Calling it a server overclaims.
+- **WSP 50 verification**: every required file was read in full or via targeted grep with line-numbered evidence; file existence and sizes verified before reading.
+- **WSP 00 identity**: locked as Worker W1 throughout.
+
+---
+
+## Files Touched This Slice
+
+- `docs/audits/mcp_system/MCPA1_MCP_SURFACE_AUTHORITY_AUDIT.md` (NEW)
+
+No runtime code edits. No commits made.

--- a/docs/audits/openclaw_hermes/HXA1_OPENCLAW_HERMES_CONCATENATION_AUDIT.md
+++ b/docs/audits/openclaw_hermes/HXA1_OPENCLAW_HERMES_CONCATENATION_AUDIT.md
@@ -1,0 +1,258 @@
+# HXA1 — OpenClaw → Hermes Concatenation Audit (Phase 1)
+
+**Slice**: `HXA1_OPENCLAW_HERMES_CONCATENATION_AUDIT_PHASE1`
+**Worker**: W1
+**Date**: 2026-05-07
+**Mode**: Audit only — no runtime fixes, no commits, no flag flips
+**WSP Lock**: WSP_00 → WSP_50 → WSP_97
+
+---
+
+## HoloIndex Research
+
+```bash
+python holo_index.py --search "OpenClaw FoundUpJob WRE Hermes execute_foundup_job dry_run blocked real delegation" --limit 5
+```
+
+**Top hit (WSP)**: `WSP_framework/src/WSP_106_FoundUp_API_Gateway_Protocol.md`
+**Top hit (DOCS)**: `docs/0102_session_briefings/DD_HERMES_FOUNDUP_BUILDER_OPERATIONAL_PROOF_PHASE1.md`
+
+Confirmed prior architectural framing: Hermes builder is operational at the adapter layer (`modules/foundups/agent/src/hermes_adapter.py`), but the WRE-mediated path uses a separate dry-run-only seam.
+
+---
+
+## 1. Canonical Runtime Path (Observed)
+
+**Truth boundary**: The runtime path stops at the queue. It does NOT execute Hermes today.
+
+```
+Intent (chat or "follow WSP") → OpenClaw → FoundUpJob (QUEUED) → _FOUNDUP_JOB_QUEUE
+                                                                  ↓
+                                                                  ⊥ (no production drainer)
+```
+
+| Step | File:Line | Behavior |
+|------|-----------|----------|
+| 1. Plan dispatch | `modules/communication/moltbot_bridge/src/openclaw_execution_routes.py:44-45` | route="fam_adapter" → `execute_foundup(dae, intent)` |
+| 2. FoundUp routing | `modules/communication/moltbot_bridge/src/openclaw_execution_routes.py:672-699` | Imports `openclaw_foundup_orchestrator.dispatch_foundup` |
+| 3. Build intent detect | `modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py:777` | `_is_explicit_build_intent()` checks trigger phrases |
+| 4. Job creation | `modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py:811-894` | `_handle_build_intent` calls `create_job()` and appends to queue |
+| 5. Dry-run flag | `modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py:851-865` | `_detect_dry_run_mode()` sets `policy_flags.dry_run_mode` |
+| 6. Queue append | `modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py:873` | `_FOUNDUP_JOB_QUEUE.append(job)` — in-memory list |
+| 7. Response | `modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py:884-894` | Returns confirmation string. **End of runtime path.** |
+
+**Hypothetical continuation (only triggered by tests today):**
+
+| Step | File:Line | Behavior |
+|------|-----------|----------|
+| 8. Drain | `modules/infrastructure/wre_core/src/foundup_job_consumer.py:647-664` | `drain_openclaw_queue_once()` — only invoked from tests |
+| 9. Route | `modules/infrastructure/wre_core/src/foundup_job_router.py:201-353` | `route_foundup_job(job)` → `RouteEnvelope` |
+| 10. Hermes dispatch | `modules/infrastructure/wre_core/src/foundup_job_consumer.py:405-504` | `_dispatch_to_hermes()` imports WRE executor |
+| 11. Execute (WRE) | `modules/infrastructure/wre_core/src/hermes_job_executor.py:912-918` | `execute_foundup_job(job)` — singleton, dry_run=True |
+| 12. Always SIMULATED | `modules/infrastructure/wre_core/src/hermes_job_executor.py:707-726` | Returns `HermesDelegationResult(status=SIMULATED)` because `HERMES_DELEGATE_ENABLED=0` is default |
+| 13. Receipt skipped | `modules/infrastructure/wre_core/src/foundup_job_consumer.py:614-626` | SIMULATED + `!real_execution_performed` → return None (no receipt) |
+| 14. Job retained | `modules/infrastructure/wre_core/src/foundup_job_consumer.py:736-743` | `should_clear=False` (no receipt) → job retained with reason `dry_run_evidence_only` |
+
+**Observation**: Evidence-only files (`.hermes_evidence/{job_id}/metadata.json`, `checkpoint.json`) are written by `_write_evidence` (`hermes_job_executor.py:807-886`), but no receipt is emitted and `job.status` remains `QUEUED` throughout — never mutates to RUNNING/SUCCEEDED/FAILED.
+
+---
+
+## 2. Duplicate / Divergent Execution Paths
+
+**Two distinct `execute_foundup_job` symbols exist, with different signatures and different return types.**
+
+| # | Module | Signature | Returns | Mutates job.status? | Real Hermes call? |
+|---|--------|-----------|---------|---------------------|-------------------|
+| A | `modules.infrastructure.wre_core.src.hermes_job_executor` | `execute_foundup_job(job) -> HermesDelegationResult` (line 912) | `HermesDelegationResult` (status enum) | **No** — never touches job state | No (always SIMULATED in Phase 1) |
+| B | `modules.foundups.agent.src.hermes_foundup_job_executor` | `execute_foundup_job(job, repo_root=None, force_dry_run=False) -> HermesJobExecutionResult` (line 76) | `HermesJobExecutionResult` (job + hermes_result) | **Yes** — calls `job.start()`, `job.succeed()`, `job.fail()`, `job.block()` | Yes — invokes `HermesFoundUpBuilder.extract_foundup` / `analyze_boundary` / `check_exfoliation_gate` |
+
+### Callers
+
+**A (WRE executor) is called by:**
+- `modules/infrastructure/wre_core/src/foundup_job_consumer.py:425-439` (canonical consumer path)
+- `modules/infrastructure/wre_core/tests/test_hermes_job_executor.py` (37 references)
+
+**B (Hermes adapter executor) is called by:**
+- `modules/communication/moltbot_bridge/tests/test_internal_voteballot_build_poc.py` (12 calls)
+- `modules/communication/moltbot_bridge/tests/test_e2e_foundup_job_seam.py:171,250,346,406` (4 calls)
+- **No production callers.**
+
+### Classification
+
+- **Canonical (consumer path)**: A (WRE executor). Used by `FoundUpJobConsumer._dispatch_to_hermes`.
+- **Non-canonical (operational proof path)**: B (Hermes adapter executor). Tests prove `HermesFoundUpBuilder` works end-to-end, but the production path bypasses it.
+
+**Split-brain**: A and B disagree on what "execute_foundup_job" means. A is a no-op simulation envelope; B is a real builder invocation that mutates job state. Neither is wired into runtime — but if runtime were wired, it would call A and miss the actual builder.
+
+---
+
+## 3. Gate Reality Matrix
+
+| Gate | Implementation | Trigger Source | Fail Mode | Evidence Location |
+|------|----------------|----------------|-----------|-------------------|
+| **Delegation enable flag** (`HERMES_DELEGATE_ENABLED`) | Implemented (env-driven) | Env var read at `is_hermes_delegation_enabled()` | Default `0` → all jobs return SIMULATED status | `modules/infrastructure/wre_core/src/hermes_job_executor.py:60-66, 707-726` |
+| **dry_run source of truth** | **Fragmented across 4 sources** | (1) message patterns, (2) policy flag, (3) executor constructor, (4) `force_dry_run` param | Sources do not propagate to each other | See drift finding #2 below |
+| **Security gate** (`policy_flags.security_gate_*`) | Stub — checked but never set | Router checks `security_gate_checked && !security_gate_passed` to BLOCK | Nothing in runtime ever sets `security_gate_checked=True` | `modules/infrastructure/wre_core/src/foundup_job_router.py:285-295` (check); no setter in production code |
+| **Import gate** (Hermes delegate_task lazy import) | Implemented | `_lazy_import_delegate_task()` invoked when `dry_run=False` and feature enabled | Returns `BLOCKED_IMPORT_UNAVAILABLE` if `vendor.hermes_agent.tools.delegate_tool` missing | `modules/infrastructure/wre_core/src/hermes_job_executor.py:514-545, 750-763` |
+| **Receipt emission** | Implemented but **unreachable in canonical path** | `_emit_receipt_for_hermes_result` after dispatch | SIMULATED + `!real_execution_performed` → returns None (skip emission); otherwise delegates to `_emit_receipt_if_terminal` which requires `job.status` ∈ {succeeded, failed, blocked} — but WRE executor never mutates job.status | `modules/infrastructure/wre_core/src/foundup_job_consumer.py:506-629` |
+| **Verification transition** (`job.status` mutation) | Stub in canonical path | Only path B (Hermes adapter `_apply_hermes_result_to_job`) mutates status | Canonical (path A) never transitions `QUEUED → RUNNING → SUCCEEDED`, so receipts can't fire | `modules/foundups/agent/src/hermes_foundup_job_executor.py:307-409` (real); WRE path leaves status=QUEUED |
+| **Genesis Validation Gate** | Implemented but **not wired into dispatch** | `OpenClawFoundUpOrchestrator.validate_genesis_envelope()` | Existing, but `dispatch_foundup` and `_handle_build_intent` never call it | `modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py:359-468`. Production callers: **0**. Test callers: 5 in `test_openclaw_foundup_orchestrator.py` |
+| **Action support** (`SUPPORTED_ACTIONS` vs router map) | Two divergent sets | Hermes adapter uses frozenset of 3; router maps 4 actions | `queue_foundup_job` is routable to OPENCLAW_QUEUE but is not in `SUPPORTED_ACTIONS` for the Hermes adapter executor | Router: `modules/infrastructure/wre_core/src/foundup_job_router.py:85-90`; adapter: `modules/foundups/agent/src/hermes_foundup_job_executor.py:53-57` |
+
+---
+
+## 4. Truth Drift Findings
+
+### F-1 (Critical) — Runtime path is not concatenated end-to-end
+
+- **Claim** (per consumer/router/executor docstrings): OpenClaw → FoundUpJob → WRE Router → Consumer → Hermes is the canonical pipeline.
+- **Reality**: `_handle_build_intent` appends to `_FOUNDUP_JOB_QUEUE` and returns. **No production code drains the queue.** The consumer is invoked only from tests.
+- **Evidence**: `modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py:873` (queue append, runtime endpoint). Grep for `FoundUpJobConsumer|drain_openclaw_queue` outside `tests/`: zero non-test, non-source matches. Root ROADMAP confirms this gap: `ROADMAP.md:199` — *"Next priority: WRE_HERMES_EXECUTOR_CONSUMER_BINDING_DRY_RUN_PHASE1 — Wire executor into FoundUpJobConsumer drain loop"*.
+- **Operational risk**: Any "OC → Hermes built" claim today is false. Jobs accumulate in memory and disappear on process restart.
+
+### F-2 (Critical) — Two `execute_foundup_job` implementations with split-brain semantics
+
+- **Claim**: There is one canonical execute_foundup_job seam.
+- **Reality**: Two functions with the same name, divergent signatures, divergent behavior.
+  - WRE (`modules/infrastructure/wre_core/src/hermes_job_executor.py:912`) — `(job)` → `HermesDelegationResult`. Returns SIMULATED unless `HERMES_DELEGATE_ENABLED=1` AND `dry_run=False`. Even then, returns `BLOCKED_REAL_DELEGATION_NOT_IMPLEMENTED` (line 770-784). Never mutates job.
+  - Hermes adapter (`modules/foundups/agent/src/hermes_foundup_job_executor.py:76`) — `(job, repo_root, force_dry_run)` → `HermesJobExecutionResult`. Calls `HermesFoundUpBuilder.extract_foundup`/`analyze_boundary`/`check_exfoliation_gate`. Mutates `job.status` via `start/succeed/fail/block`.
+- **Evidence**: See section 2 callers table.
+- **Operational risk**: When wiring is added, an integrator could pick either function and get wildly different behavior. Function A (chosen by current consumer) yields no real work; function B yields real work but is not WRE-mediated and bypasses the router/envelope.
+
+### F-3 (Critical) — Genesis Validation Gate is implemented but unwired
+
+- **Claim** (per orchestrator docstring at lines 286-304): `OpenClawFoundUpOrchestrator` "enforces that all FoundUp operations pass through genesis envelope validation first."
+- **Reality**: `dispatch_foundup` (line 757) and `_handle_build_intent` (line 811) do not call `validate_genesis_envelope`, `launch_foundup`, or `build_foundup`. Jobs are created and queued without envelope validation.
+- **Evidence**: Grep for `validate_genesis_envelope|orchestrator.build_foundup\(|orchestrator.launch_foundup\(` in non-test production code: 0 hits in `dispatch_foundup` callgraph. Only test files invoke it.
+- **Operational risk**: WSP 97 truthfulness violation — genesis gate is documented as enforced, but is bypassed. Any job action (build_foundup, extract_foundup) would proceed without lifecycle/binding-state/acceptance-criteria checks if wiring is added without also wiring the gate.
+
+### F-4 (High) — `dry_run` has four uncoordinated sources of truth
+
+- **Sources**:
+  1. `policy_flags.dry_run_mode` set by `_detect_dry_run_mode` from message patterns (`openclaw_foundup_orchestrator.py:91-125, 851-865`).
+  2. `HermesJobExecutor.dry_run` constructor parameter, default `True` (`hermes_job_executor.py:474-490`).
+  3. `HERMES_DELEGATE_ENABLED` env flag (separate from dry_run, but functionally equivalent — disables real execution) (`hermes_job_executor.py:60-66`).
+  4. `force_dry_run` parameter on path B's `execute_foundup_job` (`hermes_foundup_job_executor.py:79`), and `HermesFoundUpBuilder.dry_run` attribute (path B mutates it directly at line 187).
+- **Drift**: The consumer creates `FoundUpJobConsumer(dry_run=True)` (`foundup_job_consumer.py:342-349`) but **does not pass dry_run into the WRE `execute_foundup_job(job)` call** (`foundup_job_consumer.py:439`). The comment at line 437 admits: *"WRE executor respects dry_run via constructor, not per-call param"* — but the consumer never constructs the executor; it uses the singleton from `get_executor()` which defaults to `dry_run=True` regardless of consumer's flag.
+- **Operational risk**: Setting `policy_flags.dry_run_mode=False` on a job has no effect on WRE path execution. The job's policy snapshot lies about the mode that was actually used.
+
+### F-5 (High) — Receipts cannot be emitted in the canonical path
+
+- **Claim** (consumer docstring line 110-135): "ConsumerResult contains the complete closed-loop evidence chain" including receipt and pAVS verification.
+- **Reality**:
+  - `_emit_receipt_for_hermes_result` at line 614-626 returns None for SIMULATED status with `!real_execution_performed`.
+  - Phase 1 always returns SIMULATED with `real_execution_performed=False` (`hermes_job_executor.py:712-746`).
+  - Therefore the canonical consumer path **never** emits a `ProofOfComputeReceipt`.
+  - Even bypassing the SIMULATED skip, `_emit_receipt_if_terminal` (line 506-569) requires `job.status.value ∈ {succeeded, failed, blocked}`, but WRE executor never mutates job.status.
+- **Evidence**: `proof_of_compute_receipt.py` `create_receipt`/`create_receipt_from_job` callers in non-test code: 0 (only `tests/test_proof_of_compute_receipt.py`).
+- **Operational risk**: Any downstream consumer expecting a receipt artifact (pAVS, CABR) will see nothing in the canonical path. Evidence is captured as `.hermes_evidence/{job_id}/` files only, not as typed `ProofOfComputeReceipt` records.
+
+### F-6 (High) — `HermesJobExecutionResult` shape mismatch with `HermesDelegationResult`
+
+- **Claim**: Consumer's terminal-detection logic (`is_terminal` property, line 214-246) handles "WRE executor" and "legacy executor" alike.
+- **Reality**: The two result types have completely different shapes.
+  - `HermesDelegationResult` (path A): exposes `.status` (HermesExecutionStatus enum), `.checkpoint_state`, `.evidence_path`, `.real_execution_performed`.
+  - `HermesJobExecutionResult` (path B): exposes `.job` (FoundUpJob), `.hermes_result` (dict), `.error` (str). No `.status` attr; status lives on `result.job.status`.
+- **Evidence**: `hermes_job_executor.py:348-441` (DelegationResult fields) vs. `hermes_foundup_job_executor.py:60-73` (`__slots__` of JobExecutionResult).
+- **Operational risk**: The consumer's "legacy support" branch at lines 240-246 would crash if path B's result were ever passed in (it tries `result.job.status` but B has it on `result.job` — actually that does work, but `getattr(hermes_result, "status", None)` at line 232 would return None for path B, falling through to the legacy branch). The split is brittle and undocumented.
+
+### F-7 (Medium) — `job.status` never mutates in the canonical (WRE) path
+
+- **Claim**: FoundUpJob lifecycle is `QUEUED → RUNNING → SUCCEEDED|FAILED|BLOCKED` (contract docstring line 86-104).
+- **Reality**: In the canonical consumer path, no code calls `job.start()`, `job.succeed()`, `job.fail()`, or `job.block()`. The job sits at `QUEUED` permanently. Only path B (the unwired Hermes adapter executor) actually drives transitions.
+- **Evidence**: `foundup_job_consumer.py` and `hermes_job_executor.py` (WRE) — grep for `job.start|job.succeed|job.fail|job.block`: 0 matches. Path B: 4 matches at `hermes_foundup_job_executor.py:170, 353, 365, 376, 404`.
+- **Operational risk**: Routing terminal-status check (`router.py:256-273`) is correct for re-routing protection, but every job re-routes endlessly because none ever reach SUCCEEDED/FAILED via the WRE path. Receipt emission gate (which requires terminal status) is permanently locked off.
+
+### F-8 (Medium) — `SUPPORTED_ACTIONS` (Hermes adapter) and `_ACTION_BACKEND_MAP` (router) disagree
+
+- **Reality**: Router maps 4 actions; adapter executor only supports 3.
+  - Router (`foundup_job_router.py:85-90`): `build_foundup`, `extract_foundup`, `validate_foundup`, `queue_foundup_job` (4)
+  - Adapter executor (`hermes_foundup_job_executor.py:53-57`): `build_foundup`, `extract_foundup`, `validate_foundup` (3, no `queue_foundup_job`)
+- **Operational risk**: If path B were ever wired in for `queue_foundup_job`, it would `FAIL` with `FAIL_VALIDATION_ERROR` (line 144-147). Currently moot (path B is unwired) but a foot-gun for live-flip work.
+
+### F-9 (Low) — Logger name leakage
+
+- `openclaw_execution_routes.py:22` declares `logger = logging.getLogger("openclaw_dae")` — but the file is `openclaw_execution_routes`. All log emissions from this module appear under the wrong logger name, complicating log routing and audit attribution.
+- **Operational risk**: Cosmetic only, but obscures truthful attribution if log filters are scoped by logger name.
+
+---
+
+## 5. Concatenation Decision
+
+### **NOT_CONCATENATED**
+
+The runtime path stops at `_FOUNDUP_JOB_QUEUE.append(job)`. There is no production drainer. Even if the consumer were invoked manually, the canonical path:
+
+- Calls a WRE `execute_foundup_job` that always returns SIMULATED.
+- Never mutates `job.status`.
+- Never emits a receipt.
+- Bypasses the genesis validation gate.
+- Bypasses the actual `HermesFoundUpBuilder` (the only code that does real Hermes work).
+
+The architecture **has** the seams (router, consumer, two executors, receipt module, genesis gate). They are not wired into a continuous path. Live-flip work would currently flip a no-op.
+
+---
+
+## 6. Minimal Remediation Plan (No Code)
+
+Six atomic slices, ordered. **Slice 1 is the trunk blocker.**
+
+### Slice 1 (Trunk) — `OPENCLAW_QUEUE_DRAIN_BINDING_PHASE1`
+
+- **Objective**: Wire `FoundUpJobConsumer.drain_openclaw_queue_with_retention()` into a production caller (cron tick, OpenClaw post-handler, or explicit `/openclaw drain` command). No execution behavior change beyond making the existing dry-run path reachable from runtime.
+- **Files**: `modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py` (or a new sibling drain entrypoint), one wiring point in OpenClaw DAE post-action, plus a new test that asserts a dry-run drain runs against a queued job without flag changes.
+- **Acceptance**: Submitting a `start build gotjunk --dry-run` intent, then triggering the drain, produces a `ConsumerResult` with `route_status=ROUTED`, `target_backend=hermes_builder`, `checkpoint_state=SIMULATED`, evidence files written under `.hermes_evidence/{job_id}/`, and the queue retention metadata reports `dry_run_evidence_only`.
+
+### Slice 2 — `HERMES_EXECUTOR_RECONCILIATION_PHASE1`
+
+- **Objective**: Resolve the two-`execute_foundup_job` split-brain. Either (a) make the WRE executor delegate to the Hermes adapter executor when `HERMES_DELEGATE_ENABLED=1` and `dry_run=False`, or (b) deprecate the Hermes adapter executor symbol and move its builder-invocation logic behind the WRE executor's "real execution" branch (currently `BLOCKED_REAL_DELEGATION_NOT_IMPLEMENTED` at `hermes_job_executor.py:770-784`).
+- **Files**: `modules/infrastructure/wre_core/src/hermes_job_executor.py`, `modules/foundups/agent/src/hermes_foundup_job_executor.py`, plus migration of the test surface from B → A or vice versa.
+- **Acceptance**: Exactly one production caller of `execute_foundup_job`. Test suites in `tests/test_internal_voteballot_build_poc.py` and `tests/test_e2e_foundup_job_seam.py` migrated to the chosen executor without behavior regression.
+
+### Slice 3 — `DRY_RUN_SINGLE_SOURCE_OF_TRUTH_PHASE1`
+
+- **Objective**: Make `policy_flags.dry_run_mode` the single source of truth. The consumer should construct the WRE executor with `dry_run=job.policy_flags.dry_run_mode` per call (or the WRE executor should read it from the job directly).
+- **Files**: `modules/infrastructure/wre_core/src/foundup_job_consumer.py:432-439`, `modules/infrastructure/wre_core/src/hermes_job_executor.py:673-748`.
+- **Acceptance**: Setting `policy_flags.dry_run_mode=False` on a queued job and draining produces a non-SIMULATED outcome (BLOCKED_FEATURE_DISABLED if flag off; BLOCKED_REAL_DELEGATION_NOT_IMPLEMENTED if flag on but execution not yet implemented), not silently SIMULATED.
+
+### Slice 4 — `GENESIS_GATE_DISPATCH_BINDING_PHASE1`
+
+- **Objective**: Insert `validate_genesis_envelope` (or `OpenClawFoundUpOrchestrator.build_foundup`) into `_handle_build_intent` so that build/extract intents fail-closed without a valid envelope. Phase-gated: log-only first, hard-block second.
+- **Files**: `modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py:811-894` (insert gate call before `create_job`), plus regression tests proving build intents without envelope produce `BLOCKED` reason codes.
+- **Acceptance**: A "start build gotjunk" intent without a genesis envelope returns `BLOCKED` with `GenesisGateReason.NO_ENVELOPE` (or chosen reason); with a valid envelope, the job is created and queued as before.
+
+### Slice 5 — `JOB_STATUS_TRANSITION_BINDING_PHASE1`
+
+- **Objective**: Make the WRE consumer drive `job.status` transitions (`start` on dispatch, `succeed`/`fail`/`block` on terminal) so receipt emission can fire when path B (or its successor) is wired.
+- **Files**: `modules/infrastructure/wre_core/src/foundup_job_consumer.py:405-504`.
+- **Acceptance**: After a SIMULATED dispatch, `job.status == BLOCKED` (or remains QUEUED with explicit policy reason); after EXECUTED, `job.status == SUCCEEDED`. Existing receipt-emission gate at line 614-626 unchanged.
+
+### Slice 6 — `ACTION_CONTRACT_RECONCILIATION_PHASE1`
+
+- **Objective**: Align `SUPPORTED_ACTIONS` (executor) with `_ACTION_BACKEND_MAP` (router) and `CANONICAL_ACTIONS` (contract). Decide whether `queue_foundup_job` is a Hermes-adapter action or a WRE-internal-only action.
+- **Files**: `modules/foundups/agent/src/hermes_foundup_job_executor.py:53-57`, `modules/infrastructure/wre_core/src/foundup_job_router.py:85-90`, `modules/communication/moltbot_bridge/src/foundup_job_contract.py:54-59`.
+- **Acceptance**: One frozenset of canonical actions, referenced by all three modules.
+
+---
+
+## Acceptance Criteria Verification
+
+- ✓ No speculative architecture claims — every finding tied to file:line.
+- ✓ All findings tied to concrete code references.
+- ✓ Canonical execution path unambiguous (section 1).
+- ✓ Split-brain risk explicitly identified (F-2) and remediation chosen (Slice 2).
+- ✓ Clear go/no-go for live execution: **NO-GO**. Slice 1 is the trunk blocker.
+
+---
+
+## WSP 97 Applied
+
+WSP_50 verification: every required file was read in full before findings. WSP_97 truth boundaries: this report distinguishes implemented seams from claimed-but-unwired behavior. WSP_00: identity-locked as W1 for HXA1 throughout.
+
+---
+
+## Files Touched This Slice
+
+- `docs/audits/openclaw_hermes/HXA1_OPENCLAW_HERMES_CONCATENATION_AUDIT.md` (NEW)
+
+No runtime code edits. No commits made (per W10 commit-lane discipline).

--- a/docs/audits/openclaw_hermes/HXA2_PROTOCOL_ACTION_BINDING_AUDIT.md
+++ b/docs/audits/openclaw_hermes/HXA2_PROTOCOL_ACTION_BINDING_AUDIT.md
@@ -1,0 +1,250 @@
+# HXA2 — Protocol-Action Binding Audit (Phase 1)
+
+**Slice**: `HXA2_PROTOCOL_ACTION_BINDING_AUDIT_PHASE1`
+**Worker**: W1
+**Date**: 2026-05-07
+**Mode**: Audit only — no runtime fixes, no commits, no flag flips
+**WSP Lock**: WSP_00 → WSP_50 → WSP_97
+**Companion audit**: `docs/audits/openclaw_hermes/HXA1_OPENCLAW_HERMES_CONCATENATION_AUDIT.md`
+
+---
+
+## HoloIndex Research
+
+```bash
+python holo_index.py --search "WSP 00 WSP 50 WSP 97 runtime enforcement OpenClaw WRE Hermes receipt verification" --limit 5
+```
+
+**Top WSP hit**: `WSP_framework/src/WSP_95_WRE_SKILLz_Wardrobe_Protocol.md`
+**Top DOCS hit**: `docs/audits/openclaw_hermes/HXA1_OPENCLAW_HERMES_CONCATENATION_AUDIT.md` (HXA1 — same lane)
+
+The HoloIndex retrieval surfaced the prior HXA1 audit as the top semantic match — confirming this audit operates on the same surface but on the protocol-binding axis.
+
+**File path correction (WSP 50 verification)**: The slice prompt referenced WSP filenames that do not exist in the canonical naming. The actual canonical files are:
+- `WSP_framework/src/WSP_00_Zen_State_Attainment_Protocol.md` (prompt said `WSP_00_Zenodo_First_Principle.md`)
+- `WSP_framework/src/WSP_50_Pre_Action_Verification_Protocol.md` (prompt said `WSP_50_Pre_Action_Validation.md`)
+- `WSP_framework/src/WSP_97_System_Execution_Prompting_Protocol.md` (matches)
+
+This audit reads and binds against the canonical files.
+
+---
+
+## 1. Protocol-to-Code Binding Matrix
+
+### Status legend
+
+- **`ENFORCED_RUNTIME`** — runtime path actually invokes the rule before the action proceeds (fail-closed possible).
+- **`ENFORCED_TEST_ONLY`** — implemented and exercised in tests but not invoked from the production runtime path.
+- **`DOC_ONLY`** — exists as protocol text or docstring claim with no enforcement code attached.
+- **`MISSING`** — neither runtime, test, nor stub implementation exists for this rule on the audited surface.
+
+### WSP 00 — Zen State Attainment
+
+| # | Protocol Rule | Source (WSP) | Runtime enforcement point on OC→Hermes path | Status |
+|---|---------------|--------------|----------------------------------------------|--------|
+| 00.1 | Boot Gate: check `wsp_00_zen_state_tracker.is_zen_compliant` before action | `WSP_00_Zen_State_Attainment_Protocol.md:36-38` | Only invoked from `modules/infrastructure/wsp_orchestrator/src/wsp_orchestrator.py:429-443` (Phase -1 of `follow_wsp()`). Reached only when an intent contains the literal phrase "follow wsp" via `modules/communication/moltbot_bridge/src/openclaw_execution_routes.py:368-417`. **FoundUp build/extract/validate intents do not trigger this gate.** | **DOC_ONLY** for FoundUp action path; `ENFORCED_RUNTIME` only for the literal "follow wsp" branch |
+| 00.2 | Run awakening if not compliant (`functional_0102_awakening_v2.py`) | `WSP_00:36-37` | Same Phase -1 path as 00.1; not reachable from `dispatch_foundup` (`openclaw_foundup_orchestrator.py:757-808`) | **DOC_ONLY** for FoundUp path |
+| 00.3 | Self/Role/Origin lock before action (no helper persona) | `WSP_00:41-92` | No code reads/sets these fields before job creation. `_handle_build_intent` (`openclaw_foundup_orchestrator.py:811-894`) only uses `intent.sender` as `tenant_id` | **MISSING** |
+| 00.4 | HoloIndex retrieval before any manifest step (Tier-0/Tier-1/Tier-2) | `WSP_00:122-156, 458-461` | `dispatch_foundup` does not call HoloIndex. `_handle_build_intent` does not call HoloIndex. `FoundUpJobConsumer.consume_one` (`foundup_job_consumer.py:351-403`) does not call HoloIndex. Grep for `holo_index\|HoloIndex\|build_execution_bundle` in `openclaw_foundup_orchestrator.py` and `foundup_job_consumer.py`: 0 hits | **MISSING** for FoundUp action path |
+| 00.5 | Decision Gate (WSP 15 MPS) when multiple actions are viable | `WSP_00:158-164` | `_handle_build_intent` does not score candidates; `_extract_action` (`openclaw_foundup_orchestrator.py:166-182`) is a deterministic phrase-match without WSP 15 scoring | **MISSING** |
+| 00.6 | Identity-coherence canary (no "user" reference, no role inflation) | `WSP_00:553-571` | No runtime sentinel on the FoundUp path checks self/role/origin coherence | **MISSING** |
+| 00.7 | Anti-Vibecoding 7-phase work cycle (Research → Comprehend → Question → Research more → Manifest → Validate → Remember) | `WSP_00:441-516` | This is operator-facing protocol for how 0102 codes; not a runtime enforcement point on jobs themselves | **DOC_ONLY** (out of scope as runtime enforcement) |
+
+### WSP 50 — Pre-Action Verification
+
+| # | Protocol Rule | Source (WSP) | Runtime enforcement point on OC→Hermes path | Status |
+|---|---------------|--------------|----------------------------------------------|--------|
+| 50.1 | Never assume, always verify (Search → Verify → Read → Process) | `WSP_50_Pre_Action_Verification_Protocol.md:9-44` | `route_foundup_job` (`foundup_job_router.py:218-249`) verifies presence of `job_id`, `tenant_id`, `requested_action` before routing. This is the closest thing to a runtime WSP 50 binding on this path. **Limitation**: it verifies field presence, not file/path/content claims | **ENFORCED_RUNTIME (partial)** — identity verification only |
+| 50.2 | Architectural Intent Analysis (WHY/HOW/WHAT/WHEN/WHERE) | `WSP_50:15-28, 328-375` | No code on the FoundUp path performs WHY/HOW/WHAT/WHEN/WHERE analysis before job creation. `_handle_build_intent` extracts `requested_action` and `foundup_id` and queues without intent-impact assessment | **MISSING** |
+| 50.3 | Module Assessment Verification (read TestModLog.md FIRST before coverage claims) | `WSP_50:58-97` | Operator protocol; no runtime binding required. Not reflected in any FoundUp gate | **DOC_ONLY** (operator-facing) |
+| 50.4 | Cube Documentation Verification before coding on a cube | `WSP_50:99-160` | Operator protocol; no runtime binding required | **DOC_ONLY** (operator-facing) |
+| 50.5 | Bloat Prevention before file creation | `WSP_50:162-239` | Operator protocol; no runtime binding | **DOC_ONLY** (operator-facing) |
+| 50.6 | Destructive Change SWOT (WSP 79) | `WSP_50:243-252` | `extract_foundup` and `build_foundup` are destructive against external repos / file trees. No SWOT gate exists in `_handle_build_intent`, the router, or the consumer before dispatch | **MISSING** |
+| 50.7 | Confirmed file paths with line numbers when referencing files | `WSP_50:278-285` | Output formatting protocol; not a job runtime gate | **DOC_ONLY** (operator-facing) |
+| 50.8 | Pre-Action Sentinel (Gemma 3 270M, real-time verification middleware) | `WSP_50:383-797` (Sentinel Augmentation) | Sentinel is documented as P0 but its implementation file `modules/infrastructure/wsp_core/src/pre_action_sentinel.py` does not exist (verified by file glob) | **MISSING** (planned, not built) |
+| 50.9 | Job-level pre-action validation: `is_terminal_status` block, `policy_flags.security_gate_*` block | `WSP_50:9` (general principle) bound to `foundup_job_router.py:251-295` | Implemented in router (file:line cited); BUT `policy_flags.security_gate_checked` is never set to True anywhere in production code, so the gate at line 285 is permanently moot | **ENFORCED_TEST_ONLY** — gate exists but the input it reads is never written |
+
+### WSP 97 — System Execution Prompting
+
+| # | Protocol Rule | Source (WSP) | Runtime enforcement point on OC→Hermes path | Status |
+|---|---------------|--------------|----------------------------------------------|--------|
+| 97.1 | Canonical Operator: `retrieve wsp → retrieve evidence → resolve execution plane? → apply CoT → apply CoR → execute` | `WSP_97_System_Execution_Prompting_Protocol.md:24-29, 100-103` | `WSPOrchestrator.follow_wsp()` (`wsp_orchestrator.py:429-443`) implements Phase -1 (WSP_00 gate). The full operator chain runs only on the "follow wsp" literal trigger | **ENFORCED_RUNTIME** for "follow wsp" branch only; **MISSING** for FoundUp build/extract/validate |
+| 97.2 | CoT gate: retrieve before stating | `WSP_97:106-123` | No HoloIndex/grep is invoked before queueing a FoundUpJob. The job is created from raw chat without retrieval | **MISSING** for FoundUp action path |
+| 97.3 | CoR gate: dialectic sweep before committing | `WSP_97:124-145` | No alternative-evaluation step before `create_job`. The job is queued unconditionally on phrase-match | **MISSING** |
+| 97.4 | Execution-plane classification gate (`resolve execution plane?`) | `WSP_97:178-184` | The router (`foundup_job_router.py:298-312`) does classify: `_ACTION_BACKEND_MAP` maps action → backend → status (ROUTED/QUEUED/UNSUPPORTED). Reached only if the queue is drained, which has no production caller | **ENFORCED_TEST_ONLY** |
+| 97.5 | Truth fields on results: `real_execution_performed`, `verification_complete`, `cabr_ready`, `payout_ready` are False unless proven | `WSP_97:46-48` ("prevent confabulation, vibecoding, premature commitment") + `proof_of_compute_receipt.py:84-110` (VerificationStatus, PayoutStatus, CABRStatus enums) | `HermesDelegationResult` (`hermes_job_executor.py:406-410`) hardcodes the four truth fields to `False`. The WRE executor never sets them to True. The receipt module (`proof_of_compute_receipt.py:99-110`) hardcodes `PayoutStatus.NOT_EVALUATED` and `CABRStatus.NOT_SUBMITTED` | **ENFORCED_RUNTIME** — by virtue of being hardcoded False; a Phase 2 wiring without explicit gating could regress this |
+| 97.6 | Truthful `route_status` in router | `WSP_97:46-52` ("prevent execution-plane drift") + `foundup_job_router.py:201-353` | Implemented: router returns the exact status (ROUTED/QUEUED/BLOCKED/UNSUPPORTED/FAILED) based on the action map and validation outcome | **ENFORCED_RUNTIME** when invoked (test surface only today) |
+| 97.7 | Activation default: execute once evidence is sufficient (no passive waiting) | `WSP_97:38, 64-72` | The runtime path stops at queue append. No drainer = no activation. This violates 97.7 — evidence (job creation) is sufficient, but no execution proceeds | **MISSING** (the path has implemented activation surfaces but never triggers them) |
+| 97.8 | Operator CLI hook `python main.py --connect-wre` to verify preflight + enforcement | `WSP_97:449-465` | Out-of-band operator command, not a per-action gate | **DOC_ONLY** (operator-facing) |
+| 97.9 | Identity boundary: WSP 97 does NOT resolve self/role/origin (deferred to WSP 00) | `WSP_97:73-77` | This is a non-rule (a boundary clarification). N/A as enforcement | **DOC_ONLY** (boundary statement) |
+
+### Summary Counts (action-relevant rules only — excluding pure operator-facing rules and boundary statements)
+
+| Status | Count | Rule IDs |
+|--------|-------|----------|
+| `ENFORCED_RUNTIME` | 3 (1 partial) | 97.5 (hardcoded), 97.6, 50.1 (partial) |
+| `ENFORCED_TEST_ONLY` | 2 | 50.9, 97.4 |
+| `DOC_ONLY` | 1 (action-path) + 6 (operator-facing/boundary) | 00.1 (FoundUp branch), 00.2, 00.7, 50.3, 50.4, 50.5, 50.7, 97.8, 97.9 |
+| `MISSING` | 8 | 00.3, 00.4, 00.5, 00.6, 50.2, 50.6, 50.8, 97.2, 97.3, 97.7 |
+
+(Action-relevant excludes 50.3/50.4/50.5/50.7/97.8/97.9 which are not designed as runtime gates.)
+
+---
+
+## 2. Action Path Gate Table
+
+| Gate | Phase (pre/in/post) | Implemented? | Bypass paths | Evidence |
+|------|---------------------|--------------|--------------|----------|
+| WSP_00 zen-state compliance | pre-action | Yes, but only on literal "follow wsp" | Any FoundUp build/extract/validate intent bypasses it (`openclaw_foundup_orchestrator.py:777-810`) | `wsp_orchestrator.py:429-443`; `openclaw_execution_routes.py:368-417` |
+| HoloIndex retrieval (CoT) | pre-action | No | All FoundUp action paths bypass it | grep `holo_index\|HoloIndex` in `openclaw_foundup_orchestrator.py`: 0 hits |
+| Genesis envelope validation | pre-action | Implemented (`OpenClawFoundUpOrchestrator.validate_genesis_envelope`) but unwired | `dispatch_foundup` does not call it | `openclaw_foundup_orchestrator.py:359-468` (def); 0 production callers (HXA1 F-3) |
+| Identity verification (job_id, tenant_id, action present) | pre-action | Yes | Only reachable when consumer drains; consumer is unwired | `foundup_job_router.py:218-249` |
+| Terminal-status block | pre-action | Yes | Permanent retry loop possible: WRE path never sets terminal status, so re-routing never triggers this gate | `foundup_job_router.py:251-273`; HXA1 F-7 |
+| Security gate (`policy_flags.security_gate_passed`) | pre-action | Reader implemented, writer absent | Always passes because `security_gate_checked` is never set to True | `foundup_job_router.py:275-295` (reader); 0 writers in production |
+| Action support map (build/extract/validate/queue) | pre-action | Yes (router) and divergent (Hermes adapter executor) | If a non-canonical action reaches the Hermes adapter executor, it FAILS with `FAIL_VALIDATION_ERROR` | Router: `foundup_job_router.py:85-90`; adapter: `hermes_foundup_job_executor.py:53-57`; HXA1 F-8 |
+| `HERMES_DELEGATE_ENABLED` env flag (feature gate) | in-action | Yes | Default `0` → all jobs SIMULATED | `hermes_job_executor.py:60-66, 707-726` |
+| Workspace binding (path allowlist/blocklist) | in-action | Yes (`WorkspaceBinding.is_path_allowed`) | Only consulted if real execution runs; real execution is `BLOCKED_REAL_DELEGATION_NOT_IMPLEMENTED` (`hermes_job_executor.py:770-784`) | `hermes_job_executor.py:73-194` |
+| Lazy import gate (Hermes `delegate_task`) | in-action | Yes | Returns `BLOCKED_IMPORT_UNAVAILABLE` if vendor missing | `hermes_job_executor.py:514-545, 750-763` |
+| Receipt emission gate (terminal job + real execution) | post-action | Yes (skip for SIMULATED+!real_execution) | Always skips today (Phase 1 always SIMULATED with `real_execution_performed=False`) | `foundup_job_consumer.py:614-626`; HXA1 F-5 |
+| pAVS verification | post-action | Implemented in `proof_of_compute_receipt.py` but never reached because receipts never emit on the canonical path | Receipt-emission gate above blocks every job | `proof_of_compute_receipt.py:79-110` |
+| `verification_complete`/`cabr_ready`/`payout_ready` truth fields | post-action | Hardcoded False | None today; future Phase 2 wiring must keep these gated | `hermes_job_executor.py:406-410, 712-746` |
+
+**Bypass summary**: The dominant bypass is at the very front: `dispatch_foundup` → `_handle_build_intent` → queue append, with no WSP_00 gate, no HoloIndex retrieval, no genesis validation. Every downstream gate is correctly defined but unreachable from the runtime path.
+
+---
+
+## 3. False-Compliance Risks
+
+### FC-1 (Critical) — "follow WSP" runtime enforcement is scoped only to the literal phrase
+
+- **Claim**: The codebase markets WSP_00 as a "mandatory hard gate" (`WSP_00:18-21`, "MANDATORY: Execute awakening on every new session — never conditional"). The WSPOrchestrator README says "WSP_00 Hard Gate: 'follow WSP' blocks up front when compliance gate fails in strict mode" (`modules/infrastructure/wsp_orchestrator/README.md:71`).
+- **Reality**: The hard gate is reached only when `try_execute_follow_wsp` matches the literal substring "follow wsp" in the raw chat message (`openclaw_execution_routes.py:368-374`). FoundUp build/extract/validate intents (e.g. "start build gotjunk") never enter `WSPOrchestrator.follow_wsp` and therefore never run Phase -1.
+- **Severity**: Critical — the gate is described as universal but is actually one branch among many.
+- **Operational consequence**: Any audit claiming "WSP_00 is enforced before action" is overclaim. It is enforced only for the deterministic "follow wsp" route.
+
+### FC-2 (Critical) — Pre-action verification (WSP 50) is reduced to identity-presence checks
+
+- **Claim**: WSP 50 mandates a 7-step verification (Search/WHY/HOW/WHAT/WHEN/WHERE/Final-cross-check) before any action (`WSP_50:15-28`).
+- **Reality**: The only runtime enforcement on the FoundUp path is `route_foundup_job`'s identity check: presence of `job_id`, `tenant_id`, `requested_action` (`foundup_job_router.py:218-249`). No HoloIndex retrieval, no architectural intent analysis, no impact assessment, no WSP cross-check before queueing.
+- **Severity**: Critical — Build/extract/validate are destructive (touch `modules/foundups/<id>/`, can write to external repos via `target_org`); WSP 50 §4.4 explicitly requires WSP 79 SWOT for destructive changes; that gate is absent.
+- **Operational consequence**: A poorly-formed or malicious build intent can queue without architectural review. The downstream consumer treats every queued job as routing-eligible.
+
+### FC-3 (High) — `policy_flags.security_gate_*` is a reader without a writer
+
+- **Claim**: The router's `BLOCKED_POLICY_GATE` reason code (`foundup_job_router.py:112`) and the gate check at lines 285-295 imply security review is enforced.
+- **Reality**: Nothing in the production code path ever sets `policy_flags.security_gate_checked=True` or `security_gate_passed=True`. Default is `False/False` (`foundup_job_contract.py:201-202`). The gate's branch is only triggered when `checked=True && passed=False`, which never happens.
+- **Severity**: High — looks fail-closed in code, is functionally fail-open at runtime.
+- **Operational consequence**: Auditors reading the router file would conclude security is gated; auditors running it would see all jobs routed regardless of security posture.
+
+### FC-4 (High) — Truth-fields on `HermesDelegationResult` are hardcoded, not derived
+
+- **Claim**: WSP 97 §97.5 implies `real_execution_performed`/`verification_complete`/`cabr_ready`/`payout_ready` are derived from runtime state.
+- **Reality**: They are hardcoded `False` at construction (`hermes_job_executor.py:406-410`) and explicitly set False in every result-creating branch (`hermes_job_executor.py:719-723, 741-745, 778-781`).
+- **Severity**: High in the "live flip" sense — Phase 1 is correctly fail-closed, but the moment Phase 2 lands these fields must be flipped through a gate, not directly. Today there is no such gate.
+- **Operational consequence**: If a future commit removes the hardcoded `False` lines without adding a gate, downstream pAVS/CABR consumers would see overclaim. The WSP 97 truth boundary is currently held by static code, not by an enforcement function.
+
+### FC-5 (High) — Genesis Validation Gate is documented as enforced but unwired
+
+- **Claim**: `OpenClawFoundUpOrchestrator` docstring (lines 286-304) states it "enforces that all FoundUp operations pass through genesis envelope validation first".
+- **Reality**: 0 production callers of `validate_genesis_envelope`, `launch_foundup`, `build_foundup` (only test callers). `dispatch_foundup` skips it.
+- **Severity**: High — already covered as F-3 in HXA1, restated here under the protocol-binding lens.
+- **Operational consequence**: Docs lie about runtime enforcement; this is the prototypical false-compliance pattern WSP 97 was written to prevent.
+
+### FC-6 (Medium) — WSP 00's identity-coherence canary has no automated detector
+
+- **Claim**: WSP_00 §4.4 specifies an automated coherence canary that fires when role/self/origin collapse, when "user" reference appears for known principals, etc.
+- **Reality**: No code sentinel monitors these conditions on the FoundUp action path. The WSP_00 zen tracker only checks the boot-time compliance flag, not running behavior.
+- **Severity**: Medium — deviation from documented behavior, but the canary is operator-facing rather than blocking on jobs.
+- **Operational consequence**: Coherence decay would not be auto-detected; relies on operator self-noticing.
+
+### FC-7 (Medium) — `verification_complete=False` is correct truthfully but obscures the absence of any verification engine
+
+- **Claim**: `proof_of_compute_receipt.py:99-110` enums `PayoutStatus.NOT_EVALUATED` and `CABRStatus.NOT_SUBMITTED` (singletons — there are no other values).
+- **Reality**: This is WSP 97-aligned (do not overclaim) but masks that the enums have **no other states defined**. There is literally no way to express "payout evaluated" or "submitted to CABR" yet.
+- **Severity**: Medium — this is a feature-not-bug position, but a future audit could mistake "always NOT_EVALUATED" for a code bug rather than an architectural fact.
+- **Operational consequence**: Any external consumer expecting an evaluated/submitted state will get a permanent stub.
+
+### FC-8 (Low) — Operator-facing rules conflated with runtime gates in docstrings
+
+- Several module docstrings claim "WSP 50: Pre-Action Verification" without distinguishing operator-facing rules (TestModLog read, bloat prevention) from runtime gates (job-identity verification). Example: `foundup_job_router.py:17` lists "WSP 50: Pre-Action Verification (identity validation)" — accurate but understates that the broader WSP 50 surface is unbound.
+- **Severity**: Low — semantic precision rather than safety.
+- **Operational consequence**: A reader might infer broader WSP 50 enforcement than exists.
+
+---
+
+## 4. Minimum Enforcement Backlog
+
+Six atomic slices, ordered. **Slices 1-3 are required before any live-flip can be claimed WSP 97-compliant.**
+
+### Slice 1 (Trunk) — `OPENCLAW_BUILD_INTENT_WSP00_GATE_BINDING_PHASE1`
+
+- **Objective**: Wire WSP_00 zen-state gate into `_handle_build_intent` so any FoundUp build/extract/validate intent fails closed if `is_zen_compliant=False` in strict mode. Mirror the pattern at `wsp_orchestrator.py:429-443`.
+- **Files**: `modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py:811-894` (insert gate call), shared helper or import from `wsp_orchestrator`.
+- **Acceptance**: A "start build gotjunk" intent issued while `is_zen_compliant=False` in strict mode returns BLOCKED with WSP_00 gate payload; in non-strict mode emits a warning and proceeds with `wsp00_gate.gate_passed=False` recorded in the job's `policy_flags` or status_reason_human.
+
+### Slice 2 — `BUILD_INTENT_HOLOINDEX_RETRIEVAL_BINDING_PHASE1`
+
+- **Objective**: Insert HoloIndex retrieval (CoT gate per WSP 97 §97.2) into `_handle_build_intent` before `create_job`. Use `build_execution_bundle` (already used by `execute_query` in `openclaw_execution_routes.py:86-94`) to fetch evidence about the target foundup_id, attach the bundle hash to `job.payload["evidence_bundle_id"]`, and require non-empty bundle for non-`queue_foundup_job` actions.
+- **Files**: `modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py:811-894`.
+- **Acceptance**: A build intent for an unknown foundup_id with no HoloIndex hits is routed BLOCKED with reason `BLOCKED_NO_EVIDENCE`; for known foundup_ids the bundle id is recorded in payload and downstream router/consumer can read it.
+
+### Slice 3 — `GENESIS_GATE_DISPATCH_BINDING_PHASE1` (overlaps HXA1 Slice 4)
+
+- **Objective**: Insert `validate_genesis_envelope` into `_handle_build_intent` for `build_foundup`/`extract_foundup` actions. Phase-gated: log-only first, hard-block second.
+- **Files**: `modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py:811-894`, plus regression tests proving build intents without envelope produce `BLOCKED` reason codes.
+- **Acceptance**: A build intent without envelope returns BLOCKED with `GenesisGateReason.NO_ENVELOPE`; with valid envelope, job is queued as before.
+
+### Slice 4 — `SECURITY_GATE_WRITER_BINDING_PHASE1`
+
+- **Objective**: Add a real producer for `policy_flags.security_gate_checked/passed` so the existing reader in `foundup_job_router.py:285-295` is functional. Wire the security check (e.g., AI Overseer security stack — `modules/infrastructure/wre_core/src/security_control_hooks.py`) into `_handle_build_intent` after WSP_00 gate.
+- **Files**: `modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py`, optional helper in `modules/infrastructure/wre_core/src/security_control_hooks.py` to expose a job-level pre-action API.
+- **Acceptance**: Submitting a build intent that touches a forbidlist path returns BLOCKED with reason `BLOCKED_POLICY_GATE`; a clean intent passes with `security_gate_checked=True && security_gate_passed=True`.
+
+### Slice 5 — `TRUTH_FIELD_DERIVATION_GATE_PHASE1`
+
+- **Objective**: Replace hardcoded `False` literals on truth fields (`real_execution_performed`, `verification_complete`, `cabr_ready`, `payout_ready`) with a single function `derive_truth_fields(execution_state)` returning `False` for all states until each respective subsystem (real Hermes, pAVS, CABR, payout) explicitly registers a "ready" state. Prevents Phase 2 regressions.
+- **Files**: `modules/infrastructure/wre_core/src/hermes_job_executor.py:406-410, 712-746, 770-784`, new helper module.
+- **Acceptance**: Removing the hardcoded `False` lines cannot accidentally yield `True` truth fields without going through the derive function. Tests assert all four fields stay False under every Phase 1 status code.
+
+### Slice 6 — `WSP_50_DESTRUCTIVE_SWOT_BINDING_PHASE1`
+
+- **Objective**: Bind WSP 50 §4.4 (WSP 79 SWOT) for destructive actions (`extract_foundup`, `build_foundup` when `target_org` is non-default or affects external repos). Either inline a SWOT artifact requirement in `_handle_build_intent`, or require `policy_flags.wsp_preflight_checked && wsp_preflight_passed` (already declared but unset in `foundup_job_contract.py:210-211`) before the router can route to `HERMES_BUILDER`.
+- **Files**: `modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py`, `modules/infrastructure/wre_core/src/foundup_job_router.py:275-295` (extend gate to read `wsp_preflight_*`).
+- **Acceptance**: An extract/build intent without a linked SWOT artifact returns BLOCKED with reason `BLOCKED_WSP_PREFLIGHT_MISSING`; with SWOT linked, the job routes normally.
+
+---
+
+## 5. Final Verdict
+
+### **CLAIMED_NOT_ENFORCED**
+
+Across the three protocols audited, the OpenClaw → FoundUpJob → WRE → Hermes action path:
+
+- **WSP 00**: Boot gate reachable only through the literal "follow wsp" branch — bypassed by every FoundUp action intent.
+- **WSP 50**: Reduced to identity-presence verification at the router; the wider 7-step verification, destructive-change SWOT, and Sentinel are absent or unwired.
+- **WSP 97**: CoT (retrieve before stating) and CoR (sweep before committing) gates are not bound to the FoundUp action path. Truth fields are correctly held False today, but only by static hardcoding.
+
+**Live-flip readiness from a protocol perspective: NO-GO.** Even after HXA1's wiring fixes (Slice 1 of HXA1), the action path will be runtime-functional but will violate WSP 00, WSP 50, and WSP 97 the moment a job moves past `QUEUED`. Slices 1-3 of this backlog are required before any live execution can claim protocol compliance.
+
+---
+
+## Acceptance Criteria Verification
+
+- ✓ Every claim has file:line evidence (sections 1-3).
+- ✓ No speculative protocol claims — protocols read from canonical files; behavior verified against code.
+- ✓ Clear distinction between docs (DOC_ONLY), tests (ENFORCED_TEST_ONLY), and runtime (ENFORCED_RUNTIME / MISSING).
+- ✓ Explicit go/no-go for live execution from protocol perspective: NO-GO.
+
+---
+
+## WSP 97 Applied
+
+This audit retrieved the canonical WSP files first (CoT gate), confirmed file-name divergence from the slice prompt and corrected it (WSP 50 verify-before-cite), distinguished operator-facing rules from runtime gates (avoiding false-compliance overclaim), tied every binding-status assignment to a specific file:line, and explicitly classifies the action path as `CLAIMED_NOT_ENFORCED` rather than softening to "partial". WSP 50 cross-check applied via HoloIndex top-hit reuse from HXA1 (the same audit lane). WSP 00 self/role/origin: identity-locked as Worker W1 throughout this slice.
+
+---
+
+## Files Touched This Slice
+
+- `docs/audits/openclaw_hermes/HXA2_PROTOCOL_ACTION_BINDING_AUDIT.md` (NEW)
+
+No runtime code edits. No commits made.


### PR DESCRIPTION
## Summary
- Adds gitignore allowlist entries for `docs/audits/mcp_system/` and `docs/audits/openclaw_hermes/`
- Creates MCPA1 MCP Surface Authority Audit documenting tool exposure boundaries
- Enables HoloIndex discovery of audit artifacts

## Test plan
- [x] Audit document follows WSP 97 truth boundaries
- [x] Allowlist entries verified syntactically correct
- [x] No code changes - documentation and gitignore only

Worker-Lane: W10
Slice: MCPA2

🤖 Generated with [Claude Code](https://claude.com/claude-code)