### PR TITLE
docs(architecture): rename multi-agent audit WSP_->WRE_ to free WSP_ namespace (W6)

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -1,5 +1,27 @@
 # FoundUps Agent - Development Log
 
+## [2026-06-13] WRE Multi-Agent Audit Filename Alignment Phase 1 (W6, docs-only rename)
+
+**Change Type**: DOCS-ONLY rename + reference alignment. NO code, NO tests, NO runtime change.
+NO analytical-content rewrite.
+**By**: 0102 (W6, Worker-Lane A) | Commander: 012 | Reviewer: W10
+**WSP References**: WSP 22, WSP 50, WSP 57
+**Slice**: WRE_MULTI_AGENT_AUDIT_FILENAME_ALIGNMENT_PHASE1
+**Base**: `99426435ba4d5ddbcee0eac6f38fbe5e16c01ea3` (origin/main)
+
+- RENAME `docs/audits/architecture/WSP_MULTI_AGENT_EVOLUTION_AUDIT_PHASE1.md` ->
+  `docs/audits/architecture/WRE_MULTI_AGENT_EVOLUTION_AUDIT_PHASE1.md` (git rename R, history
+  preserved). The `WSP_` prefix falsely implied a WSP framework/protocol artifact; `WSP_` is reserved
+  for actual WSP protocol artifacts (WSP 57). This is an architecture audit, so the correct prefix is
+  `WRE_`.
+- ALIGN 4 references to the token `WRE_MULTI_AGENT_EVOLUTION_AUDIT_PHASE1`: the renamed audit doc's
+  H1 title + Slice line + self-referential token; the wre_master_orchestrator ROADMAP anchor link;
+  this root ModLog (the #791 entry's Slice/path mentions); and the sibling
+  WRE_MULTI_AGENT_CONCURRENCY_RISK_CONFIRMATION_PHASE1 parent reference.
+- Identity-only change: filename, H1 title, Slice line, reference links/tokens. NO analytical
+  sentence, finding, classification, or WSP_97 table cell substance altered. NO WSP_framework /
+  WSP_knowledge / NAVIGATION.py / holo_index catalog change.
+
 ## [2026-06-13] WRE Multi-Agent Concurrency Risk Confirmation Phase 1 (W9, decision-only)
 
 **Change Type**: DECISION-ONLY confirmation audit. NO src change, NO fix, NO committed test.
@@ -44,10 +66,10 @@ research, with a gap matrix, a critic-clean blueprint, and an ordered roadmap.
 Concurrency risks are DOCUMENTED, NOT FIXED.
 **By**: 0102 (W9, Worker-Lane A) | Commander: 012 | Reviewer: W10
 **WSP References**: WSP 22, WSP 50, WSP 65, WSP 77, WSP 97
-**Slice**: WSP_MULTI_AGENT_EVOLUTION_AUDIT_PHASE1
+**Slice**: WRE_MULTI_AGENT_EVOLUTION_AUDIT_PHASE1
 **Base**: `3339d34c48a0b98e18c2996d5e3dd74354108bb8` (origin/main)
 
-- NEW `docs/audits/architecture/WSP_MULTI_AGENT_EVOLUTION_AUDIT_PHASE1.md`. Ten
+- NEW `docs/audits/architecture/WRE_MULTI_AGENT_EVOLUTION_AUDIT_PHASE1.md`. Ten
   deliverables: executive summary, WSP_97 truth-boundary report (13 load-bearing
   repo claims re-verified via `git show 3339d34c4:<path>`), architecture map,
   web-verified external comparison (6 systems), 16-row gap matrix, 15-component

--- a/docs/audits/architecture/WRE_MULTI_AGENT_CONCURRENCY_RISK_CONFIRMATION_PHASE1.md
+++ b/docs/audits/architecture/WRE_MULTI_AGENT_CONCURRENCY_RISK_CONFIRMATION_PHASE1.md
@@ -5,7 +5,7 @@
 - Method: WSP_00 (Zen State) / WSP_50 (pre-action verification) / WSP_97 (Truth Boundary) / COTCAR
 - Status: DECISION-ONLY confirmation. NO src change, NO fix, NO committed test.
 - Worker-Lane: A (W9)
-- Parent: docs/audits/architecture/WSP_MULTI_AGENT_EVOLUTION_AUDIT_PHASE1.md (documented these two
+- Parent: docs/audits/architecture/WRE_MULTI_AGENT_EVOLUTION_AUDIT_PHASE1.md (documented these two
   races as "DOCUMENTED, NOT FIXED" and named this slice as the first execution follow-up).
 
 ---

--- a/docs/audits/architecture/WRE_MULTI_AGENT_EVOLUTION_AUDIT_PHASE1.md
+++ b/docs/audits/architecture/WRE_MULTI_AGENT_EVOLUTION_AUDIT_PHASE1.md
@@ -1,6 +1,6 @@
-# WSP Multi-Agent Evolution Audit -- Phase 1 (Decision-Only)
+# WRE Multi-Agent Evolution Audit -- Phase 1 (Decision-Only)
 
-- Slice: WSP_MULTI_AGENT_EVOLUTION_AUDIT_PHASE1
+- Slice: WRE_MULTI_AGENT_EVOLUTION_AUDIT_PHASE1
 - Base SHA: 3339d34c4
 - Method: WSP_00 (Zen State) / WSP_50 (pre-action verification) / WSP_97 (Truth Boundary) / COTCAR
 - Status: decision-only architecture audit. NO runtime / source / test changes. No fixes.
@@ -377,4 +377,4 @@ Declared rows: 11
 | 8 | NO_NAVIGATION_CHANGE | YES | NAVIGATION.py not touched; out of scope this slice; git diff confirms it is not in the changed set |
 | 9 | NO_HOLOINDEX_ARTIFACTS_COMMITTED | YES | No HoloIndex DB/index, AGENT_CLI_CATALOG.md, command_rolodex.json, or .claude/** staged; only the three in-scope docs |
 | 10 | ASCII_CLEAN | YES | Audit doc byte-checked NON_ASCII 0; ROADMAP added lines and ModLog entry contain 0 non-ASCII bytes |
-| 11 | FILE_SCOPE_EXACTLY_THREE | YES | git diff --cached --name-only = exactly docs/audits/architecture/WSP_MULTI_AGENT_EVOLUTION_AUDIT_PHASE1.md, modules/infrastructure/wre_core/wre_master_orchestrator/ROADMAP.md, ModLog.md |
+| 11 | FILE_SCOPE_EXACTLY_THREE | YES | git diff --cached --name-only = exactly docs/audits/architecture/WRE_MULTI_AGENT_EVOLUTION_AUDIT_PHASE1.md, modules/infrastructure/wre_core/wre_master_orchestrator/ROADMAP.md, ModLog.md |

--- a/modules/infrastructure/wre_core/wre_master_orchestrator/ROADMAP.md
+++ b/modules/infrastructure/wre_core/wre_master_orchestrator/ROADMAP.md
@@ -20,7 +20,7 @@ Grounded current state: WREMasterOrchestrator declares "THE orchestrator" but is
 FoundUpJob seam (grep FoundUpJob/drain/_FOUNDUP_JOB_QUEUE in this module = ZERO); 4-5 competing
 orchestrators run as peers; thread-safety is accidental (worktree process isolation + GIL, not
 guaranteed in-process). Full evidence and blueprint:
-[docs/audits/architecture/WSP_MULTI_AGENT_EVOLUTION_AUDIT_PHASE1.md](../../../../docs/audits/architecture/WSP_MULTI_AGENT_EVOLUTION_AUDIT_PHASE1.md)
+[docs/audits/architecture/WRE_MULTI_AGENT_EVOLUTION_AUDIT_PHASE1.md](../../../../docs/audits/architecture/WRE_MULTI_AGENT_EVOLUTION_AUDIT_PHASE1.md)
 Ordered next slices:
 1. WRE_MULTI_AGENT_CONCURRENCY_RISK_CONFIRMATION_PHASE1 (confirm queue TOCTOU + policy_flags race vs current main)
 2. queue-ownership consolidation (OpenClaw PUSH only; consumer sole drainer/remover)


### PR DESCRIPTION
## Summary
Docs-only rename + reference alignment. NO code, NO tests, NO analytical-content rewrite.

The architecture audit was mis-prefixed `WSP_`, which falsely implies a WSP framework/protocol artifact. Per **WSP 57**, the `WSP_` prefix is reserved for actual WSP protocol artifacts. This is an architecture audit, so the correct prefix is `WRE_`. This frees the `WSP_` namespace and removes the false protocol implication.

## What changed (namespace identity only)
- **RENAME (git R, history preserved)** `docs/audits/architecture/WSP_MULTI_AGENT_EVOLUTION_AUDIT_PHASE1.md` -> `docs/audits/architecture/WRE_MULTI_AGENT_EVOLUTION_AUDIT_PHASE1.md`
- In the renamed doc: H1 title, `Slice:` line, and the one self-referential token (WSP_97 FILE_SCOPE row) -- identity swaps only.
- `modules/infrastructure/wre_core/wre_master_orchestrator/ROADMAP.md` -- anchor link path swap.
- `ModLog.md` -- #791 entry Slice/path token swap, plus ONE new dated entry for this rename slice.
- `docs/audits/architecture/WRE_MULTI_AGENT_CONCURRENCY_RISK_CONFIRMATION_PHASE1.md` -- parent reference swap.

## Scope (4 files)
`git diff --name-status` vs base = `R099` (rename) + 3x `M`. Nothing else.

## Guarantees
- NO analytical sentence, finding, classification, or WSP_97 table-cell substance altered (rename-aware diff = similarity 99%, only H1 + Slice + self-token changed).
- NO `WSP_framework/**`, `WSP_knowledge/**`, `NAVIGATION.py`, or holo_index catalog (`AGENT_CLI_CATALOG.md` / `command_rolodex.json`) change.
- NO `.py` / test changes.
- ASCII-clean: 0 non-ASCII bytes in all changed/added lines.

Base: `99426435ba4d5ddbcee0eac6f38fbe5e16c01ea3`
Worker-Lane: A | Slice: WRE_MULTI_AGENT_AUDIT_FILENAME_ALIGNMENT_PHASE1

🤖 Generated with [Claude Code](https://claude.com/claude-code)