### PR TITLE
fix(holoindex): restore slice-id metadata ranking precedence

### DIFF
--- a/docs/audits/holoindex_search_quality/HOLOINDEX_T1_RANKING_QUALITY_PHASE1.md
+++ b/docs/audits/holoindex_search_quality/HOLOINDEX_T1_RANKING_QUALITY_PHASE1.md
@@ -1,0 +1,308 @@
+# HoloIndex T1 Ranking Quality -- Phase 1
+
+**Slice**: `HOLOINDEX_T1_RANKING_QUALITY_PHASE1`
+**Decision**: RESUME_AND_REPAIR
+**Worker-Lane**: W6
+**Agent**: 0102
+**Date**: 2026-05-30
+**Mode**: Search-time ranking tuning (no reindex, no indexer change)
+**Branch**: `main` (working tree, dirty)
+**Base commit**: `3dc26e6f9` (origin/main HEAD, post-PR #730)
+**Lineage**: Resumes the abandoned W7 slice originally based at `d86450997`
+(post-#701). Re-validated against current main after #728 (full-body
+chunking) and #730 (cold-process timeout).
+**WSP Lock**: WSP_00 -> WSP_15 -> WSP_50 -> WSP_64 -> WSP_83 -> WSP_87 -> WSP_97 -> WSP_22
+
+---
+
+## WSP_97 Truth Boundary Checklist
+
+| # | Truth Boundary Checklist Item | Status | Evidence |
+|---|-------------------------------|--------|----------|
+| 1 | HOLOINDEX_T1_RANKING_QUALITY_ONLY | YES | Single-function tier added to `_slice_id_match_boost`; no other behavior change. |
+| 2 | SEARCH_TIME_ONLY | YES | No indexing-engine touch; no Chroma writes; no reindex run. |
+| 3 | NO_INDEXING_ENGINE_CHANGE | YES | `holo_index/core/indexing_engine.py` untouched (`git status` confirms). |
+| 4 | NO_REINDEX | YES | Fix takes effect at search time against the existing `navigation_docs` collection. |
+| 5 | NO_LIVE_CHROMA_MUTATION | YES | No writes; no reindex executed. |
+| 6 | NO_DOCS_INDEX_MUTATION | YES | No artifacts written under any index path. |
+| 7 | NO_TIMEOUT_DEFAULT_CHANGE | YES | `holo_index/core/holo_index.py` timeouts untouched (still 120 from #730). |
+| 8 | NO_KNOWLEDGE_CHUNKING_CHANGE | YES | Indexer chunking logic untouched (#728 behavior preserved). |
+| 9 | NO_SEARCH_ALGORITHM_REWRITE | YES | Single-function tier inside `_slice_id_match_boost`; cosine + lexical pipelines unchanged. |
+| 10 | NO_TRADE_SPECIFIC_SPECIAL_CASE | YES | Rule contains no Trade-specific text, slice prefix, or filename. Proven by `TestNoTradeOrPathSpecialCase` and `TestGenericMetadataPrecedenceProperty`. |
+| 11 | NO_PATH_SPECIFIC_SPECIAL_CASE | YES | Rule references no path string; behavior is uniform across slice prefixes. |
+| 12 | EXACT_SLICE_ID_METADATA_PRECEDENCE | YES | Tier-1 boost gated on `meta_slice_id.upper() == query_slice`. |
+| 13 | NON_SLICE_TRADE_QUERY_BEHAVIOR_PRESERVED | YES | Proven by `TestNonSliceTradeQueryBehaviorPreserved`; analyst-language queries still get path+alias cascade. |
+| 14 | NO_PUBLIC_SURFACE_MUTATION | YES | `_slice_id_match_boost` signature unchanged; two new module-private constants added. |
+| 15 | NO_WSP_MUTATION | YES | No file under `WSP_framework/` or `WSP_knowledge/` modified. |
+| 16 | NO_DEPENDENCY_CHANGE | YES | `requirements*.txt` and `pyproject.toml` untouched. |
+| 17 | NO_CI_CHANGE | YES | No file under `.github/workflows/` modified. |
+| 18 | RUNTIME_OUTPUT_UNTOUCHED | YES | `holo_index/holo_index/output/holo_output_history.jsonl` left alone (separate hygiene slice). |
+| 19 | T2_AUDIT_DOC_RANK_LIFTED | YES | Pre-fix CLI [DOCS] rank=2 (INTERFACE.md=1); post-fix CLI [DOCS] rank=1 (INTERFACE.md=2). |
+| 20 | T1_T3_NO_REGRESSION | YES | T1 and T3 audit docs remained at [DOCS] rank=1 (verified via `python holo_index.py --search ...`). |
+
+**WSP_97 VERDICT**: PASS (20/20)
+
+---
+
+## 1. Mission
+
+Apply a generic search-time ranking rule that lifts audit/spec docs to
+[DOCS] rank #1 for their exact slice-ID queries when they carry the
+correct `slice_id` metadata, without special-casing any individual
+slice, file path, or Trade-only terms. T1/T2/T3 must all rank #1 on
+their respective slice-ID queries.
+
+Non-slice-ID analyst queries (e.g., "trade due diligence scoring") must
+continue to benefit from the Trade alias/path boost cascade. No reindex,
+no indexer change.
+
+---
+
+## 2. Lineage and resume context
+
+The original W7 slice (2026-05-24, base `d86450997` post-#701) wrote:
+
+- `docs/audits/holoindex_search_quality/HOLOINDEX_T1_RANKING_QUALITY_PHASE1.md` (this audit)
+- `holo_index/tests/test_t1_ranking_quality.py` (15 tests)
+
+but never landed the actual code patch to
+`holo_index/core/search_engine.py`. The patch and the four sibling
+test-assertion updates were missing from the worktree.
+
+Between then and this resume, two HoloIndex fixes landed:
+
+- PR #728: full-body paper chunking (1451 chunks across 47 papers).
+- PR #730: cold-process model import/load timeout raised to 120s.
+
+Neither touched the ranking math; the T2 defect described below was
+re-verified on `3dc26e6f9` and is unchanged.
+
+---
+
+## 3. WSP_97 CoT / CoA / CoE
+
+### 3.1 CoT -- hypothesis and rank-factor analysis
+
+For T2's exact slice-ID query `TRADE_ADAPTER_INTEGRATION_PHASE1` on the
+post-#730 baseline, the keyword-score composition at
+`holo_index/core/search_engine.py:_compute_keyword_score` is:
+
+```
+keyword_score = (
+    _wsp_number_match_boost +    # 0 for non-WSP queries
+    _wsp_alias_match_boost +     # 0 for non-WSP queries
+    _slice_id_match_boost +      # 5.0 (flat) on exact slice-ID match (pre-fix)
+    _work_ledger_combined_boost +
+    _trade_path_boost +          # 8.0 for Trade target docs
+    _trade_alias_keyword_boost   # up to 6.0
+)
+```
+
+For T2's exact slice-ID query:
+
+| Doc | slice_id | trade_path | trade_alias | Total |
+|---|---|---|---|---|
+| `docs/audits/architecture/TRADE_ADAPTER_INTEGRATION_PHASE1.md` | 5.0 | 0 | ~6.0 | ~11.0 |
+| `modules/foundups/trade/INTERFACE.md` | 0 | 8.0 | ~6.0 | ~14.0 |
+
+INTERFACE.md outranks the audit doc on its own slice-ID query because
+the flat `_slice_id_match_boost` (5.0) cannot exceed the
+`_trade_path_boost` + `_trade_alias_keyword_boost` cascade (up to 14.0).
+
+The fix tiers the existing `_slice_id_match_boost` so an exact
+`meta_slice_id` match returns 20.0 (strictly greater than 14.0). The
+rule:
+
+- Refers to no specific slice ID, filename, or module.
+- Triggers only when (a) the query contains a literal slice-ID token AND
+  (b) the document's `meta_slice_id.upper()` exactly equals that token.
+- Leaves the path/title-only fallback at 5.0 so docs without populated
+  `slice_id` metadata are not regressed.
+- Returns 0.0 unchanged for queries that contain no slice-ID literal --
+  so analyst-language queries still ride the Trade path/alias cascade.
+
+### 3.2 CoA -- exact change
+
+Single-function edit in `holo_index/core/search_engine.py`:
+
+| Before | After |
+|--------|-------|
+| `_slice_id_match_boost` returned flat `5.0` for any slice-ID match across path, title, OR metadata. | Two module-private constants `_SLICE_ID_METADATA_PRECEDENCE_BOOST = 20.0` (tier 1) and `_SLICE_ID_PATH_OR_TITLE_BOOST = 5.0` (tier 2). The function checks metadata first; returns 20.0 when `meta_slice_id.upper()` matches a query-extracted slice ID, else returns 5.0 on path/title match, else 0.0. |
+
+No other code path changed. No new file added under `holo_index/core/`.
+No indexer touch. No Chroma writes. No reindex.
+
+The lexical-fallback path (`_lexical_search_collection`) automatically
+benefits from the same fix because it imports and calls the same
+function.
+
+### 3.3 CoE -- before / after evidence (post-#730 CLI)
+
+CLI command used for each row:
+`python holo_index.py --search "<slice_id>" --limit 10`
+
+| Target | Slice ID | BEFORE [DOCS] rank-1 | T-doc rank | AFTER [DOCS] rank-1 | T-doc rank |
+|--------|----------|----------------------|-----------:|---------------------|-----------:|
+| T1 | `TRADE_PUMPFUN_DUE_DILIGENCE_SCORING_SPEC_PHASE1` | T1 audit | 1 | T1 audit | 1 (unchanged) |
+| T2 | `TRADE_ADAPTER_INTEGRATION_PHASE1` | `modules/foundups/trade/INTERFACE.md` | 2 | T2 audit | **1 (lifted)** |
+| T3 | `HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1` | T3 audit | 1 | T3 audit | 1 (unchanged) |
+
+Architect success bar (T1/T2/T3 all [DOCS] rank #1): **MET**.
+
+**No-reindex proof**: this slice did not invoke `python holo_index.py
+--index-docs` nor any indexer entrypoint. The same persistent Chroma
+collection at `E:/HoloIndex/vectors` is queried before and after.
+
+---
+
+## 4. DESIGN -- the rule
+
+For any slice-ID `S` extracted from the query, a document whose
+`metadata.slice_id.upper() == S` receives the tier-1 precedence boost
+`_SLICE_ID_METADATA_PRECEDENCE_BOOST` (20.0). Otherwise, if `S` appears
+in the document's path or title, the tier-2 fallback
+`_SLICE_ID_PATH_OR_TITLE_BOOST` (5.0) applies. Otherwise 0.0.
+
+**Why 20.0**: it must strictly exceed the maximum sum of all current
+non-slice-id keyword boosts. The dominant non-slice-id stack is
+`_trade_path_boost.cap (8.0) + _trade_alias_keyword_boost.cap (6.0) =
+14.0`. 20.0 leaves a 6-point margin against accidental escalation. This
+invariant is pinned by
+`TestSliceIdPrecedenceConstants::test_metadata_precedence_exceeds_max_trade_combination`,
+which reads the caps directly from the boost helpers and asserts strict
+inequality -- so any future cap increase will fail loudly before
+causing a silent regression.
+
+**Why path/title fallback stays at 5.0**: docs whose `slice_id`
+metadata is empty (e.g., older docs that have not been re-indexed under
+the HXA fix) still receive the original 5.0 boost. The fix is strictly
+additive to the existing tier; no doc loses a boost.
+
+---
+
+## 5. IMPLEMENTATION -- files changed
+
+| File | Change | Reason |
+|------|--------|--------|
+| `holo_index/core/search_engine.py` | MODIFIED -- two module-private constants (`_SLICE_ID_METADATA_PRECEDENCE_BOOST`, `_SLICE_ID_PATH_OR_TITLE_BOOST`); `_slice_id_match_boost` tiered into metadata-precedence vs. path/title tiers. | The fix itself. |
+| `holo_index/tests/test_t1_ranking_quality.py` | NEW (resumed from W7) -- 15 tests pinning the precedence constants, per-target metadata-wins property, and anti-overfit / no-Trade-special-case / non-slice-id-query-behavior-preserved invariants. | Slice scope item 2. |
+| `holo_index/tests/test_audit_spec_slice_id_indexing.py` | MODIFIED -- 4 assertion-only updates to reference the new tier constants; docstrings updated to record the tiered semantics. | Reflect tiered policy; no behavioral change to those tests. |
+| `holo_index/tests/test_hxa_retrieval_fix.py` | MODIFIED -- 2 assertion-only updates to reference the new tier constants. | Reflect tiered policy. |
+| `docs/audits/holoindex_search_quality/HOLOINDEX_T1_RANKING_QUALITY_PHASE1.md` | NEW (this audit -- W6 resume) | Slice scope item 3; W7 dirty file repaired. |
+| `holo_index/ModLog.md` | MODIFIED -- W6 resume entry. | WSP 22. |
+
+Files **not** touched (boundary preserved):
+
+- `holo_index/core/indexing_engine.py`
+- `holo_index/core/holo_index.py` (no timeout-default change)
+- Any Chroma collection / persisted vector
+- `modules/foundups/trade/**`
+- `modules/foundups/registry/**`, `manifest/**`, `projection/**`, `catalog/**`
+- `WSP_framework/**`, `WSP_knowledge/**`
+- CI workflow files
+- `holo_index/holo_index/output/holo_output_history.jsonl` (runtime output -- separate hygiene slice)
+
+---
+
+## 6. VERIFICATION
+
+### 6.1 Targeted ranking-quality suites
+
+```
+$ python -m pytest holo_index/tests/test_t1_ranking_quality.py \
+                   holo_index/tests/test_hxa_retrieval_fix.py \
+                   holo_index/tests/test_audit_spec_slice_id_indexing.py -q
+65 passed in 2.64s
+```
+
+Per-suite breakdown:
+
+| Suite | Status |
+|-------|--------|
+| `test_t1_ranking_quality.py` (resumed) | PASS (15 tests) |
+| `test_hxa_retrieval_fix.py` (2 assertions updated) | PASS |
+| `test_audit_spec_slice_id_indexing.py` (4 assertions updated) | PASS |
+
+### 6.2 CLI ranking proof
+
+```
+$ python holo_index.py --search "TRADE_ADAPTER_INTEGRATION_PHASE1" --limit 10
+[DOCS] docs/audits/architecture/TRADE_ADAPTER_INTEGRATION_PHASE1.md   <- rank 1 (lifted)
+[DOCS] modules/foundups/trade/INTERFACE.md                            <- rank 2
+
+$ python holo_index.py --search "TRADE_PUMPFUN_DUE_DILIGENCE_SCORING_SPEC_PHASE1" --limit 10
+[DOCS] docs/audits/architecture/TRADE_PUMPFUN_DUE_DILIGENCE_SCORING_SPEC_PHASE1.md   <- rank 1
+
+$ python holo_index.py --search "HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1" --limit 10
+[DOCS] docs/audits/holoindex_search_quality/HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1.md   <- rank 1
+```
+
+### 6.3 HoloIndex retrieval evaluation (WSP 87)
+
+| Query | Surfaced expected docs? | Quality |
+|-------|-------------------------|---------|
+| `slice id metadata precedence ranking boost HoloIndex` | YES -- HOLOINDEX audit docs in [DOCS]; `holoindex_plugin.py` in [CODE]. | OK |
+| `TRADE_ADAPTER_INTEGRATION_PHASE1 ranking interface outranks audit` | YES -- T2 audit doc in [DOCS]; HIA_AGENTIC_RAG_RANKING_QUALITY_PHASE6 surfaced (relevant prior ranking work). | OK |
+| `HOLOINDEX_T1_RANKING_QUALITY_PHASE1` | NO (pre-fix) -- this audit doc had not yet been indexed; sibling HOLOINDEX_* audit docs surfaced instead. | EXPECTED (no reindex run) |
+
+The third query's gap is expected: this audit doc is freshly written
+this slice and not yet in the `navigation_docs` collection. A future
+docs-reindex slice will pick it up; that is out of scope here per
+`NO_REINDEX`.
+
+---
+
+## 7. Anti-overfit guarantees
+
+Pinned by `holo_index/tests/test_t1_ranking_quality.py`:
+
+- `TestNoTradeOrPathSpecialCase::test_non_slice_id_query_returns_zero` --
+  analyst-language queries (no slice-ID literal) get 0.0 from
+  `_slice_id_match_boost`, so Trade alias/path boosts still control
+  ranking on those queries.
+- `TestNoTradeOrPathSpecialCase::test_metadata_match_works_for_non_trade_slice` --
+  a HOLOINDEX-domain slice (no Trade content) gets the tier-1 boost --
+  the rule is not Trade-specific.
+- `TestNoTradeOrPathSpecialCase::test_unrelated_slice_id_no_boost` -- a
+  doc with a different `meta_slice_id` than the query gets 0.0 -- not
+  a blanket "all audit docs win" lever.
+- `TestNoTradeOrPathSpecialCase::test_path_only_slice_match_keeps_original_5point0` --
+  backward-compatible: docs with empty `meta_slice_id` still get the
+  tier-2 (5.0) boost from path/title match.
+- `TestNonSliceTradeQueryBehaviorPreserved::test_trade_path_boost_still_fires_for_trade_target_docs` --
+  `_trade_path_boost` still returns 8.0 for Trade target docs on
+  analyst queries.
+- `TestNonSliceTradeQueryBehaviorPreserved::test_trade_alias_boost_still_fires_for_alias_match` --
+  `_trade_alias_keyword_boost` still fires for alias queries.
+- `TestGenericMetadataPrecedenceProperty::test_arbitrary_holoindex_slice_id_metadata_wins`,
+  `..._foundups_slice_id_metadata_wins`,
+  `..._short_form_slice_id_metadata_wins` -- the rule applies uniformly
+  to any slice ID, any prefix (HOLOINDEX_, FOUNDUPS_, HXA*), any path.
+
+---
+
+## 8. Completion Summary
+
+| Item | Value |
+|------|-------|
+| Decision | RESUME_AND_REPAIR |
+| Branch | `main` (working tree -- this audit + sibling files) |
+| Worker-Lane | W6 |
+| Slice | `HOLOINDEX_T1_RANKING_QUALITY_PHASE1` |
+| Base commit | `3dc26e6f9` (origin/main, post-PR #730) |
+| Files changed | 6 (1 src tier, 1 new test file resumed, 2 sibling test-assertion updates, 1 audit doc rewrite, 1 ModLog entry) |
+| Dirty files resolved | both (audit doc repaired + lineage updated; tests reconciled with code) |
+| Runtime output untouched | YES (`holo_index/holo_index/output/holo_output_history.jsonl` not modified) |
+| Reindex executed | NO |
+| T1 [DOCS] rank (BEFORE -> AFTER) | 1 -> 1 (unchanged) |
+| T2 [DOCS] rank (BEFORE -> AFTER) | 2 -> **1 (lifted)** |
+| T3 [DOCS] rank (BEFORE -> AFTER) | 1 -> 1 (unchanged) |
+| Architect success bar (T1/T2/T3 all #1) | MET |
+| Tests run | `test_t1_ranking_quality.py` + `test_hxa_retrieval_fix.py` + `test_audit_spec_slice_id_indexing.py` -- 65 passed |
+| WSP_97 truth boundary | PASS (20/20) |
+
+---
+
+**Worker-Lane**: W6
+**Slice**: `HOLOINDEX_T1_RANKING_QUALITY_PHASE1`
+**WSP Lock**: WSP_00 -> WSP_15 -> WSP_50 -> WSP_64 -> WSP_83 -> WSP_87 -> WSP_97 -> WSP_22

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,82 @@
 # HoloIndex Package ModLog
 
+## [2026-05-30] HOLOINDEX_T1_RANKING_QUALITY_PHASE1 (W6 resume)
+
+**Agent**: W6 (0102)
+**WSP References**: WSP 50, WSP 87, WSP 97, WSP 22
+**Status**: COMPLETE
+**Decision**: RESUME_AND_REPAIR (stale W7 slice from 2026-05-24)
+**Base**: `3dc26e6f9` (post-PR #730)
+
+### Summary
+
+Tiered `_slice_id_match_boost` in `holo_index/core/search_engine.py` so
+docs whose `meta_slice_id` exactly matches a query slice-ID literal
+outrank sibling docs that only benefit from the Trade module path/alias
+keyword cascade. T2 audit doc lifted from CLI [DOCS] rank 2 to rank 1
+on its exact slice-ID query; T1 and T3 unchanged at rank 1.
+
+### Root Cause
+
+Pre-fix `_slice_id_match_boost` returned a flat 5.0 on any slice-ID
+match (path, title, or metadata). `_trade_path_boost.cap (8.0) +
+_trade_alias_keyword_boost.cap (6.0) = 14.0` could exceed the flat
+slice-ID boost, letting `modules/foundups/trade/INTERFACE.md` outrank
+the `TRADE_ADAPTER_INTEGRATION_PHASE1` audit doc on its own slice-ID
+query. The defect persisted across PR #728 and PR #730 because neither
+touched the ranking math.
+
+### Changes
+
+- `holo_index/core/search_engine.py`:
+  - Added module-private constants `_SLICE_ID_METADATA_PRECEDENCE_BOOST
+    = 20.0` (tier 1) and `_SLICE_ID_PATH_OR_TITLE_BOOST = 5.0` (tier 2).
+  - Rewrote `_slice_id_match_boost` body: metadata-exact match returns
+    tier 1; path/title-only match returns tier 2; otherwise 0.0.
+  - Function signature, lexical-fallback path, and cosine search path
+    unchanged.
+- `holo_index/tests/test_t1_ranking_quality.py` (NEW, 15 tests).
+- `holo_index/tests/test_audit_spec_slice_id_indexing.py`: 4
+  assertion-only updates -- metadata-match assertions now reference
+  `_SLICE_ID_METADATA_PRECEDENCE_BOOST`; path/title-only assertions
+  reference `_SLICE_ID_PATH_OR_TITLE_BOOST`.
+- `holo_index/tests/test_hxa_retrieval_fix.py`: 2 assertion-only
+  updates -- HXA22 / CFZ4 metadata-match assertions reference
+  `_SLICE_ID_METADATA_PRECEDENCE_BOOST`.
+- `docs/audits/holoindex_search_quality/HOLOINDEX_T1_RANKING_QUALITY_PHASE1.md`
+  (REWRITE): repaired mojibake -> ASCII, canonical WSP_97 header (20
+  rows), lineage updated to post-#730, decision recorded as
+  RESUME_AND_REPAIR.
+
+### Tests
+
+```
+python -m pytest holo_index/tests/test_t1_ranking_quality.py \
+                 holo_index/tests/test_hxa_retrieval_fix.py \
+                 holo_index/tests/test_audit_spec_slice_id_indexing.py -q
+65 passed in 2.64s
+```
+
+CLI verification on post-#730 baseline:
+
+| Query | Pre-fix [DOCS] rank-1 | Post-fix [DOCS] rank-1 |
+|-------|-----------------------|------------------------|
+| `TRADE_ADAPTER_INTEGRATION_PHASE1` | `modules/foundups/trade/INTERFACE.md` | `docs/audits/architecture/TRADE_ADAPTER_INTEGRATION_PHASE1.md` |
+| `TRADE_PUMPFUN_DUE_DILIGENCE_SCORING_SPEC_PHASE1` | T1 audit (unchanged) | T1 audit |
+| `HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1` | T3 audit (unchanged) | T3 audit |
+
+### Hard Constraints (all upheld)
+
+NO_LIVE_CHROMA_MUTATION, NO_REINDEX, NO_DOCS_INDEX_MUTATION,
+NO_TIMEOUT_DEFAULT_CHANGE, NO_KNOWLEDGE_CHUNKING_CHANGE,
+NO_SEARCH_ALGORITHM_REWRITE, NO_TRADE_SPECIFIC_SPECIAL_CASE,
+NO_PATH_SPECIFIC_SPECIAL_CASE, NO_WSP_MUTATION, NO_DEPENDENCY_CHANGE,
+NO_CI_CHANGE, NO_PUBLIC_SURFACE_MUTATION.
+
+WSP_97 checklist: PASS 20/20.
+
+---
+
 ## [2026-05-30] HOLOINDEX_COLD_MODEL_TIMEOUT_BOUNDARY_PHASE1
 
 **Agent**: W6 (0102)

--- a/holo_index/core/search_engine.py
+++ b/holo_index/core/search_engine.py
@@ -195,26 +195,50 @@ def _extract_slice_ids(text: str) -> List[str]:
     return short_ids + long_matches
 
 
-def _slice_id_match_boost(query: str, path: str, title: str, meta_slice_id: str = "") -> float:
-    """HXA Audit Fix: Return keyword boost if query slice ID matches path/title/metadata.
+# Tier-1 boost when an exact ``meta_slice_id`` match is observed. Must
+# strictly exceed the maximum sum of all non-slice-id keyword boosts
+# (currently _trade_path_boost cap 8.0 + _trade_alias_keyword_boost cap
+# 6.0 = 14.0) so a doc carrying proper slice_id metadata cannot be
+# outranked by a sibling that benefits from the module path/alias
+# cascade. A future cap increase will fail the precedence invariant test.
+_SLICE_ID_METADATA_PRECEDENCE_BOOST = 20.0
 
-    Boosts exact slice ID matches (HXA22, FX1, CFZ4) to fix retrieval gaps.
+# Tier-2 fallback for docs that match the query slice ID only via path
+# or title (no slice_id metadata). Preserves prior behavior for docs that
+# have not been re-indexed under the HXA metadata fix.
+_SLICE_ID_PATH_OR_TITLE_BOOST = 5.0
+
+
+def _slice_id_match_boost(query: str, path: str, title: str, meta_slice_id: str = "") -> float:
+    """Return tiered slice-ID keyword boost.
+
+    - Tier 1 (metadata precedence): if the query contains a literal
+      slice-ID token and the doc's ``meta_slice_id`` exactly equals that
+      token, return ``_SLICE_ID_METADATA_PRECEDENCE_BOOST``.
+    - Tier 2 (path/title fallback): if the same query slice-ID literal
+      appears in the doc path or title (no metadata match), return
+      ``_SLICE_ID_PATH_OR_TITLE_BOOST``.
+    - Otherwise 0.0 — including any query that carries no slice-ID
+      literal, so analyst-language queries are not affected by this rule.
     """
     query_slices = _extract_slice_ids(query)
     if not query_slices:
         return 0.0
 
-    # Check path, title, and metadata slice_id
+    # Tier 1: exact metadata slice_id match wins over path/title hits.
+    if meta_slice_id:
+        meta_upper = meta_slice_id.upper()
+        for qslice in query_slices:
+            if qslice == meta_upper:
+                return _SLICE_ID_METADATA_PRECEDENCE_BOOST
+
+    # Tier 2: path or title slice-ID hit.
     path_slices = _extract_slice_ids(path)
     title_slices = _extract_slice_ids(title)
-    all_target_slices = set(path_slices + title_slices)
-    if meta_slice_id:
-        all_target_slices.add(meta_slice_id.upper())
-
-    # Strong boost for exact match
+    path_or_title = set(path_slices + title_slices)
     for qslice in query_slices:
-        if qslice in all_target_slices:
-            return 5.0  # Strong boost for exact slice ID match
+        if qslice in path_or_title:
+            return _SLICE_ID_PATH_OR_TITLE_BOOST
 
     return 0.0
 

--- a/holo_index/tests/test_audit_spec_slice_id_indexing.py
+++ b/holo_index/tests/test_audit_spec_slice_id_indexing.py
@@ -166,8 +166,11 @@ class TestAuditSpecSliceIdBoost:
     """Test slice ID boost for audit spec IDs in search ranking."""
 
     def test_audit_spec_match_boost(self):
-        """Audit spec ID query boosts matching doc."""
-        from holo_index.core.search_engine import _slice_id_match_boost
+        """Audit spec ID query boosts matching doc via meta_slice_id (tier 1)."""
+        from holo_index.core.search_engine import (
+            _SLICE_ID_METADATA_PRECEDENCE_BOOST,
+            _slice_id_match_boost,
+        )
 
         boost = _slice_id_match_boost(
             query="FOUNDUPS_PORTFOLIO_DATA_VALIDATOR_PHASE1",
@@ -175,11 +178,14 @@ class TestAuditSpecSliceIdBoost:
             title="Portfolio Data Validator Phase 1",
             meta_slice_id="FOUNDUPS_PORTFOLIO_DATA_VALIDATOR_PHASE1",
         )
-        assert boost == 5.0
+        assert boost == _SLICE_ID_METADATA_PRECEDENCE_BOOST
 
     def test_audit_spec_match_via_path(self):
-        """Boost applied when slice ID is in path even if not in meta."""
-        from holo_index.core.search_engine import _slice_id_match_boost
+        """Boost applied when slice ID is in path even if not in meta (tier 2)."""
+        from holo_index.core.search_engine import (
+            _SLICE_ID_PATH_OR_TITLE_BOOST,
+            _slice_id_match_boost,
+        )
 
         boost = _slice_id_match_boost(
             query="FOUNDUPS_PORTFOLIO_DATA_VALIDATOR_PHASE1",
@@ -187,11 +193,14 @@ class TestAuditSpecSliceIdBoost:
             title="Some Title",
             meta_slice_id="",  # No metadata slice_id
         )
-        assert boost == 5.0
+        assert boost == _SLICE_ID_PATH_OR_TITLE_BOOST
 
     def test_audit_spec_match_via_title(self):
-        """Boost applied when slice ID is in title."""
-        from holo_index.core.search_engine import _slice_id_match_boost
+        """Boost applied when slice ID is in title (tier 2)."""
+        from holo_index.core.search_engine import (
+            _SLICE_ID_PATH_OR_TITLE_BOOST,
+            _slice_id_match_boost,
+        )
 
         boost = _slice_id_match_boost(
             query="PORTFOLIO_DATA_VALIDATOR_PHASE1",
@@ -199,11 +208,14 @@ class TestAuditSpecSliceIdBoost:
             title="PORTFOLIO_DATA_VALIDATOR_PHASE1 - Audit Report",
             meta_slice_id="",
         )
-        assert boost == 5.0
+        assert boost == _SLICE_ID_PATH_OR_TITLE_BOOST
 
     def test_audit_spec_match_via_metadata(self):
-        """Boost applied when slice ID is only in metadata."""
-        from holo_index.core.search_engine import _slice_id_match_boost
+        """Boost applied when slice ID is only in metadata (tier 1)."""
+        from holo_index.core.search_engine import (
+            _SLICE_ID_METADATA_PRECEDENCE_BOOST,
+            _slice_id_match_boost,
+        )
 
         boost = _slice_id_match_boost(
             query="FOUNDUPS_PORTFOLIO_DATA_VALIDATOR_PHASE1",
@@ -211,7 +223,7 @@ class TestAuditSpecSliceIdBoost:
             title="Generic Audit",
             meta_slice_id="FOUNDUPS_PORTFOLIO_DATA_VALIDATOR_PHASE1",
         )
-        assert boost == 5.0
+        assert boost == _SLICE_ID_METADATA_PRECEDENCE_BOOST
 
     def test_no_boost_for_different_audit_spec(self):
         """No boost when query audit spec differs from target."""
@@ -238,8 +250,11 @@ class TestAuditSpecSliceIdBoost:
         assert boost == 0.0
 
     def test_hxa_boost_still_works(self):
-        """HXA boost still works (no regression)."""
-        from holo_index.core.search_engine import _slice_id_match_boost
+        """HXA boost still works (tier 1 via metadata)."""
+        from holo_index.core.search_engine import (
+            _SLICE_ID_METADATA_PRECEDENCE_BOOST,
+            _slice_id_match_boost,
+        )
 
         boost = _slice_id_match_boost(
             query="HXA22 destructive action guard",
@@ -247,7 +262,7 @@ class TestAuditSpecSliceIdBoost:
             title="HXA22 - Destructive Action Guard Runtime",
             meta_slice_id="HXA22",
         )
-        assert boost == 5.0
+        assert boost == _SLICE_ID_METADATA_PRECEDENCE_BOOST
 
 
 class TestSyntheticIndexAndSearch:
@@ -281,12 +296,17 @@ class TestSyntheticIndexAndSearch:
             assert slice_id == expected_slice_id, f"Failed for {filename}"
 
     def test_synthetic_search_ranking_prefers_exact_slice_match(self):
-        """Synthetic proof: exact slice ID match gets 5.0 boost over semantic-similar docs."""
-        from holo_index.core.search_engine import _slice_id_match_boost
+        """Synthetic proof: exact metadata slice ID match gets tier-1 boost
+        over semantic-similar distractor docs (which match no query slice).
+        """
+        from holo_index.core.search_engine import (
+            _SLICE_ID_METADATA_PRECEDENCE_BOOST,
+            _slice_id_match_boost,
+        )
 
         query = "FOUNDUPS_PORTFOLIO_DATA_VALIDATOR_PHASE1"
 
-        # Target doc: exact slice ID match
+        # Target doc: exact metadata slice ID match
         target_boost = _slice_id_match_boost(
             query=query,
             path="docs/audits/architecture/FOUNDUPS_PORTFOLIO_DATA_VALIDATOR_PHASE1.md",
@@ -316,8 +336,8 @@ class TestSyntheticIndexAndSearch:
             ),
         ]
 
-        # Target gets 5.0 boost, distractors get 0.0
-        assert target_boost == 5.0
+        # Target gets tier-1 boost, distractors get 0.0
+        assert target_boost == _SLICE_ID_METADATA_PRECEDENCE_BOOST
         for distractor_boost in distractor_boosts:
             assert distractor_boost == 0.0
 

--- a/holo_index/tests/test_hxa_retrieval_fix.py
+++ b/holo_index/tests/test_hxa_retrieval_fix.py
@@ -67,8 +67,11 @@ class TestSliceIdBoost:
     """Test slice ID boost in search ranking."""
 
     def test_slice_id_match_boost_hxa(self):
-        """HXA22 query boosts HXA22 path."""
-        from holo_index.core.search_engine import _slice_id_match_boost
+        """HXA22 query boosts HXA22 doc via metadata (tier 1)."""
+        from holo_index.core.search_engine import (
+            _SLICE_ID_METADATA_PRECEDENCE_BOOST,
+            _slice_id_match_boost,
+        )
 
         boost = _slice_id_match_boost(
             query="HXA22 destructive action guard",
@@ -76,11 +79,14 @@ class TestSliceIdBoost:
             title="HXA22 - Destructive Action Guard Runtime",
             meta_slice_id="HXA22",
         )
-        assert boost == 5.0
+        assert boost == _SLICE_ID_METADATA_PRECEDENCE_BOOST
 
     def test_slice_id_match_boost_cfz(self):
-        """CFZ4 query boosts CFZ4 path."""
-        from holo_index.core.search_engine import _slice_id_match_boost
+        """CFZ4 query boosts CFZ4 doc via metadata (tier 1)."""
+        from holo_index.core.search_engine import (
+            _SLICE_ID_METADATA_PRECEDENCE_BOOST,
+            _slice_id_match_boost,
+        )
 
         boost = _slice_id_match_boost(
             query="CFZ4 collection separation",
@@ -88,7 +94,7 @@ class TestSliceIdBoost:
             title="CFZ4 - Collection Separation",
             meta_slice_id="CFZ4",
         )
-        assert boost == 5.0
+        assert boost == _SLICE_ID_METADATA_PRECEDENCE_BOOST
 
     def test_no_boost_for_different_slice(self):
         """No boost when query slice differs from path slice."""

--- a/holo_index/tests/test_t1_ranking_quality.py
+++ b/holo_index/tests/test_t1_ranking_quality.py
@@ -1,0 +1,322 @@
+# -*- coding: utf-8 -*-
+"""Slice-ID metadata precedence — search-time ranking quality tests.
+
+Slice: HOLOINDEX_T1_RANKING_QUALITY_PHASE1
+Worker: W7
+
+The rule under test is generic:
+
+    When a query carries a literal slice-ID token AND a document's
+    ``meta_slice_id`` is exactly that token, the document outranks any
+    other document on the same query — including a sibling that benefits
+    from the Trade module path / alias boosts — purely by composition of
+    keyword-score boosts (no reindex, no Chroma writes).
+
+These tests exercise the boost-composition math directly so a future
+boost-cap change anywhere in the cascade is caught immediately. They do
+**not** mock the search pipeline as a whole — they call the boost helpers
+that the pipeline composes, with realistic inputs (audit-doc path vs.
+module-root path, with and without ``slice_id`` metadata).
+"""
+
+from __future__ import annotations
+
+from holo_index.core.search_engine import (
+    _SLICE_ID_METADATA_PRECEDENCE_BOOST,
+    _SLICE_ID_PATH_OR_TITLE_BOOST,
+    _slice_id_match_boost,
+    _trade_alias_keyword_boost,
+    _trade_path_boost,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixed constants for the three reference targets from the slice prompt.
+# ---------------------------------------------------------------------------
+
+T1_SLICE = "TRADE_PUMPFUN_DUE_DILIGENCE_SCORING_SPEC_PHASE1"
+T1_PATH = (
+    "docs/audits/architecture/TRADE_PUMPFUN_DUE_DILIGENCE_SCORING_SPEC_PHASE1.md"
+)
+T1_TITLE = "Trade Pump.fun Due Diligence Scoring Spec - Phase 1"
+
+T2_SLICE = "TRADE_ADAPTER_INTEGRATION_PHASE1"
+T2_PATH = "docs/audits/architecture/TRADE_ADAPTER_INTEGRATION_PHASE1.md"
+T2_TITLE = "Trade Adapter Integration - Phase 1"
+
+T3_SLICE = "HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1"
+T3_PATH = (
+    "docs/audits/holoindex_search_quality/"
+    "HOLOINDEX_FOUNDUP_QUERY_ALIAS_AND_TARGETED_VERDICT_PHASE1.md"
+)
+T3_TITLE = "HoloIndex FoundUp Query Alias and Targeted Verdict - Phase 1"
+
+# Sibling that previously outranked T2 on its own slice-ID query because of
+# the Trade module-root path boost.
+TRADE_INTERFACE_PATH = "modules/foundups/trade/INTERFACE.md"
+TRADE_INTERFACE_TITLE = "Trade Module Interface"
+
+
+# ---------------------------------------------------------------------------
+# Precedence constants — defended against silent erosion
+# ---------------------------------------------------------------------------
+
+
+class TestSliceIdPrecedenceConstants:
+    """The numeric precedence rule must dominate competing boosts."""
+
+    def test_metadata_precedence_exceeds_max_trade_combination(self):
+        """Metadata precedence boost must strictly exceed the max sum of
+        ``_trade_path_boost`` cap (8.0) + ``_trade_alias_keyword_boost`` cap
+        (6.0). If a future code change raises either cap, this assertion
+        forces the precedence boost to be re-evaluated.
+        """
+        # Sanity: read the caps directly out of the boost helpers by
+        # probing them at their documented saturation points.
+        trade_path_cap = _trade_path_boost(
+            "trade scoring", "modules/foundups/trade/INTERFACE.md"
+        )
+        # Trade alias boost saturates at 6.0 for any number of alias matches.
+        trade_alias_cap = _trade_alias_keyword_boost(
+            "trade analyst due diligence rug honeypot whale concentration",
+            "docs/audits/architecture/SOMETHING.md",
+            "Some audit doc",
+            "trade analyst due diligence rug honeypot whale concentration",
+        )
+        max_competing = trade_path_cap + trade_alias_cap
+        assert _SLICE_ID_METADATA_PRECEDENCE_BOOST > max_competing, (
+            f"metadata precedence boost ({_SLICE_ID_METADATA_PRECEDENCE_BOOST}) "
+            f"must strictly exceed max non-slice-id boost sum ({max_competing})"
+        )
+
+    def test_metadata_precedence_strictly_greater_than_path_title(self):
+        """Tier-1 (metadata) boost must strictly exceed tier-2 (path/title)
+        boost so a doc with proper metadata cannot be outranked by a doc
+        whose only signal is path/title slice-ID presence.
+        """
+        assert (
+            _SLICE_ID_METADATA_PRECEDENCE_BOOST > _SLICE_ID_PATH_OR_TITLE_BOOST
+        )
+
+
+# ---------------------------------------------------------------------------
+# Generic rule: exact metadata slice_id match wins
+# ---------------------------------------------------------------------------
+
+
+class TestExactSliceIdMetadataPrecedence:
+    """For an exact slice-ID query, a doc whose ``meta_slice_id`` exactly
+    matches the query MUST outrank a doc whose only signal is the Trade
+    path/alias boost cascade.
+    """
+
+    def _competing_score(self, query: str, path: str, title: str, content: str) -> float:
+        """The non-slice-id boost portion of the keyword score, as composed
+        in ``_compute_keyword_score`` (path + alias)."""
+        return (
+            _trade_path_boost(query, path)
+            + _trade_alias_keyword_boost(query, path, title, content)
+        )
+
+    def test_t2_audit_doc_outranks_trade_interface_on_t2_slice_id_query(self):
+        """The regression target named by the slice prompt: T2 must outrank
+        ``modules/foundups/trade/INTERFACE.md`` for the exact T2 slice-ID query.
+        """
+        audit_score = _slice_id_match_boost(
+            T2_SLICE, T2_PATH, T2_TITLE, T2_SLICE
+        ) + self._competing_score(T2_SLICE, T2_PATH, T2_TITLE, T2_TITLE)
+        interface_score = _slice_id_match_boost(
+            T2_SLICE, TRADE_INTERFACE_PATH, TRADE_INTERFACE_TITLE, ""
+        ) + self._competing_score(
+            T2_SLICE, TRADE_INTERFACE_PATH, TRADE_INTERFACE_TITLE, ""
+        )
+        assert audit_score > interface_score, (
+            f"T2 audit doc score ({audit_score}) must outrank Trade "
+            f"INTERFACE.md score ({interface_score}) on its own slice-ID query"
+        )
+
+    def test_t1_audit_doc_outranks_trade_interface_on_t1_slice_id_query(self):
+        audit_score = _slice_id_match_boost(
+            T1_SLICE, T1_PATH, T1_TITLE, T1_SLICE
+        ) + self._competing_score(T1_SLICE, T1_PATH, T1_TITLE, T1_TITLE)
+        interface_score = _slice_id_match_boost(
+            T1_SLICE, TRADE_INTERFACE_PATH, TRADE_INTERFACE_TITLE, ""
+        ) + self._competing_score(
+            T1_SLICE, TRADE_INTERFACE_PATH, TRADE_INTERFACE_TITLE, ""
+        )
+        assert audit_score > interface_score
+
+    def test_t3_audit_doc_outranks_trade_interface_on_t3_slice_id_query(self):
+        audit_score = _slice_id_match_boost(
+            T3_SLICE, T3_PATH, T3_TITLE, T3_SLICE
+        ) + self._competing_score(T3_SLICE, T3_PATH, T3_TITLE, T3_TITLE)
+        interface_score = _slice_id_match_boost(
+            T3_SLICE, TRADE_INTERFACE_PATH, TRADE_INTERFACE_TITLE, ""
+        ) + self._competing_score(
+            T3_SLICE, TRADE_INTERFACE_PATH, TRADE_INTERFACE_TITLE, ""
+        )
+        assert audit_score > interface_score
+
+
+# ---------------------------------------------------------------------------
+# Generic property — the rule does not name any specific slice or file
+# ---------------------------------------------------------------------------
+
+
+class TestGenericMetadataPrecedenceProperty:
+    """The metadata-precedence rule must apply uniformly to any audit/spec
+    doc that carries proper ``slice_id`` metadata, regardless of file
+    path, slice prefix, or domain.
+    """
+
+    def test_arbitrary_holoindex_slice_id_metadata_wins(self):
+        slice_id = "HOLOINDEX_HXA_AUDIT_INDEXING_FIX_PHASE1"
+        audit_path = (
+            "docs/audits/holoindex_search_quality/"
+            "HOLOINDEX_HXA_AUDIT_INDEXING_FIX_PHASE1.md"
+        )
+        audit_score = _slice_id_match_boost(slice_id, audit_path, "Some title", slice_id)
+        non_audit_score = _slice_id_match_boost(
+            slice_id, "modules/foundups/trade/INTERFACE.md", "Trade INTERFACE", ""
+        )
+        assert audit_score > non_audit_score
+        assert audit_score == _SLICE_ID_METADATA_PRECEDENCE_BOOST
+
+    def test_arbitrary_foundups_slice_id_metadata_wins(self):
+        slice_id = "FOUNDUPS_PORTFOLIO_DATA_VALIDATOR_PHASE1"
+        audit_path = (
+            "docs/audits/architecture/FOUNDUPS_PORTFOLIO_DATA_VALIDATOR_PHASE1.md"
+        )
+        audit_score = _slice_id_match_boost(slice_id, audit_path, "Some title", slice_id)
+        # Even a Trade-target path can't beat metadata precedence
+        non_audit_score = _slice_id_match_boost(
+            slice_id, "modules/foundups/trade/README.md", "Trade README", ""
+        )
+        assert audit_score > non_audit_score
+        assert audit_score == _SLICE_ID_METADATA_PRECEDENCE_BOOST
+
+    def test_short_form_slice_id_metadata_wins(self):
+        """The tiering also covers short-form HXA/FX/CFZ slice IDs."""
+        slice_id = "HXA22"
+        audit_score = _slice_id_match_boost(
+            slice_id, "docs/audits/openclaw_hermes/HXA22.md", "Some title", slice_id
+        )
+        non_audit_score = _slice_id_match_boost(
+            slice_id, "modules/foundups/trade/INTERFACE.md", "Trade INTERFACE", ""
+        )
+        assert audit_score > non_audit_score
+        assert audit_score == _SLICE_ID_METADATA_PRECEDENCE_BOOST
+
+
+# ---------------------------------------------------------------------------
+# Anti-overfit guards
+# ---------------------------------------------------------------------------
+
+
+class TestNoTradeOrPathSpecialCase:
+    """The fix must not encode any Trade-specific or path-specific
+    short-circuit. These tests pin behaviour against accidental
+    special-casing.
+    """
+
+    def test_non_slice_id_query_returns_zero(self):
+        """Analyst-language queries (no slice-ID literal) get no slice-ID
+        boost, so Trade alias / path boosts still control ranking."""
+        assert (
+            _slice_id_match_boost(
+                "trade due diligence scoring",
+                T1_PATH,
+                T1_TITLE,
+                T1_SLICE,
+            )
+            == 0.0
+        )
+        assert (
+            _slice_id_match_boost(
+                "pumpfun token launch detection",
+                T1_PATH,
+                T1_TITLE,
+                T1_SLICE,
+            )
+            == 0.0
+        )
+
+    def test_metadata_match_works_for_non_trade_slice(self):
+        """A non-Trade slice ID with metadata gets the same precedence
+        boost — proving the rule isn't Trade-specific."""
+        slice_id = "HOLOINDEX_INDEXER_PROJECT_ROOT_WORKTREE_SAFETY_PHASE1"
+        audit_path = (
+            "docs/audits/holoindex_search_quality/"
+            "HOLOINDEX_INDEXER_PROJECT_ROOT_WORKTREE_SAFETY_PHASE1.md"
+        )
+        score = _slice_id_match_boost(slice_id, audit_path, "", slice_id)
+        assert score == _SLICE_ID_METADATA_PRECEDENCE_BOOST
+
+    def test_path_only_slice_match_keeps_original_5point0(self):
+        """Backward compatibility: docs that match by path/title only
+        (no ``meta_slice_id``) still receive the original 5.0 boost."""
+        slice_id = "HOLOINDEX_INDEXER_PROJECT_ROOT_WORKTREE_SAFETY_PHASE1"
+        audit_path = (
+            "docs/audits/holoindex_search_quality/"
+            "HOLOINDEX_INDEXER_PROJECT_ROOT_WORKTREE_SAFETY_PHASE1.md"
+        )
+        score = _slice_id_match_boost(slice_id, audit_path, "", "")
+        assert score == _SLICE_ID_PATH_OR_TITLE_BOOST
+
+    def test_unrelated_slice_id_no_boost(self):
+        """A doc with the wrong ``meta_slice_id`` gets no boost from this
+        rule — the fix isn't a blanket "all audit docs win" lever."""
+        score = _slice_id_match_boost(
+            T1_SLICE,
+            "docs/audits/architecture/SOMETHING_ELSE_PHASE1.md",
+            "Something else",
+            "SOMETHING_ELSE_PHASE1",
+        )
+        assert score == 0.0
+
+
+class TestNonSliceTradeQueryBehaviorPreserved:
+    """Non-slice-ID Trade analyst queries must continue to benefit from
+    ``_trade_path_boost`` + ``_trade_alias_keyword_boost`` as before. This
+    pins the architect's anti-overfit constraint: no general suppression of
+    the path/alias cascade.
+    """
+
+    def test_trade_path_boost_still_fires_for_trade_target_docs(self):
+        boost = _trade_path_boost(
+            "trade due diligence scoring", "modules/foundups/trade/INTERFACE.md"
+        )
+        assert boost == 8.0
+
+    def test_trade_alias_boost_still_fires_for_alias_match(self):
+        # ``_trade_alias_keyword_boost`` only fires when (a) the query has
+        # Trade intent AND (b) an alias-group key in the query expands to
+        # at least one alias not already in the query. "pumpfun rug pull"
+        # satisfies both: "pumpfun" expands to {pump.fun, pump fun,
+        # pump_fun}; "rug pull" expands to {rug_pull_score, soft-rug,
+        # honeypot, ...}.
+        content = (
+            "Trade pump.fun audit doc covering rug_pull_score, honeypot "
+            "detection, pump fun bonding curve metrics."
+        )
+        boost = _trade_alias_keyword_boost(
+            "trade pumpfun rug pull",
+            "docs/audits/architecture/TRADE_DUE_DILIGENCE_SCORING_ENGINE_PHASE1.md",
+            "Trade Due Diligence Scoring Engine - Phase 1",
+            content,
+        )
+        assert boost > 0.0
+
+    def test_non_slice_id_query_does_not_lift_audit_doc_unfairly(self):
+        """Without a slice-ID literal in the query, the audit doc does not
+        receive a metadata-precedence boost. This proves the lift is gated
+        on the user typing the literal slice ID."""
+        # Query is purely analyst-language; T1 has metadata but no slice_id
+        # is in the query → tier-1 boost does NOT fire.
+        boost = _slice_id_match_boost(
+            "due diligence scoring engine",
+            T1_PATH,
+            T1_TITLE,
+            T1_SLICE,
+        )
+        assert boost == 0.0


### PR DESCRIPTION
## Summary

Resumes and repairs the stale `HOLOINDEX_T1_RANKING_QUALITY_PHASE1` work. The original W7 residue had the audit and tests but never landed the `search_engine.py` implementation. This PR adds generic slice-ID metadata precedence so exact slice-ID audit/spec docs outrank module-root docs on their own slice-ID queries.

## Root Cause

On post-#730 main, `python holo_index.py --search "TRADE_ADAPTER_INTEGRATION_PHASE1"` still ranked `modules/foundups/trade/INTERFACE.md` above the actual T2 audit doc because Trade path/alias boosts outweighed the existing slice-ID boost.

## Changes

- Add `_SLICE_ID_METADATA_PRECEDENCE_BOOST = 20.0`
- Add `_SLICE_ID_PATH_OR_TITLE_BOOST = 5.0`
- Tier `_slice_id_match_boost()` so exact `metadata.slice_id` matches outrank path/module/alias boosts
- Resume and repair `test_t1_ranking_quality.py`
- Update related tests to use the named constants
- Repair the stale audit doc to ASCII/canonical WSP_97 format
- Add ModLog entry

## Verification

- `python -m pytest holo_index/tests/test_t1_ranking_quality.py holo_index/tests/test_hxa_retrieval_fix.py holo_index/tests/test_audit_spec_slice_id_indexing.py -q`
- Result: 65 passed

Worker report also ran a broader focused suite: 198 passed.

## Boundary

- No reindex
- No live Chroma mutation
- No timeout changes
- No knowledge chunking changes
- No search algorithm rewrite
- No Trade-specific special case
- No path-specific special case
- No WSP mutation
- No dependency or CI change

## WSP_97

Audit reports 20/20 PASS with canonical `Truth Boundary Checklist Item` header and evidence cells.
