### PR TITLE
feat(youtube_shorts_scheduler): auto-fire reschedule_plan + live-signal from the WRE trigger (live-signal self-gated)

### DIFF
--- a/modules/communication/moltbot_bridge/src/youtube_automation_adapter.py
+++ b/modules/communication/moltbot_bridge/src/youtube_automation_adapter.py
@@ -12,6 +12,7 @@ Supported actions:
   schedule_priority -> what_should_i_schedule SKILLz (read-only channel need ranking)
   reschedule_plan   -> reschedule_plan SKILLz (dry-run rebalance PLAN for over-cap days; apply is Phase 2)
   reschedule_apply  -> reschedule_apply SKILLz (flag-gated apply of the plan; DEFAULT DRY-RUN, mutates nothing unless YT_RESCHEDULE_APPLY=1)
+  live_schedule_signal -> shorts_live_schedule_signal SKILLz (read-only LIVE "Has schedule" count + low-viewed signal; self-gated DEFAULT-OFF, no live DOM work unless YT_LIVE_SCHEDULE_SIGNAL_ENABLED=1)
 
 Examples:
   youtube action comments channel=move2japan max_comments=3 like=true heart=true reply=false
@@ -20,6 +21,7 @@ Examples:
   youtube action schedule_priority upcoming_days=7
   youtube action reschedule_plan horizon_days=90
   youtube action reschedule_apply
+  youtube action live_schedule_signal channel=foundups connect=edge
 """
 
 from __future__ import annotations
@@ -40,6 +42,7 @@ SUPPORTED_ACTIONS = {
     "schedule_priority",
     "reschedule_plan",
     "reschedule_apply",
+    "live_schedule_signal",
 }
 
 ACTION_ALIASES = {
@@ -63,6 +66,10 @@ ACTION_ALIASES = {
     "apply_reschedule": "reschedule_apply",
     "rebalance_apply": "reschedule_apply",
     "reschedule_apply_plan": "reschedule_apply",
+    # shorts_live_schedule_signal SKILLz: read-only LIVE "Has schedule" + low-viewed signal
+    "shorts_live_schedule_signal": "live_schedule_signal",
+    "live_signal": "live_schedule_signal",
+    "schedule_signal": "live_schedule_signal",
 }
 
 # Repo root: modules/communication/moltbot_bridge/src -> parents[4]
@@ -347,6 +354,33 @@ def _build_reschedule_apply_command(params: Dict[str, str]) -> list[str]:
     return cmd
 
 
+def _build_live_schedule_signal_command(params: Dict[str, str]) -> list[str]:
+    """Build the read-only shorts_live_schedule_signal SKILLz invocation.
+
+    Reads the LIVE "Has schedule" scheduled count (fixes the [CPS-AUDIT] false-0) plus
+    a per-video low-viewed signal. The executor SELF-GATES on
+    YT_LIVE_SCHEDULE_SIGNAL_ENABLED (default off): without a live `connect` browser AND
+    the flag set, it does no live DOM work and returns scheduled_count=null (UNKNOWN),
+    never a false 0. No mutation.
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "modules.platform_integration.youtube_shorts_scheduler.skillz.shorts_live_schedule_signal.run_skill",
+        "--channel",
+        params.get("channel", "foundups"),
+        "--low-view-threshold",
+        str(_int_param(params, "low_view_threshold", 100)),
+        "--json",
+    ]
+    connect = params.get("connect", "").strip().lower()
+    if connect in {"chrome", "edge"}:
+        cmd.extend(["--connect", connect])
+    if _truthy(params.get("no_signals", "false")):
+        cmd.append("--no-signals")
+    return cmd
+
+
 async def execute_youtube_action(action: str, params: Dict[str, str]) -> Dict[str, Any]:
     if action == "comments":
         cmd = _build_comments_command(params)
@@ -408,6 +442,22 @@ async def execute_youtube_action(action: str, params: Dict[str, str]) -> Dict[st
     if action == "reschedule_apply":
         cmd = _build_reschedule_apply_command(params)
         timeout_s = _int_param(params, "timeout_s", 120)
+        run_result = await asyncio.to_thread(_run_subprocess, cmd, timeout_s)
+        parsed = _extract_json_tail(run_result.get("stdout_tail", ""))
+        success = bool(run_result.get("success", False))
+        if isinstance(parsed, dict) and parsed.get("success") is False:
+            success = False
+        return {
+            "success": success,
+            "action": action,
+            "result": parsed,
+            **run_result,
+        }
+
+    if action == "live_schedule_signal":
+        cmd = _build_live_schedule_signal_command(params)
+        # A live DOM read can take longer than the offline read-only skills.
+        timeout_s = _int_param(params, "timeout_s", 300)
         run_result = await asyncio.to_thread(_run_subprocess, cmd, timeout_s)
         parsed = _extract_json_tail(run_result.get("stdout_tail", ""))
         success = bool(run_result.get("success", False))

--- a/modules/communication/moltbot_bridge/tests/test_youtube_automation_adapter.py
+++ b/modules/communication/moltbot_bridge/tests/test_youtube_automation_adapter.py
@@ -6,8 +6,10 @@ import unittest
 from unittest.mock import AsyncMock, patch
 
 from modules.communication.moltbot_bridge.src.youtube_automation_adapter import (
+    SUPPORTED_ACTIONS,
     _build_comments_command,
     _build_indexing_command,
+    _build_live_schedule_signal_command,
     _build_scheduling_command,
     _parse_action_command,
     execute_youtube_action,
@@ -104,6 +106,75 @@ class TestYouTubeAutomationAdapter(unittest.IsolatedAsyncioTestCase):
         )
         self.assertIsNotNone(response)
         self.assertIn("not recognized", response or "")
+
+    # --- live_schedule_signal routing (SHORTS_SKILLZ_AUTONOMOUS_REGISTRATION_PHASE1) ---
+
+    def test_live_schedule_signal_is_supported(self):
+        self.assertIn("live_schedule_signal", SUPPORTED_ACTIONS)
+
+    def test_parse_live_schedule_signal_command(self):
+        parsed = _parse_action_command(
+            "youtube action live_schedule_signal channel=foundups connect=edge"
+        )
+        self.assertIsNotNone(parsed)
+        action, params = parsed  # type: ignore[misc]
+        self.assertEqual(action, "live_schedule_signal")
+        self.assertEqual(params.get("channel"), "foundups")
+        self.assertEqual(params.get("connect"), "edge")
+
+    def test_parse_live_schedule_signal_alias(self):
+        parsed = _parse_action_command("yt action shorts_live_schedule_signal channel=antifafm")
+        self.assertIsNotNone(parsed)
+        action, params = parsed  # type: ignore[misc]
+        self.assertEqual(action, "live_schedule_signal")
+        self.assertEqual(params.get("channel"), "antifafm")
+
+    def test_build_live_schedule_signal_command(self):
+        cmd = _build_live_schedule_signal_command(
+            {"channel": "foundups", "connect": "edge", "low_view_threshold": "50"}
+        )
+        command_text = " ".join(cmd)
+        self.assertIn(
+            "modules.platform_integration.youtube_shorts_scheduler.skillz.shorts_live_schedule_signal.run_skill",
+            command_text,
+        )
+        self.assertIn("--channel", cmd)
+        self.assertIn("foundups", cmd)
+        self.assertIn("--connect", cmd)
+        self.assertIn("edge", cmd)
+        self.assertIn("--low-view-threshold", cmd)
+        self.assertIn("50", cmd)
+        self.assertIn("--json", cmd)
+
+    def test_build_live_schedule_signal_command_no_connect_omits_flag(self):
+        cmd = _build_live_schedule_signal_command({"channel": "foundups"})
+        # No connect -> the live browser flag is absent (offline/no-op by construction).
+        self.assertNotIn("--connect", cmd)
+
+    async def test_execute_live_schedule_signal_routes_and_parses_json(self):
+        fake_run = {
+            "success": True,
+            "returncode": 0,
+            "command": ["python", "-m", "fake"],
+            "stdout_tail": '{"skill":"shorts_live_schedule_signal","success":true,"scheduled_count":131}',
+            "stderr_tail": "",
+        }
+        with patch(
+            "modules.communication.moltbot_bridge.src.youtube_automation_adapter._run_subprocess",
+            return_value=fake_run,
+        ) as run_mock:
+            result = await execute_youtube_action(
+                "live_schedule_signal", {"channel": "foundups", "connect": "edge"}
+            )
+        # Routed to the live-signal builder (not some other action's command).
+        dispatched_cmd = run_mock.call_args.args[0]
+        self.assertIn(
+            "modules.platform_integration.youtube_shorts_scheduler.skillz.shorts_live_schedule_signal.run_skill",
+            " ".join(dispatched_cmd),
+        )
+        self.assertEqual(result.get("action"), "live_schedule_signal")
+        self.assertTrue(result.get("success"))
+        self.assertEqual(result.get("result", {}).get("scheduled_count"), 131)
 
 
 if __name__ == "__main__":

--- a/modules/platform_integration/youtube_shorts_scheduler/ModLog.md
+++ b/modules/platform_integration/youtube_shorts_scheduler/ModLog.md
@@ -1,5 +1,63 @@
 # YouTube Shorts Scheduler - ModLog
 
+## 2026-06-19 - Auto-fire reschedule_plan + live-signal from the WRE trigger (live-signal self-gated)
+
+**By:** 0102 (Worker-Lane SKILLZ-REGISTER)
+**Slice:** SHORTS_SKILLZ_AUTONOMOUS_REGISTRATION_PHASE1
+**WSP References:** WSP 22 (ModLog), WSP 49 (Structure), WSP 50 (Pre-Action), WSP 84 (Code Reuse: existing domain-trigger + adapter wiring), WSP 91 (Observability), WSP 95 (SKILLz Wardrobe), WSP 97 (truth signaling: UNKNOWN never false-0)
+
+### Why (the orphaning gap)
+The WRE skill-trigger discovers + fires skills whose SKILLz.md frontmatter carries
+`domain: youtube` (`skill_trigger.py:91-115`, match at `:103`; discovery glob
+`modules/*/*/skillz/**/SKILLz.md`). `what_should_i_schedule` was given `domain: youtube`
+in the prior slice and now auto-fires; the other two read-only scheduling SKILLz
+(`reschedule_plan`, `shorts_live_schedule_signal`) LACKED `domain:` -> orphaned (never
+fired by the daemon, only reachable by `--agent-command`/`run_skill`). 012's rule:
+everything runs from the daemon autonomously, 012 observes. So these must auto-register.
+
+### What changed (minimal)
+- `skillz/reschedule_plan/SKILLz.md`: added `domain: youtube` (Skills 2.0 fields intact).
+  Cheap + offline + dry-run -> safe to auto-fire every cadence cycle. No executor change.
+- `skillz/shorts_live_schedule_signal/SKILLz.md`: added `domain: youtube` + an
+  "Auto-fire self-gate (cost control)" section.
+- `skillz/shorts_live_schedule_signal/executor.py`: NEW self-gate. `run_skill()` checks
+  `YT_LIVE_SCHEDULE_SIGNAL_ENABLED` (default `"0"`); when not `"1"` it returns a NO-OP
+  immediately (no driver/filter/scrape; `skipped=true`, `skip_reason="disabled_by_flag"`,
+  `scheduled_count=null` UNKNOWN never false-0) and still emits breadcrumb/PatternMemory
+  so the WRE records the fired-but-skipped run. When `=1` it runs the live DOM read as
+  before. Rationale: a live DOM round-trip every ~10m is costly and contends with the
+  daemon browser, so it auto-fires DEFAULT-OFF until 012 enables it.
+- `modules/communication/moltbot_bridge/src/youtube_automation_adapter.py`: mapped a new
+  `live_schedule_signal` action (+ aliases `shorts_live_schedule_signal`/`live_signal`/
+  `schedule_signal`, a `_build_live_schedule_signal_command`, and the dispatch branch),
+  mirroring the `reschedule_plan`/`schedule_priority` wiring, so it is `--agent-command`
+  invocable (it was previously only reachable via `python -m ...run_skill`).
+
+### Out of scope (unchanged)
+- `reschedule_apply` (MUTATING) stays manual / `--agent-command` + its `YT_RESCHEDULE_APPLY`
+  gate; it is NOT auto-registered (no `domain: youtube`).
+- priority/music wiring (prior slices); the executor business logic; no mutation anywhere.
+
+### Tests (mock-only, NON-VACUOUS, no live browser/daemon/models)
+- `tests/test_shorts_skillz_domain_registration.py` (NEW): both SKILLz parse via the SAME
+  parser the trigger uses (`WRESkillsDiscovery._extract_frontmatter`) with `domain==youtube`
+  and Skills 2.0 fields intact; a real `discover_all_skills()` scan surfaces both as
+  youtube; guard asserts `reschedule_apply` is NOT youtube-registered.
+- `tests/test_shorts_live_schedule_signal.py` (EXTENDED): flag-OFF run NO-OPs and the
+  filter/scrape MagicMocks are `assert_not_called()` (MUST FAIL if the DOM is scraped while
+  disabled -- verified by a gate-mutation that flips the no-op test to FAIL); flag-ON run
+  calls the (mock) scrape and returns the accurate count; existing live-path tests pin the
+  flag ON.
+- `tests/test_youtube_automation_adapter.py` (EXTENDED): `live_schedule_signal` is supported;
+  command + alias parse; builder targets the live-signal `run_skill` with `--channel/--connect/
+  --low-view-threshold/--json`; `execute_youtube_action` routes to the live-signal command.
+- Scoped run: 53 passed (`--import-mode=importlib`).
+
+### Live gap
+The live DOM read path remains mock-tested only; 012 enables it with
+`YT_LIVE_SCHEDULE_SIGNAL_ENABLED=1` and live-validates the chip-bar / "Has schedule" /
+views selectors before graduation.
+
 ## 2026-06-19 - OBSERVE-mode acoustic music/talk label log (no scheduling gate)
 
 **By:** 0102 (Worker-Lane MUSIC-OBSERVE)

--- a/modules/platform_integration/youtube_shorts_scheduler/skillz/reschedule_plan/SKILLz.md
+++ b/modules/platform_integration/youtube_shorts_scheduler/skillz/reschedule_plan/SKILLz.md
@@ -2,6 +2,7 @@
 # Metadata (YAML Frontmatter)
 name: reschedule_plan
 description: Compute a dry-run REBALANCE PLAN for over-crowded schedule days -- move count>cap excess onto under-target upcoming days into US-ET peak slots per channel tz (read-only, agent-invoked; apply is Phase 2)
+domain: youtube  # WRE auto-fire tag (SkillTriggerMixin domain-discovery, skill_trigger.py:91-115) -> the youtube DAE fires this every cadence cycle. Cheap+offline+dry-run, safe to auto-fire (SHORTS_SKILLZ_AUTONOMOUS_REGISTRATION_PHASE1)
 version: 1.0_prototype
 author: 0102
 created: 2026-06-19

--- a/modules/platform_integration/youtube_shorts_scheduler/skillz/shorts_live_schedule_signal/SKILLz.md
+++ b/modules/platform_integration/youtube_shorts_scheduler/skillz/shorts_live_schedule_signal/SKILLz.md
@@ -2,6 +2,7 @@
 # Metadata (YAML Frontmatter)
 name: shorts_live_schedule_signal
 description: Read-only LIVE shorts-list signals - accurate "Has schedule" scheduled count (fixes the [CPS-AUDIT] false-0) + per-video view count -> low-viewed signal (agent-invoked)
+domain: youtube  # WRE auto-fire tag (SkillTriggerMixin domain-discovery, skill_trigger.py:91-115) -> the youtube DAE discovers+fires this every cadence cycle. COST GATE: the live DOM round-trip is costly + contends with the daemon browser, so the executor SELF-GATES on YT_LIVE_SCHEDULE_SIGNAL_ENABLED (default "0"): auto-fires but NO-OPs (no browser, no scrape) until 012 sets it to "1" (SHORTS_SKILLZ_AUTONOMOUS_REGISTRATION_PHASE1)
 version: 1.0_prototype
 author: 0102
 created: 2026-06-19
@@ -177,6 +178,27 @@ python -m modules.platform_integration.youtube_shorts_scheduler.skillz.shorts_li
 - Mode B re-schedule / apply (mutating) -- this skill is strictly read-only.
 - Wiring this signal into the scheduler ordering / `what_should_i_schedule` ranking.
 - music-vs-talk content gate.
+
+---
+
+## Auto-fire self-gate (cost control)
+
+This skill now carries `domain: youtube`, so the youtube DAE's WRE trigger discovers
+and fires it every cadence cycle WITHOUT manual invocation. But the live signal is a
+DOM round-trip (browser cost + contention with the daemon's own browser), so firing it
+unconditionally every ~10m is wasteful. The executor therefore **self-gates**:
+
+- `run_skill(...)` checks `os.getenv("YT_LIVE_SCHEDULE_SIGNAL_ENABLED", "0")`. When it is
+  not `"1"`, it returns a NO-OP result immediately -- it does **NOT** touch the browser,
+  does **NOT** apply the filter, does **NOT** scrape the DOM. The no-op result carries
+  `skipped=true`, `skip_reason="disabled_by_flag"`, `scheduled_count=null` (UNKNOWN,
+  never a false 0), and still emits the breadcrumb/PatternMemory so the WRE records that
+  the skill fired-but-skipped.
+- When `YT_LIVE_SCHEDULE_SIGNAL_ENABLED=1`, it runs exactly as before (live DOM read).
+
+Net: the skill auto-fires (no orphan), but is **default-off** so 012 enables the live
+cost explicitly. `reschedule_plan` / `what_should_i_schedule` have NO such gate -- they
+are cheap, offline, read-only and safe to auto-fire every cycle.
 
 ---
 

--- a/modules/platform_integration/youtube_shorts_scheduler/skillz/shorts_live_schedule_signal/executor.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/skillz/shorts_live_schedule_signal/executor.py
@@ -58,6 +58,7 @@ Usage (--agent-command surface):
 from __future__ import annotations
 
 import logging
+import os
 import re
 import time
 import uuid
@@ -69,6 +70,46 @@ logger = logging.getLogger(__name__)
 
 SOURCE_DAE = "youtube_shorts_scheduler"
 SKILL_NAME = "shorts_live_schedule_signal"
+
+# Auto-fire cost gate (SHORTS_SKILLZ_AUTONOMOUS_REGISTRATION_PHASE1).
+# This skill now carries `domain: youtube`, so the WRE trigger discovers+fires it every
+# cadence cycle. But a live DOM round-trip every ~10m is costly and contends with the
+# daemon's browser, so we self-gate: unless this env flag is "1", run_skill() returns a
+# NO-OP immediately -- it never touches the driver / applies the filter / scrapes the DOM.
+# Default OFF: the skill auto-fires (no orphan) but does no live work until 012 enables it.
+LIVE_SIGNAL_ENABLED_ENV = "YT_LIVE_SCHEDULE_SIGNAL_ENABLED"
+
+
+def _live_signal_enabled() -> bool:
+    """True only when 012 has explicitly enabled the costly live DOM read."""
+    return os.getenv(LIVE_SIGNAL_ENABLED_ENV, "0").strip() == "1"
+
+
+def _disabled_no_op_signal(channel: str, channel_id: Optional[str], low_view_threshold: int) -> Dict[str, Any]:
+    """The NO-OP result returned when the live-signal flag is OFF.
+
+    No browser, no filter, no scrape. scheduled_count is None (UNKNOWN, NEVER a false 0),
+    matching the rest of the skill's fail-safe contract.
+    """
+    return {
+        "success": True,  # the skill fired correctly; it just (by design) did no live work
+        "skill": SKILL_NAME,
+        "channel": channel,
+        "channel_id": channel_id,
+        "skipped": True,
+        "skip_reason": "disabled_by_flag",
+        "enabled_env": LIVE_SIGNAL_ENABLED_ENV,
+        "filter_applied": False,
+        "scheduled_count": None,  # UNKNOWN, not a false 0
+        "scheduled_count_status": "skipped_disabled_by_flag",
+        "low_view_threshold": low_view_threshold,
+        "low_viewed_count": None,
+        "low_viewed_videos": [],
+        "scheduled_videos": [],
+        "videos": [],
+        "row_count": 0,
+        "patterns": {},
+    }
 
 # 012: shorts under this view count are "low viewed" candidates for re-scheduling.
 DEFAULT_LOW_VIEW_THRESHOLD = 100
@@ -625,8 +666,28 @@ def run_skill(
 
     If `driver` is None, no live browser is available -> returns a clear
     unavailable result (scheduled_count None / UNKNOWN), still NEVER a false 0.
+
+    COST GATE: if `YT_LIVE_SCHEDULE_SIGNAL_ENABLED` != "1", return a NO-OP result
+    immediately WITHOUT touching the browser / applying the filter / scraping the DOM.
+    The skill still auto-fires (no orphan) but does no live work until 012 enables it.
     """
     channel_id = _resolve_channel_id(channel)
+
+    # --- Auto-fire cost gate: default-off, no live DOM work unless 012 enabled it. ---
+    if not _live_signal_enabled():
+        logger.info(
+            "[%s] live signal disabled (%s!=1) -> NO-OP (no browser/scrape)",
+            SKILL_NAME, LIVE_SIGNAL_ENABLED_ENV,
+        )
+        signal = _disabled_no_op_signal(channel, channel_id, low_view_threshold)
+        breadcrumb_emitted = False
+        outcome_stored = False
+        if emit_signals:
+            breadcrumb_emitted = _emit_breadcrumb(signal)
+            outcome_stored = _store_outcome(signal)
+        signal["breadcrumb_emitted"] = breadcrumb_emitted
+        signal["outcome_stored"] = outcome_stored
+        return signal
 
     if driver is None:
         signal = {

--- a/modules/platform_integration/youtube_shorts_scheduler/tests/test_shorts_live_schedule_signal.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/tests/test_shorts_live_schedule_signal.py
@@ -31,6 +31,7 @@ import pytest
 
 from modules.platform_integration.youtube_shorts_scheduler.skillz.shorts_live_schedule_signal.executor import (
     DEFAULT_LOW_VIEW_THRESHOLD,
+    LIVE_SIGNAL_ENABLED_ENV,
     parse_row_signal,
     parse_view_count,
     read_live_schedule_signal,
@@ -279,8 +280,9 @@ def test_signal_responds_to_dom_not_static():
 # Signal emission: breadcrumb + PatternMemory must be invoked.
 # ---------------------------------------------------------------------------
 
-def test_run_skill_emits_breadcrumb_and_pattern_memory():
+def test_run_skill_emits_breadcrumb_and_pattern_memory(monkeypatch):
     """run_skill must emit a live_schedule_signal breadcrumb AND a SkillOutcome."""
+    monkeypatch.setenv(LIVE_SIGNAL_ENABLED_ENV, "1")  # enable live read for this test
     with patch(
         "modules.communication.livechat.src.breadcrumb_telemetry.get_breadcrumb_telemetry"
     ) as bc, patch(
@@ -311,8 +313,9 @@ def test_run_skill_emits_breadcrumb_and_pattern_memory():
     assert result["outcome_stored"] is True
 
 
-def test_run_skill_no_driver_returns_unknown_not_zero():
-    """No live browser -> scheduled_count None (UNKNOWN), never a false 0."""
+def test_run_skill_no_driver_returns_unknown_not_zero(monkeypatch):
+    """No live browser (flag ON) -> scheduled_count None (UNKNOWN), never a false 0."""
+    monkeypatch.setenv(LIVE_SIGNAL_ENABLED_ENV, "1")  # enabled; gate passes, driver None
     with patch(
         "modules.communication.livechat.src.breadcrumb_telemetry.get_breadcrumb_telemetry"
     ), patch(
@@ -326,8 +329,9 @@ def test_run_skill_no_driver_returns_unknown_not_zero():
     assert result["success"] is False
 
 
-def test_run_skill_no_signals_skips_emission():
+def test_run_skill_no_signals_skips_emission(monkeypatch):
     """emit_signals=False must NOT emit breadcrumb/outcome (diagnostic path)."""
+    monkeypatch.setenv(LIVE_SIGNAL_ENABLED_ENV, "1")  # enable live read for this test
     with patch(
         "modules.communication.livechat.src.breadcrumb_telemetry.get_breadcrumb_telemetry"
     ) as bc, patch(
@@ -348,6 +352,126 @@ def test_run_skill_no_signals_skips_emission():
 
 def test_default_low_view_threshold_is_sane():
     assert DEFAULT_LOW_VIEW_THRESHOLD == 100
+
+
+# ---------------------------------------------------------------------------
+# Auto-fire COST self-gate (SHORTS_SKILLZ_AUTONOMOUS_REGISTRATION_PHASE1).
+# The skill now carries `domain: youtube` and auto-fires every cadence cycle.
+# A live DOM round-trip is costly + contends with the daemon browser, so the
+# executor SELF-GATES on YT_LIVE_SCHEDULE_SIGNAL_ENABLED (default "0"):
+#   - flag OFF  -> NO-OP: filter applier + scrape are NEVER called, no DOM touch.
+#   - flag ON   -> runs as before (mock scrape drives an accurate count).
+# These are the load-bearing non-vacuity assertions: a regression that scrapes
+# the DOM while the flag is off FAILS (assert the scrape/filter not called).
+# ---------------------------------------------------------------------------
+
+def test_disabled_by_default_no_ops_without_touching_dom(monkeypatch):
+    """Flag OFF (default): no browser/filter/scrape, scheduled_count UNKNOWN not 0.
+
+    The apply_filter_fn and scrape_fn are MagicMocks that MUST NOT be invoked.
+    If the executor scrapes the DOM while disabled, these assertions FAIL.
+    """
+    monkeypatch.delenv(LIVE_SIGNAL_ENABLED_ENV, raising=False)  # ensure default-off
+
+    apply_filter_spy = MagicMock(return_value=True)
+    scrape_spy = MagicMock(return_value=_mock_rows_present_schedule())
+
+    with patch(
+        "modules.communication.livechat.src.breadcrumb_telemetry.get_breadcrumb_telemetry"
+    ), patch(
+        "modules.infrastructure.wre_core.src.pattern_memory.PatternMemory"
+    ), patch(
+        "modules.infrastructure.wre_core.src.pattern_memory.SkillOutcome"
+    ):
+        result = run_skill(
+            channel="UC_FOUNDUPS",
+            driver=MagicMock(),               # a driver IS available...
+            apply_filter_fn=apply_filter_spy,  # ...but these must NOT be called
+            scrape_fn=scrape_spy,
+            emit_signals=True,
+        )
+
+    # The DOM was NOT touched (the whole point of the cost gate).
+    apply_filter_spy.assert_not_called()
+    scrape_spy.assert_not_called()
+
+    assert result["skipped"] is True
+    assert result["skip_reason"] == "disabled_by_flag"
+    assert result["scheduled_count"] is None         # UNKNOWN, never a false 0
+    assert result["scheduled_count"] != 0
+    assert result["scheduled_count_status"] == "skipped_disabled_by_flag"
+    assert result["enabled_env"] == LIVE_SIGNAL_ENABLED_ENV
+
+
+def test_disabled_explicit_zero_no_ops(monkeypatch):
+    """Flag explicitly '0' also no-ops (not just unset)."""
+    monkeypatch.setenv(LIVE_SIGNAL_ENABLED_ENV, "0")
+    scrape_spy = MagicMock(return_value=_mock_rows_present_schedule())
+    with patch(
+        "modules.communication.livechat.src.breadcrumb_telemetry.get_breadcrumb_telemetry"
+    ), patch(
+        "modules.infrastructure.wre_core.src.pattern_memory.PatternMemory"
+    ), patch(
+        "modules.infrastructure.wre_core.src.pattern_memory.SkillOutcome"
+    ):
+        result = run_skill(
+            channel="UC_FOUNDUPS",
+            driver=MagicMock(),
+            apply_filter_fn=_filter_ok,
+            scrape_fn=scrape_spy,
+            emit_signals=False,
+        )
+    scrape_spy.assert_not_called()
+    assert result["skipped"] is True
+    assert result["scheduled_count"] is None
+
+
+def test_disabled_no_op_still_emits_signals(monkeypatch):
+    """Even when skipped, the fired-but-skipped run is recorded (breadcrumb + outcome)."""
+    monkeypatch.delenv(LIVE_SIGNAL_ENABLED_ENV, raising=False)
+    with patch(
+        "modules.communication.livechat.src.breadcrumb_telemetry.get_breadcrumb_telemetry"
+    ) as bc, patch(
+        "modules.infrastructure.wre_core.src.pattern_memory.PatternMemory"
+    ) as pm, patch(
+        "modules.infrastructure.wre_core.src.pattern_memory.SkillOutcome"
+    ):
+        result = run_skill(
+            channel="UC_FOUNDUPS",
+            driver=MagicMock(),
+            apply_filter_fn=_filter_ok,
+            scrape_fn=lambda d: _mock_rows_present_schedule(),
+            emit_signals=True,
+        )
+        bc.return_value.store_breadcrumb.assert_called_once()
+        pm.return_value.store_outcome.assert_called_once()
+    assert result["skipped"] is True
+    assert result["breadcrumb_emitted"] is True
+    assert result["outcome_stored"] is True
+
+
+def test_enabled_runs_live_path_and_scrapes(monkeypatch):
+    """Flag ON: the gate passes, the (mock) scrape IS called, accurate count returned."""
+    monkeypatch.setenv(LIVE_SIGNAL_ENABLED_ENV, "1")
+    scrape_spy = MagicMock(return_value=_mock_rows_present_schedule())
+    with patch(
+        "modules.communication.livechat.src.breadcrumb_telemetry.get_breadcrumb_telemetry"
+    ), patch(
+        "modules.infrastructure.wre_core.src.pattern_memory.PatternMemory"
+    ), patch(
+        "modules.infrastructure.wre_core.src.pattern_memory.SkillOutcome"
+    ):
+        result = run_skill(
+            channel="UC_FOUNDUPS",
+            driver=MagicMock(),
+            apply_filter_fn=_filter_ok,
+            scrape_fn=scrape_spy,
+            emit_signals=True,
+        )
+    scrape_spy.assert_called_once()                  # the DOM read DID happen when enabled
+    assert result.get("skipped") is not True
+    assert result["scheduled_count"] == 3            # accurate, mock-driven
+    assert result["success"] is True
 
 
 if __name__ == "__main__":

--- a/modules/platform_integration/youtube_shorts_scheduler/tests/test_shorts_skillz_domain_registration.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/tests/test_shorts_skillz_domain_registration.py
@@ -1,0 +1,117 @@
+"""
+Auto-fire registration tests for the shorts scheduling SKILLz.
+
+Slice: SHORTS_SKILLZ_AUTONOMOUS_REGISTRATION_PHASE1
+
+What these pin (mock-only, no daemon, no browser, no live models)
+----------------------------------------------------------------
+The WRE skill-trigger discovers + fires skills whose SKILLz.md frontmatter carries
+`domain: youtube` (SkillTriggerMixin domain-discovery, skill_trigger.py:91-115; the
+match is `skill.metadata.get("domain") == self._trigger_domain`). So a scheduling
+SKILLz that LACKS `domain:` is orphaned -- it never auto-fires from the daemon.
+
+These tests assert the two remaining read-only scheduling SKILLz now carry
+`domain: youtube` AND still parse as valid YAML with their Skills 2.0 hygiene fields
+intact, using the SAME frontmatter parser the WRE discovery uses
+(WRESkillsDiscovery._extract_frontmatter -> yaml.safe_load). They are NON-VACUOUS:
+the assertion is on the parsed metadata dict the trigger actually reads, not on raw
+text -- a malformed frontmatter (e.g. a stray tab) would FAIL the parse.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from modules.infrastructure.wre_core.skillz.wre_skills_discovery import (
+    WRESkillsDiscovery,
+)
+
+# Repo root: .../youtube_shorts_scheduler/tests -> parents[4]
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_SKILLZ_DIR = (
+    _REPO_ROOT
+    / "modules"
+    / "platform_integration"
+    / "youtube_shorts_scheduler"
+    / "skillz"
+)
+
+_DISCOVERY = WRESkillsDiscovery(_REPO_ROOT)
+
+
+def _frontmatter(skill_dir: str) -> dict:
+    """Parse a SKILLz.md frontmatter exactly as the WRE discovery does."""
+    path = _SKILLZ_DIR / skill_dir / "SKILLz.md"
+    content = path.read_text(encoding="utf-8")
+    meta = _DISCOVERY._extract_frontmatter(content)
+    assert isinstance(meta, dict) and meta, f"{skill_dir}: frontmatter failed to parse"
+    return meta
+
+
+# The two SKILLz this slice registers for auto-fire (the live one is also self-gated).
+AUTO_FIRE_SKILLS = ["reschedule_plan", "shorts_live_schedule_signal"]
+
+
+@pytest.mark.parametrize("skill_dir", AUTO_FIRE_SKILLS)
+def test_skill_has_domain_youtube(skill_dir):
+    """The trigger fires iff metadata['domain'] == 'youtube' -- assert exactly that."""
+    meta = _frontmatter(skill_dir)
+    domain = str(meta.get("domain", "")).lower().strip()
+    assert domain == "youtube", (
+        f"{skill_dir}: domain must be 'youtube' for WRE auto-fire "
+        f"(skill_trigger.py:103); got {meta.get('domain')!r}"
+    )
+    # name must still match the directory (sanity that we edited the right file).
+    assert meta.get("name") == skill_dir
+
+
+@pytest.mark.parametrize("skill_dir", AUTO_FIRE_SKILLS)
+def test_skills_2_0_fields_intact(skill_dir):
+    """Adding domain must NOT drop the Skills 2.0 hygiene fields."""
+    meta = _frontmatter(skill_dir)
+    assert "category" in meta, f"{skill_dir}: missing Skills 2.0 'category'"
+    assert "evals" in meta, f"{skill_dir}: missing Skills 2.0 'evals'"
+    assert "retirement_date" in meta, f"{skill_dir}: missing Skills 2.0 'retirement_date'"
+    # version/intent_type still present (the rest of the frontmatter survived).
+    assert meta.get("version")
+    assert meta.get("intent_type")
+
+
+def test_what_should_i_schedule_already_registered():
+    """Control: the prior-landed skill is the registration template (must stay youtube)."""
+    meta = _frontmatter("what_should_i_schedule")
+    assert str(meta.get("domain", "")).lower().strip() == "youtube"
+
+
+def test_discovery_tags_both_skills_youtube():
+    """End-to-end via the REAL discovery scan: both skills surface with domain=youtube.
+
+    Non-vacuous: this runs WRESkillsDiscovery.discover_all_skills() (the same call the
+    trigger uses) and confirms the two skills appear with the youtube domain tag, i.e.
+    the trigger's `domain == 'youtube'` filter would include them.
+    """
+    skills = _DISCOVERY.discover_all_skills()
+    by_name = {s.skill_name: s for s in skills}
+    for name in AUTO_FIRE_SKILLS:
+        assert name in by_name, f"{name} not discovered by WRESkillsDiscovery"
+        domain = str(by_name[name].metadata.get("domain", "")).lower().strip()
+        assert domain == "youtube", f"{name}: discovery domain={domain!r}, expected youtube"
+
+
+def test_reschedule_apply_NOT_auto_registered():
+    """Out-of-scope guard: the MUTATING reschedule_apply must stay manual/gated.
+
+    It must NOT carry domain:youtube (it would auto-fire its mutating path). If the
+    skill exists it is asserted orphan-by-design; if it does not exist, that is fine too.
+    """
+    path = _SKILLZ_DIR / "reschedule_apply" / "SKILLz.md"
+    if not path.exists():
+        pytest.skip("reschedule_apply SKILLz.md not present")
+    meta = _DISCOVERY._extract_frontmatter(path.read_text(encoding="utf-8"))
+    assert str(meta.get("domain", "")).lower().strip() != "youtube", (
+        "reschedule_apply (mutating) must NOT auto-fire -- keep it manual/gated"
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Slice: SHORTS_SKILLZ_AUTONOMOUS_REGISTRATION_PHASE1

**Worker-Lane:** SKILLZ-REGISTER · **Base:** origin/main @ `73e1795`

012's rule: everything runs from the daemon autonomously, 012 observes. This makes the two remaining read-only scheduling SKILLz auto-fire from the daemon's existing WRE skill-trigger so they emit signal each cycle with no manual invocation.

### The orphaning fix (`domain: youtube`)
The WRE skill-trigger discovers + fires skills whose SKILLz.md frontmatter carries `domain: youtube` (`skill_trigger.py:91-115`, match at `:103`; discovery glob `modules/*/*/skillz/**/SKILLz.md`, parsed by `WRESkillsDiscovery._extract_frontmatter` -> `yaml.safe_load`). `what_should_i_schedule` was given `domain: youtube` in the prior slice and now auto-fires; `reschedule_plan` and `shorts_live_schedule_signal` LACKED `domain:` -> orphaned (only reachable via `--agent-command`/`run_skill`). Both now carry `domain: youtube`.

- `reschedule_plan` is cheap + offline + dry-run -> safe to auto-fire each cadence cycle (emits its plan/breadcrumb). **No executor change.**

### The live-signal self-gate (cost) — DEFAULT-OFF
`shorts_live_schedule_signal` does a live Studio DOM round-trip (browser cost + contention with the daemon's own browser). Auto-firing that every ~10m is wasteful, so its executor self-gates:

- `run_skill()` checks `YT_LIVE_SCHEDULE_SIGNAL_ENABLED` (default `"0"`). When not `"1"` it returns a NO-OP immediately — **no driver, no filter, no scrape** — with `skipped=true`, `skip_reason="disabled_by_flag"`, `scheduled_count=null` (UNKNOWN, never a false 0), and still emits breadcrumb + PatternMemory so the WRE records the fired-but-skipped run.
- When `YT_LIVE_SCHEDULE_SIGNAL_ENABLED=1` it runs the live DOM read exactly as before.

Net: the skill auto-fires (no orphan) but does no live work until 012 explicitly enables it.

### The adapter mapping
`youtube_automation_adapter.py` gains a `live_schedule_signal` action (+ aliases `shorts_live_schedule_signal`/`live_signal`/`schedule_signal`, a `_build_live_schedule_signal_command`, and the dispatch branch), mirroring the existing `reschedule_plan`/`schedule_priority` wiring — so the live-signal is now `--agent-command` invocable (previously only `python -m ...run_skill`).

### Non-vacuity proof
- `test_shorts_skillz_domain_registration.py` (NEW): both SKILLz parse via the SAME parser the trigger uses (`WRESkillsDiscovery._extract_frontmatter`) with `domain==youtube` and Skills 2.0 fields (`category`/`evals`/`retirement_date`) intact; a real `discover_all_skills()` scan surfaces both as youtube; a guard asserts `reschedule_apply` is NOT youtube-registered.
- `test_shorts_live_schedule_signal.py` (EXTENDED): the flag-OFF run NO-OPs and the filter/scrape `MagicMock`s are `assert_not_called()`. **This MUST FAIL if the live-signal scrapes the DOM while the flag is off** — verified by a gate-mutation (forcing the gate always-on) which flipped that test to FAIL on `apply_filter_spy.assert_not_called()`, then reverted. The flag-ON test asserts the (mock) scrape IS called and returns the accurate count (3).
- `test_youtube_automation_adapter.py` (EXTENDED): `live_schedule_signal` supported; command + alias parse; builder targets the live-signal `run_skill` with `--channel/--connect/--low-view-threshold/--json`; `execute_youtube_action` routes to the live-signal command.
- **Scoped run: 53 passed** (`--import-mode=importlib`). Mock-only — no live browser/daemon/models.

### Scope
Touched ONLY: the 2 SKILLz.md, the live-signal executor (the flag-gate), `youtube_automation_adapter.py`, the 3 test files, and the module ModLog. No mutation anywhere. Executor business logic unchanged. priority/music wiring (prior slices) untouched.

### reschedule_apply stays manual/gated
The MUTATING `reschedule_apply` is deliberately **NOT** auto-registered (no `domain: youtube`). It remains manual / `--agent-command` + its own `YT_RESCHEDULE_APPLY` gate. A test asserts it never carries `domain: youtube`.

### Live gap
The live DOM read path remains mock-tested only; 012 enables it with `YT_LIVE_SCHEDULE_SIGNAL_ENABLED=1` and live-validates the chip-bar / "Has schedule" / views selectors before graduation.

Status: VERIFIED_READY — leave OPEN, do NOT merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
