### PR TITLE
fix(dependency_launcher): non-destructive Chrome/Edge attach recovery - open a tab instead of killing the operator session (Phase 1)

### DIFF
--- a/modules/infrastructure/dependency_launcher/INTERFACE.md
+++ b/modules/infrastructure/dependency_launcher/INTERFACE.md
@@ -65,6 +65,31 @@ Launch LM Studio for UI-TARS vision.
 
 ---
 
+### `connect_chrome_with_retry(max_retries=3, retry_delay=2.0, relaunch_on_fail=True) -> Optional[WebDriver]`
+
+Attach Selenium to the debug-port Chrome with retries and DevTools verification.
+
+**Non-destructive recovery (Phase 1):** if DevTools is UP but exposes no
+discoverable page target (Selenium "unable to discover open pages"), this opens a
+normal tab via `open_devtools_page()` and retries the attach. It does NOT taskkill
+the operator's prepared Chrome on this path; if a tab cannot be opened it logs a
+clear actionable error and returns `None`. The genuinely-DevTools-DOWN path still
+relaunches (follow-up: BROWSER_ATTACH_RECOVERY_DEVTOOLS_DOWN_PHASE2).
+
+### `connect_edge_with_retry(max_retries=3, retry_delay=2.0, relaunch_on_fail=True) -> Optional[WebDriver]`
+
+Same as `connect_chrome_with_retry` for Edge (port 9223), including the
+non-destructive no-page recovery (no `msedge.exe` taskkill on the no-page path).
+
+### `open_devtools_page(port: int, url: str = "about:blank", timeout: float = 3.0) -> bool`
+
+Open a new normal page/tab via the DevTools HTTP endpoint (`PUT /json/new?<url>`
+with `GET` fallback). Used to recover the "unable to discover open pages" condition
+without killing the browser. Returns `True` if DevTools reported a new target,
+`False` otherwise. Never raises, never kills any process.
+
+---
+
 ### `is_chrome_running() -> bool`
 
 Check if Chrome debug port is responding.

--- a/modules/infrastructure/dependency_launcher/ModLog.md
+++ b/modules/infrastructure/dependency_launcher/ModLog.md
@@ -7,6 +7,61 @@
 
 ## Change Log
 
+### 2026-06-17: Non-Destructive Attach Recovery - Open a Tab, Do NOT Kill (Phase 1)
+
+**By:** 0102 (Worker-Lane: ATTACH-AUTHOR)
+**Slice:** BROWSER_ATTACH_RECOVERY_NO_KILL_PHASE1
+**WSP References:** WSP 22 (ModLog), WSP 50 (Pre-Action), WSP 84 (Code Reuse), WSP 87 (Navigation), WSP 97 (Truth Boundary)
+
+**Problem (012 live-observed):** When the operator-prepared Chrome on 9222 is UP
+(DevTools /json/version works) but has NO discoverable page target (/json
+page-list empty -> Selenium raises "unable to discover open pages"),
+`connect_chrome_with_retry` ran `taskkill /F /IM chrome.exe` and relaunched a
+fresh Chrome. This DESTROYED the operator's authenticated/prepared window,
+relaunched a Chrome whose auth/active-channel state is uncertain, and confounded
+every live test. Edge had the identical destructive path.
+
+**Solution (NO_KILL contract):** On the discover-pages (no-page) condition, RECOVER
+NON-DESTRUCTIVELY:
+1. New helper `open_devtools_page(port, url='about:blank')` opens a normal tab via
+   the DevTools HTTP endpoint - HTTP PUT `/json/new?about:blank` (modern Chrome/Edge)
+   with GET fallback. Reuses the existing `urllib.request` + `/json` pattern from
+   `is_devtools_responding` (no new HTTP machinery, no new dependency).
+2. `connect_chrome_with_retry` / `connect_edge_with_retry` no-page branch now calls
+   `open_devtools_page`, re-checks `is_devtools_responding`, and RETRIES the attach.
+3. If a tab cannot be opened (endpoint blocked), they log a CLEAR actionable error
+   ("open a normal tab in the debug Chrome/Edge, or relaunch with
+   --remote-allow-origins") and return None - NEVER taskkill. The success attach
+   path is unchanged.
+
+**Reuse:** Checked for an existing DevTools open-tab helper. `foundups_selenium/src/
+devtools_mcp_adapter.py:new_page()` (:510) exists but requires an already-initialized
+driver/MCP backend (`self._driver.execute_script("window.open")`), so it CANNOT
+recover the pre-attach no-driver case. No repo code uses `/json/new` or
+`Target.createTarget`. Reused the in-file urllib/`/json` HTTP pattern instead.
+
+**Out of scope / follow-up:** The genuinely-DevTools-DOWN path (port not answering
+/json/version twice) still taskkills+relaunches; left in place, logged loudly, and
+tracked as **BROWSER_ATTACH_RECOVERY_DEVTOOLS_DOWN_PHASE2**.
+
+**Files Changed:**
+- `src/dae_dependencies.py`: added `open_devtools_page()`; rewrote the no-page branch
+  of `connect_chrome_with_retry` and `connect_edge_with_retry` to be non-destructive.
+- `tests/test_attach_recovery_no_kill.py`: 11 mock-only tests (no live browser).
+- `INTERFACE.md`: documented `open_devtools_page` + recovery behavior.
+
+**Tests:** `python -m pytest modules/infrastructure/dependency_launcher/` -> 11 passed.
+No-kill proof: the core `test_*_no_kill_on_discover_pages` tests FAIL on the base
+SHA (which invokes `taskkill /F /IM chrome.exe` at the discover-pages branch and
+has no `open_devtools_page`); they PASS on this change.
+
+**HONEST LIVE GAP:** Whether PUT/GET `/json/new` actually opens a discoverable tab
+on real Chrome 149 is MOCK-validated ONLY. 012 live-validates by re-running with an
+operator-prepared 9222 that has no normal tab: expect a NEW tab opened + successful
+attach + NO "killing stale Chrome" in the logs.
+
+---
+
 ### 2026-03-22: Multi-Model Auto-Loading (WSP 77 Agent Coordination)
 
 **By:** 0102

--- a/modules/infrastructure/dependency_launcher/src/dae_dependencies.py
+++ b/modules/infrastructure/dependency_launcher/src/dae_dependencies.py
@@ -231,6 +231,65 @@ def is_devtools_responding(port: int, timeout: float = 2.0) -> bool:
         return False
 
 
+def open_devtools_page(port: int, url: str = "about:blank", timeout: float = 3.0) -> bool:
+    """Open a new normal page/tab via the DevTools HTTP endpoint - NON-DESTRUCTIVE.
+
+    Used to RECOVER from the "unable to discover open pages" condition: DevTools
+    /json/version works but /json (page list) is empty, so Selenium cannot attach.
+    Instead of killing the operator's prepared browser, we ask DevTools to open a
+    normal page target so Selenium has something to attach to.
+
+    Uses the same urllib HTTP pattern as is_devtools_responding(). Tries
+    HTTP PUT /json/new?<url> first (modern Chrome/Edge), falling back to GET
+    /json/new?<url> for builds that still accept the legacy verb.
+
+    Returns:
+        True if DevTools reported a new target was created, False otherwise.
+        Never raises, never kills any process.
+    """
+    try:
+        import urllib.request
+        import urllib.parse
+        import json as json_module
+
+        # /json/new?<url> ; url-quote so about:blank etc. survive transport
+        new_url = f"http://127.0.0.1:{port}/json/new?{urllib.parse.quote(url, safe='')}"
+
+        def _try(method: str) -> bool:
+            req = urllib.request.Request(new_url, method=method)
+            with urllib.request.urlopen(req, timeout=timeout) as response:
+                body = response.read().decode("utf-8")
+            try:
+                data = json_module.loads(body)
+            except Exception:
+                # Some builds return a bare page object string; treat any 2xx
+                # body that mentions an id/target as success.
+                return bool(body and ("id" in body or "targetId" in body))
+            # A created target carries an id (and usually a webSocketDebuggerUrl)
+            return isinstance(data, dict) and bool(
+                data.get("id") or data.get("targetId") or data.get("webSocketDebuggerUrl")
+            )
+
+        # Modern Chrome (>=111) requires PUT for /json/new; older accepts GET.
+        try:
+            if _try("PUT"):
+                logger.info(f"[DEPS] Opened new DevTools page on port {port} via PUT /json/new")
+                return True
+        except Exception as put_err:
+            logger.debug(f"[DEPS] PUT /json/new failed on port {port}: {put_err}; trying GET")
+
+        if _try("GET"):
+            logger.info(f"[DEPS] Opened new DevTools page on port {port} via GET /json/new")
+            return True
+
+        logger.debug(f"[DEPS] /json/new did not report a new target on port {port}")
+        return False
+
+    except Exception as e:
+        logger.debug(f"[DEPS] open_devtools_page failed on port {port}: {e}")
+        return False
+
+
 def is_chrome_running() -> bool:
     """Check if Chrome with debug port is running AND responding."""
     if not is_port_open(CHROME_DEBUG_PORT):
@@ -695,13 +754,24 @@ def connect_chrome_with_retry(
     """
     Connect to Chrome with retry logic and DevTools verification.
 
-    Handles timing races and stale browser states. If DevTools check fails
-    (including "unable to discover open pages"), will kill and restart Chrome.
+    Handles timing races and stale browser states.
+
+    NON-DESTRUCTIVE recovery (Phase 1): when DevTools is UP but exposes no
+    discoverable page target (Selenium raises "unable to discover open pages"),
+    we DO NOT taskkill the operator's prepared Chrome. Instead we open a normal
+    tab via the DevTools HTTP endpoint (open_devtools_page) and retry the attach.
+    If a tab cannot be opened, we log a clear actionable error and return None -
+    NEVER killing the session. (See BROWSER_ATTACH_RECOVERY_NO_KILL_PHASE1.)
+
+    NOTE (BROWSER_ATTACH_RECOVERY_DEVTOOLS_DOWN_PHASE2): the genuinely-DevTools-
+    DOWN path (is_devtools_responding False twice) still taskkills+relaunches as
+    a follow-up; that is out of scope for Phase 1 (no-page recovery).
 
     Args:
         max_retries: Maximum connection attempts
         retry_delay: Seconds between retries
         relaunch_on_fail: If True, attempt to relaunch Chrome on persistent failure
+            (DevTools-DOWN path only; the no-page path never relaunches/kills)
 
     Returns:
         Selenium WebDriver or None if connection failed
@@ -718,9 +788,13 @@ def connect_chrome_with_retry(
             devtools_failures += 1
             logger.warning(f"[DEPS] Chrome DevTools not responding (attempt {attempt}/{max_retries})")
 
-            # If DevTools failed twice, Chrome is likely in bad state - kill it
+            # If DevTools failed twice, Chrome is likely DOWN (port not even
+            # answering /json/version) - kill it. This is the DevTools-DOWN path,
+            # distinct from the no-page path below. NOTE: still destructive;
+            # tracked as BROWSER_ATTACH_RECOVERY_DEVTOOLS_DOWN_PHASE2.
             if devtools_failures >= 2 and relaunch_on_fail:
-                logger.info("[DEPS] DevTools failed twice - killing stale Chrome...")
+                logger.warning("[DEPS] DevTools DOWN twice (not just no-page) - "
+                               "killing stale Chrome [PHASE2: make non-destructive]...")
                 try:
                     subprocess.run(["taskkill", "/F", "/IM", "chrome.exe"],
                                    capture_output=True, timeout=10)
@@ -759,18 +833,41 @@ def connect_chrome_with_retry(
             error_str = str(e)
             logger.warning(f"[DEPS] Chrome connection failed (attempt {attempt}/{max_retries}): {e}")
 
-            # "unable to discover open pages" = DevTools is broken, need to restart
-            if "unable to discover open pages" in error_str and relaunch_on_fail:
-                logger.info("[DEPS] Chrome DevTools broken - killing and relaunching...")
-                try:
-                    subprocess.run(["taskkill", "/F", "/IM", "chrome.exe"],
-                                   capture_output=True, timeout=10)
-                    time.sleep(2)
-                except Exception:
-                    pass
-                launch_chrome()
-                time.sleep(5)
-                continue  # Retry immediately after relaunch
+            # "unable to discover open pages" = DevTools is UP but exposes no
+            # page target. RECOVER NON-DESTRUCTIVELY: open a normal tab via the
+            # DevTools HTTP endpoint, then retry the attach. NEVER taskkill the
+            # operator's prepared Chrome here (NO_KILL contract, Phase 1).
+            if "unable to discover open pages" in error_str:
+                logger.info("[DEPS] Chrome up but no discoverable page - "
+                            "opening a tab via DevTools (NO taskkill)...")
+                if open_devtools_page(port):
+                    # Re-check the page list, then retry the attach on next loop.
+                    if is_devtools_responding(port):
+                        logger.info("[DEPS] DevTools page now discoverable - retrying attach")
+                    else:
+                        logger.warning("[DEPS] Opened a tab but page list still not ready - "
+                                       "retrying attach anyway")
+                    if attempt < max_retries:
+                        time.sleep(retry_delay)
+                        continue
+                    # Last attempt: try one immediate attach after opening the tab.
+                    try:
+                        opts = Options()
+                        opts.add_experimental_option("debuggerAddress", f"127.0.0.1:{port}")
+                        driver = webdriver.Chrome(options=opts)
+                        _ = driver.current_url
+                        logger.info("[DEPS] Chrome connected after opening a recovery tab")
+                        return driver
+                    except Exception as e2:
+                        logger.error("[DEPS] Chrome attach still failed after opening a tab: "
+                                     f"{e2}. Open a normal tab in the debug Chrome (port "
+                                     f"{port}), or relaunch with --remote-allow-origins. NO taskkill performed.")
+                        return None
+                # Opening a tab was not possible - clear actionable error, NO kill.
+                logger.error(f"[DEPS] Chrome {port} up but no discoverable page and DevTools "
+                             "/json/new could not open one. Open a normal tab in the debug "
+                             "Chrome, or relaunch it with --remote-allow-origins. NO taskkill performed.")
+                return None
 
             if attempt < max_retries:
                 time.sleep(retry_delay)
@@ -807,13 +904,23 @@ def connect_edge_with_retry(
     """
     Connect to Edge with retry logic and DevTools verification.
 
-    Handles timing races and stale browser states. If DevTools check fails
-    (including "unable to discover open pages"), will kill and restart Edge.
+    Handles timing races and stale browser states.
+
+    NON-DESTRUCTIVE recovery (Phase 1): when DevTools is UP but exposes no
+    discoverable page target ("unable to discover open pages"), we DO NOT
+    taskkill the operator's prepared Edge. Instead we open a normal tab via the
+    DevTools HTTP endpoint (open_devtools_page) and retry the attach; if a tab
+    cannot be opened we log a clear actionable error and return None - NEVER
+    killing the session. (See BROWSER_ATTACH_RECOVERY_NO_KILL_PHASE1.)
+
+    NOTE (BROWSER_ATTACH_RECOVERY_DEVTOOLS_DOWN_PHASE2): the genuinely-DevTools-
+    DOWN path still taskkills+relaunches as a follow-up (out of scope for Phase 1).
 
     Args:
         max_retries: Maximum connection attempts
         retry_delay: Seconds between retries
         relaunch_on_fail: If True, attempt to relaunch Edge on persistent failure
+            (DevTools-DOWN path only; the no-page path never relaunches/kills)
 
     Returns:
         Selenium WebDriver or None if connection failed
@@ -830,9 +937,13 @@ def connect_edge_with_retry(
             devtools_failures += 1
             logger.warning(f"[DEPS] Edge DevTools not responding (attempt {attempt}/{max_retries})")
 
-            # If DevTools failed twice, Edge is likely in bad state - kill it
+            # If DevTools failed twice, Edge is likely DOWN (port not even
+            # answering /json/version) - kill it. Distinct from the no-page path
+            # below. NOTE: still destructive; tracked as
+            # BROWSER_ATTACH_RECOVERY_DEVTOOLS_DOWN_PHASE2.
             if devtools_failures >= 2 and relaunch_on_fail:
-                logger.info("[DEPS] DevTools failed twice - killing stale Edge...")
+                logger.warning("[DEPS] DevTools DOWN twice (not just no-page) - "
+                               "killing stale Edge [PHASE2: make non-destructive]...")
                 try:
                     subprocess.run(["taskkill", "/F", "/IM", "msedge.exe"],
                                    capture_output=True, timeout=10)
@@ -871,18 +982,39 @@ def connect_edge_with_retry(
             error_str = str(e)
             logger.warning(f"[DEPS] Edge connection failed (attempt {attempt}/{max_retries}): {e}")
 
-            # "unable to discover open pages" = DevTools is broken, need to restart
-            if "unable to discover open pages" in error_str and relaunch_on_fail:
-                logger.info("[DEPS] Edge DevTools broken - killing and relaunching...")
-                try:
-                    subprocess.run(["taskkill", "/F", "/IM", "msedge.exe"],
-                                   capture_output=True, timeout=10)
-                    time.sleep(2)
-                except Exception:
-                    pass
-                launch_edge()
-                time.sleep(5)
-                continue  # Retry immediately after relaunch
+            # "unable to discover open pages" = DevTools is UP but exposes no
+            # page target. RECOVER NON-DESTRUCTIVELY: open a normal tab via the
+            # DevTools HTTP endpoint, then retry the attach. NEVER taskkill the
+            # operator's prepared Edge here (NO_KILL contract, Phase 1).
+            if "unable to discover open pages" in error_str:
+                logger.info("[DEPS] Edge up but no discoverable page - "
+                            "opening a tab via DevTools (NO taskkill)...")
+                if open_devtools_page(port):
+                    if is_devtools_responding(port):
+                        logger.info("[DEPS] DevTools page now discoverable - retrying attach")
+                    else:
+                        logger.warning("[DEPS] Opened a tab but page list still not ready - "
+                                       "retrying attach anyway")
+                    if attempt < max_retries:
+                        time.sleep(retry_delay)
+                        continue
+                    try:
+                        opts = EdgeOptions()
+                        opts.add_experimental_option("debuggerAddress", f"127.0.0.1:{port}")
+                        driver = webdriver.Edge(options=opts)
+                        _ = driver.current_url
+                        logger.info("[DEPS] Edge connected after opening a recovery tab")
+                        return driver
+                    except Exception as e2:
+                        logger.error("[DEPS] Edge attach still failed after opening a tab: "
+                                     f"{e2}. Open a normal tab in the debug Edge (port "
+                                     f"{port}), or relaunch with --remote-allow-origins. NO taskkill performed.")
+                        return None
+                # Opening a tab was not possible - clear actionable error, NO kill.
+                logger.error(f"[DEPS] Edge {port} up but no discoverable page and DevTools "
+                             "/json/new could not open one. Open a normal tab in the debug "
+                             "Edge, or relaunch it with --remote-allow-origins. NO taskkill performed.")
+                return None
 
             if attempt < max_retries:
                 time.sleep(retry_delay)

--- a/modules/infrastructure/dependency_launcher/tests/test_attach_recovery_no_kill.py
+++ b/modules/infrastructure/dependency_launcher/tests/test_attach_recovery_no_kill.py
@@ -1,0 +1,314 @@
+"""Non-destructive browser-attach recovery tests (NO_KILL contract, Phase 1).
+
+Slice: BROWSER_ATTACH_RECOVERY_NO_KILL_PHASE1
+
+Confirmed problem (012 live-observed): when the operator-prepared Chrome/Edge on
+the debug port is UP (DevTools /json/version works) but has NO discoverable page
+target (/json page-list empty -> Selenium raises "unable to discover open pages"),
+the old code ran `taskkill /F /IM chrome.exe` and relaunched, DESTROYING the
+operator's prepared session.
+
+These tests are MOCK ONLY - no live browser is started. They verify that the
+discover-pages (no-page) path NEVER taskkills, recovers by opening a tab, and
+fails clearly (no kill) when a tab cannot be opened. The success path is guarded
+as a regression check.
+
+Whether PUT/GET /json/new actually opens a discoverable tab on real Chrome 149 is
+MOCK-validated only here; 012 live-validates (see ModLog "HONEST LIVE GAP").
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# Ensure repo root on path (pytest.ini sets pythonpath=. but be explicit/robust).
+# file -> tests -> dependency_launcher -> infrastructure -> modules -> <repo root>
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from modules.infrastructure.dependency_launcher.src import dae_dependencies as deps
+
+
+class _DiscoverPagesError(Exception):
+    """Stand-in for the Selenium error Chrome/Edge raise with no page target."""
+
+    def __init__(self):
+        super().__init__(
+            "Message: session not created: unable to discover open pages"
+        )
+
+
+class _FakeDriver:
+    """Minimal driver: .current_url read must succeed for the attach to 'pass'."""
+
+    @property
+    def current_url(self):
+        return "https://studio.youtube.com/"
+
+
+def _spy_subprocess_run():
+    """Return (spy, taskkill_calls_list). taskkill_calls captures any taskkill."""
+    taskkill_calls = []
+
+    def _run(cmd, *args, **kwargs):
+        # Record any taskkill invocation against a browser image.
+        if isinstance(cmd, (list, tuple)) and cmd and cmd[0] == "taskkill":
+            taskkill_calls.append(list(cmd))
+        return mock.Mock(returncode=0, stdout=b"", stderr=b"")
+
+    spy = mock.Mock(side_effect=_run)
+    return spy, taskkill_calls
+
+
+# ---------------------------------------------------------------------------
+# CHROME
+# ---------------------------------------------------------------------------
+
+def test_chrome_no_kill_on_discover_pages():
+    """CORE non-vacuous test: discover-pages -> open-tab recovery, NO taskkill.
+
+    On OLD code the discover-pages branch ran subprocess.run(["taskkill", ...,
+    "chrome.exe"]) at dae_dependencies.py:766, so taskkill_calls would be
+    non-empty and this assertion (call_count == 0) would FAIL. On the new code
+    open_devtools_page is called instead and taskkill is never invoked.
+    """
+    spy_run, taskkill_calls = _spy_subprocess_run()
+
+    # DevTools is UP (version works) - is_devtools_responding True; the no-page
+    # condition is surfaced only by the Selenium attach raising the error.
+    chrome_ctor = mock.Mock(side_effect=_DiscoverPagesError())
+
+    with mock.patch.object(deps, "subprocess") as sp, \
+         mock.patch.object(deps, "is_devtools_responding", return_value=True), \
+         mock.patch.object(deps, "open_devtools_page", return_value=True) as open_tab, \
+         mock.patch.object(deps, "launch_chrome") as launch, \
+         mock.patch.object(deps, "time"), \
+         mock.patch("selenium.webdriver.Chrome", chrome_ctor):
+        sp.run = spy_run
+        # max_retries=1 so the no-page branch runs on the final attempt and we
+        # exercise the "no tab opened in time / attach again" tail deterministically.
+        result = deps.connect_chrome_with_retry(max_retries=1, retry_delay=0)
+
+    # The recovery helper MUST have been called on the no-page path.
+    assert open_tab.called, "open_devtools_page was not called on discover-pages path"
+    # NO taskkill anywhere - this is the NO_KILL contract and the proof that
+    # differentiates new code from old (old code's call_count would be >= 1).
+    assert all("taskkill" not in str(c) for c in spy_run.call_args_list), spy_run.call_args_list
+    assert len(taskkill_calls) == 0, f"taskkill was invoked: {taskkill_calls}"
+    # launch_chrome (relaunch) must NOT happen on the no-page path either.
+    assert not launch.called, "launch_chrome (relaunch) must not run on no-page path"
+
+
+def test_chrome_recover_then_attach():
+    """After open-tab succeeds and page becomes discoverable, attach is retried."""
+    spy_run, taskkill_calls = _spy_subprocess_run()
+
+    # First attach raises discover-pages; second attach (after open-tab) succeeds.
+    chrome_ctor = mock.Mock(side_effect=[_DiscoverPagesError(), _FakeDriver()])
+
+    with mock.patch.object(deps, "subprocess") as sp, \
+         mock.patch.object(deps, "is_devtools_responding", return_value=True), \
+         mock.patch.object(deps, "open_devtools_page", return_value=True) as open_tab, \
+         mock.patch.object(deps, "launch_chrome") as launch, \
+         mock.patch.object(deps, "time"), \
+         mock.patch("selenium.webdriver.Chrome", chrome_ctor):
+        sp.run = spy_run
+        result = deps.connect_chrome_with_retry(max_retries=3, retry_delay=0)
+
+    assert isinstance(result, _FakeDriver), "expected a driver after recover-then-attach"
+    assert open_tab.called, "open_devtools_page must be called before retry"
+    assert chrome_ctor.call_count == 2, "attach must be retried after opening a tab"
+    assert len(taskkill_calls) == 0, f"no taskkill allowed: {taskkill_calls}"
+    assert not launch.called, "no relaunch on the no-page recovery path"
+
+
+def test_chrome_fail_clear_no_kill_when_open_fails():
+    """If open-tab fails, return None with a clear error AND no taskkill."""
+    spy_run, taskkill_calls = _spy_subprocess_run()
+
+    chrome_ctor = mock.Mock(side_effect=_DiscoverPagesError())
+
+    with mock.patch.object(deps, "subprocess") as sp, \
+         mock.patch.object(deps, "is_devtools_responding", return_value=True), \
+         mock.patch.object(deps, "open_devtools_page", return_value=False) as open_tab, \
+         mock.patch.object(deps, "launch_chrome") as launch, \
+         mock.patch.object(deps, "time"), \
+         mock.patch("selenium.webdriver.Chrome", chrome_ctor):
+        sp.run = spy_run
+        result = deps.connect_chrome_with_retry(max_retries=3, retry_delay=0)
+
+    assert result is None, "open-tab failure must return None (clear failure)"
+    assert open_tab.called, "open_devtools_page must be attempted"
+    assert len(taskkill_calls) == 0, f"no taskkill on open-tab failure: {taskkill_calls}"
+    assert not launch.called, "no relaunch when open-tab fails on no-page path"
+
+
+def test_chrome_success_attach_preserved():
+    """Regression guard: a normal discoverable attach returns a driver, no recovery."""
+    spy_run, taskkill_calls = _spy_subprocess_run()
+
+    chrome_ctor = mock.Mock(return_value=_FakeDriver())
+
+    with mock.patch.object(deps, "subprocess") as sp, \
+         mock.patch.object(deps, "is_devtools_responding", return_value=True), \
+         mock.patch.object(deps, "open_devtools_page", return_value=True) as open_tab, \
+         mock.patch.object(deps, "launch_chrome") as launch, \
+         mock.patch.object(deps, "time"), \
+         mock.patch("selenium.webdriver.Chrome", chrome_ctor):
+        sp.run = spy_run
+        result = deps.connect_chrome_with_retry(max_retries=3, retry_delay=0)
+
+    assert isinstance(result, _FakeDriver), "success path must return a driver"
+    assert not open_tab.called, "no recovery should be attempted on success"
+    assert chrome_ctor.call_count == 1, "success should attach on first try"
+    assert len(taskkill_calls) == 0, f"success path must not taskkill: {taskkill_calls}"
+    assert not launch.called, "success path must not relaunch"
+
+
+# ---------------------------------------------------------------------------
+# EDGE PARITY
+# ---------------------------------------------------------------------------
+
+def test_edge_no_kill_on_discover_pages():
+    """EDGE PARITY: discover-pages -> open-tab recovery, NO msedge.exe taskkill."""
+    spy_run, taskkill_calls = _spy_subprocess_run()
+
+    edge_ctor = mock.Mock(side_effect=_DiscoverPagesError())
+
+    with mock.patch.object(deps, "subprocess") as sp, \
+         mock.patch.object(deps, "is_devtools_responding", return_value=True), \
+         mock.patch.object(deps, "open_devtools_page", return_value=True) as open_tab, \
+         mock.patch.object(deps, "launch_edge") as launch, \
+         mock.patch.object(deps, "time"), \
+         mock.patch("selenium.webdriver.Edge", edge_ctor):
+        sp.run = spy_run
+        result = deps.connect_edge_with_retry(max_retries=1, retry_delay=0)
+
+    assert open_tab.called, "open_devtools_page must be called on Edge no-page path"
+    assert all("taskkill" not in str(c) for c in spy_run.call_args_list), spy_run.call_args_list
+    assert len(taskkill_calls) == 0, f"taskkill was invoked for Edge: {taskkill_calls}"
+    assert not launch.called, "launch_edge (relaunch) must not run on no-page path"
+
+
+def test_edge_recover_then_attach():
+    """EDGE PARITY: open-tab then successful retry returns a driver."""
+    spy_run, taskkill_calls = _spy_subprocess_run()
+
+    edge_ctor = mock.Mock(side_effect=[_DiscoverPagesError(), _FakeDriver()])
+
+    with mock.patch.object(deps, "subprocess") as sp, \
+         mock.patch.object(deps, "is_devtools_responding", return_value=True), \
+         mock.patch.object(deps, "open_devtools_page", return_value=True) as open_tab, \
+         mock.patch.object(deps, "launch_edge") as launch, \
+         mock.patch.object(deps, "time"), \
+         mock.patch("selenium.webdriver.Edge", edge_ctor):
+        sp.run = spy_run
+        result = deps.connect_edge_with_retry(max_retries=3, retry_delay=0)
+
+    assert isinstance(result, _FakeDriver), "expected a driver after Edge recover-then-attach"
+    assert open_tab.called
+    assert edge_ctor.call_count == 2
+    assert len(taskkill_calls) == 0, f"no taskkill allowed for Edge: {taskkill_calls}"
+    assert not launch.called
+
+
+def test_edge_fail_clear_no_kill_when_open_fails():
+    """EDGE PARITY: open-tab failure returns None, no taskkill."""
+    spy_run, taskkill_calls = _spy_subprocess_run()
+
+    edge_ctor = mock.Mock(side_effect=_DiscoverPagesError())
+
+    with mock.patch.object(deps, "subprocess") as sp, \
+         mock.patch.object(deps, "is_devtools_responding", return_value=True), \
+         mock.patch.object(deps, "open_devtools_page", return_value=False) as open_tab, \
+         mock.patch.object(deps, "launch_edge") as launch, \
+         mock.patch.object(deps, "time"), \
+         mock.patch("selenium.webdriver.Edge", edge_ctor):
+        sp.run = spy_run
+        result = deps.connect_edge_with_retry(max_retries=3, retry_delay=0)
+
+    assert result is None
+    assert open_tab.called
+    assert len(taskkill_calls) == 0, f"no taskkill on Edge open-tab failure: {taskkill_calls}"
+    assert not launch.called
+
+
+def test_edge_success_attach_preserved():
+    """EDGE PARITY regression guard: normal attach returns driver, no recovery."""
+    spy_run, taskkill_calls = _spy_subprocess_run()
+
+    edge_ctor = mock.Mock(return_value=_FakeDriver())
+
+    with mock.patch.object(deps, "subprocess") as sp, \
+         mock.patch.object(deps, "is_devtools_responding", return_value=True), \
+         mock.patch.object(deps, "open_devtools_page", return_value=True) as open_tab, \
+         mock.patch.object(deps, "launch_edge") as launch, \
+         mock.patch.object(deps, "time"), \
+         mock.patch("selenium.webdriver.Edge", edge_ctor):
+        sp.run = spy_run
+        result = deps.connect_edge_with_retry(max_retries=3, retry_delay=0)
+
+    assert isinstance(result, _FakeDriver)
+    assert not open_tab.called
+    assert edge_ctor.call_count == 1
+    assert len(taskkill_calls) == 0, f"Edge success path must not taskkill: {taskkill_calls}"
+    assert not launch.called
+
+
+# ---------------------------------------------------------------------------
+# open_devtools_page helper (HTTP layer) - mocked urllib, no real network
+# ---------------------------------------------------------------------------
+
+def test_open_devtools_page_put_success():
+    """PUT /json/new returning a target id -> True (no GET fallback needed)."""
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return b'{"id": "ABCD", "webSocketDebuggerUrl": "ws://x"}'
+
+    with mock.patch("urllib.request.urlopen", return_value=_Resp()) as urlopen:
+        ok = deps.open_devtools_page(9222)
+
+    assert ok is True
+    # First call is PUT.
+    first_req = urlopen.call_args_list[0].args[0]
+    assert first_req.get_method() == "PUT"
+
+
+def test_open_devtools_page_get_fallback():
+    """If PUT raises, GET fallback that returns a target id -> True."""
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return b'{"id": "EFGH"}'
+
+    def _urlopen(req, *a, **k):
+        if req.get_method() == "PUT":
+            raise OSError("PUT not allowed")
+        return _Resp()
+
+    with mock.patch("urllib.request.urlopen", side_effect=_urlopen):
+        ok = deps.open_devtools_page(9222)
+
+    assert ok is True
+
+
+def test_open_devtools_page_failure_returns_false_never_raises():
+    """All HTTP attempts fail -> False, and the helper never raises or kills."""
+    with mock.patch("urllib.request.urlopen", side_effect=OSError("blocked")):
+        ok = deps.open_devtools_page(9222)
+    assert ok is False


### PR DESCRIPTION
## Summary

Phase 1 NO_KILL fix for SHARED browser-attach infrastructure (`dependency_launcher`, used by scheduler / video indexer / comment engagement).

**Confirmed problem (012 live-observed):** when the operator-prepared Chrome on 9222 is UP (DevTools `/json/version` works) but has **no discoverable page target** (`/json` page-list empty -> Selenium raises "unable to discover open pages"), `connect_chrome_with_retry` ran `taskkill /F /IM chrome.exe` and relaunched a fresh Chrome - destroying the operator's authenticated/prepared window and confounding every live test. Edge had the identical destructive path.

**Fix:** on the discover-pages (no-page) condition, recover **non-destructively**:
- New helper `open_devtools_page(port, url="about:blank")` opens a normal tab via the DevTools HTTP endpoint - `PUT /json/new?about:blank` (modern Chrome/Edge) with `GET` fallback.
- `connect_chrome_with_retry` / `connect_edge_with_retry` now call `open_devtools_page`, re-check `is_devtools_responding`, and **retry the attach**.
- If a tab cannot be opened, they log a **clear actionable error** ("open a normal tab in the debug Chrome/Edge, or relaunch with `--remote-allow-origins`") and return `None` - **never taskkill**.
- The success attach path is **unchanged**.

## HoloIndex note
- Q1 "DevTools open tab CDP Target.createTarget json new chrome debug port" -> top code hit `foundups_selenium/src/devtools_mcp_adapter.py` (candidate helper), plus the target `dae_dependencies.py`. Rated: useful (surfaced the only existing open-tab method).
- Q2 "browser attach retry open page target taskkill chrome relaunch" -> `browser_manager.py`, `browser_health_check.py`, `dae_dependencies.py`. Rated: moderate (located the target + adjacent browser code; no `/json/new` helper anywhere).

## Reuse statement (WSP 84)
Checked for an existing DevTools open-tab / CDP helper to reuse. `devtools_mcp_adapter.py:new_page()` (`:510`) exists but requires an **already-initialized driver/MCP backend** (`self._driver.execute_script("window.open")`), so it **cannot** recover the pre-attach, no-driver case that is exactly our failure. A repo-wide search for `/json/new` and `Target.createTarget` found **no** existing usage. Reused the in-file `urllib.request` + `/json` HTTP pattern from `is_devtools_responding` (`dae_dependencies.py:200-227`) instead of inventing new HTTP machinery or adding a dependency.

## No-taskkill proof (how the core test FAILS on old code)
The core tests `test_chrome_no_kill_on_discover_pages` / `test_edge_no_kill_on_discover_pages` simulate "unable to discover open pages", spy on `subprocess.run`, and assert `taskkill` call_count == 0 plus `open_devtools_page.called`.

Run against the **base SHA** (`6f651a8c6`) the discover-pages branch invokes `subprocess.run(["taskkill","/F","/IM","chrome.exe"])` (and `msedge.exe` for Edge), and the base has **no** `open_devtools_page` attribute - so both assertions fail. Verified directly by loading the base module and exercising the path:
```
OLD has open_devtools_page attr: False
CHROME taskkill calls on OLD code: [['taskkill', '/F', '/IM', 'chrome.exe']]
EDGE  taskkill calls on OLD code: [['taskkill', '/F', '/IM', 'msedge.exe']]
```
On this change the same tests PASS (no taskkill, open-tab recovery called).

## Tests (mock only - no live browser)
`python -m pytest modules/infrastructure/dependency_launcher/` -> **11 passed**:
- `test_chrome_no_kill_on_discover_pages` / `test_edge_no_kill_on_discover_pages` (core, non-vacuous; fail on base SHA)
- `test_chrome_recover_then_attach` / `test_edge_recover_then_attach`
- `test_chrome_fail_clear_no_kill_when_open_fails` / `test_edge_fail_clear_no_kill_when_open_fails`
- `test_chrome_success_attach_preserved` / `test_edge_success_attach_preserved` (regression guard)
- `test_open_devtools_page_put_success` / `test_open_devtools_page_get_fallback` / `test_open_devtools_page_failure_returns_false_never_raises`

Dependent-caller import smoke (scheduler, multi_channel_coordinator): OK.

## HONEST LIVE GAP
Whether `PUT`/`GET /json/new` actually opens a discoverable tab on **real Chrome 149** is **MOCK-validated only**. No live browser was started.

## Operator live-check (012)
Re-run with an operator-prepared 9222 that has **no normal tab**. Expect in the logs: a **NEW tab opened** ("Opened new DevTools page ... via PUT/GET /json/new"), a **successful attach** ("connected after opening a recovery tab"), and **NO** "killing stale Chrome" / no taskkill. If `/json/new` is blocked on Chrome 149, expect the clear actionable error + `None` (still **no** taskkill).

## Out of scope / follow-up
The genuinely-DevTools-DOWN path (port not answering `/json/version` twice) still taskkills+relaunches; left intact, logged loudly, tracked as **BROWSER_ATTACH_RECOVERY_DEVTOOLS_DOWN_PHASE2**.

## WSP_97 Truth Boundary Checklist

| # | Truth Boundary Checklist Item | Status | Evidence |
|---|---|---|---|
| 1 | HOLOINDEX_DISCOVERY_RECORDED | YES | 2 queries above; surfaced `devtools_mcp_adapter.py` + target `dae_dependencies.py` |
| 2 | DISCOVER_PAGES_PATH_NO_TASKKILL_TESTED | YES | `test_chrome_no_kill_on_discover_pages`, `test_edge_no_kill_on_discover_pages` (taskkill call_count==0) |
| 3 | OPEN_TAB_RECOVERY_THEN_RETRY_TESTED | YES | `test_chrome_recover_then_attach`, `test_edge_recover_then_attach` (attach retried, driver returned) |
| 4 | FAIL_CLEAR_NO_KILL_WHEN_OPEN_FAILS | YES | `test_chrome_fail_clear_no_kill_when_open_fails`, Edge parity (None + no taskkill) |
| 5 | EDGE_PARITY_NO_KILL | YES | all `test_edge_*` assert no `msedge.exe` taskkill on no-page path |
| 6 | SUCCESS_ATTACH_PATH_PRESERVED | YES | `test_chrome_success_attach_preserved`, `test_edge_success_attach_preserved` (driver, no recovery) |
| 7 | REUSES_EXISTING_DEVTOOLS_HELPER_IF_ANY | YES | reuse statement above; `new_page()` needs a driver (unusable pre-attach); reused in-file urllib `/json` pattern |
| 8 | SCOPE_DEPENDENCY_LAUNCHER_ONLY | YES | `git diff` touches only `modules/infrastructure/dependency_launcher/` (4 files) |
| 9 | TESTS_MOCK_ONLY_NO_LIVE_BROWSER | YES | all tests mock `webdriver.Chrome/Edge`, `urllib`, helpers; no browser launched |
| 10 | LIVE_OPEN_TAB_ON_CHROME149_UNVERIFIED_GAP_DECLARED | YES | HONEST LIVE GAP section + ModLog |
| 11 | NO_SKIP_XFAIL | YES | 11 passed, 0 skipped, 0 xfail |
| 12 | ASCII_CLEAN | YES | 0 non-ASCII bytes in source/test; 0 new non-ASCII in added doc lines |
| 13 | PRIMARY_CHECKOUT_UNTOUCHED | YES | all work via `git -C /o/tmp/wt-attach`; no edits/commits to `/o/Foundups-Agent`; no stash; no worktree add/remove |

Declared items: 13 - Rows: 13 - All YES

---
Worker-Lane: ATTACH-AUTHOR | Slice: BROWSER_ATTACH_RECOVERY_NO_KILL_PHASE1
Status: OPEN at VERIFIED_READY - do NOT merge (sovereign 012 merge after live re-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
