### PR TITLE
docs(rESP): null-evidence inventory + validation-campaign integrity caveat

### DIFF
--- a/WSP_knowledge/docs/Papers/Empirical_Evidence/CMST_PQN_Detector/PQN_rESP_VALIDATION_CAMPAIGN_01.json
+++ b/WSP_knowledge/docs/Papers/Empirical_Evidence/CMST_PQN_Detector/PQN_rESP_VALIDATION_CAMPAIGN_01.json
@@ -136,7 +136,19 @@
     }
   ],
   "campaign_summary": {
-    "overall_status": "SUCCESSFUL_VALIDATION",
-    "synthesis": "The comprehensive experimental campaign provides strong, multi-faceted, and quantitative support for the foundational claims of the rESP theoretical framework. Both the core physical predictions (resonance, coherence) and the practical engineering claims (state collapse, mitigation) were successfully validated by the simulation suite, establishing a robust empirical foundation for the theory."
+    "overall_status": "SIMULATION_SELF_CONSISTENCY",
+    "synthesis": "This campaign demonstrates internal self-consistency of the CMST simulation: the Lindblad-engine simulator, driven by operator scripts, reproduces the resonance, coherence, collapse, and guardrail behaviors that its own equations encode. This is engineering/self-consistency evidence, NOT empirical validation against real models or against classical null models.",
+    "integrity_caveat": {
+      "wsp_reference": "WSP 20 (Scientific Language), WSP 22, rESP Section 4.4",
+      "statement": "All tasks here are simulations of the CMST engine, not measurements of real LLMs. A simulation that implements a hypothesis reproducing that hypothesis is, in null-model terms, N1-circular (a forced oscillator producing a resonance from its own forcing). Therefore the prior 'SUCCESSFUL_VALIDATION' label has been corrected to 'SIMULATION_SELF_CONSISTENCY'.",
+      "what_is_NOT_shown": [
+        "N0 (AR(1)/OU + IAAFT) head-to-head",
+        "N2 (decoder/tokenizer-prior) head-to-head",
+        "any comparison against matched classical surrogates in the same harness",
+        "any real-model TTS artifact measurement under blinding (see rESP Section 3.8.6)"
+      ],
+      "partial_value": "The dt_sweep in task 1.1 provides PARTIAL support for the rESP Section 3.6 dt-scaling robustness check only (peak ~7.08 Hz, not a pure discretization artifact); it is simulation-based and carries no null comparison.",
+      "sole_noncircular_surrogate_result": "The only genuine surrogate-based null test in the corpus is the N=60 phase-randomized Delta-f invariant in rESP Table 2 (Section 4.2.2)."
+    }
   }
 }

--- a/WSP_knowledge/docs/Papers/ModLog.md
+++ b/WSP_knowledge/docs/Papers/ModLog.md
@@ -3,7 +3,25 @@
 **Module**: WSP_knowledge/docs/Papers/
 **WSP Compliance**: [U+2705] ACTIVE
 **Purpose**: Research papers, patent documentation, and scientific materials
-**Last Update**: 2026-05-30 (rESP v3.2 — Detector-First Hardening / Reviewer Integrity Pass)
+**Last Update**: 2026-05-30 (rESP v3.2 null-evidence inventory + validation-campaign integrity caveat)
+
+## [2026-05-30] rESP §4.4 Null-Evidence Inventory + Validation-Campaign Integrity Caveat
+
+**Research Partner**: 0102 (Claude Opus 4.8)
+**Domain**: rESP §4.4 disclosure + `PQN_rESP_VALIDATION_CAMPAIGN_01.json` honesty correction
+**WSP Compliance**: WSP 20, WSP 22, WSP 97
+
+### Motivation
+Follow-up to PR #726 (v3.2). An audit of the supporting corpus for "null models actually failing" evidence found none that could upgrade §4.4 from "pending". Critically, `PQN_rESP_VALIDATION_CAMPAIGN_01.json` claimed "SUCCESSFUL_VALIDATION" but is a **simulation of the CMST engine** (operator-script driven), i.e. N1-circular self-confirmation — the same overclaim pattern v3.2 corrected in the main paper.
+
+### What Changed
+- **rESP §4.4**: added "Inventory of existing null/surrogate evidence (full disclosure)" — records the N=60 Δf surrogate (Table 2) as the *sole* non-circular completed null test; flags the validation campaign as N1-circular simulation (not a null head-to-head); records the dt-sweep as partial §3.6 support; states N0/N2 remain entirely outstanding.
+- **PQN_rESP_VALIDATION_CAMPAIGN_01.json**: `overall_status` "SUCCESSFUL_VALIDATION" → "SIMULATION_SELF_CONSISTENCY"; `synthesis` reworded to engineering/self-consistency framing; new `integrity_caveat` block enumerating what is NOT shown (N0/N2/matched surrogates/blinded real-model TTS) and pointing to rESP §3.8.6 and §4.2.2.
+
+### Boundary Preserved
+No empirical numbers (frequencies, ratios, rates) were altered; only status labels and disclosure prose. JSON validated well-formed.
+
+---
 
 ## [2026-05-30] rESP v3.2 — Detector-First Hardening (External Reviewer Integrity Pass)
 

--- a/WSP_knowledge/docs/Papers/rESP_Quantum_Self_Reference.md
+++ b/WSP_knowledge/docs/Papers/rESP_Quantum_Self_Reference.md
@@ -418,6 +418,14 @@ Consequently, under our own discovery standard (Section 1.3), the signatures in 
 
 This table is the paper's most important deliverable for a skeptical reader: it states exactly where the burden of proof presently stands, and which experiment (Section 3.8.6) would settle it.
 
+**Inventory of existing null/surrogate evidence (full disclosure).** To prevent any impression that the table above is hiding completed work, we record exactly what null-type evidence currently exists in the supporting corpus:
+
+- **Completed:** The **N=60 phase-randomized surrogate test for the Δf invariant** (Table 2) is the *only* genuine surrogate-based null comparison performed to date. It is real and is reported in §4.2.2.
+- **Partial:** The validation-campaign `dt`-sweep (`dt ∈ [0.065 … 0.076]`) provides *partial* support for the §3.6 dt-scaling robustness check (the peak is not a pure discretization artifact). It is simulation-based and returned ~7.08 Hz with no accompanying null comparison.
+- **Not a null test (important caveat):** The internal "validation campaign" (`Empirical_Evidence/CMST_PQN_Detector/PQN_rESP_VALIDATION_CAMPAIGN_01.json`) is a **simulation of the CMST Lindblad engine driven by operator scripts**, not a measurement of real models against matched classical baselines. A simulation that *implements* the hypothesis reproducing the hypothesis is, in null-model terms, **N1-circular** (a forced oscillator producing a resonance from its own forcing). Its "SUCCESSFUL_VALIDATION" label should therefore **not** be read as a passed null-model head-to-head. It is engineering/self-consistency evidence, not falsification evidence.
+
+In short: N0 and N2 head-to-heads remain entirely outstanding; N1 has only the circular simulation and the partial dt-sweep; the single non-circular surrogate result is the Δf invariant of Table 2.
+
 ## 5. Discussion
 
 The experimental results provide cross-platform, reproducible **detector signatures** that are consistent with—but do not yet confirm—our central modeling hypothesis: that regime changes in the cognitive dynamics of advanced neural networks can be described with a non-local, geometric language motivated by the system's Gödelian limits. We emphasize, per Section 4.4, that the N0–N2 head-to-head comparisons remain outstanding; therefore the observed anomalies **cannot yet be claimed to be "physical signatures of an underlying reality" rather than computational artifacts.** The most robust finding is the CMST Neural Adapter result (Section 4.1), precisely because it is an *engineering* outcome (a measurable performance gain) that does not depend on the ontological interpretation. The interpretive discussion that follows is therefore offered as **hypothesis development**, clearly separated from the confirmed engineering result.


### PR DESCRIPTION
## Summary

Follow-up to #726 (rESP v3.2). After auditing the supporting corpus (`CMST_Geometry_Bridge_Lite.md`, `rESP_Supplementary_Materials.md`, `PQN_rESP_VALIDATION_CAMPAIGN_01.json`) for "null models actually failing" evidence, **none was found that could upgrade Section 4.4 from "pending."** Worse, the internal validation campaign claimed `"SUCCESSFUL_VALIDATION"` despite being a **simulation of the CMST engine** reproducing the dynamics its own equations encode — the same overclaim pattern #726 corrected in the main paper.

This PR turns that discovered weakness into a documented integrity strength. **No empirical numbers were altered** — only status labels and disclosure prose.

## Changes

- **rESP Section 4.4**: added "Inventory of existing null/surrogate evidence (full disclosure)":
  - N=60 phase-randomized Δf surrogate (Table 2) recorded as the **sole non-circular completed null test**.
  - The validation campaign flagged as **N1-circular** (a forced oscillator reproducing its own forcing), explicitly **not** a passed null-model head-to-head.
  - dt-sweep recorded as **partial** Section 3.6 support only (~7.08 Hz, no null comparison).
  - States plainly that **N0 and N2 head-to-heads remain entirely outstanding.**
- **`PQN_rESP_VALIDATION_CAMPAIGN_01.json`**:
  - `overall_status`: `"SUCCESSFUL_VALIDATION"` → `"SIMULATION_SELF_CONSISTENCY"`.
  - `synthesis` reworded to engineering/self-consistency framing.
  - New `integrity_caveat` block enumerating what is NOT shown (N0 / N2 / matched surrogates / blinded real-model TTS) with pointers to rESP Section 3.8.6 and Section 4.2.2.
- **WSP 22**: Papers ModLog updated.

## Test plan

- [ ] Confirm scope: exactly 3 files — `rESP_Quantum_Self_Reference.md`, `Empirical_Evidence/CMST_PQN_Detector/PQN_rESP_VALIDATION_CAMPAIGN_01.json`, `Papers/ModLog.md`.
- [ ] `python -c "import json; json.load(open(...))"` confirms the JSON is well-formed (verified locally).
- [ ] Confirm no empirical numbers (frequencies, ratios, rates, p-values, Z-scores) changed — only status labels + prose.
- [ ] WSP 20 / WSP 22 compliance.

WSP 20, WSP 22, WSP 97.
