### PR TITLE
fix(security): sanitize router envelope policy_flags + fail-close Gate 2 (Phase 1)

### DIFF
--- a/docs/audits/security/FOUNDUP_JOB_ROUTER_POLICYFLAGS_BOUNDARY_SANITIZATION_AND_GATE2_FAILCLOSED_PHASE1.md
+++ b/docs/audits/security/FOUNDUP_JOB_ROUTER_POLICYFLAGS_BOUNDARY_SANITIZATION_AND_GATE2_FAILCLOSED_PHASE1.md
@@ -1,0 +1,312 @@
+# FOUNDUP_JOB_ROUTER_POLICYFLAGS_BOUNDARY_SANITIZATION_AND_GATE2_FAILCLOSED_PHASE1
+
+**Worker-Lane**: W6
+**Slice**: FOUNDUP_JOB_ROUTER_POLICYFLAGS_BOUNDARY_SANITIZATION_AND_GATE2_FAILCLOSED_PHASE1
+**WSP**: WSP 97 (Truth Boundary), WSP 50 (Pre-Action), WSP 22 (ModLog), WSP 5 (Test Coverage)
+**Base**: `origin/main` @ `f3b0293e5`
+**Scope**: ROUTER BOUNDARY ONLY — `modules/infrastructure/wre_core/src/foundup_job_router.py` (+ its test/ModLog/audit).
+
+---
+
+## 1. Mission
+
+Close the #752 bounded trust-boundary defect at the ROUTER boundary only:
+
+1. Sanitize raw-dict envelope `policy_flags` so a caller cannot self-assert server-authored
+   gate/token flags (e.g. `security_gate_passed=True`).
+2. Preserve the safe dry-run default (an absent `dry_run_mode` must NOT be treated as live).
+3. Make live-mode Gate 2 (security) FAIL-CLOSED: in live mode, security MUST have passed.
+
+Edit ONLY the router file and its tests/ModLog/audit. Do NOT touch `dae_gateway.py`,
+`foundup_job_contract.py`, `hermes_job_executor.py`, or `destructive_action_guard.py`.
+
+---
+
+## 2. Predecessors / Context
+
+- **#752** (`docs/audits/security/DAE_GATEWAY_ENVELOPE_GATEFLAGS_TRUST_BOUNDARY_AUDIT_PHASE1.md`):
+  decision-only audit of the gate-flags trust boundary at the DAE gateway envelope surface;
+  identified the bounded router-side defect remediated here.
+- **#744 → #746 → #747 → #751**: the PolicyFlags write-back / deserialization-chokepoint line of
+  work. #747 established `PolicyFlags.from_dict` as the single deserialization chokepoint that
+  zeroes all `_SERVER_AUTHORED_FLAGS` and preserves only `dry_run_mode`; #746 closed the
+  Hermes executor write-back path. This slice reuses that same chokepoint (`from_dict`) to
+  sanitize the router's raw-dict envelope branch.
+
+The router's `validate_foundup_job_envelope` consumes a **raw envelope dict** (untrusted), which
+the #747 chokepoint did NOT cover — that chokepoint runs on `FoundUpJob` deserialization, not on
+the router's loose envelope-dict path. This slice plugs that bounded gap.
+
+---
+
+## 3. Pre-State Defect (origin/main @ f3b0293e5)
+
+In `validate_foundup_job_envelope` (`def :337`):
+
+- `:413 if policy_flags is None:` → `dry_run_defaulted=True`, `policy_snapshot={"dry_run_mode": True}` (SAFE).
+- `:420 elif isinstance(policy_flags, dict):` → **`policy_snapshot = policy_flags` (RAW/UNSANITIZED — THE DEFECT)**.
+  A caller's raw dict carrying `security_gate_passed=True` / `capability_token_validated=True`
+  flowed straight into the snapshot used by the live-mode gate.
+- `:428 elif hasattr(policy_flags, "to_dict"):` → server-authored `PolicyFlags` object (trusted).
+- `:435 is_live_mode = policy_snapshot.get("dry_run_mode") is False and not dry_run_defaulted`.
+
+Gate 2 in `_validate_live_mode_gates` (`def :549`):
+
+- `:588 security_gate_checked = policy_snapshot.get("security_gate_checked", False)`
+- `:589 security_gate_passed = policy_snapshot.get("security_gate_passed", False)`
+- `:591 if security_gate_checked and not security_gate_passed:` → **OPT-IN (THE DEFECT)**.
+  A caller could simply omit `security_gate_checked` (or set it False) and the security gate was
+  never enforced; combined with the unsanitized raw dict, a caller could also forge a pass.
+
+---
+
+## 4. Implementation Summary
+
+Three changes, exactly per the locked design. The object branch (`:428-432`) and the None branch
+(`:413-419`) are unchanged.
+
+**CHANGE 1 — Sanitization helper (NEW)** — `_sanitize_untrusted_policy_flags_dict(policy_flags) -> Tuple[Dict[str, bool], bool]`:
+- Deferred import (inside the function) of `PolicyFlags` from
+  `modules.communication.moltbot_bridge.src.foundup_job_contract`, matching the existing deferred
+  cross-module import pattern in this module (`route_foundup_job` `:1073`). No module-level import
+  added → no new circular dependency.
+- `sanitized = PolicyFlags.from_dict(policy_flags).to_dict()` — zeroes ALL `_SERVER_AUTHORED_FLAGS`,
+  preserves explicit `dry_run_mode`.
+- `dry_run_defaulted = "dry_run_mode" not in policy_flags`; if defaulted, restore
+  `sanitized["dry_run_mode"] = True` (because `from_dict({})` yields `dry_run_mode=False`).
+- Returns `(sanitized, dry_run_defaulted)`.
+
+**CHANGE 2 — Dict branch uses the helper** (`:420-427`):
+- `policy_snapshot, dry_run_defaulted = _sanitize_untrusted_policy_flags_dict(policy_flags)`.
+- The existing `[WSP97] ... missing dry_run_mode - defaulted to True` log is retained, fired when
+  `dry_run_defaulted` is True.
+
+**CHANGE 3 — Gate 2 fail-closed** (`:587-592`):
+- `if not security_gate_passed: missing_gates.append("security_gate_passed")` (+ log-only line
+  recording `security_gate_checked`). The legacy `security_gate_checked` opt-in is no longer a
+  precondition. Docstring updated: "security_gate_passed=True (required in live mode)".
+
+**CHANGE 4 — Sibling `route_foundup_job` (`:1017`, check `:1101`): DEFERRED** (see Section 9).
+
+`Tuple` added to the `typing` import (the only import-line change).
+
+---
+
+## 5. Sanitization Field Matrix
+
+For a raw inbound `policy_flags` dict, after `_sanitize_untrusted_policy_flags_dict`:
+
+| Inbound flag                          | In `_SERVER_AUTHORED_FLAGS`? | PolicyFlags field? | Survives? | Sanitized value |
+|---------------------------------------|------------------------------|--------------------|-----------|-----------------|
+| `security_gate_checked`               | yes                          | yes                | forced    | False           |
+| `security_gate_passed`                | yes                          | yes                | forced    | False           |
+| `permission_gate_checked`             | yes                          | yes                | forced    | False           |
+| `permission_gate_passed`              | yes                          | yes                | forced    | False           |
+| `exfoliation_gate_checked`            | yes                          | yes                | forced    | False           |
+| `exfoliation_gate_passed`             | yes                          | yes                | forced    | False           |
+| `wsp_preflight_checked`               | yes                          | yes                | forced    | False           |
+| `wsp_preflight_passed`                | yes                          | yes                | forced    | False           |
+| `capability_token_checked`            | yes                          | yes                | forced    | False           |
+| `capability_token_present`            | yes                          | yes                | forced    | False           |
+| `capability_token_validated`          | yes                          | yes                | forced    | False           |
+| `capability_token_scope_authorized`   | yes                          | yes                | forced    | False           |
+| `dry_run_mode` (explicit)             | no (operator-authored)       | yes                | preserved | as supplied     |
+| `dry_run_mode` (absent)               | n/a                          | yes                | defaulted | True (safe)     |
+| `human_approval` (not a PolicyFlags field) | no                      | NO                 | dropped   | absent → `.get()` False |
+| any other non-field key               | no                           | NO                 | dropped   | absent          |
+
+Consequence: a raw dict can express ONLY a `dry_run_mode` choice (and even that defaults safe when
+absent). All gate/token authority must come from a server-authored `PolicyFlags` object snapshot.
+
+---
+
+## 6. Dry-Run Default Preservation Proof
+
+`PolicyFlags.from_dict({})` returns `dry_run_mode=False` (the `data.get("dry_run_mode", False)`
+default). Left unrestored, a raw dict omitting `dry_run_mode` would be mis-classified as LIVE — the
+unsafe direction. The helper detects absence (`"dry_run_mode" not in policy_flags`) and restores
+`dry_run_mode=True`, so an absent flag is dry-run, NOT live.
+
+- Helper-level: `test_raw_dict_missing_dry_run_defaults_true`
+- Envelope-level: `test_envelope_raw_dict_missing_dry_run_not_live`
+  (`dry_run_defaulted is True`, `is_live_mode is False`, snapshot `dry_run_mode is True`)
+- None branch (unchanged): `test_missing_policy_flags_defaults_dry_run`
+- Explicit `dry_run_mode=False` is PRESERVED (not over-defaulted):
+  `test_foundup_envelope_with_explicit_dry_run_false_not_defaulted`
+  (`dry_run_defaulted is False`, `is_live_mode is True`).
+
+---
+
+## 7. Gate 2 Fail-Closed Proof
+
+In live mode, `security_gate_passed` must be True or the gate appends `security_gate_passed` to
+`missing_gates` and blocks with `LIVE_MODE_REQUIRES_SECURITY_GATE`. `security_gate_checked` is now
+log-only.
+
+- `TestLiveModeSecurityGate::test_live_mode_security_gate_passed_false_fails`
+  (server-authored snapshot passes Gate 1 via `permission_gate_passed`; `security_gate_passed=False`
+  → blocked).
+- `TestLiveModeSecurityGate::test_live_mode_security_gate_required_even_when_not_checked`
+  (FAIL-CLOSED inversion: `security_gate_checked=False` no longer makes the gate optional).
+- Boundary file: `TestLegitimateLivePassServerAuthored::test_server_authored_snapshot_without_security_still_fails`.
+- End-to-end at the envelope: `TestLiveRawDictWithoutSecurityBlocked::test_live_raw_dict_no_security_blocked`,
+  `TestLiveRawDictForgedSecurityBlocked::test_forged_security_gate_passed_blocked`
+  (forged `security_gate_passed=True` sanitized to False → blocked; snapshot proves it did not survive).
+
+A legitimate live PASS therefore requires a server-authored `PolicyFlags` snapshot with
+`security_gate_passed=True`, proven directly on `_validate_live_mode_gates`:
+`TestLegitimateLivePassServerAuthored::test_server_authored_snapshot_passes_gates`.
+
+---
+
+## 8. GENERIC_DAE No-Regression Proof
+
+The GENERIC_DAE branch (`:354-370`) runs before any policy handling and is untouched. A
+`run_wre`-style envelope (`{"objective": ...}`, no `policy_flags`, no identity fields) still
+classifies GENERIC_DAE and passes.
+
+- `TestGenericDAENoRegression::test_generic_dae_objective_only_passes` (VALID, GENERIC_DAE)
+- `TestGenericDAENoRegression::test_generic_dae_with_context_passes`
+- Pre-existing generic tests in `test_foundup_job_envelope_validation.py`
+  (`TestGenericDAEEnvelope`, `TestGenericDAEEvidenceBehavior`) remain green.
+
+---
+
+## 9. Sibling `route_foundup_job` Decision — DEFERRED
+
+`route_foundup_job` (`:1017`) has a Gate-2-like check at `:1101`:
+`if policy_summary.get("security_gate_checked") and not policy_summary.get("security_gate_passed"):`.
+**Decision: DEFER — do NOT change in this slice.** Confirmed during discovery:
+
+1. **Object, not raw envelope.** `route_foundup_job` reads `job.policy_flags` off a `FoundUpJob`
+   OBJECT (`:1092`), whose flags are already sanitized by the #747 `PolicyFlags.from_dict`
+   deserialization chokepoint. Its `:1095-1098` only `to_dict()`s an object or copies a dict that
+   has already passed through deserialization — it is not the loose untrusted-envelope surface.
+2. **No live-mode discriminator.** There is NO `is_live_mode` (or `dry_run_mode`) discriminator
+   anywhere in `:1091-1111`. The check is unconditional across dry-run and live. Forcing
+   `if not security_gate_passed` fail-closed here would block legitimate dry-run / default routing
+   (which is the common, safe path), an over-block regression.
+
+**Follow-up named:** `FOUNDUP_JOB_ROUTER_ROUTE_GATE_LIVE_MODE_DISCRIMINATOR_PHASE1` — introduce a
+live-mode discriminator at `:1091-1111` first, then apply fail-closed only in live mode.
+`test_foundup_job_router.py` (the object-path suite) remains fully green, confirming the deferral
+preserved that path.
+
+---
+
+## 10. Test Matrix
+
+### New file: `tests/test_foundup_job_router_policyflags_boundary.py` (12 tests, all pass)
+
+| # | Test | Proves |
+|---|------|--------|
+| 1 | `TestRawDictSelfAssertionSanitized::test_self_asserted_gate_and_token_flags_zeroed_in_helper` | All server-authored gate/token flags forced False; explicit dry_run preserved |
+| 2 | `…::test_self_asserted_flags_zeroed_in_envelope_snapshot` | Envelope snapshot is sanitized end-to-end |
+| 3 | `TestMissingDryRunDefaultsSafe::test_raw_dict_missing_dry_run_defaults_true` | Absent dry_run → True (helper) |
+| 4 | `…::test_envelope_raw_dict_missing_dry_run_not_live` | Absent dry_run → not live (envelope) |
+| 5 | `TestMissingPolicyFlagsNoneBranch::test_missing_policy_flags_defaults_dry_run` | None branch unchanged (dry_run True) |
+| 6 | `TestLiveRawDictWithoutSecurityBlocked::test_live_raw_dict_no_security_blocked` | Live raw dict without real security → BLOCKED |
+| 7 | `TestLiveRawDictForgedSecurityBlocked::test_forged_security_gate_passed_blocked` | Forged `security_gate_passed=True` → sanitized → BLOCKED |
+| 8 | `TestLegitimateLivePassServerAuthored::test_server_authored_snapshot_passes_gates` | Server-authored snapshot live-passes |
+| 9 | `…::test_server_authored_snapshot_human_approval_variant_passes` | human_approval Gate-1 variant passes |
+| 10 | `…::test_server_authored_snapshot_without_security_still_fails` | Fail-closed even server-authored |
+| 11 | `TestGenericDAENoRegression::test_generic_dae_objective_only_passes` | GENERIC_DAE non-regressed |
+| 12 | `…::test_generic_dae_with_context_passes` | GENERIC_DAE non-regressed |
+
+### Updated existing tests in `tests/test_foundup_job_envelope_validation.py` (each justified)
+
+Root cause of every update: under the locked design (raw dict sanitized; object branch — unchanged —
+coerces a falsy `dry_run_mode` object back to dry-run), a **legitimate live PASS is no longer
+reachable through the public envelope API**. Per dispatch Test #6, legitimate live passes and
+live-only gate codes are exercised directly on `_validate_live_mode_gates` /
+`_validate_compute_budget` with a SERVER-AUTHORED snapshot. No assertion deleted without a
+replacement; every security intent is preserved or strengthened (fail-closed).
+
+| Test (updated) | Old (insecure/raw) | New (faithful) |
+|----------------|--------------------|----------------|
+| `test_foundup_envelope_with_explicit_dry_run_false_not_defaulted` | raw `human_approval` dict expected VALID live | proves explicit dry_run preserved (`dry_run_defaulted False`, `is_live_mode True`) AND fail-closed BLOCK (`security_gate_passed` missing) |
+| `test_valid_evidence_does_not_set_verification_complete` | raw `human_approval` live dict | dry-run valid envelope (truth field guarantee is mode-independent) → `verification_complete is False` |
+| `test_live_mode_with_empty_evidence_fails` | raw dict, `LIVE_MODE_REQUIRES_EVIDENCE` | direct gate call (server-authored), `evidence_count=0` → evidence the sole missing gate |
+| `test_live_mode_with_no_evidence_field_fails` | raw dict, `LIVE_MODE_REQUIRES_EVIDENCE` | direct gate call (server-authored), `evidence_pending=True` |
+| `test_live_mode_gate_pass_does_not_imply_verification_complete` (renamed) | raw `human_approval` live dict expected VALID | gate PASS via server-authored snapshot + WSP-97 truth field False on valid envelope |
+| `test_live_mode_gate_pass_does_not_imply_cabr_ready` (renamed) | raw live dict | same pattern; `cabr_ready is False` |
+| `test_live_mode_gate_pass_does_not_imply_payout_ready` (renamed) | raw live dict | same pattern; `payout_ready is False` |
+| `test_live_mode_security_gate_passed_false_fails` (renamed) | raw `human_approval` + `security_gate_checked=True` opt-in | direct gate call: Gate 1 passes (permission), `security_gate_passed=False` → fail-closed |
+| `test_live_mode_security_gate_required_even_when_not_checked` (renamed; was `..._not_checked_passes`) | asserted PASS when not checked (legacy opt-in) | INVERTED to fail-closed: `security_gate_checked=False` no longer makes the gate optional → BLOCKED |
+| `test_live_mode_fields_in_serialized_result` | raw live dict expected `live_mode_gates_passed True` | serialization shape + `is_live_mode True` via explicit raw live dict; gate PASS proven at gate surface |
+| `test_live_mode_with_budget_passes` | raw live dict expected VALID | direct `_validate_compute_budget(is_live_mode=True)` budget=5000 → valid |
+| `test_live_mode_without_budget_fails` | raw live dict, `LIVE_MODE_REQUIRES_COMPUTE_BUDGET` | direct `_validate_compute_budget(is_live_mode=True)` budget=None |
+
+All other live-FAILURE tests (`TestLiveModeWithoutApprovalFails`, malformed-evidence, missing-gates
+detail, message tests) were left unchanged and remain green: they already expected a BLOCK and their
+primary code (`LIVE_MODE_REQUIRES_HUMAN_APPROVAL`) is unaffected by sanitization (or fail earlier at
+evidence-type validation).
+
+---
+
+## 11. Boundary Proof
+
+- **dae_gateway.py** — NOT touched. `git status --porcelain` lists only the router src, the router
+  test file, and the new boundary test file.
+- **FoundUpJob / Hermes path** — NOT touched. `foundup_job_contract.py`, `hermes_job_executor.py`,
+  `destructive_action_guard.py` unchanged. `test_foundup_job_router.py` (object path) fully green.
+- **No circular dependency** — `PolicyFlags` is imported with a DEFERRED import inside the helper
+  (matching the existing pattern at `:1073`); `import modules.infrastructure.wre_core.src.foundup_job_router`
+  succeeds at module load.
+- **No contract mutation** — `PolicyFlags.from_dict`/`to_dict`/`_SERVER_AUTHORED_FLAGS` are consumed,
+  not modified.
+
+---
+
+## 12. Critic Review Result
+
+Self-critic pass over the diff before writing this audit:
+
+| Critic question | Result |
+|-----------------|--------|
+| Did missing `dry_run_mode` become live? | NO — helper restores True; tests confirm not live |
+| Did GENERIC_DAE over-block? | NO — generic branch precedes policy handling; tests green |
+| Did `route_foundup_job` dry-run routing break? | NO — DEFERRED; object-path suite green |
+| Circular import introduced? | NO — deferred import; module loads |
+| Touched dae_gateway / Hermes / contract / guard? | NO — status shows only 3 router files |
+| Deleted an insecure assertion without replacement? | NO — every change preserves/strengthens intent |
+| Did an explicit `dry_run_mode=False` get over-defaulted? | NO — helper preserves explicit False |
+
+Critic verdict: PASS.
+
+---
+
+## 13. Internal Review Verdict
+
+**APPROVED.** The defect is closed at the router boundary exactly per the locked design: raw-dict
+envelope `policy_flags` are sanitized through the #747 chokepoint, the safe dry-run default is
+preserved, and live-mode Gate 2 is fail-closed. The sibling `route_foundup_job` is correctly
+deferred with a named follow-up. Focused tests are green (12/12); the broader `wre_core/tests`
+suite is green except 5 pre-existing, unrelated failures proven via a clean-baseline comparison.
+
+---
+
+## 14. WSP_97 Truth Boundary Checklist
+
+| # | Truth Boundary Checklist Item | Status | Evidence |
+|---|-------------------------------|--------|----------|
+| 1 | ROUTER_BOUNDARY_ONLY | YES | Only `foundup_job_router.py` (+ its tests) changed; `git status --porcelain` = 3 files |
+| 2 | NO_DAE_GATEWAY_MUTATION | YES | `dae_gateway.py` untouched (not in status) |
+| 3 | NO_FOUNDUPJOB_HERMES_PATH_CHANGE | YES | `hermes_job_executor.py` untouched; `test_foundup_job_router.py` object path green |
+| 4 | NO_CONTRACT_MUTATION | YES | `foundup_job_contract.py` untouched; `from_dict`/`to_dict` only consumed |
+| 5 | RAW_ENVELOPE_SANITIZED | YES | `_sanitize_untrusted_policy_flags_dict`; Group 1 + forged-block tests |
+| 6 | DRY_RUN_DEFAULT_PRESERVED | YES | Helper restores True; `test_envelope_raw_dict_missing_dry_run_not_live` |
+| 7 | GATE2_FAILCLOSED | YES | `if not security_gate_passed`; `test_live_mode_security_gate_passed_false_fails` |
+| 8 | GENERIC_DAE_NO_REGRESSION | YES | `TestGenericDAENoRegression` + existing generic suites green |
+| 9 | SIBLING_ROUTE_DECISION_DOCUMENTED | YES | Section 9 DEFERRED + follow-up `FOUNDUP_JOB_ROUTER_ROUTE_GATE_LIVE_MODE_DISCRIMINATOR_PHASE1` |
+| 10 | NO_SKIP_XFAIL_ADDED | YES | No `skip`/`xfail` added; new file has none |
+| 11 | NO_DEPENDENCY_CHANGE | YES | No requirements/imports added beyond `typing.Tuple` |
+| 12 | NO_CI_CHANGE | YES | No CI files touched |
+| 13 | NO_WSP_MUTATION | YES | No `WSP_*` files touched |
+| 14 | NO_NEW_CIRCULAR_DEP | YES | Deferred import; `import foundup_job_router` succeeds |
+| 15 | CRITIC_REVIEW_COMPLETED | YES | Section 12 |
+| 16 | NO_CABR_READY | YES | No CABR claims; result `cabr_ready=False` unchanged |
+| 17 | NO_PAYOUT_READY | YES | No payout claims; result `payout_ready=False` unchanged |
+| 18 | NO_DAO_ACTIVATION | YES | No DAO activation introduced |
+
+All declared == actual. All YES.

--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -2,6 +2,46 @@
 
 ## Chronological Change Log
 
+### [2026-06-02] - FOUNDUP_JOB_ROUTER_POLICYFLAGS_BOUNDARY_SANITIZATION_AND_GATE2_FAILCLOSED_PHASE1 (W6)
+
+**WSP Protocol References**: WSP 97 (Truth Boundary), WSP 50 (Pre-Action), WSP 22 (ModLog), WSP 5 (Coverage)
+**Predecessors**: #752 (DAE gateway gate-flags trust-boundary audit, decision-only); #744 → #746 → #747 → #751 (PolicyFlags write-back / `from_dict` chokepoint line)
+**Impact Analysis**: Closes the bounded #752 trust-boundary defect at the ROUTER boundary. ROUTER-ONLY; no gateway/Hermes/contract mutation.
+
+**Change** — `src/foundup_job_router.py` (3 changes, locked design):
+- **NEW helper** `_sanitize_untrusted_policy_flags_dict(policy_flags) -> Tuple[Dict[str,bool], bool]` (`:337`-region).
+  Deferred import of `PolicyFlags` (matches existing `:1073` pattern → no circular dep). Runs the raw
+  envelope dict through `PolicyFlags.from_dict(...).to_dict()` — zeroes ALL `_SERVER_AUTHORED_FLAGS`
+  (security/permission/exfoliation/wsp-preflight gates + all capability_token_*), preserving only
+  `dry_run_mode`. Restores the router's safe default (`dry_run_mode=True`) when the inbound dict omits
+  it (because `from_dict({})` yields `dry_run_mode=False`).
+- **Dict branch** (`:420`-region): replaced `policy_snapshot = policy_flags` (RAW — the defect) with
+  `policy_snapshot, dry_run_defaulted = _sanitize_untrusted_policy_flags_dict(policy_flags)`; retained the
+  `[WSP97] ... missing dry_run_mode - defaulted to True` log. None branch and object branch unchanged.
+- **Gate 2 fail-closed** in `_validate_live_mode_gates` (`:587`-region): replaced the
+  `if security_gate_checked and not security_gate_passed:` opt-in with `if not security_gate_passed:`
+  (`security_gate_checked` retained log-only). Docstring updated to "security_gate_passed=True (required
+  in live mode)".
+
+**Behavior**: A raw self-asserted live envelope (e.g. forged `security_gate_passed=True`) is sanitized to
+all-gates-False and BLOCKED in live mode. An absent `dry_run_mode` stays SAFE (dry-run, not live). A
+legitimate live PASS requires a server-authored `PolicyFlags` object snapshot with
+`security_gate_passed=True`. GENERIC_DAE routing is non-regressed.
+
+**Sibling `route_foundup_job` (`:1101`): DEFERRED** — operates on a `FoundUpJob` OBJECT (already
+sanitized by the #747 chokepoint) and has NO live-mode discriminator at `:1091-1111`; forcing fail-closed
+there would block legitimate dry-run routing. Follow-up: `FOUNDUP_JOB_ROUTER_ROUTE_GATE_LIVE_MODE_DISCRIMINATOR_PHASE1`.
+
+**Tests**: new `tests/test_foundup_job_router_policyflags_boundary.py` (12 passed). Updated 12 existing
+tests in `test_foundup_job_envelope_validation.py` to the new fail-closed/sanitized semantics (legitimate
+live passes + live-only gate codes exercised directly on `_validate_live_mode_gates` /
+`_validate_compute_budget` with server-authored snapshots; no assertion deleted without replacement).
+Focused router/envelope/boundary: 140 passed. Full `wre_core/tests`: 1395 passed, 5 failed
+(pre-existing, unrelated — `test_hxa16_real_hermes_delegate_adapter_safe_harness.py` x4 + 
+`test_wre_skills_discovery.py::test_initialization`; proven identical on clean origin/main), 3 skipped,
+2 xfailed.
+**Audit**: `docs/audits/security/FOUNDUP_JOB_ROUTER_POLICYFLAGS_BOUNDARY_SANITIZATION_AND_GATE2_FAILCLOSED_PHASE1.md`.
+
 ### [2026-06-02] - HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (W6)
 
 **WSP Protocol References**: WSP 97 (Truth Boundary), WSP 22 (ModLog), WSP 50 (Pre-Action)

--- a/modules/infrastructure/wre_core/src/foundup_job_router.py
+++ b/modules/infrastructure/wre_core/src/foundup_job_router.py
@@ -30,7 +30,7 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger("wre_foundup_job_router")
 
@@ -334,6 +334,52 @@ def detect_envelope_type(envelope: Dict[str, Any]) -> EnvelopeType:
     return EnvelopeType.GENERIC_DAE
 
 
+def _sanitize_untrusted_policy_flags_dict(
+    policy_flags: Dict[str, Any],
+) -> Tuple[Dict[str, bool], bool]:
+    """Sanitize a raw, untrusted envelope ``policy_flags`` dict at the router boundary.
+
+    SECURITY (FOUNDUP_JOB_ROUTER_POLICYFLAGS_BOUNDARY_SANITIZATION, #752):
+    A raw ``policy_flags`` dict arriving on an inbound envelope is UNTRUSTED.
+    A malicious or stale caller can self-assert any gate/token flag (e.g.
+    ``security_gate_passed=True``) by carrying ``True`` in the dict. This is the
+    untrusted-envelope trust boundary: every server-authored gate/token flag
+    (all of ``_SERVER_AUTHORED_FLAGS`` — security_gate_*, permission_gate_*,
+    exfoliation_gate_*, wsp_preflight_*, capability_token_*) is FORCED to False
+    here regardless of inbound data. Server authority for those flags comes
+    EXCLUSIVELY from a server-authored ``PolicyFlags`` object snapshot (the
+    ``hasattr(policy_flags, "to_dict")`` branch), never from a raw dict.
+
+    Only ``dry_run_mode`` survives from inbound data: it is operator-authored and
+    ``True`` is the safe/sandbox direction. ``PolicyFlags.from_dict`` yields
+    ``dry_run_mode=False`` when the key is absent, which would mis-classify a
+    missing flag as LIVE; this function restores the router's safe default so an
+    absent ``dry_run_mode`` is treated as dry-run (True), NOT live.
+
+    Args:
+        policy_flags: Raw untrusted dict from the inbound envelope.
+
+    Returns:
+        Tuple of (sanitized_policy_snapshot, dry_run_defaulted) where the snapshot
+        has all server-authored gate/token flags forced False and a safe
+        ``dry_run_mode`` default applied when the inbound dict omitted it.
+    """
+    # Deferred import to avoid a circular dependency (router <-> contract); matches
+    # the existing deferred-import pattern used elsewhere in this module.
+    from modules.communication.moltbot_bridge.src.foundup_job_contract import PolicyFlags
+
+    # from_dict zeroes ALL _SERVER_AUTHORED_FLAGS and preserves only dry_run_mode.
+    sanitized = PolicyFlags.from_dict(policy_flags).to_dict()
+
+    dry_run_defaulted = "dry_run_mode" not in policy_flags
+    if dry_run_defaulted:
+        # from_dict({}) yields dry_run_mode=False; restore the router's safe
+        # default so missing flags are NOT treated as live.
+        sanitized["dry_run_mode"] = True
+
+    return sanitized, dry_run_defaulted
+
+
 def validate_foundup_job_envelope(envelope: Dict[str, Any]) -> EnvelopeValidationResult:
     """
     Validate envelope for FoundUpJob execution.
@@ -418,10 +464,12 @@ def validate_foundup_job_envelope(envelope: Dict[str, Any]) -> EnvelopeValidatio
             "[WSP97] FoundUpJob envelope missing policy_flags - dry_run_mode defaulted to True"
         )
     elif isinstance(policy_flags, dict):
-        policy_snapshot = policy_flags
-        if "dry_run_mode" not in policy_flags:
-            dry_run_defaulted = True
-            policy_snapshot["dry_run_mode"] = True
+        # SECURITY (#752): raw envelope dict is UNTRUSTED. Sanitize so self-asserted
+        # gate/token flags cannot survive; preserve safe dry_run default.
+        policy_snapshot, dry_run_defaulted = _sanitize_untrusted_policy_flags_dict(
+            policy_flags
+        )
+        if dry_run_defaulted:
             logger.info(
                 "[WSP97] FoundUpJob envelope missing dry_run_mode - defaulted to True"
             )
@@ -564,8 +612,14 @@ def _validate_live_mode_gates(
 
     Required gates for Phase 1:
       - human_approval=True OR permission_gate_passed=True
-      - security_gate_passed=True (if security_gate_checked=True)
+      - security_gate_passed=True (required in live mode)
       - Non-empty evidence_refs (evidence_pending=False)
+
+    SECURITY (#752): Gate 2 is FAIL-CLOSED. In live mode, security MUST have
+    passed; ``security_gate_passed`` is read from a server-authored snapshot only
+    (raw envelope dicts are sanitized to False upstream), so a self-asserted raw
+    dict can never satisfy this gate. The legacy ``security_gate_checked`` opt-in
+    is no longer a precondition.
 
     Args:
         policy_snapshot: Policy flags at validation time
@@ -584,12 +638,18 @@ def _validate_live_mode_gates(
     if not human_approval and not permission_gate_passed:
         missing_gates.append("human_approval")
 
-    # Gate 2: Security gate (if checked, must pass)
+    # Gate 2: Security gate (FAIL-CLOSED) — must pass in live mode.
+    # security_gate_checked is retained for logging only; it is NOT a precondition.
     security_gate_checked = policy_snapshot.get("security_gate_checked", False)
     security_gate_passed = policy_snapshot.get("security_gate_passed", False)
 
-    if security_gate_checked and not security_gate_passed:
+    if not security_gate_passed:
         missing_gates.append("security_gate_passed")
+        logger.info(
+            "[WSP97] Live mode security_gate_passed=False "
+            "(security_gate_checked=%s) - fail-closed",
+            security_gate_checked,
+        )
 
     # Gate 3: Evidence must be present (not pending)
     if evidence_pending or evidence_count == 0:

--- a/modules/infrastructure/wre_core/tests/TestModLog.md
+++ b/modules/infrastructure/wre_core/tests/TestModLog.md
@@ -1,5 +1,41 @@
 # TestModLog - wre_core/tests
 
+## 2026-06-02: FOUNDUP_JOB_ROUTER_POLICYFLAGS_BOUNDARY_SANITIZATION_AND_GATE2_FAILCLOSED_PHASE1 (W6)
+
+**Slice**: `FOUNDUP_JOB_ROUTER_POLICYFLAGS_BOUNDARY_SANITIZATION_AND_GATE2_FAILCLOSED_PHASE1` | **Predecessors**: #752, #747/#746/#744
+
+**New** `test_foundup_job_router_policyflags_boundary.py` (12 tests):
+- `TestRawDictSelfAssertionSanitized`: forged gate/token flags do NOT survive helper or envelope snapshot.
+- `TestMissingDryRunDefaultsSafe` / `TestMissingPolicyFlagsNoneBranch`: absent `dry_run_mode` → safe True (dry-run, not live); None branch unchanged.
+- `TestLiveRawDictWithoutSecurityBlocked` / `TestLiveRawDictForgedSecurityBlocked`: explicit live raw dict (incl. forged `security_gate_passed=True`) is BLOCKED after sanitization.
+- `TestLegitimateLivePassServerAuthored`: server-authored snapshot live-passes; missing security still fails (fail-closed).
+- `TestGenericDAENoRegression`: run_wre-style `{objective}` envelope still classifies GENERIC_DAE and passes.
+
+**Updated existing suites to the NEW fail-closed/sanitized semantics** (each justified in audit §10).
+Root cause: under the locked design a legitimate live PASS is no longer reachable through the public
+envelope API (raw dicts sanitized; the unchanged object branch coerces a falsy `dry_run_mode` object back
+to dry-run). Per dispatch Test #6, legitimate live passes and live-only gate codes are exercised directly
+on `_validate_live_mode_gates` / `_validate_compute_budget` with SERVER-AUTHORED snapshots. No assertion
+deleted without a replacement.
+- `test_foundup_envelope_with_explicit_dry_run_false_not_defaulted`: proves explicit `dry_run_mode=False`
+  preserved (`dry_run_defaulted False`, `is_live_mode True`) AND fail-closed BLOCK.
+- WSP-97 truth-field tests (`..._verification_complete` / `..._cabr_ready` / `..._payout_ready`,
+  renamed to `test_live_mode_gate_pass_does_not_imply_*`): gate PASS via server-authored snapshot +
+  truth field False on a valid envelope (mode-independent guarantee).
+- Evidence-required tests (`test_live_mode_with_empty_evidence_fails`, `..._no_evidence_field_fails`):
+  direct `_validate_live_mode_gates` with server-authored snapshot so evidence is the sole missing gate.
+- Security-gate tests (`test_live_mode_security_gate_passed_false_fails`,
+  `..._required_even_when_not_checked` — the latter INVERTS the old `..._not_checked_passes` to fail-closed).
+- Compute-budget live tests: direct `_validate_compute_budget(is_live_mode=True)`.
+- `test_live_mode_fields_in_serialized_result`: serialization shape + `is_live_mode True` via explicit raw
+  live dict; gate PASS proven at gate surface.
+
+**Determinism**: pure validation-layer unit tests; NO network / NO model / NO live DAE / NO WRE start.
+
+**Run**: `pytest modules/infrastructure/wre_core/tests/test_foundup_job_router_policyflags_boundary.py
+test_foundup_job_envelope_validation.py test_foundup_job_router.py` → 140 passed. Full `wre_core/tests`
+→ 1395 passed, 5 failed (pre-existing, unrelated — proven on clean origin/main), 3 skipped, 2 xfailed.
+
 ## 2026-06-02: HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1 (W6)
 
 **Slice**: `HXA_POLICYFLAGS_WRITEBACK_REMEDIATION_PHASE1` | **Predecessors**: #746, #744, HXA24/27/30

--- a/modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py
+++ b/modules/infrastructure/wre_core/tests/test_foundup_job_envelope_validation.py
@@ -21,10 +21,36 @@ from typing import Dict, Any
 from modules.infrastructure.wre_core.src.foundup_job_router import (
     detect_envelope_type,
     validate_foundup_job_envelope,
+    _validate_live_mode_gates,
+    _validate_compute_budget,
     EnvelopeType,
     EnvelopeValidationCode,
     EnvelopeValidationResult,
 )
+
+
+def _server_authored_live_snapshot(
+    *,
+    security_gate_passed: bool = True,
+    permission_gate_passed: bool = True,
+) -> dict:
+    """Build a SERVER-AUTHORED live-mode policy snapshot for _validate_live_mode_gates.
+
+    #752 fail-closed semantics: a legitimate live pass requires a server-authored
+    snapshot (security/permission gates set True by a trusted server path), NOT a
+    raw envelope dict (which is sanitized to all-gates-False). The router's object
+    branch additionally coerces any PolicyFlags object whose dry_run_mode is falsy
+    back to dry-run, so a legitimate live PASS is reachable at the gate function
+    surface — which is what these tests exercise directly. (See dispatch Test #6:
+    "do not require a raw dict to live-pass".)
+    """
+    return {
+        "dry_run_mode": False,
+        "security_gate_checked": True,
+        "security_gate_passed": security_gate_passed,
+        "permission_gate_checked": True,
+        "permission_gate_passed": permission_gate_passed,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -200,27 +226,32 @@ class TestFoundUpJobDryRunDefault:
         assert result.policy_flags_snapshot.get("dry_run_mode") is True
 
     def test_foundup_envelope_with_explicit_dry_run_false_not_defaulted(self):
-        """FoundUpJob envelope with explicit dry_run_mode=False is not defaulted."""
+        """FoundUpJob envelope with explicit dry_run_mode=False is not defaulted.
+
+        #752: the sanitizer PRESERVES an explicit dry_run_mode=False (only absent
+        flags default to True), so is_live_mode is correctly True. Under fail-closed
+        Gate 2, a raw live dict without a server-authored security pass is BLOCKED.
+        """
         envelope = {
             "job_id": "job_003",
             "foundup_id": "move2japan",
             "tenant_id": "tenant_carol",
             "requested_action": "extract_foundup",
             "policy_flags": {
-                "dry_run_mode": False,  # Explicit live mode
-                "human_approval": True,  # Required for live mode
+                "dry_run_mode": False,  # explicit -> preserved, NOT defaulted
             },
-            "evidence_refs": ["manifest.json"],  # Required for live mode
-            "compute_budget": 5000,  # Required for live mode
+            "evidence_refs": ["manifest.json"],
+            "compute_budget": 5000,
         }
 
         result = validate_foundup_job_envelope(envelope)
 
-        assert result.valid is True
+        # Explicit dry_run_mode=False is preserved (not defaulted) -> live mode.
+        assert result.dry_run_defaulted is False
         assert result.is_live_mode is True
-        # Note: dry_run_defaulted logic checks if dry_run_mode is missing or falsy
-        # When explicitly set to False, we still default to True for safety per WSP 97
-        # This is the safety-first approach
+        # Fail-closed: a raw self-asserted live dict cannot pass live-mode security.
+        assert result.valid is False
+        assert "security_gate_passed" in result.missing_live_gates
 
 
 # ---------------------------------------------------------------------------
@@ -687,18 +718,18 @@ class TestEvidenceRefsWSP97TruthFields:
     """Test evidence_refs do not change WSP 97 truth fields."""
 
     def test_valid_evidence_does_not_set_verification_complete(self):
-        """Valid evidence_refs does NOT set verification_complete=True."""
+        """Valid evidence_refs does NOT set verification_complete=True.
+
+        #752: the WSP-97 truth guarantee (verification_complete=False) is
+        mode-independent. A valid dry-run envelope with evidence still must not
+        claim verification.
+        """
         envelope = {
             "job_id": "job_017",
             "foundup_id": "kosei",
             "tenant_id": "tenant_quinn",
             "requested_action": "validate_foundup",
-            "policy_flags": {
-                "dry_run_mode": False,
-                "human_approval": True,  # Required for live mode
-            },
             "evidence_refs": ["manifest.json", "proof_abc123"],
-            "compute_budget": 5000,  # Required for live mode
         }
 
         result = validate_foundup_job_envelope(envelope)
@@ -876,43 +907,42 @@ class TestLiveModeWithoutEvidenceFails:
     """Test live-mode envelope without evidence fails."""
 
     def test_live_mode_with_empty_evidence_fails(self):
-        """Live mode with empty evidence_refs fails."""
-        envelope = {
-            "job_id": "job_live_005",
-            "foundup_id": "pqn_portal",
-            "tenant_id": "tenant_eve",
-            "requested_action": "validate_foundup",
-            "policy_flags": {
-                "dry_run_mode": False,
-                "human_approval": True,
-            },
-            "evidence_refs": [],
-        }
+        """Live mode with empty evidence_refs fails (evidence is a required gate).
 
-        result = validate_foundup_job_envelope(envelope)
+        #752: a legitimate live pass is only reachable at the gate function
+        (server-authored snapshot; the router object branch coerces falsy
+        dry_run_mode back to dry-run). Exercise _validate_live_mode_gates directly
+        with approval+security passing so evidence is the SOLE missing gate.
+        """
+        snapshot = _server_authored_live_snapshot()
 
-        assert result.valid is False
-        assert result.validation_code == EnvelopeValidationCode.LIVE_MODE_REQUIRES_EVIDENCE
-        assert "evidence_refs" in result.missing_live_gates
+        result = _validate_live_mode_gates(
+            policy_snapshot=snapshot,
+            evidence_count=0,  # empty evidence
+            evidence_pending=False,
+        )
+
+        assert result["valid"] is False
+        assert result["code"] == EnvelopeValidationCode.LIVE_MODE_REQUIRES_EVIDENCE
+        assert "evidence_refs" in result["missing_gates"]
 
     def test_live_mode_with_no_evidence_field_fails(self):
-        """Live mode without evidence_refs field fails."""
-        envelope = {
-            "job_id": "job_live_006",
-            "foundup_id": "gotjunk",
-            "tenant_id": "tenant_frank",
-            "requested_action": "build_foundup",
-            "policy_flags": {
-                "dry_run_mode": False,
-                "human_approval": True,
-            },
-        }
+        """Live mode with pending evidence fails (evidence is a required gate).
 
-        result = validate_foundup_job_envelope(envelope)
+        #752: exercised directly on _validate_live_mode_gates with approval+security
+        passing (server-authored) so evidence_pending is the SOLE missing gate.
+        """
+        snapshot = _server_authored_live_snapshot()
 
-        assert result.valid is False
-        assert result.validation_code == EnvelopeValidationCode.LIVE_MODE_REQUIRES_EVIDENCE
-        assert "evidence_refs" in result.missing_live_gates
+        result = _validate_live_mode_gates(
+            policy_snapshot=snapshot,
+            evidence_count=0,
+            evidence_pending=True,  # no evidence provided -> pending
+        )
+
+        assert result["valid"] is False
+        assert result["code"] == EnvelopeValidationCode.LIVE_MODE_REQUIRES_EVIDENCE
+        assert "evidence_refs" in result["missing_gates"]
 
 
 class TestLiveModeWithMalformedEvidenceFails:
@@ -958,118 +988,125 @@ class TestLiveModeWithMalformedEvidenceFails:
 
 
 class TestLiveModeWithApprovalAndEvidenceNoVerification:
-    """Test live-mode envelope with approval and evidence does not claim verification."""
+    """Test live-mode gate pass does not imply verification/CABR/payout.
 
-    def test_live_mode_valid_does_not_set_verification_complete(self):
-        """Valid live mode envelope does NOT set verification_complete."""
+    #752: a legitimate live PASS is reachable at the gate function with a
+    SERVER-AUTHORED snapshot (the router object branch coerces falsy dry_run_mode
+    back to dry-run, and raw dicts are sanitized to all-gates-False). The WSP-97
+    truth guarantees (verification_complete/cabr_ready/payout_ready always False)
+    are mode-independent properties of EnvelopeValidationResult, asserted here on a
+    valid envelope. Both facets of the original intent are preserved.
+    """
+
+    def test_live_mode_gate_pass_does_not_imply_verification_complete(self):
+        """Live gates can pass (server-authored) AND result never claims verification."""
+        # Gate-level legitimate live PASS (server-authored snapshot).
+        gate = _validate_live_mode_gates(
+            policy_snapshot=_server_authored_live_snapshot(),
+            evidence_count=2,
+            evidence_pending=False,
+        )
+        assert gate["valid"] is True
+
+        # WSP-97 truth guarantee on a valid envelope (mode-independent).
         envelope = {
             "job_id": "job_live_009",
             "foundup_id": "social_twin",
             "tenant_id": "tenant_ivan",
             "requested_action": "build_foundup",
-            "policy_flags": {
-                "dry_run_mode": False,
-                "human_approval": True,
-            },
             "evidence_refs": ["manifest.json", "proof.json"],
-            "compute_budget": 5000,  # Required for live mode
         }
-
         result = validate_foundup_job_envelope(envelope)
-
         assert result.valid is True
-        assert result.is_live_mode is True
-        assert result.live_mode_gates_passed is True
-        assert result.verification_complete is False  # WSP 97
+        assert result.verification_complete is False  # WSP 97: Always False
 
-    def test_live_mode_valid_does_not_set_cabr_ready(self):
-        """Valid live mode envelope does NOT set cabr_ready."""
+    def test_live_mode_gate_pass_does_not_imply_cabr_ready(self):
+        """Live gates can pass (server-authored) AND result never claims cabr_ready."""
+        gate = _validate_live_mode_gates(
+            policy_snapshot=_server_authored_live_snapshot(),
+            evidence_count=1,
+            evidence_pending=False,
+        )
+        assert gate["valid"] is True
+
         envelope = {
             "job_id": "job_live_010",
             "foundup_id": "pqn_portal",
             "tenant_id": "tenant_judy",
             "requested_action": "validate_foundup",
-            "policy_flags": {
-                "dry_run_mode": False,
-                "permission_gate_passed": True,  # Alternative approval
-            },
             "evidence_refs": ["cabr_evidence.json"],
-            "compute_budget": 5000,  # Required for live mode
         }
-
         result = validate_foundup_job_envelope(envelope)
-
         assert result.valid is True
         assert result.cabr_ready is False  # WSP 97
 
-    def test_live_mode_valid_does_not_set_payout_ready(self):
-        """Valid live mode envelope does NOT set payout_ready."""
+    def test_live_mode_gate_pass_does_not_imply_payout_ready(self):
+        """Live gates can pass (server-authored) AND result never claims payout_ready."""
+        gate = _validate_live_mode_gates(
+            policy_snapshot=_server_authored_live_snapshot(),
+            evidence_count=1,
+            evidence_pending=False,
+        )
+        assert gate["valid"] is True
+
         envelope = {
             "job_id": "job_live_011",
             "foundup_id": "gotjunk",
             "tenant_id": "tenant_kevin",
             "requested_action": "extract_foundup",
-            "policy_flags": {
-                "dry_run_mode": False,
-                "human_approval": True,
-                "security_gate_checked": True,
-                "security_gate_passed": True,
-            },
             "evidence_refs": ["payout_ready_evidence.json"],
-            "compute_budget": 5000,  # Required for live mode
         }
-
         result = validate_foundup_job_envelope(envelope)
-
         assert result.valid is True
         assert result.payout_ready is False  # WSP 97
 
 
 class TestLiveModeSecurityGate:
-    """Test live mode security gate validation."""
+    """Test live mode security gate validation (#752: FAIL-CLOSED)."""
 
-    def test_live_mode_security_gate_checked_but_not_passed_fails(self):
-        """Live mode with security_gate_checked=True but security_gate_passed=False fails."""
-        envelope = {
-            "job_id": "job_live_012",
-            "foundup_id": "kosei",
-            "tenant_id": "tenant_larry",
-            "requested_action": "build_foundup",
-            "policy_flags": {
-                "dry_run_mode": False,
-                "human_approval": True,
-                "security_gate_checked": True,
-                "security_gate_passed": False,
-            },
-            "evidence_refs": ["manifest.json"],
+    def test_live_mode_security_gate_passed_false_fails(self):
+        """Live mode with security_gate_passed=False fails (fail-closed).
+
+        #752: exercised at the gate surface (the legitimate live surface). Gate 1
+        passes via permission_gate_passed; security_gate_passed=False -> Gate 2
+        fail-closed -> blocked with LIVE_MODE_REQUIRES_SECURITY_GATE.
+        """
+        snapshot = _server_authored_live_snapshot(security_gate_passed=False)
+
+        result = _validate_live_mode_gates(
+            policy_snapshot=snapshot,
+            evidence_count=1,
+            evidence_pending=False,
+        )
+
+        assert result["valid"] is False
+        assert result["code"] == EnvelopeValidationCode.LIVE_MODE_REQUIRES_SECURITY_GATE
+        assert "security_gate_passed" in result["missing_gates"]
+
+    def test_live_mode_security_gate_required_even_when_not_checked(self):
+        """#752 FAIL-CLOSED inversion: live mode REQUIRES security_gate_passed=True.
+
+        Previously a missing security_gate_checked meant the gate was optional.
+        Under fail-closed, security MUST pass in live mode; a snapshot with
+        security_gate_checked=False (so the legacy opt-in would NOT fire) is still
+        blocked because security_gate_passed is not True.
+        """
+        snapshot = {
+            "dry_run_mode": False,
+            "permission_gate_passed": True,  # Gate 1 satisfied (server-authored)
+            "security_gate_checked": False,  # legacy opt-in would NOT trigger
+            "security_gate_passed": False,  # but fail-closed still requires True
         }
 
-        result = validate_foundup_job_envelope(envelope)
+        result = _validate_live_mode_gates(
+            policy_snapshot=snapshot,
+            evidence_count=1,
+            evidence_pending=False,
+        )
 
-        assert result.valid is False
-        assert result.validation_code == EnvelopeValidationCode.LIVE_MODE_REQUIRES_SECURITY_GATE
-        assert "security_gate_passed" in result.missing_live_gates
-
-    def test_live_mode_security_gate_not_checked_passes(self):
-        """Live mode without security_gate_checked passes (gate not required if not checked)."""
-        envelope = {
-            "job_id": "job_live_013",
-            "foundup_id": "move2japan",
-            "tenant_id": "tenant_mary",
-            "requested_action": "validate_foundup",
-            "policy_flags": {
-                "dry_run_mode": False,
-                "human_approval": True,
-                "security_gate_checked": False,  # Not checked, so not required
-            },
-            "evidence_refs": ["evidence.json"],
-            "compute_budget": 5000,  # Required for live mode
-        }
-
-        result = validate_foundup_job_envelope(envelope)
-
-        assert result.valid is True
-        assert result.live_mode_gates_passed is True
+        assert result["valid"] is False
+        assert result["code"] == EnvelopeValidationCode.LIVE_MODE_REQUIRES_SECURITY_GATE
+        assert "security_gate_passed" in result["missing_gates"]
 
 
 class TestLiveModeValidationErrorDetails:
@@ -1134,28 +1171,40 @@ class TestLiveModeValidationErrorDetails:
         assert "human_approval" in result.validation_message or "gates" in result.validation_message
 
     def test_live_mode_fields_in_serialized_result(self):
-        """Live mode fields appear in to_dict() output."""
+        """Live mode fields appear in to_dict() output; is_live_mode reflects intent.
+
+        #752: an explicit live raw dict reaches is_live_mode=True at the envelope
+        level (the sanitizer preserves dry_run_mode=False), so the serialized
+        fields are present and is_live_mode=True. The gate PASS itself is proven at
+        the gate surface (a raw live dict is fail-closed, so live_mode_gates_passed
+        is False on the envelope result by design).
+        """
         envelope = {
             "job_id": "job_live_017",
             "foundup_id": "kosei",
             "tenant_id": "tenant_quinn",
             "requested_action": "build_foundup",
-            "policy_flags": {
-                "dry_run_mode": False,
-                "human_approval": True,
-            },
+            "policy_flags": {"dry_run_mode": False},  # explicit live (raw, untrusted)
             "evidence_refs": ["complete_evidence.json"],
-            "compute_budget": 5000,  # Required for live mode
+            "compute_budget": 5000,
         }
 
         result = validate_foundup_job_envelope(envelope)
         result_dict = result.to_dict()
 
+        # Serialization shape is preserved.
         assert "is_live_mode" in result_dict
         assert "live_mode_gates_passed" in result_dict
         assert "missing_live_gates" in result_dict
         assert result_dict["is_live_mode"] is True
-        assert result_dict["live_mode_gates_passed"] is True
+
+        # Legitimate gate PASS is reachable only at the gate surface (server-authored).
+        gate = _validate_live_mode_gates(
+            policy_snapshot=_server_authored_live_snapshot(),
+            evidence_count=1,
+            evidence_pending=False,
+        )
+        assert gate["valid"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -1484,46 +1533,35 @@ class TestLiveModeRequiresComputeBudget:
     """Test live mode requires explicit compute_budget."""
 
     def test_live_mode_with_budget_passes(self):
-        """Live mode with explicit compute_budget passes."""
+        """Live mode with explicit compute_budget passes the budget gate.
+
+        #752: the live compute-budget requirement is a property of
+        _validate_compute_budget(is_live_mode=True); exercised directly because a
+        legitimate live PASS is unreachable through the public envelope API (raw
+        dicts sanitized, object branch coerces falsy dry_run_mode to dry-run).
+        """
         envelope = {
-            "job_id": "job_budget_020",
-            "foundup_id": "pqn_portal",
-            "tenant_id": "tenant_tina",
-            "requested_action": "validate_foundup",
-            "policy_flags": {
-                "dry_run_mode": False,
-                "human_approval": True,
-            },
-            "evidence_refs": ["manifest.json"],
             "compute_budget": 5000,
         }
 
-        result = validate_foundup_job_envelope(envelope)
+        result = _validate_compute_budget(envelope, is_live_mode=True)
 
-        assert result.valid is True
-        assert result.is_live_mode is True
-        assert result.compute_budget_value == 5000
+        assert result["valid"] is True
+        assert result["budget"] == 5000
 
     def test_live_mode_without_budget_fails(self):
-        """Live mode without compute_budget fails."""
+        """Live mode without compute_budget fails (LIVE_MODE_REQUIRES_COMPUTE_BUDGET).
+
+        #752: exercised directly on _validate_compute_budget(is_live_mode=True).
+        """
         envelope = {
-            "job_id": "job_budget_021",
-            "foundup_id": "gotjunk",
-            "tenant_id": "tenant_uma",
-            "requested_action": "build_foundup",
-            "policy_flags": {
-                "dry_run_mode": False,
-                "human_approval": True,
-            },
-            "evidence_refs": ["evidence.json"],
             "compute_budget": None,
         }
 
-        result = validate_foundup_job_envelope(envelope)
+        result = _validate_compute_budget(envelope, is_live_mode=True)
 
-        assert result.valid is False
-        assert result.validation_code == EnvelopeValidationCode.LIVE_MODE_REQUIRES_COMPUTE_BUDGET
-        assert result.is_live_mode is True
+        assert result["valid"] is False
+        assert result["code"] == EnvelopeValidationCode.LIVE_MODE_REQUIRES_COMPUTE_BUDGET
 
     def test_dry_run_without_budget_passes(self):
         """Dry-run mode without compute_budget passes (allowed for dry-run)."""

--- a/modules/infrastructure/wre_core/tests/test_foundup_job_router_policyflags_boundary.py
+++ b/modules/infrastructure/wre_core/tests/test_foundup_job_router_policyflags_boundary.py
@@ -1,0 +1,313 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for FoundUpJob Router policy_flags trust-boundary sanitization + Gate 2 fail-closed.
+
+Slice: FOUNDUP_JOB_ROUTER_POLICYFLAGS_BOUNDARY_SANITIZATION_AND_GATE2_FAILCLOSED_PHASE1 (#752)
+
+Proves at the ROUTER boundary (validate_foundup_job_envelope + _validate_live_mode_gates
++ _sanitize_untrusted_policy_flags_dict):
+  1. Raw dict self-asserted gate/token flags do NOT survive sanitization.
+  2. Missing dry_run_mode in a raw dict defaults safely (dry_run_mode=True, NOT live).
+  3. Missing policy_flags entirely defaults dry_run_mode=True (None branch unchanged).
+  4. Explicit live raw dict without a real security pass is BLOCKED (fail-closed).
+  5. Explicit live raw dict with FORGED security_gate_passed=True is still BLOCKED.
+  6. A legitimate live PASS uses a SERVER-AUTHORED snapshot, exercised directly on
+     _validate_live_mode_gates (raw dicts are untrusted by design).
+  7. GENERIC_DAE / run_wre-style envelope (no policy_flags) is non-regressed.
+
+WSP Compliance:
+  WSP 5  : Test coverage for the trust-boundary fix
+  WSP 97 : Truthful validation (explicit failures, fail-closed, no silent fallback)
+
+NO network / NO model / NO live DAE / NO WRE start. Pure validation-layer unit tests.
+"""
+
+import pytest
+
+from modules.infrastructure.wre_core.src.foundup_job_router import (
+    validate_foundup_job_envelope,
+    _validate_live_mode_gates,
+    _sanitize_untrusted_policy_flags_dict,
+    EnvelopeType,
+    EnvelopeValidationCode,
+)
+
+
+# ---------------------------------------------------------------------------
+# Group 1: Raw dict self-asserted gate/token flags are sanitized to False
+# ---------------------------------------------------------------------------
+
+
+class TestRawDictSelfAssertionSanitized:
+    """Inbound self-asserted gate/token flags must NOT survive into the snapshot."""
+
+    def test_self_asserted_gate_and_token_flags_zeroed_in_helper(self):
+        """Helper zeroes ALL server-authored gate/token flags from a raw dict."""
+        sanitized, dry_run_defaulted = _sanitize_untrusted_policy_flags_dict(
+            {
+                "dry_run_mode": False,
+                "security_gate_checked": True,
+                "security_gate_passed": True,
+                "permission_gate_checked": True,
+                "permission_gate_passed": True,
+                "exfoliation_gate_passed": True,
+                "wsp_preflight_passed": True,
+                "capability_token_checked": True,
+                "capability_token_present": True,
+                "capability_token_validated": True,
+                "capability_token_scope_authorized": True,
+            }
+        )
+        # Every server-authored flag forced False.
+        assert sanitized.get("security_gate_passed") is False
+        assert sanitized.get("security_gate_checked") is False
+        assert sanitized.get("permission_gate_passed") is False
+        assert sanitized.get("permission_gate_checked") is False
+        assert sanitized.get("exfoliation_gate_passed") is False
+        assert sanitized.get("wsp_preflight_passed") is False
+        assert sanitized.get("capability_token_checked") is False
+        assert sanitized.get("capability_token_present") is False
+        assert sanitized.get("capability_token_validated") is False
+        assert sanitized.get("capability_token_scope_authorized") is False
+        # Explicit operator-authored dry_run_mode preserved (not defaulted).
+        assert sanitized.get("dry_run_mode") is False
+        assert dry_run_defaulted is False
+
+    def test_self_asserted_flags_zeroed_in_envelope_snapshot(self):
+        """validate_foundup_job_envelope exposes a sanitized policy_flags_snapshot."""
+        envelope = {
+            "job_id": "job_san_001",
+            "foundup_id": "gotjunk",
+            "tenant_id": "tenant_alice",
+            "requested_action": "build_foundup",
+            "policy_flags": {
+                "dry_run_mode": True,  # keep dry-run so evidence is pending-friendly
+                "security_gate_passed": True,
+                "permission_gate_passed": True,
+                "capability_token_validated": True,
+            },
+        }
+        result = validate_foundup_job_envelope(envelope)
+
+        snap = result.policy_flags_snapshot
+        assert snap.get("security_gate_passed") is False
+        assert snap.get("permission_gate_passed") is False
+        assert snap.get("capability_token_validated") is False
+        # dry_run preserved -> not live, validation still passes structurally
+        assert snap.get("dry_run_mode") is True
+        assert result.valid is True
+        assert result.is_live_mode is False
+
+
+# ---------------------------------------------------------------------------
+# Group 2: Missing dry_run_mode in a raw dict defaults safely (NOT live)
+# ---------------------------------------------------------------------------
+
+
+class TestMissingDryRunDefaultsSafe:
+    """A raw dict that omits dry_run_mode must default to True (dry-run), not live."""
+
+    def test_raw_dict_missing_dry_run_defaults_true(self):
+        """Helper restores dry_run_mode=True when the inbound dict omits it."""
+        sanitized, dry_run_defaulted = _sanitize_untrusted_policy_flags_dict(
+            {"security_gate_passed": True}  # no dry_run_mode key
+        )
+        assert sanitized.get("dry_run_mode") is True
+        assert dry_run_defaulted is True
+        # And the forged flag is still zeroed.
+        assert sanitized.get("security_gate_passed") is False
+
+    def test_envelope_raw_dict_missing_dry_run_not_live(self):
+        """Envelope with a raw dict missing dry_run_mode is dry-run, not live."""
+        envelope = {
+            "job_id": "job_san_002",
+            "foundup_id": "kosei",
+            "tenant_id": "tenant_bob",
+            "requested_action": "validate_foundup",
+            "policy_flags": {
+                "security_gate_passed": True,  # forged, no dry_run_mode
+            },
+        }
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.dry_run_defaulted is True
+        assert result.is_live_mode is False
+        assert result.policy_flags_snapshot.get("dry_run_mode") is True
+
+
+# ---------------------------------------------------------------------------
+# Group 3: Missing policy_flags entirely (None branch unchanged)
+# ---------------------------------------------------------------------------
+
+
+class TestMissingPolicyFlagsNoneBranch:
+    """No policy_flags at all -> dry_run_mode True (None branch is unchanged)."""
+
+    def test_missing_policy_flags_defaults_dry_run(self):
+        envelope = {
+            "job_id": "job_san_003",
+            "foundup_id": "move2japan",
+            "tenant_id": "tenant_carol",
+            "requested_action": "build_foundup",
+        }
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.dry_run_defaulted is True
+        assert result.is_live_mode is False
+        assert result.policy_flags_snapshot.get("dry_run_mode") is True
+
+
+# ---------------------------------------------------------------------------
+# Group 4: Explicit live raw dict without real security pass -> BLOCKED
+# ---------------------------------------------------------------------------
+
+
+class TestLiveRawDictWithoutSecurityBlocked:
+    """An explicit live raw dict can never pass live mode (security sanitized False)."""
+
+    def test_live_raw_dict_no_security_blocked(self):
+        """Live raw dict (dry_run_mode=False) with no real security pass is blocked."""
+        envelope = {
+            "job_id": "job_san_004",
+            "foundup_id": "social_twin",
+            "tenant_id": "tenant_dave",
+            "requested_action": "build_foundup",
+            "policy_flags": {
+                "dry_run_mode": False,
+                "permission_gate_passed": True,  # sanitized away -> Gate1 also fails
+            },
+            "evidence_refs": ["manifest.json"],
+            "compute_budget": 5000,
+        }
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.is_live_mode is True
+        # security_gate_passed is among the missing live gates (fail-closed).
+        assert "security_gate_passed" in result.missing_live_gates
+        # Primary code is one of the live-mode gate codes (human_approval is
+        # checked first since permission_gate_passed was sanitized away).
+        assert result.validation_code in (
+            EnvelopeValidationCode.LIVE_MODE_REQUIRES_SECURITY_GATE,
+            EnvelopeValidationCode.LIVE_MODE_REQUIRES_HUMAN_APPROVAL,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Group 5: Explicit live raw dict with FORGED security_gate_passed -> BLOCKED
+# ---------------------------------------------------------------------------
+
+
+class TestLiveRawDictForgedSecurityBlocked:
+    """A forged security_gate_passed=True on a raw dict is sanitized -> still blocked."""
+
+    def test_forged_security_gate_passed_blocked(self):
+        envelope = {
+            "job_id": "job_san_005",
+            "foundup_id": "pqn_portal",
+            "tenant_id": "tenant_eve",
+            "requested_action": "extract_foundup",
+            "policy_flags": {
+                "dry_run_mode": False,
+                "human_approval": True,  # dropped (not a PolicyFlags field)
+                "permission_gate_passed": True,  # sanitized False
+                "security_gate_checked": True,  # sanitized False
+                "security_gate_passed": True,  # FORGED -> sanitized False
+            },
+            "evidence_refs": ["manifest.json"],
+            "compute_budget": 5000,
+        }
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is False
+        assert result.is_live_mode is True
+        assert "security_gate_passed" in result.missing_live_gates
+        # The sanitized snapshot proves the forged flag did not survive.
+        assert result.policy_flags_snapshot.get("security_gate_passed") is False
+
+
+# ---------------------------------------------------------------------------
+# Group 6: Legitimate live PASS uses a SERVER-AUTHORED snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestLegitimateLivePassServerAuthored:
+    """A legitimate live pass requires a server-authored snapshot.
+
+    Raw dicts are untrusted by design and cannot live-pass; therefore the
+    legitimate-pass path is proven directly on _validate_live_mode_gates with a
+    server-authored snapshot (the object branch's to_dict() output).
+    """
+
+    def test_server_authored_snapshot_passes_gates(self):
+        """Server-authored snapshot with security_gate_passed=True passes Gate 2."""
+        snapshot = {
+            "dry_run_mode": False,
+            "permission_gate_passed": True,
+            "security_gate_passed": True,
+        }
+        result = _validate_live_mode_gates(
+            policy_snapshot=snapshot,
+            evidence_count=1,
+            evidence_pending=False,
+        )
+        assert result["valid"] is True
+        assert result.get("missing_gates", []) == []
+
+    def test_server_authored_snapshot_human_approval_variant_passes(self):
+        """human_approval=True satisfies Gate 1; security_gate_passed satisfies Gate 2."""
+        snapshot = {
+            "dry_run_mode": False,
+            "human_approval": True,
+            "security_gate_passed": True,
+        }
+        result = _validate_live_mode_gates(
+            policy_snapshot=snapshot,
+            evidence_count=2,
+            evidence_pending=False,
+        )
+        assert result["valid"] is True
+
+    def test_server_authored_snapshot_without_security_still_fails(self):
+        """Even server-authored, missing security_gate_passed fails (fail-closed)."""
+        snapshot = {
+            "dry_run_mode": False,
+            "permission_gate_passed": True,
+            # security_gate_passed omitted -> False -> blocked
+        }
+        result = _validate_live_mode_gates(
+            policy_snapshot=snapshot,
+            evidence_count=1,
+            evidence_pending=False,
+        )
+        assert result["valid"] is False
+        assert "security_gate_passed" in result.get("missing_gates", [])
+
+
+# ---------------------------------------------------------------------------
+# Group 7: GENERIC_DAE / run_wre-style envelope non-regression
+# ---------------------------------------------------------------------------
+
+
+class TestGenericDAENoRegression:
+    """run_wre-style generic envelope (objective only, no policy_flags) still passes."""
+
+    def test_generic_dae_objective_only_passes(self):
+        envelope = {"objective": "Run a generic WRE objective with no identity fields"}
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.envelope_type == EnvelopeType.GENERIC_DAE
+        assert result.validation_code == EnvelopeValidationCode.VALID
+
+    def test_generic_dae_with_context_passes(self):
+        envelope = {
+            "objective": "Generic objective",
+            "context": {"some": "context"},
+        }
+        result = validate_foundup_job_envelope(envelope)
+
+        assert result.valid is True
+        assert result.envelope_type == EnvelopeType.GENERIC_DAE


### PR DESCRIPTION
## Mission

Close the #752 bounded trust-boundary defect at the FoundUpJob **router boundary only**: sanitize raw-dict envelope `policy_flags`, preserve the safe dry-run default, and make live-mode Gate 2 fail-closed.

Edits are confined to `modules/infrastructure/wre_core/src/foundup_job_router.py` plus its tests/ModLog/audit. No change to `dae_gateway.py`, `foundup_job_contract.py`, `hermes_job_executor.py`, or `destructive_action_guard.py`.

## Changes (locked design)

1. **NEW** `_sanitize_untrusted_policy_flags_dict(policy_flags) -> Tuple[Dict[str,bool], bool]` — runs a raw, untrusted envelope dict through the #747 `PolicyFlags.from_dict` chokepoint (zeroes ALL `_SERVER_AUTHORED_FLAGS`: security/permission/exfoliation/wsp-preflight gates + all `capability_token_*`), preserving only `dry_run_mode`. Restores the safe default (`dry_run_mode=True`) when absent. Deferred import → no new circular dependency.
2. **Dict branch** of `validate_foundup_job_envelope` now sanitizes instead of assigning the raw dict to the policy snapshot. None branch and (trusted) object branch unchanged.
3. **Gate 2 fail-closed** in `_validate_live_mode_gates`: live mode now requires `security_gate_passed=True` (legacy `security_gate_checked` opt-in dropped; retained log-only).

### Consequences
- A forged raw live envelope (e.g. `security_gate_passed=True`) is sanitized to all-gates-False and **BLOCKED**.
- An absent `dry_run_mode` stays **safe** (dry-run, not live).
- A legitimate live PASS requires a **server-authored** `PolicyFlags` object snapshot with `security_gate_passed=True`.
- GENERIC_DAE / `run_wre`-style routing is non-regressed.

### Sibling `route_foundup_job` (`:1101`) — DEFERRED
Operates on a `FoundUpJob` OBJECT (already sanitized by the #747 chokepoint) and has **no live-mode discriminator** at `:1091-1111`; forcing fail-closed there would block legitimate dry-run routing. Follow-up: `FOUNDUP_JOB_ROUTER_ROUTE_GATE_LIVE_MODE_DISCRIMINATOR_PHASE1`.

## Tests
- **New** `test_foundup_job_router_policyflags_boundary.py` (12 tests): self-assertion sanitized, missing-dry_run safe default, None branch, live-without/forged-security blocked, server-authored live pass, GENERIC_DAE no-regression.
- **Updated** 12 existing tests in `test_foundup_job_envelope_validation.py` to the new fail-closed/sanitized semantics — legitimate live passes and live-only gate codes are exercised directly on `_validate_live_mode_gates` / `_validate_compute_budget` with server-authored snapshots (no assertion deleted without replacement). No skip/xfail.
- Focused router/envelope/boundary: **140 passed**.
- Full `wre_core/tests`: **1395 passed**, 5 failed (pre-existing, unrelated — `test_hxa16_real_hermes_delegate_adapter_safe_harness.py` x4 + `test_wre_skills_discovery.py::test_initialization`; proven identical on clean `origin/main`), 3 skipped, 2 xfailed.

## Audit
`docs/audits/security/FOUNDUP_JOB_ROUTER_POLICYFLAGS_BOUNDARY_SANITIZATION_AND_GATE2_FAILCLOSED_PHASE1.md` (14 sections + WSP_97 checklist, 18/18 YES).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
