### PR TITLE
fix(holoindex): coerce work ledger priority for retrieval ranking

### DIFF
--- a/docs/audits/holoindex_search_quality/FOUNDUPS_WORK_LEDGER_SEARCH_RETRIEVAL_PRIORITY_HOTFIX_PHASE1.md
+++ b/docs/audits/holoindex_search_quality/FOUNDUPS_WORK_LEDGER_SEARCH_RETRIEVAL_PRIORITY_HOTFIX_PHASE1.md
@@ -1,0 +1,268 @@
+# FoundUps Work Ledger Search Retrieval Priority Hotfix — Phase 1
+
+**Date**: 2026-05-22
+**Slice**: FOUNDUPS_WORK_LEDGER_SEARCH_RETRIEVAL_PRIORITY_HOTFIX_PHASE1
+**Base Commit**: `600eee482` (main; PR #649 + later merges, ancestry includes `1c937cf5c`)
+**Branch**: `feat/work-ledger-priority-hotfix`
+**Worktree**: `.claude/worktrees/work-ledger-priority-hotfix`
+**Mode**: IMPLEMENTATION (hotfix)
+
+---
+
+## WSP 97 Truth Boundary Labels
+
+| Label | Status |
+|-------|--------|
+| HOLOINDEX_RETRIEVAL_HOTFIX_ONLY | YES |
+| WORK_LEDGER_SEARCH_FIX_ONLY | YES |
+| NO_LIVE_REINDEX | YES (only end-to-end read against pre-existing populated collection) |
+| NO_LEDGER_MUTATION | YES |
+| NO_AGENTDB_MUTATION | YES |
+| NO_REGISTRY_MUTATION | YES |
+| NO_RUNTIME_WRE_CHANGE | YES |
+| NO_MCP_CHANGE | YES |
+| NO_GENERATED_INDEX_ARTIFACTS | YES |
+| NO_CABR_READY | YES |
+| NO_PAYOUT_READY | YES |
+| NO_DAO_ACTIVATION | YES |
+
+---
+
+## 1. Defect Context
+
+`FOUNDUPS_WORK_LEDGER_CONTROLLED_REINDEX_PHASE1_RETRY` documented:
+
+- `navigation_work_ledger` collection populated with 5 entries via `python holo_index.py --index-work-ledger`
+- CLI search returns `0 WorkLedger` despite collection being populated
+- Root cause: `priority = meta.get("priority", 1)` in `_search_collection` returns string `"P3"` for work-ledger entries; `_format_hit` then evaluates `0.5 * "P3"` → `TypeError`
+- The exception was silently swallowed by `except Exception: work_ledger_hits = []`, erasing the entire bucket without diagnostic signal
+
+---
+
+## 2. HoloIndex Assessment (WSP 87)
+
+| Query | Hits | Quality |
+|-------|------|---------|
+| `work ledger priority_num priority P3 search_engine _format_hit` | 32 | LOW — generic CLI/economics hits |
+| `work_ledger_slice search_engine execute_search exception logging` | 32 | LOW — generic search hits |
+
+Fallback to direct code reading was required (consistent with prior search-engine slices).
+
+---
+
+## 3. Implementation Summary
+
+### 3.1 Files Modified
+
+| File | Changes |
+|------|---------|
+| `holo_index/core/search_engine.py` | Added `_PRIORITY_LABEL_WEIGHTS` constant, added `_coerce_priority()` helper, replaced bare `meta.get("priority", 1)` lookup, upgraded silent `except Exception` in work-ledger block to logged warning |
+| `holo_index/tests/test_work_ledger_indexing.py` | Added 11 tests across 3 new test classes |
+| `docs/audits/holoindex_search_quality/FOUNDUPS_WORK_LEDGER_SEARCH_RETRIEVAL_PRIORITY_HOTFIX_PHASE1.md` | NEW (this audit) |
+
+### 3.2 New helper: `_coerce_priority(meta, default=1.0)`
+
+Resolution order, never raises:
+1. `priority_num` if numeric (work-ledger indexer always writes this).
+2. `priority` if numeric (standard collections).
+3. `priority` interpreted as P0..P4 label via `_PRIORITY_LABEL_WEIGHTS` (`P0=5, P1=4, P2=3, P3=2, P4=1`).
+4. `priority` interpreted as a numeric string.
+5. `default`.
+
+Boolean values are explicitly rejected from the numeric branches (Python booleans subclass `int`).
+
+### 3.3 Replaced call site
+
+In `_search_collection` (~line 686):
+```python
+# Before
+priority = meta.get("priority", 1)
+
+# After
+priority = _coerce_priority(meta)
+```
+
+This is the single arithmetic input that `_format_hit` consumes for the `_sort_key` calculation. Coercing at the source ensures every downstream usage receives a number.
+
+### 3.4 Logging upgrade in `execute_search` (lines 1088-1099)
+
+```python
+# Before
+except Exception:
+    work_ledger_hits = []
+
+# After
+except Exception as exc:
+    logger.warning(
+        "Work-ledger search failed (%s): %s. Falling back to empty hits — normal search continues.",
+        type(exc).__name__, exc, exc_info=True,
+    )
+    work_ledger_hits = []
+```
+
+Silent failure is the operational hazard that caused W6/W10 to waste a full reindex cycle before detection. Logging here makes future regressions surface in normal observability.
+
+### 3.5 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Coerce at `_search_collection` rather than `_format_hit` | Single chokepoint; downstream signature stays numeric. Less surface area than touching `_format_hit` across all collection types. |
+| Defensive label fallback (P0..P4) | Indexer currently writes both `priority_num` AND `priority`. The label fallback protects against future indexer changes that drop one or the other. |
+| Reject booleans explicitly | Python `bool` subclasses `int`. Without explicit rejection, `priority=True` would propagate as `1.0`, masking metadata bugs. |
+| Keep work-ledger fallback returning `[]` (not raising) | Other search buckets (code/wsp/docs) still need to work even if work-ledger errors. Continuity > strict failure. |
+| Log at `WARNING`, not `ERROR` | Operationally important but the search still returns useful results. `WARNING` is the right severity for a degraded-but-functional state. |
+
+---
+
+## 4. End-to-End Verification (Read-Only Against Live Collection)
+
+The previous reindex slice left the `navigation_work_ledger` collection populated with 5 entries on E:/HoloIndex. **No reindex was executed in this slice** — the existing index was queried read-only to verify the fix end-to-end.
+
+### 4.1 Before this hotfix (per RETRY audit)
+```
+[HOLO-0102] Search complete: ... 0 WorkLedger
+result['work_ledger_hits'] == []
+```
+
+### 4.2 After this hotfix
+```
+$ python -c "from holo_index.core.holo_index import HoloIndex; ..."
+[HOLO-0102] Search complete: 0 code, 0 WSP, 0 Tests, 0 Skillz, 0 Docs, 0 Knowledge, 5 WorkLedger
+work_ledger_hits: 5
+  - Work Ledger JSON Schema Definition (priority=10.0)
+  - Patch Brain Existing Artifacts into Work Ledger Audit (priority=10.0)
+  - I_i Bonding Curve Legal Review Packet (priority=10.0)
+  - Du Pool Staker Model Truth Alignment (priority=10.0)
+  - OpenClaw Security Fail Dispatch to AI Overseer (priority=10.0)
+```
+
+All 5 slices retrievable. Priority correctly coerced to numeric (10.0 from `priority_num`).
+
+---
+
+## 5. Test Results
+
+### 5.1 New Tests (11 added)
+
+| Class | Test | Status |
+|-------|------|--------|
+| `TestPriorityCoercion` | `test_priority_num_wins_over_string_priority` | PASS |
+| `TestPriorityCoercion` | `test_numeric_priority_returned_unchanged` | PASS |
+| `TestPriorityCoercion` | `test_p_label_coerced_to_weight` | PASS |
+| `TestPriorityCoercion` | `test_p_label_case_and_whitespace_tolerated` | PASS |
+| `TestPriorityCoercion` | `test_unknown_label_falls_back_to_default` | PASS |
+| `TestPriorityCoercion` | `test_numeric_string_parsed` | PASS |
+| `TestPriorityCoercion` | `test_missing_metadata_returns_default` | PASS |
+| `TestPriorityCoercion` | `test_bool_priority_rejected_falls_through` | PASS |
+| `TestFormatHitWithStringPriority` | `test_search_collection_does_not_crash_with_string_priority` | PASS |
+| `TestExecuteSearchWorkLedgerLogging` | `test_work_ledger_exception_is_logged_and_search_continues` | PASS |
+| `TestExecuteSearchWorkLedgerLogging` | `test_work_ledger_collection_none_does_not_log_warning` | PASS |
+
+### 5.2 Full Work-Ledger Suite
+
+```
+============================= 74 passed in 7.21s ==============================
+```
+
+All prior 63 tests + 11 new = **74/74 passing**.
+
+### 5.3 Regression Suites
+
+```
+============================= 32 passed in 1.28s ==============================
+```
+
+| Suite | Tests | Status |
+|-------|-------|--------|
+| `test_hxa_retrieval_fix.py` | 22 | PASS |
+| `test_search_quality_baseline.py` | 10 | PASS |
+
+### 5.4 Total
+
+**106 tests passing in modified scope, 0 regressions.**
+
+---
+
+## 6. Verification Matrix
+
+| Requirement | Status | Evidence |
+|-------------|--------|----------|
+| Work-ledger result with `priority="P3"` and `priority_num=10` does not crash | PASS | test_search_collection_does_not_crash_with_string_priority |
+| Query by slice_id returns ≥1 hit in mocked search path | PASS | test_search_collection_does_not_crash_with_string_priority (returns 1 hit) |
+| `_sort_key` uses numeric priority | PASS | Live e2e shows `priority=10.0` (float) |
+| Missing `priority_num` with label `P1` coerces safely | PASS | test_p_label_coerced_to_weight |
+| Invalid priority label falls back safely | PASS | test_unknown_label_falls_back_to_default |
+| Exception in work-ledger block logged, not silenced | PASS | test_work_ledger_exception_is_logged_and_search_continues |
+| Normal search continues when work-ledger errors | PASS | Other hits still returned; only `work_ledger_hits=[]` |
+| Existing work-ledger tests pass | PASS | 63/63 |
+| HXA retrieval tests pass | PASS | 22/22 |
+| Search quality baseline pass | PASS | 10/10 |
+| No live reindex executed | PASS | No `--index-work-ledger` invocation in this slice |
+| No source mutations outside allowed scope | PASS | Only `search_engine.py` + tests + audit |
+| No generated index artifacts | PASS | No reindex, no Chroma writes from this slice |
+
+---
+
+## 7. Outputs
+
+### 7.1 Files Changed by This Slice
+
+| File | Type |
+|------|------|
+| `holo_index/core/search_engine.py` | Modified — added `_coerce_priority` helper, replaced call site, upgraded exception handler |
+| `holo_index/tests/test_work_ledger_indexing.py` | Modified — added 3 test classes / 11 tests |
+| `docs/audits/holoindex_search_quality/FOUNDUPS_WORK_LEDGER_SEARCH_RETRIEVAL_PRIORITY_HOTFIX_PHASE1.md` | NEW |
+
+Zero ledger, AgentDB, registry, WRE, OpenClaw, MCP, or pFMALL catalog changes.
+
+### 7.2 Generated Artifacts Status
+
+None. No reindex executed. The end-to-end verification queried the pre-existing collection state from the prior controlled-reindex slice (read-only).
+
+---
+
+## 8. WSP 97 Verdict
+
+| Check | Result |
+|-------|--------|
+| False claims detected? | NO |
+| Live reindex executed? | NO |
+| Ledger JSON modified? | NO |
+| AgentDB / Registry / WRE / OpenClaw / MCP changed? | NO |
+| Generated index artifacts committed? | NO |
+| Defect fully fixed (retrieval working end-to-end)? | YES |
+| New test coverage prevents regression? | YES (11 tests) |
+
+**WSP 97 VERDICT**: **PASS**
+
+---
+
+## 9. Next Slice Recommendation
+
+**Slice ID**: `FOUNDUPS_WORK_LEDGER_CONTROLLED_REINDEX_PHASE1_RETRY` — **search-verification mode**
+
+**Purpose**: With the hotfix merged, re-run the controlled reindex verification slice in **search-verification mode only** (do NOT re-execute `--index-work-ledger`; the existing collection state is intact and already-correct metadata). Confirm:
+1. All 5 verification queries return `>0` work-ledger hits via the CLI summary line `(... N WorkLedger)`.
+2. slice_id, PR number, owner_worker, status, and related_foundup_id queries each return the expected slice.
+3. No regression in normal HoloIndex queries.
+
+If the operator/W10 chooses to re-reindex first (e.g., to verify the indexer side still writes correctly), use `python holo_index.py --index-work-ledger` — the wrapper is unchanged by this slice.
+
+---
+
+## 10. Summary
+
+| Aspect | State |
+|--------|-------|
+| Retrieval defect identified by RETRY slice | FIXED |
+| Search returns work-ledger hits | YES (5/5 against live collection) |
+| Silent exception swallowing | REPLACED with logged warning |
+| Test coverage added | 11 tests across coercion, format-hit, and exception logging |
+| Regression risk | LOW (no behavior change for non-work-ledger collections, helper is purely additive) |
+| Ready for W10 | YES |
+
+---
+
+**Implementation Complete**: 2026-05-22
+**Author**: Targeted HoloIndex bugfix worker
+**WSP Lock**: WSP_00, WSP_15, WSP_50, WSP_87, WSP_97, WSP_22

--- a/holo_index/core/search_engine.py
+++ b/holo_index/core/search_engine.py
@@ -37,6 +37,52 @@ def _tokenize_query(query: str) -> List[str]:
     return [token for token in re.findall(r"[a-z0-9_]+", query.lower()) if token]
 
 
+# Slice-priority label → numeric weight (used when metadata stores P0/P1/.../P4 strings
+# instead of a numeric priority_num field). Mirrors WSP 15 priority ordering, scaled to the
+# 1-5 range that _format_hit's _sort_key expects.
+_PRIORITY_LABEL_WEIGHTS: Dict[str, float] = {
+    "P0": 5.0,
+    "P1": 4.0,
+    "P2": 3.0,
+    "P3": 2.0,
+    "P4": 1.0,
+}
+
+
+def _coerce_priority(meta: Dict[str, Any], default: float = 1.0) -> float:
+    """Return a numeric priority for *meta* suitable for arithmetic scoring.
+
+    Resolution order:
+      1. `priority_num` (work-ledger metadata always writes a numeric here).
+      2. `priority` interpreted as int/float.
+      3. `priority` interpreted as a P0..P4 label via `_PRIORITY_LABEL_WEIGHTS`.
+      4. *default*.
+
+    Never raises. Guards against the historical bug where work-ledger entries
+    stored `priority="P3"` (string) and downstream scoring did `0.5 * priority`
+    → TypeError, which was silently swallowed and erased work-ledger hits from
+    the search payload.
+    """
+    raw_num = meta.get("priority_num")
+    if isinstance(raw_num, (int, float)) and not isinstance(raw_num, bool):
+        return float(raw_num)
+
+    raw = meta.get("priority", default)
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+        return float(raw)
+
+    if isinstance(raw, str):
+        label = raw.strip().upper()
+        if label in _PRIORITY_LABEL_WEIGHTS:
+            return _PRIORITY_LABEL_WEIGHTS[label]
+        try:
+            return float(label)
+        except (TypeError, ValueError):
+            pass
+
+    return float(default)
+
+
 # ---------------------------------------------------------------------------
 # HIA3 (2026-04-23): backend quality taxonomy (WSP 97 truth distinction).
 #
@@ -683,7 +729,7 @@ def _search_collection(
         if similarity < min_similarity:
             continue
         doc_type = meta.get("type", "other")
-        priority = meta.get("priority", 1)
+        priority = _coerce_priority(meta)
 
         keyword_score = 0.0
         ql = query.lower()
@@ -1089,7 +1135,16 @@ def execute_search(
         if doc_type_filter in ["work_ledger", "all"] and work_ledger_collection is not None:
             try:
                 work_ledger_hits = _search_collection(holo, work_ledger_collection, query, limit, kind="work_ledger")
-            except Exception:
+            except Exception as exc:
+                # Log instead of silently erasing hits — silent failures here cost W6/W10 an
+                # entire reindex cycle before the bug was detected. See
+                # FOUNDUPS_WORK_LEDGER_SEARCH_RETRIEVAL_PRIORITY_HOTFIX_PHASE1.
+                logger.warning(
+                    "Work-ledger search failed (%s): %s. Falling back to empty hits — normal search continues.",
+                    type(exc).__name__,
+                    exc,
+                    exc_info=True,
+                )
                 work_ledger_hits = []
 
         # Symbol-query fallback: lexical + rg for exact identifiers/paths

--- a/holo_index/tests/test_work_ledger_indexing.py
+++ b/holo_index/tests/test_work_ledger_indexing.py
@@ -843,3 +843,162 @@ class TestCLIFlagParsing:
         assert "--index-skillz" in output
         assert "--index-cli" in output
         assert "--index-all" in output
+
+
+class TestPriorityCoercion:
+    """_coerce_priority — FOUNDUPS_WORK_LEDGER_SEARCH_RETRIEVAL_PRIORITY_HOTFIX_PHASE1."""
+
+    def test_priority_num_wins_over_string_priority(self):
+        """priority_num takes precedence — work-ledger indexer writes both fields."""
+        from holo_index.core.search_engine import _coerce_priority
+        # Work-ledger indexer writes priority="P3" AND priority_num=10
+        assert _coerce_priority({"priority_num": 10, "priority": "P3"}) == 10.0
+
+    def test_numeric_priority_returned_unchanged(self):
+        """Standard collections (code/wsp/docs) pass numeric priority through."""
+        from holo_index.core.search_engine import _coerce_priority
+        assert _coerce_priority({"priority": 7}) == 7.0
+        assert _coerce_priority({"priority": 2.5}) == 2.5
+
+    def test_p_label_coerced_to_weight(self):
+        """P0..P4 string labels coerce to numeric weights."""
+        from holo_index.core.search_engine import _coerce_priority
+        assert _coerce_priority({"priority": "P0"}) == 5.0
+        assert _coerce_priority({"priority": "P1"}) == 4.0
+        assert _coerce_priority({"priority": "P2"}) == 3.0
+        assert _coerce_priority({"priority": "P3"}) == 2.0
+        assert _coerce_priority({"priority": "P4"}) == 1.0
+
+    def test_p_label_case_and_whitespace_tolerated(self):
+        """Defensive coercion handles lowercase/whitespace variants."""
+        from holo_index.core.search_engine import _coerce_priority
+        assert _coerce_priority({"priority": "p3"}) == 2.0
+        assert _coerce_priority({"priority": " P1 "}) == 4.0
+
+    def test_unknown_label_falls_back_to_default(self):
+        """Invalid label does not crash; returns default."""
+        from holo_index.core.search_engine import _coerce_priority
+        assert _coerce_priority({"priority": "URGENT"}) == 1.0
+        assert _coerce_priority({"priority": "URGENT"}, default=7.0) == 7.0
+
+    def test_numeric_string_parsed(self):
+        """String containing numeric value is parsed."""
+        from holo_index.core.search_engine import _coerce_priority
+        assert _coerce_priority({"priority": "3"}) == 3.0
+        assert _coerce_priority({"priority": "10.5"}) == 10.5
+
+    def test_missing_metadata_returns_default(self):
+        """Empty metadata returns default."""
+        from holo_index.core.search_engine import _coerce_priority
+        assert _coerce_priority({}) == 1.0
+        assert _coerce_priority({}, default=2.5) == 2.5
+
+    def test_bool_priority_rejected_falls_through(self):
+        """Booleans (which subclass int in Python) should fall through to default."""
+        from holo_index.core.search_engine import _coerce_priority
+        # bool subclasses int in Python; ensure we don't propagate True/False as 1.0/0.0
+        assert _coerce_priority({"priority": True}) == 1.0
+        assert _coerce_priority({"priority": False}) == 1.0
+
+
+class TestFormatHitWithStringPriority:
+    """Search path with work-ledger string priority — regression for the silent TypeError."""
+
+    def test_search_collection_does_not_crash_with_string_priority(self):
+        """Full _search_collection path no longer raises on priority=\"P3\"."""
+        from holo_index.core.search_engine import _search_collection
+
+        holo = MagicMock()
+        holo.search_cache = None
+        holo.model = None
+
+        collection = MagicMock()
+        collection.query.return_value = {
+            "documents": [["Work Slice: TEST_SLICE\nTitle: Test"]],
+            "metadatas": [[{
+                "type": "work_ledger_slice",
+                "slice_id": "TEST_SLICE",
+                "title": "Test Slice",
+                "path": "/tmp/work_ledger.example.json",
+                "priority": "P3",       # historical poison
+                "priority_num": 10,     # numeric companion field
+                "pr_number": 642,
+                "owner_worker": "W9",
+                "status": "MERGED",
+                "branch": "",
+                "related_foundup_id": "",
+                "summary": "",
+                "keywords": "",
+            }]],
+            "distances": [[0.4]],
+        }
+        collection.get.return_value = {"documents": [], "metadatas": [], "ids": []}
+
+        hits = _search_collection(holo, collection, "TEST_SLICE", limit=5, kind="work_ledger")
+        assert isinstance(hits, list)
+        assert len(hits) == 1
+        # _sort_key is stripped before return; verify result payload is intact and
+        # priority was coerced from "P3" string to numeric (via priority_num=10)
+        assert hits[0].get("title") == "Test Slice"
+        assert hits[0].get("type") == "work_ledger_slice"
+        assert hits[0].get("priority") == 10.0  # coerced from priority_num, not "P3"
+
+
+class TestExecuteSearchWorkLedgerLogging:
+    """execute_search work-ledger block no longer silently swallows exceptions."""
+
+    def test_work_ledger_exception_is_logged_and_search_continues(self, caplog):
+        """If work-ledger _search_collection raises, log a warning AND let other hits return."""
+        import logging
+        from holo_index.core.search_engine import execute_search
+
+        holo = MagicMock()
+        holo.search_cache = None
+        holo.model = None
+        holo.code_collection = None
+        holo.symbol_collection = None
+        holo.wsp_collection = None
+        holo.test_collection = None
+        holo.skill_collection = None
+        holo.docs_collection = None
+        holo.knowledge_collection = None
+
+        boom_collection = MagicMock()
+        boom_collection.query.side_effect = TypeError("can't multiply sequence by non-int of type 'float'")
+        boom_collection.get.return_value = {"documents": [], "metadatas": [], "ids": []}
+        holo.work_ledger_collection = boom_collection
+
+        with caplog.at_level(logging.WARNING, logger="holo_index.core.search_engine"):
+            result = execute_search(holo, "test_query", limit=5, doc_type_filter="work_ledger")
+
+        assert isinstance(result, dict)
+        assert result.get("work_ledger_hits") == []
+
+        warning_messages = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("Work-ledger search failed" in m for m in warning_messages), \
+            f"Expected warning containing 'Work-ledger search failed', got: {warning_messages}"
+
+    def test_work_ledger_collection_none_does_not_log_warning(self, caplog):
+        """If collection is None (uninitialized), no warning — that's normal pre-reindex state."""
+        import logging
+        from holo_index.core.search_engine import execute_search
+
+        holo = MagicMock()
+        holo.search_cache = None
+        holo.model = None
+        holo.code_collection = None
+        holo.symbol_collection = None
+        holo.wsp_collection = None
+        holo.test_collection = None
+        holo.skill_collection = None
+        holo.docs_collection = None
+        holo.knowledge_collection = None
+        holo.work_ledger_collection = None
+
+        with caplog.at_level(logging.WARNING, logger="holo_index.core.search_engine"):
+            result = execute_search(holo, "test_query", limit=5, doc_type_filter="all")
+
+        warning_messages = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert not any("Work-ledger search failed" in m for m in warning_messages), \
+            "Should not warn when work_ledger_collection is None"
+        assert result.get("work_ledger_hits") == []


### PR DESCRIPTION
## Summary

Hotfix for FOUNDUPS_WORK_LEDGER_SEARCH_RETRIEVAL_PRIORITY_HOTFIX_PHASE1.

Work-ledger entries were being silently erased from search payloads because their `priority` metadata is stored as the string `"P3"` (etc.), while downstream scoring did `0.5 * priority` and raised `TypeError`. The exception was swallowed by a bare `except Exception:` in `execute_search`, masking the failure as an empty result set.

This change:
- Adds `_PRIORITY_LABEL_WEIGHTS` (P0..P4 -> 5..1) and `_coerce_priority(meta)` helper in `holo_index/core/search_engine.py`.
- Prefers `priority_num` (work-ledger indexer writes both fields) over the string `priority` label.
- Safely coerces P0..P4 labels, numeric strings, and rejects booleans (which subclass `int` in Python) to avoid `True/False -> 1.0/0.0` propagation.
- Replaces the silent `except Exception:` in the work-ledger branch of `execute_search` with a logged warning so future failures are diagnosable.

## Root cause

`_search_collection` did `priority = meta.get("priority", 1)` then `_format_hit` did `priority_weight = 0.5 * priority`. For work-ledger entries `meta["priority"] == "P3"`, producing `TypeError: can't multiply sequence by non-int of type 'float'`. The outer `try/except Exception` in `execute_search` (work-ledger branch only) erased the entire bucket without logging. Net effect: 0 WorkLedger hits despite a fully populated `navigation_work_ledger` collection.

## Scope verification

Files changed (3, exactly the expected scope):
- `holo_index/core/search_engine.py`
- `holo_index/tests/test_work_ledger_indexing.py`
- `docs/audits/holoindex_search_quality/FOUNDUPS_WORK_LEDGER_SEARCH_RETRIEVAL_PRIORITY_HOTFIX_PHASE1.md`

No live reindex executed by this PR. No generated index artifacts committed. No work-ledger JSON mutation. No AgentDB / FoundUp registry / WRE / OpenClaw / MCP / pFMALL changes. No unrelated dirty files.

## Tests

Run locally on the rebased branch:

```
python -m pytest holo_index/tests/test_work_ledger_indexing.py \
                 holo_index/tests/test_hxa_retrieval_fix.py \
                 holo_index/tests/test_search_quality_baseline.py
```

Result: **106 passed in 8.49s**
- work-ledger suite: 74/74
- HXA retrieval fix: 22/22
- search quality baseline: 10/10

New tests added in this PR (11):
- `TestPriorityCoercion` (8 tests): `priority_num` precedence, numeric passthrough, P0..P4 label coercion, case/whitespace tolerance, unknown-label fallback, numeric-string parsing, missing-metadata default, bool rejection.
- `TestFormatHitWithStringPriority` (3 tests): full `_search_collection` no longer crashes on `priority="P3"`; logged warning replaces silent erase.

## Live verification summary

Per the slice audit (`docs/audits/holoindex_search_quality/FOUNDUPS_WORK_LEDGER_SEARCH_RETRIEVAL_PRIORITY_HOTFIX_PHASE1.md`):
- Before: CLI search reported `0 WorkLedger` against the populated `navigation_work_ledger` collection.
- After: end-to-end audit reports **5 WorkLedger hits** (matches the 5 known indexed entries).
- No live reindex was performed by the hotfix; the end-to-end check is a read against the pre-existing collection.

## WSP_97 verdict

| Label | Status |
|-------|--------|
| HOLOINDEX_RETRIEVAL_HOTFIX_ONLY | YES |
| WORK_LEDGER_SEARCH_FIX_ONLY | YES |
| NO_LIVE_REINDEX | YES |
| NO_LEDGER_MUTATION | YES |
| NO_AGENTDB_MUTATION | YES |
| NO_REGISTRY_MUTATION | YES |
| NO_RUNTIME_WRE_CHANGE | YES |
| NO_MCP_CHANGE | YES |
| NO_GENERATED_INDEX_ARTIFACTS | YES |
| NO_CABR_READY | YES |
| NO_PAYOUT_READY | YES |
| NO_DAO_ACTIVATION | YES |

Verdict: **clean retrieval-layer hotfix**. No runtime semantics outside the work-ledger search branch are altered.

## Next slice

`FOUNDUPS_WORK_LEDGER_CONTROLLED_REINDEX_PHASE1_RETRY` — verification mode (re-run controlled reindex audit against the now-fixed retrieval path to confirm hit count stability without a fresh live reindex inside this PR).