### PR TITLE
fix(livechat): channel-scope the OODA activity signal (RC3 observability)

### DIFF
--- a/modules/communication/livechat/ModLog.md
+++ b/modules/communication/livechat/ModLog.md
@@ -10,6 +10,45 @@ This log tracks changes specific to the **livechat** module in the **communicati
 
 ---
 
+## 2026-06-18 - RC3: channel-scope the OODA activity signal (YOUTUBE_COMMENT_FLOW_OODA_OBSERVABILITY_PHASE1)
+
+**By:** 0102 (CTO)
+**WSP References:** WSP 22 (ModLog), WSP 50 (verify), WSP 84 (reuse page-state probe), WSP 97 (Truth Signaling)
+
+### Why
+The heartbeat's OODA `current_activity` was derived from the **Chrome page-type
+alone** (`auto_moderator_dae.py:2386-2404`). Chrome 9222 = Move2Japan/UnDaoDu,
+Edge 9223 = FoundUps/antifaFM, so a (possibly stale) Chrome comments tab made the
+OODA log REPORT `Current=COMMENT_ENGAGEMENT ... Processing comments for FoundUps`
+while the Edge-bound channels were untouched. During a live stream the executor
+loop is cancelled, so a Chrome comments tab is a stale tab - this mislabel made a
+live-stream window look like a comment-processing outage (the trigger for the
+comment-flow audit). Forensic confirmed the executor was cancelled, not stalled.
+
+### Changed (observability only - no behavior change to should_pivot or the router)
+- NEW `src/ooda_activity_signal.py`: pure, unit-testable `derive_activity_signal(page_state,
+  live_chat_active) -> ActivitySignal`. Reports per-browser activity (chrome 9222 /
+  edge 9223), `chrome_stale_during_live` / `edge_stale_during_live`, and
+  `is_misleading_comment_signal`. The rollup `current_activity` preserves the exact
+  2026-02-21 precedence (Chrome-comments -> live -> default) so `should_pivot` is
+  byte-for-byte unchanged.
+- `auto_moderator_dae.py` OODA block: uses the helper; the OODA log now leads with
+  the channel-scoped truth and emits a `[OODA] RC3` WARNING when the rollup says
+  COMMENT_ENGAGEMENT but it is only a stale tab during live. `signal_comments_complete`
+  (router-state side effect) preserved exactly. Breadcrumb metadata enriched with the
+  channel-scoped fields (prerequisite for later reliable pivot detection).
+
+### Tests
+- NEW `tests/test_ooda_activity_signal.py` (15 tests): rollup precedence unchanged
+  (parametrized), RC3 stale-tab-during-live flagged + Edge not mislabelled, per-browser
+  channel-scoping (non-vacuous: independent activities), malformed/None page_state safe.
+  Non-vacuity proven by inject/revert (disabling the stale flag fails the RC3 test).
+
+### Scope (WSP 97)
+Observability/diagnostics only. No change to the executor loop, the supervisor
+cancellation, the break gate, or `should_pivot`/router behavior. The selective-cancellation
+"always-flow" fix is a SEPARATE future slice.
+
 ## 2026-05-01 - OC21: WSP 97 Auth Truth Signaling Fix
 
 **By:** 0102 (Worker AW3)

--- a/modules/communication/livechat/src/auto_moderator_dae.py
+++ b/modules/communication/livechat/src/auto_moderator_dae.py
@@ -2381,38 +2381,45 @@ class AutoModeratorDAE:
                             # ORIENT: Query for next activity decision
                             decision = activity_router.get_next_activity()
 
-                            # DECIDE: Determine current activity based on ACTUAL page state (not just _live_chat_active)
-                            # FIX (2026-02-21): Use Chrome page type to determine actual activity
-                            chrome_page = page_state.get("chrome", {}).get("page_type") if page_state else None
+                            # DECIDE: channel-scope the activity signal across BOTH browser
+                            # groups (RC3) instead of the Chrome page alone. Chrome 9222 =
+                            # M2J/UnDaoDu, Edge 9223 = FoundUps/antifaFM; a Chrome comments tab
+                            # says nothing about whether the Edge-bound channels are processed.
+                            # The rollup current_activity precedence is UNCHANGED (FIX 2026-02-21:
+                            # Chrome page wins -> live -> default) so should_pivot is identical.
+                            from .ooda_activity_signal import derive_activity_signal
+                            activity_signal = derive_activity_signal(page_state, self._live_chat_active)
+                            current_activity = activity_signal.current_activity
 
-                            # If Chrome is on comments page, that's what we're doing (regardless of _live_chat_active)
-                            if chrome_page == "youtube_studio_comments":
-                                current_activity = ActivityType.COMMENT_ENGAGEMENT
-
-                                # FIX: When comments are cleared AND we're on comments page, signal completion
-                                if edge_comments_cleared:
-                                    # Get current channel from router
-                                    router_channel_id = activity_router.current_channel_id
-                                    if router_channel_id:
-                                        logger.info(f"[OODA-PIVOT] Comments cleared for {router_channel_id} - signaling completion")
-                                        activity_router.signal_comments_complete(router_channel_id)
-                                        # After signaling, get updated decision
-                                        decision = activity_router.get_next_activity()
-                            elif self._live_chat_active:
-                                current_activity = ActivityType.LIVE_CHAT
-                            else:
-                                current_activity = ActivityType.COMMENT_ENGAGEMENT
+                            # PRESERVED: when Chrome is on comments AND edge comments cleared,
+                            # signal completion to the router (router-state side effect, unchanged).
+                            if activity_signal.chrome_on_comments and edge_comments_cleared:
+                                router_channel_id = activity_router.current_channel_id
+                                if router_channel_id:
+                                    logger.info(f"[OODA-PIVOT] Comments cleared for {router_channel_id} - signaling completion")
+                                    activity_router.signal_comments_complete(router_channel_id)
+                                    # After signaling, get updated decision
+                                    decision = activity_router.get_next_activity()
 
                             should_pivot = decision.next_activity != current_activity and decision.next_activity != ActivityType.IDLE
 
-                            # Log OODA decision
+                            # Log OODA decision -- lead with the channel-scoped truth so a stale
+                            # Chrome comments tab during live cannot read as a real outage.
                             logger.info(
                                 f"[OODA] Pulse #{heartbeat_count}: "
                                 f"Current={current_activity.name}, "
+                                f"{activity_signal.log_summary()}, "
                                 f"Suggested={decision.next_activity.name}, "
                                 f"Pivot={'YES' if should_pivot else 'NO'}, "
                                 f"Reason={decision.reason[:50] if decision.reason else 'none'}"
                             )
+                            if activity_signal.is_misleading_comment_signal:
+                                logger.warning(
+                                    "[OODA] RC3: Current=COMMENT_ENGAGEMENT is a STALE comments tab during live "
+                                    f"(chrome_stale={activity_signal.chrome_stale_during_live}, "
+                                    f"edge_stale={activity_signal.edge_stale_during_live}); the Edge-bound "
+                                    "channels (FoundUps/antifaFM) are NOT being processed this pulse."
+                                )
 
                             # ACT: Signal pivot opportunity (actual pivot handled by higher orchestration)
                             if should_pivot and decision.next_activity != ActivityType.IDLE:
@@ -2438,6 +2445,14 @@ class AutoModeratorDAE:
                                                 # Layer 5: Page state observation
                                                 "page_state_chrome": page_state.get("chrome", {}).get("page_type") if page_state else None,
                                                 "page_state_edge": page_state.get("edge", {}).get("page_type") if page_state else None,
+                                                # RC3: channel-scoped activity signal (Chrome 9222 = M2J/UnDaoDu,
+                                                # Edge 9223 = FoundUps/antifaFM) so a stale Chrome tab can't read
+                                                # as Edge-channel comment processing.
+                                                "chrome_activity": activity_signal.chrome_activity.name if activity_signal.chrome_activity else None,
+                                                "edge_activity": activity_signal.edge_activity.name if activity_signal.edge_activity else None,
+                                                "chrome_stale_during_live": activity_signal.chrome_stale_during_live,
+                                                "edge_stale_during_live": activity_signal.edge_stale_during_live,
+                                                "is_misleading_comment_signal": activity_signal.is_misleading_comment_signal,
                                             }
                                         )
                                     except Exception as bc_e:

--- a/modules/communication/livechat/src/ooda_activity_signal.py
+++ b/modules/communication/livechat/src/ooda_activity_signal.py
@@ -1,0 +1,121 @@
+"""
+OODA activity-signal derivation (RC3 observability).
+
+Channel-scopes the heartbeat's OODA "current activity" signal across BOTH
+browser groups instead of deriving it from the Chrome page-type alone.
+
+Browser <-> channel-group binding (fixed): Chrome 9222 = Move2Japan + UnDaoDu;
+Edge 9223 = FoundUps + antifaFM. A Chrome page-type therefore says NOTHING about
+whether the Edge-bound channels are being processed. Deriving COMMENT_ENGAGEMENT
+from the Chrome page alone made the OODA log REPORT comments-for-FoundUps while
+only a (possibly stale) Chrome tab sat on the Studio comments page -- the RC3
+mislabel that made a live-stream window look like a comment-processing outage,
+when in reality the executor was cancelled and nothing was being processed.
+
+This module is PURE (no driver, no router, no I/O) so it is unit-testable
+without a live browser. It does NOT change the rollup `current_activity`
+precedence (so the downstream `should_pivot` comparison is byte-for-byte
+unchanged); it only adds the channel-scoped truth the OODA log/breadcrumb emit.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from modules.infrastructure.activity_control.src.activity_control import ActivityType
+
+# page_type values produced by the heartbeat's page-state probe
+# (auto_moderator_dae.py ~2318-2361).
+COMMENTS_PAGE = "youtube_studio_comments"
+LIVE_PAGE = "youtube_live"
+
+
+def _page_type(page_state: Optional[dict], browser: str) -> Optional[str]:
+    """Safely read page_state[browser]['page_type'] without raising."""
+    if not page_state:
+        return None
+    entry = page_state.get(browser) or {}
+    if not isinstance(entry, dict):
+        return None
+    return entry.get("page_type")
+
+
+def _activity_for_page(page_type: Optional[str]) -> Optional[ActivityType]:
+    """Map a single browser's page_type to the activity it implies, or None."""
+    if page_type == COMMENTS_PAGE:
+        return ActivityType.COMMENT_ENGAGEMENT
+    if page_type == LIVE_PAGE:
+        return ActivityType.LIVE_CHAT
+    return None  # not a tracked-activity page
+
+
+@dataclass(frozen=True)
+class ActivitySignal:
+    """Channel-scoped OODA activity signal across both browser groups."""
+
+    current_activity: ActivityType            # rollup (precedence UNCHANGED; drives should_pivot)
+    chrome_activity: Optional[ActivityType]   # Chrome 9222 = Move2Japan / UnDaoDu
+    edge_activity: Optional[ActivityType]     # Edge 9223 = FoundUps / antifaFM
+    chrome_page_type: Optional[str]
+    edge_page_type: Optional[str]
+    chrome_on_comments: bool
+    edge_on_comments: bool
+    chrome_stale_during_live: bool            # live AND Chrome still on a comments page (likely stale tab)
+    edge_stale_during_live: bool
+
+    @property
+    def is_misleading_comment_signal(self) -> bool:
+        """True when the rollup says COMMENT_ENGAGEMENT but it is only a
+        (likely stale) browser tab during a live stream -- the RC3 condition an
+        observer must NOT read as 'comments are being processed'."""
+        return self.current_activity == ActivityType.COMMENT_ENGAGEMENT and (
+            self.chrome_stale_during_live or self.edge_stale_during_live
+        )
+
+    def log_summary(self) -> str:
+        """Human-readable, channel-scoped one-liner for the OODA log."""
+        def fmt(a: Optional[ActivityType]) -> str:
+            return a.name if a is not None else "none"
+
+        summary = (
+            f"chrome(9222 M2J/UnDaoDu)={fmt(self.chrome_activity)}, "
+            f"edge(9223 FoundUps/antifaFM)={fmt(self.edge_activity)}"
+        )
+        if self.chrome_stale_during_live or self.edge_stale_during_live:
+            summary += " [STALE-TAB-DURING-LIVE: a comments page is open but NOT active processing]"
+        return summary
+
+
+def derive_activity_signal(page_state: Optional[dict], live_chat_active: bool) -> ActivitySignal:
+    """
+    Derive the channel-scoped OODA activity signal from BOTH browsers' page state.
+
+    The rollup `current_activity` preserves the historical precedence EXACTLY
+    (Chrome-comments wins -> else live -> else COMMENT_ENGAGEMENT) so the
+    downstream should_pivot comparison is unchanged. The per-browser activities
+    and the stale-during-live flags are the new, honest, channel-scoped signal.
+    """
+    chrome_pt = _page_type(page_state, "chrome")
+    edge_pt = _page_type(page_state, "edge")
+    chrome_on_comments = chrome_pt == COMMENTS_PAGE
+    edge_on_comments = edge_pt == COMMENTS_PAGE
+
+    # Rollup precedence preserved byte-for-byte (auto_moderator_dae.py:2388-2404).
+    if chrome_on_comments:
+        current = ActivityType.COMMENT_ENGAGEMENT
+    elif live_chat_active:
+        current = ActivityType.LIVE_CHAT
+    else:
+        current = ActivityType.COMMENT_ENGAGEMENT
+
+    return ActivitySignal(
+        current_activity=current,
+        chrome_activity=_activity_for_page(chrome_pt),
+        edge_activity=_activity_for_page(edge_pt),
+        chrome_page_type=chrome_pt,
+        edge_page_type=edge_pt,
+        chrome_on_comments=chrome_on_comments,
+        edge_on_comments=edge_on_comments,
+        chrome_stale_during_live=bool(live_chat_active and chrome_on_comments),
+        edge_stale_during_live=bool(live_chat_active and edge_on_comments),
+    )

--- a/modules/communication/livechat/tests/test_ooda_activity_signal.py
+++ b/modules/communication/livechat/tests/test_ooda_activity_signal.py
@@ -1,0 +1,120 @@
+"""
+Unit tests for the channel-scoped OODA activity signal (RC3 observability).
+
+PURE tests -- no live browser, no driver, no router. They pin two things:
+  1. the rollup `current_activity` precedence is UNCHANGED (so should_pivot is
+     byte-for-byte identical to the pre-fix Chrome-only logic), and
+  2. the NEW channel-scoped truth: a stale Chrome comments tab during a live
+     stream is flagged, and Edge-bound channels (FoundUps/antifaFM) are never
+     mislabelled as "processing comments" just because Chrome is on a comments
+     page.
+"""
+import pytest
+
+from modules.communication.livechat.src.ooda_activity_signal import (
+    ActivitySignal,
+    derive_activity_signal,
+)
+from modules.infrastructure.activity_control.src.activity_control import ActivityType
+
+
+def _ps(chrome=None, edge=None):
+    """Build a page_state dict like the heartbeat probe produces."""
+    return {
+        "chrome": {"page_type": chrome} if chrome is not None else None,
+        "edge": {"page_type": edge} if edge is not None else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Rollup precedence preserved (proves should_pivot is unchanged)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "chrome,edge,live,expected",
+    [
+        # Chrome on comments wins regardless of live (FIX 2026-02-21 precedence).
+        ("youtube_studio_comments", "other", False, ActivityType.COMMENT_ENGAGEMENT),
+        ("youtube_studio_comments", "other", True, ActivityType.COMMENT_ENGAGEMENT),
+        # Chrome NOT on comments + live -> LIVE_CHAT.
+        ("youtube_live", "other", True, ActivityType.LIVE_CHAT),
+        ("other", None, True, ActivityType.LIVE_CHAT),
+        # Chrome NOT on comments + not live -> default COMMENT_ENGAGEMENT.
+        ("youtube_studio", "other", False, ActivityType.COMMENT_ENGAGEMENT),
+        (None, None, False, ActivityType.COMMENT_ENGAGEMENT),
+    ],
+)
+def test_rollup_precedence_unchanged(chrome, edge, live, expected):
+    sig = derive_activity_signal(_ps(chrome, edge), live)
+    assert sig.current_activity == expected
+
+
+# ---------------------------------------------------------------------------
+# RC3 CORE: stale Chrome comments tab during live is flagged, Edge not mislabelled
+# ---------------------------------------------------------------------------
+
+def test_rc3_stale_chrome_comments_during_live_is_flagged():
+    # Live stream active, but a Chrome comments tab is open (the incident shape:
+    # executor cancelled, tab is stale). Edge is NOT on a comments page.
+    sig = derive_activity_signal(_ps("youtube_studio_comments", "youtube_studio"), live_chat_active=True)
+    # Rollup unchanged (still COMMENT_ENGAGEMENT) ...
+    assert sig.current_activity == ActivityType.COMMENT_ENGAGEMENT
+    # ... but now explicitly flagged as a stale tab during live.
+    assert sig.chrome_stale_during_live is True
+    assert sig.is_misleading_comment_signal is True
+    # Edge-bound channels (FoundUps/antifaFM) are NOT reported as processing comments.
+    assert sig.edge_on_comments is False
+    assert sig.edge_activity != ActivityType.COMMENT_ENGAGEMENT
+    # The human-readable summary names the staleness so an observer is not misled.
+    assert "STALE-TAB-DURING-LIVE" in sig.log_summary()
+
+
+def test_chrome_comments_offline_is_not_flagged_stale():
+    sig = derive_activity_signal(_ps("youtube_studio_comments", "other"), live_chat_active=False)
+    assert sig.current_activity == ActivityType.COMMENT_ENGAGEMENT
+    assert sig.chrome_stale_during_live is False
+    assert sig.is_misleading_comment_signal is False
+    assert "STALE-TAB-DURING-LIVE" not in sig.log_summary()
+
+
+# ---------------------------------------------------------------------------
+# Channel-scoping is real (non-vacuity): per-browser activities differ
+# ---------------------------------------------------------------------------
+
+def test_edge_comments_scoped_to_edge_not_chrome():
+    # Only EDGE is on comments (FoundUps/antifaFM working); Chrome is idle.
+    sig = derive_activity_signal(_ps("youtube_studio", "youtube_studio_comments"), live_chat_active=False)
+    assert sig.edge_activity == ActivityType.COMMENT_ENGAGEMENT
+    assert sig.chrome_activity != ActivityType.COMMENT_ENGAGEMENT  # Chrome group NOT doing comments
+    assert sig.edge_on_comments is True
+    assert sig.chrome_on_comments is False
+
+
+def test_per_browser_split_is_independent():
+    # Non-vacuity: when only one browser is on comments, the two activities differ
+    # (proves we report per-browser truth, not a single value copied to both).
+    sig = derive_activity_signal(_ps("youtube_studio_comments", "youtube_live"), live_chat_active=False)
+    assert sig.chrome_activity == ActivityType.COMMENT_ENGAGEMENT
+    assert sig.edge_activity == ActivityType.LIVE_CHAT
+    assert sig.chrome_activity != sig.edge_activity
+
+
+def test_live_chat_page_not_mislabelled_as_comments():
+    sig = derive_activity_signal(_ps("youtube_live", "other"), live_chat_active=True)
+    assert sig.current_activity == ActivityType.LIVE_CHAT
+    assert sig.chrome_activity == ActivityType.LIVE_CHAT
+    assert sig.is_misleading_comment_signal is False
+
+
+# ---------------------------------------------------------------------------
+# Robustness: missing / malformed page_state never raises
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("ps", [None, {}, {"chrome": None, "edge": None}, {"chrome": "bad", "edge": 5}])
+def test_missing_or_malformed_page_state_is_safe(ps):
+    sig = derive_activity_signal(ps, live_chat_active=False)
+    assert isinstance(sig, ActivitySignal)
+    assert sig.current_activity == ActivityType.COMMENT_ENGAGEMENT  # else branch
+    assert sig.chrome_on_comments is False
+    assert sig.edge_on_comments is False
+    assert sig.chrome_stale_during_live is False


### PR DESCRIPTION
First slice of the comment-flow work (`YOUTUBE_COMMENT_FLOW_OODA_OBSERVABILITY_PHASE1`). **Observability only** — de-risks the always-flow arc by making the OODA signal honest before any behavior change.

## Problem (forensic-confirmed)
The heartbeat's OODA `current_activity` was derived from the **Chrome page-type alone** ([auto_moderator_dae.py:2386-2404](modules/communication/livechat/src/auto_moderator_dae.py#L2386)). Chrome 9222 = M2J/UnDaoDu, Edge 9223 = FoundUps/antifaFM — so a stale Chrome comments tab during a live stream made the log report `Current=COMMENT_ENGAGEMENT … Processing comments for FoundUps` while nothing was being processed (the executor loop is cancelled on live-confirm). That mislabel is what made a live window look like an outage and triggered the whole audit.

## Change (no behavior change)
- **NEW** `src/ooda_activity_signal.py` — pure `derive_activity_signal(page_state, live_chat_active)`: per-browser activity (chrome/edge), `chrome_stale_during_live`/`edge_stale_during_live`, `is_misleading_comment_signal`. Rollup `current_activity` keeps the exact 2026-02-21 precedence → **`should_pivot` byte-for-byte unchanged**.
- OODA block uses the helper; log now leads with the channel-scoped truth + a `[OODA] RC3` warning on the stale-tab case. `signal_comments_complete` (router side-effect) **preserved exactly**. Breadcrumb enriched (prerequisite for later pivot detection).

## Tests (15, mock-only)
Rollup-precedence-unchanged (parametrized), RC3 stale-tab-during-live flagged + Edge **not** mislabelled, per-browser channel-scoping (non-vacuous), malformed/None page_state safe. **Non-vacuity proven by inject/revert** (disabling the stale flag fails the RC3 test).

## Out of scope
The selective-cancellation **always-flow** fix (keep the non-live browser loop alive during live) is a separate future slice. RC4 backlog-abandonment is its own slice.

Runtime livechat DAE: **VERIFIED_READY**, awaiting authorization to merge.