### PR TITLE
feat(reddog): validate governed repo work orders in dry-run

### DIFF
--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -71,6 +71,8 @@ RedDog is the 0102 architect interface — **not an authority owner**. RedDog re
 | Authority contract + schema | `docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md` |
 | Slice queue | `extensions/foundups_advisory_workers/ROADMAP.md` |
 
+**Dry-run validator (no mutation):** `modules/communication/moltbot_bridge/src/reddog_governed_work_order_dryrun.py` — validates envelope + HoloIndex evidence packet; returns `WOULD_ACCEPT` / `WOULD_REJECT` / `WOULD_ACCEPT_WITH_RETRIEVAL_GAP`. Extension v0.3.27 does not invoke it yet.
+
 **Specified flow (not implemented in extension v0.3.27):**
 
 ```text
@@ -295,7 +297,8 @@ Formal contract:
 | Advisory-only; no shell/repo/browser/OpenClaw/Hermes execution | OBSERVED |
 | Redaction gate before OpenRouter | OBSERVED |
 | Governed handoff contract (typed WRE dispatch) | SPECIFIED_NOT_IMPLEMENTED |
-| Governed repo work order (`RedDogGovernedWorkOrder`) | SPECIFIED_NOT_IMPLEMENTED (schema in audit doc) |
+| Governed repo work order dry-run validator | OBSERVED (Python module); extension does not invoke yet |
+| Governed repo work order (`RedDogGovernedWorkOrder`) | SPECIFIED_NOT_IMPLEMENTED (runtime emission from extension) |
 | GitHub permission snapshot per work order | SPECIFIED_NOT_IMPLEMENTED |
 | F0 autonomous merge | SPECIFIED_NOT_IMPLEMENTED |
 | WSP Applicability Preflight | SPECIFIED_NOT_IMPLEMENTED |

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -1,5 +1,15 @@
 # Foundups®Agent ModLog
 
+## 2026-06-28 - REDDOG_GOVERNED_REPO_WORK_ORDER_DRYRUN_PHASE1
+
+- Added `reddog_governed_work_order_dryrun.py` — typed `RedDogGovernedWorkOrder` + `HoloIndexEvidencePacket` dry-run validator.
+- Decisions: `WOULD_ACCEPT`, `WOULD_REJECT`, `WOULD_ACCEPT_WITH_RETRIEVAL_GAP`; receipt digest; in-memory nonce replay guard.
+- Gates: required fields, expiry, nonce, forbidden ops/paths, main mutation block, HoloIndex evidence (Addendum A), WAE-L1 mapping docstring (Addendum B).
+- Tests: 13 pytest cases (accept + all rejection paths).
+- No GitHub, branch, PR, write, shell, or merge calls.
+
+WSP: WSP_34, WSP_50, WSP_97, WSP_22.
+
 ## 2026-06-28 - REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1
 
 - Added `docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md` — authority model, `RedDogGovernedWorkOrder` schema, HoloIndex discoverability + reindex gate.

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -146,7 +146,8 @@ Output is prefixed with a visible **RedDog Routing** block (tier, effort, mode, 
 | Fusion Lead/Critic/Synthesis structure validated | OBSERVED |
 | Governed handoff contract (typed WRE dispatch) | SPECIFIED_NOT_IMPLEMENTED |
 | Governed repo work order contract | OBSERVED (audit doc); RUNTIME_EMISSION SPECIFIED_NOT_IMPLEMENTED |
-| RedDogGovernedWorkOrder schema | SPECIFIED_NOT_IMPLEMENTED (draft in audit doc) |
+| RedDogGovernedWorkOrder dry-run validator | OBSERVED (OpenClaw bridge module) |
+| RedDogGovernedWorkOrder schema | SPECIFIED_NOT_IMPLEMENTED (extension emission) |
 | GitHub permission probe per work order | SPECIFIED_NOT_IMPLEMENTED |
 | F0 autonomous merge | SPECIFIED_NOT_IMPLEMENTED (not planned) |
 | WSP Applicability Preflight before work order | SPECIFIED_NOT_IMPLEMENTED |

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -214,9 +214,12 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 
 ### REDDOG_GOVERNED_REPO_WORK_ORDER_DRYRUN_PHASE1
 
-- **Status:** **P0 QUEUED** — first implementation slice after contract PR merges.
-- **Purpose:** validate work-order envelope shape and gate semantics without real branch/PR/write.
-- **Prerequisite:** `REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1` merged.
+- **Status:** **PR-READY** — dry-run validator; no GitHub/branch/PR/write.
+- **Module:** `modules/communication/moltbot_bridge/src/reddog_governed_work_order_dryrun.py`
+- **Tests:** `modules/communication/moltbot_bridge/tests/test_reddog_governed_work_order_dryrun.py`
+- Validates `RedDogGovernedWorkOrder` + `HoloIndexEvidencePacket`; returns `WOULD_ACCEPT` / `WOULD_REJECT` / `WOULD_ACCEPT_WITH_RETRIEVAL_GAP` receipt.
+- **Prerequisite:** #889 contract merged.
+- **Blocks:** GitHub permission probe until dry-run gate passes review.
 
 ### REDDOG_CONTEXT_TARGET_CONTENT_INCLUSION_PHASE1
 

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -176,6 +176,11 @@ includes(extensionJs, 'mode_selection_reasoning', 'review packet mode selection 
 includes(readme, 'WSP_97 Truth Table', 'README WSP_97 truth table missing');
 includes(roadmap, 'REDDOG_GOVERNED_HANDOFF_CONTRACT_PHASE1', 'governed handoff roadmap slice missing');
 includes(auditDoc, 'RedDogGovernedWorkOrder', 'audit doc schema missing');
+const dryrunPy = fs.readFileSync(path.join(root, 'modules', 'communication', 'moltbot_bridge', 'src', 'reddog_governed_work_order_dryrun.py'), 'utf8');
+includes(dryrunPy, 'validate_work_order_dryrun', 'dry-run validator missing');
+includes(dryrunPy, 'WOULD_ACCEPT_WITH_RETRIEVAL_GAP', 'dry-run retrieval gap decision missing');
+includes(dryrunPy, 'HoloIndexEvidencePacket', 'HoloIndex evidence packet missing');
+includes(iface, 'reddog_governed_work_order_dryrun.py', 'INTERFACE dry-run module pointer missing');
 includes(auditDoc, 'authenticated principal', 'audit doc principal wording missing');
 includes(auditDoc, 'HoloIndex Discoverability', 'audit doc discoverability section missing');
 includes(auditDoc, 'F0_AUTONOMOUS_MERGE_NOT_IMPLEMENTED', 'audit doc F0 merge row missing');

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,15 @@
 # ModLog - moltbot_bridge
 
+## 2026-06-28: REDDOG_GOVERNED_REPO_WORK_ORDER_DRYRUN_PHASE1
+
+**Slice:** External RedDog lane dry-run validator (shared with future OpenClaw policy gate)
+**WSP:** WSP_34, WSP_50, WSP_97, WSP_22
+
+- ADD `src/reddog_governed_work_order_dryrun.py` — `validate_work_order_dryrun()` with typed envelope, HoloIndex evidence gate, nonce replay guard, receipt digest.
+- ADD `tests/test_reddog_governed_work_order_dryrun.py` — 13 tests (accept + rejection paths).
+- WAE-L1 field mapping documented in module docstring (Addendum B); no WAE runtime changes.
+- No GitHub, branch, PR, write, shell, or merge.
+
 ## 2026-06-19: Fusion ALIAS live path -- valve-gated OFF, redaction-gated, advisory-only (W6)
 
 **Author**: 0102 (Worker-Lane W6, AUTHOR + internal SENTINEL)

--- a/modules/communication/moltbot_bridge/src/reddog_governed_work_order_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_governed_work_order_dryrun.py
@@ -1,0 +1,461 @@
+"""RedDog governed repo work-order dry-run validator (no mutation).
+
+Slice: REDDOG_GOVERNED_REPO_WORK_ORDER_DRYRUN_PHASE1
+Contract: docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md
+
+RedDog receives bounded delegated capability per work order after fresh verification.
+This module validates envelope + policy semantics only — no GitHub, branch, PR, write,
+shell, or merge.
+
+WAE-L1 alignment (Addendum B — mapping only, no WAE refactor this slice):
+| WAE-L1 direction field      | RedDogGovernedWorkOrder field   |
+|-----------------------------|---------------------------------|
+| direction_id                | work_order_id                   |
+| created_at                  | created_at                      |
+| principal_id                | authenticated_principal         |
+| target_repo                 | repo_full_name                  |
+| proposed_action             | requested_operation             |
+| authority_hint              | authority_tier                  |
+| path_scope                  | allowed_paths / denied_paths    |
+| branch_hint                 | branch_name / base_ref          |
+| holo_evidence_packet        | holoindex_evidence              |
+| wsp_tags                    | wsp_applicability               |
+| skillz_hints                | skillz_candidates               |
+| advisory_digest             | evidence_digest                 |
+| source_packet               | advisory_only_source_packet     |
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Mapping, MutableSet, Optional, Sequence, Union
+
+DECISION_ACCEPT = "WOULD_ACCEPT"
+DECISION_REJECT = "WOULD_REJECT"
+DECISION_ACCEPT_WITH_GAP = "WOULD_ACCEPT_WITH_RETRIEVAL_GAP"
+
+RETRIEVAL_QUALITIES = frozenset({"HIGH", "MEDIUM", "LOW", "INDEX_GAP"})
+
+WRITE_SENSITIVE_OPERATIONS = frozenset(
+    {
+        "repo",
+        "write",
+        "branch",
+        "pr",
+        "source",
+        "feature_slice",
+        "test_fix",
+        "docs_patch",
+        "merge_request",
+        "security",
+        "auth",
+        "runtime",
+    }
+)
+
+DOCS_ONLY_OPERATIONS = frozenset({"audit_only", "docs_audit", "docs_only"})
+
+FORBIDDEN_OPERATION_TOKENS = frozenset(
+    {
+        "admin",
+        "permission_management",
+        "grant_permission",
+        "merge_autonomous",
+        "autonomous_merge",
+        "credential",
+        "secret",
+        "oauth_token",
+        "deploy_production",
+    }
+)
+
+FORBIDDEN_PATH_GLOBS = (
+    ".env",
+    ".env.*",
+    "**/.env",
+    "**/credentials*",
+    "**/secrets/**",
+    "**/.git/**",
+)
+
+PROTECTED_BASE_REFS = frozenset({"main", "master"})
+
+
+@dataclass
+class RepoPermissionSnapshot:
+    permission_level: str
+    captured_at: str
+    source: str
+    digest: str
+
+
+@dataclass
+class AdvisoryOnlySourcePacket:
+    work_focus_digest: str
+    wsp_prompt_digest: str
+    copy_md_run_trace_digest: str
+
+
+@dataclass
+class HoloIndexEvidencePacket:
+    holoindex_query: str
+    holoindex_status: str
+    code_hits: List[str] = field(default_factory=list)
+    wsp_hits: List[str] = field(default_factory=list)
+    skillz_hits: List[str] = field(default_factory=list)
+    direct_read_fallback_used: bool = False
+    index_gap_detected: bool = False
+    applicable_wsps: List[str] = field(default_factory=list)
+    evidence_refs: List[str] = field(default_factory=list)
+    retrieval_quality: str = "LOW"
+    skillz_gap_detected: bool = False
+
+
+@dataclass
+class RedDogGovernedWorkOrder:
+    work_order_id: str
+    created_at: str
+    red_dog_instance_id: str
+    authenticated_principal: str
+    principal_provider: str
+    repo_full_name: str
+    repo_permission_snapshot: RepoPermissionSnapshot
+    requested_operation: str
+    authority_tier: str
+    allowed_paths: List[str]
+    denied_paths: List[str]
+    branch_name: str
+    base_ref: str
+    task_summary: str
+    wsp_applicability: List[str]
+    holoindex_evidence_refs: List[str]
+    skillz_candidates: List[str]
+    required_tests: List[str]
+    required_policy_gates: List[str]
+    required_reviewers: List[str]
+    sentinel_checks: List[str]
+    rollback_plan: str
+    expiry: str
+    nonce: str
+    evidence_digest: str
+    advisory_only_source_packet: AdvisoryOnlySourcePacket
+    holoindex_evidence: Optional[HoloIndexEvidencePacket] = None
+
+
+@dataclass
+class DryRunReceipt:
+    decision: str
+    rejection_reasons: List[str]
+    gates_checked: List[str]
+    no_mutation_performed: bool
+    receipt_digest: str
+    work_order_id: str
+
+
+def _parse_iso8601(value: str) -> datetime:
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _canonical_digest(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _non_empty(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, tuple, dict)):
+        return len(value) > 0
+    return True
+
+
+def _normalize_operation(op: str) -> str:
+    return op.strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _is_write_sensitive_operation(operation: str) -> bool:
+    norm = _normalize_operation(operation)
+    if norm in DOCS_ONLY_OPERATIONS:
+        return False
+    if norm in WRITE_SENSITIVE_OPERATIONS:
+        return True
+    return any(token in norm for token in ("write", "branch", "pr", "repo", "source", "auth", "runtime", "security"))
+
+
+def _path_matches_any(path: str, patterns: Sequence[str]) -> bool:
+    normalized = path.replace("\\", "/")
+    for pattern in patterns:
+        pat = pattern.replace("\\", "/")
+        if fnmatch.fnmatch(normalized, pat) or fnmatch.fnmatch(normalized, f"**/{pat}"):
+            return True
+    return False
+
+
+def _forbidden_path_overlap(paths: Iterable[str]) -> List[str]:
+    hits: List[str] = []
+    for path in paths:
+        if _path_matches_any(path, FORBIDDEN_PATH_GLOBS):
+            hits.append(path)
+    return hits
+
+
+def _skillz_handoff_claimed(order: RedDogGovernedWorkOrder) -> bool:
+    summary = order.task_summary.lower()
+    if order.skillz_candidates:
+        return False
+    if "skillz" in summary or "wardrobe" in summary or "rolodex" in summary:
+        return True
+    gates = " ".join(order.required_policy_gates).lower()
+    return "skillz" in gates or "wardrobe" in gates
+
+
+def _work_order_from_mapping(data: Mapping[str, Any]) -> RedDogGovernedWorkOrder:
+    snap = data["repo_permission_snapshot"]
+    packet = data["advisory_only_source_packet"]
+    holo_raw = data.get("holoindex_evidence")
+    holo = None
+    if holo_raw is not None:
+        holo = HoloIndexEvidencePacket(
+            holoindex_query=str(holo_raw["holoindex_query"]),
+            holoindex_status=str(holo_raw["holoindex_status"]),
+            code_hits=list(holo_raw.get("code_hits") or []),
+            wsp_hits=list(holo_raw.get("wsp_hits") or []),
+            skillz_hits=list(holo_raw.get("skillz_hits") or []),
+            direct_read_fallback_used=bool(holo_raw.get("direct_read_fallback_used")),
+            index_gap_detected=bool(holo_raw.get("index_gap_detected")),
+            applicable_wsps=list(holo_raw.get("applicable_wsps") or []),
+            evidence_refs=list(holo_raw.get("evidence_refs") or []),
+            retrieval_quality=str(holo_raw.get("retrieval_quality") or "LOW"),
+            skillz_gap_detected=bool(holo_raw.get("skillz_gap_detected")),
+        )
+    return RedDogGovernedWorkOrder(
+        work_order_id=str(data["work_order_id"]),
+        created_at=str(data["created_at"]),
+        red_dog_instance_id=str(data["red_dog_instance_id"]),
+        authenticated_principal=str(data["authenticated_principal"]),
+        principal_provider=str(data["principal_provider"]),
+        repo_full_name=str(data["repo_full_name"]),
+        repo_permission_snapshot=RepoPermissionSnapshot(
+            permission_level=str(snap["permission_level"]),
+            captured_at=str(snap["captured_at"]),
+            source=str(snap["source"]),
+            digest=str(snap["digest"]),
+        ),
+        requested_operation=str(data["requested_operation"]),
+        authority_tier=str(data["authority_tier"]),
+        allowed_paths=list(data.get("allowed_paths") or []),
+        denied_paths=list(data.get("denied_paths") or []),
+        branch_name=str(data["branch_name"]),
+        base_ref=str(data["base_ref"]),
+        task_summary=str(data["task_summary"]),
+        wsp_applicability=list(data.get("wsp_applicability") or []),
+        holoindex_evidence_refs=list(data.get("holoindex_evidence_refs") or []),
+        skillz_candidates=list(data.get("skillz_candidates") or []),
+        required_tests=list(data.get("required_tests") or []),
+        required_policy_gates=list(data.get("required_policy_gates") or []),
+        required_reviewers=list(data.get("required_reviewers") or []),
+        sentinel_checks=list(data.get("sentinel_checks") or []),
+        rollback_plan=str(data.get("rollback_plan") or ""),
+        expiry=str(data["expiry"]),
+        nonce=str(data["nonce"]),
+        evidence_digest=str(data["evidence_digest"]),
+        advisory_only_source_packet=AdvisoryOnlySourcePacket(
+            work_focus_digest=str(packet["work_focus_digest"]),
+            wsp_prompt_digest=str(packet["wsp_prompt_digest"]),
+            copy_md_run_trace_digest=str(packet["copy_md_run_trace_digest"]),
+        ),
+        holoindex_evidence=holo,
+    )
+
+
+def validate_work_order_dryrun(
+    order: Union[RedDogGovernedWorkOrder, Mapping[str, Any]],
+    *,
+    now: Optional[datetime] = None,
+    seen_nonces: Optional[MutableSet[str]] = None,
+) -> DryRunReceipt:
+    """Validate a governed work order without performing any mutation."""
+    if isinstance(order, Mapping):
+        work_order = _work_order_from_mapping(order)
+    else:
+        work_order = order
+
+    gates_checked: List[str] = []
+    rejection_reasons: List[str] = []
+    now_utc = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    nonce_store = seen_nonces if seen_nonces is not None else set()
+
+    required_scalar_fields = {
+        "work_order_id": work_order.work_order_id,
+        "created_at": work_order.created_at,
+        "red_dog_instance_id": work_order.red_dog_instance_id,
+        "authenticated_principal": work_order.authenticated_principal,
+        "principal_provider": work_order.principal_provider,
+        "repo_full_name": work_order.repo_full_name,
+        "requested_operation": work_order.requested_operation,
+        "authority_tier": work_order.authority_tier,
+        "branch_name": work_order.branch_name,
+        "base_ref": work_order.base_ref,
+        "task_summary": work_order.task_summary,
+        "rollback_plan": work_order.rollback_plan,
+        "expiry": work_order.expiry,
+        "nonce": work_order.nonce,
+        "evidence_digest": work_order.evidence_digest,
+    }
+    gates_checked.append("required_fields")
+    for name, value in required_scalar_fields.items():
+        if not _non_empty(value):
+            rejection_reasons.append(f"missing_required_field:{name}")
+
+    snap = work_order.repo_permission_snapshot
+    gates_checked.append("repo_permission_snapshot")
+    for name, value in (
+        ("permission_level", snap.permission_level),
+        ("captured_at", snap.captured_at),
+        ("source", snap.source),
+        ("digest", snap.digest),
+    ):
+        if not _non_empty(value):
+            rejection_reasons.append(f"missing_required_field:repo_permission_snapshot.{name}")
+
+    packet = work_order.advisory_only_source_packet
+    gates_checked.append("advisory_only_source_packet")
+    for name, value in (
+        ("work_focus_digest", packet.work_focus_digest),
+        ("wsp_prompt_digest", packet.wsp_prompt_digest),
+        ("copy_md_run_trace_digest", packet.copy_md_run_trace_digest),
+    ):
+        if not _non_empty(value):
+            rejection_reasons.append(f"missing_required_field:advisory_only_source_packet.{name}")
+
+    list_fields = {
+        "allowed_paths": work_order.allowed_paths,
+        "denied_paths": work_order.denied_paths,
+        "wsp_applicability": work_order.wsp_applicability,
+        "holoindex_evidence_refs": work_order.holoindex_evidence_refs,
+        "skillz_candidates": work_order.skillz_candidates,
+        "required_tests": work_order.required_tests,
+        "required_policy_gates": work_order.required_policy_gates,
+        "required_reviewers": work_order.required_reviewers,
+        "sentinel_checks": work_order.sentinel_checks,
+    }
+    gates_checked.append("required_list_fields")
+    for name, value in list_fields.items():
+        if value is None:
+            rejection_reasons.append(f"missing_required_field:{name}")
+
+    gates_checked.append("expiry")
+    try:
+        expiry_dt = _parse_iso8601(work_order.expiry)
+        if now_utc > expiry_dt:
+            rejection_reasons.append("expired_work_order")
+    except ValueError:
+        rejection_reasons.append("invalid_expiry_timestamp")
+
+    gates_checked.append("nonce_replay")
+    if work_order.nonce in nonce_store:
+        rejection_reasons.append("replayed_nonce")
+    else:
+        nonce_store.add(work_order.nonce)
+
+    gates_checked.append("forbidden_operations")
+    op_norm = _normalize_operation(work_order.requested_operation)
+    tier_norm = work_order.authority_tier.strip().lower()
+    if tier_norm in {"admin", "autonomous_f0_merge", "merge_autonomous"}:
+        rejection_reasons.append("forbidden_authority_tier")
+    if any(token in op_norm for token in FORBIDDEN_OPERATION_TOKENS):
+        rejection_reasons.append("forbidden_requested_operation")
+    if snap.permission_level.strip().lower() == "admin" and _is_write_sensitive_operation(op_norm):
+        rejection_reasons.append("admin_permission_snapshot_write_blocked")
+
+    gates_checked.append("main_mutation")
+    branch = work_order.branch_name.strip().lower()
+    if branch in PROTECTED_BASE_REFS and _is_write_sensitive_operation(op_norm):
+        rejection_reasons.append("direct_main_branch_mutation")
+    if branch == work_order.base_ref.strip().lower() and _is_write_sensitive_operation(op_norm):
+        rejection_reasons.append("branch_equals_base_ref_for_write")
+
+    gates_checked.append("path_scope")
+    forbidden_allowed = _forbidden_path_overlap(work_order.allowed_paths)
+    if forbidden_allowed:
+        rejection_reasons.append("forbidden_paths_in_allowed_scope")
+    forbidden_denied = _forbidden_path_overlap(work_order.denied_paths)
+    if forbidden_denied and not work_order.denied_paths:
+        rejection_reasons.append("invalid_denied_paths")
+    overlap = [p for p in work_order.denied_paths if p in work_order.allowed_paths]
+    if overlap:
+        rejection_reasons.append("denied_path_also_allowed")
+    if _is_write_sensitive_operation(op_norm) and not work_order.allowed_paths:
+        rejection_reasons.append("empty_allowed_paths_for_write_operation")
+
+    gates_checked.append("holoindex_evidence")
+    index_gap_docs_only = False
+    holo = work_order.holoindex_evidence
+    if holo is None:
+        rejection_reasons.append("missing_holoindex_evidence")
+    else:
+        if holo.retrieval_quality not in RETRIEVAL_QUALITIES:
+            rejection_reasons.append("invalid_retrieval_quality")
+        if not _non_empty(holo.holoindex_query) or not _non_empty(holo.holoindex_status):
+            rejection_reasons.append("missing_holoindex_evidence")
+        write_sensitive = _is_write_sensitive_operation(op_norm)
+        if write_sensitive:
+            if not holo.applicable_wsps and not holo.wsp_hits:
+                rejection_reasons.append("missing_applicable_wsp_evidence")
+            if holo.retrieval_quality == "INDEX_GAP" or holo.index_gap_detected:
+                rejection_reasons.append("index_gap_blocks_write_operation")
+            elif holo.retrieval_quality in {"LOW", "MEDIUM"} and not holo.direct_read_fallback_used:
+                rejection_reasons.append("weak_wsp_recall_requires_direct_read_fallback")
+        elif holo.retrieval_quality == "INDEX_GAP" or holo.index_gap_detected:
+            index_gap_docs_only = True
+            gates_checked.append("index_gap_docs_only_exception")
+
+    gates_checked.append("skillz_handoff")
+    if _skillz_handoff_claimed(work_order):
+        holo_skillz_ok = bool(work_order.skillz_candidates)
+        if holo is not None:
+            holo_skillz_ok = holo_skillz_ok or bool(holo.skillz_hits) or holo.skillz_gap_detected
+        if not holo_skillz_ok:
+            rejection_reasons.append("skillz_handoff_missing_evidence")
+
+    if rejection_reasons:
+        decision = DECISION_REJECT
+    elif index_gap_docs_only:
+        decision = DECISION_ACCEPT_WITH_GAP
+    else:
+        decision = DECISION_ACCEPT
+
+    receipt_core = {
+        "decision": decision,
+        "rejection_reasons": rejection_reasons,
+        "gates_checked": gates_checked,
+        "no_mutation_performed": True,
+        "work_order_id": work_order.work_order_id,
+    }
+    return DryRunReceipt(
+        decision=decision,
+        rejection_reasons=rejection_reasons,
+        gates_checked=gates_checked,
+        no_mutation_performed=True,
+        receipt_digest=_canonical_digest(receipt_core),
+        work_order_id=work_order.work_order_id,
+    )
+
+
+def work_order_to_dict(order: RedDogGovernedWorkOrder) -> Dict[str, Any]:
+    """Serialize a work order for receipts and tests."""
+    data = asdict(order)
+    return data

--- a/modules/communication/moltbot_bridge/tests/test_reddog_governed_work_order_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_governed_work_order_dryrun.py
@@ -1,0 +1,189 @@
+"""Tests for RedDog governed repo work-order dry-run validator."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_governed_work_order_dryrun import (
+    DECISION_ACCEPT,
+    DECISION_ACCEPT_WITH_GAP,
+    DECISION_REJECT,
+    validate_work_order_dryrun,
+)
+
+
+def _future_expiry(hours: int = 2) -> str:
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).replace(microsecond=0).isoformat()
+
+
+def _base_order(**overrides):
+    payload = {
+        "work_order_id": "wo-test-001",
+        "created_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "red_dog_instance_id": "reddog-ext-0.3.27",
+        "authenticated_principal": "principal-012",
+        "principal_provider": "gh_cli_session",
+        "repo_full_name": "FOUNDUPS/Foundups-Agent",
+        "repo_permission_snapshot": {
+            "permission_level": "write",
+            "captured_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+            "source": "github_api",
+            "digest": "sha256:" + ("a" * 64),
+        },
+        "requested_operation": "feature_slice",
+        "authority_tier": "source",
+        "allowed_paths": ["extensions/foundups_advisory_workers/**"],
+        "denied_paths": [".env"],
+        "branch_name": "feat/reddog-dryrun-test",
+        "base_ref": "main",
+        "task_summary": "Add governed work-order dry-run validator",
+        "wsp_applicability": ["WSP_34", "WSP_50", "WSP_97"],
+        "holoindex_evidence_refs": ["docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md"],
+        "skillz_candidates": ["qwen_wsp_enhancement"],
+        "required_tests": [
+            "modules/communication/moltbot_bridge/tests/test_reddog_governed_work_order_dryrun.py"
+        ],
+        "required_policy_gates": ["openclaw_source_check", "github_permission_fresh"],
+        "required_reviewers": ["sentinel_wsp_compliance"],
+        "sentinel_checks": ["wsp_compliance", "regression"],
+        "rollback_plan": "Revert branch if dry-run receipt fails downstream gates.",
+        "expiry": _future_expiry(),
+        "nonce": "nonce-001",
+        "evidence_digest": "sha256:" + ("b" * 64),
+        "advisory_only_source_packet": {
+            "work_focus_digest": "sha256:" + ("c" * 64),
+            "wsp_prompt_digest": "sha256:" + ("d" * 64),
+            "copy_md_run_trace_digest": "sha256:" + ("e" * 64),
+        },
+        "holoindex_evidence": {
+            "holoindex_query": "RedDog governed repo work order",
+            "holoindex_status": "bundle_json_ok",
+            "code_hits": ["modules/communication/moltbot_bridge/src/openclaw_permission_policy.py"],
+            "wsp_hits": ["WSP_framework/src/WSP_34_Git_Operations_Protocol.md"],
+            "skillz_hits": ["qwen_wsp_enhancement"],
+            "direct_read_fallback_used": False,
+            "index_gap_detected": False,
+            "applicable_wsps": ["WSP_34", "WSP_50", "WSP_97"],
+            "evidence_refs": ["docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md"],
+            "retrieval_quality": "HIGH",
+            "skillz_gap_detected": False,
+        },
+    }
+    payload.update(overrides)
+    if "holoindex_evidence" in overrides and overrides["holoindex_evidence"] is None:
+        payload.pop("holoindex_evidence", None)
+    return payload
+
+
+class TestDryRunAccept:
+    def test_valid_work_order_with_holoindex_would_accept(self):
+        seen = set()
+        receipt = validate_work_order_dryrun(_base_order(), seen_nonces=seen)
+        assert receipt.decision == DECISION_ACCEPT
+        assert receipt.rejection_reasons == []
+        assert receipt.no_mutation_performed is True
+        assert len(receipt.receipt_digest) == 64
+        assert "holoindex_evidence" in receipt.gates_checked
+
+    def test_index_gap_docs_only_would_accept_with_retrieval_gap(self):
+        order = _base_order(
+            requested_operation="audit_only",
+            authority_tier="advisory",
+            branch_name="docs/reddog-audit",
+            allowed_paths=["docs/**"],
+        )
+        order["holoindex_evidence"]["retrieval_quality"] = "INDEX_GAP"
+        order["holoindex_evidence"]["index_gap_detected"] = True
+        receipt = validate_work_order_dryrun(order, seen_nonces=set())
+        assert receipt.decision == DECISION_ACCEPT_WITH_GAP
+        assert receipt.rejection_reasons == []
+
+
+class TestDryRunReject:
+    def test_missing_holoindex_evidence(self):
+        receipt = validate_work_order_dryrun(_base_order(holoindex_evidence=None), seen_nonces=set())
+        assert receipt.decision == DECISION_REJECT
+        assert "missing_holoindex_evidence" in receipt.rejection_reasons
+
+    def test_index_gap_on_write_operation(self):
+        order = _base_order()
+        order["holoindex_evidence"]["retrieval_quality"] = "INDEX_GAP"
+        order["holoindex_evidence"]["index_gap_detected"] = True
+        receipt = validate_work_order_dryrun(order, seen_nonces=set())
+        assert receipt.decision == DECISION_REJECT
+        assert "index_gap_blocks_write_operation" in receipt.rejection_reasons
+
+    def test_skillz_handoff_missing_evidence(self):
+        order = _base_order(
+            skillz_candidates=[],
+            task_summary="Route via Skillz/Wardrobe handoff to WRE",
+        )
+        order["holoindex_evidence"]["skillz_hits"] = []
+        order["holoindex_evidence"]["skillz_gap_detected"] = False
+        receipt = validate_work_order_dryrun(order, seen_nonces=set())
+        assert receipt.decision == DECISION_REJECT
+        assert "skillz_handoff_missing_evidence" in receipt.rejection_reasons
+
+    def test_expired_work_order(self):
+        past = (datetime.now(timezone.utc) - timedelta(hours=1)).replace(microsecond=0).isoformat()
+        receipt = validate_work_order_dryrun(_base_order(expiry=past), seen_nonces=set())
+        assert receipt.decision == DECISION_REJECT
+        assert "expired_work_order" in receipt.rejection_reasons
+
+    def test_replayed_nonce(self):
+        seen = set()
+        first = validate_work_order_dryrun(_base_order(nonce="nonce-replay"), seen_nonces=seen)
+        assert first.decision == DECISION_ACCEPT
+        second = validate_work_order_dryrun(_base_order(nonce="nonce-replay"), seen_nonces=seen)
+        assert second.decision == DECISION_REJECT
+        assert "replayed_nonce" in second.rejection_reasons
+
+    def test_direct_main_branch_mutation(self):
+        receipt = validate_work_order_dryrun(_base_order(branch_name="main"), seen_nonces=set())
+        assert receipt.decision == DECISION_REJECT
+        assert "direct_main_branch_mutation" in receipt.rejection_reasons
+
+    def test_forbidden_admin_operation(self):
+        receipt = validate_work_order_dryrun(
+            _base_order(requested_operation="grant_permission_admin"),
+            seen_nonces=set(),
+        )
+        assert receipt.decision == DECISION_REJECT
+        assert "forbidden_requested_operation" in receipt.rejection_reasons
+
+    def test_forbidden_env_path_in_allowed_scope(self):
+        receipt = validate_work_order_dryrun(
+            _base_order(allowed_paths=[".env", "extensions/**"]),
+            seen_nonces=set(),
+        )
+        assert receipt.decision == DECISION_REJECT
+        assert "forbidden_paths_in_allowed_scope" in receipt.rejection_reasons
+
+    def test_denied_path_also_allowed(self):
+        receipt = validate_work_order_dryrun(
+            _base_order(
+                allowed_paths=["extensions/**", ".env"],
+                denied_paths=[".env"],
+            ),
+            seen_nonces=set(),
+        )
+        assert receipt.decision == DECISION_REJECT
+        assert "denied_path_also_allowed" in receipt.rejection_reasons
+
+    def test_weak_wsp_recall_requires_direct_read_fallback(self):
+        order = _base_order()
+        order["holoindex_evidence"]["retrieval_quality"] = "LOW"
+        order["holoindex_evidence"]["direct_read_fallback_used"] = False
+        order["holoindex_evidence"]["wsp_hits"] = []
+        order["holoindex_evidence"]["applicable_wsps"] = []
+        receipt = validate_work_order_dryrun(order, seen_nonces=set())
+        assert receipt.decision == DECISION_REJECT
+        assert "missing_applicable_wsp_evidence" in receipt.rejection_reasons
+
+    def test_missing_required_field(self):
+        order = _base_order(work_order_id="")
+        receipt = validate_work_order_dryrun(order, seen_nonces=set())
+        assert receipt.decision == DECISION_REJECT
+        assert "missing_required_field:work_order_id" in receipt.rejection_reasons


### PR DESCRIPTION
## Summary

- Adds `reddog_governed_work_order_dryrun.py` in `moltbot_bridge` — single contract module for `RedDogGovernedWorkOrder` + `HoloIndexEvidencePacket` validation without GitHub/branch/PR/write/shell/merge.
- Returns dry-run receipt: `WOULD_ACCEPT` | `WOULD_REJECT` | `WOULD_ACCEPT_WITH_RETRIEVAL_GAP` with `rejection_reasons[]`, `gates_checked[]`, `receipt_digest`, `no_mutation_performed: true`.
- Gates: required fields, expiry, nonce replay, forbidden ops/paths, main-branch mutation block, HoloIndex evidence (Addendum A), skillz handoff evidence, WAE-L1 mapping docstring (Addendum B).
- Extension docs updated (ROADMAP/INTERFACE/README/ModLog); extension does not invoke validator yet.

## Test plan

- [x] `pytest modules/communication/moltbot_bridge/tests/test_reddog_governed_work_order_dryrun.py` — 13 passed
- [x] `node extensions/foundups_advisory_workers/tests/verify_extension_contract.js`
- [x] `git diff --check` scoped files
- [ ] CI green
- [ ] 012 gate before merge

## Placement

OpenClaw bridge (`moltbot_bridge`) — adjacent to `openclaw_permission_policy.py`; future OpenClaw envelope gate reuses this module. Not scattered across extension + WRE.

Draft PR — stop at VERIFIED_READY; do not merge without sovereign token.