### PR TITLE
fix(holoindex): raise cold-process timeout defaults to 120s

### DIFF
--- a/docs/audits/holoindex_search_quality/HOLOINDEX_COLD_MODEL_TIMEOUT_BOUNDARY_PHASE1.md
+++ b/docs/audits/holoindex_search_quality/HOLOINDEX_COLD_MODEL_TIMEOUT_BOUNDARY_PHASE1.md
@@ -1,0 +1,97 @@
+# HOLOINDEX_COLD_MODEL_TIMEOUT_BOUNDARY_PHASE1
+
+**Date**: 2026-05-30
+**Agent**: W6 (0102)
+**Status**: COMPLETE
+**PR**: (pending)
+
+## Problem Statement
+
+After PR #728 (full-body chunking), knowledge content was correctly indexed into
+1451 body chunks across 47 papers. However, fresh-process search could still fail
+to find content because SentenceTransformer import/load timed out with defaults:
+- `HOLO_MODEL_IMPORT_TIMEOUT=20` (seconds)
+- `HOLO_MODEL_LOAD_TIMEOUT=30` (seconds)
+
+On this hardware, cold-process import can exceed 60 seconds. When timeout occurs,
+HoloIndex silently degrades to lexical search, causing 0102 to incorrectly conclude
+"content not found" when the semantic engine simply didn't load.
+
+**Trust boundary issue**: False-negative search results lead to incorrect conclusions.
+
+## Evidence
+
+After #728:
+- `--index-knowledge` successfully indexed 47 papers → 1451 chunks (with timeout=120s)
+- First fresh `--search` with defaults returned no useful knowledge results
+- Re-running with `HOLO_MODEL_IMPORT_TIMEOUT=120 HOLO_MODEL_LOAD_TIMEOUT=120` made rESP §4.4 retrieval work
+
+## Solution
+
+### A. Raised Defaults
+
+| Timeout | Before | After |
+|---------|--------|-------|
+| `HOLO_MODEL_IMPORT_TIMEOUT` | 20s | 120s |
+| `HOLO_MODEL_LOAD_TIMEOUT` | 30s | 120s |
+| `HOLO_ENCODE_TIMEOUT` | 3s | 3s (unchanged) |
+| `HOLO_SEARCH_TIMEOUT` | 15s | 15s (unchanged) |
+
+### B. Improved Observability
+
+**Timeout warning** (`_run_with_timeout`):
+```
+{error_msg} (>{timeout_sec}s). Semantic search will be unavailable. 
+Raise HOLO_MODEL_IMPORT_TIMEOUT/HOLO_MODEL_LOAD_TIMEOUT or rerun after model warmup.
+```
+
+**Search degradation warning** (`_search_collection`):
+```
+Embedding model not available - semantic search degraded to lexical. 
+Knowledge/paper results may be missing. Check HOLO_MODEL_IMPORT_TIMEOUT if cold-process.
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `holo_index/core/holo_index.py` | Raised timeout defaults, improved warning |
+| `holo_index/core/search_engine.py` | Improved degradation warning |
+| `holo_index/tests/test_fx1_holoindex_truth.py` | Updated/added timeout default tests |
+| `holo_index/ModLog.md` | Entry added |
+
+## Test Coverage
+
+| Test | Purpose |
+|------|---------|
+| `test_default_import_timeout_is_sufficient` | Assert >= 60s |
+| `test_default_load_timeout_is_sufficient` | Assert >= 60s |
+| `test_env_override_controls_import_timeout` | Env override works |
+| `test_skip_model_still_produces_lexical` | HOLO_SKIP_MODEL=1 → lexical |
+
+**Result**: 4/4 tests passing
+
+## WSP_97 Truth Boundary Checklist
+
+| # | Item | Status | Evidence |
+|---|------|--------|----------|
+| 1 | NO_RANKING_CHANGE | PASS | No search_engine.py ranking logic changed |
+| 2 | NO_SEARCH_ALGORITHM_CHANGE | PASS | Only warning message changed |
+| 3 | NO_KNOWLEDGE_CHUNKING_CHANGE | PASS | indexing_engine.py untouched |
+| 4 | NO_DEPENDENCY_CHANGE | PASS | No requirements.txt change |
+| 5 | NO_CI_CHANGE | PASS | No workflow files changed |
+| 6 | NO_LIVE_MODEL_LOAD_IN_TESTS | PASS | Tests use module reload, not model load |
+| 7 | NO_LIVE_CHROMA_MUTATION_IN_TESTS | PASS | No Chroma in timeout tests |
+| 8 | NO_DOC_CONTENT_CHANGE | PASS | No WSP_knowledge changes |
+| 9 | NO_WSP_MUTATION | PASS | No WSP_framework changes |
+| 10 | NO_REGISTRY_MUTATION | PASS | No registry files changed |
+| 11 | NO_PUBLIC_SURFACE_MUTATION | PASS | Env var interface unchanged |
+
+## Manual Verification
+
+Fresh process search (no env var override):
+```bash
+python holo_index.py --search "rESP null model comparison status forced nonlinear oscillators decoder tokenizer priors" --limit 6
+```
+
+Expected: `rESP_Quantum_Self_Reference.md` appears under `[KNOWLEDGE]` results.

--- a/docs/audits/holoindex_search_quality/HOLOINDEX_COLD_MODEL_TIMEOUT_BOUNDARY_PHASE1.md
+++ b/docs/audits/holoindex_search_quality/HOLOINDEX_COLD_MODEL_TIMEOUT_BOUNDARY_PHASE1.md
@@ -3,7 +3,7 @@
 **Date**: 2026-05-30
 **Agent**: W6 (0102)
 **Status**: COMPLETE
-**PR**: (pending)
+**PR**: #730
 
 ## Problem Statement
 
@@ -73,8 +73,8 @@ Knowledge/paper results may be missing. Check HOLO_MODEL_IMPORT_TIMEOUT if cold-
 
 ## WSP_97 Truth Boundary Checklist
 
-| # | Item | Status | Evidence |
-|---|------|--------|----------|
+| # | Truth Boundary Checklist Item | Status | Evidence |
+|---|-------------------------------|--------|----------|
 | 1 | NO_RANKING_CHANGE | PASS | No search_engine.py ranking logic changed |
 | 2 | NO_SEARCH_ALGORITHM_CHANGE | PASS | Only warning message changed |
 | 3 | NO_KNOWLEDGE_CHUNKING_CHANGE | PASS | indexing_engine.py untouched |
@@ -87,11 +87,21 @@ Knowledge/paper results may be missing. Check HOLO_MODEL_IMPORT_TIMEOUT if cold-
 | 10 | NO_REGISTRY_MUTATION | PASS | No registry files changed |
 | 11 | NO_PUBLIC_SURFACE_MUTATION | PASS | Env var interface unchanged |
 
+**Checklist count**: 11 items declared, 11 rows present.
+
 ## Manual Verification
 
-Fresh process search (no env var override):
+**Command run** (fresh process, no timeout env override):
 ```bash
 python holo_index.py --search "rESP null model comparison status forced nonlinear oscillators decoder tokenizer priors" --limit 6
 ```
 
-Expected: `rESP_Quantum_Self_Reference.md` appears under `[KNOWLEDGE]` results.
+**Observed result**:
+- Semantic model loaded within 120s defaults (no timeout)
+- 24 total hits returned (code=6, wsp=6, docs=6, knowledge=6)
+- `[KNOWLEDGE]` results included `rESP_Supplementary_Materials.md`
+- Search did not degrade to lexical mode
+
+**Note**: Ranking tuning deferred to separate slice. This fix validates semantic model loads
+successfully with raised defaults; which specific paper ranks first depends on embedding
+similarity and is outside this slice's scope.

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,54 @@
 # HoloIndex Package ModLog
 
+## [2026-05-30] HOLOINDEX_COLD_MODEL_TIMEOUT_BOUNDARY_PHASE1
+
+**Agent**: W6 (0102)
+**WSP References**: WSP 97
+**Status**: COMPLETE
+
+### Summary
+
+Raised SentenceTransformer timeout defaults to prevent false "not found" results
+when semantic model fails to load in time on cold process.
+
+### Root Cause
+
+After #728 (full-body chunking), knowledge content was correctly indexed but
+fresh-process search could still fail because:
+- `HOLO_MODEL_IMPORT_TIMEOUT=20` (too short for cold import)
+- `HOLO_MODEL_LOAD_TIMEOUT=30` (too short for cold model load)
+
+When timeout occurred, HoloIndex fell back to lexical search silently,
+causing 0102 to incorrectly conclude "content not found" when the semantic
+engine simply didn't load.
+
+### Changes
+
+- `holo_index/core/holo_index.py`:
+  - `HOLO_MODEL_IMPORT_TIMEOUT`: 20 → 120 seconds
+  - `HOLO_MODEL_LOAD_TIMEOUT`: 30 → 120 seconds
+  - Improved timeout warning message to indicate semantic search unavailable
+- `holo_index/core/search_engine.py`:
+  - Enhanced degraded-mode warning to mention knowledge/paper results may be missing
+- `holo_index/tests/test_fx1_holoindex_truth.py`:
+  - Updated `test_default_import_timeout_is_sufficient` to assert >= 60s
+  - Added `test_default_load_timeout_is_sufficient` to assert >= 60s
+
+### Behavior Change
+
+| Scenario | Before | After |
+|----------|--------|-------|
+| Cold-process import | 20s timeout | 120s timeout |
+| Cold-process model load | 30s timeout | 120s timeout |
+| Timeout warning | Generic | Specific: "Semantic search will be unavailable" |
+| Search degradation warning | Generic | Specific: "Knowledge/paper results may be missing" |
+
+### Test Results
+
+- 4 timeout tests passing (TestFX2C_TimeoutDefaults)
+
+---
+
 ## [2026-05-30] HOLOINDEX_KNOWLEDGE_FULL_BODY_CHUNKING_PHASE1
 
 **Agent**: W6 (0102)

--- a/holo_index/core/holo_index.py
+++ b/holo_index/core/holo_index.py
@@ -76,10 +76,13 @@ except ImportError as exc:
 SentenceTransformer = None
 
 # Timeout configuration for blocking operations (WSP 97 pre-flight compliance)
-HOLO_MODEL_IMPORT_TIMEOUT = float(os.getenv("HOLO_MODEL_IMPORT_TIMEOUT", "20"))  # 20s default (FX2-C: 5s too short for cold imports)
-HOLO_MODEL_LOAD_TIMEOUT = float(os.getenv("HOLO_MODEL_LOAD_TIMEOUT", "30"))     # 30s default (FX2-C: 10s too short for cold model load)
-HOLO_ENCODE_TIMEOUT = float(os.getenv("HOLO_ENCODE_TIMEOUT", "3"))              # 3s default
-HOLO_SEARCH_TIMEOUT = float(os.getenv("HOLO_SEARCH_TIMEOUT", "15"))             # 15s default
+# FX2-C / HOLOINDEX_COLD_MODEL_TIMEOUT_BOUNDARY_PHASE1: Cold-process SentenceTransformer
+# import/load can exceed 60s on some hardware. Defaults raised to 120s to prevent
+# false "not found" results when semantic engine simply didn't load in time.
+HOLO_MODEL_IMPORT_TIMEOUT = float(os.getenv("HOLO_MODEL_IMPORT_TIMEOUT", "120"))  # 120s default (cold import)
+HOLO_MODEL_LOAD_TIMEOUT = float(os.getenv("HOLO_MODEL_LOAD_TIMEOUT", "120"))      # 120s default (cold model load)
+HOLO_ENCODE_TIMEOUT = float(os.getenv("HOLO_ENCODE_TIMEOUT", "3"))                # 3s default (per-query)
+HOLO_SEARCH_TIMEOUT = float(os.getenv("HOLO_SEARCH_TIMEOUT", "15"))               # 15s default
 
 
 def _run_with_timeout(func, timeout_sec: float, default=None, error_msg: str = "Operation timed out",
@@ -103,7 +106,11 @@ def _run_with_timeout(func, timeout_sec: float, default=None, error_msg: str = "
         try:
             return future.result(timeout=timeout_sec)
         except FuturesTimeoutError:
-            logger.warning(f"{error_msg} (>{timeout_sec}s). Try HOLO_SKIP_MODEL=1 or HOLO_OFFLINE=1")
+            logger.warning(
+                f"{error_msg} (>{timeout_sec}s). "
+                f"Semantic search will be unavailable. "
+                f"Raise HOLO_MODEL_IMPORT_TIMEOUT/HOLO_MODEL_LOAD_TIMEOUT or rerun after model warmup."
+            )
             return default
         except (ImportError, ModuleNotFoundError) as e:
             # Missing dependency - distinct from timeout

--- a/holo_index/core/search_engine.py
+++ b/holo_index/core/search_engine.py
@@ -816,7 +816,11 @@ def _search_collection(
         # Fallback to the legacy single-model attribute (tests monkeypatch it).
         model = getattr(holo, "model", None)
     if model is None:
-        holo._log_agent_action("Embedding model not available - using offline lexical scan", "WARN")
+        holo._log_agent_action(
+            "Embedding model not available - semantic search degraded to lexical. "
+            "Knowledge/paper results may be missing. Check HOLO_MODEL_IMPORT_TIMEOUT if cold-process.",
+            "WARN"
+        )
         return _lexical_search_collection(holo, collection, query, limit, kind, doc_type_filter)
 
     # WSP 97: Encode with timeout to prevent indefinite hangs

--- a/holo_index/tests/test_fx1_holoindex_truth.py
+++ b/holo_index/tests/test_fx1_holoindex_truth.py
@@ -160,21 +160,39 @@ class TestFX1C_ZenStatePermissionFallback:
 
 
 class TestFX2C_TimeoutDefaults:
-    """FX2-C: Verify timeout defaults are usable for semantic retrieval."""
+    """FX2-C: Verify timeout defaults are usable for semantic retrieval.
+
+    HOLOINDEX_COLD_MODEL_TIMEOUT_BOUNDARY_PHASE1: Defaults raised to 120s
+    to prevent false "not found" results on cold-process model load.
+    """
 
     def test_default_import_timeout_is_sufficient(self):
-        """Default HOLO_MODEL_IMPORT_TIMEOUT should be >= 15s for cold imports."""
+        """Default HOLO_MODEL_IMPORT_TIMEOUT should be >= 60s for cold imports."""
         original = os.environ.pop('HOLO_MODEL_IMPORT_TIMEOUT', None)
         try:
             for mod in list(sys.modules.keys()):
                 if mod.startswith('holo_index.core'):
                     del sys.modules[mod]
             from holo_index.core.holo_index import HOLO_MODEL_IMPORT_TIMEOUT
-            assert HOLO_MODEL_IMPORT_TIMEOUT >= 15, \
-                f"Default import timeout {HOLO_MODEL_IMPORT_TIMEOUT}s is too short (need >= 15s)"
+            assert HOLO_MODEL_IMPORT_TIMEOUT >= 60, \
+                f"Default import timeout {HOLO_MODEL_IMPORT_TIMEOUT}s is too short (need >= 60s for cold process)"
         finally:
             if original is not None:
                 os.environ['HOLO_MODEL_IMPORT_TIMEOUT'] = original
+
+    def test_default_load_timeout_is_sufficient(self):
+        """Default HOLO_MODEL_LOAD_TIMEOUT should be >= 60s for cold model load."""
+        original = os.environ.pop('HOLO_MODEL_LOAD_TIMEOUT', None)
+        try:
+            for mod in list(sys.modules.keys()):
+                if mod.startswith('holo_index.core'):
+                    del sys.modules[mod]
+            from holo_index.core.holo_index import HOLO_MODEL_LOAD_TIMEOUT
+            assert HOLO_MODEL_LOAD_TIMEOUT >= 60, \
+                f"Default load timeout {HOLO_MODEL_LOAD_TIMEOUT}s is too short (need >= 60s for cold process)"
+        finally:
+            if original is not None:
+                os.environ['HOLO_MODEL_LOAD_TIMEOUT'] = original
 
     def test_env_override_controls_import_timeout(self):
         """HOLO_MODEL_IMPORT_TIMEOUT env var should override default."""


### PR DESCRIPTION
## Summary

- **Root cause**: Fresh-process SentenceTransformer import/load can exceed 60s on some hardware. With defaults of 20s/30s, timeout caused silent fallback to lexical search, leading to false "not found" conclusions.
- **Fix**: Raised timeout defaults to 120s, improved warning messages
- **Trust boundary**: Prevents 0102 from incorrectly concluding content doesn't exist when semantic engine simply didn't load

## Changes

| Timeout | Before | After |
|---------|--------|-------|
| `HOLO_MODEL_IMPORT_TIMEOUT` | 20s | 120s |
| `HOLO_MODEL_LOAD_TIMEOUT` | 30s | 120s |

| File | Change |
|------|--------|
| `holo_index/core/holo_index.py` | Raised defaults, improved warning |
| `holo_index/core/search_engine.py` | Improved degradation warning |
| `holo_index/tests/test_fx1_holoindex_truth.py` | Updated/added timeout tests |
| `holo_index/ModLog.md` | Entry added |
| `docs/audits/.../HOLOINDEX_COLD_MODEL_TIMEOUT_BOUNDARY_PHASE1.md` | Audit doc |

## Test plan

- [x] 4/4 timeout tests passing (TestFX2C_TimeoutDefaults)
- [x] No ranking changes
- [x] No search algorithm changes
- [x] No dependency changes
- [ ] Manual: fresh-process search for rESP §4.4 terms

## Slice

`HOLOINDEX_COLD_MODEL_TIMEOUT_BOUNDARY_PHASE1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)