### PR TITLE
fix(holoindex): coerce work ledger priority in lexical fallback path

### DIFF
--- a/holo_index/core/search_engine.py
+++ b/holo_index/core/search_engine.py
@@ -896,7 +896,7 @@ def _lexical_search_collection(
                 continue
 
             similarity = min(1.0, keyword_score / max(1.0, len(tokens) * 2.5))
-            priority = meta.get("priority", 1)
+            priority = _coerce_priority(meta)
 
             result = _format_hit(kind, meta, doc, similarity, keyword_score, priority)
             raw_results.append(result)

--- a/holo_index/tests/test_work_ledger_indexing.py
+++ b/holo_index/tests/test_work_ledger_indexing.py
@@ -904,6 +904,39 @@ class TestPriorityCoercion:
 class TestFormatHitWithStringPriority:
     """Search path with work-ledger string priority — regression for the silent TypeError."""
 
+    def test_lexical_search_does_not_crash_with_string_priority(self):
+        """Lexical fallback path handles priority=\"P3\" via _coerce_priority."""
+        from holo_index.core.search_engine import _lexical_search_collection
+
+        holo = MagicMock()
+        holo.search_cache = None
+        holo.model = None
+
+        collection = MagicMock()
+        collection.count.return_value = 1  # one document in collection
+        collection.get.return_value = {
+            "ids": ["wl_test_001"],
+            "documents": ["Work Slice: TEST_SLICE\nPriority: P3\nTitle: Test Lexical"],
+            "metadatas": [{
+                "type": "work_ledger_slice",
+                "slice_id": "TEST_SLICE",
+                "title": "Test Lexical Slice",
+                "path": "/tmp/work_ledger.example.json",
+                "priority": "P3",       # string priority that crashed lexical fallback
+                "pr_number": 999,
+                "owner_worker": "W1",
+                "status": "IN_PROGRESS",
+            }],
+        }
+
+        # This would crash with TypeError before the fix (line 899 in search_engine.py)
+        hits = _lexical_search_collection(holo, collection, "TEST_SLICE", limit=5, kind="work_ledger")
+        assert isinstance(hits, list)
+        assert len(hits) == 1
+        assert hits[0].get("title") == "Test Lexical Slice"
+        # Priority coerced from "P3" (label) to 2.0 (weight) via PRIORITY_MAP
+        assert hits[0].get("priority") == 2.0
+
     def test_search_collection_does_not_crash_with_string_priority(self):
         """Full _search_collection path no longer raises on priority=\"P3\"."""
         from holo_index.core.search_engine import _search_collection


### PR DESCRIPTION
## Summary

Follow-up to PR #652 (priority coercion hotfix). PR #652 fixed the vector search path but missed the lexical fallback path at the same crash site. This one-line hotfix completes the coverage.

### The miss

PR #652 introduced `_coerce_priority(meta)` and applied it at the vector search hit-format site. However, `search_engine.py:899` (the lexical fallback branch in `_lexical_search_collection`) continued to use the raw `meta.get("priority", 1)` accessor. When a work ledger entry with a string priority like `"P3"` flowed through the lexical path, the downstream multiplication by freshness raised `TypeError: can't multiply sequence by non-int`.

Two callsites; the prior hotfix only patched one. Same root cause, same fix, different code path.

### Change

`holo_index/core/search_engine.py:899`
```diff
- priority = meta.get("priority", 1)
+ priority = _coerce_priority(meta)
```

Reuses the existing helper from PR #652 (no new helper, no inline coercion).

### Regression test

`holo_index/tests/test_work_ledger_indexing.py::TestFormatHitWithStringPriority::test_lexical_search_does_not_crash_with_string_priority`

- Exercises `_lexical_search_collection` directly (lexical fallback, not the vector path)
- Uses `priority="P3"` (string label)
- Asserts no TypeError raised
- Asserts hit count and that priority is coerced to `2.0` via `PRIORITY_MAP`

Pairs with PR #652's `test_search_collection_does_not_crash_with_string_priority` (vector path).

## Test results

| Suite | Result |
|---|---|
| `holo_index/tests/test_work_ledger_indexing.py` | 75/75 (+1 regression) |
| `holo_index/tests/test_hxa_retrieval_fix.py` | 22/22 |
| `holo_index/tests/test_search_quality_baseline.py` | 10/10 |
| **Total** | **107/107** |

## WSP 97 verdict

| Label | Status |
|---|---|
| HOLOINDEX_RETRIEVAL_HOTFIX_ONLY | YES |
| WORK_LEDGER_LEXICAL_FALLBACK_FIX_ONLY | YES |
| NO_LIVE_REINDEX | YES |
| NO_LEDGER_MUTATION | YES |
| NO_AGENTDB_MUTATION | YES |
| NO_REGISTRY_MUTATION | YES |
| NO_RUNTIME_WRE_CHANGE | YES |
| NO_MCP_CHANGE | YES |
| NO_GENERATED_INDEX_ARTIFACTS | YES |
| NO_CABR_READY | YES |
| NO_PAYOUT_READY | YES |
| NO_DAO_ACTIVATION | YES |

## Scope

Exactly 2 files changed:
- `holo_index/core/search_engine.py` (1 line)
- `holo_index/tests/test_work_ledger_indexing.py` (+33 lines, 1 new test)

No audit doc (`FOUNDUPS_WORK_LEDGER_LEXICAL_PRIORITY_HOTFIX_PHASE1.md`) is included; one-line follow-up hotfix to PR #652 (which has its own audit doc).

## Test plan

- [x] work_ledger suite 75/75
- [x] HXA retrieval suite 22/22
- [x] Search quality baseline 10/10
- [x] Lexical fallback regression test added and passes
- [x] Live HoloIndex search (`"PR 646"`) returns 5 work_ledger_hits without TypeError

Slice: FOUNDUPS_WORK_LEDGER_LEXICAL_PRIORITY_HOTFIX_PHASE1
Worker-Lane: W10