### PR TITLE
feat(youtube_shorts_scheduler): reschedule APPLY (Mode B Phase 2) — flag-gated, default dry-run

### DIFF
--- a/modules/communication/moltbot_bridge/src/youtube_automation_adapter.py
+++ b/modules/communication/moltbot_bridge/src/youtube_automation_adapter.py
@@ -11,6 +11,7 @@ Supported actions:
   scheduling        -> shorts scheduler CLI
   schedule_priority -> what_should_i_schedule SKILLz (read-only channel need ranking)
   reschedule_plan   -> reschedule_plan SKILLz (dry-run rebalance PLAN for over-cap days; apply is Phase 2)
+  reschedule_apply  -> reschedule_apply SKILLz (flag-gated apply of the plan; DEFAULT DRY-RUN, mutates nothing unless YT_RESCHEDULE_APPLY=1)
 
 Examples:
   youtube action comments channel=move2japan max_comments=3 like=true heart=true reply=false
@@ -18,6 +19,7 @@ Examples:
   youtube action scheduling channel=foundups max_videos=3 dry_run=true
   youtube action schedule_priority upcoming_days=7
   youtube action reschedule_plan horizon_days=90
+  youtube action reschedule_apply
 """
 
 from __future__ import annotations
@@ -37,6 +39,7 @@ SUPPORTED_ACTIONS = {
     "scheduling",
     "schedule_priority",
     "reschedule_plan",
+    "reschedule_apply",
 }
 
 ACTION_ALIASES = {
@@ -56,6 +59,10 @@ ACTION_ALIASES = {
     "reschedule": "reschedule_plan",
     "rebalance": "reschedule_plan",
     "rebalance_plan": "reschedule_plan",
+    # reschedule_apply SKILLz: flag-gated apply of the plan (DEFAULT DRY-RUN)
+    "apply_reschedule": "reschedule_apply",
+    "rebalance_apply": "reschedule_apply",
+    "reschedule_apply_plan": "reschedule_apply",
 }
 
 # Repo root: modules/communication/moltbot_bridge/src -> parents[4]
@@ -321,6 +328,25 @@ def _build_reschedule_plan_command(params: Dict[str, str]) -> list[str]:
     return cmd
 
 
+def _build_reschedule_apply_command(params: Dict[str, str]) -> list[str]:
+    """Build the reschedule_apply SKILLz invocation.
+
+    Flag-gated apply of the reschedule plan. Via this subprocess surface no live
+    browser is supplied, so it is DRY-RUN by construction (it logs would-apply
+    moves, mutates nothing). Real apply requires YT_RESCHEDULE_APPLY=1 AND a live
+    driver wired through the daemon path (not this CLI surface).
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "modules.platform_integration.youtube_shorts_scheduler.skillz.reschedule_apply.run_skill",
+        "--json",
+    ]
+    if _truthy(params.get("no_signals", "false")):
+        cmd.append("--no-signals")
+    return cmd
+
+
 async def execute_youtube_action(action: str, params: Dict[str, str]) -> Dict[str, Any]:
     if action == "comments":
         cmd = _build_comments_command(params)
@@ -366,6 +392,21 @@ async def execute_youtube_action(action: str, params: Dict[str, str]) -> Dict[st
 
     if action == "reschedule_plan":
         cmd = _build_reschedule_plan_command(params)
+        timeout_s = _int_param(params, "timeout_s", 120)
+        run_result = await asyncio.to_thread(_run_subprocess, cmd, timeout_s)
+        parsed = _extract_json_tail(run_result.get("stdout_tail", ""))
+        success = bool(run_result.get("success", False))
+        if isinstance(parsed, dict) and parsed.get("success") is False:
+            success = False
+        return {
+            "success": success,
+            "action": action,
+            "result": parsed,
+            **run_result,
+        }
+
+    if action == "reschedule_apply":
+        cmd = _build_reschedule_apply_command(params)
         timeout_s = _int_param(params, "timeout_s", 120)
         run_result = await asyncio.to_thread(_run_subprocess, cmd, timeout_s)
         parsed = _extract_json_tail(run_result.get("stdout_tail", ""))

--- a/modules/platform_integration/youtube_shorts_scheduler/ModLog.md
+++ b/modules/platform_integration/youtube_shorts_scheduler/ModLog.md
@@ -1,5 +1,62 @@
 # YouTube Shorts Scheduler - ModLog
 
+## 2026-06-19 - reschedule_apply: flag-gated MUTATING apply of the #851 plan (Mode B Phase 2, DEFAULT DRY-RUN)
+
+**By:** 0102 (Worker-Lane RESCHED-APPLY)
+**Slice:** SHORTS_RESCHEDULE_APPLY_PHASE2
+**WSP References:** WSP 95 (SKILLz Wardrobe), WSP 77 (Agent Coordination), WSP 91 (Observability), WSP 60/48 (Pattern Memory), WSP 84 (Code Reuse: planner + date/time picker + shadow_dom_finder + cap), WSP 50 (flag-gated mutation, default read-only), WSP 27 (Phase 0 KNOWLEDGE), WSP 22 (ModLog), WSP 49 (Structure)
+
+### Problem
+
+The #851 `reschedule_plan` SKILLz produces a dry-run rebalance PLAN (move rows
+`{channel_id, channel_name, from_date, to_date, slot_et, slot_local, video_id}`) for
+over-crowded days, but had no applier. Phase 2 is the MUTATING apply -- built FLAG-GATED
+and DEFAULT DRY-RUN so merging this code mutates NOTHING.
+
+### What changed (default dry-run; merge mutates nothing)
+
+1. **`src/reschedule_applier.py`** -- `apply_moves` / `apply_plan` consume the #851 plan rows.
+   DEFAULT DRY-RUN: each eligible move is only LOGGED as `would move <video> <from> -> <to>
+   @ <slot_local>` plus a per-move breadcrumb (WSP 91) + PatternMemory SkillOutcome (WSP 60/48,
+   status `dry_run`). The DOM picker/save helpers are NEVER called in dry-run. Real apply happens
+   ONLY when env `YT_RESCHEDULE_APPLY == "1"` (default `"0"`) AND a live driver is connected.
+   Safety: `(needs-live-list)` rows -> skipped (`needs_live_list`); per-channel target-day cap
+   re-checked, over-cap -> skipped (`cap`); per-move try/except so one failure never aborts the batch.
+2. **`src/dom_automation.py`** -- reschedule-popup entry helpers (WSP 84 reuse):
+   `open_scheduled_edit_popup(video_id)` clicks the list row's "Scheduled" `span.label-span`
+   (shadow-pierced via `shadow_dom_finder.first_deep`) to open `ytcp-video-visibility-edit-popup`,
+   then `reschedule_open_set_save(date, time, video_id)` reuses the EXISTING `set_schedule_date`
+   (`:2947`), `set_schedule_time` (`:3098`), `click_done` (`:3200`), `click_save` (`:2703`)
+   UNCHANGED -- the popup exposes the same `ytcp-datetime-picker`. `slot_local` is the
+   ready-to-type bare 12h Studio time (ET->channel-tz, #847), typed directly.
+3. **`skillz/reschedule_apply/`** -- `executor.run_skill` (wraps `apply_plan`) + `run_skill.py`
+   (`--json`, dry-run by construction over the subprocess surface) + `SKILLz.md`. Mirrors the
+   #850/#851 read-only/agent-invoked pattern; 012 only observes outcomes and flips the env flag.
+4. **`youtube_automation_adapter.py`** -- `reschedule_apply` action + aliases
+   (`apply_reschedule`, `rebalance_apply`, `reschedule_apply_plan`) + `_build_reschedule_apply_command`
+   + dispatch branch (`youtube action reschedule_apply`).
+
+### Live gap (honest)
+
+The DOM apply path is MOCK-TESTED only (no live browser run). 012 enables `YT_RESCHEDULE_APPLY=1`,
+supplies a connected driver through the daemon, and live-validates the popup picker against real
+Studio before trusting apply.
+
+### Tests (mock-only, NON-VACUOUS, no live browser)
+
+`tests/test_reschedule_applier.py` (15 tests, all pass): dry-run default -> picker/save NOT called,
+moves logged; `YT_RESCHEDULE_APPLY=1` -> picker called with the EXACT date+time per move;
+over-cap -> skipped (`cap`); `(needs-live-list)` -> skipped; per-move error -> batch continues;
+signals emitted per move. Non-vacuity proven: temporarily disabling the dry-run guard FAILS
+`test_dryrun_must_not_call_dom_helpers` + `test_dryrun_default_logs_moves_without_dom`, then reverted.
+
+### Out of scope (NOT built here)
+
+The planner (done #851); wiring into the scheduler loop/cadence; view-based ("low-viewed first")
+selection; the music-vs-talk gate; naming `(needs-live-list)` videos from the live list.
+
+---
+
 ## 2026-06-19 - shorts_live_schedule_signal SKILLz: live "Has schedule" count fix + per-video view signal (read-only)
 
 **By:** 0102 (Worker-Lane LIVE-SIGNAL)

--- a/modules/platform_integration/youtube_shorts_scheduler/skillz/reschedule_apply/SKILLz.md
+++ b/modules/platform_integration/youtube_shorts_scheduler/skillz/reschedule_apply/SKILLz.md
@@ -1,0 +1,178 @@
+---
+# Metadata (YAML Frontmatter)
+name: reschedule_apply
+description: Flag-gated MUTATING apply of the #851 reschedule plan -- move a scheduled short to a target day+peak slot via the Studio visibility-edit popup picker. DEFAULT DRY-RUN (YT_RESCHEDULE_APPLY!="1"): logs would-apply moves, zero mutation. Agent-invoked.
+version: 1.0_prototype
+author: 0102
+created: 2026-06-19
+agents: [qwen, gemma]
+primary_agent: qwen
+intent_type: AUTOMATION
+promotion_state: prototype
+pattern_fidelity_threshold: 0.90
+test_status: needs_validation
+
+# Dependencies
+dependencies:
+  data_stores:
+    - name: schedule_tracker
+      type: json
+      path: modules/platform_integration/youtube_shorts_scheduler/memory/schedule_{channel_id}.json
+  required_context:
+    - YT_RESCHEDULE_APPLY: "env gate; must == '1' for real apply (default '0' => dry-run)"
+  throttles:
+    - name: apply_gate
+      max_rate: gated
+      cost_per_call: 0
+
+# Metrics Configuration
+metrics:
+  pattern_fidelity_scoring:
+    enabled: true
+    frequency: every_execution
+    scorer_agent: gemma
+  promotion_criteria:
+    min_pattern_fidelity: 0.90
+    min_outcome_quality: 0.85
+    min_execution_count: 100
+    required_test_pass_rate: 0.95
+category: capability-uplift
+evals: []
+retirement_date: null
+---
+# reschedule_apply
+
+**Purpose**: Flag-gated MUTATING apply of the #851 reschedule PLAN. For each plan
+move with a real `video_id`, move a scheduled short from its over-crowded
+`from_date` onto the target `to_date` at the peak `slot_local` via the YouTube
+Studio visibility-edit popup date/time picker.
+
+**Intent Type**: AUTOMATION (Mode B Phase 2 -- the apply layer for #851's plan).
+
+**Agent**: Qwen drives the apply, Gemma validates the deterministic guards.
+
+**For the agent, never for a human**: the WRE/daemon triggers this SKILLz and the
+`--agent-command` surface invokes it programmatically. 012 only observes the
+emitted breadcrumb + PatternMemory outcomes and the JSON result. There is NO
+manual-012 apply path.
+
+---
+
+## DEFAULT = DRY-RUN (merging mutates NOTHING)
+
+This skill mutates NOTHING by default. Real DOM apply happens ONLY when:
+
+```
+YT_RESCHEDULE_APPLY == "1"   (default "0")   AND   a live DOM driver is connected
+```
+
+In dry-run (the default), each eligible move is only LOGGED as
+`would move <video> <from> -> <to> @ <slot_local>` plus a per-move breadcrumb +
+PatternMemory outcome with status `dry_run`. The picker/save DOM helpers are NEVER
+called. 012 enables the flag after observing dry-runs and live-validates.
+
+Via the `--agent-command` subprocess surface there is no live browser supplied, so
+that surface is dry-run by construction; a live driver is wired through the daemon
+path.
+
+---
+
+## Reuse (WSP 84)
+
+- **Plan**: `reschedule_planner.plan_all_channels` / `MovePlan` rows / `NEEDS_LIVE_LIST`
+  (#851). Each row is a complete move instruction
+  (`channel_id, channel_name, from_date, to_date, slot_et, slot_local, video_id`).
+  `slot_local` is the ready-to-type bare 12h Studio time (ET->channel-tz, #847).
+- **DOM picker**: `dom_automation.YouTubeStudioDOM.reschedule_open_set_save`, which
+  opens the `ytcp-video-visibility-edit-popup` via `open_scheduled_edit_popup`
+  (clicking the list row's "Scheduled" `span.label-span`, shadow-pierced via
+  `shadow_dom_finder.first_deep`) and then reuses `set_schedule_date`,
+  `set_schedule_time`, `click_done`, `click_save` UNCHANGED.
+- **Cap**: `HARD_CAP_PER_DAY` (`schedule_tracker.py`, #844).
+
+---
+
+## Safety guards
+
+- `YT_RESCHEDULE_APPLY != "1"` -> dry-run hard (picker/save helpers never called).
+- `video_id == "(needs-live-list)"` -> **skipped** (reason `needs_live_list`);
+  naming those specific videos needs the live Studio list (out of scope).
+- **CAP**: before applying a move, the batch re-counts how many items already target
+  `to_date` for the channel. Applying past the cap -> **skipped** (reason `cap`).
+- Per-move try/except: one failure -> status `error`, batch continues.
+
+---
+
+## Output (consumed by daemon / Qwen)
+
+```json
+{
+  "skill": "reschedule_apply",
+  "apply_env": "YT_RESCHEDULE_APPLY",
+  "apply_enabled": false,
+  "dry_run": true,
+  "cap": 3,
+  "total": 2,
+  "applied": 0,
+  "dry_run_count": 1,
+  "skipped": 1,
+  "errors": 0,
+  "results": [
+    {"video_id":"abc123","from_date":"Jan 5, 2026","to_date":"Jan 2, 2026","slot_local":"8:00 AM","status":"dry_run","reason":""},
+    {"video_id":"(needs-live-list)","status":"skipped","reason":"needs_live_list"}
+  ],
+  "plan_summary": {"days_over_cap": 1, "total_moves": 2, "unplaceable_moves": 0},
+  "success": true
+}
+```
+
+---
+
+## Invocation
+
+**SKILLz (WRE / daemon, default dry-run):**
+```python
+from modules.platform_integration.youtube_shorts_scheduler.skillz.reschedule_apply.executor import run_skill
+result = run_skill()              # dry-run; logs would-apply moves, emits signals
+# live apply (012-enabled): set YT_RESCHEDULE_APPLY=1 and pass a connected driver:
+# run_skill(dom=youtube_studio_dom)
+```
+
+**--agent-command (agent/DAE-invocable, structured JSON, dry-run by construction):**
+```bash
+python main.py --agent-command "youtube action reschedule_apply"
+# adapter spawns:
+python -m modules.platform_integration.youtube_shorts_scheduler.skillz.reschedule_apply.run_skill --json
+```
+
+---
+
+## Live gap (honest)
+
+The DOM apply path is **mock-tested only** in this slice (no live browser run).
+012 enables `YT_RESCHEDULE_APPLY=1`, supplies a connected driver through the daemon,
+and live-validates the popup picker against real Studio before trusting apply.
+
+---
+
+## Out of scope (separate follow-ups -- NOT built here)
+
+- The planner itself (done, #851).
+- Wiring into the scheduler loop / daemon cadence.
+- View-based ("low-viewed first") move selection (needs per-video view data).
+- The music-vs-talk content gate; the live filter-fix.
+- Naming `(needs-live-list)` videos from the live Studio list.
+
+---
+
+## Success criteria
+
+- Dry-run default: picker/save helpers NOT called; eligible moves logged as `dry_run`.
+- `YT_RESCHEDULE_APPLY=1` + driver: picker called with the correct date+time per move.
+- A move that would exceed the target-day cap -> `skipped` (reason `cap`).
+- `(needs-live-list)` -> `skipped` (reason `needs_live_list`).
+- Per-move error -> `error`; batch continues.
+- Breadcrumb + PatternMemory emitted per move.
+
+**WSP Compliance**: WSP 95, WSP 77, WSP 91, WSP 60/48, WSP 50 (flag-gated mutation),
+WSP 84 (reuse planner + picker + shadow finder + cap).

--- a/modules/platform_integration/youtube_shorts_scheduler/skillz/reschedule_apply/__init__.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/skillz/reschedule_apply/__init__.py
@@ -1,0 +1,5 @@
+"""reschedule_apply SKILLz - flag-gated MUTATING apply of the #851 reschedule plan.
+
+Default DRY-RUN (YT_RESCHEDULE_APPLY != "1"): logs would-apply moves, ZERO DOM
+mutation. See executor.run_skill / SKILLz.md.
+"""

--- a/modules/platform_integration/youtube_shorts_scheduler/skillz/reschedule_apply/executor.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/skillz/reschedule_apply/executor.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+reschedule_apply - SKILLz Executor
+
+Flag-gated MUTATING apply of the #851 reschedule PLAN. Moves a scheduled short
+from an over-crowded day to a target day + peak slot via the Studio
+visibility-edit popup date/time picker (reused from dom_automation.py).
+
+DEFAULT = DRY-RUN (Mode B Phase 2)
+----------------------------------
+This skill mutates NOTHING by default. Each move is only LOGGED as a "would move"
+plus a per-move breadcrumb + PatternMemory outcome (status ``dry_run``). Real DOM
+apply happens ONLY when the env ``YT_RESCHEDULE_APPLY == "1"`` (default ``"0"``)
+AND a live DOM driver is connected. Merging this code changes no schedule; 012
+enables the flag after observing dry-runs and live-validates.
+
+For the agent, never for a human
+--------------------------------
+The WRE/daemon triggers this SKILLz and the ``--agent-command`` surface invokes it
+(``youtube action reschedule_apply``). 012 only observes the emitted breadcrumb +
+PatternMemory outcomes and the JSON result. There is NO manual-012 apply path.
+
+Safety (delegated to reschedule_applier.apply_moves):
+    - dry-run hard unless YT_RESCHEDULE_APPLY == "1".
+    - ``(needs-live-list)`` moves are SKIPPED.
+    - per-channel target-day cap is re-checked; over-cap moves SKIPPED.
+    - per-move try/except: one failure never aborts the batch.
+
+WSP Compliance:
+    WSP 95: SKILLz Wardrobe   WSP 77: Agent Coordination
+    WSP 91: Observability     WSP 60/48: Pattern Memory
+    WSP 50: flag-gated mutation, default read-only
+
+Usage (agent / daemon, default dry-run):
+    from .executor import run_skill
+    result = run_skill()   # dry-run; logs would-apply moves, emits signals
+
+Usage (--agent-command surface):
+    youtube action reschedule_apply
+    (adapter spawns: python -m ...skillz.reschedule_apply.run_skill --json)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+from modules.platform_integration.youtube_shorts_scheduler.src.reschedule_applier import (
+    APPLY_ENV,
+    SKILL_NAME,
+    apply_enabled,
+    apply_plan,
+)
+
+try:
+    from modules.platform_integration.youtube_shorts_scheduler.src.schedule_tracker import (
+        HARD_CAP_PER_DAY,
+    )
+except Exception:  # pragma: no cover - defensive import
+    HARD_CAP_PER_DAY = 3
+
+
+def run_skill(
+    *,
+    dom: Any = None,
+    plan: Optional[Dict[str, Any]] = None,
+    plan_factory: Optional[Callable[[], Dict[str, Any]]] = None,
+    cap: int = HARD_CAP_PER_DAY,
+    dry_run: Optional[bool] = None,
+    emit_signals: bool = True,
+) -> Dict[str, Any]:
+    """SKILLz entry: compute the #851 plan and apply/dry-run its moves.
+
+    Args:
+        dom: optional live DOM driver (YouTubeStudioDOM). Only used on real apply.
+            When None and apply is requested, apply_moves records ``error`` for each
+            move (no browser is auto-launched here; the daemon supplies a driver).
+        plan / plan_factory: pre-computed plan or factory (default: plan_all_channels).
+        cap: per-day hard cap for the target-day guard.
+        dry_run: force dry-run/apply; None => resolve from YT_RESCHEDULE_APPLY.
+        emit_signals: emit breadcrumb + PatternMemory per move.
+
+    Returns:
+        apply summary (dry_run, counts, results, plan_summary, skill, success).
+    """
+    result = apply_plan(
+        dom=dom,
+        plan=plan,
+        plan_factory=plan_factory,
+        cap=cap,
+        dry_run=dry_run,
+        emit_signals=emit_signals,
+    )
+    # Pin observability fields for the agent/daemon consumer.
+    result["skill"] = SKILL_NAME
+    result["apply_env"] = APPLY_ENV
+    result["apply_enabled"] = apply_enabled()
+    return result

--- a/modules/platform_integration/youtube_shorts_scheduler/skillz/reschedule_apply/run_skill.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/skillz/reschedule_apply/run_skill.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+reschedule_apply - module entrypoint for agent/DAE invocation.
+
+This is the surface the --agent-command path spawns:
+    youtube action reschedule_apply
+        -> python -m ...skillz.reschedule_apply.run_skill --json
+
+DEFAULT = DRY-RUN. It NEVER mutates a schedule unless env YT_RESCHEDULE_APPLY=="1"
+AND a live DOM driver is connected. Via this subprocess surface there is no live
+browser supplied, so it is dry-run by construction here; 012 wires a live driver
+through the daemon path and flips YT_RESCHEDULE_APPLY to enable real apply. 012
+only observes the emitted breadcrumb / outcomes and the JSON printed here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+# UTF-8 enforcement (WSP 90) - entry point only
+if sys.platform.startswith("win"):  # pragma: no cover - platform guard
+    import io
+
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace", line_buffering=True)
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="replace", line_buffering=True)
+
+from modules.platform_integration.youtube_shorts_scheduler.skillz.reschedule_apply.executor import (
+    run_skill,
+)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "reschedule_apply SKILLz - flag-gated apply of the reschedule plan. "
+            "DEFAULT DRY-RUN: logs would-apply moves, zero mutation. Real apply "
+            "only when YT_RESCHEDULE_APPLY=1 and a live driver is connected."
+        )
+    )
+    parser.add_argument(
+        "--no-signals",
+        action="store_true",
+        help="Skip breadcrumb + PatternMemory emission (diagnostic only).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON (agent consumption).",
+    )
+    args = parser.parse_args(argv)
+
+    # No live DOM driver is supplied through the subprocess surface -> dry-run by
+    # construction (apply_moves never touches a browser without a driver).
+    result = run_skill(emit_signals=not args.no_signals)
+
+    print(json.dumps(result, ensure_ascii=False, separators=(",", ":")))
+    return 0 if result.get("success") else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/modules/platform_integration/youtube_shorts_scheduler/src/dom_automation.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/src/dom_automation.py
@@ -2788,6 +2788,157 @@ class YouTubeStudioDOM:
         raise TimeoutException(f"Save button not found/clickable: {last_err}")
 
     # =========================================
+    # RESCHEDULE (already-scheduled video) — edit-popup entry
+    # =========================================
+
+    def open_scheduled_edit_popup(self, video_id: Optional[str] = None) -> bool:
+        """Open the visibility-edit popup for an already-Scheduled list row.
+
+        Reschedule entry (Mode B Phase 2): on the videos/short *list* (filtered to
+        Scheduled / "Has schedule"), each row's visibility cell shows a "Scheduled"
+        ``span.label-span``. Clicking it opens ``ytcp-video-visibility-edit-popup
+        tp-yt-paper-dialog#dialog`` which exposes the SAME ``ytcp-datetime-picker``
+        date/time inputs the new-schedule flow uses — so the existing
+        ``set_schedule_date`` / ``set_schedule_time`` / ``click_done`` / ``click_save``
+        helpers drive it unchanged (WSP 84 reuse).
+
+        Args:
+            video_id: optional id to scope the click to a specific row (matches the
+                row's ``a[href*='/video/<id>']``). When None, the FIRST Scheduled
+                row's label is clicked.
+
+        Returns:
+            True if the edit popup opened (dialog present), False otherwise.
+
+        NOTE: shadow_dom_finder.first_deep pierces Studio's shadow roots; a flat
+        querySelector fallback covers light-DOM/mock drivers.
+        """
+        import time
+
+        try:
+            from modules.infrastructure.foundups_selenium.src.shadow_dom_finder import (
+                first_deep,
+            )
+        except Exception:  # pragma: no cover - defensive import
+            first_deep = None  # type: ignore
+
+        # 1) Click the row's "Scheduled" label. Prefer a video-scoped row when an id
+        #    is given so a batch never edits the wrong short.
+        clicked = False
+        if first_deep is not None:
+            try:
+                selectors: List[Any] = []
+                if video_id:
+                    # Row containing the id -> its visibility label span.
+                    selectors.append(
+                        [f"ytcp-video-row a[href*='/video/{video_id}']"],
+                    )
+                # Generic: any Scheduled label span on the list.
+                selectors.append(["ytcp-video-row span.label-span"])
+                anchor = first_deep(self.driver, selectors)
+                if anchor is not None:
+                    # If we matched the title link, hop to the row's label span.
+                    target = self.driver.execute_script(
+                        """
+                        const el = arguments[0];
+                        if (!el) return null;
+                        const row = el.closest ? el.closest('ytcp-video-row') : null;
+                        const scope = row || document;
+                        const spans = scope.querySelectorAll('span.label-span');
+                        for (const s of spans) {
+                          const t = (s.textContent || '').trim().toLowerCase();
+                          if (t.includes('scheduled')) return s;
+                        }
+                        return (scope.querySelector('span.label-span') || el);
+                        """,
+                        anchor,
+                    )
+                    self.safe_click(target or anchor)
+                    clicked = True
+            except Exception as exc:
+                logger.debug(f"[RESCHED] shadow label click failed: {exc}")
+
+        if not clicked:
+            # Flat fallback (light-DOM / mocks): click the first Scheduled label.
+            try:
+                clicked = bool(self.driver.execute_script(
+                    """
+                    const vid = arguments[0];
+                    let scope = document;
+                    if (vid) {
+                      const link = document.querySelector(
+                        "ytcp-video-row a[href*='/video/" + vid + "']");
+                      if (link && link.closest) scope = link.closest('ytcp-video-row') || document;
+                    }
+                    const spans = scope.querySelectorAll('span.label-span');
+                    for (const s of spans) {
+                      const t = (s.textContent || '').trim().toLowerCase();
+                      if (t.includes('scheduled')) { s.click(); return true; }
+                    }
+                    return false;
+                    """,
+                    video_id,
+                ))
+            except Exception as exc:
+                logger.warning(f"[RESCHED] flat label click failed: {exc}")
+                clicked = False
+
+        if not clicked:
+            logger.warning("[RESCHED] Could not click a 'Scheduled' label to open edit popup")
+            return False
+
+        time.sleep(0.6)
+
+        # 2) Confirm the edit popup dialog is present.
+        try:
+            WebDriverWait(self.driver, 8).until(lambda d: d.execute_script(
+                """
+                const popup = document.querySelector('ytcp-video-visibility-edit-popup');
+                const dlg = document.querySelector('ytcp-video-visibility-edit-popup tp-yt-paper-dialog#dialog')
+                          || document.querySelector('tp-yt-paper-dialog#dialog');
+                return !!(popup || dlg);
+                """
+            ))
+            return True
+        except Exception:
+            logger.warning("[RESCHED] Edit popup did not appear after clicking 'Scheduled'")
+            return False
+
+    def reschedule_open_set_save(self, date_str: str, time_str: str, video_id: Optional[str] = None) -> bool:
+        """Full reschedule flow for one already-scheduled video (reuses the picker).
+
+        open_scheduled_edit_popup -> set_schedule_date -> set_schedule_time ->
+        click_done -> click_save. Mirrors ``schedule_video`` but enters via the list
+        "Scheduled" label instead of the edit-page visibility dialog, and SKIPS
+        select_schedule_option (the popup is already in scheduled state).
+
+        Returns True only when every step succeeds.
+        """
+        import time as _t
+
+        if not self.open_scheduled_edit_popup(video_id=video_id):
+            return False
+        steps = [
+            ("set_schedule_date", lambda: self.set_schedule_date(date_str)),
+            ("set_schedule_time", lambda: self.set_schedule_time(time_str)),
+            ("click_done", lambda: self.click_done()),
+            ("click_save", lambda: self.click_save()),
+        ]
+        for name, fn in steps:
+            try:
+                fn()
+            except Exception as exc:
+                logger.error(f"[RESCHED] reschedule failed at {name}: {type(exc).__name__}: {exc}")
+                try:
+                    ActionChains(self.driver).send_keys(Keys.ESCAPE).perform()
+                    _t.sleep(0.4)
+                except Exception:
+                    pass
+                return False
+        logger.info(f"[RESCHED] Rescheduled {video_id or '(first scheduled)'} -> {date_str} {time_str}")
+        return True
+
+    # =========================================
     # PAGE 3: SCHEDULING DIALOG METHODS
     # =========================================
 

--- a/modules/platform_integration/youtube_shorts_scheduler/src/reschedule_applier.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/src/reschedule_applier.py
@@ -1,0 +1,346 @@
+"""
+Reschedule Applier - MUTATING apply for the #851 reschedule PLAN.
+
+Slice: SHORTS_RESCHEDULE_APPLY_PHASE2  (Mode B, Phase 2 - the apply layer)
+
+What this does
+--------------
+Consumes the dry-run rebalance PLAN produced by reschedule_planner.py / the
+reschedule_plan SKILLz (#851) and, for each move with a real video_id, moves a
+scheduled short from its over-crowded ``from_date`` onto the target ``to_date`` at
+the peak ``slot_local`` via the Studio visibility-edit popup date/time picker.
+
+DEFAULT = DRY-RUN (zero DOM mutation)
+-------------------------------------
+This module mutates NOTHING by default. Each move is, by default, only LOGGED as a
+"would move" plus a breadcrumb + PatternMemory outcome with status ``dry_run``.
+Real DOM apply happens ONLY when the environment variable
+``YT_RESCHEDULE_APPLY == "1"`` (default ``"0"``). Merging this code therefore
+changes no schedule; 012 enables the flag after observing dry-runs and
+live-validates.
+
+For the agent, never for a human
+--------------------------------
+The WRE/daemon triggers this and the ``--agent-command`` surface invokes it
+(``youtube action reschedule_apply``). There is NO manual-012 apply path; 012 only
+observes outcomes and flips the env flag.
+
+Safety
+------
+- ``YT_RESCHEDULE_APPLY != "1"`` -> dry-run hard (picker/save helpers NEVER called).
+- A move whose ``video_id`` is the sentinel ``(needs-live-list)`` is SKIPPED
+  (specific-video selection for those needs the live Studio list, out of scope).
+- CAP SAFETY: before applying a move we re-count, within THIS batch, how many items
+  already target ``to_date`` for the channel. If applying would exceed the cap on
+  the target day, the move is SKIPPED (status ``skipped``, reason ``cap``). This is
+  a second guard on top of the planner's own cap math.
+- Per-move try/except: one failed move never aborts the batch.
+
+Reuse (WSP 84)
+--------------
+- Plan rows: reschedule_planner.MovePlan / NEEDS_LIVE_LIST + plan_all_channels.
+- DOM picker: dom_automation.YouTubeStudioDOM.reschedule_open_set_save (which
+  reuses set_schedule_date / set_schedule_time / click_done / click_save and the
+  shadow_dom_finder-backed open_scheduled_edit_popup).
+- Cap: HARD_CAP_PER_DAY (schedule_tracker, #844).
+
+WSP References:
+- WSP 3:  platform_integration owns publish-time/rebalance policy.
+- WSP 50: flag-gated mutation; default read-only; pure-where-possible + injectable DOM.
+- WSP 84: reuse the planner, the date/time picker, the shadow finder, the cap.
+- WSP 91: breadcrumb per move. WSP 60/48: PatternMemory outcome per move.
+- WSP 22: ModLog documents the apply gate + the needs-live-list skip seam.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Authoritative per-day cap (#844) + the needs-live-list sentinel (#851).
+try:
+    from modules.platform_integration.youtube_shorts_scheduler.src.schedule_tracker import (
+        HARD_CAP_PER_DAY,
+    )
+except Exception:  # pragma: no cover - defensive import for isolated tests
+    HARD_CAP_PER_DAY = 3
+
+try:
+    from modules.platform_integration.youtube_shorts_scheduler.src.reschedule_planner import (
+        NEEDS_LIVE_LIST,
+    )
+except Exception:  # pragma: no cover - defensive import for isolated tests
+    NEEDS_LIVE_LIST = "(needs-live-list)"
+
+# Env gate name (single load-bearing knob). Default "0" => DRY-RUN.
+APPLY_ENV = "YT_RESCHEDULE_APPLY"
+
+SOURCE_DAE = "youtube_shorts_scheduler"
+SKILL_NAME = "reschedule_apply"
+
+# Per-move outcome statuses.
+STATUS_APPLIED = "applied"
+STATUS_DRY_RUN = "dry_run"
+STATUS_SKIPPED = "skipped"
+STATUS_ERROR = "error"
+
+
+def apply_enabled() -> bool:
+    """True ONLY when YT_RESCHEDULE_APPLY == "1" (default off -> dry-run)."""
+    return os.getenv(APPLY_ENV, "0").strip() == "1"
+
+
+# === Signal emission (WSP 91 breadcrumb + WSP 60/48 PatternMemory) ===========
+
+def _emit_move_breadcrumb(move_result: Dict[str, Any], dry_run: bool) -> None:
+    """Emit a per-move breadcrumb so the WRE/overseer can learn (WSP 91)."""
+    try:
+        from modules.communication.livechat.src.breadcrumb_telemetry import (
+            get_breadcrumb_telemetry,
+        )
+
+        status = move_result.get("status")
+        get_breadcrumb_telemetry().store_breadcrumb(
+            source_dae=SOURCE_DAE,
+            event_type="reschedule_apply",
+            message=(
+                f"reschedule-apply ({'dry-run' if dry_run else 'apply'}): "
+                f"{status} {move_result.get('video_id')} "
+                f"{move_result.get('from_date')} -> {move_result.get('to_date')} "
+                f"@ {move_result.get('slot_local')}"
+            ),
+            phase="RESCHEDULE_APPLY",
+            metadata={
+                "skill": SKILL_NAME,
+                "dry_run": dry_run,
+                "move": move_result,
+            },
+        )
+    except Exception as exc:  # pragma: no cover - telemetry best-effort
+        logger.debug(f"[{SKILL_NAME}] breadcrumb emit failed: {exc}")
+
+
+def _store_move_outcome(move_result: Dict[str, Any], dry_run: bool) -> None:
+    """Store a per-move SkillOutcome so the WRE remembers each move (WSP 60/48)."""
+    try:
+        from modules.infrastructure.wre_core.src.pattern_memory import (
+            PatternMemory,
+            SkillOutcome,
+        )
+
+        status = move_result.get("status")
+        success = status in (STATUS_APPLIED, STATUS_DRY_RUN)
+        outcome = SkillOutcome(
+            execution_id=f"{SKILL_NAME}-{uuid.uuid4().hex[:12]}",
+            skill_name=SKILL_NAME,
+            agent="qwen",
+            timestamp=datetime.now().isoformat(),
+            input_context=str(
+                {
+                    "dry_run": dry_run,
+                    "channel_id": move_result.get("channel_id"),
+                    "video_id": move_result.get("video_id"),
+                    "to_date": move_result.get("to_date"),
+                }
+            ),
+            output_result=str({"status": status, "reason": move_result.get("reason")})[:10000],
+            success=success,
+            pattern_fidelity=1.0,
+            outcome_quality=1.0 if success else 0.0,
+            execution_time_ms=0,
+            step_count=1,
+            failed_at_step=None if success else status,
+            notes=f"source={SKILL_NAME} dry_run={str(dry_run).lower()} status={status}",
+        )
+        PatternMemory().store_outcome(outcome)
+    except Exception as exc:  # pragma: no cover - memory best-effort
+        logger.debug(f"[{SKILL_NAME}] pattern memory store failed: {exc}")
+
+
+# === Core per-move apply =====================================================
+
+def _move_record(move: Dict[str, Any], status: str, reason: str = "") -> Dict[str, Any]:
+    """Build a normalized per-move result record."""
+    return {
+        "channel_id": move.get("channel_id"),
+        "channel_name": move.get("channel_name"),
+        "from_date": move.get("from_date"),
+        "to_date": move.get("to_date"),
+        "slot_et": move.get("slot_et"),
+        "slot_local": move.get("slot_local"),
+        "video_id": move.get("video_id"),
+        "status": status,
+        "reason": reason,
+    }
+
+
+def apply_moves(
+    moves: List[Dict[str, Any]],
+    *,
+    dom: Any = None,
+    cap: int = HARD_CAP_PER_DAY,
+    dry_run: Optional[bool] = None,
+    emit_signals: bool = True,
+) -> Dict[str, Any]:
+    """Apply (or dry-run) a list of plan move rows.
+
+    Args:
+        moves: list of plan move dicts (channel_id, channel_name, from_date,
+            to_date, slot_et, slot_local, video_id) -- the #851 plan rows.
+        dom: the DOM driver exposing ``reschedule_open_set_save(date, time, video_id)``
+            (a ``YouTubeStudioDOM``). REQUIRED only when actually applying; in
+            dry-run it is never touched. Injectable for tests.
+        cap: per-day hard cap (default HARD_CAP_PER_DAY=3) for the target-day guard.
+        dry_run: force dry-run (True) / force apply (False). When None (default),
+            resolved from the ``YT_RESCHEDULE_APPLY`` env gate (default => dry-run).
+        emit_signals: emit breadcrumb + PatternMemory per move.
+
+    Returns:
+        {
+          dry_run, cap, total, applied, dry_run_count, skipped, errors,
+          results: [per-move record...]
+        }
+
+    Behavior:
+        - dry-run (default): the DOM picker/save helpers are NEVER called. Each
+          eligible move is recorded as ``dry_run`` ("would move ...").
+        - apply (YT_RESCHEDULE_APPLY=1): each eligible move drives
+          ``dom.reschedule_open_set_save``.
+        - NEEDS_LIVE_LIST moves -> ``skipped`` (reason ``needs_live_list``).
+        - target-day cap would be exceeded -> ``skipped`` (reason ``cap``).
+        - per-move exception -> ``error``; the batch continues.
+    """
+    is_dry_run = (not apply_enabled()) if dry_run is None else bool(dry_run)
+
+    results: List[Dict[str, Any]] = []
+    # Batch-local target-day fill counter: (channel_id, to_date) -> planned count.
+    target_fill: Dict[tuple, int] = {}
+
+    for move in moves or []:
+        video_id = move.get("video_id")
+        channel_id = move.get("channel_id")
+        to_date = move.get("to_date")
+        slot_local = move.get("slot_local")
+
+        # 1) Skip surplus moves the planner couldn't name (needs the live list).
+        if video_id == NEEDS_LIVE_LIST or not video_id:
+            rec = _move_record(move, STATUS_SKIPPED, reason="needs_live_list")
+            results.append(rec)
+            if emit_signals:
+                _emit_move_breadcrumb(rec, is_dry_run)
+                _store_move_outcome(rec, is_dry_run)
+            continue
+
+        # 2) CAP SAFETY: never plan/apply more than `cap` onto a target day.
+        key = (channel_id, to_date)
+        if target_fill.get(key, 0) >= cap:
+            rec = _move_record(move, STATUS_SKIPPED, reason="cap")
+            results.append(rec)
+            logger.warning(
+                "[RESCHED-APPLY] Skip %s -> %s @ %s: target day at cap (%d)",
+                video_id, to_date, slot_local, cap,
+            )
+            if emit_signals:
+                _emit_move_breadcrumb(rec, is_dry_run)
+                _store_move_outcome(rec, is_dry_run)
+            continue
+
+        # 3) Dry-run: log a "would move" and NEVER touch the DOM.
+        if is_dry_run:
+            logger.info(
+                "[RESCHED-APPLY] would move %s %s -> %s @ %s",
+                video_id, move.get("from_date"), to_date, slot_local,
+            )
+            rec = _move_record(move, STATUS_DRY_RUN)
+            results.append(rec)
+            target_fill[key] = target_fill.get(key, 0) + 1
+            if emit_signals:
+                _emit_move_breadcrumb(rec, is_dry_run)
+                _store_move_outcome(rec, is_dry_run)
+            continue
+
+        # 4) REAL APPLY (YT_RESCHEDULE_APPLY=1): drive the reused picker per move.
+        try:
+            if dom is None:
+                raise RuntimeError("apply requested but no DOM driver provided")
+            ok = dom.reschedule_open_set_save(to_date, slot_local, video_id=video_id)
+            if ok:
+                rec = _move_record(move, STATUS_APPLIED)
+                target_fill[key] = target_fill.get(key, 0) + 1
+            else:
+                rec = _move_record(move, STATUS_ERROR, reason="dom_returned_false")
+        except Exception as exc:  # per-move: never abort the batch
+            logger.error(
+                "[RESCHED-APPLY] apply error for %s -> %s: %s: %s",
+                video_id, to_date, type(exc).__name__, exc,
+            )
+            rec = _move_record(move, STATUS_ERROR, reason=f"{type(exc).__name__}: {exc}")
+        results.append(rec)
+        if emit_signals:
+            _emit_move_breadcrumb(rec, is_dry_run)
+            _store_move_outcome(rec, is_dry_run)
+
+    summary = {
+        "dry_run": is_dry_run,
+        "cap": cap,
+        "total": len(results),
+        "applied": sum(1 for r in results if r["status"] == STATUS_APPLIED),
+        "dry_run_count": sum(1 for r in results if r["status"] == STATUS_DRY_RUN),
+        "skipped": sum(1 for r in results if r["status"] == STATUS_SKIPPED),
+        "errors": sum(1 for r in results if r["status"] == STATUS_ERROR),
+        "results": results,
+    }
+    return summary
+
+
+def flatten_plan_moves(plan: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Flatten a plan_all_channels() result into a single list of move rows."""
+    moves: List[Dict[str, Any]] = []
+    for ch in plan.get("channels", []) or []:
+        for mv in ch.get("moves", []) or []:
+            moves.append(mv)
+    return moves
+
+
+def apply_plan(
+    *,
+    dom: Any = None,
+    plan: Optional[Dict[str, Any]] = None,
+    plan_factory: Optional[Callable[[], Dict[str, Any]]] = None,
+    cap: int = HARD_CAP_PER_DAY,
+    dry_run: Optional[bool] = None,
+    emit_signals: bool = True,
+) -> Dict[str, Any]:
+    """Compute (or accept) the #851 plan, then apply/dry-run its moves.
+
+    Args:
+        dom: injected DOM driver (only used on real apply).
+        plan: a pre-computed plan_all_channels() result; if omitted, ``plan_factory``
+            is called (default: reschedule_planner.plan_all_channels).
+        plan_factory: zero-arg callable returning a plan dict (injectable for tests).
+        cap / dry_run / emit_signals: see apply_moves.
+
+    Returns:
+        apply_moves(...) summary augmented with ``skill`` + ``plan_summary``.
+    """
+    if plan is None:
+        if plan_factory is None:
+            from modules.platform_integration.youtube_shorts_scheduler.src.reschedule_planner import (
+                plan_all_channels,
+            )
+            plan_factory = plan_all_channels
+        plan = plan_factory()
+
+    moves = flatten_plan_moves(plan)
+    result = apply_moves(
+        moves, dom=dom, cap=cap, dry_run=dry_run, emit_signals=emit_signals
+    )
+    result["skill"] = SKILL_NAME
+    result["plan_summary"] = plan.get("summary", {})
+    result["success"] = True
+    return result

--- a/modules/platform_integration/youtube_shorts_scheduler/tests/test_reschedule_applier.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/tests/test_reschedule_applier.py
@@ -1,0 +1,298 @@
+"""
+Unit tests for the reschedule_applier + reschedule_apply SKILLz (Mode B Phase 2).
+
+Slice: SHORTS_RESCHEDULE_APPLY_PHASE2
+
+Model under test
+----------------
+apply_moves consumes #851 plan rows and, per move:
+  - DEFAULT DRY-RUN (YT_RESCHEDULE_APPLY != "1"): logs "would move", NEVER touches
+    the DOM picker/save helpers, records status `dry_run`.
+  - APPLY (YT_RESCHEDULE_APPLY == "1") with a driver: calls
+    dom.reschedule_open_set_save(to_date, slot_local, video_id=...) per move.
+  - `(needs-live-list)` -> skipped (reason needs_live_list).
+  - target-day cap would be exceeded -> skipped (reason cap).
+  - per-move exception -> error, batch continues.
+
+These tests are MOCK-ONLY (no live browser, no daemon, no live models) and
+NON-VACUOUS:
+  - apply path asserts the picker is called with the EXACT date+time per move.
+  - test_dryrun_must_not_call_dom_helpers PROVES the dry-run guard: it would FAIL
+    if dry-run ever called the mutating helpers (the whole point of "merge mutates
+    nothing").
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from modules.platform_integration.youtube_shorts_scheduler.src.reschedule_applier import (
+    NEEDS_LIVE_LIST,
+    STATUS_APPLIED,
+    STATUS_DRY_RUN,
+    STATUS_ERROR,
+    STATUS_SKIPPED,
+    apply_enabled,
+    apply_moves,
+    apply_plan,
+    flatten_plan_moves,
+)
+
+
+# --- helpers -----------------------------------------------------------------
+
+def _move(video_id, to_date="Jan 2, 2026", slot_local="8:00 AM", channel_id="UC_x",
+          from_date="Jan 5, 2026", slot_et="08:00"):
+    return {
+        "channel_id": channel_id,
+        "channel_name": "FoundUps",
+        "from_date": from_date,
+        "to_date": to_date,
+        "slot_et": slot_et,
+        "slot_local": slot_local,
+        "video_id": video_id,
+    }
+
+
+def _mock_dom(ok=True):
+    """A DOM whose reschedule_open_set_save records calls and returns `ok`."""
+    dom = MagicMock()
+    dom.reschedule_open_set_save.return_value = ok
+    return dom
+
+
+# --- dry-run (default) -------------------------------------------------------
+
+def test_dryrun_default_logs_moves_without_dom(monkeypatch):
+    """Default (no env, no driver) is dry-run: moves recorded as dry_run, no DOM."""
+    monkeypatch.delenv("YT_RESCHEDULE_APPLY", raising=False)
+    dom = _mock_dom()
+    moves = [_move("vid1"), _move("vid2", to_date="Jan 3, 2026")]
+
+    result = apply_moves(moves, dom=dom, emit_signals=False)
+
+    assert result["dry_run"] is True
+    assert result["dry_run_count"] == 2
+    assert result["applied"] == 0
+    assert all(r["status"] == STATUS_DRY_RUN for r in result["results"])
+    dom.reschedule_open_set_save.assert_not_called()
+
+
+def test_dryrun_must_not_call_dom_helpers(monkeypatch):
+    """NON-VACUITY / merge-safety proof: dry-run NEVER calls the mutating helper.
+
+    If apply_moves wrongly drove the picker in dry-run, this assertion FAILS --
+    which is exactly the regression we must catch (merging mutates nothing).
+    """
+    monkeypatch.setenv("YT_RESCHEDULE_APPLY", "0")
+    dom = _mock_dom()
+    # Spy that EXPLODES if anyone tries to drive a mutation in dry-run.
+    dom.reschedule_open_set_save.side_effect = AssertionError(
+        "dry-run must not call reschedule_open_set_save"
+    )
+
+    result = apply_moves([_move("vid1")], dom=dom, emit_signals=False)
+
+    assert result["dry_run"] is True
+    assert result["results"][0]["status"] == STATUS_DRY_RUN
+    # Also assert directly that no mutation was attempted.
+    dom.reschedule_open_set_save.assert_not_called()
+
+
+def test_apply_enabled_env_gate(monkeypatch):
+    monkeypatch.setenv("YT_RESCHEDULE_APPLY", "1")
+    assert apply_enabled() is True
+    monkeypatch.setenv("YT_RESCHEDULE_APPLY", "0")
+    assert apply_enabled() is False
+    monkeypatch.delenv("YT_RESCHEDULE_APPLY", raising=False)
+    assert apply_enabled() is False
+
+
+# --- apply (flag on) ---------------------------------------------------------
+
+def test_apply_calls_picker_with_correct_date_time(monkeypatch):
+    """YT_RESCHEDULE_APPLY=1: picker called with the exact date+time per move."""
+    monkeypatch.setenv("YT_RESCHEDULE_APPLY", "1")
+    dom = _mock_dom(ok=True)
+    moves = [
+        _move("vidA", to_date="Jan 2, 2026", slot_local="8:00 AM"),
+        _move("vidB", to_date="Jan 3, 2026", slot_local="12:00 PM"),
+    ]
+
+    result = apply_moves(moves, dom=dom, emit_signals=False)
+
+    assert result["dry_run"] is False
+    assert result["applied"] == 2
+    assert all(r["status"] == STATUS_APPLIED for r in result["results"])
+    # Exact picker args per move (date=to_date, time=slot_local, scoped by video_id).
+    calls = dom.reschedule_open_set_save.call_args_list
+    assert calls[0].args == ("Jan 2, 2026", "8:00 AM")
+    assert calls[0].kwargs == {"video_id": "vidA"}
+    assert calls[1].args == ("Jan 3, 2026", "12:00 PM")
+    assert calls[1].kwargs == {"video_id": "vidB"}
+
+
+def test_apply_force_dry_run_overrides_env(monkeypatch):
+    """dry_run=True forces dry-run even when the env flag says apply."""
+    monkeypatch.setenv("YT_RESCHEDULE_APPLY", "1")
+    dom = _mock_dom()
+    result = apply_moves([_move("vid1")], dom=dom, dry_run=True, emit_signals=False)
+    assert result["dry_run"] is True
+    dom.reschedule_open_set_save.assert_not_called()
+
+
+# --- skip: needs-live-list ---------------------------------------------------
+
+def test_needs_live_list_is_skipped(monkeypatch):
+    monkeypatch.setenv("YT_RESCHEDULE_APPLY", "1")
+    dom = _mock_dom()
+    moves = [_move(NEEDS_LIVE_LIST), _move("realvid")]
+
+    result = apply_moves(moves, dom=dom, emit_signals=False)
+
+    statuses = [r["status"] for r in result["results"]]
+    assert statuses == [STATUS_SKIPPED, STATUS_APPLIED]
+    assert result["results"][0]["reason"] == "needs_live_list"
+    # Only the real video is applied -- the sentinel never reaches the picker.
+    dom.reschedule_open_set_save.assert_called_once()
+    assert dom.reschedule_open_set_save.call_args.kwargs == {"video_id": "realvid"}
+
+
+# --- skip: cap safety --------------------------------------------------------
+
+def test_cap_exceeded_on_target_is_skipped(monkeypatch):
+    """cap=3 on the SAME target day: 4th move onto that day is skipped (reason cap)."""
+    monkeypatch.setenv("YT_RESCHEDULE_APPLY", "1")
+    dom = _mock_dom()
+    same_day = "Jan 2, 2026"
+    moves = [
+        _move("v1", to_date=same_day),
+        _move("v2", to_date=same_day),
+        _move("v3", to_date=same_day),
+        _move("v4", to_date=same_day),  # exceeds cap=3
+    ]
+
+    result = apply_moves(moves, dom=dom, cap=3, emit_signals=False)
+
+    statuses = [r["status"] for r in result["results"]]
+    assert statuses == [STATUS_APPLIED, STATUS_APPLIED, STATUS_APPLIED, STATUS_SKIPPED]
+    assert result["results"][3]["reason"] == "cap"
+    assert result["applied"] == 3
+    assert result["skipped"] == 1
+    assert dom.reschedule_open_set_save.call_count == 3
+
+
+def test_cap_guard_also_applies_in_dry_run(monkeypatch):
+    """The cap guard holds in dry-run too (would-be 4th onto a day is skipped)."""
+    monkeypatch.delenv("YT_RESCHEDULE_APPLY", raising=False)
+    dom = _mock_dom()
+    day = "Jan 2, 2026"
+    moves = [_move(f"v{i}", to_date=day) for i in range(4)]
+
+    result = apply_moves(moves, dom=dom, cap=3, emit_signals=False)
+
+    assert result["dry_run_count"] == 3
+    assert result["skipped"] == 1
+    assert result["results"][3]["reason"] == "cap"
+    dom.reschedule_open_set_save.assert_not_called()
+
+
+# --- per-move error: batch continues ----------------------------------------
+
+def test_per_move_error_continues_batch(monkeypatch):
+    """One failing move -> status error; the batch keeps going."""
+    monkeypatch.setenv("YT_RESCHEDULE_APPLY", "1")
+    dom = MagicMock()
+    # First call raises, second succeeds.
+    dom.reschedule_open_set_save.side_effect = [RuntimeError("boom"), True]
+    moves = [_move("vbad", to_date="Jan 2, 2026"), _move("vok", to_date="Jan 3, 2026")]
+
+    result = apply_moves(moves, dom=dom, emit_signals=False)
+
+    statuses = [r["status"] for r in result["results"]]
+    assert statuses == [STATUS_ERROR, STATUS_APPLIED]
+    assert result["errors"] == 1
+    assert result["applied"] == 1
+    assert "boom" in result["results"][0]["reason"]
+    assert dom.reschedule_open_set_save.call_count == 2
+
+
+def test_dom_returns_false_is_error(monkeypatch):
+    """A picker that returns False (without raising) is recorded as error."""
+    monkeypatch.setenv("YT_RESCHEDULE_APPLY", "1")
+    dom = _mock_dom(ok=False)
+    result = apply_moves([_move("v1")], dom=dom, emit_signals=False)
+    assert result["results"][0]["status"] == STATUS_ERROR
+    assert result["results"][0]["reason"] == "dom_returned_false"
+
+
+def test_apply_requested_without_driver_is_error(monkeypatch):
+    """Apply requested but no driver -> error per move (no browser auto-launch)."""
+    monkeypatch.setenv("YT_RESCHEDULE_APPLY", "1")
+    result = apply_moves([_move("v1")], dom=None, emit_signals=False)
+    assert result["results"][0]["status"] == STATUS_ERROR
+
+
+# --- plan plumbing -----------------------------------------------------------
+
+def test_flatten_plan_moves():
+    plan = {
+        "channels": [
+            {"moves": [_move("a"), _move("b")]},
+            {"moves": [_move("c")]},
+            {"moves": []},
+        ]
+    }
+    flat = flatten_plan_moves(plan)
+    assert [m["video_id"] for m in flat] == ["a", "b", "c"]
+
+
+def test_apply_plan_uses_factory_and_is_dry_run_by_default(monkeypatch):
+    """apply_plan pulls moves from the injected plan factory; default dry-run."""
+    monkeypatch.delenv("YT_RESCHEDULE_APPLY", raising=False)
+    dom = _mock_dom()
+    plan = {
+        "summary": {"days_over_cap": 1, "total_moves": 1, "unplaceable_moves": 0},
+        "channels": [{"moves": [_move("vid1")]}],
+    }
+    result = apply_plan(dom=dom, plan_factory=lambda: plan, emit_signals=False)
+
+    assert result["skill"] == "reschedule_apply"
+    assert result["dry_run"] is True
+    assert result["dry_run_count"] == 1
+    assert result["plan_summary"] == plan["summary"]
+    assert result["success"] is True
+    dom.reschedule_open_set_save.assert_not_called()
+
+
+# --- SKILLz executor / run_skill --------------------------------------------
+
+def test_executor_run_skill_default_dry_run(monkeypatch):
+    monkeypatch.delenv("YT_RESCHEDULE_APPLY", raising=False)
+    from modules.platform_integration.youtube_shorts_scheduler.skillz.reschedule_apply.executor import (
+        run_skill,
+    )
+    plan = {
+        "summary": {"days_over_cap": 1, "total_moves": 1, "unplaceable_moves": 0},
+        "channels": [{"moves": [_move("vid1")]}],
+    }
+    result = run_skill(plan_factory=lambda: plan, emit_signals=False)
+    assert result["skill"] == "reschedule_apply"
+    assert result["apply_env"] == "YT_RESCHEDULE_APPLY"
+    assert result["apply_enabled"] is False
+    assert result["dry_run"] is True
+
+
+# --- signal emission (mocked + asserted) ------------------------------------
+
+def test_signals_emitted_per_move(monkeypatch):
+    """Breadcrumb + PatternMemory invoked once per move when emit_signals=True."""
+    monkeypatch.delenv("YT_RESCHEDULE_APPLY", raising=False)
+    with patch(
+        "modules.platform_integration.youtube_shorts_scheduler.src.reschedule_applier._emit_move_breadcrumb"
+    ) as mock_bc, patch(
+        "modules.platform_integration.youtube_shorts_scheduler.src.reschedule_applier._store_move_outcome"
+    ) as mock_pm:
+        apply_moves([_move("a"), _move("b", to_date="Jan 3, 2026")], dom=_mock_dom(), emit_signals=True)
+    assert mock_bc.call_count == 2
+    assert mock_pm.call_count == 2


### PR DESCRIPTION
## Summary

Phase 2 of Mode B: the **MUTATING apply** for the #851 reschedule plan, built **FLAG-GATED + DEFAULT DRY-RUN** so **merging this PR mutates NOTHING**. It moves a scheduled short from an over-crowded day onto a target day + peak slot via the Studio visibility-edit-popup date/time picker.

## Default dry-run / no mutation on merge

`reschedule_applier.apply_moves` is **dry-run by default**: each eligible move is only LOGGED as `would move <video> <from> -> <to> @ <slot_local>` plus a per-move breadcrumb + PatternMemory outcome (status `dry_run`). The DOM picker/save helpers are **never called** in dry-run. Real DOM apply happens **only** when env `YT_RESCHEDULE_APPLY == "1"` (default `"0"`) **AND** a live driver is connected. The `--agent-command` subprocess surface supplies no browser, so it is dry-run by construction. 012 enables the flag after observing dry-runs and live-validates.

## Reuse (WSP 84 — nothing reinvented)

- **Plan**: `reschedule_planner.plan_all_channels` / `MovePlan` rows / `NEEDS_LIVE_LIST` (#851). `slot_local` is the ready-to-type bare 12h Studio time (ET→channel-tz, #847) — typed directly.
- **Date/time picker**: `dom_automation.reschedule_open_set_save` reuses the existing `set_schedule_date` / `set_schedule_time` / `click_done` / `click_save` **unchanged**; entry is `open_scheduled_edit_popup`, which clicks the list-row "Scheduled" `span.label-span` (shadow-pierced via `shadow_dom_finder.first_deep`) to open `ytcp-video-visibility-edit-popup` (same `ytcp-datetime-picker`).
- **Cap**: `HARD_CAP_PER_DAY` (#844).

## Cap-safety + skip-needs-live-list

- Before applying a move, the batch re-counts how many items already target `to_date` for the channel; applying past the cap → **skipped** (reason `cap`). Second guard on top of the planner's own cap math.
- `video_id == "(needs-live-list)"` → **skipped** (reason `needs_live_list`); naming those needs the live Studio list (out of scope).
- Per-move try/except: one failure → status `error`, batch continues.

## Honest live gap

The DOM apply path is **mock-tested only** (no live browser run). 012 enables `YT_RESCHEDULE_APPLY=1`, supplies a connected driver through the daemon, and **live-validates** the popup picker against real Studio before trusting apply.

## Non-vacuity proof

`tests/test_reschedule_applier.py` (15 tests, all pass), mock-only, no live browser:
- dry-run default → picker/save NOT called, moves logged as `dry_run`
- `YT_RESCHEDULE_APPLY=1` → picker called with the **exact** date+time per move
- over-cap on target day → skipped (`cap`); `(needs-live-list)` → skipped; per-move error → batch continues; signals emitted per move

**Proven non-vacuous**: temporarily disabling the dry-run guard FAILS `test_dryrun_must_not_call_dom_helpers` + `test_dryrun_default_logs_moves_without_dom` (verified, then reverted). Adapter tests (17) and planner tests (14) still pass.

```
modules/platform_integration/youtube_shorts_scheduler/tests/test_reschedule_applier.py ... 15 passed
```

## Scope

Touches only `youtube_shorts_scheduler` (+ its skillz/tests/ModLog) and the `youtube_automation_adapter` `--agent-command` surface; reuses `dom_automation` / `shadow_dom_finder` / `peak_window`. **Out of scope**: the planner (#851), wiring into the scheduler loop, the music gate, view-based selection, naming `(needs-live-list)` videos.

Worker-Lane: RESCHED-APPLY · Slice: SHORTS_RESCHEDULE_APPLY_PHASE2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
