### PR TITLE
feat(youtube_shorts_scheduler): optionally schedule PRIVATE videos too (flag-gated, default off, private->public)

### DIFF
--- a/modules/platform_integration/youtube_shorts_scheduler/ModLog.md
+++ b/modules/platform_integration/youtube_shorts_scheduler/ModLog.md
@@ -1,5 +1,57 @@
 # YouTube Shorts Scheduler - ModLog
 
+## 2026-06-19 - Optionally schedule PRIVATE Shorts too (flag-gated, default-off, private->public)
+
+**By:** 0102 (Worker-Lane SCHED-PRIVATE)
+**Slice:** SHORTS_SCHEDULE_INCLUDE_PRIVATE_PHASE1
+**WSP References:** WSP 22 (ModLog), WSP 49 (Structure), WSP 50 (Pre-Action), WSP 84 (Code Reuse: the DOM/URL layer already accepts PRIVATE), WSP 97 (truth signaling / outward-action breadcrumb)
+
+### Why (the UNLISTED-only gap)
+The scheduling cycle only processed UNLISTED Shorts: `run_scheduling_cycle` navigated with
+`navigate_to_shorts_with_fallback(channel_id, "UNLISTED")` (was `scheduler.py:317`), the batch
+loop scraped via `get_unlisted_videos()` (was `scheduler.py:350/370`), and the edit-page guard
+rejected anything not `unlisted`/`unknown` (was `scheduler.py:502`). 012 also wants PRIVATE
+videos processed. Scheduling a PRIVATE video uses the YouTube Studio `PUBLISH_FROM_PRIVATE`
+schedule radio (`dom_automation.py:144-145,240,246`) -> the video PUBLISHES PUBLIC at its slot.
+That is OUTWARD-FACING, so the PRIVATE pass is **default-OFF** and opt-in only.
+
+### Phase 0 (verified on origin/main `47a6aa437`)
+- UNLISTED-only nav: `scheduler.py:317` (and re-navs `:366`, `:666`).
+- Scrape under UNLISTED filter: `get_unlisted_videos()` is UNLISTED-hardcoded -- guard
+  `ensure_visibility_filter("UNLISTED")` (`dom_automation.py:2522`) AND a JS row scan that
+  requires `\bunlisted\b` (`dom_automation.py:2537-2540`). It returns `[]` under a PRIVATE
+  filter, so it is NOT a drop-in private scraper.
+- Edit-page guard: `scheduler.py:502` `if edit_vis not in ("unlisted","unknown")` rejects
+  `private` (which `read_edit_page_visibility` returns at `dom_automation.py:1316-1317`).
+- DOM layer ALREADY supports PRIVATE for nav + filter + schedule:
+  `navigate_to_shorts_with_fallback(..., "PRIVATE")` (`dom_automation.py:1411-1437`, generic),
+  `ensure_visibility_filter("PRIVATE")` (`:1324`), PRIVATE chip/url markers (`:294,306`),
+  and the schedule radio IS `PUBLISH_FROM_PRIVATE` (private -> public). Confirmed.
+
+### What changed (minimal; scheduler.py ONLY)
+- **`_resolve_visibility_targets()`**: default `["UNLISTED"]`; when
+  `YT_SCHEDULE_INCLUDE_PRIVATE == "1"` returns `["UNLISTED","PRIVATE"]` (strict `=="1"`;
+  emits a warning that private->public is enabled). UNLISTED is always first.
+- **`_run_visibility_pass(target, ...)`**: extracted the existing navigate + continuous batch
+  loop verbatim, with the `"UNLISTED"` literal replaced by `target`. `run_scheduling_cycle`
+  now runs this loop ONCE PER TARGET. The single `self.tracker` is shared across passes, so the
+  per-day cap (3), peak window/tz, and rotation budget are SHARED (UNLISTED fills slots first,
+  PRIVATE continues into the remainder -- no per-channel budget doubling).
+- **`_scrape_videos_for_visibility(target)`**: UNLISTED delegates to the unchanged
+  `self.dom.get_unlisted_videos()`; PRIVATE scrapes rows scheduler-side via
+  `self.driver.execute_script` (mirrors the strict scan, keyed on `private`, excludes
+  scheduled rows) -- WITHOUT modifying the DOM/URL layer. Precedent: `_get_all_videos`
+  already scrapes scheduler-side.
+- **Edit-page guard relaxed**: accepts `private` ONLY when the active pass is PRIVATE; the
+  UNLISTED pass still rejects `private`.
+- **Outward breadcrumb**: per private video scheduled, logs
+  `[PRIVATE->PUBLIC] {video_id} scheduled to publish {date} {time}` (live + dry-run) so 012 can
+  review each private->public action. Default-off => zero private scheduling unless flagged.
+
+### Scope / follow-ups
+- OUT OF SCOPE: long-form private (note as follow-up), indexing, the detector, the long-form
+  path. The DOM/URL layer was NOT modified.
+
 ## 2026-06-19 - Long-form uses US-ET peak + per-channel Studio-tz conversion (match shorts)
 
 **By:** 0102 (Worker-Lane LONGFORM-TZ)

--- a/modules/platform_integration/youtube_shorts_scheduler/src/scheduler.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/src/scheduler.py
@@ -311,63 +311,276 @@ class YouTubeShortsScheduler:
         # Pre-cycle schedule report
         self.tracker.log_schedule_report()
 
+        # SHORTS_SCHEDULE_INCLUDE_PRIVATE_PHASE1: resolve the visibility targets.
+        # Default is UNLISTED-only. When YT_SCHEDULE_INCLUDE_PRIVATE=1 the cycle
+        # ALSO makes a PRIVATE pass. Scheduling a PRIVATE video uses the
+        # PUBLISH_FROM_PRIVATE schedule radio -> the video PUBLISHES PUBLIC at its
+        # slot. This is an OUTWARD-FACING action, so it is DEFAULT-OFF and 012 must
+        # opt in deliberately (each private schedule is logged with a
+        # [PRIVATE->PUBLIC] breadcrumb below).
+        visibility_targets = self._resolve_visibility_targets()
+        results["visibility_targets"] = visibility_targets
+
         try:
-            # Step 1: Navigate to unlisted Shorts (with fallback for robustness)
-            logger.info(f"[SCHEDULER] Navigating to unlisted Shorts for {self.channel_name}")
-            if not self.dom.navigate_to_shorts_with_fallback(self.channel_id, "UNLISTED"):
-                logger.error("[SCHEDULER] Failed to navigate to unlisted Shorts")
-                results["errors"].append({"error": "Navigation to unlisted Shorts failed"})
-                return results
-            filter_state = self.dom.read_visibility_filter_state()
-            logger.info(
-                f"[SCHEDULER] List filter state: detected={filter_state.get('detected')} "
-                f"chips={filter_state.get('chip_texts')}"
-            )
-            if filter_state.get("detected") == "SCHEDULED":
-                logger.error(
-                    "[SCHEDULER] Aborting cycle — Shorts list is on Scheduled/Has schedule, not Unlisted"
+            # Run the existing navigate + batch loop ONCE PER TARGET. The single
+            # self.tracker is shared across passes, so the per-day cap (3), the
+            # peak window/tz, and the rotation budget are shared: UNLISTED fills
+            # the available slots first, then PRIVATE continues into whatever
+            # remains (no per-channel budget doubling).
+            for target in visibility_targets:
+                aborted = await self._run_visibility_pass(
+                    target=target,
+                    max_videos=max_videos,
+                    update_metadata=update_metadata,
+                    results=results,
                 )
-                results["errors"].append({"error": "Wrong visibility filter: SCHEDULED"})
-                return results
-            await asyncio.sleep(2)  # Wait for page load
+                if aborted:
+                    # Navigation/filter failure for this target — stop the cycle.
+                    break
 
-            # Step 1.5: Set page size to 50 for larger batches (2026-01-28)
-            self.dom.set_page_size(50)
-            await asyncio.sleep(1)
+        except Exception as e:
+            logger.error(f"[SCHEDULER] Cycle error: {e}")
+            results["errors"].append({"error": str(e)})
 
-            # Step 2-4: CONTINUOUS PROCESSING LOOP (2026-01-28: Added for true "until complete")
-            # Process batches of videos until no unlisted remain
-            batch_num = 0
-            total_processed = 0
-            import os
-            sync_enabled = os.getenv("YT_SCHEDULER_DO_SYNC", "false").lower() in ("1", "true", "yes")
+        cycle_elapsed = _time.time() - cycle_start
+        results["finished_at"] = datetime.now().isoformat()
+        results["total_scheduled"] = len(results["scheduled"])
+        results["total_errors"] = len(results["errors"])
+        results["total_skipped"] = len(results["skipped"])
+        results["cycle_seconds"] = round(cycle_elapsed, 1)
 
-            while True:
+        # End-of-cycle report
+        n_ok = results["total_scheduled"]
+        n_err = results["total_errors"]
+        n_skip = results["total_skipped"]
+        logger.info(f"[SCHEDULER] ╔══ CYCLE COMPLETE: {self.channel_name} ══╗")
+        logger.info(f"[SCHEDULER] ║ Scheduled: {n_ok:>4} videos")
+        logger.info(f"[SCHEDULER] ║ Errors:    {n_err:>4}")
+        logger.info(f"[SCHEDULER] ║ Skipped:   {n_skip:>4}")
+        logger.info(f"[SCHEDULER] ║ Duration:  {cycle_elapsed:>7.1f}s")
+        if n_ok > 0:
+            avg = cycle_elapsed / n_ok
+            logger.info(f"[SCHEDULER] ║ Avg/video: {avg:>7.1f}s")
+            # Date spread
+            dates_used = set(v["date"] for v in results["scheduled"])
+            logger.info(f"[SCHEDULER] ║ Dates:     {len(dates_used):>4} unique days")
+            for d in sorted(dates_used):
+                vids_on_day = [v for v in results["scheduled"] if v["date"] == d]
+                times = ", ".join(v["time"] for v in vids_on_day)
+                logger.info(f"[SCHEDULER] ║   {d}: {times}")
+        logger.info(f"[SCHEDULER] ╚{'═' * 42}╝")
+
+        # Post-cycle schedule report (updated totals)
+        self.tracker.log_schedule_report()
+
+        # Post-cycle audit: verify scheduled state matches YouTube reality
+        # Enable with YT_SCHEDULER_POST_AUDIT=true (default: false — opt-in)
+        if os.getenv("YT_SCHEDULER_POST_AUDIT", "false").lower() in ("1", "true", "yes"):
+            try:
+                from .schedule_auditor import ScheduleAuditor
+                auditor = ScheduleAuditor(self.channel_key, self.driver)
+                auto_heal = os.getenv("YT_SCHEDULER_AUDIT_AUTO_HEAL", "true").lower() in ("1", "true", "yes")
+                audit_report = auditor.run_audit(auto_heal=auto_heal)
+                results["audit"] = {
+                    "healthy": audit_report.get("healthy", False),
+                    "false_positives": len(audit_report.get("false_positives", [])),
+                    "time_collisions": len(audit_report.get("time_collisions", [])),
+                    "healed": len(audit_report.get("healed", [])),
+                }
+                if not audit_report.get("healthy"):
+                    logger.warning(
+                        f"[SCHEDULER] Post-cycle audit found issues: "
+                        f"{len(audit_report.get('false_positives', []))} false positives, "
+                        f"{len(audit_report.get('time_collisions', []))} time collisions"
+                    )
+                    # G4: Emit breadcrumb for AI Overseer sentinel detection (Phase 3)
+                    try:
+                        from modules.communication.livechat.src.breadcrumb_telemetry import get_breadcrumb_telemetry
+                        telemetry = get_breadcrumb_telemetry()
+                        telemetry.store_breadcrumb(
+                            source_dae="youtube_shorts_scheduler",
+                            event_type="schedule_audit_unhealthy",
+                            message=f"Schedule audit failed for {self.channel_key}",
+                            phase="POST_AUDIT",
+                            metadata={
+                                "channel_key": self.channel_key,
+                                "channel_id": self.channel_id,
+                                "false_positives": len(audit_report.get("false_positives", [])),
+                                "time_collisions": len(audit_report.get("time_collisions", [])),
+                                "missing_from_tracker": len(audit_report.get("missing_from_tracker", [])),
+                                "auto_heal": auto_heal,
+                                "healed": len(audit_report.get("healed", [])),
+                            },
+                        )
+                    except Exception as bc_err:
+                        logger.debug(f"[SCHEDULER] Breadcrumb emission failed: {bc_err}")
+            except Exception as e:
+                logger.debug(f"[SCHEDULER] Post-cycle audit skipped: {e}")
+
+        return results
+
+    def _resolve_visibility_targets(self) -> List[str]:
+        """Resolve which list-visibility filters the cycle should process.
+
+        SHORTS_SCHEDULE_INCLUDE_PRIVATE_PHASE1.
+
+        Default: ["UNLISTED"] (unchanged behaviour). When the OUTWARD-FACING flag
+        YT_SCHEDULE_INCLUDE_PRIVATE is enabled (=="1"), a PRIVATE pass is appended:
+        ["UNLISTED", "PRIVATE"]. UNLISTED is always processed first so it consumes
+        the rotation budget before any private->public publishing occurs.
+
+        Scheduling a PRIVATE video uses the PUBLISH_FROM_PRIVATE radio, which
+        PUBLISHES it PUBLIC at the slot — hence default-OFF and deliberate opt-in.
+        """
+        if os.getenv("YT_SCHEDULE_INCLUDE_PRIVATE", "0") == "1":
+            logger.warning(
+                "[SCHEDULER] YT_SCHEDULE_INCLUDE_PRIVATE=1 — PRIVATE pass ENABLED. "
+                "Scheduling a PRIVATE Short PUBLISHES it PUBLIC at its slot "
+                "(PUBLISH_FROM_PRIVATE). Each one is logged [PRIVATE->PUBLIC]."
+            )
+            return ["UNLISTED", "PRIVATE"]
+        return ["UNLISTED"]
+
+    def _scrape_videos_for_visibility(self, target: str) -> List[Dict[str, str]]:
+        """Scrape the Shorts row list under the ACTIVE visibility filter.
+
+        SHORTS_SCHEDULE_INCLUDE_PRIVATE_PHASE1.
+
+        UNLISTED delegates to the unchanged DOM helper
+        ``self.dom.get_unlisted_videos()`` (which enforces the UNLISTED filter and
+        rejects Scheduled rows). The DOM layer has no PRIVATE row-scraper (it is
+        UNLISTED-hardcoded by design), so for the PRIVATE pass the scheduler scrapes
+        the rows itself via the driver — mirroring the strict row scan but keyed on
+        ``private`` — WITHOUT modifying the DOM/URL layer. The PRIVATE filter is
+        navigated + enforced by the existing generic
+        ``navigate_to_shorts_with_fallback(..., "PRIVATE")`` before this is called.
+        """
+        target = (target or "UNLISTED").upper()
+        if target == "UNLISTED":
+            return self.dom.get_unlisted_videos()
+
+        # PRIVATE pass: scheduler-side scrape under the already-applied PRIVATE
+        # filter. Pattern mirrors dom_automation.get_unlisted_videos but keyed on
+        # 'private' and excludes any row that already shows a schedule.
+        try:
+            scraped = self.driver.execute_script(
+                """
+                const rows = document.querySelectorAll('ytcp-video-row');
+                const out = [];
+                for (const row of rows) {
+                    const text = (row.textContent || '').toLowerCase();
+                    const hasPrivate = /\\bprivate\\b/.test(text);
+                    const hasScheduled = /\\bscheduled\\b/.test(text) || text.includes('has schedule');
+                    if (!hasPrivate) continue;
+                    if (hasScheduled) continue;
+                    const link = row.querySelector("a[href*='/video/']");
+                    if (!link) continue;
+                    const href = link.getAttribute('href') || '';
+                    const m = href.match(/\\/video\\/([^/?]+)/);
+                    if (!m) continue;
+                    out.push({
+                        video_id: m[1],
+                        title: (link.textContent || '').trim(),
+                        href: href,
+                    });
+                }
+                return out;
+                """
+            ) or []
+        except Exception as exc:
+            logger.error(f"[SCHEDULER] Private row scrape failed: {exc}")
+            return []
+
+        videos = [
+            {
+                "video_id": item.get("video_id"),
+                "title": item.get("title", ""),
+                "href": item.get("href", ""),
+            }
+            for item in scraped
+            if item.get("video_id")
+        ]
+        logger.info(f"[SCHEDULER] Private scrape: {len(videos)} videos under PRIVATE filter")
+        return videos
+
+    async def _run_visibility_pass(
+        self,
+        target: str,
+        max_videos: int,
+        update_metadata: bool,
+        results: Dict[str, Any],
+    ) -> bool:
+        """Run the navigate + continuous batch loop for ONE visibility target.
+
+        SHORTS_SCHEDULE_INCLUDE_PRIVATE_PHASE1: extracted verbatim from the
+        original UNLISTED-only cycle body, with the hard-coded "UNLISTED" literal
+        replaced by ``target`` and the row scrape delegated to
+        ``_scrape_videos_for_visibility(target)``. The per-day cap, peak window/tz,
+        and rotation budget come from the shared ``self.tracker`` and are therefore
+        shared across targets.
+
+        Returns:
+            True if the pass aborted on a navigation/filter failure (caller should
+            stop the cycle), False otherwise.
+        """
+        is_private = (target or "").upper() == "PRIVATE"
+
+        # Step 1: Navigate to the target-visibility Shorts (with fallback).
+        logger.info(f"[SCHEDULER] Navigating to {target} Shorts for {self.channel_name}")
+        if not self.dom.navigate_to_shorts_with_fallback(self.channel_id, target):
+            logger.error(f"[SCHEDULER] Failed to navigate to {target} Shorts")
+            results["errors"].append({"error": f"Navigation to {target} Shorts failed"})
+            return True
+        filter_state = self.dom.read_visibility_filter_state()
+        logger.info(
+            f"[SCHEDULER] List filter state: detected={filter_state.get('detected')} "
+            f"chips={filter_state.get('chip_texts')}"
+        )
+        if filter_state.get("detected") == "SCHEDULED":
+            logger.error(
+                f"[SCHEDULER] Aborting {target} pass — Shorts list is on "
+                f"Scheduled/Has schedule, not {target}"
+            )
+            results["errors"].append({"error": "Wrong visibility filter: SCHEDULED"})
+            return True
+        await asyncio.sleep(2)  # Wait for page load
+
+        # Step 1.5: Set page size to 50 for larger batches (2026-01-28)
+        self.dom.set_page_size(50)
+        await asyncio.sleep(1)
+
+        # Step 2-4: CONTINUOUS PROCESSING LOOP (2026-01-28: Added for true "until complete")
+        # Process batches of videos until none remain under this filter.
+        batch_num = 0
+        total_processed = 0
+        sync_enabled = os.getenv("YT_SCHEDULER_DO_SYNC", "false").lower() in ("1", "true", "yes")
+
+        while True:
                 batch_num += 1
                 logger.info(f"[SCHEDULER] === BATCH {batch_num} ===")
 
-                # Step 2: Get unlisted videos for this batch
-                unlisted = self.dom.get_unlisted_videos()
-                logger.info(f"[SCHEDULER] Found {len(unlisted)} unlisted videos in batch {batch_num}")
+                # Step 2: Get videos for this batch under the active filter.
+                unlisted = self._scrape_videos_for_visibility(target)
+                logger.info(f"[SCHEDULER] Found {len(unlisted)} {target} videos in batch {batch_num}")
 
                 if not unlisted:
                     if batch_num == 1:
-                        results["message"] = "No unlisted videos found"
+                        results["message"] = f"No {target} videos found"
                     else:
-                        results["message"] = f"All unlisted videos processed after {batch_num - 1} batches"
-                    logger.info(f"[SCHEDULER] No more unlisted videos - continuous processing complete")
+                        results["message"] = f"All {target} videos processed after {batch_num - 1} batches"
+                    logger.info(f"[SCHEDULER] No more {target} videos - continuous processing complete")
                     break
 
                 # Step 3: Sync existing scheduled videos (disabled by default)
                 if batch_num == 1:  # Only sync on first batch
                     await self._sync_scheduled_videos()
                     if sync_enabled:
-                        logger.info("[SCHEDULER] Returning to unlisted Shorts after sync...")
-                        if not self.dom.navigate_to_shorts_with_fallback(self.channel_id, "UNLISTED"):
-                            logger.warning("[SCHEDULER] Could not return to unlisted Shorts, continuing with cached list")
+                        logger.info(f"[SCHEDULER] Returning to {target} Shorts after sync...")
+                        if not self.dom.navigate_to_shorts_with_fallback(self.channel_id, target):
+                            logger.warning(f"[SCHEDULER] Could not return to {target} Shorts, continuing with cached list")
                         await asyncio.sleep(2)
                         # Re-fetch after returning
-                        unlisted = self.dom.get_unlisted_videos()
+                        unlisted = self._scrape_videos_for_visibility(target)
 
                 # Step 4: Process each video in this batch
                 processed = 0
@@ -473,6 +686,13 @@ class YouTubeShortsScheduler:
 
                         if self.dry_run:
                             logger.info(f"[DRY RUN] Would schedule {video_id} for {date_str} at {time_str}")
+                            # SHORTS_SCHEDULE_INCLUDE_PRIVATE_PHASE1: surface the
+                            # outward private->public action in dry-run too.
+                            if is_private:
+                                logger.warning(
+                                    f"[PRIVATE->PUBLIC] {video_id} scheduled to publish "
+                                    f"{date_str} {time_str} (dry_run)"
+                                )
                             results["scheduled"].append({
                                 "video_id": video_id,
                                 "date": date_str,
@@ -499,9 +719,17 @@ class YouTubeShortsScheduler:
                                 "reason": "Already Scheduled on YouTube (not Unlisted)",
                             })
                             continue
-                        if edit_vis not in ("unlisted", "unknown"):
+                        # SHORTS_SCHEDULE_INCLUDE_PRIVATE_PHASE1: accept 'private' on
+                        # the edit page when this is the PRIVATE pass, so a private
+                        # video isn't rejected as "wrong visibility". Otherwise the
+                        # guard is unchanged (unlisted/unknown only).
+                        allowed_vis = ("unlisted", "unknown")
+                        if is_private:
+                            allowed_vis = ("unlisted", "unknown", "private")
+                        if edit_vis not in allowed_vis:
+                            expected = "Private" if is_private else "Unlisted"
                             logger.warning(
-                                f"[SCHEDULER] SKIP {video_id}: visibility={edit_vis} (expected Unlisted)"
+                                f"[SCHEDULER] SKIP {video_id}: visibility={edit_vis} (expected {expected})"
                             )
                             results["skipped"].append({
                                 "video_id": video_id,
@@ -523,6 +751,16 @@ class YouTubeShortsScheduler:
 
                         if success:
                             self.tracker.increment(date_str, video_id)
+
+                            # SHORTS_SCHEDULE_INCLUDE_PRIVATE_PHASE1: per-private-video
+                            # OUTWARD-FACING breadcrumb. Scheduling a PRIVATE Short via
+                            # PUBLISH_FROM_PRIVATE PUBLISHES it PUBLIC at the slot, so 012
+                            # gets one clear log line per private->public action to review.
+                            if is_private:
+                                logger.warning(
+                                    f"[PRIVATE->PUBLIC] {video_id} scheduled to publish "
+                                    f"{date_str} {time_str}"
+                                )
 
                             # Update local index JSON with scheduling + description sync (best-effort)
                             try:
@@ -661,94 +899,16 @@ class YouTubeShortsScheduler:
                     logger.info(f"[SCHEDULER] Reached max_videos limit ({max_videos}), stopping")
                     break
 
-                # Navigate back to unlisted Shorts list for next batch
-                logger.info("[SCHEDULER] Navigating back to unlisted Shorts for next batch...")
-                if not self.dom.navigate_to_shorts_with_fallback(self.channel_id, "UNLISTED"):
+                # Navigate back to the target-visibility Shorts list for next batch
+                logger.info(f"[SCHEDULER] Navigating back to {target} Shorts for next batch...")
+                if not self.dom.navigate_to_shorts_with_fallback(self.channel_id, target):
                     logger.warning("[SCHEDULER] Could not navigate back, attempting back button...")
                     self.dom.click_back_to_shorts_list()
                 await asyncio.sleep(2)
                 # Loop continues to get next batch
 
-        except Exception as e:
-            logger.error(f"[SCHEDULER] Cycle error: {e}")
-            results["errors"].append({"error": str(e)})
-
-        cycle_elapsed = _time.time() - cycle_start
-        results["finished_at"] = datetime.now().isoformat()
-        results["total_scheduled"] = len(results["scheduled"])
-        results["total_errors"] = len(results["errors"])
-        results["total_skipped"] = len(results["skipped"])
-        results["cycle_seconds"] = round(cycle_elapsed, 1)
-
-        # End-of-cycle report
-        n_ok = results["total_scheduled"]
-        n_err = results["total_errors"]
-        n_skip = results["total_skipped"]
-        logger.info(f"[SCHEDULER] ╔══ CYCLE COMPLETE: {self.channel_name} ══╗")
-        logger.info(f"[SCHEDULER] ║ Scheduled: {n_ok:>4} videos")
-        logger.info(f"[SCHEDULER] ║ Errors:    {n_err:>4}")
-        logger.info(f"[SCHEDULER] ║ Skipped:   {n_skip:>4}")
-        logger.info(f"[SCHEDULER] ║ Duration:  {cycle_elapsed:>7.1f}s")
-        if n_ok > 0:
-            avg = cycle_elapsed / n_ok
-            logger.info(f"[SCHEDULER] ║ Avg/video: {avg:>7.1f}s")
-            # Date spread
-            dates_used = set(v["date"] for v in results["scheduled"])
-            logger.info(f"[SCHEDULER] ║ Dates:     {len(dates_used):>4} unique days")
-            for d in sorted(dates_used):
-                vids_on_day = [v for v in results["scheduled"] if v["date"] == d]
-                times = ", ".join(v["time"] for v in vids_on_day)
-                logger.info(f"[SCHEDULER] ║   {d}: {times}")
-        logger.info(f"[SCHEDULER] ╚{'═' * 42}╝")
-
-        # Post-cycle schedule report (updated totals)
-        self.tracker.log_schedule_report()
-
-        # Post-cycle audit: verify scheduled state matches YouTube reality
-        # Enable with YT_SCHEDULER_POST_AUDIT=true (default: false — opt-in)
-        if os.getenv("YT_SCHEDULER_POST_AUDIT", "false").lower() in ("1", "true", "yes"):
-            try:
-                from .schedule_auditor import ScheduleAuditor
-                auditor = ScheduleAuditor(self.channel_key, self.driver)
-                auto_heal = os.getenv("YT_SCHEDULER_AUDIT_AUTO_HEAL", "true").lower() in ("1", "true", "yes")
-                audit_report = auditor.run_audit(auto_heal=auto_heal)
-                results["audit"] = {
-                    "healthy": audit_report.get("healthy", False),
-                    "false_positives": len(audit_report.get("false_positives", [])),
-                    "time_collisions": len(audit_report.get("time_collisions", [])),
-                    "healed": len(audit_report.get("healed", [])),
-                }
-                if not audit_report.get("healthy"):
-                    logger.warning(
-                        f"[SCHEDULER] Post-cycle audit found issues: "
-                        f"{len(audit_report.get('false_positives', []))} false positives, "
-                        f"{len(audit_report.get('time_collisions', []))} time collisions"
-                    )
-                    # G4: Emit breadcrumb for AI Overseer sentinel detection (Phase 3)
-                    try:
-                        from modules.communication.livechat.src.breadcrumb_telemetry import get_breadcrumb_telemetry
-                        telemetry = get_breadcrumb_telemetry()
-                        telemetry.store_breadcrumb(
-                            source_dae="youtube_shorts_scheduler",
-                            event_type="schedule_audit_unhealthy",
-                            message=f"Schedule audit failed for {self.channel_key}",
-                            phase="POST_AUDIT",
-                            metadata={
-                                "channel_key": self.channel_key,
-                                "channel_id": self.channel_id,
-                                "false_positives": len(audit_report.get("false_positives", [])),
-                                "time_collisions": len(audit_report.get("time_collisions", [])),
-                                "missing_from_tracker": len(audit_report.get("missing_from_tracker", [])),
-                                "auto_heal": auto_heal,
-                                "healed": len(audit_report.get("healed", [])),
-                            },
-                        )
-                    except Exception as bc_err:
-                        logger.debug(f"[SCHEDULER] Breadcrumb emission failed: {bc_err}")
-            except Exception as e:
-                logger.debug(f"[SCHEDULER] Post-cycle audit skipped: {e}")
-
-        return results
+        # Pass completed normally (not aborted).
+        return False
 
     async def _sync_scheduled_videos(self):
         """Sync tracker with actual YouTube scheduled videos.

--- a/modules/platform_integration/youtube_shorts_scheduler/tests/TestModLog.md
+++ b/modules/platform_integration/youtube_shorts_scheduler/tests/TestModLog.md
@@ -1,5 +1,29 @@
 # YouTube Shorts Scheduler - TestModLog
 
+## 2026-06-19 - test_schedule_include_private: flag-gated PRIVATE pass (mock-only, MUST-FAIL proven)
+
+**By:** 0102 (Worker-Lane SCHED-PRIVATE)
+**Slice:** SHORTS_SCHEDULE_INCLUDE_PRIVATE_PHASE1
+**File:** `tests/test_schedule_include_private.py` (11 tests, mock-only, NO live browser)
+
+### Coverage
+- Resolver: default `["UNLISTED"]`; `=="1"` -> `["UNLISTED","PRIVATE"]`; non-`"1"` stays off.
+- Flag OFF -> only the UNLISTED pass runs: `navigate_to_shorts_with_fallback` called with
+  `"UNLISTED"` and NEVER `"PRIVATE"`; no private video scheduled.
+- Flag ON -> both UNLISTED and PRIVATE passes run (navigate called with each); both videos
+  scheduled; `[PRIVATE->PUBLIC]` log fires exactly once per private video (1-video and
+  2-video cases).
+- Edit-page guard: accepts `private` on the PRIVATE pass (non-dry-run, p1 scheduled), still
+  REJECTS `private` on the UNLISTED pass (u1 skipped "Wrong visibility").
+
+### Non-vacuity (MUST-FAIL proven via mutation)
+- Forcing the resolver to always include PRIVATE (default-off broken) -> all 5 OFF-guard tests
+  FAIL, incl. `test_flag_off_never_navigates_private` (navigate called with PRIVATE while off).
+- Removing the edit-guard relax -> `test_edit_guard_accepts_private_on_private_pass` FAILS
+  (p1 rejected), while the unlisted-pass rejection test still passes.
+- Result with code intact: 11 passed. Full module suite (with `test_scheduler.py`): 45 passed,
+  2 skipped (live-browser).
+
 ## 2026-06-19 - shorts_live_schedule_signal: live "Has schedule" count + view signal (mock-only)
 
 **By:** 0102 (Worker-Lane LIVE-SIGNAL)

--- a/modules/platform_integration/youtube_shorts_scheduler/tests/test_schedule_include_private.py
+++ b/modules/platform_integration/youtube_shorts_scheduler/tests/test_schedule_include_private.py
@@ -1,0 +1,321 @@
+"""
+Mock-only tests for SHORTS_SCHEDULE_INCLUDE_PRIVATE_PHASE1.
+
+Proves the flag-gated PRIVATE pass on YouTubeShortsScheduler.run_scheduling_cycle:
+
+  * flag OFF (default) -> ONLY the UNLISTED pass runs (navigate is called with
+    "UNLISTED" and NEVER with "PRIVATE").  <-- the MUST-FAIL guard
+  * flag ON  -> BOTH the UNLISTED and PRIVATE passes run (navigate called with
+    each), and a [PRIVATE->PUBLIC] log fires per private video scheduled.
+  * the edit-page visibility guard ACCEPTS "private" only when the private pass
+    is active, and still REJECTS it on the unlisted pass.
+
+NO live browser: self.driver / self.dom / self.tracker are mocks. The scheduler
+is built with __new__ so __init__ (which connects config) is bypassed and only the
+attributes the cycle touches are wired by hand.
+
+NON-VACUITY: test_flag_off_never_navigates_private FAILS if the PRIVATE pass runs
+while the flag is off (it asserts navigate is NEVER called with PRIVATE). Reverting
+_resolve_visibility_targets to always include PRIVATE makes that test fail.
+"""
+
+import asyncio
+import logging
+import os
+
+import pytest
+
+from modules.platform_integration.youtube_shorts_scheduler.src.scheduler import (
+    YouTubeShortsScheduler,
+)
+
+
+class _FakeTracker:
+    """Minimal stand-in for ScheduleTracker.
+
+    Hands out a unique slot per call (so the loop never thinks slots are
+    exhausted) and records increments. Shared across passes, exactly like the
+    real single self.tracker.
+    """
+
+    def __init__(self):
+        self.increments = []
+        self._scheduled_ids = set()
+        self._n = 0
+
+    def log_schedule_report(self):
+        pass
+
+    def is_video_scheduled(self, video_id):
+        return video_id in self._scheduled_ids
+
+    def get_next_available_slot(self, time_slots, max_per_day, channel_tz=None):
+        self._n += 1
+        # Distinct date per allocation so the per-day cap never short-circuits
+        # the test (the cap itself is exercised by the dedicated tracker tests).
+        return (f"Jan {self._n:02d}, 2026", "5:30 AM")
+
+    def increment(self, date_str, video_id):
+        self.increments.append((date_str, video_id))
+        self._scheduled_ids.add(video_id)
+
+    def remove_video(self, video_id):
+        self._scheduled_ids.discard(video_id)
+
+
+class _RecordingDOM:
+    """Mock DOM that records navigate_to_shorts_with_fallback visibility args.
+
+    get_unlisted_videos returns the UNLISTED roster ONCE then empties (so the
+    continuous batch loop terminates). The scheduler's own private scrape reads
+    self.driver.execute_script, which we stub to return the PRIVATE roster once.
+    """
+
+    def __init__(self, unlisted_rows, private_rows, edit_vis="unlisted"):
+        self.navigate_calls = []  # list of visibility strings
+        self._unlisted = list(unlisted_rows)
+        self._unlisted_served = False
+        self._edit_vis = edit_vis
+
+    # --- navigation / filter ---
+    def navigate_to_shorts_with_fallback(self, channel_id, visibility, use_ui_tars=True):
+        self.navigate_calls.append(visibility)
+        return True
+
+    def read_visibility_filter_state(self):
+        return {"detected": None, "chip_texts": []}
+
+    def set_page_size(self, n):
+        pass
+
+    def click_back_to_shorts_list(self):
+        pass
+
+    # --- UNLISTED scrape (delegated to by the scheduler for the unlisted pass) ---
+    def get_unlisted_videos(self):
+        if self._unlisted_served:
+            return []
+        self._unlisted_served = True
+        return list(self._unlisted)
+
+    # --- edit page / scheduling ---
+    def navigate_to_video(self, video_id):
+        pass
+
+    def read_edit_page_visibility(self):
+        return self._edit_vis
+
+    def schedule_video(self, date_str, time_str):
+        return True
+
+    def human_delay(self, base, variance):
+        return 0.0
+
+
+class _FakeDriver:
+    """Stubs execute_script for the scheduler-side PRIVATE row scrape.
+
+    Returns the private roster once (per PRIVATE navigation), then []. The
+    scheduler calls execute_script(<private scrape JS>); we ignore the JS text
+    and serve the roster based on the active filter recorded by the DOM mock.
+    """
+
+    def __init__(self, dom, private_rows):
+        self._dom = dom
+        self._private = list(private_rows)
+        self._private_served = False
+
+    def execute_script(self, script, *args):
+        # Only the private scrape uses execute_script in the cycle path.
+        if self._private_served:
+            return []
+        self._private_served = True
+        return list(self._private)
+
+
+def _make_scheduler(unlisted_rows, private_rows, dry_run=True, edit_vis="unlisted"):
+    s = YouTubeShortsScheduler.__new__(YouTubeShortsScheduler)
+    s.channel_key = "move2japan"
+    s.channel_id = "UC_TEST"
+    s.channel_name = "TestChannel"
+    s.channel_tz = None
+    s.time_slots = ["5:30 AM"]
+    s.max_per_day = 3
+    s.dry_run = dry_run
+    s.tracker = _FakeTracker()
+    dom = _RecordingDOM(unlisted_rows, private_rows, edit_vis=edit_vis)
+    s.dom = dom
+    s.driver = _FakeDriver(dom, private_rows)
+    # ensure_healthy_connection() is called at cycle start; force it healthy.
+    s.ensure_healthy_connection = lambda: True
+    return s
+
+
+def _run(s, **kwargs):
+    return asyncio.run(s.run_scheduling_cycle(update_metadata=False, **kwargs))
+
+
+@pytest.fixture(autouse=True)
+def _clear_flag(monkeypatch):
+    monkeypatch.delenv("YT_SCHEDULE_INCLUDE_PRIVATE", raising=False)
+    # Keep optional side-channels off for deterministic mock runs.
+    monkeypatch.delenv("YT_SCHEDULER_DO_SYNC", raising=False)
+    monkeypatch.delenv("YT_SCHEDULER_POST_AUDIT", raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Flag resolution (unit)
+# ---------------------------------------------------------------------------
+
+def test_resolve_targets_default_unlisted_only():
+    s = YouTubeShortsScheduler.__new__(YouTubeShortsScheduler)
+    assert s._resolve_visibility_targets() == ["UNLISTED"]
+
+
+def test_resolve_targets_flag_on(monkeypatch):
+    monkeypatch.setenv("YT_SCHEDULE_INCLUDE_PRIVATE", "1")
+    s = YouTubeShortsScheduler.__new__(YouTubeShortsScheduler)
+    assert s._resolve_visibility_targets() == ["UNLISTED", "PRIVATE"]
+
+
+def test_resolve_targets_flag_non_one_is_off(monkeypatch):
+    # Spec is strict equality to "1"; anything else stays UNLISTED-only.
+    monkeypatch.setenv("YT_SCHEDULE_INCLUDE_PRIVATE", "true")
+    s = YouTubeShortsScheduler.__new__(YouTubeShortsScheduler)
+    assert s._resolve_visibility_targets() == ["UNLISTED"]
+
+
+# ---------------------------------------------------------------------------
+# Flag OFF -> UNLISTED-only (MUST-FAIL guard)
+# ---------------------------------------------------------------------------
+
+def test_flag_off_runs_only_unlisted_pass():
+    s = _make_scheduler(
+        unlisted_rows=[{"video_id": "u1", "title": "U one"}],
+        private_rows=[{"video_id": "p1", "title": "P one"}],
+    )
+    results = _run(s)
+    assert results["visibility_targets"] == ["UNLISTED"]
+    # navigate called with UNLISTED, NEVER with PRIVATE
+    assert "UNLISTED" in s.dom.navigate_calls
+    assert "PRIVATE" not in s.dom.navigate_calls
+
+
+def test_flag_off_never_navigates_private():
+    """MUST-FAIL guard: if the private pass ever runs while the flag is off,
+    navigate would be called with 'PRIVATE' and this assertion fails."""
+    s = _make_scheduler(
+        unlisted_rows=[{"video_id": "u1", "title": "U one"}],
+        private_rows=[{"video_id": "p1", "title": "P one"}],
+    )
+    _run(s)
+    assert s.dom.navigate_calls.count("PRIVATE") == 0
+
+
+def test_flag_off_no_private_scheduled():
+    s = _make_scheduler(
+        unlisted_rows=[{"video_id": "u1", "title": "U one"}],
+        private_rows=[{"video_id": "p1", "title": "P one"}],
+    )
+    results = _run(s)
+    scheduled_ids = {v["video_id"] for v in results["scheduled"]}
+    assert scheduled_ids == {"u1"}
+    assert "p1" not in scheduled_ids
+
+
+# ---------------------------------------------------------------------------
+# Flag ON -> UNLISTED + PRIVATE passes
+# ---------------------------------------------------------------------------
+
+def test_flag_on_runs_both_passes(monkeypatch):
+    monkeypatch.setenv("YT_SCHEDULE_INCLUDE_PRIVATE", "1")
+    s = _make_scheduler(
+        unlisted_rows=[{"video_id": "u1", "title": "U one"}],
+        private_rows=[{"video_id": "p1", "title": "P one"}],
+    )
+    results = _run(s)
+    assert results["visibility_targets"] == ["UNLISTED", "PRIVATE"]
+    assert "UNLISTED" in s.dom.navigate_calls
+    assert "PRIVATE" in s.dom.navigate_calls
+    scheduled_ids = {v["video_id"] for v in results["scheduled"]}
+    assert {"u1", "p1"} <= scheduled_ids
+
+
+def test_flag_on_private_to_public_log_fires(monkeypatch, caplog):
+    monkeypatch.setenv("YT_SCHEDULE_INCLUDE_PRIVATE", "1")
+    s = _make_scheduler(
+        unlisted_rows=[{"video_id": "u1", "title": "U one"}],
+        private_rows=[{"video_id": "p1", "title": "P one"}],
+    )
+    with caplog.at_level(logging.WARNING):
+        _run(s)
+    breadcrumbs = [
+        r.getMessage() for r in caplog.records
+        if r.getMessage().startswith("[PRIVATE->PUBLIC]")
+    ]
+    assert len(breadcrumbs) == 1, breadcrumbs
+    assert "p1" in breadcrumbs[0]
+    # No breadcrumb for the unlisted video.
+    assert all("u1" not in b for b in breadcrumbs)
+
+
+def test_flag_on_log_fires_once_per_private_video(monkeypatch, caplog):
+    monkeypatch.setenv("YT_SCHEDULE_INCLUDE_PRIVATE", "1")
+    s = _make_scheduler(
+        unlisted_rows=[{"video_id": "u1", "title": "U one"}],
+        private_rows=[
+            {"video_id": "p1", "title": "P one"},
+            {"video_id": "p2", "title": "P two"},
+        ],
+    )
+    with caplog.at_level(logging.WARNING):
+        _run(s)
+    breadcrumbs = [
+        r.getMessage() for r in caplog.records
+        if r.getMessage().startswith("[PRIVATE->PUBLIC]")
+    ]
+    assert len(breadcrumbs) == 2
+    assert {"p1", "p2"} == {b.split()[1] for b in breadcrumbs}
+
+
+# ---------------------------------------------------------------------------
+# Edit-page visibility guard
+# ---------------------------------------------------------------------------
+
+def test_edit_guard_accepts_private_on_private_pass(monkeypatch):
+    """Non-dry-run: a private edit-page video is scheduled (not skipped) when the
+    private pass is active."""
+    monkeypatch.setenv("YT_SCHEDULE_INCLUDE_PRIVATE", "1")
+    s = _make_scheduler(
+        unlisted_rows=[],  # skip straight to the private pass
+        private_rows=[{"video_id": "p1", "title": "P one"}],
+        dry_run=False,
+        edit_vis="private",
+    )
+    results = _run(s)
+    scheduled_ids = {v["video_id"] for v in results["scheduled"]}
+    assert "p1" in scheduled_ids
+    # Not rejected as wrong visibility.
+    assert not any(
+        sk.get("video_id") == "p1" and "Wrong visibility" in sk.get("reason", "")
+        for sk in results["skipped"]
+    )
+
+
+def test_edit_guard_rejects_private_on_unlisted_pass():
+    """Non-dry-run, flag OFF: a video that reads 'private' on the edit page during
+    the UNLISTED pass is still rejected as wrong visibility (guard NOT relaxed)."""
+    s = _make_scheduler(
+        unlisted_rows=[{"video_id": "u1", "title": "U one"}],
+        private_rows=[],
+        dry_run=False,
+        edit_vis="private",  # edit page disagrees with the unlisted list filter
+    )
+    results = _run(s)
+    scheduled_ids = {v["video_id"] for v in results["scheduled"]}
+    assert "u1" not in scheduled_ids
+    assert any(
+        sk.get("video_id") == "u1" and "Wrong visibility" in sk.get("reason", "")
+        for sk in results["skipped"]
+    )


### PR DESCRIPTION
## Summary

The shorts scheduler is **UNLISTED-only today**. This adds PRIVATE as an additional, **flag-gated, default-OFF** visibility target. Scheduling a PRIVATE Short uses YouTube Studio's `PUBLISH_FROM_PRIVATE` schedule radio, so it **publishes the video PUBLIC at its slot** -- an OUTWARD-FACING action. 012 must enable it deliberately, and every private->public schedule is logged.

Slice: `SHORTS_SCHEDULE_INCLUDE_PRIVATE_PHASE1` | Base: origin/main `47a6aa437`

## UNLISTED-only today (file:line, origin/main)

- Navigate hard-coded UNLISTED: `scheduler.py:317` `navigate_to_shorts_with_fallback(channel_id, "UNLISTED")` (re-navs `:366`, `:666`).
- Scrape under UNLISTED filter: `get_unlisted_videos()` (`scheduler.py:350/370`) -- UNLISTED-hardcoded in the DOM layer: guard `ensure_visibility_filter("UNLISTED")` (`dom_automation.py:2522`) + JS row scan requiring `\bunlisted\b` (`dom_automation.py:2537-2540`). Returns `[]` under a PRIVATE filter.
- Edit-page guard: `scheduler.py:502` `if edit_vis not in ("unlisted","unknown")` rejects `private` (which `read_edit_page_visibility` returns at `dom_automation.py:1316-1317`).

## Per-target pass + PRIVATE already in the DOM layer

The DOM/URL layer **already supports PRIVATE** for navigation, filtering, and scheduling -- it was **not modified**:
- `navigate_to_shorts_with_fallback(..., "PRIVATE")` is generic (`dom_automation.py:1411-1437`); `ensure_visibility_filter("PRIVATE")` (`:1324`); PRIVATE chip/url markers (`:294,306`).
- The schedule radio **is** `PUBLISH_FROM_PRIVATE` (`dom_automation.py:144-145,240,246`) -> private becomes PUBLIC. Confirmed.

Change (scheduler.py only):
- `_resolve_visibility_targets()`: default `["UNLISTED"]`; `YT_SCHEDULE_INCLUDE_PRIVATE=="1"` -> `["UNLISTED","PRIVATE"]` (UNLISTED first, strict `=="1"`).
- `_run_visibility_pass(target)`: the existing navigate + batch loop, extracted and run **once per target**. The single shared `self.tracker` keeps the per-day cap (3), peak window/tz, and rotation budget **shared** across targets -- UNLISTED fills slots first, PRIVATE continues into the remainder (no per-channel budget doubling).
- `_scrape_videos_for_visibility(target)`: UNLISTED delegates to the unchanged `dom.get_unlisted_videos()`; PRIVATE scrapes rows scheduler-side via `execute_script` (mirrors the strict scan, keyed on `private`), **without** touching the DOM layer (precedent: `_get_all_videos` already scrapes scheduler-side).

## Edit-guard relax + outward warning

- Edit-page guard now accepts `private` **only** on the PRIVATE pass; the UNLISTED pass still rejects it.
- Per private video scheduled: `logger.warning("[PRIVATE->PUBLIC] {video_id} scheduled to publish {date} {time}")` (live + dry-run) so 012 can review each outward action.
- The resolver also emits a one-time warning when the flag enables the PRIVATE pass.

## Default-off

`YT_SCHEDULE_INCLUDE_PRIVATE` defaults to `"0"`. With the flag off, the cycle behaves exactly as before: zero private scraping, zero private navigation, zero private->public publishing.

## MUST-FAIL proof (mock-only, NO browser; 11 new tests)

- Forcing the resolver to always include PRIVATE (default-off broken) -> all 5 OFF-guard tests FAIL, incl. `test_flag_off_never_navigates_private` (asserts navigate is NEVER called with PRIVATE when off).
- Removing the edit-guard relax -> `test_edit_guard_accepts_private_on_private_pass` FAILS (p1 rejected as wrong visibility); the unlisted-pass rejection test still passes.
- Code intact: **11 passed**. Module suite (`+ test_scheduler.py`): **45 passed, 2 skipped** (live-browser only).

## Scope

OUT: long-form private (follow-up), indexing, the detector, the long-form path. Touched **only** `scheduler.py` (+ new test + ModLog/TestModLog). The DOM/URL layer was NOT modified.

Status: VERIFIED_READY -- leave OPEN, do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
