### PR TITLE
fix(shared-utils): gate LM Studio as explicit optional dependency

### DIFF
--- a/docs/audits/architecture/LM_STUDIO_DEPENDENCY_BOUNDARY_DOC_AND_GATE_PHASE1.md
+++ b/docs/audits/architecture/LM_STUDIO_DEPENDENCY_BOUNDARY_DOC_AND_GATE_PHASE1.md
@@ -1,0 +1,187 @@
+# LM_STUDIO_DEPENDENCY_BOUNDARY_DOC_AND_GATE_PHASE1
+
+**Slice**: `fix/lm-studio-dependency-boundary-doc-and-gate-phase1`
+**Operating protocols**: WSP_00 (Zen State), WSP_97 (Truthful state distinction)
+**Internal Review Verdict**: READY
+
+---
+
+## 1. Mission + Scope
+
+Make LM Studio a clearly bounded **optional/local** dependency. The HoloIndex
+cold-model timeout work (#730) removed SentenceTransformer false negatives, but
+the broader local-model stack (Qwen / Gemma / UI-TARS via LM Studio) could still
+degrade silently or warn ambiguously when LM Studio is absent.
+
+This slice **documents and gates** LM Studio usage. It:
+
+- Makes LM Studio absence **explicit and operator-actionable** instead of a
+  silent `None` return.
+- Guarantees the resolver layer is **probe-only** (never launches LM Studio).
+- Keeps the **launch** behavior confined to the explicit dependency launcher.
+
+**In scope (locked after discovery)**:
+- `modules/infrastructure/shared_utilities/local_llm_resolver.py` (additive gate)
+- `modules/infrastructure/shared_utilities/tests/test_lm_studio_dependency_boundary.py` (NEW)
+- `modules/infrastructure/shared_utilities/ModLog.md` / `tests/TestModLog.md`
+- this audit doc
+
+**Out of scope (proven by discovery)**:
+- `main.py` — does **not** probe or launch LM Studio at menu boot (grep: no
+  matches for `lm_studio`/`ensure_dependencies`/`launch_lm_studio`). Not touched.
+- `dependency_launcher/dae_dependencies.py` — already the correct explicit launch
+  site; no behavior change.
+- HoloIndex timeout defaults (#730), OBS startup boundaries (#720/#721) — untouched.
+
+---
+
+## 2. Predecessor Citations
+
+- **#720** OBS secret logging guard
+- **#721** main-menu startup boundary
+- **#728** HoloIndex knowledge full-body chunking
+- **#730** HoloIndex cold model timeout boundary
+- **#732** local-first MoltBot config pin (base for this slice)
+
+---
+
+## 3. HoloIndex Retrieval Evaluation
+
+Queries run (mandatory discovery):
+1. `LM Studio local model resolver fallback`
+2. `localhost 1234 local_llm_resolver qwen gemma`
+3. `AutoModeratorDAE LM Studio dependency launcher`
+
+| Dimension | Evaluation |
+|-----------|------------|
+| Noise | Low. Top code hits were the exact target files (`local_llm_resolver.py`, `local_llm_backends.py`, `local_model_selection.py`, `dae_dependencies.py`). |
+| Ordering | Correct. Query 1/2 surfaced shared_utilities resolver first; query 3 surfaced `dae_dependencies.py` first. |
+| Missing artifacts | None critical. `ai_engine_singletons.py` (caller) was not top-ranked but found via grep on `local_llm_resolver` imports. |
+| Staleness risk | Low. Knowledge hits (Papers/*) were tangential and ignored; code hits matched current tree. |
+| Duplication | None. Single resolver + single backend module; launch lives only in `dae_dependencies.py`. |
+
+Grep confirmed the launch site is unique: `launch_lm_studio` /
+`subprocess.Popen([lm_studio_path])` exists only in `dae_dependencies.py`.
+
+---
+
+## 4. LM Studio Dependency Matrix
+
+| Subsystem | Current behavior | Requires LM Studio? | Fallback behavior | Operator action |
+|-----------|------------------|---------------------|-------------------|-----------------|
+| Qwen reasoning (`resolve_qwen_backend` / `get_qwen_engine`) | Probe LM Studio; if reachable + model loaded → `LMStudioBackend`; else llama.cpp GGUF | **OPTIONAL** | `LlamaCppBackend` via `model_path` (GGUF) | None if reachable; else provide GGUF `model_path` or start LM Studio via launcher |
+| Gemma pattern matching (`resolve_gemma_backend` / `get_gemma_engine`) | Same as Qwen (CPU-only GGUF fallback) | **OPTIONAL** | `LlamaCppBackend` via `resolve_triage_model_path` | Same as Qwen |
+| UI-TARS vision (`auto_moderator_dae` Phase -2 → `ensure_dependencies(require_lm_studio=True)`) | Explicit launch via `dae_dependencies.launch_lm_studio`; absent → DOM-only mode | **OPTIONAL (no GGUF fallback)** — degrades to DOM-only, not a hard failure | Vision-less DOM-only engagement | Start LM Studio via dependency launcher / load UI-TARS model |
+| `is_lm_studio_available()` probe (`local_llm_backends`) | 2s HTTP GET to `localhost:1234/v1/models` | N/A (pure probe) | N/A | N/A |
+| Dependency launcher (`dae_dependencies.launch_lm_studio`) | `subprocess.Popen` LM Studio, waits ≤120s, then `load_all_models()` | This **is** the launch path (explicit, operator/DAE-initiated) | N/A | This is the sanctioned launch entry point |
+| `main.py` menu boot | No LM Studio probe or launch | **NO** | N/A | N/A |
+
+**Conclusion**: No subsystem *hard-requires* LM Studio. Qwen/Gemma fall back to
+llama.cpp; UI-TARS degrades to DOM-only. LM Studio is uniformly OPTIONAL.
+
+---
+
+## 5. Pre-State Failure / Warning Map
+
+| Path | Pre-state issue |
+|------|-----------------|
+| `resolve_qwen_backend` / `resolve_gemma_backend` (LM Studio absent + `model_path` provided) | Silently jumped to llama.cpp with **no message stating why** LM Studio was skipped — looked like LM Studio was simply not chosen. |
+| `resolve_*_backend` (LM Studio absent + `model_path=None`) | `logger.warning("No Qwen backend: LM Studio unavailable and no model_path for fallback")` — accurate but **not operator-actionable** (no remedy stated). |
+| `ai_engine_singletons.get_*_engine` | Returns `None` with `"no backend available"` — **silent degradation**; caller cannot distinguish "LM Studio absent" from "GGUF missing" or get a remedy. |
+| Required-LM-Studio callers (e.g. UI-TARS) | No **named** unavailable state to branch on — would have to inspect logs or a bare `None`. |
+
+---
+
+## 6. Post-State Gate Map
+
+All additions are in `local_llm_resolver.py` and are **probe-only / additive**
+(no existing signature or return type changed):
+
+| New symbol | Purpose | Launches LM Studio? |
+|------------|---------|---------------------|
+| `LocalLLMAvailability` (Enum) | Named states: `LM_STUDIO_READY` / `FALLBACK_LLAMA_CPP` / `UNAVAILABLE` | No |
+| `probe_backend_availability(model_path=None)` | Probe-only classifier (HTTP probe + GGUF filesystem check) | No |
+| `operator_action_for(status)` | Operator-actionable guidance string per state | No |
+| `LMStudioUnavailableError` | Named error for paths that strictly require LM Studio | No |
+| `require_lm_studio_backend(model_id, base_url=None)` | Required-path resolver; raises the named error w/ remedy instead of `None` | No |
+
+Resolver messaging upgraded:
+- LM Studio absent + fallback → **INFO** clearly states "using local GGUF
+  fallback via llama.cpp … resolver does not auto-launch it."
+- LM Studio absent + no fallback → **WARNING** with operator remedy (start via
+  launcher or provide `model_path`).
+
+Happy path (LM Studio reachable → `LMStudioBackend`; otherwise → `LlamaCppBackend`)
+is byte-for-byte unchanged in behavior.
+
+---
+
+## 7. Explicit Non-Launch Boundary
+
+- `local_llm_resolver.py` and `local_llm_backends.py` **never** import
+  `subprocess`, `dependency_launcher`, or `launch_lm_studio`. Verified by test
+  (`test_resolver_does_not_import_launch_symbols`) and by patching
+  `subprocess.Popen` and asserting it is never called
+  (`test_resolve_never_calls_subprocess`, `test_require_never_calls_subprocess`).
+- The **only** LM Studio launch site remains
+  `dependency_launcher.dae_dependencies.launch_lm_studio`, invoked exclusively
+  from the explicit DAE startup path
+  (`auto_moderator_dae` Phase -2, gated by `YT_DEPS_AUTO_LAUNCH`) /
+  `ensure_dependencies(require_lm_studio=...)`.
+
+---
+
+## 8. Test Matrix
+
+File: `modules/infrastructure/shared_utilities/tests/test_lm_studio_dependency_boundary.py`
+
+| # | Requirement | Test(s) |
+|---|-------------|---------|
+| 1 | LM Studio absent + fallback → clear fallback state/message | `test_fallback_state_when_lm_studio_absent_but_gguf_exists`, `test_fallback_operator_action_states_llama_cpp_and_non_launch`, `test_resolver_logs_clear_fallback_when_lm_studio_absent` |
+| 2 | LM Studio absent + required path → named error + operator action | `test_require_raises_named_error_when_lm_studio_absent`, `test_require_raises_when_reachable_but_model_not_loaded`, `test_unavailable_operator_action_is_actionable` |
+| 3 | LM Studio available → happy path preserved | `test_lm_studio_ready_when_probe_succeeds`, `test_require_returns_backend_when_available`, `test_resolve_qwen_uses_lm_studio_when_available`, `test_resolve_gemma_falls_back_to_llama_cpp_when_lm_studio_absent` |
+| 4 | Resolver does not call dependency launcher / subprocess | `test_resolve_never_calls_subprocess`, `test_require_never_calls_subprocess`, `test_resolver_does_not_import_launch_symbols` |
+| 5 | No live LM Studio, no network, no `.env` reads | All tests patch `is_lm_studio_available` (the sole network site); no `.env` access anywhere in the suite |
+| 6 | Existing DAE dependency behavior still routes through explicit launcher | `test_launch_lives_in_dependency_launcher`, `test_ensure_dependencies_still_gates_lm_studio` |
+
+**Run**:
+`python -m pytest modules/infrastructure/shared_utilities/tests/test_lm_studio_dependency_boundary.py modules/infrastructure/shared_utilities/tests/test_local_llm_backends.py -v`
+**Result**: `33 passed` (16 new + 17 existing regression-guard).
+
+---
+
+## 9. Internal Review Verdict
+
+**READY.** Smallest viable gate: additive named states + probe-only classifier +
+named required-path error, plus clearer resolver messaging. No model behavior
+change, no launch added to the probe layer, launch boundary intact, `main.py`
+untouched.
+
+---
+
+## 10. WSP_97 Truth Boundary Checklist
+
+20 items declared, 20 rows present.
+
+| # | Truth Boundary Checklist Item | Status | Evidence |
+|---|-------------------------------|--------|----------|
+| 1 | LM_STUDIO_DEPENDENCY_BOUNDARY_ONLY | PASS | Only resolver gate + tests + docs changed; matrix scoped to LM Studio dependency. |
+| 2 | NO_AUTO_LAUNCH_LM_STUDIO | PASS | No `subprocess`/launch in resolver; `subprocess.Popen` patched and asserted never called. |
+| 3 | LOCAL_LLM_RESOLVER_PROBES_ONLY | PASS | `probe_backend_availability` does HTTP probe + filesystem check only; resolver imports no launch symbols (`test_resolver_does_not_import_launch_symbols`). |
+| 4 | NO_MODEL_BEHAVIOR_CHANGE | PASS | Happy/fallback selection unchanged; only logging + additive helpers. Existing 17 backend tests still pass. |
+| 5 | NO_HOLOINDEX_TIMEOUT_CHANGE | PASS | No edit to `holo_index/core/*`; timeout defaults from #730 untouched. |
+| 6 | NO_OBS_BOUNDARY_CHANGE | PASS | `dae_dependencies.launch_obs` / OBS paths from #720/#721 untouched. |
+| 7 | NO_MAIN_MENU_STARTUP_REGRESSION | PASS | `main.py` not touched; grep confirms it never probes/launches LM Studio. |
+| 8 | NO_LIVE_LM_STUDIO_IN_TESTS | PASS | All tests patch `is_lm_studio_available`; no live API used. |
+| 9 | NO_NETWORK_CALL_IN_TESTS | PASS | Sole network site (`is_lm_studio_available`) mocked in every test. |
+| 10 | NO_DOTENV_READ_IN_TESTS | PASS | No `.env` access in suite; no `load_dotenv`/env-file reads. |
+| 11 | NO_REAL_SECRET_VALUES | PASS | No secrets referenced; only `localhost:1234` and model ids. |
+| 12 | NO_DEPENDENCY_CHANGE | PASS | No `requirements.txt`/lockfile change; uses stdlib `enum`. |
+| 13 | NO_CI_CHANGE | PASS | No workflow/CI files touched. |
+| 14 | NO_WSP_MUTATION | PASS | No `WSP_framework`/`WSP_knowledge` protocol files edited. |
+| 15 | NO_REGISTRY_MUTATION | PASS | No registry/SKILLz/manifest files edited. |
+| 16 | NO_MANIFEST_MUTATION | PASS | No manifest files edited. |
+| 17 | NO_PUBLIC_SURFACE_MUTATION | PASS | No existing signature/return type changed; only **additive, non-breaking** new symbols introduced (required by dispatch). |
+| 18 | NO_CABR_READY | PASS | No CABR/valuation logic touched. |
+| 19 | NO_PAYOUT_READY | PASS | No payout logic touched. |
+| 20 | NO_DAO_ACTIVATION | PASS | No DAO activation logic touched. |

--- a/modules/infrastructure/shared_utilities/ModLog.md
+++ b/modules/infrastructure/shared_utilities/ModLog.md
@@ -1,6 +1,31 @@
 # WSP Module ModLog: Shared Utilities
 **WSP Compliance**: WSP 22 (Module ModLog and Roadmap Protocol)
 
+## 2026-05-30 - LM Studio Dependency Boundary Doc + Gate (LM_STUDIO_DEPENDENCY_BOUNDARY_DOC_AND_GATE_PHASE1)
+
+- **Problem**: LM Studio is an optional local dependency, but absence produced a
+  silent `None` from `resolve_*_backend` / `ai_engine_singletons` and an
+  ambiguous, non-actionable warning. Required-LM-Studio callers had no named
+  state to branch on.
+- **Solution** (probe-only, additive — no existing signature/return type changed):
+  - `local_llm_resolver.py`:
+    - `LocalLLMAvailability` (Enum): `LM_STUDIO_READY` / `FALLBACK_LLAMA_CPP` / `UNAVAILABLE`
+    - `probe_backend_availability(model_path=None)`: probe-only classifier (HTTP probe + GGUF filesystem check); never launches LM Studio
+    - `operator_action_for(status)`: operator-actionable guidance per state
+    - `LMStudioUnavailableError` + `require_lm_studio_backend(model_id, base_url=None)`: named error for paths that strictly require LM Studio
+    - `resolve_qwen_backend` / `resolve_gemma_backend`: clearer fallback INFO ("using local GGUF fallback via llama.cpp … resolver does not auto-launch it") and operator-actionable WARNING when no fallback exists
+- **Boundary preserved**: LM Studio launch stays solely in
+  `dependency_launcher.dae_dependencies.launch_lm_studio` (explicit DAE/menu path).
+  Resolver imports no `subprocess`/launch symbols.
+- **Non-scope (verified)**: `main.py` never probes/launches LM Studio at boot;
+  HoloIndex timeout defaults (#730) and OBS boundaries (#720/#721) untouched.
+- **Files**:
+  - `local_llm_resolver.py` (UPDATED — additive)
+  - `tests/test_lm_studio_dependency_boundary.py` (NEW — 16 tests)
+  - `docs/audits/architecture/LM_STUDIO_DEPENDENCY_BOUNDARY_DOC_AND_GATE_PHASE1.md` (NEW)
+- **Predecessors**: #720, #721, #728, #730, #732
+- **WSP Compliance**: WSP 77 (Agent Coordination), WSP 91 (Observability), WSP 97 (Truthful state distinction)
+
 ## 2026-04-13 - Local LLM Backend Adapter Layer (LM Studio API Support)
 
 - **Problem**: Qwen/Gemma model loading fails when LM Studio holds file locks on GGUF files. Startup log shows `PermissionError` or silent failures.

--- a/modules/infrastructure/shared_utilities/local_llm_resolver.py
+++ b/modules/infrastructure/shared_utilities/local_llm_resolver.py
@@ -8,10 +8,21 @@ Policy:
 1. If LM Studio is available and has the requested model → use LMStudioBackend
 2. Else → use LlamaCppBackend (direct file loading)
 
+Dependency boundary (LM_STUDIO_DEPENDENCY_BOUNDARY_DOC_AND_GATE_PHASE1):
+LM Studio is an OPTIONAL local dependency. This resolver only PROBES for it
+(``is_lm_studio_available`` → a short HTTP GET). It never launches LM Studio.
+Launching LM Studio is the sole responsibility of the explicit dependency
+launcher (``dependency_launcher.dae_dependencies.launch_lm_studio``) invoked
+from explicit DAE/menu startup paths. When LM Studio is absent the resolver
+states the chosen fallback (local GGUF via llama.cpp) clearly, and callers that
+strictly require LM Studio can use ``require_lm_studio_backend`` to obtain a
+named, operator-actionable unavailable state instead of a silent ``None``.
+
 WSP 77: Agent Coordination
 """
 
 import logging
+from enum import Enum
 from pathlib import Path
 from typing import Optional
 
@@ -29,6 +40,97 @@ LM_STUDIO_MODEL_IDS = {
     "qwen": "qwen-coder-7b",
     "gemma": "gemma-270m",
 }
+
+
+class LocalLLMAvailability(str, Enum):
+    """Named, probe-only result states for local LLM backend availability.
+
+    Makes LM Studio absence explicit instead of an ambiguous ``None`` return:
+
+    - ``LM_STUDIO_READY``: LM Studio API is reachable on localhost:1234.
+    - ``FALLBACK_LLAMA_CPP``: LM Studio absent, but a local GGUF file exists so
+      the llama.cpp fallback can serve the request.
+    - ``UNAVAILABLE``: LM Studio absent and no local GGUF fallback is available.
+    """
+
+    LM_STUDIO_READY = "lm_studio_ready"
+    FALLBACK_LLAMA_CPP = "fallback_llama_cpp"
+    UNAVAILABLE = "unavailable"
+
+
+class LMStudioUnavailableError(RuntimeError):
+    """Raised when a caller strictly requires LM Studio but it is unreachable.
+
+    Carries operator-actionable guidance. This is the named state returned for
+    "required" paths so callers do not silently degrade. The resolver never
+    launches LM Studio to satisfy this requirement.
+    """
+
+    def __init__(self, message: Optional[str] = None):
+        super().__init__(message or operator_action_for(LocalLLMAvailability.UNAVAILABLE))
+
+
+def operator_action_for(status: LocalLLMAvailability) -> str:
+    """Return operator-actionable guidance for a given availability status."""
+    if status is LocalLLMAvailability.LM_STUDIO_READY:
+        return "LM Studio reachable on localhost:1234 - no action needed."
+    if status is LocalLLMAvailability.FALLBACK_LLAMA_CPP:
+        return (
+            "LM Studio not reachable on localhost:1234 - using local GGUF "
+            "fallback via llama.cpp. This is expected when LM Studio is not "
+            "running. To use LM Studio instead, start it via the dependency "
+            "launcher / main menu (the resolver does not auto-launch it)."
+        )
+    return (
+        "LM Studio not reachable on localhost:1234 and no local GGUF fallback "
+        "is available. Either start LM Studio via the dependency launcher / "
+        "main menu, or provide a model_path to a local GGUF file. The resolver "
+        "never auto-launches LM Studio."
+    )
+
+
+def probe_backend_availability(
+    model_path: Optional[Path] = None,
+) -> LocalLLMAvailability:
+    """Probe-only classification of local LLM availability.
+
+    NEVER launches LM Studio and NEVER loads a model - it only performs the
+    lightweight ``is_lm_studio_available`` HTTP probe and a filesystem check for
+    the optional GGUF fallback. Returns a named :class:`LocalLLMAvailability`.
+    """
+    if is_lm_studio_available():
+        return LocalLLMAvailability.LM_STUDIO_READY
+    if model_path is not None and Path(model_path).exists():
+        return LocalLLMAvailability.FALLBACK_LLAMA_CPP
+    return LocalLLMAvailability.UNAVAILABLE
+
+
+def require_lm_studio_backend(
+    model_id: str,
+    base_url: Optional[str] = None,
+) -> LocalLLMBackend:
+    """Resolve an LM-Studio-backed engine for paths that strictly require it.
+
+    Probes for LM Studio (never launches it). If unavailable, raises
+    :class:`LMStudioUnavailableError` with operator-actionable guidance instead
+    of returning a silent ``None``. Use this only for operations that genuinely
+    cannot fall back to llama.cpp (e.g. UI-TARS vision via LM Studio).
+    """
+    if not is_lm_studio_available():
+        raise LMStudioUnavailableError()
+
+    backend = (
+        LMStudioBackend(model_id=model_id, base_url=base_url)
+        if base_url is not None
+        else LMStudioBackend(model_id=model_id)
+    )
+    if not backend.initialize():
+        raise LMStudioUnavailableError(
+            f"LM Studio reachable but model '{model_id}' is not loaded. "
+            "Load it in LM Studio (or via the dependency launcher's "
+            "load_all_models) before retrying."
+        )
+    return backend
 
 
 def resolve_qwen_backend(
@@ -51,19 +153,30 @@ def resolve_qwen_backend(
     Returns:
         Initialized LocalLLMBackend, or None if unavailable
     """
-    # Try LM Studio first (avoids file locks, doesn't need model_path)
-    if is_lm_studio_available():
+    # Try LM Studio first (avoids file locks, doesn't need model_path).
+    # Probe-only: this never launches LM Studio.
+    lm_studio_reachable = is_lm_studio_available()
+    if lm_studio_reachable:
         model_id = LM_STUDIO_MODEL_IDS["qwen"]
         backend = LMStudioBackend(model_id=model_id)
         if backend.initialize():
             logger.info(f"[RESOLVER] Qwen using LMStudioBackend ({model_id})")
             return backend
-        logger.debug("[RESOLVER] LM Studio available but Qwen model not loaded")
+        logger.debug("[RESOLVER] LM Studio reachable but Qwen model not loaded; trying local GGUF fallback")
 
     # Fall back to llama_cpp (requires model_path)
     if model_path is None:
-        logger.warning("[RESOLVER] No Qwen backend: LM Studio unavailable and no model_path for fallback")
+        logger.warning(
+            "[RESOLVER] No Qwen backend. %s",
+            operator_action_for(LocalLLMAvailability.UNAVAILABLE),
+        )
         return None
+
+    if not lm_studio_reachable:
+        logger.info(
+            "[RESOLVER] %s",
+            operator_action_for(LocalLLMAvailability.FALLBACK_LLAMA_CPP),
+        )
 
     backend = LlamaCppBackend(
         model_path=model_path,
@@ -74,7 +187,7 @@ def resolve_qwen_backend(
         logger.info(f"[RESOLVER] Qwen using LlamaCppBackend ({model_path.name})")
         return backend
 
-    logger.warning("[RESOLVER] No Qwen backend available")
+    logger.warning("[RESOLVER] No Qwen backend available (llama.cpp fallback load failed)")
     return None
 
 
@@ -98,19 +211,30 @@ def resolve_gemma_backend(
     Returns:
         Initialized LocalLLMBackend, or None if unavailable
     """
-    # Try LM Studio first (avoids file locks, doesn't need model_path)
-    if is_lm_studio_available():
+    # Try LM Studio first (avoids file locks, doesn't need model_path).
+    # Probe-only: this never launches LM Studio.
+    lm_studio_reachable = is_lm_studio_available()
+    if lm_studio_reachable:
         model_id = LM_STUDIO_MODEL_IDS["gemma"]
         backend = LMStudioBackend(model_id=model_id)
         if backend.initialize():
             logger.info(f"[RESOLVER] Gemma using LMStudioBackend ({model_id})")
             return backend
-        logger.debug("[RESOLVER] LM Studio available but Gemma model not loaded")
+        logger.debug("[RESOLVER] LM Studio reachable but Gemma model not loaded; trying local GGUF fallback")
 
     # Fall back to llama_cpp (requires model_path)
     if model_path is None:
-        logger.warning("[RESOLVER] No Gemma backend: LM Studio unavailable and no model_path for fallback")
+        logger.warning(
+            "[RESOLVER] No Gemma backend. %s",
+            operator_action_for(LocalLLMAvailability.UNAVAILABLE),
+        )
         return None
+
+    if not lm_studio_reachable:
+        logger.info(
+            "[RESOLVER] %s",
+            operator_action_for(LocalLLMAvailability.FALLBACK_LLAMA_CPP),
+        )
 
     backend = LlamaCppBackend(
         model_path=model_path,
@@ -122,5 +246,5 @@ def resolve_gemma_backend(
         logger.info(f"[RESOLVER] Gemma using LlamaCppBackend ({model_path.name})")
         return backend
 
-    logger.warning("[RESOLVER] No Gemma backend available")
+    logger.warning("[RESOLVER] No Gemma backend available (llama.cpp fallback load failed)")
     return None

--- a/modules/infrastructure/shared_utilities/tests/TestModLog.md
+++ b/modules/infrastructure/shared_utilities/tests/TestModLog.md
@@ -1,6 +1,24 @@
 # TestModLog
 
 ====================================================================
+## 2026-05-30 - LM Studio Dependency Boundary Gate Coverage
+- Command:
+  - `python -m pytest modules/infrastructure/shared_utilities/tests/test_lm_studio_dependency_boundary.py modules/infrastructure/shared_utilities/tests/test_local_llm_backends.py -v`
+- Status: PASS
+- Result: `33 passed in 0.76s` (16 new + 17 existing regression-guard)
+- Scope (new file `test_lm_studio_dependency_boundary.py`):
+  - TestProbeAvailabilityState: named probe-only states (3 tests)
+  - TestFallbackMessageClarity: clear fallback INFO + operator action (3 tests)
+  - TestRequiredPathNamedError: `LMStudioUnavailableError` w/ operator action (3 tests)
+  - TestHappyPathPreserved: LM Studio + llama.cpp fallback unchanged (2 tests)
+  - TestResolverProbesOnly: no subprocess / no launch symbols (3 tests)
+  - TestDaeLaunchBoundaryIntact: launch still lives in dependency_launcher (2 tests)
+- Constraints proven: NO_AUTO_LAUNCH_LM_STUDIO, LOCAL_LLM_RESOLVER_PROBES_ONLY,
+  NO_LIVE_LM_STUDIO_IN_TESTS, NO_NETWORK_CALL_IN_TESTS (all probes mocked)
+- WSP References: WSP 77 (Agent Coordination), WSP 91 (Observability), WSP 97 (Truthful state distinction)
+====================================================================
+
+====================================================================
 ## 2026-04-13 - Local LLM Backend Adapter Layer Coverage
 - Command:
   - `python -m pytest modules/infrastructure/shared_utilities/tests/test_local_llm_backends.py -v`

--- a/modules/infrastructure/shared_utilities/tests/test_lm_studio_dependency_boundary.py
+++ b/modules/infrastructure/shared_utilities/tests/test_lm_studio_dependency_boundary.py
@@ -1,0 +1,250 @@
+"""Tests for the LM Studio dependency boundary gate.
+
+Slice: LM_STUDIO_DEPENDENCY_BOUNDARY_DOC_AND_GATE_PHASE1
+
+Verifies that LM Studio is a clearly bounded OPTIONAL local dependency:
+1. LM Studio absent + GGUF fallback available -> fallback state/message is clear.
+2. LM Studio absent + required path -> named unavailable error w/ operator action.
+3. LM Studio available -> happy path (LMStudioBackend) preserved.
+4. local_llm_resolver never launches LM Studio (no subprocess, no launcher).
+5. No live LM Studio process, no network calls, no .env reads (all probes mocked).
+6. Existing YouTube/DAE dependency launch still lives in the explicit launcher.
+
+WSP 77: Agent Coordination
+WSP 97: Truthful state distinction - LM Studio absence is explicit, not silent.
+"""
+
+import inspect
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+RESOLVER = "modules.infrastructure.shared_utilities.local_llm_resolver"
+
+
+# ---------------------------------------------------------------------------
+# (1)/(3) Probe-only availability classification - named states
+# ---------------------------------------------------------------------------
+class TestProbeAvailabilityState:
+    def test_lm_studio_ready_when_probe_succeeds(self):
+        from modules.infrastructure.shared_utilities.local_llm_resolver import (
+            LocalLLMAvailability,
+            probe_backend_availability,
+        )
+
+        with patch(f"{RESOLVER}.is_lm_studio_available", return_value=True):
+            assert probe_backend_availability() is LocalLLMAvailability.LM_STUDIO_READY
+
+    def test_fallback_state_when_lm_studio_absent_but_gguf_exists(self):
+        from modules.infrastructure.shared_utilities.local_llm_resolver import (
+            LocalLLMAvailability,
+            probe_backend_availability,
+        )
+
+        with patch(f"{RESOLVER}.is_lm_studio_available", return_value=False):
+            with patch.object(Path, "exists", return_value=True):
+                status = probe_backend_availability(model_path=Path("E:/models/qwen.gguf"))
+
+        assert status is LocalLLMAvailability.FALLBACK_LLAMA_CPP
+
+    def test_unavailable_state_when_no_lm_studio_and_no_fallback(self):
+        from modules.infrastructure.shared_utilities.local_llm_resolver import (
+            LocalLLMAvailability,
+            probe_backend_availability,
+        )
+
+        with patch(f"{RESOLVER}.is_lm_studio_available", return_value=False):
+            status = probe_backend_availability(model_path=None)
+
+        assert status is LocalLLMAvailability.UNAVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# (1) Fallback messaging is clear (no false/silent warnings)
+# ---------------------------------------------------------------------------
+class TestFallbackMessageClarity:
+    def test_fallback_operator_action_states_llama_cpp_and_non_launch(self):
+        from modules.infrastructure.shared_utilities.local_llm_resolver import (
+            LocalLLMAvailability,
+            operator_action_for,
+        )
+
+        msg = operator_action_for(LocalLLMAvailability.FALLBACK_LLAMA_CPP)
+        assert "llama.cpp" in msg
+        assert "does not auto-launch" in msg
+
+    def test_unavailable_operator_action_is_actionable(self):
+        from modules.infrastructure.shared_utilities.local_llm_resolver import (
+            LocalLLMAvailability,
+            operator_action_for,
+        )
+
+        msg = operator_action_for(LocalLLMAvailability.UNAVAILABLE)
+        assert "dependency launcher" in msg
+        assert "model_path" in msg
+
+    def test_resolver_logs_clear_fallback_when_lm_studio_absent(self, caplog):
+        from modules.infrastructure.shared_utilities.local_llm_resolver import (
+            resolve_qwen_backend,
+        )
+
+        with patch(f"{RESOLVER}.is_lm_studio_available", return_value=False):
+            with patch(f"{RESOLVER}.LlamaCppBackend") as mock_cls:
+                mock_backend = MagicMock()
+                mock_backend.initialize.return_value = True
+                mock_backend.backend_name = "llama_cpp"
+                mock_cls.return_value = mock_backend
+                with caplog.at_level(logging.INFO):
+                    backend = resolve_qwen_backend(model_path=Path("E:/models/qwen.gguf"))
+
+        assert backend is mock_backend
+        assert any("llama.cpp" in r.getMessage() for r in caplog.records), (
+            "Resolver should log a clear fallback message naming llama.cpp"
+        )
+
+
+# ---------------------------------------------------------------------------
+# (2) Required path -> named unavailable error with operator action
+# ---------------------------------------------------------------------------
+class TestRequiredPathNamedError:
+    def test_require_raises_named_error_when_lm_studio_absent(self):
+        from modules.infrastructure.shared_utilities.local_llm_resolver import (
+            LMStudioUnavailableError,
+            require_lm_studio_backend,
+        )
+
+        with patch(f"{RESOLVER}.is_lm_studio_available", return_value=False):
+            with pytest.raises(LMStudioUnavailableError) as exc:
+                require_lm_studio_backend(model_id="ui-tars")
+
+        text = str(exc.value)
+        assert "LM Studio" in text
+        assert "dependency launcher" in text
+
+    def test_require_returns_backend_when_available(self):
+        from modules.infrastructure.shared_utilities.local_llm_resolver import (
+            require_lm_studio_backend,
+        )
+
+        with patch(f"{RESOLVER}.is_lm_studio_available", return_value=True):
+            with patch(f"{RESOLVER}.LMStudioBackend") as mock_cls:
+                mock_backend = MagicMock()
+                mock_backend.initialize.return_value = True
+                mock_backend.backend_name = "lm_studio"
+                mock_cls.return_value = mock_backend
+                backend = require_lm_studio_backend(model_id="ui-tars")
+
+        assert backend is mock_backend
+        assert backend.backend_name == "lm_studio"
+
+    def test_require_raises_when_reachable_but_model_not_loaded(self):
+        from modules.infrastructure.shared_utilities.local_llm_resolver import (
+            LMStudioUnavailableError,
+            require_lm_studio_backend,
+        )
+
+        with patch(f"{RESOLVER}.is_lm_studio_available", return_value=True):
+            with patch(f"{RESOLVER}.LMStudioBackend") as mock_cls:
+                mock_backend = MagicMock()
+                mock_backend.initialize.return_value = False
+                mock_cls.return_value = mock_backend
+                with pytest.raises(LMStudioUnavailableError) as exc:
+                    require_lm_studio_backend(model_id="ui-tars")
+
+        assert "not loaded" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# (3) Happy path preserved (no model behavior change)
+# ---------------------------------------------------------------------------
+class TestHappyPathPreserved:
+    def test_resolve_qwen_uses_lm_studio_when_available(self):
+        from modules.infrastructure.shared_utilities.local_llm_resolver import (
+            resolve_qwen_backend,
+        )
+
+        with patch(f"{RESOLVER}.is_lm_studio_available", return_value=True):
+            with patch(f"{RESOLVER}.LMStudioBackend") as mock_cls:
+                mock_backend = MagicMock()
+                mock_backend.initialize.return_value = True
+                mock_backend.backend_name = "lm_studio"
+                mock_cls.return_value = mock_backend
+                backend = resolve_qwen_backend(model_path=Path("E:/models/qwen.gguf"))
+
+        assert backend.backend_name == "lm_studio"
+
+    def test_resolve_gemma_falls_back_to_llama_cpp_when_lm_studio_absent(self):
+        from modules.infrastructure.shared_utilities.local_llm_resolver import (
+            resolve_gemma_backend,
+        )
+
+        with patch(f"{RESOLVER}.is_lm_studio_available", return_value=False):
+            with patch(f"{RESOLVER}.LlamaCppBackend") as mock_cls:
+                mock_backend = MagicMock()
+                mock_backend.initialize.return_value = True
+                mock_backend.backend_name = "llama_cpp"
+                mock_cls.return_value = mock_backend
+                backend = resolve_gemma_backend(model_path=Path("E:/models/gemma.gguf"))
+
+        assert backend.backend_name == "llama_cpp"
+
+
+# ---------------------------------------------------------------------------
+# (4)/(5) Resolver is probe-only - never launches LM Studio / no subprocess
+# ---------------------------------------------------------------------------
+class TestResolverProbesOnly:
+    def test_resolve_never_calls_subprocess(self):
+        from modules.infrastructure.shared_utilities.local_llm_resolver import (
+            resolve_qwen_backend,
+        )
+
+        with patch(f"{RESOLVER}.is_lm_studio_available", return_value=False):
+            with patch("subprocess.Popen") as mock_popen:
+                backend = resolve_qwen_backend(model_path=None)
+
+        assert backend is None
+        mock_popen.assert_not_called()
+
+    def test_require_never_calls_subprocess(self):
+        from modules.infrastructure.shared_utilities.local_llm_resolver import (
+            LMStudioUnavailableError,
+            require_lm_studio_backend,
+        )
+
+        with patch(f"{RESOLVER}.is_lm_studio_available", return_value=False):
+            with patch("subprocess.Popen") as mock_popen:
+                with pytest.raises(LMStudioUnavailableError):
+                    require_lm_studio_backend(model_id="ui-tars")
+
+        mock_popen.assert_not_called()
+
+    def test_resolver_does_not_import_launch_symbols(self):
+        import modules.infrastructure.shared_utilities.local_llm_resolver as resolver_mod
+
+        # The resolver must not pull launch/subprocess machinery into its namespace.
+        assert not hasattr(resolver_mod, "launch_lm_studio")
+        assert not hasattr(resolver_mod, "ensure_dependencies")
+        assert not hasattr(resolver_mod, "subprocess")
+
+
+# ---------------------------------------------------------------------------
+# (6) Launch behavior still lives in the explicit dependency launcher
+# ---------------------------------------------------------------------------
+class TestDaeLaunchBoundaryIntact:
+    def test_launch_lives_in_dependency_launcher(self):
+        from modules.infrastructure.dependency_launcher.src import dae_dependencies
+
+        assert hasattr(dae_dependencies, "launch_lm_studio")
+        assert hasattr(dae_dependencies, "ensure_dependencies")
+
+    def test_ensure_dependencies_still_gates_lm_studio(self):
+        from modules.infrastructure.dependency_launcher.src import dae_dependencies
+
+        sig = inspect.signature(dae_dependencies.ensure_dependencies)
+        assert "require_lm_studio" in sig.parameters
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
Makes LM Studio a clearly bounded **optional/local** dependency. LM Studio absence is now **explicit and operator-actionable** instead of a silent `None`. Probe-only and additive — no existing signature/return type changed, no model behavior change.

Slice: `LM_STUDIO_DEPENDENCY_BOUNDARY_DOC_AND_GATE_PHASE1`
Predecessors: #720, #721, #728, #730, #732

## Changes (all in `modules/infrastructure/shared_utilities`)
- `local_llm_resolver.py` (additive):
  - `LocalLLMAvailability` enum: `LM_STUDIO_READY` / `FALLBACK_LLAMA_CPP` / `UNAVAILABLE`
  - `probe_backend_availability()` — probe-only classifier (HTTP probe + GGUF filesystem check), never launches
  - `operator_action_for(status)` — operator-actionable guidance
  - `LMStudioUnavailableError` + `require_lm_studio_backend()` — named error for required paths
  - Clearer fallback INFO / actionable WARNING in `resolve_qwen_backend` / `resolve_gemma_backend`
- `tests/test_lm_studio_dependency_boundary.py` (NEW, 16 tests)
- `docs/audits/architecture/LM_STUDIO_DEPENDENCY_BOUNDARY_DOC_AND_GATE_PHASE1.md` (NEW)
- ModLog / TestModLog updates

## Boundary
- Resolver imports **no** `subprocess`/launch symbols — verified by test + by patching `subprocess.Popen` and asserting it is never called.
- LM Studio launch stays solely in `dependency_launcher.dae_dependencies.launch_lm_studio` (explicit DAE/menu path).
- `main.py` verified to **not** probe/launch LM Studio at boot → out of scope, untouched.
- HoloIndex timeout defaults (#730) and OBS boundaries (#720/#721) untouched.

## Test plan
- [x] `python -m pytest modules/infrastructure/shared_utilities/tests/test_lm_studio_dependency_boundary.py modules/infrastructure/shared_utilities/tests/test_local_llm_backends.py -v` → **33 passed** (16 new + 17 existing regression-guard)
- [x] No live LM Studio, no network calls, no `.env` reads (all probes mocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)