### PR TITLE
feat(youtube_shorts_scheduler): reschedule rebalance PLAN (dry-run, read-only) -- Mode B Phase 1

### DIFF
--- a/modules/communication/moltbot_bridge/src/youtube_automation_adapter.py
+++ b/modules/communication/moltbot_bridge/src/youtube_automation_adapter.py
@@ -10,12 +10,14 @@ Supported actions:
   indexing          -> video indexer CLI
   scheduling        -> shorts scheduler CLI
   schedule_priority -> what_should_i_schedule SKILLz (read-only channel need ranking)
+  reschedule_plan   -> reschedule_plan SKILLz (dry-run rebalance PLAN for over-cap days; apply is Phase 2)
 
 Examples:
   youtube action comments channel=move2japan max_comments=3 like=true heart=true reply=false
   youtube action indexing channel=undaodu batch_size=5
   youtube action scheduling channel=foundups max_videos=3 dry_run=true
   youtube action schedule_priority upcoming_days=7
+  youtube action reschedule_plan horizon_days=90
 """
 
 from __future__ import annotations
@@ -29,7 +31,13 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 
-SUPPORTED_ACTIONS = {"comments", "indexing", "scheduling", "schedule_priority"}
+SUPPORTED_ACTIONS = {
+    "comments",
+    "indexing",
+    "scheduling",
+    "schedule_priority",
+    "reschedule_plan",
+}
 
 ACTION_ALIASES = {
     "comment": "comments",
@@ -44,6 +52,10 @@ ACTION_ALIASES = {
     "what_should_i_schedule": "schedule_priority",
     "schedule_next": "schedule_priority",
     "scheduling_priority": "schedule_priority",
+    # reschedule_plan SKILLz: dry-run rebalance PLAN for over-cap days (apply=Phase 2)
+    "reschedule": "reschedule_plan",
+    "rebalance": "reschedule_plan",
+    "rebalance_plan": "reschedule_plan",
 }
 
 # Repo root: modules/communication/moltbot_bridge/src -> parents[4]
@@ -290,6 +302,25 @@ def _build_schedule_priority_command(params: Dict[str, str]) -> list[str]:
     return cmd
 
 
+def _build_reschedule_plan_command(params: Dict[str, str]) -> list[str]:
+    """Build the dry-run reschedule_plan SKILLz invocation.
+
+    Agent/DAE-invoked rebalance PLAN for over-crowded schedule days. Read-only:
+    no browser, no mutation, no live model. The mutating apply is a Phase-2 slice.
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "modules.platform_integration.youtube_shorts_scheduler.skillz.reschedule_plan.run_skill",
+        "--horizon-days",
+        str(_int_param(params, "horizon_days", 90)),
+        "--json",
+    ]
+    if _truthy(params.get("no_signals", "false")):
+        cmd.append("--no-signals")
+    return cmd
+
+
 async def execute_youtube_action(action: str, params: Dict[str, str]) -> Dict[str, Any]:
     if action == "comments":
         cmd = _build_comments_command(params)
@@ -320,6 +351,21 @@ async def execute_youtube_action(action: str, params: Dict[str, str]) -> Dict[st
 
     if action == "schedule_priority":
         cmd = _build_schedule_priority_command(params)
+        timeout_s = _int_param(params, "timeout_s", 120)
+        run_result = await asyncio.to_thread(_run_subprocess, cmd, timeout_s)
+        parsed = _extract_json_tail(run_result.get("stdout_tail", ""))
+        success = bool(run_result.get("success", False))
+        if isinstance(parsed, dict) and parsed.get("success") is False:
+            success = False
+        return {
+            "success": success,
+            "action": action,
+            "result": parsed,
+            **run_result,
+        }
+
+    if action == "reschedule_plan":
+        cmd = _build_reschedule_plan_command(params)
         timeout_s = _int_param(params, "timeout_s", 120)
         run_result = await asyncio.to_thread(_run_subprocess, cmd, timeout_s)
         parsed = _extract_json_tail(run_result.get("stdout_tail", ""))

--- a/modules/platform_integration/youtube_shorts_scheduler/ModLog.md
+++ b/modules/platform_integration/youtube_shorts_scheduler/ModLog.md
@@ -1,5 +1,75 @@
 # YouTube Shorts Scheduler - ModLog
 
+## 2026-06-19 - reschedule_plan SKILLz: dry-run rebalance PLAN for over-cap days (Mode B Phase 1)
+
+**By:** 0102 (Worker-Lane RESCHED-PLAN)
+**Slice:** SHORTS_RESCHEDULE_PLAN_PHASE1
+**WSP References:** WSP 95 (SKILLz Wardrobe), WSP 77 (Agent Coordination), WSP 91 (Observability), WSP 60/48 (Pattern Memory), WSP 22 (ModLog), WSP 49 (Structure), WSP 50 (Pre-Action), WSP 84 (Code Reuse)
+
+### Problem
+
+Before the per-day cap landed (`HARD_CAP_PER_DAY = 3`, `src/schedule_tracker.py:30`, #844), the
+historical backlog was scheduled at up to 8/day. Those over-crowded days are now over the cap. The
+agent needs a PREVIEW PLAN that proposes moving the excess (`count > 3`) off each over-crowded day
+onto under-target upcoming days, into the US-ET peak slots converted per channel tz. This is the
+decision layer; the mutating DOM apply is a separate Phase-2 follow-up.
+
+### Phase 0 confirmation (verified, not assumed)
+
+1. **Tracker DATA MODEL = video<->date AND counts.** `ScheduleTracker` stores BOTH
+   `schedule: Dict[date_str, int]` (`src/schedule_tracker.py:100`) AND
+   `video_ids: Dict[date_str, List[str]]` (`:101`); both persisted (`:127-128`). So the plan NAMES
+   which videos move when ids are recorded. BUT `count` is authoritative and can exceed the recorded
+   id list (`set_count()` `:185-193` and `sync_from_youtube()` can leave `video_ids` incomplete, and
+   the historical 8/day backlog predates id tracking). Surplus moves beyond recorded ids are labelled
+   `video_id="(needs-live-list)"` -- naming those specific videos needs the LIVE Studio list (Phase 2).
+2. **Peak slots + per-channel tz CONFIRMED (#847).** `src/peak_window.py`: `get_peak_slots_et()`
+   returns ET `["08:00","12:00","20:00"]`; `convert_et_to_channel_tz(et_time, channel_tz, on_date)`
+   does the DST-aware ET->account-tz wall-clock conversion (verified: NY 08:00->8:00 AM identity,
+   Tokyo 08:00->10:00 PM JST, NY 20:00->8:00 PM).
+3. **SKILLz pattern CITED + mirrored (#850).** `skillz/what_should_i_schedule/{SKILLz.md, executor.py,
+   run_skill.py, __init__.py}` -- Skills 2.0 frontmatter, pure executor + lazy-imported breadcrumb /
+   PatternMemory emit helpers, JSON-tail `run_skill` entrypoint, `--agent-command` wiring in
+   `modules/communication/moltbot_bridge/src/youtube_automation_adapter.py` (action +
+   `_build_*_command` + dispatch). New skill mirrors this exactly.
+
+### Changes (DRY-RUN / read-only, agent-invoked -- NO manual-012 apply path)
+
+1. **New pure planner** `src/reschedule_planner.py`:
+   - `find_over_cap_days(schedule, cap)`: days with `count > cap`; `excess = count - cap`.
+   - `find_target_days(...)`: under-cap upcoming days (after today, within horizon), excluding the
+     over-crowded source days; nearest-first.
+   - `assign_peak_slot(slot_index, channel_tz, on_date)`: maps fill-index 0/1/2 to ET morning/lunch/
+     evening, converted to the channel tz (#847).
+   - `plan_channel_reschedule(...)`: for each over-cap day, place the excess on the nearest target
+     with free capacity, filling each target up to (NEVER over) the cap, assigning peak slots. Returns
+     `ChannelReschedulePlan` (moves + days_over_cap, total_moves, unplaceable_moves).
+   - `plan_all_channels(...)`: aggregates across registry shorts channels; `dry_run: True` always.
+2. **New SKILLz** `skillz/reschedule_plan/{SKILLz.md, executor.py, run_skill.py, __init__.py}`:
+   - `run_skill(...)`: runs the planner and emits a breadcrumb (`source_dae=youtube_shorts_scheduler`,
+     `event_type=reschedule_plan`, full plan in metadata) + a PatternMemory `SkillOutcome` per run.
+   - `DRY_RUN = True` constant pins the preview contract; the apply is Phase 2.
+3. **--agent-command wiring** in `youtube_automation_adapter.py`: `reschedule_plan` action +
+   aliases (`reschedule`/`rebalance`/`rebalance_plan`) + `_build_reschedule_plan_command` + dispatch.
+   `youtube action reschedule_plan [horizon_days=N] [no_signals=true]`.
+
+### Documented Phase-2 / future seams (NOT built here)
+
+- **DOM apply / mutation**: the `ytcp-video-visibility-edit-popup` date/time-picker applier that
+  consumes the plan rows (each row is a complete move instruction). Gated behind its own slice.
+- **View-based ("low-viewed first") prioritization**: choosing WHICH videos move by per-video view
+  counts -- needs view data NOT in the tracker (separate Phase-2 signal). Target-DAY selection here
+  is date-driven; the `find_target_days` / `_video_ids_for_excess` seams are where it would plug in.
+
+### Tests (mock-only, NON-VACUOUS)
+
+`tests/test_reschedule_planner.py` (14 tests, all pass): day at 5 -> exactly 2 moves with no target
+over cap; near target at cap-1 takes only 1; fully-<=cap schedule -> empty plan; NY identity +
+Tokyo-offset peak/tz assignment; recorded surplus ids NAMED + missing surplus -> `(needs-live-list)`;
+no-target-within-horizon -> unplaceable; breadcrumb + PatternMemory emit invoked; `--no-signals`
+skips emit. Non-vacuity PROVEN: sabotaging the planner to ignore over-cap days fails 9/14 (incl.
+`test_planner_must_not_ignore_over_cap`). Existing adapter suite still 9/9 green.
+
 ## 2026-06-19 - what_should_i_schedule SKILLz: channel scheduling-priority (Phase 1)
 
 **By:** 0102 (Worker-Lane SCHED-PRIORITY)

--- a/modules/platform_integration/youtube_shorts_scheduler/skillz/reschedule_plan/SKILLz.md
+++ b/modules/platform_integration/youtube_shorts_scheduler/skillz/reschedule_plan/SKILLz.md
@@ -1,0 +1,211 @@
+---
+# Metadata (YAML Frontmatter)
+name: reschedule_plan
+description: Compute a dry-run REBALANCE PLAN for over-crowded schedule days -- move count>cap excess onto under-target upcoming days into US-ET peak slots per channel tz (read-only, agent-invoked; apply is Phase 2)
+version: 1.0_prototype
+author: 0102
+created: 2026-06-19
+agents: [qwen, gemma]
+primary_agent: qwen
+intent_type: PLANNING
+promotion_state: prototype
+pattern_fidelity_threshold: 0.90
+test_status: needs_validation
+
+# Dependencies
+dependencies:
+  data_stores:
+    - name: schedule_tracker
+      type: json
+      path: modules/platform_integration/youtube_shorts_scheduler/memory/schedule_{channel_id}.json
+  required_context:
+    - horizon_days: "How far ahead to search for under-target days (default 90)"
+  throttles:
+    - name: read_only
+      max_rate: unlimited
+      cost_per_call: 0
+
+# Metrics Configuration
+metrics:
+  pattern_fidelity_scoring:
+    enabled: true
+    frequency: every_execution
+    scorer_agent: gemma
+  promotion_criteria:
+    min_pattern_fidelity: 0.90
+    min_outcome_quality: 0.85
+    min_execution_count: 100
+    required_test_pass_rate: 0.95
+category: capability-uplift
+evals: []
+retirement_date: null
+---
+# reschedule_plan
+
+**Purpose**: Compute a dry-run REBALANCE PLAN for over-crowded schedule days. The
+historical backlog was scheduled at up to 8/day before the per-day cap landed
+(`HARD_CAP_PER_DAY = 3`, `schedule_tracker.py`, #844). This skill proposes moving
+the excess (`count > cap`) off each over-crowded day onto the nearest under-target
+upcoming days, placing each moved item into a US-ET peak slot converted to the
+channel's Studio-account timezone (`peak_window.py`, #847).
+
+**Intent Type**: PLANNING
+
+**Agent**: Qwen (plans the rebalance) / Gemma (validates the deterministic math).
+
+**For the agent, never for a human**: the WRE/daemon triggers this SKILLz and the
+`--agent-command` surface invokes it programmatically. 012 only observes the emitted
+breadcrumb + PatternMemory outcome and the JSON plan. There is NO manual-012 apply.
+
+---
+
+## DRY-RUN / READ-ONLY (Mode B Phase 1)
+
+This is the PREVIEW/decision layer. `DRY_RUN` is ALWAYS `True` in this slice: the
+skill RETURNS the plan and emits learning signals, but NEVER mutates a schedule,
+never opens a browser, never calls a live model. The mutating DOM apply (click
+"Scheduled" -> `ytcp-video-visibility-edit-popup` date/time picker) is an explicit
+**Phase-2** follow-up, NOT built here.
+
+---
+
+## Data source (offline, reliable, no browser)
+
+Reads `memory/schedule_<CHANNEL_ID>.json` via `ScheduleTracker`. The tracker stores
+BOTH `schedule` (`date -> count`) AND `video_ids` (`date -> [video_ids]`). Channels
++ IDs + IANA timezone come from `youtube_channel_registry` (`get_channels(role="shorts")`).
+No DOM, no live model, no mutation.
+
+---
+
+## Plan granularity (Phase 0 finding)
+
+A video<->date mapping EXISTS (`video_ids`), so the plan NAMES which videos move
+when the ids are recorded for the over-crowded day. BUT `count` is authoritative
+and can exceed the recorded id list (`set_count()`/`sync_from_youtube()` can leave
+`video_ids` incomplete, and the historical 8/day backlog predates id tracking).
+When recorded ids are fewer than the excess, the surplus moves are labelled
+`video_id="(needs-live-list)"` -- naming those specific videos needs the LIVE
+Studio list (**Phase 2**).
+
+---
+
+## The plan algorithm
+
+For each channel:
+1. `find_over_cap_days`: days with `count > cap`; `excess = count - cap` must move.
+2. `find_target_days`: under-cap upcoming days (`count < cap`, after today, within
+   horizon), excluding the over-crowded source days; nearest-first.
+3. For each excess item, place it on the nearest target with free capacity, filling
+   each target up to (NEVER over) the cap. Assign the peak slot by fill-index
+   (0->08:00 ET morning, 1->12:00 ET lunch, 2->20:00 ET evening), converted to the
+   channel tz (`convert_et_to_channel_tz`, DST-aware).
+
+Excess that finds no under-cap target within the horizon is counted as
+`unplaceable_moves`.
+
+---
+
+## Output (consumed by daemon / Qwen)
+
+```json
+{
+  "dry_run": true,
+  "skill": "reschedule_plan",
+  "cap": 3,
+  "channel_count": 4,
+  "channels": [
+    {
+      "channel_id": "...", "channel_name": "FoundUps", "timezone": "America/New_York",
+      "cap": 3, "days_over_cap": 1, "total_moves": 2, "unplaceable_moves": 0,
+      "moves": [
+        {"channel_id":"...","channel_name":"FoundUps","from_date":"Jan 5, 2026","to_date":"Jan 2, 2026","slot_et":"08:00","slot_local":"8:00 AM","video_id":"abc123"},
+        {"channel_id":"...","channel_name":"FoundUps","from_date":"Jan 5, 2026","to_date":"Jan 2, 2026","slot_et":"12:00","slot_local":"12:00 PM","video_id":"(needs-live-list)"}
+      ]
+    }
+  ],
+  "summary": {"days_over_cap": 1, "total_moves": 2, "unplaceable_moves": 0, "channels_needing_rebalance": 1},
+  "success": true,
+  "breadcrumb_emitted": true,
+  "outcome_stored": true
+}
+```
+
+---
+
+## Signal emission (WRE self-improvement testbed)
+
+Every run emits BOTH:
+- **Breadcrumb** (WSP 91) via `get_breadcrumb_telemetry().store_breadcrumb(source_dae="youtube_shorts_scheduler", event_type="reschedule_plan", ...)` with the full plan in metadata.
+- **PatternMemory SkillOutcome** (WSP 60/48) via `PatternMemory().store_outcome(SkillOutcome(skill_name="reschedule_plan", ...))`.
+
+---
+
+## Invocation
+
+**SKILLz (WRE / daemon):**
+```python
+from modules.platform_integration.youtube_shorts_scheduler.skillz.reschedule_plan.executor import run_skill
+plan = run_skill()  # dry-run; emits breadcrumb + PatternMemory
+```
+
+**--agent-command (agent/DAE-invocable, structured JSON):**
+```bash
+python main.py --agent-command "youtube action reschedule_plan"
+# adapter spawns:
+python -m modules.platform_integration.youtube_shorts_scheduler.skillz.reschedule_plan.run_skill --json
+```
+
+---
+
+## Malleable seams (intentional)
+
+- **Data source** is injected via `load_schedule` (default: `ScheduleTracker` JSON).
+  A future LIVE Studio scrape plugs in here WITHOUT touching the plan math.
+- **Plan math** lives in `src/reschedule_planner.py` behind pure functions
+  (`find_over_cap_days` / `find_target_days` / `assign_peak_slot`). Slot policy and
+  target selection are independently swappable.
+
+---
+
+## Out of scope (separate Phase-2 follow-ups -- NOT built here)
+
+- **DOM apply / mutation**: the `ytcp-video-visibility-edit-popup` date/time picker
+  applier that consumes the plan rows. Each plan row is already a complete move
+  instruction (channel, from_date, to_date, slot_et, slot_local, video_id).
+- **View-based ("low-viewed first") prioritization**: choosing WHICH videos move by
+  per-video view counts -- needs view data that is NOT in the tracker (separate
+  Phase-2 signal). Target-DAY selection here is date-driven.
+- The live filter-fix; the music-vs-talk content gate.
+
+---
+
+## Expected patterns (WSP 95 fidelity)
+
+```json
+{
+  "skill": "reschedule_plan",
+  "patterns": {
+    "channels_loaded": true,
+    "over_cap_days_found": true,
+    "targets_selected": true,
+    "moves_assigned_peak_slots": true,
+    "cap_never_exceeded_on_targets": true,
+    "breadcrumb_emitted": true,
+    "outcome_stored": true
+  }
+}
+```
+
+---
+
+## Success criteria
+
+- A day at 5 (cap=3) plans exactly 2 moves; no target day exceeds the cap.
+- A fully-<=cap schedule plans 0 moves (`total_moves == 0`).
+- Peak slot + per-channel tz assignment correct (ET -> channel-tz wall clock).
+- Breadcrumb + PatternMemory emitted on every run.
+- Strictly dry-run: `dry_run == true`, no mutation, no browser, no live model.
+
+**WSP Compliance**: WSP 95 (SKILLz Wardrobe), WSP 77 (Agent Coordination),
+WSP 91 (Observability), WSP 60/48 (Pattern Memory), WSP 27 (Phase 0 KNOWLEDGE).

--- a/modules/platform_integration/youtube_shorts_scheduler/skillz/reschedule_plan/__init__.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/skillz/reschedule_plan/__init__.py
@@ -1,0 +1,11 @@
+"""reschedule_plan SKILLz package.
+
+Dry-run REBALANCE PLAN for over-crowded schedule days (move count>cap excess onto
+under-target upcoming days, into US-ET peak slots per channel tz). Read-only; the
+mutating DOM apply is an explicit Phase-2 follow-up. See SKILLz.md for the WSP 95
+micro chain-of-thought contract.
+"""
+
+from .executor import DRY_RUN, run_skill
+
+__all__ = ["run_skill", "DRY_RUN"]

--- a/modules/platform_integration/youtube_shorts_scheduler/skillz/reschedule_plan/executor.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/skillz/reschedule_plan/executor.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+reschedule_plan - SKILLz Executor
+
+Computes a dry-run REBALANCE PLAN for over-crowded schedule days. The historical
+backlog was scheduled at up to 8/day before the per-day cap landed (#844,
+HARD_CAP_PER_DAY=3). This SKILLz proposes moving the excess (count > cap) off each
+over-crowded day onto the nearest under-target upcoming days, placing each moved
+item into a US-ET peak slot converted to the channel Studio-account timezone
+(peak_window.py, #847).
+
+DRY-RUN / READ-ONLY (Mode B Phase 1)
+------------------------------------
+This is the PREVIEW/decision layer. DRY_RUN is ALWAYS True in this slice: the skill
+RETURNS the plan and emits learning signals, but NEVER mutates a schedule, never
+opens a browser, never calls a live model. The mutating DOM apply (click
+"Scheduled" -> ytcp-video-visibility-edit-popup date/time picker) is an explicit
+Phase-2 follow-up wired through this same plan -- NOT built here.
+
+For the agent, never for a human
+--------------------------------
+The WRE/daemon triggers this SKILLz and the `--agent-command` surface invokes it
+(`youtube action reschedule_plan`). 012 only OBSERVES the emitted breadcrumb +
+PatternMemory outcome and the JSON plan. There is NO manual-012 apply path.
+
+WSP Compliance:
+    WSP 95: SKILLz Wardrobe (micro chain-of-thought + pattern fidelity)
+    WSP 77: Agent Coordination (Qwen/daemon consumes the plan)
+    WSP 91: DAEmon Observability (breadcrumb on every run)
+    WSP 60/48: Pattern Memory outcome on every run (WRE self-improvement)
+    WSP 27: Phase 0 KNOWLEDGE (plan-before-act)
+
+Malleable seams (intentional):
+    - DATA SOURCE is injected via `load_schedule` (default: ScheduleTracker JSON).
+      A future LIVE Studio scrape plugs in here WITHOUT touching the plan math.
+    - PLAN MATH lives in src/reschedule_planner.py behind pure functions
+      (find_over_cap_days / find_target_days / assign_peak_slot). Slot policy and
+      target selection are independently swappable.
+    - Phase-2 apply seam: each plan row is a complete move instruction; the Phase-2
+      DOM applier consumes rows. View-based ("low-viewed first") prioritization
+      needs per-video view data (NOT in the tracker) -- separate Phase-2 signal.
+
+Usage (agent / daemon):
+    from .executor import run_skill
+    plan = run_skill()  # dry-run; emits breadcrumb + PatternMemory
+
+Usage (--agent-command surface, via youtube_automation_adapter):
+    youtube action reschedule_plan
+    (the adapter spawns: python -m ...skillz.reschedule_plan.run_skill --json)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Authoritative per-day cap, imported from the tracker (#844).
+try:
+    from modules.platform_integration.youtube_shorts_scheduler.src.schedule_tracker import (
+        HARD_CAP_PER_DAY,
+    )
+except Exception:  # pragma: no cover - defensive import for isolated tests
+    HARD_CAP_PER_DAY = 3
+
+from modules.platform_integration.youtube_shorts_scheduler.src.reschedule_planner import (
+    plan_all_channels,
+)
+
+# This slice is ALWAYS a dry-run preview. The mutating apply is a Phase-2 slice
+# that flips its own gate; this constant documents the seam and pins the behavior.
+DRY_RUN = True
+
+# Source DAE label for breadcrumb attribution (WSP 91).
+SOURCE_DAE = "youtube_shorts_scheduler"
+SKILL_NAME = "reschedule_plan"
+
+
+# === Signal emission (WSP 91 breadcrumb + WSP 60/48 PatternMemory) ==========
+
+def _emit_breadcrumb(result: Dict[str, Any]) -> bool:
+    """Emit a reschedule_plan breadcrumb so the WRE/overseer can learn (WSP 91)."""
+    try:
+        from modules.communication.livechat.src.breadcrumb_telemetry import (
+            get_breadcrumb_telemetry,
+        )
+
+        summary = result.get("summary", {})
+        get_breadcrumb_telemetry().store_breadcrumb(
+            source_dae=SOURCE_DAE,
+            event_type="reschedule_plan",
+            message=(
+                f"reschedule-plan (dry-run): {summary.get('days_over_cap', 0)} days "
+                f"over cap, {summary.get('total_moves', 0)} moves across "
+                f"{summary.get('channels_needing_rebalance', 0)} channel(s)"
+            ),
+            phase="RESCHEDULE_PLAN",
+            metadata={
+                "skill": SKILL_NAME,
+                "dry_run": result.get("dry_run", True),
+                "cap": result.get("cap", HARD_CAP_PER_DAY),
+                "summary": summary,
+                "plan": result.get("channels", []),
+            },
+        )
+        return True
+    except Exception as exc:  # pragma: no cover - telemetry is best-effort
+        logger.warning(f"[{SKILL_NAME}] breadcrumb emit failed: {exc}")
+        return False
+
+
+def _store_outcome(result: Dict[str, Any]) -> bool:
+    """Store a SkillOutcome so the WRE remembers each run (WSP 60/48)."""
+    try:
+        from modules.infrastructure.wre_core.src.pattern_memory import (
+            PatternMemory,
+            SkillOutcome,
+        )
+
+        summary = result.get("summary", {})
+        total_moves = summary.get("total_moves", 0)
+        outcome = SkillOutcome(
+            execution_id=f"{SKILL_NAME}-{uuid.uuid4().hex[:12]}",
+            skill_name=SKILL_NAME,
+            agent="qwen",
+            timestamp=datetime.now().isoformat(),
+            input_context=json.dumps(
+                {
+                    "dry_run": result.get("dry_run", True),
+                    "cap": result.get("cap", HARD_CAP_PER_DAY),
+                    "channels": result.get("channel_count", 0),
+                },
+                separators=(",", ":"),
+            ),
+            output_result=json.dumps({"summary": summary}, separators=(",", ":"))[:10000],
+            success=True,
+            pattern_fidelity=1.0,
+            outcome_quality=1.0 if total_moves > 0 else 0.8,
+            execution_time_ms=0,
+            step_count=total_moves,
+            failed_at_step=None,
+            notes=f"source={SKILL_NAME} dry_run=true read_only=true cap={result.get('cap')}",
+        )
+        PatternMemory().store_outcome(outcome)
+        return True
+    except Exception as exc:  # pragma: no cover - memory is best-effort
+        logger.warning(f"[{SKILL_NAME}] pattern memory store failed: {exc}")
+        return False
+
+
+def run_skill(
+    *,
+    cap: int = HARD_CAP_PER_DAY,
+    channels: Optional[List[Dict[str, str]]] = None,
+    load_schedule: Optional[Callable[[str], tuple]] = None,
+    today: Optional[datetime] = None,
+    horizon_days: Optional[int] = None,
+    emit_signals: bool = True,
+) -> Dict[str, Any]:
+    """SKILLz entry point: compute the dry-run rebalance plan + emit WRE signals.
+
+    Returns a structured result (for the daemon/Qwen to consume) including the
+    per-channel plans, the summary, and which signals were emitted. NEVER mutates.
+    """
+    plan_kwargs: Dict[str, Any] = {"cap": cap, "channels": channels, "today": today}
+    if load_schedule is not None:
+        plan_kwargs["load_schedule"] = load_schedule
+    if horizon_days is not None:
+        plan_kwargs["horizon_days"] = horizon_days
+
+    result = plan_all_channels(**plan_kwargs)
+    # Pin the dry-run contract for this slice regardless of any downstream override.
+    result["dry_run"] = DRY_RUN
+    result["skill"] = SKILL_NAME
+
+    breadcrumb_emitted = False
+    outcome_stored = False
+    if emit_signals:
+        breadcrumb_emitted = _emit_breadcrumb(result)
+        outcome_stored = _store_outcome(result)
+
+    result["success"] = True
+    result["breadcrumb_emitted"] = breadcrumb_emitted
+    result["outcome_stored"] = outcome_stored
+    return result

--- a/modules/platform_integration/youtube_shorts_scheduler/skillz/reschedule_plan/run_skill.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/skillz/reschedule_plan/run_skill.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+reschedule_plan - module entrypoint for agent/DAE invocation.
+
+This is the surface the --agent-command path spawns (DRY-RUN, read-only,
+agent-invoked):
+    youtube action reschedule_plan
+        -> python -m ...skillz.reschedule_plan.run_skill --json
+
+It is NOT a manual-012 menu and it NEVER mutates a schedule (no browser, no live
+model). 012 only observes the emitted breadcrumb / outcome and the JSON plan
+printed here. The daemon/Qwen consumes the JSON plan; the mutating apply is a
+separate Phase-2 slice.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+# UTF-8 enforcement (WSP 90) - entry point only
+if sys.platform.startswith("win"):  # pragma: no cover - platform guard
+    import io
+
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace", line_buffering=True)
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="replace", line_buffering=True)
+
+from modules.platform_integration.youtube_shorts_scheduler.skillz.reschedule_plan.executor import (
+    run_skill,
+)
+from modules.platform_integration.youtube_shorts_scheduler.src.reschedule_planner import (
+    DEFAULT_HORIZON_DAYS,
+)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "reschedule_plan SKILLz - dry-run rebalance PLAN for over-crowded "
+            "schedule days (read-only, agent-invoked; apply is Phase 2)."
+        )
+    )
+    parser.add_argument(
+        "--horizon-days",
+        type=int,
+        default=DEFAULT_HORIZON_DAYS,
+        help=f"How far ahead to search for under-target days (default {DEFAULT_HORIZON_DAYS}).",
+    )
+    parser.add_argument(
+        "--no-signals",
+        action="store_true",
+        help="Skip breadcrumb + PatternMemory emission (diagnostic only).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON (agent consumption).",
+    )
+    args = parser.parse_args(argv)
+
+    result = run_skill(
+        horizon_days=args.horizon_days,
+        emit_signals=not args.no_signals,
+    )
+
+    # Always print a single JSON line last so the adapter's _extract_json_tail can
+    # parse it deterministically.
+    print(json.dumps(result, ensure_ascii=False, separators=(",", ":")))
+    return 0 if result.get("success") else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/modules/platform_integration/youtube_shorts_scheduler/src/reschedule_planner.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/src/reschedule_planner.py
@@ -1,0 +1,457 @@
+"""
+Reschedule Planner - dry-run REBALANCE PLAN for over-crowded schedule days.
+
+Slice: SHORTS_RESCHEDULE_PLAN_PHASE1  (Mode B, Phase 1 - PREVIEW/decision layer)
+
+Problem
+-------
+Before the per-day cap landed (#844, HARD_CAP_PER_DAY=3 in schedule_tracker.py),
+the historical backlog was scheduled at up to 8/day. Those over-crowded days are
+now "illegal" against the cap. This module computes a PLAN to MOVE the excess
+(count > HARD_CAP_PER_DAY) off each over-crowded day onto the nearest under-target
+upcoming days, placing each moved item into a US-ET peak slot converted to the
+channel's Studio-account timezone (peak_window.py, #847).
+
+Strictly read-only / dry-run
+----------------------------
+This is the PREVIEW/decision layer. It NEVER mutates a schedule, never opens a
+browser, never calls a live model. It reads the persisted per-channel tracker
+(memory/schedule_<id>.json via ScheduleTracker) and RETURNS a structured plan.
+
+The MUTATING DOM apply (click "Scheduled" -> ytcp-video-visibility-edit-popup
+date/time picker) is an explicit Phase-2 follow-up, NOT built here. See the
+"Phase-2 apply seam" note below.
+
+Data model granularity (Phase 0 finding)
+-----------------------------------------
+ScheduleTracker stores BOTH:
+  - schedule:  Dict[date_str, int]        (date -> count)            line ~100
+  - video_ids: Dict[date_str, List[str]]  (date -> [video_ids])      line ~101
+So a video<->date mapping EXISTS and the plan names which videos move WHEN the
+ids are present for the over-crowded date. BUT the count is authoritative and can
+exceed the recorded id list (set_count()/sync_from_youtube() can leave video_ids
+incomplete, and the historical 8/day backlog predates id tracking). When the
+recorded ids for a date are fewer than the excess to move, the surplus moves are
+labelled video_id="(needs-live-list)" -- specific-video selection for those needs
+the LIVE Studio list (Phase 2).
+
+Malleable seams (intentional)
+-----------------------------
+- SLOT ASSIGNMENT is a pure function (assign_peak_slots) behind get_peak_slots_*.
+  Swap the peak policy WITHOUT touching the move math.
+- TARGET SELECTION (find_target_days) is pure; a future view-based ("low-viewed
+  first") prioritization plugs in here -- BUT that needs per-video view data which
+  is NOT in the tracker (Phase-2 / separate signal). See "view-data seam" below.
+- Phase-2 apply seam: a plan row is a complete instruction (channel, from_date,
+  to_date, slot_et, slot_local, video_id). The Phase-2 DOM applier consumes these
+  rows; it lives outside this module and is gated behind its own explicit slice.
+
+WSP References:
+- WSP 3:  platform_integration owns publish-time/rebalance policy.
+- WSP 84: reuse ScheduleTracker, HARD_CAP_PER_DAY (#844), peak_window.py (#847),
+          youtube_channel_registry.
+- WSP 50: pure, unit-testable; no mutation, no browser, no live model.
+- WSP 22: ModLog documents the Phase-2 apply seam + view-data prioritization seam.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Authoritative per-day cap. Imported from the tracker so this planner tracks the
+# single load-bearing knob (HARD_CAP_PER_DAY, schedule_tracker.py, landed #844).
+try:
+    from modules.platform_integration.youtube_shorts_scheduler.src.schedule_tracker import (
+        HARD_CAP_PER_DAY,
+        ScheduleTracker,
+    )
+except Exception:  # pragma: no cover - defensive import for isolated tests
+    HARD_CAP_PER_DAY = 3
+    ScheduleTracker = None  # type: ignore
+
+# Peak-slot policy + per-channel tz conversion (#847). Pure helpers.
+try:
+    from modules.platform_integration.youtube_shorts_scheduler.src.peak_window import (
+        convert_et_to_channel_tz,
+        get_peak_slots_et,
+    )
+except Exception:  # pragma: no cover - defensive import for isolated tests
+    def get_peak_slots_et() -> List[str]:  # type: ignore
+        return ["08:00", "12:00", "20:00"]
+
+    def convert_et_to_channel_tz(et_time, channel_tz, on_date):  # type: ignore
+        return et_time
+
+# How far ahead to search for under-target target days when none are free sooner.
+DEFAULT_HORIZON_DAYS = 90
+
+# Sentinel for moves whose specific video id is unknown from the tracker (needs
+# the LIVE Studio list -- Phase 2).
+NEEDS_LIVE_LIST = "(needs-live-list)"
+
+# Date format the tracker uses everywhere: "Jan 5, 2026" (Windows-safe, no %-d).
+_DATE_FMT = "%b %d, %Y"
+
+
+def _format_date(d: datetime) -> str:
+    """Format a datetime in the tracker's exact date-key format."""
+    return f"{d.strftime('%b')} {d.day}, {d.year}"
+
+
+def _parse_date(date_str: str) -> Optional[datetime]:
+    """Parse a 'Jan 5, 2026' tracker date key to a datetime (None if unparseable)."""
+    try:
+        return datetime.strptime(date_str.strip(), _DATE_FMT)
+    except ValueError:
+        try:
+            return datetime.strptime(" ".join(date_str.split()), _DATE_FMT)
+        except ValueError:
+            return None
+
+
+@dataclass
+class MovePlan:
+    """One proposed move: take an over-cap item off from_date onto to_date@slot."""
+
+    channel_id: str
+    channel_name: str
+    from_date: str
+    to_date: str
+    slot_et: str
+    slot_local: str
+    video_id: str  # real id, or NEEDS_LIVE_LIST when the tracker can't name it
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "channel_id": self.channel_id,
+            "channel_name": self.channel_name,
+            "from_date": self.from_date,
+            "to_date": self.to_date,
+            "slot_et": self.slot_et,
+            "slot_local": self.slot_local,
+            "video_id": self.video_id,
+        }
+
+
+@dataclass
+class ChannelReschedulePlan:
+    """The rebalance plan for one channel + its summary."""
+
+    channel_id: str
+    channel_name: str
+    timezone: str
+    cap: int
+    days_over_cap: int
+    total_moves: int
+    unplaceable_moves: int  # excess that found no under-cap target within horizon
+    moves: List[MovePlan] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "channel_id": self.channel_id,
+            "channel_name": self.channel_name,
+            "timezone": self.timezone,
+            "cap": self.cap,
+            "days_over_cap": self.days_over_cap,
+            "total_moves": self.total_moves,
+            "unplaceable_moves": self.unplaceable_moves,
+            "moves": [m.to_dict() for m in self.moves],
+        }
+
+
+# === Pure helper: which dates are over the cap, and by how much ===============
+
+def find_over_cap_days(
+    schedule: Dict[str, int], cap: int = HARD_CAP_PER_DAY
+) -> List[tuple]:
+    """Return [(date_str, parsed_dt, excess)] for days with count > cap.
+
+    excess = count - cap (the number of items that MUST move off that day).
+    Sorted chronologically (nearest over-crowded day first). Days that don't parse
+    are skipped (cannot place them deterministically).
+    """
+    over: List[tuple] = []
+    for date_str, count in schedule.items():
+        if count <= cap:
+            continue
+        parsed = _parse_date(date_str)
+        if parsed is None:
+            logger.warning("[RESCHED] Unparseable over-cap date skipped: %r", date_str)
+            continue
+        over.append((date_str, parsed, count - cap))
+    over.sort(key=lambda t: t[1])
+    return over
+
+
+# === Malleable seam: target-day selection ====================================
+
+def find_target_days(
+    schedule: Dict[str, int],
+    *,
+    cap: int = HARD_CAP_PER_DAY,
+    after: datetime,
+    horizon_days: int = DEFAULT_HORIZON_DAYS,
+    source_dates: Optional[set] = None,
+) -> List[tuple]:
+    """Return [(date_str, parsed_dt, free_slots)] for under-cap upcoming days.
+
+    A target day is any calendar day in (after, after+horizon] whose current count
+    is < cap, EXCLUDING the over-crowded source days themselves (never plan a move
+    onto a day we're trying to drain). free_slots = cap - count (>= 1). Ordered
+    nearest-first so excess lands as soon as possible.
+
+    NOTE (view-data seam): this orders targets by date only. A future "low-viewed
+    first" prioritization would re-order/select the items being MOVED by per-video
+    view counts -- but view data is NOT in the tracker, so that prioritization is a
+    separate signal (Phase 2). Target-DAY selection stays date-driven here.
+    """
+    source = source_dates or set()
+    targets: List[tuple] = []
+    for offset in range(1, horizon_days + 1):
+        d = after + timedelta(days=offset)
+        date_str = _format_date(d)
+        if date_str in source:
+            continue
+        count = schedule.get(date_str, 0)
+        free = cap - count
+        if free >= 1:
+            targets.append((date_str, d, free))
+    return targets
+
+
+# === Malleable seam: peak-slot assignment (per channel tz) ====================
+
+def assign_peak_slot(slot_index: int, channel_tz: str, on_date: datetime) -> tuple:
+    """Return (slot_et, slot_local) for the slot_index-th fill of a day.
+
+    slot_index 0 -> morning (08:00 ET), 1 -> lunch (12:00 ET), 2 -> evening (20:00
+    ET); beyond the list it clamps to the last slot. slot_local is the bare 12h
+    wall-clock to type into Studio in the channel account tz (DST-aware, #847).
+    """
+    et_slots = get_peak_slots_et()
+    idx = min(slot_index, len(et_slots) - 1)
+    slot_et = et_slots[idx]
+    slot_local = convert_et_to_channel_tz(slot_et, channel_tz, on_date)
+    return slot_et, slot_local
+
+
+def _video_ids_for_excess(
+    video_ids: Dict[str, List[str]], from_date: str, excess: int, cap: int
+) -> List[str]:
+    """Pick which video ids move off an over-crowded day (the surplus over the cap).
+
+    We keep the FIRST `cap` recorded ids on the source day and move the surplus
+    (the trailing ids). When the recorded id list is shorter than count (historical
+    8/day backlog predates id tracking, or set_count/sync left it incomplete), the
+    missing surplus ids are NEEDS_LIVE_LIST -- naming those needs the live Studio
+    list (Phase 2).
+    """
+    ids = list(video_ids.get(from_date, []))
+    # Surplus recorded ids are everything beyond the first `cap` kept on the day.
+    surplus_recorded = ids[cap:] if len(ids) > cap else []
+    moving: List[str] = list(surplus_recorded[:excess])
+    while len(moving) < excess:
+        moving.append(NEEDS_LIVE_LIST)
+    return moving
+
+
+def plan_channel_reschedule(
+    channel_id: str,
+    channel_name: str,
+    channel_tz: str,
+    schedule: Dict[str, int],
+    *,
+    video_ids: Optional[Dict[str, List[str]]] = None,
+    cap: int = HARD_CAP_PER_DAY,
+    today: Optional[datetime] = None,
+    horizon_days: int = DEFAULT_HORIZON_DAYS,
+) -> ChannelReschedulePlan:
+    """Compute the dry-run rebalance plan for ONE channel (pure + deterministic).
+
+    For each over-crowded day (count > cap), move the excess (count - cap) onto the
+    nearest under-target upcoming days, filling each target up to (but never over)
+    the cap and assigning peak slots in the channel tz. A target day's remaining
+    free capacity is tracked so it is NEVER planned over the cap.
+
+    Args:
+        channel_id: tracker key / YouTube channel id.
+        channel_name: human-readable name (for plan rows).
+        channel_tz: IANA tz of the channel Studio account (for slot conversion).
+        schedule: date_str -> count (from ScheduleTracker.schedule).
+        video_ids: date_str -> [ids] (from ScheduleTracker.video_ids); optional.
+        cap: per-day hard cap (default HARD_CAP_PER_DAY=3).
+        today: injectable clock (default datetime.now()); targets are strictly after.
+        horizon_days: how far ahead to search for target days.
+
+    Returns:
+        ChannelReschedulePlan with moves + summary (days_over_cap, total_moves,
+        unplaceable_moves).
+    """
+    vids = video_ids or {}
+    base = today or datetime.now()
+
+    over_days = find_over_cap_days(schedule, cap=cap)
+    source_dates = {d for (d, _dt, _x) in over_days}
+
+    # Build a fill-tracker for target days: date_str -> already-used count in the
+    # plan (start from current schedule count, never exceed cap).
+    targets = find_target_days(
+        schedule,
+        cap=cap,
+        after=base,
+        horizon_days=horizon_days,
+        source_dates=source_dates,
+    )
+    target_used: Dict[str, int] = {d: schedule.get(d, 0) for (d, _dt, _f) in targets}
+    target_order: List[tuple] = list(targets)  # (date_str, dt, free) nearest-first
+
+    moves: List[MovePlan] = []
+    unplaceable = 0
+
+    for from_date, _from_dt, excess in over_days:
+        moving_ids = _video_ids_for_excess(vids, from_date, excess, cap)
+        for vid in moving_ids:
+            placed = False
+            for to_date, to_dt, _free in target_order:
+                used = target_used.get(to_date, 0)
+                if used >= cap:
+                    continue
+                slot_index = used  # 0->morning, 1->lunch, 2->evening
+                slot_et, slot_local = assign_peak_slot(slot_index, channel_tz, to_dt)
+                moves.append(
+                    MovePlan(
+                        channel_id=channel_id,
+                        channel_name=channel_name,
+                        from_date=from_date,
+                        to_date=to_date,
+                        slot_et=slot_et,
+                        slot_local=slot_local,
+                        video_id=vid,
+                    )
+                )
+                target_used[to_date] = used + 1
+                placed = True
+                break
+            if not placed:
+                unplaceable += 1
+                logger.warning(
+                    "[RESCHED] No under-cap target within %d days for a move off %s "
+                    "(channel %s)",
+                    horizon_days,
+                    from_date,
+                    channel_id,
+                )
+
+    return ChannelReschedulePlan(
+        channel_id=channel_id,
+        channel_name=channel_name,
+        timezone=channel_tz,
+        cap=cap,
+        days_over_cap=len(over_days),
+        total_moves=len(moves),
+        unplaceable_moves=unplaceable,
+        moves=moves,
+    )
+
+
+# === Data source seam: load a channel's persisted schedule (read-only) ========
+
+def _default_load_schedule(channel_id: str) -> tuple:
+    """Default data source: persisted per-channel tracker JSON (read-only).
+
+    Returns (schedule, video_ids) from ScheduleTracker(channel_id). No browser,
+    no mutation.
+    """
+    if ScheduleTracker is None:  # pragma: no cover - only when import failed
+        return {}, {}
+    tracker = ScheduleTracker(channel_id)
+    return dict(tracker.schedule), dict(tracker.video_ids)
+
+
+def plan_all_channels(
+    *,
+    cap: int = HARD_CAP_PER_DAY,
+    channels: Optional[List[Dict[str, str]]] = None,
+    load_schedule: Callable[[str], tuple] = _default_load_schedule,
+    today: Optional[datetime] = None,
+    horizon_days: int = DEFAULT_HORIZON_DAYS,
+) -> Dict[str, Any]:
+    """Compute the dry-run rebalance plan across all shorts-enabled channels.
+
+    Args:
+        cap: per-day hard cap (default HARD_CAP_PER_DAY=3).
+        channels: optional [{channel_id, name, timezone}, ...] override (default:
+                  registry shorts channels).
+        load_schedule: (channel_id) -> (schedule, video_ids). Swappable data source.
+        today: injectable clock for deterministic tests.
+        horizon_days: target-search horizon.
+
+    Returns:
+        {dry_run: True, cap, channel_count, channels: [plan_dict...], summary:
+         {days_over_cap, total_moves, unplaceable_moves, channels_needing_rebalance}}.
+    """
+    chan_list = channels if channels is not None else _default_channels()
+
+    channel_plans: List[Dict[str, Any]] = []
+    total_days_over = 0
+    total_moves = 0
+    total_unplaceable = 0
+    channels_needing = 0
+
+    for ch in chan_list:
+        schedule, video_ids = load_schedule(ch["channel_id"])
+        plan = plan_channel_reschedule(
+            ch["channel_id"],
+            ch.get("name", ch["channel_id"]),
+            ch.get("timezone", "UTC"),
+            schedule,
+            video_ids=video_ids,
+            cap=cap,
+            today=today,
+            horizon_days=horizon_days,
+        )
+        channel_plans.append(plan.to_dict())
+        total_days_over += plan.days_over_cap
+        total_moves += plan.total_moves
+        total_unplaceable += plan.unplaceable_moves
+        if plan.total_moves > 0 or plan.days_over_cap > 0:
+            channels_needing += 1
+
+    return {
+        "dry_run": True,  # ALWAYS preview in this slice; apply is Phase 2.
+        "cap": cap,
+        "channel_count": len(chan_list),
+        "channels": channel_plans,
+        "summary": {
+            "days_over_cap": total_days_over,
+            "total_moves": total_moves,
+            "unplaceable_moves": total_unplaceable,
+            "channels_needing_rebalance": channels_needing,
+        },
+    }
+
+
+def _default_channels() -> List[Dict[str, str]]:
+    """Load shorts-enabled channels (id + name + timezone) from the registry."""
+    from modules.infrastructure.shared_utilities.youtube_channel_registry import (
+        get_channels,
+    )
+
+    channels: List[Dict[str, str]] = []
+    for ch in get_channels(role="shorts"):
+        cid = ch.get("id")
+        if not cid:
+            continue
+        channels.append(
+            {
+                "channel_id": cid,
+                "name": ch.get("name", ch.get("key", cid)),
+                "timezone": ch.get("timezone", "UTC"),
+            }
+        )
+    return channels

--- a/modules/platform_integration/youtube_shorts_scheduler/tests/test_reschedule_planner.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/tests/test_reschedule_planner.py
@@ -1,0 +1,338 @@
+"""
+Unit tests for the reschedule_plan SKILLz + reschedule_planner (Mode B Phase 1).
+
+Slice: SHORTS_RESCHEDULE_PLAN_PHASE1
+
+Model under test
+----------------
+Given the persisted per-channel schedule tracker (date -> count, date -> [ids]),
+compute a dry-run REBALANCE PLAN: for any day with count > HARD_CAP_PER_DAY, move
+the excess (count - cap) onto the nearest under-target upcoming days, into US-ET
+peak slots converted to the channel tz, NEVER exceeding the cap on a target day.
+
+These tests are mock-only (no browser, no daemon, no live models) and NON-VACUOUS:
+  - a day at 5 (cap 3) -> plan moves exactly 2; no target exceeds the cap
+  - a fully-<=cap schedule -> empty plan (nothing to do)
+  - peak-slot + per-channel tz assignment correct (ET -> channel wall-clock)
+  - breadcrumb + PatternMemory emission invoked (mocked + asserted)
+  - NON-VACUITY: an injected over-cap day MUST produce moves -- a planner that
+    ignored over-cap days would fail (see test_planner_must_not_ignore_over_cap).
+"""
+
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from modules.platform_integration.youtube_shorts_scheduler.src.reschedule_planner import (
+    NEEDS_LIVE_LIST,
+    find_over_cap_days,
+    plan_all_channels,
+    plan_channel_reschedule,
+)
+from modules.platform_integration.youtube_shorts_scheduler.src.schedule_tracker import (
+    HARD_CAP_PER_DAY,
+)
+from modules.platform_integration.youtube_shorts_scheduler.skillz.reschedule_plan.executor import (
+    DRY_RUN,
+    run_skill,
+)
+
+# Deterministic clock so upcoming-date strings are stable across runs.
+# Jan 1 2026; targets are strictly AFTER this date.
+FIXED_TODAY = datetime(2026, 1, 1)
+
+# A New York channel (identity ET conversion) and a Tokyo channel (offset).
+NY_TZ = "America/New_York"
+TOKYO_TZ = "Asia/Tokyo"
+
+
+def _date(d: datetime) -> str:
+    return f"{d.strftime('%b')} {d.day}, {d.year}"
+
+
+def test_hard_cap_is_three():
+    """Pin the load-bearing cap (HARD_CAP_PER_DAY=3, landed #844)."""
+    assert HARD_CAP_PER_DAY == 3
+
+
+def test_dry_run_constant_is_true():
+    """This slice is ALWAYS a dry-run preview; the apply is Phase 2."""
+    assert DRY_RUN is True
+
+
+# --- Core: a day at 5 -> exactly 2 moves, no target over cap -----------------
+
+def test_day_at_five_moves_two_no_target_over_cap():
+    """A day with 5 (cap 3) plans exactly 2 moves onto under-target days."""
+    over_date = _date(datetime(2026, 1, 20))  # 19 days out, well past targets
+    schedule = {over_date: 5}
+    plan = plan_channel_reschedule(
+        "UC_NY",
+        "FoundUps",
+        NY_TZ,
+        schedule,
+        video_ids={},
+        today=FIXED_TODAY,
+    )
+    assert plan.days_over_cap == 1
+    assert plan.total_moves == 2  # excess = 5 - 3
+    assert plan.unplaceable_moves == 0
+    # All moves originate from the over-crowded day.
+    assert all(m.from_date == over_date for m in plan.moves)
+    # No target day is planned over the cap: tally per to_date <= cap.
+    per_target = {}
+    for m in plan.moves:
+        per_target[m.to_date] = per_target.get(m.to_date, 0) + 1
+    assert all(c <= HARD_CAP_PER_DAY for c in per_target.values())
+    # Targets must be strictly in the future (after FIXED_TODAY) and not the source.
+    for m in plan.moves:
+        to_dt = datetime.strptime(m.to_date, "%b %d, %Y")
+        assert to_dt > FIXED_TODAY
+        assert m.to_date != over_date
+
+
+def test_target_with_existing_count_not_pushed_over_cap():
+    """A near target already at cap-1 takes only ONE move, never exceeding the cap."""
+    over_date = _date(datetime(2026, 1, 20))
+    near1 = _date(datetime(2026, 1, 2))  # already at 2 -> 1 free slot
+    near2 = _date(datetime(2026, 1, 3))  # empty -> 3 free
+    schedule = {over_date: 5, near1: 2, near2: 0}
+    plan = plan_channel_reschedule(
+        "UC_NY", "FoundUps", NY_TZ, schedule, video_ids={}, today=FIXED_TODAY
+    )
+    assert plan.total_moves == 2
+    per_target = {}
+    for m in plan.moves:
+        per_target[m.to_date] = per_target.get(m.to_date, 0) + 1
+    # near1 had 2 -> at most 1 new move there (2 + 1 = 3 = cap).
+    assert per_target.get(near1, 0) <= 1
+    # And no target's (existing + planned) exceeds the cap.
+    assert schedule.get(near1, 0) + per_target.get(near1, 0) <= HARD_CAP_PER_DAY
+    assert schedule.get(near2, 0) + per_target.get(near2, 0) <= HARD_CAP_PER_DAY
+
+
+# --- Empty plan when nothing is over the cap --------------------------------
+
+def test_all_under_cap_yields_empty_plan():
+    """A schedule with every day <= cap plans zero moves (nothing to do)."""
+    schedule = {
+        _date(datetime(2026, 1, 10)): 3,
+        _date(datetime(2026, 1, 11)): 2,
+        _date(datetime(2026, 1, 12)): 1,
+    }
+    plan = plan_channel_reschedule(
+        "UC_NY", "FoundUps", NY_TZ, schedule, video_ids={}, today=FIXED_TODAY
+    )
+    assert plan.days_over_cap == 0
+    assert plan.total_moves == 0
+    assert plan.moves == []
+
+
+# --- Peak-slot + per-channel tz assignment ----------------------------------
+
+def test_peak_slot_and_tz_assignment_ny_identity():
+    """NY channel: ET peak slots type through as the same wall clock (identity)."""
+    over_date = _date(datetime(2026, 1, 20))
+    # 4 over the cap so the first target fills all 3 slots (morning/lunch/evening).
+    schedule = {over_date: 7}  # excess 4
+    plan = plan_channel_reschedule(
+        "UC_NY", "FoundUps", NY_TZ, schedule, video_ids={}, today=FIXED_TODAY
+    )
+    # The first 3 moves land on the SAME nearest target with the 3 peak slots.
+    first_target = plan.moves[0].to_date
+    same_day = [m for m in plan.moves if m.to_date == first_target]
+    assert len(same_day) == 3
+    # Slots assigned in order morning/lunch/evening by ET source.
+    assert [m.slot_et for m in same_day] == ["08:00", "12:00", "20:00"]
+    # NY in January (EST) is identity to ET -> bare 12h local equals the ET clock.
+    assert [m.slot_local for m in same_day] == ["8:00 AM", "12:00 PM", "8:00 PM"]
+
+
+def test_peak_slot_tz_conversion_tokyo_offset():
+    """Tokyo channel: 08:00 ET (EST) converts to 10:00 PM JST same calendar day.
+
+    EST is UTC-5, JST is UTC+9 -> +14h. 08:00 ET -> 22:00 JST = '10:00 PM'.
+    """
+    over_date = _date(datetime(2026, 1, 20))
+    schedule = {over_date: 4}  # excess 1 -> single morning slot
+    plan = plan_channel_reschedule(
+        "UC_TOKYO", "Move2Japan", TOKYO_TZ, schedule, video_ids={}, today=FIXED_TODAY
+    )
+    assert plan.total_moves == 1
+    move = plan.moves[0]
+    assert move.slot_et == "08:00"
+    assert move.slot_local == "10:00 PM"  # 08:00 EST + 14h = 22:00 JST
+
+
+# --- video<->date naming + needs-live-list fallback -------------------------
+
+def test_recorded_ids_named_surplus_labelled_needs_live_list():
+    """Recorded surplus ids are NAMED; missing surplus -> '(needs-live-list)'.
+
+    Day count 5 (excess 2). Only 4 ids recorded -> the first 3 stay, 1 recorded
+    surplus id moves NAMED, the 2nd move is unnamed (needs the live Studio list).
+    """
+    over_date = _date(datetime(2026, 1, 20))
+    schedule = {over_date: 5}
+    video_ids = {over_date: ["v0", "v1", "v2", "v3"]}  # 4 recorded for count 5
+    plan = plan_channel_reschedule(
+        "UC_NY", "FoundUps", NY_TZ, schedule, video_ids=video_ids, today=FIXED_TODAY
+    )
+    moved_ids = [m.video_id for m in plan.moves]
+    assert "v3" in moved_ids  # the recorded surplus id (index 3, beyond first cap=3)
+    assert NEEDS_LIVE_LIST in moved_ids  # the unrecorded surplus -> needs live list
+    assert len(moved_ids) == 2
+
+
+# --- find_over_cap_days helper ----------------------------------------------
+
+def test_find_over_cap_days_excess_math():
+    """find_over_cap_days returns (date, dt, excess=count-cap) only for over days."""
+    schedule = {
+        _date(datetime(2026, 1, 10)): 3,  # at cap, not over
+        _date(datetime(2026, 1, 11)): 8,  # excess 5
+        _date(datetime(2026, 1, 12)): 4,  # excess 1
+    }
+    over = find_over_cap_days(schedule, cap=HARD_CAP_PER_DAY)
+    excess_by_date = {d: x for (d, _dt, x) in over}
+    assert _date(datetime(2026, 1, 10)) not in excess_by_date
+    assert excess_by_date[_date(datetime(2026, 1, 11))] == 5
+    assert excess_by_date[_date(datetime(2026, 1, 12))] == 1
+
+
+# --- NON-VACUITY: the planner MUST act on over-cap days ----------------------
+
+def test_planner_must_not_ignore_over_cap():
+    """Inject an over-cap day; a planner that IGNORED it would produce 0 moves.
+
+    This is the load-bearing non-vacuity guard: total_moves MUST equal the injected
+    excess. A no-op / over-cap-ignoring implementation fails here.
+    """
+    over_date = _date(datetime(2026, 2, 1))
+    schedule = {over_date: 6}  # excess 3
+    plan = plan_channel_reschedule(
+        "UC_NY", "FoundUps", NY_TZ, schedule, video_ids={}, today=FIXED_TODAY
+    )
+    # Exactly the excess (6 - 3) must be planned for movement.
+    assert plan.total_moves == 3
+    assert plan.days_over_cap == 1
+    # And every move actually leaves the over-crowded day.
+    assert all(m.from_date == over_date for m in plan.moves)
+
+
+def test_no_target_within_horizon_marks_unplaceable():
+    """When no under-cap target exists within the horizon, excess is unplaceable.
+
+    Horizon of 0 days means no target days at all -> the excess cannot be placed.
+    """
+    over_date = _date(datetime(2026, 1, 20))
+    schedule = {over_date: 5}  # excess 2
+    plan = plan_channel_reschedule(
+        "UC_NY",
+        "FoundUps",
+        NY_TZ,
+        schedule,
+        video_ids={},
+        today=FIXED_TODAY,
+        horizon_days=0,
+    )
+    assert plan.total_moves == 0
+    assert plan.unplaceable_moves == 2
+
+
+# --- plan_all_channels aggregation + dry-run flag ---------------------------
+
+def test_plan_all_channels_aggregates_and_is_dry_run():
+    """plan_all_channels sums per-channel plans and is flagged dry-run."""
+    over_date = _date(datetime(2026, 1, 20))
+
+    def load_schedule(channel_id):
+        if channel_id == "UC_NY":
+            return {over_date: 5}, {}  # excess 2
+        return {over_date: 3}, {}  # at cap, no moves
+
+    channels = [
+        {"channel_id": "UC_NY", "name": "FoundUps", "timezone": NY_TZ},
+        {"channel_id": "UC_TOKYO", "name": "Move2Japan", "timezone": TOKYO_TZ},
+    ]
+    result = plan_all_channels(
+        channels=channels,
+        load_schedule=load_schedule,
+        today=FIXED_TODAY,
+    )
+    assert result["dry_run"] is True
+    assert result["channel_count"] == 2
+    assert result["summary"]["days_over_cap"] == 1
+    assert result["summary"]["total_moves"] == 2
+    assert result["summary"]["channels_needing_rebalance"] == 1
+
+
+# --- Signal emission: breadcrumb + PatternMemory must be invoked -------------
+
+def test_run_skill_emits_breadcrumb_and_pattern_memory():
+    """run_skill must emit a reschedule_plan breadcrumb AND a SkillOutcome."""
+    over_date = _date(datetime(2026, 1, 20))
+
+    def load_schedule(channel_id):
+        return {over_date: 5}, {}  # excess 2
+
+    channels = [{"channel_id": "UC_NY", "name": "FoundUps", "timezone": NY_TZ}]
+
+    with patch(
+        "modules.communication.livechat.src.breadcrumb_telemetry.get_breadcrumb_telemetry"
+    ) as bc, patch(
+        "modules.infrastructure.wre_core.src.pattern_memory.PatternMemory"
+    ) as pm, patch(
+        "modules.infrastructure.wre_core.src.pattern_memory.SkillOutcome"
+    ) as outcome:
+        result = run_skill(
+            channels=channels,
+            load_schedule=load_schedule,
+            today=FIXED_TODAY,
+            emit_signals=True,
+        )
+
+        # Breadcrumb stored with the reschedule_plan event type + plan metadata.
+        bc.return_value.store_breadcrumb.assert_called_once()
+        kwargs = bc.return_value.store_breadcrumb.call_args.kwargs
+        assert kwargs["event_type"] == "reschedule_plan"
+        assert kwargs["source_dae"] == "youtube_shorts_scheduler"
+        assert "plan" in kwargs["metadata"]
+        assert "summary" in kwargs["metadata"]
+
+        # PatternMemory().store_outcome called with a SkillOutcome.
+        outcome.assert_called_once()
+        out_kwargs = outcome.call_args.kwargs
+        assert out_kwargs["skill_name"] == "reschedule_plan"
+        pm.return_value.store_outcome.assert_called_once()
+
+    assert result["success"] is True
+    assert result["dry_run"] is True
+    assert result["skill"] == "reschedule_plan"
+    assert result["breadcrumb_emitted"] is True
+    assert result["outcome_stored"] is True
+
+
+def test_run_skill_no_signals_skips_emission():
+    """--no-signals path: emission helpers are NOT invoked."""
+    over_date = _date(datetime(2026, 1, 20))
+
+    def load_schedule(channel_id):
+        return {over_date: 5}, {}
+
+    channels = [{"channel_id": "UC_NY", "name": "FoundUps", "timezone": NY_TZ}]
+
+    with patch(
+        "modules.communication.livechat.src.breadcrumb_telemetry.get_breadcrumb_telemetry"
+    ) as bc:
+        result = run_skill(
+            channels=channels,
+            load_schedule=load_schedule,
+            today=FIXED_TODAY,
+            emit_signals=False,
+        )
+        bc.assert_not_called()
+
+    assert result["breadcrumb_emitted"] is False
+    assert result["outcome_stored"] is False


### PR DESCRIPTION
## Summary

Compute a **dry-run REBALANCE PLAN** for over-crowded schedule days. The historical backlog was scheduled at up to 8/day before the per-day cap landed (`HARD_CAP_PER_DAY = 3`, `src/schedule_tracker.py:30`, #844). For any day with `count > cap`, the plan proposes moving the excess onto the nearest under-target upcoming days, placing each moved item into a **US-ET peak slot** converted to the channel's Studio-account timezone (`peak_window.py`, #847). It never plans a target day over the cap.

## Dry-run / read-only (NO mutation -- apply is Phase 2)

This is the **PREVIEW/decision layer**. `DRY_RUN = True` always in this slice: the skill RETURNS the plan and emits learning signals, but **NEVER mutates a schedule, no browser, no live model**. The mutating DOM apply (click "Scheduled" -> `ytcp-video-visibility-edit-popup` date/time picker) is an explicit **Phase-2** follow-up, documented as a seam, NOT built here. It is an AGENT capability (SKILLz + `--agent-command`), never manual-for-012; 012 observes the preview.

## What landed

- **`src/reschedule_planner.py`** -- pure, unit-testable planner:
  - `find_over_cap_days` (`excess = count - cap`), `find_target_days` (under-cap upcoming days, nearest-first, excludes source days), `assign_peak_slot` (fill-index 0/1/2 -> ET morning/lunch/evening, converted per channel tz), `plan_channel_reschedule`, `plan_all_channels` (`dry_run: True`).
  - Each move is a complete row: `{channel, from_date, to_date, slot_et, slot_local, video_id}` + summary `{days_over_cap, total_moves, unplaceable_moves}`.
- **`skillz/reschedule_plan/`** -- SKILLz (`executor.py` + `run_skill.py` + `__init__.py` + `SKILLz.md`) mirroring the #850 `what_should_i_schedule` pattern. Emits a **breadcrumb** (`source_dae=youtube_shorts_scheduler`, `event_type=reschedule_plan`, full plan in metadata) + a **PatternMemory `SkillOutcome`** every run. `DRY_RUN` constant pins the preview contract.
- **`youtube_automation_adapter.py`** -- `reschedule_plan` `--agent-command` surface (action + `reschedule`/`rebalance`/`rebalance_plan` aliases + `_build_reschedule_plan_command` + dispatch). `youtube action reschedule_plan [horizon_days=N]`. Agent-invoked, never manual.

## Peak / per-channel tz placement (#847)

`assign_peak_slot` maps the fill order to ET `08:00 / 12:00 / 20:00` then `convert_et_to_channel_tz(...)` to the channel account tz (DST-aware). Verified: NY 08:00 -> `8:00 AM` (identity), Tokyo 08:00 -> `10:00 PM` JST, NY 20:00 -> `8:00 PM`.

## Phase-2 + view-data seams (documented, NOT built)

- **DOM apply / mutation**: the visibility-edit-popup date/time-picker applier that consumes the plan rows. Gated behind its own slice.
- **View-based ("low-viewed first") prioritization**: choosing WHICH videos move by per-video view counts -- needs view data **NOT in the tracker** (separate Phase-2 signal). Target-DAY selection here is date-driven; `find_target_days` / `_video_ids_for_excess` are the plug-in seams.

## Plan granularity (Phase 0 finding)

`ScheduleTracker` stores BOTH `schedule` (`date -> count`, `:100`) AND `video_ids` (`date -> [ids]`, `:101`). So the plan NAMES which videos move when ids are recorded. But `count` is authoritative and can exceed the recorded id list (`set_count()`/`sync_from_youtube()`, and the historical 8/day backlog predates id tracking) -- surplus moves beyond recorded ids are labelled `video_id="(needs-live-list)"` (specific-video selection for those needs the LIVE Studio list, Phase 2).

## Non-vacuity proof

`tests/test_reschedule_planner.py` -- **14 mock-only tests, all pass** (no browser, no daemon, no live models). Sabotaging the planner to ignore over-cap days fails **9/14** (incl. `test_planner_must_not_ignore_over_cap`, `test_day_at_five_moves_two_no_target_over_cap`, peak/tz assignment, aggregation). The 5 that still pass are the cap-pin / empty-plan / dry-run-flag / no-signals cases, which correctly don't depend on over-cap handling. Existing adapter suite still **9/9** green.

## Scope

Touches only `youtube_shorts_scheduler` (+ its `skillz/`, tests, ModLog) + minimal `--agent-command` wiring in `youtube_automation_adapter.py`. No browser, no mutation, no live models.

Worker-Lane: RESCHED-PLAN
Slice: SHORTS_RESCHEDULE_PLAN_PHASE1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
