### PR TITLE
test(trade): synthetic regime pack Phase 1 (post-#691 de-rounded)

### DIFF
--- a/docs/audits/architecture/TRADE_DUE_DILIGENCE_SYNTHETIC_REGIME_PACK_PHASE1.md
+++ b/docs/audits/architecture/TRADE_DUE_DILIGENCE_SYNTHETIC_REGIME_PACK_PHASE1.md
@@ -1,0 +1,432 @@
+# Trade Due-Diligence Synthetic Regime Pack — Phase 1
+
+**Date**: 2026-05-24
+**Slice**: TRADE_DUE_DILIGENCE_SYNTHETIC_REGIME_PACK_PHASE1
+**Base Commit**: `871dded55` (origin/main; includes PR #687 engine + PR #685 schema)
+**Branch**: `feat/trade-due-diligence-synthetic-regime-pack-phase1`
+**Worktree**: `.claude/worktrees/trade-due-diligence-synthetic-regime-pack`
+**Worker**: W6
+**Spec**: `docs/audits/architecture/TRADE_PUMPFUN_DUE_DILIGENCE_SCORING_SPEC_PHASE1.md` (PR #683)
+**Engine**: `docs/audits/architecture/TRADE_DUE_DILIGENCE_SCORING_ENGINE_PHASE1.md` (PR #687)
+
+---
+
+## WSP 97 Verdict
+
+| Truth Boundary Checklist Item | Status |
+|-------------------------------|--------|
+| TRADE_SYNTHETIC_REGIME_PACK_ONLY | YES |
+| SIMULATION_MODE_ONLY | YES |
+| SYNTHETIC_EVIDENCE_ONLY | YES |
+| DETERMINISTIC_FIXTURE_ONLY | YES |
+| DETERMINISTIC_BYTE_IDENTICAL_REQUIRED | YES |
+| NO_ROUNDED_DETERMINISM_MASK | YES |
+| NO_ENGINE_MUTATION | YES |
+| NO_CONTRACT_MUTATION | YES |
+| NO_LIVE_FEEDS | YES |
+| NO_NETWORK_CALLS | YES |
+| NO_WALLET | YES |
+| NO_WALLET_SIGNING | YES |
+| NO_KEY_MATERIAL | YES |
+| NO_ORDER_PLACEMENT | YES |
+| NO_REAL_TRADING | YES |
+| NO_EXCHANGE_SDK_IMPORT | YES |
+| NO_REGISTRY_MUTATION | YES |
+| NO_CATALOG_MUTATION | YES |
+| NO_MANIFEST_MUTATION | YES |
+| NO_PROJECTION_MUTATION | YES |
+| NO_PORTFOLIO_PROMOTION | YES |
+| NO_PUBLIC_SURFACE_CLAIM | YES |
+| NO_CI_GATE_ACTIVATION | YES |
+| NO_DEPENDENCY_INSTALL | YES |
+| NO_CABR_READY | YES |
+| NO_PAYOUT_READY | YES |
+| NO_DAO_ACTIVATION | YES |
+
+**WSP 97 VERDICT**: **PASS** (27/27 YES)
+
+### Post-#691 De-Rounding (architect requirement)
+
+After PR #691 made `evaluation_time` explicit and removed `_utc_now()` from
+the scoring engine, this slice was rebased and the prior rounded-hash
+workaround was removed:
+
+- `_HASH_ROUND_PRECISION` constant: **DELETED**
+- All `round(score.X, 2)` calls in `deterministic_hash()` and
+  `build_regime_result()`: **DELETED**
+- `_age_offset()` fixed to use `FIXTURE_REFERENCE_TIME` instead of
+  `datetime.now()`, eliminating fixture-time drift
+- Tests pass `evaluation_time=FIXED_EVAL_TIME` (alias of
+  `FIXTURE_REFERENCE_TIME`) to every `scoring_engine.score(...)` call
+- `test_regime_scoring_is_deterministic` now asserts true byte-identical
+  determinism via SHA-256 over RAW (non-rounded) component scores
+
+The 5 decision-shape divergence findings recorded below are preserved as
+evidence; they are independent of the rounding mask.
+
+---
+
+## 1. Mission
+
+Exercise the deterministic due-diligence scoring engine (PR #687) against 7 named synthetic regimes that span the decision-shape space. Produce evidence that the engine's decision bands fire correctly on realistic scenario fixtures — without introducing live data, wallets, network, order placement, or any boundary change.
+
+This is an **evidence-pack slice**, not an engine-tuning slice. Per the operator's patched W6 test policy:
+
+> Per-regime tests MUST fail on: nondeterministic output, invalid DecisionBand value, malformed TradeDueDiligenceScore, missing component score, forbidden import/field, boundary violation, real-trading authorization claim.
+>
+> Per-regime tests MUST NOT fail solely because `expected_band != actual_band`. Divergence is evidence — record it in the audit and route to a future targeted engine-tuning slice.
+
+---
+
+## 2. HoloIndex Assessment (WSP 87)
+
+| Query | Surfaced engine/contracts? | Quality |
+|-------|---------------------------|---------|
+| `TRADE_DUE_DILIGENCE_SCHEMA_PHASE1` | YES (`contracts.py` #1) | OK |
+| `TRADE_DUE_DILIGENCE_SCORING_ENGINE_PHASE1` | NO (slice ID alias gap; audit doc absent from top-5) | LOW |
+| `trade synthetic regime decision band` | YES (`contracts.py` #1, `test_trade_contracts.py` #2) | OK |
+| `deterministic fixture scoring engine` | NO (priority_scorer hits dominate) | LOW |
+
+Slice ID alias gap (Q2/Q4) is a known stale-index / retrieval-quality finding from prior slice (HOLOINDEX_DOCS_REINDEX_OBSERVATION_PHASE1). It does NOT block this slice — direct reads of `contracts.py`, `due_diligence_scoring.py`, and `test_due_diligence_scoring.py` provided complete coverage.
+
+---
+
+## 3. Regime Matrix (discovery_subworker)
+
+7 mandatory regimes, ordered by intended decision-shape coverage:
+
+| Regime ID | Description | Expected Band (hypothesis) | Tests in isolation |
+|-----------|-------------|----------------------------|--------------------|
+| R1 `organic_launch_clean_socials` | Fresh launch (~2 min old), clean issuer, distributed retail holders, active authentic socials | `CANDIDATE_FOR_FUTURE_REVIEW` | All components high → reward path |
+| R2 `influencer_pump_high_concentration` | Coordinated influencer pump, heavy top-holder + whale concentration | `REJECT` | Influencer + whale degradation path |
+| R3 `dead_x_no_telegram` | X account with no engagement, no Telegram, otherwise neutral | `REJECT` or `OBSERVE` | Social-presence component path |
+| R4 `issuer_prior_rug_history` | Issuer with 3 prior rug pulls, FLAGGED classification | `REJECT` (issuer disqualifier) | Hard-disqualifier path |
+| R5 `whale_accumulation_then_dump` | Multiple whale wallets, high concentration + prior dumps | `REJECT` (whale_risk) | Whale + holder_distribution path |
+| R6 `telegram_active_low_authenticity` | TG looks busy (admin active, high members) but high bot/spam ratios | `SIMULATE_ONLY` or `OBSERVE` | social_authenticity vs telegram_quality split |
+| R7 `bonding_curve_migration_risk` | Bonding curve well past sweet spot (progress=0.85) | `SIMULATE_ONLY` or `OBSERVE` | Bonding-curve-late penalty in isolation |
+
+Each regime declares its expected band as a **hypothesis**. The audit records expected vs actual per regime (see §5).
+
+---
+
+## 4. Per-Regime Result Table
+
+The table below is the deterministic evidence snapshot captured by `test_expected_vs_actual_table_is_complete_for_all_regimes` at slice authoring time. Each row is reproducible by running the same regime constructor against the merged engine.
+
+| Regime | Expected | **Actual** | Match | Total | Risk | Conf | Hard Disq. | Hash (8) |
+|--------|----------|------------|-------|-------|------|------|------------|----------|
+| R1 `organic_launch_clean_socials` | candidate_for_future_review | **candidate_for_future_review** | ✅ | 94.85 | 5.15 | 0.94 | — | `6258aca1` |
+| R2 `influencer_pump_high_concentration` | reject | **simulate_only** | ❌ | 51.73 | 48.27 | 0.82 | — | `4cc7ed0a` |
+| R3 `dead_x_no_telegram` | reject | **simulate_only** | ❌ | 66.90 | 33.10 | 0.64 | — | `3567e08c` |
+| R4 `issuer_prior_rug_history` | reject | **reject** | ✅ | 52.27 | 47.73 | 0.79 | `issuer_history_below_20`, `rug_honeypot_below_20` | `ee885820` |
+| R5 `whale_accumulation_then_dump` | reject | **candidate_for_future_review** | ❌ | 72.12 | 27.88 | 0.71 | — | `82bc4bc8` |
+| R6 `telegram_active_low_authenticity` | simulate_only | **candidate_for_future_review** | ❌ | 84.78 | 15.22 | 0.85 | — | `a13aef6b` |
+| R7 `bonding_curve_migration_risk` | simulate_only | **candidate_for_future_review** | ❌ | 89.70 | 10.30 | 0.86 | — | `9e25cab5` |
+
+**Band-match rate: 2/7 (R1, R4).** Five divergences are recorded as decision-shape findings (§6).
+
+---
+
+## 5. Component-Level Breakdowns
+
+Component scores (raw float values, no rounding — post-#691 byte-identical determinism) for each regime, captured from the same deterministic snapshot.
+
+### R1 `organic_launch_clean_socials` — actual: `candidate_for_future_review` (match)
+
+| Component | Score | Component | Score |
+|-----------|------:|-----------|------:|
+| launch_timing | 100.00 | holder_distribution | 100.00 |
+| issuer_history | 97.50 | whale_risk | 90.00 |
+| social_authenticity | 88.00 | prior_token_history | 100.00 |
+| telegram_quality | 76.00 | bonding_curve | 92.50 |
+| influencer_risk | 90.00 | rug_honeypot | 100.00 |
+
+Rationale: `CANDIDATE: Total score 94.8 qualifies for future review (>70)`.
+
+### R2 `influencer_pump_high_concentration` — actual: `simulate_only` (divergence)
+
+| Component | Score | Component | Score |
+|-----------|------:|-----------|------:|
+| launch_timing | 88.00 | holder_distribution | 40.00 |
+| issuer_history | 85.00 | whale_risk | 13.00 |
+| social_authenticity | 18.00 | prior_token_history | 100.00 |
+| telegram_quality | 19.00 | bonding_curve | 82.50 |
+| influencer_risk | 10.00 | rug_honeypot | 50.00 |
+
+Rationale: `SIMULATE_ONLY: Total score 51.7 qualifies for simulation (50-70)`.
+
+### R3 `dead_x_no_telegram` — actual: `simulate_only` (divergence)
+
+| Component | Score | Component | Score |
+|-----------|------:|-----------|------:|
+| launch_timing | 82.00 | holder_distribution | 50.00 |
+| issuer_history | 75.00 | whale_risk | 90.00 |
+| social_authenticity | 5.00 | prior_token_history | 60.00 |
+| telegram_quality | 20.00 | bonding_curve | 99.00 |
+| influencer_risk | 85.00 | rug_honeypot | 100.00 |
+
+Rationale: `SIMULATE_ONLY: Total score 66.9 qualifies for simulation (50-70)`.
+
+### R4 `issuer_prior_rug_history` — actual: `reject` (match)
+
+| Component | Score | Component | Score |
+|-----------|------:|-----------|------:|
+| launch_timing | 100.00 | holder_distribution | 50.00 |
+| issuer_history | **0.00** | whale_risk | 90.00 |
+| social_authenticity | 65.00 | prior_token_history | 28.00 |
+| telegram_quality | 64.50 | bonding_curve | 95.00 |
+| influencer_risk | 75.00 | rug_honeypot | **10.00** |
+
+Rationale: `REJECT: Critical rug/honeypot risk (score=10.0)`. Hard disqualifiers: `issuer_history_below_20`, `rug_honeypot_below_20`.
+
+### R5 `whale_accumulation_then_dump` — actual: `candidate_for_future_review` (divergence)
+
+| Component | Score | Component | Score |
+|-----------|------:|-----------|------:|
+| launch_timing | 96.40 | holder_distribution | 55.00 |
+| issuer_history | 85.00 | whale_risk | 14.50 |
+| social_authenticity | 62.00 | prior_token_history | 75.00 |
+| telegram_quality | 66.60 | bonding_curve | 90.00 |
+| influencer_risk | 85.00 | rug_honeypot | 100.00 |
+
+Rationale: `CANDIDATE: Total score 72.1 qualifies for future review (>70)`.
+
+### R6 `telegram_active_low_authenticity` — actual: `candidate_for_future_review` (divergence)
+
+| Component | Score | Component | Score |
+|-----------|------:|-----------|------:|
+| launch_timing | 100.00 | holder_distribution | 100.00 |
+| issuer_history | 90.00 | whale_risk | 90.00 |
+| social_authenticity | 35.00 | prior_token_history | 100.00 |
+| telegram_quality | 45.50 | bonding_curve | 90.00 |
+| influencer_risk | 70.00 | rug_honeypot | 100.00 |
+
+Rationale: `CANDIDATE: Total score 84.8 qualifies for future review (>70)`.
+
+### R7 `bonding_curve_migration_risk` — actual: `candidate_for_future_review` (divergence)
+
+| Component | Score | Component | Score |
+|-----------|------:|-----------|------:|
+| launch_timing | 100.00 | holder_distribution | 100.00 |
+| issuer_history | 92.50 | whale_risk | 90.00 |
+| social_authenticity | 78.00 | prior_token_history | 100.00 |
+| telegram_quality | 73.90 | bonding_curve | 42.50 |
+| influencer_risk | 82.00 | rug_honeypot | 100.00 |
+
+Rationale: `CANDIDATE: Total score 89.7 qualifies for future review (>70)`.
+
+---
+
+## 6. Expected-vs-Actual Divergence Findings
+
+5 of 7 regimes diverge. The findings below describe what the engine *currently does*, not what it *should* do — engine-side judgement is deferred to a targeted engine-tuning slice.
+
+### Finding F1 — R2 influencer_pump_high_concentration: REJECT → SIMULATE_ONLY
+
+| Aspect | Value |
+|--------|-------|
+| Hypothesis | Coordinated influencer pump with heavy whale + top-holder concentration should land REJECT. |
+| Actual | `simulate_only` at total=51.73 (just above the 50 REJECT/OBSERVE boundary). |
+| Component evidence | `influencer_risk=10`, `whale_risk=13`, `holder_distribution=40`, `social_authenticity=18`, `telegram_quality=19` — five components in the 10-40 floor. |
+| Why permissive | Weighted contribution: degraded components combined weight ≈ 0.10+0.10+0.15+0.10+0.05 = 0.50 of the total. Even with all five at ~15, that's `0.50 × 15 = 7.5` total points. The remaining 0.50 weight at ~85 contributes ~42.5. Sum ≈ 50, lands just inside SIMULATE_ONLY. |
+| Hard disqualifier triggered | None (`rug_honeypot=50` clears 20; `issuer_history=85` clears 20; `evidence_confidence=0.82` clears 0.50). |
+| Decision-shape gap | The "obviously bad pump" pattern does not currently trip any hard disqualifier. Operator-judgement question: should an aggregate of degraded influencer/whale/holder signals trigger a soft disqualifier? |
+
+### Finding F2 — R3 dead_x_no_telegram: REJECT → SIMULATE_ONLY
+
+| Aspect | Value |
+|--------|-------|
+| Hypothesis | Token with no real social engagement should land at least OBSERVE, plausibly REJECT. |
+| Actual | `simulate_only` at total=66.90. |
+| Component evidence | `social_authenticity=5`, `telegram_quality=20` — both near floor. |
+| Why permissive | Social weights: `social_authenticity=0.10` + `telegram_quality=0.05` = 0.15 of total. `0.15 × 12.5_avg = 1.9` total points contributed. The other 0.85 of the weight at high values pulls total to 67. |
+| Hard disqualifier triggered | None (`evidence_confidence=0.64` clears 0.50). |
+| Decision-shape gap | Social-presence is too lightly weighted to surface "obvious astroturf" cases on its own. Operator-judgement question: should "no social presence" be a soft disqualifier that downgrades by one band? |
+
+### Finding F3 — R5 whale_accumulation_then_dump: REJECT → CANDIDATE_FOR_FUTURE_REVIEW
+
+| Aspect | Value |
+|--------|-------|
+| Hypothesis | Whale concentration + prior dumps should land REJECT. |
+| Actual | `candidate_for_future_review` at total=72.12 (just above the 70 SIMULATE/CANDIDATE boundary). |
+| Component evidence | `whale_risk=14.5` (floor); `holder_distribution=55` (concentration penalty kicked in, but not severely — top-holder ~18% triggers `-15`, not the worse cuts). |
+| Why permissive | `whale_risk` weight is 0.10 only. Worst case (`whale_risk=0`) costs 10 points. Other components at ~85-100 contribute 65+ points → total stays above 70. |
+| Hard disqualifier triggered | None. |
+| Decision-shape gap | Whale concentration is treated as a *modifier* rather than a *disqualifier*. Operator-judgement question: when top-N wallets hold >50% AND have `prior_dumps_executed > 0`, should that be a hard disqualifier (or at least force OBSERVE)? |
+
+### Finding F4 — R6 telegram_active_low_authenticity: SIMULATE_ONLY → CANDIDATE_FOR_FUTURE_REVIEW
+
+| Aspect | Value |
+|--------|-------|
+| Hypothesis | Mixed social signal (active TG but bot-heavy, low X authenticity) should land SIMULATE_ONLY. |
+| Actual | `candidate_for_future_review` at total=84.78. |
+| Component evidence | `social_authenticity=35`, `telegram_quality=45.5` — degraded; rest of components high. |
+| Why permissive | Same as F2: combined social weight is 0.15, degraded contribution ~6 points; rest of components push total past 70. |
+| Decision-shape gap | Same as F2 — social-presence weight is small relative to the signal's diagnostic value. |
+
+### Finding F5 — R7 bonding_curve_migration_risk: SIMULATE_ONLY → CANDIDATE_FOR_FUTURE_REVIEW
+
+| Aspect | Value |
+|--------|-------|
+| Hypothesis | Token past bonding-curve sweet spot (progress=0.85) should land SIMULATE_ONLY. |
+| Actual | `candidate_for_future_review` at total=89.70. |
+| Component evidence | `bonding_curve=42.5` — degraded; rest high. |
+| Why permissive | `bonding_curve` weight is 0.05 only. `bonding_curve` going from 90 → 42.5 costs `(90-42.5) × 0.05 ≈ 2.4` points. |
+| Decision-shape gap | Late-curve penalty is too weak to surface migration risk in band terms. Operator-judgement question: should `bonding_curve_progress > 0.80` be a hard disqualifier OR have a higher weight? |
+
+### Cross-cutting pattern
+
+**Only hard disqualifiers reliably move bands below `CANDIDATE_FOR_FUTURE_REVIEW`** once other components are reasonable. The weighted-sum aggregate is highly permissive — even severe single-component degradation rarely changes the band tier because every component has weight ≤ 0.15. The 4 divergences in §6 (F1–F5 minus the social pattern overlap) all share this structural cause.
+
+**This finding does NOT fail the slice.** It is decision-shape evidence routed to a future targeted engine-tuning slice.
+
+---
+
+## 7. Determinism Proof
+
+Per-regime determinism is verified by `test_regime_scoring_is_deterministic[R*]` (×7): each regime is scored twice in the same test invocation with the same explicit `evaluation_time` (post-#691), and the `deterministic_hash` (SHA-256 over RAW non-rounded component scores + total + risk + confidence + decision_band + sorted hard-disqualifier list) must match byte-for-byte.
+
+Pack-level determinism is verified by `test_expected_vs_actual_table_is_complete_for_all_regimes`: the full 7-regime evidence snapshot is generated, then immediately re-generated, and the per-regime hash lists must be bit-equal.
+
+Both pass:
+```
+test_regime_scoring_is_deterministic[R1_organic_launch_clean_socials]              PASSED
+test_regime_scoring_is_deterministic[R2_influencer_pump_high_concentration]        PASSED
+test_regime_scoring_is_deterministic[R3_dead_x_no_telegram]                        PASSED
+test_regime_scoring_is_deterministic[R4_issuer_prior_rug_history]                  PASSED
+test_regime_scoring_is_deterministic[R5_whale_accumulation_then_dump]              PASSED
+test_regime_scoring_is_deterministic[R6_telegram_active_low_authenticity]          PASSED
+test_regime_scoring_is_deterministic[R7_bonding_curve_migration_risk]              PASSED
+test_expected_vs_actual_table_is_complete_for_all_regimes                          PASSED
+```
+
+The deterministic hash deliberately rounds component scores to 2 decimals. This tolerates the sub-second drift in the engine's internal `datetime.now(timezone.utc)` call (only affects `launch_timing`, and only across coarse bucket boundaries at 5min/30min/60min/360min). All fixtures construct `candidate.timestamp` as `datetime.now(timezone.utc) - timedelta(...)` so age is always evaluated near the same wall-clock instant the engine calls `_utc_now()`.
+
+---
+
+## 8. Truth Boundary Preserved
+
+### 8.1 Trade status (unchanged)
+
+| Field | Before this slice | After this slice |
+|-------|-------------------|------------------|
+| portfolio status | not_portfolio | not_portfolio |
+| poc_status | idea | idea |
+| entity_type | skeleton_candidate | skeleton_candidate |
+| public surface claim | none | none |
+
+No promotion, no manifest change, no projection change.
+
+### 8.2 No live capability
+
+No code in the new fixtures or tests imports any of: `requests`, `urllib`, `urllib3`, `httpx`, `aiohttp`, `websocket`, `websockets`, `socket`, `asyncio`, `ccxt`, `web3`, `alpaca`, `binance`, `coinbase`, `kraken`, `ib_insync`, `ftx`, `bitfinex`, `polygon`, `yfinance`, `eth_account`, `cryptography`. Enforced by `test_regime_fixture_has_no_forbidden_imports` + `test_regime_test_file_has_no_forbidden_imports`.
+
+No code references any of: `api_key`, `secret`, `signer`, `wallet_private_key`, `order_id`, `endpoint`, `exchange_client`. Enforced by `test_regime_fixture_has_no_forbidden_fields`.
+
+### 8.3 No real-trading authorization
+
+`assert_no_real_trading_authorized(score.decision_band)` passes silently for every regime in `test_regime_no_band_authorizes_real_trading[R*]` (×7). The contracts module's authorization flag remains `False`; any flip to `True` would raise and fail the test.
+
+### 8.4 No src/ mutation
+
+`git diff --name-only origin/main...HEAD` includes only:
+- `modules/foundups/trade/tests/fixtures/__init__.py` (new)
+- `modules/foundups/trade/tests/fixtures/due_diligence_regimes.py` (new)
+- `modules/foundups/trade/tests/test_due_diligence_regimes.py` (new)
+- `modules/foundups/trade/tests/TestModLog.md` (append-only)
+- `docs/audits/architecture/TRADE_DUE_DILIGENCE_SYNTHETIC_REGIME_PACK_PHASE1.md` (new)
+
+Zero files under `modules/foundups/trade/src/`. Zero modifications to existing test files.
+
+---
+
+## 9. Test Results
+
+```
+$ python -m pytest modules/foundups/trade/tests/test_due_diligence_regimes.py -v
+42 passed in 0.16s
+
+$ python -m pytest modules/foundups/trade/tests/ -q
+384 passed in 1.91s   (342 existing + 42 new, 0 skipped)
+```
+
+| Suite | Pass count | Skipped |
+|-------|-----------:|--------:|
+| Existing Trade tests (PR #687 + earlier) | 342 | 0 |
+| New regime pack tests (this slice) | 42 | 0 |
+| **Total** | **384** | **0** |
+
+No flake markers, no skip markers.
+
+---
+
+## 10. Recommendations (smallest-first)
+
+The 5 expected-vs-actual divergences identified in §6 share a common root cause (weighted aggregate too permissive for non-hard-disqualifier signals). They warrant a **single targeted engine-tuning slice**, not five separate ones.
+
+### Slice candidate 1 — soft disqualifiers (highest leverage)
+
+`TRADE_DUE_DILIGENCE_SOFT_DISQUALIFIER_PHASE1`
+
+Add to `TradeDueDiligenceScore.determine_decision_band()`:
+- `if whale_risk < 20: band ≤ OBSERVE` (closes F3)
+- `if social_authenticity < 20 AND telegram_quality < 30: band ≤ OBSERVE` (closes F2 + F4)
+- `if influencer_risk < 20 AND coordination flags set: band ≤ REJECT` (closes F1)
+- `if bonding_curve_progress > 0.80: band ≤ SIMULATE_ONLY` (closes F5)
+
+Each is a localised conditional, not a weight recalibration — small blast radius. Existing 342 tests should remain green; this regime pack's expected_band hypotheses become assertable after the tuning.
+
+### Slice candidate 2 — weight recalibration
+
+`TRADE_DUE_DILIGENCE_WEIGHT_RECALIBRATION_PHASE1`
+
+Increase weights on `whale_risk`, `social_authenticity`, `holder_distribution` (currently 0.10 / 0.10 / 0.15). Trade-off: changes ALL existing regimes' totals — larger blast radius. Only do this if soft disqualifiers prove insufficient.
+
+### Slice candidate 3 — broader regime coverage
+
+`TRADE_DUE_DILIGENCE_REGIME_PACK_EXPANSION_PHASE1`
+
+Add regimes for edge cases not covered here (e.g., insider concentration, age-decay boundary, blacklisted issuer, evidence_confidence < 0.5 forced OBSERVE path). Should come *after* soft disqualifiers land, so each new regime's expected band corresponds to the engine's tuned behaviour.
+
+**Recommended next slice**: candidate 1 (soft disqualifiers). Smallest change, highest leverage on the 5 divergences this evidence pack surfaced.
+
+---
+
+## 11. Files Changed
+
+| File | Type |
+|------|------|
+| `modules/foundups/trade/tests/fixtures/__init__.py` | NEW — fixtures package marker |
+| `modules/foundups/trade/tests/fixtures/due_diligence_regimes.py` | NEW — 7 regime constructors, result helpers, deterministic hash |
+| `modules/foundups/trade/tests/test_due_diligence_regimes.py` | NEW — 42 tests (forbidden-import guards, registry invariants, per-regime parametrized tests, expected-vs-actual evidence table, no-mutation tripwire) |
+| `modules/foundups/trade/tests/TestModLog.md` | APPENDED — new section for this slice |
+| `docs/audits/architecture/TRADE_DUE_DILIGENCE_SYNTHETIC_REGIME_PACK_PHASE1.md` | NEW — this audit |
+
+No files under `modules/foundups/trade/src/`. No existing tests modified.
+
+---
+
+## 12. Completion Summary
+
+| Property | Value |
+|----------|-------|
+| Branch | `feat/trade-due-diligence-synthetic-regime-pack-phase1` |
+| Worker | W6 |
+| Commit SHA | (populated by W10 on merge) |
+| New tests | 42 (all pass, 0 skipped) |
+| Full Trade suite | 384/384 passing (342 existing + 42 new) |
+| Engine/contracts mutation | NONE |
+| `src/` files changed | 0 |
+| Expected-vs-actual band match rate | 2/7 (R1, R4) |
+| Decision-shape findings | 5 (recorded, routed to next slice) |
+| Determinism | Verified per-regime and pack-level |
+| Boundary violations | 0 |
+| WSP_97 truth boundary | PASS (25/25) |
+
+**W10 Readiness**: **YES** — ready for merge gate.
+
+---
+
+**Worker-Lane**: W6
+**Slice**: TRADE_DUE_DILIGENCE_SYNTHETIC_REGIME_PACK_PHASE1
+**WSP Lock**: WSP_00, WSP_15, WSP_50, WSP_64, WSP_83, WSP_87, WSP_97, WSP_104, WSP_22

--- a/modules/foundups/trade/tests/TestModLog.md
+++ b/modules/foundups/trade/tests/TestModLog.md
@@ -300,6 +300,68 @@ python -m pytest modules/foundups/trade/tests/ -q
 
 ---
 
+### [2026-05-24] - TRADE_DUE_DILIGENCE_SYNTHETIC_REGIME_PACK_PHASE1
+
+**Worker**: W6
+**Branch**: `feat/trade-due-diligence-synthetic-regime-pack-phase1`
+**Scope**: test/fixture only — no engine, no contracts, no `src/` mutation.
+
+#### Cases added (42 new tests)
+
+| Test | Coverage |
+|------|----------|
+| `test_regime_fixture_has_no_forbidden_imports` | Fixture file does not import any networking / exchange SDK from the slice forbidden list. |
+| `test_regime_fixture_has_no_forbidden_fields` | Fixture file does not reference any wallet/order/key field name. |
+| `test_regime_test_file_has_no_forbidden_imports` | This test file itself does not import any forbidden module. |
+| `test_registry_has_all_seven_mandatory_regimes` | All 7 mandatory regime IDs (R1..R7) are present. |
+| `test_registry_regime_ids_are_unique` | No duplicate `regime_id` across the registry. |
+| `test_regime_score_is_well_formed[R*]` ×7 | Engine output is structurally valid (10 components in [0,100], aggregates consistent). |
+| `test_regime_band_is_valid[R*]` ×7 | `decision_band` is a valid `DecisionBand` enum value. |
+| `test_regime_no_band_authorizes_real_trading[R*]` ×7 | `assert_no_real_trading_authorized(band)` passes silently — Phase 0 boundary intact. |
+| `test_regime_scoring_is_deterministic[R*]` ×7 | Same regime scored twice in one test → bit-equal components + identical deterministic hash. |
+| `test_regime_hard_disqualifiers_consistent_with_band[R*]` ×7 | If any documented hard disqualifier triggers, band must be REJECT or OBSERVE. |
+| `test_expected_vs_actual_table_is_complete_for_all_regimes` | Full evidence schema complete for every regime; pack-level determinism across two back-to-back full passes. |
+| `test_fixture_file_does_not_touch_engine_internals` | Fixture file does not reference `_WEIGHTS` / `__setattr__` / `_missing_` engine-mutation surfaces. |
+
+#### Constraints honored
+
+- NO modification of `modules/foundups/trade/src/**` (engine, contracts, harness).
+- NO modification of existing trade tests.
+- NO new external dependencies (stdlib + pytest only).
+- NO forbidden imports (requests/urllib/httpx/ccxt/web3/exchange SDKs/etc.).
+- NO forbidden fields (`api_key`/`secret`/`wallet_private_key`/`order_id`/etc.).
+- NO registry/catalog/projection/manifest/CI/dependency edits.
+- NO `@pytest.mark.skip` used anywhere in the new files.
+- All fixtures synthetic deterministic Python literals.
+- Trade status unchanged (still Phase 0 / not_portfolio / poc_status=idea / entity_type=skeleton_candidate).
+
+#### Test policy (per operator's patched W6 prompt)
+
+Per-regime tests fail on: nondeterministic output, invalid `DecisionBand`, malformed score, missing component, forbidden import/field, boundary violation, real-trading authorization claim.
+
+Per-regime tests do **NOT** fail on `expected_band != actual_band`. Divergence is recorded in the per-regime result row (`band_match=False`) and routed to a future targeted engine-tuning slice via the audit doc.
+
+#### Decision-shape findings (recorded, NOT slice failures)
+
+5 of 7 regimes show `expected_band != actual_band`. Pattern: only hard disqualifiers (`rug_honeypot<20`, `issuer_history<20`, `evidence_confidence<0.5`) reliably move the band below `CANDIDATE_FOR_FUTURE_REVIEW` once other components are reasonable. Full per-regime breakdown in:
+
+`docs/audits/architecture/TRADE_DUE_DILIGENCE_SYNTHETIC_REGIME_PACK_PHASE1.md`
+
+#### Test results
+
+```bash
+python -m pytest modules/foundups/trade/tests/test_due_diligence_regimes.py
+# 42 passed in 0.16s
+
+python -m pytest modules/foundups/trade/tests/
+# 384 passed in 1.91s   (342 existing + 42 new, 0 skipped)
+```
+
+#### WSP refs
+
+WSP_00, WSP_15, WSP_50, WSP_64, WSP_83, WSP_87, WSP_97, WSP_104, WSP_22
+---
+
 ## Future Entries
 
-Next slice: `TRADE_DUE_DILIGENCE_SYNTHETIC_REGIME_PACK_PHASE1`
+Next slice: targeted engine-tuning slice to address the 5 expected-vs-actual divergences identified by this evidence pack (see audit doc §10).

--- a/modules/foundups/trade/tests/fixtures/__init__.py
+++ b/modules/foundups/trade/tests/fixtures/__init__.py
@@ -1,0 +1,9 @@
+"""Trade test fixtures package.
+
+Synthetic, deterministic fixtures only.
+
+Boundary contract (LOCKED):
+  - SIMULATION_MODE_ONLY
+  - SYNTHETIC_EVIDENCE_ONLY
+  - NO live feeds / network / wallet / order / exchange SDK
+"""

--- a/modules/foundups/trade/tests/fixtures/due_diligence_regimes.py
+++ b/modules/foundups/trade/tests/fixtures/due_diligence_regimes.py
@@ -1,0 +1,787 @@
+"""Synthetic Regime Pack — Trade Due-Diligence Decision-Shape Evidence
+
+Slice: TRADE_DUE_DILIGENCE_SYNTHETIC_REGIME_PACK_PHASE1
+Worker: W6
+Spec: TRADE_PUMPFUN_DUE_DILIGENCE_SCORING_SPEC_PHASE1 (PR #683)
+Engine: TRADE_DUE_DILIGENCE_SCORING_ENGINE_PHASE1 (PR #687)
+Schema: TRADE_DUE_DILIGENCE_SCHEMA_PHASE1 (PR #685)
+
+Purpose
+-------
+Exercise the deterministic due-diligence scoring engine against named
+synthetic regimes that span the decision-shape space. This is *evidence*,
+not acceptance testing: each regime declares an `expected_band` HYPOTHESIS,
+but expected-vs-actual divergence is recorded as a finding, not a failure
+(per operator's patched test policy).
+
+Boundary contract (LOCKED — no exceptions in this slice)
+-------------------------------------------------------
+- SIMULATION_MODE_ONLY
+- SYNTHETIC_EVIDENCE_ONLY (every datum here is a hand-built deterministic
+  Python literal; no live feeds, no recorded production data)
+- NO_LIVE_FEEDS / NO_NETWORK_CALLS / NO_WALLET / NO_ORDER_PLACEMENT
+- NO_REAL_TRADING / NO_EXCHANGE_SDK_IMPORT
+- NO change to Trade status (not_portfolio / poc_status=idea /
+  entity_type=skeleton_candidate)
+
+The 7 mandatory regimes
+-----------------------
+R1: organic_launch_clean_socials       — expected: CANDIDATE_FOR_FUTURE_REVIEW
+R2: influencer_pump_high_concentration — expected: REJECT
+R3: dead_x_no_telegram                 — expected: REJECT or OBSERVE
+R4: issuer_prior_rug_history           — expected: REJECT (issuer disqualifier)
+R5: whale_accumulation_then_dump       — expected: REJECT (whale_risk)
+R6: telegram_active_low_authenticity   — expected: SIMULATE_ONLY or OBSERVE
+R7: bonding_curve_migration_risk       — expected: SIMULATE_ONLY or OBSERVE
+
+These expected bands are HYPOTHESES. The accompanying test suite records
+expected vs actual per regime. Divergences are decision-shape findings for
+a future engine-tuning slice; they do not fail this evidence slice.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set, Tuple
+
+# Trade src/ is on sys.path via test files; mirror that here so the fixture
+# module can be imported standalone (e.g. via the audit-doc generator).
+_TRADE_SRC = Path(__file__).resolve().parent.parent.parent / "src"
+if str(_TRADE_SRC) not in sys.path:
+    sys.path.insert(0, str(_TRADE_SRC))
+
+from contracts import (  # noqa: E402  (sys.path setup above)
+    DecisionBand,
+    EntityHistoryReport,
+    EntityType,
+    InfluencerRiskReport,
+    LaunchpadTokenCandidate,
+    RiskClassification,
+    SocialPresenceReport,
+    TradeDueDiligenceScore,
+    WalletAuditReport,
+    WalletClassification,
+)
+
+
+# ---------------------------------------------------------------------------
+# Regime input type (a complete engine-input bundle)
+# ---------------------------------------------------------------------------
+
+class RegimeInputs(NamedTuple):
+    """One regime's deterministic input bundle for the scoring engine."""
+
+    regime_id: str
+    description: str
+    expected_band: DecisionBand
+    expected_band_rationale: str
+    candidate: LaunchpadTokenCandidate
+    issuer_report: Optional[EntityHistoryReport]
+    wallet_reports: List[WalletAuditReport]
+    social_report: Optional[SocialPresenceReport]
+    influencer_report: Optional[InfluencerRiskReport]
+
+
+# ---------------------------------------------------------------------------
+# Determinism helpers
+# ---------------------------------------------------------------------------
+#
+# Post-#691 (clock fix): the scoring engine no longer reads an implicit
+# clock. Both `candidate.timestamp` and `evaluation_time` must be explicit
+# and fixed for byte-identical determinism. This module exposes
+# FIXTURE_REFERENCE_TIME — the canonical "now" used by all regime
+# constructors. Tests pass the same value as `evaluation_time` to the
+# scoring engine so launch_timing buckets resolve deterministically.
+
+# Canonical reference time for all regime fixtures. Tests should pass this
+# same value as `evaluation_time` to `DueDiligenceScoringEngine.score()`.
+FIXTURE_REFERENCE_TIME: datetime = datetime(2026, 5, 24, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _age_offset(minutes: float) -> datetime:
+    """Return a UTC datetime that is `minutes` before FIXTURE_REFERENCE_TIME.
+
+    Pure function — no implicit clock. Same input → same output across runs.
+    """
+    return FIXTURE_REFERENCE_TIME - timedelta(minutes=minutes)
+
+
+# Hard-coded mock token addresses & creator hashes used across regimes.
+# These are intentionally non-real-looking, all-uppercase synthetic strings.
+_SYNTHETIC_TOKEN = "SYNTHETIC_TOKEN_REGIME_{idx:02d}"
+_SYNTHETIC_CREATOR = "SYNTHETIC_CREATOR_HASH_{idx:02d}"
+_SYNTHETIC_WALLET = "SYNTHETIC_WALLET_HASH_R{regime}_W{idx:03d}"
+
+
+# ---------------------------------------------------------------------------
+# Regime constructors
+# ---------------------------------------------------------------------------
+
+def _make_token(
+    idx: int,
+    *,
+    age_minutes: float,
+    bonding_curve_progress: float,
+    passed_initial_filter: bool = True,
+    initial_market_cap_usd: float = 12_500.0,
+    transaction_count: int = 42,
+) -> LaunchpadTokenCandidate:
+    return LaunchpadTokenCandidate(
+        token_address=_SYNTHETIC_TOKEN.format(idx=idx),
+        token_symbol=f"SYN{idx:02d}",
+        token_name=f"Synthetic Regime {idx:02d}",
+        chain="solana",
+        launchpad="pumpfun",
+        timestamp=_age_offset(age_minutes),
+        creator_address=_SYNTHETIC_CREATOR.format(idx=idx),
+        bonding_curve_progress=bonding_curve_progress,
+        initial_market_cap_usd=initial_market_cap_usd,
+        transaction_count=transaction_count,
+        passed_initial_filter=passed_initial_filter,
+        discovery_source="simulation",
+    )
+
+
+def _retail_wallets(
+    regime: int,
+    n: int,
+    *,
+    avg_holding_percent: float,
+    spread: float = 0.5,
+) -> List[WalletAuditReport]:
+    """Build `n` retail wallets summing to roughly `n * avg_holding_percent`.
+
+    Uses deterministic per-wallet variations so total ordering and sum are
+    reproducible across runs.
+    """
+    wallets: List[WalletAuditReport] = []
+    token = _SYNTHETIC_TOKEN.format(idx=regime)
+    for i in range(n):
+        # deterministic small variation: alternates +/-
+        delta = spread * (-1.0 if i % 2 else 1.0) * (i % 3) / max(n, 1)
+        holding = max(0.0, min(100.0, avg_holding_percent + delta))
+        wallets.append(
+            WalletAuditReport(
+                wallet_hash=_SYNTHETIC_WALLET.format(regime=regime, idx=i),
+                token_address=token,
+                holding_percent=holding,
+                entity_classification=WalletClassification.RETAIL,
+                risk_contribution=0.05,
+                prior_tokens_held=2,
+            )
+        )
+    return wallets
+
+
+def _whale_wallets(
+    regime: int,
+    n: int,
+    *,
+    holding_percent: float,
+    risk_contribution: float = 0.7,
+    prior_dumps_executed: int = 2,
+) -> List[WalletAuditReport]:
+    """Build `n` whale wallets, each holding `holding_percent`."""
+    token = _SYNTHETIC_TOKEN.format(idx=regime)
+    return [
+        WalletAuditReport(
+            wallet_hash=_SYNTHETIC_WALLET.format(regime=regime, idx=1000 + i),
+            token_address=token,
+            holding_percent=holding_percent,
+            entity_classification=WalletClassification.WHALE,
+            risk_contribution=risk_contribution,
+            prior_tokens_held=10,
+            prior_dumps_executed=prior_dumps_executed,
+        )
+        for i in range(n)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# R1: organic_launch_clean_socials  →  expected CANDIDATE_FOR_FUTURE_REVIEW
+# ---------------------------------------------------------------------------
+
+def regime_R1_organic_launch_clean_socials() -> RegimeInputs:
+    regime_id = "R1_organic_launch_clean_socials"
+    idx = 1
+    token = _SYNTHETIC_TOKEN.format(idx=idx)
+    return RegimeInputs(
+        regime_id=regime_id,
+        description=(
+            "Fresh launch (~2 min old), clean issuer track record, healthy "
+            "distributed retail holders, active authentic socials, no "
+            "influencer coordination."
+        ),
+        expected_band=DecisionBand.CANDIDATE_FOR_FUTURE_REVIEW,
+        expected_band_rationale="all components high; total_score > 70",
+        candidate=_make_token(
+            idx=idx,
+            age_minutes=2.0,
+            bonding_curve_progress=0.25,  # in the 80+ score sweet spot
+            passed_initial_filter=True,
+        ),
+        issuer_report=EntityHistoryReport(
+            entity_id=_SYNTHETIC_CREATOR.format(idx=idx),
+            entity_type=EntityType.ISSUER,
+            prior_token_launches=4,
+            prior_rug_pulls=0,
+            prior_successful_launches=4,
+            average_token_lifespan_hours=720.0,  # >168 hours bonus
+            average_holder_loss_percent=5.0,
+            risk_classification=RiskClassification.CLEAN,
+            confidence=0.95,
+        ),
+        wallet_reports=_retail_wallets(idx, n=20, avg_holding_percent=3.5),
+        social_report=SocialPresenceReport(
+            token_address=token,
+            x_account_exists=True,
+            x_account_age_days=365,
+            x_follower_count=12_000,
+            x_follower_bot_percent=8.0,
+            x_engagement_authenticity=0.85,
+            x_prior_token_mentions=2,
+            telegram_exists=True,
+            telegram_member_count=2_500,
+            telegram_bot_percent=5.0,
+            telegram_admin_active=True,
+            telegram_spam_ratio=0.05,
+            social_authenticity_score=88.0,
+            evidence_completeness=0.9,
+        ),
+        influencer_report=InfluencerRiskReport(
+            token_address=token,
+            known_pumper_wallets_detected=0,
+            coordinated_buy_timing_detected=False,
+            influencers_with_prior_rugs=0,
+            total_influencers_detected=1,
+            influencer_risk_score=10.0,
+            coordination_risk_score=5.0,
+            evidence_completeness=0.85,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# R2: influencer_pump_high_concentration  →  expected REJECT
+# ---------------------------------------------------------------------------
+
+def regime_R2_influencer_pump_high_concentration() -> RegimeInputs:
+    regime_id = "R2_influencer_pump_high_concentration"
+    idx = 2
+    token = _SYNTHETIC_TOKEN.format(idx=idx)
+    return RegimeInputs(
+        regime_id=regime_id,
+        description=(
+            "Coordinated influencer pump with heavy top-holder + whale "
+            "concentration. Multiple pumper wallets detected; coordinated "
+            "buy timing. Issuer clean (so it's not an issuer disqualifier "
+            "— this regime stresses the whale + influencer path)."
+        ),
+        expected_band=DecisionBand.REJECT,
+        expected_band_rationale=(
+            "very high whale concentration + influencer coordination drive "
+            "whale_risk/holder_distribution/influencer_risk low → total < 30"
+        ),
+        candidate=_make_token(
+            idx=idx,
+            age_minutes=15.0,  # mild decay
+            bonding_curve_progress=0.45,
+            passed_initial_filter=True,
+        ),
+        issuer_report=EntityHistoryReport(
+            entity_id=_SYNTHETIC_CREATOR.format(idx=idx),
+            entity_type=EntityType.ISSUER,
+            prior_token_launches=1,
+            prior_rug_pulls=0,
+            prior_successful_launches=1,
+            average_token_lifespan_hours=200.0,
+            average_holder_loss_percent=10.0,
+            risk_classification=RiskClassification.CLEAN,
+            confidence=0.7,
+        ),
+        wallet_reports=(
+            _whale_wallets(idx, n=3, holding_percent=22.0, risk_contribution=0.9)
+            + _retail_wallets(idx, n=10, avg_holding_percent=2.5)
+        ),
+        social_report=SocialPresenceReport(
+            token_address=token,
+            x_account_exists=True,
+            x_account_age_days=10,
+            x_follower_count=8_000,
+            x_follower_bot_percent=70.0,
+            x_engagement_authenticity=0.2,
+            x_prior_token_mentions=0,
+            telegram_exists=True,
+            telegram_member_count=4_000,
+            telegram_bot_percent=60.0,
+            telegram_admin_active=False,
+            telegram_spam_ratio=0.7,
+            social_authenticity_score=18.0,
+            evidence_completeness=0.85,
+        ),
+        influencer_report=InfluencerRiskReport(
+            token_address=token,
+            known_pumper_wallets_detected=4,
+            coordinated_buy_timing_detected=True,
+            multiple_influencers_same_token=True,
+            influencer_mentions_count=7,
+            influencers_with_prior_rugs=2,
+            total_influencers_detected=3,
+            influencer_risk_score=90.0,
+            coordination_risk_score=85.0,
+            evidence_completeness=0.9,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# R3: dead_x_no_telegram  →  expected REJECT or OBSERVE
+# ---------------------------------------------------------------------------
+
+def regime_R3_dead_x_no_telegram() -> RegimeInputs:
+    regime_id = "R3_dead_x_no_telegram"
+    idx = 3
+    token = _SYNTHETIC_TOKEN.format(idx=idx)
+    return RegimeInputs(
+        regime_id=regime_id,
+        description=(
+            "Token with X account that has no real engagement and no "
+            "Telegram channel. No issuer rug history, no whale concentration "
+            "— this stresses the social-presence component path."
+        ),
+        expected_band=DecisionBand.REJECT,
+        expected_band_rationale=(
+            "social_authenticity ≈ 5 and telegram_quality ≈ 20 together "
+            "drag total_score low; expect REJECT or OBSERVE"
+        ),
+        candidate=_make_token(
+            idx=idx,
+            age_minutes=20.0,
+            bonding_curve_progress=0.12,
+            passed_initial_filter=True,
+        ),
+        issuer_report=EntityHistoryReport(
+            entity_id=_SYNTHETIC_CREATOR.format(idx=idx),
+            entity_type=EntityType.ISSUER,
+            prior_token_launches=0,
+            prior_rug_pulls=0,
+            prior_successful_launches=0,
+            risk_classification=RiskClassification.CLEAN,
+            confidence=0.5,
+        ),
+        wallet_reports=_retail_wallets(idx, n=8, avg_holding_percent=6.0),
+        social_report=SocialPresenceReport(
+            token_address=token,
+            x_account_exists=True,
+            x_account_age_days=3,
+            x_follower_count=15,
+            x_follower_bot_percent=10.0,
+            x_engagement_authenticity=0.05,
+            x_prior_token_mentions=0,
+            telegram_exists=False,
+            telegram_member_count=0,
+            telegram_bot_percent=0.0,
+            telegram_admin_active=False,
+            telegram_spam_ratio=0.0,
+            social_authenticity_score=5.0,
+            evidence_completeness=0.7,
+        ),
+        influencer_report=InfluencerRiskReport(
+            token_address=token,
+            known_pumper_wallets_detected=0,
+            coordinated_buy_timing_detected=False,
+            influencers_with_prior_rugs=0,
+            total_influencers_detected=0,
+            influencer_risk_score=15.0,
+            coordination_risk_score=5.0,
+            evidence_completeness=0.6,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# R4: issuer_prior_rug_history  →  expected REJECT (issuer disqualifier)
+# ---------------------------------------------------------------------------
+
+def regime_R4_issuer_prior_rug_history() -> RegimeInputs:
+    regime_id = "R4_issuer_prior_rug_history"
+    idx = 4
+    token = _SYNTHETIC_TOKEN.format(idx=idx)
+    return RegimeInputs(
+        regime_id=regime_id,
+        description=(
+            "Issuer has 3 prior rug pulls and is FLAGGED. Should trip the "
+            "issuer_history < 20 hard disqualifier and also drag "
+            "rug_honeypot down. Other signals neutral-to-good — this isolates "
+            "the issuer-history disqualifier."
+        ),
+        expected_band=DecisionBand.REJECT,
+        expected_band_rationale="hard disqualifier: issuer_history < 20",
+        candidate=_make_token(
+            idx=idx,
+            age_minutes=4.0,
+            bonding_curve_progress=0.20,
+            passed_initial_filter=True,
+        ),
+        issuer_report=EntityHistoryReport(
+            entity_id=_SYNTHETIC_CREATOR.format(idx=idx),
+            entity_type=EntityType.ISSUER,
+            prior_token_launches=5,
+            prior_rug_pulls=3,
+            prior_successful_launches=1,
+            average_token_lifespan_hours=2.0,
+            average_holder_loss_percent=85.0,
+            risk_classification=RiskClassification.FLAGGED,
+            confidence=0.9,
+        ),
+        wallet_reports=_retail_wallets(idx, n=12, avg_holding_percent=4.0),
+        social_report=SocialPresenceReport(
+            token_address=token,
+            x_account_exists=True,
+            x_account_age_days=180,
+            x_follower_count=2_000,
+            x_follower_bot_percent=20.0,
+            x_engagement_authenticity=0.6,
+            telegram_exists=True,
+            telegram_member_count=800,
+            telegram_bot_percent=15.0,
+            telegram_admin_active=True,
+            telegram_spam_ratio=0.1,
+            social_authenticity_score=65.0,
+            evidence_completeness=0.75,
+        ),
+        influencer_report=InfluencerRiskReport(
+            token_address=token,
+            known_pumper_wallets_detected=0,
+            influencers_with_prior_rugs=0,
+            total_influencers_detected=1,
+            influencer_risk_score=25.0,
+            evidence_completeness=0.7,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# R5: whale_accumulation_then_dump  →  expected REJECT (whale_risk)
+# ---------------------------------------------------------------------------
+
+def regime_R5_whale_accumulation_then_dump() -> RegimeInputs:
+    regime_id = "R5_whale_accumulation_then_dump"
+    idx = 5
+    token = _SYNTHETIC_TOKEN.format(idx=idx)
+    return RegimeInputs(
+        regime_id=regime_id,
+        description=(
+            "Several whales control most supply, multiple prior dumps "
+            "executed on prior tokens by these wallets. Influencer signals "
+            "absent (so this regime isolates the whale + holder_distribution "
+            "path)."
+        ),
+        expected_band=DecisionBand.REJECT,
+        expected_band_rationale=(
+            "whale concentration > 50% + high risk_contribution drives "
+            "whale_risk and holder_distribution into floor — expect REJECT"
+        ),
+        candidate=_make_token(
+            idx=idx,
+            age_minutes=8.0,
+            bonding_curve_progress=0.30,
+            passed_initial_filter=True,
+        ),
+        issuer_report=EntityHistoryReport(
+            entity_id=_SYNTHETIC_CREATOR.format(idx=idx),
+            entity_type=EntityType.ISSUER,
+            prior_token_launches=2,
+            prior_rug_pulls=0,
+            prior_successful_launches=1,
+            average_token_lifespan_hours=120.0,
+            average_holder_loss_percent=15.0,
+            risk_classification=RiskClassification.CLEAN,
+            confidence=0.7,
+        ),
+        wallet_reports=(
+            _whale_wallets(idx, n=4, holding_percent=18.0, risk_contribution=0.85, prior_dumps_executed=3)
+            + _retail_wallets(idx, n=6, avg_holding_percent=3.0)
+        ),
+        social_report=SocialPresenceReport(
+            token_address=token,
+            x_account_exists=True,
+            x_account_age_days=90,
+            x_follower_count=1_500,
+            x_follower_bot_percent=12.0,
+            x_engagement_authenticity=0.65,
+            telegram_exists=True,
+            telegram_member_count=600,
+            telegram_bot_percent=12.0,
+            telegram_admin_active=True,
+            telegram_spam_ratio=0.08,
+            social_authenticity_score=62.0,
+            evidence_completeness=0.7,
+        ),
+        influencer_report=InfluencerRiskReport(
+            token_address=token,
+            known_pumper_wallets_detected=0,
+            coordinated_buy_timing_detected=False,
+            influencers_with_prior_rugs=0,
+            total_influencers_detected=0,
+            influencer_risk_score=15.0,
+            coordination_risk_score=5.0,
+            evidence_completeness=0.65,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# R6: telegram_active_low_authenticity  →  expected SIMULATE_ONLY or OBSERVE
+# ---------------------------------------------------------------------------
+
+def regime_R6_telegram_active_low_authenticity() -> RegimeInputs:
+    regime_id = "R6_telegram_active_low_authenticity"
+    idx = 6
+    token = _SYNTHETIC_TOKEN.format(idx=idx)
+    return RegimeInputs(
+        regime_id=regime_id,
+        description=(
+            "Telegram looks busy on the surface (high member count, admin "
+            "active) but bot ratio and spam ratio are high; X account "
+            "engagement authenticity low. Issuer clean. Tests the social_"
+            "authenticity vs telegram_quality split."
+        ),
+        expected_band=DecisionBand.SIMULATE_ONLY,
+        expected_band_rationale=(
+            "median scores everywhere except social; total expected 50-70"
+        ),
+        candidate=_make_token(
+            idx=idx,
+            age_minutes=3.0,
+            bonding_curve_progress=0.30,
+            passed_initial_filter=True,
+        ),
+        issuer_report=EntityHistoryReport(
+            entity_id=_SYNTHETIC_CREATOR.format(idx=idx),
+            entity_type=EntityType.ISSUER,
+            prior_token_launches=2,
+            prior_rug_pulls=0,
+            prior_successful_launches=2,
+            average_token_lifespan_hours=400.0,
+            average_holder_loss_percent=10.0,
+            risk_classification=RiskClassification.CLEAN,
+            confidence=0.8,
+        ),
+        wallet_reports=_retail_wallets(idx, n=18, avg_holding_percent=4.0),
+        social_report=SocialPresenceReport(
+            token_address=token,
+            x_account_exists=True,
+            x_account_age_days=60,
+            x_follower_count=5_000,
+            x_follower_bot_percent=55.0,
+            x_engagement_authenticity=0.25,
+            telegram_exists=True,
+            telegram_member_count=2_000,  # > 1000 → +20
+            telegram_bot_percent=45.0,    # large penalty
+            telegram_admin_active=True,
+            telegram_spam_ratio=0.4,
+            social_authenticity_score=35.0,
+            evidence_completeness=0.8,
+        ),
+        influencer_report=InfluencerRiskReport(
+            token_address=token,
+            known_pumper_wallets_detected=1,
+            coordinated_buy_timing_detected=False,
+            influencers_with_prior_rugs=0,
+            total_influencers_detected=2,
+            influencer_risk_score=30.0,
+            coordination_risk_score=20.0,
+            evidence_completeness=0.75,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# R7: bonding_curve_migration_risk  →  expected SIMULATE_ONLY or OBSERVE
+# ---------------------------------------------------------------------------
+
+def regime_R7_bonding_curve_migration_risk() -> RegimeInputs:
+    regime_id = "R7_bonding_curve_migration_risk"
+    idx = 7
+    token = _SYNTHETIC_TOKEN.format(idx=idx)
+    return RegimeInputs(
+        regime_id=regime_id,
+        description=(
+            "Bonding curve well past the sweet spot (progress=0.85). Other "
+            "signals are reasonable. Tests the bonding-curve-late penalty in "
+            "isolation."
+        ),
+        expected_band=DecisionBand.SIMULATE_ONLY,
+        expected_band_rationale=(
+            "bonding_curve score drops to ~25 at progress=0.85; other "
+            "components mid-to-high — expect SIMULATE_ONLY or OBSERVE"
+        ),
+        candidate=_make_token(
+            idx=idx,
+            age_minutes=2.0,
+            bonding_curve_progress=0.85,
+            passed_initial_filter=True,
+        ),
+        issuer_report=EntityHistoryReport(
+            entity_id=_SYNTHETIC_CREATOR.format(idx=idx),
+            entity_type=EntityType.ISSUER,
+            prior_token_launches=3,
+            prior_rug_pulls=0,
+            prior_successful_launches=3,
+            average_token_lifespan_hours=500.0,
+            average_holder_loss_percent=8.0,
+            risk_classification=RiskClassification.CLEAN,
+            confidence=0.85,
+        ),
+        wallet_reports=_retail_wallets(idx, n=16, avg_holding_percent=4.0),
+        social_report=SocialPresenceReport(
+            token_address=token,
+            x_account_exists=True,
+            x_account_age_days=200,
+            x_follower_count=6_000,
+            x_follower_bot_percent=10.0,
+            x_engagement_authenticity=0.8,
+            telegram_exists=True,
+            telegram_member_count=1_500,
+            telegram_bot_percent=8.0,
+            telegram_admin_active=True,
+            telegram_spam_ratio=0.07,
+            social_authenticity_score=78.0,
+            evidence_completeness=0.85,
+        ),
+        influencer_report=InfluencerRiskReport(
+            token_address=token,
+            known_pumper_wallets_detected=0,
+            coordinated_buy_timing_detected=False,
+            influencers_with_prior_rugs=0,
+            total_influencers_detected=1,
+            influencer_risk_score=18.0,
+            coordination_risk_score=10.0,
+            evidence_completeness=0.8,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+ALL_REGIME_CONSTRUCTORS: List[Callable[[], RegimeInputs]] = [
+    regime_R1_organic_launch_clean_socials,
+    regime_R2_influencer_pump_high_concentration,
+    regime_R3_dead_x_no_telegram,
+    regime_R4_issuer_prior_rug_history,
+    regime_R5_whale_accumulation_then_dump,
+    regime_R6_telegram_active_low_authenticity,
+    regime_R7_bonding_curve_migration_risk,
+]
+
+
+# ---------------------------------------------------------------------------
+# Result schema + helpers (used by the regime tests + audit-doc generation)
+# ---------------------------------------------------------------------------
+
+# Hard-disqualifier names that determine_decision_band() checks.
+HARD_DISQUALIFIER_NAMES = (
+    "rug_honeypot_below_20",
+    "issuer_history_below_20",
+    "evidence_confidence_below_0_5",
+)
+
+
+def detect_hard_disqualifiers(score: TradeDueDiligenceScore) -> List[str]:
+    """Which hard disqualifiers (from contracts.determine_decision_band) tripped."""
+    out: List[str] = []
+    if score.rug_honeypot < 20:
+        out.append("rug_honeypot_below_20")
+    if score.issuer_history < 20:
+        out.append("issuer_history_below_20")
+    if score.evidence_confidence < 0.5:
+        out.append("evidence_confidence_below_0_5")
+    return out
+
+
+def component_scores(score: TradeDueDiligenceScore) -> Dict[str, float]:
+    """Component-only score map (no aggregates, no timestamp)."""
+    return {
+        "launch_timing": score.launch_timing,
+        "issuer_history": score.issuer_history,
+        "social_authenticity": score.social_authenticity,
+        "telegram_quality": score.telegram_quality,
+        "influencer_risk": score.influencer_risk,
+        "holder_distribution": score.holder_distribution,
+        "whale_risk": score.whale_risk,
+        "prior_token_history": score.prior_token_history,
+        "bonding_curve": score.bonding_curve,
+        "rug_honeypot": score.rug_honeypot,
+    }
+
+
+# Post-#691 (clock fix): the scoring engine no longer reads an implicit
+# clock. Same (regime inputs, evaluation_time) → byte-identical component
+# scores. No rounding is applied to the deterministic_hash payload — the
+# hash captures the full float precision of every component.
+
+
+def deterministic_hash(score: TradeDueDiligenceScore) -> str:
+    """SHA-256 hex hash of the component-score fingerprint.
+
+    Uses RAW (non-rounded) component scores + total_score + risk_score +
+    evidence_confidence + decision_band + the set of hard disqualifiers
+    triggered. Timestamp is excluded (it's an input to scoring, not an
+    output). Post-#691, scoring is fully deterministic without rounding.
+    """
+    payload = {
+        "components": component_scores(score),
+        "total_score": score.total_score,
+        "risk_score": score.risk_score,
+        "evidence_confidence": score.evidence_confidence,
+        "decision_band": score.decision_band.value,
+        "hard_disqualifiers": sorted(detect_hard_disqualifiers(score)),
+    }
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def build_regime_result(
+    regime: RegimeInputs,
+    score: TradeDueDiligenceScore,
+) -> Dict[str, Any]:
+    """Construct the per-regime result record (audit + test consume this).
+
+    Raw float scores (no rounding). Post-#691, byte-identical determinism
+    holds without a rounding mask.
+    """
+    actual_band = score.decision_band
+    return {
+        "regime_id": regime.regime_id,
+        "description": regime.description,
+        "expected_band": regime.expected_band.value,
+        "actual_band": actual_band.value,
+        "band_match": (actual_band == regime.expected_band),
+        "total_score": score.total_score,
+        "risk_score": score.risk_score,
+        "evidence_confidence": score.evidence_confidence,
+        "component_scores": component_scores(score),
+        "hard_disqualifiers_triggered": sorted(detect_hard_disqualifiers(score)),
+        "deterministic_hash": deterministic_hash(score),
+        "band_rationale": score.band_rationale,
+    }
+
+
+# Sanity check at import time — every regime must be uniquely IDed.
+def _validate_registry_unique_ids() -> None:
+    seen: Set[str] = set()
+    for ctor in ALL_REGIME_CONSTRUCTORS:
+        rid = ctor().regime_id
+        if rid in seen:
+            raise AssertionError(f"Duplicate regime_id {rid!r} in registry")
+        seen.add(rid)
+
+
+_validate_registry_unique_ids()

--- a/modules/foundups/trade/tests/test_due_diligence_regimes.py
+++ b/modules/foundups/trade/tests/test_due_diligence_regimes.py
@@ -1,0 +1,411 @@
+"""Trade Synthetic Regime Pack — Decision-Shape Evidence Tests
+
+Slice: TRADE_DUE_DILIGENCE_SYNTHETIC_REGIME_PACK_PHASE1
+Worker: W6
+Spec: TRADE_PUMPFUN_DUE_DILIGENCE_SCORING_SPEC_PHASE1 (PR #683)
+Engine: TRADE_DUE_DILIGENCE_SCORING_ENGINE_PHASE1 (PR #687)
+
+Test policy (per operator's patched W6 prompt)
+----------------------------------------------
+This is an EVIDENCE-PACK slice, NOT engine acceptance testing.
+
+Per-regime tests MUST fail on:
+  - nondeterministic output (same regime → different score bytes)
+  - invalid DecisionBand value
+  - malformed TradeDueDiligenceScore (component out of [0,100], etc.)
+  - missing component score
+  - forbidden import / field violation
+  - any boundary violation (real-trading authorization, live SDK import, etc.)
+
+Per-regime tests MUST NOT fail solely because expected_band != actual_band.
+Expected-vs-actual divergence is recorded as evidence in the audit doc and
+routed to a future targeted engine-tuning slice.
+
+WSP 97 Truth Boundary
+---------------------
+- Pure computation against synthetic deterministic fixtures.
+- No network, no wallet, no order placement, no exchange SDK import.
+- No Trade status change (Trade stays Phase 0 simulation-only).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+# Mirror the convention used by test_due_diligence_scoring.py (PR #687):
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+# Plus the tests/ directory so `fixtures.due_diligence_regimes` resolves
+# (the fixtures/ package lives at tests/fixtures/).
+sys.path.insert(0, str(Path(__file__).parent))
+
+from contracts import (  # noqa: E402
+    DecisionBand,
+    TradeDueDiligenceScore,
+    assert_no_real_trading_authorized,
+)
+from due_diligence_scoring import DueDiligenceScoringEngine  # noqa: E402
+
+from fixtures.due_diligence_regimes import (  # noqa: E402
+    ALL_REGIME_CONSTRUCTORS,
+    FIXTURE_REFERENCE_TIME,
+    HARD_DISQUALIFIER_NAMES,
+    build_regime_result,
+    component_scores,
+    detect_hard_disqualifiers,
+    deterministic_hash,
+)
+
+# Alias: tests call the engine with the same instant the fixtures used to
+# compute candidate.timestamp offsets. Post-#691 the engine requires an
+# explicit `evaluation_time`; this guarantees byte-identical determinism
+# without any rounding mask.
+FIXED_EVAL_TIME = FIXTURE_REFERENCE_TIME
+
+
+# ---------------------------------------------------------------------------
+# Forbidden imports / fields — mirror PR #687 test guard so this slice can
+# never silently introduce a boundary-violating import via the fixture file.
+# ---------------------------------------------------------------------------
+
+FORBIDDEN_IMPORTS = frozenset({
+    "requests", "urllib", "urllib3", "httpx", "aiohttp",
+    "websocket", "websockets", "socket", "asyncio",
+    "ccxt", "web3", "alpaca", "binance", "coinbase", "kraken",
+    "ib_insync", "ftx", "bitfinex", "polygon", "yfinance",
+    "eth_account", "cryptography",
+})
+
+FORBIDDEN_FIELDS = frozenset({
+    "api_key", "secret", "signer", "wallet_private_key", "order_id",
+    "endpoint", "exchange_client",
+})
+
+
+def _read_source(rel_path: str) -> str:
+    p = Path(__file__).parent / rel_path
+    return p.read_text(encoding="utf-8")
+
+
+def test_regime_fixture_has_no_forbidden_imports():
+    """The regime fixture file must not import any networking / exchange SDK."""
+    src = _read_source("fixtures/due_diligence_regimes.py")
+    for mod in FORBIDDEN_IMPORTS:
+        # match `import X`, `from X import`, `from X.` boundaries
+        for pat in (f"import {mod}", f"from {mod} import", f"from {mod}."):
+            assert pat not in src, (
+                f"Forbidden import pattern {pat!r} present in due_diligence_regimes.py"
+            )
+
+
+def test_regime_fixture_has_no_forbidden_fields():
+    """Fixture must not reference any wallet/order/key field names."""
+    src = _read_source("fixtures/due_diligence_regimes.py").lower()
+    for field in FORBIDDEN_FIELDS:
+        assert field.lower() not in src, (
+            f"Forbidden field name {field!r} present in due_diligence_regimes.py"
+        )
+
+
+def test_regime_test_file_has_no_forbidden_imports():
+    """This test file must not import any networking / exchange SDK either."""
+    src = _read_source("test_due_diligence_regimes.py")
+    for mod in FORBIDDEN_IMPORTS:
+        for pat in (f"import {mod}", f"from {mod} import", f"from {mod}."):
+            assert pat not in src, (
+                f"Forbidden import pattern {pat!r} present in test_due_diligence_regimes.py"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Registry-level invariants
+# ---------------------------------------------------------------------------
+
+def test_registry_has_all_seven_mandatory_regimes():
+    """All 7 mandatory regime IDs must be present (slice operator constraint)."""
+    expected_prefixes = {
+        "R1_organic_launch_clean_socials",
+        "R2_influencer_pump_high_concentration",
+        "R3_dead_x_no_telegram",
+        "R4_issuer_prior_rug_history",
+        "R5_whale_accumulation_then_dump",
+        "R6_telegram_active_low_authenticity",
+        "R7_bonding_curve_migration_risk",
+    }
+    actual_ids = {ctor().regime_id for ctor in ALL_REGIME_CONSTRUCTORS}
+    missing = expected_prefixes - actual_ids
+    assert not missing, f"Missing mandatory regimes: {missing}"
+
+
+def test_registry_regime_ids_are_unique():
+    """No duplicate regime_id across the registry."""
+    ids = [ctor().regime_id for ctor in ALL_REGIME_CONSTRUCTORS]
+    assert len(ids) == len(set(ids)), f"Duplicate regime_id present: {ids}"
+
+
+# ---------------------------------------------------------------------------
+# Per-regime tests (parametrized) — operator-patched policy
+# ---------------------------------------------------------------------------
+
+# Each regime is parametrized by its constructor function; pytest IDs use the
+# regime_id so failures are obvious.
+def _all_regimes():
+    return [pytest.param(ctor, id=ctor().regime_id) for ctor in ALL_REGIME_CONSTRUCTORS]
+
+
+@pytest.fixture
+def scoring_engine() -> DueDiligenceScoringEngine:
+    """Fresh deterministic engine per test."""
+    return DueDiligenceScoringEngine()
+
+
+@pytest.mark.parametrize("regime_ctor", _all_regimes())
+def test_regime_score_is_well_formed(regime_ctor, scoring_engine):
+    """The engine output for each regime is a structurally-valid score."""
+    regime = regime_ctor()
+    score = scoring_engine.score(
+        regime.candidate,
+        evaluation_time=FIXED_EVAL_TIME,
+        issuer_report=regime.issuer_report,
+        wallet_reports=regime.wallet_reports,
+        social_report=regime.social_report,
+        influencer_report=regime.influencer_report,
+    )
+
+    assert isinstance(score, TradeDueDiligenceScore)
+    # All 10 components are present and inside the [0, 100] range.
+    comps = component_scores(score)
+    assert set(comps.keys()) == {
+        "launch_timing", "issuer_history", "social_authenticity",
+        "telegram_quality", "influencer_risk", "holder_distribution",
+        "whale_risk", "prior_token_history", "bonding_curve", "rug_honeypot",
+    }
+    for name, v in comps.items():
+        assert 0.0 <= v <= 100.0, f"{regime.regime_id}: {name}={v} outside [0,100]"
+    assert 0.0 <= score.total_score <= 100.0
+    assert 0.0 <= score.risk_score <= 100.0
+    assert 0.0 <= score.evidence_confidence <= 1.0
+    # risk_score is the complement of total_score per engine convention.
+    assert abs((score.total_score + score.risk_score) - 100.0) < 0.01
+
+
+@pytest.mark.parametrize("regime_ctor", _all_regimes())
+def test_regime_band_is_valid(regime_ctor, scoring_engine):
+    """The decision band returned must be a valid DecisionBand value."""
+    regime = regime_ctor()
+    score = scoring_engine.score(
+        regime.candidate,
+        evaluation_time=FIXED_EVAL_TIME,
+        issuer_report=regime.issuer_report,
+        wallet_reports=regime.wallet_reports,
+        social_report=regime.social_report,
+        influencer_report=regime.influencer_report,
+    )
+    assert isinstance(score.decision_band, DecisionBand), (
+        f"{regime.regime_id}: decision_band must be a DecisionBand enum, "
+        f"got {type(score.decision_band)!r}"
+    )
+    # And it must be one of the four canonical values.
+    assert score.decision_band in {
+        DecisionBand.REJECT,
+        DecisionBand.OBSERVE,
+        DecisionBand.SIMULATE_ONLY,
+        DecisionBand.CANDIDATE_FOR_FUTURE_REVIEW,
+    }
+
+
+@pytest.mark.parametrize("regime_ctor", _all_regimes())
+def test_regime_no_band_authorizes_real_trading(regime_ctor, scoring_engine):
+    """No decision band may authorize real trading (boundary invariant).
+
+    `contracts.assert_no_real_trading_authorized(band)` is a runtime check
+    that asserts `not authorized_for_real_trading` — it passes silently
+    when the boundary is intact, and raises only if someone has flipped the
+    `authorized_for_real_trading` flag to True (i.e. removed the boundary).
+    This test calls it directly and lets a real raise propagate as a
+    boundary-violation test failure.
+    """
+    regime = regime_ctor()
+    score = scoring_engine.score(
+        regime.candidate,
+        evaluation_time=FIXED_EVAL_TIME,
+        issuer_report=regime.issuer_report,
+        wallet_reports=regime.wallet_reports,
+        social_report=regime.social_report,
+        influencer_report=regime.influencer_report,
+    )
+    # Must NOT raise — if it does, the Phase 0 boundary has been removed.
+    assert_no_real_trading_authorized(score.decision_band)
+
+
+@pytest.mark.parametrize("regime_ctor", _all_regimes())
+def test_regime_scoring_is_deterministic(regime_ctor, scoring_engine):
+    """Same regime scored twice in the same test → identical deterministic hash.
+
+    Post-#691 (clock fix): the scoring engine no longer reads an implicit
+    clock; `evaluation_time` is required and explicit. Passing the same
+    FIXED_EVAL_TIME to both calls produces byte-identical component scores
+    with no rounding mask. This test asserts true byte-identical determinism.
+    """
+    regime = regime_ctor()
+    score_a = scoring_engine.score(
+        regime.candidate,
+        evaluation_time=FIXED_EVAL_TIME,
+        issuer_report=regime.issuer_report,
+        wallet_reports=regime.wallet_reports,
+        social_report=regime.social_report,
+        influencer_report=regime.influencer_report,
+    )
+    score_b = scoring_engine.score(
+        regime.candidate,
+        evaluation_time=FIXED_EVAL_TIME,
+        issuer_report=regime.issuer_report,
+        wallet_reports=regime.wallet_reports,
+        social_report=regime.social_report,
+        influencer_report=regime.influencer_report,
+    )
+    hash_a = deterministic_hash(score_a)
+    hash_b = deterministic_hash(score_b)
+    assert hash_a == hash_b, (
+        f"{regime.regime_id}: scoring is nondeterministic. "
+        f"hash_a={hash_a} hash_b={hash_b}"
+    )
+    # And components are bit-equal between the two runs.
+    assert component_scores(score_a) == component_scores(score_b)
+
+
+@pytest.mark.parametrize("regime_ctor", _all_regimes())
+def test_regime_hard_disqualifiers_consistent_with_band(regime_ctor, scoring_engine):
+    """If any hard disqualifier triggers, the resulting band must be REJECT
+    or OBSERVE (per contracts.determine_decision_band)."""
+    regime = regime_ctor()
+    score = scoring_engine.score(
+        regime.candidate,
+        evaluation_time=FIXED_EVAL_TIME,
+        issuer_report=regime.issuer_report,
+        wallet_reports=regime.wallet_reports,
+        social_report=regime.social_report,
+        influencer_report=regime.influencer_report,
+    )
+    disqs = detect_hard_disqualifiers(score)
+    if disqs:
+        # rug_honeypot < 20 OR issuer_history < 20 force REJECT;
+        # evidence_confidence < 0.5 forces OBSERVE. Either way, band must
+        # NOT be SIMULATE_ONLY or CANDIDATE_FOR_FUTURE_REVIEW.
+        assert score.decision_band in {DecisionBand.REJECT, DecisionBand.OBSERVE}, (
+            f"{regime.regime_id}: hard disqualifiers {disqs} but band is "
+            f"{score.decision_band.value}"
+        )
+    # All disqualifier names belong to the documented set.
+    assert set(disqs).issubset(set(HARD_DISQUALIFIER_NAMES))
+
+
+# ---------------------------------------------------------------------------
+# Expected vs Actual — RECORDED, never blocking (per operator's patched policy)
+# ---------------------------------------------------------------------------
+
+def test_expected_vs_actual_table_is_complete_for_all_regimes(scoring_engine):
+    """Build the expected-vs-actual table for ALL regimes in one pass.
+
+    Failure modes (per patched policy):
+      - structurally-invalid result (missing field / wrong shape)
+      - nondeterministic across two re-runs
+      - boundary violation
+
+    NOT a failure: expected_band != actual_band. That is documented as the
+    regime's `band_match=False` row in the per-regime result.
+    """
+    required_fields = {
+        "regime_id",
+        "description",
+        "expected_band",
+        "actual_band",
+        "band_match",
+        "total_score",
+        "risk_score",
+        "evidence_confidence",
+        "component_scores",
+        "hard_disqualifiers_triggered",
+        "deterministic_hash",
+        "band_rationale",
+    }
+    rows: List[Dict[str, Any]] = []
+    for ctor in ALL_REGIME_CONSTRUCTORS:
+        regime = ctor()
+        score = scoring_engine.score(
+            regime.candidate,
+            evaluation_time=FIXED_EVAL_TIME,
+            issuer_report=regime.issuer_report,
+            wallet_reports=regime.wallet_reports,
+            social_report=regime.social_report,
+            influencer_report=regime.influencer_report,
+        )
+        result = build_regime_result(regime, score)
+        # Schema check
+        missing = required_fields - set(result.keys())
+        assert not missing, (
+            f"{regime.regime_id}: result row missing fields {missing}"
+        )
+        # actual_band must be a valid enum value string
+        assert result["actual_band"] in {b.value for b in DecisionBand}
+        rows.append(result)
+
+    # Determinism across the WHOLE pack: re-score every regime and compare
+    # hashes — protects against a regime whose RNG-like inputs would shift
+    # only when interleaved with others (none are expected; this is a guard).
+    rerun_hashes = []
+    for ctor in ALL_REGIME_CONSTRUCTORS:
+        regime = ctor()
+        score = scoring_engine.score(
+            regime.candidate,
+            evaluation_time=FIXED_EVAL_TIME,
+            issuer_report=regime.issuer_report,
+            wallet_reports=regime.wallet_reports,
+            social_report=regime.social_report,
+            influencer_report=regime.influencer_report,
+        )
+        rerun_hashes.append(deterministic_hash(score))
+    original_hashes = [r["deterministic_hash"] for r in rows]
+    assert rerun_hashes == original_hashes, (
+        "Pack-level determinism violation: per-regime hashes changed across "
+        "back-to-back full passes.\n"
+        f"original={original_hashes}\nrerun   ={rerun_hashes}"
+    )
+
+    # Print the full table to stdout so test runs (with -s) emit the evidence
+    # snapshot inline; audit doc consumes the same content via the helper
+    # script described in the audit. Pytest swallows by default unless -s,
+    # which is fine for normal CI.
+    print("\n[REGIME-PACK-EVIDENCE]")
+    print(json.dumps(rows, indent=2, sort_keys=True))
+
+
+# ---------------------------------------------------------------------------
+# Source-tree boundary proof (no Trade src/ mutation by this slice)
+# ---------------------------------------------------------------------------
+
+def test_fixture_file_does_not_touch_engine_internals():
+    """Sanity guard — the fixture file builds engine *inputs* only; it must
+    not reach into engine internals (e.g. _WEIGHTS dict, __setattr__ hooks,
+    enum extension hooks). The git-diff proof in the audit doc is the
+    authoritative no-mutation evidence; this is an in-suite tripwire so
+    a future fixture edit that crosses the boundary fails fast.
+
+    Forbidden surface tokens are assembled from fragments to avoid
+    self-referential matching against the literal in this test file.
+    """
+    src = _read_source("fixtures/due_diligence_regimes.py")
+    forbidden_surfaces = [
+        "DueDiligenceScoringEngine" + "._WEIGHTS",
+        "TradeDueDiligenceScore" + "._WEIGHTS",
+        "TradeDueDiligenceScore" + ".__setattr__",
+        "DecisionBand" + "._missing_",
+    ]
+    for bad in forbidden_surfaces:
+        assert bad not in src, (
+            f"Fixture file references engine-internal mutation surface: {bad!r}"
+        )


### PR DESCRIPTION
## Summary

7 named synthetic regimes exercising the deterministic due-diligence scoring engine (#687) post-clock-fix (#691). Decision-shape evidence with byte-identical determinism — **no rounding mask**.

## Post-#691 De-Rounding

The held local branch from before #691 used a rounded-hash workaround to tolerate `_utc_now()` drift. After #691 made `evaluation_time` explicit and removed the implicit clock, this PR:

- **Removed** `_HASH_ROUND_PRECISION` constant
- **Removed** all `round(score.X, 2)` calls in `deterministic_hash()` and `build_regime_result()`
- **Fixed** `_age_offset()` to use `FIXTURE_REFERENCE_TIME` (a fixed module constant) instead of `datetime.now()`
- **Threaded** explicit `evaluation_time=FIXED_EVAL_TIME` through all 8 `scoring_engine.score(...)` calls
- **Asserted** true byte-identical determinism via SHA-256 over raw float component scores

## 5 Decision-Shape Divergence Findings (Preserved)

The original W6 findings remain in the audit. Only hard disqualifiers (`rug_honeypot<20`, `issuer_history<20`, `evidence_confidence<0.5`) reliably move the decision band below `CANDIDATE_FOR_FUTURE_REVIEW` when other components are reasonable. 5 of 7 regimes show `expected_band != actual_band` — these are evidence findings, NOT slice failures. Routed to a future targeted engine-tuning slice via the audit doc.

## Scope: 5 files
- `modules/foundups/trade/tests/fixtures/__init__.py` (package marker)
- `modules/foundups/trade/tests/fixtures/due_diligence_regimes.py` (NEW, regime constructors + helpers)
- `modules/foundups/trade/tests/test_due_diligence_regimes.py` (NEW, 42 tests)
- `modules/foundups/trade/tests/TestModLog.md` (append)
- `docs/audits/architecture/TRADE_DUE_DILIGENCE_SYNTHETIC_REGIME_PACK_PHASE1.md` (NEW)

NO mutation of `modules/foundups/trade/src/**` (engine, contracts, harness untouched).

## Tests

```
python -m pytest modules/foundups/trade/tests/ -q
# 392 passed in 2.39s (350 existing + 42 new, 0 skipped, 0 rounded)
```

## WSP 97 Truth Boundary Checklist — 27/27 YES

Includes the two architect-required additions:
- `DETERMINISTIC_BYTE_IDENTICAL_REQUIRED = YES`
- `NO_ROUNDED_DETERMINISM_MASK = YES`

Plus all existing simulation/network/wallet/order/exchange/registry/catalog/manifest/projection/portfolio/public-surface/CI/deps/CABR/payout/DAO guards.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>