### PR TITLE
fix(youtube_shorts_scheduler): long-form uses US-ET peak + per-channel tz (match shorts)

### DIFF
--- a/modules/platform_integration/youtube_shorts_scheduler/ModLog.md
+++ b/modules/platform_integration/youtube_shorts_scheduler/ModLog.md
@@ -1,5 +1,57 @@
 # YouTube Shorts Scheduler - ModLog
 
+## 2026-06-19 - Long-form uses US-ET peak + per-channel Studio-tz conversion (match shorts)
+
+**By:** 0102 (Worker-Lane LONGFORM-TZ)
+**Slice:** LONG_FORM_TZ_PEAK_WINDOW_PHASE1  (#847 follow-up; closes the #859 TZ gap)
+**WSP References:** WSP 22 (ModLog), WSP 49 (Structure), WSP 50 (Pre-Action), WSP 84 (Code Reuse: reuse `get_peak_slots_et` + `get_next_available_slot(channel_tz=...)` from #847, mirror the shorts path), WSP 97 (truth signaling)
+
+### Why (the long-form TZ gap, closed)
+The shorts path publishes at the US-ET peak for EVERY channel: `scheduler.py:90` uses
+`get_peak_slots_et()` and `scheduler.py:457-461` passes `channel_tz=self.channel_tz` into
+`tracker.get_next_available_slot(...)`, which DST-converts ET -> Studio-account tz
+(`schedule_tracker.py:251-252` via `peak_window.convert_et_to_channel_tz`, #847).
+The long-form path did NOT: `ContentPageScheduler.schedule_all_visible` called
+`tracker.get_next_available_slot(time_slots, max_per_day)` WITHOUT `channel_tz`
+(`content_page_scheduler.py:896` on origin/main `c1b475a06`), using the bare
+`_DEFAULT_TIME_SLOTS_FALLBACK` typed AS-IS in the account's own tz. For the Asia/Tokyo
+channels (`move2japan`/`undaodu`) that meant 08:00 ET was typed as 8:00 AM JST -- the WRONG
+US wall-clock (off the US peak). The #859 ModLog named exactly this follow-up.
+
+### What changed (minimal; mirror the shorts path)
+- **`content_page_scheduler.py` `schedule_all_visible`**: added `channel_tz: Optional[str] = None`
+  and forward it into `get_next_available_slot(time_slots, max_per_day, channel_tz=channel_tz)`.
+  When set, each ET base slot is DST-converted to the account-local wall-clock before the bare
+  time is typed (identity for ET accounts, shifted for Tokyo). Backwards compatible (None = old).
+- **`scripts/launch.py` long-form block**: now uses `get_peak_slots_et()` as the ET base slots
+  (was the bare per-account `time_slots`/`_DEFAULT_TIME_SLOTS_FALLBACK`) AND forwards
+  `channel_tz=<registry timezone>` into `schedule_all_visible`. The old `[VIDEO][TZ-WARN]`
+  "would publish off-peak" condition is REMOVED (the times are now correct); the
+  `[VIDEO][LONG-FORM] pass START` breadcrumb now reads `ET-peak->tz=<tz>` (info, not warning).
+  `_DEFAULT_TIME_SLOTS_FALLBACK` is retained for reference only with a do-not-reintroduce note.
+- **Master gate `YT_VIDEO_PROCESSING_ENABLED` unchanged & DEFAULT OFF** — enabling long-form
+  is still 012's call; this slice only makes the TIMES correct when enabled.
+
+### Tests (mock-only, non-vacuous, NO browser)
+`tests/test_long_form_tz_peak_window.py` (7 tests) drives the REAL `schedule_all_visible` with a
+REAL `ScheduleTracker`, stubbing only the DOM row-read + per-row Studio click flow to capture the
+time string that WOULD be typed:
+- Tokyo 08:00 ET -> ~21:00 JST (summer/EDT) and ~22:00 JST (winter/EST) -> DST proven (summer !=
+  winter); full-day peaks (08/12/20 ET) -> 21:00/01:00/09:00 JST in order;
+- NY 08:00 ET -> ~8:00 AM (identity); Tokyo vs NY diverge (PM vs AM) for the same ET slot;
+- MUST-FAIL probe: the no-`channel_tz` path types bare ET while the with-tz path types JST evening.
+**MUST-FAIL on origin/main:** verified -- all 7 fail there with
+`TypeError: schedule_all_visible() got an unexpected keyword argument 'channel_tz'` (the param
+does not exist pre-slice). The #859 `test_long_form_scheduling_enable.py` mock was updated to
+accept the new kwarg; it + `test_peak_window.py` + `test_scheduler.py` stay green (no regression).
+
+### Scope
+Touched: `content_page_scheduler.py` (`schedule_all_visible` channel_tz), `scripts/launch.py`
+(ET peaks + thread channel_tz, drop TZ-WARN), the new test, the #859 test mock, this ModLog.
+Did NOT touch: the enable flag, private path, indexing, shorts path, the rotation budget, the
+other `get_next_available_slot` call sites (`resolve_conflicts`/`thin_schedule` — calendar helpers,
+not the long-form launch path).
+
 ## 2026-06-19 - Enable long-form video scheduling for all 4 channels (flag-gated, default OFF)
 
 **By:** 0102 (Worker-Lane LONGFORM-SCHED)

--- a/modules/platform_integration/youtube_shorts_scheduler/scripts/launch.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/scripts/launch.py
@@ -19,6 +19,7 @@ Usage:
 import logging
 from typing import Optional, List
 from modules.infrastructure.shared_utilities.youtube_channel_registry import group_channels_by_browser, get_channel_by_key
+from modules.platform_integration.youtube_shorts_scheduler.src.peak_window import get_peak_slots_et
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +47,12 @@ BROWSER_PORTS = {
     "edge": 9223,
 }
 
-# Fallback time slots when channel config unavailable
+# LEGACY bare per-account fallback slots (overnight-heavy, NO US-peak / tz
+# awareness). RETAINED for reference only -- the long-form path now uses the
+# canonical US-ET peak slots (peak_window.get_peak_slots_et) DST-converted to
+# each channel's Studio-account tz, identical to the shorts path
+# (LONG_FORM_TZ_PEAK_WINDOW_PHASE1, #847 follow-up). Do not reintroduce these
+# as a long-form source; they publish off the US peak for non-ET channels.
 _DEFAULT_TIME_SLOTS_FALLBACK = [
     "12:00 AM", "3:00 AM", "6:00 AM", "9:00 AM",
     "12:00 PM", "3:00 PM", "6:00 PM", "9:00 PM",
@@ -1052,7 +1058,14 @@ def run_multi_channel_scheduler(
                             except Exception:
                                 pass
 
-                            vps_time_slots = (vps_config or {}).get("time_slots", _DEFAULT_TIME_SLOTS_FALLBACK)
+                            # LONG_FORM_TZ_PEAK_WINDOW_PHASE1: use the canonical
+                            # US-ET peak slots as the ET base (identical to the
+                            # shorts path scheduler.py:90), NOT the bare per-account
+                            # time_slots. These ET slots get DST-converted to the
+                            # channel account tz inside schedule_all_visible via the
+                            # channel_tz forwarded below (#847 conversion path), so
+                            # long-form publishes at the US peak for EVERY channel.
+                            vps_time_slots = get_peak_slots_et()
 
                             # LONG_FORM_SCHEDULING_ENABLE_PHASE1: per-channel per-pass
                             # ROTATION budget (mirror of the shorts #858 fairness fix).
@@ -1071,29 +1084,23 @@ def run_multi_channel_scheduler(
                                 vps_per_pass = 8
                             vps_max = min(max_per_channel, vps_per_pass)  # rotation-budgeted
 
-                            # LONG_FORM_SCHEDULING_ENABLE_PHASE1 TZ GAP (#847 follow-up):
-                            # ContentPageScheduler.schedule_all_visible() calls
-                            # tracker.get_next_available_slot(time_slots) WITHOUT channel_tz,
-                            # so these bare times are typed AS-IS in the Studio account's own
-                            # tz (no ET-peak -> account-tz conversion like the shorts path does
-                            # via scheduler.py self.channel_tz). For ET-account channels
-                            # (foundups/antifafm) this is tz-coherent; for Asia/Tokyo channels
-                            # (move2japan/undaodu) the wall-clock is NOT the US-ET peak. Full
-                            # correctness requires forwarding channel_tz through
-                            # schedule_all_visible (out of scope here: cps.py). Surface it.
-                            vps_tz = (vps_config or {}).get("timezone") or "as-is"
-                            if vps_tz not in ("America/New_York", "as-is"):
-                                print(
-                                    f"[VIDEO][TZ-WARN] {channel_key}: long-form slots typed "
-                                    f"naively in account tz '{vps_tz}' (NOT #847 ET-peak "
-                                    f"converted). Follow-up: forward channel_tz through "
-                                    f"schedule_all_visible before enabling for this channel."
-                                )
+                            # LONG_FORM_TZ_PEAK_WINDOW_PHASE1 (#847 follow-up, GAP CLOSED):
+                            # The channel's Studio-account tz (registry field) is now
+                            # forwarded into schedule_all_visible, which DST-converts the
+                            # canonical ET peak slots above to that account's local
+                            # wall-clock -- identical to the shorts path
+                            # (scheduler.py self.channel_tz). So long-form publishes at the
+                            # US-ET peak for EVERY channel: identity for ET-account channels
+                            # (foundups/antifafm), shifted for Asia/Tokyo (move2japan/undaodu).
+                            vps_channel_tz = (vps_config or {}).get("timezone")
+                            vps_tz = vps_channel_tz or "as-is"
 
                             # LONG_FORM_SCHEDULING_ENABLE_PHASE1 breadcrumb: pass is running.
+                            # tz here is now the ET->account conversion target, not a warning.
                             print(
                                 f"[VIDEO][LONG-FORM] {channel_key}: pass START "
-                                f"(budget={vps_max}/pass, max_per_day=4, tz={vps_tz})"
+                                f"(budget={vps_max}/pass, max_per_day=4, "
+                                f"ET-peak->tz={vps_tz})"
                             )
 
                             vps_results = asyncio.run(
@@ -1103,6 +1110,7 @@ def run_multi_channel_scheduler(
                                     max_per_day=4,  # Lower rate for long-form videos
                                     max_videos=vps_max,
                                     stop_event=stop_event,
+                                    channel_tz=vps_channel_tz,
                                 )
                             )
 

--- a/modules/platform_integration/youtube_shorts_scheduler/src/content_page_scheduler.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/src/content_page_scheduler.py
@@ -843,16 +843,26 @@ class ContentPageScheduler:
         max_per_day: int = 8,
         max_videos: int = 9999,
         stop_event=None,
+        channel_tz: Optional[str] = None,
     ) -> Dict:
         """
         Schedule all visible unlisted videos on the current content page.
 
         Args:
             tracker: ScheduleTracker instance for slot management
-            time_slots: List of base time slots like ["12:00 AM", "3:00 AM", ...]
+            time_slots: Canonical US-Eastern (ET) peak slots, e.g.
+                ["08:00", "12:00", "20:00"]. These describe the desired
+                US-audience publish time in ET (also accepts 12h "8:00 AM").
             max_per_day: Max videos per day
             max_videos: Max total videos to schedule
             stop_event: Optional threading.Event for cooperative abort
+            channel_tz: IANA tz of the channel's Studio account
+                (e.g. "Asia/Tokyo", "America/New_York"). When provided, each ET
+                base slot is converted (DST-aware) to that account's local
+                wall-clock before the bare time is typed into Studio, so
+                long-form publishes at the US-ET peak for EVERY channel -- the
+                same contract the shorts path uses (#847). When None the slot is
+                typed as-is (backwards compatible).
 
         Returns:
             Dict with scheduled count, errors, video details
@@ -892,8 +902,13 @@ class ContentPageScheduler:
                 results["total_skipped"] += 1
                 continue
 
-            # Get next available slot
-            slot = tracker.get_next_available_slot(time_slots, max_per_day)
+            # Get next available slot. Forward channel_tz so the canonical ET
+            # peak slot is DST-converted to the channel account's local
+            # wall-clock before typing (identity for ET-account channels;
+            # shifts for Asia/Tokyo etc.). Mirrors the shorts path (#847).
+            slot = tracker.get_next_available_slot(
+                time_slots, max_per_day, channel_tz=channel_tz
+            )
             if slot is None:
                 logger.warning("[CPS] No more available slots — stopping")
                 break

--- a/modules/platform_integration/youtube_shorts_scheduler/tests/test_long_form_scheduling_enable.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/tests/test_long_form_scheduling_enable.py
@@ -96,6 +96,7 @@ class _FakeContentPageScheduler:
     instances = 0                      # count constructions (flag-off must stay 0)
     schedule_calls = []                # list of (channel_key, max_videos)
     nav_calls = []                     # list of (channel_key, content_type)
+    tz_calls = []                      # list of (channel_key, channel_tz, time_slots)
 
     def __init__(self, driver):
         self.driver = driver
@@ -108,9 +109,11 @@ class _FakeContentPageScheduler:
         return True
 
     async def schedule_all_visible(self, tracker, time_slots, max_per_day=8,
-                                   max_videos=9999, stop_event=None):
+                                   max_videos=9999, stop_event=None,
+                                   channel_tz=None):
         ch = self._channel_key
         _FakeContentPageScheduler.schedule_calls.append((ch, max_videos))
+        _FakeContentPageScheduler.tz_calls.append((ch, channel_tz, list(time_slots)))
         scheduled = min(max_videos, _LONGFORM_BACKLOG)
         return {
             "total_scheduled": scheduled,
@@ -130,6 +133,7 @@ def _reset_recorders():
     _FakeContentPageScheduler.instances = 0
     _FakeContentPageScheduler.schedule_calls = []
     _FakeContentPageScheduler.nav_calls = []
+    _FakeContentPageScheduler.tz_calls = []
 
 
 @pytest.fixture

--- a/modules/platform_integration/youtube_shorts_scheduler/tests/test_long_form_tz_peak_window.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/tests/test_long_form_tz_peak_window.py
@@ -1,0 +1,279 @@
+"""
+Long-form (Videos-tab) US-ET peak + per-channel Studio-tz conversion tests.
+
+Slice: LONG_FORM_TZ_PEAK_WINDOW_PHASE1  (#847 follow-up)
+
+Model under test
+----------------
+Long-form videos target the US audience exactly like shorts do, so their peak
+publish times are the SAME canonical US-Eastern (ET) slots
+(peak_window.get_peak_slots_et() -> ["08:00", "12:00", "20:00"]). The scheduler
+types a BARE time string that YouTube Studio interprets in each channel's own
+account timezone, so an ET target must be DST-converted to the channel-local
+wall-clock before typing.
+
+Before this slice the long-form path
+(ContentPageScheduler.schedule_all_visible) called
+tracker.get_next_available_slot(time_slots, max_per_day) WITHOUT channel_tz, so
+the bare ET slot was typed AS-IS in the account tz. For an Asia/Tokyo channel
+(Move2Japan / UnDaoDu) that means 08:00 ET was typed as 8:00 AM JST -- the WRONG
+US wall-clock (off the US peak). This slice forwards channel_tz so the ET peak is
+converted to the channel-local equivalent (DST-aware), identical to the shorts
+path (scheduler.py self.channel_tz, #847).
+
+These tests are MOCK-ONLY (no browser, no daemon, no network, no models) and
+NON-VACUOUS. They drive the REAL ContentPageScheduler.schedule_all_visible with a
+REAL ScheduleTracker; only the DOM row-read and the per-row Studio click flow are
+stubbed (to capture the time string that WOULD be typed). They prove:
+  * a Tokyo channel types the JST-equivalent of the ET peak (summer AND winter),
+  * a NY channel types the ET peak as-is (identity),
+  * DST is handled (summer != winter JST wall-clock),
+  * MUST-FAIL: the OLD behavior (no channel_tz) types bare ET for Tokyo, which is
+    the wrong wall-clock -- so the with-tz path MUST differ from it.
+"""
+
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from modules.platform_integration.youtube_shorts_scheduler.src.content_page_scheduler import (
+    ContentPageScheduler,
+)
+from modules.platform_integration.youtube_shorts_scheduler.src.schedule_tracker import (
+    ScheduleTracker,
+    MAX_JITTER_STEPS,
+)
+from modules.platform_integration.youtube_shorts_scheduler.src.peak_window import (
+    get_peak_slots_et,
+)
+
+# Channel Studio-account timezones (verified in registry youtube_channel_registry).
+TOKYO_TZ = "Asia/Tokyo"           # Move2Japan, UnDaoDu
+NY_TZ = "America/New_York"        # FoundUps, antifaFM
+
+# DST probe dates: US Eastern observes DST roughly mid-Mar..early-Nov.
+SUMMER = datetime(2026, 7, 15)    # EDT = UTC-4 -> JST(+9) = +13h
+WINTER = datetime(2026, 1, 15)    # EST = UTC-5 -> JST(+9) = +14h
+
+
+def _to_24h(bare: str) -> str:
+    """Normalize a bare 12h time like '9:00 PM' to '21:00' for comparison."""
+    return datetime.strptime(bare.strip(), "%I:%M %p").strftime("%H:%M")
+
+
+def _hour24(bare: str) -> int:
+    """
+    Hour-of-day (0-23) from either a 12h '9:00 PM' string or a bare 24h '08:00'.
+    The no-tz path types the canonical 24h ET slot as-is (no jitter), so the
+    must-fail comparison must tolerate both forms.
+    """
+    s = bare.strip()
+    for fmt in ("%I:%M %p", "%H:%M"):
+        try:
+            return datetime.strptime(s, fmt).hour
+        except ValueError:
+            continue
+    raise ValueError(f"unparseable time: {bare!r}")
+
+
+def _within_jitter(actual_bare: str, base_bare: str) -> bool:
+    """True if actual is within +/- (MAX_JITTER_STEPS * 15min) of base."""
+    a = datetime.strptime(actual_bare.strip(), "%I:%M %p")
+    b = datetime.strptime(base_bare.strip(), "%I:%M %p")
+    return abs((a - b).total_seconds()) / 60.0 <= MAX_JITTER_STEPS * 15
+
+
+def _tracker():
+    """Real ScheduleTracker in a throwaway temp dir (no shared state)."""
+    return ScheduleTracker("UC_test_longform_tz", Path(tempfile.mkdtemp()))
+
+
+class _StubDom:
+    """Minimal DOM stand-in: only human_delay is exercised by schedule_all_visible."""
+
+    def human_delay(self, *a, **k):
+        return 0.0
+
+
+class _CapturingScheduler(ContentPageScheduler):
+    """
+    REAL ContentPageScheduler with ONLY the browser-touching seams stubbed:
+      * get_video_rows_with_data -> a fixed list of unlisted rows (no DOM),
+      * schedule_video_from_row -> captures the (date_str, time_str) that WOULD
+        be typed into Studio and returns True (no clicks).
+    Everything else -- including the slot allocation / channel_tz conversion in
+    schedule_all_visible + get_next_available_slot -- runs for real.
+    """
+
+    def __init__(self, n_rows: int):
+        # Do NOT call super().__init__ (it builds a DOM against a real driver).
+        self.driver = None
+        # Minimal DOM stub: schedule_all_visible calls dom.human_delay() between
+        # videos. Return 0 so the inter-video asyncio.sleep is a no-op.
+        self.dom = _StubDom()
+        self._n_rows = n_rows
+        self.typed = []  # list of (date_str, time_str)
+
+    def refresh_page(self):
+        # schedule_all_visible refreshes every 3rd schedule; no real browser here.
+        return None
+
+    def get_video_rows_with_data(self):
+        return [
+            {
+                "video_id": f"vid_{i}",
+                "title": f"Long-form {i}",
+                "visibility": "unlisted",
+                "row_element": object(),
+            }
+            for i in range(self._n_rows)
+        ]
+
+    async def schedule_video_from_row(self, row_element, date_str, time_str, video_id="unknown"):
+        self.typed.append((date_str, time_str))
+        return True
+
+
+async def _run(channel_tz, start_date, n_rows=1, max_per_day=4):
+    """
+    Drive the REAL schedule_all_visible with the ET peak slots + given channel_tz,
+    forcing the tracker's scheduling window to begin on `start_date` so the DST
+    branch under test is deterministic. Returns the list of typed time strings.
+    """
+    sched = _CapturingScheduler(n_rows=n_rows)
+    tracker = _tracker()
+    # Pin the allocation window so DST (summer/winter) is deterministic.
+    orig = tracker.get_next_available_slot
+
+    def pinned(time_slots, mpd=max_per_day, **kw):
+        return orig(time_slots, mpd, start_date=start_date, **kw)
+
+    tracker.get_next_available_slot = pinned  # type: ignore[assignment]
+
+    await sched.schedule_all_visible(
+        tracker=tracker,
+        time_slots=get_peak_slots_et(),
+        max_per_day=max_per_day,
+        max_videos=n_rows,
+        channel_tz=channel_tz,
+    )
+    return [t for _, t in sched.typed]
+
+
+# ---------------------------------------------------------------------------
+# 1. Tokyo channel: ET peak -> JST-equivalent (DST-aware).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_tokyo_morning_slot_summer_is_jst_evening_not_bare_8am():
+    # 08:00 ET (EDT, UTC-4) -> 21:00 JST. The long-form path MUST type ~9:00 PM,
+    # NOT the bare ET "8:00 AM".
+    typed = await _run(TOKYO_TZ, SUMMER, n_rows=1)
+    assert typed, "no slot was allocated"
+    t = typed[0]
+    assert _to_24h(t) != "08:00", (
+        f"REGRESSION: Tokyo 08:00 ET morning typed as bare ET time {t!r} "
+        f"(channel_tz not consulted -> wrong US wall-clock)"
+    )
+    assert _within_jitter(t, "9:00 PM"), (
+        f"Tokyo 08:00 ET (summer) expected ~9:00 PM JST, got {t!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tokyo_morning_slot_winter_is_one_hour_later_dst_aware():
+    # 08:00 ET (EST, UTC-5) -> 22:00 JST: one hour LATER than summer, proving the
+    # conversion is DST-aware (not a fixed offset).
+    typed = await _run(TOKYO_TZ, WINTER, n_rows=1)
+    assert typed
+    assert _within_jitter(typed[0], "10:00 PM"), (
+        f"Tokyo 08:00 ET (winter) expected ~10:00 PM JST, got {typed[0]!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tokyo_dst_summer_winter_diverge():
+    # The SAME ET morning target yields a DIFFERENT JST wall-clock across the DST
+    # boundary (21:00 summer vs 22:00 winter base). A naive/fixed-offset or
+    # bare-ET path would make these equal. Jitter (+/-30min) is bounded, so each
+    # output stays within jitter of its OWN base; the bases differ by 60min.
+    summer = await _run(TOKYO_TZ, SUMMER, n_rows=1)
+    winter = await _run(TOKYO_TZ, WINTER, n_rows=1)
+    assert _within_jitter(summer[0], "9:00 PM"), (
+        f"Tokyo summer expected ~21:00 JST base, got {summer[0]!r}"
+    )
+    assert _within_jitter(winter[0], "10:00 PM"), (
+        f"Tokyo winter expected ~22:00 JST base, got {winter[0]!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. NY channel: ET peak typed as-is (identity).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ny_morning_slot_is_typed_8am_identity():
+    # America/New_York Studio account == the ET canonical, so 08:00 ET stays 8 AM.
+    typed = await _run(NY_TZ, SUMMER, n_rows=1)
+    assert typed
+    assert _within_jitter(typed[0], "8:00 AM"), (
+        f"NY 08:00 ET morning expected ~8:00 AM (identity), got {typed[0]!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Cross-channel + MUST-FAIL proofs.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_tokyo_and_ny_diverge_for_same_et_morning_slot():
+    # tz is actually consulted: the same ET morning slot produces materially
+    # different typed times (PM in Tokyo, AM in NY).
+    tokyo = await _run(TOKYO_TZ, SUMMER, n_rows=1)
+    ny = await _run(NY_TZ, SUMMER, n_rows=1)
+    assert tokyo[0].split()[-1] == "PM", f"tokyo not PM: {tokyo[0]!r}"
+    assert ny[0].split()[-1] == "AM", f"ny not AM: {ny[0]!r}"
+
+
+@pytest.mark.asyncio
+async def test_must_fail_old_behavior_types_bare_et_for_tokyo():
+    """
+    MUST-FAIL proof. The OLD long-form path called get_next_available_slot
+    WITHOUT channel_tz (channel_tz=None), which types the bare ET slot in the
+    account tz. For a Tokyo channel that is 8:00 AM JST -- the WRONG US wall-clock.
+    The new with-tz behavior MUST differ. This test pins that the two paths are
+    NOT equal, so a regression that drops channel_tz forwarding re-collapses them
+    and FAILS.
+    """
+    old = await _run(None, SUMMER, n_rows=1)         # no channel_tz -> bare ET
+    new = await _run(TOKYO_TZ, SUMMER, n_rows=1)     # converted to JST
+
+    # The bare-ET (no-tz) path types the canonical 24h ET morning slot "08:00"
+    # as-is (it never reaches the 12h jitter path because convert is skipped),
+    # i.e. an 08:xx ET-morning wall-clock. The with-tz path converts to JST
+    # evening (~21:00 / 9 PM). An ET-morning vs JST-evening wall-clock can never
+    # collide -> robust proof the tz conversion changed the typed time.
+    assert _hour24(old[0]) == 8, (
+        f"baseline drifted: bare-ET (no tz) path expected the 08:00 ET morning "
+        f"slot, got {old[0]!r}"
+    )
+    assert _hour24(new[0]) != _hour24(old[0]) and 19 <= _hour24(new[0]) <= 23, (
+        f"NO-OP BUG: bare-ET={old[0]!r} with-tz={new[0]!r} did not diverge to JST "
+        f"evening -> channel_tz not forwarded through schedule_all_visible"
+    )
+
+
+@pytest.mark.asyncio
+async def test_full_day_of_peaks_converted_in_order_for_tokyo():
+    # Three ET peaks (08/12/20) -> three JST wall-clocks in order on one day
+    # (summer): 08:00 ET->21:00, 12:00 ET->01:00, 20:00 ET->09:00 JST. Each
+    # output is within bounded jitter (+/-30min) of its converted base, in order.
+    typed = await _run(TOKYO_TZ, SUMMER, n_rows=3, max_per_day=3)
+    assert len(typed) == 3, f"expected 3 slots, got {typed}"
+    expected_bases = ["9:00 PM", "1:00 AM", "9:00 AM"]  # 21:00 / 01:00 / 09:00 JST
+    for got, base in zip(typed, expected_bases):
+        assert _within_jitter(got, base), (
+            f"Tokyo ET peak did not convert to JST {base!r} (within jitter); got {got!r}"
+        )


### PR DESCRIPTION
## The long-form TZ gap (file:line)

Long-form (Videos-tab) scheduling typed bare time slots AS-IS in each Studio account's own timezone, so the Asia/Tokyo channels published off the US-ET peak.

- **Reference (shorts, correct):** `scheduler.py:90` uses `get_peak_slots_et()`; `scheduler.py:457-461` passes `channel_tz=self.channel_tz` into `tracker.get_next_available_slot(...)`, which DST-converts ET -> account tz (`schedule_tracker.py:251-252` via `peak_window.convert_et_to_channel_tz`, #847).
- **Gap (long-form):** `content_page_scheduler.py:896` (origin/main `c1b475a06`) called `tracker.get_next_available_slot(time_slots, max_per_day)` **without** `channel_tz`, using the bare `_DEFAULT_TIME_SLOTS_FALLBACK` (`launch.py:50,1055`) typed as-is. Entry: the `YT_VIDEO_PROCESSING_ENABLED` block at `launch.py:~1028-1107` (#859). For `move2japan`/`undaodu` (Asia/Tokyo) this meant 08:00 ET was typed as 8:00 AM JST — the wrong US wall-clock.

The #859 ModLog explicitly named this follow-up: `LONG_FORM_TZ_PEAK_WINDOW_PHASE1`.

## The fix (minimal, mirror shorts)

- **`content_page_scheduler.py`** — `schedule_all_visible` gains `channel_tz: Optional[str] = None` and forwards it: `get_next_available_slot(time_slots, max_per_day, channel_tz=channel_tz)`. When set, each ET base slot is DST-converted to the account-local wall-clock before the bare time is typed (identity for ET accounts, shifted for Tokyo). Backwards compatible (None = old behavior).
- **`launch.py` long-form block** — now uses `get_peak_slots_et()` as the ET base slots (was the bare per-account `time_slots`/`_DEFAULT_TIME_SLOTS_FALLBACK`) and forwards `channel_tz=<registry timezone>` into `schedule_all_visible`. The old `[VIDEO][TZ-WARN]` "would publish off-peak" condition is **removed** (times are now correct); the `[VIDEO][LONG-FORM] pass START` breadcrumb now reads `ET-peak->tz=<tz>`.
- **Master gate `YT_VIDEO_PROCESSING_ENABLED` unchanged & DEFAULT OFF** — enabling long-form is still 012's call; this slice only makes the TIMES correct when enabled.

## DST proof

Registry tz: `move2japan`/`undaodu` = `Asia/Tokyo`; `foundups`/`antifafm` = `America/New_York`.

- 08:00 ET (EDT, UTC-4, summer) -> **21:00 JST** (+13h)
- 08:00 ET (EST, UTC-5, winter) -> **22:00 JST** (+14h) — one hour later, proving DST-awareness (pytz, not a fixed offset)
- Full day (08/12/20 ET) -> 21:00 / 01:00 / 09:00 JST (summer), in order
- NY: 08:00 ET -> 8:00 AM (identity)

## MUST-FAIL

`tests/test_long_form_tz_peak_window.py` (7 tests, mock-only, no browser) drives the **REAL** `schedule_all_visible` with a **REAL** `ScheduleTracker`, stubbing only the DOM row-read + per-row Studio click flow to capture the time string that would be typed. Jitter-robust (`_within_jitter`, ±30min), mirroring `test_peak_window.py`.

Verified MUST-FAIL on origin/main: **all 7 fail** with `TypeError: schedule_all_visible() got an unexpected keyword argument 'channel_tz'` (the param does not exist pre-slice). There is also an in-test no-tz-vs-with-tz divergence probe (bare ET morning vs JST evening) so a regression that drops `channel_tz` forwarding re-collapses them and fails.

The #859 `test_long_form_scheduling_enable.py` mock was updated to accept the new kwarg and now records it; that suite + `test_peak_window.py` + `test_scheduler.py` stay green (no regression).

```
test_long_form_tz_peak_window.py ....... 7 passed
+ test_long_form_scheduling_enable.py + test_peak_window.py -> 30 passed
test_scheduler.py -> 34 passed, 2 skipped
```

## Scope

Touched ONLY: `content_page_scheduler.py` (`schedule_all_visible` channel_tz), `scripts/launch.py` (ET peaks + thread channel_tz, drop TZ-WARN), the new test, the #859 test mock, the module ModLog. Did NOT touch: the enable flag, private path, indexing, shorts path, the rotation budget, or the other `get_next_available_slot` call sites (`resolve_conflicts`/`thin_schedule` — calendar helpers, not the long-form launch path).

Worker-Lane: LONGFORM-TZ | Slice: LONG_FORM_TZ_PEAK_WINDOW_PHASE1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
