### PR TITLE
docs(wsp): add WSP-FRAMEWORK drift audit spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -350,6 +350,8 @@ docs/audits/*
 !docs/audits/consensus/**
 !docs/audits/architecture/
 !docs/audits/architecture/**
+!docs/audits/wsp/
+!docs/audits/wsp/**
 docs/sessions/
 
 # WSP agentic awakening runtime state (changes every session)

--- a/docs/audits/wsp/WSP_FRAMEWORK_DRIFT_AUDIT_20260517.md
+++ b/docs/audits/wsp/WSP_FRAMEWORK_DRIFT_AUDIT_20260517.md
@@ -1,0 +1,133 @@
+# WSP Framework Drift Audit
+
+**Slice**: `WSP_FRAMEWORK_DRIFT_AUDIT_20260517`
+**Worker**: W10
+**Date**: 2026-05-17
+**Mode**: Audit / spec only
+**WSP Lock**: WSP_00 → WSP_97 → WSP_50 → WSP_64
+
+---
+
+## WSP 97 Labels
+
+| Label | Status |
+|-------|--------|
+| `SPEC_ONLY` | Applied |
+| `NO_RUNTIME_MUTATION` | Applied |
+
+**This PR does not modify any WSP protocol files.**
+
+---
+
+## 1. Source Signal
+
+Original preflight signal:
+```
+WSP-FRAMEWORK preflight=FAIL drift=5 framework_only=1 knowledge_only=0 index_issues=1
+```
+
+---
+
+## 2. Drift Summary
+
+| Metric | Count |
+|--------|-------|
+| **Framework-only** | 1 |
+| **Knowledge-only** | 0 |
+| **Drifted (content mismatch)** | 5 |
+| **Index issues** | 1 |
+| **Total** | 7 |
+
+---
+
+## 3. Affected WSPs
+
+### 3.1 Framework-Only (Missing from Knowledge)
+
+| WSP | File | Issue |
+|-----|------|-------|
+| WSP 106 | `WSP_106_FoundUp_API_Gateway_Protocol.md` | Exists in `WSP_framework/src/` but not in `WSP_knowledge/src/` |
+
+**Sync Decision Required**: Framework → Knowledge (copy) or Knowledge → Framework (delete)?
+
+### 3.2 Content Drift (Framework ≠ Knowledge)
+
+| WSP | Framework File | Knowledge File | Issue |
+|-----|----------------|----------------|-------|
+| WSP 102 | `WSP_framework/src/WSP_102_*.md` | `WSP_knowledge/src/WSP_102_*.md` | Content mismatch |
+| WSP 61 | `WSP_framework/src/WSP_61_*.md` | `WSP_knowledge/src/WSP_61_*.md` | Content mismatch |
+| WSP 96 | `WSP_framework/src/WSP_96_*.md` | `WSP_knowledge/src/WSP_96_*.md` | Content mismatch |
+| WSP 97 | `WSP_framework/src/WSP_97_*.md` | `WSP_knowledge/src/WSP_97_*.md` | Content mismatch |
+| WSP 99 | `WSP_framework/src/WSP_99_*.md` | `WSP_knowledge/src/WSP_99_*.md` | Content mismatch |
+
+**Sync Decision Required for Each**:
+- Framework → Knowledge (framework is source of truth)
+- Knowledge → Framework (knowledge is source of truth)
+- Intentional divergence (document reason)
+
+### 3.3 Index Issues
+
+| Issue | Description |
+|-------|-------------|
+| Master index next available | WSP_MASTER_INDEX.md shows next available number is not WSP 99 |
+
+**Investigation Required**: Verify master index accuracy and correct if needed.
+
+---
+
+## 4. Sync Direction Decision Template
+
+Each drift must be resolved with explicit sync direction:
+
+| WSP | Sync Direction | Justification | Approved By |
+|-----|----------------|---------------|-------------|
+| WSP 102 | TBD | TBD | TBD |
+| WSP 61 | TBD | TBD | TBD |
+| WSP 96 | TBD | TBD | TBD |
+| WSP 97 | TBD | TBD | TBD |
+| WSP 99 | TBD | TBD | TBD |
+| WSP 106 | TBD | TBD | TBD |
+| Index | TBD | TBD | TBD |
+
+**Sync Direction Options**:
+- `framework → knowledge`: Copy framework version to knowledge
+- `knowledge → framework`: Copy knowledge version to framework
+- `index-only`: Correct master index without touching protocol files
+- `intentional-divergence`: Document reason, no sync required
+
+---
+
+## 5. Proposed Worker Lane
+
+| Lane | Role | Scope |
+|------|------|-------|
+| **W1/W2** | Sync implementation | Execute approved sync directions |
+| **W10** | PR manager | Review/merge sync PRs |
+| **012** | Approval | Decide sync directions for each drift |
+
+---
+
+## 6. Next Slice
+
+**`WSP_FRAMEWORK_SYNC_PHASE1`**
+
+Prerequisites:
+1. This audit merged
+2. Sync directions approved for all 7 issues
+3. Index correction strategy approved
+
+---
+
+## 7. WSP 97 Truth Table
+
+| Claim | Status |
+|-------|--------|
+| No WSP protocol files modified in this PR | ENFORCED |
+| No runtime mutation | ENFORCED |
+| Drift count documented | VERIFIED (5 drifted, 1 framework-only, 1 index) |
+| Affected WSPs listed | VERIFIED |
+| Sync direction decisions deferred | VERIFIED |
+
+---
+
+*Audit created by Worker W10 under WSP_00 → WSP_97 → WSP_50 → WSP_64.*


### PR DESCRIPTION
## Summary

Documents the WSP-FRAMEWORK preflight failure for sync planning.

- **Drifted**: 5 (WSP 102, 61, 96, 97, 99)
- **Framework-only**: 1 (WSP 106)
- **Index issues**: 1

## WSP 97 Labels

- `SPEC_ONLY`
- `NO_RUNTIME_MUTATION`

## Contents

- Affected WSPs listed with file locations
- Sync direction decision template (framework→knowledge, knowledge→framework, intentional-divergence)
- Worker lane assignments
- Next slice: `WSP_FRAMEWORK_SYNC_PHASE1`

## Scope

**This PR does not modify any WSP protocol files.**

Also adds `.gitignore` exception for `docs/audits/wsp/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)