### PR TITLE
feat(holoindex): add work ledger indexing and search boosts

### DIFF
--- a/docs/audits/holoindex_search_quality/FOUNDUPS_WORK_LEDGER_HOLOINDEX_IMPLEMENTATION_PHASE1.md
+++ b/docs/audits/holoindex_search_quality/FOUNDUPS_WORK_LEDGER_HOLOINDEX_IMPLEMENTATION_PHASE1.md
@@ -1,0 +1,288 @@
+# FoundUps Work Ledger HoloIndex Implementation — Phase 1
+
+**Date**: 2026-05-21
+**Window**: W9
+**Slice**: FOUNDUPS_WORK_LEDGER_HOLOINDEX_IMPLEMENTATION_PHASE1
+**Base Commit**: `17364bfa1` (origin/main with PRs #642, #643, #644 merged)
+**Branch**: `feat/foundups-work-ledger-holoindex-implementation-phase1`
+**Mode**: IMPLEMENTATION
+
+---
+
+## WSP 97 Truth Boundary Labels
+
+| Label | Status |
+|-------|--------|
+| IMPLEMENTATION | YES |
+| HOLOINDEX_MODIFICATION | YES |
+| SEARCH_ENGINE_MODIFICATION | YES |
+| NO_LEDGER_MUTATION | YES |
+| NO_AGENTDB_MUTATION | YES |
+| NO_REGISTRY_MUTATION | YES |
+| NO_CABR_READY | YES |
+| NO_PAYOUT_READY | YES |
+| NO_DAO_ACTIVATION | YES |
+
+---
+
+## 1. Purpose
+
+Implement HoloIndex indexing and retrieval for work ledger slices as specified in FOUNDUPS_WORK_LEDGER_HOLOINDEX_INDEXING_SPEC_PHASE1.
+
+---
+
+## 2. Implementation Summary
+
+### 2.1 Files Modified
+
+| File | Changes |
+|------|---------|
+| `holo_index/core/indexing_engine.py` | Added `index_work_ledger_entries()`, `_calculate_freshness()`, `WORK_LEDGER_STATUS_RANKING` |
+| `holo_index/core/search_engine.py` | Added work ledger boost functions: `_pr_number_match_boost()`, `_owner_worker_match_boost()`, `_branch_match_boost()`, `_status_match_boost()`, `_related_foundup_match_boost()`, `_work_ledger_combined_boost()` |
+
+### 2.2 Files Created
+
+| File | Purpose |
+|------|---------|
+| `holo_index/tests/test_work_ledger_indexing.py` | 42 tests covering all implementation requirements |
+
+---
+
+## 3. Implementation Details
+
+### 3.1 Indexing Engine Additions (indexing_engine.py)
+
+#### 3.1.1 Freshness Calculation
+
+```python
+def _calculate_freshness(last_verified_at: str | None) -> float:
+    """Calculate freshness score from last_verified_at timestamp.
+    
+    Returns 1.0 for today, decays to 0.5 at 14 days, 0.1 at 30 days.
+    """
+```
+
+| Age | Freshness Score |
+|-----|-----------------|
+| 0-1 days | 1.0 |
+| 2-7 days | 0.9 |
+| 8-14 days | 0.7 |
+| 15-30 days | 0.5 |
+| 31+ days | 0.1-0.5 (decaying) |
+| None/Invalid | 0.5 (fallback) |
+
+#### 3.1.2 Status Ranking Weights
+
+```python
+WORK_LEDGER_STATUS_RANKING = {
+    "IN_PROGRESS": 1.0,
+    "STAGED_FOR_W10": 0.95,
+    "PR_OPEN": 0.9,
+    "ASSIGNED": 0.8,
+    "PROPOSED": 0.7,
+    "BLOCKED": 0.5,
+    "PARKED": 0.4,
+    "MERGED": 0.3,
+    "CLOSED": 0.3,
+    "SUPERSEDED": 0.1,
+    "ABANDONED": 0.05,
+}
+```
+
+#### 3.1.3 index_work_ledger_entries()
+
+- **Source**: `docs/0102_session_briefings/work_ledger.example.json`
+- **Collection**: `navigation_work_ledger`
+- **Document Type**: `work_ledger_slice`
+
+**Metadata Fields Extracted**:
+| Field | Type | Filter | Search |
+|-------|------|--------|--------|
+| slice_id | string | YES | YES |
+| title | string | NO | YES |
+| lane | string | YES | YES |
+| priority | string | YES | YES |
+| status | string | YES | YES |
+| owner_worker | string | YES | YES |
+| source | string | YES | YES |
+| branch | string | YES | YES |
+| pr_number | int | YES | YES |
+| related_foundup_id | string | YES | YES |
+| related_wsp_joined | string | NO | YES |
+| blocked_by_joined | string | NO | YES |
+| next_slice | string | YES | YES |
+| evidence_docs_joined | string | NO | YES |
+| wsp_labels_joined | string | NO | YES |
+| last_verified_at | string | YES | NO |
+| freshness_score | float | YES | NO |
+| status_rank | float | YES | NO |
+
+### 3.2 Search Engine Additions (search_engine.py)
+
+#### 3.2.1 Boost Functions
+
+| Function | Boost Factor | Pattern |
+|----------|-------------|---------|
+| `_pr_number_match_boost()` | 2.5x | `PR 642`, `PR#642`, `PR642` |
+| `_owner_worker_match_boost()` | 2.0x | `W9`, `W10`, `0102-A` |
+| `_branch_match_boost()` | 2.0x (exact), 1.5x (partial) | Branch name tokens |
+| `_status_match_boost()` | 1.5x | `IN_PROGRESS`, `BLOCKED`, etc. |
+| `_related_foundup_match_boost()` | 2.0x | `gotjunk`, `kosei`, etc. |
+
+#### 3.2.2 Combined Boost
+
+`_work_ledger_combined_boost()` applies all boosts for `work_ledger_slice` type documents:
+- Integrates into both vector search and lexical search paths
+- Only applies when `doc_type == "work_ledger_slice"`
+
+---
+
+## 4. Test Coverage
+
+### 4.1 Test Categories
+
+| Category | Tests | Status |
+|----------|-------|--------|
+| Freshness Calculation | 7 | PASS |
+| Status Ranking | 5 | PASS |
+| PR Number Boost | 6 | PASS |
+| Owner Worker Boost | 6 | PASS |
+| Branch Boost | 4 | PASS |
+| Status Boost | 6 | PASS |
+| Related FoundUp Boost | 3 | PASS |
+| Combined Boost | 3 | PASS |
+| End-to-End Indexing | 2 | PASS |
+| **Total** | **42** | **PASS** |
+
+### 4.2 Test Results
+
+```
+============================= 42 passed in 3.02s ==============================
+```
+
+### 4.3 Regression Tests
+
+Existing HoloIndex tests verified:
+- `test_hxa_retrieval_fix.py`: 17 passed
+- `test_search_quality_baseline.py`: 15 passed
+
+---
+
+## 5. Query Resolution Examples
+
+### 5.1 "PR 642"
+
+```
+Query: "PR 642"
+Boost: pr_number = 642 → +2.5
+Result: Slice with pr_number 642 ranked top
+```
+
+### 5.2 "what did W9 do"
+
+```
+Query: "what did W9 do"
+Boost: owner_worker = "W9" → +2.0
+Result: All W9-owned slices boosted
+```
+
+### 5.3 "what is open"
+
+```
+Query: "what is open"
+Boost: status ∈ {IN_PROGRESS, PR_OPEN, PROPOSED, ASSIGNED, STAGED_FOR_W10} → +1.0
+Result: Open work items boosted
+```
+
+### 5.4 "gotjunk work"
+
+```
+Query: "gotjunk work"
+Boost: related_foundup_id contains "gotjunk" → +2.0
+Result: GotJunk-related slices boosted
+```
+
+---
+
+## 6. Integration Notes
+
+### 6.1 Collection Registration
+
+The `work_ledger_collection` is created via `holo._reset_collection("navigation_work_ledger")`. To activate indexing, call `index_work_ledger_entries(holo)` during index refresh.
+
+### 6.2 Caller Integration
+
+Add to HoloIndex refresh cycle:
+```python
+from holo_index.core.indexing_engine import index_work_ledger_entries
+index_work_ledger_entries(holo)
+```
+
+### 6.3 Search Integration
+
+Work ledger boosts are automatically applied when:
+- `doc_type == "work_ledger_slice"`
+- Query matches PR numbers, worker IDs, branches, statuses, or foundup IDs
+
+---
+
+## 7. What This Implementation Does NOT Do
+
+| Action | Why Not |
+|--------|---------|
+| Modify work_ledger.example.json | NO_LEDGER_MUTATION |
+| Change AgentDB | NO_AGENTDB_MUTATION |
+| Modify foundup_registry.json | NO_REGISTRY_MUTATION |
+| Add ACTIVE_SLICE_LEDGER.md deprecation | Deferred to Phase 2 |
+| Add priority root configuration | Deferred to integration phase |
+
+---
+
+## 8. Next Phases
+
+| Phase | Slice ID | Deliverable |
+|-------|----------|-------------|
+| Current | FOUNDUPS_WORK_LEDGER_HOLOINDEX_IMPLEMENTATION_PHASE1 | Core indexing + boosts (this PR) |
+| +1 | FOUNDUPS_WORK_LEDGER_HOLOINDEX_INTEGRATION_PHASE1 | Priority root + refresh cycle integration |
+| +2 | FOUNDUPS_WORK_LEDGER_MARKDOWN_DEPRECATION_PHASE1 | Deprecate ACTIVE_SLICE_LEDGER indexing |
+
+---
+
+## 9. Summary
+
+### 9.1 Deliverables
+
+1. **Indexing**: `index_work_ledger_entries()` parses work ledger JSON and creates searchable slice documents
+2. **Freshness**: `_calculate_freshness()` scores entries by verification age
+3. **Status Ranking**: `WORK_LEDGER_STATUS_RANKING` weights active work above historical
+4. **Search Boosts**: 5 boost functions for PR, worker, branch, status, foundup queries
+5. **Tests**: 42 tests covering all spec requirements
+
+### 9.2 Spec Compliance
+
+| Spec Section | Implemented |
+|--------------|-------------|
+| 3.3 Metadata Fields | YES - 17 fields extracted |
+| 3.4 Exact-Match Boosts | YES - 5 boost functions |
+| 3.5 Query Resolution | YES - Status/worker/PR patterns |
+| 3.6 Status-Aware Ranking | YES - WORK_LEDGER_STATUS_RANKING |
+| 4.4 Freshness Calculation | YES - _calculate_freshness() |
+| 3.9 Test Cases | YES - 42 tests |
+
+### 9.3 W10 Readiness
+
+| Gate | Status |
+|------|--------|
+| Implementation complete | YES |
+| All tests pass | YES (42/42) |
+| No regressions | YES (32/32 existing tests pass) |
+| Audit doc complete | YES |
+| Ready for PR | YES |
+
+---
+
+**Implementation Complete**: 2026-05-21
+**Author**: W9
+**WSP 97 Verdict**: PASS — implementation with tests, no data mutations
+**Next Slice**: FOUNDUPS_WORK_LEDGER_HOLOINDEX_INTEGRATION_PHASE1
+**W10 Readiness**: APPROVED for PR

--- a/holo_index/core/indexing_engine.py
+++ b/holo_index/core/indexing_engine.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import re
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
@@ -911,3 +912,173 @@ def index_skillz_entries(holo: "HoloIndex") -> None:
         holo._log_agent_action(f"SKILLz index refreshed: {len(embeddings)} skills indexed", "OK")
     else:
         holo._log_agent_action("No SKILLz entries were indexed", "WARN")
+
+
+# ---------------------------------------------------------------------------
+# Work Ledger Indexing (FOUNDUPS_WORK_LEDGER_HOLOINDEX_IMPLEMENTATION_PHASE1)
+# ---------------------------------------------------------------------------
+
+def _calculate_freshness(last_verified_at: str | None) -> float:
+    """Calculate freshness score from last_verified_at timestamp.
+
+    Returns 1.0 for today, decays to 0.5 at 14 days, 0.1 at 30 days.
+    """
+    if not last_verified_at:
+        return 0.5
+
+    try:
+        verified = datetime.fromisoformat(last_verified_at.replace("Z", "+00:00"))
+        age_days = (datetime.now(timezone.utc) - verified).days
+
+        if age_days <= 1:
+            return 1.0
+        elif age_days <= 7:
+            return 0.9
+        elif age_days <= 14:
+            return 0.7
+        elif age_days <= 30:
+            return 0.5
+        else:
+            return max(0.1, 0.5 - (age_days - 30) * 0.01)
+    except Exception:
+        return 0.5
+
+
+# Status ranking weights for work ledger queries
+WORK_LEDGER_STATUS_RANKING = {
+    "IN_PROGRESS": 1.0,
+    "STAGED_FOR_W10": 0.95,
+    "PR_OPEN": 0.9,
+    "ASSIGNED": 0.8,
+    "PROPOSED": 0.7,
+    "BLOCKED": 0.5,
+    "PARKED": 0.4,
+    "MERGED": 0.3,
+    "CLOSED": 0.3,
+    "SUPERSEDED": 0.1,
+    "ABANDONED": 0.05,
+}
+
+
+def index_work_ledger_entries(holo: "HoloIndex") -> None:
+    """Index work ledger slices for semantic search.
+
+    Spec: FOUNDUPS_WORK_LEDGER_HOLOINDEX_INDEXING_SPEC_PHASE1
+    Source: docs/0102_session_briefings/work_ledger.example.json
+
+    Extracts each slice entry as a searchable document with metadata fields:
+    - slice_id, title, lane, priority, status, owner_worker
+    - source, branch, pr_number, related_foundup_id
+    - related_wsp_joined, blocked_by_joined, next_slice
+    - last_verified_at, freshness_score, status_rank
+    """
+    ledger_path = holo.project_root / "docs" / "0102_session_briefings" / "work_ledger.example.json"
+
+    if not ledger_path.exists():
+        holo._log_agent_action("work_ledger.example.json not found", "WARN")
+        return
+
+    try:
+        ledger_data = json.loads(ledger_path.read_text(encoding="utf-8"))
+    except Exception as e:
+        holo._log_agent_action(f"Failed to load work ledger: {e}", "ERROR")
+        return
+
+    slices = ledger_data.get("slices", [])
+    if not slices:
+        holo._log_agent_action("Work ledger has no slices", "WARN")
+        return
+
+    holo._log_agent_action(f"Indexing {len(slices)} work ledger slices...", "INDEX")
+    holo.work_ledger_collection = holo._reset_collection("navigation_work_ledger")
+
+    ids: List[str] = []
+    embeddings: List[List[float]] = []
+    documents: List[str] = []
+    metadatas: List[Dict[str, Any]] = []
+
+    for idx, slice_entry in enumerate(slices, start=1):
+        slice_id = slice_entry.get("slice_id", f"unknown_{idx}")
+        title = slice_entry.get("title", "")
+        lane = slice_entry.get("lane")
+        priority = slice_entry.get("priority", "P3")
+        status = slice_entry.get("status", "PROPOSED")
+        owner_worker = slice_entry.get("owner_worker")
+        source = slice_entry.get("source", "manual")
+        branch = slice_entry.get("branch")
+        pr_number = slice_entry.get("pr_number")
+        related_foundup_id = slice_entry.get("related_foundup_id")
+        related_wsp = slice_entry.get("related_wsp", [])
+        blocked_by = slice_entry.get("blocked_by", [])
+        next_slice = slice_entry.get("next_slice")
+        last_verified_at = slice_entry.get("last_verified_at")
+        evidence_docs = slice_entry.get("evidence_docs", [])
+        wsp_97_labels = slice_entry.get("wsp_97_labels", [])
+
+        related_wsp_joined = "|".join(related_wsp) if related_wsp else ""
+        blocked_by_joined = "|".join(blocked_by) if blocked_by else ""
+        evidence_docs_joined = "|".join(evidence_docs) if evidence_docs else ""
+        wsp_labels_joined = "|".join(wsp_97_labels) if wsp_97_labels else ""
+
+        freshness_score = _calculate_freshness(last_verified_at)
+        status_rank = WORK_LEDGER_STATUS_RANKING.get(status, 0.5)
+
+        doc_payload = (
+            f"Work Slice: {slice_id}\n"
+            f"Title: {title}\n"
+            f"Status: {status}\n"
+            f"Priority: {priority}\n"
+            f"Owner: {owner_worker or 'unassigned'}\n"
+            f"Lane: {lane or 'unassigned'}\n"
+            f"Branch: {branch or 'none'}\n"
+            f"PR: {pr_number or 'none'}\n"
+            f"Related FoundUp: {related_foundup_id or 'none'}\n"
+            f"Related WSPs: {related_wsp_joined or 'none'}\n"
+            f"Blocked by: {blocked_by_joined or 'none'}\n"
+            f"Next slice: {next_slice or 'none'}\n"
+        )
+
+        metadata: Dict[str, Any] = {
+            "slice_id": slice_id,
+            "title": title,
+            "lane": lane or "",
+            "priority": priority,
+            "status": status,
+            "owner_worker": owner_worker or "",
+            "source": source,
+            "branch": branch or "",
+            "pr_number": pr_number if pr_number is not None else -1,
+            "related_foundup_id": related_foundup_id or "",
+            "related_wsp_joined": related_wsp_joined,
+            "blocked_by_joined": blocked_by_joined,
+            "next_slice": next_slice or "",
+            "evidence_docs_joined": evidence_docs_joined,
+            "wsp_labels_joined": wsp_labels_joined,
+            "last_verified_at": last_verified_at or "",
+            "freshness_score": freshness_score,
+            "status_rank": status_rank,
+            "type": "work_ledger_slice",
+            "priority_num": 10,
+            "path": str(ledger_path),
+        }
+
+        embedding = holo._get_embedding(doc_payload)
+        ids.append(f"slice_{idx}")
+        embeddings.append(embedding)
+        documents.append(doc_payload)
+        metadatas.append(metadata)
+
+    if embeddings:
+        if not (len(ids) == len(embeddings) == len(documents) == len(metadatas)):
+            holo._log_agent_action(
+                f"Work ledger index length mismatch (ids={len(ids)}, embeddings={len(embeddings)}, "
+                f"documents={len(documents)}, metadatas={len(metadatas)}). Aborting.",
+                "ERROR",
+            )
+            return
+        holo.work_ledger_collection.add(
+            ids=ids, embeddings=embeddings, documents=documents, metadatas=metadatas
+        )
+        holo._log_agent_action(f"Work ledger index refreshed: {len(embeddings)} slices indexed", "OK")
+    else:
+        holo._log_agent_action("No work ledger entries were indexed", "WARN")

--- a/holo_index/core/search_engine.py
+++ b/holo_index/core/search_engine.py
@@ -160,6 +160,174 @@ def _normalize_for_match(text: str) -> str:
     return text.lower().replace("_", "")
 
 
+# ---------------------------------------------------------------------------
+# Work Ledger Boost Functions (FOUNDUPS_WORK_LEDGER_HOLOINDEX_IMPLEMENTATION_PHASE1)
+# ---------------------------------------------------------------------------
+
+_PR_NUMBER_PATTERN = re.compile(r"\bPR[\s#]?(\d+)\b", re.IGNORECASE)
+_WORKER_PATTERN = re.compile(r"\b(W\d+|0102-[A-G])\b", re.IGNORECASE)
+_STATUS_PATTERN = re.compile(
+    r"\b(IN_PROGRESS|STAGED_FOR_W10|PR_OPEN|ASSIGNED|PROPOSED|BLOCKED|PARKED|MERGED|CLOSED|SUPERSEDED|ABANDONED)\b",
+    re.IGNORECASE
+)
+
+
+def _extract_pr_numbers(text: str) -> List[str]:
+    """Extract PR numbers from text (e.g., 'PR 642', 'PR#642', 'PR642')."""
+    matches = _PR_NUMBER_PATTERN.findall(text)
+    return matches
+
+
+def _extract_workers(text: str) -> List[str]:
+    """Extract worker IDs from text (e.g., 'W9', 'W10', '0102-A')."""
+    matches = _WORKER_PATTERN.findall(text)
+    return [m.upper() for m in matches]
+
+
+def _extract_statuses(text: str) -> List[str]:
+    """Extract work ledger statuses from text."""
+    matches = _STATUS_PATTERN.findall(text)
+    return [m.upper() for m in matches]
+
+
+def _pr_number_match_boost(query: str, meta_pr_number: int) -> float:
+    """Return 2.5x boost if query PR number matches metadata pr_number.
+
+    Spec: FOUNDUPS_WORK_LEDGER_HOLOINDEX_INDEXING_SPEC_PHASE1 Section 3.4
+    """
+    if meta_pr_number <= 0:
+        return 0.0
+
+    query_prs = _extract_pr_numbers(query)
+    for pr_str in query_prs:
+        if int(pr_str) == meta_pr_number:
+            return 2.5
+
+    return 0.0
+
+
+def _owner_worker_match_boost(query: str, meta_owner_worker: str) -> float:
+    """Return 2.0x boost if query worker ID matches metadata owner_worker.
+
+    Spec: FOUNDUPS_WORK_LEDGER_HOLOINDEX_INDEXING_SPEC_PHASE1 Section 3.4
+    """
+    if not meta_owner_worker:
+        return 0.0
+
+    query_workers = _extract_workers(query)
+    meta_worker_normalized = meta_owner_worker.upper()
+
+    for worker in query_workers:
+        if worker == meta_worker_normalized:
+            return 2.0
+
+    return 0.0
+
+
+def _branch_match_boost(query: str, meta_branch: str) -> float:
+    """Return 2.0x boost if query branch name matches metadata branch.
+
+    Spec: FOUNDUPS_WORK_LEDGER_HOLOINDEX_INDEXING_SPEC_PHASE1 Section 3.4
+    """
+    if not meta_branch:
+        return 0.0
+
+    query_lower = query.lower()
+    branch_lower = meta_branch.lower()
+
+    if branch_lower in query_lower or query_lower in branch_lower:
+        return 2.0
+
+    branch_tokens = set(branch_lower.replace("/", "-").replace("_", "-").split("-"))
+    query_tokens = set(query_lower.split())
+    if len(branch_tokens & query_tokens) >= 2:
+        return 1.5
+
+    return 0.0
+
+
+def _status_match_boost(query: str, meta_status: str) -> float:
+    """Return 1.5x boost if query status matches metadata status.
+
+    Spec: FOUNDUPS_WORK_LEDGER_HOLOINDEX_INDEXING_SPEC_PHASE1 Section 3.4
+    """
+    if not meta_status:
+        return 0.0
+
+    query_statuses = _extract_statuses(query)
+    meta_status_normalized = meta_status.upper()
+
+    for status in query_statuses:
+        if status == meta_status_normalized:
+            return 1.5
+
+    query_lower = query.lower()
+    if "open" in query_lower and meta_status_normalized in ("IN_PROGRESS", "PR_OPEN", "PROPOSED", "ASSIGNED", "STAGED_FOR_W10"):
+        return 1.0
+    if "blocked" in query_lower and meta_status_normalized == "BLOCKED":
+        return 1.5
+    if "merged" in query_lower and meta_status_normalized == "MERGED":
+        return 1.5
+
+    return 0.0
+
+
+def _related_foundup_match_boost(query: str, meta_related_foundup_id: str) -> float:
+    """Return 2.0x boost if query contains the related foundup ID.
+
+    Spec: FOUNDUPS_WORK_LEDGER_HOLOINDEX_INDEXING_SPEC_PHASE1 Section 3.4
+    """
+    if not meta_related_foundup_id:
+        return 0.0
+
+    query_lower = query.lower()
+    foundup_lower = meta_related_foundup_id.lower()
+
+    # Exact match in query
+    if foundup_lower in query_lower:
+        return 2.0
+
+    # Match base name without suffix (e.g., "gotjunk" matches "gotjunk_001")
+    foundup_base = foundup_lower.split("_")[0] if "_" in foundup_lower else foundup_lower
+    if foundup_base and foundup_base in query_lower:
+        return 2.0
+
+    return 0.0
+
+
+def _work_ledger_combined_boost(
+    query: str,
+    meta: Dict[str, Any],
+) -> float:
+    """Apply all work ledger boosts and return combined score.
+
+    This is called for work_ledger_slice type entries.
+    """
+    total = 0.0
+
+    pr_number = meta.get("pr_number", -1)
+    if isinstance(pr_number, int):
+        total += _pr_number_match_boost(query, pr_number)
+
+    owner_worker = meta.get("owner_worker", "")
+    if owner_worker:
+        total += _owner_worker_match_boost(query, owner_worker)
+
+    branch = meta.get("branch", "")
+    if branch:
+        total += _branch_match_boost(query, branch)
+
+    status = meta.get("status", "")
+    if status:
+        total += _status_match_boost(query, status)
+
+    related_foundup_id = meta.get("related_foundup_id", "")
+    if related_foundup_id:
+        total += _related_foundup_match_boost(query, related_foundup_id)
+
+    return total
+
+
 def _wsp_number_match_boost(query: str, path: str, title: str) -> float:
     """Return keyword boost if query WSP number matches path/title WSP number.
 
@@ -555,6 +723,9 @@ def _search_collection(
         # HXA Audit Fix: Slice ID exact match boost
         meta_slice_id = meta.get("slice_id", "")
         keyword_score += _slice_id_match_boost(query, path, title, meta_slice_id)
+        # Work Ledger boost: PR, worker, branch, status, foundup_id
+        if doc_type == "work_ledger_slice":
+            keyword_score += _work_ledger_combined_boost(query, meta)
 
         if doc_type_filter != "all" and not doc_type.startswith(doc_type_filter):
             continue
@@ -671,6 +842,9 @@ def _lexical_search_collection(
             # HXA Audit Fix: Slice ID exact match boost
             meta_slice_id = meta.get("slice_id", "")
             keyword_score += _slice_id_match_boost(query, path, title, meta_slice_id)
+            # Work Ledger boost: PR, worker, branch, status, foundup_id
+            if doc_type == "work_ledger_slice":
+                keyword_score += _work_ledger_combined_boost(query, meta)
 
             if keyword_score <= 0:
                 continue

--- a/holo_index/tests/test_work_ledger_indexing.py
+++ b/holo_index/tests/test_work_ledger_indexing.py
@@ -1,0 +1,444 @@
+# -*- coding: utf-8 -*-
+"""Tests for Work Ledger HoloIndex Indexing.
+
+FOUNDUPS_WORK_LEDGER_HOLOINDEX_IMPLEMENTATION_PHASE1
+
+These tests verify:
+1. Work ledger metadata extraction
+2. Freshness score calculation
+3. Status ranking weights
+4. Work ledger search boosts (PR, worker, branch, status, foundup_id)
+5. End-to-end indexing
+"""
+
+import json
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestFreshnessCalculation:
+    """Test freshness score calculation from last_verified_at."""
+
+    def test_freshness_today_returns_1_0(self):
+        """Entry verified today returns 1.0 freshness."""
+        from holo_index.core.indexing_engine import _calculate_freshness
+
+        now = datetime.now(timezone.utc).isoformat()
+        assert _calculate_freshness(now) == 1.0
+
+    def test_freshness_7_days_returns_0_9(self):
+        """Entry verified 7 days ago returns 0.9 freshness."""
+        from holo_index.core.indexing_engine import _calculate_freshness
+
+        week_ago = (datetime.now(timezone.utc) - timedelta(days=5)).isoformat()
+        assert _calculate_freshness(week_ago) == 0.9
+
+    def test_freshness_14_days_returns_0_7(self):
+        """Entry verified 14 days ago returns 0.7 freshness."""
+        from holo_index.core.indexing_engine import _calculate_freshness
+
+        two_weeks = (datetime.now(timezone.utc) - timedelta(days=12)).isoformat()
+        assert _calculate_freshness(two_weeks) == 0.7
+
+    def test_freshness_30_days_returns_0_5(self):
+        """Entry verified 30 days ago returns 0.5 freshness."""
+        from holo_index.core.indexing_engine import _calculate_freshness
+
+        month_ago = (datetime.now(timezone.utc) - timedelta(days=25)).isoformat()
+        assert _calculate_freshness(month_ago) == 0.5
+
+    def test_freshness_60_days_returns_low(self):
+        """Entry verified 60 days ago returns low freshness."""
+        from holo_index.core.indexing_engine import _calculate_freshness
+
+        two_months = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+        result = _calculate_freshness(two_months)
+        assert result <= 0.3
+        assert result >= 0.1
+
+    def test_freshness_null_returns_0_5(self):
+        """None last_verified_at returns 0.5 (middle value)."""
+        from holo_index.core.indexing_engine import _calculate_freshness
+
+        assert _calculate_freshness(None) == 0.5
+
+    def test_freshness_invalid_string_returns_0_5(self):
+        """Invalid date string returns 0.5 (fallback)."""
+        from holo_index.core.indexing_engine import _calculate_freshness
+
+        assert _calculate_freshness("not-a-date") == 0.5
+
+
+class TestStatusRanking:
+    """Test status ranking weights."""
+
+    def test_in_progress_highest_rank(self):
+        """IN_PROGRESS has highest rank (1.0)."""
+        from holo_index.core.indexing_engine import WORK_LEDGER_STATUS_RANKING
+
+        assert WORK_LEDGER_STATUS_RANKING["IN_PROGRESS"] == 1.0
+
+    def test_staged_for_w10_second_highest(self):
+        """STAGED_FOR_W10 has second highest rank."""
+        from holo_index.core.indexing_engine import WORK_LEDGER_STATUS_RANKING
+
+        assert WORK_LEDGER_STATUS_RANKING["STAGED_FOR_W10"] == 0.95
+
+    def test_superseded_near_lowest(self):
+        """SUPERSEDED has near lowest rank (0.1)."""
+        from holo_index.core.indexing_engine import WORK_LEDGER_STATUS_RANKING
+
+        assert WORK_LEDGER_STATUS_RANKING["SUPERSEDED"] == 0.1
+
+    def test_abandoned_lowest(self):
+        """ABANDONED has lowest rank (0.05)."""
+        from holo_index.core.indexing_engine import WORK_LEDGER_STATUS_RANKING
+
+        assert WORK_LEDGER_STATUS_RANKING["ABANDONED"] == 0.05
+
+    def test_merged_lower_than_open(self):
+        """MERGED ranks lower than IN_PROGRESS."""
+        from holo_index.core.indexing_engine import WORK_LEDGER_STATUS_RANKING
+
+        assert WORK_LEDGER_STATUS_RANKING["MERGED"] < WORK_LEDGER_STATUS_RANKING["IN_PROGRESS"]
+
+
+class TestPRNumberBoost:
+    """Test PR number exact match boost."""
+
+    def test_pr_number_match_returns_2_5(self):
+        """Exact PR number match returns 2.5 boost."""
+        from holo_index.core.search_engine import _pr_number_match_boost
+
+        boost = _pr_number_match_boost("PR 642", 642)
+        assert boost == 2.5
+
+    def test_pr_hash_format_match(self):
+        """PR#642 format matches."""
+        from holo_index.core.search_engine import _pr_number_match_boost
+
+        boost = _pr_number_match_boost("PR#642", 642)
+        assert boost == 2.5
+
+    def test_pr_no_space_match(self):
+        """PR642 format matches."""
+        from holo_index.core.search_engine import _pr_number_match_boost
+
+        boost = _pr_number_match_boost("PR642", 642)
+        assert boost == 2.5
+
+    def test_pr_mismatch_returns_0(self):
+        """PR number mismatch returns 0."""
+        from holo_index.core.search_engine import _pr_number_match_boost
+
+        boost = _pr_number_match_boost("PR 642", 643)
+        assert boost == 0.0
+
+    def test_no_pr_in_query_returns_0(self):
+        """No PR in query returns 0."""
+        from holo_index.core.search_engine import _pr_number_match_boost
+
+        boost = _pr_number_match_boost("work ledger schema", 642)
+        assert boost == 0.0
+
+    def test_negative_pr_number_returns_0(self):
+        """Negative/invalid PR number returns 0."""
+        from holo_index.core.search_engine import _pr_number_match_boost
+
+        boost = _pr_number_match_boost("PR 642", -1)
+        assert boost == 0.0
+
+
+class TestOwnerWorkerBoost:
+    """Test owner_worker exact match boost."""
+
+    def test_worker_match_returns_2_0(self):
+        """Exact worker match returns 2.0 boost."""
+        from holo_index.core.search_engine import _owner_worker_match_boost
+
+        boost = _owner_worker_match_boost("what did W9 do", "W9")
+        assert boost == 2.0
+
+    def test_worker_case_insensitive(self):
+        """Worker match is case insensitive."""
+        from holo_index.core.search_engine import _owner_worker_match_boost
+
+        boost = _owner_worker_match_boost("what did w9 do", "W9")
+        assert boost == 2.0
+
+    def test_lane_worker_format(self):
+        """0102-A format matches."""
+        from holo_index.core.search_engine import _owner_worker_match_boost
+
+        boost = _owner_worker_match_boost("0102-A work", "0102-A")
+        assert boost == 2.0
+
+    def test_worker_mismatch_returns_0(self):
+        """Worker mismatch returns 0."""
+        from holo_index.core.search_engine import _owner_worker_match_boost
+
+        boost = _owner_worker_match_boost("what did W9 do", "W10")
+        assert boost == 0.0
+
+    def test_no_worker_in_query_returns_0(self):
+        """No worker in query returns 0."""
+        from holo_index.core.search_engine import _owner_worker_match_boost
+
+        boost = _owner_worker_match_boost("work ledger status", "W9")
+        assert boost == 0.0
+
+    def test_empty_worker_returns_0(self):
+        """Empty owner_worker returns 0."""
+        from holo_index.core.search_engine import _owner_worker_match_boost
+
+        boost = _owner_worker_match_boost("what did W9 do", "")
+        assert boost == 0.0
+
+
+class TestBranchBoost:
+    """Test branch name match boost."""
+
+    def test_branch_substring_match(self):
+        """Branch substring match returns 2.0 boost."""
+        from holo_index.core.search_engine import _branch_match_boost
+
+        boost = _branch_match_boost(
+            "docs/foundups-work-ledger-schema-phase1",
+            "docs/foundups-work-ledger-schema-phase1"
+        )
+        assert boost == 2.0
+
+    def test_branch_partial_match(self):
+        """Branch partial match returns 1.5 boost."""
+        from holo_index.core.search_engine import _branch_match_boost
+
+        boost = _branch_match_boost("work ledger schema", "docs/foundups-work-ledger-schema-phase1")
+        assert boost >= 1.5
+
+    def test_branch_no_match_returns_0(self):
+        """No branch match returns 0."""
+        from holo_index.core.search_engine import _branch_match_boost
+
+        boost = _branch_match_boost("security audit", "docs/foundups-work-ledger-schema-phase1")
+        assert boost == 0.0
+
+    def test_empty_branch_returns_0(self):
+        """Empty branch returns 0."""
+        from holo_index.core.search_engine import _branch_match_boost
+
+        boost = _branch_match_boost("work ledger", "")
+        assert boost == 0.0
+
+
+class TestStatusBoost:
+    """Test status match boost."""
+
+    def test_exact_status_match(self):
+        """Exact status match returns 1.5 boost."""
+        from holo_index.core.search_engine import _status_match_boost
+
+        boost = _status_match_boost("IN_PROGRESS work", "IN_PROGRESS")
+        assert boost == 1.5
+
+    def test_open_query_matches_in_progress(self):
+        """'open' query matches IN_PROGRESS."""
+        from holo_index.core.search_engine import _status_match_boost
+
+        boost = _status_match_boost("what is open", "IN_PROGRESS")
+        assert boost >= 1.0
+
+    def test_blocked_query_matches_blocked(self):
+        """'blocked' query matches BLOCKED status."""
+        from holo_index.core.search_engine import _status_match_boost
+
+        boost = _status_match_boost("what is blocked", "BLOCKED")
+        assert boost == 1.5
+
+    def test_merged_query_matches_merged(self):
+        """'merged' query matches MERGED status."""
+        from holo_index.core.search_engine import _status_match_boost
+
+        boost = _status_match_boost("what merged", "MERGED")
+        assert boost == 1.5
+
+    def test_status_mismatch_returns_0(self):
+        """Status mismatch returns 0."""
+        from holo_index.core.search_engine import _status_match_boost
+
+        boost = _status_match_boost("PR_OPEN", "MERGED")
+        assert boost == 0.0
+
+    def test_empty_status_returns_0(self):
+        """Empty status returns 0."""
+        from holo_index.core.search_engine import _status_match_boost
+
+        boost = _status_match_boost("IN_PROGRESS", "")
+        assert boost == 0.0
+
+
+class TestRelatedFoundupBoost:
+    """Test related_foundup_id match boost."""
+
+    def test_foundup_match_returns_2_0(self):
+        """Foundup ID match returns 2.0 boost."""
+        from holo_index.core.search_engine import _related_foundup_match_boost
+
+        boost = _related_foundup_match_boost("gotjunk work", "gotjunk_001")
+        assert boost == 2.0
+
+    def test_foundup_no_match_returns_0(self):
+        """No foundup match returns 0."""
+        from holo_index.core.search_engine import _related_foundup_match_boost
+
+        boost = _related_foundup_match_boost("kosei work", "gotjunk_001")
+        assert boost == 0.0
+
+    def test_empty_foundup_returns_0(self):
+        """Empty related_foundup_id returns 0."""
+        from holo_index.core.search_engine import _related_foundup_match_boost
+
+        boost = _related_foundup_match_boost("gotjunk work", "")
+        assert boost == 0.0
+
+
+class TestCombinedBoost:
+    """Test combined work ledger boost function."""
+
+    def test_combined_boost_with_all_fields(self):
+        """Combined boost adds all matching fields."""
+        from holo_index.core.search_engine import _work_ledger_combined_boost
+
+        meta: Dict[str, Any] = {
+            "pr_number": 642,
+            "owner_worker": "W9",
+            "branch": "docs/foundups-work-ledger",
+            "status": "IN_PROGRESS",
+            "related_foundup_id": "gotjunk_001",
+        }
+
+        # Query hits PR and worker
+        boost = _work_ledger_combined_boost("PR 642 W9 work", meta)
+        assert boost >= 4.5  # PR (2.5) + Worker (2.0)
+
+    def test_combined_boost_partial_match(self):
+        """Combined boost with partial matches."""
+        from holo_index.core.search_engine import _work_ledger_combined_boost
+
+        meta: Dict[str, Any] = {
+            "pr_number": 642,
+            "owner_worker": "W9",
+            "branch": "",
+            "status": "MERGED",
+            "related_foundup_id": "",
+        }
+
+        boost = _work_ledger_combined_boost("PR 642", meta)
+        assert boost == 2.5  # Only PR matches
+
+    def test_combined_boost_no_match(self):
+        """Combined boost with no matches returns 0."""
+        from holo_index.core.search_engine import _work_ledger_combined_boost
+
+        meta: Dict[str, Any] = {
+            "pr_number": 642,
+            "owner_worker": "W9",
+            "branch": "feature/something",
+            "status": "IN_PROGRESS",
+            "related_foundup_id": "gotjunk_001",
+        }
+
+        boost = _work_ledger_combined_boost("unrelated query", meta)
+        assert boost == 0.0
+
+
+class TestWorkLedgerIndexing:
+    """Test end-to-end work ledger indexing."""
+
+    def test_index_work_ledger_entries_extracts_metadata(self):
+        """index_work_ledger_entries extracts all required metadata fields."""
+        from holo_index.core.indexing_engine import index_work_ledger_entries
+
+        # Create mock HoloIndex
+        mock_holo = MagicMock()
+        mock_holo._get_embedding = MagicMock(return_value=[0.1] * 384)
+        mock_holo._reset_collection = MagicMock(return_value=MagicMock())
+        mock_holo._log_agent_action = MagicMock()
+
+        # Create temp work ledger
+        ledger_data = {
+            "schema_version": "1.0.0",
+            "last_updated": "2026-05-21T12:00:00Z",
+            "slices": [
+                {
+                    "slice_id": "TEST_SLICE_001",
+                    "title": "Test Slice",
+                    "lane": "W9",
+                    "priority": "P1",
+                    "status": "IN_PROGRESS",
+                    "owner_worker": "W9",
+                    "source": "audit",
+                    "branch": "test/branch",
+                    "pr_number": 123,
+                    "related_foundup_id": "gotjunk_001",
+                    "related_wsp": ["WSP 97"],
+                    "blocked_by": [],
+                    "next_slice": "TEST_SLICE_002",
+                    "created_at": "2026-05-21T10:00:00Z",
+                    "last_verified_at": "2026-05-21T12:00:00Z",
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger_path = Path(tmpdir) / "docs" / "0102_session_briefings"
+            ledger_path.mkdir(parents=True)
+            (ledger_path / "work_ledger.example.json").write_text(
+                json.dumps(ledger_data), encoding="utf-8"
+            )
+
+            mock_holo.project_root = Path(tmpdir)
+
+            index_work_ledger_entries(mock_holo)
+
+            # Verify collection.add was called
+            mock_collection = mock_holo.work_ledger_collection
+            assert mock_collection.add.called
+
+            # Get the metadata that was passed
+            call_args = mock_collection.add.call_args
+            metadatas = call_args[1]["metadatas"]
+            assert len(metadatas) == 1
+
+            meta = metadatas[0]
+            assert meta["slice_id"] == "TEST_SLICE_001"
+            assert meta["title"] == "Test Slice"
+            assert meta["lane"] == "W9"
+            assert meta["priority"] == "P1"
+            assert meta["status"] == "IN_PROGRESS"
+            assert meta["owner_worker"] == "W9"
+            assert meta["pr_number"] == 123
+            assert meta["related_foundup_id"] == "gotjunk_001"
+            assert meta["type"] == "work_ledger_slice"
+            assert meta["freshness_score"] > 0.0
+            assert meta["status_rank"] == 1.0  # IN_PROGRESS
+
+    def test_index_work_ledger_handles_missing_file(self):
+        """index_work_ledger_entries handles missing file gracefully."""
+        from holo_index.core.indexing_engine import index_work_ledger_entries
+
+        mock_holo = MagicMock()
+        mock_holo._log_agent_action = MagicMock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mock_holo.project_root = Path(tmpdir)
+            index_work_ledger_entries(mock_holo)
+
+            # Should log warning
+            mock_holo._log_agent_action.assert_called_with(
+                "work_ledger.example.json not found", "WARN"
+            )


### PR DESCRIPTION
## Summary

- Add `index_work_ledger_entries()` to parse `work_ledger.example.json` and index slices into ChromaDB
- Extract 17 metadata fields per slice (slice_id, status, pr_number, owner_worker, branch, etc.)
- Implement freshness calculation based on `last_verified_at` (1.0 for today, decays over time)
- Add `WORK_LEDGER_STATUS_RANKING` weights (IN_PROGRESS=1.0 highest, ABANDONED=0.05 lowest)
- Add 5 search boost functions: PR (2.5x), worker (2.0x), branch (2.0x), status (1.5x), foundup_id (2.0x)
- Integrate boosts into both vector and lexical search paths

## Test Plan

- [x] 42 unit tests for all boost functions, freshness calculation, status ranking
- [x] End-to-end indexing test with mock HoloIndex
- [x] Regression tests pass: test_hxa_retrieval_fix.py (17), test_search_quality_baseline.py (15)

## Spec Reference

- `docs/audits/holoindex_search_quality/FOUNDUPS_WORK_LEDGER_HOLOINDEX_INDEXING_SPEC_PHASE1.md`

## WSP 97 Truth Boundaries

| Label | Status |
|-------|--------|
| IMPLEMENTATION | YES |
| HOLOINDEX_MODIFICATION | YES |
| NO_LEDGER_MUTATION | YES |
| NO_REGISTRY_MUTATION | YES |

🤖 Generated with [Claude Code](https://claude.com/claude-code)