### PR TITLE
docs(continuity): model-store E: drive migration RedDog capture (Phase 1)

### DIFF
--- a/WSP_knowledge/red_dog_external_state/CURRENT_CONTEXT.md
+++ b/WSP_knowledge/red_dog_external_state/CURRENT_CONTEXT.md
@@ -22,6 +22,14 @@
 - **NOT enabled**: OpenClaw import (preview cancelled), Nous Portal login (cancelled), messaging/gateway (unconfigured). FoundUps repo source unchanged.
 - **WRE binding**: `HermesJobExecutor` → vendored `delegate_task` is RUNTIME_DEPENDENCY_MISSING with IMPORT_PATH_DRIFT; real delegation stays `BLOCKED_REAL_DELEGATION_NOT_IMPLEMENTED` (see PR #745, session `2026-06-02T12-00-00Z__hermes-wsl-docker-bootstrap.json`).
 
+## Model Runtime / SSD State (2026-06-02)
+
+- **Active model SSD**: `E:` (label 'Agents'). F:->E: migration copied 6 model/payload folders (~82 GB / 280k files, 0 failed).
+- **Ollama**: serves from `E:\0102_Digital_Twin\models` (persistent `OLLAMA_MODELS` at User scope; Machine unset). Store hydrated from the default C: store (26 blobs / 11.11 GB), restarted clean, validated (`ollama list` 4 models; HTTP generate `done=True`, ~88.5s first-load; model resident 100% GPU).
+- **C: default store**: RETAINED (non-destructive copy), NOT deleted, pending `OLLAMA_C_STORE_CLEANUP_AUDIT_PHASE1`.
+- **Repo config**: unchanged - path-reference scan found no stale `F:` refs and no `OLLAMA_HOME`/`O:` paths; hardcoded LM Studio/HoloIndex paths already pointed at `E:`. Follow-up: `MODEL_RUNTIME_PATH_REFERENCE_AUDIT_PHASE1`.
+- Detail: session `2026-06-02T16-10-00Z__model-store-e-drive-migration.json`.
+
 ## Worker Coordination
 
 - **Architect window**: Not active this session

--- a/WSP_knowledge/red_dog_external_state/sessions/2026-06-02T16-10-00Z__model-store-e-drive-migration.json
+++ b/WSP_knowledge/red_dog_external_state/sessions/2026-06-02T16-10-00Z__model-store-e-drive-migration.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "1.0.0",
+  "record_type": "reddog_session_closeout",
+  "session_id": "2026-06-02__model-store-e-drive-migration",
+  "source": "reddog_session",
+  "captured_at": "2026-06-02T16:10:00Z",
+  "lane": "architect",
+  "work_summary": "Model-runtime SSD migration executed and validated. New high-speed SSD mounted as E: (label 'Agents'). F:->E: payload migration copied 6 folders (0102_Digital_Twin, LM_studio, HuggingFace, .pnpm-store, pywinassistant, HoloIndex merge-only), ~82 GB / 280k files via robocopy with 0 failed files. Ollama store hydrated: the real default Windows Ollama store (C:/Users/<user>/.ollama/models, 26 blobs / 11.11 GB) was copied NON-DESTRUCTIVELY into the configured fast-SSD target E:/0102_Digital_Twin/models. The prior premise (models on F:) was corrected - F:/0102_Digital_Twin/models was empty; the real blobs were on C:. Persistent OLLAMA_MODELS=E:/0102_Digital_Twin/models confirmed at User scope (Machine unset). Ollama restarted cleanly (server+app stopped, none remained, relaunched). Validation: ollama list shows 4 models; HTTP generate on qwen-overseer:latest returned done=True (411 tokens, ~88.5s first-load); ollama ps shows the model resident at 100% GPU - inference served from E:. C: store left INTACT pending a cleanup audit. Repo runtime config unchanged - a path-reference scan found no stale F: refs in code/config and no OLLAMA_HOME/O: ollama_models anywhere; hardcoded LM Studio/HoloIndex paths already pointed at E:, so the migration aligned the filesystem to pre-existing references. Pairs with the Hermes/Docker bootstrap (session 2026-06-02T12-00-00Z): Hermes in WSL, Docker containment working, OpenClaw import/gateway still blocked pending audit. No secrets, keys, or .env values stored.",
+  "pr_refs": [748, 749],
+  "slice_refs": [
+    "MODEL_STORE_E_DRIVE_MIGRATION_PHASE1",
+    "OLLAMA_STORE_E_DRIVE_HYDRATION_PHASE1"
+  ],
+  "decisions": [
+    "E: is the active model SSD; Ollama serves from E:/0102_Digital_Twin/models",
+    "C: default Ollama store retained via non-destructive copy, NOT deleted, pending cleanup audit",
+    "Repo runtime config left unchanged - migration aligned filesystem to pre-existing E: path references",
+    "Validation done via HTTP generate after the backgrounded ollama run stalled on ~88.5s first-load"
+  ],
+  "carry_forward": [
+    "MODEL_RUNTIME_PATH_REFERENCE_AUDIT_PHASE1",
+    "OLLAMA_C_STORE_CLEANUP_AUDIT_PHASE1"
+  ],
+  "redaction_notes": "Operational machine-state only. Absolute model-store paths recorded for recovery; the C: home username segment is anonymized as <user>. No API key values, OAuth/login codes, .env contents, or raw terminal transcript stored.",
+  "main_head_sha": "87edcd779",
+  "gaps": [
+    "C: default Ollama store not yet removed (retained pending OLLAMA_C_STORE_CLEANUP_AUDIT_PHASE1)",
+    "Server-process OLLAMA_MODELS env not directly inspected; inferred from User-scope env + fresh relaunch + successful E: serve",
+    "MODEL_RUNTIME_PATH_REFERENCE_AUDIT_PHASE1 scan completed but not yet formalized into a doc/PR"
+  ]
+}


### PR DESCRIPTION
## RedDog continuity capture — model-runtime SSD migration

Records the machine-state truth for future 0102 after the F:→E: model SSD migration + Ollama hydration (validated this session). Pairs with the Hermes/Docker bootstrap capture (#748).

### Machine state recorded
- **E: is the active model SSD** (label `Agents`). F:→E: migration: 6 folders, ~82 GB / 280k files, **0 failed**.
- **Ollama serves from `E:\0102_Digital_Twin\models`** — `OLLAMA_MODELS` persistent at **User** scope (Machine unset). Store hydrated from the default C: store (26 blobs / 11.11 GB), restarted clean.
- **Validated**: `ollama list` → 4 models; HTTP `generate` on `qwen-overseer:latest` → `done=True` (411 tok, ~88.5s first-load); `ollama ps` → resident **100% GPU**. Inference confirmed served from E:.
- **C: default store retained** (non-destructive copy), **NOT deleted**, pending `OLLAMA_C_STORE_CLEANUP_AUDIT_PHASE1`.
- **Repo config unchanged** — path-reference scan found no stale `F:` refs, no `OLLAMA_HOME`/`O:` paths; hardcoded LM Studio/HoloIndex paths already pointed at `E:`.

### Files (2, additive)
- `sessions/2026-06-02T16-10-00Z__model-store-e-drive-migration.json` — session closeout, **validator PASS** (`validate_session_closeout.py` exit 0).
- `CURRENT_CONTEXT.md` — adds a compact Model Runtime / SSD State section.

### Carry-forward
- `MODEL_RUNTIME_PATH_REFERENCE_AUDIT_PHASE1` (scan done, not yet formalized)
- `OLLAMA_C_STORE_CLEANUP_AUDIT_PHASE1`

Redaction: machine-state only; C: home username anonymized; no keys/OAuth/.env/transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)