### PR TITLE
feat(youtube_shorts_scheduler): live Has-schedule audit fix + per-video view signal (read-only)

### DIFF
--- a/modules/platform_integration/youtube_shorts_scheduler/ModLog.md
+++ b/modules/platform_integration/youtube_shorts_scheduler/ModLog.md
@@ -1,5 +1,66 @@
 # YouTube Shorts Scheduler - ModLog
 
+## 2026-06-19 - shorts_live_schedule_signal SKILLz: live "Has schedule" count fix + per-video view signal (read-only)
+
+**By:** 0102 (Worker-Lane LIVE-SIGNAL)
+**Slice:** SHORTS_LIVE_SCHEDULE_AND_VIEW_SIGNAL_PHASE1
+**WSP References:** WSP 95 (SKILLz Wardrobe), WSP 77 (Agent Coordination), WSP 91 (Observability), WSP 60/48 (Pattern Memory), WSP 84 (Code Reuse: shadow_dom_finder), WSP 27 (Phase 0 KNOWLEDGE), WSP 22 (ModLog), WSP 49 (Structure), WSP 50 (Pre-Action)
+
+### Problem (the false-0 audit bug)
+
+`content_page_scheduler.audit_calendar()` (`[CPS-AUDIT]`) reports "Total scheduled: 0"
+(`src/content_page_scheduler.py:992`) for Edge channels (foundups/antifaFM) even though the tracker
+holds 131 / 55. Root cause: it filters to Scheduled via the OLD sidebar flow
+`#filter-icon -> "Visibility" -> "Has schedule"` in `_apply_visibility_filter_via_ui`
+(`src/content_page_scheduler.py:313-412`). That flow TIMES OUT on those channels; the filter never
+lands, `navigate_to_content` "continues unfiltered" (`:276`), and `get_scheduled_videos_detailed`
+(`src/dom_automation.py:2466`) then scrapes 0 Scheduled rows on an unfiltered page -> a FALSE 0.
+012's reliable path is the **chip-bar "Filter" input -> "Has schedule" checkbox in the filter dialog**.
+
+### What changed (read-only; NO scheduling mutation)
+
+New SKILLz `skillz/shorts_live_schedule_signal/` mirroring the `what_should_i_schedule` (#850) +
+`reschedule_plan` (#851) read-only/agent-invoked pattern (`executor.py` + `run_skill.py` + `SKILLz.md`):
+
+1. **Accurate "Has schedule" count** -- `read_live_schedule_signal()` clicks the chip-bar filter input
+   and ticks the "Has schedule" label in `ytcp-filter-dialog tp-yt-paper-dialog#dialog`, then scrapes
+   `ytcp-video-row` for scheduled rows. **Fail-safe**: if the filter cannot be applied it returns
+   `scheduled_count = None` (UNKNOWN, status `unknown_filter_not_applied` / `unknown_no_driver`),
+   **NEVER a false 0**.
+2. **Per-video view signal** -- each row's views cell is parsed (`parse_view_count`: "1.2K views" ->
+   1200, "-"/"" -> None UNKNOWN, distinct from 0) into `{video_id, scheduled, scheduled_date, views}`;
+   `summarize_rows` derives the low-viewed list (views known AND < threshold; UNKNOWN never low-viewed).
+3. **WSP 84 reuse**: Studio is shadow-rooted, so the chip-bar / dialog / rows are reached with the
+   EXISTING `modules/infrastructure/foundups_selenium/src/shadow_dom_finder.py`
+   (`first_deep`/`find_deep`, from the Studio-Ask #825/#827 work), not flat CSS.
+4. **WRE signals**: every run emits a `live_schedule_signal` breadcrumb (WSP 91) + a PatternMemory
+   SkillOutcome (WSP 60/48). Agent-invoked via `--agent-command` -> `run_skill.py`; no manual-012 menu.
+
+Malleable: parsing is behind pure functions; the DOM scrape + "Has schedule" applier are injectable
+seams (`scrape_fn` / `apply_filter_fn`) so tests are mock-only.
+
+### Scope / out of scope
+
+ONLY touches `youtube_shorts_scheduler` (+ new skillz/tests/ModLog) and REUSES `shadow_dom_finder`.
+No mutation. OUT: Mode B apply, wiring into the scheduler order / ranking, music gate. The existing
+timing-out `_apply_visibility_filter_via_ui` is left intact (no behavior change there this phase);
+this skill is the accurate read-only signal the audit/daemon consumes.
+
+### Live gap (honest)
+
+DOM read path is **mock-tested only** (simulated Studio DOM); no live browser ran. 012 live-validates
+the real chip-bar / "Has schedule" / views selectors on the Edge channels before graduation. Selectors
+are 012-grounded but the live structure must be re-confirmed in-code.
+
+### Tests (mock-only, non-vacuous) -- 27 passed
+
+`tests/test_shorts_live_schedule_signal.py`. Non-vacuity proven: regressing the executor to the old
+false-0 behavior RED-fails `test_filter_fail_returns_unknown_not_zero`,
+`test_old_path_produces_false_zero_then_new_path_returns_unknown`, and
+`test_accurate_scheduled_count_when_rows_exist` (`assert 0 is None`).
+
+---
+
 ## 2026-06-19 - reschedule_plan SKILLz: dry-run rebalance PLAN for over-cap days (Mode B Phase 1)
 
 **By:** 0102 (Worker-Lane RESCHED-PLAN)

--- a/modules/platform_integration/youtube_shorts_scheduler/skillz/shorts_live_schedule_signal/SKILLz.md
+++ b/modules/platform_integration/youtube_shorts_scheduler/skillz/shorts_live_schedule_signal/SKILLz.md
@@ -1,0 +1,209 @@
+---
+# Metadata (YAML Frontmatter)
+name: shorts_live_schedule_signal
+description: Read-only LIVE shorts-list signals - accurate "Has schedule" scheduled count (fixes the [CPS-AUDIT] false-0) + per-video view count -> low-viewed signal (agent-invoked)
+version: 1.0_prototype
+author: 0102
+created: 2026-06-19
+agents: [gemma, qwen]
+primary_agent: gemma
+intent_type: KNOWLEDGE
+promotion_state: prototype
+pattern_fidelity_threshold: 0.90
+test_status: needs_live_validation
+
+# Dependencies
+dependencies:
+  data_stores:
+    - name: youtube_studio_shorts_list
+      type: dom
+      path: "https://studio.youtube.com/channel/{CHANNEL_ID}/videos/short"
+  required_context:
+    - channel: "Channel key (foundups, antifafm, ...) or UC... id; id resolved from registry"
+  code_reuse:
+    - name: shadow_dom_finder
+      path: modules/infrastructure/foundups_selenium/src/shadow_dom_finder.py
+      why: "Studio DOM is shadow-rooted; flat selectors silently fail. Reuse first_deep/find_deep (WSP 84)."
+  throttles:
+    - name: read_only
+      max_rate: unlimited
+      cost_per_call: 0
+
+# Metrics Configuration
+metrics:
+  pattern_fidelity_scoring:
+    enabled: true
+    frequency: every_execution
+    scorer_agent: gemma
+  promotion_criteria:
+    min_pattern_fidelity: 0.90
+    min_outcome_quality: 0.85
+    min_execution_count: 100
+    required_test_pass_rate: 0.95
+category: capability-uplift
+evals: []
+retirement_date: null
+---
+# shorts_live_schedule_signal
+
+**Purpose**: Read TWO read-only LIVE signals from the YouTube Studio shorts list so
+the scheduling priority is accurate and so 012's "re-schedule low viewed shorts" has a
+signal:
+
+1. **Accurate scheduled count** via the Filter chip-bar **"Has schedule"** checkbox
+   (the path 012 confirmed reliable) -- this **fixes the false-0 audit bug**.
+2. **Per-video view count** parsed from the list -> a **low-viewed** signal.
+
+**Intent Type**: KNOWLEDGE (read/verify before any act).
+
+**Agent**: Gemma (fast deterministic parse) / Qwen (consumes the signal to plan).
+
+**For the agent, never for a human**: the WRE/daemon triggers this SKILLz and the
+`--agent-command` surface invokes it programmatically. 012 only observes the emitted
+breadcrumb + PatternMemory outcome and the JSON output. There is NO manual-012 menu.
+
+---
+
+## The false-0 bug this fixes
+
+Today `content_page_scheduler.audit_calendar()` (`[CPS-AUDIT]`) does:
+
+```
+audit_calendar()
+  -> navigate_to_scheduled()                        # content_page_scheduler.py:414
+  -> navigate_to_content(visibility="SCHEDULED")    # content_page_scheduler.py:221
+  -> _apply_visibility_filter_via_ui("SCHEDULED")   # content_page_scheduler.py:313-412
+       # OLD sidebar flow: #filter-icon -> "Visibility" -> "Has schedule" checkbox.
+       # This TIMES OUT on the Edge channels (foundups/antifaFM): the filter never
+       # lands, the function returns False, and the audit "continues unfiltered".
+  -> get_scheduled_videos_detailed()                # dom_automation.py:2466
+       # scrapes XPATH_SCHEDULED_ROWS on the (unfiltered) page -> 0 rows
+  -> "Total scheduled: 0"                            # content_page_scheduler.py:992
+```
+
+So a channel whose tracker holds **131 / 55** scheduled shorts reports **0**. The
+reliable path 012 uses is the **chip-bar "Filter" input -> "Has schedule" checkbox in
+the filter dialog**, not the sidebar visibility flow.
+
+**This skill clicks that path with the shadow-piercing finder and, when the filter
+cannot be applied, returns `scheduled_count = null` (UNKNOWN) -- NEVER a false 0.**
+
+---
+
+## Grounded DOM (012-confirmed; re-confirm live before graduation)
+
+- **List URL**: `https://studio.youtube.com/channel/{CHANNEL_ID}/videos/short?filter=%5B%5D&sort={date}`
+  (channel id from the registry, **never hardcoded**).
+- **Filter input**: `ytcp-video-filter#video-filter ytcp-chip-bar#chip-bar input#text-input` (placeholder "Filter").
+- **"Has schedule" option**: a `label` with text "Has schedule" inside
+  `ytcp-filter-dialog tp-yt-paper-dialog#dialog`.
+- **Video rows**: `ytcp-video-row` under `ytcp-video-section-content#video-list`;
+  visibility cell `span.label-span` text "Scheduled"; the row also has a views column.
+
+Studio is **shadow-rooted**, so these are reached with
+`shadow_dom_finder.first_deep / find_deep` (WSP 84 reuse), not flat CSS.
+
+---
+
+## Output (consumed by daemon / Qwen)
+
+```json
+{
+  "success": true,
+  "skill": "shorts_live_schedule_signal",
+  "channel": "foundups",
+  "channel_id": "UC...",
+  "filter_applied": true,
+  "scheduled_count": 131,
+  "scheduled_count_status": "ok",
+  "low_view_threshold": 100,
+  "low_viewed_count": 4,
+  "low_viewed_videos": [{"video_id": "...", "scheduled": false, "scheduled_date": null, "views": 12}],
+  "scheduled_videos": [{"video_id": "...", "scheduled": true, "scheduled_date": "Feb 5, 2026", "views": 0}],
+  "videos": [ ... ],
+  "row_count": 50,
+  "breadcrumb_emitted": true,
+  "outcome_stored": true
+}
+```
+
+**Fail-safe contract**: when the "Has schedule" filter cannot be applied (timeout,
+selector miss, no driver), `scheduled_count` is `null` with
+`scheduled_count_status` in `{unknown_filter_not_applied, unknown_no_driver}` and
+`success` is `false`. It is **never** a false `0`.
+
+---
+
+## Signal emission (WRE self-improvement testbed)
+
+Every run emits BOTH:
+- **Breadcrumb** (WSP 91): `event_type="live_schedule_signal"`,
+  `source_dae="youtube_shorts_scheduler"`, full counts in metadata.
+- **PatternMemory SkillOutcome** (WSP 60/48): `skill_name="shorts_live_schedule_signal"`.
+
+---
+
+## Invocation
+
+**SKILLz (WRE / daemon):**
+```python
+from modules.platform_integration.youtube_shorts_scheduler.skillz.shorts_live_schedule_signal.executor import read_live_schedule_signal
+signal = read_live_schedule_signal(driver, channel_id="UC...")
+if signal["scheduled_count"] is None:
+    ...  # UNKNOWN -- do NOT treat as 0
+```
+
+**--agent-command (agent/DAE-invocable, structured JSON):**
+```bash
+python main.py --agent-command "youtube action live_schedule_signal channel=foundups"
+# adapter spawns:
+python -m modules.platform_integration.youtube_shorts_scheduler.skillz.shorts_live_schedule_signal.run_skill --channel foundups --connect edge --json
+```
+
+---
+
+## Malleable seams (intentional)
+
+- **Parsing** is behind pure functions (`parse_view_count`, `parse_row_signal`,
+  `summarize_rows`) -- swap the parser without touching scrape/orchestration.
+- **The DOM scrape** is injected via `scrape_fn` (default: `scrape_live_rows`); the
+  **"Has schedule" applier** is injected via `apply_filter_fn`. Tests inject a
+  mock-DOM scrape; live runs use the real shadow-pierced ones. The math is identical.
+
+---
+
+## Out of scope (separate follow-ups -- NOT built here)
+
+- Mode B re-schedule / apply (mutating) -- this skill is strictly read-only.
+- Wiring this signal into the scheduler ordering / `what_should_i_schedule` ranking.
+- music-vs-talk content gate.
+
+---
+
+## Live gap (honest)
+
+The DOM read path is **mock-tested only** (a simulated Studio DOM); no live browser
+ran here. **012 live-validates** the real chip-bar / "Has schedule" / views selectors
+against the Edge channels before this skill graduates from `prototype`. The selectors
+above are 012-grounded but the live structure must be re-confirmed in-code.
+
+---
+
+## Expected patterns (WSP 95 fidelity)
+
+```json
+{
+  "skill": "shorts_live_schedule_signal",
+  "patterns": {
+    "has_schedule_filter_attempted": true,
+    "has_schedule_filter_applied": true,
+    "rows_scraped": true,
+    "rows_parsed": true,
+    "views_parsed": true
+  }
+}
+```
+
+**WSP Compliance**: WSP 95 (SKILLz Wardrobe), WSP 77 (Agent Coordination),
+WSP 91 (Observability), WSP 60/48 (Pattern Memory), WSP 84 (Code Reuse:
+shadow_dom_finder), WSP 27 (Phase 0 KNOWLEDGE).

--- a/modules/platform_integration/youtube_shorts_scheduler/skillz/shorts_live_schedule_signal/__init__.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/skillz/shorts_live_schedule_signal/__init__.py
@@ -1,0 +1,8 @@
+"""shorts_live_schedule_signal SKILLz package.
+
+Read-only LIVE signal from the YouTube Studio shorts list:
+  1. Accurate "Has schedule" scheduled count (fixes the [CPS-AUDIT] false-0).
+  2. Per-video VIEW count -> a low-viewed signal (012: "re-schedule low viewed shorts").
+
+Agent-invoked only (WRE/daemon + --agent-command surface). NO scheduling mutation.
+"""

--- a/modules/platform_integration/youtube_shorts_scheduler/skillz/shorts_live_schedule_signal/executor.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/skillz/shorts_live_schedule_signal/executor.py
@@ -1,0 +1,692 @@
+#!/usr/bin/env python3
+"""
+shorts_live_schedule_signal - SKILLz Executor
+
+Two READ-ONLY live signals scraped from the YouTube Studio shorts list:
+
+  1. ACCURATE scheduled count via the Filter chip-bar "Has schedule" checkbox.
+     This fixes the [CPS-AUDIT] false-0 bug: today
+     `content_page_scheduler.audit_calendar()` applies the OLD sidebar
+     `#filter-icon -> "Visibility" -> "Has schedule"` flow
+     (`_apply_visibility_filter_via_ui`, content_page_scheduler.py:313-412) which
+     TIMES OUT on the Edge channels (foundups/antifaFM); the filter never lands,
+     `get_scheduled_videos_detailed()` then scrapes ZERO rows and the audit
+     reports "Total scheduled: 0" (content_page_scheduler.py:992) even though the
+     tracker holds 131 / 55. 012's reliable path is the chip-bar input ->
+     "Has schedule" checkbox in the filter dialog. We click THAT path with the
+     shadow-piercing finder (Studio is shadow-rooted; flat selectors silently
+     fail) and -- critically -- when the filter cannot be applied we return
+     scheduled_count = None (UNKNOWN), NEVER a false 0.
+
+  2. Per-video VIEW count parsed from each row's views column -> a low-viewed
+     signal (012: "re-schedule low viewed shorts"). Views are parsed from the
+     row's views cell text / aria-label into an int (e.g. "1.2K views" -> 1200).
+
+WSP Compliance:
+    WSP 95: SKILLz Wardrobe Protocol (micro chain-of-thought + pattern fidelity)
+    WSP 77: Agent Coordination (Qwen/daemon consumes the signal)
+    WSP 91: DAEmon Observability (breadcrumb on every run)
+    WSP 60/48: Pattern Memory outcome on every run (WRE self-improvement testbed)
+    WSP 84: Code Reuse -- pierces the Studio shadow DOM with the EXISTING
+            foundups_selenium.shadow_dom_finder (first_deep/find_deep), the same
+            helper proven by the Studio-Ask work (#825/#827).
+    WSP 27: Phase 0 KNOWLEDGE (read/verify before any act).
+
+Read-only:
+    - Reads the live shorts list (DOM). Ticks a filter checkbox to FILTER the
+      view -- this is a view-state read aid, NOT a content mutation.
+    - Never schedules, never edits metadata, never opens a publish path.
+
+Malleable seams (intentional):
+    - PARSING is behind pure functions (`parse_view_count`, `parse_row_signal`,
+      `summarize_rows`) -- swap the parser without touching scrape/orchestration.
+    - The DOM SCRAPE is injected via `scrape_fn` (default: `scrape_live_rows`,
+      which uses shadow_dom_finder). Tests inject a mock-DOM scrape; live runs
+      use the real one. The orchestration math is identical either way.
+
+Usage (agent / daemon):
+    from .executor import read_live_schedule_signal
+    signal = read_live_schedule_signal(driver, channel_id="UC...")
+    if signal["scheduled_count"] is None:
+        ...  # filter could not be applied -> UNKNOWN (do NOT treat as 0)
+
+Usage (--agent-command surface):
+    youtube action live_schedule_signal channel=foundups
+    (the adapter spawns run_skill.py --channel foundups --json)
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+SOURCE_DAE = "youtube_shorts_scheduler"
+SKILL_NAME = "shorts_live_schedule_signal"
+
+# 012: shorts under this view count are "low viewed" candidates for re-scheduling.
+DEFAULT_LOW_VIEW_THRESHOLD = 100
+
+# Sentinel: a row whose views cell could not be parsed. Distinct from 0 views.
+VIEWS_UNKNOWN = None
+
+
+# ---------------------------------------------------------------------------
+# Grounded Studio DOM (012-confirmed; re-confirm live before graduation).
+# These mirror the structure 012 gave and the existing content_page_scheduler
+# selectors. They are consumed by the shadow-piercing finder, NOT flat CSS.
+# ---------------------------------------------------------------------------
+
+# Filter chip-bar text input (placeholder "Filter").
+FILTER_INPUT_CHAIN = ["ytcp-video-filter#video-filter ytcp-chip-bar#chip-bar input#text-input"]
+# Fallback chain: walk into the chip-bar first, then the input (shadow steps).
+FILTER_INPUT_CHAIN_FALLBACK = [
+    "ytcp-video-filter#video-filter",
+    "ytcp-chip-bar#chip-bar",
+    "input#text-input",
+]
+# The filter dialog that opens after focusing the chip-bar input.
+FILTER_DIALOG_SELECTORS = ["ytcp-filter-dialog tp-yt-paper-dialog#dialog"]
+# Video rows live under the list section.
+VIDEO_ROW_SELECTOR = "ytcp-video-row"
+VIDEO_LIST_SELECTOR = "ytcp-video-section-content#video-list"
+
+
+@dataclass
+class RowSignal:
+    """One scraped+parsed shorts-list row."""
+
+    video_id: str
+    scheduled: bool
+    scheduled_date: Optional[str]
+    views: Optional[int]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "video_id": self.video_id,
+            "scheduled": self.scheduled,
+            "scheduled_date": self.scheduled_date,
+            "views": self.views,
+        }
+
+
+# === Malleable seam 1: pure parsing ========================================
+
+def parse_view_count(text: Optional[str]) -> Optional[int]:
+    """Parse a Studio views cell into an int (or None if unparseable).
+
+    Handles the formats Studio renders in the views column:
+        "1,234 views" -> 1234
+        "1.2K views"  -> 1200
+        "3.4M"        -> 3400000
+        "0"           -> 0
+        "-" / "" / None / "No views" -> None (UNKNOWN, distinct from 0)
+
+    Pure + deterministic. The orchestration treats None as UNKNOWN (it is NOT
+    counted as a low-viewed video).
+    """
+    if text is None:
+        return None
+    s = str(text).strip().lower()
+    if not s:
+        return None
+    # Strip the trailing word "views" / "view".
+    s = re.sub(r"\bviews?\b", "", s).strip()
+    if not s or s in ("-", "--", "no", "no views", "none"):
+        return None
+
+    m = re.search(r"([0-9][0-9.,]*)\s*([kmb])?", s)
+    if not m:
+        return None
+    num_raw, suffix = m.group(1), m.group(2)
+
+    # "1,234" -> 1234 ; "1.2" (with K) -> 1.2 ; "1.234" plain thousands -> 1234.
+    if suffix:
+        # Suffix present: the dot is a decimal point (1.2K).
+        try:
+            value = float(num_raw.replace(",", ""))
+        except ValueError:
+            return None
+        mult = {"k": 1_000, "m": 1_000_000, "b": 1_000_000_000}[suffix]
+        return int(round(value * mult))
+
+    # No suffix: commas and dots are thousands separators -> strip both.
+    digits = num_raw.replace(",", "").replace(".", "")
+    if not digits.isdigit():
+        return None
+    return int(digits)
+
+
+def parse_row_signal(raw: Dict[str, Any]) -> RowSignal:
+    """Turn a raw scraped row dict into a typed RowSignal (pure).
+
+    Expected raw keys (whatever the scrape produced):
+        video_id: str
+        visibility_text: str  (e.g. "Scheduled", "Unlisted")
+        scheduled_date: str | None
+        views_text: str | None
+
+    The "scheduled" boolean is derived from the visibility label-span text
+    (span.label-span -> "Scheduled"), matching the live row structure.
+    """
+    visibility_text = (raw.get("visibility_text") or "").strip().lower()
+    scheduled = "scheduled" in visibility_text
+    scheduled_date = raw.get("scheduled_date") or None
+    if not scheduled:
+        scheduled_date = None  # only carry a date for genuinely-scheduled rows
+    return RowSignal(
+        video_id=str(raw.get("video_id") or "").strip(),
+        scheduled=scheduled,
+        scheduled_date=scheduled_date,
+        views=parse_view_count(raw.get("views_text")),
+    )
+
+
+def summarize_rows(
+    rows: List[RowSignal],
+    *,
+    low_view_threshold: int = DEFAULT_LOW_VIEW_THRESHOLD,
+) -> Dict[str, Any]:
+    """Aggregate parsed rows into the read-only signal summary (pure).
+
+    Returns scheduled_count, the scheduled videos, and the low-viewed shorts
+    (views known AND strictly below the threshold). Rows with UNKNOWN views are
+    NEVER counted as low-viewed.
+    """
+    scheduled = [r for r in rows if r.scheduled]
+    low_viewed = [
+        r for r in rows
+        if r.views is not None and r.views < low_view_threshold
+    ]
+    return {
+        "row_count": len(rows),
+        "scheduled_count": len(scheduled),
+        "scheduled_videos": [r.to_dict() for r in scheduled],
+        "low_view_threshold": low_view_threshold,
+        "low_viewed_count": len(low_viewed),
+        "low_viewed_videos": [r.to_dict() for r in low_viewed],
+        "videos": [r.to_dict() for r in rows],
+    }
+
+
+# === Malleable seam 2: the live DOM scrape (shadow-pierced) =================
+
+def _apply_has_schedule_filter(driver) -> bool:
+    """Click the Filter chip-bar input, then tick "Has schedule" in the dialog.
+
+    Uses the EXISTING shadow-piercing finder (WSP 84) because Studio is
+    shadow-rooted and flat selectors silently miss the chip-bar / dialog.
+
+    Returns True only if the "Has schedule" checkbox was found AND ticked.
+    Any failure -> False (caller maps that to UNKNOWN, never false-0).
+    """
+    try:
+        from modules.infrastructure.foundups_selenium.src.shadow_dom_finder import (
+            first_deep,
+        )
+    except Exception as exc:  # pragma: no cover - import guard
+        logger.warning(f"[{SKILL_NAME}] shadow_dom_finder unavailable: {exc}")
+        return False
+
+    # Step 1: focus the chip-bar filter input to open the filter dialog.
+    chip_input = first_deep(driver, [FILTER_INPUT_CHAIN[0], FILTER_INPUT_CHAIN_FALLBACK])
+    if chip_input is None:
+        logger.warning(f"[{SKILL_NAME}] filter chip-bar input not found (deep)")
+        return False
+    try:
+        chip_input.click()
+    except Exception as exc:
+        logger.warning(f"[{SKILL_NAME}] filter chip-bar input click failed: {exc}")
+        return False
+
+    # Step 2: wait briefly for the filter dialog, then find the "Has schedule"
+    # checkbox label inside it. We search labels deep and match the text.
+    dialog = None
+    for _ in range(10):
+        dialog = first_deep(driver, FILTER_DIALOG_SELECTORS)
+        if dialog is not None:
+            break
+        time.sleep(0.2)
+    if dialog is None:
+        logger.warning(f"[{SKILL_NAME}] filter dialog did not open")
+        return False
+
+    # Find a clickable "Has schedule" label/checkbox within the dialog subtree.
+    checkbox = _find_has_schedule_option(driver, dialog)
+    if checkbox is None:
+        logger.warning(f"[{SKILL_NAME}] 'Has schedule' option not found in dialog")
+        return False
+    try:
+        checkbox.click()
+    except Exception as exc:
+        logger.warning(f"[{SKILL_NAME}] 'Has schedule' click failed: {exc}")
+        return False
+
+    # Give the list a moment to re-filter.
+    time.sleep(0.5)
+    return True
+
+
+def _find_has_schedule_option(driver, dialog):
+    """Locate the "Has schedule" label/checkbox in the filter dialog subtree.
+
+    Tries label elements first (the dialog renders a `label` with the text
+    "Has schedule"), then a couple of paper-checkbox fallbacks. Text match is
+    case-insensitive and tolerant of surrounding whitespace.
+    """
+    from modules.infrastructure.foundups_selenium.src.shadow_dom_finder import (
+        find_deep,
+    )
+
+    # Walk the dialog subtree for candidate option elements.
+    for sel in ("label", "tp-yt-paper-checkbox", "ytcp-checkbox-lit", "div.label"):
+        candidate = find_deep(dialog, sel)
+        # find_deep returns only the FIRST match; we need to scan text, so use a
+        # JS scan over the dialog subtree for any element whose trimmed text is
+        # exactly/contains "has schedule".
+        # (candidate is just a cheap existence probe.)
+        if candidate is None:
+            continue
+        match = _scan_text_for_has_schedule(driver, dialog, sel)
+        if match is not None:
+            return match
+    # Last resort: scan all labels in the dialog.
+    return _scan_text_for_has_schedule(driver, dialog, "*")
+
+
+_SCAN_HAS_SCHEDULE_JS = r"""
+const root = arguments[0];
+const sel = arguments[1];
+function* walk(node) {
+    if (!node) return;
+    let nodes;
+    try { nodes = node.querySelectorAll(sel); } catch (e) { nodes = []; }
+    for (const n of nodes) yield n;
+    let all;
+    try { all = node.querySelectorAll('*'); } catch (e) { return; }
+    for (const child of all) {
+        if (child.shadowRoot) { yield* walk(child.shadowRoot); }
+    }
+}
+for (const el of walk(root)) {
+    const t = (el.textContent || '').trim().toLowerCase();
+    if (t === 'has schedule' || (t.includes('has schedule') && t.length < 40)) {
+        return el;
+    }
+}
+return null;
+"""
+
+
+def _scan_text_for_has_schedule(driver, dialog, sel):
+    """JS-scan the dialog subtree (incl. shadow roots) for a 'Has schedule' element."""
+    try:
+        return driver.execute_script(_SCAN_HAS_SCHEDULE_JS, dialog, sel)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug(f"[{SKILL_NAME}] has-schedule scan failed for {sel!r}: {exc}")
+        return None
+
+
+_SCRAPE_ROWS_JS = r"""
+// Scrape shorts-list rows across shadow roots. Returns raw dicts only; all
+// parsing happens in Python (pure seam). No mutation.
+function findInShadowAll(root, sel, out) {
+    if (!root) return;
+    let direct;
+    try { direct = root.querySelectorAll(sel); } catch (e) { direct = []; }
+    for (const d of direct) out.push(d);
+    let all;
+    try { all = root.querySelectorAll('*'); } catch (e) { return; }
+    for (const child of all) {
+        if (child.shadowRoot) findInShadowAll(child.shadowRoot, sel, out);
+    }
+}
+function deepText(el, sel) {
+    if (!el) return '';
+    let hit = null;
+    try { hit = el.querySelector(sel); } catch (e) {}
+    if (hit) return (hit.textContent || '').trim();
+    let all;
+    try { all = el.querySelectorAll('*'); } catch (e) { return ''; }
+    for (const c of all) {
+        if (c.shadowRoot) {
+            const t = deepText(c.shadowRoot.host || c, sel);
+            if (t) return t;
+        }
+    }
+    return '';
+}
+const rows = [];
+findInShadowAll(document, 'ytcp-video-row', rows);
+const out = [];
+for (const row of rows) {
+    // video id from the title link href.
+    let video_id = '';
+    let link = null;
+    try { link = row.querySelector("a#video-title, a[href*='/video/']"); } catch (e) {}
+    if (link) {
+        const href = link.getAttribute('href') || '';
+        const m = href.match(/\/video\/([^/?]+)/);
+        if (m) video_id = m[1];
+    }
+    // visibility label-span text (e.g. "Scheduled").
+    let visibility_text = '';
+    try {
+        const vs = row.querySelector('span.label-span');
+        if (vs) visibility_text = (vs.textContent || '').trim();
+    } catch (e) {}
+    // scheduled date cell.
+    let scheduled_date = '';
+    try {
+        const dc = row.querySelector('div.tablecell-date, .tablecell-date');
+        if (dc) scheduled_date = (dc.textContent || '').trim().split('\n')[0];
+    } catch (e) {}
+    // views cell: prefer an explicit views column, else any cell containing 'view'.
+    let views_text = '';
+    try {
+        const vc = row.querySelector(
+            "#views, .tablecell-views, [class*='views'], span.cell-views"
+        );
+        if (vc) views_text = (vc.getAttribute('aria-label') || vc.textContent || '').trim();
+    } catch (e) {}
+    if (!views_text) {
+        try {
+            const cells = row.querySelectorAll('*');
+            for (const c of cells) {
+                const t = (c.textContent || '').trim();
+                if (/\bviews?\b/i.test(t) && t.length < 30) { views_text = t; break; }
+            }
+        } catch (e) {}
+    }
+    out.push({
+        video_id: video_id,
+        visibility_text: visibility_text,
+        scheduled_date: scheduled_date,
+        views_text: views_text,
+    });
+}
+return out;
+"""
+
+
+def scrape_live_rows(driver) -> List[Dict[str, Any]]:
+    """Scrape the shorts-list rows (raw dicts) across shadow roots. No mutation.
+
+    Returns a list of raw row dicts (video_id, visibility_text, scheduled_date,
+    views_text). Parsing into typed signals happens in the pure seam.
+    """
+    try:
+        rows = driver.execute_script(_SCRAPE_ROWS_JS)
+        return list(rows or [])
+    except Exception as exc:
+        logger.warning(f"[{SKILL_NAME}] row scrape failed: {exc}")
+        return []
+
+
+# === Orchestration =========================================================
+
+def read_live_schedule_signal(
+    driver,
+    *,
+    channel_id: str,
+    low_view_threshold: int = DEFAULT_LOW_VIEW_THRESHOLD,
+    apply_filter_fn: Callable[[Any], bool] = _apply_has_schedule_filter,
+    scrape_fn: Callable[[Any], List[Dict[str, Any]]] = scrape_live_rows,
+) -> Dict[str, Any]:
+    """Read the two live read-only signals from the shorts list (no mutation).
+
+    Flow:
+      1. Apply the "Has schedule" filter via the chip-bar input + dialog
+         (shadow-pierced). If it cannot be applied -> filter_applied=False and
+         scheduled_count = None (UNKNOWN). We do NOT scrape an unfiltered list
+         and call its scheduled rows "the count" -- and we NEVER return 0 here.
+      2. Scrape rows -> parse -> summarize: accurate scheduled_count + per-video
+         views + low-viewed signal.
+
+    Args:
+        driver: Selenium WebDriver already on the channel's shorts list.
+        channel_id: YouTube channel ID (from the registry; never hardcoded).
+        low_view_threshold: views strictly below this => low-viewed candidate.
+        apply_filter_fn: swappable "Has schedule" applier (default: real DOM).
+        scrape_fn: swappable row scrape (default: real shadow-pierced scrape).
+
+    Returns a structured signal dict. KEY CONTRACT:
+        - scheduled_count is an int ONLY when filter_applied is True.
+        - scheduled_count is None (UNKNOWN) when the filter could not be applied
+          -- this is the false-0 fix.
+    """
+    patterns = {
+        "has_schedule_filter_attempted": False,
+        "has_schedule_filter_applied": False,
+        "rows_scraped": False,
+        "rows_parsed": False,
+        "views_parsed": False,
+    }
+
+    patterns["has_schedule_filter_attempted"] = True
+    filter_applied = bool(apply_filter_fn(driver))
+    patterns["has_schedule_filter_applied"] = filter_applied
+
+    if not filter_applied:
+        # FAIL-SAFE: unknown, NOT a false 0 (the whole point of this slice).
+        return {
+            "success": False,
+            "skill": SKILL_NAME,
+            "channel_id": channel_id,
+            "filter_applied": False,
+            "scheduled_count": None,  # UNKNOWN
+            "scheduled_count_status": "unknown_filter_not_applied",
+            "low_view_threshold": low_view_threshold,
+            "low_viewed_count": None,
+            "low_viewed_videos": [],
+            "scheduled_videos": [],
+            "videos": [],
+            "row_count": 0,
+            "patterns": patterns,
+        }
+
+    raw_rows = scrape_fn(driver)
+    patterns["rows_scraped"] = True
+
+    parsed = [parse_row_signal(r) for r in raw_rows]
+    patterns["rows_parsed"] = True
+    patterns["views_parsed"] = any(r.views is not None for r in parsed)
+
+    summary = summarize_rows(parsed, low_view_threshold=low_view_threshold)
+
+    return {
+        "success": True,
+        "skill": SKILL_NAME,
+        "channel_id": channel_id,
+        "filter_applied": True,
+        "scheduled_count": summary["scheduled_count"],  # accurate int
+        "scheduled_count_status": "ok",
+        "low_view_threshold": summary["low_view_threshold"],
+        "low_viewed_count": summary["low_viewed_count"],
+        "low_viewed_videos": summary["low_viewed_videos"],
+        "scheduled_videos": summary["scheduled_videos"],
+        "videos": summary["videos"],
+        "row_count": summary["row_count"],
+        "patterns": patterns,
+    }
+
+
+# === Signal emission (WSP 91 breadcrumb + WSP 60/48 PatternMemory) ==========
+
+def _emit_breadcrumb(signal: Dict[str, Any]) -> bool:
+    """Emit a live_schedule_signal breadcrumb so the WRE/overseer can learn."""
+    try:
+        from modules.communication.livechat.src.breadcrumb_telemetry import (
+            get_breadcrumb_telemetry,
+        )
+
+        sc = signal.get("scheduled_count")
+        get_breadcrumb_telemetry().store_breadcrumb(
+            source_dae=SOURCE_DAE,
+            event_type="live_schedule_signal",
+            message=(
+                f"live schedule signal ch={signal.get('channel_id')} "
+                f"filter_applied={signal.get('filter_applied')} "
+                f"scheduled_count={'UNKNOWN' if sc is None else sc} "
+                f"low_viewed={signal.get('low_viewed_count')}"
+            ),
+            phase="SHORTS_LIVE_SCHEDULE_AND_VIEW_SIGNAL",
+            metadata={
+                "skill": SKILL_NAME,
+                "channel_id": signal.get("channel_id"),
+                "filter_applied": signal.get("filter_applied"),
+                "scheduled_count": sc,
+                "scheduled_count_status": signal.get("scheduled_count_status"),
+                "low_view_threshold": signal.get("low_view_threshold"),
+                "low_viewed_count": signal.get("low_viewed_count"),
+                "row_count": signal.get("row_count"),
+            },
+        )
+        return True
+    except Exception as exc:  # pragma: no cover - telemetry is best-effort
+        logger.warning(f"[{SKILL_NAME}] breadcrumb emit failed: {exc}")
+        return False
+
+
+def _store_outcome(signal: Dict[str, Any]) -> bool:
+    """Store a SkillOutcome so the WRE remembers each live-signal read."""
+    try:
+        import json
+
+        from modules.infrastructure.wre_core.src.pattern_memory import (
+            PatternMemory,
+            SkillOutcome,
+        )
+
+        success = bool(signal.get("success"))
+        outcome = SkillOutcome(
+            execution_id=f"{SKILL_NAME}-{uuid.uuid4().hex[:12]}",
+            skill_name=SKILL_NAME,
+            agent="gemma",
+            timestamp=datetime.now().isoformat(),
+            input_context=json.dumps(
+                {
+                    "channel_id": signal.get("channel_id"),
+                    "low_view_threshold": signal.get("low_view_threshold"),
+                },
+                separators=(",", ":"),
+            ),
+            output_result=json.dumps(
+                {
+                    "filter_applied": signal.get("filter_applied"),
+                    "scheduled_count": signal.get("scheduled_count"),
+                    "scheduled_count_status": signal.get("scheduled_count_status"),
+                    "low_viewed_count": signal.get("low_viewed_count"),
+                    "row_count": signal.get("row_count"),
+                },
+                separators=(",", ":"),
+            )[:10000],
+            success=success,
+            pattern_fidelity=_pattern_fidelity(signal.get("patterns") or {}),
+            outcome_quality=1.0 if success else 0.0,
+            execution_time_ms=0,
+            step_count=len(signal.get("patterns") or {}),
+            failed_at_step=None if success else 1,
+            notes=f"source={SKILL_NAME} read_only=true filter_applied={signal.get('filter_applied')}",
+        )
+        PatternMemory().store_outcome(outcome)
+        return True
+    except Exception as exc:  # pragma: no cover - memory is best-effort
+        logger.warning(f"[{SKILL_NAME}] pattern memory store failed: {exc}")
+        return False
+
+
+def _pattern_fidelity(patterns: Dict[str, bool]) -> float:
+    if not patterns:
+        return 0.0
+    return round(sum(1 for v in patterns.values() if v) / len(patterns), 3)
+
+
+def run_skill(
+    *,
+    channel: str,
+    low_view_threshold: int = DEFAULT_LOW_VIEW_THRESHOLD,
+    driver=None,
+    apply_filter_fn: Callable[[Any], bool] = _apply_has_schedule_filter,
+    scrape_fn: Callable[[Any], List[Dict[str, Any]]] = scrape_live_rows,
+    emit_signals: bool = True,
+) -> Dict[str, Any]:
+    """SKILLz entry point: read the live signal for one channel and emit WRE signals.
+
+    Resolves the channel_id from the registry (never hardcoded), reads the live
+    read-only signal, and emits breadcrumb + PatternMemory. Returns a structured
+    result for the daemon/Qwen to consume.
+
+    If `driver` is None, no live browser is available -> returns a clear
+    unavailable result (scheduled_count None / UNKNOWN), still NEVER a false 0.
+    """
+    channel_id = _resolve_channel_id(channel)
+
+    if driver is None:
+        signal = {
+            "success": False,
+            "skill": SKILL_NAME,
+            "channel": channel,
+            "channel_id": channel_id,
+            "filter_applied": False,
+            "scheduled_count": None,
+            "scheduled_count_status": "unknown_no_driver",
+            "low_view_threshold": low_view_threshold,
+            "low_viewed_count": None,
+            "low_viewed_videos": [],
+            "scheduled_videos": [],
+            "videos": [],
+            "row_count": 0,
+            "patterns": {},
+        }
+    else:
+        signal = read_live_schedule_signal(
+            driver,
+            channel_id=channel_id or channel,
+            low_view_threshold=low_view_threshold,
+            apply_filter_fn=apply_filter_fn,
+            scrape_fn=scrape_fn,
+        )
+        signal["channel"] = channel
+
+    breadcrumb_emitted = False
+    outcome_stored = False
+    if emit_signals:
+        breadcrumb_emitted = _emit_breadcrumb(signal)
+        outcome_stored = _store_outcome(signal)
+
+    signal["breadcrumb_emitted"] = breadcrumb_emitted
+    signal["outcome_stored"] = outcome_stored
+    return signal
+
+
+def _resolve_channel_id(channel: str) -> Optional[str]:
+    """Resolve a channel KEY (e.g. 'foundups') to its channel ID via the registry.
+
+    Never hardcodes IDs. If `channel` is already an ID (UC...) it is returned as
+    is. Returns None if it cannot be resolved (caller still degrades safely).
+    """
+    if channel and channel.startswith("UC"):
+        return channel
+    try:
+        from modules.platform_integration.youtube_shorts_scheduler.src.channel_config import (
+            get_channel_config,
+        )
+
+        config = get_channel_config(channel)
+        if config:
+            return config.get("id")
+    except Exception as exc:  # pragma: no cover - registry best-effort
+        logger.debug(f"[{SKILL_NAME}] channel resolve failed for {channel!r}: {exc}")
+    return None
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke
+    logging.basicConfig(level=logging.INFO)
+    print(f"{SKILL_NAME} SKILLz - run via run_skill.py or the --agent-command surface")

--- a/modules/platform_integration/youtube_shorts_scheduler/skillz/shorts_live_schedule_signal/run_skill.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/skillz/shorts_live_schedule_signal/run_skill.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+shorts_live_schedule_signal - module entrypoint for agent/DAE invocation.
+
+This is the surface the --agent-command path spawns (read-only, agent-invoked):
+    youtube action live_schedule_signal channel=foundups
+        -> python -m ...skillz.shorts_live_schedule_signal.run_skill --channel foundups --json
+
+It is NOT a manual-012 menu. 012 only observes the emitted breadcrumb / outcome and
+the JSON tail printed here. The daemon/Qwen consumes the JSON signal:
+  - an ACCURATE scheduled_count (or null=UNKNOWN, never a false 0), and
+  - the low-viewed shorts list (012: "re-schedule low viewed shorts").
+
+A live browser is required for the real signal; without one (no --connect or no
+debug session) the skill returns scheduled_count=null (UNKNOWN), never 0.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+# UTF-8 enforcement (WSP 90) - entry point only
+if sys.platform.startswith("win"):  # pragma: no cover - platform guard
+    import io
+
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace", line_buffering=True)
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="replace", line_buffering=True)
+
+from modules.platform_integration.youtube_shorts_scheduler.skillz.shorts_live_schedule_signal.executor import (
+    DEFAULT_LOW_VIEW_THRESHOLD,
+    run_skill,
+)
+
+
+def _connect_driver(browser: str):
+    """Connect to an existing logged-in debug browser session (read-only).
+
+    Returns a Selenium WebDriver attached to the running Chrome/Edge debug
+    session, or None if connection fails (skill then degrades to UNKNOWN).
+    """
+    try:
+        from selenium import webdriver
+        from selenium.webdriver.chrome.options import Options as ChromeOptions
+        from selenium.webdriver.edge.options import Options as EdgeOptions
+
+        ports = {"chrome": 9222, "edge": 9223}
+        port = ports.get(browser.lower(), 9222)
+        if browser.lower() == "edge":
+            options = EdgeOptions()
+            options.add_experimental_option("debuggerAddress", f"127.0.0.1:{port}")
+            return webdriver.Edge(options=options)
+        options = ChromeOptions()
+        options.add_experimental_option("debuggerAddress", f"127.0.0.1:{port}")
+        return webdriver.Chrome(options=options)
+    except Exception:
+        return None
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "shorts_live_schedule_signal SKILLz - read-only live 'Has schedule' "
+            "count + per-video view (low-viewed) signal from the Studio shorts list."
+        )
+    )
+    parser.add_argument(
+        "--channel",
+        required=True,
+        help="Channel key (e.g. foundups, antifafm) or a UC... channel ID.",
+    )
+    parser.add_argument(
+        "--low-view-threshold",
+        type=int,
+        default=DEFAULT_LOW_VIEW_THRESHOLD,
+        help=f"Views strictly below this are 'low viewed' (default {DEFAULT_LOW_VIEW_THRESHOLD}).",
+    )
+    parser.add_argument(
+        "--connect",
+        choices=["chrome", "edge"],
+        default=None,
+        help="Connect to an existing debug browser session for a LIVE read.",
+    )
+    parser.add_argument(
+        "--no-signals",
+        action="store_true",
+        help="Skip breadcrumb + PatternMemory emission (diagnostic only).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON (agent consumption).",
+    )
+    args = parser.parse_args(argv)
+
+    driver = _connect_driver(args.connect) if args.connect else None
+
+    result = run_skill(
+        channel=args.channel,
+        low_view_threshold=args.low_view_threshold,
+        driver=driver,
+        emit_signals=not args.no_signals,
+    )
+
+    # Always print a single JSON line last so the adapter's _extract_json_tail can
+    # parse it deterministically.
+    print(json.dumps(result, ensure_ascii=False, separators=(",", ":")))
+    return 0 if result.get("success") else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/modules/platform_integration/youtube_shorts_scheduler/tests/TestModLog.md
+++ b/modules/platform_integration/youtube_shorts_scheduler/tests/TestModLog.md
@@ -1,5 +1,40 @@
 # YouTube Shorts Scheduler - TestModLog
 
+## 2026-06-19 - shorts_live_schedule_signal: live "Has schedule" count + view signal (mock-only)
+
+**By:** 0102 (Worker-Lane LIVE-SIGNAL)
+**Slice:** SHORTS_LIVE_SCHEDULE_AND_VIEW_SIGNAL_PHASE1
+**WSP References:** WSP 6 (Test Audit), WSP 5 (Coverage), WSP 22 (ModLog), WSP 84 (Code Reuse), WSP 97 (Truth Signaling)
+
+### Added `tests/test_shorts_live_schedule_signal.py` (unit, mock-only -- no browser/daemon/models) -- 27 passed
+
+- `test_parse_view_count[...]` (13 cases) - pure parser: "1.2K views"->1200, "3.4M"->3.4M, "2B"->2B,
+  "1,234 views"->1234, "1.234"->1234 (plain thousands), "0"->0, "-"/""/None/"No views"->None (UNKNOWN).
+- `test_parse_view_count_unknown_is_not_zero` - UNKNOWN ("-") is None, distinct from 0.
+- `test_parse_row_signal_*` - scheduled flag derived from `span.label-span` text; unlisted rows carry
+  no scheduled_date.
+- `test_summarize_counts_scheduled_and_low_viewed` - 3 scheduled rows -> count 3 (NOT 0); low-viewed
+  = views known AND < threshold (sch1/sch3/unl1); UNKNOWN-views row (unl2) NOT counted low-viewed.
+- `test_accurate_scheduled_count_when_rows_exist` / `test_false_zero_is_fixed_*` - filter applied +
+  rows present -> scheduled_count == 3 and != 0 (the false-0 fix).
+- `test_views_parsed_from_list` - per-video views surface in the signal; UNKNOWN preserved as None.
+- `test_filter_fail_returns_unknown_not_zero` - filter TIMEOUT -> scheduled_count is None (UNKNOWN),
+  status `unknown_filter_not_applied`, success False; NEVER 0.
+- `test_old_path_produces_false_zero_then_new_path_returns_unknown` - REGRESSION ANCHOR: reproduces the
+  OLD `[CPS-AUDIT]` timeout->false-0 (`old_count == 0`), then asserts the NEW path on the SAME timeout
+  returns None. A regression to the old false-0 fails here.
+- `test_signal_responds_to_dom_not_static` - count FLIPS with the injected DOM (3 vs 1), proving the
+  scrape drives it (a static impl fails).
+- `test_run_skill_emits_breadcrumb_and_pattern_memory` - emits `live_schedule_signal` breadcrumb
+  (source_dae `youtube_shorts_scheduler`, metadata scheduled_count==3) + a PatternMemory SkillOutcome.
+- `test_run_skill_no_driver_returns_unknown_not_zero` - no browser -> None (UNKNOWN), not 0.
+- `test_run_skill_no_signals_skips_emission` - emit_signals=False emits nothing.
+
+**Non-vacuity proof (recorded):** runtime-monkeypatching the executor to the OLD false-0 behavior
+RED-fails the three load-bearing tests with `assert 0 is None`; the real executor file was unchanged.
+
+**Live gap:** DOM read is mock-only; 012 live-validates the real Studio selectors before graduation.
+
 ## 2026-06-19 - US-ET peak slots + per-channel Studio-tz conversion (Phase 1)
 
 **By:** 0102 (Worker-Lane SCHED-WINDOW)

--- a/modules/platform_integration/youtube_shorts_scheduler/tests/test_shorts_live_schedule_signal.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/tests/test_shorts_live_schedule_signal.py
@@ -1,0 +1,354 @@
+"""
+Unit tests for the shorts_live_schedule_signal SKILLz (read-only live signals).
+
+Slice: SHORTS_LIVE_SCHEDULE_AND_VIEW_SIGNAL_PHASE1
+
+Model under test
+----------------
+Read two read-only signals from the YouTube Studio shorts list:
+  1. ACCURATE scheduled count via the "Has schedule" filter (chip-bar input +
+     filter dialog), reached through the shadow-piercing finder. When the filter
+     CANNOT be applied -> scheduled_count = None (UNKNOWN), NEVER a false 0.
+  2. Per-video VIEW count -> a low-viewed signal (views strictly below threshold;
+     UNKNOWN views never counted as low-viewed).
+
+These tests are MOCK-ONLY (no live browser, no daemon, no live models) and
+NON-VACUOUS:
+  - accurate scheduled count when rows exist (NOT 0),
+  - the false-0 is fixed: a present-schedule channel returns > 0,
+  - views parsed from the list,
+  - filter-fail returns UNKNOWN/None, NOT 0,
+  - a reproduction of the OLD timing-out behavior (returns a false 0) is asserted,
+    then the NEW path on the SAME timeout returns UNKNOWN (None) instead -- so a
+    regression back to the false-0 behavior FAILS this test,
+  - breadcrumb + PatternMemory emission are invoked (mocked + asserted),
+  - parsing responds to the injected DOM (a static impl fails).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from modules.platform_integration.youtube_shorts_scheduler.skillz.shorts_live_schedule_signal.executor import (
+    DEFAULT_LOW_VIEW_THRESHOLD,
+    parse_row_signal,
+    parse_view_count,
+    read_live_schedule_signal,
+    run_skill,
+    summarize_rows,
+)
+
+
+# --- A mock Studio DOM: rows with scheduled/views + a "Has schedule" filter ---
+
+def _mock_rows_present_schedule():
+    """Raw scraped rows as the shadow-pierced JS scrape would return them.
+
+    3 scheduled rows + 2 unlisted rows, mixed view counts including a low-viewed
+    one and an UNKNOWN-views one.
+    """
+    return [
+        {"video_id": "sch1", "visibility_text": "Scheduled", "scheduled_date": "Feb 5, 2026", "views_text": "0 views"},
+        {"video_id": "sch2", "visibility_text": "Scheduled", "scheduled_date": "Feb 6, 2026", "views_text": "1.2K views"},
+        {"video_id": "sch3", "visibility_text": "Scheduled", "scheduled_date": "Feb 7, 2026", "views_text": "12 views"},
+        {"video_id": "unl1", "visibility_text": "Unlisted", "scheduled_date": "", "views_text": "5 views"},
+        {"video_id": "unl2", "visibility_text": "Unlisted", "scheduled_date": "", "views_text": "-"},
+    ]
+
+
+def _filter_ok(_driver):
+    """A 'Has schedule' applier that succeeds (mock live filter applied)."""
+    return True
+
+
+def _filter_timeout(_driver):
+    """A 'Has schedule' applier that FAILS (simulates the live filter TIMEOUT).
+
+    This is the failure the real [CPS-AUDIT] path hits on the Edge channels.
+    """
+    return False
+
+
+# ---------------------------------------------------------------------------
+# parse_view_count: pure parser
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("1,234 views", 1234),
+        ("1.2K views", 1200),
+        ("3.4M", 3_400_000),
+        ("2B views", 2_000_000_000),
+        ("0", 0),
+        ("0 views", 0),
+        ("12 views", 12),
+        ("1,000,000 views", 1_000_000),
+        ("1.234", 1234),       # plain thousands separator, no suffix
+        ("-", None),           # UNKNOWN, distinct from 0
+        ("", None),
+        (None, None),
+        ("No views", None),
+    ],
+)
+def test_parse_view_count(text, expected):
+    assert parse_view_count(text) == expected
+
+
+def test_parse_view_count_unknown_is_not_zero():
+    """UNKNOWN views must be None, NOT 0 (so it is never a low-viewed false hit)."""
+    assert parse_view_count("-") is None
+    assert parse_view_count("0") == 0
+    assert parse_view_count("-") != parse_view_count("0")
+
+
+# ---------------------------------------------------------------------------
+# parse_row_signal + summarize_rows: pure aggregation
+# ---------------------------------------------------------------------------
+
+def test_parse_row_signal_scheduled_flag_from_label():
+    row = parse_row_signal(
+        {"video_id": "x", "visibility_text": "Scheduled", "scheduled_date": "Feb 5, 2026", "views_text": "9 views"}
+    )
+    assert row.scheduled is True
+    assert row.scheduled_date == "Feb 5, 2026"
+    assert row.views == 9
+
+
+def test_parse_row_signal_unlisted_has_no_scheduled_date():
+    row = parse_row_signal(
+        {"video_id": "x", "visibility_text": "Unlisted", "scheduled_date": "Feb 5, 2026", "views_text": "9 views"}
+    )
+    assert row.scheduled is False
+    assert row.scheduled_date is None  # date only carried for scheduled rows
+
+
+def test_summarize_counts_scheduled_and_low_viewed():
+    rows = [parse_row_signal(r) for r in _mock_rows_present_schedule()]
+    summary = summarize_rows(rows, low_view_threshold=100)
+
+    # 3 scheduled rows -> count is 3, NOT 0.
+    assert summary["scheduled_count"] == 3
+    # low-viewed (<100, views known): sch1(0), sch3(12), unl1(5) = 3.
+    # sch2 (1200) is high; unl2 (UNKNOWN) is NOT low-viewed.
+    assert summary["low_viewed_count"] == 3
+    low_ids = {v["video_id"] for v in summary["low_viewed_videos"]}
+    assert low_ids == {"sch1", "sch3", "unl1"}
+    assert "unl2" not in low_ids  # UNKNOWN views never counted low-viewed
+
+
+# ---------------------------------------------------------------------------
+# read_live_schedule_signal: orchestration (accurate count + fail-safe)
+# ---------------------------------------------------------------------------
+
+def test_accurate_scheduled_count_when_rows_exist():
+    """Filter applied + rows present -> accurate scheduled_count > 0 (NOT a false 0)."""
+    signal = read_live_schedule_signal(
+        MagicMock(),
+        channel_id="UC_FOUNDUPS",
+        apply_filter_fn=_filter_ok,
+        scrape_fn=lambda d: _mock_rows_present_schedule(),
+    )
+    assert signal["filter_applied"] is True
+    assert signal["scheduled_count"] == 3        # the load-bearing assertion
+    assert signal["scheduled_count"] != 0        # false-0 is fixed
+    assert signal["scheduled_count_status"] == "ok"
+    assert signal["success"] is True
+
+
+def test_false_zero_is_fixed_present_schedule_channel_returns_positive():
+    """A present-schedule channel must NOT report 0 when the filter is applied."""
+    signal = read_live_schedule_signal(
+        MagicMock(),
+        channel_id="UC_ANTIFAFM",
+        apply_filter_fn=_filter_ok,
+        scrape_fn=lambda d: _mock_rows_present_schedule(),
+    )
+    assert signal["scheduled_count"] > 0
+
+
+def test_views_parsed_from_list():
+    """Per-video views are parsed into the signal output."""
+    signal = read_live_schedule_signal(
+        MagicMock(),
+        channel_id="UC_FOUNDUPS",
+        apply_filter_fn=_filter_ok,
+        scrape_fn=lambda d: _mock_rows_present_schedule(),
+    )
+    views_by_id = {v["video_id"]: v["views"] for v in signal["videos"]}
+    assert views_by_id["sch2"] == 1200
+    assert views_by_id["sch1"] == 0
+    assert views_by_id["unl2"] is None  # UNKNOWN preserved as None
+    assert signal["patterns"]["views_parsed"] is True
+
+
+def test_filter_fail_returns_unknown_not_zero():
+    """Filter cannot be applied (TIMEOUT) -> scheduled_count is None (UNKNOWN), NOT 0."""
+    signal = read_live_schedule_signal(
+        MagicMock(),
+        channel_id="UC_FOUNDUPS",
+        apply_filter_fn=_filter_timeout,
+        # Even if rows could be scraped, a non-applied filter must not be trusted.
+        scrape_fn=lambda d: _mock_rows_present_schedule(),
+    )
+    assert signal["filter_applied"] is False
+    assert signal["scheduled_count"] is None      # UNKNOWN, not 0
+    assert signal["scheduled_count"] != 0
+    assert signal["scheduled_count_status"] == "unknown_filter_not_applied"
+    assert signal["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# Regression anchor: the OLD timing-out behavior returned a FALSE 0.
+# The NEW path on the SAME timeout returns UNKNOWN (None). A regression back to
+# the old false-0 behavior FAILS this test.
+# ---------------------------------------------------------------------------
+
+def _old_audit_path_on_timeout(rows):
+    """Reproduction of the OLD [CPS-AUDIT] behavior.
+
+    Mirrors content_page_scheduler.audit_calendar(): when the visibility filter
+    fails it "continues unfiltered" and then scrapes XPATH_SCHEDULED_ROWS on a
+    page where the Scheduled view never loaded -> 0 rows -> "Total scheduled: 0".
+    We model the timeout as: filter not applied -> the scheduled-row scrape yields
+    nothing -> count 0. THIS IS THE BUG.
+    """
+    filter_applied = False  # the timeout
+    if not filter_applied:
+        scheduled_rows = []  # unfiltered page: scheduled scrape finds nothing
+    else:  # pragma: no cover - not the timeout case here
+        scheduled_rows = [r for r in rows if "scheduled" in r["visibility_text"].lower()]
+    return len(scheduled_rows)  # -> 0 (false)
+
+
+def test_old_path_produces_false_zero_then_new_path_returns_unknown():
+    """Pin the bug, then prove the new path does NOT reproduce it.
+
+    Step 1: the OLD path on a timeout returns a false 0 (the documented bug).
+    Step 2: the NEW path on the SAME timeout returns None (UNKNOWN), never 0.
+    """
+    rows = _mock_rows_present_schedule()
+
+    # Step 1: the OLD behavior is the false 0 (the bug we are fixing).
+    old_count = _old_audit_path_on_timeout(rows)
+    assert old_count == 0  # demonstrates the false-0 bug exists in the old path
+
+    # Step 2: the NEW path on the same timeout must NOT return 0.
+    new_signal = read_live_schedule_signal(
+        MagicMock(),
+        channel_id="UC_FOUNDUPS",
+        apply_filter_fn=_filter_timeout,  # same timeout
+        scrape_fn=lambda d: rows,
+    )
+    assert new_signal["scheduled_count"] is None        # UNKNOWN
+    assert new_signal["scheduled_count"] != old_count   # i.e. != 0 (false)
+
+
+# ---------------------------------------------------------------------------
+# Non-vacuity: the signal MUST depend on the injected DOM.
+# ---------------------------------------------------------------------------
+
+def test_signal_responds_to_dom_not_static():
+    """Changing the mock DOM changes the count -> proves the scrape drives it.
+
+    A static impl that ignored the DOM (e.g. always 3, or always 0) would keep
+    the SAME count; this asserts the count FLIPS with the injected rows.
+    """
+    sig_three = read_live_schedule_signal(
+        MagicMock(),
+        channel_id="UC_X",
+        apply_filter_fn=_filter_ok,
+        scrape_fn=lambda d: _mock_rows_present_schedule(),  # 3 scheduled
+    )
+    one_scheduled = [
+        {"video_id": "only", "visibility_text": "Scheduled", "scheduled_date": "Feb 9, 2026", "views_text": "7 views"},
+        {"video_id": "u", "visibility_text": "Unlisted", "scheduled_date": "", "views_text": "7 views"},
+    ]
+    sig_one = read_live_schedule_signal(
+        MagicMock(),
+        channel_id="UC_X",
+        apply_filter_fn=_filter_ok,
+        scrape_fn=lambda d: one_scheduled,
+    )
+    assert sig_three["scheduled_count"] == 3
+    assert sig_one["scheduled_count"] == 1
+    assert sig_three["scheduled_count"] != sig_one["scheduled_count"]
+
+
+# ---------------------------------------------------------------------------
+# Signal emission: breadcrumb + PatternMemory must be invoked.
+# ---------------------------------------------------------------------------
+
+def test_run_skill_emits_breadcrumb_and_pattern_memory():
+    """run_skill must emit a live_schedule_signal breadcrumb AND a SkillOutcome."""
+    with patch(
+        "modules.communication.livechat.src.breadcrumb_telemetry.get_breadcrumb_telemetry"
+    ) as bc, patch(
+        "modules.infrastructure.wre_core.src.pattern_memory.PatternMemory"
+    ) as pm, patch(
+        "modules.infrastructure.wre_core.src.pattern_memory.SkillOutcome"
+    ) as outcome:
+        result = run_skill(
+            channel="UC_FOUNDUPS",            # UC... id -> no registry lookup
+            driver=MagicMock(),
+            apply_filter_fn=_filter_ok,
+            scrape_fn=lambda d: _mock_rows_present_schedule(),
+            emit_signals=True,
+        )
+
+        bc.return_value.store_breadcrumb.assert_called_once()
+        kwargs = bc.return_value.store_breadcrumb.call_args.kwargs
+        assert kwargs["event_type"] == "live_schedule_signal"
+        assert kwargs["source_dae"] == "youtube_shorts_scheduler"
+        assert kwargs["metadata"]["scheduled_count"] == 3
+
+        pm.return_value.store_outcome.assert_called_once()
+        outcome.assert_called_once()
+
+    assert result["success"] is True
+    assert result["scheduled_count"] == 3
+    assert result["breadcrumb_emitted"] is True
+    assert result["outcome_stored"] is True
+
+
+def test_run_skill_no_driver_returns_unknown_not_zero():
+    """No live browser -> scheduled_count None (UNKNOWN), never a false 0."""
+    with patch(
+        "modules.communication.livechat.src.breadcrumb_telemetry.get_breadcrumb_telemetry"
+    ), patch(
+        "modules.infrastructure.wre_core.src.pattern_memory.PatternMemory"
+    ), patch(
+        "modules.infrastructure.wre_core.src.pattern_memory.SkillOutcome"
+    ):
+        result = run_skill(channel="UC_FOUNDUPS", driver=None, emit_signals=True)
+    assert result["scheduled_count"] is None
+    assert result["scheduled_count_status"] == "unknown_no_driver"
+    assert result["success"] is False
+
+
+def test_run_skill_no_signals_skips_emission():
+    """emit_signals=False must NOT emit breadcrumb/outcome (diagnostic path)."""
+    with patch(
+        "modules.communication.livechat.src.breadcrumb_telemetry.get_breadcrumb_telemetry"
+    ) as bc, patch(
+        "modules.infrastructure.wre_core.src.pattern_memory.PatternMemory"
+    ) as pm:
+        result = run_skill(
+            channel="UC_FOUNDUPS",
+            driver=MagicMock(),
+            apply_filter_fn=_filter_ok,
+            scrape_fn=lambda d: _mock_rows_present_schedule(),
+            emit_signals=False,
+        )
+        bc.return_value.store_breadcrumb.assert_not_called()
+        pm.return_value.store_outcome.assert_not_called()
+    assert result["breadcrumb_emitted"] is False
+    assert result["outcome_stored"] is False
+
+
+def test_default_low_view_threshold_is_sane():
+    assert DEFAULT_LOW_VIEW_THRESHOLD == 100
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary (read-only; NO scheduling mutation)

Two read-only LIVE signals from the YouTube Studio shorts list, packaged as a new
agent-invoked SKILLz `shorts_live_schedule_signal` (mirrors the `what_should_i_schedule`
#850 / `reschedule_plan` #851 read-only pattern):

1. **Accurate "Has schedule" scheduled count** (fixes the false-0 audit).
2. **Per-video VIEW count -> a low-viewed signal** (012: "re-schedule low viewed shorts").

Slice: `SHORTS_LIVE_SCHEDULE_AND_VIEW_SIGNAL_PHASE1`. Status: **VERIFIED_READY** (leave OPEN, do not merge).

---

## The false-0 bug (file:line)

`content_page_scheduler.audit_calendar()` (`[CPS-AUDIT]`) reports "Total scheduled: 0" for the
Edge channels (foundups/antifaFM) even though the tracker holds 131 / 55. Chain:

- `audit_calendar()` -> `navigate_to_scheduled()` (`src/content_page_scheduler.py:414`)
- -> `navigate_to_content(visibility="SCHEDULED")` (`src/content_page_scheduler.py:221`)
- -> `_apply_visibility_filter_via_ui("SCHEDULED")` (`src/content_page_scheduler.py:313-412`) -- the
  OLD sidebar flow `#filter-icon -> "Visibility" -> "Has schedule"`. This **TIMES OUT** on those
  channels; the filter never lands and `navigate_to_content` "continues unfiltered"
  (`src/content_page_scheduler.py:276`).
- -> `get_scheduled_videos_detailed()` (`src/dom_automation.py:2466`) then scrapes
  `XPATH_SCHEDULED_ROWS` (`src/dom_automation.py:77`) on the unfiltered page -> **0 rows**.
- -> "Total scheduled: 0" (`src/content_page_scheduler.py:992`). **A FALSE 0.**

012's reliable path is the chip-bar **"Filter" input -> "Has schedule" checkbox** in the filter
dialog, not the sidebar visibility flow.

## The Has-schedule fix

`read_live_schedule_signal()` clicks the chip-bar filter input
(`ytcp-video-filter#video-filter ytcp-chip-bar#chip-bar input#text-input`), then ticks the
**"Has schedule"** label inside `ytcp-filter-dialog tp-yt-paper-dialog#dialog`, then scrapes
`ytcp-video-row` for scheduled rows. The existing timing-out `_apply_visibility_filter_via_ui` is
left untouched this phase; this skill is the accurate read-only signal the audit/daemon consumes.

## The view signal

Each row's views cell is parsed by the pure `parse_view_count` ("1.2K views" -> 1200; "-"/"" -> None
UNKNOWN, distinct from 0) into `{video_id, scheduled(bool), scheduled_date, views(int|None)}`.
`summarize_rows` derives the low-viewed list (views known AND below threshold; UNKNOWN never
counted low-viewed).

## shadow_dom_finder reuse (WSP 84)

Studio is shadow-rooted, so flat selectors silently fail. The chip-bar / filter dialog / rows are
reached with the EXISTING `modules/infrastructure/foundups_selenium/src/shadow_dom_finder.py`
(`first_deep` / `find_deep`, from the Studio-Ask #825/#827 work) -- no new finder.

## Fallback is NOT a false 0

When the "Has schedule" filter cannot be applied (timeout, selector miss, no driver),
`scheduled_count = None` (UNKNOWN) with `scheduled_count_status` in
`{unknown_filter_not_applied, unknown_no_driver}` and `success = False`. It is **never** a false 0.

## Honest live gap

The DOM read path is **mock-tested only** (a simulated Studio DOM); no live browser ran. **012
live-validates** the real chip-bar / "Has schedule" / views selectors on the Edge channels before
this skill graduates from `prototype`. The selectors are 012-grounded but the live structure must be
re-confirmed in-code (noted in the SKILLz.md and ModLog).

## Non-vacuity proof

`tests/test_shorts_live_schedule_signal.py` -- **27 passed**, mock-only (no browser/daemon/models).
Recorded proof: runtime-monkeypatching the executor to the OLD false-0 behavior RED-fails the three
load-bearing tests with `assert 0 is None`:

- `test_filter_fail_returns_unknown_not_zero`
- `test_old_path_produces_false_zero_then_new_path_returns_unknown` (regression anchor: reproduces the
  OLD timeout->false-0, then asserts the NEW path on the SAME timeout returns None)
- `test_accurate_scheduled_count_when_rows_exist`

Plus `test_signal_responds_to_dom_not_static` (count FLIPS 3 vs 1 with the injected DOM, so a static
impl fails) and breadcrumb/PatternMemory emission asserted.

## WRE signals

Every run emits a `live_schedule_signal` breadcrumb (WSP 91) + a PatternMemory SkillOutcome (WSP
60/48). Agent-invoked via `--agent-command` -> `run_skill.py`; no manual-012 menu. Parsing is behind
pure functions; the DOM scrape + "Has schedule" applier are injectable seams.

## Scope

Touches ONLY `youtube_shorts_scheduler` (new `skillz/shorts_live_schedule_signal/` + the new test +
ModLog/TestModLog) and REUSES `shadow_dom_finder`. **No mutation.** OUT: Mode B apply, wiring into the
scheduler order/ranking, music gate.

## pytest summary

```
27 passed in 0.13s   (tests/test_shorts_live_schedule_signal.py)
52 passed in 0.74s   (with sibling what_should_i_schedule + reschedule_planner -- no regression)
```

Worker-Lane: LIVE-SIGNAL | Slice: SHORTS_LIVE_SCHEDULE_AND_VIEW_SIGNAL_PHASE1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
