### PR TITLE
fix(foundups): guard Hermes module_path resolution with manifest validator (W6)

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -1,5 +1,76 @@
 # FoundUps Agent - Development Log
 
+## [2026-06-10] Hermes Module-Path Trust Removal Phase 1 (#774 carry-forward closure)
+
+**Change Type**: Authoring slice (security pre-flight, last consumer-wiring
+precondition)
+**By**: 0102 (W6) | Commander: 012
+**WSP References**: WSP 11, WSP 50, WSP 77, WSP 84, WSP 87, WSP 97, WSP 22
+**Slice**: `HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1`
+**Branch / PR**: `w6/hermes-module-path-trust-removal-phase1` -- PR opened
+against `main` (do NOT merge; W10 gate hold)
+**Base**: `0952f51e9` (origin/main after #777)
+
+**What this slice closes**: The #774 audit identified
+`hermes_foundup_job_executor._extract_module_path:217-237` as a
+"validator bypass risk" -- the legacy executor trusted
+`payload.module_path` / `payload.source_module` / a path-shaped
+`foundup_id` without manifest validation. The audit classified this as
+a BLOCKER for consumer wiring, NOT for the #775 ContextBundle builder.
+
+**What this slice does**: Replaces the raw extraction with
+`_resolve_validated_module_path`, which consumes the #773 manifest
+validator and enforces fail-closed behavior with a 4-token greppable
+failure taxonomy (`syntactic_reject` / `manifest_mismatch` /
+`manifest_missing` / `cross_foundup_mismatch`). Cross-FoundUp
+substitution defense (Addendum D #1) binds resolution strictly to
+`job.foundup_id`. Case-variant + backslash + traversal + absolute /
+UNC / non-`modules/` paths all reject pre-manifest. Empty-string
+payload is treated as ABSENT (Addendum D #4). The `foundup_id`-as-path
+heuristic is REMOVED entirely; when payload omits a path, a bounded
+scan over the 6 canonical manifest directories locates the manifest
+by `foundup_id`. Observable-ignore: the rejected payload value is
+preserved in `evidence_refs` even when the failure token is not strictly
+about it (mirrors #777's source_authority resolver convention).
+
+**Consumer-wiring precondition status (post-this-slice)**:
+
+- Precondition (a) `FOUNDUP_LIFECYCLE_SOURCE_AUTHORITY_CONTRACT_PHASE1`
+  -- satisfied by #777.
+- Precondition (b) legacy `payload.module_path` trust removed /
+  validator-guarded -- **satisfied by THIS SLICE at the Hermes
+  executor seam**.
+- Carry-forward to next consumer slice: per Addendum D #2 tie-break,
+  the `build_plan_generator.py:167, :276, :282` reads are
+  `OUT_OF_SCOPE_NAMED_FOLLOWUP` for this slice (zero non-test, non-doc
+  importers; `BuildPlanExecutor.execute_step` is a BLOCKED stub today).
+  Phase-0 ruling: **current reachability decides**. The follow-up
+  `BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1` becomes a
+  HARD precondition row in `WRE_CONTEXT_BUNDLE_DRYRUN_CONSUMER_PHASE1`
+  or any other slice that makes build_plan_generator reachable from a
+  real-execution sink.
+
+**Tests**: 621 passed / 0 skipped / 0 xfailed across the agent module
+suite (46 executor tests including 24 new in
+`TestResolvedModulePathValidation`).
+
+**Boundary preserved**: validator NOT mutated; manifests NOT mutated;
+`hermes_adapter.py` and runtime NOT touched; no new dependency; no WSP
+file mutated; `StatusReasonCode` enum unchanged (granularity is in the
+greppable token prefix on `reason_human` + parallel `evidence_refs`
+entry).
+
+**WSP_97**: PASS (27/27) -- full table in
+[`modules/foundups/agent/ModLog.md`](modules/foundups/agent/ModLog.md).
+
+**Predecessors**: #770 (manifest readiness audit), #771 (baseline
+validator), #772 (context-bundle boundary audit), #773 (exact-match
+validator hardening), #774 (execution-chain audit -- this is the
+carry-forward closure), #775 (ContextBundle builder), #777
+(source-authority contract).
+
+---
+
 ## [2026-06-10] WSP_00 State Bridge Restored - Gate Now Observes V2 Awakening
 
 **Change Type**: Bug fix (compliance gate) + WSP_00 doc enhancement

--- a/modules/foundups/agent/INTERFACE.md
+++ b/modules/foundups/agent/INTERFACE.md
@@ -1,6 +1,90 @@
 # Agent Module Interface
 
-Public API and schema contracts for agent lifecycle management, BuildPlan generation, controlled execution, read-only manifest provenance, and the FoundUp source-authority contract.
+Public API and schema contracts for agent lifecycle management, BuildPlan generation, controlled execution, read-only manifest provenance, source-authority contract, and validated module-path resolution.
+
+## Validated Module-Path Resolution (HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1)
+
+Closes the #774 carry-forward by forcing every job's `module_path` through the
+#773 manifest validator before the Hermes executor's subprocess sink is reached.
+This is the LAST consumer-wiring precondition.
+
+```python
+# modules/foundups/agent/src/hermes_foundup_job_executor.py
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class ResolvedModulePath:
+    """Outcome of validated module-path resolution. Observable-ignore shape."""
+    effective: Optional[str]              # canonical module_path from validated manifest
+    ignored: Optional[str]                # stringified payload-declared value (None iff no declaration)
+    failed: bool
+    fail_token: Optional[str]             # closed-set greppable token, or None on success
+    fail_human: str                       # token-prefixed explanation; empty on success
+
+
+def _resolve_validated_module_path(
+    job: FoundUpJob,
+    repo_root: Path,
+) -> ResolvedModulePath:
+    """Resolve a job's module_path through the #773 validator. Fail-closed.
+
+    Pinned design:
+    - candidate = payload.module_path | payload.source_module (alias).
+    - empty-string is ABSENT (Addendum D #4).
+    - foundup_id-as-path heuristic REMOVED ("/" in foundup_id is never a source).
+    - syntactic hardening BEFORE manifest contact: backslashes / absolute /
+      UNC / ".." traversal / not-under-modules/ all reject pre-manifest.
+    - manifest located: <repo_root>/<canonical>/foundup_manifest.json, OR
+      bounded foundup_id scan when candidate absent.
+    - validator gate: validate_manifest_file (#773); never raises.
+    - cross-FoundUp substitution defense (Addendum D #1, load-bearing):
+      the manifest's foundup_id MUST equal job.foundup_id; otherwise reject.
+    - case-variant defense (Addendum D #3): candidate canonical exact-string
+      compared against manifest canonical (case-sensitive).
+    - observable ignored: payload-declared value visible in result.ignored
+      even on success (mirrors source_authority.resolve_source_authority).
+    """
+```
+
+### Greppable failure-mode tokens
+
+`StatusReasonCode` stays frozen at `FAIL_VALIDATION_ERROR`; granularity is
+emitted as a token prefix on `reason_human` plus a parallel
+`evidence_refs` entry (`fail_token:<token>`):
+
+```python
+FAIL_TOKEN_SYNTACTIC_REJECT       = "syntactic_reject"        # absolute / UNC / .. / backslash / not-under-modules/
+FAIL_TOKEN_MANIFEST_MISMATCH      = "manifest_mismatch"       # validator returned shape error or candidate != manifest canonical
+FAIL_TOKEN_MANIFEST_MISSING       = "manifest_missing"        # file not found / unreadable / JSON-invalid
+FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH = "cross_foundup_mismatch"  # manifest foundup_id != job.foundup_id
+
+ALL_FAIL_TOKENS: frozenset = frozenset({
+    "syntactic_reject", "manifest_mismatch", "manifest_missing", "cross_foundup_mismatch",
+})
+```
+
+### Evidence-trail contract (`execute_foundup_job` failure path)
+
+When the resolver fails, `execute_foundup_job` calls
+`job.fail(reason_code=FAIL_VALIDATION_ERROR, reason_human=resolved.fail_human,
+evidence_refs=evidence)` BEFORE `job.start(...)`, so the subprocess sink
+(`HermesFoundUpBuilder.run_hermes_extraction` per the #774 audit) is
+never reached. The evidence list includes:
+
+- `rejected_payload_value:<stringified declaration>` (only if the payload
+  actually declared something), and
+- `fail_token:<one of ALL_FAIL_TOKENS>` (always).
+
+### Consumer-wiring precondition status
+
+This slice satisfies the #774 carry-forward at the Hermes executor seam.
+The follow-up `BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1`
+(Phase-0 ruling: `OUT_OF_SCOPE_NAMED_FOLLOWUP`, Addendum B/D tie-break:
+"current reachability decides") is a hard precondition for
+`WRE_CONTEXT_BUNDLE_DRYRUN_CONSUMER_PHASE1` or any other slice that
+makes `build_plan_generator` reachable from a real-execution sink.
 
 ## Source-Authority Contract (FOUNDUP_LIFECYCLE_SOURCE_AUTHORITY_CONTRACT_PHASE1)
 

--- a/modules/foundups/agent/ModLog.md
+++ b/modules/foundups/agent/ModLog.md
@@ -1,5 +1,267 @@
 # Agent Module ModLog
 
+## 2026-06-10 - Hermes Module-Path Trust Removal Phase 1 (#774 carry-forward closure)
+
+**Author**: 0102 (W6)
+**Commander**: 012
+**Slice**: HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1
+**Branch**: `w6/hermes-module-path-trust-removal-phase1`
+**Base**: `0952f51e9` (origin/main after #777)
+**Effort**: ULTRA
+
+**Type**: Authoring slice (last consumer-wiring precondition).
+Closes the #774 carry-forward by forcing every job's `module_path`
+through the #773 validator before the Hermes executor's subprocess
+sink. Fail-closed. No consumer wiring; no validator / manifest /
+runtime / WSP touch.
+
+**WSP References**: WSP 11, WSP 50, WSP 77, WSP 84, WSP 87, WSP 97,
+WSP 22.
+
+### Phase 0 -- Mandatory Discovery summary
+
+- **HoloIndex**: 4/4 queries returned HOLOINDEX_LOW_SIGNAL despite the
+  subject domain being well-represented in `modules/foundups/agent/`,
+  `modules/communication/moltbot_bridge/`, and recent commits
+  (`27d6d2c22` hermes delegate-path fix). `public/litepaper.html` and
+  similar large HTML/JS surfaces dominated cosine ranking. Recorded as
+  a HoloIndex tuning concern, not a slice blocker; manual `Read`/`Grep`
+  surfaced every target file with verbatim file:line citations.
+- **Executor + validator + manifest convention survey**: full quotes
+  with file:line cited; the manifest-on-disk join key is
+  `<repo_root>/<module_path>/foundup_manifest.json`. No
+  `foundup_id`-to-path index exists; bounded scan over the 6 canonical
+  manifest directories (8 manifests today) is the explicit alternative
+  to the removed `foundup_id`-as-path heuristic.
+- **#774 audit verbatim finding**: "Legacy executor trusts
+  payload.module_path. This is a consumer-wiring blocker, not a
+  builder blocker." Cited at
+  `docs/audits/architecture/OPENCLAW_HERMES_WRE_EXECUTION_CHAIN_AUDIT_PHASE1.md:378-390`
+  with evidence pointer to
+  `modules/foundups/agent/src/hermes_foundup_job_executor.py:217-237`
+  (the now-removed `_extract_module_path`).
+- **#770-#773 ModLog reading**: lineage captured. The #773 validator
+  exposes `validate_manifest` / `validate_manifest_file` /
+  `ManifestValidationResult` publicly; `_canonicalize_module_path` is
+  module-private but consumable via explicit import (minimum
+  blast-radius per Survey B.2; no public-surface change).
+- **Build-plan-generator scope ruling** (Addendum B/D, load-bearing):
+  **`OUT_OF_SCOPE_NAMED_FOLLOWUP`**. Evidence:
+  `modules/foundups/agent/src/build_plan_generator.py:167, :276` read
+  `payload.module_path`/`source_module` and at `:282` synthesize
+  `f"modules/foundups/{job.foundup_id}"`. Reachability analysis
+  confirmed ZERO non-test, non-doc importers; the only downstream
+  consumer (`BuildPlanExecutor.execute_step`) is a stub that returns
+  `StepExecutionStatus.BLOCKED` for any real execution
+  (`build_plan_executor.py:634-665`). `build_plan_swarm.py` and
+  `swarm_dispatch_integration.py` only label-match
+  `target.module_path`; no `subprocess`, no `hermes_adapter` import.
+  Tie-break per Addendum D #2: **current reachability decides** --
+  unreachable now, follow-up
+  `BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1` becomes a
+  hard precondition row in `WRE_CONTEXT_BUNDLE_DRYRUN_CONSUMER_PHASE1`
+  or any other slice that makes build_plan_generator reachable from a
+  real-execution sink.
+
+### Changed
+
+- **`modules/foundups/agent/src/hermes_foundup_job_executor.py`**:
+  - **REMOVED** `_extract_module_path` (raw-trust extraction; the
+    function and its 3-priority cascade including the
+    `foundup_id`-with-`/`-is-a-path heuristic).
+  - **ADDED** `ResolvedModulePath` frozen dataclass with the
+    observable-ignore tuple shape (`effective`, `ignored`, `failed`,
+    `fail_token`, `fail_human`) mirroring #777's
+    `source_authority.resolve_source_authority`.
+  - **ADDED** `_stringify_ignored(declared)` -- mirror of
+    source_authority's ignored-value stringification; None iff
+    declaration None, else `str(declared)`.
+  - **ADDED** `_find_manifest_for_foundup_id(repo_root, foundup_id)` --
+    bounded glob over the 6 canonical manifest directories; reads each
+    candidate's top-level `foundup_id` and returns the first match.
+    Used ONLY when payload omits both `module_path` and `source_module`.
+    Replaces the removed `foundup_id`-as-path heuristic with an
+    explicit, evidence-backed lookup.
+  - **ADDED** `_resolve_validated_module_path(job, repo_root)` -- the
+    fail-closed resolver. Pinned-design conformance:
+      1. candidate from `payload.module_path` / `payload.source_module`
+         (alias); empty string is ABSENT (Addendum D #4).
+      2. syntactic hardening BEFORE any manifest contact: backslashes
+         (Addendum C #5), absolute / UNC (Addendum C #6), `..`
+         traversal (Addendum C #6), `not startswith("modules/")` all
+         REJECTED with `fail_token=syntactic_reject`.
+      3. manifest located at
+         `<repo_root>/<canonical>/foundup_manifest.json`, OR via
+         bounded `foundup_id` scan when candidate absent.
+      4. `validate_manifest_file` (#773) gates; I/O-class errors map to
+         `manifest_missing`, shape errors to `manifest_mismatch`.
+      5. **Cross-FoundUp substitution defense** (Addendum D #1,
+         load-bearing): manifest's `foundup_id` MUST equal
+         `job.foundup_id`; otherwise `fail_token=cross_foundup_mismatch`.
+      6. **Case-variant defense** (Addendum D #3, Windows host
+         reality): candidate canonical exact-string-compared
+         (case-sensitive) against manifest canonical; mismatch =>
+         `fail_token=manifest_mismatch`.
+      7. Success: `effective` is the manifest's canonical
+         `module_path` (the source of truth). The payload-declared
+         value remains in `ignored` even when it matches (observable
+         silent-swallow refused).
+  - **ADDED** `DEFAULT_REPO_ROOT` (derived from `__file__`),
+    `_MANIFEST_SEARCH_GLOBS`, `ALL_FAIL_TOKENS` frozenset, and four
+    `FAIL_TOKEN_*` constants (`syntactic_reject`, `manifest_mismatch`,
+    `manifest_missing`, `cross_foundup_mismatch`) -- greppable
+    failure-mode taxonomy per Addendum D #5.
+  - **REPLACED** the prior `if not module_path: job.fail(...)` block
+    (lines 153-167) with the resolver invocation. On failure, the
+    evidence list carries both
+    `rejected_payload_value:<stringified>` (when the payload declared
+    something) and `fail_token:<one of ALL_FAIL_TOKENS>` (always).
+    `StatusReasonCode.FAIL_VALIDATION_ERROR` reused as-is; no
+    job-contract schema changes.
+- **`modules/foundups/agent/tests/test_hermes_foundup_job_executor.py`**:
+  - **UPDATED FIXTURES** `queued_extract_job` / `queued_validate_job` /
+    `queued_build_job` to use the real manifest `gotjunk_001`
+    (`modules/foundups/gotjunk`) so the new validated-resolution
+    pre-flight passes and the downstream mocked-Hermes paths still
+    exercise their mappings. Prior synthetic `modules/foundups/widget`
+    path no longer reaches the executor (refused as
+    `manifest_missing`).
+  - **UPDATED** `TestActionDispatch::test_extract_foundup_calls_extract_method`
+    and `..._validate_foundup_calls_gate_and_boundary` assertions to
+    expect `modules/foundups/gotjunk` (was `widget`).
+  - **UPDATED** `TestModulePathExtraction`: replaced
+    `test_foundup_id_as_fallback` with
+    `test_foundup_id_path_heuristic_removed` (explicit no-inference
+    assertion); existing `test_module_path_from_payload` and
+    `test_source_module_from_payload` retained as documentation of
+    payload shape; new behavior covered in
+    `TestResolvedModulePathValidation`.
+  - **ADDED** `TestResolvedModulePathValidation` (24 tests, no skip /
+    no xfail) covering:
+    - Happy paths: real `gotjunk_001` manifest; cross-domain `kosei`.
+    - Addendum C #1 (`test_payload_path_wrong_manifest_path_rejected`)
+      + payload alias variant.
+    - Addendum C #2 (`test_source_module_alias_validates_same_as_module_path`,
+      `..._with_wrong_path_rejected`).
+    - Addendum C #4 (`test_suffix_only_path_rejected`,
+      `test_partial_path_rejected`).
+    - Addendum C #5 (`test_backslash_payload_rejected_pre_manifest`).
+    - Addendum C #6 (`test_absolute_path_rejected_pre_manifest`,
+      `..._absolute_drive_path_..`, `..._traversal_path_..`,
+      `..._internal_traversal_..`).
+    - Addendum C #7 (`test_payload_omitted_derives_from_validated_manifest`,
+      `..._unknown_foundup_id_fails_missing`).
+    - Addendum C #8 (`test_rejected_payload_value_appears_in_evidence`,
+      end-to-end through `execute_foundup_job`).
+    - Addendum D #1 (`test_cross_foundup_substitution_rejected`,
+      `..._via_alias_rejected`).
+    - Addendum D #3 (`test_case_variant_payload_rejected`,
+      `test_uppercase_modules_prefix_rejected`).
+    - Addendum D #4 (`test_empty_string_payload_treated_as_absent`,
+      `..._empty_string_alias_..`).
+    - Closed-set token taxonomy
+      (`test_all_fail_tokens_present_in_taxonomy`).
+    - End-to-end no-builder-instantiation guards
+      (`test_execute_foundup_job_fails_closed_on_invalid_payload`,
+      `..._on_cross_foundup_substitution`).
+
+### Boundary preserved
+
+- **NO_VALIDATOR_MUTATION**: `foundup_manifest_validator.py` untouched;
+  the executor IMPORTS public + one underscore-helper without changing
+  the validator's surface.
+- **NO_MANIFEST_MUTATION**: no `foundup_manifest.json` modified.
+- **NO_RUNTIME_OR_BUILDER_CHANGE**: `hermes_adapter.py` and the rest of
+  the runtime are untouched. The patch is purely in the executor's
+  pre-flight; the subprocess sink remains exactly where it was
+  (`hermes_adapter.py:939, :946`).
+- **NO_CONSUMER_WIRING**: no new caller wired into the Hermes
+  executor; this slice only hardens the EXISTING execution seam.
+- **NO_WSP_FILE_MUTATION**: nothing under `WSP_framework/` or
+  `WSP_knowledge/`.
+- **NO_NEW_DEPENDENCY**: only stdlib imports (`json`, `pathlib`,
+  `dataclasses`) and the existing intra-repo validator import.
+- **NO_JOB_CONTRACT_SCHEMA_CHANGE**: `StatusReasonCode` enum unchanged;
+  `FAIL_VALIDATION_ERROR` reused. Granularity comes from the greppable
+  fail-token prefix on `reason_human` + a parallel `evidence_refs`
+  entry.
+
+### Tests
+
+```
+python -m pytest modules/foundups/agent/tests/test_hermes_foundup_job_executor.py -q
+  -> 46 passed in 0.84s
+python -m pytest modules/foundups/agent/tests/ -q
+  -> 621 passed in 9.06s (575 prior + 22 pre-existing executor + 24 new resolution tests)
+```
+
+0 skipped. 0 xfailed.
+
+### Updated assertions (logged for W10 audit per dispatch)
+
+- `TestActionDispatch::test_extract_foundup_calls_extract_method` --
+  expected source_module changed from `modules/foundups/widget` to
+  `modules/foundups/gotjunk` (validator-confirmed real manifest).
+- `TestActionDispatch::test_validate_foundup_calls_gate_and_boundary` --
+  same change.
+- `TestModulePathExtraction::test_foundup_id_as_fallback` -- RENAMED to
+  `test_foundup_id_path_heuristic_removed`; assertion flipped from
+  "foundup_id with '/' is used as a path" to "foundup_id with '/' is
+  NEVER used as a path; bounded scan or manifest_missing wins".
+- Fixtures `queued_extract_job` / `queued_validate_job` /
+  `queued_build_job` -- payload/foundup_id changed from synthetic
+  `widget` to real `gotjunk_001`/`modules/foundups/gotjunk`.
+
+### WSP_97 Truth Boundary Checklist
+
+| # | Truth Boundary Checklist Item | Status | Evidence |
+|---|-------------------------------|--------|----------|
+| 1 | HOLOINDEX_PRIOR_ART_SEARCHED | YES | Phase-0 ran 4 queries; results recorded above with retrieval evaluation. All 4 returned LOW signal -- a HoloIndex tuning finding, not a slice blocker. Manual Read/Grep surfaced every target file. |
+| 2 | WSP_84_REUSE_DECISION_DOCUMENTED | YES | Imports validator (`validate_manifest_file`, `_canonicalize_module_path`) -- does not reimplement. No competing axis invented. |
+| 3 | VALIDATOR_REUSED_NOT_REIMPLEMENTED | YES | `from modules.foundups.agent.src.foundup_manifest_validator import validate_manifest_file` and `_canonicalize_module_path as _validator_canonicalize_module_path`. No validator logic duplicated. |
+| 4 | NO_VALIDATOR_MUTATION | YES | `git diff` confirms `foundup_manifest_validator.py` is unchanged. |
+| 5 | NO_MANIFEST_MUTATION | YES | `git diff` confirms no `foundup_manifest.json` modified. |
+| 6 | NO_RUNTIME_OR_BUILDER_CHANGE | YES | `hermes_adapter.py` untouched. The patch is purely in the executor's pre-flight; the subprocess sink (`hermes_adapter.py:939, :946`) is unreached for failed jobs (verified by end-to-end test with mocked builder). |
+| 7 | NO_CONSUMER_WIRING | YES | No new caller wired; existing execution seam only hardened. |
+| 8 | NO_WSP_FILE_MUTATION | YES | `git diff` confirms no file under `WSP_framework/` or `WSP_knowledge/`. |
+| 9 | NO_JOB_CONTRACT_SCHEMA_CHANGE | YES | `StatusReasonCode` enum unchanged; `FAIL_VALIDATION_ERROR` reused. |
+| 10 | NO_USER_QUESTION_FRAMING | YES | Addendum A respected: no AskUser dialog used in this slice. Phase-0 fork (`build_plan_generator` ruling) was decided by 4-step protocol (evidence -> WSP_97 condition -> recommendation -> stop only if dispatch requires) -- ruling was OUT_OF_SCOPE_NAMED_FOLLOWUP, recorded in the Phase-0 summary. |
+| 11 | BUILD_PLAN_GENERATOR_SCOPE_RULED | YES | Phase-0 ruling: `OUT_OF_SCOPE_NAMED_FOLLOWUP`. Evidence: `build_plan_generator.py:167, :276, :282` quoted; reachability shows zero non-test, non-doc importers and BuildPlanExecutor.execute_step is a BLOCKED stub. Follow-up named: `BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1`. Tie-break per Addendum D #2: current reachability decides; follow-up becomes a hard precondition row in `WRE_CONTEXT_BUNDLE_DRYRUN_CONSUMER_PHASE1`. |
+| 12 | OLD_PAYLOAD_MODULE_PATH_TRUST_DEAD | YES | The prior `_extract_module_path` is REMOVED from the source tree. `git diff` confirms removal. Tests that would have passed under the legacy trust (`test_payload_path_wrong_manifest_path_rejected`, `test_cross_foundup_substitution_rejected`) now FAIL the prior behavior and PASS the new fail-closed semantics. |
+| 13 | SOURCE_MODULE_ALIAS_VALIDATED | YES | `test_source_module_alias_validates_same_as_module_path` (happy path), `..._with_wrong_path_rejected` (alias gets the same fail-closed treatment), `test_cross_foundup_substitution_via_alias_rejected`, `test_empty_string_alias_also_treated_as_absent`. |
+| 14 | FOUNDUP_ID_PATH_HEURISTIC_REMOVED | YES | Source: the `if job.foundup_id and "/" in job.foundup_id: return job.foundup_id` branch is gone. Test: `TestModulePathExtraction::test_foundup_id_path_heuristic_removed` asserts that a path-shaped foundup_id with empty payload returns `failed=True, fail_token=manifest_missing`, NOT a derived path. |
+| 15 | REJECTED_PAYLOAD_VALUE_OBSERVABLE | YES | `ResolvedModulePath.ignored` preserved even on success. `test_happy_path_real_manifest_resolves_to_canonical` asserts `ignored == "modules/foundups/gotjunk"` even on a successful match. `test_rejected_payload_value_appears_in_evidence` asserts the `rejected_payload_value:...` entry is in `evidence_refs` on FAILED end-to-end. |
+| 16 | VALIDATED_MANIFEST_SOURCE_OF_TRUTH | YES | `ResolvedModulePath.effective` is sourced from `manifest_data.get("build_contract", {}).get("module_path", "")` after `validate_manifest_file` returns `ok=True`. Payload candidate is only used for the candidate-vs-manifest exact-string check; the effective value is always the manifest's canonical module_path. `test_payload_omitted_derives_from_validated_manifest` pins the derivation. |
+| 17 | CROSS_FOUNDUP_SUBSTITUTION_REJECTED | YES | Step 6 of the resolver enforces `manifest_foundup_id != job.foundup_id -> FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH`. Tests: `test_cross_foundup_substitution_rejected` (primary, via `module_path`), `test_cross_foundup_substitution_via_alias_rejected` (via `source_module`), `test_execute_foundup_job_fails_closed_on_cross_foundup_substitution` (end-to-end with mocked builder asserting `mock_builder_cls.assert_not_called()`). |
+| 18 | CASE_VARIANT_PATH_REJECTED | YES | `test_case_variant_payload_rejected` (`modules/Foundups/gotjunk` -- inner caps), `test_uppercase_modules_prefix_rejected` (`Modules/foundups/gotjunk` -- prefix caps). Both reject (either at the `startswith("modules/")` syntactic guard or at the step-7 case-sensitive exact-match against the manifest canonical). |
+| 19 | SYNTACTIC_REJECT_PRE_MANIFEST | YES | `test_backslash_payload_rejected_pre_manifest`, `test_absolute_path_rejected_pre_manifest`, `test_absolute_drive_path_rejected_pre_manifest`, `test_traversal_path_rejected_pre_manifest`, `test_internal_traversal_rejected`, `test_suffix_only_path_rejected`, `test_partial_path_rejected`. All return `fail_token=syntactic_reject` BEFORE the manifest is read. |
+| 20 | GREPPABLE_FAIL_TOKENS_PINNED | YES | `test_all_fail_tokens_present_in_taxonomy` asserts the closed set is exactly `{syntactic_reject, manifest_mismatch, manifest_missing, cross_foundup_mismatch}`. Every `_resolve_validated_module_path` failure path emits one of these tokens via `reason_human` prefix + `evidence_refs[fail_token:...]` entry. |
+| 21 | EMPTY_STRING_TREATED_AS_ABSENT | YES | `test_empty_string_payload_treated_as_absent` and `..._empty_string_alias_..` pin that `""` is falsy and falls through to derivation; `ignored` stays `None`. |
+| 22 | NO_NEW_DEPENDENCY | YES | Imports added: stdlib `json`, `dataclasses.dataclass`; intra-repo validator only. No new package or version. |
+| 23 | NO_SKIP_XFAIL | YES | `pytest -q modules/foundups/agent/tests/` -> `621 passed in 9.06s`; 0 skipped; 0 xfailed. |
+| 24 | CITES_PR_770_771_772_773_774_AND_777 | YES | Header Predecessors cites #770-#774; section 5 cites the laundering-fix lineage and #777's observable-ignore convention; the resolver docstring cites #773 for exact-match and #774 for the trust gap; INTERFACE.md "Consumer-wiring precondition status" cites the follow-up name. |
+| 25 | CONSUMER_WIRING_REMAINS_BLOCKED_UNTIL_FOLLOWUP | YES | INTERFACE.md and the contract section above state that
+`BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1` is a hard precondition row for `WRE_CONTEXT_BUNDLE_DRYRUN_CONSUMER_PHASE1`. Tie-break per Addendum D #2: current reachability decides. |
+| 26 | INTERFACE_MD_UPDATED | YES | New "Validated Module-Path Resolution" section added (WSP_22 order: INTERFACE -> ROADMAP -> ModLog -> TestModLog). |
+| 27 | ASCII_CLEAN | YES | Slice-introduced content is 0 non-ASCII bytes across `hermes_foundup_job_executor.py` patch, new tests, INTERFACE/ROADMAP additions, this ModLog entry, TestModLog entry, and root ModLog entry. |
+
+**WSP_97 VERDICT**: PASS (27/27).
+
+### Follow-ups (recorded; not executed here)
+
+- `BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1` -- hardens
+  the build_plan_generator value flow with the same validator gate;
+  becomes a HARD precondition row in
+  `WRE_CONTEXT_BUNDLE_DRYRUN_CONSUMER_PHASE1` per Addendum D #2.
+- `HOLOINDEX_LIFECYCLE_TUNING_PHASE1` (already proposed by #777) --
+  the LOW signal on all 4 Phase-0 queries here strengthens the case.
+- `WRE_CONTEXT_BUNDLE_DRYRUN_CONSUMER_PHASE1` -- can now safely wire
+  the #775 ContextBundle into the Hermes executor seam IF AND ONLY IF
+  the BUILD_PLAN_GENERATOR follow-up has landed (per Addendum D #2
+  tie-break).
+
+---
+
 ## 2026-06-10 - FoundUp Lifecycle / Source-Authority Contract Phase 1
 
 **Author**: 0102 (W6)

--- a/modules/foundups/agent/ROADMAP.md
+++ b/modules/foundups/agent/ROADMAP.md
@@ -23,8 +23,23 @@
   - Deterministic sha256-derived `bundle_id`; `created_at` injected
   - Stream-hashed file refs (no full-body load); per-file + total caps
   - Refuses any readiness promotion, external agent, self-authorize
-  - No Hermes / OpenClaw / WRE consumer wiring (consumer wiring blocked
-    until #774 carry-forward removes legacy payload.module_path trust)
+  - No Hermes / OpenClaw / WRE consumer wiring
+- [x] Validated module-path resolution in Hermes executor
+  (HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1)
+  - Closes the #774 carry-forward: payload.module_path is no longer trusted
+  - `_resolve_validated_module_path` consumes the #773 validator;
+    `_extract_module_path` raw-trust function REMOVED
+  - foundup_id-as-path heuristic REMOVED (path-shaped foundup_id is not
+    a path source); bounded foundup_id scan used when payload omits path
+  - Cross-FoundUp substitution defense: manifest's foundup_id MUST equal
+    job.foundup_id (Addendum D #1)
+  - Case-variant + backslash + traversal + absolute + UNC all rejected
+    pre-manifest (`fail_token=syntactic_reject`)
+  - Greppable failure tokens: `syntactic_reject` / `manifest_mismatch` /
+    `manifest_missing` / `cross_foundup_mismatch`
+  - Observable-ignore: rejected payload value visible in evidence_refs
+  - StatusReasonCode unchanged (FAIL_VALIDATION_ERROR); no job-contract
+    schema changes; no validator / manifest / runtime / WSP touch
 - [x] FoundUp source-authority contract (FOUNDUP_LIFECYCLE_SOURCE_AUTHORITY_CONTRACT_PHASE1)
   - Authoritative definition doc at
     `docs/architecture/FOUNDUP_SOURCE_AUTHORITY_CONTRACT.md`

--- a/modules/foundups/agent/src/hermes_foundup_job_executor.py
+++ b/modules/foundups/agent/src/hermes_foundup_job_executor.py
@@ -32,7 +32,9 @@ NAVIGATION:
 
 from __future__ import annotations
 
+import json
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -42,6 +44,19 @@ from modules.communication.moltbot_bridge.src.foundup_job_contract import (
     PolicyFlags,
     StatusReasonCode,
     is_terminal_status,
+)
+
+# Module-path resolution (HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1):
+# the #773 validator is imported and consumed as the source of truth for
+# any module_path that enters the executor. The leading-underscore helper
+# is intentionally a module-private import per the validator's "no IO /
+# no execution" contract; we do NOT mutate the validator's public surface
+# in this slice.
+from modules.foundups.agent.src.foundup_manifest_validator import (
+    validate_manifest_file,
+)
+from modules.foundups.agent.src.foundup_manifest_validator import (
+    _canonicalize_module_path as _validator_canonicalize_module_path,
 )
 
 logger = logging.getLogger("hermes_foundup_job_executor")
@@ -55,6 +70,78 @@ SUPPORTED_ACTIONS = frozenset({
     "extract_foundup",
     "validate_foundup",
 })
+
+
+# ---------------------------------------------------------------------------
+# Module-path resolution constants (HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1)
+# ---------------------------------------------------------------------------
+
+# Default repository root for manifest lookup. Derived from this source file's
+# location so the executor does not depend on a CWD or env var.
+# modules/foundups/agent/src/hermes_foundup_job_executor.py -> parents[4] = repo root
+DEFAULT_REPO_ROOT: Path = Path(__file__).resolve().parents[4]
+
+# Bounded glob set for foundup_id -> manifest lookup when the job payload
+# omits module_path / source_module entirely. Mirrors the canonical
+# manifest directory set surveyed in Phase 0 (8 manifests on disk today;
+# this slice's lookup walks at most these globs and never recurses).
+_MANIFEST_SEARCH_GLOBS: Tuple[str, ...] = (
+    "modules/foundups/*/foundup_manifest.json",
+    "modules/gamification/*/foundup_manifest.json",
+    "modules/platform_integration/*/foundup_manifest.json",
+    "modules/communication/*/foundup_manifest.json",
+    "modules/ai_intelligence/*/foundup_manifest.json",
+    "modules/infrastructure/*/foundup_manifest.json",
+)
+
+# Greppable failure-mode tokens emitted on resolution failure. The
+# StatusReasonCode stays frozen at FAIL_VALIDATION_ERROR per the dispatch
+# (no job-contract schema change); granularity comes from this prefix on
+# reason_human + a parallel evidence_refs entry. This lets W10 and future
+# audits distinguish failure classes by greppable string match instead of
+# prose parsing.
+FAIL_TOKEN_SYNTACTIC_REJECT: str = "syntactic_reject"
+FAIL_TOKEN_MANIFEST_MISMATCH: str = "manifest_mismatch"
+FAIL_TOKEN_MANIFEST_MISSING: str = "manifest_missing"
+FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH: str = "cross_foundup_mismatch"
+
+ALL_FAIL_TOKENS: frozenset = frozenset({
+    FAIL_TOKEN_SYNTACTIC_REJECT,
+    FAIL_TOKEN_MANIFEST_MISMATCH,
+    FAIL_TOKEN_MANIFEST_MISSING,
+    FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH,
+})
+
+
+@dataclass(frozen=True)
+class ResolvedModulePath:
+    """Outcome of validated module-path resolution.
+
+    Observable-ignore shape mirroring
+    ``modules/foundups/agent/src/source_authority.py:resolve_source_authority``:
+    the consumer can inspect ``ignored`` to see exactly what the caller
+    tried to declare, even on success. Silent swallow is refused per the
+    #777 convention.
+
+    Attributes:
+        effective: canonical module_path from the validated manifest (the
+            source of truth). ``None`` iff ``failed`` is True.
+        ignored: the payload-declared candidate, stringified, or ``None``
+            if and only if the caller supplied no candidate (neither
+            ``payload.module_path`` nor ``payload.source_module``).
+            Visible even on success; this is the observable-ignore
+            channel.
+        failed: True iff resolution failed.
+        fail_token: one of ``ALL_FAIL_TOKENS`` on failure, else ``None``.
+        fail_human: human-readable explanation prefixed with the
+            ``fail_token`` for grep-ability; empty on success.
+    """
+
+    effective: Optional[str]
+    ignored: Optional[str]
+    failed: bool
+    fail_token: Optional[str]
+    fail_human: str
 
 
 class HermesJobExecutionResult:
@@ -150,21 +237,40 @@ def execute_foundup_job(
             error=f"Unsupported action: {action}",
         )
 
-    # Pre-validation: Module path must be provided
-    module_path = _extract_module_path(job)
-    if not module_path:
+    # Pre-validation: Module path must resolve via validated manifest (#773).
+    # Replaces the prior _extract_module_path raw-trust behavior; closes the
+    # #774 carry-forward "validator bypass risk" before this executor's
+    # subprocess sink (HermesFoundUpBuilder.run_hermes_extraction).
+    effective_repo_root = repo_root or DEFAULT_REPO_ROOT
+    resolved = _resolve_validated_module_path(job, effective_repo_root)
+    if resolved.failed:
         logger.warning(
-            "[HERMES-EXEC] Missing module_path for job %s",
+            "[HERMES-EXEC] Module-path resolution failed for job %s: %s",
             job.job_id,
+            resolved.fail_human,
         )
+        # Observable-ignore: a rejected payload value is recorded in
+        # evidence even when the failure_token is not strictly about it
+        # (mirrors #777's source_authority.resolve convention).
+        evidence: List[str] = []
+        if resolved.ignored is not None:
+            evidence.append(f"rejected_payload_value:{resolved.ignored}")
+        if resolved.fail_token:
+            evidence.append(f"fail_token:{resolved.fail_token}")
         job.fail(
             reason_code=StatusReasonCode.FAIL_VALIDATION_ERROR,
-            reason_human="Missing module_path in payload or foundup_id",
+            reason_human=resolved.fail_human,
+            evidence_refs=evidence if evidence else None,
         )
         return HermesJobExecutionResult(
             job=job,
-            error="Missing module_path",
+            error=resolved.fail_human,
         )
+    # ``resolved.effective`` is guaranteed non-None when ``failed`` is False
+    # (see ResolvedModulePath success path). Bind a narrowed local for the
+    # downstream type signature on _dispatch_action.
+    assert resolved.effective is not None
+    module_path: str = resolved.effective
 
     # Transition to RUNNING
     if not job.start(
@@ -214,27 +320,266 @@ def execute_foundup_job(
     return HermesJobExecutionResult(job=job, hermes_result=hermes_result)
 
 
-def _extract_module_path(job: FoundUpJob) -> Optional[str]:
-    """
-    Extract module path from job payload or foundup_id.
+def _stringify_ignored(declared: Any) -> Optional[str]:
+    """Mirror of ``source_authority.py``'s ignored-value stringification.
 
-    Priority:
-        1. payload.module_path
-        2. payload.source_module
-        3. foundup_id (if it looks like a path)
+    Returns ``None`` if and only if ``declared`` is ``None``; otherwise
+    ``str(declared)``. The observable-ignore channel uses this so callers
+    can detect a (potentially malicious) declaration attempt regardless
+    of input type.
+    """
+    if declared is None:
+        return None
+    return str(declared)
+
+
+def _find_manifest_for_foundup_id(
+    repo_root: Path, foundup_id: str
+) -> Optional[Path]:
+    """Locate a manifest file whose top-level ``foundup_id`` matches.
+
+    Bounded scan over the 6 canonical manifest directories (Phase 0 found
+    8 manifests today). Returns the first matching path, or ``None``.
+    Used ONLY when the job payload omits both ``module_path`` and
+    ``source_module``; this is the explicit alternative to the removed
+    ``foundup_id``-as-path heuristic.
+
+    The scan reads each candidate JSON only to check its top-level
+    ``foundup_id`` field. No execution. No write.
+    """
+    if not foundup_id:
+        return None
+    for glob in _MANIFEST_SEARCH_GLOBS:
+        for candidate in sorted(repo_root.glob(glob)):
+            try:
+                data = json.loads(candidate.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if data.get("foundup_id") == foundup_id:
+                return candidate
+    return None
+
+
+def _resolve_validated_module_path(
+    job: FoundUpJob,
+    repo_root: Path,
+) -> ResolvedModulePath:
+    """Resolve a job's ``module_path`` through the #773 validator. Fail-closed.
+
+    Pinned design (HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1):
+
+    - **candidate** = ``payload.module_path`` or, if absent, the alias
+      ``payload.source_module``. Empty string is treated as ABSENT
+      (Addendum D #4).
+    - **foundup_id heuristic REMOVED**: a ``/`` in ``foundup_id`` is
+      no longer a path source. If the candidate is absent, fall through
+      to a bounded foundup_id scan, NEVER to the raw ``foundup_id``
+      string.
+    - **syntactic hardening BEFORE any manifest contact**: the candidate
+      is canonicalized via the validator's ``_canonicalize_module_path``
+      helper. Empty / absolute / UNC / ``..`` traversal / backslash
+      forms (and anything not under ``modules/``) are REJECTED with
+      ``FAIL_TOKEN_SYNTACTIC_REJECT``.
+    - **manifest location**: when the candidate resolves syntactically,
+      the manifest is ``<repo_root>/<canonical>/foundup_manifest.json``.
+      When the candidate is absent, the manifest is the first hit of the
+      bounded foundup_id scan.
+    - **validator gate**: ``validate_manifest_file`` (#773) is consumed
+      as-is. It never raises; ``ok=False`` on missing / unreadable /
+      shape-invalid manifest. Tokenized as ``manifest_missing`` for
+      I/O-class errors, ``manifest_mismatch`` otherwise.
+    - **cross-FoundUp substitution defense** (Addendum D #1, load-bearing):
+      after validator passes, the manifest's ``foundup_id`` MUST equal
+      ``job.foundup_id``. A job carrying ``foundup_id=A`` with a payload
+      pointing at FoundUp B's real manifest is REJECTED with
+      ``FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH``. The "some valid manifest
+      exists for this path" check is NOT sufficient.
+    - **case-variant defense** (Addendum D #3, Windows host reality):
+      when the candidate was provided, the candidate's canonical form
+      is exact-string-compared (case-sensitive) against the manifest's
+      ``build_contract.module_path`` canonical form. Mismatch =>
+      ``FAIL_TOKEN_MANIFEST_MISMATCH``.
+    - **derivation when candidate absent**: ``effective`` becomes the
+      manifest's canonical ``module_path`` (manifest is the source of
+      truth). The ``foundup_id`` heuristic is never the source.
+    - **observable ignored**: the payload-declared candidate is visible
+      in ``ResolvedModulePath.ignored`` even on success (mirrors #777).
     """
     payload = job.payload or {}
 
-    # Direct module_path in payload
-    module_path = payload.get("module_path") or payload.get("source_module")
-    if module_path:
-        return str(module_path)
+    # Step 1: extract candidate; treat empty string as ABSENT.
+    raw_candidate: Any = payload.get("module_path")
+    if isinstance(raw_candidate, str) and not raw_candidate:
+        raw_candidate = None
+    if raw_candidate is None:
+        raw_candidate = payload.get("source_module")
+        if isinstance(raw_candidate, str) and not raw_candidate:
+            raw_candidate = None
+    ignored = _stringify_ignored(raw_candidate)
 
-    # Fallback to foundup_id if it looks like a path
-    if job.foundup_id and "/" in job.foundup_id:
-        return job.foundup_id
+    canonical: Optional[str] = None
+    manifest_path: Path
 
-    return None
+    if raw_candidate is not None:
+        # Step 2: syntactic harden BEFORE any manifest contact.
+        #
+        # The validator's ``_canonicalize_module_path`` would itself convert
+        # backslashes to forward slashes ("harmless equivalents"). For the
+        # CONSUMER boundary (Addendum C #5) backslashes must be REJECTED
+        # before any manifest contact -- on a Windows host, accepting them
+        # invites path-name confusion. We do the backslash check here
+        # explicitly so the rejection token is ``syntactic_reject`` and not
+        # the more ambiguous ``manifest_mismatch``.
+        if isinstance(raw_candidate, str) and "\\" in raw_candidate:
+            return ResolvedModulePath(
+                effective=None,
+                ignored=ignored,
+                failed=True,
+                fail_token=FAIL_TOKEN_SYNTACTIC_REJECT,
+                fail_human=(
+                    f"{FAIL_TOKEN_SYNTACTIC_REJECT}: payload module_path "
+                    f"{raw_candidate!r} contains backslashes; only "
+                    f"POSIX-style forward slashes are accepted"
+                ),
+            )
+        canonical = _validator_canonicalize_module_path(raw_candidate)
+        if canonical is None or not canonical.startswith("modules/"):
+            return ResolvedModulePath(
+                effective=None,
+                ignored=ignored,
+                failed=True,
+                fail_token=FAIL_TOKEN_SYNTACTIC_REJECT,
+                fail_human=(
+                    f"{FAIL_TOKEN_SYNTACTIC_REJECT}: payload module_path "
+                    f"{raw_candidate!r} is empty, absolute, UNC, contains "
+                    f"'..' traversal, or is not under modules/"
+                ),
+            )
+        manifest_path = repo_root / canonical / "foundup_manifest.json"
+    else:
+        # Step 3: derive from validated manifest via bounded foundup_id scan.
+        manifest_path_opt = _find_manifest_for_foundup_id(
+            repo_root, job.foundup_id or ""
+        )
+        if manifest_path_opt is None:
+            return ResolvedModulePath(
+                effective=None,
+                ignored=ignored,
+                failed=True,
+                fail_token=FAIL_TOKEN_MANIFEST_MISSING,
+                fail_human=(
+                    f"{FAIL_TOKEN_MANIFEST_MISSING}: no payload module_path; "
+                    f"bounded scan for foundup_id={job.foundup_id!r} returned "
+                    f"no manifest"
+                ),
+            )
+        manifest_path = manifest_path_opt
+
+    # Step 4: validate via #773 (never raises). Pass the manifest path as a
+    # string -- the validator's public signature accepts ``str | PurePosixPath``
+    # and normalizes internally; passing the OS ``Path`` directly satisfies
+    # the runtime contract but tickles the static-type checker, which is why
+    # we stringify here.
+    result = validate_manifest_file(str(manifest_path))
+    if not result.ok:
+        err = result.errors[0] if result.errors else "validation failed"
+        # I/O-class errors -> manifest_missing; shape errors -> manifest_mismatch.
+        if (
+            "not found" in err
+            or "unreadable" in err
+            or "not valid JSON" in err
+        ):
+            token = FAIL_TOKEN_MANIFEST_MISSING
+        else:
+            token = FAIL_TOKEN_MANIFEST_MISMATCH
+        return ResolvedModulePath(
+            effective=None,
+            ignored=ignored,
+            failed=True,
+            fail_token=token,
+            fail_human=f"{token}: {err}",
+        )
+
+    # Step 5: re-read the validated manifest to extract foundup_id and
+    # module_path for the two final cross-checks. The validator confirmed
+    # the manifest is well-formed and that its declared module_path matches
+    # the manifest file's parent directory; we now confirm the foundup_id
+    # binding and (when applicable) the candidate's case-sensitive match.
+    try:
+        manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return ResolvedModulePath(
+            effective=None,
+            ignored=ignored,
+            failed=True,
+            fail_token=FAIL_TOKEN_MANIFEST_MISSING,
+            fail_human=(
+                f"{FAIL_TOKEN_MANIFEST_MISSING}: re-read failed: "
+                f"{type(exc).__name__}"
+            ),
+        )
+    manifest_foundup_id = manifest_data.get("foundup_id")
+    manifest_module_path = manifest_data.get("build_contract", {}).get(
+        "module_path", ""
+    )
+    canonical_manifest_module = _validator_canonicalize_module_path(
+        manifest_module_path
+    )
+
+    if canonical_manifest_module is None:
+        return ResolvedModulePath(
+            effective=None,
+            ignored=ignored,
+            failed=True,
+            fail_token=FAIL_TOKEN_MANIFEST_MISMATCH,
+            fail_human=(
+                f"{FAIL_TOKEN_MANIFEST_MISMATCH}: manifest at {manifest_path} "
+                f"has un-canonicalizable build_contract.module_path="
+                f"{manifest_module_path!r}"
+            ),
+        )
+
+    # Step 6: cross-FoundUp substitution defense (Addendum D #1).
+    if manifest_foundup_id != job.foundup_id:
+        return ResolvedModulePath(
+            effective=None,
+            ignored=ignored,
+            failed=True,
+            fail_token=FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH,
+            fail_human=(
+                f"{FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH}: job.foundup_id="
+                f"{job.foundup_id!r} but the manifest at {manifest_path} "
+                f"declares foundup_id={manifest_foundup_id!r}"
+            ),
+        )
+
+    # Step 7: when candidate provided, exact-string compare candidate canonical
+    # vs manifest canonical (#773 exact-match at consumer boundary; Addendum
+    # D #3 case-variant defense). When candidate was absent, derivation is
+    # already from the validated manifest and this check is a no-op.
+    if raw_candidate is not None and canonical != canonical_manifest_module:
+        return ResolvedModulePath(
+            effective=None,
+            ignored=ignored,
+            failed=True,
+            fail_token=FAIL_TOKEN_MANIFEST_MISMATCH,
+            fail_human=(
+                f"{FAIL_TOKEN_MANIFEST_MISMATCH}: payload candidate canonical "
+                f"{canonical!r} != manifest module_path "
+                f"{canonical_manifest_module!r}"
+            ),
+        )
+
+    # Success: effective is the manifest's canonical module_path (the source
+    # of truth). The payload-declared value is preserved in ``ignored`` for
+    # observability even when it matches.
+    return ResolvedModulePath(
+        effective=canonical_manifest_module,
+        ignored=ignored,
+        failed=False,
+        fail_token=None,
+        fail_human="",
+    )
 
 
 def _dispatch_action(

--- a/modules/foundups/agent/tests/TestModLog.md
+++ b/modules/foundups/agent/tests/TestModLog.md
@@ -1,5 +1,96 @@
 # Agent Module TestModLog
 
+## 2026-06-10 - Hermes Module-Path Trust Removal Phase 1 Tests
+
+**Command**:
+
+```bash
+python -m pytest modules/foundups/agent/tests/test_hermes_foundup_job_executor.py -q
+python -m pytest modules/foundups/agent/tests/ -q
+```
+
+**Result**: PASS
+
+**Summary**:
+- Executor test file alone: **46 passed in 0.84s** (22 pre-existing + 24
+  new in `TestResolvedModulePathValidation`).
+- Full agent-module suite: **621 passed in 9.06s**; 0 skipped; 0 xfailed
+  (575 prior + 46 executor).
+
+**Slice**: HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1
+
+**Added** (in `test_hermes_foundup_job_executor.py`):
+
+- `TestResolvedModulePathValidation` (24 tests, mapped 1:1 to dispatch
+  Addenda C and D):
+  - Happy paths: real gotjunk_001 manifest; cross-domain kosei.
+  - Addendum C #1 -- payload path with no backing manifest rejected.
+  - Addendum C #2 -- source_module alias receives the same treatment as
+    module_path (happy + reject variants).
+  - Addendum C #4 -- bare basename and partial paths rejected at
+    syntactic-harden step.
+  - Addendum C #5 -- backslashes rejected pre-manifest.
+  - Addendum C #6 -- absolute / drive-prefix / `..` traversal /
+    internal traversal rejected pre-manifest.
+  - Addendum C #7 -- omitted payload derives from validated manifest
+    via bounded foundup_id scan; unknown id -> manifest_missing.
+  - Addendum C #8 -- rejected payload value visible in
+    `evidence_refs` (end-to-end through `execute_foundup_job`).
+  - Addendum D #1 -- cross-FoundUp substitution (job foundup_id A,
+    payload module_path B's real path) rejected with
+    `cross_foundup_mismatch`; also via alias.
+  - Addendum D #3 -- case-variant payload rejected; uppercase
+    `Modules/` prefix rejected at syntactic guard.
+  - Addendum D #4 -- empty-string payload semantics: treated as ABSENT
+    (falsy); derivation falls through; `ignored=None`.
+  - Closed-set token taxonomy: `test_all_fail_tokens_present_in_taxonomy`
+    asserts `ALL_FAIL_TOKENS == {syntactic_reject, manifest_mismatch,
+    manifest_missing, cross_foundup_mismatch}` exactly.
+  - End-to-end fail-closed guards: `test_execute_foundup_job_fails_closed_on_invalid_payload`,
+    `..._on_cross_foundup_substitution`, both asserting
+    `HermesFoundUpBuilder` is NEVER instantiated when resolution fails.
+
+**Updated assertions** (per dispatch "UPDATE stale assertions" + "flag
+each updated assertion in TestModLog"):
+
+- `TestActionDispatch::test_extract_foundup_calls_extract_method` --
+  expected `source_module` argument changed from `"modules/foundups/widget"`
+  to `"modules/foundups/gotjunk"` (the fixture now anchors on a real
+  validator-passing manifest; the dispatch forwards the validator-
+  confirmed canonical, not a raw payload string).
+- `TestActionDispatch::test_validate_foundup_calls_gate_and_boundary` --
+  same change for `check_exfoliation_gate` and `analyze_boundary`.
+- `TestModulePathExtraction::test_foundup_id_as_fallback` -- RENAMED to
+  `test_foundup_id_path_heuristic_removed`. Assertion flipped from "a
+  path-shaped foundup_id IS used as a path source" to "a path-shaped
+  foundup_id is NEVER a path source; bounded scan or
+  `manifest_missing` wins". Asserts
+  `resolved.fail_token == FAIL_TOKEN_MANIFEST_MISSING`.
+- `TestModulePathExtraction::test_module_path_from_payload` /
+  `test_source_module_from_payload` -- docstrings updated to record
+  that the payload-shape check is documentary; behavioral coverage
+  now lives in `TestResolvedModulePathValidation`.
+
+**Updated fixtures**:
+
+- `queued_extract_job` / `queued_validate_job` / `queued_build_job` --
+  switched from synthetic `"modules/foundups/widget"` (which no longer
+  reaches the executor under the new pre-flight) to the real
+  `gotjunk_001` / `modules/foundups/gotjunk` pair. Fixture docstring
+  explains the change.
+
+**Boundary preserved**:
+
+- AST scan rejects new banned imports (verified by `git diff`: only
+  added imports are stdlib `json`, `dataclasses.dataclass`, and the
+  intra-repo validator import).
+- Validator NOT edited.
+- Manifests NOT edited.
+- No new dependencies.
+- No skip / no xfail.
+
+---
+
 ## 2026-06-10 - FoundUp Source-Authority Contract Phase 1 Tests
 
 **Command**:

--- a/modules/foundups/agent/tests/test_hermes_foundup_job_executor.py
+++ b/modules/foundups/agent/tests/test_hermes_foundup_job_executor.py
@@ -51,32 +51,43 @@ from modules.foundups.agent.src.hermes_foundup_job_executor import (
 
 @pytest.fixture
 def queued_extract_job() -> FoundUpJob:
-    """Create a QUEUED job for extract_foundup action."""
+    """Create a QUEUED job for extract_foundup action.
+
+    Uses a REAL on-disk manifest (gotjunk_001 at modules/foundups/gotjunk)
+    so the new validated-resolution pre-flight
+    (HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1) passes and the test can
+    exercise the downstream mocked Hermes path. Prior to the trust-
+    removal patch this fixture used a synthetic ``modules/foundups/widget``
+    path; that no longer reaches the executor because the new pre-flight
+    rejects any module_path without a backing validated manifest.
+    """
     return create_job(
         tenant_id="012",
         requested_action="extract_foundup",
-        foundup_id="modules/foundups/widget",
-        payload={"module_path": "modules/foundups/widget", "target_org": "FOUNDUPS"},
+        foundup_id="gotjunk_001",
+        payload={"module_path": "modules/foundups/gotjunk", "target_org": "FOUNDUPS"},
     )
 
 
 @pytest.fixture
 def queued_validate_job() -> FoundUpJob:
-    """Create a QUEUED job for validate_foundup action."""
+    """Create a QUEUED job for validate_foundup action (real manifest)."""
     return create_job(
         tenant_id="012",
         requested_action="validate_foundup",
-        payload={"module_path": "modules/foundups/widget"},
+        foundup_id="gotjunk_001",
+        payload={"module_path": "modules/foundups/gotjunk"},
     )
 
 
 @pytest.fixture
 def queued_build_job() -> FoundUpJob:
-    """Create a QUEUED job for build_foundup action."""
+    """Create a QUEUED job for build_foundup action (real manifest, alias key)."""
     return create_job(
         tenant_id="012",
         requested_action="build_foundup",
-        payload={"source_module": "modules/foundups/widget"},
+        foundup_id="gotjunk_001",
+        payload={"source_module": "modules/foundups/gotjunk"},
     )
 
 
@@ -355,8 +366,12 @@ class TestActionDispatch:
 
         result = execute_foundup_job(queued_extract_job, force_dry_run=True)
 
+        # UPDATED for HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1: the queued_extract_job
+        # fixture now uses real manifest ``modules/foundups/gotjunk`` so the validated
+        # pre-flight passes; the dispatch then forwards the validator-confirmed
+        # canonical path (NOT a raw payload string) into the builder.
         mock_builder.extract_foundup.assert_called_once_with(
-            source_module="modules/foundups/widget",
+            source_module="modules/foundups/gotjunk",
             target_org="FOUNDUPS",
         )
         assert result.job.status == JobStatus.SUCCEEDED
@@ -391,8 +406,10 @@ class TestActionDispatch:
 
         result = execute_foundup_job(queued_validate_job, force_dry_run=True)
 
-        mock_builder.check_exfoliation_gate.assert_called_once_with("modules/foundups/widget")
-        mock_builder.analyze_boundary.assert_called_once_with("modules/foundups/widget")
+        # UPDATED for HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1: the fixture now
+        # uses real manifest ``modules/foundups/gotjunk`` (see fixture docstring).
+        mock_builder.check_exfoliation_gate.assert_called_once_with("modules/foundups/gotjunk")
+        mock_builder.analyze_boundary.assert_called_once_with("modules/foundups/gotjunk")
         assert result.job.status == JobStatus.SUCCEEDED
         assert result.job.status_reason_code == StatusReasonCode.OK_DRY_RUN_PASSED
 
@@ -524,37 +541,494 @@ class TestUtilityFunctions:
 
 
 class TestModulePathExtraction:
-    """Tests for module path extraction from job."""
+    """Tests for module path extraction from job.
+
+    UPDATED (HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1, see TestModLog):
+    These tests previously pinned the prior raw-payload-trust behavior
+    of ``_extract_module_path`` (which trusted ``payload.module_path``
+    /  ``payload.source_module`` / a ``foundup_id`` containing "/"
+    without manifest validation). The function has been REMOVED;
+    resolution now flows through ``_resolve_validated_module_path`` which
+    requires the #773 manifest validator to confirm the path. The
+    payload-shape assertions below are retained for documentation but the
+    foundup-id-as-fallback test is replaced by an explicit
+    no-inference assertion.
+    """
 
     def test_module_path_from_payload(self) -> None:
-        """Module path should be extracted from payload.module_path."""
+        """Payload may declare module_path; the validated resolver decides
+        whether it is the source of truth (see
+        TestResolvedModulePathValidation)."""
         job = create_job(
             tenant_id="012",
             requested_action="extract_foundup",
             payload={"module_path": "modules/foundups/custom"},
         )
-
-        # Cannot test internal function directly, but can verify job works
-        # by checking validation passes
         assert job.payload.get("module_path") == "modules/foundups/custom"
 
     def test_source_module_from_payload(self) -> None:
-        """Module path should be extracted from payload.source_module."""
+        """The ``source_module`` alias key may also declare a candidate
+        module_path; the validated resolver treats it identically to
+        ``module_path``."""
         job = create_job(
             tenant_id="012",
             requested_action="extract_foundup",
             payload={"source_module": "modules/foundups/other"},
         )
-
         assert job.payload.get("source_module") == "modules/foundups/other"
 
-    def test_foundup_id_as_fallback(self) -> None:
-        """Module path should fallback to foundup_id if it looks like a path."""
+    def test_foundup_id_path_heuristic_removed(self) -> None:
+        """The prior heuristic "foundup_id contains '/' -> treat as path"
+        is REMOVED. A path-shaped foundup_id with no payload module_path
+        no longer resolves to a module path by itself; the executor must
+        find a real manifest by foundup_id or fail
+        ``manifest_missing``."""
+        from modules.foundups.agent.src.hermes_foundup_job_executor import (
+            DEFAULT_REPO_ROOT,
+            FAIL_TOKEN_MANIFEST_MISSING,
+            _resolve_validated_module_path,
+        )
         job = create_job(
             tenant_id="012",
             requested_action="extract_foundup",
-            foundup_id="modules/foundups/fromid",
+            foundup_id="modules/foundups/fromid",  # path-shaped, fake
             payload={},
         )
+        resolved = _resolve_validated_module_path(job, DEFAULT_REPO_ROOT)
+        assert resolved.failed is True
+        assert resolved.fail_token == FAIL_TOKEN_MANIFEST_MISSING
+        assert resolved.effective is None
+        # Even though the foundup_id "looks like a path", it is NOT used
+        # as a path source by the resolver.
+        assert "modules/foundups/fromid" not in (resolved.fail_human or "").lower() \
+            or "manifest_missing" in resolved.fail_human
 
-        assert job.foundup_id == "modules/foundups/fromid"
+
+# ---------------------------------------------------------------------------
+# HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1: validated module-path resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolvedModulePathValidation:
+    """Validated-resolution tests for ``_resolve_validated_module_path``.
+
+    These tests replace the prior raw-trust extraction and pin the
+    fail-closed contract dictated by HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1.
+    Real on-disk manifests (gotjunk_001, kosei) are used as the happy-path
+    anchors so the validator's exact-match check has a stable target.
+
+    Coverage map (Addendum C tests 1-8 + Addendum D tests 1, 3, 4 +
+    Addendum A 4-step fork protocol verified by the resolver's
+    fail-token taxonomy):
+      C1 mismatch              -> test_payload_path_wrong_manifest_path_rejected
+      C2 alias mismatch        -> test_source_module_alias_validates_same_as_module_path
+      C3 foundup_id heuristic  -> TestModulePathExtraction.test_foundup_id_path_heuristic_removed
+      C4 suffix-only           -> test_suffix_only_path_rejected
+      C5 backslash             -> test_backslash_payload_rejected_pre_manifest
+      C6 absolute / traversal  -> test_absolute_path_rejected_pre_manifest /
+                                  test_traversal_path_rejected_pre_manifest
+      C7 omitted               -> test_payload_omitted_derives_from_validated_manifest
+      C8 observable ignored    -> test_rejected_payload_value_appears_in_evidence
+      D1 cross-foundup         -> test_cross_foundup_substitution_rejected
+      D3 case-variant          -> test_case_variant_payload_rejected
+      D4 empty-string semantics-> test_empty_string_payload_treated_as_absent
+    """
+
+    # ---- Imports / constants used throughout the class ------------------
+
+    @staticmethod
+    def _resolver_module():
+        from modules.foundups.agent.src import hermes_foundup_job_executor as e
+        return e
+
+    @staticmethod
+    def _resolve(job):
+        e = TestResolvedModulePathValidation._resolver_module()
+        return e._resolve_validated_module_path(job, e.DEFAULT_REPO_ROOT)
+
+    # ---- Happy paths ----------------------------------------------------
+
+    def test_happy_path_real_manifest_resolves_to_canonical(self) -> None:
+        """Real manifest gotjunk_001 + matching payload: resolves to the
+        validator-confirmed canonical module_path. Observable-ignore
+        preserves the payload value even though it equals the result."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="gotjunk_001",
+            payload={"module_path": "modules/foundups/gotjunk"},
+        )
+        r = self._resolve(job)
+        assert r.failed is False
+        assert r.effective == "modules/foundups/gotjunk"
+        assert r.ignored == "modules/foundups/gotjunk"  # observable even on success
+        assert r.fail_token is None
+
+    def test_cross_domain_real_manifest_resolves(self) -> None:
+        """Cross-domain real manifest (kosei) is also accepted."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="kosei",
+            payload={"module_path": "modules/foundups/kosei"},
+        )
+        r = self._resolve(job)
+        assert r.failed is False
+        assert r.effective == "modules/foundups/kosei"
+
+    # ---- Addendum C #1: payload path wrong manifest path ----------------
+
+    def test_payload_path_wrong_manifest_path_rejected(self) -> None:
+        """Payload points at a path with no backing manifest -> manifest_missing
+        (the value is rejected before the executor's subprocess sink)."""
+        e = self._resolver_module()
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="gotjunk_001",
+            payload={"module_path": "modules/foundups/nonexistent_xyz"},
+        )
+        r = self._resolve(job)
+        assert r.failed is True
+        assert r.fail_token == e.FAIL_TOKEN_MANIFEST_MISSING
+        # Rejected payload value is observable.
+        assert r.ignored == "modules/foundups/nonexistent_xyz"
+        assert r.effective is None
+
+    # ---- Addendum C #2: source_module alias path ------------------------
+
+    def test_source_module_alias_validates_same_as_module_path(self) -> None:
+        """``payload.source_module`` (the alias) goes through the same
+        validated resolution as ``payload.module_path``."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="gotjunk_001",
+            payload={"source_module": "modules/foundups/gotjunk"},
+        )
+        r = self._resolve(job)
+        assert r.failed is False
+        assert r.effective == "modules/foundups/gotjunk"
+        assert r.ignored == "modules/foundups/gotjunk"
+
+    def test_source_module_alias_with_wrong_path_rejected(self) -> None:
+        """The alias receives the same fail-closed treatment as the
+        primary key."""
+        e = self._resolver_module()
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="gotjunk_001",
+            payload={"source_module": "modules/foundups/nope_alias"},
+        )
+        r = self._resolve(job)
+        assert r.failed is True
+        assert r.fail_token == e.FAIL_TOKEN_MANIFEST_MISSING
+
+    # ---- Addendum C #4: suffix-only / basename rejected -----------------
+
+    def test_suffix_only_path_rejected(self) -> None:
+        """A bare basename (``gotjunk``) that matches the LAST segment of a
+        real manifest's module_path must NOT validate. This pins #773's
+        exact-match semantics at the consumer boundary."""
+        e = self._resolver_module()
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="gotjunk_001",
+            payload={"module_path": "gotjunk"},
+        )
+        r = self._resolve(job)
+        assert r.failed is True
+        assert r.fail_token == e.FAIL_TOKEN_SYNTACTIC_REJECT  # not under modules/
+
+    def test_partial_path_rejected(self) -> None:
+        """A path that is partial (missing the leading ``modules/``) is
+        rejected at the syntactic-hardening step, never reaching the
+        manifest."""
+        e = self._resolver_module()
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="gotjunk_001",
+            payload={"module_path": "foundups/gotjunk"},
+        )
+        r = self._resolve(job)
+        assert r.failed is True
+        assert r.fail_token == e.FAIL_TOKEN_SYNTACTIC_REJECT
+
+    # ---- Addendum C #5: backslashes rejected pre-manifest ---------------
+
+    def test_backslash_payload_rejected_pre_manifest(self) -> None:
+        """Backslashes are rejected BEFORE any manifest contact. On
+        Windows, the validator would itself convert them; the consumer
+        boundary refuses them so the token stays ``syntactic_reject``."""
+        e = self._resolver_module()
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="gotjunk_001",
+            payload={"module_path": r"modules\foundups\gotjunk"},
+        )
+        r = self._resolve(job)
+        assert r.failed is True
+        assert r.fail_token == e.FAIL_TOKEN_SYNTACTIC_REJECT
+        assert "backslash" in r.fail_human.lower()
+
+    # ---- Addendum C #6: absolute / traversal rejected pre-manifest ------
+
+    def test_absolute_path_rejected_pre_manifest(self) -> None:
+        e = self._resolver_module()
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="gotjunk_001",
+            payload={"module_path": "/modules/foundups/gotjunk"},
+        )
+        r = self._resolve(job)
+        assert r.failed is True
+        assert r.fail_token == e.FAIL_TOKEN_SYNTACTIC_REJECT
+
+    def test_absolute_drive_path_rejected_pre_manifest(self) -> None:
+        e = self._resolver_module()
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="gotjunk_001",
+            payload={"module_path": "O:/Foundups-Agent/modules/foundups/gotjunk"},
+        )
+        r = self._resolve(job)
+        assert r.failed is True
+        assert r.fail_token == e.FAIL_TOKEN_SYNTACTIC_REJECT
+
+    def test_traversal_path_rejected_pre_manifest(self) -> None:
+        e = self._resolver_module()
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="gotjunk_001",
+            payload={"module_path": "../modules/foundups/gotjunk"},
+        )
+        r = self._resolve(job)
+        assert r.failed is True
+        assert r.fail_token == e.FAIL_TOKEN_SYNTACTIC_REJECT
+
+    def test_internal_traversal_rejected(self) -> None:
+        e = self._resolver_module()
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="gotjunk_001",
+            payload={"module_path": "modules/foundups/../foundups/gotjunk"},
+        )
+        r = self._resolve(job)
+        assert r.failed is True
+        assert r.fail_token == e.FAIL_TOKEN_SYNTACTIC_REJECT
+
+    # ---- Addendum C #7: omitted payload derives from manifest -----------
+
+    def test_payload_omitted_derives_from_validated_manifest(self) -> None:
+        """No payload candidate; the executor must NOT infer from
+        foundup_id-as-path. It must run a bounded foundup_id scan and
+        derive the effective path from the validated manifest."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="gotjunk_001",
+            payload={},
+        )
+        r = self._resolve(job)
+        assert r.failed is False
+        assert r.effective == "modules/foundups/gotjunk"
+        # No candidate was supplied; observable-ignore is None.
+        assert r.ignored is None
+
+    def test_payload_omitted_unknown_foundup_id_fails_missing(self) -> None:
+        """Bounded scan misses for an unknown foundup_id -> manifest_missing."""
+        e = self._resolver_module()
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="totally_unknown_foundup_xyz",
+            payload={},
+        )
+        r = self._resolve(job)
+        assert r.failed is True
+        assert r.fail_token == e.FAIL_TOKEN_MANIFEST_MISSING
+
+    # ---- Addendum C #8: rejected payload value visible in evidence ------
+
+    def test_rejected_payload_value_appears_in_evidence(self) -> None:
+        """End-to-end through ``execute_foundup_job``: when the resolver
+        fails, the job's evidence_refs contains the rejected payload
+        value AND the greppable fail token (mirrors #777 observable-
+        ignore)."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="gotjunk_001",
+            payload={"module_path": "modules/foundups/nope_evidence"},
+        )
+        result = execute_foundup_job(job=job)
+        assert result.job.status == JobStatus.FAILED
+        assert result.job.status_reason_code == StatusReasonCode.FAIL_VALIDATION_ERROR
+        refs = result.job.evidence_refs or []
+        assert any("rejected_payload_value:modules/foundups/nope_evidence" in r for r in refs)
+        assert any("fail_token:manifest_missing" in r for r in refs)
+
+    # ---- Addendum D #1: cross-FoundUp substitution rejected -------------
+
+    def test_cross_foundup_substitution_rejected(self) -> None:
+        """job.foundup_id = A, payload.module_path = B's REAL, validator-
+        passing module path. The manifest must bind to A; resolving B's
+        manifest and finding A != B is the load-bearing defense."""
+        e = self._resolver_module()
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="gotjunk_001",  # A
+            payload={"module_path": "modules/foundups/kosei"},  # B's real path
+        )
+        r = self._resolve(job)
+        assert r.failed is True
+        assert r.fail_token == e.FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH
+        # The mismatch is observable: both ids appear in the human message.
+        assert "gotjunk_001" in r.fail_human
+        assert "kosei" in r.fail_human
+
+    def test_cross_foundup_substitution_via_alias_rejected(self) -> None:
+        """The alias key carries the same protection."""
+        e = self._resolver_module()
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="gotjunk_001",
+            payload={"source_module": "modules/foundups/kosei"},
+        )
+        r = self._resolve(job)
+        assert r.failed is True
+        assert r.fail_token == e.FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH
+
+    # ---- Addendum D #3: case-variant rejected ---------------------------
+
+    def test_case_variant_payload_rejected(self) -> None:
+        """Windows host reality: a case-variant payload (same on disk
+        case-insensitively, different string) MUST be rejected. The
+        resolver's exact-string comparison against the canonical
+        manifest module_path catches it."""
+        e = self._resolver_module()
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="gotjunk_001",
+            payload={"module_path": "modules/Foundups/gotjunk"},  # caps inside
+        )
+        r = self._resolve(job)
+        assert r.failed is True
+        # The token may be syntactic_reject OR manifest_mismatch depending on
+        # which check catches first; both are valid "reject" outcomes per
+        # Addendum D #3. Pin that the FAILURE happened and the value is
+        # observable.
+        assert r.fail_token in (
+            e.FAIL_TOKEN_SYNTACTIC_REJECT, e.FAIL_TOKEN_MANIFEST_MISMATCH,
+        )
+        assert r.ignored == "modules/Foundups/gotjunk"
+
+    def test_uppercase_modules_prefix_rejected(self) -> None:
+        """Uppercase ``Modules/`` prefix fails the ``startswith('modules/')``
+        guard at the syntactic-harden step."""
+        e = self._resolver_module()
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="gotjunk_001",
+            payload={"module_path": "Modules/foundups/gotjunk"},
+        )
+        r = self._resolve(job)
+        assert r.failed is True
+        assert r.fail_token == e.FAIL_TOKEN_SYNTACTIC_REJECT
+
+    # ---- Addendum D #4: empty-string semantics --------------------------
+
+    def test_empty_string_payload_treated_as_absent(self) -> None:
+        """``payload.module_path = ''`` is ABSENT (falsy semantics pinned).
+        Derivation falls through to the bounded foundup_id scan."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="gotjunk_001",
+            payload={"module_path": ""},
+        )
+        r = self._resolve(job)
+        assert r.failed is False
+        assert r.effective == "modules/foundups/gotjunk"
+        # Empty string is treated as absent, so ignored stays None.
+        assert r.ignored is None
+
+    def test_empty_string_alias_also_treated_as_absent(self) -> None:
+        """The same falsy-semantics rule applies to ``source_module``."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="extract_foundup",
+            foundup_id="gotjunk_001",
+            payload={"source_module": ""},
+        )
+        r = self._resolve(job)
+        assert r.failed is False
+        assert r.effective == "modules/foundups/gotjunk"
+        assert r.ignored is None
+
+    # ---- Greppable fail-token taxonomy ----------------------------------
+
+    def test_all_fail_tokens_present_in_taxonomy(self) -> None:
+        """Addendum D #5: the closed token set is exactly the documented
+        four. No other tokens may leak into ``reason_human`` from this
+        resolver."""
+        e = self._resolver_module()
+        assert e.ALL_FAIL_TOKENS == frozenset({
+            "syntactic_reject",
+            "manifest_mismatch",
+            "manifest_missing",
+            "cross_foundup_mismatch",
+        })
+
+    # ---- End-to-end through execute_foundup_job -------------------------
+
+    def test_execute_foundup_job_fails_closed_on_invalid_payload(self) -> None:
+        """End-to-end: invalid payload reaches FAILED before HermesFoundUpBuilder
+        is instantiated (subprocess sink is unreached)."""
+        with patch(
+            "modules.foundups.agent.src.hermes_foundup_job_executor"
+            ".HermesFoundUpBuilder" if False else
+            "modules.foundups.agent.src.hermes_adapter.HermesFoundUpBuilder"
+        ) as mock_builder_cls:
+            job = create_job(
+                tenant_id="012",
+                requested_action="extract_foundup",
+                foundup_id="gotjunk_001",
+                payload={"module_path": "modules/foundups/will_not_resolve"},
+            )
+            result = execute_foundup_job(job=job)
+            # FAILED before any builder construction.
+            mock_builder_cls.assert_not_called()
+            assert result.job.status == JobStatus.FAILED
+            assert result.job.status_reason_code == StatusReasonCode.FAIL_VALIDATION_ERROR
+
+    def test_execute_foundup_job_fails_closed_on_cross_foundup_substitution(self) -> None:
+        """End-to-end cross-FoundUp substitution attempt is rejected and
+        the subprocess sink is unreached."""
+        with patch(
+            "modules.foundups.agent.src.hermes_adapter.HermesFoundUpBuilder"
+        ) as mock_builder_cls:
+            job = create_job(
+                tenant_id="012",
+                requested_action="extract_foundup",
+                foundup_id="gotjunk_001",
+                payload={"module_path": "modules/foundups/kosei"},
+            )
+            result = execute_foundup_job(job=job)
+            mock_builder_cls.assert_not_called()
+            assert result.job.status == JobStatus.FAILED
+            assert result.job.status_reason_code == StatusReasonCode.FAIL_VALIDATION_ERROR
+            refs = result.job.evidence_refs or []
+            assert any("fail_token:cross_foundup_mismatch" in r for r in refs)


### PR DESCRIPTION
## Summary

`HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1` (W6). Closes the #774
carry-forward at the Hermes executor seam. The legacy
`_extract_module_path` is REMOVED; every job's `module_path` now flows
through `_resolve_validated_module_path`, which consumes the #773
manifest validator and fails-closed with a 4-token greppable taxonomy.
This is the LAST consumer-wiring precondition.

## Trust-point evidence (from #774 audit, verbatim)

> Legacy executor trusts payload.module_path. This is a consumer-wiring
> blocker, not a builder blocker.
> -- docs/audits/architecture/OPENCLAW_HERMES_WRE_EXECUTION_CHAIN_AUDIT_PHASE1.md:378-390, 587-588

The audit's evidence pointer (`hermes_foundup_job_executor.py:217-237`)
maps exactly to the now-removed `_extract_module_path` function.

## Pinned-design conformance

1. Candidate from `payload.module_path` / `payload.source_module`
   (alias). Empty-string is ABSENT (Addendum D #4).
2. Syntactic hardening BEFORE manifest contact: backslash (Addendum C
   #5), absolute / UNC (Addendum C #6), `..` traversal (Addendum C
   #6), `not startswith("modules/")` -- all `fail_token=syntactic_reject`.
3. Manifest located at `<repo_root>/<canonical>/foundup_manifest.json`
   OR bounded `foundup_id` scan when candidate absent.
4. `validate_manifest_file` (#773) gate; never raises. I/O errors ->
   `manifest_missing`; shape errors -> `manifest_mismatch`.
5. **Cross-FoundUp substitution defense** (Addendum D #1,
   load-bearing): manifest `foundup_id` MUST equal `job.foundup_id`
   -- otherwise `fail_token=cross_foundup_mismatch`. "Some valid
   manifest exists for this path" is NOT sufficient.
6. **Case-variant defense** (Addendum D #3, Windows host reality):
   candidate canonical exact-string-compared (case-sensitive) against
   manifest canonical -> `fail_token=manifest_mismatch`.
7. `foundup_id`-as-path heuristic REMOVED (a `/` in `foundup_id` is
   no longer a path source); bounded scan used when payload omits path.
8. Observable-ignore (mirrors #777): payload-declared value is in
   `ResolvedModulePath.ignored` even on success; rejected value lands
   in `evidence_refs` as `rejected_payload_value:<stringified>` plus
   `fail_token:<one-of-ALL_FAIL_TOKENS>`.
9. No silent fallbacks. No env-flag bypass.

## Phase-0 scope ruling on `build_plan_generator`

**`OUT_OF_SCOPE_NAMED_FOLLOWUP`** (Addendum B + D tie-break: current
reachability decides).

Evidence:

- `build_plan_generator.py:167, :276` read `payload.module_path` /
  `source_module` and `:282` synthesizes
  `f"modules/foundups/{job.foundup_id}"`.
- **Zero non-test, non-doc importers**:
  ```
  modules\foundups\agent\src\build_plan_generator.py   (self)
  ```
- `BuildPlanExecutor.execute_step` is a BLOCKED stub
  (`build_plan_executor.py:634-665`); `build_plan_swarm.py` only
  label-matches `target.module_path`; no subprocess / `hermes_adapter`
  reachable.

Follow-up: `BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1`
becomes a **hard precondition row** in
`WRE_CONTEXT_BUNDLE_DRYRUN_CONSUMER_PHASE1` or any other slice that
makes `build_plan_generator` reachable from a real-execution sink.

## Test counts

```
python -m pytest modules/foundups/agent/tests/test_hermes_foundup_job_executor.py -q
  -> 46 passed in 0.84s (22 pre-existing + 24 new in TestResolvedModulePathValidation)
python -m pytest modules/foundups/agent/tests/ -q
  -> 621 passed in 8.13s; 0 skipped; 0 xfailed
```

New tests map 1:1 to Addendum C #1-#8 + Addendum D #1, #3, #4 + closed-
set token taxonomy + end-to-end fail-closed guards (asserting
`HermesFoundUpBuilder` is NEVER instantiated when resolution fails).

Updated assertions (flagged in TestModLog per dispatch):
- `TestActionDispatch::test_extract_foundup_calls_extract_method` +
  `..._test_validate_foundup_calls_gate_and_boundary`: expected arg
  changed from `"modules/foundups/widget"` to `"modules/foundups/gotjunk"`.
- `TestModulePathExtraction::test_foundup_id_as_fallback` RENAMED to
  `test_foundup_id_path_heuristic_removed`; assertion flipped.
- Fixtures `queued_extract_job` / `queued_validate_job` /
  `queued_build_job` switched to real `gotjunk_001`
  / `modules/foundups/gotjunk`.

## Boundary preserved

- `NO_VALIDATOR_MUTATION` -- `foundup_manifest_validator.py` untouched.
- `NO_MANIFEST_MUTATION` -- no `foundup_manifest.json` modified.
- `NO_RUNTIME_OR_BUILDER_CHANGE` -- `hermes_adapter.py` untouched.
- `NO_CONSUMER_WIRING` -- no new caller wired.
- `NO_WSP_FILE_MUTATION`.
- `NO_NEW_DEPENDENCY` -- only stdlib + intra-repo validator import.
- `NO_JOB_CONTRACT_SCHEMA_CHANGE` -- `StatusReasonCode` unchanged.

## WSP_97 Truth Boundary Checklist

**PASS 27/27** with the 9 rows added per the dispatch + Addendum D:
`NO_USER_QUESTION_FRAMING`, `BUILD_PLAN_GENERATOR_SCOPE_RULED`,
`OLD_PAYLOAD_MODULE_PATH_TRUST_DEAD`, `SOURCE_MODULE_ALIAS_VALIDATED`,
`FOUNDUP_ID_PATH_HEURISTIC_REMOVED`,
`REJECTED_PAYLOAD_VALUE_OBSERVABLE`,
`VALIDATED_MANIFEST_SOURCE_OF_TRUTH`,
`CROSS_FOUNDUP_SUBSTITUTION_REJECTED`, `CASE_VARIANT_PATH_REJECTED`.

Full table with verbatim evidence in
[`modules/foundups/agent/ModLog.md`](../tree/w6/hermes-module-path-trust-removal-phase1/modules/foundups/agent/ModLog.md)
Section "WSP_97 Truth Boundary Checklist".

Predecessors: #770, #771, #772, #773, #774, #775, #777.

Worker-Lane: W6
Slice: HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1
Do NOT merge. Leave OPEN for W10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)