### PR TITLE
feat(video_indexer): typed SKILLz action surface + bounded Studio Ask single-video action (Phase 1)

### DIFF
--- a/modules/ai_intelligence/video_indexer/INTERFACE.md
+++ b/modules/ai_intelligence/video_indexer/INTERFACE.md
@@ -275,6 +275,69 @@ async def run_indexing_daemon(
     """Run continuous indexing cycles with STOP/REINDEX signals."""
 ```
 
+### Action Surface (typed SKILLz/ACTION SURFACE - Phase 1)
+
+A typed, reusable capability surface so the CLI menu, OpenClaw/WRE, Hermes, or
+any 0102 agent invoke the SAME governed indexing capability by action ID
+instead of a one-off helper.
+
+```python
+from modules.ai_intelligence.video_indexer.src.action_surface import (
+    VideoIndexAction,            # typed action IDs (string constants)
+    StudioAskSingleVideoInput,   # typed input dataclass
+    StudioAskSingleVideoOutput,  # typed output dataclass
+    run_action,                  # dispatcher: run_action(action_id, **kwargs)
+    run_studio_ask_single_video, # direct entry for the single_video action
+    parse_video_id,              # raw ID or URL -> bare video ID
+    port_for_browser,            # 'chrome'->9222, 'edge'->9223
+    BROWSER_PORTS,
+    ALL_ACTION_IDS,
+    IMPLEMENTED_ACTION_IDS,
+    REGISTERED_ONLY_ACTION_IDS,
+)
+
+# Action IDs
+#   IMPLEMENTED (Phase 1):
+#     VideoIndexAction.STUDIO_ASK_SINGLE_VIDEO = "video_index.studio_ask.single_video"
+#   REGISTERED ONLY (NOT wired this phase -> 'not_implemented'):
+#     STUDIO_ASK_CHANNEL_CYCLE = "video_index.studio_ask.channel_cycle"
+#     STUDIO_ASK_DAEMON_CYCLE  = "video_index.studio_ask.daemon_cycle"
+#     GEMINI_API_SINGLE_VIDEO  = "video_index.gemini_api.single_video"
+#     WHISPER_LOCAL_TRANSCRIPT = "video_index.whisper.local_transcript"
+#     SHORTS_SCHEDULER_CONSUME = "shorts_scheduler.consume_video_index"
+
+@dataclass
+class StudioAskSingleVideoInput:
+    video_id: str               # raw ID OR a URL (parsed to bare ID)
+    browser: str = "chrome"     # 'chrome' (9222) | 'edge' (9223)
+    channel_id: Optional[str] = None
+    persist: bool = True        # write memory/video_index/{channel}/{video_id}.json
+
+@dataclass
+class StudioAskSingleVideoOutput:
+    success: bool
+    video_id: str
+    browser: str
+    provider: str = "studio_ask"
+    response_text_length: int = 0
+    topics_count: int = 0
+    saved_path: Optional[str] = None
+    error: Optional[str] = None
+
+async def run_studio_ask_single_video(
+    inp: StudioAskSingleVideoInput,
+) -> StudioAskSingleVideoOutput:
+    """Bounded single-video Studio Ask index. Routes ONLY to
+    StudioAskIndexer.ask_about_video (navigate + DOM scrape). NEVER calls the
+    Gemini API, the Shorts Scheduler, or any publish/schedule/metadata-mutation
+    path. Attaches to an already-authenticated browser session (no credentials).
+    Fail-closed on error."""
+
+async def run_action(action_id: str, **kwargs) -> Any:
+    """Route by typed action ID. Implemented IDs run real work; registered-only
+    IDs return a 'not_implemented' result; unknown IDs raise ValueError."""
+```
+
 ## Data Classes
 
 ```python

--- a/modules/ai_intelligence/video_indexer/ModLog.md
+++ b/modules/ai_intelligence/video_indexer/ModLog.md
@@ -2,6 +2,101 @@
 
 **WSP Compliance**: WSP 22 (ModLog Updates)
 
+## V0.21.0 - Typed SKILLz/ACTION SURFACE + bounded Studio Ask single-video action (VIDEO_INDEXING_SKILLZ_ACTION_SURFACE_PHASE1) (2026-06-16)
+
+### Why
+Predecessor audit #818 found the indexing menu mislabels providers and there is
+NO bounded single-video Studio-Ask test entrypoint. Callers (menu, OpenClaw/WRE,
+Hermes/Kanban, any 0102 agent) reached indexing via a one-off menu helper rather
+than a shared, governed capability. This phase introduces a typed action surface
+so all callers invoke the SAME governed capability by action ID.
+
+Model: SKILLz = capability contract; DAE = executor; menu = operator trigger;
+heartbeat = observability; scheduler = artifact CONSUMER (NOT owner of indexing).
+
+### Changed
+- NEW `src/action_surface.py`:
+  - Typed action IDs (`VideoIndexAction`):
+    - IMPLEMENTED: `video_index.studio_ask.single_video`.
+    - REGISTERED ONLY (NOT wired -> 'not_implemented'; no Gemini/scheduler
+      import): `video_index.studio_ask.channel_cycle`,
+      `video_index.studio_ask.daemon_cycle`,
+      `video_index.gemini_api.single_video`,
+      `video_index.whisper.local_transcript`,
+      `shorts_scheduler.consume_video_index`.
+  - Typed `StudioAskSingleVideoInput` (video_id raw-ID-or-URL, browser, optional
+    channel_id, persist) + `StudioAskSingleVideoOutput` (success, video_id,
+    browser, provider='studio_ask', response_text_length, topics_count,
+    saved_path, error).
+  - `run_studio_ask_single_video(inp)`: attaches to the governed browser
+    (chrome->9222 / edge->9223 via existing dae_dependencies connect helpers;
+    attach only, NO credentials), calls `StudioAskIndexer.ask_about_video`, and
+    (if persist AND success) writes
+    `memory/video_index/{channel}/{video_id}.json` via the EXISTING
+    `VideoIndexStore` + `StudioAskIndexer._ask_result_to_index_data` (no new
+    store invented). Fail-closed on any error.
+  - `run_action(action_id, **kwargs)` dispatcher routes by ID.
+  - BOUNDARY: never imports/calls `GeminiVideoAnalyzer`, the Shorts Scheduler,
+    or any publish/schedule/metadata-mutation path. Lazy module-specific imports
+    (not the package `__init__`) keep the path Gemini-free. NOT added to
+    `src/__init__.py` (avoids pulling Gemini into the surface import).
+- `modules/infrastructure/cli/src/indexing_menu.py`:
+  - Relabeled per #818 audit: option 1 "[GEMINI] Gemini AI Indexing" ->
+    "[STUDIO ASK] Browser Studio Ask Indexing" (it runs the browser Studio Ask
+    cycle, not the API); option 4 "[TEST] Test Video Indexing (single video)" ->
+    "[GEMINI API] Gemini Video Analyzer (single video)" (it runs
+    GeminiVideoAnalyzer). Underlying Gemini/whisper behavior UNCHANGED.
+  - Added option 8 "[TEST] Studio Ask Single Video (bounded action surface)" ->
+    prompts for video id/URL + browser (chrome|edge) + optional channel, then
+    `run_action('video_index.studio_ask.single_video', ...)` and prints the
+    typed output (no secrets).
+- `skillz/transcript_ask/SKILLz.md`: documented the action-surface binding +
+  the #817 Ask-Studio header selector model; KEPT `promotion_state: prototype`
+  and `evals: []` (graduation blocked pending operator live-DOM proof, #818
+  Appendix A). ASCII-clean.
+- `INTERFACE.md`: added the Action Surface exports section.
+
+### Tests
+- NEW `tests/test_action_surface.py` (21): action-ID registry (impl vs
+  registered-only; consume_video_index is a SEPARATE registered ID); URL->bare
+  ID parse; browser->port (chrome 9222 / edge 9223); single_video calls
+  ask_about_video + returns typed output; fail-closed (ask fail / no driver);
+  persists to memory/video_index/{channel}/{video_id}.json ONLY when persist=True
+  AND success (mocked store; path shape asserted); does NOT call
+  GeminiVideoAnalyzer (patched raise-if-called, asserted not called); does NOT
+  call the Shorts Scheduler / mutate metadata (patched edit_title /
+  edit_description / schedule_video on YouTubeStudioDOM raise-if-called, asserted
+  not called); dispatcher routing.
+- NO live browser: StudioAskIndexer / driver / ask_about_video and the connect
+  helpers are mocked. pytest: 21 passed. Related suite re-run (header /
+  persistence / scheduler-order): 15 passed. No skip/xfail.
+
+### HoloIndex Retrieval Report
+- Q1 "video indexer studio ask action surface skill executor" -> HIGH
+  (transcript_ask/executor.py, studio_ask_indexer.py, WSP_95 wardrobe).
+- Q2 "StudioAskIndexer ask_about_video single video" -> HIGH
+  (studio_ask_indexer.py top hit; confirmed signature
+  `ask_about_video(video_id, prompt=None, channel_entry=None) -> AskResult`).
+- Q3 "indexing_menu studio ask gemini option handler" -> HIGH
+  (indexing_menu.py + studio_ask_indexer.py; confirmed option 1 routes to
+  run_video_indexing_cycle, option 4 routes to GeminiVideoAnalyzer).
+- Retrieval evaluation: low noise, correct ordering, no missing artifacts;
+  staleness low (files re-read directly from worktree). Direct-reads:
+  studio_ask_indexer.py, video_index_store.py, indexing_menu.py,
+  transcript_ask/{SKILLz.md,executor.py}, dae_dependencies.py connect helpers.
+
+### Attention flags
+- StudioAskIndexer ctor takes a `driver` (NOT a browser/port). The 9222/9223
+  port mapping lives in dae_dependencies connect helpers; the action surface
+  constructs the driver via those and passes it in. BROWSER_PORTS is documented
+  for callers but the ctor itself is driver-based.
+- `save_video` is NOT a method on the scheduler DOM class; the mutation methods
+  that DO exist on `YouTubeStudioDOM` are edit_title/edit_description/
+  schedule_video (all patched + asserted-not-called).
+- This is runtime CODE (browser-driving). The action surface is bounded and
+  governed; live execution requires an already-authenticated session. PR left
+  OPEN for the sovereign gate. transcript_ask stays prototype (evals []).
+
 ## V0.20.0 - Ask Studio Header PRIMARY path (STUDIO_ASK_STUDIO_HEADER_PHASE1) (2026-06-15)
 
 ### Why

--- a/modules/ai_intelligence/video_indexer/skillz/transcript_ask/SKILLz.md
+++ b/modules/ai_intelligence/video_indexer/skillz/transcript_ask/SKILLz.md
@@ -1,16 +1,18 @@
 ---
 name: transcript_ask
-description: Extract full video transcripts using YouTube's "Ask" Gemini feature
+description: Extract video transcripts/topics via the YouTube Studio "Ask Studio" header feature (browser, no API)
 version: 1.0.0
 author: 0102_video_indexer_team
 agents: [gemini, qwen]
-dependencies: [browser_actions, studio_ask_indexer]
+dependencies: [browser_actions, studio_ask_indexer, action_surface]
 domain: video_indexing
 intent_type: EXTRACTION
 promotion_state: prototype
 category: capability-uplift
 evals: []
 retirement_date: null
+action_ids:
+  - video_index.studio_ask.single_video
 ---
 # Transcript Ask SKILLz
 
@@ -23,26 +25,55 @@ retirement_date: null
 
 ---
 
-## ⚠️ Phase 1 Selector Notice (STUDIO_ASK_STUDIO_HEADER_PHASE1)
+## Phase 1 Selector Notice (STUDIO_ASK_STUDIO_HEADER_PHASE1)
 
 **STALE**: The watch-page `button[aria-label="Ask"]` path documented below
 (Architecture / Step 2) is **STALE** and is now a labelled *fallback only*.
 
-**Phase 1 canonical path** is the **YouTube Studio "Ask Studio" header**:
+**Phase 1 canonical path** is the **YouTube Studio "Ask Studio" header**
+(#817 Ask-Studio header selector model):
 - Entry: `ytcp-icon-button[aria-label="Ask Studio"]` on the Studio video-edit page
 - Dialog: `ytcp-dialog#dialog`
 - Prompt: `div[contenteditable][aria-label="Ask something"]`
 - Response: scraped from `#PAcreator_chat_streaming` (DOM text, **no clipboard**)
 
 Canonical implementation: `src/studio_ask_indexer.py`
-(`ASK_STUDIO_SELECTORS`, `StudioAskIndexer.ask_about_video`).
+(`ASK_STUDIO_SELECTORS`, `StudioAskIndexer.ask_about_video`). The watch-page
+selectors in Step 2 below are retained only as documented fallback.
 
-**Phase 2 — `STUDIO_ASK_SKILL_PROMOTE_PHASE2`**: promote the working Ask Studio
-selectors into an `ask_studio_index` Skillz and register with WRE *after* Phase 1
-proves stable. (Phase 1 does NOT touch the Skillz registry or WRE router.)
+## Action Surface Binding (SKILLZ_ACTION_SURFACE_PHASE1)
 
-**Phase 3 — `INDEX_BEFORE_SHORTS_SCHEDULE_PHASE3`**: only after Phase 1 is stable,
-revisit scheduler ordering (already `comments -> index -> schedule` in
+This Skillz contract is backed by the typed action surface in
+`src/action_surface.py`. The action ID it backs is:
+
+- `video_index.studio_ask.single_video` (IMPLEMENTED Phase 1) -> a bounded,
+  single-video Studio Ask index test. Routes ONLY to
+  `StudioAskIndexer.ask_about_video` (navigate + DOM scrape) and optionally
+  persists to `memory/video_index/{channel}/{video_id}.json` via
+  `VideoIndexStore`. It NEVER calls the Gemini API
+  (`GeminiVideoAnalyzer`), the Shorts Scheduler, or any
+  publish/schedule/metadata-mutation path.
+
+The same surface REGISTERS (IDs only, NOT wired in Phase 1):
+`video_index.studio_ask.channel_cycle`, `video_index.studio_ask.daemon_cycle`,
+`video_index.gemini_api.single_video`, `video_index.whisper.local_transcript`,
+`shorts_scheduler.consume_video_index` (scheduler is an artifact CONSUMER, not
+the owner of indexing).
+
+The CLI menu, OpenClaw/WRE, and Hermes invoke the SAME capability via
+`run_action(action_id, ...)` instead of a one-off menu helper.
+
+**Promotion gate**: this Skillz stays `promotion_state: prototype` with
+`evals: []`. Graduation is BLOCKED pending operator live-DOM proof of the Ask
+Studio selectors (#818 Appendix A). Phase 1 does NOT touch the Skillz registry
+or WRE router.
+
+**Phase 2 - `STUDIO_ASK_SKILL_PROMOTE_PHASE2`**: promote the working Ask Studio
+selectors into a registered Skillz and wire the channel/daemon action IDs
+*after* Phase 1 proves stable.
+
+**Phase 3 - `INDEX_BEFORE_SHORTS_SCHEDULE_PHASE3`**: only after Phase 1 is
+stable, revisit scheduler ordering (already `comments -> index -> schedule` in
 `auto_moderator_dae.py`).
 
 ---
@@ -64,15 +95,20 @@ Extract **full verbatim transcripts** from YouTube videos using the built-in "As
 
 ```
 Browser (Selenium/Antigravity)
-    ↓
+    |
+    v
 Navigate to: youtube.com/watch?v={video_id}
-    ↓
+    |
+    v
 Click "Ask" button (aria-label="Ask")
-    ↓
+    |
+    v
 Query: "Give me the full transcript with timestamps"
-    ↓
-Parse Gemini response → Structured segments
-    ↓
+    |
+    v
+Parse Gemini response -> Structured segments
+    |
+    v
 Update video JSON in memory/video_index/
 ```
 
@@ -210,17 +246,17 @@ def update_video_json(video_id: str, segments: List[Dict], channel: str):
 
 ## WSP Compliance
 
-- **WSP 96**: Micro Chain-of-Thought ✅
-- **WSP 91**: DAE Observability (logging) ✅
-- **WSP 72**: Module Independence ✅
-- **WSP 84**: Code Reuse (uses existing browser infra) ✅
+- **WSP 96**: Micro Chain-of-Thought (PASS)
+- **WSP 91**: DAE Observability (logging) (PASS)
+- **WSP 72**: Module Independence (PASS)
+- **WSP 84**: Code Reuse (uses existing browser infra) (PASS)
 
 ---
 
 ## Integration
 
 **Called From**:
-- `auto_moderator_dae.py` → `run_video_indexing_cycle()`
+- `auto_moderator_dae.py` -> `run_video_indexing_cycle()`
 - Manual: CLI tool
 
 **Output Storage**:

--- a/modules/ai_intelligence/video_indexer/src/action_surface.py
+++ b/modules/ai_intelligence/video_indexer/src/action_surface.py
@@ -1,0 +1,393 @@
+# -*- coding: utf-8 -*-
+"""
+Video Indexing Action Surface (SKILLz/ACTION SURFACE) - Phase 1.
+
+A typed, reusable capability surface for video indexing so the CLI menu,
+OpenClaw/WRE, Hermes/Kanban, or any 0102 agent can invoke the SAME governed
+capability instead of a one-off menu helper.
+
+Model (WSP 27 / WSP 80 / WSP 95):
+    SKILLz   = capability contract (the typed action IDs + dataclasses here)
+    DAE      = executor (StudioAskIndexer.ask_about_video does the work)
+    menu     = operator trigger (indexing_menu.py routes through run_action)
+    heartbeat= observability (existing telemetry, not owned here)
+    scheduler= artifact CONSUMER (NOT the owner of indexing)
+
+BOUNDARY (HARD - Phase 1):
+    - This surface may DESCRIBE and ROUTE an action.
+    - It MUST NOT carry credentials, gate-pass state, or self-authorize live
+      mutation. 0102 ATTACHES to an already-authenticated browser session via
+      the existing dae_dependencies connect helpers (debuggerAddress); it never
+      handles credentials.
+    - It MUST NOT call GeminiVideoAnalyzer, the Shorts Scheduler, or any
+      metadata-mutation / publish / schedule / save_video path.
+    - The single_video action routes ONLY to StudioAskIndexer.ask_about_video,
+      which navigates + scrapes the Studio "Ask Studio" DOM and returns a
+      result. It does NOT edit_title / edit_description / save_video / schedule.
+
+WSP Compliance:
+    WSP 11: Interface Protocol (typed inputs/outputs)
+    WSP 27: DAE Architecture (Signal -> Knowledge -> Protocol -> Agentic)
+    WSP 72: Module Independence
+    WSP 84: Code Reuse (reuses StudioAskIndexer + VideoIndexStore; no new store)
+    WSP 91: DAE Observability
+
+Phase 1 IMPLEMENTS: video_index.studio_ask.single_video
+Phase 1 REGISTERS (NOT wired -> Phase 2): channel_cycle, daemon_cycle,
+    gemini_api.single_video, whisper.local_transcript,
+    shorts_scheduler.consume_video_index
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Reuse the canonical index root (same as studio_ask_indexer.INDEX_ROOT).
+INDEX_ROOT = Path("memory") / "video_index"
+
+# Governed browser -> Chrome DevTools remote-debug port mapping.
+# 0102 ATTACHES to an already-authenticated session; it never handles creds.
+#   chrome -> 9222 (Move2Japan / UnDaoDu)
+#   edge   -> 9223 (FoundUps / antifaFM)
+BROWSER_PORTS: Dict[str, int] = {
+    "chrome": 9222,
+    "edge": 9223,
+}
+
+
+# =============================================================================
+# Typed Action IDs
+# =============================================================================
+
+class VideoIndexAction:
+    """
+    Typed action IDs for the video indexing action surface.
+
+    IMPLEMENTED this phase:
+        STUDIO_ASK_SINGLE_VIDEO
+
+    REGISTERED as IDs but NOT wired this phase (-> raise NotImplementedError or
+    return a 'not_implemented' result). Phase 1 does NOT import Gemini/scheduler.
+    """
+
+    # IMPLEMENTED (Phase 1): bounded single-video Studio Ask index test.
+    STUDIO_ASK_SINGLE_VIDEO = "video_index.studio_ask.single_video"
+
+    # REGISTERED ONLY (Phase 2+): not wired this phase.
+    STUDIO_ASK_CHANNEL_CYCLE = "video_index.studio_ask.channel_cycle"
+    STUDIO_ASK_DAEMON_CYCLE = "video_index.studio_ask.daemon_cycle"
+    GEMINI_API_SINGLE_VIDEO = "video_index.gemini_api.single_video"
+    WHISPER_LOCAL_TRANSCRIPT = "video_index.whisper.local_transcript"
+    SHORTS_SCHEDULER_CONSUME = "shorts_scheduler.consume_video_index"
+
+
+# All action IDs the surface knows about (impl + registered).
+ALL_ACTION_IDS = (
+    VideoIndexAction.STUDIO_ASK_SINGLE_VIDEO,
+    VideoIndexAction.STUDIO_ASK_CHANNEL_CYCLE,
+    VideoIndexAction.STUDIO_ASK_DAEMON_CYCLE,
+    VideoIndexAction.GEMINI_API_SINGLE_VIDEO,
+    VideoIndexAction.WHISPER_LOCAL_TRANSCRIPT,
+    VideoIndexAction.SHORTS_SCHEDULER_CONSUME,
+)
+
+# Subset implemented (routes to real work) this phase.
+IMPLEMENTED_ACTION_IDS = (
+    VideoIndexAction.STUDIO_ASK_SINGLE_VIDEO,
+)
+
+# Subset registered-but-not-wired this phase.
+REGISTERED_ONLY_ACTION_IDS = tuple(
+    a for a in ALL_ACTION_IDS if a not in IMPLEMENTED_ACTION_IDS
+)
+
+
+# =============================================================================
+# Typed I/O dataclasses
+# =============================================================================
+
+@dataclass
+class StudioAskSingleVideoInput:
+    """
+    Typed input for video_index.studio_ask.single_video.
+
+    Args:
+        video_id: Raw YouTube video ID OR a watch/Studio URL. A URL is parsed
+            down to the bare 11-char video ID (see parse_video_id).
+        browser: 'chrome' (port 9222) or 'edge' (port 9223). 0102 attaches to
+            an already-authenticated session on that port.
+        channel_id: Optional YouTube channel ID. Used only to resolve the
+            channel-specific Ask prompt + the persist folder key. NOT required.
+        persist: When True (default), a successful result is written to
+            memory/video_index/{channel}/{video_id}.json via VideoIndexStore.
+    """
+
+    video_id: str
+    browser: str = "chrome"
+    channel_id: Optional[str] = None
+    persist: bool = True
+
+
+@dataclass
+class StudioAskSingleVideoOutput:
+    """Typed output for video_index.studio_ask.single_video (no secrets)."""
+
+    success: bool
+    video_id: str
+    browser: str
+    provider: str = "studio_ask"
+    response_text_length: int = 0
+    topics_count: int = 0
+    saved_path: Optional[str] = None
+    error: Optional[str] = None
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def parse_video_id(value: str) -> str:
+    """
+    Accept a raw video ID OR a YouTube/Studio URL and return the bare video ID.
+
+    Recognized URL shapes:
+        https://www.youtube.com/watch?v=VIDEOID
+        https://youtu.be/VIDEOID
+        https://studio.youtube.com/video/VIDEOID/edit
+        https://www.youtube.com/shorts/VIDEOID
+    A bare ID is returned unchanged (whitespace stripped).
+    """
+    if not value:
+        return value
+    raw = value.strip()
+
+    # studio.youtube.com/video/<id>/edit  OR  /video/<id>
+    m = re.search(r"/video/([^/?&#]+)", raw)
+    if m:
+        return m.group(1)
+    # watch?v=<id>  (or &v=<id>)
+    m = re.search(r"[?&]v=([^&#]+)", raw)
+    if m:
+        return m.group(1)
+    # youtu.be/<id>  OR  /shorts/<id>  OR  /embed/<id>
+    m = re.search(r"(?:youtu\.be/|/shorts/|/embed/)([^/?&#]+)", raw)
+    if m:
+        return m.group(1)
+    # No URL markers -> treat as a bare ID.
+    return raw
+
+
+def port_for_browser(browser: str) -> int:
+    """Resolve the Chrome DevTools remote-debug port for a browser label."""
+    key = (browser or "").strip().lower()
+    if key not in BROWSER_PORTS:
+        raise ValueError(
+            f"Unknown browser '{browser}'. Expected one of {sorted(BROWSER_PORTS)}."
+        )
+    return BROWSER_PORTS[key]
+
+
+def _connect_attached_driver(browser: str):
+    """
+    Attach to the already-authenticated browser session on the governed port.
+
+    Reuses the existing dae_dependencies connect helpers (which own the
+    9222/9223 mapping + debuggerAddress attach). NO credentials handled here.
+    Returns a Selenium driver or None on failure.
+    """
+    # Validate/normalize the port mapping up-front (fail-closed on bad browser).
+    _ = port_for_browser(browser)
+    key = browser.strip().lower()
+
+    from modules.infrastructure.dependency_launcher.src.dae_dependencies import (
+        connect_chrome_with_retry,
+        connect_edge_with_retry,
+    )
+    if key == "edge":
+        return connect_edge_with_retry(max_retries=3, retry_delay=2.0)
+    return connect_chrome_with_retry(max_retries=3, retry_delay=2.0)
+
+
+# =============================================================================
+# Single-video action (IMPLEMENTED this phase)
+# =============================================================================
+
+async def run_studio_ask_single_video(
+    inp: StudioAskSingleVideoInput,
+) -> StudioAskSingleVideoOutput:
+    """
+    Run a bounded, single-video Studio "Ask Studio" index (Phase 1).
+
+    Routes ONLY to StudioAskIndexer.ask_about_video. It NEVER calls Gemini,
+    the Shorts Scheduler, or any metadata-mutation / publish / schedule path.
+
+    Flow:
+        1. Parse the bare video ID (accepts raw ID or URL).
+        2. Attach to the governed browser session (chrome->9222 / edge->9223).
+        3. Construct StudioAskIndexer(driver=...) and await ask_about_video().
+        4. IF persist AND success: write the result to
+           memory/video_index/{channel}/{video_id}.json via VideoIndexStore
+           (reusing StudioAskIndexer._ask_result_to_index_data; no new store).
+        5. Map -> typed output. On any failure return success=False + error
+           (fail-closed).
+    """
+    # Lazy, module-specific imports (NOT the package __init__) so this code
+    # path never imports/uses GeminiVideoAnalyzer.
+    from modules.ai_intelligence.video_indexer.src.studio_ask_indexer import (
+        StudioAskIndexer,
+    )
+    from modules.ai_intelligence.video_indexer.src.video_index_store import (
+        VideoIndexStore,
+    )
+
+    video_id = parse_video_id(inp.video_id)
+    browser = (inp.browser or "chrome").strip().lower()
+
+    # Resolve the channel folder key + registry entry (best-effort; optional).
+    channel_key = "test"
+    channel_entry: Optional[Dict[str, Any]] = None
+    if inp.channel_id:
+        try:
+            from modules.infrastructure.shared_utilities.youtube_channel_registry import (
+                get_channel_by_id,
+            )
+            channel_entry = get_channel_by_id(inp.channel_id)
+            if channel_entry:
+                channel_key = channel_entry.get("key") or inp.channel_id
+            else:
+                channel_key = inp.channel_id
+        except Exception as e:  # registry optional; never fail the action on it
+            logger.debug(f"[ACTION-SURFACE] channel registry lookup skipped: {e}")
+            channel_key = inp.channel_id
+
+    # Validate browser/port up-front (fail-closed).
+    try:
+        port_for_browser(browser)
+    except ValueError as e:
+        return StudioAskSingleVideoOutput(
+            success=False, video_id=video_id, browser=browser, error=str(e),
+        )
+
+    # Attach to the governed, already-authenticated browser session.
+    try:
+        driver = _connect_attached_driver(browser)
+    except Exception as e:
+        logger.error(f"[ACTION-SURFACE] browser attach failed: {e}")
+        return StudioAskSingleVideoOutput(
+            success=False, video_id=video_id, browser=browser,
+            error=f"browser attach failed: {e}",
+        )
+    if driver is None:
+        return StudioAskSingleVideoOutput(
+            success=False, video_id=video_id, browser=browser,
+            error=f"could not attach to {browser} session (port "
+                  f"{BROWSER_PORTS.get(browser)})",
+        )
+
+    # Run the bounded Studio Ask (navigate + scrape only; no mutation).
+    try:
+        indexer = StudioAskIndexer(driver=driver)
+        ask_result = await indexer.ask_about_video(
+            video_id, channel_entry=channel_entry,
+        )
+    except Exception as e:
+        logger.error(f"[ACTION-SURFACE] ask_about_video error: {e}")
+        return StudioAskSingleVideoOutput(
+            success=False, video_id=video_id, browser=browser,
+            error=str(e),
+        )
+
+    if not ask_result.success:
+        return StudioAskSingleVideoOutput(
+            success=False, video_id=video_id, browser=browser,
+            response_text_length=len(ask_result.response_text or ""),
+            topics_count=len(ask_result.topics or []),
+            error=ask_result.error or "ask_about_video returned success=False",
+        )
+
+    # Persist ONLY when requested AND the ask succeeded (fail-closed otherwise).
+    saved_path: Optional[str] = None
+    if inp.persist:
+        try:
+            index_data = StudioAskIndexer._ask_result_to_index_data(
+                ask_result, channel_key=channel_key,
+            )
+            store = VideoIndexStore(base_path=str(INDEX_ROOT / channel_key))
+            saved_path = store.save_index(video_id, index_data)
+        except Exception as e:
+            logger.error(f"[ACTION-SURFACE] persist failed: {e}")
+            # Persist failure is reported but the ask itself succeeded.
+            return StudioAskSingleVideoOutput(
+                success=False, video_id=video_id, browser=browser,
+                response_text_length=len(ask_result.response_text or ""),
+                topics_count=len(ask_result.topics or []),
+                error=f"persist failed: {e}",
+            )
+
+    return StudioAskSingleVideoOutput(
+        success=True, video_id=video_id, browser=browser,
+        response_text_length=len(ask_result.response_text or ""),
+        topics_count=len(ask_result.topics or []),
+        saved_path=saved_path,
+    )
+
+
+# =============================================================================
+# Registered-only actions (NOT wired this phase)
+# =============================================================================
+
+def _not_implemented(action_id: str) -> Dict[str, Any]:
+    """Uniform 'not_implemented' result for registered-but-unwired actions."""
+    return {
+        "action_id": action_id,
+        "status": "not_implemented",
+        "phase": "Phase 2",
+        "detail": (
+            f"Action '{action_id}' is registered as an ID but not wired in "
+            f"Phase 1. Do not route live work through it yet."
+        ),
+    }
+
+
+# =============================================================================
+# Dispatcher
+# =============================================================================
+
+async def run_action(action_id: str, **kwargs) -> Any:
+    """
+    Route a call to the action surface by typed action ID.
+
+    IMPLEMENTED:
+        video_index.studio_ask.single_video
+            kwargs -> StudioAskSingleVideoInput fields
+            (video_id, browser, channel_id, persist) OR pass inp=<dataclass>.
+            Returns StudioAskSingleVideoOutput.
+
+    REGISTERED ONLY (Phase 2 - NOT wired): returns a 'not_implemented' result
+    dict. NEVER imports Gemini/scheduler from here.
+
+    Unknown action IDs raise ValueError (fail-closed).
+    """
+    if action_id == VideoIndexAction.STUDIO_ASK_SINGLE_VIDEO:
+        inp = kwargs.get("inp")
+        if inp is None:
+            inp = StudioAskSingleVideoInput(
+                video_id=kwargs["video_id"],
+                browser=kwargs.get("browser", "chrome"),
+                channel_id=kwargs.get("channel_id"),
+                persist=kwargs.get("persist", True),
+            )
+        return await run_studio_ask_single_video(inp)
+
+    if action_id in REGISTERED_ONLY_ACTION_IDS:
+        return _not_implemented(action_id)
+
+    raise ValueError(
+        f"Unknown action_id '{action_id}'. Known IDs: {list(ALL_ACTION_IDS)}"
+    )

--- a/modules/ai_intelligence/video_indexer/tests/test_action_surface.py
+++ b/modules/ai_intelligence/video_indexer/tests/test_action_surface.py
@@ -1,0 +1,342 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the video indexing typed SKILLz/ACTION SURFACE (Phase 1).
+
+NO live browser: StudioAskIndexer / its driver / ask_about_video and the
+dae_dependencies connect helpers are mocked. Asserts the single_video action
+routes ONLY to ask_about_video and provably never calls GeminiVideoAnalyzer,
+the Shorts Scheduler, or any metadata-mutation / publish / schedule path.
+
+WSP Compliance:
+    WSP 5/6: Test coverage + audit
+    WSP 72: Module Independence (no cross-module live calls)
+    WSP 84: Code Reuse (asserts reuse of VideoIndexStore path shape)
+"""
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from modules.ai_intelligence.video_indexer.src import action_surface as A
+from modules.ai_intelligence.video_indexer.src.action_surface import (
+    ALL_ACTION_IDS,
+    BROWSER_PORTS,
+    IMPLEMENTED_ACTION_IDS,
+    REGISTERED_ONLY_ACTION_IDS,
+    StudioAskSingleVideoInput,
+    StudioAskSingleVideoOutput,
+    VideoIndexAction,
+    parse_video_id,
+    port_for_browser,
+    run_action,
+    run_studio_ask_single_video,
+)
+from modules.ai_intelligence.video_indexer.src.studio_ask_indexer import AskResult
+
+
+def _ok_ask_result(video_id="vid123"):
+    return AskResult(
+        video_id=video_id,
+        title="Test Video",
+        response_text="Topics covered: memory, WSP",
+        topics=["memory", "WSP"],
+        timestamps=[
+            {"time": "0:10", "topic": "Memory", "summary": "Memory basics"},
+        ],
+        success=True,
+    )
+
+
+def _patched_indexer(ask_result):
+    """Build a MagicMock StudioAskIndexer instance whose ask_about_video is async."""
+    inst = MagicMock(name="StudioAskIndexerInstance")
+    inst.ask_about_video = AsyncMock(return_value=ask_result)
+    return inst
+
+
+# =============================================================================
+# Action ID registry
+# =============================================================================
+
+def test_single_video_is_implemented_id():
+    assert VideoIndexAction.STUDIO_ASK_SINGLE_VIDEO == "video_index.studio_ask.single_video"
+    assert VideoIndexAction.STUDIO_ASK_SINGLE_VIDEO in IMPLEMENTED_ACTION_IDS
+
+
+def test_registered_only_ids_present_not_implemented():
+    expected_registered = {
+        VideoIndexAction.STUDIO_ASK_CHANNEL_CYCLE,
+        VideoIndexAction.STUDIO_ASK_DAEMON_CYCLE,
+        VideoIndexAction.GEMINI_API_SINGLE_VIDEO,
+        VideoIndexAction.WHISPER_LOCAL_TRANSCRIPT,
+        VideoIndexAction.SHORTS_SCHEDULER_CONSUME,
+    }
+    assert expected_registered.issubset(set(REGISTERED_ONLY_ACTION_IDS))
+    # single_video must NOT be in the registered-only set.
+    assert VideoIndexAction.STUDIO_ASK_SINGLE_VIDEO not in REGISTERED_ONLY_ACTION_IDS
+    # All declared IDs are covered by impl + registered-only, no overlap.
+    assert set(ALL_ACTION_IDS) == set(IMPLEMENTED_ACTION_IDS) | set(REGISTERED_ONLY_ACTION_IDS)
+
+
+def test_shorts_scheduler_consume_is_separate_registered_id():
+    """consume_video_index is a SEPARATE registered ID, not an indexing action."""
+    assert VideoIndexAction.SHORTS_SCHEDULER_CONSUME == "shorts_scheduler.consume_video_index"
+    assert VideoIndexAction.SHORTS_SCHEDULER_CONSUME in REGISTERED_ONLY_ACTION_IDS
+
+    # Dispatching it returns 'not_implemented' and never runs an indexing action.
+    out = asyncio.run(run_action(VideoIndexAction.SHORTS_SCHEDULER_CONSUME))
+    assert isinstance(out, dict)
+    assert out["status"] == "not_implemented"
+    assert out["action_id"] == VideoIndexAction.SHORTS_SCHEDULER_CONSUME
+
+
+def test_unknown_action_id_raises():
+    with pytest.raises(ValueError):
+        asyncio.run(run_action("video_index.does.not.exist"))
+
+
+# =============================================================================
+# URL / browser parsing
+# =============================================================================
+
+@pytest.mark.parametrize("url,expected", [
+    ("dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+    ("https://www.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+    ("https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42s", "dQw4w9WgXcQ"),
+    ("https://youtu.be/dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+    ("https://studio.youtube.com/video/dQw4w9WgXcQ/edit", "dQw4w9WgXcQ"),
+    ("https://www.youtube.com/shorts/dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+])
+def test_parse_video_id(url, expected):
+    assert parse_video_id(url) == expected
+
+
+def test_browser_port_mapping():
+    assert BROWSER_PORTS["chrome"] == 9222
+    assert BROWSER_PORTS["edge"] == 9223
+    assert port_for_browser("chrome") == 9222
+    assert port_for_browser("CHROME") == 9222
+    assert port_for_browser("edge") == 9223
+    with pytest.raises(ValueError):
+        port_for_browser("firefox")
+
+
+def test_single_video_url_parsed_to_bare_id():
+    """A raw URL input is parsed down to the bare video id in the output."""
+    ask_result = _ok_ask_result(video_id="dQw4w9WgXcQ")
+    inst = _patched_indexer(ask_result)
+    with patch.object(A, "_connect_attached_driver", return_value=MagicMock()), \
+         patch("modules.ai_intelligence.video_indexer.src.studio_ask_indexer.StudioAskIndexer",
+               return_value=inst):
+        out = asyncio.run(run_studio_ask_single_video(
+            StudioAskSingleVideoInput(
+                video_id="https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=9s",
+                browser="chrome",
+                persist=False,
+            )
+        ))
+    assert out.video_id == "dQw4w9WgXcQ"
+    # ask_about_video received the bare id, not the URL.
+    inst.ask_about_video.assert_awaited_once()
+    assert inst.ask_about_video.await_args.args[0] == "dQw4w9WgXcQ"
+
+
+# =============================================================================
+# single_video routes to ask_about_video + typed output
+# =============================================================================
+
+def test_single_video_calls_ask_about_video_returns_typed_output():
+    ask_result = _ok_ask_result()
+    inst = _patched_indexer(ask_result)
+    with patch.object(A, "_connect_attached_driver", return_value=MagicMock()), \
+         patch("modules.ai_intelligence.video_indexer.src.studio_ask_indexer.StudioAskIndexer",
+               return_value=inst):
+        out = asyncio.run(run_studio_ask_single_video(
+            StudioAskSingleVideoInput(video_id="vid123", browser="chrome", persist=False)
+        ))
+    inst.ask_about_video.assert_awaited_once()
+    assert isinstance(out, StudioAskSingleVideoOutput)
+    assert out.success is True
+    assert out.video_id == "vid123"
+    assert out.provider == "studio_ask"
+    assert out.browser == "chrome"
+    assert out.response_text_length == len("Topics covered: memory, WSP")
+    assert out.topics_count == 2
+    assert out.saved_path is None  # persist=False
+
+
+def test_single_video_fail_closed_when_ask_fails():
+    ask_result = AskResult(
+        video_id="vid123", title="", response_text="", topics=[],
+        timestamps=[], success=False, error="Ask Studio response timeout (no DOM text)",
+    )
+    inst = _patched_indexer(ask_result)
+    with patch.object(A, "_connect_attached_driver", return_value=MagicMock()), \
+         patch("modules.ai_intelligence.video_indexer.src.studio_ask_indexer.StudioAskIndexer",
+               return_value=inst):
+        out = asyncio.run(run_studio_ask_single_video(
+            StudioAskSingleVideoInput(video_id="vid123", browser="chrome", persist=True)
+        ))
+    assert out.success is False
+    assert out.saved_path is None
+    assert "timeout" in (out.error or "")
+
+
+def test_single_video_fail_closed_when_no_driver():
+    with patch.object(A, "_connect_attached_driver", return_value=None):
+        out = asyncio.run(run_studio_ask_single_video(
+            StudioAskSingleVideoInput(video_id="vid123", browser="edge", persist=True)
+        ))
+    assert out.success is False
+    assert "9223" in (out.error or "")
+
+
+# =============================================================================
+# Persistence path shape (memory/video_index/{channel}/{video_id}.json)
+# =============================================================================
+
+def test_single_video_persists_only_when_persist_and_success():
+    ask_result = _ok_ask_result()
+    inst = _patched_indexer(ask_result)
+
+    fake_store = MagicMock(name="VideoIndexStore")
+    fake_store.save_index.return_value = "memory/video_index/test/vid123.json"
+    store_ctor = MagicMock(return_value=fake_store)
+
+    with patch.object(A, "_connect_attached_driver", return_value=MagicMock()), \
+         patch("modules.ai_intelligence.video_indexer.src.studio_ask_indexer.StudioAskIndexer",
+               return_value=inst), \
+         patch("modules.ai_intelligence.video_indexer.src.video_index_store.VideoIndexStore",
+               store_ctor):
+        out = asyncio.run(run_studio_ask_single_video(
+            StudioAskSingleVideoInput(video_id="vid123", browser="chrome", persist=True)
+        ))
+
+    # Store constructed with base_path memory/video_index/{channel}.
+    store_ctor.assert_called_once()
+    base_path = store_ctor.call_args.kwargs.get("base_path") or store_ctor.call_args.args[0]
+    assert base_path.replace("\\", "/").endswith("memory/video_index/test")
+    # save_index called with the bare video id.
+    fake_store.save_index.assert_called_once()
+    assert fake_store.save_index.call_args.args[0] == "vid123"
+    assert out.saved_path.replace("\\", "/") == "memory/video_index/test/vid123.json"
+
+
+def test_single_video_does_not_persist_when_persist_false():
+    ask_result = _ok_ask_result()
+    inst = _patched_indexer(ask_result)
+    store_ctor = MagicMock(name="VideoIndexStoreCtor")
+
+    with patch.object(A, "_connect_attached_driver", return_value=MagicMock()), \
+         patch("modules.ai_intelligence.video_indexer.src.studio_ask_indexer.StudioAskIndexer",
+               return_value=inst), \
+         patch("modules.ai_intelligence.video_indexer.src.video_index_store.VideoIndexStore",
+               store_ctor):
+        out = asyncio.run(run_studio_ask_single_video(
+            StudioAskSingleVideoInput(video_id="vid123", browser="chrome", persist=False)
+        ))
+    store_ctor.assert_not_called()
+    assert out.saved_path is None
+
+
+def test_single_video_uses_channel_key_in_path():
+    """When channel_id resolves to a registry key, the path uses that key."""
+    ask_result = _ok_ask_result()
+    inst = _patched_indexer(ask_result)
+    fake_store = MagicMock()
+    fake_store.save_index.return_value = "memory/video_index/undaodu/vid123.json"
+    store_ctor = MagicMock(return_value=fake_store)
+
+    with patch.object(A, "_connect_attached_driver", return_value=MagicMock()), \
+         patch("modules.ai_intelligence.video_indexer.src.studio_ask_indexer.StudioAskIndexer",
+               return_value=inst), \
+         patch("modules.ai_intelligence.video_indexer.src.video_index_store.VideoIndexStore",
+               store_ctor), \
+         patch("modules.infrastructure.shared_utilities.youtube_channel_registry.get_channel_by_id",
+               return_value={"key": "undaodu", "name": "UnDaoDu"}):
+        asyncio.run(run_studio_ask_single_video(
+            StudioAskSingleVideoInput(
+                video_id="vid123", browser="chrome",
+                channel_id="UCfHM9Fw9HD-NwiS0seD_oIA", persist=True,
+            )
+        ))
+    base_path = store_ctor.call_args.kwargs.get("base_path") or store_ctor.call_args.args[0]
+    assert base_path.replace("\\", "/").endswith("memory/video_index/undaodu")
+
+
+# =============================================================================
+# BOUNDARY: Gemini + scheduler + metadata mutation provably NOT called
+# =============================================================================
+
+def test_single_video_does_not_call_gemini_video_analyzer():
+    ask_result = _ok_ask_result()
+    inst = _patched_indexer(ask_result)
+
+    gemini_mock = MagicMock(side_effect=AssertionError("GeminiVideoAnalyzer MUST NOT be called"))
+
+    with patch.object(A, "_connect_attached_driver", return_value=MagicMock()), \
+         patch("modules.ai_intelligence.video_indexer.src.studio_ask_indexer.StudioAskIndexer",
+               return_value=inst), \
+         patch("modules.ai_intelligence.video_indexer.src.gemini_video_analyzer.GeminiVideoAnalyzer",
+               gemini_mock):
+        out = asyncio.run(run_studio_ask_single_video(
+            StudioAskSingleVideoInput(video_id="vid123", browser="chrome", persist=False)
+        ))
+    assert out.success is True
+    gemini_mock.assert_not_called()
+
+
+def test_single_video_does_not_call_scheduler_or_mutate_metadata():
+    """Patch every scheduler mutation method to raise-if-called; assert untouched."""
+    ask_result = _ok_ask_result()
+    inst = _patched_indexer(ask_result)
+
+    from modules.platform_integration.youtube_shorts_scheduler.src import (
+        dom_automation as dom_mod,
+    )
+
+    raise_if_called = MagicMock(side_effect=AssertionError("scheduler mutation MUST NOT be called"))
+
+    # The Studio DOM scheduler class that owns metadata-mutation methods.
+    scheduler_dom_cls = dom_mod.YouTubeStudioDOM
+
+    patches = []
+    for method in ("edit_title", "edit_description", "save_video", "schedule_video"):
+        if hasattr(scheduler_dom_cls, method):
+            patches.append(patch.object(scheduler_dom_cls, method, raise_if_called))
+    # Sanity: at least one real mutation method must be patched for the
+    # assertion to be meaningful.
+    assert patches, "expected scheduler DOM mutation methods to patch"
+
+    with patch.object(A, "_connect_attached_driver", return_value=MagicMock()), \
+         patch("modules.ai_intelligence.video_indexer.src.studio_ask_indexer.StudioAskIndexer",
+               return_value=inst):
+        for p in patches:
+            p.start()
+        try:
+            out = asyncio.run(run_studio_ask_single_video(
+                StudioAskSingleVideoInput(video_id="vid123", browser="chrome", persist=False)
+            ))
+        finally:
+            for p in patches:
+                p.stop()
+
+    assert out.success is True
+    raise_if_called.assert_not_called()
+
+
+def test_dispatcher_routes_single_video_via_kwargs():
+    ask_result = _ok_ask_result()
+    inst = _patched_indexer(ask_result)
+    with patch.object(A, "_connect_attached_driver", return_value=MagicMock()), \
+         patch("modules.ai_intelligence.video_indexer.src.studio_ask_indexer.StudioAskIndexer",
+               return_value=inst):
+        out = asyncio.run(run_action(
+            VideoIndexAction.STUDIO_ASK_SINGLE_VIDEO,
+            video_id="vid123", browser="chrome", persist=False,
+        ))
+    assert isinstance(out, StudioAskSingleVideoOutput)
+    assert out.success is True
+    inst.ask_about_video.assert_awaited_once()

--- a/modules/infrastructure/cli/src/indexing_menu.py
+++ b/modules/infrastructure/cli/src/indexing_menu.py
@@ -22,13 +22,16 @@ def handle_indexing_menu() -> None:
     print("Creates searchable knowledge base from 012's videos")
     print("Each video saved as JSON with transcripts, topics, timestamps")
     print("=" * 60)
-    print("1. [GEMINI] Gemini AI Indexing (fast, no download)")
+    # NOTE: labels corrected per #818 audit. Option 1 runs the BROWSER Studio
+    # Ask path (NOT the Gemini API); option 4 runs the Gemini Video Analyzer.
+    print("1. [STUDIO ASK] Browser Studio Ask Indexing (fast, no download)")
     print("2. [DAEMON] Continuous Indexing (24/7 daemon mode)")
     print("3. [LOCAL] Whisper Indexing (yt-dlp + faster-whisper)")
-    print("4. [TEST] Test Video Indexing (single video)")
+    print("4. [GEMINI API] Gemini Video Analyzer (single video)")
     print("5. [BATCH] Batch Index Channel (bulk process)")
     print("6. [ENHANCE] Batch Enhance Videos (AI Training Data)")
     print("7. [TRAIN] Extract Training Data (Gemma quality filter)")
+    print("8. [TEST] Studio Ask Single Video (bounded action surface)")
     print("0. Back")
     print("=" * 60)
 
@@ -48,13 +51,20 @@ def handle_indexing_menu() -> None:
         _handle_batch_enhancement()
     elif idx_choice == "7":
         _handle_training_data_extraction()
+    elif idx_choice == "8":
+        _handle_studio_ask_single_video()
     elif idx_choice == "0":
         pass  # Back to YT menu
 
 
 def _handle_gemini_indexing() -> None:
-    """Handle Gemini-based indexing - BROWSER-AWARE like commenting."""
-    print("\n[GEMINI] Autonomous Video Indexing")
+    """Handle browser Studio Ask indexing - BROWSER-AWARE like commenting.
+
+    NOTE: despite the legacy function name, this path uses the YouTube Studio
+    "Ask Studio" BROWSER feature (run_video_indexing_cycle), NOT the Gemini API.
+    Label corrected per #818 audit.
+    """
+    print("\n[STUDIO ASK] Autonomous Browser Video Indexing")
     print("=" * 60)
     print("Browser rotation (same as comment engagement):")
     groups = group_channels_by_browser(role="indexing")
@@ -227,8 +237,12 @@ def _handle_whisper_indexing() -> None:
 
 
 def _handle_test_video_indexing() -> None:
-    """Handle test single video indexing."""
-    print("\n[TEST] Single Video Indexing Test")
+    """Handle single-video indexing via the Gemini Video Analyzer (API).
+
+    Label corrected per #818 audit: this is the GEMINI API path
+    (GeminiVideoAnalyzer), distinct from the browser Studio Ask path.
+    """
+    print("\n[GEMINI API] Gemini Video Analyzer (single video)")
     video_id = input("Enter YouTube video ID: ").strip()
     if video_id:
         try:
@@ -267,6 +281,64 @@ def _handle_test_video_indexing() -> None:
             print(f"[ERROR] Test failed: {e}")
             import traceback
             traceback.print_exc()
+
+
+def _handle_studio_ask_single_video() -> None:
+    """Handle bounded single-video Studio Ask via the typed action surface.
+
+    Routes through run_action('video_index.studio_ask.single_video', ...) so the
+    menu, OpenClaw/WRE, and Hermes all invoke the SAME governed capability.
+    This path NEVER calls Gemini, the Shorts Scheduler, or any metadata-mutation
+    / publish / schedule path (see action_surface boundary).
+    """
+    print("\n[TEST] Studio Ask Single Video (bounded action surface)")
+    print("=" * 60)
+    print("Routes to video_index.studio_ask.single_video")
+    print("Attaches to an already-authenticated browser (chrome=9222/edge=9223).")
+    print("No Gemini API, no scheduler, no metadata mutation.")
+    print("=" * 60)
+
+    raw = input("Enter YouTube video ID or URL: ").strip()
+    if not raw:
+        print("[ERROR] No video id/URL provided")
+        return
+    browser = (input("Browser (chrome|edge) [chrome]: ").strip().lower() or "chrome")
+    if browser not in ("chrome", "edge"):
+        print(f"[ERROR] Invalid browser '{browser}' (expected chrome|edge)")
+        return
+    channel_id = input("Channel ID (optional, Enter to skip): ").strip() or None
+
+    try:
+        from modules.ai_intelligence.video_indexer.src.action_surface import (
+            VideoIndexAction,
+            run_action,
+        )
+
+        out = asyncio.run(run_action(
+            VideoIndexAction.STUDIO_ASK_SINGLE_VIDEO,
+            video_id=raw,
+            browser=browser,
+            channel_id=channel_id,
+            persist=True,
+        ))
+
+        # Print the typed output (no secrets).
+        print("\n[RESULT] Studio Ask Single Video")
+        print(f"  success: {out.success}")
+        print(f"  video_id: {out.video_id}")
+        print(f"  browser: {out.browser}")
+        print(f"  provider: {out.provider}")
+        print(f"  response_text_length: {out.response_text_length}")
+        print(f"  topics_count: {out.topics_count}")
+        print(f"  saved_path: {out.saved_path}")
+        if out.error:
+            print(f"  error: {out.error}")
+    except ImportError as e:
+        print(f"[ERROR] action_surface not available: {e}")
+    except Exception as e:
+        print(f"[ERROR] Studio Ask single video failed: {e}")
+        import traceback
+        traceback.print_exc()
 
 
 def _handle_batch_indexing() -> None:


### PR DESCRIPTION
## Summary

Introduces a typed, reusable **SKILLz/ACTION SURFACE** for video indexing so the CLI menu, OpenClaw/WRE, Hermes/Kanban, or any 0102 agent invoke the **SAME governed capability by action ID** instead of a one-off menu helper. Slice `VIDEO_INDEXING_SKILLZ_ACTION_SURFACE_PHASE1` (Worker-Lane A1), following predecessor audit #818.

Model: SKILLz = capability contract; DAE = executor; menu = operator trigger; heartbeat = observability; scheduler = artifact CONSUMER (NOT owner of indexing).

## What changed
- **NEW `src/action_surface.py`**
  - Typed action IDs (`VideoIndexAction`):
    - **IMPLEMENTED**: `video_index.studio_ask.single_video`
    - **REGISTERED ONLY** (NOT wired -> `not_implemented`; no Gemini/scheduler import): `video_index.studio_ask.channel_cycle`, `video_index.studio_ask.daemon_cycle`, `video_index.gemini_api.single_video`, `video_index.whisper.local_transcript`, `shorts_scheduler.consume_video_index`
  - Typed `StudioAskSingleVideoInput` (video_id raw-ID-or-URL, browser, optional channel_id, persist) + `StudioAskSingleVideoOutput` (success, video_id, browser, provider='studio_ask', response_text_length, topics_count, saved_path, error).
  - `run_studio_ask_single_video(inp)`: attaches to the governed browser (chrome->9222 / edge->9223 via existing `dae_dependencies` connect helpers; **attach only, NO credentials**), calls `StudioAskIndexer.ask_about_video`, and (if persist AND success) writes `memory/video_index/{channel}/{video_id}.json` via the **existing** `VideoIndexStore` + `StudioAskIndexer._ask_result_to_index_data` (no new store). Fail-closed.
  - `run_action(action_id, **kwargs)` dispatcher.
  - **BOUNDARY**: never imports/calls `GeminiVideoAnalyzer`, the Shorts Scheduler, or any publish/schedule/metadata-mutation path. Lazy module-specific imports (not the package `__init__`) keep the path Gemini-free.
- **`indexing_menu.py`**: relabeled per #818 (option 1 `[GEMINI] Gemini AI Indexing` -> `[STUDIO ASK] Browser Studio Ask Indexing`; option 4 `[TEST] Test Video Indexing` -> `[GEMINI API] Gemini Video Analyzer (single video)`), Gemini kept a SEPARATE option; added option 8 `[TEST] Studio Ask Single Video` calling `run_action(...)`. Underlying Gemini/whisper behavior unchanged.
- **`skillz/transcript_ask/SKILLz.md`**: documents the action-surface binding + #817 Ask-Studio header selector model; KEEPS `promotion_state: prototype` + `evals: []` (graduation blocked pending operator live-DOM proof, #818 Appendix A). ASCII-clean.
- **`INTERFACE.md`** + **`ModLog.md`** updated.

## Tests (`tests/test_action_surface.py`, 21, mocked, NO live browser)
`pytest`: **21 passed**. Related suite re-run (header / persistence / scheduler-order): **15 passed**.
- single_video routes to `ask_about_video` + returns typed output
- persists to `memory/video_index/{channel}/{video_id}.json` ONLY when persist=True AND success (path shape asserted)
- does **NOT** call `GeminiVideoAnalyzer` (patched raise-if-called, asserted not called)
- does **NOT** call the Shorts Scheduler / mutate metadata (patched `edit_title`/`edit_description`/`schedule_video` on `YouTubeStudioDOM`, asserted not called)
- `shorts_scheduler.consume_video_index` is a SEPARATE registered ID, not invoked by indexing actions
- browser->port: chrome 9222 / edge 9223; raw URL parsed to bare video id; fail-closed paths

## HoloIndex Retrieval Report
- Q1 "video indexer studio ask action surface skill executor" -> **HIGH** (transcript_ask/executor.py, studio_ask_indexer.py, WSP_95).
- Q2 "StudioAskIndexer ask_about_video single video" -> **HIGH** (confirmed `ask_about_video(video_id, prompt=None, channel_entry=None) -> AskResult`).
- Q3 "indexing_menu studio ask gemini option handler" -> **HIGH** (confirmed option 1 -> `run_video_indexing_cycle`, option 4 -> `GeminiVideoAnalyzer`).
- Retrieval evaluation: low noise, correct ordering, no missing artifacts, staleness low (files re-read directly from worktree). Direct-reads: studio_ask_indexer.py, video_index_store.py, indexing_menu.py, transcript_ask/{SKILLz.md,executor.py}, dae_dependencies.py.

## Attention flags
- `StudioAskIndexer` ctor takes a `driver` (NOT a browser/port). The 9222/9223 mapping lives in `dae_dependencies` connect helpers; the surface builds the driver via those and passes it in.
- `save_video` is NOT a method on the scheduler DOM; the mutation methods that DO exist on `YouTubeStudioDOM` are `edit_title`/`edit_description`/`schedule_video` (all patched + asserted-not-called).
- This is **runtime CODE** (browser-driving). Live execution requires an already-authenticated session.

## Governance
- This is **runtime CODE** -> **do NOT self-merge**. Left **OPEN** at **VERIFIED_READY** for the sovereign gate.
- No live YouTube / no browser opened in tests / no metadata mutation / no publish / no schedule / no credentials handled.

Worker-Lane: A1 | Slice: VIDEO_INDEXING_SKILLZ_ACTION_SURFACE_PHASE1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
