### PR TITLE
rnd(audio_content_classifier): music-vs-talk PoC — librosa acoustic + whisper no_speech fusion (isolated, not wired)

### DIFF
--- a/modules/ai_intelligence/audio_content_classifier/INTERFACE.md
+++ b/modules/ai_intelligence/audio_content_classifier/INTERFACE.md
@@ -1,0 +1,91 @@
+# INTERFACE - audio_content_classifier (WSP 11)
+
+> R&D PoC. NOT wired into scheduling. Read-only w.r.t. the system.
+
+## Public surface
+
+```python
+from modules.ai_intelligence.audio_content_classifier.src.audio_content_classifier import (
+    classify_content,
+    ClassificationResult,
+    extract_acoustic_features,   # exposed for the live entrypoint / tuning
+    aggregate_stt_signals,       # exposed for fusion + testing
+)
+```
+
+## `classify_content`
+
+```python
+classify_content(
+    audio_or_video_path: str,
+    *,
+    transcript: Optional[str] = None,
+    segments: Optional[list[dict]] = None,
+    sample_rate: int = 16000,
+) -> ClassificationResult
+```
+
+- **audio_or_video_path**: path to a local `.wav`/`.mp3`. (A YouTube `video_id`
+  fetch path is exercised only by `scripts/live_classify.py`, not by this
+  function, to keep the module hermetic.)
+- **transcript** *(optional)*: transcript text. Reserved for the OPTIONAL Gemma
+  tie-breaker in the live entrypoint; accepted so the contract is stable and
+  testable. Does not affect the acoustic decision.
+- **segments** *(optional)*: list of whisper segment dicts. Recognized keys:
+  `no_speech_prob`, `compression_ratio` (openai-whisper standard). When supplied,
+  enables `acoustic+stt_fusion` AND makes the decision deterministically
+  unit-testable without running a model.
+- **sample_rate** *(optional)*: assumed sample rate of the loaded waveform.
+
+### Returns: `ClassificationResult`
+
+| field | type | meaning |
+|---|---|---|
+| `label` | `'music' \| 'talk'` | predicted dominant content (`'talk'` is the fail-safe default) |
+| `confidence` | `float` 0.0-1.0 | `0.0` means **unavailable** (no decision made); success is in `[0.5, 1.0)` |
+| `method` | `'acoustic' \| 'acoustic+stt_fusion' \| 'unavailable'` | which signal path produced the result |
+| `signals` | `dict` | feature values that drove the decision |
+
+### `signals` keys
+
+Always present on a successful (non-`unavailable`) result:
+
+`spectral_flatness`, `harmonic_percussive_ratio`, `zero_crossing_rate`,
+`tempo_bpm`, `beat_strength`, `rms_dynamic_range`, `mfcc_var`, `_score`.
+
+Present only when whisper segments are supplied/available:
+
+`avg_no_speech_prob`, `avg_compression_ratio`.
+
+## Fail-safe contract
+
+`classify_content` **never raises into the caller and never hangs**. On a missing
+file, missing dependency (e.g. `librosa`/`numpy` absent), or an audio
+load/extraction failure, it returns:
+
+```python
+ClassificationResult(label="talk", confidence=0.0, method="unavailable", signals={...partial...})
+```
+
+## Helper functions
+
+```python
+extract_acoustic_features(wav_float32_mono_16k, sample_rate=16000) -> dict
+# librosa-based; raises ImportError if librosa/numpy absent (caller guards it).
+
+aggregate_stt_signals(segments: Optional[list[dict]]) -> dict
+# mean no_speech_prob / compression_ratio over segments; {} when none usable.
+```
+
+## Isolation guarantees (WSP 49 / #819-#820)
+
+- No import of, and no import by, `youtube_shorts_scheduler`.
+- No write/re-index/delete of any index artifact.
+- All heavy/optional integrations (`librosa`, `whisper`, `VideoArchiveExtractor`,
+  Gemma, the LLM `content_category` oracle) are **lazy-imported** behind guards;
+  the module imports cleanly with zero heavy deps installed.
+
+## Tunability
+
+Decision thresholds + weights are externalized in `src/feature_thresholds.py`.
+Overriding a constant changes the decision boundary without editing logic.

--- a/modules/ai_intelligence/audio_content_classifier/ModLog.md
+++ b/modules/ai_intelligence/audio_content_classifier/ModLog.md
@@ -1,0 +1,76 @@
+# ModLog - audio_content_classifier
+
+## 2026-06-19 - PoC creation (Slice: RND_MUSIC_VS_TALK_DETECTION_POC)
+
+**Worker-Lane**: RND-MUSIC-TALK
+**Branch**: rnd/music-vs-talk-detection-poc (off origin/main)
+**WSP**: WSP 00 (zen), WSP 22 (this log), WSP 49 (module structure),
+WSP 84 (reuse-first), WSP 97 (truth boundary / isolation), WSP 11 (interface).
+
+### What was built
+
+An ISOLATED R&D PoC: `audio_content_classifier`, an acoustic music-vs-talk
+discriminator (Approach B). It decides on the **waveform** (librosa) and
+optionally **fuses** openai-whisper segment `no_speech_prob` /
+`compression_ratio`, so sung lyrics that transcribe as words still classify as
+`music` (the lyrics-as-text confound text-only methods fail).
+
+Files:
+- `src/audio_content_classifier.py` - `classify_content`, `extract_acoustic_features`,
+  `aggregate_stt_signals`, `_decide`, `ClassificationResult`. All heavy ops behind
+  lazy imports + guards; fail-safe `method='unavailable'` on missing file/deps.
+- `src/feature_thresholds.py` - externalized `THRESHOLDS` + `WEIGHTS` with per-feature
+  provenance, so the live eval calibrates boundaries without touching logic.
+- `tests/test_decision_logic.py` - hermetic decision tests incl. the confound test.
+- `tests/test_classify_contract.py` - hermetic API/contract + fail-safe tests.
+- `scripts/live_classify.py` - the ONLY place real models/audio run (NOT pytest).
+- `README.md`, `INTERFACE.md`, `requirements.txt`, `tests/README.md`,
+  `tests/TestModLog.md`.
+
+### Why Approach B (and not A or C)
+
+- **A (reuse the existing LLM `content_category` label)**: usually ABSENT for
+  unlisted scheduler shorts (stub artifacts have empty `transcript_summary`;
+  scheduler decoupled per #819/#820) and is an unvalidated emergent prompt
+  property, not a calibrated detector. Reused only as a live **oracle** for
+  agreement, not as a build dependency.
+- **C (Gemma on transcript text)**: by construction sees lyrics-as-text and is
+  fooled by sung words / spoken-word; kept as an OPTIONAL secondary tie-breaker
+  behind a flag in the live entrypoint, never primary.
+- **B**: only candidate runnable offline today with zero new deps (librosa 0.11.0
+  + openai-whisper verified installed; faster-whisper intentionally avoided) and
+  robust to the confound at the signal level. Occam layer discipline: one
+  validated signal-level layer first; fuse A/C only if the eval demands it.
+
+### WSP 84 reuse map (cited file:line)
+
+- librosa MFCC/feature pattern: `acoustic_lab/src/acoustic_processor.py:160`.
+- 16kHz mono audio fetch (unlisted-cookie support):
+  `youtube_live_audio/src/youtube_live_audio.py:405` (cookies `:451`).
+- whisper segment dicts (`no_speech_prob`/`compression_ratio`): openai-whisper
+  `transcribe` standard, consumed as injectable fusion signals.
+- Gemma transcript tie-breaker (optional): `video_indexer/src/gemma_segment_classifier.py:63`
+  (bracket keywords `:99-101`).
+
+### Isolation contract (#819/#820, WSP 49/97)
+
+MUST NOT import from / be imported by `youtube_shorts_scheduler`. No edit to the
+scheduler gate, no change to `executor.py` `classify_content` taxonomy, no new
+content_type branch in the live gate. Read-only: never writes/re-indexes/deletes
+the index artifact. Promotion to scheduling is OUT OF SCOPE - only after the live
+eval passes would a SEPARATE, separately-reviewed slice precompute a music/talk
+label into the artifact the read-only gate already consumes.
+
+### Tests
+
+Scoped unit tests pass (mocked features + injected whisper segment dicts; no
+model, no audio, no network). See `tests/TestModLog.md` for the run summary.
+
+### Deferred to live validation (012, via scripts/live_classify.py)
+
+Real-audio accuracy on a labeled set (~30-50 shorts oversampling the confound
+classes: instrumental FFCPLN, sung-lyrics Suno, rap/spoken-over-beat, plain
+talking-head), threshold calibration in `feature_thresholds.py`, oracle agreement
+%, and the sung-lyrics acceptance gate. Target: >=90% overall AND sung-lyrics
+correctly called `music` on the majority of that subset. No scheduling change
+ships regardless of eval outcome.

--- a/modules/ai_intelligence/audio_content_classifier/README.md
+++ b/modules/ai_intelligence/audio_content_classifier/README.md
@@ -1,0 +1,96 @@
+# audio_content_classifier (R&D PoC)
+
+> [!WARNING]
+> **R&D PoC ONLY - NOT WIRED INTO SCHEDULING.**
+> Slice: `RND_MUSIC_VS_TALK_DETECTION_POC` | Worker-Lane: `RND-MUSIC-TALK`
+> This module is an isolated proof-of-concept. It MUST NOT be imported by, or
+> import from, `modules/platform_integration/youtube_shorts_scheduler`. It does
+> NOT change the scheduler gate, does NOT change the `executor.py` taxonomy, and
+> does NOT add a content_type branch to the live gate. It is read-only with
+> respect to the system: it reads audio/artifacts and never writes, re-indexes,
+> or deletes the index artifact (honoring the #819/#820 decoupling contract).
+
+## Purpose
+
+Answer one question about a short, at the **signal level**: is the dominant
+content **music** or **talk** (a person speaking)?
+
+This is **Approach B**: a `librosa`-based acoustic music/speech discriminator,
+optionally **fused** with `openai-whisper` segment `no_speech_prob` /
+`compression_ratio`.
+
+## Why acoustic (the lyrics-as-text confound)
+
+Text-only methods (transcript keyword gates, Gemma-on-transcript) are fooled by
+**sung lyrics**: a Suno song with words transcribes to words and looks like
+"talk". At the signal level, sung lyrics stay **acoustically music** (sustained
+harmonics, steady beat, low zero-crossing-rate). Deciding on the waveform means
+text presence does not flip the label. This is the only candidate approach
+immune to the lyrics confound, which is why it was selected for the PoC over:
+
+- **A. Reuse the existing LLM `content_category` label** (Gemini analyzer /
+  Studio Ask twin) - usually **absent** for unlisted scheduler shorts (stub
+  artifacts with empty `transcript_summary`), and an unvalidated emergent prompt
+  property. Reused here only as a live **oracle** for agreement, not a build dep.
+- **C. Gemma on transcript text** - by construction can only see lyrics-as-text;
+  kept as an OPTIONAL secondary tie-breaker behind a flag, never primary.
+
+## Install note
+
+- `librosa` (>= 0.11) and `openai-whisper` are **already present** in this repo's
+  environment (verified: librosa 0.11.0, numpy 2.4.4, openai-whisper importable).
+- `faster-whisper` is **intentionally NOT** a dependency (it is not installed).
+- The LIVE video-id path additionally needs `yt-dlp` + `ffmpeg` (+ `soundfile`)
+  for `VideoArchiveExtractor.extract_audio` - required only by the live
+  entrypoint, **never** by the unit tests.
+
+## How to run (live, NOT pytest)
+
+```bash
+# Local clip:
+python -m modules.ai_intelligence.audio_content_classifier.scripts.live_classify --path clip.wav --whisper
+
+# YouTube video id (reuses VideoArchiveExtractor; close live Chrome/Edge first):
+YT_DLP_COOKIES_BROWSER=chrome \
+  python -m modules.ai_intelligence.audio_content_classifier.scripts.live_classify --video-id VIDEOID --whisper --json
+```
+
+The live script prints predicted label, confidence, full signals dict, method,
+and - when an index artifact exists - the existing Gemini/Studio
+`content_category` as an independent **oracle** for agreement.
+
+## Public API
+
+```python
+from modules.ai_intelligence.audio_content_classifier.src.audio_content_classifier \
+    import classify_content, ClassificationResult
+
+result = classify_content("clip.wav", segments=whisper_segments)  # segments optional
+# ClassificationResult(label='music'|'talk', confidence=0.0-1.0, method=..., signals={...})
+```
+
+See `INTERFACE.md` for the full WSP 11 contract.
+
+## WSP 84 reuse map (cited)
+
+| Reused capability | Source (file:line) |
+|---|---|
+| librosa MFCC/feature pattern | `modules/platform_integration/acoustic_lab/src/acoustic_processor.py:160` |
+| 16kHz mono audio fetch (unlisted cookies) | `modules/platform_integration/youtube_live_audio/src/youtube_live_audio.py:405` (cookies at `:451`) |
+| whisper segment dicts (no_speech_prob/compression_ratio) | openai-whisper `transcribe` standard |
+| Gemma transcript tie-breaker (optional) | `modules/ai_intelligence/video_indexer/src/gemma_segment_classifier.py:63` (bracket keywords `:99-101`) |
+| LLM content_category oracle (live cross-check only) | Gemini analyzer / `studio_ask_indexer` `content_category` |
+
+## Tunability
+
+All decision thresholds + weights live in `src/feature_thresholds.py` so the
+live eval and 012 can calibrate boundaries **without touching decision logic**.
+The unit test `test_thresholds_externalized` proves overriding a constant moves
+the boundary.
+
+## What is deferred to live validation
+
+Unit tests are hermetic (mocked features + injected whisper segment dicts; no
+model, no audio, no network). Real-audio accuracy, threshold calibration, and
+the confound-subset acceptance gate are validated by 012 via the live entrypoint
+on a labeled set - see `tests/TestModLog.md` and `ModLog.md`.

--- a/modules/ai_intelligence/audio_content_classifier/requirements.txt
+++ b/modules/ai_intelligence/audio_content_classifier/requirements.txt
@@ -1,0 +1,15 @@
+# audio_content_classifier (R&D PoC) requirements
+#
+# Unit tests require NONE of these (features + whisper segments are mocked/injected).
+# These are needed only for the LIVE entrypoint (scripts/live_classify.py).
+
+librosa>=0.11        # already present in repo env (verified 0.11.0)
+numpy>=2             # already present (verified 2.4.4)
+openai-whisper       # already present (verified importable); STT fusion signals
+
+# faster-whisper deliberately NOT a dependency (it is NOT installed in this env).
+
+# LIVE video-id path only (NOT needed for unit tests):
+#   yt-dlp            # VideoArchiveExtractor.extract_audio (reused)
+#   ffmpeg            # system binary, audio -> 16kHz mono wav
+#   soundfile         # persist fetched float32 audio to a temp .wav

--- a/modules/ai_intelligence/audio_content_classifier/scripts/live_classify.py
+++ b/modules/ai_intelligence/audio_content_classifier/scripts/live_classify.py
@@ -1,0 +1,176 @@
+"""
+live_classify.py - ISOLATED LIVE ENTRYPOINT for the music-vs-talk PoC.
+
+=============================================================================
+THIS IS THE ONLY PLACE REAL MODELS / REAL AUDIO RUN. NEVER EXECUTED IN PYTEST.
+Slice: RND_MUSIC_VS_TALK_DETECTION_POC   Worker-Lane: RND-MUSIC-TALK
+=============================================================================
+
+PURPOSE:
+    012 validates the PoC on labeled real shorts here (NOT via pytest). Given a
+    local .wav/.mp3 OR a YouTube --video-id, this script:
+      1. Loads real audio (librosa, or VideoArchiveExtractor.extract_audio for an
+         id - reused, not reinvented; unlisted via YT_DLP_COOKIES_BROWSER).
+      2. OPTIONALLY transcribes with openai-whisper to harvest real segment
+         no_speech_prob / compression_ratio for acoustic+stt_fusion.
+      3. Calls classify_content and prints label + confidence + full signals.
+      4. OPTIONALLY cross-checks the existing Gemini/Studio content_category
+         ORACLE if an index artifact is present (agreement only; NOT a build dep).
+
+RUN:
+    python -m modules.ai_intelligence.audio_content_classifier.scripts.live_classify --path clip.wav
+    python -m modules.ai_intelligence.audio_content_classifier.scripts.live_classify --video-id VIDEOID --whisper
+    (close any live Chrome/Edge debug session first to avoid the cookie lock.)
+
+WSP 84 reuse:
+    - VideoArchiveExtractor.extract_audio:
+        modules/platform_integration/youtube_live_audio/src/youtube_live_audio.py:405
+    - openai-whisper segment dicts (no_speech_prob/compression_ratio): standard.
+
+ISOLATION: read-only; never writes/re-indexes the artifact; never imports the
+scheduler. All heavy imports are LAZY and inside functions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from typing import Any, Dict, List, Optional
+
+from modules.ai_intelligence.audio_content_classifier.src.audio_content_classifier import (
+    ClassificationResult,
+    classify_content,
+)
+
+
+def _fetch_audio_for_video_id(video_id: str) -> Optional[str]:
+    """Reuse VideoArchiveExtractor to fetch 16kHz mono audio for a video id.
+
+    Returns a local .wav path or None. LAZY import keeps the module hermetic.
+    """
+    try:
+        from modules.platform_integration.youtube_live_audio.src.youtube_live_audio import (
+            VideoArchiveExtractor,
+        )
+        import numpy as np
+        import soundfile as sf  # optional; only the live path needs it
+    except ImportError as exc:
+        print(f"[live_classify] cannot fetch by video-id (missing dep): {exc}", file=sys.stderr)
+        return None
+
+    extractor = VideoArchiveExtractor()
+    audio = extractor.extract_audio(video_id)
+    if audio is None:
+        print(f"[live_classify] extract_audio returned None for {video_id}", file=sys.stderr)
+        return None
+    # Persist the float32 array to a temp wav so classify_content can load it.
+    tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+    sf.write(tmp.name, np.asarray(audio, dtype="float32"), 16000)
+    return tmp.name
+
+
+def _whisper_segments(wav_path: str) -> Optional[List[Dict[str, Any]]]:
+    """Transcribe with openai-whisper and return segment dicts for fusion.
+
+    LAZY import; returns None if whisper is unavailable (acoustic-only fallback).
+    """
+    try:
+        import whisper
+    except ImportError as exc:
+        print(f"[live_classify] whisper unavailable, acoustic-only: {exc}", file=sys.stderr)
+        return None
+    model = whisper.load_model("base")
+    result = model.transcribe(wav_path)
+    segments = result.get("segments", []) or []
+    # Keep only the keys the fusion consumes (no_speech_prob/compression_ratio).
+    return [
+        {
+            "text": s.get("text", ""),
+            "no_speech_prob": s.get("no_speech_prob"),
+            "compression_ratio": s.get("compression_ratio"),
+            "avg_logprob": s.get("avg_logprob"),
+        }
+        for s in segments
+    ]
+
+
+def _oracle_content_category(video_id: Optional[str]) -> Optional[str]:
+    """Best-effort read of the existing Gemini/Studio content_category artifact.
+
+    ORACLE ONLY: used to report agreement, never as a build dependency. Returns
+    None if no artifact is present (the usual case for unlisted scheduler shorts).
+    Implemented as a defensive glob so it never breaks the live run.
+    """
+    if not video_id:
+        return None
+    try:
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[4]
+        # Defensive search across known index artifact roots; read-only.
+        candidates = list(repo_root.glob(f"**/{video_id}*.json"))
+        for c in candidates[:25]:
+            try:
+                data = json.loads(c.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            cat = data.get("content_category") if isinstance(data, dict) else None
+            if cat:
+                return str(cat)
+    except Exception as exc:  # never let the oracle break the run
+        print(f"[live_classify] oracle lookup skipped: {exc}", file=sys.stderr)
+    return None
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Music-vs-talk PoC live classifier (R&D).")
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument("--path", help="local .wav/.mp3 to classify")
+    src.add_argument("--video-id", help="YouTube video id (reuses VideoArchiveExtractor)")
+    parser.add_argument("--whisper", action="store_true", help="run openai-whisper for STT fusion")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    wav_path = args.path
+    if args.video_id:
+        wav_path = _fetch_audio_for_video_id(args.video_id)
+        if not wav_path:
+            print("[live_classify] no audio available; aborting", file=sys.stderr)
+            return 2
+
+    segments = _whisper_segments(wav_path) if args.whisper else None
+    result: ClassificationResult = classify_content(wav_path, segments=segments)
+    oracle = _oracle_content_category(args.video_id)
+
+    payload = {
+        "input": args.path or args.video_id,
+        "label": result.label,
+        "confidence": round(result.confidence, 4),
+        "method": result.method,
+        "signals": {k: (round(v, 5) if isinstance(v, float) else v) for k, v in result.signals.items()},
+        "oracle_content_category": oracle,
+        "oracle_agreement": (
+            None if oracle is None else (
+                (result.label == "music" and "music" in oracle.lower())
+                or (result.label == "talk" and "music" not in oracle.lower())
+            )
+        ),
+    }
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"label      : {payload['label']}")
+        print(f"confidence : {payload['confidence']}")
+        print(f"method     : {payload['method']}")
+        print(f"oracle     : {oracle} (agreement={payload['oracle_agreement']})")
+        print("signals    :")
+        for k, v in payload["signals"].items():
+            print(f"  {k}: {v}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/modules/ai_intelligence/audio_content_classifier/src/__init__.py
+++ b/modules/ai_intelligence/audio_content_classifier/src/__init__.py
@@ -1,0 +1,23 @@
+"""
+audio_content_classifier (R&D PoC) - acoustic music-vs-talk discriminator.
+
+Slice: RND_MUSIC_VS_TALK_DETECTION_POC. NOT wired into scheduling. See README.md.
+
+Public API (WSP 11, see INTERFACE.md):
+    from modules.ai_intelligence.audio_content_classifier.src.audio_content_classifier \
+        import classify_content, ClassificationResult
+"""
+
+from .audio_content_classifier import (
+    ClassificationResult,
+    aggregate_stt_signals,
+    classify_content,
+    extract_acoustic_features,
+)
+
+__all__ = [
+    "ClassificationResult",
+    "classify_content",
+    "extract_acoustic_features",
+    "aggregate_stt_signals",
+]

--- a/modules/ai_intelligence/audio_content_classifier/src/audio_content_classifier.py
+++ b/modules/ai_intelligence/audio_content_classifier/src/audio_content_classifier.py
@@ -1,0 +1,344 @@
+"""
+audio_content_classifier.py - Acoustic music-vs-talk discriminator (R&D PoC).
+
+=============================================================================
+R&D PoC ONLY - NOT WIRED INTO SCHEDULING
+Slice: RND_MUSIC_VS_TALK_DETECTION_POC   Worker-Lane: RND-MUSIC-TALK
+=============================================================================
+
+WHAT THIS IS (Approach B):
+    A librosa-based acoustic music/speech discriminator, OPTIONALLY fused with
+    openai-whisper segment no_speech_prob / compression_ratio. It answers ONE
+    question about a short audio/video: is the dominant content MUSIC or TALK?
+
+WHY ACOUSTIC (the lyrics-as-text confound):
+    Text-only methods (transcript keyword gates, Gemma-on-transcript) are fooled
+    by sung lyrics: a Suno song with words transcribes to words and looks like
+    "talk". At the SIGNAL level, sung lyrics stay acoustically MUSIC (sustained
+    harmonics, steady beat, low ZCR). This module decides on the waveform, so
+    text presence does not flip the label. See feature_thresholds.py for the
+    per-feature provenance.
+
+WSP 84 REUSE MAP (cited file:line):
+    - librosa MFCC/feature extraction pattern:
+        modules/platform_integration/acoustic_lab/src/acoustic_processor.py:160
+        (_extract_fingerprint -> librosa.feature.mfcc, n_mfcc=13)
+    - audio fetch for the LIVE path (16kHz mono float32, unlisted-cookie support):
+        modules/platform_integration/youtube_live_audio/src/youtube_live_audio.py:405
+        (VideoArchiveExtractor.extract_audio; YT_DLP_COOKIES_BROWSER at :451)
+    - whisper segment dicts carry no_speech_prob/avg_logprob/compression_ratio
+        (openai-whisper transcribe standard; consumed here as injectable signals)
+    - Gemma transcript tie-breaker (OPTIONAL, secondary, flag-gated):
+        modules/ai_intelligence/video_indexer/src/gemma_segment_classifier.py:63
+        ([music]/[applause] bracket keywords at :99-101)
+
+WSP 49 / #819-#820 ISOLATION CONTRACT:
+    This module MUST NOT import from, or be imported by,
+    modules/platform_integration/youtube_shorts_scheduler. It is READ-ONLY w.r.t.
+    the system: it reads audio/artifacts, never writes the index artifact, never
+    re-indexes, never deletes. All heavy/optional integrations (librosa, whisper,
+    VideoArchiveExtractor, Gemma) are LAZY-imported behind guards so this module
+    imports cleanly with ZERO heavy deps installed, and unit tests run hermetically
+    by injecting features + whisper segment dicts.
+
+FAIL-SAFE CONTRACT (never raises into a caller, never hangs):
+    On a missing file, missing dependency, or extraction failure, classify_content
+    returns ClassificationResult(label="talk", confidence=0.0, method="unavailable").
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from . import feature_thresholds as ft
+
+logger = logging.getLogger(__name__)
+
+# Documented signal keys always present on a successful (non-unavailable) result.
+ACOUSTIC_SIGNAL_KEYS = (
+    "spectral_flatness",
+    "harmonic_percussive_ratio",
+    "zero_crossing_rate",
+    "tempo_bpm",
+    "beat_strength",
+    "rms_dynamic_range",
+    "mfcc_var",
+)
+# Optional fusion keys (present only when whisper segments are supplied/available).
+STT_SIGNAL_KEYS = (
+    "avg_no_speech_prob",
+    "avg_compression_ratio",
+)
+
+
+@dataclass
+class ClassificationResult:
+    """Result of a music-vs-talk classification.
+
+    Attributes:
+        label: 'music' | 'talk'. On unavailable, fail-safe default is 'talk'.
+        confidence: 0.0-1.0. 0.0 means UNAVAILABLE (no decision was made).
+        method: 'acoustic' | 'acoustic+stt_fusion' | 'unavailable'.
+        signals: dict of the feature values that drove the decision (see
+            ACOUSTIC_SIGNAL_KEYS, optionally STT_SIGNAL_KEYS).
+    """
+
+    label: str
+    confidence: float
+    method: str
+    signals: Dict[str, Any] = field(default_factory=dict)
+
+
+def _unavailable(reason: str, partial_signals: Optional[Dict[str, Any]] = None) -> ClassificationResult:
+    """Build the fail-safe result. Never raises, never hangs."""
+    logger.warning("[AUDIO-CLASSIFY] unavailable: %s", reason)
+    return ClassificationResult(
+        label="talk",
+        confidence=0.0,
+        method="unavailable",
+        signals=dict(partial_signals or {}),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Feature extraction (lazy librosa). Pure-ish: a function of the waveform.
+# Unit tests do NOT call this; they monkeypatch it or call _decide directly.
+# ---------------------------------------------------------------------------
+def extract_acoustic_features(wav_float32_mono_16k, sample_rate: int = 16000) -> Dict[str, float]:
+    """Extract classic music/speech discriminator features via librosa.
+
+    Args:
+        wav_float32_mono_16k: 1-D float32 numpy array, mono, ~16kHz.
+        sample_rate: sample rate of the array (default 16000).
+
+    Returns:
+        dict with every key in ACOUSTIC_SIGNAL_KEYS.
+
+    Raises:
+        ImportError if librosa/numpy are not installed (caller guards this).
+    The librosa.feature.mfcc usage mirrors acoustic_processor.py:189.
+    """
+    import numpy as np  # lazy
+    import librosa  # lazy
+
+    y = np.asarray(wav_float32_mono_16k, dtype=np.float32)
+    if y.ndim > 1:
+        y = np.mean(y, axis=0).astype(np.float32)
+
+    # spectral flatness (tonal vs noise-like)
+    flatness = float(np.mean(librosa.feature.spectral_flatness(y=y)))
+
+    # harmonic / percussive energy ratio via HPSS
+    harmonic, percussive = librosa.effects.hpss(y)
+    h_energy = float(np.sum(harmonic.astype(np.float64) ** 2))
+    p_energy = float(np.sum(percussive.astype(np.float64) ** 2))
+    # sustained-harmonic content relative to total non-percussive baseline
+    denom = p_energy + 1e-9
+    hp_ratio = float(h_energy / denom)
+
+    # zero crossing rate (speech fricatives -> high)
+    zcr = float(np.mean(librosa.feature.zero_crossing_rate(y=y)))
+
+    # tempo + beat strength (music -> stable strong beat)
+    onset_env = librosa.onset.onset_strength(y=y, sr=sample_rate)
+    tempo, _ = librosa.beat.beat_track(onset_envelope=onset_env, sr=sample_rate)
+    tempo_bpm = float(np.atleast_1d(tempo)[0]) if tempo is not None else 0.0
+    beat_strength = float(np.mean(onset_env)) if onset_env.size else 0.0
+
+    # rms dynamic range (speech -> wide range with pauses)
+    rms = librosa.feature.rms(y=y)[0]
+    if rms.size:
+        rms_dynamic_range = float(np.max(rms) - np.min(rms))
+    else:
+        rms_dynamic_range = 0.0
+
+    # mfcc variance over time (weak supporting signal)
+    mfcc = librosa.feature.mfcc(y=y, sr=sample_rate, n_mfcc=13)
+    mfcc_var = float(np.mean(np.var(mfcc, axis=1)))
+
+    return {
+        "spectral_flatness": flatness,
+        "harmonic_percussive_ratio": hp_ratio,
+        "zero_crossing_rate": zcr,
+        "tempo_bpm": tempo_bpm,
+        "beat_strength": beat_strength,
+        "rms_dynamic_range": rms_dynamic_range,
+        "mfcc_var": mfcc_var,
+    }
+
+
+# ---------------------------------------------------------------------------
+# STT fusion signal aggregation. Operates on INJECTED whisper segment dicts so
+# unit tests need no model. Each segment is a dict with optional keys
+# no_speech_prob / compression_ratio (openai-whisper standard).
+# ---------------------------------------------------------------------------
+def aggregate_stt_signals(segments: Optional[List[Dict[str, Any]]]) -> Dict[str, float]:
+    """Aggregate whisper segment dicts into mean fusion signals.
+
+    Returns an empty dict if no usable segments are provided (=> acoustic-only).
+    """
+    if not segments:
+        return {}
+    nsp_vals: List[float] = []
+    cr_vals: List[float] = []
+    for seg in segments:
+        if not isinstance(seg, dict):
+            continue
+        if "no_speech_prob" in seg and seg["no_speech_prob"] is not None:
+            try:
+                nsp_vals.append(float(seg["no_speech_prob"]))
+            except (TypeError, ValueError):
+                pass
+        if "compression_ratio" in seg and seg["compression_ratio"] is not None:
+            try:
+                cr_vals.append(float(seg["compression_ratio"]))
+            except (TypeError, ValueError):
+                pass
+    out: Dict[str, float] = {}
+    if nsp_vals:
+        out["avg_no_speech_prob"] = sum(nsp_vals) / len(nsp_vals)
+    if cr_vals:
+        out["avg_compression_ratio"] = sum(cr_vals) / len(cr_vals)
+    return out
+
+
+def _confidence_from_score(score: float) -> float:
+    """Squash a signed weighted score to a 0.5-1.0 confidence magnitude.
+
+    confidence 1.0 is asymptotic; a score of 0 yields 0.5 (max uncertainty,
+    but still a real decision, distinct from 0.0 == unavailable).
+    """
+    import math
+
+    mag = abs(score) / max(ft.SCORE_CONFIDENCE_SCALE, 1e-9)
+    # logistic-ish squash mapped into [0.5, 1.0)
+    conf = 0.5 + 0.5 * (1.0 - math.exp(-mag))
+    # clamp into a sane, never-exactly-0.0 success band
+    return float(min(0.999, max(0.5, conf)))
+
+
+def _decide(features: Dict[str, float], stt_signals: Optional[Dict[str, float]] = None) -> ClassificationResult:
+    """Core decision: weighted vote over acoustic features (+ optional STT fusion).
+
+    Positive score => MUSIC, negative => TALK. This is the unit under test for
+    the lyrics-confound and rap-over-beat cases; it touches NO disk or model.
+    """
+    stt_signals = stt_signals or {}
+    th = ft.THRESHOLDS
+    w = ft.WEIGHTS
+    score = 0.0
+
+    # spectral_flatness: low => music (+), high => talk (-)
+    sf = features.get("spectral_flatness", 0.5)
+    score += w["spectral_flatness"] * (th["spectral_flatness_music_below"] - sf) / max(th["spectral_flatness_music_below"], 1e-9)
+
+    # harmonic_percussive_ratio: high => music (+)
+    hp = features.get("harmonic_percussive_ratio", 1.0)
+    score += w["harmonic_percussive_ratio"] * (hp - th["harmonic_percussive_ratio_music_above"]) / max(th["harmonic_percussive_ratio_music_above"], 1e-9)
+
+    # zero_crossing_rate: high => talk (-)
+    zcr = features.get("zero_crossing_rate", 0.1)
+    score += w["zero_crossing_rate"] * (th["zero_crossing_rate_talk_above"] - zcr) / max(th["zero_crossing_rate_talk_above"], 1e-9)
+
+    # beat_strength: high => music (+) -- strongest discriminator
+    bs = features.get("beat_strength", 0.0)
+    score += w["beat_strength"] * (bs - th["beat_strength_music_above"]) / max(th["beat_strength_music_above"], 1e-9)
+
+    # tempo_bpm: within a musical band reinforces music (+), else mild talk (-)
+    tempo = features.get("tempo_bpm", 0.0)
+    if th["tempo_bpm_music_low"] <= tempo <= th["tempo_bpm_music_high"]:
+        score += w["tempo_bpm"]
+    else:
+        score -= w["tempo_bpm"] * 0.5
+
+    # rms_dynamic_range: wide => talk (-)
+    rdr = features.get("rms_dynamic_range", 0.0)
+    score += w["rms_dynamic_range"] * (th["rms_dynamic_range_talk_above"] - rdr) / max(th["rms_dynamic_range_talk_above"], 1e-9)
+
+    # mfcc_var: high => talk (-)
+    mv = features.get("mfcc_var", 0.0)
+    score += w["mfcc_var"] * (th["mfcc_var_talk_above"] - mv) / max(th["mfcc_var_talk_above"], 1e-9)
+
+    method = "acoustic"
+
+    # ---- STT fusion (the lyrics-confound defense) ----
+    if stt_signals:
+        method = "acoustic+stt_fusion"
+        nsp = stt_signals.get("avg_no_speech_prob")
+        if nsp is not None and nsp >= th["avg_no_speech_prob_music_above"]:
+            # whisper itself doubts speech despite emitting words => nudge MUSIC
+            score += w["avg_no_speech_prob"]
+        cr = stt_signals.get("avg_compression_ratio")
+        if cr is not None and cr >= th["avg_compression_ratio_music_above"]:
+            score += w["avg_compression_ratio"]
+
+    label = "music" if score >= ft.DECISION_DEADZONE else "talk"
+    confidence = _confidence_from_score(score)
+
+    signals: Dict[str, Any] = {k: features.get(k) for k in ACOUSTIC_SIGNAL_KEYS}
+    for k in STT_SIGNAL_KEYS:
+        if k in stt_signals:
+            signals[k] = stt_signals[k]
+    signals["_score"] = score
+
+    return ClassificationResult(label=label, confidence=confidence, method=method, signals=signals)
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator (public API). Wires extraction -> fusion -> decision, all behind
+# lazy imports + guards. The LIVE audio fetch path is reused, not reinvented.
+# ---------------------------------------------------------------------------
+def classify_content(
+    audio_or_video_path: str,
+    *,
+    transcript: Optional[str] = None,
+    segments: Optional[List[Dict[str, Any]]] = None,
+    sample_rate: int = 16000,
+) -> ClassificationResult:
+    """Classify a short's dominant content as 'music' or 'talk'.
+
+    Args:
+        audio_or_video_path: Path to a local .wav/.mp3 (the audio is loaded via
+            librosa). A YouTube video_id LIVE path is exercised only by
+            scripts/live_classify.py, not here.
+        transcript: OPTIONAL transcript text (currently unused by the acoustic
+            decision; reserved for the OPTIONAL Gemma tie-breaker in the live
+            entrypoint, and accepted so the contract is stable + testable).
+        segments: OPTIONAL list of whisper segment dicts (no_speech_prob /
+            compression_ratio). When supplied, enables acoustic+stt_fusion AND
+            makes the decision deterministically unit-testable without a model.
+        sample_rate: sample rate to assume for the loaded waveform.
+
+    Returns:
+        ClassificationResult. Never raises into the caller; on any failure
+        returns method='unavailable', label='talk', confidence=0.0.
+    """
+    # Fail-safe: missing file.
+    if not audio_or_video_path or not os.path.exists(audio_or_video_path):
+        return _unavailable(f"path missing: {audio_or_video_path!r}")
+
+    # Lazy-load the waveform (guard missing deps).
+    try:
+        import numpy as np  # noqa: F401  (guard only)
+        import librosa
+    except ImportError as exc:  # deps absent => fail-safe, never hang/raise
+        return _unavailable(f"librosa/numpy unavailable: {exc}")
+
+    try:
+        y, sr = librosa.load(audio_or_video_path, sr=sample_rate, mono=True)
+    except Exception as exc:  # corrupt/unsupported file => fail-safe
+        return _unavailable(f"audio load failed: {exc}")
+
+    # Extract features (guarded).
+    try:
+        features = extract_acoustic_features(y, sample_rate=sr)
+    except Exception as exc:
+        return _unavailable(f"feature extraction failed: {exc}")
+
+    # Fuse any provided STT segment signals (no model call here).
+    stt_signals = aggregate_stt_signals(segments)
+
+    return _decide(features, stt_signals)

--- a/modules/ai_intelligence/audio_content_classifier/src/feature_thresholds.py
+++ b/modules/ai_intelligence/audio_content_classifier/src/feature_thresholds.py
@@ -1,0 +1,105 @@
+"""
+feature_thresholds.py - Externalized decision thresholds and weights.
+
+R&D PoC ONLY (Slice: RND_MUSIC_VS_TALK_DETECTION_POC). NOT wired into scheduling.
+
+WHY THIS FILE EXISTS (WSP 5 tunability):
+    The acoustic music-vs-talk discriminator decides via a weighted score over
+    classic music/speech discriminator features. Keeping every threshold and
+    weight in named constants here lets the live eval (scripts/live_classify.py)
+    and 012 calibrate decision boundaries WITHOUT touching decision logic in
+    audio_content_classifier.py. Unit test test_thresholds_externalized proves
+    that overriding a constant moves the boundary.
+
+PROVENANCE OF FEATURES (classic music/speech discrimination, signal-level):
+    spectral_flatness        - Music is more tonal/structured across a sustained
+                               window; high flatness => noise-like, low flatness
+                               => tonal. Sustained tonal energy (instruments,
+                               sung notes) trends toward MUSIC. librosa.feature.
+                               spectral_flatness.
+    harmonic_percussive_ratio- Music carries strong harmonic + percussive energy
+                               (HPSS); speech is dominated by transient, less
+                               sustained harmonic structure. librosa.effects.hpss.
+                               HIGH ratio (sustained harmonics) => MUSIC.
+    zero_crossing_rate       - Speech (esp. fricatives/consonants) has HIGH ZCR;
+                               sustained musical tones have LOWER ZCR. HIGH ZCR
+                               => TALK. librosa.feature.zero_crossing_rate.
+    tempo_bpm / beat_strength- Music has a stable tempo and strong beat;
+                               speech does not. STRONG beat => MUSIC.
+                               librosa.beat.beat_track / onset envelope.
+    rms_dynamic_range        - Speech has wide RMS dynamics (pauses between
+                               phrases, syllable stress); music (esp. mastered
+                               shorts) is more compressed/sustained. WIDE range
+                               => TALK. librosa.feature.rms.
+    mfcc_var                 - Variance of MFCCs over time; speech timbre shifts
+                               rapidly (phonemes), sustained music is steadier in
+                               some bands but lyric singing varies - used as a
+                               weak supporting signal only.
+
+FUSION SIGNALS (openai-whisper segment dicts, OPTIONAL):
+    avg_no_speech_prob       - Mean whisper segment no_speech_prob. HIGH => the
+                               STT model itself judged "no speech" even if it
+                               still emitted tokens (the sung-lyrics confound).
+    avg_compression_ratio    - Abnormally high whisper compression_ratio is a
+                               known marker of repetitive/degenerate text often
+                               seen when transcribing music; treated as a weak
+                               MUSIC nudge.
+
+NOTE: thresholds below are STARTING POINTS for the live eval. They are explicitly
+documented as un-calibrated until the labeled-set run in TestModLog.md scores them.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Per-feature decision thresholds (a feature votes "music" or "talk" relative
+# to its threshold; magnitude of crossing feeds the weighted score).
+# ---------------------------------------------------------------------------
+THRESHOLDS = {
+    # spectral_flatness: BELOW this leans MUSIC (tonal), ABOVE leans noise/talk.
+    "spectral_flatness_music_below": 0.30,
+    # harmonic_percussive_ratio: ABOVE this leans MUSIC (sustained harmonics).
+    "harmonic_percussive_ratio_music_above": 1.6,
+    # zero_crossing_rate: ABOVE this leans TALK (fricatives/consonants).
+    "zero_crossing_rate_talk_above": 0.12,
+    # beat_strength: ABOVE this leans MUSIC (stable strong beat).
+    "beat_strength_music_above": 0.45,
+    # tempo_bpm: a plausible musical tempo band reinforces MUSIC.
+    "tempo_bpm_music_low": 60.0,
+    "tempo_bpm_music_high": 180.0,
+    # rms_dynamic_range: ABOVE this leans TALK (wide dynamics / pauses).
+    "rms_dynamic_range_talk_above": 0.22,
+    # mfcc_var: ABOVE this leans TALK (rapid timbral phoneme shifts).
+    "mfcc_var_talk_above": 55.0,
+    # avg_no_speech_prob: ABOVE this is a strong MUSIC fusion nudge even when
+    # words were transcribed (the lyrics confound defense).
+    "avg_no_speech_prob_music_above": 0.50,
+    # avg_compression_ratio: ABOVE this is a weak MUSIC fusion nudge.
+    "avg_compression_ratio_music_above": 2.4,
+}
+
+# ---------------------------------------------------------------------------
+# Weights for the weighted vote. Acoustic signals dominate (signal-level
+# robustness to the lyrics-as-text confound); STT fusion signals are additive
+# nudges, never strong enough alone to flip a clear acoustic decision.
+# Positive contribution => MUSIC, negative => TALK.
+# ---------------------------------------------------------------------------
+WEIGHTS = {
+    "spectral_flatness": 1.0,
+    "harmonic_percussive_ratio": 1.4,
+    "zero_crossing_rate": 1.2,
+    "beat_strength": 1.6,        # strongest single acoustic discriminator
+    "tempo_bpm": 0.6,
+    "rms_dynamic_range": 1.0,
+    "mfcc_var": 0.5,            # weak supporting signal
+    # fusion (only applied when whisper segments are injected/available)
+    "avg_no_speech_prob": 1.1,  # confound defense, but < combined acoustic weight
+    "avg_compression_ratio": 0.4,
+}
+
+# Score (sum of signed weighted votes) is squashed to confidence via this scale.
+# Larger => need stronger evidence to reach high confidence.
+SCORE_CONFIDENCE_SCALE = 4.0
+
+# Minimum |score| treated as a real decision; below this confidence stays modest.
+DECISION_DEADZONE = 0.0

--- a/modules/ai_intelligence/audio_content_classifier/tests/README.md
+++ b/modules/ai_intelligence/audio_content_classifier/tests/README.md
@@ -1,0 +1,38 @@
+# tests - audio_content_classifier
+
+Hermetic unit tests for the music-vs-talk PoC. **No live models, no real audio,
+no network.** Every test injects crafted feature vectors and/or whisper segment
+dicts and asserts the real decision logic.
+
+## Run (scoped)
+
+```bash
+python -m pytest modules/ai_intelligence/audio_content_classifier/tests/ -q
+```
+
+## Files
+
+- `test_decision_logic.py` - core `_decide` behavior:
+  - pure-music features -> `music` (confidence > 0.7)
+  - pure-speech features -> `talk` (confidence > 0.7)
+  - **lyrics confound**: acoustically-music features + transcribed words +
+    high `avg_no_speech_prob` -> still `music` (the key proof)
+  - rap/spoken-over-beat tie-break -> `music`, method `acoustic+stt_fusion`
+  - thresholds externalized: overriding a constant moves the boundary
+  - stt aggregation edge cases
+- `test_classify_contract.py` - `classify_content` wiring + fail-safe:
+  - extractor + audio load mocked -> features flow to `_decide`
+  - segments flip method to `acoustic+stt_fusion`
+  - fail-safe: missing file / missing deps / audio load failure -> `unavailable`
+  - documented signal keys present; result shape matches contract
+
+## Why no `importorskip` on heavy models
+
+Extraction and STT are always mocked or injected, so the tests never need
+librosa/whisper at runtime. The module also imports cleanly with zero heavy deps
+(guarded lazy imports), which is asserted directly.
+
+## What is NOT tested here (deferred to live)
+
+Real-audio accuracy, threshold calibration, and the confound-subset acceptance
+gate run via `scripts/live_classify.py` on a 012-labeled set. See `TestModLog.md`.

--- a/modules/ai_intelligence/audio_content_classifier/tests/TestModLog.md
+++ b/modules/ai_intelligence/audio_content_classifier/tests/TestModLog.md
@@ -1,0 +1,44 @@
+# TestModLog - audio_content_classifier
+
+## 2026-06-19 - Initial hermetic unit suite (Slice: RND_MUSIC_VS_TALK_DETECTION_POC)
+
+**Command**:
+```
+python -m pytest modules/ai_intelligence/audio_content_classifier/tests/ -q
+```
+
+**Result**: `14 passed in 0.32s`
+
+**Coverage of decision logic (non-vacuous, no model / no audio / no network)**:
+
+| test | asserts |
+|---|---|
+| test_decide_pure_music_features | instrumental features -> `music`, conf > 0.7, method `acoustic` |
+| test_decide_pure_speech_features | speech features -> `talk`, conf > 0.7, method `acoustic` |
+| test_lyrics_confound_sung_words | acoustically-music + transcribed words + high `avg_no_speech_prob` -> STILL `music` (confound defense) |
+| test_rap_spoken_over_beat | strong-beat tie-break -> `music`, method `acoustic+stt_fusion` |
+| test_thresholds_externalized | overriding a `feature_thresholds` constant moves the boundary |
+| test_aggregate_stt_signals_empty | no/malformed segments -> `{}` (acoustic-only), never raises |
+| test_module_imports_without_heavy_deps | module reload imports cleanly (guarded lazy deps) |
+| test_classify_content_mocks_extractor | extractor + load mocked -> features flow to `_decide` |
+| test_classify_content_fusion_via_segments | injected segments -> method `acoustic+stt_fusion` |
+| test_failsafe_missing_file | missing path -> `talk`/0.0/`unavailable`, no exception |
+| test_failsafe_missing_deps | simulated `ImportError` on librosa -> `unavailable`, no hang/raise |
+| test_failsafe_audio_load_failure | `librosa.load` raising -> `unavailable` |
+| test_signals_dict_keys_present | every documented acoustic signal key present |
+| test_classification_result_shape | result fields match the WSP 11 contract |
+
+**AST check**: `py_compile` OK on all `src/`, `scripts/`, `tests/` files.
+**ASCII check**: all source + doc files 0 non-ASCII bytes (`.pyc` caches gitignored).
+
+## Deferred to LIVE validation (012, NOT pytest)
+
+Run via `scripts/live_classify.py` on a 012-labeled set (~30-50 real shorts,
+oversampling confound classes: instrumental FFCPLN, sung-lyrics Suno,
+rap/spoken-over-beat, plain talking-head). Score a confusion matrix vs
+`true_label`, overall accuracy, and **per-confound-class** accuracy. The
+sung-lyrics row is the acceptance gate. Target: >=90% overall AND sung-lyrics
+correctly called `music` on the majority of that subset. Calibrate via
+`feature_thresholds.py` constants and re-run; logic untouched. Cross-check the
+existing Gemini/Studio `content_category` oracle for agreement where present.
+Record live results here when run.

--- a/modules/ai_intelligence/audio_content_classifier/tests/test_classify_contract.py
+++ b/modules/ai_intelligence/audio_content_classifier/tests/test_classify_contract.py
@@ -1,0 +1,121 @@
+"""
+test_classify_contract.py - Hermetic API/contract + fail-safe tests.
+
+NO live models, NO real audio, NO network. The orchestrator classify_content is
+exercised with extract_acoustic_features and audio loading monkeypatched, so the
+wiring (features -> _decide) is asserted without touching disk or any model.
+
+Slice: RND_MUSIC_VS_TALK_DETECTION_POC
+"""
+
+import builtins
+
+import pytest
+
+from modules.ai_intelligence.audio_content_classifier.src import audio_content_classifier as acc
+
+
+def _music_features():
+    return {
+        "spectral_flatness": 0.10,
+        "harmonic_percussive_ratio": 3.5,
+        "zero_crossing_rate": 0.05,
+        "tempo_bpm": 120.0,
+        "beat_strength": 0.85,
+        "rms_dynamic_range": 0.08,
+        "mfcc_var": 20.0,
+    }
+
+
+def test_classify_content_mocks_extractor(monkeypatch, tmp_path):
+    """classify_content wires extracted features -> _decide, never touching a model.
+
+    We monkeypatch the librosa load + feature extraction so no real audio/model
+    runs; the path merely needs to exist for the fail-safe gate to pass.
+    """
+    fake_path = tmp_path / "clip.wav"
+    fake_path.write_bytes(b"RIFF....")  # existence only; never really decoded
+
+    # Stub librosa.load to return a dummy waveform without decoding the bytes.
+    import types
+    fake_librosa = types.SimpleNamespace(load=lambda *a, **k: ([0.0, 0.1, 0.0], 16000))
+    monkeypatch.setitem(__import__("sys").modules, "librosa", fake_librosa)
+    monkeypatch.setattr(acc, "extract_acoustic_features", lambda *a, **k: _music_features())
+
+    result = acc.classify_content(str(fake_path))
+    assert result.label == "music"
+    assert result.method in ("acoustic", "acoustic+stt_fusion")
+    assert result.confidence > 0.0
+
+
+def test_classify_content_fusion_via_segments(monkeypatch, tmp_path):
+    """Injected segments flip method to acoustic+stt_fusion through classify_content."""
+    fake_path = tmp_path / "clip.wav"
+    fake_path.write_bytes(b"RIFF....")
+    import types
+    fake_librosa = types.SimpleNamespace(load=lambda *a, **k: ([0.0, 0.1], 16000))
+    monkeypatch.setitem(__import__("sys").modules, "librosa", fake_librosa)
+    monkeypatch.setattr(acc, "extract_acoustic_features", lambda *a, **k: _music_features())
+
+    segments = [{"text": "sung words", "no_speech_prob": 0.8, "compression_ratio": 2.6}]
+    result = acc.classify_content(str(fake_path), segments=segments)
+    assert result.method == "acoustic+stt_fusion"
+    assert result.label == "music"
+
+
+def test_failsafe_missing_file():
+    """Nonexistent path -> unavailable fail-safe, no exception."""
+    result = acc.classify_content("/no/such/file/at/all.wav")
+    assert result.label == "talk"
+    assert result.confidence == 0.0
+    assert result.method == "unavailable"
+
+
+def test_failsafe_missing_deps(monkeypatch, tmp_path):
+    """Simulated ImportError on librosa -> unavailable, no hang/raise."""
+    fake_path = tmp_path / "clip.wav"
+    fake_path.write_bytes(b"RIFF....")
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "librosa":
+            raise ImportError("simulated: librosa not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    result = acc.classify_content(str(fake_path))
+    assert result.method == "unavailable"
+    assert result.label == "talk"
+    assert result.confidence == 0.0
+
+
+def test_failsafe_audio_load_failure(monkeypatch, tmp_path):
+    """librosa.load raising (corrupt file) -> unavailable, no exception escapes."""
+    fake_path = tmp_path / "clip.wav"
+    fake_path.write_bytes(b"not-audio")
+    import types
+
+    def _boom(*a, **k):
+        raise RuntimeError("corrupt audio")
+
+    fake_librosa = types.SimpleNamespace(load=_boom)
+    monkeypatch.setitem(__import__("sys").modules, "librosa", fake_librosa)
+    result = acc.classify_content(str(fake_path))
+    assert result.method == "unavailable"
+
+
+def test_signals_dict_keys_present():
+    """Every successful result exposes all documented acoustic signal keys."""
+    result = acc._decide(_music_features())
+    for key in acc.ACOUSTIC_SIGNAL_KEYS:
+        assert key in result.signals, f"missing documented signal key: {key}"
+
+
+def test_classification_result_shape():
+    """ClassificationResult fields match the published contract."""
+    result = acc._decide(_music_features())
+    assert result.label in ("music", "talk")
+    assert 0.0 <= result.confidence <= 1.0
+    assert result.method in ("acoustic", "acoustic+stt_fusion", "unavailable")
+    assert isinstance(result.signals, dict)

--- a/modules/ai_intelligence/audio_content_classifier/tests/test_decision_logic.py
+++ b/modules/ai_intelligence/audio_content_classifier/tests/test_decision_logic.py
@@ -1,0 +1,149 @@
+"""
+test_decision_logic.py - Hermetic unit tests for the music-vs-talk decision.
+
+NO live models, NO audio files, NO network. Every test injects crafted feature
+vectors and/or whisper segment dicts and asserts the REAL decision logic in
+_decide. This is the non-vacuous core: it proves the lyrics-as-text confound is
+defeated at the signal level (the whole reason Approach B was chosen).
+
+Slice: RND_MUSIC_VS_TALK_DETECTION_POC
+"""
+
+import importlib
+
+import pytest
+
+from modules.ai_intelligence.audio_content_classifier.src import audio_content_classifier as acc
+from modules.ai_intelligence.audio_content_classifier.src import feature_thresholds as ft
+
+
+def _music_features():
+    """Hand-crafted instrumental-music feature vector."""
+    return {
+        "spectral_flatness": 0.10,          # tonal -> music
+        "harmonic_percussive_ratio": 3.5,   # sustained harmonics -> music
+        "zero_crossing_rate": 0.05,         # low ZCR -> music
+        "tempo_bpm": 120.0,                 # stable musical tempo
+        "beat_strength": 0.85,              # strong beat -> music
+        "rms_dynamic_range": 0.08,          # compressed/sustained -> music
+        "mfcc_var": 20.0,                   # steady timbre
+    }
+
+
+def _speech_features():
+    """Hand-crafted talking-head speech feature vector."""
+    return {
+        "spectral_flatness": 0.55,          # noise-like -> talk
+        "harmonic_percussive_ratio": 0.6,   # weak sustained harmonics -> talk
+        "zero_crossing_rate": 0.22,         # high ZCR (fricatives) -> talk
+        "tempo_bpm": 0.0,                   # no stable tempo
+        "beat_strength": 0.10,              # no beat -> talk
+        "rms_dynamic_range": 0.45,          # wide dynamics / pauses -> talk
+        "mfcc_var": 95.0,                   # rapid phoneme shifts -> talk
+    }
+
+
+def test_decide_pure_music_features():
+    """Instrumental-music features -> music, confidence > 0.7."""
+    result = acc._decide(_music_features())
+    assert result.label == "music"
+    assert result.confidence > 0.7
+    assert result.method == "acoustic"
+
+
+def test_decide_pure_speech_features():
+    """Speech features -> talk, confidence > 0.7."""
+    result = acc._decide(_speech_features())
+    assert result.label == "talk"
+    assert result.confidence > 0.7
+    assert result.method == "acoustic"
+
+
+def test_lyrics_confound_sung_words():
+    """THE CONFOUND TEST.
+
+    Features are acoustically MUSIC, but we inject whisper segments containing
+    real transcribed WORDS plus a HIGH avg_no_speech_prob (whisper itself doubts
+    speech). Fusion must STILL return 'music' -> proves text presence does not
+    flip the label, which is exactly where text-only methods fail.
+    """
+    features = _music_features()
+    # whisper transcribed lyrics-as-words yet flagged high no_speech_prob
+    segments = [
+        {"text": "we are the champions my friend", "no_speech_prob": 0.82, "compression_ratio": 2.6},
+        {"text": "and we'll keep on fighting", "no_speech_prob": 0.77, "compression_ratio": 2.7},
+    ]
+    stt = acc.aggregate_stt_signals(segments)
+    result = acc._decide(features, stt)
+    assert result.label == "music"
+    assert result.method == "acoustic+stt_fusion"
+    # fusion signals must be surfaced for auditability
+    assert "avg_no_speech_prob" in result.signals
+    assert result.signals["avg_no_speech_prob"] >= 0.7
+
+
+def test_rap_spoken_over_beat():
+    """Borderline rap/spoken-over-beat: words + steady strong beat + speech-like ZCR.
+
+    Documented tie-break: beat_strength threshold wins -> 'music'. Method must be
+    acoustic+stt_fusion because whisper segments are supplied.
+    """
+    features = {
+        "spectral_flatness": 0.32,          # slightly noisy
+        "harmonic_percussive_ratio": 1.7,   # moderate harmonics
+        "zero_crossing_rate": 0.14,         # speech-ish ZCR
+        "tempo_bpm": 95.0,                  # hip-hop tempo band
+        "beat_strength": 0.80,              # STRONG beat -> tie-break to music
+        "rms_dynamic_range": 0.20,          # moderate
+        "mfcc_var": 50.0,                   # moderate
+    }
+    segments = [
+        {"text": "spitting bars over this beat", "no_speech_prob": 0.30, "compression_ratio": 2.1},
+    ]
+    stt = acc.aggregate_stt_signals(segments)
+    result = acc._decide(features, stt)
+    assert result.label == "music"
+    assert result.method == "acoustic+stt_fusion"
+
+
+def test_thresholds_externalized(monkeypatch):
+    """Overriding a feature_thresholds constant moves the decision boundary,
+    proving tunability without touching decision logic (live-eval calibration).
+    """
+    # A near-neutral feature set that lands on 'talk' by default.
+    features = {
+        "spectral_flatness": 0.30,
+        "harmonic_percussive_ratio": 1.5,
+        "zero_crossing_rate": 0.12,
+        "tempo_bpm": 200.0,                 # outside default musical band
+        "beat_strength": 0.40,              # just below default music threshold
+        "rms_dynamic_range": 0.22,
+        "mfcc_var": 55.0,
+    }
+    baseline = acc._decide(features)
+
+    # Lower the beat threshold so this same vector now reads as music.
+    patched = dict(ft.THRESHOLDS)
+    patched["beat_strength_music_above"] = 0.20
+    patched["tempo_bpm_music_high"] = 220.0
+    monkeypatch.setattr(ft, "THRESHOLDS", patched)
+    tuned = acc._decide(features)
+
+    assert baseline.label != tuned.label or baseline.signals["_score"] < tuned.signals["_score"]
+    # specifically: the tuned, looser thresholds should now classify as music
+    assert tuned.label == "music"
+
+
+def test_aggregate_stt_signals_empty():
+    """No segments -> empty fusion dict (acoustic-only path)."""
+    assert acc.aggregate_stt_signals(None) == {}
+    assert acc.aggregate_stt_signals([]) == {}
+    # malformed entries are ignored, not raised
+    assert acc.aggregate_stt_signals([{"text": "no probs here"}, "not-a-dict"]) == {}
+
+
+def test_module_imports_without_heavy_deps():
+    """The module must import cleanly even if heavy deps are absent (guarded)."""
+    mod = importlib.reload(acc)
+    assert hasattr(mod, "classify_content")
+    assert hasattr(mod, "ClassificationResult")


### PR DESCRIPTION
**R&D / PoC — isolated module, not wired into core scheduling.** Tests the music-vs-talk detection 012 asked about, via a WSP_00/97 worker swarm (discover -> design -> build -> adversarial verify).

## Why not reuse the LLM content_category
Discovery found the existing `content_category` (gemini/studio-ask) is (a) usually **absent** for unlisted scheduler shorts (stub artifacts, empty transcript) and (b) an unvalidated emergent prompt property — not a calibrated detector. So reuse-first pointed at the **installed primitives** instead.

## What this builds (Approach B)
`modules/ai_intelligence/audio_content_classifier/` — a **librosa acoustic discriminator** (spectral flatness, HPSS harmonic/percussive ratio, ZCR, tempo/beat strength, RMS dynamics, MFCC variance) **fused with openai-whisper `no_speech_prob`**. Signal-level => **immune to the lyrics-as-text confound**. librosa 0.11 + openai-whisper already installed; faster-whisper deliberately avoided (not installed).

- **14 hermetic unit tests pass** (mock features/whisper dicts; NO live models/audio/network).
- Live validation **deferred** to `scripts/live_classify.py` (012 supplies ~30-50 labeled real shorts; never runs in pytest).
- **Not wired into the scheduler** — if validated, it precomputes a label into the artifact the read-only gate already consumes.

Adversarial verify: PASS (isolation_ok, reuse_ok, tests_nonvacuous, decision soundness empirically checked — STT fusion is a bounded nudge that cannot override a clear acoustic call).