### PR TITLE
docs(extension): FoundUps Agent branding + F0 safety (manifest/docs)

### DIFF
--- a/docs/audits/architecture/FOUNDUPS_AGENT_EXTENSION_F0_SAFETY_PHASE1.md
+++ b/docs/audits/architecture/FOUNDUPS_AGENT_EXTENSION_F0_SAFETY_PHASE1.md
@@ -1,0 +1,125 @@
+# FOUNDUPS_AGENT_EXTENSION_F0_SAFETY_PHASE1 — Audit
+
+**Slice:** FOUNDUPS_AGENT_EXTENSION_BRANDING_AND_F0_SAFETY_PHASE1  
+**Calibration:** DECISION_ONLY_DOCS + manifest  
+**Base:** post-#874 `origin/main` (`51ba16dfb`)  
+**Date:** 2026-06-24  
+**Package id (unchanged):** `foundups-fusion-worker`
+
+---
+
+## 1. Manifest audit
+
+| Field | Before | After (this slice) | Notes |
+| --- | --- | --- | --- |
+| `name` | `foundups-fusion-worker` | **unchanged** | Avoid breaking installs/settings |
+| `displayName` | FoundUps Fusion Worker | **FoundUps Agent** | Product surface name |
+| `description` | Fusion advisory worker | **WSP-guided advisory coding architect** | RedDog persona inside product |
+| Command title | FoundUps Fusion: Open | **FoundUps Agent: Open RedDog** | Persona explicit |
+| Configuration title | FoundUps Fusion Worker | **FoundUps Agent** | Settings namespace still `foundupsFusion.*` |
+| `activationEvents` | `onCommand:foundupsFusion.open` | **unchanged** | Command id stable |
+| Categories | Other | **unchanged** | No capability expansion |
+
+**Deferred (follow-up slice):** webview header strings in `extension.js` still say "FoundUps Fusion" until `FOUNDUPS_AGENT_UI_LABELS_PHASE1`.
+
+---
+
+## 2. Capability matrix (current truth)
+
+### Can do now
+
+| Capability | Status | Boundary |
+| --- | --- | --- |
+| Read bounded repo context | OBSERVED | Extension-gathered packet only; no model filesystem access |
+| HoloIndex / git diff context | OBSERVED | Tiered by WSP_15 classification; bundle-json first |
+| Redaction-gated OpenRouter egress | OBSERVED | `advisory_model_once.py` + Fusion redaction gate |
+| WSP_00 / WSP_97 / WSP_15 advisory reviews | OBSERVED | Schema validator + one repair pass |
+| Skillz / OpenClaw / Hermes / WRE handoff **recommendations** | OBSERVED | Advisory text only |
+| Review packet copy for 0102 | OBSERVED | Digests, not raw context |
+| Working trail (v0.3.17) | OBSERVED | Progress/status separation; no execution |
+
+### Cannot do now
+
+| Capability | Status |
+| --- | --- |
+| Edit code directly | BLOCKED |
+| Run arbitrary shell for the model | BLOCKED |
+| Merge PRs | BLOCKED |
+| Create repos | BLOCKED |
+| Execute Skillz / OpenClaw / Hermes | BLOCKED |
+| Mutate F0 (FoundUps-Agent repo) automatically | BLOCKED |
+| Safe arbitrary-repo integration without audit | NEEDS_VERIFICATION |
+
+---
+
+## 3. F0 safety threat model
+
+| Threat | Vector | Current control | Residual |
+| --- | --- | --- | --- |
+| Malicious prompt injection | 012 work focus or repo context steers model | WSP_97 labels; advisory-only; no tool execution | Model may still recommend unsafe actions in text |
+| Malicious repo content | HoloIndex/git/editor context includes hostile text | Bounded caps; redaction gate; no auto-execution | INFERRED content can influence recommendations |
+| `.env` / gitignored secret leakage | Context gather reads sensitive files | Redaction gate; no `.env` in prompt contract; git ls-files bounded | Host git/HoloIndex paths NEEDS_VERIFICATION per workspace |
+| Extension host command execution | `cp.spawn` for bridge/context | Fixed scripts only; model cannot invoke | Bridge compromise out of scope |
+| OpenRouter data egress | Prompt/context after redaction | Redaction before network; digests in packet | Provider trust boundary |
+| Model-generated malware instructions | Advisory output | No auto-run; 012 sovereign review | Human must not paste-run blindly |
+| Accidental F0 mutation | Extension writes repo | **No write path in extension** | Other Cursor tools out of scope |
+| Worm / viral self-propagation | Auto-install, hooks, spread | No auto-install; no hook writes; no dispatch | Future intake mode must preserve gates |
+
+---
+
+## 4. Required safeguards (documented)
+
+- Advisory-only by default  
+- Redaction before network  
+- No `.env` / gitignored secret ingestion by design intent  
+- No automatic writes from extension  
+- No automatic shell execution from model output  
+- No auto-install hooks  
+- No repo mutation without WRE-governed handoff  
+- 012 sovereign approval for merges/publish  
+- WSP_97 truth labels on substantive claims  
+
+---
+
+## 5. Future path: FoundUps Agent Intake Mode
+
+```text
+external repo
+  -> FoundUps Agent scans bounded context
+  -> WSP readiness audit
+  -> FoundUp intake packet (WSP_109)
+  -> Skillz map
+  -> integration risk / safety report
+  -> optional governed WRE handoff recommendation
+  -> NO automatic onboarding without verification
+```
+
+**F0 rule:** FoundUps-Agent repo (F0) must never be mutated automatically by the extension.
+
+**External repos:** Assessed through advisory WSP intake, not automatic execution.
+
+---
+
+## 6. WSP_97 truth table (this slice)
+
+| Claim | Status |
+| --- | --- |
+| PRODUCT_NAME_IS_FOUNDUPS_AGENT | OBSERVED (manifest + docs) |
+| PACKAGE_ID_UNCHANGED | OBSERVED (`foundups-fusion-worker`) |
+| REDDOG_IS_ARCHITECT_PERSONA | OBSERVED |
+| FUSION_IS_INTERNAL_MODE_NOT_PRODUCT | OBSERVED (docs) |
+| EXTENSION_REMAINS_ADVISORY_ONLY | OBSERVED |
+| NO_REPO_WRITE_AUTHORITY | OBSERVED |
+| NO_MODEL_SHELL_AUTHORITY | OBSERVED |
+| F0_NO_AUTO_MUTATION | OBSERVED (by absence of write paths) |
+| INTAKE_MODE_FUTURE_NOT_IMPLEMENTED | SPECIFIED_NOT_IMPLEMENTED |
+| WEBVIEW_HEADER_LABELS_LAG_MANIFEST | NEEDS_VERIFICATION (extension.js follow-up) |
+
+---
+
+## 7. Residual NEEDS_VERIFICATION
+
+1. Webview runtime strings (`extension.js`) still say "FoundUps Fusion" until UI labels slice.  
+2. VSIX marketplace/install display vs manifest-only rename on existing installs.  
+3. External-repo safety for Intake Mode requires separate threat review before implementation.  
+4. Legal/trademark review before any `FoundUps(R)Agent` registered-mark styling.

--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -1,10 +1,16 @@
-# FoundUps Fusion Worker Interface
+# FoundUps Agent Interface (RedDog Architect)
 
 ## Purpose
 
-`foundups-fusion-worker` is a local Cursor/VS Code extension that opens a RedDog Architect advisory surface backed by OpenRouter models through `scripts/advisory_model_once.py`.
+FoundUps Agent is the product surface. RedDog is the 0102 architect persona inside it. Fusion is an internal reasoning mode, not the product name.
 
-It is an IDE-side proof surface for the future RedDog/pfMALL/WRE intake pattern. It does not implement pfMALL runtime wiring, WRE dispatch, FoundUp registration, repository creation, or CABR verification.
+Package id (unchanged for install stability): `foundups-fusion-worker`
+
+This local Cursor/VS Code extension opens the RedDog Architect advisory surface backed by OpenRouter models through `scripts/advisory_model_once.py`.
+
+It is a WSP-guided advisory coding architect for integrating projects into FoundUps. It is an IDE-side proof surface for the future RedDog/pfMALL/WRE intake pattern. It does not implement pfMALL runtime wiring, WRE dispatch, FoundUp registration, repository creation, or CABR verification.
+
+**F0:** The FoundUps-Agent repo is F0. The extension must never mutate F0 automatically. External repos are assessed through advisory WSP intake, not automatic execution.
 
 ## RedDog and the Recursive 0102 DAE Ecosystem
 

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -1,4 +1,15 @@
-# FoundUps Fusion Worker ModLog
+# FoundUps Agent ModLog (package: foundups-fusion-worker)
+
+## 2026-06-24 - FOUNDUPS_AGENT_EXTENSION_BRANDING_AND_F0_SAFETY_PHASE1
+
+- Renamed user-facing identity: **FoundUps Agent** (product) with **RedDog Architect** persona.
+- Manifest: `displayName` FoundUps Agent; command `FoundUps Agent: Open RedDog`; package id unchanged (`foundups-fusion-worker`).
+- Documented F0 safety boundary, capability can/cannot matrix, threat model, and future Intake Mode path.
+- Added audit: `docs/audits/architecture/FOUNDUPS_AGENT_EXTENSION_F0_SAFETY_PHASE1.md`.
+- Fusion documented as internal mode only; no runtime behavior changes.
+- Webview header strings deferred to `FOUNDUPS_AGENT_UI_LABELS_PHASE1`.
+
+WSP: WSP_22, WSP_97.
 
 ## V0.3.17 — REDDOG_WORKING_TRAIL_PHASE1_CODE — 2026-06-23
 

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,14 +1,18 @@
-# FoundUps Fusion Worker
+# FoundUps Agent — RedDog Architect
 
-Version: 0.3.15
+Version: 0.3.17
 
-This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
+FoundUps Agent is the product surface. RedDog is the 0102 digital-twin / architect persona inside it. Fusion is one internal reasoning mode (along with single-model and panel paths), not the product name.
+
+This local Cursor/VS Code extension opens the RedDog Architect advisory worker as an editor webview tab — similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 
 Command:
 
-- `FoundUps Fusion: Open`
+- `FoundUps Agent: Open RedDog`
 
-Default panel:
+**F0 safety:** F0 is the foundation FoundUps-Agent repo. The extension must never mutate F0 automatically. External repos can be assessed for FoundUps integration through advisory WSP intake, not automatic execution.
+
+Default panel (internal Fusion mode):
 
 - Principal/synthesis: `z-ai/glm-5.2`
 - Critics: `deepseek/deepseek-v4-pro` and `moonshotai/kimi-k2.7-code`
@@ -43,6 +47,42 @@ Default panel:
 ### Autonomy Boundary
 
 Autonomous WRE/DAE agents are NOT 012 work. 012 provides work focus, testing, sovereign approval, and override. 0102 DAEs communicate recursively and perform bounded autonomous work under WRE governance. The extension remains advisory; WRE retains execution authority.
+
+## Capability truth (F0)
+
+### Can do now
+
+- Read bounded repo context (extension-gathered; model has no direct filesystem access)
+- Run HoloIndex / git diff context gathering (tiered by WSP_15)
+- Send redaction-gated prompts to OpenRouter
+- Produce WSP_00 / WSP_97 / WSP_15 advisory reviews
+- Recommend Skillz / OpenClaw / Hermes / WRE handoffs (advisory only)
+- Copy redacted review packet for 0102 review
+
+### Cannot do now
+
+- Edit code directly
+- Run arbitrary shell for the model
+- Merge PRs or create repos
+- Execute Skillz / OpenClaw / Hermes
+- Guarantee safe operation on arbitrary repos without a dedicated safety audit
+- Automatically onboard external repos into FoundUps
+
+## Future: FoundUps Agent Intake Mode
+
+For "any repo can integrate into FoundUps," the planned path is **FoundUps Agent Intake Mode**:
+
+```text
+external repo
+  -> bounded context scan
+  -> WSP readiness audit
+  -> FoundUp intake packet (WSP_109)
+  -> Skillz map
+  -> integration risk / safety report
+  -> optional governed WRE handoff recommendation
+```
+
+No automatic onboarding without verification. Intake Mode is not implemented in v0.3.17.
 
 ## Operating Contract
 
@@ -85,7 +125,7 @@ The webview follows the VS Code terminal/chat shape:
 - Context: automatic. ULTRA tasks attach WSP + HoloIndex + active editor + git diff + Skillz/Wardrobe/Rolodex discovery; HIGH tasks attach WSP + HoloIndex + active editor + Skillz/Wardrobe/Rolodex discovery; REGULAR smoke avoids repo context.
 - Tests: regular smoke, Fusion smoke, WSP_97 repo review, RedDog architect review.
 
-For WSP/security/runtime/architecture work, RedDog auto-routes to `foundups_fusion` because it preserves a review packet with principal, critic, and synthesis excerpts. Regular smoke/simple prompts auto-route to a single GLM principal call. OpenRouter Fusion alias remains implemented in the bridge for explicit future use, but is not a 012-facing default control because individual critic traces are not exposed by the API response.
+For WSP/security/runtime/architecture work, RedDog auto-routes to internal **`foundups_fusion`** panel mode because it preserves a review packet with principal, critic, and synthesis excerpts. Regular smoke/simple prompts auto-route to a single GLM principal call. OpenRouter Fusion alias remains implemented in the bridge for explicit future use, but is not a 012-facing default control because individual critic traces are not exposed by the API response.
 
 Substantive RedDog answers must include: Decision, Findings, Evidence, Proposed fixes, Uncertainties, Architect Trace (structured evidence/alternatives/critic rationale — never raw hidden chain-of-thought), WSP_97 Truth Labels, WSP_15 Priority, Verification gaps, Next safest step. Fusion runs also expose Lead/Critic/Synthesis panel structure from the bridge. If sections are missing, the extension runs one repair pass through the same redaction-gated bridge before showing the final answer.
 
@@ -127,6 +167,10 @@ Output is prefixed with a visible **RedDog Routing** block (tier, effort, mode, 
 | SENTINELS_REVIEW_NOT_EXECUTE | OBSERVED |
 | CABR_PAVS_VALIDATES_BENEFIT | OBSERVED |
 | EXTENSION_REMAINS_ADVISORY_ONLY | OBSERVED |
+| PRODUCT_NAME_IS_FOUNDUPS_AGENT | OBSERVED (manifest; webview labels follow-up) |
+| FUSION_IS_INTERNAL_MODE | OBSERVED |
+| F0_NO_AUTO_MUTATION | OBSERVED (no extension write path) |
+| FOUNDUPS_AGENT_INTAKE_MODE | SPECIFIED_NOT_IMPLEMENTED |
 
 ## Settings
 
@@ -170,4 +214,4 @@ From Cursor:
 1. Open Command Palette.
 2. Run `Extensions: Install from VSIX...` and select the generated `foundups-fusion-worker-0.3.15-work-focus.vsix` (or current package version).
 3. Do not use workspace-extension install for normal operation; install the VSIX and reload the window.
-4. Run `FoundUps Fusion: Open` from Command Palette or the three-dot command list.
+4. Run `FoundUps Agent: Open RedDog` from Command Palette or the three-dot command list.

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -1,12 +1,12 @@
-# FoundUps Fusion Worker Roadmap
+# FoundUps Agent Roadmap (RedDog Architect)
 
 ## Status
 
-Phase: IDE-side RedDog Architect proof surface.
+Phase: IDE-side **FoundUps Agent** proof surface with **RedDog Architect** persona.
 
 Current implementation:
 
-- Cursor command: `FoundUps Fusion: Open`.
+- Cursor command: `FoundUps Agent: Open RedDog`.
 - Bottom-composer webview with scrollback output.
 - OpenRouter bridge with redaction gate.
 - WSP_00/WSP_97/WSP_15 operating prompt.
@@ -62,6 +62,26 @@ IDE extension POC
 | WRE/OpenClaw dispatch bridge | 4 | 5 | 3 | 5 | 17 | P0 | Must remain governed; extension cannot dispatch directly |
 
 ## Next Slices
+
+### FOUNDUPS_AGENT_INTAKE_MODE_PHASE1
+
+External repo -> FoundUps integration assessment (advisory only):
+
+- Bounded context scan of target repo
+- WSP readiness audit
+- WSP_109 FoundUp intake packet draft
+- Skillz map recommendation
+- Integration risk / F0 safety report
+- Governed WRE handoff recommendation
+- No automatic onboarding or repo mutation without verification
+
+### FOUNDUPS_AGENT_UI_LABELS_PHASE1
+
+Align runtime webview strings in `extension.js` with manifest branding:
+
+- Header: `FoundUps Agent — RedDog Architect`
+- Loaded status line
+- Keep package id and command id unchanged
 
 ### REDDOG_BRIDGE_HARDENING_PHASE1
 

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -1,7 +1,7 @@
 {
     "name":  "foundups-fusion-worker",
-    "displayName":  "FoundUps Fusion Worker",
-    "description":  "Open a WSP_00/WSP_97 RedDog Architect Fusion advisory worker in a Cursor editor webview tab.",
+    "displayName":  "FoundUps Agent",
+    "description":  "WSP-guided advisory coding architect for integrating projects into FoundUps. Opens the RedDog Architect persona inside a Cursor webview tab.",
     "version":  "0.3.17",
     "publisher":  "foundups",
     "icon":  "icon.png",
@@ -19,7 +19,7 @@
                         "commands":  [
                                          {
                                              "command":  "foundupsFusion.open",
-                                             "title":  "FoundUps Fusion: Open",
+                                             "title":  "FoundUps Agent: Open RedDog",
                                              "category":  "FoundUps"
                                          }
                                      ],
@@ -43,7 +43,7 @@
                                                                ]
                                   },
                         "configuration":  {
-                                              "title":  "FoundUps Fusion Worker",
+                                              "title":  "FoundUps Agent",
                                               "properties":  {
                                                                  "foundupsFusion.pythonPath":  {
                                                                                                    "type":  "string",

--- a/extensions/foundups_advisory_workers/tests/TestModLog.md
+++ b/extensions/foundups_advisory_workers/tests/TestModLog.md
@@ -1,4 +1,11 @@
-# FoundUps Fusion Worker TestModLog
+# FoundUps Agent TestModLog
+
+## 2026-06-24 — FoundUps Agent branding + F0 safety contract tests
+
+- Package id unchanged: `foundups-fusion-worker`.
+- displayName: FoundUps Agent; command: FoundUps Agent: Open RedDog.
+- README/INTERFACE product identity + F0 + Intake Mode wording.
+- Fusion-as-internal-mode assertions; no Fusion-as-product title.
 
 ## 2026-06-23 — v0.3.17 Working Trail Phase 2 CODE Tests
 

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -16,6 +16,18 @@ function includes(haystack, needle, label) {
   assert(haystack.includes(needle), label || `missing ${needle}`);
 }
 
+assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain foundups-fusion-worker');
+assert.strictEqual(pkg.displayName, 'FoundUps Agent', 'displayName must be FoundUps Agent');
+includes(JSON.stringify(pkg.contributes.commands), 'FoundUps Agent: Open RedDog', 'command title must be FoundUps Agent: Open RedDog');
+includes(readme, 'FoundUps Agent is the product surface', 'README product identity missing');
+includes(readme, 'RedDog is the 0102 digital-twin / architect persona', 'README RedDog persona missing');
+includes(readme, 'Fusion is one internal reasoning mode', 'README Fusion-as-mode wording missing');
+includes(readme, 'F0 is the foundation FoundUps-Agent repo', 'README F0 safety missing');
+includes(readme, 'FoundUps Agent Intake Mode', 'README intake mode path missing');
+assert(!readme.startsWith('# FoundUps Fusion Worker'), 'Fusion must not remain product title');
+includes(iface, 'FoundUps Agent is the product surface', 'INTERFACE product identity missing');
+includes(roadmap, 'FOUNDUPS_AGENT_INTAKE_MODE_PHASE1', 'intake mode roadmap slice missing');
+
 assert.strictEqual(pkg.version, '0.3.17', 'package version must be 0.3.17');
 includes(extensionJs, "const EXTENSION_VERSION = '0.3.17'", 'extension build mismatch');
 includes(extensionJs, 'id="reddogWorkingTrail"', 'working trail DOM missing');
@@ -249,4 +261,4 @@ for (const glyph of forbiddenPixels) {
   assert(!extensionJs.includes(glyph), 'trail pixel grammar must stay ASCII-only');
 }
 
-console.log('FoundUps Fusion extension contract checks passed.');
+console.log('FoundUps Agent extension contract checks passed.');


### PR DESCRIPTION
## Summary

FOUNDUPS_AGENT_EXTENSION_BRANDING_AND_F0_SAFETY_PHASE1 — docs + manifest + tests only.

Renames user-facing identity from FoundUps Fusion Worker to **FoundUps Agent** while keeping package id \oundups-fusion-worker\ stable.

## Manifest changes

| Field | Value |
| --- | --- |
| name | foundups-fusion-worker (unchanged) |
| displayName | FoundUps Agent |
| command title | FoundUps Agent: Open RedDog |
| configuration title | FoundUps Agent |

## Audit

- docs/audits/architecture/FOUNDUPS_AGENT_EXTENSION_F0_SAFETY_PHASE1.md
- Capability can/cannot matrix
- F0 threat model
- FoundUps Agent Intake Mode (future, not implemented)

## Out of scope

- extension.js runtime UI labels (FOUNDUPS_AGENT_UI_LABELS_PHASE1 follow-up)
- Bridge behavior
- Repo write authority

## Validation

- node --check extension.js PASS
- verify_extension_contract.js PASS
- git diff --check PASS
- mojibake scan PASS

## Gate

VERIFIED_READY for review — **no merge without 012 sovereign token**

Made with [Cursor](https://cursor.com)