### PR TITLE
feat(foundups_mcp_bridge): align S2 holo_search with WSP96 Annex A request/meta contract

### DIFF
--- a/modules/infrastructure/foundups_mcp_bridge/ModLog.md
+++ b/modules/infrastructure/foundups_mcp_bridge/ModLog.md
@@ -1,0 +1,107 @@
+# foundups_mcp_bridge - ModLog
+
+## 2026-05-08 - S63: S2 holo_search → WSP 96 Annex A request/meta conformance
+
+**Author**: 0102 (Worker W1)
+**WSP**: 97 (Truth Boundaries), 96 (MCP Governance — Annex A.2/A.3)
+**Slice**: `S63_S2_ANNEX_A_RENAME_AND_META_PHASE1`
+**Closes (MCPA6 audit drift)**: D12, D13, D14, D15, D16, D17, D18
+
+### Why
+
+Per MCPA6 conformance audit (`docs/audits/mcp_system/MCPA6_MCP_CONFORMANCE_AUDIT.md`),
+S2 was the closest of the three `holo_search` surfaces to the WSP 96 Annex A
+canonical contract — but still drifted on field naming (`scope` vs
+`doc_type_filter`, `top_k` vs `limit`), lacked the federation request fields
+(`foundup_id`, `include_shared`), did not tag responses with `meta.surface`,
+returned a flat string error instead of the canonical `error.code` object,
+and used a hardcoded `0.5` relevance for ripgrep fallback instead of the
+Annex A.3 0.6 cap policy. This slice closes those gaps without rewriting
+S2 architecture.
+
+### Changes
+
+- `src/holo_tools.py`:
+  - Added module-level constants `S2_SURFACE_ID`, `ANNEX_A_LIMIT_MAX`,
+    `ANNEX_A_LIMIT_DEFAULT`, `ANNEX_A_FALLBACK_RELEVANCE_CAP`.
+  - Added `_build_s2_error_envelope()` helper producing the Annex A.3
+    `{code, message, details?}` error shape (the generic `error_response()`
+    keeps returning a flat string for the other tools — no cross-tool drift).
+  - Added `_build_s2_ok_envelope()` helper producing the canonical Annex A.3
+    ok envelope with `data.metadata.retrieval_mode`, `data.metadata.warnings`,
+    `meta.surface = "S2"`, etc.
+  - Rewrote `holo_search` signature to accept the five canonical Annex A.2
+    request fields (`query`, `limit`, `doc_type_filter`, `foundup_id`,
+    `include_shared`). Legacy `scope` and `top_k` retained as deprecated
+    aliases; canonical names win when both are supplied.
+  - Empty-query rejection now returns `error.code = "EMPTY_QUERY"` with a
+    truthful message naming Annex A.2.
+  - Limit is clamped to Annex A.2 [1..50] with a truthful warning when the
+    clamp applies; invalid types fall back to default 10 with a warning.
+  - Lexical fallback path now caps every hit's `relevance` at
+    `ANNEX_A_FALLBACK_RELEVANCE_CAP = 0.6` per Annex A.3.
+  - `data.metadata` block now always carries `retrieval_mode`,
+    `engine_version`, `collections_searched`, and `warnings`. Engine
+    metadata is merged in without overriding canonical keys.
+  - `meta.surface = "S2"` and `meta.tool = "holo_search"` emitted on both
+    ok and error responses.
+  - Federation field acceptance is truthful: `foundup_id` is echoed but
+    surfaces an Annex A.2/Slice-6 "tenant scoping not yet enforced" warning;
+    `include_shared` is echoed as `None` when `foundup_id` is null so callers
+    cannot infer a scope decision was made.
+  - Imports `MCPResponse` from `response_schema` (was importing
+    `ok_response`/`error_response` only).
+
+- `tests/test_mcp_bridge.py`:
+  - Updated `test_holo_search_empty_query_error` to assert the canonical
+    `error.code = "EMPTY_QUERY"` shape and `meta.surface = "S2"`.
+  - Added `TestS2HoloSearchAnnexAConformance` class with 22 focused tests
+    covering: canonical field names accepted, foundup_id/include_shared
+    echo semantics, legacy aliases (`scope`, `top_k`) still work with
+    truthful warnings, canonical wins over alias when both supplied,
+    Annex A.2 limit bounds (clamp warnings), `meta.surface`, `meta.tool`,
+    `meta.source` truthfulness, `data.metadata` canonical keys, empty-query
+    canonical error, whitespace-query rejection, foundup_id unenforced
+    warning, fallback relevance ≤ 0.6 cap, BACKEND_UNAVAILABLE error
+    envelope, and direct `holo_tools.holo_search()` invocation.
+
+- `ModLog.md` (NEW): this entry.
+
+### Behavior boundaries (what did NOT change)
+
+- S1 (`foundups-mcp-p1/servers/holo_index/server.py`) untouched.
+- S3 (`pavs_mcp/src/server.py`) untouched.
+- MCP Manager untouched.
+- `error_response()` and `ok_response()` helpers in `response_schema.py`
+  unchanged — only `holo_search` builds the canonical structured error.
+  Other bridge tools keep the legacy flat-string error shape.
+- Other tools in `holo_tools.py` (`holo_related`, `holo_failure_memory`,
+  `holo_pattern_search`, `holo_task_packet`) are untouched per slice scope
+  (deferred until they have a canonical Annex A entry of their own).
+- No federation auth implementation. `foundup_id` is accepted and echoed
+  but tenant scoping is NOT enforced — explicitly tracked as MCPA1 Slice 6.
+- No real-relevance computation change in the semantic path — Annex A's
+  `1/(1+distance)` rule was already approximated by `_parse_similarity`
+  which converts "85.1%" → 0.851. Only the fallback path needed the cap.
+
+### Tests
+
+```
+PYTHONPATH=. python -m pytest \
+  modules/infrastructure/foundups_mcp_bridge/tests/test_mcp_bridge.py \
+  -k "holo_search or AnnexAConformance" -q
+-> 26 passed, 87 deselected
+```
+
+### Tracked follow-ups
+
+- MCPA1 Slice 6 (`MCP_FEDERATION_AUTH_AND_SCOPE_PHASE1`) — actually
+  enforce `foundup_id` tenant scoping. The truthful "not yet enforced"
+  warning surfaced by this slice will flip to a real authority check.
+- MCPA6 Slice 6.2 — bring S1 (`semantic_code_search`) into the same
+  envelope conformance applied here to S2.
+- The four other holo_* tools in this module (`holo_related`,
+  `holo_failure_memory`, `holo_pattern_search`, `holo_task_packet`)
+  remain on the legacy `ok_response` envelope. WSP 96 Annex A only
+  defines `holo_search` today; those tools get their own annex when
+  they have a canonical contract.

--- a/modules/infrastructure/foundups_mcp_bridge/src/holo_tools.py
+++ b/modules/infrastructure/foundups_mcp_bridge/src/holo_tools.py
@@ -28,7 +28,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from .response_schema import ok_response, error_response
+from .response_schema import MCPResponse, ok_response, error_response
 
 logger = logging.getLogger(__name__)
 
@@ -77,39 +77,159 @@ def _get_holoindex(repo_root: Path):
 # =============================================================================
 
 
+# =============================================================================
+# Canonical Annex A constants (S63: WSP 96 Annex A.2/A.3 conformance)
+# =============================================================================
+
+S2_SURFACE_ID = "S2"
+"""Surface tag per WSP 96 Annex A.1 — emitted in every meta block."""
+
+ANNEX_A_LIMIT_MAX = 50
+"""Annex A.2: hard upper bound on `limit` to prevent denial-by-pagination."""
+
+ANNEX_A_LIMIT_DEFAULT = 10
+"""Annex A.2: default `limit` when none supplied."""
+
+ANNEX_A_FALLBACK_RELEVANCE_CAP = 0.6
+"""Annex A.3: surfaces using lexical fallback MUST cap relevance at 0.6."""
+
+
+def _build_s2_error_envelope(
+    *,
+    code: str,
+    message: str,
+    details: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build a WSP 96 Annex A.3 canonical error envelope for S2 holo_search.
+
+    The generic `error_response()` returns `error` as a flat string. Annex A.3
+    requires `error: {code, message, details?}` for `holo_search` so clients
+    can branch on the machine-readable code (e.g. EMPTY_QUERY) rather than
+    string-matching the message. This helper produces only the holo_search
+    error shape — other tools continue to use `error_response()` unchanged.
+    """
+    error_obj: Dict[str, Any] = {"code": code, "message": message}
+    if details is not None:
+        error_obj["details"] = details
+    return MCPResponse(
+        status="error",
+        error=error_obj,
+        meta={"tool": "holo_search", "surface": S2_SURFACE_ID},
+    ).to_dict()
+
+
 def holo_search(
     repo_root: Path,
     query: str,
-    scope: str = "all",
-    top_k: int = 10,
+    *,
+    # Canonical Annex A.2 request fields (preferred names)
+    limit: Optional[int] = None,
+    doc_type_filter: Optional[str] = None,
+    foundup_id: Optional[str] = None,
+    include_shared: bool = True,
+    # Back-compat aliases (deprecated; canonical names win if both supplied)
+    scope: Optional[str] = None,
+    top_k: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """
-    Semantic search across the repository.
+    """Semantic search across the repository (S2 — canonical internal adapter).
+
+    Conforms to WSP 96 Annex A.2 (request schema) and Annex A.3 (response
+    envelope). Federation auth/scope (`foundup_id`, `include_shared`) is
+    accepted but NOT enforced at this surface — enforcement lands in
+    MCPA1 Slice 6. `data.metadata.warnings` truthfully reports this gap.
 
     Args:
-        repo_root: Repository root path
-        query: Search query
-        scope: Search scope ("all", "code", "wsp", "test", "skill")
-        top_k: Maximum results to return
+        repo_root: Repository root path.
+        query: Natural-language search query (required, non-empty).
+        limit: Annex A.2 canonical name. Default 10, range 1..50.
+        doc_type_filter: Annex A.2 canonical name. Enum: all|code|wsp|test|
+            skill|docs|knowledge.
+        foundup_id: Federation tenant scope (echoed; not yet enforced).
+        include_shared: Federation share flag (only meaningful when
+            `foundup_id` is set; otherwise echoed as None).
+        scope: Legacy alias for `doc_type_filter` (back-compat). If
+            `doc_type_filter` is also passed, the canonical name wins.
+        top_k: Legacy alias for `limit` (back-compat). If `limit` is also
+            passed, the canonical name wins.
 
     Returns:
-        MCPResponse with search results
+        WSP 96 Annex A.3 canonical envelope:
+        - `status`: "ok" | "error"
+        - `data`: {query, doc_type_filter, scope (alias), foundup_id,
+                   include_shared, hits[], hit_count, metadata}
+        - `meta`: {timestamp, source, tool, surface, confidence, ...}
+        - `error` (when status="error"): {code, message, details?}
     """
-    if not query or not query.strip():
-        return error_response("Query cannot be empty")
+    # ----- Resolve canonical inputs (canonical wins over aliases) -----
+    warnings: List[str] = []
 
+    if limit is not None:
+        effective_limit_raw = limit
+    elif top_k is not None:
+        effective_limit_raw = top_k
+        warnings.append(
+            "Legacy 'top_k' parameter accepted as alias for canonical 'limit'; "
+            "please migrate per WSP 96 Annex A.2."
+        )
+    else:
+        effective_limit_raw = ANNEX_A_LIMIT_DEFAULT
+
+    if doc_type_filter is not None:
+        effective_filter = doc_type_filter
+    elif scope is not None:
+        effective_filter = scope
+        warnings.append(
+            "Legacy 'scope' parameter accepted as alias for canonical "
+            "'doc_type_filter'; please migrate per WSP 96 Annex A.2."
+        )
+    else:
+        effective_filter = "all"
+
+    # Annex A.2: clamp limit to [1..50]; surface clamping truthfully.
+    try:
+        bounded_limit = int(effective_limit_raw) if effective_limit_raw is not None else ANNEX_A_LIMIT_DEFAULT
+    except (TypeError, ValueError):
+        bounded_limit = ANNEX_A_LIMIT_DEFAULT
+        warnings.append(
+            f"Invalid limit value {effective_limit_raw!r}; defaulted to "
+            f"{ANNEX_A_LIMIT_DEFAULT} per WSP 96 Annex A.2."
+        )
+    clamped_limit = max(1, min(bounded_limit, ANNEX_A_LIMIT_MAX))
+    if clamped_limit != bounded_limit:
+        warnings.append(
+            f"limit clamped to Annex A.2 range (1..{ANNEX_A_LIMIT_MAX}): "
+            f"requested={bounded_limit}, applied={clamped_limit}."
+        )
+
+    # Federation scope honesty (not yet enforced — MCPA1 Slice 6).
+    if foundup_id is not None:
+        warnings.append(
+            "foundup_id received; tenant scoping not yet enforced at S2 "
+            "(deferred to MCPA1 Slice 6 / federation auth)."
+        )
+
+    # ----- Empty-query rejection (Annex A.2 + WSP 97 truth boundary) -----
+    if not query or not query.strip():
+        return _build_s2_error_envelope(
+            code="EMPTY_QUERY",
+            message=(
+                "Query cannot be empty. WSP 96 Annex A.2 requires a "
+                "non-empty `query` field."
+            ),
+        )
+
+    # ----- Real backend path -----
     holo = _get_holoindex(repo_root)
     source = "holoindex"
     confidence = 0.8
+    retrieval_mode = "semantic"
 
     if holo:
         try:
-            # Use real HoloIndex search
-            results = holo.search(query, limit=top_k, doc_type_filter=scope)
+            results = holo.search(query, limit=clamped_limit, doc_type_filter=effective_filter)
 
-            hits = []
-            # Combine all hit types
-            for hit in results.get("code_hits", [])[:top_k]:
+            hits: List[Dict[str, Any]] = []
+            for hit in results.get("code_hits", [])[:clamped_limit]:
                 hits.append({
                     "type": "code",
                     "path": hit.get("path") or hit.get("location"),
@@ -117,8 +237,7 @@ def holo_search(
                     "preview": hit.get("preview", "")[:200],
                     "need": hit.get("need", ""),
                 })
-
-            for hit in results.get("wsp_hits", [])[:top_k]:
+            for hit in results.get("wsp_hits", [])[:clamped_limit]:
                 hits.append({
                     "type": "wsp",
                     "path": hit.get("path"),
@@ -126,15 +245,13 @@ def holo_search(
                     "summary": hit.get("summary", "")[:200],
                     "relevance": _parse_similarity(hit.get("similarity", "0%")),
                 })
-
-            for hit in results.get("test_hits", [])[:top_k]:
+            for hit in results.get("test_hits", [])[:clamped_limit]:
                 hits.append({
                     "type": "test",
                     "path": hit.get("path"),
                     "relevance": _parse_similarity(hit.get("similarity", "0%")),
                 })
-
-            for hit in results.get("skill_hits", [])[:top_k]:
+            for hit in results.get("skill_hits", [])[:clamped_limit]:
                 hits.append({
                     "type": "skill",
                     "path": hit.get("path"),
@@ -142,60 +259,122 @@ def holo_search(
                     "relevance": _parse_similarity(hit.get("similarity", "0%")),
                 })
 
-            # Sort by relevance and limit
             hits.sort(key=lambda x: x.get("relevance", 0), reverse=True)
-            hits = hits[:top_k]
+            hits = hits[:clamped_limit]
 
-            return ok_response(
-                {
-                    "query": query,
-                    "scope": scope,
-                    "hits": hits,
-                    "hit_count": len(hits),
-                    "metadata": results.get("metadata", {}),
-                },
+            return _build_s2_ok_envelope(
+                query=query,
+                effective_filter=effective_filter,
+                foundup_id=foundup_id,
+                include_shared=include_shared,
+                hits=hits,
+                engine_metadata=results.get("metadata", {}),
+                retrieval_mode=retrieval_mode,
                 source=source,
                 confidence=confidence,
-                tool="holo_search",
+                warnings=warnings,
             )
 
         except Exception as e:
             logger.warning(f"[MCP] HoloIndex search failed, using fallback: {e}")
+            warnings.append(
+                f"HoloIndex backend error; using lexical fallback: {e}"
+            )
             source = "fallback"
             confidence = 0.5
+            retrieval_mode = "lexical"
+    else:
+        warnings.append("HoloIndex unavailable; using lexical fallback.")
+        source = "fallback"
+        confidence = 0.4
+        retrieval_mode = "lexical"
 
-    # Fallback: use ripgrep search
-    source = "fallback"
-    confidence = 0.4
-
+    # ----- Fallback path (ripgrep) -----
     from .repo_tools import search_repo
-    fallback_result = search_repo(repo_root, query=query, path=".", top_k=top_k)
+    fallback_result = search_repo(repo_root, query=query, path=".", top_k=clamped_limit)
 
     if fallback_result.get("status") != "ok":
-        return fallback_result
+        return _build_s2_error_envelope(
+            code="BACKEND_UNAVAILABLE",
+            message=(
+                "Both HoloIndex and ripgrep fallback failed; cannot serve "
+                "holo_search on S2 right now."
+            ),
+            details={"fallback_error": fallback_result.get("error", "unknown")},
+        )
 
-    # Convert fallback results to holo format
-    hits = []
+    # Convert fallback results to canonical hit shape.
+    # Annex A.3: surfaces using lexical fallback MUST cap relevance at 0.6
+    # to truthfully signal weaker confidence (WSP 97).
+    fallback_hits: List[Dict[str, Any]] = []
     for match in fallback_result["data"].get("matches", []):
-        hits.append({
+        fallback_hits.append({
             "type": "code",
             "path": match.get("file"),
-            "relevance": 0.5,  # No semantic score in fallback
             "preview": match.get("line", "")[:200],
             "line_num": match.get("line_num"),
+            "relevance": ANNEX_A_FALLBACK_RELEVANCE_CAP,
         })
+    fallback_hits = fallback_hits[:clamped_limit]
+
+    return _build_s2_ok_envelope(
+        query=query,
+        effective_filter=effective_filter,
+        foundup_id=foundup_id,
+        include_shared=include_shared,
+        hits=fallback_hits,
+        engine_metadata={"engine_version": "ripgrep_fallback"},
+        retrieval_mode=retrieval_mode,
+        source=source,
+        confidence=confidence,
+        warnings=warnings,
+    )
+
+
+def _build_s2_ok_envelope(
+    *,
+    query: str,
+    effective_filter: str,
+    foundup_id: Optional[str],
+    include_shared: bool,
+    hits: List[Dict[str, Any]],
+    engine_metadata: Dict[str, Any],
+    retrieval_mode: str,
+    source: str,
+    confidence: float,
+    warnings: List[str],
+) -> Dict[str, Any]:
+    """Build the WSP 96 Annex A.3 canonical ok envelope for S2 holo_search."""
+    metadata: Dict[str, Any] = {
+        "retrieval_mode": retrieval_mode,
+        "engine_version": engine_metadata.get("engine_version", "holoindex"),
+        "collections_searched": engine_metadata.get("collections_searched", []),
+        "warnings": warnings,
+    }
+    # Pass through any extra engine metadata fields without overriding canonical keys.
+    for k, v in engine_metadata.items():
+        if k not in metadata:
+            metadata[k] = v
+
+    data: Dict[str, Any] = {
+        "query": query,
+        "doc_type_filter": effective_filter,
+        # Back-compat alias: legacy callers reading `data.scope` keep working.
+        "scope": effective_filter,
+        "foundup_id": foundup_id,
+        # Annex A.2: include_shared only meaningful when foundup_id is set.
+        "include_shared": include_shared if foundup_id is not None else None,
+        "hits": hits,
+        "hit_count": len(hits),
+        "metadata": metadata,
+    }
 
     return ok_response(
-        {
-            "query": query,
-            "scope": scope,
-            "hits": hits[:top_k],
-            "hit_count": len(hits[:top_k]),
-            "fallback_note": "Using ripgrep text search (HoloIndex unavailable)",
-        },
+        data,
         source=source,
         confidence=confidence,
         tool="holo_search",
+        surface=S2_SURFACE_ID,
     )
 
 

--- a/modules/infrastructure/foundups_mcp_bridge/tests/test_mcp_bridge.py
+++ b/modules/infrastructure/foundups_mcp_bridge/tests/test_mcp_bridge.py
@@ -501,10 +501,16 @@ class TestHoloTools:
         assert result["data"]["query"] == "WSP protocol"
 
     def test_holo_search_empty_query_error(self, bridge):
-        """holo_search rejects empty query."""
+        """holo_search rejects empty query with canonical Annex A.3 error envelope."""
         result = bridge.call_tool("holo_search", query="", scope="all", top_k=5)
         assert result["status"] == "error"
-        assert "empty" in result["error"].lower()
+        # WSP 96 Annex A.3: error is a dict with code/message, not a flat string.
+        assert isinstance(result["error"], dict)
+        assert result["error"]["code"] == "EMPTY_QUERY"
+        assert "empty" in result["error"]["message"].lower()
+        # meta.surface must identify S2 even on error path.
+        assert result["meta"]["surface"] == "S2"
+        assert result["meta"]["tool"] == "holo_search"
 
     def test_holo_search_scoped(self, bridge):
         """holo_search respects scope filter."""
@@ -930,3 +936,256 @@ class TestErrorHandling:
         result = bridge.call_tool("get_repo_tree", invalid_param="test")
         assert result["status"] == "error"
         assert "invalid" in result["error"].lower() or "unexpected" in result["error"].lower()
+
+
+# ==================== S63: S2 holo_search Annex A Conformance ====================
+
+
+class TestS2HoloSearchAnnexAConformance:
+    """S63 (MCPA6 follow-up): verify S2 holo_search conforms to WSP 96 Annex A.
+
+    Closes MCPA6 drift IDs:
+      - D12: `scope` -> `doc_type_filter` (with alias)
+      - D13: `top_k` -> `limit` (with alias)
+      - D14: `foundup_id` request field accepted and echoed
+      - D15: `include_shared` request field accepted and echoed
+      - D16: empty-query error includes canonical `error.code = "EMPTY_QUERY"`
+      - D17: lexical fallback caps relevance at 0.6 (Annex A.3 policy)
+      - D18: meta.surface = "S2" present on every response
+    """
+
+    # ----- Canonical request fields accepted -----
+
+    def test_canonical_doc_type_filter_accepted(self, bridge):
+        """`doc_type_filter` works as the canonical name for scope."""
+        result = bridge.call_tool(
+            "holo_search", query="WSP", doc_type_filter="wsp", limit=3
+        )
+        assert result["status"] == "ok"
+        assert result["data"]["doc_type_filter"] == "wsp"
+        # Back-compat alias `scope` mirrors the same value
+        assert result["data"]["scope"] == "wsp"
+
+    def test_canonical_limit_accepted(self, bridge):
+        """`limit` works as the canonical name for top_k."""
+        result = bridge.call_tool("holo_search", query="WSP", limit=3)
+        assert result["status"] == "ok"
+        # hits should not exceed the canonical limit
+        assert result["data"]["hit_count"] <= 3
+
+    def test_foundup_id_accepted_and_echoed(self, bridge):
+        result = bridge.call_tool(
+            "holo_search", query="WSP", foundup_id="gotjunk", limit=3
+        )
+        assert result["status"] == "ok"
+        assert result["data"]["foundup_id"] == "gotjunk"
+
+    def test_include_shared_with_foundup_id_echoed(self, bridge):
+        """include_shared echoes the request value when foundup_id is set."""
+        result = bridge.call_tool(
+            "holo_search",
+            query="WSP",
+            foundup_id="kosei",
+            include_shared=False,
+            limit=3,
+        )
+        assert result["status"] == "ok"
+        assert result["data"]["include_shared"] is False
+
+    def test_include_shared_null_when_no_foundup_id(self, bridge):
+        """include_shared echoes None when foundup_id is absent (Annex A.2)."""
+        result = bridge.call_tool(
+            "holo_search", query="WSP", include_shared=False, limit=3
+        )
+        assert result["status"] == "ok"
+        assert result["data"]["include_shared"] is None
+
+    # ----- Back-compat aliases still work -----
+
+    def test_legacy_scope_alias_accepted(self, bridge):
+        """Legacy `scope` keyword still works (back-compat)."""
+        result = bridge.call_tool("holo_search", query="WSP", scope="wsp", top_k=3)
+        assert result["status"] == "ok"
+        assert result["data"]["doc_type_filter"] == "wsp"
+
+    def test_legacy_top_k_alias_accepted(self, bridge):
+        """Legacy `top_k` keyword still works (back-compat)."""
+        result = bridge.call_tool("holo_search", query="WSP", top_k=3)
+        assert result["status"] == "ok"
+        assert result["data"]["hit_count"] <= 3
+
+    def test_alias_warnings_surfaced(self, bridge):
+        """Using legacy names triggers a truthful warning per WSP 97."""
+        result = bridge.call_tool(
+            "holo_search", query="WSP", scope="wsp", top_k=3
+        )
+        warnings = result["data"]["metadata"]["warnings"]
+        assert any("scope" in w for w in warnings), (
+            "expected a warning naming legacy 'scope' alias"
+        )
+        assert any("top_k" in w for w in warnings), (
+            "expected a warning naming legacy 'top_k' alias"
+        )
+
+    def test_canonical_wins_over_alias_for_filter(self, bridge):
+        """When both doc_type_filter and scope are passed, canonical wins."""
+        result = bridge.call_tool(
+            "holo_search",
+            query="WSP",
+            doc_type_filter="wsp",
+            scope="code",
+            limit=3,
+        )
+        assert result["data"]["doc_type_filter"] == "wsp"
+
+    def test_canonical_wins_over_alias_for_limit(self, bridge):
+        """When both limit and top_k are passed, canonical wins."""
+        result = bridge.call_tool(
+            "holo_search", query="WSP", limit=2, top_k=10
+        )
+        assert result["data"]["hit_count"] <= 2
+
+    # ----- Annex A.2 limit bounds -----
+
+    def test_limit_clamped_above_50(self, bridge):
+        """limit > 50 is clamped per Annex A.2; warning surfaces the clamp."""
+        result = bridge.call_tool("holo_search", query="WSP", limit=999)
+        warnings = result["data"]["metadata"]["warnings"]
+        assert any(
+            "clamp" in w.lower() and "50" in w for w in warnings
+        ), f"expected clamp warning naming 50; got {warnings}"
+
+    def test_limit_clamped_below_1(self, bridge):
+        """limit < 1 is clamped per Annex A.2."""
+        result = bridge.call_tool("holo_search", query="WSP", limit=0)
+        warnings = result["data"]["metadata"]["warnings"]
+        assert any("clamp" in w.lower() for w in warnings)
+
+    # ----- meta block (Annex A.3) -----
+
+    def test_meta_surface_is_s2(self, bridge):
+        """Every response carries meta.surface = 'S2'."""
+        result = bridge.call_tool("holo_search", query="WSP", limit=3)
+        assert result["meta"]["surface"] == "S2"
+
+    def test_meta_tool_is_holo_search(self, bridge):
+        result = bridge.call_tool("holo_search", query="WSP", limit=3)
+        assert result["meta"]["tool"] == "holo_search"
+
+    def test_meta_source_truthful(self, bridge):
+        """meta.source MUST be 'holoindex' or 'fallback' — never overclaimed."""
+        result = bridge.call_tool("holo_search", query="WSP", limit=3)
+        assert result["meta"]["source"] in ("holoindex", "fallback")
+
+    # ----- data.metadata block (Annex A.3) -----
+
+    def test_data_metadata_has_canonical_keys(self, bridge):
+        """data.metadata MUST include retrieval_mode + warnings (canonical)."""
+        result = bridge.call_tool("holo_search", query="WSP", limit=3)
+        meta = result["data"]["metadata"]
+        assert "retrieval_mode" in meta
+        assert "warnings" in meta
+        assert isinstance(meta["warnings"], list)
+
+    def test_data_metadata_retrieval_mode_truthful(self, bridge):
+        """retrieval_mode value must be one of the Annex A.3 enum strings."""
+        result = bridge.call_tool("holo_search", query="WSP", limit=3)
+        mode = result["data"]["metadata"]["retrieval_mode"]
+        assert mode in ("semantic", "lexical", "fallback", "none")
+
+    # ----- Empty query error envelope (Annex A.3) -----
+
+    def test_empty_query_error_has_canonical_code(self, bridge):
+        result = bridge.call_tool("holo_search", query="")
+        assert result["status"] == "error"
+        assert isinstance(result["error"], dict)
+        assert result["error"]["code"] == "EMPTY_QUERY"
+        assert "message" in result["error"]
+        assert result["meta"]["surface"] == "S2"
+
+    def test_whitespace_query_rejected_with_empty_query_code(self, bridge):
+        """Whitespace-only queries are also rejected as EMPTY_QUERY."""
+        result = bridge.call_tool("holo_search", query="   \t\n  ")
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "EMPTY_QUERY"
+
+    # ----- Federation field warnings (truthful per WSP 97) -----
+
+    def test_foundup_id_surfaces_unenforced_warning(self, bridge):
+        """Passing foundup_id surfaces a truthful 'not yet enforced' warning."""
+        result = bridge.call_tool(
+            "holo_search", query="WSP", foundup_id="gotjunk", limit=3
+        )
+        warnings = result["data"]["metadata"]["warnings"]
+        assert any(
+            "foundup_id" in w and "not yet enforced" in w for w in warnings
+        ), f"expected unenforced-tenant warning; got {warnings}"
+
+    # ----- Fallback relevance cap (Annex A.3 lexical-fallback rule) -----
+
+    def test_fallback_relevance_capped_at_06(self, bridge, monkeypatch):
+        """When falling back to ripgrep, hit relevance MUST be capped at 0.6.
+
+        Forces the fallback path by stubbing the HoloIndex factory. The
+        fallback may either find hits (cap applies) OR fail to find any
+        (canonical BACKEND_UNAVAILABLE error). Both branches are honored
+        truthfully — the slice's invariant is that the cap is never exceeded
+        when hits ARE returned, never that the fallback always returns hits.
+        """
+        from modules.infrastructure.foundups_mcp_bridge.src import holo_tools
+
+        monkeypatch.setattr(holo_tools, "_get_holoindex", lambda _root: None)
+
+        result = bridge.call_tool("holo_search", query="WSP", limit=5)
+
+        if result["status"] == "ok":
+            # Cap MUST apply to any returned hit
+            for hit in result["data"]["hits"]:
+                assert hit.get("relevance", 0) <= 0.6, (
+                    "Annex A.3: lexical fallback hits MUST cap relevance at 0.6"
+                )
+            # And retrieval_mode must truthfully name the fallback path
+            assert result["data"]["metadata"]["retrieval_mode"] in (
+                "lexical",
+                "fallback",
+            )
+        else:
+            # When ripgrep also fails, S2 emits the canonical BACKEND_UNAVAILABLE
+            # error envelope rather than fake hits.
+            assert isinstance(result["error"], dict)
+            assert result["error"]["code"] == "BACKEND_UNAVAILABLE"
+            assert result["meta"]["surface"] == "S2"
+
+    # ----- Direct invocation (the slice spec requires one direct example) -----
+
+    def test_direct_holo_tools_invocation_canonical_envelope(self):
+        """Direct call to holo_tools.holo_search bypasses the bridge wrapper
+        and proves the envelope conforms even without bridge dispatch."""
+        from pathlib import Path
+        from modules.infrastructure.foundups_mcp_bridge.src.holo_tools import (
+            holo_search,
+        )
+
+        repo_root = Path(__file__).resolve().parents[4]
+        result = holo_search(
+            repo_root,
+            query="WSP",
+            limit=3,
+            doc_type_filter="all",
+            foundup_id=None,
+            include_shared=True,
+        )
+
+        # Canonical envelope shape
+        assert result["status"] == "ok"
+        assert "data" in result
+        assert "meta" in result
+        assert result["data"]["query"] == "WSP"
+        assert result["data"]["doc_type_filter"] == "all"
+        assert result["data"]["foundup_id"] is None
+        assert result["data"]["include_shared"] is None  # null without foundup_id
+        assert "hits" in result["data"]
+        assert "hit_count" in result["data"]
+        assert "metadata" in result["data"]
+        assert result["meta"]["surface"] == "S2"
+        assert result["meta"]["tool"] == "holo_search"


### PR DESCRIPTION
## Summary
- Aligns S2 (MCP Bridge) `holo_search` with WSP 96 Annex A request/meta contract
- Canonical parameter names accepted: `limit`, `doc_type_filter`
- Legacy aliases retained with deprecation warning: `top_k`, `scope`
- Adds `meta.surface = "S2"` to response envelope
- Empty query returns canonical `EMPTY_QUERY` error code

## Test Evidence
```
26 passed, 87 deselected in 15.76s
```

## Test plan
- [x] Canonical names (`limit`, `doc_type_filter`) accepted
- [x] Legacy aliases (`top_k`, `scope`) work with warning
- [x] `meta.surface = "S2"` present in response
- [x] Empty query returns `EMPTY_QUERY` code per Annex A
- [x] WSP 97 truth boundaries enforced

Worker-Lane: W10
Slice: S6.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)