### PR TITLE
feat(moltbot_bridge): Hermes Fusion ALIAS live path Phase 2 (valve-gated OFF, advisory) (Lane W6)

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -1,5 +1,31 @@
 # FoundUps Agent - Development Log
 
+## [2026-06-19] Hermes Fusion ALIAS Mode Phase 2 (Lane W6, AUTHOR + internal SENTINEL, valve-gated live egress OFF)
+
+**Change Type**: First LIVE OpenRouter integration -- VALVE-GATED OFF by default. NO live call on landing,
+NO new dependency (reuses `requests`), NO key logged, NO raw retained, advisory only. Opened DRAFT.
+**By**: 0102 (Worker-Lane W6) | Commander: 012 | Gate: external 0102 (do NOT self-merge)
+**WSP References**: WSP 11, WSP 50, WSP 84, WSP 97
+**Slice**: HERMES_FUSION_ALIAS_MODE_PHASE2
+**Predecessors**: #832 (contract `7bd68e73a`), #842 (redaction gate `972d082a0`)
+**Base**: `005dd3629` (origin/main; #842 landed)
+
+- ADD `modules/communication/moltbot_bridge/src/fusion_alias_live.py` -- valve-gated, redaction-gated,
+  advisory-only ALIAS live path. A network call requires ALL of: env flag FUSION_ALIAS_LIVE_ENABLED ON
+  (default OFF) + typed LiveFusionAuthorization (authority 012, not bool-coercible) + redaction gate PASSED
+  + OPENROUTER_API_KEY + bounded budget/timeout. Raw text redacted ON ENTRY; only redacted prompt/context
+  sent to openrouter/fusion via the reused `requests` client; only digests retained; key never logged.
+  One bounded POST, no stream, no retry. Advisory ModelContributionReceipt (advisory_not_canonical=True;
+  redaction_status=REDACTION_GATE_PASSED). Response re-scanned before any bounded summary enters the receipt.
+  Manual smoke in `__main__` (--authorize-012) -- not a pytest, never in CI.
+- ADD `modules/communication/moltbot_bridge/tests/test_fusion_alias_live.py` -- 33 tests over 5 sentinel
+  lanes; network MOCKED, synthetic keys, no skip/xfail. 138 pass (33 alias + 65 gate + 40 adapter regression).
+- EDIT `INTERFACE.md` + module ModLog -- alias surface, manual-smoke command, 28-row WSP_97 table (declared==actual==28).
+- `fusion_adapter` UNCHANGED (ALIAS/SERVER_TOOL/LOCAL_FALLBACK still raise via MockFusionAdapter; FusionRequest
+  stays digest-only). Boundaries honored; ASCII-clean (0 non-ASCII, no mojibake). Internal SENTINEL (5 lanes) ran.
+  DRAFT PR; STOP at MERGE_READY (external 0102 gate). Next (NOT this slice): operationally flipping the valve is a
+  separate sovereign action; SERVER_TOOL mode is later.
+
 ## [2026-06-19] Hermes Fusion Redaction Gate Phase 1 (Lane W6, AUTHOR + internal SENTINEL, security precondition)
 
 **Change Type**: SECURITY-CRITICAL redaction gate + adversarial tests + module docs. NO live OpenRouter,

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -109,6 +109,69 @@ input. This slice does NOT enable live OpenRouter -- alias/server_tool/local_fal
 
 Declared == Actual == 26 / 26 YES.
 
+### Fusion ALIAS live path (VALVE-GATED OFF by default; first live OpenRouter integration)
+
+```python
+from modules.communication.moltbot_bridge.src.fusion_alias_live import (
+    run_alias_live,            # (prompt, context=None, *, authorization, ...) -> AliasLiveResult
+    LiveFusionAuthorization,   # typed sovereign auth (authorized=True, authority="012", purpose="fusion_alias_live_call")
+    AliasLiveResult,           # status / reason / made_network_call / receipt
+    run_manual_smoke,          # MANUAL live smoke (module __main__); NOT a pytest, never in CI
+)
+```
+
+Landing this makes **ZERO** live calls. A network call requires ALL of: (1) `FUSION_ALIAS_LIVE_ENABLED`
+env flag ON (default OFF), (2) a valid `LiveFusionAuthorization` object (authority `012` -- a bool/int/
+str/dict cannot satisfy it), (3) the redaction gate PASSED, (4) `OPENROUTER_API_KEY` present, (5) budget/
+timeout within bounds. Raw text is redacted ON ENTRY; only the REDACTED prompt/context is sent to the
+`openrouter/fusion` alias; only digests are retained; the API key is never logged. Output is ADVISORY
+(`advisory_not_canonical=True`). All failure paths fail closed with a low-cardinality reason
+(`valve_closed`/`redaction_blocked`/`authorization_missing`/`missing_api_key`/`budget_exceeded`/`timeout`/
+`http_error`/`malformed_response`). SERVER_TOOL / LOCAL_FALLBACK remain blocked. HTTP client reused from
+`ai_gateway` (`requests`) -- no new dependency.
+
+**Manual live smoke (NOT CI; requires explicit 012 opt-in):**
+```
+FUSION_ALIAS_LIVE_ENABLED=1 OPENROUTER_API_KEY=<real-key> \
+  python -m modules.communication.moltbot_bridge.src.fusion_alias_live --authorize-012
+```
+Without `--authorize-012` it refuses. With the valve OFF it prints `valve_closed` and makes no call.
+
+#### WSP_97 Truth Boundary Checklist (HERMES_FUSION_ALIAS_MODE_PHASE2)
+
+| # | Truth Boundary Checklist Item | Status | Evidence |
+|---|-------------------------------|--------|----------|
+| 1 | ALIAS_REQUIRES_PASSED_REDACTION_GATE | YES | `run_alias_live` calls `evaluate_redaction_gate` first; not-passed -> `redaction_blocked`, no call |
+| 2 | VALVE_OFF_BY_DEFAULT_NO_LIVE_CALL | YES | `test_valve_off_by_default_makes_zero_network` (socket-blocked, 0 calls) |
+| 3 | ONLY_REDACTED_TEXT_SENT | YES | `test_only_redacted_text_is_sent` (body == gate.redacted_prompt) |
+| 4 | NO_RAW_RETAINED_OR_LOGGED | YES | `test_no_raw_prompt_or_secret_retained_in_receipt` |
+| 5 | KEY_NEVER_LOGGED | YES | `test_key_never_in_result_or_receipt` |
+| 6 | FAIL_CLOSED_ALL_BRANCHES | YES | timeout/http/malformed/missing-key/budget tests -> blocked, no crash |
+| 7 | OUTPUT_ADVISORY_NOT_CANONICAL | YES | receipt forces `advisory_not_canonical=True` (`test_receipt_invariants`) |
+| 8 | NO_NEW_DEPENDENCY_REUSE_GATEWAY | YES | reuses `requests` (ai_gateway); `test_module_no_new_dependency_imports` |
+| 9 | SERVER_TOOL_LOCALFALLBACK_STILL_BLOCKED | YES | `test_mock_adapter_live_modes_still_blocked` (incl. ALIAS via mock) |
+| 10 | NETWORK_MOCKED_IN_TESTS_NO_LIVE_CI | YES | all tests monkeypatch `requests.post`; no real call |
+| 11 | NO_CABR_OR_MERGE_AUTHORITY | YES | gate blocks authority/merge markers; alias touches none |
+| 12 | NO_REAL_KEY_COMMITTED | YES | synthetic split-fragment fake key only |
+| 13 | NO_SKIP_XFAIL | YES | `test_test_file_has_no_skip_or_xfail` (AST) |
+| 14 | FILE_SCOPE_EXACT | YES | alias module + test + INTERFACE + module ModLog + root ModLog |
+| 15 | HOLOINDEX_RESULTS_RATED | YES | Phase 0 ratings recorded (module ModLog) |
+| 16 | INTERNAL_SENTINEL_READY | YES | 5 sentinel lanes ran; findings folded |
+| 17 | FUSIONREQUEST_REMAINS_DIGEST_ONLY | YES | `fusion_adapter` unchanged; raw text is a function arg, never a FusionRequest field |
+| 18 | LIVE_INPUT_NOT_PERSISTED_OR_LOGGED | YES | raw prompt/context only function-local; never stored/logged |
+| 19 | AUTHORIZATION_NOT_BOOL_COERCIBLE | YES | `isinstance LiveFusionAuthorization` (`test_env_flag_alone_cannot_enable_network`) |
+| 20 | ENV_FLAG_ALONE_CANNOT_ENABLE_NETWORK | YES | env on + bad/no auth -> `authorization_missing`, 0 calls |
+| 21 | RAW_PROMPT_ABSENT_FROM_HTTP_BODY | YES | `test_only_redacted_text_is_sent` (raw absent, `scan_forbidden`==[]) |
+| 22 | RAW_CONTEXT_ABSENT_FROM_HTTP_BODY | YES | `test_redacted_context_sent_raw_context_absent` |
+| 23 | BLOCK_CATEGORY_BUILDS_NO_REQUEST | YES | `test_redaction_blocked_builds_no_request` (0 calls) |
+| 24 | RESPONSE_RECEIPT_ADVISORY_ONLY | YES | receipt advisory; `redaction_status=REDACTION_GATE_PASSED` |
+| 25 | RESPONSE_DOES_NOT_RETAIN_REQUEST_RAW | YES | response re-scanned; `test_response_secret_is_redacted_in_summary` / `_block_marker_is_withheld` |
+| 26 | TIMEOUT_AND_BUDGET_BOUNDED | YES | bounded timeout + `MAX_TOKENS_CEILING`; `test_budget_exceeded_fails_closed` |
+| 27 | NO_STREAMING_PHASE2 | YES | `test_no_streaming` (`stream=False`) |
+| 28 | LIVE_SMOKE_MANUAL_NOT_CI_SKIP | YES | smoke in `__main__`; `test_manual_smoke_is_main_guarded_not_collected` |
+
+Declared == Actual == 28 / 28 YES.
+
 ### WebhookReceiver
 
 ```python

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,44 @@
 # ModLog - moltbot_bridge
 
+## 2026-06-19: Fusion ALIAS live path -- valve-gated OFF, redaction-gated, advisory-only (W6)
+
+**Author**: 0102 (Worker-Lane W6, AUTHOR + internal SENTINEL)
+**WSP**: 11 (Interface), 50 (Pre-Action), 84 (HTTP-client reuse), 97 (Truth Boundary)
+**Slice**: `HERMES_FUSION_ALIAS_MODE_PHASE2`
+**Predecessors**: #832 (contract, `7bd68e73a`), #842 (redaction gate, `972d082a0`)
+**Base**: `005dd3629` (origin/main; #842 landed)
+
+### Summary
+
+First live OpenRouter integration -- but it makes ZERO live calls on landing. The actual network call is
+behind a SOVEREIGN VALVE: env flag `FUSION_ALIAS_LIVE_ENABLED` (default OFF) AND a typed
+`LiveFusionAuthorization` (authority `012`). Raw text is redacted ON ENTRY via the landed redaction gate;
+only the REDACTED prompt/context is sent; only digests are retained. Phase 0 (HoloIndex MEDIUM/HIGH;
+gate exposes `redacted_prompt`/`.passed`; ai_gateway uses `requests`) confirmed: no gate API gap, no new dep.
+
+- ADD `src/fusion_alias_live.py` -- `run_alias_live(prompt, context=None, *, authorization, ...)`:
+  redaction-gate-first -> env valve -> typed 012 authorization -> key -> budget -> ONE bounded POST (no
+  stream, no retry) to `openrouter/fusion` via the reused `requests` client. `LiveFusionAuthorization`
+  (frozen, not bool-coercible); `AliasLiveResult` (status/reason/made_network_call/receipt). Response is
+  re-scanned with the same policy before a bounded summary can enter the advisory `ModelContributionReceipt`
+  (advisory_not_canonical forced True; `redaction_status=REDACTION_GATE_PASSED`; digests from redacted
+  output). Key read via `os.getenv`, never logged. Manual smoke in `__main__` (`run_manual_smoke`, requires
+  `--authorize-012`) -- NOT a pytest, never collected in CI.
+- ADD `tests/test_fusion_alias_live.py` -- 33 tests over 5 sentinel lanes (valve-bypass, raw-egress,
+  response-retention, manual-smoke, live-mode-scope): valve-off zero-network (socket-blocked), env-flag-alone
+  cannot enable, bad/typed-invalid auth refused, redacted-only send (raw prompt + raw context absent),
+  block-category-builds-no-request, key-never-in-output, response re-scan, fail-closed (timeout/http/malformed/
+  missing-key/budget), no-streaming, no-new-dependency, live-modes-still-blocked. Network MOCKED; synthetic keys.
+  138 pass (33 alias + 65 gate + 40 adapter regression). No skip/xfail.
+- EDIT `INTERFACE.md` + module/root ModLog -- alias surface, manual-smoke command, 28-row WSP_97 table
+  (declared==actual==28).
+- `fusion_adapter` UNCHANGED: ALIAS/SERVER_TOOL/LOCAL_FALLBACK still raise via MockFusionAdapter; the live
+  path is a separate, fully-gated entry. FusionRequest stays digest-only.
+- Boundaries: no live call by default, no new dependency, no key logged, no raw retained, advisory only, no
+  CABR/payout/merge authority. ASCII-clean (0 non-ASCII; no mojibake). DRAFT; STOP at MERGE_READY.
+  Next (NOT this slice): operationally flipping FUSION_ALIAS_LIVE_ENABLED is a separate sovereign action;
+  SERVER_TOOL mode is a later slice.
+
 ## 2026-06-19: Fusion Redaction Gate -- deterministic FAIL-CLOSED precondition (W6)
 
 **Author**: 0102 (Worker-Lane W6, AUTHOR + internal SENTINEL)

--- a/modules/communication/moltbot_bridge/src/fusion_alias_live.py
+++ b/modules/communication/moltbot_bridge/src/fusion_alias_live.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Fusion ALIAS live path -- VALVE-GATED, redaction-gated, advisory-only OpenRouter call.
+
+Slice: HERMES_FUSION_ALIAS_MODE_PHASE2. This is the first live OpenRouter integration, but it makes
+ZERO live calls by default: the network call is gated behind a SOVEREIGN VALVE -- BOTH an env flag
+(FUSION_ALIAS_LIVE_ENABLED, default OFF) AND a typed LiveFusionAuthorization (authority="012"). Raw
+text is redacted ON ENTRY via the landed redaction gate; only the REDACTED text is ever sent; only
+digests are retained. Output is ADVISORY only. SERVER_TOOL / LOCAL_FALLBACK stay blocked (not here).
+
+WSP 97 TRUTH BOUNDARIES:
+  DOES: redact raw on entry; refuse unless the gate PASSED; require env-flag AND typed 012 authorization
+        before any call; send only the redacted text; one bounded request (no stream, no retry); parse
+        into an advisory ModelContributionReceipt (digests from redacted output); fail closed everywhere.
+  DOES NOT: make any call by default; send unredacted content; retain/log raw prompt/context; log the
+        API key; enable SERVER_TOOL/LOCAL_FALLBACK; touch CABR/payout/source-authority/merge authority;
+        add a new dependency (reuses `requests`, already used by ai_gateway).
+
+Live input never becomes storage: raw prompt/context exist only as function arguments long enough to
+call evaluate_redaction_gate(). They never enter FusionRequest, the receipt, a log, or any object field.
+
+WSP: WSP 11 (interface), WSP 50 (pre-action), WSP 84 (reuse HTTP client), WSP 97 (truth boundary).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import requests  # REUSED from ai_gateway's HTTP stack (ai_gateway.py imports requests) -- NOT a new dependency
+
+from .fusion_adapter import (
+    NOT_EVALUATED,
+    FusionProvider,
+    ModelContributionReceipt,
+    digest,
+)
+from .fusion_redaction_gate import (
+    REDACTION_GATE_PASSED,
+    evaluate_redaction_gate,
+    redact_text,
+    scan_forbidden,
+)
+
+# --- config (all bounded) ----------------------------------------------------
+ENV_LIVE_FLAG = "FUSION_ALIAS_LIVE_ENABLED"
+ENV_API_KEY = "OPENROUTER_API_KEY"
+OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+OPENROUTER_ALIAS_MODEL = "openrouter/fusion"
+EXPECTED_AUTHORITY = "012"
+EXPECTED_PURPOSE = "fusion_alias_live_call"
+DEFAULT_TIMEOUT_SECONDS = 30
+MAX_TIMEOUT_SECONDS = 60
+DEFAULT_MAX_TOKENS = 1024
+MAX_TOKENS_CEILING = 4096
+RESPONSE_SUMMARY_CHARS = 200
+
+# --- low-cardinality reasons (never echo raw input) --------------------------
+REASON_OK = "ok"
+REASON_VALVE_CLOSED = "valve_closed"
+REASON_REDACTION_BLOCKED = "redaction_blocked"
+REASON_AUTHORIZATION_MISSING = "authorization_missing"
+REASON_MISSING_API_KEY = "missing_api_key"
+REASON_BUDGET_EXCEEDED = "budget_exceeded"
+REASON_TIMEOUT = "timeout"
+REASON_HTTP_ERROR = "http_error"
+REASON_MALFORMED_RESPONSE = "malformed_response"
+ALIAS_REASONS = frozenset(
+    {
+        REASON_OK,
+        REASON_VALVE_CLOSED,
+        REASON_REDACTION_BLOCKED,
+        REASON_AUTHORIZATION_MISSING,
+        REASON_MISSING_API_KEY,
+        REASON_BUDGET_EXCEEDED,
+        REASON_TIMEOUT,
+        REASON_HTTP_ERROR,
+        REASON_MALFORMED_RESPONSE,
+    }
+)
+
+STATUS_ADVISORY_OK = "advisory_ok"
+STATUS_BLOCKED = "blocked"
+
+
+@dataclass(frozen=True)
+class LiveFusionAuthorization:
+    """Typed sovereign authorization -- NOT a bool. A plain True/1/"true"/dict cannot satisfy it."""
+
+    authorized: bool
+    authority: str
+    purpose: str
+
+    def is_valid(self) -> bool:
+        return (
+            self.authorized is True
+            and self.authority == EXPECTED_AUTHORITY
+            and self.purpose == EXPECTED_PURPOSE
+        )
+
+
+@dataclass
+class AliasLiveResult:
+    status: str                 # STATUS_ADVISORY_OK | STATUS_BLOCKED
+    reason: str                 # one of ALIAS_REASONS
+    made_network_call: bool
+    receipt: Optional[ModelContributionReceipt]
+
+
+def _env_flag_enabled() -> bool:
+    return os.getenv(ENV_LIVE_FLAG, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _authorization_valid(authorization: object) -> bool:
+    # Must be a real LiveFusionAuthorization instance -- bool/int/str/dict cannot coerce in.
+    return isinstance(authorization, LiveFusionAuthorization) and authorization.is_valid()
+
+
+def _blocked(reason: str, made_network_call: bool = False) -> AliasLiveResult:
+    return AliasLiveResult(status=STATUS_BLOCKED, reason=reason, made_network_call=made_network_call, receipt=None)
+
+
+def _receipt_id(task_id: object) -> str:
+    return "rcpt_alias_" + hashlib.sha256(str(task_id).encode("utf-8")).hexdigest()[:12]
+
+
+def _safe_response_summary(text: object) -> str:
+    """Re-scan the model response with the same policy BEFORE it can enter the receipt.
+
+    If the response carries any forbidden/block pattern, withhold it (store nothing raw). Otherwise a
+    bounded, redacted summary is allowed. The full response is never stored.
+    """
+    if not isinstance(text, str):
+        return "[no response]"
+    redacted, report = redact_text(text)
+    if report.blocked_categories or scan_forbidden(redacted):
+        return "[response withheld: failed post-response scan]"
+    return redacted[:RESPONSE_SUMMARY_CHARS]
+
+
+def _build_receipt(
+    task_id: object,
+    slice_id: Optional[str],
+    redacted_prompt_digest: str,
+    response_text: object,
+    token_usage: Optional[Dict[str, int]],
+    latency_ms: Optional[float],
+) -> ModelContributionReceipt:
+    response_digest = digest(response_text) if isinstance(response_text, str) else digest("")
+    return ModelContributionReceipt(
+        receipt_id=_receipt_id(task_id),
+        task_id=str(task_id),
+        slice_id=slice_id,
+        provider=FusionProvider.OPENROUTER.value,
+        mode="alias",
+        outer_model=OPENROUTER_ALIAS_MODEL,
+        panel_models=[OPENROUTER_ALIAS_MODEL],
+        judge_model=OPENROUTER_ALIAS_MODEL,
+        prompt_digest=redacted_prompt_digest,
+        response_digest=response_digest,
+        consensus=_safe_response_summary(response_text),
+        token_usage=token_usage,
+        latency_ms=latency_ms,
+        accepted_by_judge=False,
+        later_verified_outcome=NOT_EVALUATED,
+        wsp97_status=NOT_EVALUATED,
+        redaction_status=REDACTION_GATE_PASSED,
+        advisory_not_canonical=True,
+    )
+
+
+def run_alias_live(
+    prompt: object,
+    context: object = None,
+    *,
+    authorization: object = None,
+    task_id: str = "alias-live",
+    slice_id: Optional[str] = None,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+) -> AliasLiveResult:
+    """Run a redacted, valve-gated, advisory-only ALIAS call. Makes NO call unless every gate opens.
+
+    Precedence (fail-closed): redaction gate PASSED -> env flag ON -> typed 012 authorization ->
+    API key present -> budget within bounds -> ONE bounded POST. Any failure -> blocked, no raw leak.
+    """
+    # 1. Redact on entry. Raw prompt/context are used ONLY to compute the gate result and never stored.
+    gate = evaluate_redaction_gate(prompt, context)
+    if not gate.passed:
+        return _blocked(REASON_REDACTION_BLOCKED)  # BLOCK category / dirty -> no request body is built
+
+    # 2. Sovereign valve, part A: env flag. (Env flag ALONE cannot enable a call -- see part B.)
+    if not _env_flag_enabled():
+        return _blocked(REASON_VALVE_CLOSED)
+
+    # 3. Sovereign valve, part B: typed 012 authorization (not bool-coercible).
+    if not _authorization_valid(authorization):
+        return _blocked(REASON_AUTHORIZATION_MISSING)
+
+    # 4. API key (read via env; NEVER logged/echoed/stored).
+    api_key = os.getenv(ENV_API_KEY)
+    if not api_key:
+        return _blocked(REASON_MISSING_API_KEY)
+
+    # 5. Budget bounds.
+    if not isinstance(max_tokens, int) or max_tokens <= 0 or max_tokens > MAX_TOKENS_CEILING:
+        return _blocked(REASON_BUDGET_EXCEEDED)
+    bounded_timeout = min(max(1, int(timeout_seconds)), MAX_TIMEOUT_SECONDS)
+
+    # 6. Build the request from the REDACTED text ONLY (redacted prompt + redacted context, if any).
+    #    No streaming, single request.
+    messages: List[Dict[str, str]] = []
+    if context is not None and gate.redacted_context:
+        messages.append({"role": "system", "content": gate.redacted_context})
+    messages.append({"role": "user", "content": gate.redacted_prompt})
+    body: Dict[str, Any] = {
+        "model": OPENROUTER_ALIAS_MODEL,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "stream": False,
+    }
+    headers = {"Authorization": "Bearer " + api_key, "Content-Type": "application/json"}
+
+    # 7. One bounded POST. No retry storm. Every error path is fail-closed advisory.
+    try:
+        resp = requests.post(OPENROUTER_URL, headers=headers, json=body, timeout=bounded_timeout)
+    except requests.exceptions.Timeout:
+        return _blocked(REASON_TIMEOUT, made_network_call=True)
+    except Exception:
+        return _blocked(REASON_HTTP_ERROR, made_network_call=True)
+
+    if getattr(resp, "status_code", 500) != 200:
+        return _blocked(REASON_HTTP_ERROR, made_network_call=True)
+
+    try:
+        data = resp.json()
+        response_text = data["choices"][0]["message"]["content"]
+        token_usage = data.get("usage")
+    except Exception:
+        return _blocked(REASON_MALFORMED_RESPONSE, made_network_call=True)
+
+    receipt = _build_receipt(task_id, slice_id, gate.prompt_digest, response_text, token_usage, None)
+    return AliasLiveResult(status=STATUS_ADVISORY_OK, reason=REASON_OK, made_network_call=True, receipt=receipt)
+
+
+def run_manual_smoke(argv: Optional[List[str]] = None) -> int:
+    """MANUAL live smoke -- NOT a pytest, NOT collected by CI. Requires explicit opt-in:
+    FUSION_ALIAS_LIVE_ENABLED=1, a real OPENROUTER_API_KEY, and the --authorize-012 argument.
+
+    Without --authorize-012 it refuses. It prints only status/reason/digests -- never the API key.
+    """
+    import sys
+
+    args = list(argv) if argv is not None else sys.argv[1:]
+    if "--authorize-012" not in args:
+        print("[fusion-alias smoke] refusing: pass --authorize-012 to authorize a live call.")
+        return 2
+    auth = LiveFusionAuthorization(authorized=True, authority=EXPECTED_AUTHORITY, purpose=EXPECTED_PURPOSE)
+    result = run_alias_live("hello from the manual fusion alias smoke", authorization=auth, task_id="manual-smoke")
+    print(
+        "[fusion-alias smoke] status=%s reason=%s made_network_call=%s"
+        % (result.status, result.reason, result.made_network_call)
+    )
+    if result.receipt is not None:
+        print(
+            "[fusion-alias smoke] receipt_id=%s redaction_status=%s advisory_not_canonical=%s"
+            % (result.receipt.receipt_id, result.receipt.redaction_status, result.receipt.advisory_not_canonical)
+        )
+    return 0
+
+
+__all__ = [
+    "ENV_LIVE_FLAG",
+    "ENV_API_KEY",
+    "OPENROUTER_URL",
+    "OPENROUTER_ALIAS_MODEL",
+    "EXPECTED_AUTHORITY",
+    "EXPECTED_PURPOSE",
+    "MAX_TOKENS_CEILING",
+    "ALIAS_REASONS",
+    "REASON_OK",
+    "REASON_VALVE_CLOSED",
+    "REASON_REDACTION_BLOCKED",
+    "REASON_AUTHORIZATION_MISSING",
+    "REASON_MISSING_API_KEY",
+    "REASON_BUDGET_EXCEEDED",
+    "REASON_TIMEOUT",
+    "REASON_HTTP_ERROR",
+    "REASON_MALFORMED_RESPONSE",
+    "STATUS_ADVISORY_OK",
+    "STATUS_BLOCKED",
+    "LiveFusionAuthorization",
+    "AliasLiveResult",
+    "run_alias_live",
+    "run_manual_smoke",
+]
+
+
+if __name__ == "__main__":  # manual smoke entry -- never collected by pytest
+    raise SystemExit(run_manual_smoke())

--- a/modules/communication/moltbot_bridge/tests/test_fusion_alias_live.py
+++ b/modules/communication/moltbot_bridge/tests/test_fusion_alias_live.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Tests for the Fusion ALIAS live path (HERMES_FUSION_ALIAS_MODE_PHASE2).
+
+The network is MOCKED -- there is NO real OpenRouter call in CI. All keys/secrets are SYNTHETIC,
+assembled from split fragments. No skip / no xfail. The MANUAL live smoke lives in the module's
+__main__ (run_manual_smoke) and is NOT collected here.
+
+Sentinel lanes: valve-bypass, raw-egress, response-retention, manual-smoke, live-mode-scope.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+import requests
+
+import modules.communication.moltbot_bridge.src.fusion_alias_live as alias_mod
+from modules.communication.moltbot_bridge.src.fusion_alias_live import (
+    ALIAS_REASONS,
+    ENV_API_KEY,
+    ENV_LIVE_FLAG,
+    EXPECTED_PURPOSE,
+    OPENROUTER_ALIAS_MODEL,
+    REASON_AUTHORIZATION_MISSING,
+    REASON_BUDGET_EXCEEDED,
+    REASON_HTTP_ERROR,
+    REASON_MALFORMED_RESPONSE,
+    REASON_MISSING_API_KEY,
+    REASON_OK,
+    REASON_REDACTION_BLOCKED,
+    REASON_TIMEOUT,
+    REASON_VALVE_CLOSED,
+    STATUS_ADVISORY_OK,
+    STATUS_BLOCKED,
+    AliasLiveResult,
+    LiveFusionAuthorization,
+    run_alias_live,
+    run_manual_smoke,
+)
+from modules.communication.moltbot_bridge.src.fusion_redaction_gate import (
+    REDACTION_GATE_PASSED,
+    evaluate_redaction_gate,
+    scan_forbidden,
+)
+from modules.communication.moltbot_bridge.src.fusion_adapter import (
+    FusionMode,
+    FusionRequest,
+    MockFusionAdapter,
+    RedactionGateBlocked,
+    digest,
+    is_valid_digest,
+)
+
+MODULE_SRC = Path(alias_mod.__file__)
+FAKE_KEY = "s" "k-or-" + "F" * 40           # synthetic OpenRouter-shaped key
+SECRET = "s" "k-" + "A" * 48                  # synthetic le-redactable secret in a prompt
+VALID_AUTH = LiveFusionAuthorization(authorized=True, authority="012", purpose=EXPECTED_PURPOSE)
+
+
+class FakeResp:
+    def __init__(self, status_code=200, payload=None, raise_json=False):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {
+            "choices": [{"message": {"content": "an ordinary advisory answer about ramen"}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 20},
+        }
+        self._raise_json = raise_json
+
+    def json(self):
+        if self._raise_json:
+            raise ValueError("bad json")
+        return self._payload
+
+
+class Recorder:
+    def __init__(self, resp=None, exc=None):
+        self.calls = []
+        self.resp = resp if resp is not None else FakeResp()
+        self.exc = exc
+
+    def __call__(self, url, headers=None, json=None, timeout=None):
+        self.calls.append({"url": url, "headers": headers or {}, "json": json or {}, "timeout": timeout})
+        if self.exc is not None:
+            raise self.exc
+        return self.resp
+
+
+def _install(monkeypatch, recorder, *, enable=True, key=FAKE_KEY):
+    monkeypatch.setattr(alias_mod.requests, "post", recorder)
+    if enable:
+        monkeypatch.setenv(ENV_LIVE_FLAG, "1")
+    else:
+        monkeypatch.delenv(ENV_LIVE_FLAG, raising=False)
+    if key is not None:
+        monkeypatch.setenv(ENV_API_KEY, key)
+    else:
+        monkeypatch.delenv(ENV_API_KEY, raising=False)
+    return recorder
+
+
+# ---------------------------------------------------------------------------
+# valve-bypass lane
+# ---------------------------------------------------------------------------
+
+
+def test_valve_off_by_default_makes_zero_network(monkeypatch):
+    import socket
+
+    rec = Recorder()
+    monkeypatch.setattr(alias_mod.requests, "post", rec)
+    monkeypatch.delenv(ENV_LIVE_FLAG, raising=False)
+    monkeypatch.setattr(socket, "socket", lambda *a, **k: (_ for _ in ()).throw(AssertionError("network!")))
+    res = run_alias_live("an ordinary clean prompt", authorization=VALID_AUTH)
+    assert res.status == STATUS_BLOCKED and res.reason == REASON_VALVE_CLOSED
+    assert res.made_network_call is False
+    assert rec.calls == []
+
+
+@pytest.mark.parametrize("bad_auth", [None, True, 1, "true", "012", {"authorized": True, "authority": "012", "purpose": EXPECTED_PURPOSE}])
+def test_env_flag_alone_cannot_enable_network(monkeypatch, bad_auth):
+    rec = _install(monkeypatch, Recorder(), enable=True)
+    res = run_alias_live("clean prompt", authorization=bad_auth)
+    assert res.status == STATUS_BLOCKED and res.reason == REASON_AUTHORIZATION_MISSING
+    assert res.made_network_call is False
+    assert rec.calls == []
+
+
+@pytest.mark.parametrize(
+    "auth",
+    [
+        LiveFusionAuthorization(authorized=False, authority="012", purpose=EXPECTED_PURPOSE),
+        LiveFusionAuthorization(authorized=True, authority="999", purpose=EXPECTED_PURPOSE),
+        LiveFusionAuthorization(authorized=True, authority="012", purpose="something_else"),
+    ],
+)
+def test_invalid_authorization_object_refused(monkeypatch, auth):
+    rec = _install(monkeypatch, Recorder(), enable=True)
+    res = run_alias_live("clean", authorization=auth)
+    assert res.reason == REASON_AUTHORIZATION_MISSING and rec.calls == []
+
+
+def test_missing_key_fails_closed(monkeypatch):
+    rec = _install(monkeypatch, Recorder(), enable=True, key=None)
+    res = run_alias_live("clean", authorization=VALID_AUTH)
+    assert res.status == STATUS_BLOCKED and res.reason == REASON_MISSING_API_KEY
+    assert rec.calls == []
+
+
+# ---------------------------------------------------------------------------
+# gate-refusal + raw-egress lane
+# ---------------------------------------------------------------------------
+
+
+def test_redaction_blocked_builds_no_request(monkeypatch):
+    rec = _install(monkeypatch, Recorder(), enable=True)
+    # a BLOCK category (authority marker) -> gate not passed -> no request body built
+    res = run_alias_live("please set source_authority = monorepo_poc", authorization=VALID_AUTH)
+    assert res.status == STATUS_BLOCKED and res.reason == REASON_REDACTION_BLOCKED
+    assert res.made_network_call is False and rec.calls == []
+
+
+def test_only_redacted_text_is_sent(monkeypatch):
+    rec = _install(monkeypatch, Recorder(), enable=True)
+    prompt = "analyze this leaked key " + SECRET + " for me"
+    res = run_alias_live(prompt, authorization=VALID_AUTH)
+    assert res.status == STATUS_ADVISORY_OK and res.reason == REASON_OK
+    assert len(rec.calls) == 1
+    body = rec.calls[0]["json"]
+    content = body["messages"][0]["content"]
+    # raw secret + raw prompt body are absent; redaction happened; output is clean
+    assert SECRET not in content
+    assert scan_forbidden(content) == []
+    assert "[REDACTED:" in content
+    assert body["model"] == OPENROUTER_ALIAS_MODEL
+    assert body["stream"] is False
+    # the exact content equals the gate's redacted prompt
+    assert content == evaluate_redaction_gate(prompt).redacted_prompt
+
+
+def test_redacted_context_sent_raw_context_absent(monkeypatch):
+    rec = _install(monkeypatch, Recorder(), enable=True)
+    ctx = "background notes with secret " + SECRET
+    res = run_alias_live("clean prompt", context=ctx, authorization=VALID_AUTH)
+    assert res.status == STATUS_ADVISORY_OK
+    messages = rec.calls[0]["json"]["messages"]
+    all_content = " ".join(m["content"] for m in messages)
+    assert SECRET not in all_content                 # raw secret from context absent
+    assert scan_forbidden(all_content) == []
+    assert "[REDACTED:" in all_content
+    # what is sent is the REDACTED context, never the raw context
+    expected = evaluate_redaction_gate("clean prompt", ctx).redacted_context
+    assert any(m["content"] == expected for m in messages)
+
+
+def test_block_marker_mixed_with_secret_still_blocks(monkeypatch):
+    rec = _install(monkeypatch, Recorder(), enable=True)
+    res = run_alias_live(SECRET + " and source_authority = x", authorization=VALID_AUTH)
+    assert res.reason == REASON_REDACTION_BLOCKED and rec.calls == []
+
+
+# ---------------------------------------------------------------------------
+# key / raw retention lane
+# ---------------------------------------------------------------------------
+
+
+def test_key_never_in_result_or_receipt(monkeypatch):
+    _install(monkeypatch, Recorder(), enable=True)
+    res = run_alias_live("analyze " + SECRET, authorization=VALID_AUTH)
+    assert res.status == STATUS_ADVISORY_OK
+    blob = repr(res) + json.dumps(res.receipt.to_dict())
+    assert FAKE_KEY not in blob
+
+
+def test_no_raw_prompt_or_secret_retained_in_receipt(monkeypatch):
+    _install(monkeypatch, Recorder(), enable=True)
+    prompt = "secret-bearing prompt " + SECRET
+    res = run_alias_live(prompt, authorization=VALID_AUTH)
+    blob = json.dumps(res.receipt.to_dict())
+    assert SECRET not in blob
+    assert "secret-bearing prompt" not in blob   # raw prompt body not retained
+    assert is_valid_digest(res.receipt.prompt_digest)
+
+
+def test_receipt_invariants(monkeypatch):
+    _install(monkeypatch, Recorder(), enable=True)
+    prompt = "analyze " + SECRET
+    res = run_alias_live(prompt, authorization=VALID_AUTH)
+    r = res.receipt
+    assert r.advisory_not_canonical is True
+    assert r.redaction_status == REDACTION_GATE_PASSED
+    assert r.mode == "alias" and r.provider == "openrouter"
+    # prompt_digest is the gate's digest of the REDACTED output
+    assert r.prompt_digest == evaluate_redaction_gate(prompt).prompt_digest
+    assert is_valid_digest(r.response_digest)
+    # advisory_not_canonical cannot be flipped and still serialize
+    r.advisory_not_canonical = False
+    with pytest.raises(ValueError):
+        r.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# response-retention lane
+# ---------------------------------------------------------------------------
+
+
+def test_response_secret_is_redacted_in_summary(monkeypatch):
+    dirty = FakeResp(payload={"choices": [{"message": {"content": "here is a key " + SECRET + " do not store"}}]})
+    _install(monkeypatch, Recorder(resp=dirty), enable=True)
+    res = run_alias_live("clean prompt", authorization=VALID_AUTH)
+    assert res.status == STATUS_ADVISORY_OK
+    blob = json.dumps(res.receipt.to_dict())
+    assert SECRET not in blob                          # echoed secret never stored raw
+    assert "[REDACTED:" in res.receipt.consensus
+
+
+def test_response_block_marker_is_withheld(monkeypatch):
+    dirty = FakeResp(payload={"choices": [{"message": {"content": "the source_authority should change to X"}}]})
+    _install(monkeypatch, Recorder(resp=dirty), enable=True)
+    res = run_alias_live("clean prompt", authorization=VALID_AUTH)
+    assert res.status == STATUS_ADVISORY_OK
+    assert res.receipt.consensus.startswith("[response withheld")
+    assert "source_authority" not in res.receipt.consensus
+
+
+# ---------------------------------------------------------------------------
+# fail-closed lane (network errors)
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_fails_closed(monkeypatch):
+    _install(monkeypatch, Recorder(exc=requests.exceptions.Timeout()), enable=True)
+    res = run_alias_live("clean", authorization=VALID_AUTH)
+    assert res.status == STATUS_BLOCKED and res.reason == REASON_TIMEOUT
+    assert res.made_network_call is True and res.receipt is None
+
+
+def test_http_error_fails_closed(monkeypatch):
+    _install(monkeypatch, Recorder(resp=FakeResp(status_code=500)), enable=True)
+    res = run_alias_live("clean", authorization=VALID_AUTH)
+    assert res.reason == REASON_HTTP_ERROR and res.receipt is None
+
+
+def test_malformed_response_fails_closed(monkeypatch):
+    _install(monkeypatch, Recorder(resp=FakeResp(raise_json=True)), enable=True)
+    res = run_alias_live("clean", authorization=VALID_AUTH)
+    assert res.reason == REASON_MALFORMED_RESPONSE and res.receipt is None
+
+
+def test_budget_exceeded_fails_closed(monkeypatch):
+    rec = _install(monkeypatch, Recorder(), enable=True)
+    res = run_alias_live("clean", authorization=VALID_AUTH, max_tokens=10_000_000)
+    assert res.reason == REASON_BUDGET_EXCEEDED and rec.calls == []
+
+
+def test_all_reasons_low_cardinality(monkeypatch):
+    _install(monkeypatch, Recorder(), enable=True)
+    for r in [
+        run_alias_live("clean", authorization=VALID_AUTH),
+        run_alias_live("source_authority = x", authorization=VALID_AUTH),
+        run_alias_live("clean", authorization=None),
+    ]:
+        assert r.reason in ALIAS_REASONS
+
+
+def test_no_streaming(monkeypatch):
+    rec = _install(monkeypatch, Recorder(), enable=True)
+    run_alias_live("clean", authorization=VALID_AUTH)
+    assert rec.calls[0]["json"]["stream"] is False
+
+
+# ---------------------------------------------------------------------------
+# live-mode-scope lane: SERVER_TOOL / LOCAL_FALLBACK (and ALIAS via mock) still raise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", [FusionMode.ALIAS, FusionMode.SERVER_TOOL, FusionMode.LOCAL_FALLBACK])
+def test_mock_adapter_live_modes_still_blocked(monkeypatch, mode):
+    req = FusionRequest(task_id="t", prompt_digest=digest("p"), panel_models=["m"], mode=mode)
+    with pytest.raises(RedactionGateBlocked):
+        MockFusionAdapter().run(req)
+
+
+# ---------------------------------------------------------------------------
+# manual-smoke lane + no-new-dependency
+# ---------------------------------------------------------------------------
+
+
+def test_manual_smoke_refuses_without_authorization(monkeypatch, capsys):
+    rec = _install(monkeypatch, Recorder(), enable=False)
+    code = run_manual_smoke([])  # no --authorize-012
+    assert code == 2
+    assert rec.calls == []
+
+
+def test_manual_smoke_is_main_guarded_not_collected():
+    src = MODULE_SRC.read_text(encoding="utf-8")
+    assert 'if __name__ == "__main__":' in src
+    tree = ast.parse(src)
+    imports = set()
+    test_defs = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(a.name.split(".")[0] for a in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imports.add((node.module or "").split(".")[0])
+        elif isinstance(node, ast.FunctionDef) and node.name.startswith("test_"):
+            test_defs.append(node.name)
+    # the live module imports no pytest and defines no test_* -> CI cannot collect a live call from it
+    assert "pytest" not in imports
+    assert test_defs == []
+
+
+def _has_skip_or_xfail(src: str) -> bool:
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for dec in node.decorator_list:
+                target = dec.func if isinstance(dec, ast.Call) else dec
+                attrs = []
+                cur = target
+                while isinstance(cur, ast.Attribute):
+                    attrs.append(cur.attr)
+                    cur = cur.value
+                if any(a in ("skip", "skipif", "xfail") for a in attrs):
+                    return True
+        if isinstance(node, ast.Call):
+            f = node.func
+            if isinstance(f, ast.Attribute) and f.attr in ("skip", "xfail") and isinstance(f.value, ast.Name) and f.value.id == "pytest":
+                return True
+    return False
+
+
+def test_test_file_has_no_skip_or_xfail():
+    # AST-based (not substring) -- a true marker decorator or pytest.skip() call would be caught
+    assert not _has_skip_or_xfail(Path(__file__).read_text(encoding="utf-8"))
+
+
+def test_module_no_new_dependency_imports():
+    tree = ast.parse(MODULE_SRC.read_text(encoding="utf-8"))
+    roots = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            roots.update(a.name.split(".")[0] for a in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0:
+                roots.add((node.module or "").split(".")[0])
+    # allowed: stdlib + requests (already used by ai_gateway) + intra-package relative (level>0)
+    allowed = {"os", "hashlib", "dataclasses", "typing", "requests", "sys", "__future__"}
+    assert roots <= allowed, f"unexpected top-level imports: {roots - allowed}"
+    forbidden = {"httpx", "aiohttp", "openai", "openrouter"}
+    assert not (forbidden & roots)


### PR DESCRIPTION
## HERMES_FUSION_ALIAS_MODE_PHASE2 (Lane W6 -- AUTHOR + internal SENTINEL)

**DRAFT. First live OpenRouter integration -- VALVE-GATED OFF.** Landing this makes **ZERO** live calls. The network call requires **ALL** of: (1) `FUSION_ALIAS_LIVE_ENABLED` env flag ON (default OFF), (2) a typed `LiveFusionAuthorization` (authority `012` -- a `bool`/`int`/`str`/`dict` cannot satisfy it), (3) the redaction gate **PASSED**, (4) `OPENROUTER_API_KEY` present, (5) budget/timeout within bounds. Base `005dd3629` (#842 landed `972d082a0`). **STOP at MERGE_READY -- external 0102 gate (do NOT self-merge).**

### Design
- **Redact on entry**: raw prompt/context are function-local only, passed once to `evaluate_redaction_gate`; never stored/logged. `FusionRequest` stays digest-only (not extended).
- **Only redacted text sent**: the `openrouter/fusion` request body is built from `gate.redacted_prompt`/`redacted_context` and only after `gate.passed`. A BLOCK-category payload builds **no request at all**.
- **Sovereign valve**: env flag AND typed 012 authorization both required; env-flag-alone cannot enable a call.
- **Reused HTTP client** (`requests`, from ai_gateway) -- **no new dependency**. One bounded POST, **no streaming, no retry**; bounded timeout + `MAX_TOKENS_CEILING`.
- **Advisory receipt**: `advisory_not_canonical=True` (cannot flip), `redaction_status=REDACTION_GATE_PASSED`, digests from redacted output. **Key never logged**; response **re-scanned** before any bounded summary; full response never stored.
- **Manual live smoke** in `__main__` (`run_manual_smoke`, requires `--authorize-012`) -- **not a pytest, never collected in CI**.

### Tests
**33 tests** over the 5 sentinel lanes (valve-bypass, raw-egress, response-retention, manual-smoke, live-mode-scope). Network **MOCKED**, synthetic keys, **no skip/xfail**. **138 pass** (33 alias + 65 gate + 40 adapter regression).

### Internal SENTINEL (5 lanes)
All 5 lanes **REFUTED** (no valve-bypass, no raw egress, no retention, smoke clean, scope intact); no new holes. **MERGE_READY.** `fusion_adapter` **unchanged** -- ALIAS/SERVER_TOOL/LOCAL_FALLBACK still raise via `MockFusionAdapter`.

**WSP_97: 28/28 declared==actual** (full table in `INTERFACE.md`). ASCII-clean (0 non-ASCII, no mojibake). **Next (NOT this slice):** operationally flipping `FUSION_ALIAS_LIVE_ENABLED` + the first real smoke is a separate sovereign action; SERVER_TOOL mode is a later slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)