### PR TITLE
feat(extension): REGULAR tier always attaches wsp_holo HoloIndex grounding (0.3.23)

### DIFF
--- a/.prompt_reddog_always_holoindex_grounding_phase1.md
+++ b/.prompt_reddog_always_holoindex_grounding_phase1.md
@@ -1,0 +1,374 @@
+AUTHOR - REDDOG_ALWAYS_HOLOINDEX_GROUNDING_PHASE1
+
+Operate in WSP_00. Apply WSP_97 CoT/CoR before any edit.
+
+PREREQUISITE GATE:
+
+- **#883 LANDED on `main`** (content inclusion + ADDENDUM F redaction-safe snippets, v0.3.22).
+- **Branch from `main` after #883 merge** (see ADDENDUM D). Do not branch from pre-#883 main.
+- Do **not** widen #883. This is the **next external-lane P0 slice** after #883 lands.
+- **Do not** implement `HOLOINDEX_SKILLZ_MANIFEST_PHASE1` in this slice (P1, separate).
+
+LANE LOCK:
+
+External 012-facing Foundups(R)Agent auto-router + bounded-context lane only.
+Do NOT touch Lane B / WRE / Sakana / OpenClaw execution dispatch.
+Do NOT register HoloIndex as a Skillz manifest in this slice.
+
+---
+
+INVARIANT (012 directive)
+
+```text
+RedDog should always ground with proof.
+Never assume.
+HoloIndex first.
+```
+
+**Current behavior (OBSERVED - must change):**
+
+```text
+REGULAR -> openrouter_single + context none
+HIGH    -> foundups_fusion + wsp_holo_skillz
+ULTRA   -> foundups_fusion + wsp_holo_git_skillz
+```
+
+REGULAR can answer without HoloIndex grounding. That was originally for cheap smoke tests but conflicts with the invariant above.
+
+**Target behavior (REQUIRED):**
+
+```text
+REGULAR -> openrouter_single + wsp_holo
+HIGH    -> foundups_fusion + wsp_holo_skillz
+ULTRA   -> foundups_fusion + wsp_holo_git_skillz
+```
+
+REGULAR stays cheap: single-model GLM principal, no Fusion panel, no Skillz, no git diff.
+REGULAR still runs local HoloIndex bundle-json (or honest offline fallback) and reports scorecard evidence.
+
+**HoloIndex is NOT a Skillz today (OBSERVED):**
+
+```text
+python -B holo_index.py --bundle-json --search ...
+```
+
+Direct Python CLI from `extension.js` (`holoIndexOutput`). Not registered in Skillz/Wardrobe/Rolodex manifest.
+P1 follow-up: `HOLOINDEX_SKILLZ_MANIFEST_PHASE1` for formal WRE/OpenClaw discovery.
+
+---
+
+BASELINE EVIDENCE
+
+```yaml
+routing_gap:
+  function: resolveAutoContextMode
+  file: extensions/foundups_advisory_workers/extension.js
+  current_regular: none
+  required_regular: wsp_holo
+  contract_test: verify_extension_contract.js line ~213 asserts REGULAR -> none (must flip)
+
+mode_selection_copy:
+  modeSelectionReasoning currently says REGULAR "avoids panel latency/cost"
+  must not imply "no repo context" after this slice
+
+acceptance_baseline:
+  EXT-ACC-008 run A uses HIGH + wsp_holo_skillz
+  REGULAR smoke prompts (smoke_tester) currently expect context none
+  after slice: REGULAR smoke must show holoindex_status in Run Trace
+
+docs_drift:
+  README.md REGULAR row says "no repo context" (fix ASCII mojibake if present)
+  INTERFACE.md resolveAutoContextMode table says "none / WSP+Holo+Skillz / ..."
+  REDDOG_EXTERNAL_ACCEPTANCE_BASELINE_PHASE1.md context enum includes none for REGULAR paths
+```
+
+---
+
+PURPOSE
+
+Ensure **every** RedDog auto-routed run attaches HoloIndex-grounded bounded context at minimum `wsp_holo`, so Copy MD Run Trace always carries HoloIndex scorecard fields and models cannot silently assume repo state.
+
+After this slice lands:
+
+1. 012 runs one **REGULAR-tier smoke** (smoke_tester work focus) and confirms HoloIndex scorecard in Run Trace.
+2. Re-run **EXT-ACC-008 run A** pattern at REGULAR tier if useful; do not schedule full 15-pack replacement pass unless architect directs.
+
+---
+
+HARD ACCEPTANCE CHECKS (must pass in PR)
+
+1. **REGULAR auto context = wsp_holo:**
+   `resolveAutoContextMode({ tier: 'REGULAR' }, 'auto')` returns `wsp_holo` (not `none`).
+
+2. **HIGH / ULTRA unchanged:**
+   HIGH -> `wsp_holo_skillz`; ULTRA -> `wsp_holo_git_skillz`.
+
+3. **REGULAR mode unchanged:**
+   `resolveModelMode({ tier: 'REGULAR' }, 'auto', 'smoke_tester')` still returns `openrouter_single`.
+
+4. **buildBoundedRepoContext('wsp_holo', taskText)** includes:
+   - `### HoloIndex recall` section
+   - HoloIndex scorecard fields in returned `holoindex_scorecard`
+   - WSP operating contract (existing)
+
+5. **Copy MD Run Trace for REGULAR run** includes:
+   - `context mode: wsp_holo`
+   - `holoindex_status: ...` (not absent)
+   - `code_hits_count: ...` when bundle-json succeeds
+
+6. **HoloIndex failure is explicit, not silent:**
+   When bundle-json fails and offline fallback runs, Run Trace shows `holoindex_status: offline_fallback` or `parse_error` / `unknown` - never implies retrieval succeeded without evidence.
+   Model-facing quality string must say NEEDS_VERIFICATION when protocol coverage is uncertain (existing `holoIndexOutput` quality strings - verify, do not weaken).
+
+7. **modeSelectionReasoning** updated:
+   REGULAR path must cite `context=wsp_holo` and state HoloIndex grounding (not "no repo context").
+
+8. **Version bump:** `0.3.22` -> **`0.3.23`** (install hygiene).
+
+9. **Contract tests (test-first):**
+   - Flip REGULAR context assertion in `verify_extension_contract.js`
+   - Add test: REGULAR + `buildBoundedRepoContext` includes HoloIndex section
+   - Add TestModLog registry rows (THG-001..); extend `tests/fixtures.js` if needed
+   - No OpenRouter calls in tests
+
+10. **Docs:** README, INTERFACE, ROADMAP, ModLog, tests/README.md, tests/TestModLog.md updated in same change.
+
+Regression: **do not** remove target content inclusion (#883) or ADDENDUM F sanitization behavior.
+
+---
+
+ADDENDUM A - ASCII / MOJIBAKE CLEAN
+
+Clean touched docs to ASCII-safe text before commit.
+Run contract tests + `git diff --check` on touched paths.
+
+---
+
+ADDENDUM B - TEST-FIRST EXECUTION (0102)
+
+Do not wait for 012 Cursor UI to prove routing correctness.
+
+Required deterministic tests:
+
+1. `resolveAutoContextMode(regularClassification, 'auto') === 'wsp_holo'`
+
+2. `resolveAutoContextMode(highClassification, 'auto') === 'wsp_holo_skillz'` (unchanged)
+
+3. `resolveAutoContextMode(ultraClassification, 'auto') === 'wsp_holo_git_skillz'` (unchanged)
+
+4. `buildBoundedRepoContext('wsp_holo', fixtures.REGULAR_SMOKE_PROMPT)` includes `### HoloIndex recall`
+
+5. `extractHoloIndexScorecard('wsp_holo', meta)` returns non-null when holo meta present
+
+6. `modeSelectionReasoning(regular, 'regular', 'openrouter_single', 'wsp_holo')` mentions `wsp_holo`
+
+Reuse `tests/fixtures.js`; add `REGULAR_SMOKE_PROMPT` constant if missing.
+
+Validation:
+
+```powershell
+node --check extensions/foundups_advisory_workers/extension.js
+node extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+git diff --check -- extensions/foundups_advisory_workers
+```
+
+---
+
+ADDENDUM C - OUT OF SCOPE (explicit)
+
+- HoloIndex Skillz manifest registration (`HOLOINDEX_SKILLZ_MANIFEST_PHASE1` - P1)
+- Target snippet content inclusion changes (#883 - already landed)
+- Output schema repair / repair-path redaction (`REDDOG_OUTPUT_SCHEMA_REPAIR_HARDENING_PHASE1`)
+- HoloIndex ranking/index-gap fixes (#882 - landed)
+- Changing HIGH/ULTRA tier boundaries or Fusion panel composition
+- Weakening `fusion_redaction_gate.py`
+- Lane B / WRE execution dispatch
+- Full 15-prompt acceptance replacement pass
+
+---
+
+ADDENDUM D - POST-#883 BASE ONLY
+
+Start from `main` after #883 is landed. Do not branch from pre-#883 main.
+
+Preserve all v0.3.22 target-content inclusion behavior:
+
+```text
+target_content_included
+target_content_paths
+target_content_chars
+target_content_sanitized
+target_content_sanitized_categories
+TCI-001..TCI-010 contract tests (must still pass)
+```
+
+This slice **only** changes default REGULAR grounding from `none` to `wsp_holo` and updates docs/tests/trace expectations.
+
+If target-content tests regress, **stop** and return REQUEST_CHANGES.
+
+Does **not** fix (separate slices):
+
+```text
+output_validation repair
+made_network_call unknown telemetry
+model-output mojibake in Copy MD
+target_recall_ok HoloIndex ranking instability
+```
+
+---
+
+READ BEFORE EDITING (WSP_87)
+
+- extensions/foundups_advisory_workers/extension.js
+  (`resolveAutoContextMode`, `resolveModelMode`, `modeSelectionReasoning`, `buildBoundedRepoContext`, `holoIndexOutput`, `buildRunTraceSection`, `extractHoloIndexScorecard`)
+- extensions/foundups_advisory_workers/tests/verify_extension_contract.js (~211-214)
+- extensions/foundups_advisory_workers/tests/fixtures.js
+- extensions/foundups_advisory_workers/docs/REDDOG_EXTERNAL_ACCEPTANCE_BASELINE_PHASE1.md (EXT-ACC-008)
+- extensions/foundups_advisory_workers/README.md (routing table)
+- extensions/foundups_advisory_workers/INTERFACE.md
+
+---
+
+ADDENDUM E - BASE / VERSION PREFLIGHT
+
+Before editing:
+
+1. `git fetch origin main`
+2. Confirm #883 is merged on main:
+   `gh pr view 883 --json state,mergedAt,mergeCommit`
+3. Confirm branch starts from current origin/main:
+   `git rev-parse origin/main`
+   `git switch -c feat/reddog-always-holoindex-grounding-phase1 origin/main`
+
+Pre-edit source must show v0.3.22 and #883 behavior:
+
+- `EXTENSION_VERSION = 0.3.22`
+- `target_content_included` code present
+- `target_content_sanitized` code present
+- TCI-001..TCI-010 tests present
+
+If any are missing, **STOP** and return `DEFER: #883_NOT_ON_BASE`.
+
+---
+
+IMPLEMENTATION HINTS (verify, do not blindly copy)
+
+Single-line change core in `resolveAutoContextMode`:
+
+```javascript
+if (tier === 'REGULAR') {
+  return 'wsp_holo';  // was 'none'
+}
+```
+
+Confirm `buildBoundedRepoContext('wsp_holo', ...)` already calls `holoIndexOutput` (it should - same branch as wsp_holo_skillz minus Skillz/git).
+
+Optional: add Run Trace note when `context mode === wsp_holo` that Skillz/git are intentionally omitted for REGULAR cost control.
+
+---
+
+BRANCH / PR
+
+Branch: `feat/reddog-always-holoindex-grounding-phase1`
+Title: feat(extension): REGULAR tier always attaches wsp_holo HoloIndex grounding
+Draft PR only. Stop at VERIFIED_READY. Do not merge without sovereign token.
+
+PR body must include:
+
+- Before/after routing table
+- Hard checks 1-10 evidence
+- Contract test output
+- 012 REGULAR smoke steps (post-install 0.3.23)
+- Explicit note: HoloIndex Skillz manifest deferred to P1
+
+WSP_97 rows (ModLog + PR):
+
+- REGULAR_NO_CONTEXT_VIOLATES_INVARIANT
+- REGULAR_WSP_HOLO_GROUNDING_ADDED
+- HIGH_ULTRA_ROUTING_UNCHANGED
+- HOLOINDEX_SCORECARD_ALWAYS_ON_AUTO_ROUTE
+- HOLOINDEX_FAILURE_EXPLICIT_NOT_SILENT
+- HOLOINDEX_NOT_SKILLZ_YET
+- SKILLZ_MANIFEST_OUT_OF_SCOPE
+- LANE_B_EXCLUDED
+- TARGET_CONTENT_INCLUSION_UNCHANGED
+
+WSP_15:
+
+| C | I | D | Impact | MPS | P |
+|---:|---:|---:|---:|---:|---|
+| 2 | 5 | 1 | 5 | 13 | **P0** |
+
+---
+
+ARCHITECT REVIEW STATUS
+
+```text
+APPROVE_WORKER_DISPATCH after #883 lands on main (Addenda A-F).
+Do not implement until #883 is merged and worker branches from post-#883 main.
+```
+
+SEQUENCE (012):
+
+```text
+1. Land #883 (v0.3.22) - target content + sanitized snippets
+2. REDDOG_ALWAYS_HOLOINDEX_GROUNDING_PHASE1 (v0.3.23) - this prompt
+3. Repair/schema/telemetry polish (output validation, made_network_call, mojibake)
+```
+
+---
+
+RETURN (worker -> architect review)
+
+1. Files changed
+2. Before/after routing table (OBSERVED vs target)
+3. Hard checks 1-10 evidence
+4. Contract test output
+5. PR URL
+6. Residual NEEDS_VERIFICATION
+7. Ready for 012 REGULAR smoke: yes/no
+
+ADDENDUM F - WORKER RETURN MUST INCLUDE 012 RUN CARD
+
+Also return the exact 012 smoke card:
+
+```text
+Version expected: Foundups(R)Agent Build 0.3.23
+Role: Smoke Tester
+Work focus:
+Reply with exactly: regular mode works
+
+Expected Run Trace:
+- WSP_15 tier: REGULAR
+- mode: openrouter_single
+- context mode: wsp_holo
+- holoindex_status: present
+- code_hits_count: present when bundle-json succeeds
+- mode selection reason mentions context=wsp_holo
+```
+
+---
+
+012 REGULAR SMOKE (after VERIFIED_READY + VSIX install)
+
+**Role:** Smoke Tester (or any prompt that classifies REGULAR)
+
+**Work focus (example):**
+
+```text
+Reply with exactly: regular mode works
+```
+
+**Expected Run Trace:**
+
+```text
+Build: 0.3.23
+WSP_15 tier: REGULAR
+mode: openrouter_single
+context mode: wsp_holo
+holoindex_status: bundle_json_ok|offline_fallback|parse_error (never absent)
+code_hits_count: ...
+mode selection reason: ... context=wsp_holo ...
+```
+
+Pass when HoloIndex scorecard is present and model did not answer as if repo state were unknowable without stating NEEDS_VERIFICATION when HoloIndex failed.

--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -164,7 +164,7 @@ Internal contract layer. Advisory-only. No new authority.
 | Function | Purpose |
 |---|---|
 | `classifyTaskForRedDog(prompt, contextMode, workerType)` | WSP_15-style effort/risk classification |
-| `resolveAutoContextMode(classification, selectedContextMode)` | Maps Auto context to none / WSP+Holo+Skillz / WSP+Holo+git+Skillz |
+| `resolveAutoContextMode(classification, selectedContextMode)` | Maps Auto context to `wsp_holo` (REGULAR) / WSP+Holo+Skillz (HIGH) / WSP+Holo+git+Skillz (ULTRA) |
 | `resolveAutoEffort(classification, selectedEffort)` | Maps Auto -> regular/high/ultra |
 | `resolveModelMode(classification, selectedMode, workerType)` | RedDog WSP work defaults to auditable manual panel |
 | `validateRedDogOutput(markdown)` | Required schema section check |
@@ -194,7 +194,7 @@ Model and context routing:
 - Principal/synthesis default: `z-ai/glm-5.2`.
 - Adversarial critic default: `deepseek/deepseek-v4-pro`.
 - Implementation critic default: `moonshotai/kimi-k2.7-code`.
-- REGULAR smoke/simple prompts auto-route to `openrouter_single` with the GLM principal and no repo context.
+- REGULAR smoke/simple prompts auto-route to `openrouter_single` with the GLM principal and `wsp_holo` HoloIndex grounding (no Fusion panel, Skillz, or git).
 - Context is not a 012-facing selector; it is resolved from WSP_15 tier.
 - Skillz/Wardrobe/Rolodex/OpenClaw/Hermes discovery is context only. RedDog may recommend a governed handoff, but this extension cannot execute it.
 - `openrouter_fusion_alias` remains implemented for future explicit use, but is not the RedDog default because critic traces are not exposed.

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -1,5 +1,15 @@
 # Foundups®Agent ModLog
 
+## 2026-06-14 - REDDOG_ALWAYS_HOLOINDEX_GROUNDING_PHASE1 (v0.3.23)
+
+- REGULAR auto context: `none` -> `wsp_holo` (HoloIndex bundle-json; no Skillz/git/Fusion panel).
+- Updated `modeSelectionReasoning` for REGULAR: cites HoloIndex-grounded wsp_holo.
+- Contract tests THG-001..006; fixtures `REGULAR_SMOKE_PROMPT`.
+- Preserved #883 target content + TCI-001..TCI-010 + ADDENDUM F gate tests.
+- Version bump 0.3.22 -> 0.3.23.
+
+WSP: WSP_00, WSP_15, WSP_87, WSP_97, WSP_22.
+
 ## 2026-06-14 - ADDENDUM F redaction-safe target snippets (v0.3.22)
 
 - Raw `extension.js` snippets tripped Fusion BLOCK categories (`governance_instruction`, `private_reasoning`, etc.) before OpenRouter.

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.22
+Version: 0.3.23
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 
@@ -99,7 +99,7 @@ The webview follows the VS Code terminal/chat shape:
 
 - Worker: RedDog Architect, WSP Gate Critic, Repair Planner, Smoke Test.
 - Routing: automatic via WSP_15-style task classification; 012 no longer picks Mode/Effort/Context for normal use.
-- Context: automatic. ULTRA tasks attach WSP + HoloIndex + active editor + git diff + Skillz/Wardrobe/Rolodex discovery; HIGH tasks attach WSP + HoloIndex + active editor + Skillz/Wardrobe/Rolodex discovery; REGULAR smoke avoids repo context.
+- Context: automatic. ULTRA tasks attach WSP + HoloIndex + active editor + git diff + Skillz/Wardrobe/Rolodex discovery; HIGH tasks attach WSP + HoloIndex + active editor + Skillz/Wardrobe/Rolodex discovery; REGULAR attaches WSP + HoloIndex only (`wsp_holo`, no Skillz/git).
 - Tests: regular smoke, Fusion smoke, WSP_97 repo review, RedDog architect review.
 
 For WSP/security/runtime/architecture work, RedDog auto-routes to `foundups_fusion` because it preserves a review packet with principal, critic, and synthesis excerpts. Regular smoke/simple prompts auto-route to a single GLM principal call. OpenRouter Fusion alias remains implemented in the bridge for explicit future use, but is not a 012-facing default control because individual critic traces are not exposed by the API response.
@@ -122,9 +122,9 @@ Output is prefixed with a visible **RedDog Routing** block (tier, effort, mode, 
 | DIGESTS_NOT_RAW_CONTEXT | OBSERVED |
 | ROUTING_UNCHANGED_FROM_0_3_14 | OBSERVED |
 | Mode/Effort/Context not 012-facing dropdowns | OBSERVED |
-| REGULAR 竊・`openrouter_single`, no repo context | OBSERVED |
-| HIGH 竊・`foundups_fusion` + WSP/Holo/Skillz context | OBSERVED |
-| ULTRA 竊・`foundups_fusion` + WSP/Holo/git/Skillz context | OBSERVED |
+| REGULAR -> `openrouter_single` + `wsp_holo` (HoloIndex only; no Skillz/git) | OBSERVED |
+| HIGH -> `foundups_fusion` + WSP/Holo/Skillz context | OBSERVED |
+| ULTRA -> `foundups_fusion` + WSP/Holo/git/Skillz context | OBSERVED |
 | Skillz/Rolodex discovery for operational prompts | OBSERVED |
 | Filesystem fallback when git spawn fails | OBSERVED |
 | RedDog Routing block in output | OBSERVED |

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -121,9 +121,16 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 - Add regression retrieval tests so extension bridge code ranks above adjacent WRE routers.
 - **Status:** **LANDED** #882 (`99d0e35c2`) — ranking + target recall telemetry only; not source-content inclusion.
 
+### REDDOG_ALWAYS_HOLOINDEX_GROUNDING_PHASE1
+
+- **Status:** IN PROGRESS (v0.3.23) - REGULAR auto context `none` -> `wsp_holo`.
+- Every auto-routed tier attaches HoloIndex bundle-json at minimum; REGULAR stays single-model without Skillz/git.
+- Prerequisite: #883 landed (target content + sanitization on v0.3.22).
+- Does not fix output validation, made_network_call telemetry, or mojibake (separate slices).
+
 ### REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1
 
-- **Status:** IN PROGRESS (v0.3.22) — test-first ADDENDUM E; 0102-runnable without 012 Cursor UI.
+- **Status:** VERIFIED_READY on #883 (v0.3.22) - stacked base for grounding slice.
 - Inject target file **content/snippets** into bounded bridge context when HoloIndex ranks the path but omits source body.
 - Trigger: EXT-ACC-001 criterion #2 fail with model egress (path hit ~7.4%, no source body) — **OBSERVED**.
 - Run Trace: `target_content_included`, `target_content_paths`, `target_content_chars`, `target_content_omitted_reason`, `target_content_truncated`.

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.22';
+const EXTENSION_VERSION = '0.3.23';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
 const TARGET_READ_BLOCKED_EXTENSIONS = ['.vsix'];
@@ -303,7 +303,7 @@ function resolveProviderReasoningReport(resolvedEffort) {
   return {
     provider_reasoning_requested: requestedMap[effort] || 'medium',
     provider_reasoning_applied: 'unknown',
-    provider_reasoning_note: 'Report-only in v0.3.22; bridge does not confirm provider reasoning application.'
+    provider_reasoning_note: 'Report-only in v0.3.23; bridge does not confirm provider reasoning application.'
   };
 }
 
@@ -784,7 +784,7 @@ function resolveAutoContextMode(classification, selectedContextMode) {
   }
   const tier = classification && classification.tier ? classification.tier : 'HIGH';
   if (tier === 'REGULAR') {
-    return 'none';
+    return 'wsp_holo';
   }
   if (tier === 'ULTRA') {
     return 'wsp_holo_git_skillz';
@@ -857,7 +857,10 @@ function validateRedDogOutput(markdown, options) {
 function modeSelectionReasoning(classification, resolvedEffort, resolvedMode, resolvedContextMode) {
   const tier = classification && classification.tier ? classification.tier : 'HIGH';
   if (resolvedMode === 'openrouter_single') {
-    return 'Single-model GLM principal: REGULAR-tier or smoke-classified work; avoids panel latency/cost; context=' + resolvedContextMode + '.';
+    if (tier === 'REGULAR') {
+      return 'Single-model GLM principal: REGULAR-tier work; HoloIndex-grounded wsp_holo (no Fusion panel, Skillz, or git); context=' + resolvedContextMode + '.';
+    }
+    return 'Single-model GLM principal: smoke-classified work; avoids panel latency/cost; context=' + resolvedContextMode + '.';
   }
   if (resolvedMode === 'openrouter_fusion_alias') {
     return 'Explicit Fusion alias path: black-box synthesis; critic transcripts not exposed.';

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups®Agent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.22",
+    "version":  "0.3.23",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/README.md
+++ b/extensions/foundups_advisory_workers/tests/README.md
@@ -31,13 +31,14 @@ python -m pytest holo_index/tests/test_reddog_extension_bundle_recall.py -q
 
 ## TEST_REGISTRY
 
-See `TestModLog.md` for TCI-001 through TCI-010. Extend registry rows; do not duplicate probes.
+See `TestModLog.md` for TCI-001 through TCI-010 and THG-001 through THG-006.
 
 ## Expected behavior
 
 - `inferRecallTargetPaths(EXT_ACC_001_PROMPT)` includes `extension.js`.
-- `buildBoundedRepoContext('wsp_holo_skillz', EXT_ACC_001_PROMPT)` includes target recall content, WSP_97 excerpt, and `target_content_included: true` in scorecard.
+- `resolveAutoContextMode(EXT_ACC_001_PROMPT tier HIGH)` unchanged; REGULAR -> `wsp_holo`.
 - ADDENDUM F: sanitized snippets pass Python `evaluate_redaction_gate` (TCI-009/TCI-010).
+- THG-001..006: REGULAR HoloIndex grounding (see TestModLog registry).
 - Path safety rejects absolute, traversal, `.env`, `.git`, `node_modules`, `.vsix`.
 
 ## Integration requirements

--- a/extensions/foundups_advisory_workers/tests/TestModLog.md
+++ b/extensions/foundups_advisory_workers/tests/TestModLog.md
@@ -1,5 +1,26 @@
 # Foundups®Agent TestModLog
 
+## 2026-06-14 - REDDOG_ALWAYS_HOLOINDEX_GROUNDING_PHASE1 (THG-001..006)
+
+| ID | Asserts |
+| --- | --- |
+| THG-001 | `resolveAutoContextMode(regular, 'auto') === 'wsp_holo'` |
+| THG-002 | HIGH -> `wsp_holo_skillz` (unchanged) |
+| THG-003 | ULTRA -> `wsp_holo_git_skillz` (unchanged) |
+| THG-004 | `buildBoundedRepoContext('wsp_holo', REGULAR_SMOKE_PROMPT)` includes HoloIndex recall |
+| THG-005 | `wsp_holo` returns non-null `holoindex_scorecard` |
+| THG-006 | `modeSelectionReasoning` cites HoloIndex-grounded `wsp_holo` for REGULAR |
+
+Regression: TCI-001..TCI-010 (#883) must still pass.
+
+Commands:
+
+```powershell
+node --check extensions/foundups_advisory_workers/extension.js
+node extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+git diff --check -- extensions/foundups_advisory_workers
+```
+
 ## 2026-06-14 - REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1 (ADDENDUM E)
 
 **Reuse:** `tests/fixtures.js` + registry below. Do not duplicate EXT-ACC-001 prompt strings in new tests.

--- a/extensions/foundups_advisory_workers/tests/fixtures.js
+++ b/extensions/foundups_advisory_workers/tests/fixtures.js
@@ -8,6 +8,8 @@ const EXT_ACC_001_TARGET_PATH = 'extensions/foundups_advisory_workers/extension.
 
 const BUILD_COPY_MARKDOWN_PROMPT = 'Review buildCopyMarkdown in extensions/foundups_advisory_workers/extension.js for WSP_97 compliance.';
 
+const REGULAR_SMOKE_PROMPT = 'Reply with exactly: regular mode works';
+
 const TARGET_READ_DENIED_PATHS = [
   ['C:/Windows/System32/drivers/etc/hosts', 'absolute path'],
   ['../outside.txt', 'traversal'],
@@ -21,5 +23,6 @@ module.exports = {
   EXT_ACC_001_PROMPT,
   EXT_ACC_001_TARGET_PATH,
   BUILD_COPY_MARKDOWN_PROMPT,
+  REGULAR_SMOKE_PROMPT,
   TARGET_READ_DENIED_PATHS
 };

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -52,8 +52,8 @@ function extractTargetRecallSection(contextText) {
   return next === -1 ? tail : tail.slice(0, next);
 }
 
-assert.strictEqual(pkg.version, '0.3.22', 'package version must be 0.3.22');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.22'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.23', 'package version must be 0.3.23');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.23'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups®Agent', 'display name must be Foundups®Agent');
 includes(JSON.stringify(pkg), 'Foundups®Agent: Open', 'command title must use Foundups®Agent');
@@ -70,7 +70,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.22', 'README version mismatch');
+includes(readme, 'Version: 0.3.23', 'README version mismatch');
 includes(extensionJs, 'function resolvePythonInterpreter', 'python resolver missing');
 includes(extensionJs, 'function applyBridgeContextBudget', 'context budget missing');
 includes(extensionJs, 'function killBridgeChild', 'orphan cleanup missing');
@@ -210,7 +210,7 @@ assert.strictEqual(
 assert.strictEqual(orchestrator.resolveAutoEffort(ultra, 'auto'), 'ultra', 'auto effort must map ULTRA classification to ultra');
 assert.strictEqual(orchestrator.resolveAutoContextMode(ultra, 'auto'), 'wsp_holo_git_skillz', 'ULTRA must attach WSP/Holo/git/Skillz context');
 assert.strictEqual(orchestrator.resolveAutoContextMode(wsp, 'auto'), 'wsp_holo_skillz', 'HIGH/WSP must attach WSP/Holo/Skillz context');
-assert.strictEqual(orchestrator.resolveAutoContextMode(regular, 'auto'), 'none', 'REGULAR smoke must avoid repo context');
+assert.strictEqual(orchestrator.resolveAutoContextMode(regular, 'auto'), 'wsp_holo', 'REGULAR must attach wsp_holo HoloIndex grounding');
 assert.strictEqual(orchestrator.resolveAutoEffort(regular, 'auto'), 'regular', 'auto effort must map REGULAR classification to regular');
 
 const reasoning = orchestrator.modeSelectionReasoning(wsp, 'high', 'foundups_fusion', 'wsp_holo_skillz');
@@ -557,7 +557,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.22'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.23'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -571,7 +571,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.22'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.23'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -583,7 +583,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.22'", 'bounded context must include extension.js source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.23'", 'bounded context must include extension.js source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');
@@ -607,5 +607,13 @@ assertFusionRedactionGatePasses(targetRecallSection, 'target recall section must
 assertFusionRedactionGatePasses(boundedContext.text, 'EXT-ACC-001 bounded context must pass fusion redaction gate');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_sanitized, true, 'scorecard target_content_sanitized must be true when replacements occurred');
 assert(boundedContext.holoindex_scorecard.target_content_sanitized_categories.length > 0, 'scorecard must list sanitized categories');
+
+// ADDENDUM B - REDDOG_ALWAYS_HOLOINDEX_GROUNDING_PHASE1 (THG-001..THG-006)
+const regularHoloContext = orchestrator.buildBoundedRepoContext('wsp_holo', fixtures.REGULAR_SMOKE_PROMPT);
+includes(regularHoloContext.text, '### HoloIndex recall', 'THG-004: wsp_holo must include HoloIndex recall section');
+assert(regularHoloContext.holoindex_scorecard !== null, 'THG-005: wsp_holo must return holoindex_scorecard');
+const regularReasoning = orchestrator.modeSelectionReasoning(regular, 'regular', 'openrouter_single', 'wsp_holo');
+includes(regularReasoning, 'wsp_holo', 'THG-006: REGULAR mode selection must cite wsp_holo');
+includes(regularReasoning, 'HoloIndex-grounded', 'THG-006: REGULAR mode selection must state HoloIndex grounding');
 
 console.log('Foundups®Agent extension contract checks passed.');


### PR DESCRIPTION
## Summary
- REGULAR tier routes to `context mode: wsp_holo` instead of `none` (still `openrouter_single`; no Fusion/Skillz/git).
- Adds THG-001..006 contract tests and worker dispatch prompt.
- Rebased onto `main` after #883 land (`acfbecd57`).

## Validation
- `node --check extension.js` PASS
- `verify_extension_contract.js` PASS (TCI-001..010 + THG-001..006)
- `git diff --check` PASS
- VSIX built: `foundups-fusion-worker-0.3.23.vsix`

## Test plan
- [ ] 012 REGULAR smoke (Addendum F): Role Smoke Tester, prompt `Reply with exactly: regular mode works`
- [ ] Run Trace: `WSP_15 tier: REGULAR`, `context mode: wsp_holo`, `holoindex_status` present

## Depends on
- #883 (merged)
