### PR TITLE
feat(trade): add multi-seed simulation evidence pack

### DIFF
--- a/docs/audits/architecture/TRADE_POC_SIMULATION_EVIDENCE_PACK_PHASE1.md
+++ b/docs/audits/architecture/TRADE_POC_SIMULATION_EVIDENCE_PACK_PHASE1.md
@@ -1,0 +1,248 @@
+# Trade PoC Simulation Evidence Pack — Phase 1
+
+**Slice**: `TRADE_POC_SIMULATION_EVIDENCE_PACK_PHASE1`
+**Worker**: W6
+**Date**: 2026-05-23
+**Mode**: Evidence generation (multi-seed runs)
+**Base commit**: PR #679 merged (simulation harness)
+**Branch**: `feat/trade-poc-simulation-evidence-pack-phase1`
+**WSP Lock**: WSP_00 -> WSP_15 -> WSP_50 -> WSP_83 -> WSP_87 -> WSP_97 -> WSP_104 -> WSP_22
+
+---
+
+## WSP_97 Truth Boundary Labels
+
+| Label | Status |
+|-------|--------|
+| EVIDENCE_GENERATION_ONLY | YES |
+| SYNTHETIC_DATA_ONLY | YES |
+| DETERMINISTIC_OUTPUT_ONLY | YES |
+| NO_REAL_TRADING | YES |
+| NO_WALLET_SIGNING | YES |
+| NO_KEY_MATERIAL | YES |
+| NO_ORDER_PLACEMENT | YES |
+| NO_NETWORK_CALL | YES |
+| NO_EXCHANGE_SDK_IMPORT | YES |
+| NO_REGISTRY_MUTATION | YES |
+| NO_CATALOG_MUTATION | YES |
+| NO_MANIFEST_MUTATION | YES |
+| NO_PROJECTION_MUTATION | YES |
+| NO_PORTFOLIO_PROMOTION | YES |
+| NO_PUBLIC_SURFACE_CLAIM | YES |
+| NO_CI_GATE_ACTIVATION | YES |
+| NO_DEPENDENCY_INSTALL | YES |
+| NO_CABR_READY | YES |
+| NO_PAYOUT_READY | YES |
+| NO_DAO_ACTIVATION | YES |
+
+---
+
+## 1. Goal
+
+Generate a multi-seed evidence pack to satisfy the requirements defined in TRADE_POC_SIMULATION_EVIDENCE_REVIEW_PHASE1.
+
+**Required evidence** (from review doc):
+- 5+ seeds (42, 123, 456, 789, 1000)
+- 3+ bar counts (100, 500, 1000)
+- invariant_violations=0 for all runs
+- Determinism verification for all runs
+- Machine-readable JSON summary
+
+---
+
+## 2. Evidence Pack Summary
+
+| Metric | Value |
+|--------|-------|
+| Total runs | 15 |
+| Seeds tested | 5 |
+| Bar counts tested | 3 |
+| Total invariant violations | **0** |
+| All deterministic | **True** |
+| Runs with violations | 0 |
+| Average trades per run | 64.13 |
+| Average max drawdown | 0.310841 |
+
+---
+
+## 3. Multi-Seed Run Matrix
+
+| Seed | Bars | Final Equity | Gross PnL | Trades | Max DD | Violations |
+|------|------|-------------|-----------|--------|--------|------------|
+| 42 | 100 | 9,203.68 | -796.32 | 16 | 0.178 | 0 |
+| 42 | 500 | 6,091.98 | -3,908.02 | 65 | 0.449 | 0 |
+| 42 | 1000 | 4,780.24 | -5,219.76 | 118 | 0.552 | 0 |
+| 123 | 100 | 9,098.43 | -901.57 | 12 | 0.115 | 0 |
+| 123 | 500 | 7,270.69 | -2,729.31 | 61 | 0.340 | 0 |
+| 123 | 1000 | 5,278.28 | -4,721.72 | 133 | 0.566 | 0 |
+| 456 | 100 | 9,469.18 | -530.82 | 13 | 0.150 | 0 |
+| 456 | 500 | 11,048.67 | +1,048.67 | 63 | 0.286 | 0 |
+| 456 | 1000 | 15,279.39 | +5,279.39 | 112 | 0.286 | 0 |
+| 789 | 100 | 8,287.45 | -1,712.55 | 15 | 0.173 | 0 |
+| 789 | 500 | 5,655.34 | -4,344.66 | 68 | 0.434 | 0 |
+| 789 | 1000 | 4,480.41 | -5,519.59 | 137 | 0.602 | 0 |
+| 1000 | 100 | 11,510.31 | +1,510.31 | 4 | 0.062 | 0 |
+| 1000 | 500 | 12,680.84 | +2,680.84 | 44 | 0.235 | 0 |
+| 1000 | 1000 | 17,028.83 | +7,028.83 | 101 | 0.235 | 0 |
+
+---
+
+## 4. Determinism Verification Matrix
+
+| Seed | Bars | Determinism | JSON Length |
+|------|------|-------------|-------------|
+| 42 | 100 | PASS | 3,690 bytes |
+| 42 | 500 | PASS | 12,964 bytes |
+| 42 | 1000 | PASS | 22,966 bytes |
+| 123 | 100 | PASS | 2,954 bytes |
+| 123 | 500 | PASS | 12,284 bytes |
+| 123 | 1000 | PASS | 25,941 bytes |
+| 456 | 100 | PASS | 3,152 bytes |
+| 456 | 500 | PASS | 12,685 bytes |
+| 456 | 1000 | PASS | 22,031 bytes |
+| 789 | 100 | PASS | 3,513 bytes |
+| 789 | 500 | PASS | 13,577 bytes |
+| 789 | 1000 | PASS | 26,664 bytes |
+| 1000 | 100 | PASS | 1,460 bytes |
+| 1000 | 500 | PASS | 9,136 bytes |
+| 1000 | 1000 | PASS | 20,061 bytes |
+
+**All 15 runs produce byte-identical JSON on rerun.**
+
+---
+
+## 5. Aggregate Statistics
+
+| Statistic | Value |
+|-----------|-------|
+| Profitable runs | 5/15 (33.3%) |
+| Loss runs | 10/15 (66.7%) |
+| Best gross PnL | +7,028.83 (seed=1000, bars=1000) |
+| Worst gross PnL | -5,519.59 (seed=789, bars=1000) |
+| Lowest max drawdown | 0.062 (seed=1000, bars=100) |
+| Highest max drawdown | 0.602 (seed=789, bars=1000) |
+| Min trades | 4 (seed=1000, bars=100) |
+| Max trades | 137 (seed=789, bars=1000) |
+
+**Note**: The reference SMA strategy is intentionally simple and unoptimized. Loss runs are expected and demonstrate the harness tracks losses correctly.
+
+---
+
+## 6. Evidence Sufficiency Assessment
+
+### 6.1 Requirements Met
+
+| Requirement | Threshold | Actual | Status |
+|-------------|-----------|--------|--------|
+| Seeds tested | 5+ | 5 | PASS |
+| Bar counts tested | 3+ | 3 | PASS |
+| Total invariant violations | 0 | 0 | PASS |
+| All deterministic | True | True | PASS |
+| Machine-readable report | Yes | Yes | PASS |
+| Forbidden imports | 0 | 0 | PASS |
+
+### 6.2 Evidence Pack Status
+
+```
+╔═══════════════════════════════════════════════════════════════════╗
+║                    EVIDENCE PACK STATUS                            ║
+║                                                                     ║
+║                          PASS                                       ║
+║                                                                     ║
+║  All criteria from EVIDENCE_REVIEW_PHASE1 are met                  ║
+║                                                                     ║
+╚═══════════════════════════════════════════════════════════════════╝
+```
+
+---
+
+## 7. What This Does NOT Prove
+
+| Claim | Status |
+|-------|--------|
+| Market edge | NOT CLAIMED |
+| Positive expectancy | NOT CLAIMED |
+| Production readiness | NOT CLAIMED |
+| Real trading readiness | NOT CLAIMED |
+| Portfolio eligibility | NOT CLAIMED |
+| Public-surface readiness | NOT CLAIMED |
+| CABR/payout/DAO readiness | NOT CLAIMED |
+
+---
+
+## 8. Recommendation for Next Review
+
+The evidence pack demonstrates:
+- The simulation harness is functionally complete
+- Invariants hold across diverse seeds and bar counts
+- Output is deterministic and audit-ready
+- No forbidden imports or network behavior
+
+**Recommendation**: Trade may proceed to next PoC phase (adapter integration) while remaining in Phase 0 with all current truth boundary constraints intact.
+
+**NOT Recommended**:
+- Registry status change (poc_status remains "idea")
+- Catalog/projection promotion
+- Public surface activation
+- Any real trading capability
+
+---
+
+## 9. Files Changed
+
+| File | Change |
+|------|--------|
+| `modules/foundups/trade/scripts/generate_evidence_pack.py` | NEW |
+| `docs/audits/architecture/TRADE_POC_SIMULATION_EVIDENCE_PACK_PHASE1.md` | NEW (this file) |
+
+---
+
+## 10. WSP_97 Verdict
+
+| Check | Result |
+|-------|--------|
+| Evidence generation only | PASS |
+| Synthetic data only | PASS |
+| Deterministic output only | PASS |
+| No real trading | PASS |
+| No wallet signing | PASS |
+| No key material | PASS |
+| No order placement | PASS |
+| No network call | PASS |
+| No exchange SDK import | PASS |
+| No registry mutation | PASS |
+| No catalog mutation | PASS |
+| No manifest mutation | PASS |
+| No projection mutation | PASS |
+| No portfolio promotion | PASS |
+| No public surface claim | PASS |
+| No CI gate activation | PASS |
+| No dependency install | PASS |
+| No CABR ready | PASS |
+| No payout ready | PASS |
+| No DAO activation | PASS |
+
+**Verdict**: PASS
+
+---
+
+## 11. Next Slice (Do Not Start)
+
+| Slice | Purpose |
+|-------|---------|
+| `TRADE_ADAPTER_INTEGRATION_PHASE1` | Integrate data adapters (simulation mode only) |
+
+---
+
+## 12. Machine-Readable Evidence
+
+The complete evidence pack JSON is available via:
+
+```bash
+python modules/foundups/trade/scripts/generate_evidence_pack.py --output evidence_pack.json
+```
+
+---
+
+*Slice authored under WSP_00 -> WSP_15 -> WSP_50 -> WSP_83 -> WSP_87 -> WSP_97 -> WSP_104 -> WSP_22.*
+*Slice: TRADE_POC_SIMULATION_EVIDENCE_PACK_PHASE1*

--- a/modules/foundups/trade/scripts/generate_evidence_pack.py
+++ b/modules/foundups/trade/scripts/generate_evidence_pack.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Generate Trade PoC Simulation Evidence Pack
+
+Runs simulation harness with multiple seeds and bar counts to generate
+a machine-readable evidence pack for review.
+
+Slice: TRADE_POC_SIMULATION_EVIDENCE_PACK_PHASE1
+
+Usage:
+    python scripts/generate_evidence_pack.py [--output PATH]
+"""
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from simulation_harness import SimulationHarness
+
+
+SEEDS = [42, 123, 456, 789, 1000]
+BAR_COUNTS = [100, 500, 1000]
+
+
+def run_single(seed: int, bars: int) -> Dict[str, Any]:
+    """Run single simulation and return result."""
+    harness = SimulationHarness(seed=seed, bars=bars)
+    summary = harness.run()
+
+    return {
+        "seed": seed,
+        "bars": bars,
+        "run_id": summary.run_id,
+        "initial_capital": summary.initial_capital,
+        "final_equity": round(summary.final_equity, 6),
+        "total_trades": summary.total_trades,
+        "gross_pnl": round(summary.gross_pnl, 6),
+        "max_drawdown": round(summary.max_drawdown, 6),
+        "sharpe_like_ratio": round(summary.sharpe_like_ratio, 6) if summary.sharpe_like_ratio else None,
+        "invariant_violations": summary.invariant_violations,
+        "violations": [v.to_dict() for v in summary.violations],
+    }
+
+
+def verify_determinism(seed: int, bars: int) -> Dict[str, Any]:
+    """Verify determinism by running twice and comparing JSON output."""
+    harness1 = SimulationHarness(seed=seed, bars=bars)
+    json1 = harness1.to_json()
+
+    harness2 = SimulationHarness(seed=seed, bars=bars)
+    json2 = harness2.to_json()
+
+    identical = json1 == json2
+
+    return {
+        "seed": seed,
+        "bars": bars,
+        "determinism_pass": identical,
+        "json_length": len(json1),
+    }
+
+
+def generate_evidence_pack() -> Dict[str, Any]:
+    """Generate complete evidence pack."""
+    run_results: List[Dict[str, Any]] = []
+    determinism_results: List[Dict[str, Any]] = []
+
+    print("Running evidence pack generation...")
+    print(f"Seeds: {SEEDS}")
+    print(f"Bar counts: {BAR_COUNTS}")
+    print()
+
+    for seed in SEEDS:
+        for bars in BAR_COUNTS:
+            print(f"  Running seed={seed} bars={bars}...", end=" ")
+            result = run_single(seed, bars)
+            run_results.append(result)
+
+            det = verify_determinism(seed, bars)
+            determinism_results.append(det)
+
+            status = "PASS" if result["invariant_violations"] == 0 else "FAIL"
+            print(f"{status} (trades={result['total_trades']}, violations={result['invariant_violations']})")
+
+    total_runs = len(run_results)
+    total_violations = sum(r["invariant_violations"] for r in run_results)
+    all_deterministic = all(d["determinism_pass"] for d in determinism_results)
+
+    aggregate = {
+        "total_runs": total_runs,
+        "seeds_tested": len(SEEDS),
+        "bar_counts_tested": len(BAR_COUNTS),
+        "total_invariant_violations": total_violations,
+        "all_deterministic": all_deterministic,
+        "runs_with_violations": sum(1 for r in run_results if r["invariant_violations"] > 0),
+        "average_trades": round(sum(r["total_trades"] for r in run_results) / total_runs, 2),
+        "average_max_drawdown": round(sum(r["max_drawdown"] for r in run_results) / total_runs, 6),
+    }
+
+    pack = {
+        "evidence_pack_version": "1.0.0",
+        "slice": "TRADE_POC_SIMULATION_EVIDENCE_PACK_PHASE1",
+        "aggregate": aggregate,
+        "run_results": run_results,
+        "determinism_verification": determinism_results,
+        "truth_boundary": {
+            "is_simulation": True,
+            "no_money_mode": True,
+            "dry_run_mode": True,
+            "real_execution_performed": False,
+            "network_calls": False,
+            "wallet_signing": False,
+            "order_placement": False,
+        },
+    }
+
+    return pack
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate Trade PoC Simulation Evidence Pack")
+    parser.add_argument("--output", type=str, default=None, help="Output JSON file path")
+    args = parser.parse_args()
+
+    pack = generate_evidence_pack()
+
+    print()
+    print("=" * 60)
+    print("EVIDENCE PACK SUMMARY")
+    print("=" * 60)
+    print(f"Total runs: {pack['aggregate']['total_runs']}")
+    print(f"Seeds tested: {pack['aggregate']['seeds_tested']}")
+    print(f"Bar counts tested: {pack['aggregate']['bar_counts_tested']}")
+    print(f"Total invariant violations: {pack['aggregate']['total_invariant_violations']}")
+    print(f"All deterministic: {pack['aggregate']['all_deterministic']}")
+    print(f"Runs with violations: {pack['aggregate']['runs_with_violations']}")
+    print()
+
+    if pack['aggregate']['total_invariant_violations'] == 0 and pack['aggregate']['all_deterministic']:
+        print("EVIDENCE PACK STATUS: PASS")
+    else:
+        print("EVIDENCE PACK STATUS: FAIL")
+
+    json_output = json.dumps(pack, sort_keys=True, indent=2)
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(json_output)
+        print(f"\nEvidence pack written to: {args.output}")
+    else:
+        print("\n--- JSON OUTPUT ---")
+        print(json_output)
+
+    return 0 if pack['aggregate']['total_invariant_violations'] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Generates evidence pack with 5 seeds × 3 bar counts = 15 total runs
- All 15 runs complete with invariant_violations=0
- All 15 runs are deterministic (byte-identical on rerun)
- Satisfies requirements from TRADE_POC_SIMULATION_EVIDENCE_REVIEW_PHASE1

## Evidence Pack Results

| Metric | Value |
|--------|-------|
| Total runs | 15 |
| Seeds tested | 5 (42, 123, 456, 789, 1000) |
| Bar counts | 3 (100, 500, 1000) |
| Total invariant violations | **0** |
| All deterministic | **True** |

## Evidence Pack Status

```
PASS - All criteria met
```

## What This Does NOT Prove
- Market edge, positive expectancy, production readiness
- Registry/catalog/projection changes remain unauthorized

## Test plan
- [x] Evidence pack generator runs successfully
- [x] All 15 runs: invariant_violations=0
- [x] All 15 runs: determinism verified
- [x] Machine-readable JSON output available
- [x] WSP_97 verdict: PASS

Slice: TRADE_POC_SIMULATION_EVIDENCE_PACK_PHASE1
Worker-Lane: W6

🤖 Generated with [Claude Code](https://claude.com/claude-code)