### PR TITLE
feat(extension): egress bounded target snippets into RedDog context (0.3.22)

### DIFF
--- a/.prompt_reddog_context_target_content_inclusion_phase1.md
+++ b/.prompt_reddog_context_target_content_inclusion_phase1.md
@@ -1,0 +1,368 @@
+AUTHOR - REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1
+
+Operate in WSP_00. Apply WSP_97 CoT/CoR before any edit.
+
+PREREQUISITE GATE - SATISFIED:
+- #882 LANDED (`99d0e35c2`) - path ranking + `target_recall_ok` telemetry only.
+- EXT-ACC-001 probes (r1-r3) complete; 012 stopped reruns - evidence sufficient.
+- Model egress confirmed; RedDog correctly BLOCKed on missing source (partial_good).
+- **Do NOT** rerun full 15-pack until this slice lands and EXT-ACC-001 criterion #2 passes.
+
+LANE LOCK:
+External 012-facing Foundups(R)Agent bounded-context lane only.
+Do NOT touch Lane B / WRE / Sakana / OpenClaw execution dispatch.
+
+---
+
+BASELINE EVIDENCE (2026-06-26) - DO NOT IGNORE
+
+Core finding (distinct from #882):
+
+```text
+path hit in HoloIndex bundle-json does not equal source content in bounded bridge context
+```
+
+```yaml
+EXT-ACC-001_rerun:
+  verdict: needs_repair
+  model_egress: true
+  target_path_hit: true
+  target_source_content_included: false
+  target_recall_telemetry_active: false  # install trap; bump version in this slice
+  wsp97_source_findings: false
+  output_validation: failed
+  primary_next_slice: REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1
+
+PROBE_SIGNALS:
+  holoindex_status: bundle_json_ok
+  code_hits: 5
+  extension_js_path_similarity: 7.4%
+  context_mode: wsp_holo_skillz
+  context_chars: ~25982
+  model_finding_F1: >
+    HoloIndex code_hits lists extension.js path; no file contents, snippets,
+    or function signatures in bounded context packet.
+  redaction_primary: passed
+  architect_quality: partial_good  # correct BLOCK, no hallucinated review
+
+ROOT_CAUSE (direct-read, verify before acting):
+- extension.js `buildBoundedRepoContext()` embeds HoloIndex bundle-json JSON only
+  (`holoIndexOutput` -> `sections.push('### HoloIndex recall ...')`).
+- Bundle-json `task_retrieval.code_hits` returns paths + similarity - not file bodies.
+- `activeEditorContext()` already reads file/selection content with truncation -
+  reuse this pattern for inferred recall targets, not only active editor.
+- `inferRecallTargetPaths()` / `evaluateTargetRecall()` exist (#882) but no content egress step.
+
+INSTALL_TRAP (record; fix in content-inclusion slice with 0.3.22 bump):
+- #882 landed on label **0.3.21** without changing the version string.
+- Header `Build: 0.3.21` does not match Run Trace internals when host is stale (`v0.3.20` note, missing telemetry).
+- **Next version bump:** 0.3.22 in `REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1` (not shipped yet).
+
+---
+
+PURPOSE
+
+When HoloIndex ranks a recall target path, **egress bounded source snippets** into
+`buildBoundedRepoContext` so the redaction-gated bridge receives actual file content
+for architecture / WSP_97 review tasks - not path metadata alone.
+
+After this slice lands:
+1. 012 reruns **EXT-ACC-001** only (then EXT-ACC-003 if #2 passes).
+2. Do **not** schedule full replacement pass until EXT-ACC-001 five-criteria gate evaluated.
+
+---
+
+HARD ACCEPTANCE CHECKS (must pass in PR)
+
+1. **Target content inclusion (EXT-ACC-001 criterion #2):**
+   For work focus reviewing `extensions/foundups_advisory_workers/extension.js`,
+   bounded context includes a `### Target recall content` (or equivalent) section
+   with **line-bounded snippets** from `extension.js` (function names, comments, or
+   claim strings visible - not path-only JSON).
+
+2. **Recall target inference reused:**
+   Content inclusion driven by `inferRecallTargetPaths(taskText)` - no hardcoded
+   one-off for EXT-ACC-001 only. Must also cover:
+   - `scripts/advisory_model_once.py` (bridge queries)
+   - `extensions/foundups_advisory_workers/docs/REDDOG_EXTERNAL_ACCEPTANCE_BASELINE_PHASE1.md`
+     when task matches acceptance patterns.
+
+3. **Run Trace telemetry (ADDENDUM C):**
+   Add and populate in HoloIndex / context scorecard after final context assembly:
+   ```text
+   target_content_included: true|false|unknown
+   target_content_paths: [<rel paths actually included>]
+   target_content_chars: <number>
+   target_content_omitted_reason: no_targets|path_missing|outside_root|binary_or_oversized|read_error|budget_omitted|none
+   target_content_truncated: true|false
+   ```
+   `target_content_included=true` ONLY if snippet section is present in final context string.
+   Preserve existing: `target_recall_ok`, `code_hits_count`, `index_gap_detected`.
+
+4. **WSP_97 task boost (minimal):**
+   When task text mentions `WSP_97` or `truth label`, include bounded excerpt from
+   `WSP_framework/src/WSP_97_System_Execution_Prompting_Protocol.md` (first ~4KB or
+   truth-label section only). Label section `### WSP protocol excerpt (bounded)`.
+
+5. **Redaction + budget safety (ADDENDUM B):**
+   - All new content passes existing redaction gate (no raw secrets).
+   - Workspace-confined reads only; reject traversal, absolute paths, symlink escape.
+   - Respect `BRIDGE_MAX_CONTEXT_CHARS` (48000) and existing 42000 slice in
+     `buildBoundedRepoContext`; truncate with explicit `[TRUNCATED n chars]` marker.
+   - No policy weakening in `fusion_redaction_gate.py`.
+
+6. **Version bump:**
+   `package.json` + `EXTENSION_VERSION` -> **0.3.22** (install verification hygiene).
+
+7. **Contract tests (ADDENDUM D):**
+   Export and test new helpers; prove inclusion, rejection, and scorecard fields.
+
+Regression probe (document in PR, 012 runs live):
+```text
+EXT-ACC-001 work focus (RedDog Architect, wsp_holo_skillz):
+Review extensions/foundups_advisory_workers/extension.js for WSP_97 truth-label compliance...
+```
+Pass when criterion #2-#4 observable in Copy MD Run Trace + model cites source lines.
+
+---
+
+ADDENDUM A - ASCII / MOJIBAKE CLEAN DISPATCH
+
+Before implementation, clean this prompt and all touched docs to ASCII-safe text.
+
+Required:
+- Replace corrupted separators/arrows with ASCII: "->", "-", "does not equal", "Phase"
+- Do not introduce Unicode punctuation or corrupted markers in touched files.
+- Validation (run from repo root; use exported marker class from extension.js):
+```powershell
+node -e "const o=require('./extensions/foundups_advisory_workers/extension.js'); const p=o.MOJIBAKE_MARKERS.join('|'); console.log(p)"
+# Pipe that pattern to rg on touched files, or rely on detectMojibake in contract tests
+node extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+```
+Must return no new mojibake hits in touched files, except documented detector examples
+already present before this slice (e.g. ModLog entries describing detectMojibake).
+
+---
+
+ADDENDUM B - TARGET CONTENT READ SAFETY
+
+Target snippet reading must be workspace-confined.
+
+Required:
+- Use only relative repo paths inferred by `inferRecallTargetPaths()`.
+- Resolve with `path.resolve(root, relPath)`, then realpath.
+- Reject absolute paths, ".." traversal, symlink escape, missing files, binary files, and oversized files.
+- Do not read `.env`, key files, credentials, `node_modules`, `.git`, or generated VSIX artifacts.
+- New helper exposes low-cardinality omit reasons:
+  `no_targets | path_missing | outside_root | binary_or_oversized | read_error | budget_omitted`
+- Redaction gate remains unchanged and remains the final egress boundary.
+
+Suggested helper surface:
+- `readBoundedTargetSnippets(root, taskText, opts)` -> `{ sections, meta }`
+- `buildTargetRecallContentSection(root, taskText, maxChars)` -> `{ text, meta }`
+
+---
+
+ADDENDUM C - FINAL-CONTEXT TELEMETRY
+
+Telemetry must describe what reached the **final** bounded context string.
+
+Required:
+- `target_content_included=true` only if a snippet section is present in the final context string sent toward the bridge (after `buildBoundedRepoContext` assembly, before or after char slice - document which boundary in INTERFACE).
+- `target_content_paths` lists only paths actually included.
+- `target_content_chars` is the actual included snippet character count.
+- Add `target_content_omitted_reason` and `target_content_truncated`.
+- Scorecard extraction must happen **after** content inclusion metadata is merged into `holoindex_meta`.
+
+---
+
+ADDENDUM D - TEST EXPORTS
+
+Export and contract-test the new helpers:
+- `readBoundedTargetSnippets` or equivalent
+- `buildTargetRecallContentSection` or equivalent
+- WSP_97 excerpt helper (name in implementation)
+
+Tests must prove:
+- extension.js review task includes extension.js snippet
+- buildCopyMarkdown task includes extension.js snippet
+- WSP_97 task includes bounded WSP_97 excerpt
+- traversal / absolute path is rejected
+- scorecard includes all `target_content_*` fields
+- `target_content_included=true` only when snippet section in final context
+
+Add to `module.exports` and `verify_extension_contract.js`.
+
+---
+
+READ BEFORE EDITING (WSP_87 direct-read after HoloIndex)
+
+- extensions/foundups_advisory_workers/extension.js
+  (`buildBoundedRepoContext`, `holoIndexOutput`, `activeEditorContext`,
+  `inferRecallTargetPaths`, `evaluateTargetRecall`, `extractHoloIndexScorecard`,
+  `applyBridgeContextBudget`, `BRIDGE_MAX_CONTEXT_CHARS`)
+- extensions/foundups_advisory_workers/docs/REDDOG_EXTERNAL_ACCEPTANCE_BASELINE_PHASE1.md
+  (five-criteria gate, probe results)
+- holo_index/cli/commands/bundle_json.py (read-only - path hits only, no change required)
+- extensions/foundups_advisory_workers/INTERFACE.md
+- extensions/foundups_advisory_workers/ROADMAP.md
+- modules/communication/moltbot_bridge/src/fusion_redaction_gate.py (read-only boundary)
+
+---
+
+SCOPE - IN
+
+- New helpers in extension.js (ADDENDUM B-D)
+- Wire into `buildBoundedRepoContext` after HoloIndex section
+- Scorecard + Run Trace fields per ADDENDUM C
+- Version bump 0.3.21 -> 0.3.22
+- Contract tests + ModLog / INTERFACE / TestModLog / ROADMAP updates
+- Optional: architect review doc `docs/REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_ARCHITECT_REVIEW_PHASE1.md`
+
+SCOPE - OUT (explicit)
+
+- HoloIndex ranking / bundle-json path fixes (#882 - done)
+- `REDDOG_OUTPUT_SCHEMA_REPAIR_HARDENING_PHASE1`
+- `REDDOG_RUN_TRACE_TELEMETRY_CORRECTION_PHASE1` (duplicate Work Trail - separate)
+- `REDDOG_MOJIBAKE_OUTPUT_SANITIZATION_PHASE1` (separate)
+- OpenRouter routing / model slug changes
+- Redaction policy weakening
+- Semantic HoloIndex mode switch (`skip_model: false`) - optional future, not this slice
+- WRE / Sakana / Lane B
+- Full 15-prompt replacement pass
+- VSIX commit to repo
+
+---
+
+IMPLEMENTATION HINTS (verify, do not blindly copy)
+
+Pattern to reuse - `activeEditorContext()` lines ~1442-1457:
+```javascript
+// fs read + language fence + truncation marker
+```
+
+Suggested flow in `buildBoundedRepoContext`:
+```text
+1. holoIndexOutput (unchanged bundle-json embed)
+2. inferRecallTargetPaths(taskText) + evaluateTargetRecall from bundle parse
+3. buildTargetRecallContentSection for file targets (ADDENDUM B safety)
+4. If task mentions WSP_97: append bounded WSP_97 protocol excerpt
+5. existing Skillz / editor / git sections
+6. merge final text; aggregate target_content_* meta -> holoindex_scorecard (ADDENDUM C)
+```
+
+Priority when budget tight: target file(s) from inference **before** Skillz noise
+(probe F5: Skillz returned unrelated modules at score 17).
+
+---
+
+VALIDATION
+
+```powershell
+node --check extensions/foundups_advisory_workers/extension.js
+node extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+python -B -c "import ast, pathlib; ast.parse(pathlib.Path('scripts/advisory_model_once.py').read_text(encoding='utf-8'))"
+git diff --check -- extensions/foundups_advisory_workers
+# ADDENDUM A mojibake scan (see pattern in ADDENDUM A)
+```
+
+Optional local snippet smoke (no OpenRouter):
+```javascript
+// node -e harness calling buildBoundedRepoContext with fixture taskText
+```
+
+---
+
+BRANCH / PR
+
+Branch: `feat/reddog-context-target-content-inclusion-phase1`
+Title: feat(extension): egress bounded target file snippets into RedDog context
+Draft PR only. Stop at VERIFIED_READY. Do not merge without sovereign token.
+
+PR body must include:
+- EXT-ACC-001 probe evidence (path hit, no content)
+- Before/after bounded context excerpt (redacted - no secrets)
+- Hard acceptance checks 1-7 + ADDENDUM A-D evidence
+- Version 0.3.22 install verification note
+- Post-land: 012 reruns EXT-ACC-001 only
+
+WSP_97 rows (ModLog + PR):
+- PATH_HIT_DISTINCT_FROM_CONTENT_EGRESS
+- TARGET_SNIPPET_INCLUSION_ADDED
+- TARGET_CONTENT_TELEMETRY_FINAL_CONTEXT
+- WORKSPACE_CONFINED_READ_SAFETY
+- WSP97_PROTOCOL_EXCERPT_ON_TASK_MATCH
+- REDACTION_GATE_UNCHANGED
+- VERSION_BUMP_INSTALL_HYGIENE
+- ASCII_CLEAN_DISPATCH
+- NO_HOLOINDEX_RANKING_CHANGE
+- LANE_B_EXCLUDED
+- REPLACEMENT_PASS_NOT_IN_SCOPE
+
+WSP_15:
+| C | I | D | Impact | MPS | P |
+|---:|---:|---:|---:|---:|---|
+| 4 | 5 | 3 | 5 | 17 | **P0** |
+
+---
+
+ARCHITECT REVIEW STATUS
+
+```text
+REQUEST_CHANGES resolved in prompt revision (addenda A-D, ASCII clean).
+Decision after worker completes: APPROVE_WORKER_DISPATCH -> implement -> VERIFIED_READY PR.
+```
+
+---
+
+RETURN (worker -> architect review)
+
+1. Files changed
+2. Sample bounded context shape (redacted)
+3. Hard checks 1-7 + ADDENDUM A-D evidence
+4. Contract test output
+5. PR URL
+6. Residual NEEDS_VERIFICATION
+7. Ready for 012 EXT-ACC-001 rerun: yes/no
+
+---
+
+ADDENDUM E - 0102 TEST-FIRST EXECUTION
+
+Do not wait for 012 manual Cursor testing to prove implementation correctness.
+
+Add deterministic tests that run locally without OpenRouter or Cursor UI:
+
+1. inferRecallTargetPaths maps the EXT-ACC-001 prompt to:
+   extensions/foundups_advisory_workers/extension.js
+
+2. target snippet helper includes bounded source content for extension.js.
+
+3. buildBoundedRepoContext("wsp_holo_skillz", EXT-ACC-001 prompt) includes:
+   - "### Target recall content"
+   - "extensions/foundups_advisory_workers/extension.js"
+   - nonzero source snippet
+   - target_content_included=true
+   - target_content_chars > 0
+
+4. WSP_97 prompt includes:
+   - "### WSP protocol excerpt (bounded)"
+   - WSP_97_System_Execution_Prompting_Protocol.md excerpt
+
+5. Path safety rejects:
+   - absolute path
+   - ..
+   - symlink escape
+   - .env
+   - .git
+   - node_modules
+   - *.vsix
+
+6. No OpenRouter calls in tests.
+
+Validation:
+node --check extensions/foundups_advisory_workers/extension.js
+node extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+git diff --check -- extensions/foundups_advisory_workers
+
+012 role after VERIFIED_READY PR: installed Cursor UX smoke on v0.3.22 only.

--- a/.prompt_reddog_context_target_content_inclusion_phase1.md
+++ b/.prompt_reddog_context_target_content_inclusion_phase1.md
@@ -366,3 +366,22 @@ node extensions/foundups_advisory_workers/tests/verify_extension_contract.js
 git diff --check -- extensions/foundups_advisory_workers
 
 012 role after VERIFIED_READY PR: installed Cursor UX smoke on v0.3.22 only.
+
+---
+
+ADDENDUM F - REDACTION-SAFE TARGET SNIPPETS (REQUEST_CHANGES from 012 smoke)
+
+Problem:
+v0.3.22 includes target source snippets, but raw extension.js contains policy-boundary strings that trip Fusion redaction before OpenRouter.
+
+Required:
+1. Keep redaction gate unchanged.
+2. Do not weaken fusion_redaction_gate.py.
+3. Sanitize target snippets before adding them to bounded context:
+   - replace block-triggering source literals with neutral placeholders `[SANITIZED_BLOCK:NN]`
+   - preserve line/function/code shape enough for WSP_97 review
+   - record target_content_sanitized: true|false
+   - record target_content_sanitized_categories: [...]
+4. Redaction gate must pass for EXT-ACC-001 after target content inclusion.
+5. Contract test TCI-009/TCI-010: Python evaluate_redaction_gate on target section + full bounded context.
+6. Run Trace must show target_content_included: true, target_content_sanitized: true when replacements occurred, redaction gate status: passed.

--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -125,12 +125,14 @@ Run Trace HoloIndex scorecard fields (v0.3.22+):
 | `target_content_chars` | Character count of included target snippets | OBSERVED |
 | `target_content_omitted_reason` | Why snippets omitted when `target_content_included=false` | OBSERVED |
 | `target_content_truncated` | Any target snippet truncated by per-file budget | OBSERVED |
+| `target_content_sanitized` | Block-triggering literals replaced before egress | OBSERVED |
+| `target_content_sanitized_categories` | Fusion BLOCK categories sanitized (metadata only) | OBSERVED |
 
 `evaluateTargetRecall(taskText, bundleOutput)` and `inferRecallTargetPaths(taskText)` implement target-specific recall inference from bundle `task_retrieval.code_hits`.
 
-Target content egress (v0.3.22+): `buildTargetRecallContentSection(root, taskText, maxChars)` reads workspace-confined snippets for inferred recall targets after HoloIndex path ranking. Telemetry reflects the **final** bounded context string assembled by `buildBoundedRepoContext` (before the 42000-char slice). `buildWsp97ProtocolExcerpt(root, maxChars)` adds a bounded WSP_97 protocol excerpt when the task mentions WSP_97 or truth labels.
+Target content egress (v0.3.22+): `buildTargetRecallContentSection(root, taskText, maxChars)` reads workspace-confined snippets for inferred recall targets after HoloIndex path ranking. Snippets pass through `sanitizeTargetSnippetForRedaction()` before inclusion (ADDENDUM F); placeholders use neutral `[SANITIZED_BLOCK:NN]` tokens so category names do not re-trigger the Fusion gate. Telemetry reflects the **final** bounded context string assembled by `buildBoundedRepoContext` (before the 42000-char slice). `buildWsp97ProtocolExcerpt(root, maxChars)` adds a bounded WSP_97 protocol excerpt when the task mentions WSP_97 or truth labels.
 
-Exported helpers for contract tests: `isTargetReadPathDenied`, `resolveSafeRepoFile`, `readBoundedTargetSnippet`, `readBoundedTargetSnippets`, `buildTargetRecallContentSection`, `taskMentionsWsp97`, `buildWsp97ProtocolExcerpt`.
+Exported helpers for contract tests: `isTargetReadPathDenied`, `resolveSafeRepoFile`, `readBoundedTargetSnippet`, `readBoundedTargetSnippets`, `buildTargetRecallContentSection`, `sanitizeTargetSnippetForRedaction`, `taskMentionsWsp97`, `buildWsp97ProtocolExcerpt`.
 
 ## WSP_97 Truth Boundary
 

--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -111,7 +111,7 @@ The model cannot access the filesystem. It receives only the bounded context pac
 
 If HoloIndex recall reports zero WSP hits, missing Tier-0 docs, stale/offline fallback, or unavailable output, the answer must treat protocol claims as `NEEDS_VERIFICATION` and propose retrieval/index repair before strong claims.
 
-Run Trace HoloIndex scorecard fields (v0.3.21+):
+Run Trace HoloIndex scorecard fields (v0.3.22+):
 
 | Field | Meaning | WSP_97 |
 | --- | --- | --- |
@@ -120,8 +120,17 @@ Run Trace HoloIndex scorecard fields (v0.3.21+):
 | `target_recall_ok` | Requested target file/symbol appeared in hits | OBSERVED |
 | `index_gap_detected` | Target-specific miss (may be true when `code_hits_count > 0`) | OBSERVED |
 | `direct_read_fallback_used` | Offline lexical fallback used | OBSERVED |
+| `target_content_included` | Target snippet section present in final bounded context | OBSERVED |
+| `target_content_paths` | Relative paths whose snippets were included | OBSERVED |
+| `target_content_chars` | Character count of included target snippets | OBSERVED |
+| `target_content_omitted_reason` | Why snippets omitted when `target_content_included=false` | OBSERVED |
+| `target_content_truncated` | Any target snippet truncated by per-file budget | OBSERVED |
 
 `evaluateTargetRecall(taskText, bundleOutput)` and `inferRecallTargetPaths(taskText)` implement target-specific recall inference from bundle `task_retrieval.code_hits`.
+
+Target content egress (v0.3.22+): `buildTargetRecallContentSection(root, taskText, maxChars)` reads workspace-confined snippets for inferred recall targets after HoloIndex path ranking. Telemetry reflects the **final** bounded context string assembled by `buildBoundedRepoContext` (before the 42000-char slice). `buildWsp97ProtocolExcerpt(root, maxChars)` adds a bounded WSP_97 protocol excerpt when the task mentions WSP_97 or truth labels.
+
+Exported helpers for contract tests: `isTargetReadPathDenied`, `resolveSafeRepoFile`, `readBoundedTargetSnippet`, `readBoundedTargetSnippets`, `buildTargetRecallContentSection`, `taskMentionsWsp97`, `buildWsp97ProtocolExcerpt`.
 
 ## WSP_97 Truth Boundary
 

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -1,5 +1,15 @@
 # Foundups®Agent ModLog
 
+## 2026-06-14 - ADDENDUM F redaction-safe target snippets (v0.3.22)
+
+- Raw `extension.js` snippets tripped Fusion BLOCK categories (`governance_instruction`, `private_reasoning`, etc.) before OpenRouter.
+- Added `sanitizeTargetSnippetForRedaction()` mirroring `fusion_redaction_gate.py` BLOCK detectors; neutral `[SANITIZED_BLOCK:NN]` placeholders (category names in metadata only).
+- Run Trace: `target_content_sanitized`, `target_content_sanitized_categories`.
+- Contract tests TCI-009/TCI-010: Python gate probe on EXT-ACC-001 bounded context (no OpenRouter).
+- `fusion_redaction_gate.py` unchanged.
+
+WSP: WSP_97, WSP_22, WSP_84.
+
 ## 2026-06-14 - REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1 (v0.3.22)
 
 - Added workspace-confined target snippet readers: `readBoundedTargetSnippet`, `buildTargetRecallContentSection`, `buildWsp97ProtocolExcerpt`.

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -1,5 +1,18 @@
 # Foundups®Agent ModLog
 
+## 2026-06-14 - REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1 (v0.3.22)
+
+- Added workspace-confined target snippet readers: `readBoundedTargetSnippet`, `buildTargetRecallContentSection`, `buildWsp97ProtocolExcerpt`.
+- Wired `buildBoundedRepoContext` to egress `### Target recall content` after HoloIndex bundle-json (before Skillz noise).
+- WSP_97 tasks append bounded `### WSP protocol excerpt (bounded)` from `WSP_97_System_Execution_Prompting_Protocol.md`.
+- Run Trace scorecard: `target_content_included`, `target_content_paths`, `target_content_chars`, `target_content_omitted_reason`, `target_content_truncated`.
+- Path safety rejects absolute paths, `..`, `.git`, `node_modules`, `.env`, `.vsix`; realpath confinement.
+- ADDENDUM E contract tests: inferRecallTargetPaths, snippet inclusion, buildBoundedRepoContext integration, path denial (no OpenRouter).
+- Shared fixtures: `tests/fixtures.js`; TEST_REGISTRY TCI-001..008 in `tests/TestModLog.md`; `tests/README.md` for reuse policy.
+- Version bump 0.3.21 -> 0.3.22 (install hygiene).
+
+WSP: WSP_00, WSP_15, WSP_87, WSP_97, WSP_22, WSP_84.
+
 ## 2026-06-26 - REDDOG_EXTERNAL_ACCEPTANCE_BASELINE_PHASE1 (docs)
 - Added `docs/REDDOG_EXTERNAL_ACCEPTANCE_BASELINE_PHASE1.md`: 15-prompt pack, 012 rubric, runbook, WSP_97 truth rows, baseline vs replacement pass.
 - Added `docs/acceptance/README.md` artifact storage rules.
@@ -7,6 +20,57 @@
 - No runtime behavior changes; external lane scoreboard only.
 
 WSP: WSP_00, WSP_15, WSP_87, WSP_97, WSP_22.
+
+## 2026-06-26 - Content inclusion prompt REQUEST_CHANGES resolved
+
+- Architect addenda A-D merged into `.prompt_reddog_context_target_content_inclusion_phase1.md`
+- ASCII clean dispatch; MOJIBAKE validation via `MOJIBAKE_MARKERS` export not embedded chars
+- Workspace-confined read safety + final-context telemetry + test exports specified
+- Status: **APPROVE_WORKER_DISPATCH** (architect) pending worker implementation
+
+WSP: WSP_97, WSP_22.
+
+## 2026-06-26 - REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION worker prompt (review)
+
+- Worker prompt: `.prompt_reddog_context_target_content_inclusion_phase1.md`
+- Queued from EXT-ACC-001 evidence: path hit, no source content in bounded context.
+- Version bump 0.3.22 planned in slice (install hygiene).
+
+WSP: WSP_97, WSP_22.
+
+## 2026-06-26 - EXT-ACC-001 post-#882 probe r3 (telemetry gate still open)
+
+- Same path-only signal as r2; repair redaction passed (r2 repair blocked).
+- Run Trace still `v0.3.20` — force-install did not reflect in host; telemetry gate open.
+- Queue content inclusion; hold dispatch until `target_recall_ok` appears in Run Trace.
+
+WSP: WSP_97, WSP_22.
+
+## 2026-06-26 - Install trap: header 0.3.21 vs stale host (docs)
+
+- **OBSERVED:** Cursor header `Build: 0.3.21` while installed `extension.js` had `v0.3.20` provider note and no #882 telemetry.
+- **Cause:** #882 landed without version bump beyond `0.3.21`; force VSIX install required.
+- **Runbook:** Preflight requires Run Trace internals, not header alone.
+
+WSP: WSP_97, WSP_22.
+
+## 2026-06-26 - EXT-ACC-001 post-#882 probe r2 (needs_repair, stale telemetry)
+
+- Main egress succeeded; RedDog correctly BLOCKed on missing source (path hit ~7.4%, no content body).
+- **Queue** `REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1` — do **not** treat as final post-#882 proof (v0.3.20 note; no `target_recall_ok` / `code_hits_count`).
+- **Pending:** Clean EXT-ACC-001 after force-install VSIX; then dispatch content-inclusion if criterion #2 still fails with telemetry active.
+
+WSP: WSP_97, WSP_22.
+
+## 2026-06-26 - EXT-ACC-001 post-#882 probe recorded (blocked)
+
+- **Verdict:** `blocked` — `redactor_error` before OpenRouter; HoloIndex fix not assessable at model layer.
+- **Distinction:** `redactor_error` (gate scan error, fail-closed) ≠ `blocked_policy` (intentional policy block).
+- **Next slice (P0):** `REDDOG_REDACTION_GATE_CONTEXT_ERROR_DIAGNOSTIC_PHASE1` — before `REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1`.
+- **Pending:** EXT-ACC-003 post-#882 probe (confirms context bundle vs work focus if same error).
+- **Note:** Trace showed `v0.3.20` provider note — reinstall post-#882 VSIX before reruns.
+
+WSP: WSP_97, WSP_22.
 
 ## 2026-06-26 - Post-#882 acceptance criteria update (docs)
 

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.21
+Version: 0.3.22
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -99,19 +99,38 @@ Addendum B required controls (after v0.3.15 lands):
 - Context budget: bounded char budget before bridge; truncation_applied + truncation_reason in packet
 - Failure taxonomy: redaction_blocked, valve_closed, missing_key, timeout, retry_exhausted, http_error, malformed_response, subprocess_failed, output_cap_exceeded
 
+Add slice spec section before WSP_15 table or after - actually add to ROADMAP with full acceptance criteria
+
+### REDDOG_REDACTION_GATE_CONTEXT_ERROR_DIAGNOSTIC_PHASE1
+
+- **Trigger:** Post-#882 EXT-ACC-001/003 probe returns `redactor_error` on `wsp_holo_skillz` bounded context (~25k chars).
+- **Purpose:** Identify what in post-#882 bounded context triggers `redactor_error`; preserve fail-closed behavior.
+- **In scope:** Low-cardinality reason telemetry; safe category reporting (`blocked_policy`, `residual_forbidden`, `non_text_context`, etc.); redaction tests.
+- **Out of scope:** Policy weakening; raw blocked snippets in Copy MD; OpenRouter routing changes.
+- **Acceptance:**
+  - Same EXT-ACC-001 prompt no longer returns `redactor_error`
+  - If blocked, reports specific safe category (not generic `redactor_error`)
+  - No raw blocked content included
+  - Redaction gate tests pass
+- **Blocks:** `REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1` until diagnostic lands and probe reruns successfully.
+
 ### HOLOINDEX_REDDOG_EXTENSION_INDEX_GAP_PHASE1
 
 - Index `extensions/foundups_advisory_workers/extension.js`, `scripts/advisory_model_once.py`, and Skillz/Rolodex discovery paths.
 - Improve semantic recall for RedDog auto-router, WSP_15/97, and governed-handoff queries.
 - Add regression retrieval tests so extension bridge code ranks above adjacent WRE routers.
-- **Status:** PR #882 draft — land before post-land acceptance probe.
+- **Status:** **LANDED** #882 (`99d0e35c2`) — ranking + target recall telemetry only; not source-content inclusion.
 
 ### REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1
 
-- **Conditional — do not start until post-#882 probe proves need.**
+- **Status:** IN PROGRESS (v0.3.22) — test-first ADDENDUM E; 0102-runnable without 012 Cursor UI.
 - Inject target file **content/snippets** into bounded bridge context when HoloIndex ranks the path but omits source body.
-- Trigger: EXT-ACC-001 post-#882 fails criterion 2 (path hit, no source content) despite `target_recall_ok: true`.
-- Distinct from HoloIndex ranking (#882); this slice is bounded context assembly, not retrieval index work.
+- Trigger: EXT-ACC-001 criterion #2 fail with model egress (path hit ~7.4%, no source body) — **OBSERVED**.
+- Run Trace: `target_content_included`, `target_content_paths`, `target_content_chars`, `target_content_omitted_reason`, `target_content_truncated`.
+- WSP_97 tasks: bounded protocol excerpt section.
+- Bump version **0.3.22** (install hygiene after #882 no-bump trap).
+- Distinct from HoloIndex ranking (#882); bounded context assembly in `buildBoundedRepoContext`.
+- 012 only: installed Cursor UX smoke + Copy MD usability after PR VERIFIED_READY.
 
 ### REDDOG_GOVERNED_HANDOFF_CONTRACT_PHASE1
 

--- a/extensions/foundups_advisory_workers/docs/REDDOG_EXTERNAL_ACCEPTANCE_BASELINE_PHASE1.md
+++ b/extensions/foundups_advisory_workers/docs/REDDOG_EXTERNAL_ACCEPTANCE_BASELINE_PHASE1.md
@@ -70,6 +70,7 @@ Direct-read fallback used per WSP_87 after HoloIndex retrieval evaluation.
 | LANE_B_EXCLUDED | OBSERVED |
 | PATH_RANKING_DISTINCT_FROM_CONTENT_INCLUSION | OBSERVED |
 | EXT_ACC_001_REPLACEMENT_REQUIRES_SOURCE_CONTENT | OBSERVED |
+| HEADER_BUILD_LABEL_DISTINCT_FROM_HOST_CODE | OBSERVED |
 
 ---
 
@@ -89,13 +90,28 @@ Direct-read fallback used per WSP_87 after HoloIndex retrieval evaluation.
 
 ### Preflight
 
-1. Confirm `origin/main` includes v0.3.21 (#878 landed).
+**Current shipped label:** Foundups(R)Agent **0.3.22** on branch `feat/reddog-context-target-content-inclusion-phase1` (VERIFIED_READY draft PR; main still **0.3.21** until merge).
+
+1. Confirm `origin/main` includes landed slices under test (e.g. #882 at `99d0e35c2`+).
 2. Build VSIX: `cd extensions/foundups_advisory_workers && npx vsce package --no-dependencies --out foundups-fusion-worker-0.3.21.vsix`
-3. Install VSIX; **Developer: Reload Window**.
+3. Force reinstall (preferred CLI):
+   ```powershell
+   cursor --install-extension "O:\Foundups-Agent\extensions\foundups_advisory_workers\foundups-fusion-worker-0.3.21.vsix" --force
+   ```
+   Or **Extensions: Install from VSIX...** then **Developer: Reload Window**.
 4. Open **Foundups(R)Agent: Open**.
-5. Confirm header shows **Build: 0.3.21**.
-6. Set `OPENROUTER_API_KEY` in Cursor launch environment (never paste into work focus).
-7. Record `installed_version_confirmed: true` only after header matches.
+5. Header `Build: 0.3.21` is **expected** today. It is not sufficient alone - same label can hide stale pre-#882 host code.
+6. **Install verification (required):** First Copy MD Run Trace must show:
+   - `provider_reasoning_note: Report-only in v0.3.21` (not v0.3.20)
+   - `code_hits_count: ...`
+   - `target_recall_ok: ...`
+   Optional disk check (012): compare installed Cursor extension folder `extension.js` against repo.
+7. Set `OPENROUTER_API_KEY` in Cursor launch environment (never paste into work focus).
+8. Record `installed_version_confirmed: true` only when **Run Trace internals** match post-#882 landed code on **0.3.21**.
+
+**Not in scope:** `devcontainer.json` does not install local VSIX or fix Cursor extension cache - do not use for this issue.
+
+**WSP_97:** Header `Build` = OBSERVED label only. Run Trace telemetry fields = OBSERVED proof of installed host code.
 
 ### Per-prompt procedure
 
@@ -393,10 +409,100 @@ Comparison fields: `012_verdict`, rubric totals, HoloIndex hit quality, `target_
 
 **012 action order:**
 
-1. Clean/land PR #882 (`HOLOINDEX_REDDOG_EXTENSION_INDEX_GAP_PHASE1`).
-2. Rerun EXT-ACC-001 and EXT-ACC-003 on installed extension.
-3. If EXT-ACC-001 sees paths but not source content → queue `REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1` (do not start until probe proves need).
-4. If EXT-ACC-001 passes all five replacement criteria → schedule full `REDDOG_EXTERNAL_ACCEPTANCE_REPLACEMENT_PHASE1`.
+1. ~~Clean/land PR #882~~ **DONE** (`99d0e35c2`).
+2. Rerun EXT-ACC-001 and EXT-ACC-003 on installed extension (post-#882 VSIX required).
+3. If probe **`redactor_error`** on clean post-#882 install → `REDDOG_REDACTION_GATE_CONTEXT_ERROR_DIAGNOSTIC_PHASE1`.
+4. **Telemetry gate:** One clean EXT-ACC-001 rerun must show `v0.3.21` note + `code_hits_count` + `target_recall_ok` before closing post-#882 verification.
+5. **Content-inclusion queue:** Stale/mixed artifacts may **queue** `REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1` but do **not** close the telemetry gate or dispatch the slice alone.
+6. After telemetry gate + criterion #2 fail on clean run → dispatch `REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1`.
+7. If EXT-ACC-001 passes all five replacement criteria → schedule full `REDDOG_EXTERNAL_ACCEPTANCE_REPLACEMENT_PHASE1`.
+
+---
+
+## Post-#882 probe results (recorded)
+
+### EXT-ACC-001_post_882_probe (2026-06-26)
+
+```yaml
+EXT-ACC-001_post_882_probe:
+  verdict: blocked
+  test_intent_fulfilled: false
+  reason: redaction_gate_blocked_before_openrouter
+  rule_class: redactor_error
+  made_network_call: false
+  model_output: none
+  target_recall_ok: not_reported
+  index_gap_detected: false  # transport-style; not useful when gate errors
+  holoindex_evaluated: false  # HoloIndex fix not assessable at model layer
+  context_chars: ~25708
+  context_mode: wsp_holo_skillz
+  stale_build_signal: provider_reasoning_note v0.3.20 in trace (post-#882 expects v0.3.21 + target_recall_ok)
+  next_slice_candidate: REDDOG_REDACTION_GATE_CONTEXT_ERROR_DIAGNOSTIC_PHASE1
+```
+
+**WSP_97 distinction:** `redactor_error` ≠ intentional `blocked_policy`. The redaction gate **errored while scanning** the bounded prompt/context, then failed closed. Correct safety behavior; blocks replacement probe.
+
+**Does not evaluate:** HoloIndex ranking (#882), target recall telemetry, or criterion #2 (source content inclusion).
+
+### EXT-ACC-001_post_882_probe_r2 (2026-06-26)
+
+```yaml
+EXT-ACC-001_post_882_probe_r2:
+  verdict: needs_repair
+  test_intent_fulfilled: partial
+  post_882_telemetry_gate: open  # v0.3.20 note; code_hits_count/target_recall_ok missing
+  reason: path_ranked_no_source_content; output_validation_failed
+  made_network_call: true
+  redaction_primary: passed
+  redaction_repair: blocked
+  model_quality: partial_good
+  target_recall_ok: not_reported
+  target_content_included: false
+  wsp97_finding_on_source_content: false
+  holoindex_path_hit: true
+  replacement_pass: fail
+  queue_content_inclusion: true
+  close_post_882_telemetry_gate: false
+  next_slice_candidate: REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1
+  secondary_slice: REDDOG_OUTPUT_SCHEMA_REPAIR_HARDENING_PHASE1
+```
+
+**WSP_97 calibration (012):** This artifact is sufficient to **queue** `REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1`, but **not** sufficient to close the post-#882 telemetry verification gate. Main egress succeeded (not `redactor_error`). RedDog correctly refused to fake a source review; strongest signal: path hit, no source body in bounded context.
+
+**Pending:** One clean EXT-ACC-001 after force-install VSIX; then dispatch content-inclusion if criterion #2 still fails with telemetry active.
+
+**Install trap (2026-06-26, OBSERVED):** Header showed `Build: 0.3.21` while Run Trace had `v0.3.20` note and missing #882 fields. Cause: #882 changed `extension.js` without bumping version past `0.3.21`; Cursor retained older installed host. Force VSIX install + reload required; disk verify optional.
+
+### EXT-ACC-001_post_882_probe_r3 (2026-06-26)
+
+```yaml
+EXT-ACC-001_post_882_probe_r3:
+  verdict: needs_repair
+  test_intent_fulfilled: partial
+  post_882_telemetry_gate: open  # still v0.3.20 note; no code_hits_count/target_recall_ok
+  reason: path_ranked_no_source_content; output_validation_failed_after_repair
+  made_network_call: true
+  redaction_primary: passed
+  redaction_repair: passed  # both repair bridge passes succeeded (vs r2 repair blocked)
+  model_quality: partial_good
+  target_recall_ok: not_reported
+  target_content_included: false
+  wsp97_finding_on_source_content: false
+  holoindex_path_hit: true
+  replacement_pass: fail
+  queue_content_inclusion: true
+  close_post_882_telemetry_gate: false
+  mojibake_in_output: true  # 窶? in lead prose
+  next_slice_candidate: REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1
+  secondary_slice: REDDOG_OUTPUT_SCHEMA_REPAIR_HARDENING_PHASE1
+  install_action: force_install_did_not_stick_in_run_trace — re-verify Cursor extension host folder
+```
+
+**0102 note:** Same substantive signal as r2 (path hit, no source body). Telemetry gate **still open** — not valid as final post-#882 proof artifact. Sufficient to **queue** content inclusion; **dispatch** only after one run shows `v0.3.21` note + `target_recall_ok`.
+
+### EXT-ACC-003_post_882_probe
+
+**Status:** DEFER — rerun EXT-ACC-001 on clean install first (comparison path already established).
 
 ---
 
@@ -404,9 +510,10 @@ Comparison fields: `012_verdict`, rubric totals, HoloIndex hit quality, `target_
 
 | Slice | C | I | D | Impact | MPS | P | Trigger |
 | --- | ---: | ---: | ---: | ---: | ---: | --- | --- |
-| HOLOINDEX_REDDOG_EXTENSION_INDEX_GAP_PHASE1 | 3 | 5 | 4 | 5 | 17 | **P0** | EXT-ACC-003/014 INDEX_GAP — PR #882 draft |
-| REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1 | 4 | 5 | 3 | 5 | 17 | **P0** | **Conditional:** EXT-ACC-001 post-#882 probe shows path hit but no source snippet in bounded context |
-| REDDOG_EXTERNAL_ACCEPTANCE_REPLACEMENT_PHASE1 | 2 | 5 | 5 | 4 | 16 | **P0** | After #882 probe + any required content-inclusion slice |
+| HOLOINDEX_REDDOG_EXTENSION_INDEX_GAP_PHASE1 | 3 | 5 | 4 | 5 | 17 | **P0** | **LANDED** #882 — path ranking + target recall telemetry |
+| REDDOG_REDACTION_GATE_CONTEXT_ERROR_DIAGNOSTIC_PHASE1 | 4 | 5 | 3 | 5 | 17 | **P0** | `redactor_error` on **clean** post-#882 install (probe r1 only so far) |
+| REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1 | 4 | 5 | 3 | 5 | 17 | **P0** | **QUEUED** — worker prompt ready; dispatch on architect approval |
+| REDDOG_EXTERNAL_ACCEPTANCE_REPLACEMENT_PHASE1 | 2 | 5 | 5 | 4 | 16 | **P0** | After probe + redaction fix + any content-inclusion slice |
 | REDDOG_DISPATCH_PROMPT_GENERATOR_PHASE1 | 3 | 5 | 3 | 5 | 16 | **P1** | EXT-ACC-006 weak dispatch output |
 | REDDOG_MODEL_REGISTRY_AND_ROUTING_AUDIT_PHASE1 | 2 | 4 | 3 | 4 | 13 | **P1** | EXT-ACC-008 routing confusion |
 | REDDOG_REVIEW_PACKET_MEMORY_PHASE1 | 3 | 4 | 2 | 4 | 13 | **P2** | After replacement pass |

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,14 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.21';
+const EXTENSION_VERSION = '0.3.22';
+const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
+const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
+const TARGET_READ_BLOCKED_EXTENSIONS = ['.vsix'];
+const TARGET_SNIPPET_MAX_FILE_BYTES = 500000;
+const TARGET_SNIPPET_DEFAULT_CHARS = 16000;
+const WSP97_EXCERPT_MAX_CHARS = 4096;
+const WSP97_PROTOCOL_REL_PATH = 'WSP_framework/src/WSP_97_System_Execution_Prompting_Protocol.md';
 const REDDOG_TERMINAL_HOLD_MS = 3000;
 const REDACTION_BLOCK_OPERATOR_MESSAGE = 'Stopped before OpenRouter. Nothing left the machine.';
 const BRIDGE_MAX_STDOUT_BYTES = 262144;
@@ -287,7 +294,7 @@ function resolveProviderReasoningReport(resolvedEffort) {
   return {
     provider_reasoning_requested: requestedMap[effort] || 'medium',
     provider_reasoning_applied: 'unknown',
-    provider_reasoning_note: 'Report-only in v0.3.21; bridge does not confirm provider reasoning application.'
+    provider_reasoning_note: 'Report-only in v0.3.22; bridge does not confirm provider reasoning application.'
   };
 }
 
@@ -354,7 +361,12 @@ function extractHoloIndexScorecard(contextMode, holoMeta) {
     skill_hits: meta.skill_hits !== undefined ? meta.skill_hits : 'unknown',
     target_recall_ok: meta.target_recall_ok !== undefined ? meta.target_recall_ok : 'unknown',
     index_gap_detected: meta.index_gap_detected !== undefined ? meta.index_gap_detected : 'unknown',
-    direct_read_fallback_used: meta.direct_read_fallback_used !== undefined ? meta.direct_read_fallback_used : 'unknown'
+    direct_read_fallback_used: meta.direct_read_fallback_used !== undefined ? meta.direct_read_fallback_used : 'unknown',
+    target_content_included: meta.target_content_included !== undefined ? meta.target_content_included : 'unknown',
+    target_content_paths: Array.isArray(meta.target_content_paths) ? meta.target_content_paths : 'unknown',
+    target_content_chars: meta.target_content_chars !== undefined ? meta.target_content_chars : 'unknown',
+    target_content_omitted_reason: meta.target_content_omitted_reason !== undefined ? meta.target_content_omitted_reason : 'unknown',
+    target_content_truncated: meta.target_content_truncated !== undefined ? meta.target_content_truncated : 'unknown'
   };
 }
 
@@ -369,7 +381,12 @@ function formatHoloIndexScorecardLines(scorecard) {
     '- skill_hits: ' + scorecard.skill_hits,
     '- target_recall_ok: ' + scorecard.target_recall_ok,
     '- index_gap_detected: ' + scorecard.index_gap_detected,
-    '- direct_read_fallback_used: ' + scorecard.direct_read_fallback_used
+    '- direct_read_fallback_used: ' + scorecard.direct_read_fallback_used,
+    '- target_content_included: ' + scorecard.target_content_included,
+    '- target_content_paths: ' + (Array.isArray(scorecard.target_content_paths) ? scorecard.target_content_paths.join(', ') : scorecard.target_content_paths),
+    '- target_content_chars: ' + scorecard.target_content_chars,
+    '- target_content_omitted_reason: ' + scorecard.target_content_omitted_reason,
+    '- target_content_truncated: ' + scorecard.target_content_truncated
   ];
 }
 
@@ -1416,6 +1433,22 @@ function buildBoundedRepoContext(mode, taskText) {
     holoindex_scorecard = extractHoloIndexScorecard(mode, holoindex_meta);
     sections.push('### HoloIndex recall (WSP_00 bundle-json first; offline fallback only if needed)\n```text\n' + (holo.output || '(no HoloIndex output)') + '\n```');
   }
+  let targetContentMeta = null;
+  if (mode !== 'none') {
+    const targetSection = buildTargetRecallContentSection(root, taskText || '', 24000);
+    if (targetSection.text) {
+      sections.push(targetSection.text);
+    }
+    targetContentMeta = targetSection.meta;
+    holoindex_meta = mergeTargetContentMeta(holoindex_meta, targetContentMeta);
+    holoindex_scorecard = extractHoloIndexScorecard(mode, holoindex_meta);
+    if (taskMentionsWsp97(taskText)) {
+      const wsp97 = buildWsp97ProtocolExcerpt(root, WSP97_EXCERPT_MAX_CHARS);
+      if (wsp97.text) {
+        sections.push(wsp97.text);
+      }
+    }
+  }
   if (mode === 'wsp_holo_skillz' || mode === 'wsp_holo_git_skillz') {
     const skillz = skillzWardrobeRolodexContext(root, taskText || '', 12000);
     sections.push(skillz);
@@ -1571,6 +1604,196 @@ function scoreSkillzPath(file, tokens) {
     if (normalized.includes(token)) score += 4;
   }
   return score;
+}
+
+function normalizeRelRepoPath(relPath) {
+  return String(relPath || '').replace(/\\/g, '/').replace(/^\/+/, '');
+}
+
+function isTargetReadPathDenied(relPath) {
+  const normalized = normalizeRelRepoPath(relPath);
+  if (!normalized) {
+    return 'path_missing';
+  }
+  if (path.isAbsolute(normalized) || /^[a-zA-Z]:/.test(normalized)) {
+    return 'outside_root';
+  }
+  if (normalized.includes('..')) {
+    return 'outside_root';
+  }
+  const lower = normalized.toLowerCase();
+  const parts = lower.split('/');
+  for (const seg of TARGET_READ_BLOCKED_SEGMENTS) {
+    if (parts.includes(seg)) {
+      return 'outside_root';
+    }
+  }
+  const base = path.basename(lower);
+  for (const name of TARGET_READ_BLOCKED_BASENAMES) {
+    if (base === name || base.startsWith(name + '.')) {
+      return 'outside_root';
+    }
+  }
+  for (const ext of TARGET_READ_BLOCKED_EXTENSIONS) {
+    if (lower.endsWith(ext)) {
+      return 'outside_root';
+    }
+  }
+  return null;
+}
+
+function resolveSafeRepoFile(root, relPath) {
+  const deny = isTargetReadPathDenied(relPath);
+  if (deny) {
+    return { ok: false, reason: deny };
+  }
+  try {
+    const resolvedRoot = path.resolve(root);
+    const full = path.resolve(resolvedRoot, relPath);
+    if (full !== resolvedRoot && !full.startsWith(resolvedRoot + path.sep)) {
+      return { ok: false, reason: 'outside_root' };
+    }
+    const realpathFn = fs.realpathSync.native || fs.realpathSync;
+    const real = realpathFn(full);
+    const realRoot = realpathFn(resolvedRoot);
+    if (real !== realRoot && !real.startsWith(realRoot + path.sep)) {
+      return { ok: false, reason: 'outside_root' };
+    }
+    return { ok: true, full: real };
+  } catch (err) {
+    return { ok: false, reason: 'path_missing' };
+  }
+}
+
+function isLikelyBinaryFile(fullPath) {
+  try {
+    const fd = fs.openSync(fullPath, 'r');
+    const buf = Buffer.alloc(8192);
+    const n = fs.readSync(fd, buf, 0, 8192, 0);
+    fs.closeSync(fd);
+    return buf.slice(0, n).includes(0);
+  } catch (err) {
+    return true;
+  }
+}
+
+function targetSnippetLanguageId(relPath) {
+  const normalized = normalizeRelRepoPath(relPath).toLowerCase();
+  if (normalized.endsWith('.py')) {
+    return 'python';
+  }
+  if (normalized.endsWith('.js')) {
+    return 'javascript';
+  }
+  if (normalized.endsWith('.md')) {
+    return 'markdown';
+  }
+  return 'text';
+}
+
+function readBoundedTargetSnippet(root, relPath, maxChars) {
+  const max = maxChars || TARGET_SNIPPET_DEFAULT_CHARS;
+  const resolved = resolveSafeRepoFile(root, relPath);
+  if (!resolved.ok) {
+    return { content: '', omitted_reason: resolved.reason, truncated: false, chars: 0 };
+  }
+  try {
+    const stat = fs.statSync(resolved.full);
+    if (!stat.isFile()) {
+      return { content: '', omitted_reason: 'path_missing', truncated: false, chars: 0 };
+    }
+    if (stat.size > TARGET_SNIPPET_MAX_FILE_BYTES) {
+      return { content: '', omitted_reason: 'binary_or_oversized', truncated: false, chars: 0 };
+    }
+    if (isLikelyBinaryFile(resolved.full)) {
+      return { content: '', omitted_reason: 'binary_or_oversized', truncated: false, chars: 0 };
+    }
+    const raw = fs.readFileSync(resolved.full, 'utf8');
+    const truncated = raw.length > max;
+    const clipped = truncated ? raw.slice(0, max) + '\n...[TRUNCATED ' + (raw.length - max) + ' chars]' : raw;
+    return { content: clipped, omitted_reason: 'none', truncated, chars: clipped.length };
+  } catch (err) {
+    return { content: '', omitted_reason: 'read_error', truncated: false, chars: 0 };
+  }
+}
+
+function readBoundedTargetSnippets(root, taskText, opts) {
+  const options = opts && typeof opts === 'object' ? opts : {};
+  const built = buildTargetRecallContentSection(root, taskText, options.maxChars || 24000);
+  return {
+    sections: built.text ? [built.text] : [],
+    meta: built.meta
+  };
+}
+
+function buildTargetRecallContentSection(root, taskText, maxChars) {
+  const budget = maxChars || 24000;
+  const targets = inferRecallTargetPaths(taskText).filter((target) => !target.startsWith('symbol:'));
+  const meta = {
+    target_content_included: false,
+    target_content_paths: [],
+    target_content_chars: 0,
+    target_content_omitted_reason: 'no_targets',
+    target_content_truncated: false
+  };
+  if (!targets.length) {
+    return { text: '', meta };
+  }
+  const sections = [];
+  let used = 0;
+  let anyIncluded = false;
+  let truncatedAny = false;
+  const omitted = [];
+  for (const rel of targets) {
+    const perFile = Math.max(2000, Math.floor(budget / targets.length));
+    const snippet = readBoundedTargetSnippet(root, rel, perFile);
+    if (snippet.content) {
+      anyIncluded = true;
+      meta.target_content_paths.push(rel);
+      used += snippet.chars;
+      if (snippet.truncated) {
+        truncatedAny = true;
+      }
+      sections.push('#### ' + rel + '\n```' + targetSnippetLanguageId(rel) + '\n' + snippet.content + '\n```');
+    } else if (snippet.omitted_reason && snippet.omitted_reason !== 'none') {
+      omitted.push(snippet.omitted_reason);
+    }
+  }
+  meta.target_content_included = anyIncluded;
+  meta.target_content_chars = used;
+  meta.target_content_truncated = truncatedAny;
+  meta.target_content_omitted_reason = anyIncluded ? 'none' : (omitted[0] || 'path_missing');
+  if (!sections.length) {
+    return { text: '', meta };
+  }
+  return { text: '### Target recall content\n' + sections.join('\n\n'), meta };
+}
+
+function taskMentionsWsp97(taskText) {
+  return /wsp[_\s-]?97|truth[\s_-]?label/i.test(String(taskText || ''));
+}
+
+function buildWsp97ProtocolExcerpt(root, maxChars) {
+  const snippet = readBoundedTargetSnippet(root, WSP97_PROTOCOL_REL_PATH, maxChars || WSP97_EXCERPT_MAX_CHARS);
+  if (!snippet.content) {
+    return { text: '', meta: { wsp97_excerpt_included: false, wsp97_excerpt_chars: 0 } };
+  }
+  return {
+    text: '### WSP protocol excerpt (bounded)\n```markdown\n' + snippet.content + '\n```',
+    meta: { wsp97_excerpt_included: true, wsp97_excerpt_chars: snippet.chars }
+  };
+}
+
+function mergeTargetContentMeta(holoMeta, targetMeta) {
+  const meta = holoMeta && typeof holoMeta === 'object' ? Object.assign({}, holoMeta) : {};
+  if (targetMeta) {
+    meta.target_content_included = targetMeta.target_content_included;
+    meta.target_content_paths = targetMeta.target_content_paths || [];
+    meta.target_content_chars = targetMeta.target_content_chars || 0;
+    meta.target_content_omitted_reason = targetMeta.target_content_omitted_reason || 'unknown';
+    meta.target_content_truncated = !!targetMeta.target_content_truncated;
+  }
+  return meta;
 }
 
 function readBoundedRepoFile(root, relPath, maxChars) {
@@ -2157,6 +2380,15 @@ module.exports = {
   evaluateTargetRecall,
   inferRecallTargetPaths,
   holoIndexMetaFromBundle,
+  isTargetReadPathDenied,
+  resolveSafeRepoFile,
+  readBoundedTargetSnippet,
+  readBoundedTargetSnippets,
+  buildTargetRecallContentSection,
+  taskMentionsWsp97,
+  buildWsp97ProtocolExcerpt,
+  mergeTargetContentMeta,
+  WSP97_PROTOCOL_REL_PATH,
   MOJIBAKE_MARKERS,
   WORK_TRAIL_MAX_EVENTS,
   VALIDATION_FAILED_FOOTER

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -12,6 +12,15 @@ const TARGET_SNIPPET_MAX_FILE_BYTES = 500000;
 const TARGET_SNIPPET_DEFAULT_CHARS = 16000;
 const WSP97_EXCERPT_MAX_CHARS = 4096;
 const WSP97_PROTOCOL_REL_PATH = 'WSP_framework/src/WSP_97_System_Execution_Prompting_Protocol.md';
+// Mirrors fusion_redaction_gate.py BLOCK categories only (policy v1). Do not weaken Python gate.
+const TARGET_SNIPPET_BLOCK_SANITIZERS = [
+  ['private_key_residual', /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----/gi],
+  ['private_reasoning', /(?:<\s*think(?:ing)?\b|<\/\s*think|<\s*scratchpad|chain[\s_\-]?of[\s_\-]?thought|hidden[\s_\-]+chain[\s_\-]?of[\s_\-]?thought|hidden[\s_\-]?reasoning|private[\s_\-]?reasoning)/gi],
+  ['merge_authorization', /\b(?:pull_request_merge|merge[\s_\-]?token|auto[\s_\-]?merge[\s_\-]?token|merge[\s_\-]?authoriz\w*)\b/gi],
+  ['source_authority', /\bsource[\s_\-]?authority\b/gi],
+  ['cabr_payout_authority', /\b(?:cabr[\s_\-]?ready|cabr[\s_\-]?payout|payout[\s_\-]?ready|payout[\s_\-]?routing|benefit[\s_\-]?routing|route[\s_\-]?payouts|capability_token\w*)\b/gi],
+  ['governance_instruction', /\b(?:internal[\s_\-]?governance|governance[\s_\-]?instruction|redaction_gate_(?:passed|blocked|started)|gate[\s_\-]?passed|grant[\s_\-]?authority)\b/gi]
+];
 const REDDOG_TERMINAL_HOLD_MS = 3000;
 const REDACTION_BLOCK_OPERATOR_MESSAGE = 'Stopped before OpenRouter. Nothing left the machine.';
 const BRIDGE_MAX_STDOUT_BYTES = 262144;
@@ -366,7 +375,11 @@ function extractHoloIndexScorecard(contextMode, holoMeta) {
     target_content_paths: Array.isArray(meta.target_content_paths) ? meta.target_content_paths : 'unknown',
     target_content_chars: meta.target_content_chars !== undefined ? meta.target_content_chars : 'unknown',
     target_content_omitted_reason: meta.target_content_omitted_reason !== undefined ? meta.target_content_omitted_reason : 'unknown',
-    target_content_truncated: meta.target_content_truncated !== undefined ? meta.target_content_truncated : 'unknown'
+    target_content_truncated: meta.target_content_truncated !== undefined ? meta.target_content_truncated : 'unknown',
+    target_content_sanitized: meta.target_content_sanitized !== undefined ? meta.target_content_sanitized : 'unknown',
+    target_content_sanitized_categories: Array.isArray(meta.target_content_sanitized_categories)
+      ? meta.target_content_sanitized_categories
+      : 'unknown'
   };
 }
 
@@ -386,7 +399,11 @@ function formatHoloIndexScorecardLines(scorecard) {
     '- target_content_paths: ' + (Array.isArray(scorecard.target_content_paths) ? scorecard.target_content_paths.join(', ') : scorecard.target_content_paths),
     '- target_content_chars: ' + scorecard.target_content_chars,
     '- target_content_omitted_reason: ' + scorecard.target_content_omitted_reason,
-    '- target_content_truncated: ' + scorecard.target_content_truncated
+    '- target_content_truncated: ' + scorecard.target_content_truncated,
+    '- target_content_sanitized: ' + scorecard.target_content_sanitized,
+    '- target_content_sanitized_categories: ' + (Array.isArray(scorecard.target_content_sanitized_categories)
+      ? scorecard.target_content_sanitized_categories.join(', ')
+      : scorecard.target_content_sanitized_categories)
   ];
 }
 
@@ -1446,6 +1463,8 @@ function buildBoundedRepoContext(mode, taskText) {
       const wsp97 = buildWsp97ProtocolExcerpt(root, WSP97_EXCERPT_MAX_CHARS);
       if (wsp97.text) {
         sections.push(wsp97.text);
+        holoindex_meta = applyWsp97SanitizationMeta(holoindex_meta, wsp97.meta);
+        holoindex_scorecard = extractHoloIndexScorecard(mode, holoindex_meta);
       }
     }
   }
@@ -1691,6 +1710,38 @@ function targetSnippetLanguageId(relPath) {
   return 'text';
 }
 
+function sanitizeTargetSnippetForRedaction(raw) {
+  let out = String(raw || '');
+  const categories = [];
+  TARGET_SNIPPET_BLOCK_SANITIZERS.forEach((entry, idx) => {
+    const cat = entry[0];
+    const rx = entry[1];
+    const placeholder = '[SANITIZED_BLOCK:' + String(idx + 1).padStart(2, '0') + ']';
+    let hit = false;
+    out = out.replace(rx, () => {
+      hit = true;
+      return placeholder;
+    });
+    if (hit && categories.indexOf(cat) === -1) {
+      categories.push(cat);
+    }
+  });
+  return { text: out, sanitized: categories.length > 0, categories: categories };
+}
+
+function mergeSanitizedCategories(into, from) {
+  const merged = Array.isArray(into) ? into.slice() : [];
+  if (!Array.isArray(from)) {
+    return merged;
+  }
+  for (const cat of from) {
+    if (merged.indexOf(cat) === -1) {
+      merged.push(cat);
+    }
+  }
+  return merged;
+}
+
 function readBoundedTargetSnippet(root, relPath, maxChars) {
   const max = maxChars || TARGET_SNIPPET_DEFAULT_CHARS;
   const resolved = resolveSafeRepoFile(root, relPath);
@@ -1711,9 +1762,17 @@ function readBoundedTargetSnippet(root, relPath, maxChars) {
     const raw = fs.readFileSync(resolved.full, 'utf8');
     const truncated = raw.length > max;
     const clipped = truncated ? raw.slice(0, max) + '\n...[TRUNCATED ' + (raw.length - max) + ' chars]' : raw;
-    return { content: clipped, omitted_reason: 'none', truncated, chars: clipped.length };
+    const sanitized = sanitizeTargetSnippetForRedaction(clipped);
+    return {
+      content: sanitized.text,
+      omitted_reason: 'none',
+      truncated,
+      chars: sanitized.text.length,
+      sanitized: sanitized.sanitized,
+      sanitized_categories: sanitized.categories
+    };
   } catch (err) {
-    return { content: '', omitted_reason: 'read_error', truncated: false, chars: 0 };
+    return { content: '', omitted_reason: 'read_error', truncated: false, chars: 0, sanitized: false, sanitized_categories: [] };
   }
 }
 
@@ -1734,7 +1793,9 @@ function buildTargetRecallContentSection(root, taskText, maxChars) {
     target_content_paths: [],
     target_content_chars: 0,
     target_content_omitted_reason: 'no_targets',
-    target_content_truncated: false
+    target_content_truncated: false,
+    target_content_sanitized: false,
+    target_content_sanitized_categories: []
   };
   if (!targets.length) {
     return { text: '', meta };
@@ -1753,6 +1814,10 @@ function buildTargetRecallContentSection(root, taskText, maxChars) {
       used += snippet.chars;
       if (snippet.truncated) {
         truncatedAny = true;
+      }
+      if (snippet.sanitized) {
+        meta.target_content_sanitized = true;
+        meta.target_content_sanitized_categories = mergeSanitizedCategories(meta.target_content_sanitized_categories, snippet.sanitized_categories);
       }
       sections.push('#### ' + rel + '\n```' + targetSnippetLanguageId(rel) + '\n' + snippet.content + '\n```');
     } else if (snippet.omitted_reason && snippet.omitted_reason !== 'none') {
@@ -1776,11 +1841,16 @@ function taskMentionsWsp97(taskText) {
 function buildWsp97ProtocolExcerpt(root, maxChars) {
   const snippet = readBoundedTargetSnippet(root, WSP97_PROTOCOL_REL_PATH, maxChars || WSP97_EXCERPT_MAX_CHARS);
   if (!snippet.content) {
-    return { text: '', meta: { wsp97_excerpt_included: false, wsp97_excerpt_chars: 0 } };
+    return { text: '', meta: { wsp97_excerpt_included: false, wsp97_excerpt_chars: 0, wsp97_excerpt_sanitized: false, wsp97_excerpt_sanitized_categories: [] } };
   }
   return {
     text: '### WSP protocol excerpt (bounded)\n```markdown\n' + snippet.content + '\n```',
-    meta: { wsp97_excerpt_included: true, wsp97_excerpt_chars: snippet.chars }
+    meta: {
+      wsp97_excerpt_included: true,
+      wsp97_excerpt_chars: snippet.chars,
+      wsp97_excerpt_sanitized: !!snippet.sanitized,
+      wsp97_excerpt_sanitized_categories: snippet.sanitized_categories || []
+    }
   };
 }
 
@@ -1792,7 +1862,24 @@ function mergeTargetContentMeta(holoMeta, targetMeta) {
     meta.target_content_chars = targetMeta.target_content_chars || 0;
     meta.target_content_omitted_reason = targetMeta.target_content_omitted_reason || 'unknown';
     meta.target_content_truncated = !!targetMeta.target_content_truncated;
+    meta.target_content_sanitized = !!targetMeta.target_content_sanitized;
+    meta.target_content_sanitized_categories = Array.isArray(targetMeta.target_content_sanitized_categories)
+      ? targetMeta.target_content_sanitized_categories.slice()
+      : [];
   }
+  return meta;
+}
+
+function applyWsp97SanitizationMeta(holoMeta, wsp97Meta) {
+  const meta = holoMeta && typeof holoMeta === 'object' ? Object.assign({}, holoMeta) : {};
+  if (!wsp97Meta || !wsp97Meta.wsp97_excerpt_sanitized) {
+    return meta;
+  }
+  meta.target_content_sanitized = true;
+  meta.target_content_sanitized_categories = mergeSanitizedCategories(
+    meta.target_content_sanitized_categories,
+    wsp97Meta.wsp97_excerpt_sanitized_categories
+  );
   return meta;
 }
 
@@ -2388,6 +2475,10 @@ module.exports = {
   taskMentionsWsp97,
   buildWsp97ProtocolExcerpt,
   mergeTargetContentMeta,
+  applyWsp97SanitizationMeta,
+  sanitizeTargetSnippetForRedaction,
+  mergeSanitizedCategories,
+  TARGET_SNIPPET_BLOCK_SANITIZERS,
   WSP97_PROTOCOL_REL_PATH,
   MOJIBAKE_MARKERS,
   WORK_TRAIL_MAX_EVENTS,

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups®Agent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.21",
+    "version":  "0.3.22",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/README.md
+++ b/extensions/foundups_advisory_workers/tests/README.md
@@ -27,12 +27,17 @@ python -m pytest holo_index/tests/test_reddog_extension_bundle_recall.py -q
 | File | Purpose |
 | --- | --- |
 | `fixtures.js` | Shared prompts and path lists (EXT-ACC-001, denied paths) |
-| `verify_extension_contract.js` | Single contract runner; ADDENDUM E block ~line 516+ |
+| `verify_extension_contract.js` | Single contract runner; ADDENDUM E ~line 518+, ADDENDUM F gate probe ~line 595+ |
+
+## TEST_REGISTRY
+
+See `TestModLog.md` for TCI-001 through TCI-010. Extend registry rows; do not duplicate probes.
 
 ## Expected behavior
 
 - `inferRecallTargetPaths(EXT_ACC_001_PROMPT)` includes `extension.js`.
 - `buildBoundedRepoContext('wsp_holo_skillz', EXT_ACC_001_PROMPT)` includes target recall content, WSP_97 excerpt, and `target_content_included: true` in scorecard.
+- ADDENDUM F: sanitized snippets pass Python `evaluate_redaction_gate` (TCI-009/TCI-010).
 - Path safety rejects absolute, traversal, `.env`, `.git`, `node_modules`, `.vsix`.
 
 ## Integration requirements

--- a/extensions/foundups_advisory_workers/tests/README.md
+++ b/extensions/foundups_advisory_workers/tests/README.md
@@ -1,0 +1,41 @@
+# Foundups(R)Agent Extension Tests
+
+## Test strategy
+
+Contract tests run **without OpenRouter, Cursor UI, or live bridge calls**. They validate extension source shape, exported helpers, bounded-context assembly, and Copy MD schema.
+
+**Reuse rule (WSP 50):** Before adding tests, read `fixtures.js`, `TestModLog.md` TEST_REGISTRY, and `verify_extension_contract.js`. Extend existing fixtures and assertions; do not duplicate prompt strings or EXT-ACC probes.
+
+## How to run
+
+From repo root:
+
+```powershell
+node --check extensions/foundups_advisory_workers/extension.js
+node extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+git diff --check -- extensions/foundups_advisory_workers
+```
+
+HoloIndex bundle recall (separate module tests):
+
+```powershell
+python -m pytest holo_index/tests/test_reddog_extension_bundle_recall.py -q
+```
+
+## Fixtures
+
+| File | Purpose |
+| --- | --- |
+| `fixtures.js` | Shared prompts and path lists (EXT-ACC-001, denied paths) |
+| `verify_extension_contract.js` | Single contract runner; ADDENDUM E block ~line 516+ |
+
+## Expected behavior
+
+- `inferRecallTargetPaths(EXT_ACC_001_PROMPT)` includes `extension.js`.
+- `buildBoundedRepoContext('wsp_holo_skillz', EXT_ACC_001_PROMPT)` includes target recall content, WSP_97 excerpt, and `target_content_included: true` in scorecard.
+- Path safety rejects absolute, traversal, `.env`, `.git`, `node_modules`, `.vsix`.
+
+## Integration requirements
+
+- VSCode API mocked via `node_modules/vscode` stub in contract runner.
+- Workspace root = repo root (three levels above `tests/`).

--- a/extensions/foundups_advisory_workers/tests/TestModLog.md
+++ b/extensions/foundups_advisory_workers/tests/TestModLog.md
@@ -1,5 +1,34 @@
 # Foundups®Agent TestModLog
 
+## 2026-06-14 - REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1 (ADDENDUM E)
+
+**Reuse:** `tests/fixtures.js` + registry below. Do not duplicate EXT-ACC-001 prompt strings in new tests.
+
+### TEST_REGISTRY (contract runner)
+
+| ID | Location | Asserts | Reuse for |
+| --- | --- | --- | --- |
+| TCI-001 | `verify_extension_contract.js` | `inferRecallTargetPaths(EXT_ACC_001_PROMPT)` -> `extension.js` | Recall inference regressions |
+| TCI-002 | same | `readBoundedTargetSnippet` nonzero body, `omitted_reason: none` | Snippet read regressions |
+| TCI-003 | same | `TARGET_READ_DENIED_PATHS` all rejected by `isTargetReadPathDenied` | Path safety regressions |
+| TCI-004 | same | `resolveSafeRepoFile` ok for `extension.js` | Workspace confinement |
+| TCI-005 | same | `buildTargetRecallContentSection` header + `target_content_included: true` | Section assembly |
+| TCI-006 | same | `buildWsp97ProtocolExcerpt` protocol title present | WSP_97 excerpt on task match |
+| TCI-007 | same | `buildBoundedRepoContext('wsp_holo_skillz', EXT_ACC_001_PROMPT)` integration | End-to-end bounded context |
+| TCI-008 | same | `inferRecallTargetPaths(BUILD_COPY_MARKDOWN_PROMPT)` -> `extension.js` | Symbol/path dual inference |
+
+**Fixtures file:** `tests/fixtures.js` exports `EXT_ACC_001_PROMPT`, `EXT_ACC_001_TARGET_PATH`, `BUILD_COPY_MARKDOWN_PROMPT`, `TARGET_READ_DENIED_PATHS`.
+
+**Prior slice (do not recreate):** HoloIndex path ranking -> `holo_index/tests/test_reddog_extension_bundle_recall.py` + TCI predecessor block (`evaluateTargetRecall`, `target_recall_ok`) in same contract file ~line 443.
+
+Commands:
+
+```powershell
+node --check extensions/foundups_advisory_workers/extension.js
+node extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+git diff --check -- extensions/foundups_advisory_workers
+```
+
 ## 2026-06-26 - HOLOINDEX_REDDOG_EXTENSION_INDEX_GAP_PHASE1
 - Verified `extension.js` in top 3 for EXT-ACC-001 review query (bundle-json + pytest).
 - Verified `extension.js:buildCopyMarkdown` top hit for buildCopyMarkdown query.

--- a/extensions/foundups_advisory_workers/tests/TestModLog.md
+++ b/extensions/foundups_advisory_workers/tests/TestModLog.md
@@ -16,6 +16,10 @@
 | TCI-006 | same | `buildWsp97ProtocolExcerpt` protocol title present | WSP_97 excerpt on task match |
 | TCI-007 | same | `buildBoundedRepoContext('wsp_holo_skillz', EXT_ACC_001_PROMPT)` integration | End-to-end bounded context |
 | TCI-008 | same | `inferRecallTargetPaths(BUILD_COPY_MARKDOWN_PROMPT)` -> `extension.js` | Symbol/path dual inference |
+| TCI-009 | same | `target_content_sanitized` + no raw block literals in target section | ADDENDUM F sanitization |
+| TCI-010 | same | Python `evaluate_redaction_gate` PASS on target section + full EXT-ACC-001 context | Egress safety (no OpenRouter) |
+
+**Gate probe helper:** `assertFusionRedactionGatePasses()` in contract runner (stdin to Python policy).
 
 **Fixtures file:** `tests/fixtures.js` exports `EXT_ACC_001_PROMPT`, `EXT_ACC_001_TARGET_PATH`, `BUILD_COPY_MARKDOWN_PROMPT`, `TARGET_READ_DENIED_PATHS`.
 

--- a/extensions/foundups_advisory_workers/tests/fixtures.js
+++ b/extensions/foundups_advisory_workers/tests/fixtures.js
@@ -1,0 +1,25 @@
+/**
+ * Shared contract-test fixtures. Reuse in verify_extension_contract.js and future
+ * RedDog slices — do not duplicate prompt strings across test files.
+ */
+const EXT_ACC_001_PROMPT = 'Review extensions/foundups_advisory_workers/extension.js for WSP_97 truth-label compliance. List OBSERVED vs INFERRED claims, missing evidence, and smallest valid fixes. Include WSP_15 priority for each fix.';
+
+const EXT_ACC_001_TARGET_PATH = 'extensions/foundups_advisory_workers/extension.js';
+
+const BUILD_COPY_MARKDOWN_PROMPT = 'Review buildCopyMarkdown in extensions/foundups_advisory_workers/extension.js for WSP_97 compliance.';
+
+const TARGET_READ_DENIED_PATHS = [
+  ['C:/Windows/System32/drivers/etc/hosts', 'absolute path'],
+  ['../outside.txt', 'traversal'],
+  ['.env', '.env basename'],
+  ['extensions/foundups_advisory_workers/node_modules/pkg/index.js', 'node_modules segment'],
+  ['.git/config', '.git segment'],
+  ['extensions/foundups_advisory_workers/foundups-fusion-worker-0.3.21.vsix', 'vsix extension']
+];
+
+module.exports = {
+  EXT_ACC_001_PROMPT,
+  EXT_ACC_001_TARGET_PATH,
+  BUILD_COPY_MARKDOWN_PROMPT,
+  TARGET_READ_DENIED_PATHS
+};

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -3,6 +3,8 @@ const path = require('path');
 const assert = require('assert');
 const Module = require('module');
 
+const fixtures = require('./fixtures');
+
 const root = path.resolve(__dirname, '..', '..', '..');
 const extDir = path.join(root, 'extensions', 'foundups_advisory_workers');
 const extensionJs = fs.readFileSync(path.join(extDir, 'extension.js'), 'utf8');
@@ -16,8 +18,8 @@ function includes(haystack, needle, label) {
   assert(haystack.includes(needle), label || `missing ${needle}`);
 }
 
-assert.strictEqual(pkg.version, '0.3.21', 'package version must be 0.3.21');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.21'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.22', 'package version must be 0.3.22');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.22'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups®Agent', 'display name must be Foundups®Agent');
 includes(JSON.stringify(pkg), 'Foundups®Agent: Open', 'command title must use Foundups®Agent');
@@ -34,7 +36,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.21', 'README version mismatch');
+includes(readme, 'Version: 0.3.22', 'README version mismatch');
 includes(extensionJs, 'function resolvePythonInterpreter', 'python resolver missing');
 includes(extensionJs, 'function applyBridgeContextBudget', 'context budget missing');
 includes(extensionJs, 'function killBridgeChild', 'orphan cleanup missing');
@@ -512,5 +514,49 @@ includes(repairFailCopy, 'provider_reasoning_applied: unknown', 'provider reason
 
 const sanitized = orchestrator.sanitizeCopyMdText('OPENROUTER_API_KEY visible to bridge: yes');
 includes(sanitized, 'key_env_present: true', 'trail sanitizer must normalize secret-adjacent env phrase');
+
+// ADDENDUM E - 0102 test-first content inclusion (no OpenRouter)
+// Fixtures: tests/fixtures.js — reuse EXT_ACC_001_PROMPT; do not duplicate.
+const extAcc001Prompt = fixtures.EXT_ACC_001_PROMPT;
+
+const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
+assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
+
+const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.22'", 'target snippet must include extension.js source');
+assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
+assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
+
+for (const [badPath, label] of fixtures.TARGET_READ_DENIED_PATHS) {
+  assert(orchestrator.isTargetReadPathDenied(badPath), 'must reject ' + label + ': ' + badPath);
+}
+
+const safeResolve = orchestrator.resolveSafeRepoFile(root, fixtures.EXT_ACC_001_TARGET_PATH);
+assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside workspace root');
+
+const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
+includes(targetSection.text, '### Target recall content', 'target recall section header missing');
+includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.22'", 'target recall must include source snippet');
+assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
+assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
+
+const wsp97Excerpt = orchestrator.buildWsp97ProtocolExcerpt(root, 4096);
+includes(wsp97Excerpt.text, '### WSP protocol excerpt (bounded)', 'WSP_97 excerpt header missing');
+includes(wsp97Excerpt.text, 'WSP 97: System Execution Prompting Protocol', 'WSP_97 excerpt must include protocol title');
+assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerpt_included must be true');
+
+const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
+includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
+includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.22'", 'bounded context must include extension.js source snippet');
+includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
+includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
+assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');
+assert(boundedContext.holoindex_scorecard.target_content_chars > 0, 'scorecard target_content_chars must be > 0');
+includes(boundedContext.holoindex_scorecard.target_content_paths.join(','), fixtures.EXT_ACC_001_TARGET_PATH, 'scorecard must list included path');
+
+const copyTargets = orchestrator.inferRecallTargetPaths(fixtures.BUILD_COPY_MARKDOWN_PROMPT);
+assert(copyTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'buildCopyMarkdown prompt must map to extension.js');
 
 console.log('Foundups®Agent extension contract checks passed.');

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
+const cp = require('child_process');
 const Module = require('module');
 
 const fixtures = require('./fixtures');
@@ -16,6 +17,39 @@ const roadmap = fs.readFileSync(path.join(extDir, 'ROADMAP.md'), 'utf8');
 
 function includes(haystack, needle, label) {
   assert(haystack.includes(needle), label || `missing ${needle}`);
+}
+
+function assertFusionRedactionGatePasses(contextText, label) {
+  const script = [
+    'import sys',
+    'from modules.communication.moltbot_bridge.src.fusion_redaction_gate import evaluate_redaction_gate, REDACTION_GATE_PASSED',
+    'ctx = sys.stdin.read()',
+    'r = evaluate_redaction_gate("012 work focus digest placeholder for gate probe", ctx)',
+    'if r.status != REDACTION_GATE_PASSED:',
+    '    cats = ",".join(r.report.blocked_categories)',
+    '    print("BLOCKED:" + r.reason + ":" + cats)',
+    '    sys.exit(1)',
+    'print("PASSED")'
+  ].join('\n');
+  const out = cp.execFileSync('python', ['-B', '-c', script], {
+    cwd: root,
+    input: String(contextText || ''),
+    encoding: 'utf8',
+    timeout: 30000,
+    maxBuffer: 1024 * 1024
+  }).trim();
+  assert.strictEqual(out, 'PASSED', label || 'bounded context must pass fusion redaction gate');
+}
+
+function extractTargetRecallSection(contextText) {
+  const marker = '### Target recall content';
+  const start = String(contextText || '').indexOf(marker);
+  if (start === -1) {
+    return '';
+  }
+  const tail = contextText.slice(start);
+  const next = tail.indexOf('\n### ', marker.length);
+  return next === -1 ? tail : tail.slice(0, next);
 }
 
 assert.strictEqual(pkg.version, '0.3.22', 'package version must be 0.3.22');
@@ -558,5 +592,20 @@ includes(boundedContext.holoindex_scorecard.target_content_paths.join(','), fixt
 
 const copyTargets = orchestrator.inferRecallTargetPaths(fixtures.BUILD_COPY_MARKDOWN_PROMPT);
 assert(copyTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'buildCopyMarkdown prompt must map to extension.js');
+
+// ADDENDUM F - redaction-safe target snippets (reuse fixtures; gate probe via Python policy)
+assert.strictEqual(targetSection.meta.target_content_sanitized, true, 'extension.js snippet must be sanitized for gate safety');
+assert(targetSection.meta.target_content_sanitized_categories.length > 0, 'sanitized categories must be recorded');
+includes(targetSection.text, '[SANITIZED_BLOCK:', 'sanitized placeholders must preserve review shape');
+assert(!targetSection.text.includes('grant authority'), 'raw grant authority must not remain in target recall section');
+assert(!targetSection.text.includes('hidden chain-of-thought'), 'raw hidden chain-of-thought must not remain in target recall section');
+assert(!targetSection.text.includes('redaction_gate_passed'), 'raw redaction_gate_passed must not remain in target recall section');
+
+const targetRecallSection = extractTargetRecallSection(boundedContext.text);
+assert(targetRecallSection.length > 0, 'target recall section must exist for gate probe');
+assertFusionRedactionGatePasses(targetRecallSection, 'target recall section must pass fusion redaction gate');
+assertFusionRedactionGatePasses(boundedContext.text, 'EXT-ACC-001 bounded context must pass fusion redaction gate');
+assert.strictEqual(boundedContext.holoindex_scorecard.target_content_sanitized, true, 'scorecard target_content_sanitized must be true when replacements occurred');
+assert(boundedContext.holoindex_scorecard.target_content_sanitized_categories.length > 0, 'scorecard must list sanitized categories');
 
 console.log('Foundups®Agent extension contract checks passed.');


### PR DESCRIPTION
## Summary

- **REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1:** When HoloIndex ranks a recall target path, `buildBoundedRepoContext` now egresses bounded source snippets (`### Target recall content`) plus optional WSP_97 protocol excerpt — not path-only bundle-json metadata alone.
- **Run Trace telemetry:** `target_content_included`, `target_content_paths`, `target_content_chars`, `target_content_omitted_reason`, `target_content_truncated` (final bounded context boundary documented in INTERFACE).
- **Version 0.3.22** for install hygiene after #882 no-bump trap.
- **ADDENDUM E test reuse:** `tests/fixtures.js`, `tests/README.md`, TestModLog registry **TCI-001..TCI-008**; contract runner imports fixtures (no duplicated EXT-ACC-001 prompt).

## EXT-ACC-001 evidence (before)

Post-#882 probe: `target_recall_ok: true`, path hit ~7.4%, **no source body** in bounded context; model correctly BLOCKed. Criterion #2 failed.

## Hard checks (this PR)

| # | Check | Evidence |
|---|--------|----------|
| 1 | Target snippet section for extension.js review task | TCI-005, TCI-007 |
| 2 | Driven by `inferRecallTargetPaths` (not one-off) | TCI-001, TCI-008 |
| 3 | Run Trace `target_content_*` telemetry | INTERFACE + scorecard exports |
| 4 | WSP_97 excerpt on task match | TCI-006, TCI-007 |
| 5 | Workspace-confined reads; deny traversal/secrets paths | TCI-003, TCI-004 |
| 6 | Version 0.3.22 | package.json + EXTENSION_VERSION |
| 7 | Contract tests + fixtures | `verify_extension_contract.js` |

## Test plan

```powershell
node --check extensions/foundups_advisory_workers/extension.js
node extensions/foundups_advisory_workers/tests/verify_extension_contract.js
git diff --check -- extensions/foundups_advisory_workers
```

## Post-land (012 only)

1. Build/install `foundups-fusion-worker-0.3.22.vsix` + Reload Window
2. Rerun EXT-ACC-001; expect Run Trace:
   - `provider_reasoning_note: Report-only in v0.3.22`
   - `target_recall_ok: true`
   - `target_content_included: true`
   - `target_content_chars: <nonzero>`

## Status

**VERIFIED_READY** — draft only; no merge without sovereign token.

## Out of scope

- HoloIndex ranking (#882 done)
- Output schema repair hardening
- VSIX committed to repo
- Lane B / WRE / OpenRouter routing changes