### PR TITLE
fix(security): remediate gotjunk backend CVEs

### DIFF
--- a/modules/foundups/gotjunk/backend/requirements.txt
+++ b/modules/foundups/gotjunk/backend/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.104.1
+fastapi==0.122.0  # CVE-2024-24762 fix (pulls starlette>=0.40.0, fixes CVE-2024-47874/CVE-2025-54121/CVE-2025-62727)
 uvicorn[standard]==0.24.0
-python-multipart==0.0.6
+python-multipart==0.0.29  # CVE-2026-42561 fix
 pydantic==2.5.0


### PR DESCRIPTION
## Summary

Security remediation for gotjunk backend dependencies.

**Changes:**
- `fastapi`: 0.104.1 → 0.122.0 (CVE-2024-24762)
- `python-multipart`: 0.0.6 → 0.0.29 (CVE-2026-42561)
- Transitive: `starlette` 0.50.0 (CVE-2024-47874, CVE-2025-54121, CVE-2025-62727)

**Verification:**
- pip-audit: CLEAN (no known vulnerabilities)
- Import smoke: fastapi, starlette, python-multipart, pydantic OK
- API load: 8 routes verified
- FastAPI version jump justified by CVE chain

## Test Plan

- [x] pip-audit clean
- [x] Import smoke test passed
- [x] API loads with 8 routes
- [ ] CI passes

## WSP 97 Truth Boundary Labels

- DEPENDENCY_PATCH_ONLY
- GOTJUNK_BACKEND_ONLY
- PINNED_VERSION_REQUIRED
- NO_BROAD_UPGRADE
- NO_RUNTIME_CODE_CHANGE
- NO_ROOT_REQUIREMENTS_CHANGE
- NO_OTHER_MODULE_REQUIREMENTS_CHANGE
- NO_CABR_READY
- NO_PAYOUT_READY
- NO_DAO_ACTIVATION

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>