### PR TITLE
fix(livechat): run PHASE 2 video indexing on the Edge loop (FoundUps/antifaFM), not Chrome-only

### DIFF
--- a/modules/communication/livechat/ModLog.md
+++ b/modules/communication/livechat/ModLog.md
@@ -10,6 +10,41 @@ This log tracks changes specific to the **livechat** module in the **communicati
 
 ---
 
+## 2026-06-18 - fix: run PHASE 2 video indexing on the Edge loop (EDGE_LOOP_INDEXING_PHASE1)
+
+**By:** 0102 (CTO) | **Worker-Lane:** EDGE-INDEX | **Slice:** EDGE_LOOP_INDEXING_PHASE1
+**WSP References:** WSP 22 (ModLog), WSP 50 (verify), WSP 84 (reuse), WSP 5/6 (tests)
+
+### Why
+`_browser_engagement_loop` runs PHASE 1 (comments) -> PHASE 2 (video indexing)
+-> PHASE 3 (scheduling) -> PHASE 4 (LinkedIn). PHASE 2 was gated Chrome-only at
+`src/auto_moderator_dae.py:1566` (`if browser_name == "chrome" and os.getenv("YT_VIDEO_INDEXING_ENABLED", ...)`),
+so the Edge loop (FoundUps/antifaFM, port 9223) went PHASE 1 -> PHASE 3 and those
+channels were never indexed by the loop. Artifacts confirmed the gap: move2japan
+650 / undaodu 550 indexed vs foundups 81 / antifafm 56 (stale). This is the
+indexing half of 012's #1 "fix scheduling/indexing on FoundUps/antifaFM"
+(scheduling already landed via #844 cap / #847 window).
+
+### Changed (minimal, scoped to auto_moderator_dae.py)
+- Relaxed the PHASE 2 gate to `if os.getenv("YT_VIDEO_INDEXING_ENABLED", "false")...`
+  (dropped the `browser_name == "chrome"` restriction). PHASE 2 now runs for
+  WHICHEVER browser drives the loop, under the SAME enablement flag (not a new
+  always-on path). `run_video_indexing_cycle(browser=browser_name)` is REUSED
+  unchanged (WSP 84) - it already filters channels by browser internally
+  (`studio_ask_indexer.py:903-927`: chrome=M2J/UnDaoDu, edge=FoundUps/antifaFM),
+  so passing `browser="edge"` indexes the Edge channels. PHASE 1/3/4 ordering and
+  the landed cap/window are preserved. The existing `[<TAG>-LOOP] PHASE 2: VIDEO
+  INDEXING starting...` log + `ActivityType.VIDEO_INDEXING` breadcrumb now also
+  fire for Edge, so the WRE sees Edge indexing.
+
+### Tests (mock only, no live browser)
+- NEW `tests/test_browser_loop_phase2_indexing.py` (4 tests): drives one loop
+  cycle with PHASE 1/3/4 disabled and `run_video_indexing_cycle` mocked.
+  - edge + enabled -> indexing invoked with `browser="edge"` (NON-VACUOUS:
+    FAILS on the old Chrome-only code, "Awaited 0 times").
+  - chrome + enabled -> still invoked with `browser="chrome"` (regression).
+  - edge/chrome + disabled -> indexing NOT invoked (regression guards).
+
 ## 2026-06-18 - RC3: channel-scope the OODA activity signal (YOUTUBE_COMMENT_FLOW_OODA_OBSERVABILITY_PHASE1)
 
 **By:** 0102 (CTO)

--- a/modules/communication/livechat/src/auto_moderator_dae.py
+++ b/modules/communication/livechat/src/auto_moderator_dae.py
@@ -1561,9 +1561,16 @@ class AutoModeratorDAE:
                     logger.debug(f"[{tag}-LOOP] [ACTIVITY-ROUTER] Signal failed: {e}")
 
                 # ============================================
-                # PHASE 2: VIDEO INDEXING (Chrome only, optional)
+                # PHASE 2: VIDEO INDEXING (per-browser, optional)
+                # 2026-06-18 (EDGE_LOOP_INDEXING_PHASE1): Run for WHICHEVER
+                # browser drives this loop, not Chrome-only. The Chrome-only
+                # gate left Edge channels (FoundUps/antifaFM, port 9223) never
+                # indexed by the loop. run_video_indexing_cycle already filters
+                # channels by the browser param (WSP 84 reuse), so passing
+                # browser_name="edge" indexes FoundUps/antifaFM, "chrome" still
+                # indexes Move2Japan/UnDaoDu. Same YT_VIDEO_INDEXING_ENABLED gate.
                 # ============================================
-                if browser_name == "chrome" and os.getenv("YT_VIDEO_INDEXING_ENABLED", "false").lower() in ("1", "true", "yes"):
+                if os.getenv("YT_VIDEO_INDEXING_ENABLED", "false").lower() in ("1", "true", "yes"):
                     try:
                         from modules.ai_intelligence.video_indexer.src.studio_ask_indexer import run_video_indexing_cycle
                         logger.info(f"[{tag}-LOOP] PHASE 2: VIDEO INDEXING starting...")

--- a/modules/communication/livechat/tests/test_browser_loop_phase2_indexing.py
+++ b/modules/communication/livechat/tests/test_browser_loop_phase2_indexing.py
@@ -1,0 +1,155 @@
+"""
+Tests for PHASE 2 (VIDEO INDEXING) gating in AutoModeratorDAE._browser_engagement_loop.
+
+Slice: EDGE_LOOP_INDEXING_PHASE1
+WSP refs: WSP 5 (coverage), WSP 6 (audit), WSP 84 (reuse run_video_indexing_cycle).
+
+Context
+-------
+The per-browser engagement loop runs:
+    PHASE 1 (comments) -> PHASE 2 (video indexing) -> PHASE 3 (scheduling) -> PHASE 4 (LinkedIn)
+
+Before this slice, PHASE 2 was gated Chrome-only:
+
+    if browser_name == "chrome" and os.getenv("YT_VIDEO_INDEXING_ENABLED", ...):
+
+So the Edge loop (FoundUps / antifaFM, port 9223) NEVER ran PHASE 2 and those
+channels were never indexed by the loop. This slice relaxes the gate so PHASE 2
+runs for WHICHEVER browser drives the loop, under the SAME YT_VIDEO_INDEXING_ENABLED
+flag, reusing run_video_indexing_cycle (which already filters channels by browser).
+
+These tests are MOCK ONLY. No real browser is ever opened:
+  - run_video_indexing_cycle is mocked (the only PHASE 2 work) and asserted.
+  - PHASE 1 / 3 / 4 are disabled via env flags so the loop isolates PHASE 2.
+  - asyncio.sleep is patched to raise CancelledError after the first cycle,
+    so the otherwise-infinite `while True` loop runs exactly one cycle.
+
+Non-vacuity: test_edge_loop_runs_phase2_indexing_when_enabled MUST FAIL on the
+pre-slice code (Edge skipped PHASE 2 -> mock never called -> assert_called fails).
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Ensure repo root on path (tests may be invoked from various cwds)
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from modules.communication.livechat.src.auto_moderator_dae import AutoModeratorDAE
+
+
+# Env that isolates PHASE 2: disable PHASE 1 (comments), PHASE 3 (shorts),
+# PHASE 4 (LinkedIn), and the RotationSupervisor path. Only the indexing flag varies.
+_ISOLATE_PHASE2_ENV = {
+    "YT_COMMENTS_ENABLED": "false",
+    "YT_SHORTS_SCHEDULING_ENABLED": "false",
+    "LN_FEED_ENGAGEMENT_ENABLED": "false",
+    "YT_USE_ROTATION_SUPERVISOR": "false",
+}
+
+
+def _make_dae():
+    """Build a minimal AutoModeratorDAE without the heavyweight __init__.
+
+    The loop only touches a handful of attributes; we set exactly those so no
+    real auth / browser / scheduler is constructed.
+    """
+    dae = object.__new__(AutoModeratorDAE)
+    dae.multi_channel_coordinator = MagicMock()
+    dae._shorts_scheduler_available = False  # PHASE 3 short-circuits before any work
+    dae._skill_trigger = None
+    dae._shorts_total_cycles = 0
+    dae._shorts_total_scheduled = 0
+    dae._shorts_last_cycle_result = None
+    return dae
+
+
+async def _run_one_cycle(browser_name: str, indexing_enabled: bool, mock_indexing_cycle):
+    """Drive _browser_engagement_loop for exactly one cycle and return.
+
+    asyncio.sleep is patched to raise CancelledError so the infinite while-loop
+    exits after a single pass (the loop re-raises CancelledError cleanly).
+    """
+    dae = _make_dae()
+
+    env = dict(_ISOLATE_PHASE2_ENV)
+    env["YT_VIDEO_INDEXING_ENABLED"] = "true" if indexing_enabled else "false"
+
+    async def _sleep_then_stop(*_args, **_kwargs):
+        # End-of-cycle sleep -> stop the loop after one full cycle.
+        raise asyncio.CancelledError()
+
+    with patch.dict("os.environ", env, clear=False), \
+         patch(
+             "modules.ai_intelligence.video_indexer.src.studio_ask_indexer.run_video_indexing_cycle",
+             mock_indexing_cycle,
+         ), \
+         patch(
+             "modules.communication.livechat.src.auto_moderator_dae.get_activity_router",
+             MagicMock(),
+         ), \
+         patch("asyncio.sleep", side_effect=_sleep_then_stop):
+        with pytest.raises(asyncio.CancelledError):
+            await dae._browser_engagement_loop(
+                browser_name=browser_name,
+                runner=MagicMock(),
+                max_comments=0,
+                mode="test",
+                interval_minutes=10,
+                browser_lock=None,
+                scheduler_stop_event=None,
+            )
+
+
+@pytest.mark.asyncio
+async def test_edge_loop_runs_phase2_indexing_when_enabled():
+    """EDGE loop MUST invoke run_video_indexing_cycle for the Edge browser.
+
+    NON-VACUITY: This fails on pre-slice code, where PHASE 2 was gated
+    `browser_name == "chrome"` and the Edge loop skipped it entirely.
+    """
+    mock_cycle = AsyncMock(return_value={"ok": True})
+    await _run_one_cycle("edge", indexing_enabled=True, mock_indexing_cycle=mock_cycle)
+
+    mock_cycle.assert_awaited_once()
+    # PHASE 2 must run for the Edge channels (FoundUps / antifaFM live behind browser="edge").
+    _, kwargs = mock_cycle.call_args
+    assert kwargs.get("browser") == "edge", (
+        f"Edge loop must index Edge channels, got browser={kwargs.get('browser')!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_chrome_loop_still_runs_phase2_indexing_when_enabled():
+    """Regression: CHROME loop must STILL invoke indexing (M2J/UnDaoDu) for browser=chrome."""
+    mock_cycle = AsyncMock(return_value={"ok": True})
+    await _run_one_cycle("chrome", indexing_enabled=True, mock_indexing_cycle=mock_cycle)
+
+    mock_cycle.assert_awaited_once()
+    _, kwargs = mock_cycle.call_args
+    assert kwargs.get("browser") == "chrome", (
+        f"Chrome loop must index Chrome channels, got browser={kwargs.get('browser')!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_edge_loop_skips_phase2_when_indexing_disabled():
+    """Regression guard: with YT_VIDEO_INDEXING_ENABLED=false the Edge loop runs NO indexing."""
+    mock_cycle = AsyncMock(return_value={"ok": True})
+    await _run_one_cycle("edge", indexing_enabled=False, mock_indexing_cycle=mock_cycle)
+
+    mock_cycle.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_chrome_loop_skips_phase2_when_indexing_disabled():
+    """Regression guard: with indexing disabled the Chrome loop also runs NO indexing."""
+    mock_cycle = AsyncMock(return_value={"ok": True})
+    await _run_one_cycle("chrome", indexing_enabled=False, mock_indexing_cycle=mock_cycle)
+
+    mock_cycle.assert_not_awaited()


### PR DESCRIPTION
## Problem
`AutoModeratorDAE._browser_engagement_loop` runs per browser:
**PHASE 1 (comments) -> PHASE 2 (video indexing) -> PHASE 3 (scheduling) -> PHASE 4 (LinkedIn)**.

PHASE 2 was gated **Chrome-only**, so the Edge loop (FoundUps/antifaFM, port 9223) went PHASE 1 -> PHASE 3 and those channels were never indexed by the loop. Artifacts confirm the gap: move2japan 650 / undaodu 550 indexed vs **foundups 81 / antifafm 56** (stale). This is the indexing half of 012's #1 "fix scheduling/indexing on FoundUps/antifaFM" (scheduling already landed: #844 cap, #847 window).

## The Chrome-only gate (before)
`modules/communication/livechat/src/auto_moderator_dae.py:1566`
```python
# PHASE 2: VIDEO INDEXING (Chrome only, optional)
if browser_name == "chrome" and os.getenv("YT_VIDEO_INDEXING_ENABLED", "false").lower() in ("1", "true", "yes"):
```

## The fix (minimal)
Drop only the `browser_name == "chrome"` restriction; keep the SAME enablement flag:
```python
# PHASE 2: VIDEO INDEXING (per-browser, optional)
if os.getenv("YT_VIDEO_INDEXING_ENABLED", "false").lower() in ("1", "true", "yes"):
```

## Reuse of run_video_indexing_cycle (WSP 84 - no reinvented logic)
`run_video_indexing_cycle(browser=browser_name)` is reused unchanged. It is already browser-parametrized (`studio_ask_indexer.py:876-880`) and filters channels by browser internally (`studio_ask_indexer.py:903-927`):
- `browser="chrome"` -> Move2Japan / UnDaoDu
- `browser="edge"` -> FoundUps / antifaFM

So passing the loop's own `browser_name` indexes the correct channel set. PHASE 1/3/4 ordering and the landed cap/window are preserved. The existing `[<TAG>-LOOP] PHASE 2: VIDEO INDEXING starting...` log + `ActivityType.VIDEO_INDEXING` breadcrumb now also fire for Edge, so the WRE sees Edge indexing.

## Same-enablement gating
PHASE 2 stays gated by `YT_VIDEO_INDEXING_ENABLED` (default `"false"` at the call site) - this is **not** a new always-on path. Edge runs PHASE 2 under exactly the same flag as Chrome.

## Tests (mock only, no live browser)
NEW `modules/communication/livechat/tests/test_browser_loop_phase2_indexing.py` (4 tests). Drives one loop cycle with PHASE 1/3/4 disabled via env and `run_video_indexing_cycle` mocked; `asyncio.sleep` patched to break the infinite `while True` after one cycle. No browser is ever opened.

- `test_edge_loop_runs_phase2_indexing_when_enabled` -> asserts indexing invoked with `browser="edge"`.
- `test_chrome_loop_still_runs_phase2_indexing_when_enabled` -> still `browser="chrome"` (regression).
- `test_edge_loop_skips_phase2_when_indexing_disabled` / `test_chrome_loop_skips_phase2_when_indexing_disabled` -> indexing NOT invoked (regression guards).

### MUST-FAIL-on-old-code proof (non-vacuity)
Stashing the source change and running against the original Chrome-only code:
```
FAILED ...::test_edge_loop_runs_phase2_indexing_when_enabled
  AssertionError: Expected mock to have been awaited once. Awaited 0 times.
1 failed, 3 passed
```
With the fix applied: **4 passed**. The Edge test fails iff the Edge loop skips PHASE 2 - exactly the bug.

## Scope
Touches ONLY `auto_moderator_dae.py` + its new test + livechat `ModLog.md`. Out of scope (untouched): the indexing logic, the scheduler, activity_control, music R&D, studio_ask_indexer.

Worker-Lane: EDGE-INDEX | Slice: EDGE_LOOP_INDEXING_PHASE1 | Status: VERIFIED_READY (do not merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
