### PR TITLE
fix(holoindex): add Trade analyst language alias expansion and target-aware verdict

### DIFF
--- a/docs/audits/holoindex_search_quality/HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1.md
+++ b/docs/audits/holoindex_search_quality/HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1.md
@@ -1,0 +1,201 @@
+# HoloIndex FoundUp Query Alias and Targeted Verdict — Phase 1
+
+**Slice**: `HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1`
+**Agent**: 0102
+**Date**: 2026-05-23
+**Mode**: HoloIndex retrieval quality fix
+**Branch**: `feat/holoindex-foundup-query-alias-phase1`
+**WSP Lock**: WSP_00 -> WSP_15 -> WSP_50 -> WSP_87 -> WSP_97 -> WSP_104 -> WSP_22
+
+---
+
+## WSP_97 Truth Boundary Checklist
+
+| Label | Status |
+|-------|--------|
+| HOLOINDEX_RETRIEVAL_QUALITY_FIX_ONLY | YES |
+| QUERY_ALIAS_EXPANSION_ONLY | YES |
+| TARGET_VERDICT_CHECK_ONLY | YES |
+| HOLOINDEX_CORE_MUTATION_AUTHORIZED_FOR_RETRIEVAL_QUALITY | YES |
+| NO_LIVE_REINDEX | YES |
+| NO_GENERATED_INDEX_ARTIFACTS | YES |
+| NO_TRADE_STATUS_CHANGE | YES |
+| NO_TRADE_RUNTIME_CHANGE | YES |
+| NO_REGISTRY_MUTATION | YES |
+| NO_CATALOG_MUTATION | YES |
+| NO_PROJECTION_MUTATION | YES |
+| NO_DEPENDENCY_INSTALL | YES |
+| NO_CI_CHANGE | YES |
+| NO_CABR_READY | YES |
+| NO_PAYOUT_READY | YES |
+| NO_DAO_ACTIVATION | YES |
+
+---
+
+## 1. Problem Statement
+
+Natural analyst language queries for Trade module failed to surface Trade documentation:
+
+| Query | Before Fix | After Fix |
+|-------|------------|-----------|
+| "Trade pump.fun memecoin issuer X telegram influencer rug pull large trades" | whack_a_magat, ritual, unrelated | Trade ModLog, pumpfun_comparison |
+| "Trade FoundUp pump.fun memecoin launchpad simulation" | partial | Trade README, ROADMAP, ModLog, test_adapter_contracts.py |
+
+**Root cause**: HoloIndex did not expand analyst language aliases (pump.fun, memecoin, issuer, rug pull) to Trade module terminology (pumpfun, meme-coin, creator_address, rug_pull_score).
+
+---
+
+## 2. Implementation
+
+### 2.1 Search-Time Alias Expansion (search_engine.py)
+
+Added `_TRADE_ALIAS_GROUPS` mapping analyst language to Trade terminology:
+
+```python
+_TRADE_ALIAS_GROUPS = {
+    "pump.fun": ["pumpfun", "pump fun", "pump_fun"],
+    "memecoin": ["meme-coin", "meme coin", "meme_coin"],
+    "issuer": ["creator", "creator_address", "token_creator"],
+    "rug pull": ["rug_pull_score", "soft-rug", "honeypot"],
+    "twitter": ["x account", "socialevent", "social_event"],
+    "large trades": ["top traders", "walletevent", "holder distribution"],
+    # ... additional aliases
+}
+```
+
+### 2.2 Trade Intent Detection
+
+Added `_is_trade_intent_query()` detecting Trade keywords:
+- Platform: pump.fun, pumpfun, launchpad
+- Token: memecoin, meme-coin
+- Risk: rug pull, honeypot, soft-rug
+- Social: twitter, telegram, influencer
+- Activity: whale, top traders, holder distribution
+
+### 2.3 Path Boost for Trade Module
+
+Added `_trade_path_boost()`:
+- 8.0 boost for Trade target docs (README, INTERFACE, ROADMAP, contracts.py)
+- 5.0 boost for any Trade module path
+
+### 2.4 Target-Aware Verdict (agentic_rag_verdict.py)
+
+Added `QueryIntent.TRADE` with target-aware rules:
+- **SUFFICIENT**: Trade module evidence found in results
+- **DEGRADED**: Hits exist but no Trade module evidence
+- **UNSAFE_TO_ACT**: No hits at all
+
+---
+
+## 3. Before/After Retrieval Comparison
+
+### Query 1: "Trade pump.fun memecoin issuer X telegram influencer rug pull large trades WSP 15 rating"
+
+**BEFORE**:
+```
+[CODE] modules/infrastructure/wre_core/src/improvement_job_contract.py
+[CODE] modules/gamification/whack_a_magat/src/whack.py
+[DOCS] docs/SPRINT_1_2_WSP_COMPLIANCE_AUDIT.md
+[DOCS] modules/communication/video_comments/skillz/tars_account_swapper/README.md
+```
+Trade docs: **0 in top results**
+
+**AFTER**:
+```
+[CODE] modules/foundups/simulator/economics/pumpfun_comparison.py
+[DOCS] modules/foundups/trade/ModLog.md
+```
+Trade docs: **1+ in top results**
+
+### Query 2: "Trade FoundUp pump.fun memecoin launchpad simulation"
+
+**BEFORE**: Partial Trade hits
+
+**AFTER**:
+```
+[CODE] modules/foundups/trade/tests/test_adapter_contracts.py
+[DOCS] modules/foundups/trade/README.md
+[DOCS] modules/foundups/trade/ROADMAP.md
+[DOCS] modules/foundups/trade/ModLog.md
+```
+Trade docs: **3 in top docs results**
+
+---
+
+## 4. Test Results
+
+### 4.1 New Tests
+
+```
+python -m pytest holo_index/tests/test_trade_query_alias_retrieval.py -v
+36 passed in 2.52s
+```
+
+| Test Class | Tests | Purpose |
+|------------|-------|---------|
+| TestTradeIntentDetection | 8 | Trade keyword detection |
+| TestTradeAliasExpansion | 5 | Alias expansion logic |
+| TestTradePathBoost | 6 | Path boost scoring |
+| TestTradeAliasKeywordBoost | 2 | Content alias matching |
+| TestTradeQueryIntentClassification | 5 | Intent classification |
+| TestTradeModuleEvidenceDetection | 5 | Evidence detection |
+| TestTradeVerdictClassification | 3 | Verdict logic |
+| TestRegressionPreviousBehavior | 2 | WSP/general intent preserved |
+
+### 4.2 Regression Suites
+
+```
+python -m pytest holo_index/tests/test_audit_spec_slice_id_indexing.py \
+                 holo_index/tests/test_hxa_retrieval_fix.py \
+                 holo_index/tests/test_work_ledger_indexing.py \
+                 holo_index/tests/test_search_quality_baseline.py -q
+135 passed in 13.91s
+```
+
+---
+
+## 5. Files Changed
+
+| File | Change |
+|------|--------|
+| `holo_index/core/search_engine.py` | Added Trade alias registry, path boost, keyword boost |
+| `holo_index/core/agentic_rag_verdict.py` | Added TRADE intent, target-aware verdict |
+| `holo_index/tests/test_trade_query_alias_retrieval.py` | NEW (36 tests) |
+| `docs/audits/holoindex_search_quality/HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1.md` | NEW (this file) |
+| `holo_index/ModLog.md` | UPDATED |
+
+---
+
+## 6. WSP_97 Verdict
+
+| Check | Result |
+|-------|--------|
+| HoloIndex retrieval quality fix only | PASS |
+| Query alias expansion only | PASS |
+| Target verdict check only | PASS |
+| HoloIndex core mutation authorized | PASS |
+| No live reindex | PASS |
+| No generated index artifacts | PASS |
+| No Trade status change | PASS |
+| No Trade runtime change | PASS |
+| No registry mutation | PASS |
+| No catalog mutation | PASS |
+| No projection mutation | PASS |
+| No dependency install | PASS |
+| No CI change | PASS |
+| No CABR ready | PASS |
+| No payout ready | PASS |
+| No DAO activation | PASS |
+
+**Verdict**: PASS
+
+---
+
+## 7. W10 Readiness
+
+This slice improves HoloIndex retrieval quality for Trade module queries. W10 can now rely on HoloIndex to surface Trade documentation when analyst language queries are used.
+
+---
+
+*Slice authored under WSP_00 -> WSP_15 -> WSP_50 -> WSP_87 -> WSP_97 -> WSP_104 -> WSP_22.*
+*Slice: HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1*

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,58 @@
 # HoloIndex Package ModLog
 
+## [2026-05-23] HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1
+
+**Agent**: 0102
+**WSP References**: WSP 97, WSP 87, WSP 50, WSP 22
+**Status**: COMPLETE
+
+### Summary
+
+Fixed HoloIndex retrieval gap where natural Trade analyst language queries failed to surface
+Trade module documentation. Added search-time alias expansion and target-aware verdict logic.
+
+### Problem
+
+Queries using analyst language (pump.fun, memecoin, issuer, X account, rug pull) did not
+surface Trade docs because Trade uses different terminology (pumpfun, meme-coin,
+creator_address, twitter, rug_pull_score). The agentic RAG verdict was too shallow and
+did not require Trade evidence for Trade-intent queries.
+
+### Changes
+
+- `holo_index/core/search_engine.py`:
+  - Added `_TRADE_ALIAS_GROUPS` for analyst-to-Trade terminology mapping
+  - Added `_TRADE_INTENT_KEYWORDS` for Trade intent detection
+  - Added `_trade_path_boost()` for Trade module path boosting (8.0 for target docs)
+  - Added `_trade_alias_keyword_boost()` for alias expansion in content matching
+- `holo_index/core/agentic_rag_verdict.py`:
+  - Added `QueryIntent.TRADE` intent type
+  - Added `_TRADE_INTENT_KEYWORDS` for intent detection
+  - Added `_has_trade_module_evidence()` for target-aware verdict
+  - Added Trade-specific verdict rules requiring Trade module evidence
+
+### Alias Mappings
+
+| Analyst Term | Trade Terms |
+|--------------|-------------|
+| pump.fun | pumpfun, pump fun, pump_fun |
+| memecoin | meme-coin, meme coin, meme_coin |
+| issuer | creator, creator_address, token_creator |
+| rug pull | rug_pull_score, soft-rug, honeypot |
+| twitter/X | socialevent, social_event |
+| large trades | top traders, walletevent, holder_distribution |
+
+### Test Results
+
+- 36 new tests passed (test_trade_query_alias_retrieval.py)
+- 135 regression tests passed (audit spec, HXA, work ledger, search quality)
+
+### No Reindex Required
+
+This fix uses search-time expansion and boosting — no live reindex needed.
+
+---
+
 ## [2026-05-22] HOLOINDEX_AUDIT_SPEC_SLICE_ID_INDEXING_FIX_PHASE1
 
 **Agent**: 0102 (W1)

--- a/holo_index/core/agentic_rag_verdict.py
+++ b/holo_index/core/agentic_rag_verdict.py
@@ -54,6 +54,9 @@ class QueryIntent(Enum):
     SKILL = "skill"
     """Query seeks skillz definition."""
 
+    TRADE = "trade"
+    """Query seeks Trade FoundUp module information (pump.fun, memecoin, etc.)."""
+
     GENERAL = "general"
     """General query — any hits acceptable."""
 
@@ -90,12 +93,33 @@ class RetrievalEvidenceSummary:
         )
 
 
+# Trade FoundUp intent keywords
+# HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1
+_TRADE_INTENT_KEYWORDS = [
+    "trade", "trading",
+    "pump.fun", "pumpfun", "pump fun",
+    "memecoin", "meme-coin", "meme coin",
+    "issuer", "creator", "token_creator",
+    "rug pull", "rugpull", "honeypot", "soft-rug",
+    "launchpad", "bonding curve",
+    "whale", "top traders", "holder distribution",
+    "x account", "telegram",
+    "influencer", "promoter",
+    "wallet audit", "due diligence",
+]
+
+
 def classify_query_intent(query: str) -> QueryIntent:
     """Classify query intent based on keywords.
 
     Simple heuristic classification. Can be enhanced with Gemma later.
     """
     query_lower = query.lower()
+
+    # Trade FoundUp intent detection (check first - specific module)
+    # HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1
+    if any(kw in query_lower for kw in _TRADE_INTENT_KEYWORDS):
+        return QueryIntent.TRADE
 
     # WSP intent detection
     if any(kw in query_lower for kw in ["wsp", "protocol", "compliance"]):
@@ -287,10 +311,68 @@ def classify_retrieval_evidence(
             summary.verdict = RetrievalVerdict.SUFFICIENT
         return summary
 
+    # Trade FoundUp intent — must have Trade module evidence
+    # HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1
+    if query_intent == QueryIntent.TRADE:
+        # Check if any hits are from Trade module
+        trade_evidence = _has_trade_module_evidence(payload)
+        if trade_evidence:
+            summary.reason = f"Trade intent satisfied: Trade module evidence found"
+            summary.verdict = RetrievalVerdict.SUFFICIENT
+        elif docs_count > 0 or code_count > 0:
+            # Has hits but none from Trade module
+            summary.degraded = True
+            summary.reason = "Trade intent but no Trade module evidence in results — retrieval may miss relevant docs"
+            summary.verdict = RetrievalVerdict.DEGRADED
+        else:
+            # No relevant hits at all
+            summary.reason = "Trade intent with no Trade module evidence"
+            summary.verdict = RetrievalVerdict.UNSAFE_TO_ACT
+        return summary
+
     # General intent — any hits are acceptable
     summary.reason = f"General query: {summary.total_hits} total hits"
     summary.verdict = RetrievalVerdict.SUFFICIENT
     return summary
+
+
+# Trade module target paths for evidence checking
+# HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1
+_TRADE_TARGET_PATHS = [
+    "modules/foundups/trade/readme.md",
+    "modules/foundups/trade/interface.md",
+    "modules/foundups/trade/roadmap.md",
+    "modules/foundups/trade/src/contracts.py",
+    "modules/foundups/trade/src/adapters.py",
+    "modules/foundups/trade/src/guards.py",
+    "modules/foundups/trade/",
+]
+
+
+def _has_trade_module_evidence(payload: Dict[str, Any]) -> bool:
+    """Check if retrieval results contain Trade module evidence.
+
+    HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1:
+    Trade intent queries are not sufficient unless Trade docs/code appear
+    in the results. This prevents false positives where unrelated hits
+    satisfy generic thresholds.
+    """
+    # Check all hit types
+    hit_lists = [
+        payload.get("code_hits", []),
+        payload.get("docs_hits", []),
+        payload.get("wsp_hits", []),
+        payload.get("knowledge_hits", []),
+    ]
+
+    for hits in hit_lists:
+        for hit in hits:
+            path = (hit.get("path") or hit.get("location") or "").lower().replace("\\", "/")
+            for target in _TRADE_TARGET_PATHS:
+                if target in path:
+                    return True
+
+    return False
 
 
 def format_verdict_for_agent(summary: RetrievalEvidenceSummary) -> str:

--- a/holo_index/core/search_engine.py
+++ b/holo_index/core/search_engine.py
@@ -502,6 +502,140 @@ def _wsp_alias_match_boost(query: str, path: str, title: str) -> float:
 
 
 # ---------------------------------------------------------------------------
+# HIA6: Trade/FoundUp analyst language alias registry
+# HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1
+# ---------------------------------------------------------------------------
+
+# Maps natural analyst language to Trade module terminology.
+# When a query uses analyst terms like "pump.fun" or "rug pull", expands
+# to include the actual terminology used in Trade contracts/docs.
+# No LLM required. Deterministic pattern matching.
+
+_TRADE_ALIAS_GROUPS: Dict[str, List[str]] = {
+    # Platform aliases
+    "pump.fun": ["pumpfun", "pump fun", "pump_fun"],
+    "pumpfun": ["pump.fun", "pump fun", "pump_fun"],
+    # Token type aliases
+    "memecoin": ["meme-coin", "meme coin", "meme_coin"],
+    "meme-coin": ["memecoin", "meme coin", "meme_coin"],
+    "meme coin": ["memecoin", "meme-coin", "meme_coin"],
+    # Creator/issuer aliases
+    "issuer": ["creator", "creator_address", "token_creator"],
+    "creator": ["issuer", "creator_address", "token_creator"],
+    # Social platform aliases
+    "x account": ["twitter", "socialevent", "social_event"],
+    "twitter": ["x account", "socialevent", "social_event"],
+    "telegram": ["socialevent", "social_event", "tg"],
+    # Risk/fraud aliases
+    "rug pull": ["rug_pull_score", "soft-rug", "honeypot", "rugpull", "rug_pull"],
+    "rug_pull": ["rug pull", "rug_pull_score", "soft-rug", "honeypot"],
+    "rugpull": ["rug pull", "rug_pull_score", "soft-rug", "honeypot"],
+    "honeypot": ["rug pull", "rug_pull_score", "honeypot_detection"],
+    # Trading activity aliases
+    "large trades": ["top traders", "walletevent", "wallet_event", "holder distribution"],
+    "top traders": ["large trades", "walletevent", "wallet_event", "holder_distribution"],
+    "whale": ["top traders", "large trades", "holder_distribution"],
+    # Social influence aliases
+    "influencer": ["social", "engagement", "promoter", "socialevent"],
+    "promoter": ["influencer", "social", "engagement"],
+}
+
+# Trade-specific keywords that indicate Trade intent
+_TRADE_INTENT_KEYWORDS: List[str] = [
+    "trade", "trading", "pump.fun", "pumpfun", "pump fun",
+    "memecoin", "meme-coin", "meme coin",
+    "issuer", "creator", "token_creator",
+    "rug pull", "rugpull", "honeypot", "soft-rug",
+    "launchpad", "bonding curve",
+    "whale", "top traders", "holder distribution",
+    "x account", "twitter", "telegram",
+    "influencer", "promoter",
+    "wallet audit", "due diligence",
+]
+
+# Trade module paths that MUST appear for Trade intent queries
+_TRADE_TARGET_PATHS: List[str] = [
+    "modules/foundups/trade/readme.md",
+    "modules/foundups/trade/interface.md",
+    "modules/foundups/trade/roadmap.md",
+    "modules/foundups/trade/src/contracts.py",
+    "modules/foundups/trade/src/adapters.py",
+    "modules/foundups/trade/src/guards.py",
+]
+
+
+def _is_trade_intent_query(query: str) -> bool:
+    """Detect if query has Trade/FoundUp intent based on keywords."""
+    ql = query.lower()
+    for kw in _TRADE_INTENT_KEYWORDS:
+        if kw in ql:
+            return True
+    return False
+
+
+def _expand_trade_aliases(query: str) -> List[str]:
+    """Expand Trade analyst language to include all aliases.
+
+    Returns list of additional search terms to consider.
+    """
+    ql = query.lower()
+    expansions: List[str] = []
+
+    for term, aliases in _TRADE_ALIAS_GROUPS.items():
+        if term in ql:
+            for alias in aliases:
+                if alias not in ql:
+                    expansions.append(alias)
+
+    return expansions
+
+
+def _trade_path_boost(query: str, path: str) -> float:
+    """Return boost if Trade intent query targets Trade module path.
+
+    HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1:
+    When query has Trade intent, boost Trade module paths significantly.
+    """
+    if not _is_trade_intent_query(query):
+        return 0.0
+
+    path_lower = path.lower().replace("\\", "/")
+
+    # Strong boost for Trade module paths
+    if "modules/foundups/trade/" in path_lower:
+        # Extra boost for core documentation
+        for target in _TRADE_TARGET_PATHS:
+            if target in path_lower:
+                return 8.0  # Very strong boost for Trade target docs
+        return 5.0  # Strong boost for any Trade module file
+
+    return 0.0
+
+
+def _trade_alias_keyword_boost(query: str, path: str, title: str, content: str = "") -> float:
+    """Return boost if expanded Trade aliases match document content.
+
+    HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1:
+    Bridges analyst language to Trade module terminology.
+    """
+    if not _is_trade_intent_query(query):
+        return 0.0
+
+    expansions = _expand_trade_aliases(query)
+    if not expansions:
+        return 0.0
+
+    boost = 0.0
+    combined = (path + " " + title + " " + content).lower()
+
+    for alias in expansions:
+        if alias in combined:
+            boost += 1.5  # Boost for each matched alias
+
+    return min(boost, 6.0)  # Cap at 6.0
+
+
+# ---------------------------------------------------------------------------
 # HIA2: Confidence scoring (pure heuristic, no LLM)
 # ---------------------------------------------------------------------------
 
@@ -793,6 +927,9 @@ def _search_collection(
         # Work Ledger boost: PR, worker, branch, status, foundup_id
         if doc_type == "work_ledger_slice":
             keyword_score += _work_ledger_combined_boost(query, meta)
+        # HIA6: Trade/FoundUp alias and path boost
+        keyword_score += _trade_path_boost(query, path)
+        keyword_score += _trade_alias_keyword_boost(query, path, title, doc or "")
 
         if doc_type_filter != "all" and not doc_type.startswith(doc_type_filter):
             continue
@@ -912,6 +1049,9 @@ def _lexical_search_collection(
             # Work Ledger boost: PR, worker, branch, status, foundup_id
             if doc_type == "work_ledger_slice":
                 keyword_score += _work_ledger_combined_boost(query, meta)
+            # HIA6: Trade/FoundUp alias and path boost
+            keyword_score += _trade_path_boost(query, path)
+            keyword_score += _trade_alias_keyword_boost(query, path, title, doc_text)
 
             if keyword_score <= 0:
                 continue

--- a/holo_index/tests/test_trade_query_alias_retrieval.py
+++ b/holo_index/tests/test_trade_query_alias_retrieval.py
@@ -1,0 +1,333 @@
+# -*- coding: utf-8 -*-
+"""Tests for Trade FoundUp query alias retrieval fix.
+
+HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1
+
+Verifies that natural analyst language queries (pump.fun, memecoin, issuer,
+X account, rug pull, etc.) correctly surface Trade module documentation.
+
+WSP 97: Truth boundary — this slice fixes retrieval quality, not Trade behavior.
+"""
+
+from holo_index.core.search_engine import (
+    _is_trade_intent_query,
+    _expand_trade_aliases,
+    _trade_path_boost,
+    _trade_alias_keyword_boost,
+)
+from holo_index.core.agentic_rag_verdict import (
+    QueryIntent,
+    RetrievalVerdict,
+    classify_query_intent,
+    classify_retrieval_evidence,
+    _has_trade_module_evidence,
+)
+
+
+class TestTradeIntentDetection:
+    """Tests for Trade intent detection from query keywords."""
+
+    def test_pump_fun_triggers_trade_intent(self):
+        """pump.fun keyword triggers Trade intent."""
+        assert _is_trade_intent_query("Trade pump.fun memecoin issuer") is True
+
+    def test_pumpfun_triggers_trade_intent(self):
+        """pumpfun (no dot) triggers Trade intent."""
+        assert _is_trade_intent_query("pumpfun launchpad analysis") is True
+
+    def test_memecoin_triggers_trade_intent(self):
+        """memecoin keyword triggers Trade intent."""
+        assert _is_trade_intent_query("memecoin due diligence wallet audit") is True
+
+    def test_rug_pull_triggers_trade_intent(self):
+        """rug pull keyword triggers Trade intent."""
+        assert _is_trade_intent_query("rug pull detection honeypot") is True
+
+    def test_x_account_triggers_trade_intent(self):
+        """X account keyword triggers Trade intent."""
+        assert _is_trade_intent_query("check x account twitter telegram") is True
+
+    def test_influencer_triggers_trade_intent(self):
+        """influencer keyword triggers Trade intent."""
+        assert _is_trade_intent_query("influencer promoter social engagement") is True
+
+    def test_large_trades_triggers_trade_intent(self):
+        """large trades / whale keyword triggers Trade intent."""
+        assert _is_trade_intent_query("whale top traders holder distribution") is True
+
+    def test_unrelated_query_no_trade_intent(self):
+        """Unrelated queries do not trigger Trade intent."""
+        assert _is_trade_intent_query("pytest fixtures module structure") is False
+
+
+class TestTradeAliasExpansion:
+    """Tests for Trade alias expansion."""
+
+    def test_pump_fun_expands_to_variants(self):
+        """pump.fun expands to pumpfun, pump fun variants."""
+        expansions = _expand_trade_aliases("pump.fun launchpad")
+        assert "pumpfun" in expansions
+        assert "pump fun" in expansions
+
+    def test_memecoin_expands_to_variants(self):
+        """memecoin expands to meme-coin, meme coin variants."""
+        expansions = _expand_trade_aliases("memecoin analysis")
+        assert "meme-coin" in expansions
+        assert "meme coin" in expansions
+
+    def test_issuer_expands_to_creator(self):
+        """issuer expands to creator, creator_address."""
+        expansions = _expand_trade_aliases("check issuer background")
+        assert "creator" in expansions
+        assert "creator_address" in expansions
+
+    def test_rug_pull_expands_to_score_and_honeypot(self):
+        """rug pull expands to rug_pull_score, honeypot."""
+        expansions = _expand_trade_aliases("rug pull detection")
+        assert "rug_pull_score" in expansions
+        assert "honeypot" in expansions
+
+    def test_twitter_expands_to_socialevent(self):
+        """twitter expands to socialevent."""
+        expansions = _expand_trade_aliases("check twitter account")
+        assert "socialevent" in expansions
+
+
+class TestTradePathBoost:
+    """Tests for Trade module path boosting."""
+
+    def test_trade_readme_gets_strong_boost(self):
+        """Trade README gets 8.0 boost for Trade intent queries."""
+        boost = _trade_path_boost(
+            "pump.fun memecoin analysis",
+            "modules/foundups/trade/README.md"
+        )
+        assert boost == 8.0
+
+    def test_trade_interface_gets_strong_boost(self):
+        """Trade INTERFACE gets 8.0 boost for Trade intent queries."""
+        boost = _trade_path_boost(
+            "memecoin launchpad",
+            "modules/foundups/trade/INTERFACE.md"
+        )
+        assert boost == 8.0
+
+    def test_trade_contracts_gets_strong_boost(self):
+        """Trade contracts.py gets 8.0 boost for Trade intent queries."""
+        boost = _trade_path_boost(
+            "rug pull detection",
+            "modules/foundups/trade/src/contracts.py"
+        )
+        assert boost == 8.0
+
+    def test_trade_other_files_get_medium_boost(self):
+        """Other Trade module files get 5.0 boost."""
+        boost = _trade_path_boost(
+            "memecoin analysis",
+            "modules/foundups/trade/src/simulation_harness.py"
+        )
+        assert boost == 5.0
+
+    def test_non_trade_path_no_boost(self):
+        """Non-Trade paths get no boost even for Trade queries."""
+        boost = _trade_path_boost(
+            "pump.fun analysis",
+            "modules/gamification/whack_a_magat/src/whack.py"
+        )
+        assert boost == 0.0
+
+    def test_non_trade_query_no_boost(self):
+        """Non-Trade queries get no boost even for Trade paths."""
+        boost = _trade_path_boost(
+            "pytest fixtures",
+            "modules/foundups/trade/README.md"
+        )
+        assert boost == 0.0
+
+
+class TestTradeAliasKeywordBoost:
+    """Tests for Trade alias keyword boosting in content."""
+
+    def test_alias_match_in_content_gets_boost(self):
+        """Expanded aliases matching content get boost."""
+        # Query uses "issuer", content has "creator_address"
+        boost = _trade_alias_keyword_boost(
+            "check issuer background",
+            "modules/foundups/trade/src/contracts.py",
+            "Trade Contracts",
+            "creator_address validation"
+        )
+        assert boost > 0.0
+
+    def test_multiple_alias_matches_accumulate(self):
+        """Multiple alias matches accumulate boost."""
+        boost = _trade_alias_keyword_boost(
+            "issuer rug pull",
+            "modules/foundups/trade/src/contracts.py",
+            "Trade Contracts",
+            "creator_address rug_pull_score honeypot_detection"
+        )
+        # Should accumulate multiple boosts (capped at 6.0)
+        assert boost >= 3.0
+
+
+class TestTradeQueryIntentClassification:
+    """Tests for Trade query intent classification in verdict module."""
+
+    def test_pump_fun_classified_as_trade_intent(self):
+        """pump.fun query classified as TRADE intent."""
+        intent = classify_query_intent("Trade pump.fun memecoin analysis")
+        assert intent == QueryIntent.TRADE
+
+    def test_memecoin_classified_as_trade_intent(self):
+        """memecoin query classified as TRADE intent."""
+        intent = classify_query_intent("memecoin launchpad bonding curve")
+        assert intent == QueryIntent.TRADE
+
+    def test_rug_pull_classified_as_trade_intent(self):
+        """rug pull query classified as TRADE intent."""
+        intent = classify_query_intent("rug pull honeypot detection")
+        assert intent == QueryIntent.TRADE
+
+    def test_wsp_still_classified_as_wsp_intent(self):
+        """WSP queries still classified as WSP intent."""
+        intent = classify_query_intent("WSP 97 compliance check")
+        # WSP takes precedence since we check Trade first but WSP is more specific
+        # Actually Trade is checked first, but "WSP 97" doesn't match Trade keywords
+        assert intent == QueryIntent.WSP
+
+    def test_unrelated_query_classified_as_general(self):
+        """Unrelated queries classified as GENERAL intent."""
+        # Note: "module" triggers CODE intent, so use a different example
+        intent = classify_query_intent("pytest fixtures setup teardown")
+        assert intent == QueryIntent.GENERAL
+
+
+class TestTradeModuleEvidenceDetection:
+    """Tests for Trade module evidence detection in retrieval results."""
+
+    def test_trade_readme_is_evidence(self):
+        """Trade README in results counts as Trade evidence."""
+        payload = {
+            "docs_hits": [
+                {"path": "modules/foundups/trade/README.md", "title": "Trade README"}
+            ],
+            "code_hits": [],
+        }
+        assert _has_trade_module_evidence(payload) is True
+
+    def test_trade_contracts_is_evidence(self):
+        """Trade contracts.py in results counts as Trade evidence."""
+        payload = {
+            "code_hits": [
+                {"path": "modules/foundups/trade/src/contracts.py"}
+            ],
+            "docs_hits": [],
+        }
+        assert _has_trade_module_evidence(payload) is True
+
+    def test_trade_guards_is_evidence(self):
+        """Trade guards.py in results counts as Trade evidence."""
+        payload = {
+            "code_hits": [
+                {"location": "modules\\foundups\\trade\\src\\guards.py"}
+            ],
+            "docs_hits": [],
+        }
+        assert _has_trade_module_evidence(payload) is True
+
+    def test_unrelated_hits_not_evidence(self):
+        """Unrelated module hits do not count as Trade evidence."""
+        payload = {
+            "code_hits": [
+                {"path": "modules/gamification/whack_a_magat/src/whack.py"}
+            ],
+            "docs_hits": [
+                {"path": "docs/SPRINT_1_2_WSP_COMPLIANCE_AUDIT.md"}
+            ],
+        }
+        assert _has_trade_module_evidence(payload) is False
+
+    def test_empty_results_not_evidence(self):
+        """Empty results do not count as Trade evidence."""
+        payload = {"code_hits": [], "docs_hits": []}
+        assert _has_trade_module_evidence(payload) is False
+
+
+class TestTradeVerdictClassification:
+    """Tests for Trade intent verdict classification."""
+
+    def test_trade_intent_with_trade_evidence_is_sufficient(self):
+        """Trade intent with Trade module evidence is SUFFICIENT."""
+        payload = {
+            "docs_hits": [
+                {"path": "modules/foundups/trade/README.md", "title": "Trade README"}
+            ],
+            "code_hits": [],
+            "wsp_hits": [],
+            "knowledge_hits": [],
+            "metadata": {"query": "pump.fun memecoin analysis"},
+        }
+        summary = classify_retrieval_evidence(payload, QueryIntent.TRADE)
+        assert summary.verdict == RetrievalVerdict.SUFFICIENT
+
+    def test_trade_intent_with_unrelated_hits_is_degraded(self):
+        """Trade intent with unrelated hits is DEGRADED."""
+        payload = {
+            "docs_hits": [
+                {"path": "docs/SPRINT_1_2_WSP_COMPLIANCE_AUDIT.md"}
+            ],
+            "code_hits": [
+                {"path": "modules/gamification/whack_a_magat/src/whack.py"}
+            ],
+            "wsp_hits": [],
+            "knowledge_hits": [],
+            "metadata": {"query": "pump.fun memecoin analysis"},
+        }
+        summary = classify_retrieval_evidence(payload, QueryIntent.TRADE)
+        assert summary.verdict == RetrievalVerdict.DEGRADED
+        assert "Trade intent but no Trade module evidence" in summary.reason
+
+    def test_trade_intent_with_no_hits_is_unsafe(self):
+        """Trade intent with no hits is UNSAFE_TO_ACT."""
+        payload = {
+            "docs_hits": [],
+            "code_hits": [],
+            "wsp_hits": [],
+            "knowledge_hits": [],
+            "metadata": {"query": "pump.fun memecoin analysis"},
+        }
+        summary = classify_retrieval_evidence(payload, QueryIntent.TRADE)
+        assert summary.verdict == RetrievalVerdict.UNSAFE_TO_ACT
+
+
+class TestRegressionPreviousBehavior:
+    """Regression tests to ensure previous behavior is preserved."""
+
+    def test_wsp_intent_still_works(self):
+        """WSP intent verdict logic still works correctly."""
+        payload = {
+            "wsp_hits": [
+                {"path": "WSP_framework/src/WSP_97.md", "title": "WSP 97"}
+            ],
+            "docs_hits": [],
+            "code_hits": [],
+            "knowledge_hits": [],
+            "metadata": {"query": "WSP 97 compliance"},
+        }
+        summary = classify_retrieval_evidence(payload, QueryIntent.WSP)
+        assert summary.verdict == RetrievalVerdict.SUFFICIENT
+
+    def test_general_intent_still_works(self):
+        """General intent verdict logic still works correctly."""
+        payload = {
+            "code_hits": [
+                {"path": "some/code/file.py"}
+            ],
+            "docs_hits": [],
+            "wsp_hits": [],
+            "knowledge_hits": [],
+            "metadata": {"query": "some general query"},
+        }
+        summary = classify_retrieval_evidence(payload, QueryIntent.GENERAL)
+        assert summary.verdict == RetrievalVerdict.SUFFICIENT


### PR DESCRIPTION
## Summary

- Fix HoloIndex retrieval gap where natural Trade analyst queries failed to surface Trade docs
- Add search-time alias expansion for Trade terminology (pump.fun -> pumpfun, memecoin -> meme-coin, etc.)
- Add target-aware verdict requiring Trade module evidence for Trade-intent queries
- No live reindex required (search-time expansion)

## Problem

| Analyst Query | Before | After |
|---------------|--------|-------|
| "Trade pump.fun memecoin issuer" | whack_a_magat, unrelated | Trade ModLog, pumpfun_comparison |
| "Trade FoundUp pump.fun launchpad" | partial | Trade README, ROADMAP, test_adapter_contracts.py |

## Key Aliases Added

| Analyst Term | Trade Terms |
|--------------|-------------|
| pump.fun | pumpfun, pump fun |
| memecoin | meme-coin, meme coin |
| issuer | creator, creator_address |
| rug pull | rug_pull_score, honeypot |
| twitter/X | socialevent |
| large trades | top traders, walletevent |

## WSP_97 Truth Boundary

- HOLOINDEX_RETRIEVAL_QUALITY_FIX_ONLY: YES
- NO_LIVE_REINDEX: YES
- NO_TRADE_STATUS_CHANGE: YES

## Test plan

- [x] 36 new tests pass (test_trade_query_alias_retrieval.py)
- [x] 135 regression tests pass (audit spec, HXA, work ledger, search quality)
- [x] Before/after retrieval comparison verified
- [x] Trade docs now surface for Trade-intent queries

🤖 Generated with [Claude Code](https://claude.ai/code)