### PR TITLE
test(youtube_shorts_scheduler): pin video-index context consumption on the scheduling path (Phase 1)

### DIFF
--- a/modules/platform_integration/youtube_shorts_scheduler/ModLog.md
+++ b/modules/platform_integration/youtube_shorts_scheduler/ModLog.md
@@ -1,5 +1,29 @@
 # YouTube Shorts Scheduler - ModLog
 
+## 2026-06-16 - Pin video-index context consumption on the scheduling path (Phase 1)
+
+**By:** 0102 (Worker-Lane SSVCC-AUTHOR)
+**Slice:** SHORTS_SCHEDULER_VIDEO_INDEX_CONTEXT_CONSUMPTION_COVERAGE_PHASE1
+**WSP References:** WSP 22 (ModLog), WSP 50 (Pre-Action), WSP 84 (Code Reuse), WSP 97 (Truth Signaling)
+**Basis:** #820 ALREADY built the artifact-consumption path; this slice PINS it with tests (no rebuild).
+
+### Tests (deliverable)
+
+Added scheduling-path consumption coverage to `tests/test_index_metadata_decoupling.py` (reusing the
+existing harness): TEST A (MISSING artifact -> base content, no enhancement, no scheduler-owned
+indexing) and TEST B (PRESENT artifact -> index context + woven hashtags + `0102 DIGITAL TWIN INDEX`
+block applied; `schedule_video` only on the explicit scheduling path), plus an env-gate complement and
+an observability-marker test. See `tests/TestModLog.md` for details and non-vacuity notes.
+
+### Production (observability only - the single permitted touch)
+
+`_update_video_metadata` now emits ONE behaviour-neutral log line
+`index_context=present|missing|disabled` (present = `ctx` not None; missing = artifact absent/`ctx`
+None; disabled = `YT_SCHEDULER_INDEX_WEAVE_ENABLED` false). This unifies/replaces the prior
+"No index artifact ... skipping enhancement" debug line. No response body, no transcript, no secrets.
+Control flow (consumption logic) is UNCHANGED - the `present`/`missing` branches still set the same
+`new_title`/`new_description` as before; only the log output differs.
+
 ## 2026-06-16 - Decouple Index Read-for-Context from Live Metadata Write (Phase 1)
 
 **By:** 0102 (Worker-Lane SSIMD-AUTHOR)

--- a/modules/platform_integration/youtube_shorts_scheduler/src/scheduler.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/src/scheduler.py
@@ -888,6 +888,7 @@ class YouTubeShortsScheduler:
             # read path. If the artifact is ABSENT, build_index_metadata_context
             # returns None and we SKIP enhancement (keep base_description /
             # original title) -- we do NOT "index now".
+            index_context = "disabled"
             if os.getenv("YT_SCHEDULER_INDEX_WEAVE_ENABLED", "true").lower() in ("1", "true", "yes"):
                 inform_title = os.getenv(
                     "YT_SCHEDULER_INDEX_INFORM_TITLE", "false"
@@ -906,14 +907,16 @@ class YouTubeShortsScheduler:
                 )
                 if ctx is not None:
                     # Artifact present -> apply woven title/description.
+                    index_context = "present"
                     new_title = ctx.new_title
                     new_description = ctx.new_description
                 else:
                     # Artifact absent -> skip enhancement (NOT index now).
-                    logger.debug(
-                        "[SCHEDULER] No index artifact for %s - skipping enhancement",
-                        video_id,
-                    )
+                    index_context = "missing"
+
+            # Behaviour-neutral observability: which index-context branch ran
+            # (no response body, no transcript, no secrets).
+            logger.info("[SCHEDULER] index_context=%s for %s", index_context, video_id)
 
             # Update via DOM
             self.dom.edit_title(new_title)

--- a/modules/platform_integration/youtube_shorts_scheduler/tests/TestModLog.md
+++ b/modules/platform_integration/youtube_shorts_scheduler/tests/TestModLog.md
@@ -1,5 +1,49 @@
 # YouTube Shorts Scheduler - TestModLog
 
+## 2026-06-16 - Pin video-index context consumption on the scheduling path (Phase 1)
+
+**By:** 0102 (Worker-Lane SSVCC-AUTHOR)
+**Slice:** SHORTS_SCHEDULER_VIDEO_INDEX_CONTEXT_CONSUMPTION_COVERAGE_PHASE1
+**WSP References:** WSP 6 (Test Audit), WSP 22 (ModLog), WSP 84 (Code Reuse), WSP 97 (Truth Signaling)
+**Basis:** #820 ALREADY built the artifact-consumption path; this PINS it (no rebuild).
+
+### Added (extend `tests/test_index_metadata_decoupling.py`, reuse the existing harness)
+
+- TEST A `test_scheduling_path_missing_artifact_writes_base_content` - `run_scheduling_cycle`
+  with NO artifact: reachability (`navigate_to_video('vid1')`) FIRST; `edit_title`/`edit_description`/
+  `schedule_video` STILL fire (`schedule_video.call_count == 1`); the `edit_description` argument
+  equals the pinned BASE sentinel (no twin marker `0102 DIGITAL TWIN INDEX`, none of the index
+  hashtags `#Mindfulness`/`#Zen`); no scheduler-owned indexing (bound `save_index_json` spy never
+  fires, `GeminiVideoAnalyzer` never constructed, no artifact file on disk); structural proof that
+  `ensure_index_json`/`create_stub_index_json` are NOT bound in the scheduler namespace.
+- TEST B `test_scheduling_path_present_artifact_weaves_index_context` - `run_scheduling_cycle` with a
+  PRESENT artifact (topics `[Mindfulness, Zen]`, key_points populated): reachability FIRST;
+  `edit_description` includes the index context (`Breathe and be present.`), >=1 woven index hashtag,
+  AND the twin block; `schedule_video.call_count == 1`. Cross-check: `run_indexing_cycle` over the
+  same harness yields `schedule_video.call_count == 0` (scheduling write is invoked ONLY from the
+  explicit scheduling path; pairs with Control 3/7).
+- TEST B (env-gate complement) `test_scheduling_path_present_artifact_disabled_skips_enhancement` -
+  PRESENT artifact + `YT_SCHEDULER_INDEX_WEAVE_ENABLED=false` -> twin block ABSENT (proves the TEST B
+  twin assertion is env-gated, not unconditional).
+- Observability `test_update_metadata_logs_index_context_marker` - asserts the
+  `index_context=present|missing|disabled` token only (via caplog), never content/transcript.
+
+### Non-vacuity
+
+TEST A FAILS if the missing-artifact path were (re-)coupled to indexing (bound `save_index_json`
+side-effect raises, or an artifact appears on disk) or if base content were enhanced (twin/hashtag
+assertion fires). TEST B FAILS if consumption became a no-op/None (the PRESENT twin/context/hashtag
+markers would be absent) or if scheduling fired from a read path. `get_standard_description` is
+randomized, so TEST A pins the BASE via a deterministic stub of the BOUND scheduler name. Strict
+`spec_set` DOM double, `dry_run=False`, `read_edit_page_visibility -> "unlisted"`. No browser, no
+live YouTube, ASCII-only. No skip/xfail.
+
+### Pre-existing unrelated failures (NOT mine)
+
+`test_scheduler.py` 3 failures (`test_get_channel_config_move2japan` time-slots 8 vs 3;
+`test_get_next_available_slot_empty`/`_partial` time-of-day-dependent slot values) are byte-identical
+to base (`test_scheduler.py` unchanged in this diff). Classified by reading tracebacks; never stashed.
+
 ## 2026-06-16 - Index<->Metadata Decoupling tests (Phase 1)
 
 **By:** 0102 (Worker-Lane SSIMD-AUTHOR)

--- a/modules/platform_integration/youtube_shorts_scheduler/tests/test_index_metadata_decoupling.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/tests/test_index_metadata_decoupling.py
@@ -502,3 +502,282 @@ def test_pure_builder_missing_artifact_returns_none(tmp_path, monkeypatch):
     assert ctx is None
     assert ensure_spy.call_count == 0
     assert save_spy.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# SCHEDULING PATH x INDEX-CONTEXT CONSUMPTION (Phase 1 consumption coverage)
+#
+# Slice: SHORTS_SCHEDULER_VIDEO_INDEX_CONTEXT_CONSUMPTION_COVERAGE_PHASE1
+#
+# These two tests PIN the artifact-consumption behavior that #820 ALREADY built
+# in _update_video_metadata (scheduler.py:891-916), driven end-to-end through
+# run_scheduling_cycle. They do NOT rebuild consumption; they only observe it via
+# the strict spec_set DOM double. WSP_97: CONSUMPTION_ALREADY_IMPLEMENTED_NOT_REBUILT.
+#
+# Both run dry_run=False so the per-video write/schedule body executes; both first
+# assert REACHABILITY (navigate_to_video) before any content/sink claim, because a
+# write path that never ran makes every "not called" / content assertion vacuous
+# (the #820 Control-4 lesson). read_edit_page_visibility -> "unlisted" (set by the
+# shared _make_strict_dom) -- otherwise the video is skipped before the write and
+# the test would be a FALSE NEGATIVE.
+#
+# Bound-name discipline: ensure_index_json and create_stub_index_json are NOT
+# imported into the scheduler module namespace (scheduler.py:24-30 imports only
+# load_index_json/save_index_json/build_digital_twin_index_block/
+# update_index_after_schedule/build_index_metadata_context). The read path
+# therefore CANNOT call them; we assert that structurally via hasattr (a stronger,
+# non-vacuous proof than spying a name that is not bound). save_index_json IS bound
+# and is spied directly.
+# ---------------------------------------------------------------------------
+
+# Index-derived hashtags that the PRESENT-artifact path would weave in (topics
+# ["Mindfulness", "Zen"] from _write_artifact). TEST A asserts NONE of these leak
+# into the description when the artifact is ABSENT.
+_INDEX_DERIVED_HASHTAGS = ("#Mindfulness", "#Zen")
+_TWIN_MARKER = "0102 DIGITAL TWIN INDEX"
+
+
+async def test_scheduling_path_missing_artifact_writes_base_content(tmp_path, monkeypatch):
+    """
+    TEST A - scheduling path + MISSING artifact.
+
+    run_scheduling_cycle(max_videos=1, update_metadata=True) with NO artifact on
+    disk (VIDEO_INDEXER_ARTIFACT_PATH points at an empty tmp dir). The explicit
+    scheduling write STILL fires (edit_title/edit_description/schedule_video), but
+    the description is BASE content -- build_index_metadata_context returns None so
+    NO enhancement is injected, and the read path never indexes.
+
+    NON-VACUITY: this test FAILS if the missing-artifact path were (re-)coupled to
+    indexing (a bound ensure_index_json / save_index_json on the read path would
+    fire, or an artifact file would appear), OR if base content were enhanced
+    without an artifact (the twin marker / index hashtags would appear in the
+    edit_description argument).
+    """
+    from modules.platform_integration.youtube_shorts_scheduler.src import (
+        scheduler as scheduler_module,
+    )
+
+    # Empty artifact dir -> artifact ABSENT for vid1.
+    monkeypatch.setenv("VIDEO_INDEXER_ARTIFACT_PATH", str(tmp_path))
+    monkeypatch.setenv("YT_SCHEDULER_INDEX_WEAVE_ENABLED", "true")
+    monkeypatch.setenv("YT_SCHEDULER_INDEX_ENHANCE_DESCRIPTION", "true")
+
+    # Pin the channel base description deterministically. get_standard_description
+    # is randomized (content_generator.py: 70% main / 30% alt + random ICE victim
+    # interpolation), so we stub the BOUND scheduler name to a fixed sentinel that
+    # contains NEITHER the twin marker NOR the index-derived hashtags. The written
+    # description must then equal this sentinel EXACTLY -> proves no enhancement was
+    # injected on the missing-artifact path (non-vacuous, deterministic).
+    _BASE_SENTINEL = "FIXED BASE DESCRIPTION - no enhancement expected."
+    monkeypatch.setattr(
+        scheduler_module, "get_standard_description", lambda *a, **k: _BASE_SENTINEL
+    )
+
+    # Bound-name structural proof: the read path cannot call indexing entrypoints
+    # that were removed from the scheduler namespace.
+    assert not hasattr(scheduler_module, "ensure_index_json")
+    assert not hasattr(scheduler_module, "create_stub_index_json")
+
+    # save_index_json IS bound -> spy it (must NOT fire when artifact is absent:
+    # the post-schedule sync at scheduler.py:481-497 short-circuits on a None
+    # load_index_json, so save_index_json is never reached).
+    save_spy = MagicMock(
+        side_effect=AssertionError("save_index_json must NOT be called on the missing-artifact path")
+    )
+    monkeypatch.setattr(scheduler_module, "save_index_json", save_spy)
+
+    # GeminiVideoAnalyzer must never be imported/instantiated on the read path.
+    import sys
+    import types
+
+    constructed = {"count": 0}
+
+    class _BoomGemini:
+        def __init__(self, *a, **k):
+            constructed["count"] += 1
+            raise AssertionError("GeminiVideoAnalyzer must NOT be instantiated on the scheduling read path")
+
+    fake_mod = types.ModuleType("modules.ai_intelligence.video_indexer.src.gemini_video_analyzer")
+    fake_mod.GeminiVideoAnalyzer = _BoomGemini
+    fake_mod.save_analysis_result = lambda *a, **k: None
+    monkeypatch.setitem(
+        sys.modules,
+        "modules.ai_intelligence.video_indexer.src.gemini_video_analyzer",
+        fake_mod,
+    )
+
+    scheduler = _make_scheduler()
+
+    await scheduler.run_scheduling_cycle(max_videos=1, update_metadata=True)
+
+    # REACHABILITY (before any content/sink claim): the per-video write body ran.
+    scheduler.dom.navigate_to_video.assert_called_with("vid1")
+
+    # The explicit scheduling write STILL fires.
+    assert scheduler.dom.edit_title.call_count >= 1
+    assert scheduler.dom.edit_description.call_count >= 1
+    assert scheduler.dom.schedule_video.call_count == 1
+
+    # The description argument is BASE content (no enhancement injected).
+    desc_args, _ = scheduler.dom.edit_description.call_args
+    written_description = desc_args[0]
+    assert _TWIN_MARKER not in written_description, (
+        "base description must NOT contain the digital-twin block when no artifact exists"
+    )
+    for tag in _INDEX_DERIVED_HASHTAGS:
+        assert tag not in written_description, (
+            f"base description must NOT contain index-derived hashtag {tag} with no artifact"
+        )
+    # Equals the (pinned) channel base description exactly: no woven context,
+    # hashtags, or twin block were appended.
+    assert written_description == _BASE_SENTINEL
+
+    # NO scheduler-owned indexing: bound save_index_json never fired (side_effect
+    # would have raised), GeminiVideoAnalyzer never constructed, and NO artifact
+    # file was created on disk during the run.
+    assert save_spy.call_count == 0
+    assert constructed["count"] == 0
+    artifact_path = Path(tmp_path) / "move2japan" / "vid1.json"
+    assert not artifact_path.exists(), "missing-artifact scheduling path must NOT create an artifact"
+
+
+async def test_scheduling_path_present_artifact_weaves_index_context(tmp_path, monkeypatch):
+    """
+    TEST B - scheduling path + PRESENT artifact.
+
+    A realistic artifact (topics ["Mindfulness", "Zen"], key_points populated) is
+    written via tmp_path + VIDEO_INDEXER_ARTIFACT_PATH, then
+    run_scheduling_cycle(update_metadata=True) is driven. The edit_description
+    argument INCLUDES the index context, the woven index hashtags, AND the
+    digital-twin block -> proving the consumption is APPLIED (not a no-op). The
+    explicit scheduling path schedules the video exactly once.
+
+    NON-VACUITY: the enhanced markers are asserted PRESENT (a no-op / None builder
+    would fail this). A companion read-path cross-check proves schedule_video is
+    invoked ONLY from the explicit scheduling path: run_indexing_cycle over the same
+    harness yields schedule_video.call_count == 0.
+    """
+    channel_key = "move2japan"
+    video_id = "vid1"
+    artifact_path = _write_artifact(tmp_path, monkeypatch, channel_key, video_id)
+    assert artifact_path.exists()  # precondition: artifact present
+
+    monkeypatch.setenv("YT_SCHEDULER_INDEX_WEAVE_ENABLED", "true")
+    monkeypatch.setenv("YT_SCHEDULER_INDEX_ENHANCE_DESCRIPTION", "true")
+
+    scheduler = _make_scheduler()
+
+    await scheduler.run_scheduling_cycle(max_videos=1, update_metadata=True)
+
+    # REACHABILITY (before any content/sink claim): the per-video write body ran.
+    scheduler.dom.navigate_to_video.assert_called_with("vid1")
+
+    # schedule_video fired exactly once on the explicit scheduling path.
+    assert scheduler.dom.schedule_video.call_count == 1
+
+    # The woven description proves consumption is APPLIED (not a no-op):
+    assert scheduler.dom.edit_description.call_count >= 1
+    desc_args, _ = scheduler.dom.edit_description.call_args
+    written_description = desc_args[0]
+    # (i) index context injected (key_point from the artifact surfaces in context),
+    assert "Breathe and be present." in written_description, (
+        "human-facing index context must be injected into the description"
+    )
+    # (ii) at least one woven index hashtag present,
+    assert any(tag in written_description for tag in _INDEX_DERIVED_HASHTAGS), (
+        "woven index hashtags must appear in the enhanced description"
+    )
+    # (iii) the digital-twin block present.
+    assert _TWIN_MARKER in written_description, (
+        "digital-twin index block must appear in the enhanced description"
+    )
+
+    # CROSS-CHECK: schedule_video is invoked ONLY from the explicit scheduling
+    # path. A fresh scheduler running the READ path (run_indexing_cycle) never
+    # schedules (pairs with Control 3/7).
+    read_scheduler = _make_scheduler()
+    await read_scheduler.run_indexing_cycle(max_videos=1, video_type="shorts")
+    read_scheduler.dom.navigate_to_video.assert_called_with("vid1")
+    assert read_scheduler.dom.schedule_video.call_count == 0
+
+
+async def test_scheduling_path_present_artifact_disabled_skips_enhancement(tmp_path, monkeypatch):
+    """
+    TEST B (env-gate complement) - PRESENT artifact but enhancement DISABLED.
+
+    With YT_SCHEDULER_INDEX_WEAVE_ENABLED=false the read path skips
+    build_index_metadata_context entirely, so the digital-twin block and woven
+    index hashtags are ABSENT even though the artifact exists. This proves the
+    twin block in TEST B is gated by the env switch (not unconditional), making the
+    PRESENT/ENABLED assertion in TEST B non-vacuous.
+    """
+    channel_key = "move2japan"
+    video_id = "vid1"
+    artifact_path = _write_artifact(tmp_path, monkeypatch, channel_key, video_id)
+    assert artifact_path.exists()
+
+    monkeypatch.setenv("YT_SCHEDULER_INDEX_WEAVE_ENABLED", "false")
+
+    scheduler = _make_scheduler()
+
+    await scheduler.run_scheduling_cycle(max_videos=1, update_metadata=True)
+
+    scheduler.dom.navigate_to_video.assert_called_with("vid1")
+    assert scheduler.dom.schedule_video.call_count == 1
+    assert scheduler.dom.edit_description.call_count >= 1
+    desc_args, _ = scheduler.dom.edit_description.call_args
+    written_description = desc_args[0]
+    assert _TWIN_MARKER not in written_description, (
+        "twin block must be ABSENT when YT_SCHEDULER_INDEX_WEAVE_ENABLED=false"
+    )
+
+
+async def test_update_metadata_logs_index_context_marker(tmp_path, monkeypatch, caplog):
+    """
+    Observability: _update_video_metadata emits a single behaviour-neutral marker
+    'index_context=present|missing|disabled'. This asserts ONLY the token is
+    present (not any content/transcript). present -> ctx applied; missing ->
+    artifact absent; disabled -> weave env switch off.
+    """
+    import logging
+
+    # present (artifact written, weave enabled by default)
+    _write_artifact(tmp_path, monkeypatch, "move2japan", "vid1")
+    monkeypatch.setenv("YT_SCHEDULER_INDEX_WEAVE_ENABLED", "true")
+    scheduler = _make_scheduler()
+    with caplog.at_level(logging.INFO):
+        await scheduler._update_video_metadata(
+            video_id="vid1",
+            original_title="Original Title",
+            date_str="Jun 20, 2026",
+            time_str="5:00 PM",
+        )
+    assert "index_context=present" in caplog.text
+
+    # missing (empty artifact dir)
+    caplog.clear()
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    monkeypatch.setenv("VIDEO_INDEXER_ARTIFACT_PATH", str(empty_dir))
+    scheduler_missing = _make_scheduler()
+    with caplog.at_level(logging.INFO):
+        await scheduler_missing._update_video_metadata(
+            video_id="vid_absent",
+            original_title="Original Title",
+            date_str="Jun 20, 2026",
+            time_str="5:00 PM",
+        )
+    assert "index_context=missing" in caplog.text
+
+    # disabled (weave env switch off)
+    caplog.clear()
+    monkeypatch.setenv("YT_SCHEDULER_INDEX_WEAVE_ENABLED", "false")
+    scheduler_disabled = _make_scheduler()
+    with caplog.at_level(logging.INFO):
+        await scheduler_disabled._update_video_metadata(
+            video_id="vid1",
+            original_title="Original Title",
+            date_str="Jun 20, 2026",
+            time_str="5:00 PM",
+        )
+    assert "index_context=disabled" in caplog.text


### PR DESCRIPTION
## Summary

`#820` ALREADY built the artifact-consumption path in `_update_video_metadata`
(`scheduler.py:891-916`, driven end-to-end via `run_scheduling_cycle`). **This slice
PINS that already-built behavior with tests; it does NOT rebuild consumption** (WSP 84).
The only production touch is a single behaviour-neutral observability log line.

## HoloIndex retrieval note (discovery only)

Query: `scheduler update_video_metadata index context consumption build_index_metadata_context`.
Rating: **LOW signal** for this specific path. HoloIndex surfaced `video_indexer`
artifacts (`video_index_metadata_db.py`, `indexer_telemetry.py`) and generic WSP/docs,
but did NOT return `scheduler.py` / `index_weave.py` `_update_video_metadata` /
`build_index_metadata_context` - the actual consumption code under test (consistent with
the known HoloIndex indexing gap). The real code was located by direct read of the
worktree (`scheduler.py:751-925`, `index_weave.py:557-628`) and confirmed against the
existing Control 5/7 + pure-builder tests so this slice EXTENDS rather than duplicates.

## Tests added (extend `tests/test_index_metadata_decoupling.py`, reuse the existing harness)

Reuse `_make_scheduler()` + the strict `spec_set=YouTubeStudioDOM` double;
`dry_run=False`; `read_edit_page_visibility -> "unlisted"`; each test asserts
**reachability** (`navigate_to_video('vid1')`) BEFORE any content/sink claim.

- **TEST A** `test_scheduling_path_missing_artifact_writes_base_content` - MISSING
  artifact: `edit_title`/`edit_description`/`schedule_video` STILL fire
  (`schedule_video.call_count == 1`); `edit_description` arg equals the pinned BASE
  sentinel (no `0102 DIGITAL TWIN INDEX`, no `#Mindfulness`/`#Zen`); no scheduler-owned
  indexing (bound `save_index_json` spy never fires, `GeminiVideoAnalyzer` never
  constructed, no artifact on disk); `ensure_index_json`/`create_stub_index_json`
  structurally NOT bound in the scheduler namespace.
- **TEST B** `test_scheduling_path_present_artifact_weaves_index_context` - PRESENT
  artifact: `edit_description` includes index context + woven hashtags + the twin block;
  `schedule_video` once and ONLY on the explicit scheduling path (`run_indexing_cycle`
  cross-check yields `schedule_video.call_count == 0`).
- **env-gate complement** + **caplog observability** marker test.

## Production touch (observability only - the single permitted change)

`_update_video_metadata` emits ONE behaviour-neutral log
`index_context=present|missing|disabled` (replaces the prior "No index artifact"
debug line). Consumption control flow is unchanged.

## Pre-existing unrelated failures (NOT mine)

`test_scheduler.py` 3 failures (`test_get_channel_config_move2japan` time-slots 8 vs 3;
`test_get_next_available_slot_empty`/`_partial` time-of-day-dependent slot values) are
byte-identical to base (`test_scheduler.py` unchanged in this diff). Classified by reading
tracebacks; never stashed.

## WSP_97 Truth Boundary Checklist

| # | Truth Boundary Checklist Item | Status | Evidence |
|---|---|---|---|
| 1 | CONSUMPTION_ALREADY_IMPLEMENTED_NOT_REBUILT | YES | `scheduler.py:891-916` consumes `build_index_metadata_context` (`index_weave.py:557-628`); tests only observe, zero consumption-logic edits |
| 2 | MISSING_ARTIFACT_SCHEDULING_PATH_TESTED | YES | TEST A: empty `VIDEO_INDEXER_ARTIFACT_PATH`, `edit_description == _BASE_SENTINEL`, no twin/hashtags, no artifact on disk |
| 3 | PRESENT_ARTIFACT_HASHTAGS_CONTEXT_TESTED | YES | TEST B: `edit_description` includes `Breathe and be present.`, >=1 of `#Mindfulness`/`#Zen`, and `0102 DIGITAL TWIN INDEX` |
| 4 | NO_SCHEDULER_OWNED_INDEXING_REGRESSION | YES | TEST A: bound `save_index_json` spy `call_count == 0`, `ensure_index_json`/`create_stub_index_json` not bound (`hasattr` False), no artifact file created |
| 5 | NO_GEMINI_ANALYZER_ON_SCHEDULING_READ_PATH | YES | TEST A: `sys.modules` guard `_BoomGemini` raises on construction; `constructed["count"] == 0` |
| 6 | EXPLICIT_SCHEDULING_WRITE_PATH_STILL_INTENTIONAL | YES | TEST A/B: `schedule_video.call_count == 1`; TEST B cross-check `run_indexing_cycle -> schedule_video.call_count == 0` (pairs w/ Control 3/7) |
| 7 | HOLOINDEX_DISCOVERY_RECORDED | YES | LOW-signal note above; consumption code found by direct worktree read |
| 8 | TESTS_MOCK_DOM_NO_LIVE_YOUTUBE | YES | strict `MagicMock(spec_set=YouTubeStudioDOM)` (`:62`); no browser, no network, no credentials |
| 9 | REACHABILITY_ASSERTED_BEFORE_SINKS | YES | every added test asserts `navigate_to_video('vid1')` before content/sink claims |
| 10 | NO_SKIP_XFAIL | YES | no `pytest.mark.skip`/`xfail` in the added tests; all 4 new tests pass |
| 11 | ASCII_CLEAN | YES | byte-check: 0 non-ASCII chars across all added diff lines (tests + scheduler.py + ModLogs) |
| 12 | PRIMARY_CHECKOUT_UNTOUCHED | YES | all work in `/o/tmp/wt-ssvcc`; no edit/commit/stash/worktree-mutate in `/o/Foundups-Agent` |
| 13 | PRODUCTION_TOUCH_OBSERVABILITY_ONLY_OR_NONE | YES | only `scheduler.py` change is the `index_context=...` log; consumption control flow unchanged (diff in PR) |

Declared items: 13 - Rows: 13 - All YES

🤖 Generated with [Claude Code](https://claude.com/claude-code)
