### PR TITLE
fix(antifafm): use env-resolved browser port for metadata editors

### DIFF
--- a/modules/platform_integration/antifafm_broadcaster/ModLog.md
+++ b/modules/platform_integration/antifafm_broadcaster/ModLog.md
@@ -1,5 +1,48 @@
 # antifaFM Broadcaster - ModLog
 
+## V3.4.1 - Metadata Editor Browser Port Fix (2026-05-17)
+
+**Slice**: `ANTIFAFM_METADATA_EDITOR_BROWSER_PORT_FIX`
+**Branch**: `fix/antifafm-metadata-editor-browser-port`
+**Worker**: W1
+**WSP Lock**: WSP_00, WSP_50, WSP_97, WSP_22
+
+**Context**: Post-PR #606 audit found that metadata editor skills hardcoded Chrome debug port `9222`, while antifaFM commonly uses Edge on port `9223`. This caused metadata DOM fallback to fail when the antifaFM browser was available but on Edge.
+
+**Changes**:
+
+1. **Updated `skillz/manage_metadata_editor/executor.py`**:
+   - Replaced `CHROME_DEBUG_PORT = 9222` with env-resolved `ANTIFAFM_BROWSER_PORT`
+   - Env precedence: `ANTIFAFM_BROWSER_PORT` > `FOUNDUPS_EDGE_PORT` > `EDGE_DEBUG_PORT` > `9223`
+   - Renamed `_connect_to_chrome()` to `_connect_to_browser()`
+   - Updated error messages to report actual port and browser type
+
+2. **Updated `skillz/stream_metadata_editor/executor.py`**:
+   - Same changes as manage_metadata_editor
+   - Error messages now report actual browser type and port
+
+**Port Resolution Policy**:
+```
+Default: Edge port 9223 (matches youtube_go_live.py pattern)
+Override: Set ANTIFAFM_BROWSER_PORT=9222 for Chrome
+Fallback chain: ANTIFAFM_BROWSER_PORT > FOUNDUPS_EDGE_PORT > EDGE_DEBUG_PORT > 9223
+```
+
+**Backward Compatibility**:
+- Chrome users can set `ANTIFAFM_BROWSER_PORT=9222`
+- Existing `FOUNDUPS_EDGE_PORT` and `EDGE_DEBUG_PORT` env vars respected
+
+**Files Modified**:
+- `skillz/manage_metadata_editor/executor.py`
+- `skillz/stream_metadata_editor/executor.py`
+- `ModLog.md` - This entry
+
+**WSP Compliance**:
+- WSP 97: Error messages truthfully report actual port/browser
+- WSP 50: Consistent with youtube_go_live.py pattern
+
+---
+
 ## V3.4.0 - Preflight Relocation (2026-05-16)
 
 **Slice**: `ANTIFAFM_PREFLIGHT_RELOCATION_IMPL_PHASE1`

--- a/modules/platform_integration/antifafm_broadcaster/skillz/manage_metadata_editor/executor.py
+++ b/modules/platform_integration/antifafm_broadcaster/skillz/manage_metadata_editor/executor.py
@@ -18,6 +18,7 @@ WSP 103: CLI Interface Standard
 import asyncio
 import argparse
 import logging
+import os
 import socket
 import time
 from typing import Optional, Dict, Any, List
@@ -32,7 +33,17 @@ from selenium.webdriver.support import expected_conditions as EC
 
 logger = logging.getLogger(__name__)
 
-CHROME_DEBUG_PORT = 9222
+# Browser debug port for antifaFM metadata editing
+# antifaFM uses Edge (port 9223) per youtube_channel_registry.py
+# Chrome (9222) = Move2Japan/UnDaoDu, Edge (9223) = FoundUps/antifaFM
+# Env precedence: ANTIFAFM_BROWSER_PORT > FOUNDUPS_EDGE_PORT > EDGE_DEBUG_PORT > 9223
+ANTIFAFM_BROWSER_PORT = int(os.getenv(
+    "ANTIFAFM_BROWSER_PORT",
+    os.getenv("FOUNDUPS_EDGE_PORT", os.getenv("EDGE_DEBUG_PORT", "9223"))
+))
+# Browser type for error messages
+ANTIFAFM_BROWSER_TYPE = os.getenv("ANTIFAFM_BROWSER_TYPE", "Edge")
+
 ANTIFAFM_CHANNEL_ID = "UCVSmg5aOhP4tnQ9KFUg97qA"
 MANAGE_URL = f"https://studio.youtube.com/channel/{ANTIFAFM_CHANNEL_ID}/livestreaming/manage"
 
@@ -49,20 +60,24 @@ def _port_open(port: int, timeout: float = 2) -> bool:
         return False
 
 
-def _connect_to_chrome():
-    """Connect to existing Chrome via debug port."""
-    if not _port_open(CHROME_DEBUG_PORT):
-        logger.error(f"Chrome not running on port {CHROME_DEBUG_PORT}")
+def _connect_to_browser():
+    """Connect to existing browser via debug port.
+
+    Uses ANTIFAFM_BROWSER_PORT (default: 9223 for Edge).
+    Set ANTIFAFM_BROWSER_PORT=9222 to use Chrome instead.
+    """
+    if not _port_open(ANTIFAFM_BROWSER_PORT):
+        logger.error(f"{ANTIFAFM_BROWSER_TYPE} not running on port {ANTIFAFM_BROWSER_PORT}")
         return None
 
     opts = Options()
-    opts.add_experimental_option("debuggerAddress", f"127.0.0.1:{CHROME_DEBUG_PORT}")
+    opts.add_experimental_option("debuggerAddress", f"127.0.0.1:{ANTIFAFM_BROWSER_PORT}")
 
     try:
         driver = webdriver.Chrome(options=opts)
         return driver
     except Exception as e:
-        logger.error(f"Failed to connect to Chrome: {e}")
+        logger.error(f"Failed to connect to {ANTIFAFM_BROWSER_TYPE} on port {ANTIFAFM_BROWSER_PORT}: {e}")
         return None
 
 
@@ -73,7 +88,7 @@ async def list_broadcasts(limit: int = 10) -> List[Dict[str, Any]]:
     Returns:
         List of broadcast info dicts
     """
-    driver = _connect_to_chrome()
+    driver = _connect_to_browser()
     if not driver:
         return []
 
@@ -151,9 +166,9 @@ async def edit_broadcast_metadata(
         result["error"] = "Must provide title or description"
         return result
 
-    driver = _connect_to_chrome()
+    driver = _connect_to_browser()
     if not driver:
-        result["error"] = "Could not connect to Chrome on debug port 9222"
+        result["error"] = f"Could not connect to {ANTIFAFM_BROWSER_TYPE} on debug port {ANTIFAFM_BROWSER_PORT}"
         return result
 
     try:
@@ -325,9 +340,9 @@ async def get_shareable_link(video_index: int = 0) -> Dict[str, Any]:
     """
     result = {"success": False, "error": None, "link": None}
 
-    driver = _connect_to_chrome()
+    driver = _connect_to_browser()
     if not driver:
-        result["error"] = "Could not connect to Chrome on debug port 9222"
+        result["error"] = f"Could not connect to {ANTIFAFM_BROWSER_TYPE} on debug port {ANTIFAFM_BROWSER_PORT}"
         return result
 
     try:

--- a/modules/platform_integration/antifafm_broadcaster/skillz/stream_metadata_editor/executor.py
+++ b/modules/platform_integration/antifafm_broadcaster/skillz/stream_metadata_editor/executor.py
@@ -8,6 +8,7 @@ WSP 84: Code Reuse (youtube_go_live patterns)
 
 import asyncio
 import logging
+import os
 from typing import Optional
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
@@ -19,7 +20,17 @@ import time
 
 logger = logging.getLogger(__name__)
 
-CHROME_DEBUG_PORT = 9222
+# Browser debug port for antifaFM metadata editing
+# antifaFM uses Edge (port 9223) per youtube_channel_registry.py
+# Chrome (9222) = Move2Japan/UnDaoDu, Edge (9223) = FoundUps/antifaFM
+# Env precedence: ANTIFAFM_BROWSER_PORT > FOUNDUPS_EDGE_PORT > EDGE_DEBUG_PORT > 9223
+ANTIFAFM_BROWSER_PORT = int(os.getenv(
+    "ANTIFAFM_BROWSER_PORT",
+    os.getenv("FOUNDUPS_EDGE_PORT", os.getenv("EDGE_DEBUG_PORT", "9223"))
+))
+# Browser type for error messages
+ANTIFAFM_BROWSER_TYPE = os.getenv("ANTIFAFM_BROWSER_TYPE", "Edge")
+
 ANTIFAFM_CHANNEL_ID = "UCVSmg5aOhP4tnQ9KFUg97qA"
 LIVE_DASHBOARD_URL = f"https://studio.youtube.com/channel/{ANTIFAFM_CHANNEL_ID}/livestreaming/stream"
 
@@ -50,20 +61,24 @@ def _port_open(port: int, timeout: float = 2) -> bool:
         return False
 
 
-def _connect_to_chrome():
-    """Connect to existing Chrome via debug port."""
-    if not _port_open(CHROME_DEBUG_PORT):
-        logger.error(f"Chrome not running on port {CHROME_DEBUG_PORT}")
+def _connect_to_browser():
+    """Connect to existing browser via debug port.
+
+    Uses ANTIFAFM_BROWSER_PORT (default: 9223 for Edge).
+    Set ANTIFAFM_BROWSER_PORT=9222 to use Chrome instead.
+    """
+    if not _port_open(ANTIFAFM_BROWSER_PORT):
+        logger.error(f"{ANTIFAFM_BROWSER_TYPE} not running on port {ANTIFAFM_BROWSER_PORT}")
         return None
 
     opts = Options()
-    opts.add_experimental_option("debuggerAddress", f"127.0.0.1:{CHROME_DEBUG_PORT}")
+    opts.add_experimental_option("debuggerAddress", f"127.0.0.1:{ANTIFAFM_BROWSER_PORT}")
 
     try:
         driver = webdriver.Chrome(options=opts)
         return driver
     except Exception as e:
-        logger.error(f"Failed to connect to Chrome: {e}")
+        logger.error(f"Failed to connect to {ANTIFAFM_BROWSER_TYPE} on port {ANTIFAFM_BROWSER_PORT}: {e}")
         return None
 
 
@@ -85,10 +100,10 @@ async def edit_stream_metadata(
     """
     result = {"success": False, "error": None, "changes": []}
 
-    # Connect to Chrome
-    driver = _connect_to_chrome()
+    # Connect to browser (Edge port 9223 by default, Chrome 9222 via ANTIFAFM_BROWSER_PORT)
+    driver = _connect_to_browser()
     if not driver:
-        result["error"] = "Could not connect to Chrome on debug port 9222"
+        result["error"] = f"Could not connect to {ANTIFAFM_BROWSER_TYPE} on debug port {ANTIFAFM_BROWSER_PORT}"
         return result
 
     try:
@@ -209,9 +224,9 @@ async def set_customization_options(
     """
     result = {"success": False, "error": None, "changes": []}
 
-    driver = _connect_to_chrome()
+    driver = _connect_to_browser()
     if not driver:
-        result["error"] = "Could not connect to Chrome"
+        result["error"] = f"Could not connect to {ANTIFAFM_BROWSER_TYPE} on port {ANTIFAFM_BROWSER_PORT}"
         return result
 
     try:


### PR DESCRIPTION
## Summary

Post-PR #606 audit found that antifaFM metadata editor skills hardcoded Chrome debug port `9222`, while antifaFM commonly uses Edge on port `9223`. This caused metadata DOM fallback to fail when the antifaFM browser was available but on Edge.

- Replace `CHROME_DEBUG_PORT=9222` with env-resolved `ANTIFAFM_BROWSER_PORT`
- Env precedence: `ANTIFAFM_BROWSER_PORT` > `FOUNDUPS_EDGE_PORT` > `EDGE_DEBUG_PORT` > `9223`
- Rename `_connect_to_chrome()` to `_connect_to_browser()`
- Update error messages to report actual port and browser type

## Port Resolution Policy

```
Default: Edge port 9223 (matches youtube_go_live.py pattern)
Override: Set ANTIFAFM_BROWSER_PORT=9222 for Chrome
Fallback chain: ANTIFAFM_BROWSER_PORT > FOUNDUPS_EDGE_PORT > EDGE_DEBUG_PORT > 9223
```

## Test plan

- [x] `py_compile` PASS on all modified files
- [x] `pytest modules/platform_integration/antifafm_broadcaster/tests` - 55 passed (28 errors pre-existing)
- [ ] Manual: Verify metadata edit works with Edge on 9223

Worker-Lane: W1
Slice: ANTIFAFM_METADATA_EDITOR_BROWSER_PORT_FIX

🤖 Generated with [Claude Code](https://claude.com/claude-code)