### PR TITLE
docs(holoindex): index-docs consistency audit Phase 1

### DIFF
--- a/docs/audits/holoindex_search_quality/HOLOINDEX_INDEX_DOCS_CONSISTENCY_AUDIT_PHASE1.md
+++ b/docs/audits/holoindex_search_quality/HOLOINDEX_INDEX_DOCS_CONSISTENCY_AUDIT_PHASE1.md
@@ -1,0 +1,498 @@
+# HoloIndex `--index-docs` Pipeline Consistency Audit — Phase 1
+
+**Slice**: `HOLOINDEX_INDEX_DOCS_CONSISTENCY_AUDIT_PHASE1`
+**Worker**: W6
+**Agent**: 0102
+**Date**: 2026-05-24
+**Mode**: DIAGNOSTIC (dry-run, read-only)
+**Branch**: `feat/holoindex-index-docs-consistency-audit-phase1`
+**Base commit**: `d4827f639` (origin/main, post-PR #689)
+**Worktree**: `.claude/worktrees/holoindex-index-docs-consistency-audit`
+**WSP Lock**: WSP_00 → WSP_15 → WSP_50 → WSP_64 → WSP_83 → WSP_87 → WSP_97 → WSP_104 → WSP_22
+
+---
+
+## WSP_97 Truth Boundary Checklist
+
+| Truth Boundary Checklist Item | Status |
+|-------------------------------|--------|
+| HOLOINDEX_DIAGNOSTIC_DRY_RUN_ONLY | YES |
+| READ_ONLY_CHROMA_ACCESS | YES |
+| NO_CHROMA_MUTATION | YES |
+| NO_REINDEX | YES (no indexer flag was invoked) |
+| NO_HOLOINDEX_CORE_INSTRUMENTATION | YES (no `holo_index/core/**` change) |
+| NO_HOLOINDEX_CORE_MUTATION | YES |
+| NO_REGISTRY_MUTATION | YES |
+| NO_CATALOG_MUTATION | YES |
+| NO_MANIFEST_MUTATION | YES |
+| NO_PROJECTION_MUTATION | YES |
+| NO_TRADE_MUTATION | YES |
+| NO_WSP_MUTATION | YES |
+| NO_CI_CHANGE | YES |
+| NO_DEPENDENCY_INSTALL | YES |
+| NO_GENERATED_INDEX_ARTIFACTS_COMMITTED | YES |
+| REPORT_ONLY | YES |
+| STATIC_SAFETY_SCAN_PASSES_ON_DIAGNOSTIC_SCRIPT | YES |
+| NO_CABR_READY | YES |
+| NO_PAYOUT_READY | YES |
+| NO_DAO_ACTIVATION | YES |
+
+---
+
+## 1. Mission
+
+PR #689 (HOLOINDEX_AUDIT_DOC_INDEXING_PROBE_PHASE1) confirmed empirically that
+`navigation_docs` is missing **9** of the **42** files in
+`docs/audits/architecture/`, including three target audit docs (T1/T2/T3),
+even though PR #688 ran the docs reindexer with **exit code 0** and the
+reward marker `+5 Refreshed indexes`. The probe explicitly recommended
+**not** simply rerunning the indexer.
+
+This slice is the diagnostic follow-on. It investigates why the indexer
+reports success but leaves files out of the index, classifies the failure
+mode, and names the smallest follow-on fix slice. It does this **without**
+running the indexer, without writing to Chroma, and without instrumenting
+the core indexing engine.
+
+---
+
+## 2. Chain-of-Thought / Chain-of-Action / Chain-of-Evidence (CoT/CoA/CoE)
+
+### 2.1 Chain-of-Thought
+
+- The probe found a per-file *index inclusion* failure, not a *ranking* failure.
+- The indexer is structured as: discover files → filter → embed → bulk-add.
+  Each stage can fail silently.
+- The CLI emits `[DOCS] Indexed module/root docs in {duration}s` and the
+  reward marker is granted on flag completion rather than on inserted count.
+  So a no-op run is observationally indistinguishable from a successful run.
+- HoloIndex resolves `project_root = Path(__file__).parent.parent.parent`
+  from `holo_index/core/holo_index.py`. Worktrees in this repo live under
+  `.claude/worktrees/<name>/` and contain a full copy of `holo_index/`, so
+  a worktree-launched run picks up the worktree as `project_root`.
+- The indexer file filter rejects any path whose `f.parts` contains a
+  component starting with `.`. **Every** absolute path inside a worktree
+  contains the part `.claude`, so the filter would reject **all** files
+  the worktree discovers.
+
+### 2.2 Chain-of-Action
+
+| Step | Action | Mutates? |
+|------|--------|----------|
+| 1 | Verify worktree base (`d4827f639`) and presence of all target files on disk | NO |
+| 2 | Read the indexer source (`holo_index/_cli_main.py`, `holo_index/core/indexing_engine.py::index_docs_entries`, `holo_index/core/holo_index.py::project_root`) | NO |
+| 3 | Build a dry-run diagnostic script (`holo_index/scripts/diagnose_index_docs_pipeline.py`) replicating the filter, model-cache check, and id scheme **without** invoking the indexer or touching Chroma | NO |
+| 4 | Run the diagnostic; observe `navigation_docs` read-only for count + architecture-paths sample | NO (read-only) |
+| 5 | Cross-check expected vs. actual missing files by enumerating disk vs. Chroma | NO (read-only) |
+| 6 | Classify the failure mode and name the smallest fix slice | NO |
+
+### 2.3 Chain-of-Evidence
+
+| Evidence | Source | Value |
+|----------|--------|-------|
+| Worktree `project_root` resolves under `.claude/worktrees/` | `Path(__file__).parent.parent.parent` from `holo_index/core/holo_index.py` | `O:\Foundups-Agent\.claude\worktrees\holoindex-index-docs-consistency-audit` |
+| Indexer filter rejects any `f.parts` containing a dot-prefixed part | `indexing_engine.py:650` | `not any(part.startswith('.') for part in f.parts)` |
+| Indexer also has a redundant clause that rejects literal `.claude/worktrees` substring | `indexing_engine.py:655–656` | both clauses fire on the same paths |
+| When `files` is empty, the indexer returns early with `WARN` log only | `indexing_engine.py:660–662` | `if not files: holo._log_agent_action("No docs found to index", "WARN"); return` |
+| CLI awards `indexing_awarded = True` after the function returns regardless of insertion count | `_cli_main.py:1010–1016` | reward decoupled from N |
+| `navigation_docs` total: 3309; architecture subset: 33; on-disk: 42; gap: 9 | live probe (read-only) | matches PR #689's finding exactly |
+| All 9 missing files are the 9 most recently added architecture audit docs | git log + Chroma metadata enumeration | see §6.3 |
+
+---
+
+## 3. HoloIndex WSP_50 Retrieval Quality (per-query)
+
+Five preflight HoloIndex queries were run from the main repo before any
+work began in this slice. None of the queries surfaced the canonical
+source files needed (`_cli_main.py`, `indexing_engine.py`,
+`probe_audit_doc_indexing.py`) or the PR #688/#689 audit docs *by slice
+ID*. The audit fell back to direct file reads.
+
+| # | Query | Retrieval quality | Notes |
+|---|-------|-------------------|-------|
+| Q1 | `--index-docs handler CFZ4 navigation_docs` | WEAK | generic CFZ hits; CLI handler not surfaced |
+| Q2 | `index_docs_entries indexing_engine project_root` | WEAK | core file not in top hits |
+| Q3 | `HOLOINDEX_AUDIT_DOC_INDEXING_PROBE_PHASE1` | WEAK | PR #689 doc not surfaced by slice ID |
+| Q4 | `HOLOINDEX_DOCS_REINDEX_OBSERVATION_PHASE1` | WEAK | PR #688 doc not surfaced by slice ID |
+| Q5 | `probe_audit_doc_indexing.py` | WEAK | script not surfaced; `ls` confirmed presence |
+
+**Retrieval evaluation**: noise (generic hits dominate over targeted ones),
+missing artifacts (slice-ID lookup is unreliable for recent docs),
+**staleness risk confirmed** — Q3/Q4 absence is itself an instance of the
+very failure under investigation. Duplication: not observed. Ordering:
+recency/priority not honoured for slice-ID literal matches.
+
+**Improve retrieval**: cannot be addressed in this slice (out of scope per
+the WSP_97 boundary checklist). Documented for the follow-on slice
+recommendation.
+
+---
+
+## 4. DISCOVERY — Pipeline Map (end-to-end)
+
+### 4.1 Entry point
+
+`python holo_index.py --index-docs` (CLI handler at
+`holo_index/_cli_main.py:1009–1016`):
+
+```python
+index_docs = getattr(args, 'index_docs', False) or args.index_all
+if index_docs:
+    start_time = time.time()
+    holo.index_docs_entries()
+    duration = time.time() - start_time
+    safe_print(f"[DOCS] Indexed module/root docs in {duration:.2f}s")
+    indexing_awarded = True
+```
+
+Observation: no return-value check, no try/except, no count surfaced. The
+reward `indexing_awarded = True` is set unconditionally on flag completion.
+
+### 4.2 Façade
+
+`holo_index/core/holo_index.py:502–505`:
+
+```python
+def index_docs_entries(self) -> None:
+    """CFZ4: Index module/root docs into navigation_docs collection."""
+    from .indexing_engine import index_docs_entries as _idx_docs
+    _idx_docs(self)
+```
+
+### 4.3 Implementation — `holo_index/core/indexing_engine.py:625–711`
+
+| Stage | Lines | What happens | Failure mode |
+|-------|-------|--------------|--------------|
+| **S1** Resolve roots | 634–639 | `doc_paths = [project_root / r for r in ("modules","docs","holo_index/docs","WSP_framework/docs")]` | If `project_root` is wrong → wrong tree |
+| **S2** Glob | 644 | `all_doc_files = sorted(list(base.rglob("*.md")))` for each existing base | None observed |
+| **S3** Filter | 645–657 | 9 clauses including `not any(part.startswith('.') for part in f.parts)` | **Over-rejection inside worktrees** |
+| **S4** Empty check | 660–662 | `if not files: _log_agent_action("No docs found to index", "WARN"); return` | **Silent no-op**; exit 0 |
+| **S5** Reset | 665 | `holo.docs_collection = holo._reset_collection("navigation_docs")` | Skipped when S4 short-circuits |
+| **S6** Embed | 689 | `embeddings.append(holo._get_embedding(doc_payload))` | Falls back to `[0.0]*384` if model absent |
+| **S7** Bulk insert | 707–709 | single bulk insertion of `(ids, embeddings, documents, metadatas)` | Skipped when S4 short-circuits |
+| **S8** Log | 709–711 | `Docs index refreshed: {N} entries` or `No docs entries were indexed` | Stderr only; CLI does not surface |
+
+### 4.4 `project_root` resolution
+
+`holo_index/core/holo_index.py:180`:
+
+```python
+self.project_root = Path(__file__).parent.parent.parent
+```
+
+For `holo_index/core/holo_index.py` inside the worktree
+`O:\Foundups-Agent\.claude\worktrees\holoindex-index-docs-consistency-audit`,
+this resolves to the worktree root, **not** the main repository.
+
+### 4.5 Embedding fallback
+
+`holo_index/core/holo_index.py:474–480`:
+
+```python
+def _get_embedding(self, text: str) -> List[float]:
+    if self.model:
+        return self.model.encode(text, show_progress_bar=False).tolist()
+    return [0.0] * 384
+```
+
+Silent fallback to a zero vector when `self.model` is `None`. Distinct
+from the consistency failure under investigation (zero vectors would
+still produce indexed entries), but documented for completeness.
+
+---
+
+## 5. PROBE_DESIGN — Diagnostic script
+
+`holo_index/scripts/diagnose_index_docs_pipeline.py` (new, dry-run only).
+
+| Property | Value |
+|----------|-------|
+| Mutates Chroma? | NO |
+| Spawns child processes? | NO |
+| Invokes the indexer CLI flag? | NO |
+| Imports `indexing_engine.py`? | NO (filter logic mirrored to avoid Chroma init) |
+| Reads Chroma? | YES (`count()`, `get(include=["metadatas"])` — read-only) |
+| Determinism | Verified (two consecutive runs → identical md5) |
+
+### 5.1 Stub-only mutation simulation
+
+The diagnostic uses a `_RecorderStub` class for the H3 bulk-insertion
+simulation. It exposes a single `accumulate(...)` method that appends to
+lists and tracks duplicates. It has no Chroma surface. None of the
+forbidden mutation tokens appear in the script.
+
+### 5.2 Static safety scan (forbidden-token table)
+
+The diagnostic script asserts that the following Chroma-mutation,
+process-spawn, and reset/persist verbs never appear as literal
+substrings in its own source. The token list is assembled at runtime
+from a fragment table so the file itself does not contain the literal
+tokens it forbids.
+
+Externally verified count (this slice, against the worktree file):
+
+| Token fragment-assembled at runtime | Count in script |
+|-------------------------------------|-----------------|
+| chroma add-method prefix | 0 |
+| chroma update-method prefix | 0 |
+| chroma delete-method prefix | 0 |
+| collection-removal verb | 0 |
+| in-place state reset verb | 0 |
+| in-place persistence verb | 0 |
+| host process spawn primitive | 0 |
+| host shell invocation primitive | 0 |
+| indexer CLI flag as child command | 0 |
+
+**Static safety scan: PASS** (also self-reported by the script).
+
+---
+
+## 6. INVESTIGATION — Hypotheses H1..H6
+
+### 6.1 Summary table
+
+| Hyp | Finding | Evidence |
+|-----|---------|----------|
+| **H1** project_root mismatch | **CONFIRMED** | resolved root: `O:\Foundups-Agent\.claude\worktrees\holoindex-index-docs-consistency-audit` |
+| **H2** embedding model silent fallback | NOT CAUSAL (sec. effect noted) | model cache absent at default candidates; falls back to zero vector — would still produce entries |
+| **H3** bulk insertion silent partial failure | NOT TRIGGERED in simulation | `doc_{idx}` scheme is unique per run; no duplicate ids observed; bulk insertion site has no try/except in core |
+| **H4** file-discovery filter excludes audit docs | **CONFIRMED — primary cause** | 387/387 docs in worktree `docs/` tree fail the `no_dot_prefixed_parts` clause; identical 387 also fail the `no_claude_worktrees_token` clause |
+| **H5** source-policy treats `docs/audits/architecture/` differently | NOT TRIGGERED | no path-class exclusion; priority boosts exist for `audits/openclaw_hermes/` and `audits/holoindex/` only |
+| **H6** observability gap | **CONFIRMED** | reward `+5 Refreshed indexes` is awarded on flag completion, not on N inserted; no per-file count surfaced on stdout; no non-zero exit on empty discovery |
+
+### 6.2 Target-by-target filter result (from diagnostic JSON)
+
+All five target files (T1..T5) exist on disk inside the worktree and ALL
+fail the indexer filter due to **two clauses simultaneously**:
+
+| Target | Path | Exists | `no_dot_prefixed_parts` | `no_claude_worktrees_token` | Overall |
+|--------|------|--------|------------------------|----------------------------|---------|
+| T1 | `docs/audits/architecture/TRADE_PUMPFUN_DUE_DILIGENCE_SCORING_SPEC_PHASE1.md` | YES | FAIL | FAIL | **REJECTED** |
+| T2 | `docs/audits/architecture/TRADE_ADAPTER_INTEGRATION_PHASE1.md` | YES | FAIL | FAIL | **REJECTED** |
+| T3 | `docs/audits/holoindex_search_quality/HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1.md` | YES | FAIL | FAIL | **REJECTED** |
+| T4 | `docs/audits/architecture/TRADE_DUE_DILIGENCE_SCORING_ENGINE_PHASE1.md` | YES | FAIL | FAIL | **REJECTED** |
+| T5 | `docs/audits/architecture/TRADE_DUE_DILIGENCE_SCHEMA_PHASE1.md` | YES | FAIL | FAIL | **REJECTED** |
+
+The aggregate failure profile over the worktree's `docs/` subtree:
+
+| Clause | Files failing |
+|--------|--------------|
+| `no_dot_prefixed_parts` | 387 / 387 |
+| `no_claude_worktrees_token` | 387 / 387 |
+| `no_backup` | 6 / 387 |
+| (all other clauses) | 0 / 387 |
+
+100% of the worktree's `docs/` markdown corpus is rejected, dominated by
+the dot-prefixed-parts clause.
+
+### 6.3 The 9 missing architecture docs (cross-check)
+
+Live read-only enumeration of `navigation_docs` against the main repo's
+`docs/audits/architecture/` directory:
+
+| | Count |
+|--|------|
+| Architecture audit docs on disk (main repo) | 42 |
+| Architecture audit docs in `navigation_docs` | 33 |
+| Gap | **9** |
+
+The 9 missing files (recovered via Chroma metadata vs. disk diff):
+
+1. `TRADE_PUMPFUN_DUE_DILIGENCE_SCORING_SPEC_PHASE1.md`
+2. `TRADE_ADAPTER_INTEGRATION_PHASE1.md`
+3. `TRADE_DUE_DILIGENCE_SCHEMA_PHASE1.md`
+4. `TRADE_DUE_DILIGENCE_SCORING_ENGINE_PHASE1.md`
+5. `TRADE_FOUNDUP_PUBLIC_SURFACE_MANIFEST_AUDIT_PHASE1.md`
+6. `TRADE_POC_SIMULATION_EVIDENCE_PACK_PHASE1.md`
+7. `TRADE_POC_SIMULATION_EVIDENCE_REVIEW_PHASE1.md`
+8. `TRADE_POC_SIMULATION_HARNESS_PHASE1.md`
+9. `PUBLIC_FOUNDUP_POC_LANDING_ROUTE_CONTRACT_DOCS_PHASE1.md`
+
+These are the **9 most recently added** architecture audit docs (commits
+from 2026-05-22 onwards). Their absence is consistent with: the last
+**successful** docs reindex was a **main-repo** invocation that
+**predates** these commits; every subsequent `--index-docs` was launched
+from a **worktree**, hit S4's empty-discovery short-circuit, and left
+the collection untouched.
+
+### 6.4 Why PR #688's reindex (exit 0) produced a no-op
+
+PR #688's worktree (`.claude/worktrees/holoindex-docs-reindex-observation`)
+shared the same `project_root` resolution rule. Its `--index-docs` run
+discovered 0 files (per H4), returned at the empty-file check (S4),
+skipped the reset and bulk insertion (S5+S7), and exited cleanly. The
+CLI still emitted the `+5 Refreshed indexes` reward (H6), making the
+no-op indistinguishable from a successful run.
+
+---
+
+## 7. CLASSIFICATION
+
+| Field | Value |
+|-------|-------|
+| Symptom | `--index-docs` exits 0 but 9 architecture audit docs remain absent from `navigation_docs` |
+| **Primary root cause** | **H1+H4 interlock**: worktree-resolved `project_root` introduces `.claude` into every absolute path; the `no_dot_prefixed_parts` filter clause rejects 100% of files; the indexer short-circuits at the empty-files guard (S4) without resetting or writing the collection |
+| Contributing factor | **H6**: the reward marker `+5 Refreshed indexes` is decoupled from inserted-count; no per-file count is surfaced; no non-zero exit on empty discovery — making the no-op invisible |
+| Secondary observation | **H2**: model cache absent at default candidates — would silently fall back to a 384-dim zero vector; orthogonal to this failure but worth noting for retrieval-quality work |
+| Stale-index vs. doc-missing vs. retrieval-quality | **Stale-index** (failure is at the *write* stage of the indexing pipeline, not at file discovery from disk and not at retrieval ranking) |
+| Failure mode | **Silent no-op on worktree-launched `--index-docs`** |
+| Blast radius | Every `--index-docs` invocation from any `.claude/worktrees/<name>/` path is a no-op |
+
+The PR #689 probe correctly characterised the targets as `A` (NOT_INDEXED).
+This audit refines the diagnosis to a specific failure mode and a single
+clause-level cause.
+
+---
+
+## 8. SMALLEST-FIX SLICE — Recommendation (not started)
+
+### 8.1 Named slice
+
+**`HOLOINDEX_INDEXER_PROJECT_ROOT_WORKTREE_SAFETY_PHASE1`**
+
+### 8.2 Scope
+
+Change the file-discovery filter in
+`holo_index/core/indexing_engine.py::index_docs_entries` so it
+evaluates path components **relative to the discovery base**, not
+against the absolute path. Concretely: change
+
+```python
+and not any(part.startswith('.') for part in f.parts)
+```
+
+to evaluate against `f.relative_to(base).parts` (or equivalent). This
+preserves the intent of the clause (skip dotfiles **inside** the docs
+tree such as `.git` or `.cache`) while no longer rejecting every file
+when the worktree's own location contains a dot-prefixed component.
+
+Apply the analogous change to the redundant `.claude/worktrees` /
+`.worktrees` substring clauses on the same call site so they only fire
+when the worktree token appears **inside** the discovery base.
+
+### 8.3 What this slice MUST NOT do
+
+- **MUST NOT** simply rerun the indexer.
+- **MUST NOT** widen the `project_root` resolution beyond a documented,
+  explicit override (the structural rule `Path(__file__).parent.parent.parent`
+  is intentional for portability).
+- **MUST NOT** silently swallow the dot-prefix clause; it is correct
+  inside the discovery tree.
+- **MUST NOT** change the reward-marker semantics (that is a separate
+  slice — `HOLOINDEX_INDEX_DOCS_REWARD_GATE_BY_INSERTED_COUNT_PHASE1`).
+
+### 8.4 Acceptance for the fix slice
+
+After the filter change, a `--index-docs` run launched from a worktree
+should discover the same on-disk file count as the equivalent run from
+the main repo, and the resulting `navigation_docs` size should match
+disk for `docs/audits/architecture/` (42 = 42).
+
+### 8.5 Companion observability slice (deferred, smaller still)
+
+**`HOLOINDEX_INDEX_DOCS_REWARD_GATE_BY_INSERTED_COUNT_PHASE1`** —
+gate the `+5 Refreshed indexes` reward on `N > 0` and surface the
+inserted count on stdout. ~10 lines in `_cli_main.py`. Independently
+mergeable from the filter fix.
+
+---
+
+## 9. Static Safety Verification (this audit)
+
+| Check | Result |
+|-------|--------|
+| Diagnostic script forbidden-token static scan | PASS (0 occurrences of any banned token; counted externally) |
+| Diagnostic script invokes the indexer CLI flag as child command | NO |
+| Diagnostic script spawns child processes | NO |
+| Diagnostic script writes to Chroma | NO |
+| Diagnostic script imports `indexing_engine` (would init Chroma) | NO |
+| Diagnostic determinism | PASS (two consecutive runs → identical md5) |
+| `git status --porcelain` after diagnostic (artifact guard) | clean apart from this audit + the new diagnostic script |
+
+---
+
+## 10. WSP_97 Verdict
+
+| Check | Result |
+|-------|--------|
+| HoloIndex diagnostic dry-run only | PASS |
+| No core instrumentation (no `holo_index/core/**` change) | PASS |
+| Read-only Chroma access | PASS |
+| No Chroma mutation | PASS |
+| No reindex invocation | PASS |
+| No HoloIndex core mutation | PASS |
+| No registry mutation | PASS |
+| No catalog mutation | PASS |
+| No manifest mutation | PASS |
+| No projection mutation | PASS |
+| No Trade mutation | PASS |
+| No WSP mutation | PASS |
+| No CI change | PASS |
+| No dependency install | PASS |
+| Report only | PASS |
+| Static safety scan on diagnostic script | PASS |
+| No CABR ready | PASS |
+| No payout ready | PASS |
+| No DAO activation | PASS |
+
+**Verdict**: PASS (19/19)
+
+---
+
+## 11. Files Changed
+
+| File | Change |
+|------|--------|
+| `holo_index/scripts/diagnose_index_docs_pipeline.py` | NEW (dry-run diagnostic, ~410 lines) |
+| `docs/audits/holoindex_search_quality/HOLOINDEX_INDEX_DOCS_CONSISTENCY_AUDIT_PHASE1.md` | NEW (this file) |
+
+No `holo_index/core/**` change. No CI/config/dep change. No ModLog
+append in this commit — the optional `holo_index/ModLog.md` append is
+deliberately deferred to the fix slice to avoid coupling diagnosis to
+the eventual remediation entry.
+
+---
+
+## 12. Completion Summary
+
+| Item | Value |
+|------|-------|
+| Branch | `feat/holoindex-index-docs-consistency-audit-phase1` |
+| Base commit | `d4827f639` (origin/main, post-PR #689) |
+| New commit SHA | *(populated by W10 on merge)* |
+| Files changed | exactly 2 (this audit + the diagnostic script) |
+| Indexer CLI invocation in this slice | NONE |
+| Chroma read operations | `count()`, `get(include=["metadatas"])` — read-only |
+| Chroma write operations | NONE |
+| Hypotheses tested | H1, H2, H3, H4, H5, H6 |
+| Confirmed | H1, H4, H6 |
+| Not triggered | H2 (orthogonal), H3, H5 |
+| Primary root cause | H1+H4 interlock |
+| Smallest-fix slice recommended | `HOLOINDEX_INDEXER_PROJECT_ROOT_WORKTREE_SAFETY_PHASE1` |
+| Companion observability slice (deferred) | `HOLOINDEX_INDEX_DOCS_REWARD_GATE_BY_INSERTED_COUNT_PHASE1` |
+| WSP_97 truth boundary | PASS (§10) |
+
+---
+
+## 13. W10 Readiness
+
+| Gate | Status |
+|------|--------|
+| Branch base = origin/main post-PR #689 | YES |
+| Files changed = exactly 2 | YES |
+| No indexer CLI invocation in this slice | YES |
+| No generated Chroma / index / cache artifact committed | YES |
+| Hypothesis-by-hypothesis findings recorded | YES |
+| Primary root cause classification recorded | YES |
+| Smallest-fix slice named (single follow-on) | YES |
+| Diagnostic script passes static safety scan | YES |
+| Diagnostic script is dry-run only | YES |
+| WSP_97 truth boundary checklist complete | YES |
+| **Ready for PR** | **YES** |
+
+---
+
+**Audit Complete**: 2026-05-24
+**Worker**: W6
+**Slice**: HOLOINDEX_INDEX_DOCS_CONSISTENCY_AUDIT_PHASE1
+**WSP Lock**: WSP_00 → WSP_15 → WSP_50 → WSP_64 → WSP_83 → WSP_87 → WSP_97 → WSP_104 → WSP_22

--- a/holo_index/scripts/diagnose_index_docs_pipeline.py
+++ b/holo_index/scripts/diagnose_index_docs_pipeline.py
@@ -1,0 +1,669 @@
+#!/usr/bin/env python3
+"""Diagnose --index-docs pipeline consistency (HOLOINDEX_INDEX_DOCS_CONSISTENCY_AUDIT_PHASE1).
+
+DRY-RUN ONLY. This script never mutates Chroma, never spawns child processes,
+never invokes the indexer. It probes the six hypotheses (H1..H6) describing
+why ``--index-docs`` can exit 0 yet leave audit docs absent from
+``navigation_docs``.
+
+Hypotheses probed:
+
+  H1  project_root mismatch
+      HoloIndex resolves ``project_root = Path(__file__).parent.parent.parent``.
+      A worktree-launched invocation therefore roots indexing at the worktree
+      path, not the main repository.
+
+  H2  embedding model silent fallback
+      ``_get_embedding`` returns a 384-dim zero vector when the sentence
+      transformer fails to load. The model cache footprint on E:/HoloIndex is
+      audited here for presence only; nothing is loaded.
+
+  H3  bulk collection insertion silent partial failure
+      The indexer accumulates ids/embeddings/documents/metadatas and performs a
+      single bulk insertion at the end of ``index_docs_entries``. This probe
+      simulates accumulation against a recorder stub (no Chroma mutation) and
+      checks for duplicate id risks given the ``doc_{idx}`` scheme.
+
+  H4  file-discovery filter excludes audit docs by absolute-path rule
+      The filter rejects any path whose ``f.parts`` contains a component
+      starting with ``.``. For a worktree, every absolute path includes
+      ``.claude``, so the filter rejects the entire corpus.
+
+  H5  source-policy treatment of ``docs/audits/architecture/``
+      The indexer applies no special-casing to ``docs/audits/architecture/``.
+      Priority is boosted post-classification by ``_calculate_document_priority``
+      but no path-class is excluded.
+
+  H6  observability gap
+      ``index_docs_entries`` emits an INFO/WARN log line but the CLI does not
+      surface per-file or per-collection counts on stdout. The ``+5 Refreshed
+      indexes`` reward marker is awarded based on the indexing flag, not on the
+      actual document count, so a no-op run is indistinguishable from a
+      successful run.
+
+Forbidden patterns asserted absent from this file (static safety scan):
+the Chroma mutation method-call prefixes for write/modify/remove operations,
+the collection-removal verb, the in-place reset/persist verbs, and any host
+process invocation primitive. The full token list is assembled at runtime
+from the ``_FORBIDDEN_FRAGMENTS`` table below; nothing else in this file
+contains those tokens as literal substrings. The diagnostic also never
+invokes the indexer CLI flag as a child command.
+
+Exit codes:
+  0 - probe completed (regardless of findings)
+  2 - probe could not complete (Chroma unavailable, etc.)
+
+Slice: HOLOINDEX_INDEX_DOCS_CONSISTENCY_AUDIT_PHASE1
+WSP_97: REPORT_ONLY, READ_ONLY, NO_REINDEX, NO_CORE_INSTRUMENTATION.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Forbidden-token self-scan
+# ---------------------------------------------------------------------------
+#
+# Tokens enumerated as fragments so this self-scan does not falsely flag itself.
+# The audit also runs an external static safety scan that asserts these tokens
+# never appear anywhere in the file (including docstrings and assembled
+# fragments). The fragments below are intentionally split so they reassemble
+# only at runtime.
+
+_FORBIDDEN_FRAGMENTS: List[Tuple[str, str]] = [
+    (".", "add("),
+    (".", "update("),
+    (".", "delete("),
+    ("delete_", "collection"),
+    ("re", "set("),
+    ("per", "sist("),
+    ("sub", "process"),
+    ("os.", "system"),
+]
+
+
+def _assemble_forbidden_tokens() -> List[str]:
+    return [a + b for a, b in _FORBIDDEN_FRAGMENTS]
+
+
+# ---------------------------------------------------------------------------
+# Targets and reference indexer constants
+# ---------------------------------------------------------------------------
+
+TARGETS: List[Dict[str, str]] = [
+    {
+        "id": "T1",
+        "rel_path": "docs/audits/architecture/TRADE_PUMPFUN_DUE_DILIGENCE_SCORING_SPEC_PHASE1.md",
+    },
+    {
+        "id": "T2",
+        "rel_path": "docs/audits/architecture/TRADE_ADAPTER_INTEGRATION_PHASE1.md",
+    },
+    {
+        "id": "T3",
+        "rel_path": "docs/audits/holoindex_search_quality/HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1.md",
+    },
+    {
+        "id": "T4",
+        "rel_path": "docs/audits/architecture/TRADE_DUE_DILIGENCE_SCORING_ENGINE_PHASE1.md",
+    },
+    {
+        "id": "T5",
+        "rel_path": "docs/audits/architecture/TRADE_DUE_DILIGENCE_SCHEMA_PHASE1.md",
+    },
+]
+
+# Mirror of ``holo_index/core/indexing_engine.py::index_docs_entries`` source
+# roots (CFZ4). Kept in lockstep manually; the audit prompt forbids importing
+# from the indexing engine to avoid the indexer initializing Chroma.
+INDEXER_DOC_ROOTS: List[str] = [
+    "modules",
+    "docs",
+    "holo_index/docs",
+    "WSP_framework/docs",
+]
+
+
+# ---------------------------------------------------------------------------
+# Filter replication (read-only mirror of indexer logic)
+# ---------------------------------------------------------------------------
+
+
+def replicate_indexer_filter(file_path: Path) -> Dict[str, bool]:
+    """Return per-clause pass/fail mirroring ``index_docs_entries``.
+
+    The indexer filter is:
+
+        f for f in all_doc_files
+        if 'node_modules' not in str(f)
+        and 'CHANGELOG' not in f.name.upper()
+        and 'package-lock' not in f.name.lower()
+        and not any(part.startswith('.') for part in f.parts)
+        and '_backup' not in str(f).lower()
+        and '/archive/' not in str(f).lower()
+        and '\\archive\\' not in str(f).lower()
+        and '.claude/worktrees' not in str(f).replace("\\", "/").lower()
+        and '.worktrees' not in str(f).replace("\\", "/").lower()
+
+    Each clause is reported separately so the audit can pinpoint which clause
+    rejects a target file.
+    """
+    path_str = str(file_path)
+    path_str_fwd = path_str.replace("\\", "/").lower()
+    clauses = {
+        "no_node_modules": "node_modules" not in path_str,
+        "no_changelog": "CHANGELOG" not in file_path.name.upper(),
+        "no_package_lock": "package-lock" not in file_path.name.lower(),
+        "no_dot_prefixed_parts": not any(
+            part.startswith(".") for part in file_path.parts
+        ),
+        "no_backup": "_backup" not in path_str.lower(),
+        "no_unix_archive": "/archive/" not in path_str.lower(),
+        "no_windows_archive": "\\archive\\" not in path_str.lower(),
+        "no_claude_worktrees_token": ".claude/worktrees" not in path_str_fwd,
+        "no_dot_worktrees_token": ".worktrees" not in path_str_fwd,
+    }
+    clauses["overall_pass"] = all(clauses.values())
+    return clauses
+
+
+# ---------------------------------------------------------------------------
+# H1 - project_root resolution
+# ---------------------------------------------------------------------------
+
+
+def probe_h1_project_root() -> Dict[str, Any]:
+    """Resolve project_root the same way HoloIndex does, without instantiating."""
+    # HoloIndex itself uses: Path(__file__).parent.parent.parent from
+    # holo_index/core/holo_index.py. This script lives at
+    # holo_index/scripts/diagnose_index_docs_pipeline.py. The equivalent
+    # resolution from this script is .parent.parent (scripts/ -> holo_index/
+    # -> repo_root).
+    here = Path(__file__).resolve()
+    inferred_repo_root = here.parent.parent.parent
+    # Also probe whether the holo_index module sits inside the same tree we
+    # think we are running from.
+    holo_index_pkg = here.parent.parent
+    holo_index_core = holo_index_pkg / "core" / "holo_index.py"
+    parts = inferred_repo_root.parts
+    parts_lower = [p.lower() for p in parts]
+    inside_worktree = (
+        ".claude" in parts_lower
+        or any(p.lower() == ".worktrees" for p in parts)
+    )
+    return {
+        "script_path": str(here),
+        "inferred_repo_root": str(inferred_repo_root),
+        "inferred_repo_root_parts": list(parts),
+        "holo_index_core_exists": holo_index_core.exists(),
+        "inside_dot_claude_worktree": ".claude" in parts_lower
+        and "worktrees" in parts_lower,
+        "inside_any_dot_prefixed_dir": inside_worktree,
+        "h1_finding": (
+            "WORKTREE_PROJECT_ROOT"
+            if inside_worktree
+            else "MAIN_REPO_PROJECT_ROOT"
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# H2 - embedding model cache presence
+# ---------------------------------------------------------------------------
+
+
+def probe_h2_embedding_model(
+    ssd_path: str = "E:/HoloIndex", model_name: str = "all-MiniLM-L6-v2"
+) -> Dict[str, Any]:
+    """Check whether the sentence-transformer cache exists on the SSD path.
+
+    No model is loaded. The check mirrors ``_model_cache_present`` in
+    ``holo_index/core/holo_index.py``: presence of ``config.json`` or
+    ``modules.json`` under either ``models/sentence_transformers/<name>``
+    or ``models/<name>``.
+    """
+    models_path = Path(ssd_path) / "models"
+    candidates = [
+        models_path / "sentence_transformers" / model_name,
+        models_path / model_name,
+    ]
+    cache_hit = False
+    matched: Optional[str] = None
+    for candidate in candidates:
+        config_present = (candidate / "config.json").exists()
+        modules_present = (candidate / "modules.json").exists()
+        if config_present or modules_present:
+            cache_hit = True
+            matched = str(candidate)
+            break
+        if candidate.exists() and candidate.is_dir():
+            cache_hit = True
+            matched = str(candidate)
+            break
+    return {
+        "ssd_path": str(ssd_path),
+        "models_path_exists": models_path.exists(),
+        "model_name": model_name,
+        "candidate_paths": [str(c) for c in candidates],
+        "cache_hit": cache_hit,
+        "matched_candidate": matched,
+        "embedding_fallback_active_on_miss": (
+            "Yes - _get_embedding returns [0.0]*384 when self.model is None;"
+            " all docs would still be enumerated, but vectors are zero-similar."
+        ),
+        "h2_finding": (
+            "MODEL_CACHE_PRESENT"
+            if cache_hit
+            else "MODEL_CACHE_ABSENT_FALLBACK_TO_ZEROS"
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# H3 - bulk insertion accumulation simulation (stub recorder, no Chroma)
+# ---------------------------------------------------------------------------
+
+
+class _RecorderStub:
+    """Pure recorder. Mimics the indexer's accumulation pattern.
+
+    No method here mutates Chroma. The class intentionally does NOT expose
+    any method that would collide with the forbidden static-scan tokens.
+    """
+
+    def __init__(self) -> None:
+        self.ids: List[str] = []
+        self.embeddings_dim: List[int] = []
+        self.documents_len: List[int] = []
+        self.metadatas_keys: List[List[str]] = []
+        self.duplicate_ids: List[str] = []
+
+    def accumulate(
+        self,
+        doc_id: str,
+        embedding_dim: int,
+        document_length: int,
+        metadata_keys: List[str],
+    ) -> None:
+        if doc_id in self.ids:
+            self.duplicate_ids.append(doc_id)
+        self.ids.append(doc_id)
+        self.embeddings_dim.append(embedding_dim)
+        self.documents_len.append(document_length)
+        self.metadatas_keys.append(metadata_keys)
+
+
+def probe_h3_bulk_insertion_simulation(
+    project_root: Path, max_simulated: int = 50
+) -> Dict[str, Any]:
+    """Simulate accumulation against ``_RecorderStub`` for up to ``max_simulated``
+    files. No Chroma writes. Detects duplicate id risk under the
+    ``doc_{idx}`` scheme used by the real indexer.
+    """
+    recorder = _RecorderStub()
+    discovered: List[Path] = []
+    base_roots = [project_root / r for r in INDEXER_DOC_ROOTS]
+    for base in base_roots:
+        if not base.exists():
+            continue
+        # Mirror sorted(list(...rglob('*.md'))) from the indexer.
+        for f in sorted(base.rglob("*.md")):
+            if len(discovered) >= max_simulated:
+                break
+            clauses = replicate_indexer_filter(f)
+            if clauses["overall_pass"]:
+                discovered.append(f)
+        if len(discovered) >= max_simulated:
+            break
+    for idx, file_path in enumerate(discovered, start=1):
+        try:
+            raw_head = file_path.read_bytes()[:2]
+            if raw_head == b"\xff\xfe":
+                text = (
+                    file_path.read_bytes()
+                    .decode("utf-16-le", errors="ignore")
+                    .lstrip("﻿")
+                )
+            else:
+                text = file_path.read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            text = ""
+        lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+        if not lines:
+            continue
+        title = lines[0].lstrip("# ")
+        summary = " ".join(lines[1:6])[:400]
+        recorder.accumulate(
+            doc_id=f"doc_{idx}",
+            embedding_dim=384,
+            document_length=len(f"{title}\n{summary}"),
+            metadata_keys=[
+                "title",
+                "path",
+                "summary",
+                "type",
+                "priority",
+                "foundup_id",
+                "tenant_id",
+                "source_scope",
+                "external_repo",
+            ],
+        )
+    return {
+        "max_simulated": max_simulated,
+        "files_passing_filter_within_cap": len(discovered),
+        "ids_accumulated": len(recorder.ids),
+        "duplicate_ids_detected": recorder.duplicate_ids,
+        "id_scheme": "doc_{idx} starting at 1",
+        "bulk_insert_pattern": (
+            "Single call appending ids/embeddings/documents/metadatas at end of"
+            " index_docs_entries(); no try/except in indexing_engine.py around"
+            " the bulk call site."
+        ),
+        "h3_finding": (
+            "DUPLICATE_ID_RISK"
+            if recorder.duplicate_ids
+            else "NO_DUPLICATE_ID_IN_SIMULATION"
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# H4 - file-discovery filter clause-by-clause for targets
+# ---------------------------------------------------------------------------
+
+
+def probe_h4_filter_targets(project_root: Path) -> Dict[str, Any]:
+    """Apply the indexer filter to each named TARGET and report the failing
+    clause (if any). Also report the aggregate filter outcome over the full
+    ``docs/`` tree under ``project_root`` to quantify the blast radius.
+    """
+    target_reports: List[Dict[str, Any]] = []
+    for target in TARGETS:
+        absolute = project_root / target["rel_path"]
+        report = {
+            "target_id": target["id"],
+            "rel_path": target["rel_path"],
+            "absolute_path": str(absolute),
+            "exists_on_disk": absolute.exists(),
+        }
+        if absolute.exists():
+            clauses = replicate_indexer_filter(absolute)
+            failing = [k for k, v in clauses.items() if v is False and k != "overall_pass"]
+            report["clause_results"] = clauses
+            report["failing_clauses"] = failing
+            report["passes_filter"] = clauses["overall_pass"]
+        target_reports.append(report)
+
+    docs_root = project_root / "docs"
+    aggregate_total = 0
+    aggregate_pass = 0
+    aggregate_failure_by_clause: Dict[str, int] = {}
+    if docs_root.exists():
+        for f in docs_root.rglob("*.md"):
+            aggregate_total += 1
+            clauses = replicate_indexer_filter(f)
+            if clauses["overall_pass"]:
+                aggregate_pass += 1
+            else:
+                for k, v in clauses.items():
+                    if k == "overall_pass":
+                        continue
+                    if v is False:
+                        aggregate_failure_by_clause[k] = (
+                            aggregate_failure_by_clause.get(k, 0) + 1
+                        )
+
+    return {
+        "targets": target_reports,
+        "docs_tree_total": aggregate_total,
+        "docs_tree_passing": aggregate_pass,
+        "docs_tree_failing": aggregate_total - aggregate_pass,
+        "failure_counts_by_clause": aggregate_failure_by_clause,
+        "h4_finding": (
+            "ALL_FILES_REJECTED_BY_DOT_PREFIX_CLAUSE"
+            if aggregate_total > 0 and aggregate_pass == 0
+            else "FILTER_DISCRIMINATES_NORMALLY"
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# H5 - source policy inspection (static)
+# ---------------------------------------------------------------------------
+
+
+def probe_h5_source_policy() -> Dict[str, Any]:
+    """Report the static source-policy of ``index_docs_entries`` relevant to
+    ``docs/audits/architecture/``.
+    """
+    return {
+        "source_roots": INDEXER_DOC_ROOTS,
+        "docs_audits_architecture_explicitly_routed": True,
+        "docs_audits_architecture_priority_boost": (
+            "_calculate_document_priority does NOT have an explicit branch for"
+            " docs/audits/architecture/. The boosted families are openclaw_hermes"
+            " and holoindex. Architecture audit docs receive base priority for"
+            " their classified type only."
+        ),
+        "exclusion_clauses_targeting_audits": "none",
+        "h5_finding": "NO_DIFFERENTIAL_TREATMENT_FOR_ARCHITECTURE_AUDITS",
+    }
+
+
+# ---------------------------------------------------------------------------
+# H6 - observability gap
+# ---------------------------------------------------------------------------
+
+
+def probe_h6_observability() -> Dict[str, Any]:
+    """Static inspection of what the indexer + CLI surface vs. what would be
+    needed to detect a no-op indexing run.
+    """
+    return {
+        "indexer_emits": [
+            "_log_agent_action 'Indexing {N} docs into navigation_docs...' on non-empty discovery",
+            "_log_agent_action 'No docs found to index' on empty discovery (WARN tag)",
+            "_log_agent_action 'Docs index refreshed: {N} entries' after bulk insertion",
+        ],
+        "cli_emits": [
+            "safe_print '[DOCS] Indexed module/root docs in {duration}s'",
+            "Session Summary +5 Refreshed indexes (variant A) - awarded when indexing_awarded=True regardless of N",
+        ],
+        "missing_signals": [
+            "No per-file count surfaced on stdout when N==0",
+            "No non-zero exit code on empty-discovery early return",
+            "No verification step comparing on-disk file count to inserted entries",
+            "Reward marker is decoupled from actual entries; a 0-file no-op still earns +5",
+        ],
+        "h6_finding": "REWARD_DECOUPLED_FROM_ACTUAL_INSERTION_COUNT",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Read-only Chroma observation (optional)
+# ---------------------------------------------------------------------------
+
+
+def observe_navigation_docs_collection_readonly(
+    ssd_path: str = "E:/HoloIndex",
+) -> Dict[str, Any]:
+    """Read-only observation of ``navigation_docs`` size + a small sample of
+    metadatas, used to triangulate the discrepancy. No mutations.
+    """
+    report: Dict[str, Any] = {
+        "ssd_path": str(ssd_path),
+        "navigation_docs_available": False,
+    }
+    try:
+        import chromadb  # type: ignore
+    except ImportError:
+        report["error"] = "chromadb_not_installed"
+        return report
+    vector_path = Path(ssd_path) / "vectors"
+    if not vector_path.exists():
+        report["error"] = "vectors_path_missing"
+        report["vector_path"] = str(vector_path)
+        return report
+    try:
+        client = chromadb.PersistentClient(path=str(vector_path))
+    except Exception as exc:
+        report["error"] = f"client_init_failed: {exc}"
+        return report
+    try:
+        collection = client.get_collection("navigation_docs")
+    except Exception as exc:
+        report["error"] = f"get_collection_failed: {exc}"
+        return report
+    try:
+        total = collection.count()
+    except Exception as exc:
+        report["error"] = f"count_failed: {exc}"
+        return report
+    report["navigation_docs_available"] = True
+    report["navigation_docs_total"] = total
+    try:
+        payload = collection.get(include=["metadatas"])
+        metadatas = payload.get("metadatas", []) or []
+        architecture_count = 0
+        sample_paths: List[str] = []
+        for meta in metadatas:
+            if not meta:
+                continue
+            path_field = meta.get("path", "") or meta.get("source", "")
+            if not path_field:
+                continue
+            normalized = str(path_field).replace("\\", "/").lower()
+            if "docs/audits/architecture/" in normalized:
+                architecture_count += 1
+                if len(sample_paths) < 5:
+                    sample_paths.append(str(path_field))
+        report["docs_audits_architecture_in_index"] = architecture_count
+        report["sample_architecture_paths"] = sample_paths
+    except Exception as exc:
+        report["enumeration_error"] = f"{exc}"
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Static safety scan over THIS file
+# ---------------------------------------------------------------------------
+
+
+def static_safety_scan_self() -> Dict[str, Any]:
+    """Read this very file from disk and assert none of the runtime-assembled
+    forbidden tokens appear as literal substrings outside the fragment table.
+    """
+    here = Path(__file__).resolve()
+    text = here.read_text(encoding="utf-8")
+    tokens = _assemble_forbidden_tokens()
+    hits: Dict[str, int] = {}
+    fragment_table_marker = "_FORBIDDEN_FRAGMENTS"
+    for tok in tokens:
+        count = text.count(tok)
+        hits[tok] = count
+    # Tokens may legitimately appear inside the fragment table only as split
+    # halves, never as the full token. So the scan passes if every count is 0.
+    return {
+        "self_path": str(here),
+        "tokens_checked": tokens,
+        "hit_counts": hits,
+        "fragment_table_present": fragment_table_marker in text,
+        "passes_static_scan": all(count == 0 for count in hits.values()),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    print("=" * 70, file=sys.stderr)
+    print(
+        "HoloIndex --index-docs pipeline diagnostic (DRY-RUN, NO CHROMA MUTATION)",
+        file=sys.stderr,
+    )
+    print("Slice: HOLOINDEX_INDEX_DOCS_CONSISTENCY_AUDIT_PHASE1", file=sys.stderr)
+    print("=" * 70, file=sys.stderr)
+
+    h1 = probe_h1_project_root()
+    project_root = Path(h1["inferred_repo_root"])
+
+    safety = static_safety_scan_self()
+    h2 = probe_h2_embedding_model()
+    h3 = probe_h3_bulk_insertion_simulation(project_root)
+    h4 = probe_h4_filter_targets(project_root)
+    h5 = probe_h5_source_policy()
+    h6 = probe_h6_observability()
+    chroma_obs = observe_navigation_docs_collection_readonly()
+
+    findings = {
+        "H1": h1["h1_finding"],
+        "H2": h2["h2_finding"],
+        "H3": h3["h3_finding"],
+        "H4": h4["h4_finding"],
+        "H5": h5["h5_finding"],
+        "H6": h6["h6_finding"],
+    }
+
+    # Classification of the consistency failure.
+    if (
+        h1["inside_any_dot_prefixed_dir"]
+        and h4.get("docs_tree_total", 0) > 0
+        and h4.get("docs_tree_passing", 0) == 0
+    ):
+        primary_root_cause = (
+            "H1+H4_INTERLOCK: worktree-resolved project_root introduces a"
+            " '.claude' part in every absolute path; the dot-prefix filter"
+            " clause then rejects 100% of files; the function returns at"
+            " 'if not files: return' without resetting or writing the"
+            " collection; CLI still awards +5 Refreshed indexes."
+        )
+    elif h4.get("docs_tree_passing", 0) < h4.get("docs_tree_total", 0):
+        primary_root_cause = "FILTER_REJECTS_SUBSET_OF_FILES"
+    else:
+        primary_root_cause = "INCONCLUSIVE_FROM_DRY_RUN"
+
+    summary = {
+        "slice": "HOLOINDEX_INDEX_DOCS_CONSISTENCY_AUDIT_PHASE1",
+        "probe_version": "1.0.0",
+        "static_safety_scan": safety,
+        "h1_project_root": h1,
+        "h2_embedding_model": h2,
+        "h3_bulk_insertion_simulation": h3,
+        "h4_file_discovery_filter": h4,
+        "h5_source_policy": h5,
+        "h6_observability": h6,
+        "chroma_readonly_observation": chroma_obs,
+        "hypothesis_findings": findings,
+        "primary_root_cause": primary_root_cause,
+    }
+
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+    print("\n" + "=" * 70, file=sys.stderr)
+    print("DIAGNOSTIC SUMMARY", file=sys.stderr)
+    print("=" * 70, file=sys.stderr)
+    for hk, hv in findings.items():
+        print(f"  {hk}: {hv}", file=sys.stderr)
+    print(f"\nPRIMARY ROOT CAUSE: {primary_root_cause}", file=sys.stderr)
+    print("=" * 70, file=sys.stderr)
+
+    if not safety["passes_static_scan"]:
+        print(
+            "WARN: static safety scan flagged forbidden tokens; treating as"
+            " probe-incomplete.",
+            file=sys.stderr,
+        )
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Diagnostic-first audit explaining why `python holo_index.py --index-docs` exits 0 but leaves 9 architecture/audit docs out of `navigation_docs`. Reconciles PR #688 (exit 0, no index change) and PR #689 (T1/T2/T3 all NOT_INDEXED).

## Root Cause (H1 CONFIRMED)

When `--index-docs` runs from a worktree under `.claude/worktrees/...`:

1. `project_root = Path(__file__).parent.parent.parent` resolves to the worktree path
2. The worktree contains `.claude/` in its absolute path parts
3. `indexing_engine.py:650` rejects any file whose `f.parts` contains a dot-prefixed part — including the parent `.claude` directory
4. All 388 docs fail the filter
5. Empty file list short-circuits before `_reset_collection` / bulk `collection.add`
6. CLI still reports exit 0 and awards +5 reward

This is why #688's reindex changed nothing and #689 found targets NOT_INDEXED. The 33 existing `navigation_docs` are stale from earlier main-repo indexing.

## Hypothesis Space Result

| Hypothesis | Result |
|---|---|
| H1 project_root mismatch | **CONFIRMED** (worktree path under `.claude/`) |
| H2 embedding model fallback | possible but irrelevant once H1 fires |
| H3 collection.add silent failure | not reached (short-circuit) |
| H4 file discovery filter | **CONFIRMED** — 388/388 fail |
| H5 index source policy | filter clause is the policy |
| H6 observability gap | confirmed (exit 0 + reward despite zero adds) |

## Scope

- 2 files (matches expected gate scope):
  - `docs/audits/holoindex_search_quality/HOLOINDEX_INDEX_DOCS_CONSISTENCY_AUDIT_PHASE1.md` (+498)
  - `holo_index/scripts/diagnose_index_docs_pipeline.py` (+669)
- No Chroma mutation
- No reindex
- No HoloIndex core behavior change
- Diagnostic script is read-only and deterministic (byte-identical reruns)

## Static Scan of Diagnostic

0 actual mutation calls. The 3 string matches for `--index-docs` in the script are docstring/banner references to the command being diagnosed, not invocations.

## Next Slice (Smallest Fix)

`HOLOINDEX_INDEXER_PROJECT_ROOT_WORKTREE_SAFETY_PHASE1`

Change the dot-prefix filter to evaluate `f.relative_to(base).parts` (or equivalent) so it skips dotfiles **inside** the docs tree while NOT rejecting parent directories like `.claude` that contain the worktree.

## WSP 97 Verdict

PASS — diagnostic-first, no core behavior change, smallest-fix recommendation explicit, reconciles prior PRs. WSP_97 Truth Boundary Checklist satisfied.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>