### PR TITLE
fix(config): update Claude and MoltBot model pins

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -143,5 +143,5 @@
       "o:\\Foundups-Agent\\modules\\infrastructure\\container_isolation"
     ]
   },
-  "model": "claude-opus-4-5-20251101"
+  "model": "claude-opus-4-8"
 }

--- a/modules/communication/moltbot_bridge/config/moltbot.json
+++ b/modules/communication/moltbot_bridge/config/moltbot.json
@@ -1,6 +1,6 @@
 {
     "agent": {
-        "model": "anthropic/claude-opus-4-5"
+        "model": "ollama/qwen2.5-coder:7b"
     },
     "agents": {
         "defaults": {

--- a/modules/communication/moltbot_bridge/docs/CHANNEL_SETUP.md
+++ b/modules/communication/moltbot_bridge/docs/CHANNEL_SETUP.md
@@ -151,7 +151,7 @@ openclaw start
 ```json
 {
   "agent": {
-    "model": "anthropic/claude-opus-4-5"
+    "model": "ollama/qwen2.5-coder:7b"
   },
   "agents": {
     "defaults": {


### PR DESCRIPTION
## Summary

Separates the Claude/MoltBot model pin work from the HoloIndex ranking PR.

Changes:
- Update Claude Code local setting from `claude-opus-4-5-20251101` to `claude-opus-4-8`
- Switch MoltBot default config from `anthropic/claude-opus-4-5` to local `ollama/qwen2.5-coder:7b`
- Update MoltBot channel setup docs to match the local Ollama default

## Rationale

MoltBot runs through OpenClaw, and Anthropic subscription OAuth use in third-party tools is not a valid path. The MoltBot config is already local-first and env-driven, so the committed default should use local Ollama. Operators can still override with `OPENCLAW_OLLAMA_MODEL` / `OPENCLAW_NO_API_KEYS`.

## Scope

Expected files only:
- `.claude/settings.local.json`
- `modules/communication/moltbot_bridge/config/moltbot.json`
- `modules/communication/moltbot_bridge/docs/CHANNEL_SETUP.md`

## Verification

- `python -m json.tool .claude/settings.local.json`
- `python -m json.tool modules/communication/moltbot_bridge/config/moltbot.json`

No runtime code changed.
