### PR TITLE
test(wre): operational-WRE monorepo-PoC vertical dry-run proof (W6)

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -1,5 +1,45 @@
 # FoundUps Agent - Development Log
 
+## [2026-06-12] Operational WRE monorepo-PoC Vertical Dry-Run Proof Phase 1 (W6)
+
+**Change Type**: VERTICAL PROOF (integration test + proof doc). Proves one full
+dry-run invocation end-to-end through the EXISTING OpenClaw/WRE create+drain seam
+for a safe monorepo_poc FoundUp (`gotjunk_001`). NO production code, NO new
+wiring, NO broadening of actions.
+**By**: 0102 (W6) | Commander: 012 | Reviewer: W10
+**WSP References**: WSP 11, WSP 50, WSP 77, WSP 97, WSP 22
+**Slice**: OPERATIONAL_WRE_MONOREPO_POC_VERTICAL_PROOF_PHASE1
+**Base**: `c7839c2ab` (origin/main = #787 dry-run runtime wiring)
+
+- NEW `modules/infrastructure/wre_core/tests/test_operational_wre_monorepo_poc_vertical_proof.py`
+  (3 passed, 0 skip/xfail). Drives the REAL create entry
+  (`openclaw_foundup_orchestrator.dispatch_foundup` enqueue ->
+  `_FOUNDUP_JOB_QUEUE.append`) and the REAL drain entry
+  (`FoundUpJobConsumer.drain_openclaw_queue_with_retention` -> `consume_one` ->
+  `_dispatch_to_hermes` -> `execute_foundup_job` SIMULATED ->
+  `_attach_context_bundle_dry_run` #787). Does NOT mock the seam; does NOT call
+  the #786 consumer in isolation. Only mocks are the real-exec sinks
+  (`subprocess.Popen`/`run`/`call`, `HermesJobExecutor._lazy_import_delegate_task`),
+  asserted `assert_not_called` through the full seam.
+- ACCEPTANCE (one invocation): real create + real drain; SIMULATED /
+  `real_execution_performed False`; ContextBundle BUILT (#775); #786 consumer
+  RAN; DryRunResult ATTACHED to the EXISTING `ConsumerResult` receipt;
+  `source_authority == monorepo_poc`; `resolved_module_path` from the shared
+  validated resolver (validated canonical, NOT payload); `evidence_refs`
+  refs+sha256(+size+role) only; no file bodies; no live Hermes delegation; no
+  subprocess/build execution; readiness all False. NEGATIVE: forged cross-FoundUp
+  `module_path` rejected end-to-end (`cross_foundup_mismatch`; observable; never
+  used). `validate_foundup` is the action reaching SIMULATED (build/extract
+  guard-blocked). `gotjunk_001` is a PARAMETERIZED fixture default.
+- NEW `docs/audits/architecture/OPERATIONAL_WRE_MONOREPO_POC_VERTICAL_PROOF_PHASE1.md`
+  (proof doc: REAL path file:line, asserted chain, WSP_97 20-row table).
+- Boundary: `git diff --name-only c7839c2ab HEAD` lists ONLY the new test, the
+  new proof doc, and the wre_core + root ModLogs -- 0 production-code files. New
+  `.py`/`.md` 0 non-ASCII. Broader wre_core consumer suite 58 passed (isolated
+  worktree).
+
+---
+
 ## [2026-06-12] WRE ContextBundle Dry-Run Runtime Wiring Phase 2 (W6)
 
 **Change Type**: FIRST runtime integration -- wires the standalone #786

--- a/docs/audits/architecture/OPERATIONAL_WRE_MONOREPO_POC_VERTICAL_PROOF_PHASE1.md
+++ b/docs/audits/architecture/OPERATIONAL_WRE_MONOREPO_POC_VERTICAL_PROOF_PHASE1.md
@@ -1,0 +1,189 @@
+# Operational WRE monorepo-PoC Vertical Dry-Run Proof Phase 1 (W6)
+
+**Slice**: OPERATIONAL_WRE_MONOREPO_POC_VERTICAL_PROOF_PHASE1
+**Author**: 0102 (W6) | **Commander**: 012 | **Reviewer**: W10
+**Base**: `c7839c2ab` (origin/main = #787 dry-run runtime wiring)
+**Branch**: `w6/operational-wre-monorepo-poc-vertical-proof-phase1`
+**Type**: VERTICAL PROOF (integration test + proof doc). NO new production code,
+NO new wiring, NO broadening of actions.
+**Effort**: ULTRA
+
+## Summary
+
+Proves ONE full dry-run invocation end-to-end through the EXISTING OpenClaw/WRE
+create+drain seam for a safe monorepo_poc FoundUp (default `gotjunk_001`). The
+proof drives the REAL create entry (OpenClaw orchestrator enqueue) AND the REAL
+drain entry (WRE consumer over the OpenClaw queue) -- it does NOT mock the seam
+and does NOT call the #786 consumer in isolation. The only mocks are the
+real-execution SINKS (subprocess `Popen`/`run`/`call` and the executor's
+real-delegate loader), asserted `assert_not_called` THROUGH the full seam.
+
+Every acceptance item is asserted in a single pytest invocation. A negative
+case proves a forged `module_path` is rejected by the shared validated resolver
+end-to-end (observable, never used). No production code changes; the proof
+consumes the existing path AS-IS.
+
+## The REAL create/drain path (identified, not invented)
+
+All constructs below pre-existed at Base `c7839c2ab` (proven via
+`git show c7839c2ab:<path>`). The proof's new test is the ONLY new file in the
+WRE/consumer trees.
+
+### REAL CREATE (OpenClaw orchestrator enqueue)
+
+`modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py`
+
+- `dispatch_foundup(dae, intent)` (line 840) -- the orchestrator entrypoint.
+  On an explicit build/validate intent it calls `_handle_build_intent`.
+- `_handle_build_intent(intent)` (line 914) -- builds the typed FoundUpJob via
+  `create_job(...)` and appends it to the real in-memory queue:
+  `_FOUNDUP_JOB_QUEUE.append(job)` (line 976). The queue is declared at
+  line 39 (`_FOUNDUP_JOB_QUEUE: List[FoundUpJob] = []`).
+- `get_job_queue()` (line 230) -- returns the same real queue the drain reads.
+
+The natural-language intake message `"validate foundup gotjunk_001 --dry-run"`
+makes the REAL orchestrator (not the test) extract
+`requested_action=validate_foundup`, `foundup_id=gotjunk_001`, and
+`policy_flags.dry_run_mode=True`. The create entry builds the job payload
+itself; it carries NO `module_path` / `source_module`.
+
+### REAL DRAIN (WRE consumer over the OpenClaw queue)
+
+`modules/infrastructure/wre_core/src/foundup_job_consumer.py`
+
+- `FoundUpJobConsumer.drain_openclaw_queue_with_retention(clear=...)`
+  (line 858) -- the real queue drain. It pulls `get_job_queue()` and runs
+  each job through `drain_jobs` (line 823) -> `consume_one` (line 370).
+- `consume_one` -> `_dispatch_to_hermes` (line 424) -> `execute_foundup_job`
+  (Hermes executor) -> `_attach_context_bundle_dry_run` (line 537).
+- `ConsumerResult` (line 112) is the EXISTING typed receipt; its
+  `context_bundle_dry_run` field (line 188) carries the #786 `DryRunResult`.
+
+### PRE-EXISTING dry-run branch + the #786/#787 wiring
+
+`modules/infrastructure/wre_core/src/hermes_job_executor.py`
+
+- `is_hermes_delegation_enabled()` (line 92) reads `HERMES_DELEGATE_ENABLED`
+  (default "0").
+- `HermesJobExecutor.execute` Step 4 `if not is_hermes_delegation_enabled():`
+  (line 1767) returns `HermesExecutionStatus.SIMULATED` (line 1773) with
+  `real_execution_performed=False` -- the dry-run branch.
+- `execute_foundup_job(job)` (line 2360) is the module-level convenience the
+  consumer calls (singleton, dry_run=True).
+
+The `_attach_context_bundle_dry_run` helper (#787 wiring, line 537) runs ONLY
+when the executor returns SIMULATED AND `real_execution_performed` is False AND
+`is_hermes_delegation_enabled()` is False. It builds the #775 ContextBundle and
+calls the #786 consumer, attaching the returned `DryRunResult` to the EXISTING
+receipt.
+
+### Why validate_foundup is the action under proof
+
+`validate_foundup` is the ONLY canonical action that reaches the PRE-EXISTING
+SIMULATED branch. `build_foundup` / `extract_foundup` are blocked earlier by the
+destructive-action guard (`BLOCKED_BY_DESTRUCTIVE_ACTION_GUARD`). The proof
+asserts this control directly (`TestActionReachesSimulated`). So the validate
+action is what exercises the #786/#787 dry-run wiring.
+
+## Consumed AS-IS (NOT modified)
+
+- `openclaw_foundup_orchestrator.py` -- real create/enqueue entry.
+- `foundup_job_consumer.py` (#774/#787) -- real drain seam + receipt.
+- `hermes_job_executor.py` (#787) -- executor + its dry-run / real-exec branch.
+- `context_bundle_dry_run_consumer.py` (#786) -- `consume_context_bundle_dry_run`.
+- `context_bundle_builder.py` (#775) -- `build_context_bundle`.
+- `module_path_resolution.py` (#778/#779) -- single `_resolve_validated_module_path`.
+- `source_authority.py` (#777) -- `resolve_source_authority` / `ACTIVE_STAGES`.
+- `foundup_manifest_validator.py` (#773) -- canonical module_path validator.
+
+`git diff --name-only c7839c2ab HEAD` lists NONE of these files. It lists only:
+the new test, this doc, the wre_core ModLog, and the root ModLog.
+
+## The asserted acceptance chain (single invocation)
+
+Test: `modules/infrastructure/wre_core/tests/test_operational_wre_monorepo_poc_vertical_proof.py`
+Method: `TestOperationalWREMonorepoPoCVerticalProof::test_full_dry_run_invocation_end_to_end`
+
+1. The OpenClaw/WRE path CREATES the job -- real `dispatch_foundup` enqueue
+   (`_create_via_real_openclaw_entry`); job is QUEUED `validate_foundup`,
+   `dry_run_mode=True`, payload carries NO `module_path` / `source_module`.
+2. The OpenClaw/WRE path DRAINS the job -- real
+   `drain_openclaw_queue_with_retention` over `get_job_queue()`.
+3. The dispatch seam took the DRY-RUN branch -- `checkpoint_state == "SIMULATED"`,
+   `real_execution_performed is False`.
+4. A ContextBundle was BUILT (#775) and the #786 consumer RAN -- the attached
+   `context_bundle_dry_run` carries a populated `DryRunResult`
+   (`bundle_id`, `consumer_version`, no `context_bundle_error`).
+5. DryRunResult is ATTACHED to the receipt -- `context_bundle_dry_run` present
+   on `ConsumerResult` and survives `to_dict()`.
+6. `source_authority == "monorepo_poc"`.
+7. `module_path` from the shared validated resolver -- `resolved_module_path ==
+   "modules/foundups/gotjunk"` (validated canonical, derived from the manifest,
+   NOT the payload); `rejected_input.resolver_run is True`,
+   `payload_module_path_ignored is None`, `resolver_failed is False`.
+8. `evidence_refs` are refs + sha256 (+ size + role) ONLY -- each ref's keys are
+   a subset of `{path, sha256, size_bytes, role}`; every sha256 is 64 hex chars.
+9. NO file bodies anywhere in the receipt -- no `body`/`content`/`source_text`/
+   `file_body` key in the serialized receipt.
+10. NO pass-state key in the dry-run evidence -- no gate-pass key in the
+    `context_bundle_dry_run` blob; gates are NAME strings, never booleans.
+11. NO live Hermes delegation -- `HERMES_DELEGATE_ENABLED` unset; the executor's
+    real-delegate loader is patched and `assert_not_called` through the seam.
+12. NO subprocess / build execution -- `subprocess.Popen`/`run`/`call` are
+    patched and `assert_not_called` through the full create+drain path.
+13. Readiness flags remain False -- every flag in `readiness_flags` is `False`;
+    the receipt's EXISTING WSP 97 truth fields (`verification_complete`,
+    `cabr_ready`, `payout_ready`) are all `False`.
+
+### Negative through the full seam
+
+Method: `TestForgedModulePathFailsEndToEnd::test_forged_cross_foundup_module_path_rejected_via_seam`
+
+A forged job arrives in the real OpenClaw queue carrying a cross-FoundUp
+`module_path` (`modules/foundups/kosei` on a `gotjunk_001` job). Draining it
+through the REAL WRE entry still reaches SIMULATED, but the shared resolver
+REJECTS the forged path end-to-end: `context_bundle_error ==
+"module_path_resolution_failed"`, `fail_token == "cross_foundup_mismatch"`,
+`resolved_module_path is None` (never used), and the forged value is observable
+in `payload_module_path_ignored`. Real-exec sinks are `assert_not_called` here
+too. This is proven THROUGH the seam, not at unit level.
+
+## Boundary / isolation notes
+
+- The executor's PRE-EXISTING SIMULATED branch writes observability JSON to
+  `.hermes_evidence/{job_id}/` under the workspace root (`_write_evidence`,
+  line 2223). This is existing seam behaviour (no subprocess, no real
+  delegation). The proof redirects writes to a tmp dir via
+  `FOUNDUPS_WORKSPACE_ROOT` and resets the executor singleton, so it leaves no
+  repo artifact.
+- `gotjunk_001` is a PARAMETERIZED fixture default (`proof_foundup`), not a
+  permanent hard-code: add a `(foundup_id, module_path)` tuple to the fixture
+  `params` to run the whole vertical proof for any safe monorepo_poc FoundUp.
+- The only mocks are the real-execution sinks (subprocess + real-delegate
+  loader) for `assert_not_called`. The create entry, drain entry, dispatch,
+  executor, and #786 consumer all run for real.
+
+## WSP_97 Truth Boundary Checklist
+
+| # | Truth Boundary Checklist Item | Status | Evidence |
+|---|-------------------------------|--------|----------|
+| 1 | HOLOINDEX_PRIOR_ART_SEARCHED | YES | Phase 0: `holo_index.py --search "FoundUpJobConsumer drain consume_one dispatch foundup job queue create"` + "OpenClaw create foundup job enqueue WRE consumer ConsumerResult". Real entry located by glob + `git show`. |
+| 2 | HOLOINDEX_RETRIEVAL_ASSESSED | YES | HoloIndex surfaced contract/router/webhook hits but NOT `foundup_job_consumer.py`; staleness/missing-artifact gap closed by glob (`**/foundup_job_consumer.py`) + base ground-truth read. |
+| 3 | REAL_CREATE_DRAIN_PATH_USED_NOT_MOCKED | YES | Test drives `dispatch_foundup` enqueue (orchestrator.py:840/976) + `drain_openclaw_queue_with_retention` (consumer.py:858); `_dispatch_to_hermes` and `consume_context_bundle_dry_run` are NOT mocked. |
+| 4 | SEAM_TOOK_DRYRUN_BRANCH | YES | `result.checkpoint_state == "SIMULATED"`, `result.real_execution_performed is False` (executor SIMULATED branch, hermes_job_executor.py:1767-1773). |
+| 5 | CONTEXTBUNDLE_BUILT | YES | `context_bundle_dry_run` carries populated `bundle_id`; no `context_bundle_error` (build_context_bundle #775 ran). |
+| 6 | CONSUMER_786_RAN | YES | `consumer_version` present and `resolved_module_path`/`evidence_refs` populated (consume_context_bundle_dry_run #786 ran). |
+| 7 | DRYRUNRESULT_ATTACHED_TO_RECEIPT | YES | `ConsumerResult.context_bundle_dry_run` present and survives `to_dict()`. |
+| 8 | SOURCE_AUTHORITY_MONOREPO_POC | YES | `cb["source_authority"] == "monorepo_poc"` (builder constant SOURCE_AUTHORITY, builder.py:132). |
+| 9 | MODULE_PATH_FROM_SHARED_RESOLVER | YES | `resolved_module_path == "modules/foundups/gotjunk"` (validated canonical, payload had no module_path); `rejected_input.resolver_run is True`. |
+| 10 | EVIDENCE_REFS_HASHES_ONLY_NO_BODIES | YES | Each ref's keys subset of `{path, sha256, size_bytes, role}`; sha256 64 hex; no body key. |
+| 11 | NO_LIVE_HERMES_DELEGATION | YES | `HERMES_DELEGATE_ENABLED` unset; `HermesJobExecutor._lazy_import_delegate_task` patched, `assert_not_called`. |
+| 12 | NO_SUBPROCESS_OR_BUILD_EXECUTION | YES | `subprocess.Popen`/`run`/`call` patched, `assert_not_called` through the full path. |
+| 13 | READINESS_REMAINS_FALSE | YES | every `readiness_flags` value False; receipt `verification_complete`/`cabr_ready`/`payout_ready` all False. |
+| 14 | FORGED_MODULE_PATH_FAILS_END_TO_END | YES | `TestForgedModulePathFailsEndToEnd`: forged kosei path on gotjunk_001 job -> `fail_token == "cross_foundup_mismatch"`, `resolved_module_path is None`, observable in `payload_module_path_ignored`. |
+| 15 | GOTJUNK_001_PARAMETERIZED_NOT_HARDCODED | YES | `proof_foundup` pytest fixture with `params=[(gotjunk_001, modules/foundups/gotjunk)]`; swap param to run any safe monorepo_poc FoundUp. |
+| 16 | NO_NEW_PRODUCTION_CODE | YES | `git diff --name-only c7839c2ab HEAD` lists only the new test + this doc + wre_core ModLog + root ModLog. |
+| 17 | NO_REAL_EXECUTION | YES | dry-run branch only; real-exec sinks asserted not-called; no `_write_evidence` outside tmp workspace. |
+| 18 | NO_USER_QUESTION_FRAMING | YES | This is a WSP_97 evidence-backed proof; no "user questions". |
+| 19 | CITES_PR_775_786_787 | YES | #775 build_context_bundle, #786 consume_context_bundle_dry_run, #787 _attach_context_bundle_dry_run wiring cited above. |
+| 20 | ASCII_CLEAN | YES | New `.py` and `.md` files are 0 non-ASCII bytes. |

--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -2,6 +2,68 @@
 
 ## Chronological Change Log
 
+### [2026-06-12] - OPERATIONAL_WRE_MONOREPO_POC_VERTICAL_PROOF_PHASE1 (W6)
+
+**WSP Protocol References**: WSP 11 (Interface), WSP 50 (Pre-Action), WSP 77 (Agent
+Coordination), WSP 97 (Truth Boundary), WSP 22 (ModLog)
+**Base**: `c7839c2ab` (origin/main = #787 dry-run runtime wiring)
+**Predecessors**: #774 (consumer seam), #775 (`build_context_bundle`), #777
+(source_authority), #778/#779 (shared `_resolve_validated_module_path`), #786
+(`consume_context_bundle_dry_run`), #787 (`_attach_context_bundle_dry_run`
+runtime wiring).
+**Type**: VERTICAL PROOF (integration test + proof doc). NO production code, NO
+new wiring, NO broadening of actions.
+
+**Mission (012)**: Prove ONE full dry-run invocation end-to-end through the
+EXISTING OpenClaw/WRE create+drain seam using a safe FoundUp (`gotjunk_001`).
+
+**Phase 0 (HoloIndex)**: 2 queries (`FoundUpJobConsumer drain consume_one
+dispatch foundup job queue create`; `OpenClaw create foundup job enqueue WRE
+consumer ConsumerResult`). Retrieval assessment: hits surfaced the job contract /
+router / webhook receiver but NOT `foundup_job_consumer.py` (missing-artifact /
+staleness gap); closed via glob `**/foundup_job_consumer.py` + base ground-truth
+read (`git show c7839c2ab:<path>`). REAL path identified:
+- CREATE: `openclaw_foundup_orchestrator.dispatch_foundup` (line 840) ->
+  `_handle_build_intent` (914) -> `create_job` + `_FOUNDUP_JOB_QUEUE.append`
+  (976); `get_job_queue` (230).
+- DRAIN: `FoundUpJobConsumer.drain_openclaw_queue_with_retention` (consumer
+  line 858) -> `drain_jobs` (823) -> `consume_one` (370) -> `_dispatch_to_hermes`
+  (424) -> `execute_foundup_job` (SIMULATED) -> `_attach_context_bundle_dry_run`
+  (537) -> `ConsumerResult.context_bundle_dry_run` (188).
+
+**Deliverable** - NEW test
+`tests/test_operational_wre_monorepo_poc_vertical_proof.py` (3 tests, all pass,
+0 skip/xfail). Drives the REAL create entry (`dispatch_foundup` enqueue) and the
+REAL drain entry (`drain_openclaw_queue_with_retention`); does NOT mock the seam
+and does NOT call the #786 consumer in isolation. The only mocks are the
+real-execution sinks (`subprocess.Popen`/`run`/`call` and
+`HermesJobExecutor._lazy_import_delegate_task`), asserted `assert_not_called`
+through the full seam.
+
+**Acceptance proven in ONE invocation**: real create + real drain; SIMULATED /
+`real_execution_performed False`; ContextBundle BUILT (#775); #786 consumer RAN;
+DryRunResult ATTACHED to receipt; `source_authority == monorepo_poc`;
+`resolved_module_path` from the shared validated resolver (== validated
+canonical, not payload); `evidence_refs` refs+sha256(+size+role) only; no file
+bodies; no live Hermes delegation; no subprocess/build execution; readiness all
+False. NEGATIVE: a forged cross-FoundUp `module_path` is rejected end-to-end via
+the shared resolver (`cross_foundup_mismatch`; rejected value observable; never
+used). `validate_foundup` is the action that reaches SIMULATED (build/extract
+guard-blocked) -- asserted directly. `gotjunk_001` is a PARAMETERIZED fixture
+default, not a hard-code.
+
+**Boundary**: NO production-code changes. `git diff --name-only c7839c2ab HEAD`
+lists only the new test, the new proof doc
+(`docs/audits/architecture/OPERATIONAL_WRE_MONOREPO_POC_VERTICAL_PROOF_PHASE1.md`),
+and the wre_core + root ModLogs. Real-exec / Hermes-delegation branch untouched
+and BLOCKED. New `.py`/`.md` 0 non-ASCII.
+
+**Verification**: new test 3 passed, 0 skip/xfail; broader wre_core consumer
+suite 58 passed (isolated worktree). Evidence writes redirected to a tmp
+workspace via `FOUNDUPS_WORKSPACE_ROOT` (no repo artifact).
+
+---
+
 ### [2026-06-12] - WRE_CONTEXT_BUNDLE_DRYRUN_RUNTIME_WIRING_PHASE2 (W6)
 
 **WSP Protocol References**: WSP 11 (Interface), WSP 50 (Pre-Action), WSP 77 (Agent

--- a/modules/infrastructure/wre_core/tests/test_operational_wre_monorepo_poc_vertical_proof.py
+++ b/modules/infrastructure/wre_core/tests/test_operational_wre_monorepo_poc_vertical_proof.py
@@ -1,0 +1,448 @@
+# -*- coding: utf-8 -*-
+"""
+Operational WRE monorepo-PoC vertical dry-run PROOF (W6).
+
+Slice: OPERATIONAL_WRE_MONOREPO_POC_VERTICAL_PROOF_PHASE1
+
+This is a VERTICAL PROOF, not new wiring. It drives ONE full dry-run
+invocation end-to-end through the EXISTING OpenClaw/WRE create+drain seam
+for a safe monorepo_poc FoundUp (default ``gotjunk_001``) and asserts the
+entire closed-loop evidence chain in a single invocation.
+
+The proof drives the REAL create and REAL drain entry points -- it does NOT
+mock the seam and does NOT call the #786 consumer in isolation:
+
+  REAL CREATE (OpenClaw orchestrator enqueue):
+    openclaw_foundup_orchestrator.dispatch_foundup(dae=None, intent)
+      -> _is_explicit_build_intent("validate foundup ...")  (True)
+      -> _handle_build_intent(intent)
+      -> create_job(requested_action="validate_foundup", foundup_id=...)
+      -> _FOUNDUP_JOB_QUEUE.append(job)         # the real in-memory queue
+
+  REAL DRAIN (WRE consumer over the OpenClaw queue):
+    FoundUpJobConsumer.drain_openclaw_queue_with_retention(clear=False)
+      -> get_job_queue()                        # the same real queue
+      -> drain_jobs -> consume_one
+      -> _dispatch_to_hermes
+      -> execute_foundup_job(job)               # Hermes executor -> SIMULATED
+      -> _attach_context_bundle_dry_run(...)    # #786/#787 dry-run wiring
+      -> ConsumerResult.context_bundle_dry_run  # #775 build -> #786 DryRunResult
+
+Action selection: ``validate_foundup`` is the ONLY canonical action that
+reaches the PRE-EXISTING dry-run (SIMULATED) branch -- ``build_foundup`` /
+``extract_foundup`` are blocked earlier by the destructive-action guard
+(asserted in TestActionReachesSimulated). So the validate action is what
+exercises the #786/#787 dry-run wiring.
+
+Boundary discipline (no overclaim, no real execution):
+  - HERMES_DELEGATE_ENABLED unset/0 for the whole module: the seam stays on
+    its PRE-EXISTING dry-run branch and real Hermes delegation stays BLOCKED.
+  - The ONLY mocks are the real-execution SINKS (subprocess Popen/run/call
+    and the executor's real-delegate loader) asserted ``assert_not_called``
+    THROUGH the full create+drain seam. The seam itself is NEVER mocked.
+  - Evidence writes (the executor's PRE-EXISTING .hermes_evidence JSONs) are
+    redirected to a tmp workspace via FOUNDUPS_WORKSPACE_ROOT so the proof
+    leaves no repo artifact; this is the existing seam behaviour, not a new
+    side effect.
+  - The default FoundUp id is a PARAMETERIZED fixture (``proof_foundup``),
+    not a permanent hard-code: swap the param to run for any safe
+    monorepo_poc FoundUp.
+
+NO new production code, NO new wiring, NO broadening of actions. The proof
+consumes the existing path AS-IS.
+
+WSP Compliance:
+  WSP 11 : Interface contract (typed ConsumerResult + DryRunResult).
+  WSP 50 : Pre-action validation (shared resolver gate before any build).
+  WSP 77 : Agent coordination (WRE consumer owns dispatch; no new loop).
+  WSP 97 : Truth boundaries (dry-run only, no overclaim, no real exec).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import types
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from modules.communication.moltbot_bridge.src import (
+    openclaw_foundup_orchestrator as orchestrator,
+)
+from modules.communication.moltbot_bridge.src.foundup_job_contract import (
+    create_job,
+)
+from modules.infrastructure.wre_core.src import hermes_job_executor as hje
+from modules.infrastructure.wre_core.src.foundup_job_consumer import (
+    ConsumerResult,
+    FoundUpJobConsumer,
+)
+
+# Repo root: tests/ -> wre_core/ -> infrastructure/ -> modules/ -> repo root
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+# A safe monorepo_poc FoundUp whose manifest passes the #773 validator and
+# whose canonical module_path is the validated source of truth.
+DEFAULT_PROOF_FOUNDUP_ID = "gotjunk_001"
+DEFAULT_PROOF_MODULE_PATH = "modules/foundups/gotjunk"
+
+# A second real FoundUp used ONLY to prove cross-FoundUp payload substitution
+# is rejected by the shared resolver end-to-end.
+FORGED_OTHER_MODULE_PATH = "modules/foundups/kosei"
+
+# Authority / gate-pass keys that must NEVER appear in the serialized
+# context_bundle_dry_run evidence (they would imply pass-state / promotion).
+_FORBIDDEN_SERIALIZED_KEYS = frozenset({
+    "gate_passed", "gates_passed", "passed", "all_gates_passed",
+    "security_passed", "permission_passed", "dry_run_passed", "build_passed",
+    "verification_complete", "cabr_ready", "cabr_passed", "payout_ready",
+    "payout_approved", "dao_ready", "dao_approved", "dao_passed",
+})
+
+# Body / content keys that must NEVER appear (no file bodies in the receipt).
+_FORBIDDEN_BODY_KEYS = ('"body"', '"content"', '"source_text"', '"file_body"')
+
+
+# ---------------------------------------------------------------------------
+# Parameterized fixture: the proof FoundUp (default gotjunk_001, swappable).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(
+    params=[(DEFAULT_PROOF_FOUNDUP_ID, DEFAULT_PROOF_MODULE_PATH)],
+    ids=["gotjunk_001"],
+)
+def proof_foundup(request):
+    """The safe monorepo_poc FoundUp under proof.
+
+    Default param is ``gotjunk_001`` but the proof is NOT hard-coded to it:
+    add a ``(foundup_id, module_path)`` tuple to ``params`` to run the whole
+    vertical proof for any other safe monorepo_poc FoundUp.
+    """
+    foundup_id, module_path = request.param
+    return types.SimpleNamespace(
+        foundup_id=foundup_id,
+        module_path=module_path,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _dry_run_branch_and_isolated_workspace(monkeypatch):
+    """Pin the dry-run branch and isolate the seam's evidence writes.
+
+    - HERMES_DELEGATE_ENABLED unset: the seam stays on its PRE-EXISTING
+      dry-run branch (SIMULATED) and real Hermes delegation stays BLOCKED.
+    - FOUNDUPS_WORKSPACE_ROOT -> a fresh tmp dir so the executor's
+      PRE-EXISTING .hermes_evidence/*.json writes never touch the repo.
+    - Reset the Hermes executor singleton and the in-memory job queue so each
+      param runs cleanly through the real create+drain entries.
+    """
+    monkeypatch.delenv("HERMES_DELEGATE_ENABLED", raising=False)
+    tmp_ws = tempfile.mkdtemp(prefix="w6_vertical_proof_")
+    monkeypatch.setenv("FOUNDUPS_WORKSPACE_ROOT", tmp_ws)
+    # Force the executor singleton to re-detect the tmp workspace root.
+    monkeypatch.setattr(hje, "_executor_singleton", None, raising=False)
+    orchestrator.clear_job_queue()
+    yield
+    orchestrator.clear_job_queue()
+    monkeypatch.setattr(hje, "_executor_singleton", None, raising=False)
+
+
+def _build_intent(foundup_id, *, forged_module_path=None):
+    """Construct a minimal OpenClaw build intent for the REAL create path.
+
+    ``dispatch_foundup`` reads only ``raw_message``, ``sender``,
+    ``session_key`` and ``channel`` on the explicit-build branch, so a
+    SimpleNamespace is a faithful stand-in for an inbound intent. The message
+    is natural language ("validate foundup <id> --dry-run") -- the same intake
+    a real OpenClaw chat prompt would carry -- so action/foundup_id/dry-run
+    are extracted by the REAL orchestrator, not injected by the test.
+    """
+    return types.SimpleNamespace(
+        raw_message=f"validate foundup {foundup_id} --dry-run",
+        sender="tenant_w6",
+        session_key="w6_proof_session",
+        channel="w6_proof_channel",
+    )
+
+
+def _create_via_real_openclaw_entry(foundup_id):
+    """Drive the REAL OpenClaw create/enqueue entry and return the queued job.
+
+    Asserts the real orchestrator -- not the test -- produced a QUEUED
+    validate_foundup job for ``foundup_id`` and appended it to the real queue.
+    """
+    response = orchestrator.dispatch_foundup(None, _build_intent(foundup_id))
+    assert "FoundUpJob created" in response
+    queue = orchestrator.get_job_queue()
+    assert len(queue) == 1, "real OpenClaw entry must enqueue exactly one job"
+    job = queue[0]
+    assert job.requested_action == "validate_foundup"
+    assert job.foundup_id == foundup_id
+    assert job.status.value == "queued"
+    return job
+
+
+def _drain_via_real_wre_entry():
+    """Drive the REAL WRE drain entry over the OpenClaw queue, return result.
+
+    Uses ``drain_openclaw_queue_with_retention`` (the real queue drain) which
+    pulls ``get_job_queue()`` and runs each job through ``consume_one`` ->
+    ``_dispatch_to_hermes``. ``clear=False`` keeps the queue inspectable.
+    """
+    consumer = FoundUpJobConsumer(dry_run=True)
+    drain_result = consumer.drain_openclaw_queue_with_retention(clear=False)
+    assert len(drain_result.results) == 1, "drain must consume the one job"
+    return drain_result.results[0]
+
+
+# ===========================================================================
+# Action-reaches-SIMULATED control: validate_foundup is the dry-run action.
+# ===========================================================================
+
+
+class TestActionReachesSimulated:
+    def test_validate_reaches_simulated_build_extract_blocked(self, proof_foundup):
+        """validate_foundup reaches SIMULATED; build/extract are guard-blocked.
+
+        Proves WHICH action exercises the #786/#787 dry-run wiring: only the
+        validate action reaches the PRE-EXISTING SIMULATED branch.
+        """
+        statuses = {}
+        for action in ("validate_foundup", "build_foundup", "extract_foundup"):
+            job = create_job(
+                tenant_id="tenant_w6",
+                requested_action=action,
+                foundup_id=proof_foundup.foundup_id,
+                payload={},
+            )
+            statuses[action] = hje.execute_foundup_job(job).status.value
+            # Reset singleton between calls (workspace stays isolated).
+            hje._executor_singleton = None
+
+        assert statuses["validate_foundup"] == "SIMULATED"
+        assert statuses["build_foundup"] == "BLOCKED_BY_DESTRUCTIVE_ACTION_GUARD"
+        assert statuses["extract_foundup"] == "BLOCKED_BY_DESTRUCTIVE_ACTION_GUARD"
+
+
+# ===========================================================================
+# THE vertical proof: every acceptance item asserted in ONE invocation.
+# ===========================================================================
+
+
+class TestOperationalWREMonorepoPoCVerticalProof:
+    def test_full_dry_run_invocation_end_to_end(self, proof_foundup):
+        """One full dry-run invocation through the REAL create+drain seam.
+
+        Every acceptance item is asserted in this single run. The real-exec
+        sinks are mocked ONLY to prove they are never called; the seam itself
+        (create entry, drain entry, dispatch, executor, #786 consumer) runs
+        for real.
+        """
+        foundup_id = proof_foundup.foundup_id
+        expected_module_path = proof_foundup.module_path
+
+        # --- ACCEPTANCE: real-exec sinks must never fire THROUGH the seam. ---
+        # subprocess.* and the executor's real-delegate loader are patched and
+        # asserted not-called across the ENTIRE create+drain path. These are
+        # the only mocks; the seam is real.
+        with mock.patch("subprocess.Popen") as m_popen, \
+                mock.patch("subprocess.run") as m_run, \
+                mock.patch("subprocess.call") as m_call, \
+                mock.patch(
+                    "modules.infrastructure.wre_core.src.hermes_job_executor."
+                    "HermesJobExecutor._lazy_import_delegate_task",
+                    side_effect=AssertionError(
+                        "real delegate loader must not run in dry-run"
+                    ),
+                ) as m_delegate:
+
+            # --- ACCEPTANCE: the OpenClaw/WRE path CREATES a FoundUp job
+            #     (real entry, not mocked). ---
+            job = _create_via_real_openclaw_entry(foundup_id)
+            assert job.policy_flags.dry_run_mode is True
+            # The real create entry built the payload itself; it carries NO
+            # module_path -- so the resolver MUST derive it from the manifest.
+            assert "module_path" not in job.payload
+            assert "source_module" not in job.payload
+
+            # --- ACCEPTANCE: the OpenClaw/WRE path DRAINS the job
+            #     (real entry, not mocked). ---
+            result = _drain_via_real_wre_entry()
+
+            # The real-exec sinks were never reached on the dry-run path.
+            m_popen.assert_not_called()
+            m_run.assert_not_called()
+            m_call.assert_not_called()
+            m_delegate.assert_not_called()
+
+        # The drained result is the EXISTING typed receipt.
+        assert isinstance(result, ConsumerResult)
+        assert result.job_id == job.job_id
+        assert result.dispatched is True
+
+        # --- ACCEPTANCE: the existing dispatch seam took the DRY-RUN branch
+        #     (SIMULATED, real_execution_performed False). ---
+        assert result.checkpoint_state == "SIMULATED"
+        assert result.real_execution_performed is False
+
+        cb = result.context_bundle_dry_run
+        assert cb is not None, "dry-run evidence must attach on the dry-run branch"
+
+        # --- ACCEPTANCE: a ContextBundle is BUILT (#775) and the #786 consumer
+        #     RAN -> DryRunResult attached to the receipt. ---
+        # A populated DryRunResult (bundle_id + refs) proves both the #775
+        # build_context_bundle producer and the #786
+        # consume_context_bundle_dry_run consumer executed; an error
+        # projection would carry context_bundle_error instead.
+        assert "context_bundle_error" not in cb
+        assert cb["dry_run"] is True
+        assert cb["real_execution_performed"] is False
+        assert isinstance(cb.get("bundle_id"), str) and cb["bundle_id"]
+        assert isinstance(cb.get("consumer_version"), str) and cb["consumer_version"]
+
+        # --- ACCEPTANCE: DryRunResult is ATTACHED to ConsumerResult / receipt
+        #     and survives serialization (context_bundle_dry_run present). ---
+        receipt = result.to_dict()
+        assert receipt.get("context_bundle_dry_run") is not None
+        assert receipt["context_bundle_dry_run"]["source_authority"] == "monorepo_poc"
+
+        # --- ACCEPTANCE: source_authority == "monorepo_poc". ---
+        assert cb["source_authority"] == "monorepo_poc"
+
+        # --- ACCEPTANCE: module_path comes from the shared validated resolver
+        #     (== validated canonical, NOT the payload). ---
+        assert cb["resolved_module_path"] == expected_module_path
+        # The create entry put no module_path in the payload; observable-ignore
+        # confirms the resolver ran and trusted no payload candidate.
+        assert cb["rejected_input"]["resolver_run"] is True
+        assert cb["rejected_input"]["payload_module_path_ignored"] is None
+        assert cb["rejected_input"]["resolver_failed"] is False
+
+        # --- ACCEPTANCE: evidence_refs are refs + sha256 (+ size) ONLY. ---
+        refs = cb["evidence_refs"]
+        assert len(refs) >= 1
+        allowed_ref_keys = {"path", "sha256", "size_bytes", "role"}
+        for ref in refs:
+            assert set(ref.keys()) <= allowed_ref_keys, (
+                "evidence ref carries an unexpected key (possible body leak): "
+                + repr(set(ref.keys()) - allowed_ref_keys)
+            )
+            assert isinstance(ref["sha256"], str) and len(ref["sha256"]) == 64
+            assert isinstance(ref["size_bytes"], int)
+
+        # --- ACCEPTANCE: NO file bodies anywhere in the receipt. ---
+        # The body check covers the WHOLE receipt; no file body may appear
+        # anywhere in the serialized ConsumerResult.
+        receipt_blob = json.dumps(receipt)
+        for body_key in _FORBIDDEN_BODY_KEYS:
+            assert body_key not in receipt_blob, (
+                "file body leaked into receipt: " + body_key
+            )
+
+        # --- ACCEPTANCE: no gate-pass / pass-state key leaked into the
+        #     dry-run EVIDENCE. ---
+        # The pass-state scan targets the context_bundle_dry_run evidence blob
+        # (cb), NOT the whole ConsumerResult: the receipt legitimately carries
+        # the EXISTING WSP 97 truth fields (verification_complete / cabr_ready
+        # / payout_ready) -- all False -- which are truth boundaries, not
+        # pass-state. The dry-run evidence must never imply pass-state.
+        cb_blob = json.dumps(cb)
+        for forbidden in _FORBIDDEN_SERIALIZED_KEYS:
+            assert ('"' + forbidden + '"') not in cb_blob, (
+                "forbidden pass-state key leaked into dry-run evidence: "
+                + forbidden
+            )
+        # gates are NAMES to re-check, never pass-state booleans.
+        gates = cb["gates_to_recheck"]
+        assert isinstance(gates, list) and len(gates) >= 1
+        for gate in gates:
+            assert isinstance(gate, str) and not isinstance(gate, bool)
+
+        # --- ACCEPTANCE: readiness flags remain False. ---
+        readiness = cb["readiness_flags"]
+        assert len(readiness) >= 1
+        for name, value in readiness.items():
+            assert value is False, "readiness flag promoted: " + name
+
+        # --- ACCEPTANCE: the EXISTING WSP 97 truth fields stay False. ---
+        assert receipt["verification_complete"] is False
+        assert receipt["cabr_ready"] is False
+        assert receipt["payout_ready"] is False
+
+        # --- planned actions are declared-only, never executed. ---
+        for action in cb["planned_actions"]:
+            assert action["executed"] is False
+
+
+# ===========================================================================
+# NEGATIVE through the FULL seam: forged module_path fails end-to-end.
+# ===========================================================================
+
+
+class TestForgedModulePathFailsEndToEnd:
+    def test_forged_cross_foundup_module_path_rejected_via_seam(self, proof_foundup):
+        """A forged module_path on the queued job FAILS through the full seam.
+
+        A forged job arrives in the real OpenClaw queue carrying a
+        cross-FoundUp ``module_path``. Draining it through the REAL WRE entry
+        still reaches SIMULATED, but the shared resolver REJECTS the forged
+        path end-to-end: no preview is produced, the rejected value is
+        observable, and it is NEVER used as the resolved module_path.
+
+        Real-exec sinks are asserted not-called here too: rejection happens
+        on the dry-run path, never via real execution.
+        """
+        foundup_id = proof_foundup.foundup_id
+
+        with mock.patch("subprocess.Popen") as m_popen, \
+                mock.patch("subprocess.run") as m_run, \
+                mock.patch("subprocess.call") as m_call, \
+                mock.patch(
+                    "modules.infrastructure.wre_core.src.hermes_job_executor."
+                    "HermesJobExecutor._lazy_import_delegate_task",
+                    side_effect=AssertionError(
+                        "real delegate loader must not run in dry-run"
+                    ),
+                ) as m_delegate:
+
+            # Real create entry -> queued job for foundup_id.
+            job = _create_via_real_openclaw_entry(foundup_id)
+            # Forge a cross-FoundUp module_path on the queued job (a forged job
+            # landing in the queue). The shared resolver must reject it.
+            assert FORGED_OTHER_MODULE_PATH != proof_foundup.module_path
+            job.payload["module_path"] = FORGED_OTHER_MODULE_PATH
+
+            # Real drain entry over the queue.
+            result = _drain_via_real_wre_entry()
+
+            m_popen.assert_not_called()
+            m_run.assert_not_called()
+            m_call.assert_not_called()
+            m_delegate.assert_not_called()
+
+        # Seam still took the dry-run branch...
+        assert result.checkpoint_state == "SIMULATED"
+        assert result.real_execution_performed is False
+
+        cb = result.context_bundle_dry_run
+        assert cb is not None
+        # ...but the forged path was REJECTED by the shared resolver.
+        assert cb.get("context_bundle_error") == "module_path_resolution_failed"
+        assert cb.get("fail_token") == "cross_foundup_mismatch"
+        # The forged value is observable (never used as the resolved path).
+        assert cb.get("payload_module_path_ignored") == FORGED_OTHER_MODULE_PATH
+        assert cb.get("resolved_module_path") is None
+
+        # No file bodies anywhere in the receipt on the negative path.
+        receipt_blob = json.dumps(result.to_dict())
+        for body_key in _FORBIDDEN_BODY_KEYS:
+            assert body_key not in receipt_blob
+        # No pass-state key in the dry-run evidence blob (cb); the receipt's
+        # EXISTING WSP 97 truth fields are out of scope for this scan.
+        cb_blob = json.dumps(cb)
+        for forbidden in _FORBIDDEN_SERIALIZED_KEYS:
+            assert ('"' + forbidden + '"') not in cb_blob


### PR DESCRIPTION
## Preflight
- Base = origin/main = `c7839c2ab` (#787 dry-run runtime wiring); branch cut from that SHA; HEAD verified == `c7839c2ab...` at start.
- Re-searched open PRs / branches / worktrees for `operational-wre-monorepo-poc-vertical-proof` / `vertical-proof` / `monorepo-poc` -> none.
- Did NOT touch the allow-listed out-of-scope files (`.claude/settings.local.json`, `holo_index/docs/AGENT_CLI_CATALOG.md`, `holo_index/docs/command_rolodex.json`, `.claude/scheduled_tasks.lock`). Shared main HEAD never moved.

## Phase 0 -- the REAL create/drain path (file:line, base `c7839c2ab`)
HoloIndex (2 queries) surfaced the job contract/router/webhook but NOT `foundup_job_consumer.py` (missing-artifact gap); closed via glob + `git show c7839c2ab:<path>`.
- **REAL CREATE**: `modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py` -- `dispatch_foundup` (840) -> `_handle_build_intent` (914) -> `create_job` + `_FOUNDUP_JOB_QUEUE.append` (976); `get_job_queue` (230).
- **REAL DRAIN**: `modules/infrastructure/wre_core/src/foundup_job_consumer.py` -- `drain_openclaw_queue_with_retention` (858) -> `drain_jobs` (823) -> `consume_one` (370) -> `_dispatch_to_hermes` (424) -> `execute_foundup_job` (SIMULATED) -> `_attach_context_bundle_dry_run` (537) -> `ConsumerResult.context_bundle_dry_run` (188).
- **Dry-run branch**: `hermes_job_executor.py` `is_hermes_delegation_enabled` (92) -> SIMULATED (1767-1773).

The proof drives both real entries (`dispatch_foundup` enqueue + `drain_openclaw_queue_with_retention`); it does NOT mock the seam and does NOT call `consume_context_bundle_dry_run` in isolation.

## Asserted acceptance chain (one invocation)
real create + real drain; SIMULATED / `real_execution_performed False`; ContextBundle BUILT (#775); #786 consumer RAN; DryRunResult ATTACHED to `ConsumerResult`; `source_authority == monorepo_poc`; `resolved_module_path` from the shared validated resolver (== validated canonical `modules/foundups/gotjunk`, not payload); `evidence_refs` refs+sha256(+size+role) only; no file bodies; no live Hermes delegation (`HERMES_DELEGATE_ENABLED` unset; delegate loader `assert_not_called`); no subprocess/build execution (`Popen`/`run`/`call` `assert_not_called`); readiness all False. `validate_foundup` is the action that reaches SIMULATED (build/extract guard-blocked) -- asserted directly.

## gotjunk_001 parameterized
YES -- `proof_foundup` pytest fixture with `params=[(gotjunk_001, modules/foundups/gotjunk)]`; swap the param to run the whole proof for any safe monorepo_poc FoundUp.

## Negative forged-path end-to-end
YES -- a forged cross-FoundUp `module_path` (`modules/foundups/kosei` on a `gotjunk_001` job) is rejected through the FULL seam: `fail_token == cross_foundup_mismatch`, `resolved_module_path is None` (never used), observable in `payload_module_path_ignored`. Real-exec sinks `assert_not_called` here too.

## 0 production-code changes
`git diff --name-only c7839c2ab HEAD`:
- `modules/infrastructure/wre_core/tests/test_operational_wre_monorepo_poc_vertical_proof.py` (new)
- `docs/audits/architecture/OPERATIONAL_WRE_MONOREPO_POC_VERTICAL_PROOF_PHASE1.md` (new)
- `modules/infrastructure/wre_core/ModLog.md`
- `ModLog.md`

NONE of `foundup_job_consumer.py` / `hermes_job_executor.py` / `context_bundle_dry_run_consumer.py` / `context_bundle_builder.py` / `module_path_resolution.py` / `source_authority.py` / `foundup_manifest_validator.py`. New `.py`/`.md` 0 non-ASCII.

## Tests
New test 3 passed (0 skip/xfail). Broader wre_core consumer suite 58 passed (isolated worktree).

## WSP_97
20/20 YES (see proof doc table). Type: VERTICAL PROOF; dry-run path only; no real execution; live-delegation boundary intact and BLOCKED.

DO NOT MERGE -- hold for W10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
