### PR TITLE
feat(extension): polish blocked RedDog review packets

### DIFF
--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -267,7 +267,7 @@ When redaction blocks before OpenRouter, Copy MD includes `## Redaction Gate Rep
 
 All fields carry WSP_97 truth labels (`OBSERVED` or `UNKNOWN`). If the gate cannot identify the payload part, report `unknown`; do not infer.
 
-## Governed Handoff Recommendation (v0.3.20)
+## Governed Handoff Recommendation (v0.3.20+)
 
 Substantive Copy MD packets append `## Governed Handoff Recommendation`:
 
@@ -279,7 +279,10 @@ Substantive Copy MD packets append `## Governed Handoff Recommendation`:
 | suggested_slice_name | Bounded slice identifier |
 | WSP_15 priority | Inferred from tier |
 | required_human_gate | `012_sovereign` \| `none` |
+| reason | Conservative blocked-local reason when no model output (e.g. `blocked_context_needs_local_0102_review`) |
 | evidence_refs | Bounded digest references only |
+
+Redaction-block-only runs default to `handoff_needed: unknown`, `wsp15_priority: P1`, and `suggested_slice_name: none` unless concrete fix evidence exists.
 
 Extension retains no repo/shell/merge authority.
 

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -1,5 +1,12 @@
 # Foundups®Agent ModLog
 
+## 2026-06-25 - v0.3.21 Blocked RedDog Copy MD polish
+- Adjacent duplicate Work Trail events collapse to one entry (detail-bearing event retained).
+- Redaction-block-only runs use conservative Governed Handoff defaults: `handoff_needed: unknown`, `reason: blocked_context_needs_local_0102_review`, `wsp15_priority: P1`, `suggested_slice_name: none`.
+- Target may remain `[INFERRED]` from work focus; no automatic WRE dispatch assertion on blocked-local packets.
+
+WSP: WSP_22, WSP_97.
+
 ## 2026-06-24 - v0.3.20 Redaction Gate Report + WRE Handoff Readiness (Addendum F)
 - Rebased onto #871 bridge hardening (`9e5416af4`); version bump 0.3.19 -> 0.3.20.
 - Copy MD redaction blocks now include `## Redaction Gate Report` with WSP_97 truth labels (OBSERVED/UNKNOWN); no raw blocked content.

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.20
+Version: 0.3.21
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.20';
+const EXTENSION_VERSION = '0.3.21';
 const REDDOG_TERMINAL_HOLD_MS = 3000;
 const REDACTION_BLOCK_OPERATOR_MESSAGE = 'Stopped before OpenRouter. Nothing left the machine.';
 const BRIDGE_MAX_STDOUT_BYTES = 262144;
@@ -221,6 +221,21 @@ function createWorkTrail() {
       if (detail) {
         entry.detail = sanitizeCopyMdText(String(detail)).slice(0, 240);
       }
+      const last = events[events.length - 1];
+      if (last && last.event === name) {
+        const lastDetail = last.detail || '';
+        const newDetail = entry.detail || '';
+        if (!newDetail && lastDetail) {
+          return;
+        }
+        if (newDetail && !lastDetail) {
+          last.detail = newDetail;
+          return;
+        }
+        if (newDetail && lastDetail && newDetail === lastDetail) {
+          return;
+        }
+      }
       events.push(entry);
       while (events.length > WORK_TRAIL_MAX_EVENTS) {
         events.shift();
@@ -432,6 +447,7 @@ function buildRedactionGateReportSection(report) {
 function buildGovernedHandoffRecommendation(workFocus, classification, workerType, contextMode, options) {
   const opts = options && typeof options === 'object' ? options : {};
   const substantive = !!opts.substantive;
+  const redactionBlockedOnly = !!opts.redactionBlockedOnly;
   const text = String(workFocus || '').toLowerCase();
   let target = 'none';
   if (/\bwre\b/.test(text)) {
@@ -443,16 +459,6 @@ function buildGovernedHandoffRecommendation(workFocus, classification, workerTyp
   } else if (/\bsentinel\b/.test(text)) {
     target = 'Sentinel';
   }
-  let handoffNeeded = 'false';
-  if (!substantive) {
-    handoffNeeded = 'false';
-  } else if (target !== 'none') {
-    handoffNeeded = 'true';
-  } else {
-    handoffNeeded = 'unknown';
-  }
-  const tier = classification && classification.tier ? classification.tier : 'HIGH';
-  const priority = tier === 'ULTRA' ? 'P0' : tier === 'REGULAR' ? 'P2' : 'P1';
   const evidenceRefs = [];
   if (opts.workFocusDigest) {
     evidenceRefs.push('work_focus_digest:' + opts.workFocusDigest);
@@ -463,6 +469,28 @@ function buildGovernedHandoffRecommendation(workFocus, classification, workerTyp
   if (contextMode) {
     evidenceRefs.push('context_mode:' + String(contextMode));
   }
+  if (redactionBlockedOnly) {
+    return {
+      handoff_needed: 'unknown',
+      target: target,
+      authority_level: 'advisory_only',
+      reason: 'blocked_context_needs_local_0102_review',
+      suggested_slice_name: 'none',
+      wsp15_priority: 'P1',
+      required_human_gate: 'none',
+      evidence_refs: evidenceRefs.length ? evidenceRefs : ['unknown']
+    };
+  }
+  let handoffNeeded = 'false';
+  if (!substantive) {
+    handoffNeeded = 'false';
+  } else if (target !== 'none') {
+    handoffNeeded = 'true';
+  } else {
+    handoffNeeded = 'unknown';
+  }
+  const tier = classification && classification.tier ? classification.tier : 'HIGH';
+  const priority = tier === 'ULTRA' ? 'P0' : tier === 'REGULAR' ? 'P2' : 'P1';
   return {
     handoff_needed: handoffNeeded,
     target: target,
@@ -480,12 +508,17 @@ function buildGovernedHandoffSection(recommendation) {
     '## Governed Handoff Recommendation',
     '- handoff_needed: ' + (rec.handoff_needed || 'unknown') + ' [INFERRED]',
     '- target: ' + (rec.target || 'none') + ' [INFERRED]',
-    '- authority_level: advisory_only [OBSERVED]',
+    '- authority_level: advisory_only [OBSERVED]'
+  ];
+  if (rec.reason) {
+    lines.push('- reason: ' + rec.reason + ' [INFERRED]');
+  }
+  lines.push(
     '- suggested_slice_name: ' + (rec.suggested_slice_name || 'none') + ' [INFERRED]',
     '- WSP_15 priority: ' + (rec.wsp15_priority || 'unknown') + ' [INFERRED]',
     '- required_human_gate: ' + (rec.required_human_gate || 'none') + ' [INFERRED]',
     '- evidence_refs: ' + JSON.stringify(rec.evidence_refs || ['unknown']) + ' [OBSERVED]'
-  ];
+  );
   return lines.join('\n');
 }
 
@@ -1045,6 +1078,7 @@ function wireFusionWebview(context, webview, worker, state) {
     const substantiveTask = isSubstantiveRedDogWorker(workerType);
     const handoffRecommendation = buildGovernedHandoffRecommendation(workFocus, classification, workerType, contextMode, {
       substantive: substantiveTask,
+      redactionBlockedOnly: result.reason === 'redaction_blocked',
       workFocusDigest: promptConstruction.work_focus_digest && promptConstruction.work_focus_digest.hash,
       wspPromptDigest: promptConstruction.wsp_prompt_digest && promptConstruction.wsp_prompt_digest.hash
     });

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups®Agent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.20",
+    "version":  "0.3.21",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/TestModLog.md
+++ b/extensions/foundups_advisory_workers/tests/TestModLog.md
@@ -1,5 +1,20 @@
 # Foundups®Agent TestModLog
 
+## 2026-06-25 - v0.3.21 Blocked Copy MD polish
+- Verified adjacent duplicate Work Trail events dedupe; detail-bearing event retained.
+- Verified blocked-local Copy MD has no duplicate `redaction_gate_blocked` lines.
+- Verified conservative blocked-local handoff: `handoff_needed: unknown`, `reason: blocked_context_needs_local_0102_review`, `WSP_15 priority: P1`, `suggested_slice_name: none`.
+- Verified successful substantive runs retain prior assertive handoff behavior when model output exists.
+- Verified Copy MD excludes secret-adjacent strings.
+
+Commands:
+
+```powershell
+node --check extensions/foundups_advisory_workers/extension.js
+node extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+git diff --check -- extensions/foundups_advisory_workers
+```
+
 ## 2026-06-24 - v0.3.20 Redaction Gate + Governed Handoff Contract
 - Verified blocked Copy MD includes `## Redaction Gate Report` with `BLOCKED_LOCALLY`, `made_network_call: false`, `blocked_payload_part: unknown`, `raw_snippets_included: false`.
 - Verified blocked packet contains no `OPENROUTER_API_KEY`, Bearer, or sk- token patterns.

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -16,8 +16,8 @@ function includes(haystack, needle, label) {
   assert(haystack.includes(needle), label || `missing ${needle}`);
 }
 
-assert.strictEqual(pkg.version, '0.3.20', 'package version must be 0.3.20');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.20'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.21', 'package version must be 0.3.21');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.21'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups®Agent', 'display name must be Foundups®Agent');
 includes(JSON.stringify(pkg), 'Foundups®Agent: Open', 'command title must use Foundups®Agent');
@@ -34,7 +34,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.20', 'README version mismatch');
+includes(readme, 'Version: 0.3.21', 'README version mismatch');
 includes(extensionJs, 'function resolvePythonInterpreter', 'python resolver missing');
 includes(extensionJs, 'function applyBridgeContextBudget', 'context budget missing');
 includes(extensionJs, 'function killBridgeChild', 'orphan cleanup missing');
@@ -353,7 +353,26 @@ const handoffRec = orchestrator.buildGovernedHandoffRecommendation('audit WRE br
   wspPromptDigest: 'def456'
 });
 assert.strictEqual(handoffRec.target, 'WRE', 'substantive WRE task must target WRE handoff');
+assert.strictEqual(handoffRec.handoff_needed, 'true', 'successful substantive WRE task may recommend handoff');
 assert.strictEqual(handoffRec.authority_level, 'advisory_only', 'handoff must remain advisory_only');
+
+const blockedHandoffRec = orchestrator.buildGovernedHandoffRecommendation('audit WRE bridge handoff', { tier: 'ULTRA' }, 'reddog_architect', 'wsp_holo_skillz', {
+  substantive: true,
+  redactionBlockedOnly: true,
+  workFocusDigest: 'abc123',
+  wspPromptDigest: 'def456'
+});
+assert.strictEqual(blockedHandoffRec.handoff_needed, 'unknown', 'redaction-block-only run must use conservative handoff_needed');
+assert.strictEqual(blockedHandoffRec.target, 'WRE', 'target may remain inferred for blocked-local packet');
+assert.strictEqual(blockedHandoffRec.reason, 'blocked_context_needs_local_0102_review', 'blocked-local handoff must include conservative reason');
+assert.strictEqual(blockedHandoffRec.wsp15_priority, 'P1', 'blocked-local handoff must default to P1');
+assert.strictEqual(blockedHandoffRec.suggested_slice_name, 'none', 'blocked-local handoff must not invent slice name');
+
+const dedupeTrail = orchestrator.createWorkTrail();
+dedupeTrail.push('redaction_gate_blocked', 'Redaction gate blocked before network.');
+dedupeTrail.push('redaction_gate_blocked');
+assert.strictEqual(dedupeTrail.count(), 1, 'adjacent duplicate Work Trail events must dedupe');
+assert.strictEqual(dedupeTrail.toEvents()[0].detail, 'Redaction gate blocked before network.', 'dedupe must keep detail-bearing event');
 
 const blockedCopy = orchestrator.buildCopyMarkdown({
   reason: 'redaction_blocked',
@@ -392,7 +411,7 @@ const blockedCopy = orchestrator.buildCopyMarkdown({
   },
   contextMode: 'wsp_holo_skillz',
   substantive: true,
-  handoffRecommendation: handoffRec
+  handoffRecommendation: blockedHandoffRec
 });
 includes(blockedCopy, '## Run Trace', 'Copy MD must include Run Trace');
 includes(blockedCopy, '## Work Trail', 'Copy MD must include Work Trail');
@@ -404,9 +423,24 @@ includes(blockedCopy, 'blocked_payload_part: unknown', 'unknown payload part mus
 includes(blockedCopy, 'raw_snippets_included: false', 'blocked packet must declare no raw snippets');
 includes(blockedCopy, 'holoindex_status:', 'Copy MD must include HoloIndex recall scorecard');
 includes(blockedCopy, '## Governed Handoff Recommendation', 'substantive task must include governed handoff recommendation');
+includes(blockedCopy, 'handoff_needed: unknown', 'blocked-local packet must use conservative handoff_needed');
+includes(blockedCopy, 'reason: blocked_context_needs_local_0102_review', 'blocked-local packet must include conservative handoff reason');
+includes(blockedCopy, 'WSP_15 priority: P1', 'blocked-local packet must default handoff priority to P1');
+includes(blockedCopy, 'suggested_slice_name: none', 'blocked-local packet must not invent slice name');
 includes(blockedCopy, 'authority_level: advisory_only', 'handoff must remain advisory_only');
 assert(!blockedCopy.includes('OPENROUTER_API_KEY'), 'Copy MD must not include secret-adjacent env names');
 assert(!blockedCopy.includes('Bearer sk-'), 'Copy MD must not include bearer/token patterns');
+
+const blockedTrail = orchestrator.createWorkTrail();
+blockedTrail.push('orchestrator_started');
+blockedTrail.push('redaction_gate_blocked', 'Redaction gate blocked before network.');
+blockedTrail.push('redaction_gate_blocked');
+const blockedTrailCopy = orchestrator.buildCopyMarkdown({
+  reason: 'redaction_blocked',
+  review_packet: { made_network_call: false, retry_count: 0, output_validation: { validated: false, reason: 'redaction_blocked' } }
+}, 'reddog_architect', '', blockedTrail, null, 'high', { substantive: true, handoffRecommendation: blockedHandoffRec });
+const trailLines = blockedTrailCopy.split('\n').filter((line) => line.startsWith('- redaction_gate_blocked'));
+assert.strictEqual(trailLines.length, 1, 'blocked-local Copy MD must not show adjacent duplicate Work Trail events');
 
 const cappedTrail = orchestrator.createWorkTrail();
 for (let i = 0; i < 60; i++) {


### PR DESCRIPTION
## Summary
- Dedupe adjacent duplicate Work Trail events on redaction-block runs (detail-bearing event retained).
- Conservative blocked-local Governed Handoff: `handoff_needed: unknown`, `reason: blocked_context_needs_local_0102_review`, `WSP_15 priority: P1`, `suggested_slice_name: none`.
- Version bump `0.3.20` -> `0.3.21`; contract tests for dedupe + conservative handoff.

## Scope
Extension-only (8 files). Excludes unrelated WRE daemon report dirty file.

## Test plan
- [x] `node --check extensions/foundups_advisory_workers/extension.js`
- [x] `node extensions/foundups_advisory_workers/tests/verify_extension_contract.js`
- [x] `git diff --check -- extensions/foundups_advisory_workers`
- [ ] CI green on PR
- [ ] Manual redaction-block Copy MD retest after VSIX install (`0.3.21`)

## Status
VERIFIED_READY (local). Do not merge without sovereign token.