### PR TITLE
fix(projection): add is_dual_identity field to holoindex_prod_01 (#674)

### DIFF
--- a/docs/audits/architecture/HOLOINDEX_PROD_01_PROJECTION_DUAL_IDENTITY_FIELD_PHASE1.md
+++ b/docs/audits/architecture/HOLOINDEX_PROD_01_PROJECTION_DUAL_IDENTITY_FIELD_PHASE1.md
@@ -1,0 +1,152 @@
+# HoloIndex Prod 01 Projection Dual Identity Field — Phase 1
+
+**Slice**: `HOLOINDEX_PROD_01_PROJECTION_DUAL_IDENTITY_FIELD_PHASE1`
+**Worker**: W6
+**Date**: 2026-05-22
+**Mode**: Projection data fix + tests
+**Base commit**: PR #673 merged
+**Branch**: `feat/holoindex-prod-01-projection-dual-identity-field-phase1`
+**WSP Lock**: WSP_00 -> WSP_15 -> WSP_50 -> WSP_83 -> WSP_87 -> WSP_97 -> WSP_104 -> WSP_22
+
+---
+
+## WSP_97 Truth Boundary Labels
+
+| Label | Status |
+|-------|--------|
+| PROJECTION_DATA_FIX_ONLY | YES |
+| HOLOINDEX_PROD_01_PROJECTION_BACKING_ONLY | YES |
+| DUAL_IDENTITY_BOUNDARY_ENFORCED | YES |
+| NO_PFMALL_CATALOG_MUTATION | YES |
+| NO_REGISTRY_MUTATION | YES |
+| NO_UI_CHANGE | YES |
+| NO_ROUTE_CHANGE | YES |
+| NO_HOLOINDEX_CORE_MUTATION | YES |
+| NO_BACKEND_ACCESS_ENABLEMENT | YES |
+| NO_INTERNAL_INDEX_EXPOSURE | YES |
+| NO_TOKEN_ASSIGNMENT | YES |
+| NO_MCP_CHANGE | YES |
+| NO_CI_CHANGE | YES |
+| NO_CABR_READY | YES |
+| NO_PAYOUT_READY | YES |
+| NO_DAO_ACTIVATION | YES |
+
+---
+
+## 1. Mission
+
+Add `is_dual_identity: true` to holoindex_prod_01 in portfolio projection to resolve the validator-detected C4 warning.
+
+## 2. Pre-Fix Validator Output
+
+```
+registry_total              : 15
+registry_portfolio_eligible : 3
+projection_total            : 3
+errors                      : 0
+warnings                    : 1
+
+[WARNING] C4 entity='holoindex_prod_01' field='is_dual_identity' source=projection
+    expected: True
+    actual  : None
+    -> HoloIndex projection must set is_dual_identity=true (spec section 5)
+
+Exit code: 1
+```
+
+## 3. Post-Fix Validator Output
+
+```
+registry_total              : 15
+registry_portfolio_eligible : 3
+projection_total            : 3
+errors                      : 0
+warnings                    : 0
+
+OK - no drift detected.
+
+Exit code: 0
+```
+
+## 4. Projection Field Added
+
+| Field | Value | Source |
+|-------|-------|--------|
+| `is_dual_identity` | `true` | Spec section 5 |
+
+### 4.1 Field Rationale
+
+**Choice**: `true`
+
+**Rationale**:
+- Spec section 5 requires `is_dual_identity=true` for holoindex_prod_01
+- HoloIndex has dual identity: internal infrastructure + external public FoundUp surface
+- C4 consistency check enforces this requirement
+- Field enables UI/display components to render dual identity notice
+
+## 5. Drift Resolution
+
+| Drift | Status |
+|-------|--------|
+| C4 (is_dual_identity missing) | **CLEARED** |
+
+All portfolio validator drifts are now resolved:
+- R1, R11, R10: Cleared by PR #673 (registry entry)
+- C4: Cleared by this slice (projection field)
+
+## 6. Test Results
+
+### 6.1 Portfolio Validator Tests
+
+```
+43 passed in 0.73s
+```
+
+Tests updated to reflect clean state:
+- `test_cli_exit_code_0_against_current_repo` — validator exits 0 with no drift
+
+## 7. Files Changed
+
+| File | Change |
+|------|--------|
+| `public/f/portfolio_data.json` | Added `is_dual_identity: true` to holoindex_prod_01 (+1 line) |
+| `modules/foundups/portfolio_validator/tests/test_validator.py` | Renamed test, updated to expect exit 0 (~4 lines) |
+| `docs/audits/architecture/HOLOINDEX_PROD_01_PROJECTION_DUAL_IDENTITY_FIELD_PHASE1.md` | NEW (this file) |
+
+## 8. WSP_97 Verdict
+
+| Check | Result |
+|-------|--------|
+| Projection data fix only | PASS |
+| No registry mutation | PASS |
+| No catalog mutation | PASS |
+| No UI change | PASS |
+| No route change | PASS |
+| No HoloIndex core mutation | PASS |
+| No backend access enablement | PASS |
+| No internal index exposure | PASS |
+| No token assignment | PASS |
+| No MCP change | PASS |
+| No CI change | PASS |
+| Dual identity boundary enforced | PASS |
+
+**Verdict**: PASS
+
+## 9. Validator Chain Complete
+
+| PR | Slice | Status |
+|----|-------|--------|
+| #672 | `PORTFOLIO_DATA_VALIDATOR_PHASE1` | MERGED |
+| #673 | `HOLOINDEX_PROD_01_REGISTRY_ENTRY_PHASE1` | MERGED |
+| #674 | `HOLOINDEX_PROD_01_PROJECTION_DUAL_IDENTITY_FIELD_PHASE1` | THIS SLICE |
+
+Final validator state:
+- 0 errors
+- 0 warnings
+- Exit code 0
+- All drifts resolved
+
+---
+
+*Slice authored under WSP_00 -> WSP_15 -> WSP_50 -> WSP_83 -> WSP_87 -> WSP_97 -> WSP_104 -> WSP_22.*
+*Slice: HOLOINDEX_PROD_01_PROJECTION_DUAL_IDENTITY_FIELD_PHASE1*

--- a/modules/foundups/portfolio_validator/tests/test_validator.py
+++ b/modules/foundups/portfolio_validator/tests/test_validator.py
@@ -580,8 +580,8 @@ def test_cli_exit_code_2_when_projection_malformed(tmp_path: Path):
     assert result.returncode == 2
 
 
-def test_cli_exit_code_1_against_current_repo():
-    """Running against the real repo surfaces C4 warning => exit 1."""
+def test_cli_exit_code_0_against_current_repo():
+    """Running against the real repo passes clean => exit 0."""
     result = subprocess.run(
         [
             sys.executable,
@@ -593,8 +593,8 @@ def test_cli_exit_code_1_against_current_repo():
         capture_output=True,
         text=True,
     )
-    assert result.returncode == 1
-    assert "C4" in result.stdout, "C4 (is_dual_identity) should remain as projection-side drift"
+    assert result.returncode == 0
+    assert "OK - no drift detected" in result.stdout
 
 
 def test_cli_json_output_is_parseable():

--- a/public/f/portfolio_data.json
+++ b/public/f/portfolio_data.json
@@ -43,7 +43,8 @@
       "screenshot_url": null,
       "public_summary": "HoloIndex has a dual identity boundary. Internally, HoloIndex is Foundups retrieval/memory infrastructure used by 0102, WRE, OpenClaw, MCP, and workers. Externally, HoloIndex may also have a public FoundUp surface discoverable through p.fMALL.",
       "portfolio_priority": 3,
-      "portfolio_ready": false
+      "portfolio_ready": false,
+      "is_dual_identity": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `is_dual_identity: true` to holoindex_prod_01 in `public/f/portfolio_data.json`
- Resolves C4 validator warning (spec section 5 requirement)
- Updates test to expect exit code 0 (all drifts now cleared)

## Validator Result
```
registry_total              : 15
registry_portfolio_eligible : 3
projection_total            : 3
errors                      : 0
warnings                    : 0
OK - no drift detected.
```

## Test Results
```
43 passed in 0.73s
```

## WSP_97 Verdict
PASS — projection data fix only, no registry/catalog/UI/backend mutations

## Validator Chain Complete
| PR | Slice | Status |
|----|-------|--------|
| #672 | PORTFOLIO_DATA_VALIDATOR_PHASE1 | MERGED |
| #673 | HOLOINDEX_PROD_01_REGISTRY_ENTRY_PHASE1 | MERGED |
| #674 | HOLOINDEX_PROD_01_PROJECTION_DUAL_IDENTITY_FIELD_PHASE1 | THIS PR |

Slice: `HOLOINDEX_PROD_01_PROJECTION_DUAL_IDENTITY_FIELD_PHASE1`
Worker-Lane: W6

🤖 Generated with [Claude Code](https://claude.com/claude-code)