### PR TITLE
fix(youtube_shorts_scheduler): US-ET peak slots (morning/lunch/evening) + per-channel Studio-tz conversion

### DIFF
--- a/modules/infrastructure/shared_utilities/youtube_channel_registry.py
+++ b/modules/infrastructure/shared_utilities/youtube_channel_registry.py
@@ -28,10 +28,14 @@ _REGISTRY_PATH = Path(__file__).resolve().parent / "memory" / "youtube_channels.
 _CHROME_PORT = 9222
 _EDGE_PORT = 9223
 
-_DEFAULT_TIME_SLOTS = [
-    "12:00 AM", "3:00 AM", "6:00 AM", "9:00 AM",
-    "12:00 PM", "3:00 PM", "6:00 PM", "9:00 PM",
-]
+# Canonical US-Eastern (ET) peak publish slots: morning / lunch / evening.
+# ALL shorts target the US audience, so optimum times are expressed in ET and
+# converted per-channel to the channel's Studio-account tz before typing.
+# The authoritative, env-configurable (SHORTS_PEAK_SLOTS_ET) definition and the
+# DST-aware conversion live in:
+#   modules/platform_integration/youtube_shorts_scheduler/src/peak_window.py
+# These literals are the inert default mirror (24h ET) persisted to the registry.
+_DEFAULT_TIME_SLOTS = ["08:00", "12:00", "20:00"]
 
 
 def _default_channels() -> List[Dict[str, Any]]:

--- a/modules/platform_integration/youtube_shorts_scheduler/ModLog.md
+++ b/modules/platform_integration/youtube_shorts_scheduler/ModLog.md
@@ -1,5 +1,72 @@
 # YouTube Shorts Scheduler - ModLog
 
+## 2026-06-19 - US-ET peak slots + per-channel Studio-tz conversion (Phase 1)
+
+**By:** 0102 (Worker-Lane SCHED-WINDOW)
+**Slice:** SHORTS_SCHEDULE_US_PEAK_WINDOW_PHASE1
+**WSP References:** WSP 22 (ModLog), WSP 49 (Structure), WSP 50 (Pre-Action), WSP 84 (Code Reuse), WSP 97 (Truth Signaling)
+
+### Problem
+
+The prior slice (#844) capped the day at 3 but DEFERRED the publish window because the Studio
+timezone was unverified. Shorts target the US audience, but 012 posts from Japan and two of four
+channels run on Asia/Tokyo Studio accounts. The old `_DEFAULT_TIME_SLOTS` was a 24h grid whose
+first three slots (12AM/3AM/6AM ET-ish) were graveyard hours for US viewers, and a bare time typed
+into a Tokyo Studio account publishes at that time IN JST -- the wrong US wall-clock.
+
+### Phase 0 confirmation (verified, not assumed)
+
+1. **Bare-time-in-account-tz model CONFIRMED.** `src/dom_automation.py` `set_schedule_time`
+   (~3098) types the bare time string via `slow_type` (~3196) and never touches the timezone
+   selector; `click_done` explicitly guards against the timezone-select-button (~3214, ~3226-3232).
+   Studio interprets the typed time in each ACCOUNT's own tz.
+2. **Registry tz == Studio ACCOUNT tz CONFIRMED.** The `timezone` field in
+   `youtube_channel_registry.py` (Move2Japan/UnDaoDu = `Asia/Tokyo`; FoundUps/antifaFM =
+   `America/New_York`) is the Studio account tz -- corroborated by the #844 commit body, which
+   states Studio "interprets it in each account's own tz (Asia/Tokyo for Move2Japan/UnDaoDu vs
+   America/New_York for FoundUps/antifaFM)". This is the authoritative source; we did NOT have to
+   STOP.
+3. **Python tz support.** `zoneinfo` requires `tzdata` on Windows, which is NOT installed; `pytz`
+   IS installed (2026.1) and is already a repo dependency (stream_resolver, social_media_orchestrator,
+   foundups). Used `pytz` to avoid a runtime ModuleNotFoundError on the Windows host (WSP 84 reuse).
+
+### Changes (minimal)
+
+1. **Canonical ET peaks defined ONCE.** New pure module `src/peak_window.py` holds the research-
+   backed US-Eastern peaks -- morning ~08:00, lunch ~12:00, evening ~20:00 ET -- configurable via
+   env `SHORTS_PEAK_SLOTS_ET` (e.g. "08:00,12:00,20:00"). Three slots match the landed 3/day cap.
+2. **Pure DST-aware conversion.** `convert_et_to_channel_tz(et_time, channel_tz, on_date)` and
+   `get_peak_slots_for_channel(...)` map an ET target to the channel account-tz wall-clock using
+   the publish date (DST correct: 08:00 ET -> 21:00 JST in summer, 22:00 JST in winter; -> 08:00
+   for NY). Returns the bare 12h string the typer consumes.
+3. **Allocator wired (reuses cap + jitter).** `schedule_tracker.get_next_available_slot` gained an
+   optional `channel_tz`; when set it converts the ET base slot to channel-local BEFORE the existing
+   jitter. `HARD_CAP_PER_DAY` / `effective_cap` clamp is UNCHANGED. `channel_tz=None` stays
+   backwards-compatible (identity).
+4. **Scheduler passes the channel tz.** `scheduler.py` sources `self.time_slots` from
+   `peak_window.get_peak_slots_et()` and passes `channel_tz=self.config["timezone"]` at both
+   allocator call sites.
+5. **Registry grid replaced.** `_DEFAULT_TIME_SLOTS` is now the 3 ET peaks `["08:00","12:00","20:00"]`
+   (inert default mirror; the authoritative/env-config + conversion live in `peak_window.py` to
+   avoid an infra->platform import).
+
+### Future WRE enhancement (extension seam)
+
+The ET defaults are RESEARCHED static defaults. A future WRE skill can LEARN the optimum per-channel
+publish times from real engagement data (impressions/CTR/retention by hour) and replace
+`get_peak_slots_et()` or override slots per channel -- feeding through the SAME conversion path so
+the bare-time-in-account-tz contract is preserved. Seam documented in `peak_window.py` header.
+
+### Tests (unit, mock-only, non-vacuous)
+
+`tests/test_peak_window.py`: pins the ET peaks (08/12/20), proves NY=identity and Tokyo summer/winter
+offsets with explicit DST divergence, guards the old bare-time bug (Tokyo 08:00 ET is typed ~9:00 PM
+JST, NOT 8:00 AM), and proves cross-channel divergence. Non-vacuity verified by temporarily removing
+the conversion -> 3 allocator tests FAIL (Tokyo guard, NY check, divergence), restored after.
+Scoped run: 47 passed, 2 skipped (includes the #844 density-cap suite, still green).
+
+---
+
 ## 2026-06-19 - Cap shorts at 3/day + 1-6am window decision (was 8/day) (Phase 1)
 
 **By:** 0102 (Worker-Lane SCHED-DENSITY)

--- a/modules/platform_integration/youtube_shorts_scheduler/requirements.txt
+++ b/modules/platform_integration/youtube_shorts_scheduler/requirements.txt
@@ -1,3 +1,7 @@
 # YouTube Shorts Scheduler Dependencies
 selenium>=4.15.0
 undetected-chromedriver>=3.5.0
+# DST-aware US-ET -> per-channel Studio-account-tz conversion (peak_window.py).
+# pytz over zoneinfo+tzdata: pytz is already installed and a repo-wide dependency,
+# and works on the Windows host without the tzdata package.
+pytz>=2023.3

--- a/modules/platform_integration/youtube_shorts_scheduler/src/peak_window.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/src/peak_window.py
@@ -1,0 +1,155 @@
+"""
+Peak Window - US-audience peak publish slots for YouTube Shorts.
+
+Canonical model
+---------------
+ALL shorts target the US audience, so the optimum publish times are defined
+ONCE in US-Eastern (ET). Research-backed daily peaks for short-form watch time
+on YouTube cluster around the morning commute, the lunch break, and the evening
+prime-time window:
+
+    morning ~08:00 ET  |  lunch ~12:00 ET  |  evening ~20:00 ET
+
+The scheduler types a *bare* time string into YouTube Studio and never touches
+Studio's timezone selector (verified: dom_automation.set_schedule_time types
+the string directly; click_done guards against the timezone-select-button).
+Studio therefore interprets the typed time in each ACCOUNT's own timezone.
+
+So to publish at an ET target on a channel whose Studio account tz = X, we must
+type the X-local wall-clock equivalent of the ET time. Example (DST-aware):
+
+    08:00 ET on a Tokyo-Studio channel  -> type ~21:00 JST (summer) / ~22:00 (winter)
+    08:00 ET on a New York-Studio channel -> type 08:00 (identity)
+
+This module is the single, pure, unit-testable source of:
+  1. the canonical ET peak slots (configurable via env SHORTS_PEAK_SLOTS_ET), and
+  2. the ET -> channel-account-tz conversion (DST-aware via pytz).
+
+Future WRE enhancement (extension seam)
+---------------------------------------
+The ET defaults below are RESEARCHED static defaults. A future WRE skill can
+LEARN the optimum per-channel publish times from real engagement data
+(impressions/CTR/retention by hour) and replace get_peak_slots_et() /
+override the slots per channel. Keep that learner pure and feed it through the
+same conversion path so the bare-time-in-account-tz contract is preserved.
+
+WSP References:
+- WSP 3: Functional Distribution (platform_integration owns publish-time policy)
+- WSP 50/84: reuse pytz (already a repo dependency) instead of zoneinfo+tzdata
+- WSP 22: ModLog documents the future-learns-optimum seam
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import List
+
+import pytz
+
+# Canonical US-Eastern peak slots, in 24h "HH:MM" ET. Defined ONCE here.
+# Override via env: SHORTS_PEAK_SLOTS_ET="08:00,12:00,20:00"
+_DEFAULT_PEAK_SLOTS_ET: List[str] = ["08:00", "12:00", "20:00"]
+
+# Canonical timezone the slots are expressed in.
+PEAK_SLOTS_TZ = "America/New_York"
+
+# Env var name (single knob) for overriding the ET peak slots.
+PEAK_SLOTS_ENV = "SHORTS_PEAK_SLOTS_ET"
+
+
+def get_peak_slots_et() -> List[str]:
+    """
+    Return the canonical ET peak slots as 24h "HH:MM" strings.
+
+    Reads the env override SHORTS_PEAK_SLOTS_ET if present (comma-separated,
+    e.g. "08:00,12:00,20:00"); otherwise returns the researched defaults.
+    Malformed env values fall back to the defaults (fail-safe).
+    """
+    raw = os.getenv(PEAK_SLOTS_ENV, "").strip()
+    if not raw:
+        return list(_DEFAULT_PEAK_SLOTS_ET)
+    slots: List[str] = []
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        # Validate "HH:MM" before accepting.
+        try:
+            datetime.strptime(token, "%H:%M")
+        except ValueError:
+            return list(_DEFAULT_PEAK_SLOTS_ET)
+        slots.append(token)
+    return slots or list(_DEFAULT_PEAK_SLOTS_ET)
+
+
+def _format_bare_time(dt: datetime) -> str:
+    """
+    Format a datetime as the bare 12h time string YouTube Studio accepts.
+
+    e.g. "8:00 AM", "12:00 PM", "9:00 PM" (no leading zero on the hour),
+    matching the existing jitter/typer convention in schedule_tracker.py.
+    """
+    hour = dt.hour % 12 or 12
+    period = "AM" if dt.hour < 12 else "PM"
+    return f"{hour}:{dt.minute:02d} {period}"
+
+
+def convert_et_to_channel_tz(et_time: str, channel_tz: str, on_date: datetime) -> str:
+    """
+    Convert a canonical ET peak time to the channel account-tz wall-clock.
+
+    DST-aware: the conversion uses ``on_date`` so summer/winter offsets are
+    correct. The returned string is the *bare* 12h time to TYPE into Studio
+    (Studio interprets it in the account's own tz).
+
+    Args:
+        et_time: ET slot as 24h "HH:MM" (e.g. "08:00") or 12h "8:00 AM".
+        channel_tz: IANA tz of the channel's Studio account
+                    (e.g. "America/New_York", "Asia/Tokyo").
+        on_date: the calendar date the slot will publish on (for DST).
+
+    Returns:
+        Bare 12h time string in the channel account tz, e.g. "9:00 PM".
+
+    Raises:
+        pytz.UnknownTimeZoneError: if channel_tz is not a valid IANA zone.
+        ValueError: if et_time cannot be parsed.
+    """
+    # Parse the ET time-of-day (accept "HH:MM" 24h or "I:MM AM/PM" 12h).
+    parsed = None
+    for fmt in ("%H:%M", "%I:%M %p"):
+        try:
+            parsed = datetime.strptime(et_time.strip(), fmt)
+            break
+        except ValueError:
+            continue
+    if parsed is None:
+        raise ValueError(f"Unparseable ET time: {et_time!r}")
+
+    src_tz = pytz.timezone(PEAK_SLOTS_TZ)
+    dst_tz = pytz.timezone(channel_tz)
+
+    # Anchor the ET time-of-day to the publish date, localized in ET (DST-aware).
+    naive = datetime(
+        on_date.year, on_date.month, on_date.day, parsed.hour, parsed.minute
+    )
+    et_dt = src_tz.localize(naive)
+
+    # Convert to the channel account tz; the wall-clock there is what we type.
+    local_dt = et_dt.astimezone(dst_tz)
+    return _format_bare_time(local_dt)
+
+
+def get_peak_slots_for_channel(channel_tz: str, on_date: datetime) -> List[str]:
+    """
+    Return the canonical ET peak slots converted to channel account-tz wall-clocks.
+
+    Pure helper: maps each ET slot through convert_et_to_channel_tz for the given
+    date (DST-aware). Order is preserved (morning/lunch/evening) so it lines up
+    with the allocator's slot-index logic.
+    """
+    return [
+        convert_et_to_channel_tz(et_time, channel_tz, on_date)
+        for et_time in get_peak_slots_et()
+    ]

--- a/modules/platform_integration/youtube_shorts_scheduler/src/schedule_tracker.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/src/schedule_tracker.py
@@ -11,6 +11,13 @@ from pathlib import Path
 from typing import Dict, Optional, Tuple, List
 from datetime import datetime, timedelta
 
+# Pure ET-peak -> channel-account-tz conversion (DST-aware). The scheduler types
+# a bare time that Studio interprets in the account's own tz, so an ET target
+# must be converted to the channel-local wall-clock before typing.
+from modules.platform_integration.youtube_shorts_scheduler.src.peak_window import (
+    convert_et_to_channel_tz,
+)
+
 logger = logging.getLogger(__name__)
 
 # Default storage location
@@ -192,18 +199,29 @@ class ScheduleTracker:
         max_per_day: int = 3,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
+        channel_tz: Optional[str] = None,
     ) -> Optional[Tuple[str, str]]:
         """
         Find next available scheduling slot.
 
         Args:
-            time_slots: List of time strings ["5:00 AM", "11:00 AM", "5:00 PM"]
+            time_slots: Canonical ET peak slots, e.g. ["08:00", "12:00", "20:00"]
+                (also accepts 12h "8:00 AM" form). These describe the desired
+                US-audience publish time in US-Eastern.
             max_per_day: Maximum videos per day
             start_date: Start of scheduling window (default: tomorrow)
             end_date: End of scheduling window (default: 60 days out)
+            channel_tz: IANA tz of the channel's Studio account
+                (e.g. "Asia/Tokyo", "America/New_York"). When provided, the ET
+                base slot is converted to that account's local wall-clock
+                (DST-aware) BEFORE jitter, because the scheduler types a bare
+                time string that Studio interprets in the account's own tz.
+                When None, the slot is used as-is (backwards compatible).
 
         Returns:
-            (date_str, time_str) tuple or None if all slots filled
+            (date_str, time_str) tuple or None if all slots filled.
+            time_str is the bare time to TYPE into Studio (channel-tz local
+            when channel_tz is given).
         """
         if start_date is None:
             start_date = datetime.now() + timedelta(days=1)
@@ -224,12 +242,23 @@ class ScheduleTracker:
             count = self.get_count(date_str)
 
             if count < effective_cap:
-                # Determine base time slot, then add jitter for human-like variance
-                base_time = time_slots[count] if count < len(time_slots) else time_slots[-1]
+                # Determine canonical ET base slot for this slot index.
+                et_base = time_slots[count] if count < len(time_slots) else time_slots[-1]
+
+                # Convert ET -> channel Studio-account tz (DST-aware) when known,
+                # so the bare time we type publishes at the intended US-audience
+                # peak. Identity for ET-account channels; shifts for others.
+                if channel_tz:
+                    base_time = convert_et_to_channel_tz(et_base, channel_tz, current)
+                else:
+                    base_time = et_base
+
+                # Add jitter for human-like variance (reused, unchanged).
                 time_slot = _add_time_jitter(base_time)
                 slot_label = f"slot {count + 1}/{effective_cap}"
                 logger.info(
-                    f"[TRACKER] Allocated: {date_str} at {time_slot} ({slot_label}, base={base_time})"
+                    f"[TRACKER] Allocated: {date_str} at {time_slot} "
+                    f"({slot_label}, et_base={et_base}, local_base={base_time}, tz={channel_tz or 'as-is'})"
                 )
                 return (date_str, time_slot)
 

--- a/modules/platform_integration/youtube_shorts_scheduler/src/scheduler.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/src/scheduler.py
@@ -20,6 +20,7 @@ from selenium.common.exceptions import WebDriverException
 from .channel_config import get_channel_config, CHANNELS
 from .dom_automation import YouTubeStudioDOM
 from .schedule_tracker import ScheduleTracker
+from .peak_window import get_peak_slots_et
 from .schedule_dba import record_schedule_outcome
 from .index_weave import (
     load_index_json,
@@ -83,7 +84,13 @@ class YouTubeShortsScheduler:
         self.channel_id = self.config["id"]
         self.channel_name = self.config["name"]
         self.chrome_port = self.config["chrome_port"]
-        self.time_slots = self.config["time_slots"]
+        # Canonical US-Eastern peak slots (morning/lunch/evening), env-configurable
+        # via SHORTS_PEAK_SLOTS_ET. Defined ONCE in peak_window; these are ET and
+        # get converted to the channel's Studio-account tz at allocation time.
+        self.time_slots = get_peak_slots_et()
+        # Channel Studio-account timezone (registry field). Used to convert the
+        # ET peak slot to the local wall-clock the bare-time typer must enter.
+        self.channel_tz = self.config.get("timezone")
         self.max_per_day = self.config["max_per_day"]
         self.dry_run = dry_run
 
@@ -410,6 +417,7 @@ class YouTubeShortsScheduler:
                         slot = self.tracker.get_next_available_slot(
                             self.time_slots,
                             self.max_per_day,
+                            channel_tz=self.channel_tz,
                         )
 
                         if not slot:
@@ -955,6 +963,7 @@ class YouTubeShortsScheduler:
             slot = temp_tracker.get_next_available_slot(
                 self.time_slots,
                 self.max_per_day,
+                channel_tz=self.channel_tz,
             )
             if slot:
                 date_str, time_str = slot

--- a/modules/platform_integration/youtube_shorts_scheduler/tests/TestModLog.md
+++ b/modules/platform_integration/youtube_shorts_scheduler/tests/TestModLog.md
@@ -1,5 +1,36 @@
 # YouTube Shorts Scheduler - TestModLog
 
+## 2026-06-19 - US-ET peak slots + per-channel Studio-tz conversion (Phase 1)
+
+**By:** 0102 (Worker-Lane SCHED-WINDOW)
+**Slice:** SHORTS_SCHEDULE_US_PEAK_WINDOW_PHASE1
+**WSP References:** WSP 6 (Test Audit), WSP 22 (ModLog), WSP 84 (Code Reuse), WSP 97 (Truth Signaling)
+
+### Added `tests/test_peak_window.py` (unit, mock-only -- no browser/daemon/models)
+
+- `TestCanonicalETPeaks` - defaults are exactly the US-ET peaks `["08:00","12:00","20:00"]`
+  (== `_DEFAULT_PEAK_SLOTS_ET`), count == 3 (matches the landed HARD_CAP_PER_DAY), env override
+  `SHORTS_PEAK_SLOTS_ET` respected, malformed env falls back to defaults.
+- `TestConversionPerChannel` - NY account is identity with ET; Tokyo summer 08:00 ET -> 21:00 JST
+  and 20:00 ET -> 09:00 JST; Tokyo winter 08:00 ET -> 22:00 JST; explicit DST divergence assertion
+  (summer != winter, == ("21:00","22:00")); `get_peak_slots_for_channel` preserves morning/lunch/
+  evening order; non-vacuity guard that Tokyo conversion != identity ("08:00").
+- `TestAllocatorTypesChannelLocal` - Tokyo morning slot is typed ~9:00 PM JST (within jitter), NOT
+  bare 8:00 AM (regression guard for the old bare-time bug); NY morning slot typed ~8:00 AM; Tokyo
+  vs NY diverge (PM vs AM) for the same ET morning slot, proving tz is actually consulted.
+
+### Non-vacuity proof
+
+Temporarily forced the allocator to `base_time = et_base` (conversion removed): 3 allocator tests
+FAILED (`test_tokyo_morning_slot_is_jst_evening_not_bare_8am`, `test_ny_morning_slot_is_typed_8am`,
+`test_tokyo_and_ny_diverge_for_same_et_slot`) with "tz not consulted: tokyo='08:00' ny='08:00'".
+Implementation restored; suite green.
+
+### Result
+
+Scoped run (`test_peak_window.py` + `test_scheduler.py`): 47 passed, 2 skipped. The #844
+`TestScheduleDensityCap` suite stays green (cap untouched).
+
 ## 2026-06-16 - Pin video-index context consumption on the scheduling path (Phase 1)
 
 **By:** 0102 (Worker-Lane SSVCC-AUTHOR)

--- a/modules/platform_integration/youtube_shorts_scheduler/tests/test_peak_window.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/tests/test_peak_window.py
@@ -1,0 +1,185 @@
+"""
+Unit tests for US-ET peak slots + per-channel Studio-tz conversion.
+
+Slice: SHORTS_SCHEDULE_US_PEAK_WINDOW_PHASE1
+
+Model under test
+----------------
+ALL shorts target the US audience, so peak publish times are defined ONCE in
+US-Eastern (ET): morning ~08:00, lunch ~12:00, evening ~20:00. The scheduler
+types a BARE time string that YouTube Studio interprets in each channel's own
+account timezone, so an ET target must be converted to the channel-local
+wall-clock (DST-aware) before typing.
+
+These tests are mock-only (no browser, no daemon, no models) and NON-VACUOUS:
+they pin the ET peaks, prove the conversion produces channel-local wall-clocks,
+prove DST is handled (summer vs winter), and guard against the old bare-time bug
+(a Tokyo channel must NOT type 8:00 AM for an 08:00 ET morning slot).
+"""
+
+import os
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from modules.platform_integration.youtube_shorts_scheduler.src.peak_window import (
+    get_peak_slots_et,
+    convert_et_to_channel_tz,
+    get_peak_slots_for_channel,
+    _DEFAULT_PEAK_SLOTS_ET,
+    PEAK_SLOTS_ENV,
+)
+from modules.platform_integration.youtube_shorts_scheduler.src.schedule_tracker import (
+    ScheduleTracker,
+    MAX_JITTER_STEPS,
+)
+
+# Channel Studio-account timezones (verified in registry / #844 commit body).
+TOKYO_TZ = "Asia/Tokyo"
+NY_TZ = "America/New_York"
+
+# DST probe dates: US Eastern observes DST roughly mid-Mar..early-Nov.
+SUMMER = datetime(2026, 7, 15)  # EDT = UTC-4
+WINTER = datetime(2026, 1, 15)  # EST = UTC-5
+
+
+def _to_24h(bare: str) -> str:
+    """Normalize a bare 12h time like '9:00 PM' to '21:00' for comparison."""
+    return datetime.strptime(bare.strip(), "%I:%M %p").strftime("%H:%M")
+
+
+def _within_jitter(actual_bare: str, base_bare: str) -> bool:
+    """True if actual is within +/- (MAX_JITTER_STEPS * 15min) of base."""
+    a = datetime.strptime(actual_bare.strip(), "%I:%M %p")
+    b = datetime.strptime(base_bare.strip(), "%I:%M %p")
+    return abs((a - b).total_seconds()) / 60.0 <= MAX_JITTER_STEPS * 15
+
+
+# ---------------------------------------------------------------------------
+# 1. The canonical slots are the ET peaks (08 / 12 / 20 ET).
+# ---------------------------------------------------------------------------
+
+class TestCanonicalETPeaks:
+    def test_defaults_are_the_three_us_et_peaks(self):
+        assert get_peak_slots_et() == ["08:00", "12:00", "20:00"]
+        assert _DEFAULT_PEAK_SLOTS_ET == ["08:00", "12:00", "20:00"]
+
+    def test_three_slots_matching_the_daily_cap(self):
+        # Default count must match the landed 3/day HARD_CAP_PER_DAY.
+        assert len(get_peak_slots_et()) == 3
+
+    def test_env_override_is_respected(self, monkeypatch):
+        monkeypatch.setenv(PEAK_SLOTS_ENV, "07:30, 13:00, 19:00")
+        assert get_peak_slots_et() == ["07:30", "13:00", "19:00"]
+
+    def test_malformed_env_falls_back_to_defaults(self, monkeypatch):
+        monkeypatch.setenv(PEAK_SLOTS_ENV, "not-a-time,99:99")
+        assert get_peak_slots_et() == ["08:00", "12:00", "20:00"]
+
+
+# ---------------------------------------------------------------------------
+# 2. Conversion correctness per channel + DST.
+# ---------------------------------------------------------------------------
+
+class TestConversionPerChannel:
+    def test_ny_channel_is_identity_with_et(self):
+        # America/New_York Studio account == the ET canonical, so no shift.
+        assert _to_24h(convert_et_to_channel_tz("08:00", NY_TZ, SUMMER)) == "08:00"
+        assert _to_24h(convert_et_to_channel_tz("12:00", NY_TZ, WINTER)) == "12:00"
+        assert _to_24h(convert_et_to_channel_tz("20:00", NY_TZ, SUMMER)) == "20:00"
+
+    def test_tokyo_channel_summer_offset(self):
+        # EDT (UTC-4) -> JST (UTC+9) = +13h. 08:00 ET -> 21:00 JST.
+        assert _to_24h(convert_et_to_channel_tz("08:00", TOKYO_TZ, SUMMER)) == "21:00"
+        assert _to_24h(convert_et_to_channel_tz("20:00", TOKYO_TZ, SUMMER)) == "09:00"
+
+    def test_tokyo_channel_winter_offset_dst_aware(self):
+        # EST (UTC-5) -> JST (UTC+9) = +14h. 08:00 ET -> 22:00 JST (one hour
+        # later than summer => proves the conversion is DST-aware, not a fixed
+        # offset).
+        assert _to_24h(convert_et_to_channel_tz("08:00", TOKYO_TZ, WINTER)) == "22:00"
+
+    def test_dst_changes_the_tokyo_wallclock(self):
+        # The SAME ET target yields a DIFFERENT JST wall-clock across the DST
+        # boundary. If this were a naive/fixed-offset conversion, these would be
+        # equal -- so this asserts genuine DST handling.
+        summer = _to_24h(convert_et_to_channel_tz("08:00", TOKYO_TZ, SUMMER))
+        winter = _to_24h(convert_et_to_channel_tz("08:00", TOKYO_TZ, WINTER))
+        assert summer != winter, "DST not handled: summer/winter JST identical"
+        assert (summer, winter) == ("21:00", "22:00")
+
+    def test_get_peak_slots_for_channel_preserves_order(self):
+        ny = get_peak_slots_for_channel(NY_TZ, SUMMER)
+        assert [_to_24h(t) for t in ny] == ["08:00", "12:00", "20:00"]
+        tokyo = get_peak_slots_for_channel(TOKYO_TZ, SUMMER)
+        assert [_to_24h(t) for t in tokyo] == ["21:00", "01:00", "09:00"]
+
+    def test_conversion_is_not_a_no_op_for_tokyo(self):
+        # NON-VACUITY GUARD: if convert_et_to_channel_tz ever degenerates to
+        # identity (no-op), this fails. The Tokyo wall-clock MUST differ from
+        # the ET input string for the morning slot.
+        out = _to_24h(convert_et_to_channel_tz("08:00", TOKYO_TZ, SUMMER))
+        assert out != "08:00", "Conversion is identity/no-op (bug reintroduced)"
+
+
+# ---------------------------------------------------------------------------
+# 3. Allocator regression guard: Tokyo 08:00 ET is NOT typed as 08:00.
+# ---------------------------------------------------------------------------
+
+class TestAllocatorTypesChannelLocal:
+    def _tracker(self):
+        return ScheduleTracker("UC_test_peak", Path(tempfile.mkdtemp()))
+
+    def test_tokyo_morning_slot_is_jst_evening_not_bare_8am(self):
+        t = self._tracker()
+        slot = t.get_next_available_slot(
+            get_peak_slots_et(),
+            max_per_day=3,
+            start_date=SUMMER,
+            channel_tz=TOKYO_TZ,
+        )
+        assert slot is not None
+        _, typed = slot
+        # Old bug: typed the bare ET "8:00 AM" on a Tokyo Studio account, which
+        # Studio reads as 8:00 AM JST -> wrong US wall-clock. New behavior types
+        # the JST-local equivalent (~9:00 PM) so it publishes at 08:00 ET.
+        assert "AM" not in typed or _to_24h(typed) != "08:00", (
+            f"REGRESSION: Tokyo morning slot typed as bare ET time {typed!r}"
+        )
+        assert _within_jitter(typed, "9:00 PM"), (
+            f"Tokyo 08:00 ET morning expected ~9:00 PM JST, got {typed!r}"
+        )
+
+    def test_ny_morning_slot_is_typed_8am(self):
+        t = self._tracker()
+        slot = t.get_next_available_slot(
+            get_peak_slots_et(),
+            max_per_day=3,
+            start_date=SUMMER,
+            channel_tz=NY_TZ,
+        )
+        assert slot is not None
+        _, typed = slot
+        # NY Studio account == ET, so the bare 8:00 AM is correct here.
+        assert _within_jitter(typed, "8:00 AM"), (
+            f"NY 08:00 ET morning expected ~8:00 AM, got {typed!r}"
+        )
+
+    def test_tokyo_and_ny_diverge_for_same_et_slot(self):
+        # Cross-channel proof that tz is actually consulted: the same ET morning
+        # slot produces materially different typed times for Tokyo vs NY.
+        t_tokyo = self._tracker().get_next_available_slot(
+            get_peak_slots_et(), max_per_day=3, start_date=SUMMER, channel_tz=TOKYO_TZ
+        )
+        t_ny = self._tracker().get_next_available_slot(
+            get_peak_slots_et(), max_per_day=3, start_date=SUMMER, channel_tz=NY_TZ
+        )
+        assert t_tokyo is not None and t_ny is not None
+        # Compare AM/PM period to be robust against jitter on the boundary.
+        tokyo_period = t_tokyo[1].split()[-1]
+        ny_period = t_ny[1].split()[-1]
+        assert (tokyo_period, ny_period) == ("PM", "AM"), (
+            f"tz not consulted: tokyo={t_tokyo[1]!r} ny={t_ny[1]!r}"
+        )


### PR DESCRIPTION
## Summary

Shorts publish at **US-audience peak times**, defined ONCE in canonical US-Eastern (ET) and then **converted per channel to that channel's Studio-account timezone** (DST-aware) before the bare time string is typed. 012 posts from Japan, but ALL shorts target the US audience.

Slice: `SHORTS_SCHEDULE_US_PEAK_WINDOW_PHASE1` (Worker-Lane: SCHED-WINDOW). Window/timezone ONLY -- the 3/day cap landed in #844 (`HARD_CAP_PER_DAY`) and is **untouched**.

## Research-backed ET peaks (audience-tz principle)

Short-form watch time on YouTube clusters around the US viewer's day: morning commute, lunch break, and evening prime time. Because the audience is US-based, the optimum is expressed in **US-Eastern**:

- morning **~08:00 ET** | lunch **~12:00 ET** | evening **~20:00 ET**

Three slots, matching the landed 3/day cap. Configurable via env `SHORTS_PEAK_SLOTS_ET` (e.g. `"08:00,12:00,20:00"`).

## Per-channel Studio-tz conversion + DST

The scheduler types a **bare** time string; YouTube Studio interprets it in each channel's **own account timezone**. So to hit an ET target on a channel whose Studio tz = X, we type the X-local equivalent (DST-aware via `pytz`):

| ET target | Tokyo Studio (summer / winter) | NY Studio |
|-----------|-------------------------------|-----------|
| 08:00 ET  | 21:00 JST / 22:00 JST         | 08:00     |
| 12:00 ET  | 01:00 JST / 02:00 JST         | 12:00     |
| 20:00 ET  | 09:00 JST / 10:00 JST         | 20:00     |

DST is genuinely handled: the same ET target yields a different JST wall-clock across the boundary (21:00 summer vs 22:00 winter).

## Phase 0 confirmation (verified, did NOT have to STOP)

1. **Bare-time-in-account-tz model CONFIRMED.** `dom_automation.set_schedule_time` (~3098) types the string via `slow_type` (~3196) and never sets the timezone selector; `click_done` guards against the timezone-select-button (~3214, ~3226-3232). Studio reads the typed time in the account's own tz.
2. **Registry tz == Studio ACCOUNT tz CONFIRMED.** The `timezone` field in `youtube_channel_registry.py` (Move2Japan/UnDaoDu = `Asia/Tokyo`; FoundUps/antifaFM = `America/New_York`) is the Studio account tz -- corroborated verbatim by the #844 commit body ("interprets it in each account's own tz (Asia/Tokyo for Move2Japan/UnDaoDu vs America/New_York for FoundUps/antifaFM)"). Authoritative -> proceeded.
3. **tz library.** `zoneinfo` needs `tzdata`, which is NOT installed on the Windows host; `pytz` IS installed (2026.1) and is already a repo-wide dependency (stream_resolver, social_media_orchestrator, foundups). Used `pytz` (WSP 84 reuse) to avoid a runtime ModuleNotFoundError.

## Changes (minimal, malleable)

- **`src/peak_window.py` (new, pure):** ET defaults defined ONCE (env-configurable) + DST-aware `convert_et_to_channel_tz` / `get_peak_slots_for_channel`.
- **`src/schedule_tracker.py`:** `get_next_available_slot` gains optional `channel_tz`; converts the ET base slot to channel-local BEFORE the existing jitter. **Cap clamp unchanged.** `channel_tz=None` stays backwards-compatible (identity).
- **`src/scheduler.py`:** sources `self.time_slots` from `get_peak_slots_et()` and passes `channel_tz=config["timezone"]` at both allocator call sites.
- **`youtube_channel_registry.py`:** `_DEFAULT_TIME_SLOTS` replaced by the 3 ET peaks (inert mirror; authoritative config + conversion live in `peak_window.py`).
- **`requirements.txt`:** declare `pytz>=2023.3`.

## Future WRE learns optimum (extension seam)

These ET defaults are RESEARCHED static defaults. A future WRE skill can LEARN per-channel optimum publish times from engagement data (impressions/CTR/retention by hour) and replace `get_peak_slots_et()` / override slots per channel -- feeding the SAME conversion path so the bare-time-in-account-tz contract holds. Seam documented in the `peak_window.py` header + ModLog.

## Non-vacuity proof

Temporarily forced the allocator to skip the conversion (`base_time = et_base`): **3 allocator tests FAILED** -- `test_tokyo_morning_slot_is_jst_evening_not_bare_8am`, `test_ny_morning_slot_is_typed_8am`, `test_tokyo_and_ny_diverge_for_same_et_slot` ("tz not consulted: tokyo='08:00' ny='08:00'"). Restored; suite green. Tests genuinely exercise the conversion, not a no-op.

## Tests

`tests/test_peak_window.py` (unit, mock-only -- no browser/daemon/models): pins the ET peaks (08/12/20), proves NY=identity + Tokyo summer/winter offsets with explicit DST divergence, guards the old bare-time bug (Tokyo 08:00 ET typed ~9:00 PM JST not 8:00 AM), and proves cross-channel divergence.

Scoped run (`test_peak_window.py` + `test_scheduler.py`): **47 passed, 2 skipped** (the #844 `TestScheduleDensityCap` suite stays green).

## Scope

Touched ONLY `youtube_shorts_scheduler` + the registry tz/grid read. Did NOT touch the daemon loop, activity_control, auto_moderator_dae, the music R&D module, or the 3/day cap. ASCII-clean (0 non-ASCII in added lines).

Status: **VERIFIED_READY** -- left OPEN, not merged.

Worker-Lane: SCHED-WINDOW
Slice: SHORTS_SCHEDULE_US_PEAK_WINDOW_PHASE1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
