### PR TITLE
fix(antifafm): redact OBS WebSocket secrets from logs

### DIFF
--- a/docs/audits/architecture/OBS_WEBSOCKET_SECRET_LOGGING_FIX_PHASE1.md
+++ b/docs/audits/architecture/OBS_WEBSOCKET_SECRET_LOGGING_FIX_PHASE1.md
@@ -1,0 +1,105 @@
+# OBS_WEBSOCKET_SECRET_LOGGING_FIX_PHASE1
+
+## Status
+
+Implemented for W10 review.
+
+## Worker-Lane
+
+0102 implementation lane after W1/W3 audit findings.
+
+## Slice
+
+OBS_WEBSOCKET_SECRET_LOGGING_FIX_PHASE1
+
+## Problem
+
+The AntifaFM OBS WebSocket dependency path could emit OBS connection
+parameters through third-party `obsws_python` log records. The runtime audit
+found plaintext password fields in local log files. This is a P0 secret
+exposure boundary.
+
+This slice prevents future emission of OBS WebSocket passwords,
+authentication tokens, and stream keys through console or file logging. It
+does not rotate secrets and does not purge historical logs; those are
+operational actions outside the code slice.
+
+## Root Cause
+
+`OBS_WEBSOCKET_PASSWORD` is passed into `obsws_python.ReqClient(...)`. The
+third-party package may log connection parameters or object representations
+at INFO/WARNING levels. Repository root logging writes to stdout and
+`logs/foundups_agent.log`, so unredacted third-party records can persist.
+
+## Fix Shape
+
+Added a narrow OBS logging guard:
+
+- redaction filter for OBS password/authentication/key fields
+- known `obsws_python` logger suppression above INFO
+- guarded `create_obs_req_client()` helper
+- root logger installation after `logging.basicConfig(...)`
+- replacement of OBS client construction paths that read
+  `OBS_WEBSOCKET_PASSWORD`
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `main.py` | Install OBS logging guard after root logging setup |
+| `modules/platform_integration/antifafm_broadcaster/src/obs_logging_guard.py` | New redaction and client-construction helper |
+| `modules/platform_integration/antifafm_broadcaster/src/obs_controller.py` | Use guarded OBS client creation |
+| `modules/platform_integration/antifafm_broadcaster/skillz/boot_layer_rotator/executor.py` | Use guarded OBS client creation |
+| `modules/platform_integration/antifafm_broadcaster/skillz/news_maps/executor.py` | Use guarded OBS client creation |
+| `modules/platform_integration/antifafm_broadcaster/skillz/gcc_shipping_tracker/executor.py` | Use guarded OBS client creation |
+| `modules/platform_integration/antifafm_broadcaster/tests/test_obs_logging_guard.py` | New synthetic secret redaction tests |
+| `modules/platform_integration/antifafm_broadcaster/ModLog.md` | WSP 22 change entry |
+| `modules/platform_integration/antifafm_broadcaster/tests/TestModLog.md` | Test coverage entry |
+
+## Validation Contract
+
+All tests use synthetic secrets only.
+
+No test reads `.env`, prints a real password, connects to OBS, starts OBS,
+opens browser automation, or performs a network call.
+
+## Operational Follow-Up
+
+Because local logs already contained plaintext password fields before this
+slice, the OBS WebSocket password should be treated as compromised unless it
+has been rotated after the affected logs were produced.
+
+Recommended operational actions:
+
+1. Rotate the OBS WebSocket password.
+2. Redact or purge local affected log files.
+3. Keep the new guard in place to prevent recurrence.
+
+## Truth Boundary Checklist Item
+
+| # | Truth Boundary Checklist Item | Status | Evidence |
+|---|-------------------------------|--------|----------|
+| 1 | OBS_WEBSOCKET_SECRET_LOGGING_FIX_ONLY | YES | Scope is limited to OBS log redaction and affected client construction paths |
+| 2 | DEFAULT_NO_SECRET_LOGGING | YES | Guard installs root/handler filters and suppresses known obsws loggers |
+| 3 | SYNTHETIC_SECRET_TESTS_ONLY | YES | New tests use synthetic strings only |
+| 4 | NO_ENV_SECRET_READ_IN_TESTS | YES | Tests do not read `.env` or `OBS_WEBSOCKET_PASSWORD` |
+| 5 | NO_LIVE_OBS_CONNECTION_IN_TESTS | YES | Tests use a fake OBS module |
+| 6 | NO_NETWORK_CALL_IN_TESTS | YES | Tests only exercise logging and fake client construction |
+| 7 | NO_SECRET_VALUE_PRINTED | YES | Audit and tests contain no real password values |
+| 8 | NO_STREAM_KEY_EXPOSURE | YES | Redaction covers stream key and key fields |
+| 9 | HISTORICAL_LOG_ROTATION_NOT_PERFORMED | YES | Operational rotation/purge documented as follow-up |
+| 10 | NO_ANTIFAFM_STARTUP_BOUNDARY_CHANGE | YES | Startup auto-launch behavior is deferred to a separate slice |
+| 11 | NO_DEPENDENCY_CHANGE | YES | No new dependency added |
+| 12 | NO_CI_CHANGE | YES | No workflow files changed |
+| 13 | NO_REGISTRY_MUTATION | YES | No registry/catalog/manifest/projection files changed |
+| 14 | NO_PUBLIC_ROUTE_ACTIVATION | YES | No public surface changed |
+| 15 | NO_CABR_READY | YES | No readiness or governance promotion claimed |
+| 16 | NO_PAYOUT_READY | YES | No payout readiness claimed |
+| 17 | NO_DAO_ACTIVATION | YES | No DAO activation claimed |
+
+## Next Slice
+
+`MAIN_MENU_ANTIFAFM_STARTUP_BOUNDARY_FIX_PHASE1`
+
+That slice should remove or strictly gate the legacy `ANTIFAFM_AUTO_START`
+path that can launch OBS/metadata/rotator before the interactive menu.

--- a/main.py
+++ b/main.py
@@ -128,6 +128,15 @@ logging.basicConfig(
     ]
 )
 
+try:
+    from modules.platform_integration.antifafm_broadcaster.src.obs_logging_guard import (
+        install_obs_logging_guard,
+    )
+
+    install_obs_logging_guard()
+except Exception:
+    pass
+
 # Suppress noisy warnings from optional dependencies during startup
 import warnings
 

--- a/modules/platform_integration/antifafm_broadcaster/ModLog.md
+++ b/modules/platform_integration/antifafm_broadcaster/ModLog.md
@@ -1665,4 +1665,30 @@ modules/platform_integration/antifafm_broadcaster/
 
 ---
 
+## V1.3.7 - OBS WebSocket Secret Logging Guard (2026-05-26)
+
+**Context**: Runtime logs showed OBS WebSocket connection records could include
+the configured password in plaintext through third-party `obsws_python` logging.
+
+**Changes**:
+- Added `src/obs_logging_guard.py`
+  - redacts OBS WebSocket passwords, authentication values, and stream keys from
+    emitted log records
+  - raises known `obsws_python` loggers above INFO before client construction
+  - provides a guarded `create_obs_req_client()` helper
+- Updated OBS client construction paths that read `OBS_WEBSOCKET_PASSWORD`
+  - `src/obs_controller.py`
+  - `skillz/boot_layer_rotator/executor.py`
+  - `skillz/news_maps/executor.py`
+  - `skillz/gcc_shipping_tracker/executor.py`
+- Installed the guard after root logging setup in repository `main.py`.
+
+**Impact**:
+- Future OBS WebSocket connection logs redact secrets before console or file
+  handlers emit them.
+- Existing logs that already captured secrets still require operational rotation
+  and cleanup outside this code change.
+
+---
+
 *ModLog format per WSP 22*

--- a/modules/platform_integration/antifafm_broadcaster/skillz/boot_layer_rotator/executor.py
+++ b/modules/platform_integration/antifafm_broadcaster/skillz/boot_layer_rotator/executor.py
@@ -25,11 +25,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Any, List, Optional, Callable
 
+from modules.platform_integration.antifafm_broadcaster.src.obs_logging_guard import (
+    create_obs_req_client,
+    install_obs_logging_guard,
+)
+
 logger = logging.getLogger(__name__)
 
-# Suppress obsws_python password logging (security)
-logging.getLogger("obsws_python.baseclient").setLevel(logging.WARNING)
-logging.getLogger("obsws_python.reqs").setLevel(logging.WARNING)
+install_obs_logging_guard()
 
 # Telemetry path for event logging
 TELEMETRY_DIR = Path(__file__).parent.parent.parent / "telemetry"
@@ -210,7 +213,12 @@ def _get_obs_client():
         port = int(os.getenv("OBS_WEBSOCKET_PORT", 4455))
         password = os.getenv("OBS_WEBSOCKET_PASSWORD", "")
 
-        _obs_client = obs.ReqClient(host=host, port=port, password=password)
+        _obs_client = create_obs_req_client(
+            obs,
+            host=host,
+            port=port,
+            password=password,
+        )
         logger.info(f"[ROTATOR] OBS WebSocket connected to {host}:{port}")
         return _obs_client
 

--- a/modules/platform_integration/antifafm_broadcaster/skillz/gcc_shipping_tracker/executor.py
+++ b/modules/platform_integration/antifafm_broadcaster/skillz/gcc_shipping_tracker/executor.py
@@ -28,6 +28,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, Any, List, Optional
 
+from modules.platform_integration.antifafm_broadcaster.src.obs_logging_guard import (
+    create_obs_req_client,
+)
+
 logger = logging.getLogger(__name__)
 
 # Screenshot cache directory (012 behavior - fetch once, display cached)
@@ -438,7 +442,7 @@ async def update_obs_browser_source(url: str, fallback_on_fail: bool = True) -> 
         port = int(os.getenv("OBS_WEBSOCKET_PORT", 4455))
         password = os.getenv("OBS_WEBSOCKET_PASSWORD", "")
 
-        client = obs.ReqClient(host=host, port=port, password=password)
+        client = create_obs_req_client(obs, host=host, port=port, password=password)
 
         # Browser source name (env var or default to existing)
         source_name = os.getenv("OBS_BROWSER_SOURCE", "antifaFM Website")

--- a/modules/platform_integration/antifafm_broadcaster/skillz/news_maps/executor.py
+++ b/modules/platform_integration/antifafm_broadcaster/skillz/news_maps/executor.py
@@ -30,6 +30,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from modules.platform_integration.antifafm_broadcaster.src.obs_logging_guard import (
+    create_obs_req_client,
+)
+
 logger = logging.getLogger(__name__)
 
 # Cache directories
@@ -298,7 +302,7 @@ async def update_obs_image_source(source_name: str, image_path: Path) -> Dict[st
         port = int(os.getenv("OBS_WEBSOCKET_PORT", 4455))
         password = os.getenv("OBS_WEBSOCKET_PASSWORD", "")
 
-        client = obs.ReqClient(host=host, port=port, password=password)
+        client = create_obs_req_client(obs, host=host, port=port, password=password)
         client.set_input_settings(
             name=source_name,
             settings={"file": str(image_path.absolute())},

--- a/modules/platform_integration/antifafm_broadcaster/src/obs_controller.py
+++ b/modules/platform_integration/antifafm_broadcaster/src/obs_controller.py
@@ -28,11 +28,17 @@ import os
 import time
 from typing import Optional, Dict, Any, Tuple
 
+from modules.platform_integration.antifafm_broadcaster.src.obs_logging_guard import (
+    create_obs_req_client,
+    install_obs_logging_guard,
+)
+
 logger = logging.getLogger(__name__)
 
 # Use obsws-python (v5 protocol for OBS 28+)
 OBS_CLIENT = None
 try:
+    install_obs_logging_guard()
     import obsws_python as obs
     OBS_CLIENT = "obsws_python"
 except ImportError:
@@ -66,7 +72,12 @@ class OBSController:
             return False
 
         try:
-            self.ws = obs.ReqClient(host=self.host, port=self.port, password=self.password)
+            self.ws = create_obs_req_client(
+                obs,
+                host=self.host,
+                port=self.port,
+                password=self.password,
+            )
             self.connected = True
             logger.info(f"[OBS] Connected to OBS on {self.host}:{self.port}")
             return True

--- a/modules/platform_integration/antifafm_broadcaster/src/obs_logging_guard.py
+++ b/modules/platform_integration/antifafm_broadcaster/src/obs_logging_guard.py
@@ -1,0 +1,91 @@
+"""OBS logging guard for third-party WebSocket clients.
+
+The obsws_python package can include connection parameters in log records and
+object representations. This module installs a narrow redaction filter and
+raises known obsws loggers above INFO before constructing any OBS client.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+
+_REDACTED = "<redacted>"
+_OBS_LOGGER_NAMES = (
+    "obsws_python",
+    "obsws_python.baseclient",
+    "obsws_python.baseclient.ObsClient",
+    "obsws_python.reqs",
+    "obsws_python.reqs.ReqClient",
+)
+
+_SECRET_PATTERNS = (
+    re.compile(r"(?P<prefix>\bpassword\s*=\s*)'[^']*'", re.IGNORECASE),
+    re.compile(r'(?P<prefix>\bpassword\s*=\s*)"[^"]*"', re.IGNORECASE),
+    re.compile(r"(?P<prefix>\bpassword\s*=\s*)([^,\s)]+)", re.IGNORECASE),
+    re.compile(r"(?P<prefix>['\"]password['\"]\s*:\s*)'[^']*'", re.IGNORECASE),
+    re.compile(r'(?P<prefix>[\'"]password[\'"]\s*:\s*)"[^"]*"', re.IGNORECASE),
+    re.compile(r"(?P<prefix>['\"]authentication['\"]\s*:\s*)'[^']*'", re.IGNORECASE),
+    re.compile(r'(?P<prefix>[\'"]authentication[\'"]\s*:\s*)"[^"]*"', re.IGNORECASE),
+    re.compile(r"(?P<prefix>\bauthentication\s*=\s*)'[^']*'", re.IGNORECASE),
+    re.compile(r'(?P<prefix>\bauthentication\s*=\s*)"[^"]*"', re.IGNORECASE),
+    re.compile(r"(?P<prefix>['\"]key['\"]\s*:\s*)'[^']+'", re.IGNORECASE),
+    re.compile(r'(?P<prefix>[\'"]key[\'"]\s*:\s*)"[^"]+"', re.IGNORECASE),
+    re.compile(r"(?P<prefix>\bkey\s*=\s*)'[^']+'", re.IGNORECASE),
+    re.compile(r'(?P<prefix>\bkey\s*=\s*)"[^"]+"', re.IGNORECASE),
+    re.compile(r"(?P<prefix>\bstream_key\s*=\s*)'[^']+'", re.IGNORECASE),
+    re.compile(r'(?P<prefix>\bstream_key\s*=\s*)"[^"]+"', re.IGNORECASE),
+)
+
+
+def redact_obs_log_message(value: Any) -> str:
+    """Return a log-safe string with OBS credentials redacted."""
+    text = str(value)
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub(lambda match: f"{match.group('prefix')}'{_REDACTED}'", text)
+    return text
+
+
+class OBSSecretRedactionFilter(logging.Filter):
+    """Redact OBS/WebSocket secrets from log records before handlers emit them."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.msg = redact_obs_log_message(record.getMessage())
+        record.args = ()
+        return True
+
+
+def _has_redaction_filter(target: Any) -> bool:
+    return any(isinstance(filter_, OBSSecretRedactionFilter) for filter_ in target.filters)
+
+
+def _attach_filter(target: Any) -> None:
+    if not _has_redaction_filter(target):
+        target.addFilter(OBSSecretRedactionFilter())
+
+
+def install_obs_logging_guard() -> None:
+    """Install OBS log redaction and suppress known verbose obsws loggers.
+
+    This function is idempotent and safe to call before every OBS client
+    construction.
+    """
+    root = logging.getLogger()
+    _attach_filter(root)
+    for handler in root.handlers:
+        _attach_filter(handler)
+
+    for logger_name in _OBS_LOGGER_NAMES:
+        obs_logger = logging.getLogger(logger_name)
+        obs_logger.setLevel(logging.WARNING)
+        _attach_filter(obs_logger)
+        for handler in obs_logger.handlers:
+            _attach_filter(handler)
+
+
+def create_obs_req_client(obs_module: Any, *, host: str, port: int, password: str) -> Any:
+    """Create an obsws_python ReqClient after installing the logging guard."""
+    install_obs_logging_guard()
+    return obs_module.ReqClient(host=host, port=port, password=password)

--- a/modules/platform_integration/antifafm_broadcaster/tests/TestModLog.md
+++ b/modules/platform_integration/antifafm_broadcaster/tests/TestModLog.md
@@ -288,6 +288,12 @@ dropdown_verified = verify_dropdown_appeared(driver, timeout=5)
 
 ## Planned Tests
 
+### `test_obs_logging_guard.py`
+- Verifies synthetic OBS WebSocket passwords are redacted from formatted log records.
+- Verifies `obsws_python` logger levels are raised above INFO.
+- Verifies guarded OBS client construction redacts constructor-time third-party logs.
+- Uses synthetic secrets only; does not read `.env`, connect to OBS, or run network calls.
+
 ### `test_ffmpeg_stream.py` (TODO)
 - Test FFmpeg command generation
 - Test RTMP connection to YouTube

--- a/modules/platform_integration/antifafm_broadcaster/tests/test_obs_logging_guard.py
+++ b/modules/platform_integration/antifafm_broadcaster/tests/test_obs_logging_guard.py
@@ -1,0 +1,100 @@
+"""Tests for OBS WebSocket secret log redaction."""
+
+from __future__ import annotations
+
+import io
+import logging
+
+from modules.platform_integration.antifafm_broadcaster.src.obs_logging_guard import (
+    OBSSecretRedactionFilter,
+    create_obs_req_client,
+    install_obs_logging_guard,
+    redact_obs_log_message,
+)
+
+
+SYNTHETIC_PASSWORD = "synthetic-obs-password"
+SYNTHETIC_AUTH = "synthetic-auth-token"
+SYNTHETIC_STREAM_KEY = "synthetic-stream-key"
+
+
+def test_redact_obs_log_message_masks_password_authentication_and_keys():
+    message = (
+        "ReqClient(host='localhost', password='synthetic-obs-password', "
+        "authentication=\"synthetic-auth-token\", key='synthetic-stream-key', "
+        "stream_key=\"synthetic-stream-key\")"
+    )
+
+    redacted = redact_obs_log_message(message)
+
+    assert SYNTHETIC_PASSWORD not in redacted
+    assert SYNTHETIC_AUTH not in redacted
+    assert SYNTHETIC_STREAM_KEY not in redacted
+    assert redacted.count("<redacted>") >= 4
+
+
+def test_redaction_filter_masks_formatted_log_record():
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.addFilter(OBSSecretRedactionFilter())
+    logger = logging.getLogger("tests.obs_redaction_filter")
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+    try:
+        logger.info("OBS connect password='%s'", SYNTHETIC_PASSWORD)
+    finally:
+        logger.removeHandler(handler)
+
+    output = stream.getvalue()
+    assert SYNTHETIC_PASSWORD not in output
+    assert "password='<redacted>'" in output
+
+
+def test_install_obs_logging_guard_suppresses_known_obsws_info_loggers():
+    install_obs_logging_guard()
+
+    for logger_name in (
+        "obsws_python",
+        "obsws_python.baseclient",
+        "obsws_python.reqs",
+    ):
+        assert logging.getLogger(logger_name).getEffectiveLevel() >= logging.WARNING
+
+
+def test_create_obs_req_client_redacts_third_party_constructor_logs():
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    obs_logger = logging.getLogger("obsws_python.baseclient")
+    obs_logger.addHandler(handler)
+    obs_logger.setLevel(logging.WARNING)
+    obs_logger.propagate = False
+
+    class FakeObsModule:
+        class ReqClient:
+            def __init__(self, *, host, port, password):
+                self.host = host
+                self.port = port
+                self.password = password
+                logging.getLogger("obsws_python.baseclient").warning(
+                    "ReqClient(host='%s', port=%s, password='%s')",
+                    host,
+                    port,
+                    password,
+                )
+
+    try:
+        client = create_obs_req_client(
+            FakeObsModule,
+            host="localhost",
+            port=4455,
+            password=SYNTHETIC_PASSWORD,
+        )
+    finally:
+        obs_logger.removeHandler(handler)
+
+    output = stream.getvalue()
+    assert client.password == SYNTHETIC_PASSWORD
+    assert SYNTHETIC_PASSWORD not in output
+    assert "password='<redacted>'" in output


### PR DESCRIPTION
﻿## Summary

Closes the P0 OBS WebSocket secret-logging boundary surfaced during worktree/runtime triage.

Changes:
- Adds `obs_logging_guard.py` for OBS/WebSocket secret redaction and guarded `ReqClient` creation.
- Installs the guard after root logging setup in `main.py`.
- Routes OBS client construction paths that read `OBS_WEBSOCKET_PASSWORD` through the guard.
- Adds synthetic-only tests for password/authentication/stream-key redaction.
- Adds ModLog/TestModLog entries and an audit doc with WSP_97 checklist.

## Root Cause

`obsws_python.ReqClient(...)` can emit connection parameters through third-party logger records/object representations. Repository logging writes to stdout and `logs/foundups_agent.log`, so unredacted OBS password fields can persist in local logs.

## Validation

- `python -m pytest modules/platform_integration/antifafm_broadcaster/tests/test_obs_logging_guard.py -q` -> 4 passed
- `python -m pytest modules/platform_integration/antifafm_broadcaster/tests/test_obs_controller_startup.py -q` -> 11 passed
- `python -m pytest modules/platform_integration/antifafm_broadcaster/tests/test_boot_layer_rotator.py -q` -> 16 passed
- `python -m pytest modules/platform_integration/antifafm_broadcaster/tests/test_gcc_shipping_tracker.py -q` -> 22 passed

## Boundary

- No real secret values read or printed.
- No `.env` read in tests.
- No live OBS connection in tests.
- No network calls in tests.
- No dependency or CI changes.
- Historical log rotation/purge is documented as an operational follow-up, not performed in this PR.

## WSP_97

See `docs/audits/architecture/OBS_WEBSOCKET_SECRET_LOGGING_FIX_PHASE1.md`: 17/17 YES.
