### PR TITLE
feat(mcp): align S1/S2 foundup scope request parity under WSP96 Annex A

### DIFF
--- a/foundups-mcp-p1/ModLog.md
+++ b/foundups-mcp-p1/ModLog.md
@@ -2,6 +2,62 @@
 
 **Purpose**: MCP server workspace for 0102 tool access in Claude Code
 
+## 2026-05-08 - S64: S1 / S2 federation-scope request parity
+
+**Author**: 0102 (Worker W1)
+**WSP**: 97 (Truth Boundaries), 96 (MCP Governance — Annex A.2)
+**Slice**: `S64_S1_S2_FOUNDUP_SCOPE_REQUEST_PARITY_PHASE1`
+**Closes (MCPA6 audit drift)**: D7, D8, D14, D15 (cross-surface parity portion); D19 fully
+
+### Why
+
+S62 added `foundup_id` / `include_shared` to S1 and S63 added them to S2.
+Both surfaces emitted near-identical truthful warnings, but the warning
+text was duplicated as separate string literals in two modules. A future
+edit on either side could drift the wording without breaking either
+surface's tests, leaving contract consumers (gateway dashboards, audit
+checkers, regex-matchers) silently chasing two phrasings. This slice
+introduces a shared template constant on each side and a parity test
+suite that fails if the templates ever diverge.
+
+### Changes (S1 side)
+
+- `servers/holo_index/canonical_search.py`:
+  - Added `FEDERATION_SCOPE_WARNING_TEMPLATE` constant — the canonical
+    truthful warning template with `{surface}` substitution token.
+  - Added `federation_scope_warning(surface)` formatter.
+  - `canonical_holo_search` now emits
+    `federation_scope_warning(S1_SURFACE_ID)` instead of an inline
+    string literal.
+
+- `servers/holo_index/tests/test_canonical_holo_search.py`:
+  - Added `TestS64FederationScopeParity` class (8 tests): template
+    token presence, canonical phrasing fragments,
+    `federation_scope_warning("S1")` shape, no-foundup-id-echoes-null
+    pair (with and without explicit `include_shared`), with-foundup-id
+    echo + warning emission, byte-for-byte template match in the
+    runtime warning, and a cross-surface parity test that imports S2's
+    template and asserts byte equality.
+
+### Behavior boundaries (what did NOT change)
+
+- No federation auth implementation (still deferred to MCPA1 Slice 6).
+- Legacy `semantic_code_search` tool untouched.
+- Envelope shape from S62 unchanged.
+- The runtime warning text is byte-identical to what S62 emitted —
+  only the source of the string changed (template constant instead of
+  inline literal).
+
+### Tests
+
+```
+PYTHONPATH=. python -m pytest \
+  foundups-mcp-p1/servers/holo_index/tests/test_canonical_holo_search.py -q
+-> 54 passed (46 from S62 + 8 new S64 parity tests)
+```
+
+---
+
 ## 2026-05-08 - S62: S1 holo_search → WSP 96 Annex A canonical envelope adapter
 
 **Author**: 0102 (Worker W1)

--- a/foundups-mcp-p1/servers/holo_index/canonical_search.py
+++ b/foundups-mcp-p1/servers/holo_index/canonical_search.py
@@ -54,6 +54,35 @@ ANNEX_A_FALLBACK_RELEVANCE_CAP = 0.6
 """Annex A.3: lexical fallback caps relevance at 0.6."""
 
 
+# ----- S64: cross-surface federation-scope warning template (S1 / S2 parity) -----
+
+FEDERATION_SCOPE_WARNING_TEMPLATE = (
+    "foundup_id received; tenant scoping not yet enforced at {surface} "
+    "(deferred to MCPA1 Slice 6 / federation auth)."
+)
+"""Canonical truthful warning when ``foundup_id`` is supplied but not enforced.
+
+Per S64 (`S1_S2_FOUNDUP_SCOPE_REQUEST_PARITY_PHASE1`), both S1 and S2 emit
+exactly this string with their own surface tag substituted, so contract
+consumers (tests, gateways, dashboards) can match a single template. The
+substitution token MUST remain ``{surface}`` so that grep on either module
+finds the same identifier — drift in either surface is a parity violation.
+The S2 mirror lives in
+``modules/infrastructure/foundups_mcp_bridge/src/holo_tools.py``; both
+copies MUST stay byte-identical and the pair is covered by parity tests
+on both sides.
+"""
+
+
+def federation_scope_warning(surface: str) -> str:
+    """Format the canonical federation-scope warning for ``surface``.
+
+    Returns the string a surface MUST emit when ``foundup_id`` is supplied
+    but tenant scoping is not enforced (deferred to MCPA1 Slice 6).
+    """
+    return FEDERATION_SCOPE_WARNING_TEMPLATE.format(surface=surface)
+
+
 # ============================================================================
 # Helpers
 # ============================================================================
@@ -320,12 +349,10 @@ async def canonical_holo_search(
             f"requested={requested_limit}, applied={bounded_limit}."
         )
 
-    # Federation honesty (Slice 6 deferred)
+    # Federation honesty (Slice 6 deferred). S64: use the shared template so
+    # S1/S2 parity is enforced by code, not by copy-paste hygiene.
     if foundup_id is not None:
-        warnings.append(
-            "foundup_id received; tenant scoping not yet enforced at S1 "
-            "(deferred to MCPA1 Slice 6 / federation auth)."
-        )
+        warnings.append(federation_scope_warning(S1_SURFACE_ID))
 
     # Empty-query rejection (Annex A.2 + WSP 97)
     if not query or not query.strip():

--- a/foundups-mcp-p1/servers/holo_index/tests/test_canonical_holo_search.py
+++ b/foundups-mcp-p1/servers/holo_index/tests/test_canonical_holo_search.py
@@ -34,11 +34,13 @@ from canonical_search import (  # noqa: E402  (sys.path manipulation above)
     ANNEX_A_FALLBACK_RELEVANCE_CAP,
     ANNEX_A_LIMIT_DEFAULT,
     ANNEX_A_LIMIT_MAX,
+    FEDERATION_SCOPE_WARNING_TEMPLATE,
     S1_SURFACE_ID,
     build_error_envelope,
     build_ok_envelope,
     canonical_holo_search,
     distance_to_similarity,
+    federation_scope_warning,
 )
 
 
@@ -556,3 +558,100 @@ class TestDirectInvocationExample:
         assert result["meta"]["surface"] == "S1"
         assert result["meta"]["tool"] == "holo_search"
         assert result["meta"]["source"] == "holoindex"
+
+
+# ---------------------------------------------------------------------------
+# S64: S1 / S2 federation-scope request parity
+# ---------------------------------------------------------------------------
+
+
+class TestS64FederationScopeParity:
+    """S64: request-level parity for ``foundup_id`` / ``include_shared``.
+
+    Verifies the S1 side of the contract:
+      - shared template constant is intact and contains ``{surface}`` token
+      - ``federation_scope_warning(S1)`` produces the expected text
+      - request without ``foundup_id`` echoes ``foundup_id=None``,
+        ``include_shared=None``
+      - request with ``foundup_id`` echoes both, plus the canonical warning
+      - the actual warning emitted by ``canonical_holo_search`` matches
+        ``federation_scope_warning(S1)`` byte-for-byte
+      - cross-surface check: S2's template byte-equals S1's template
+    """
+
+    def test_template_has_surface_token(self):
+        assert "{surface}" in FEDERATION_SCOPE_WARNING_TEMPLATE
+
+    def test_template_carries_canonical_phrasing(self):
+        for phrase in (
+            "foundup_id received",
+            "tenant scoping not yet enforced",
+            "MCPA1 Slice 6",
+        ):
+            assert phrase in FEDERATION_SCOPE_WARNING_TEMPLATE
+
+    def test_federation_scope_warning_for_s1(self):
+        warn = federation_scope_warning("S1")
+        assert "at S1" in warn
+        assert "MCPA1 Slice 6" in warn
+        assert "{surface}" not in warn
+
+    def test_no_foundup_id_echoes_null_pair(self, stub_backend):
+        """Without ``foundup_id``, both echoes are null (parity invariant)."""
+        result = _run(canonical_holo_search(stub_backend, query="x"))
+        assert result["data"]["foundup_id"] is None
+        assert result["data"]["include_shared"] is None
+        warnings = result["data"]["metadata"]["warnings"]
+        assert not any("tenant scoping" in w for w in warnings)
+
+    def test_no_foundup_id_with_explicit_include_shared_still_null(
+        self, stub_backend
+    ):
+        """Even when caller passes ``include_shared=False``, the echo is
+        ``None`` if no ``foundup_id`` was supplied (Annex A.2 semantics
+        — the flag is only meaningful with tenant scope)."""
+        result = _run(
+            canonical_holo_search(stub_backend, query="x", include_shared=False)
+        )
+        assert result["data"]["foundup_id"] is None
+        assert result["data"]["include_shared"] is None
+
+    def test_with_foundup_id_echoes_both_and_warns(self, stub_backend):
+        result = _run(
+            canonical_holo_search(
+                stub_backend, query="x", foundup_id="gotjunk", include_shared=False
+            )
+        )
+        assert result["data"]["foundup_id"] == "gotjunk"
+        assert result["data"]["include_shared"] is False
+        warnings = result["data"]["metadata"]["warnings"]
+        assert federation_scope_warning("S1") in warnings
+
+    def test_emitted_warning_matches_template_byte_for_byte(self, stub_backend):
+        """The runtime-emitted warning MUST equal ``federation_scope_warning(S1)``
+        verbatim — protects against drift if a future edit adds a stray space
+        or punctuation difference."""
+        result = _run(
+            canonical_holo_search(stub_backend, query="x", foundup_id="kosei")
+        )
+        warnings = result["data"]["metadata"]["warnings"]
+        scope_warnings = [w for w in warnings if "foundup_id received" in w]
+        assert len(scope_warnings) == 1
+        assert scope_warnings[0] == federation_scope_warning("S1")
+
+    def test_s2_template_matches_s1_template(self):
+        """Cross-surface parity: S1's template MUST match S2's template
+        byte-for-byte (modulo `{surface}` substitution). Drift in either
+        module flags here.
+        """
+        try:
+            from modules.infrastructure.foundups_mcp_bridge.src.holo_tools import (
+                FEDERATION_SCOPE_WARNING_TEMPLATE as s2_template,
+            )
+        except Exception:
+            pytest.skip("S2 holo_tools not importable in this environment")
+
+        assert s2_template == FEDERATION_SCOPE_WARNING_TEMPLATE, (
+            "S1 and S2 federation-scope warning templates have drifted; "
+            "they MUST be byte-identical per S64 parity contract."
+        )

--- a/modules/infrastructure/foundups_mcp_bridge/ModLog.md
+++ b/modules/infrastructure/foundups_mcp_bridge/ModLog.md
@@ -1,5 +1,59 @@
 # foundups_mcp_bridge - ModLog
 
+## 2026-05-08 - S64: S1 / S2 federation-scope request parity
+
+**Author**: 0102 (Worker W1)
+**WSP**: 97 (Truth Boundaries), 96 (MCP Governance — Annex A.2)
+**Slice**: `S64_S1_S2_FOUNDUP_SCOPE_REQUEST_PARITY_PHASE1`
+**Closes (MCPA6 audit drift)**: D7, D8, D14, D15 (cross-surface parity portion); D19 fully
+
+### Why
+
+S63 added `foundup_id` / `include_shared` to S2, and S62 did the same for S1.
+Both surfaces emitted truthful "tenant scoping not yet enforced" warnings,
+but the warning text was duplicated as separate string literals. Per WSP 97,
+contract consumers should be able to match a single canonical phrase rather
+than two near-identical strings that could drift over time. This slice
+extracts the warning into a shared template constant on each side and adds
+parity tests that fail if either side drifts.
+
+### Changes (S2 side)
+
+- `src/holo_tools.py`:
+  - Added `FEDERATION_SCOPE_WARNING_TEMPLATE` constant (byte-identical to
+    the S1 mirror in `foundups-mcp-p1/servers/holo_index/canonical_search.py`).
+  - Added `federation_scope_warning(surface)` formatter.
+  - `holo_search` now emits `federation_scope_warning(S2_SURFACE_ID)` instead
+    of an inline string literal.
+
+- `tests/test_mcp_bridge.py`:
+  - Added `TestS64FederationScopeParity` class (8 tests): S2 template token
+    presence, canonical phrasing fragments, `federation_scope_warning("S2")`
+    shape, no-foundup-id-echoes-null pair (with and without explicit
+    `include_shared`), with-foundup-id echo + warning emission, byte-for-byte
+    template match in the runtime warning, and a cross-surface parity test
+    that imports S1's template and asserts byte equality.
+
+### Behavior boundaries (what did NOT change)
+
+- No federation auth implementation (still deferred to MCPA1 Slice 6).
+- Envelope shape from S63 unchanged.
+- The runtime warning text is byte-identical to what S63 emitted — only
+  the source of the string changed (template constant instead of inline
+  literal).
+- S3 (pavs_mcp) and MCP Manager untouched.
+
+### Tests
+
+```
+PYTHONPATH=. python -m pytest \
+  modules/infrastructure/foundups_mcp_bridge/tests/test_mcp_bridge.py \
+  -k "holo_search or AnnexAConformance or FederationScopeParity" -q
+-> 34 passed (26 from S63 + 8 new S64 parity tests)
+```
+
+---
+
 ## 2026-05-08 - S63: S2 holo_search → WSP 96 Annex A request/meta conformance
 
 **Author**: 0102 (Worker W1)

--- a/modules/infrastructure/foundups_mcp_bridge/src/holo_tools.py
+++ b/modules/infrastructure/foundups_mcp_bridge/src/holo_tools.py
@@ -94,6 +94,33 @@ ANNEX_A_FALLBACK_RELEVANCE_CAP = 0.6
 """Annex A.3: surfaces using lexical fallback MUST cap relevance at 0.6."""
 
 
+# ----- S64: cross-surface federation-scope warning template (S1 / S2 parity) -----
+
+FEDERATION_SCOPE_WARNING_TEMPLATE = (
+    "foundup_id received; tenant scoping not yet enforced at {surface} "
+    "(deferred to MCPA1 Slice 6 / federation auth)."
+)
+"""Canonical truthful warning when ``foundup_id`` is supplied but not enforced.
+
+Per S64 (`S1_S2_FOUNDUP_SCOPE_REQUEST_PARITY_PHASE1`), both S1 and S2 emit
+exactly this string with their own surface tag substituted, so contract
+consumers (tests, gateways, dashboards) can match a single template. The
+canonical S1 mirror lives in
+``foundups-mcp-p1/servers/holo_index/canonical_search.py`` —
+both copies MUST stay byte-identical and the pair is covered by parity tests
+on both sides.
+"""
+
+
+def federation_scope_warning(surface: str) -> str:
+    """Format the canonical federation-scope warning for ``surface``.
+
+    Returns the string a surface MUST emit when ``foundup_id`` is supplied
+    but tenant scoping is not enforced (deferred to MCPA1 Slice 6).
+    """
+    return FEDERATION_SCOPE_WARNING_TEMPLATE.format(surface=surface)
+
+
 def _build_s2_error_envelope(
     *,
     code: str,
@@ -201,12 +228,11 @@ def holo_search(
             f"requested={bounded_limit}, applied={clamped_limit}."
         )
 
-    # Federation scope honesty (not yet enforced — MCPA1 Slice 6).
+    # Federation scope honesty (not yet enforced — MCPA1 Slice 6). S64:
+    # use the shared template so S1/S2 parity is enforced by code, not by
+    # copy-paste hygiene.
     if foundup_id is not None:
-        warnings.append(
-            "foundup_id received; tenant scoping not yet enforced at S2 "
-            "(deferred to MCPA1 Slice 6 / federation auth)."
-        )
+        warnings.append(federation_scope_warning(S2_SURFACE_ID))
 
     # ----- Empty-query rejection (Annex A.2 + WSP 97 truth boundary) -----
     if not query or not query.strip():

--- a/modules/infrastructure/foundups_mcp_bridge/tests/test_mcp_bridge.py
+++ b/modules/infrastructure/foundups_mcp_bridge/tests/test_mcp_bridge.py
@@ -1189,3 +1189,131 @@ class TestS2HoloSearchAnnexAConformance:
         assert "metadata" in result["data"]
         assert result["meta"]["surface"] == "S2"
         assert result["meta"]["tool"] == "holo_search"
+
+
+# ==================== S64: S1/S2 federation scope request parity ====================
+
+
+class TestS64FederationScopeParity:
+    """S64: cross-surface parity for ``foundup_id`` / ``include_shared``.
+
+    Verifies the S2 side of the contract:
+      - shared template constant is intact and contains ``{surface}`` token
+      - ``federation_scope_warning(S2)`` produces the expected text
+      - request without ``foundup_id`` echoes ``foundup_id=None``,
+        ``include_shared=None``
+      - request with ``foundup_id`` echoes both, plus the canonical warning
+      - the actual warning emitted by S2 ``holo_search`` matches
+        ``federation_scope_warning(S2)`` byte-for-byte
+      - cross-surface check: S1's template byte-equals S2's template
+    """
+
+    def test_s2_template_has_surface_token(self):
+        from modules.infrastructure.foundups_mcp_bridge.src.holo_tools import (
+            FEDERATION_SCOPE_WARNING_TEMPLATE,
+        )
+        assert "{surface}" in FEDERATION_SCOPE_WARNING_TEMPLATE
+
+    def test_s2_template_carries_canonical_phrasing(self):
+        from modules.infrastructure.foundups_mcp_bridge.src.holo_tools import (
+            FEDERATION_SCOPE_WARNING_TEMPLATE,
+        )
+        for phrase in (
+            "foundup_id received",
+            "tenant scoping not yet enforced",
+            "MCPA1 Slice 6",
+        ):
+            assert phrase in FEDERATION_SCOPE_WARNING_TEMPLATE
+
+    def test_federation_scope_warning_for_s2(self):
+        from modules.infrastructure.foundups_mcp_bridge.src.holo_tools import (
+            federation_scope_warning,
+        )
+        warn = federation_scope_warning("S2")
+        assert "at S2" in warn
+        assert "MCPA1 Slice 6" in warn
+        assert "{surface}" not in warn
+
+    def test_no_foundup_id_echoes_null_pair(self, bridge):
+        """Without ``foundup_id``, both echoes are null (parity invariant)."""
+        result = bridge.call_tool("holo_search", query="WSP", limit=3)
+        assert result["status"] == "ok"
+        assert result["data"]["foundup_id"] is None
+        assert result["data"]["include_shared"] is None
+        warnings = result["data"]["metadata"]["warnings"]
+        assert not any("tenant scoping" in w for w in warnings)
+
+    def test_no_foundup_id_with_explicit_include_shared_still_null(self, bridge):
+        """``include_shared=False`` without ``foundup_id`` echoes ``None``
+        (Annex A.2 semantics — the flag is only meaningful with scope)."""
+        result = bridge.call_tool(
+            "holo_search", query="WSP", include_shared=False, limit=3
+        )
+        assert result["data"]["foundup_id"] is None
+        assert result["data"]["include_shared"] is None
+
+    def test_with_foundup_id_echoes_both_and_warns(self, bridge):
+        from modules.infrastructure.foundups_mcp_bridge.src.holo_tools import (
+            federation_scope_warning,
+        )
+        result = bridge.call_tool(
+            "holo_search",
+            query="WSP",
+            foundup_id="gotjunk",
+            include_shared=False,
+            limit=3,
+        )
+        assert result["data"]["foundup_id"] == "gotjunk"
+        assert result["data"]["include_shared"] is False
+        warnings = result["data"]["metadata"]["warnings"]
+        assert federation_scope_warning("S2") in warnings
+
+    def test_emitted_warning_matches_template_byte_for_byte(self, bridge):
+        """The runtime-emitted warning MUST equal ``federation_scope_warning(S2)``
+        verbatim — protects against drift if a future edit changes spacing
+        or punctuation."""
+        from modules.infrastructure.foundups_mcp_bridge.src.holo_tools import (
+            federation_scope_warning,
+        )
+        result = bridge.call_tool(
+            "holo_search", query="WSP", foundup_id="kosei", limit=3
+        )
+        warnings = result["data"]["metadata"]["warnings"]
+        scope_warnings = [w for w in warnings if "foundup_id received" in w]
+        assert len(scope_warnings) == 1
+        assert scope_warnings[0] == federation_scope_warning("S2")
+
+    def test_s1_template_matches_s2_template(self):
+        """Cross-surface parity: S1's template MUST match S2's template
+        byte-for-byte (modulo `{surface}` substitution). Drift in either
+        module flags here.
+        """
+        import sys
+        from pathlib import Path
+
+        s1_dir = (
+            Path(__file__).resolve().parents[4]
+            / "foundups-mcp-p1"
+            / "servers"
+            / "holo_index"
+        )
+        if str(s1_dir) not in sys.path:
+            sys.path.insert(0, str(s1_dir))
+
+        try:
+            from canonical_search import (  # type: ignore
+                FEDERATION_SCOPE_WARNING_TEMPLATE as s1_template,
+            )
+        except Exception:
+            import pytest as _pytest
+
+            _pytest.skip("S1 canonical_search not importable in this environment")
+
+        from modules.infrastructure.foundups_mcp_bridge.src.holo_tools import (
+            FEDERATION_SCOPE_WARNING_TEMPLATE as s2_template,
+        )
+
+        assert s1_template == s2_template, (
+            "S1 and S2 federation-scope warning templates have drifted; "
+            "they MUST be byte-identical per S64 parity contract."
+        )


### PR DESCRIPTION
## Summary
S6.4 parity-only recovery branch. Aligns `foundup_id`/`include_shared` semantics between S1 and S2 surfaces under WSP 96 Annex A.

- S1 and S2 now accept identical `foundup_id` and `include_shared` parameters
- Warning template parity machine-enforced between surfaces
- No auth enforcement overclaim (scope params accepted but auth deferred to federation gate)

## Test Evidence (W1 handoff)
- S1 suite: `54 passed`
- S2 focused suite: `34 passed`

## Test plan
- [x] `foundup_id` parameter accepted on both S1 and S2
- [x] `include_shared` parameter accepted on both surfaces
- [x] Warning templates identical between S1 and S2
- [x] No auth enforcement overclaim (WSP 97)

Worker-Lane: W10
Slice: S6.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)