### PR TITLE
feat(reddog): add read-only GitHub permission snapshot probe

### DIFF
--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -73,6 +73,8 @@ RedDog is the 0102 architect interface — **not an authority owner**. RedDog re
 
 **Dry-run validator (no mutation):** `modules/communication/moltbot_bridge/src/reddog_governed_work_order_dryrun.py` — validates envelope + HoloIndex evidence packet; returns `WOULD_ACCEPT` / `WOULD_REJECT` / `WOULD_ACCEPT_WITH_RETRIEVAL_GAP`. Extension v0.3.27 does not invoke it yet.
 
+**Permission probe (read-only):** `modules/platform_integration/github_integration/src/reddog_github_permission_probe.py` — `probe_repo_permission()` produces fresh `repo_permission_snapshot` evidence. Extension does not invoke it yet.
+
 **Specified flow (not implemented in extension v0.3.27):**
 
 ```text
@@ -297,7 +299,8 @@ Formal contract:
 | Advisory-only; no shell/repo/browser/OpenClaw/Hermes execution | OBSERVED |
 | Redaction gate before OpenRouter | OBSERVED |
 | Governed handoff contract (typed WRE dispatch) | SPECIFIED_NOT_IMPLEMENTED |
-| Governed repo work order dry-run validator | OBSERVED (Python module); extension does not invoke yet |
+| GitHub permission probe (read-only snapshot) | OBSERVED (github_integration module) |
+| Governed repo work order dry-run validator | OBSERVED (OpenClaw bridge module) |
 | Governed repo work order (`RedDogGovernedWorkOrder`) | SPECIFIED_NOT_IMPLEMENTED (runtime emission from extension) |
 | GitHub permission snapshot per work order | SPECIFIED_NOT_IMPLEMENTED |
 | F0 autonomous merge | SPECIFIED_NOT_IMPLEMENTED |

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -1,5 +1,12 @@
 # Foundups®Agent ModLog
 
+## 2026-06-28 - REDDOG_GITHUB_PERMISSION_PROBE_PHASE1 (extension pointers)
+
+- Points to `modules/platform_integration/github_integration/src/reddog_github_permission_probe.py`.
+- Read-only snapshot feeds `repo_permission_snapshot` for future work-order emission.
+
+WSP: WSP_34, WSP_50, WSP_97.
+
 ## 2026-06-28 - #890 LANDED + post-dryrun queue revision
 
 - **#890 merged** @ `bd68ab83a` — `validate_work_order_dryrun()` pure validation module.

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -191,7 +191,9 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 
 ### REDDOG_GITHUB_PERMISSION_PROBE_PHASE1
 
-- **Status:** **P0 NEXT** — read-only GitHub permission snapshot; no branch/PR/write.
+- **Status:** **PR-READY** — read-only `probe_repo_permission()` in github_integration.
+- **Module:** `modules/platform_integration/github_integration/src/reddog_github_permission_probe.py`
+- Maps to `repo_permission_snapshot` for `#890` dry-run validator.
 - **Rationale:** OpenClaw can validate envelope shape only after fresh permission evidence exists.
 
 ### REDDOG_OPENCLAW_WORK_ORDER_POLICY_GATE_PHASE1

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -180,6 +180,10 @@ const dryrunPy = fs.readFileSync(path.join(root, 'modules', 'communication', 'mo
 includes(dryrunPy, 'validate_work_order_dryrun', 'dry-run validator missing');
 includes(dryrunPy, 'WOULD_ACCEPT_WITH_RETRIEVAL_GAP', 'dry-run retrieval gap decision missing');
 includes(dryrunPy, 'HoloIndexEvidencePacket', 'HoloIndex evidence packet missing');
+const probePy = fs.readFileSync(path.join(root, 'modules', 'platform_integration', 'github_integration', 'src', 'reddog_github_permission_probe.py'), 'utf8');
+includes(probePy, 'probe_repo_permission', 'GitHub permission probe missing');
+includes(probePy, 'raw_secret_included', 'probe raw_secret_included flag missing');
+includes(iface, 'reddog_github_permission_probe.py', 'INTERFACE permission probe pointer missing');
 includes(iface, 'reddog_governed_work_order_dryrun.py', 'INTERFACE dry-run module pointer missing');
 includes(auditDoc, 'authenticated principal', 'audit doc principal wording missing');
 includes(auditDoc, 'HoloIndex Discoverability', 'audit doc discoverability section missing');

--- a/modules/platform_integration/github_integration/INTERFACE.md
+++ b/modules/platform_integration/github_integration/INTERFACE.md
@@ -1,6 +1,35 @@
 # INTERFACE (WSP 11)
 
-## Public API
+## RedDog read-only permission probe
+
+**Module:** `reddog_github_permission_probe.py`
+**Slice:** `REDDOG_GITHUB_PERMISSION_PROBE_PHASE1`
+
+### `probe_repo_permission(repo_full_name, *, principal_login=None, principal_provider="github", backend=None, now=None, ttl_seconds=300) -> RepoPermissionProbeSnapshot`
+
+Read-only probe of GitHub repository permission for the authenticated principal.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `repo_full_name` | `str` | yes | `owner/repo` |
+| `principal_login` | `str` | no | Override login; default from backend |
+| `principal_provider` | `str` | no | Default `github` |
+| `backend` | `PermissionProbeBackend` | no | Injectable backend; default `gh_cli` read-only |
+| `now` | `datetime` | no | Test clock |
+| `ttl_seconds` | `int` | no | Snapshot freshness TTL (default 300) |
+
+**Returns:** `RepoPermissionProbeSnapshot` with conservative `can_read` / `can_write` / `can_admin`, `evidence_digest`, `raw_secret_included=false`.
+
+**Errors:** Does not raise on missing auth; returns `permission=unknown` fail-closed.
+
+### `RepoPermissionProbeSnapshot.to_repo_permission_snapshot() -> dict`
+
+Maps into `#889` work-order `repo_permission_snapshot` fields.
+
+### `is_snapshot_fresh(snapshot, now=None) -> bool`
+
+Returns false when `expires_at` is in the past.
+
 ## Parameters
 ## Returns
 ## Errors

--- a/modules/platform_integration/github_integration/ModLog.md
+++ b/modules/platform_integration/github_integration/ModLog.md
@@ -1,5 +1,14 @@
 # GitHub Integration Module Log
 
+## 2026-06-28 - REDDOG_GITHUB_PERMISSION_PROBE_PHASE1
+
+- ADD `src/reddog_github_permission_probe.py` — read-only `probe_repo_permission()` with gh CLI allowlist backend.
+- Snapshot maps to `#889` `repo_permission_snapshot` via `to_repo_permission_snapshot()`.
+- Tests: 14 pytest cases + dry-run integration; mocks only in CI.
+- No branch/PR/write/merge/token persistence.
+
+WSP: WSP_34, WSP_50, WSP_97, WSP_22.
+
 ## Version History
 
 ### v1.0.0 - Complete GitHub Integration (Current)

--- a/modules/platform_integration/github_integration/README.md
+++ b/modules/platform_integration/github_integration/README.md
@@ -13,6 +13,11 @@
 
 ## [ROCKET] Core Functionality
 
+### **RedDog Permission Probe (read-only)**
+- **`probe_repo_permission()`**: Read-only GitHub permission snapshot for governed work orders
+- **Conservative mapping**: `write`/`maintain`/`admin` -> `can_write`; `unknown` fail-closed
+- **No mutation**: allowlisted `gh` GET commands only; injectable mock backend for tests
+
 ### **GitHub API Client**
 - **Complete REST API Coverage**: Repository, pull requests, issues, branches, commits, workflows
 - **Async/Await Architecture**: High-performance async operations with aiohttp

--- a/modules/platform_integration/github_integration/src/reddog_github_permission_probe.py
+++ b/modules/platform_integration/github_integration/src/reddog_github_permission_probe.py
@@ -1,0 +1,289 @@
+"""Read-only GitHub permission probe for RedDog governed work orders.
+
+Slice: REDDOG_GITHUB_PERMISSION_PROBE_PHASE1
+Contract: docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md
+
+Reports current repository permission for an authenticated principal.
+Does NOT create branches, PRs, commits, merges, or mutate repository content.
+
+Allowed read-only `gh` invocations (when default backend is used):
+- `gh auth status`
+- `gh api user` (GET)
+- `gh repo view <repo> --json viewerPermission,defaultBranchRef,nameWithOwner`
+- `gh api repos/{owner}/{repo}/branches/{branch}/protection` (GET, optional)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import subprocess
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Dict, List, Mapping, Optional, Protocol, Tuple
+
+logger = logging.getLogger(__name__)
+
+PERMISSION_LEVELS = frozenset({"admin", "maintain", "write", "triage", "read", "none", "unknown"})
+READ_ONLY_GH_COMMANDS = frozenset(
+    {
+        "auth status",
+        "api user",
+        "repo view",
+        "api repos/",
+    }
+)
+
+_SECRET_PATTERNS = (
+    re.compile(r"ghp_[A-Za-z0-9_]+"),
+    re.compile(r"github_pat_[A-Za-z0-9_]+"),
+    re.compile(r"gho_[A-Za-z0-9_]+"),
+    re.compile(r"ghu_[A-Za-z0-9_]+"),
+)
+
+
+@dataclass
+class RepoPermissionProbeSnapshot:
+    repo_full_name: str
+    principal_login: str
+    principal_provider: str
+    permission: str
+    can_read: bool
+    can_write: bool
+    can_admin: bool
+    source: str
+    checked_at: str
+    expires_at: Optional[str]
+    token_scopes: List[str] = field(default_factory=list)
+    branch_protection_observed: str = "unknown"
+    default_branch: str = "unknown"
+    evidence_digest: str = ""
+    raw_secret_included: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def to_repo_permission_snapshot(self) -> Dict[str, str]:
+        """Map into #889 RedDogGovernedWorkOrder.repo_permission_snapshot shape."""
+        return {
+            "permission_level": self.permission,
+            "captured_at": self.checked_at,
+            "source": self.source,
+            "digest": self.evidence_digest,
+        }
+
+
+class PermissionProbeBackend(Protocol):
+    def probe(self, repo_full_name: str) -> Mapping[str, Any]:
+        """Return backend fields: authenticated, login, permission, default_branch, scopes, branch_protection."""
+
+
+def _utc_now(now: Optional[datetime] = None) -> datetime:
+    value = now or datetime.now(timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _iso8601(dt: datetime) -> str:
+    return dt.replace(microsecond=0).isoformat()
+
+
+def _sanitize_text(text: str) -> str:
+    cleaned = text
+    for pattern in _SECRET_PATTERNS:
+        cleaned = pattern.sub("[REDACTED]", cleaned)
+    return cleaned
+
+
+def _canonical_digest(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def permission_to_capabilities(permission: str) -> Tuple[bool, bool, bool]:
+    """Conservative capability mapping for probe snapshots."""
+    level = (permission or "unknown").strip().lower()
+    if level in {"admin", "maintain", "write"}:
+        return True, True, level == "admin"
+    if level in {"triage", "read"}:
+        return True, False, False
+    return False, False, False
+
+
+def normalize_permission(raw: Optional[str]) -> str:
+    if not raw:
+        return "unknown"
+    level = raw.strip().lower()
+    if level in PERMISSION_LEVELS:
+        return level
+    return "unknown"
+
+
+def is_snapshot_fresh(snapshot: RepoPermissionProbeSnapshot, *, now: Optional[datetime] = None) -> bool:
+    if not snapshot.expires_at:
+        return True
+    try:
+        expires = datetime.fromisoformat(snapshot.expires_at.replace("Z", "+00:00"))
+        if expires.tzinfo is None:
+            expires = expires.replace(tzinfo=timezone.utc)
+        return _utc_now(now) <= expires.astimezone(timezone.utc)
+    except ValueError:
+        return False
+
+
+def _run_gh_readonly(args: List[str], *, timeout: int = 20) -> Tuple[int, str, str]:
+    cmd = ["gh", *args]
+    cmd_text = " ".join(cmd)
+    if not any(marker in cmd_text for marker in READ_ONLY_GH_COMMANDS):
+        raise ValueError(f"gh command not allowlisted for read-only probe: {cmd_text}")
+    if any(token in cmd_text for token in ("--show-token", "auth login", "auth refresh")):
+        raise ValueError(f"gh command blocked for secret safety: {cmd_text}")
+
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    stdout = _sanitize_text(result.stdout or "")
+    stderr = _sanitize_text(result.stderr or "")
+    return result.returncode, stdout, stderr
+
+
+class GhCliPermissionProbeBackend:
+    """Read-only GitHub permission probe via gh CLI."""
+
+    def probe(self, repo_full_name: str) -> Mapping[str, Any]:
+        auth_code, auth_out, auth_err = _run_gh_readonly(["auth", "status"])
+        authenticated = auth_code == 0 and "Logged in" in auth_out
+        scopes: List[str] = []
+        for line in (auth_out + "\n" + auth_err).splitlines():
+            if "Token scopes:" in line or "token scopes:" in line.lower():
+                _, _, tail = line.partition(":")
+                scopes = [s.strip("'\" ") for s in tail.split(",") if s.strip()]
+
+        login = "unknown"
+        permission = "unknown"
+        default_branch = "unknown"
+        branch_protection: str = "unknown"
+
+        if authenticated:
+            user_code, user_out, _ = _run_gh_readonly(["api", "user"])
+            if user_code == 0 and user_out.strip():
+                try:
+                    login = str(json.loads(user_out).get("login") or "unknown")
+                except json.JSONDecodeError:
+                    login = "unknown"
+
+            repo_code, repo_out, _ = _run_gh_readonly(
+                [
+                    "repo",
+                    "view",
+                    repo_full_name,
+                    "--json",
+                    "viewerPermission,defaultBranchRef,nameWithOwner",
+                ]
+            )
+            if repo_code == 0 and repo_out.strip():
+                try:
+                    payload = json.loads(repo_out)
+                    permission = normalize_permission(payload.get("viewerPermission"))
+                    ref = payload.get("defaultBranchRef") or {}
+                    default_branch = str(ref.get("name") or "unknown")
+                except json.JSONDecodeError:
+                    permission = "unknown"
+            else:
+                permission = "none" if repo_code != 0 else "unknown"
+
+            if default_branch not in {"unknown", ""}:
+                owner, _, repo = repo_full_name.partition("/")
+                if owner and repo:
+                    prot_code, _, _ = _run_gh_readonly(
+                        ["api", f"repos/{owner}/{repo}/branches/{default_branch}/protection"]
+                    )
+                    if prot_code == 0:
+                        branch_protection = "true"
+                    elif prot_code == 404:
+                        branch_protection = "false"
+                    else:
+                        branch_protection = "unknown"
+
+        return {
+            "authenticated": authenticated,
+            "login": login,
+            "permission": permission,
+            "default_branch": default_branch,
+            "scopes": scopes,
+            "branch_protection_observed": branch_protection,
+            "source": "gh_cli",
+        }
+
+
+def probe_repo_permission(
+    repo_full_name: str,
+    *,
+    principal_login: Optional[str] = None,
+    principal_provider: str = "github",
+    backend: Optional[PermissionProbeBackend] = None,
+    now: Optional[datetime] = None,
+    ttl_seconds: int = 300,
+) -> RepoPermissionProbeSnapshot:
+    """Probe read-only GitHub repository permission for the current authenticated principal."""
+    checked = _utc_now(now)
+    expires = checked + timedelta(seconds=max(1, ttl_seconds))
+
+    try:
+        raw = backend.probe(repo_full_name) if backend is not None else GhCliPermissionProbeBackend().probe(repo_full_name)
+    except Exception as exc:
+        logger.debug("permission probe failed closed: %s", _sanitize_text(str(exc)))
+        raw = {
+            "authenticated": False,
+            "login": "unknown",
+            "permission": "unknown",
+            "default_branch": "unknown",
+            "scopes": [],
+            "branch_protection_observed": "unknown",
+            "source": "gh_cli",
+        }
+
+    permission = normalize_permission(str(raw.get("permission", "unknown")))
+    if not raw.get("authenticated"):
+        permission = "unknown"
+
+    can_read, can_write, can_admin = permission_to_capabilities(permission)
+    login = principal_login or str(raw.get("login") or "unknown")
+
+    snapshot_core = {
+        "repo_full_name": repo_full_name,
+        "principal_login": login,
+        "principal_provider": principal_provider,
+        "permission": permission,
+        "can_read": can_read,
+        "can_write": can_write,
+        "can_admin": can_admin,
+        "source": str(raw.get("source") or "unknown"),
+        "checked_at": _iso8601(checked),
+        "expires_at": _iso8601(expires),
+        "token_scopes": list(raw.get("scopes") or []),
+        "branch_protection_observed": str(raw.get("branch_protection_observed") or "unknown"),
+        "default_branch": str(raw.get("default_branch") or "unknown"),
+        "raw_secret_included": False,
+    }
+    digest = _canonical_digest(snapshot_core)
+
+    return RepoPermissionProbeSnapshot(
+        evidence_digest=f"sha256:{digest}",
+        **snapshot_core,
+    )
+
+
+def build_probe_backend_from_callable(
+    fn: Callable[[str], Mapping[str, Any]]
+) -> PermissionProbeBackend:
+    class _CallableBackend:
+        def probe(self, repo_full_name: str) -> Mapping[str, Any]:
+            return fn(repo_full_name)
+
+    return _CallableBackend()

--- a/modules/platform_integration/github_integration/tests/TestModLog.md
+++ b/modules/platform_integration/github_integration/tests/TestModLog.md
@@ -1,3 +1,6 @@
 # TestModLog
 
-- Initialize test change log per WSP 34.
+## 2026-06-28 - REDDOG_GITHUB_PERMISSION_PROBE_PHASE1
+
+- ADD `test_reddog_github_permission_probe.py` — 14 tests (capabilities, probe paths, dry-run integration, gh allowlist).
+- CI uses mock backend only; no live GitHub.

--- a/modules/platform_integration/github_integration/tests/test_reddog_github_permission_probe.py
+++ b/modules/platform_integration/github_integration/tests/test_reddog_github_permission_probe.py
@@ -1,0 +1,224 @@
+"""Tests for read-only RedDog GitHub permission probe."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_governed_work_order_dryrun import (
+    DECISION_ACCEPT,
+    DECISION_ACCEPT_WITH_GAP,
+    DECISION_REJECT,
+    validate_work_order_dryrun,
+)
+from modules.platform_integration.github_integration.src.reddog_github_permission_probe import (
+    GhCliPermissionProbeBackend,
+    build_probe_backend_from_callable,
+    is_snapshot_fresh,
+    permission_to_capabilities,
+    probe_repo_permission,
+)
+
+
+def _future_expiry(hours: int = 2) -> str:
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).replace(microsecond=0).isoformat()
+
+
+def _backend(**fields):
+    payload = {
+        "authenticated": True,
+        "login": "operator-012",
+        "permission": "write",
+        "default_branch": "main",
+        "scopes": ["repo"],
+        "branch_protection_observed": "true",
+        "source": "mock",
+    }
+    payload.update(fields)
+    return build_probe_backend_from_callable(lambda _repo: payload)
+
+
+class TestPermissionCapabilities:
+    def test_read_permission(self):
+        can_read, can_write, can_admin = permission_to_capabilities("read")
+        assert can_read is True
+        assert can_write is False
+        assert can_admin is False
+
+    def test_write_permission(self):
+        can_read, can_write, can_admin = permission_to_capabilities("write")
+        assert can_read is True
+        assert can_write is True
+        assert can_admin is False
+
+    def test_admin_permission_reports_capabilities_without_authorizing_admin_ops(self):
+        can_read, can_write, can_admin = permission_to_capabilities("admin")
+        assert can_read is True
+        assert can_write is True
+        assert can_admin is True
+
+
+class TestProbeRepoPermission:
+    def test_unauthenticated_unknown_fail_closed(self):
+        backend = _backend(authenticated=False, permission="write", login="unknown")
+        snap = probe_repo_permission("FOUNDUPS/Foundups-Agent", backend=backend)
+        assert snap.permission == "unknown"
+        assert snap.can_read is False
+        assert snap.can_write is False
+        assert snap.can_admin is False
+
+    def test_read_permission_snapshot(self):
+        snap = probe_repo_permission(
+            "FOUNDUPS/Foundups-Agent",
+            backend=_backend(permission="read"),
+        )
+        assert snap.can_read is True
+        assert snap.can_write is False
+        assert snap.raw_secret_included is False
+
+    def test_write_permission_snapshot(self):
+        snap = probe_repo_permission(
+            "FOUNDUPS/Foundups-Agent",
+            backend=_backend(permission="write"),
+        )
+        assert snap.can_write is True
+        assert snap.can_admin is False
+
+    def test_admin_permission_snapshot(self):
+        snap = probe_repo_permission(
+            "FOUNDUPS/Foundups-Agent",
+            backend=_backend(permission="admin"),
+        )
+        assert snap.can_write is True
+        assert snap.can_admin is True
+
+    def test_unknown_permission_fail_closed(self):
+        snap = probe_repo_permission(
+            "FOUNDUPS/Foundups-Agent",
+            backend=_backend(permission="unexpected-role"),
+        )
+        assert snap.permission == "unknown"
+        assert snap.can_write is False
+
+    def test_token_scopes_not_leaked_in_digest_payload(self):
+        snap = probe_repo_permission(
+            "FOUNDUPS/Foundups-Agent",
+            backend=_backend(scopes=["repo", "read:org"]),
+        )
+        assert "ghp_" not in snap.evidence_digest
+        assert snap.token_scopes == ["repo", "read:org"]
+
+    def test_snapshot_digest_stable(self):
+        fixed = datetime(2026, 6, 28, 12, 0, 0, tzinfo=timezone.utc)
+        snap_a = probe_repo_permission(
+            "FOUNDUPS/Foundups-Agent",
+            backend=_backend(permission="write"),
+            now=fixed,
+        )
+        snap_b = probe_repo_permission(
+            "FOUNDUPS/Foundups-Agent",
+            backend=_backend(permission="write"),
+            now=fixed,
+        )
+        assert snap_a.evidence_digest == snap_b.evidence_digest
+        assert snap_a.evidence_digest.startswith("sha256:")
+
+    def test_stale_snapshot_rejected(self):
+        past = datetime(2026, 6, 28, 10, 0, 0, tzinfo=timezone.utc)
+        snap = probe_repo_permission(
+            "FOUNDUPS/Foundups-Agent",
+            backend=_backend(permission="write"),
+            now=past,
+            ttl_seconds=60,
+        )
+        assert is_snapshot_fresh(snap, now=datetime(2026, 6, 28, 12, 0, 0, tzinfo=timezone.utc)) is False
+
+    def test_to_repo_permission_snapshot_shape(self):
+        snap = probe_repo_permission(
+            "FOUNDUPS/Foundups-Agent",
+            backend=_backend(permission="write"),
+        )
+        mapped = snap.to_repo_permission_snapshot()
+        assert set(mapped.keys()) == {"permission_level", "captured_at", "source", "digest"}
+        assert mapped["permission_level"] == "write"
+        assert mapped["digest"].startswith("sha256:")
+
+
+class TestDryRunIntegration:
+    def _work_order_with_snapshot(self, permission_level: str):
+        snap = probe_repo_permission(
+            "FOUNDUPS/Foundups-Agent",
+            backend=_backend(permission=permission_level),
+        )
+        return {
+            "work_order_id": "wo-perm-001",
+            "created_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+            "red_dog_instance_id": "reddog-ext-0.3.27",
+            "authenticated_principal": "principal-012",
+            "principal_provider": "github",
+            "repo_full_name": "FOUNDUPS/Foundups-Agent",
+            "repo_permission_snapshot": snap.to_repo_permission_snapshot(),
+            "requested_operation": "audit_only",
+            "authority_tier": "advisory",
+            "allowed_paths": ["docs/**"],
+            "denied_paths": [".env"],
+            "branch_name": "docs/probe-test",
+            "base_ref": "main",
+            "task_summary": "Validate permission probe snapshot wiring",
+            "wsp_applicability": ["WSP_34", "WSP_50"],
+            "holoindex_evidence_refs": [
+                "docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md"
+            ],
+            "skillz_candidates": [],
+            "required_tests": [],
+            "required_policy_gates": ["github_permission_fresh"],
+            "required_reviewers": [],
+            "sentinel_checks": [],
+            "rollback_plan": "No mutation performed.",
+            "expiry": _future_expiry(),
+            "nonce": "nonce-perm-001",
+            "evidence_digest": "sha256:" + ("f" * 64),
+            "advisory_only_source_packet": {
+                "work_focus_digest": "sha256:" + ("a" * 64),
+                "wsp_prompt_digest": "sha256:" + ("b" * 64),
+                "copy_md_run_trace_digest": "sha256:" + ("c" * 64),
+            },
+            "holoindex_evidence": {
+                "holoindex_query": "RedDog governed repo work order",
+                "holoindex_status": "bundle_json_ok",
+                "code_hits": [],
+                "wsp_hits": ["WSP_framework/src/WSP_34_Git_Operations_Protocol.md"],
+                "skillz_hits": [],
+                "direct_read_fallback_used": False,
+                "index_gap_detected": True,
+                "applicable_wsps": ["WSP_34"],
+                "evidence_refs": [],
+                "retrieval_quality": "INDEX_GAP",
+                "skillz_gap_detected": True,
+            },
+        }
+
+    def test_snapshot_accepted_by_dry_run_validator(self):
+        receipt = validate_work_order_dryrun(
+            self._work_order_with_snapshot("write"),
+            seen_nonces=set(),
+        )
+        assert receipt.decision in {DECISION_ACCEPT, DECISION_ACCEPT_WITH_GAP}
+
+    def test_admin_snapshot_still_blocks_admin_operation_in_dry_run(self):
+        order = self._work_order_with_snapshot("admin")
+        order["requested_operation"] = "grant_permission_admin"
+        receipt = validate_work_order_dryrun(order, seen_nonces=set())
+        assert receipt.decision == DECISION_REJECT
+        assert "forbidden_requested_operation" in receipt.rejection_reasons
+
+
+class TestReadOnlyGhAllowlist:
+    def test_non_allowlisted_gh_command_blocked(self):
+        from modules.platform_integration.github_integration.src.reddog_github_permission_probe import (
+            _run_gh_readonly,
+        )
+
+        with pytest.raises(ValueError, match="not allowlisted"):
+            _run_gh_readonly(["pr", "create"])


### PR DESCRIPTION
## Summary

- Adds `probe_repo_permission()` in `modules/platform_integration/github_integration/src/reddog_github_permission_probe.py` — read-only GitHub permission evidence for `RedDogGovernedWorkOrder.repo_permission_snapshot`.
- Injectable `PermissionProbeBackend`; default `GhCliPermissionProbeBackend` allowlists only read-only `gh` commands (`auth status`, `api user`, `repo view --json`, branch protection GET).
- Conservative capability mapping (fail-closed on missing auth / unknown permission); snapshot digest + TTL freshness helper; no token values in output or logs.
- 14 pytest cases (mocks only); integration test confirms snapshot accepted by #890 dry-run validator.
- Extension INTERFACE/ROADMAP/ModLog pointers + contract test updates.

**Sequencing:** #891 (queue docs) landed @ `3cbc58913`. This PR rebased onto `main` — single commit, probe-only diff.

## Read-only proof

- No branch/PR/commit/merge/file-write paths in probe module.
- `_run_gh_readonly` blocks non-allowlisted commands and secret-exposing flags.
- Missing auth returns `permission: unknown` without raising.

## Test plan

- [x] `pytest` probe + dry-run (28 passed)
- [x] `node extensions/foundups_advisory_workers/tests/verify_extension_contract.js`
- [x] `git diff --check` clean

## Residual (non-blocking)

- `permission_truth_label: OBSERVED | NEEDS_VERIFICATION` — deferred to OpenClaw policy gate slice when `viewerPermission` absent.

## Residual SPECIFIED_NOT_IMPLEMENTED

- Extension runtime invocation of permission probe
- OpenClaw policy gate wiring (next P0)
- Hermes work-order receipt persistence
- WRE isolated worktree executor
