### PR TITLE
docs(audit): evaluate Ritual as optional ROC milestone attestation layer

### DIFF
--- a/docs/audits/external_protocols/ritual/README.md
+++ b/docs/audits/external_protocols/ritual/README.md
@@ -20,6 +20,7 @@ This audit lane evaluates Ritual (decentralized AI execution substrate) for pote
 | [RITUAL_FOUNDUPS_ARCHITECTURE_FIT.md](RITUAL_FOUNDUPS_ARCHITECTURE_FIT.md) | W3 | Role boundaries, WSP alignment, overlap matrix |
 | [RITUAL_INFERENCE_ECONOMICS_AND_VERIFICATION.md](RITUAL_INFERENCE_ECONOMICS_AND_VERIFICATION.md) | W4 | Cost/latency tradeoffs, verification methods |
 | [RITUAL_FOUNDUPS_STRATEGIC_SYNTHESIS.md](RITUAL_FOUNDUPS_STRATEGIC_SYNTHESIS.md) | W5 | Final synthesis, verdict, next actions |
+| [RITUAL_ROC_MILESTONE_ATTESTATION_AUDIT.md](RITUAL_ROC_MILESTONE_ATTESTATION_AUDIT.md) | W2 | ROC milestone attestation, DAE-to-DAO certification fit |
 
 ---
 
@@ -43,6 +44,7 @@ This audit lane evaluates Ritual (decentralized AI execution substrate) for pote
 |----------|---------|
 | **Architecture Fit** | `FIT_AS_OPTIONAL_ADAPTER` — not core, not rejected |
 | **Economics Fit** | `SELECTIVE_USE_ONLY` — batch only, not interactive |
+| **ROC Attestation Fit** | `FIT_AS_OPTIONAL_ATTESTATION_LAYER` — milestone verification, not computation |
 | **Strategic Verdict** | `WATCH_AND_OPTIONAL_ADAPTER` |
 
 ---

--- a/docs/audits/external_protocols/ritual/RITUAL_ROC_MILESTONE_ATTESTATION_AUDIT.md
+++ b/docs/audits/external_protocols/ritual/RITUAL_ROC_MILESTONE_ATTESTATION_AUDIT.md
@@ -1,0 +1,398 @@
+# Ritual ROC Milestone Attestation Audit
+
+**Audit Date**: 2026-05-09  
+**Slice**: `RITUAL_ROC_MILESTONE_ATTESTATION_AUDIT_PHASE1`  
+**Worker**: W2  
+**WSP Lock**: WSP 00 → WSP 97 → WSP 15 → WSP 50  
+**Mode**: Architecture research — not implementation
+
+---
+
+## 1. Executive Verdict
+
+### **FIT_AS_OPTIONAL_ATTESTATION_LAYER**
+
+Ritual Chain's TEE-based verification infrastructure is architecturally suitable for **optional attestation** of FoundUp milestone transitions, without requiring FoundUps to move core ROC/CABR computation onto Ritual.
+
+**Key Constraints Preserved**:
+- FoundUps computes ROC, CABR, milestones internally (WSP 29, WSP 100)
+- Ritual only attests/timestamps/verifies outcomes
+- No dependency on Ritual for core operation
+- Kill switch: attestation layer can be bypassed without breaking FoundUps
+
+---
+
+## 2. FoundUps Milestone State Model
+
+### 2.1 Internal Milestone Types (from WSPs)
+
+| Milestone Category | Source | Examples |
+|--------------------|--------|----------|
+| **FoundUp Lifecycle** | WSP 27 | PoC complete, Prototype complete, MVP complete, Launch |
+| **Tier Escalation** | WSP 100 | F₀→F₁ (DAE→SmartDAO), F₁→F₂, ... F₄→F₅ |
+| **CABR Thresholds** | WSP 29 | PoB threshold reached, env_score ≥ 0.7, part_score ≥ 0.8 |
+| **Treasury Milestones** | WSP 100 | 100K UPS (F₁), 1M UPS (F₂), 10M UPS (F₃), etc. |
+| **Adoption Milestones** | WSP 100 | 16% (early majority), 34% (growth), 50% (infra) |
+| **Governance Readiness** | WSP 100 | 10+ agents (F₁), 50+ agents (F₂), 200+ agents (F₃) |
+| **WSP Compliance** | WSP Framework | Audit passed, ModLog snapshot verified, clean state |
+
+### 2.2 Transition Trigger Model
+
+From WSP 100 Section 3.2:
+```python
+# Internal FoundUps computation - NOT on Ritual
+def check_transition(foundup: FoundUp) -> bool:
+    adoption_ready = foundup.adoption_ratio >= 0.16  # 16% threshold
+    treasury_ready = foundup.treasury_ups >= 100_000  # 100K UPS
+    governance_needed = foundup.active_agents >= 10   # 10+ agents
+    return adoption_ready and treasury_ready and governance_needed
+```
+
+**Critical**: This computation happens INSIDE FoundUps (FAM DAEmon, CABR Engine). Ritual does not determine transition eligibility.
+
+### 2.3 Attestation-Ready Milestone Format
+
+Milestones that could be attested externally:
+```python
+@dataclass
+class MilestoneAttestation:
+    foundup_id: str              # FoundUp identifier
+    milestone_type: str          # "tier_escalation", "cabr_threshold", "wsp_audit"
+    milestone_value: str         # "F0_to_F1", "pob_0.8", "wsp_100_compliant"
+    internal_hash: bytes32       # SHA-256 of internal state at milestone
+    timestamp: int               # Unix timestamp
+    evidence_refs: List[str]     # IPFS/Arweave references to supporting data
+    cabr_score: float            # CABR score at attestation time
+    validator_signatures: List[bytes]  # 0102 agent attestations
+```
+
+---
+
+## 3. Ritual Attestation Fit
+
+### 3.1 Ritual Verification Capabilities
+
+| Capability | Ritual Implementation | FoundUps Use Case |
+|------------|----------------------|-------------------|
+| **TEE Attestation** | Intel SGX / AMD SEV enclaves | Verify milestone hash computed correctly |
+| **On-chain Timestamp** | Block inclusion (350ms finality) | Immutable milestone timestamp |
+| **Persistent Agents** | Native on-chain agents with keys | Cross-DAO verification agents |
+| **HTTP Precompile** | 0x0800 for external API calls | Fetch FoundUp state for verification |
+| **LLM Precompile** | 0x0802 for inference | AI-assisted audit validation |
+
+### 3.2 Attestation Flow (Proposed Architecture)
+
+```
+INTERNAL (FoundUps)                    EXTERNAL (Ritual - Optional)
+─────────────────────────────────────────────────────────────────────
+
+1. FoundUp reaches milestone
+   (computed by CABR/WSP 100)
+           │
+           ▼
+2. Internal validators confirm
+   (0102 agent consensus)
+           │
+           ▼
+3. Milestone hash generated         ──────►  4. Hash submitted to Ritual
+   (internal state snapshot)                     │
+           │                                     ▼
+           │                              5. TEE verification
+           │                                 (hash integrity check)
+           │                                     │
+           │                                     ▼
+           │                              6. On-chain attestation
+           │                                 (immutable record)
+           │                                     │
+           ▼                              ◄──────┘
+7. Attestation receipt stored
+   (optional proof layer)
+```
+
+### 3.3 Fit Assessment
+
+| Criterion | Fit | Rationale |
+|-----------|-----|-----------|
+| **TEE for hash verification** | HIGH | Ritual TEE can verify milestone hash integrity without seeing underlying data |
+| **Immutable timestamping** | HIGH | 350ms block finality provides strong timestamp guarantees |
+| **No core logic migration** | REQUIRED | FoundUps MUST NOT move CABR/ROC computation to Ritual |
+| **Latency tolerance** | MEDIUM | Milestone attestation is async (not real-time critical) |
+| **Cost** | ACCEPTABLE | One-time attestation per milestone (not continuous inference) |
+
+---
+
+## 4. DAE-to-DAO Certification Fit
+
+### 4.1 F₀→F₁ Transition (DAE→SmartDAO)
+
+From WSP 100, transition requires:
+- adoption_ratio ≥ 0.16
+- treasury_ups ≥ 100,000
+- active_agents ≥ 10
+
+**Ritual Role**: OPTIONAL certification that:
+- Threshold values were correctly computed (hash verification)
+- Timestamp of transition is immutable
+- External parties can verify transition occurred
+
+**Ritual Does NOT**:
+- Compute adoption ratio
+- Count treasury UPS
+- Determine agent count
+- Make transition decision
+
+### 4.2 Higher Tier Transitions
+
+| Transition | Internal Computation | Ritual Attestation |
+|------------|---------------------|-------------------|
+| F₁→F₂ | adoption ≥ 0.34, treasury ≥ 1M, agents ≥ 50 | Hash + timestamp |
+| F₂→F₃ | adoption ≥ 0.50, treasury ≥ 10M, agents ≥ 200 | Hash + timestamp |
+| F₃→F₄ | adoption ≥ 0.84, treasury ≥ 100M, agents ≥ 1000 | Hash + timestamp |
+| F₄→F₅ | adoption ≥ 0.95, treasury ≥ 1B, agents ≥ 10000 | Hash + timestamp |
+
+### 4.3 SmartDAO Spawning Events
+
+From WSP 100 Section 8.2:
+```python
+FAMEventType.SMARTDAO_EMERGENCE = "smartdao_emergence"  # F₀ → F₁
+FAMEventType.TIER_ESCALATION = "tier_escalation"        # F_n → F_n+1
+```
+
+**Ritual Attestation**: Could provide external audit trail for spawning events, useful for:
+- Regulatory compliance (proving transition occurred at specific time)
+- Cross-DAO trust (other DAOs can verify tier status)
+- Historical record (immutable proof of ecosystem growth)
+
+---
+
+## 5. Cross-DAO Trust Coordination Fit
+
+### 5.1 Use Case: DAO A Verifies DAO B Status
+
+**Scenario**: SmartDAO A wants to confirm SmartDAO B is F₂ tier before entering compute agreement.
+
+**Without Ritual**:
+- DAO A queries DAO B directly
+- Trust requires either: direct verification or trusted third party
+- No immutable external proof
+
+**With Ritual (Optional)**:
+- DAO B's F₂ transition was attested on Ritual Chain
+- DAO A queries Ritual for attestation record
+- TEE-verified proof of transition
+- No trust required between DAOs
+
+### 5.2 Machine-Readable Verification
+
+```python
+# Proposed interface (NOT implementation)
+class RitualDAOVerification:
+    def verify_tier(self, dao_id: str, expected_tier: int) -> bool:
+        """Check if DAO attestation exists for claimed tier."""
+        attestation = ritual_chain.query_attestation(dao_id, "tier_escalation")
+        return attestation and attestation.tier >= expected_tier
+```
+
+### 5.3 Inter-DAO Agreements
+
+| Agreement Type | Internal (FoundUps) | External (Ritual) |
+|----------------|---------------------|-------------------|
+| Compute sharing | FAM DAEmon coordinates | Attestation of compute receipt |
+| Treasury transfer | pAVS/UPS accounting | Proof of treasury milestone |
+| Agent delegation | MCP federation | Attestation of agent authority |
+
+---
+
+## 6. WSP / ModLog / Evidence Snapshot Fit
+
+### 6.1 WSP Milestone Verification
+
+| WSP Event | Internal Handling | Ritual Attestation |
+|-----------|-------------------|-------------------|
+| WSP audit passed | 0102 validator consensus | Hash of audit result + timestamp |
+| ModLog snapshot | Git commit / FAM event | Hash of ModLog state |
+| Clean state achieved | WSP 2 verification | Hash of clean state proof |
+
+### 6.2 Evidence Reference Layer
+
+FoundUps already uses evidence storage:
+- IPFS for large artifacts
+- Arweave for permanent storage
+- FAM DAEmon for event history
+
+**Ritual Addition**: Attestation that evidence hash existed at specific timestamp, without storing evidence on-chain.
+
+```
+Evidence (IPFS/Arweave)  ──►  Evidence Hash  ──►  Ritual Attestation
+                                                       │
+                                                       ▼
+                                               Immutable proof:
+                                               "Hash X existed at time T"
+```
+
+### 6.3 Audit Trail Compliance
+
+For regulated FoundUps (climate credits, social impact):
+- Ritual attestation provides external verification
+- dMRV (digital Measurement, Reporting, Verification) compatible
+- Reduces reliance on centralized auditors
+
+---
+
+## 7. Required Interface Boundary
+
+### 7.1 FoundUps → Ritual Interface (Proposed)
+
+```python
+# FoundUps emits - Ritual receives
+@dataclass
+class MilestoneAttestationRequest:
+    foundup_id: str
+    milestone_type: MilestoneType
+    milestone_hash: bytes32
+    evidence_refs: List[str]
+    validator_count: int
+    requested_at: int
+```
+
+### 7.2 Ritual → FoundUps Interface (Proposed)
+
+```python
+# Ritual returns - FoundUps stores
+@dataclass
+class MilestoneAttestationReceipt:
+    attestation_id: bytes32
+    ritual_block_number: int
+    ritual_timestamp: int
+    tee_signature: bytes
+    verification_status: AttestationStatus
+```
+
+### 7.3 Non-Interface (Boundary Violations)
+
+| Action | Status | Reason |
+|--------|--------|--------|
+| Compute CABR on Ritual | PROHIBITED | Core logic must stay internal |
+| Store UPS balances on Ritual | PROHIBITED | Treasury on Algorand/BTC |
+| Run OpenClaw on Ritual | PROHIBITED | Latency incompatible |
+| Determine tier transitions on Ritual | PROHIBITED | FoundUps sovereignty |
+
+---
+
+## 8. Risks And Failure Modes
+
+### 8.1 Technical Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Ritual mainnet not launching | MEDIUM | Attestation layer is optional; bypass if unavailable |
+| TEE vulnerabilities (SGX side-channels) | LOW | Attestation is proof-of-existence, not secret computation |
+| Ritual chain congestion | LOW | Milestones are infrequent; batch attestations acceptable |
+| Network partition | MEDIUM | FoundUps continues operating; attestation deferred |
+
+### 8.2 Architectural Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Scope creep (moving core logic to Ritual) | HIGH | Strict interface boundary; WSP compliance check |
+| Dependency lock-in | MEDIUM | Attestation layer abstraction; swap to alternative |
+| Over-reliance on external verification | MEDIUM | Internal validators remain primary; Ritual is supplementary |
+
+### 8.3 Economic Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Ritual token economics instability | LOW | FoundUps economics independent (UPS/BTC) |
+| Attestation costs escalating | LOW | Batch attestations; cost ceiling in adapter |
+| Node operator incentive misalignment | MEDIUM | Use multiple attestation providers if available |
+
+### 8.4 Failure Mode: Ritual Unavailable
+
+```
+IF Ritual unavailable:
+  - FoundUps continues normal operation
+  - Milestones recorded internally (FAM DAEmon)
+  - External attestation deferred or skipped
+  - No core functionality impacted
+```
+
+---
+
+## 9. Final Recommendation
+
+### 9.1 Verdict: **FIT_AS_OPTIONAL_ATTESTATION_LAYER**
+
+Ritual Chain's verification infrastructure is suitable for optional attestation of FoundUp milestone transitions. The architecture preserves:
+
+1. **FoundUps Sovereignty**: All ROC/CABR computation remains internal
+2. **Ritual as Optional Layer**: Attestation can be bypassed without breaking operation
+3. **Clear Interface Boundary**: Only milestone hashes cross the boundary
+4. **Cross-DAO Trust**: External verification enables trust-minimized coordination
+
+### 9.2 Strongest Fit
+
+**DAE-to-DAO Certification**: Ritual's TEE + on-chain timestamping provides strong external proof of tier transitions, useful for:
+- Regulatory compliance
+- Cross-DAO trust
+- Historical audit trail
+
+### 9.3 Strongest Risk
+
+**Scope Creep**: Risk that attestation layer expands into core computation. Mitigated by:
+- Strict WSP interface boundary
+- No CABR/ROC computation on Ritual
+- Kill switch (bypass attestation layer)
+
+### 9.4 WSP Integration Recommendation
+
+This audit suggests Ritual attestation could be referenced in:
+
+| WSP | Integration Point |
+|-----|-------------------|
+| **WSP 100** | Add optional external attestation for tier transitions |
+| **WSP 29** | Add optional dMRV attestation for CABR oracle scores |
+| **WSP 27** | Add optional milestone hash attestation at phase transitions |
+
+**No WSP modification required** for this audit — only future optional integration points identified.
+
+### 9.5 Next Slice
+
+If 012 approves:
+- **RITUAL_ATTESTATION_ADAPTER_SPEC_PHASE1**: Define abstract attestation interface
+- **RITUAL_ATTESTATION_PROTOTYPE_PHASE1**: Build minimal adapter (only if mainnet launches)
+
+---
+
+## Sources
+
+### Internal (FoundUps)
+- `WSP_framework/src/WSP_100_DAE_SmartDAO_Escalation_Protocol.md` — Tier thresholds, transition model
+- `WSP_framework/src/WSP_29_CABR_Engine.md` — CABR scoring, oracle tiers
+- `WSP_framework/src/WSP_27_pArtifact_DAE_Architecture.md` — FoundUp lifecycle phases
+- `docs/audits/external_protocols/ritual/RITUAL_FOUNDUPS_STRATEGIC_SYNTHESIS.md` — Prior synthesis
+
+### External (Ritual)
+- [Ritual Chain Developer Documentation](https://docs.ritualfoundation.org/)
+- [Ritual TEE Verification](https://www.ritualfoundation.org/docs/whats-new/symphony)
+- [Ritual Precompiles](https://docs.ritualfoundation.org/docs/architecture/precompiles)
+
+---
+
+## WSP 97 Note
+
+**Truth Boundaries Applied**:
+
+1. All claims sourced from internal WSPs or external Ritual documentation
+2. "Optional attestation" means FoundUps operates without Ritual (no dependency)
+3. No partnership or integration claimed — this is architecture research only
+4. Risks explicitly enumerated with mitigations
+5. Core constraint preserved: FoundUps computes ROC internally; Ritual only attests outcomes
+
+**Uncertainty Acknowledgment**:
+- Ritual mainnet not yet live (testnet only)
+- TEE attestation flow not tested against actual Ritual infrastructure
+- Interface boundary is proposed, not implemented
+
+---
+
+*Audit performed by Worker W2 under WSP 97 truth boundaries.*


### PR DESCRIPTION
## Summary
Evaluates Ritual Chain as optional external attestation layer for FoundUp milestone transitions (DAE-to-SmartDAO, tier escalation, CABR thresholds).

**Verdict**: `FIT_AS_OPTIONAL_ATTESTATION_LAYER`

## Key Boundaries Preserved
- FoundUps computes ROC/CABR/milestones internally (WSP 29, WSP 100)
- Ritual only attests/timestamps/verifies outcomes
- No dependency on Ritual for core operation
- Kill switch: attestation layer can be bypassed

## Test plan
- [x] Audit follows WSP 97 truth boundaries
- [x] No partnership or integration claim
- [x] Ritual is optional attestation only
- [x] ROC computation remains internal to FoundUps

Worker-Lane: W10
Slice: RITUAL_ROC_MILESTONE_ATTESTATION_AUDIT

🤖 Generated with [Claude Code](https://claude.com/claude-code)