### PR TITLE
feat(cabr): add store export integration

### DIFF
--- a/docs/audits/consensus/CABR_CONSENSUS_FINALIZATION_PHASE9_STORE_EXPORT_INTEGRATION.md
+++ b/docs/audits/consensus/CABR_CONSENSUS_FINALIZATION_PHASE9_STORE_EXPORT_INTEGRATION.md
@@ -1,0 +1,225 @@
+# CABR Consensus Finalization Phase 9: Store-Export Integration
+
+**Slice**: CABR_CONSENSUS_FINALIZATION_PHASE9_STORE_EXPORT_INTEGRATION
+**Worker**: W1
+**Date**: 2026-05-13
+**Status**: COMPLETE
+
+## Overview
+
+Phase 9 adds a caller-driven store-to-export integration helper that composes:
+- CABRConsensusStore (Phase 2) - SQLite persistence
+- Lifecycle Query (Phase 7) - store query with correlation
+- Lifecycle Report Export (Phase 8) - unified JSON/Markdown export
+
+## WSP 97 Critical Constraint
+
+Store-export integration is **OBSERVABILITY ONLY**. It does NOT mean:
+- automatic state progression
+- verification_complete=True
+- cabr_ready=True
+- payout_ready=True
+- payout approval
+- DAO activation
+- token issuance
+- final consensus readiness
+- external settlement
+
+## Implementation
+
+### Files Created
+
+1. **`modules/communication/moltbot_bridge/src/cabr_store_export.py`**
+   - `CABRStoreExportRequest` - Request dataclass
+   - `CABRStoreExportResult` - Result dataclass with WSP 97 fields
+   - `build_store_export()` - Main orchestration helper
+   - `build_store_export_json()` - JSON-only convenience function
+   - `build_store_export_markdown()` - Markdown-only convenience function
+
+2. **`modules/communication/moltbot_bridge/tests/test_cabr_store_export.py`**
+   - 65 test cases covering all required scenarios
+
+### API
+
+```python
+from modules.communication.moltbot_bridge.src.cabr_store_export import (
+    build_store_export,
+    build_store_export_json,
+    build_store_export_markdown,
+)
+from modules.communication.moltbot_bridge.src.cabr_consensus_store import CABRConsensusStore
+
+# Caller must provide store (no default DB path)
+store = CABRConsensusStore(db_path="/path/to/db.sqlite")
+store.initialize_schema()
+
+# Full export with both formats
+result = build_store_export(
+    store=store,
+    receipts=receipts,           # Optional supplemental data
+    pavs_results=pavs_results,   # Optional supplemental data
+    score_results=score_results, # Optional supplemental data
+    quorum_results=quorum_results, # Optional supplemental data
+    start=datetime(2026, 1, 1, tzinfo=timezone.utc),  # Optional time filter
+    end=datetime(2026, 12, 31, tzinfo=timezone.utc),  # Optional time filter
+    limit=100,                   # Optional record limit
+    include_json=True,           # Default True
+    include_markdown=True,       # Default True
+)
+
+# Access exports (strings only, no file writes)
+json_export = result.json_export
+markdown_export = result.markdown_export
+
+# Or use convenience functions
+json_str = build_store_export_json(store)
+md_str = build_store_export_markdown(store)
+```
+
+### Behavior
+
+1. Caller MUST provide store object (no default DB path)
+2. No filesystem writes (returns strings only)
+3. Composes existing lifecycle query and report export APIs
+4. Returns JSON/Markdown strings only
+5. Preserves all required WSP 97 labels:
+   - REVIEW_ONLY
+   - OBSERVABILITY_ONLY
+   - NOT_CABR_READY
+   - NOT_PAYOUT_READY
+   - NO_DAO_ACTIVATION
+   - NO_EXTERNAL_ATTESTATION_REQUIRED
+6. Invalid query params fail closed (raises ValueError)
+7. Missing supplemental data reported as gaps, not inferred
+8. Truth-boundary anomalies flagged, not corrected
+9. No payout/DAO/final consensus readiness inferred
+
+## Test Coverage
+
+### Test Results
+
+```
+test_cabr_store_export.py: 65 passed
+test_cabr_lifecycle_report_export.py: 67 passed (regression)
+test_cabr_lifecycle_query.py: 45 passed (regression)
+test_cabr_consensus_store.py: 35 passed (regression)
+```
+
+### Test Categories
+
+1. **No Store Provided Fails Closed** (4 tests)
+   - build_store_export raises without store
+   - build_store_export_json raises without store
+   - build_store_export_markdown raises without store
+   - Request validation fails without store
+
+2. **Empty Store Exports** (5 tests)
+   - Valid JSON output
+   - Valid Markdown output
+   - Deterministic JSON
+   - Zero records reported
+   - Sorted JSON keys
+
+3. **Store With Records Exports** (6 tests)
+   - Valid JSON output
+   - Valid Markdown output
+   - Correct record count
+   - Correlations present
+   - JSON convenience function
+   - Markdown convenience function
+
+4. **Include Toggles** (4 tests)
+   - Both enabled by default
+   - JSON only
+   - Markdown only
+   - Neither export
+
+5. **Invalid Time Range** (4 tests)
+   - ValueError on start > end
+   - JSON function raises
+   - Markdown function raises
+   - Request validation fails
+
+6. **Missing Receipts Produce Gaps** (5 tests)
+   - No receipts produces gaps
+   - Partial receipts produces gaps
+   - Full receipts reduces gaps
+   - Gap summary in JSON
+   - Gap summary in Markdown
+
+7. **WSP 97 Labels Present** (9 tests)
+   - All required labels in result
+   - All required labels in JSON
+   - All required labels in Markdown
+   - Individual label tests
+
+8. **No Filesystem Writes** (4 tests)
+   - Export does not create files
+   - JSON function does not create files
+   - Markdown function does not create files
+   - Returns strings not paths
+
+9. **No Default DB Path** (4 tests)
+   - build_store_export requires store
+   - JSON function requires store
+   - Markdown function requires store
+   - No db_path parameter
+
+10. **No Payout Readiness Inferred** (3 tests)
+    - payout_ready always False
+    - No payout amount fields
+    - NOT_PAYOUT_READY label present
+
+11. **No DAO Activation Inferred** (3 tests)
+    - cabr_ready always False
+    - No DAO fields
+    - NO_DAO_ACTIVATION label present
+
+12. **No CABR Readiness Inferred** (2 tests)
+    - verification_complete always False
+    - NOT_CABR_READY label present
+
+13. **Truth Anomaly Propagation** (6 tests)
+    - Anomaly in pavs flagged
+    - Anomaly in score flagged
+    - Anomaly in quorum flagged
+    - No anomalies by default
+    - Anomaly section in JSON
+    - Anomaly section in Markdown
+
+14. **Request Dataclass** (3 tests)
+    - Valid request
+    - Request with time range
+    - Request with all options
+
+15. **Result Dataclass** (3 tests)
+    - WSP 97 fields initialized
+    - to_dict serialization
+    - Sorted keys
+
+## WSP Compliance
+
+- **WSP 11**: Interface contract (explicit, typed)
+- **WSP 91**: Observability (timestamps, audit fields)
+- **WSP 97**: System Execution Prompting (truth boundaries)
+
+## Architecture
+
+```
+Phase 2: CABRConsensusStore (SQLite persistence)
+    |
+Phase 7: query_lifecycle_from_store() (store + correlation)
+    |
+Phase 8: build_lifecycle_report_export() (unified export)
+    |
+Phase 9: build_store_export() (orchestration helper) <-- THIS PHASE
+```
+
+## Next Steps
+
+Recommended next slice: CABR_CONSENSUS_FINALIZATION_PHASE10_CONSENSUS_REPORT_EXPORT_INTEGRATION
+
+This would add consensus report integration to the store export, combining:
+- Store export (Phase 9)
+- Consensus reporting (Phase 4)
+- Full end-to-end pipeline export

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,96 @@
 # ModLog - moltbot_bridge
 
+## 2026-05-13: CABR Consensus Finalization Phase 9 - Store-Export Integration (WSP 97)
+
+**Author**: 0102 (Worker W1)
+**WSP**: 97 (System Execution Prompting), 91 (Observability)
+**Slice**: `CABR_CONSENSUS_FINALIZATION_PHASE9_STORE_EXPORT_INTEGRATION`
+
+### Summary
+
+Added caller-driven store-to-export integration helper that composes:
+- CABRConsensusStore (Phase 2) - SQLite persistence
+- Lifecycle Query (Phase 7) - store query with correlation
+- Lifecycle Report Export (Phase 8) - unified JSON/Markdown export
+
+### WSP 97 Critical Constraint
+
+Store-export integration is observability only. It must NOT mean:
+- Automatic state progression
+- verification_complete=True
+- cabr_ready=True
+- payout_ready=True
+- Payout approval
+- DAO activation
+- Token issuance
+- Final consensus readiness
+- External settlement
+
+### Files Created
+
+| File | Lines | Purpose |
+|------|-------|---------|
+| `src/cabr_store_export.py` | ~400 | Store-export orchestration helper |
+| `tests/test_cabr_store_export.py` | ~650 | Test coverage (65 tests) |
+| `docs/audits/consensus/CABR_CONSENSUS_FINALIZATION_PHASE9_STORE_EXPORT_INTEGRATION.md` | ~180 | Audit documentation |
+
+### New API Surface
+
+```python
+@dataclass
+class CABRStoreExportRequest:
+    store: Any  # MUST be provided by caller
+    receipts: Optional[List[Dict]]
+    pavs_results: Optional[List[Dict]]
+    score_results: Optional[List[Dict]]
+    quorum_results: Optional[List[Dict]]
+    start: Optional[datetime]
+    end: Optional[datetime]
+    limit: Optional[int]
+    include_markdown: bool = True
+    include_json: bool = True
+
+@dataclass
+class CABRStoreExportResult:
+    success: bool
+    error_message: Optional[str]
+    persisted_record_count: int
+    total_correlations: int
+    total_gaps: int
+    has_anomalies: bool
+    anomaly_count: int
+    json_export: Optional[str]
+    markdown_export: Optional[str]
+    wsp97_labels: List[str]
+    truth_boundary: Dict[str, bool]
+
+def build_store_export(store, receipts=None, ...) -> CABRStoreExportResult
+def build_store_export_json(store, ...) -> str
+def build_store_export_markdown(store, ...) -> str
+```
+
+### Behavior
+
+- Caller MUST provide store object (no default DB path)
+- No filesystem writes (returns strings only)
+- Composes existing lifecycle query and report export APIs
+- Returns JSON/Markdown strings only
+- Preserves all required WSP 97 labels
+- Invalid query params fail closed (raises ValueError)
+- Missing supplemental data reported as gaps, not inferred
+- Truth-boundary anomalies flagged, not corrected
+- No payout/DAO/final consensus readiness inferred
+
+### Test Results
+
+- `test_cabr_store_export.py`: 65 passed
+- Regression tests:
+  - `test_cabr_lifecycle_report_export.py`: 67 passed
+  - `test_cabr_lifecycle_query.py`: 45 passed
+  - `test_cabr_consensus_store.py`: 35 passed
+
+---
+
 ## 2026-05-13: CABR Consensus Finalization Phase 8 - Lifecycle Report Export Integration (WSP 97)
 
 **Author**: 0102 (Worker W1)

--- a/modules/communication/moltbot_bridge/src/cabr_store_export.py
+++ b/modules/communication/moltbot_bridge/src/cabr_store_export.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+CABR Store Export Phase 9 -- Caller-Driven Store-to-Export Integration
+
+Provides a pure orchestration helper that composes:
+  CABRConsensusStore -> lifecycle query -> lifecycle report export
+
+This is OBSERVABILITY ONLY -- store-export integration does NOT mean:
+  - automatic state progression
+  - verification_complete=True
+  - cabr_ready=True
+  - payout_ready=True
+  - Payout approval
+  - DAO activation
+  - Token issuance
+  - External settlement
+  - Final consensus readiness
+
+WSP 97 TRUTH BOUNDARIES -- All exports MUST include:
+  - REVIEW_ONLY
+  - OBSERVABILITY_ONLY
+  - verification_complete=False
+  - cabr_ready=False
+  - payout_ready=False
+  - NOT_CABR_READY
+  - NOT_PAYOUT_READY
+  - NO_DAO_ACTIVATION
+  - NO_EXTERNAL_ATTESTATION_REQUIRED
+
+WSP 97 TRUTH BOUNDARIES:
+  * DOES:
+    - Pure orchestration (composes existing APIs)
+    - Caller must provide store object (no default DB path)
+    - No filesystem writes (returns strings only)
+    - No network calls
+    - No secrets or credentials
+    - No implicit side effects
+    - Preserves all required WSP 97 labels
+    - Reports missing supplemental data as gaps (not inferred)
+    - Flags truth-boundary anomalies (does not correct them)
+    - Fails closed on invalid query params
+
+  X DOES NOT:
+    - Provide default DB path
+    - Write to filesystem
+    - Mutate store
+    - Issue tokens or UPS
+    - Allocate rewards
+    - Write to wallet
+    - Trigger payouts
+    - Activate DAO transitions
+    - Make network calls
+    - Infer payout readiness
+    - Infer DAO activation
+    - Infer CABR readiness
+    - Cause automatic state progression
+    - Alter store/query/correlation/report/export semantics
+
+Architecture:
+  Phase 1-6 -> Pipeline stages (receipt -> verification -> scoring -> quorum -> consensus -> persistence)
+  Phase 7   -> Lifecycle Query (store + lifecycle integration)
+  Phase 8   -> Lifecycle Report Export (unified export)
+  Phase 9   -> Store Export (this) -> orchestration helper composing 7 + 8
+
+WSP Compliance:
+  WSP 11  : Interface contract (explicit, typed)
+  WSP 91  : Observability (timestamps, audit fields)
+  WSP 97  : System Execution Prompting (truth boundaries)
+
+Slice: CABR_CONSENSUS_FINALIZATION_PHASE9_STORE_EXPORT_INTEGRATION
+Worker: W1
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from .cabr_lifecycle_query import (
+    query_lifecycle_from_store,
+)
+from .cabr_lifecycle_report_export import (
+    CABRExportFormat,
+    CABRLifecycleReportExport,
+    WSP97_REQUIRED_LABELS,
+    WSP97_TRUTH_FIELDS,
+    build_lifecycle_report_export,
+    export_lifecycle_report_json,
+    export_lifecycle_report_markdown,
+)
+
+logger = logging.getLogger("cabr_store_export")
+
+
+def _utc_now() -> datetime:
+    """Return current UTC timestamp."""
+    return datetime.now(timezone.utc)
+
+
+def _utc_iso(dt: Optional[datetime]) -> Optional[str]:
+    """Convert datetime to ISO string or None."""
+    return dt.isoformat() if dt else None
+
+
+# ---------------------------------------------------------------------------
+# Request Dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CABRStoreExportRequest:
+    """
+    Request for store-to-export integration.
+
+    WSP 97 Critical:
+      This request is for OBSERVABILITY ONLY. It does NOT enable:
+        - automatic state progression
+        - verification_complete=True
+        - cabr_ready=True
+        - payout_ready=True
+        - Payout approval
+        - DAO activation
+        - Token issuance
+        - External settlement
+    """
+
+    # Store reference (caller MUST provide)
+    store: Any = None
+    """CABRConsensusStore instance. MUST be provided by caller."""
+
+    # Supplemental pipeline data (optional)
+    receipts: Optional[List[Dict[str, Any]]] = None
+    """Optional list of ProofOfComputeReceipt dicts."""
+
+    pavs_results: Optional[List[Dict[str, Any]]] = None
+    """Optional list of PAVSVerificationResult dicts."""
+
+    score_results: Optional[List[Dict[str, Any]]] = None
+    """Optional list of CABRScoreResult dicts."""
+
+    quorum_results: Optional[List[Dict[str, Any]]] = None
+    """Optional list of QuorumVerificationResult dicts."""
+
+    # Query parameters
+    start: Optional[datetime] = None
+    """Optional start time filter (inclusive)."""
+
+    end: Optional[datetime] = None
+    """Optional end time filter (inclusive)."""
+
+    limit: Optional[int] = None
+    """Optional maximum records to query."""
+
+    # Export options
+    include_markdown: bool = True
+    """Include Markdown export in result."""
+
+    include_json: bool = True
+    """Include JSON export in result."""
+
+    def validate(self) -> bool:
+        """
+        Validate request parameters.
+
+        Returns:
+            True if valid, False otherwise.
+        """
+        # Store is required
+        if self.store is None:
+            return False
+
+        # Time range validation
+        if self.start is not None and self.end is not None:
+            if self.start > self.end:
+                return False
+
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Result Dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CABRStoreExportResult:
+    """
+    Result from store-to-export integration.
+
+    WSP 97 Critical:
+      This result is for OBSERVABILITY ONLY. It does NOT indicate:
+        - verification_complete=True
+        - cabr_ready=True
+        - payout_ready=True
+        - Payout approval
+        - DAO activation
+        - Token issuance
+        - External settlement
+        - Automatic state progression
+    """
+
+    success: bool = False
+    """True if export completed successfully."""
+
+    error_message: Optional[str] = None
+    """Error message if not successful."""
+
+    # Lifecycle data
+    persisted_record_count: int = 0
+    """Number of persisted records queried."""
+
+    total_correlations: int = 0
+    """Number of lifecycle correlations."""
+
+    total_gaps: int = 0
+    """Total gaps detected."""
+
+    has_anomalies: bool = False
+    """True if truth boundary anomalies detected."""
+
+    anomaly_count: int = 0
+    """Number of anomalies detected."""
+
+    # Export outputs (strings only, no file writes)
+    json_export: Optional[str] = None
+    """JSON export string (if include_json=True)."""
+
+    markdown_export: Optional[str] = None
+    """Markdown export string (if include_markdown=True)."""
+
+    # Internal export reference (for advanced use)
+    export: Optional[CABRLifecycleReportExport] = None
+    """Full export dataclass (for additional processing)."""
+
+    generated_at: datetime = field(default_factory=_utc_now)
+    """When this result was generated."""
+
+    # WSP 97 Required Fields
+    wsp97_labels: List[str] = field(default_factory=list)
+    """Required WSP 97 labels (always present)."""
+
+    truth_boundary: Dict[str, bool] = field(default_factory=dict)
+    """Truth boundary fields (all must be False)."""
+
+    wsp97_compliance_note: str = (
+        "WSP 97: This store export is REVIEW_ONLY and OBSERVABILITY_ONLY. "
+        "No payout, DAO activation, or state progression is implied. "
+        "verification_complete=False, cabr_ready=False, payout_ready=False. "
+        "NOT_CABR_READY, NOT_PAYOUT_READY, NO_DAO_ACTIVATION, "
+        "NO_EXTERNAL_ATTESTATION_REQUIRED."
+    )
+    """WSP 97 compliance statement."""
+
+    def __post_init__(self):
+        """Initialize WSP 97 fields."""
+        if not self.wsp97_labels:
+            self.wsp97_labels = WSP97_REQUIRED_LABELS.copy()
+        if not self.truth_boundary:
+            self.truth_boundary = WSP97_TRUTH_FIELDS.copy()
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dict (sorted keys for determinism)."""
+        return {
+            "anomaly_count": self.anomaly_count,
+            "error_message": self.error_message,
+            "generated_at": _utc_iso(self.generated_at),
+            "has_anomalies": self.has_anomalies,
+            "json_export": self.json_export,
+            "markdown_export": self.markdown_export,
+            "persisted_record_count": self.persisted_record_count,
+            "success": self.success,
+            "total_correlations": self.total_correlations,
+            "total_gaps": self.total_gaps,
+            "truth_boundary": dict(sorted(self.truth_boundary.items())),
+            "wsp97_compliance_note": self.wsp97_compliance_note,
+            "wsp97_labels": sorted(self.wsp97_labels),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Public API: Build Store Export
+# ---------------------------------------------------------------------------
+
+
+def build_store_export(
+    store: Any,
+    receipts: Optional[List[Dict[str, Any]]] = None,
+    pavs_results: Optional[List[Dict[str, Any]]] = None,
+    score_results: Optional[List[Dict[str, Any]]] = None,
+    quorum_results: Optional[List[Dict[str, Any]]] = None,
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    limit: Optional[int] = None,
+    include_markdown: bool = True,
+    include_json: bool = True,
+) -> CABRStoreExportResult:
+    """
+    Build store export by composing lifecycle query and report export.
+
+    This is a pure orchestration helper. It:
+      1. Queries lifecycle from store (Phase 7)
+      2. Builds lifecycle report export (Phase 8)
+      3. Returns JSON/Markdown strings (no file writes)
+
+    WSP 97 Critical:
+      This export is for OBSERVABILITY ONLY. It does NOT mean:
+        - verification_complete=True
+        - cabr_ready=True
+        - payout_ready=True
+        - Payout approval
+        - DAO activation
+        - Token issuance
+        - External settlement
+        - Automatic state progression
+
+    Args:
+        store: CABRConsensusStore instance. MUST be provided by caller.
+               No default DB path is used.
+        receipts: Optional list of ProofOfComputeReceipt dicts.
+        pavs_results: Optional list of PAVSVerificationResult dicts.
+        score_results: Optional list of CABRScoreResult dicts.
+        quorum_results: Optional list of QuorumVerificationResult dicts.
+        start: Optional start time filter (inclusive).
+        end: Optional end time filter (inclusive).
+        limit: Optional maximum records to query.
+        include_markdown: Include Markdown export in result (default True).
+        include_json: Include JSON export in result (default True).
+
+    Returns:
+        CABRStoreExportResult with export strings and WSP 97 compliance.
+
+    Raises:
+        ValueError: If store is None or time range is invalid.
+    """
+    # Fail closed: store is required
+    if store is None:
+        raise ValueError(
+            "store is required. No default DB path is used. "
+            "Caller must provide CABRConsensusStore instance."
+        )
+
+    # Fail closed: invalid time range
+    if start is not None and end is not None and start > end:
+        raise ValueError(
+            f"Invalid time range: start ({start}) must be <= end ({end})"
+        )
+
+    try:
+        # Step 1: Query lifecycle from store (Phase 7)
+        lifecycle_query_result = query_lifecycle_from_store(
+            store=store,
+            receipts=receipts,
+            pavs_results=pavs_results,
+            score_results=score_results,
+            quorum_results=quorum_results,
+            start=start,
+            end=end,
+            limit=limit,
+        )
+
+        # Step 2: Build lifecycle report export (Phase 8)
+        export = build_lifecycle_report_export(
+            lifecycle_query_result=lifecycle_query_result.to_dict(),
+            consensus_report=None,  # No consensus report in basic store export
+        )
+
+        # Step 3: Build result
+        result = CABRStoreExportResult(
+            success=True,
+            persisted_record_count=lifecycle_query_result.persisted_record_count,
+            total_correlations=export.total_correlations,
+            total_gaps=export.total_gaps,
+            has_anomalies=export.has_anomalies,
+            anomaly_count=export.anomaly_count,
+            export=export,
+        )
+
+        # Step 4: Generate export strings (no file writes)
+        if include_json:
+            result.json_export = export_lifecycle_report_json(export)
+
+        if include_markdown:
+            result.markdown_export = export_lifecycle_report_markdown(export)
+
+        logger.info(
+            "[CABR-STORE-EXPORT] Built export: %d records, %d correlations, "
+            "%d gaps, %d anomalies, json=%s, md=%s",
+            result.persisted_record_count,
+            result.total_correlations,
+            result.total_gaps,
+            result.anomaly_count,
+            include_json,
+            include_markdown,
+        )
+
+        return result
+
+    except ValueError:
+        # Re-raise validation errors
+        raise
+    except Exception as e:
+        # Wrap other errors
+        logger.error("[CABR-STORE-EXPORT] Export failed: %s", e)
+        return CABRStoreExportResult(
+            success=False,
+            error_message=f"Export failed: {e}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API: Build Store Export JSON
+# ---------------------------------------------------------------------------
+
+
+def build_store_export_json(
+    store: Any,
+    receipts: Optional[List[Dict[str, Any]]] = None,
+    pavs_results: Optional[List[Dict[str, Any]]] = None,
+    score_results: Optional[List[Dict[str, Any]]] = None,
+    quorum_results: Optional[List[Dict[str, Any]]] = None,
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    limit: Optional[int] = None,
+    indent: int = 2,
+) -> str:
+    """
+    Build store export and return JSON string only.
+
+    Convenience function that returns only the JSON export string.
+    Raises on error (no result object returned).
+
+    WSP 97 Critical:
+      This export is for OBSERVABILITY ONLY. It does NOT mean:
+        - verification_complete=True
+        - cabr_ready=True
+        - payout_ready=True
+        - Payout approval
+        - DAO activation
+        - Token issuance
+        - External settlement
+        - Automatic state progression
+
+    Args:
+        store: CABRConsensusStore instance. MUST be provided by caller.
+        receipts: Optional list of ProofOfComputeReceipt dicts.
+        pavs_results: Optional list of PAVSVerificationResult dicts.
+        score_results: Optional list of CABRScoreResult dicts.
+        quorum_results: Optional list of QuorumVerificationResult dicts.
+        start: Optional start time filter (inclusive).
+        end: Optional end time filter (inclusive).
+        limit: Optional maximum records to query.
+        indent: JSON indentation level (default 2).
+
+    Returns:
+        Deterministic JSON string.
+
+    Raises:
+        ValueError: If store is None, time range is invalid, or export fails.
+    """
+    result = build_store_export(
+        store=store,
+        receipts=receipts,
+        pavs_results=pavs_results,
+        score_results=score_results,
+        quorum_results=quorum_results,
+        start=start,
+        end=end,
+        limit=limit,
+        include_json=True,
+        include_markdown=False,
+    )
+
+    if not result.success:
+        raise ValueError(result.error_message or "Export failed")
+
+    # Re-export with custom indent if needed
+    if indent != 2 and result.export:
+        return export_lifecycle_report_json(result.export, indent=indent)
+
+    return result.json_export or ""
+
+
+# ---------------------------------------------------------------------------
+# Public API: Build Store Export Markdown
+# ---------------------------------------------------------------------------
+
+
+def build_store_export_markdown(
+    store: Any,
+    receipts: Optional[List[Dict[str, Any]]] = None,
+    pavs_results: Optional[List[Dict[str, Any]]] = None,
+    score_results: Optional[List[Dict[str, Any]]] = None,
+    quorum_results: Optional[List[Dict[str, Any]]] = None,
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    limit: Optional[int] = None,
+) -> str:
+    """
+    Build store export and return Markdown string only.
+
+    Convenience function that returns only the Markdown export string.
+    Raises on error (no result object returned).
+
+    WSP 97 Critical:
+      This export is for OBSERVABILITY ONLY. It does NOT mean:
+        - verification_complete=True
+        - cabr_ready=True
+        - payout_ready=True
+        - Payout approval
+        - DAO activation
+        - Token issuance
+        - External settlement
+        - Automatic state progression
+
+    Args:
+        store: CABRConsensusStore instance. MUST be provided by caller.
+        receipts: Optional list of ProofOfComputeReceipt dicts.
+        pavs_results: Optional list of PAVSVerificationResult dicts.
+        score_results: Optional list of CABRScoreResult dicts.
+        quorum_results: Optional list of QuorumVerificationResult dicts.
+        start: Optional start time filter (inclusive).
+        end: Optional end time filter (inclusive).
+        limit: Optional maximum records to query.
+
+    Returns:
+        Deterministic Markdown string.
+
+    Raises:
+        ValueError: If store is None, time range is invalid, or export fails.
+    """
+    result = build_store_export(
+        store=store,
+        receipts=receipts,
+        pavs_results=pavs_results,
+        score_results=score_results,
+        quorum_results=quorum_results,
+        start=start,
+        end=end,
+        limit=limit,
+        include_json=False,
+        include_markdown=True,
+    )
+
+    if not result.success:
+        raise ValueError(result.error_message or "Export failed")
+
+    return result.markdown_export or ""

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,31 @@
+## 2026-05-13: CABR Store Export Tests (WSP 97)
+
+**File**: `test_cabr_store_export.py` (NEW - 65 tests)
+
+**Test Classes**:
+- `TestNoStoreProvidedFailsClosed`: Store required, raises ValueError
+- `TestProvidedEmptyStoreExportsDeterministic`: Valid JSON/Markdown, sorted keys
+- `TestStoreWithPersistedRecordsExportsDeterministic`: Correct counts, correlations
+- `TestIncludeTogglesWork`: JSON only, Markdown only, both, neither
+- `TestInvalidTimeRangeFailsClosed`: ValueError for start > end
+- `TestMissingReceiptsProduceGaps`: Gap reporting for missing data
+- `TestRequiredWsp97LabelsPresent`: All 6 labels in result/JSON/Markdown
+- `TestNoFilesystemWrites`: No files created, returns strings
+- `TestNoDefaultDbPath`: Store parameter required, no db_path
+- `TestNoPayoutReadinessInferred`: payout_ready=False, no payout fields
+- `TestNoDAOActivationInferred`: cabr_ready=False, no DAO fields
+- `TestNoCABRReadinessInferred`: verification_complete=False
+- `TestTruthAnomalyPropagation`: Anomalies flagged from pavs/score/quorum
+- `TestRequestDataclass`: Request validation
+- `TestResultDataclass`: Result serialization, WSP 97 fields
+
+**Run**:
+- `python -m pytest modules/communication/moltbot_bridge/tests/test_cabr_store_export.py -q`
+
+**Result**: 65 passed
+
+---
+
 ## 2026-05-13: CABR Lifecycle Report Export Tests (WSP 97)
 
 **File**: `test_cabr_lifecycle_report_export.py` (NEW - 67 tests)

--- a/modules/communication/moltbot_bridge/tests/test_cabr_store_export.py
+++ b/modules/communication/moltbot_bridge/tests/test_cabr_store_export.py
@@ -1,0 +1,1057 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Tests for CABR Store Export Phase 9 - Store-to-Export Integration.
+
+Validates caller-driven store-to-export integration helper per WSP 97.
+
+Required coverage:
+  - no store provided fails closed
+  - provided empty store exports deterministic JSON/Markdown
+  - store with persisted records exports deterministic JSON/Markdown
+  - include_json/include_markdown toggles work
+  - invalid time range fails closed
+  - missing receipts produce gaps
+  - required WSP_97 labels present
+  - no filesystem writes
+  - no default DB path
+  - no payout readiness inferred
+  - no DAO activation inferred
+  - no CABR readiness inferred
+  - truth anomaly propagation
+
+WSP 97 Critical Constraint:
+  Store export is observability only.
+  It must NOT mean:
+    - automatic state progression
+    - verification_complete=True
+    - cabr_ready=True
+    - payout_ready=True
+    - payout approval
+    - DAO activation
+    - token issuance
+    - final consensus readiness
+    - external settlement
+
+Slice: CABR_CONSENSUS_FINALIZATION_PHASE9_STORE_EXPORT_INTEGRATION
+Worker: W1
+"""
+
+from __future__ import annotations
+
+import gc
+import json
+import sys
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Dict
+
+# Add project root to path
+project_root = Path(__file__).parent.parent.parent.parent.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+from modules.communication.moltbot_bridge.src.cabr_store_export import (
+    CABRStoreExportRequest,
+    CABRStoreExportResult,
+    build_store_export,
+    build_store_export_json,
+    build_store_export_markdown,
+)
+from modules.communication.moltbot_bridge.src.cabr_lifecycle_report_export import (
+    WSP97_REQUIRED_LABELS,
+    WSP97_TRUTH_FIELDS,
+)
+from modules.communication.moltbot_bridge.src.cabr_consensus_store import (
+    CABRConsensusStore,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_consensus_record(
+    record_id: str = "ccr_test_18a3b2c1_abc123",
+    record_hash: str = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6",
+    receipt_id: str = "rcpt_test_001",
+    job_id: str = "j_test_001",
+    tenant_id: str = "t_test",
+    decision: str = "accepted_for_review",
+    reason_code: str = "ok_score_accepted_quorum_met",
+    finalized_at: str = "2026-05-13T12:00:00+00:00",
+    verification_complete: bool = False,
+    cabr_ready: bool = False,
+    payout_ready: bool = False,
+) -> Dict[str, Any]:
+    """Create a mock CABRConsensusRecord dict."""
+    return {
+        "record_id": record_id,
+        "record_hash": record_hash,
+        "receipt_id": receipt_id,
+        "job_id": job_id,
+        "tenant_id": tenant_id,
+        "score_id": f"cabr_{receipt_id}",
+        "score_decision": "accepted_for_review",
+        "score_reason_code": "ok_evidence_present_quorum_met",
+        "quorum_id": f"qv_{receipt_id}",
+        "quorum_decision": "consensus_accepted_for_review",
+        "quorum_reason_code": "ok_quorum_met_threshold_met",
+        "decision": decision,
+        "reason_code": reason_code,
+        "reason_human": f"Test record: {decision}",
+        "quorum_met": True,
+        "threshold_met": True,
+        "unique_verifiers": 3,
+        "consensus_score": 1.0,
+        "evidence_present": True,
+        "evidence_count": 2,
+        "is_dry_run": False,
+        "is_simulated": False,
+        "verification_complete": verification_complete,
+        "cabr_ready": cabr_ready,
+        "payout_ready": payout_ready,
+        "finalized_at": finalized_at,
+        "finalizer_version": "0.1.0",
+    }
+
+
+def _make_receipt(
+    receipt_id: str = "rcpt_test_001",
+    job_id: str = "j_test_001",
+    verification_status: str = "pending_pavs",
+) -> Dict[str, Any]:
+    """Create a mock ProofOfComputeReceipt dict."""
+    return {
+        "receipt_id": receipt_id,
+        "job_id": job_id,
+        "tenant_id": "t_test",
+        "verification_status": verification_status,
+        "status_reason_code": "OK",
+        "created_at": "2026-05-13T10:00:00+00:00",
+    }
+
+
+def _make_pavs_result(
+    receipt_id: str = "rcpt_test_001",
+    job_id: str = "j_test_001",
+    decision: str = "accepted_for_review",
+    verification_complete: bool = False,
+    cabr_ready: bool = False,
+    payout_ready: bool = False,
+) -> Dict[str, Any]:
+    """Create a mock PAVSVerificationResult dict."""
+    return {
+        "verification_id": f"pv_{receipt_id}",
+        "receipt_id": receipt_id,
+        "job_id": job_id,
+        "tenant_id": "t_test",
+        "decision": decision,
+        "reason_code": "ok_evidence_present",
+        "evidence_refs": ["ref1"],
+        "evidence_count": 1,
+        "verification_complete": verification_complete,
+        "cabr_ready": cabr_ready,
+        "payout_ready": payout_ready,
+        "created_at": "2026-05-13T10:01:00+00:00",
+    }
+
+
+def _make_score_result(
+    receipt_id: str = "rcpt_test_001",
+    job_id: str = "j_test_001",
+    decision: str = "accepted_for_review",
+    verification_complete: bool = False,
+    cabr_ready: bool = False,
+    payout_ready: bool = False,
+) -> Dict[str, Any]:
+    """Create a mock CABRScoreResult dict."""
+    return {
+        "score_id": f"cabr_{receipt_id}",
+        "receipt_id": receipt_id,
+        "job_id": job_id,
+        "tenant_id": "t_test",
+        "decision": decision,
+        "reason_code": "ok_evidence_present_quorum_met",
+        "verification_complete": verification_complete,
+        "cabr_ready": cabr_ready,
+        "payout_ready": payout_ready,
+        "scored_at": "2026-05-13T10:02:00+00:00",
+    }
+
+
+def _make_quorum_result(
+    receipt_id: str = "rcpt_test_001",
+    job_id: str = "j_test_001",
+    decision: str = "consensus_accepted_for_review",
+    verification_complete: bool = False,
+    cabr_ready: bool = False,
+    payout_ready: bool = False,
+) -> Dict[str, Any]:
+    """Create a mock QuorumVerificationResult dict."""
+    return {
+        "quorum_id": f"qv_{receipt_id}",
+        "receipt_id": receipt_id,
+        "job_id": job_id,
+        "tenant_id": "t_test",
+        "decision": decision,
+        "reason_code": "ok_quorum_met_threshold_met",
+        "quorum_met": True,
+        "threshold_met": True,
+        "verification_complete": verification_complete,
+        "cabr_ready": cabr_ready,
+        "payout_ready": payout_ready,
+        "evaluated_at": "2026-05-13T10:03:00+00:00",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test: No Store Provided Fails Closed
+# ---------------------------------------------------------------------------
+
+
+class TestNoStoreProvidedFailsClosed(unittest.TestCase):
+    """Tests that missing store raises error."""
+
+    def test_build_store_export_raises_without_store(self):
+        """build_store_export raises ValueError without store."""
+        with self.assertRaises(ValueError) as ctx:
+            build_store_export(store=None)
+
+        self.assertIn("store is required", str(ctx.exception))
+
+    def test_build_store_export_json_raises_without_store(self):
+        """build_store_export_json raises ValueError without store."""
+        with self.assertRaises(ValueError) as ctx:
+            build_store_export_json(store=None)
+
+        self.assertIn("store is required", str(ctx.exception))
+
+    def test_build_store_export_markdown_raises_without_store(self):
+        """build_store_export_markdown raises ValueError without store."""
+        with self.assertRaises(ValueError) as ctx:
+            build_store_export_markdown(store=None)
+
+        self.assertIn("store is required", str(ctx.exception))
+
+    def test_request_validation_fails_without_store(self):
+        """Request validation fails without store."""
+        request = CABRStoreExportRequest(store=None)
+        self.assertFalse(request.validate())
+
+
+# ---------------------------------------------------------------------------
+# Test: Provided Empty Store Exports Deterministic JSON/Markdown
+# ---------------------------------------------------------------------------
+
+
+class TestProvidedEmptyStoreExportsDeterministic(unittest.TestCase):
+    """Tests for empty store exports."""
+
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.db_path = Path(self.tmp_dir.name) / "test_consensus.db"
+        self.store = CABRConsensusStore(self.db_path)
+        self.store.initialize_schema()
+
+    def tearDown(self):
+        self.store.close()
+        gc.collect()
+        self.tmp_dir.cleanup()
+
+    def test_empty_store_exports_valid_json(self):
+        """Empty store exports valid JSON."""
+        result = build_store_export(self.store)
+
+        self.assertTrue(result.success)
+        self.assertIsNotNone(result.json_export)
+        parsed = json.loads(result.json_export)
+        self.assertIsInstance(parsed, dict)
+
+    def test_empty_store_exports_valid_markdown(self):
+        """Empty store exports valid Markdown."""
+        result = build_store_export(self.store)
+
+        self.assertTrue(result.success)
+        self.assertIsNotNone(result.markdown_export)
+        self.assertIn("# CABR Lifecycle Report Export", result.markdown_export)
+
+    def test_empty_store_json_deterministic(self):
+        """Empty store produces deterministic JSON."""
+        result1 = build_store_export(self.store)
+        result2 = build_store_export(self.store)
+
+        # Parse and compare (generated_at will differ)
+        parsed1 = json.loads(result1.json_export)
+        parsed2 = json.loads(result2.json_export)
+
+        # Core structure should match
+        self.assertEqual(parsed1["persisted_record_count"], parsed2["persisted_record_count"])
+        self.assertEqual(parsed1["truth_boundary"], parsed2["truth_boundary"])
+
+    def test_empty_store_has_zero_records(self):
+        """Empty store reports zero records."""
+        result = build_store_export(self.store)
+
+        self.assertEqual(result.persisted_record_count, 0)
+
+    def test_empty_store_json_has_sorted_keys(self):
+        """Empty store JSON has sorted keys."""
+        result = build_store_export(self.store)
+        parsed = json.loads(result.json_export)
+
+        top_keys = list(parsed.keys())
+        self.assertEqual(top_keys, sorted(top_keys))
+
+
+# ---------------------------------------------------------------------------
+# Test: Store With Persisted Records Exports Deterministic JSON/Markdown
+# ---------------------------------------------------------------------------
+
+
+class TestStoreWithPersistedRecordsExportsDeterministic(unittest.TestCase):
+    """Tests for store with records exports."""
+
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.db_path = Path(self.tmp_dir.name) / "test_consensus.db"
+        self.store = CABRConsensusStore(self.db_path)
+        self.store.initialize_schema()
+
+        # Insert records
+        for i in range(5):
+            self.store.save_record(_make_consensus_record(
+                record_id=f"ccr_{i:04d}",
+                receipt_id=f"rcpt_{i:04d}",
+                finalized_at=f"2026-0{i + 1}-15T10:00:00+00:00",
+            ))
+
+    def tearDown(self):
+        self.store.close()
+        gc.collect()
+        self.tmp_dir.cleanup()
+
+    def test_store_with_records_exports_valid_json(self):
+        """Store with records exports valid JSON."""
+        result = build_store_export(self.store)
+
+        self.assertTrue(result.success)
+        self.assertIsNotNone(result.json_export)
+        parsed = json.loads(result.json_export)
+        self.assertIsInstance(parsed, dict)
+
+    def test_store_with_records_exports_valid_markdown(self):
+        """Store with records exports valid Markdown."""
+        result = build_store_export(self.store)
+
+        self.assertTrue(result.success)
+        self.assertIsNotNone(result.markdown_export)
+        self.assertIn("# CABR Lifecycle Report Export", result.markdown_export)
+
+    def test_store_with_records_reports_correct_count(self):
+        """Store with records reports correct record count."""
+        result = build_store_export(self.store)
+
+        self.assertEqual(result.persisted_record_count, 5)
+
+    def test_store_with_records_has_correlations(self):
+        """Store with records has correlations."""
+        result = build_store_export(self.store)
+
+        self.assertEqual(result.total_correlations, 5)
+
+    def test_json_convenience_function(self):
+        """build_store_export_json returns JSON string."""
+        json_str = build_store_export_json(self.store)
+
+        parsed = json.loads(json_str)
+        self.assertIn("persisted_record_count", parsed)
+
+    def test_markdown_convenience_function(self):
+        """build_store_export_markdown returns Markdown string."""
+        md = build_store_export_markdown(self.store)
+
+        self.assertIn("# CABR Lifecycle Report Export", md)
+
+
+# ---------------------------------------------------------------------------
+# Test: Include JSON/Markdown Toggles Work
+# ---------------------------------------------------------------------------
+
+
+class TestIncludeTogglesWork(unittest.TestCase):
+    """Tests for include_json/include_markdown toggles."""
+
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.db_path = Path(self.tmp_dir.name) / "test_consensus.db"
+        self.store = CABRConsensusStore(self.db_path)
+        self.store.initialize_schema()
+
+    def tearDown(self):
+        self.store.close()
+        gc.collect()
+        self.tmp_dir.cleanup()
+
+    def test_both_exports_enabled_by_default(self):
+        """Both JSON and Markdown enabled by default."""
+        result = build_store_export(self.store)
+
+        self.assertIsNotNone(result.json_export)
+        self.assertIsNotNone(result.markdown_export)
+
+    def test_json_only(self):
+        """Only JSON when include_markdown=False."""
+        result = build_store_export(
+            self.store,
+            include_json=True,
+            include_markdown=False,
+        )
+
+        self.assertIsNotNone(result.json_export)
+        self.assertIsNone(result.markdown_export)
+
+    def test_markdown_only(self):
+        """Only Markdown when include_json=False."""
+        result = build_store_export(
+            self.store,
+            include_json=False,
+            include_markdown=True,
+        )
+
+        self.assertIsNone(result.json_export)
+        self.assertIsNotNone(result.markdown_export)
+
+    def test_neither_export(self):
+        """No exports when both disabled."""
+        result = build_store_export(
+            self.store,
+            include_json=False,
+            include_markdown=False,
+        )
+
+        self.assertIsNone(result.json_export)
+        self.assertIsNone(result.markdown_export)
+        # But result should still be successful
+        self.assertTrue(result.success)
+
+
+# ---------------------------------------------------------------------------
+# Test: Invalid Time Range Fails Closed
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidTimeRangeFailsClosed(unittest.TestCase):
+    """Tests for invalid time range handling."""
+
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.db_path = Path(self.tmp_dir.name) / "test_consensus.db"
+        self.store = CABRConsensusStore(self.db_path)
+        self.store.initialize_schema()
+
+    def tearDown(self):
+        self.store.close()
+        gc.collect()
+        self.tmp_dir.cleanup()
+
+    def test_start_after_end_raises_value_error(self):
+        """Invalid time range (start > end) raises ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            build_store_export(
+                self.store,
+                start=datetime(2026, 12, 31, tzinfo=timezone.utc),
+                end=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            )
+
+        self.assertIn("Invalid time range", str(ctx.exception))
+
+    def test_json_function_raises_on_invalid_time_range(self):
+        """build_store_export_json raises on invalid time range."""
+        with self.assertRaises(ValueError) as ctx:
+            build_store_export_json(
+                self.store,
+                start=datetime(2026, 12, 31, tzinfo=timezone.utc),
+                end=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            )
+
+        self.assertIn("Invalid time range", str(ctx.exception))
+
+    def test_markdown_function_raises_on_invalid_time_range(self):
+        """build_store_export_markdown raises on invalid time range."""
+        with self.assertRaises(ValueError) as ctx:
+            build_store_export_markdown(
+                self.store,
+                start=datetime(2026, 12, 31, tzinfo=timezone.utc),
+                end=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            )
+
+        self.assertIn("Invalid time range", str(ctx.exception))
+
+    def test_request_validation_fails_on_invalid_time_range(self):
+        """Request validation fails on invalid time range."""
+        request = CABRStoreExportRequest(
+            store=self.store,
+            start=datetime(2026, 12, 31, tzinfo=timezone.utc),
+            end=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        self.assertFalse(request.validate())
+
+
+# ---------------------------------------------------------------------------
+# Test: Missing Receipts Produce Gaps
+# ---------------------------------------------------------------------------
+
+
+class TestMissingReceiptsProduceGaps(unittest.TestCase):
+    """Tests for gap reporting with missing receipts."""
+
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.db_path = Path(self.tmp_dir.name) / "test_consensus.db"
+        self.store = CABRConsensusStore(self.db_path)
+        self.store.initialize_schema()
+
+        # Insert records
+        self.store.save_record(_make_consensus_record(
+            record_id="ccr_001",
+            receipt_id="rcpt_001",
+        ))
+        self.store.save_record(_make_consensus_record(
+            record_id="ccr_002",
+            receipt_id="rcpt_002",
+        ))
+
+    def tearDown(self):
+        self.store.close()
+        gc.collect()
+        self.tmp_dir.cleanup()
+
+    def test_no_receipts_produces_gaps(self):
+        """No supplied receipts produces gaps."""
+        result = build_store_export(self.store)
+
+        # Should have gaps for missing upstream stages
+        self.assertGreater(result.total_gaps, 0)
+
+    def test_partial_receipts_produces_gaps(self):
+        """Partial receipts produces gaps."""
+        result = build_store_export(
+            self.store,
+            receipts=[_make_receipt(receipt_id="rcpt_001")],
+        )
+
+        # One receipt matched, one missing
+        self.assertGreater(result.total_gaps, 0)
+
+    def test_full_receipts_reduces_gaps(self):
+        """Full receipts reduces gaps."""
+        result_without = build_store_export(self.store)
+
+        result_with = build_store_export(
+            self.store,
+            receipts=[
+                _make_receipt(receipt_id="rcpt_001"),
+                _make_receipt(receipt_id="rcpt_002"),
+            ],
+        )
+
+        # Should have fewer gaps with receipts
+        self.assertLessEqual(result_with.total_gaps, result_without.total_gaps)
+
+    def test_gap_summary_in_json(self):
+        """Gap summary appears in JSON export."""
+        result = build_store_export(self.store)
+        parsed = json.loads(result.json_export)
+
+        self.assertIn("gap_summary", parsed)
+
+    def test_gap_summary_in_markdown(self):
+        """Gap summary appears in Markdown export."""
+        result = build_store_export(self.store)
+
+        self.assertIn("## Gap Summary", result.markdown_export)
+
+
+# ---------------------------------------------------------------------------
+# Test: Required WSP_97 Labels Present
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredWsp97LabelsPresent(unittest.TestCase):
+    """Tests for required WSP 97 labels."""
+
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.db_path = Path(self.tmp_dir.name) / "test_consensus.db"
+        self.store = CABRConsensusStore(self.db_path)
+        self.store.initialize_schema()
+
+    def tearDown(self):
+        self.store.close()
+        gc.collect()
+        self.tmp_dir.cleanup()
+
+    def test_all_required_labels_in_result(self):
+        """All required WSP 97 labels present in result."""
+        result = build_store_export(self.store)
+
+        for label in WSP97_REQUIRED_LABELS:
+            self.assertIn(label, result.wsp97_labels)
+
+    def test_all_required_labels_in_json(self):
+        """All required WSP 97 labels present in JSON export."""
+        result = build_store_export(self.store)
+
+        for label in WSP97_REQUIRED_LABELS:
+            self.assertIn(label, result.json_export)
+
+    def test_all_required_labels_in_markdown(self):
+        """All required WSP 97 labels present in Markdown export."""
+        result = build_store_export(self.store)
+
+        for label in WSP97_REQUIRED_LABELS:
+            self.assertIn(label, result.markdown_export)
+
+    def test_review_only_label_present(self):
+        """REVIEW_ONLY label is present."""
+        result = build_store_export(self.store)
+        self.assertIn("REVIEW_ONLY", result.wsp97_labels)
+
+    def test_observability_only_label_present(self):
+        """OBSERVABILITY_ONLY label is present."""
+        result = build_store_export(self.store)
+        self.assertIn("OBSERVABILITY_ONLY", result.wsp97_labels)
+
+    def test_not_cabr_ready_label_present(self):
+        """NOT_CABR_READY label is present."""
+        result = build_store_export(self.store)
+        self.assertIn("NOT_CABR_READY", result.wsp97_labels)
+
+    def test_not_payout_ready_label_present(self):
+        """NOT_PAYOUT_READY label is present."""
+        result = build_store_export(self.store)
+        self.assertIn("NOT_PAYOUT_READY", result.wsp97_labels)
+
+    def test_no_dao_activation_label_present(self):
+        """NO_DAO_ACTIVATION label is present."""
+        result = build_store_export(self.store)
+        self.assertIn("NO_DAO_ACTIVATION", result.wsp97_labels)
+
+    def test_no_external_attestation_label_present(self):
+        """NO_EXTERNAL_ATTESTATION_REQUIRED label is present."""
+        result = build_store_export(self.store)
+        self.assertIn("NO_EXTERNAL_ATTESTATION_REQUIRED", result.wsp97_labels)
+
+
+# ---------------------------------------------------------------------------
+# Test: No Filesystem Writes
+# ---------------------------------------------------------------------------
+
+
+class TestNoFilesystemWrites(unittest.TestCase):
+    """Tests that export does not write to filesystem."""
+
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.db_path = Path(self.tmp_dir.name) / "test_consensus.db"
+        self.store = CABRConsensusStore(self.db_path)
+        self.store.initialize_schema()
+
+    def tearDown(self):
+        self.store.close()
+        gc.collect()
+        self.tmp_dir.cleanup()
+
+    def test_export_does_not_create_files(self):
+        """Export does not create files in temp directory."""
+        import os
+        import tempfile
+
+        temp_files_before = set(os.listdir(tempfile.gettempdir()))
+
+        build_store_export(self.store)
+
+        temp_files_after = set(os.listdir(tempfile.gettempdir()))
+        new_files = temp_files_after - temp_files_before
+
+        # No CABR-related files created
+        for f in new_files:
+            self.assertNotIn("cabr", f.lower())
+            self.assertNotIn("export", f.lower())
+
+    def test_json_function_does_not_create_files(self):
+        """build_store_export_json does not create files."""
+        import os
+        import tempfile
+
+        temp_files_before = set(os.listdir(tempfile.gettempdir()))
+
+        build_store_export_json(self.store)
+
+        temp_files_after = set(os.listdir(tempfile.gettempdir()))
+        new_files = temp_files_after - temp_files_before
+
+        for f in new_files:
+            self.assertNotIn("cabr", f.lower())
+
+    def test_markdown_function_does_not_create_files(self):
+        """build_store_export_markdown does not create files."""
+        import os
+        import tempfile
+
+        temp_files_before = set(os.listdir(tempfile.gettempdir()))
+
+        build_store_export_markdown(self.store)
+
+        temp_files_after = set(os.listdir(tempfile.gettempdir()))
+        new_files = temp_files_after - temp_files_before
+
+        for f in new_files:
+            self.assertNotIn("cabr", f.lower())
+
+    def test_exports_return_strings_not_paths(self):
+        """Export functions return strings, not file paths."""
+        result = build_store_export(self.store)
+
+        # Results are strings containing content, not file paths
+        self.assertIn("{", result.json_export)  # JSON content
+        self.assertIn("#", result.markdown_export)  # Markdown headers
+
+
+# ---------------------------------------------------------------------------
+# Test: No Default DB Path
+# ---------------------------------------------------------------------------
+
+
+class TestNoDefaultDbPath(unittest.TestCase):
+    """Tests that no default DB path is used."""
+
+    def test_build_store_export_requires_store(self):
+        """build_store_export requires store parameter."""
+        with self.assertRaises((TypeError, ValueError)):
+            build_store_export()  # type: ignore
+
+    def test_json_function_requires_store(self):
+        """build_store_export_json requires store parameter."""
+        with self.assertRaises((TypeError, ValueError)):
+            build_store_export_json()  # type: ignore
+
+    def test_markdown_function_requires_store(self):
+        """build_store_export_markdown requires store parameter."""
+        with self.assertRaises((TypeError, ValueError)):
+            build_store_export_markdown()  # type: ignore
+
+    def test_no_db_path_parameter_in_function(self):
+        """No db_path parameter in export functions."""
+        import inspect
+
+        sig = inspect.signature(build_store_export)
+        param_names = list(sig.parameters.keys())
+
+        self.assertNotIn("db_path", param_names)
+
+
+# ---------------------------------------------------------------------------
+# Test: No Payout Readiness Inferred
+# ---------------------------------------------------------------------------
+
+
+class TestNoPayoutReadinessInferred(unittest.TestCase):
+    """Tests that payout readiness is never inferred."""
+
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.db_path = Path(self.tmp_dir.name) / "test_consensus.db"
+        self.store = CABRConsensusStore(self.db_path)
+        self.store.initialize_schema()
+
+        self.store.save_record(_make_consensus_record(
+            record_id="ccr_001",
+            receipt_id="rcpt_001",
+        ))
+
+    def tearDown(self):
+        self.store.close()
+        gc.collect()
+        self.tmp_dir.cleanup()
+
+    def test_payout_ready_always_false(self):
+        """payout_ready is always False in result."""
+        result = build_store_export(self.store)
+
+        self.assertFalse(result.truth_boundary.get("payout_ready"))
+
+    def test_no_payout_amount_fields(self):
+        """Export has no payout amount fields."""
+        result = build_store_export(self.store)
+
+        self.assertNotIn("payout_amount", result.json_export)
+        self.assertNotIn("total_payout", result.json_export)
+        self.assertNotIn("tokens_issued", result.json_export)
+
+    def test_not_payout_ready_label_always_present(self):
+        """NOT_PAYOUT_READY label always present."""
+        result = build_store_export(self.store)
+
+        self.assertIn("NOT_PAYOUT_READY", result.wsp97_labels)
+
+
+# ---------------------------------------------------------------------------
+# Test: No DAO Activation Inferred
+# ---------------------------------------------------------------------------
+
+
+class TestNoDAOActivationInferred(unittest.TestCase):
+    """Tests that DAO activation is never inferred."""
+
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.db_path = Path(self.tmp_dir.name) / "test_consensus.db"
+        self.store = CABRConsensusStore(self.db_path)
+        self.store.initialize_schema()
+
+        self.store.save_record(_make_consensus_record(
+            record_id="ccr_001",
+            receipt_id="rcpt_001",
+        ))
+
+    def tearDown(self):
+        self.store.close()
+        gc.collect()
+        self.tmp_dir.cleanup()
+
+    def test_cabr_ready_always_false(self):
+        """cabr_ready is always False in result."""
+        result = build_store_export(self.store)
+
+        self.assertFalse(result.truth_boundary.get("cabr_ready"))
+
+    def test_no_dao_activation_fields(self):
+        """Export has no DAO activation fields."""
+        result = build_store_export(self.store)
+
+        self.assertNotIn("dao_activated", result.json_export)
+        self.assertNotIn("dao_transition", result.json_export)
+
+    def test_no_dao_activation_label_always_present(self):
+        """NO_DAO_ACTIVATION label always present."""
+        result = build_store_export(self.store)
+
+        self.assertIn("NO_DAO_ACTIVATION", result.wsp97_labels)
+
+
+# ---------------------------------------------------------------------------
+# Test: No CABR Readiness Inferred
+# ---------------------------------------------------------------------------
+
+
+class TestNoCABRReadinessInferred(unittest.TestCase):
+    """Tests that CABR readiness is never inferred."""
+
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.db_path = Path(self.tmp_dir.name) / "test_consensus.db"
+        self.store = CABRConsensusStore(self.db_path)
+        self.store.initialize_schema()
+
+        self.store.save_record(_make_consensus_record(
+            record_id="ccr_001",
+            receipt_id="rcpt_001",
+        ))
+
+    def tearDown(self):
+        self.store.close()
+        gc.collect()
+        self.tmp_dir.cleanup()
+
+    def test_verification_complete_always_false(self):
+        """verification_complete is always False in result."""
+        result = build_store_export(self.store)
+
+        self.assertFalse(result.truth_boundary.get("verification_complete"))
+
+    def test_not_cabr_ready_label_always_present(self):
+        """NOT_CABR_READY label always present."""
+        result = build_store_export(self.store)
+
+        self.assertIn("NOT_CABR_READY", result.wsp97_labels)
+
+
+# ---------------------------------------------------------------------------
+# Test: Truth Anomaly Propagation
+# ---------------------------------------------------------------------------
+
+
+class TestTruthAnomalyPropagation(unittest.TestCase):
+    """Tests for truth boundary anomaly propagation."""
+
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.db_path = Path(self.tmp_dir.name) / "test_consensus.db"
+        self.store = CABRConsensusStore(self.db_path)
+        self.store.initialize_schema()
+
+        self.store.save_record(_make_consensus_record(
+            record_id="ccr_001",
+            receipt_id="rcpt_001",
+        ))
+
+    def tearDown(self):
+        self.store.close()
+        gc.collect()
+        self.tmp_dir.cleanup()
+
+    def test_anomaly_in_pavs_flagged(self):
+        """verification_complete=True in pavs_results is flagged."""
+        result = build_store_export(
+            self.store,
+            pavs_results=[_make_pavs_result(
+                receipt_id="rcpt_001",
+                verification_complete=True,  # Anomaly
+            )],
+        )
+
+        self.assertTrue(result.has_anomalies)
+        self.assertGreater(result.anomaly_count, 0)
+
+    def test_anomaly_in_score_flagged(self):
+        """cabr_ready=True in score_results is flagged."""
+        result = build_store_export(
+            self.store,
+            score_results=[_make_score_result(
+                receipt_id="rcpt_001",
+                cabr_ready=True,  # Anomaly
+            )],
+        )
+
+        self.assertTrue(result.has_anomalies)
+
+    def test_anomaly_in_quorum_flagged(self):
+        """payout_ready=True in quorum_results is flagged."""
+        result = build_store_export(
+            self.store,
+            quorum_results=[_make_quorum_result(
+                receipt_id="rcpt_001",
+                payout_ready=True,  # Anomaly
+            )],
+        )
+
+        self.assertTrue(result.has_anomalies)
+
+    def test_no_anomalies_by_default(self):
+        """No anomalies when all truth fields are False."""
+        result = build_store_export(self.store)
+
+        self.assertFalse(result.has_anomalies)
+        self.assertEqual(result.anomaly_count, 0)
+
+    def test_anomaly_section_in_json(self):
+        """Anomaly section appears in JSON export."""
+        result = build_store_export(self.store)
+        parsed = json.loads(result.json_export)
+
+        self.assertIn("has_anomalies", parsed)
+        self.assertIn("anomaly_count", parsed)
+
+    def test_anomaly_section_in_markdown(self):
+        """Anomaly section appears in Markdown export."""
+        result = build_store_export(self.store)
+
+        self.assertIn("## Anomaly Report", result.markdown_export)
+
+
+# ---------------------------------------------------------------------------
+# Test: Request Dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestRequestDataclass(unittest.TestCase):
+    """Tests for CABRStoreExportRequest dataclass."""
+
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.db_path = Path(self.tmp_dir.name) / "test_consensus.db"
+        self.store = CABRConsensusStore(self.db_path)
+        self.store.initialize_schema()
+
+    def tearDown(self):
+        self.store.close()
+        gc.collect()
+        self.tmp_dir.cleanup()
+
+    def test_valid_request(self):
+        """Valid request passes validation."""
+        request = CABRStoreExportRequest(store=self.store)
+        self.assertTrue(request.validate())
+
+    def test_request_with_time_range(self):
+        """Request with valid time range passes validation."""
+        request = CABRStoreExportRequest(
+            store=self.store,
+            start=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            end=datetime(2026, 12, 31, tzinfo=timezone.utc),
+        )
+        self.assertTrue(request.validate())
+
+    def test_request_with_all_options(self):
+        """Request with all options passes validation."""
+        request = CABRStoreExportRequest(
+            store=self.store,
+            receipts=[_make_receipt()],
+            pavs_results=[_make_pavs_result()],
+            score_results=[_make_score_result()],
+            quorum_results=[_make_quorum_result()],
+            start=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            end=datetime(2026, 12, 31, tzinfo=timezone.utc),
+            limit=100,
+            include_markdown=True,
+            include_json=True,
+        )
+        self.assertTrue(request.validate())
+
+
+# ---------------------------------------------------------------------------
+# Test: Result Dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestResultDataclass(unittest.TestCase):
+    """Tests for CABRStoreExportResult dataclass."""
+
+    def test_result_has_wsp97_fields(self):
+        """Result has WSP 97 fields initialized."""
+        result = CABRStoreExportResult()
+
+        self.assertIsNotNone(result.wsp97_labels)
+        self.assertIsNotNone(result.truth_boundary)
+        self.assertIn("WSP 97", result.wsp97_compliance_note)
+
+    def test_result_to_dict(self):
+        """Result serializes to dict."""
+        result = CABRStoreExportResult(
+            success=True,
+            persisted_record_count=5,
+        )
+
+        d = result.to_dict()
+
+        self.assertTrue(d["success"])
+        self.assertEqual(d["persisted_record_count"], 5)
+        self.assertIn("wsp97_labels", d)
+        self.assertIn("truth_boundary", d)
+
+    def test_result_to_dict_sorted_keys(self):
+        """Result.to_dict has sorted keys."""
+        result = CABRStoreExportResult()
+        d = result.to_dict()
+
+        keys = list(d.keys())
+        self.assertEqual(keys, sorted(keys))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Phase 9 of CABR consensus finalization pipeline - store export integration.

- Caller must provide store (no default DB path)
- No filesystem writes
- Returns JSON/Markdown strings only
- Composes Phase 7 lifecycle query + Phase 8 report export
- Missing supplemental data becomes gaps, not inference
- Truth anomalies flagged, not corrected
- No payout/DAO/final consensus readiness inferred

## Labels

- `REVIEW_ONLY`
- `OBSERVABILITY_ONLY`
- `NOT_CABR_READY`
- `NOT_PAYOUT_READY`
- `NO_DAO_ACTIVATION`
- `NO_EXTERNAL_ATTESTATION_REQUIRED`

## Truth Fields

All truth fields remain `false`:
- `cabr_ready=False`
- `payout_ready=False`
- `dao_activation=False`
- `external_attestation_required=False`

## Test Plan

- [x] `test_cabr_store_export.py` - 65 tests
- [x] `test_cabr_lifecycle_report_export.py` - 67 tests
- [x] `test_cabr_lifecycle_query.py` - 45 tests
- [x] `test_cabr_consensus_store.py` - 35 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)