### PR TITLE
feat(mcp_manager): expand discovery to include MCP bridge and placeholder surfaces with truthful status flags

### DIFF
--- a/modules/infrastructure/mcp_manager/INTERFACE.md
+++ b/modules/infrastructure/mcp_manager/INTERFACE.md
@@ -18,13 +18,38 @@ show_mcp_services_menu()
 ## Classes
 
 ### `MCPServerManager`
-Core manager for MCP server lifecycle.
+Core manager for MCP server lifecycle and all-surface discovery.
 
-**Methods**:
+**Lifecycle methods** (runnable servers only):
 - `get_server_status(server_name: str) -> Tuple[bool, Optional[int]]`
 - `start_server(server_name: str) -> bool`
 - `stop_server(server_name: str) -> bool`
 - `get_available_tools(server_name: str) -> List[Dict[str, str]]`
+
+**All-surface discovery** (MCPA5 / WSP 96 Annex A):
+- `discover_all_surfaces() -> List[KnownSurface]` — return S1+S2+S3 plus any auxiliary FastMCP servers, with truthful flags. Never starts a server.
+- `format_surface_report(surfaces=None) -> str` — render the truth-flagged table for stdout/logs.
+- `report_all_surfaces() -> List[KnownSurface]` — print and return the canonical list.
+
+### `KnownSurface` (dataclass)
+Truthful descriptor for one MCP-related surface. Frozen, JSON-serializable via `to_dict()`.
+
+| Field | Meaning |
+|-------|---------|
+| `surface_id` | `S1` / `S2` / `S3` / `AUX:<name>` |
+| `surface_kind` | `external_mcp_server` / `internal_python_bridge` / `placeholder_stub` / `auxiliary_mcp_server` |
+| `name` | Human-readable name |
+| `path` | Repo-relative path |
+| `runnable` | `True` for processes the manager can start; `False` for non-runnable surfaces |
+| `implementation_status` | `RUNTIME_LIVE` / `RUNTIME_INTERNAL_ONLY` / `PLACEHOLDER_STUB` / `UNKNOWN` |
+| `holo_search_support` | `real` / `real_with_fallback` / `placeholder` / `none` |
+| `authority_role` | `canonical_external_adapter` / `canonical_internal_adapter` / `no_authority` / `auxiliary` |
+| `notes` | Short truthful caveat |
+
+### Module-level constants
+- `S2_FOUNDUPS_MCP_BRIDGE: KnownSurface` — canonical S2 descriptor
+- `S3_PAVS_MCP: KnownSurface` — canonical S3 descriptor
+- `KNOWN_NON_RUNNABLE_SURFACES: Tuple[KnownSurface, ...]` — `(S2, S3)`
 
 ## Integration Example
 

--- a/modules/infrastructure/mcp_manager/ModLog.md
+++ b/modules/infrastructure/mcp_manager/ModLog.md
@@ -17,6 +17,88 @@ First-principles MCP server manager providing auto-discovery, status tracking, a
 
 ## Recent Changes
 
+### V003 - MCPA5: All-Surface Discovery Expansion (Truthful S1/S2/S3 Reporting)
+
+**Type**: Discovery expansion (no lifecycle change)
+**Date**: 2026-05-08
+**Author**: 0102 (Worker W1)
+**WSP**: 97 (Truth Boundaries), 96 (MCP Governance — Annex A)
+**Slice**: `MCPA5_MCP_MANAGER_DISCOVERY_EXPANSION_PHASE1`
+
+#### Why
+
+Per MCPA1 audit (`docs/audits/mcp_system/MCPA1_MCP_SURFACE_AUTHORITY_AUDIT.md`),
+the prior `_discover_mcp_servers` only scanned `foundups-mcp-p1/servers/`,
+omitting two of the three `holo_search`-capable surfaces:
+
+- S2: `modules/infrastructure/foundups_mcp_bridge/` (internal Python bridge)
+- S3: `modules/infrastructure/pavs_mcp/` (placeholder stub)
+
+WSP 96 Annex A.5 C7 requires every production-ready MCP surface to register
+in the manager's discovery output. This slice closes the omission gap.
+
+#### Changes
+
+- `src/mcp_manager.py`:
+  - Added `KnownSurface` frozen dataclass with the 9 truth fields specified
+    by the slice (`surface_id`, `surface_kind`, `name`, `path`, `runnable`,
+    `implementation_status`, `holo_search_support`, `authority_role`, `notes`).
+  - Added module-level constants `S2_FOUNDUPS_MCP_BRIDGE`, `S3_PAVS_MCP`,
+    `KNOWN_NON_RUNNABLE_SURFACES`.
+  - Added `MCPServerManager.discover_all_surfaces()` — merges discovered
+    runnable servers (S1 + AUX:*) with the known non-runnable triad (S2, S3).
+  - Added `MCPServerManager.format_surface_report()` — renders the truthful
+    table with column auto-sizing.
+  - Added `MCPServerManager.report_all_surfaces()` — prints + returns the list.
+  - Wired the surface report into `show_mcp_services_menu()` so operators see
+    the S1/S2/S3 truth at the top of the gateway report.
+
+- `tests/__init__.py` (NEW), `tests/test_surface_discovery.py` (NEW):
+  - 20 focused tests covering: constant truth fields, discovery without any
+    runnable servers (S2/S3 still appear), full triad with `holo_index`,
+    auxiliary servers tagged AUX:*, no auto-start, format report content,
+    runtime safety (no subprocess/psutil calls), lifecycle preservation.
+
+- `README.md`, `INTERFACE.md`: updated to document the all-surface API and
+  the S1/S2/S3 truth table.
+
+#### Behavior boundaries (what did NOT change)
+
+- Existing runnable-server lifecycle methods (`start_server`, `stop_server`,
+  `get_server_status`, `get_available_tools`) untouched.
+- `self.servers` dict shape unchanged — S2/S3 are listed separately, never
+  added to `self.servers`, so the manager cannot accidentally try to start them.
+- No S1/S2/S3 source-code changes outside this module.
+- No auth/transport rewrites.
+
+#### Tests
+
+```
+PYTHONPATH=. python -m pytest \
+  modules/infrastructure/mcp_manager/tests/test_surface_discovery.py -q
+-> 20 passed
+```
+
+Live runtime-safe discovery against the real repo:
+
+```
+PYTHONPATH=. python -c "from modules.infrastructure.mcp_manager.src.mcp_manager \
+  import MCPServerManager; MCPServerManager().report_all_surfaces()"
+-> 12 surfaces visible (10 runnable, 2 non-runnable)
+   S1=holo_index, S2=foundups_mcp_bridge, S3=pavs_mcp + 9 AUX:*
+```
+
+#### Tracked follow-ups
+
+- MCPA1 Slice 4 — once S3 returns `not_implemented`, no flag change here is
+  needed; the `holo_search_support` value remains `placeholder`.
+- MCPA1 Slice 6 — when federation auth lands, S3's `implementation_status`
+  upgrades from `PLACEHOLDER_STUB` to `RUNTIME_INTERNAL_ONLY` or `RUNTIME_LIVE`,
+  and `authority_role` from `no_authority` to a real role. The `KnownSurface`
+  descriptor in this module is the single edit point.
+
+
+
 ### V001 - Initial MCP Manager Implementation (Occam's Razor PoC)
 **Type**: New Module
 **Date**: 2025-10-18

--- a/modules/infrastructure/mcp_manager/README.md
+++ b/modules/infrastructure/mcp_manager/README.md
@@ -34,6 +34,23 @@ From main.py menu:
 - **Auto-Start**: Yes
 - **Status Tracking**: Real-time PID monitoring
 
+## All-Surface Discovery (MCPA5)
+
+Beyond the runnable FastMCP servers under `foundups-mcp-p1/servers/`, the
+manager surfaces the complete `holo_search` triad anchored in WSP 96 Annex A:
+
+| ID | Surface | Runnable | Status | holo_search |
+|----|---------|----------|--------|-------------|
+| **S1** | `foundups-mcp-p1/servers/holo_index/` | yes | `RUNTIME_LIVE` | real |
+| **S2** | `modules/infrastructure/foundups_mcp_bridge/` | no | `RUNTIME_INTERNAL_ONLY` | real_with_fallback |
+| **S3** | `modules/infrastructure/pavs_mcp/` | no | `PLACEHOLDER_STUB` | placeholder |
+| `AUX:*` | other FastMCP servers (codeindex, wsp_governance, ...) | yes | `RUNTIME_LIVE` | none |
+
+S2 and S3 are reported but never auto-started: S2 has no MCP wire transport
+(Python class + CLI only); S3 does not bind a port (`start()` is a sleep loop)
+and its tools return hardcoded data. Use `MCPServerManager.report_all_surfaces()`
+or `discover_all_surfaces()` to access the truthful list programmatically.
+
 ## WSP Compliance
 
 - **WSP 3**: Infrastructure domain (server management)

--- a/modules/infrastructure/mcp_manager/src/mcp_manager.py
+++ b/modules/infrastructure/mcp_manager/src/mcp_manager.py
@@ -16,6 +16,7 @@ import asyncio
 import time
 import json
 import io
+from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Any
 import threading
@@ -83,6 +84,118 @@ if sys.platform.startswith('win'):
 logger = logging.getLogger(__name__)
 
 
+# =============================================================================
+# MCP Surface Discovery Model (MCPA5 — anchored to WSP 96 Annex A)
+# =============================================================================
+#
+# This module historically discovered only S1-class runnable MCP servers under
+# `foundups-mcp-p1/servers/`. Per MCPA1 audit and WSP 96 Annex A, the manager
+# must also expose:
+#
+#   - S2: `modules/infrastructure/foundups_mcp_bridge` (internal Python bridge)
+#   - S3: `modules/infrastructure/pavs_mcp` (placeholder stub)
+#
+# These are NOT runnable servers in the foundups-mcp-p1 sense (S2 has no MCP
+# transport; S3 does not bind a port). They are reported with truthful flags so
+# operators see all `holo_search`-capable surfaces without overclaiming runtime
+# capability. Runnable lifecycle methods are unchanged for S1-class servers.
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class KnownSurface:
+    """Truthful descriptor for an MCP-related surface (MCPA5 / WSP 96 Annex A).
+
+    Carries the conformance fields required by WSP 96 Annex A.5 so any consumer
+    of the manager's discovery output can distinguish runnable servers from
+    internal bridges from placeholder stubs without inspecting runtime state.
+    """
+
+    surface_id: str
+    """Stable identifier per MCPA1 audit (e.g. "S1", "S2", "S3")."""
+
+    surface_kind: str
+    """High-level kind: external_mcp_server | internal_python_bridge | placeholder_stub | auxiliary_mcp_server."""
+
+    name: str
+    """Human-readable name used in reports/menus."""
+
+    path: str
+    """Repository-relative path to the surface's primary entrypoint."""
+
+    runnable: bool
+    """True if this surface is a process that can be started/stopped via the manager."""
+
+    implementation_status: str
+    """RUNTIME_LIVE | RUNTIME_INTERNAL_ONLY | PLACEHOLDER_STUB | UNKNOWN (mirrors WSP 96 Annex A.1 truth-status)."""
+
+    holo_search_support: str
+    """real | real_with_fallback | placeholder | none."""
+
+    authority_role: str
+    """canonical_external_adapter | canonical_internal_adapter | no_authority | auxiliary."""
+
+    notes: str = ""
+    """Short truthful note (deferred work, caveats)."""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dict for JSON/log output. Frozen dataclass safe."""
+        return asdict(self)
+
+
+# ---------------------------------------------------------------------------
+# Authoritative non-runnable surfaces (S2, S3)
+#
+# S1 (holo_index MCP server) is discovered dynamically via the existing
+# `_discover_mcp_servers` scan and enriched with metadata at report time.
+# S2 and S3 are NOT runnable as managed processes — they are listed here so the
+# gateway report stops omitting them.
+# ---------------------------------------------------------------------------
+
+S1_SURFACE_NAME = "holo_index"
+"""Name under which S1 appears in `_discover_mcp_servers` output."""
+
+S2_FOUNDUPS_MCP_BRIDGE = KnownSurface(
+    surface_id="S2",
+    surface_kind="internal_python_bridge",
+    name="foundups_mcp_bridge",
+    path="modules/infrastructure/foundups_mcp_bridge/src/holo_tools.py",
+    runnable=False,
+    implementation_status="RUNTIME_INTERNAL_ONLY",
+    holo_search_support="real_with_fallback",
+    authority_role="canonical_internal_adapter",
+    notes=(
+        "Real backend via lazy holo_index.core.holo_index.HoloIndex. "
+        "ripgrep fallback when HoloIndex unavailable. No MCP wire transport — "
+        "Python class + CLI only. Auth is unenforced (MCPA1 R5)."
+    ),
+)
+"""S2 surface descriptor — canonical internal Python adapter for holo_search."""
+
+S3_PAVS_MCP = KnownSurface(
+    surface_id="S3",
+    surface_kind="placeholder_stub",
+    name="pavs_mcp",
+    path="modules/infrastructure/pavs_mcp/src/server.py",
+    runnable=False,
+    implementation_status="PLACEHOLDER_STUB",
+    holo_search_support="placeholder",
+    authority_role="no_authority",
+    notes=(
+        "Tool bodies return hardcoded data; start() does not bind a port; "
+        "auth is TODO. NOT canonical owner of holo_search (WSP 96 Annex A.1). "
+        "Tracked remediation: MCPA1 Slice 4, Slice 6."
+    ),
+)
+"""S3 surface descriptor — placeholder stub. NOT canonical for any capability."""
+
+KNOWN_NON_RUNNABLE_SURFACES: Tuple[KnownSurface, ...] = (
+    S2_FOUNDUPS_MCP_BRIDGE,
+    S3_PAVS_MCP,
+)
+"""Surfaces that must always appear in the gateway report regardless of runtime state."""
+
+
 class MCPServerManager:
     """
     Enhanced MCP Services Gateway - Comprehensive server management and testing platform.
@@ -136,6 +249,144 @@ class MCPServerManager:
                     servers[server_dir.name] = server_py
 
         return servers
+
+    # =========================================================================
+    # MCPA5: All-surface discovery (S1 + S2 + S3 truthful merge)
+    # =========================================================================
+
+    def discover_all_surfaces(self) -> List[KnownSurface]:
+        """Return the canonical list of all MCP-related surfaces.
+
+        Merges:
+          1. Runnable servers discovered under `foundups-mcp-p1/servers/` (S1
+             when name == "holo_index", auxiliary otherwise).
+          2. Known non-runnable surfaces (S2, S3) per WSP 96 Annex A.1.
+
+        Truth boundaries (WSP 97):
+          - This method does NOT start any servers.
+          - `runnable=False` surfaces never auto-start.
+          - `implementation_status` reflects the audit-anchored state, not
+            runtime liveness — runtime liveness is reported separately by
+            `get_server_status` for runnable surfaces.
+
+        Returns:
+            List of KnownSurface descriptors. Order: runnable first (S1 + any
+            auxiliary servers), then known non-runnable surfaces (S2, S3).
+        """
+        surfaces: List[KnownSurface] = []
+
+        for server_name, server_path in self.servers.items():
+            try:
+                rel_path = server_path.relative_to(self.repo_root).as_posix()
+            except ValueError:
+                rel_path = str(server_path)
+
+            if server_name == S1_SURFACE_NAME:
+                surfaces.append(
+                    KnownSurface(
+                        surface_id="S1",
+                        surface_kind="external_mcp_server",
+                        name=server_name,
+                        path=rel_path,
+                        runnable=True,
+                        implementation_status="RUNTIME_LIVE",
+                        holo_search_support="real",
+                        authority_role="canonical_external_adapter",
+                        notes=(
+                            "FastMCP transport (stdio/sse). Real backend via "
+                            "holo_index.core.holo_index.HoloIndex. Canonical "
+                            "external owner of holo_search (WSP 96 Annex A.1)."
+                        ),
+                    )
+                )
+            else:
+                # Other discovered S1-class servers (codeindex, wsp_governance,
+                # youtube_dae_gemma, unicode_cleanup, secrets_mcp, etc.).
+                # They are runnable but not part of the holo_search authority
+                # triad. Reported as auxiliary so operators see them honestly.
+                surfaces.append(
+                    KnownSurface(
+                        surface_id=f"AUX:{server_name}",
+                        surface_kind="auxiliary_mcp_server",
+                        name=server_name,
+                        path=rel_path,
+                        runnable=True,
+                        implementation_status="RUNTIME_LIVE",
+                        holo_search_support="none",
+                        authority_role="auxiliary",
+                        notes="Auxiliary FastMCP server (not in S1/S2/S3 triad).",
+                    )
+                )
+
+        # Append known non-runnable surfaces (S2, S3) — always present.
+        surfaces.extend(KNOWN_NON_RUNNABLE_SURFACES)
+
+        return surfaces
+
+    def format_surface_report(
+        self,
+        surfaces: Optional[List[KnownSurface]] = None,
+    ) -> str:
+        """Render a truthful operator-facing report of all MCP surfaces.
+
+        Args:
+            surfaces: Optional pre-computed list; if None, calls
+                `discover_all_surfaces()`.
+
+        Returns:
+            Multi-line string suitable for stdout / logs. Each surface row
+            shows surface_id, name, runnable, implementation_status, and
+            holo_search_support so operators can see the truth at a glance.
+        """
+        if surfaces is None:
+            surfaces = self.discover_all_surfaces()
+
+        # Column widths sized to fit the longest expected AUX:* surface_id.
+        id_w = max(10, max((len(s.surface_id) for s in surfaces), default=10) + 2)
+        name_w = max(28, max((len(s.name) for s in surfaces), default=28) + 2)
+
+        total_w = id_w + name_w + 10 + 24 + 22 + 4  # +4 for column gaps
+        lines: List[str] = []
+        lines.append("=" * total_w)
+        lines.append("[MCP] All MCP Surfaces (MCPA5 / WSP 96 Annex A)")
+        lines.append("-" * total_w)
+        lines.append(
+            f"{'ID':<{id_w}} {'NAME':<{name_w}} {'RUNNABLE':<10} "
+            f"{'STATUS':<24} {'HOLO_SEARCH':<22}"
+        )
+        lines.append("-" * total_w)
+        for s in surfaces:
+            lines.append(
+                f"{s.surface_id:<{id_w}} {s.name:<{name_w}} "
+                f"{('yes' if s.runnable else 'no'):<10} "
+                f"{s.implementation_status:<24} {s.holo_search_support:<22}"
+            )
+        lines.append("-" * total_w)
+        lines.append(
+            f"Total surfaces: {len(surfaces)} "
+            f"(runnable: {sum(1 for s in surfaces if s.runnable)}, "
+            f"non-runnable: {sum(1 for s in surfaces if not s.runnable)})"
+        )
+        lines.append(
+            "Authority anchor: WSP_framework/src/WSP_96_MCP_Governance_and_Consensus_Protocol.md (Annex A)"
+        )
+        lines.append("=" * 88)
+        return "\n".join(lines)
+
+    def report_all_surfaces(self) -> List[KnownSurface]:
+        """Print and return the canonical surface list (truth-flagged).
+
+        Safe to call without starting any server. Designed for the gateway
+        menu's status path and for `python -m ... --report-surfaces` style
+        introspection.
+
+        Returns:
+            The list passed through `discover_all_surfaces()` (so callers can
+            chain into JSON output, tests, or further analysis).
+        """
+        surfaces = self.discover_all_surfaces()
+        print(self.format_surface_report(surfaces))
+        return surfaces
 
     def get_server_status(self, server_name: str) -> Tuple[bool, Optional[int]]:
         """
@@ -402,6 +653,11 @@ class MCPServerManager:
         print("       WSP 77 Agent Coordination | Real-time Monitoring & Testing")
         print("       💰 Token Cost: $0 (Local Services) | 🤖 AI Enhancement Available")
         print("="*80)
+
+        # MCPA5: surface the full S1/S2/S3 truth before per-server status.
+        # This makes non-runnable surfaces (foundups_mcp_bridge, pavs_mcp)
+        # visible to operators without affecting runnable lifecycle.
+        print(self.format_surface_report())
 
         # Overall system status
         running_count = sum(1 for s in self.servers.keys() if self.get_server_status(s)[0])

--- a/modules/infrastructure/mcp_manager/tests/test_surface_discovery.py
+++ b/modules/infrastructure/mcp_manager/tests/test_surface_discovery.py
@@ -1,0 +1,333 @@
+"""
+MCPA5 surface discovery tests.
+
+Verifies that `MCPServerManager.discover_all_surfaces()` truthfully exposes
+the S1/S2/S3 triad anchored in WSP 96 Annex A.1 without starting any servers
+and without overclaiming runtime capability.
+
+Anchored to:
+  - WSP 97 (truth distinction)
+  - WSP 96 Annex A (canonical holo_search contract + surface ownership)
+  - MCPA1 audit findings (S2 + S3 omitted from prior gateway reports)
+
+These tests do NOT require any live transport or backend.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from modules.infrastructure.mcp_manager.src import mcp_manager
+from modules.infrastructure.mcp_manager.src.mcp_manager import (
+    KNOWN_NON_RUNNABLE_SURFACES,
+    KnownSurface,
+    MCPServerManager,
+    S2_FOUNDUPS_MCP_BRIDGE,
+    S3_PAVS_MCP,
+)
+
+
+# ---------------------------------------------------------------------------
+# Module-level constants (defensive — prevent silent removal)
+# ---------------------------------------------------------------------------
+
+
+class TestSurfaceConstants:
+    """The canonical S2/S3 descriptors must exist and be truthful."""
+
+    def test_s2_descriptor_truth_fields(self):
+        assert S2_FOUNDUPS_MCP_BRIDGE.surface_id == "S2"
+        assert S2_FOUNDUPS_MCP_BRIDGE.surface_kind == "internal_python_bridge"
+        assert S2_FOUNDUPS_MCP_BRIDGE.runnable is False
+        assert S2_FOUNDUPS_MCP_BRIDGE.implementation_status == "RUNTIME_INTERNAL_ONLY"
+        assert S2_FOUNDUPS_MCP_BRIDGE.holo_search_support == "real_with_fallback"
+        assert S2_FOUNDUPS_MCP_BRIDGE.authority_role == "canonical_internal_adapter"
+        assert "foundups_mcp_bridge" in S2_FOUNDUPS_MCP_BRIDGE.path
+
+    def test_s3_descriptor_truth_fields(self):
+        assert S3_PAVS_MCP.surface_id == "S3"
+        assert S3_PAVS_MCP.surface_kind == "placeholder_stub"
+        assert S3_PAVS_MCP.runnable is False
+        assert S3_PAVS_MCP.implementation_status == "PLACEHOLDER_STUB"
+        assert S3_PAVS_MCP.holo_search_support == "placeholder"
+        assert S3_PAVS_MCP.authority_role == "no_authority"
+        assert "pavs_mcp" in S3_PAVS_MCP.path
+
+    def test_known_non_runnable_surfaces_includes_s2_and_s3(self):
+        ids = {s.surface_id for s in KNOWN_NON_RUNNABLE_SURFACES}
+        assert ids == {"S2", "S3"}, (
+            "KNOWN_NON_RUNNABLE_SURFACES must contain exactly S2 and S3"
+        )
+        # Every entry must be non-runnable
+        for s in KNOWN_NON_RUNNABLE_SURFACES:
+            assert s.runnable is False
+
+    def test_known_surface_is_serializable(self):
+        d = S2_FOUNDUPS_MCP_BRIDGE.to_dict()
+        for key in (
+            "surface_id",
+            "surface_kind",
+            "name",
+            "path",
+            "runnable",
+            "implementation_status",
+            "holo_search_support",
+            "authority_role",
+            "notes",
+        ):
+            assert key in d, f"Required truth field missing in to_dict(): {key}"
+
+
+# ---------------------------------------------------------------------------
+# discover_all_surfaces — does not start servers, returns truthful triad
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def manager_with_no_runnable_servers(monkeypatch):
+    """Manager fixture where the foundups-mcp-p1 scan returns an empty dict.
+
+    Lets us assert the S2/S3 baseline appears even when no S1-class server
+    is discovered (e.g. fresh checkout, no foundups-mcp-p1 directory).
+    """
+    monkeypatch.setattr(
+        MCPServerManager,
+        "_discover_mcp_servers",
+        lambda self: {},
+    )
+    return MCPServerManager()
+
+
+@pytest.fixture
+def manager_with_holo_index_only(monkeypatch, tmp_path):
+    """Manager fixture where _discover_mcp_servers returns just S1 (holo_index)."""
+    fake_path = tmp_path / "foundups-mcp-p1" / "servers" / "holo_index" / "server.py"
+    fake_path.parent.mkdir(parents=True)
+    fake_path.write_text("# stub\n")
+    monkeypatch.setattr(
+        MCPServerManager,
+        "_discover_mcp_servers",
+        lambda self: {"holo_index": fake_path},
+    )
+    m = MCPServerManager(repo_root=str(tmp_path))
+    return m
+
+
+@pytest.fixture
+def manager_with_aux_servers(monkeypatch, tmp_path):
+    """Manager fixture with holo_index + auxiliary servers (codeindex etc)."""
+    base = tmp_path / "foundups-mcp-p1" / "servers"
+    holo = base / "holo_index" / "server.py"
+    aux = base / "codeindex" / "server.py"
+    holo.parent.mkdir(parents=True)
+    aux.parent.mkdir(parents=True)
+    holo.write_text("# stub\n")
+    aux.write_text("# stub\n")
+    monkeypatch.setattr(
+        MCPServerManager,
+        "_discover_mcp_servers",
+        lambda self: {"holo_index": holo, "codeindex": aux},
+    )
+    return MCPServerManager(repo_root=str(tmp_path))
+
+
+class TestDiscoverAllSurfaces:
+    """discover_all_surfaces must return S1+S2+S3 truthfully."""
+
+    def test_no_runnable_returns_only_known_surfaces(
+        self, manager_with_no_runnable_servers
+    ):
+        """Even with no S1-class servers found, S2 and S3 must appear."""
+        surfaces = manager_with_no_runnable_servers.discover_all_surfaces()
+        ids = [s.surface_id for s in surfaces]
+        assert ids == ["S2", "S3"], (
+            "When no runnable server discovered, only S2/S3 should appear"
+        )
+
+    def test_holo_index_present_yields_full_triad(self, manager_with_holo_index_only):
+        """S1 + S2 + S3 are all reported when holo_index is discovered."""
+        surfaces = manager_with_holo_index_only.discover_all_surfaces()
+        ids = [s.surface_id for s in surfaces]
+        assert ids == ["S1", "S2", "S3"], (
+            f"Expected S1/S2/S3 triad, got {ids}"
+        )
+
+    def test_s1_truth_fields_when_discovered(self, manager_with_holo_index_only):
+        """The S1 entry constructed from discovery has truthful runnable=True."""
+        surfaces = manager_with_holo_index_only.discover_all_surfaces()
+        s1 = next(s for s in surfaces if s.surface_id == "S1")
+        assert s1.surface_kind == "external_mcp_server"
+        assert s1.name == "holo_index"
+        assert s1.runnable is True
+        assert s1.implementation_status == "RUNTIME_LIVE"
+        assert s1.holo_search_support == "real"
+        assert s1.authority_role == "canonical_external_adapter"
+
+    def test_auxiliary_servers_marked_aux_not_s1(self, manager_with_aux_servers):
+        """Servers other than holo_index get AUX:* surface_id, not S1."""
+        surfaces = manager_with_aux_servers.discover_all_surfaces()
+
+        # Exactly one S1
+        s1_count = sum(1 for s in surfaces if s.surface_id == "S1")
+        assert s1_count == 1
+
+        # codeindex -> AUX:codeindex
+        aux = [s for s in surfaces if s.surface_id.startswith("AUX:")]
+        assert len(aux) == 1
+        assert aux[0].surface_id == "AUX:codeindex"
+        assert aux[0].surface_kind == "auxiliary_mcp_server"
+        assert aux[0].holo_search_support == "none"
+        assert aux[0].authority_role == "auxiliary"
+
+    def test_does_not_start_any_server(
+        self, manager_with_holo_index_only, monkeypatch
+    ):
+        """discover_all_surfaces must never call start_server."""
+        called = []
+        monkeypatch.setattr(
+            manager_with_holo_index_only,
+            "start_server",
+            lambda name: called.append(name) or True,
+        )
+        manager_with_holo_index_only.discover_all_surfaces()
+        assert called == [], (
+            "discover_all_surfaces must not auto-start any server; got starts: "
+            f"{called}"
+        )
+
+    def test_non_runnable_surfaces_are_runnable_false(
+        self, manager_with_holo_index_only
+    ):
+        """S2/S3 must always be runnable=False so the manager never tries to start them."""
+        surfaces = manager_with_holo_index_only.discover_all_surfaces()
+        for s in surfaces:
+            if s.surface_id in {"S2", "S3"}:
+                assert s.runnable is False
+
+
+# ---------------------------------------------------------------------------
+# format_surface_report — visible truth fields in operator output
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSurfaceReport:
+    """The textual report must surface every truth field for every surface."""
+
+    def test_report_includes_all_surface_ids(self, manager_with_holo_index_only):
+        report = manager_with_holo_index_only.format_surface_report()
+        assert "S1" in report
+        assert "S2" in report
+        assert "S3" in report
+
+    def test_report_distinguishes_runnable_from_non_runnable(
+        self, manager_with_holo_index_only
+    ):
+        report = manager_with_holo_index_only.format_surface_report()
+        # The runnable column must show "yes" for at least S1 and "no" for S2/S3
+        # We assert by counting tokens loosely.
+        assert " yes " in report or "yes" in report
+        assert "no" in report
+
+    def test_report_includes_status_labels(self, manager_with_holo_index_only):
+        report = manager_with_holo_index_only.format_surface_report()
+        assert "RUNTIME_LIVE" in report
+        assert "RUNTIME_INTERNAL_ONLY" in report
+        assert "PLACEHOLDER_STUB" in report
+
+    def test_report_includes_holo_search_support_column(
+        self, manager_with_holo_index_only
+    ):
+        report = manager_with_holo_index_only.format_surface_report()
+        assert "real" in report  # S1
+        assert "real_with_fallback" in report  # S2
+        assert "placeholder" in report  # S3
+
+    def test_report_includes_wsp96_authority_anchor(
+        self, manager_with_holo_index_only
+    ):
+        report = manager_with_holo_index_only.format_surface_report()
+        assert "WSP_96" in report
+        assert "Annex A" in report
+
+
+# ---------------------------------------------------------------------------
+# report_all_surfaces — runtime-safe (no startup), prints + returns
+# ---------------------------------------------------------------------------
+
+
+class TestReportAllSurfaces:
+    """report_all_surfaces must be safe to call standalone (no server boot)."""
+
+    def test_returns_list_of_known_surfaces(self, manager_with_holo_index_only, capsys):
+        result = manager_with_holo_index_only.report_all_surfaces()
+        assert isinstance(result, list)
+        assert all(isinstance(s, KnownSurface) for s in result)
+        # Output captured
+        captured = capsys.readouterr()
+        assert "S1" in captured.out
+        assert "S2" in captured.out
+        assert "S3" in captured.out
+
+    def test_no_subprocess_or_psutil_calls(
+        self, manager_with_holo_index_only, monkeypatch
+    ):
+        """The discovery report must not invoke subprocess or psutil."""
+        # Explicit guard: replace subprocess.Popen and psutil.process_iter with
+        # exploding stubs. If the report path touches them, the test fails.
+        def boom_popen(*_a, **_kw):
+            raise AssertionError("report_all_surfaces must not call subprocess.Popen")
+
+        def boom_iter(*_a, **_kw):
+            raise AssertionError(
+                "report_all_surfaces must not call psutil.process_iter"
+            )
+
+        monkeypatch.setattr(mcp_manager.subprocess, "Popen", boom_popen)
+        monkeypatch.setattr(mcp_manager.psutil, "process_iter", boom_iter)
+
+        # Should still succeed without touching either
+        result = manager_with_holo_index_only.report_all_surfaces()
+        assert len(result) >= 2  # at least S2 + S3
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle preservation — runnable surfaces still managed normally
+# ---------------------------------------------------------------------------
+
+
+class TestLifecyclePreservation:
+    """Existing runnable-server methods must still work for S1-class surfaces."""
+
+    def test_get_server_status_still_callable(self, manager_with_holo_index_only):
+        """Existing API not broken by the discovery expansion."""
+        is_running, pid = manager_with_holo_index_only.get_server_status("holo_index")
+        # We did not start anything, so it must report not running.
+        assert is_running is False
+        assert pid is None
+
+    def test_servers_dict_unchanged_in_shape(self, manager_with_holo_index_only):
+        """`self.servers` is still a {name: Path} dict for runnable servers only."""
+        servers = manager_with_holo_index_only.servers
+        assert "holo_index" in servers
+        # S2/S3 are NOT in self.servers — they are listed separately
+        assert "foundups_mcp_bridge" not in servers
+        assert "pavs_mcp" not in servers
+
+
+# ---------------------------------------------------------------------------
+# Module exports (defensive — prevent accidental constant removal)
+# ---------------------------------------------------------------------------
+
+
+def test_module_exports_required_discovery_symbols():
+    """If a future refactor removes these, the test suite fails loudly."""
+    assert hasattr(mcp_manager, "KnownSurface")
+    assert hasattr(mcp_manager, "S2_FOUNDUPS_MCP_BRIDGE")
+    assert hasattr(mcp_manager, "S3_PAVS_MCP")
+    assert hasattr(mcp_manager, "KNOWN_NON_RUNNABLE_SURFACES")
+    assert hasattr(MCPServerManager, "discover_all_surfaces")
+    assert hasattr(MCPServerManager, "format_surface_report")
+    assert hasattr(MCPServerManager, "report_all_surfaces")


### PR DESCRIPTION
## Summary
- Expands `MCPManager.discover_surfaces()` to include S1, S2, S3 per WSP 96 Annex A
- Returns truthful status flags: `RUNTIME_LIVE`, `RUNTIME_INTERNAL_ONLY`, `PLACEHOLDER_STUB`
- S2 (MCP Bridge) and S3 (pAVS) discovered but NOT auto-started (no runtime behavior change)
- Adds 20 tests validating discovery behavior and status accuracy

## Test Evidence
- `modules/infrastructure/mcp_manager/tests/test_surface_discovery.py` — 20 tests passed (W1 handoff)

## Test plan
- [x] S1/S2/S3 surfaces discovered with correct paths
- [x] Status flags match WSP 96 Annex A ownership table
- [x] S2/S3 remain non-runnable (no auto-start)
- [x] WSP 97 truth boundaries enforced (discovery/reporting only, no runtime overclaim)

Worker-Lane: W10
Slice: MCPA5

🤖 Generated with [Claude Code](https://claude.com/claude-code)