### PR TITLE
feat(youtube_shorts_scheduler): wire what_should_i_schedule into the daemon — auto-fire + flag-gated channel priority

### DIFF
--- a/modules/platform_integration/youtube_shorts_scheduler/ModLog.md
+++ b/modules/platform_integration/youtube_shorts_scheduler/ModLog.md
@@ -1,5 +1,58 @@
 # YouTube Shorts Scheduler - ModLog
 
+## 2026-06-19 - shorts priority wiring: auto-fire what_should_i_schedule + flag-gated channel priority
+
+**By:** 0102 (Worker-Lane PRIORITY-WIRE)
+**Slice:** SHORTS_PRIORITY_WIRING_PHASE1
+**WSP References:** WSP 95 (SKILLz Wardrobe), WSP 77 (Agent Coordination), WSP 91 (Observability breadcrumb), WSP 60/48 (Pattern Memory via the existing skill), WSP 84 (Code Reuse: existing SkillTriggerMixin + rank_channels_by_need), WSP 50 (flag-gated, default-off, read-only steering), WSP 27 (Phase 0 KNOWLEDGE), WSP 22 (ModLog), WSP 49 (Structure)
+
+### Problem
+
+`what_should_i_schedule` (the read-only schedule-priority ranking skill, landed earlier)
+was an ORPHAN on two fronts: (1) its `SKILLz.md` frontmatter had no `domain:` field, so the
+DAE's existing WRE skill-trigger (`SkillTriggerMixin`, domain-discovery by frontmatter `domain`,
+`skill_trigger.py:91-115`; initialized `domain="youtube"` at `auto_moderator_dae.py:221`, fired
+`:1788`) never auto-fired it; and (2) the scheduler's channel rotation
+(`run_multi_channel_scheduler`, `scripts/launch.py`) ignored the ranking entirely -- it walked
+channels in static registry order with no need signal. 012's rule: everything runs from the
+daemon autonomously; 012 observes.
+
+### What changed (minimal, default-off, fallback-safe)
+
+1. **REGISTER (orphaning fix)** -- `skillz/what_should_i_schedule/SKILLz.md`: added
+   `domain: youtube` to the frontmatter. The existing youtube-domain skill-trigger now discovers
+   and auto-fires this skill every cadence cycle (emitting its breadcrumb + PatternMemory outcome
+   for 012 to observe). Skills 2.0 fields (`category`/`evals`/`retirement_date`) intact; YAML still
+   parses. Executor logic UNCHANGED.
+
+2. **STEER (flag-gated)** -- `scripts/launch.py`: new `_prioritize_channels(channels)` helper,
+   called once in `run_multi_channel_scheduler` right after `channels = BROWSER_CHANNELS[browser]`,
+   BEFORE the rotation loop. When `YT_SCHEDULE_PRIORITY_ENABLED == "1"`: call
+   `rank_channels_by_need()` (read-only), map ranking `channel_id -> registry key`, REORDER the
+   rotation highest-need-first, and DROP channels whose `total_deficit == 0` (already at the hard
+   cap -> nothing to schedule, no work lost). Any rotation key the ranking didn't cover is kept in
+   original order (no silent work loss). Wrapped in try/except -> on ANY error (or if the result is
+   empty) it returns the ORIGINAL `channels` unchanged. A WSP 91 breadcrumb
+   (`schedule_priority_order`) records the chosen order + skips. **Default-off => zero behavior
+   change** unless 012 sets the flag. No scheduling content is mutated; this only orders/skips.
+
+### Tests (mock-only, non-vacuous, NO browser)
+
+`tests/test_shorts_priority_wiring.py` (8 tests, all passing):
+- flag off (unset + explicit `0`) -> original order, no skip
+- flag on -> reorder by injected need + `deficit==0` channel dropped; breadcrumb asserted
+- NON-VACUITY: swapping which channel has the top deficit swaps the chosen head (a
+  ranking-ignoring impl FAILS -- verified by injection: 2 tests fail when the ranking is ignored)
+- rank error -> fallback to original order, no exception escapes
+- all-at-cap -> fallback to original (never hand the scheduler an empty list)
+- uncovered rotation key kept
+- `SKILLz.md` has `domain: youtube` and still parses with Skills 2.0 fields
+
+### Out of scope (separate slices)
+
+Music-vs-talk wiring, reschedule plan/apply wiring, live-signal wiring, and the executor logic
+itself. Touched ONLY `SKILLz.md` + `scripts/launch.py` (+ the new test + this ModLog).
+
 ## 2026-06-19 - reschedule_apply: flag-gated MUTATING apply of the #851 plan (Mode B Phase 2, DEFAULT DRY-RUN)
 
 **By:** 0102 (Worker-Lane RESCHED-APPLY)

--- a/modules/platform_integration/youtube_shorts_scheduler/scripts/launch.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/scripts/launch.py
@@ -122,6 +122,114 @@ def _record_channel_result(channel_key: str, cache: dict, unlisted_count: int, s
 
 
 # ---------------------------------------------------------------------------
+# Schedule-priority steering (SHORTS_PRIORITY_WIRING_PHASE1)
+#
+# Flag-gated, default-off, fallback-safe. When YT_SCHEDULE_PRIORITY_ENABLED=1
+# we consume the read-only `what_should_i_schedule` ranking (deficit per channel
+# over the upcoming window) to (a) process the highest-need channel first and
+# (b) DROP channels whose deficit==0 (already at the hard cap -> nothing to
+# schedule, so no work is lost by skipping them). On ANY error we return the
+# ORIGINAL channel order unchanged -> the scheduler never breaks. This only
+# orders/skips; it never mutates schedule content.
+# ---------------------------------------------------------------------------
+def _prioritize_channels(channels: "list[str]") -> "list[str]":
+    """Reorder `channels` (channel KEYS) highest scheduling-need first and drop
+    deficit==0 channels, gated on YT_SCHEDULE_PRIORITY_ENABLED.
+
+    Args:
+        channels: original rotation order (list of registry channel keys).
+
+    Returns:
+        Reordered+filtered keys when the flag is on and ranking succeeds;
+        otherwise the ORIGINAL `channels` list (fallback-safe, default-off).
+    """
+    if os.getenv("YT_SCHEDULE_PRIORITY_ENABLED", "0") != "1":
+        return channels
+
+    try:
+        from modules.platform_integration.youtube_shorts_scheduler.skillz.what_should_i_schedule.executor import (
+            rank_channels_by_need,
+        )
+        from modules.infrastructure.shared_utilities.youtube_channel_registry import (
+            get_channels,
+        )
+
+        # Map channel_id -> key for the shorts channels so we can translate the
+        # ranking (which is keyed by channel_id) back onto the rotation keys.
+        id_to_key = {
+            ch.get("id"): ch.get("key")
+            for ch in get_channels(role="shorts")
+            if ch.get("id") and ch.get("key")
+        }
+
+        ranking = rank_channels_by_need()  # read-only; reads persisted tracker JSON
+
+        # Walk the ranking in need order; keep only keys present in this
+        # browser's rotation and whose deficit > 0 (something to schedule).
+        original = list(channels)
+        original_set = set(original)
+        ordered: "list[str]" = []
+        skipped: "list[str]" = []
+        seen: set = set()
+        for row in ranking:
+            key = id_to_key.get(row.get("channel_id"))
+            if key is None or key not in original_set or key in seen:
+                continue
+            seen.add(key)
+            if int(row.get("total_deficit", 0)) > 0:
+                ordered.append(key)
+            else:
+                skipped.append(key)
+
+        # Any rotation key the ranking didn't cover (registry/ranking drift):
+        # keep it, in original order, so we never silently drop real work.
+        uncovered = [k for k in original if k not in seen]
+        result = ordered + uncovered
+
+        if not result:
+            # Everything was deficit==0 (or ranking covered nothing actionable).
+            # Don't hand the scheduler an empty list — fall back to original.
+            logger.info("[PRIORITY] all channels at cap (deficit==0); using original order")
+            return original
+
+        _emit_priority_breadcrumb(original, result, skipped)
+        logger.info(
+            "[PRIORITY] reordered %s -> %s (skipped deficit==0: %s)",
+            original, result, skipped,
+        )
+        return result
+    except Exception as exc:
+        # Never break the scheduler: fall back to the original order untouched.
+        logger.warning("[PRIORITY] ranking failed, using original order: %s", exc)
+        return channels
+
+
+def _emit_priority_breadcrumb(original: "list[str]", chosen: "list[str]", skipped: "list[str]") -> None:
+    """Emit a WSP 91 breadcrumb of the chosen priority order + skips (best-effort)."""
+    try:
+        from modules.communication.livechat.src.breadcrumb_telemetry import (
+            get_breadcrumb_telemetry,
+        )
+
+        get_breadcrumb_telemetry().store_breadcrumb(
+            source_dae="youtube_shorts_scheduler",
+            event_type="schedule_priority_order",
+            message=(
+                f"priority steer: {len(chosen)} channel(s) by need; "
+                f"order={chosen}; skipped(deficit==0)={skipped}"
+            ),
+            phase="SHORTS_PRIORITY_WIRING",
+            metadata={
+                "original_order": original,
+                "chosen_order": chosen,
+                "skipped_sufficient": skipped,
+            },
+        )
+    except Exception as exc:  # pragma: no cover - telemetry is best-effort
+        logger.warning(f"[PRIORITY] breadcrumb emit failed: {exc}")
+
+
+# ---------------------------------------------------------------------------
 # Idle Detection for Continuous Rotation
 # ---------------------------------------------------------------------------
 _IDLE_THRESHOLD_SECONDS = int(os.getenv("YT_IDLE_THRESHOLD", "60"))  # 1 min default
@@ -693,6 +801,12 @@ def run_multi_channel_scheduler(
 
     channels = BROWSER_CHANNELS[browser]
     port = BROWSER_PORTS[browser]
+
+    # SHORTS_PRIORITY_WIRING_PHASE1: flag-gated (default-off), fallback-safe.
+    # When YT_SCHEDULE_PRIORITY_ENABLED=1, reorder highest scheduling-need first
+    # and drop channels already at the hard cap (deficit==0). On the default flag
+    # OR any error this returns `channels` unchanged -> zero behavior change.
+    channels = _prioritize_channels(channels)
 
     print(f"\n[MULTI-CHANNEL] {browser.upper()} Rotation Scheduler")
     print("=" * 60)

--- a/modules/platform_integration/youtube_shorts_scheduler/skillz/what_should_i_schedule/SKILLz.md
+++ b/modules/platform_integration/youtube_shorts_scheduler/skillz/what_should_i_schedule/SKILLz.md
@@ -2,6 +2,7 @@
 # Metadata (YAML Frontmatter)
 name: what_should_i_schedule
 description: Rank the shorts-enabled channels by scheduling NEED so the daemon works the most-needed channel next (read-only, agent-invoked)
+domain: youtube  # WRE auto-fire tag (SkillTriggerMixin domain-discovery, skill_trigger.py:91-115) -> the youtube DAE fires this every cadence cycle (SHORTS_PRIORITY_WIRING_PHASE1)
 version: 1.0_prototype
 author: 0102
 created: 2026-06-19

--- a/modules/platform_integration/youtube_shorts_scheduler/tests/test_shorts_priority_wiring.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/tests/test_shorts_priority_wiring.py
@@ -1,0 +1,240 @@
+"""
+Unit tests for SHORTS_PRIORITY_WIRING_PHASE1.
+
+Slice: SHORTS_PRIORITY_WIRING_PHASE1
+
+What is wired
+-------------
+1. REGISTER: `what_should_i_schedule` SKILLz.md carries `domain: youtube` so the
+   existing WRE SkillTriggerMixin (domain-discovery, skill_trigger.py:91-115;
+   auto_moderator_dae.py:221 domain="youtube") auto-fires it every cadence cycle.
+2. STEER: `_prioritize_channels` in scripts/launch.py reorders the rotation
+   highest scheduling-need first and DROPS channels at the hard cap (deficit==0),
+   gated on YT_SCHEDULE_PRIORITY_ENABLED (default-off), fallback-safe.
+
+These tests are MOCK-ONLY (no browser, no daemon, no live model, no real
+registry/tracker) and NON-VACUOUS:
+  - flag on  -> channels reordered by need AND deficit==0 channels skipped
+  - flag off -> original order, no skip
+  - rank error -> fallback to original order (no exception escapes)
+  - the reorder MUST respond to the ranking (a ranking-ignoring impl fails):
+    swapping which channel has the highest deficit swaps the chosen head.
+  - SKILLz.md has `domain: youtube` and still parses with Skills 2.0 fields.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+import modules.platform_integration.youtube_shorts_scheduler.scripts.launch as launch
+
+
+# --- Fixtures: a deterministic registry + ranking, no real I/O ---------------
+
+# channel_id -> key, mirroring the shorts registry shape used by launch.
+_REGISTRY = [
+    {"id": "UC_M2J", "key": "move2japan", "name": "Move2Japan"},
+    {"id": "UC_UDU", "key": "undaodu", "name": "UnDaoDu"},
+    {"id": "UC_FUP", "key": "foundups", "name": "FoundUps"},
+    {"id": "UC_AFM", "key": "antifafm", "name": "antifaFM"},
+]
+
+
+def _registry_channels(role=None):
+    """Stand-in for youtube_channel_registry.get_channels(role='shorts')."""
+    return list(_REGISTRY)
+
+
+def _ranking(*ordered_pairs):
+    """Build a rank_channels_by_need-shaped list: (channel_id, total_deficit)."""
+    return [
+        {
+            "channel_id": cid,
+            "name": cid,
+            "total_deficit": deficit,
+            "days_empty": 0,
+            "recommend": "schedule" if deficit > 0 else "sufficient",
+        }
+        for cid, deficit in ordered_pairs
+    ]
+
+
+# === STEER tests =============================================================
+
+
+def test_flag_off_returns_original_order(monkeypatch):
+    """Default-off: with the flag unset the rotation is untouched (no skip)."""
+    monkeypatch.delenv("YT_SCHEDULE_PRIORITY_ENABLED", raising=False)
+    original = ["move2japan", "undaodu", "foundups", "antifafm"]
+    # If anything tried to rank here it would blow up -> patch nothing on purpose.
+    assert launch._prioritize_channels(original) == original
+
+
+def test_flag_off_explicit_zero(monkeypatch):
+    """Explicit '0' is also off."""
+    monkeypatch.setenv("YT_SCHEDULE_PRIORITY_ENABLED", "0")
+    original = ["foundups", "antifafm"]
+    assert launch._prioritize_channels(original) == original
+
+
+def test_flag_on_reorders_by_need_and_skips_deficit_zero(monkeypatch):
+    """Flag on: reorder by need; channels at the cap (deficit==0) are dropped."""
+    monkeypatch.setenv("YT_SCHEDULE_PRIORITY_ENABLED", "1")
+    original = ["move2japan", "undaodu", "foundups", "antifafm"]
+
+    # Need order (desc): foundups(21) > move2japan(7) > undaodu(3); antifafm==0 -> skip.
+    ranking = _ranking(("UC_FUP", 21), ("UC_M2J", 7), ("UC_UDU", 3), ("UC_AFM", 0))
+
+    with patch.object(launch, "_emit_priority_breadcrumb") as mock_bc, \
+         patch(
+             "modules.infrastructure.shared_utilities.youtube_channel_registry.get_channels",
+             side_effect=_registry_channels,
+         ), \
+         patch(
+             "modules.platform_integration.youtube_shorts_scheduler.skillz."
+             "what_should_i_schedule.executor.rank_channels_by_need",
+             return_value=ranking,
+         ):
+        result = launch._prioritize_channels(original)
+
+    # Highest-need first, antifafm (deficit==0) skipped entirely.
+    assert result == ["foundups", "move2japan", "undaodu"]
+    assert "antifafm" not in result
+    # Breadcrumb emitted with the chosen order + the skipped channel.
+    mock_bc.assert_called_once()
+    args = mock_bc.call_args.args
+    assert args[1] == ["foundups", "move2japan", "undaodu"]  # chosen
+    assert args[2] == ["antifafm"]  # skipped (deficit==0)
+
+
+def test_reorder_responds_to_ranking_NONVACUOUS(monkeypatch):
+    """NON-VACUITY: swapping which channel has the top deficit swaps the head.
+
+    A ranking-ignoring implementation (e.g. returning the original order) would
+    fail BOTH assertions below, because the only thing that changes between the
+    two calls is the injected deficit ordering.
+    """
+    monkeypatch.setenv("YT_SCHEDULE_PRIORITY_ENABLED", "1")
+    original = ["move2japan", "undaodu", "foundups", "antifafm"]
+
+    rank_a = _ranking(("UC_FUP", 21), ("UC_M2J", 7), ("UC_UDU", 3), ("UC_AFM", 1))
+    rank_b = _ranking(("UC_M2J", 21), ("UC_FUP", 7), ("UC_UDU", 3), ("UC_AFM", 1))
+
+    with patch.object(launch, "_emit_priority_breadcrumb"), \
+         patch(
+             "modules.infrastructure.shared_utilities.youtube_channel_registry.get_channels",
+             side_effect=_registry_channels,
+         ):
+        with patch(
+            "modules.platform_integration.youtube_shorts_scheduler.skillz."
+            "what_should_i_schedule.executor.rank_channels_by_need",
+            return_value=rank_a,
+        ):
+            result_a = launch._prioritize_channels(original)
+        with patch(
+            "modules.platform_integration.youtube_shorts_scheduler.skillz."
+            "what_should_i_schedule.executor.rank_channels_by_need",
+            return_value=rank_b,
+        ):
+            result_b = launch._prioritize_channels(original)
+
+    # Head must follow the injected top-deficit channel, not the original order.
+    assert result_a[0] == "foundups"
+    assert result_b[0] == "move2japan"
+    assert result_a != result_b
+    # And neither equals the original order (proving the ranking actually steered).
+    assert result_a != original
+    assert result_b != original
+
+
+def test_rank_error_falls_back_to_original_order(monkeypatch):
+    """Fallback-safe: if ranking raises, return the original order, no exception."""
+    monkeypatch.setenv("YT_SCHEDULE_PRIORITY_ENABLED", "1")
+    original = ["move2japan", "undaodu", "foundups", "antifafm"]
+
+    with patch(
+        "modules.infrastructure.shared_utilities.youtube_channel_registry.get_channels",
+        side_effect=_registry_channels,
+    ), patch(
+        "modules.platform_integration.youtube_shorts_scheduler.skillz."
+        "what_should_i_schedule.executor.rank_channels_by_need",
+        side_effect=RuntimeError("tracker JSON corrupt"),
+    ):
+        result = launch._prioritize_channels(original)
+
+    assert result == original  # untouched, scheduler never breaks
+
+
+def test_all_at_cap_falls_back_to_original(monkeypatch):
+    """If every channel is deficit==0, don't hand the scheduler an empty list."""
+    monkeypatch.setenv("YT_SCHEDULE_PRIORITY_ENABLED", "1")
+    original = ["foundups", "antifafm"]
+    ranking = _ranking(("UC_FUP", 0), ("UC_AFM", 0))
+
+    with patch.object(launch, "_emit_priority_breadcrumb"), \
+         patch(
+             "modules.infrastructure.shared_utilities.youtube_channel_registry.get_channels",
+             side_effect=_registry_channels,
+         ), \
+         patch(
+             "modules.platform_integration.youtube_shorts_scheduler.skillz."
+             "what_should_i_schedule.executor.rank_channels_by_need",
+             return_value=ranking,
+         ):
+        result = launch._prioritize_channels(original)
+
+    assert result == original
+
+
+def test_uncovered_rotation_key_is_kept(monkeypatch):
+    """A rotation key the ranking didn't cover is kept (no silent work loss)."""
+    monkeypatch.setenv("YT_SCHEDULE_PRIORITY_ENABLED", "1")
+    original = ["foundups", "antifafm"]
+    # Ranking only mentions foundups; antifafm is uncovered -> appended after.
+    ranking = _ranking(("UC_FUP", 9))
+
+    with patch.object(launch, "_emit_priority_breadcrumb"), \
+         patch(
+             "modules.infrastructure.shared_utilities.youtube_channel_registry.get_channels",
+             side_effect=_registry_channels,
+         ), \
+         patch(
+             "modules.platform_integration.youtube_shorts_scheduler.skillz."
+             "what_should_i_schedule.executor.rank_channels_by_need",
+             return_value=ranking,
+         ):
+        result = launch._prioritize_channels(original)
+
+    assert result == ["foundups", "antifafm"]
+
+
+# === REGISTER test (orphaning fix) ==========================================
+
+
+def test_skillz_has_domain_youtube_and_skills2_intact():
+    """SKILLz.md must carry `domain: youtube` (WRE auto-fire) and keep Skills 2.0."""
+    skillz_path = (
+        Path(__file__).resolve().parent.parent
+        / "skillz"
+        / "what_should_i_schedule"
+        / "SKILLz.md"
+    )
+    content = skillz_path.read_text(encoding="utf-8")
+    assert content.startswith("---\n")
+    end = content.find("\n---\n", 4)
+    assert end != -1, "frontmatter must terminate"
+    fm = yaml.safe_load(content[4:end])
+
+    # The orphaning fix: domain tag matched by SkillTriggerMixin (domain="youtube").
+    assert fm.get("domain") == "youtube"
+    # Skills 2.0 fields still present and parseable.
+    assert "category" in fm
+    assert "evals" in fm
+    assert "retirement_date" in fm
+    assert fm.get("name") == "what_should_i_schedule"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Slice: SHORTS_PRIORITY_WIRING_PHASE1  (Worker-Lane: PRIORITY-WIRE)

Wires the read-only `what_should_i_schedule` priority skill into the autonomous daemon so everything runs from main.py / the daemon and 012 only observes. Two minimal changes, both safe-by-default.

### 1. REGISTER (orphaning fix)
`skillz/what_should_i_schedule/SKILLz.md` frontmatter had **no `domain:` field**, so the existing WRE skill-trigger never auto-fired it. `SkillTriggerMixin` discovers skills by matching the frontmatter `domain` against the DAE's trigger domain (`skill_trigger.py:91-115`), and the live youtube DAE initializes `domain="youtube"` (`auto_moderator_dae.py:221`, fired `:1788`).

Fix: add `domain: youtube`. The trigger now discovers + fires the skill **every cadence cycle**, emitting its breadcrumb + PatternMemory outcome for 012 to observe. Executor logic untouched; Skills 2.0 fields (`category`/`evals`/`retirement_date`) intact; YAML still parses (verified).

### 2. STEER (flag-gated, default-off, fallback-safe)
New `_prioritize_channels(channels)` in `scripts/launch.py`, called once in `run_multi_channel_scheduler` **before** the rotation loop (right after `channels = BROWSER_CHANNELS[browser]`).

When `YT_SCHEDULE_PRIORITY_ENABLED == "1"`:
- call `rank_channels_by_need()` (pure, read-only; reads the persisted schedule-tracker JSON),
- map ranking `channel_id` -> registry `key`,
- **reorder** the rotation highest scheduling-need first,
- **skip** channels whose `total_deficit == 0` (already at the hard cap -> nothing to schedule, so **no work is lost**),
- keep any rotation key the ranking didn't cover, in original order (no silent work loss),
- emit a WSP 91 breadcrumb (`schedule_priority_order`) of the chosen order + skips.

Wrapped in `try/except`: on **any** error — or if the filtered result is empty — it returns the **ORIGINAL `channels` unchanged**. The scheduler can never break. This only orders/skips; **no scheduling content is mutated**.

**Default-off => zero behavior change** unless 012 sets the flag.

### Non-vacuity proof
Injected a ranking-**ignoring** implementation (returns original order, never skips) and re-ran the two steering assertions: **both FAIL** (`test_reorder_responds_to_ranking_NONVACUOUS`, `test_flag_on_reorders_by_need_and_skips_deficit_zero`). With the real ranking-respecting impl they pass. So the tests genuinely pin the ranking-driven ordering, not a tautology.

### Tests (mock-only, no browser) — 8/8 pass
- flag off (unset + explicit `0`) -> original order, no skip
- flag on -> reorder by injected need + `deficit==0` channel dropped; breadcrumb asserted
- NON-VACUITY: swapping which channel has the top deficit swaps the chosen head
- rank error -> fallback to original order, no exception escapes
- all-at-cap -> fallback to original (never an empty list)
- uncovered rotation key kept
- `SKILLz.md` has `domain: youtube` and still parses with Skills 2.0 fields

### Scope
Touched ONLY `SKILLz.md` + `scripts/launch.py` (+ new test + ModLog). **Out of scope** (separate slices): music-vs-talk wiring, reschedule plan/apply wiring, live-signal wiring, the executor logic.

WSP 95 / 77 / 91 / 60 / 48 / 84 / 50 / 27 / 22 / 49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
