### PR TITLE
chore(video_indexer): gate live-browser tests behind --run-live so automated runs never drive the operator session

### DIFF
--- a/modules/ai_intelligence/video_indexer/ModLog.md
+++ b/modules/ai_intelligence/video_indexer/ModLog.md
@@ -2,6 +2,52 @@
 
 **WSP Compliance**: WSP 22 (ModLog Updates)
 
+## V0.21.1 - Gate live-browser tests behind --run-live (VIDEO_INDEXER_LIVE_TEST_GATING_PHASE1) (2026-06-17)
+
+### Why
+Automated/default pytest runs were attaching to the operator's REAL signed-in
+Chrome on port 9222 and navigating to a hardcoded video (8_DUQaqY6Tc), opening
+tabs in the operator's browser. These showed up as the "pre-existing failures"
+and drove the live operator session. Test runs must never touch the operator's
+browser by default.
+
+### Added
+- NEW `tests/conftest.py`:
+  - Registers the `live_browser` marker (`pytest_configure` /
+    `addinivalue_line`).
+  - Adds a `--run-live` command-line option (default `False`).
+  - `pytest_collection_modifyitems` auto-SKIPS every `live_browser` item unless
+    `--run-live` is passed (reason: "live-browser test: needs a signed-in Chrome
+    on 9222; pass --run-live to run").
+
+### Changed
+- Marked 4 real live-browser test classes with `@pytest.mark.live_browser`
+  (these attach to Chrome 9222 via `debuggerAddress` and call `driver.get(...)`,
+  or run the real VideoIndexer pipeline against the hardcoded video):
+  - `tests/test_integration_oldest_video.py::TestUnDaoDuOldestVideo`
+  - `tests/test_stage2_batch_navigation.py::TestStage2BatchNavigation`
+  - `tests/test_stage3_video_indexing.py::TestStage3VideoIndexing`
+  - `tests/test_stage3b_hybrid_indexing.py::TestStage3bHybridIndexing`
+- NOT gated (mock-only; patch/FakeDriver the driver, no live attach):
+  `tests/test_action_surface.py`, `tests/test_studio_ask_header.py`,
+  `tests/test_studio_ask_indexer_*.py`. Also NOT gated: `test_stage4_validation.py`
+  (reads index JSON from disk only) and `test_selenium_navigation.py` (no pytest
+  items; runnable only via `__main__`).
+
+### Result
+- Default `pytest tests/`: the 8 live-browser tests are now SKIPPED, not run
+  (84s -> 0.18s for the candidate files; no browser driven).
+- `pytest tests/ -m live_browser --run-live --collect-only` still collects all 8.
+- OUT OF SCOPE (unchanged here): the 4 remaining
+  `test_gemini_video_analyzer.py` failures - 2 are the pre-existing
+  `GeminiVideoAnalyzer._pattern_memory` bug in `src/gemini_video_analyzer.py`,
+  2 are Gemini-API-key failures. None drive the operator's Chrome session.
+
+### WSP Compliance
+- WSP 5 (gate, do not delete coverage), WSP 22 (ModLog), WSP 50 (verify
+  before edit), WSP 84 (standard pytest marker + skip pattern), WSP 97 (Truth
+  Boundary: tests/ + conftest only; no src/ or production code touched).
+
 ## V0.21.0 - Typed SKILLz/ACTION SURFACE + bounded Studio Ask single-video action (VIDEO_INDEXING_SKILLZ_ACTION_SURFACE_PHASE1) (2026-06-16)
 
 ### Why

--- a/modules/ai_intelligence/video_indexer/tests/conftest.py
+++ b/modules/ai_intelligence/video_indexer/tests/conftest.py
@@ -1,0 +1,59 @@
+"""Pytest configuration for video_indexer tests.
+
+Gates LIVE-BROWSER tests behind an explicit opt-in flag so that automated /
+default pytest runs never drive the operator's signed-in Chrome session on
+port 9222.
+
+Several tests in this package attach to a REAL signed-in Chrome via
+``debuggerAddress`` (127.0.0.1:9222) and call ``driver.get(...)`` to navigate
+to a hardcoded video (``8_DUQaqY6Tc``). On the operator's machine that opens
+tabs in their live browser. To prevent that, every test marked
+``@pytest.mark.live_browser`` is SKIPPED by default and only runs when the
+``--run-live`` command-line option is passed.
+
+WSP Compliance:
+    - WSP 5: Test Coverage (gate, do not delete coverage)
+    - WSP 50: Pre-Action Verification
+    - WSP 84: Code Reuse (standard pytest marker + skip pattern)
+"""
+
+import pytest
+
+
+def pytest_addoption(parser):
+    """Register the --run-live opt-in flag (default: live-browser tests skipped)."""
+    parser.addoption(
+        "--run-live",
+        action="store_true",
+        default=False,
+        help=(
+            "Run live-browser tests that attach to a signed-in Chrome on port "
+            "9222 and navigate the operator's session. Off by default."
+        ),
+    )
+
+
+def pytest_configure(config):
+    """Register the live_browser marker so it is not an unknown-mark warning."""
+    config.addinivalue_line(
+        "markers",
+        "live_browser: test attaches to a signed-in Chrome on port 9222 and "
+        "drives the operator's live browser session; skipped unless --run-live "
+        "is passed.",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Auto-skip every live_browser item unless --run-live was passed."""
+    if config.getoption("--run-live"):
+        return
+
+    skip_live = pytest.mark.skip(
+        reason=(
+            "live-browser test: needs a signed-in Chrome on 9222; pass "
+            "--run-live to run"
+        )
+    )
+    for item in items:
+        if "live_browser" in item.keywords:
+            item.add_marker(skip_live)

--- a/modules/ai_intelligence/video_indexer/tests/test_integration_oldest_video.py
+++ b/modules/ai_intelligence/video_indexer/tests/test_integration_oldest_video.py
@@ -306,9 +306,14 @@ def save_test_artifact(data: Dict[str, Any], filename: str) -> str:
 # Test Cases
 # =============================================================================
 
+@pytest.mark.live_browser
 @pytest.mark.integration
 class TestUnDaoDuOldestVideo:
-    """Integration tests for indexing UnDaoDu's oldest video."""
+    """Integration tests for indexing UnDaoDu's oldest video.
+
+    LIVE BROWSER: attaches to a signed-in Chrome on port 9222 and navigates
+    to a hardcoded video. Skipped by default; pass --run-live to run.
+    """
 
     def test_list_videos_via_studio(self):
         """Test: List videos via YouTube Studio (same as commenting system)."""

--- a/modules/ai_intelligence/video_indexer/tests/test_stage2_batch_navigation.py
+++ b/modules/ai_intelligence/video_indexer/tests/test_stage2_batch_navigation.py
@@ -255,9 +255,14 @@ def save_batch_artifact(videos: List[Dict], channel: str) -> str:
 # Test Cases
 # =============================================================================
 
+@pytest.mark.live_browser
 @pytest.mark.integration
 class TestStage2BatchNavigation:
-    """Stage 2: Batch video navigation tests."""
+    """Stage 2: Batch video navigation tests.
+
+    LIVE BROWSER: attaches to a signed-in Chrome on port 9222 and navigates
+    YouTube Studio. Skipped by default; pass --run-live to run.
+    """
 
     def test_find_10_videos_undaodu(self):
         """Test: Find 10 oldest videos from UnDaoDu."""

--- a/modules/ai_intelligence/video_indexer/tests/test_stage3_video_indexing.py
+++ b/modules/ai_intelligence/video_indexer/tests/test_stage3_video_indexing.py
@@ -212,9 +212,15 @@ def save_indexing_artifact(result: Dict, video_id: str) -> str:
 # Test Cases
 # =============================================================================
 
+@pytest.mark.live_browser
 @pytest.mark.integration
 class TestStage3VideoIndexing:
-    """Stage 3: Single video indexing tests."""
+    """Stage 3: Single video indexing tests.
+
+    LIVE BROWSER: runs the real VideoIndexer pipeline against a hardcoded
+    video, which drives the signed-in Chrome session. Skipped by default;
+    pass --run-live to run.
+    """
 
     def test_index_short_video_audio_only(self):
         """Test: Index short video with audio layer only."""

--- a/modules/ai_intelligence/video_indexer/tests/test_stage3b_hybrid_indexing.py
+++ b/modules/ai_intelligence/video_indexer/tests/test_stage3b_hybrid_indexing.py
@@ -516,9 +516,14 @@ def run_hybrid_test(video_id: str = None) -> Dict[str, Any]:
 # Test Cases
 # =============================================================================
 
+@pytest.mark.live_browser
 @pytest.mark.integration
 class TestStage3bHybridIndexing:
-    """Stage 3b: Hybrid video indexing tests."""
+    """Stage 3b: Hybrid video indexing tests.
+
+    LIVE BROWSER: attaches to a signed-in Chrome on port 9222 and navigates
+    YouTube Studio / a watch page. Skipped by default; pass --run-live to run.
+    """
 
     def test_approach_a_studio_download(self):
         """Test: Download video via YouTube Studio."""


### PR DESCRIPTION
## Problem

Several `modules/ai_intelligence/video_indexer/tests/` tests attach to a **REAL signed-in Chrome on port 9222** (`debuggerAddress=127.0.0.1:9222`) and call `driver.get(...)` to navigate to a **hardcoded video** (`8_DUQaqY6Tc`, "Vision Goal - UnDaoDu on eSingularity"). On the operator's machine, every default `pytest` run opens tabs in their live browser and drives the operator's session. These are the "pre-existing failures" seen during automated runs.

## Fix

New `tests/conftest.py` that:
- Registers a `live_browser` marker (`pytest_configure` / `addinivalue_line`).
- Adds a `--run-live` command-line option (default `False`).
- `pytest_collection_modifyitems` auto-**SKIPS** every `live_browser`-marked item unless `--run-live` is passed. Skip reason: `live-browser test: needs a signed-in Chrome on 9222; pass --run-live to run`.

4 real live-browser test classes are marked `@pytest.mark.live_browser`. No `src/`, scheduler, studio_ask stack, dependency_launcher, or other production code was touched - only `tests/` + the module `ModLog`.

## Gated (live-browser) - WHY: attach to 9222 / navigate to `8_DUQaqY6Tc`

| Test (class) | Location | Live signal |
|---|---|---|
| `TestUnDaoDuOldestVideo` | `tests/test_integration_oldest_video.py:310` | `debuggerAddress` 9222 (L146/150/271/275), `driver.get(...)` (L159/281) |
| `TestStage2BatchNavigation` | `tests/test_stage2_batch_navigation.py:259` | `debuggerAddress` 9222 (L133/137), `dom.driver.get(...)` (L145) |
| `TestStage3VideoIndexing` | `tests/test_stage3_video_indexing.py:216` | real `VideoIndexer.index_video(video_id="8_DUQaqY6Tc")` pipeline (L143) - drives the live session |
| `TestStage3bHybridIndexing` | `tests/test_stage3b_hybrid_indexing.py:520` | `debuggerAddress` 9222 (L148/318), `driver.get(...)` (L155/324) |

(8 test items total.)

## NOT gated - WHY (still run normally)

- `tests/test_action_surface.py` - **mock-only**: docstring says "NO live browser"; patches `_connect_attached_driver` with `MagicMock()`/`None` (L130/153/176/188/208). 21 tests, all pass.
- `tests/test_studio_ask_header.py` - **mock-only**: uses a `FakeDriver` class (L60) with a mocked DOM selector map; no live attach. 12 tests, all pass.
- `tests/test_studio_ask_indexer_persistence.py`, `tests/test_studio_ask_indexer_signals.py` - disk/signal mock tests.
- `tests/test_stage4_validation.py::TestStage4Validation` - reads index JSON from disk only (`load_index`), no browser/`driver.get`; self-skips when no index file exists.
- `tests/test_selenium_navigation.py` - has live-browser code but **no pytest test_ function/class** (runnable only via `__main__`); pytest collects 0 items, nothing to mark.

## Before / After (default `pytest tests/ -q`)

```
Before: 4 failed, 52 passed,  2 skipped
After:  4 failed, 44 passed, 10 skipped
```

The 8 live-browser tests moved **passed -> skipped** (candidate files: 84s -> 0.18s, no browser driven). The **4 remaining failures are OUT OF SCOPE** and are NOT live-browser:
- 2x `test_gemini_video_analyzer.py::TestGeminiResponseParsing` - pre-existing `GeminiVideoAnalyzer._pattern_memory` bug in `src/gemini_video_analyzer.py:475` (per task: do NOT fix here).
- 2x `test_gemini_video_analyzer.py::TestGeminiVideoAnalyzerIntegration` - Gemini API-key failures (call the Gemini API, not Chrome 9222).

## --run-live still collects them

```
$ pytest modules/ai_intelligence/video_indexer/tests/ -m live_browser --run-live --collect-only -q
# -> all 8 live-browser tests collected (not actually run live in CI)
```

Default-run confirmation: the 8 live-browser tests SKIP, so the operator's signed-in Chrome session is **no longer driven by the default run**.

## WSP

WSP 5 (gate, do not delete coverage), WSP 22 (ModLog), WSP 50, WSP 84 (standard pytest marker + skip pattern), WSP 97 (Truth Boundary: `tests/` + conftest only).

Worker-Lane: GATE-AUTHOR
Slice: VIDEO_INDEXER_LIVE_TEST_GATING_PHASE1

Status: VERIFIED_READY - leave open, do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)