### PR TITLE
chore(gitignore): add .claude/worktrees/ to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,9 @@ env/
 # Git worktrees (local working directories)
 .worktrees/
 
+# Claude Code worktrees (local runtime artifacts)
+.claude/worktrees/
+
 # IDE
 .idea/
 .vscode/


### PR DESCRIPTION
## Summary
- Adds `.claude/worktrees/` to root `.gitignore`
- Claude Code creates worktree directories for agent isolation during PR workflows
- These are local runtime artifacts, not source files
- Prevents 53+ orphaned directories from appearing as untracked

## WSP Compliance
- WSP_50: Pre-Action Verification (W4 audit confirmed missing rule)
- WSP_97: Truth Boundaries (no source changes, gitignore only)

## Safety Labels
```
GITIGNORE_ONLY
NO_SOURCE_CHANGE
NO_WORKTREE_DELETION
NO_RUNTIME_CHANGE
```

## Verification
```
$ git check-ignore -v .claude/worktrees/
.gitignore:78:.claude/worktrees/	.claude/worktrees/
```

## Test plan
- [ ] Verify `.claude/worktrees/` no longer appears in `git status`
- [ ] Verify existing worktrees unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)