### PR TITLE
fix(openclaw): gate FOUNDUP ImportError fallback (#737 L0)

### DIFF
--- a/modules/communication/moltbot_bridge/src/openclaw_execution_routes.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_execution_routes.py
@@ -669,18 +669,68 @@ async def execute_automation(dae: Any, intent: Any) -> str:
         return f"Automation error: {exc}"
 
 
+# WAE-L0 (#737): launch/onboard/create/genesis verbs that would otherwise reach a
+# real ``fam_adapter.launch_foundup`` via FAM passthrough. The ImportError fallback
+# below must FAIL CLOSED for these verbs (the WSP 109 genesis gate lives in the
+# orchestrator; if the orchestrator import fails, the gate is unavailable and no
+# launch may proceed). Local/private predicate only - NOT a shared classifier.
+_LAUNCH_ONBOARD_GENESIS_VERBS = (
+    "launch foundup",
+    "launch this foundup",
+    "onboard",
+    "create foundup",
+    "genesis",
+    "go live",
+)
+
+
+def _is_launch_or_onboard_verb(message: str) -> bool:
+    """Detect launch/onboard/create-foundup/genesis verbs (WAE-L0, #737).
+
+    These verbs would reach a real FAM launch via passthrough and therefore MUST
+    pass the WSP 109 genesis gate first. The gate lives in the orchestrator, so if
+    the orchestrator import fails we cannot gate the intent and must fail closed.
+    Defensive against non-string ``raw_message`` (e.g. mock intents).
+    """
+    if not isinstance(message, str):
+        return False
+    msg_lower = message.lower().strip()
+    return any(verb in msg_lower for verb in _LAUNCH_ONBOARD_GENESIS_VERBS)
+
+
 def execute_foundup(dae: Any, intent: Any) -> str:
     """Route FOUNDUP intent through orchestrator entrypoint.
 
     Phase 1 (OC1): Orchestrator dispatches to FAM with safe fallback.
     Phase 2+: Will add genesis validation gate before FAM handoff.
+
+    WAE-L0 (#737): the ImportError fallback fails CLOSED for launch/onboard/create/
+    genesis verbs. The WSP 109 genesis gate lives in the orchestrator; if its import
+    fails the gate is unavailable, so a launch/onboard intent must return NOT_READY
+    rather than reaching ``fam_adapter.launch_foundup`` ungated. Non-launch advisory
+    queries keep the safe FAM passthrough.
     """
     try:
         from .openclaw_foundup_orchestrator import dispatch_foundup
 
         return dispatch_foundup(dae, intent)
     except ImportError as exc:
-        # Fallback: orchestrator unavailable, try direct FAM
+        # WAE-L0 (#737): orchestrator (and thus the WSP 109 genesis gate) is
+        # unavailable. For launch/onboard/create/genesis verbs we FAIL CLOSED - no
+        # ungated path may reach fam_adapter.launch_foundup.
+        if _is_launch_or_onboard_verb(getattr(intent, "raw_message", "")):
+            logger.warning(
+                "[OPENCLAW-DAE] Genesis gate unavailable (orchestrator import "
+                "failed); launch/onboard intent blocked NOT_READY: %s",
+                exc,
+            )
+            return (
+                "FoundUp launch/onboarding is NOT_READY: the WSP 109 genesis gate "
+                "is unavailable (orchestrator import failed), so this request is "
+                "blocked. No FoundUp was started. Required next action: restore the "
+                "FoundUp orchestrator, then retry."
+            )
+        # Non-launch advisory queries: orchestrator unavailable, safe FAM passthrough.
         logger.warning(
             "[OPENCLAW-DAE] Orchestrator unavailable, trying direct FAM: %s", exc
         )

--- a/modules/communication/moltbot_bridge/tests/test_openclaw_foundup_fallback_gate.py
+++ b/modules/communication/moltbot_bridge/tests/test_openclaw_foundup_fallback_gate.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+WAE-L0 (#737): Tests for the FOUNDUP ImportError fallback genesis gate.
+
+Closes the ONE residual ungated path identified and ratified by WAE-AR1: the
+ImportError fallback in ``execute_foundup`` that previously reached
+``fam_adapter.launch_foundup`` (via ``handle_fam_intent``) WITHOUT passing the
+WSP 109 genesis gate.
+
+Invariant proven here:
+    For a FOUNDUP launch/onboard/create/genesis intent, when the orchestrator
+    import (and thus the genesis gate) is forced to raise ImportError,
+    ``execute_foundup`` FAILS CLOSED - it returns a NOT_READY/blocked packet and
+    does NOT invoke ``fam_adapter.handle_fam_intent`` / ``launch_foundup``.
+
+Non-launch advisory queries keep the safe FAM passthrough (regression guard).
+
+Slice: WAE-L0   Worker-Lane: B
+"""
+
+import builtins
+import sys
+import pytest
+from unittest.mock import MagicMock
+
+
+def _make_intent(raw_message: str, sender: str = "test_user") -> MagicMock:
+    """Build a minimal mock intent with the fields execute_foundup reads."""
+    intent = MagicMock()
+    intent.raw_message = raw_message
+    intent.sender = sender
+    return intent
+
+
+def _force_orchestrator_import_error(monkeypatch):
+    """Force ``from .openclaw_foundup_orchestrator import dispatch_foundup`` to
+    raise ImportError, simulating the residual fallback path. Real ``__import__``
+    is preserved for all other modules.
+    """
+    real_import = builtins.__import__
+    target = "openclaw_foundup_orchestrator"
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if target in name or (fromlist and "dispatch_foundup" in fromlist and target in name):
+            raise ImportError(f"forced import error for {name}")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+# ---------------------------------------------------------------------------
+# The ONE pass/fail test (WAE-L0)
+# ---------------------------------------------------------------------------
+
+
+class TestFoundupImportErrorFallbackGate:
+    """Launch/onboard intents fail closed when the orchestrator import fails."""
+
+    def test_launch_intent_blocked_when_orchestrator_import_fails(self, monkeypatch):
+        """PASS: 'launch foundup Shield with token SHLD' through execute_foundup
+        with the orchestrator import forced to raise ImportError returns
+        NOT_READY/blocked AND fam_adapter.launch_foundup is NOT invoked.
+        FAIL: a FoundUp is created, or launch_foundup / handle_fam_intent is called.
+        """
+        from modules.communication.moltbot_bridge.src import openclaw_execution_routes
+
+        # Mock fam_adapter so we can assert it is NEVER reached on the launch path.
+        mock_fam_adapter = MagicMock()
+        mock_fam_adapter.handle_fam_intent = MagicMock(return_value="LAUNCHED!")
+        mock_fam_adapter.launch_foundup = MagicMock(return_value="LAUNCHED!")
+        monkeypatch.setitem(
+            sys.modules,
+            "modules.communication.moltbot_bridge.src.fam_adapter",
+            mock_fam_adapter,
+        )
+
+        # Force the orchestrator (and thus the genesis gate) import to fail.
+        _force_orchestrator_import_error(monkeypatch)
+
+        intent = _make_intent("launch foundup Shield with token SHLD")
+        result = openclaw_execution_routes.execute_foundup(MagicMock(), intent)
+
+        # Genesis gate unavailable -> FAM launch must NOT be invoked.
+        mock_fam_adapter.handle_fam_intent.assert_not_called()
+        mock_fam_adapter.launch_foundup.assert_not_called()
+
+        # Response must signal a blocked / NOT_READY state.
+        result_lower = result.lower()
+        assert any(
+            blocker in result_lower
+            for blocker in ("not_ready", "blocked", "unavailable", "genesis gate unavailable")
+        ), f"expected a NOT_READY/blocked packet, got: {result!r}"
+
+        # Response must NOT claim FoundUp creation / success.
+        assert "launched" not in result_lower
+        assert "created" not in result_lower
+        assert "onboarded" not in result_lower
+
+    @pytest.mark.parametrize(
+        "raw_message",
+        [
+            "launch foundup Shield with token SHLD",
+            "launch this foundup now",
+            "onboard a FoundUp called Shield",
+            "create foundup Shield",
+            "follow WSP 109 and run genesis for Shield",
+            "go live with foundup Shield",
+        ],
+    )
+    def test_all_launch_verbs_fail_closed(self, monkeypatch, raw_message):
+        """Every launch/onboard/create/genesis verb fails closed on import error."""
+        from modules.communication.moltbot_bridge.src import openclaw_execution_routes
+
+        mock_fam_adapter = MagicMock()
+        mock_fam_adapter.handle_fam_intent = MagicMock(return_value="LAUNCHED!")
+        mock_fam_adapter.launch_foundup = MagicMock(return_value="LAUNCHED!")
+        monkeypatch.setitem(
+            sys.modules,
+            "modules.communication.moltbot_bridge.src.fam_adapter",
+            mock_fam_adapter,
+        )
+        _force_orchestrator_import_error(monkeypatch)
+
+        intent = _make_intent(raw_message)
+        result = openclaw_execution_routes.execute_foundup(MagicMock(), intent)
+
+        mock_fam_adapter.handle_fam_intent.assert_not_called()
+        mock_fam_adapter.launch_foundup.assert_not_called()
+        assert "not_ready" in result.lower() or "blocked" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# Regression guard: non-launch advisory queries keep the FAM passthrough.
+# ---------------------------------------------------------------------------
+
+
+class TestAdvisoryFallbackPreserved:
+    """Non-launch advisory queries still reach FAM on the fallback path."""
+
+    def test_advisory_query_still_routes_to_fam_on_import_error(self, monkeypatch):
+        """An advisory 'what is cabr' query keeps the safe FAM passthrough when
+        the orchestrator import fails (the launch gate must not over-block).
+        """
+        from modules.communication.moltbot_bridge.src import openclaw_execution_routes
+
+        mock_fam_adapter = MagicMock()
+        mock_fam_adapter.handle_fam_intent = MagicMock(return_value="CABR advisory response")
+        monkeypatch.setitem(
+            sys.modules,
+            "modules.communication.moltbot_bridge.src.fam_adapter",
+            mock_fam_adapter,
+        )
+        _force_orchestrator_import_error(monkeypatch)
+
+        intent = _make_intent("what is cabr")
+        result = openclaw_execution_routes.execute_foundup(MagicMock(), intent)
+
+        mock_fam_adapter.handle_fam_intent.assert_called_once_with("what is cabr", "test_user")
+        assert result == "CABR advisory response"
+
+
+# ---------------------------------------------------------------------------
+# Predicate unit tests (local/private helper).
+# ---------------------------------------------------------------------------
+
+
+class TestLaunchVerbPredicate:
+    """The local launch-verb predicate covers the ratified verbs only."""
+
+    def test_launch_verbs_detected(self):
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            _is_launch_or_onboard_verb,
+        )
+
+        assert _is_launch_or_onboard_verb("launch foundup Shield with token SHLD") is True
+        assert _is_launch_or_onboard_verb("onboard a FoundUp called Shield") is True
+        assert _is_launch_or_onboard_verb("create foundup Shield") is True
+        assert _is_launch_or_onboard_verb("run genesis for Shield") is True
+        assert _is_launch_or_onboard_verb("go live with foundup Shield") is True
+
+    def test_non_launch_queries_not_detected(self):
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            _is_launch_or_onboard_verb,
+        )
+
+        assert _is_launch_or_onboard_verb("what is cabr") is False
+        assert _is_launch_or_onboard_verb("tell me about foundups") is False
+        assert _is_launch_or_onboard_verb("list all foundups") is False
+
+    def test_non_string_message_is_safe(self):
+        from modules.communication.moltbot_bridge.src.openclaw_execution_routes import (
+            _is_launch_or_onboard_verb,
+        )
+
+        assert _is_launch_or_onboard_verb(None) is False
+        assert _is_launch_or_onboard_verb(MagicMock()) is False


### PR DESCRIPTION
## WAE-L0: Close #737 FOUNDUP ImportError fallback bypass (EXECUTION)

**Window:** WAE **Slice:** WAE-L0 **Lane:** B
**Base SHA:** `9079232143838da7cab073395784206958ed3a1c` (origin/main, post-AR1)
**Spec:** `docs/audits/architecture/WAE_LAYER_SPECS.md` section L0

### Problem
WAE-AR1 ratified ONE residual ungated path: `execute_foundup`'s `ImportError`
fallback called `handle_fam_intent` directly, reaching `fam_adapter.launch_foundup`
WITHOUT passing the WSP 109 genesis gate (the gate lives in the orchestrator). A
`"launch foundup X with token Y"` prompt in that fallback would launch ungated.

### Fix (minimal)
`modules/communication/moltbot_bridge/src/openclaw_execution_routes.py`:
- New local/private predicate `_is_launch_or_onboard_verb` (NOT a shared classifier)
  covering `launch foundup` / `launch this foundup` / `onboard` / `create foundup` /
  `genesis` / `go live`.
- In the `ImportError` fallback: if the intent is a launch/onboard/create/genesis
  verb, **fail closed** -> return a NOT_READY/blocked packet and do NOT call
  `handle_fam_intent`. Non-launch advisory queries keep the safe FAM passthrough.

### Test
`modules/communication/moltbot_bridge/tests/test_openclaw_foundup_fallback_gate.py`:
- Forces the orchestrator import to raise `ImportError`; sends
  `"launch foundup Shield with token SHLD"` through `execute_foundup`; asserts
  response is NOT_READY/blocked AND `fam_adapter.launch_foundup` /
  `handle_fam_intent` were **never** invoked (mock + assert-not-called).
- Asserts response contains no success wording (`launched`/`created`/`onboarded`).
- Parametrized across all launch verbs; regression guard keeps advisory passthrough.
- **Negative control verified**: with the fix stashed, the test fails (old code
  calls `handle_fam_intent('launch foundup Shield ...')`).

### Validation
- `git diff --name-only origin/main...HEAD` = exactly 1 src file + 1 test file.
- New test: 11 passed. FOUNDUP-related suites: 76 passed, no regressions.
- `git diff --check` clean; 0 non-ASCII bytes in both files; no mojibake.

### Truth Boundary Checklist
- [x] SCOPE_TO_FALLBACK_ONLY
- [x] LAUNCH_VERBS_FAIL_CLOSED
- [x] NO_GENESIS_GATE_REFACTOR
- [x] NO_PERMISSION_WIDENING
- [x] NO_NEW_ORCHESTRATOR / NO_SHARED_CLASSIFIER (predicate is local/private)
- [x] NO_LIVE_EXECUTION
- [x] TESTS_REQUIRED (added and green)
- [x] NO_MERGE_TO_MAIN (PR-ready; W10 gate + 012 land token required)
- [x] ASCII_CLEAN
- [x] BASE_SHA re-pinned to current origin/main

**Do NOT merge** - W10 gate + 012 land token required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
