### PR TITLE
fix(foundups): #807 redact dict keys + token-precise command matching (no weakening AND no over-rejection)

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -1,5 +1,36 @@
 # FoundUps Agent - Development Log
 
+## [2026-06-20] Kanban Contract: dict-KEY redaction + token-precise command match (AUTHOR worker, gate=independent SENTINEL)
+
+**Change Type**: LOGIC change to the #807 Kanban authority contract closing 2 findings the parked
+publish adapter's RE-REVIEW exposed (after #843). Contract source + tests + ModLogs only. NO adapter
+code, NO Kanban DB, NO Hermes import, NO runtime wiring.
+**By**: 0102 (AUTHOR worker) | Commander: 012 | Gate: independent SENTINEL (do NOT self-merge)
+**WSP References**: WSP 22, WSP 50, WSP 64, WSP 84, WSP 97
+**Slice**: FOUNDUP_KANBAN_CONTRACT_REDACT_KEYS_AND_PRECISE_COMMAND_MATCH_PHASE1
+**Base**: `005dd3629` (origin/main; contains landed #807 + #838 + #843)
+
+- EDIT `modules/foundups/agent/src/kanban_plugin_contract.py` (2 logic edits):
+  - **Fix 1 (`_redact_deep` dict branch)**: now redacts string dict KEYS via the same
+    `redact_sensitive` used for values (`{(redact_sensitive(k) if str else k): _redact_deep(v) ...}`).
+    Non-string keys pass through; returns a NEW structure (no mutation). A secret used AS a nested
+    dict KEY no longer survives into `to_dict()`/serialization (origin leaked it; HEAD does not).
+  - **Fix 2 (command-key match)**: replaced SUBSTRING matching with `_key_is_command()` --
+    TOKEN/BOUNDARY-precise: `_normalize` the key, split on `_`, match IFF a token EXACTLY equals a
+    single-token marker `{command, cmd, argv, shell, exec, script}`. Fixes the #843 over-rejection
+    regression: `description`/`transcript`/`subscription`/... (substring-only) are no longer treated
+    as command-keys (flip REJECTED->ACCEPTED for ordinary string values). `run_cmd`/`runCmd`/
+    `exec_now`/`shell_command` still caught via their `cmd`/`exec`/`shell`/`command` tokens; a bare
+    string under a TRUE command key still REJECTED (`_command_value_is_argv_or_null` unchanged).
+- TWO-DIRECTIONAL parity proven (live origin-vs-HEAD cross-check + committed batteries): NO WEAKENING
+  of AUTHORITY detection (0 origin-rejected authority payloads newly accepted) AND NO FALSE-POSITIVE
+  on legit command-substring fields (new `_FALSE_POSITIVE_BATTERY`, the invariant #843 lacked).
+- EDIT `tests/test_kanban_plugin_contract.py`: 319 passed (was 251; +68). Full agent suite **1016
+  passed** in BOTH heavy (`AI_OVERSEER_HEAVY_TESTS=1`) and CI mode; no skip/xfail, no regression.
+- 14-row WSP_97 Truth Boundary Checklist in the module ModLog. ASCII-clean (0 non-ASCII; synthetic
+  secret via `chr()`). Parked KANBAN_EXTERNAL_ADAPTER_PUBLISH_PILOT_PHASE1 rebases onto this. Left
+  dirty for the orchestrator audit + independent SENTINEL (no commit/stage).
+
 ## [2026-06-19] Hermes Fusion Redaction Gate Phase 1 (Lane W6, AUTHOR + internal SENTINEL, security precondition)
 
 **Change Type**: SECURITY-CRITICAL redaction gate + adversarial tests + module docs. NO live OpenRouter,

--- a/modules/foundups/agent/ModLog.md
+++ b/modules/foundups/agent/ModLog.md
@@ -1,5 +1,100 @@
 # Agent Module ModLog
 
+## 2026-06-20 - Kanban Contract dict-key redaction + token-precise command match (FOUNDUP_KANBAN_CONTRACT_REDACT_KEYS_AND_PRECISE_COMMAND_MATCH_PHASE1)
+
+**Author**: 0102 (AUTHOR worker) | Commander: 012 | Gate: independent SENTINEL (do NOT self-merge)
+**WSP References**: WSP 22, WSP 50, WSP 64, WSP 84, WSP 97
+**Base**: `005dd3629` (origin/main; contains the landed #807 + #838 + #843)
+**Slice**: FOUNDUP_KANBAN_CONTRACT_REDACT_KEYS_AND_PRECISE_COMMAND_MATCH_PHASE1
+
+### Why (closes 2 findings the parked publish adapter's RE-REVIEW exposed)
+
+After #843 landed, a re-review of the parked publish adapter (slice
+KANBAN_EXTERNAL_ADAPTER_PUBLISH_PILOT_PHASE1, NOT part of this slice) exposed two NEW gaps in the
+#807 authority contract. Decision A (again): fix the contract at its SOURCE.
+- **Finding 1 (secret-as-dict-KEY survives serialization)**: `_redact_deep` redacted string
+  VALUES/leaves but NOT dict KEYS (`{k: _redact_deep(v) for k, v in node.items()}`). A secret used
+  as a nested dict KEY therefore survived verbatim into `to_dict()` and the adapter outbox.
+  Confirmed live: origin `to_dict()` of a card carrying `{sk: "v", "f": sk}` in a list field leaks
+  the raw `sk-...` as a KEY; HEAD does not.
+- **Finding 2 (#843 command-key over-rejection regression)**: the command-key check used SUBSTRING
+  matching (`any(c in nkey for c in _COMMAND_KEY_MARKERS)`), so `description` (contains "script"),
+  `transcript`, `subscription`, etc. were treated as command-keys. Since #843 made command-keys
+  reject bare strings, an ordinary raw-dict field like `{"description": "ordinary text"}` was now
+  FALSELY REJECTED. The #843 no-weakening lane allowed this regression because a field going
+  accepted->rejected reads as a "strengthening". Confirmed live: origin REJECTS description/
+  transcript/subscription/executive_summary/scripted_notes/prescription/descriptor with an ordinary
+  string value; HEAD ACCEPTS them.
+
+### Changed (LOGIC change to the #807 authority contract -- src: `kanban_plugin_contract.py`)
+
+1. **Fix 1 -- `_redact_deep` now redacts string KEYS as well as string values** (dict branch,
+   `~line 124`): `{(redact_sensitive(k) if isinstance(k, str) else k): _redact_deep(v) for k, v in
+   node.items()}`. Non-string keys pass through unchanged. Uses the SAME `redact_sensitive` redactor
+   as values, returns a NEW structure (the input mapping is NOT mutated), and preserves the
+   deterministic/canonical behavior (downstream `to_dict()` is `json.dumps(sort_keys=True)`). A
+   secret-as-key can no longer survive into `to_dict()` or any serialization.
+2. **Fix 2 -- command-key matching is now TOKEN/BOUNDARY-precise, NOT substring** (`~line 245`):
+   replaced the substring test with `_key_is_command()` (`~line 165`), which runs the existing
+   `_normalize` on the key, splits the normalized key into tokens by `_`, and matches a command-key
+   IFF some TOKEN is EXACTLY a single-token command marker. `_COMMAND_KEY_MARKERS` is now the
+   single-token set `{command, cmd, argv, shell, exec, script}` (frozenset). `run_cmd`/`runCmd` are
+   caught via their `cmd` token; `exec_now` via `exec`; `shell_command` via `shell`/`command`. Legit
+   fields whose names merely CONTAIN a marker substring (description/transcript/subscription/
+   executive/scripted/prescription/...) each normalize to a single NON-marker token and are NOT
+   command-keys. `_command_value_is_argv_or_null` is UNCHANGED -- a bare string under a TRUE command
+   key remains REJECTED; a valid all-safe argv list under a true command key is still ACCEPTED.
+
+### Two-directional parity (this slice needs BOTH no-weakening AND no-over-rejection)
+
+AUTHORITY detection is UNCHANGED and not weakened (the command-KEY change is the only logic change
+on the key path; redaction only ADDS key coverage). The command-KEY change is an INTENDED narrowing:
+it removes false-positive command-keys (description/transcript/...) while keeping the true command
+keys. So `{description: "text"}` flips REJECTED(origin)->ACCEPTED(HEAD) -- the intended fix, NOT a
+weakening (it was never a real authority/command key). The no-weakening invariant applies to
+AUTHORITY markers, not to the command-substring over-matches being fixed.
+
+AUDIT-time live cross-check (origin/main module vs HEAD over the corpus):
+- **NO WEAKENING**: 0 origin-rejected AUTHORITY payloads newly accepted by HEAD.
+- **TRUE command keys (command/cmd/shell/script/exec/argv + run_command/runCmd/exec_now/
+  shell_command) still reject a bare string** (origin False -> HEAD False; #843 invariant carried).
+- **FALSE-POSITIVE FIX**: description/transcript/subscription/executive_summary/scripted_notes/
+  prescription/descriptor flip REJECTED(origin)->ACCEPTED(HEAD).
+- **KEY-REDACTION**: secret-as-key survives origin `to_dict()` (True), does NOT survive HEAD (False);
+  HEAD instance not mutated.
+
+### WSP_97 Truth Boundary Checklist
+
+| # | Truth Boundary Checklist Item | Status | Evidence |
+|---|---|---|---|
+| 1 | DICT_KEYS_REDACTED | PASS | `_redact_deep` dict branch redacts string KEYS via `redact_sensitive`; non-string keys pass through |
+| 2 | NESTED_KEYS_REDACTED | PASS | secret-as-KEY nested several levels deep is redacted (test) |
+| 3 | TO_DICT_NO_SECRET_IN_KEYS_OR_VALUES | PASS | card `to_dict()` of `{sk:"v","f":sk}` in a list field carries no raw secret in keys OR values |
+| 4 | COMMAND_MATCH_TOKEN_PRECISE_NOT_SUBSTRING | PASS | `_key_is_command` matches on a normalized `_`-token == single-token marker; substring fields excluded |
+| 5 | DESCRIPTION_TRANSCRIPT_NOT_COMMAND_KEYS | PASS | description/transcript (+ false-positive battery) accepted with ordinary string values |
+| 6 | TRUE_COMMAND_KEYS_STILL_REJECT_BARE_STRING | PASS | command/cmd/shell/script/exec/argv/run_command/runCmd/exec_now/shell_command bare string rejected |
+| 7 | AUTHORITY_DETECTION_NOT_WEAKENED | PASS | full origin-rejected AUTHORITY corpus still rejected; 0 newly accepted (battery + live cross-check) |
+| 8 | FALSE_POSITIVE_BATTERY_PRESENT | PASS | corpus of legit command-substring field names with ordinary values, all ACCEPTED (NEW #843-lacked invariant) |
+| 9 | ADAPTER_FINDINGS_CLOSED_AT_CONTRACT_SOURCE | PASS | both findings fixed in the contract; adapter inherits safety |
+| 10 | ASCII_CLEAN | PASS | 0 non-ASCII bytes in both edited files (synthetic secret via `chr()`) |
+| 11 | NO_SKIP_XFAIL | PASS | no skip/xfail added |
+| 12 | FILE_SCOPE_EXACT | PASS | only `kanban_plugin_contract.py` + its tests + ModLogs changed |
+| 13 | NO_HERMES_OR_DB_OR_RUNTIME_WIRING | PASS | pure dataclasses/validators; no Hermes import, no Kanban DB, no runtime wiring |
+| 14 | ORIGINAL_OBJECT_NOT_MUTATED | PASS | `_redact_deep` builds a NEW dict; card instance keeps raw key/value after `to_dict()` |
+
+### Validation
+
+- `test_kanban_plugin_contract.py`: 319 passed (was 251; +68 net new for key-redaction + token-
+  precise-command + two-directional parity). Full agent suite: **1016 passed** in BOTH heavy
+  (`AI_OVERSEER_HEAVY_TESTS=1`) and CI mode -- no skip/xfail, no regression.
+
+### Follow-up
+
+The parked slice **KANBAN_EXTERNAL_ADAPTER_PUBLISH_PILOT_PHASE1** rebases onto this once it lands
+(it relies on the now-guaranteed key+value redaction and the token-precise command-key contract).
+
+---
+
 ## 2026-06-19 - Kanban Contract card redaction + command argv-or-null (FOUNDUP_KANBAN_CONTRACT_CARD_REDACTION_AND_COMMAND_ARGV_PHASE1)
 
 **Author**: 0102 (AUTHOR worker) | Commander: 012 | Gate: independent SENTINEL (do NOT self-merge)

--- a/modules/foundups/agent/src/kanban_plugin_contract.py
+++ b/modules/foundups/agent/src/kanban_plugin_contract.py
@@ -118,11 +118,21 @@ def _redact_deep(node: Any) -> Any:
     Reuses ``redact_sensitive`` per string so a raw secret can NEVER appear in
     serialized output, even when nested inside a list/dict free-text field. Pure;
     returns a NEW structure (does not mutate the input). Non-string leaves pass
-    through unchanged (only string-shaped credential material is touched)."""
+    through unchanged (only string-shaped credential material is touched).
+
+    Dict KEYS are redacted with the SAME ``redact_sensitive`` redactor as values
+    (a secret used as a nested dict KEY -- not just a value -- must NEVER survive
+    into serialized output). Non-string keys pass through unchanged. The result is
+    a NEW dict (the input mapping is not mutated); downstream ``to_dict()`` is the
+    canonical body, and any consumer digest over it is a digest over redacted keys
+    AND values."""
     if isinstance(node, str):
         return redact_sensitive(node)
     if isinstance(node, dict):
-        return {k: _redact_deep(v) for k, v in node.items()}
+        return {
+            (redact_sensitive(k) if isinstance(k, str) else k): _redact_deep(v)
+            for k, v in node.items()
+        }
     if isinstance(node, (list, tuple)):
         return [_redact_deep(item) for item in node]
     return node
@@ -152,6 +162,17 @@ def _normalize(token: Any) -> str:
     return s.strip("_ \t")
 
 
+def _key_is_command(key: str) -> bool:
+    """A KEY names a command/exec field IFF, after ``_normalize``, one of its
+    underscore-split TOKENS is EXACTLY a single-token command marker (TOKEN/BOUNDARY
+    precise -- NOT substring). This catches command/cmd/argv/shell/exec/script,
+    run_command/run_cmd/runCmd (-> cmd), exec_now (-> exec), shell_command
+    (-> shell/command); and does NOT catch description/transcript/subscription/
+    executive/scripted/prescription (each a single NON-marker token)."""
+    tokens = [t for t in _normalize(key).split("_") if t]
+    return any(t in _COMMAND_KEY_MARKERS for t in tokens)
+
+
 def _is_printable_ascii(s: str) -> bool:
     return all(32 <= ord(c) < 127 for c in s)
 
@@ -176,8 +197,16 @@ _NON_MONOREPO_STAGES: frozenset = frozenset({
     "external_proto", "proto", "soft_proto", "mvp", "opo", "growth", "infra",
     "mega", "systemic", "dao", "smartdao",
 })
-# Keys that name a command/exec field; a shell-string value there is a smuggle.
-_COMMAND_KEY_MARKERS: tuple = ("command", "cmd", "argv", "shell", "exec", "run_cmd", "script")
+# Single-TOKEN command-key markers. A key names a command/exec field IFF, after
+# normalization, one of its underscore-split TOKENS is EXACTLY one of these markers
+# (TOKEN/BOUNDARY-precise, NOT substring). So run_cmd -> [run, cmd] -> cmd (caught),
+# runCmd -> normalize run_cmd -> [run, cmd] -> cmd, exec_now -> [exec, now] -> exec,
+# shell_command -> [shell, command] -> shell/command; while description (token
+# [description], NOT "script"), transcript, subscription, executive, scripted,
+# prescription, etc. each normalize to a single NON-marker token and are NOT
+# command-keys. ("run_cmd" itself is NOT a single token -- it is caught via its
+# "cmd" token -- so it is intentionally absent from this single-token marker set.)
+_COMMAND_KEY_MARKERS: frozenset = frozenset({"command", "cmd", "argv", "shell", "exec", "script"})
 _SHELL_METACHARS: frozenset = frozenset(";|&$`><(){}\n\r\t!#\\\"'")
 _SHELL_METASTRINGS: tuple = ("&&", "||", "$(", "${", ">>", "<<")
 
@@ -241,8 +270,12 @@ def _scan_authority(node: Any, trail: str, errors: List[str]) -> None:
             # when it is null/None OR an argv LIST of safe strings. A bare STRING
             # (even metachar-free, e.g. "rm -rf /"), a dict, or a list with any unsafe
             # element (shell metachar / authority marker / path bypass) is rejected.
+            # The KEY match is TOKEN/BOUNDARY-precise (a NORMALIZED token == a single-
+            # token marker), NOT substring -- so "description"/"transcript" are NOT
+            # command-keys (the #843 substring over-rejection regression is fixed) while
+            # the true command keys still reject bare strings.
             # No-raw-echo (#838): name the rule class only; NEVER echo the command value.
-            if any(c in nkey for c in _COMMAND_KEY_MARKERS):
+            if _key_is_command(nkey):
                 if not _command_value_is_argv_or_null(value):
                     errors.append("command must be argv-list-or-null (bare string / unsafe argv forbidden)")
             _scan_authority(value, f"{trail}{key}.", errors)

--- a/modules/foundups/agent/tests/TestModLog.md
+++ b/modules/foundups/agent/tests/TestModLog.md
@@ -1,5 +1,54 @@
 # Agent Module TestModLog
 
+## 2026-06-20 - Kanban Contract dict-key redaction + token-precise command tests (FOUNDUP_KANBAN_CONTRACT_REDACT_KEYS_AND_PRECISE_COMMAND_MATCH_PHASE1)
+
+**Commands** (PYTHONIOENCODING=utf-8):
+
+```bash
+python -m pytest modules/foundups/agent/tests/test_kanban_plugin_contract.py -q
+AI_OVERSEER_HEAVY_TESTS=1 python -m pytest modules/foundups/agent -q   # heavy
+python -m pytest modules/foundups/agent -q                            # CI mode
+```
+
+**Result**: PASS
+
+**Summary**:
+- `test_kanban_plugin_contract.py`: 319 passed (was 251; +68 net new). Full agent suite:
+  **1016 passed** in BOTH heavy and CI mode. No skip/xfail, no regression.
+
+**New coverage (this slice -- closes the parked-adapter RE-REVIEW findings)**:
+1. **Fix 1 -- dict-KEY redaction** (`_redact_deep`): a secret used as a string dict KEY (and as a
+   value) is redacted; a secret-as-KEY nested several levels deep is redacted; non-string keys
+   (int/tuple) pass through unchanged; `_redact_deep` does NOT mutate the input mapping (a NEW
+   structure is built); through `KanbanCardSpec.to_dict()` a secret hidden as a dict KEY inside a
+   list field appears in NEITHER keys NOR values of the serialized body, and the instance is not
+   mutated.
+2. **Fix 2 -- token-precise command-key match** (`_key_is_command`):
+   - true command keys (command/cmd/shell/script/exec/argv + run_command/runCmd/exec_now/
+     shell_command/run_cmd) are detected;
+   - legit substring fields (description/transcript/subscription/executive/scripted/prescription/
+     descriptor/executive_summary/scripted_notes/subscription_id/transcription) are NOT command keys;
+   - direct contrast test: `script` is a command key, `description`/`transcript` are not.
+3. **Must-catch / must-not-catch through the validator**: a bare string under any TRUE command key
+   (incl. multi-token forms) is REJECTED; `command: "rm -rf /"` rejected; a valid all-safe argv list
+   under a true command key is ACCEPTED; description/transcript with an ordinary string value are
+   ACCEPTED.
+4. **Two-directional parity batteries**:
+   - `_FALSE_POSITIVE_BATTERY` (NEW invariant #843 lacked): a corpus of legit field names that
+     CONTAIN a command-marker substring, carrying ordinary string values, are ALL ACCEPTED;
+     `test_false_positive_battery_zero_falsely_rejected_summary` asserts ZERO falsely rejected.
+   - `test_authority_detection_not_weakened_by_token_match`: the whole `_ORIGIN_REJECTED_CARDS`
+     AUTHORITY corpus stays rejected (0 newly accepted) -- the command-KEY change does not weaken
+     authority detection.
+   - `test_command_marker_set_is_single_token`: the marker set is single-token by construction.
+- Imports extended: `_redact_deep`, `_key_is_command`, `_COMMAND_KEY_MARKERS`.
+- ASCII-clean: the synthetic secret is built via `chr()` (0 non-ASCII bytes).
+- AUDIT cross-check (NOT a committed test): origin/main module vs HEAD over the corpus confirmed
+  0 authority weakening, true-command-keys still reject bare strings, and description/transcript/...
+  flip REJECTED(origin)->ACCEPTED(HEAD); secret-as-key survives origin `to_dict()` but not HEAD.
+
+---
+
 ## 2026-06-19 - Kanban Contract card-redaction + command-argv tests (FOUNDUP_KANBAN_CONTRACT_CARD_REDACTION_AND_COMMAND_ARGV_PHASE1)
 
 **Commands** (PYTHONIOENCODING=utf-8):

--- a/modules/foundups/agent/tests/test_kanban_plugin_contract.py
+++ b/modules/foundups/agent/tests/test_kanban_plugin_contract.py
@@ -26,6 +26,9 @@ from modules.foundups.agent.src.kanban_plugin_contract import (
     _scan_authority,
     _check_path,
     _AUTHORITY_MARKERS,
+    _redact_deep,
+    _key_is_command,
+    _COMMAND_KEY_MARKERS,
 )
 
 MODULE_SRC = (
@@ -928,3 +931,200 @@ def test_downstream_bad_path_still_rejected_outcome_only():
         {"slice_id": "s", "lane": "ready", "contextbundle_id": "cb", "risk_class": "SPINE_CODE",
          "allowed_paths": ["/etc/passwd"]}
     ).ok
+
+
+# ===========================================================================
+# SLICE FIX 1 -- _redact_deep redacts string KEYS as well as string VALUES.
+# Re-review of the parked publish adapter exposed that origin/main's _redact_deep
+# redacted dict VALUES/leaves but NOT dict KEYS, so a secret used as a nested dict
+# KEY survived verbatim into to_dict() and the adapter outbox. HEAD redacts the KEY
+# with the SAME redact_sensitive used for values; non-string keys pass through; the
+# input mapping is NOT mutated.
+# ===========================================================================
+
+# A synthetic credential whose shape redact_sensitive matches (sk- + 16+ alnum).
+# Built from chr() so no literal token rides in the source.
+_SYNTH_SECRET = "sk-" + "".join(chr(c) for c in range(ord("A"), ord("A") + 16)) + "1234"
+# -> "sk-ABCDEFGHIJKLMNOP1234"; redact_sensitive must collapse it to [REDACTED].
+
+
+def test_redact_deep_redacts_string_dict_key():
+    # The exact Finding-1 case: a secret used as a dict KEY (and the same secret as a
+    # value under a benign key). BOTH must be redacted; the raw secret must not survive.
+    src = {_SYNTH_SECRET: "v", "f": _SYNTH_SECRET}
+    out = _redact_deep(src)
+    blob = json.dumps(out)
+    assert _SYNTH_SECRET not in blob, "raw secret survived as a dict KEY or VALUE"
+    # The key was redacted (no raw secret key remains); a redacted key/value is present.
+    assert _SYNTH_SECRET not in out, "raw secret survived as a dict KEY"
+    assert "[REDACTED]" in blob
+
+
+def test_redact_deep_redacts_nested_dict_key():
+    # A secret KEY nested several levels deep is still redacted. The secret is used as a
+    # STANDALONE key at each level (the Finding-1 scenario: a secret used AS a dict key),
+    # matching the same token-shape the value redactor matches (redact_sensitive uses
+    # word-boundary anchors, so a standalone secret token -- key OR value -- is redacted).
+    src = {"outer": {"mid": {_SYNTH_SECRET: {_SYNTH_SECRET: "x"}}}}
+    blob = json.dumps(_redact_deep(src))
+    assert _SYNTH_SECRET not in blob, "raw secret survived as a nested dict KEY"
+    assert "[REDACTED]" in blob
+
+
+def test_redact_deep_non_string_keys_pass_through():
+    # Non-string keys (int / tuple) are preserved as-is (only string keys are redacted).
+    src = {7: "v", (1, 2): "w"}
+    out = _redact_deep(src)
+    assert 7 in out and (1, 2) in out, "non-string keys must pass through unchanged"
+
+
+def test_redact_deep_does_not_mutate_input():
+    # Purity: the original mapping (keys AND values) is unchanged; a NEW structure is built.
+    inner = {_SYNTH_SECRET: "v"}
+    src = {"a": inner}
+    out = _redact_deep(src)
+    assert src == {"a": {_SYNTH_SECRET: "v"}}, "input mapping must not be mutated"
+    assert inner == {_SYNTH_SECRET: "v"}, "nested input mapping must not be mutated"
+    assert out is not src and out["a"] is not inner
+
+
+def test_card_to_dict_no_secret_in_keys_or_values():
+    # End-to-end through KanbanCardSpec.to_dict(): a secret hidden as a dict KEY inside a
+    # list/dict free-text field never appears in keys OR values of the serialized body.
+    card = KanbanCardSpec(
+        slice_id="s", lane="ready", contextbundle_id="cb", risk_class="SPINE_CODE",
+        expected_evidence=[{_SYNTH_SECRET: "note", "f": _SYNTH_SECRET}],
+    )
+    body = card.to_dict()
+    blob = json.dumps(body)
+    assert _SYNTH_SECRET not in blob, "raw secret leaked into card to_dict() keys OR values"
+    assert "[REDACTED]" in blob
+    # The instance is not mutated (raw secret key still present on the live object).
+    assert card.expected_evidence == [{_SYNTH_SECRET: "note", "f": _SYNTH_SECRET}]
+
+
+# ===========================================================================
+# SLICE FIX 2 -- command-key matching is TOKEN/BOUNDARY-precise, NOT substring.
+# Re-review exposed that the substring check (#843) treated "description" (contains
+# "script"), "transcript", etc. as command-keys, so an ordinary string field was
+# FALSELY REJECTED after #843 made command-keys reject bare strings. HEAD matches a
+# command-key IFF a NORMALIZED underscore-token equals a single-token marker.
+# ===========================================================================
+
+# Single-token command markers that MUST be treated as command-keys.
+_TRUE_COMMAND_KEYS = [
+    "command", "cmd", "shell", "script", "exec", "argv",
+    "run_command", "runCmd", "exec_now", "shell_command", "run_cmd",
+]
+
+# Legit field names that CONTAIN a command-marker substring but are NOT command-keys
+# (each normalizes to a single NON-marker token, or tokens with no marker token).
+_FALSE_POSITIVE_FIELDS = [
+    "description", "transcript", "subscription", "executive",
+    "scripted", "prescription", "descriptor", "executive_summary",
+    "scripted_notes", "subscription_id", "transcription",
+]
+
+
+@pytest.mark.parametrize("key", _TRUE_COMMAND_KEYS)
+def test_key_is_command_true_for_real_command_keys(key):
+    assert _key_is_command(key), f"true command key not detected: {key!r}"
+
+
+@pytest.mark.parametrize("key", _FALSE_POSITIVE_FIELDS)
+def test_key_is_command_false_for_legit_fields(key):
+    assert not _key_is_command(key), f"legit field falsely treated as command key: {key!r}"
+
+
+def test_command_match_is_token_precise_not_substring():
+    # Direct contrast: 'script' (marker) vs 'description'/'transcript' (substring only).
+    assert _key_is_command("script")
+    assert not _key_is_command("description")
+    assert not _key_is_command("transcript")
+
+
+@pytest.mark.parametrize("field_name", _FALSE_POSITIVE_FIELDS)
+def test_legit_substring_field_with_string_value_accepted(field_name):
+    # NEW invariant #843 lacked: a legit field whose name CONTAINS a command-marker
+    # substring, carrying an ordinary string value, is ACCEPTED (no false rejection).
+    res = validate_card_spec(_card(**{field_name: "ordinary text value"}))
+    assert res.ok, f"legit field {field_name!r} falsely rejected: {res.errors}"
+
+
+def test_description_and_transcript_accepted():
+    assert validate_card_spec(_card(description="ordinary string")).ok
+    assert validate_card_spec(_card(transcript="ordinary string")).ok
+
+
+@pytest.mark.parametrize("cmd_key", [
+    "command", "run_command", "runCmd", "exec_now", "shell_command",
+    "cmd", "shell", "script", "exec", "argv",
+])
+def test_true_command_keys_still_reject_bare_string(cmd_key):
+    # MUST CATCH: a bare string under any TRUE command key (incl. multi-token forms) is
+    # rejected (argv-or-null only). 'rm -rf /' / 'pytest' / 'x' all bare -> rejected.
+    res = validate_card_spec(_card(**{cmd_key: "pytest"}))
+    assert not res.ok, f"true command key {cmd_key!r} accepted a bare string"
+
+
+def test_command_rm_rf_rejected():
+    assert not validate_card_spec(_card(command="rm -rf /")).ok
+
+
+@pytest.mark.parametrize("cmd_key", ["command", "run_command", "shell_command", "cmd", "exec"])
+def test_true_command_key_safe_argv_list_accepted(cmd_key):
+    # A valid all-safe argv list under a TRUE command key is still ACCEPTED.
+    res = validate_card_spec(_card(**{cmd_key: ["python", "-m", "pytest", "tests/"]}))
+    assert res.ok, f"safe argv under {cmd_key!r} falsely rejected: {res.errors}"
+
+
+# ===========================================================================
+# TWO-DIRECTIONAL PARITY -- (a) NO WEAKENING of AUTHORITY detection and
+# (b) NO FALSE-POSITIVE on legit command-substring fields (the NEW invariant).
+# ===========================================================================
+
+# Legit field names that CONTAIN a command-marker substring, carrying ORDINARY string
+# values, must ALL be ACCEPTED. This is the NEW invariant #843's substring check lacked.
+_FALSE_POSITIVE_BATTERY = [
+    _card(description="ordinary text"),
+    _card(transcript="meeting transcript text"),
+    _card(subscription="monthly subscription note"),
+    _card(executive_summary="summary text"),
+    _card(descriptor="a descriptor string"),
+    _card(prescription="a prescription note"),
+    _card(scripted_notes="scripted notes content"),
+    _card(transcription="transcription text"),
+    _card(subscription_id="sub_12345"),
+]
+
+
+@pytest.mark.parametrize("payload", _FALSE_POSITIVE_BATTERY)
+def test_false_positive_battery_legit_fields_accepted(payload):
+    # NO FALSE-POSITIVE: a legit command-substring field with an ordinary value is ACCEPTED.
+    assert validate_card_spec(payload).ok, validate_card_spec(payload).errors
+
+
+def test_false_positive_battery_zero_falsely_rejected_summary():
+    # Summary guard: across the WHOLE legit-field corpus, ZERO are rejected by HEAD.
+    falsely_rejected = [p for p in _FALSE_POSITIVE_BATTERY if not validate_card_spec(p).ok]
+    assert falsely_rejected == [], (
+        f"{len(falsely_rejected)} legit command-substring fields falsely REJECTED (over-rejection)"
+    )
+
+
+def test_authority_detection_not_weakened_by_token_match():
+    # The command-KEY change must NOT touch AUTHORITY detection. Re-assert the whole
+    # origin-rejected AUTHORITY corpus stays rejected (the no-weakening invariant applies
+    # to AUTHORITY markers -- NOT to the command-substring over-matches being fixed).
+    authority_corpus = [p for p in _ORIGIN_REJECTED_CARDS]
+    newly_accepted = [p for p in authority_corpus if validate_card_spec(p).ok]
+    assert newly_accepted == [], (
+        f"{len(newly_accepted)} origin-rejected AUTHORITY payloads newly ACCEPTED (weakening)"
+    )
+
+
+def test_command_marker_set_is_single_token():
+    # The marker set is single-token by construction (no underscore inside any marker),
+    # which is what makes the token-equality match well-defined.
+    assert all("_" not in m for m in _COMMAND_KEY_MARKERS), _COMMAND_KEY_MARKERS
+    assert _COMMAND_KEY_MARKERS == frozenset({"command", "cmd", "argv", "shell", "exec", "script"})


### PR DESCRIPTION
## Summary

Closes the two findings the parked Kanban publish adapter's **independent re-review** surfaced, at the **#807
contract source** (decision A). LOGIC change. This slice satisfies **both** parity directions -- the #843 gate
proved "no weakening" but **not** "no over-rejection"; here we prove both. Base origin/main `005dd3629`.
Worker-Lane A. **File scope: 5** (the contract + its tests + 3 ModLogs).

## Fix 1 -- `_redact_deep` redacts dict KEYS as well as values (`:133`)
```python
{(redact_sensitive(k) if isinstance(k, str) else k): _redact_deep(v) for k, v in node.items()}
```
A secret used as a nested **dict key** now serializes as `[REDACTED]` in `to_dict()` (it previously survived
raw -- the adapter outbox leak). Non-string keys pass through; a **new** structure is returned (no mutation).

## Fix 2 -- command-key matching is TOKEN-precise, not substring (`_key_is_command`, `:165`)
The normalized key is split into tokens and matched **iff a token is exactly** a single-token marker
`{command, cmd, argv, shell, exec, script}`. So `description` (contains "script") / `transcript` are **no longer**
false command-keys, while true command keys (`command`/`cmd`/`shell`/`script`/`exec`/`argv`/`run_command`/
`runCmd`/`exec_now`/`shell_command`) still reject bare strings (argv-or-null preserved). This fixes the **#843
over-rejection regression** where a raw-dict `{"description":"text"}` field was hard-rejected.

## Two-directional parity (the gate-philosophy correction)
- **No weakening**: authority detection (the real markers -- gate/merge/repo/dao/payout/cabr/source_authority/
  verified/path/shell-metachar-in-value/key-presence/normalization-evasion) is **unchanged**; every authority
  input origin rejected is still rejected (**0 newly accepted**).
- **No over-rejection (new invariant #843 lacked)**: legitimate field names containing a command substring
  (`description`/`transcript`/`subscription`/`executive_summary`/`descriptor`/`prescription`/`scripted_notes`)
  with ordinary string values are now **accepted**. The command-key narrowing is an **intended fix**, not a
  weakening (those were never real authority/command keys).

## Adversarial review
Independent 5-lane SENTINEL (key-redaction-leak / command-token-precision / **no-weakening-authority** /
**no-false-positive-legit-field** / adapter-regression-fixture). The two critical two-directional lanes both
passed (0 authority weakenings; legit fields accepted), and the adapter-regression lane confirms **both findings
closed at source**. One lane raised a HIGH that was a **confirmed false alarm** -- it read the committed HEAD
blob (`005dd3629`, still the #843 substring version) instead of the working tree; direct verification (live:
secret-as-key -> `[REDACTED]`, `description`-string accepted, `command` bare-string rejected) disproved it.
Orchestrator audit independently re-confirmed: 0 weakenings, 0 false-positives, secret-as-key redacted, 1016 suite.

## Tests
`test_kanban_plugin_contract.py` 251 -> **319**; full agent suite **1016 passed** (heavy + CI), no skip/xfail.
**WSP_97 14/14 PASS** (canonical header). ASCII-clean.

## Scope + next step
Only `kanban_plugin_contract.py` + its tests + ModLogs. No adapter work, no Kanban DB, no Hermes import, no
runtime wiring. **The parked `KANBAN_EXTERNAL_ADAPTER_PUBLISH_PILOT_PHASE1` rebases onto this** and inherits
redacted-keys + precise-command behavior, closing its outbox-redaction and false-rejection issues at the source.

Predecessors: #807, #838, #843. Surfaced by the parked publish-adapter re-review.

**STOP at MERGE_READY** -- not self-merged; external 0102 gate authorizes LAND.
