### PR TITLE
feat(pavs_mcp): enforce api key ownership for federated FoundUp scope

### DIFF
--- a/modules/infrastructure/mcp_manager/src/mcp_manager.py
+++ b/modules/infrastructure/mcp_manager/src/mcp_manager.py
@@ -182,12 +182,13 @@ S3_PAVS_MCP = KnownSurface(
     holo_search_support="placeholder",
     authority_role="no_authority",
     notes=(
-        "Tool bodies return hardcoded data; start() does not bind a port; "
-        "auth is TODO. NOT canonical owner of holo_search (WSP 96 Annex A.1). "
-        "Tracked remediation: MCPA1 Slice 4, Slice 6."
+        "MCPA1 Slice 6: api_key validation + cross-tenant scope enforcement "
+        "(in-memory registry). Tool bodies still return hardcoded data; "
+        "start() does not bind a port. NOT canonical owner of holo_search. "
+        "Tracked remediation: MCPA1 Slice 7+ (persist, transport, backends)."
     ),
 )
-"""S3 surface descriptor — placeholder stub. NOT canonical for any capability."""
+"""S3 surface descriptor — placeholder stub with basic auth. NOT canonical for any capability."""
 
 KNOWN_NON_RUNNABLE_SURFACES: Tuple[KnownSurface, ...] = (
     S2_FOUNDUPS_MCP_BRIDGE,

--- a/modules/infrastructure/pavs_mcp/ModLog.md
+++ b/modules/infrastructure/pavs_mcp/ModLog.md
@@ -1,5 +1,86 @@
 # pAVS MCP Server - ModLog
 
+## 2026-05-09 - MCPA1_SLICE_6: Federation Auth/Scope Enforcement (Phase 1)
+
+**Author**: 0102 (Worker W1)
+**WSP**: 97 (Truth Boundaries), 96 (MCP Governance — Annex A)
+**Slice**: `MCPA1_SLICE_6_S3_FEDERATION_AUTH_AND_SCOPE_PHASE1`
+**Closes (MCPA1 audit)**: R1 (auth TODO), D24 (cross-tenant enforcement)
+
+### Why
+
+Per MCPA1 audit and MCPA6B re-audit, S3's `handle_tool_call` accepted `api_key`
+but never validated it. Any caller could pass any `foundup_id` to tools like
+`fam_emit` without ownership verification. This slice implements minimum viable
+federation auth/scope enforcement.
+
+### Changes
+
+- `src/server.py`:
+  - `FoundUpRegistration` extended with `owner_pubkey` and `registered_at` fields.
+  - Added `_api_key_to_foundup: dict[str, str]` reverse lookup in `__init__`.
+  - Added auth error codes: `MISSING_API_KEY`, `UNKNOWN_API_KEY`, `CROSS_TENANT_VIOLATION`.
+  - Added `BOOTSTRAP_TOOLS = {"foundup_register"}` — tools that remain unauthenticated.
+  - Added `_build_auth_meta()` helper for truthful `auth_enforced` flag.
+  - Added `_validate_api_key()` — returns (valid, foundup_id, error_response).
+  - Added `_validate_scope()` — rejects cross-tenant `foundup_id` attempts.
+  - Rewrote `handle_tool_call()`:
+    - Bootstrap tools (`foundup_register`) bypass auth.
+    - Protected tools require valid registered API key.
+    - `foundup_id` arguments validated against registered identity.
+    - `meta.auth_enforced=True` when auth actually ran.
+    - `meta.registered_foundup_id` echoed on successful auth.
+  - Updated `foundup_register` to populate `_api_key_to_foundup` mapping.
+  - Updated `PLACEHOLDER_BANNER` to declare `BASIC` auth enforcement.
+
+- `tests/test_server_holo_search.py`:
+  - Added `_register_and_get_key()` helper for auth tests.
+  - Added `authed_server` fixture for tests requiring auth.
+  - Updated 13 existing tests to pass API key where required.
+  - Added `TestFederationAuth` class with 20 focused tests:
+    - Bootstrap tool remains unauthenticated
+    - Missing API key rejected
+    - Unknown API key rejected
+    - Registered API key accepted
+    - Cross-tenant `foundup_id` rejected
+    - Matching `foundup_id` accepted
+    - No `foundup_id` argument OK
+    - Meta flags truthful
+    - Registration creates proper bindings
+    - All protected tools enforce auth (parametrized)
+
+- `README.md`:
+  - Updated status from `NO_AUTH_ENFORCEMENT` to `BASIC_AUTH_ENFORCEMENT`.
+  - Added `scope_enforcement` and `registry_persistence` status notes.
+
+- `mcp_manager.py`:
+  - Updated S3 descriptor notes to reflect MCPA1 Slice 6 completion.
+
+### Behavior boundaries (what did NOT change)
+
+- Registry is **in-memory only** — lost on restart. Persistent registry deferred.
+- No WebSocket transport — `start()` still does not bind a port.
+- Tool bodies still return hardcoded/fake data — backends not connected.
+- S1 and S2 untouched.
+- `foundup_register` remains unauthenticated (bootstrap-only pattern).
+
+### Tests
+
+```
+PYTHONPATH=. python -m pytest modules/infrastructure/pavs_mcp/tests/test_server_holo_search.py -q
+-> 67 passed
+
+PYTHONPATH=. python -m pytest modules/infrastructure/mcp_manager/tests/test_surface_discovery.py -q
+-> 20 passed
+```
+
+### Tracked follow-ups
+
+- MCPA1 Slice 7+ — Persistent registry (SQLite), real transport (WebSocket/SSE),
+  real backend connections.
+
+---
+
 ## 2026-05-08 - MCPA1_SLICE_4: S3 holo_search → canonical not_implemented envelope
 
 **Author**: 0102 (Worker W1)

--- a/modules/infrastructure/pavs_mcp/README.md
+++ b/modules/infrastructure/pavs_mcp/README.md
@@ -1,15 +1,15 @@
 # pAVS MCP Server
 
-> ## ⚠️ STATUS: `PLACEHOLDER_STUB`
+> ## ⚠️ STATUS: `PLACEHOLDER_STUB` with `BASIC_AUTH_ENFORCEMENT`
 >
 > **DO NOT USE FOR REAL TENANTS OR PRODUCTION TRAFFIC.**
 >
 > - **Implementation status**: `PLACEHOLDER_STUB`
-> - **Auth enforcement**: `NO_AUTH_ENFORCEMENT` — `handle_tool_call` accepts `api_key` parameter but never validates it (`src/server.py:329` is a `# TODO`).
+> - **Auth enforcement**: `BASIC_AUTH_ENFORCEMENT` (MCPA1 Slice 6) — `handle_tool_call` validates `api_key` for protected tools; rejects missing/unknown keys; rejects cross-tenant `foundup_id` attempts. `foundup_register` remains unauthenticated (bootstrap-only). Registry is **in-memory only** (lost on restart).
 > - **Tool data**: `TOOLS RETURN HARDCODED/FAKE DATA` — every `cabr_validate`, `gemma_classify`, `qwen_plan`, `fam_emit`, `pattern_recall`, `pattern_store`, `holo_search`, `foundup_register` body returns hardcoded values; `# TODO: Connect to actual <X>` markers in code.
-> - **Server transport**: `NOT PRODUCTION READY` — `start()` does not bind a port; the body is `await asyncio.sleep(60)` in a loop (`src/server.py:354, 362`).
-> - **Canonical contract**: see WSP 96 Annex A (`holo_search` contract). Per Annex A.1, S3 has **NO authority** over `holo_search` until the federation auth/scope work is complete; the placeholder implementation is retained only for surface-shape preservation.
-> - **Tracked remediation**: MCPA1 Slice 4 (`MCP_HOLO_SEARCH_DELEGATION_PHASE1`) and Slice 6 (`MCP_FEDERATION_AUTH_AND_SCOPE_PHASE1`).
+> - **Server transport**: `NOT PRODUCTION READY` — `start()` does not bind a port; the body is `await asyncio.sleep(60)` in a loop.
+> - **Canonical contract**: see WSP 96 Annex A (`holo_search` contract). Per Annex A.1, S3 has **NO authority** over `holo_search`; the placeholder implementation is retained only for surface-shape preservation.
+> - **Tracked remediation**: MCPA1 Slice 7+ (persistent registry, real transport, real backends).
 
 **Location**: `modules/infrastructure/pavs_mcp/`
 **WSP Compliance**: WSP 103 (FoundUp Federation), WSP 96 (MCP Governance), WSP 49 (Module Structure)

--- a/modules/infrastructure/pavs_mcp/src/server.py
+++ b/modules/infrastructure/pavs_mcp/src/server.py
@@ -39,17 +39,19 @@ data and refuse to use it for production decisions. See WSP 96 Annex A.5 C3.
 
 PLACEHOLDER_BANNER = (
     "==============================================================\n"
-    " pAVS MCP Server - PLACEHOLDER_STUB\n"
+    " pAVS MCP Server - PLACEHOLDER_STUB + BASIC_AUTH\n"
     "--------------------------------------------------------------\n"
     "  implementation_status : placeholder_stub\n"
-    "  auth_enforcement      : NONE (api_key parameter is ignored)\n"
+    "  auth_enforcement      : BASIC (api_key validated, in-memory)\n"
+    "  scope_enforcement     : YES (cross-tenant foundup_id rejected)\n"
     "  tool_data             : HARDCODED / FAKE\n"
     "  server_transport      : NONE (start() does not bind a port)\n"
+    "  registry_persistence  : NONE (lost on restart)\n"
     "  canonical owner of holo_search : NOT THIS SURFACE\n"
     "                                   (see WSP 96 Annex A.1)\n"
     "\n"
     "  DO NOT USE FOR REAL TENANTS OR PRODUCTION TRAFFIC.\n"
-    "  Tracked remediation: MCPA1 Slice 4, Slice 6.\n"
+    "  Tracked remediation: MCPA1 Slice 7+ (persist, transport).\n"
     "=============================================================="
 )
 """Operator-facing startup warning. Printed and logged on server start."""
@@ -79,11 +81,40 @@ def _truth_meta() -> dict[str, Any]:
 
 @dataclass
 class FoundUpRegistration:
-    """Registered FoundUp for pAVS access."""
+    """Registered FoundUp for pAVS access.
+
+    MCPA1 Slice 6: This dataclass now anchors the api_key -> foundup_id
+    ownership binding. The `owner_pubkey` field is stored for future
+    cryptographic verification but not yet enforced.
+    """
     foundup_id: str
     repo_url: str
     api_key: str
+    owner_pubkey: str
     tier: str = "free"
+    registered_at: str = ""
+
+    def __post_init__(self):
+        if not self.registered_at:
+            self.registered_at = datetime.now(timezone.utc).isoformat()
+
+
+# =============================================================================
+# Auth Error Codes (MCPA1 Slice 6 — Federation Auth/Scope)
+# =============================================================================
+
+AUTH_ERROR_MISSING_API_KEY = "MISSING_API_KEY"
+"""Returned when a protected tool is called without an api_key."""
+
+AUTH_ERROR_UNKNOWN_API_KEY = "UNKNOWN_API_KEY"
+"""Returned when the api_key does not match any registered FoundUp."""
+
+AUTH_ERROR_CROSS_TENANT = "CROSS_TENANT_VIOLATION"
+"""Returned when foundup_id argument does not match the registered identity."""
+
+# Protected tools: all tools EXCEPT foundup_register (bootstrap-only)
+BOOTSTRAP_TOOLS = frozenset({"foundup_register"})
+"""Tools that may be called without auth — bootstrap registration only."""
 
 
 class PAVSMCPServer:
@@ -105,6 +136,8 @@ class PAVSMCPServer:
         self.host = host
         self.port = port
         self.registrations: dict[str, FoundUpRegistration] = {}
+        # MCPA1 Slice 6: Reverse lookup for api_key -> foundup_id ownership
+        self._api_key_to_foundup: dict[str, str] = {}
         self._tools = self._register_tools()
 
     def _register_tools(self) -> dict[str, callable]:
@@ -432,8 +465,12 @@ class PAVSMCPServer:
             foundup_id=foundup_id,
             repo_url=repo_url,
             api_key=api_key,
-            tier="free"
+            owner_pubkey=owner_pubkey,
+            tier="free",
         )
+
+        # MCPA1 Slice 6: Build reverse lookup (api_key -> foundup_id)
+        self._api_key_to_foundup[api_key] = foundup_id
 
         logger.info(f"FoundUp registered: {foundup_id} ({repo_url})")
         return {
@@ -443,6 +480,82 @@ class PAVSMCPServer:
             "tier": "free"
         }
 
+    def _build_auth_meta(self, auth_enforced: bool, registered_foundup_id: Optional[str] = None) -> dict[str, Any]:
+        """Build meta block with auth enforcement status.
+
+        MCPA1 Slice 6: Truthfully reports whether auth ran and the registered
+        identity when applicable. Merges with base _truth_meta().
+        """
+        meta = _truth_meta()
+        meta["auth_enforced"] = auth_enforced
+        if registered_foundup_id is not None:
+            meta["registered_foundup_id"] = registered_foundup_id
+        return meta
+
+    def _validate_api_key(self, api_key: Optional[str]) -> tuple[bool, Optional[str], Optional[dict]]:
+        """Validate API key and return (valid, foundup_id, error_response).
+
+        Returns:
+            - (True, foundup_id, None) if valid
+            - (False, None, error_dict) if invalid
+        """
+        if api_key is None:
+            return (False, None, {
+                "error": {
+                    "code": AUTH_ERROR_MISSING_API_KEY,
+                    "message": "API key required. Use foundup_register to obtain one.",
+                },
+                "meta": self._build_auth_meta(auth_enforced=True),
+            })
+
+        foundup_id = self._api_key_to_foundup.get(api_key)
+        if foundup_id is None:
+            return (False, None, {
+                "error": {
+                    "code": AUTH_ERROR_UNKNOWN_API_KEY,
+                    "message": "API key not recognized. Verify key or re-register.",
+                },
+                "meta": self._build_auth_meta(auth_enforced=True),
+            })
+
+        return (True, foundup_id, None)
+
+    def _validate_scope(
+        self,
+        registered_foundup_id: str,
+        requested_foundup_id: Optional[str],
+    ) -> Optional[dict]:
+        """Validate that requested foundup_id matches registered identity.
+
+        MCPA1 Slice 6: Cross-tenant violation check.
+
+        Returns:
+            None if scope is valid, error_dict if cross-tenant violation.
+        """
+        if requested_foundup_id is None:
+            # No scope requested — OK (uses caller's registered identity)
+            return None
+
+        if requested_foundup_id != registered_foundup_id:
+            return {
+                "error": {
+                    "code": AUTH_ERROR_CROSS_TENANT,
+                    "message": (
+                        f"Cross-tenant access denied. "
+                        f"Registered as '{registered_foundup_id}', "
+                        f"but requested scope for '{requested_foundup_id}'."
+                    ),
+                    "registered_foundup_id": registered_foundup_id,
+                    "requested_foundup_id": requested_foundup_id,
+                },
+                "meta": self._build_auth_meta(
+                    auth_enforced=True,
+                    registered_foundup_id=registered_foundup_id,
+                ),
+            }
+
+        return None
+
     async def handle_tool_call(
         self,
         tool_name: str,
@@ -450,20 +563,25 @@ class PAVSMCPServer:
         api_key: Optional[str] = None
     ) -> dict[str, Any]:
         """
-        Handle incoming MCP tool call.
+        Handle incoming MCP tool call with federation auth/scope enforcement.
+
+        MCPA1 Slice 6 implementation:
+        - Bootstrap tools (foundup_register) may be called without auth
+        - All other tools require a valid, registered API key
+        - Tools accepting foundup_id reject cross-tenant attempts
 
         Args:
             tool_name: Name of tool to invoke
             arguments: Tool arguments
-            api_key: Caller's API key (currently IGNORED — auth is a TODO)
+            api_key: Caller's API key (ENFORCED for protected tools)
 
         Returns:
             Tool result or error. All responses embed the truth-meta block
             (`meta.implementation_status = "placeholder_stub"`) per WSP 97
             so clients can detect the placeholder state regardless of payload.
+            `meta.auth_enforced` is True when auth validation ran.
         """
-        # TODO: Implement proper auth (tracked: MCPA1 Slice 6)
-
+        # Unknown tool check (before auth, so we don't leak registered state)
         if tool_name not in self._tools:
             return {
                 "error": {
@@ -474,13 +592,35 @@ class PAVSMCPServer:
                 "meta": _truth_meta(),
             }
 
+        # MCPA1 Slice 6: Auth enforcement for protected tools
+        registered_foundup_id: Optional[str] = None
+
+        if tool_name not in BOOTSTRAP_TOOLS:
+            # Protected tool — require valid API key
+            valid, validated_foundup_id, error_response = self._validate_api_key(api_key)
+            if not valid:
+                assert error_response is not None  # Type narrowing
+                return error_response
+
+            assert validated_foundup_id is not None  # Type narrowing: valid=True implies foundup_id
+            registered_foundup_id = validated_foundup_id
+
+            # Scope enforcement: check foundup_id argument if present
+            requested_foundup_id = arguments.get("foundup_id")
+            scope_error = self._validate_scope(registered_foundup_id, requested_foundup_id)
+            if scope_error is not None:
+                return scope_error
+
         try:
             tool_func = self._tools[tool_name]
             result = await tool_func(**arguments)
             return {
                 "result": result,
                 "meta": {
-                    **_truth_meta(),
+                    **self._build_auth_meta(
+                        auth_enforced=(tool_name not in BOOTSTRAP_TOOLS),
+                        registered_foundup_id=registered_foundup_id,
+                    ),
                     "tool": tool_name,
                 },
             }
@@ -492,7 +632,10 @@ class PAVSMCPServer:
                     "message": str(e),
                     "tool": tool_name,
                 },
-                "meta": _truth_meta(),
+                "meta": self._build_auth_meta(
+                    auth_enforced=(tool_name not in BOOTSTRAP_TOOLS),
+                    registered_foundup_id=registered_foundup_id,
+                ),
             }
 
     async def start(self):

--- a/modules/infrastructure/pavs_mcp/tests/test_server_holo_search.py
+++ b/modules/infrastructure/pavs_mcp/tests/test_server_holo_search.py
@@ -42,12 +42,12 @@ class TestTruthBoundaryConstants:
         required_phrases = [
             "PLACEHOLDER_STUB",
             "implementation_status : placeholder_stub",
-            "auth_enforcement      : NONE",
+            "auth_enforcement      : BASIC",  # MCPA1 Slice 6: now enforced
+            "scope_enforcement     : YES",    # MCPA1 Slice 6: cross-tenant rejected
             "tool_data             : HARDCODED / FAKE",
             "server_transport      : NONE",
+            "registry_persistence  : NONE",   # MCPA1 Slice 6: in-memory only
             "DO NOT USE FOR REAL TENANTS",
-            "Slice 4",
-            "Slice 6",
         ]
         for phrase in required_phrases:
             assert phrase in PLACEHOLDER_BANNER, (
@@ -96,20 +96,43 @@ def _run(coro):
     return asyncio.get_event_loop().run_until_complete(coro)
 
 
+def _register_and_get_key(server, foundup_id="test_foundup"):
+    """Helper to register a FoundUp and return the api_key."""
+    result = _run(server.handle_tool_call(
+        "foundup_register",
+        {
+            "foundup_id": foundup_id,
+            "repo_url": f"https://github.com/test/{foundup_id}",
+            "owner_pubkey": "ed25519_test_pubkey",
+        },
+    ))
+    return result["result"]["api_key"]
+
+
 @pytest.fixture
 def server():
     """Fresh PAVSMCPServer instance per test."""
     return PAVSMCPServer()
 
 
+@pytest.fixture
+def authed_server():
+    """PAVSMCPServer with a registered FoundUp, returns (server, api_key)."""
+    srv = PAVSMCPServer()
+    api_key = _register_and_get_key(srv, "test_foundup")
+    return srv, api_key
+
+
 class TestHoloSearchTruthFlag:
     """holo_search responses must carry the placeholder_stub truth flag."""
 
-    def test_holo_search_response_carries_truth_meta(self, server):
+    def test_holo_search_response_carries_truth_meta(self, authed_server):
+        server, api_key = authed_server
         result = _run(
             server.handle_tool_call(
                 "holo_search",
                 {"query": "WSP 97 audit", "limit": 5},
+                api_key=api_key,
             )
         )
 
@@ -123,13 +146,15 @@ class TestHoloSearchTruthFlag:
         assert meta["canonical_owner"] is False
         assert meta["tool"] == "holo_search"
 
-    def test_holo_search_payload_uses_canonical_envelope(self, server):
+    def test_holo_search_payload_uses_canonical_envelope(self, authed_server):
         """MCPA1 Slice 4: holo_search MUST return the WSP 96 Annex A.3
         not_implemented envelope, not the legacy `matches[]` shape."""
+        server, api_key = authed_server
         result = _run(
             server.handle_tool_call(
                 "holo_search",
                 {"query": "anything"},
+                api_key=api_key,
             )
         )
         inner = result["result"]
@@ -152,21 +177,25 @@ class TestHoloSearchTruthFlag:
 
 
 @pytest.mark.parametrize(
-    "tool_name,arguments",
+    "tool_name,arguments,is_bootstrap",
     [
-        ("cabr_validate", {"content": "x", "context": {}}),
-        ("gemma_classify", {"text": "x", "categories": ["a", "b"]}),
-        ("qwen_plan", {"objective": "x", "constraints": {}}),
-        ("fam_emit", {"foundup_id": "x", "event_type": "test", "payload": {}}),
-        ("pattern_recall", {"skill": "x", "min_fidelity": 0.5}),
-        ("pattern_store", {"skill": "x", "outcome": {}}),
-        ("holo_search", {"query": "x"}),
-        ("foundup_register", {"foundup_id": "x", "repo_url": "y", "owner_pubkey": "z"}),
+        ("cabr_validate", {"content": "x", "context": {}}, False),
+        ("gemma_classify", {"text": "x", "categories": ["a", "b"]}, False),
+        ("qwen_plan", {"objective": "x", "constraints": {}}, False),
+        ("fam_emit", {"foundup_id": "test_foundup", "event_type": "test", "payload": {}}, False),
+        ("pattern_recall", {"skill": "x", "min_fidelity": 0.5}, False),
+        ("pattern_store", {"skill": "x", "outcome": {}}, False),
+        ("holo_search", {"query": "x"}, False),
+        ("foundup_register", {"foundup_id": "new_x", "repo_url": "y", "owner_pubkey": "z"}, True),
     ],
 )
-def test_every_tool_response_carries_truth_flag(tool_name, arguments):
+def test_every_tool_response_carries_truth_flag(tool_name, arguments, is_bootstrap):
     server = PAVSMCPServer()
-    result = _run(server.handle_tool_call(tool_name, arguments))
+    # MCPA1 Slice 6: Protected tools need auth; bootstrap tools do not
+    api_key = None
+    if not is_bootstrap:
+        api_key = _register_and_get_key(server, "test_foundup")
+    result = _run(server.handle_tool_call(tool_name, arguments, api_key=api_key))
 
     assert "meta" in result, f"{tool_name}: response missing 'meta' block"
     assert result["meta"]["implementation_status"] == "placeholder_stub", (
@@ -197,18 +226,19 @@ class TestErrorPathHonesty:
         assert "meta" in result
         assert result["meta"]["implementation_status"] == "placeholder_stub"
 
-    def test_internal_error_response_carries_truth_meta(self, server):
+    def test_internal_error_response_carries_truth_meta(self, authed_server):
         """Force a tool to raise so we hit the INTERNAL_ERROR branch."""
+        server, api_key = authed_server
 
         async def boom(**_kwargs):
             raise RuntimeError("simulated failure")
 
         # Replace one tool with a raising stub. Safe to mutate directly: the
-        # `server` fixture builds a fresh PAVSMCPServer per test, so this does
+        # fixture builds a fresh PAVSMCPServer per test, so this does
         # not leak across cases.
         server._tools["holo_search"] = boom
 
-        result = _run(server.handle_tool_call("holo_search", {"query": "x"}))
+        result = _run(server.handle_tool_call("holo_search", {"query": "x"}, api_key=api_key))
 
         assert "error" in result
         assert result["error"]["code"] == "INTERNAL_ERROR"
@@ -224,28 +254,47 @@ class TestErrorPathHonesty:
 
 
 class TestAuthHonesty:
-    """The api_key parameter must be accepted (back-compat) but explicitly
-    surfaced as not-enforced via meta.auth_enforced=False."""
+    """MCPA1 Slice 6: Auth is now enforced. Tests verify enforcement behavior."""
 
-    def test_api_key_is_ignored_but_meta_says_so(self, server):
-        result_with_key = _run(
+    def test_unregistered_api_key_rejected(self, server):
+        """Unregistered api_key is rejected with UNKNOWN_API_KEY."""
+        result = _run(
             server.handle_tool_call(
                 "holo_search",
                 {"query": "x"},
                 api_key="fp_definitely_not_registered",
             )
         )
-        result_without_key = _run(
+
+        # Auth is enforced — unregistered key rejected
+        assert "error" in result
+        assert result["error"]["code"] == "UNKNOWN_API_KEY"
+        assert result["meta"]["auth_enforced"] is True
+
+    def test_registered_api_key_accepted(self, authed_server):
+        """Registered api_key allows the call."""
+        server, api_key = authed_server
+        result = _run(
+            server.handle_tool_call(
+                "holo_search",
+                {"query": "x"},
+                api_key=api_key,
+            )
+        )
+
+        # Auth enforced and passed
+        assert "result" in result
+        assert result["meta"]["auth_enforced"] is True
+
+    def test_missing_api_key_rejected(self, server):
+        """Missing api_key rejected with MISSING_API_KEY."""
+        result = _run(
             server.handle_tool_call("holo_search", {"query": "x"})
         )
 
-        # Both succeed identically — proving auth is NOT enforced
-        assert "result" in result_with_key
-        assert "result" in result_without_key
-
-        # And both meta blocks declare auth_enforced=False truthfully
-        assert result_with_key["meta"]["auth_enforced"] is False
-        assert result_without_key["meta"]["auth_enforced"] is False
+        assert "error" in result
+        assert result["error"]["code"] == "MISSING_API_KEY"
+        assert result["meta"]["auth_enforced"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -459,10 +508,13 @@ class TestNotImplementedEnvelope:
 
     def test_via_handle_tool_call_inner_envelope_canonical(self, srv):
         """Through the dispatch path, the canonical envelope is intact under .result."""
+        # MCPA1 Slice 6: Need to register with matching foundup_id
+        api_key = _register_and_get_key(srv, "kosei")
         wrapped = _run(
             srv.handle_tool_call(
                 "holo_search",
                 {"query": "x", "foundup_id": "kosei"},
+                api_key=api_key,
             )
         )
         inner = wrapped["result"]
@@ -471,3 +523,262 @@ class TestNotImplementedEnvelope:
         assert inner["meta"]["surface"] == "S3"
         # Outer wrapper still adds its own truth meta (MCPA4 contract)
         assert wrapped["meta"]["implementation_status"] == "placeholder_stub"
+
+
+# ---------------------------------------------------------------------------
+# MCPA1 Slice 6 — Federation Auth/Scope Enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestFederationAuth:
+    """MCPA1 Slice 6: API key validation and scope enforcement tests."""
+
+    @pytest.fixture
+    def srv(self):
+        return PAVSMCPServer()
+
+    def _register_foundup(self, srv, foundup_id="test_foundup"):
+        """Helper to register a FoundUp and return the api_key."""
+        result = _run(srv.handle_tool_call(
+            "foundup_register",
+            {
+                "foundup_id": foundup_id,
+                "repo_url": f"https://github.com/test/{foundup_id}",
+                "owner_pubkey": "ed25519_test_pubkey_placeholder",
+            },
+        ))
+        assert "result" in result
+        return result["result"]["api_key"]
+
+    # ----- Bootstrap tool (foundup_register) remains unauthenticated -----
+
+    def test_foundup_register_accepts_no_api_key(self, srv):
+        """foundup_register is a bootstrap tool — no auth required."""
+        result = _run(srv.handle_tool_call(
+            "foundup_register",
+            {
+                "foundup_id": "new_foundup",
+                "repo_url": "https://github.com/test/new",
+                "owner_pubkey": "pubkey123",
+            },
+            api_key=None,
+        ))
+        assert "result" in result
+        assert "api_key" in result["result"]
+        # meta.auth_enforced should be False for bootstrap tools
+        assert result["meta"]["auth_enforced"] is False
+
+    # ----- Protected tools reject missing API key -----
+
+    def test_protected_tool_rejects_missing_api_key(self, srv):
+        """Protected tools require api_key."""
+        result = _run(srv.handle_tool_call(
+            "holo_search",
+            {"query": "test"},
+            api_key=None,
+        ))
+        assert "error" in result
+        assert result["error"]["code"] == "MISSING_API_KEY"
+        assert result["meta"]["auth_enforced"] is True
+
+    def test_cabr_validate_rejects_missing_api_key(self, srv):
+        """cabr_validate is protected."""
+        result = _run(srv.handle_tool_call(
+            "cabr_validate",
+            {"content": "test"},
+            api_key=None,
+        ))
+        assert "error" in result
+        assert result["error"]["code"] == "MISSING_API_KEY"
+
+    # ----- Protected tools reject unknown API key -----
+
+    def test_protected_tool_rejects_unknown_api_key(self, srv):
+        """Unknown api_key is rejected."""
+        result = _run(srv.handle_tool_call(
+            "holo_search",
+            {"query": "test"},
+            api_key="fp_definitely_not_registered_key",
+        ))
+        assert "error" in result
+        assert result["error"]["code"] == "UNKNOWN_API_KEY"
+        assert result["meta"]["auth_enforced"] is True
+
+    # ----- Registered API key is accepted -----
+
+    def test_registered_api_key_accepted(self, srv):
+        """Valid registered api_key allows tool call."""
+        api_key = self._register_foundup(srv, "my_foundup")
+
+        result = _run(srv.handle_tool_call(
+            "holo_search",
+            {"query": "test"},
+            api_key=api_key,
+        ))
+        assert "result" in result
+        assert result["meta"]["auth_enforced"] is True
+        assert result["meta"]["registered_foundup_id"] == "my_foundup"
+
+    # ----- Cross-tenant foundup_id rejected -----
+
+    def test_cross_tenant_foundup_id_rejected(self, srv):
+        """Requesting a different foundup_id than registered is rejected."""
+        api_key = self._register_foundup(srv, "foundup_a")
+
+        result = _run(srv.handle_tool_call(
+            "holo_search",
+            {"query": "test", "foundup_id": "foundup_b"},
+            api_key=api_key,
+        ))
+        assert "error" in result
+        assert result["error"]["code"] == "CROSS_TENANT_VIOLATION"
+        assert result["error"]["registered_foundup_id"] == "foundup_a"
+        assert result["error"]["requested_foundup_id"] == "foundup_b"
+        assert result["meta"]["auth_enforced"] is True
+
+    def test_fam_emit_cross_tenant_rejected(self, srv):
+        """fam_emit with wrong foundup_id is rejected."""
+        api_key = self._register_foundup(srv, "foundup_x")
+
+        result = _run(srv.handle_tool_call(
+            "fam_emit",
+            {
+                "foundup_id": "foundup_y",
+                "event_type": "test",
+                "payload": {},
+            },
+            api_key=api_key,
+        ))
+        assert "error" in result
+        assert result["error"]["code"] == "CROSS_TENANT_VIOLATION"
+
+    # ----- Matching foundup_id is accepted -----
+
+    def test_matching_foundup_id_accepted(self, srv):
+        """Own foundup_id in request is accepted."""
+        api_key = self._register_foundup(srv, "my_foundup")
+
+        result = _run(srv.handle_tool_call(
+            "holo_search",
+            {"query": "test", "foundup_id": "my_foundup"},
+            api_key=api_key,
+        ))
+        assert "result" in result
+        assert result["meta"]["registered_foundup_id"] == "my_foundup"
+
+    def test_fam_emit_matching_foundup_id_accepted(self, srv):
+        """fam_emit with matching foundup_id succeeds."""
+        api_key = self._register_foundup(srv, "my_foundup")
+
+        result = _run(srv.handle_tool_call(
+            "fam_emit",
+            {
+                "foundup_id": "my_foundup",
+                "event_type": "test",
+                "payload": {"key": "value"},
+            },
+            api_key=api_key,
+        ))
+        assert "result" in result
+        assert "event_id" in result["result"]
+
+    # ----- No foundup_id argument is OK (uses caller identity) -----
+
+    def test_no_foundup_id_argument_ok(self, srv):
+        """Tools without foundup_id argument still work."""
+        api_key = self._register_foundup(srv, "my_foundup")
+
+        result = _run(srv.handle_tool_call(
+            "gemma_classify",
+            {"text": "test text", "categories": ["a", "b"]},
+            api_key=api_key,
+        ))
+        assert "result" in result
+        assert result["meta"]["auth_enforced"] is True
+
+    # ----- Meta flags are truthful -----
+
+    def test_meta_auth_enforced_true_for_protected_tools(self, srv):
+        """Protected tools set auth_enforced=True."""
+        api_key = self._register_foundup(srv, "test")
+
+        result = _run(srv.handle_tool_call(
+            "pattern_recall",
+            {"skill": "test_skill"},
+            api_key=api_key,
+        ))
+        assert result["meta"]["auth_enforced"] is True
+
+    def test_meta_auth_enforced_false_for_bootstrap_tools(self, srv):
+        """Bootstrap tools set auth_enforced=False."""
+        result = _run(srv.handle_tool_call(
+            "foundup_register",
+            {
+                "foundup_id": "new",
+                "repo_url": "https://test",
+                "owner_pubkey": "key",
+            },
+        ))
+        assert result["meta"]["auth_enforced"] is False
+
+    def test_meta_registered_foundup_id_present_on_success(self, srv):
+        """Successful auth includes registered_foundup_id in meta."""
+        api_key = self._register_foundup(srv, "tracked_foundup")
+
+        result = _run(srv.handle_tool_call(
+            "qwen_plan",
+            {"objective": "test"},
+            api_key=api_key,
+        ))
+        assert result["meta"]["registered_foundup_id"] == "tracked_foundup"
+
+    # ----- Registration creates proper bindings -----
+
+    def test_registration_creates_api_key_binding(self, srv):
+        """foundup_register creates api_key -> foundup_id mapping."""
+        result = _run(srv.handle_tool_call(
+            "foundup_register",
+            {
+                "foundup_id": "bound_foundup",
+                "repo_url": "https://test",
+                "owner_pubkey": "key",
+            },
+        ))
+        api_key = result["result"]["api_key"]
+
+        # Verify internal state
+        assert srv._api_key_to_foundup[api_key] == "bound_foundup"
+        assert "bound_foundup" in srv.registrations
+        assert srv.registrations["bound_foundup"].api_key == api_key
+
+    def test_registration_stores_owner_pubkey(self, srv):
+        """Registration stores owner_pubkey for future verification."""
+        result = _run(srv.handle_tool_call(
+            "foundup_register",
+            {
+                "foundup_id": "keyed_foundup",
+                "repo_url": "https://test",
+                "owner_pubkey": "ed25519_test_key_abc123",
+            },
+        ))
+
+        assert srv.registrations["keyed_foundup"].owner_pubkey == "ed25519_test_key_abc123"
+
+    # ----- All protected tools enforce auth -----
+
+    @pytest.mark.parametrize("tool_name,arguments", [
+        ("cabr_validate", {"content": "x"}),
+        ("gemma_classify", {"text": "x", "categories": ["a"]}),
+        ("qwen_plan", {"objective": "x"}),
+        ("fam_emit", {"foundup_id": "x", "event_type": "t", "payload": {}}),
+        ("pattern_recall", {"skill": "x"}),
+        ("pattern_store", {"skill": "x", "outcome": {}}),
+        ("holo_search", {"query": "x"}),
+    ])
+    def test_all_protected_tools_reject_missing_api_key(self, tool_name, arguments):
+        """Every non-bootstrap tool rejects calls without api_key."""
+        srv = PAVSMCPServer()
+        result = _run(srv.handle_tool_call(tool_name, arguments, api_key=None))
+
+        assert "error" in result, f"{tool_name} should reject missing api_key"
+        assert result["error"]["code"] == "MISSING_API_KEY"


### PR DESCRIPTION
## Summary
Implements MCPA1 Slice 6: S3 federation auth and scope enforcement.

- Missing/unknown API keys rejected for protected tools
- Cross-tenant `foundup_id` access rejected (ownership verified)
- `foundup_register` remains bootstrap unauthenticated (intentional)
- Registry is in-memory only (no production transport overclaim)

## Test Evidence
```
pavs_mcp: 67 passed, 30 warnings in 0.18s
mcp_manager: 20 passed in 0.28s
```

## Test plan
- [x] Missing API key returns auth error
- [x] Unknown API key rejected
- [x] Cross-tenant scope request rejected
- [x] `foundup_register` works without auth (bootstrap)
- [x] Valid API key + matching tenant succeeds
- [x] WSP 97 truth boundaries enforced (no production transport overclaim)

Worker-Lane: W10
Slice: MCPA1-S6

🤖 Generated with [Claude Code](https://claude.com/claude-code)