### PR TITLE
fix(extension): harden RedDog schema repair pass with minimal context (0.3.26)

### DIFF
--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -179,7 +179,9 @@ Internal contract layer. Advisory-only. No new authority.
 | `resolveAutoEffort(classification, selectedEffort)` | Maps Auto -> regular/high/ultra |
 | `resolveModelMode(classification, selectedMode, workerType)` | RedDog WSP work defaults to auditable manual panel |
 | `validateRedDogOutput(markdown)` | Required schema section check |
-| `buildRepairPrompt(originalPrompt, badOutput, missingSections)` | One bounded repair pass |
+| `buildRepairPrompt(originalPrompt, badOutput, missingSections)` | One bounded repair pass; sanitizes draft for gate |
+| `buildRepairBoundedContext()` | Minimal WSP-only context for repair (no HoloIndex resend) |
+| `mergeRepairedOutput(primaryContent, repairContent)` | Appends schema supplement to primary Fusion output |
 
 Required substantive output sections:
 
@@ -223,7 +225,7 @@ Review packet additions:
 - `work_focus_digest` (`hash`, `excerpt`, `length` - redacted)
 - `wsp_prompt_digest` (`hash`, `excerpt`, `length` - redacted)
 - `prompt_construction`: `0102_generated_from_work_focus`
-- `output_validation` (`validated`, `missing_sections`, `repair_attempted`, `repair_ok`, `fusion_panel_ok`)
+- `output_validation` (`validated`, `missing_sections`, `repair_attempted`, `repair_ok`, `repair_context_mode`, `repair_mode`, `fusion_panel_ok`)
 
 ## Bridge Hardening (v0.3.16)
 

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -1,5 +1,16 @@
 # Foundups®Agent ModLog
 
+## 2026-06-14 - REDDOG_OUTPUT_SCHEMA_REPAIR_HARDENING_PHASE1 addendum (v0.3.27)
+
+- Run Trace always emits `repair_context_mode` / `repair_mode` when `repair_attempted`.
+- Dedicated repair Work Trail mapping (`repair_single_started`, no `panel_started` after repair).
+- `extractMarkdownSection` + section-aware `mergeRepairedOutput(..., missingSections)`.
+- Repair prompt lists required `## Section` headers explicitly; repair `max_tokens: 2400`.
+- Contract tests OSR-007..OSR-010 (smoke-missing tail sections).
+- Version bump 0.3.26 -> 0.3.27.
+
+WSP: WSP_97, WSP_22.
+
 ## 2026-06-14 - REDDOG_OUTPUT_SCHEMA_REPAIR_HARDENING_PHASE1 (v0.3.26)
 
 - Repair pass uses `buildRepairBoundedContext()` (minimal WSP contract; no HoloIndex resend).

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -1,5 +1,16 @@
 # Foundups®Agent ModLog
 
+## 2026-06-14 - REDDOG_OUTPUT_SCHEMA_REPAIR_HARDENING_PHASE1 (v0.3.26)
+
+- Repair pass uses `buildRepairBoundedContext()` (minimal WSP contract; no HoloIndex resend).
+- Repair routes `openrouter_single` with sanitized draft via `sanitizeTargetSnippetForRedaction`.
+- `mergeRepairedOutput()` appends schema supplement to primary Fusion output.
+- Run Trace: `repair_context_mode`, `repair_mode` on validation state.
+- Contract tests OSR-001..OSR-006.
+- Version bump 0.3.25 -> 0.3.26.
+
+WSP: WSP_97, WSP_22, WSP_84.
+
 ## 2026-06-14 - ADDENDUM B bridge UTF-8 stdin invariant (v0.3.25)
 
 - **Problem:** Valid U+2014 em dash in HoloIndex context passed JS normalization but Windows Python text stdin mis-decoded UTF-8 to surrogate `\udc94`, causing `redactor_error` at digest.

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.25
+Version: 0.3.26
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.26
+Version: 0.3.27
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -130,11 +130,18 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 
 ### REDDOG_CONTEXT_UNICODE_NORMALIZATION_PHASE1
 
-- **Status:** IN PROGRESS (v0.3.25) — JS surrogate normalization + bridge UTF-8 stdin invariant (Addendum B).
-- Trigger: safe architect prompt blocked with `redactor_error` when HoloIndex context contains lone surrogate (e.g. `\udc94`).
-- Run Trace: `unicode_normalization_applied`, `unicode_replacements_count`, `unicode_normalization_sources`, `unicode_normalization_form`.
-- Out of scope: redaction policy weakening, schema repair, made_network_call telemetry, HoloIndex upstream cleanup (follow-up).
-- Acceptance: synthetic surrogate normalized; gate passes; `blocked_policy` unchanged; TCI + THG regression green.
+- **Status:** **LANDED** #886 (`ca5703611`) — JS surrogate normalization + bridge UTF-8 stdin (0.3.25).
+
+### REDDOG_OUTPUT_SCHEMA_REPAIR_HARDENING_PHASE1
+
+- **Status:** IN PROGRESS (v0.3.26) — repair pass minimal context, sanitized draft, merge supplement.
+- Trigger: primary Fusion egress ok but `output_validation: failed`; repair re-blocked on full context.
+- Run Trace: `repair_context_mode: repair_minimal`, `repair_mode: openrouter_single`.
+- Does not replace sanitized-target provenance slice (fold placeholder guidance there).
+
+### REDDOG_SANITIZED_TARGET_CONTEXT_PROVENANCE_PHASE1
+
+- **Status:** QUEUED — tell RedDog target snippets may contain egress-safe placeholders; not repo source truth.
 
 ### REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1
 

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -134,7 +134,7 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 
 ### REDDOG_OUTPUT_SCHEMA_REPAIR_HARDENING_PHASE1
 
-- **Status:** IN PROGRESS (v0.3.26) — repair pass minimal context, sanitized draft, merge supplement.
+- **Status:** IN PROGRESS (v0.3.27) — repair telemetry, isolated trail, section-aware merge.
 - Trigger: primary Fusion egress ok but `output_validation: failed`; repair re-blocked on full context.
 - Run Trace: `repair_context_mode: repair_minimal`, `repair_mode: openrouter_single`.
 - Does not replace sanitized-target provenance slice (fold placeholder guidance there).

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.26';
+const EXTENSION_VERSION = '0.3.27';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -53,6 +53,11 @@ const WORK_TRAIL_ALLOWLIST = new Set([
   'repair_started',
   'repair_blocked',
   'repair_complete',
+  'repair_redaction_started',
+  'repair_redaction_passed',
+  'repair_redaction_blocked',
+  'repair_single_started',
+  'repair_single_done',
   'completed',
   'failed'
 ]);
@@ -74,6 +79,22 @@ const BRIDGE_STAGE_WORK_TRAIL = {
   single_done: 'lead_started',
   fusion_alias_start: 'panel_started',
   fusion_alias_done: 'panel_started'
+};
+
+const BRIDGE_REPAIR_STAGE_WORK_TRAIL = {
+  bridge_start: 'repair_started',
+  env_check: 'repair_started',
+  redaction_start: 'repair_redaction_started',
+  redaction_blocked: 'repair_redaction_blocked',
+  redaction_pass: 'repair_redaction_passed',
+  single_start: 'repair_single_started',
+  single_done: 'repair_single_done',
+  lead_start: 'repair_single_started',
+  lead_done: 'repair_single_done',
+  panel_start: 'repair_single_started',
+  panel_done: 'repair_single_started',
+  synthesis_start: 'repair_single_started',
+  synthesis_done: 'repair_single_started'
 };
 
 const ADVISORY_BRIDGE_STAGES = [
@@ -265,6 +286,14 @@ function createWorkTrail() {
       return events.length;
     }
   };
+}
+
+function normalizeRepairBridgeStageToWorkTrail(stage, text) {
+  const stageName = stage ? String(stage) : '';
+  if (stageName && BRIDGE_REPAIR_STAGE_WORK_TRAIL[stageName]) {
+    return { event: BRIDGE_REPAIR_STAGE_WORK_TRAIL[stageName], detail: sanitizeCopyMdText(text) };
+  }
+  return null;
 }
 
 function normalizeBridgeStageToWorkTrail(stage, text) {
@@ -534,11 +563,12 @@ function buildRunTraceSection(result, workerType, contextSummary, holoScorecard,
     }
   }
   lines.push('- output_validation: ' + formatOutputValidationStatus(rp.output_validation));
-  if (rp.output_validation && rp.output_validation.repair_context_mode) {
-    lines.push('- repair_context_mode: ' + rp.output_validation.repair_context_mode);
-  }
-  if (rp.output_validation && rp.output_validation.repair_mode) {
-    lines.push('- repair_mode: ' + rp.output_validation.repair_mode);
+  if (rp.output_validation && rp.output_validation.repair_attempted) {
+    lines.push('- repair_context_mode: ' + (rp.output_validation.repair_context_mode || 'unknown'));
+    lines.push('- repair_mode: ' + (rp.output_validation.repair_mode || 'unknown'));
+    if (Array.isArray(rp.output_validation.missing_sections_after_repair) && rp.output_validation.missing_sections_after_repair.length) {
+      lines.push('- missing_sections_after_repair: ' + rp.output_validation.missing_sections_after_repair.join(', '));
+    }
   }
   return lines.join('\n');
 }
@@ -996,15 +1026,42 @@ function constructWspTaskPrompt(workFocus, classification, contextQuality, worke
   return lines.join('\n');
 }
 
+function buildSectionHeaderPattern(sectionName) {
+  const escaped = String(sectionName || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp('(^|\\n)\\s*(#{1,3}\\s*)?' + escaped + '\\b', 'i');
+}
+
+function extractMarkdownSection(text, sectionName) {
+  const src = String(text || '');
+  const pattern = buildSectionHeaderPattern(sectionName);
+  const match = pattern.exec(src);
+  if (!match) {
+    return '';
+  }
+  const start = match.index + match[0].length;
+  const tail = src.slice(start);
+  const nextHeader = tail.search(/\n#{1,3}\s+\S/);
+  const body = (nextHeader === -1 ? tail : tail.slice(0, nextHeader)).trim();
+  if (!body) {
+    return '';
+  }
+  return '## ' + sectionName + '\n\n' + body;
+}
+
 function buildRepairPrompt(originalPrompt, badOutput, missingSections) {
   const sections = Array.isArray(missingSections) ? missingSections : [];
   const sanitizedDraft = sanitizeTargetSnippetForRedaction(String(badOutput || '').slice(0, 12000));
+  const requiredHeaders = sections.map((section) => '## ' + section).join('\n');
   return [
     'Repair pass: add ONLY the missing required schema sections listed below.',
     'Preserve factual content from the draft answer. Do not invent evidence, repo paths, test results, or authority.',
     'Draft text may contain egress-safe placeholders such as [SANITIZED_BLOCK:NN]; those are not repo source truth.',
     'Label new claims with WSP_97 truth labels where applicable.',
     'Missing sections: ' + (sections.length ? sections.join(', ') : '(none listed)'),
+    '',
+    'Required output format — include EVERY missing section using exactly these markdown headers (one section each):',
+    requiredHeaders || '(none listed)',
+    'Do not omit any listed section. Each section must contain at least one substantive line.',
     '',
     'Original WSP task prompt (bounded excerpt):',
     String(originalPrompt || '').slice(0, 2000),
@@ -1027,19 +1084,33 @@ function buildRepairBoundedContext() {
   ].join('\n');
 }
 
-function mergeRepairedOutput(primaryContent, repairContent) {
+function mergeRepairedOutput(primaryContent, repairContent, missingSections) {
   const primary = String(primaryContent || '').trim();
   const repair = String(repairContent || '').trim();
-  if (!repair) {
-    return primary;
+  const wanted = Array.isArray(missingSections) ? missingSections.slice() : [];
+  let merged = primary;
+  if (repair) {
+    if (/^## Decision\b/m.test(repair) && /## (?:Lead|Synthesis)\b/m.test(repair)) {
+      merged = repair;
+    } else if (!primary) {
+      merged = repair;
+    } else {
+      merged = primary + '\n\n## Schema repair supplement\n\n' + repair;
+    }
   }
-  if (/^## Decision\b/m.test(repair) && /## (?:Lead|Synthesis)\b/m.test(repair)) {
-    return repair;
+  const appended = [];
+  for (const section of wanted) {
+    if (buildSectionHeaderPattern(section).test(merged)) {
+      continue;
+    }
+    const extracted = extractMarkdownSection(repair, section);
+    if (extracted) {
+      merged += '\n\n' + extracted;
+      appended.push(section);
+    }
   }
-  if (!primary) {
-    return repair;
-  }
-  return primary + '\n\n## Schema repair supplement\n\n' + repair;
+  const stillMissing = wanted.filter((section) => !buildSectionHeaderPattern(section).test(merged));
+  return { text: merged, appendedSections: appended, stillMissing: stillMissing };
 }
 
 function isSubstantiveRedDogWorker(workerType) {
@@ -1248,6 +1319,14 @@ function wireFusionWebview(context, webview, worker, state) {
         workTrail.push(normalized.event, normalized.detail);
       }
     };
+    const onRepairBridgeProgress = (stage, text) => {
+      postStatusMessage(webview, text);
+      postProgressMessage(webview, stage, text);
+      const normalized = normalizeRepairBridgeStageToWorkTrail(stage, text);
+      if (normalized) {
+        workTrail.push(normalized.event, normalized.detail);
+      }
+    };
     let result = await callFusion(context, worker, wspTaskPrompt, contextPacket.text, systemPrompt, state.history, mode, onBridgeProgress, state, promptConstruction);
     absorbUnicodeMeta(result);
     if (result.ok && isSubstantiveRedDogWorker(workerType)) {
@@ -1261,11 +1340,18 @@ function wireFusionWebview(context, webview, worker, state) {
       };
       if (!validation.valid && validation.missingSections.length) {
         validationState.repair_attempted = true;
-        workTrail.push('repair_started');
+        validationState.repair_context_mode = 'repair_minimal';
+        validationState.repair_mode = 'openrouter_single';
+        workTrail.push('repair_started', 'repair_mode=openrouter_single; context=repair_minimal');
         postStatusAndProgress(webview, null, 'Output schema incomplete. Missing: ' + validation.missingSections.join(', ') + '. Running one repair pass...');
         const repairPrompt = buildRepairPrompt(wspTaskPrompt, result.content, validation.missingSections);
         const repairContext = buildRepairBoundedContext();
-        const repairSystemPrompt = 'Complete missing advisory markdown sections only. Output the missing section headers and bodies. Do not repeat the full document unless necessary.';
+        const repairSystemPrompt = [
+          'Complete missing advisory markdown sections only.',
+          'Output ONLY the missing section headers and bodies listed in the user prompt.',
+          'Use openrouter_single repair semantics; do not invoke a Fusion panel.',
+          'Do not repeat the full document unless necessary.'
+        ].join(' ');
         const repairResult = await callFusion(
           context,
           worker,
@@ -1274,29 +1360,30 @@ function wireFusionWebview(context, webview, worker, state) {
           repairSystemPrompt,
           [],
           'openrouter_single',
-          onBridgeProgress,
+          onRepairBridgeProgress,
           state,
           promptConstruction,
-          { promptSource: 'repair_prompt' }
+          { promptSource: 'repair_prompt', maxTokens: 2400 }
         );
         absorbUnicodeMeta(repairResult);
-        validationState.repair_context_mode = 'repair_minimal';
-        validationState.repair_mode = 'openrouter_single';
         if (repairResult.ok) {
-          const mergedContent = mergeRepairedOutput(result.content, repairResult.content);
-          const repairValidation = validateRedDogOutput(mergedContent, { substantiveArchitect: true, mode: mode });
+          const mergeResult = mergeRepairedOutput(result.content, repairResult.content, validation.missingSections);
+          validationState.repair_appended_sections = mergeResult.appendedSections;
+          const repairValidation = validateRedDogOutput(mergeResult.text, { substantiveArchitect: true, mode: mode });
           validationState.repair_ok = repairValidation.valid;
-          validationState.missing_sections_after_repair = repairValidation.missingSections;
+          validationState.missing_sections_after_repair = repairValidation.missingSections.length
+            ? repairValidation.missingSections
+            : mergeResult.stillMissing;
           if (repairValidation.valid) {
-            result = Object.assign({}, repairResult, { content: mergedContent });
+            result = Object.assign({}, repairResult, { content: mergeResult.text, mode: mode });
             validationState.validated = true;
             validationState.missing_sections = [];
-            workTrail.push('repair_complete');
+            workTrail.push('repair_complete', 'schema_repair_pass');
           } else {
             validationState.validated = false;
             validationState.output_validation_failed = true;
             validationState.repair_failure_reason = 'schema_incomplete_after_repair';
-            result.content = appendValidationFailureContent(result.content, validationState);
+            result.content = appendValidationFailureContent(mergeResult.text, validationState);
           }
         } else {
           validationState.validated = false;
@@ -1443,14 +1530,15 @@ function attachBridgeMetadata(reviewPacket, bridgeMeta) {
   return Object.assign({}, reviewPacket, meta);
 }
 
-function callFusion(context, worker, prompt, boundedContext, systemPrompt, history, mode, onProgress, state, bridgeMeta, callOptions) {
+function callFusion(context, worker, prompt, boundedContext, systemPrompt, history, mode, onProgress, state, bridgeMeta, callOptionsArg) {
   return new Promise((resolve) => {
     const root = workspaceRoot();
     const script = path.join(root, 'scripts', 'advisory_model_once.py');
     const config = vscode.workspace.getConfiguration('foundupsFusion');
     const configuredPython = config.get('pythonPath') || 'python';
     const interpreter = resolvePythonInterpreter(root, configuredPython);
-    const promptSource = callOptions && callOptions.promptSource ? callOptions.promptSource : 'prompt';
+    const callOptions = callOptionsArg && typeof callOptionsArg === 'object' ? callOptionsArg : {};
+    const promptSource = callOptions.promptSource ? callOptions.promptSource : 'prompt';
     const promptNorm = normalizeBridgeTextForUnicode(prompt, promptSource);
     const contextNorm = normalizeBridgeTextForUnicode(boundedContext, 'context');
     const unicodeMeta = mergeUnicodeNormalizationMeta(null, Object.assign({}, promptNorm, { unicode_normalization_source: promptSource }));
@@ -1503,7 +1591,7 @@ function callFusion(context, worker, prompt, boundedContext, systemPrompt, histo
       history,
       lead_model: worker.lead,
       panel_models: worker.panel,
-      max_tokens: 2200,
+      max_tokens: callOptions.maxTokens || 2200,
       temperature: 0.2,
       timeout: mode === 'foundups_fusion' ? 120 : 90,
       bridge_meta: Object.assign({}, bridgeMeta || {}, {
@@ -2602,6 +2690,10 @@ module.exports = {
   buildRepairPrompt,
   buildRepairBoundedContext,
   mergeRepairedOutput,
+  extractMarkdownSection,
+  buildSectionHeaderPattern,
+  normalizeRepairBridgeStageToWorkTrail,
+  BRIDGE_REPAIR_STAGE_WORK_TRAIL,
   constructWspTaskPrompt,
   redactedDigest,
   resolvePythonInterpreter,

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.25';
+const EXTENSION_VERSION = '0.3.26';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -534,6 +534,12 @@ function buildRunTraceSection(result, workerType, contextSummary, holoScorecard,
     }
   }
   lines.push('- output_validation: ' + formatOutputValidationStatus(rp.output_validation));
+  if (rp.output_validation && rp.output_validation.repair_context_mode) {
+    lines.push('- repair_context_mode: ' + rp.output_validation.repair_context_mode);
+  }
+  if (rp.output_validation && rp.output_validation.repair_mode) {
+    lines.push('- repair_mode: ' + rp.output_validation.repair_mode);
+  }
   return lines.join('\n');
 }
 
@@ -992,18 +998,48 @@ function constructWspTaskPrompt(workFocus, classification, contextQuality, worke
 
 function buildRepairPrompt(originalPrompt, badOutput, missingSections) {
   const sections = Array.isArray(missingSections) ? missingSections : [];
+  const sanitizedDraft = sanitizeTargetSnippetForRedaction(String(badOutput || '').slice(0, 12000));
   return [
-    'Repair pass: preserve the existing answer content and add only the missing required schema sections.',
-    'Do not invent evidence, repo paths, test results, or authority.',
-    'Label claims with WSP_97 truth labels where applicable.',
+    'Repair pass: add ONLY the missing required schema sections listed below.',
+    'Preserve factual content from the draft answer. Do not invent evidence, repo paths, test results, or authority.',
+    'Draft text may contain egress-safe placeholders such as [SANITIZED_BLOCK:NN]; those are not repo source truth.',
+    'Label new claims with WSP_97 truth labels where applicable.',
     'Missing sections: ' + (sections.length ? sections.join(', ') : '(none listed)'),
     '',
-    'Original WSP task prompt:',
-    String(originalPrompt || '').slice(0, 4000),
+    'Original WSP task prompt (bounded excerpt):',
+    String(originalPrompt || '').slice(0, 2000),
     '',
-    'Draft answer to repair:',
-    String(badOutput || '').slice(0, 12000)
+    'Draft answer to repair (sanitized for redaction gate):',
+    sanitizedDraft.text
   ].join('\n');
+}
+
+function buildRepairBoundedContext() {
+  return [
+    '## REPAIR_PASS_BOUNDED_CONTEXT',
+    'Schema repair pass only. Full repo/HoloIndex context was consumed in the primary advisory pass.',
+    'Do not treat this packet as fresh repo evidence. Complete missing schema sections from the draft in the user prompt.',
+    'Target recall snippets may contain egress-safe placeholders; do not claim placeholders exist in committed repo source.',
+    '',
+    '## WSP_OPERATING_CONTRACT',
+    '- Advisory only. No shell, repo modification, credential, browser, deploy, or runtime control.',
+    '- Apply WSP_97 truth labels on any new claims.'
+  ].join('\n');
+}
+
+function mergeRepairedOutput(primaryContent, repairContent) {
+  const primary = String(primaryContent || '').trim();
+  const repair = String(repairContent || '').trim();
+  if (!repair) {
+    return primary;
+  }
+  if (/^## Decision\b/m.test(repair) && /## (?:Lead|Synthesis)\b/m.test(repair)) {
+    return repair;
+  }
+  if (!primary) {
+    return repair;
+  }
+  return primary + '\n\n## Schema repair supplement\n\n' + repair;
 }
 
 function isSubstantiveRedDogWorker(workerType) {
@@ -1228,26 +1264,31 @@ function wireFusionWebview(context, webview, worker, state) {
         workTrail.push('repair_started');
         postStatusAndProgress(webview, null, 'Output schema incomplete. Missing: ' + validation.missingSections.join(', ') + '. Running one repair pass...');
         const repairPrompt = buildRepairPrompt(wspTaskPrompt, result.content, validation.missingSections);
+        const repairContext = buildRepairBoundedContext();
+        const repairSystemPrompt = 'Complete missing advisory markdown sections only. Output the missing section headers and bodies. Do not repeat the full document unless necessary.';
         const repairResult = await callFusion(
           context,
           worker,
           repairPrompt,
-          contextPacket.text,
-          systemPrompt + '\n\nRepair pass: add missing schema sections only. Do not invent evidence.',
-          state.history,
-          mode,
+          repairContext,
+          repairSystemPrompt,
+          [],
+          'openrouter_single',
           onBridgeProgress,
           state,
           promptConstruction,
           { promptSource: 'repair_prompt' }
         );
         absorbUnicodeMeta(repairResult);
+        validationState.repair_context_mode = 'repair_minimal';
+        validationState.repair_mode = 'openrouter_single';
         if (repairResult.ok) {
-          const repairValidation = validateRedDogOutput(repairResult.content || '', { substantiveArchitect: true, mode: mode });
+          const mergedContent = mergeRepairedOutput(result.content, repairResult.content);
+          const repairValidation = validateRedDogOutput(mergedContent, { substantiveArchitect: true, mode: mode });
           validationState.repair_ok = repairValidation.valid;
           validationState.missing_sections_after_repair = repairValidation.missingSections;
           if (repairValidation.valid) {
-            result = repairResult;
+            result = Object.assign({}, repairResult, { content: mergedContent });
             validationState.validated = true;
             validationState.missing_sections = [];
             workTrail.push('repair_complete');
@@ -2559,6 +2600,8 @@ module.exports = {
   resolveModelMode,
   validateRedDogOutput,
   buildRepairPrompt,
+  buildRepairBoundedContext,
+  mergeRepairedOutput,
   constructWspTaskPrompt,
   redactedDigest,
   resolvePythonInterpreter,

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups®Agent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.26",
+    "version":  "0.3.27",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups®Agent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.25",
+    "version":  "0.3.26",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/TestModLog.md
+++ b/extensions/foundups_advisory_workers/tests/TestModLog.md
@@ -1,5 +1,14 @@
 # Foundups®Agent TestModLog
 
+## 2026-06-14 - REDDOG_OUTPUT_SCHEMA_REPAIR_HARDENING addendum (OSR-007..OSR-010)
+
+| ID | Asserts |
+| --- | --- |
+| OSR-007 | Primary missing Evidence/Architect Trace/Verification gaps/Next safest step; supplement completes schema |
+| OSR-008 | Repair trail maps single/panel stages to `repair_single_started` |
+| OSR-009 | Repair prompt lists explicit `## Section` headers |
+| OSR-010 | Failed repair still exposes repair metadata + missing_sections_after_repair |
+
 ## 2026-06-14 - REDDOG_OUTPUT_SCHEMA_REPAIR_HARDENING_PHASE1 (OSR-001..OSR-006)
 
 | ID | Asserts |

--- a/extensions/foundups_advisory_workers/tests/TestModLog.md
+++ b/extensions/foundups_advisory_workers/tests/TestModLog.md
@@ -1,5 +1,18 @@
 # Foundups®Agent TestModLog
 
+## 2026-06-14 - REDDOG_OUTPUT_SCHEMA_REPAIR_HARDENING_PHASE1 (OSR-001..OSR-006)
+
+| ID | Asserts |
+| --- | --- |
+| OSR-001 | `buildRepairBoundedContext()` minimal, declares repair pass |
+| OSR-002 | Repair context notes egress-safe placeholders |
+| OSR-003 | Minimal repair context passes Python gate |
+| OSR-004 | `buildRepairPrompt` sanitizes block literals; gate passes |
+| OSR-005 | `mergeRepairedOutput` satisfies Fusion schema when supplemented |
+| OSR-006 | Run Trace exposes `repair_context_mode` / `repair_mode` |
+
+Regression: UNI, TCI, THG unchanged.
+
 ## 2026-06-14 - ADDENDUM B bridge UTF-8 stdin (UNI-008..UNI-010)
 
 | ID | Asserts |

--- a/extensions/foundups_advisory_workers/tests/fixtures.js
+++ b/extensions/foundups_advisory_workers/tests/fixtures.js
@@ -27,6 +27,8 @@ const REPAIR_DRAFT_WITH_BLOCK_LITERALS = [
 ].join('\n');
 
 const REPAIR_SUPPLEMENT_SECTIONS = [
+  '## Evidence',
+  'E1: OBSERVED — primary pass completed with bounded context attached.',
   '## Proposed fixes',
   'F1: defer until verified.',
   '## Uncertainties',
@@ -44,6 +46,18 @@ const REPAIR_SUPPLEMENT_SECTIONS = [
   '## Next safest step',
   'Re-run with narrower context.'
 ].join('\n');
+
+const REPAIR_TAIL_SUPPLEMENT = [
+  '## Evidence',
+  'E1: OBSERVED — primary Fusion pass completed with routing summary attached.',
+  '## Architect Trace',
+  '- Evidence retrieved: primary lead/panel/synthesis excerpts from prior pass.',
+  '- Alternatives considered: full re-run rejected; schema supplement chosen.',
+  '## Verification gaps',
+  'NEEDS_VERIFICATION: whether supplement fully satisfies local schema validator.',
+  '## Next safest step',
+  '012 confirms Run Trace shows repair_minimal + openrouter_single, then land if validation passes.'
+].join('\n\n');
 
 const TARGET_READ_DENIED_PATHS = [
   ['C:/Windows/System32/drivers/etc/hosts', 'absolute path'],
@@ -64,5 +78,6 @@ module.exports = {
   EMDASH_UNICODE_CONTEXT,
   REPAIR_DRAFT_WITH_BLOCK_LITERALS,
   REPAIR_SUPPLEMENT_SECTIONS,
+  REPAIR_TAIL_SUPPLEMENT,
   TARGET_READ_DENIED_PATHS
 };

--- a/extensions/foundups_advisory_workers/tests/fixtures.js
+++ b/extensions/foundups_advisory_workers/tests/fixtures.js
@@ -16,6 +16,35 @@ const BLOCKED_POLICY_CONTEXT = 'Bounded repo context with grant authority and me
 
 const EMDASH_UNICODE_CONTEXT = 'PR #718 \u2014 `WSP_109_FOUNDUP_ONBOARDI' + ' trailing HoloIndex context for UTF-8 bridge probe.';
 
+const REPAIR_DRAFT_WITH_BLOCK_LITERALS = [
+  '## Decision',
+  'Review redaction_gate_passed handling and grant authority paths.',
+  'internal governance instruction noted in draft.',
+  '## Findings',
+  'F1: example',
+  '## Evidence',
+  'E1: example'
+].join('\n');
+
+const REPAIR_SUPPLEMENT_SECTIONS = [
+  '## Proposed fixes',
+  'F1: defer until verified.',
+  '## Uncertainties',
+  'NEEDS_VERIFICATION: none.',
+  '## Architect Trace',
+  'Evidence retrieved from primary pass.',
+  '## WSP_97 Truth Labels',
+  '- OBSERVED: primary pass completed.',
+  '## WSP_15 Priority',
+  '| Action | Priority |',
+  '| --- | --- |',
+  '| Verify | P2 |',
+  '## Verification gaps',
+  'None listed.',
+  '## Next safest step',
+  'Re-run with narrower context.'
+].join('\n');
+
 const TARGET_READ_DENIED_PATHS = [
   ['C:/Windows/System32/drivers/etc/hosts', 'absolute path'],
   ['../outside.txt', 'traversal'],
@@ -33,5 +62,7 @@ module.exports = {
   MALFORMED_UNICODE_CONTEXT,
   BLOCKED_POLICY_CONTEXT,
   EMDASH_UNICODE_CONTEXT,
+  REPAIR_DRAFT_WITH_BLOCK_LITERALS,
+  REPAIR_SUPPLEMENT_SECTIONS,
   TARGET_READ_DENIED_PATHS
 };

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -79,8 +79,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.26', 'package version must be 0.3.26');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.26'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.27', 'package version must be 0.3.27');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.27'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups®Agent', 'display name must be Foundups®Agent');
 includes(JSON.stringify(pkg), 'Foundups®Agent: Open', 'command title must use Foundups®Agent');
@@ -97,7 +97,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.26', 'README version mismatch');
+includes(readme, 'Version: 0.3.27', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -163,6 +163,9 @@ includes(extensionJs, 'function buildRepairBoundedContext', 'repair bounded cont
 includes(extensionJs, 'function mergeRepairedOutput', 'merge repaired output helper missing');
 includes(extensionJs, 'repair_minimal', 'repair context mode telemetry missing');
 includes(extensionJs, 'egress-safe placeholders', 'repair prompt placeholder provenance missing');
+includes(extensionJs, 'repair_single_started', 'repair single trail event missing');
+includes(extensionJs, 'normalizeRepairBridgeStageToWorkTrail', 'repair trail normalizer missing');
+includes(extensionJs, 'function extractMarkdownSection', 'extractMarkdownSection missing');
 includes(extensionJs, 'function modeSelectionReasoning', 'mode selection reasoning missing');
 includes(extensionJs, 'Architect Trace', 'architect trace schema missing');
 includes(extensionJs, 'Verification gaps', 'verification gaps schema missing');
@@ -288,13 +291,41 @@ const blockDraftPrompt = orchestrator.buildRepairPrompt('safe task', fixtures.RE
 assert(!blockDraftPrompt.includes('grant authority'), 'OSR-004: repair prompt must sanitize block literals in draft');
 assertFusionRedactionGatePasses(blockDraftPrompt, 'OSR-004: sanitized repair prompt must pass gate');
 
-const fusionPrimary = '## RedDog Routing\n\n## Lead (z-ai/glm-5.2)\n\n## Decision\n\nok\n\n## Findings\n\nF1\n\n## Evidence\n\nE1\n\n## Critic (deepseek/deepseek-v4-pro)\n\nNone\n\n## Synthesis (z-ai/glm-5.2)\n\n## Decision\n\nok\n\n## Findings\n\nF1\n\n## Evidence\n\nE1';
-const mergedRepair = orchestrator.mergeRepairedOutput(fusionPrimary, fixtures.REPAIR_SUPPLEMENT_SECTIONS);
-const mergedValidation = orchestrator.validateRedDogOutput(mergedRepair, { substantiveArchitect: true, mode: 'foundups_fusion' });
+const fusionPrimary = '## RedDog Routing\n\n## Lead (z-ai/glm-5.2)\n\n## Decision\n\nok\n\n## Findings\n\nF1\n\n## Critic (deepseek/deepseek-v4-pro)\n\nNone\n\n## Synthesis (z-ai/glm-5.2)\n\n## Decision\n\nok\n\n## Findings\n\nF1';
+const mergedRepair = orchestrator.mergeRepairedOutput(
+  fusionPrimary,
+  fixtures.REPAIR_SUPPLEMENT_SECTIONS,
+  ['Proposed fixes', 'Uncertainties', 'WSP_97 Truth Labels', 'WSP_15 Priority', 'Verification gaps', 'Next safest step', 'Architect Trace', 'Evidence']
+);
+const mergedValidation = orchestrator.validateRedDogOutput(mergedRepair.text, { substantiveArchitect: true, mode: 'foundups_fusion' });
 assert.strictEqual(mergedValidation.valid, true, 'OSR-005: merged primary+supplement must satisfy schema');
-assert(mergedRepair.includes('## Schema repair supplement'), 'OSR-005: merged output must retain supplement marker');
+assert(mergedRepair.text.includes('## Schema repair supplement'), 'OSR-005: merged output must retain supplement marker');
 
-const repairTrace = orchestrator.buildRunTraceSection({
+const primaryMissingTail = fusionPrimary;
+const combinedSupplement = fixtures.REPAIR_TAIL_SUPPLEMENT + '\n\n' + fixtures.REPAIR_SUPPLEMENT_SECTIONS;
+const tailMerge = orchestrator.mergeRepairedOutput(
+  primaryMissingTail,
+  combinedSupplement,
+  ['Evidence', 'Verification gaps', 'Next safest step', 'Architect Trace', 'Proposed fixes', 'Uncertainties', 'WSP_97 Truth Labels', 'WSP_15 Priority']
+);
+includes(tailMerge.text, '## Evidence', 'OSR-007: tail merge must include Evidence');
+includes(tailMerge.text, '## Verification gaps', 'OSR-007: tail merge must include Verification gaps');
+includes(tailMerge.text, '## Next safest step', 'OSR-007: tail merge must include Next safest step');
+includes(tailMerge.text, '## Architect Trace', 'OSR-007: tail merge must include Architect Trace');
+const tailValidation = orchestrator.validateRedDogOutput(tailMerge.text, { substantiveArchitect: true, mode: 'foundups_fusion' });
+assert.strictEqual(tailValidation.valid, true, 'OSR-007: tail supplement must complete schema');
+
+const repairStage = orchestrator.normalizeRepairBridgeStageToWorkTrail('single_start', 'Regular OpenRouter request started');
+assert.strictEqual(repairStage.event, 'repair_single_started', 'OSR-008: repair single_start maps to repair_single_started');
+const repairPanelStage = orchestrator.normalizeRepairBridgeStageToWorkTrail('panel_start', 'Panel requests started');
+assert.strictEqual(repairPanelStage.event, 'repair_single_started', 'OSR-008: repair panel_start must not emit panel_started');
+
+const repairPromptSections = orchestrator.buildRepairPrompt('task', 'draft', ['Evidence', 'Architect Trace', 'Next safest step']);
+includes(repairPromptSections, '## Evidence', 'OSR-009: repair prompt must list required headers');
+includes(repairPromptSections, '## Architect Trace', 'OSR-009: repair prompt must list Architect Trace header');
+includes(repairPromptSections, '## Next safest step', 'OSR-009: repair prompt must list Next safest step header');
+
+const repairTraceFailed = orchestrator.buildRunTraceSection({
   review_packet: {
     task_classification: { tier: 'HIGH' },
     resolved_effort: 'high',
@@ -304,16 +335,18 @@ const repairTrace = orchestrator.buildRunTraceSection({
     principal_model: 'z-ai/glm-5.2',
     panel_models: ['deepseek/deepseek-v4-pro'],
     output_validation: {
-      validated: true,
+      validated: false,
       repair_attempted: true,
-      repair_ok: true,
+      repair_ok: false,
       repair_context_mode: 'repair_minimal',
-      repair_mode: 'openrouter_single'
+      repair_mode: 'openrouter_single',
+      missing_sections_after_repair: ['Evidence', 'Next safest step']
     }
   }
 }, 'reddog_architect', 'Repo context attached', null, 'high');
-includes(repairTrace, 'repair_context_mode: repair_minimal', 'OSR-006: Run Trace must expose repair context mode');
-includes(repairTrace, 'repair_mode: openrouter_single', 'OSR-006: Run Trace must expose repair mode');
+includes(repairTraceFailed, 'repair_context_mode: repair_minimal', 'OSR-010: Run Trace must expose repair context on failed repair');
+includes(repairTraceFailed, 'repair_mode: openrouter_single', 'OSR-010: Run Trace must expose repair mode on failed repair');
+includes(repairTraceFailed, 'missing_sections_after_repair: Evidence, Next safest step', 'OSR-010: Run Trace must list remaining missing sections');
 
 const handoffContext = orchestrator.skillzWardrobeRolodexContext(root, 'process all youtube comments with existing skillz', 12000);
 includes(handoffContext, 'Skillz/Wardrobe/Rolodex discovery', 'handoff context header missing');
@@ -633,7 +666,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.26'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.27'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -647,7 +680,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.26'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.27'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -659,7 +692,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.26'", 'bounded context must include extension.js source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.27'", 'bounded context must include extension.js source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -79,8 +79,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.25', 'package version must be 0.3.25');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.25'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.26', 'package version must be 0.3.26');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.26'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups®Agent', 'display name must be Foundups®Agent');
 includes(JSON.stringify(pkg), 'Foundups®Agent: Open', 'command title must use Foundups®Agent');
@@ -97,7 +97,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.25', 'README version mismatch');
+includes(readme, 'Version: 0.3.26', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -159,7 +159,10 @@ includes(extensionJs, 'function resolveModelMode', 'resolveModelMode missing');
 includes(extensionJs, 'function validateRedDogOutput', 'validateRedDogOutput missing');
 includes(extensionJs, 'function buildRepairPrompt', 'buildRepairPrompt missing');
 includes(extensionJs, 'output_validation', 'review packet validator status missing');
-includes(extensionJs, 'Do not invent evidence', 'repair prompt evidence guard missing');
+includes(extensionJs, 'function buildRepairBoundedContext', 'repair bounded context helper missing');
+includes(extensionJs, 'function mergeRepairedOutput', 'merge repaired output helper missing');
+includes(extensionJs, 'repair_minimal', 'repair context mode telemetry missing');
+includes(extensionJs, 'egress-safe placeholders', 'repair prompt placeholder provenance missing');
 includes(extensionJs, 'function modeSelectionReasoning', 'mode selection reasoning missing');
 includes(extensionJs, 'Architect Trace', 'architect trace schema missing');
 includes(extensionJs, 'Verification gaps', 'verification gaps schema missing');
@@ -271,7 +274,46 @@ assert(validation.missingSections.includes('Proposed fixes'), 'validator must li
 
 const repairPrompt = orchestrator.buildRepairPrompt('task', badOutput, validation.missingSections);
 includes(repairPrompt, 'Do not invent evidence', 'repair prompt must forbid invented evidence');
-includes(repairPrompt, 'preserve the existing answer content', 'repair prompt must be bounded');
+includes(repairPrompt, 'egress-safe placeholders', 'repair prompt must warn on sanitized placeholders');
+includes(repairPrompt, 'Preserve factual content', 'repair prompt must preserve draft content');
+
+// OSR-001..OSR-006 REDDOG_OUTPUT_SCHEMA_REPAIR_HARDENING_PHASE1
+const repairContext = orchestrator.buildRepairBoundedContext();
+assert(repairContext.length < 2000, 'OSR-001: repair context must stay minimal');
+includes(repairContext, 'REPAIR_PASS_BOUNDED_CONTEXT', 'OSR-001: repair context must declare repair pass');
+includes(repairContext, 'egress-safe placeholders', 'OSR-002: repair context must note placeholder provenance');
+assertFusionRedactionGatePasses(repairContext, 'OSR-003: minimal repair context must pass gate');
+
+const blockDraftPrompt = orchestrator.buildRepairPrompt('safe task', fixtures.REPAIR_DRAFT_WITH_BLOCK_LITERALS, ['Proposed fixes']);
+assert(!blockDraftPrompt.includes('grant authority'), 'OSR-004: repair prompt must sanitize block literals in draft');
+assertFusionRedactionGatePasses(blockDraftPrompt, 'OSR-004: sanitized repair prompt must pass gate');
+
+const fusionPrimary = '## RedDog Routing\n\n## Lead (z-ai/glm-5.2)\n\n## Decision\n\nok\n\n## Findings\n\nF1\n\n## Evidence\n\nE1\n\n## Critic (deepseek/deepseek-v4-pro)\n\nNone\n\n## Synthesis (z-ai/glm-5.2)\n\n## Decision\n\nok\n\n## Findings\n\nF1\n\n## Evidence\n\nE1';
+const mergedRepair = orchestrator.mergeRepairedOutput(fusionPrimary, fixtures.REPAIR_SUPPLEMENT_SECTIONS);
+const mergedValidation = orchestrator.validateRedDogOutput(mergedRepair, { substantiveArchitect: true, mode: 'foundups_fusion' });
+assert.strictEqual(mergedValidation.valid, true, 'OSR-005: merged primary+supplement must satisfy schema');
+assert(mergedRepair.includes('## Schema repair supplement'), 'OSR-005: merged output must retain supplement marker');
+
+const repairTrace = orchestrator.buildRunTraceSection({
+  review_packet: {
+    task_classification: { tier: 'HIGH' },
+    resolved_effort: 'high',
+    resolved_mode: 'foundups_fusion',
+    resolved_context: 'wsp_holo_skillz',
+    mode_selection_reasoning: 'Fusion manual panel',
+    principal_model: 'z-ai/glm-5.2',
+    panel_models: ['deepseek/deepseek-v4-pro'],
+    output_validation: {
+      validated: true,
+      repair_attempted: true,
+      repair_ok: true,
+      repair_context_mode: 'repair_minimal',
+      repair_mode: 'openrouter_single'
+    }
+  }
+}, 'reddog_architect', 'Repo context attached', null, 'high');
+includes(repairTrace, 'repair_context_mode: repair_minimal', 'OSR-006: Run Trace must expose repair context mode');
+includes(repairTrace, 'repair_mode: openrouter_single', 'OSR-006: Run Trace must expose repair mode');
 
 const handoffContext = orchestrator.skillzWardrobeRolodexContext(root, 'process all youtube comments with existing skillz', 12000);
 includes(handoffContext, 'Skillz/Wardrobe/Rolodex discovery', 'handoff context header missing');
@@ -591,7 +633,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.25'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.26'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -605,7 +647,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.25'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.26'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -617,7 +659,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.25'", 'bounded context must include extension.js source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.26'", 'bounded context must include extension.js source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');


### PR DESCRIPTION
## Summary
- Repair pass no longer resends full HoloIndex context (42k); uses `buildRepairBoundedContext()` only.
- Sanitizes draft output in repair prompt before redaction gate.
- Routes repair via `openrouter_single`; merges supplement into primary Fusion output.
- Run Trace: `repair_context_mode: repair_minimal`, `repair_mode: openrouter_single`.
- Version **0.3.26**. Tests OSR-001..006.

## Problem
Primary Fusion egress succeeded but schema validation failed; repair pass re-sent full context and got `redaction_blocked`.

## Validation
- node --check extension.js PASS
- verify_extension_contract.js (TCI + THG + UNI + OSR) PASS
- git diff --check PASS

## Test plan
- [ ] 012 re-run RedDog Architect smoke; expect repair pass redaction passed if validation triggers repair
- [ ] `output_validation: passed` or repair completes without `repair_failure_reason: redaction_blocked`

## Out of scope
Sanitized target provenance slice (queued separately), made_network_call telemetry, mojibake.
