### PR TITLE
feat(video_indexer): index Shorts as well as long-form (add videos/short pass)

### DIFF
--- a/modules/ai_intelligence/video_indexer/ModLog.md
+++ b/modules/ai_intelligence/video_indexer/ModLog.md
@@ -2,6 +2,48 @@
 
 **WSP Compliance**: WSP 22 (ModLog Updates)
 
+## V0.30.0 - Index Shorts as well as long-form (add videos/short pass) (INDEXER_SHORTS_PASS_PHASE1) (2026-06-19)
+
+**By:** 0102 (Worker-Lane INDEX-SHORTS)
+**Slice:** INDEXER_SHORTS_PASS_PHASE1
+**WSP References:** WSP 22 (ModLog), WSP 49 (Structure), WSP 50 (existing-flag gated, no new public mutation), WSP 84 (Code Reuse: ask_about_video + VideoIndexStore.save_index), WSP 91 (per-pass observability)
+
+### Why (the gap)
+`index_channel_videos` navigated ONLY the long-form list
+(`https://studio.youtube.com/channel/{id}/videos/upload`, src:2304) and EXPLICITLY
+skipped short rows (`if "short" in row_text or "#short" in row_text: continue`,
+src:2380). Result: SHORTS were NEVER indexed, even for channels whose registry
+`content_types` are shorts-only (foundups/antifafm = `["short"]`). 012 wants both
+shorts AND long-form indexed.
+
+### What changed (minimal, read-mostly, no new public mutation)
+- `src/studio_ask_indexer.py`:
+  - `index_channel_videos(..., content_type="upload")`: navigation now targets
+    `videos/{content_type}`; the short-row skip is gated `if not is_shorts_pass`
+    so the `videos/upload` pass STILL skips shorts while the new `videos/short`
+    pass KEEPS short rows and indexes them via the SAME `ask_about_video` +
+    `save_index` path. Summary now carries `content_type`.
+  - `_ask_result_to_index_data(..., content_type="upload")`: records
+    `metadata.content_type` (`"short"`|`"upload"`) so shorts vs long-form
+    artifacts are distinguishable downstream.
+  - `run_video_indexing_cycle`: for each channel runs the passes from the
+    registry `content_types` via new helper `_resolve_index_passes` (foundups/
+    antifafm `["short"]` -> shorts only; move2japan/undaodu `["short","upload"]`
+    -> both; unknown/absent -> both). Per-pass try/except isolates a failing pass;
+    `_merge_pass_results` sums per-channel totals and keeps a per-pass breakdown
+    (`passes`, `pass_errors`).
+  - Gated by the EXISTING `YT_VIDEO_INDEXING_ENABLED` (no new flag, no scheduling
+    change). Indexing remains read-mostly JSON persistence.
+- `tests/test_shorts_indexing_pass.py` (NEW, mock-only, no live browser):
+  shorts pass indexes short rows with `content_type=short`; upload pass skips
+  shorts; `_resolve_index_passes` short-only/both/default; cycle runs the right
+  passes per channel; one failing pass does not abort the sibling. All 7 FAIL on
+  pre-change source (shorts never indexed) and PASS after the change.
+
+### Scope (OUT)
+No scheduling change, no rotation fix, no private/detector work. Touched only
+`studio_ask_indexer.py` (+ `run_video_indexing_cycle`) + the new test + this ModLog.
+
 ## V0.29.0 - OBSERVE-mode acoustic music/talk label in PHASE 2 indexing (SHORTS_MUSIC_LABEL_OBSERVE_PHASE1) (2026-06-19)
 
 **By:** 0102 (Worker-Lane MUSIC-OBSERVE)

--- a/modules/ai_intelligence/video_indexer/src/studio_ask_indexer.py
+++ b/modules/ai_intelligence/video_indexer/src/studio_ask_indexer.py
@@ -766,8 +766,14 @@ Give a brief category and a few mood/genre topics only.""",
     def _ask_result_to_index_data(
         ask_result: AskResult,
         channel_key: str,
+        content_type: str = "upload",
     ) -> IndexData:
-        """Build IndexData from Ask Gemini response."""
+        """Build IndexData from Ask Gemini response.
+
+        ``content_type`` records WHICH Studio list pass produced this artifact
+        ("upload" long-form vs "short"); it is stored in metadata so shorts and
+        long-form indices are distinguishable downstream (INDEXER_SHORTS_PASS).
+        """
         segments = []
         for seg in ask_result.timestamps or []:
             start = StudioAskIndexer._parse_timestamp(seg.get("time", ""))
@@ -802,6 +808,9 @@ Give a brief category and a few mood/genre topics only.""",
                 "topics": ask_result.topics or [],
                 "key_points": [],
                 "summary": ask_result.response_text or "",
+                # Which Studio list pass produced this artifact ("short" | "upload").
+                # Lets shorts and long-form indices be told apart (INDEXER_SHORTS_PASS).
+                "content_type": content_type,
                 "content_category": ask_result.content_category or "other",
                 # PRESERVE Gemini's raw (pre-normalization) category in the saved
                 # index so the rich label is never lost. None if Gemini returned no
@@ -2272,19 +2281,30 @@ Give a brief category and a few mood/genre topics only.""",
         channel_id: str,
         max_videos: Optional[int] = None,
         force_reindex: bool = False,
+        content_type: str = "upload",
     ) -> Dict[str, Any]:
         """
         Index videos for a channel using Ask Gemini.
-        
+
         Args:
             channel_id: YouTube channel ID
             max_videos: Override max videos to index
-            
+            content_type: Which Studio list to enumerate -- "upload" (long-form,
+                the original behaviour which SKIPS short rows) or "short" (the
+                Shorts list, which KEEPS short rows so they get indexed too).
+                Navigation targets ``videos/{content_type}`` and the recorded
+                artifact metadata carries this label (INDEXER_SHORTS_PASS).
+
         Returns:
             Summary of indexing results
         """
         import asyncio
-        
+
+        content_type = (content_type or "upload").strip().lower()
+        if content_type not in ("upload", "short"):
+            content_type = "upload"
+        is_shorts_pass = content_type == "short"
+
         max_videos = max_videos or self.max_videos_per_cycle
         results = []
         skipped = 0
@@ -2293,15 +2313,16 @@ Give a brief category and a few mood/genre topics only.""",
         channel_key = (channel_entry or {}).get("key") or channel_id or "unknown"
         channel_name = (channel_entry or {}).get("name", channel_key)
 
-        logger.info(f"[STUDIO-ASK] Starting video indexing for channel {channel_id} ({channel_name})")
+        logger.info(f"[STUDIO-ASK] Starting video indexing for channel {channel_id} ({channel_name}) [pass={content_type}]")
         logger.info(f"[STUDIO-ASK] Max videos: {max_videos}")
-        
+
         if not self.driver:
             return {"error": "No browser driver", "indexed": 0}
-        
+
         try:
-            # Navigate to channel content page
-            content_url = f"https://studio.youtube.com/channel/{channel_id}/videos/upload"
+            # Navigate to channel content page. videos/upload = long-form list
+            # (skips shorts), videos/short = Shorts list (indexes shorts).
+            content_url = f"https://studio.youtube.com/channel/{channel_id}/videos/{content_type}"
             logger.info(f"[STUDIO-ASK] Navigating to: {content_url}")
             self.driver.get(content_url)
             await self._human_delay(3.0, 0.4)
@@ -2358,8 +2379,10 @@ Give a brief category and a few mood/genre topics only.""",
                 logger.warning(f"[STUDIO-ASK] Sort failed (using default order): {e}")
                 # Continue with default order - better than failing
 
-            # Get list of video IDs (PRIORITIZE: LIVE > Regular, skip Shorts)
-            # 2026-03-18: Added LIVE prioritization and Shorts filtering
+            # Get list of video IDs (PRIORITIZE: LIVE > Regular).
+            # 2026-03-18: Added LIVE prioritization and Shorts filtering.
+            # INDEXER_SHORTS_PASS: the upload pass still SKIPS short rows; the
+            # shorts pass (videos/short) KEEPS them so shorts get indexed too.
             video_ids = []
             live_videos = []
             regular_videos = []
@@ -2376,8 +2399,9 @@ Give a brief category and a few mood/genre topics only.""",
                         # Get row text to detect LIVE/Shorts
                         row_text = row.text.lower()
 
-                        # Skip Shorts (they have limited content value for indexing)
-                        if "short" in row_text or "#short" in row_text:
+                        # Skip Shorts on the long-form (upload) pass only -- they
+                        # are indexed by the dedicated shorts pass instead.
+                        if not is_shorts_pass and ("short" in row_text or "#short" in row_text):
                             continue
 
                         # Detect LIVE/Premiered videos (higher priority)
@@ -2422,7 +2446,9 @@ Give a brief category and a few mood/genre topics only.""",
                     logger.info(f"[STUDIO-ASK] ✅ {vid_id}: {len(result.topics)} topics")
 
                     # Persist Ask results as JSON artifacts for indexing continuity
-                    index_data = self._ask_result_to_index_data(result, channel_key=channel_key)
+                    index_data = self._ask_result_to_index_data(
+                        result, channel_key=channel_key, content_type=content_type
+                    )
 
                     # OBSERVE-MODE acoustic music/talk label (flag-gated, default OFF;
                     # SHORTS_MUSIC_LABEL_OBSERVE_PHASE1). When YT_AUDIO_LABEL_OBSERVE=1
@@ -2454,6 +2480,7 @@ Give a brief category and a few mood/genre topics only.""",
             indexed = sum(1 for r in results if r.success)
             return {
                 "channel_id": channel_id,
+                "content_type": content_type,
                 "indexed": indexed,
                 "skipped": skipped,
                 "failed": len(results) - indexed,
@@ -2463,6 +2490,65 @@ Give a brief category and a few mood/genre topics only.""",
         except Exception as e:
             logger.error(f"[STUDIO-ASK] Channel indexing failed: {e}")
             return {"error": str(e), "indexed": 0}
+
+
+# Canonical, ordered Studio list passes for a channel: long-form first, shorts
+# second. A channel with no usable registry content_types is indexed on BOTH.
+_DEFAULT_INDEX_PASSES = ("upload", "short")
+
+
+def _resolve_index_passes(channel_id: str) -> List[str]:
+    """Return the ordered list of content-type passes for ``channel_id``.
+
+    INDEXER_SHORTS_PASS: derived from the channel registry ``content_types``
+    (move2japan/undaodu = ["short","upload"] -> both; foundups/antifafm =
+    ["short"] -> shorts only). Unknown channel or missing/empty content_types
+    falls back to indexing BOTH lists. Order is normalized to upload-then-short
+    so long-form is indexed first, shorts second.
+    """
+    try:
+        channel_entry = get_channel_by_id(channel_id) or {}
+        content_types = channel_entry.get("content_types") or []
+        wanted = {str(ct).strip().lower() for ct in content_types}
+    except Exception as e:
+        logger.warning(f"[VIDEO-INDEX] content_types lookup failed for {channel_id}: {e}")
+        wanted = set()
+
+    passes = [ct for ct in _DEFAULT_INDEX_PASSES if ct in wanted]
+    if not passes:
+        # Absent / unrecognized content_types -> default to both passes.
+        passes = list(_DEFAULT_INDEX_PASSES)
+    return passes
+
+
+def _merge_pass_results(channel_id: str, pass_results: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Combine per-pass index_channel_videos summaries into one channel summary.
+
+    Sums indexed/skipped/failed across passes, unions the indexed video ids, and
+    keeps a per-pass breakdown (``passes``) so shorts vs long-form contribution
+    stays observable. Pass-level errors are surfaced under ``pass_errors``.
+    """
+    merged: Dict[str, Any] = {
+        "channel_id": channel_id,
+        "indexed": 0,
+        "skipped": 0,
+        "failed": 0,
+        "videos": [],
+        "passes": {},
+    }
+    pass_errors: Dict[str, str] = {}
+    for pr in pass_results:
+        ct = pr.get("content_type", "unknown")
+        merged["indexed"] += int(pr.get("indexed", 0) or 0)
+        merged["skipped"] += int(pr.get("skipped", 0) or 0)
+        merged["failed"] += int(pr.get("failed", 0) or 0)
+        merged["videos"].extend(pr.get("videos", []) or [])
+        merged["passes"][ct] = pr
+        if pr.get("error"):
+            pass_errors[ct] = pr["error"]
+    if pass_errors:
+        merged["pass_errors"] = pass_errors
+    return merged
 
 
 async def run_video_indexing_cycle(
@@ -2562,12 +2648,38 @@ async def run_video_indexing_cycle(
 
     results = {}
     for channel_id in channels:
-        result = await indexer.index_channel_videos(
-            channel_id,
-            force_reindex=force_reindex,
-        )
+        # INDEXER_SHORTS_PASS: run the passes appropriate to this channel's
+        # registry content_types. A ["short"] channel gets the shorts pass; a
+        # ["short","upload"] channel gets both; absent/unknown -> default both.
+        passes = _resolve_index_passes(channel_id)
+        pass_results = []
+        for content_type in passes:
+            # Per-pass try/except so one pass failing does not abort the other.
+            try:
+                pass_result = await indexer.index_channel_videos(
+                    channel_id,
+                    force_reindex=force_reindex,
+                    content_type=content_type,
+                )
+            except Exception as e:
+                logger.error(
+                    f"[VIDEO-INDEX] {channel_id} pass={content_type} raised: {e}"
+                )
+                pass_result = {
+                    "channel_id": channel_id,
+                    "content_type": content_type,
+                    "error": str(e),
+                    "indexed": 0,
+                }
+            pass_results.append(pass_result)
+            logger.info(
+                f"[VIDEO-INDEX] {channel_id} [{content_type}]: "
+                f"{pass_result.get('indexed', 0)} videos indexed"
+            )
+
+        result = _merge_pass_results(channel_id, pass_results)
         results[channel_id] = result
-        logger.info(f"[VIDEO-INDEX] {channel_id}: {result.get('indexed', 0)} videos indexed")
+        logger.info(f"[VIDEO-INDEX] {channel_id}: {result.get('indexed', 0)} videos indexed (all passes)")
 
     total_indexed = sum(r.get("indexed", 0) for r in results.values())
     total_skipped = sum(r.get("skipped", 0) for r in results.values())

--- a/modules/ai_intelligence/video_indexer/tests/test_shorts_indexing_pass.py
+++ b/modules/ai_intelligence/video_indexer/tests/test_shorts_indexing_pass.py
@@ -1,0 +1,280 @@
+"""
+INDEXER_SHORTS_PASS_PHASE1 - mock-only tests for the Shorts indexing pass.
+
+GOAL: the video indexer must index Shorts as well as long-form. On origin/main
+``index_channel_videos`` enumerates ONLY ``videos/upload`` and SKIPS short rows
+(``if "short" in row_text: continue``) -- so shorts are NEVER indexed. These
+tests assert that:
+
+  1. the shorts pass (content_type="short") navigates ``videos/short``,
+     KEEPS short rows, and writes artifacts with metadata.content_type == "short";
+  2. the upload pass still indexes long-form and SKIPS short rows;
+  3. a ["short"] channel (foundups) runs ONLY the shorts pass;
+  4. a ["short","upload"] channel (move2japan) runs BOTH passes.
+
+NON-VACUITY: tests 1 and 4 FAIL on current (pre-change) code because no short
+artifact is ever produced. NO live browser / network: a FakeDriver returns
+mocked rows by URL and ask_about_video / audio-observe are monkeypatched.
+
+WSP 5 (coverage), WSP 50 (verify), WSP 84 (reuse existing mock patterns).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from modules.ai_intelligence.video_indexer.src import studio_ask_indexer
+from modules.ai_intelligence.video_indexer.src.studio_ask_indexer import (
+    AskResult,
+    StudioAskIndexer,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake Selenium driver (NO live browser): rows are chosen by the navigated URL.
+# ---------------------------------------------------------------------------
+
+class _FakeLink:
+    def __init__(self, href):
+        self._href = href
+
+    def get_attribute(self, _name):
+        return self._href
+
+
+class _FakeRow:
+    """A Studio video row. ``text`` drives the LIVE/Shorts detection."""
+
+    def __init__(self, video_id, text):
+        self._link = _FakeLink(f"https://studio.youtube.com/video/{video_id}/edit")
+        self.text = text
+
+    def find_element(self, _by, _selector):
+        return self._link
+
+
+class _FakeDriver:
+    """Returns long-form rows for /videos/upload and short rows for /videos/short."""
+
+    def __init__(self):
+        self.current_url = ""
+        self.navigated = []
+
+    def get(self, url):
+        self.current_url = url
+        self.navigated.append(url)
+
+    def execute_script(self, _script, *args):
+        # No sort button in the fake DOM -> indexer keeps default order.
+        return "no_sort_button"
+
+    def find_elements(self, _by, _selector):
+        if self.current_url.endswith("/videos/short"):
+            # Shorts list: every row is a Short.
+            return [
+                _FakeRow("short001", "My Short #shorts"),
+                _FakeRow("short002", "Another short video"),
+            ]
+        # Upload (long-form) list: one long-form row plus a stray Short row.
+        return [
+            _FakeRow("long001", "Full length stream live recording"),
+            _FakeRow("shortX", "leftover short #short"),
+        ]
+
+
+def _make_indexer(monkeypatch, tmp_path):
+    """Build an indexer wired to a temp INDEX_ROOT with fast, mocked I/O."""
+    index_root = tmp_path / "video_index"
+    monkeypatch.setattr(studio_ask_indexer, "INDEX_ROOT", index_root)
+    # Never touch real audio/network.
+    monkeypatch.setattr(studio_ask_indexer, "_observe_audio_label", lambda vid: None)
+
+    indexer = StudioAskIndexer(driver=_FakeDriver(), max_videos_per_cycle=10)
+
+    # No real human delays.
+    async def _no_delay(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(indexer, "_human_delay", _no_delay)
+
+    # ask_about_video returns a successful AskResult for any id (no browser).
+    async def _fake_ask(video_id, *_a, **_k):
+        return AskResult(
+            video_id=video_id,
+            title=f"Title {video_id}",
+            response_text="Topics: a, b",
+            topics=["a", "b"],
+            timestamps=[{"time": "0:05", "topic": "T", "summary": "S"}],
+            success=True,
+        )
+
+    monkeypatch.setattr(indexer, "ask_about_video", _fake_ask)
+    return indexer, index_root
+
+
+def _load_artifacts(channel_dir: Path):
+    """Return {video_id: parsed_json} for all artifacts under a channel dir."""
+    if not channel_dir.exists():
+        return {}
+    out = {}
+    for p in channel_dir.glob("*.json"):
+        out[p.stem] = json.loads(p.read_text(encoding="utf-8"))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# 1. Shorts pass indexes shorts with content_type == "short".
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_shorts_pass_indexes_short_rows(monkeypatch, tmp_path):
+    indexer, index_root = _make_indexer(monkeypatch, tmp_path)
+
+    result = await indexer.index_channel_videos(
+        "UCSNTUXjAgpd4sgWYP0xoJgw",  # foundups
+        content_type="short",
+    )
+
+    # Navigated the SHORTS list, not the upload list.
+    assert any(u.endswith("/videos/short") for u in indexer.driver.navigated)
+    assert result["content_type"] == "short"
+    assert result["indexed"] == 2
+
+    arts = _load_artifacts(index_root / "foundups")
+    assert set(arts) == {"short001", "short002"}, "shorts must be indexed"
+    for vid, data in arts.items():
+        # NON-VACUITY: the gap on origin/main is that shorts are never indexed,
+        # so this artifact + label cannot exist there.
+        assert data["metadata"]["content_type"] == "short", vid
+
+
+# ---------------------------------------------------------------------------
+# 2. Upload pass still indexes long-form and SKIPS shorts.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_upload_pass_skips_shorts(monkeypatch, tmp_path):
+    indexer, index_root = _make_indexer(monkeypatch, tmp_path)
+
+    result = await indexer.index_channel_videos(
+        "UC-LSSlOZwpGIRIYihaz8zCw",  # move2japan
+        content_type="upload",
+    )
+
+    assert any(u.endswith("/videos/upload") for u in indexer.driver.navigated)
+    assert result["content_type"] == "upload"
+
+    arts = _load_artifacts(index_root / "move2japan")
+    # The stray short row ("shortX") on the upload list is skipped.
+    assert "shortX" not in arts
+    assert "long001" in arts
+    assert arts["long001"]["metadata"]["content_type"] == "upload"
+
+
+# ---------------------------------------------------------------------------
+# 3 & 4. Per-channel content_types decide which passes run.
+# ---------------------------------------------------------------------------
+
+def test_resolve_passes_short_only_channel():
+    # foundups registry content_types == ["short"] -> shorts pass only.
+    passes = studio_ask_indexer._resolve_index_passes("UCSNTUXjAgpd4sgWYP0xoJgw")
+    assert passes == ["short"]
+
+
+def test_resolve_passes_both_channel():
+    # move2japan registry content_types == ["short","upload"] -> both passes,
+    # normalized to upload-then-short.
+    passes = studio_ask_indexer._resolve_index_passes("UC-LSSlOZwpGIRIYihaz8zCw")
+    assert passes == ["upload", "short"]
+
+
+def test_resolve_passes_unknown_channel_defaults_both():
+    passes = studio_ask_indexer._resolve_index_passes("UC_does_not_exist")
+    assert passes == ["upload", "short"]
+
+
+@pytest.mark.asyncio
+async def test_cycle_runs_passes_per_content_types(monkeypatch, tmp_path):
+    """run_video_indexing_cycle: ["short"] chan -> shorts only; both -> both."""
+    index_root = tmp_path / "video_index"
+    monkeypatch.setattr(studio_ask_indexer, "INDEX_ROOT", index_root)
+    monkeypatch.setenv("YT_VIDEO_INDEXING_ENABLED", "true")
+    # No STOP file, no Gemini analysis pass.
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setattr(studio_ask_indexer, "_stop_active", lambda: False)
+    monkeypatch.setattr(studio_ask_indexer, "_consume_reindex_signal", lambda: False)
+    monkeypatch.setattr(studio_ask_indexer, "_count_indexed_by_channel", lambda root: {})
+
+    # Record every (channel_id, content_type) pass that actually runs.
+    calls = []
+
+    async def _fake_index(self, channel_id, force_reindex=False, content_type="upload"):
+        calls.append((channel_id, content_type))
+        return {
+            "channel_id": channel_id,
+            "content_type": content_type,
+            "indexed": 1,
+            "skipped": 0,
+            "failed": 0,
+            "videos": [f"{content_type}_vid"],
+        }
+
+    monkeypatch.setattr(StudioAskIndexer, "index_channel_videos", _fake_index)
+
+    foundups = "UCSNTUXjAgpd4sgWYP0xoJgw"   # ["short"]
+    move2japan = "UC-LSSlOZwpGIRIYihaz8zCw"  # ["short","upload"]
+
+    result = await studio_ask_indexer.run_video_indexing_cycle(
+        driver=_FakeDriver(),
+        channels=[foundups, move2japan],
+        max_videos_per_channel=5,
+    )
+
+    # foundups: shorts pass ONLY.
+    assert (foundups, "short") in calls
+    assert (foundups, "upload") not in calls
+    # move2japan: BOTH passes.
+    assert (move2japan, "upload") in calls
+    assert (move2japan, "short") in calls
+
+    # Merged per-channel summary keeps a per-pass breakdown.
+    assert set(result["channels"][foundups]["passes"]) == {"short"}
+    assert set(result["channels"][move2japan]["passes"]) == {"upload", "short"}
+
+
+@pytest.mark.asyncio
+async def test_cycle_one_pass_error_does_not_abort_other(monkeypatch, tmp_path):
+    """A failing pass is isolated; the sibling pass still indexes."""
+    monkeypatch.setattr(studio_ask_indexer, "INDEX_ROOT", tmp_path / "video_index")
+    monkeypatch.setenv("YT_VIDEO_INDEXING_ENABLED", "true")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setattr(studio_ask_indexer, "_stop_active", lambda: False)
+    monkeypatch.setattr(studio_ask_indexer, "_consume_reindex_signal", lambda: False)
+    monkeypatch.setattr(studio_ask_indexer, "_count_indexed_by_channel", lambda root: {})
+
+    async def _fake_index(self, channel_id, force_reindex=False, content_type="upload"):
+        if content_type == "upload":
+            raise RuntimeError("upload pass blew up")
+        return {
+            "channel_id": channel_id,
+            "content_type": content_type,
+            "indexed": 3,
+            "skipped": 0,
+            "failed": 0,
+            "videos": ["s1", "s2", "s3"],
+        }
+
+    monkeypatch.setattr(StudioAskIndexer, "index_channel_videos", _fake_index)
+
+    move2japan = "UC-LSSlOZwpGIRIYihaz8zCw"  # both passes
+    result = await studio_ask_indexer.run_video_indexing_cycle(
+        driver=_FakeDriver(),
+        channels=[move2japan],
+        max_videos_per_channel=5,
+    )
+
+    ch = result["channels"][move2japan]
+    # Shorts pass still produced its 3 videos despite the upload pass raising.
+    assert ch["indexed"] == 3
+    assert "upload" in ch["pass_errors"]


### PR DESCRIPTION
## The gap (file:line)
`index_channel_videos` navigated ONLY the long-form list
`https://studio.youtube.com/channel/{id}/videos/upload`
(`modules/ai_intelligence/video_indexer/src/studio_ask_indexer.py:2304`) and
EXPLICITLY skipped short rows
(`studio_ask_indexer.py:2380` -> `if "short" in row_text or "#short" in row_text: continue`).
Result: **Shorts were never indexed**, even for channels whose registry
`content_types` are shorts-only (foundups/antifafm = `["short"]`,
`youtube_channel_registry.py:81,98`). `run_video_indexing_cycle` selected
channels by browser only and never consulted `content_types`.

## The new Shorts pass + content_type metadata
- `index_channel_videos(..., content_type="upload")`: navigation now targets
  `videos/{content_type}` (same `videos/short` URL the scheduler uses,
  `youtube_shorts_scheduler/src/scheduler.py:1033`). The short-row skip is gated
  `if not is_shorts_pass`, so the `videos/upload` pass STILL skips shorts while
  the `videos/short` pass KEEPS short rows and indexes them through the SAME
  `ask_about_video` + `VideoIndexStore.save_index` path.
- `_ask_result_to_index_data(..., content_type="upload")` records
  `metadata.content_type` (`"short"` | `"upload"`) so shorts vs long-form
  artifacts are distinguishable downstream.

## Per-channel content_types
`run_video_indexing_cycle` runs the passes from each channel's registry
`content_types` via the new `_resolve_index_passes` helper:
- foundups / antifafm `["short"]` -> shorts pass only
- move2japan / undaodu `["short","upload"]` -> both passes (upload then short)
- unknown / absent content_types -> default to both

Per-pass `try/except` isolates a failing pass; `_merge_pass_results` sums
per-channel totals and keeps a `passes` / `pass_errors` breakdown.

## Existing-flag gated (no new public mutation)
Everything stays under the EXISTING `YT_VIDEO_INDEXING_ENABLED` gate
(`studio_ask_indexer.py:2488`). Indexing remains read-mostly JSON persistence.
No new flag, no scheduling/rotation change.

## MUST-FAIL proof (non-vacuity)
`tests/test_shorts_indexing_pass.py` (mock-only, no live browser, FakeDriver
returns rows by URL; `ask_about_video` and audio-observe monkeypatched). Run
against the pre-change `origin/main` source, **all 7 tests FAIL** (no short
artifact is ever produced; `_resolve_index_passes` does not exist). Against this
branch, all 7 PASS. The load-bearing assertion: the shorts pass writes artifacts
with `metadata.content_type == "short"`.

## Scope
Touched ONLY `studio_ask_indexer.py` (+ `run_video_indexing_cycle`), the new
test, and the module ModLog. OUT: scheduling, rotation fix, private, the
detector.

Worker-Lane: INDEX-SHORTS
Slice: INDEXER_SHORTS_PASS_PHASE1

🤖 Generated with [Claude Code](https://claude.com/claude-code)