### PR TITLE
fix(extension): normalize RedDog bridge context unicode before redaction

### DIFF
--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -128,6 +128,15 @@ Run Trace HoloIndex scorecard fields (v0.3.22+):
 | `target_content_sanitized` | Block-triggering literals replaced before egress | OBSERVED |
 | `target_content_sanitized_categories` | Fusion BLOCK categories sanitized (metadata only) | OBSERVED |
 
+Run Trace Unicode normalization fields (v0.3.24+):
+
+| Field | Meaning | WSP_97 |
+|---|---|---|
+| `unicode_normalization_applied` | Bridge payload required surrogate replacement before gate | OBSERVED |
+| `unicode_replacements_count` | Count of isolated surrogate replacements (counts only) | OBSERVED |
+| `unicode_normalization_sources` | Pipe-separated: `prompt`, `context`, `repair_prompt` | OBSERVED |
+| `unicode_normalization_form` | `NFC` when normalization ran; `none` when skipped | OBSERVED |
+
 `evaluateTargetRecall(taskText, bundleOutput)` and `inferRecallTargetPaths(taskText)` implement target-specific recall inference from bundle `task_retrieval.code_hits`.
 
 Target content egress (v0.3.22+): `buildTargetRecallContentSection(root, taskText, maxChars)` reads workspace-confined snippets for inferred recall targets after HoloIndex path ranking. Snippets pass through `sanitizeTargetSnippetForRedaction()` before inclusion (ADDENDUM F); placeholders use neutral `[SANITIZED_BLOCK:NN]` tokens so category names do not re-trigger the Fusion gate. Telemetry reflects the **final** bounded context string assembled by `buildBoundedRepoContext` (before the 42000-char slice). `buildWsp97ProtocolExcerpt(root, maxChars)` adds a bounded WSP_97 protocol excerpt when the task mentions WSP_97 or truth labels.

--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -128,7 +128,7 @@ Run Trace HoloIndex scorecard fields (v0.3.22+):
 | `target_content_sanitized` | Block-triggering literals replaced before egress | OBSERVED |
 | `target_content_sanitized_categories` | Fusion BLOCK categories sanitized (metadata only) | OBSERVED |
 
-Run Trace Unicode normalization fields (v0.3.24+):
+Run Trace Unicode normalization fields (v0.3.24+) and bridge UTF-8 invariant (v0.3.25+):
 
 | Field | Meaning | WSP_97 |
 |---|---|---|
@@ -136,6 +136,8 @@ Run Trace Unicode normalization fields (v0.3.24+):
 | `unicode_replacements_count` | Count of isolated surrogate replacements (counts only) | OBSERVED |
 | `unicode_normalization_sources` | Pipe-separated: `prompt`, `context`, `repair_prompt` | OBSERVED |
 | `unicode_normalization_form` | `NFC` when normalization ran; `none` when skipped | OBSERVED |
+
+Bridge child env (v0.3.25+): `PYTHONIOENCODING=utf-8`, `PYTHONUTF8=1`. Python bridge reads stdin via `sys.stdin.buffer` UTF-8 decode so valid Unicode (e.g. U+2014 em dash) is not mis-decoded on Windows before the redaction gate.
 
 `evaluateTargetRecall(taskText, bundleOutput)` and `inferRecallTargetPaths(taskText)` implement target-specific recall inference from bundle `task_retrieval.code_hits`.
 

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -1,5 +1,16 @@
 # Foundups®Agent ModLog
 
+## 2026-06-14 - REDDOG_CONTEXT_UNICODE_NORMALIZATION_PHASE1 (v0.3.24)
+
+- Added `normalizeBridgeTextForUnicode()` to replace isolated UTF-16 surrogates with `[MALFORMED_SURROGATE]` and apply NFC before bridge/redaction gate.
+- Wired normalization in `callFusion` for WSP task prompt, bounded context, and repair prompt (`repair_prompt` source label).
+- Run Trace / review packet: `unicode_normalization_applied`, `unicode_replacements_count`, `unicode_normalization_sources`, `unicode_normalization_form`.
+- Contract tests UNI-001..UNI-007; fixtures `MALFORMED_UNICODE_CONTEXT`, `BLOCKED_POLICY_CONTEXT`.
+- `fusion_redaction_gate.py` unchanged; policy not weakened.
+- Version bump 0.3.23 -> 0.3.24.
+
+WSP: WSP_00, WSP_15, WSP_97, WSP_22, WSP_84.
+
 ## 2026-06-14 - REDDOG_ALWAYS_HOLOINDEX_GROUNDING_PHASE1 (v0.3.23)
 
 - REGULAR auto context: `none` -> `wsp_holo` (HoloIndex bundle-json; no Skillz/git/Fusion panel).

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -1,5 +1,16 @@
 # Foundups®Agent ModLog
 
+## 2026-06-14 - ADDENDUM B bridge UTF-8 stdin invariant (v0.3.25)
+
+- **Problem:** Valid U+2014 em dash in HoloIndex context passed JS normalization but Windows Python text stdin mis-decoded UTF-8 to surrogate `\udc94`, causing `redactor_error` at digest.
+- **`scripts/advisory_model_once.py`:** `_read_stdin_json()` reads `sys.stdin.buffer` as UTF-8 (`errors="replace"`).
+- **`extension.js`:** `buildBridgePythonEnv()` sets `PYTHONIOENCODING=utf-8`, `PYTHONUTF8=1` on bridge child.
+- Tests UNI-008..UNI-010; Python `test_main_em_dash_utf8_stdin_not_redactor_error`.
+- Prior surrogate normalization (Addendum A / UNI-001..007) unchanged.
+- Version bump 0.3.24 -> 0.3.25.
+
+WSP: WSP_00, WSP_97, WSP_22, WSP_84.
+
 ## 2026-06-14 - REDDOG_CONTEXT_UNICODE_NORMALIZATION_PHASE1 (v0.3.24)
 
 - Added `normalizeBridgeTextForUnicode()` to replace isolated UTF-16 surrogates with `[MALFORMED_SURROGATE]` and apply NFC before bridge/redaction gate.

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.24
+Version: 0.3.25
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.23
+Version: 0.3.24
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -123,10 +123,18 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 
 ### REDDOG_ALWAYS_HOLOINDEX_GROUNDING_PHASE1
 
-- **Status:** IN PROGRESS (v0.3.23) - REGULAR auto context `none` -> `wsp_holo`.
+- **Status:** **LANDED** #885 (`888d0c9cc`) — REGULAR auto context `none` -> `wsp_holo`.
 - Every auto-routed tier attaches HoloIndex bundle-json at minimum; REGULAR stays single-model without Skillz/git.
 - Prerequisite: #883 landed (target content + sanitization on v0.3.22).
 - Does not fix output validation, made_network_call telemetry, or mojibake (separate slices).
+
+### REDDOG_CONTEXT_UNICODE_NORMALIZATION_PHASE1
+
+- **Status:** IN PROGRESS (v0.3.24) — normalize malformed Unicode in bridge payload before redaction gate.
+- Trigger: safe architect prompt blocked with `redactor_error` when HoloIndex context contains lone surrogate (e.g. `\udc94`).
+- Run Trace: `unicode_normalization_applied`, `unicode_replacements_count`, `unicode_normalization_sources`, `unicode_normalization_form`.
+- Out of scope: redaction policy weakening, schema repair, made_network_call telemetry, HoloIndex upstream cleanup (follow-up).
+- Acceptance: synthetic surrogate normalized; gate passes; `blocked_policy` unchanged; TCI + THG regression green.
 
 ### REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1
 

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -130,7 +130,7 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 
 ### REDDOG_CONTEXT_UNICODE_NORMALIZATION_PHASE1
 
-- **Status:** IN PROGRESS (v0.3.24) — normalize malformed Unicode in bridge payload before redaction gate.
+- **Status:** IN PROGRESS (v0.3.25) — JS surrogate normalization + bridge UTF-8 stdin invariant (Addendum B).
 - Trigger: safe architect prompt blocked with `redactor_error` when HoloIndex context contains lone surrogate (e.g. `\udc94`).
 - Run Trace: `unicode_normalization_applied`, `unicode_replacements_count`, `unicode_normalization_sources`, `unicode_normalization_form`.
 - Out of scope: redaction policy weakening, schema repair, made_network_call telemetry, HoloIndex upstream cleanup (follow-up).

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,8 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.23';
+const EXTENSION_VERSION = '0.3.24';
+const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
 const TARGET_READ_BLOCKED_EXTENSIONS = ['.vsix'];
@@ -407,6 +408,90 @@ function formatHoloIndexScorecardLines(scorecard) {
   ];
 }
 
+function normalizeBridgeTextForUnicode(text, sourceLabel) {
+  const source = typeof sourceLabel === 'string' && sourceLabel.length ? sourceLabel : 'unknown';
+  const input = String(text || '');
+  let replacements = 0;
+  let stripped = '';
+  for (let i = 0; i < input.length; i++) {
+    const code = input.charCodeAt(i);
+    if (code >= 0xD800 && code <= 0xDBFF) {
+      if (i + 1 < input.length) {
+        const next = input.charCodeAt(i + 1);
+        if (next >= 0xDC00 && next <= 0xDFFF) {
+          stripped += input[i] + input[i + 1];
+          i += 1;
+          continue;
+        }
+      }
+      stripped += UNICODE_SURROGATE_PLACEHOLDER;
+      replacements += 1;
+    } else if (code >= 0xDC00 && code <= 0xDFFF) {
+      stripped += UNICODE_SURROGATE_PLACEHOLDER;
+      replacements += 1;
+    } else {
+      stripped += input[i];
+    }
+  }
+  let normalized = stripped;
+  let form = 'none';
+  try {
+    normalized = stripped.normalize('NFC');
+    form = 'NFC';
+  } catch (err) {
+    normalized = stripped;
+  }
+  return {
+    text: normalized,
+    unicode_normalization_applied: replacements > 0,
+    unicode_replacements_count: replacements,
+    unicode_normalization_source: source,
+    unicode_normalization_form: form
+  };
+}
+
+function emptyUnicodeNormalizationMeta() {
+  return {
+    unicode_normalization_applied: false,
+    unicode_replacements_count: 0,
+    unicode_normalization_sources: '',
+    unicode_normalization_form: 'none'
+  };
+}
+
+function mergeUnicodeNormalizationMeta(existing, incoming) {
+  const base = existing && typeof existing === 'object' ? existing : emptyUnicodeNormalizationMeta();
+  if (!incoming || typeof incoming !== 'object') {
+    return base;
+  }
+  const sources = new Set(String(base.unicode_normalization_sources || '').split('|').filter(Boolean));
+  if (incoming.unicode_normalization_source) {
+    sources.add(String(incoming.unicode_normalization_source));
+  }
+  if (Array.isArray(incoming.unicode_normalization_sources)) {
+    incoming.unicode_normalization_sources.forEach((item) => {
+      if (item) {
+        sources.add(String(item));
+      }
+    });
+  } else if (typeof incoming.unicode_normalization_sources === 'string' && incoming.unicode_normalization_sources) {
+    incoming.unicode_normalization_sources.split('|').filter(Boolean).forEach((item) => sources.add(item));
+  }
+  const replacementDelta = typeof incoming.unicode_replacements_count === 'number' ? incoming.unicode_replacements_count : 0;
+  const applied = base.unicode_normalization_applied === true
+    || incoming.unicode_normalization_applied === true
+    || replacementDelta > 0;
+  const form = incoming.unicode_normalization_form && incoming.unicode_normalization_form !== 'none'
+    ? incoming.unicode_normalization_form
+    : base.unicode_normalization_form || 'none';
+  return {
+    unicode_normalization_applied: applied,
+    unicode_replacements_count: (base.unicode_replacements_count || 0) + replacementDelta,
+    unicode_normalization_sources: Array.from(sources).sort().join('|'),
+    unicode_normalization_form: form
+  };
+}
+
 function buildRunTraceSection(result, workerType, contextSummary, holoScorecard, resolvedEffort) {
   const rp = result && result.review_packet && typeof result.review_packet === 'object' ? result.review_packet : {};
   const cls = rp.task_classification && typeof rp.task_classification === 'object' ? rp.task_classification : {};
@@ -433,6 +518,10 @@ function buildRunTraceSection(result, workerType, contextSummary, holoScorecard,
     lines.push('- HoloIndex/context summary: ' + sanitizeCopyMdText(String(contextSummary)).slice(0, 500));
   }
   lines.push.apply(lines, formatHoloIndexScorecardLines(holoScorecard || rp.holoindex_scorecard));
+  lines.push('- unicode_normalization_applied: ' + (rp.unicode_normalization_applied === true ? 'true' : rp.unicode_normalization_applied === false ? 'false' : 'unknown'));
+  lines.push('- unicode_replacements_count: ' + (typeof rp.unicode_replacements_count === 'number' ? rp.unicode_replacements_count : 'unknown'));
+  lines.push('- unicode_normalization_sources: ' + (typeof rp.unicode_normalization_sources === 'string' && rp.unicode_normalization_sources.length ? rp.unicode_normalization_sources : '(none)'));
+  lines.push('- unicode_normalization_form: ' + (rp.unicode_normalization_form || 'none'));
   if (result && result.reason === 'redaction_blocked') {
     lines.push('- redaction gate status: BLOCKED_LOCALLY');
     lines.push('- made_network_call: false');
@@ -922,10 +1011,11 @@ function isSubstantiveRedDogWorker(workerType) {
   return worker === 'reddog_architect' || worker === 'wsp_gate_critic' || worker === 'repair_planner';
 }
 
-function attachOrchestratorMetadata(reviewPacket, classification, resolvedEffort, resolvedMode, validationState, resolvedContextMode, worker, promptConstruction, holoScorecard, workTrail) {
+function attachOrchestratorMetadata(reviewPacket, classification, resolvedEffort, resolvedMode, validationState, resolvedContextMode, worker, promptConstruction, holoScorecard, workTrail, unicodeMeta) {
   const base = reviewPacket && typeof reviewPacket === 'object' ? reviewPacket : {};
   const construction = promptConstruction && typeof promptConstruction === 'object' ? promptConstruction : {};
   const providerReport = resolveProviderReasoningReport(resolvedEffort);
+  const unicode = unicodeMeta && typeof unicodeMeta === 'object' ? unicodeMeta : emptyUnicodeNormalizationMeta();
   return Object.assign({}, base, {
     task_classification: classification,
     resolved_effort: resolvedEffort,
@@ -943,7 +1033,11 @@ function attachOrchestratorMetadata(reviewPacket, classification, resolvedEffort
     work_trail: workTrail && typeof workTrail.toEvents === 'function' ? workTrail.toEvents() : workTrail,
     provider_reasoning_requested: providerReport.provider_reasoning_requested,
     provider_reasoning_applied: providerReport.provider_reasoning_applied,
-    provider_reasoning_note: providerReport.provider_reasoning_note
+    provider_reasoning_note: providerReport.provider_reasoning_note,
+    unicode_normalization_applied: unicode.unicode_normalization_applied === true,
+    unicode_replacements_count: typeof unicode.unicode_replacements_count === 'number' ? unicode.unicode_replacements_count : 0,
+    unicode_normalization_sources: typeof unicode.unicode_normalization_sources === 'string' ? unicode.unicode_normalization_sources : '',
+    unicode_normalization_form: unicode.unicode_normalization_form || 'none'
   });
 }
 
@@ -1098,6 +1192,18 @@ function wireFusionWebview(context, webview, worker, state) {
     workTrail.push('wsp_prompt_assembled');
 
     let validationState = { validated: false, skipped: true, reason: 'not_validated' };
+    let unicodeMeta = emptyUnicodeNormalizationMeta();
+    const absorbUnicodeMeta = (bridgeResult) => {
+      if (!bridgeResult || typeof bridgeResult !== 'object') {
+        return;
+      }
+      unicodeMeta = mergeUnicodeNormalizationMeta(unicodeMeta, {
+        unicode_normalization_applied: bridgeResult.unicode_normalization_applied,
+        unicode_replacements_count: bridgeResult.unicode_replacements_count,
+        unicode_normalization_sources: bridgeResult.unicode_normalization_sources,
+        unicode_normalization_form: bridgeResult.unicode_normalization_form
+      });
+    };
     const onBridgeProgress = (stage, text) => {
       postStatusMessage(webview, text);
       postProgressMessage(webview, stage, text);
@@ -1107,6 +1213,7 @@ function wireFusionWebview(context, webview, worker, state) {
       }
     };
     let result = await callFusion(context, worker, wspTaskPrompt, contextPacket.text, systemPrompt, state.history, mode, onBridgeProgress, state, promptConstruction);
+    absorbUnicodeMeta(result);
     if (result.ok && isSubstantiveRedDogWorker(workerType)) {
       workTrail.push('validator_started');
       const validation = validateRedDogOutput(result.content || '', { substantiveArchitect: true, mode: mode });
@@ -1131,8 +1238,10 @@ function wireFusionWebview(context, webview, worker, state) {
           mode,
           onBridgeProgress,
           state,
-          promptConstruction
+          promptConstruction,
+          { promptSource: 'repair_prompt' }
         );
+        absorbUnicodeMeta(repairResult);
         if (repairResult.ok) {
           const repairValidation = validateRedDogOutput(repairResult.content || '', { substantiveArchitect: true, mode: mode });
           validationState.repair_ok = repairValidation.valid;
@@ -1182,7 +1291,8 @@ function wireFusionWebview(context, webview, worker, state) {
       worker,
       promptConstruction,
       holoScorecard,
-      workTrail
+      workTrail,
+      unicodeMeta
     );
     result.governed_handoff_recommendation = handoffRecommendation;
     if (result.reason === 'redaction_blocked') {
@@ -1285,14 +1395,19 @@ function attachBridgeMetadata(reviewPacket, bridgeMeta) {
   return Object.assign({}, reviewPacket, meta);
 }
 
-function callFusion(context, worker, prompt, boundedContext, systemPrompt, history, mode, onProgress, state, bridgeMeta) {
+function callFusion(context, worker, prompt, boundedContext, systemPrompt, history, mode, onProgress, state, bridgeMeta, callOptions) {
   return new Promise((resolve) => {
     const root = workspaceRoot();
     const script = path.join(root, 'scripts', 'advisory_model_once.py');
     const config = vscode.workspace.getConfiguration('foundupsFusion');
     const configuredPython = config.get('pythonPath') || 'python';
     const interpreter = resolvePythonInterpreter(root, configuredPython);
-    const budgeted = applyBridgeContextBudget(prompt, boundedContext);
+    const promptSource = callOptions && callOptions.promptSource ? callOptions.promptSource : 'prompt';
+    const promptNorm = normalizeBridgeTextForUnicode(prompt, promptSource);
+    const contextNorm = normalizeBridgeTextForUnicode(boundedContext, 'context');
+    const unicodeMeta = mergeUnicodeNormalizationMeta(null, Object.assign({}, promptNorm, { unicode_normalization_source: promptSource }));
+    const mergedUnicodeMeta = mergeUnicodeNormalizationMeta(unicodeMeta, Object.assign({}, contextNorm, { unicode_normalization_source: 'context' }));
+    const budgeted = applyBridgeContextBudget(promptNorm.text, contextNorm.text);
     onProgress(null, 'Mode: ' + mode);
     onProgress(null, 'Python interpreter: ' + interpreter.path + ' (' + interpreter.source + ')');
     onProgress(null, 'Bridge process starting');
@@ -1301,6 +1416,9 @@ function callFusion(context, worker, prompt, boundedContext, systemPrompt, histo
     onProgress(null, 'OpenRouter key visible to Cursor process: ' + (process.env.OPENROUTER_API_KEY ? 'yes' : 'no'));
     if (budgeted.budget.truncation_applied) {
       onProgress(null, 'Context budget applied: ' + budgeted.budget.truncation_reason);
+    }
+    if (mergedUnicodeMeta.unicode_normalization_applied) {
+      onProgress(null, 'Unicode normalization applied before redaction gate: replacements=' + mergedUnicodeMeta.unicode_replacements_count + ' sources=' + (mergedUnicodeMeta.unicode_normalization_sources || 'unknown'));
     }
     let settled = false;
     function finish(result) {
@@ -1344,7 +1462,11 @@ function callFusion(context, worker, prompt, boundedContext, systemPrompt, histo
         python_interpreter: interpreter.path,
         python_interpreter_source: interpreter.source,
         truncation_applied: budgeted.budget.truncation_applied,
-        truncation_reason: budgeted.budget.truncation_reason
+        truncation_reason: budgeted.budget.truncation_reason,
+        unicode_normalization_applied: mergedUnicodeMeta.unicode_normalization_applied,
+        unicode_replacements_count: mergedUnicodeMeta.unicode_replacements_count,
+        unicode_normalization_sources: mergedUnicodeMeta.unicode_normalization_sources,
+        unicode_normalization_form: mergedUnicodeMeta.unicode_normalization_form
       })
     };
 
@@ -1391,7 +1513,7 @@ function callFusion(context, worker, prompt, boundedContext, systemPrompt, histo
           parsed.reason = 'subprocess_failed';
           parsed.exit_code = code;
         }
-        finish(parsed);
+        finish(Object.assign({}, parsed, mergedUnicodeMeta));
       } catch (err) {
         finish({ ok: false, reason: 'malformed_response', detail: stderr.slice(0, 500) });
       }
@@ -2485,5 +2607,9 @@ module.exports = {
   WSP97_PROTOCOL_REL_PATH,
   MOJIBAKE_MARKERS,
   WORK_TRAIL_MAX_EVENTS,
-  VALIDATION_FAILED_FOOTER
+  VALIDATION_FAILED_FOOTER,
+  UNICODE_SURROGATE_PLACEHOLDER,
+  normalizeBridgeTextForUnicode,
+  emptyUnicodeNormalizationMeta,
+  mergeUnicodeNormalizationMeta
 };

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.24';
+const EXTENSION_VERSION = '0.3.25';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -1365,6 +1365,13 @@ function bridgeStreamCapExceeded(currentBytes, chunkLength, cap) {
   return currentBytes + chunkLength > cap;
 }
 
+function buildBridgePythonEnv(baseEnv) {
+  return Object.assign({}, baseEnv || process.env, {
+    PYTHONIOENCODING: 'utf-8',
+    PYTHONUTF8: '1'
+  });
+}
+
 function applyBridgeContextBudget(prompt, context) {
   const budget = {
     truncation_applied: false,
@@ -1434,7 +1441,7 @@ function callFusion(context, worker, prompt, boundedContext, systemPrompt, histo
 
     const child = cp.spawn(interpreter.path, [script], {
       cwd: root,
-      env: process.env,
+      env: buildBridgePythonEnv(process.env),
       windowsHide: true,
       stdio: ['pipe', 'pipe', 'pipe']
     });
@@ -2555,6 +2562,7 @@ module.exports = {
   constructWspTaskPrompt,
   redactedDigest,
   resolvePythonInterpreter,
+  buildBridgePythonEnv,
   applyBridgeContextBudget,
   killBridgeChild,
   bridgeStreamCapExceeded,

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups®Agent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.24",
+    "version":  "0.3.25",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups®Agent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.23",
+    "version":  "0.3.24",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/README.md
+++ b/extensions/foundups_advisory_workers/tests/README.md
@@ -31,7 +31,7 @@ python -m pytest holo_index/tests/test_reddog_extension_bundle_recall.py -q
 
 ## TEST_REGISTRY
 
-See `TestModLog.md` for TCI-001 through TCI-010 and THG-001 through THG-006.
+See `TestModLog.md` for TCI-001 through TCI-010, THG-001 through THG-006, and UNI-001 through UNI-007.
 
 ## Expected behavior
 

--- a/extensions/foundups_advisory_workers/tests/TestModLog.md
+++ b/extensions/foundups_advisory_workers/tests/TestModLog.md
@@ -1,5 +1,15 @@
 # Foundups®Agent TestModLog
 
+## 2026-06-14 - ADDENDUM B bridge UTF-8 stdin (UNI-008..UNI-010)
+
+| ID | Asserts |
+| --- | --- |
+| UNI-008 | `evaluate_redaction_gate(safe, EMDASH_UNICODE_CONTEXT)` passes (U+2014) |
+| UNI-009 | `buildBridgePythonEnv` sets PYTHONIOENCODING + PYTHONUTF8 |
+| UNI-010 | `test_main_em_dash_utf8_stdin_not_redactor_error` passes |
+
+Regression: UNI-001..UNI-007, TCI, THG unchanged.
+
 ## 2026-06-14 - REDDOG_CONTEXT_UNICODE_NORMALIZATION_PHASE1 (UNI-001..UNI-007)
 
 | ID | Asserts |

--- a/extensions/foundups_advisory_workers/tests/TestModLog.md
+++ b/extensions/foundups_advisory_workers/tests/TestModLog.md
@@ -1,5 +1,27 @@
 # Foundups®Agent TestModLog
 
+## 2026-06-14 - REDDOG_CONTEXT_UNICODE_NORMALIZATION_PHASE1 (UNI-001..UNI-007)
+
+| ID | Asserts |
+| --- | --- |
+| UNI-001 | Lone surrogate breaks UTF-8 digest path without normalization |
+| UNI-002 | `evaluate_redaction_gate(safe, MALFORMED_UNICODE_CONTEXT)` -> `redactor_error` |
+| UNI-003 | `normalizeBridgeTextForUnicode` replaces lone surrogate; count > 0 |
+| UNI-004 | Normalized context passes Python gate |
+| UNI-005 | `BLOCKED_POLICY_CONTEXT` still -> `blocked_policy` |
+| UNI-006 | `buildRunTraceSection` exposes unicode normalization telemetry |
+| UNI-007 | No raw malformed surrogate in normalized text or Run Trace |
+
+Regression: TCI-001..TCI-010 and THG-001..THG-006 must still pass.
+
+Commands:
+
+```powershell
+node --check extensions/foundups_advisory_workers/extension.js
+node extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+git diff --check -- extensions/foundups_advisory_workers
+```
+
 ## 2026-06-14 - REDDOG_ALWAYS_HOLOINDEX_GROUNDING_PHASE1 (THG-001..006)
 
 | ID | Asserts |

--- a/extensions/foundups_advisory_workers/tests/fixtures.js
+++ b/extensions/foundups_advisory_workers/tests/fixtures.js
@@ -10,6 +10,10 @@ const BUILD_COPY_MARKDOWN_PROMPT = 'Review buildCopyMarkdown in extensions/found
 
 const REGULAR_SMOKE_PROMPT = 'Reply with exactly: regular mode works';
 
+const MALFORMED_UNICODE_CONTEXT = 'PR #718 WSP_109_FOUNDUP_ONBOARDI' + '\udc94' + ' trailing safe context for gate probe.';
+
+const BLOCKED_POLICY_CONTEXT = 'Bounded repo context with grant authority and merge authorization token present.';
+
 const TARGET_READ_DENIED_PATHS = [
   ['C:/Windows/System32/drivers/etc/hosts', 'absolute path'],
   ['../outside.txt', 'traversal'],
@@ -24,5 +28,7 @@ module.exports = {
   EXT_ACC_001_TARGET_PATH,
   BUILD_COPY_MARKDOWN_PROMPT,
   REGULAR_SMOKE_PROMPT,
+  MALFORMED_UNICODE_CONTEXT,
+  BLOCKED_POLICY_CONTEXT,
   TARGET_READ_DENIED_PATHS
 };

--- a/extensions/foundups_advisory_workers/tests/fixtures.js
+++ b/extensions/foundups_advisory_workers/tests/fixtures.js
@@ -14,6 +14,8 @@ const MALFORMED_UNICODE_CONTEXT = 'PR #718 WSP_109_FOUNDUP_ONBOARDI' + '\udc94' 
 
 const BLOCKED_POLICY_CONTEXT = 'Bounded repo context with grant authority and merge authorization token present.';
 
+const EMDASH_UNICODE_CONTEXT = 'PR #718 \u2014 `WSP_109_FOUNDUP_ONBOARDI' + ' trailing HoloIndex context for UTF-8 bridge probe.';
+
 const TARGET_READ_DENIED_PATHS = [
   ['C:/Windows/System32/drivers/etc/hosts', 'absolute path'],
   ['../outside.txt', 'traversal'],
@@ -30,5 +32,6 @@ module.exports = {
   REGULAR_SMOKE_PROMPT,
   MALFORMED_UNICODE_CONTEXT,
   BLOCKED_POLICY_CONTEXT,
+  EMDASH_UNICODE_CONTEXT,
   TARGET_READ_DENIED_PATHS
 };

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -23,7 +23,7 @@ function assertFusionRedactionGatePasses(contextText, label) {
   const script = [
     'import sys',
     'from modules.communication.moltbot_bridge.src.fusion_redaction_gate import evaluate_redaction_gate, REDACTION_GATE_PASSED',
-    'ctx = sys.stdin.read()',
+    'ctx = sys.stdin.buffer.read().decode("utf-8", errors="replace")',
     'r = evaluate_redaction_gate("012 work focus digest placeholder for gate probe", ctx)',
     'if r.status != REDACTION_GATE_PASSED:',
     '    cats = ",".join(r.report.blocked_categories)',
@@ -33,10 +33,11 @@ function assertFusionRedactionGatePasses(contextText, label) {
   ].join('\n');
   const out = cp.execFileSync('python', ['-B', '-c', script], {
     cwd: root,
-    input: String(contextText || ''),
+    input: Buffer.from(String(contextText || ''), 'utf8'),
     encoding: 'utf8',
     timeout: 30000,
-    maxBuffer: 1024 * 1024
+    maxBuffer: 1024 * 1024,
+    env: Object.assign({}, process.env, { PYTHONIOENCODING: 'utf-8', PYTHONUTF8: '1' })
   }).trim();
   assert.strictEqual(out, 'PASSED', label || 'bounded context must pass fusion redaction gate');
 }
@@ -56,7 +57,7 @@ function assertFusionRedactionGateBlocks(contextText, expectedReason, label) {
   const script = [
     'import sys',
     'from modules.communication.moltbot_bridge.src.fusion_redaction_gate import evaluate_redaction_gate, REDACTION_GATE_PASSED',
-    'ctx = sys.stdin.read()',
+    'ctx = sys.stdin.buffer.read().decode("utf-8", errors="replace")',
     'r = evaluate_redaction_gate("012 work focus digest placeholder for gate probe", ctx)',
     'if r.status == REDACTION_GATE_PASSED:',
     '    print("UNEXPECTED_PASS")',
@@ -65,10 +66,11 @@ function assertFusionRedactionGateBlocks(contextText, expectedReason, label) {
   ].join('\n');
   const out = cp.execFileSync('python', ['-B', '-c', script], {
     cwd: root,
-    input: String(contextText || ''),
+    input: Buffer.from(String(contextText || ''), 'utf8'),
     encoding: 'utf8',
     timeout: 30000,
-    maxBuffer: 1024 * 1024
+    maxBuffer: 1024 * 1024,
+    env: Object.assign({}, process.env, { PYTHONIOENCODING: 'utf-8', PYTHONUTF8: '1' })
   }).trim();
   assert.strictEqual(out, expectedReason, label || 'bounded context must be blocked by fusion redaction gate');
 }
@@ -77,8 +79,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.24', 'package version must be 0.3.24');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.24'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.25', 'package version must be 0.3.25');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.25'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups®Agent', 'display name must be Foundups®Agent');
 includes(JSON.stringify(pkg), 'Foundups®Agent: Open', 'command title must use Foundups®Agent');
@@ -95,9 +97,14 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.24', 'README version mismatch');
-includes(extensionJs, 'function normalizeBridgeTextForUnicode', 'unicode normalization helper missing');
+includes(readme, 'Version: 0.3.25', 'README version mismatch');
+includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
+includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
+includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
+includes(bridgePy, 'def _read_stdin_json', 'bridge must read stdin as UTF-8 bytes');
+includes(bridgePy, 'sys.stdin.buffer.read()', 'bridge UTF-8 stdin invariant missing');
 includes(extensionJs, 'UNICODE_SURROGATE_PLACEHOLDER', 'unicode surrogate placeholder missing');
+includes(extensionJs, 'function normalizeBridgeTextForUnicode', 'unicode normalization helper missing');
 includes(extensionJs, 'unicode_normalization_applied', 'unicode normalization telemetry missing');
 includes(extensionJs, 'function applyBridgeContextBudget', 'context budget missing');
 includes(extensionJs, 'function killBridgeChild', 'orphan cleanup missing');
@@ -584,7 +591,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.24'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.25'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -598,7 +605,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.24'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.25'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -610,7 +617,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.24'", 'bounded context must include extension.js source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.25'", 'bounded context must include extension.js source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');
@@ -656,7 +663,12 @@ try {
 }
 assert(uni001Failed, 'UNI-001: lone surrogate must break UTF-8 digest path without normalization');
 
-assertFusionRedactionGateFails(fixtures.MALFORMED_UNICODE_CONTEXT, 'redactor_error', 'UNI-002: malformed surrogate context must fail gate before normalization');
+const uni002Reason = cp.execFileSync('python', ['-B', '-c', "from modules.communication.moltbot_bridge.src.fusion_redaction_gate import evaluate_redaction_gate; r=evaluate_redaction_gate('012 work focus digest placeholder for gate probe', 'PR\\udc94 tail'); print(r.reason)"], {
+  cwd: root,
+  encoding: 'utf8',
+  timeout: 30000
+}).trim();
+assert.strictEqual(uni002Reason, 'redactor_error', 'UNI-002: Python surrogate in context must fail gate before normalization');
 
 const normalizedMalformed = orchestrator.normalizeBridgeTextForUnicode(fixtures.MALFORMED_UNICODE_CONTEXT, 'context');
 assert(normalizedMalformed.unicode_replacements_count > 0, 'UNI-003: lone surrogate must increment replacement count');
@@ -664,6 +676,19 @@ includes(normalizedMalformed.text, orchestrator.UNICODE_SURROGATE_PLACEHOLDER, '
 assert(!normalizedMalformed.text.includes('\udc94'), 'UNI-007: raw malformed surrogate must not remain in normalized text');
 assertFusionRedactionGatePasses(normalizedMalformed.text, 'UNI-004: normalized malformed context must pass fusion redaction gate');
 assertFusionRedactionGateBlocks(fixtures.BLOCKED_POLICY_CONTEXT, 'blocked_policy', 'UNI-005: blocked_policy context must still block after normalization contract');
+assertFusionRedactionGatePasses(fixtures.EMDASH_UNICODE_CONTEXT, 'UNI-008: U+2014 em dash context must pass fusion redaction gate when UTF-8 decoded');
+
+const bridgeEnv = orchestrator.buildBridgePythonEnv({});
+assert.strictEqual(bridgeEnv.PYTHONIOENCODING, 'utf-8', 'UNI-009: bridge child env must force PYTHONIOENCODING=utf-8');
+assert.strictEqual(bridgeEnv.PYTHONUTF8, '1', 'UNI-009: bridge child env must force PYTHONUTF8=1');
+
+const bridgeEmDashProbe = cp.execFileSync('python', ['-B', '-m', 'pytest', 'scripts/tests/test_advisory_model_once_hardening.py::AdvisoryBridgeHardeningTests::test_main_em_dash_utf8_stdin_not_redactor_error', '-q'], {
+  cwd: root,
+  encoding: 'utf8',
+  timeout: 120000,
+  env: Object.assign({}, process.env, { PYTHONIOENCODING: 'utf-8', PYTHONUTF8: '1' })
+}).trim();
+includes(bridgeEmDashProbe, '1 passed', 'UNI-010: bridge UTF-8 stdin em dash must not redactor_error');
 
 const unicodeTrace = orchestrator.buildRunTraceSection({
   review_packet: {

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -52,8 +52,33 @@ function extractTargetRecallSection(contextText) {
   return next === -1 ? tail : tail.slice(0, next);
 }
 
-assert.strictEqual(pkg.version, '0.3.23', 'package version must be 0.3.23');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.23'", 'extension build mismatch');
+function assertFusionRedactionGateBlocks(contextText, expectedReason, label) {
+  const script = [
+    'import sys',
+    'from modules.communication.moltbot_bridge.src.fusion_redaction_gate import evaluate_redaction_gate, REDACTION_GATE_PASSED',
+    'ctx = sys.stdin.read()',
+    'r = evaluate_redaction_gate("012 work focus digest placeholder for gate probe", ctx)',
+    'if r.status == REDACTION_GATE_PASSED:',
+    '    print("UNEXPECTED_PASS")',
+    '    sys.exit(1)',
+    'print(r.reason)'
+  ].join('\n');
+  const out = cp.execFileSync('python', ['-B', '-c', script], {
+    cwd: root,
+    input: String(contextText || ''),
+    encoding: 'utf8',
+    timeout: 30000,
+    maxBuffer: 1024 * 1024
+  }).trim();
+  assert.strictEqual(out, expectedReason, label || 'bounded context must be blocked by fusion redaction gate');
+}
+
+function assertFusionRedactionGateFails(contextText, expectedReason, label) {
+  assertFusionRedactionGateBlocks(contextText, expectedReason, label);
+}
+
+assert.strictEqual(pkg.version, '0.3.24', 'package version must be 0.3.24');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.24'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups®Agent', 'display name must be Foundups®Agent');
 includes(JSON.stringify(pkg), 'Foundups®Agent: Open', 'command title must use Foundups®Agent');
@@ -70,8 +95,10 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.23', 'README version mismatch');
-includes(extensionJs, 'function resolvePythonInterpreter', 'python resolver missing');
+includes(readme, 'Version: 0.3.24', 'README version mismatch');
+includes(extensionJs, 'function normalizeBridgeTextForUnicode', 'unicode normalization helper missing');
+includes(extensionJs, 'UNICODE_SURROGATE_PLACEHOLDER', 'unicode surrogate placeholder missing');
+includes(extensionJs, 'unicode_normalization_applied', 'unicode normalization telemetry missing');
 includes(extensionJs, 'function applyBridgeContextBudget', 'context budget missing');
 includes(extensionJs, 'function killBridgeChild', 'orphan cleanup missing');
 includes(extensionJs, 'output_cap_exceeded', 'output cap failure reason missing');
@@ -557,7 +584,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.23'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.24'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -571,7 +598,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.23'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.24'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -583,7 +610,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.23'", 'bounded context must include extension.js source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.24'", 'bounded context must include extension.js source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');
@@ -615,5 +642,55 @@ assert(regularHoloContext.holoindex_scorecard !== null, 'THG-005: wsp_holo must 
 const regularReasoning = orchestrator.modeSelectionReasoning(regular, 'regular', 'openrouter_single', 'wsp_holo');
 includes(regularReasoning, 'wsp_holo', 'THG-006: REGULAR mode selection must cite wsp_holo');
 includes(regularReasoning, 'HoloIndex-grounded', 'THG-006: REGULAR mode selection must state HoloIndex grounding');
+
+// ADDENDUM G - REDDOG_CONTEXT_UNICODE_NORMALIZATION_PHASE1 (UNI-001..UNI-007)
+let uni001Failed = false;
+try {
+  cp.execFileSync('python', ['-B', '-c', "import hashlib; s='PR\\udc94'; hashlib.sha256(s.encode('utf-8')).hexdigest()"], {
+    cwd: root,
+    encoding: 'utf8',
+    timeout: 30000
+  });
+} catch (err) {
+  uni001Failed = /UnicodeEncodeError|surrogate/i.test(String(err && (err.stderr || err.message || err)));
+}
+assert(uni001Failed, 'UNI-001: lone surrogate must break UTF-8 digest path without normalization');
+
+assertFusionRedactionGateFails(fixtures.MALFORMED_UNICODE_CONTEXT, 'redactor_error', 'UNI-002: malformed surrogate context must fail gate before normalization');
+
+const normalizedMalformed = orchestrator.normalizeBridgeTextForUnicode(fixtures.MALFORMED_UNICODE_CONTEXT, 'context');
+assert(normalizedMalformed.unicode_replacements_count > 0, 'UNI-003: lone surrogate must increment replacement count');
+includes(normalizedMalformed.text, orchestrator.UNICODE_SURROGATE_PLACEHOLDER, 'UNI-003: lone surrogate must become ASCII placeholder');
+assert(!normalizedMalformed.text.includes('\udc94'), 'UNI-007: raw malformed surrogate must not remain in normalized text');
+assertFusionRedactionGatePasses(normalizedMalformed.text, 'UNI-004: normalized malformed context must pass fusion redaction gate');
+assertFusionRedactionGateBlocks(fixtures.BLOCKED_POLICY_CONTEXT, 'blocked_policy', 'UNI-005: blocked_policy context must still block after normalization contract');
+
+const unicodeTrace = orchestrator.buildRunTraceSection({
+  review_packet: {
+    task_classification: { tier: 'HIGH' },
+    resolved_effort: 'high',
+    resolved_mode: 'openrouter_single',
+    resolved_context: 'wsp_holo_skillz',
+    mode_selection_reasoning: 'Single-model GLM principal',
+    principal_model: 'z-ai/glm-5.2',
+    panel_models: ['deepseek/deepseek-v4-pro'],
+    unicode_normalization_applied: true,
+    unicode_replacements_count: 1,
+    unicode_normalization_sources: 'context',
+    unicode_normalization_form: 'NFC',
+    holoindex_scorecard: {
+      holoindex_status: 'bundle_json_ok',
+      wsp_hits: 3,
+      code_hits_count: 3,
+      code_hits: 3
+    },
+    output_validation: { validated: false, skipped: true }
+  }
+}, 'reddog_architect', 'Repo context attached', null, 'high');
+includes(unicodeTrace, 'unicode_normalization_applied: true', 'UNI-006: Run Trace must expose unicode normalization applied');
+includes(unicodeTrace, 'unicode_replacements_count: 1', 'UNI-006: Run Trace must expose replacement count');
+includes(unicodeTrace, 'unicode_normalization_sources: context', 'UNI-006: Run Trace must expose normalization sources');
+includes(unicodeTrace, 'unicode_normalization_form: NFC', 'UNI-006: Run Trace must expose normalization form');
+assert(!unicodeTrace.includes('\udc94'), 'UNI-007: Run Trace must not echo raw malformed surrogate');
 
 console.log('Foundups®Agent extension contract checks passed.');

--- a/scripts/advisory_model_once.py
+++ b/scripts/advisory_model_once.py
@@ -408,10 +408,20 @@ def _run_foundups_fusion(
     }
 
 
+def _read_stdin_json() -> dict[str, Any]:
+    """Read bridge payload as UTF-8 bytes (ADDENDUM B: Windows text stdin is not UTF-8-safe)."""
+    raw = sys.stdin.buffer.read()
+    text = raw.decode("utf-8", errors="replace")
+    data = json.loads(text)
+    if not isinstance(data, dict):
+        raise json.JSONDecodeError("expected JSON object", text, 0)
+    return data
+
+
 def main() -> int:
     _progress("bridge_start", "Bridge Python started.")
     try:
-        payload = json.loads(sys.stdin.read())
+        payload = _read_stdin_json()
     except json.JSONDecodeError:
         return _json_result(ok=False, reason="invalid_json")
 

--- a/scripts/tests/test_advisory_model_once_hardening.py
+++ b/scripts/tests/test_advisory_model_once_hardening.py
@@ -32,10 +32,13 @@ def _passed_gate(*, prompt: str = "redacted-prompt", context: str | None = None)
 
 class AdvisoryBridgeHardeningTests(unittest.TestCase):
     def _invoke_main(self, payload: dict, *, api_key: str = "test-key") -> tuple[int, dict]:
-        stdin = io.StringIO(json.dumps(payload))
+        stdin_bytes = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        stdin_buffer = io.BytesIO(stdin_bytes)
         stdout = io.StringIO()
         env = {bridge.ENV_API_KEY: api_key}
-        with mock.patch("sys.stdin", stdin), mock.patch("sys.stdout", stdout), mock.patch.dict(
+        fake_stdin = mock.Mock()
+        fake_stdin.buffer = stdin_buffer
+        with mock.patch("sys.stdin", fake_stdin), mock.patch("sys.stdout", stdout), mock.patch.dict(
             os.environ, env, clear=False
         ):
             rc = bridge.main()
@@ -210,6 +213,39 @@ class AdvisoryBridgeHardeningTests(unittest.TestCase):
         self.assertTrue(packet.get("panel_models_truncated"))
         self.assertEqual(packet.get("python_interpreter_source"), "system")
         self.assertLessEqual(len(packet.get("panel_models") or []), bridge.MAX_PANEL_MODELS)
+
+    def test_read_stdin_json_em_dash(self) -> None:
+        payload = {"prompt": "safe", "context": "PR #718 \u2014 `WSP_109_FOUNDUP_ONBOARDI"}
+        stdin_buffer = io.BytesIO(json.dumps(payload, ensure_ascii=False).encode("utf-8"))
+        fake_stdin = mock.Mock()
+        fake_stdin.buffer = stdin_buffer
+        with mock.patch("sys.stdin", fake_stdin):
+            parsed = bridge._read_stdin_json()
+        self.assertIn("\u2014", parsed["context"])
+
+    def test_main_em_dash_utf8_stdin_not_redactor_error(self) -> None:
+        context = "PR #718 \u2014 `WSP_109_FOUNDUP_ONBOARDI"
+        responses = [
+            json.dumps({"choices": [{"message": {"content": "ok"}}]}).encode("utf-8"),
+        ]
+
+        def fake_urlopen(request, timeout=0):  # noqa: ARG001
+            item = responses.pop(0)
+            return io.BytesIO(item)
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _rc, out = self._invoke_main(
+                {
+                    "mode": "openrouter_single",
+                    "prompt": "Operate as RedDog Architect. Review the supplied repo context.",
+                    "context": context,
+                    "lead_model": "z-ai/glm-5.2",
+                }
+            )
+
+        self.assertNotEqual(out.get("reason"), "redaction_blocked")
+        self.assertNotEqual(out.get("redaction_reason"), "redactor_error")
+        self.assertTrue(out.get("ok"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds `normalizeBridgeTextForUnicode()` — replaces isolated UTF-16 surrogates with `[MALFORMED_SURROGATE]`, applies NFC, counts-only metadata.
- Applies normalization in `callFusion` before context budget + Python redaction gate (prompt, context, repair_prompt).
- Run Trace / review packet: `unicode_normalization_applied`, `unicode_replacements_count`, `unicode_normalization_sources`, `unicode_normalization_form`.
- Version **0.3.24**. `fusion_redaction_gate.py` unchanged.

## WSP_97
| Row | Status |
|-----|--------|
| SAFE_PROMPT_NOT_POLICY_BLOCKED | PASS (design) |
| REDACTOR_ERROR_ROOT_CAUSE_SURROGATE | PASS (UNI-001/002) |
| UNICODE_NORMALIZATION_BEFORE_GATE | PASS |
| BLOCK_POLICY_UNCHANGED | PASS (UNI-005) |
| RAW_MALFORMED_CONTENT_NOT_ECHOED | PASS (UNI-007) |
| TCI_REGRESSION_UNCHANGED | PASS |
| THG_REGRESSION_UNCHANGED | PASS |
| LANE_B_EXCLUDED | PASS |

## Validation
All PASS on branch:
- node --check extension.js
- verify_extension_contract.js (TCI + THG + UNI)
- fusion_redaction_gate import
- git diff --check

## Test plan
- [ ] 012 smoke after VSIX install (RedDog Architect prompt; expect redaction passed, no redactor_error)
- [ ] If HoloIndex still emits surrogates: unicode_normalization_applied true, unicode_replacements_count >= 1

## Out of scope
Schema repair, made_network_call telemetry, mojibake, HoloIndex upstream cleanup, Lane B.
