### PR TITLE
feat(reddog): add OpenClaw work-order policy gate (no execution)

### DIFF
--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -75,6 +75,8 @@ RedDog is the 0102 architect interface — **not an authority owner**. RedDog re
 
 **Permission probe (read-only):** `modules/platform_integration/github_integration/src/reddog_github_permission_probe.py` — `probe_repo_permission()` produces fresh `repo_permission_snapshot` evidence. Extension does not invoke it yet.
 
+**OpenClaw policy gate (no execution):** `modules/communication/moltbot_bridge/src/reddog_openclaw_work_order_policy_gate.py` — `evaluate_work_order_policy_gate()` composes dry-run + permission freshness + HoloIndex policy; returns `PolicyGateReceipt`. Extension does not invoke it yet.
+
 **Specified flow (not implemented in extension v0.3.27):**
 
 ```text
@@ -300,6 +302,7 @@ Formal contract:
 | Redaction gate before OpenRouter | OBSERVED |
 | Governed handoff contract (typed WRE dispatch) | SPECIFIED_NOT_IMPLEMENTED |
 | GitHub permission probe (read-only snapshot) | OBSERVED (github_integration module) |
+| OpenClaw work-order policy gate | OBSERVED (moltbot_bridge module); no execution |
 | Governed repo work order dry-run validator | OBSERVED (OpenClaw bridge module) |
 | Governed repo work order (`RedDogGovernedWorkOrder`) | SPECIFIED_NOT_IMPLEMENTED (runtime emission from extension) |
 | GitHub permission snapshot per work order | SPECIFIED_NOT_IMPLEMENTED |

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -1,5 +1,12 @@
 # Foundups®Agent ModLog
 
+## 2026-06-28 - REDDOG_OPENCLAW_WORK_ORDER_POLICY_GATE_PHASE1 (extension pointers)
+
+- Points to `modules/communication/moltbot_bridge/src/reddog_openclaw_work_order_policy_gate.py`.
+- Policy gate composes #890 dry-run + #892 permission snapshot freshness; Hermes-shaped receipt; no execution.
+
+WSP: WSP_34, WSP_50, WSP_97.
+
 ## 2026-06-28 - REDDOG_GITHUB_PERMISSION_PROBE_PHASE1 (extension pointers)
 
 - Points to `modules/platform_integration/github_integration/src/reddog_github_permission_probe.py`.

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -76,25 +76,25 @@ DONE
 2. #888 schema repair hardening (9c3a8f829, v0.3.27)
 3. #889 governed repo work-order contract (764084bc4)
 4. #890 governed work-order dry-run validator (bd68ab83a)
+5. #891 post-#890 queue docs (3cbc58913)
+6. #892 GitHub permission probe (21aeff32d)
 
-P0 NEXT (sequenced — permission before OpenClaw wiring)
-5. REDDOG_GITHUB_PERMISSION_PROBE_PHASE1
-   - read-only GitHub permission snapshot; no branch/PR/write
-6. REDDOG_OPENCLAW_WORK_ORDER_POLICY_GATE_PHASE1
-   - OpenClaw calls dry-run validator; still no execution
-7. REDDOG_HERMES_WORK_ORDER_RECEIPT_PHASE1
-   - persist dry-run receipts
-8. REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_PHASE1
-   - only after policy + permission + receipts proven
+P0 NEXT (sequenced — policy before receipts before executor)
+7. REDDOG_OPENCLAW_WORK_ORDER_POLICY_GATE_PHASE1
+   - dry-run + permission freshness + HoloIndex policy; still no execution
+8. REDDOG_HERMES_WORK_ORDER_RECEIPT_PHASE1
+   - persist policy gate receipts
+9. REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_PHASE1
+   - only after policy + receipts proven
 
 P1
-9. REDDOG_SANITIZED_TARGET_CONTEXT_PROVENANCE_PHASE1
-10. REDDOG_RUN_TRACE_TELEMETRY_CORRECTION_PHASE1
-11. HOLOINDEX_REDDOG_GOVERNED_WORK_ORDER_INDEX_GAP_PHASE1
+10. REDDOG_SANITIZED_TARGET_CONTEXT_PROVENANCE_PHASE1
+11. REDDOG_RUN_TRACE_TELEMETRY_CORRECTION_PHASE1
+12. HOLOINDEX_REDDOG_GOVERNED_WORK_ORDER_INDEX_GAP_PHASE1
 
 P2/P3
-12. REDDOG_REVIEW_CONSENSUS_RECEIPTS_PHASE1
-13. REDDOG_AUTONOMOUS_MERGE_POLICY_PHASE1 (blocked)
+13. REDDOG_REVIEW_CONSENSUS_RECEIPTS_PHASE1
+14. REDDOG_AUTONOMOUS_MERGE_POLICY_PHASE1 (blocked)
 ```
 
 **Rationale:** Sanitized provenance and telemetry are real polish issues, but the strategic blocker is that RedDog still cannot safely become a worker. The work-order contract is the missing bridge between “advisory RedDog” and “RedDog can direct WRE to do meaningful code work.”
@@ -191,22 +191,22 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 
 ### REDDOG_GITHUB_PERMISSION_PROBE_PHASE1
 
-- **Status:** **PR-READY** — read-only `probe_repo_permission()` in github_integration.
+- **Status:** **LANDED** #892 (`21aeff32d`) — read-only `probe_repo_permission()` in github_integration.
 - **Module:** `modules/platform_integration/github_integration/src/reddog_github_permission_probe.py`
-- Maps to `repo_permission_snapshot` for `#890` dry-run validator.
-- **Rationale:** OpenClaw can validate envelope shape only after fresh permission evidence exists.
 
 ### REDDOG_OPENCLAW_WORK_ORDER_POLICY_GATE_PHASE1
 
-- **Status:** **P0 QUEUED** — after permission probe; OpenClaw calls `validate_work_order_dryrun()`; still no execution.
+- **Status:** **PR-READY** — `evaluate_work_order_policy_gate()` in moltbot_bridge.
+- **Module:** `modules/communication/moltbot_bridge/src/reddog_openclaw_work_order_policy_gate.py`
+- Composes #890 dry-run + permission freshness + HoloIndex policy (Addenda A–D); Hermes-shaped receipt; no execution.
 
 ### REDDOG_HERMES_WORK_ORDER_RECEIPT_PHASE1
 
-- **Status:** **P0 QUEUED** — persist dry-run receipts; Hermes lifecycle only; no execution dispatch.
+- **Status:** **P0 QUEUED** — persist policy gate receipts; Hermes lifecycle only; no execution dispatch.
 
 ### REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_PHASE1
 
-- **Status:** **P0 QUEUED** — after permission probe + OpenClaw gate + Hermes receipts.
+- **Status:** **P0 QUEUED** — after OpenClaw gate + Hermes receipts.
 
 ### REDDOG_REVIEW_CONSENSUS_RECEIPTS_PHASE1
 

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -183,6 +183,12 @@ includes(dryrunPy, 'HoloIndexEvidencePacket', 'HoloIndex evidence packet missing
 const probePy = fs.readFileSync(path.join(root, 'modules', 'platform_integration', 'github_integration', 'src', 'reddog_github_permission_probe.py'), 'utf8');
 includes(probePy, 'probe_repo_permission', 'GitHub permission probe missing');
 includes(probePy, 'raw_secret_included', 'probe raw_secret_included flag missing');
+const policyGatePy = fs.readFileSync(path.join(root, 'modules', 'communication', 'moltbot_bridge', 'src', 'reddog_openclaw_work_order_policy_gate.py'), 'utf8');
+includes(policyGatePy, 'evaluate_work_order_policy_gate', 'OpenClaw policy gate missing');
+includes(policyGatePy, 'POLICY_ACCEPT_WITH_RETRIEVAL_GAP', 'policy gate retrieval gap decision missing');
+includes(policyGatePy, 'no_execution_performed', 'policy gate no_execution_performed missing');
+includes(policyGatePy, 'permission_truth_label', 'policy gate permission_truth_label missing');
+includes(iface, 'reddog_openclaw_work_order_policy_gate.py', 'INTERFACE policy gate pointer missing');
 includes(iface, 'reddog_github_permission_probe.py', 'INTERFACE permission probe pointer missing');
 includes(iface, 'reddog_governed_work_order_dryrun.py', 'INTERFACE dry-run module pointer missing');
 includes(auditDoc, 'authenticated principal', 'audit doc principal wording missing');
@@ -192,6 +198,7 @@ includes(iface, 'REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md', 'INTERFACE
 includes(readme, 'REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md', 'README audit doc pointer missing');
 includes(roadmap, 'docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md', 'audit doc path missing from roadmap');
 includes(roadmap, 'REDDOG_GITHUB_PERMISSION_PROBE_PHASE1', 'github permission probe slice missing');
+includes(roadmap, 'REDDOG_OPENCLAW_WORK_ORDER_POLICY_GATE_PHASE1', 'OpenClaw policy gate slice missing');
 includes(roadmap, 'External RedDog Lane Queue (post-#888)', 'post-#888 external lane queue missing');
 includes(roadmap, 'REDDOG_GOVERNED_REPO_WORK_ORDER_DRYRUN_PHASE1', 'governed work order dryrun slice missing');
 includes(roadmap, 'REDDOG_RUN_TRACE_TELEMETRY_CORRECTION_PHASE1', 'run trace telemetry correction slice missing');

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -759,3 +759,21 @@ if mutation_surface_report:
 ```
 
 Higher-priority work (restarts, autonomous tasks, self-audit events) blocks skill evolution report generation.
+
+### RedDog Governed Work-Order Policy Gate (no execution)
+
+```python
+from modules.communication.moltbot_bridge.src.reddog_openclaw_work_order_policy_gate import (
+    evaluate_work_order_policy_gate,  # (order, *, now, seen_nonces, permission_ttl_seconds, permission_expires_at) -> PolicyGateReceipt
+    PolicyGateReceipt,
+    POLICY_ACCEPT,
+    POLICY_REJECT,
+    POLICY_ACCEPT_WITH_RETRIEVAL_GAP,
+    permission_truth_label,
+)
+```
+
+Composes `#890` `validate_work_order_dryrun()` and embedded `repo_permission_snapshot` freshness
+(uses `#892` `permission_to_capabilities` only — does not call `probe_repo_permission` or `gh`).
+Returns Hermes-shaped receipt with `no_execution_performed: true`. Spec:
+`docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md`.

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,15 @@
 # ModLog - moltbot_bridge
 
+## 2026-06-28: REDDOG_OPENCLAW_WORK_ORDER_POLICY_GATE_PHASE1
+
+**Slice:** OpenClaw policy gate — dry-run + permission freshness + HoloIndex policy (no execution)
+**WSP:** WSP_34, WSP_50, WSP_97, WSP_22
+
+- ADD `src/reddog_openclaw_work_order_policy_gate.py` — `evaluate_work_order_policy_gate()` returns Hermes-shaped `PolicyGateReceipt`.
+- ADD `tests/test_reddog_openclaw_work_order_policy_gate.py` — 22 tests (Addenda A–D; mocked permissions only).
+- Reuses #890 `validate_work_order_dryrun()` and #892 `permission_to_capabilities()`; no WAE runtime, no `gh`, no execution.
+- WAE-L1 ↔ RedDog ↔ PolicyGateReceipt mapping in module docstring (Addendum B).
+
 ## 2026-06-28: REDDOG_GOVERNED_REPO_WORK_ORDER_DRYRUN_PHASE1
 
 **Slice:** External RedDog lane dry-run validator (shared with future OpenClaw policy gate)

--- a/modules/communication/moltbot_bridge/src/reddog_openclaw_work_order_policy_gate.py
+++ b/modules/communication/moltbot_bridge/src/reddog_openclaw_work_order_policy_gate.py
@@ -1,0 +1,325 @@
+"""OpenClaw RedDog governed work-order policy gate (no execution).
+
+Slice: REDDOG_OPENCLAW_WORK_ORDER_POLICY_GATE_PHASE1
+Contract: docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md
+
+Convergence point before any future WRE execution. Validates dry-run envelope,
+permission snapshot freshness/capability, and HoloIndex evidence policy — without
+branch, PR, commit, merge, file write, WRE executor, or Hermes queue dispatch.
+
+WAE-L1 / external RedDog alignment (Addendum B — mapping only, no WAE refactor):
+| WAE-L1 direction field      | RedDogGovernedWorkOrder field   | PolicyGateReceipt field        |
+|-----------------------------|---------------------------------|--------------------------------|
+| direction_id                | work_order_id                   | work_order_id                  |
+| created_at                  | created_at                      | checked_at (gate evaluation)   |
+| principal_id                | authenticated_principal         | (via permission_truth_label)   |
+| target_repo                 | repo_full_name                  | permission_snapshot_digest     |
+| proposed_action             | requested_operation             | gates_checked (capability)     |
+| authority_hint              | authority_tier                  | rejection_reasons              |
+| path_scope                  | allowed_paths / denied_paths    | dry_run_receipt_digest         |
+| branch_hint                 | branch_name / base_ref          | dry_run_receipt_digest         |
+| holo_evidence_packet        | holoindex_evidence              | holoindex_evidence_digest      |
+| wsp_tags                    | wsp_applicability               | holoindex_evidence_digest      |
+| skillz_hints                | skillz_candidates               | rejection_reasons (skillz)     |
+| advisory_digest             | evidence_digest                 | receipt_digest                 |
+| source_packet               | advisory_only_source_packet     | SPECIFIED_NOT_IMPLEMENTED      |
+| (no WAE runtime dispatch)   | (no extension execution)        | no_execution_performed: true   |
+
+Field gaps marked SPECIFIED_NOT_IMPLEMENTED — do not refactor WAE in this slice.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Mapping, MutableSet, Optional, Union
+
+from modules.communication.moltbot_bridge.src.reddog_governed_work_order_dryrun import (
+    DECISION_ACCEPT,
+    DECISION_ACCEPT_WITH_GAP,
+    DECISION_REJECT,
+    DOCS_ONLY_OPERATIONS,
+    RedDogGovernedWorkOrder,
+    validate_work_order_dryrun,
+    _is_write_sensitive_operation,
+    _normalize_operation,
+    _work_order_from_mapping,
+)
+from modules.platform_integration.github_integration.src.reddog_github_permission_probe import (
+    permission_to_capabilities,
+)
+
+POLICY_ACCEPT = "POLICY_ACCEPT"
+POLICY_REJECT = "POLICY_REJECT"
+POLICY_ACCEPT_WITH_RETRIEVAL_GAP = "POLICY_ACCEPT_WITH_RETRIEVAL_GAP"
+
+TRUTH_OBSERVED = "OBSERVED"
+TRUTH_NEEDS_VERIFICATION = "NEEDS_VERIFICATION"
+
+DEFAULT_PERMISSION_TTL_SECONDS = 300
+TRUSTED_PERMISSION_SOURCES = frozenset({"gh_cli", "github_api", "mock"})
+
+
+@dataclass
+class PolicyGateReceipt:
+    receipt_id: str
+    work_order_id: str
+    decision: str
+    rejection_reasons: List[str]
+    gates_checked: List[str]
+    dry_run_receipt_digest: str
+    permission_snapshot_digest: str
+    permission_truth_label: str
+    holoindex_evidence_digest: str
+    no_execution_performed: bool
+    checked_at: str
+    expires_at: Optional[str]
+    next_required_check_at: Optional[str]
+    receipt_digest: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def _utc_now(now: Optional[datetime] = None) -> datetime:
+    value = now or datetime.now(timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _iso8601(dt: datetime) -> str:
+    return dt.replace(microsecond=0).isoformat()
+
+
+def _parse_iso8601(value: str) -> datetime:
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _canonical_digest(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def permission_truth_label(permission_level: str, source: str) -> str:
+    """OBSERVED when permission is proven; NEEDS_VERIFICATION when not."""
+    level = (permission_level or "").strip().lower()
+    src = (source or "").strip().lower()
+    if level in {"unknown", "none", ""}:
+        return TRUTH_NEEDS_VERIFICATION
+    if src in TRUSTED_PERMISSION_SOURCES and level in {
+        "admin",
+        "maintain",
+        "write",
+        "triage",
+        "read",
+    }:
+        return TRUTH_OBSERVED
+    if level in {"admin", "maintain", "write", "triage", "read"}:
+        return TRUTH_OBSERVED
+    return TRUTH_NEEDS_VERIFICATION
+
+
+def _permission_snapshot_fresh(
+    captured_at: str,
+    *,
+    now: datetime,
+    ttl_seconds: int = DEFAULT_PERMISSION_TTL_SECONDS,
+    expires_at: Optional[str] = None,
+) -> bool:
+    if expires_at:
+        try:
+            return now <= _parse_iso8601(expires_at)
+        except ValueError:
+            return False
+    try:
+        captured = _parse_iso8601(captured_at)
+        return now <= captured + timedelta(seconds=max(1, ttl_seconds))
+    except ValueError:
+        return False
+
+
+def _holoindex_evidence_digest(work_order: RedDogGovernedWorkOrder) -> str:
+    holo = work_order.holoindex_evidence
+    if holo is None:
+        return _canonical_digest({"missing": True})
+    payload = {
+        "holoindex_status": holo.holoindex_status,
+        "retrieval_quality": holo.retrieval_quality,
+        "applicable_wsps": sorted(holo.applicable_wsps),
+        "evidence_refs": sorted(holo.evidence_refs),
+        "direct_read_fallback_used": holo.direct_read_fallback_used,
+        "index_gap_detected": holo.index_gap_detected,
+        "skillz_gap_detected": holo.skillz_gap_detected,
+    }
+    return _canonical_digest(payload)
+
+
+def _evaluate_holoindex_policy(work_order: RedDogGovernedWorkOrder) -> List[str]:
+    """Addendum A — HoloIndex evidence enforcement at policy layer."""
+    reasons: List[str] = []
+    holo = work_order.holoindex_evidence
+    op_norm = _normalize_operation(work_order.requested_operation)
+    write_sensitive = _is_write_sensitive_operation(op_norm)
+
+    if holo is None:
+        return ["missing_holoindex_evidence"]
+
+    required_fields = {
+        "holoindex_status": holo.holoindex_status,
+        "retrieval_quality": holo.retrieval_quality,
+        "applicable_wsps": holo.applicable_wsps,
+        "evidence_refs": holo.evidence_refs,
+    }
+    if write_sensitive:
+        for name, value in required_fields.items():
+            if not value:
+                reasons.append("missing_holoindex_evidence")
+
+    if holo.retrieval_quality == "INDEX_GAP" or holo.index_gap_detected:
+        if write_sensitive:
+            reasons.append("index_gap_blocks_write_operation")
+        elif op_norm not in DOCS_ONLY_OPERATIONS:
+            reasons.append("index_gap_blocks_non_docs_operation")
+
+    if write_sensitive and holo.retrieval_quality in {"LOW", "MEDIUM"}:
+        if not holo.direct_read_fallback_used:
+            reasons.append("weak_wsp_recall_requires_direct_read_fallback")
+        elif not holo.evidence_refs:
+            reasons.append("weak_wsp_recall_missing_direct_read_ref")
+
+    return reasons
+
+
+def _permission_supports_operation(permission_level: str, operation: str) -> bool:
+    op_norm = _normalize_operation(operation)
+    can_read, can_write, _ = permission_to_capabilities(permission_level)
+    if op_norm in DOCS_ONLY_OPERATIONS:
+        return can_read
+    if _is_write_sensitive_operation(op_norm):
+        return can_write
+    return can_read
+
+
+def evaluate_work_order_policy_gate(
+    order: Union[RedDogGovernedWorkOrder, Mapping[str, Any]],
+    *,
+    now: Optional[datetime] = None,
+    seen_nonces: Optional[MutableSet[str]] = None,
+    permission_ttl_seconds: int = DEFAULT_PERMISSION_TTL_SECONDS,
+    permission_expires_at: Optional[str] = None,
+) -> PolicyGateReceipt:
+    """Evaluate OpenClaw policy gate for a governed work order. No execution performed."""
+    if isinstance(order, Mapping):
+        work_order = _work_order_from_mapping(order)
+    else:
+        work_order = order
+
+    checked = _utc_now(now)
+    gates_checked: List[str] = ["dry_run_validator"]
+    rejection_reasons: List[str] = []
+
+    dry_run = validate_work_order_dryrun(work_order, now=checked, seen_nonces=seen_nonces)
+    gates_checked.extend(dry_run.gates_checked)
+    if dry_run.decision == DECISION_REJECT:
+        rejection_reasons.extend(dry_run.rejection_reasons)
+
+    gates_checked.append("holoindex_evidence_policy")
+    holo_reasons = _evaluate_holoindex_policy(work_order)
+    rejection_reasons.extend(holo_reasons)
+
+    snap = work_order.repo_permission_snapshot
+    truth = permission_truth_label(snap.permission_level, snap.source)
+    gates_checked.append("permission_snapshot_freshness")
+    fresh = _permission_snapshot_fresh(
+        snap.captured_at,
+        now=checked,
+        ttl_seconds=permission_ttl_seconds,
+        expires_at=permission_expires_at,
+    )
+    if not fresh:
+        rejection_reasons.append("stale_permission_snapshot")
+
+    gates_checked.append("permission_capability")
+    op_norm = _normalize_operation(work_order.requested_operation)
+    if not _permission_supports_operation(snap.permission_level, work_order.requested_operation):
+        rejection_reasons.append("insufficient_permission_for_operation")
+
+    if truth == TRUTH_NEEDS_VERIFICATION and _is_write_sensitive_operation(op_norm):
+        rejection_reasons.append("permission_needs_verification")
+
+    permission_expiry_dt: Optional[datetime] = None
+    if permission_expires_at:
+        try:
+            permission_expiry_dt = _parse_iso8601(permission_expires_at)
+        except ValueError:
+            pass
+    elif snap.captured_at:
+        try:
+            permission_expiry_dt = _parse_iso8601(snap.captured_at) + timedelta(
+                seconds=max(1, permission_ttl_seconds)
+            )
+        except ValueError:
+            pass
+
+    work_order_expiry_dt: Optional[datetime] = None
+    try:
+        work_order_expiry_dt = _parse_iso8601(work_order.expiry)
+    except ValueError:
+        pass
+
+    next_check_candidates = [dt for dt in (work_order_expiry_dt, permission_expiry_dt) if dt is not None]
+    next_required_check_at = _iso8601(min(next_check_candidates)) if next_check_candidates else None
+
+    deduped_reasons = list(dict.fromkeys(rejection_reasons))
+
+    if deduped_reasons:
+        decision = POLICY_REJECT
+    elif dry_run.decision == DECISION_ACCEPT_WITH_GAP or (
+        holo := work_order.holoindex_evidence
+    ) and (holo.retrieval_quality == "INDEX_GAP" or holo.index_gap_detected) and op_norm in DOCS_ONLY_OPERATIONS:
+        decision = POLICY_ACCEPT_WITH_RETRIEVAL_GAP
+    elif dry_run.decision == DECISION_ACCEPT:
+        decision = POLICY_ACCEPT
+    else:
+        decision = POLICY_REJECT
+        if "policy_gate_unexpected_dry_run_state" not in deduped_reasons:
+            deduped_reasons.append("policy_gate_unexpected_dry_run_state")
+
+    holo_digest = _holoindex_evidence_digest(work_order)
+    id_seed = _canonical_digest(
+        {
+            "work_order_id": work_order.work_order_id,
+            "checked_at": _iso8601(checked),
+            "nonce": work_order.nonce,
+        }
+    )
+    receipt_id = f"policy-gate-{work_order.work_order_id}-{id_seed[:12]}"
+
+    receipt_core = {
+        "receipt_id": receipt_id,
+        "work_order_id": work_order.work_order_id,
+        "decision": decision,
+        "rejection_reasons": deduped_reasons,
+        "gates_checked": gates_checked,
+        "dry_run_receipt_digest": dry_run.receipt_digest,
+        "permission_snapshot_digest": snap.digest,
+        "permission_truth_label": truth,
+        "holoindex_evidence_digest": holo_digest,
+        "no_execution_performed": True,
+        "checked_at": _iso8601(checked),
+        "expires_at": work_order.expiry,
+        "next_required_check_at": next_required_check_at,
+    }
+    receipt_digest = _canonical_digest(receipt_core)
+
+    return PolicyGateReceipt(
+        receipt_digest=receipt_digest,
+        **receipt_core,
+    )

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,14 @@
+## 2026-06-28: REDDOG_OPENCLAW_WORK_ORDER_POLICY_GATE_PHASE1
+
+**File**: `test_reddog_openclaw_work_order_policy_gate.py` (NEW — 22 tests)
+**Slice**: `REDDOG_OPENCLAW_WORK_ORDER_POLICY_GATE_PHASE1` | **Predecessors**: #890 dry-run, #892 permission probe
+
+Policy gate tests use mocked `repo_permission_snapshot` only (Addendum D — no live `gh`).
+Covers: accept write/audit, reject admin/stale/replay/forbidden paths, HoloIndex Addendum A paths,
+receipt compatibility (Addendum C), WAE runtime non-import (Addendum B).
+
+**Run**: `pytest modules/communication/moltbot_bridge/tests/test_reddog_openclaw_work_order_policy_gate.py -q`
+
 ## 2026-06-02: PolicyFlags Deserialization Sanitization Tests (W6)
 
 **File**: `test_foundup_job_contract.py` (UPDATED + new class)

--- a/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_work_order_policy_gate.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_work_order_policy_gate.py
@@ -1,0 +1,352 @@
+"""Tests for OpenClaw RedDog work-order policy gate (no execution, mocked permissions)."""
+
+from __future__ import annotations
+
+import ast
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_openclaw_work_order_policy_gate import (
+    POLICY_ACCEPT,
+    POLICY_ACCEPT_WITH_RETRIEVAL_GAP,
+    POLICY_REJECT,
+    TRUTH_NEEDS_VERIFICATION,
+    TRUTH_OBSERVED,
+    evaluate_work_order_policy_gate,
+    permission_truth_label,
+)
+from modules.communication.moltbot_bridge.src.reddog_governed_work_order_dryrun import (
+    validate_work_order_dryrun,
+)
+
+
+def _future_expiry(hours: int = 2) -> str:
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).replace(microsecond=0).isoformat()
+
+
+def _fresh_captured() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _base_order(**overrides):
+    payload = {
+        "work_order_id": "wo-policy-001",
+        "created_at": _fresh_captured(),
+        "red_dog_instance_id": "reddog-ext-0.3.27",
+        "authenticated_principal": "principal-012",
+        "principal_provider": "github",
+        "repo_full_name": "FOUNDUPS/Foundups-Agent",
+        "repo_permission_snapshot": {
+            "permission_level": "write",
+            "captured_at": _fresh_captured(),
+            "source": "mock",
+            "digest": "sha256:" + ("a" * 64),
+        },
+        "requested_operation": "feature_slice",
+        "authority_tier": "source",
+        "allowed_paths": ["modules/communication/moltbot_bridge/**"],
+        "denied_paths": [".env"],
+        "branch_name": "feat/policy-gate-test",
+        "base_ref": "main",
+        "task_summary": "Policy gate validation slice",
+        "wsp_applicability": ["WSP_34", "WSP_50", "WSP_97"],
+        "holoindex_evidence_refs": [
+            "docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md"
+        ],
+        "skillz_candidates": ["qwen_wsp_enhancement"],
+        "required_tests": [
+            "modules/communication/moltbot_bridge/tests/test_reddog_openclaw_work_order_policy_gate.py"
+        ],
+        "required_policy_gates": ["openclaw_policy_gate", "github_permission_fresh"],
+        "required_reviewers": [],
+        "sentinel_checks": [],
+        "rollback_plan": "No execution performed.",
+        "expiry": _future_expiry(),
+        "nonce": "nonce-policy-001",
+        "evidence_digest": "sha256:" + ("b" * 64),
+        "advisory_only_source_packet": {
+            "work_focus_digest": "sha256:" + ("c" * 64),
+            "wsp_prompt_digest": "sha256:" + ("d" * 64),
+            "copy_md_run_trace_digest": "sha256:" + ("e" * 64),
+        },
+        "holoindex_evidence": {
+            "holoindex_query": "RedDog OpenClaw policy gate",
+            "holoindex_status": "bundle_json_ok",
+            "code_hits": [
+                "modules/communication/moltbot_bridge/src/reddog_openclaw_work_order_policy_gate.py"
+            ],
+            "wsp_hits": ["WSP_framework/src/WSP_34_Git_Operations_Protocol.md"],
+            "skillz_hits": ["qwen_wsp_enhancement"],
+            "direct_read_fallback_used": False,
+            "index_gap_detected": False,
+            "applicable_wsps": ["WSP_34", "WSP_50", "WSP_97"],
+            "evidence_refs": [
+                "docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md"
+            ],
+            "retrieval_quality": "HIGH",
+            "skillz_gap_detected": False,
+        },
+    }
+    snap_override = overrides.pop("repo_permission_snapshot", None)
+    payload.update(overrides)
+    if snap_override:
+        payload["repo_permission_snapshot"] = {
+            **payload["repo_permission_snapshot"],
+            **snap_override,
+        }
+    if "holoindex_evidence" in overrides and overrides["holoindex_evidence"] is None:
+        payload.pop("holoindex_evidence", None)
+    return payload
+
+
+class TestPolicyAccept:
+    def test_write_operation_with_fresh_write_snapshot(self):
+        receipt = evaluate_work_order_policy_gate(_base_order(), seen_nonces=set())
+        assert receipt.decision == POLICY_ACCEPT
+        assert receipt.rejection_reasons == []
+        assert receipt.no_execution_performed is True
+        assert receipt.permission_truth_label == TRUTH_OBSERVED
+
+    def test_audit_only_with_read_permission(self):
+        order = _base_order(
+            requested_operation="audit_only",
+            authority_tier="advisory",
+            branch_name="docs/policy-audit",
+            allowed_paths=["docs/**"],
+            repo_permission_snapshot={
+                "permission_level": "read",
+                "captured_at": _fresh_captured(),
+                "source": "mock",
+            },
+        )
+        receipt = evaluate_work_order_policy_gate(order, seen_nonces=set())
+        assert receipt.decision == POLICY_ACCEPT
+        assert receipt.no_execution_performed is True
+
+
+class TestPolicyReject:
+    def test_admin_operation_rejected_even_with_admin_snapshot(self):
+        order = _base_order(
+            requested_operation="grant_permission_admin",
+            repo_permission_snapshot={
+                "permission_level": "admin",
+                "captured_at": _fresh_captured(),
+                "source": "mock",
+            },
+        )
+        receipt = evaluate_work_order_policy_gate(order, seen_nonces=set())
+        assert receipt.decision == POLICY_REJECT
+        assert "forbidden_requested_operation" in receipt.rejection_reasons
+
+    def test_stale_permission_snapshot_rejected(self):
+        past = (datetime.now(timezone.utc) - timedelta(hours=2)).replace(microsecond=0).isoformat()
+        order = _base_order(
+            repo_permission_snapshot={
+                "permission_level": "write",
+                "captured_at": past,
+                "source": "mock",
+            },
+        )
+        receipt = evaluate_work_order_policy_gate(order, seen_nonces=set(), permission_ttl_seconds=300)
+        assert receipt.decision == POLICY_REJECT
+        assert "stale_permission_snapshot" in receipt.rejection_reasons
+
+    def test_replayed_nonce_rejected(self):
+        seen = set()
+        first = evaluate_work_order_policy_gate(
+            _base_order(nonce="nonce-replay-policy"), seen_nonces=seen
+        )
+        assert first.decision == POLICY_ACCEPT
+        second = evaluate_work_order_policy_gate(
+            _base_order(nonce="nonce-replay-policy"), seen_nonces=seen
+        )
+        assert second.decision == POLICY_REJECT
+        assert "replayed_nonce" in second.rejection_reasons
+
+    def test_forbidden_path_in_allowed_scope(self):
+        order = _base_order(allowed_paths=[".env", "docs/**"])
+        receipt = evaluate_work_order_policy_gate(order, seen_nonces=set())
+        assert receipt.decision == POLICY_REJECT
+        assert "forbidden_paths_in_allowed_scope" in receipt.rejection_reasons
+
+    def test_insufficient_permission_for_write(self):
+        order = _base_order(
+            repo_permission_snapshot={
+                "permission_level": "read",
+                "captured_at": _fresh_captured(),
+                "source": "mock",
+            },
+        )
+        receipt = evaluate_work_order_policy_gate(order, seen_nonces=set())
+        assert receipt.decision == POLICY_REJECT
+        assert "insufficient_permission_for_operation" in receipt.rejection_reasons
+
+    def test_unknown_permission_blocks_write_with_needs_verification(self):
+        order = _base_order(
+            repo_permission_snapshot={
+                "permission_level": "unknown",
+                "captured_at": _fresh_captured(),
+                "source": "gh_cli",
+            },
+        )
+        receipt = evaluate_work_order_policy_gate(order, seen_nonces=set())
+        assert receipt.decision == POLICY_REJECT
+        assert receipt.permission_truth_label == TRUTH_NEEDS_VERIFICATION
+        assert "permission_needs_verification" in receipt.rejection_reasons
+
+
+class TestHoloIndexPolicy:
+    def test_missing_holoindex_evidence_rejected(self):
+        receipt = evaluate_work_order_policy_gate(
+            _base_order(holoindex_evidence=None), seen_nonces=set()
+        )
+        assert receipt.decision == POLICY_REJECT
+        assert "missing_holoindex_evidence" in receipt.rejection_reasons
+
+    def test_index_gap_write_operation_rejected(self):
+        order = _base_order()
+        order["holoindex_evidence"]["retrieval_quality"] = "INDEX_GAP"
+        order["holoindex_evidence"]["index_gap_detected"] = True
+        receipt = evaluate_work_order_policy_gate(order, seen_nonces=set())
+        assert receipt.decision == POLICY_REJECT
+        assert "index_gap_blocks_write_operation" in receipt.rejection_reasons
+
+    def test_index_gap_audit_only_accept_with_retrieval_gap(self):
+        order = _base_order(
+            requested_operation="audit_only",
+            authority_tier="advisory",
+            branch_name="docs/audit-gap",
+            allowed_paths=["docs/**"],
+        )
+        order["holoindex_evidence"]["retrieval_quality"] = "INDEX_GAP"
+        order["holoindex_evidence"]["index_gap_detected"] = True
+        order["holoindex_evidence"]["evidence_refs"] = []
+        receipt = evaluate_work_order_policy_gate(order, seen_nonces=set())
+        assert receipt.decision == POLICY_ACCEPT_WITH_RETRIEVAL_GAP
+        assert receipt.rejection_reasons == []
+
+    def test_weak_wsp_recall_without_fallback_rejected(self):
+        order = _base_order()
+        order["holoindex_evidence"]["retrieval_quality"] = "LOW"
+        order["holoindex_evidence"]["direct_read_fallback_used"] = False
+        receipt = evaluate_work_order_policy_gate(order, seen_nonces=set())
+        assert receipt.decision == POLICY_REJECT
+        assert "weak_wsp_recall_requires_direct_read_fallback" in receipt.rejection_reasons
+
+    def test_weak_wsp_recall_with_fallback_and_refs_accepts(self):
+        order = _base_order()
+        order["holoindex_evidence"]["retrieval_quality"] = "LOW"
+        order["holoindex_evidence"]["direct_read_fallback_used"] = True
+        order["holoindex_evidence"]["evidence_refs"] = [
+            "docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md"
+        ]
+        receipt = evaluate_work_order_policy_gate(order, seen_nonces=set())
+        assert receipt.decision == POLICY_ACCEPT
+
+    def test_weak_wsp_recall_with_fallback_missing_refs_rejected(self):
+        order = _base_order()
+        order["holoindex_evidence"]["retrieval_quality"] = "LOW"
+        order["holoindex_evidence"]["direct_read_fallback_used"] = True
+        order["holoindex_evidence"]["evidence_refs"] = []
+        receipt = evaluate_work_order_policy_gate(order, seen_nonces=set())
+        assert receipt.decision == POLICY_REJECT
+        assert "weak_wsp_recall_missing_direct_read_ref" in receipt.rejection_reasons
+
+
+class TestReceiptCompatibility:
+    def test_receipt_digest_stable_for_same_input(self):
+        fixed = datetime(2026, 6, 28, 14, 0, 0, tzinfo=timezone.utc)
+        captured = (fixed - timedelta(seconds=60)).replace(microsecond=0).isoformat()
+        order = _base_order(
+            nonce="nonce-stable-digest",
+            repo_permission_snapshot={
+                "permission_level": "write",
+                "captured_at": captured,
+                "source": "mock",
+            },
+        )
+        kwargs = {"seen_nonces": set(), "now": fixed}
+
+        first = evaluate_work_order_policy_gate(order, **kwargs)
+        second = evaluate_work_order_policy_gate(order, seen_nonces=set(), now=fixed)
+
+        assert first.to_dict() == second.to_dict()
+        assert first.receipt_digest == second.receipt_digest
+
+    def test_receipt_json_serializable_no_secrets(self):
+        receipt = evaluate_work_order_policy_gate(_base_order(nonce="nonce-json"), seen_nonces=set())
+        blob = json.dumps(receipt.to_dict())
+        assert "ghp_" not in blob
+        assert "sk-" not in blob
+        parsed = json.loads(blob)
+        assert parsed["no_execution_performed"] is True
+        assert "receipt_digest" in parsed
+        assert "holoindex_evidence_digest" in parsed
+        assert "dry_run_receipt_digest" in parsed
+        assert "permission_snapshot_digest" in parsed
+        assert "next_required_check_at" in parsed
+
+    def test_required_receipt_fields_present(self):
+        receipt = evaluate_work_order_policy_gate(_base_order(nonce="nonce-fields"), seen_nonces=set())
+        data = receipt.to_dict()
+        for key in (
+            "receipt_id",
+            "work_order_id",
+            "decision",
+            "rejection_reasons",
+            "gates_checked",
+            "dry_run_receipt_digest",
+            "permission_snapshot_digest",
+            "permission_truth_label",
+            "holoindex_evidence_digest",
+            "no_execution_performed",
+            "checked_at",
+            "expires_at",
+            "next_required_check_at",
+            "receipt_digest",
+        ):
+            assert key in data
+
+
+class TestNoWaeRuntimeOrLiveGithub:
+    def test_policy_gate_does_not_import_wae_runtime(self):
+        module_path = (
+            Path(__file__).resolve().parents[1]
+            / "src"
+            / "reddog_openclaw_work_order_policy_gate.py"
+        )
+        tree = ast.parse(module_path.read_text(encoding="utf-8"))
+        imported = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.append(node.module)
+        wae_hits = [name for name in imported if "wae" in name.lower()]
+        assert wae_hits == []
+
+    def test_policy_gate_module_has_no_live_github_probe(self):
+        source = (
+            Path(__file__).resolve().parents[1]
+            / "src"
+            / "reddog_openclaw_work_order_policy_gate.py"
+        ).read_text(encoding="utf-8")
+        assert "import subprocess" not in source
+        assert "from modules.platform_integration.github_integration" in source
+        assert "permission_to_capabilities" in source
+
+
+class TestPermissionTruthLabel:
+    def test_observed_for_proven_permission(self):
+        assert permission_truth_label("write", "gh_cli") == TRUTH_OBSERVED
+
+    def test_needs_verification_for_unknown(self):
+        assert permission_truth_label("unknown", "gh_cli") == TRUTH_NEEDS_VERIFICATION
+
+
+class TestDryRunDelegation:
+    def test_dry_run_still_independent(self):
+        order = _base_order(nonce="nonce-dryrun-only")
+        dry = validate_work_order_dryrun(order, seen_nonces=set())
+        assert dry.no_mutation_performed is True


### PR DESCRIPTION
## Summary

- Adds `evaluate_work_order_policy_gate()` in `modules/communication/moltbot_bridge/src/reddog_openclaw_work_order_policy_gate.py`.
- Composes #890 `validate_work_order_dryrun()` + embedded permission snapshot freshness (#892 capability mapping only) + HoloIndex policy enforcement.
- Returns Hermes-shaped `PolicyGateReceipt` with `no_execution_performed: true`.
- 22 pytest cases (mocked permissions only — Addendum D).

## Addenda

- **A:** HoloIndex evidence gate input (INDEX_GAP write reject, audit-only accept-with-gap, weak WSP + fallback refs)
- **B:** WAE-L1 ↔ RedDog ↔ PolicyGateReceipt mapping in docstring; no WAE runtime import
- **C:** Receipt fields for future Hermes persistence (stable digest, JSON-serializable, no secrets)
- **D:** Policy tests never call `gh` or `probe_repo_permission`

## Gate matrix

| Check | Reject reason |
|-------|---------------|
| Dry-run WOULD_REJECT | propagated |
| Missing/stale permission | `stale_permission_snapshot` |
| Insufficient permission | `insufficient_permission_for_operation` |
| Unknown permission + write op | `permission_needs_verification` |
| HoloIndex missing | `missing_holoindex_evidence` |
| INDEX_GAP + write | `index_gap_blocks_write_operation` |
| Admin/forbidden ops | from dry-run |

## Test plan

- [x] 50 pytest (22 policy + 13 dry-run + 14 probe + 1 integration path)
- [x] extension contract checks
- [x] git diff --check

## Residual SPECIFIED_NOT_IMPLEMENTED

- Hermes receipt persistence
- Extension/OpenClaw runtime wiring
- WRE isolated worktree executor
- Live `permission_truth_label` from gh probe at gate time (uses embedded snapshot)
