### PR TITLE
feat(reddog): add governed work-order runtime dry-run invocation

### DIFF
--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -79,6 +79,8 @@ RedDog is the 0102 architect interface — **not an authority owner**. RedDog re
 
 **Work-order receipt (Hermes-compatible audit):** `modules/communication/moltbot_bridge/src/reddog_work_order_receipt.py` — `emit_work_order_receipt()` persists/emits pre-execution audit records from `PolicyGateReceipt`. Extension does not invoke it yet.
 
+**Runtime invocation dry-run:** `modules/communication/moltbot_bridge/src/reddog_work_order_runtime_invocation.py` — `invoke_reddog_work_order_dryrun()` chains policy gate + receipt; returns audit result. Extension does not invoke it yet.
+
 **Specified flow (not implemented in extension v0.3.27):**
 
 ```text
@@ -306,6 +308,7 @@ Formal contract:
 | GitHub permission probe (read-only snapshot) | OBSERVED (github_integration module) |
 | OpenClaw work-order policy gate | OBSERVED (moltbot_bridge module); no execution |
 | RedDog work-order receipt (Hermes-compatible audit) | OBSERVED (moltbot_bridge module); not live Hermes queue |
+| RedDog runtime invocation dry-run | OBSERVED (moltbot_bridge module); no execution |
 | Governed repo work order dry-run validator | OBSERVED (OpenClaw bridge module) |
 | Governed repo work order (`RedDogGovernedWorkOrder`) | SPECIFIED_NOT_IMPLEMENTED (runtime emission from extension) |
 | GitHub permission snapshot per work order | SPECIFIED_NOT_IMPLEMENTED |

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -1,5 +1,12 @@
 # Foundups®Agent ModLog
 
+## 2026-06-28 - REDDOG_WORK_ORDER_RUNTIME_INVOCATION_DRYRUN_PHASE1 (extension pointers)
+
+- Points to `modules/communication/moltbot_bridge/src/reddog_work_order_runtime_invocation.py`.
+- Chains #893 policy gate + #894 receipt; proves handoff without repo mutation.
+
+WSP: WSP_34, WSP_50, WSP_97.
+
 ## 2026-06-28 - REDDOG_HERMES_WORK_ORDER_RECEIPT_PHASE1 (extension pointers)
 
 - Points to `modules/communication/moltbot_bridge/src/reddog_work_order_receipt.py`.

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -79,22 +79,23 @@ DONE
 5. #891 post-#890 queue docs (3cbc58913)
 6. #892 GitHub permission probe (21aeff32d)
 7. #893 OpenClaw policy gate (329db7113)
+8. #894 Hermes-compatible receipt (b42db2165)
 
-P0 NEXT (sequenced — receipts before executor)
-8. REDDOG_HERMES_WORK_ORDER_RECEIPT_PHASE1
-   - persist policy gate receipts (pre-execution audit)
-9. REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_PHASE1
-   - only after receipts proven
+P0 NEXT
+9. REDDOG_WORK_ORDER_RUNTIME_INVOCATION_DRYRUN_PHASE1
+   - invoke policy gate + receipt; no repo mutation
+10. REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_CONTRACT_PHASE1
+   - contract only, after invocation dry-run proven
 
 P1
-10. REDDOG_SANITIZED_TARGET_CONTEXT_PROVENANCE_PHASE1
-11. REDDOG_RUN_TRACE_TELEMETRY_CORRECTION_PHASE1
-12. HOLOINDEX_REDDOG_GOVERNED_WORK_ORDER_INDEX_GAP_PHASE1
-13. HOLOINDEX_REDDOG_RECEIPT_MODULE_INDEX_GAP_PHASE1 (semantic ranking; static pointers landed)
+11. REDDOG_SANITIZED_TARGET_CONTEXT_PROVENANCE_PHASE1
+12. REDDOG_RUN_TRACE_TELEMETRY_CORRECTION_PHASE1
+13. HOLOINDEX_REDDOG_GOVERNED_WORK_ORDER_INDEX_GAP_PHASE1
+14. HOLOINDEX_REDDOG_RUNTIME_INVOCATION_INDEX_GAP_PHASE1
 
 P2/P3
-13. REDDOG_REVIEW_CONSENSUS_RECEIPTS_PHASE1
-14. REDDOG_AUTONOMOUS_MERGE_POLICY_PHASE1 (blocked)
+15. REDDOG_REVIEW_CONSENSUS_RECEIPTS_PHASE1
+16. REDDOG_AUTONOMOUS_MERGE_POLICY_PHASE1 (blocked)
 ```
 
 **Rationale:** Sanitized provenance and telemetry are real polish issues, but the strategic blocker is that RedDog still cannot safely become a worker. The work-order contract is the missing bridge between “advisory RedDog” and “RedDog can direct WRE to do meaningful code work.”
@@ -201,14 +202,18 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 
 ### REDDOG_HERMES_WORK_ORDER_RECEIPT_PHASE1
 
-- **Status:** **PR-READY** — `emit_work_order_receipt()` + SQLite audit store.
+- **Status:** **LANDED** #894 (`b42db2165`) — `emit_work_order_receipt()` + SQLite audit store.
 - **Module:** `modules/communication/moltbot_bridge/src/reddog_work_order_receipt.py`
-- Hermes-compatible pre-execution audit; idempotent by `policy_gate_receipt_digest`.
-- HoloIndex: INDEX_GAP for semantic ranking (static INTERFACE/ModLog pointers added).
+
+### REDDOG_WORK_ORDER_RUNTIME_INVOCATION_DRYRUN_PHASE1
+
+- **Status:** **PR-READY** — `invoke_reddog_work_order_dryrun()` chains #893 + #894.
+- **Module:** `modules/communication/moltbot_bridge/src/reddog_work_order_runtime_invocation.py`
+- Proves runtime handoff + audit receipt without repo mutation.
 
 ### REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_PHASE1
 
-- **Status:** **P0 QUEUED** — after Hermes receipts.
+- **Status:** **P0 QUEUED** — after invocation dry-run + executor contract.
 
 ### REDDOG_REVIEW_CONSENSUS_RECEIPTS_PHASE1
 

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -192,6 +192,10 @@ const receiptPy = fs.readFileSync(path.join(root, 'modules', 'communication', 'm
 includes(receiptPy, 'emit_work_order_receipt', 'RedDog work order receipt emitter missing');
 includes(receiptPy, 'RedDogWorkOrderReceipt', 'RedDogWorkOrderReceipt schema missing');
 includes(receiptPy, 'no_execution_performed', 'work order receipt no_execution_performed missing');
+const invokePy = fs.readFileSync(path.join(root, 'modules', 'communication', 'moltbot_bridge', 'src', 'reddog_work_order_runtime_invocation.py'), 'utf8');
+includes(invokePy, 'invoke_reddog_work_order_dryrun', 'runtime invocation dryrun missing');
+includes(invokePy, 'no_execution_performed', 'runtime invocation no_execution_performed missing');
+includes(iface, 'reddog_work_order_runtime_invocation.py', 'INTERFACE runtime invocation pointer missing');
 includes(iface, 'reddog_work_order_receipt.py', 'INTERFACE work order receipt pointer missing');
 includes(iface, 'reddog_openclaw_work_order_policy_gate.py', 'INTERFACE policy gate pointer missing');
 includes(iface, 'reddog_github_permission_probe.py', 'INTERFACE permission probe pointer missing');
@@ -205,6 +209,7 @@ includes(roadmap, 'docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONT
 includes(roadmap, 'REDDOG_GITHUB_PERMISSION_PROBE_PHASE1', 'github permission probe slice missing');
 includes(roadmap, 'REDDOG_OPENCLAW_WORK_ORDER_POLICY_GATE_PHASE1', 'OpenClaw policy gate slice missing');
 includes(roadmap, 'REDDOG_HERMES_WORK_ORDER_RECEIPT_PHASE1', 'Hermes work order receipt slice missing');
+includes(roadmap, 'REDDOG_WORK_ORDER_RUNTIME_INVOCATION_DRYRUN_PHASE1', 'runtime invocation dryrun slice missing');
 includes(roadmap, 'External RedDog Lane Queue (post-#888)', 'post-#888 external lane queue missing');
 includes(roadmap, 'REDDOG_GOVERNED_REPO_WORK_ORDER_DRYRUN_PHASE1', 'governed work order dryrun slice missing');
 includes(roadmap, 'REDDOG_RUN_TRACE_TELEMETRY_CORRECTION_PHASE1', 'run trace telemetry correction slice missing');

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -792,3 +792,18 @@ from modules.communication.moltbot_bridge.src.reddog_work_order_receipt import (
 
 Pre-execution audit trail only. Maps #893 `PolicyGateReceipt` into durable Hermes-compatible
 records (digests/refs only). NOT live Hermes queue dispatch, NOT WRE execution.
+
+### RedDog Work-Order Runtime Invocation Dry-Run (no execution)
+
+```python
+from modules.communication.moltbot_bridge.src.reddog_work_order_runtime_invocation import (
+    invoke_reddog_work_order_dryrun,  # (work_order, permission_snapshot, *, now, seen_nonces, receipt_store) -> WorkOrderDryRunInvocationResult
+    WorkOrderDryRunInvocationResult,
+    INVOCATION_ACCEPT,
+    INVOCATION_REJECT,
+    INVOCATION_ACCEPT_WITH_RETRIEVAL_GAP,
+)
+```
+
+Orchestrates #893 policy gate + #894 receipt emission/persistence. Returns audit result to caller.
+No WRE, git, shell, live GitHub probe, or extension runtime wiring.

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,14 @@
 # ModLog - moltbot_bridge
 
+## 2026-06-28: REDDOG_WORK_ORDER_RUNTIME_INVOCATION_DRYRUN_PHASE1
+
+**Slice:** Runtime dry-run invocation orchestrator (policy gate + receipt, no execution)
+**WSP:** WSP_34, WSP_50, WSP_91, WSP_97, WSP_22
+
+- ADD `src/reddog_work_order_runtime_invocation.py` — `invoke_reddog_work_order_dryrun()` chains #893 + #894.
+- ADD `tests/test_reddog_work_order_runtime_invocation.py` — 7 tests (accept/reject/replay/idempotency/AST denylist).
+- HoloIndex: pre-edit hits on OpenClaw orchestrator/routing; post-edit INDEX_GAP for new module — static pointers added.
+
 ## 2026-06-28: REDDOG_HERMES_WORK_ORDER_RECEIPT_PHASE1
 
 **Slice:** Hermes-compatible pre-execution audit receipts for governed work orders

--- a/modules/communication/moltbot_bridge/src/reddog_work_order_runtime_invocation.py
+++ b/modules/communication/moltbot_bridge/src/reddog_work_order_runtime_invocation.py
@@ -1,0 +1,152 @@
+"""RedDog governed work-order runtime invocation dry-run (no execution).
+
+Slice: REDDOG_WORK_ORDER_RUNTIME_INVOCATION_DRYRUN_PHASE1
+Contract: docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md
+
+Orchestrates the pre-execution governance spine:
+  work order -> #893 policy gate -> #894 Hermes-compatible receipt -> caller result
+
+WSP 97 TRUTH BOUNDARIES:
+  ✓ DOES:
+    - Evaluate OpenClaw policy gate on a RedDogGovernedWorkOrder
+    - Emit/persist audit receipt via #894 receipt layer
+    - Return dry-run invocation result to caller (digests/refs only)
+
+  ✗ DOES NOT:
+    - Create branches, PRs, commits, merges, or mutate repository content
+    - Invoke WRE executor, shell, git, live GitHub probe, Skillz execution, or Hermes queue
+    - Make external API calls
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Mapping, MutableSet, Optional, Union
+
+from modules.communication.moltbot_bridge.src.reddog_openclaw_work_order_policy_gate import (
+    POLICY_ACCEPT,
+    POLICY_ACCEPT_WITH_RETRIEVAL_GAP,
+    POLICY_REJECT,
+    PolicyGateReceipt,
+    evaluate_work_order_policy_gate,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_receipt import (
+    RedDogWorkOrderReceiptStore,
+    emit_work_order_receipt,
+)
+
+INVOCATION_ACCEPT = "INVOCATION_ACCEPT"
+INVOCATION_REJECT = "INVOCATION_REJECT"
+INVOCATION_ACCEPT_WITH_RETRIEVAL_GAP = "INVOCATION_ACCEPT_WITH_RETRIEVAL_GAP"
+
+_POLICY_TO_INVOCATION = {
+    POLICY_ACCEPT: INVOCATION_ACCEPT,
+    POLICY_REJECT: INVOCATION_REJECT,
+    POLICY_ACCEPT_WITH_RETRIEVAL_GAP: INVOCATION_ACCEPT_WITH_RETRIEVAL_GAP,
+}
+
+
+@dataclass
+class WorkOrderDryRunInvocationResult:
+    decision: str
+    work_order_id: str
+    policy_gate_decision: str
+    receipt_id: str
+    receipt_digest: str
+    no_execution_performed: bool
+    rejection_reasons: List[str]
+    gates_checked: List[str]
+    idempotent_replay: bool = False
+    policy_gate_receipt_digest: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def _canonical_digest(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _merge_permission_snapshot(
+    work_order: Mapping[str, Any],
+    permission_snapshot: Optional[Mapping[str, Any]],
+) -> Dict[str, Any]:
+    merged = dict(work_order)
+    if permission_snapshot is None:
+        return merged
+    base = dict(merged.get("repo_permission_snapshot") or {})
+    base.update(dict(permission_snapshot))
+    merged["repo_permission_snapshot"] = base
+    return merged
+
+
+def _invocation_decision(policy_decision: str) -> str:
+    return _POLICY_TO_INVOCATION.get(policy_decision, INVOCATION_REJECT)
+
+
+def invoke_reddog_work_order_dryrun(
+    work_order: Mapping[str, Any],
+    permission_snapshot: Optional[Mapping[str, Any]] = None,
+    *,
+    now: Optional[datetime] = None,
+    seen_nonces: Optional[MutableSet[str]] = None,
+    receipt_store: Optional[RedDogWorkOrderReceiptStore] = None,
+    permission_ttl_seconds: int = 300,
+    permission_expires_at: Optional[str] = None,
+) -> WorkOrderDryRunInvocationResult:
+    """Run governed work-order dry-run invocation: policy gate + receipt, no execution."""
+    order = _merge_permission_snapshot(work_order, permission_snapshot)
+    checked = now or datetime.now(timezone.utc)
+
+    policy_receipt: PolicyGateReceipt = evaluate_work_order_policy_gate(
+        order,
+        now=checked,
+        seen_nonces=seen_nonces,
+        permission_ttl_seconds=permission_ttl_seconds,
+        permission_expires_at=permission_expires_at,
+    )
+
+    emission = emit_work_order_receipt(policy_receipt, store=receipt_store, now=checked)
+    if not emission.success or emission.receipt is None:
+        return WorkOrderDryRunInvocationResult(
+            decision=INVOCATION_REJECT,
+            work_order_id=str(order.get("work_order_id") or "unknown"),
+            policy_gate_decision=policy_receipt.decision,
+            receipt_id="",
+            receipt_digest="",
+            no_execution_performed=True,
+            rejection_reasons=list(policy_receipt.rejection_reasons) + (
+                [emission.error] if emission.error else ["receipt_emission_failed"]
+            ),
+            gates_checked=list(policy_receipt.gates_checked),
+            policy_gate_receipt_digest=policy_receipt.receipt_digest,
+        )
+
+    receipt = emission.receipt
+    invocation_decision = _invocation_decision(policy_receipt.decision)
+
+    return WorkOrderDryRunInvocationResult(
+        decision=invocation_decision,
+        work_order_id=receipt.work_order_id,
+        policy_gate_decision=policy_receipt.decision,
+        receipt_id=receipt.receipt_id,
+        receipt_digest=receipt.receipt_digest,
+        no_execution_performed=True,
+        rejection_reasons=list(policy_receipt.rejection_reasons),
+        gates_checked=list(policy_receipt.gates_checked),
+        idempotent_replay=emission.idempotent_replay,
+        policy_gate_receipt_digest=policy_receipt.receipt_digest,
+    )
+
+
+__all__ = [
+    "INVOCATION_ACCEPT",
+    "INVOCATION_ACCEPT_WITH_RETRIEVAL_GAP",
+    "INVOCATION_REJECT",
+    "WorkOrderDryRunInvocationResult",
+    "invoke_reddog_work_order_dryrun",
+]

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,12 @@
+## 2026-06-28: REDDOG_WORK_ORDER_RUNTIME_INVOCATION_DRYRUN_PHASE1
+
+**File**: `test_reddog_work_order_runtime_invocation.py` (NEW — 7 tests)
+**Slice**: `REDDOG_WORK_ORDER_RUNTIME_INVOCATION_DRYRUN_PHASE1` | **Predecessors**: #893 policy gate, #894 receipt
+
+End-to-end dry-run invocation: policy gate + receipt store; accept/reject/replay/idempotency; AST denylist.
+
+**Run**: `pytest modules/communication/moltbot_bridge/tests/test_reddog_work_order_runtime_invocation.py -q`
+
 ## 2026-06-28: REDDOG_HERMES_WORK_ORDER_RECEIPT_PHASE1
 
 **File**: `test_reddog_work_order_receipt.py` (NEW — 14 tests)

--- a/modules/communication/moltbot_bridge/tests/test_reddog_work_order_runtime_invocation.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_work_order_runtime_invocation.py
@@ -1,0 +1,268 @@
+"""Tests for RedDog work-order runtime invocation dry-run."""
+
+from __future__ import annotations
+
+import ast
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_openclaw_work_order_policy_gate import (
+    POLICY_REJECT,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_receipt import (
+    RedDogWorkOrderReceiptStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_runtime_invocation import (
+    INVOCATION_ACCEPT_WITH_RETRIEVAL_GAP,
+    INVOCATION_REJECT,
+    invoke_reddog_work_order_dryrun,
+)
+
+
+def _future_expiry(hours: int = 2) -> str:
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).replace(microsecond=0).isoformat()
+
+
+def _fresh_captured() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _base_order(**overrides):
+    payload = {
+        "work_order_id": "wo-invoke-001",
+        "created_at": _fresh_captured(),
+        "red_dog_instance_id": "reddog-ext-0.3.27",
+        "authenticated_principal": "principal-012",
+        "principal_provider": "github",
+        "repo_full_name": "FOUNDUPS/Foundups-Agent",
+        "repo_permission_snapshot": {
+            "permission_level": "read",
+            "captured_at": _fresh_captured(),
+            "source": "mock",
+            "digest": "sha256:" + ("a" * 64),
+        },
+        "requested_operation": "audit_only",
+        "authority_tier": "advisory",
+        "allowed_paths": ["docs/**"],
+        "denied_paths": [".env"],
+        "branch_name": "docs/invoke-test",
+        "base_ref": "main",
+        "task_summary": "Runtime invocation dry-run validation",
+        "wsp_applicability": ["WSP_34", "WSP_50"],
+        "holoindex_evidence_refs": [
+            "docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md"
+        ],
+        "skillz_candidates": [],
+        "required_tests": [],
+        "required_policy_gates": ["openclaw_policy_gate"],
+        "required_reviewers": [],
+        "sentinel_checks": [],
+        "rollback_plan": "No execution performed.",
+        "expiry": _future_expiry(),
+        "nonce": "nonce-invoke-001",
+        "evidence_digest": "sha256:" + ("b" * 64),
+        "advisory_only_source_packet": {
+            "work_focus_digest": "sha256:" + ("c" * 64),
+            "wsp_prompt_digest": "sha256:" + ("d" * 64),
+            "copy_md_run_trace_digest": "sha256:" + ("e" * 64),
+        },
+        "holoindex_evidence": {
+            "holoindex_query": "RedDog runtime invocation dryrun",
+            "holoindex_status": "bundle_json_ok",
+            "code_hits": [],
+            "wsp_hits": ["WSP_framework/src/WSP_34_Git_Operations_Protocol.md"],
+            "skillz_hits": [],
+            "direct_read_fallback_used": False,
+            "index_gap_detected": True,
+            "applicable_wsps": ["WSP_34"],
+            "evidence_refs": [
+                "docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md"
+            ],
+            "retrieval_quality": "INDEX_GAP",
+            "skillz_gap_detected": True,
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestInvocationAccept:
+    def test_audit_docs_work_order_stores_receipt(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with RedDogWorkOrderReceiptStore(Path(tmp) / "receipts.db") as store:
+                result = invoke_reddog_work_order_dryrun(
+                    _base_order(nonce="nonce-audit-accept"),
+                    permission_snapshot={
+                        "permission_level": "read",
+                        "captured_at": _fresh_captured(),
+                        "source": "mock",
+                    },
+                    seen_nonces=set(),
+                    receipt_store=store,
+                )
+                assert result.decision == INVOCATION_ACCEPT_WITH_RETRIEVAL_GAP
+                assert result.no_execution_performed is True
+                assert result.receipt_id
+                assert result.receipt_digest
+                loaded = store.get_by_policy_digest(result.policy_gate_receipt_digest)
+                assert loaded is not None
+                assert loaded.receipt_id == result.receipt_id
+
+
+class TestInvocationReject:
+    def test_stale_permission_write_rejects_and_stores_receipt(self):
+        past = (datetime.now(timezone.utc) - timedelta(hours=2)).replace(microsecond=0).isoformat()
+        order = _base_order(
+            nonce="nonce-stale-write",
+            requested_operation="feature_slice",
+            authority_tier="source",
+            branch_name="feat/stale-test",
+            allowed_paths=["modules/**"],
+            holoindex_evidence={
+                "holoindex_query": "stale permission test",
+                "holoindex_status": "bundle_json_ok",
+                "code_hits": [],
+                "wsp_hits": ["WSP_framework/src/WSP_34_Git_Operations_Protocol.md"],
+                "skillz_hits": [],
+                "direct_read_fallback_used": False,
+                "index_gap_detected": False,
+                "applicable_wsps": ["WSP_34"],
+                "evidence_refs": [
+                    "docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md"
+                ],
+                "retrieval_quality": "HIGH",
+                "skillz_gap_detected": False,
+            },
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            with RedDogWorkOrderReceiptStore(Path(tmp) / "receipts.db") as store:
+                result = invoke_reddog_work_order_dryrun(
+                    order,
+                    permission_snapshot={
+                        "permission_level": "write",
+                        "captured_at": past,
+                        "source": "mock",
+                    },
+                    seen_nonces=set(),
+                    receipt_store=store,
+                    permission_ttl_seconds=300,
+                )
+                assert result.decision == INVOCATION_REJECT
+                assert result.policy_gate_decision == POLICY_REJECT
+                assert "stale_permission_snapshot" in result.rejection_reasons
+                assert result.receipt_id
+                loaded = store.get_by_policy_digest(result.policy_gate_receipt_digest)
+                assert loaded is not None
+
+    def test_index_gap_write_rejects_and_stores_receipt(self):
+        order = _base_order(
+            nonce="nonce-index-gap-write",
+            requested_operation="feature_slice",
+            authority_tier="source",
+            branch_name="feat/index-gap",
+            allowed_paths=["modules/**"],
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            with RedDogWorkOrderReceiptStore(Path(tmp) / "receipts.db") as store:
+                result = invoke_reddog_work_order_dryrun(
+                    order,
+                    permission_snapshot={
+                        "permission_level": "write",
+                        "captured_at": _fresh_captured(),
+                        "source": "mock",
+                    },
+                    seen_nonces=set(),
+                    receipt_store=store,
+                )
+                assert result.decision == INVOCATION_REJECT
+                assert "index_gap_blocks_write_operation" in result.rejection_reasons
+                assert result.receipt_id
+                loaded = store.get_by_policy_digest(result.policy_gate_receipt_digest)
+                assert loaded is not None
+
+    def test_replayed_nonce_fails_closed(self):
+        seen = set()
+        order = _base_order(nonce="nonce-replay-invoke")
+        first = invoke_reddog_work_order_dryrun(
+            order,
+            permission_snapshot={"permission_level": "read", "captured_at": _fresh_captured()},
+            seen_nonces=seen,
+        )
+        assert first.decision == INVOCATION_ACCEPT_WITH_RETRIEVAL_GAP
+        second = invoke_reddog_work_order_dryrun(
+            order,
+            permission_snapshot={"permission_level": "read", "captured_at": _fresh_captured()},
+            seen_nonces=seen,
+        )
+        assert second.decision == INVOCATION_REJECT
+        assert "replayed_nonce" in second.rejection_reasons
+
+
+class TestInvocationStability:
+    def test_receipt_id_and_digest_stable(self):
+        fixed = datetime(2026, 6, 28, 16, 0, 0, tzinfo=timezone.utc)
+        captured = (fixed - timedelta(seconds=60)).replace(microsecond=0).isoformat()
+        order = _base_order(
+            nonce="nonce-stable-invoke",
+            repo_permission_snapshot={
+                "permission_level": "read",
+                "captured_at": captured,
+                "source": "mock",
+                "digest": "sha256:" + ("f" * 64),
+            },
+        )
+        first = invoke_reddog_work_order_dryrun(order, seen_nonces=set(), now=fixed)
+        second = invoke_reddog_work_order_dryrun(order, seen_nonces=set(), now=fixed)
+        assert first.receipt_id == second.receipt_id
+        assert first.receipt_digest == second.receipt_digest
+        assert first.no_execution_performed is True
+
+    def test_idempotent_store_replay(self):
+        fixed = datetime(2026, 6, 28, 16, 5, 0, tzinfo=timezone.utc)
+        order = _base_order(nonce="nonce-idem-invoke")
+        with tempfile.TemporaryDirectory() as tmp:
+            with RedDogWorkOrderReceiptStore(Path(tmp) / "receipts.db") as store:
+                first = invoke_reddog_work_order_dryrun(
+                    order, seen_nonces=set(), receipt_store=store, now=fixed
+                )
+                second = invoke_reddog_work_order_dryrun(
+                    order, seen_nonces=set(), receipt_store=store, now=fixed
+                )
+                assert first.receipt_id == second.receipt_id
+                assert second.idempotent_replay is True
+
+
+class TestNoExecutionBoundary:
+    def test_ast_denylist(self):
+        module_path = (
+            Path(__file__).resolve().parents[1]
+            / "src"
+            / "reddog_work_order_runtime_invocation.py"
+        )
+        source = module_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imported: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.append(node.module)
+        forbidden = [
+            name
+            for name in imported
+            if any(
+                token in name
+                for token in ("subprocess", "github_integration", "wre_core", "skillz")
+            )
+        ]
+        assert forbidden == []
+        for token in (
+            "subprocess",
+            "probe_repo_permission",
+            "create_branch",
+            "merge_pull_request",
+            "git ",
+            "gh ",
+        ):
+            assert token not in source


### PR DESCRIPTION
## Summary

- Adds `invoke_reddog_work_order_dryrun()` in `modules/communication/moltbot_bridge/src/reddog_work_order_runtime_invocation.py`.
- Orchestrates #893 policy gate + #894 receipt emission/persistence; returns `WorkOrderDryRunInvocationResult`.
- 7 pytest cases: accept audit/docs, reject stale permission, reject INDEX_GAP write, nonce replay, digest stability, idempotent store, AST denylist.

## Invocation flow

```text
RedDogGovernedWorkOrder + permission_snapshot
  -> evaluate_work_order_policy_gate()  (#893)
  -> emit_work_order_receipt()          (#894)
  -> WorkOrderDryRunInvocationResult    (no_execution_performed: true)
```

## Hard boundary

No branch/PR/commit/merge, no WRE, no live GitHub, no external API, no extension runtime.

## HoloIndex (Addendum)

**Pre-edit:** OpenClaw orchestrator/routing, RedDog contract audit, WSP_46/WSP_97.
**Post-edit:** New module not in top semantic hits — INDEX_GAP recorded (`HOLOINDEX_REDDOG_RUNTIME_INVOCATION_INDEX_GAP_PHASE1`); static pointers in INTERFACE/ModLog.

## Test plan

- [x] 70 pytest (7 invocation + full governance suite)
- [x] extension contract checks
- [x] git diff --check clean

## Residual SPECIFIED_NOT_IMPLEMENTED

- Extension/OpenClaw runtime wiring
- WRE isolated worktree executor
- Campaign Skillz work-order emission
- Live Hermes queue dispatch
