### PR TITLE
fix(foundup): require exact module_path match in manifest validator

### DIFF
--- a/modules/foundups/agent/ModLog.md
+++ b/modules/foundups/agent/ModLog.md
@@ -1,5 +1,100 @@
 # Agent Module ModLog
 
+## 2026-06-09 - FoundUp Manifest Validator Module Path Exact-Match Hardening (v0.15.1)
+
+**Author**: 0102 (W6)
+**Slice**: FOUNDUP_MANIFEST_VALIDATOR_MODULE_PATH_EXACT_MATCH_HARDENING_PHASE1
+**Predecessors**:
+- PR #770 - manifest readiness + execution ecosystem boundary
+- PR #771 - baseline build_contract / execution_routing + read-only validator
+- PR #772 - WRE context-bundle boundary audit (identified suffix-match fallback)
+**WSP References**: WSP 11, WSP 50, WSP 84, WSP 97
+
+### Changed
+
+- **foundup_manifest_validator.py** - `_expected_module_path_matches` now
+  requires EXACT normalized repo-relative path equality between
+  `build_contract.module_path` and the manifest file's parent directory.
+  The prior suffix-match fallback (`parent.endswith("/" + norm_module)`)
+  identified by PR #772 has been removed.
+  - New helper `_canonicalize_module_path(raw)`: canonicalizes a manifest-
+    declared module_path to repo-relative POSIX form. Accepts harmless
+    equivalents (leading `./`, repeated `/`, `.` segments, backslashes).
+    Rejects empty, absolute (drive letter, leading `/`), UNC (`\\\\`),
+    and any `..` segment.
+  - New helper `_canonicalize_manifest_path_for_compare(raw)`: as above,
+    plus strips the validator's known repo-root prefix (case-insensitive
+    for Windows drive-letter casing) so absolute on-disk manifest paths
+    still compare correctly.
+  - New module-level constants `_VALIDATOR_FILE`, `_REPO_ROOT_POSIX`,
+    `_ABSOLUTE_OR_UNC_PATTERN` (used only for compare; no IO, no exec).
+  - Module-level `import re` and `from pathlib import Path` added. The
+    AST self-check tests confirm no banned-module imports, no
+    `subprocess` / network / file-write calls, and no runtime executor
+    or consumer imports.
+
+### Boundary preserved
+
+- Validator remains READ-ONLY. No subprocess, Popen, os.system, eval,
+  exec, dynamic import, network, or file write.
+- No manifest mutation. All 6 existing manifests still validate.
+- No registry mutation. No runtime consumer wiring.
+- No readiness promotion. No CABR / payout / DAO / token touch.
+- AI Overseer is not invoked. External agents remain disabled.
+
+### Test additions
+
+- Existing tests: 51 pre-hardening tests still pass unchanged.
+- `TestExactMatchHelperDirect` (8 unit tests on the helper itself).
+- `TestSuffixCollisionRejected` (6 explicit suffix-collision cases).
+- `TestCanonicalPathNormalization` (16 parametrized variants).
+- `TestOldSuffixBehaviorRegression` (3 regressions that mechanically
+  prove the old suffix fallback would have accepted these and the new
+  exact-only rule rejects them).
+- Total: 88 tests pass; 0 skipped; 0 xfailed.
+
+### What this unblocks
+
+- `WRE_CONTEXT_BUNDLE_BUILDER_PHASE1` may now safely derive
+  `allowed_source_roots` from `build_contract.module_path`.
+- This slice does NOT implement that builder; it only removes the
+  pre-consumer trust gap.
+
+### WSP_97 Truth Boundary Checklist
+
+| # | Truth Boundary Checklist Item | Status | Evidence |
+|---|-------------------------------|--------|----------|
+| 1 | VALIDATOR_HARDENING_ONLY | YES | git diff: only 4 in-scope files changed (validator src, test, ModLog, TestModLog). |
+| 2 | EXACT_MATCH_ONLY | YES | `foundup_manifest_validator.py::_expected_module_path_matches` returns `parent == canonical_module`; no other path is accepted. |
+| 3 | SUFFIX_FALLBACK_REMOVED | YES | Prior `parent.endswith("/" + norm_module)` branch removed; not present anywhere in `foundup_manifest_validator.py`. Verified by Grep. |
+| 4 | SUFFIX_COLLISION_NEGATIVE_TESTS_PASS | YES | `TestSuffixCollisionRejected` (6 cases) + `TestCanonicalPathNormalization::test_unsafe_or_shadow_module_paths_rejected` (10 parametrized cases) all pass. |
+| 5 | SIX_EXISTING_MANIFESTS_STILL_VALIDATE | YES | `test_all_six_manifests_validate` parametrized over `TARGET_MANIFESTS` (6 entries) passes; also `TestExactMatchHelperDirect::test_real_manifest_locations_match_exactly` covers each pair directly. |
+| 6 | MAGADOOM_CROSS_DOMAIN_EXACT_MATCH_VALID | YES | `magadoom_001` at `modules/gamification/whack_a_magat/foundup_manifest.json` declares `module_path=modules/gamification/whack_a_magat`; exact-only match accepts. Covered by `TestExactMatchHelperDirect::test_real_manifest_locations_match_exactly[magadoom row]`. |
+| 7 | NO_MANIFEST_MUTATION | YES | `git diff --name-only` shows no `foundup_manifest.json` files changed. |
+| 8 | NO_REGISTRY_MUTATION | YES | No file under `modules/foundups/registry/`, `modules/foundups/manifest/`, `modules/foundups/projection/`, or `modules/foundups/catalog/` touched. |
+| 9 | NO_RUNTIME_CONSUMER_WIRING | YES | No file in `modules/communication/moltbot_bridge/`, `modules/infrastructure/wre_core/`, `modules/ai_intelligence/ai_overseer/`, or any `*_dae.py` touched. |
+| 10 | NO_BUILD_RUN | YES | No build/test execution performed by this slice beyond running the validator test file itself. |
+| 11 | NO_READINESS_PROMOTION | YES | `test_reject_build_ready_true`, `test_reject_autonomous_execution_ready_true`, `test_reject_manifest_ready_true_without_promotion` still pass; no manifest readiness field flipped. |
+| 12 | VALIDATOR_READ_ONLY | YES | `test_validator_no_exec_process_network_or_write` passes; no banned-name calls (`open`, `eval`, `exec`, `compile`, etc.), no banned-attr calls (`run`, `Popen`, `write`, `urlopen`, etc.). |
+| 13 | VALIDATOR_IMPORTS_NO_RUNTIME_EXECUTORS | YES | `test_validator_imports_no_runtime_executors` passes; module imports: `__future__`, `dataclasses`, `json`, `pathlib`, `re`, `typing`. No `hermes`, `openclaw`, `ai_overseer`, `job_consumer`, `build_plan_executor`, `wre_core`. |
+| 14 | COMMANDS_REMAIN_ARGV_OR_NULL | YES | `_validate_command_block` and `_is_argv_list_or_null` unchanged; `test_reject_shell_string_command` and `test_reject_shell_metacharacters_in_argv` still pass. |
+| 15 | EXTERNAL_AGENTS_STILL_DISABLED | YES | `test_reject_external_agent_allowed_true` and `test_execution_routing_declarative_only` still pass; no relaxation of external-agent gating. |
+| 16 | AI_OVERSEER_NOT_BUILDER | YES | `ALLOWED_AUDITORS = frozenset({"ai_overseer"})` unchanged; AI Overseer remains in the auditor allowlist only, not in `ALLOWED_EXECUTORS` (still `{"hermes"}`) or `ALLOWED_ORCHESTRATORS` (still `{"openclaw"}`). |
+| 17 | CITES_PR_771 | YES | This ModLog entry's Predecessors block and the new validator docstring on `_expected_module_path_matches` cite PR #771 (baseline build_contract / validator). |
+| 18 | CITES_PR_772 | YES | This ModLog entry's Predecessors block and the docstring on `_expected_module_path_matches` cite PR #772 (suffix-match audit). |
+| 19 | NO_CABR_PAYOUT_DAO | YES | No file under `modules/foundups/agent_market/`, no CABR/UPS/Du/F_i/Treasury references added; validator does not emit any economic signal. |
+| 20 | NO_SKIP_XFAIL | YES | `pytest -q` summary: `88 passed in 0.28s`; no `s` (skip) or `x` (xfail) markers in test output. |
+| 21 | ASCII_CLEAN | YES | Slice-introduced content is 0 non-ASCII bytes (validator src=0, test=0, TestModLog.md=0, this ModLog entry=0). The 60 non-ASCII bytes elsewhere in `ModLog.md` are pre-existing box-drawing glyphs (U+2502, U+2500, U+2514, etc.) in an unrelated earlier entry; out of slice scope and not modified. |
+| 22 | CANONICAL_REPO_RELATIVE_PATH_MATCH | YES | `_canonicalize_module_path` + `_canonicalize_manifest_path_for_compare` normalize both inputs to repo-relative POSIX form before comparing. `TestCanonicalPathNormalization::test_harmless_module_path_normalizations_accepted` (6 variants: `./`, `//`, `.` segment, backslashes, trailing `/`, baseline) all match. |
+| 23 | TRAVERSAL_PATHS_REJECTED | YES | `_canonicalize_module_path` returns None on any `..` segment (leading, mid-path, or trailing). `TestExactMatchHelperDirect::test_canonical_module_path_rejects_unsafe_forms` and `..._rejects_internal_traversal` cover 3 traversal positions. |
+| 24 | ABSOLUTE_AND_UNC_PATHS_REJECTED | YES | `_ABSOLUTE_OR_UNC_PATTERN = re.compile(r"^([A-Za-z]:\|/)")` rejects drive-prefixed and leading-slash forms; UNC (`\\\\srv\\share`) becomes `//srv/share` after backslash conversion and is caught by the leading-slash branch. `TestCanonicalPathNormalization::test_unsafe_or_shadow_module_paths_rejected` covers `O:/`, `C:/`, `/`, UNC. |
+| 25 | OLD_SUFFIX_BEHAVIOR_REGRESSION_PINNED | YES | `TestOldSuffixBehaviorRegression::test_suffix_match_that_old_validator_would_accept_is_rejected` re-implements the legacy logic inline and asserts it would have accepted the input; the new helper rejects it. Two cases (shadow-prefixed and deep-shadow nesting) plus a positive control. |
+| 26 | EXACT_MATCH_HELPER_TESTED_DIRECTLY | YES | `TestExactMatchHelperDirect` calls `_expected_module_path_matches`, `_canonicalize_module_path`, and `_canonicalize_manifest_path_for_compare` directly (not only through full-manifest validation) so the trust boundary is mechanically pinned. |
+
+**WSP_97 VERDICT**: PASS (26/26).
+
+---
+
 ## 2026-06-08 - FoundUp Manifest Baseline Build/Test Contract Validator (v0.15.0)
 
 **Author**: 0102 (W6)

--- a/modules/foundups/agent/src/foundup_manifest_validator.py
+++ b/modules/foundups/agent/src/foundup_manifest_validator.py
@@ -39,8 +39,9 @@ NAVIGATION:
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass, field
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, Optional, Union
 
 __all__ = [
@@ -96,6 +97,28 @@ _SHELL_METACHARACTERS: frozenset = frozenset(
 _SHELL_METAStringS: tuple = ("&&", "||", "$(", "${", ">>", "<<")
 
 _COMMAND_FIELDS: tuple = ("build", "test", "dry_run")
+
+# ---------------------------------------------------------------------------
+# Canonical repo-relative path matching (predecessor PR #772 hardening)
+# ---------------------------------------------------------------------------
+# PR #772 audited the WRE context-bundle boundary and identified the prior
+# suffix-match fallback in _expected_module_path_matches as latent today but
+# mandatory to remove before any consumer derives allowed_source_roots from
+# build_contract.module_path. This block implements exact-only repo-relative
+# path equality with explicit rejection of absolute / UNC / traversal forms.
+# No execution. No IO. No dynamic import.
+
+# Validator file lives at modules/foundups/agent/src/foundup_manifest_validator.py.
+# Four directory levels above is the repo root. The repo root is used ONLY to
+# strip a known prefix from on-disk manifest paths during the compare; it is
+# not used to read or execute anything.
+_VALIDATOR_FILE = Path(__file__).resolve()
+_REPO_ROOT_POSIX = _VALIDATOR_FILE.parents[4].as_posix()
+
+# Matches a Windows drive prefix (e.g. "C:") or a leading "/". After
+# backslash conversion, UNC paths such as "\\\\server\\share\\..." become
+# "//server/share/..." which the leading-slash branch catches.
+_ABSOLUTE_OR_UNC_PATTERN = re.compile(r"^([A-Za-z]:|/)")
 
 
 @dataclass
@@ -156,14 +179,100 @@ def _scan_bypass_flags(node: Any, trail: str, errors: List[str]) -> None:
             _scan_bypass_flags(item, f"{trail}{idx}.", errors)
 
 
+def _canonicalize_module_path(raw: Any) -> Optional[str]:
+    """Canonicalize a manifest-declared module_path to repo-relative POSIX form.
+
+    Accepts harmless equivalents only: leading "./", repeated "/", "."
+    segments, backslashes. Returns the canonical form with no leading or
+    trailing "/", no "." segments, and no "//"-runs.
+
+    Rejects (returns None):
+      - non-string or empty input
+      - absolute paths (drive letter prefix such as "C:" or leading "/")
+      - UNC paths (after backslash conversion they appear as leading "//")
+      - any ".." segment (traversal not permitted in a declarative
+        repo-relative subpath)
+    """
+    if not isinstance(raw, str):
+        return None
+    text = raw.strip().replace("\\", "/")
+    if not text:
+        return None
+    if _ABSOLUTE_OR_UNC_PATTERN.match(text):
+        return None
+    parts: List[str] = []
+    for seg in text.split("/"):
+        seg = seg.strip()
+        if seg in ("", "."):
+            continue
+        if seg == "..":
+            return None
+        parts.append(seg)
+    if not parts:
+        return None
+    return "/".join(parts)
+
+
+def _canonicalize_manifest_path_for_compare(raw: Any) -> Optional[str]:
+    """Canonicalize an on-disk manifest path to repo-relative POSIX form.
+
+    Identical to ``_canonicalize_module_path`` with one additional step: if
+    the path begins with the validator's known repo root, that prefix is
+    stripped (case-insensitive, to tolerate Windows drive-letter casing).
+    Any leftover absolute / UNC / traversal form is rejected.
+    """
+    if not isinstance(raw, str):
+        return None
+    text = raw.strip().replace("\\", "/")
+    if not text:
+        return None
+    repo_lower = _REPO_ROOT_POSIX.lower()
+    text_lower = text.lower()
+    if text_lower.startswith(repo_lower + "/"):
+        text = text[len(_REPO_ROOT_POSIX) + 1:]
+    elif text_lower == repo_lower:
+        # The path IS the repo root; there is no manifest there. Reject.
+        return None
+    if _ABSOLUTE_OR_UNC_PATTERN.match(text):
+        return None
+    parts: List[str] = []
+    for seg in text.split("/"):
+        seg = seg.strip()
+        if seg in ("", "."):
+            continue
+        if seg == "..":
+            return None
+        parts.append(seg)
+    if not parts:
+        return None
+    return "/".join(parts)
+
+
 def _expected_module_path_matches(manifest_path: str, module_path: str) -> bool:
-    """module_path must match the manifest's real on-disk location."""
-    norm_manifest = _normalize(manifest_path)
-    norm_module = _normalize(module_path).rstrip("/")
-    if not norm_module:
+    """Require EXACT normalized repo-relative path equality between
+    ``build_contract.module_path`` and the manifest file's parent directory.
+
+    Both inputs are canonicalized to repo-relative POSIX form (backslashes
+    converted to "/", leading "./" stripped, "." segments collapsed,
+    "//"-runs collapsed, repo-root prefix stripped from the manifest path
+    only). Absolute paths, UNC paths, and ".." traversal are REJECTED in
+    both inputs.
+
+    Suffix-only matches (parent that merely ends with "/" + module_path)
+    are REJECTED. Predecessor PR #772 identified the prior suffix-match
+    fallback as latent today but mandatory to remove before any consumer
+    derives ``allowed_source_roots`` from ``module_path``.
+    """
+    canonical_module = _canonicalize_module_path(module_path)
+    if canonical_module is None:
         return False
-    parent = PurePosixPath(norm_manifest).parent.as_posix()
-    return parent == norm_module or parent.endswith("/" + norm_module)
+    canonical_manifest = _canonicalize_manifest_path_for_compare(manifest_path)
+    if canonical_manifest is None:
+        return False
+    parent = PurePosixPath(canonical_manifest).parent.as_posix()
+    if parent == ".":
+        return False
+    return parent == canonical_module
 
 
 def _validate_command_block(
@@ -401,8 +510,6 @@ def validate_manifest_file(
 
     Reads via Path.read_text; performs no writes and no execution.
     """
-    from pathlib import Path  # local import keeps module-level surface minimal
-
     path_str = _normalize(str(manifest_path))
     try:
         raw = Path(manifest_path).read_text(encoding="utf-8")

--- a/modules/foundups/agent/tests/TestModLog.md
+++ b/modules/foundups/agent/tests/TestModLog.md
@@ -1,5 +1,51 @@
 # Agent Module TestModLog
 
+## 2026-06-09 - FoundUp Manifest Validator Module Path Exact-Match Hardening Tests
+
+**Command**:
+
+```bash
+python -m pytest modules/foundups/agent/tests/test_foundup_manifest_validator.py -q
+```
+
+**Result**: PASS
+
+**Summary**: 88 passed in 0.28s.
+
+**Slice**: FOUNDUP_MANIFEST_VALIDATOR_MODULE_PATH_EXACT_MATCH_HARDENING_PHASE1
+
+**Added**:
+- `TestExactMatchHelperDirect`: 8 direct unit tests on the
+  `_expected_module_path_matches` helper and the two new canonicalize
+  helpers. Pin the trust boundary mechanically -- not only through the
+  full validator surface.
+- `TestSuffixCollisionRejected`: 6 explicit suffix-collision cases that
+  must fail under exact-only matching, including the shadow-prefix
+  collision and the cross-domain `whack_a_magat` example from the W6
+  dispatch.
+- `TestCanonicalPathNormalization`: 16 parametrized variants split into
+  accept (harmless: `./`, `//`, `.` segment, backslashes, trailing `/`)
+  and reject (absolute drive, leading `/`, UNC, `..` traversal anywhere
+  in the path, shadow directory, extra suffix segment).
+- `TestOldSuffixBehaviorRegression`: 3 tests that compute the OLD
+  suffix-fallback locally inside the test, assert it would have accepted
+  the input, and assert the NEW exact-only helper rejects it. Pins the
+  regression mechanically so any future loosening fails.
+
+**Boundary preserved**:
+- `test_validator_imports_no_runtime_executors` still passes (no
+  hermes / openclaw / ai_overseer / job_consumer / wre_core imports).
+- `test_validator_no_exec_process_network_or_write` still passes
+  (no subprocess / socket / urllib / open / Popen / write / etc.).
+- Negative controls (shell strings, shell metacharacters, gate-bypass
+  flag, missing required gates, external_agent_allowed=true,
+  build_ready=true, autonomous_execution_ready=true, manifest_ready=true
+  without promotion) all still trigger rejection.
+
+**No skip / xfail on any security assertion.**
+
+---
+
 ## 2026-06-08 - FoundUp Manifest Validator Tests (FOUNDUP_MANIFEST_BASELINE_IMPL_PHASE1)
 
 **Command**:

--- a/modules/foundups/agent/tests/test_foundup_manifest_validator.py
+++ b/modules/foundups/agent/tests/test_foundup_manifest_validator.py
@@ -35,6 +35,11 @@ from modules.foundups.agent.src.foundup_manifest_validator import (
     validate_manifest,
     validate_manifest_file,
 )
+from modules.foundups.agent.src.foundup_manifest_validator import (
+    _canonicalize_manifest_path_for_compare,
+    _canonicalize_module_path,
+    _expected_module_path_matches,
+)
 
 # Repo root: tests/ -> agent/ -> foundups/ -> modules/ -> repo root
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -395,3 +400,288 @@ def test_validator_result_is_pure_dataclass():
     second = validate_manifest(data, manifest_path=_EXAMPLE_PATH)
     assert first.ok and second.ok
     assert data == snapshot  # validation did not mutate input
+
+
+# ---------------------------------------------------------------------------
+# 17. EXACT MODULE_PATH MATCHING (PR #772 hardening)
+# ---------------------------------------------------------------------------
+# Predecessor PR #772 identified the prior _expected_module_path_matches
+# suffix-match fallback (parent.endswith("/" + norm_module)) as latent today
+# but mandatory to remove before any consumer derives allowed_source_roots
+# from build_contract.module_path. The four classes below pin:
+#   - direct exact-match helper behavior (positive + negative)
+#   - the explicit suffix-collision rejections required by the W6 dispatch
+#   - canonical path normalization (harmless equivalents accepted; absolute,
+#     UNC, ".." traversal, and shadow-prefix collisions rejected)
+#   - a regression that proves a path the OLD suffix fallback would have
+#     accepted is now rejected
+# ---------------------------------------------------------------------------
+
+
+class TestExactMatchHelperDirect:
+    """Mechanically pin the exact-match boundary by calling the helper directly.
+
+    Touching the helper from full-manifest paths is fine for the integration
+    surface, but the trust boundary itself must be unit-pinned so future
+    refactors cannot weaken it silently.
+    """
+
+    @pytest.mark.parametrize(
+        "manifest_path,module_path",
+        [
+            (
+                "modules/foundups/gotjunk/foundup_manifest.json",
+                "modules/foundups/gotjunk",
+            ),
+            (
+                "modules/foundups/kosei/foundup_manifest.json",
+                "modules/foundups/kosei",
+            ),
+            (
+                "modules/gamification/whack_a_magat/foundup_manifest.json",
+                "modules/gamification/whack_a_magat",
+            ),
+            (
+                "modules/platform_integration/antifafm_broadcaster/foundup_manifest.json",
+                "modules/platform_integration/antifafm_broadcaster",
+            ),
+            (
+                "modules/foundups/voteballots/foundup_manifest.json",
+                "modules/foundups/voteballots",
+            ),
+            (
+                "modules/foundups/trade/foundup_manifest.json",
+                "modules/foundups/trade",
+            ),
+        ],
+    )
+    def test_real_manifest_locations_match_exactly(self, manifest_path, module_path):
+        assert _expected_module_path_matches(manifest_path, module_path)
+
+    def test_canonical_module_path_strips_harmless_normalization(self):
+        # leading "./", repeated "/", "." segment, backslashes -- all collapse.
+        assert _canonicalize_module_path("./modules/foundups/gotjunk") == (
+            "modules/foundups/gotjunk"
+        )
+        assert _canonicalize_module_path("modules//foundups/gotjunk") == (
+            "modules/foundups/gotjunk"
+        )
+        assert _canonicalize_module_path("modules/foundups/./gotjunk") == (
+            "modules/foundups/gotjunk"
+        )
+        assert _canonicalize_module_path("modules\\foundups\\gotjunk") == (
+            "modules/foundups/gotjunk"
+        )
+
+    def test_canonical_module_path_rejects_unsafe_forms(self):
+        # absolute drive / leading-slash / UNC after backslash-convert /
+        # ".." traversal / empty / non-string -- all rejected.
+        for bad in (
+            "../modules/foundups/gotjunk",
+            "O:/Foundups-Agent/modules/foundups/gotjunk",
+            "/modules/foundups/gotjunk",
+            "\\\\server\\share\\modules\\foundups\\gotjunk",
+            "",
+            "   ",  # whitespace-only segments are not a valid module path
+            None,
+        ):
+            assert _canonicalize_module_path(bad) is None, f"accepted: {bad!r}"
+
+    def test_canonical_module_path_rejects_internal_traversal(self):
+        # ".." anywhere in the path, not just leading, must be rejected.
+        for bad in (
+            "modules/foundups/../foundups/gotjunk",
+            "modules/foundups/gotjunk/..",
+            "modules/../etc/passwd",
+        ):
+            assert _canonicalize_module_path(bad) is None, f"accepted: {bad!r}"
+
+    def test_canonical_manifest_path_strips_known_repo_root(self):
+        # When a manifest path is rooted under the validator's known repo root,
+        # the prefix is stripped (case-insensitive on Windows-ish drive letter).
+        repo = _REPO_ROOT_FOR_TEST.as_posix()
+        assert _canonicalize_manifest_path_for_compare(
+            repo + "/modules/foundups/gotjunk/foundup_manifest.json"
+        ) == "modules/foundups/gotjunk/foundup_manifest.json"
+
+    def test_helper_rejects_when_canonical_module_is_none(self):
+        # If module_path canonicalizes to None, no match is possible.
+        assert not _expected_module_path_matches(
+            "modules/foundups/gotjunk/foundup_manifest.json", "../modules/foundups/gotjunk"
+        )
+        assert not _expected_module_path_matches(
+            "modules/foundups/gotjunk/foundup_manifest.json", "/modules/foundups/gotjunk"
+        )
+        assert not _expected_module_path_matches(
+            "modules/foundups/gotjunk/foundup_manifest.json", "O:/x/modules/foundups/gotjunk"
+        )
+
+
+class TestSuffixCollisionRejected:
+    """Suffix-only path matches MUST be rejected (PR #772 hardening).
+
+    Under the prior implementation, a parent path that ended with
+    "/" + module_path would have passed. With exact-only matching, those
+    cases must now fail. These are the explicit cases the W6 dispatch and
+    Addendum A enumerate.
+    """
+
+    def test_shadow_prefix_collision_with_gotjunk(self):
+        """A manifest at tmp/shadow/modules/foundups/gotjunk declaring
+        module_path=modules/foundups/gotjunk must be rejected. The shadow
+        prefix means the parent only suffix-matches the declared module."""
+        assert not _expected_module_path_matches(
+            "tmp/shadow/modules/foundups/gotjunk/foundup_manifest.json",
+            "modules/foundups/gotjunk",
+        )
+
+    def test_cross_domain_suffix_with_whack_a_magat(self):
+        """A manifest at tmp/modules/foundups/x/whack_a_magat declaring
+        module_path=modules/gamification/whack_a_magat must be rejected
+        (parent ends with the basename but not with the declared module)."""
+        assert not _expected_module_path_matches(
+            "tmp/modules/foundups/x/whack_a_magat/foundup_manifest.json",
+            "modules/gamification/whack_a_magat",
+        )
+
+    def test_basename_only_match_rejected(self):
+        """Declaring module_path as a bare basename that happens to match the
+        manifest directory's last segment must be rejected; the entire
+        repo-relative path must match."""
+        assert not _expected_module_path_matches(
+            "modules/foundups/gotjunk/foundup_manifest.json",
+            "gotjunk",
+        )
+
+    def test_extra_suffix_segment_rejected(self):
+        """A module_path with an extra trailing segment that the parent does
+        not have must be rejected."""
+        assert not _expected_module_path_matches(
+            "modules/foundups/gotjunk/foundup_manifest.json",
+            "modules/foundups/gotjunk_extra",
+        )
+
+    def test_shadow_directory_collision_rejected(self):
+        """A module_path placed under a renamed parent (foundups_shadow) must
+        not validate against a real foundups/<name> manifest."""
+        assert not _expected_module_path_matches(
+            "modules/foundups/gotjunk/foundup_manifest.json",
+            "modules/foundups_shadow/gotjunk",
+        )
+
+    def test_suffix_collision_fails_through_full_validator(self):
+        """End-to-end through validate_manifest: a shadow-prefixed manifest
+        path with a clean module_path must fail validation with a clear
+        module_path error message."""
+        data = _valid_manifest()
+        result = validate_manifest(
+            data,
+            manifest_path="tmp/shadow/modules/foundups/example/foundup_manifest.json",
+        )
+        assert not result.ok
+        assert any("module_path" in e for e in result.errors)
+
+
+class TestCanonicalPathNormalization:
+    """Addendum A: harmless equivalents accepted; absolute, UNC, traversal,
+    and shadow-prefix forms rejected."""
+
+    @pytest.mark.parametrize(
+        "module_variant",
+        [
+            "./modules/foundups/gotjunk",
+            "modules//foundups/gotjunk",
+            "modules/foundups/./gotjunk",
+            "modules\\foundups\\gotjunk",
+            "modules/foundups/gotjunk/",  # trailing slash
+            "modules/foundups/gotjunk",   # baseline canonical
+        ],
+    )
+    def test_harmless_module_path_normalizations_accepted(self, module_variant):
+        assert _expected_module_path_matches(
+            "modules/foundups/gotjunk/foundup_manifest.json", module_variant
+        )
+
+    @pytest.mark.parametrize(
+        "bad_module_path",
+        [
+            "../modules/foundups/gotjunk",
+            "../../modules/foundups/gotjunk",
+            "O:/Foundups-Agent/modules/foundups/gotjunk",
+            "C:/Foundups-Agent/modules/foundups/gotjunk",
+            "/modules/foundups/gotjunk",
+            "\\\\server\\share\\modules\\foundups\\gotjunk",
+            "tmp/shadow/modules/foundups/gotjunk",
+            "modules/foundups_shadow/gotjunk",
+            "modules/foundups/gotjunk_extra",
+            "modules/foundups/../foundups/gotjunk",
+        ],
+    )
+    def test_unsafe_or_shadow_module_paths_rejected(self, bad_module_path):
+        assert not _expected_module_path_matches(
+            "modules/foundups/gotjunk/foundup_manifest.json", bad_module_path
+        )
+
+    def test_repo_root_absolute_manifest_with_clean_module_still_matches(self):
+        """A manifest passed in as an absolute path under the known repo
+        root must validate against a clean repo-relative module_path."""
+        absolute_manifest = (
+            _REPO_ROOT_FOR_TEST.as_posix()
+            + "/modules/foundups/gotjunk/foundup_manifest.json"
+        )
+        assert _expected_module_path_matches(
+            absolute_manifest, "modules/foundups/gotjunk"
+        )
+
+
+class TestOldSuffixBehaviorRegression:
+    """Prove the OLD suffix fallback would have accepted these, and the NEW
+    exact-only check rejects them. Mechanical regression pin."""
+
+    @staticmethod
+    def _old_suffix_match(manifest_path: str, module_path: str) -> bool:
+        """Recompute the legacy logic locally so the assertion below is
+        mechanical: we are not asking the validator about the old behavior
+        (it no longer exists); we are asking the dispatch's regression
+        guarantee directly."""
+        from pathlib import PurePosixPath as _PP
+        nm = manifest_path.replace("\\", "/")
+        no = module_path.replace("\\", "/").rstrip("/")
+        if not no:
+            return False
+        parent = _PP(nm).parent.as_posix()
+        return parent == no or parent.endswith("/" + no)
+
+    def test_suffix_match_that_old_validator_would_accept_is_rejected(self):
+        """A shadow-prefixed manifest with a clean module_path: the OLD
+        suffix fallback would have accepted; the NEW exact-only rule
+        rejects."""
+        manifest_path = "tmp/shadow/modules/foundups/gotjunk/foundup_manifest.json"
+        module_path = "modules/foundups/gotjunk"
+        # Old: would have accepted (parent ends with "/" + module_path).
+        assert self._old_suffix_match(manifest_path, module_path)
+        # New: rejected (exact-only).
+        assert not _expected_module_path_matches(manifest_path, module_path)
+
+    def test_deep_shadow_suffix_match_old_accepted_new_rejected(self):
+        """Same property, deeper shadow nesting, to catch any partial fix."""
+        manifest_path = (
+            "tmp/x/y/z/modules/platform_integration/antifafm_broadcaster"
+            "/foundup_manifest.json"
+        )
+        module_path = "modules/platform_integration/antifafm_broadcaster"
+        assert self._old_suffix_match(manifest_path, module_path)
+        assert not _expected_module_path_matches(manifest_path, module_path)
+
+    def test_exact_match_still_accepted_under_new_rule(self):
+        """Negative control: a clean exact-match path that BOTH old and new
+        accept stays accepting -- prevents over-tightening."""
+        manifest_path = "modules/foundups/kosei/foundup_manifest.json"
+        module_path = "modules/foundups/kosei"
+        assert self._old_suffix_match(manifest_path, module_path)
+        assert _expected_module_path_matches(manifest_path, module_path)
+
+
+# Repo root for tests that need to build an absolute manifest path. Computed
+# the same way the validator computes its repo root so the two stay aligned.
+_REPO_ROOT_FOR_TEST = REPO_ROOT


### PR DESCRIPTION
## Summary

Hardens `foundup_manifest_validator.py` so `build_contract.module_path` must
exact-match the manifest parent path. Suffix-match fallback identified in
#772 is removed. Pre-consumer safety fix before any WRE context-bundle
builder or runtime consumer may trust `module_path`.

- Exact-match-only validator hardening
- Suffix-match fallback removed
- All 6 manifests still validate
- Suffix-collision negative tests added
- magadoom cross-domain path remains valid by exact match
- No manifests changed
- No runtime consumer wired
- No build run
- No readiness promotion
- This unblocks the later `WRE_CONTEXT_BUNDLE_BUILDER_PHASE1` but does
  not implement it

## What changed

`modules/foundups/agent/src/foundup_manifest_validator.py`:

- `_expected_module_path_matches` now requires EXACT normalized
  repo-relative path equality. The prior `parent.endswith("/" +
  norm_module)` branch is gone.
- New helper `_canonicalize_module_path(raw)` normalizes to repo-relative
  POSIX form. Accepts harmless equivalents (leading `./`, repeated `/`,
  `.` segments, backslashes). Rejects empty / absolute (drive prefix or
  leading `/`) / UNC / any `..` segment.
- New helper `_canonicalize_manifest_path_for_compare(raw)` does the same
  plus strips a known repo-root prefix (case-insensitive for Windows
  drive-letter casing) so absolute on-disk manifest paths compare
  correctly.
- Module-level `import re` and `from pathlib import Path` added.
  Validator imports are still: `__future__`, `dataclasses`, `json`,
  `pathlib`, `re`, `typing`. No runtime executor / consumer imports.

`modules/foundups/agent/tests/test_foundup_manifest_validator.py`:

- `TestExactMatchHelperDirect` (8): direct unit tests on the three
  helpers, including the harmless / unsafe / internal-traversal /
  repo-root-strip / canonical-module-None paths.
- `TestSuffixCollisionRejected` (6): shadow-prefix collision,
  cross-domain `whack_a_magat`, basename-only match, extra-suffix
  segment, shadow-directory collision, and the through-validator path.
- `TestCanonicalPathNormalization` (16 parametrized): harmless
  normalizations accepted; absolute / UNC / `..` / shadow rejected; an
  absolute repo-rooted manifest still matches a clean repo-relative
  module_path.
- `TestOldSuffixBehaviorRegression` (3): reimplements the legacy
  suffix-match locally inside the test, asserts it would have accepted
  the input, asserts the new exact-only helper rejects it. Mechanically
  pins the regression.

`modules/foundups/agent/ModLog.md`:

- Slice entry citing #770, #771, #772.
- WSP_97 Truth Boundary Checklist with 26 rows, all YES (canonical
  header `| # | Truth Boundary Checklist Item | Status | Evidence |`).

`modules/foundups/agent/tests/TestModLog.md`:

- Test summary: 88 passed in 0.28s; 0 skipped; 0 xfailed.

## Boundary preserved

- Validator remains read-only (`test_validator_no_exec_process_network_or_write`
  and `test_validator_imports_no_runtime_executors` both pass).
- No `foundup_manifest.json` touched. No registry / projection / catalog
  / manifest module touched. No runtime consumer wired (no file in
  `moltbot_bridge/`, `wre_core/`, `ai_overseer/`, no `*_dae.py`).
- No readiness promotion. No CABR / payout / DAO / token / `.env` /
  `main.py` touched.
- AI Overseer is in `ALLOWED_AUDITORS` only; not added to
  `ALLOWED_EXECUTORS` or `ALLOWED_ORCHESTRATORS`.
- Commands remain argv-or-null only; shell strings / metacharacters
  still rejected by the unchanged `_validate_command_block`.
- No skip / no xfail.

## Test plan

- [x] `python -m pytest modules/foundups/agent/tests/test_foundup_manifest_validator.py -q` -> **88 passed in 0.28s**
- [x] AST self-check: 0 banned imports (subprocess / socket / urllib /
      os / sys / shutil / pickle / ...), 0 runtime executor imports
      (hermes / openclaw / ai_overseer / job_consumer / wre_core), 0
      banned name calls (`open`, `eval`, `exec`, `compile`, ...), 0
      banned attr calls (`run`, `Popen`, `write`, `urlopen`, ...).
- [x] ASCII check: slice-introduced content is 0 non-ASCII bytes.
- [x] All 6 real manifests validate via `test_all_six_manifests_validate`
      and via the direct helper parametrize in `TestExactMatchHelperDirect`.

## Scope guardrails

Allowed files only:
- `modules/foundups/agent/src/foundup_manifest_validator.py`
- `modules/foundups/agent/tests/test_foundup_manifest_validator.py`
- `modules/foundups/agent/ModLog.md`
- `modules/foundups/agent/tests/TestModLog.md`

Predecessors: #770 (manifest readiness boundary), #771 (baseline
build_contract / read-only validator), #772 (WRE context-bundle
boundary audit; identified the suffix-match fallback).

Worker-Lane: W6
Slice: FOUNDUP_MANIFEST_VALIDATOR_MODULE_PATH_EXACT_MATCH_HARDENING_PHASE1
Do NOT merge. Leave OPEN for W10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)