### PR TITLE
feat(antifafm): opt-in after-selection auto-launch of the 24/7 broadcaster (ANTIFAFM_AUTOSTART, default off)

### DIFF
--- a/main.py
+++ b/main.py
@@ -430,6 +430,34 @@ async def monitor_youtube(disable_lock: bool = False, enable_ai_monitoring: bool
         print(f"[INFO] AI Overseer: {'ENABLED' if enable_ai_monitoring else 'DISABLED'}")
         print("[INFO] Press Ctrl+C to stop")
 
+        # ANTIFAFM_AUTOSTART_AFTER_SELECT_PHASE1:
+        # Opt-in, after-selection auto-launch of the 24/7 antifaFM broadcaster.
+        # This is FUNCTION-SCOPE (only runs once 012 has selected the YouTube DAE
+        # and the instance lock above is held) -- NOT the menu-boot autostart that
+        # was deliberately removed (that broke the daemon; see
+        # MAIN_MENU_ANTIFAFM_STARTUP_BOUNDARY_FIX_PHASE1 at module scope).
+        #
+        # Distinct flag name ANTIFAFM_AUTOSTART (the retired ANTIFAFM_AUTO_START is
+        # still ignored). Default OFF -> merging never auto-broadcasts; 012 must opt
+        # in via .env, and start_antifafm_background() itself returns False harmlessly
+        # without ANTIFAFM_YOUTUBE_STREAM_KEY. start_antifafm_background() reuses the
+        # antifafm_broadcaster instance lock and has blocking setup (FFmpeg cleanup +
+        # ~5s settle + stream verification), so we dispatch it to a daemon thread to
+        # avoid stalling the monitor. try/except guards: a broadcaster failure must
+        # never break the YouTube daemon.
+        if os.getenv("ANTIFAFM_AUTOSTART", "0") == "1":
+            try:
+                import threading as _threading
+                _antifafm_thread = _threading.Thread(
+                    target=start_antifafm_background,
+                    daemon=True,
+                    name="antifafm-autostart-after-select",
+                )
+                _antifafm_thread.start()
+                print("[ANTIFAFM] ANTIFAFM_AUTOSTART=1 -> launching broadcaster (background, non-blocking)")
+            except Exception as _antifafm_exc:
+                logger.error(f"[ANTIFAFM] after-selection autostart failed (continuing daemon): {_antifafm_exc}")
+
         dae = AutoModeratorDAE(enable_ai_monitoring=enable_ai_monitoring)
         await dae.run()
 

--- a/modules/platform_integration/antifafm_broadcaster/ModLog.md
+++ b/modules/platform_integration/antifafm_broadcaster/ModLog.md
@@ -1,5 +1,35 @@
 # antifaFM Broadcaster - ModLog
 
+## V3.6.0 - Opt-in After-Selection Auto-Launch (2026-06-19)
+
+**Slice**: `ANTIFAFM_AUTOSTART_AFTER_SELECT_PHASE1`
+**Branch**: `fix/antifafm-autostart-after-select-phase1`
+**Worker-Lane**: ANTIFAFM-AUTOSTART
+**WSP Lock**: WSP_00, WSP_22, WSP_49, WSP_50, WSP_84, WSP_97
+
+**Context**: The 24/7 antifaFM broadcaster was previously auto-launched at *menu boot* via the legacy `ANTIFAFM_AUTO_START` block. That boot-time launch broke the daemon (OBS/FFmpeg/metadata/rotator side effects before any user action) and was deliberately removed in V3.5.0 (`MAIN_MENU_ANTIFAFM_STARTUP_BOUNDARY_FIX_PHASE1`, enforced by `test_main_menu_startup_boundary.py`). This slice re-enables auto-launch but at the **correct, safe place**: *after* 012 selects/starts the YouTube DAE, inside `main.monitor_youtube()` (function scope), gated by a **new, distinct** opt-in flag — never at module-scope boot.
+
+**Changes**:
+
+1. **New flag `ANTIFAFM_AUTOSTART` (default `0`/OFF)** in `main.monitor_youtube()`:
+   - Distinct name from the retired/ignored `ANTIFAFM_AUTO_START` (note: no underscore between `AUTO` and `START`).
+   - Gate runs at *function scope*, after the instance lock is acquired and OAuth preflight completes, immediately before the blocking `await dae.run()`.
+   - Both YouTube DAE menu option 1 (Live Chat Monitor) and option 6 (Full Production Mode) route through `monitor_youtube()`, so this is the single after-selection entry point.
+
+2. **Non-blocking dispatch**: `start_antifafm_background()` has synchronous setup (FFmpeg/Edge cleanup, ~5s settle, stream verification), so it is launched on a daemon `threading.Thread` to avoid stalling the YouTube daemon (the original boot-time stall is what broke it). Wrapped in `try/except` — a broadcaster failure logs and continues; it never breaks the monitor.
+
+3. **Reuses the existing `antifafm_broadcaster` instance lock** inside `start_antifafm_background()` — no second lock added.
+
+4. **Boundary test untouched and still green**: `ANTIFAFM_AUTOSTART` does not match the boundary test's `ANTIFAFM_AUTO_START` regex; the new code calls `start_antifafm_background()` (not OBSController/`start_obs_stream`/`init_dynamic_metadata`/`rotator_thread.start`), and module-scope boot is unchanged. No edit to `test_main_menu_startup_boundary.py` was required.
+
+5. **Tests added**: `tests/test_monitor_youtube_antifafm_autostart.py` (4 tests) — extracts `monitor_youtube()` via AST and runs it with all inner deps mocked (no real browser/FFmpeg/OBS/broadcast). Asserts: flag=1 launches, unset is OFF, explicit 0 is OFF, retired `ANTIFAFM_AUTO_START` does NOT trigger the new gate. Non-vacuity verified by mutation: always-on gate fails the OFF tests; removed gate fails the ON test.
+
+**Safety**: Default OFF -> merging does NOT auto-broadcast. 012 enables via `.env` (`ANTIFAFM_AUTOSTART=1`). `start_antifafm_background()` additionally returns False harmlessly without `ANTIFAFM_YOUTUBE_STREAM_KEY`, and the launch is lock-guarded.
+
+**Scope**: Touched only `main.py` (`monitor_youtube`) + new test + this ModLog note. Broadcaster internals, OBS, scheduler, and music R&D are out of scope.
+
+---
+
 ## V3.5.0 - Main Menu Startup Boundary Fix (2026-05-26)
 
 **Slice**: `MAIN_MENU_ANTIFAFM_STARTUP_BOUNDARY_FIX_PHASE1`

--- a/modules/platform_integration/antifafm_broadcaster/tests/test_monitor_youtube_antifafm_autostart.py
+++ b/modules/platform_integration/antifafm_broadcaster/tests/test_monitor_youtube_antifafm_autostart.py
@@ -1,0 +1,216 @@
+# -*- coding: utf-8 -*-
+"""Tests for the opt-in after-selection antifaFM auto-launch in monitor_youtube.
+
+ANTIFAFM_AUTOSTART_AFTER_SELECT_PHASE1
+
+The 24/7 antifaFM broadcaster must NOT launch at menu boot (that block was
+deliberately removed because it broke the daemon -- see
+MAIN_MENU_ANTIFAFM_STARTUP_BOUNDARY_FIX_PHASE1). Instead it may launch AFTER 012
+selects/starts the YouTube DAE -- i.e. inside main.monitor_youtube() (the
+function both menu option 1 and option 6 route through).
+
+These tests pin the gate behavior WITHOUT importing the full main.py (which runs
+heavy module-scope startup and needs a logs/ dir). We extract ONLY the
+monitor_youtube() source via AST and execute it in a controlled namespace where
+every inner dependency is mocked. No real browser, FFmpeg, OBS, or YouTube Live
+broadcast is touched.
+
+Non-vacuity contract:
+- ANTIFAFM_AUTOSTART=1  -> monitor_youtube() invokes start_antifafm_background.
+- ANTIFAFM_AUTOSTART unset/0 (default OFF) -> it does NOT.
+- The mocked start_antifafm_background runs on the real threading dispatch, so a
+  removed/always-on gate would flip exactly one of these assertions and fail.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+# Project root (tests/ -> antifafm_broadcaster/ -> platform_integration/ ->
+# modules/ -> repo root).
+PROJECT_ROOT = Path(__file__).parents[4]
+MAIN_PY = PROJECT_ROOT / "main.py"
+
+
+def _extract_monitor_youtube_source() -> str:
+    """Return the exact source text of the async monitor_youtube function."""
+    tree = ast.parse(MAIN_PY.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "monitor_youtube":
+            return ast.get_source_segment(MAIN_PY.read_text(encoding="utf-8"), node)
+    raise AssertionError("async monitor_youtube not found in main.py")
+
+
+def _install_fake_inner_modules(start_spy: mock.Mock) -> dict:
+    """Patch sys.modules with the modules monitor_youtube imports function-locally.
+
+    Returns the patched sys.modules dict context manager backing store; callers
+    should use it under mock.patch.dict.
+    """
+    fakes: dict[str, types.ModuleType] = {}
+
+    # instance_lock: get_instance_lock(name) -> lock with no duplicates, acquires.
+    lock = mock.Mock()
+    lock.check_duplicates.return_value = []
+    lock.acquire.return_value = True
+    lock.release.return_value = None
+    inst_mod = types.ModuleType(
+        "modules.infrastructure.instance_lock.src.instance_manager"
+    )
+    inst_mod.get_instance_lock = mock.Mock(return_value=lock)
+    fakes["modules.infrastructure.instance_lock.src.instance_manager"] = inst_mod
+
+    # youtube_auth: preflight returns a healthy, no-reauth-needed status.
+    auth_mod = types.ModuleType(
+        "modules.platform_integration.youtube_auth.src.youtube_auth"
+    )
+    auth_mod.preflight_oauth_check = mock.Mock(
+        return_value={
+            "healthy": [1, 10],
+            "expired": [],
+            "missing": [],
+            "reauth_needed": False,
+        }
+    )
+    fakes["modules.platform_integration.youtube_auth.src.youtube_auth"] = auth_mod
+
+    # quota_monitor: empty summary (the per-set loop just skips).
+    quota_mod = types.ModuleType(
+        "modules.platform_integration.youtube_auth.src.quota_monitor"
+    )
+    quota_instance = mock.Mock()
+    quota_instance.get_usage_summary.return_value = {"sets": {}}
+    quota_mod.QuotaMonitor = mock.Mock(return_value=quota_instance)
+    fakes["modules.platform_integration.youtube_auth.src.quota_monitor"] = quota_mod
+
+    # ai_overseer preflight resolution: on_preflight_fail is best-effort no-op.
+    overseer_mod = types.ModuleType(
+        "modules.ai_intelligence.ai_overseer.src.preflight_resolution"
+    )
+    overseer_mod.on_preflight_fail = mock.Mock()
+    fakes["modules.ai_intelligence.ai_overseer.src.preflight_resolution"] = overseer_mod
+
+    # auto_moderator_dae: AutoModeratorDAE().run() is an awaitable no-op so the
+    # function returns immediately after the (already-evaluated) autostart gate.
+    dae_mod = types.ModuleType("modules.communication.livechat.src.auto_moderator_dae")
+
+    class _FakeDAE:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def run(self):
+            return None
+
+    dae_mod.AutoModeratorDAE = _FakeDAE
+    fakes["modules.communication.livechat.src.auto_moderator_dae"] = dae_mod
+
+    return fakes
+
+
+def _build_monitor_youtube(start_spy: mock.Mock):
+    """Compile monitor_youtube() into an isolated namespace with mocked globals."""
+    src = _extract_monitor_youtube_source()
+    import os as _os
+    import logging as _logging
+
+    ns: dict = {
+        "os": _os,
+        "sys": sys,
+        "logger": _logging.getLogger("test_monitor_youtube"),
+        "Optional": __import__("typing").Optional,
+        "Dict": __import__("typing").Dict,
+        # The module-level symbol monitor_youtube references directly:
+        "start_antifafm_background": start_spy,
+        # builtins input must never block in tests; default OAuth path avoids it,
+        # but guard anyway.
+        "input": lambda *a, **k: "2",
+    }
+    exec(compile(src, str(MAIN_PY), "exec"), ns)
+    return ns["monitor_youtube"]
+
+
+def _run_monitor(monkeyenv: dict | None, start_spy: mock.Mock) -> None:
+    fakes = _install_fake_inner_modules(start_spy)
+    monitor_youtube = _build_monitor_youtube(start_spy)
+    with mock.patch.dict(sys.modules, fakes):
+        asyncio.run(monitor_youtube(env_overrides=monkeyenv, auto_reauth=True))
+
+
+def test_autostart_flag_on_launches_broadcaster(monkeypatch):
+    """ANTIFAFM_AUTOSTART=1 -> monitor_youtube launches the broadcaster."""
+    monkeypatch.delenv("ANTIFAFM_AUTOSTART", raising=False)
+    start_spy = mock.Mock(return_value=True)
+
+    # Pass the flag via env_overrides (real path used by the menu) so the gate
+    # sees it set inside the function.
+    _run_monitor({"ANTIFAFM_AUTOSTART": "1"}, start_spy)
+
+    # Dispatched on a daemon thread -- give it a beat to start.
+    import time
+
+    for _ in range(50):
+        if start_spy.called:
+            break
+        time.sleep(0.02)
+
+    assert start_spy.called, (
+        "start_antifafm_background should be invoked when ANTIFAFM_AUTOSTART=1"
+    )
+
+
+def test_autostart_flag_off_does_not_launch_broadcaster(monkeypatch):
+    """Default OFF: no ANTIFAFM_AUTOSTART -> broadcaster is NOT launched."""
+    monkeypatch.delenv("ANTIFAFM_AUTOSTART", raising=False)
+    start_spy = mock.Mock(return_value=True)
+
+    _run_monitor(None, start_spy)
+
+    import time
+
+    time.sleep(0.2)  # would-be thread window
+    assert not start_spy.called, (
+        "start_antifafm_background must NOT run when ANTIFAFM_AUTOSTART is unset"
+    )
+
+
+def test_autostart_flag_explicit_zero_does_not_launch(monkeypatch):
+    """Explicit ANTIFAFM_AUTOSTART=0 is OFF (regression guard)."""
+    monkeypatch.delenv("ANTIFAFM_AUTOSTART", raising=False)
+    start_spy = mock.Mock(return_value=True)
+
+    _run_monitor({"ANTIFAFM_AUTOSTART": "0"}, start_spy)
+
+    import time
+
+    time.sleep(0.2)
+    assert not start_spy.called, (
+        "start_antifafm_background must NOT run when ANTIFAFM_AUTOSTART=0"
+    )
+
+
+def test_gate_is_distinct_from_retired_flag(monkeypatch):
+    """The retired ANTIFAFM_AUTO_START name must NOT trigger the new gate.
+
+    Setting only the old flag (underscore between AUTO and START) must leave the
+    broadcaster OFF -- proving the new gate keys on ANTIFAFM_AUTOSTART, not the
+    deprecated/ignored ANTIFAFM_AUTO_START.
+    """
+    monkeypatch.delenv("ANTIFAFM_AUTOSTART", raising=False)
+    start_spy = mock.Mock(return_value=True)
+
+    _run_monitor({"ANTIFAFM_AUTO_START": "1"}, start_spy)
+
+    import time
+
+    time.sleep(0.2)
+    assert not start_spy.called, (
+        "Retired ANTIFAFM_AUTO_START must not trigger the after-selection autostart"
+    )


### PR DESCRIPTION
## Slice: ANTIFAFM_AUTOSTART_AFTER_SELECT_PHASE1
**Worker-Lane:** ANTIFAFM-AUTOSTART

### Why boot-launch was removed
The 24/7 antifaFM broadcaster used to auto-launch at **menu boot** via the legacy `ANTIFAFM_AUTO_START` block in `main.py`. That boot-time launch **broke the daemon** (OBS/FFmpeg/metadata/rotator side effects, plus a blocking ~5s+ stall, before any user action). It was deliberately removed in V3.5.0 (`MAIN_MENU_ANTIFAFM_STARTUP_BOUNDARY_FIX_PHASE1`) and is enforced by `test_main_menu_startup_boundary.py`, which forbids the `ANTIFAFM_AUTO_START` gate + OBS/FFmpeg/rotator/metadata auto-start at module scope. The old flag is now deprecated/ignored.

### What this PR does (after-selection, non-blocking placement)
Re-enables auto-launch at the **correct, safe place**: *after* 012 selects/starts the YouTube DAE, inside `main.monitor_youtube()` (function scope) — never at module-scope boot.
- Insertion point: after the instance lock is acquired and OAuth preflight completes, immediately before the blocking `await dae.run()`.
- Both YouTube DAE menu **option 1** (Live Chat Monitor) and **option 6** (Full Production Mode) route through `monitor_youtube()` (`youtube_menu.py:215` / `:314`), so this is the single after-selection entry point.
- `start_antifafm_background()` has synchronous setup (FFmpeg/Edge cleanup, ~5s settle, stream verification), so it is dispatched on a **daemon `threading.Thread`** to avoid stalling the YouTube daemon. Wrapped in `try/except` — a broadcaster failure logs and continues; it never breaks the monitor.
- Reuses the existing `antifafm_broadcaster` instance lock inside `start_antifafm_background()` — no second lock added.

### New flag vs retired flag
- New: **`ANTIFAFM_AUTOSTART`** (no underscore between `AUTO` and `START`), default `"0"`/OFF.
- Retired/ignored: `ANTIFAFM_AUTO_START` (still deprecated; does NOT trigger the new gate).

### Boundary-test handling
`test_main_menu_startup_boundary.py` is **untouched and still green (12 tests)**. The new flag name does not match the boundary regex `ANTIFAFM_AUTO_START`; the new code calls `start_antifafm_background()` (not OBSController/`start_obs_stream`/`init_dynamic_metadata`/`rotator_thread.start`); module-scope boot is unchanged. No allowance/edit to the boundary test was required.

### Default-OFF + stream-key safety
This launches a **real outward-facing YouTube Live broadcast when enabled**, so:
- Default **OFF** -> merging this PR does **not** auto-broadcast.
- 012 opts in via `.env` (`ANTIFAFM_AUTOSTART=1`).
- `start_antifafm_background()` returns `False` harmlessly without `ANTIFAFM_YOUTUBE_STREAM_KEY`.
- Launch is lock-guarded.

### Non-vacuity proof
New test `test_monitor_youtube_antifafm_autostart.py` (4 tests, **mock-only, no real browser/FFmpeg/OBS/broadcast**) extracts `monitor_youtube()` via AST and runs it with all inner deps mocked:
- `ANTIFAFM_AUTOSTART=1` -> `start_antifafm_background` is invoked.
- unset (default) -> NOT invoked.
- explicit `0` -> NOT invoked.
- retired `ANTIFAFM_AUTO_START=1` only -> NOT invoked.

Mutation-verified:
- **Always-on** mutation (`if True`) -> the 3 OFF/regression tests FAIL.
- **Removed/never-launch** mutation (`if False`) -> the ON test FAILS.

```
pytest test_monitor_youtube_antifafm_autostart.py + test_main_menu_startup_boundary.py
16 passed in 0.78s
```

### Scope
Touched only `main.py` (`monitor_youtube`) + new test + `antifafm_broadcaster/ModLog.md`. Broadcaster internals, OBS, scheduler, and music R&D are out of scope. Boundary test not modified.

**Status:** VERIFIED_READY — do NOT merge (leave open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
