### PR TITLE
feat(extension): brand RedDog surface as Foundups®Agent

### DIFF
--- a/docs/audits/architecture/FOUNDUPS_AGENT_EXTENSION_F0_SAFETY_PHASE1.md
+++ b/docs/audits/architecture/FOUNDUPS_AGENT_EXTENSION_F0_SAFETY_PHASE1.md
@@ -1,0 +1,81 @@
+# Foundups®Agent Extension F0 Safety Audit
+
+**Date:** 2026-06-24
+**Slice:** FOUNDUPS_AGENT_EXTENSION_BRANDING_AND_F0_SAFETY_PHASE1
+**Calibration:** DOCS_PLUS_MANIFEST
+
+## Purpose
+
+Rename the user-facing extension surface from "FoundUps Fusion Worker" to
+"Foundups®Agent" while preserving the current authority boundary.
+
+Foundups®Agent is the product surface. RedDog is the 0102 digital-twin architect
+inside it. Fusion is one internal reasoning mode, not the product identity.
+
+## Current Capability Matrix
+
+| Capability | Current Status | Boundary |
+|---|---|---|
+| Bounded repo context | YES | Extension gathers limited WSP/HoloIndex/editor/git/Skillz context |
+| HoloIndex recall | YES | Retrieval evidence only; weak recall must be reported |
+| OpenRouter egress | YES | Redaction gate runs before network |
+| WSP_00/WSP_97/WSP_15 advisory review | YES | Model output is advisory only |
+| Review packet copy | YES | Redacted packet for 0102 review |
+| Model-controlled repo edits | NO | No write tool exposed to model |
+| Model-controlled shell execution | NO | No shell authority exposed to model |
+| Merge/deploy/repo creation | NO | Sovereign/WRE-governed only |
+| Skillz/OpenClaw/Hermes execution | NO | Recommendation only |
+| CABR/pAVS authority | NO | No benefit, payout, or source-authority claim |
+
+## F0 Threat Model
+
+F0 is the foundation Foundups-Agent repo. Foundups®Agent must never mutate F0
+automatically.
+
+Threats considered:
+
+- malicious work focus prompt injection
+- malicious repository content in bounded context
+- accidental inclusion of secrets or gitignored files
+- model-generated malware or worm instructions
+- extension-host command execution expansion
+- OpenRouter data egress before redaction
+- automatic repo mutation, merge, deploy, or package install behavior
+- false WSP/CABR/source-authority claims
+
+## Safeguards
+
+- 012 supplies work focus only; 0102 assembles WSP task prompt.
+- Redaction gate runs before any OpenRouter call.
+- The extension provides no model-controlled file write, shell, browser, merge, or
+  deploy tool.
+- Skillz/OpenClaw/Hermes/WRE surfaces are advisory handoff candidates only.
+- `.env` and gitignored secret ingestion remain out of scope.
+- WSP_97 truth labels are required for substantive claims.
+- Any future execution path must go through governed WRE/OpenClaw/Hermes handoff.
+
+## Future Any-Repo Path
+
+FoundUps Agent Intake Mode should assess external repositories without mutating them:
+
+1. WSP readiness audit
+2. FoundUp intake packet
+3. Skillz map
+4. integration risk report
+5. governed WRE handoff recommendation
+
+No automatic onboarding, package install, repo mutation, publication, CABR claim, or
+FoundUp registration is permitted in this phase.
+
+## WSP_97 Truth Table
+
+| # | Truth Boundary Checklist Item | Status | Evidence |
+|---|---|---|---|
+| 1 | FOUNDUPS_AGENT_IS_PRODUCT_SURFACE | OBSERVED | package.json displayName and docs use Foundups®Agent. |
+| 2 | REDDOG_IS_ARCHITECT_INSIDE_AGENT | OBSERVED | README, INTERFACE, ROADMAP state RedDog is the 0102 architect inside Foundups®Agent. |
+| 3 | FUSION_IS_INTERNAL_MODE | OBSERVED | README, INTERFACE, ROADMAP state Fusion is an internal reasoning mode. |
+| 4 | PACKAGE_ID_STABLE | OBSERVED | package.json name remains foundups-fusion-worker. |
+| 5 | F0_NO_AUTO_MUTATION | SPECIFIED_NOT_IMPLEMENTED | Docs define boundary; no new execution path added. |
+| 6 | MODEL_NO_SHELL_AUTHORITY | OBSERVED | Extension contract exposes no model-controlled shell tool. |
+| 7 | GOVERNED_HANDOFF_ONLY | SPECIFIED_NOT_IMPLEMENTED | Handoff execution remains roadmap only. |
+| 8 | ANY_REPO_INTAKE_ADVISORY_ONLY | SPECIFIED_NOT_IMPLEMENTED | Intake mode is roadmap only; no runtime wiring added. |

--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -1,10 +1,12 @@
-# FoundUps Fusion Worker Interface
+# Foundups®Agent Interface
 
 ## Purpose
 
-`foundups-fusion-worker` is a local Cursor/VS Code extension that opens a RedDog Architect advisory surface backed by OpenRouter models through `scripts/advisory_model_once.py`.
+`foundups-fusion-worker` is a local Cursor/VS Code extension whose user-facing product name is Foundups®Agent. It opens a RedDog Architect advisory surface backed by OpenRouter models through `scripts/advisory_model_once.py`.
 
 It is an IDE-side proof surface for the future RedDog/pfMALL/WRE intake pattern. It does not implement pfMALL runtime wiring, WRE dispatch, FoundUp registration, repository creation, or CABR verification.
+
+Foundups®Agent is the product surface. RedDog is the 0102 digital-twin architect inside it. Fusion is one internal reasoning mode, not the product identity.
 
 ## RedDog and the Recursive 0102 DAE Ecosystem
 
@@ -51,6 +53,14 @@ Autonomous WRE/DAE agents are NOT 012 work. 012 provides work focus, testing, so
 | CABR/payout/source authority | NO | Blocked by Fusion redaction gate and prompt contract |
 | pfMALL integration | SPECIFIED_NOT_IMPLEMENTED | Roadmap only |
 | FoundUp onboarding automation | SPECIFIED_NOT_IMPLEMENTED | Roadmap only; WSP_109 packet production is not implemented here |
+
+## F0 Safety Boundary
+
+F0 is the foundation Foundups-Agent repo. Foundups®Agent must never mutate F0 automatically.
+
+The extension may gather bounded context and produce advisory review packets. It must not execute model-generated code, install packages, create persistence, write files, mutate repositories, publish artifacts, or call Skillz/OpenClaw/Hermes/WRE execution surfaces directly. Any future execution path must be a governed handoff where WRE retains repo/process authority and 012 remains sovereign for test, land, publish, and override decisions.
+
+External repositories are assessed through advisory WSP intake before they can become FoundUps candidates. The extension can recommend a FoundUp intake packet and integration risk report; it cannot automatically enroll or mutate an external repo.
 
 ## Webview Contract
 

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -1,6 +1,11 @@
-# FoundUps Fusion Worker ModLog
+# Foundups®Agent ModLog
 
-## V0.3.17 — REDDOG_WORKING_TRAIL_PHASE1_CODE — 2026-06-23
+## 2026-06-24 - v0.3.18 Foundups®Agent Branding
+- Renamed user-facing extension surface from "FoundUps Fusion Worker" to "Foundups®Agent".
+- Kept internal package id and command id stable (`foundups-fusion-worker`, `foundupsFusion.open`) to avoid breaking existing installs/settings.
+- Clarified that RedDog is the 0102 digital-twin architect inside Foundups®Agent and Fusion is an internal reasoning mode.
+
+## V0.3.17 窶・REDDOG_WORKING_TRAIL_PHASE1_CODE 窶・2026-06-23
 
 - Implemented RedDog working trail strip (`#reddogWorkingTrail`) under work focus composer.
 - ASCII pixel grammar: `~~~`, `.rd.`, `<rd>`, `>rd>`, `!rd!`.
@@ -25,7 +30,7 @@ Audit and doc additions for correct FoundUps architecture capture:
 
 WSP: WSP_00, WSP_48, WSP_54, WSP_73, WSP_97.
 
-## V0.3.17b — REDDOG_WORKING_TRAIL_PHASE1_REPAIR — 2026-06-23
+## V0.3.17b 窶・REDDOG_WORKING_TRAIL_PHASE1_REPAIR 窶・2026-06-23
 
 - Repair pass on docs/REDDOG_WORKING_TRAIL_PHASE1.md.
 - ASCII pixel grammar: replaced `.v.`, `xvx`, `!v!`, `IvI` Unicode glyphs with `.rd.`, `<rd>`, `!rd!`, `>rd>` throughout (tables, code blocks, prose, JS signatures, CSS). Zero non-ASCII confirmed by rg scan.

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,12 +1,14 @@
-# FoundUps Fusion Worker
+# Foundups®Agent
 
-Version: 0.3.15
+Version: 0.3.18
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 
+Foundups®Agent is the product surface. RedDog is the 0102 digital-twin architect inside it. Fusion is one internal reasoning mode, not the product identity.
+
 Command:
 
-- `FoundUps Fusion: Open`
+- `Foundups®Agent: Open`
 
 Default panel:
 
@@ -56,6 +58,21 @@ The extension is a bounded 0102 advisory surface:
 
 The extension does not grant repo authority. **012 supplies work focus only**; 0102 assembles a WSP task prompt before the bridge runs. Work focus and bounded repo context are sent through `scripts/advisory_model_once.py`, which runs the landed Fusion redaction gate before making OpenRouter requests. The webview receives only advisory text and redacted local history.
 
+## F0 Safety Boundary
+
+F0 is the foundation Foundups-Agent repo. Foundups®Agent must never mutate F0 automatically.
+
+Current behavior is advisory-only:
+
+- no model-controlled shell execution
+- no automatic file edits
+- no automatic PR creation, merge, deployment, or repository creation
+- no CABR, payout, source-authority, or verification claims
+- no direct Skillz/OpenClaw/Hermes/WRE execution from the extension
+- redaction gate runs before any OpenRouter egress
+
+External repositories can be assessed for FoundUps integration through advisory WSP intake, not automatic execution. The future path is FoundUps Agent Intake Mode: WSP readiness audit, FoundUp intake packet, Skillz map, integration risk report, and governed WRE handoff recommendation.
+
 ## Work Focus Contract (v0.3.15)
 
 012 does not prompt RedDog directly. The operating flow is:
@@ -87,7 +104,7 @@ The webview follows the VS Code terminal/chat shape:
 
 For WSP/security/runtime/architecture work, RedDog auto-routes to `foundups_fusion` because it preserves a review packet with principal, critic, and synthesis excerpts. Regular smoke/simple prompts auto-route to a single GLM principal call. OpenRouter Fusion alias remains implemented in the bridge for explicit future use, but is not a 012-facing default control because individual critic traces are not exposed by the API response.
 
-Substantive RedDog answers must include: Decision, Findings, Evidence, Proposed fixes, Uncertainties, Architect Trace (structured evidence/alternatives/critic rationale — never raw hidden chain-of-thought), WSP_97 Truth Labels, WSP_15 Priority, Verification gaps, Next safest step. Fusion runs also expose Lead/Critic/Synthesis panel structure from the bridge. If sections are missing, the extension runs one repair pass through the same redaction-gated bridge before showing the final answer.
+Substantive RedDog answers must include: Decision, Findings, Evidence, Proposed fixes, Uncertainties, Architect Trace (structured evidence/alternatives/critic rationale 窶・never raw hidden chain-of-thought), WSP_97 Truth Labels, WSP_15 Priority, Verification gaps, Next safest step. Fusion runs also expose Lead/Critic/Synthesis panel structure from the bridge. If sections are missing, the extension runs one repair pass through the same redaction-gated bridge before showing the final answer.
 
 Output is prefixed with a visible **RedDog Routing** block (tier, effort, mode, mode-selection reasoning, principal, panel, context, advisory boundary).
 
@@ -105,9 +122,9 @@ Output is prefixed with a visible **RedDog Routing** block (tier, effort, mode, 
 | DIGESTS_NOT_RAW_CONTEXT | OBSERVED |
 | ROUTING_UNCHANGED_FROM_0_3_14 | OBSERVED |
 | Mode/Effort/Context not 012-facing dropdowns | OBSERVED |
-| REGULAR → `openrouter_single`, no repo context | OBSERVED |
-| HIGH → `foundups_fusion` + WSP/Holo/Skillz context | OBSERVED |
-| ULTRA → `foundups_fusion` + WSP/Holo/git/Skillz context | OBSERVED |
+| REGULAR 竊・`openrouter_single`, no repo context | OBSERVED |
+| HIGH 竊・`foundups_fusion` + WSP/Holo/Skillz context | OBSERVED |
+| ULTRA 竊・`foundups_fusion` + WSP/Holo/git/Skillz context | OBSERVED |
 | Skillz/Rolodex discovery for operational prompts | OBSERVED |
 | Filesystem fallback when git spawn fails | OBSERVED |
 | RedDog Routing block in output | OBSERVED |
@@ -168,6 +185,6 @@ vsce package --no-dependencies
 From Cursor:
 
 1. Open Command Palette.
-2. Run `Extensions: Install from VSIX...` and select the generated `foundups-fusion-worker-0.3.15-work-focus.vsix` (or current package version).
+2. Run `Extensions: Install from VSIX...` and select the generated `foundups-fusion-worker-0.3.18.vsix` (or current package version).
 3. Do not use workspace-extension install for normal operation; install the VSIX and reload the window.
-4. Run `FoundUps Fusion: Open` from Command Palette or the three-dot command list.
+4. Run `Foundups®Agent: Open` from Command Palette or the three-dot command list.

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -1,4 +1,4 @@
-# FoundUps Fusion Worker Roadmap
+# Foundups®Agent Roadmap
 
 ## Status
 
@@ -6,7 +6,7 @@ Phase: IDE-side RedDog Architect proof surface.
 
 Current implementation:
 
-- Cursor command: `FoundUps Fusion: Open`.
+- Cursor command: `Foundups®Agent: Open`.
 - Bottom-composer webview with scrollback output.
 - OpenRouter bridge with redaction gate.
 - WSP_00/WSP_97/WSP_15 operating prompt.
@@ -17,6 +17,8 @@ Current implementation:
 ## Architecture Direction
 
 This extension is not the final RedDog runtime. It is the operator-facing proof surface for how RedDog should behave before becoming accessible through pfMALL or an OpenClaw/WRE route.
+
+Foundups®Agent is the product surface. RedDog is the 0102 digital-twin architect inside it. Fusion is one internal reasoning mode, not the product identity.
 
 ### RedDog and the Recursive 0102 DAE Ecosystem
 
@@ -62,6 +64,13 @@ IDE extension POC
 | WRE/OpenClaw dispatch bridge | 4 | 5 | 3 | 5 | 17 | P0 | Must remain governed; extension cannot dispatch directly |
 
 ## Next Slices
+
+### FOUNDUPS_AGENT_INTAKE_MODE_PHASE1
+
+- Assess arbitrary external repositories for FoundUps integration readiness.
+- Produce advisory WSP readiness audit, FoundUp intake packet, Skillz map, and integration risk report.
+- No automatic onboarding, repo mutation, package install, or execution.
+- Governed WRE handoff recommendation only.
 
 ### REDDOG_BRIDGE_HARDENING_PHASE1
 
@@ -144,3 +153,5 @@ Addendum B required controls (after v0.3.15 lands):
 - No automatic pfMALL publication.
 - No CABR/payout/source-authority claims.
 - No hidden access to `.env` or gitignored files.
+- No automatic F0 mutation.
+- No worm-like self-propagation, auto-install, or background repo modification behavior.

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.17';
+const EXTENSION_VERSION = '0.3.18';
 const REDDOG_TERMINAL_HOLD_MS = 3000;
 const REDACTION_BLOCK_OPERATOR_MESSAGE = 'Stopped before OpenRouter. Nothing left the machine.';
 
@@ -116,7 +116,7 @@ function enrichRedactionBlockResult(result) {
   return Object.assign({}, result, { review_packet: packet, retry_count: 0 });
 }
 const DEFAULT_FUSION_WORKER = {
-  title: 'FoundUps Fusion',
+  title: 'Foundups®Agent',
   lead: 'z-ai/glm-5.2',
   panel: ['deepseek/deepseek-v4-pro', 'moonshotai/kimi-k2.7-code']
 };
@@ -1090,8 +1090,8 @@ function renderHtml(worker, surface, logoUri) {
       <div class="brand"><img src="${escapedLogoUri}" alt="RedDawg"><h1>${escapedTitle}</h1></div>
       <div class="meta">Build: ${EXTENSION_VERSION}<br>Surface: ${escapedSurface}<br>Principal: ${escapedLead}<br>Panel: ${escapedPanel}<br>Advisory only. Redaction-gated. No repo, shell, or merge authority.</div>
     </header>
-    <main id="log" aria-label="FoundUps Fusion output scrollback">
-      <div class="entry status"><span class="label">status</span>FoundUps Fusion extension ${EXTENSION_VERSION} loaded.</div>
+    <main id="log" aria-label="Foundups®Agent output scrollback">
+      <div class="entry status"><span class="label">status</span>Foundups®Agent extension ${EXTENSION_VERSION} loaded.</div>
       <div class="entry status"><span class="label">status</span>OPENROUTER_API_KEY must be set in the environment used to launch Cursor. Do not paste secrets.</div>
     </main>
     <form id="form">

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -1,8 +1,8 @@
 {
     "name":  "foundups-fusion-worker",
-    "displayName":  "FoundUps Fusion Worker",
-    "description":  "Open a WSP_00/WSP_97 RedDog Architect Fusion advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.17",
+    "displayName":  "Foundups®Agent",
+    "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
+    "version":  "0.3.18",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {
@@ -19,7 +19,7 @@
                         "commands":  [
                                          {
                                              "command":  "foundupsFusion.open",
-                                             "title":  "FoundUps Fusion: Open",
+                                             "title":  "Foundups®Agent: Open",
                                              "category":  "FoundUps"
                                          }
                                      ],
@@ -43,7 +43,7 @@
                                                                ]
                                   },
                         "configuration":  {
-                                              "title":  "FoundUps Fusion Worker",
+                                              "title":  "Foundups®Agent",
                                               "properties":  {
                                                                  "foundupsFusion.pythonPath":  {
                                                                                                    "type":  "string",

--- a/extensions/foundups_advisory_workers/tests/TestModLog.md
+++ b/extensions/foundups_advisory_workers/tests/TestModLog.md
@@ -1,6 +1,10 @@
-# FoundUps Fusion Worker TestModLog
+# Foundups®Agent TestModLog
 
-## 2026-06-23 — v0.3.17 Working Trail Phase 2 CODE Tests
+## 2026-06-24 - v0.3.18 Branding Contract
+- Verified user-facing branding uses Foundups®Agent while the internal package id and command id remain stable.
+- Verified Fusion remains documented as an internal mode, not the product identity.
+
+## 2026-06-23 窶・v0.3.17 Working Trail Phase 2 CODE Tests
 
 - Trail DOM + progress command shape + operator message rg gate.
 - `REDDOG_STAGE_ACTIONS` key set equals unique `_progress` stages from bridge (16/16).

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -16,8 +16,15 @@ function includes(haystack, needle, label) {
   assert(haystack.includes(needle), label || `missing ${needle}`);
 }
 
-assert.strictEqual(pkg.version, '0.3.17', 'package version must be 0.3.17');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.17'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.18', 'package version must be 0.3.18');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.18'", 'extension build mismatch');
+assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
+assert.strictEqual(pkg.displayName, 'Foundups®Agent', 'display name must be Foundups®Agent');
+includes(JSON.stringify(pkg), 'Foundups®Agent: Open', 'command title must use Foundups®Agent');
+includes(extensionJs, "title: 'Foundups®Agent'", 'webview title must use Foundups®Agent');
+includes(readme, 'Foundups®Agent is the product surface', 'README product identity statement missing');
+includes(iface, 'Fusion is one internal reasoning mode, not the product identity', 'INTERFACE mode identity statement missing');
+includes(roadmap, 'Foundups®Agent is the product surface', 'ROADMAP product identity statement missing');
 includes(extensionJs, 'id="reddogWorkingTrail"', 'working trail DOM missing');
 includes(extensionJs, 'data-reddog-pixel', 'trail pixel attribute missing');
 includes(extensionJs, "command: 'progress'", 'progress command shape missing');
@@ -249,4 +256,4 @@ for (const glyph of forbiddenPixels) {
   assert(!extensionJs.includes(glyph), 'trail pixel grammar must stay ASCII-only');
 }
 
-console.log('FoundUps Fusion extension contract checks passed.');
+console.log('Foundups®Agent extension contract checks passed.');


### PR DESCRIPTION
## Summary

Renames the user-facing extension surface from **FoundUps Fusion Worker** to **Foundups®Agent** while keeping internal package/command identifiers stable.

## Scope

- `package.json`: display name, command title, configuration title, version `0.3.18`
- `extension.js`: build version, webview title, scrollback aria/status branding
- README/INTERFACE/ROADMAP/ModLogs/tests: product wording and safety boundary
- Added F0 safety audit: `docs/audits/architecture/FOUNDUPS_AGENT_EXTENSION_F0_SAFETY_PHASE1.md`

## Boundary

- Package id remains `foundups-fusion-worker`
- Command id remains `foundupsFusion.open`
- Settings remain `foundupsFusion.*`
- No bridge behavior changes
- No model call changes
- No repo write / shell / Skillz / OpenClaw / Hermes / WRE execution added
- Fusion remains documented as an internal reasoning mode, not the product identity

## F0 Safety

Documents that F0 is the foundation Foundups-Agent repo and Foundups®Agent must never mutate F0 automatically. External repositories can be assessed through advisory WSP intake, not automatic execution.

## Validation

- `node --check extensions/foundups_advisory_workers/extension.js` PASS
- `node extensions/foundups_advisory_workers/tests/verify_extension_contract.js` PASS
- `git diff --check -- extensions/foundups_advisory_workers docs/audits/architecture/FOUNDUPS_AGENT_EXTENSION_F0_SAFETY_PHASE1.md` PASS
- Legacy `(R)Agent` scan PASS: no `Foundups(R)Agent` remains
- `npx vsce package --no-dependencies --out foundups-agent-0.3.18.vsix` PASS

## WSP_97

Truth table included in the F0 safety audit. Key rows: `FOUNDUPS_AGENT_IS_PRODUCT_SURFACE`, `REDDOG_IS_ARCHITECT_INSIDE_AGENT`, `FUSION_IS_INTERNAL_MODE`, `PACKAGE_ID_STABLE`, `F0_NO_AUTO_MUTATION`.

Stop at draft PR. Do not merge without 012 token.
