### PR TITLE
fix(youtube_auth): quota tracking truth - reconcile drift, PT reset boundary, real-signal alert gating (Phase 1)

### DIFF
--- a/modules/platform_integration/youtube_auth/ModLog.md
+++ b/modules/platform_integration/youtube_auth/ModLog.md
@@ -194,6 +194,93 @@ rotation/fallback, exhausted_sets logic (separate PRs build on this).
 python -m pytest modules/platform_integration/youtube_auth/tests/test_oauth_browser.py
 # 6 passed
 ```
+### 2026-06-15 - YT-QUOTA-TRACKING-TRUTH-PHASE1: Quota Tracking Truth (drift reconcile, PT reset boundary, real-signal alert gating)
+
+**By:** 0102 (Worker-Lane Q1, Slice YT-QUOTA-TRACKING-TRUTH-PHASE1)
+**WSP References:** WSP 22 (ModLog), WSP 50 (Pre-Action Verification), WSP 84 (Code Reuse), WSP 97 (Truth Signaling)
+
+**Problem (verified from source, not assumed):**
+`quota_monitor.py` could emit a CRITICAL "~99% quota" alert from a STALE / drift-corrupted
+local counter rather than a real Google `quotaExceeded`. This is a WSP 97 truth violation:
+the monitor signalled exhaustion that was not true.
+
+Three confirmed mechanisms in `src/quota_monitor.py`:
+1. `_normalize_usage_data()` loaded the stored `sets.N.used` verbatim without checking it
+   against the sum of its per-operation `units` ledger. A corrupted record (e.g.
+   `used=9901` while the operations ledger sums to `1`) loaded as 99% used.
+2. `_check_alerts()` computed `usage_percent = used / limit` purely from that local counter
+   and raised CRITICAL with no requirement for a real Google signal.
+3. `_check_daily_reset()` used a rolling-24h-from-last_reset window, NOT Google's actual
+   midnight-Pacific quota boundary, so a stale counter could persist across the real reset.
+
+**Changes (`src/quota_monitor.py` only):**
+- **Drift reconciliation on load** (`_normalize_usage_data`): per set, compute
+  `used_from_ops = sum(op["units"])`; if `abs(used - used_from_ops) > 1`, log
+  `WARNING [QUOTA-DRIFT] set N used=X ops_sum=Y; reconciling to Y` and set `used = used_from_ops`.
+  The operations ledger is treated as the source of truth.
+- **Pacific-Time daily reset boundary** (`_check_daily_reset`): reset when the *Pacific-Time
+  calendar date* rolls over (midnight America/Los_Angeles), replacing rolling-24h. Added
+  `to_pacific()` + `_us_pacific_offset_hours()` helpers using stdlib `zoneinfo` when available,
+  with a manual US-DST fallback (PST UTC-8 / PDT UTC-7, 2nd-Sun-Mar to 1st-Sun-Nov) for hosts
+  where the tz database is unavailable. NOTE: this host has no `tzdata` (zoneinfo raised
+  `ZoneInfoNotFoundError`), so the manual fallback is the ACTIVE path here and is exercised by
+  the tests. `last_reset` is now persisted as Pacific wall-clock isoformat.
+- **Real-signal alert gating** (`_check_alerts` + new `report_quota_signal()`): a CRITICAL/
+  WARNING alert now requires EITHER a real Google signal (`report_quota_signal`,
+  for HTTP 403 `quotaExceeded` / `dailyLimitExceeded`) OR a *reconciled* local `used` at/above
+  the threshold. Because the counter is reconciled at load, a drift-corrupted counter alone can
+  no longer produce a false CRITICAL. Alerts now carry a `trigger` field (`google_signal` /
+  `local_counter`) for auditability. Real signals are cleared on the PT daily reset.
+- **Injectable clock**: `__init__` accepts an optional `now_provider` (defaults to
+  `datetime.now`); all internal time reads go through `self._now()` / `self._now_pacific()` so
+  tests are deterministic and offline. Fully backward compatible (additive kwarg; existing
+  callers `QuotaMonitor()` / `QuotaMonitor(memory_dir=...)` unchanged).
+
+**Tests (`tests/test_quota_monitor.py`):**
+- New `TestQuotaTruthSignaling` class (8 tests, all deterministic / no network):
+  corrupt `{used:9901, ops sum:1}` load -> `used==1` + `[QUOTA-DRIFT]` warning; no false
+  CRITICAL after corrupt load; consistent counter -> no drift warning; real `quotaExceeded`
+  signal raises CRITICAL even at ~0% local usage; genuinely high reconciled counter still
+  alerts (`trigger=local_counter`); PT same-day no-reset; PT cross-day reset; PT-boundary is
+  not rolling-24h (1h gap that crosses PT midnight still resets). Times injected as tz-aware
+  UTC for host-independent determinism.
+- Updated the two pre-existing reset tests (`test_check_daily_reset`,
+  `test_check_daily_reset_not_needed`) to assert the new PT-day boundary instead of the
+  removed rolling-24h contract (they previously encoded the old behavior).
+
+**Verification (truthful, executed):**
+- `pytest tests/test_quota_monitor.py` -> 22 passed, 5 failed.
+- The 5 failures are PRE-EXISTING and unrelated to this slice: the test file still assumes a
+  7-set (1-7) credential config while production `daily_limits` is `{1, 10}`
+  (`test_initialization`, `test_get_best_credential_set`,
+  `test_get_best_credential_set_all_exhausted`, `test_get_usage_summary`,
+  `test_quota_file_persistence`). Baseline before this slice was also 5 failed / 14 passed;
+  this slice adds 8 passing tests and fixes 2 reset tests without changing the pre-existing
+  failure set. Those 7-set mismatches are out of scope for this truth slice.
+
+### HoloIndex Retrieval Report
+| # | Query | Hits | Top result | Quality | Used? |
+|---|-------|------|------------|---------|-------|
+| 1 | quota monitor usage reconcile drift credential set | 20 | modules\communication\livechat\src\quota_aware_poller.py | LOW | N |
+| 2 | youtube quota daily reset pacific time critical alert threshold | 20 | modules\communication\livechat\src\mcp_youtube_integration.py | LOW | N |
+| 3 | quota_usage operations units track_api_call get_usage_summary | 20 | modules\communication\livechat\src\intelligent_throttle_manager.py | LOW | N |
+
+### Retrieval verdict
+- noise: HIGH - all 3 queries returned livechat throttle/poller + WSP/docs; none surfaced the
+  actual target `quota_monitor.py`.
+- ordering: target file never ranked; semantic index biased toward livechat quota consumers.
+- missing artifacts: `modules/platform_integration/youtube_auth/src/quota_monitor.py` and its
+  tests were absent from all result sets.
+- staleness/duplication: not the issue; this is a retrieval miss.
+- action: re-queried 3x (all LOW) -> fell back to direct path reads via Glob + Read of
+  `quota_monitor.py`, `tests/test_quota_monitor.py`, and `youtube_auth/ModLog.md`.
+
+### Attention flags (012 triage)
+- [ ] NEEDS_012: merge / sovereign nod / OAuth browser / secrets
+- [x] NEEDS_012: HoloIndex miss - relied on direct path reads (target file not surfaced by 3 queries)
+- [ ] NEEDS_012: test failure / worktree integrity / quota drift (5 failures are PRE-EXISTING 7-set mismatch, not introduced)
+- [ ] CLEAR: CI green, worktree clean, no flags
+- Note: this is quota runtime code -> PR left OPEN for the external gate regardless.
 
 ### 2026-05-01 - OC21: WSP 97 Truth Violation + Operations KeyError Fix
 

--- a/modules/platform_integration/youtube_auth/src/quota_monitor.py
+++ b/modules/platform_integration/youtube_auth/src/quota_monitor.py
@@ -23,11 +23,70 @@ import os
 import time
 import json
 import logging
-from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Tuple
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Dict, List, Optional, Tuple
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+# America/Los_Angeles standard/daylight offsets (UTC hours).
+# Used by the manual fallback when the stdlib `zoneinfo` tz database is
+# unavailable on the host (e.g. Windows without the `tzdata` package).
+_PACIFIC_STANDARD_OFFSET = -8   # PST = UTC-8
+_PACIFIC_DAYLIGHT_OFFSET = -7   # PDT = UTC-7
+
+
+def _us_pacific_offset_hours(utc_dt: datetime) -> int:
+    """Return the US Pacific UTC offset (hours) for a UTC instant.
+
+    Implements current US DST rules (Energy Policy Act of 2005):
+    DST starts 2nd Sunday of March 02:00 local, ends 1st Sunday of
+    November 02:00 local. This is a pure-stdlib fallback used only when
+    `zoneinfo` cannot load 'America/Los_Angeles'. It is an approximation
+    around the exact DST transition hour but is exact for daily-quota
+    boundary purposes (midnight), which never falls in the ambiguous hour.
+    """
+    year = utc_dt.year
+
+    def _nth_sunday(month: int, n: int) -> datetime:
+        # First day of month in UTC
+        d = datetime(year, month, 1)
+        # weekday(): Mon=0 .. Sun=6 ; days until first Sunday
+        first_sunday = 1 + ((6 - d.weekday()) % 7)
+        day = first_sunday + (n - 1) * 7
+        return datetime(year, month, day)
+
+    # DST transitions occur at 02:00 LOCAL; approximate the instant in UTC
+    # by adding the standard offset (the side we are leaving/entering for the
+    # comparison boundary). Standard offset is -8, so 02:00 PT ~ 10:00 UTC.
+    dst_start = _nth_sunday(3, 2).replace(hour=2) - timedelta(hours=_PACIFIC_STANDARD_OFFSET)
+    dst_end = _nth_sunday(11, 1).replace(hour=2) - timedelta(hours=_PACIFIC_DAYLIGHT_OFFSET)
+
+    if dst_start <= utc_dt < dst_end:
+        return _PACIFIC_DAYLIGHT_OFFSET
+    return _PACIFIC_STANDARD_OFFSET
+
+
+def to_pacific(dt: datetime) -> datetime:
+    """Convert a datetime to America/Los_Angeles wall-clock time.
+
+    Prefers stdlib `zoneinfo`; falls back to a manual US-DST calculation
+    when the tz database is unavailable. A naive input is treated as local
+    system time (matching the historical behaviour of datetime.now()).
+
+    Returns a tz-aware datetime in Pacific time.
+    """
+    if dt.tzinfo is None:
+        dt = dt.astimezone()  # attach local system tz
+    try:
+        from zoneinfo import ZoneInfo
+        return dt.astimezone(ZoneInfo("America/Los_Angeles"))
+    except Exception:
+        # tzdata unavailable - manual fallback
+        utc_dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+        offset = _us_pacific_offset_hours(utc_dt)
+        pacific_tz = timezone(timedelta(hours=offset))
+        return dt.astimezone(pacific_tz)
 
 class QuotaMonitor:
     """Monitors YouTube API quota usage and provides alerting."""
@@ -51,20 +110,33 @@ class QuotaMonitor:
         'comments.delete': 50,
     }
     
-    def __init__(self, memory_dir: str = "memory"):
+    def __init__(self, memory_dir: str = "memory",
+                 now_provider: Optional[Callable[[], datetime]] = None):
         """
         Initialize quota monitor.
-        
+
         Args:
             memory_dir: Directory for storing quota tracking data
+            now_provider: Optional callable returning the current datetime.
+                Defaults to datetime.now. Injectable for deterministic tests
+                (no real wall-clock / network dependency).
         """
         self.memory_dir = Path(memory_dir)
         self.memory_dir.mkdir(exist_ok=True)
-        
+
         self.quota_file = self.memory_dir / "quota_usage.json"
         self.alert_file = self.memory_dir / "quota_alerts.json"
-        
-        # Load existing data
+
+        # Injectable clock (WSP 97: deterministic, verifiable time handling)
+        self._now_provider = now_provider or datetime.now
+
+        # Real Google quota signals (quotaExceeded / 403) reported per
+        # credential set. A drift-corrupted LOCAL counter alone must NEVER
+        # raise CRITICAL (WSP 97 truth signaling); only a real signal or a
+        # reconciled local counter at/above threshold may alert.
+        self._google_quota_signals: Dict[int, Dict] = {}
+
+        # Load existing data (reconciles drift on load - WSP 97)
         self.usage_data = self._load_usage_data()
         self.alerts = self._load_alerts()
         
@@ -78,7 +150,15 @@ class QuotaMonitor:
         # Alert thresholds
         self.warning_threshold = 0.8  # Alert at 80% usage
         self.critical_threshold = 0.95  # Critical alert at 95% usage
-        
+
+    def _now(self) -> datetime:
+        """Current local datetime via injectable provider (WSP 97)."""
+        return self._now_provider()
+
+    def _now_pacific(self) -> datetime:
+        """Current America/Los_Angeles wall-clock time (tz-aware)."""
+        return to_pacific(self._now())
+
     def _load_usage_data(self) -> Dict:
         """Load quota usage data from file."""
         if self.quota_file.exists():
@@ -89,10 +169,10 @@ class QuotaMonitor:
             except Exception as e:
                 logger.error(f"Error loading quota data: {e}")
 
-        # Initialize empty usage data
+        # Initialize empty usage data (last_reset anchored to Pacific time)
         return {
             'sets': {},
-            'last_reset': datetime.now().isoformat()
+            'last_reset': self._now_pacific().isoformat()
         }
 
     def _normalize_usage_data(self, data: Dict) -> Dict:
@@ -100,17 +180,46 @@ class QuotaMonitor:
         if not isinstance(data, dict):
             return {
                 'sets': {},
-                'last_reset': datetime.now().isoformat()
+                'last_reset': self._now_pacific().isoformat()
             }
         if not isinstance(data.get('sets'), dict):
             data['sets'] = {}
         if not data.get('last_reset'):
-            data['last_reset'] = datetime.now().isoformat()
+            data['last_reset'] = self._now_pacific().isoformat()
 
         # Migrate old set entries without 'operations' key (WSP 97 fix)
         for set_key, set_data in data['sets'].items():
             if isinstance(set_data, dict) and 'operations' not in set_data:
                 set_data['operations'] = {}
+
+        # Reconcile drift: the stored 'used' counter must equal the sum of
+        # per-operation units. A drifted (e.g. corrupted/inflated) counter
+        # is a WSP 97 truth violation - it can make the monitor emit a
+        # CRITICAL "~99% quota" alert from a stale local number rather than
+        # a real Google quotaExceeded. On load, trust the operations ledger
+        # and reconcile 'used' down/up to match it.
+        for set_key, set_data in data['sets'].items():
+            if not isinstance(set_data, dict):
+                continue
+            operations = set_data.get('operations') or {}
+            used_from_ops = 0
+            for op in operations.values():
+                if isinstance(op, dict):
+                    try:
+                        used_from_ops += int(op.get('units', 0) or 0)
+                    except (TypeError, ValueError):
+                        continue
+            try:
+                current_used = int(set_data.get('used', 0) or 0)
+            except (TypeError, ValueError):
+                current_used = 0
+
+            if abs(current_used - used_from_ops) > 1:
+                logger.warning(
+                    f"[QUOTA-DRIFT] set {set_key} used={current_used} "
+                    f"ops_sum={used_from_ops}; reconciling to {used_from_ops}"
+                )
+                set_data['used'] = used_from_ops
 
         return data
     
@@ -173,7 +282,7 @@ class QuotaMonitor:
         # Update usage
         set_data = self.usage_data['sets'][set_key]
         set_data['used'] += units
-        set_data['last_call'] = datetime.now().isoformat()
+        set_data['last_call'] = self._now().isoformat()
         
         # Track operation counts
         if operation not in set_data['operations']:
@@ -191,60 +300,142 @@ class QuotaMonitor:
                     f"(Total: {set_data['used']}/{self.daily_limits[credential_set]})")
     
     def _check_daily_reset(self):
-        """Check if quotas should reset (new day in Pacific Time)."""
-        last_reset = datetime.fromisoformat(self.usage_data['last_reset'])
-        now = datetime.now()
-        
-        # Check if it's been 24 hours
-        if now - last_reset > timedelta(hours=24):
-            logger.info("[U+1F4C5] Daily quota reset - clearing usage data")
+        """Reset quotas when the Pacific-Time calendar day rolls over.
+
+        YouTube/Google daily quota resets at midnight America/Los_Angeles,
+        NOT on a rolling-24h-from-last_reset basis. We therefore compare the
+        Pacific calendar DATE of the last reset against the Pacific calendar
+        date of now: if now is a later PT day, the quota has reset.
+
+        Pacific time is derived via stdlib zoneinfo when available and a
+        manual US-DST fallback otherwise (see to_pacific()). last_reset is
+        persisted as Pacific wall-clock isoformat.
+        """
+        now_pt = self._now_pacific()
+
+        raw_last_reset = self.usage_data.get('last_reset')
+        try:
+            last_reset_dt = datetime.fromisoformat(raw_last_reset)
+        except (TypeError, ValueError):
+            # Corrupt/absent timestamp: re-anchor to now, do not wipe usage.
+            self.usage_data['last_reset'] = now_pt.isoformat()
+            self._save_usage_data()
+            return
+
+        last_reset_pt = to_pacific(last_reset_dt)
+
+        if now_pt.date() > last_reset_pt.date():
+            logger.info("[QUOTA-RESET] New Pacific-Time day - clearing quota usage data")
             self.usage_data = {
                 'sets': {},
-                'last_reset': now.isoformat()
+                'last_reset': now_pt.isoformat()
             }
             self._save_usage_data()
     
+    def report_quota_signal(self, credential_set: int, signal: str = 'quotaExceeded'):
+        """Record a REAL Google quota signal for a credential set (WSP 97).
+
+        Call this when the YouTube API itself reports exhaustion
+        (HTTP 403 with reason 'quotaExceeded' / 'dailyLimitExceeded'). This
+        is the authoritative truth signal: unlike the local counter it cannot
+        drift. It forces a CRITICAL alert and is recorded so subsequent
+        _check_alerts() calls treat the set as genuinely exhausted until the
+        Pacific-Time daily reset clears it.
+
+        Args:
+            credential_set: Credential set number that received the signal.
+            signal: The Google reason string (for the audit trail).
+        """
+        self._google_quota_signals[credential_set] = {
+            'signal': signal,
+            'timestamp': self._now().isoformat(),
+        }
+        logger.warning(
+            f"[QUOTA-SIGNAL] Real Google quota signal '{signal}' for set {credential_set}"
+        )
+        self._check_alerts(credential_set)
+
+    def _has_real_quota_signal(self, credential_set: int) -> bool:
+        """Whether a real Google quota signal is currently active for a set.
+
+        Signals are cleared on the Pacific-Time daily reset (which rebuilds
+        usage_data); a signal older than the current last_reset is stale.
+        """
+        sig = self._google_quota_signals.get(credential_set)
+        if not sig:
+            return False
+        try:
+            sig_dt = to_pacific(datetime.fromisoformat(sig['timestamp']))
+            last_reset_dt = to_pacific(datetime.fromisoformat(self.usage_data['last_reset']))
+            # Stale if it predates the current PT day's reset.
+            if sig_dt.date() < last_reset_dt.date():
+                self._google_quota_signals.pop(credential_set, None)
+                return False
+        except (TypeError, ValueError, KeyError):
+            pass
+        return True
+
     def _check_alerts(self, credential_set: int):
-        """Check if usage warrants an alert."""
+        """Emit quota alerts under WSP 97 truth gating.
+
+        A CRITICAL/WARNING alert is emitted ONLY when at least one of:
+          - a REAL Google quota signal is active (report_quota_signal), OR
+          - the RECONCILED local 'used' counter is >= the threshold.
+
+        Because the local counter is reconciled to the operations ledger on
+        load, a drift-corrupted counter alone can no longer trigger a false
+        CRITICAL: it is corrected before this check ever runs.
+        """
         set_key = str(credential_set)
-        if set_key not in self.usage_data['sets']:
-            return
-        
-        used = self.usage_data['sets'][set_key]['used']
-        limit = self.daily_limits[credential_set]
-        usage_percent = used / limit
-        
+        used = 0
+        if set_key in self.usage_data['sets']:
+            used = self.usage_data['sets'][set_key].get('used', 0)
+
+        limit = self.daily_limits.get(credential_set, 10000)
+        usage_percent = (used / limit) if limit > 0 else 0
+
+        real_signal = self._has_real_quota_signal(credential_set)
+
         alert = None
-        if usage_percent >= self.critical_threshold:
+        # CRITICAL: real Google signal OR reconciled local usage >= critical.
+        if real_signal or usage_percent >= self.critical_threshold:
+            trigger = 'google_signal' if real_signal else 'local_counter'
             alert = {
-                'timestamp': datetime.now().isoformat(),
+                'timestamp': self._now().isoformat(),
                 'credential_set': credential_set,
                 'severity': 'CRITICAL',
                 'usage_percent': usage_percent * 100,
                 'used': used,
                 'limit': limit,
+                'trigger': trigger,
                 'message': f"[ALERT] CRITICAL: Set {credential_set} at {usage_percent*100:.1f}% quota usage!"
             }
             logger.critical(alert['message'])
-            
+
+        # WARNING: only on reconciled local usage (no real signal needed,
+        # but a drift-corrupted counter is already reconciled away above).
         elif usage_percent >= self.warning_threshold:
-            # Only alert once per threshold crossing
-            recent_alerts = [a for a in self.alerts 
-                           if a['credential_set'] == credential_set 
-                           and datetime.fromisoformat(a['timestamp']) > datetime.now() - timedelta(hours=1)]
-            
+            # Only alert once per threshold crossing (within the last hour).
+            now = self._now()
+            recent_alerts = [
+                a for a in self.alerts
+                if a['credential_set'] == credential_set
+                and datetime.fromisoformat(a['timestamp']) > now - timedelta(hours=1)
+            ]
+
             if not any(a['severity'] == 'WARNING' for a in recent_alerts):
                 alert = {
-                    'timestamp': datetime.now().isoformat(),
+                    'timestamp': now.isoformat(),
                     'credential_set': credential_set,
                     'severity': 'WARNING',
                     'usage_percent': usage_percent * 100,
                     'used': used,
                     'limit': limit,
-                    'message': f"[U+26A0]️ WARNING: Set {credential_set} at {usage_percent*100:.1f}% quota usage"
+                    'trigger': 'local_counter',
+                    'message': f"[WARNING] Set {credential_set} at {usage_percent*100:.1f}% quota usage"
                 }
                 logger.warning(alert['message'])
-        
+
         if alert:
             self._save_alert(alert)
             self._trigger_external_alert(alert)
@@ -269,7 +460,7 @@ class QuotaMonitor:
         self._check_daily_reset()
         
         summary = {
-            'timestamp': datetime.now().isoformat(),
+            'timestamp': self._now().isoformat(),
             'total_available': sum(self.daily_limits.values()),
             'total_used': 0,
             'sets': {}

--- a/modules/platform_integration/youtube_auth/tests/test_quota_monitor.py
+++ b/modules/platform_integration/youtube_auth/tests/test_quota_monitor.py
@@ -16,7 +16,7 @@ import json
 import os
 import tempfile
 import shutil
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch, MagicMock, mock_open
 from pathlib import Path
 import sys
@@ -88,40 +88,49 @@ class TestQuotaMonitor(unittest.TestCase):
         self.assertEqual(set_data['operations']['search.list']['units'], 100)
     
     def test_check_daily_reset(self):
-        """WSP 4 FMAS-F: Test daily quota reset at 24-hour boundary."""
-        # Set last reset to 25 hours ago
-        old_time = datetime.now() - timedelta(hours=25)
-        self.monitor.usage_data['last_reset'] = old_time.isoformat()
-        
-        # Add some usage
-        self.monitor.usage_data['sets']['1'] = {'used': 5000, 'operations': {}}
-        
-        # Trigger reset check
-        self.monitor._check_daily_reset()
-        
-        # Verify reset occurred
-        self.assertEqual(self.monitor.usage_data['sets'], {})
-        
-        # Verify new reset time is recent
-        new_reset = datetime.fromisoformat(self.monitor.usage_data['last_reset'])
-        time_diff = datetime.now() - new_reset
-        self.assertLess(time_diff.seconds, 5)
-    
+        """WSP 4 FMAS-F: Reset across a Pacific-Time day boundary clears usage.
+
+        Updated for slice YT-QUOTA-TRACKING-TRUTH-PHASE1: the reset boundary is
+        midnight America/Los_Angeles (Google quota boundary), not rolling-24h.
+        Times injected as tz-aware UTC for determinism (June 2026 = PDT, UTC-7).
+        """
+        # last_reset 06:00 UTC = 2026-06-14 23:00 PT; now = 2026-06-15 10:00 PT.
+        monitor = QuotaMonitor(
+            memory_dir=self.test_dir,
+            now_provider=lambda: datetime(2026, 6, 15, 17, 0, 0, tzinfo=timezone.utc),
+        )
+        monitor.usage_data['last_reset'] = datetime(
+            2026, 6, 15, 6, 0, 0, tzinfo=timezone.utc).isoformat()
+        monitor.usage_data['sets']['1'] = {'used': 5000, 'operations': {}}
+
+        monitor._check_daily_reset()
+
+        # New Pacific-Time day -> usage cleared.
+        self.assertEqual(monitor.usage_data['sets'], {})
+        # And last_reset re-anchored to the injected "now" (in PT).
+        new_reset = datetime.fromisoformat(monitor.usage_data['last_reset'])
+        self.assertEqual(new_reset.date(), datetime(2026, 6, 15).date())
+
     def test_check_daily_reset_not_needed(self):
-        """WSP 4 FMAS-F: Test daily reset when not yet 24 hours."""
-        # Set last reset to 23 hours ago
-        recent_time = datetime.now() - timedelta(hours=23)
-        self.monitor.usage_data['last_reset'] = recent_time.isoformat()
-        
-        # Add some usage
-        self.monitor.usage_data['sets']['1'] = {'used': 5000, 'operations': {}}
-        
-        # Trigger reset check
-        self.monitor._check_daily_reset()
-        
-        # Verify NO reset occurred
-        self.assertIn('1', self.monitor.usage_data['sets'])
-        self.assertEqual(self.monitor.usage_data['sets']['1']['used'], 5000)
+        """WSP 4 FMAS-F: Same Pacific-Time day -> usage is NOT reset.
+
+        Updated for slice YT-QUOTA-TRACKING-TRUTH-PHASE1: even a >20h gap does
+        NOT reset as long as it stays within the same PT calendar day.
+        """
+        # last_reset 08:00 UTC = 2026-06-15 01:00 PT; now = 2026-06-15 13:00 PT.
+        monitor = QuotaMonitor(
+            memory_dir=self.test_dir,
+            now_provider=lambda: datetime(2026, 6, 15, 20, 0, 0, tzinfo=timezone.utc),
+        )
+        monitor.usage_data['last_reset'] = datetime(
+            2026, 6, 15, 8, 0, 0, tzinfo=timezone.utc).isoformat()
+        monitor.usage_data['sets']['1'] = {'used': 5000, 'operations': {}}
+
+        monitor._check_daily_reset()
+
+        # Same Pacific-Time day -> no reset.
+        self.assertIn('1', monitor.usage_data['sets'])
+        self.assertEqual(monitor.usage_data['sets']['1']['used'], 5000)
     
     @patch('src.quota_monitor.logger')
     def test_alert_warning_threshold(self, mock_logger):
@@ -299,6 +308,237 @@ class TestQuotaMonitor(unittest.TestCase):
         set_data = self.monitor.usage_data['sets']['1']
         self.assertEqual(set_data['used'], 10)
         self.assertEqual(set_data['operations']['channels.list']['count'], 10)
+
+
+class TestQuotaTruthSignaling(unittest.TestCase):
+    """
+    WSP 97 Truth Signaling tests for QuotaMonitor.
+
+    Covers the quota-tracking-truth fixes (slice YT-QUOTA-TRACKING-TRUTH-PHASE1):
+      - drift reconciliation on load (used vs operations ledger),
+      - real-signal alert gating (drift-corrupted counter must NOT emit CRITICAL),
+      - Pacific-Time daily reset boundary (deterministic via injected `now`).
+
+    All tests are deterministic and offline: time is injected via now_provider,
+    and the on-disk quota_usage.json is written to a private temp dir.
+    """
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+
+    def _write_quota_file(self, payload):
+        """Write a quota_usage.json into the temp memory dir."""
+        path = os.path.join(self.test_dir, "quota_usage.json")
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+        return path
+
+    # --- Drift reconciliation -------------------------------------------------
+
+    def test_drift_reconcile_on_load_corrupt_used(self):
+        """Corrupt {used:9901, ops sum:1} loads -> used==1 with [QUOTA-DRIFT] warning."""
+        self._write_quota_file({
+            "sets": {
+                "1": {
+                    "used": 9901,
+                    "operations": {"channels.list": {"count": 1, "units": 1}},
+                }
+            },
+            "last_reset": datetime(2026, 6, 15, 9, 0, 0).isoformat(),
+        })
+
+        with patch("src.quota_monitor.logger") as mock_logger:
+            monitor = QuotaMonitor(
+                memory_dir=self.test_dir,
+                now_provider=lambda: datetime(2026, 6, 15, 10, 0, 0),
+            )
+
+        # Reconciled down to the operations-ledger sum.
+        self.assertEqual(monitor.usage_data["sets"]["1"]["used"], 1)
+
+        # [QUOTA-DRIFT] warning emitted.
+        drift_warnings = [
+            call.args[0] for call in mock_logger.warning.call_args_list
+            if "[QUOTA-DRIFT]" in call.args[0]
+        ]
+        self.assertTrue(drift_warnings, "expected a [QUOTA-DRIFT] warning on load")
+        self.assertIn("used=9901", drift_warnings[0])
+        self.assertIn("ops_sum=1", drift_warnings[0])
+        self.assertIn("reconciling to 1", drift_warnings[0])
+
+    def test_no_drift_warning_when_consistent(self):
+        """A counter within +/-1 of the ops sum must NOT warn or change."""
+        self._write_quota_file({
+            "sets": {
+                "1": {
+                    "used": 305,
+                    "operations": {
+                        "liveChatMessages.list": {"count": 1, "units": 5},
+                        "liveChatMessages.insert": {"count": 1, "units": 200},
+                        "search.list": {"count": 1, "units": 100},
+                    },
+                }
+            },
+            "last_reset": datetime(2026, 6, 15, 9, 0, 0).isoformat(),
+        })
+
+        with patch("src.quota_monitor.logger") as mock_logger:
+            monitor = QuotaMonitor(
+                memory_dir=self.test_dir,
+                now_provider=lambda: datetime(2026, 6, 15, 10, 0, 0),
+            )
+
+        self.assertEqual(monitor.usage_data["sets"]["1"]["used"], 305)
+        drift_warnings = [
+            call for call in mock_logger.warning.call_args_list
+            if "[QUOTA-DRIFT]" in call.args[0]
+        ]
+        self.assertEqual(drift_warnings, [])
+
+    # --- Alert gating (WSP 97 truth) -----------------------------------------
+
+    def test_drift_corrupted_counter_does_not_emit_false_critical(self):
+        """After a corrupt load, _check_alerts must NOT raise CRITICAL (truth gate)."""
+        self._write_quota_file({
+            "sets": {
+                "1": {
+                    "used": 9901,
+                    "operations": {"channels.list": {"count": 1, "units": 1}},
+                }
+            },
+            "last_reset": datetime(2026, 6, 15, 9, 0, 0).isoformat(),
+        })
+
+        monitor = QuotaMonitor(
+            memory_dir=self.test_dir,
+            now_provider=lambda: datetime(2026, 6, 15, 10, 0, 0),
+        )
+
+        with patch("src.quota_monitor.logger") as mock_logger:
+            monitor._check_alerts(1)
+
+        mock_logger.critical.assert_not_called()
+        # And no CRITICAL alert was persisted.
+        self.assertFalse(
+            any(a["severity"] == "CRITICAL" for a in monitor.alerts),
+            "drift-corrupted counter must never persist a CRITICAL alert",
+        )
+
+    def test_real_quota_signal_raises_critical_even_at_low_usage(self):
+        """A real Google quotaExceeded signal DOES raise CRITICAL regardless of counter."""
+        self._write_quota_file({
+            "sets": {
+                "1": {
+                    "used": 1,
+                    "operations": {"channels.list": {"count": 1, "units": 1}},
+                }
+            },
+            "last_reset": datetime(2026, 6, 15, 9, 0, 0).isoformat(),
+        })
+
+        monitor = QuotaMonitor(
+            memory_dir=self.test_dir,
+            now_provider=lambda: datetime(2026, 6, 15, 10, 0, 0),
+        )
+
+        with patch("src.quota_monitor.logger") as mock_logger:
+            monitor.report_quota_signal(1, "quotaExceeded")
+
+        mock_logger.critical.assert_called_once()
+        critical_alerts = [a for a in monitor.alerts if a["severity"] == "CRITICAL"]
+        self.assertEqual(len(critical_alerts), 1)
+        self.assertEqual(critical_alerts[0]["trigger"], "google_signal")
+
+    def test_reconciled_counter_at_threshold_still_alerts(self):
+        """A genuinely high reconciled counter (>=95%) still raises CRITICAL."""
+        self._write_quota_file({
+            "sets": {
+                "1": {
+                    "used": 9600,
+                    "operations": {"search.list": {"count": 96, "units": 9600}},
+                }
+            },
+            "last_reset": datetime(2026, 6, 15, 9, 0, 0).isoformat(),
+        })
+
+        monitor = QuotaMonitor(
+            memory_dir=self.test_dir,
+            now_provider=lambda: datetime(2026, 6, 15, 10, 0, 0),
+        )
+        # No drift: ops_sum == used == 9600.
+        self.assertEqual(monitor.usage_data["sets"]["1"]["used"], 9600)
+
+        with patch("src.quota_monitor.logger") as mock_logger:
+            monitor._check_alerts(1)
+
+        mock_logger.critical.assert_called_once()
+        critical_alerts = [a for a in monitor.alerts if a["severity"] == "CRITICAL"]
+        self.assertEqual(critical_alerts[0]["trigger"], "local_counter")
+
+    # --- Pacific-Time daily reset boundary -----------------------------------
+    #
+    # Times are injected as tz-aware UTC so the PT wall-clock is deterministic
+    # regardless of the host system timezone or whether tzdata is installed.
+    # June 2026 is PDT (UTC-7), so PT-midnight == 07:00 UTC.
+
+    def test_pt_same_day_no_reset(self):
+        """Same Pacific-Time calendar day -> usage is NOT reset."""
+        # last_reset 08:00 UTC = 01:00 PT (2026-06-15); now 20:00 UTC = 13:00 PT same day.
+        last_reset_utc = datetime(2026, 6, 15, 8, 0, 0, tzinfo=timezone.utc)
+        monitor = QuotaMonitor(
+            memory_dir=self.test_dir,
+            now_provider=lambda: datetime(2026, 6, 15, 20, 0, 0, tzinfo=timezone.utc),
+        )
+        monitor.usage_data["last_reset"] = last_reset_utc.isoformat()
+        monitor.usage_data["sets"]["1"] = {
+            "used": 5000, "operations": {}, "last_call": None,
+        }
+
+        monitor._check_daily_reset()
+
+        self.assertIn("1", monitor.usage_data["sets"])
+        self.assertEqual(monitor.usage_data["sets"]["1"]["used"], 5000)
+
+    def test_pt_cross_day_resets(self):
+        """Crossing into a new Pacific-Time day -> usage IS reset."""
+        # last_reset 06:00 UTC = 2026-06-14 23:00 PT; now 17:00 UTC = 2026-06-15 10:00 PT.
+        last_reset_utc = datetime(2026, 6, 15, 6, 0, 0, tzinfo=timezone.utc)
+        monitor = QuotaMonitor(
+            memory_dir=self.test_dir,
+            now_provider=lambda: datetime(2026, 6, 15, 17, 0, 0, tzinfo=timezone.utc),
+        )
+        monitor.usage_data["last_reset"] = last_reset_utc.isoformat()
+        monitor.usage_data["sets"]["1"] = {
+            "used": 5000, "operations": {}, "last_call": None,
+        }
+
+        monitor._check_daily_reset()
+
+        # New PT day -> sets cleared.
+        self.assertEqual(monitor.usage_data["sets"], {})
+
+    def test_pt_boundary_is_not_rolling_24h(self):
+        """A <24h gap that still crosses PT midnight DOES reset (not rolling-24h)."""
+        # last_reset 06:30 UTC = 2026-06-14 23:30 PT; now 07:30 UTC = 2026-06-15 00:30 PT.
+        # Only 1 hour elapsed, but it is a new Pacific-Time calendar day.
+        last_reset_utc = datetime(2026, 6, 15, 6, 30, 0, tzinfo=timezone.utc)
+        monitor = QuotaMonitor(
+            memory_dir=self.test_dir,
+            now_provider=lambda: datetime(2026, 6, 15, 7, 30, 0, tzinfo=timezone.utc),
+        )
+        monitor.usage_data["last_reset"] = last_reset_utc.isoformat()
+        monitor.usage_data["sets"]["1"] = {
+            "used": 5000, "operations": {}, "last_call": None,
+        }
+
+        monitor._check_daily_reset()
+
+        # Rolling-24h logic would NOT reset here; PT-boundary logic DOES.
+        self.assertEqual(monitor.usage_data["sets"], {})
 
 
 class TestQuotaMonitorWSPCompliance(unittest.TestCase):


### PR DESCRIPTION
## Slice: YT-QUOTA-TRACKING-TRUTH-PHASE1 (Worker-Lane Q1)

Decision-for-gate, independent of the OAuth arc. **Do NOT self-merge - leave OPEN for the external gate** (quota runtime code).

### Problem (verified from source, WSP 97)
`quota_monitor.py` could emit a CRITICAL "~99% quota" alert from a **stale / drift-corrupted local counter** rather than a real Google `quotaExceeded` - a WSP 97 truth violation. Three confirmed mechanisms:
1. `_normalize_usage_data()` loaded `sets.N.used` verbatim, never checking it against the sum of its per-operation `units` ledger. A corrupt `{used:9901, ops sum:1}` loaded as 99%.
2. `_check_alerts()` raised CRITICAL purely on `used/limit` from that local counter - no real Google signal required.
3. `_check_daily_reset()` used rolling-24h-from-last_reset, NOT Google's midnight-Pacific quota boundary.

### Changes (`src/quota_monitor.py` only)
- **Drift reconciliation on load**: per set `used_from_ops = sum(op["units"])`; if `abs(used - used_from_ops) > 1`, log `WARNING [QUOTA-DRIFT] set N used=X ops_sum=Y; reconciling to Y` and set `used = used_from_ops`.
- **Pacific-Time reset boundary**: reset when the PT calendar date rolls over (midnight America/Los_Angeles). Added `to_pacific()` using stdlib `zoneinfo` with a manual US-DST fallback (PST UTC-8 / PDT UTC-7). NOTE: this host has no `tzdata` (zoneinfo raised `ZoneInfoNotFoundError`), so the fallback is the **active** path and is exercised by tests.
- **Real-signal alert gating**: new `report_quota_signal()` for HTTP 403 `quotaExceeded`; CRITICAL/WARNING now requires a real Google signal OR a *reconciled* local `used >= threshold`. A drift-corrupted counter alone can no longer fire. Alerts carry a `trigger` field (`google_signal` / `local_counter`).
- **Injectable `now_provider`** for deterministic offline tests (additive, backward compatible).

### Tests (`tests/test_quota_monitor.py`)
- New `TestQuotaTruthSignaling` (8 tests): corrupt load -> `used==1` + `[QUOTA-DRIFT]`; no false CRITICAL after corrupt load; real signal raises CRITICAL at ~0% usage; high reconciled counter still alerts; PT same-day no-reset; PT cross-day reset; PT-boundary != rolling-24h.
- Updated 2 pre-existing reset tests to the new PT-day contract.
- **pytest: 22 passed, 5 failed.** The 5 failures are **PRE-EXISTING** and out of scope: the test file assumes a 7-set (1-7) config while production `daily_limits` is `{1, 10}` (`test_initialization`, `test_get_best_credential_set`, `test_get_best_credential_set_all_exhausted`, `test_get_usage_summary`, `test_quota_file_persistence`). Baseline was 5 failed / 14 passed; this slice adds 8 passing tests and fixes 2 reset tests without changing the pre-existing failure set.

### HoloIndex Retrieval Report
| # | Query | Hits | Top result | Quality | Used? |
|---|-------|------|------------|---------|-------|
| 1 | quota monitor usage reconcile drift credential set | 20 | modules\communication\livechat\src\quota_aware_poller.py | LOW | N |
| 2 | youtube quota daily reset pacific time critical alert threshold | 20 | modules\communication\livechat\src\mcp_youtube_integration.py | LOW | N |
| 3 | quota_usage operations units track_api_call get_usage_summary | 20 | modules\communication\livechat\src\intelligent_throttle_manager.py | LOW | N |

### Retrieval verdict
- noise: HIGH - all 3 queries returned livechat throttle/poller + WSP/docs; none surfaced the target `quota_monitor.py`.
- ordering: target file never ranked; index biased toward livechat quota consumers.
- missing artifacts: `youtube_auth/src/quota_monitor.py` + its tests absent from all result sets.
- staleness/duplication: not the issue - a retrieval miss.
- action: re-queried 3x (all LOW) -> fell back to direct path reads (Glob + Read of `quota_monitor.py`, `tests/test_quota_monitor.py`, `youtube_auth/ModLog.md`).

### Attention flags (012 triage)
- [ ] NEEDS_012: merge / sovereign nod / OAuth browser / secrets
- [x] NEEDS_012: HoloIndex miss - relied on direct path reads (target not surfaced by 3 queries)
- [ ] NEEDS_012: test failure / worktree integrity / quota drift (5 failures are PRE-EXISTING 7-set mismatch, not introduced)
- [ ] CLEAR: CI green, worktree clean, no flags

Scope: exactly 3 files (`src/quota_monitor.py`, `tests/test_quota_monitor.py`, `ModLog.md`). No `memory/*.json`, no OAuth/stream_resolver/menu code. No `git stash` used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
