### PR TITLE
feat(reddog): add Hermes-compatible work-order receipt audit layer

### DIFF
--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -77,6 +77,8 @@ RedDog is the 0102 architect interface — **not an authority owner**. RedDog re
 
 **OpenClaw policy gate (no execution):** `modules/communication/moltbot_bridge/src/reddog_openclaw_work_order_policy_gate.py` — `evaluate_work_order_policy_gate()` composes dry-run + permission freshness + HoloIndex policy; returns `PolicyGateReceipt`. Extension does not invoke it yet.
 
+**Work-order receipt (Hermes-compatible audit):** `modules/communication/moltbot_bridge/src/reddog_work_order_receipt.py` — `emit_work_order_receipt()` persists/emits pre-execution audit records from `PolicyGateReceipt`. Extension does not invoke it yet.
+
 **Specified flow (not implemented in extension v0.3.27):**
 
 ```text
@@ -303,6 +305,7 @@ Formal contract:
 | Governed handoff contract (typed WRE dispatch) | SPECIFIED_NOT_IMPLEMENTED |
 | GitHub permission probe (read-only snapshot) | OBSERVED (github_integration module) |
 | OpenClaw work-order policy gate | OBSERVED (moltbot_bridge module); no execution |
+| RedDog work-order receipt (Hermes-compatible audit) | OBSERVED (moltbot_bridge module); not live Hermes queue |
 | Governed repo work order dry-run validator | OBSERVED (OpenClaw bridge module) |
 | Governed repo work order (`RedDogGovernedWorkOrder`) | SPECIFIED_NOT_IMPLEMENTED (runtime emission from extension) |
 | GitHub permission snapshot per work order | SPECIFIED_NOT_IMPLEMENTED |

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -1,5 +1,12 @@
 # Foundups®Agent ModLog
 
+## 2026-06-28 - REDDOG_HERMES_WORK_ORDER_RECEIPT_PHASE1 (extension pointers)
+
+- Points to `modules/communication/moltbot_bridge/src/reddog_work_order_receipt.py`.
+- Pre-execution audit trail from #893 `PolicyGateReceipt`; Hermes-compatible, not live queue.
+
+WSP: WSP_34, WSP_50, WSP_91, WSP_97.
+
 ## 2026-06-28 - REDDOG_OPENCLAW_WORK_ORDER_POLICY_GATE_PHASE1 (extension pointers)
 
 - Points to `modules/communication/moltbot_bridge/src/reddog_openclaw_work_order_policy_gate.py`.

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -78,19 +78,19 @@ DONE
 4. #890 governed work-order dry-run validator (bd68ab83a)
 5. #891 post-#890 queue docs (3cbc58913)
 6. #892 GitHub permission probe (21aeff32d)
+7. #893 OpenClaw policy gate (329db7113)
 
-P0 NEXT (sequenced — policy before receipts before executor)
-7. REDDOG_OPENCLAW_WORK_ORDER_POLICY_GATE_PHASE1
-   - dry-run + permission freshness + HoloIndex policy; still no execution
+P0 NEXT (sequenced — receipts before executor)
 8. REDDOG_HERMES_WORK_ORDER_RECEIPT_PHASE1
-   - persist policy gate receipts
+   - persist policy gate receipts (pre-execution audit)
 9. REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_PHASE1
-   - only after policy + receipts proven
+   - only after receipts proven
 
 P1
 10. REDDOG_SANITIZED_TARGET_CONTEXT_PROVENANCE_PHASE1
 11. REDDOG_RUN_TRACE_TELEMETRY_CORRECTION_PHASE1
 12. HOLOINDEX_REDDOG_GOVERNED_WORK_ORDER_INDEX_GAP_PHASE1
+13. HOLOINDEX_REDDOG_RECEIPT_MODULE_INDEX_GAP_PHASE1 (semantic ranking; static pointers landed)
 
 P2/P3
 13. REDDOG_REVIEW_CONSENSUS_RECEIPTS_PHASE1
@@ -196,17 +196,19 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 
 ### REDDOG_OPENCLAW_WORK_ORDER_POLICY_GATE_PHASE1
 
-- **Status:** **PR-READY** — `evaluate_work_order_policy_gate()` in moltbot_bridge.
+- **Status:** **LANDED** #893 (`329db7113`) — `evaluate_work_order_policy_gate()` in moltbot_bridge.
 - **Module:** `modules/communication/moltbot_bridge/src/reddog_openclaw_work_order_policy_gate.py`
-- Composes #890 dry-run + permission freshness + HoloIndex policy (Addenda A–D); Hermes-shaped receipt; no execution.
 
 ### REDDOG_HERMES_WORK_ORDER_RECEIPT_PHASE1
 
-- **Status:** **P0 QUEUED** — persist policy gate receipts; Hermes lifecycle only; no execution dispatch.
+- **Status:** **PR-READY** — `emit_work_order_receipt()` + SQLite audit store.
+- **Module:** `modules/communication/moltbot_bridge/src/reddog_work_order_receipt.py`
+- Hermes-compatible pre-execution audit; idempotent by `policy_gate_receipt_digest`.
+- HoloIndex: INDEX_GAP for semantic ranking (static INTERFACE/ModLog pointers added).
 
 ### REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_PHASE1
 
-- **Status:** **P0 QUEUED** — after OpenClaw gate + Hermes receipts.
+- **Status:** **P0 QUEUED** — after Hermes receipts.
 
 ### REDDOG_REVIEW_CONSENSUS_RECEIPTS_PHASE1
 

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -188,6 +188,11 @@ includes(policyGatePy, 'evaluate_work_order_policy_gate', 'OpenClaw policy gate 
 includes(policyGatePy, 'POLICY_ACCEPT_WITH_RETRIEVAL_GAP', 'policy gate retrieval gap decision missing');
 includes(policyGatePy, 'no_execution_performed', 'policy gate no_execution_performed missing');
 includes(policyGatePy, 'permission_truth_label', 'policy gate permission_truth_label missing');
+const receiptPy = fs.readFileSync(path.join(root, 'modules', 'communication', 'moltbot_bridge', 'src', 'reddog_work_order_receipt.py'), 'utf8');
+includes(receiptPy, 'emit_work_order_receipt', 'RedDog work order receipt emitter missing');
+includes(receiptPy, 'RedDogWorkOrderReceipt', 'RedDogWorkOrderReceipt schema missing');
+includes(receiptPy, 'no_execution_performed', 'work order receipt no_execution_performed missing');
+includes(iface, 'reddog_work_order_receipt.py', 'INTERFACE work order receipt pointer missing');
 includes(iface, 'reddog_openclaw_work_order_policy_gate.py', 'INTERFACE policy gate pointer missing');
 includes(iface, 'reddog_github_permission_probe.py', 'INTERFACE permission probe pointer missing');
 includes(iface, 'reddog_governed_work_order_dryrun.py', 'INTERFACE dry-run module pointer missing');
@@ -199,6 +204,7 @@ includes(readme, 'REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md', 'README a
 includes(roadmap, 'docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md', 'audit doc path missing from roadmap');
 includes(roadmap, 'REDDOG_GITHUB_PERMISSION_PROBE_PHASE1', 'github permission probe slice missing');
 includes(roadmap, 'REDDOG_OPENCLAW_WORK_ORDER_POLICY_GATE_PHASE1', 'OpenClaw policy gate slice missing');
+includes(roadmap, 'REDDOG_HERMES_WORK_ORDER_RECEIPT_PHASE1', 'Hermes work order receipt slice missing');
 includes(roadmap, 'External RedDog Lane Queue (post-#888)', 'post-#888 external lane queue missing');
 includes(roadmap, 'REDDOG_GOVERNED_REPO_WORK_ORDER_DRYRUN_PHASE1', 'governed work order dryrun slice missing');
 includes(roadmap, 'REDDOG_RUN_TRACE_TELEMETRY_CORRECTION_PHASE1', 'run trace telemetry correction slice missing');

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -777,3 +777,18 @@ Composes `#890` `validate_work_order_dryrun()` and embedded `repo_permission_sna
 (uses `#892` `permission_to_capabilities` only — does not call `probe_repo_permission` or `gh`).
 Returns Hermes-shaped receipt with `no_execution_performed: true`. Spec:
 `docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md`.
+
+### RedDog Work-Order Receipt (Hermes-compatible audit trail, no execution)
+
+```python
+from modules.communication.moltbot_bridge.src.reddog_work_order_receipt import (
+    build_reddog_work_order_receipt,   # PolicyGateReceipt -> RedDogWorkOrderReceipt
+    emit_work_order_receipt,           # optional SQLite persist via RedDogWorkOrderReceiptStore
+    RedDogWorkOrderReceipt,
+    RedDogWorkOrderReceiptStore,
+    RECEIPT_SOURCE,                    # "reddog_openclaw_policy_gate"
+)
+```
+
+Pre-execution audit trail only. Maps #893 `PolicyGateReceipt` into durable Hermes-compatible
+records (digests/refs only). NOT live Hermes queue dispatch, NOT WRE execution.

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,15 @@
 # ModLog - moltbot_bridge
 
+## 2026-06-28: REDDOG_HERMES_WORK_ORDER_RECEIPT_PHASE1
+
+**Slice:** Hermes-compatible pre-execution audit receipts for governed work orders
+**WSP:** WSP_34, WSP_50, WSP_91, WSP_97, WSP_22
+
+- ADD `src/reddog_work_order_receipt.py` — `RedDogWorkOrderReceipt`, `emit_work_order_receipt()`, SQLite `RedDogWorkOrderReceiptStore`.
+- ADD `tests/test_reddog_work_order_receipt.py` — 14 tests (digest stability, redaction, idempotency, no-execution boundary).
+- Reuses #893 `PolicyGateReceipt`; Hermes-compatible shape; NOT live Hermes queue wiring.
+- HoloIndex: pre-edit hits on Hermes/CABR receipt patterns; post-edit static pointers in INTERFACE/ModLog (INDEX_GAP for semantic ranking — follow-up if needed).
+
 ## 2026-06-28: REDDOG_OPENCLAW_WORK_ORDER_POLICY_GATE_PHASE1
 
 **Slice:** OpenClaw policy gate — dry-run + permission freshness + HoloIndex policy (no execution)

--- a/modules/communication/moltbot_bridge/src/reddog_work_order_receipt.py
+++ b/modules/communication/moltbot_bridge/src/reddog_work_order_receipt.py
@@ -1,0 +1,405 @@
+"""RedDog governed work-order receipt layer (Hermes-compatible, pre-execution audit).
+
+Slice: REDDOG_HERMES_WORK_ORDER_RECEIPT_PHASE1
+Contract: docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md
+
+Persists or emits audit receipts from #893 PolicyGateReceipt records.
+Pre-execution audit trail only — NOT Hermes queue dispatch, NOT WRE execution.
+
+WSP 97 TRUTH BOUNDARIES:
+  ✓ DOES:
+    - Map PolicyGateReceipt -> RedDogWorkOrderReceipt (Hermes-compatible shape)
+    - Append-only SQLite persistence when caller provides store path
+    - Idempotent insert keyed by policy_gate_receipt_digest
+    - Preserve digests/refs only (no raw prompts, tokens, or secrets)
+
+  ✗ DOES NOT:
+    - Create branches, PRs, commits, merges, or file writes to repos
+    - Invoke WRE executor, live gh probe, or extension runtime
+    - Dispatch to live Hermes queue
+    - Claim execution occurred (no_execution_performed remains true)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import sqlite3
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Union
+
+from modules.communication.moltbot_bridge.src.reddog_openclaw_work_order_policy_gate import (
+    POLICY_ACCEPT,
+    POLICY_ACCEPT_WITH_RETRIEVAL_GAP,
+    POLICY_REJECT,
+    PolicyGateReceipt,
+)
+
+logger = logging.getLogger("reddog_work_order_receipt")
+
+RECEIPT_SOURCE = "reddog_openclaw_policy_gate"
+DEFAULT_RETENTION_DAYS = 90
+SCHEMA_VERSION = 1
+
+_SECRET_PATTERNS = (
+    re.compile(r"ghp_[A-Za-z0-9_]+"),
+    re.compile(r"github_pat_[A-Za-z0-9_]+"),
+    re.compile(r"sk-[A-Za-z0-9_]+"),
+    re.compile(r"gho_[A-Za-z0-9_]+"),
+)
+
+
+class ReceiptStoreStatus(str, Enum):
+    SUCCESS = "success"
+    ALREADY_EXISTS = "already_exists"
+    VALIDATION_ERROR = "validation_error"
+    SCHEMA_ERROR = "schema_error"
+    WRITE_ERROR = "write_error"
+    READ_ERROR = "read_error"
+
+
+@dataclass
+class RedDogWorkOrderReceipt:
+    """Hermes-compatible pre-execution audit receipt for governed work orders."""
+
+    receipt_id: str
+    work_order_id: str
+    policy_gate_decision: str
+    policy_gate_receipt_digest: str
+    dry_run_receipt_digest: str
+    permission_snapshot_digest: str
+    holoindex_evidence_digest: str
+    permission_truth_label: str
+    no_execution_performed: bool
+    created_at: str
+    expires_at: Optional[str]
+    source: str
+    retention_days: int
+    receipt_digest: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+
+
+@dataclass
+class WorkOrderReceiptEmissionResult:
+    success: bool
+    receipt: Optional[RedDogWorkOrderReceipt]
+    persisted: bool
+    idempotent_replay: bool
+    store_status: Optional[ReceiptStoreStatus] = None
+    error: Optional[str] = None
+
+
+@dataclass
+class ReceiptStoreResult:
+    status: ReceiptStoreStatus
+    message: str
+    receipt_id: Optional[str] = None
+    receipt: Optional[RedDogWorkOrderReceipt] = None
+
+
+def _utc_now(now: Optional[datetime] = None) -> datetime:
+    value = now or datetime.now(timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _iso8601(dt: datetime) -> str:
+    return dt.replace(microsecond=0).isoformat()
+
+
+def _canonical_digest(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _sanitize_text(text: str) -> str:
+    cleaned = text
+    for pattern in _SECRET_PATTERNS:
+        cleaned = pattern.sub("[REDACTED]", cleaned)
+    return cleaned
+
+
+def _sanitize_dict(data: Dict[str, Any]) -> Dict[str, Any]:
+    sanitized: Dict[str, Any] = {}
+    for key, value in data.items():
+        if isinstance(value, str):
+            sanitized[key] = _sanitize_text(value)
+        elif isinstance(value, list):
+            sanitized[key] = [_sanitize_text(v) if isinstance(v, str) else v for v in value]
+        else:
+            sanitized[key] = value
+    return sanitized
+
+
+def build_reddog_work_order_receipt(
+    policy_receipt: PolicyGateReceipt,
+    *,
+    now: Optional[datetime] = None,
+    retention_days: int = DEFAULT_RETENTION_DAYS,
+) -> RedDogWorkOrderReceipt:
+    """Map a PolicyGateReceipt into a Hermes-compatible RedDogWorkOrderReceipt."""
+    if not policy_receipt.no_execution_performed:
+        raise ValueError("policy receipt must have no_execution_performed=true")
+
+    created = _utc_now(now)
+    retention = max(1, retention_days)
+    retention_expires = created + timedelta(days=retention)
+
+    expires_at = policy_receipt.expires_at
+    if expires_at:
+        try:
+            policy_exp = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+            if policy_exp.tzinfo is None:
+                policy_exp = policy_exp.replace(tzinfo=timezone.utc)
+            retention_expires = min(retention_expires, policy_exp.astimezone(timezone.utc))
+        except ValueError:
+            pass
+
+    receipt_core = {
+        "receipt_id": f"rdog-rcpt-{policy_receipt.work_order_id}-{policy_receipt.receipt_digest[:12]}",
+        "work_order_id": policy_receipt.work_order_id,
+        "policy_gate_decision": policy_receipt.decision,
+        "policy_gate_receipt_digest": policy_receipt.receipt_digest,
+        "dry_run_receipt_digest": policy_receipt.dry_run_receipt_digest,
+        "permission_snapshot_digest": policy_receipt.permission_snapshot_digest,
+        "holoindex_evidence_digest": policy_receipt.holoindex_evidence_digest,
+        "permission_truth_label": policy_receipt.permission_truth_label,
+        "no_execution_performed": True,
+        "created_at": _iso8601(created),
+        "expires_at": _iso8601(retention_expires),
+        "source": RECEIPT_SOURCE,
+        "retention_days": retention,
+    }
+    digest = _canonical_digest(receipt_core)
+    return RedDogWorkOrderReceipt(receipt_digest=digest, **receipt_core)
+
+
+_CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS reddog_work_order_receipts (
+    receipt_id TEXT PRIMARY KEY,
+    work_order_id TEXT NOT NULL,
+    policy_gate_receipt_digest TEXT NOT NULL UNIQUE,
+    receipt_json TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    expires_at TEXT,
+    source TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_rdog_receipt_work_order
+    ON reddog_work_order_receipts(work_order_id);
+CREATE INDEX IF NOT EXISTS idx_rdog_receipt_created
+    ON reddog_work_order_receipts(created_at);
+CREATE TABLE IF NOT EXISTS reddog_receipt_schema_version (
+    version INTEGER PRIMARY KEY,
+    applied_at TEXT NOT NULL
+);
+"""
+
+
+class RedDogWorkOrderReceiptStore:
+    """Append-only SQLite audit store for RedDogWorkOrderReceipt records."""
+
+    def __init__(self, db_path: Union[str, Path]) -> None:
+        self.db_path = Path(db_path)
+        self._conn: Optional[sqlite3.Connection] = None
+        self._schema_initialized = False
+
+    def _get_connection(self) -> sqlite3.Connection:
+        if self._conn is None:
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+            self._conn = sqlite3.connect(str(self.db_path))
+            self._conn.row_factory = sqlite3.Row
+            self._conn.execute("PRAGMA journal_mode=WAL")
+            self._conn.execute("PRAGMA foreign_keys=ON")
+        return self._conn
+
+    def initialize_schema(self) -> ReceiptStoreResult:
+        try:
+            conn = self._get_connection()
+            conn.executescript(_CREATE_TABLE_SQL)
+            conn.execute(
+                "INSERT OR IGNORE INTO reddog_receipt_schema_version (version, applied_at) VALUES (?, ?)",
+                (SCHEMA_VERSION, _iso8601(_utc_now())),
+            )
+            conn.commit()
+            self._schema_initialized = True
+            return ReceiptStoreResult(status=ReceiptStoreStatus.SUCCESS, message="schema ready")
+        except sqlite3.Error as exc:
+            return ReceiptStoreResult(
+                status=ReceiptStoreStatus.SCHEMA_ERROR,
+                message=f"schema initialization failed: {exc}",
+            )
+
+    def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+            self._schema_initialized = False
+
+    def __enter__(self) -> "RedDogWorkOrderReceiptStore":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+    def get_by_policy_digest(self, policy_gate_receipt_digest: str) -> Optional[RedDogWorkOrderReceipt]:
+        try:
+            conn = self._get_connection()
+            row = conn.execute(
+                "SELECT receipt_json FROM reddog_work_order_receipts WHERE policy_gate_receipt_digest = ?",
+                (policy_gate_receipt_digest,),
+            ).fetchone()
+            if row is None:
+                return None
+            payload = json.loads(row["receipt_json"])
+            return RedDogWorkOrderReceipt(**payload)
+        except (sqlite3.Error, json.JSONDecodeError, TypeError) as exc:
+            logger.debug("receipt read failed: %s", _sanitize_text(str(exc)))
+            return None
+
+    def insert(self, receipt: RedDogWorkOrderReceipt) -> ReceiptStoreResult:
+        if not self._schema_initialized:
+            init = self.initialize_schema()
+            if init.status != ReceiptStoreStatus.SUCCESS:
+                return init
+
+        if not receipt.no_execution_performed:
+            return ReceiptStoreResult(
+                status=ReceiptStoreStatus.VALIDATION_ERROR,
+                message="no_execution_performed must be true",
+            )
+
+        existing = self.get_by_policy_digest(receipt.policy_gate_receipt_digest)
+        if existing is not None:
+            return ReceiptStoreResult(
+                status=ReceiptStoreStatus.ALREADY_EXISTS,
+                message="receipt already stored for policy_gate_receipt_digest",
+                receipt_id=existing.receipt_id,
+                receipt=existing,
+            )
+
+        safe_json = json.dumps(_sanitize_dict(receipt.to_dict()), sort_keys=True, separators=(",", ":"))
+        try:
+            conn = self._get_connection()
+            conn.execute(
+                """
+                INSERT INTO reddog_work_order_receipts (
+                    receipt_id, work_order_id, policy_gate_receipt_digest,
+                    receipt_json, created_at, expires_at, source
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    receipt.receipt_id,
+                    receipt.work_order_id,
+                    receipt.policy_gate_receipt_digest,
+                    safe_json,
+                    receipt.created_at,
+                    receipt.expires_at,
+                    receipt.source,
+                ),
+            )
+            conn.commit()
+            return ReceiptStoreResult(
+                status=ReceiptStoreStatus.SUCCESS,
+                message="receipt stored",
+                receipt_id=receipt.receipt_id,
+                receipt=receipt,
+            )
+        except sqlite3.IntegrityError:
+            existing = self.get_by_policy_digest(receipt.policy_gate_receipt_digest)
+            if existing is not None:
+                return ReceiptStoreResult(
+                    status=ReceiptStoreStatus.ALREADY_EXISTS,
+                    message="receipt already stored (race)",
+                    receipt_id=existing.receipt_id,
+                    receipt=existing,
+                )
+            return ReceiptStoreResult(
+                status=ReceiptStoreStatus.WRITE_ERROR,
+                message="integrity error without readable existing receipt",
+            )
+        except sqlite3.Error as exc:
+            return ReceiptStoreResult(
+                status=ReceiptStoreStatus.WRITE_ERROR,
+                message=f"write failed: {exc}",
+            )
+
+
+def emit_work_order_receipt(
+    policy_receipt: PolicyGateReceipt,
+    *,
+    store: Optional[RedDogWorkOrderReceiptStore] = None,
+    now: Optional[datetime] = None,
+    retention_days: int = DEFAULT_RETENTION_DAYS,
+) -> WorkOrderReceiptEmissionResult:
+    """Emit a RedDogWorkOrderReceipt from a policy gate receipt (optional persist)."""
+    try:
+        receipt = build_reddog_work_order_receipt(
+            policy_receipt,
+            now=now,
+            retention_days=retention_days,
+        )
+    except ValueError as exc:
+        return WorkOrderReceiptEmissionResult(
+            success=False,
+            receipt=None,
+            persisted=False,
+            idempotent_replay=False,
+            error=str(exc),
+        )
+
+    if store is None:
+        return WorkOrderReceiptEmissionResult(
+            success=True,
+            receipt=receipt,
+            persisted=False,
+            idempotent_replay=False,
+        )
+
+    result = store.insert(receipt)
+    if result.status == ReceiptStoreStatus.SUCCESS:
+        return WorkOrderReceiptEmissionResult(
+            success=True,
+            receipt=result.receipt or receipt,
+            persisted=True,
+            idempotent_replay=False,
+            store_status=result.status,
+        )
+    if result.status == ReceiptStoreStatus.ALREADY_EXISTS:
+        return WorkOrderReceiptEmissionResult(
+            success=True,
+            receipt=result.receipt or receipt,
+            persisted=True,
+            idempotent_replay=True,
+            store_status=result.status,
+        )
+
+    return WorkOrderReceiptEmissionResult(
+        success=False,
+        receipt=receipt,
+        persisted=False,
+        idempotent_replay=False,
+        store_status=result.status,
+        error=result.message,
+    )
+
+
+__all__ = [
+    "DEFAULT_RETENTION_DAYS",
+    "RECEIPT_SOURCE",
+    "RedDogWorkOrderReceipt",
+    "RedDogWorkOrderReceiptStore",
+    "ReceiptStoreResult",
+    "ReceiptStoreStatus",
+    "WorkOrderReceiptEmissionResult",
+    "build_reddog_work_order_receipt",
+    "emit_work_order_receipt",
+]

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,13 @@
+## 2026-06-28: REDDOG_HERMES_WORK_ORDER_RECEIPT_PHASE1
+
+**File**: `test_reddog_work_order_receipt.py` (NEW — 14 tests)
+**Slice**: `REDDOG_HERMES_WORK_ORDER_RECEIPT_PHASE1` | **Predecessors**: #893 policy gate
+
+Hermes-compatible receipt emission/persistence from `PolicyGateReceipt`; digest stability, secret
+redaction, idempotent SQLite store, no mutation imports.
+
+**Run**: `pytest modules/communication/moltbot_bridge/tests/test_reddog_work_order_receipt.py -q`
+
 ## 2026-06-28: REDDOG_OPENCLAW_WORK_ORDER_POLICY_GATE_PHASE1
 
 **File**: `test_reddog_openclaw_work_order_policy_gate.py` (NEW — 22 tests)

--- a/modules/communication/moltbot_bridge/tests/test_reddog_work_order_receipt.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_work_order_receipt.py
@@ -1,0 +1,251 @@
+"""Tests for RedDog Hermes-compatible work-order receipt layer."""
+
+from __future__ import annotations
+
+import ast
+import json
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_openclaw_work_order_policy_gate import (
+    evaluate_work_order_policy_gate,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_receipt import (
+    RECEIPT_SOURCE,
+    RedDogWorkOrderReceiptStore,
+    ReceiptStoreStatus,
+    build_reddog_work_order_receipt,
+    emit_work_order_receipt,
+)
+
+
+def _future_expiry(hours: int = 2) -> str:
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).replace(microsecond=0).isoformat()
+
+
+def _fresh_captured() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _accept_policy_order(**overrides):
+    payload = {
+        "work_order_id": "wo-receipt-001",
+        "created_at": _fresh_captured(),
+        "red_dog_instance_id": "reddog-ext-0.3.27",
+        "authenticated_principal": "principal-012",
+        "principal_provider": "github",
+        "repo_full_name": "FOUNDUPS/Foundups-Agent",
+        "repo_permission_snapshot": {
+            "permission_level": "write",
+            "captured_at": _fresh_captured(),
+            "source": "mock",
+            "digest": "sha256:" + ("a" * 64),
+        },
+        "requested_operation": "audit_only",
+        "authority_tier": "advisory",
+        "allowed_paths": ["docs/**"],
+        "denied_paths": [".env"],
+        "branch_name": "docs/receipt-test",
+        "base_ref": "main",
+        "task_summary": "Receipt layer validation",
+        "wsp_applicability": ["WSP_34", "WSP_50"],
+        "holoindex_evidence_refs": [
+            "docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md"
+        ],
+        "skillz_candidates": [],
+        "required_tests": [],
+        "required_policy_gates": ["openclaw_policy_gate"],
+        "required_reviewers": [],
+        "sentinel_checks": [],
+        "rollback_plan": "No execution performed.",
+        "expiry": _future_expiry(),
+        "nonce": "nonce-receipt-001",
+        "evidence_digest": "sha256:" + ("b" * 64),
+        "advisory_only_source_packet": {
+            "work_focus_digest": "sha256:" + ("c" * 64),
+            "wsp_prompt_digest": "sha256:" + ("d" * 64),
+            "copy_md_run_trace_digest": "sha256:" + ("e" * 64),
+        },
+        "holoindex_evidence": {
+            "holoindex_query": "RedDog work order receipt",
+            "holoindex_status": "bundle_json_ok",
+            "code_hits": [],
+            "wsp_hits": ["WSP_framework/src/WSP_34_Git_Operations_Protocol.md"],
+            "skillz_hits": [],
+            "direct_read_fallback_used": False,
+            "index_gap_detected": True,
+            "applicable_wsps": ["WSP_34"],
+            "evidence_refs": [
+                "docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md"
+            ],
+            "retrieval_quality": "INDEX_GAP",
+            "skillz_gap_detected": True,
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestReceiptSchema:
+    def test_build_from_policy_gate_receipt(self):
+        policy = evaluate_work_order_policy_gate(_accept_policy_order(), seen_nonces=set())
+        receipt = build_reddog_work_order_receipt(policy)
+        assert receipt.work_order_id == "wo-receipt-001"
+        assert receipt.policy_gate_decision == policy.decision
+        assert receipt.policy_gate_receipt_digest == policy.receipt_digest
+        assert receipt.dry_run_receipt_digest == policy.dry_run_receipt_digest
+        assert receipt.permission_snapshot_digest == policy.permission_snapshot_digest
+        assert receipt.holoindex_evidence_digest == policy.holoindex_evidence_digest
+        assert receipt.permission_truth_label == policy.permission_truth_label
+        assert receipt.source == RECEIPT_SOURCE
+
+    def test_no_execution_performed_invariant(self):
+        policy = evaluate_work_order_policy_gate(
+            _accept_policy_order(nonce="nonce-noexec"), seen_nonces=set()
+        )
+        receipt = build_reddog_work_order_receipt(policy)
+        assert receipt.no_execution_performed is True
+
+    def test_receipt_digest_stable(self):
+        fixed = datetime(2026, 6, 28, 15, 0, 0, tzinfo=timezone.utc)
+        captured = (fixed - timedelta(seconds=60)).replace(microsecond=0).isoformat()
+        order = _accept_policy_order(
+            nonce="nonce-stable-receipt",
+            repo_permission_snapshot={
+                "permission_level": "write",
+                "captured_at": captured,
+                "source": "mock",
+                "digest": "sha256:" + ("f" * 64),
+            },
+        )
+        policy = evaluate_work_order_policy_gate(order, seen_nonces=set(), now=fixed)
+        first = build_reddog_work_order_receipt(policy, now=fixed)
+        second = build_reddog_work_order_receipt(policy, now=fixed)
+        assert first.to_dict() == second.to_dict()
+        assert first.receipt_digest == second.receipt_digest
+
+    def test_json_serializable(self):
+        policy = evaluate_work_order_policy_gate(
+            _accept_policy_order(nonce="nonce-json"), seen_nonces=set()
+        )
+        receipt = build_reddog_work_order_receipt(policy)
+        parsed = json.loads(receipt.to_json())
+        assert parsed["source"] == RECEIPT_SOURCE
+        assert parsed["no_execution_performed"] is True
+
+
+class TestSecretSafety:
+    def test_redaction_on_store_payload(self):
+        policy = evaluate_work_order_policy_gate(
+            _accept_policy_order(nonce="nonce-redact"), seen_nonces=set()
+        )
+        receipt = build_reddog_work_order_receipt(policy)
+        poisoned = receipt.to_dict()
+        poisoned["work_order_id"] = "ghp_abcdefghijklmnopqrstuvwxyz1234567890"
+        from modules.communication.moltbot_bridge.src.reddog_work_order_receipt import _sanitize_dict
+
+        cleaned = _sanitize_dict(poisoned)
+        assert "ghp_" not in cleaned["work_order_id"]
+        assert "[REDACTED]" in cleaned["work_order_id"]
+
+    def test_receipt_json_has_no_token_patterns(self):
+        policy = evaluate_work_order_policy_gate(
+            _accept_policy_order(nonce="nonce-token-scan"), seen_nonces=set()
+        )
+        receipt = build_reddog_work_order_receipt(policy)
+        blob = receipt.to_json()
+        assert "ghp_" not in blob
+        assert "sk-" not in blob
+
+
+class TestIdempotency:
+    def test_same_policy_receipt_same_receipt_id(self):
+        policy = evaluate_work_order_policy_gate(
+            _accept_policy_order(nonce="nonce-idem"), seen_nonces=set()
+        )
+        a = build_reddog_work_order_receipt(policy)
+        b = build_reddog_work_order_receipt(policy)
+        assert a.receipt_id == b.receipt_id
+        assert a.receipt_digest == b.receipt_digest
+
+    def test_store_replay_is_idempotent(self):
+        policy = evaluate_work_order_policy_gate(
+            _accept_policy_order(nonce="nonce-store-idem"), seen_nonces=set()
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            with RedDogWorkOrderReceiptStore(Path(tmp) / "receipts.db") as store:
+                first = emit_work_order_receipt(policy, store=store)
+                second = emit_work_order_receipt(policy, store=store)
+                assert first.success is True
+                assert second.success is True
+                assert second.idempotent_replay is True
+                assert first.receipt.receipt_id == second.receipt.receipt_id
+                assert second.store_status == ReceiptStoreStatus.ALREADY_EXISTS
+
+    def test_different_policy_digest_different_receipt_id(self):
+        policy_a = evaluate_work_order_policy_gate(
+            _accept_policy_order(nonce="nonce-a"), seen_nonces=set()
+        )
+        policy_b = evaluate_work_order_policy_gate(
+            _accept_policy_order(nonce="nonce-b"), seen_nonces=set()
+        )
+        receipt_a = build_reddog_work_order_receipt(policy_a)
+        receipt_b = build_reddog_work_order_receipt(policy_b)
+        assert receipt_a.receipt_id != receipt_b.receipt_id
+
+
+class TestEmission:
+    def test_emit_without_store(self):
+        policy = evaluate_work_order_policy_gate(
+            _accept_policy_order(nonce="nonce-emit-memory"), seen_nonces=set()
+        )
+        result = emit_work_order_receipt(policy)
+        assert result.success is True
+        assert result.persisted is False
+        assert result.receipt is not None
+
+    def test_emit_with_store_persists(self):
+        policy = evaluate_work_order_policy_gate(
+            _accept_policy_order(nonce="nonce-emit-store"), seen_nonces=set()
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            with RedDogWorkOrderReceiptStore(Path(tmp) / "receipts.db") as store:
+                result = emit_work_order_receipt(policy, store=store)
+                assert result.success is True
+                assert result.persisted is True
+                loaded = store.get_by_policy_digest(policy.receipt_digest)
+                assert loaded is not None
+                assert loaded.receipt_id == result.receipt.receipt_id
+
+
+class TestNoExecutionBoundary:
+    def test_module_has_no_mutation_imports(self):
+        module_path = (
+            Path(__file__).resolve().parents[1] / "src" / "reddog_work_order_receipt.py"
+        )
+        source = module_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imported: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.append(node.module)
+        forbidden = [
+            name
+            for name in imported
+            if any(token in name for token in ("subprocess", "github_integration", "wre_core"))
+        ]
+        assert forbidden == []
+        assert "probe_repo_permission" not in source
+
+    def test_rejects_policy_receipt_without_no_execution_flag(self):
+        policy = evaluate_work_order_policy_gate(
+            _accept_policy_order(nonce="nonce-bad-flag"), seen_nonces=set()
+        )
+        policy.no_execution_performed = False
+        with pytest.raises(ValueError, match="no_execution_performed"):
+            build_reddog_work_order_receipt(policy)


### PR DESCRIPTION
## Summary

- Adds `emit_work_order_receipt()` and `RedDogWorkOrderReceipt` in `modules/communication/moltbot_bridge/src/reddog_work_order_receipt.py`.
- Maps #893 `PolicyGateReceipt` into Hermes-compatible pre-execution audit records (digests/refs only).
- Optional SQLite `RedDogWorkOrderReceiptStore` with idempotent insert keyed by `policy_gate_receipt_digest`.
- 14 pytest cases: schema, digest stability, redaction, idempotency, no-execution boundary.

## Hard boundary (unchanged)

No branch/PR/commit/merge, no WRE executor, no live `gh`, no extension runtime, no live Hermes queue, no campaign/AutoPost execution.

## HoloIndex (Addendum A)

**Pre-edit hits:** `proof_of_compute_receipt.py`, `receipt_emitter.py`, CABR store patterns, RedDog contract audit doc.

**Post-edit:** Static pointers in moltbot_bridge + extension INTERFACE/ModLog. Semantic search INDEX_GAP for new module filename — follow-up `HOLOINDEX_REDDOG_RECEIPT_MODULE_INDEX_GAP_PHASE1` recorded in ROADMAP P1.

## Test plan

- [x] 63 pytest (14 receipt + 22 policy + 13 dry-run + 14 probe)
- [x] extension contract checks
- [x] git diff --check clean

## Residual SPECIFIED_NOT_IMPLEMENTED

- Live Hermes queue dispatch
- Extension/OpenClaw runtime wiring
- WRE isolated worktree executor
- Campaign Skillz governed work-order emission
