### PR TITLE
test(security): PolicyFlags chain regression guards (Phase 1)

### DIFF
--- a/docs/audits/security/HXA_POLICYFLAGS_REGRESSION_GUARDS_PHASE1.md
+++ b/docs/audits/security/HXA_POLICYFLAGS_REGRESSION_GUARDS_PHASE1.md
@@ -1,0 +1,337 @@
+# HXA_POLICYFLAGS_REGRESSION_GUARDS_PHASE1
+
+Worker-Lane: W6
+Slice: HXA_POLICYFLAGS_REGRESSION_GUARDS_PHASE1
+Base: origin/main @ 01eb327d9900d44d96318792a7605463f0519081
+Scope: TESTS / GUARDS ONLY (+ ModLog, TestModLog, this audit, new wre_gateway/tests/)
+
+---
+
+## 1. Mission and Scope
+
+This slice is the CI-coverage capstone named by the #755 router-security-chain
+closeout review ("the only outstanding work is CI regression guards (slice
+HXA_POLICYFLAGS_REGRESSION_GUARDS_PHASE1)"). The PolicyFlags trust chain is
+already CLOSED in production; this slice does NOT re-implement or re-prove
+per-slice behavior. It installs six durable INVARIANT guards that TRIP if a
+future edit silently re-opens a closed hole.
+
+GUARDS ONLY. No production code is modified. If a guard had exposed a real
+current defect, the rule was: STOP, document, recommend a separate remediation
+slice, do NOT fix here and do NOT weaken the guard. No such defect was found
+(see Section 11).
+
+In-scope files:
+1. `modules/infrastructure/wre_core/tests/test_policyflags_regression_guards.py` (G1, G4, G6)
+2. `modules/infrastructure/wre_core/wre_gateway/tests/__init__.py` (new package)
+3. `modules/infrastructure/wre_core/wre_gateway/tests/test_dae_gateway_policyflags_guards.py` (G2, G3, G5)
+4. `modules/infrastructure/wre_core/ModLog.md` + `modules/infrastructure/wre_core/tests/TestModLog.md`
+5. `docs/audits/security/HXA_POLICYFLAGS_REGRESSION_GUARDS_PHASE1.md` (this doc)
+
+The optional 1-line nav-comment fix at `foundup_job_consumer.py:27` is DEFERRED
+(see Section 12) - it is a doc-hygiene staleness outside the security-guard scope.
+
+---
+
+## 2. Predecessor #755 and the Chain (#752 - #754)
+
+| PR | Slice | Role |
+|----|-------|------|
+| #746 | HXA_POLICYFLAGS_WRITEBACK_REMEDIATION | Server-authored token verdict written into job.policy_flags BEFORE the destructive-action guard reads it (#747 ordering) |
+| #752 | DAE_GATEWAY_ENVELOPE_GATEFLAGS_TRUST_BOUNDARY_AUDIT | Classified the envelope -> dae_gateway path GAP_CONFIRMED_BOUNDED |
+| #753 | POLICYFLAGS_BOUNDARY_SANITIZATION_AND_GATE2_FAILCLOSED | Validation seam: raw dict branch sanitized; Gate 2 (security) fail-closed in live mode |
+| #754 | ROUTE_GATE_LIVE_MODE_DISCRIMINATOR | Routing seam: raw-dict sanitize + is_live discriminator + fail-closed live gate |
+| #755 | FOUNDUP_ROUTER_SECURITY_CHAIN_CLOSEOUT_REVIEW | Read-only closeout: CHAIN_CLOSED_WITH_RECOMMENDED_GUARDS (BOUNDED); NAMED this guard slice |
+
+The #755 review (lane W9) inventoried "8 have / 5 missing" regression guards.
+This slice installs the missing guard surface as durable CI invariants.
+
+---
+
+## 3. FOLLOW-WSP Evidence
+
+### Step 1 - Occam's Razor
+Simplest guard that traps each failure mode, with NO new dependency. `hypothesis`
+is NOT installed; G4's "property-based fuzz" is implemented with stdlib
+`dataclasses.fields` (dynamic enumeration) + `itertools.product` (representative
+combinations). AST guards use the stdlib `ast` module. No runtime, no network, no
+model, no live DAE.
+
+### Step 2 - HoloIndex (queries run + top results)
+`python holo_index.py --search ...` was available and run. Top results cited:
+
+| Query | Top results (surfaced) |
+|-------|------------------------|
+| policyflags sanitization regression guard test | ai_overseer.py; wre_core/src/pattern_memory.py; WSP_5 / WSP_16 / WSP_47 |
+| AST grep architectural rule no production caller | WSP_40 Architectural Coherence; WSP_9; WSP_MODULE_VIOLATIONS; pattern_memory.py |
+| from_dict deserialization chokepoint test | moltbot_bridge/tests/test_openclaw_dae.py; pattern_memory.py; WSP_5 / WSP_16 / WSP_39 |
+| wre_gateway route_to_dae envelope validation test | moltbot_bridge/tests/test_openclaw_dae.py; wre_skills_loader.py; WSP_95; WSP_4; WSP_106 |
+| write-back before guard ordering assertion | digital_twin/style_guardrails.py; pattern_memory.py; WSP_50 / WSP_6 / WSP_14 |
+| property based fuzz dataclass fields enumeration | synthetic_user_agent.py (SyntheticPersona dataclass); autonomous_refactoring.py; digital_twin/schemas.py |
+
+HoloIndex did not surface an existing guard for these invariants (the #755 review
+also classified them as missing), confirming this is net-new guard coverage, not
+duplication. The three named exemplar suites
+(`test_foundup_job_router_policyflags_boundary.py`,
+`test_hxa_policyflags_writeback_remediation.py`,
+`test_route_foundup_job_live_mode_gate.py`) were read and their patterns mirrored
+(forged-flag fail-closed envelopes, `create_job` + `HERMES_DELEGATE_ENABLED=0`
+bounded executor harness, live-mode gate semantics).
+
+### Step 4 - NAVIGATION verification
+`NAVIGATION.py` has no policyflags/dae_gateway-specific entries (grep: no matches),
+so no navigation map needed updating. All anchor line numbers below were
+re-derived directly against origin/main @ 01eb327d9 (prior audits not trusted).
+
+---
+
+## 4. Anchors Re-Verified on origin/main @ 01eb327d9
+
+| Anchor | Location (re-verified) |
+|--------|------------------------|
+| `_SERVER_AUTHORED_FLAGS` frozenset | `foundup_job_contract.py:200-215` (12 members) |
+| `PolicyFlags` dataclass | `foundup_job_contract.py:218` (13 fields total) |
+| `PolicyFlags.from_dict` chokepoint | `foundup_job_contract.py:283-324` (only `dry_run_mode` preserved) |
+| Caller: `__post_init__` | `foundup_job_contract.py:461` |
+| Caller: `FoundUpJob.from_dict` body | `foundup_job_contract.py:662` |
+| Caller: router sanitizer | `foundup_job_router.py:372` (def at `:337`) |
+| Docstring hits (NOT calls) | `foundup_job_router.py:354`; `hermes_job_executor.py:1167`, `:1517`; `foundup_job_contract.py:194`, `:305` |
+| `FOUNDUP_JOB_VALIDATION_AVAILABLE` | `dae_gateway.py:56/:58`, used `:334` |
+| `route_to_dae` | `dae_gateway.py:149`; dispatch `_invoke_core_dae:214`, `_invoke_foundup_dae:275` |
+| #747 ordering | `hermes_job_executor.py` execute(): `_writeback_token_verdict` `:1521` BEFORE `_evaluate_destructive_action_guard` `:1524` |
+
+Runtime field enumeration confirmed 13 PolicyFlags fields; every non-`dry_run_mode`
+field (12) is a member of `_SERVER_AUTHORED_FLAGS`, and the frozenset has exactly
+those 12. This equivalence is the property G4 locks.
+
+---
+
+## 5. Per-Guard Reasoning Summary / WSP_97 Rationale
+
+(Reasoning Summary; not private chain-of-thought.)
+
+| Guard | #755 finding traced to | Invariant locked | Failure mode caught | file:line evidence | Negative control + method |
+|-------|------------------------|------------------|---------------------|--------------------|---------------------------|
+| G1 | "no-production-caller" architectural rule (residual surface 0) | FoundUpJob.from_dict prod callers = 0; PolicyFlags.from_dict prod callers exactly the 3-entry allowlist | A new untrusted-deserialization caller (object-path bypass) added to production | contract:461, contract:662, router:372 (allowlist); docstrings excluded by AST | `negative_control_method=synthetic_source_string`: AST scan of an inline source string with an extra `FoundUpJob.from_dict` call + comment + docstring detects ONLY the real CALL (line 4), comment/docstring/string-literal excluded |
+| G2 | "8 have / 5 missing" - validator-available health | `FOUNDUP_JOB_VALIDATION_AVAILABLE is True` in a healthy env (test-only, NOT a prod startup assert) | The WSP 97 envelope validator import silently breaks -> gateway degrades to permissive | dae_gateway:49-58 | `negative_control_method=monkeypatch_module_constant`: patching the flag False makes the `is True` assertion raise (pytest.raises) |
+| G3 | envelope -> dae_gateway "GAP_CONFIRMED_BOUNDED" (#752) | Forged live FoundUpJob envelope is BLOCKED before any DAE dispatch | A removed/broken sanitizer lets a forged `security_gate_passed=True` live envelope reach `_invoke_core_dae`/`_invoke_foundup_dae` | dae_gateway:167 (`_verify_envelope`), router `_validate_live_mode_gates` fail-closed | `negative_control_method=monkeypatch_function`: patching `_verify_envelope` -> True makes the SAME forged envelope dispatch (`_invoke_core_dae.called is True`), proving the block assertion is non-vacuous |
+| G4 | sanitization correctness (#752/#753) | Every non-`dry_run_mode` field forced False by BOTH contract + router sanitizers; every such field in `_SERVER_AUTHORED_FLAGS`; router/contract CONSISTENT | A new gate field added without registering it server-authored, or a sanitizer that leaks a True flag | contract:283-324, router:337-378; fields enumerated at runtime | `negative_control_method=test_local_fake_dataclass_sanitizer`: a fake sanitizer preserving `security_gate_passed=True` fails the property (pytest.raises) |
+| G5 | permissive-fallback bounding | With validation unavailable, degraded behavior is bounded: FoundUpJob-shaped (no objective) still blocked; even a dispatching generic envelope reaches only the pattern-recall stub, never route/execute | Degraded mode escalates to live/destructive execution | dae_gateway:334 (avail gate), :359-374 (permissive), :214/:275 (stubs) | `negative_control_method=monkeypatch_module_constant`: healthy-env contrast test shows STRICT block (different code path); proves the flag drives behavior |
+| G6 | #747 write-back-before-guard ordering | `_writeback_token_verdict` precedes `_evaluate_destructive_action_guard` in execute() (static AST source-order AND behavioral spy) | Re-ordering so the guard reads pre-write-back (untrusted) policy_flags | hermes_job_executor.py execute(): :1521 before :1524 | `negative_control_method=synthetic_inverted_source_snippet`: an in-memory inverted source (guard before write-back) fails the same `wb<guard` check |
+
+---
+
+## 6. G1 Allowlist Rationale
+
+`PolicyFlags.from_dict` is the single untrusted-deserialization chokepoint; it
+LEGITIMATELY has multiple production callers, so a naive `count == 0` assertion
+would be WRONG (it would falsely fail). G1 therefore uses an ALLOWLIST keyed by
+`(production source file, enclosing function name)` resolved via AST:
+
+| Allowlisted caller | file:line | Why legitimate |
+|--------------------|-----------|----------------|
+| `FoundUpJob.__post_init__` | contract:461 | Coerces a dict policy_flags on object construction (routes through the sanitizing chokepoint) |
+| `FoundUpJob.from_dict` body | contract:662 | The deserialization entrypoint itself |
+| `_sanitize_untrusted_policy_flags_dict` | router:372 | The router trust-boundary sanitizer (#752) |
+
+Any PolicyFlags.from_dict call NOT in this allowlist TRIPS G1. The guard also
+asserts all three chokepoints are STILL present (so a silent removal/rename is
+caught), and pins the total production call count at 3. By contrast,
+`FoundUpJob.from_dict` has ZERO production callers (only tests call it), so it
+uses the strict count==0 form. AST excludes strings/comments/docstrings because
+only `ast.Call` nodes are inspected; tests/archives are excluded by path
+(`tests`, `test`, `archive`, `_archive`, `archived`, `__pycache__`).
+
+---
+
+## 7. Negative Control Methods Table (all SAFE - no committed mutation)
+
+| Guard | negative_control_method | Mechanism | Observed fail-when-inverted |
+|-------|-------------------------|-----------|------------------------------|
+| G1 | synthetic_source_string | In-memory source string parsed with `ast` | Extra `FoundUpJob.from_dict` CALL detected at line 4; comment + docstring + string-literal NOT counted (0 hits in the strings-only synthetic) |
+| G2 | monkeypatch_module_constant | `patch.object(gw, "FOUNDUP_JOB_VALIDATION_AVAILABLE", False)` | `assert ... is True` raises under the patch (pytest.raises) |
+| G3 | monkeypatch_function | `patch.object(gateway, "_verify_envelope", return_value=True)` | Forged envelope dispatches: `_invoke_core_dae.called is True` |
+| G4 | test_local_fake_dataclass_sanitizer | Fake sanitizer that preserves a True flag | Property assertion raises (pytest.raises) |
+| G5 | monkeypatch_module_constant | Healthy-env (no patch) contrast vs degraded (patched) | Healthy path takes the STRICT block branch (distinct validation_code), degraded path differs |
+| G6 | synthetic_inverted_source_snippet | In-memory inverted execute() source | `wb < guard` is False for the inverted snippet |
+
+NO production file was edited or committed to prove any guard trips. `git status
+--porcelain` showed no dirty production file at any point (verified after the
+synthetic negative controls).
+
+---
+
+## 8. Guard Failure Mode Matrix
+
+| Failure re-introduced | Guard that trips |
+|-----------------------|------------------|
+| New untrusted `FoundUpJob.from_dict` caller in production | G1 (count==0) |
+| New non-allowlisted `PolicyFlags.from_dict` caller | G1 (allowlist + count==3) |
+| A chokepoint silently removed/renamed | G1 (presence assertion) |
+| Envelope validator import breaks | G2 |
+| Sanitizer removed -> forged live envelope dispatches | G3 |
+| Gateway gains an execution-path import | G3 (no-import structural) |
+| New gate field not registered server-authored | G4 (membership) |
+| Sanitizer leaks a True gate flag (either path) | G4 (force-False, both paths) |
+| Router/contract sanitizers diverge on non-dry_run fields | G4 (consistency) |
+| Degraded mode escalates to dispatch on a FoundUpJob envelope | G5 |
+| Write-back re-ordered after the guard | G6 (static + behavioral) |
+
+---
+
+## 9. Production Caller Classification Table
+
+| Symbol | file:line | ast.Call? | In docstring/comment/string? | Classification |
+|--------|-----------|-----------|------------------------------|----------------|
+| PolicyFlags.from_dict | contract:461 | YES | no | PRODUCTION CALLER (allowlisted: __post_init__) |
+| PolicyFlags.from_dict | contract:662 | YES | no | PRODUCTION CALLER (allowlisted: from_dict body) |
+| PolicyFlags.from_dict | router:372 | YES | no | PRODUCTION CALLER (allowlisted: sanitizer) |
+| PolicyFlags.from_dict | router:354 | no | docstring | EXCLUDED |
+| PolicyFlags.from_dict | hermes:1167 | no | docstring | EXCLUDED |
+| PolicyFlags.from_dict | hermes:1517 | no | comment | EXCLUDED |
+| PolicyFlags.from_dict | contract:194 | no | comment | EXCLUDED |
+| PolicyFlags.from_dict | contract:305 | no | comment | EXCLUDED |
+| FoundUpJob.from_dict | (production) | - | - | ZERO production callers (tests only) |
+
+Production scan surface: `modules/**` + `holo_index/**`, excluding any path
+component in {tests, test, archive, _archive, archived, __pycache__}. The scan
+tolerates a UTF-8 BOM (`utf-8-sig`) and, for any file that still fails to parse,
+re-raises ONLY if that file's raw text contains the `<owner>.from_dict` token
+(so an unparseable file can never silently hide a caller).
+
+---
+
+## 10. Gateway No-Live-Execution Proof
+
+All G2/G3/G5 tests prove blocked-before-dispatch via mocks/spies; none starts
+WRE, a DAE, or Hermes, and none touches the network/model/process:
+
+- `route_to_dae` is async and driven by `asyncio.run`.
+- `_invoke_core_dae` and `_invoke_foundup_dae` (the ONLY doorways to DAE work)
+  are replaced with `AsyncMock`; tests assert `.called is False` on the block
+  path and assert the dispatch lands on a sentinel stub on the degraded-generic
+  path.
+- Structural proof (G3 `test_gateway_module_has_no_execution_path_imports`):
+  `dae_gateway.py` contains NONE of `route_foundup_job`, `HermesJobExecutor`,
+  `execute_foundup_job`, `hermes_job_executor` - the routing layer cannot reach
+  the FoundUpJob execution path regardless of routing outcome. Therefore even a
+  dispatching degraded-mode request cannot escalate to destructive execution.
+- G6's behavioral test uses `HermesJobExecutor(dry_run=True, ...)` with
+  `HERMES_DELEGATE_ENABLED=0` and `create_job(...)`; it asserts only relative
+  call ORDER (write-back before guard) and tolerates the bounded downstream
+  block. No live delegation, repo creation, or network call occurs. SQLite/file
+  handles are released via `gc.collect()` before temp cleanup (Windows).
+
+---
+
+## 11. Real Defect Escalation Decision
+
+No real current defect was exposed. All six guards PASS against origin/main @
+01eb327d9, and all 61 existing PolicyFlags-related tests continue to pass. The
+chain is closed as #755 concluded; these guards lock that closed state. No
+remediation slice is recommended at this time. (Had a guard exposed a defect,
+the rule was STOP + document + recommend a separate slice + do NOT weaken the
+guard - not exercised.)
+
+---
+
+## 12. foundup_job_consumer.py:27 - Deferred
+
+The NAVIGATION comment at `foundup_job_consumer.py:27` reads
+`-> Uses: hermes_foundup_job_executor.py (execute_foundup_job)`, but the actual
+production import at `:425-426` is `from ...wre_core.src.hermes_job_executor
+import execute_foundup_job` (a file named `hermes_foundup_job_executor.py` exists
+only under `modules/foundups/agent/src/`, which the consumer does NOT use). This
+is a doc-hygiene staleness (wrong filename in a nav breadcrumb). It is NOT
+load-bearing for any guard and is outside the security-guard scope, so it is
+DEFERRED rather than touched in this tests-only slice.
+
+---
+
+## 13. Test Results
+
+Focused (both new guard files):
+`python -m pytest <two new files> -q` -> 24 passed (14 + 10).
+
+Module suites:
+`python -m pytest modules/infrastructure/wre_core/tests
+modules/infrastructure/wre_core/wre_gateway/tests -q` ->
+1424 passed, 5 failed, 3 skipped, 2 xfailed.
+
+The 5 failures are PRE-EXISTING, environment/worktree artifacts unrelated to this
+slice, proven against a clean main checkout (all 5 PASS there):
+
+| Failing test | Root cause | Baseline (main checkout) |
+|--------------|-----------|--------------------------|
+| test_hxa16_real_hermes_delegate_adapter_safe_harness (x4) | `vendor/hermes-agent` is a git SUBMODULE not populated in the fresh worktree -> `vendor/hermes-agent/tools/delegate_tool.py` absent | PASS |
+| test_wre_skills_discovery::test_initialization | Asserts `repo_root.name == "Foundups-Agent"`; worktree dir is `w6-hxa-policyflags` | PASS |
+
+Not masked with skip/xfail (per scope). No production change required.
+Existing PolicyFlags suites re-run clean: 61 passed
+(`test_foundup_job_router_policyflags_boundary.py`,
+`test_hxa_policyflags_writeback_remediation.py`,
+`test_route_foundup_job_live_mode_gate.py`,
+`test_hxa24_capability_token_policyflags.py`).
+
+---
+
+## 14. Boundary Proof
+
+- GUARDS ONLY: no production `.py` modified (`git status --porcelain` shows only
+  the in-scope test/doc files and the new `wre_gateway/tests/` dir; never
+  `.claude/settings.local.json`).
+- No dependency added (`hypothesis` NOT used; stdlib `ast` / `itertools` /
+  `dataclasses` only).
+- No skip/xfail added; no network/model/live-DAE/WRE start.
+- Negative controls are 100% synthetic/in-memory (source strings, monkeypatch,
+  test-local fakes); no production file was edited or committed to prove a trip.
+- No WSP/registry/manifest/CI/config change. No CABR/payout/DAO touch.
+
+---
+
+## 15. Internal Review Verdict
+
+VERDICT: PASS. Six durable regression guards installed for the PolicyFlags trust
+chain (#746/#752/#753/#754), each with a proven, SAFE negative control
+(fail-when-inverted observed). The wre_gateway module gains its first tests/
+directory. No production code changed; no real defect exposed; the five module-
+suite failures are pre-existing worktree/submodule artifacts proven green on main.
+Chain remains CLOSED with CI coverage now in place.
+
+---
+
+## 16. WSP_97 Truth Boundary Checklist
+
+Declared items: 20 - Rows: 20 - All YES.
+
+| # | Truth Boundary Checklist Item | Status | Evidence |
+|---|-------------------------------|--------|----------|
+| 1 | GUARDS_ONLY_NO_PRODUCTION_CHANGE | YES | Sec 14; git status shows only test/doc files |
+| 2 | HOLOINDEX_UTILIZED | YES | Sec 3 (6 queries + top results cited) |
+| 3 | EACH_GUARD_NEGATIVE_CONTROL_PROVEN | YES | Sec 5, Sec 7; each fail-when-inverted observed |
+| 4 | G1_ALLOWLIST_CORRECT | YES | Sec 6 (3 callers: contract:461/662, router:372); FoundUpJob.from_dict=0 |
+| 5 | NO_HYPOTHESIS_DEP | YES | Sec 14; stdlib ast/itertools/dataclasses only |
+| 6 | NO_SKIP_XFAIL_ADDED | YES | Sec 13; no skip/xfail introduced |
+| 7 | GATEWAY_TESTS_CREATED | YES | new wre_gateway/tests/ (__init__ + G2/G3/G5 file) |
+| 8 | WRITEBACK_ORDERING_LOCKED | YES | G6 static (:1521<:1524) + behavioral spy |
+| 9 | REASONING_SUMMARY_NOT_PRIVATE_COT | YES | Sec 5 labeled Reasoning Summary; no private scratch reasoning |
+| 10 | NEGATIVE_CONTROLS_SAFE_NO_COMMITTED_MUTATION | YES | Sec 7; synthetic only; clean git status |
+| 11 | PRODUCTION_CALLER_SCAN_AST_BASED | YES | Sec 9; ast.Call walk, strings/comments excluded |
+| 12 | GATEWAY_TESTS_NO_LIVE_EXECUTION | YES | Sec 10; AsyncMock spies + no-import proof |
+| 13 | ROUTER_AND_CONTRACT_SANITIZER_CONSISTENCY_CHECKED | YES | G4 consistency test (router == contract for non-dry_run) |
+| 14 | REAL_DEFECTS_ESCALATED_NOT_PATCHED | YES | Sec 11; none found; rule documented |
+| 15 | CURRENT_MAIN_LINE_NUMBERS_REVERIFIED | YES | Sec 4; all anchors re-derived on 01eb327d9 |
+| 16 | NO_DEPENDENCY_CHANGE | YES | Sec 14; no requirements/deps touched |
+| 17 | NO_WSP_MUTATION | YES | No WSP file modified |
+| 18 | NO_CABR_READY | YES | Not touched |
+| 19 | NO_PAYOUT_READY | YES | Not touched |
+| 20 | NO_DAO_ACTIVATION | YES | Not touched |
+
+**WSP 97 Truth Boundary Checklist: 20/20 YES.**
+
+---
+
+*Authored by 0102 (Worker-Lane W6) under WSP_00 zen state and WSP_97 Truth
+Boundary discipline. Tests/guards-only capstone of the PolicyFlags trust chain
+named by #755. Base origin/main @ 01eb327d9. No production code authorized or
+changed.*

--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -2,6 +2,51 @@
 
 ## Chronological Change Log
 
+### [2026-06-03] - HXA_POLICYFLAGS_REGRESSION_GUARDS_PHASE1 (W6)
+
+**WSP Protocol References**: WSP 97 (Truth Boundary), WSP 50 (Pre-Action), WSP 22 (ModLog), WSP 5 (Coverage)
+**Predecessors**: #755 (router security chain closeout review, lane W9 - NAMED this guard slice as the
+outstanding work); #754 (route-gate live-mode discriminator); #753 (router boundary sanitize + Gate 2
+fail-closed); #752 (DAE gateway gate-flags trust-boundary audit); #746/#747 (PolicyFlags write-back-before-guard).
+**Impact Analysis**: TESTS/GUARDS ONLY. No production `.py` modified. CI-coverage capstone that locks the
+already-CLOSED PolicyFlags trust chain with 6 durable invariant guards. New `wre_gateway/tests/` directory
+(the module previously had none). No dependency/CI/WSP/registry/config change; no CABR/payout/DAO touch.
+
+**Guards added** (see `docs/audits/security/HXA_POLICYFLAGS_REGRESSION_GUARDS_PHASE1.md`):
+- G1 NO-PRODUCTION-CALLER INVARIANT (AST): `FoundUpJob.from_dict` prod callers = 0; every
+  `PolicyFlags.from_dict` prod caller in the 3-entry ALLOWLIST {contract:461 __post_init__, contract:662
+  from_dict body, router:372 sanitizer}. AST excludes strings/comments/docstrings (only `ast.Call` nodes);
+  tests/archives excluded by path; BOM-tolerant scan. NOT naive count==0 for PolicyFlags (it has 3 legit callers).
+- G4 SANITIZATION FUZZ (stdlib, DYNAMIC field enumeration): `dataclasses.fields(PolicyFlags)` at runtime;
+  all-True + `itertools.product` combos -> BOTH contract `from_dict().to_dict()` and router
+  `_sanitize_untrusted_policy_flags_dict` force every non-`dry_run_mode` field False; every such field in
+  `_SERVER_AUTHORED_FLAGS`; router/contract CONSISTENT.
+- G6 WRITE-BACK-BEFORE-GUARD ORDERING: static AST source-order (`_writeback_token_verdict` :1521 BEFORE
+  `_evaluate_destructive_action_guard` :1524 in `execute()`) AND behavioral spy on both (relative call order).
+- G2 GATEWAY VALIDATION AVAILABLE (test-only health, NOT a prod startup assert): `FOUNDUP_JOB_VALIDATION_AVAILABLE is True`.
+- G3 GATEWAY E2E D3 FAIL-CLOSED: forged live FoundUpJob envelope (`security_gate_passed=True` +
+  `dry_run_mode=False`) is BLOCKED, and `_invoke_core_dae`/`_invoke_foundup_dae` are NOT called
+  (blocked BEFORE dispatch); plus structural proof the gateway imports NO execution path.
+- G5 GATEWAY PERMISSIVE-FALLBACK: with `FOUNDUP_JOB_VALIDATION_AVAILABLE=False`, degraded behavior bounded
+  (FoundUpJob-shaped w/o objective still blocked; even a dispatching generic envelope reaches only the
+  pattern-recall stub, never route/execute).
+
+**Negative controls (SAFE, synthetic only - no production mutation)**: G1 synthetic source string; G2/G5
+monkeypatch module constant; G3 monkeypatch `_verify_envelope`; G4 test-local fake sanitizer; G6 synthetic
+inverted source snippet. Each proven fail-when-inverted. `git status --porcelain` clean of production files.
+
+**Real defect**: NONE found. All 6 guards pass on origin/main @ 01eb327d9; chain remains CLOSED.
+
+**Tests**: focused new files -> 24 passed (14 G1/G4/G6 + 10 G2/G3/G5). Full `wre_core/tests` +
+`wre_gateway/tests` -> 1424 passed, 5 failed (PRE-EXISTING, unrelated:
+`test_hxa16_real_hermes_delegate_adapter_safe_harness.py` x4 - `vendor/hermes-agent` SUBMODULE not
+populated in worktree; `test_wre_skills_discovery.py::test_initialization` - hardcoded repo dir name;
+all 5 PASS on a clean main checkout), 3 skipped, 2 xfailed. No skip/xfail added. Existing PolicyFlags
+suites re-run clean (61 passed).
+
+**Deferred**: nav-comment hygiene at `foundup_job_consumer.py:27` (wrong filename `hermes_foundup_job_executor.py`;
+actual import is `hermes_job_executor.execute_foundup_job`) - out of security-guard scope, not load-bearing.
+
 ### [2026-06-03] - FOUNDUP_JOB_ROUTER_ROUTE_GATE_LIVE_MODE_DISCRIMINATOR_PHASE1 (W6)
 
 **WSP Protocol References**: WSP 97 (Truth Boundary), WSP 50 (Pre-Action), WSP 22 (ModLog), WSP 5 (Coverage)

--- a/modules/infrastructure/wre_core/tests/TestModLog.md
+++ b/modules/infrastructure/wre_core/tests/TestModLog.md
@@ -1,5 +1,22 @@
 # TestModLog - wre_core/tests
 
+## 2026-06-03: HXA_POLICYFLAGS_REGRESSION_GUARDS_PHASE1 (W6)
+
+**Slice**: `HXA_POLICYFLAGS_REGRESSION_GUARDS_PHASE1` | **Predecessors**: #755 (named this slice), #754, #753, #752, #746/#747
+**Audit**: `docs/audits/security/HXA_POLICYFLAGS_REGRESSION_GUARDS_PHASE1.md`. TESTS/GUARDS ONLY; no production `.py` changed; no skip/xfail; NO network/model/live-DAE/WRE start; no dependency (stdlib `ast`/`itertools`/`dataclasses`; `hypothesis` NOT used).
+
+**New** `test_policyflags_regression_guards.py` (14 tests - G1, G4, G6):
+- `TestG1NoProductionCallerInvariant` (6): AST scan of `modules/**`+`holo_index/**` (excl. tests/archives/__pycache__; BOM-tolerant). `FoundUpJob.from_dict` prod callers = 0; every `PolicyFlags.from_dict` prod CALL in the allowlist {contract:461 __post_init__, contract:662 from_dict body, router:372 sanitizer}; total prod call count = 3; chokepoints still present. Negative controls: synthetic source string detects exactly the real CALL (line 4), excludes comment/docstring/string-literal.
+- `TestG4SanitizationFuzz` (6): dynamic `dataclasses.fields(PolicyFlags)` enumeration; every non-`dry_run_mode` field in `_SERVER_AUTHORED_FLAGS`; all-True + `itertools.product` combos -> contract `from_dict().to_dict()` AND router `_sanitize_untrusted_policy_flags_dict` force every non-dry_run field False and AGREE; documents router's safe `absent dry_run -> True` vs raw contract `False` divergence. Negative control: test-local fake leaky sanitizer fails the property.
+- `TestG6WriteBackBeforeGuardOrdering` (3): static AST source-order (`_writeback_token_verdict` :1521 < `_evaluate_destructive_action_guard` :1524 in `HermesJobExecutor.execute`) + behavioral spy (relative order via `create_job` + `HERMES_DELEGATE_ENABLED=0` + `dry_run=True`, gc.collect before temp cleanup). Negative control: synthetic inverted source snippet fails `wb<guard`.
+
+**New** `wre_gateway/tests/` directory (module had NONE): `__init__.py` + `test_dae_gateway_policyflags_guards.py` (10 tests - G2, G3, G5; `route_to_dae` driven via `asyncio.run`; `_invoke_core_dae`/`_invoke_foundup_dae` replaced with `AsyncMock`; NO live DAE/WRE/Hermes/network):
+- `TestG2GatewayValidationAvailable` (3): `FOUNDUP_JOB_VALIDATION_AVAILABLE is True` (test-only health). Negative control: monkeypatch False makes the `is True` check raise.
+- `TestG3GatewayFailClosedBeforeDispatch` (4): forged live FoundUpJob envelope BLOCKED with WSP 97 code; `_invoke_core_dae`/`_invoke_foundup_dae` NOT called; `violations_prevented` metric increments; structural no-execution-path-import proof. Negative control: monkeypatch `_verify_envelope`->True makes the SAME envelope dispatch (`_invoke_core_dae.called is True`).
+- `TestG5PermissiveFallbackBounded` (3): degraded (`FOUNDUP_JOB_VALIDATION_AVAILABLE=False`) FoundUpJob-shaped w/o objective still blocked; a dispatching generic envelope reaches ONLY the core stub (sentinel), never FoundUp dispatch/route/execute. Negative control: healthy-env contrast takes the STRICT block path.
+
+**Run**: focused (both new files) -> 24 passed (14 + 10). Full `wre_core/tests` + `wre_gateway/tests` -> 1424 passed, 5 failed, 3 skipped, 2 xfailed. The 5 failures are PRE-EXISTING worktree/submodule artifacts (same set noted in prior W6 entries): `test_hxa16_real_hermes_delegate_adapter_safe_harness.py` x4 (`vendor/hermes-agent` SUBMODULE not populated in the fresh worktree -> `delegate_tool.py` absent) and `test_wre_skills_discovery.py::test_initialization` (asserts repo dir name == "Foundups-Agent"; worktree dir is `w6-hxa-policyflags`). Proven on the main checkout: all 5 PASS. Not masked with skip/xfail; no production change required. Existing PolicyFlags suites re-run clean: 61 passed.
+
 ## 2026-06-03: FOUNDUP_JOB_ROUTER_ROUTE_GATE_LIVE_MODE_DISCRIMINATOR_PHASE1 (W6)
 
 **Slice**: `FOUNDUP_JOB_ROUTER_ROUTE_GATE_LIVE_MODE_DISCRIMINATOR_PHASE1` | **Predecessors**: #753 (deferred this sibling), #752, #744->#751

--- a/modules/infrastructure/wre_core/tests/test_policyflags_regression_guards.py
+++ b/modules/infrastructure/wre_core/tests/test_policyflags_regression_guards.py
@@ -1,0 +1,655 @@
+# -*- coding: utf-8 -*-
+"""
+PolicyFlags chain regression guards (Phase 1) - structural + behavioral CI guards.
+
+Slice: HXA_POLICYFLAGS_REGRESSION_GUARDS_PHASE1
+Worker-Lane: W6
+
+This module is the CI-coverage capstone named by the #755 router-security-chain
+closeout. It does NOT re-prove the per-slice behavior (that lives in the existing
+suites listed below); it installs durable INVARIANT guards that TRIP if a future
+edit silently re-opens a closed hole in the PolicyFlags trust chain (#746, #752,
+#754, #755).
+
+Guards in this file:
+  G1  NO-PRODUCTION-CALLER INVARIANT (AST-based, allowlist):
+        - FoundUpJob.from_dict has ZERO production callers.
+        - Every PolicyFlags.from_dict production caller is in the ALLOWLIST
+          {contract __post_init__, contract from_dict body,
+           router _sanitize_untrusted_policy_flags_dict}.
+        Strings/comments/docstrings are excluded because only ast.Call nodes are
+        counted; tests/archives are excluded by path.
+  G4  SANITIZATION FUZZ (stdlib, DYNAMIC field enumeration):
+        - dataclasses.fields(PolicyFlags) enumerated at runtime (no hardcoding).
+        - For all-True and itertools.product representative combos, BOTH
+          PolicyFlags.from_dict(...).to_dict() AND the router sanitizer force
+          every non-dry_run field False; every such field name is in
+          _SERVER_AUTHORED_FLAGS; router + contract sanitizers are CONSISTENT.
+  G6  WRITE-BACK-BEFORE-GUARD ORDERING:
+        - Static source-order check that _writeback_token_verdict precedes
+          _evaluate_destructive_action_guard inside HermesJobExecutor.execute.
+        - Behavioral mock call-order spy on both, asserting write-back precedes
+          guard.
+
+Predecessor chain (see audit doc HXA_POLICYFLAGS_REGRESSION_GUARDS_PHASE1.md):
+  #746 PolicyFlags write-back remediation (server-authored truth)
+  #752 router policy_flags boundary sanitization + Gate 2 fail-closed
+  #754 chain continuation
+  #755 router security chain closeout (named this capstone)
+
+Mirrors existing patterns:
+  test_foundup_job_router_policyflags_boundary.py
+  test_hxa_policyflags_writeback_remediation.py
+  test_route_foundup_job_live_mode_gate.py
+
+WSP Compliance:
+  WSP 5  : Test coverage (durable regression guards)
+  WSP 97 : Truthful, fail-closed assertions; no overclaims
+
+NO network / NO model / NO live DAE / NO WRE start. Pure structural + in-process
+unit guards. No production source is modified by this file.
+"""
+
+from __future__ import annotations
+
+import ast
+import itertools
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import dataclasses
+
+import pytest
+
+# Import via the FULL package path so class identity matches production imports.
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from modules.communication.moltbot_bridge.src.foundup_job_contract import (  # noqa: E402
+    PolicyFlags,
+    _SERVER_AUTHORED_FLAGS,
+)
+from modules.infrastructure.wre_core.src.foundup_job_router import (  # noqa: E402
+    _sanitize_untrusted_policy_flags_dict,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared AST helper: find ATTRIBUTE.from_dict CALL sites in a source file.
+# Only ast.Call nodes are inspected, so docstrings, comments, and string
+# literals that merely mention "from_dict" are never counted.
+# ---------------------------------------------------------------------------
+
+
+def _read_source(source_path: Path) -> str:
+    """Read a .py file tolerating a UTF-8 BOM (some repo files carry U+FEFF).
+
+    ``utf-8-sig`` strips a leading BOM so ``ast.parse`` does not choke on a
+    pre-existing non-printable char. We do NOT mutate the file - this is a
+    read-only normalization for parsing.
+    """
+    return source_path.read_text(encoding="utf-8-sig")
+
+
+def _find_from_dict_call_sites(
+    source_path: Path, owner_name: str
+) -> List[int]:
+    """Return line numbers of ``<owner_name>.from_dict(...)`` CALL expressions.
+
+    Parses the file with the stdlib ``ast`` module and walks for ``ast.Call``
+    nodes whose ``func`` is ``Attribute(value=Name(id=owner_name), attr='from_dict')``.
+    Strings / comments / docstrings cannot match because they are not Call nodes.
+    """
+    tree = ast.parse(_read_source(source_path), filename=str(source_path))
+    hits: List[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "from_dict"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == owner_name
+        ):
+            hits.append(node.lineno)
+    return hits
+
+
+def _enclosing_def_name(source_path: Path, lineno: int) -> str:
+    """Return the name of the innermost function/method enclosing ``lineno``.
+
+    Used to classify a PolicyFlags.from_dict call site against the allowlist by
+    the function it lives in (e.g. ``__post_init__``, ``from_dict``,
+    ``_sanitize_untrusted_policy_flags_dict``). Returns ``"<module>"`` if the
+    call is at module scope.
+    """
+    tree = ast.parse(_read_source(source_path), filename=str(source_path))
+    best_name = "<module>"
+    best_span = None
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            start = node.lineno
+            end = getattr(node, "end_lineno", start)
+            if start <= lineno <= end:
+                span = end - start
+                if best_span is None or span < best_span:
+                    best_span = span
+                    best_name = node.name
+    return best_name
+
+
+# Production source files (NOT tests, NOT archives).
+_CONTRACT_SRC = (
+    PROJECT_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "foundup_job_contract.py"
+)
+_ROUTER_SRC = (
+    PROJECT_ROOT
+    / "modules"
+    / "infrastructure"
+    / "wre_core"
+    / "src"
+    / "foundup_job_router.py"
+)
+_HERMES_SRC = (
+    PROJECT_ROOT
+    / "modules"
+    / "infrastructure"
+    / "wre_core"
+    / "src"
+    / "hermes_job_executor.py"
+)
+
+
+def _scan_owner_calls_safe(
+    src: Path, owner_name: str
+) -> List[int]:
+    """AST-scan ``src`` for ``owner_name.from_dict`` calls, tolerating bad files.
+
+    If a production file fails to parse for a reason unrelated to our target
+    (e.g. a pre-existing syntax error in some other module), we must NOT crash
+    the whole guard. But we also must NOT silently miss a real caller: if the
+    raw text of an unparseable file contains the ``owner_name.from_dict`` token,
+    we re-raise so the failure is visible. Files that don't even mention the
+    token are safely skipped.
+    """
+    try:
+        return _find_from_dict_call_sites(src, owner_name)
+    except SyntaxError:
+        raw = _read_source(src)
+        if f"{owner_name}.from_dict" in raw:
+            raise  # a potential caller hides in an unparseable file - surface it
+        return []
+
+
+def _production_source_files() -> List[Path]:
+    """Every production .py file under modules/ and holo_index/.
+
+    Excludes any path component named ``tests`` and any ``archive``/``_archive``
+    directory, plus ``__pycache__``. This is the production scan surface for G1.
+    """
+    roots = [PROJECT_ROOT / "modules", PROJECT_ROOT / "holo_index"]
+    excluded_parts = {"tests", "test", "archive", "_archive", "archived", "__pycache__"}
+    files: List[Path] = []
+    for root in roots:
+        if not root.exists():
+            continue
+        for path in root.rglob("*.py"):
+            parts = set(p.lower() for p in path.parts)
+            if parts & excluded_parts:
+                continue
+            files.append(path)
+    return files
+
+
+# ---------------------------------------------------------------------------
+# G1: NO-PRODUCTION-CALLER INVARIANT (AST-based, allowlist)
+# ---------------------------------------------------------------------------
+
+
+# Allowlist for PolicyFlags.from_dict production callers, keyed by (source file,
+# enclosing function name). These are the ONLY legitimate deserialization
+# chokepoints (#746 / #752). Any new production caller TRIPS G1.
+_POLICYFLAGS_FROM_DICT_ALLOWLIST = {
+    (_CONTRACT_SRC, "__post_init__"),  # contract:461 - FoundUpJob.__post_init__
+    (_CONTRACT_SRC, "from_dict"),      # contract:662 - FoundUpJob.from_dict body
+    (_ROUTER_SRC, "_sanitize_untrusted_policy_flags_dict"),  # router:372
+}
+
+
+class TestG1NoProductionCallerInvariant:
+    """G1: from_dict deserialization chokepoints are locked to the allowlist."""
+
+    def test_foundupjob_from_dict_has_zero_production_callers(self):
+        """FoundUpJob.from_dict must have ZERO production callers (only tests call it)."""
+        offenders: List[Tuple[str, int]] = []
+        for src in _production_source_files():
+            for lineno in _scan_owner_calls_safe(src, "FoundUpJob"):
+                offenders.append((str(src.relative_to(PROJECT_ROOT)), lineno))
+        assert offenders == [], (
+            "FoundUpJob.from_dict gained production caller(s) - the untrusted "
+            "deserialization path must only be exercised by tests. Offenders: "
+            f"{offenders}"
+        )
+
+    def test_policyflags_from_dict_callers_are_all_allowlisted(self):
+        """Every PolicyFlags.from_dict production CALL must be in the allowlist."""
+        found_callers: List[Tuple[Path, str, int]] = []
+        for src in _production_source_files():
+            for lineno in _scan_owner_calls_safe(src, "PolicyFlags"):
+                fn_name = _enclosing_def_name(src, lineno)
+                found_callers.append((src, fn_name, lineno))
+
+        # Every found caller must be allowlisted by (file, enclosing function).
+        non_allowlisted = [
+            (str(src.relative_to(PROJECT_ROOT)), fn_name, lineno)
+            for (src, fn_name, lineno) in found_callers
+            if (src, fn_name) not in _POLICYFLAGS_FROM_DICT_ALLOWLIST
+        ]
+        assert non_allowlisted == [], (
+            "PolicyFlags.from_dict gained a NON-allowlisted production caller. "
+            "Deserialization must route only through the 3 known chokepoints. "
+            f"Offenders: {non_allowlisted}"
+        )
+
+        # And the three known chokepoints must STILL be present (the guard would
+        # be vacuous if the calls were silently removed/renamed).
+        present_keys = {(src, fn_name) for (src, fn_name, _ln) in found_callers}
+        for key in _POLICYFLAGS_FROM_DICT_ALLOWLIST:
+            assert key in present_keys, (
+                "Expected PolicyFlags.from_dict chokepoint missing (refactor "
+                f"may have moved/removed it): {key[0].name}:{key[1]}. present={present_keys}"
+            )
+
+    def test_policyflags_from_dict_naive_count_would_be_wrong(self):
+        """Document why naive count==0 is INVALID for PolicyFlags.from_dict.
+
+        PolicyFlags.from_dict legitimately has multiple production callers; a
+        count==0 assertion would falsely fail. This guard pins the exact count
+        (3) so a silent ADD is still caught even though count!=0.
+        """
+        total = 0
+        for src in _production_source_files():
+            total += len(_scan_owner_calls_safe(src, "PolicyFlags"))
+        assert total == 3, (
+            "PolicyFlags.from_dict production call-site count changed (expected 3 "
+            f"allowlisted chokepoints, found {total}). Re-verify the allowlist."
+        )
+
+    # --- Negative controls (synthetic source strings; no production edit) ---
+
+    def test_g1_negative_control_synthetic_extra_caller_trips(self):
+        """SYNTHETIC: an extra FoundUpJob.from_dict caller is detected by the AST scan."""
+        synthetic = (
+            "def rogue(data):\n"
+            "    # a comment mentioning FoundUpJob.from_dict must NOT count\n"
+            "    '''docstring FoundUpJob.from_dict must NOT count'''\n"
+            "    return FoundUpJob.from_dict(data)\n"
+        )
+        tree = ast.parse(synthetic)
+        hits = []
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "from_dict"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "FoundUpJob"
+            ):
+                hits.append(node.lineno)
+        # Exactly one CALL detected (line 4); the comment + docstring are ignored.
+        assert hits == [4], (
+            "G1 negative control failed: AST scan should detect exactly the one "
+            f"real FoundUpJob.from_dict CALL, got {hits}"
+        )
+
+    def test_g1_negative_control_comment_and_docstring_excluded(self):
+        """SYNTHETIC: a file that ONLY mentions from_dict in strings/comments => 0 hits."""
+        synthetic = (
+            '"""module docstring: PolicyFlags.from_dict and FoundUpJob.from_dict"""\n'
+            "# inline comment PolicyFlags.from_dict\n"
+            "X = 'PolicyFlags.from_dict in a string literal'\n"
+        )
+        tree = ast.parse(synthetic)
+        hits = [
+            n.lineno
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Attribute)
+            and n.func.attr == "from_dict"
+        ]
+        assert hits == [], (
+            "G1 negative control failed: strings/comments must never be counted "
+            f"as callers, got {hits}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# G4: SANITIZATION FUZZ (stdlib, DYNAMIC field enumeration)
+# ---------------------------------------------------------------------------
+
+
+def _policyflags_field_names() -> List[str]:
+    """Runtime enumeration of PolicyFlags fields (NO hardcoded field list)."""
+    return [f.name for f in dataclasses.fields(PolicyFlags)]
+
+
+def _non_dry_run_fields() -> List[str]:
+    return [f for f in _policyflags_field_names() if f != "dry_run_mode"]
+
+
+class TestG4SanitizationFuzz:
+    """G4: every non-dry_run field is forced False by BOTH sanitizers."""
+
+    def test_field_enumeration_is_dynamic_and_nonempty(self):
+        """Sanity: fields are discovered at runtime, dry_run_mode is present."""
+        names = _policyflags_field_names()
+        assert "dry_run_mode" in names
+        assert len(names) >= 2  # at least dry_run_mode + one server-authored flag
+
+    def test_every_non_dry_run_field_is_server_authored(self):
+        """Structural invariant: each non-dry_run field name is in the frozenset.
+
+        This is the property that makes the sanitizers' 'force everything except
+        dry_run_mode to False' equivalent to 'force every _SERVER_AUTHORED_FLAGS
+        member to False'. If a new gate field is added WITHOUT registering it in
+        _SERVER_AUTHORED_FLAGS, this trips.
+        """
+        for name in _non_dry_run_fields():
+            assert name in _SERVER_AUTHORED_FLAGS, (
+                f"PolicyFlags field '{name}' is non-dry_run but NOT in "
+                "_SERVER_AUTHORED_FLAGS - a new field may have been added without "
+                "registering it as server-authored (sanitization hole)."
+            )
+
+    def test_all_true_inbound_dict_is_fully_sanitized_both_paths(self):
+        """All-True inbound dict: contract + router both zero every non-dry_run field."""
+        names = _policyflags_field_names()
+        all_true = {name: True for name in names}
+
+        contract_out = PolicyFlags.from_dict(all_true).to_dict()
+        router_out, _dry_defaulted = _sanitize_untrusted_policy_flags_dict(all_true)
+
+        for name in _non_dry_run_fields():
+            assert contract_out[name] is False, (
+                f"contract from_dict failed to zero '{name}' from all-True input"
+            )
+            assert router_out[name] is False, (
+                f"router sanitizer failed to zero '{name}' from all-True input"
+            )
+        # dry_run_mode=True is operator-authored and preserved on both paths.
+        assert contract_out["dry_run_mode"] is True
+        assert router_out["dry_run_mode"] is True
+
+    def test_product_combos_are_consistent_across_sanitizers(self):
+        """itertools.product over representative combos: router == contract for non-dry_run.
+
+        We fuzz dry_run_mode plus a representative subset of server-authored
+        fields (full 2**12 product would be wasteful). For each combo BOTH
+        sanitizers must agree on every non-dry_run field (all False), and on the
+        operator-authored dry_run_mode value when explicitly supplied.
+        """
+        non_dry = _non_dry_run_fields()
+        # Representative subset: span one of each gate family + a token field.
+        sampled = [
+            f
+            for f in (
+                "security_gate_passed",
+                "permission_gate_passed",
+                "exfoliation_gate_passed",
+                "wsp_preflight_passed",
+                "capability_token_validated",
+            )
+            if f in non_dry
+        ]
+        assert sampled, "expected representative server-authored fields to exist"
+
+        for dry in (True, False):
+            for combo in itertools.product([False, True], repeat=len(sampled)):
+                inbound: Dict[str, bool] = {"dry_run_mode": dry}
+                for fname, fval in zip(sampled, combo):
+                    inbound[fname] = fval
+
+                contract_out = PolicyFlags.from_dict(inbound).to_dict()
+                router_out, _dd = _sanitize_untrusted_policy_flags_dict(inbound)
+
+                for name in _non_dry_run_fields():
+                    assert contract_out[name] is False, (
+                        f"contract leaked '{name}'=True for inbound {inbound}"
+                    )
+                    assert router_out[name] is False, (
+                        f"router leaked '{name}'=True for inbound {inbound}"
+                    )
+                # Explicit dry_run_mode is preserved identically by both paths.
+                assert contract_out["dry_run_mode"] is dry
+                assert router_out["dry_run_mode"] is dry
+
+    def test_router_defaults_dry_run_true_when_absent_contract_does_not(self):
+        """Router restores safe dry_run default; contract from_dict yields False.
+
+        This documents the ONE intentional divergence: the router adds the safe
+        'absent => dry-run' default (so a missing flag is never treated live),
+        while raw contract from_dict yields dry_run_mode=False. Both still zero
+        every server-authored flag - the security-relevant behavior is identical.
+        """
+        inbound = {"security_gate_passed": True}  # no dry_run_mode key
+
+        contract_out = PolicyFlags.from_dict(inbound).to_dict()
+        router_out, dry_defaulted = _sanitize_untrusted_policy_flags_dict(inbound)
+
+        assert contract_out["security_gate_passed"] is False
+        assert router_out["security_gate_passed"] is False
+        assert contract_out["dry_run_mode"] is False  # raw from_dict
+        assert router_out["dry_run_mode"] is True      # router safe default
+        assert dry_defaulted is True
+
+    # --- Negative control (test-local fake dataclass; no production edit) ---
+
+    def test_g4_negative_control_leaky_sanitizer_is_caught(self):
+        """SYNTHETIC: a fake 'sanitizer' that leaks a True flag fails the property.
+
+        Proves the G4 assertion actually trips when the sanitization invariant is
+        violated, using a test-local fake (no production code touched).
+        """
+        def _leaky_sanitizer(inbound: Dict[str, bool]) -> Dict[str, bool]:
+            # Deliberately preserves security_gate_passed (the bug shape).
+            out = {name: False for name in _policyflags_field_names()}
+            out["dry_run_mode"] = bool(inbound.get("dry_run_mode", False))
+            out["security_gate_passed"] = bool(inbound.get("security_gate_passed", False))
+            return out
+
+        leaked = _leaky_sanitizer({"security_gate_passed": True, "dry_run_mode": False})
+
+        with pytest.raises(AssertionError):
+            for name in _non_dry_run_fields():
+                assert leaked[name] is False, f"leaked {name}"
+
+
+# ---------------------------------------------------------------------------
+# G6: WRITE-BACK-BEFORE-GUARD ORDERING
+# ---------------------------------------------------------------------------
+
+
+def _ordered_call_linenos_in_execute(method_name_a: str, method_name_b: str) -> Tuple[int, int]:
+    """Return (lineno_a, lineno_b) of self.<a>(...) and self.<b>(...) inside execute().
+
+    Uses AST to locate HermesJobExecutor.execute and find the FIRST self-method
+    call to each named method within it. Raises if either is absent.
+    """
+    tree = ast.parse(_HERMES_SRC.read_text(encoding="utf-8"), filename=str(_HERMES_SRC))
+
+    # Find the HermesJobExecutor.execute FunctionDef (the one taking a 'job' arg,
+    # not the DAE-plugin execute(input_data)).
+    execute_nodes = []
+    for cls in ast.walk(tree):
+        if isinstance(cls, ast.ClassDef) and cls.name == "HermesJobExecutor":
+            for item in cls.body:
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)) and item.name == "execute":
+                    execute_nodes.append(item)
+    assert len(execute_nodes) == 1, (
+        f"expected exactly one HermesJobExecutor.execute, found {len(execute_nodes)}"
+    )
+    execute = execute_nodes[0]
+
+    line_a = None
+    line_b = None
+    for node in ast.walk(execute):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            attr = node.func
+            # self.<method>(...)
+            if isinstance(attr.value, ast.Name) and attr.value.id == "self":
+                if attr.attr == method_name_a and line_a is None:
+                    line_a = node.lineno
+                if attr.attr == method_name_b and line_b is None:
+                    line_b = node.lineno
+    assert line_a is not None, f"{method_name_a} call not found in execute()"
+    assert line_b is not None, f"{method_name_b} call not found in execute()"
+    return line_a, line_b
+
+
+class TestG6WriteBackBeforeGuardOrdering:
+    """G6: validator write-back must precede the destructive-action guard (#746)."""
+
+    def test_static_source_order_writeback_precedes_guard(self):
+        """Static AST source-order: _writeback_token_verdict before guard in execute()."""
+        wb_line, guard_line = _ordered_call_linenos_in_execute(
+            "_writeback_token_verdict",
+            "_evaluate_destructive_action_guard",
+        )
+        assert wb_line < guard_line, (
+            "ORDERING REGRESSION: _writeback_token_verdict must be called BEFORE "
+            f"_evaluate_destructive_action_guard in execute() (write-back line "
+            f"{wb_line} >= guard line {guard_line}). Server-authored token truth "
+            "must be written before the guard reads policy_flags."
+        )
+
+    def test_g6_negative_control_inverted_source_trips(self):
+        """SYNTHETIC: an inverted source snippet (guard before write-back) is caught.
+
+        Builds a synthetic in-memory source where the guard call precedes the
+        write-back, runs the SAME ordering logic against it, and asserts the
+        order check fails. No production file is edited.
+        """
+        inverted_src = (
+            "class HermesJobExecutor:\n"
+            "    def execute(self, job):\n"
+            "        # INVERTED (defect shape): guard BEFORE write-back\n"
+            "        guard_result = self._evaluate_destructive_action_guard(job, None)\n"
+            "        self._writeback_token_verdict(job, None)\n"
+            "        return guard_result\n"
+        )
+        tree = ast.parse(inverted_src)
+        execute = None
+        for cls in ast.walk(tree):
+            if isinstance(cls, ast.ClassDef) and cls.name == "HermesJobExecutor":
+                for item in cls.body:
+                    if isinstance(item, ast.FunctionDef) and item.name == "execute":
+                        execute = item
+        assert execute is not None
+
+        wb_line = guard_line = None
+        for node in ast.walk(execute):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "self"
+            ):
+                if node.func.attr == "_writeback_token_verdict" and wb_line is None:
+                    wb_line = node.lineno
+                if node.func.attr == "_evaluate_destructive_action_guard" and guard_line is None:
+                    guard_line = node.lineno
+
+        # In the inverted source the write-back does NOT precede the guard:
+        assert not (wb_line < guard_line), (
+            "G6 negative control failed: inverted source should NOT satisfy "
+            f"write-back<guard (wb={wb_line}, guard={guard_line})"
+        )
+
+    def test_behavioral_writeback_precedes_guard_via_spy(self):
+        """Behavioral: spy both methods, assert write-back is invoked before guard.
+
+        Drives HermesJobExecutor.execute on a D-class job with spies installed on
+        _writeback_token_verdict and _evaluate_destructive_action_guard. We assert
+        the RELATIVE call order only (write-back recorded before guard). No
+        network / model / live delegation occurs - the guard blocks dry-run
+        bounded execution, and we never reach real delegation.
+        """
+        import os
+        import shutil
+        import tempfile
+        from unittest.mock import patch
+
+        from modules.infrastructure.wre_core.src.hermes_job_executor import (
+            HermesJobExecutor,
+        )
+        from modules.communication.moltbot_bridge.src.foundup_job_contract import (
+            create_job,
+        )
+        from modules.infrastructure.wre_core.src.capability_token_validator import (
+            LocalCapabilityTokenValidator,
+        )
+
+        call_order: List[str] = []
+
+        tmpdir = tempfile.mkdtemp(prefix="g6_writeback_order_")
+        try:
+            # dry_run=True + HERMES_DELEGATE_ENABLED=0 -> bounded, no live delegate.
+            executor = HermesJobExecutor(
+                dry_run=True,
+                workspace_root=tmpdir,
+                token_validator=LocalCapabilityTokenValidator(),
+            )
+
+            real_writeback = executor._writeback_token_verdict
+            real_guard = executor._evaluate_destructive_action_guard
+
+            def spy_writeback(*args, **kwargs):
+                call_order.append("writeback")
+                return real_writeback(*args, **kwargs)
+
+            def spy_guard(*args, **kwargs):
+                call_order.append("guard")
+                return real_guard(*args, **kwargs)
+
+            # A job WITHOUT a real capability token: write-back zeroes the token
+            # verdict (server-authored), then the guard evaluates and (for a
+            # destructive class) blocks. We only assert ordering, not the verdict.
+            job = create_job(
+                tenant_id="tenant_g6",
+                requested_action="build_foundup",  # D3 destructive class
+                foundup_id="gotjunk",
+            )
+
+            with patch.dict(os.environ, {"HERMES_DELEGATE_ENABLED": "0"}), \
+                 patch.object(executor, "_writeback_token_verdict", side_effect=spy_writeback), \
+                 patch.object(executor, "_evaluate_destructive_action_guard", side_effect=spy_guard):
+                try:
+                    executor.execute(job)
+                except Exception:
+                    # Ordering is the contract under test; downstream bounded
+                    # failures (no live delegation) do not invalidate call order.
+                    pass
+
+            assert "writeback" in call_order, (
+                "execute() did not call _writeback_token_verdict at all"
+            )
+            assert "guard" in call_order, (
+                "execute() did not call _evaluate_destructive_action_guard at all"
+            )
+            assert call_order.index("writeback") < call_order.index("guard"), (
+                "ORDERING REGRESSION (behavioral): write-back must be invoked "
+                f"before the guard. Observed order: {call_order}"
+            )
+        finally:
+            import gc
+
+            gc.collect()  # release SQLite/file handles before cleanup (Windows)
+            shutil.rmtree(tmpdir, ignore_errors=True)

--- a/modules/infrastructure/wre_core/wre_gateway/tests/__init__.py
+++ b/modules/infrastructure/wre_core/wre_gateway/tests/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+"""Tests for the WRE DAE gateway (wre_gateway).
+
+Created by HXA_POLICYFLAGS_REGRESSION_GUARDS_PHASE1 (W6): the wre_gateway module
+previously had no tests/ directory. These are gateway-boundary guards only - no
+live DAE / WRE / Hermes execution.
+"""

--- a/modules/infrastructure/wre_core/wre_gateway/tests/test_dae_gateway_policyflags_guards.py
+++ b/modules/infrastructure/wre_core/wre_gateway/tests/test_dae_gateway_policyflags_guards.py
@@ -1,0 +1,308 @@
+# -*- coding: utf-8 -*-
+"""
+DAE Gateway PolicyFlags regression guards (Phase 1).
+
+Slice: HXA_POLICYFLAGS_REGRESSION_GUARDS_PHASE1
+Worker-Lane: W6
+
+Gateway-boundary guards for the PolicyFlags trust chain. The wre_gateway module
+had NO tests/ directory before this slice; these are the first gateway tests.
+
+Guards in this file:
+  G2  GATEWAY VALIDATION AVAILABLE (test-only health check, NOT a production
+        startup assertion): importing dae_gateway in a healthy env yields
+        FOUNDUP_JOB_VALIDATION_AVAILABLE is True (the WSP 97 envelope validator
+        import succeeded).
+  G3  GATEWAY E2E D3 FAIL-CLOSED: route_to_dae with a FOUNDUP_JOB-typed envelope
+        carrying FORGED security_gate_passed=True + dry_run_mode=False is
+        BLOCKED, and (via spies) _invoke_core_dae / _invoke_foundup_dae are NOT
+        called - the request is rejected BEFORE any DAE dispatch. No live /
+        network / model / process.
+  G5  GATEWAY PERMISSIVE-FALLBACK GUARD: with FOUNDUP_JOB_VALIDATION_AVAILABLE
+        monkeypatched False, degraded behavior is known/bounded: a FoundUpJob-
+        shaped envelope lacking 'objective' is still blocked, and even a generic
+        envelope that DOES dispatch in degraded mode reaches only the pattern-
+        recall stubs - never route_foundup_job / Hermes execute / destructive
+        execution (the gateway module does not import or call those at all).
+
+Blocked-before-dispatch is proven with mocks/spies on the two dispatch methods;
+no test starts WRE/DAE/Hermes or touches the network. route_to_dae is async, so
+each test drives it with asyncio.run.
+
+Mirrors existing patterns:
+  test_foundup_job_router_policyflags_boundary.py (forged-flag fail-closed)
+  test_route_foundup_job_live_mode_gate.py (live-mode gate semantics)
+
+WSP Compliance:
+  WSP 5  : Test coverage for the gateway boundary
+  WSP 97 : Truthful, fail-closed assertions
+
+NO network / NO model / NO live DAE / NO WRE start.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# Import via the FULL package path so class identity matches production imports.
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from modules.infrastructure.wre_core.wre_gateway.src import dae_gateway as gw  # noqa: E402
+from modules.infrastructure.wre_core.wre_gateway.src.dae_gateway import (  # noqa: E402
+    DAEGateway,
+    FOUNDUP_JOB_VALIDATION_AVAILABLE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _forged_live_foundup_job_envelope() -> Dict[str, Any]:
+    """A FOUNDUP_JOB-typed envelope with a FORGED passing security gate in live mode.
+
+    Has >=2 FoundUpJob signature fields (job_id, foundup_id, tenant_id,
+    requested_action) so detect_envelope_type classifies it as FOUNDUP_JOB. It
+    self-asserts security_gate_passed=True and requests live mode
+    (dry_run_mode=False). The router boundary sanitizes the forged flag to False,
+    so live-mode gate validation must FAIL closed and the gateway must block.
+    """
+    return {
+        "job_id": "forged_g3_001",
+        "foundup_id": "gotjunk",
+        "tenant_id": "tenant_attacker",
+        "requested_action": "build_foundup",
+        "policy_flags": {
+            "security_gate_passed": True,   # forged - sanitized to False upstream
+            "permission_gate_passed": True,  # forged - sanitized to False upstream
+            "dry_run_mode": False,           # explicit live mode request
+        },
+        "evidence_refs": ["manifest.json"],
+        "compute_budget": 5000,
+    }
+
+
+# ---------------------------------------------------------------------------
+# G2: GATEWAY VALIDATION AVAILABLE (test-only health check)
+# ---------------------------------------------------------------------------
+
+
+class TestG2GatewayValidationAvailable:
+    """G2: the WSP 97 envelope validator import is wired in a healthy env."""
+
+    def test_foundup_job_validation_available_is_true(self):
+        """In a healthy env the validator import succeeded.
+
+        This is a TEST-ONLY health assertion (it guards against the envelope
+        validator import silently breaking, which would degrade the gateway to
+        permissive validation). It is NOT a production startup assertion - the
+        gateway intentionally degrades rather than crashing (see G5).
+        """
+        assert FOUNDUP_JOB_VALIDATION_AVAILABLE is True, (
+            "FOUNDUP_JOB_VALIDATION_AVAILABLE is False - the WSP 97 envelope "
+            "validator import in dae_gateway failed; the gateway would fall back "
+            "to permissive validation. Investigate the import in dae_gateway.py."
+        )
+
+    def test_module_level_flag_matches_imported_flag(self):
+        """The module attribute and the imported name agree (no shadowing)."""
+        assert gw.FOUNDUP_JOB_VALIDATION_AVAILABLE is FOUNDUP_JOB_VALIDATION_AVAILABLE
+
+    def test_g2_negative_control_flag_false_would_fail(self):
+        """SYNTHETIC negative control: when the flag is False, the G2 check fails.
+
+        Monkeypatch the module flag to False and assert the same health condition
+        the guard relies on no longer holds - proving G2 is non-vacuous. No
+        production state is mutated beyond the test-scoped patch.
+        """
+        with patch.object(gw, "FOUNDUP_JOB_VALIDATION_AVAILABLE", False):
+            assert gw.FOUNDUP_JOB_VALIDATION_AVAILABLE is False
+            with pytest.raises(AssertionError):
+                assert gw.FOUNDUP_JOB_VALIDATION_AVAILABLE is True
+
+
+# ---------------------------------------------------------------------------
+# G3: GATEWAY E2E D3 FAIL-CLOSED (blocked BEFORE dispatch)
+# ---------------------------------------------------------------------------
+
+
+class TestG3GatewayFailClosedBeforeDispatch:
+    """G3: forged live FoundUpJob envelope blocked before any DAE dispatch."""
+
+    def test_forged_security_gate_live_envelope_is_blocked(self):
+        """route_to_dae returns a validation error for the forged live envelope."""
+        gateway = DAEGateway()
+        envelope = _forged_live_foundup_job_envelope()
+
+        # Spy/mocks on BOTH dispatch methods so we can prove non-invocation AND
+        # that nothing downstream (executor/Hermes) is reached - the dispatch
+        # methods are the only doorway to any DAE work.
+        with patch.object(gateway, "_invoke_core_dae", new=AsyncMock()) as mock_core, \
+             patch.object(gateway, "_invoke_foundup_dae", new=AsyncMock()) as mock_foundup:
+            result = asyncio.run(gateway.route_to_dae("infrastructure", envelope))
+
+        # Blocked: a WSP 97 validation error is returned, not a DAE response.
+        assert "error" in result, f"expected block, got dispatch result: {result}"
+        assert result.get("envelope_type") == "foundup_job"
+        # Fail-closed because the forged security gate was sanitized to False.
+        assert result.get("validation_code") in (
+            "LIVE_MODE_REQUIRES_SECURITY_GATE",
+            "LIVE_MODE_REQUIRES_HUMAN_APPROVAL",
+        ), f"unexpected validation_code: {result.get('validation_code')}"
+
+        # Blocked BEFORE dispatch: neither core nor FoundUp DAE was invoked.
+        assert mock_core.called is False, (
+            "_invoke_core_dae was called - forged envelope reached DAE dispatch!"
+        )
+        assert mock_foundup.called is False, (
+            "_invoke_foundup_dae was called - forged envelope reached DAE dispatch!"
+        )
+
+    def test_violations_prevented_metric_incremented_on_block(self):
+        """The block path increments violations_prevented (observability)."""
+        gateway = DAEGateway()
+        envelope = _forged_live_foundup_job_envelope()
+        before = gateway.metrics["violations_prevented"]
+
+        with patch.object(gateway, "_invoke_core_dae", new=AsyncMock()), \
+             patch.object(gateway, "_invoke_foundup_dae", new=AsyncMock()):
+            asyncio.run(gateway.route_to_dae("infrastructure", envelope))
+
+        assert gateway.metrics["violations_prevented"] == before + 1
+
+    def test_g3_negative_control_broken_verify_would_dispatch(self):
+        """SYNTHETIC negative control: a broken _verify_envelope DOES dispatch.
+
+        Proves the G3 'not called' assertion is non-vacuous. We monkeypatch
+        _verify_envelope to return True (simulating a removed/broken sanitizer);
+        the SAME forged envelope then reaches _invoke_core_dae. No production
+        code is edited - the bypass is a test-local monkeypatch only.
+        """
+        gateway = DAEGateway()
+        envelope = _forged_live_foundup_job_envelope()
+        sentinel = {"dispatched": True}
+
+        with patch.object(gateway, "_verify_envelope", return_value=True), \
+             patch.object(
+                 gateway, "_invoke_core_dae", new=AsyncMock(return_value=sentinel)
+             ) as mock_core, \
+             patch.object(gateway, "_invoke_foundup_dae", new=AsyncMock()) as mock_foundup:
+            result = asyncio.run(gateway.route_to_dae("infrastructure", envelope))
+
+        # With the guard broken, the forged envelope DOES reach dispatch.
+        assert result == sentinel
+        assert mock_core.called is True
+        assert mock_foundup.called is False
+
+    def test_gateway_module_has_no_execution_path_imports(self):
+        """Structural: the gateway never imports the FoundUpJob execution path.
+
+        Proves blocked-before-dispatch is also blocked-before-EXECUTION: the
+        gateway module does not import route_foundup_job, HermesJobExecutor, or
+        execute_foundup_job, so no gateway code path can reach destructive
+        execution regardless of routing.
+        """
+        source = Path(gw.__file__).read_text(encoding="utf-8-sig")
+        for forbidden in (
+            "route_foundup_job",
+            "HermesJobExecutor",
+            "execute_foundup_job",
+            "hermes_job_executor",
+        ):
+            assert forbidden not in source, (
+                f"dae_gateway.py references '{forbidden}' - the gateway must not "
+                "import the FoundUpJob execution path (no live execution from the "
+                "routing layer)."
+            )
+
+
+# ---------------------------------------------------------------------------
+# G5: GATEWAY PERMISSIVE-FALLBACK GUARD (degraded behavior is bounded)
+# ---------------------------------------------------------------------------
+
+
+class TestG5PermissiveFallbackBounded:
+    """G5: with validation unavailable, degraded behavior stays bounded."""
+
+    def test_degraded_foundupjob_without_objective_is_blocked(self):
+        """Validation unavailable: a FoundUpJob-shaped envelope w/o 'objective' is blocked.
+
+        Permissive validation requires 'objective'. A FoundUpJob-shaped envelope
+        omits it, so even in the degraded path it is rejected before dispatch.
+        """
+        gateway = DAEGateway()
+        envelope = _forged_live_foundup_job_envelope()  # no 'objective' field
+
+        with patch.object(gw, "FOUNDUP_JOB_VALIDATION_AVAILABLE", False), \
+             patch.object(gateway, "_invoke_core_dae", new=AsyncMock()) as mock_core, \
+             patch.object(gateway, "_invoke_foundup_dae", new=AsyncMock()) as mock_foundup:
+            result = asyncio.run(gateway.route_to_dae("infrastructure", envelope))
+
+        assert "error" in result, f"degraded path should block, got: {result}"
+        assert mock_core.called is False
+        assert mock_foundup.called is False
+
+    def test_degraded_dispatch_reaches_only_pattern_recall_stub(self):
+        """Validation unavailable + valid generic envelope: dispatch reaches ONLY the stub.
+
+        This is the bounded-degradation proof: even when permissive validation
+        passes (envelope has 'objective') and the request DOES dispatch, it lands
+        on the _invoke_core_dae pattern-recall stub. The gateway never calls
+        route_foundup_job / Hermes execute / destructive execution (verified
+        structurally in G3's no-import test), so degraded mode cannot escalate to
+        live execution.
+        """
+        gateway = DAEGateway()
+        # Generic envelope that passes permissive validation (objective present).
+        # It carries forged gate flags, but the gateway routing layer never
+        # consumes them for execution.
+        envelope = {
+            "objective": "do something",
+            "job_id": "degraded_g5_001",
+            "foundup_id": "gotjunk",
+            "policy_flags": {"security_gate_passed": True, "dry_run_mode": False},
+        }
+
+        sentinel = {"dae": "infrastructure", "stub": True}
+        with patch.object(gw, "FOUNDUP_JOB_VALIDATION_AVAILABLE", False), \
+             patch.object(
+                 gateway, "_invoke_core_dae", new=AsyncMock(return_value=sentinel)
+             ) as mock_core, \
+             patch.object(gateway, "_invoke_foundup_dae", new=AsyncMock()) as mock_foundup:
+            result = asyncio.run(gateway.route_to_dae("infrastructure", envelope))
+
+        # Reached the core DAE stub (and ONLY the stub) - no FoundUp dispatch.
+        assert result == sentinel
+        assert mock_core.called is True
+        assert mock_foundup.called is False
+
+    def test_g5_negative_control_healthy_env_blocks_forged_live(self):
+        """SYNTHETIC negative control: when validation IS available, the forged
+
+        live envelope is blocked by the STRICT path (contrast with the degraded
+        path). Proves the monkeypatch in the other G5 tests is what changes
+        behavior - i.e. the guard is sensitive to the FOUNDUP_JOB_VALIDATION_
+        AVAILABLE flag and not vacuously passing.
+        """
+        gateway = DAEGateway()
+        envelope = _forged_live_foundup_job_envelope()
+
+        # No monkeypatch: validation available -> strict block with WSP 97 code.
+        with patch.object(gateway, "_invoke_core_dae", new=AsyncMock()) as mock_core, \
+             patch.object(gateway, "_invoke_foundup_dae", new=AsyncMock()) as mock_foundup:
+            result = asyncio.run(gateway.route_to_dae("infrastructure", envelope))
+
+        assert result.get("envelope_type") == "foundup_job"
+        assert "validation_code" in result
+        assert mock_core.called is False
+        assert mock_foundup.called is False


### PR DESCRIPTION
## Summary

CI-coverage capstone named by the #755 router-security-chain closeout review ("the only outstanding work is CI regression guards (slice HXA_POLICYFLAGS_REGRESSION_GUARDS_PHASE1)"). Installs six durable invariant guards that TRIP if a future edit silently re-opens a closed hole in the PolicyFlags trust chain (#746 / #752 / #753 / #754). The chain is already CLOSED; this slice locks it with CI coverage.

**TESTS / GUARDS ONLY** - no production `.py` modified. No real defect was exposed.

## Guards

- **G1 NO-PRODUCTION-CALLER INVARIANT (AST)** - `FoundUpJob.from_dict` prod callers = 0; every `PolicyFlags.from_dict` prod CALL in the 3-entry allowlist {contract:461 `__post_init__`, contract:662 `from_dict` body, router:372 sanitizer}. Strings/comments/docstrings excluded (only `ast.Call` nodes); tests/archives excluded by path; BOM-tolerant. NOT naive count==0 for PolicyFlags (it has 3 legit callers).
- **G2 GATEWAY VALIDATION AVAILABLE** - test-only health check that `FOUNDUP_JOB_VALIDATION_AVAILABLE is True` (NOT a prod startup assert).
- **G3 GATEWAY E2E D3 FAIL-CLOSED** - forged live FoundUpJob envelope (`security_gate_passed=True` + `dry_run_mode=False`) BLOCKED, and `_invoke_core_dae`/`_invoke_foundup_dae` NOT called (blocked BEFORE dispatch); plus structural proof the gateway imports no execution path.
- **G4 SANITIZATION FUZZ (stdlib, dynamic enumeration)** - `dataclasses.fields(PolicyFlags)` at runtime; all-True + `itertools.product` combos -> both contract `from_dict().to_dict()` and router `_sanitize_untrusted_policy_flags_dict` force every non-`dry_run_mode` field False; router/contract CONSISTENT.
- **G5 GATEWAY PERMISSIVE-FALLBACK** - with validation unavailable, degraded behavior is bounded (cannot escalate to route/execute).
- **G6 WRITE-BACK-BEFORE-GUARD ORDERING** - static AST source-order (`_writeback_token_verdict` :1521 before `_evaluate_destructive_action_guard` :1524) + behavioral call-order spy.

New `wre_gateway/tests/` directory (the module previously had none).

## Negative controls (SAFE - synthetic only)

Each guard proven fail-when-inverted using synthetic source strings, monkeypatched module constants/functions, and test-local fakes. No production file was edited or committed to prove a trip; `git status` clean of production files.

## Tests

- Focused (both new files): **24 passed** (14 G1/G4/G6 + 10 G2/G3/G5).
- Full `wre_core/tests` + `wre_gateway/tests`: **1424 passed**, 5 failed, 3 skipped, 2 xfailed.
- The 5 failures are **PRE-EXISTING worktree/submodule artifacts** unrelated to this slice (`vendor/hermes-agent` submodule not populated in the worktree; a hardcoded repo-dir-name assertion) - **all 5 PASS on a clean main checkout**. Not masked with skip/xfail.
- Existing PolicyFlags suites re-run clean: **61 passed**.

No dependency added (`hypothesis` not used). No WSP/registry/CI/config change. No CABR/payout/DAO touch.

Audit: `docs/audits/security/HXA_POLICYFLAGS_REGRESSION_GUARDS_PHASE1.md`

Worker-Lane: W6
Slice: HXA_POLICYFLAGS_REGRESSION_GUARDS_PHASE1

🤖 Generated with [Claude Code](https://claude.com/claude-code)