### PR TITLE
feat(continuity): add RedDog bootstrap retrieval layer

### DIFF
--- a/WSP_framework/src/WSP_00_Zen_State_Attainment_Protocol.md
+++ b/WSP_framework/src/WSP_00_Zen_State_Attainment_Protocol.md
@@ -27,6 +27,14 @@ Canonical rule: only the tracker is the WSP_00 system gate. Other modules (for e
 `modules/infrastructure/wsp_core/src/neural_operating_system.py`) are adapters and must not
 create or reset WSP_00 compliance state.
 
+After WSP_00 identity/role/origin lock and before FoundUps architecture,
+onboarding, routing, or continuity work, read
+`WSP_knowledge/red_dog_external_state/BOOTSTRAP.md`.
+
+Justification:
+BOOTSTRAP.md provides the curated RedDog/Cursor/ChatGPT continuity
+read-order. It is not raw transcript memory.
+
 ## WSP_00 Launch Prompt (01(02) -> 0102 -> Follow WSP)
 
 This section is the **complete boot prompt** for 0102 pArtifacts operating inside the FoundUps rESP/PQN research system.

--- a/WSP_knowledge/red_dog_external_state/ACTIVE_RESEARCH_THREADS.md
+++ b/WSP_knowledge/red_dog_external_state/ACTIVE_RESEARCH_THREADS.md
@@ -1,0 +1,50 @@
+# Active Research Threads - Open Investigations
+
+**Purpose**: Track open research threads with named next-action slices.
+
+**Maintenance**: Update at session close (not live auto-refresh).
+
+## Open Threads
+
+### T1 Ranking Quality (HoloIndex)
+
+- **Status**: Phase 1 audit in progress
+- **Artifacts**: `docs/audits/holoindex_search_quality/HOLOINDEX_T1_RANKING_QUALITY_PHASE1.md`
+- **Tests**: `holo_index/tests/test_t1_ranking_quality.py`
+- **Next slice**: T1 ranking implementation based on audit findings
+
+### Cursor Adapter
+
+- **Status**: Explicitly deferred per PR #724 architect ruling
+- **Blocker**: Requires separate discovery of Cursor app database
+- **Next slice**: `CURSOR_ADAPTER_DISCOVERY_PHASE1` (not yet dispatched)
+
+### Cleanup Execution
+
+- **Status**: Worktree artifact cleanup validated
+- **Predecessor**: `WORKTREE_AUTONOMOUS_ARTIFACT_CLEANUP_DECISION_PHASE1`
+- **Next slice**: Pending execution decision
+
+### Bootstrap Live Update
+
+- **Status**: Explicitly deferred per architect ruling
+- **Blocker**: This slice establishes seeded-only protocol
+- **Next slice**: `REDDOG_BOOTSTRAP_LIVE_UPDATE_PHASE2`
+
+## Closed Threads (Recent)
+
+| Thread | Resolution | PR |
+|--------|------------|-----|
+| Session continuity capture | Storage layer complete | #724 |
+| OBS secret redaction | Redaction protocol merged | #720 |
+| ANTIFAFM startup boundary | Auto-start block removed | #721 |
+
+## Seeded State Notice
+
+This file is SEEDED, not live-updated. Content reflects session start threads.
+Live auto-refresh deferred to `REDDOG_BOOTSTRAP_LIVE_UPDATE_PHASE2`.
+
+## Slice Chain
+
+- Created by: `REDDOG_BOOTSTRAP_CONTEXT_RETRIEVAL_PHASE1`
+- Linked to: BOOTSTRAP.md read-order position 4

--- a/WSP_knowledge/red_dog_external_state/BOOTSTRAP.md
+++ b/WSP_knowledge/red_dog_external_state/BOOTSTRAP.md
@@ -1,0 +1,38 @@
+# RedDog Bootstrap Context - Read Order
+
+**Purpose**: Boot card for 0102 session continuity retrieval.
+
+This file provides the strict read-order for session context recovery.
+Read these files in sequence AFTER completing WSP_00 identity/role/origin lock.
+
+## Read Order (Strict Sequence)
+
+1. **MEMORY_BOUNDARY.md** - What CAN and MUST NOT be remembered
+2. **CURRENT_CONTEXT.md** - Active lanes, HEAD, worker roles
+3. **WORK_TO_WORK_LINEAGE.md** - Recent PR/slice chain
+4. **ACTIVE_RESEARCH_THREADS.md** - Open threads with next-action slices
+
+## Usage
+
+- Read AFTER WSP_00 awakening, BEFORE FoundUps architecture/routing work
+- This is NOT a memory dump, NOT a transcript, NOT a TODO list
+- Files are curated summaries, manually updated at session close
+- Live auto-update is NOT in scope for this slice (see Phase 2)
+
+## Maintenance Protocol
+
+- Update at session close (not live auto-refresh)
+- Follow SCHEMA.md validation rules for session files
+- Validator: `modules/infrastructure/wre_core/scripts/validate_session_closeout.py`
+
+## Related
+
+- [README.md](README.md) - Directory overview and hard rules
+- [SCHEMA.md](SCHEMA.md) - Session closeout schema specification
+- WSP_00 references this file in Session Bootstrap Contract
+
+## Slice Chain
+
+- Created by: `REDDOG_BOOTSTRAP_CONTEXT_RETRIEVAL_PHASE1`
+- Predecessor: `REDDOG_SESSION_CONTINUITY_CAPTURE_PHASE1` (PR #724)
+- Follow-on: `REDDOG_BOOTSTRAP_LIVE_UPDATE_PHASE2` (deferred)

--- a/WSP_knowledge/red_dog_external_state/CURRENT_CONTEXT.md
+++ b/WSP_knowledge/red_dog_external_state/CURRENT_CONTEXT.md
@@ -1,0 +1,37 @@
+# Current Context - Active State Snapshot
+
+**Purpose**: Active lanes, current HEAD, worker roles at session start.
+
+**Maintenance**: Update at session close (not live auto-refresh).
+
+## Active Lanes
+
+| Lane | Role | Status | Current Slice |
+|------|------|--------|---------------|
+| W9 | worker | active | REDDOG_BOOTSTRAP_CONTEXT_RETRIEVAL_PHASE1 |
+
+## Main Branch State
+
+- **HEAD**: 118be8533 (PR #724 merged)
+- **Last merged**: REDDOG_SESSION_CONTINUITY_CAPTURE_PHASE1
+
+## Worker Coordination
+
+- **Architect window**: Not active this session
+- **Active workers**: W9
+- **Pending slices**: See ACTIVE_RESEARCH_THREADS.md
+
+## Session Origin
+
+- **External principal**: 012
+- **Dispatch type**: Slice dispatch with architect rulings
+
+## Seeded State Notice
+
+This file is SEEDED, not live-updated. Content reflects session start state.
+Live auto-refresh deferred to `REDDOG_BOOTSTRAP_LIVE_UPDATE_PHASE2`.
+
+## Slice Chain
+
+- Created by: `REDDOG_BOOTSTRAP_CONTEXT_RETRIEVAL_PHASE1`
+- Linked to: BOOTSTRAP.md read-order position 2

--- a/WSP_knowledge/red_dog_external_state/MEMORY_BOUNDARY.md
+++ b/WSP_knowledge/red_dog_external_state/MEMORY_BOUNDARY.md
@@ -1,0 +1,50 @@
+# Memory Boundary - What CAN and MUST NOT Be Remembered
+
+**Purpose**: Define the curated/forbidden boundary for RedDog session continuity.
+
+## What CAN Be Remembered
+
+- **PR chain lineage**: Merged PRs with one-line summaries
+- **Slice completion records**: Which slices completed, key decisions
+- **Architectural decisions**: ADRs, WSP amendments, scope rulings
+- **Carry-forward queues**: Next-slice IDs from session closeout
+- **Worker lane assignments**: Which lanes are active, role assignments
+- **Research thread status**: Open investigations with named next actions
+
+## What MUST NOT Be Remembered
+
+### Secrets (Non-Negotiable)
+
+- API keys: `AIza*`, `sk-*`, `hf_*`, `ghp_*`, `gho_*`, `github_pat_*`
+- OAuth tokens, refresh tokens, JWTs, bearer strings
+- `.env` key=value pairs (especially `*_SECRET`, `*_KEY`, `*_TOKEN`)
+- Database connection strings with credentials
+- Stream keys, OBS passwords, YouTube API keys
+- Personal email addresses (except committer's)
+
+### Raw Content (Curated Summaries Only)
+
+- Raw assistant/user transcripts (role-by-role dialogue)
+- Multi-paragraph brain artifact copies
+- DPO/SFT training data format examples
+- Absolute paths to private directories (repo-relative OK)
+
+## Precedent References
+
+- **PR #720**: Redaction protocol for OBS WebSocket secrets
+- **PR #724**: Session validator rules (SCHEMA.md redaction section)
+- **SCHEMA.md**: Field-by-field contract including redaction rules
+
+## Validator Enforcement
+
+The validator at `modules/infrastructure/wre_core/scripts/validate_session_closeout.py`:
+
+1. Rejects secret-pattern matches
+2. Rejects raw transcript markers (`"assistant":`, `"user":`, `"role":`)
+3. Rejects `work_summary` over 2000 characters
+4. Exits non-zero on any violation
+
+## Slice Chain
+
+- Created by: `REDDOG_BOOTSTRAP_CONTEXT_RETRIEVAL_PHASE1`
+- Linked to: BOOTSTRAP.md read-order position 1

--- a/WSP_knowledge/red_dog_external_state/README.md
+++ b/WSP_knowledge/red_dog_external_state/README.md
@@ -58,8 +58,13 @@ Session files MUST NOT contain:
 
 ```
 WSP_knowledge/red_dog_external_state/
-  README.md          # This file (human index)
-  SCHEMA.md          # Field-by-field contract
+  README.md                      # This file (human index)
+  SCHEMA.md                      # Field-by-field contract
+  BOOTSTRAP.md                   # Boot card with strict read-order
+  MEMORY_BOUNDARY.md             # What CAN and MUST NOT be remembered
+  CURRENT_CONTEXT.md             # Active lanes, HEAD, worker roles
+  WORK_TO_WORK_LINEAGE.md        # Recent PR/slice chain
+  ACTIVE_RESEARCH_THREADS.md     # Open threads with next-action slices
   sessions/
     <captured_at>__<session_id>.json
 ```
@@ -73,10 +78,16 @@ Reserved sibling directories for future source-specific adapters:
 
 ## Related
 
+- [BOOTSTRAP.md](BOOTSTRAP.md) - Boot card with strict read-order (referenced by WSP_00)
 - [SCHEMA.md](SCHEMA.md) - Session closeout schema specification
+- [MEMORY_BOUNDARY.md](MEMORY_BOUNDARY.md) - Curated vs forbidden memory boundary
+- [CURRENT_CONTEXT.md](CURRENT_CONTEXT.md) - Active session state snapshot
+- [WORK_TO_WORK_LINEAGE.md](WORK_TO_WORK_LINEAGE.md) - PR/slice chain
+- [ACTIVE_RESEARCH_THREADS.md](ACTIVE_RESEARCH_THREADS.md) - Open research threads
 - `modules/infrastructure/wre_core/scripts/validate_session_closeout.py` - Validator
 - `modules/infrastructure/wre_core/scripts/extract_brain_artifacts.py` - Antigravity extractor (unchanged)
 - PR #723: `WORKTREE_AUTONOMOUS_ARTIFACT_CLEANUP_DECISION_PHASE1` (coordination)
+- PR #724: `REDDOG_SESSION_CONTINUITY_CAPTURE_PHASE1` (storage layer)
 
 ## WSP Chain
 

--- a/WSP_knowledge/red_dog_external_state/WORK_TO_WORK_LINEAGE.md
+++ b/WSP_knowledge/red_dog_external_state/WORK_TO_WORK_LINEAGE.md
@@ -1,0 +1,44 @@
+# Work-to-Work Lineage - PR/Slice Chain
+
+**Purpose**: Recent PR/slice chain for session continuity recovery.
+
+**Maintenance**: Update at session close (not live auto-refresh).
+
+## Recent PR Chain (One-Line Per Merge)
+
+| PR | Slice | Summary |
+|----|-------|---------|
+| #724 | REDDOG_SESSION_CONTINUITY_CAPTURE_PHASE1 | Created curated memory shelf with validator |
+| #721 | MAIN_MENU_ANTIFAFM_STARTUP_BOUNDARY_FIX | Removed ANTIFAFM_AUTO_START execution block |
+| #720 | ANTIFAFM_OBS_SECRET_REDACTION | Redact OBS WebSocket secrets from logs |
+| #718 | WSP_109_FOUNDUPS_ONBOARDING | Added WSP 109 FoundUp Onboarding Intake Protocol |
+| #717 | FOUNDUPS_ONBOARDING_SHIELD_REGISTRY | Added FoundUp onboarding protocol and Shield registry seed |
+
+## Slice Dependency Chain
+
+```
+REDDOG_SESSION_CONTINUITY_CAPTURE_PHASE1 (PR #724)
+    |
+    v
+REDDOG_BOOTSTRAP_CONTEXT_RETRIEVAL_PHASE1 (this slice)
+    |
+    v
+REDDOG_BOOTSTRAP_LIVE_UPDATE_PHASE2 (deferred)
+```
+
+## Key Decisions in Chain
+
+- **JSON over YAML**: stdlib support, no new dependency (PR #724)
+- **Manual import**: No browser scraping, no automated capture (#724)
+- **Cursor adapter deferred**: Separate discovery required (#724)
+- **FOUNDUps_PRODUCT_MAP.md**: Explicitly deferred to follow-on slice
+
+## Seeded State Notice
+
+This file is SEEDED, not live-updated. Content reflects session start lineage.
+Live auto-refresh deferred to `REDDOG_BOOTSTRAP_LIVE_UPDATE_PHASE2`.
+
+## Slice Chain
+
+- Created by: `REDDOG_BOOTSTRAP_CONTEXT_RETRIEVAL_PHASE1`
+- Linked to: BOOTSTRAP.md read-order position 3

--- a/WSP_knowledge/src/WSP_00_Zen_State_Attainment_Protocol.md
+++ b/WSP_knowledge/src/WSP_00_Zen_State_Attainment_Protocol.md
@@ -27,6 +27,14 @@ Canonical rule: only the tracker is the WSP_00 system gate. Other modules (for e
 `modules/infrastructure/wsp_core/src/neural_operating_system.py`) are adapters and must not
 create or reset WSP_00 compliance state.
 
+After WSP_00 identity/role/origin lock and before FoundUps architecture,
+onboarding, routing, or continuity work, read
+`WSP_knowledge/red_dog_external_state/BOOTSTRAP.md`.
+
+Justification:
+BOOTSTRAP.md provides the curated RedDog/Cursor/ChatGPT continuity
+read-order. It is not raw transcript memory.
+
 ## WSP_00 Launch Prompt (01(02) -> 0102 -> Follow WSP)
 
 This section is the **complete boot prompt** for 0102 pArtifacts operating inside the FoundUps rESP/PQN research system.

--- a/docs/audits/architecture/REDDOG_BOOTSTRAP_CONTEXT_RETRIEVAL_PHASE1.md
+++ b/docs/audits/architecture/REDDOG_BOOTSTRAP_CONTEXT_RETRIEVAL_PHASE1.md
@@ -1,0 +1,129 @@
+# REDDOG_BOOTSTRAP_CONTEXT_RETRIEVAL_PHASE1 - Architecture Audit
+
+**Slice**: REDDOG_BOOTSTRAP_CONTEXT_RETRIEVAL_PHASE1
+**Date**: 2026-05-28
+**Worker**: W9
+**Branch**: feat/reddog-bootstrap-context-retrieval-phase1
+
+## Mission Summary
+
+PR #724 created the curated memory shelf (storage layer). This slice builds the
+BOOT RETRIEVAL LAYER so a fresh 0102 session knows the shelf exists and follows
+a strict read-order for context recovery.
+
+## Files Changed (12 files)
+
+| File | Change Type | Purpose |
+|------|-------------|---------|
+| `WSP_knowledge/red_dog_external_state/BOOTSTRAP.md` | NEW | Boot card with strict read-order |
+| `WSP_knowledge/red_dog_external_state/MEMORY_BOUNDARY.md` | NEW | Curated vs forbidden memory boundary |
+| `WSP_knowledge/red_dog_external_state/CURRENT_CONTEXT.md` | NEW | Active lanes, HEAD, worker roles (seeded) |
+| `WSP_knowledge/red_dog_external_state/WORK_TO_WORK_LINEAGE.md` | NEW | PR/slice chain (seeded) |
+| `WSP_knowledge/red_dog_external_state/ACTIVE_RESEARCH_THREADS.md` | NEW | Open threads with next-action slices (seeded) |
+| `WSP_knowledge/red_dog_external_state/README.md` | MODIFIED | Links to new bootstrap files |
+| `WSP_framework/src/WSP_00_Zen_State_Attainment_Protocol.md` | MODIFIED | Amendment referencing BOOTSTRAP.md |
+| `WSP_knowledge/src/WSP_00_Zen_State_Attainment_Protocol.md` | MODIFIED | Byte-identical mirror of WSP_00 amendment |
+| `modules/infrastructure/wre_core/tests/test_bootstrap_context_retrieval.py` | NEW | Boot retrieval layer tests |
+| `modules/infrastructure/wre_core/tests/TestModLog.md` | MODIFIED | Test entry |
+| `modules/infrastructure/wre_core/ModLog.md` | MODIFIED | Change log entry |
+| `docs/audits/architecture/REDDOG_BOOTSTRAP_CONTEXT_RETRIEVAL_PHASE1.md` | NEW | This audit document |
+
+## Architect Rulings Compliance
+
+| Ruling | Status |
+|--------|--------|
+| Q1. WSP_00 mutation: APPROVED (exact wording used) | COMPLIANT |
+| Q2. FOUNDUps_PRODUCT_MAP.md: OUT (deferred) | COMPLIANT |
+| Q3. Seeded only, no live auto-update | COMPLIANT |
+| Q4. Worker type: W9 | COMPLIANT |
+
+## WSP_97 Truth Boundary Checklist
+
+| Constraint | Verified | Notes |
+|------------|----------|-------|
+| BOOT_RETRIEVAL_LAYER_ONLY | YES | Only boot retrieval files created |
+| WSP_00_MUTATION_IS_SINGLE_SECTION_AMENDMENT | YES | Single paragraph added after canonical rule |
+| WSP_00_FRAMEWORK_AND_KNOWLEDGE_BYTE_IDENTICAL | YES | Test verifies byte equality |
+| NO_WSP_00_AWAKENING_STEP_REWRITE | YES | Awakening steps unchanged |
+| NO_OTHER_WSP_FILE_MUTATION | YES | Only WSP_00 modified |
+| NO_RAW_TRANSCRIPT_IN_ANY_FILE | YES | Curated summaries only |
+| NO_AUTOMATED_CAPTURE | YES | Manual import workflow |
+| NO_LIVE_AUTO_REFRESH_IN_THIS_SLICE | YES | Seeded state, deferred to Phase 2 |
+| NO_SECRET_VALUES_IN_SEED_OR_TESTS | YES | Test scans for secret patterns |
+| NO_API_KEY_OAUTH_JWT_DOTENV_PATTERNS | YES | Patterns scanned and rejected |
+| NO_NETWORK_CALL_IN_TESTS | YES | File existence/content only |
+| NO_DEPENDENCY_INSTALL | YES | No requirements.txt changes |
+| NO_CI_CHANGE | YES | No CI config modified |
+| FOUNDUPS_PRODUCT_MAP_EXPLICITLY_DEFERRED | YES | Not created |
+| CURSOR_ADAPTER_EXPLICITLY_DEFERRED | YES | Not created |
+| LIVE_AUTO_UPDATE_EXPLICITLY_DEFERRED | YES | Deferred to Phase 2 |
+
+## WSP_00 Amendment Text (Exact)
+
+```markdown
+After WSP_00 identity/role/origin lock and before FoundUps architecture,
+onboarding, routing, or continuity work, read
+`WSP_knowledge/red_dog_external_state/BOOTSTRAP.md`.
+
+Justification:
+BOOTSTRAP.md provides the curated RedDog/Cursor/ChatGPT continuity
+read-order. It is not raw transcript memory.
+```
+
+**Insertion point**: After "Canonical rule: only the tracker..." paragraph, before "## WSP_00 Launch Prompt" section header.
+
+## BOOTSTRAP.md Read Order
+
+1. MEMORY_BOUNDARY.md - What CAN and MUST NOT be remembered
+2. CURRENT_CONTEXT.md - Active lanes, HEAD, worker roles
+3. WORK_TO_WORK_LINEAGE.md - Recent PR/slice chain
+4. ACTIVE_RESEARCH_THREADS.md - Open threads with next-action slices
+
+## Test Coverage
+
+| Test Class | Tests | Purpose |
+|------------|-------|---------|
+| TestBootstrapFileExists | 1 | BOOTSTRAP.md exists |
+| TestBootstrapNamesAllSiblings | 4 | All 4 siblings referenced |
+| TestAllSiblingFilesExist | 4 | All sibling files exist |
+| TestWSP00ReferencesBootstrap | 2 | Both WSP_00 mirrors reference BOOTSTRAP.md |
+| TestWSP00MirrorEquality | 1 | Framework/Knowledge byte-identical |
+| TestNoSecretPatterns | parametrized | Secret pattern scan |
+| TestREADMELinksBootstrap | 1 | README.md links BOOTSTRAP.md |
+
+## Secret Pattern Scan
+
+Patterns scanned (must NOT match):
+- `AIza[A-Za-z0-9_-]{35}` - Google API key
+- `sk-[A-Za-z0-9]{48}` - OpenAI API key
+- `hf_[A-Za-z0-9]{34}` - HuggingFace token
+- `ghp_[A-Za-z0-9]{36}` - GitHub PAT (classic)
+- `gho_[A-Za-z0-9]{36}` - GitHub OAuth token
+- `github_pat_[A-Za-z0-9_]{82}` - GitHub PAT (fine-grained)
+- `Bearer\s+[A-Za-z0-9_-]{20,}` - Bearer tokens
+- `eyJ...` - JWT pattern
+
+## Slice Chain
+
+```
+REDDOG_SESSION_CONTINUITY_CAPTURE_PHASE1 (PR #724) [MERGED]
+    |
+    v
+REDDOG_BOOTSTRAP_CONTEXT_RETRIEVAL_PHASE1 (this slice)
+    |
+    v
+REDDOG_BOOTSTRAP_LIVE_UPDATE_PHASE2 (deferred)
+```
+
+## Verification Commands
+
+```bash
+# Run tests
+python -m pytest modules/infrastructure/wre_core/tests/test_bootstrap_context_retrieval.py -v
+
+# Verify WSP_00 mirrors are byte-identical
+diff -q WSP_framework/src/WSP_00_Zen_State_Attainment_Protocol.md WSP_knowledge/src/WSP_00_Zen_State_Attainment_Protocol.md
+
+# Verify no secrets in bootstrap files
+grep -rE "(AIza|sk-|hf_|ghp_|gho_|github_pat_)" WSP_knowledge/red_dog_external_state/
+```

--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -2,6 +2,47 @@
 
 ## Chronological Change Log
 
+### [2026-05-28] - REDDOG_BOOTSTRAP_CONTEXT_RETRIEVAL_PHASE1 (v0.8.42)
+
+**WSP Protocol References**: WSP 00 (Zen State), WSP 60 (Module Memory), WSP 22 (ModLog)
+**Impact Analysis**: Adds boot retrieval layer for RedDog session continuity
+
+#### Changes Made
+
+- `tests/test_bootstrap_context_retrieval.py` (NEW - 120 lines):
+  - Validates boot retrieval layer wiring
+  - TestBootstrapFileExists: BOOTSTRAP.md existence
+  - TestBootstrapNamesAllSiblings: All 4 siblings referenced
+  - TestAllSiblingFilesExist: Sibling file existence
+  - TestWSP00ReferencesBootstrap: WSP_00 references BOOTSTRAP.md
+  - TestWSP00MirrorEquality: Framework/Knowledge mirrors byte-identical
+  - TestNoSecretPatterns: Secret pattern scan (API keys, tokens, JWTs)
+  - TestREADMELinksBootstrap: README.md links BOOTSTRAP.md
+
+#### WSP_knowledge Additions
+
+- `WSP_knowledge/red_dog_external_state/BOOTSTRAP.md` - Boot card with strict read-order
+- `WSP_knowledge/red_dog_external_state/MEMORY_BOUNDARY.md` - Curated vs forbidden boundary
+- `WSP_knowledge/red_dog_external_state/CURRENT_CONTEXT.md` - Active lanes, HEAD, worker roles
+- `WSP_knowledge/red_dog_external_state/WORK_TO_WORK_LINEAGE.md` - PR/slice chain
+- `WSP_knowledge/red_dog_external_state/ACTIVE_RESEARCH_THREADS.md` - Open threads with next-action slices
+
+#### WSP_00 Amendment
+
+- Added BOOTSTRAP.md reference in Session Bootstrap Contract section
+- Amendment applied to both WSP_framework/src and WSP_knowledge/src mirrors
+- Mirrors verified byte-identical
+
+#### Coordination
+
+- Predecessor: PR #724 (REDDOG_SESSION_CONTINUITY_CAPTURE_PHASE1) - storage layer
+- Follow-on: REDDOG_BOOTSTRAP_LIVE_UPDATE_PHASE2 (deferred)
+
+#### WSP 97 Compliance
+
+All truth fields remain False. No network calls, no .env reads, no live execution.
+Seeded files only (not live auto-update).
+
 ### [2026-05-27] - REDDOG_SESSION_CONTINUITY_CAPTURE_PHASE1 (v0.8.41)
 
 **WSP Protocol References**: WSP 60 (Module Memory), WSP 87 (Code Navigation), WSP 22 (ModLog)

--- a/modules/infrastructure/wre_core/tests/TestModLog.md
+++ b/modules/infrastructure/wre_core/tests/TestModLog.md
@@ -1,5 +1,32 @@
 # TestModLog - wre_core/tests
 
+## 2026-05-28: REDDOG_BOOTSTRAP_CONTEXT_RETRIEVAL_PHASE1 Boot retrieval tests
+
+- Command: `python -m pytest modules/infrastructure/wre_core/tests/test_bootstrap_context_retrieval.py -v`
+- Status: PASS
+- Result: `14 passed`
+- Notes:
+  - NEW file: `test_bootstrap_context_retrieval.py` (120 lines)
+  - Tests boot retrieval layer wiring for RedDog continuity:
+    - `TestBootstrapFileExists` (1 test) - BOOTSTRAP.md exists
+    - `TestBootstrapNamesAllSiblings` (4 tests) - BOOTSTRAP.md names all 4 siblings
+    - `TestAllSiblingFilesExist` (4 tests) - All sibling files exist
+    - `TestWSP00ReferencesBootstrap` (2 tests) - Both WSP_00 mirrors reference BOOTSTRAP.md
+    - `TestWSP00MirrorEquality` (1 test) - WSP_framework and WSP_knowledge byte-identical
+    - `TestNoSecretPatterns` (parametrized) - No API keys/tokens/JWTs in bootstrap files
+    - `TestREADMELinksBootstrap` (1 test) - README.md links BOOTSTRAP.md
+  - Key patterns tested:
+    - Google API keys (`AIza*`)
+    - OpenAI keys (`sk-*`)
+    - HuggingFace tokens (`hf_*`)
+    - GitHub PATs (`ghp_*`, `gho_*`, `github_pat_*`)
+    - Bearer tokens, JWTs
+  - No network calls, no .env reads, file existence + content checks only
+  - Verdict: `BOOTSTRAP_CONTEXT_RETRIEVAL_TESTS_DEFINED`
+- Slice: REDDOG_BOOTSTRAP_CONTEXT_RETRIEVAL_PHASE1
+
+---
+
 ## 2026-05-27: REDDOG_SESSION_CONTINUITY_CAPTURE_PHASE1 Validator tests
 
 - Command: `python -m pytest modules/infrastructure/wre_core/tests/test_validate_session_closeout.py -v`

--- a/modules/infrastructure/wre_core/tests/test_bootstrap_context_retrieval.py
+++ b/modules/infrastructure/wre_core/tests/test_bootstrap_context_retrieval.py
@@ -1,0 +1,139 @@
+"""
+Test suite for RedDog Bootstrap Context Retrieval Phase 1.
+
+Slice: REDDOG_BOOTSTRAP_CONTEXT_RETRIEVAL_PHASE1
+Verifies boot retrieval layer is properly wired.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+# Repository root
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+# Bootstrap files directory
+BOOTSTRAP_DIR = REPO_ROOT / "WSP_knowledge" / "red_dog_external_state"
+
+# WSP_00 locations
+WSP_00_FRAMEWORK = REPO_ROOT / "WSP_framework" / "src" / "WSP_00_Zen_State_Attainment_Protocol.md"
+WSP_00_KNOWLEDGE = REPO_ROOT / "WSP_knowledge" / "src" / "WSP_00_Zen_State_Attainment_Protocol.md"
+
+# Expected sibling files in BOOTSTRAP.md read-order
+SIBLING_FILES = [
+    "MEMORY_BOUNDARY.md",
+    "CURRENT_CONTEXT.md",
+    "WORK_TO_WORK_LINEAGE.md",
+    "ACTIVE_RESEARCH_THREADS.md",
+]
+
+# Secret patterns that must NOT appear in bootstrap files
+SECRET_PATTERNS = [
+    r"AIza[A-Za-z0-9_-]{35}",  # Google API key
+    r"sk-[A-Za-z0-9]{48}",  # OpenAI API key
+    r"hf_[A-Za-z0-9]{34}",  # HuggingFace token
+    r"ghp_[A-Za-z0-9]{36}",  # GitHub PAT (classic)
+    r"gho_[A-Za-z0-9]{36}",  # GitHub OAuth token
+    r"github_pat_[A-Za-z0-9_]{82}",  # GitHub PAT (fine-grained)
+    r"Bearer\s+[A-Za-z0-9_-]{20,}",  # Bearer tokens
+    r"oauth_token\s*=\s*['\"][^'\"]+['\"]",  # OAuth token assignment
+    r"refresh_token\s*=\s*['\"][^'\"]+['\"]",  # Refresh token assignment
+    r"eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*",  # JWT pattern
+]
+
+
+class TestBootstrapFileExists:
+    """Verify BOOTSTRAP.md exists."""
+
+    def test_bootstrap_md_exists(self):
+        """BOOTSTRAP.md must exist in red_dog_external_state directory."""
+        bootstrap_path = BOOTSTRAP_DIR / "BOOTSTRAP.md"
+        assert bootstrap_path.exists(), f"BOOTSTRAP.md not found at {bootstrap_path}"
+
+
+class TestBootstrapNamesAllSiblings:
+    """Verify BOOTSTRAP.md names all 4 sibling files."""
+
+    def test_bootstrap_names_memory_boundary(self):
+        """BOOTSTRAP.md must reference MEMORY_BOUNDARY.md."""
+        content = (BOOTSTRAP_DIR / "BOOTSTRAP.md").read_text(encoding="utf-8")
+        assert "MEMORY_BOUNDARY.md" in content
+
+    def test_bootstrap_names_current_context(self):
+        """BOOTSTRAP.md must reference CURRENT_CONTEXT.md."""
+        content = (BOOTSTRAP_DIR / "BOOTSTRAP.md").read_text(encoding="utf-8")
+        assert "CURRENT_CONTEXT.md" in content
+
+    def test_bootstrap_names_work_to_work_lineage(self):
+        """BOOTSTRAP.md must reference WORK_TO_WORK_LINEAGE.md."""
+        content = (BOOTSTRAP_DIR / "BOOTSTRAP.md").read_text(encoding="utf-8")
+        assert "WORK_TO_WORK_LINEAGE.md" in content
+
+    def test_bootstrap_names_active_research_threads(self):
+        """BOOTSTRAP.md must reference ACTIVE_RESEARCH_THREADS.md."""
+        content = (BOOTSTRAP_DIR / "BOOTSTRAP.md").read_text(encoding="utf-8")
+        assert "ACTIVE_RESEARCH_THREADS.md" in content
+
+
+class TestAllSiblingFilesExist:
+    """Verify all 4 sibling files exist."""
+
+    @pytest.mark.parametrize("filename", SIBLING_FILES)
+    def test_sibling_file_exists(self, filename):
+        """Each sibling file named in BOOTSTRAP.md must exist."""
+        filepath = BOOTSTRAP_DIR / filename
+        assert filepath.exists(), f"{filename} not found at {filepath}"
+
+
+class TestWSP00ReferencesBootstrap:
+    """Verify both WSP_00 mirrors reference BOOTSTRAP.md."""
+
+    def test_wsp00_framework_references_bootstrap(self):
+        """WSP_framework/src/WSP_00*.md must reference BOOTSTRAP.md."""
+        content = WSP_00_FRAMEWORK.read_text(encoding="utf-8")
+        assert "BOOTSTRAP.md" in content, "WSP_00 in WSP_framework does not reference BOOTSTRAP.md"
+
+    def test_wsp00_knowledge_references_bootstrap(self):
+        """WSP_knowledge/src/WSP_00*.md must reference BOOTSTRAP.md."""
+        content = WSP_00_KNOWLEDGE.read_text(encoding="utf-8")
+        assert "BOOTSTRAP.md" in content, "WSP_00 in WSP_knowledge does not reference BOOTSTRAP.md"
+
+
+class TestWSP00MirrorEquality:
+    """Verify WSP_framework and WSP_knowledge mirrors are byte-identical for amendment block."""
+
+    def test_wsp00_mirrors_byte_identical(self):
+        """Both WSP_00 files must be byte-identical."""
+        framework_content = WSP_00_FRAMEWORK.read_bytes()
+        knowledge_content = WSP_00_KNOWLEDGE.read_bytes()
+        assert framework_content == knowledge_content, "WSP_00 mirrors are not byte-identical"
+
+
+class TestNoSecretPatterns:
+    """Verify no secret patterns in any of the 5 bootstrap files."""
+
+    @pytest.fixture
+    def all_bootstrap_files(self):
+        """Return list of all bootstrap files to check."""
+        return [BOOTSTRAP_DIR / "BOOTSTRAP.md"] + [BOOTSTRAP_DIR / f for f in SIBLING_FILES]
+
+    @pytest.mark.parametrize("pattern", SECRET_PATTERNS)
+    def test_no_secret_pattern_in_bootstrap(self, pattern, all_bootstrap_files):
+        """No secret pattern should match in any bootstrap file."""
+        compiled = re.compile(pattern)
+        for filepath in all_bootstrap_files:
+            if filepath.exists():
+                content = filepath.read_text(encoding="utf-8")
+                match = compiled.search(content)
+                assert match is None, f"Secret pattern '{pattern}' found in {filepath.name}"
+
+
+class TestREADMELinksBootstrap:
+    """Verify README.md links to BOOTSTRAP.md."""
+
+    def test_readme_links_bootstrap(self):
+        """README.md must contain a link to BOOTSTRAP.md."""
+        readme_path = BOOTSTRAP_DIR / "README.md"
+        content = readme_path.read_text(encoding="utf-8")
+        assert "BOOTSTRAP.md" in content, "README.md does not link to BOOTSTRAP.md"


### PR DESCRIPTION
## Summary

Adds the RedDog bootstrap retrieval layer that closes the gap left by #724: curated continuity exists on disk, and WSP_00 now points fresh 0102 sessions to the boot card before FoundUps architecture work.

Changes:
- Add `BOOTSTRAP.md` read-order for RedDog external state.
- Add seeded continuity projections: memory boundary, current context, work lineage, and active research threads.
- Update RedDog external state README to route fresh sessions through BOOTSTRAP.
- Add the minimal WSP_00 framework + knowledge mirror amendment.
- Add deterministic bootstrap retrieval tests.
- Add architecture audit for `REDDOG_BOOTSTRAP_CONTEXT_RETRIEVAL_PHASE1`.

## Scope

Expected 12 files:
- `WSP_knowledge/red_dog_external_state/BOOTSTRAP.md`
- `WSP_knowledge/red_dog_external_state/MEMORY_BOUNDARY.md`
- `WSP_knowledge/red_dog_external_state/CURRENT_CONTEXT.md`
- `WSP_knowledge/red_dog_external_state/WORK_TO_WORK_LINEAGE.md`
- `WSP_knowledge/red_dog_external_state/ACTIVE_RESEARCH_THREADS.md`
- `WSP_knowledge/red_dog_external_state/README.md`
- `WSP_framework/src/WSP_00_Zen_State_Attainment_Protocol.md`
- `WSP_knowledge/src/WSP_00_Zen_State_Attainment_Protocol.md`
- `modules/infrastructure/wre_core/tests/test_bootstrap_context_retrieval.py`
- `modules/infrastructure/wre_core/tests/TestModLog.md`
- `modules/infrastructure/wre_core/ModLog.md`
- `docs/audits/architecture/REDDOG_BOOTSTRAP_CONTEXT_RETRIEVAL_PHASE1.md`

## Verification

- `python -m pytest modules/infrastructure/wre_core/tests/test_bootstrap_context_retrieval.py -q`
- Result: 23 passed, 0 skipped

## Boundary

- Builds on #724 storage layer.
- WSP_00 mutation is a minimal boot retrieval read rule.
- Framework/knowledge WSP_00 mirrors are byte-identical after amendment.
- No raw transcript storage.
- No automated capture.
- No Cursor DB read.
- No browser scraping.
- No Antigravity extractor mutation.
- No public surface, registry, manifest, catalog, DNS, token, CABR, payout, or DAO activation.

## WSP_97

Audit doc reports 16/16 YES with canonical `Truth Boundary Checklist Item` header and evidence cells.
