### PR TITLE
fix(video_indexer): pin ytcp-icon-button#action-button as primary Ask Studio send selector (Phase 1)

### DIFF
--- a/modules/ai_intelligence/video_indexer/ModLog.md
+++ b/modules/ai_intelligence/video_indexer/ModLog.md
@@ -2,6 +2,34 @@
 
 **WSP Compliance**: WSP 22 (ModLog Updates)
 
+## V0.28.0 - Ask Studio: pin ytcp-icon-button#action-button as PRIMARY send selector (STUDIO_ASK_SEND_ACTION_BUTTON_SELECTOR_PHASE1) (2026-06-18)
+
+### Why
+012 live-grounded the real Ask Studio prompt-box send control as
+`ytcp-icon-button#action-button` (ytcp-ask-studio-input-view-model ->
+...ActionButton). The `send_button` list led with the aria-label variants only;
+the action button is the more reliable primary click target. This selector was
+validated during the live Studio Ask proof but left uncommitted; this slice lands
+it with coverage.
+
+### Changed
+- `ASK_STUDIO_SELECTORS["send_button"]`: prepend `"ytcp-icon-button#action-button"`
+  as index 0 (primary). The aria-label variants and the Enter fallback
+  (`_submit_prompt`) are unchanged and remain as fallbacks. Submit path, action ID,
+  and output schema untouched.
+
+### Tests
+- `test_action_button_pinned_first_in_send_button_list`: pins the selector + its
+  index-0 ordering (guard against silent drop/reorder).
+- `test_action_button_preferred_over_aria_label`: with BOTH the action button and
+  an aria-label Send button present, submit clicks the action button (primary) and
+  never the aria-label one. Non-vacuity proven by removal-injection (both fail when
+  the selector is removed).
+
+### WSP Compliance
+- WSP 22 (ModLog), WSP 50 (verify), WSP 84 (extend existing selector list, no new
+  mechanism), WSP 97 (Truth Boundary: selector + tests only).
+
 ## V0.21.1 - Gate live-browser tests behind --run-live (VIDEO_INDEXER_LIVE_TEST_GATING_PHASE1) (2026-06-17)
 
 ### Why

--- a/modules/ai_intelligence/video_indexer/src/studio_ask_indexer.py
+++ b/modules/ai_intelligence/video_indexer/src/studio_ask_indexer.py
@@ -225,6 +225,10 @@ class StudioAskIndexer:
         # Send / submit button inside the dialog. PREFERRED submission path
         # (mirror reply_executor's button-click submit, NEVER Enter-spam).
         "send_button": [
+            # 012 live-grounded: the Ask Studio prompt-box send/action button
+            # (ytcp-ask-studio-input-view-model -> ...ActionButton -> ytcp-icon-button#action-button).
+            # Tried FIRST; the aria-label variants + the Enter fallback (_submit_prompt) remain.
+            "ytcp-icon-button#action-button",
             'ytcp-icon-button[aria-label="Send"]',
             'ytcp-icon-button[aria-label*="Send"]',
             'button[aria-label="Send"]',

--- a/modules/ai_intelligence/video_indexer/tests/test_studio_ask_human_input.py
+++ b/modules/ai_intelligence/video_indexer/tests/test_studio_ask_human_input.py
@@ -266,6 +266,39 @@ async def test_submit_prefers_send_button_single_click(monkeypatch):
     assert result.success is True
 
 
+def test_action_button_pinned_first_in_send_button_list():
+    """012 live-grounded: ytcp-icon-button#action-button is pinned as the PRIMARY
+    send selector (index 0), ahead of the aria-label variants which remain as
+    fallbacks. Regression guard so it can't be silently dropped or reordered.
+    """
+    sels = StudioAskIndexer.ASK_STUDIO_SELECTORS["send_button"]
+    assert "ytcp-icon-button#action-button" in sels
+    assert sels[0] == "ytcp-icon-button#action-button"
+    assert 'ytcp-icon-button[aria-label="Send"]' in sels  # fallback retained
+
+
+async def test_action_button_preferred_over_aria_label(monkeypatch):
+    """With BOTH the action button and an aria-label Send button present, submit
+    clicks the action button (primary) and never the aria-label one -- proving the
+    pinned ordering is actually exercised by the submit path, not just declared.
+    """
+    _patch_human_for_box(monkeypatch)
+    box = ContentEditableBox()
+    action_btn = _Simple(attributes={"id": "action-button"})
+    aria_btn = _Simple(attributes={"aria-label": "Send"})
+    css = _make_css_map(box, response_text="{\"topics\": [\"x\"]}", send_button=aria_btn)
+    css["ytcp-icon-button#action-button"] = action_btn
+    driver = SoftNewlineDriver(css_map=css)
+    indexer = StudioAskIndexer(driver=driver)
+
+    result = await indexer.ask_about_video("vidX", channel_id=UNDAODU_ID)
+
+    assert action_btn.clicked is True   # primary clicked
+    assert aria_btn.clicked is False    # fallback never reached
+    assert box.submits == 0             # no bare-Enter submit
+    assert result.success is True
+
+
 # ---------------------------------------------------------------------------
 # HUMAN_TYPE reuse
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to the landed Studio Ask stack (#825/#827/#833/#836). Lands the 012-live-grounded primary send selector that was validated during the live proof but left uncommitted.

## Change
- `ASK_STUDIO_SELECTORS["send_button"]`: prepend `ytcp-icon-button#action-button` as index-0 primary (ytcp-ask-studio-input-view-model -> ...ActionButton). aria-label variants + Enter fallback (`_submit_prompt`) unchanged and retained.
- **Submit path, action ID, output schema: untouched.**

## Tests (89 studio-ask mock green)
- `test_action_button_pinned_first_in_send_button_list` - pins selector + index-0 ordering.
- `test_action_button_preferred_over_aria_label` - with both present, submit clicks the action button, never the aria-label fallback.
- **Non-vacuity:** both FAIL when the selector line is removed (verified by inject+revert).

## Scope (WSP 97)
selector + tests + ModLog only; reuses existing `send_button`/`_first_element`/`_submit_prompt` mechanism (WSP 84). No live browser in tests.

Auth-runtime (`studio_ask_indexer.py`): VERIFIED_READY, awaiting sovereign token to merge.