### PR TITLE
fix(main): bootstrap DAE launch specs in run_headless before supervisor cycle (dry-run Phase 1)

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -1,5 +1,39 @@
 # FoundUps Agent - Development Log
 
+## [2026-06-07] Headless Bootstrap Seam Fix - WRE/OpenClaw/Hermes Dry-Run (W6)
+
+**Change Type**: Minimal remediation + characterization tests
+**By**: 0102 (Worker-Lane W6)
+**WSP References**: WSP 00, WSP 15, WSP 22, WSP 84, WSP 97
+**Slice**: `WRE_OPENCLAW_HERMES_AUTONOMOUS_BUILD_DRYRUN_PHASE1`
+
+**Root cause**: `main.py --headless` routes to `run_headless()` (L1414-1415), bypassing
+`main()`, so `bootstrap_runtime_dae_launches()` (called only from `main()` L1260) never ran.
+`run_headless` built a FRESH empty `DAELaunchBroker()` -> the supervisor's `_observe` saw
+`registered=False` and `_triage` escalated `openclaw_runtime_not_registered` every cycle
+(dead-loop, no plan/execute).
+
+**Fix (main.py, thin router preserved)**: `run_headless` now reuses
+`bootstrap_runtime_dae_launches()` (no duplicated specs) and consumes the shared singleton
+`get_dae_launch_broker()`. It sets dry-run-safe `setdefault` defaults
+(`OPENCLAW_RESIDENT_AUTOSTART`/`OPENCLAW_SUPERVISOR_AUTOSTART`/`OPENCLAW_SUPERVISOR_ALLOW_RESTART`
+= "0") so one cycle registers specs yet launches no live service (triage escalates
+`resident_openclaw_down_restart_disabled` instead of `start_openclaw`). Operator opts into live
+autonomy via the existing env flags.
+
+**Proven (HEADLESS_BOOTSTRAP_SEAM_FIXED)**: 9 passing tests in `tests/test_main_runtime_bootstrap.py`
+(bootstrap-before-cycle order, fail-closed WRE gate, no-live-execution, restart-disabled guard).
+All heavy seams mocked; no live process/network/model/OAuth/Docker/GitHub-write.
+
+**Honest scope (WSP 97)**: bounded one-cycle dry-run only - NOT continuous autonomy. The
+FoundUp->Hermes dry-run is a verified but SEPARATE seam (via `run_wre.py`/`FoundUpJobConsumer`),
+NOT wired into the headless supervisor loop. FoundUp coverage: 11/16 HAS_TESTS, 5 NO_TEST_COVERAGE.
+Pre-existing `test_openclaw_supervisor_p0.py` failure verified on clean main (out of scope).
+Full audit: `docs/audits/architecture/WRE_OPENCLAW_HERMES_AUTONOMOUS_BUILD_DRYRUN_PHASE1.md`.
+Next: `WRE_HEADLESS_BOOTSTRAP_W10_GATE`, `FOUNDUP_AUTO_TEST_MATRIX_COVERAGE_PHASE1`. WSP_97: 22/22 YES.
+
+---
+
 ## [2026-06-03] Worktree Stranded-Work Removal - Execution Phase 1 (W6)
 
 **Change Type**: Maintenance / Controlled Destructive (worktree removal only)

--- a/docs/audits/architecture/WRE_OPENCLAW_HERMES_AUTONOMOUS_BUILD_DRYRUN_PHASE1.md
+++ b/docs/audits/architecture/WRE_OPENCLAW_HERMES_AUTONOMOUS_BUILD_DRYRUN_PHASE1.md
@@ -1,0 +1,232 @@
+# WRE_OPENCLAW_HERMES_AUTONOMOUS_BUILD_DRYRUN_PHASE1
+
+**Slice:** WRE_OPENCLAW_HERMES_AUTONOMOUS_BUILD_DRYRUN_PHASE1
+**Worker-Lane:** W6
+**Author:** 0102 (WSP_00 zen state, WSP_97 Truth Boundary discipline)
+**Type:** code/test characterization + minimal remediation (headless bootstrap seam).
+
+---
+
+## 1. Mission
+
+Prove the repo can run a BOUNDED ONE-CYCLE dry-run of the headless autonomous seam through
+the real WRE/OpenClaw/Hermes surfaces, and fix the headless bootstrap seam if broken. This is
+NOT a claim of continuous autonomous coding, NOT a second orchestration layer, and NOT an
+end-to-end live build. Where a part is mocked, it is labeled mocked.
+
+**Honest scope statement (WSP 97):** this slice proves (a) the `main.py --headless` bootstrap
+seam is fixed and dry-run-safe, and (b) the FoundUp->Hermes dry-run path is dry-run-safe.
+It does NOT claim these two are wired into one end-to-end loop today (see Section 9).
+
+---
+
+## 2. WSP_15 Score and Priority
+
+| Dimension | Score (1-5) | Rationale |
+|-----------|-------------|-----------|
+| Complexity | 2 | Minimal fix: reuse existing bootstrap; no new module |
+| Importance | 4 | Headless autonomous mode is inoperative without it |
+| Deferability | 4 | Broken seam blocks any headless autonomous cycle (low deferability) |
+| Impact | 4 | Enables a bounded, dry-run-safe headless cycle |
+
+**Total: 14/20 -> Priority P1.**
+
+---
+
+## 3. Runtime Topology Map
+
+Verified stage-by-stage (file:line). `present` = wired into the `main.py --headless` path.
+
+| Stage | Surface | present |
+|-------|---------|---------|
+| Mode routing | `main.py` __main__ L1414-1415: `--headless -> run_headless()`, bypassing `main()` | YES |
+| WRE readiness gate (fail-closed) | `run_headless` L1334-1341 -> `run_connect_wre` L785 (dashboard health only) | YES |
+| DAE launch-spec registration | `bootstrap_runtime_dae_launches` L1087-1223 (`register_launch_spec` L1204-1205 on the singleton broker) | **YES (after fix)** |
+| Broker/supervisor construction | `run_headless` L1346-1364 -> `OpenClawSupervisor(broker=...)` | YES |
+| Supervisor state machine | `openclaw_supervisor.run_cycle` L161 (observe->triage->plan->execute->verify->remember->escalate) | YES |
+| OBSERVE reads broker status | `_observe` L448-489 (`broker.get_runtime_status("openclaw")` L452) | YES |
+| TRIAGE | `_triage` L495-598 (restart L505-519; auto-tasks L524; maintenance L542; self-audit L587) | YES |
+| **FoundUp job / test selection** | none in supervisor (grep `foundup_job\|FoundUpJob\|drain` = 0 matches) | **NO** |
+| FoundUpJobConsumer | `foundup_job_consumer.FoundUpJobConsumer` L322 (`consume_one` L351, `_dispatch_to_hermes` L405) | present, **not in headless loop** |
+| Hermes dry-run executor | `hermes_job_executor.execute` L1536 (dry_run short-circuit -> SIMULATED L1794-1820) | present, **not in headless loop** |
+| FoundUp->Hermes entrypoint (out of band) | `run_wre.py` L436-439 `drain_openclaw_queue_dry_run` (separate CLI) | YES (separate) |
+
+**Key topology truth:** the headless supervisor cycle and the FoundUp->Hermes dry-run pipeline
+are SEPARATE. The supervisor selects restart / AgentDB auto-tasks / maintenance / self-audit,
+not FoundUp builds. The FoundUp->Hermes dry-run is reachable only via `FoundUpJobConsumer`
+(callers: `openclaw_foundup_orchestrator.py`, `receipt_emitter.py`, `run_wre.py`).
+
+---
+
+## 4. Existing Seams Reused (WSP 84)
+
+- `bootstrap_runtime_dae_launches()` (main.py L1087) -- the canonical DAE-spec registration; the
+  fix calls it instead of duplicating specs.
+- `get_dae_launch_broker()` singleton (dae_launch_broker.py L418-423) -- shared broker the fix
+  consumes after bootstrap populates it.
+- Existing env flags (`OPENCLAW_RESIDENT_AUTOSTART`, `OPENCLAW_SUPERVISOR_AUTOSTART`,
+  `OPENCLAW_SUPERVISOR_ALLOW_RESTART`) -- the fix sets dry-run-safe defaults via `setdefault`,
+  preserving operator opt-in.
+- Existing dry-run coverage (cited, not duplicated): `test_foundup_registry_loader.py`,
+  `test_foundup_registry_schema.py`, `test_foundup_job_consumer.py`, `test_hermes_job_executor.py`
+  -- 105 passing, covering registry load + Hermes dry-run truth fields.
+
+---
+
+## 5. Tests Added
+
+Extended `tests/test_main_runtime_bootstrap.py` (the existing main.py bootstrap harness):
+
+| Test | Proves | Mocked |
+|------|--------|--------|
+| `test_run_headless_bootstraps_dae_specs_before_supervisor_cycle` | `--headless` (MAX_CYCLES=1) calls `bootstrap_runtime_dae_launches` BEFORE the supervisor cycle and hands the supervisor the shared broker (call-order asserted) | WRE readiness, bootstrap, broker, supervisor, sleep |
+| `test_run_headless_fail_closed_when_wre_not_ready` | exits 1, never bootstraps/constructs supervisor when WRE not ready | WRE readiness |
+| `test_run_headless_one_cycle_no_live_execution` | one mocked cycle; sets `RESIDENT_AUTOSTART/SUPERVISOR_AUTOSTART/SUPERVISOR_ALLOW_RESTART=0` (no live service) | all heavy seams |
+| `test_supervisor_triage_escalates_not_live_starts_when_restart_disabled` | with restart disabled, `_triage` returns escalate `resident_openclaw_down_restart_disabled`, NOT the live `start_openclaw` action | broker/observer |
+
+**Result: 9 passed** (5 pre-existing bootstrap + 4 new). No live process/network/model/OAuth/
+GitHub-write/Docker. All non-pure seams are mocked (labeled above).
+
+---
+
+## 6. FoundUp Auto-Test Matrix
+
+16 registered FoundUps (`foundup_registry.json`); each `foundup_id` mapped to a module path and
+test status. Missing coverage is reported, not hidden.
+
+| foundup_id | module_path | status |
+|------------|-------------|--------|
+| gotjunk_001 | modules/foundups/gotjunk | HAS_TESTS |
+| kosei | modules/foundups/kosei | HAS_TESTS |
+| voteballots | modules/foundups/voteballots | HAS_TESTS |
+| trade | modules/foundups/trade | HAS_TESTS |
+| magadoom_001 | modules/gamification/whack_a_magat | HAS_TESTS |
+| antifafm_001 | modules/platform_integration/antifafm_broadcaster | HAS_TESTS |
+| pfmall | modules/foundups/pfmall | HAS_TESTS |
+| agent_market | modules/foundups/agent_market | HAS_TESTS |
+| move2japan | modules/foundups/move2japan | HAS_TESTS |
+| simulator | modules/foundups/simulator | HAS_TESTS |
+| social_twin | modules/foundups/social_twin | HAS_TESTS |
+| autopost | **ABSENT** | **NO_TEST_COVERAGE** |
+| pqn_portal | modules/foundups/pqn_portal | **NO_TEST_COVERAGE** |
+| science_swarm_hub | modules/foundups/pqn_swarm_hub | **NO_TEST_COVERAGE** |
+| holoindex_prod_01 | modules/foundups/holoindex_prod_01 | **NO_TEST_COVERAGE** |
+| shield | modules/foundups/shield | **NO_TEST_COVERAGE** |
+
+**Coverage: 11/16 HAS_TESTS, 5/16 NO_TEST_COVERAGE** (autopost also has no module path).
+
+---
+
+## 7. Headless / main.py Binding Result
+
+**Root cause (confirmed):** `--headless` routes directly to `run_headless()` (L1414-1415),
+bypassing `main()`; `bootstrap_runtime_dae_launches()` is called ONLY from `main()` (L1260).
+Pre-fix, `run_headless` built a FRESH empty `DAELaunchBroker()` (`_specs={}`), so the supervisor's
+`_observe` read `registered=False` and `_triage` escalated `openclaw_runtime_not_registered`
+(L502-503) **every cycle**, dead-looping with no plan/execute.
+
+**Fix (minimal, thin router preserved):** `run_headless` now reuses
+`bootstrap_runtime_dae_launches()` (no duplicated specs) and consumes the shared singleton
+`get_dae_launch_broker()`. It sets dry-run-safe `setdefault` defaults
+(`OPENCLAW_RESIDENT_AUTOSTART=0`, `OPENCLAW_SUPERVISOR_AUTOSTART=0`,
+`OPENCLAW_SUPERVISOR_ALLOW_RESTART=0`) so a one-cycle run registers specs (triage passes
+`registered=True`) yet performs NO live launch (triage escalates `resident_openclaw_down_
+restart_disabled` instead of `start_openclaw`). Auto-tasks/maintenance are already off by
+default. Operator opts into live autonomy via the existing env flags.
+
+**`HEADLESS_BOOTSTRAP_SEAM_FIXED`: YES** -- proven by 4 tests (Section 5), not asserted.
+
+**Critic note addressed:** the adversarial pass found the initial fix closed the bootstrap
+autostart door but left the supervisor restart side-door open (would live-launch the resident
+on cycle 1). The final fix suppresses `OPENCLAW_SUPERVISOR_ALLOW_RESTART` by default and a guard
+test proves triage escalates instead of starting a live service.
+
+---
+
+## 8. Dry-Run Evidence (FoundUp -> Hermes, separate seam)
+
+The FoundUp->Hermes dry-run path is dry-run-safe (verified, covered by existing tests):
+`FoundUpJobConsumer.__init__` defaults `dry_run=True` (L342) -> `consume_one` (L351) ->
+`_dispatch_to_hermes` (L405) -> `execute_foundup_job` -> `get_executor(dry_run=True).execute`
+(hermes L2344-2366) -> Step5 `if self.dry_run:` short-circuit returns `SIMULATED` (L1794-1820)
+**before** any real `delegate_task` import (L1823) or the `BLOCKED_REAL_DELEGATION_NOT_IMPLEMENTED`
+branch (L1843-1868, reachable only with `HERMES_DELEGATE_ENABLED` true AND `dry_run` false).
+
+**WSP 97 truth fields stay false:** `real_execution_performed=False` (L448),
+`verification_complete=False` (L449), `cabr_ready=False` (L450), `payout_ready=False` (L451) --
+re-asserted in every SIMULATED/BLOCKED branch. Consumer-side: SIMULATED ->
+`_emit_receipt_for_hermes_result` returns None (L614-626) -> `receipt_emission` stays None ->
+the three verification properties resolve False. No CABR_READY, no PAYOUT_READY, no
+verification_complete overclaim. This seam is NOT reached by `main.py --headless` (Section 3).
+
+---
+
+## 9. Gaps and Next Slices
+
+1. **FoundUp job/test selection is not wired into the headless supervisor cycle.** The
+   supervisor does restart/auto-task/maintenance/self-audit, not FoundUp builds. The
+   FoundUp->Hermes dry-run is a SEPARATE entrypoint (`run_wre.py`). Wiring it into the cycle is
+   future work -> **`WRE_AUTONOMOUS_BUILD_CONTEXT_BUNDLE_PHASE1`** (or a dedicated
+   `WRE_HEADLESS_FOUNDUP_JOB_SELECTION` slice).
+2. **5/16 FoundUps have NO_TEST_COVERAGE** (autopost, pqn_portal, science_swarm_hub,
+   holoindex_prod_01, shield); autopost also lacks a module path ->
+   **`FOUNDUP_AUTO_TEST_MATRIX_COVERAGE_PHASE1`**.
+3. **Headless binding was fixed** -> a W10 readiness gate for the headless bootstrap ->
+   **`WRE_HEADLESS_BOOTSTRAP_W10_GATE`**.
+4. **Pre-existing (out of scope):** `test_openclaw_supervisor_p0.py::test_run_cycle_executes_
+   and_completes_pending_autonomous_task` fails on clean `origin/main` (27d6d2c22) with this
+   slice's changes stashed -- not caused by this fix; flagged for a separate slice.
+
+**Recommended next slice:** `WRE_HEADLESS_BOOTSTRAP_W10_GATE` (binding fixed), with
+`FOUNDUP_AUTO_TEST_MATRIX_COVERAGE_PHASE1` for the 5 coverage gaps.
+
+---
+
+## 10. Internal Review Verdict
+
+**READY.** The headless bootstrap seam is fixed by reusing the existing bootstrap path (no
+second layer; critic `second_layer_drift=false`), proven by 4 mocked tests (9 passing total).
+The fix is dry-run-safe by default (no live launch; restart side-door closed and guard-tested).
+The FoundUp->Hermes dry-run truth boundary is verified (all four WSP 97 fields false) via the
+existing seam. Claims are bounded to a one-cycle dry-run; mocked parts are labeled; the
+not-yet-wired FoundUp->headless gap and a pre-existing failure are reported, not hidden.
+
+---
+
+## 11. WSP_97 Truth Boundary Checklist
+
+Declared count: 22 / 22 YES (rows below = 22).
+
+| # | Truth Boundary Checklist Item | Status | Evidence |
+|---|-------------------------------|--------|----------|
+| 1 | CHARACTERIZATION_AND_MINIMAL_FIX_ONLY | YES | main.py run_headless fix + tests; no new module |
+| 2 | HEADLESS_ONE_CYCLE_TESTABLE_MAX_CYCLES_1 | YES | test_run_headless_bootstraps... uses OPENCLAW_HEADLESS_MAX_CYCLES=1 |
+| 3 | HEADLESS_REGISTERS_SPECS_BEFORE_CYCLE | YES | call-order assert [bootstrap, run_cycle]; Section 7 |
+| 4 | FAIL_CLOSED_WHEN_WRE_NOT_READY | YES | test_run_headless_fail_closed... returns 1, no bootstrap |
+| 5 | SUPERVISOR_ONE_MOCKED_CYCLE_NO_LIVE_MUTATION | YES | test_run_headless_one_cycle_no_live_execution |
+| 6 | NO_LIVE_SERVICE_LAUNCH_RESTART_GUARD | YES | test_supervisor_triage_escalates_not_live_starts... |
+| 7 | FOUNDUP_REGISTRY_LOADS_IDS_MAPPED | YES | Section 6 matrix (16); existing test_foundup_registry_loader passes |
+| 8 | MISSING_TESTS_REPORTED_NOT_HIDDEN | YES | 5 NO_TEST_COVERAGE listed (autopost module ABSENT) |
+| 9 | FOUNDUP_DRYRUN_REACHES_HERMES_NO_REAL_DELEGATE | YES | Section 8; existing test_foundup_job_consumer/test_hermes_job_executor pass |
+| 10 | TRUTH_FIELDS_FALSE_NO_CABR_PAYOUT_VERIFICATION | YES | Section 8 (L448-451 + re-asserted SIMULATED/BLOCKED) |
+| 11 | NO_LIVE_PROCESS_NETWORK_MODEL_IN_TESTS | YES | all heavy seams mocked (Section 5) |
+| 12 | NO_LIVE_HERMES_DELEGATION | YES | HERMES_DELEGATE_ENABLED off; dry_run short-circuit L1795 |
+| 13 | NO_OAUTH_NO_NOUS_PORTAL | YES | no OAuth/portal call in fix or tests |
+| 14 | NO_DOCKER_START | YES | no container start |
+| 15 | NO_GITHUB_WRITE_FROM_RUNTIME | YES | no git/PR action in fix or tests |
+| 16 | NO_SECOND_ORCHESTRATION_LAYER | YES | critic second_layer_drift=false; reuses bootstrap |
+| 17 | MAIN_PY_THIN_ROUTER_PRESERVED | YES | run_headless calls bootstrap; no logic duplicated |
+| 18 | NO_WSP_MUTATION | YES | no WSP file changed |
+| 19 | NO_FOUNDUP_PRODUCTION_BEHAVIOR_CHANGE | YES | only run_headless default env posture changed |
+| 20 | NO_OVERCLAIM_CONTINUOUS_AUTONOMY | YES | claim bounded one-cycle dry-run only (Section 1) |
+| 21 | MOCKED_PARTS_LABELED | YES | Section 5 mocked column; Section 8 labels seam |
+| 22 | PREEXISTING_FAILURE_REPORTED | YES | Section 9 item 4 (verified on clean main via stash) |
+
+**WSP 97 Truth Boundary Checklist: 22/22 YES.**
+
+---
+
+*Authored by 0102 (Worker-Lane W6) under WSP_00 zen state and WSP_97 Truth Boundary discipline.
+Headless bootstrap seam fixed by reusing the existing bootstrap path; bounded one-cycle dry-run
+proven via mocked tests. The FoundUp->Hermes dry-run is a verified but separate seam, not yet
+wired into the headless loop.*

--- a/main.py
+++ b/main.py
@@ -1344,10 +1344,24 @@ def run_headless() -> int:
 
     try:
         from modules.communication.moltbot_bridge.src.openclaw_supervisor import OpenClawSupervisor
-        from modules.infrastructure.dae_daemon.src.dae_launch_broker import DAELaunchBroker
         from modules.infrastructure.dae_daemon.src.dae_observer import DAEObserver
 
-        broker = DAELaunchBroker()
+        # WSP 97 headless bootstrap seam: register broker-managed DAE launch specs
+        # BEFORE the supervisor cycle by reusing the existing bootstrap path (no
+        # duplicated specs; shared singleton broker). Default the headless loop to a
+        # BOUNDED, dry-run-safe posture so a one-cycle run performs no live launch:
+        #   - suppress resident/supervisor DAE autostart (avoid duplicate runtimes)
+        #   - suppress the supervisor's service-restart path so triage escalates
+        #     ("resident_openclaw_down_restart_disabled") instead of live-starting
+        #     the resident webhook service.
+        # Autonomous task/maintenance execution is already off by default
+        # (OPENCLAW_AUTO_TASKS_ENABLED / OPENCLAW_MAINTENANCE_ENABLED default "0").
+        # An operator opts into live autonomy via these existing env flags.
+        os.environ.setdefault("OPENCLAW_RESIDENT_AUTOSTART", "0")
+        os.environ.setdefault("OPENCLAW_SUPERVISOR_AUTOSTART", "0")
+        os.environ.setdefault("OPENCLAW_SUPERVISOR_ALLOW_RESTART", "0")
+        bootstrap_runtime_dae_launches()
+        broker = get_dae_launch_broker()
         observer = DAEObserver()
 
         supervisor = OpenClawSupervisor(

--- a/tests/TestModLog.md
+++ b/tests/TestModLog.md
@@ -1,5 +1,20 @@
 # TestModLog - shared tests
 
+## 2026-06-07: Headless bootstrap seam (WRE/OpenClaw/Hermes dry-run, W6)
+
+- File: `tests/test_main_runtime_bootstrap.py` (extended: 5 existing + 4 new = 9 tests)
+- Slice: `WRE_OPENCLAW_HERMES_AUTONOMOUS_BUILD_DRYRUN_PHASE1`
+- New tests:
+  - `test_run_headless_bootstraps_dae_specs_before_supervisor_cycle` - asserts call order [bootstrap, run_cycle] and shared broker (OPENCLAW_HEADLESS_MAX_CYCLES=1).
+  - `test_run_headless_fail_closed_when_wre_not_ready` - exits 1, no bootstrap/supervisor.
+  - `test_run_headless_one_cycle_no_live_execution` - asserts RESIDENT/SUPERVISOR autostart + ALLOW_RESTART defaulted "0".
+  - `test_supervisor_triage_escalates_not_live_starts_when_restart_disabled` - triage escalates `resident_openclaw_down_restart_disabled`, not the live `start_openclaw` action.
+- Command: `python -m pytest tests/test_main_runtime_bootstrap.py -q`
+- Status: **9 passed**. All heavy seams mocked; no live process/network/model/OAuth/Docker/GitHub-write.
+- Note: bounded one-cycle dry-run proof only (WSP 97). Pre-existing `test_openclaw_supervisor_p0.py::test_run_cycle_executes_and_completes_pending_autonomous_task` fails on clean main (verified via stash) - out of scope.
+
+---
+
 ## 2026-03-18: Main bootstrap resident OpenClaw registration
 
 - Command: `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; python -m pytest tests/test_main_runtime_bootstrap.py -q`

--- a/tests/test_main_runtime_bootstrap.py
+++ b/tests/test_main_runtime_bootstrap.py
@@ -1,4 +1,5 @@
 import importlib.util
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -133,3 +134,142 @@ def test_bootstrap_runtime_dae_launches_registers_and_autostarts_openclaw_superv
     assert len(supervisor_specs) == 1
     assert supervisor_specs[0].stop_callable is main.stop_openclaw_supervisor_service
     broker.start_dae.assert_called_once_with("openclaw_supervisor", actor_id="0102")
+
+
+# ---------------------------------------------------------------------------
+# Headless bootstrap seam (WRE_OPENCLAW_HERMES_AUTONOMOUS_BUILD_DRYRUN_PHASE1)
+#
+# These prove the BOUNDED ONE-CYCLE dry-run autonomous build/test seam only.
+# Every heavy runtime (WRE readiness, bootstrap, broker, supervisor, sleep) is
+# MOCKED: no live process, network, model, Hermes delegate_task, Docker, OAuth,
+# or GitHub write occurs. This is NOT a claim of continuous autonomous coding.
+# ---------------------------------------------------------------------------
+
+_SUPERVISOR_CLS = (
+    "modules.communication.moltbot_bridge.src.openclaw_supervisor.OpenClawSupervisor"
+)
+_OBSERVER_CLS = "modules.infrastructure.dae_daemon.src.dae_observer.DAEObserver"
+_READY_WRE = {"readiness": "READY", "alert_counts": {"critical": 0}}
+
+
+def test_run_headless_bootstraps_dae_specs_before_supervisor_cycle(monkeypatch):
+    """--headless one-cycle path reuses bootstrap_runtime_dae_launches to register
+    DAE launch specs BEFORE the supervisor cycle, and hands the supervisor the
+    shared (bootstrap-populated) broker rather than a fresh empty one. Mocked."""
+    monkeypatch.setenv("OPENCLAW_HEADLESS_MAX_CYCLES", "1")
+    monkeypatch.setenv("OPENCLAW_HEADLESS_INTERVAL", "0")
+
+    order = []
+    bootstrap_mock = MagicMock(side_effect=lambda: order.append("bootstrap"))
+    shared_broker = MagicMock(name="shared_broker")
+
+    supervisor_instance = MagicMock(name="supervisor")
+
+    def _run_cycle():
+        order.append("run_cycle")
+        return {"plan": {"action": "idle"}, "verify": {"ok": True}}
+
+    supervisor_instance.run_cycle.side_effect = _run_cycle
+    supervisor_cls = MagicMock(return_value=supervisor_instance)
+
+    with patch.object(main, "run_connect_wre", return_value=_READY_WRE), patch.object(
+        main, "bootstrap_runtime_dae_launches", bootstrap_mock
+    ), patch.object(
+        main, "get_dae_launch_broker", MagicMock(return_value=shared_broker)
+    ), patch.object(main.time, "sleep", MagicMock()), patch(
+        _SUPERVISOR_CLS, supervisor_cls
+    ), patch(
+        _OBSERVER_CLS, MagicMock()
+    ):
+        rc = main.run_headless()
+
+    assert rc == 0
+    bootstrap_mock.assert_called_once()
+    # Spec registration happens BEFORE the supervisor cycle:
+    assert order == ["bootstrap", "run_cycle"]
+    # Supervisor receives the shared, bootstrap-populated broker:
+    assert supervisor_cls.call_args.kwargs["broker"] is shared_broker
+    supervisor_instance.run_cycle.assert_called_once()
+
+
+def test_run_headless_fail_closed_when_wre_not_ready():
+    """Headless exits 1 (fail-closed) and never bootstraps or constructs the
+    supervisor when WRE readiness is not acceptable."""
+    supervisor_cls = MagicMock()
+    bootstrap_mock = MagicMock()
+
+    with patch.object(
+        main,
+        "run_connect_wre",
+        return_value={"readiness": "DEGRADED", "alert_counts": {"critical": 3}},
+    ), patch.object(
+        main, "bootstrap_runtime_dae_launches", bootstrap_mock
+    ), patch(
+        _SUPERVISOR_CLS, supervisor_cls
+    ):
+        rc = main.run_headless()
+
+    assert rc == 1
+    bootstrap_mock.assert_not_called()
+    supervisor_cls.assert_not_called()
+
+
+def test_run_headless_one_cycle_no_live_execution(monkeypatch):
+    """One mocked cycle performs no live Hermes delegation, Docker, OAuth, network,
+    or GitHub write. The fix defaults resident/supervisor DAE autostart OFF so the
+    headless path would not spawn live services even with a real bootstrap."""
+    monkeypatch.setenv("OPENCLAW_HEADLESS_MAX_CYCLES", "1")
+    monkeypatch.setenv("OPENCLAW_HEADLESS_INTERVAL", "0")
+    monkeypatch.delenv("OPENCLAW_RESIDENT_AUTOSTART", raising=False)
+    monkeypatch.delenv("OPENCLAW_SUPERVISOR_AUTOSTART", raising=False)
+    monkeypatch.delenv("OPENCLAW_SUPERVISOR_ALLOW_RESTART", raising=False)
+
+    supervisor_instance = MagicMock(name="supervisor")
+    supervisor_instance.run_cycle.return_value = {
+        "plan": {"action": "idle"},
+        "verify": {"ok": True},
+    }
+
+    with patch.object(main, "run_connect_wre", return_value=_READY_WRE), patch.object(
+        main, "bootstrap_runtime_dae_launches", MagicMock()
+    ), patch.object(main, "get_dae_launch_broker", MagicMock()), patch.object(
+        main.time, "sleep", MagicMock()
+    ), patch(
+        _SUPERVISOR_CLS, MagicMock(return_value=supervisor_instance)
+    ), patch(
+        _OBSERVER_CLS, MagicMock()
+    ):
+        rc = main.run_headless()
+
+    assert rc == 0
+    # The fix sets dry-run-safe defaults: headless owns the single supervisor loop,
+    # does not autostart live resident/supervisor services, and disables the
+    # supervisor's service-restart path so no live webhook service is launched.
+    assert os.environ.get("OPENCLAW_RESIDENT_AUTOSTART") == "0"
+    assert os.environ.get("OPENCLAW_SUPERVISOR_AUTOSTART") == "0"
+    assert os.environ.get("OPENCLAW_SUPERVISOR_ALLOW_RESTART") == "0"
+    supervisor_instance.run_cycle.assert_called_once()
+
+
+def test_supervisor_triage_escalates_not_live_starts_when_restart_disabled(monkeypatch):
+    """Guard for the headless dry-run posture: with restart disabled (the default
+    run_headless sets), the supervisor triage ESCALATES instead of emitting the
+    live 'start_openclaw' action, so no real DAE service is launched. Mocked
+    broker/observer; no live process."""
+    monkeypatch.setenv("OPENCLAW_SUPERVISOR_ALLOW_RESTART", "0")
+    from modules.communication.moltbot_bridge.src.openclaw_supervisor import (
+        OpenClawSupervisor,
+    )
+
+    sup = OpenClawSupervisor(
+        repo_root=Path(__file__).resolve().parents[1],
+        broker=MagicMock(),
+        observer=MagicMock(),
+    )
+    # Resident is registered (fix applied) but not running -> with restart disabled
+    # the only live-launch branch must NOT be taken.
+    result = sup._triage({"openclaw_runtime": {"registered": True, "running": False}})
+
+    assert result["kind"] == "escalate"
+    assert result["reason"] == "resident_openclaw_down_restart_disabled"
+    assert result.get("action") != "start_openclaw"


### PR DESCRIPTION
## Summary

Minimal remediation of the broken **headless bootstrap seam** + a bounded **one-cycle dry-run** characterization (Worker-Lane W6). **No second orchestration layer; `main.py` stays a thin router.** Confirmed by an adversarial critic pass (`second_layer_drift=false`).

## Root cause

`main.py --headless` routes to `run_headless()` (L1414-1415), **bypassing `main()`** — so `bootstrap_runtime_dae_launches()` (called only from `main()` L1260) never ran. `run_headless` built a **fresh empty `DAELaunchBroker()`**, so the supervisor's `_observe` saw `registered=False` and `_triage` **escalated `openclaw_runtime_not_registered` every cycle** (dead-loop, no plan/execute).

## Fix (reuse, don't duplicate)

`run_headless` now reuses `bootstrap_runtime_dae_launches()` and consumes the **shared singleton** `get_dae_launch_broker()`. It sets dry-run-safe `setdefault` defaults (`OPENCLAW_RESIDENT_AUTOSTART` / `OPENCLAW_SUPERVISOR_AUTOSTART` / `OPENCLAW_SUPERVISOR_ALLOW_RESTART` = `"0"`) so one cycle **registers specs yet launches no live service** — triage escalates `resident_openclaw_down_restart_disabled` instead of the live `start_openclaw`. Operator opts into live autonomy via the existing flags.

> **Critic catch addressed:** the initial fix closed the bootstrap-autostart door but left the supervisor **restart side-door** open (would live-launch the resident on cycle 1). The final fix suppresses restart by default, with a guard test proving triage escalates.

## Tests — `tests/test_main_runtime_bootstrap.py` (9 passed = 5 existing + 4 new)

| Test | Proves |
|------|--------|
| `..._bootstraps_dae_specs_before_supervisor_cycle` | call order `[bootstrap, run_cycle]` + shared broker (`MAX_CYCLES=1`) |
| `..._fail_closed_when_wre_not_ready` | exits 1, no bootstrap/supervisor |
| `..._one_cycle_no_live_execution` | autostart + `ALLOW_RESTART` defaulted `"0"` |
| `test_supervisor_triage_escalates_not_live_starts_when_restart_disabled` | triage escalates, not live `start_openclaw` |

All heavy seams **mocked** — no live process/network/model/OAuth/Docker/GitHub-write.

## Honest scope (WSP 97)

**Bounded one-cycle dry-run only — NOT continuous autonomy.** The FoundUp→Hermes dry-run is a **verified but SEPARATE seam** (`run_wre.py` / `FoundUpJobConsumer`, all 4 truth fields false), **NOT wired into the headless supervisor loop** (the supervisor does restart/maintenance/self-audit, not FoundUp builds). FoundUp matrix: **11/16 HAS_TESTS, 5 NO_TEST_COVERAGE**. A pre-existing `test_openclaw_supervisor_p0.py` failure was verified on clean main (stashed) → out of scope.

## Completion Report

| Metric | Value |
|--------|-------|
| Branch | fix/wre-openclaw-hermes-autonomous-build-dryrun-phase1 |
| Files changed | 5 (main.py, test, audit, 2 ModLogs) |
| Tests run | `tests/test_main_runtime_bootstrap.py` → **9 passed** |
| Dry-run proof | bounded one-cycle, all seams mocked; FoundUp→Hermes truth fields false (separate seam) |
| FoundUp coverage | 11/16 HAS_TESTS, 5 NO_TEST_COVERAGE |
| Headless seam | **HEADLESS_BOOTSTRAP_SEAM_FIXED** (tests prove) |
| WSP_97 checklist | 22/22 YES |
| Recommended next slice | `WRE_HEADLESS_BOOTSTRAP_W10_GATE` + `FOUNDUP_AUTO_TEST_MATRIX_COVERAGE_PHASE1` |
| Internal Review Verdict | READY |

Do not merge — review requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
