### PR TITLE
feat(antifafm): implement preflight relocation from main.py startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -1251,11 +1251,13 @@ def main():
 
     bootstrap_runtime_dae_launches()
 
-    # Auto-start antifaFM broadcaster (default ON, disable with ANTIFAFM_AUTO_START=0)
+    # Auto-start antifaFM broadcaster (default OFF per ANTIFAFM_PREFLIGHT_RELOCATION_AUDIT_20260516)
+    # Enable with ANTIFAFM_AUTO_START=1 for legacy behavior.
+    # Preferred: Use YouTube DAE menu option 1 (preflight) or option 10 (broadcaster control).
     # NOTE: Uses OBS mode by default - OBS handles streaming, script handles chat/schemas
     # Stream runs while main.py is running. Exit menu = stream stops.
     antifafm_auto_started = False
-    if os.getenv("ANTIFAFM_AUTO_START", "1") == "1":
+    if os.getenv("ANTIFAFM_AUTO_START", "0") == "1":
         # Launch OBS first (like LM Studio auto-launches for YT DAE)
         from modules.infrastructure.dependency_launcher.src.dae_dependencies import launch_obs, is_obs_running
 

--- a/modules/infrastructure/cli/src/youtube_menu.py
+++ b/modules/infrastructure/cli/src/youtube_menu.py
@@ -34,6 +34,17 @@ from modules.communication.headless_video_orchestrator.src.oss_adapters import (
     ExternalToolError,
 )
 
+# antifaFM preflight (ANTIFAFM_PREFLIGHT_RELOCATION_AUDIT_20260516)
+try:
+    from modules.platform_integration.antifafm_broadcaster.src.preflight import (
+        preflight_check_for_menu,
+        run_preflight,
+        format_preflight_status,
+    )
+    PREFLIGHT_AVAILABLE = True
+except ImportError:
+    PREFLIGHT_AVAILABLE = False
+
 logger = logging.getLogger(__name__)
 
 
@@ -169,6 +180,19 @@ def handle_youtube_menu(
         # 1.1 Live Chat Monitor DAE - Direct launch with 012 profile (ADR-013)
         print("\n[DAE] Live Chat Monitor - 012 Operational Profile")
         print("=" * 60)
+
+        # === PREFLIGHT CHECK (ANTIFAFM_PREFLIGHT_RELOCATION_AUDIT_20260516) ===
+        # Informational: shows antifaFM/OBS status before starting monitor
+        if PREFLIGHT_AVAILABLE:
+            ready, status_msg = preflight_check_for_menu(
+                require_obs=False,  # Non-strict: OBS is optional for monitor
+                require_youtube=False,
+            )
+            print("\n" + status_msg)
+            print("=" * 60)
+            if not ready:
+                print("[INFO] Monitor will start. For antifaFM streaming, use option 10.")
+            print()
 
         env_overrides = {
             "YT_ENGAGEMENT_TEMPO": "012",
@@ -734,6 +758,22 @@ def _handle_antifafm_broadcaster_menu() -> None:
     print("Streams antifaFM.com radio to YouTube Live via FFmpeg")
     print("Icecast -> FFmpeg -> RTMP -> YouTube Live")
     print("=" * 60)
+
+    # === PREFLIGHT CHECK (ANTIFAFM_PREFLIGHT_RELOCATION_AUDIT_20260516) ===
+    # Show OBS/YouTube readiness before broadcaster menu
+    if PREFLIGHT_AVAILABLE:
+        ready, status_msg = preflight_check_for_menu(
+            require_obs=True,  # Strict: OBS required for broadcaster
+            require_youtube=True,
+        )
+        print("\n" + status_msg)
+        print("=" * 60)
+        if not ready:
+            print("[WARN] Not all components ready. Broadcasting may fail.")
+            proceed = input("Continue anyway? [Y/n]: ").strip().lower()
+            if proceed == 'n':
+                return
+        print()
 
     try:
         from modules.platform_integration.antifafm_broadcaster.src import AntifaFMBroadcaster

--- a/modules/platform_integration/antifafm_broadcaster/INTERFACE.md
+++ b/modules/platform_integration/antifafm_broadcaster/INTERFACE.md
@@ -2,6 +2,48 @@
 
 ## Public API
 
+### Preflight Module (NEW - V3.4.0)
+
+Side-effect-free readiness checks for antifaFM/OBS components.
+
+```python
+from modules.platform_integration.antifafm_broadcaster.src.preflight import (
+    run_preflight,
+    format_preflight_status,
+    preflight_check_for_menu,
+    AntifaFMPreflightResult,
+)
+
+# Full preflight check (side-effect-free)
+result = run_preflight(
+    obs_host="localhost",
+    obs_port=4455,
+    require_obs=True,      # Fail if OBS not reachable
+    require_youtube=True,  # Fail if YouTube not configured
+)
+
+# Check result
+result.ready              # bool: all checks passed
+result.obs_available      # bool: OBS WebSocket reachable
+result.youtube_api_configured  # bool: API keys/secrets found
+result.ffmpeg_available   # bool: ffmpeg in PATH
+result.broadcaster_running  # bool: already running
+result.errors             # list: blocking issues
+result.warnings           # list: non-blocking issues
+
+# Format for display
+print(format_preflight_status(result))
+
+# Convenience for menu integration
+ready, status_msg = preflight_check_for_menu(require_obs=False)
+```
+
+**Contract**: `run_preflight()` has NO SIDE EFFECTS:
+- Does NOT start OBS
+- Does NOT spawn FFmpeg processes  
+- Does NOT create YouTube broadcasts
+- Does NOT connect to WebSocket (only TCP probe)
+
 ### AntifaFMBroadcaster
 
 Main DAE class for streaming radio to YouTube Live.

--- a/modules/platform_integration/antifafm_broadcaster/ModLog.md
+++ b/modules/platform_integration/antifafm_broadcaster/ModLog.md
@@ -1,5 +1,51 @@
 # antifaFM Broadcaster - ModLog
 
+## V3.4.0 - Preflight Relocation (2026-05-16)
+
+**Slice**: `ANTIFAFM_PREFLIGHT_RELOCATION_IMPL_PHASE1`
+**Branch**: `feat/antifafm-preflight-relocation`
+**Worker**: W1
+**WSP Lock**: WSP_00, WSP_50, WSP_97, WSP_22
+
+**Context**: Per `ANTIFAFM_PREFLIGHT_RELOCATION_AUDIT_20260516`, the `ANTIFAFM_AUTO_START` block in `main.py` caused OBS/streaming side effects at application startup. These should be deferred to explicit user action via YouTube DAE menu.
+
+**Changes**:
+
+1. **Created `src/preflight.py`** (~200 lines):
+   - `AntifaFMPreflightResult` dataclass for status
+   - `run_preflight()` - side-effect-free readiness checks
+   - `format_preflight_status()` - human-readable output
+   - `preflight_check_for_menu()` - convenience for CLI integration
+   - Checks: OBS WebSocket reachability, YouTube API config, FFmpeg, stream config, broadcaster state
+
+2. **Disabled auto-start in `main.py`**:
+   - Changed default from `ANTIFAFM_AUTO_START=1` to `ANTIFAFM_AUTO_START=0`
+   - Added comment referencing audit document
+   - Legacy behavior available via `ANTIFAFM_AUTO_START=1`
+
+3. **Added preflight to YouTube DAE menu**:
+   - Option 1 (Live Chat Monitor): Shows informational preflight status before `monitor_youtube()`
+   - Option 10 (antifaFM Broadcaster): Shows strict preflight with continue/abort prompt
+
+**Target Behavior Achieved**:
+- NO antifaFM/OBS side effects at `main.py` startup (default)
+- Preflight checks show status in YouTube DAE menu
+- Explicit action required to start broadcaster
+
+**Files Modified**:
+- `main.py` - Disabled auto-start default
+- `modules/infrastructure/cli/src/youtube_menu.py` - Added preflight integration
+- `modules/platform_integration/antifafm_broadcaster/src/preflight.py` - NEW
+- `modules/platform_integration/antifafm_broadcaster/INTERFACE.md` - Added preflight API
+- `modules/platform_integration/antifafm_broadcaster/ModLog.md` - This entry
+
+**WSP Compliance**:
+- WSP 97: Truth boundaries (no false side-effect claims)
+- WSP 50: Pre-action verification (preflight checks before action)
+- WSP 22: ModLog updated
+
+---
+
 ## V3.3.4 - AF1/AF2 briefing persistence (2026-04-19)
 
 **Slices**: `AF1_ANTIFAFM_INTERNAL_OPERATIONAL_READINESS_AUDIT_PHASE1`, `AF2_ANTIFAFM_OBS_FAILURE_ESCALATION_SPEC_PHASE1`

--- a/modules/platform_integration/antifafm_broadcaster/src/preflight.py
+++ b/modules/platform_integration/antifafm_broadcaster/src/preflight.py
@@ -1,0 +1,270 @@
+"""antifaFM Preflight Module
+
+Side-effect-free preflight checks for antifaFM/OBS readiness.
+Per ANTIFAFM_PREFLIGHT_RELOCATION_AUDIT_20260516.
+
+WSP References:
+- WSP 97: Truth Boundaries (no false claims)
+- WSP 50: Pre-Action Verification
+"""
+
+import os
+import socket
+from dataclasses import dataclass, field
+from typing import Optional
+from pathlib import Path
+
+
+@dataclass
+class AntifaFMPreflightResult:
+    """Result of preflight check - NO SIDE EFFECTS."""
+
+    # Overall status
+    ready: bool = False
+
+    # Component status
+    obs_available: bool = False
+    obs_websocket_reachable: bool = False
+    stream_config_valid: bool = False
+    youtube_api_configured: bool = False
+    ffmpeg_available: bool = False
+
+    # Runtime state (read-only checks)
+    broadcaster_running: bool = False
+    active_stream_id: Optional[str] = None
+
+    # Diagnostics
+    errors: list = field(default_factory=list)
+    warnings: list = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Serialize for logging/display."""
+        return {
+            "ready": self.ready,
+            "obs_available": self.obs_available,
+            "obs_websocket_reachable": self.obs_websocket_reachable,
+            "stream_config_valid": self.stream_config_valid,
+            "youtube_api_configured": self.youtube_api_configured,
+            "ffmpeg_available": self.ffmpeg_available,
+            "broadcaster_running": self.broadcaster_running,
+            "active_stream_id": self.active_stream_id,
+            "errors": self.errors,
+            "warnings": self.warnings,
+        }
+
+
+def _check_obs_websocket_reachable(
+    host: str = "localhost",
+    port: int = 4455,
+    timeout: float = 1.0
+) -> bool:
+    """Check if OBS WebSocket port is reachable (TCP connect only).
+
+    NO SIDE EFFECTS - just checks if port accepts connections.
+    Does NOT authenticate or send commands.
+    """
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(timeout)
+        result = sock.connect_ex((host, port))
+        sock.close()
+        return result == 0
+    except Exception:
+        return False
+
+
+def _check_ffmpeg_available() -> bool:
+    """Check if ffmpeg is in PATH.
+
+    NO SIDE EFFECTS - just checks PATH/existence.
+    """
+    import shutil
+    return shutil.which("ffmpeg") is not None
+
+
+def _check_youtube_api_configured() -> bool:
+    """Check if YouTube API credentials are configured.
+
+    NO SIDE EFFECTS - checks file existence and env vars.
+    """
+    # Check for client secrets file
+    secrets_paths = [
+        Path("client_secrets.json"),
+        Path("modules/platform_integration/video_comments/client_secrets.json"),
+        Path.home() / ".config" / "youtube" / "client_secrets.json",
+    ]
+    has_secrets = any(p.exists() for p in secrets_paths)
+
+    # Check for API key in environment
+    has_api_key = bool(os.environ.get("YOUTUBE_API_KEY"))
+
+    return has_secrets or has_api_key
+
+
+def _check_stream_config_valid() -> bool:
+    """Check if stream configuration exists and is valid.
+
+    NO SIDE EFFECTS - reads config files only.
+    """
+    config_paths = [
+        Path("antifafm_config.json"),
+        Path("modules/platform_integration/antifafm_broadcaster/config/stream_config.json"),
+    ]
+
+    for path in config_paths:
+        if path.exists():
+            try:
+                import json
+                with open(path, "r") as f:
+                    config = json.load(f)
+                # Minimal validation - has required keys
+                if "stream_key" in config or "broadcast_id" in config:
+                    return True
+            except (json.JSONDecodeError, IOError):
+                continue
+
+    # Also check environment for stream key
+    return bool(os.environ.get("YOUTUBE_STREAM_KEY"))
+
+
+def _check_broadcaster_running() -> tuple[bool, Optional[str]]:
+    """Check if antifaFM broadcaster is currently running.
+
+    NO SIDE EFFECTS - reads state files only.
+
+    Returns:
+        (is_running, active_stream_id)
+    """
+    state_file = Path("antifafm_state.json")
+    if state_file.exists():
+        try:
+            import json
+            with open(state_file, "r") as f:
+                state = json.load(f)
+            is_running = state.get("running", False)
+            stream_id = state.get("broadcast_id") or state.get("stream_id")
+            return is_running, stream_id
+        except (json.JSONDecodeError, IOError):
+            pass
+    return False, None
+
+
+def run_preflight(
+    obs_host: str = "localhost",
+    obs_port: int = 4455,
+    require_obs: bool = True,
+    require_youtube: bool = True,
+) -> AntifaFMPreflightResult:
+    """Run preflight checks for antifaFM readiness.
+
+    THIS FUNCTION HAS NO SIDE EFFECTS.
+    - Does NOT start OBS
+    - Does NOT spawn FFmpeg processes
+    - Does NOT create YouTube broadcasts
+    - Does NOT connect to WebSocket (only TCP probe)
+
+    Args:
+        obs_host: OBS WebSocket host
+        obs_port: OBS WebSocket port
+        require_obs: If True, OBS must be available for ready=True
+        require_youtube: If True, YouTube API must be configured for ready=True
+
+    Returns:
+        AntifaFMPreflightResult with status and diagnostics
+    """
+    result = AntifaFMPreflightResult()
+
+    # Check OBS WebSocket
+    result.obs_websocket_reachable = _check_obs_websocket_reachable(obs_host, obs_port)
+    if result.obs_websocket_reachable:
+        result.obs_available = True
+    else:
+        if require_obs:
+            result.errors.append(f"OBS WebSocket not reachable at {obs_host}:{obs_port}")
+        else:
+            result.warnings.append(f"OBS WebSocket not reachable at {obs_host}:{obs_port}")
+
+    # Check FFmpeg
+    result.ffmpeg_available = _check_ffmpeg_available()
+    if not result.ffmpeg_available:
+        result.warnings.append("FFmpeg not found in PATH")
+
+    # Check YouTube API
+    result.youtube_api_configured = _check_youtube_api_configured()
+    if not result.youtube_api_configured:
+        if require_youtube:
+            result.errors.append("YouTube API not configured (no client_secrets.json or YOUTUBE_API_KEY)")
+        else:
+            result.warnings.append("YouTube API not configured")
+
+    # Check stream config
+    result.stream_config_valid = _check_stream_config_valid()
+    if not result.stream_config_valid:
+        result.warnings.append("No stream configuration found")
+
+    # Check broadcaster state
+    result.broadcaster_running, result.active_stream_id = _check_broadcaster_running()
+    if result.broadcaster_running:
+        result.warnings.append(f"Broadcaster already running (stream: {result.active_stream_id})")
+
+    # Determine overall readiness
+    result.ready = (
+        (not require_obs or result.obs_available) and
+        (not require_youtube or result.youtube_api_configured) and
+        not result.broadcaster_running and
+        len(result.errors) == 0
+    )
+
+    return result
+
+
+def format_preflight_status(result: AntifaFMPreflightResult) -> str:
+    """Format preflight result for display.
+
+    Returns human-readable status string.
+    """
+    lines = []
+
+    status = "READY" if result.ready else "NOT READY"
+    lines.append(f"antifaFM Preflight: {status}")
+    lines.append("-" * 40)
+
+    lines.append(f"  OBS WebSocket:     {'OK' if result.obs_websocket_reachable else 'NOT REACHABLE'}")
+    lines.append(f"  YouTube API:       {'CONFIGURED' if result.youtube_api_configured else 'NOT CONFIGURED'}")
+    lines.append(f"  FFmpeg:            {'AVAILABLE' if result.ffmpeg_available else 'NOT FOUND'}")
+    lines.append(f"  Stream Config:     {'VALID' if result.stream_config_valid else 'NOT FOUND'}")
+    lines.append(f"  Broadcaster:       {'RUNNING' if result.broadcaster_running else 'STOPPED'}")
+
+    if result.active_stream_id:
+        lines.append(f"  Active Stream:     {result.active_stream_id}")
+
+    if result.errors:
+        lines.append("")
+        lines.append("Errors:")
+        for err in result.errors:
+            lines.append(f"  - {err}")
+
+    if result.warnings:
+        lines.append("")
+        lines.append("Warnings:")
+        for warn in result.warnings:
+            lines.append(f"  - {warn}")
+
+    return "\n".join(lines)
+
+
+# Convenience function for menu integration
+def preflight_check_for_menu(
+    require_obs: bool = False,
+    require_youtube: bool = False,
+) -> tuple[bool, str]:
+    """Run preflight and return (ready, status_message) for menu display.
+
+    Default: non-strict mode (warnings instead of errors).
+    Call with require_obs=True for strict OBS checks.
+    """
+    result = run_preflight(
+        require_obs=require_obs,
+        require_youtube=require_youtube,
+    )
+    return result.ready, format_preflight_status(result)


### PR DESCRIPTION
## Summary

Per `ANTIFAFM_PREFLIGHT_RELOCATION_AUDIT_20260516` (#601):

- Add `preflight.py` with side-effect-free readiness checks for OBS/YouTube/FFmpeg
- Disable `ANTIFAFM_AUTO_START` default (0 instead of 1) - no OBS/streaming at startup
- Add preflight integration to YouTube DAE menu options 1 and 10
- Document preflight API in INTERFACE.md

## Test plan

- [x] `py_compile` passes on all modified files
- [x] `pytest modules/platform_integration/antifafm_broadcaster/tests/` - 56 passed, 14 skipped (pre-existing test issues unrelated to this PR)
- [ ] Manual: Start main.py, verify no OBS/antifaFM side effects at startup
- [ ] Manual: Select YouTube DAE option 1, verify preflight status displays
- [ ] Manual: Select YouTube DAE option 10, verify preflight check with prompt

Worker-Lane: W1
Slice: ANTIFAFM_PREFLIGHT_RELOCATION_IMPL_PHASE1

🤖 Generated with [Claude Code](https://claude.com/claude-code)