### PR TITLE
fix(holoindex): add slice ID extraction and boost for HXA retrieval

### DIFF
--- a/docs/audits/holoindex_search_quality/HOLOINDEX_HXA_AUDIT_INDEXING_FIX_PHASE1.md
+++ b/docs/audits/holoindex_search_quality/HOLOINDEX_HXA_AUDIT_INDEXING_FIX_PHASE1.md
@@ -1,0 +1,206 @@
+# HOLOINDEX_HXA_AUDIT_INDEXING_FIX_PHASE1
+
+**Slice**: HOLOINDEX_HXA_AUDIT_INDEXING_FIX_PHASE1
+**Worker**: W1
+**Date**: 2026-05-18
+**Mode**: Code implementation (indexing logic changes)
+**WSP Lock**: WSP_00, WSP_97, WSP_87, WSP_50
+
+---
+
+## WSP 97 Labels
+
+| Label | Status |
+|-------|--------|
+| `INDEXING_CHANGE_ALLOWED` | Applied |
+| `NO_RUNTIME_CHANGE` | ENFORCED |
+| `NO_LIVE_REINDEX_WITHOUT_APPROVAL` | ENFORCED |
+| `TEST_COVERAGE_REQUIRED` | VERIFIED (22/22 tests) |
+| `NO_CABR_READY` | Applied |
+| `NO_PAYOUT_READY` | Applied |
+| `NO_DAO_ACTIVATION` | Applied |
+
+---
+
+## 1. Implementation Summary
+
+This slice implements the minimal fixes specified in `HOLOINDEX_HXA_AUDIT_RETRIEVAL_IMPROVEMENT_AUDIT_PHASE1.md` Section 7.2:
+
+| Fix | Description | Status |
+|-----|-------------|--------|
+| Slice ID extraction | Extract HXA/FX/CFZ patterns from filenames and titles | COMPLETE |
+| Slice ID boost | +5.0 keyword boost for exact slice ID match in query | COMPLETE |
+| Audit path priority | openclaw_hermes=9, holoindex=9, security=8 | COMPLETE |
+| Worktree exclusion | Filter `.claude/worktrees` and `.worktrees` paths | COMPLETE |
+| Path display fix | Never return "Unknown" for indexed files | COMPLETE |
+
+---
+
+## 2. Files Modified
+
+### holo_index/core/indexing_engine.py
+
+**Changes**:
+1. Added `_SLICE_ID_PATTERN` regex: `(HXA\d+|FX\d+|CFZ\d+)`
+2. Added `_extract_slice_id(filename, title)` function
+3. Enhanced `_calculate_document_priority()` with audit path boosts
+4. Updated `index_docs_entries()` to:
+   - Exclude worktree paths
+   - Extract and store slice_id in metadata
+
+**Lines added**: ~55
+
+### holo_index/core/search_engine.py
+
+**Changes**:
+1. Added `_SLICE_ID_PATTERN` regex with word boundaries
+2. Added `_extract_slice_ids(text)` function
+3. Added `_slice_id_match_boost(query, path, title, meta_slice_id)` function
+4. Enhanced `_search_collection()` to apply slice ID boost
+5. Enhanced `_lexical_search_collection()` to apply slice ID boost
+6. Enhanced `_format_hit()` with docs/knowledge handler ensuring path is never None
+
+**Lines added**: ~64
+
+### holo_index/tests/test_hxa_retrieval_fix.py (NEW)
+
+**Test classes**:
+- `TestSliceIdExtraction` (6 tests)
+- `TestSliceIdBoost` (4 tests)
+- `TestSliceIdPatternExtraction` (2 tests)
+- `TestAuditPathPriority` (3 tests)
+- `TestWorktreeExclusion` (1 test)
+- `TestDocsFormatHit` (2 tests)
+- `TestSliceIdPattern` (4 tests)
+
+**Total**: 22 tests, all passing
+
+---
+
+## 3. Test Results
+
+```
+============================= test session starts =============================
+platform win32 -- Python 3.12.2, pytest-9.0.3
+collected 22 items
+
+holo_index/tests/test_hxa_retrieval_fix.py ...................... [100%]
+
+============================= 22 passed in 1.32s ==============================
+```
+
+---
+
+## 4. Baseline vs Expected (Post-Reindex)
+
+### Baseline (Before Fix)
+
+| Query | Result | Verdict |
+|-------|--------|---------|
+| "HXA22 destructive action guard runtime" | HXA1, HXA2 (wrong slices) | MISS |
+| "HXA23 Hermes guard integration" | HXA1, hermes_job_executor.py | MISS |
+| "HXA28 D3 native classification" | gemma_segment_classifier.py | MISS |
+| "HXA30 scope action class integration" | 5 "Unknown" paths | FAIL |
+
+### Expected (After Reindex with Fix)
+
+| Query | Expected Result | Reason |
+|-------|-----------------|--------|
+| "HXA22 destructive action guard runtime" | HXA22_DESTRUCTIVE_ACTION_GUARD_RUNTIME.md | +5.0 slice ID boost |
+| "HXA23 Hermes guard integration" | HXA23_HERMES_GUARD_INTEGRATION.md | +5.0 slice ID boost |
+| "HXA28 D3 native classification" | HXA28_D3_NATIVE_CLASSIFICATION.md | +5.0 slice ID boost |
+| "HXA30 scope action class integration" | HXA30_SCOPE_TO_ACTION_CLASS_HERMES_INTEGRATION.md with path | +5.0 boost + path fix |
+
+**Note**: Full verification requires reindex, which is deferred per `NO_LIVE_REINDEX_WITHOUT_APPROVAL`.
+
+---
+
+## 5. Algorithm Details
+
+### Slice ID Extraction
+
+```python
+_SLICE_ID_PATTERN = re.compile(r"(HXA\d+|FX\d+|CFZ\d+)", re.IGNORECASE)
+
+def _extract_slice_id(filename: str, title: str) -> Optional[str]:
+    # Try filename first
+    match = _SLICE_ID_PATTERN.search(filename)
+    if match:
+        return match.group(1).upper()
+    # Fall back to title
+    match = _SLICE_ID_PATTERN.search(title)
+    if match:
+        return match.group(1).upper()
+    return None
+```
+
+### Slice ID Boost Scoring
+
+```python
+def _slice_id_match_boost(query, path, title, meta_slice_id) -> float:
+    query_slices = _extract_slice_ids(query)
+    if not query_slices:
+        return 0.0
+    
+    # Check metadata slice_id (primary)
+    if meta_slice_id and meta_slice_id.upper() in [s.upper() for s in query_slices]:
+        return 5.0
+    
+    # Check path/title (fallback)
+    combined = f"{path} {title}".upper()
+    for slice_id in query_slices:
+        if slice_id.upper() in combined:
+            return 5.0
+    
+    return 0.0
+```
+
+### Audit Path Priority
+
+```python
+if "/audits/openclaw_hermes/" in path_str:
+    base_priority = max(base_priority, 9)  # HXA series
+elif "/audits/holoindex/" in path_str:
+    base_priority = max(base_priority, 9)
+elif "/audits/security/" in path_str:
+    base_priority = max(base_priority, 8)
+elif "/audits/" in path_str:
+    base_priority = max(base_priority, 7)
+```
+
+---
+
+## 6. WSP 97 Truth Table
+
+| Claim | Status | Evidence |
+|-------|--------|----------|
+| Indexing logic modified | **COMPLIANT** | indexing_engine.py, search_engine.py |
+| No runtime changes | **COMPLIANT** | No execution flow changes |
+| No live reindex | **COMPLIANT** | Index mutation deferred |
+| Test coverage | **VERIFIED** | 22/22 tests passing |
+| No CABR readiness | **COMPLIANT** | Not production |
+| No payout readiness | **COMPLIANT** | Not production |
+| No DAO activation | **COMPLIANT** | Not production |
+
+---
+
+## 7. Next Slice Recommendation
+
+**ID**: HOLOINDEX_HXA_AUDIT_INDEXING_FIX_PHASE2
+**Objective**: Execute reindex and verify query improvements
+**Scope**:
+- Run full reindex with new logic
+- Execute baseline queries and compare results
+- Document before/after metrics
+
+**Preconditions**:
+- This slice merged and approved
+- W10 approval for live reindex
+
+---
+
+**END OF AUDIT**
+
+Worker: W1
+Slice: HOLOINDEX_HXA_AUDIT_INDEXING_FIX_PHASE1
+WSP 97 Verdict: COMPLIANT

--- a/holo_index/core/indexing_engine.py
+++ b/holo_index/core/indexing_engine.py
@@ -111,6 +111,29 @@ def _extract_wsp_id(filename: str, title: str) -> str:
     return title.split()[0] if title else "WSP"
 
 
+# HXA Audit Fix: Extract slice IDs (HXA, FX, CFZ patterns) from filenames
+_SLICE_ID_PATTERN = re.compile(r"(HXA\d+|FX\d+|CFZ\d+)", re.IGNORECASE)
+
+
+def _extract_slice_id(filename: str, title: str) -> Optional[str]:
+    """Extract slice ID (HXA, FX, CFZ patterns) from filename or title.
+
+    Examples:
+        HXA22_DESTRUCTIVE_ACTION_GUARD_RUNTIME.md -> HXA22
+        test_hxa30_scope_to_action_class.py -> HXA30
+        CFZ4_COLLECTION_SEPARATION.md -> CFZ4
+    """
+    # Check filename first
+    match = _SLICE_ID_PATTERN.search(filename)
+    if match:
+        return match.group(1).upper()
+    # Check title
+    match = _SLICE_ID_PATTERN.search(title)
+    if match:
+        return match.group(1).upper()
+    return None
+
+
 def _classify_document_type(file_path: Path, title: str, lines: List[str]) -> str:
     """Classify document type based on filename, path, and content patterns.
 
@@ -146,7 +169,11 @@ def _classify_document_type(file_path: Path, title: str, lines: List[str]) -> st
 
 
 def _calculate_document_priority(doc_type: str, file_path: Path) -> int:
-    """Calculate document priority for search ranking (1-10, higher = more important)."""
+    """Calculate document priority for search ranking (1-10, higher = more important).
+
+    HXA Audit Fix: Boost audit paths (docs/audits/openclaw_hermes, etc.) for
+    better slice ID retrieval.
+    """
     priority_map = {
         "wsp_protocol": 10,
         "interface": 9,
@@ -161,8 +188,18 @@ def _calculate_document_priority(doc_type: str, file_path: Path) -> int:
 
     base_priority = priority_map.get(doc_type, 2)
 
-    path_str = str(file_path).lower()
-    if 'wsp_framework' in path_str:
+    path_str = str(file_path).lower().replace("\\", "/")
+
+    # HXA Audit Fix: Boost audit paths
+    if "/audits/openclaw_hermes/" in path_str:
+        base_priority = max(base_priority, 9)  # HXA series high priority
+    elif "/audits/holoindex/" in path_str:
+        base_priority = max(base_priority, 9)
+    elif "/audits/security/" in path_str:
+        base_priority = max(base_priority, 8)
+    elif "/audits/" in path_str:
+        base_priority = max(base_priority, 7)
+    elif 'wsp_framework' in path_str:
         base_priority += 1
     elif 'modules/' in path_str and 'platform_integration' in path_str:
         base_priority += 1
@@ -558,6 +595,9 @@ def index_docs_entries(holo: "HoloIndex") -> None:
 
     Content: modules/**, docs/**, holo_index/docs/**, WSP_framework/docs/**
     ID prefix: doc_
+
+    HXA Audit Fix: Excludes .claude/worktrees to prevent duplicate indexing,
+    extracts slice_id metadata for HXA/FX/CFZ patterns.
     """
     doc_paths = [
         holo.project_root / "modules",
@@ -579,6 +619,9 @@ def index_docs_entries(holo: "HoloIndex") -> None:
                 and '_backup' not in str(f).lower()
                 and '/archive/' not in str(f).lower()
                 and '\\archive\\' not in str(f).lower()
+                # HXA Audit Fix: Exclude worktrees to prevent duplicates
+                and '.claude/worktrees' not in str(f).replace("\\", "/").lower()
+                and '.worktrees' not in str(f).replace("\\", "/").lower()
             ]
             files.extend(filtered_files)
 
@@ -607,10 +650,13 @@ def index_docs_entries(holo: "HoloIndex") -> None:
         doc_payload = f"{title}\n{summary}"
 
         doc_fed = resolve_foundup_metadata(file_path, holo.project_root)
+        # HXA Audit Fix: Extract slice_id for HXA/FX/CFZ patterns
+        slice_id = _extract_slice_id(file_path.name, title)
+
         ids.append(f"doc_{idx}")
         embeddings.append(holo._get_embedding(doc_payload))
         documents.append(doc_payload)
-        metadatas.append({
+        metadata_entry: Dict[str, Any] = {
             "title": title,
             "path": str(file_path),
             "summary": summary,
@@ -620,7 +666,11 @@ def index_docs_entries(holo: "HoloIndex") -> None:
             "tenant_id": doc_fed["tenant_id"],
             "source_scope": doc_fed["source_scope"],
             "external_repo": doc_fed["external_repo"],
-        })
+        }
+        # HXA Audit Fix: Add slice_id to metadata if present
+        if slice_id:
+            metadata_entry["slice_id"] = slice_id
+        metadatas.append(metadata_entry)
 
     if embeddings:
         holo.docs_collection.add(ids=ids, embeddings=embeddings, documents=documents, metadatas=metadatas)

--- a/holo_index/core/search_engine.py
+++ b/holo_index/core/search_engine.py
@@ -103,6 +103,12 @@ _WSP_NUMBER_PATTERN = re.compile(
     re.IGNORECASE
 )
 
+# HXA Audit Fix: Slice ID pattern for HXA, FX, CFZ
+_SLICE_ID_PATTERN = re.compile(
+    r"\b(HXA\d+|FX\d+|CFZ\d+)\b",  # Match HXA22, FX1, CFZ4, etc.
+    re.IGNORECASE
+)
+
 
 def _extract_wsp_numbers(text: str) -> List[str]:
     """Extract WSP numbers from text (e.g., 'WSP 97', 'WSP_97', 'WSP-97').
@@ -111,6 +117,39 @@ def _extract_wsp_numbers(text: str) -> List[str]:
     """
     matches = _WSP_NUMBER_PATTERN.findall(text)
     return [m.lstrip("0") or "0" for m in matches]  # Normalize: '00' -> '0', '97' -> '97'
+
+
+def _extract_slice_ids(text: str) -> List[str]:
+    """HXA Audit Fix: Extract slice IDs from text (e.g., 'HXA22', 'FX1', 'CFZ4').
+
+    Returns list of normalized slice IDs like ['HXA22', 'CFZ4'].
+    """
+    matches = _SLICE_ID_PATTERN.findall(text)
+    return [m.upper() for m in matches]
+
+
+def _slice_id_match_boost(query: str, path: str, title: str, meta_slice_id: str = "") -> float:
+    """HXA Audit Fix: Return keyword boost if query slice ID matches path/title/metadata.
+
+    Boosts exact slice ID matches (HXA22, FX1, CFZ4) to fix retrieval gaps.
+    """
+    query_slices = _extract_slice_ids(query)
+    if not query_slices:
+        return 0.0
+
+    # Check path, title, and metadata slice_id
+    path_slices = _extract_slice_ids(path)
+    title_slices = _extract_slice_ids(title)
+    all_target_slices = set(path_slices + title_slices)
+    if meta_slice_id:
+        all_target_slices.add(meta_slice_id.upper())
+
+    # Strong boost for exact match
+    for qslice in query_slices:
+        if qslice in all_target_slices:
+            return 5.0  # Strong boost for exact slice ID match
+
+    return 0.0
 
 
 def _normalize_for_match(text: str) -> str:
@@ -513,6 +552,9 @@ def _search_collection(
         keyword_score += _wsp_number_match_boost(query, path, title)
         # HIA5: WSP alias phrase match boost
         keyword_score += _wsp_alias_match_boost(query, path, title)
+        # HXA Audit Fix: Slice ID exact match boost
+        meta_slice_id = meta.get("slice_id", "")
+        keyword_score += _slice_id_match_boost(query, path, title, meta_slice_id)
 
         if doc_type_filter != "all" and not doc_type.startswith(doc_type_filter):
             continue
@@ -626,6 +668,9 @@ def _lexical_search_collection(
             keyword_score += _wsp_number_match_boost(query, path, title)
             # HIA5: WSP alias phrase match boost
             keyword_score += _wsp_alias_match_boost(query, path, title)
+            # HXA Audit Fix: Slice ID exact match boost
+            meta_slice_id = meta.get("slice_id", "")
+            keyword_score += _slice_id_match_boost(query, path, title, meta_slice_id)
 
             if keyword_score <= 0:
                 continue
@@ -715,6 +760,25 @@ def _format_hit(
         }
         if emit_conf:
             result["confidence"] = _compute_confidence(similarity, keyword_score, "skillz")
+        return result
+
+    # HXA Audit Fix: Explicit docs/knowledge handlers to ensure path is always populated
+    if kind in ("docs", "knowledge"):
+        # Ensure path is never None - fallback to document content or title
+        path_value = meta.get("path") or meta.get("title", "")
+        result_type = meta.get("type", kind)
+        result = {
+            "title": meta.get("title"),
+            "summary": meta.get("summary"),
+            "path": path_value,
+            "slice_id": meta.get("slice_id"),  # HXA Audit Fix: Include slice_id
+            "similarity": sim_str,
+            "type": result_type,
+            "priority": priority,
+            "_sort_key": (0.5 * priority + 0.3 * similarity + 0.2 * keyword_score, similarity, priority),
+        }
+        if emit_conf:
+            result["confidence"] = _compute_confidence(similarity, keyword_score, result_type)
         return result
 
     # WSP / default

--- a/holo_index/tests/test_hxa_retrieval_fix.py
+++ b/holo_index/tests/test_hxa_retrieval_fix.py
@@ -1,0 +1,282 @@
+# -*- coding: utf-8 -*-
+"""Tests for HXA retrieval quality fixes.
+
+HOLOINDEX_HXA_AUDIT_INDEXING_FIX_PHASE1
+
+These tests verify:
+1. Slice ID extraction (HXA, FX, CFZ patterns)
+2. Slice ID boost in search ranking
+3. Path display is never "Unknown" for indexed files
+4. Worktree exclusion in indexing
+5. Audit path priority boost
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+class TestSliceIdExtraction:
+    """Test slice ID extraction from filenames and titles."""
+
+    def test_extract_hxa_from_filename(self):
+        """HXA22 extracted from HXA22_DESTRUCTIVE_ACTION_GUARD_RUNTIME.md."""
+        from holo_index.core.indexing_engine import _extract_slice_id
+
+        result = _extract_slice_id("HXA22_DESTRUCTIVE_ACTION_GUARD_RUNTIME.md", "")
+        assert result == "HXA22"
+
+    def test_extract_hxa_from_test_filename(self):
+        """HXA30 extracted from test_hxa30_scope_to_action_class.py."""
+        from holo_index.core.indexing_engine import _extract_slice_id
+
+        result = _extract_slice_id("test_hxa30_scope_to_action_class.py", "")
+        assert result == "HXA30"
+
+    def test_extract_fx_from_filename(self):
+        """FX1 extracted from FX1_RETRIEVAL_AUDIT.md."""
+        from holo_index.core.indexing_engine import _extract_slice_id
+
+        result = _extract_slice_id("FX1_RETRIEVAL_AUDIT.md", "")
+        assert result == "FX1"
+
+    def test_extract_cfz_from_filename(self):
+        """CFZ4 extracted from CFZ4_COLLECTION_SEPARATION.md."""
+        from holo_index.core.indexing_engine import _extract_slice_id
+
+        result = _extract_slice_id("CFZ4_COLLECTION_SEPARATION.md", "")
+        assert result == "CFZ4"
+
+    def test_extract_from_title_when_not_in_filename(self):
+        """Slice ID extracted from title when not in filename."""
+        from holo_index.core.indexing_engine import _extract_slice_id
+
+        result = _extract_slice_id("README.md", "HXA23 - Hermes Guard Integration")
+        assert result == "HXA23"
+
+    def test_no_slice_id_returns_none(self):
+        """None returned when no slice ID present."""
+        from holo_index.core.indexing_engine import _extract_slice_id
+
+        result = _extract_slice_id("README.md", "Installation Guide")
+        assert result is None
+
+
+class TestSliceIdBoost:
+    """Test slice ID boost in search ranking."""
+
+    def test_slice_id_match_boost_hxa(self):
+        """HXA22 query boosts HXA22 path."""
+        from holo_index.core.search_engine import _slice_id_match_boost
+
+        boost = _slice_id_match_boost(
+            query="HXA22 destructive action guard",
+            path="docs/audits/openclaw_hermes/HXA22_DESTRUCTIVE_ACTION_GUARD_RUNTIME.md",
+            title="HXA22 - Destructive Action Guard Runtime",
+            meta_slice_id="HXA22",
+        )
+        assert boost == 5.0
+
+    def test_slice_id_match_boost_cfz(self):
+        """CFZ4 query boosts CFZ4 path."""
+        from holo_index.core.search_engine import _slice_id_match_boost
+
+        boost = _slice_id_match_boost(
+            query="CFZ4 collection separation",
+            path="docs/audits/holoindex/CFZ4_COLLECTION_SEPARATION.md",
+            title="CFZ4 - Collection Separation",
+            meta_slice_id="CFZ4",
+        )
+        assert boost == 5.0
+
+    def test_no_boost_for_different_slice(self):
+        """No boost when query slice differs from path slice."""
+        from holo_index.core.search_engine import _slice_id_match_boost
+
+        boost = _slice_id_match_boost(
+            query="HXA22 destructive action guard",
+            path="docs/audits/openclaw_hermes/HXA23_HERMES_GUARD_INTEGRATION.md",
+            title="HXA23 - Hermes Guard Integration",
+            meta_slice_id="HXA23",
+        )
+        assert boost == 0.0
+
+    def test_no_boost_for_non_slice_query(self):
+        """No boost when query has no slice ID."""
+        from holo_index.core.search_engine import _slice_id_match_boost
+
+        boost = _slice_id_match_boost(
+            query="destructive action guard",
+            path="docs/audits/openclaw_hermes/HXA22_DESTRUCTIVE_ACTION_GUARD_RUNTIME.md",
+            title="HXA22 - Destructive Action Guard Runtime",
+            meta_slice_id="HXA22",
+        )
+        assert boost == 0.0
+
+
+class TestSliceIdPatternExtraction:
+    """Test _extract_slice_ids function in search_engine."""
+
+    def test_extract_multiple_slice_ids(self):
+        """Multiple slice IDs extracted from text."""
+        from holo_index.core.search_engine import _extract_slice_ids
+
+        result = _extract_slice_ids("HXA22 and HXA23 integration")
+        assert "HXA22" in result
+        assert "HXA23" in result
+
+    def test_case_insensitive_extraction(self):
+        """Slice ID extraction is case-insensitive."""
+        from holo_index.core.search_engine import _extract_slice_ids
+
+        result = _extract_slice_ids("hxa22 lowercase test")
+        assert "HXA22" in result
+
+
+class TestAuditPathPriority:
+    """Test audit path priority boost."""
+
+    def test_openclaw_hermes_priority(self):
+        """docs/audits/openclaw_hermes gets priority 9."""
+        from holo_index.core.indexing_engine import _calculate_document_priority
+
+        priority = _calculate_document_priority(
+            "documentation",
+            Path("O:/Foundups-Agent/docs/audits/openclaw_hermes/HXA22_AUDIT.md"),
+        )
+        assert priority >= 9
+
+    def test_security_audits_priority(self):
+        """docs/audits/security gets priority 8."""
+        from holo_index.core.indexing_engine import _calculate_document_priority
+
+        priority = _calculate_document_priority(
+            "documentation",
+            Path("O:/Foundups-Agent/docs/audits/security/DEP_SECURITY.md"),
+        )
+        assert priority >= 8
+
+    def test_regular_docs_lower_priority(self):
+        """Regular docs without audit path get lower priority."""
+        from holo_index.core.indexing_engine import _calculate_document_priority
+
+        priority = _calculate_document_priority(
+            "documentation",
+            Path("O:/Foundups-Agent/docs/README.md"),
+        )
+        # Should be base priority (7 for documentation)
+        assert priority <= 8
+
+
+class TestWorktreeExclusion:
+    """Test worktree exclusion patterns."""
+
+    def test_worktree_path_excluded(self):
+        """Worktree paths should be filtered out."""
+        # Test the filter pattern used in index_docs_entries
+        test_paths = [
+            "O:/Foundups-Agent/.claude/worktrees/agent-xxx/docs/README.md",
+            "O:/Foundups-Agent/.worktrees/agent-xxx/docs/README.md",
+            "O:/Foundups-Agent/docs/README.md",  # Should NOT be excluded
+        ]
+
+        for path in test_paths:
+            path_lower = path.replace("\\", "/").lower()
+            is_excluded = (
+                ".claude/worktrees" in path_lower or ".worktrees" in path_lower
+            )
+
+            if "worktrees" in path.lower():
+                assert is_excluded, f"Path should be excluded: {path}"
+            else:
+                assert not is_excluded, f"Path should NOT be excluded: {path}"
+
+
+class TestDocsFormatHit:
+    """Test _format_hit for docs kind."""
+
+    def test_docs_format_includes_path(self):
+        """Docs format always includes path, never None."""
+        from holo_index.core.search_engine import _format_hit
+
+        meta = {
+            "title": "Test Doc",
+            "summary": "Test summary",
+            "path": "O:/Foundups-Agent/docs/test.md",
+            "type": "documentation",
+            "priority": 7,
+            "slice_id": "HXA22",
+        }
+
+        result = _format_hit(
+            kind="docs",
+            meta=meta,
+            doc="Test Doc\nTest summary",
+            similarity=0.85,
+            keyword_score=3.0,
+            priority=7,
+        )
+
+        assert result["path"] == "O:/Foundups-Agent/docs/test.md"
+        assert result["slice_id"] == "HXA22"
+        assert result["title"] == "Test Doc"
+
+    def test_docs_format_fallback_when_path_none(self):
+        """Docs format uses title as fallback when path is None."""
+        from holo_index.core.search_engine import _format_hit
+
+        meta = {
+            "title": "Test Doc Title",
+            "summary": "Test summary",
+            "path": None,  # Explicitly None
+            "type": "documentation",
+            "priority": 7,
+        }
+
+        result = _format_hit(
+            kind="docs",
+            meta=meta,
+            doc="Test Doc\nTest summary",
+            similarity=0.85,
+            keyword_score=3.0,
+            priority=7,
+        )
+
+        # Path should fall back to title, not be None
+        assert result["path"] == "Test Doc Title"
+        assert result["path"] != "Unknown"
+
+
+class TestSliceIdPattern:
+    """Test the slice ID regex pattern."""
+
+    def test_pattern_matches_hxa(self):
+        """Pattern matches HXA followed by digits."""
+        from holo_index.core.search_engine import _SLICE_ID_PATTERN
+
+        assert _SLICE_ID_PATTERN.search("HXA22") is not None
+        assert _SLICE_ID_PATTERN.search("HXA1") is not None
+        assert _SLICE_ID_PATTERN.search("HXA123") is not None
+
+    def test_pattern_matches_fx(self):
+        """Pattern matches FX followed by digits."""
+        from holo_index.core.search_engine import _SLICE_ID_PATTERN
+
+        assert _SLICE_ID_PATTERN.search("FX1") is not None
+        assert _SLICE_ID_PATTERN.search("FX99") is not None
+
+    def test_pattern_matches_cfz(self):
+        """Pattern matches CFZ followed by digits."""
+        from holo_index.core.search_engine import _SLICE_ID_PATTERN
+
+        assert _SLICE_ID_PATTERN.search("CFZ4") is not None
+        assert _SLICE_ID_PATTERN.search("CFZ123") is not None
+
+    def test_pattern_case_insensitive(self):
+        """Pattern is case-insensitive."""
+        from holo_index.core.search_engine import _SLICE_ID_PATTERN
+
+        assert _SLICE_ID_PATTERN.search("hxa22") is not None
+        assert _SLICE_ID_PATTERN.search("Hxa22") is not None
+        assert _SLICE_ID_PATTERN.search("HXA22") is not None


### PR DESCRIPTION
## Summary

- Adds slice ID extraction from filenames and titles (HXA, FX, CFZ patterns)
- Implements slice ID boost in search engine for exact audit/slice queries
- Adds audit path priority weighting for `docs/audits/` paths
- Excludes `.claude/worktrees/` from search results
- Ensures `docs` format includes path in hit output

Resolves retrieval quality issues documented in HOLOINDEX_HXA_AUDIT_RETRIEVAL_IMPROVEMENT_AUDIT_PHASE1.

## Test Plan

- [x] Run `holo_index/tests/test_hxa_retrieval_fix.py` - 22/22 tests pass
- [x] Test slice ID extraction for HXA, FX, CFZ patterns
- [x] Test boost logic for exact slice queries
- [x] Test audit path priority
- [x] Test worktree exclusion

## WSP 97 Truth Boundary Labels

- INDEXING_CHANGE_ALLOWED
- NO_RUNTIME_CHANGE
- NO_LIVE_REINDEX_WITHOUT_APPROVAL
- TEST_COVERAGE_REQUIRED
- NO_CABR_READY
- NO_PAYOUT_READY
- NO_DAO_ACTIVATION

## Files Changed

- `holo_index/core/indexing_engine.py` - Slice ID extraction
- `holo_index/core/search_engine.py` - Slice ID boost, audit path priority, worktree exclusion
- `holo_index/tests/test_hxa_retrieval_fix.py` - 22 new tests
- `docs/audits/holoindex_search_quality/HOLOINDEX_HXA_AUDIT_INDEXING_FIX_PHASE1.md` - Audit doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>