### PR TITLE
fix(youtube_auth): no silent Set-10 fallback for a pinned credential set (Phase 1)

### DIFF
--- a/modules/communication/livechat/src/auto_moderator_dae.py
+++ b/modules/communication/livechat/src/auto_moderator_dae.py
@@ -844,6 +844,11 @@ class AutoModeratorDAE:
         if not self.service and video_id:
             logger.info("[AUTH] Stream found! Attempting authentication for chat interaction...")
             try:
+                # Function-local import (WSP coordination: avoid touching the
+                # module-level import block another change may also edit).
+                from modules.platform_integration.youtube_auth.src.youtube_auth import (
+                    OAuthReauthRequiredError,
+                )
                 force_set_raw = os.getenv("YT_FORCE_CREDENTIAL_SET", "").strip()
                 token_index = None
                 if force_set_raw:
@@ -895,6 +900,19 @@ class AutoModeratorDAE:
                             logger.info(f"[OK] Got chat ID with API: {live_chat_id[:20]}...")
                         else:
                             logger.warning("[WARN] Could not get chat ID even with API")
+            except OAuthReauthRequiredError as reauth_err:
+                # Pinned credential set is dead (invalid_grant). Do NOT silently
+                # authenticate via another account/set and do NOT log
+                # "[OK] Authenticated". Surface the exact operator reauth command
+                # with the Chrome/Edge hint so 012 can fix the pinned account.
+                logger.critical(
+                    f"[AUTH] Pinned credential set {reauth_err.set_id} requires "
+                    f"re-authorization (invalid_grant) - NO silent fallback. "
+                    f"Operator action: {reauth_err.operator_action} "
+                    f"(Set 1 -> Chrome for UnDaoDu/Move2Japan, "
+                    f"Set 10 -> Edge for FoundUps/antifaFM)"
+                )
+                logger.info("[NO-QUOTA] Continuing in NO-QUOTA mode (view-only)")
             except Exception as e:
                 logger.warning(f"[WARN] Authentication failed: {e}")
                 logger.info("[NO-QUOTA] Continuing in NO-QUOTA mode (view-only)")

--- a/modules/platform_integration/youtube_auth/INTERFACE.md
+++ b/modules/platform_integration/youtube_auth/INTERFACE.md
@@ -6,6 +6,7 @@ The YouTube Authentication module handles OAuth 2.0 authentication with the YouT
 ## Exports
 This module exports:
 - `get_authenticated_service`: Function to authenticate and obtain a YouTube API service object
+- `OAuthReauthRequiredError`: Raised when a dead (invalid_grant) credential set cannot be authenticated and no silent fallback is permitted
 - `oauth_browser.resolve_browser_for_set`: Resolve the per-set OAuth browser executable
 - `oauth_browser.BrowserNotFoundError`: Raised when no browser executable can be resolved for a set
 
@@ -21,13 +22,34 @@ Authenticates the user with YouTube API using OAuth 2.0 and returns a YouTube AP
 - `googleapiclient.discovery.Resource`: A YouTube API service object that can be used to make API calls
 
 **Behavior:**
-- Sequentially tries up to 4 credential sets defined in environment variables
+- Sequentially tries the configured credential sets (auto-rotation) or a single
+  explicitly pinned set when `token_index` is supplied
 - Loads existing credentials from token files if available
 - Refreshes credentials if expired
 - Initiates a new OAuth flow if no valid credentials are found
 - Saves new or refreshed credentials to the appropriate token file
-- Falls back to the next credential set if authentication fails or quota is exceeded
+- Falls back to the next credential set ONLY during auto-rotation, and only if a
+  healthy set remains; emits a truthful `[OAUTH-HEALTH]` capacity line after each skip
 - Raises an exception if all credential sets fail
+
+**No silent fallback for a pinned set (WSP 97):**
+- When `token_index` is EXPLICITLY pinned (e.g. UnDaoDu/Move2Japan pinned to
+  set 1), an `invalid_grant` refresh failure raises `OAuthReauthRequiredError`
+  immediately. The function does NOT try another set (e.g. set 10) and does NOT
+  degrade to read-only no-auth mode — that would silently authenticate via the
+  wrong account.
+- During auto-rotation (`token_index=None`), a dead set is skipped only when a
+  healthy set remains. If ALL configured sets are dead via `invalid_grant`, the
+  function raises `OAuthReauthRequiredError` listing every reauth command instead
+  of degrading to no-auth.
+
+### `class OAuthReauthRequiredError(Exception)`
+Raised when a credential set's refresh token is dead (`invalid_grant`) and no
+silent fallback is allowed. Carries operator-actionable context:
+- `set_id`: the credential set (or a list of set ids when all sets are dead) that
+  requires re-authorization.
+- `operator_action`: the exact reauth command(s) from
+  `oauth_health.reauth_command_for(set_id)`, joined with `; ` for multiple sets.
 
 ## oauth_browser (per-set OAuth browser resolution)
 
@@ -92,6 +114,9 @@ except Exception as e:
 
 ## Error Handling
 - `ValueError`: Raised if required environment variables are missing
+- `OAuthReauthRequiredError`: Raised when a pinned set is dead (`invalid_grant`)
+  or when all sets are dead during auto-rotation; carries `set_id` and
+  `operator_action` (the exact reauth command(s))
 - `Exception`: Raised if all credential sets fail to authenticate
 - HTTP errors from the YouTube API are logged but handled internally during authentication
 

--- a/modules/platform_integration/youtube_auth/ModLog.md
+++ b/modules/platform_integration/youtube_auth/ModLog.md
@@ -12,6 +12,61 @@ This log tracks changes specific to the **youtube_auth** module in the **platfor
 
 ## MODLOG ENTRIES
 
+### 2026-06-15 - YT-OAUTH-INVALID-GRANT-NO-SILENT-FALLBACK-PHASE1: No silent Set-10 fallback for a pinned set
+
+**By:** 0102 (Worker P3)
+**Slice:** YT-OAUTH-INVALID-GRANT-NO-SILENT-FALLBACK-PHASE1 (builds on #811)
+**WSP References:** WSP 22 (ModLog), WSP 50 (Pre-Action Verification), WSP 97 (Truth Signaling)
+
+**HoloIndex Retrieval (backfilled 2026-06-15, pre-contract worker):** the full retroactive retrieval report + verdict + attention flags are in the PR #812 body. NEEDS_012: HoloIndex miss - retroactive queries surfaced only adjacent files (e.g. livechat/persona_registry.py) and did NOT surface the edit target youtube_auth.py; the get_authenticated_service edits + auto_moderator_dae.py:867 auth block were located by architect-pre-verified direct reads (WSP 50). Indexing gap tracked as HOLOINDEX_YOUTUBE_AUTH_INDEXING_GAP_PHASE1.
+
+**Problem (verified):**
+- `get_authenticated_service()` on `invalid_grant` for a set logged CRITICAL,
+  added the set to `exhausted_sets`, then `continue`d to the NEXT set - even when
+  the caller had EXPLICITLY pinned a credential set. UnDaoDu/Move2Japan are
+  pinned to set 1 (`resolve_channel_credential_set`), so a dead set 1 token
+  silently authenticated via set 10 (the FoundUps/antifaFM account) or degraded
+  to read-only no-auth mode. `auto_moderator_dae.py` then logged
+  "[OK] Authenticated" as if the pinned set had worked.
+
+**Changes:**
+- **Added** `OAuthReauthRequiredError(Exception)` in `src/youtube_auth.py`,
+  carrying `set_id` (int, or list when all sets are dead) and `operator_action`
+  derived from `oauth_health.reauth_command_for(set_id)` (imported
+  function-locally). Exported in INTERFACE.md.
+- **`get_authenticated_service(token_index)`** (no change to
+  `preflight_oauth_check`):
+  - Tracks `is_pinned = token_index is not None`.
+  - Pinned + `invalid_grant` -> raises `OAuthReauthRequiredError(set_id,
+    reauth_command)`. NO fallback to another set, NO no-auth degrade.
+  - Auto-rotation + `invalid_grant` on set N -> marks exhausted, emits a
+    truthful `[OAUTH-HEALTH]` capacity line after the skip, and continues ONLY
+    if a healthy set remains; logs an explicit "falling back to remaining
+    healthy set(s)" line.
+  - Auto-rotation + ALL sets dead -> raises `OAuthReauthRequiredError` listing
+    EVERY reauth command (no no-auth degrade).
+- **`auto_moderator_dae.py`** auth block (~L867 only): catches
+  `OAuthReauthRequiredError` (function-local import) -> logs CRITICAL with the
+  operator reauth command + Chrome/Edge hint; does NOT log "[OK] Authenticated"
+  on a pinned-set failure.
+
+**Tests:** `tests/test_oauth_no_silent_fallback.py` (no network; refresh mocked
+to raise `invalid_grant`):
+- `test_pinned_set1_invalid_grant_does_not_use_set10` - asserts
+  `OAuthReauthRequiredError` raised, set 10 never consulted, no service built.
+- `test_auto_rotation_set1_dead_falls_back_to_set10_when_set10_healthy` -
+  explicit fallback still works, log says fallback to set 10.
+- `test_all_sets_dead_raises_with_both_commands` - raises listing both reauth
+  commands, no no-auth degrade.
+- Result: 3 passed. (Pre-existing legacy `test_youtube_auth.py` failures are
+  unrelated and present on the base branch.)
+
+**Coordination:** Edited ONLY `get_authenticated_service()` + new exception in
+`youtube_auth.py`; `preflight_oauth_check()` left untouched (sibling PR2 owns
+it). Stacks on #811 (browser resolver); merge order #811 -> PR2 -> this PR.
+
+---
+
 ### 2026-06-15 - YT-OAUTH-DUAL-PREFLIGHT-MENU-PHASE1: Dual-set fixed-port OAuth preflight + menu 1->1 wiring
 
 **By:** 0102 (Worker P2)

--- a/modules/platform_integration/youtube_auth/src/youtube_auth.py
+++ b/modules/platform_integration/youtube_auth/src/youtube_auth.py
@@ -42,6 +42,44 @@ quota_monitor = QuotaMonitor()
 # Load environment variables once when the module is imported
 load_dotenv()
 
+
+class OAuthReauthRequiredError(Exception):
+    """
+    Raised when a credential set cannot be authenticated because its refresh
+    token is dead (invalid_grant) and no silent fallback is permitted.
+
+    Carries operator-actionable context so callers can surface the exact
+    re-authorization command instead of silently degrading to a different
+    account or to read-only no-auth mode.
+
+    Attributes:
+        set_id: The credential set (or list of set ids when all sets are dead)
+            that requires re-authorization.
+        operator_action: The exact reauth command(s) an operator must run,
+            derived from oauth_health.reauth_command_for(set_id).
+    """
+
+    def __init__(self, set_id, operator_action=None, message=None):
+        self.set_id = set_id
+        if operator_action is None:
+            # Import function-locally to avoid coupling the module-level import
+            # block (which sibling work also edits).
+            from modules.platform_integration.youtube_auth.src import oauth_health as _oh
+            if isinstance(set_id, (list, tuple, set)):
+                operator_action = "; ".join(
+                    _oh.reauth_command_for(s) for s in set_id
+                )
+            else:
+                operator_action = _oh.reauth_command_for(set_id)
+        self.operator_action = operator_action
+        if message is None:
+            message = (
+                f"Credential set {set_id} requires re-authorization "
+                f"(invalid_grant); operator must run: {operator_action}"
+            )
+        super().__init__(message)
+
+
 def get_credentials_for_index(index):
     """
     Get credentials for a specific index (1-5).
@@ -131,8 +169,12 @@ def get_authenticated_service(token_index=None):
         get_authenticated_service.exhausted_sets.clear()
         get_authenticated_service.last_reset = current_time
 
-    # Determine which credential sets to try
-    if token_index is not None:
+    # Determine which credential sets to try.
+    # is_pinned == True means the caller EXPLICITLY pinned a credential set
+    # (e.g. UnDaoDu/Move2Japan -> set 1). For a pinned set we must NOT silently
+    # fall back to another account/set on invalid_grant; we raise instead.
+    is_pinned = token_index is not None
+    if is_pinned:
         # Use specific token index (already 1-based from caller)
         indices_to_try = [token_index]
         logger.info(f"[TARGET] Using specific credential set {token_index}")
@@ -164,6 +206,11 @@ def get_authenticated_service(token_index=None):
         ])
         logger.info(f"[OAUTH-HEALTH] {oauth_health.format_capacity_log(capacity_snapshot)}")
     
+    # Track credential sets that died via invalid_grant during this call so
+    # auto-rotation can raise a combined re-auth error if EVERY set is dead
+    # (instead of silently degrading to no-auth read-only mode).
+    invalid_grant_sets = []
+
     for index in indices_to_try:
         logger.info(f"[U+1F511] Attempting authentication with credential set {index}")
         creds_data = get_credentials_for_index(index)
@@ -230,14 +277,75 @@ def get_authenticated_service(token_index=None):
                         oauth_health.emit_critical_reauth(index, status, reason)
                         # Mark this set offline for this process to avoid repeated retries during fallback flows
                         get_authenticated_service.exhausted_sets.add(index)
+                        invalid_grant_sets.append(index)
+
+                        # Persist operator-visible health artifact for this failure
+                        _persist_health_snapshot(failing_set=index, failing_status=status, failing_reason=reason)
+
+                        if is_pinned:
+                            # No silent fallback for an EXPLICITLY pinned set:
+                            # UnDaoDu/Move2Japan are pinned to set 1 and must NOT
+                            # be allowed to authenticate via a different account
+                            # (set 10) or degrade to read-only no-auth mode.
+                            reauth_command = oauth_health.reauth_command_for(index)
+                            raise OAuthReauthRequiredError(
+                                set_id=index,
+                                operator_action=reauth_command,
+                            )
+
+                        # Auto-rotation: emit a truthful effective-capacity line
+                        # after this skip so operators see real remaining quota,
+                        # not just rotation targets. Only continue if at least one
+                        # other healthy (not-yet-dead) set remains.
+                        from modules.platform_integration.youtube_auth.src.quota_monitor import (
+                            get_available_credential_sets,
+                        )
+                        configured_sets = get_available_credential_sets()
+                        capacity_snapshot = oauth_health.compute_effective_capacity([
+                            oauth_health.build_set_entry(
+                                s,
+                                oauth_health.STATUS_TOKEN_EXPIRED_OR_REVOKED
+                                if s in get_authenticated_service.exhausted_sets
+                                else oauth_health.STATUS_HEALTHY,
+                            )
+                            for s in configured_sets
+                        ])
+                        logger.info(
+                            f"[OAUTH-HEALTH] {oauth_health.format_capacity_log(capacity_snapshot)}"
+                        )
+
+                        remaining_healthy = [
+                            s for s in configured_sets
+                            if s not in get_authenticated_service.exhausted_sets
+                        ]
+                        if not remaining_healthy:
+                            # ALL sets dead via invalid_grant: do NOT degrade to
+                            # no-auth; raise listing every reauth command.
+                            dead_sets = sorted(set(invalid_grant_sets))
+                            combined_action = "; ".join(
+                                oauth_health.reauth_command_for(s) for s in dead_sets
+                            )
+                            logger.critical(
+                                f"[OAUTH-HEALTH] CRITICAL: all credential sets "
+                                f"{dead_sets} are dead (invalid_grant); operator "
+                                f"must run: {combined_action}"
+                            )
+                            raise OAuthReauthRequiredError(
+                                set_id=dead_sets,
+                                operator_action=combined_action,
+                            )
+                        logger.info(
+                            f"[REFRESH] Set {index} dead (invalid_grant); falling "
+                            f"back to remaining healthy set(s): {remaining_healthy}"
+                        )
+                        # Continue to next credential set instead of trying OAuth flow
+                        continue
                     else:
                         logger.error(f"[FAIL] Failed to refresh token for set {index}: {e}")
-
-                    # Persist operator-visible health artifact for this failure
-                    _persist_health_snapshot(failing_set=index, failing_status=status, failing_reason=reason)
-
-                    # Continue to next credential set instead of trying OAuth flow
-                    continue
+                        # Persist operator-visible health artifact for this failure
+                        _persist_health_snapshot(failing_set=index, failing_status=status, failing_reason=reason)
+                        # Continue to next credential set instead of trying OAuth flow
+                        continue
             else:
                 if creds and creds.expired and not creds.refresh_token:
                     logger.warning(f"[U+26A0]️ Credentials expired for set {index} but no refresh token available")

--- a/modules/platform_integration/youtube_auth/tests/test_oauth_no_silent_fallback.py
+++ b/modules/platform_integration/youtube_auth/tests/test_oauth_no_silent_fallback.py
@@ -1,0 +1,210 @@
+"""
+Tests for the "no silent Set-10 fallback for a pinned credential set" behavior.
+
+Slice: YT-OAUTH-INVALID-GRANT-NO-SILENT-FALLBACK-PHASE1 (builds on #811)
+
+Verifies get_authenticated_service():
+  - When a credential set is EXPLICITLY pinned (token_index=1) and its refresh
+    raises invalid_grant, it raises OAuthReauthRequiredError and NEVER tries
+    set 10 (no silent fallback to a different account / read-only mode).
+  - When auto-rotating (token_index=None), a dead set 1 still falls back to a
+    healthy set 10 (explicit fallback log).
+  - When ALL sets are dead via invalid_grant during auto-rotation, it raises
+    OAuthReauthRequiredError listing every reauth command.
+
+No network: the refresh/flow paths are mocked. The credential .refresh() call
+is what raises invalid_grant, mirroring a dead refresh token.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from modules.platform_integration.youtube_auth.src.youtube_auth import (  # noqa: E402
+    get_authenticated_service,
+    OAuthReauthRequiredError,
+)
+from google.oauth2.credentials import Credentials  # noqa: E402
+
+
+YOUTUBE_AUTH = "modules.platform_integration.youtube_auth.src.youtube_auth"
+QUOTA_MONITOR = "modules.platform_integration.youtube_auth.src.quota_monitor"
+
+REAUTH_SET1 = (
+    "python modules/platform_integration/youtube_auth/scripts/authorize_set1.py"
+)
+REAUTH_SET10 = (
+    "python modules/platform_integration/youtube_auth/scripts/authorize_set10.py"
+)
+
+
+def _make_expired_creds_raising(error_msg):
+    """Build a creds mock that is expired/has refresh token and whose refresh()
+    raises the given error message (simulates invalid_grant)."""
+    creds = MagicMock(spec=Credentials)
+    creds.valid = False
+    creds.expired = True
+    creds.refresh_token = "fake-refresh-token"
+    creds.expiry = None
+    creds.refresh.side_effect = Exception(error_msg)
+    return creds
+
+
+def _make_valid_creds():
+    """Build a creds mock representing a healthy, valid credential."""
+    creds = MagicMock(spec=Credentials)
+    creds.valid = True
+    creds.expired = False
+    creds.expiry = None
+    return creds
+
+
+class TestNoSilentFallback(unittest.TestCase):
+    def setUp(self):
+        # Required env for get_authenticated_service to proceed.
+        self._orig_scopes = os.environ.get('YOUTUBE_SCOPES')
+        os.environ['YOUTUBE_SCOPES'] = (
+            'https://www.googleapis.com/auth/youtube.readonly'
+        )
+        # Reset per-process rotation memory so prior tests don't leak state.
+        if hasattr(get_authenticated_service, 'exhausted_sets'):
+            get_authenticated_service.exhausted_sets.clear()
+
+    def tearDown(self):
+        if self._orig_scopes is None:
+            os.environ.pop('YOUTUBE_SCOPES', None)
+        else:
+            os.environ['YOUTUBE_SCOPES'] = self._orig_scopes
+        if hasattr(get_authenticated_service, 'exhausted_sets'):
+            get_authenticated_service.exhausted_sets.clear()
+
+    # ------------------------------------------------------------------
+    # 1. Pinned set 1 invalid_grant -> raises, never touches set 10.
+    # ------------------------------------------------------------------
+    @patch(f"{YOUTUBE_AUTH}._persist_health_snapshot")
+    @patch(f"{YOUTUBE_AUTH}.build")
+    @patch(f"{YOUTUBE_AUTH}.google.oauth2.credentials.Credentials.from_authorized_user_file")
+    @patch(f"{YOUTUBE_AUTH}.os.path.exists")
+    @patch(f"{YOUTUBE_AUTH}.get_credentials_for_index")
+    def test_pinned_set1_invalid_grant_does_not_use_set10(
+        self, mock_get_creds, mock_exists, mock_from_file, mock_build, mock_snap
+    ):
+        # get_credentials_for_index should only ever be called for set 1.
+        def creds_for(index):
+            return (f"secrets{index}.json", f"token{index}.json")
+        mock_get_creds.side_effect = creds_for
+        mock_exists.return_value = True
+
+        # Set 1 refresh raises invalid_grant.
+        mock_from_file.return_value = _make_expired_creds_raising(
+            "('invalid_grant: Token has been expired or revoked.', {...})"
+        )
+
+        with self.assertRaises(OAuthReauthRequiredError) as ctx:
+            get_authenticated_service(token_index=1)
+
+        err = ctx.exception
+        self.assertEqual(err.set_id, 1)
+        self.assertEqual(err.operator_action, REAUTH_SET1)
+
+        # Set 10 must NEVER be consulted for a pinned set.
+        called_indices = [c.args[0] for c in mock_get_creds.call_args_list]
+        self.assertIn(1, called_indices)
+        self.assertNotIn(10, called_indices)
+        # No service should have been built (no silent auth via any set).
+        mock_build.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # 2. Auto-rotation: set 1 dead, set 10 healthy -> falls back to set 10.
+    # ------------------------------------------------------------------
+    @patch(f"{YOUTUBE_AUTH}._persist_health_snapshot")
+    @patch(f"{QUOTA_MONITOR}.get_available_credential_sets")
+    @patch(f"{YOUTUBE_AUTH}.build")
+    @patch(f"{YOUTUBE_AUTH}.google.oauth2.credentials.Credentials.from_authorized_user_file")
+    @patch(f"{YOUTUBE_AUTH}.os.path.exists")
+    @patch(f"{YOUTUBE_AUTH}.get_credentials_for_index")
+    def test_auto_rotation_set1_dead_falls_back_to_set10_when_set10_healthy(
+        self, mock_get_creds, mock_exists, mock_from_file,
+        mock_build, mock_avail, mock_snap,
+    ):
+        mock_avail.return_value = [1, 10]
+
+        def creds_for(index):
+            return (f"secrets{index}.json", f"token{index}.json")
+        mock_get_creds.side_effect = creds_for
+        mock_exists.return_value = True
+
+        dead_set1 = _make_expired_creds_raising(
+            "('invalid_grant: Token has been expired or revoked.', {...})"
+        )
+        healthy_set10 = _make_valid_creds()
+
+        def from_file(token_file, scopes):
+            if token_file == "token1.json":
+                return dead_set1
+            return healthy_set10
+        mock_from_file.side_effect = from_file
+
+        # Service validation succeeds for set 10.
+        mock_service = MagicMock()
+        mock_service.channels.return_value.list.return_value.execute.return_value = {
+            "items": [{"snippet": {"title": "FoundUps"}}]
+        }
+        mock_build.return_value = mock_service
+
+        with self.assertLogs(f"{YOUTUBE_AUTH}", level="INFO") as logctx:
+            service = get_authenticated_service()  # auto-rotation
+
+        self.assertIs(service, mock_service)
+        self.assertEqual(getattr(service, "_credential_set", None), 10)
+
+        # Explicit fallback log to set 10.
+        log_text = "\n".join(logctx.output)
+        self.assertIn("falling back to remaining healthy set(s): [10]", log_text)
+        # Capacity line emitted truthfully after the skip.
+        self.assertIn("[OAUTH-HEALTH]", log_text)
+
+    # ------------------------------------------------------------------
+    # 3. Auto-rotation: ALL sets dead -> raises listing both reauth commands.
+    # ------------------------------------------------------------------
+    @patch(f"{YOUTUBE_AUTH}._persist_health_snapshot")
+    @patch(f"{QUOTA_MONITOR}.get_available_credential_sets")
+    @patch(f"{YOUTUBE_AUTH}.build")
+    @patch(f"{YOUTUBE_AUTH}.google.oauth2.credentials.Credentials.from_authorized_user_file")
+    @patch(f"{YOUTUBE_AUTH}.os.path.exists")
+    @patch(f"{YOUTUBE_AUTH}.get_credentials_for_index")
+    def test_all_sets_dead_raises_with_both_commands(
+        self, mock_get_creds, mock_exists, mock_from_file,
+        mock_build, mock_avail, mock_snap,
+    ):
+        mock_avail.return_value = [1, 10]
+
+        def creds_for(index):
+            return (f"secrets{index}.json", f"token{index}.json")
+        mock_get_creds.side_effect = creds_for
+        mock_exists.return_value = True
+
+        # Both sets raise invalid_grant on refresh.
+        def from_file(token_file, scopes):
+            return _make_expired_creds_raising(
+                "('invalid_grant: Token has been expired or revoked.', {...})"
+            )
+        mock_from_file.side_effect = from_file
+
+        with self.assertRaises(OAuthReauthRequiredError) as ctx:
+            get_authenticated_service()  # auto-rotation
+
+        err = ctx.exception
+        self.assertEqual(sorted(err.set_id), [1, 10])
+        # Both reauth commands listed.
+        self.assertIn(REAUTH_SET1, err.operator_action)
+        self.assertIn(REAUTH_SET10, err.operator_action)
+        # No silent degrade to no-auth service.
+        mock_build.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Slice: YT-OAUTH-INVALID-GRANT-NO-SILENT-FALLBACK-PHASE1 (Worker-Lane P3)

### Problem (verified)
`get_authenticated_service()` on `invalid_grant` for a set logged CRITICAL, added the set to `exhausted_sets`, then `continue`d to the NEXT set - even when the caller had EXPLICITLY pinned a credential set. UnDaoDu/Move2Japan are pinned to **set 1** (`resolve_channel_credential_set`), so a dead set-1 token silently authenticated via **set 10** (the FoundUps/antifaFM account) or degraded to read-only no-auth mode. `auto_moderator_dae.py` then logged `[OK] Authenticated` as if the pinned set had worked.

### Changes
- **New** `OAuthReauthRequiredError(Exception)` in `youtube_auth.py`, carrying `set_id` (int, or list when all sets are dead) and `operator_action` from `oauth_health.reauth_command_for(set_id)` (function-local import).
- **`get_authenticated_service(token_index)`**:
  - Pinned (`token_index` explicit) + `invalid_grant` -> raise `OAuthReauthRequiredError`. **No** fallback to another set, **no** no-auth degrade.
  - Auto-rotation (`token_index=None`) + `invalid_grant` on set N -> mark exhausted, emit a truthful `[OAUTH-HEALTH]` capacity line after the skip, continue **only** if a healthy set remains (explicit fallback log).
  - Auto-rotation + ALL sets dead -> raise listing **every** reauth command (no no-auth degrade).
- **`auto_moderator_dae.py`** auth block (~L867 only): catch `OAuthReauthRequiredError` for the pinned set -> log CRITICAL with the Chrome/Edge reauth hint; do **not** log `[OK] Authenticated` on a pinned-set failure.
- **Tests** (`tests/test_oauth_no_silent_fallback.py`, no network, refresh mocked to raise `invalid_grant`):
  - `pinned_set1_invalid_grant_does_not_use_set10`
  - `auto_rotation_set1_dead_falls_back_to_set10_when_set10_healthy`
  - `all_sets_dead_raises_with_both_commands`
  - Result: **3 passed**. (Legacy `test_youtube_auth.py` failures are pre-existing on the base branch, unrelated to this change.)
- **Docs**: `INTERFACE.md` (new `OAuthReauthRequiredError` export) + `ModLog.md`.

### Out of scope
`preflight_oauth_check()` / startup menu (PR2 owns it - **left untouched**); browser resolver (#811); quota_monitor.

### Stacking / merge order
- **Stacks on #811** (per-set OAuth browser resolver). Until #811 merges, this PR's diff also shows #811's changes.
- **Merge order: #811 -> PR2 -> this PR** (rebase after PR2 lands if needed, since PR2 edits `preflight_oauth_check()` in the same file).
- A sibling PR (PR2) edits `preflight_oauth_check()` concurrently; this PR edits only `get_authenticated_service()` + the new exception class.
- **Do NOT self-merge** - leave open for the gate.

WSP 22, WSP 50, WSP 97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### HoloIndex Retrieval Report (backfilled 2026-06-15; pre-contract worker, queries run retroactively)
| # | Query | Hits | Top result | Quality | Used? |
|---|-------|------|------------|---------|-------|
| 1 | get_authenticated_service invalid_grant exhausted fallback set 10 | 20 | modules/communication/livechat/_archive/.../test_livechat_auth_handling.py | LOW | N |
| 2 | pinned credential set OAuthReauthRequiredError no silent fallback | 20 | modules/foundups/src/main.py | LOW | N |
| 3 | resolve_channel_credential_set auto_moderator authenticated pinned | 20 | modules/communication/livechat/src/persona_registry.py | MEDIUM | Y |

### Retrieval verdict
- 1/3 (q3) surfaced persona_registry.py (the resolve_channel_credential_set source) + livechat_core.py; the core edit targets (youtube_auth.py get_authenticated_service; auto_moderator_dae.py:867 auth block) located by WSP-50 direct reads.
- action: direct reads; pinned-set premise confirmed at persona_registry.py:268 + auto_moderator_dae.py:860/867.

### Attention flags (012 triage)
- [x] NEEDS_012: HoloIndex partial - core edit target via direct reads (pre-contract worker)
- [ ] NEEDS_012: secrets (none)
- [ ] NEEDS_012: test failure / worktree integrity (3 tests pass; no conflict markers; syntax OK; preflight untouched)
- [x] Stopped at VERIFIED_READY - sovereign merge only; stacked on #811 (rebase after #813)
