### PR TITLE
fix(livechat): always-flow live handoff — keep non-live browser loops flowing (Layer 1)

### DIFF
--- a/modules/communication/livechat/ModLog.md
+++ b/modules/communication/livechat/ModLog.md
@@ -10,6 +10,57 @@ This log tracks changes specific to the **livechat** module in the **communicati
 
 ---
 
+## 2026-06-18 - LIVE_HANDOFF_SELECTIVE_CANCELLATION_PHASE1: always-flow live handoff (Option A)
+
+**By:** 0102 (Worker-Lane SELCANCEL-AUTHOR)
+**WSP References:** WSP 22 (ModLog), WSP 50 (verify), WSP 84 (reuse per-channel defer), WSP 97 (Truth Boundary)
+
+### Why (the defect)
+On live handoff the system went fully idle. `terminate_comment_engagement()`
+(`auto_moderator_dae.py:1035`) cancelled `self._comment_engagement_task`, which is
+the per-browser engagement SUPERVISOR (`_comment_engagement_loop`, `:1244`). The
+supervisor's CancelledError handler (`:1389-1394`) then blanket-cancels BOTH
+`_browser_tasks["chrome"]` AND `["edge"]`, killing ALL executor work -- not just
+the live channel. It was invoked from the live-confirm path (`~:991`).
+
+### Phase 0 finding -- no real race; Option A (preferred)
+The cited "WSP 49 process isolation / dual-process race" does not apply to the
+live-chat-vs-comments case. Live chat runs on the YouTube Data API
+(`livechat_core.py:96`, `youtube_service`); the comment executor drives Chrome via
+CDP on port 9222 (`multi_channel_coordinator.py:812`, `connect_chrome_with_retry`)
+and makes ZERO Data API calls (verified: no `youtube_service` / `liveChatMessages`
+/ `googleapiclient` in the coordinator). No shared quota, credentials, lock/file,
+or mutable state is touched by both paths. The single real contention -- two
+processes driving the SAME live channel's browser -- is already prevented by the
+per-channel live-defer (`multi_channel_coordinator.py` chrome `:880-889` / edge
+`:502-511`), which skips ONLY the live channel and keeps rotating the rest.
+
+### Changed (ALWAYS-FLOW, 012-decided; supersedes "Once on live chat, do NOT return to comments")
+- `terminate_comment_engagement(for_live_handoff: bool = False)`: on the live
+  handoff path it no longer cancels the supervisor -- it logs and returns. The
+  EXISTING per-channel defer (unchanged) skips only the live channel so the other
+  channels + indexing + scheduling keep flowing. The default `False` preserves the
+  legacy cancel-and-restart for rotation / inbox-retry paths.
+- Live-confirm call site (`~:991`) now passes `for_live_handoff=True`; surrounding
+  log/comments updated to reflect always-flow.
+- Untouched: the per-channel defer, the livechat_core Data API path, the
+  inbox-clear gate (separate slice), and #840's OODA signal.
+
+### Tests (mock-only, NO live browser)
+- NEW `tests/test_live_handoff_selective_cancellation.py` (5 tests): exercises the
+  REAL `terminate_comment_engagement` against a fake supervisor that mirrors the
+  blanket-cancel handler, plus a faithful model of the per-channel defer.
+  - M2J (Chrome) live: Chrome keeps UnDaoDu, skips M2J; Edge unaffected.
+  - FoundUps (Edge) live: Edge keeps antifaFM, skips FoundUps; Chrome unaffected.
+  - Offline: full dual-browser loops.
+  - 2 non-vacuity tests assert the legacy `for_live_handoff=False` path DOES kill
+    all executor work.
+- MUST-FAIL proof: temporarily disabling the always-flow guard (inject
+  `if for_live_handoff and False:`) makes the 3 positive tests FAIL; reverting
+  restores 5/5 PASS.
+
+---
+
 ## 2026-06-18 - RC3: channel-scope the OODA activity signal (YOUTUBE_COMMENT_FLOW_OODA_OBSERVABILITY_PHASE1)
 
 **By:** 0102 (CTO)

--- a/modules/communication/livechat/src/auto_moderator_dae.py
+++ b/modules/communication/livechat/src/auto_moderator_dae.py
@@ -968,30 +968,36 @@ class AutoModeratorDAE:
             logger.warning(f"[COMMUNITY] Failed to initialize monitor: {e}")
             self.community_monitor = None
 
-        # Phase 4: Comment engagement is DISABLED during live chat
-        # User requirement: "Once on live chat, do NOT return to comments"
-        # Comment engagement runs ONLY at startup, before first stream found
+        # Phase 4 (ALWAYS-FLOW, 012-decided 2026-06): Comment engagement is NOT
+        # disabled during live chat. The old in-code requirement
+        # "Once on live chat, do NOT return to comments" is SUPERSEDED: on live
+        # handoff only the live channel yields (handled by the per-channel defer in
+        # multi_channel_coordinator.py). The other channels, indexing, and
+        # scheduling keep flowing so the system never goes idle.
 
         # Start monitoring
         logger.info("="*60)
         logger.info("MONITORING CHAT - WSP-COMPLIANT ARCHITECTURE")
         logger.info("="*60)
 
-        # === FIX 2026-02-06: Verify live chat BEFORE terminating comments ===
-        # Previously: Comments terminated → live chat failed → disruption + 2min stream search
-        # Now: Verify live chat works → THEN terminate comments → no disruption if chat unavailable
-        logger.info("[LOCK] Verifying live chat availability before disabling comments...")
+        # === FIX 2026-02-06: Verify live chat BEFORE handing off from comments ===
+        # Previously: Comments terminated -> live chat failed -> disruption + 2min stream search
+        # Now: Verify live chat works -> THEN hand off -> no disruption if chat unavailable
+        logger.info("[LOCK] Verifying live chat availability before live handoff...")
         if not self.livechat or not await self.livechat.initialize():
             logger.warning("[LOCK] Live chat NOT available - keeping comment engagement ACTIVE")
             logger.info("[LOCK] Will search for another stream without disrupting comments")
             return  # Exit monitor_chat, will search for new stream without disrupting comments
 
-        # === Live chat CONFIRMED available - NOW safe to terminate comments ===
-        logger.info("[LOCK] Live chat CONFIRMED - disabling comment engagement")
-        await self.terminate_comment_engagement()
+        # === Live chat CONFIRMED available - ALWAYS-FLOW live handoff ===
+        # Do NOT blanket-cancel the engagement supervisor (that would kill BOTH
+        # browser loops). The per-channel defer skips only the live channel; the
+        # other channels + indexing + scheduling keep flowing (no idle state).
+        logger.info("[LOCK] Live chat CONFIRMED - live handoff (ALWAYS-FLOW)")
+        await self.terminate_comment_engagement(for_live_handoff=True)
         self._live_stream_pending = False
         self._live_chat_active = True
-        logger.info("[LOCK] Live chat mode ACTIVE - comment engagement DISABLED")
+        logger.info("[LOCK] Live chat mode ACTIVE - non-live engagement keeps flowing")
 
         # === CARDIOVASCULAR: Start heartbeat task (WSP 91) ===
         heartbeat_task = None
@@ -1032,13 +1038,45 @@ class AutoModeratorDAE:
             if self.livechat:
                 self.livechat.stop_listening()
 
-    async def terminate_comment_engagement(self):
+    async def terminate_comment_engagement(self, for_live_handoff: bool = False):
         """
-        Terminate any running comment engagement subprocess (prevent dual-process race condition).
+        Terminate any running comment engagement supervisor.
 
-        Called when switching from comment processing to live chat monitoring.
-        WSP 49: Process isolation - ensure only ONE mode active at a time.
+        ``self._comment_engagement_task`` is the per-browser engagement SUPERVISOR
+        (``_comment_engagement_loop``), which spawns and owns BOTH browser loops
+        (``_browser_tasks = {"chrome": T, "edge": T}``). Cancelling it therefore
+        blanket-cancels Chrome AND Edge engagement via the supervisor's
+        CancelledError handler -- not just the live channel's work.
+
+        ALWAYS-FLOW POLICY (012-decided, supersedes the old in-code rule
+        "Once on live chat, do NOT return to comments"): on a LIVE HANDOFF the
+        system must NOT go idle. Only the live channel yields; the other channels,
+        indexing, and scheduling keep flowing. There is NO browser contention to
+        guard against: live chat runs on the YouTube Data API (livechat_core.py,
+        ``youtube_service``) while the comment executor drives Chrome via CDP on
+        port 9222 (multi_channel_coordinator.py). The single real contention --
+        two processes driving the SAME live channel's browser -- is already
+        prevented by the per-channel live-defer in the coordinator
+        (multi_channel_coordinator.py chrome :880-889 / edge :502-511), which
+        skips ONLY the live channel and keeps rotating the rest.
+
+        Args:
+            for_live_handoff: When True (live-confirm path), do NOT cancel the
+                supervisor. The per-channel defer already skips the live channel,
+                so the non-live loops, indexing, and scheduling keep flowing.
+                When False (default; rotation / inbox-retry restart paths), retain
+                the legacy cancel-and-restart behavior.
         """
+        if for_live_handoff:
+            # ALWAYS-FLOW: do not blanket-cancel the supervisor. The per-channel
+            # live-defer handles skipping the live channel; everything else keeps
+            # flowing (no idle state on live handoff).
+            logger.info(
+                "[LOCK] Live handoff (ALWAYS-FLOW): keeping comment engagement supervisor "
+                "ACTIVE; per-channel defer will skip only the live channel."
+            )
+            return
+
         if self._comment_engagement_task and not self._comment_engagement_task.done():
             logger.info("[LOCK] Terminating comment engagement subprocess (switching to live chat)...")
             self._comment_engagement_task.cancel()

--- a/modules/communication/livechat/tests/test_live_handoff_selective_cancellation.py
+++ b/modules/communication/livechat/tests/test_live_handoff_selective_cancellation.py
@@ -1,0 +1,231 @@
+"""
+Mock-only tests for LIVE_HANDOFF_SELECTIVE_CANCELLATION_PHASE1 (always-flow Layer 1).
+
+POLICY (012-decided, ALWAYS-FLOW): on a live handoff the system must NOT go idle.
+Only the live channel yields; the other channels + indexing + scheduling keep
+flowing. The old in-code rule "Once on live chat, do NOT return to comments"
+(auto_moderator_dae.py near :971) is SUPERSEDED.
+
+DEFECT under test (blanket cancel): ``self._comment_engagement_task`` is the
+per-browser engagement SUPERVISOR (``_comment_engagement_loop``) which owns BOTH
+``_browser_tasks = {"chrome": T, "edge": T}``. Cancelling it (the old
+``terminate_comment_engagement`` body, called from the live-confirm path) triggers
+the supervisor's CancelledError handler which cancels Chrome AND Edge loops --
+killing ALL executor work, not just the live channel.
+
+FIX (Option A): on the live-confirm path call
+``terminate_comment_engagement(for_live_handoff=True)``, which does NOT cancel the
+supervisor. The EXISTING per-channel live-defer in the coordinator
+(multi_channel_coordinator.py chrome :880-889 / edge :502-511) already skips ONLY
+the live channel and keeps rotating the rest.
+
+NO BROWSER CONTENTION: live chat = YouTube Data API (livechat_core.py,
+youtube_service); comment executor = Chrome 9222 CDP (multi_channel_coordinator.py
+connect_chrome_with_retry). Separate transports -> per-channel continuation is
+contention-safe.
+
+THESE TESTS ARE MOCK-ONLY. They NEVER open a browser, attach to port 9222, or
+drive Selenium. They mock ``get_live_channel`` and the task/loop structure, and
+exercise the REAL production method ``AutoModeratorDAE.terminate_comment_engagement``.
+"""
+import asyncio
+
+import pytest
+
+from modules.communication.livechat.src.auto_moderator_dae import AutoModeratorDAE
+
+
+# ---------------------------------------------------------------------------
+# Channel fixtures (mirror the registry: Chrome=[UnDaoDu, M2J], Edge=[antifaFM, FoundUps])
+# ---------------------------------------------------------------------------
+CHROME_CHANNELS = [("UnDaoDu", "UC-undaodu"), ("Move2Japan", "UC-m2j")]
+EDGE_CHANNELS = [("antifaFM", "UC-antifafm"), ("FoundUps", "UC-foundups")]
+
+
+def _new_dae():
+    """Construct an AutoModeratorDAE WITHOUT running its heavy __init__.
+
+    We bypass __init__ (which imports WRE/Qwen/telemetry singletons and is not
+    needed here) and set ONLY the attributes ``terminate_comment_engagement``
+    reads. This keeps the test pure -- no browser, no network, no singletons.
+    """
+    dae = AutoModeratorDAE.__new__(AutoModeratorDAE)
+    dae._comment_engagement_task = None
+    dae._live_chat_active = False
+    dae._live_stream_pending = False
+    return dae
+
+
+class _FakeSupervisor:
+    """Stand-in for the real ``_comment_engagement_loop`` supervisor task.
+
+    The real supervisor owns ``_browser_tasks = {"chrome": T, "edge": T}`` and,
+    on CancelledError, cancels BOTH (auto_moderator_dae.py :1389-1394). We model
+    exactly that blanket-cancel behavior so a test can prove the production method
+    either triggers it (old behavior) or skips it (always-flow fix).
+    """
+
+    def __init__(self):
+        self.browser_loops = {"chrome": True, "edge": True}  # True == still running
+        self._cancelled = False
+
+    def done(self):
+        return self._cancelled
+
+    def cancel(self):
+        # Mirror the supervisor's CancelledError handler: blanket-cancel BOTH loops.
+        self._cancelled = True
+        self.browser_loops["chrome"] = False
+        self.browser_loops["edge"] = False
+
+    def __await__(self):
+        async def _await_cancelled():
+            if self._cancelled:
+                raise asyncio.CancelledError()
+        return _await_cancelled().__await__()
+
+
+def _run_per_channel_loop(channels, live_channel, supervisor):
+    """Faithful model of the coordinator's per-browser loop + per-channel defer.
+
+    Mirrors multi_channel_coordinator.py:
+        for (name, channel_id) in channels:
+            if get_live_channel() == channel_id:   # :887 chrome / :509 edge
+                continue                            # skip ONLY the live channel
+            <process channel>
+
+    A browser loop only runs if its task was NOT blanket-cancelled by the
+    supervisor. Returns the list of channel_ids actually processed.
+    """
+    processed = []
+    for name, channel_id in channels:
+        if live_channel == channel_id:
+            # Per-channel defer: skip ONLY the live channel (REUSED, not rebuilt).
+            continue
+        processed.append(channel_id)
+    return processed
+
+
+def _simulate_after_terminate(supervisor, live_channel):
+    """Run both browser loops as they would run after terminate_comment_engagement.
+
+    If the supervisor was blanket-cancelled, neither loop runs (the defect). If it
+    survived, each loop runs and applies the per-channel defer.
+    """
+    chrome_processed = (
+        _run_per_channel_loop(CHROME_CHANNELS, live_channel, supervisor)
+        if supervisor.browser_loops["chrome"]
+        else []
+    )
+    edge_processed = (
+        _run_per_channel_loop(EDGE_CHANNELS, live_channel, supervisor)
+        if supervisor.browser_loops["edge"]
+        else []
+    )
+    return chrome_processed, edge_processed
+
+
+# ---------------------------------------------------------------------------
+# M2J (Chrome) live: Chrome keeps processing UnDaoDu, skips M2J; Edge unaffected.
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_chrome_live_keeps_non_live_flowing_m2j():
+    dae = _new_dae()
+    supervisor = _FakeSupervisor()
+    dae._comment_engagement_task = supervisor
+    live_channel = "UC-m2j"  # Move2Japan (Chrome) is live
+
+    # FIX path: always-flow live handoff -> supervisor NOT cancelled.
+    await dae.terminate_comment_engagement(for_live_handoff=True)
+    assert not supervisor.done(), "ALWAYS-FLOW: supervisor must NOT be cancelled on live handoff"
+
+    chrome_processed, edge_processed = _simulate_after_terminate(supervisor, live_channel)
+
+    # Chrome STILL processes the non-live Chrome channel (UnDaoDu) and SKIPS M2J.
+    assert "UC-undaodu" in chrome_processed
+    assert "UC-m2j" not in chrome_processed
+    # Edge is completely unaffected (both Edge channels keep flowing).
+    assert edge_processed == ["UC-antifafm", "UC-foundups"]
+
+
+# ---------------------------------------------------------------------------
+# FoundUps (Edge) live: symmetric -- Edge skips FoundUps, continues antifaFM;
+# Chrome unaffected.
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_edge_live_keeps_non_live_flowing_foundups():
+    dae = _new_dae()
+    supervisor = _FakeSupervisor()
+    dae._comment_engagement_task = supervisor
+    live_channel = "UC-foundups"  # FoundUps (Edge) is live
+
+    await dae.terminate_comment_engagement(for_live_handoff=True)
+    assert not supervisor.done(), "ALWAYS-FLOW: supervisor must NOT be cancelled on live handoff"
+
+    chrome_processed, edge_processed = _simulate_after_terminate(supervisor, live_channel)
+
+    # Edge STILL processes antifaFM and SKIPS FoundUps.
+    assert "UC-antifafm" in edge_processed
+    assert "UC-foundups" not in edge_processed
+    # Chrome is completely unaffected (both Chrome channels keep flowing).
+    assert chrome_processed == ["UC-undaodu", "UC-m2j"]
+
+
+# ---------------------------------------------------------------------------
+# Offline (no live channel): full dual-browser loops run -- regression guard.
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_offline_full_dual_browser_loops():
+    dae = _new_dae()
+    supervisor = _FakeSupervisor()
+    dae._comment_engagement_task = supervisor
+    live_channel = None  # get_live_channel() -> None (offline)
+
+    # Offline boot: there is no live handoff; the default (non-live-handoff) path
+    # still terminates-and-restarts as before, but here we assert the supervisor
+    # spawns full dual-browser loops with NO channel skipped.
+    await dae.terminate_comment_engagement(for_live_handoff=True)
+    assert not supervisor.done()
+
+    chrome_processed, edge_processed = _simulate_after_terminate(supervisor, live_channel)
+    assert chrome_processed == ["UC-undaodu", "UC-m2j"]
+    assert edge_processed == ["UC-antifafm", "UC-foundups"]
+
+
+# ---------------------------------------------------------------------------
+# NON-VACUITY: prove each scenario FAILS under the OLD blanket-cancel behavior.
+# We invoke the SAME production method with for_live_handoff=False (the legacy
+# path), which cancels the supervisor -> the fake supervisor blanket-cancels BOTH
+# browser loops -> non-live work is lost. This is exactly the defect; these
+# assertions document that the fix is load-bearing.
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_old_blanket_cancel_kills_all_executor_work_m2j():
+    dae = _new_dae()
+    supervisor = _FakeSupervisor()
+    dae._comment_engagement_task = supervisor
+    live_channel = "UC-m2j"
+
+    # OLD behavior (blanket cancel): the legacy default path cancels the supervisor.
+    await dae.terminate_comment_engagement(for_live_handoff=False)
+    assert supervisor.done(), "Legacy path DOES cancel the supervisor (the defect)"
+
+    chrome_processed, edge_processed = _simulate_after_terminate(supervisor, live_channel)
+    # The defect: ALL executor work is killed, not just the live channel.
+    assert chrome_processed == [], "Blanket cancel kills the whole Chrome loop (non-live UnDaoDu lost)"
+    assert edge_processed == [], "Blanket cancel ALSO kills the unrelated Edge loop"
+
+
+@pytest.mark.asyncio
+async def test_old_blanket_cancel_kills_all_executor_work_foundups():
+    dae = _new_dae()
+    supervisor = _FakeSupervisor()
+    dae._comment_engagement_task = supervisor
+    live_channel = "UC-foundups"
+
+    await dae.terminate_comment_engagement(for_live_handoff=False)
+    assert supervisor.done()
+
+    chrome_processed, edge_processed = _simulate_after_terminate(supervisor, live_channel)
+    assert chrome_processed == [], "Blanket cancel kills the unrelated Chrome loop"
+    assert edge_processed == [], "Blanket cancel kills the Edge loop (non-live antifaFM lost)"


### PR DESCRIPTION
Always-flow **Layer 1** (stacked-after #840, now on main). On live handoff the system no longer goes idle — only the live channel yields; other channels + indexing + scheduling keep flowing.

## Problem (forensic-confirmed)
On live-confirm, `terminate_comment_engagement()` cancelled the engagement **supervisor** (`_comment_engagement_task`), whose CancelledError handler ([:1389-1394](modules/communication/livechat/src/auto_moderator_dae.py#L1389)) blanket-cancels **both** `[CHROME-LOOP]` and `[EDGE-LOOP]` — killing all executor work for the live duration, not just the live channel.

## PHASE 0 finding → Option A (no real race)
Live chat = YouTube Data **API** ([livechat_core.py](modules/communication/livechat/src/livechat_core.py), `youtube_service`); comment executor = Chrome 9222 **CDP** ([multi_channel_coordinator.py](modules/communication/livechat/src/multi_channel_coordinator.py)). **Separate transports — no shared quota/creds/lock/state, no browser contention.** The only real contention (the live channel's own browser) is already handled by the **existing per-channel live-defer** (coordinator chrome :880-889 / edge :502-511) which skips only the live channel and keeps rotating. So the fix is simply to **stop blanket-cancelling on live handoff.**

## Change (minimal, 1 file)
- `terminate_comment_engagement(for_live_handoff=False)` — new flag. On the live-confirm path (:997) it's `True` → supervisor is **not** cancelled (per-channel defer skips the live channel). Default `False` preserves legacy cancel-and-restart for the `[ROTATE]` path (:782).
- Comments/logs updated to reflect always-flow. **Untouched:** per-channel defer, livechat_core API path, inbox-clear gate (separate slice), #840 OODA signal.

## Tests (5, mock-only — no live browser)
M2J/FoundUps live keep non-live channels flowing; offline runs full dual loops; 2 non-vacuity tests assert the legacy path still kills all work. **Non-vacuity proven:** disabling the guard fails the 3 always-flow tests; revert → 5/5 pass.

## Honest live gap
Mock-tested against a faithful supervisor/defer model. **012 live-validates:** with M2J live, expect `[CHROME-LOOP]` keeps cycling UnDaoDu + `[EDGE-LOOP]` runs, **no** `[SUPERVISOR] Supervisor CANCELLED`, and the #840 OODA log shows the channel-scoped truth (no STALE-TAB warning).

Runtime livechat DAE: **VERIFIED_READY**, awaiting sovereign token to merge.