### PR TITLE
docs(consensus): add ROC candidate derivation audit phase 1

### DIFF
--- a/docs/audits/consensus/ROC_CANDIDATE_DERIVATION_AUDIT_PHASE1.md
+++ b/docs/audits/consensus/ROC_CANDIDATE_DERIVATION_AUDIT_PHASE1.md
@@ -1,0 +1,670 @@
+# ROC_CANDIDATE Derivation Audit Phase 1
+
+**Audit ID**: ROC_CANDIDATE_DERIVATION_AUDIT_PHASE1  
+**Worker**: W9  
+**Branch**: `docs/sovereign-agent-consensus-roc-dao-readiness-audit`  
+**HEAD**: `e2e3eae9471cdc16210de8062d4ea7e1bddc78af` (latest main after PR #591)  
+**Date**: 2026-05-14  
+**WSP Lock**: WSP_00, WSP_50, WSP_97  
+**Mode**: Audit/Spec Only -- NO IMPLEMENTATION
+
+---
+
+## Required Labels
+
+- DOCS_ONLY
+- REVIEW_ONLY
+- ROC_CANDIDATE_ONLY
+- NOT_ROC_VALIDATED
+- NOT_CABR_READY
+- NOT_PAYOUT_READY
+- NO_DAO_ACTIVATION
+- NO_EXTERNAL_ATTESTATION_REQUIRED
+- NO_RUNTIME_DERIVATION
+
+---
+
+## Executive Summary
+
+This audit specifies how a `REVIEW_ONLY` ROC_CANDIDATE state may be derived from the existing CABR Phase 1-10 pipeline. The derivation is specification-only and does NOT imply runtime implementation, state mutation, or readiness claims.
+
+**Key Finding**: The CABR Phase 10 pipeline provides all necessary inputs for ROC_CANDIDATE derivation. The `ACCEPTED_FOR_REVIEW` decision with `quorum_met=True` and `threshold_met=True` is **necessary but not sufficient** -- additional evidence fields must be present.
+
+**Verdict**: ROC_CANDIDATE derivation is **SPECIFIABLE** from existing CABR outputs but **NOT IMPLEMENTABLE** until formal WSP annex is created.
+
+---
+
+## 1. Retrieval Summary
+
+### 1.1 HoloIndex Searches Executed
+
+| Query | Results |
+|-------|---------|
+| "WSP 100 ROC_CANDIDATE REVIEW_ONLY ROC state annex" | WSP_100, test_gateway_roc_shell.py, ROC_FORMULA_DERIVATION.md |
+| "CABR consensus pipeline accepted for review lifecycle query export" | cabr_consensus_pipeline.py, cabr_hooks.py, proof_of_compute_receipt.py |
+| "ROC_STATE_MACHINE_AUDIT_PHASE1 ROC_CANDIDATE inputs thresholds" | unified_sustainability.py, ROC_FORMULA_DERIVATION.md |
+| "CABRScoreResult QuorumVerificationResult CABRConsensusRecord REVIEW_ONLY" | cabr_consensus_finalizer.py, cabr_lifecycle_report_export.py |
+
+### 1.2 Documents Examined
+
+| Document | Lines | Purpose |
+|----------|-------|---------|
+| `ROC_STATE_MACHINE_AUDIT_PHASE1.md` | 650 | ROC state machine spec |
+| `SOVEREIGN_AGENT_CONSENSUS_ROC_DAO_READINESS_AUDIT.md` | 460 | Master synthesis |
+| `SACRDA_CABR_FINALIZATION_SYNTHESIS_AUDIT.md` | 463 | CABR finalization synthesis |
+| `cabr_consensus_pipeline.py` | 1123 | Phase 10 pipeline composer |
+| `cabr_consensus_finalizer.py` | 1205 | Consensus finalization |
+| `cabr_lifecycle_query.py` | 475 | Lifecycle query integration |
+| `cabr_store_export.py` | 551 | Store-export orchestration |
+| `cabr_lifecycle_report_export.py` | 612 | Report export with WSP 97 labels |
+| `WSP_100_DAE_SmartDAO_Escalation_Protocol.md` | 621 | DAO tier model |
+
+### 1.3 Test Execution
+
+| Suite | Result |
+|-------|--------|
+| `test_cabr_consensus_pipeline.py` | 35 passed |
+| `test_cabr_store_export.py` | 65 passed |
+
+---
+
+## 2. Current CABR Inputs Available
+
+### 2.1 CABRConsensusRecord Fields (Phase 3)
+
+From `cabr_consensus_finalizer.py`:
+
+```python
+@dataclass
+class CABRConsensusRecord:
+    # === Record Identity ===
+    record_id: str                    # Unique record identifier
+    record_hash: str                  # Deterministic hash for integrity
+    
+    # === Source Identity ===
+    receipt_id: str                   # ProofOfComputeReceipt reference
+    job_id: str                       # Job reference
+    tenant_id: str                    # Actor scope
+    
+    # === Consensus Decision ===
+    decision: CABRConsensusDecision   # ACCEPTED_FOR_REVIEW, REJECTED, etc.
+    reason_code: CABRConsensusReasonCode
+    
+    # === Quorum Metrics ===
+    quorum_met: bool                  # True if verifier count >= min_validators
+    threshold_met: bool               # True if consensus_score >= threshold
+    unique_verifiers: int             # Number of unique verifiers
+    consensus_score: float            # Approval ratio
+    
+    # === Evidence Metrics ===
+    evidence_present: bool            # True if evidence was provided
+    evidence_count: int               # Number of evidence refs
+    
+    # === WSP 97 Truth Fields (always False) ===
+    verification_complete: bool = False
+    cabr_ready: bool = False
+    payout_ready: bool = False
+```
+
+### 2.2 CABRConsensusPipelineResult Fields (Phase 10)
+
+From `cabr_consensus_pipeline.py`:
+
+```python
+@dataclass
+class CABRConsensusPipelineResult:
+    success: bool                     # Pipeline completed
+    consensus_records: List[CABRConsensusRecord]
+    
+    # Stage tracking
+    stage_results: List[CABRConsensusPipelineStageResult]
+    failed_stage: Optional[CABRConsensusPipelineStage]
+    
+    # Metrics
+    receipts_processed: int
+    records_accepted: int
+    records_rejected: int
+    records_pending_quorum: int
+    
+    # Persistence
+    persistence_attempted: bool
+    persistence_success: bool
+    
+    # WSP 97 Fields
+    wsp97_labels: List[str]           # REVIEW_ONLY, NOT_CABR_READY, etc.
+    truth_boundary: Dict[str, bool]   # All must be False
+```
+
+### 2.3 Available WSP 97 Truth Fields
+
+From `cabr_lifecycle_report_export.py`:
+
+```python
+WSP97_REQUIRED_LABELS: List[str] = [
+    "REVIEW_ONLY",
+    "OBSERVABILITY_ONLY",
+    "NOT_CABR_READY",
+    "NOT_PAYOUT_READY",
+    "NO_DAO_ACTIVATION",
+    "NO_EXTERNAL_ATTESTATION_REQUIRED",
+]
+
+WSP97_TRUTH_FIELDS: Dict[str, bool] = {
+    "verification_complete": False,
+    "cabr_ready": False,
+    "payout_ready": False,
+}
+```
+
+---
+
+## 3. ROC_CANDIDATE Definition (DOCS_ONLY)
+
+### 3.1 State Definition
+
+```
+ROC_CANDIDATE:
+  A consensus record that has successfully passed through the CABR Phase 10
+  pipeline with all required evidence and quorum criteria met.
+  
+  This state represents "accepted for review" status and does NOT imply:
+    - ROC_VALIDATED (ROC ratio computed and passing)
+    - CABR_READY (external verification completed)
+    - PAYOUT_READY (payout engine approval)
+    - DAE_MATURE (DAE maturity thresholds met)
+    - DAO_READY (DAO governance activated)
+    - DAO_ACTIVATED (smart contracts deployed)
+    - Token issuance
+    - External attestation dependency
+```
+
+### 3.2 Derivation Logic (Specification Only)
+
+```python
+# SPEC ONLY - NOT FOR IMPLEMENTATION
+def is_roc_candidate(record: CABRConsensusRecord) -> bool:
+    """
+    Determine if a consensus record qualifies as ROC_CANDIDATE.
+    
+    WSP 97 Critical:
+      ROC_CANDIDATE status is REVIEW_ONLY. It does NOT imply:
+        - verification_complete=True
+        - cabr_ready=True
+        - payout_ready=True
+        - Any downstream state progression
+    
+    Returns:
+        True if record meets all ROC_CANDIDATE criteria.
+    """
+    # Required condition 1: Decision must be ACCEPTED_FOR_REVIEW
+    if record.decision != CABRConsensusDecision.ACCEPTED_FOR_REVIEW:
+        return False
+    
+    # Required condition 2: Quorum must be met
+    if not record.quorum_met:
+        return False
+    
+    # Required condition 3: Threshold must be met
+    if not record.threshold_met:
+        return False
+    
+    # Required condition 4: Evidence must be present
+    if not record.evidence_present:
+        return False
+    
+    # Required condition 5: Truth fields must all be False
+    if record.verification_complete or record.cabr_ready or record.payout_ready:
+        return False  # Truth boundary violation
+    
+    # All conditions met - qualifies as ROC_CANDIDATE
+    return True
+```
+
+---
+
+## 4. Required Inputs
+
+### 4.1 Mandatory Inputs for ROC_CANDIDATE
+
+| Input | Source | Required Value |
+|-------|--------|----------------|
+| `decision` | CABRConsensusRecord | `ACCEPTED_FOR_REVIEW` |
+| `quorum_met` | CABRConsensusRecord | `True` |
+| `threshold_met` | CABRConsensusRecord | `True` |
+| `evidence_present` | CABRConsensusRecord | `True` |
+| `verification_complete` | CABRConsensusRecord | `False` |
+| `cabr_ready` | CABRConsensusRecord | `False` |
+| `payout_ready` | CABRConsensusRecord | `False` |
+
+### 4.2 Optional Context Inputs
+
+| Input | Source | Purpose |
+|-------|--------|---------|
+| `record_id` | CABRConsensusRecord | Unique identification |
+| `receipt_id` | CABRConsensusRecord | Source correlation |
+| `unique_verifiers` | CABRConsensusRecord | Quorum depth metric |
+| `consensus_score` | CABRConsensusRecord | Consensus strength metric |
+| `evidence_count` | CABRConsensusRecord | Evidence depth metric |
+| `finalized_at` | CABRConsensusRecord | Timestamp for audit trail |
+
+### 4.3 Input Availability Assessment
+
+| Input | Available in Phase 10? | Status |
+|-------|------------------------|--------|
+| CABRConsensusRecord | YES | Directly available from pipeline |
+| Quorum metrics | YES | From quorum_verification_engine |
+| Evidence metrics | YES | From scoring_engine |
+| Truth boundary fields | YES | Always False per WSP 97 |
+| Persistence status | YES | From optional store integration |
+
+---
+
+## 5. Required Thresholds
+
+### 5.1 Existing Thresholds (From Codebase)
+
+| Threshold | Value | Source | Status |
+|-----------|-------|--------|--------|
+| `min_validators` | 3 | WSP 29, cabr_scoring_engine.py | IMPLEMENTED |
+| `consensus_threshold` | 0.382 | WSP 29, quorum_verification_engine.py | IMPLEMENTED |
+
+### 5.2 Proposed ROC_CANDIDATE Thresholds (Spec Only)
+
+| Threshold | Proposed Value | Purpose |
+|-----------|----------------|---------|
+| `MIN_VERIFIERS_FOR_ROC` | 3 | Same as min_validators |
+| `MIN_CONSENSUS_SCORE_FOR_ROC` | 0.382 | Same as consensus_threshold |
+| `MIN_EVIDENCE_COUNT_FOR_ROC` | 1 | At least one evidence reference |
+
+### 5.3 Threshold Inheritance
+
+ROC_CANDIDATE inherits thresholds from CABR Phase 10:
+- Quorum requirements already enforce `min_validators >= 3`
+- Consensus threshold already enforces `consensus_score >= 0.382`
+- Evidence presence already verified by scoring engine
+
+**No additional thresholds required** for ROC_CANDIDATE derivation.
+
+---
+
+## 6. Required Evidence Fields
+
+### 6.1 Mandatory Evidence for ROC_CANDIDATE
+
+| Field | Required? | Source |
+|-------|-----------|--------|
+| `receipt_id` | YES | ProofOfComputeReceipt |
+| `job_id` | YES | ProofOfComputeReceipt |
+| `tenant_id` | YES | ProofOfComputeReceipt |
+| `evidence_present` | YES (must be True) | CABRScoreResult |
+| `quorum_met` | YES (must be True) | QuorumVerificationResult |
+| `threshold_met` | YES (must be True) | QuorumVerificationResult |
+
+### 6.2 Optional Evidence for Enhanced Confidence
+
+| Field | Source | Enhancement |
+|-------|--------|-------------|
+| `unique_verifiers` | QuorumVerificationResult | Higher count = stronger confidence |
+| `consensus_score` | QuorumVerificationResult | Higher score = stronger consensus |
+| `evidence_count` | CABRScoreResult | More evidence = richer audit trail |
+| `record_hash` | CABRConsensusRecord | Integrity verification |
+
+### 6.3 Evidence Completeness Check (Spec Only)
+
+```python
+# SPEC ONLY - NOT FOR IMPLEMENTATION
+def has_complete_evidence(record: CABRConsensusRecord) -> bool:
+    """Check if record has complete evidence for ROC_CANDIDATE."""
+    return (
+        record.receipt_id and
+        record.job_id and
+        record.tenant_id and
+        record.evidence_present and
+        record.evidence_count >= 1
+    )
+```
+
+---
+
+## 7. Stop Conditions
+
+### 7.1 What MUST NOT Happen (WSP 97 Enforcement)
+
+| Condition | Enforced By | Evidence |
+|-----------|-------------|----------|
+| `verification_complete=True` | 15+ test assertions | All CABR tests |
+| `cabr_ready=True` | 15+ test assertions | All CABR tests |
+| `payout_ready=True` | 15+ test assertions | All CABR tests |
+| `dao_activated` field present | Export tests | Absence asserted |
+| Live payout execution | Architecture | No payout engine |
+| Token issuance | Architecture | No token contract |
+| External attestation required | Architecture | Internal-first design |
+| Automatic state progression | Architecture | Manual progression only |
+
+### 7.2 ROC_CANDIDATE Blocking Conditions
+
+ROC_CANDIDATE derivation MUST be blocked if:
+
+| Condition | Reason |
+|-----------|--------|
+| `decision != ACCEPTED_FOR_REVIEW` | Not accepted for review |
+| `quorum_met == False` | Insufficient verifiers |
+| `threshold_met == False` | Consensus score too low |
+| `evidence_present == False` | No evidence provided |
+| `verification_complete == True` | Truth boundary violation |
+| `cabr_ready == True` | Truth boundary violation |
+| `payout_ready == True` | Truth boundary violation |
+| Missing `receipt_id` | Incomplete identity |
+| Missing `job_id` | Incomplete identity |
+| Missing `tenant_id` | Incomplete identity |
+
+### 7.3 Stop Condition Hierarchy
+
+```
+1. Truth boundary violation -> BLOCKED (highest priority)
+2. Decision != ACCEPTED_FOR_REVIEW -> NOT_ROC_CANDIDATE
+3. Quorum not met -> PENDING_QUORUM
+4. Threshold not met -> PENDING_CONSENSUS
+5. Evidence not present -> INSUFFICIENT_EVIDENCE
+6. All conditions pass -> ROC_CANDIDATE
+```
+
+---
+
+## 8. Anti-Claims / WSP 97 Labels
+
+### 8.1 Required Labels for ROC_CANDIDATE
+
+Any ROC_CANDIDATE derivation MUST include these labels:
+
+```yaml
+DOCS_ONLY: This derivation is specification only, not implementation
+REVIEW_ONLY: ROC_CANDIDATE is review status, not execution authority
+ROC_CANDIDATE_ONLY: State is ROC_CANDIDATE, not any downstream state
+NOT_ROC_VALIDATED: ROC ratio has not been computed or validated
+NOT_CABR_READY: External verification has not been performed
+NOT_PAYOUT_READY: Payout engine has not approved
+NO_DAO_ACTIVATION: DAO governance is not activated
+NO_EXTERNAL_ATTESTATION_REQUIRED: Internal sovereign consensus only
+NO_RUNTIME_DERIVATION: No runtime derivation is implemented
+```
+
+### 8.2 Truth Field Requirements
+
+All ROC_CANDIDATE records MUST maintain:
+
+```python
+verification_complete = False  # Always
+cabr_ready = False             # Always
+payout_ready = False           # Always
+```
+
+### 8.3 Anti-Claim Assertions (Spec Only)
+
+```python
+# SPEC ONLY - NOT FOR IMPLEMENTATION
+def assert_roc_candidate_anti_claims(record: CABRConsensusRecord) -> None:
+    """
+    Assert all anti-claims are satisfied.
+    
+    Raises AssertionError if any anti-claim is violated.
+    """
+    # Truth boundary anti-claims
+    assert record.verification_complete == False, "ANTI-CLAIM VIOLATION: verification_complete must be False"
+    assert record.cabr_ready == False, "ANTI-CLAIM VIOLATION: cabr_ready must be False"
+    assert record.payout_ready == False, "ANTI-CLAIM VIOLATION: payout_ready must be False"
+    
+    # State anti-claims (implicit)
+    # ROC_CANDIDATE does NOT imply any downstream state
+```
+
+---
+
+## 9. Proposed Future Interface
+
+### 9.1 Proposed ROCCandidateResult (Spec Only)
+
+```python
+# SPEC ONLY - NOT FOR IMPLEMENTATION
+@dataclass
+class ROCCandidateResult:
+    """
+    Result of ROC_CANDIDATE derivation check.
+    
+    WSP 97 Critical:
+      This result is REVIEW_ONLY. It does NOT imply:
+        - verification_complete=True
+        - cabr_ready=True
+        - payout_ready=True
+        - ROC_VALIDATED
+        - CABR_READY
+        - PAYOUT_READY
+        - DAO_ACTIVATION
+    """
+    
+    # Derivation result
+    is_roc_candidate: bool
+    """True if record qualifies as ROC_CANDIDATE."""
+    
+    blocking_condition: Optional[str]
+    """If not ROC_CANDIDATE, the reason code."""
+    
+    # Source reference
+    record_id: str
+    """CABRConsensusRecord.record_id reference."""
+    
+    # Audit trail
+    derived_at: datetime
+    """When derivation was performed."""
+    
+    # WSP 97 Required Fields
+    wsp97_labels: List[str]
+    """Required anti-claim labels."""
+    
+    truth_boundary: Dict[str, bool]
+    """All must be False."""
+```
+
+### 9.2 Proposed Interface Location
+
+```
+modules/communication/moltbot_bridge/src/roc_candidate_derivation.py (FUTURE)
+```
+
+### 9.3 Proposed Test Location
+
+```
+modules/communication/moltbot_bridge/tests/test_roc_candidate_derivation.py (FUTURE)
+```
+
+---
+
+## 10. Implementation Readiness Verdict
+
+### 10.1 Readiness Assessment
+
+| Criterion | Status | Notes |
+|-----------|--------|-------|
+| CABR inputs available | READY | Phase 10 provides all inputs |
+| WSP 97 enforcement | READY | 15+ test files verify |
+| Truth field protection | READY | All fields locked to False |
+| Quorum/threshold logic | READY | Implemented in Phase 2 |
+| Evidence verification | READY | Implemented in Phase 1 |
+| Persistence layer | READY | Phase 4 provides SQLite |
+| Export layer | READY | Phase 8-9 provide JSON/Markdown |
+| ROC state machine | NOT READY | No formal WSP annex |
+| ROC_CANDIDATE interface | NOT READY | Interface not implemented |
+| ROC_CANDIDATE tests | NOT READY | Tests not written |
+
+### 10.2 Implementation Blockers
+
+| Blocker | Severity | Resolution |
+|---------|----------|------------|
+| No WSP annex for ROC states | P0 | Create WSP_100 Section 11 annex |
+| No ROCCandidateResult interface | P1 | Implement after WSP annex |
+| No test suite | P1 | Write after interface |
+
+### 10.3 Final Verdict
+
+**IMPLEMENTATION READINESS: BLOCKED**
+
+ROC_CANDIDATE derivation is **fully specifiable** from existing CABR Phase 10 outputs, but implementation is **blocked** until:
+
+1. **WSP_100_ROC_STATE_ANNEX_SPEC** is created (P0)
+2. **ROCCandidateResult interface** is implemented (P1)
+3. **Test suite** is written (P1)
+
+The derivation logic is trivial once the WSP annex exists -- it is a simple boolean check over existing CABRConsensusRecord fields.
+
+---
+
+## 11. Recommended Next Slice
+
+### 11.1 Immediate Next Work
+
+| Priority | Slice | Purpose | Blocked By |
+|----------|-------|---------|------------|
+| P0 | `WSP_100_ROC_STATE_ANNEX_SPEC` | Add ROC state machine section to WSP 100 | Nothing |
+| P1 | `ROC_CANDIDATE_INTERFACE_IMPL` | Implement ROCCandidateResult | WSP annex |
+| P1 | `ROC_CANDIDATE_TESTS` | Write test suite | Interface |
+| P2 | `ROC_VALIDATED_DERIVATION_SPEC` | Spec ROC_VALIDATED from ROC_CANDIDATE | ROC_CANDIDATE impl |
+
+### 11.2 Default Recommendation
+
+**Next slice**: `WSP_100_ROC_STATE_ANNEX_SPEC`
+
+Purpose: Add formal ROC state machine definition to WSP 100 Section 11.
+
+Deliverables:
+1. ROCState enum definition (docs)
+2. ROC_CANDIDATE derivation criteria (docs)
+3. Transition guards (docs)
+4. Anti-claim labels (docs)
+5. Interface specification (docs)
+
+---
+
+## 12. Audit Questions Answered
+
+### Q1: Which CABR Phase 1-10 outputs can safely feed ROC_CANDIDATE?
+
+**Answer**: CABRConsensusRecord from Phase 3 (finalization) provides all necessary fields:
+- `decision` (must be `ACCEPTED_FOR_REVIEW`)
+- `quorum_met` (must be `True`)
+- `threshold_met` (must be `True`)
+- `evidence_present` (must be `True`)
+- Truth boundary fields (all must be `False`)
+
+Phase 10 pipeline result aggregates these records with persistence and export.
+
+### Q2: Is accepted-for-review sufficient, or only a prerequisite?
+
+**Answer**: `ACCEPTED_FOR_REVIEW` is **necessary but not sufficient**. Additional conditions required:
+- `quorum_met == True`
+- `threshold_met == True`
+- `evidence_present == True`
+- All truth boundary fields `== False`
+
+### Q3: What minimum evidence should be required?
+
+**Answer**: Minimum evidence for ROC_CANDIDATE:
+- `receipt_id` (identity)
+- `job_id` (identity)
+- `tenant_id` (identity)
+- `evidence_present == True`
+- `evidence_count >= 1`
+
+### Q4: Is quorum accepted-for-review required?
+
+**Answer**: YES. `quorum_met == True` is a mandatory condition. Records with `decision == PENDING_QUORUM` do not qualify.
+
+### Q5: Is lifecycle completeness required?
+
+**Answer**: NO. Lifecycle completeness (all 7 stages present) is observability-only. ROC_CANDIDATE can be derived from consensus record alone.
+
+### Q6: Is persistence required?
+
+**Answer**: NO. Persistence is optional for derivation. ROC_CANDIDATE can be derived from in-memory consensus record. However, for audit trail, persistence is recommended.
+
+### Q7: Is report export required?
+
+**Answer**: NO. Export is observability-only. ROC_CANDIDATE derivation does not depend on export.
+
+### Q8: What should block ROC_CANDIDATE?
+
+**Answer**: See Section 7.2 (Stop Conditions). Primary blockers:
+- Truth boundary violations
+- Decision not ACCEPTED_FOR_REVIEW
+- Quorum not met
+- Threshold not met
+- Evidence not present
+- Missing identity fields
+
+### Q9: What test cases would be required before implementation?
+
+**Answer**: Required test cases:
+1. Happy path: Record with all conditions met -> ROC_CANDIDATE
+2. Decision rejected -> NOT ROC_CANDIDATE
+3. Quorum not met -> NOT ROC_CANDIDATE
+4. Threshold not met -> NOT ROC_CANDIDATE
+5. Evidence not present -> NOT ROC_CANDIDATE
+6. Truth boundary violation (any) -> BLOCKED
+7. Missing receipt_id -> NOT ROC_CANDIDATE
+8. Missing job_id -> NOT ROC_CANDIDATE
+9. Anti-claim label verification
+10. Derivation idempotency
+
+---
+
+## Appendix A: Source Files Examined
+
+| File | Lines | Purpose |
+|------|-------|---------|
+| `cabr_consensus_pipeline.py` | 1123 | Phase 10 pipeline composer |
+| `cabr_consensus_finalizer.py` | 1205 | Consensus finalization |
+| `cabr_lifecycle_query.py` | 475 | Lifecycle query integration |
+| `cabr_store_export.py` | 551 | Store-export orchestration |
+| `cabr_lifecycle_report_export.py` | 612 | Report export with WSP 97 labels |
+| `WSP_100_DAE_SmartDAO_Escalation_Protocol.md` | 621 | DAO tier model |
+| `ROC_STATE_MACHINE_AUDIT_PHASE1.md` | 650 | ROC state machine spec |
+| `SOVEREIGN_AGENT_CONSENSUS_ROC_DAO_READINESS_AUDIT.md` | 460 | Master synthesis |
+| `SACRDA_CABR_FINALIZATION_SYNTHESIS_AUDIT.md` | 463 | CABR finalization synthesis |
+
+## Appendix B: Test Coverage Verification
+
+```bash
+# Pipeline tests
+python -m pytest modules/communication/moltbot_bridge/tests/test_cabr_consensus_pipeline.py -q
+# Result: 35 passed
+
+# Store export tests
+python -m pytest modules/communication/moltbot_bridge/tests/test_cabr_store_export.py -q
+# Result: 65 passed
+```
+
+---
+
+## WSP 97 Verdict
+
+### Audit Claims
+
+| Claim | Status | Evidence |
+|-------|--------|----------|
+| CABR inputs available for ROC_CANDIDATE | VERIFIED | CABRConsensusRecord has all fields |
+| Derivation logic specifiable | VERIFIED | Boolean check over existing fields |
+| Implementation ready | BLOCKED | WSP annex not created |
+| Truth boundaries enforced | VERIFIED | 15+ test files |
+| Anti-claims documented | VERIFIED | Section 8 of this audit |
+
+### Final Assessment
+
+**ROC_CANDIDATE DERIVATION: SPECIFIABLE, NOT IMPLEMENTABLE**
+
+The specification is complete. Implementation awaits WSP_100_ROC_STATE_ANNEX_SPEC.
+
+---
+
+*Audit performed by Worker W9 under WSP 00/50/97 truth boundaries.*
+
+Worker-Lane: W9  
+Slice: ROC_CANDIDATE_DERIVATION_AUDIT_PHASE1


### PR DESCRIPTION
## Summary
- Adds Phase 1 audit for ROC candidate derivation methodology
- Documents consensus readiness assessment for sovereign agent architecture
- Part of the SACRDA (Sovereign Agent Consensus ROC/DAO Readiness Audit) series

## Test plan
- [x] Audit document follows established audit format
- [x] Cross-references existing consensus documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)