### PR TITLE
docs(security): add DEP-SECURITY preflight audit spec

### DIFF
--- a/docs/audits/security/DEP_SECURITY_PREFLIGHT_AUDIT_20260517.md
+++ b/docs/audits/security/DEP_SECURITY_PREFLIGHT_AUDIT_20260517.md
@@ -1,0 +1,119 @@
+# DEP-SECURITY Preflight Audit
+
+**Slice**: `DEP_SECURITY_PREFLIGHT_AUDIT_20260517`
+**Worker**: W10
+**Date**: 2026-05-17
+**Mode**: Audit / spec only
+**WSP Lock**: WSP_00 → WSP_97 → WSP_50 → WSP_64 → WSP_91
+
+---
+
+## WSP 97 Labels
+
+| Label | Status |
+|-------|--------|
+| `SPEC_ONLY` | Applied |
+| `NO_RUNTIME_MUTATION` | Applied |
+| `NO_DEPENDENCY_UPDATES` | Applied |
+
+**This PR does not update any dependencies.**
+
+---
+
+## 1. Source Artifact
+
+| Field | Value |
+|-------|-------|
+| **Path** | `alerts/preflight/dep_security_20260515T222604Z.json` |
+| **Timestamp** | 2026-05-15T22:26:04Z |
+| **Tool** | Preflight dependency security scanner |
+
+**Note**: Artifact contents not dumped to avoid exposing package versions or CVE details in public audit.
+
+---
+
+## 2. Summary Counts
+
+| Severity | Count |
+|----------|-------|
+| **Critical** | 4 |
+| **High** | 7 |
+| **Unknown** | 14 |
+| **Total** | 25 |
+
+Original signal:
+```
+DEP-SECURITY preflight=FAIL critical=4 high=7 unknown=14
+```
+
+---
+
+## 3. Classification Plan
+
+Each finding must be classified before remediation:
+
+| Classification | Description | Action |
+|----------------|-------------|--------|
+| **Real Vulnerability** | Confirmed CVE affecting runtime code path | Prioritize update/patch |
+| **False Positive** | CVE does not apply (wrong platform, unused code path) | Document and suppress |
+| **Transitive Dependency** | Vulnerability in indirect dependency | Update parent or pin safe version |
+| **Dev-Only Dependency** | Affects only development/test tooling | Lower priority, document risk |
+| **Requires Package Update** | Fix available in newer version | Schedule update with compatibility check |
+| **Requires Risk Acceptance** | No fix available or update breaks compatibility | Document accepted risk with expiration |
+
+---
+
+## 4. Classification Table Template
+
+| Finding ID | Package | Severity | Classification | Notes |
+|------------|---------|----------|----------------|-------|
+| TBD-001 | TBD | Critical | TBD | Pending investigation |
+| TBD-002 | TBD | Critical | TBD | Pending investigation |
+| TBD-003 | TBD | Critical | TBD | Pending investigation |
+| TBD-004 | TBD | Critical | TBD | Pending investigation |
+| TBD-005 | TBD | High | TBD | Pending investigation |
+| TBD-006 | TBD | High | TBD | Pending investigation |
+| TBD-007 | TBD | High | TBD | Pending investigation |
+| TBD-008 | TBD | High | TBD | Pending investigation |
+| TBD-009 | TBD | High | TBD | Pending investigation |
+| TBD-010 | TBD | High | TBD | Pending investigation |
+| TBD-011 | TBD | High | TBD | Pending investigation |
+| TBD-012..025 | TBD | Unknown | TBD | Pending investigation |
+
+---
+
+## 5. Proposed Worker Lanes
+
+| Lane | Role | Scope |
+|------|------|-------|
+| **W1/W2** | Dependency remediation audit | Investigate each finding, propose classification, prepare update PRs |
+| **W10** | PR manager | Review/merge remediation PRs after classification approval |
+| **Security Reviewer** (optional) | Risk acceptance | Approve risk acceptance classifications |
+
+---
+
+## 6. Next Slice
+
+**`DEP_SECURITY_REMEDIATION_PHASE1`**
+
+Prerequisites:
+1. This audit merged
+2. Artifact inspected (W1/W2)
+3. Classifications assigned
+4. Risk acceptance decisions documented
+
+---
+
+## 7. WSP 97 Truth Table
+
+| Claim | Status |
+|-------|--------|
+| No dependencies updated in this PR | ENFORCED |
+| No runtime mutation | ENFORCED |
+| Artifact path documented | VERIFIED |
+| Classification plan defined | VERIFIED |
+| Worker lanes assigned | VERIFIED |
+
+---
+
+*Audit created by Worker W10 under WSP_00 → WSP_97 → WSP_50 → WSP_64 → WSP_91.*


### PR DESCRIPTION
## Summary

Documents the DEP-SECURITY preflight failure for remediation planning.

- **Critical**: 4
- **High**: 7
- **Unknown**: 14
- **Total**: 25 findings

## WSP 97 Labels

- `SPEC_ONLY`
- `NO_RUNTIME_MUTATION`
- `NO_DEPENDENCY_UPDATES`

## Contents

- Source artifact path (no secrets exposed)
- Classification plan template
- Worker lane assignments (W1/W2 remediation, W10 PR manager)
- Next slice: `DEP_SECURITY_REMEDIATION_PHASE1`

## Scope

**This PR does not update any dependencies.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)