### PR TITLE
fix(security): HXA PolicyFlags write-back remediation Phase 1 (#746)

### DIFF
--- a/docs/audits/security/HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1.md
+++ b/docs/audits/security/HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1.md
@@ -1,0 +1,283 @@
+# HXA PolicyFlags Write-Back Remediation (Phase 1)
+
+**Slice:** `HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1`
+**Worker-Lane:** W6 · **Author:** 0102 (WSP_00 zen state, WSP_97 Truth Boundary discipline)
+**Type:** Targeted security remediation (code + tests). NO broad refactor.
+**Base:** `origin/main` @ `d602d874b` (after #746 enforcement audit).
+**Branch:** `fix/hxa-policyflags-writeback-remediation-phase1`
+
+---
+
+## 1. Mission and Scope
+
+Close the `#746` bounded PolicyFlags write-back defect with **positive control**:
+security/token gate flags must be **server-authored only**, never trusted from deserialized job
+data, and the runtime validator verdict must be written into `job.policy_flags` **before** the
+destructive-action guard reads it.
+
+Two surgical changes, no behavior expansion:
+
+1. **Deserialization sanitization** at the single chokepoint `PolicyFlags.from_dict`
+   (`modules/communication/moltbot_bridge/src/foundup_job_contract.py`).
+2. **Validator verdict write-back** in `HermesJobExecutor.execute()`
+   (`modules/infrastructure/wre_core/src/hermes_job_executor.py`), before guard evaluation.
+
+Out of scope (explicitly deferred): wiring a real security-gate verdict in this executor; any
+production caller of `FoundUpJob.from_dict`; persistent-queue rehydrate boundary.
+
+---
+
+## 2. Predecessor Citations
+
+| PR / Item | Relationship |
+|-----------|--------------|
+| **#746** `HXA_POLICYFLAGS_WRITEBACK_ENFORCEMENT_AUDIT_PHASE1` | The read-only audit that classified this defect `GAP_CONFIRMED_BOUNDED` and specified the remediation shape (its §9). This slice implements §9 steps 1-3. |
+| **#744** `HXA26_HXA27_DEFENSE_PRIMITIVES_REDUNDANCY_AUDIT_PHASE1` | Addendum that first surfaced the write-back seam. |
+| **#743** `HXA29_SCOPE_ACTION_VALIDATION_ENFORCEMENT_AUDIT_PHASE1` | Scope→action-class enforcement precedent. |
+| HXA24 capability-token PolicyFlags · HXA27 Hermes token integration · HXA30 scope-to-action-class | Primitive lineage the write-back consumes. |
+
+---
+
+## 3. Pre-State Defect Summary (from #746)
+
+From the #746 audit (`GAP_CONFIRMED_BOUNDED`):
+
+- **Two independent channels.** The live `TokenValidationResult` from `_validate_token_if_present`
+  was used only to (a) hard-block an explicitly-present-and-invalid token and (b) serialize into
+  result metadata — it was **never written into `job.policy_flags`**
+  (`anyValidatorVerdictWriteback = False`).
+- **Guard trusts inbound flags.** `capability_token_present_for_guard` is the AND of the four
+  inbound `policy_flags.capability_token_*` (`hermes_job_executor.py:1131-1138`); `security_gate_passed`
+  read straight from the envelope. A caller could omit the token entirely (validator returns `None`,
+  no block) yet still present `capability_token_*=True` to collapse the guard's token gate to `True`.
+- **Zero sanitization.** `PolicyFlags.from_dict` blindly `bool()`-cast every gate/token flag verbatim.
+- **Bounded, not exploitable today** only because `FoundUpJob.from_dict` has **zero production callers**
+  and the live chat path uses `create_job` (born all-`False`). "The boundary is held by the *accident*
+  that `from_dict` is unwired, not by positive control."
+
+This slice replaces that accident with positive control.
+
+---
+
+## 4. Implementation Summary
+
+### CHANGE 1 — Deserialization sanitization (`foundup_job_contract.py`)
+
+- Added module-level `_SERVER_AUTHORED_FLAGS` frozenset (12 gate/token field names).
+- Rewrote `PolicyFlags.from_dict` to **force every server-authored flag to `False` regardless of
+  inbound data** (the inbound dict is not read for those fields). Only `dry_run_mode` is preserved
+  (operator-authored; `True` is the safe/sandbox direction; router already defaults it `True`).
+- Updated the `from_dict` docstring: deserialized gate/token state is UNTRUSTED and forced `False`;
+  server authority comes from runtime validation write-back (cites this slice).
+- `FoundUpJob.from_dict` (`:613`) and `FoundUpJob.__post_init__` (dict→PolicyFlags coercion,
+  `:411-412`) both route through `PolicyFlags.from_dict`, so this one edit covers every deserialization
+  path.
+- **Unchanged:** the direct `PolicyFlags(...)` constructor and `field(default_factory=PolicyFlags)`.
+  Server code can still author `True` flags by direct object construction / attribute assignment. Only
+  the untrusted-deserialization path is locked down.
+
+### CHANGE 2 — Validator verdict write-back (`hermes_job_executor.py`)
+
+- Added private helper `_writeback_token_verdict(job, token_validation_result)` (executor `:1158`).
+- Called once in `execute()` (`:1521`) **immediately before** `_evaluate_destructive_action_guard`
+  (`:1524`), after `_validate_token_if_present` (`:1496`) and after the invalid-token early-return.
+- Writes the server-authored verdict into `job.policy_flags`. `security_gate_*` is intentionally left
+  at the server-default `False` (no security-gate evaluator in this executor; out of scope).
+
+---
+
+## 5. Sanitization Field Matrix
+
+`PolicyFlags.from_dict` outcome for each field (inbound value is the attacker/stale value):
+
+| Field | Disposition | Source after from_dict |
+|-------|-------------|------------------------|
+| `security_gate_checked` | FORCED FALSE | server-default (ignores inbound) |
+| `security_gate_passed` | FORCED FALSE | server-default (ignores inbound) |
+| `permission_gate_checked` | FORCED FALSE | server-default (ignores inbound) |
+| `permission_gate_passed` | FORCED FALSE | server-default (ignores inbound) |
+| `exfoliation_gate_checked` | FORCED FALSE | server-default (ignores inbound) |
+| `exfoliation_gate_passed` | FORCED FALSE | server-default (ignores inbound) |
+| `wsp_preflight_checked` | FORCED FALSE | server-default (ignores inbound) |
+| `wsp_preflight_passed` | FORCED FALSE | server-default (ignores inbound) |
+| `capability_token_checked` | FORCED FALSE | server-default (ignores inbound) |
+| `capability_token_present` | FORCED FALSE | server-default (ignores inbound) |
+| `capability_token_validated` | FORCED FALSE | server-default (ignores inbound) |
+| `capability_token_scope_authorized` | FORCED FALSE | server-default (ignores inbound) |
+| `dry_run_mode` | **PRESERVED** | `bool(data.get("dry_run_mode", False))` |
+
+All 12 fields in `_SERVER_AUTHORED_FLAGS` are forced `False`; `dry_run_mode` is the sole preserved
+inbound flag.
+
+---
+
+## 6. Validator Write-Back Field Matrix
+
+`_writeback_token_verdict` mapping (executor `:1158`). `result = token_validation_result`
+(`None` when no token was present in the payload):
+
+| PolicyFlags field | Source expression | Rationale |
+|-------------------|-------------------|-----------|
+| `capability_token_checked` | `True` (unconditional) | `execute()` always runs token validation, so a check was always performed. |
+| `capability_token_present` | `result is not None` | A token was present iff the validator returned a (non-None) result. |
+| `capability_token_validated` | `result is not None and result.token_valid` | The validator marked the token valid. |
+| `capability_token_scope_authorized` | `validated and not result.scope_action_class_mismatch` | Token valid AND scopes authorize the classified action class. `token_valid=True` already implies no scope/action-class mismatch (validator success return `capability_token_validator.py:628` leaves `scope_action_class_mismatch=False`; the mismatch return at `:610-617` sets `token_valid=False, scope_action_class_mismatch=True`). The `not …mismatch` term is defensive belt-and-suspenders. Field defined at `capability_token_validator.py:304`. |
+| `security_gate_checked` | NOT WRITTEN — server-default `False` | No security-gate evaluator in this executor. |
+| `security_gate_passed` | NOT WRITTEN — server-default `False` | The only writer of `security_gate_*` is the SEPARATE `modules/foundups/agent/src/hermes_foundup_job_executor.py:362`. Fabricating `security_gate_passed=True` is out of scope (future). |
+
+---
+
+## 7. Guard Sequencing Proof
+
+Within `HermesJobExecutor.execute()` (`modules/infrastructure/wre_core/src/hermes_job_executor.py`):
+
+```
+:1496  token_validation_result = self._validate_token_if_present(job, request, action_class=...)
+:1500  (invalid-token early-return block — if token present and not valid -> BLOCKED_BY_TOKEN_VALIDATION)
+:1521  self._writeback_token_verdict(job, token_validation_result)   # server-authored verdict written
+:1524  guard_result = self._evaluate_destructive_action_guard(job, request)  # guard reads policy_flags
+```
+
+The write-back at line **1521** strictly precedes the guard evaluation at line **1524**. The guard's
+`_build_destructive_action_request` reads `policy_flags.capability_token_*` (`:1131-1138`), so it now
+reads the server-authored verdict, never attacker-supplied flags.
+
+---
+
+## 8. D3 / D4 / D5 / D6 Boundary Proof (behavior unchanged; bypass closed)
+
+| Path | Before | After | Mechanism |
+|------|--------|-------|-----------|
+| No-token D3 | BLOCKED (`MISSING_CAPABILITY_TOKEN`) | BLOCKED | write-back sets `present/validated/scope=False` → guard token gate False. |
+| Invalid-token D3/D4 | BLOCKED (`BLOCKED_BY_TOKEN_VALIDATION`, early-return before guard) | BLOCKED | unchanged; early-return at `:1500` precedes write-back's effect on guard. |
+| Valid-token D3 | ALLOW dry-run only **iff** other gates True | ALLOW dry-run only **iff** other gates True | capability flags True via write-back; `security_gate_passed` still server-default False → D3 BLOCKED unless server authors security gate. `live_execution_allowed=False` always. |
+| Forged flags, no token, D3 (**the bypass**) | (would clear guard token gate if ingress could pre-set flags) | **BLOCKED** | sanitization zeroes inbound flags AND write-back demotes to no-token verdict. Bypass closed. |
+| D4 / D5 / D6 (any flags / valid token) | BLOCKED (class-based, unconditional) | BLOCKED | unchanged; guard blocks by class regardless of token/flags. |
+
+No behavior expansion: D3 remains bounded/dry-run only; D4/D5/D6 remain unconditionally blocked.
+
+---
+
+## 9. Test Scenario Matrix
+
+| # | Scenario | Test(s) | Result |
+|---|----------|---------|--------|
+| 1 | from_dict ignores malicious inbound gate/token flags; `dry_run_mode` preserved | `test_foundup_job_contract.py::TestPolicyFlagsDeserializationSanitization::*` (malicious-all-true, dry_run preserved/false/missing, FoundUpJob.from_dict, __post_init__) | PASS |
+| 2 | `create_job()` yields all-False gate/token flags at birth | `…::test_create_job_yields_all_false_gate_flags` | PASS |
+| 3 | Executor writes verdict back (valid / no-token / invalid) | `test_hxa_policyflags_writeback_remediation.py::TestWriteBackReflectsVerdict::*` + `TestWriteBackHelperSemantics::*` | PASS |
+| 4 | Guard sees server-authored fields — pre-set flags + no token still BLOCKED at D3 | `…::TestBypassClosed::test_payload_preset_capability_flags_but_no_token_blocked_at_d3`, `…::test_writeback_overrides_stale_object_flags_before_guard` | PASS |
+| 5 | D4/D5/D6 remain BLOCKED regardless of flags | `…::TestBoundaryUnchanged::test_d4_d5_d6_blocked_even_with_valid_token` (parametrized) | PASS |
+| 6 | D3 bounded/dry-run only (`live_execution_allowed=False`) | `…::test_d3_valid_token_remains_dry_run_only`, `…::test_security_gate_not_fabricated_by_writeback` | PASS |
+
+**Existing tests updated to the new (correct) semantics** — each change justified:
+
+| Test (file) | Old assertion (insecure) | New assertion (secure) | Justification |
+|-------------|--------------------------|------------------------|---------------|
+| `test_foundup_job_contract.py::test_to_dict_roundtrip` → `test_from_dict_sanitizes_server_authored_flags` | from_dict preserves True gate flags | gate flags forced False; `dry_run_mode` preserved | Sanitization (CHANGE 1). |
+| `…::test_from_dict_missing_fields_default_false` | `security_gate_checked is True` from data | `security_gate_checked is False` (sanitized) | Sanitization. |
+| `…::test_policy_flags_in_job_roundtrip` → `…_sanitizes_gates` | restored gates True | restored gates False; `dry_run_mode` True | Sanitization via FoundUpJob.from_dict. |
+| `…::test_capability_token_fields_from_dict` → `…_sanitized` | token flags True | token flags False | Sanitization. |
+| `…::test_capability_token_roundtrip` → `…_sanitized_on_roundtrip` | token roundtrip preserves True | to_dict True, from_dict False | Sanitization. |
+| `test_hxa24_capability_token_policyflags.py::test_from_dict_restores_capability_token_fields` → `…_sanitizes…` | token flags restored True | token flags forced False | Sanitization. |
+| `…::test_roundtrip_preserves_all_fields` → `…_sanitizes_server_authored_preserves_dry_run` | all fields preserved | gate/token False; `dry_run_mode` preserved | Sanitization. |
+| `…::test_job_from_dict_restores_capability_token_flags` → `…_sanitizes…` | job token flags restored True | job token flags forced False | Sanitization. |
+| `…::test_all_four_true_with_security_gate_allows_d3` | forged 4 token flags + security gate → ALLOW | REAL valid token in payload (server-authored verdict) + security gate → ALLOW | Write-back: forging flags no longer works; a real token is required. |
+| `…::test_all_four_true_but_missing_security_gate_blocks_d3` | forged 4 token flags, no security gate → `MISSING_SECURITY_GATE` | REAL valid token, no security gate → `MISSING_SECURITY_GATE` | Write-back: real token promotes capability flags; security gate still blocks. |
+| `test_hxa25` / `test_hxa28` `_create_*_with_all_gates` helpers | forged capability flags | REAL broad-scope token in payload (D3 passes, D4/D5/D6 guard-blocked) | Write-back authority. |
+| `test_hxa4` / `test_hxa12` / `test_hxa14` / `test_hxa16` `set_d3_capability_token_gates` | forged capability flags | REAL valid D3 token attached to payload (`dry_run_only=False` so it validates in both dry/live executor modes) | Write-back authority; harness/guard still bounds execution. |
+
+### Test run results (exact counts)
+
+| File | Result |
+|------|--------|
+| `modules/communication/moltbot_bridge/tests/test_foundup_job_contract.py` | **78 passed** |
+| `modules/infrastructure/wre_core/tests/test_hermes_job_executor.py` | **94 passed** |
+| `modules/infrastructure/wre_core/tests/test_hxa_policyflags_writeback_remediation.py` (new) | **13 passed** |
+| Full `modules/infrastructure/wre_core/tests/` | **1383 passed, 3 skipped, 2 xfailed, 5 deselected** |
+
+**5 deselected are PRE-EXISTING environmental failures (NOT caused by this slice), verified against
+the clean tree:**
+- `test_wre_skills_discovery.py::test_initialization` — asserts repo dir name `Foundups-Agent`; fails
+  because this is an isolated worktree dir (`agent-…`).
+- `test_hxa16…::TestHermesRealDelegateInterfaceExists::{test_delegate_tool_file_exists,
+  test_delegate_tool_contains_delegate_task_function, test_delegate_task_requires_parent_agent,
+  test_delegate_task_spawns_child_agents}` — require vendored `vendor/hermes-agent/tools/delegate_tool.py`
+  which is absent in this worktree. All four fail identically on `git stash` of this slice's changes.
+
+### Regression confirm
+
+`git grep -n "FoundUpJob.from_dict" -- '*.py' | grep -v test` → **1 match, and it is a comment line in
+`foundup_job_contract.py` (not a caller). Production-caller count = 0.** No production caller of
+`FoundUpJob.from_dict` was added (NO_FROM_DICT_PRODUCTION_WIRING honored).
+
+---
+
+## 10. Residual Risks / Deferred Trip-Wire
+
+1. **Persistent-queue `from_dict` wiring (the trip-wire).** The in-memory `_FOUNDUP_JOB_QUEUE` has no
+   serialize/deserialize hop today. The moment any HTTP/API/message-queue/persisted-job ingress is
+   wired to `FoundUpJob.from_dict`, this slice's sanitization is the positive control that holds the
+   boundary. Recommended follow-up: `HXA_PERSISTENT_QUEUE_POLICYFLAGS_TRIPWIRE_AUDIT_PHASE1`.
+2. **Security-gate write-back (future).** This executor has no security-gate evaluator;
+   `security_gate_*` stays server-default `False`. Wiring a real security-gate verdict (analogous to the
+   token write-back) is deferred. Until then, valid-token D3 stays BLOCKED unless a server component
+   authors the security gate by direct assignment.
+3. **Provenance marker (optional hardening, #746 §9.4).** A non-serialized server-authored marker could
+   assert provenance so a future `from_dict` path cannot reintroduce caller-asserted gate state. Not
+   implemented in this slice (the sanitization already forces False; the marker is defense-in-depth).
+
+---
+
+## 11. Internal Review Verdict
+
+**READY.** Both changes implemented exactly to the locked design with verified `file:line` evidence:
+(1) sanitization forces all 12 server-authored flags False, preserves only `dry_run_mode`, at the single
+chokepoint `PolicyFlags.from_dict`; (2) write-back at `execute():1521` precedes guard eval at `:1524`,
+mapping the real verdict (capability_token_* from `TokenValidationResult`; security_gate_* left
+server-default). The bypass is closed (sanitization + write-back), D3 stays bounded dry-run only, and
+D4/D5/D6 remain unconditionally blocked — no behavior expansion. All target suites green
+(78 / 94 / 13); full wre_core green except 5 pre-existing worktree-environmental failures (verified
+unrelated). Zero production callers of `FoundUpJob.from_dict`. Engineering/security only — no 012 ruling
+requested.
+
+---
+
+## 12. WSP_97 Truth Boundary Checklist
+
+Declared count: **24 / 24 YES** (rows below = 24).
+
+| # | Truth Boundary Checklist Item | Status | Evidence |
+|---|-------------------------------|--------|----------|
+| 1 | POLICYFLAGS_WRITEBACK_REMEDIATION_ONLY | YES | Only `PolicyFlags.from_dict` sanitization + `_writeback_token_verdict` + their tests/audit changed; no broad refactor. |
+| 2 | NO_LIVE_HERMES_DELEGATION | YES | No delegation path enabled; tests run with `HERMES_DELEGATE_ENABLED=0`. |
+| 3 | NO_HERMES_RUNTIME_LAUNCH | YES | No Hermes runtime launched. |
+| 4 | NO_OLLAMA_LAUNCH | YES | No Ollama process started. |
+| 5 | NO_WSL_INSTALL | YES | No WSL install. |
+| 6 | NO_API_INGRESS_WIRING | YES | No HTTP/API ingress added. |
+| 7 | NO_FROM_DICT_PRODUCTION_WIRING | YES | `git grep` production-caller count of `FoundUpJob.from_dict` = 0 (only a comment line). |
+| 8 | NO_D4_D5_D6_WEAKENING | YES | D4/D5/D6 remain unconditional class blocks; parametrized test proves blocked even with valid token. |
+| 9 | NO_D3_LIVE_EXECUTION | YES | D3 ALLOW is dry-run only; `live_execution_allowed=False` asserted; `real_execution_performed=False`. |
+| 10 | NO_ENV_MUTATION | YES | Only `patch.dict(os.environ, …)` scoped within tests; no persistent env change. |
+| 11 | NO_DEPENDENCY_CHANGE | YES | No requirements/imports of new packages. |
+| 12 | NO_CI_CHANGE | YES | No CI/workflow files touched. |
+| 13 | NO_WSP_MUTATION | YES | No WSP framework file modified. |
+| 14 | NO_REGISTRY_MUTATION | YES | No registry modified. |
+| 15 | NO_MANIFEST_MUTATION | YES | No manifest modified. |
+| 16 | NO_PUBLIC_SURFACE_MUTATION | YES | No public API signature changed; `from_dict` signature unchanged (semantics hardened only). |
+| 17 | NO_SECRET_VALUES | YES | No secrets/keys/tokens printed; only test fake tokens via `LocalCapabilityTokenIssuer`. |
+| 18 | NO_CABR_READY | YES | No CABR-ready claim; not touched. |
+| 19 | NO_PAYOUT_READY | YES | No payout-ready claim; not touched. |
+| 20 | NO_DAO_ACTIVATION | YES | No DAO activation. |
+| 21 | NO_HERMES_DELEGATE_ENABLED_TOUCH | YES | `HERMES_DELEGATE_ENABLED` not modified in source; only read in scoped test env. |
+| 22 | CONFIG_SIDE_EFFECTS_REVERTED | YES | Test-run truncation of `wre_core/config/{WRE_RUNBOOK.md,wre_defaults.env}` restored via `git checkout`; not committed. |
+| 23 | TESTS_NOT_WEAKENED | YES | Existing tests updated to NEW correct semantics (Test Scenario Matrix §9), each justified; none weakened to pass. |
+| 24 | WORKTREE_ISOLATION | YES | All edits/tests/commits in the isolated worktree; other worktrees untouched. |
+
+**WSP 97 Truth Boundary Checklist: 24/24 YES.**
+
+---
+
+*Authored by 0102 (Worker-Lane W6) under WSP_00 zen state and WSP_97 Truth Boundary discipline.
+Targeted remediation of `origin/main` @ `d602d874b`. Implements #746 §9 steps 1-3: deserialization
+sanitization (positive control) + validator verdict write-back before guard evaluation. Bypass closed;
+no behavior expansion.*

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,36 @@
 # ModLog - moltbot_bridge
 
+## 2026-06-02: PolicyFlags Write-Back Remediation — Deserialization Sanitization (W6)
+
+**Author**: 0102 (Worker-Lane W6)
+**WSP**: 97 (Truth Boundary), 50 (Pre-Action Verification)
+**Slice**: `HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1`
+**Predecessors**: #746 (enforcement audit, `GAP_CONFIRMED_BOUNDED`), #744, HXA24/27/30
+
+### Summary
+
+Closes the #746 bounded PolicyFlags write-back defect (CHANGE 1 of 2). Security/token gate flags are
+now **server-authored only** — deserialized job data can never grant a passing gate or a valid token.
+
+### Changes
+- `src/foundup_job_contract.py`:
+  - Added module-level `_SERVER_AUTHORED_FLAGS` frozenset (12 gate/token fields).
+  - Rewrote `PolicyFlags.from_dict` to **force every server-authored flag to `False`** regardless of
+    inbound data; only `dry_run_mode` is preserved (operator-authored; `True` = safe/sandbox direction).
+  - `FoundUpJob.from_dict` (`:613`) and `__post_init__` (`:411-412`) both route through this single
+    chokepoint, so both untrusted-deserialization paths are covered.
+  - Direct `PolicyFlags(...)` constructor + `default_factory=PolicyFlags` are UNCHANGED — server code can
+    still author `True` flags by direct object assignment.
+- Audit: `docs/audits/security/HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1.md` (sanitization +
+  write-back field matrices, guard-sequencing proof, D3/D4/D5/D6 boundary proof, WSP 97 24/24 YES).
+
+**Regression**: `git grep FoundUpJob.from_dict` non-test caller count = **0** (no production wiring).
+
+**Tests**: `tests/test_foundup_job_contract.py` → **78 passed** (round-trip tests updated to assert the
+new sanitization; new `TestPolicyFlagsDeserializationSanitization` positive-control class added).
+
+---
+
 ## 2026-06-01: WSP 109 Genesis Gate Remediation (W6)
 
 **Author**: 0102 (Worker-Lane W6)

--- a/modules/communication/moltbot_bridge/src/foundup_job_contract.py
+++ b/modules/communication/moltbot_bridge/src/foundup_job_contract.py
@@ -189,6 +189,32 @@ class StatusReasonCode(str, Enum):
 # ---------------------------------------------------------------------------
 
 
+# HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (#746):
+# Security/token gate flags are SERVER-AUTHORED ONLY. They MUST NOT be trusted
+# from deserialized (untrusted) job data. PolicyFlags.from_dict forces every
+# field in this frozenset to False regardless of inbound data; server authority
+# comes exclusively from runtime validation write-back in the executor.
+#
+# NOT in this set (preserved across deserialization):
+#   - dry_run_mode: operator-authored; True is the safe/sandbox direction.
+_SERVER_AUTHORED_FLAGS: frozenset = frozenset(
+    {
+        "security_gate_checked",
+        "security_gate_passed",
+        "permission_gate_checked",
+        "permission_gate_passed",
+        "exfoliation_gate_checked",
+        "exfoliation_gate_passed",
+        "wsp_preflight_checked",
+        "wsp_preflight_passed",
+        "capability_token_checked",
+        "capability_token_present",
+        "capability_token_validated",
+        "capability_token_scope_authorized",
+    }
+)
+
+
 @dataclass(slots=True)
 class PolicyFlags:
     """
@@ -256,22 +282,45 @@ class PolicyFlags:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> PolicyFlags:
-        """Deserialize from dict."""
+        """Deserialize from dict.
+
+        SECURITY (HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1, #746):
+        Deserialized gate/token state is UNTRUSTED and is FORCED to False.
+        Every field in ``_SERVER_AUTHORED_FLAGS`` (all security/permission/
+        exfoliation/wsp-preflight gate flags and all four capability_token_*
+        flags) is zeroed REGARDLESS of inbound data — a malicious or stale
+        payload can never grant itself a passing gate or a valid token by
+        carrying ``True`` here.
+
+        Server authority for these flags comes EXCLUSIVELY from runtime
+        validation write-back (see HermesJobExecutor.execute, which writes the
+        validator verdict into job.policy_flags before the destructive-action
+        guard reads it). Code that legitimately needs a flag True must set it
+        via the direct ``PolicyFlags(...)`` constructor or by object attribute
+        assignment (server-authored), NOT through this untrusted path.
+
+        ONLY ``dry_run_mode`` is preserved from inbound data: it is
+        operator-authored and ``True`` is the safe/sandbox direction.
+        """
+        # Single deserialization chokepoint. Both FoundUpJob.from_dict and
+        # FoundUpJob.__post_init__ route here, so this covers every path.
         return cls(
-            security_gate_checked=bool(data.get("security_gate_checked", False)),
-            security_gate_passed=bool(data.get("security_gate_passed", False)),
-            permission_gate_checked=bool(data.get("permission_gate_checked", False)),
-            permission_gate_passed=bool(data.get("permission_gate_passed", False)),
-            exfoliation_gate_checked=bool(data.get("exfoliation_gate_checked", False)),
-            exfoliation_gate_passed=bool(data.get("exfoliation_gate_passed", False)),
-            wsp_preflight_checked=bool(data.get("wsp_preflight_checked", False)),
-            wsp_preflight_passed=bool(data.get("wsp_preflight_passed", False)),
+            # Server-authored gate/token flags: forced False (untrusted input
+            # is NOT read). See _SERVER_AUTHORED_FLAGS.
+            security_gate_checked=False,
+            security_gate_passed=False,
+            permission_gate_checked=False,
+            permission_gate_passed=False,
+            exfoliation_gate_checked=False,
+            exfoliation_gate_passed=False,
+            wsp_preflight_checked=False,
+            wsp_preflight_passed=False,
+            capability_token_checked=False,
+            capability_token_present=False,
+            capability_token_validated=False,
+            capability_token_scope_authorized=False,
+            # Operator-authored: preserved (True is the safe/sandbox direction).
             dry_run_mode=bool(data.get("dry_run_mode", False)),
-            # HXA24: Capability token policy flags (backward compatible)
-            capability_token_checked=bool(data.get("capability_token_checked", False)),
-            capability_token_present=bool(data.get("capability_token_present", False)),
-            capability_token_validated=bool(data.get("capability_token_validated", False)),
-            capability_token_scope_authorized=bool(data.get("capability_token_scope_authorized", False)),
         )
 
 

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,27 @@
+## 2026-06-02: PolicyFlags Deserialization Sanitization Tests (W6)
+
+**File**: `test_foundup_job_contract.py` (UPDATED + new class)
+**Slice**: `HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1` | **Predecessors**: #746, #744, HXA24/27/30
+
+`PolicyFlags.from_dict` now forces server-authored gate/token flags False (untrusted input). Existing
+round-trip tests that asserted from_dict PRESERVES True gate/token flags are updated to the NEW correct
+semantics (each justified in the audit Test Scenario Matrix):
+- `test_to_dict_roundtrip` → `test_from_dict_sanitizes_server_authored_flags`
+- `test_from_dict_missing_fields_default_false` (now asserts `security_gate_checked is False`)
+- `test_policy_flags_in_job_roundtrip` → `…_sanitizes_gates`
+- `test_capability_token_fields_from_dict` → `…_sanitized`
+- `test_capability_token_roundtrip` → `…_sanitized_on_roundtrip`
+
+**New** `TestPolicyFlagsDeserializationSanitization` (positive control): malicious-all-True → all-False;
+`dry_run_mode` preserved (true/false/missing); FoundUpJob.from_dict + __post_init__ chokepoint coverage;
+`create_job()` all-False at birth; direct constructor still allows server-authored True.
+
+**Determinism**: pure dataclass (de)serialization; no process/network/.env/model.
+
+**Result**: **78 passed**.
+
+---
+
 ## 2026-06-01: WSP 109 Genesis Gate Remediation Tests (W6)
 
 **File**: `test_openclaw_wsp109_onboarding_dryrun.py` (REWRITTEN - 10 tests, 0 xfail)

--- a/modules/communication/moltbot_bridge/tests/test_foundup_job_contract.py
+++ b/modules/communication/moltbot_bridge/tests/test_foundup_job_contract.py
@@ -524,8 +524,14 @@ class TestPolicyFlags:
         assert flags.capability_token_validated is False
         assert flags.capability_token_scope_authorized is False
 
-    def test_to_dict_roundtrip(self):
-        """PolicyFlags survives to_dict/from_dict roundtrip."""
+    def test_from_dict_sanitizes_server_authored_flags(self):
+        """from_dict FORCES server-authored gate flags to False (#746).
+
+        HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1: deserialized gate/token
+        state is UNTRUSTED. Even if a (possibly malicious) payload carries True
+        for security/permission gate flags, from_dict zeroes them. Only
+        dry_run_mode is preserved (operator-authored).
+        """
         flags = PolicyFlags(
             security_gate_checked=True,
             security_gate_passed=True,
@@ -536,18 +542,24 @@ class TestPolicyFlags:
         data = flags.to_dict()
         restored = PolicyFlags.from_dict(data)
 
-        assert restored.security_gate_checked is True
-        assert restored.security_gate_passed is True
-        assert restored.permission_gate_checked is True
+        # Server-authored gate flags forced False regardless of inbound True
+        assert restored.security_gate_checked is False
+        assert restored.security_gate_passed is False
+        assert restored.permission_gate_checked is False
         assert restored.permission_gate_passed is False
-        assert restored.exfoliation_gate_checked is False  # Default
+        assert restored.exfoliation_gate_checked is False
+        # Operator-authored flag preserved
         assert restored.dry_run_mode is True
 
     def test_from_dict_missing_fields_default_false(self):
-        """Missing fields in dict default to False."""
+        """Missing fields default to False; present gate flags forced False (#746).
+
+        Inbound security_gate_checked=True is IGNORED (server-authored,
+        untrusted) and sanitized to False.
+        """
         data = {"security_gate_checked": True}
         flags = PolicyFlags.from_dict(data)
-        assert flags.security_gate_checked is True
+        assert flags.security_gate_checked is False  # Sanitized: forced False
         assert flags.permission_gate_checked is False  # Not in data
         # HXA24: Capability token fields should default to False
         assert flags.capability_token_checked is False
@@ -555,8 +567,13 @@ class TestPolicyFlags:
         assert flags.capability_token_validated is False
         assert flags.capability_token_scope_authorized is False
 
-    def test_policy_flags_in_job_roundtrip(self):
-        """PolicyFlags survive job serialization."""
+    def test_policy_flags_in_job_roundtrip_sanitizes_gates(self):
+        """Job from_dict sanitizes server-authored gate flags (#746).
+
+        Even when a serialized job carries True security gate flags, the
+        untrusted FoundUpJob.from_dict path forces them False; only the
+        operator-authored dry_run_mode survives.
+        """
         job = create_job(tenant_id="t", requested_action="a")
         job.policy_flags.security_gate_checked = True
         job.policy_flags.security_gate_passed = True
@@ -565,10 +582,12 @@ class TestPolicyFlags:
         data = job.to_dict()
         restored = FoundUpJob.from_dict(data)
 
-        assert restored.policy_flags.security_gate_checked is True
-        assert restored.policy_flags.security_gate_passed is True
-        assert restored.policy_flags.dry_run_mode is True
+        # Server-authored gate flags sanitized to False on deserialization
+        assert restored.policy_flags.security_gate_checked is False
+        assert restored.policy_flags.security_gate_passed is False
         assert restored.policy_flags.permission_gate_checked is False
+        # Operator-authored flag preserved
+        assert restored.policy_flags.dry_run_mode is True
 
     # HXA24: Capability Token PolicyFlags Tests
 
@@ -595,8 +614,14 @@ class TestPolicyFlags:
         assert data["capability_token_validated"] is True
         assert data["capability_token_scope_authorized"] is True
 
-    def test_capability_token_fields_from_dict(self):
-        """Capability token fields restored from dict (HXA24)."""
+    def test_capability_token_fields_from_dict_sanitized(self):
+        """from_dict FORCES capability token fields to False (#746).
+
+        Capability token flags are server-authored and must never be trusted
+        from deserialized data. A malicious payload presenting all four as True
+        is sanitized to all-False; server authority comes from executor
+        write-back.
+        """
         data = {
             "capability_token_checked": True,
             "capability_token_present": True,
@@ -605,13 +630,17 @@ class TestPolicyFlags:
         }
         flags = PolicyFlags.from_dict(data)
 
-        assert flags.capability_token_checked is True
-        assert flags.capability_token_present is True
-        assert flags.capability_token_validated is True
-        assert flags.capability_token_scope_authorized is True
+        assert flags.capability_token_checked is False
+        assert flags.capability_token_present is False
+        assert flags.capability_token_validated is False
+        assert flags.capability_token_scope_authorized is False
 
-    def test_capability_token_roundtrip(self):
-        """Capability token fields survive roundtrip (HXA24)."""
+    def test_capability_token_fields_sanitized_on_roundtrip(self):
+        """Capability token fields forced False through from_dict (#746).
+
+        Even though to_dict faithfully serializes True flags (server-authored
+        object state), the untrusted from_dict path zeroes them.
+        """
         original = PolicyFlags(
             capability_token_checked=True,
             capability_token_present=True,
@@ -619,12 +648,120 @@ class TestPolicyFlags:
             capability_token_scope_authorized=True,
         )
         data = original.to_dict()
-        restored = PolicyFlags.from_dict(data)
+        # to_dict preserves the server-authored object state
+        assert data["capability_token_checked"] is True
+        assert data["capability_token_scope_authorized"] is True
 
-        assert restored.capability_token_checked == original.capability_token_checked
-        assert restored.capability_token_present == original.capability_token_present
-        assert restored.capability_token_validated == original.capability_token_validated
-        assert restored.capability_token_scope_authorized == original.capability_token_scope_authorized
+        restored = PolicyFlags.from_dict(data)
+        # from_dict sanitizes: untrusted deserialization cannot grant tokens
+        assert restored.capability_token_checked is False
+        assert restored.capability_token_present is False
+        assert restored.capability_token_validated is False
+        assert restored.capability_token_scope_authorized is False
+
+
+# ---------------------------------------------------------------------------
+# Test: PolicyFlags Deserialization Sanitization (#746)
+# HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1
+# ---------------------------------------------------------------------------
+
+
+# Every server-authored gate/token flag that from_dict MUST force False.
+_SANITIZED_FLAG_NAMES = [
+    "security_gate_checked",
+    "security_gate_passed",
+    "permission_gate_checked",
+    "permission_gate_passed",
+    "exfoliation_gate_checked",
+    "exfoliation_gate_passed",
+    "wsp_preflight_checked",
+    "wsp_preflight_passed",
+    "capability_token_checked",
+    "capability_token_present",
+    "capability_token_validated",
+    "capability_token_scope_authorized",
+]
+
+
+class TestPolicyFlagsDeserializationSanitization:
+    """#746: deserialized gate/token state is UNTRUSTED and forced False."""
+
+    def test_malicious_inbound_all_true_forced_false(self):
+        """A payload presenting EVERY gate/token flag True is fully sanitized."""
+        malicious = {name: True for name in _SANITIZED_FLAG_NAMES}
+        malicious["dry_run_mode"] = True  # operator-authored, must survive
+
+        flags = PolicyFlags.from_dict(malicious)
+
+        for name in _SANITIZED_FLAG_NAMES:
+            assert getattr(flags, name) is False, (
+                f"{name} must be forced False on untrusted deserialization"
+            )
+        # dry_run_mode is the only inbound flag preserved
+        assert flags.dry_run_mode is True
+
+    def test_dry_run_mode_preserved_true(self):
+        """dry_run_mode=True is preserved (safe/sandbox direction)."""
+        flags = PolicyFlags.from_dict({"dry_run_mode": True})
+        assert flags.dry_run_mode is True
+
+    def test_dry_run_mode_preserved_false(self):
+        """dry_run_mode=False is preserved verbatim."""
+        flags = PolicyFlags.from_dict({"dry_run_mode": False})
+        assert flags.dry_run_mode is False
+
+    def test_dry_run_mode_defaults_false_when_missing(self):
+        """dry_run_mode defaults False when absent from inbound data."""
+        flags = PolicyFlags.from_dict({})
+        assert flags.dry_run_mode is False
+
+    def test_foundupjob_from_dict_sanitizes_malicious_payload(self):
+        """FoundUpJob.from_dict routes through the same sanitization chokepoint."""
+        malicious_flags = {name: True for name in _SANITIZED_FLAG_NAMES}
+        malicious_flags["dry_run_mode"] = True
+        data = {
+            "job_id": "j_attack_001",
+            "tenant_id": "attacker",
+            "requested_action": "create_repo",
+            "policy_flags": malicious_flags,
+        }
+        job = FoundUpJob.from_dict(data)
+
+        for name in _SANITIZED_FLAG_NAMES:
+            assert getattr(job.policy_flags, name) is False
+        assert job.policy_flags.dry_run_mode is True
+
+    def test_post_init_dict_policy_flags_sanitized(self):
+        """__post_init__ coerces a dict of malicious flags through from_dict."""
+        malicious_flags = {name: True for name in _SANITIZED_FLAG_NAMES}
+        job = FoundUpJob(
+            job_id="j_attack_002",
+            tenant_id="attacker",
+            requested_action="delete_permanently",
+            policy_flags=malicious_flags,  # dict -> coerced in __post_init__
+        )
+        for name in _SANITIZED_FLAG_NAMES:
+            assert getattr(job.policy_flags, name) is False
+
+    def test_create_job_yields_all_false_gate_flags(self):
+        """create_job() yields all-False gate/token flags at birth (unchanged)."""
+        job = create_job(tenant_id="t", requested_action="build_foundup")
+        for name in _SANITIZED_FLAG_NAMES:
+            assert getattr(job.policy_flags, name) is False
+        assert job.policy_flags.dry_run_mode is False
+
+    def test_direct_constructor_still_allows_server_authored_true(self):
+        """Direct PolicyFlags(...) constructor is UNCHANGED (server authority).
+
+        Only the untrusted from_dict path is locked down; server code can still
+        author True flags by direct object construction/assignment.
+        """
+        flags = PolicyFlags(
+            security_gate_passed=True,
+            capability_token_validated=True,
+        )
+        assert flags.security_gate_passed is True
+        assert flags.capability_token_validated is True
 
 
 # ---------------------------------------------------------------------------

--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -2,6 +2,35 @@
 
 ## Chronological Change Log
 
+### [2026-06-02] - HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (W6)
+
+**WSP Protocol References**: WSP 97 (Truth Boundary), WSP 22 (ModLog), WSP 50 (Pre-Action)
+**Predecessors**: #746 (enforcement audit, `GAP_CONFIRMED_BOUNDED`), #744, HXA24/27/30
+**Impact Analysis**: Positive-control closure of the #746 PolicyFlags write-back defect (CHANGE 2 of 2).
+
+**Change** — `src/hermes_job_executor.py`:
+- Added private helper `_writeback_token_verdict(job, token_validation_result)` (`:1158`).
+- Called once in `execute()` (`:1521`), **immediately before** `_evaluate_destructive_action_guard`
+  (`:1524`) and after `_validate_token_if_present` (`:1496`) + the invalid-token early-return.
+- Writes the server-authored token verdict into `job.policy_flags`:
+  `capability_token_checked=True`; `capability_token_present = result is not None`;
+  `capability_token_validated = result is not None and result.token_valid`;
+  `capability_token_scope_authorized = validated and not result.scope_action_class_mismatch`.
+- `security_gate_*` intentionally left at server-default `False` (no security-gate evaluator here; the
+  sole writer is the separate `modules/foundups/agent/src/hermes_foundup_job_executor.py:362`). Wiring a
+  real security-gate verdict is deferred (future).
+
+**Behavior**: unchanged. No-token/invalid-token → capability flags not all-True → D3 BLOCKED;
+valid-token → capability flags True but `security_gate_passed` still False → D3 still BLOCKED;
+D4/D5/D6 unconditionally blocked. **Bypass closed**: a payload pre-setting `capability_token_*=True`
+with no real token is still BLOCKED at D3.
+
+**Tests**: `test_hermes_job_executor.py` (94 passed); new
+`test_hxa_policyflags_writeback_remediation.py` (13 passed); full `wre_core/tests/` 1383 passed
+(5 pre-existing worktree-environmental failures deselected, verified unrelated). HXA4/12/14/16/24/25/28
+test helpers updated to supply REAL tokens (forging flags no longer works).
+**Audit**: `docs/audits/security/HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1.md`.
+
 ### [2026-05-28] - REDDOG_BOOTSTRAP_CONTEXT_RETRIEVAL_PHASE1 (v0.8.42)
 
 **WSP Protocol References**: WSP 00 (Zen State), WSP 60 (Module Memory), WSP 22 (ModLog)

--- a/modules/infrastructure/wre_core/src/hermes_job_executor.py
+++ b/modules/infrastructure/wre_core/src/hermes_job_executor.py
@@ -1155,6 +1155,60 @@ class HermesJobExecutor:
             job_id=job.job_id,
         )
 
+    def _writeback_token_verdict(
+        self,
+        job: "FoundUpJob",
+        token_validation_result: Optional[TokenValidationResult],
+    ) -> None:
+        """
+        Write the SERVER-AUTHORED token validation verdict into job.policy_flags.
+
+        HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (#746):
+        PolicyFlags.from_dict forces all capability_token_* flags to False on
+        deserialization (untrusted input). This method is the POSITIVE CONTROL:
+        it writes the real runtime validator verdict back onto the job BEFORE
+        the destructive-action guard reads it, so the guard sees server-authored
+        truth, never attacker-supplied flags.
+
+        Field sources (read from the real TokenValidationResult):
+          - capability_token_checked: True. execute() always runs token
+            validation, so a check was always performed.
+          - capability_token_present: a token was present in the payload iff the
+            validator returned a (non-None) result.
+          - capability_token_validated: the validator marked the token valid.
+          - capability_token_scope_authorized: the token is valid AND its scopes
+            authorize the classified action class (token_valid already implies
+            no scope/action-class mismatch; ``not scope_action_class_mismatch``
+            is a defensive belt-and-suspenders against future result shapes).
+
+        NOTE: security_gate_* is intentionally NOT written here. There is no
+        security-gate evaluator in this executor (the only writer of
+        security_gate_* is the separate
+        modules/foundups/agent/.../hermes_foundup_job_executor.py). Leaving it at
+        the server-default False keeps D3 blocked for valid tokens. Wiring a real
+        security-gate verdict is out of scope (future).
+
+        Args:
+            job: Source FoundUpJob (policy_flags mutated in place).
+            token_validation_result: Result from _validate_token_if_present
+                (None when no token was present in the payload).
+        """
+        if job.policy_flags is None:
+            return
+
+        result = token_validation_result
+        token_present = result is not None
+        token_valid = bool(token_present and result.token_valid)
+        scope_authorized = bool(
+            token_valid and not result.scope_action_class_mismatch
+        )
+
+        # A check is always performed: execute() always runs validation.
+        job.policy_flags.capability_token_checked = True
+        job.policy_flags.capability_token_present = token_present
+        job.policy_flags.capability_token_validated = token_valid
+        job.policy_flags.capability_token_scope_authorized = scope_authorized
+
     def _evaluate_destructive_action_guard(
         self,
         job: "FoundUpJob",
@@ -1457,6 +1511,14 @@ class HermesJobExecutor:
                 duration_seconds=time.monotonic() - start_time,
                 guard_result=None,  # Guard not yet evaluated
             )
+
+        # Step 2.4: HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (#746)
+        # Write the SERVER-AUTHORED token validation verdict into
+        # job.policy_flags BEFORE the guard reads it. PolicyFlags.from_dict
+        # zeroed all capability_token_* on (untrusted) deserialization; this is
+        # the positive control that re-establishes server authority from the
+        # real runtime validator result. MUST run before guard evaluation.
+        self._writeback_token_verdict(job, token_validation_result)
 
         # Step 2.5: HXA23 - Evaluate destructive action guard
         guard_result = self._evaluate_destructive_action_guard(job, request)

--- a/modules/infrastructure/wre_core/tests/TestModLog.md
+++ b/modules/infrastructure/wre_core/tests/TestModLog.md
@@ -1,5 +1,39 @@
 # TestModLog - wre_core/tests
 
+## 2026-06-02: HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (W6)
+
+**Slice**: `HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1` | **Predecessors**: #746, #744, HXA24/27/30
+
+**New** `test_hxa_policyflags_writeback_remediation.py` (13 tests):
+- `TestWriteBackReflectsVerdict`: valid / no-token / invalid-token write-back of `capability_token_*`.
+- `TestBypassClosed`: payload pre-set `capability_token_*=True` + no token → STILL BLOCKED at D3;
+  write-back demotes forged object flags before guard.
+- `TestBoundaryUnchanged`: D4/D5/D6 blocked even with valid token (parametrized); D3 dry-run only;
+  write-back never fabricates `security_gate_passed`.
+- `TestWriteBackHelperSemantics`: direct unit coverage of `_writeback_token_verdict` mapping.
+
+**Updated existing suites to the NEW correct semantics** (each justified in audit §9):
+- `test_hxa24…`: 3 from_dict round-trip tests now assert sanitization (forced False); 2 D3 "all gates"
+  tests now supply a REAL token in payload (forging flags no longer works).
+- `test_hxa25…` / `test_hxa28…`: `_create_*_with_all_gates` helpers attach a REAL broad-scope token
+  (D3 passes guard; D4/D5/D6 validate token but guard-blocked by class).
+- `test_hxa4/12/14/16…`: `set_d3_capability_token_gates` attaches a REAL D3 token (`dry_run_only=False`
+  so it validates in both dry/live executor modes); imports the issuer via the FULL package path so
+  `CapabilityToken` class identity matches the executor's `isinstance` check.
+
+**Determinism**: `HERMES_DELEGATE_ENABLED=0` (scoped `patch.dict`); fake tokens via
+`LocalCapabilityTokenIssuer`; no live process/network/.env/model.
+
+**Run**: `pytest modules/infrastructure/wre_core/tests/test_hermes_job_executor.py
+test_hxa_policyflags_writeback_remediation.py test_hxa24_capability_token_policyflags.py
+test_hxa25_d3_sandbox_execution.py test_hxa28_d3_native_classification.py
+test_hxa4_real_hermes_object_dryrun.py test_hxa12_gotjunk_second_proof_dryrun.py
+test_hxa14_controlled_live_hermes_harness.py test_hxa16_real_hermes_delegate_adapter_safe_harness.py -q`
+
+**Result**: full `wre_core/tests/` = **1383 passed, 3 skipped, 2 xfailed**; 5 deselected are pre-existing
+worktree-environmental failures (skills-discovery repo-name; vendored `delegate_tool.py` absent),
+verified unrelated to this slice on the clean tree.
+
 ## 2026-05-28: REDDOG_BOOTSTRAP_CONTEXT_RETRIEVAL_PHASE1 Boot retrieval tests
 
 - Command: `python -m pytest modules/infrastructure/wre_core/tests/test_bootstrap_context_retrieval.py -v`

--- a/modules/infrastructure/wre_core/tests/test_hxa12_gotjunk_second_proof_dryrun.py
+++ b/modules/infrastructure/wre_core/tests/test_hxa12_gotjunk_second_proof_dryrun.py
@@ -57,6 +57,12 @@ from modules.infrastructure.wre_core.src.hermes_job_executor import (
     is_hermes_delegation_enabled,
 )
 
+# HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (#746): real capability token
+# issuer (server-authored verdict comes from the executor's runtime write-back).
+from modules.infrastructure.wre_core.src.capability_token_validator import (
+    LocalCapabilityTokenIssuer,
+)
+
 
 # ---------------------------------------------------------------------------
 # GotJunk Constants (from foundup_manifest.json)
@@ -88,17 +94,28 @@ def set_d3_capability_token_gates(job):
 
     HXA28: build_foundup and extract_foundup are now D3 actions that require
     capability tokens. For tests that need to reach SIMULATED status (not
-    BLOCKED_BY_DESTRUCTIVE_ACTION_GUARD), set all four capability token gates
-    AND the security gate.
+    BLOCKED_BY_DESTRUCTIVE_ACTION_GUARD), the job must carry a valid token AND
+    the security gate.
 
-    This simulates a valid capability token being present with security gate passed.
+    HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (#746): capability_token_*
+    flags are SERVER-AUTHORED by the executor's runtime write-back, so we attach
+    a REAL valid D3 token to the job payload (forging the flags no longer works).
+    security_gate_* is set directly (server-authored; no evaluator here).
     """
-    # Capability token gates
-    job.policy_flags.capability_token_checked = True
-    job.policy_flags.capability_token_present = True
-    job.policy_flags.capability_token_validated = True
-    job.policy_flags.capability_token_scope_authorized = True
-    # Security gate (also required for D3)
+    # Attach a REAL valid D3 capability token into the job payload.
+    if not isinstance(job.payload, dict):
+        job.payload = {}
+    job.payload["capability_token"] = LocalCapabilityTokenIssuer().issue_token(
+        subject="agent_hxa12",
+        audience="wre-local",
+        scopes=["d3:sandbox"],  # authorizes D3 (build_foundup / extract_foundup)
+        allowed_actions=["build_foundup", "extract_foundup"],
+        allowed_paths=["modules/foundups"],
+        # dry_run_only=False so the token validates whether the executor runs
+        # with dry_run True or False; the guard/harness still bounds execution.
+        dry_run_only=False,
+    )
+    # Security gate (also required for D3) - server-authored direct assignment.
     job.policy_flags.security_gate_checked = True
     job.policy_flags.security_gate_passed = True
 

--- a/modules/infrastructure/wre_core/tests/test_hxa14_controlled_live_hermes_harness.py
+++ b/modules/infrastructure/wre_core/tests/test_hxa14_controlled_live_hermes_harness.py
@@ -55,6 +55,12 @@ from modules.infrastructure.wre_core.src.hermes_job_executor import (
     is_hermes_delegation_enabled,
 )
 
+# HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (#746): real capability token
+# issuer (server-authored verdict comes from the executor's runtime write-back).
+from modules.infrastructure.wre_core.src.capability_token_validator import (
+    LocalCapabilityTokenIssuer,
+)
+
 
 # ---------------------------------------------------------------------------
 # Test Constants
@@ -85,17 +91,28 @@ def set_d3_capability_token_gates(job):
 
     HXA28: build_foundup and extract_foundup are now D3 actions that require
     capability tokens. For tests that need to reach SIMULATED status (not
-    BLOCKED_BY_DESTRUCTIVE_ACTION_GUARD), set all four capability token gates
-    AND the security gate.
+    BLOCKED_BY_DESTRUCTIVE_ACTION_GUARD), the job must carry a valid token AND
+    the security gate.
 
-    This simulates a valid capability token being present with security gate passed.
+    HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (#746): capability_token_*
+    flags are SERVER-AUTHORED by the executor's runtime write-back, so we attach
+    a REAL valid D3 token to the job payload (forging the flags no longer works).
+    security_gate_* is set directly (server-authored; no evaluator here).
     """
-    # Capability token gates
-    job.policy_flags.capability_token_checked = True
-    job.policy_flags.capability_token_present = True
-    job.policy_flags.capability_token_validated = True
-    job.policy_flags.capability_token_scope_authorized = True
-    # Security gate (also required for D3)
+    # Attach a REAL valid D3 capability token into the job payload.
+    if not isinstance(job.payload, dict):
+        job.payload = {}
+    job.payload["capability_token"] = LocalCapabilityTokenIssuer().issue_token(
+        subject="agent_hxa14",
+        audience="wre-local",
+        scopes=["d3:sandbox"],  # authorizes D3 (build_foundup / extract_foundup)
+        allowed_actions=["build_foundup", "extract_foundup"],
+        allowed_paths=["modules/foundups"],
+        # dry_run_only=False so the token validates whether the executor runs
+        # with dry_run True or False; the guard/harness still bounds execution.
+        dry_run_only=False,
+    )
+    # Security gate (also required for D3) - server-authored direct assignment.
     job.policy_flags.security_gate_checked = True
     job.policy_flags.security_gate_passed = True
 

--- a/modules/infrastructure/wre_core/tests/test_hxa16_real_hermes_delegate_adapter_safe_harness.py
+++ b/modules/infrastructure/wre_core/tests/test_hxa16_real_hermes_delegate_adapter_safe_harness.py
@@ -57,6 +57,12 @@ from modules.infrastructure.wre_core.src.hermes_job_executor import (
     is_hermes_delegation_enabled,
 )
 
+# HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (#746): real capability token
+# issuer (server-authored verdict comes from the executor's runtime write-back).
+from modules.infrastructure.wre_core.src.capability_token_validator import (
+    LocalCapabilityTokenIssuer,
+)
+
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -90,17 +96,28 @@ def set_d3_capability_token_gates(job):
 
     HXA28: build_foundup and extract_foundup are now D3 actions that require
     capability tokens. For tests that need to reach SIMULATED status (not
-    BLOCKED_BY_DESTRUCTIVE_ACTION_GUARD), set all four capability token gates
-    AND the security gate.
+    BLOCKED_BY_DESTRUCTIVE_ACTION_GUARD), the job must carry a valid token AND
+    the security gate.
 
-    This simulates a valid capability token being present with security gate passed.
+    HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (#746): capability_token_*
+    flags are SERVER-AUTHORED by the executor's runtime write-back, so we attach
+    a REAL valid D3 token to the job payload (forging the flags no longer works).
+    security_gate_* is set directly (server-authored; no evaluator here).
     """
-    # Capability token gates
-    job.policy_flags.capability_token_checked = True
-    job.policy_flags.capability_token_present = True
-    job.policy_flags.capability_token_validated = True
-    job.policy_flags.capability_token_scope_authorized = True
-    # Security gate (also required for D3)
+    # Attach a REAL valid D3 capability token into the job payload.
+    if not isinstance(job.payload, dict):
+        job.payload = {}
+    job.payload["capability_token"] = LocalCapabilityTokenIssuer().issue_token(
+        subject="agent_hxa16",
+        audience="wre-local",
+        scopes=["d3:sandbox"],  # authorizes D3 (build_foundup / extract_foundup)
+        allowed_actions=["build_foundup", "extract_foundup"],
+        allowed_paths=["modules/foundups"],
+        # dry_run_only=False so the token validates whether the executor runs
+        # with dry_run True or False; the guard/harness still bounds execution.
+        dry_run_only=False,
+    )
+    # Security gate (also required for D3) - server-authored direct assignment.
     job.policy_flags.security_gate_checked = True
     job.policy_flags.security_gate_passed = True
 

--- a/modules/infrastructure/wre_core/tests/test_hxa24_capability_token_policyflags.py
+++ b/modules/infrastructure/wre_core/tests/test_hxa24_capability_token_policyflags.py
@@ -79,6 +79,18 @@ from destructive_action_guard import (
     GuardBlockReasonCode,
 )
 
+# HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (#746):
+# Import the token issuer via the FULL package path so the issued
+# CapabilityToken's class identity matches the executor's internal import
+# (the executor checks isinstance(token, CapabilityToken)).
+from pathlib import Path as _Path
+_PROJECT_ROOT = _Path(__file__).parent.parent.parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+from modules.infrastructure.wre_core.src.capability_token_validator import (
+    LocalCapabilityTokenIssuer,
+)
+
 
 # ===========================================================================
 # SECTION 1: Test Fixtures
@@ -172,8 +184,14 @@ class TestPolicyFlagsSerialization:
         assert d["capability_token_validated"] is False
         assert d["capability_token_scope_authorized"] is False
 
-    def test_from_dict_restores_capability_token_fields(self):
-        """from_dict() should restore all capability token fields."""
+    def test_from_dict_sanitizes_capability_token_fields(self):
+        """from_dict() FORCES all capability token fields False (#746).
+
+        HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1: capability token state is
+        server-authored and untrusted on deserialization. A payload presenting
+        all four flags True is sanitized to all-False; server authority is
+        re-established only by the executor's runtime validator write-back.
+        """
         data = {
             "capability_token_checked": True,
             "capability_token_present": True,
@@ -182,10 +200,10 @@ class TestPolicyFlagsSerialization:
         }
         flags = PolicyFlags.from_dict(data)
 
-        assert flags.capability_token_checked is True
-        assert flags.capability_token_present is True
-        assert flags.capability_token_validated is True
-        assert flags.capability_token_scope_authorized is True
+        assert flags.capability_token_checked is False
+        assert flags.capability_token_present is False
+        assert flags.capability_token_validated is False
+        assert flags.capability_token_scope_authorized is False
 
     def test_from_dict_missing_fields_default_false(self):
         """from_dict() with missing fields should default to False."""
@@ -197,8 +215,13 @@ class TestPolicyFlagsSerialization:
         assert flags.capability_token_validated is False
         assert flags.capability_token_scope_authorized is False
 
-    def test_roundtrip_preserves_all_fields(self):
-        """to_dict/from_dict roundtrip should preserve all fields."""
+    def test_roundtrip_sanitizes_server_authored_preserves_dry_run(self):
+        """Roundtrip sanitizes server-authored flags; dry_run preserved (#746).
+
+        to_dict faithfully serializes server-authored True object state, but
+        from_dict zeroes every gate/token flag on the untrusted path. Only
+        dry_run_mode survives the roundtrip.
+        """
         original = PolicyFlags(
             security_gate_checked=True,
             security_gate_passed=True,
@@ -209,15 +232,21 @@ class TestPolicyFlagsSerialization:
             dry_run_mode=True,
         )
         data = original.to_dict()
+        # to_dict preserves server-authored object state
+        assert data["security_gate_passed"] is True
+        assert data["capability_token_validated"] is True
+
         restored = PolicyFlags.from_dict(data)
 
-        assert restored.security_gate_checked == original.security_gate_checked
-        assert restored.security_gate_passed == original.security_gate_passed
-        assert restored.capability_token_checked == original.capability_token_checked
-        assert restored.capability_token_present == original.capability_token_present
-        assert restored.capability_token_validated == original.capability_token_validated
-        assert restored.capability_token_scope_authorized == original.capability_token_scope_authorized
-        assert restored.dry_run_mode == original.dry_run_mode
+        # Server-authored gate/token flags sanitized to False on deserialization
+        assert restored.security_gate_checked is False
+        assert restored.security_gate_passed is False
+        assert restored.capability_token_checked is False
+        assert restored.capability_token_present is False
+        assert restored.capability_token_validated is False
+        assert restored.capability_token_scope_authorized is False
+        # Operator-authored flag preserved
+        assert restored.dry_run_mode is True
 
 
 # ===========================================================================
@@ -242,9 +271,15 @@ class TestJobSerializationWithCapabilityToken:
         assert policy_data["capability_token_checked"] is True
         assert policy_data["capability_token_present"] is True
 
-    def test_job_from_dict_restores_capability_token_flags(self):
-        """Job from_dict() should restore capability token flags."""
+    def test_job_from_dict_sanitizes_capability_token_flags(self):
+        """Job from_dict() FORCES capability token flags False (#746).
+
+        A serialized job whose payload pre-set the capability token flags True
+        is sanitized on the untrusted FoundUpJob.from_dict path; the bypass is
+        closed. Server authority comes only from executor write-back.
+        """
         job = create_job(tenant_id="t", requested_action="build_foundup")
+        # Server-authored object state (pre-serialization)
         job.policy_flags.capability_token_checked = True
         job.policy_flags.capability_token_present = True
         job.policy_flags.capability_token_validated = True
@@ -253,10 +288,11 @@ class TestJobSerializationWithCapabilityToken:
         data = job.to_dict()
         restored = FoundUpJob.from_dict(data)
 
-        assert restored.policy_flags.capability_token_checked is True
-        assert restored.policy_flags.capability_token_present is True
-        assert restored.policy_flags.capability_token_validated is True
-        assert restored.policy_flags.capability_token_scope_authorized is True
+        # Untrusted deserialization zeroes the capability token flags
+        assert restored.policy_flags.capability_token_checked is False
+        assert restored.policy_flags.capability_token_present is False
+        assert restored.policy_flags.capability_token_validated is False
+        assert restored.policy_flags.capability_token_scope_authorized is False
 
 
 # ===========================================================================
@@ -379,19 +415,30 @@ class TestAllFourTrueAllowsD3SandboxDryRun:
     """Test that all four capability token flags True allows D3 sandbox dry-run."""
 
     def test_all_four_true_with_security_gate_allows_d3(self, temp_workspace):
-        """D3 sandbox allowed when all four token flags True AND security gate passed."""
+        """D3 sandbox allowed with a REAL valid token AND security gate passed.
+
+        HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (#746): capability_token_*
+        flags are now SERVER-AUTHORED by the executor's runtime write-back, so a
+        REAL valid token must be supplied in the payload (forging the flags no
+        longer works). security_gate_* is still set by direct (server-authored)
+        assignment because this executor has no security-gate evaluator.
+        """
+        issuer = LocalCapabilityTokenIssuer()
+        token = issuer.issue_token(
+            subject="agent_hxa24",
+            audience="wre-local",
+            scopes=["d3:sandbox"],  # authorizes D3
+            allowed_actions=["build_foundup"],
+            allowed_paths=["modules/foundups"],
+        )
         executor = HermesJobExecutor(workspace_root=temp_workspace, dry_run=True)
         job = create_job(
             tenant_id="t1",
             requested_action="build_foundup",
             foundup_id="test",
+            payload={"capability_token": token},  # REAL token (server-authored verdict)
         )
-        # Set all capability token flags True
-        job.policy_flags.capability_token_checked = True
-        job.policy_flags.capability_token_present = True
-        job.policy_flags.capability_token_validated = True
-        job.policy_flags.capability_token_scope_authorized = True
-        # Also need security gate for D3
+        # Security gate set by direct assignment (server-authored; no evaluator here)
         job.policy_flags.security_gate_checked = True
         job.policy_flags.security_gate_passed = True
 
@@ -403,6 +450,9 @@ class TestAllFourTrueAllowsD3SandboxDryRun:
             with patch.dict(os.environ, {"HERMES_DELEGATE_ENABLED": "0"}):
                 result = executor.execute(job)
 
+                # Write-back promoted the capability flags from the real verdict
+                assert job.policy_flags.capability_token_validated is True
+                assert job.policy_flags.capability_token_scope_authorized is True
                 # With all gates passing, D3 should be allowed as dry-run
                 # Guard allows, but overall status is SIMULATED (dry_run=True)
                 assert result.guard_result["allowed"] is True
@@ -410,19 +460,29 @@ class TestAllFourTrueAllowsD3SandboxDryRun:
                 assert result.status == HermesExecutionStatus.SIMULATED
 
     def test_all_four_true_but_missing_security_gate_blocks_d3(self, temp_workspace):
-        """D3 blocked when all token flags True BUT security gate not passed."""
+        """D3 blocked with a REAL valid token but security gate not passed.
+
+        HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (#746): the capability token
+        verdict is server-authored from a real token, so the capability flags go
+        True via write-back; but security_gate_passed stays False, so the guard
+        blocks on MISSING_SECURITY_GATE.
+        """
+        issuer = LocalCapabilityTokenIssuer()
+        token = issuer.issue_token(
+            subject="agent_hxa24",
+            audience="wre-local",
+            scopes=["d3:sandbox"],
+            allowed_actions=["build_foundup"],
+            allowed_paths=["modules/foundups"],
+        )
         executor = HermesJobExecutor(workspace_root=temp_workspace, dry_run=True)
         job = create_job(
             tenant_id="t1",
             requested_action="build_foundup",
             foundup_id="test",
+            payload={"capability_token": token},  # REAL valid token
         )
-        # Set all capability token flags True
-        job.policy_flags.capability_token_checked = True
-        job.policy_flags.capability_token_present = True
-        job.policy_flags.capability_token_validated = True
-        job.policy_flags.capability_token_scope_authorized = True
-        # But security gate NOT passed
+        # Security gate NOT passed (server-authored)
         job.policy_flags.security_gate_checked = True
         job.policy_flags.security_gate_passed = False  # Not passed
 
@@ -434,7 +494,9 @@ class TestAllFourTrueAllowsD3SandboxDryRun:
             with patch.dict(os.environ, {"HERMES_DELEGATE_ENABLED": "0"}):
                 result = executor.execute(job)
 
-                # Security gate failed
+                # Capability token verdict promoted by write-back...
+                assert job.policy_flags.capability_token_validated is True
+                # ...but security gate failed -> blocked
                 assert result.status == HermesExecutionStatus.BLOCKED_BY_DESTRUCTIVE_ACTION_GUARD
                 assert result.guard_result["reason_code"] == "MISSING_SECURITY_GATE"
 

--- a/modules/infrastructure/wre_core/tests/test_hxa25_d3_sandbox_execution.py
+++ b/modules/infrastructure/wre_core/tests/test_hxa25_d3_sandbox_execution.py
@@ -79,6 +79,17 @@ from destructive_action_guard import (
     GuardBlockReasonCode,
 )
 
+# HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (#746):
+# Import the token issuer via the FULL package path so the issued
+# CapabilityToken's class identity matches the executor's internal import.
+from pathlib import Path as _Path
+_PROJECT_ROOT = _Path(__file__).parent.parent.parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+from modules.infrastructure.wre_core.src.capability_token_validator import (
+    LocalCapabilityTokenIssuer,
+)
+
 
 # ===========================================================================
 # SECTION 1: Test Fixtures
@@ -106,21 +117,50 @@ def _create_d3_job_with_all_gates(
     foundup_id: str = "test_foundup",
     requested_action: str = "build_foundup",
 ) -> FoundUpJob:
-    """Create a job with all gates True for D3 sandbox execution."""
+    """Create a job with all gates True for D3 sandbox execution.
+
+    HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (#746): capability_token_*
+    flags are now server-authored by the executor's runtime write-back. So we
+    supply a REAL valid token in the payload (broad scopes/actions so it
+    validates against whatever action class the test patches in) instead of
+    forging the capability flags. security_gate_* is still set directly
+    (server-authored; this executor has no security-gate evaluator). For
+    D4/D5/D6 tests the token validates but the GUARD blocks by class.
+    """
     job = create_job(
         tenant_id="tenant_test",
         requested_action=requested_action,
         foundup_id=foundup_id,
+        payload={
+            "capability_token": LocalCapabilityTokenIssuer().issue_token(
+                subject="agent_hxa25",
+                audience="wre-local",
+                # Broad scopes so the token authorizes whichever class the test
+                # patches (D3 passes guard; D4/D5/D6 are blocked by the guard).
+                scopes=[
+                    "d3:sandbox",
+                    "d4:repo",
+                    "d5:external",
+                    "d6:delete",
+                ],
+                allowed_actions=[
+                    "build_foundup",
+                    "extract_foundup",
+                    "create_repo",
+                    "send_email",
+                    "delete_permanently",
+                ],
+                allowed_paths=["modules/foundups"],
+                # Validates whether executor runs dry_run True or False; the
+                # guard still bounds execution (D3 dry-run only; D4/D5/D6 blocked).
+                dry_run_only=False,
+            ),
+        },
     )
-    # Set all capability token flags True
-    job.policy_flags.capability_token_checked = True
-    job.policy_flags.capability_token_present = True
-    job.policy_flags.capability_token_validated = True
-    job.policy_flags.capability_token_scope_authorized = True
-    # Set security gate True
+    # Security gate set by direct (server-authored) assignment.
     job.policy_flags.security_gate_checked = True
     job.policy_flags.security_gate_passed = True
-    # Set dry run mode True
+    # Operator-authored dry run mode.
     job.policy_flags.dry_run_mode = True
     return job
 

--- a/modules/infrastructure/wre_core/tests/test_hxa28_d3_native_classification.py
+++ b/modules/infrastructure/wre_core/tests/test_hxa28_d3_native_classification.py
@@ -75,6 +75,17 @@ from destructive_action_guard import (
     GuardBlockReasonCode,
 )
 
+# HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (#746):
+# Import the token issuer via the FULL package path so the issued
+# CapabilityToken's class identity matches the executor's internal import.
+from pathlib import Path as _Path
+_PROJECT_ROOT = _Path(__file__).parent.parent.parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+from modules.infrastructure.wre_core.src.capability_token_validator import (
+    LocalCapabilityTokenIssuer,
+)
+
 
 # ===========================================================================
 # SECTION 1: Test Fixtures
@@ -111,16 +122,45 @@ def _create_job_with_all_gates(
     action: str,
     foundup_id: str = "test_foundup",
 ) -> FoundUpJob:
-    """Create a job with all capability token gates True."""
+    """Create a job with all gates True for D3 sandbox execution.
+
+    HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (#746): capability_token_*
+    flags are server-authored by the executor's runtime write-back, so a REAL
+    valid token (broad scopes/actions covering every class these tests
+    exercise) is supplied in the payload. D3 passes the guard; D4/D5/D6
+    validate the token but are blocked by the GUARD (by class). security_gate_*
+    is set directly (server-authored; no evaluator in this executor).
+    """
     job = create_job(
         tenant_id="tenant_hxa28",
         requested_action=action,
         foundup_id=foundup_id,
+        payload={
+            "capability_token": LocalCapabilityTokenIssuer().issue_token(
+                subject="agent_hxa28",
+                audience="wre-local",
+                scopes=[
+                    "d3:sandbox",
+                    "d4:repo",
+                    "d5:external",
+                    "d6:delete",
+                ],
+                allowed_actions=[
+                    "build_foundup",
+                    "git_push",
+                    "publish_event",
+                    "payout_trigger",
+                    "create_repo",
+                    "deploy_service",
+                    "delete_foundup",
+                ],
+                allowed_paths=["modules/foundups"],
+                # Validates whether executor runs dry_run True or False; the
+                # guard still bounds execution (D3 dry-run only; D4/D5/D6 blocked).
+                dry_run_only=False,
+            ),
+        },
     )
-    job.policy_flags.capability_token_checked = True
-    job.policy_flags.capability_token_present = True
-    job.policy_flags.capability_token_validated = True
-    job.policy_flags.capability_token_scope_authorized = True
     job.policy_flags.security_gate_checked = True
     job.policy_flags.security_gate_passed = True
     job.policy_flags.dry_run_mode = True

--- a/modules/infrastructure/wre_core/tests/test_hxa4_real_hermes_object_dryrun.py
+++ b/modules/infrastructure/wre_core/tests/test_hxa4_real_hermes_object_dryrun.py
@@ -57,6 +57,12 @@ from modules.infrastructure.wre_core.src.hermes_job_executor import (
     _HERMES_DELEGATE_ENABLED_KEY,
 )
 
+# HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (#746): real capability token
+# issuer (server-authored verdict comes from the executor's runtime write-back).
+from modules.infrastructure.wre_core.src.capability_token_validator import (
+    LocalCapabilityTokenIssuer,
+)
+
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -86,17 +92,30 @@ def set_d3_capability_token_gates(job):
 
     HXA28: build_foundup and extract_foundup are now D3 actions that require
     capability tokens. For tests that need to reach SIMULATED status (not
-    BLOCKED_BY_DESTRUCTIVE_ACTION_GUARD), set all four capability token gates
-    AND the security gate.
+    BLOCKED_BY_DESTRUCTIVE_ACTION_GUARD), the job must carry a valid token AND
+    the security gate.
 
-    This simulates a valid capability token being present with security gate passed.
+    HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (#746): capability_token_*
+    flags are SERVER-AUTHORED by the executor's runtime write-back, so we attach
+    a REAL valid D3 token to the job payload (forging the flags no longer works).
+    The executor's write-back promotes the capability flags from the verdict
+    before the guard reads them. security_gate_* is set directly (server-authored;
+    no security-gate evaluator in this executor).
     """
-    # Capability token gates
-    job.policy_flags.capability_token_checked = True
-    job.policy_flags.capability_token_present = True
-    job.policy_flags.capability_token_validated = True
-    job.policy_flags.capability_token_scope_authorized = True
-    # Security gate (also required for D3)
+    # Attach a REAL valid D3 capability token into the job payload.
+    if not isinstance(job.payload, dict):
+        job.payload = {}
+    job.payload["capability_token"] = LocalCapabilityTokenIssuer().issue_token(
+        subject="agent_hxa4",
+        audience="wre-local",
+        scopes=["d3:sandbox"],  # authorizes D3 (build_foundup / extract_foundup)
+        allowed_actions=["build_foundup", "extract_foundup"],
+        allowed_paths=["modules/foundups"],
+        # dry_run_only=False so the token validates whether the executor runs
+        # with dry_run True or False; the guard/harness still bounds execution.
+        dry_run_only=False,
+    )
+    # Security gate (also required for D3) - server-authored direct assignment.
     job.policy_flags.security_gate_checked = True
     job.policy_flags.security_gate_passed = True
 

--- a/modules/infrastructure/wre_core/tests/test_hxa_policyflags_writeback_remediation.py
+++ b/modules/infrastructure/wre_core/tests/test_hxa_policyflags_writeback_remediation.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (#746) Proof Tests.
+
+Positive control for the bounded PolicyFlags write-back defect:
+security/token gate flags must be SERVER-AUTHORED ONLY, never trusted from
+deserialized job data. The validator verdict is written into job.policy_flags
+BEFORE the destructive-action guard reads it.
+
+Predecessors: #744 (PolicyFlags write-back defect), HXA24 (capability token
+policy flags), HXA27 (Hermes token validation integration), HXA30
+(scope-to-action-class integration).
+
+This slice proves:
+  1. HermesJobExecutor writes the validator verdict back into job.policy_flags
+     for valid-token, no-token, and invalid-token paths.
+  2. The write-back precedes guard evaluation (server-authored truth seen).
+  3. A job whose deserialized payload pre-set capability_token_*=True but
+     carries NO real token is still BLOCKED at D3 (bypass closed).
+  4. D4/D5/D6 remain BLOCKED regardless of flags.
+  5. D3 remains bounded/dry-run only (live_execution_allowed=False).
+
+This slice does NOT:
+  - Enable live delegation, create repos, modify production source.
+  - Issue or validate real (production) tokens.
+  - Add any production caller of FoundUpJob.from_dict.
+
+Run with:
+    python -m pytest \
+      modules/infrastructure/wre_core/tests/test_hxa_policyflags_writeback_remediation.py -q
+
+Slice: HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1
+Worker-Lane: W6
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+from unittest.mock import patch
+
+# Import via the FULL package path so CapabilityToken class identity matches the
+# executor's import (a sys.path shortcut would create a distinct module object
+# and break the executor's isinstance(token, CapabilityToken) check).
+PROJECT_ROOT = Path(__file__).parent.parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from modules.infrastructure.wre_core.src.hermes_job_executor import (  # noqa: E402
+    HermesExecutionStatus,
+    HermesJobExecutor,
+)
+from modules.communication.moltbot_bridge.src.foundup_job_contract import (  # noqa: E402
+    FoundUpJob,
+    PolicyFlags,
+    create_job,
+)
+from modules.infrastructure.wre_core.src.capability_token_validator import (  # noqa: E402
+    LocalCapabilityTokenIssuer,
+    LocalCapabilityTokenValidator,
+    TokenValidationResult,
+)
+from modules.infrastructure.wre_core.src.destructive_action_guard import (  # noqa: E402
+    DestructiveActionClass,
+)
+
+
+# ===========================================================================
+# Fixtures
+# ===========================================================================
+
+
+@pytest.fixture
+def temp_workspace():
+    """Create temporary workspace directory for tests."""
+    temp_dir = tempfile.mkdtemp()
+    yield temp_dir
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def token_issuer() -> LocalCapabilityTokenIssuer:
+    return LocalCapabilityTokenIssuer()
+
+
+@pytest.fixture
+def executor(temp_workspace) -> HermesJobExecutor:
+    """Executor with a fresh, isolated validator (no shared nonce state)."""
+    return HermesJobExecutor(
+        dry_run=True,
+        workspace_root=temp_workspace,
+        token_validator=LocalCapabilityTokenValidator(),
+    )
+
+
+def _disabled_env():
+    """HERMES_DELEGATE_ENABLED=0 so no live delegate path is taken."""
+    return patch.dict(os.environ, {"HERMES_DELEGATE_ENABLED": "0"})
+
+
+# ===========================================================================
+# SECTION 1: Write-back reflects the validator verdict
+# ===========================================================================
+
+
+class TestWriteBackReflectsVerdict:
+    """The 4 capability_token_* flags on job.policy_flags reflect the verdict."""
+
+    def test_valid_token_writeback_all_capability_flags_true(
+        self, executor, token_issuer
+    ):
+        """Valid D3 token -> capability_token_* all True after execute()."""
+        token = token_issuer.issue_token(
+            subject="agent_w6",
+            audience="wre-local",
+            scopes=["d3:sandbox"],
+            allowed_actions=["build_foundup"],
+            allowed_paths=["modules/foundups"],
+        )
+        job = create_job(
+            tenant_id="t1",
+            requested_action="build_foundup",  # D3
+            foundup_id="test",
+            payload={"capability_token": token},
+        )
+        # Birth state: all capability flags False
+        assert job.policy_flags.capability_token_validated is False
+
+        with _disabled_env():
+            executor.execute(job)
+
+        # Server-authored verdict written back into the job
+        assert job.policy_flags.capability_token_checked is True
+        assert job.policy_flags.capability_token_present is True
+        assert job.policy_flags.capability_token_validated is True
+        assert job.policy_flags.capability_token_scope_authorized is True
+
+    def test_no_token_writeback_present_false_validated_false(self, executor):
+        """No token in payload -> checked True, present/validated/scope False."""
+        job = create_job(
+            tenant_id="t1",
+            requested_action="build_foundup",  # D3
+            foundup_id="test",
+        )
+        with _disabled_env():
+            executor.execute(job)
+
+        # A check is always performed
+        assert job.policy_flags.capability_token_checked is True
+        # But no token was present
+        assert job.policy_flags.capability_token_present is False
+        assert job.policy_flags.capability_token_validated is False
+        assert job.policy_flags.capability_token_scope_authorized is False
+
+    def test_invalid_token_writeback_present_true_validated_false(
+        self, executor, token_issuer
+    ):
+        """Invalid token (D3 scope, D4 action) -> present True, validated False.
+
+        The invalid-token path early-returns BEFORE guard, but the write-back
+        runs first via _validate_token_if_present semantics. We assert the
+        verdict reflects the token presence and invalidity.
+        """
+        # D3-scoped token attempting a D4 action -> token_valid False
+        token = token_issuer.issue_token(
+            subject="agent_w6",
+            audience="wre-local",
+            scopes=["d3:sandbox"],  # does NOT authorize D4
+            allowed_actions=["create_repo"],
+            allowed_paths=["modules/foundups"],
+        )
+        job = create_job(
+            tenant_id="t1",
+            requested_action="create_repo",  # D4 action
+            foundup_id="test",
+            payload={"capability_token": token},
+        )
+        with _disabled_env():
+            result = executor.execute(job)
+
+        # Invalid token blocks before guard
+        assert result.status == HermesExecutionStatus.BLOCKED_BY_TOKEN_VALIDATION
+        # The job is blocked; capability flags were NOT promoted to all-True
+        # (the early-return path never grants a valid verdict).
+        assert job.policy_flags.capability_token_validated is False
+        assert job.policy_flags.capability_token_scope_authorized is False
+
+
+# ===========================================================================
+# SECTION 2: Guard sees server-authored fields (bypass closed)
+# ===========================================================================
+
+
+class TestBypassClosed:
+    """Pre-set capability flags from payload cannot bypass the D3 guard."""
+
+    def test_payload_preset_capability_flags_but_no_token_blocked_at_d3(
+        self, executor
+    ):
+        """A job carrying capability_token_*=True in payload but NO token is
+        STILL blocked at D3 (the deserialization sanitization + server write-back
+        close the bypass).
+        """
+        # Simulate an attacker-supplied serialized job: capability flags True
+        # but no real capability_token in payload.
+        malicious_data = {
+            "job_id": "j_attack_d3",
+            "tenant_id": "attacker",
+            "requested_action": "build_foundup",  # D3
+            "foundup_id": "test",
+            "policy_flags": {
+                "capability_token_checked": True,
+                "capability_token_present": True,
+                "capability_token_validated": True,
+                "capability_token_scope_authorized": True,
+                "security_gate_passed": True,
+                "dry_run_mode": True,
+            },
+            "payload": {},  # NO capability_token
+        }
+        job = FoundUpJob.from_dict(malicious_data)
+
+        # Sanitization already zeroed the flags at deserialization
+        assert job.policy_flags.capability_token_validated is False
+        assert job.policy_flags.security_gate_passed is False
+
+        with _disabled_env():
+            result = executor.execute(job)
+
+        # D3 requires a real validated token -> blocked
+        assert (
+            result.status
+            == HermesExecutionStatus.BLOCKED_BY_DESTRUCTIVE_ACTION_GUARD
+        )
+        # After execute, write-back reflects the TRUE state: no token present
+        assert job.policy_flags.capability_token_present is False
+        assert job.policy_flags.capability_token_validated is False
+
+    def test_writeback_overrides_stale_object_flags_before_guard(
+        self, executor
+    ):
+        """Even if object flags were manually set True but no token exists,
+        the server write-back demotes them to the real verdict before guard.
+        """
+        job = create_job(
+            tenant_id="t1",
+            requested_action="build_foundup",  # D3
+            foundup_id="test",
+        )
+        # Stale/forged object state (e.g. set by buggy upstream code)
+        job.policy_flags.capability_token_checked = True
+        job.policy_flags.capability_token_present = True
+        job.policy_flags.capability_token_validated = True
+        job.policy_flags.capability_token_scope_authorized = True
+        # No token in payload, so the write-back must demote present/validated.
+
+        with _disabled_env():
+            result = executor.execute(job)
+
+        # Write-back corrected the forged flags to the real (no-token) verdict
+        assert job.policy_flags.capability_token_present is False
+        assert job.policy_flags.capability_token_validated is False
+        assert job.policy_flags.capability_token_scope_authorized is False
+        # Guard blocks D3 accordingly
+        assert (
+            result.status
+            == HermesExecutionStatus.BLOCKED_BY_DESTRUCTIVE_ACTION_GUARD
+        )
+
+
+# ===========================================================================
+# SECTION 3: D4/D5/D6 remain blocked; D3 bounded dry-run only
+# ===========================================================================
+
+
+class TestBoundaryUnchanged:
+    """D4/D5/D6 blocked regardless of flags; D3 stays dry-run only."""
+
+    @pytest.mark.parametrize(
+        "action_class",
+        [
+            DestructiveActionClass.D4_WRITE_REPO,
+            DestructiveActionClass.D5_EXTERNAL_SIDE_EFFECT,
+            DestructiveActionClass.D6_IRREVERSIBLE,
+        ],
+    )
+    def test_d4_d5_d6_blocked_even_with_valid_token(
+        self, executor, token_issuer, action_class
+    ):
+        """D4/D5/D6 blocked even with a valid token + write-back."""
+        token = token_issuer.issue_token(
+            subject="agent_w6",
+            audience="wre-local",
+            # Scope that authorizes the class (so token itself validates) - the
+            # guard, not the token, must be what blocks.
+            scopes=["d4:repo", "d5:external", "d6:delete"],
+            allowed_actions=[
+                "create_repo",
+                "send_email",
+                "delete_permanently",
+            ],
+            allowed_paths=["modules/foundups"],
+        )
+        action_map = {
+            DestructiveActionClass.D4_WRITE_REPO: "create_repo",
+            DestructiveActionClass.D5_EXTERNAL_SIDE_EFFECT: "send_email",
+            DestructiveActionClass.D6_IRREVERSIBLE: "delete_permanently",
+        }
+        job = create_job(
+            tenant_id="t1",
+            requested_action=action_map[action_class],
+            foundup_id="test",
+            payload={"capability_token": token},
+        )
+        with patch.object(
+            executor,
+            "_classify_destructive_action",
+            return_value=action_class,
+        ):
+            with _disabled_env():
+                result = executor.execute(job)
+
+        assert (
+            result.status
+            == HermesExecutionStatus.BLOCKED_BY_DESTRUCTIVE_ACTION_GUARD
+        )
+
+    def test_d3_valid_token_remains_dry_run_only(self, executor, token_issuer):
+        """Valid D3 token: guard may allow but live_execution_allowed=False.
+
+        Note: with security_gate_passed left at server-default False, D3 is
+        still blocked. This asserts the D3 boundary stays dry-run only and live
+        execution is never enabled by the write-back.
+        """
+        token = token_issuer.issue_token(
+            subject="agent_w6",
+            audience="wre-local",
+            scopes=["d3:sandbox"],
+            allowed_actions=["build_foundup"],
+            allowed_paths=["modules/foundups"],
+        )
+        job = create_job(
+            tenant_id="t1",
+            requested_action="build_foundup",  # D3
+            foundup_id="test",
+            payload={"capability_token": token},
+        )
+        with _disabled_env():
+            result = executor.execute(job)
+
+        # Capability verdict written True, but security_gate_passed stays False
+        assert job.policy_flags.capability_token_validated is True
+        assert job.policy_flags.security_gate_passed is False
+        # No live execution enabled anywhere
+        assert result.real_execution_performed is False
+        if result.guard_result is not None:
+            assert result.guard_result.get("live_execution_allowed") is False
+
+    def test_security_gate_not_fabricated_by_writeback(
+        self, executor, token_issuer
+    ):
+        """Write-back never sets security_gate_passed True (out of scope)."""
+        token = token_issuer.issue_token(
+            subject="agent_w6",
+            audience="wre-local",
+            scopes=["d3:sandbox"],
+            allowed_actions=["build_foundup"],
+            allowed_paths=["modules/foundups"],
+        )
+        job = create_job(
+            tenant_id="t1",
+            requested_action="build_foundup",
+            foundup_id="test",
+            payload={"capability_token": token},
+        )
+        with _disabled_env():
+            executor.execute(job)
+
+        # security_gate_* untouched by token write-back
+        assert job.policy_flags.security_gate_checked is False
+        assert job.policy_flags.security_gate_passed is False
+
+
+# ===========================================================================
+# SECTION 4: Helper unit semantics
+# ===========================================================================
+
+
+class TestWriteBackHelperSemantics:
+    """Direct unit coverage of _writeback_token_verdict mapping."""
+
+    def test_none_result_checked_true_rest_false(self, executor):
+        job = create_job(tenant_id="t", requested_action="build_foundup")
+        executor._writeback_token_verdict(job, None)
+        assert job.policy_flags.capability_token_checked is True
+        assert job.policy_flags.capability_token_present is False
+        assert job.policy_flags.capability_token_validated is False
+        assert job.policy_flags.capability_token_scope_authorized is False
+
+    def test_valid_result_all_true(self, executor):
+        job = create_job(tenant_id="t", requested_action="build_foundup")
+        result = TokenValidationResult(
+            token_valid=True,
+            scope_action_class_mismatch=False,
+        )
+        executor._writeback_token_verdict(job, result)
+        assert job.policy_flags.capability_token_checked is True
+        assert job.policy_flags.capability_token_present is True
+        assert job.policy_flags.capability_token_validated is True
+        assert job.policy_flags.capability_token_scope_authorized is True
+
+    def test_invalid_result_present_true_validated_false(self, executor):
+        job = create_job(tenant_id="t", requested_action="build_foundup")
+        result = TokenValidationResult(
+            token_valid=False,
+            scope_action_class_mismatch=True,
+        )
+        executor._writeback_token_verdict(job, result)
+        assert job.policy_flags.capability_token_checked is True
+        assert job.policy_flags.capability_token_present is True
+        assert job.policy_flags.capability_token_validated is False
+        assert job.policy_flags.capability_token_scope_authorized is False
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Mission

Close the #746 bounded PolicyFlags write-back defect with **positive control**: security/token gate flags are now **server-authored only**, never trusted from deserialized job data. The runtime validator verdict is written into `job.policy_flags` **before** the destructive-action guard reads it.

Implements #746 §9 steps 1-3 (the recommended remediation shape from the `GAP_CONFIRMED_BOUNDED` enforcement audit).

## Changes

**CHANGE 1 — Deserialization sanitization** (`modules/communication/moltbot_bridge/src/foundup_job_contract.py`)
- Added module-level `_SERVER_AUTHORED_FLAGS` frozenset (12 gate/token fields).
- `PolicyFlags.from_dict` now **forces every server-authored flag to `False`** regardless of inbound data; only `dry_run_mode` is preserved (operator-authored; `True` = safe/sandbox direction).
- Single chokepoint: `FoundUpJob.from_dict` (`:613`) and `__post_init__` (`:411-412`) both route through it.
- Direct `PolicyFlags(...)` constructor + `default_factory=PolicyFlags` **unchanged** — server code can still author True flags by direct assignment.

**CHANGE 2 — Validator verdict write-back** (`modules/infrastructure/wre_core/src/hermes_job_executor.py`)
- New `_writeback_token_verdict(job, token_validation_result)` (`:1158`), called in `execute()` (`:1521`) **immediately before** `_evaluate_destructive_action_guard` (`:1524`).
- Writes server-authored `capability_token_*` from the real `TokenValidationResult`.
- `security_gate_*` left at server-default `False` (no security-gate evaluator in this executor; the sole writer is the separate `hermes_foundup_job_executor.py:362`). Real security-gate write-back deferred (future).

## Boundary proof (behavior unchanged; bypass closed)

- No-token / invalid-token D3 → **BLOCKED**.
- Valid-token D3 → capability flags True but `security_gate_passed` still False → **BLOCKED**.
- D4 / D5 / D6 → **unconditionally BLOCKED** (class-based), regardless of flags/token.
- **Bypass closed**: a payload pre-setting `capability_token_*=True` with no real token is still BLOCKED at D3 (sanitization + write-back).
- `live_execution_allowed=False` always; D3 ALLOW is dry-run only.

## Tests

| Suite | Result |
|-------|--------|
| `test_foundup_job_contract.py` | 78 passed |
| `test_hermes_job_executor.py` | 94 passed |
| `test_hxa_policyflags_writeback_remediation.py` (new) | 13 passed |
| full `wre_core/tests/` | **1383 passed**, 3 skipped, 2 xfailed |

Existing round-trip tests updated to the NEW correct sanitization semantics (each justified in the audit Test Scenario Matrix). HXA4/12/14/16/24/25/28 helpers updated to supply **REAL tokens** (forging flags no longer works).

**5 deselected** are PRE-EXISTING worktree-environmental failures (skills-discovery repo-name; vendored `delegate_tool.py` absent), verified unrelated on the clean tree.

**Regression confirm**: `git grep FoundUpJob.from_dict` non-test caller count = **0** (no production wiring added).

## Audit

`docs/audits/security/HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1.md` — sanitization + write-back field matrices, guard-sequencing proof, D3/D4/D5/D6 boundary proof, Test Scenario Matrix, residual risks, WSP 97 Truth Boundary Checklist **24/24 YES**.

**Predecessors**: #746 (enforcement audit), #744, HXA24/27/30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
