### PR TITLE
fix(foundups): guard build_plan_generator module_path with shared validated resolver (W6)

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -1,5 +1,82 @@
 # FoundUps Agent - Development Log
 
+## [2026-06-11] BuildPlan Generator Module-Path Trust Removal Phase 1 (#778 carry-forward closure + shared resolver extraction)
+
+**Change Type**: Authoring slice (security pre-flight; closes the last
+trust seam; extracts the resolver into a shared single source of truth)
+**By**: 0102 (W6) | Commander: 012
+**WSP References**: WSP 11, WSP 50, WSP 77, WSP 84, WSP 87, WSP 97, WSP 22
+**Slice**: `BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1`
+**Branch / PR**: `w6/build-plan-generator-module-path-trust-removal-phase1` --
+PR opened against `main` (do NOT merge; W10 gate hold)
+**Base**: `a3e70b5a4` (origin/main after #778)
+
+**What this slice closes**: The #778 PR landed the validator-guarded
+resolver in the Hermes executor and explicitly named
+`BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1` as a hard
+precondition row for `WRE_CONTEXT_BUNDLE_DRYRUN_CONSUMER_PHASE1`. This
+slice satisfies that precondition by reusing the #778 resolver through
+behavior-preserving extraction (Addendum C).
+
+**What this slice does**:
+
+- Creates `modules/foundups/agent/src/module_path_resolution.py` as the
+  SHARED single source of truth for the module-path trust rule.
+- Refactors `hermes_foundup_job_executor.py` into a back-compat shim
+  that re-exports every name from the shared module; the #778 test
+  file passes with **ZERO edits** (Addendum C #3 hard gate).
+- Refactors `build_plan_generator.py` to consume the shared resolver:
+  - DELETES the `KNOWN_FOUNDUP_PATHS` dict + `get_known_foundup_path()`
+    inference wrapper (DELETE_AS_DEAD_CODE per the Phase-0 census).
+  - DELETES the `f"modules/foundups/{job.foundup_id}"` synthesis
+    fallback (line 282 in the prior layout).
+  - DELETES the prefix-only `_is_valid_foundup_path()` gate with its
+    case-insensitive `.lower()` compare and PWA-surface admit.
+  - REWROTES `validate_job_for_build_plan` and `build_target_from_job`
+    to flow through `_resolve_validated_module_path`.
+  - ADDS `rejected_payload_value` field to
+    `GenerationValidationResult` (observable-ignore).
+  - PWA-surface ruling: DERIVED_ONLY -- `pwa_surface_path` derived
+    from the canonical module_path basename; payload-supplied surface
+    paths NEVER trusted as module identity.
+- Pins the single-source-of-truth invariant via AST scans on both the
+  executor and the generator.
+- 27 new generator tests covering the full 14-test dispatch contract
+  (Addendum C + D folded), plus 4 Addendum-C extraction-equivalence
+  tests, plus 2 meta-tests verifying the #778 import patterns still
+  resolve through the shim.
+
+**Consumer-wiring precondition status (post-this-slice)**:
+
+- Precondition (a) `FOUNDUP_LIFECYCLE_SOURCE_AUTHORITY_CONTRACT_PHASE1`
+  -- satisfied by #777.
+- Precondition (b) legacy `payload.module_path` trust removed at
+  Hermes executor seam -- satisfied by #778.
+- Precondition (c) `BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1`
+  (the precondition row #778 named) -- **satisfied by THIS SLICE**.
+- `WRE_CONTEXT_BUNDLE_DRYRUN_CONSUMER_PHASE1` is now unblocked.
+
+**Tests**: 646 passed / 0 skipped / 0 xfailed across the agent module
+suite. The #778 executor test file passes with ZERO edits (46/46).
+
+**Boundary preserved**: validator NOT mutated; manifests NOT mutated;
+`hermes_adapter.py` and runtime NOT touched; no new dependency; no WSP
+file mutated; generator remains orphaned (no consumer wired);
+`StatusReasonCode` and `GenerationValidationResult.error_code`
+taxonomies stay frozen (new tokens are the closed-set #778 strings;
+no schema-level change).
+
+**WSP_97**: PASS (14/14) -- full table in
+[`modules/foundups/agent/ModLog.md`](modules/foundups/agent/ModLog.md).
+
+**Predecessors**: #770 (manifest readiness audit), #771 (baseline
+validator), #772 (context-bundle boundary audit), #773 (exact-match
+validator hardening), #774 (execution-chain audit), #775 (ContextBundle
+builder), #777 (source-authority contract), #778 (Hermes executor
+trust removal -- the resolver this slice extracts and reuses).
+
+---
+
 ## [2026-06-10] Hermes Module-Path Trust Removal Phase 1 (#774 carry-forward closure)
 
 **Change Type**: Authoring slice (security pre-flight, last consumer-wiring

--- a/modules/foundups/agent/INTERFACE.md
+++ b/modules/foundups/agent/INTERFACE.md
@@ -2,6 +2,145 @@
 
 Public API and schema contracts for agent lifecycle management, BuildPlan generation, controlled execution, read-only manifest provenance, source-authority contract, and validated module-path resolution.
 
+## Shared Module-Path Resolver (BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1)
+
+The validated-module-path resolver originally introduced in
+[`hermes_foundup_job_executor.py`](src/hermes_foundup_job_executor.py) by #778
+has been EXTRACTED into a shared module -- single source of truth for the
+module-path trust rule across the agent module.
+
+```python
+# modules/foundups/agent/src/module_path_resolution.py  (NEW in this slice)
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class ResolvedModulePath:
+    """Observable-ignore shape mirroring source_authority.resolve_source_authority.
+    Identical to the #778 surface; moved verbatim."""
+    effective: Optional[str]
+    ignored: Optional[str]
+    failed: bool
+    fail_token: Optional[str]
+    fail_human: str
+
+
+def _resolve_validated_module_path(
+    job: FoundUpJob, repo_root: Path,
+) -> ResolvedModulePath:
+    """Resolve a job's module_path through the #773 validator. Fail-closed.
+    
+    Pinned design unchanged from #778. Closed-set tokens:
+    {syntactic_reject, manifest_mismatch, manifest_missing, cross_foundup_mismatch}.
+    """
+
+
+# Plus DEFAULT_REPO_ROOT, _MANIFEST_SEARCH_GLOBS, the four FAIL_TOKEN_* constants,
+# ALL_FAIL_TOKENS, _stringify_ignored, _find_manifest_for_foundup_id.
+```
+
+### Behavior-preserving back-compat shim (Addendum C #3)
+
+The Hermes executor re-exports every name so existing imports keep working
+with **zero edits** in `test_hermes_foundup_job_executor.py` (proven by a
+46-test pass after extraction):
+
+```python
+# modules/foundups/agent/src/hermes_foundup_job_executor.py
+from modules.foundups.agent.src.module_path_resolution import (  # noqa: F401
+    ALL_FAIL_TOKENS,
+    DEFAULT_REPO_ROOT,
+    FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH,
+    FAIL_TOKEN_MANIFEST_MISMATCH,
+    FAIL_TOKEN_MANIFEST_MISSING,
+    FAIL_TOKEN_SYNTACTIC_REJECT,
+    ResolvedModulePath,
+    _find_manifest_for_foundup_id,
+    _MANIFEST_SEARCH_GLOBS,
+    _resolve_validated_module_path,
+    _stringify_ignored,
+)
+```
+
+Identity is preserved: `hermes_foundup_job_executor._resolve_validated_module_path
+is module_path_resolution._resolve_validated_module_path` is `True`.
+`build_plan_generator` imports the SAME function from the shared module.
+The single-source-of-truth invariant is mechanically pinned by AST scans
+on both files (`TestSharedResolverIsSingleSourceOfTruth`).
+
+## BuildPlan Generator -- Validated Resolution (BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1)
+
+The build_plan_generator no longer trusts raw `payload.module_path` /
+`source_module`, no longer infers from `KNOWN_FOUNDUP_PATHS` (deleted as
+dead code), no longer synthesizes `modules/foundups/{foundup_id}` (deleted),
+and no longer uses the prefix-only `.lower()` `_is_valid_foundup_path`
+gate (deleted). All module-identity flows through the shared resolver.
+
+```python
+# modules/foundups/agent/src/build_plan_generator.py
+
+@dataclass
+class GenerationValidationResult:
+    """Result of job validation for BuildPlan generation."""
+    valid: bool
+    error_code: Optional[str] = None                  # closed-set #778 tokens on resolver failure
+    error_message: Optional[str] = None
+    inferred_module_path: Optional[str] = None        # manifest-derived canonical (None on failure)
+    rejected_payload_value: Optional[str] = None      # observable-ignore (mirrors resolver.ignored)
+
+
+def validate_job_for_build_plan(
+    job: FoundUpJob, repo_root: Optional[Path] = None,
+) -> GenerationValidationResult:
+    """Pre-gate (MISSING_FOUNDUP_ID / UNSUPPORTED_ACTION / UNKNOWN_ACTION)
+    then the shared resolver. ``error_code`` on resolver failure is one of
+    {syntactic_reject, manifest_mismatch, manifest_missing, cross_foundup_mismatch}."""
+
+
+def build_target_from_job(
+    job: FoundUpJob, repo_root: Optional[Path] = None,
+) -> BuildTarget:
+    """ALWAYS calls the resolver and uses the canonical ``effective``
+    module_path. PWA-surface ruling: DERIVED_ONLY -- ``pwa_surface_path``
+    is derived from the canonical module_path's basename; payload-supplied
+    surface paths are NOT trusted as module identity."""
+```
+
+### KNOWN_FOUNDUP_PATHS retention ruling
+
+**DELETE_AS_DEAD_CODE.** Phase-0 census found 2 PATH_IDENTITY_USE sites
+(both removed by this slice) and 1 DISPLAY_CATALOG_USE inline error
+string co-located inside the severed branch. Zero non-test cross-module
+callers. The constant and its `get_known_foundup_path()` wrapper are gone.
+
+### PWA-surface ruling
+
+**DERIVED_ONLY.** `BuildTarget.pwa_surface_path` is derived as
+`f"public/member/foundups/{module_basename}/"` where `module_basename`
+is the last segment of the resolver's canonical `module_path`. The
+legacy admit of `public/member/foundups/<id>` paths as module identity
+is gone -- they reject at `syntactic_reject` because they don't
+`startswith("modules/")`.
+
+### Greppable failure tokens (closed set, unchanged from #778)
+
+```python
+FAIL_TOKEN_SYNTACTIC_REJECT       = "syntactic_reject"
+FAIL_TOKEN_MANIFEST_MISMATCH      = "manifest_mismatch"
+FAIL_TOKEN_MANIFEST_MISSING       = "manifest_missing"
+FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH = "cross_foundup_mismatch"
+```
+
+### Consumer-wiring precondition status
+
+This slice closes the last #778 carry-forward (the
+build_plan_generator trust surface that was OUT_OF_SCOPE_NAMED_FOLLOWUP
+in #778's ruling). `WRE_CONTEXT_BUNDLE_DRYRUN_CONSUMER_PHASE1` no
+longer needs to gate on a generator hardening precondition; the single
+source of truth is in place across both consumers.
+
 ## Validated Module-Path Resolution (HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1)
 
 Closes the #774 carry-forward by forcing every job's `module_path` through the

--- a/modules/foundups/agent/ModLog.md
+++ b/modules/foundups/agent/ModLog.md
@@ -1,5 +1,222 @@
 # Agent Module ModLog
 
+## 2026-06-11 - BuildPlan Generator Module-Path Trust Removal Phase 1 (#778 carry-forward closure + shared resolver extraction)
+
+**Author**: 0102 (W6)
+**Commander**: 012
+**Slice**: BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1
+**Branch**: `w6/build-plan-generator-module-path-trust-removal-phase1`
+**Base**: `a3e70b5a4` (origin/main after #778)
+**Effort**: ULTRA
+
+**Type**: Authoring slice (last carry-forward closure). Closes the
+#778 carry-forward by extracting the validator-guarded resolver into a
+SHARED module and reusing it in `build_plan_generator`. The module is
+orphaned today (Phase-0 re-verified zero production importers); this
+slice fences it BEFORE `WRE_CONTEXT_BUNDLE_DRYRUN_CONSUMER_PHASE1` makes
+anything reachable.
+
+**WSP References**: WSP 11, WSP 50, WSP 77, WSP 84, WSP 87, WSP 97,
+WSP 22.
+
+### Phase 0 -- Mandatory Discovery summary
+
+- **HoloIndex**: 4/4 queries returned HOLOINDEX_LOW_SIGNAL despite
+  exact-identifier-token queries. Public HTML / WSP framework prose
+  dominated cosine ranking; canonical files (`build_plan_generator.py`,
+  `build_plan.py`, `hermes_foundup_job_executor.py`) were absent from
+  every top-8. Recorded as the second LOW-signal slice in a row -- a
+  HoloIndex re-index of `modules/foundups/agent/` is now urgent.
+  Manual `Grep` / `Read` recovered every target.
+- **Trust-point re-verification**: all 5 trust points present at
+  current line numbers; small shifts (#3 +1, #6 +4). `_is_valid_foundup_path`
+  at lines 203-223 still has `.lower()` case-folding at line 211 and
+  still admits `public/member/foundups/`.
+- **Reachability re-check**: REMAINS_ORPHANED. Zero production
+  importers (only src/ reference is the explicit "NOT imported"
+  comment at `foundup_manifest_validator.py:35`). All callers of
+  `create_build_plan_from_job` / `validate_job_for_build_plan` /
+  `build_target_from_job` / `get_known_foundup_path` are in
+  `tests/`. `BuildPlanExecutor.execute_step` is still a BLOCKED stub
+  for `dry_run=False`.
+- **KNOWN_FOUNDUP_PATHS consumer census**: 2 PATH_IDENTITY_USE sites
+  (lines 172 and 278) + 1 DISPLAY_CATALOG_USE inline string interpolation
+  (line 182 in the same severed branch) + 0 cross-module callers.
+  Ruling: **DELETE_AS_DEAD_CODE** (the DISPLAY_CATALOG_USE is removed
+  with the branch that contains it).
+- **Extraction equivalence map**: 12 names move to
+  `module_path_resolution.py`; the executor shim re-exports every name
+  the test file accesses via either `from ... import` or `import ... as e`
+  patterns. `Path(__file__).resolve().parents[4]` evaluates to the
+  same `Path` because the new module is at the same nesting depth.
+
+### Added
+
+- **`modules/foundups/agent/src/module_path_resolution.py`** -- NEW
+  shared module. Single source of truth for the module-path trust rule
+  across the agent module. Contains the verbatim-moved #778 resolver
+  surface:
+  - `ResolvedModulePath` frozen dataclass.
+  - `DEFAULT_REPO_ROOT`, `_MANIFEST_SEARCH_GLOBS`, four
+    `FAIL_TOKEN_*` constants, `ALL_FAIL_TOKENS`.
+  - `_stringify_ignored`, `_find_manifest_for_foundup_id`,
+    `_resolve_validated_module_path`.
+  - Imports only `__future__`, `json`, `dataclasses`, `pathlib`,
+    `typing`, the validator, and the `FoundUpJob` type. No runtime /
+    executor / consumer imports. No subprocess / network /
+    file-write.
+
+### Changed
+
+- **`modules/foundups/agent/src/hermes_foundup_job_executor.py`** --
+  back-compat shim. The 12 moved names are re-imported and re-exported
+  from the shared module. The executor's caller block (the
+  resolver-invocation site) is unchanged; it now resolves
+  `DEFAULT_REPO_ROOT` and `_resolve_validated_module_path` via the
+  shim, but the call semantics are identical. Identity is preserved:
+  `e._resolve_validated_module_path is m._resolve_validated_module_path`
+  is `True` (mechanically pinned by
+  `TestSharedResolverIsSingleSourceOfTruth::test_executor_shim_and_shared_module_resolve_same_function`).
+- **`modules/foundups/agent/src/build_plan_generator.py`** -- the
+  trust seams are CLOSED:
+  - DELETED: `KNOWN_FOUNDUP_PATHS` dict + `get_known_foundup_path()`
+    wrapper (lines 78-96 in the prior layout).
+  - DELETED: `_is_valid_foundup_path()` prefix-only gate with
+    `.lower()` compare and `public/member/foundups/` admit (lines
+    203-223 in the prior layout).
+  - DELETED: `f"modules/foundups/{job.foundup_id}"` synthesis fallback
+    in `build_target_from_job` (line 282 in the prior layout).
+  - DELETED: payload raw reads at the prior lines 167 and 276.
+  - REWROTE `validate_job_for_build_plan(job, repo_root=None)`: pre-
+    gates `MISSING_FOUNDUP_ID` / `UNSUPPORTED_ACTION` / `UNKNOWN_ACTION`,
+    then delegates to the shared resolver. On resolver failure the
+    `GenerationValidationResult.error_code` carries the closed-set
+    #778 token (`syntactic_reject` / `manifest_mismatch` /
+    `manifest_missing` / `cross_foundup_mismatch`).
+  - REWROTE `build_target_from_job(job, repo_root=None)`: ALWAYS calls
+    the resolver; `BuildTarget.module_path` is the resolver's
+    canonical `effective`. PWA-surface ruling: DERIVED_ONLY --
+    `pwa_surface_path` derived from the canonical module_path basename
+    (`public/member/foundups/{basename}/`); payload-supplied surface
+    paths NEVER trusted as module identity.
+  - ADDED `rejected_payload_value` field to
+    `GenerationValidationResult` -- mirrors `ResolvedModulePath.ignored`
+    (observable-ignore). Visible even on success; NEVER propagates
+    into BuildTarget output (pinned by
+    `test_rejected_payload_value_does_not_propagate_into_buildtarget`).
+- **`modules/foundups/agent/tests/test_build_plan_generator.py`** --
+  test updates (flagged in TestModLog):
+  - REMOVED dead-symbol imports `KNOWN_FOUNDUP_PATHS`,
+    `get_known_foundup_path` from the import block.
+  - DELETED `test_known_foundup_paths_include_voteballots` and
+    `test_get_known_foundup_path_returns_voteballots` (the symbols
+    they exercised are deleted).
+  - UPDATED `TestModulePathInference`: kept the happy-path tests
+    (the bounded foundup_id scan locates the real `voteballots`
+    manifest); replaced the legacy `MISSING_MODULE_PATH` error_code
+    expectation with `manifest_missing`.
+  - UPDATED `TestOutsideScopeRejected`: replaced the legacy
+    `INVALID_MODULE_PATH` error_code expectation with the closed-set
+    #778 tokens (`syntactic_reject` for absolute / drive-prefix paths;
+    `manifest_missing` for under-`modules/` paths without a backing
+    manifest).
+  - ADDED `TestSharedResolverValidationInGenerator` (the 14
+    dispatch-required negative tests + happy-path controls): payload-
+    path with no backing manifest, source_module alias variants,
+    cross-FoundUp substitution, suffix/basename, case-variant +
+    uppercase prefix, absolute + drive-prefix + traversal +
+    backslash, empty-string-as-absent, the dead-dict legacy IDs no
+    longer resolve, foundup_id synthesis dead, PWA surface as
+    identity rejected, rejected value observable on failure AND on
+    success, rejected value never propagates into BuildPlan output.
+  - ADDED `TestSharedResolverIsSingleSourceOfTruth` (Addendum C #4):
+    asserts the executor shim re-exports the SAME objects (identity
+    preservation across the import boundary), the generator and
+    executor reference the same resolver, AST scans on both files
+    confirm no second resolver implementation remains.
+  - ADDED `TestHermes778TestsUnchanged` (Addendum C #3 meta-test):
+    asserts every import pattern the #778 executor test uses still
+    resolves through the shim, including the `import ... as e`
+    attribute-access pattern.
+
+### Boundary preserved
+
+- **HERMES_778_TESTS_UNCHANGED_GREEN**: `pytest -q
+  modules/foundups/agent/tests/test_hermes_foundup_job_executor.py` ->
+  **46 passed in 0.83s** with ZERO edits to the test file. Addendum
+  C #3 satisfied.
+- **NO_SECOND_MODULE_PATH_RESOLVER**: AST scan on both the executor
+  and the generator confirms neither file defines
+  `_resolve_validated_module_path`, `_find_manifest_for_foundup_id`,
+  `_stringify_ignored`, or `ResolvedModulePath` locally. The shared
+  module is the only definition.
+- **NO_VALIDATOR_MUTATION**: `foundup_manifest_validator.py`
+  untouched.
+- **NO_MANIFEST_MUTATION**: no `foundup_manifest.json` modified.
+- **NO_RUNTIME_OR_BUILDER_CHANGE**: `hermes_adapter.py` untouched;
+  generator stays orphaned (no consumer wired).
+- **NO_WSP_FILE_MUTATION**.
+- **NO_NEW_DEPENDENCY**: only stdlib + intra-repo imports.
+- **NO_JOB_CONTRACT_SCHEMA_CHANGE**: `StatusReasonCode` enum unchanged.
+
+### Tests
+
+```
+python -m pytest modules/foundups/agent/tests/test_build_plan_generator.py -q
+  -> 71 passed in 0.97s
+python -m pytest modules/foundups/agent/tests/test_hermes_foundup_job_executor.py -q
+  -> 46 passed in 0.83s (ZERO edits; Addendum C #3 satisfied)
+python -m pytest modules/foundups/agent/tests/ -q
+  -> 646 passed in 8.99s; 0 skipped; 0 xfailed
+```
+
+### Updated assertions (logged for W10 audit per dispatch)
+
+- `TestModulePathInference::test_known_foundup_paths_include_voteballots`
+  and `..._get_known_foundup_path_returns_voteballots` -- DELETED
+  (symbols deleted).
+- `TestModulePathInference::test_unknown_foundup_without_module_path_fails` --
+  error_code expectation changed from `"MISSING_MODULE_PATH"` to
+  `"manifest_missing"`.
+- `TestOutsideScopeRejected::test_infrastructure_path_rejected` and
+  `..._ai_intelligence_path_rejected` -- expected error_code changed
+  from `"INVALID_MODULE_PATH"` to `"manifest_missing"` (paths under
+  `modules/` but with no on-disk manifest).
+- `TestOutsideScopeRejected::test_root_path_rejected` -- expected
+  error_code changed from `"INVALID_MODULE_PATH"` to
+  `"syntactic_reject"` (absolute path caught at pre-manifest hardening).
+
+### WSP_97 Truth Boundary Checklist
+
+| # | Truth Boundary Checklist Item | Status | Evidence |
+|---|-------------------------------|--------|----------|
+| 1 | OLD_PAYLOAD_MODULE_PATH_TRUST_DEAD | YES | Source removes the lines 167, 220, 276 raw payload reads; `validate_job_for_build_plan` and `build_target_from_job` now both delegate to the shared resolver. Tests `test_payload_path_with_no_backing_manifest_rejected` and `test_rejected_payload_value_does_not_propagate_into_buildtarget` pin the new behavior. |
+| 2 | KNOWN_FOUNDUP_PATHS_INFERENCE_DEAD | YES | Source: `KNOWN_FOUNDUP_PATHS` dict and `get_known_foundup_path` function REMOVED from `build_plan_generator.py`. Test `test_known_foundup_paths_symbol_is_gone` asserts the import raises `ImportError`. AST scan in `test_no_second_resolver_in_build_plan_generator` confirms no `KNOWN_FOUNDUP_PATHS` assignment node remains. `test_known_foundup_id_without_on_disk_manifest_fails_closed` parametrizes the legacy dead-dict entries (`pqn_portal`, `social_twin`, `move2japan`) and asserts every one now fails with `manifest_missing`. |
+| 3 | FOUNDUP_ID_SYNTHESIS_DEAD | YES | Source: the `f"modules/foundups/{job.foundup_id}"` fallback at the prior line 282 is REMOVED. `test_foundup_id_synthesis_dead_no_modules_foundups_fallback` asserts a non-real foundup_id with empty payload returns `manifest_missing`, not a synthesized path. `test_build_target_does_not_use_synthesized_path` asserts `build_target_from_job` raises ValueError rather than returning a BuildTarget with a synthesized module_path. |
+| 4 | CASE_VARIANT_PATH_REJECTED | YES | The `.lower()` compare in the dead `_is_valid_foundup_path` is gone. `test_case_variant_payload_rejected` (`modules/Foundups/voteballots`) and `test_uppercase_modules_prefix_rejected` (`Modules/foundups/voteballots`) both assert failure. |
+| 5 | CROSS_FOUNDUP_SUBSTITUTION_REJECTED | YES | Inherits #778's resolver defense. `test_cross_foundup_substitution_rejected` constructs `job.foundup_id="voteballots"` + `payload.module_path="modules/foundups/kosei"` (both manifests are real) and asserts `error_code == "cross_foundup_mismatch"`. |
+| 6 | PWA_SURFACE_RULING_RECORDED | YES | INTERFACE.md "PWA-surface ruling: DERIVED_ONLY" section. `test_pwa_surface_path_as_module_identity_rejected` asserts a payload-supplied `public/member/foundups/voteballots` path rejects at `syntactic_reject`. `test_buildplan_carries_only_canonical_when_payload_provided` asserts the BuildTarget's `pwa_surface_path` is derived from the manifest canonical's basename. |
+| 7 | VALIDATED_MANIFEST_SOURCE_OF_TRUTH | YES | `validate_job_for_build_plan` and `build_target_from_job` both set their outputs from `resolved.effective`. `test_buildplan_carries_only_canonical_when_payload_provided` asserts the BuildTarget carries the manifest canonical (not the payload string) even when they match. |
+| 8 | REJECTED_PAYLOAD_VALUE_OBSERVABLE | YES | New `GenerationValidationResult.rejected_payload_value` field carries the observable-ignore channel. `test_rejected_value_observable_on_failure` and `test_rejected_value_observable_on_success` both pass; the value is visible even when the payload matched. |
+| 9 | REJECTED_VALUE_NOT_IN_BUILDPLAN_OUTPUT | YES | `test_rejected_payload_value_does_not_propagate_into_buildtarget` asserts both `create_build_plan_from_job` and `build_target_from_job` raise ValueError instead of producing a BuildTarget that carries the rejected value. |
+| 10 | HERMES_778_TESTS_UNCHANGED_GREEN | YES | `pytest -q test_hermes_foundup_job_executor.py` returns `46 passed in 0.83s` with ZERO edits to the test file (Addendum C #3 hard gate). Verified by `TestHermes778TestsUnchanged::test_executor_test_imports_still_resolve` and `test_executor_attribute_access_pattern_still_works`. |
+| 11 | SHARED_RESOLVER_SINGLE_SOURCE_OF_TRUTH | YES | NEW `modules/foundups/agent/src/module_path_resolution.py` carries the only definition. Both the executor (via shim) and the generator (via direct import) reference the SAME function object: `test_executor_shim_and_shared_module_resolve_same_function` and `test_generator_uses_same_resolver_as_executor` use `is` identity comparison. |
+| 12 | HERMES_RESOLVER_EXTRACTION_BEHAVIOR_PRESERVED | YES | The 12 moved names are identical bytes (verbatim quote from #778 captured in Phase-0; reproduced unchanged in the new module). `Path(__file__).resolve().parents[4]` evaluates to the same Path because the new module is at the same nesting depth. The shim re-imports without wrapping. `test_executor_attribute_access_pattern_still_works` mechanically asserts every #778 attribute resolves correctly. |
+| 13 | NO_SECOND_MODULE_PATH_RESOLVER | YES | AST scans `test_no_second_resolver_implementation_in_executor` and `test_no_second_resolver_in_build_plan_generator` walk the AST and assert neither file defines `_resolve_validated_module_path`, `_find_manifest_for_foundup_id`, `_stringify_ignored`, or `ResolvedModulePath` locally. KNOWN_FOUNDUP_PATHS-style assignments also caught. |
+| 14 | NO_USER_QUESTION_FRAMING | YES | Addendum A respected. Phase-0 forks decided by evidence + recommendation: PWA-surface ruling -> DERIVED_ONLY (evidence: `BuildTarget` auto-derives from `module_path` basename); KNOWN_FOUNDUP_PATHS ruling -> DELETE_AS_DEAD_CODE (evidence: census shows 0 live non-PATH_IDENTITY consumers). |
+
+**WSP_97 VERDICT**: PASS (14/14).
+
+### Follow-ups (recorded; not executed here)
+
+- `WRE_CONTEXT_BUNDLE_DRYRUN_CONSUMER_PHASE1` -- can now wire a
+  dry-run consumer, IF AND ONLY IF the source of truth remains the
+  shared resolver and no second implementation appears.
+- HoloIndex re-index of `modules/foundups/agent/` -- two consecutive
+  slices have hit LOW signal on identifier-token queries.
+
+---
+
 ## 2026-06-10 - Hermes Module-Path Trust Removal Phase 1 (#774 carry-forward closure)
 
 **Author**: 0102 (W6)

--- a/modules/foundups/agent/ROADMAP.md
+++ b/modules/foundups/agent/ROADMAP.md
@@ -40,6 +40,31 @@
   - Observable-ignore: rejected payload value visible in evidence_refs
   - StatusReasonCode unchanged (FAIL_VALIDATION_ERROR); no job-contract
     schema changes; no validator / manifest / runtime / WSP touch
+- [x] Validated module-path resolution in build_plan_generator + shared
+  resolver extraction
+  (BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1)
+  - Closes the #778 carry-forward by reusing the #778 resolver via
+    extraction (Addendum-C behavior-preserving)
+  - NEW `modules/foundups/agent/src/module_path_resolution.py` --
+    single source of truth for the module-path trust rule across the
+    agent module
+  - Hermes executor re-exports the same names (back-compat shim);
+    test_hermes_foundup_job_executor.py passes with ZERO edits (46/46
+    tests, Addendum C #3 satisfied)
+  - DELETED `KNOWN_FOUNDUP_PATHS` dict + `get_known_foundup_path()`
+    wrapper + `_is_valid_foundup_path()` prefix-only gate +
+    `f"modules/foundups/{foundup_id}"` synthesis fallback
+  - GenerationValidationResult now carries closed-set #778
+    `error_code` tokens + `rejected_payload_value` observable channel
+  - PWA-surface ruling: DERIVED_ONLY (basename of canonical
+    module_path); payload-supplied surface paths NEVER trusted as
+    module identity
+  - `BuildTarget.module_path` is ALWAYS the resolver's canonical
+    `effective` value; the rejected payload value never propagates
+    into BuildPlan output (mechanically pinned in tests)
+  - Single-source-of-truth invariant pinned by AST scans on both
+    executor and generator
+  - No validator / manifest / runtime / WSP touch
 - [x] FoundUp source-authority contract (FOUNDUP_LIFECYCLE_SOURCE_AUTHORITY_CONTRACT_PHASE1)
   - Authoritative definition doc at
     `docs/architecture/FOUNDUP_SOURCE_AUTHORITY_CONTRACT.md`

--- a/modules/foundups/agent/src/build_plan_generator.py
+++ b/modules/foundups/agent/src/build_plan_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-BuildPlan Generator — Generate BuildPlan from FoundUpJob
+BuildPlan Generator -- Generate BuildPlan from FoundUpJob
 
 Creates a BuildPlan from a FoundUpJob, bridging job-based orchestration
 to plan-based build control without enabling real execution.
@@ -15,15 +15,35 @@ WSP 97 TRUTH BOUNDARIES:
 Architecture:
   FoundUpJob (OpenClaw) -> Generator -> BuildPlan -> (Future: Executor)
 
+Module-path trust (BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1):
+  Closes the #778 carry-forward: this generator no longer trusts raw
+  payload.module_path / source_module, no longer infers from
+  KNOWN_FOUNDUP_PATHS, and no longer synthesizes
+  modules/foundups/{foundup_id}. All module-identity resolution flows
+  through the SHARED ``module_path_resolution._resolve_validated_module_path``
+  -- the same single source of truth the Hermes executor (#778) consumes
+  via shim.
+
+  Cross-FoundUp substitution, case-variant payload, absolute/UNC/
+  traversal/backslash forms, and KNOWN_FOUNDUP_PATHS-style heuristics all
+  produce a fail-closed GenerationValidationResult whose error_code is
+  one of the closed-set tokens
+  ``{syntactic_reject, manifest_mismatch, manifest_missing,
+  cross_foundup_mismatch}``. The rejected payload value is observable in
+  ``inferred_module_path=None`` and the error_message verbatim, and NEVER
+  propagates into the BuildTarget output.
+
 WSP Compliance:
   WSP 11  : Interface contract (typed API)
   WSP 50  : Pre-action validation (validate_job_for_build_plan)
   WSP 77  : Agent coordination (job->plan translation)
+  WSP 84  : Single source of truth (no second resolver implementation)
   WSP 97  : Truth boundaries (dry_run=True, no real execution)
 
 NAVIGATION:
   -> Uses: build_plan.py (BuildPlan, BuildTarget, BuildScope)
   -> Uses: foundup_job_contract.py (FoundUpJob, CANONICAL_ACTIONS)
+  -> Uses: module_path_resolution.py (#778 shared resolver, validator-gated)
   -> Spec: modules/foundups/docs/FOUNDUP_BUILD_PLAN_CONTRACT.md
   -> Called by: Internal VoteBallot PoC (future integration)
 """
@@ -51,6 +71,15 @@ from .build_plan import (
     generate_build_plan_id,
 )
 
+# Shared module-path resolver -- single source of truth across the agent
+# module (BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1).
+# The Hermes executor consumes the same resolver via a re-export shim.
+from .module_path_resolution import (
+    DEFAULT_REPO_ROOT,
+    ResolvedModulePath,
+    _resolve_validated_module_path,
+)
+
 logger = logging.getLogger("build_plan_generator")
 
 
@@ -72,28 +101,26 @@ BUILDPLAN_UNSUPPORTED_ACTIONS: frozenset[str] = frozenset({
 
 
 # ---------------------------------------------------------------------------
-# Known FoundUp Module Paths (repo evidence)
+# Module-Path Trust (BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1)
 # ---------------------------------------------------------------------------
-
-# Known FoundUp IDs with proven module paths in the repo
-# Used for module_path inference when payload doesn't specify
-KNOWN_FOUNDUP_PATHS: Dict[str, str] = {
-    "voteballots": "modules/foundups/voteballots",
-    "gotjunk": "modules/foundups/gotjunk",
-    "kosei": "modules/foundups/kosei",
-    "pqn_portal": "modules/foundups/pqn_portal",
-    "social_twin": "modules/foundups/social_twin",
-    "move2japan": "modules/foundups/move2japan",
-}
-
-
-def get_known_foundup_path(foundup_id: str) -> Optional[str]:
-    """
-    Get known module path for a FoundUp ID.
-
-    Returns None if not a known FoundUp with repo evidence.
-    """
-    return KNOWN_FOUNDUP_PATHS.get(foundup_id.lower())
+#
+# The prior KNOWN_FOUNDUP_PATHS dict + get_known_foundup_path() inference
+# helper, the f"modules/foundups/{job.foundup_id}" synthesis fallback, and
+# the case-insensitive prefix-only _is_valid_foundup_path validator were
+# all PATH_IDENTITY_USE trust seams that bypassed the #771/#773 manifest
+# validator (audit verdict in #774, Phase-0 census on this branch's
+# ModLog). They have been DELETED in this slice; module-identity resolution
+# now flows exclusively through the SHARED
+# ``module_path_resolution._resolve_validated_module_path`` resolver, which
+# is the same single source of truth the Hermes executor (#778) consumes
+# via shim.
+#
+# The Phase-0 KNOWN_FOUNDUP_PATHS consumer census found:
+#   - 2 PATH_IDENTITY_USE sites (the two payload-path fallbacks here),
+#   - 1 DISPLAY_CATALOG_USE inline error string co-located inside the
+#     severed branch (string interpolation of KNOWN_FOUNDUP_PATHS.keys()),
+#   - 0 non-test cross-module callers,
+# so the symbols qualified as DELETE_AS_DEAD_CODE and have been removed.
 
 
 # ---------------------------------------------------------------------------
@@ -103,7 +130,27 @@ def get_known_foundup_path(foundup_id: str) -> Optional[str]:
 
 @dataclass
 class GenerationValidationResult:
-    """Result of job validation for BuildPlan generation."""
+    """Result of job validation for BuildPlan generation.
+
+    Module-path trust contract (BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1):
+      - ``error_code`` on failure is one of:
+            ``MISSING_FOUNDUP_ID`` / ``UNSUPPORTED_ACTION`` / ``UNKNOWN_ACTION``
+            / the closed-set #778 tokens
+            ``syntactic_reject`` / ``manifest_mismatch`` / ``manifest_missing``
+            / ``cross_foundup_mismatch``.
+      - ``inferred_module_path`` is the manifest-derived canonical
+        module_path when the payload omitted a candidate AND the bounded
+        ``foundup_id`` scan in the shared resolver located the manifest.
+        On any failure it is ``None`` -- the rejected payload value is
+        captured only in ``error_message`` (observable, never used).
+      - ``rejected_payload_value`` is the stringified payload-declared
+        candidate, mirroring the resolver's ``ResolvedModulePath.ignored``
+        channel. ``None`` iff no payload candidate was supplied; otherwise
+        the value is reported even on success (no silent swallow).
+        The rejected value MUST NOT propagate into any BuildTarget /
+        BuildPlan / source-ref output -- WSP_97 row
+        REJECTED_VALUE_NOT_IN_BUILDPLAN_OUTPUT pins this.
+    """
 
     valid: bool
     """True if job can generate a BuildPlan."""
@@ -115,7 +162,13 @@ class GenerationValidationResult:
     """Human-readable error message if invalid."""
 
     inferred_module_path: Optional[str] = None
-    """Module path inferred from foundup_id if not in payload."""
+    """Manifest-derived canonical module_path when payload omitted a
+    candidate. None on any failure."""
+
+    rejected_payload_value: Optional[str] = None
+    """Stringified payload-declared candidate (observable-ignore). None iff
+    the caller supplied no candidate. Visible even on success; NEVER
+    propagated into BuildTarget output."""
 
 
 # ---------------------------------------------------------------------------
@@ -123,20 +176,37 @@ class GenerationValidationResult:
 # ---------------------------------------------------------------------------
 
 
-def validate_job_for_build_plan(job: FoundUpJob) -> GenerationValidationResult:
-    """
-    Validate that a FoundUpJob can generate a BuildPlan.
+def validate_job_for_build_plan(
+    job: FoundUpJob, repo_root: Optional[Path] = None
+) -> GenerationValidationResult:
+    """Validate that a FoundUpJob can generate a BuildPlan.
 
-    Checks:
-      1. foundup_id is present
-      2. requested_action is supported
-      3. module_path can be determined (from payload or inference)
-      4. Path is within allowed scope
+    Module-path trust contract (BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1):
 
-    Returns:
-        GenerationValidationResult with validation outcome.
+      1. ``job.foundup_id`` must be present.
+      2. ``job.requested_action`` must be in ``BUILDPLAN_SUPPORTED_ACTIONS``.
+      3. ``module_path`` is resolved through the SHARED resolver
+         ``module_path_resolution._resolve_validated_module_path`` (the
+         same single source of truth #778 consumes via shim). No raw
+         payload trust, no ``KNOWN_FOUNDUP_PATHS`` inference, no
+         ``foundup_id``-as-path synthesis, no case-insensitive prefix
+         match, no ``public/member/foundups/`` admit.
+
+    Failure shape:
+      ``error_code`` carries one of the closed-set #778 tokens
+      ``{syntactic_reject, manifest_mismatch, manifest_missing,
+      cross_foundup_mismatch}`` when the resolver rejects, OR one of
+      ``{MISSING_FOUNDUP_ID, UNSUPPORTED_ACTION, UNKNOWN_ACTION}`` for
+      pre-resolver gates. The rejected payload value is reported in
+      ``rejected_payload_value`` (mirrors the resolver's observable-
+      ignore channel) and NEVER propagates into BuildTarget output.
+
+    Args:
+        job: FoundUpJob to validate.
+        repo_root: Optional override for manifest lookup root (defaults to
+            ``module_path_resolution.DEFAULT_REPO_ROOT``).
     """
-    # Check foundup_id
+    # Pre-resolver gate: foundup_id must be present.
     if not job.foundup_id:
         return GenerationValidationResult(
             valid=False,
@@ -144,7 +214,7 @@ def validate_job_for_build_plan(job: FoundUpJob) -> GenerationValidationResult:
             error_message="FoundUpJob.foundup_id is required for BuildPlan generation",
         )
 
-    # Check requested_action is supported
+    # Pre-resolver gate: requested_action must be supported.
     action = job.requested_action
     if action in BUILDPLAN_UNSUPPORTED_ACTIONS:
         return GenerationValidationResult(
@@ -162,65 +232,37 @@ def validate_job_for_build_plan(job: FoundUpJob) -> GenerationValidationResult:
             f"Supported actions: {', '.join(sorted(BUILDPLAN_SUPPORTED_ACTIONS))}",
         )
 
-    # Determine module_path
-    payload = job.payload or {}
-    module_path = payload.get("module_path") or payload.get("source_module")
-
-    # Try to infer from foundup_id if not provided
-    inferred_path = None
-    if not module_path:
-        inferred_path = get_known_foundup_path(job.foundup_id)
-        if inferred_path:
-            module_path = inferred_path
-        else:
-            return GenerationValidationResult(
-                valid=False,
-                error_code="MISSING_MODULE_PATH",
-                error_message=(
-                    f"Cannot determine module_path for FoundUp '{job.foundup_id}'. "
-                    f"Provide payload.module_path or use a known FoundUp ID: "
-                    f"{', '.join(sorted(KNOWN_FOUNDUP_PATHS.keys()))}"
-                ),
-            )
-
-    # Validate path is within allowed scope
-    if not _is_valid_foundup_path(module_path):
+    # Module-path resolution via the SHARED #778 resolver. Fail-closed.
+    # The resolver enforces: syntactic hardening pre-manifest (backslash /
+    # absolute / UNC / traversal / not-under-modules/), bounded foundup_id
+    # scan when payload candidate absent, #773 manifest validator gate,
+    # cross-FoundUp substitution defense, case-variant defense.
+    effective_repo_root = repo_root or DEFAULT_REPO_ROOT
+    resolved: ResolvedModulePath = _resolve_validated_module_path(
+        job, effective_repo_root
+    )
+    if resolved.failed:
+        # The closed-set fail_token doubles as the GenerationValidationResult
+        # error_code so downstream auditors can grep on the same taxonomy
+        # used by the executor (#778). The rejected payload value is
+        # observable but NEVER used downstream.
         return GenerationValidationResult(
             valid=False,
-            error_code="INVALID_MODULE_PATH",
-            error_message=(
-                f"Module path '{module_path}' is outside allowed scope. "
-                f"Must be under modules/foundups/ or a recognized target path."
-            ),
+            error_code=resolved.fail_token or "manifest_missing",
+            error_message=resolved.fail_human,
+            inferred_module_path=None,
+            rejected_payload_value=resolved.ignored,
         )
 
+    # Success: the manifest's canonical module_path is the source of truth.
+    # When the payload supplied a candidate, ``ignored`` carries that value
+    # for observability but it is NOT used downstream (the BuildTarget will
+    # be built from ``resolved.effective`` in build_target_from_job).
     return GenerationValidationResult(
         valid=True,
-        inferred_module_path=inferred_path,
+        inferred_module_path=resolved.effective,
+        rejected_payload_value=resolved.ignored,
     )
-
-
-def _is_valid_foundup_path(path: str) -> bool:
-    """
-    Check if path is a valid FoundUp module path.
-
-    Valid paths:
-      - modules/foundups/<foundup_id>/...
-      - public/member/foundups/<foundup_id>/... (PWA surface)
-    """
-    normalized = path.replace("\\", "/").lower()
-
-    # Must be under foundups module or surface
-    valid_prefixes = [
-        "modules/foundups/",
-        "public/member/foundups/",
-    ]
-
-    for prefix in valid_prefixes:
-        if normalized.startswith(prefix):
-            return True
-
-    return False
 
 
 # ---------------------------------------------------------------------------
@@ -264,28 +306,65 @@ def infer_build_scope(job: FoundUpJob) -> BuildScope:
 # ---------------------------------------------------------------------------
 
 
-def build_target_from_job(job: FoundUpJob) -> BuildTarget:
-    """
-    Generate BuildTarget from FoundUpJob payload.
+def build_target_from_job(
+    job: FoundUpJob, repo_root: Optional[Path] = None
+) -> BuildTarget:
+    """Generate BuildTarget from a validated FoundUpJob.
 
-    Maps job.payload fields to BuildTarget fields.
+    Module-path trust contract (BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1):
+
+      The ``module_path`` field of the produced BuildTarget is ALWAYS the
+      validated manifest's canonical module_path (the resolver's
+      ``effective`` value). Raw ``payload.module_path`` /
+      ``payload.source_module`` / ``foundup_id``-synthesis values are
+      NEVER used as identity. PWA-surface ruling: DERIVED_ONLY -- the
+      ``pwa_surface_path`` is derived deterministically from the canonical
+      ``module_path`` plus a fixed ``public/member/foundups/<basename>/``
+      template; ``payload.pwa_surface_path`` is no longer trusted as the
+      module-identity surface (a future slice may revisit if BuildPlan
+      ever requires a payload-specified surface path).
+
+      Other BuildTarget fields (``tests_path``, ``docs_path``, ...) remain
+      payload-overridable; they are auto-derived from ``module_path`` by
+      ``BuildTarget`` itself when omitted (see ``build_plan.py`` BuildTarget
+      auto-derivation block). The payload-supplied alternates are not
+      module identity and do not affect the trust seam this slice closes.
+
+    Args:
+        job: FoundUpJob whose payload provides BuildTarget field overrides.
+            The job MUST have passed ``validate_job_for_build_plan`` first.
+        repo_root: Optional override for manifest lookup root.
+
+    Raises:
+        ValueError: when the job fails validated module-path resolution.
+            (``create_build_plan_from_job`` calls ``validate_job_for_build_plan``
+            first, so this raise is defense-in-depth.)
     """
     payload = job.payload or {}
 
-    # Determine module_path (validated before this is called)
-    module_path = payload.get("module_path") or payload.get("source_module")
-    if not module_path and job.foundup_id:
-        module_path = get_known_foundup_path(job.foundup_id)
+    # The module_path that lands in BuildTarget is ALWAYS the resolver's
+    # canonical ``effective`` value. The rejected-payload-value channel
+    # (resolver.ignored) is read here ONLY for the error-raise path; it
+    # never enters the BuildTarget output.
+    effective_repo_root = repo_root or DEFAULT_REPO_ROOT
+    resolved: ResolvedModulePath = _resolve_validated_module_path(
+        job, effective_repo_root
+    )
+    if resolved.failed:
+        # Mirror the ValueError shape used by create_build_plan_from_job
+        # so callers see one consistent failure path. The greppable token
+        # is preserved in the message head.
+        raise ValueError(f"[{resolved.fail_token}] {resolved.fail_human}")
+    module_path: str = resolved.effective or ""
 
-    if not module_path:
-        # Should not reach here if validation passed
-        module_path = f"modules/foundups/{job.foundup_id}"
-
-    # Extract optional paths from payload
-    pwa_surface_path = payload.get("pwa_surface_path")
-    if not pwa_surface_path and job.foundup_id:
-        # Default PWA surface path
-        pwa_surface_path = f"public/member/foundups/{job.foundup_id}/"
+    # PWA-surface derivation: ALWAYS from the canonical module_path's
+    # last segment, never from payload-supplied surface paths or from
+    # job.foundup_id. The basename of a validated canonical module_path
+    # is the on-disk module directory name and is a safe surface key.
+    module_basename = module_path.rsplit("/", 1)[-1] if module_path else ""
+    pwa_surface_path = (
+        f"public/member/foundups/{module_basename}/" if module_basename else None
+    )
 
     return BuildTarget(
         module_path=module_path,

--- a/modules/foundups/agent/src/hermes_foundup_job_executor.py
+++ b/modules/foundups/agent/src/hermes_foundup_job_executor.py
@@ -32,11 +32,9 @@ NAVIGATION:
 
 from __future__ import annotations
 
-import json
 import logging
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from modules.communication.moltbot_bridge.src.foundup_job_contract import (
     FoundUpJob,
@@ -46,17 +44,24 @@ from modules.communication.moltbot_bridge.src.foundup_job_contract import (
     is_terminal_status,
 )
 
-# Module-path resolution (HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1):
-# the #773 validator is imported and consumed as the source of truth for
-# any module_path that enters the executor. The leading-underscore helper
-# is intentionally a module-private import per the validator's "no IO /
-# no execution" contract; we do NOT mutate the validator's public surface
-# in this slice.
-from modules.foundups.agent.src.foundup_manifest_validator import (
-    validate_manifest_file,
-)
-from modules.foundups.agent.src.foundup_manifest_validator import (
-    _canonicalize_module_path as _validator_canonicalize_module_path,
+# Module-path resolution moved to a shared module in
+# BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1 (Addendum-C
+# behavior-preserving extraction). This back-compat shim re-exports every
+# name the prior in-file resolver exposed so existing imports keep working
+# with ZERO test edits per Addendum C #3. The same objects are bound (no
+# wrapping, no shadowing); identity is preserved across the import boundary.
+from modules.foundups.agent.src.module_path_resolution import (  # noqa: F401
+    ALL_FAIL_TOKENS,
+    DEFAULT_REPO_ROOT,
+    FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH,
+    FAIL_TOKEN_MANIFEST_MISMATCH,
+    FAIL_TOKEN_MANIFEST_MISSING,
+    FAIL_TOKEN_SYNTACTIC_REJECT,
+    ResolvedModulePath,
+    _find_manifest_for_foundup_id,
+    _MANIFEST_SEARCH_GLOBS,
+    _resolve_validated_module_path,
+    _stringify_ignored,
 )
 
 logger = logging.getLogger("hermes_foundup_job_executor")
@@ -72,76 +77,12 @@ SUPPORTED_ACTIONS = frozenset({
 })
 
 
-# ---------------------------------------------------------------------------
-# Module-path resolution constants (HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1)
-# ---------------------------------------------------------------------------
-
-# Default repository root for manifest lookup. Derived from this source file's
-# location so the executor does not depend on a CWD or env var.
-# modules/foundups/agent/src/hermes_foundup_job_executor.py -> parents[4] = repo root
-DEFAULT_REPO_ROOT: Path = Path(__file__).resolve().parents[4]
-
-# Bounded glob set for foundup_id -> manifest lookup when the job payload
-# omits module_path / source_module entirely. Mirrors the canonical
-# manifest directory set surveyed in Phase 0 (8 manifests on disk today;
-# this slice's lookup walks at most these globs and never recurses).
-_MANIFEST_SEARCH_GLOBS: Tuple[str, ...] = (
-    "modules/foundups/*/foundup_manifest.json",
-    "modules/gamification/*/foundup_manifest.json",
-    "modules/platform_integration/*/foundup_manifest.json",
-    "modules/communication/*/foundup_manifest.json",
-    "modules/ai_intelligence/*/foundup_manifest.json",
-    "modules/infrastructure/*/foundup_manifest.json",
-)
-
-# Greppable failure-mode tokens emitted on resolution failure. The
-# StatusReasonCode stays frozen at FAIL_VALIDATION_ERROR per the dispatch
-# (no job-contract schema change); granularity comes from this prefix on
-# reason_human + a parallel evidence_refs entry. This lets W10 and future
-# audits distinguish failure classes by greppable string match instead of
-# prose parsing.
-FAIL_TOKEN_SYNTACTIC_REJECT: str = "syntactic_reject"
-FAIL_TOKEN_MANIFEST_MISMATCH: str = "manifest_mismatch"
-FAIL_TOKEN_MANIFEST_MISSING: str = "manifest_missing"
-FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH: str = "cross_foundup_mismatch"
-
-ALL_FAIL_TOKENS: frozenset = frozenset({
-    FAIL_TOKEN_SYNTACTIC_REJECT,
-    FAIL_TOKEN_MANIFEST_MISMATCH,
-    FAIL_TOKEN_MANIFEST_MISSING,
-    FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH,
-})
-
-
-@dataclass(frozen=True)
-class ResolvedModulePath:
-    """Outcome of validated module-path resolution.
-
-    Observable-ignore shape mirroring
-    ``modules/foundups/agent/src/source_authority.py:resolve_source_authority``:
-    the consumer can inspect ``ignored`` to see exactly what the caller
-    tried to declare, even on success. Silent swallow is refused per the
-    #777 convention.
-
-    Attributes:
-        effective: canonical module_path from the validated manifest (the
-            source of truth). ``None`` iff ``failed`` is True.
-        ignored: the payload-declared candidate, stringified, or ``None``
-            if and only if the caller supplied no candidate (neither
-            ``payload.module_path`` nor ``payload.source_module``).
-            Visible even on success; this is the observable-ignore
-            channel.
-        failed: True iff resolution failed.
-        fail_token: one of ``ALL_FAIL_TOKENS`` on failure, else ``None``.
-        fail_human: human-readable explanation prefixed with the
-            ``fail_token`` for grep-ability; empty on success.
-    """
-
-    effective: Optional[str]
-    ignored: Optional[str]
-    failed: bool
-    fail_token: Optional[str]
-    fail_human: str
+# NOTE: DEFAULT_REPO_ROOT, _MANIFEST_SEARCH_GLOBS, the four FAIL_TOKEN_*
+# constants, ALL_FAIL_TOKENS, and the ResolvedModulePath dataclass are now
+# defined in modules/foundups/agent/src/module_path_resolution.py and
+# re-exported by the import block above (Addendum-C behavior-preserving
+# extraction). External imports of these names from this executor module
+# continue to work unchanged.
 
 
 class HermesJobExecutionResult:
@@ -320,266 +261,16 @@ def execute_foundup_job(
     return HermesJobExecutionResult(job=job, hermes_result=hermes_result)
 
 
-def _stringify_ignored(declared: Any) -> Optional[str]:
-    """Mirror of ``source_authority.py``'s ignored-value stringification.
-
-    Returns ``None`` if and only if ``declared`` is ``None``; otherwise
-    ``str(declared)``. The observable-ignore channel uses this so callers
-    can detect a (potentially malicious) declaration attempt regardless
-    of input type.
-    """
-    if declared is None:
-        return None
-    return str(declared)
+# NOTE: _stringify_ignored, _find_manifest_for_foundup_id, and
+# _resolve_validated_module_path are now defined in
+# modules/foundups/agent/src/module_path_resolution.py and re-exported by
+# the import block above (Addendum-C behavior-preserving extraction).
+# External attribute access via `hermes_foundup_job_executor.<name>`
+# continues to resolve to the SAME objects (identity preserved).
+#
+# (Function bodies removed in BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1.)
 
 
-def _find_manifest_for_foundup_id(
-    repo_root: Path, foundup_id: str
-) -> Optional[Path]:
-    """Locate a manifest file whose top-level ``foundup_id`` matches.
-
-    Bounded scan over the 6 canonical manifest directories (Phase 0 found
-    8 manifests today). Returns the first matching path, or ``None``.
-    Used ONLY when the job payload omits both ``module_path`` and
-    ``source_module``; this is the explicit alternative to the removed
-    ``foundup_id``-as-path heuristic.
-
-    The scan reads each candidate JSON only to check its top-level
-    ``foundup_id`` field. No execution. No write.
-    """
-    if not foundup_id:
-        return None
-    for glob in _MANIFEST_SEARCH_GLOBS:
-        for candidate in sorted(repo_root.glob(glob)):
-            try:
-                data = json.loads(candidate.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError):
-                continue
-            if data.get("foundup_id") == foundup_id:
-                return candidate
-    return None
-
-
-def _resolve_validated_module_path(
-    job: FoundUpJob,
-    repo_root: Path,
-) -> ResolvedModulePath:
-    """Resolve a job's ``module_path`` through the #773 validator. Fail-closed.
-
-    Pinned design (HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1):
-
-    - **candidate** = ``payload.module_path`` or, if absent, the alias
-      ``payload.source_module``. Empty string is treated as ABSENT
-      (Addendum D #4).
-    - **foundup_id heuristic REMOVED**: a ``/`` in ``foundup_id`` is
-      no longer a path source. If the candidate is absent, fall through
-      to a bounded foundup_id scan, NEVER to the raw ``foundup_id``
-      string.
-    - **syntactic hardening BEFORE any manifest contact**: the candidate
-      is canonicalized via the validator's ``_canonicalize_module_path``
-      helper. Empty / absolute / UNC / ``..`` traversal / backslash
-      forms (and anything not under ``modules/``) are REJECTED with
-      ``FAIL_TOKEN_SYNTACTIC_REJECT``.
-    - **manifest location**: when the candidate resolves syntactically,
-      the manifest is ``<repo_root>/<canonical>/foundup_manifest.json``.
-      When the candidate is absent, the manifest is the first hit of the
-      bounded foundup_id scan.
-    - **validator gate**: ``validate_manifest_file`` (#773) is consumed
-      as-is. It never raises; ``ok=False`` on missing / unreadable /
-      shape-invalid manifest. Tokenized as ``manifest_missing`` for
-      I/O-class errors, ``manifest_mismatch`` otherwise.
-    - **cross-FoundUp substitution defense** (Addendum D #1, load-bearing):
-      after validator passes, the manifest's ``foundup_id`` MUST equal
-      ``job.foundup_id``. A job carrying ``foundup_id=A`` with a payload
-      pointing at FoundUp B's real manifest is REJECTED with
-      ``FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH``. The "some valid manifest
-      exists for this path" check is NOT sufficient.
-    - **case-variant defense** (Addendum D #3, Windows host reality):
-      when the candidate was provided, the candidate's canonical form
-      is exact-string-compared (case-sensitive) against the manifest's
-      ``build_contract.module_path`` canonical form. Mismatch =>
-      ``FAIL_TOKEN_MANIFEST_MISMATCH``.
-    - **derivation when candidate absent**: ``effective`` becomes the
-      manifest's canonical ``module_path`` (manifest is the source of
-      truth). The ``foundup_id`` heuristic is never the source.
-    - **observable ignored**: the payload-declared candidate is visible
-      in ``ResolvedModulePath.ignored`` even on success (mirrors #777).
-    """
-    payload = job.payload or {}
-
-    # Step 1: extract candidate; treat empty string as ABSENT.
-    raw_candidate: Any = payload.get("module_path")
-    if isinstance(raw_candidate, str) and not raw_candidate:
-        raw_candidate = None
-    if raw_candidate is None:
-        raw_candidate = payload.get("source_module")
-        if isinstance(raw_candidate, str) and not raw_candidate:
-            raw_candidate = None
-    ignored = _stringify_ignored(raw_candidate)
-
-    canonical: Optional[str] = None
-    manifest_path: Path
-
-    if raw_candidate is not None:
-        # Step 2: syntactic harden BEFORE any manifest contact.
-        #
-        # The validator's ``_canonicalize_module_path`` would itself convert
-        # backslashes to forward slashes ("harmless equivalents"). For the
-        # CONSUMER boundary (Addendum C #5) backslashes must be REJECTED
-        # before any manifest contact -- on a Windows host, accepting them
-        # invites path-name confusion. We do the backslash check here
-        # explicitly so the rejection token is ``syntactic_reject`` and not
-        # the more ambiguous ``manifest_mismatch``.
-        if isinstance(raw_candidate, str) and "\\" in raw_candidate:
-            return ResolvedModulePath(
-                effective=None,
-                ignored=ignored,
-                failed=True,
-                fail_token=FAIL_TOKEN_SYNTACTIC_REJECT,
-                fail_human=(
-                    f"{FAIL_TOKEN_SYNTACTIC_REJECT}: payload module_path "
-                    f"{raw_candidate!r} contains backslashes; only "
-                    f"POSIX-style forward slashes are accepted"
-                ),
-            )
-        canonical = _validator_canonicalize_module_path(raw_candidate)
-        if canonical is None or not canonical.startswith("modules/"):
-            return ResolvedModulePath(
-                effective=None,
-                ignored=ignored,
-                failed=True,
-                fail_token=FAIL_TOKEN_SYNTACTIC_REJECT,
-                fail_human=(
-                    f"{FAIL_TOKEN_SYNTACTIC_REJECT}: payload module_path "
-                    f"{raw_candidate!r} is empty, absolute, UNC, contains "
-                    f"'..' traversal, or is not under modules/"
-                ),
-            )
-        manifest_path = repo_root / canonical / "foundup_manifest.json"
-    else:
-        # Step 3: derive from validated manifest via bounded foundup_id scan.
-        manifest_path_opt = _find_manifest_for_foundup_id(
-            repo_root, job.foundup_id or ""
-        )
-        if manifest_path_opt is None:
-            return ResolvedModulePath(
-                effective=None,
-                ignored=ignored,
-                failed=True,
-                fail_token=FAIL_TOKEN_MANIFEST_MISSING,
-                fail_human=(
-                    f"{FAIL_TOKEN_MANIFEST_MISSING}: no payload module_path; "
-                    f"bounded scan for foundup_id={job.foundup_id!r} returned "
-                    f"no manifest"
-                ),
-            )
-        manifest_path = manifest_path_opt
-
-    # Step 4: validate via #773 (never raises). Pass the manifest path as a
-    # string -- the validator's public signature accepts ``str | PurePosixPath``
-    # and normalizes internally; passing the OS ``Path`` directly satisfies
-    # the runtime contract but tickles the static-type checker, which is why
-    # we stringify here.
-    result = validate_manifest_file(str(manifest_path))
-    if not result.ok:
-        err = result.errors[0] if result.errors else "validation failed"
-        # I/O-class errors -> manifest_missing; shape errors -> manifest_mismatch.
-        if (
-            "not found" in err
-            or "unreadable" in err
-            or "not valid JSON" in err
-        ):
-            token = FAIL_TOKEN_MANIFEST_MISSING
-        else:
-            token = FAIL_TOKEN_MANIFEST_MISMATCH
-        return ResolvedModulePath(
-            effective=None,
-            ignored=ignored,
-            failed=True,
-            fail_token=token,
-            fail_human=f"{token}: {err}",
-        )
-
-    # Step 5: re-read the validated manifest to extract foundup_id and
-    # module_path for the two final cross-checks. The validator confirmed
-    # the manifest is well-formed and that its declared module_path matches
-    # the manifest file's parent directory; we now confirm the foundup_id
-    # binding and (when applicable) the candidate's case-sensitive match.
-    try:
-        manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        return ResolvedModulePath(
-            effective=None,
-            ignored=ignored,
-            failed=True,
-            fail_token=FAIL_TOKEN_MANIFEST_MISSING,
-            fail_human=(
-                f"{FAIL_TOKEN_MANIFEST_MISSING}: re-read failed: "
-                f"{type(exc).__name__}"
-            ),
-        )
-    manifest_foundup_id = manifest_data.get("foundup_id")
-    manifest_module_path = manifest_data.get("build_contract", {}).get(
-        "module_path", ""
-    )
-    canonical_manifest_module = _validator_canonicalize_module_path(
-        manifest_module_path
-    )
-
-    if canonical_manifest_module is None:
-        return ResolvedModulePath(
-            effective=None,
-            ignored=ignored,
-            failed=True,
-            fail_token=FAIL_TOKEN_MANIFEST_MISMATCH,
-            fail_human=(
-                f"{FAIL_TOKEN_MANIFEST_MISMATCH}: manifest at {manifest_path} "
-                f"has un-canonicalizable build_contract.module_path="
-                f"{manifest_module_path!r}"
-            ),
-        )
-
-    # Step 6: cross-FoundUp substitution defense (Addendum D #1).
-    if manifest_foundup_id != job.foundup_id:
-        return ResolvedModulePath(
-            effective=None,
-            ignored=ignored,
-            failed=True,
-            fail_token=FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH,
-            fail_human=(
-                f"{FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH}: job.foundup_id="
-                f"{job.foundup_id!r} but the manifest at {manifest_path} "
-                f"declares foundup_id={manifest_foundup_id!r}"
-            ),
-        )
-
-    # Step 7: when candidate provided, exact-string compare candidate canonical
-    # vs manifest canonical (#773 exact-match at consumer boundary; Addendum
-    # D #3 case-variant defense). When candidate was absent, derivation is
-    # already from the validated manifest and this check is a no-op.
-    if raw_candidate is not None and canonical != canonical_manifest_module:
-        return ResolvedModulePath(
-            effective=None,
-            ignored=ignored,
-            failed=True,
-            fail_token=FAIL_TOKEN_MANIFEST_MISMATCH,
-            fail_human=(
-                f"{FAIL_TOKEN_MANIFEST_MISMATCH}: payload candidate canonical "
-                f"{canonical!r} != manifest module_path "
-                f"{canonical_manifest_module!r}"
-            ),
-        )
-
-    # Success: effective is the manifest's canonical module_path (the source
-    # of truth). The payload-declared value is preserved in ``ignored`` for
-    # observability even when it matches.
-    return ResolvedModulePath(
-        effective=canonical_manifest_module,
-        ignored=ignored,
-        failed=False,
-        fail_token=None,
-        fail_human="",
-    )
 
 
 def _dispatch_action(

--- a/modules/foundups/agent/src/module_path_resolution.py
+++ b/modules/foundups/agent/src/module_path_resolution.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Shared Module-Path Resolution -- Validated FoundUpJob module_path Resolver.
+
+Single-source-of-truth for the module-path trust rule. Lives independently of
+both ``hermes_foundup_job_executor.py`` and ``build_plan_generator.py``; both
+files import from here so the trust rule has exactly ONE implementation.
+
+History (load-bearing precedent):
+
+  - #774 audit identified payload.module_path trust at
+    hermes_foundup_job_executor.py:217-237 as the consumer-wiring blocker.
+  - #778 (HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1) closed the executor
+    seam with this resolver, originally living in the executor file.
+  - This module (BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1)
+    is the Addendum-C behavior-preserving extraction. The executor now
+    re-exports every name as a back-compat shim so its tests pass with
+    ZERO edits; build_plan_generator imports from here directly.
+  - WSP_97 verifies "exactly one implementation" via
+    NO_SECOND_MODULE_PATH_RESOLVER (an AST scan in the shared-resolver
+    test file).
+
+WSP 97 TRUTH BOUNDARIES:
+
+  - This module EXECUTES NOTHING. It reads JSON via ``Path.read_text``
+    and calls the #773 validator (which is itself execution-free).
+  - No subprocess, no Popen, no os.system, no eval, no exec, no
+    importlib dynamic loading, no network, no file write.
+  - No runtime executor / consumer imports. No CABR / payout / DAO.
+  - The #771/#773 ``foundup_manifest_validator`` is the source of truth
+    for canonical module_path exact-match. We import its public API
+    plus one underscore-helper (``_canonicalize_module_path``) and do
+    NOT mutate its public surface.
+
+Public API:
+
+  - ``ResolvedModulePath`` (frozen dataclass)
+  - ``DEFAULT_REPO_ROOT`` (Path)
+  - ``_MANIFEST_SEARCH_GLOBS`` (Tuple[str, ...])
+  - ``FAIL_TOKEN_SYNTACTIC_REJECT`` / ``..._MANIFEST_MISMATCH`` /
+    ``..._MANIFEST_MISSING`` / ``..._CROSS_FOUNDUP_MISMATCH`` (str)
+  - ``ALL_FAIL_TOKENS`` (frozenset)
+  - ``_resolve_validated_module_path(job, repo_root)`` -> ``ResolvedModulePath``
+  - ``_find_manifest_for_foundup_id(repo_root, foundup_id)`` -> ``Optional[Path]``
+  - ``_stringify_ignored(declared)`` -> ``Optional[str]``
+
+NAVIGATION:
+
+  -> Consumed by: hermes_foundup_job_executor.py (shim; re-exports here)
+  -> Consumed by: build_plan_generator.py (direct import)
+  -> Validates via: foundup_manifest_validator.validate_manifest_file (#773)
+  -> Tested by: tests/test_module_path_resolution.py (#778 test file still
+                exercises the same surface via the executor shim)
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional, Tuple
+
+from modules.communication.moltbot_bridge.src.foundup_job_contract import (
+    FoundUpJob,
+)
+from modules.foundups.agent.src.foundup_manifest_validator import (
+    validate_manifest_file,
+)
+from modules.foundups.agent.src.foundup_manifest_validator import (
+    _canonicalize_module_path as _validator_canonicalize_module_path,
+)
+
+__all__ = [
+    "ResolvedModulePath",
+    "DEFAULT_REPO_ROOT",
+    "FAIL_TOKEN_SYNTACTIC_REJECT",
+    "FAIL_TOKEN_MANIFEST_MISMATCH",
+    "FAIL_TOKEN_MANIFEST_MISSING",
+    "FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH",
+    "ALL_FAIL_TOKENS",
+]
+
+
+# Default repository root for manifest lookup. Derived from this source file's
+# location so the resolver does not depend on a CWD or env var.
+# modules/foundups/agent/src/module_path_resolution.py -> parents[4] = repo root
+# (identical depth to hermes_foundup_job_executor.py so the constant remains
+# byte-equal to the #778 origin per Addendum-C extraction equivalence.)
+DEFAULT_REPO_ROOT: Path = Path(__file__).resolve().parents[4]
+
+# Bounded glob set for foundup_id -> manifest lookup when the job payload
+# omits module_path / source_module entirely. Mirrors the canonical
+# manifest directory set surveyed in Phase 0 (8 manifests on disk today;
+# this resolver's lookup walks at most these globs and never recurses).
+_MANIFEST_SEARCH_GLOBS: Tuple[str, ...] = (
+    "modules/foundups/*/foundup_manifest.json",
+    "modules/gamification/*/foundup_manifest.json",
+    "modules/platform_integration/*/foundup_manifest.json",
+    "modules/communication/*/foundup_manifest.json",
+    "modules/ai_intelligence/*/foundup_manifest.json",
+    "modules/infrastructure/*/foundup_manifest.json",
+)
+
+# Greppable failure-mode tokens emitted on resolution failure. The
+# StatusReasonCode (executor side) stays frozen at FAIL_VALIDATION_ERROR;
+# the build_plan_generator side maps these into GenerationValidationResult
+# error_code. Granularity comes from this token prefix on reason_human +
+# a parallel evidence_refs entry. This lets W10 and future audits
+# distinguish failure classes by greppable string match instead of prose
+# parsing.
+FAIL_TOKEN_SYNTACTIC_REJECT: str = "syntactic_reject"
+FAIL_TOKEN_MANIFEST_MISMATCH: str = "manifest_mismatch"
+FAIL_TOKEN_MANIFEST_MISSING: str = "manifest_missing"
+FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH: str = "cross_foundup_mismatch"
+
+ALL_FAIL_TOKENS: frozenset = frozenset({
+    FAIL_TOKEN_SYNTACTIC_REJECT,
+    FAIL_TOKEN_MANIFEST_MISMATCH,
+    FAIL_TOKEN_MANIFEST_MISSING,
+    FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH,
+})
+
+
+@dataclass(frozen=True)
+class ResolvedModulePath:
+    """Outcome of validated module-path resolution.
+
+    Observable-ignore shape mirroring
+    ``modules/foundups/agent/src/source_authority.py:resolve_source_authority``:
+    the consumer can inspect ``ignored`` to see exactly what the caller
+    tried to declare, even on success. Silent swallow is refused per the
+    #777 convention.
+
+    Attributes:
+        effective: canonical module_path from the validated manifest (the
+            source of truth). ``None`` iff ``failed`` is True.
+        ignored: the payload-declared candidate, stringified, or ``None``
+            if and only if the caller supplied no candidate (neither
+            ``payload.module_path`` nor ``payload.source_module``).
+            Visible even on success; this is the observable-ignore
+            channel.
+        failed: True iff resolution failed.
+        fail_token: one of ``ALL_FAIL_TOKENS`` on failure, else ``None``.
+        fail_human: human-readable explanation prefixed with the
+            ``fail_token`` for grep-ability; empty on success.
+    """
+
+    effective: Optional[str]
+    ignored: Optional[str]
+    failed: bool
+    fail_token: Optional[str]
+    fail_human: str
+
+
+def _stringify_ignored(declared: Any) -> Optional[str]:
+    """Mirror of ``source_authority.py``'s ignored-value stringification.
+
+    Returns ``None`` if and only if ``declared`` is ``None``; otherwise
+    ``str(declared)``. The observable-ignore channel uses this so callers
+    can detect a (potentially malicious) declaration attempt regardless
+    of input type.
+    """
+    if declared is None:
+        return None
+    return str(declared)
+
+
+def _find_manifest_for_foundup_id(
+    repo_root: Path, foundup_id: str
+) -> Optional[Path]:
+    """Locate a manifest file whose top-level ``foundup_id`` matches.
+
+    Bounded scan over the 6 canonical manifest directories (Phase 0 found
+    8 manifests today). Returns the first matching path, or ``None``.
+    Used ONLY when the job payload omits both ``module_path`` and
+    ``source_module``; this is the explicit alternative to the removed
+    ``foundup_id``-as-path heuristic.
+
+    The scan reads each candidate JSON only to check its top-level
+    ``foundup_id`` field. No execution. No write.
+    """
+    if not foundup_id:
+        return None
+    for glob in _MANIFEST_SEARCH_GLOBS:
+        for candidate in sorted(repo_root.glob(glob)):
+            try:
+                data = json.loads(candidate.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if data.get("foundup_id") == foundup_id:
+                return candidate
+    return None
+
+
+def _resolve_validated_module_path(
+    job: FoundUpJob,
+    repo_root: Path,
+) -> ResolvedModulePath:
+    """Resolve a job's ``module_path`` through the #773 validator. Fail-closed.
+
+    Pinned design (HERMES_MODULE_PATH_TRUST_REMOVAL_PHASE1):
+
+    - **candidate** = ``payload.module_path`` or, if absent, the alias
+      ``payload.source_module``. Empty string is treated as ABSENT
+      (Addendum D #4).
+    - **foundup_id heuristic REMOVED**: a ``/`` in ``foundup_id`` is
+      no longer a path source. If the candidate is absent, fall through
+      to a bounded foundup_id scan, NEVER to the raw ``foundup_id``
+      string.
+    - **syntactic hardening BEFORE any manifest contact**: the candidate
+      is canonicalized via the validator's ``_canonicalize_module_path``
+      helper. Empty / absolute / UNC / ``..`` traversal / backslash
+      forms (and anything not under ``modules/``) are REJECTED with
+      ``FAIL_TOKEN_SYNTACTIC_REJECT``.
+    - **manifest location**: when the candidate resolves syntactically,
+      the manifest is ``<repo_root>/<canonical>/foundup_manifest.json``.
+      When the candidate is absent, the manifest is the first hit of the
+      bounded foundup_id scan.
+    - **validator gate**: ``validate_manifest_file`` (#773) is consumed
+      as-is. It never raises; ``ok=False`` on missing / unreadable /
+      shape-invalid manifest. Tokenized as ``manifest_missing`` for
+      I/O-class errors, ``manifest_mismatch`` otherwise.
+    - **cross-FoundUp substitution defense** (Addendum D #1, load-bearing):
+      after validator passes, the manifest's ``foundup_id`` MUST equal
+      ``job.foundup_id``. A job carrying ``foundup_id=A`` with a payload
+      pointing at FoundUp B's real manifest is REJECTED with
+      ``FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH``. The "some valid manifest
+      exists for this path" check is NOT sufficient.
+    - **case-variant defense** (Addendum D #3, Windows host reality):
+      when the candidate was provided, the candidate's canonical form
+      is exact-string-compared (case-sensitive) against the manifest's
+      ``build_contract.module_path`` canonical form. Mismatch =>
+      ``FAIL_TOKEN_MANIFEST_MISMATCH``.
+    - **derivation when candidate absent**: ``effective`` becomes the
+      manifest's canonical ``module_path`` (manifest is the source of
+      truth). The ``foundup_id`` heuristic is never the source.
+    - **observable ignored**: the payload-declared candidate is visible
+      in ``ResolvedModulePath.ignored`` even on success (mirrors #777).
+    """
+    payload = job.payload or {}
+
+    # Step 1: extract candidate; treat empty string as ABSENT.
+    raw_candidate: Any = payload.get("module_path")
+    if isinstance(raw_candidate, str) and not raw_candidate:
+        raw_candidate = None
+    if raw_candidate is None:
+        raw_candidate = payload.get("source_module")
+        if isinstance(raw_candidate, str) and not raw_candidate:
+            raw_candidate = None
+    ignored = _stringify_ignored(raw_candidate)
+
+    canonical: Optional[str] = None
+    manifest_path: Path
+
+    if raw_candidate is not None:
+        # Step 2: syntactic harden BEFORE any manifest contact.
+        #
+        # The validator's ``_canonicalize_module_path`` would itself convert
+        # backslashes to forward slashes ("harmless equivalents"). For the
+        # CONSUMER boundary (Addendum C #5) backslashes must be REJECTED
+        # before any manifest contact -- on a Windows host, accepting them
+        # invites path-name confusion. We do the backslash check here
+        # explicitly so the rejection token is ``syntactic_reject`` and not
+        # the more ambiguous ``manifest_mismatch``.
+        if isinstance(raw_candidate, str) and "\\" in raw_candidate:
+            return ResolvedModulePath(
+                effective=None,
+                ignored=ignored,
+                failed=True,
+                fail_token=FAIL_TOKEN_SYNTACTIC_REJECT,
+                fail_human=(
+                    f"{FAIL_TOKEN_SYNTACTIC_REJECT}: payload module_path "
+                    f"{raw_candidate!r} contains backslashes; only "
+                    f"POSIX-style forward slashes are accepted"
+                ),
+            )
+        canonical = _validator_canonicalize_module_path(raw_candidate)
+        if canonical is None or not canonical.startswith("modules/"):
+            return ResolvedModulePath(
+                effective=None,
+                ignored=ignored,
+                failed=True,
+                fail_token=FAIL_TOKEN_SYNTACTIC_REJECT,
+                fail_human=(
+                    f"{FAIL_TOKEN_SYNTACTIC_REJECT}: payload module_path "
+                    f"{raw_candidate!r} is empty, absolute, UNC, contains "
+                    f"'..' traversal, or is not under modules/"
+                ),
+            )
+        manifest_path = repo_root / canonical / "foundup_manifest.json"
+    else:
+        # Step 3: derive from validated manifest via bounded foundup_id scan.
+        manifest_path_opt = _find_manifest_for_foundup_id(
+            repo_root, job.foundup_id or ""
+        )
+        if manifest_path_opt is None:
+            return ResolvedModulePath(
+                effective=None,
+                ignored=ignored,
+                failed=True,
+                fail_token=FAIL_TOKEN_MANIFEST_MISSING,
+                fail_human=(
+                    f"{FAIL_TOKEN_MANIFEST_MISSING}: no payload module_path; "
+                    f"bounded scan for foundup_id={job.foundup_id!r} returned "
+                    f"no manifest"
+                ),
+            )
+        manifest_path = manifest_path_opt
+
+    # Step 4: validate via #773 (never raises). Pass the manifest path as a
+    # string -- the validator's public signature accepts ``str | PurePosixPath``
+    # and normalizes internally; passing the OS ``Path`` directly satisfies
+    # the runtime contract but tickles the static-type checker, which is why
+    # we stringify here.
+    result = validate_manifest_file(str(manifest_path))
+    if not result.ok:
+        err = result.errors[0] if result.errors else "validation failed"
+        # I/O-class errors -> manifest_missing; shape errors -> manifest_mismatch.
+        if (
+            "not found" in err
+            or "unreadable" in err
+            or "not valid JSON" in err
+        ):
+            token = FAIL_TOKEN_MANIFEST_MISSING
+        else:
+            token = FAIL_TOKEN_MANIFEST_MISMATCH
+        return ResolvedModulePath(
+            effective=None,
+            ignored=ignored,
+            failed=True,
+            fail_token=token,
+            fail_human=f"{token}: {err}",
+        )
+
+    # Step 5: re-read the validated manifest to extract foundup_id and
+    # module_path for the two final cross-checks. The validator confirmed
+    # the manifest is well-formed and that its declared module_path matches
+    # the manifest file's parent directory; we now confirm the foundup_id
+    # binding and (when applicable) the candidate's case-sensitive match.
+    try:
+        manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return ResolvedModulePath(
+            effective=None,
+            ignored=ignored,
+            failed=True,
+            fail_token=FAIL_TOKEN_MANIFEST_MISSING,
+            fail_human=(
+                f"{FAIL_TOKEN_MANIFEST_MISSING}: re-read failed: "
+                f"{type(exc).__name__}"
+            ),
+        )
+    manifest_foundup_id = manifest_data.get("foundup_id")
+    manifest_module_path = manifest_data.get("build_contract", {}).get(
+        "module_path", ""
+    )
+    canonical_manifest_module = _validator_canonicalize_module_path(
+        manifest_module_path
+    )
+
+    if canonical_manifest_module is None:
+        return ResolvedModulePath(
+            effective=None,
+            ignored=ignored,
+            failed=True,
+            fail_token=FAIL_TOKEN_MANIFEST_MISMATCH,
+            fail_human=(
+                f"{FAIL_TOKEN_MANIFEST_MISMATCH}: manifest at {manifest_path} "
+                f"has un-canonicalizable build_contract.module_path="
+                f"{manifest_module_path!r}"
+            ),
+        )
+
+    # Step 6: cross-FoundUp substitution defense (Addendum D #1).
+    if manifest_foundup_id != job.foundup_id:
+        return ResolvedModulePath(
+            effective=None,
+            ignored=ignored,
+            failed=True,
+            fail_token=FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH,
+            fail_human=(
+                f"{FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH}: job.foundup_id="
+                f"{job.foundup_id!r} but the manifest at {manifest_path} "
+                f"declares foundup_id={manifest_foundup_id!r}"
+            ),
+        )
+
+    # Step 7: when candidate provided, exact-string compare candidate canonical
+    # vs manifest canonical (#773 exact-match at consumer boundary; Addendum
+    # D #3 case-variant defense). When candidate was absent, derivation is
+    # already from the validated manifest and this check is a no-op.
+    if raw_candidate is not None and canonical != canonical_manifest_module:
+        return ResolvedModulePath(
+            effective=None,
+            ignored=ignored,
+            failed=True,
+            fail_token=FAIL_TOKEN_MANIFEST_MISMATCH,
+            fail_human=(
+                f"{FAIL_TOKEN_MANIFEST_MISMATCH}: payload candidate canonical "
+                f"{canonical!r} != manifest module_path "
+                f"{canonical_manifest_module!r}"
+            ),
+        )
+
+    # Success: effective is the manifest's canonical module_path (the source
+    # of truth). The payload-declared value is preserved in ``ignored`` for
+    # observability even when it matches.
+    return ResolvedModulePath(
+        effective=canonical_manifest_module,
+        ignored=ignored,
+        failed=False,
+        fail_token=None,
+        fail_human="",
+    )

--- a/modules/foundups/agent/tests/TestModLog.md
+++ b/modules/foundups/agent/tests/TestModLog.md
@@ -1,5 +1,109 @@
 # Agent Module TestModLog
 
+## 2026-06-11 - BuildPlan Generator Module-Path Trust Removal Phase 1 Tests
+
+**Command**:
+
+```bash
+python -m pytest modules/foundups/agent/tests/test_build_plan_generator.py -q
+python -m pytest modules/foundups/agent/tests/test_hermes_foundup_job_executor.py -q
+python -m pytest modules/foundups/agent/tests/ -q
+```
+
+**Result**: PASS
+
+**Summary**:
+- Generator test file: **71 passed in 0.97s** (44 prior + 27 new).
+- Executor test file (#778 file, **ZERO edits**): **46 passed in 0.83s** --
+  Addendum C #3 satisfied.
+- Full agent-module suite: **646 passed in 8.99s**; 0 skipped; 0 xfailed.
+
+**Slice**: BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1
+
+**Updated assertions** (flagged per dispatch "Update stale legacy
+assertions ... flag each in TestModLog"):
+
+- DELETED `TestModulePathInference::test_known_foundup_paths_include_voteballots`
+  (line 489-492 in pre-slice file). The symbol `KNOWN_FOUNDUP_PATHS`
+  is deleted; the assertion is moot.
+- DELETED `TestModulePathInference::test_get_known_foundup_path_returns_voteballots`
+  (line 494-497 in pre-slice file). The function
+  `get_known_foundup_path` is deleted.
+- UPDATED `TestModulePathInference::test_infer_module_path_for_voteballots`
+  docstring to record the bounded foundup_id scan as the new
+  derivation path. Now also asserts `rejected_payload_value is None`
+  (observable-ignore on the absent-payload branch).
+- UPDATED `TestModulePathInference::test_unknown_foundup_without_module_path_fails`
+  expected `error_code` from `"MISSING_MODULE_PATH"` to
+  `"manifest_missing"` (legacy MISSING_MODULE_PATH branch deleted
+  along with the KNOWN_FOUNDUP_PATHS error-message interpolation).
+- UPDATED `TestOutsideScopeRejected::test_infrastructure_path_rejected`
+  expected `error_code` from `"INVALID_MODULE_PATH"` to
+  `"manifest_missing"`. Path is under `modules/` but no on-disk
+  manifest -> resolver rejects with manifest_missing.
+- UPDATED `TestOutsideScopeRejected::test_root_path_rejected` expected
+  `error_code` from `"INVALID_MODULE_PATH"` to `"syntactic_reject"`.
+  `/etc/passwd` is an absolute path; the resolver rejects pre-manifest
+  at the syntactic-harden step.
+- UPDATED `TestOutsideScopeRejected::test_ai_intelligence_path_rejected`
+  expected `error_code` from `"INVALID_MODULE_PATH"` to
+  `"manifest_missing"`.
+
+**Added** (in `test_build_plan_generator.py`):
+
+- `TestSharedResolverValidationInGenerator` (the 14 dispatch-required
+  tests + happy-path controls). Mapping to the dispatch's 14-test
+  contract:
+  1. `test_payload_path_with_no_backing_manifest_rejected`
+  2. `test_source_module_alias_with_wrong_path_rejected`,
+     `test_source_module_alias_happy_path`
+  3. `test_cross_foundup_substitution_rejected`
+  4. `test_suffix_basename_partial_match_rejected`
+  5. `test_case_variant_payload_rejected`,
+     `test_uppercase_modules_prefix_rejected`
+  6. `test_absolute_path_rejected_pre_manifest`,
+     `test_drive_prefix_path_rejected_pre_manifest`,
+     `test_traversal_rejected_pre_manifest`,
+     `test_backslash_rejected_pre_manifest`
+  7. `test_empty_string_payload_treated_as_absent`
+  8. `test_known_foundup_id_without_on_disk_manifest_fails_closed`
+     (parametrized over `pqn_portal`, `social_twin`, `move2japan`),
+     `test_known_foundup_paths_symbol_is_gone`
+  9. `test_foundup_id_synthesis_dead_no_modules_foundups_fallback`,
+     `test_build_target_does_not_use_synthesized_path`
+  10. `test_pwa_surface_path_as_module_identity_rejected`
+  11. `test_rejected_value_observable_on_failure`,
+      `test_rejected_value_observable_on_success`
+  12. `TestHermes778TestsUnchanged::test_executor_test_imports_still_resolve`,
+      `..._executor_attribute_access_pattern_still_works`
+  13. Full agent suite green (646 / 0 / 0).
+  14. `test_rejected_payload_value_does_not_propagate_into_buildtarget`,
+      `test_buildplan_carries_only_canonical_when_payload_provided`
+- `TestSharedResolverIsSingleSourceOfTruth` (Addendum C #4 -- prove
+  exactly ONE implementation):
+  - `test_executor_shim_and_shared_module_resolve_same_function` --
+    `is` identity check on every moved name.
+  - `test_generator_uses_same_resolver_as_executor` -- `is` identity
+    between generator and executor references.
+  - `test_no_second_resolver_implementation_in_executor` -- AST scan
+    on executor file asserts no local definition of the moved names.
+  - `test_no_second_resolver_in_build_plan_generator` -- symmetric AST
+    scan on generator file; also asserts `KNOWN_FOUNDUP_PATHS`
+    assignment is gone.
+- `TestHermes778TestsUnchanged` -- meta-test that the #778 test file's
+  import patterns still resolve through the shim (Addendum C #3).
+
+**Boundary preserved**:
+
+- The #778 executor test file (`test_hermes_foundup_job_executor.py`)
+  has ZERO edits. Verified via `pytest -q` returning `46 passed`
+  unchanged from the #778 baseline.
+- AST scans reject any second resolver implementation in either the
+  executor or the generator.
+- No skip / no xfail on any security assertion.
+
+---
+
 ## 2026-06-10 - Hermes Module-Path Trust Removal Phase 1 Tests
 
 **Command**:

--- a/modules/foundups/agent/tests/test_build_plan_generator.py
+++ b/modules/foundups/agent/tests/test_build_plan_generator.py
@@ -32,6 +32,8 @@ NAVIGATION:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from modules.communication.moltbot_bridge.src.foundup_job_contract import (
@@ -53,12 +55,10 @@ from modules.foundups.agent.src.build_plan import (
 from modules.foundups.agent.src.build_plan_generator import (
     BUILDPLAN_SUPPORTED_ACTIONS,
     BUILDPLAN_UNSUPPORTED_ACTIONS,
-    KNOWN_FOUNDUP_PATHS,
     build_target_from_job,
     can_generate_build_plan,
     create_build_plan_from_job,
     get_generation_error,
-    get_known_foundup_path,
     infer_build_scope,
     validate_job_for_build_plan,
 )
@@ -484,31 +484,35 @@ class TestMissingFoundupIdFails:
 
 
 class TestModulePathInference:
-    """Test module_path inference from foundup_id."""
+    """Module-path derivation when payload omits module_path.
 
-    def test_known_foundup_paths_include_voteballots(self) -> None:
-        """KNOWN_FOUNDUP_PATHS includes voteballots."""
-        assert "voteballots" in KNOWN_FOUNDUP_PATHS
-        assert KNOWN_FOUNDUP_PATHS["voteballots"] == "modules/foundups/voteballots"
-
-    def test_get_known_foundup_path_returns_voteballots(self) -> None:
-        """get_known_foundup_path returns VoteBallots path."""
-        path = get_known_foundup_path("voteballots")
-        assert path == "modules/foundups/voteballots"
+    UPDATED (BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1, see
+    TestModLog): the prior ``KNOWN_FOUNDUP_PATHS`` / ``get_known_foundup_path``
+    inference helpers are DELETED. Module-path derivation now flows
+    exclusively through the shared resolver's bounded foundup_id scan,
+    which reads on-disk manifests rather than a hard-coded dict.
+    """
 
     def test_infer_module_path_for_voteballots(
         self, voteballot_job_no_module_path: FoundUpJob
     ) -> None:
-        """Can infer module_path for VoteBallots."""
+        """Payload omits module_path; resolver locates the real
+        ``modules/foundups/voteballots/foundup_manifest.json`` via the
+        bounded foundup_id scan and derives the canonical path."""
         result = validate_job_for_build_plan(voteballot_job_no_module_path)
 
         assert result.valid is True
         assert result.inferred_module_path == "modules/foundups/voteballots"
+        # No payload candidate was supplied; observable-ignore stays None.
+        assert result.rejected_payload_value is None
 
     def test_generate_plan_with_inferred_path(
         self, voteballot_job_no_module_path: FoundUpJob
     ) -> None:
-        """Can generate plan with inferred module_path."""
+        """Generated BuildPlan's target carries the manifest-derived
+        canonical module_path (NOT a synthesized
+        ``modules/foundups/{foundup_id}`` string -- that fallback was
+        deleted in this slice)."""
         plan = create_build_plan_from_job(voteballot_job_no_module_path)
 
         assert plan.target.module_path == "modules/foundups/voteballots"
@@ -516,11 +520,14 @@ class TestModulePathInference:
     def test_unknown_foundup_without_module_path_fails(
         self, unknown_foundup_job: FoundUpJob
     ) -> None:
-        """Unknown FoundUp without module_path fails."""
+        """Unknown FoundUp + no payload candidate -> bounded foundup_id
+        scan misses -> ``manifest_missing`` (NOT ``MISSING_MODULE_PATH``
+        which was the legacy error_code for the dead KNOWN_FOUNDUP_PATHS
+        branch)."""
         result = validate_job_for_build_plan(unknown_foundup_job)
 
         assert result.valid is False
-        assert result.error_code == "MISSING_MODULE_PATH"
+        assert result.error_code == "manifest_missing"
         assert "unknown_foundup_xyz" in result.error_message
 
 
@@ -530,10 +537,31 @@ class TestModulePathInference:
 
 
 class TestOutsideScopeRejected:
-    """Test outside-scope module_path is rejected."""
+    """Outside-scope module_path is rejected.
+
+    UPDATED (BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1, see
+    TestModLog): the prior ``_is_valid_foundup_path`` prefix-only gate
+    with case-insensitive ``.lower()`` compare is DELETED. The shared
+    resolver enforces a strict ``startswith("modules/")`` pre-manifest
+    syntactic check; non-``modules/foundups/`` paths still reach the
+    validator and reject with ``manifest_missing`` (no on-disk manifest
+    at that location) or ``manifest_mismatch``. The expected error_code
+    is now one of the closed-set #778 tokens instead of the legacy
+    ``INVALID_MODULE_PATH``.
+    """
+
+    @staticmethod
+    def _resolver_error_codes() -> set:
+        return {
+            "syntactic_reject",
+            "manifest_mismatch",
+            "manifest_missing",
+            "cross_foundup_mismatch",
+        }
 
     def test_infrastructure_path_rejected(self) -> None:
-        """Infrastructure module path is rejected."""
+        """``modules/infrastructure/wre_core`` is under modules/ but has
+        no FoundUp manifest -> ``manifest_missing``."""
         job = create_job(
             tenant_id="012",
             requested_action="build_foundup",
@@ -546,10 +574,12 @@ class TestOutsideScopeRejected:
         result = validate_job_for_build_plan(job)
 
         assert result.valid is False
-        assert result.error_code == "INVALID_MODULE_PATH"
+        assert result.error_code in self._resolver_error_codes()
+        assert result.error_code == "manifest_missing"
 
     def test_root_path_rejected(self) -> None:
-        """Root path is rejected."""
+        """``/etc/passwd`` is rejected at the pre-manifest syntactic-harden
+        step (absolute path -> ``syntactic_reject``)."""
         job = create_job(
             tenant_id="012",
             requested_action="build_foundup",
@@ -562,10 +592,11 @@ class TestOutsideScopeRejected:
         result = validate_job_for_build_plan(job)
 
         assert result.valid is False
-        assert result.error_code == "INVALID_MODULE_PATH"
+        assert result.error_code == "syntactic_reject"
 
     def test_ai_intelligence_path_rejected(self) -> None:
-        """AI intelligence module path is rejected."""
+        """``modules/ai_intelligence/agent_permissions`` is under modules/
+        but has no FoundUp manifest -> ``manifest_missing``."""
         job = create_job(
             tenant_id="012",
             requested_action="build_foundup",
@@ -578,7 +609,8 @@ class TestOutsideScopeRejected:
         result = validate_job_for_build_plan(job)
 
         assert result.valid is False
-        assert result.error_code == "INVALID_MODULE_PATH"
+        assert result.error_code in self._resolver_error_codes()
+        assert result.error_code == "manifest_missing"
 
 
 # ---------------------------------------------------------------------------
@@ -721,6 +753,512 @@ class TestConvenienceFunctions:
         error = get_generation_error(queue_job)
         assert error is not None
         assert "UNSUPPORTED_ACTION" in error
+
+
+# ===========================================================================
+# BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1: validated resolution
+# ===========================================================================
+#
+# The 14-test contract from the dispatch (Addenda C, B, D folded in). Every
+# negative test below would have PASSED under the legacy behavior (raw
+# payload trust + KNOWN_FOUNDUP_PATHS inference + foundup_id synthesis +
+# _is_valid_foundup_path prefix-only gate) and now FAILS.
+#
+# Resolver imports are read via the SHARED module (single source of truth)
+# AND via the executor shim (to verify both surfaces resolve to the same
+# objects per Addendum C #4).
+
+
+class TestSharedResolverValidationInGenerator:
+    """14 dispatch-required tests + Addendum-C extraction equivalence."""
+
+    @staticmethod
+    def _shared_module():
+        from modules.foundups.agent.src import module_path_resolution as m
+        return m
+
+    @staticmethod
+    def _executor_shim():
+        from modules.foundups.agent.src import hermes_foundup_job_executor as e
+        return e
+
+    # ------------------------------------------------------------------
+    # Test 1: payload path valid-looking but != manifest module_path
+    # ------------------------------------------------------------------
+
+    def test_payload_path_with_no_backing_manifest_rejected(self) -> None:
+        """Payload points at a syntactically-fine path with no backing
+        manifest -> ``manifest_missing``; the rejected value is observable
+        in ``rejected_payload_value`` and NEVER reaches the BuildTarget
+        (the validator returns before ``build_target_from_job`` runs)."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            payload={"module_path": "modules/foundups/nope_xyz_nobacking"},
+        )
+        result = validate_job_for_build_plan(job)
+        assert result.valid is False
+        assert result.error_code == "manifest_missing"
+        assert result.rejected_payload_value == "modules/foundups/nope_xyz_nobacking"
+        assert result.inferred_module_path is None
+
+    # ------------------------------------------------------------------
+    # Test 2: source_module alias receives the same validation
+    # ------------------------------------------------------------------
+
+    def test_source_module_alias_with_wrong_path_rejected(self) -> None:
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            payload={"source_module": "modules/foundups/nope_alias_xyz"},
+        )
+        result = validate_job_for_build_plan(job)
+        assert result.valid is False
+        assert result.error_code == "manifest_missing"
+        assert result.rejected_payload_value == "modules/foundups/nope_alias_xyz"
+
+    def test_source_module_alias_happy_path(self) -> None:
+        """The alias receives the same happy-path treatment as
+        ``module_path``."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            payload={"source_module": "modules/foundups/voteballots"},
+        )
+        result = validate_job_for_build_plan(job)
+        assert result.valid is True
+        assert result.inferred_module_path == "modules/foundups/voteballots"
+
+    # ------------------------------------------------------------------
+    # Test 3: cross-FoundUp substitution rejected
+    # ------------------------------------------------------------------
+
+    def test_cross_foundup_substitution_rejected(self) -> None:
+        """``job.foundup_id`` = A, payload points at B's REAL,
+        validator-passing manifest path. The manifest must bind to A;
+        resolving B's manifest and finding A != B is the load-bearing
+        defense from #778 Addendum D #1."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="voteballots",  # A
+            payload={"module_path": "modules/foundups/kosei"},  # B
+        )
+        result = validate_job_for_build_plan(job)
+        assert result.valid is False
+        assert result.error_code == "cross_foundup_mismatch"
+        assert "voteballots" in result.error_message
+        assert "kosei" in result.error_message
+        # The rejected B's path is observable but NEVER used downstream.
+        assert result.rejected_payload_value == "modules/foundups/kosei"
+
+    # ------------------------------------------------------------------
+    # Test 4: suffix / basename partial match rejected
+    # ------------------------------------------------------------------
+
+    def test_suffix_basename_partial_match_rejected(self) -> None:
+        """A bare basename ``voteballots`` that matches the LAST segment of
+        the manifest's module_path is REJECTED at the syntactic-harden
+        step (not under ``modules/``)."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            payload={"module_path": "voteballots"},
+        )
+        result = validate_job_for_build_plan(job)
+        assert result.valid is False
+        assert result.error_code == "syntactic_reject"
+
+    # ------------------------------------------------------------------
+    # Test 5: case-variant payload rejected (kills the .lower() compare)
+    # ------------------------------------------------------------------
+
+    def test_case_variant_payload_rejected(self) -> None:
+        """The legacy ``_is_valid_foundup_path`` did
+        ``path.replace('\\\\', '/').lower()`` -- this is dead. A case-variant
+        payload now rejects via the resolver's case-sensitive exact-match
+        against the manifest canonical."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            payload={"module_path": "modules/Foundups/voteballots"},
+        )
+        result = validate_job_for_build_plan(job)
+        assert result.valid is False
+        # Either syntactic_reject (caught at startswith) or manifest_mismatch
+        # (caught at step 7 exact-string compare). Both are valid rejections.
+        assert result.error_code in (
+            "syntactic_reject", "manifest_mismatch",
+        )
+
+    def test_uppercase_modules_prefix_rejected(self) -> None:
+        """``Modules/`` (uppercase) is rejected at the
+        ``startswith('modules/')`` syntactic guard. This is the test that
+        would have PASSED under the legacy ``.lower()`` compare."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            payload={"module_path": "Modules/foundups/voteballots"},
+        )
+        result = validate_job_for_build_plan(job)
+        assert result.valid is False
+        assert result.error_code == "syntactic_reject"
+
+    # ------------------------------------------------------------------
+    # Test 6: absolute / traversal / backslash rejected pre-manifest
+    # ------------------------------------------------------------------
+
+    def test_absolute_path_rejected_pre_manifest(self) -> None:
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            payload={"module_path": "/modules/foundups/voteballots"},
+        )
+        result = validate_job_for_build_plan(job)
+        assert result.valid is False
+        assert result.error_code == "syntactic_reject"
+
+    def test_drive_prefix_path_rejected_pre_manifest(self) -> None:
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            payload={"module_path": "O:/Foundups-Agent/modules/foundups/voteballots"},
+        )
+        result = validate_job_for_build_plan(job)
+        assert result.valid is False
+        assert result.error_code == "syntactic_reject"
+
+    def test_traversal_rejected_pre_manifest(self) -> None:
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            payload={"module_path": "../modules/foundups/voteballots"},
+        )
+        result = validate_job_for_build_plan(job)
+        assert result.valid is False
+        assert result.error_code == "syntactic_reject"
+
+    def test_backslash_rejected_pre_manifest(self) -> None:
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            payload={"module_path": r"modules\foundups\voteballots"},
+        )
+        result = validate_job_for_build_plan(job)
+        assert result.valid is False
+        assert result.error_code == "syntactic_reject"
+
+    # ------------------------------------------------------------------
+    # Test 7: empty-string payload path == ABSENT
+    # ------------------------------------------------------------------
+
+    def test_empty_string_payload_treated_as_absent(self) -> None:
+        """Empty string is ABSENT (#778 Addendum D #4). With a valid
+        foundup_id the bounded scan finds the real voteballots manifest
+        and derives the canonical path."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            payload={"module_path": ""},
+        )
+        result = validate_job_for_build_plan(job)
+        assert result.valid is True
+        assert result.inferred_module_path == "modules/foundups/voteballots"
+        assert result.rejected_payload_value is None
+
+    # ------------------------------------------------------------------
+    # Test 8: KNOWN_FOUNDUP_PATHS inference dead
+    # ------------------------------------------------------------------
+
+    def test_known_foundup_id_without_on_disk_manifest_fails_closed(self) -> None:
+        """The dispatch's example: a foundup_id that was in the dead
+        KNOWN_FOUNDUP_PATHS dict but does NOT have a real on-disk manifest
+        must now FAIL. ``pqn_portal``, ``social_twin``, ``move2japan`` were
+        all in the dead dict; none has a real manifest on disk."""
+        for legacy_id in ("pqn_portal", "social_twin", "move2japan"):
+            job = create_job(
+                tenant_id="012",
+                requested_action="build_foundup",
+                foundup_id=legacy_id,
+                payload={},
+            )
+            result = validate_job_for_build_plan(job)
+            assert result.valid is False, (
+                f"legacy dead-dict entry {legacy_id!r} unexpectedly resolved"
+            )
+            assert result.error_code == "manifest_missing"
+
+    def test_known_foundup_paths_symbol_is_gone(self) -> None:
+        """The symbol itself is gone. ``import KNOWN_FOUNDUP_PATHS`` raises
+        ImportError; this test fires the import inside the assert so a
+        future re-introduction of the symbol fails the test loudly."""
+        with pytest.raises(ImportError):
+            from modules.foundups.agent.src.build_plan_generator import (
+                KNOWN_FOUNDUP_PATHS,  # type: ignore[attr-defined]  # noqa: F401
+            )
+
+    # ------------------------------------------------------------------
+    # Test 9: foundup_id synthesis dead
+    # ------------------------------------------------------------------
+
+    def test_foundup_id_synthesis_dead_no_modules_foundups_fallback(self) -> None:
+        """The dead ``f"modules/foundups/{job.foundup_id}"`` synthesis at
+        line :282 is gone. A foundup_id that is NOT a real on-disk manifest
+        with payload absent -> fails ``manifest_missing``, NOT a fabricated
+        ``modules/foundups/<id>`` path."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="newly_invented_foundup_no_manifest",
+            payload={},
+        )
+        result = validate_job_for_build_plan(job)
+        assert result.valid is False
+        assert result.error_code == "manifest_missing"
+
+    def test_build_target_does_not_use_synthesized_path(self) -> None:
+        """``build_target_from_job`` raises ValueError instead of returning
+        a BuildTarget with a synthesized ``modules/foundups/<id>`` path.
+        Under legacy behavior the synthesis at :282 would have produced
+        a BuildTarget with module_path = "modules/foundups/synth_xyz" even
+        though no manifest exists at that location."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="synth_xyz_no_manifest",
+            payload={},
+        )
+        with pytest.raises(ValueError, match="manifest_missing"):
+            build_target_from_job(job)
+
+    # ------------------------------------------------------------------
+    # Test 10: public/member/foundups/ via payload as identity rejected
+    # ------------------------------------------------------------------
+
+    def test_pwa_surface_path_as_module_identity_rejected(self) -> None:
+        """The PWA surface
+        (``public/member/foundups/<id>/``) was admitted as module identity
+        by the dead ``_is_valid_foundup_path`` (line 216). The new resolver
+        enforces ``startswith('modules/')`` -- PWA surfaces are rejected
+        at syntactic_reject. (PWA-surface ruling: DERIVED_ONLY; surface
+        paths are derived from manifest module_path basename in
+        ``build_target_from_job``, never from payload.)"""
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            payload={"module_path": "public/member/foundups/voteballots"},
+        )
+        result = validate_job_for_build_plan(job)
+        assert result.valid is False
+        assert result.error_code == "syntactic_reject"
+
+    # ------------------------------------------------------------------
+    # Test 11: rejected/ignored payload value observable, never used
+    # ------------------------------------------------------------------
+
+    def test_rejected_value_observable_on_failure(self) -> None:
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            payload={"module_path": "modules/foundups/observable_test_no_manifest"},
+        )
+        result = validate_job_for_build_plan(job)
+        assert result.valid is False
+        assert result.rejected_payload_value == (
+            "modules/foundups/observable_test_no_manifest"
+        )
+        # The rejected value MUST be in the diagnostic message too
+        # (greppable evidence).
+        assert "observable_test_no_manifest" in result.error_message
+
+    def test_rejected_value_observable_on_success(self) -> None:
+        """Even on success, ``rejected_payload_value`` carries the
+        payload's declared candidate -- silent swallow is refused per
+        #777 / #778 convention."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            payload={"module_path": "modules/foundups/voteballots"},
+        )
+        result = validate_job_for_build_plan(job)
+        assert result.valid is True
+        assert result.rejected_payload_value == "modules/foundups/voteballots"
+
+    # ------------------------------------------------------------------
+    # Test 14: BuildPlan output must not contain rejected payload value
+    # ------------------------------------------------------------------
+
+    def test_rejected_payload_value_does_not_propagate_into_buildtarget(self) -> None:
+        """When the resolver rejects, the BuildTarget is never produced
+        (``create_build_plan_from_job`` raises ValueError before
+        ``build_target_from_job``). The rejected value is visible only as
+        evidence in the GenerationValidationResult."""
+        bogus_path = "modules/foundups/bogus_will_not_resolve"
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            payload={"module_path": bogus_path},
+        )
+        with pytest.raises(ValueError, match="manifest_missing"):
+            create_build_plan_from_job(job)
+        # And via the lower-level path: build_target_from_job also refuses
+        # to produce a BuildTarget carrying the rejected path.
+        with pytest.raises(ValueError, match="manifest_missing"):
+            build_target_from_job(job)
+
+    def test_buildplan_carries_only_canonical_when_payload_provided(self) -> None:
+        """When the payload-supplied path happens to match the manifest's
+        canonical path, the BuildTarget.module_path is the canonical
+        from the manifest (the source of truth), not the payload string."""
+        job = create_job(
+            tenant_id="012",
+            requested_action="build_foundup",
+            foundup_id="voteballots",
+            payload={"module_path": "modules/foundups/voteballots"},
+        )
+        plan = create_build_plan_from_job(job)
+        assert plan.target.module_path == "modules/foundups/voteballots"
+        # The pwa_surface_path is DERIVED from the canonical module_path's
+        # basename (DERIVED_ONLY ruling), not from any payload-supplied
+        # surface path.
+        assert plan.target.pwa_surface_path == "public/member/foundups/voteballots/"
+
+
+# ===========================================================================
+# Addendum C #4 + #5: extraction equivalence (single source of truth)
+# ===========================================================================
+
+
+class TestSharedResolverIsSingleSourceOfTruth:
+    """Addendum C: prove there is exactly ONE module-path resolver
+    implementation, and the executor shim resolves to the SAME object."""
+
+    def test_executor_shim_and_shared_module_resolve_same_function(self) -> None:
+        """``hermes_foundup_job_executor._resolve_validated_module_path`` IS
+        ``module_path_resolution._resolve_validated_module_path``. The
+        ``from ... import ...`` shim binds the same object; identity is
+        preserved across the import boundary."""
+        from modules.foundups.agent.src import hermes_foundup_job_executor as e
+        from modules.foundups.agent.src import module_path_resolution as m
+
+        assert e._resolve_validated_module_path is m._resolve_validated_module_path
+        assert e.ResolvedModulePath is m.ResolvedModulePath
+        assert e.DEFAULT_REPO_ROOT == m.DEFAULT_REPO_ROOT
+        assert e.ALL_FAIL_TOKENS is m.ALL_FAIL_TOKENS
+        assert e.FAIL_TOKEN_SYNTACTIC_REJECT == m.FAIL_TOKEN_SYNTACTIC_REJECT
+        assert e.FAIL_TOKEN_MANIFEST_MISMATCH == m.FAIL_TOKEN_MANIFEST_MISMATCH
+        assert e.FAIL_TOKEN_MANIFEST_MISSING == m.FAIL_TOKEN_MANIFEST_MISSING
+        assert e.FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH == m.FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH
+
+    def test_generator_uses_same_resolver_as_executor(self) -> None:
+        """``build_plan_generator`` and ``hermes_foundup_job_executor`` both
+        reference the SAME ``_resolve_validated_module_path`` object."""
+        from modules.foundups.agent.src import build_plan_generator as g
+        from modules.foundups.agent.src import hermes_foundup_job_executor as e
+
+        assert g._resolve_validated_module_path is e._resolve_validated_module_path
+
+    def test_no_second_resolver_implementation_in_executor(self) -> None:
+        """AST scan: ``hermes_foundup_job_executor.py`` does NOT define a
+        function literally named ``_resolve_validated_module_path``
+        anymore -- it only imports from the shared module. If a future
+        edit accidentally reintroduces an in-file definition, this test
+        catches the duplication."""
+        import ast
+        path = Path(__file__).resolve().parents[1] / "src" / "hermes_foundup_job_executor.py"
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        local_defs = [
+            node.name for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef)
+        ]
+        assert "_resolve_validated_module_path" not in local_defs, (
+            "Second resolver implementation found in executor; the "
+            "shared module is the single source of truth."
+        )
+        assert "_find_manifest_for_foundup_id" not in local_defs
+        assert "_stringify_ignored" not in local_defs
+        class_defs = [
+            node.name for node in ast.walk(tree)
+            if isinstance(node, ast.ClassDef)
+        ]
+        assert "ResolvedModulePath" not in class_defs
+
+    def test_no_second_resolver_in_build_plan_generator(self) -> None:
+        """Symmetric scan on the generator file."""
+        import ast
+        path = Path(__file__).resolve().parents[1] / "src" / "build_plan_generator.py"
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        local_defs = [
+            node.name for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef)
+        ]
+        assert "_resolve_validated_module_path" not in local_defs
+        assert "_is_valid_foundup_path" not in local_defs
+        assert "get_known_foundup_path" not in local_defs
+        # The KNOWN_FOUNDUP_PATHS module-level constant must also be gone.
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        assert target.id != "KNOWN_FOUNDUP_PATHS"
+
+
+# ===========================================================================
+# WSP_97 row HERMES_778_TESTS_UNCHANGED_GREEN: pin the cross-file invariant
+# ===========================================================================
+
+
+class TestHermes778TestsUnchanged:
+    """The #778 executor test file must keep passing with ZERO edits
+    (Addendum C #3). This is a meta-test: it asserts the test file has not
+    been modified to compensate for the extraction. The file's git status
+    is intentionally not checked here (CI would do that); instead we
+    verify the import statements the test relies on still resolve."""
+
+    def test_executor_test_imports_still_resolve(self) -> None:
+        """All names the executor test file imports from the executor module
+        still resolve via the shim."""
+        from modules.foundups.agent.src.hermes_foundup_job_executor import (  # noqa: F401
+            HermesJobExecutionResult,
+            SUPPORTED_ACTIONS,
+            WORKER_ID,
+            can_execute_action,
+            execute_foundup_job,
+            get_supported_actions,
+            DEFAULT_REPO_ROOT,
+            FAIL_TOKEN_MANIFEST_MISSING,
+            _resolve_validated_module_path,
+        )
+
+    def test_executor_attribute_access_pattern_still_works(self) -> None:
+        """The ``import ... as e`` + ``e._resolve_validated_module_path``
+        attribute-access pattern the executor test uses still works."""
+        from modules.foundups.agent.src import hermes_foundup_job_executor as e
+        assert callable(e._resolve_validated_module_path)
+        assert isinstance(e.DEFAULT_REPO_ROOT, Path)
+        assert e.FAIL_TOKEN_MANIFEST_MISSING == "manifest_missing"
+        assert e.FAIL_TOKEN_SYNTACTIC_REJECT == "syntactic_reject"
+        assert e.FAIL_TOKEN_MANIFEST_MISMATCH == "manifest_mismatch"
+        assert e.FAIL_TOKEN_CROSS_FOUNDUP_MISMATCH == "cross_foundup_mismatch"
+        assert e.ALL_FAIL_TOKENS == frozenset({
+            "syntactic_reject", "manifest_mismatch",
+            "manifest_missing", "cross_foundup_mismatch",
+        })
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1` (W6). Closes the
#778 carry-forward at the build_plan_generator seam by **extracting**
the validator-guarded resolver into a SHARED module and reusing it from
both the Hermes executor (via back-compat shim, **zero test edits**) and
the build_plan_generator (via direct import). This is the LAST
consumer-wiring precondition before `WRE_CONTEXT_BUNDLE_DRYRUN_CONSUMER_PHASE1`.

## Trust-point evidence (5 trust points, re-verified)

| # | Site | Line | Verdict |
|---|------|------|---------|
| 1 | raw `payload.module_path` / `source_module` read in `validate_job_for_build_plan` | :167 | **DELETED -> shared resolver** |
| 2 | `get_known_foundup_path` inference call | :172 | **DELETED -> bounded foundup_id scan** |
| 3 | `KNOWN_FOUNDUP_PATHS` definition | :80 | **DELETED (DELETE_AS_DEAD_CODE)** |
| 4 | raw payload re-read in `build_target_from_job` | :276 | **DELETED -> shared resolver** |
| 5 | `f"modules/foundups/{foundup_id}"` synthesis fallback | :282 | **DELETED** |
| 6 | `_is_valid_foundup_path` with `.lower()` + PWA admit | :203-223 | **DELETED -> resolver's strict gate** |

## Pinned-design conformance

1. **REUSE #778, do not duplicate (WSP 84)**:
   a. NEW `module_path_resolution.py` carries the verbatim-moved 12-name
      resolver surface.
   b. `hermes_foundup_job_executor.py` re-imports/re-exports every name
      as a back-compat shim. **`test_hermes_foundup_job_executor.py`
      passes with ZERO edits (46/46).** Addendum C #3 hard gate met.
   c. `build_plan_generator.py`'s `validate_job_for_build_plan` and
      `build_target_from_job` call the shared resolver.

2. **Removed ALL non-manifest path sources**: KNOWN_FOUNDUP_PATHS
   inference and `f"modules/foundups/{foundup_id}"` synthesis are both
   deleted. Absent candidate -> resolver's bounded `foundup_id` scan ->
   manifest-derived path. KNOWN_FOUNDUP_PATHS ruling per Phase-0 census:
   **DELETE_AS_DEAD_CODE** (zero non-PATH_IDENTITY production consumers
   after the severed branch is gone).

3. **Replaced `_is_valid_foundup_path` for module identity**: the strict
   resolver's case-SENSITIVE manifest-exact-match wins; the `.lower()`
   compare is dead.

4. **PWA-surface ruling (Addendum-B style classification)**:
   **DERIVED_ONLY**. Evidence: `BuildTarget` already auto-derives
   manifest/test/doc paths from `module_path` (line 245-262 of
   `build_plan.py`). `pwa_surface_path` is now derived from the
   canonical module_path's basename (`public/member/foundups/{basename}/`)
   in `build_target_from_job`. Payload-supplied `public/member/foundups/<id>`
   paths reject at `syntactic_reject` (not under `modules/`).

5. **Fail-closed with #778 tokens** mapped into `GenerationValidationResult.error_code`.

6. **No silent fallbacks, no env-flag bypass**.

## Addendum-C extraction proof (behavior-preserving)

- **`test_hermes_foundup_job_executor.py` passes with ZERO edits** ->
  `46 passed in 0.83s`.
- **Identity preserved across import boundary**:
  `hermes_foundup_job_executor._resolve_validated_module_path is
  module_path_resolution._resolve_validated_module_path` returns `True`.
  Same for every other moved name.
- **Single source of truth pinned by AST scans** on both executor and
  generator files (`test_no_second_resolver_implementation_in_executor`,
  `test_no_second_resolver_in_build_plan_generator`).

## KNOWN_FOUNDUP_PATHS census + ruling

| file:line | Consumer | Classification |
|-----------|----------|---------------|
| `build_plan_generator.py:172` | `validate_job_for_build_plan` -> inferred_module_path | **PATH_IDENTITY_USE** (severed) |
| `build_plan_generator.py:182` | error-message string interpolation | DISPLAY_CATALOG_USE (gone with severed branch) |
| `build_plan_generator.py:278` | `build_target_from_job` -> BuildTarget.module_path | **PATH_IDENTITY_USE** (severed) |
| tests / *.md | dead test imports / docs | DEAD_TEST_ONLY / markdown |
| cross-module callers | NONE | -- |

**Ruling: DELETE_AS_DEAD_CODE**. The DISPLAY_CATALOG_USE error string
lives inside the same severed branch; once the PATH_IDENTITY branches
are gone, no live consumer remains.

## Audit findings absorbed

None. No coordinating audit landed during the slice. The Phase-0
discovery covered the full surface independently; the COORDINATION_NOTE
slot is reported as "no findings absorbed."

## Test counts

```
python -m pytest modules/foundups/agent/tests/test_build_plan_generator.py -q
  -> 71 passed in 0.97s (44 prior + 27 new)
python -m pytest modules/foundups/agent/tests/test_hermes_foundup_job_executor.py -q
  -> 46 passed in 0.83s (ZERO EDITS to this file)
python -m pytest modules/foundups/agent/tests/ -q
  -> 646 passed in 8.15s; 0 skipped; 0 xfailed
```

The 14 dispatch-required tests (Addendum C + D folded) map 1:1 to
`TestSharedResolverValidationInGenerator` (see TestModLog for the
explicit mapping table).

## Boundary preserved

- `HERMES_778_TESTS_UNCHANGED_GREEN`: 46/46 with ZERO edits.
- `NO_SECOND_MODULE_PATH_RESOLVER`: AST scans pin only one
  implementation.
- `NO_VALIDATOR_MUTATION`; `NO_MANIFEST_MUTATION`;
  `NO_RUNTIME_OR_BUILDER_CHANGE`; `NO_WSP_FILE_MUTATION`;
  `NO_NEW_DEPENDENCY`; `NO_JOB_CONTRACT_SCHEMA_CHANGE`;
  `NO_CONSUMER_WIRING` (generator stays orphaned).

## WSP_97 Truth Boundary Checklist

**PASS 14/14** with the dispatch's required rows:
`OLD_PAYLOAD_MODULE_PATH_TRUST_DEAD`, `KNOWN_FOUNDUP_PATHS_INFERENCE_DEAD`,
`FOUNDUP_ID_SYNTHESIS_DEAD`, `CASE_VARIANT_PATH_REJECTED`,
`CROSS_FOUNDUP_SUBSTITUTION_REJECTED`, `PWA_SURFACE_RULING_RECORDED`,
`VALIDATED_MANIFEST_SOURCE_OF_TRUTH`, `REJECTED_PAYLOAD_VALUE_OBSERVABLE`,
`REJECTED_VALUE_NOT_IN_BUILDPLAN_OUTPUT`, `HERMES_778_TESTS_UNCHANGED_GREEN`,
`SHARED_RESOLVER_SINGLE_SOURCE_OF_TRUTH`,
`HERMES_RESOLVER_EXTRACTION_BEHAVIOR_PRESERVED`,
`NO_SECOND_MODULE_PATH_RESOLVER`, `NO_USER_QUESTION_FRAMING`.

Full table with verbatim evidence in
[`modules/foundups/agent/ModLog.md`](../tree/w6/build-plan-generator-module-path-trust-removal-phase1/modules/foundups/agent/ModLog.md).

Predecessors: #770, #771, #772, #773, #774, #775, #777, #778.

Worker-Lane: W6
Slice: BUILD_PLAN_GENERATOR_MODULE_PATH_TRUST_REMOVAL_PHASE1
Do NOT merge. Leave OPEN for W10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)