### PR TITLE
fix(youtube_auth): per-set OAuth browser resolver with env+fallback paths (Phase 1)

### DIFF
--- a/modules/platform_integration/youtube_auth/INTERFACE.md
+++ b/modules/platform_integration/youtube_auth/INTERFACE.md
@@ -6,6 +6,8 @@ The YouTube Authentication module handles OAuth 2.0 authentication with the YouT
 ## Exports
 This module exports:
 - `get_authenticated_service`: Function to authenticate and obtain a YouTube API service object
+- `oauth_browser.resolve_browser_for_set`: Resolve the per-set OAuth browser executable
+- `oauth_browser.BrowserNotFoundError`: Raised when no browser executable can be resolved for a set
 
 ## Functions
 
@@ -27,12 +29,38 @@ Authenticates the user with YouTube API using OAuth 2.0 and returns a YouTube AP
 - Falls back to the next credential set if authentication fails or quota is exceeded
 - Raises an exception if all credential sets fail
 
+## oauth_browser (per-set OAuth browser resolution)
+
+`src/oauth_browser.py` is the single source of truth for which browser
+executable the OAuth consent flow opens per credential set. It centralizes the
+candidate-path ordering that previously lived (and drifted) inline in
+youtube_auth.py and in the authorize_setN.py scripts.
+
+### `resolve_browser_for_set(set_id: int) -> tuple[str, str]`
+Returns `(browser_name, executable_path)` for a credential set.
+
+- `set_id == 1` -> `browser_name == "chrome"`; candidate order (first existing wins):
+  `CHROME_PATH` env, then 64-bit Chrome, then x86 Chrome (mirrors `authorize_set1.py`).
+- `set_id == 10` -> `browser_name == "edge"`; candidate order:
+  `EDGE_PATH` env, then 64-bit Edge, then x86 Edge (mirrors `authorize_set10.py`).
+- Raises `BrowserNotFoundError` if no candidate exists, or if `set_id` is unknown.
+
+### `class BrowserNotFoundError(Exception)`
+Carries operator-actionable context:
+- `set_id`: the credential set that failed resolution.
+- `attempted_paths`: concrete candidate paths that were checked (unset env vars skipped).
+- `operator_action`: the exact reauth command from `oauth_health.reauth_command_for(set_id)`.
+
 ## Environment Variables
 The module requires the following environment variables to be set:
 
 - `YOUTUBE_SCOPES`: Space-separated list of OAuth scopes required
 - `GOOGLE_CLIENT_SECRETS_FILE_1` through `GOOGLE_CLIENT_SECRETS_FILE_4`: Paths to client secrets files
 - `OAUTH_TOKEN_FILE_1` through `OAUTH_TOKEN_FILE_4`: Paths to token files for credential storage
+
+Optional (used by `oauth_browser.resolve_browser_for_set`):
+- `CHROME_PATH`: Override the Chrome executable used for set 1 OAuth.
+- `EDGE_PATH`: Override the Edge executable used for set 10 OAuth.
 
 ## Usage Example
 ```python

--- a/modules/platform_integration/youtube_auth/ModLog.md
+++ b/modules/platform_integration/youtube_auth/ModLog.md
@@ -12,6 +12,57 @@ This log tracks changes specific to the **youtube_auth** module in the **platfor
 
 ## MODLOG ENTRIES
 
+### 2026-06-15 - YT-OAUTH-BROWSER-RESOLVER-PHASE1: Per-set OAuth browser resolver
+
+**By:** 0102 (Worker P1)
+**Slice:** YT-OAUTH-BROWSER-RESOLVER-PHASE1
+**WSP References:** WSP 22 (ModLog), WSP 50 (Pre-Action Verification), WSP 84 (Code Reuse / single source of truth), WSP 97 (Truth Signaling)
+
+**Problem:**
+- `youtube_auth.py` hardcoded browser executable paths inline in TWO places
+  (`get_authenticated_service()` OAuth block and `preflight_oauth_check()`
+  auto-reauth block). No `CHROME_PATH`/`EDGE_PATH` env override and no
+  32/64-bit fallback. The inline set 10 path also pointed only at the x86 Edge
+  location, drifting from `authorize_set10.py` (which checks env, 64-bit, x86).
+- The authorize scripts (`authorize_set1.py`, `authorize_set10.py`) already had
+  the richer candidate ordering, so the same logic existed twice and diverged.
+
+**Changes:**
+- **Added** `src/oauth_browser.py`:
+  - `resolve_browser_for_set(set_id) -> (browser_name, executable_path)`.
+    Set 1 -> "chrome" (CHROME_PATH, 64-bit, x86); set 10 -> "edge"
+    (EDGE_PATH, 64-bit, x86). Candidate order EXACTLY mirrors the authorize
+    scripts. Returns the first path that `os.path.exists()`.
+  - `class BrowserNotFoundError(Exception)` carrying `set_id`,
+    `attempted_paths`, and `operator_action` (from
+    `oauth_health.reauth_command_for(set_id)`). Unknown `set_id` raises it too.
+  - Import-light: only `os` at load; `oauth_health` imported lazily inside the
+    error path to avoid import cycles.
+- **Refactored** `src/youtube_auth.py`: both inline browser-path blocks now call
+  `resolve_browser_for_set(index)`, verify `os.path.exists` before
+  `subprocess.Popen`, and on `BrowserNotFoundError` log CRITICAL with the
+  operator_action then follow the surrounding block's existing error contract
+  (OAuth block re-raises into its `except ... continue`; auto-reauth block
+  `continue`s to the next set). No browser path string literals remain in
+  either block.
+- **Tests** `tests/test_oauth_browser.py` (no network, mocks `os.path.exists`/env):
+  `test_resolve_browser_set1_prefers_chrome_path_env`,
+  `test_resolve_browser_set10_prefers_edge_path_env`,
+  `test_missing_browser_raises_with_reauth_command`, plus fallback-order and
+  unknown-set coverage. 6 passed.
+- **Docs**: INTERFACE.md documents the new exports and the CHROME_PATH/EDGE_PATH
+  env overrides.
+
+**Scope (Phase 1):** browser executable path resolution only. Out of scope:
+menu wiring, OAUTH port parity, `run_local_server(port=0)`, invalid_grant
+rotation/fallback, exhausted_sets logic (separate PRs build on this).
+
+**Verification:**
+```
+python -m pytest modules/platform_integration/youtube_auth/tests/test_oauth_browser.py
+# 6 passed
+```
+
 ### 2026-05-01 - OC21: WSP 97 Truth Violation + Operations KeyError Fix
 
 **By:** 0102 (Worker AW3)

--- a/modules/platform_integration/youtube_auth/src/oauth_browser.py
+++ b/modules/platform_integration/youtube_auth/src/oauth_browser.py
@@ -1,0 +1,151 @@
+"""
+Per-set OAuth browser executable resolution (WSP 84 single source of truth).
+
+The OAuth consent flow must open a SPECIFIC browser per credential set so the
+operator lands in the right Google profile:
+
+    - Set 1  -> Chrome (UnDaoDu / Move2Japan account)
+    - Set 10 -> Edge   (FoundUps / antifaFM account)
+
+Historically the browser executable path was hardcoded inline in
+youtube_auth.py (one literal per browser, no env override, no 32/64-bit
+fallback), while authorize_set1.py / authorize_set10.py used a richer
+candidate order (env var, then 64-bit, then x86). That duplication drifted:
+the inline Set 10 path pointed at the x86 Edge location only.
+
+This module centralizes the candidate ordering so there is ONE place that
+decides which executable to launch. The order EXACTLY mirrors the authorize
+scripts:
+
+    Set 1  (Chrome): CHROME_PATH env, 64-bit Chrome, x86 Chrome
+    Set 10 (Edge):   EDGE_PATH   env, 64-bit Edge,   x86 Edge
+
+Import-light by design: only `os` at module load. The dependency on
+oauth_health.reauth_command_for is imported lazily inside the error path to
+avoid any import-cycle risk.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import List, Optional, Tuple
+
+# Candidate executable paths per credential set, in resolution order.
+# These MUST mirror authorize_set1.py / authorize_set10.py exactly.
+# The env-var slot is represented by its variable NAME; it is resolved at
+# call time so tests and operators can override via the environment.
+_CHROME_CANDIDATES = (
+    ("env", "CHROME_PATH"),
+    ("literal", r"C:\Program Files\Google\Chrome\Application\chrome.exe"),
+    ("literal", r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe"),
+)
+
+_EDGE_CANDIDATES = (
+    ("env", "EDGE_PATH"),
+    ("literal", r"C:\Program Files\Microsoft\Edge\Application\msedge.exe"),
+    ("literal", r"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe"),
+)
+
+# set_id -> (browser_name, candidate tuple)
+_SET_BROWSER = {
+    1: ("chrome", _CHROME_CANDIDATES),
+    10: ("edge", _EDGE_CANDIDATES),
+}
+
+
+class BrowserNotFoundError(Exception):
+    """
+    Raised when no browser executable can be resolved for a credential set.
+
+    Carries enough context for an operator to act:
+        set_id          -- the credential set we tried to resolve a browser for
+        attempted_paths -- the concrete candidate paths checked (in order)
+        operator_action -- the exact reauth command to run (from oauth_health),
+                           or a generic hint for unknown sets
+    """
+
+    def __init__(
+        self,
+        set_id: int,
+        attempted_paths: List[str],
+        operator_action: str,
+        message: Optional[str] = None,
+    ) -> None:
+        self.set_id = set_id
+        self.attempted_paths = attempted_paths
+        self.operator_action = operator_action
+        if message is None:
+            message = (
+                f"No browser executable found for credential set {set_id}. "
+                f"Attempted: {attempted_paths}. Operator action: {operator_action}"
+            )
+        super().__init__(message)
+
+
+def _operator_action_for(set_id: int) -> str:
+    """Lazy import of oauth_health to avoid import cycles at module load."""
+    from modules.platform_integration.youtube_auth.src.oauth_health import (
+        reauth_command_for,
+    )
+
+    return reauth_command_for(set_id)
+
+
+def _resolve_candidates(candidates) -> Tuple[Optional[str], List[str]]:
+    """
+    Walk candidate specs in order, returning (first_existing_path, attempted).
+
+    `attempted` lists the concrete paths we actually checked (env vars resolved
+    to their value, unset env vars skipped) so the error message is truthful.
+    """
+    attempted: List[str] = []
+    for kind, value in candidates:
+        if kind == "env":
+            path = os.getenv(value)
+            if not path:
+                continue
+        else:
+            path = value
+        attempted.append(path)
+        if os.path.exists(path):
+            return path, attempted
+    return None, attempted
+
+
+def resolve_browser_for_set(set_id: int) -> Tuple[str, str]:
+    """
+    Resolve (browser_name, executable_path) for an OAuth credential set.
+
+    Args:
+        set_id: credential set id (1 -> Chrome, 10 -> Edge).
+
+    Returns:
+        (browser_name, executable_path) where executable_path is the first
+        candidate that os.path.exists().
+
+    Raises:
+        BrowserNotFoundError: if the set is unknown, or no candidate path
+            exists on this machine. The exception carries the operator_action
+            (reauth command) so callers can log it and operators can act.
+    """
+    entry = _SET_BROWSER.get(set_id)
+    if entry is None:
+        raise BrowserNotFoundError(
+            set_id=set_id,
+            attempted_paths=[],
+            operator_action=_operator_action_for(set_id),
+            message=(
+                f"Unknown credential set {set_id}: no browser mapping defined "
+                f"(known sets: {sorted(_SET_BROWSER)})."
+            ),
+        )
+
+    browser_name, candidates = entry
+    path, attempted = _resolve_candidates(candidates)
+    if path is None:
+        raise BrowserNotFoundError(
+            set_id=set_id,
+            attempted_paths=attempted,
+            operator_action=_operator_action_for(set_id),
+        )
+    return browser_name, path

--- a/modules/platform_integration/youtube_auth/src/youtube_auth.py
+++ b/modules/platform_integration/youtube_auth/src/youtube_auth.py
@@ -227,21 +227,44 @@ def get_authenticated_service(token_index=None):
                 try:
                     import webbrowser
                     import subprocess
+                    from modules.platform_integration.youtube_auth.src.oauth_browser import (
+                        resolve_browser_for_set,
+                        BrowserNotFoundError,
+                    )
 
-                    # Browser selection based on credential set
+                    # Browser selection based on credential set (WSP 84: single
+                    # source of truth in oauth_browser.resolve_browser_for_set).
                     # Set 1 = UnDaoDu/Move2Japan = Chrome
                     # Set 10 = FoundUps/antifaFM = Edge
-                    if index == 1:
-                        browser_name = "Chrome"
-                        browser_path = r"C:\Program Files\Google\Chrome\Application\chrome.exe"
-                    else:  # Set 10
-                        browser_name = "Edge"
-                        browser_path = r"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe"
+                    try:
+                        browser_name, browser_path = resolve_browser_for_set(index)
+                    except BrowserNotFoundError as browser_err:
+                        logger.critical(
+                            f"[BROWSER] Cannot launch OAuth for set {index}: "
+                            f"{browser_err}. Operator action: {browser_err.operator_action}"
+                        )
+                        raise
 
                     logger.info(f"[BROWSER] Set {index} will use {browser_name.upper()} for OAuth")
                     print(f"\n[IMPORTANT] Opening {browser_name.upper()} for Set {index} authentication")
                     print(f"  - Set 1: Chrome (UnDaoDu/Move2Japan account)")
                     print(f"  - Set 10: Edge (FoundUps/antifaFM account)\n")
+
+                    # Verify the resolved executable before launching. The
+                    # resolver already checked existence, but re-verify here so
+                    # a removed binary surfaces a CRITICAL operator action
+                    # rather than an opaque Popen failure.
+                    if not os.path.exists(browser_path):
+                        action = oauth_health.reauth_command_for(index)
+                        logger.critical(
+                            f"[BROWSER] Resolved browser for set {index} no longer "
+                            f"exists at {browser_path}. Operator action: {action}"
+                        )
+                        raise BrowserNotFoundError(
+                            set_id=index,
+                            attempted_paths=[browser_path],
+                            operator_action=action,
+                        )
 
                     # Override webbrowser.open to use the correct browser
                     original_open = webbrowser.open
@@ -565,15 +588,26 @@ def preflight_oauth_check(auto_reauth: bool = False, credential_sets=None) -> di
                 )
 
                 if auto_reauth:
-                    # Determine correct browser based on credential set
+                    # Determine correct browser based on credential set (WSP 84:
+                    # single source of truth in oauth_browser).
                     # Set 1 = UnDaoDu/Move2Japan = Chrome
                     # Set 10 = FoundUps/antifaFM = Edge
-                    if index == 1:
-                        browser_name = "Chrome"
-                        browser_path = r"C:\Program Files\Google\Chrome\Application\chrome.exe"
-                    else:  # Set 10
-                        browser_name = "Edge"
-                        browser_path = r"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe"
+                    from modules.platform_integration.youtube_auth.src.oauth_browser import (
+                        resolve_browser_for_set,
+                        BrowserNotFoundError,
+                    )
+
+                    try:
+                        browser_name, browser_path = resolve_browser_for_set(index)
+                    except BrowserNotFoundError as browser_err:
+                        logger.critical(
+                            f"[PREFLIGHT] Cannot auto-reauth set {index}: "
+                            f"{browser_err}. Operator action: {browser_err.operator_action}"
+                        )
+                        # Consistent with this block's error contract: do not
+                        # crash preflight; the set stays in 'expired' and the
+                        # operator_action was logged at CRITICAL above.
+                        continue
 
                     logger.info(f"[PREFLIGHT] Auto-reauth for set {index} - USE {browser_name.upper()}!")
                     print(f"\n{'='*60}")
@@ -585,6 +619,21 @@ def preflight_oauth_check(auto_reauth: bool = False, credential_sets=None) -> di
                     try:
                         import webbrowser
                         import subprocess
+
+                        # Re-verify the resolved executable before launching so a
+                        # removed binary surfaces a CRITICAL operator action
+                        # rather than an opaque Popen failure.
+                        if not os.path.exists(browser_path):
+                            action = oauth_health.reauth_command_for(index)
+                            logger.critical(
+                                f"[PREFLIGHT] Resolved browser for set {index} no longer "
+                                f"exists at {browser_path}. Operator action: {action}"
+                            )
+                            raise BrowserNotFoundError(
+                                set_id=index,
+                                attempted_paths=[browser_path],
+                                operator_action=action,
+                            )
 
                         # Override webbrowser.open to use the correct browser
                         original_open = webbrowser.open

--- a/modules/platform_integration/youtube_auth/tests/test_oauth_browser.py
+++ b/modules/platform_integration/youtube_auth/tests/test_oauth_browser.py
@@ -1,0 +1,105 @@
+"""
+No-network unit tests for per-set OAuth browser resolution (WSP 84 / WSP 97).
+
+Covers:
+    - Set 1 prefers CHROME_PATH env when it exists (mirrors authorize_set1.py)
+    - Set 10 prefers EDGE_PATH env when it exists (mirrors authorize_set10.py)
+    - No browser present -> BrowserNotFoundError carrying the exact reauth command
+
+All filesystem and environment access is mocked; nothing is launched and no
+network call is made.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from modules.platform_integration.youtube_auth.src import oauth_browser
+from modules.platform_integration.youtube_auth.src import oauth_health
+from modules.platform_integration.youtube_auth.src.oauth_browser import (
+    BrowserNotFoundError,
+    resolve_browser_for_set,
+)
+
+
+def test_resolve_browser_set1_prefers_chrome_path_env():
+    """Set 1 returns ('chrome', $CHROME_PATH) when CHROME_PATH exists first."""
+    env_chrome = r"D:\custom\chrome.exe"
+    with patch.dict("os.environ", {"CHROME_PATH": env_chrome}, clear=False):
+        # Only the env path "exists" -> it must win over the hardcoded fallbacks.
+        with patch("os.path.exists", side_effect=lambda p: p == env_chrome):
+            name, path = resolve_browser_for_set(1)
+    assert name == "chrome"
+    assert path == env_chrome
+
+
+def test_resolve_browser_set1_falls_back_to_64bit_then_x86():
+    """Set 1 candidate order exactly mirrors authorize_set1.py."""
+    sixtyfour = r"C:\Program Files\Google\Chrome\Application\chrome.exe"
+    x86 = r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe"
+
+    # No env var; only 64-bit exists -> 64-bit chosen.
+    with patch.dict("os.environ", {}, clear=True):
+        with patch("os.path.exists", side_effect=lambda p: p == sixtyfour):
+            name, path = resolve_browser_for_set(1)
+    assert (name, path) == ("chrome", sixtyfour)
+
+    # No env var, no 64-bit; only x86 exists -> x86 chosen last.
+    with patch.dict("os.environ", {}, clear=True):
+        with patch("os.path.exists", side_effect=lambda p: p == x86):
+            name, path = resolve_browser_for_set(1)
+    assert (name, path) == ("chrome", x86)
+
+
+def test_resolve_browser_set10_prefers_edge_path_env():
+    """Set 10 returns ('edge', $EDGE_PATH) when EDGE_PATH exists first."""
+    env_edge = r"D:\custom\msedge.exe"
+    with patch.dict("os.environ", {"EDGE_PATH": env_edge}, clear=False):
+        with patch("os.path.exists", side_effect=lambda p: p == env_edge):
+            name, path = resolve_browser_for_set(10)
+    assert name == "edge"
+    assert path == env_edge
+
+
+def test_resolve_browser_set10_falls_back_to_64bit_then_x86():
+    """Set 10 candidate order exactly mirrors authorize_set10.py."""
+    sixtyfour = r"C:\Program Files\Microsoft\Edge\Application\msedge.exe"
+    x86 = r"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe"
+
+    with patch.dict("os.environ", {}, clear=True):
+        with patch("os.path.exists", side_effect=lambda p: p == sixtyfour):
+            name, path = resolve_browser_for_set(10)
+    assert (name, path) == ("edge", sixtyfour)
+
+    with patch.dict("os.environ", {}, clear=True):
+        with patch("os.path.exists", side_effect=lambda p: p == x86):
+            name, path = resolve_browser_for_set(10)
+    assert (name, path) == ("edge", x86)
+
+
+def test_missing_browser_raises_with_reauth_command():
+    """No candidate exists -> BrowserNotFoundError with exact reauth command."""
+    with patch.dict("os.environ", {}, clear=True):
+        with patch("os.path.exists", return_value=False):
+            with pytest.raises(BrowserNotFoundError) as exc_info:
+                resolve_browser_for_set(1)
+
+    err = exc_info.value
+    assert err.set_id == 1
+    # operator_action must be the canonical oauth_health reauth command.
+    assert err.operator_action == oauth_health.reauth_command_for(1)
+    assert "authorize_set1.py" in err.operator_action
+    # attempted_paths records the concrete fallbacks we checked (env unset -> skipped).
+    assert any("chrome.exe" in p for p in err.attempted_paths)
+
+
+def test_unknown_set_raises_browser_not_found():
+    """Unknown set_id is an explicit, tested error (not a silent default)."""
+    with pytest.raises(BrowserNotFoundError) as exc_info:
+        resolve_browser_for_set(999)
+    err = exc_info.value
+    assert err.set_id == 999
+    assert err.operator_action == oauth_health.reauth_command_for(999)
+    assert err.attempted_paths == []


### PR DESCRIPTION
## Summary (decision-for-gate -- do NOT self-merge)

Phase 1 of the YouTube OAuth browser hardening series. Centralizes per-set
OAuth browser executable resolution into a single source of truth so the two
previously-divergent inline hardcoded path blocks in `youtube_auth.py` no
longer drift from the `authorize_setN.py` scripts.

This is a **worker PR left OPEN for an external gate**. Do not self-merge.

## Scope (exactly 5 files)

- **NEW** `src/oauth_browser.py`
  - `resolve_browser_for_set(set_id) -> (browser_name, executable_path)`
    - set 1  -> "chrome": candidates `CHROME_PATH` env, 64-bit Chrome, x86 Chrome
    - set 10 -> "edge":   candidates `EDGE_PATH` env, 64-bit Edge, x86 Edge
    - returns the first path that `os.path.exists()`; candidate order EXACTLY
      mirrors `authorize_set1.py` / `authorize_set10.py`.
  - `class BrowserNotFoundError(Exception)` carrying `set_id`, `attempted_paths`,
    and `operator_action` (from `oauth_health.reauth_command_for(set_id)`).
    Unknown `set_id` raises it too.
  - Import-light (only `os` at load; `oauth_health` imported lazily inside the
    error path to avoid an import cycle).
- **MODIFIED** `src/youtube_auth.py`
  - Both inline browser-path blocks (`get_authenticated_service()` OAuth block
    and `preflight_oauth_check()` auto-reauth block) now call
    `resolve_browser_for_set(index)`, verify `os.path.exists` before
    `subprocess.Popen`, and on `BrowserNotFoundError` log CRITICAL with the
    operator_action then follow each block's existing error contract (OAuth
    block re-raises into its `except ... continue`; auto-reauth block
    `continue`s to the next set). No browser path string literals remain.
- **NEW** `tests/test_oauth_browser.py` (no network; mocks `os.path.exists`/env)
- **MODIFIED** `INTERFACE.md`, `ModLog.md` (document exports + env overrides)

## Tests

```
python -m pytest modules/platform_integration/youtube_auth/tests/test_oauth_browser.py
6 passed
```

Includes the 3 required cases:
- `test_resolve_browser_set1_prefers_chrome_path_env`
- `test_resolve_browser_set10_prefers_edge_path_env`
- `test_missing_browser_raises_with_reauth_command`

plus fallback-order (64-bit then x86) and unknown-set coverage.

## Out of scope (separate PRs build on this)

menu wiring, OAUTH port parity, `run_local_server(port=0)`, invalid_grant
rotation/fallback, `get_authenticated_service` exhausted_sets logic. PR2/PR3
will build on this resolver.

## Security

Browser executable PATH resolution only. No secret material touched; no token
files read; no credentials printed/logged/committed.

## WSP

WSP_00, WSP_22, WSP_50, WSP_84 (single source of truth), WSP_97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
### HoloIndex Retrieval Report (backfilled 2026-06-15; pre-contract worker, queries run retroactively)
| # | Query | Hits | Top result | Quality | Used? |
|---|-------|------|------------|---------|-------|
| 1 | oauth browser resolver chrome edge executable path fallback | 19 | modules/infrastructure/browser_actions/src/action_router.py | LOW | N |
| 2 | youtube auth credential set browser launch subprocess popen | 20 | modules/infrastructure/browser_actions/src/youtube_actions.py | LOW | N |
| 3 | resolve browser for set BrowserNotFoundError reauth command | 20 | modules/infrastructure/foundups_selenium/src/browser_manager.py | LOW | N |

### Retrieval verdict
- HoloIndex did NOT surface the edit targets. Hits biased to browser-automation/selenium modules; youtube_auth.py was not returned and oauth_browser.py is net-new (unindexable pre-merge).
- action: relied on architect-pre-verified direct reads (youtube_auth.py:236/239/573/576; authorize_set1.py:36-38 / authorize_set10.py:37-39; oauth_health.py reauth_command_for/SET_METADATA).

### Attention flags (012 triage)
- [x] NEEDS_012: HoloIndex miss - relied on direct path reads (pre-contract worker)
- [ ] NEEDS_012: merge / OAuth browser / secrets (no secrets touched; browser-path resolution only)
- [ ] NEEDS_012: test failure / worktree integrity / quota drift (6 tests pass; no conflict markers; syntax OK; scope = 5 files)
- [x] Stopped at VERIFIED_READY - sovereign merge only (auth/runtime)
