### PR TITLE
fix(youtube_shorts_scheduler): cap 3/day + 1-6am window (was 8/day)

### DIFF
--- a/modules/infrastructure/shared_utilities/youtube_channel_registry.py
+++ b/modules/infrastructure/shared_utilities/youtube_channel_registry.py
@@ -51,7 +51,7 @@ def _default_channels() -> List[Dict[str, Any]]:
                 "available_ports": [_CHROME_PORT, _EDGE_PORT],
                 "account_section": 0,
             },
-            "shorts": {"time_slots": _DEFAULT_TIME_SLOTS, "max_per_day": 8, "description_template": "ffcpln"},
+            "shorts": {"time_slots": _DEFAULT_TIME_SLOTS, "max_per_day": 3, "description_template": "ffcpln"},
             "social": {"linkedin_company": "move2japan", "x_account": "geozai", "enabled": True, "signature": "0102🦞"},
         },
         {
@@ -68,7 +68,7 @@ def _default_channels() -> List[Dict[str, Any]]:
                 "available_ports": [_CHROME_PORT, _EDGE_PORT],
                 "account_section": 0,
             },
-            "shorts": {"time_slots": _DEFAULT_TIME_SLOTS, "max_per_day": 8, "description_template": "undaodu"},
+            "shorts": {"time_slots": _DEFAULT_TIME_SLOTS, "max_per_day": 3, "description_template": "undaodu"},
             "social": {"linkedin_company": "undaodu", "x_account": "undaodu", "enabled": True, "signature": "0102🦞012🖐️"},  # wsp01: 012 co-signs
         },
         {
@@ -85,7 +85,7 @@ def _default_channels() -> List[Dict[str, Any]]:
                 "available_ports": [_CHROME_PORT, _EDGE_PORT],
                 "account_section": 1,
             },
-            "shorts": {"time_slots": _DEFAULT_TIME_SLOTS, "max_per_day": 8, "description_template": "foundups"},
+            "shorts": {"time_slots": _DEFAULT_TIME_SLOTS, "max_per_day": 3, "description_template": "foundups"},
             "social": {"linkedin_company": "foundups", "x_account": "foundups", "enabled": True, "signature": "0102🦞"},
         },
         {
@@ -102,7 +102,7 @@ def _default_channels() -> List[Dict[str, Any]]:
                 "available_ports": [_CHROME_PORT, _EDGE_PORT],
                 "account_section": 1,
             },
-            "shorts": {"time_slots": _DEFAULT_TIME_SLOTS, "max_per_day": 8, "description_template": "ffcpln"},
+            "shorts": {"time_slots": _DEFAULT_TIME_SLOTS, "max_per_day": 3, "description_template": "ffcpln"},
             "social": {"linkedin_company": "move2japan", "x_account": "antifafm", "enabled": True, "signature": "0102🦞"},  # wsp01: antifaFM posts to move2japan
         },
     ]
@@ -142,7 +142,7 @@ def _normalize_channel(channel: Dict[str, Any]) -> Dict[str, Any]:
     shorts = normalized.get("shorts") or {}
     normalized["shorts"] = {
         "time_slots": list(shorts.get("time_slots") or _DEFAULT_TIME_SLOTS),
-        "max_per_day": int(shorts.get("max_per_day", 8)),
+        "max_per_day": int(shorts.get("max_per_day", 3)),
         "description_template": str(shorts.get("description_template", "ffcpln")),
     }
 

--- a/modules/platform_integration/youtube_shorts_scheduler/ModLog.md
+++ b/modules/platform_integration/youtube_shorts_scheduler/ModLog.md
@@ -1,5 +1,64 @@
 # YouTube Shorts Scheduler - ModLog
 
+## 2026-06-19 - Cap shorts at 3/day + 1-6am window decision (was 8/day) (Phase 1)
+
+**By:** 0102 (Worker-Lane SCHED-DENSITY)
+**Slice:** SHORTS_SCHEDULE_DENSITY_AND_WINDOW_PHASE1
+**WSP References:** WSP 22 (ModLog), WSP 49 (Structure), WSP 50 (Pre-Action), WSP 84 (Code Reuse), WSP 97 (Truth Signaling)
+
+### Problem
+
+The scheduler over-schedules: the registry defaulted `max_per_day: 8` for all 4 channels
+and the live persisted `memory/youtube_channels.json` carries `max_per_day: 8` with an 8-slot
+24h grid. The only per-day enforcement was `if count < max_per_day:` in the allocator, which
+honored whatever value the config passed (8), so the running system schedules up to 8 shorts/day.
+
+### Changes (minimal)
+
+1. **Authoritative clamp (load-bearing).** Added module constant `HARD_CAP_PER_DAY = 3` in
+   `src/schedule_tracker.py` and clamped at the allocator:
+   `effective_cap = min(max_per_day, HARD_CAP_PER_DAY)`. This holds even when a caller passes a
+   stale `max_per_day=8` (e.g. from the untracked runtime JSON), so it fixes the running system
+   regardless of config drift.
+2. **Registry/config defaults 8 -> 3.** `youtube_channel_registry.py` (4 channel entries +
+   `_normalize_channel` fallback) and `channel_config.py` `_build_channel_config` fallback now
+   default `max_per_day` to 3.
+3. **Persisted `memory/youtube_channels.json` NOT committed.** It is gitignored
+   (`.gitignore:143:memory/`) and absent from a fresh checkout; it still carries `max_per_day: 8`
+   in the runtime repo. Per scope, it is NOT committed -- the HARD_CAP_PER_DAY clamp covers the
+   stale value at allocation time.
+4. **Stale report fixed.** `get_summary` / `has_sufficient_coverage` / `log_schedule_report`
+   previously hard-coded the "full day" threshold to 3 (and printed a literal "Full days (3/3)").
+   These now use `HARD_CAP_PER_DAY`, so the report stops lying if the cap changes.
+
+### Window (1-6am): DEFERRED -- timezone unverified
+
+The 8-slot `_DEFAULT_TIME_SLOTS` grid was intentionally LEFT UNCHANGED. The scheduler types the
+bare time string into YouTube Studio and deliberately never sets the timezone selector
+(`src/dom_automation.py` set_schedule_time ~3196; timezone-select guard ~3226-3232). Studio
+interprets that time in each account's own configured timezone, which the code does not read or
+verify. The registry timezones disagree (Move2Japan/UnDaoDu = Asia/Tokyo; FoundUps/antifaFM =
+America/New_York), so a fixed "1:30 AM" would publish at different wall-clocks per channel and 2 of
+4 would be wrong for a JST-based 012. Wrong tz = videos publish at the wrong outward-facing time, so
+per the slice's safety rule the grid change is deferred until the Studio timezone is verified. The
+clamp still concentrates publishing into the first 3 grid slots (12AM/3AM/6AM) per day.
+
+### Tests (unit, mock-only, non-vacuous)
+
+`tests/test_scheduler.py` -> new `TestScheduleDensityCap`:
+- `test_allocator_caps_at_three_per_day`: 4 videos at max_per_day=3 roll the 4th to the next day
+  (counts == [3, 1]).
+- `test_clamp_authority_overrides_caller_max_per_day_eight`: 9 videos with max_per_day=8 yield
+  exactly 3 days of 3 (NON-VACUITY: reverting the clamp to `effective_cap = max_per_day` makes this
+  fail with "got 8 (>3)" -- verified by temporary revert, then restored).
+- `test_report_threshold_matches_effective_cap`: full/partial day counts track HARD_CAP_PER_DAY.
+- `test_hard_cap_constant_is_three`.
+Also corrected two pre-existing flaky exact-time assertions (jitter randomizes the slot) to use a
+bounded `_within_jitter` helper, and updated `test_get_channel_config_move2japan` to assert
+`max_per_day == 3` (slot count not asserted since the grid is unchanged this slice).
+
+Scoped pytest: 34 passed, 2 skipped (browser integration, correctly skipped).
+
 ## 2026-06-16 - Pin video-index context consumption on the scheduling path (Phase 1)
 
 **By:** 0102 (Worker-Lane SSVCC-AUTHOR)

--- a/modules/platform_integration/youtube_shorts_scheduler/src/channel_config.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/src/channel_config.py
@@ -44,7 +44,7 @@ def _build_channel_config() -> Dict[str, Dict[str, Any]]:
             "handle": ch.get("handle"),
             "timezone": ch.get("timezone"),
             "time_slots": shorts.get("time_slots") or [],
-            "max_per_day": shorts.get("max_per_day", 8),
+            "max_per_day": shorts.get("max_per_day", 3),
             "chrome_port": browser.get("preferred_port", CHROME_PORT),
             "preferred_port": browser.get("preferred_port", CHROME_PORT),
             "available_ports": browser.get("available_ports", ALL_PORTS),

--- a/modules/platform_integration/youtube_shorts_scheduler/src/schedule_tracker.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/src/schedule_tracker.py
@@ -16,6 +16,12 @@ logger = logging.getLogger(__name__)
 # Default storage location
 TRACKER_DIR = Path(__file__).parent.parent / "memory"
 
+# Authoritative per-channel daily cap on scheduled shorts.
+# Belt-and-suspenders: the allocator clamps to this value even if a caller
+# passes a larger max_per_day (e.g. a stale registry/config value of 8).
+# Lowering this is the single load-bearing knob to stop over-scheduling.
+HARD_CAP_PER_DAY = 3
+
 # Time jitter: max number of 15-minute steps to shift from base time
 # e.g. MAX_JITTER_STEPS=2 means ±30 min (±2 steps x 15 min)
 MAX_JITTER_STEPS = 2
@@ -204,6 +210,10 @@ class ScheduleTracker:
         if end_date is None:
             end_date = start_date + timedelta(days=60)
 
+        # Authoritative clamp: never schedule more than HARD_CAP_PER_DAY per day,
+        # even if a caller passes a larger max_per_day from a stale registry/config.
+        effective_cap = min(max_per_day, HARD_CAP_PER_DAY)
+
         current = start_date
 
         while current <= end_date:
@@ -213,11 +223,11 @@ class ScheduleTracker:
 
             count = self.get_count(date_str)
 
-            if count < max_per_day:
+            if count < effective_cap:
                 # Determine base time slot, then add jitter for human-like variance
                 base_time = time_slots[count] if count < len(time_slots) else time_slots[-1]
                 time_slot = _add_time_jitter(base_time)
-                slot_label = f"slot {count + 1}/{max_per_day}"
+                slot_label = f"slot {count + 1}/{effective_cap}"
                 logger.info(
                     f"[TRACKER] Allocated: {date_str} at {time_slot} ({slot_label}, base={base_time})"
                 )
@@ -238,8 +248,8 @@ class ScheduleTracker:
         """
         total = sum(self.schedule.values())
         dates_with_videos = {d: c for d, c in self.schedule.items() if c > 0}
-        full_days = sum(1 for c in dates_with_videos.values() if c >= 3)
-        partial_days = sum(1 for c in dates_with_videos.values() if 0 < c < 3)
+        full_days = sum(1 for c in dates_with_videos.values() if c >= HARD_CAP_PER_DAY)
+        partial_days = sum(1 for c in dates_with_videos.values() if 0 < c < HARD_CAP_PER_DAY)
 
         # Date range
         sorted_dates = sorted(dates_with_videos.keys(), key=lambda d: self._parse_date(d))
@@ -288,7 +298,7 @@ class ScheduleTracker:
         for date_str, count in self.schedule.items():
             try:
                 parsed_date = self._parse_date(date_str).date()
-                if parsed_date > today and count >= 3:
+                if parsed_date > today and count >= HARD_CAP_PER_DAY:
                     future_full_days += 1
             except Exception:
                 continue
@@ -312,7 +322,7 @@ class ScheduleTracker:
 
         logger.info(f"[TRACKER] ╔══ SCHEDULE REPORT: {self.channel_id[:12]}... ══╗")
         logger.info(f"[TRACKER] ║ Total scheduled: {total:>4} videos")
-        logger.info(f"[TRACKER] ║ Full days (3/3): {full:>4} days")
+        logger.info(f"[TRACKER] ║ Full days ({HARD_CAP_PER_DAY}/{HARD_CAP_PER_DAY}): {full:>4} days")
         logger.info(f"[TRACKER] ║ Partial days:    {partial:>4} days")
         logger.info(f"[TRACKER] ║ Date range:      {first} → {last}")
         logger.info(f"[TRACKER] ╚{'═' * 44}╝")

--- a/modules/platform_integration/youtube_shorts_scheduler/tests/test_scheduler.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/tests/test_scheduler.py
@@ -19,7 +19,23 @@ from modules.platform_integration.youtube_shorts_scheduler.src.channel_config im
 )
 from modules.platform_integration.youtube_shorts_scheduler.src.schedule_tracker import (
     ScheduleTracker,
+    HARD_CAP_PER_DAY,
+    MAX_JITTER_STEPS,
 )
+
+
+def _within_jitter(actual_time: str, base_time: str, max_steps: int = MAX_JITTER_STEPS) -> bool:
+    """
+    Return True if actual_time is within +/- (max_steps * 15 min) of base_time.
+
+    The allocator applies randomized 15-min-step jitter to each base slot, so
+    exact-time assertions are flaky. This verifies the slot is the expected base
+    slot (i.e. correct ordering) while tolerating the bounded jitter window.
+    """
+    parsed_actual = datetime.strptime(actual_time.strip(), "%I:%M %p")
+    parsed_base = datetime.strptime(base_time.strip(), "%I:%M %p")
+    delta_min = abs((parsed_actual - parsed_base).total_seconds()) / 60.0
+    return delta_min <= max_steps * 15
 from modules.platform_integration.youtube_shorts_scheduler.src.content_generator import (
     generate_clickbait_title,
     extract_title_hint_from_index,
@@ -52,7 +68,11 @@ class TestChannelConfig:
         assert config is not None
         assert config["id"] == "UC-LSSlOZwpGIRIYihaz8zCw"
         assert config["chrome_port"] == 9222
-        assert len(config["time_slots"]) == 3
+        # Density cap is 3/day (was 8). NOTE: the time-slot grid itself is
+        # intentionally NOT reduced in this slice (1-6am window deferred:
+        # Studio timezone is unverified) so slot count is not asserted here.
+        # The HARD_CAP_PER_DAY clamp guarantees <= 3/day regardless of grid size.
+        assert config["max_per_day"] == 3
 
     def test_get_channel_config_undaodu(self):
         """Test UnDaoDu channel config."""
@@ -134,7 +154,7 @@ class TestScheduleTracker:
             assert tracker2.get_count("Jan 6, 2026") == 1
 
     def test_get_next_available_slot_empty(self):
-        """Test finding slot with empty schedule."""
+        """Test finding slot with empty schedule (base slot 0, allowing jitter)."""
         with tempfile.TemporaryDirectory() as tmpdir:
             tracker = ScheduleTracker("test_channel", Path(tmpdir))
             time_slots = ["5:00 AM", "11:00 AM", "5:00 PM"]
@@ -142,10 +162,12 @@ class TestScheduleTracker:
             slot = tracker.get_next_available_slot(time_slots, max_per_day=3)
             assert slot is not None
             date_str, time_str = slot
-            assert time_str == "5:00 AM"  # First slot on empty day
+            # First slot on empty day = base "5:00 AM" +/- jitter (max +/-30 min).
+            # Jitter is randomized, so assert the result is within the slot-0 window.
+            assert _within_jitter(time_str, "5:00 AM")
 
     def test_get_next_available_slot_partial(self):
-        """Test finding slot with partially filled day."""
+        """Test finding slot with partially filled day (rolls to base slot 1)."""
         with tempfile.TemporaryDirectory() as tmpdir:
             tracker = ScheduleTracker("test_channel", Path(tmpdir))
             time_slots = ["5:00 AM", "11:00 AM", "5:00 PM"]
@@ -158,8 +180,8 @@ class TestScheduleTracker:
             slot = tracker.get_next_available_slot(time_slots, max_per_day=3)
             assert slot is not None
             returned_date, time_str = slot
-            # Should get second slot (11:00 AM) on same day
-            assert time_str == "11:00 AM"
+            # Should get second slot (base "11:00 AM") on same day, +/- jitter.
+            assert _within_jitter(time_str, "11:00 AM")
 
     def test_get_summary(self):
         """Test schedule summary."""
@@ -352,3 +374,99 @@ class TestIndexWeave:
         assert stub["video_id"] == "vid123"
         assert stub["indexer"] == "scheduler_stub"
         assert stub["metadata"]["summary"]
+
+
+def _allocate_n(tracker, time_slots, n, max_per_day):
+    """
+    Allocate n videos one at a time, recording each into the tracker.
+
+    Mirrors the scheduler loop: get_next_available_slot -> increment.
+    Returns the list of (date_str, time_str) slots actually allocated
+    (None entries mean the window was exhausted).
+    """
+    allocated = []
+    for i in range(n):
+        slot = tracker.get_next_available_slot(time_slots, max_per_day=max_per_day)
+        if slot is None:
+            allocated.append(None)
+            continue
+        date_str, time_str = slot
+        tracker.increment(date_str, f"vid{i}")
+        allocated.append((date_str, time_str))
+    return allocated
+
+
+class TestScheduleDensityCap:
+    """
+    Density-cap tests for SHORTS_SCHEDULE_DENSITY_AND_WINDOW_PHASE1.
+
+    These prove the authoritative HARD_CAP_PER_DAY clamp at the allocator:
+    no single day may receive more than HARD_CAP_PER_DAY (=3) videos, even
+    when a caller passes a larger max_per_day. NON-VACUOUS: removing the
+    clamp (effective_cap = min(max_per_day, HARD_CAP_PER_DAY)) makes the
+    8/day case below exceed 3 and the assertions fail.
+    """
+
+    def test_hard_cap_constant_is_three(self):
+        assert HARD_CAP_PER_DAY == 3
+
+    def test_allocator_caps_at_three_per_day(self):
+        """Allocating 4 videos with max_per_day=3 must roll the 4th to the next day."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tracker = ScheduleTracker("test_channel", Path(tmpdir))
+            time_slots = ["1:30 AM", "3:30 AM", "5:30 AM"]
+
+            allocated = _allocate_n(tracker, time_slots, n=4, max_per_day=3)
+            assert all(s is not None for s in allocated)
+
+            # No day exceeds 3
+            for date_str, count in tracker.schedule.items():
+                assert count <= 3, f"{date_str} got {count} (>3)"
+
+            # The 4th video rolled to a second, distinct day
+            distinct_days = {s[0] for s in allocated}
+            assert len(distinct_days) == 2
+            # First day holds exactly 3, second day holds exactly 1
+            counts = sorted(tracker.schedule.values(), reverse=True)
+            assert counts == [3, 1]
+
+    def test_clamp_authority_overrides_caller_max_per_day_eight(self):
+        """
+        Even when called with max_per_day=8 (stale registry value), the
+        authoritative clamp must keep every day at <= HARD_CAP_PER_DAY (3).
+        This is the load-bearing belt-and-suspenders guarantee.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tracker = ScheduleTracker("test_channel", Path(tmpdir))
+            time_slots = ["1:30 AM", "3:30 AM", "5:30 AM"]
+
+            # Try to cram 9 videos with the OLD cap of 8 per day.
+            allocated = _allocate_n(tracker, time_slots, n=9, max_per_day=8)
+            assert all(s is not None for s in allocated)
+
+            # Despite max_per_day=8, no day exceeds the hard cap of 3.
+            for date_str, count in tracker.schedule.items():
+                assert count <= HARD_CAP_PER_DAY, f"{date_str} got {count} (>{HARD_CAP_PER_DAY})"
+
+            # 9 videos at 3/day => exactly 3 distinct days, each full.
+            assert len(tracker.schedule) == 3
+            assert sorted(tracker.schedule.values()) == [3, 3, 3]
+
+    def test_report_threshold_matches_effective_cap(self):
+        """
+        get_summary's full/partial day counts must use HARD_CAP_PER_DAY,
+        not a lying hard-coded value. A day with exactly the cap is 'full';
+        one below it is 'partial'.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tracker = ScheduleTracker("test_channel", Path(tmpdir))
+            # One full day (== cap) and one partial day (cap - 1).
+            for i in range(HARD_CAP_PER_DAY):
+                tracker.increment("Jan 5, 2026", f"full{i}")
+            for i in range(HARD_CAP_PER_DAY - 1):
+                tracker.increment("Jan 6, 2026", f"part{i}")
+
+            summary = tracker.get_summary()
+            assert summary["full_days"] == 1
+            assert summary["partial_days"] == 1
+            assert summary["total_scheduled"] == (2 * HARD_CAP_PER_DAY - 1)


### PR DESCRIPTION
## Summary

Stop over-scheduling shorts. Cap each channel at **3/day** (was 8) via an authoritative allocator clamp. The **1-6am window** is **DEFERRED** because the YouTube Studio timezone is unverified (see decision below). Pure config + unit tests; no live browser, no daemon, no models.

**Slice:** SHORTS_SCHEDULE_DENSITY_AND_WINDOW_PHASE1
**Worker-Lane:** SCHED-DENSITY

## Audit context (re-confirmed at edit time)

- Registry defaulted `max_per_day: 8` for all 4 channels (`youtube_channel_registry.py:54,71,88,105`) + a fallback 8 in `_normalize_channel` (`:145`); `channel_config.py:47` fallback 8; scheduler reads it at `scheduler.py:87` and passes it to the allocator (`scheduler.py:411,956`).
- Allocator's only per-day enforcement was `if count < max_per_day:` (`schedule_tracker.py:216`), which honored the config value (8).
- Persisted **runtime** `memory/youtube_channels.json` carries `max_per_day: 8` and an 8-slot 24h grid for all 4 channels (verified live).
- The function default was already `max_per_day=3` and the report threshold was hard-coded to 3, but both were overridden/bypassed by the registry's 8 -> the running system schedules up to 8/day.

## The clamp is the authoritative fix

Added `HARD_CAP_PER_DAY = 3` in `schedule_tracker.py` and clamp at the allocator:

```python
effective_cap = min(max_per_day, HARD_CAP_PER_DAY)
```

Belt-and-suspenders: this caps at 3/day **even when a caller passes 8** (e.g. the stale untracked runtime JSON), so it fixes the running system regardless of config drift. The per-day guard and slot-label now use `effective_cap`.

## Registry / config / JSON change

- `youtube_channel_registry.py`: 4 channel `max_per_day` 8 -> 3, plus `_normalize_channel` fallback 8 -> 3.
- `channel_config.py`: `_build_channel_config` fallback 8 -> 3.
- **`memory/youtube_channels.json` NOT committed.** It is gitignored (`.gitignore:143:memory/`) and absent from a fresh checkout; the runtime copy still carries `max_per_day: 8`. Per scope, it is intentionally NOT committed -- the HARD_CAP_PER_DAY clamp covers the stale value at allocation time. (0102 may want to delete/regenerate the runtime JSON so the new default also flows through `load_registry`, but that is a runtime-ops step, not a code change.)

## Window + timezone decision: DEFERRED (tz unverified)

The 8-slot `_DEFAULT_TIME_SLOTS` grid is **left unchanged**. The scheduler types the bare time string into YouTube Studio (`dom_automation.py` set_schedule_time ~3196) and **deliberately never touches the timezone selector** (guard ~3226-3232). Studio interprets that time in **each account's own configured timezone**, which the code does not read or verify. The registry timezones disagree:

- Move2Japan / UnDaoDu -> `Asia/Tokyo`
- FoundUps / antifaFM -> `America/New_York`

So a fixed "1:30 AM" would publish at different wall-clocks per channel, and 2 of 4 would be wrong for a JST-based 012. Wrong tz = videos publish at the wrong outward-facing time, so per the slice's safety rule the grid change is **deferred until the Studio timezone is verified**. The clamp still confines publishing to the first 3 grid slots (12AM/3AM/6AM) per day.

## Non-vacuity proof

`tests/test_scheduler.py` -> new `TestScheduleDensityCap`:
- `test_allocator_caps_at_three_per_day` -- 4 videos at max_per_day=3 roll the 4th to the next day (counts == [3, 1]).
- `test_clamp_authority_overrides_caller_max_per_day_eight` -- 9 videos with **max_per_day=8** yield exactly 3 days of 3.
- `test_report_threshold_matches_effective_cap`, `test_hard_cap_constant_is_three`.

**Proof:** temporarily reverted the clamp to `effective_cap = max_per_day` and re-ran -> `test_clamp_authority_overrides_caller_max_per_day_eight` FAILED with `AssertionError: Jun 20, 2026 got 8 (>3)`. Restored the clamp -> green. (Two pre-existing flaky exact-time assertions were corrected to a bounded `_within_jitter` helper since the allocator applies +/-30min jitter; `test_get_channel_config_move2japan` now asserts `max_per_day == 3` rather than slot count, since the grid is unchanged.)

Scoped pytest: **34 passed, 2 skipped** (browser integration, correctly skipped).

## Scope / safety

Touched only: `youtube_shorts_scheduler` (schedule_tracker, channel_config, tests, ModLog) + `youtube_channel_registry`. Did NOT touch the live daemon loop, activity_control, auto_moderator_dae, or music-vs-talk R&D. ASCII-clean (no new non-ASCII; pre-existing box-drawing in the report line is inherited, not added).

Leave OPEN at VERIFIED_READY; 0102 reviews + lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
