### PR TITLE
feat(video_indexer): Ask Studio header PRIMARY indexing path (STUDIO_ASK_STUDIO_HEADER_PHASE1)

### DIFF
--- a/modules/ai_intelligence/video_indexer/ModLog.md
+++ b/modules/ai_intelligence/video_indexer/ModLog.md
@@ -2,6 +2,52 @@
 
 **WSP Compliance**: WSP 22 (ModLog Updates)
 
+## V0.20.0 - Ask Studio Header PRIMARY path (STUDIO_ASK_STUDIO_HEADER_PHASE1) (2026-06-15)
+
+### Why
+The watch-page "Ask" button and the old Studio popup menu selectors were stale.
+The current YouTube Studio video-edit page exposes an "Ask Studio" entry in the
+page header. Phase 1 makes that the canonical (PRIMARY) indexing path.
+
+### Changed
+- `src/studio_ask_indexer.py`:
+  - Added `ASK_STUDIO_SELECTORS` (header button, dialog, contenteditable prompt,
+    streaming/response containers) as PRIMARY.
+  - Demoted (kept, not deleted) the watch-page Ask + Studio popup selectors to
+    labelled FALLBACK. `USE_WATCH_PAGE` flipped to `False`.
+  - Rewrote `ask_about_video`: Studio edit page -> Ask Studio header -> dialog ->
+    focus contenteditable prompt -> type -> Enter -> DOM-scraped response
+    (`_open_ask_studio`, `_scrape_ask_response`, `_first_element` helpers).
+  - Added `RESPONSE_TIMEOUT_SECONDS` (30s) — response scrape **fails closed**
+    (no DOM text => `success=False`, nothing stored).
+  - Added `CHANNEL_PROMPTS` + `_prompt_for_channel()` keyed off the existing
+    registry `shorts.description_template` (undaodu / foundups / ffcpln-music
+    lighter / generic fallback). Threaded `channel_entry` through
+    `index_channel_videos` -> `ask_about_video`.
+- Reused existing writer `VideoIndexStore.save_index` ->
+  `memory/video_index/{channel}/{video_id}.json` (NO new storage invented).
+- **No clipboard. No publish/schedule mutation. No Skillz/WRE promotion.**
+- Scheduler order unchanged — already `comments -> index -> schedule` in
+  `auto_moderator_dae.py` (re-ordering deferred to Phase 3).
+
+### Tests
+- `tests/test_studio_ask_header.py` (12): selector presence, PRIMARY path success,
+  Ask Studio succeeds when watch-page Ask missing, response timeout fails closed,
+  no-clipboard guard, channel prompt selection (undaodu != foundups,
+  ffcpln lighter, unknown -> generic), channel prompt threaded into ask.
+- `tests/test_indexer_scheduler_order.py` (2): locks comments->index->schedule.
+- Mock DOM only; no live YouTube. No skip/xfail.
+
+### Phase notes
+- `STUDIO_ASK_SKILL_PROMOTE_PHASE2`: promote selectors into `ask_studio_index`
+  Skillz + WRE registration (later).
+- `INDEX_BEFORE_SHORTS_SCHEDULE_PHASE3`: revisit scheduler ordering after stable.
+
+### WSP
+- WSP 22 (ModLog), WSP 84 (reused VideoIndexStore + registry), WSP 72 (independence)
+
+---
+
 ## V0.19.3 - LIVE Video Prioritization + Daemon Mode (2026-03-18)
 
 ### Added

--- a/modules/ai_intelligence/video_indexer/skillz/transcript_ask/SKILLz.md
+++ b/modules/ai_intelligence/video_indexer/skillz/transcript_ask/SKILLz.md
@@ -23,6 +23,30 @@ retirement_date: null
 
 ---
 
+## ⚠️ Phase 1 Selector Notice (STUDIO_ASK_STUDIO_HEADER_PHASE1)
+
+**STALE**: The watch-page `button[aria-label="Ask"]` path documented below
+(Architecture / Step 2) is **STALE** and is now a labelled *fallback only*.
+
+**Phase 1 canonical path** is the **YouTube Studio "Ask Studio" header**:
+- Entry: `ytcp-icon-button[aria-label="Ask Studio"]` on the Studio video-edit page
+- Dialog: `ytcp-dialog#dialog`
+- Prompt: `div[contenteditable][aria-label="Ask something"]`
+- Response: scraped from `#PAcreator_chat_streaming` (DOM text, **no clipboard**)
+
+Canonical implementation: `src/studio_ask_indexer.py`
+(`ASK_STUDIO_SELECTORS`, `StudioAskIndexer.ask_about_video`).
+
+**Phase 2 — `STUDIO_ASK_SKILL_PROMOTE_PHASE2`**: promote the working Ask Studio
+selectors into an `ask_studio_index` Skillz and register with WRE *after* Phase 1
+proves stable. (Phase 1 does NOT touch the Skillz registry or WRE router.)
+
+**Phase 3 — `INDEX_BEFORE_SHORTS_SCHEDULE_PHASE3`**: only after Phase 1 is stable,
+revisit scheduler ordering (already `comments -> index -> schedule` in
+`auto_moderator_dae.py`).
+
+---
+
 ## Skill Purpose
 
 Extract **full verbatim transcripts** from YouTube videos using the built-in "Ask" Gemini feature. This bypasses API quotas by using browser automation.

--- a/modules/ai_intelligence/video_indexer/src/studio_ask_indexer.py
+++ b/modules/ai_intelligence/video_indexer/src/studio_ask_indexer.py
@@ -99,31 +99,74 @@ class StudioAskIndexer:
     query video content, then stores results in VideoContentIndex.
     """
     
-    # Selectors for YouTube (Watch Page AND Studio)
+    # =========================================================================
+    # PRIMARY (Phase 1): YouTube Studio "Ask Studio" header UI
+    # ---------------------------------------------------------------------
+    # The current Studio video-edit page exposes an "Ask Studio" entry in the
+    # page header (ytcp-icon-button). Clicking it opens a creator chat dialog
+    # with a contenteditable prompt box and a streaming response panel.
+    # This is the CANONICAL path for Phase 1. The legacy watch-page Ask button
+    # and the old Studio popup menu are DEMOTED to fallback (see SELECTORS).
+    # =========================================================================
+    ASK_STUDIO_SELECTORS = {
+        # Header entry button that opens the Ask Studio dialog.
+        "header_button": [
+            'ytcp-icon-button[aria-label="Ask Studio"]',
+            'ytcp-icon-button[aria-label*="Ask Studio"]',
+            'button[aria-label="Ask Studio"]',
+            'button[aria-label*="Ask Studio"]',
+        ],
+        # Dialog container shown after clicking the header button.
+        "dialog": [
+            'ytcp-dialog#dialog',
+            'ytcp-dialog',
+        ],
+        # Contenteditable prompt box inside the dialog.
+        "prompt_box": [
+            'div[contenteditable][aria-label="Ask something"]',
+            'div.ytcpCreatorChatEntityAttachmentInlineFlowPromptBox[contenteditable="true"]',
+            'div[contenteditable="true"][aria-label*="Ask"]',
+        ],
+        # Streaming / response container candidates (DOM text, NOT clipboard).
+        "response_stream": [
+            '#PAcreator_chat_streaming',
+            'div.ytcpCreatorChatEntityResponse',
+            'ytcp-creator-chat-response',
+            '[class*="CreatorChat"][class*="Response"]',
+        ],
+    }
+
+    # Legacy/fallback selectors (Watch Page AND Studio popup menu).
+    # FALLBACK ONLY (Phase 1): retained for resilience, never the primary path.
     SELECTORS = {
         "content_tab": "a[href*='/channel/'][href*='/videos']",
         "video_row": "ytcp-video-row",
         "video_title": "a#video-title",
 
-        # WATCH PAGE: Ask button is in #actions > ytd-menu-renderer > #flexible-item-buttons
+        # FALLBACK WATCH PAGE: Ask button is in #actions > ytd-menu-renderer > #flexible-item-buttons
         "watch_ask_button": "#flexible-item-buttons button, yt-button-view-model button",
         "watch_actions": "#actions ytd-menu-renderer",
 
-        # STUDIO PAGE: Menu trigger to open popup where Ask lives
+        # FALLBACK STUDIO POPUP: Menu trigger to open popup where old Ask lived
         "studio_menu_trigger": "ytd-menu-renderer button, button[aria-label='More actions'], #button-shape button",
         # Ask button is inside popup menu as tp-yt-paper-item
         "studio_ask_popup_item": "tp-yt-paper-item.style-scope.ytd-menu-service-item-renderer",
         "popup_menu": "ytd-menu-popup-renderer, tp-yt-iron-dropdown",
 
-        # Gemini chat interface (after clicking Ask)
+        # Gemini chat interface (legacy fallback input/response)
         "ask_input": "textarea[placeholder*='Ask'], input[placeholder*='Ask'], .gemini-input textarea",
         "ask_response": ".gemini-response, .ask-response-content, .gemini-chat-response",
         "video_details_link": "a[href*='/video/'][href*='/edit']",
     }
 
-    # Watch page is simpler (direct button), prefer it over Studio
-    USE_WATCH_PAGE = True
-    
+    # Phase 1: PRIMARY path is the Studio "Ask Studio" header (NOT watch page).
+    # Watch-page Ask is demoted to a labelled fallback only.
+    USE_WATCH_PAGE = False
+
+    # Max seconds to wait for the Ask Studio response stream to produce text
+    # before failing closed (no partial/garbage indexing).
+    RESPONSE_TIMEOUT_SECONDS = 30.0
+
     # Standard prompt for video analysis with content category detection
     ASK_PROMPT = """Analyze this video and respond in JSON format:
 {
@@ -141,6 +184,64 @@ CONTENT CATEGORY (pick ONE):
 - ice_remix: Political content, ICE/immigration, news clips, activist
 - educational: Tutorial, how-to, teaching, informational
 - other: None of the above"""
+
+    # Channel-specific Ask Studio prompts.
+    # Keyed by the channel registry `description_template` value
+    # (youtube_channel_registry: undaodu->undaodu, foundups->foundups,
+    #  move2japan/antifafm->ffcpln). Music/ffcpln channels get a LIGHTER prompt
+    # that does NOT demand a full transcript (no speech to transcribe).
+    CHANNEL_PROMPTS = {
+        "undaodu": """Analyze this UnDaoDu video and respond in JSON format:
+{
+  "content_category": "personal_vlog|educational|ice_remix|other",
+  "topics": ["topic1", "topic2"],
+  "segments": [
+    {"time": "0:00", "topic": "Introduction", "summary": "..."},
+    {"time": "1:30", "topic": "Main point", "summary": "..."}
+  ]
+}
+Focus on the spoken ideas: identity, consciousness, pAVS/FoundUps themes.
+Include timestamped segments for the key points discussed.""",
+        "foundups": """Analyze this FoundUps video and respond in JSON format:
+{
+  "content_category": "educational|personal_vlog|other",
+  "topics": ["topic1", "topic2"],
+  "segments": [
+    {"time": "0:00", "topic": "Introduction", "summary": "..."},
+    {"time": "1:30", "topic": "Main point", "summary": "..."}
+  ]
+}
+Focus on startup / autonomous-venture themes and the key points discussed.
+Include timestamped segments.""",
+        # Lighter prompt for FFCPLN / music channels (Move2Japan, antifaFM):
+        # mostly instrumental, no full transcript expected.
+        "ffcpln": """Analyze this music/short video and respond in JSON format:
+{
+  "content_category": "ffcpln_music|other",
+  "topics": ["mood", "genre"],
+  "segments": []
+}
+This is a music or short visual piece. Do NOT produce a full transcript.
+Give a brief category and a few mood/genre topics only.""",
+    }
+
+    @classmethod
+    def _prompt_for_channel(cls, channel_entry: Optional[Dict[str, Any]]) -> str:
+        """
+        Select the Ask Studio prompt for a channel.
+
+        Resolution order:
+          1. channel registry `shorts.description_template` -> CHANNEL_PROMPTS
+          2. unknown / missing -> generic ASK_PROMPT (safe default)
+
+        Does NOT invent a new registry; reads existing description_template.
+        """
+        template = ""
+        if channel_entry:
+            template = str(
+                (channel_entry.get("shorts") or {}).get("description_template", "")
+            ).strip().lower()
+        return cls.CHANNEL_PROMPTS.get(template, cls.ASK_PROMPT)
 
     def __init__(
         self,
@@ -293,18 +394,90 @@ CONTENT CATEGORY (pick ONE):
             logger.warning(f"[STUDIO-ASK] JSON parse failed: {e}")
             return {"topics": [], "segments": [], "content_category": "other", "raw": response_text}
     
-    async def ask_about_video(self, video_id: str) -> AskResult:
+    def _first_element(self, selectors: List[str]):
+        """Return the first element matching any selector in the list, else None."""
+        for selector in selectors:
+            try:
+                el = self.driver.find_element("css selector", selector)
+                if el:
+                    return el
+            except Exception:
+                continue
+        return None
+
+    def _open_ask_studio(self) -> bool:
         """
-        Use Ask Gemini feature for a specific video.
-        
+        PRIMARY (Phase 1): open the Studio "Ask Studio" dialog from the header.
+
+        Returns True if the header button was found and clicked AND the dialog
+        + prompt box subsequently appear, False otherwise (so callers can fall
+        back to the legacy watch-page / popup paths).
+        """
+        header_btn = self._first_element(self.ASK_STUDIO_SELECTORS["header_button"])
+        if not header_btn:
+            logger.info("[STUDIO-ASK] Ask Studio header button not found")
+            return False
+        try:
+            header_btn.click()
+        except Exception as e:
+            logger.info(f"[STUDIO-ASK] Ask Studio header click failed: {e}")
+            return False
+        logger.info("[STUDIO-ASK] Clicked Ask Studio header button (PRIMARY)")
+        return True
+
+    async def _scrape_ask_response(self) -> str:
+        """
+        Scrape the Ask Studio response text from the streaming/response DOM nodes.
+
+        Polls the response container selectors until non-empty text appears or
+        RESPONSE_TIMEOUT_SECONDS elapses. NO clipboard is used - DOM text only.
+        Returns the scraped text ("" if the response never materialized).
+        """
+        import time as _time
+
+        deadline = _time.monotonic() + self.RESPONSE_TIMEOUT_SECONDS
+        response_text = ""
+        while _time.monotonic() < deadline:
+            el = self._first_element(self.ASK_STUDIO_SELECTORS["response_stream"])
+            if el is not None:
+                try:
+                    text = (el.text or "").strip()
+                except Exception:
+                    text = ""
+                if text:
+                    response_text = text
+                    break
+            await self._human_delay(1.0, 0.2)
+        return response_text
+
+    async def ask_about_video(
+        self,
+        video_id: str,
+        prompt: Optional[str] = None,
+        channel_entry: Optional[Dict[str, Any]] = None,
+    ) -> AskResult:
+        """
+        Use the YouTube Studio "Ask Studio" feature to index a specific video.
+
+        Phase 1 PRIMARY path:
+          Studio video-edit page -> Ask Studio header button -> dialog/chat
+          stream -> contenteditable prompt -> Enter -> DOM-scraped response.
+
+        Legacy watch-page Ask / Studio popup menu are kept ONLY as fallback.
+
         Args:
             video_id: YouTube video ID
-            
+            prompt: Optional channel-specific prompt (defaults to ASK_PROMPT or
+                    the prompt resolved from channel_entry).
+            channel_entry: Optional channel registry entry; used to pick the
+                    channel-specific prompt via description_template.
+
         Returns:
-            AskResult with parsed response
+            AskResult with parsed response (success=False, response fails closed
+            if the Ask Studio response stream never produces text).
         """
         import asyncio
-        
+
         if not self.driver:
             return AskResult(
                 video_id=video_id,
@@ -315,54 +488,76 @@ CONTENT CATEGORY (pick ONE):
                 success=False,
                 error="No browser driver available"
             )
-        
+
+        # Resolve the prompt: explicit > channel-specific > generic default.
+        ask_prompt = prompt or self._prompt_for_channel(channel_entry)
+
         try:
-            # Navigate to video page (watch page preferred for simpler Ask button)
-            if self.USE_WATCH_PAGE:
-                video_url = f"https://www.youtube.com/watch?v={video_id}"
-            else:
-                video_url = f"https://studio.youtube.com/video/{video_id}/edit"
-            logger.info(f"[STUDIO-ASK] Navigating to {video_url}")
-            self.driver.get(video_url)
+            from selenium.webdriver.common.keys import Keys
+
+            # PRIMARY: navigate to the Studio video-edit page (Ask Studio lives here).
+            studio_url = f"https://studio.youtube.com/video/{video_id}/edit"
+            logger.info(f"[STUDIO-ASK] Navigating to {studio_url}")
+            self.driver.get(studio_url)
             await self._human_delay(3.0, 0.4)
-            
-            # Determine which page we're on and get title
+
+            # Studio title is in the title input field.
             title = ""
-            is_watch_page = "youtube.com/watch" in self.driver.current_url
+            try:
+                title_el = self.driver.find_element("css selector", "input#title-field, h1.title")
+                title = title_el.get_attribute("value") or title_el.text
+            except Exception:
+                pass
 
-            if is_watch_page:
-                # WATCH PAGE: Title is in different location
-                try:
-                    title_el = self.driver.find_element("css selector", "h1.ytd-watch-metadata, yt-formatted-string.ytd-watch-metadata")
-                    title = title_el.text
-                except Exception:
-                    pass
-            else:
-                # STUDIO PAGE: Title is in input field
-                try:
-                    title_el = self.driver.find_element("css selector", "input#title-field, h1.title")
-                    title = title_el.get_attribute("value") or title_el.text
-                except Exception:
-                    pass
-
+            used_ask_studio = False
             ask_clicked = False
 
-            if is_watch_page or self.USE_WATCH_PAGE:
-                # WATCH PAGE APPROACH: Direct button in #flexible-item-buttons
-                # Per 012 DOM: #actions > ytd-menu-renderer > #flexible-item-buttons > yt-button-view-model > button
-                logger.info("[STUDIO-ASK] Trying watch page Ask button approach")
+            # ---- PRIMARY PATH: Ask Studio header button + dialog ----
+            if self._open_ask_studio():
+                await self._human_delay(2.0, 0.3)
+                # Confirm the dialog appeared, then find the contenteditable prompt box.
+                dialog = self._first_element(self.ASK_STUDIO_SELECTORS["dialog"])
+                prompt_box = self._first_element(self.ASK_STUDIO_SELECTORS["prompt_box"])
+                if dialog is not None and prompt_box is not None:
+                    try:
+                        prompt_box.click()
+                        # contenteditable div: send_keys types into it (no clipboard).
+                        prompt_box.send_keys(ask_prompt)
+                        await self._human_delay(1.0, 0.2)
+                        prompt_box.send_keys(Keys.ENTER)
+                        logger.info("[STUDIO-ASK] Submitted prompt via Ask Studio dialog")
+                        ask_clicked = True
+                        used_ask_studio = True
+                    except Exception as e:
+                        logger.warning(f"[STUDIO-ASK] Ask Studio prompt entry failed: {e}")
+                else:
+                    logger.info("[STUDIO-ASK] Ask Studio dialog/prompt box not found - falling back")
 
-                # Find Ask button by JavaScript (most reliable for dynamic YT elements)
-                # Full watch page DOM: #flexible-item-buttons > yt-button-view-model > button-view-model > button.yt-spec-button-shape-next
+            # ---- FALLBACK PATH: legacy watch-page Ask + Studio popup menu ----
+            if not used_ask_studio:
+                logger.info("[STUDIO-ASK] FALLBACK: legacy watch-page / popup Ask path")
+                # Navigate to watch page for the legacy direct Ask button.
+                watch_url = f"https://www.youtube.com/watch?v={video_id}"
+                self.driver.get(watch_url)
+                await self._human_delay(3.0, 0.4)
+                if not title:
+                    try:
+                        title_el = self.driver.find_element(
+                            "css selector",
+                            "h1.ytd-watch-metadata, yt-formatted-string.ytd-watch-metadata",
+                        )
+                        title = title_el.text
+                    except Exception:
+                        pass
+
+                # FALLBACK A: watch-page Ask button via JS.
                 ask_button = self.driver.execute_script("""
-                    // Method 1: Precise path from 012's DOM inspection
                     const flexItems = document.querySelector('#flexible-item-buttons');
                     if (flexItems) {
                         const viewModels = flexItems.querySelectorAll('yt-button-view-model');
                         for (let vm of viewModels) {
                             const text = (vm.textContent || vm.innerText || '').toLowerCase().trim();
                             if (text === 'ask') {
-                                // Get the button inside: button-view-model > button.yt-spec-button-shape-next
                                 const btn = vm.querySelector('button-view-model button.yt-spec-button-shape-next')
                                          || vm.querySelector('button.yt-spec-button-shape-next')
                                          || vm.querySelector('button');
@@ -370,91 +565,69 @@ CONTENT CATEGORY (pick ONE):
                             }
                         }
                     }
-                    // Method 2: Find by aria-label
                     const askByLabel = document.querySelector('button[aria-label*="Ask"]');
                     if (askByLabel) return askByLabel;
-                    // Method 3: Broader search - any button with Ask text in actions area
-                    const actionsArea = document.querySelector('#actions-inner, #menu');
-                    if (actionsArea) {
-                        const buttons = actionsArea.querySelectorAll('button.yt-spec-button-shape-next');
-                        for (let btn of buttons) {
-                            const parent = btn.closest('yt-button-view-model');
-                            if (parent && parent.textContent.toLowerCase().includes('ask')) {
-                                return btn;
-                            }
-                        }
-                    }
                     return null;
                 """)
-
                 if ask_button:
-                    ask_button.click()
-                    ask_clicked = True
-                    logger.info("[STUDIO-ASK] Clicked Ask button on watch page")
-                    await self._human_delay(2.0, 0.3)
-
-            if not ask_clicked:
-                # STUDIO PAGE FALLBACK: Open menu popup, find Ask item
-                logger.info("[STUDIO-ASK] Falling back to Studio popup menu approach")
-
-                # Step 1: Open the menu popup
-                menu_clicked = False
-                menu_selectors = [
-                    "ytd-menu-renderer button",
-                    "button[aria-label='More actions']",
-                    "#button-shape button",
-                    "yt-icon-button#button",
-                ]
-                for selector in menu_selectors:
                     try:
-                        menu_btn = self.driver.find_element("css selector", selector)
-                        menu_btn.click()
-                        menu_clicked = True
-                        logger.info(f"[STUDIO-ASK] Clicked menu via: {selector}")
-                        break
+                        ask_button.click()
+                        ask_clicked = True
+                        logger.info("[STUDIO-ASK] FALLBACK: clicked watch-page Ask button")
+                        await self._human_delay(2.0, 0.3)
                     except Exception:
-                        continue
+                        ask_clicked = False
 
-                if not menu_clicked:
-                    return AskResult(
-                        video_id=video_id,
-                        title=title,
-                        response_text="",
-                        topics=[],
-                        timestamps=[],
-                        success=False,
-                        error="Menu trigger not found"
-                    )
+                # FALLBACK B: Studio popup menu Ask item.
+                if not ask_clicked:
+                    menu_selectors = [
+                        "ytd-menu-renderer button",
+                        "button[aria-label='More actions']",
+                        "#button-shape button",
+                        "yt-icon-button#button",
+                    ]
+                    menu_clicked = False
+                    for selector in menu_selectors:
+                        try:
+                            menu_btn = self.driver.find_element("css selector", selector)
+                            menu_btn.click()
+                            menu_clicked = True
+                            break
+                        except Exception:
+                            continue
+                    if menu_clicked:
+                        await self._human_delay(1.5, 0.3)
+                        ask_item = self.driver.execute_script("""
+                            const items = document.querySelectorAll('tp-yt-paper-item');
+                            for (let item of items) {
+                                if (item.textContent.trim().toLowerCase() === 'ask') {
+                                    return item;
+                                }
+                            }
+                            return null;
+                        """)
+                        if ask_item:
+                            try:
+                                ask_item.click()
+                                ask_clicked = True
+                                logger.info("[STUDIO-ASK] FALLBACK: clicked Studio popup Ask item")
+                                await self._human_delay(2.0, 0.3)
+                            except Exception:
+                                ask_clicked = False
 
-                await self._human_delay(1.5, 0.3)  # Wait for popup
-
-                # Step 2: Find "Ask" item inside popup menu by text content
-                ask_item = self.driver.execute_script("""
-                    const items = document.querySelectorAll('tp-yt-paper-item');
-                    for (let item of items) {
-                        if (item.textContent.trim().toLowerCase() === 'ask') {
-                            return item;
-                        }
-                    }
-                    return null;
-                """)
-
-                if not ask_item:
-                    return AskResult(
-                        video_id=video_id,
-                        title=title,
-                        response_text="",
-                        topics=[],
-                        timestamps=[],
-                        success=False,
-                        error="Ask menu item not found in popup"
-                    )
-
-                # Step 3: Click Ask item
-                ask_item.click()
-                ask_clicked = True
-                logger.info("[STUDIO-ASK] Clicked 'Ask' menu item in popup")
-                await self._human_delay(2.0, 0.3)
+                # Legacy fallback: type into textarea/input and submit.
+                if ask_clicked:
+                    try:
+                        ask_input = self.driver.find_element(
+                            "css selector", "textarea, input[placeholder*='Ask']"
+                        )
+                        ask_input.clear()
+                        ask_input.send_keys(ask_prompt)
+                        await self._human_delay(1.0, 0.2)
+                        ask_input.send_keys(Keys.ENTER)
+                    except Exception as e:
+                        logger.warning(f"[STUDIO-ASK] FALLBACK input entry failed: {e}")
+                        ask_clicked = False
 
             if not ask_clicked:
                 return AskResult(
@@ -464,29 +637,40 @@ CONTENT CATEGORY (pick ONE):
                     topics=[],
                     timestamps=[],
                     success=False,
-                    error="Could not click Ask button via any method"
+                    error="Could not open Ask Studio or any fallback Ask path",
                 )
-            
-            # Find input field and type prompt
-            ask_input = self.driver.find_element("css selector", "textarea, input[placeholder*='Ask']")
-            ask_input.clear()
-            ask_input.send_keys(self.ASK_PROMPT)
-            await self._human_delay(1.0, 0.2)
-            
-            # Submit (Enter key or submit button)
-            from selenium.webdriver.common.keys import Keys
-            ask_input.send_keys(Keys.ENTER)
-            await self._human_delay(5.0, 0.5)  # Wait for Gemini response
-            
-            # Get response text
-            response_text = ""
-            try:
-                response_el = self.driver.find_element("css selector", ".gemini-response, .response-content")
-                response_text = response_el.text
-            except Exception:
-                # Try to get any new text on page
-                response_text = self.driver.find_element("css selector", "body").text[-2000:]
-            
+
+            # ---- Scrape the response from DOM (NO clipboard). Fails closed. ----
+            if used_ask_studio:
+                response_text = await self._scrape_ask_response()
+            else:
+                # Legacy fallback: wait then scrape legacy response containers.
+                await self._human_delay(5.0, 0.5)
+                response_text = ""
+                try:
+                    response_el = self.driver.find_element(
+                        "css selector", ".gemini-response, .response-content"
+                    )
+                    response_text = (response_el.text or "").strip()
+                except Exception:
+                    response_text = ""
+                if not response_text:
+                    # As a last resort scrape the Ask Studio stream selectors too.
+                    response_text = await self._scrape_ask_response()
+
+            if not response_text:
+                # Response never materialized within the timeout -> FAIL CLOSED.
+                logger.warning(f"[STUDIO-ASK] {video_id}: no response within timeout (fail closed)")
+                return AskResult(
+                    video_id=video_id,
+                    title=title,
+                    response_text="",
+                    topics=[],
+                    timestamps=[],
+                    success=False,
+                    error="Ask Studio response timeout (no DOM text)",
+                )
+
             # Parse response
             parsed = self._parse_ask_response(response_text)
             content_category = parsed.get("content_category", "other")
@@ -501,7 +685,7 @@ CONTENT CATEGORY (pick ONE):
                 success=True,
                 content_category=content_category,
             )
-            
+
         except Exception as e:
             logger.error(f"[STUDIO-ASK] Error for {video_id}: {e}")
             return AskResult(
@@ -513,7 +697,7 @@ CONTENT CATEGORY (pick ONE):
                 success=False,
                 error=str(e)
             )
-    
+
     async def index_channel_videos(
         self,
         channel_id: str,
@@ -660,7 +844,7 @@ CONTENT CATEGORY (pick ONE):
                     skipped += 1
                     logger.info(f"[STUDIO-ASK] ⏭️ {vid_id}: already indexed")
                     continue
-                result = await self.ask_about_video(vid_id)
+                result = await self.ask_about_video(vid_id, channel_entry=channel_entry)
                 results.append(result)
                 
                 if result.success:

--- a/modules/ai_intelligence/video_indexer/tests/test_indexer_scheduler_order.py
+++ b/modules/ai_intelligence/video_indexer/tests/test_indexer_scheduler_order.py
@@ -1,0 +1,55 @@
+"""
+Guard test: the auto_moderator scheduler order is comments -> index -> schedule.
+
+Phase 1 does NOT change the scheduler. This static assertion documents and
+locks the existing PHASE 1 (comments) -> PHASE 2 (video indexing) ->
+PHASE 3 (shorts scheduling) ordering so a future regression (index AFTER
+schedule) is caught. Re-ordering is deferred to INDEX_BEFORE_SHORTS_SCHEDULE_PHASE3.
+
+This reads source text only - no live YouTube, no browser, no network.
+"""
+
+from pathlib import Path
+
+
+def _dae_source() -> str:
+    # Resolve relative to this test file so it works in any worktree.
+    repo_root = Path(__file__).resolve().parents[4]
+    dae = (
+        repo_root
+        / "modules"
+        / "communication"
+        / "livechat"
+        / "src"
+        / "auto_moderator_dae.py"
+    )
+    return dae.read_text(encoding="utf-8", errors="ignore")
+
+
+def test_comments_then_index_then_schedule_order():
+    src = _dae_source()
+
+    comments_marker = "PHASE 1: COMMENT ENGAGEMENT"
+    index_marker = "PHASE 2: VIDEO INDEXING"
+    schedule_marker = "PHASE 3: SHORTS SCHEDULING"
+
+    i_comments = src.find(comments_marker)
+    i_index = src.find(index_marker)
+    i_schedule = src.find(schedule_marker)
+
+    assert i_comments != -1, "comment-engagement phase marker missing"
+    assert i_index != -1, "video-indexing phase marker missing"
+    assert i_schedule != -1, "shorts-scheduling phase marker missing"
+
+    # comments -> index -> schedule  (NOT comments -> schedule -> index)
+    assert i_comments < i_index < i_schedule
+
+
+def test_indexing_invoked_before_scheduler_call():
+    """The run_video_indexing_cycle call precedes the shorts scheduler launch."""
+    src = _dae_source()
+    i_index_call = src.find("run_video_indexing_cycle(browser=browser_name)")
+    i_sched_call = src.find("run_multi_channel_scheduler")
+    assert i_index_call != -1
+    assert i_sched_call != -1
+    assert i_index_call < i_sched_call

--- a/modules/ai_intelligence/video_indexer/tests/test_studio_ask_header.py
+++ b/modules/ai_intelligence/video_indexer/tests/test_studio_ask_header.py
@@ -1,0 +1,279 @@
+"""
+Tests for the Phase 1 "Ask Studio" header indexing path.
+
+Covers:
+  - Ask Studio header selectors are present in the selector set.
+  - PRIMARY path: header button -> dialog -> contenteditable prompt -> Enter
+    -> DOM-scraped response (no clipboard).
+  - Old watch-page Ask missing but Ask Studio path still succeeds.
+  - Response timeout fails closed (no DOM text -> success=False).
+  - Channel prompt selection (undaodu != foundups; ffcpln/music is lighter;
+    unknown channel falls back to the generic ASK_PROMPT).
+
+All tests use a mock DOM driver - NO live YouTube, NO clipboard, NO network.
+
+WSP Compliance:
+    WSP 5/6: Test coverage + audit
+    WSP 72: Module independence (no cross-module fixtures)
+"""
+
+import asyncio
+
+import pytest
+
+from modules.ai_intelligence.video_indexer.src.studio_ask_indexer import (
+    StudioAskIndexer,
+)
+
+
+# ---------------------------------------------------------------------------
+# Mock DOM / Selenium driver
+# ---------------------------------------------------------------------------
+
+class FakeElement:
+    """Minimal stand-in for a Selenium WebElement."""
+
+    def __init__(self, text="", attributes=None):
+        self._text = text
+        self._attributes = attributes or {}
+        self.clicked = False
+        self.sent_keys = []
+        self.cleared = False
+
+    @property
+    def text(self):
+        return self._text
+
+    def get_attribute(self, name):
+        return self._attributes.get(name, "")
+
+    def click(self):
+        self.clicked = True
+
+    def clear(self):
+        self.cleared = True
+
+    def send_keys(self, value):
+        self.sent_keys.append(value)
+
+
+class FakeDriver:
+    """
+    Mock Selenium driver backed by a simple selector->element map.
+
+    `css_map` maps a CSS selector string to a FakeElement (or None).
+    `present_selectors` is the set of selectors considered "present"; a
+    selector not in the map raises (mimicking NoSuchElement).
+    """
+
+    def __init__(self, css_map=None, script_result=None):
+        self.css_map = css_map or {}
+        self.script_result = script_result
+        self.current_url = "https://studio.youtube.com/video/vidX/edit"
+        self.visited = []
+
+    def get(self, url):
+        self.visited.append(url)
+        self.current_url = url
+
+    def find_element(self, by, selector):
+        if selector in self.css_map and self.css_map[selector] is not None:
+            return self.css_map[selector]
+        raise Exception(f"NoSuchElement: {selector}")
+
+    def find_elements(self, by, selector):
+        el = self.css_map.get(selector)
+        return [el] if el else []
+
+    def execute_script(self, *args, **kwargs):
+        # Legacy fallback JS calls return None by default (so the watch-page
+        # Ask button is treated as MISSING unless a result is provided).
+        return self.script_result
+
+
+# Patch the indexer's human delay to be instant so timeout tests are fast.
+@pytest.fixture(autouse=True)
+def _fast_delays(monkeypatch):
+    async def _no_delay(self, base=1.0, variance=0.3):
+        await asyncio.sleep(0)
+    monkeypatch.setattr(StudioAskIndexer, "_human_delay", _no_delay)
+    # Shrink the response timeout so the fail-closed test is quick.
+    monkeypatch.setattr(StudioAskIndexer, "RESPONSE_TIMEOUT_SECONDS", 0.05)
+
+
+def _ask_studio_dom(response_text):
+    """Build a css_map where the Ask Studio PRIMARY path fully succeeds."""
+    header = FakeElement(attributes={"aria-label": "Ask Studio"})
+    dialog = FakeElement()
+    prompt_box = FakeElement(attributes={"aria-label": "Ask something"})
+    response = FakeElement(text=response_text)
+    return {
+        'ytcp-icon-button[aria-label="Ask Studio"]': header,
+        "ytcp-dialog#dialog": dialog,
+        'div[contenteditable][aria-label="Ask something"]': prompt_box,
+        "#PAcreator_chat_streaming": response,
+        "input#title-field, h1.title": FakeElement(attributes={"value": "Studio Title"}),
+    }, prompt_box
+
+
+# ---------------------------------------------------------------------------
+# Selector presence tests
+# ---------------------------------------------------------------------------
+
+def test_ask_studio_header_selector_present():
+    """ASK_STUDIO_SELECTORS must contain the canonical header target."""
+    selectors = StudioAskIndexer.ASK_STUDIO_SELECTORS
+    assert "header_button" in selectors
+    assert any(
+        'ytcp-icon-button[aria-label="Ask Studio"]' == s
+        for s in selectors["header_button"]
+    )
+
+
+def test_ask_studio_dialog_and_prompt_selectors_present():
+    selectors = StudioAskIndexer.ASK_STUDIO_SELECTORS
+    assert "ytcp-dialog#dialog" in selectors["dialog"]
+    assert 'div[contenteditable][aria-label="Ask something"]' in selectors["prompt_box"]
+    assert (
+        'div.ytcpCreatorChatEntityAttachmentInlineFlowPromptBox[contenteditable="true"]'
+        in selectors["prompt_box"]
+    )
+
+
+def test_response_stream_selector_present():
+    selectors = StudioAskIndexer.ASK_STUDIO_SELECTORS
+    assert "#PAcreator_chat_streaming" in selectors["response_stream"]
+
+
+def test_watch_page_is_not_primary():
+    """Phase 1: watch-page Ask must be demoted (USE_WATCH_PAGE False)."""
+    assert StudioAskIndexer.USE_WATCH_PAGE is False
+
+
+# ---------------------------------------------------------------------------
+# PRIMARY path behavior tests
+# ---------------------------------------------------------------------------
+
+async def test_ask_studio_primary_path_succeeds():
+    """Header found, prompt typed, response scraped from DOM (no clipboard)."""
+    css_map, prompt_box = _ask_studio_dom(
+        '{"content_category": "educational", "topics": ["a", "b"], "segments": []}'
+    )
+    driver = FakeDriver(css_map=css_map, script_result=None)
+    indexer = StudioAskIndexer(driver=driver)
+
+    result = await indexer.ask_about_video("vidX")
+
+    assert result.success is True
+    assert "topics" in result.response_text  # came from the response DOM node
+    # The prompt box (contenteditable) actually received keystrokes.
+    assert prompt_box.clicked is True
+    assert any("content_category" in str(k) or "Analyze" in str(k) or "Focus" in str(k)
+               for k in prompt_box.sent_keys)
+    # We navigated to the Studio edit page (PRIMARY), not the watch page first.
+    assert driver.visited[0] == "https://studio.youtube.com/video/vidX/edit"
+
+
+async def test_ask_studio_succeeds_when_watch_ask_missing():
+    """
+    Old watch-page Ask button is missing (execute_script returns None) but the
+    Ask Studio header path still drives a successful index.
+    """
+    css_map, _ = _ask_studio_dom('{"topics": ["x"], "segments": []}')
+    # script_result=None => legacy watch-page Ask button NOT found.
+    driver = FakeDriver(css_map=css_map, script_result=None)
+    indexer = StudioAskIndexer(driver=driver)
+
+    result = await indexer.ask_about_video("vidX")
+
+    assert result.success is True
+    # Never had to fall back to the watch page.
+    assert all("youtube.com/watch" not in url for url in driver.visited)
+
+
+async def test_response_timeout_fails_closed():
+    """No response DOM text -> success False, no garbage stored."""
+    css_map, _ = _ask_studio_dom(response_text="")  # response node has empty text
+    # Remove the response node entirely to simulate a stream that never fills.
+    css_map["#PAcreator_chat_streaming"] = FakeElement(text="")
+    driver = FakeDriver(css_map=css_map, script_result=None)
+    indexer = StudioAskIndexer(driver=driver)
+
+    result = await indexer.ask_about_video("vidX")
+
+    assert result.success is False
+    assert result.response_text == ""
+    assert "timeout" in (result.error or "").lower()
+
+
+async def test_no_clipboard_used(monkeypatch):
+    """
+    Guard: the indexing path must not call pyperclip / clipboard APIs.
+    """
+    import sys
+    import types
+
+    sentinel = {"used": False}
+    fake_clip = types.ModuleType("pyperclip")
+
+    def _paste():
+        sentinel["used"] = True
+        return ""
+
+    def _copy(_):
+        sentinel["used"] = True
+
+    fake_clip.paste = _paste
+    fake_clip.copy = _copy
+    monkeypatch.setitem(sys.modules, "pyperclip", fake_clip)
+
+    css_map, _ = _ask_studio_dom('{"topics": ["x"], "segments": []}')
+    driver = FakeDriver(css_map=css_map, script_result=None)
+    indexer = StudioAskIndexer(driver=driver)
+    await indexer.ask_about_video("vidX")
+
+    assert sentinel["used"] is False
+
+
+# ---------------------------------------------------------------------------
+# Channel prompt selection tests
+# ---------------------------------------------------------------------------
+
+def _entry(template):
+    return {"key": "k", "name": "n", "shorts": {"description_template": template}}
+
+
+def test_undaodu_prompt_differs_from_foundups():
+    undaodu = StudioAskIndexer._prompt_for_channel(_entry("undaodu"))
+    foundups = StudioAskIndexer._prompt_for_channel(_entry("foundups"))
+    assert undaodu != foundups
+    assert "UnDaoDu" in undaodu
+    assert "FoundUps" in foundups
+
+
+def test_ffcpln_music_prompt_is_lighter():
+    """FFCPLN/music prompt must NOT demand a full transcript."""
+    ffcpln = StudioAskIndexer._prompt_for_channel(_entry("ffcpln"))
+    undaodu = StudioAskIndexer._prompt_for_channel(_entry("undaodu"))
+    assert "Do NOT produce a full transcript" in ffcpln
+    # Lighter == shorter than the speech-heavy channel prompt.
+    assert len(ffcpln) < len(undaodu)
+
+
+def test_unknown_channel_falls_back_to_generic():
+    generic = StudioAskIndexer._prompt_for_channel(_entry("totally_unknown"))
+    assert generic == StudioAskIndexer.ASK_PROMPT
+    # None entry also falls back safely.
+    assert StudioAskIndexer._prompt_for_channel(None) == StudioAskIndexer.ASK_PROMPT
+
+
+async def test_channel_prompt_threaded_into_ask(monkeypatch):
+    """index path passes channel_entry through so the ffcpln prompt is used."""
+    css_map, prompt_box = _ask_studio_dom('{"topics": ["m"], "segments": []}')
+    driver = FakeDriver(css_map=css_map, script_result=None)
+    indexer = StudioAskIndexer(driver=driver)
+
+    await indexer.ask_about_video("vidX", channel_entry=_entry("ffcpln"))
+
+    typed = " ".join(str(k) for k in prompt_box.sent_keys)
+    assert "Do NOT produce a full transcript" in typed


### PR DESCRIPTION
## STUDIO_ASK_STUDIO_HEADER_PHASE1 (DRAFT — product-surface browser code, awaits sovereign nod)

**Worker-Lane:** B  **Slice:** STUDIO_ASK_STUDIO_HEADER
**Base:** origin/main `ac8549b26` (re-pinned at branch time)

### Summary
Make the YouTube Studio **"Ask Studio"** header the canonical (PRIMARY) video
indexing path. The stale watch-page `button[aria-label="Ask"]` and the old
Studio popup menu selectors are **demoted to labelled fallback** (kept, not
deleted). Channel-specific prompts are selected from the existing channel
registry. Response is scraped from the DOM (no clipboard). Fails closed on
response timeout. No publish/schedule mutation. No Skillz/WRE promotion.

### Selectors added (`ASK_STUDIO_SELECTORS`, PRIMARY)
- header_button: `ytcp-icon-button[aria-label="Ask Studio"]` (+ aria-label*/button variants)
- dialog: `ytcp-dialog#dialog`, `ytcp-dialog`
- prompt_box: `div[contenteditable][aria-label="Ask something"]`,
  `div.ytcpCreatorChatEntityAttachmentInlineFlowPromptBox[contenteditable="true"]`
- response_stream: `#PAcreator_chat_streaming` (+ creator-chat response candidates)

### Prompt map (keyed off existing registry `shorts.description_template`)
| Channel(s) | template | Prompt |
|---|---|---|
| undaodu | `undaodu` | speech/ideas, timestamped segments |
| foundups | `foundups` | startup/pAVS themes, timestamped segments |
| Move2Japan, antifaFM | `ffcpln` | LIGHTER — no full transcript demanded |
| unknown / None | — | generic `ASK_PROMPT` fallback |

### Reused (NOT invented)
- Writer: `VideoIndexStore.save_index` -> `memory/video_index/{channel}/{video_id}.json`
- Channel data: `youtube_channel_registry` (`description_template`)

### Tests (mock DOM only — no live YouTube)
- `tests/test_studio_ask_header.py` (12): selector presence; PRIMARY path success;
  Ask Studio succeeds when watch-page Ask missing; response timeout fails closed;
  no-clipboard guard; channel prompt selection (undaodu != foundups, ffcpln
  lighter, unknown -> generic); channel prompt threaded into ask.
- `tests/test_indexer_scheduler_order.py` (2): locks `comments -> index -> schedule`.
- Result: **17 passed** (incl. 2 pre-existing). No skip/xfail.

### Phase notes
- `STUDIO_ASK_SKILL_PROMOTE_PHASE2` — promote selectors into `ask_studio_index`
  Skillz + WRE registration (later).
- `INDEX_BEFORE_SHORTS_SCHEDULE_PHASE3` — scheduler order already
  `comments -> index -> schedule` in `auto_moderator_dae.py`; revisit after stable.

### WSP_97 Truth Boundary Checklist
| # | Truth Boundary Checklist Item | Status | Evidence |
|---|---|---|---|
| 1 | ASK_STUDIO_HEADER_PRIMARY | PASS | `ASK_STUDIO_SELECTORS` + rewritten `ask_about_video` opens Studio edit page then Ask Studio header first |
| 2 | STALE_WATCH_ASK_NOT_PRIMARY | PASS | `USE_WATCH_PAGE = False`; watch-page/popup paths run only in the `if not used_ask_studio` fallback block |
| 3 | RESPONSE_SCRAPED_FROM_DOM_NOT_CLIPBOARD | PASS | `_scrape_ask_response` reads `el.text` from `response_stream`; `test_no_clipboard_used` guard; grep shows clipboard only in comments |
| 4 | CHANNEL_PROMPTS_SELECTED | PASS | `CHANNEL_PROMPTS` + `_prompt_for_channel`; threaded via `channel_entry`; 4 prompt tests |
| 5 | NO_LIVE_PUBLISH_OR_SCHEDULE | PASS | grep: no schedule/publish/save_changes/set_visibility in src; indexing-only |
| 6 | NO_WRE_SKILL_PROMOTION_PHASE1 | PASS | docs add Phase 2 note only; no registry/router edits in diff |
| 7 | TESTS_USE_MOCK_DOM_NOT_LIVE_YOUTUBE | PASS | `FakeDriver`/`FakeElement`; no network; no live YT |
| 8 | RESPONSE_TIMEOUT_FAILS_CLOSED | PASS | `RESPONSE_TIMEOUT_SECONDS`; empty DOM -> `success=False`; `test_response_timeout_fails_closed` |
| 9 | HOLOINDEX_RESULTS_RATED | PASS | Searches 1 & 3 HIGH (hit `studio_ask_indexer.py`); 2 MEDIUM; 4 MEDIUM (scheduler docs) — see report |
| 10 | FILE_SCOPE_EXACT | PASS | 5 files, all under `modules/ai_intelligence/video_indexer/`; PRIMARY checkout untouched |
| 11 | NO_SKIP_XFAIL | PASS | no skip/xfail markers; 17 passed |
| 12 | INTERNAL_SENTINEL_READY | PASS | self-attack run: stale-primary / clipboard / wrong-scrape / channel-ignored / live-mutation / weak-tests / accidental-promotion all checked |

### Boundaries honored
No clipboard. No publish/schedule/metadata mutation. No Skillz registry or WRE
router wiring. No duplicate browser orchestrator. No new secrets/OAuth. No live
YouTube in tests. Storage reuses the existing writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
