### PR TITLE
fix(video_indexer): shadow-DOM traversal for Studio Ask selectors - deep finder + live-grounded selectors (Phase 1) [stacked on #827]

### DIFF
--- a/modules/ai_intelligence/video_indexer/ModLog.md
+++ b/modules/ai_intelligence/video_indexer/ModLog.md
@@ -47,6 +47,59 @@ browser by default.
 - WSP 5 (gate, do not delete coverage), WSP 22 (ModLog), WSP 50 (verify
   before edit), WSP 84 (standard pytest marker + skip pattern), WSP 97 (Truth
   Boundary: tests/ + conftest only; no src/ or production code touched).
+## V0.24.0 - Ask Studio shadow-DOM traversal: deep finder + live-grounded selectors (STUDIO_ASK_SHADOW_DOM_SELECTORS_PHASE1) [stacked on #827] (2026-06-17)
+
+### Why
+ROOT CAUSE (live-confirmed): YouTube Studio's DOM is SHADOW-ROOTED. Flat
+Selenium `find_element("css selector", ...)` does NOT pierce shadow roots, so the
+indexer's selectors silently failed on the live page even when the element
+existed. #817 fixed selector NAMES but not the TRAVERSAL model. Proven live: the
+flat `input#title-field` returns nothing but a shadow walk finds
+`ytcp-social-suggestions-textbox#title-textarea`; the old Ask-button selector
+`aria-label="Ask Studio"` does NOT exist - the real entry is the creator-chat
+"spark" trigger (`ytcp-creator-chat-trigger` -> `ytcp-icon-button`).
+
+### Changed
+- NEW `modules/infrastructure/foundups_selenium/src/shadow_dom_finder.py`:
+  `find_deep` / `shadow_query` / `first_deep` return REAL WebElements by having
+  `execute_script` RETURN the matched node (so `human_type` + `.click()` keep
+  working). WSP 84 REUSE: the recursive `findInShadow` traversal is the SAME
+  algorithm already used by the YT comment-reply path (`reply_executor.findInShadow`);
+  the only change is the return contract (node, not text/boolean). Exported via
+  `foundups_selenium/src/__init__.py`.
+- `src/studio_ask_indexer.py`: `_first_element` now does shadow-DOM deep find
+  PRIMARY (css strings + cross-shadow chains) with a flat fallback. PINNED
+  live-grounded selectors: title `ytcp-social-suggestions-textbox#title-textarea`;
+  Ask button spark chain `ytcp-creator-chat-trigger -> ytcp-icon-button` (aria-label
+  demoted to fallback); prompt
+  `div.ytcpCreatorChatEntityAttachmentInlineFlowPromptBox[contenteditable="true"][aria-label="Ask something"]`;
+  dialog `tp-yt-paper-dialog#dialog`; stream
+  `ytcp-engagement-panel-section-list-renderer#PAcreator_chat_streaming`. Dialog
+  OPEN is confirmed via the prompt box + stream (CHILDREN), never the dialog
+  host (live-observed host computes visible:false). NEW `_is_zero_state` guard:
+  the zero-state suggestion list ("How can Ask Studio help me? / Summarize
+  comments ...") is never scraped/persisted as the answer.
+- KEEPS #825 input behavior (human_type, single clean submit) and #827
+  target/channel fail-closed EXACTLY (all 44 prior tests green via the flat
+  fallback). NO action-id/output-schema change (no UI-TARS/coordinate code).
+
+### Tests
+- NEW `tests/test_studio_ask_shadow_dom.py` (10 mock tests, NO live browser):
+  flat-fails/shadow-finds (title + Ask button), full primary path over a
+  shadow-only DOM, dialog-open via children, zero-state-not-scraped, wrong/error
+  page still fails closed (#827), no-persist-on-failure, #825 single-submit
+  preserved over the shadow path.
+- NEW `modules/infrastructure/foundups_selenium/tests/test_shadow_dom_finder.py`
+  (7 tests for the helper).
+- NON-VACUITY proven: with the deep finder disabled (pre-slice flat-only model)
+  both shadow-rooted title + Ask button resolve to None/False.
+
+### Honest live gap
+Selectors are LIVE-GROUNDED (012 captured them; resolve via shadow find + Ask
+Studio opens). Mock tests + grounded selectors only; the COMBINED live happy
+path (submit -> stream -> scrape) is validated by 0102's live re-test AFTER this.
+STACKED on #827 -> do not merge before #825/#827; final order #825 -> #827 -> this.
+
 ## V0.23.0 - Ask Studio single-video: select Studio TARGET + owning-channel CONTEXT, fail-closed on mismatch (STUDIO_ASK_CHANNEL_CONTEXT_PHASE1) [stacked on #825] (2026-06-16)
 
 ### Security (CodeQL py/incomplete-url-substring-sanitization, high) - 2026-06-17

--- a/modules/ai_intelligence/video_indexer/src/studio_ask_indexer.py
+++ b/modules/ai_intelligence/video_indexer/src/studio_ask_indexer.py
@@ -45,6 +45,22 @@ except ImportError:  # pragma: no cover - import guard mirrors reply_executor
     get_human_behavior = None
     HUMAN_BEHAVIOR_AVAILABLE = False
 
+# WSP 84 REUSE: shadow-DOM deep finder (returns REAL WebElements). YouTube Studio
+# is shadow-rooted, so flat find_element silently fails on the live page even
+# when the element exists (#817 fixed selector NAMES but not the TRAVERSAL model).
+# first_deep tries shadow-piercing CSS chains FIRST, then a flat fallback - so the
+# PRIMARY path is shadow traversal while light-DOM pages still resolve.
+try:
+    from modules.infrastructure.foundups_selenium.src.shadow_dom_finder import (
+        find_deep,
+        first_deep,
+    )
+    SHADOW_FINDER_AVAILABLE = True
+except ImportError:  # pragma: no cover - import guard
+    find_deep = None
+    first_deep = None
+    SHADOW_FINDER_AVAILABLE = False
+
 logger = logging.getLogger(__name__)
 
 INDEX_ROOT = Path("memory") / "video_index"
@@ -121,23 +137,50 @@ class StudioAskIndexer:
     # This is the CANONICAL path for Phase 1. The legacy watch-page Ask button
     # and the old Studio popup menu are DEMOTED to fallback (see SELECTORS).
     # =========================================================================
+    # =========================================================================
+    # LIVE-GROUNDED SELECTORS (STUDIO_ASK_SHADOW_DOM_SELECTORS_PHASE1)
+    # ---------------------------------------------------------------------
+    # 012 captured these from the REAL shadow-rooted Studio DOM, so they are the
+    # source-of-truth PRIMARY targets (resolved via the shadow-DOM deep finder).
+    # The old aria-label="Ask Studio" flat selector does NOT exist on the live
+    # page -- the real entry is the creator-chat "spark" trigger. Each entry is
+    # either a CSS string (single deep step) or a list (a CROSS-SHADOW chain for
+    # shadow_query). The legacy flat selectors are kept ONLY as documented
+    # fallbacks (so light-DOM pages + the existing mock drivers still resolve).
+    # =========================================================================
+
+    # Edit-surface / title field (contains div#textbox[contenteditable]).
+    TITLE_TEXTAREA_SELECTOR = "ytcp-social-suggestions-textbox#title-textarea"
+
     ASK_STUDIO_SELECTORS = {
         # Header entry button that opens the Ask Studio dialog.
+        # PRIMARY (live-grounded): the "spark" creator-chat trigger chain
+        # ytcp-creator-chat-trigger -> ytcp-icon-button (NOT aria-label="Ask Studio").
         "header_button": [
+            ["ytcp-creator-chat-trigger", "ytcp-icon-button"],
+            ["ytcp-creator-chat-trigger", "ytcp-creator-chat-spark", "ytcp-icon-button"],
+            "ytcp-creator-chat-trigger",
+            # Legacy flat fallbacks (resilience only; not present on live page).
             'ytcp-icon-button[aria-label="Ask Studio"]',
             'ytcp-icon-button[aria-label*="Ask Studio"]',
             'button[aria-label="Ask Studio"]',
             'button[aria-label*="Ask Studio"]',
         ],
-        # Dialog container shown after clicking the header button.
+        # Dialog container shown after clicking the header button. Live-observed:
+        # the dialog HOST computes visible:false while its CHILDREN are visible,
+        # so callers confirm "opened" via the PROMPT BOX / STREAM, not the dialog.
         "dialog": [
+            "tp-yt-paper-dialog#dialog",
+            "ytcp-dialog",
+            # Legacy flat fallback.
             'ytcp-dialog#dialog',
-            'ytcp-dialog',
         ],
-        # Contenteditable prompt box inside the dialog.
+        # Contenteditable prompt box inside the dialog (live-grounded class).
         "prompt_box": [
-            'div[contenteditable][aria-label="Ask something"]',
+            'div.ytcpCreatorChatEntityAttachmentInlineFlowPromptBox[contenteditable="true"][aria-label="Ask something"]',
             'div.ytcpCreatorChatEntityAttachmentInlineFlowPromptBox[contenteditable="true"]',
+            # Legacy flat fallbacks.
+            'div[contenteditable][aria-label="Ask something"]',
             'div[contenteditable="true"][aria-label*="Ask"]',
         ],
         # Send / submit button inside the dialog. PREFERRED submission path
@@ -149,14 +192,30 @@ class StudioAskIndexer:
             'button[aria-label*="Send"]',
             'button[aria-label*="Submit"]',
         ],
-        # Streaming / response container candidates (DOM text, NOT clipboard).
+        # Streaming / response container (live-grounded). DOM text, NOT clipboard.
         "response_stream": [
-            '#PAcreator_chat_streaming',
+            "ytcp-engagement-panel-section-list-renderer#PAcreator_chat_streaming",
+            "#PAcreator_chat_streaming",
+            # Legacy flat fallbacks.
             'div.ytcpCreatorChatEntityResponse',
             'ytcp-creator-chat-response',
             '[class*="CreatorChat"][class*="Response"]',
         ],
     }
+
+    # Zero-state suggestion view ("How can Ask Studio help me? Summarize comments
+    # ...") rendered in the stream BEFORE any real answer. Live caveat: this must
+    # NOT be scraped as the answer -- the real answer renders after submit.
+    ZERO_STATE_SELECTOR = "ytcp-ask-studio-zero-state-view-model"
+
+    # Markers proving a scraped stream block is the ZERO-STATE suggestion list,
+    # not a real answer. If the stabilized text is ONLY zero-state, fail closed.
+    ZERO_STATE_MARKERS = (
+        "how can ask studio help",
+        "how can i help you",
+        "summarize comments",
+        "summarize the comments",
+    )
 
     # Refusal / no-answer markers. If the STABILIZED Ask Studio response contains
     # any of these, we fail closed (success=False) and persist NOTHING - a refusal
@@ -480,9 +539,30 @@ Give a brief category and a few mood/genre topics only.""",
             logger.warning(f"[STUDIO-ASK] JSON parse failed: {e}")
             return {"topics": [], "segments": [], "content_category": "other", "raw": response_text}
     
-    def _first_element(self, selectors: List[str]):
-        """Return the first element matching any selector in the list, else None."""
+    def _first_element(self, selectors: List[Any]):
+        """
+        Return the first element resolving from the selector list, else None.
+
+        PRIMARY: shadow-DOM deep traversal (first_deep) - each entry is a CSS
+        string (single deep step) OR a list (a cross-shadow chain). This pierces
+        YouTube Studio's shadow roots and returns a REAL WebElement (so #825's
+        human_type + #827's .click() keep working). FALLBACK: a flat
+        find_element per string selector (cheap, documented) so light-DOM pages
+        and the existing mock drivers still resolve. The PRIMARY mechanism is
+        shadow traversal, not the flat fallback.
+        """
+        # PRIMARY: shadow-piercing deep find (handles css strings + chains).
+        if SHADOW_FINDER_AVAILABLE and first_deep is not None:
+            try:
+                el = first_deep(self.driver, selectors)
+                if el is not None:
+                    return el
+            except Exception:
+                pass
+        # FALLBACK: flat light-DOM find for plain string selectors only.
         for selector in selectors:
+            if not isinstance(selector, str):
+                continue
             try:
                 el = self.driver.find_element("css selector", selector)
                 if el:
@@ -519,6 +599,19 @@ Give a brief category and a few mood/genre topics only.""",
         lowered = text.lower()
         return any(marker in lowered for marker in StudioAskIndexer.REFUSAL_MARKERS)
 
+    @staticmethod
+    def _is_zero_state(text: str) -> bool:
+        """
+        True if the stream text is the Ask Studio ZERO-STATE suggestion list
+        ("How can Ask Studio help me? / Summarize comments ...") and NOT a real
+        answer. Live caveat: the stream renders this zero-state BEFORE any
+        submit, so it must never be scraped/persisted as the answer.
+        """
+        if not text:
+            return False
+        lowered = text.lower()
+        return any(marker in lowered for marker in StudioAskIndexer.ZERO_STATE_MARKERS)
+
     async def _scrape_ask_response(self) -> str:
         """
         Scrape the Ask Studio response text, waiting for it to STABILIZE.
@@ -543,6 +636,14 @@ Give a brief category and a few mood/genre topics only.""",
                     text = (el.text or "").strip()
                 except Exception:
                     text = ""
+
+            # ZERO-STATE GUARD: the stream shows the suggestion list
+            # ("How can Ask Studio help me? / Summarize comments ...") BEFORE any
+            # real answer. Never treat that as content - keep polling for the
+            # real answer (so a zero-state is never returned/persisted).
+            if text and self._is_zero_state(text):
+                await self._human_delay(1.0, 0.2)
+                continue
 
             if text:
                 if text == response_text:
@@ -811,16 +912,23 @@ Give a brief category and a few mood/genre topics only.""",
     def _edit_surface_present(self) -> bool:
         """
         True if an owner/edit-surface element (the title field) is present on
-        the Studio video-edit page. Reuses the SAME title selector the edit
-        flow already relies on (ask_about_video title read).
+        the Studio video-edit page.
+
+        PRIMARY (live-grounded): the shadow-rooted title textarea
+        ytcp-social-suggestions-textbox#title-textarea via the deep finder (the
+        flat input#title-field silently fails on the live shadow DOM). FALLBACK:
+        the legacy flat input#title-field / h1.title so light-DOM pages and the
+        existing mock drivers still resolve.
         """
-        try:
-            el = self.driver.find_element(
-                "css selector", "input#title-field, h1.title"
-            )
-            return el is not None
-        except Exception:
-            return False
+        el = self._first_element(
+            [
+                self.TITLE_TEXTAREA_SELECTOR,
+                "input#title-field, h1.title",
+                "input#title-field",
+                "h1.title",
+            ]
+        )
+        return el is not None
 
     async def _verify_channel_context(self, video_id: str) -> bool:
         """
@@ -989,13 +1097,23 @@ Give a brief category and a few mood/genre topics only.""",
                     error="wrong_channel_context",
                 )
 
-            # Studio title is in the title input field.
+            # Studio title is in the (shadow-rooted) title textarea. Use the
+            # deep finder PRIMARY (ytcp-social-suggestions-textbox#title-textarea),
+            # flat input#title-field / h1.title as documented fallback.
             title = ""
-            try:
-                title_el = self.driver.find_element("css selector", "input#title-field, h1.title")
-                title = title_el.get_attribute("value") or title_el.text
-            except Exception:
-                pass
+            title_el = self._first_element(
+                [
+                    self.TITLE_TEXTAREA_SELECTOR,
+                    "input#title-field, h1.title",
+                    "input#title-field",
+                    "h1.title",
+                ]
+            )
+            if title_el is not None:
+                try:
+                    title = title_el.get_attribute("value") or title_el.text
+                except Exception:
+                    title = ""
 
             used_ask_studio = False
             ask_clicked = False
@@ -1003,10 +1121,13 @@ Give a brief category and a few mood/genre topics only.""",
             # ---- PRIMARY PATH: Ask Studio header button + dialog ----
             if self._open_ask_studio():
                 await self._human_delay(2.0, 0.3)
-                # Confirm the dialog appeared, then find the contenteditable prompt box.
-                dialog = self._first_element(self.ASK_STUDIO_SELECTORS["dialog"])
+                # CONFIRM-OPEN via CHILDREN, not the dialog host: live-observed the
+                # tp-yt-paper-dialog#dialog host computes visible:false while its
+                # prompt box + stream are visible. So "opened" == the prompt box
+                # (and/or stream) resolved, regardless of the dialog host's state.
                 prompt_box = self._first_element(self.ASK_STUDIO_SELECTORS["prompt_box"])
-                if dialog is not None and prompt_box is not None:
+                stream = self._first_element(self.ASK_STUDIO_SELECTORS["response_stream"])
+                if prompt_box is not None and stream is not None:
                     try:
                         # NEWLINE-SAFE human-cadence typing (no bare "\n" -> no
                         # implicit ENTER per line), then submit EXACTLY ONCE.

--- a/modules/ai_intelligence/video_indexer/tests/TestModLog.md
+++ b/modules/ai_intelligence/video_indexer/tests/TestModLog.md
@@ -1,6 +1,31 @@
 # Video Indexer Tests - ModLog
 **WSP Compliance**: WSP 34 (Test Documentation), WSP 22 (Change Log)
 
+## 2026-06-17 - STUDIO_ASK_SHADOW_DOM_SELECTORS_PHASE1
+
+### Test Run
+- **Command**: `python -m pytest modules/ai_intelligence/video_indexer/tests/ -q`
+- **Result**: 90 passed, 2 skipped, 8 FAILED (all pre-existing, unrelated:
+  4x `gemini_video_analyzer.py` `_pattern_memory` AttributeError; 4x live-browser
+  integration/stage tests needing a signed-in Chrome on 9222 - "Chrome not
+  running on port 9222" / "Expected 10 videos, got 0"). None touch
+  `studio_ask_indexer.py` or the new shadow-DOM files.
+- New `test_studio_ask_shadow_dom.py`: 10 passed. Prior #825/#827 suites
+  (`test_studio_ask_header.py` + `test_studio_ask_human_input.py` +
+  `test_studio_ask_channel_context.py`): 44 passed (unchanged behavior via the
+  flat fallback).
+
+### Notes
+- `test_studio_ask_shadow_dom.py`: NON-VACUOUS flat-fails/shadow-finds. A
+  `ShadowDriver` models a shadow tree where the OLD flat selector is ABSENT
+  (`find_element` raises) but the element exists under a shadow root (resolved by
+  `execute_script`). The flat path returns None (pre-fix flat-only code fails)
+  while the deep finder returns the real element. Covers title + Ask button +
+  full primary path + dialog-open-via-children + zero-state-not-scraped +
+  wrong/error page fail-closed (#827) + no-persist-on-failure + #825 single
+  submit preserved. NON-VACUITY also proven by disabling the deep finder (the
+  pre-slice flat-only model) -> both shadow-rooted elements resolve to None/False.
+
 ## 2026-06-16 - STUDIO_ASK_HUMAN_INPUT_BEHAVIOR_PHASE1
 
 ### Test Run

--- a/modules/ai_intelligence/video_indexer/tests/test_studio_ask_shadow_dom.py
+++ b/modules/ai_intelligence/video_indexer/tests/test_studio_ask_shadow_dom.py
@@ -1,0 +1,436 @@
+"""
+Tests for STUDIO_ASK_SHADOW_DOM_SELECTORS_PHASE1.
+
+ROOT CAUSE (live-confirmed): YouTube Studio's DOM is SHADOW-ROOTED. Flat
+Selenium find_element("css selector", ...) does NOT pierce shadow roots, so the
+indexer's selectors silently failed on the live page even when the element
+existed. #817 fixed selector NAMES but not the TRAVERSAL MODEL. The live-grounded
+truth: the flat input#title-field returns nothing but a shadow walk finds
+ytcp-social-suggestions-textbox#title-textarea; the old Ask-button selector
+aria-label="Ask Studio" does NOT exist -- the real entry is the creator-chat
+"spark" trigger (ytcp-creator-chat-trigger -> ytcp-icon-button).
+
+This suite proves the fix and is NON-VACUOUS: each "flat-fails / shadow-finds"
+test builds a mock DOM where the OLD flat selector is ABSENT (find_element
+raises) but the element exists under a shadow root (resolved via the deep walk
+modeled by execute_script). The flat path returns None (so the PRE-fix flat-only
+code would fail) while the deep finder returns the real element.
+
+All tests use a MOCK driver -- NO live YouTube, NO clipboard, NO network. The
+combined live happy path (submit -> stream -> scrape) is validated separately by
+0102's live re-test (HONEST LIVE GAP).
+
+WSP Compliance:
+    WSP 5/6: Test coverage + audit
+    WSP 72: Module independence (no cross-module fixtures)
+    WSP 84: REUSE of the foundups_selenium shadow-DOM deep finder
+"""
+
+import asyncio
+
+import pytest
+from selenium.webdriver.common.keys import Keys
+
+from modules.ai_intelligence.video_indexer.src import studio_ask_indexer as mod
+from modules.ai_intelligence.video_indexer.src.studio_ask_indexer import (
+    StudioAskIndexer,
+)
+
+UNDAODU_ID = "UCfHM9Fw9HD-NwiS0seD_oIA"
+STUDIO_VIDEO_EDIT = "https://studio.youtube.com/video/vidX/edit"
+STUDIO_CHANNEL_CTX = f"https://studio.youtube.com/channel/{UNDAODU_ID}/videos/upload"
+
+# Live-grounded selectors under test.
+TITLE_DEEP = "ytcp-social-suggestions-textbox#title-textarea"
+ASK_TRIGGER = "ytcp-creator-chat-trigger"
+ASK_ICON = "ytcp-icon-button"
+PROMPT_DEEP = (
+    'div.ytcpCreatorChatEntityAttachmentInlineFlowPromptBox'
+    '[contenteditable="true"][aria-label="Ask something"]'
+)
+STREAM_DEEP = "ytcp-engagement-panel-section-list-renderer#PAcreator_chat_streaming"
+
+
+# ---------------------------------------------------------------------------
+# Mock element + a SHADOW-ROOTED driver (deep walk vs flat find)
+# ---------------------------------------------------------------------------
+
+class ShadowElement:
+    """WebElement stand-in. parent is set to the driver (matching real Selenium
+    WebElement.parent) so the deep finder can run scoped chain steps."""
+
+    def __init__(self, text="", attributes=None, parent=None, deep_children=None):
+        self._text = text
+        self._attributes = attributes or {}
+        self.parent = parent
+        self.deep_children = deep_children or {}
+        self.clicked = False
+        self.cleared = False
+        self.sent_keys = []
+        # geometry so any human_* helper that reads it does not explode
+        self.location = {"x": 10, "y": 10}
+        self.size = {"width": 100, "height": 30}
+
+    @property
+    def text(self):
+        return self._text
+
+    @property
+    def tag_name(self):
+        return "div"
+
+    def get_attribute(self, name):
+        return self._attributes.get(name, "")
+
+    def click(self):
+        self.clicked = True
+
+    def clear(self):
+        self.cleared = True
+
+    def send_keys(self, *keys):
+        for k in keys:
+            self.sent_keys.append(k)
+
+
+class ShadowDriver:
+    """
+    Mock driver where elements live ONLY under shadow roots: the deep walk
+    (modeled here by ``execute_script`` consulting ``deep_map`` / element-scoped
+    ``deep_children``) resolves them, while the FLAT ``find_element`` consults a
+    SEPARATE ``flat_map`` and raises for anything absent (a non-piercing find).
+
+    This is what makes the tests non-vacuous: the flat-only PRE-fix path cannot
+    see shadow-rooted elements.
+    """
+
+    def __init__(self, deep_map=None, flat_map=None, body_text="", title="YouTube Studio"):
+        self.deep_map = deep_map or {}
+        self.flat_map = flat_map or {}
+        self._body_text = body_text
+        self._title = title
+        self.current_url = STUDIO_CHANNEL_CTX
+        self.visited = []
+
+    @property
+    def title(self):
+        return self._title
+
+    def get(self, url):
+        self.visited.append(url)
+        self.current_url = url
+
+    def execute_script(self, *args, **kwargs):
+        # The shadow-DOM deep finder calls execute_script(JS, root, css).
+        if len(args) >= 3 and isinstance(args[2], str):
+            root, css = args[1], args[2]
+            if root is not None:
+                children = getattr(root, "deep_children", None)
+                return (children or {}).get(css)
+            return self.deep_map.get(css)
+        # Any legacy JS (watch-page fallback etc.) returns nothing.
+        return None
+
+    def find_element(self, by, selector):
+        if selector == "body":
+            return ShadowElement(text=self._body_text)
+        el = self.flat_map.get(selector)
+        if el is None:
+            raise Exception(f"NoSuchElement: {selector}")
+        return el
+
+    def find_elements(self, by, selector):
+        el = self.flat_map.get(selector)
+        return [el] if el else []
+
+
+@pytest.fixture(autouse=True)
+def _fast_and_clean(monkeypatch):
+    """Instant delays, short timeout, fresh human singleton, char-typing."""
+    async def _no_delay(self, base=1.0, variance=0.3):
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(StudioAskIndexer, "_human_delay", _no_delay)
+    monkeypatch.setattr(StudioAskIndexer, "RESPONSE_TIMEOUT_SECONDS", 0.05)
+
+    import modules.infrastructure.foundups_selenium.src.human_behavior as hb
+    monkeypatch.setattr(hb, "_human_behavior_instance", None, raising=False)
+
+    def _fake_human_type(self, element, text):
+        element.click()
+        for ch in text:
+            element.send_keys(ch)
+
+    monkeypatch.setattr(hb.HumanBehavior, "human_type", _fake_human_type)
+
+
+def _shadow_dom(driver, response_text='{"topics": ["x"], "segments": []}'):
+    """Populate a ShadowDriver so the full Ask Studio path resolves via SHADOW
+    traversal ONLY (flat_map stays empty -> flat finds nothing)."""
+    title = ShadowElement(attributes={"value": "Studio Title"}, parent=driver)
+    icon = ShadowElement(attributes={"aria-label": "spark"}, parent=driver)
+    trigger = ShadowElement(parent=driver, deep_children={ASK_ICON: icon})
+    prompt = ShadowElement(attributes={"aria-label": "Ask something"}, parent=driver)
+    stream = ShadowElement(text=response_text, parent=driver)
+    driver.deep_map = {
+        TITLE_DEEP: title,
+        ASK_TRIGGER: trigger,
+        PROMPT_DEEP: prompt,
+        STREAM_DEEP: stream,
+    }
+    return {"title": title, "icon": icon, "trigger": trigger,
+            "prompt": prompt, "stream": stream}
+
+
+# ===========================================================================
+# FLAT-FAILS / SHADOW-FINDS (TITLE)
+# ===========================================================================
+
+def test_flat_fails_shadow_finds_title():
+    """
+    input#title-field is ABSENT (flat find raises) but the title field exists
+    under a shadow root -> the flat path returns None AND the deep finder returns
+    the element. NON-VACUOUS: pre-fix flat-only code returns None here.
+    """
+    driver = ShadowDriver()
+    nodes = _shadow_dom(driver)
+    indexer = StudioAskIndexer(driver=driver)
+
+    # PROOF (flat fails): the legacy flat selector is not resolvable.
+    flat_failed = False
+    try:
+        driver.find_element("css selector", "input#title-field")
+    except Exception:
+        flat_failed = True
+    assert flat_failed is True
+
+    # PROOF (shadow finds): the indexer's edit-surface check resolves via deep.
+    assert indexer._edit_surface_present() is True
+    # And it returns the REAL shadow title element (usable like a WebElement).
+    el = indexer._first_element([TITLE_DEEP, "input#title-field, h1.title"])
+    assert el is nodes["title"]
+    assert el.get_attribute("value") == "Studio Title"
+
+
+# ===========================================================================
+# FLAT-FAILS / SHADOW-FINDS (ASK BUTTON)
+# ===========================================================================
+
+def test_flat_fails_shadow_finds_ask_button():
+    """
+    aria-label="Ask Studio" is ABSENT (the live page has no such selector) but
+    the spark trigger chain ytcp-creator-chat-trigger -> ytcp-icon-button exists
+    under shadow -> deep finder resolves the icon-button; flat does not.
+    """
+    driver = ShadowDriver()
+    nodes = _shadow_dom(driver)
+    indexer = StudioAskIndexer(driver=driver)
+
+    # PROOF (flat fails): the old aria-label selector is not resolvable.
+    flat_failed = False
+    try:
+        driver.find_element("css selector", 'ytcp-icon-button[aria-label="Ask Studio"]')
+    except Exception:
+        flat_failed = True
+    assert flat_failed is True
+
+    # PROOF (shadow finds): _first_element on the header_button list (spark chain
+    # FIRST) resolves the icon-button deep within the trigger's subtree.
+    btn = indexer._first_element(StudioAskIndexer.ASK_STUDIO_SELECTORS["header_button"])
+    assert btn is nodes["icon"]
+
+    # And the open path clicks it.
+    assert indexer._open_ask_studio() is True
+    assert nodes["icon"].clicked is True
+
+
+# ===========================================================================
+# PINNED SELECTORS present + ordered shadow-first
+# ===========================================================================
+
+def test_pinned_grounded_selectors_present_and_primary():
+    sel = StudioAskIndexer.ASK_STUDIO_SELECTORS
+    # Title textarea (live-grounded).
+    assert StudioAskIndexer.TITLE_TEXTAREA_SELECTOR == TITLE_DEEP
+    # Ask button: the spark trigger chain is FIRST (primary), aria-label demoted.
+    assert sel["header_button"][0] == [ASK_TRIGGER, ASK_ICON]
+    assert 'ytcp-icon-button[aria-label="Ask Studio"]' in sel["header_button"]
+    assert sel["header_button"].index([ASK_TRIGGER, ASK_ICON]) < sel["header_button"].index(
+        'ytcp-icon-button[aria-label="Ask Studio"]'
+    )
+    # Prompt box: the live-grounded class selector is present + primary-ordered.
+    assert sel["prompt_box"][0] == PROMPT_DEEP
+    # Stream: the live-grounded host#id is present + ordered before legacy id.
+    assert STREAM_DEEP in sel["response_stream"]
+    assert sel["response_stream"].index(STREAM_DEEP) < sel["response_stream"].index(
+        "#PAcreator_chat_streaming"
+    )
+    # Dialog: tp-yt-paper-dialog#dialog is the live-grounded host.
+    assert "tp-yt-paper-dialog#dialog" in sel["dialog"]
+
+
+# ===========================================================================
+# FULL PRIMARY PATH over SHADOW-ONLY DOM (combined mock happy path)
+# ===========================================================================
+
+async def test_full_primary_path_resolves_via_shadow_only():
+    """
+    With ALL elements shadow-rooted (flat_map empty), the full ask path still
+    succeeds: title read, Ask opened, prompt typed, response scraped.
+    """
+    driver = ShadowDriver()
+    nodes = _shadow_dom(driver)
+    indexer = StudioAskIndexer(driver=driver)
+
+    result = await indexer.ask_about_video("vidX", channel_id=UNDAODU_ID)
+
+    assert result.success is True
+    assert result.title == "Studio Title"
+    assert "topics" in result.response_text
+    # The spark trigger was clicked (Ask opened) and the prompt box typed into.
+    assert nodes["icon"].clicked is True
+    assert nodes["prompt"].clicked is True
+
+
+# ===========================================================================
+# DIALOG OPEN VERIFIED VIA CHILDREN (not the host's visibility)
+# ===========================================================================
+
+async def test_dialog_open_confirmed_via_children_not_host():
+    """
+    Live caveat: the dialog HOST is not even present/visible, but the prompt box
+    + stream ARE -> the ask still proceeds (open confirmed via children).
+    """
+    driver = ShadowDriver()
+    nodes = _shadow_dom(driver)
+    # Remove the dialog host entirely; children (prompt + stream) remain.
+    driver.deep_map.pop("tp-yt-paper-dialog#dialog", None)
+    indexer = StudioAskIndexer(driver=driver)
+
+    result = await indexer.ask_about_video("vidX", channel_id=UNDAODU_ID)
+
+    assert result.success is True
+    assert nodes["prompt"].clicked is True
+
+
+# ===========================================================================
+# ZERO-STATE NOT SCRAPED AS ANSWER
+# ===========================================================================
+
+async def test_zero_state_not_scraped_as_answer():
+    """
+    The stream first shows the ZERO-STATE suggestion list, which must NOT be
+    returned as the answer. With ONLY zero-state text present -> the scrape times
+    out (no real answer) and the ask fails closed (nothing persisted).
+    """
+    driver = ShadowDriver()
+    _shadow_dom(driver, response_text="How can Ask Studio help me? Summarize comments")
+    indexer = StudioAskIndexer(driver=driver)
+
+    result = await indexer.ask_about_video("vidX", channel_id=UNDAODU_ID)
+
+    assert result.success is False
+    assert result.response_text == ""
+    assert "timeout" in (result.error or "").lower()
+
+
+def test_is_zero_state_classifier():
+    assert StudioAskIndexer._is_zero_state("How can Ask Studio help me?") is True
+    assert StudioAskIndexer._is_zero_state("Summarize comments for this video") is True
+    assert StudioAskIndexer._is_zero_state('{"topics": ["real", "answer"]}') is False
+    assert StudioAskIndexer._is_zero_state("") is False
+
+
+# ===========================================================================
+# WRONG / ERROR PAGE STILL FAILS CLOSED (#827 preserved)
+# ===========================================================================
+
+async def test_wrong_error_page_still_fails_closed_over_shadow():
+    """
+    An Oops/something-went-wrong page -> #827 wrong-context detection still
+    returns wrong_channel_context; no ask; even though the shadow DOM has the
+    elements. #827 fail-closed preserved EXACTLY.
+    """
+    driver = ShadowDriver(body_text="Oops, something went wrong", title="Oops")
+    _shadow_dom(driver)
+    indexer = StudioAskIndexer(driver=driver)
+
+    result = await indexer.ask_about_video("vidX", channel_id=UNDAODU_ID)
+
+    assert result.success is False
+    assert result.error == "wrong_channel_context"
+
+
+# ===========================================================================
+# NO PERSIST ON FAILURE (shadow path)
+# ===========================================================================
+
+async def test_no_persist_on_failure_shadow(monkeypatch):
+    """Any failure (here: zero-state -> timeout) -> save_index call_count == 0."""
+    saved = {"count": 0}
+
+    class SpyStore:
+        def __init__(self, *a, **k):
+            pass
+
+        def save_index(self, vid, data):
+            saved["count"] += 1
+            return "/tmp/should_not_happen.json"
+
+    monkeypatch.setattr(mod, "VideoIndexStore", SpyStore)
+
+    driver = ShadowDriver()
+    _shadow_dom(driver, response_text="How can I help you? Summarize comments")
+    indexer = StudioAskIndexer(driver=driver, max_videos_per_cycle=1)
+
+    async def _run(cid, max_videos=None, force_reindex=False):
+        result = await indexer.ask_about_video("vidX", channel_id=UNDAODU_ID)
+        store = mod.VideoIndexStore(base_path="/tmp/none")
+        if result.success:
+            store.save_index("vidX", None)
+        return {"indexed": 1 if result.success else 0}
+
+    summary = await _run(UNDAODU_ID)
+    assert summary["indexed"] == 0
+    assert saved["count"] == 0
+
+
+# ===========================================================================
+# #825 INPUT BEHAVIOR PRESERVED over the SHADOW path (single clean submit)
+# ===========================================================================
+
+class SubmitCountingBox(ShadowElement):
+    """A shadow prompt box modeling submit-on-Enter so we can prove #825's
+    single-submit behavior survives the shadow-finder rewrite."""
+
+    def __init__(self, parent=None):
+        super().__init__(attributes={"aria-label": "Ask something"}, parent=parent)
+        self.submits = 0
+
+    def send_keys(self, *keys):
+        shift_held = Keys.SHIFT in keys
+        for key in keys:
+            self.sent_keys.append(key)
+            if key == Keys.ENTER and not shift_held:
+                self.submits += 1
+            elif isinstance(key, str) and "\n" in key and len(key) > 1:
+                self.submits += key.count("\n")
+
+
+async def test_825_single_submit_preserved_over_shadow():
+    """
+    The multi-line prompt typed into a shadow-resolved contenteditable still
+    submits EXACTLY ONCE (no newline-spam). #825 behavior preserved.
+    """
+    driver = ShadowDriver()
+    nodes = _shadow_dom(driver, response_text='{"topics": ["x"]}')
+    box = SubmitCountingBox(parent=driver)
+    driver.deep_map[PROMPT_DEEP] = box  # prompt box is shadow-resolved
+    indexer = StudioAskIndexer(driver=driver)
+
+    assert StudioAskIndexer.ASK_PROMPT.count("\n") >= 7
+
+    result = await indexer.ask_about_video("vidX", channel_id=UNDAODU_ID)
+
+    assert box.submits == 1, f"expected exactly 1 submit, got {box.submits}"
+    assert result.success is True

--- a/modules/infrastructure/foundups_selenium/ModLog.md
+++ b/modules/infrastructure/foundups_selenium/ModLog.md
@@ -1,5 +1,31 @@
 # ModLog — FoundUps Selenium
 
+## V1.2.0 — Shadow-DOM deep finder (returns real WebElements)
+
+**Date**: 2026-06-17
+**WSP Compliance**: WSP 3 (infrastructure), WSP 11 (Interface), WSP 84 (Reuse)
+
+### Summary
+NEW `src/shadow_dom_finder.py`: `find_deep` / `shadow_query` / `first_deep`
+pierce nested shadow roots and return REAL Selenium WebElements (the matched DOM
+node is RETURNED by `execute_script`, so `human_type` + `.click()` keep working).
+Flat `find_element` does not pierce shadow roots; YouTube Studio's DOM is
+shadow-rooted, so flat selectors silently fail even when the element exists.
+
+WSP 84 REUSE: the recursive `findInShadow` traversal is the SAME algorithm
+already used by the YT comment-reply path
+(`modules/communication/video_comments/skillz/tars_like_heart_reply/src/reply_executor.py`
+`findInShadow`); the difference is the return contract (a node, not text/boolean).
+`shadow_query` resolves a CHAIN across shadow boundaries (e.g.
+`ytcp-creator-chat-trigger -> ytcp-icon-button`). Exported via `src/__init__.py`.
+Consumed by `ai_intelligence/video_indexer/studio_ask_indexer.py`
+(STUDIO_ASK_SHADOW_DOM_SELECTORS_PHASE1).
+
+### Tests
+- NEW `tests/test_shadow_dom_finder.py` (7 mock tests): flat-fails/shadow-finds,
+  flat fallback when no shadow match, cross-shadow chain resolution, first_deep
+  ordering. NO live browser.
+
 ## V1.1.0 — Chrome DevTools MCP Adapter
 
 **Date**: 2026-03-18

--- a/modules/infrastructure/foundups_selenium/src/__init__.py
+++ b/modules/infrastructure/foundups_selenium/src/__init__.py
@@ -23,6 +23,7 @@ from .telemetry_store import TelemetryStore
 from .foundup_typer import FoundupsTyper, get_typer
 from .human_behavior import HumanBehavior, get_human_behavior
 from .devtools_mcp_adapter import BrowserAdapter, get_browser_adapter, BrowserResult
+from .shadow_dom_finder import find_deep, shadow_query, first_deep
 
 __all__ = [
     "FoundUpsDriver",
@@ -36,6 +37,9 @@ __all__ = [
     "BrowserAdapter",
     "get_browser_adapter",
     "BrowserResult",
+    "find_deep",
+    "shadow_query",
+    "first_deep",
 ]
 
 __version__ = "1.1.0"

--- a/modules/infrastructure/foundups_selenium/src/shadow_dom_finder.py
+++ b/modules/infrastructure/foundups_selenium/src/shadow_dom_finder.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+"""
+Shadow-DOM deep finder (returns REAL Selenium WebElements).
+
+Flat Selenium ``find_element("css selector", ...)`` does NOT pierce shadow
+roots. YouTube Studio's DOM is shadow-rooted, so flat selectors silently fail
+on the live page even when the element exists (e.g. the flat ``input#title-field``
+returns nothing while a shadow walk finds ``ytcp-social-suggestions-textbox#title-textarea``).
+
+WSP 84 REUSE: the recursive ``findInShadow`` traversal here is the SAME proven
+algorithm already used by the YT comment-reply path
+(modules/communication/video_comments/skillz/tars_like_heart_reply/src/reply_executor.py
+findInShadow). The difference is purely the return contract: reply_executor
+self-clicks inside the JS and returns text/booleans, whereas this helper has
+``execute_script`` *return the matched DOM node*, so Selenium hands Python back a
+REAL WebElement. That keeps ``HumanBehavior.human_type`` + ``element.click()``
+working (the #825 input behavior + #827 fail-closed paths rely on real elements).
+
+Public surface:
+    find_deep(driver_or_root, css)        -> WebElement | None
+    shadow_query(driver, selector_chain)  -> WebElement | None
+    first_deep(driver, selectors)         -> WebElement | None
+
+``selector_chain`` is a list of CSS steps resolved across shadow boundaries
+(each step is find_deep'd within the prior match's subtree), e.g.
+``["ytcp-creator-chat-trigger", "ytcp-icon-button"]``.
+
+WSP References: WSP 3 (infrastructure), WSP 11 (public API), WSP 84 (reuse).
+"""
+
+import logging
+from typing import List, Optional, Sequence, Union
+
+logger = logging.getLogger(__name__)
+
+# Recursive shadow-DOM walk. Returns the FIRST element matching ``selector``
+# anywhere across nested shadow roots, starting from ``root`` (a DOM node or a
+# ShadowRoot). Mirrors reply_executor.findInShadow but RETURNS THE NODE so the
+# caller (Selenium execute_script) receives a real WebElement.
+#
+# arguments[0] = root node (or null -> document)
+# arguments[1] = css selector
+_FIND_DEEP_JS = r"""
+const selector = arguments[1];
+function findInShadow(root, sel) {
+    if (!root) return null;
+    // Direct (light-DOM) match within this root.
+    try {
+        const direct = root.querySelector(sel);
+        if (direct) return direct;
+    } catch (e) { /* invalid selector for this root -> keep walking */ }
+    // Descend into every shadow root reachable from this root.
+    let descendants;
+    try {
+        descendants = root.querySelectorAll('*');
+    } catch (e) {
+        return null;
+    }
+    for (const child of descendants) {
+        if (child.shadowRoot) {
+            const found = findInShadow(child.shadowRoot, sel);
+            if (found) return found;
+        }
+    }
+    return null;
+}
+const start = arguments[0] || document;
+return findInShadow(start, selector);
+"""
+
+
+def _resolve_driver(driver_or_root):
+    """
+    Return the object exposing ``execute_script`` (the WebDriver). ``find_deep``
+    accepts either a driver or a previously-found WebElement (whose subtree we
+    walk). A WebElement exposes ``parent`` (its driver) in real Selenium; we use
+    that to run the script, passing the element as the JS root.
+    """
+    if hasattr(driver_or_root, "execute_script"):
+        return driver_or_root, None
+    parent = getattr(driver_or_root, "parent", None)
+    if parent is not None and hasattr(parent, "execute_script"):
+        return parent, driver_or_root
+    return None, None
+
+
+def find_deep(driver_or_root, css: str):
+    """
+    Find the FIRST element matching ``css`` anywhere across shadow roots and
+    return a REAL WebElement (or None).
+
+    PRIMARY path: a single ``execute_script`` that recursively walks
+    element.shadowRoot + children and RETURNS the matched node (Selenium wraps
+    it as a WebElement). FALLBACK (cheap, documented): if the shadow walk yields
+    nothing or errors, try a flat ``find_element`` on the driver so light-DOM
+    pages (and existing mock drivers) still resolve. The flat path is a fallback
+    ONLY; the primary mechanism is shadow traversal.
+
+    Args:
+        driver_or_root: a Selenium WebDriver, OR a WebElement whose subtree
+            (including its shadow roots) should be searched.
+        css: a CSS selector string.
+
+    Returns:
+        WebElement | None
+    """
+    if not css:
+        return None
+    driver, root_el = _resolve_driver(driver_or_root)
+    if driver is None:
+        return None
+
+    # PRIMARY: shadow-piercing walk returning the real node.
+    try:
+        el = driver.execute_script(_FIND_DEEP_JS, root_el, css)
+        if el:
+            return el
+    except Exception as e:  # pragma: no cover - defensive (driver/JS hiccup)
+        logger.debug(f"[SHADOW-FIND] deep walk failed for {css!r}: {e}")
+
+    # FALLBACK: flat light-DOM find (only meaningful when searching from the
+    # driver root; a flat find from an element root is not generally available).
+    if root_el is None:
+        try:
+            flat = driver.find_element("css selector", css)
+            if flat:
+                return flat
+        except Exception:
+            pass
+    return None
+
+
+def shadow_query(driver, selector_chain: Union[str, Sequence[str]]):
+    """
+    Resolve a CHAIN of CSS selectors across shadow boundaries.
+
+    Each step is find_deep'd within the prior match's subtree, so e.g.
+    ``["ytcp-creator-chat-trigger", "ytcp-icon-button"]`` finds the chat trigger
+    deep, then the icon-button deep WITHIN that trigger's shadow subtree.
+
+    A plain string is treated as a single-step chain.
+
+    Returns the final WebElement (or None if any step fails).
+    """
+    if isinstance(selector_chain, str):
+        steps: List[str] = [selector_chain]
+    else:
+        steps = [s for s in selector_chain if s]
+    if not steps:
+        return None
+
+    current = driver
+    for step in steps:
+        match = find_deep(current, step)
+        if match is None:
+            return None
+        current = match
+    # ``current`` is the WebElement from the last step (driver only when there
+    # were zero steps, already guarded above).
+    return current
+
+
+def first_deep(driver, selectors: Sequence[Union[str, Sequence[str]]]):
+    """
+    Try a list of selectors/chains in order; return the first that resolves to a
+    real WebElement, else None. Each entry is either a CSS string (single step)
+    or a list/tuple (a cross-shadow chain for ``shadow_query``).
+    """
+    for entry in selectors or []:
+        try:
+            el = shadow_query(driver, entry)
+            if el is not None:
+                return el
+        except Exception:
+            continue
+    return None

--- a/modules/infrastructure/foundups_selenium/tests/test_shadow_dom_finder.py
+++ b/modules/infrastructure/foundups_selenium/tests/test_shadow_dom_finder.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the shadow-DOM deep finder (find_deep / shadow_query / first_deep).
+
+These are MOCK tests (NO live browser): a fake driver models a shadow tree where
+the element lives UNDER a shadow root, so flat ``find_element`` raises but the
+deep walk (modeled by ``execute_script``) returns it. They prove:
+  - find_deep returns a REAL element (the mock WebElement) via the shadow path
+    when flat find_element fails (flat-fails / shadow-finds);
+  - find_deep falls back to flat find_element when the shadow walk yields nothing
+    (so light-DOM pages + existing mock drivers keep resolving);
+  - shadow_query resolves a CHAIN across shadow boundaries;
+  - first_deep returns the first resolving entry.
+
+WSP 5/6 coverage; WSP 72 module independence (no cross-module fixtures).
+"""
+
+from modules.infrastructure.foundups_selenium.src.shadow_dom_finder import (
+    find_deep,
+    shadow_query,
+    first_deep,
+)
+
+
+class FakeElement:
+    """Minimal WebElement stand-in that records click/keystrokes (so we can
+    prove the returned object behaves like a real element for human_type/click).
+    """
+
+    def __init__(self, name="", parent=None):
+        self.name = name
+        self.parent = parent
+        self.clicked = False
+        self.sent_keys = []
+
+    def click(self):
+        self.clicked = True
+
+    def send_keys(self, value):
+        self.sent_keys.append(value)
+
+
+class ShadowDriver:
+    """
+    Fake driver that models a SHADOW tree as ``deep_map`` (selector -> element
+    reachable only via the shadow walk) and a separate FLAT map for
+    ``find_element`` (light-DOM only). ``execute_script`` running the deep-walk JS
+    consults ``deep_map``; the flat ``find_element`` consults ``flat_map`` and
+    raises for anything absent (mimicking NoSuchElement / a non-piercing find).
+    """
+
+    def __init__(self, deep_map=None, flat_map=None):
+        self.deep_map = deep_map or {}
+        self.flat_map = flat_map or {}
+
+    def execute_script(self, script, root, css):
+        # Only the shadow-walk script resolves deep elements. A chain step passes
+        # the prior element as ``root``; honor a sub-scope by checking the
+        # element-scoped map when root is an element, else the driver-level map.
+        if root is not None:
+            children = getattr(root, "deep_children", None)
+            return (children or {}).get(css)
+        return self.deep_map.get(css)
+
+    def find_element(self, by, selector):
+        el = self.flat_map.get(selector)
+        if el is None:
+            raise Exception(f"NoSuchElement: {selector}")
+        return el
+
+
+def test_find_deep_returns_element_when_flat_fails():
+    """Element exists only under a shadow root -> flat find_element raises, but
+    find_deep returns the real element via the shadow walk."""
+    title = FakeElement("title")
+    driver = ShadowDriver(
+        deep_map={"ytcp-social-suggestions-textbox#title-textarea": title},
+        flat_map={},  # flat finds NOTHING
+    )
+
+    # Sanity: the flat path genuinely fails.
+    flat_failed = False
+    try:
+        driver.find_element("css selector", "ytcp-social-suggestions-textbox#title-textarea")
+    except Exception:
+        flat_failed = True
+    assert flat_failed is True
+
+    found = find_deep(driver, "ytcp-social-suggestions-textbox#title-textarea")
+    assert found is title
+    # The returned object behaves like a real element (click/send_keys work).
+    found.click()
+    found.send_keys("x")
+    assert found.clicked is True
+    assert found.sent_keys == ["x"]
+
+
+def test_find_deep_falls_back_to_flat_when_no_shadow_match():
+    """If the shadow walk yields nothing, find_deep falls back to flat
+    find_element (so light-DOM pages and existing mocks still resolve)."""
+    flat_el = FakeElement("flat")
+    driver = ShadowDriver(deep_map={}, flat_map={"div#light": flat_el})
+
+    found = find_deep(driver, "div#light")
+    assert found is flat_el
+
+
+def test_find_deep_none_when_absent_everywhere():
+    driver = ShadowDriver(deep_map={}, flat_map={})
+    assert find_deep(driver, "div#missing") is None
+
+
+def test_shadow_query_resolves_chain_across_shadow_boundaries():
+    """A chain like creator-chat-trigger -> icon-button resolves the trigger
+    deep, then the icon-button deep WITHIN the trigger's subtree."""
+    icon_button = FakeElement("icon-button")
+    driver = ShadowDriver()
+    # Real Selenium WebElement.parent IS the driver; the finder uses that to run
+    # the scoped shadow walk within the prior match's subtree.
+    trigger = FakeElement("trigger", parent=driver)
+    # The icon button is reachable only WITHIN the trigger's subtree.
+    trigger.deep_children = {"ytcp-icon-button": icon_button}
+    driver.deep_map = {"ytcp-creator-chat-trigger": trigger}
+
+    found = shadow_query(driver, ["ytcp-creator-chat-trigger", "ytcp-icon-button"])
+    assert found is icon_button
+
+
+def test_shadow_query_chain_fails_when_step_missing():
+    driver = ShadowDriver()
+    trigger = FakeElement("trigger", parent=driver)
+    trigger.deep_children = {}  # icon-button NOT under the trigger
+    driver.deep_map = {"ytcp-creator-chat-trigger": trigger}
+
+    found = shadow_query(driver, ["ytcp-creator-chat-trigger", "ytcp-icon-button"])
+    assert found is None
+
+
+def test_first_deep_returns_first_resolving_entry():
+    second = FakeElement("second")
+    driver = ShadowDriver(deep_map={"b": second})
+    # 'a' (string) misses, ['b'] (chain) hits.
+    found = first_deep(driver, ["a", ["b"]])
+    assert found is second
+
+
+def test_first_deep_none_when_all_miss():
+    driver = ShadowDriver(deep_map={}, flat_map={})
+    assert first_deep(driver, ["a", ["b", "c"]]) is None


### PR DESCRIPTION
## STACKED ON #827 - DO NOT MERGE BEFORE #825/#827

**BASE = `fix/studio-ask-channel-context-phase1` (#827), NOT main.** This is stacked: #825 -> #827 -> this slice. Three-dot scope that matters is `e9ddd48280914a3f4a751278c24d04f7f7ca1744...HEAD` (shadow-DOM changes only). Do NOT merge any of #825/#827/this until the COMBINED live happy path passes.

## Root cause (live-confirmed)
YouTube Studio's DOM is SHADOW-ROOTED. Flat Selenium `find_element("css selector", ...)` does NOT pierce shadow roots, so `studio_ask_indexer`'s selectors silently failed on the live page even when the element existed. #817 fixed selector NAMES but not the TRAVERSAL model. Proven live: flat `input#title-field` returns nothing but a shadow walk finds `ytcp-social-suggestions-textbox#title-textarea`; the old Ask-button selector `aria-label="Ask Studio"` does NOT exist - the real entry is the creator-chat "spark" trigger.

## HoloIndex / direct-read discovery
Searched `modules/` + `holo_index/` for any deep/shadow finder (`shadowRoot`, `find_deep`, `shadow_query`, `pierce`). Found inline `findInShadow` JS in `reply_executor.py` / `comment_processor.py` (returns text/booleans, self-clicks in JS) and flat finders (`foundups_driver.smart_find_element` = flat XPath; `devtools_mcp_adapter` = flat CSS). NONE return a real WebElement across shadow boundaries.

## Reuse statement
WSP 84 REUSE: NEW `foundups_selenium/src/shadow_dom_finder.py` reuses the SAME recursive `findInShadow` traversal algorithm already proven in `reply_executor.findInShadow`; the only change is the RETURN CONTRACT - `execute_script` RETURNS the matched DOM node, so Selenium hands Python back a REAL WebElement (keeping `human_type` + `.click()` working). `shadow_query` resolves a CHAIN across shadow boundaries.

## flat-fails / shadow-finds proof
`test_studio_ask_shadow_dom.py` builds a `ShadowDriver` where the OLD flat selector is ABSENT (`find_element` raises) but the element exists under a shadow root (resolved via `execute_script`). The flat path returns None (pre-fix flat-only code FAILS) while the deep finder returns the real element - for BOTH the title (`ytcp-social-suggestions-textbox#title-textarea`) and the Ask button (spark chain `ytcp-creator-chat-trigger -> ytcp-icon-button`). NON-VACUITY also proven by disabling the deep finder (the pre-slice flat-only model): both shadow-rooted elements resolve to None/False.

## Pinned live-grounded selectors
- Title: `ytcp-social-suggestions-textbox#title-textarea`
- Ask button spark chain: `ytcp-creator-chat-trigger -> ytcp-icon-button` (aria-label="Ask Studio" demoted to fallback)
- Prompt: `div.ytcpCreatorChatEntityAttachmentInlineFlowPromptBox[contenteditable="true"][aria-label="Ask something"]`
- Dialog: `tp-yt-paper-dialog#dialog` (open confirmed via prompt box + stream CHILDREN, not the host - it computes visible:false)
- Stream: `ytcp-engagement-panel-section-list-renderer#PAcreator_chat_streaming` (zero-state suggestion list never scraped as answer)

## Honest live gap
Selectors are LIVE-GROUNDED (012 captured them; resolve via shadow find + Ask Studio opens). This PR is mock tests + grounded selectors only - the deep-finder code path + the COMBINED live happy path (submit -> stream -> scrape) are validated by 0102's live re-test AFTER this build.

## WSP_97 Truth Boundary Checklist
| # | Truth Boundary Checklist Item | Status | Evidence |
|---|---|---|---|
| 1 | HOLOINDEX_DISCOVERY_RECORDED | YES | Grep `shadowRoot/find_deep/shadow_query` across modules/+holo_index; reply_executor.py:404-412 findInShadow; foundups_driver.py:498 flat XPath; devtools_mcp_adapter flat CSS |
| 2 | DEEP_SHADOW_FINDER_ADDED_OR_REUSED | YES | NEW foundups_selenium/src/shadow_dom_finder.py find_deep/shadow_query/first_deep return real WebElements; reuses reply_executor findInShadow algorithm |
| 3 | FLAT_FAILS_SHADOW_FINDS_TITLE_TESTED | YES | test_studio_ask_shadow_dom.py::test_flat_fails_shadow_finds_title |
| 4 | FLAT_FAILS_SHADOW_FINDS_ASK_BUTTON_TESTED | YES | test_studio_ask_shadow_dom.py::test_flat_fails_shadow_finds_ask_button |
| 5 | PINNED_GROUNDED_SELECTORS_USED | YES | studio_ask_indexer.py ASK_STUDIO_SELECTORS + TITLE_TEXTAREA_SELECTOR; test_pinned_grounded_selectors_present_and_primary |
| 6 | DIALOG_OPEN_VERIFIED_VIA_CHILDREN | YES | ask_about_video confirm-open via prompt_box+stream; test_dialog_open_confirmed_via_children_not_host |
| 7 | ZERO_STATE_NOT_SCRAPED_AS_ANSWER | YES | _is_zero_state guard in _scrape_ask_response; test_zero_state_not_scraped_as_answer + test_is_zero_state_classifier |
| 8 | KEEPS_825_INPUT_BEHAVIOR | YES | test_825_single_submit_preserved_over_shadow + 14 prior #825 tests green |
| 9 | KEEPS_827_FAILCLOSED | YES | test_wrong_error_page_still_fails_closed_over_shadow + 23 prior #827 tests green |
| 10 | NO_PERSIST_ON_FAILURE | YES | test_no_persist_on_failure_shadow (save_index call_count == 0) |
| 11 | NO_UITARS_COORDINATE_PRIMARY_PATH | YES | No UI-TARS/coordinate code added; primary path is DOM/shadow traversal |
| 12 | ACTION_ID_AND_SCHEMA_PRESERVED | YES | #827 test_action_id_and_output_schema_preserved still green; no new public arg |
| 13 | TESTS_MOCK_ONLY_NO_LIVE_BROWSER | YES | ShadowDriver mock; no network/clipboard/live YouTube |
| 14 | LIVE_COMBINED_HAPPY_PATH_PENDING_DECLARED | YES | Honest live gap above + ModLog |
| 15 | STACKED_ON_827_DECLARED | YES | Banner above; base = fix/studio-ask-channel-context-phase1 |
| 16 | NO_SKIP_XFAIL | YES | No skip/xfail in new tests |
| 17 | ASCII_CLEAN | YES | 0 non-ASCII bytes in new files; 0 non-ASCII in added studio_ask_indexer.py lines |
| 18 | PRIMARY_CHECKOUT_UNTOUCHED | YES | All work in /o/tmp/wt-shadow via git -C; o/Foundups-Agent untouched |

Declared items: 18 - Rows: 18 - All YES

## pytest
- video_indexer module: 90 passed, 2 skipped, 8 failed (ALL pre-existing/unrelated: gemini_video_analyzer `_pattern_memory` AttributeError + invalid API key; live-browser stage/integration tests needing Chrome on 9222). None touch studio_ask_indexer.py or the new shadow-DOM files.
- foundups_selenium/test_shadow_dom_finder.py: 7 passed.
- Prior #825/#827 suites: 44 passed (unchanged behavior via the flat fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)