### PR TITLE
docs(architecture): audit AutoPost external FoundUp completion

### DIFF
--- a/docs/audits/architecture/AUTOPOST_EXTERNAL_FOUNDUP_COMPLETION_AUDIT_PHASE1.md
+++ b/docs/audits/architecture/AUTOPOST_EXTERNAL_FOUNDUP_COMPLETION_AUDIT_PHASE1.md
@@ -1,0 +1,356 @@
+# AUTOPOST_EXTERNAL_FOUNDUP_COMPLETION_AUDIT_PHASE1
+
+**Worker**: W9D  
+**Slice**: `AUTOPOST_EXTERNAL_FOUNDUP_COMPLETION_AUDIT_PHASE1`  
+**Date**: 2026-05-18  
+**Status**: AUDIT_COMPLETE  
+
+---
+
+## WSP_97 Labels
+
+```
+DOCS_ONLY, AUDIT_ONLY, NO_IMPLEMENTATION, NO_MODULE_DELETION,
+NO_MANIFEST_CREATION, NO_TOKEN_ASSIGNMENT, TOKEN_DEFERRED_WHERE_UNKNOWN,
+NO_RUNTIME_CHANGE, NO_CABR_READY, NO_PAYOUT_READY, NO_DAO_ACTIVATION
+```
+
+---
+
+## 1. Repository Location
+
+| Field | Value |
+|-------|-------|
+| **Type** | External FoundUp (externalized repo) |
+| **Local Path** | `O:/repos/AutoPost/` |
+| **GitHub Origin** | `https://github.com/FOUNDUPS/autopost.git` |
+| **GitHub Backup** | TBD (not configured) |
+| **Monorepo Footprint** | References only - no `modules/foundups/autopost/` directory |
+| **Visibility** | Private |
+| **Commits** | 5 (as of audit date) |
+
+---
+
+## 2. Web/PWA/Public Presence Status
+
+### 2.1 PWA Configuration
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| `manifest.json` | EXISTS | Located at `public/manifest.json` |
+| `sw.js` | EXISTS | Service worker in `public/sw.js` |
+| `index.html` PWA meta tags | COMPLETE | apple-mobile-web-app-capable, theme-color, manifest link |
+
+### 2.2 Manifest.json Analysis
+
+```json
+{
+  "name": "FoundUp AI AutoPost",
+  "short_name": "AutoPost",
+  "description": "Camera-first AI social media posting app",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "icons": [
+    { "src": "https://picsum.photos/seed/foundup/192/192", "sizes": "192x192" },
+    { "src": "https://picsum.photos/seed/foundup/512/512", "sizes": "512x512" }
+  ]
+}
+```
+
+**Missing PWA Manifest Fields**:
+
+| Field | Status | Impact |
+|-------|--------|--------|
+| `id` | MISSING | PWA identity - required for installation |
+| `scope` | MISSING | Defines navigation scope |
+| `orientation` | MISSING | Lock to portrait recommended for camera app |
+| `categories` | MISSING | App store categorization |
+| `lang` | MISSING | Language identifier |
+| `dir` | MISSING | Text direction |
+| `screenshots` | MISSING | Install prompt enhancement |
+| `related_applications` | MISSING | Native app linking |
+| `prefer_related_applications` | MISSING | Native vs PWA preference |
+| `shortcuts` | MISSING | Quick actions |
+| `protocol_handlers` | MISSING | Deep linking |
+
+**Icon Issues**:
+
+- Icons use placeholder URLs (picsum.photos) - NOT production-ready
+- No maskable icon variant for Android adaptive icons
+- No Apple touch icons (separate from PWA manifest)
+
+### 2.3 Domain Status
+
+| Domain | Status |
+|--------|--------|
+| `autopost.foundups.com` | REDIRECT (planned) |
+| AI Studio URL | `https://ai.studio/apps/a53b5519-3cb4-40f0-a999-fcf0fa381023` |
+
+### 2.4 Service Worker Status
+
+```javascript
+const CACHE_NAME = 'autopost-v1';
+const ASSETS = ['/', '/index.html', '/src/main.tsx', '/src/index.css'];
+```
+
+**Issues**:
+- Cache strategy is cache-first without network fallback for updates
+- No background sync capability
+- No push notification handling
+- No offline page
+
+---
+
+## 3. Current Completion State
+
+### 3.1 What Exists
+
+| Component | Status | Description |
+|-----------|--------|-------------|
+| **Camera Module** | FUNCTIONAL | Multi-segment recording, camera flipping |
+| **Gesture Handling** | FUNCTIONAL | Touch/swipe interaction |
+| **Gemini AI Integration** | FUNCTIONAL | Transcription + caption generation |
+| **UI Shell** | FUNCTIONAL | AppShell, CameraViewport, PostFeed, SettingsDrawer |
+| **Type System** | COMPLETE | Well-defined TypeScript types for posts, accounts, platforms |
+| **Observability** | BASIC | Logger module with log export service |
+| **Security** | BASIC | mediaGuard for video validation |
+| **Settings** | FUNCTIONAL | Locale store, settings store with Zustand |
+| **Post Repository** | PARTIAL | Local storage for posts |
+
+### 3.2 Platform Connectors Status
+
+| Platform | Connector | OAuth | Publish | Status |
+|----------|-----------|-------|---------|--------|
+| YouTube | `youtubeConnector.ts` | MOCK | MOCK | Stub only |
+| Instagram | `instagramConnector.ts` | MOCK | MOCK | Stub only |
+| TikTok | `tiktokConnector.ts` | MOCK | MOCK | Stub only |
+| LINE Official | N/A | N/A | N/A | Not implemented |
+| X/Twitter | N/A | N/A | N/A | Not implemented |
+| Facebook | N/A | N/A | N/A | Not implemented |
+| Threads | N/A | N/A | N/A | Not implemented |
+| LinkedIn | N/A | N/A | N/A | Not implemented |
+
+### 3.3 What's Missing
+
+| Component | Priority | Notes |
+|-----------|----------|-------|
+| **Real YouTube OAuth** | P0 | Core unlisted upload flow |
+| **FoundUp Routing** | P0 | Video to correct FoundUp channel |
+| **pfMALL Integration** | P1 | Catalog indexing |
+| **Social Distribution** | P1 | Auto-share to FoundUp social accounts |
+| **User Authentication** | P1 | Multi-user account management |
+| **Real Platform OAuth** | P1 | All connectors are mock stubs |
+| **Production Icons** | P2 | Replace picsum placeholders |
+| **Offline Support** | P2 | Full offline-first PWA |
+| **Push Notifications** | P2 | Post scheduling notifications |
+| **Usage Analytics** | P3 | Per-FoundUp metrics |
+
+---
+
+## 4. Registry Field Analysis
+
+### 4.1 Metadata.json (App-level)
+
+Located at `O:/repos/AutoPost/metadata.json`:
+
+```json
+{
+  "name": "FoundUp Japan - AI AutoPost Camera",
+  "description": "A frictionless capture-to-post tool for shop owners...",
+  "requestFramePermissions": ["camera", "microphone"]
+}
+```
+
+**Missing Registry Fields**:
+
+| Field | Purpose | Status |
+|-------|---------|--------|
+| `foundup_id` | Canonical identifier | MISSING |
+| `tier` | F0_DAE / F1_OPO / etc | MISSING |
+| `token` | F_i token symbol | TOKEN_DEFERRED |
+| `parent_foundup` | Parent in hierarchy | MISSING (AI Automation?) |
+| `registry_version` | Schema version | MISSING |
+| `cabr_hook` | CABR integration endpoint | MISSING |
+| `pfmall_catalog_id` | pfMALL entry ID | MISSING |
+| `discord_category` | Discord channel mapping | MISSING (planned: AUTOPOST) |
+
+### 4.2 Monorepo Registry References
+
+| Document | Location | Entry Status |
+|----------|----------|--------------|
+| FOUNDUPS_DOMAIN_CANONICAL_INDEX.md | `modules/foundups/docs/` | PRESENT |
+| PFMALL_LAUNCH_CATALOG_TAXONOMY.md | `modules/foundups/docs/` | PRESENT (`discoverable_only`) |
+| PFMALL_VIDEO_MALL_CATALOG_SCHEMA.md | `modules/foundups/docs/` | PRESENT (`external_app` type) |
+| FOUNDUP_FEDERATION_MIGRATION_PLAN.md | `modules/foundups/docs/` | PRESENT (Phase 1 target) |
+
+---
+
+## 5. Token Status
+
+| Field | Value |
+|-------|-------|
+| **Token Symbol** | TOKEN_DEFERRED |
+| **Rationale** | External FoundUp at PoC stage; no token assignment until public PoC demonstrated with real user flow |
+| **Tier Classification** | F0_DAE (candidate - unvalidated) |
+| **Prerequisites for Token** | YouTube real upload working, public URL accessible, user signups possible |
+
+---
+
+## 6. What "Completion" Would Require
+
+### 6.1 Technical Completion (NOT IMPLEMENTED - AUDIT ONLY)
+
+1. **YouTube OAuth Integration**
+   - Real API credentials
+   - Unlisted upload capability
+   - FoundUp metadata tagging
+
+2. **FoundUp Routing Engine**
+   - Channel assignment logic
+   - Category-to-FoundUp mapping
+   - pfMALL ingest notification
+
+3. **PWA Production Readiness**
+   - Production icons (512x512, 192x192, maskable variants)
+   - Apple touch icons
+   - Proper manifest with all required fields
+   - Enhanced service worker (push, background sync)
+
+4. **Domain Setup**
+   - `autopost.foundups.com` live deployment
+   - SSL certificate
+   - CDN configuration
+
+5. **Authentication System**
+   - User accounts
+   - Per-FoundUp permissions
+   - Session management
+
+### 6.2 Registry Completion (NOT IMPLEMENTED - AUDIT ONLY)
+
+1. **External Repo Registry**
+   - Add `foundup_registry.json` to AutoPost repo root
+   - Include: `foundup_id`, `tier`, `parent`, `cabr_hook`
+
+2. **Monorepo Adapter**
+   - Create `modules/foundups/adapters/autopost/` (reference only)
+   - Include: manifest reference, CABR webhook config
+
+3. **pfMALL Catalog Entry**
+   - Add `external_url` field to catalog schema
+   - Create discoverable tile with external redirect
+
+### 6.3 CABR/DAO Completion (NOT IMPLEMENTED - AUDIT ONLY)
+
+- CABR_READY: NO (requires P0 technical completion)
+- DAO_ACTIVATION: NO (requires token assignment first)
+- PAYOUT_READY: NO (requires CABR hooks)
+
+---
+
+## 7. HoloIndex vs Grep Comparison Table
+
+| Search Method | Query | Results Found | Quality |
+|---------------|-------|---------------|---------|
+| **HoloIndex** | "AutoPost FoundUp external" | 15 hits (5 WSP, 5 docs, 5 knowledge) | HIGH - semantic relevance |
+| **Grep** | `AutoPost\|autopost` | 52 files | COMPLETE - all literal matches |
+
+### Detailed Comparison
+
+| Aspect | HoloIndex | Grep |
+|--------|-----------|------|
+| **Semantic Understanding** | YES - found WSP 104, WSP 26, WSP 58 | NO - literal only |
+| **Coverage** | PARTIAL - prioritized | COMPLETE - all matches |
+| **False Positives** | LOW | MODERATE (test files, comments) |
+| **Discovery of Related WSPs** | YES (Route Namespace, Tokenization) | NO |
+| **Speed** | ~2s | ~1s |
+| **Noise Level** | LOW (ranked) | HIGH (52 unranked files) |
+
+### Key HoloIndex Findings Not in Grep Top Results
+
+1. `WSP_104_FoundUp_Route_Namespace_and_Tenant_Isolation_Protocol.md` - relevant for routing
+2. `WSP_58_FoundUp_IP_Lifecycle_and_Tokenization_Protocol.md` - relevant for token
+3. `WSP_26_FoundUPS_DAE_Tokenization.md` - relevant for DAE classification
+
+---
+
+## 8. Audit Summary
+
+### Completion Score
+
+| Category | Score | Notes |
+|----------|-------|-------|
+| Repository Structure | 8/10 | Clean, modular |
+| PWA Readiness | 4/10 | Basic manifest, placeholder icons |
+| Platform Integrations | 2/10 | All mock stubs |
+| Registry Integration | 3/10 | Monorepo references exist, no external registry |
+| Documentation | 7/10 | ROADMAP, ModLog present |
+| Token Status | 0/10 | TOKEN_DEFERRED (appropriate for PoC) |
+| CABR/DAO | 0/10 | Not started (appropriate for PoC) |
+
+**Overall PoC Completion**: 35%
+
+### Classification
+
+| Field | Value |
+|-------|-------|
+| **FoundUp Type** | External (externalized repo) |
+| **Classification** | CANDIDATE_FOUNDUP |
+| **Priority** | HIGH |
+| **Current Phase** | PoC |
+| **Next Phase** | YouTube Pipeline (Phase 2 per ROADMAP.md) |
+
+---
+
+## 9. WSP_97 Compliance Verdict
+
+| Check | Status |
+|-------|--------|
+| DOCS_ONLY | PASS |
+| AUDIT_ONLY | PASS |
+| NO_IMPLEMENTATION | PASS |
+| NO_MODULE_DELETION | PASS |
+| NO_MANIFEST_CREATION | PASS |
+| NO_TOKEN_ASSIGNMENT | PASS (TOKEN_DEFERRED used) |
+| TOKEN_DEFERRED_WHERE_UNKNOWN | PASS |
+| NO_RUNTIME_CHANGE | PASS |
+| NO_CABR_READY | PASS |
+| NO_PAYOUT_READY | PASS |
+| NO_DAO_ACTIVATION | PASS |
+
+**WSP_97 Verdict**: COMPLIANT
+
+---
+
+## 10. Next-Slice Recommendation
+
+**Next Slice**: `AUTOPOST_EXTERNAL_FOUNDUP_MANIFEST_READINESS_PHASE1`
+
+**Scope**:
+- Audit what manifest fields need to be added to AutoPost repo
+- Define `foundup_registry.json` schema for external FoundUps
+- Document adapter pattern for monorepo-to-external registry sync
+- NO implementation - document requirements only
+
+**Prerequisites**:
+- This audit accepted by 012
+- WSP_97 compliance confirmed
+
+---
+
+## Cross-References
+
+| Document | Location |
+|----------|----------|
+| AutoPost README | `O:/repos/AutoPost/README.md` |
+| AutoPost ROADMAP | `O:/repos/AutoPost/ROADMAP.md` |
+| AutoPost ModLog | `O:/repos/AutoPost/ModLog.md` |
+| Domain Canonical Index | `modules/foundups/docs/FOUNDUPS_DOMAIN_CANONICAL_INDEX.md` |
+| pfMALL Catalog Taxonomy | `modules/foundups/docs/PFMALL_LAUNCH_CATALOG_TAXONOMY.md` |
+| Federation Migration Plan | `modules/foundups/docs/FOUNDUP_FEDERATION_MIGRATION_PLAN.md` |
+
+---
+
+*Audit generated by W9D under WSP_97 compliance. No implementation performed.*


### PR DESCRIPTION
## Summary

Audits AutoPost external FoundUp completion state.

**Key content:**
- External FoundUp status documented
- PoC completion percentage/status documented
- Token deferred

## Test Plan

- [x] Docs-only change - no tests required
- [x] HoloIndex retrieval verified

## WSP 97 Truth Boundary Labels

- DOCS_ONLY
- AUDIT_ONLY
- NO_IMPLEMENTATION
- NO_MODULE_DELETION
- NO_MANIFEST_CREATION
- NO_TOKEN_ASSIGNMENT
- NO_RUNTIME_CHANGE
- NO_CABR_READY
- NO_PAYOUT_READY
- NO_DAO_ACTIVATION

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>