### PR TITLE
feat(reddog): add WRE executor dry-run planner

### DIFF
--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -83,6 +83,8 @@ RedDog is the 0102 architect interface — **not an authority owner**. RedDog re
 
 **WRE isolated worktree executor (contract only):** `docs/audits/architecture/REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_CONTRACT_PHASE1.md` — defines future executor cage; **no implementation**.
 
+**WRE executor dry-run planner:** `modules/communication/moltbot_bridge/src/reddog_wre_executor_dryrun.py` — `plan_wre_isolated_worktree_execution_dryrun()`; plan + phase receipts; **no git/worktree mutation**.
+
 **Specified flow (not implemented in extension v0.3.27):**
 
 ```text
@@ -312,6 +314,7 @@ Formal contract:
 | RedDog work-order receipt (Hermes-compatible audit) | OBSERVED (moltbot_bridge module); not live Hermes queue |
 | RedDog runtime invocation dry-run | OBSERVED (moltbot_bridge module); no execution |
 | WRE isolated worktree executor | SPECIFIED_NOT_IMPLEMENTED (contract doc only) |
+| WRE executor dry-run planner | OBSERVED (moltbot_bridge module); no mutation |
 | Governed repo work order dry-run validator | OBSERVED (OpenClaw bridge module) |
 | Governed repo work order (`RedDogGovernedWorkOrder`) | SPECIFIED_NOT_IMPLEMENTED (runtime emission from extension) |
 | GitHub permission snapshot per work order | SPECIFIED_NOT_IMPLEMENTED |

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -1,5 +1,12 @@
 # Foundups®Agent ModLog
 
+## 2026-06-28 - REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_DRYRUN_PHASE1 (extension pointers)
+
+- Module: `modules/communication/moltbot_bridge/src/reddog_wre_executor_dryrun.py`
+- `plan_wre_isolated_worktree_execution_dryrun()` — plan + phase receipts; no git/worktree mutation.
+
+WSP: WSP_00, WSP_15, WSP_50, WSP_97, WSP_22.
+
 ## 2026-06-28 - REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_CONTRACT_PHASE1 (audit doc)
 
 - Canonical: `docs/audits/architecture/REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_CONTRACT_PHASE1.md`

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -81,23 +81,26 @@ DONE
 7. #893 OpenClaw policy gate (329db7113)
 8. #894 Hermes-compatible receipt (b42db2165)
 9. #896 runtime invocation dry-run (f65ecff4e)
+10. #897 WRE isolated worktree executor contract (2fe60a280)
 
-P0 NEXT (contract before execution)
-10. REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_CONTRACT_PHASE1
-    - executor cage definition; no implementation
-11. REDDOG_WRE_EXECUTION_VALVE_PHASE1
-    - default CLOSED valve before any PoC
+P0 NEXT (plan before mutation)
+11. REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_DRYRUN_PHASE1
+    - executor plan + phase receipts; no git/worktree/file mutation
+12. REDDOG_WRE_EXECUTION_VALVE_PHASE1
+    - default CLOSED valve before first real worktree create
 
 P1
-12. REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_POC_PHASE1
-13. REDDOG_SANITIZED_TARGET_CONTEXT_PROVENANCE_PHASE1
-14. REDDOG_RUN_TRACE_TELEMETRY_CORRECTION_PHASE1
-15. HOLOINDEX_REDDOG_GOVERNED_WORK_ORDER_INDEX_GAP_PHASE1
-16. HOLOINDEX_REDDOG_WRE_EXECUTOR_CONTRACT_INDEX_GAP_PHASE1
+13. REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_WORKTREE_CREATE_PHASE1
+    - first real isolated worktree; valve OPEN only
+14. REDDOG_SANITIZED_TARGET_CONTEXT_PROVENANCE_PHASE1
+15. REDDOG_RUN_TRACE_TELEMETRY_CORRECTION_PHASE1
+16. HOLOINDEX_REDDOG_GOVERNED_WORK_ORDER_INDEX_GAP_PHASE1
+17. HOLOINDEX_REDDOG_WRE_EXECUTOR_CONTRACT_INDEX_GAP_PHASE1
+18. HOLOINDEX_REDDOG_WRE_EXECUTOR_DRYRUN_INDEX_GAP_PHASE1
 
 P2/P3
-17. REDDOG_REVIEW_CONSENSUS_RECEIPTS_PHASE1
-18. REDDOG_AUTONOMOUS_MERGE_POLICY_PHASE1 (blocked)
+19. REDDOG_REVIEW_CONSENSUS_RECEIPTS_PHASE1
+20. REDDOG_AUTONOMOUS_MERGE_POLICY_PHASE1 (blocked)
 ```
 
 **Rationale:** Sanitized provenance and telemetry are real polish issues, but the strategic blocker is that RedDog still cannot safely become a worker. The work-order contract is the missing bridge between “advisory RedDog” and “RedDog can direct WRE to do meaningful code work.”
@@ -214,13 +217,18 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 
 ### REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_CONTRACT_PHASE1
 
-- **Status:** **PR-READY** — contract-only audit doc; no executor code.
+- **Status:** **LANDED** #897 (`2fe60a280`) — contract-only audit doc; no executor code.
 - **Canonical:** `docs/audits/architecture/REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_CONTRACT_PHASE1.md`
-- Entry conditions, worktree isolation, mutation bounds, rollback, output schema, WSP_15 next slices.
 
-### REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_PHASE1
+### REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_DRYRUN_PHASE1
 
-- **Status:** **BLOCKED** — until contract + execution valve land.
+- **Status:** **PR-READY** — `plan_wre_isolated_worktree_execution_dryrun()`; plan + receipts only.
+- **Module:** `modules/communication/moltbot_bridge/src/reddog_wre_executor_dryrun.py`
+- No git, worktree, file edits, task commands, PR, or merge.
+
+### REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_WORKTREE_CREATE_PHASE1
+
+- **Status:** **BLOCKED** — until dry-run planner + execution valve land.
 
 ### REDDOG_REVIEW_CONSENSUS_RECEIPTS_PHASE1
 

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -220,6 +220,12 @@ includes(executorContractDoc, 'WSP_97 truth table', 'executor contract WSP_97 ta
 includes(executorContractDoc, 'WSP_15 — Next implementation slices', 'executor contract WSP_15 slices missing');
 includes(iface, 'REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_CONTRACT_PHASE1.md', 'INTERFACE executor contract pointer missing');
 includes(roadmap, 'docs/audits/architecture/REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_CONTRACT_PHASE1.md', 'executor contract path missing from roadmap');
+const executorDryrunPy = fs.readFileSync(path.join(root, 'modules', 'communication', 'moltbot_bridge', 'src', 'reddog_wre_executor_dryrun.py'), 'utf8');
+includes(executorDryrunPy, 'plan_wre_isolated_worktree_execution_dryrun', 'WRE executor dryrun planner missing');
+includes(executorDryrunPy, 'WREExecutorPlan', 'WREExecutorPlan schema missing');
+includes(executorDryrunPy, 'no_mutation_performed', 'executor dryrun no_mutation_performed missing');
+includes(iface, 'reddog_wre_executor_dryrun.py', 'INTERFACE executor dryrun pointer missing');
+includes(roadmap, 'REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_DRYRUN_PHASE1', 'executor dryrun slice missing');
 includes(roadmap, 'External RedDog Lane Queue (post-#888)', 'post-#888 external lane queue missing');
 includes(roadmap, 'REDDOG_GOVERNED_REPO_WORK_ORDER_DRYRUN_PHASE1', 'governed work order dryrun slice missing');
 includes(roadmap, 'REDDOG_RUN_TRACE_TELEMETRY_CORRECTION_PHASE1', 'run trace telemetry correction slice missing');

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -807,3 +807,20 @@ from modules.communication.moltbot_bridge.src.reddog_work_order_runtime_invocati
 
 Orchestrates #893 policy gate + #894 receipt emission/persistence. Returns audit result to caller.
 No WRE, git, shell, live GitHub probe, or extension runtime wiring.
+
+### RedDog WRE Executor Dry-Run Planner (no mutation)
+
+```python
+from modules.communication.moltbot_bridge.src.reddog_wre_executor_dryrun import (
+    plan_wre_isolated_worktree_execution_dryrun,  # (invocation_result, work_order, *, now, locks, repo_root) -> WREExecutorDryRunResult
+    WREExecutorPlan,
+    WREExecutorDryRunResult,
+    ExecutorDryRunPhaseReceipt,
+    EXECUTOR_PLAN_ACCEPT,
+    EXECUTOR_PLAN_REJECT,
+)
+```
+
+Consumes accepted #896 `WorkOrderDryRunInvocationResult`; validates #897 contract rules;
+emits phase receipts (`plan_built`, `lock_checked`, `cleanup_planned`). No git, worktree,
+file edits, task commands, PR, or merge.

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,14 @@
 # ModLog - moltbot_bridge
 
+## 2026-06-28: REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_DRYRUN_PHASE1
+
+**Slice:** WRE isolated worktree executor dry-run planner (plan + receipts, no mutation)
+**WSP:** WSP_34, WSP_50, WSP_91, WSP_97, WSP_22
+
+- ADD `src/reddog_wre_executor_dryrun.py` — `plan_wre_isolated_worktree_execution_dryrun()`, `WREExecutorPlan`.
+- ADD `tests/test_reddog_wre_executor_dryrun.py` — accept/reject/lock/cleanup/AST denylist.
+- Consumes #896 invocation result; validates #897 contract rules; no git/subprocess/worktree.
+
 ## 2026-06-28: REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_CONTRACT_PHASE1 (pointer)
 
 **Slice:** WRE isolated worktree executor **contract only** (audit doc; no module code)

--- a/modules/communication/moltbot_bridge/src/reddog_wre_executor_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_executor_dryrun.py
@@ -1,0 +1,414 @@
+"""RedDog WRE isolated worktree executor dry-run planner (no mutation).
+
+Slice: REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_DRYRUN_PHASE1
+Contract: docs/audits/architecture/REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_CONTRACT_PHASE1.md
+
+Consumes an accepted #896 invocation result and produces a WREExecutorPlan plus phase
+receipts. Validates #897 contract rules without creating branches, worktrees, files,
+PRs, or running task commands.
+
+WSP 97 TRUTH BOUNDARIES:
+  ✓ DOES:
+    - Require accepted invocation + no_execution_performed from prior spine
+    - Build proposed branch/worktree path, lock key, cleanup plan (plan only)
+    - Validate path confinement, branch naming, deny secrets/global config paths
+    - Emit phase receipts: plan_built, lock_checked, cleanup_planned
+    - Return rejection receipt digest on failure
+
+  ✗ DOES NOT:
+    - Call shell, WRE executor, Skillz, live GitHub, or Hermes queue
+    - Create directories, worktrees, branches, commits, PRs, or file edits
+    - Invoke task commands or mutate repository content
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Mapping, MutableSet, Optional, Sequence, Union
+
+from modules.communication.moltbot_bridge.src.reddog_governed_work_order_dryrun import (
+    PROTECTED_BASE_REFS,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_runtime_invocation import (
+    INVOCATION_ACCEPT,
+    INVOCATION_ACCEPT_WITH_RETRIEVAL_GAP,
+    INVOCATION_REJECT,
+    WorkOrderDryRunInvocationResult,
+)
+
+EXECUTOR_PLAN_ACCEPT = "EXECUTOR_PLAN_ACCEPT"
+EXECUTOR_PLAN_REJECT = "EXECUTOR_PLAN_REJECT"
+
+PHASE_PLAN_BUILT = "plan_built"
+PHASE_LOCK_CHECKED = "lock_checked"
+PHASE_CLEANUP_PLANNED = "cleanup_planned"
+
+EXECUTOR_FORBIDDEN_PATH_GLOBS = (
+    ".env",
+    ".env.*",
+    "**/.env",
+    "**/credentials*",
+    "**/secrets/**",
+    "**/.git/**",
+    ".git/config",
+    "**/.git/config",
+    ".git/hooks/**",
+    ".github/workflows/**",
+)
+
+_NONCE_SUFFIX_RE = re.compile(r"[^a-zA-Z0-9_-]+")
+
+
+@dataclass
+class ExecutorDryRunPhaseReceipt:
+    phase: str
+    work_order_id: str
+    receipt_digest: str
+    no_mutation_performed: bool
+    created_at: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class WREExecutorPlan:
+    plan_id: str
+    work_order_id: str
+    proposed_branch_name: str
+    proposed_worktree_path: str
+    lock_key: str
+    allowed_paths: List[str]
+    denied_paths: List[str]
+    required_tests: List[str]
+    cleanup_plan: Dict[str, Any]
+    phase_receipts: List[ExecutorDryRunPhaseReceipt]
+    no_mutation_performed: bool
+    invocation_receipt_digest: str
+    plan_digest: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["phase_receipts"] = [r.to_dict() for r in self.phase_receipts]
+        return payload
+
+
+@dataclass
+class WREExecutorDryRunResult:
+    decision: str
+    work_order_id: str
+    plan: Optional[WREExecutorPlan]
+    rejection_reasons: List[str]
+    rejection_receipt_digest: str
+    no_mutation_performed: bool
+    phase_receipts: List[ExecutorDryRunPhaseReceipt] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        if self.plan is not None:
+            payload["plan"] = self.plan.to_dict()
+        payload["phase_receipts"] = [r.to_dict() for r in self.phase_receipts]
+        return payload
+
+
+def _utc_now(now: Optional[datetime] = None) -> datetime:
+    value = now or datetime.now(timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _iso8601(dt: datetime) -> str:
+    return dt.replace(microsecond=0).isoformat()
+
+
+def _canonical_digest(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _path_matches_any(path: str, patterns: Sequence[str]) -> bool:
+    normalized = path.replace("\\", "/")
+    for pattern in patterns:
+        pat = pattern.replace("\\", "/")
+        if fnmatch.fnmatch(normalized, pat) or fnmatch.fnmatch(normalized, f"**/{pat}"):
+            return True
+    return False
+
+
+def _forbidden_path_overlap(paths: Sequence[str]) -> List[str]:
+    hits: List[str] = []
+    for path in paths:
+        if _path_matches_any(path, EXECUTOR_FORBIDDEN_PATH_GLOBS):
+            hits.append(path)
+    return hits
+
+
+def _normalize_posix(path: str) -> str:
+    return path.replace("\\", "/").rstrip("/")
+
+
+def _nonce_suffix(nonce: str) -> str:
+    cleaned = _NONCE_SUFFIX_RE.sub("-", nonce.strip())[:32].strip("-")
+    return cleaned or "nonce"
+
+
+def _invocation_from_any(
+    invocation_result: Union[WorkOrderDryRunInvocationResult, Mapping[str, Any]],
+) -> WorkOrderDryRunInvocationResult:
+    if isinstance(invocation_result, WorkOrderDryRunInvocationResult):
+        return invocation_result
+    return WorkOrderDryRunInvocationResult(**dict(invocation_result))
+
+
+def _work_order_id(work_order: Mapping[str, Any]) -> str:
+    return str(work_order.get("work_order_id") or "unknown")
+
+
+def _build_cleanup_plan(work_order: Mapping[str, Any]) -> Dict[str, Any]:
+    rollback = str(work_order.get("rollback_plan") or "").strip()
+    return {
+        "on_success": "remove_worktree_after_pr_draft_receipt",
+        "on_failure": "remove_worktree_delete_branch",
+        "on_interrupt": "lease_expiry_janitor_cleanup",
+        "salvage_requires_operator": True,
+        "rollback_plan_ref": rollback,
+    }
+
+
+def _proposed_worktree_path(repo_root: str, work_order_id: str, nonce: str) -> str:
+    root = _normalize_posix(repo_root) or "."
+    suffix = _nonce_suffix(nonce)
+    return f"{root}/.reddog/worktrees/{work_order_id}/{suffix}/"
+
+
+def _phase_receipt(
+    phase: str,
+    work_order_id: str,
+    payload: Mapping[str, Any],
+    checked_at: str,
+) -> ExecutorDryRunPhaseReceipt:
+    body = {
+        "phase": phase,
+        "work_order_id": work_order_id,
+        "no_mutation_performed": True,
+        "created_at": checked_at,
+        **dict(payload),
+    }
+    return ExecutorDryRunPhaseReceipt(
+        phase=phase,
+        work_order_id=work_order_id,
+        receipt_digest=_canonical_digest(body),
+        no_mutation_performed=True,
+        created_at=checked_at,
+    )
+
+
+def _rejection_result(
+    work_order_id: str,
+    reasons: List[str],
+    checked_at: str,
+    phase_receipts: Optional[List[ExecutorDryRunPhaseReceipt]] = None,
+) -> WREExecutorDryRunResult:
+    body = {
+        "decision": EXECUTOR_PLAN_REJECT,
+        "work_order_id": work_order_id,
+        "rejection_reasons": reasons,
+        "no_mutation_performed": True,
+        "created_at": checked_at,
+    }
+    return WREExecutorDryRunResult(
+        decision=EXECUTOR_PLAN_REJECT,
+        work_order_id=work_order_id,
+        plan=None,
+        rejection_reasons=reasons,
+        rejection_receipt_digest=_canonical_digest(body),
+        no_mutation_performed=True,
+        phase_receipts=list(phase_receipts or []),
+    )
+
+
+def _validate_contract_rules(
+    work_order: Mapping[str, Any],
+    repo_root: str,
+    locks: Optional[MutableSet[str]],
+) -> List[str]:
+    reasons: List[str] = []
+    work_order_id = _work_order_id(work_order)
+    branch = str(work_order.get("branch_name") or "").strip()
+    base_ref = str(work_order.get("base_ref") or "main").strip().lower()
+    nonce = str(work_order.get("nonce") or "").strip()
+    allowed_paths = list(work_order.get("allowed_paths") or [])
+    denied_paths = list(work_order.get("denied_paths") or [])
+    rollback_plan = str(work_order.get("rollback_plan") or "").strip()
+
+    if not branch:
+        reasons.append("missing_branch_name")
+    elif branch.lower() in PROTECTED_BASE_REFS:
+        reasons.append("protected_branch_forbidden")
+    elif branch.lower() == base_ref:
+        reasons.append("branch_equals_base_ref")
+
+    if not nonce:
+        reasons.append("missing_nonce")
+
+    forbidden_allowed = _forbidden_path_overlap(allowed_paths)
+    if forbidden_allowed:
+        reasons.append("forbidden_path_in_allowed_paths")
+
+    forbidden_denied = _forbidden_path_overlap(denied_paths)
+    if forbidden_denied and not denied_paths:
+        reasons.append("invalid_denied_paths")
+
+    overlap = [p for p in denied_paths if p in allowed_paths]
+    if overlap:
+        reasons.append("denied_path_also_allowed")
+
+    for path in allowed_paths:
+        norm = _normalize_posix(path)
+        if norm.startswith("../") or "/../" in norm:
+            reasons.append("allowed_path_escapes_repo_root")
+
+    if not rollback_plan:
+        reasons.append("cleanup_plan_missing")
+
+    worktree_path = _proposed_worktree_path(repo_root, work_order_id, nonce or "missing")
+    expected_prefix = f"{_normalize_posix(repo_root) or '.'}/.reddog/worktrees/{work_order_id}/"
+    if not worktree_path.startswith(expected_prefix):
+        reasons.append("worktree_path_not_confined")
+
+    lock_key = work_order_id
+    if locks is not None and lock_key in locks:
+        reasons.append("lock_collision")
+
+    return reasons
+
+
+def plan_wre_isolated_worktree_execution_dryrun(
+    invocation_result: Union[WorkOrderDryRunInvocationResult, Mapping[str, Any]],
+    work_order: Mapping[str, Any],
+    *,
+    now: Optional[datetime] = None,
+    locks: Optional[MutableSet[str]] = None,
+    repo_root: str = ".",
+) -> WREExecutorDryRunResult:
+    """Plan isolated worktree execution without mutation (dry-run only)."""
+    checked = _utc_now(now)
+    checked_at = _iso8601(checked)
+    invocation = _invocation_from_any(invocation_result)
+    work_order_id = _work_order_id(work_order)
+
+    if invocation.decision == INVOCATION_REJECT:
+        return _rejection_result(work_order_id, ["invocation_rejected"], checked_at)
+    if invocation.decision == INVOCATION_ACCEPT_WITH_RETRIEVAL_GAP:
+        return _rejection_result(
+            work_order_id,
+            ["retrieval_gap_not_allowed_for_executor_plan"],
+            checked_at,
+        )
+    if invocation.decision != INVOCATION_ACCEPT:
+        return _rejection_result(work_order_id, ["invocation_not_accepted"], checked_at)
+    if not invocation.no_execution_performed:
+        return _rejection_result(work_order_id, ["prior_spine_execution_detected"], checked_at)
+    if not invocation.receipt_digest:
+        return _rejection_result(work_order_id, ["missing_invocation_receipt_digest"], checked_at)
+
+    contract_reasons = _validate_contract_rules(work_order, repo_root, locks)
+    if contract_reasons:
+        return _rejection_result(work_order_id, contract_reasons, checked_at)
+
+    branch_name = str(work_order["branch_name"]).strip()
+    nonce = str(work_order["nonce"]).strip()
+    lock_key = work_order_id
+    worktree_path = _proposed_worktree_path(repo_root, work_order_id, nonce)
+    allowed_paths = list(work_order.get("allowed_paths") or [])
+    denied_paths = list(work_order.get("denied_paths") or [])
+    required_tests = list(work_order.get("required_tests") or [])
+    cleanup_plan = _build_cleanup_plan(work_order)
+
+    phase_receipts: List[ExecutorDryRunPhaseReceipt] = []
+    phase_receipts.append(
+        _phase_receipt(
+            PHASE_PLAN_BUILT,
+            work_order_id,
+            {
+                "proposed_branch_name": branch_name,
+                "proposed_worktree_path": worktree_path,
+                "invocation_receipt_digest": invocation.receipt_digest,
+            },
+            checked_at,
+        )
+    )
+    phase_receipts.append(
+        _phase_receipt(
+            PHASE_LOCK_CHECKED,
+            work_order_id,
+            {"lock_key": lock_key, "lock_available": True},
+            checked_at,
+        )
+    )
+    phase_receipts.append(
+        _phase_receipt(
+            PHASE_CLEANUP_PLANNED,
+            work_order_id,
+            {"cleanup_plan_digest": _canonical_digest(cleanup_plan)},
+            checked_at,
+        )
+    )
+
+    plan_body = {
+        "work_order_id": work_order_id,
+        "proposed_branch_name": branch_name,
+        "proposed_worktree_path": worktree_path,
+        "lock_key": lock_key,
+        "allowed_paths": allowed_paths,
+        "denied_paths": denied_paths,
+        "required_tests": required_tests,
+        "cleanup_plan": cleanup_plan,
+        "no_mutation_performed": True,
+        "invocation_receipt_digest": invocation.receipt_digest,
+    }
+    plan_digest = _canonical_digest(plan_body)
+    plan_id = plan_digest
+
+    plan = WREExecutorPlan(
+        plan_id=plan_id,
+        work_order_id=work_order_id,
+        proposed_branch_name=branch_name,
+        proposed_worktree_path=worktree_path,
+        lock_key=lock_key,
+        allowed_paths=allowed_paths,
+        denied_paths=denied_paths,
+        required_tests=required_tests,
+        cleanup_plan=cleanup_plan,
+        phase_receipts=phase_receipts,
+        no_mutation_performed=True,
+        invocation_receipt_digest=invocation.receipt_digest,
+        plan_digest=plan_digest,
+    )
+
+    return WREExecutorDryRunResult(
+        decision=EXECUTOR_PLAN_ACCEPT,
+        work_order_id=work_order_id,
+        plan=plan,
+        rejection_reasons=[],
+        rejection_receipt_digest="",
+        no_mutation_performed=True,
+        phase_receipts=phase_receipts,
+    )
+
+
+__all__ = [
+    "EXECUTOR_PLAN_ACCEPT",
+    "EXECUTOR_PLAN_REJECT",
+    "PHASE_CLEANUP_PLANNED",
+    "PHASE_LOCK_CHECKED",
+    "PHASE_PLAN_BUILT",
+    "ExecutorDryRunPhaseReceipt",
+    "WREExecutorDryRunResult",
+    "WREExecutorPlan",
+    "plan_wre_isolated_worktree_execution_dryrun",
+]

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,13 @@
+## 2026-06-28: REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_DRYRUN_PHASE1
+
+**File**: `test_reddog_wre_executor_dryrun.py` (NEW — 8 tests)
+**Slice**: `REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_DRYRUN_PHASE1` | **Predecessors**: #896 invocation, #897 contract
+
+Executor plan dry-run: accepted invocation -> WREExecutorPlan + phase receipts; reject protected branch,
+forbidden paths, lock collision, missing cleanup; AST denylist; no git/worktree mutation.
+
+**Run**: `pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_executor_dryrun.py -q`
+
 ## 2026-06-28: REDDOG_WORK_ORDER_RUNTIME_INVOCATION_DRYRUN_PHASE1
 
 **File**: `test_reddog_work_order_runtime_invocation.py` (NEW — 7 tests)

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_executor_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_executor_dryrun.py
@@ -1,0 +1,250 @@
+"""Tests for RedDog WRE isolated worktree executor dry-run planner."""
+
+from __future__ import annotations
+
+import ast
+import json
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_work_order_receipt import (
+    RedDogWorkOrderReceiptStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_runtime_invocation import (
+    INVOCATION_ACCEPT,
+    INVOCATION_REJECT,
+    invoke_reddog_work_order_dryrun,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_executor_dryrun import (
+    EXECUTOR_PLAN_ACCEPT,
+    EXECUTOR_PLAN_REJECT,
+    PHASE_CLEANUP_PLANNED,
+    PHASE_LOCK_CHECKED,
+    PHASE_PLAN_BUILT,
+    plan_wre_isolated_worktree_execution_dryrun,
+)
+
+
+def _future_expiry(hours: int = 2) -> str:
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).replace(microsecond=0).isoformat()
+
+
+def _fresh_captured() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _base_order(**overrides):
+    payload = {
+        "work_order_id": "wo-exec-dryrun-001",
+        "created_at": _fresh_captured(),
+        "red_dog_instance_id": "reddog-ext-0.3.27",
+        "authenticated_principal": "principal-012",
+        "principal_provider": "github",
+        "repo_full_name": "FOUNDUPS/Foundups-Agent",
+        "repo_permission_snapshot": {
+            "permission_level": "read",
+            "captured_at": _fresh_captured(),
+            "source": "mock",
+            "digest": "sha256:" + ("a" * 64),
+        },
+        "requested_operation": "audit_only",
+        "authority_tier": "advisory",
+        "allowed_paths": ["docs/**"],
+        "denied_paths": [".env"],
+        "branch_name": "docs/executor-dryrun-test",
+        "base_ref": "main",
+        "task_summary": "Executor dry-run planner validation",
+        "wsp_applicability": ["WSP_34", "WSP_50"],
+        "holoindex_evidence_refs": [
+            "docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md",
+            "docs/audits/architecture/REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_CONTRACT_PHASE1.md",
+        ],
+        "skillz_candidates": [],
+        "required_tests": ["modules/communication/moltbot_bridge/tests/test_reddog_wre_executor_dryrun.py"],
+        "required_policy_gates": ["openclaw_policy_gate"],
+        "required_reviewers": [],
+        "sentinel_checks": [],
+        "rollback_plan": "Remove worktree and delete branch on abort; no merge.",
+        "expiry": _future_expiry(),
+        "nonce": "nonce-exec-dryrun-001",
+        "evidence_digest": "sha256:" + ("b" * 64),
+        "advisory_only_source_packet": {
+            "work_focus_digest": "sha256:" + ("c" * 64),
+            "wsp_prompt_digest": "sha256:" + ("d" * 64),
+            "copy_md_run_trace_digest": "sha256:" + ("e" * 64),
+        },
+        "holoindex_evidence": {
+            "holoindex_query": "WRE executor plan dryrun",
+            "holoindex_status": "bundle_json_ok",
+            "code_hits": [],
+            "wsp_hits": ["WSP_framework/src/WSP_34_Git_Operations_Protocol.md"],
+            "skillz_hits": [],
+            "direct_read_fallback_used": False,
+            "index_gap_detected": False,
+            "applicable_wsps": ["WSP_34"],
+            "evidence_refs": [
+                "docs/audits/architecture/REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_CONTRACT_PHASE1.md"
+            ],
+            "retrieval_quality": "HIGH",
+            "skillz_gap_detected": False,
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _accepted_invocation(order=None, *, nonce_suffix: str = "accept"):
+    order = order or _base_order(nonce=f"nonce-{nonce_suffix}")
+    with tempfile.TemporaryDirectory() as tmp:
+        with RedDogWorkOrderReceiptStore(Path(tmp) / "receipts.db") as store:
+            result = invoke_reddog_work_order_dryrun(
+                order,
+                permission_snapshot={
+                    "permission_level": "read",
+                    "captured_at": _fresh_captured(),
+                    "source": "mock",
+                },
+                seen_nonces=set(),
+                receipt_store=store,
+            )
+    assert result.decision == INVOCATION_ACCEPT
+    return result, order
+
+
+class TestExecutorDryRunAccept:
+    def test_accepted_invocation_creates_plan_no_mutation(self):
+        invocation, order = _accepted_invocation()
+        result = plan_wre_isolated_worktree_execution_dryrun(invocation, order)
+        assert result.decision == EXECUTOR_PLAN_ACCEPT
+        assert result.plan is not None
+        assert result.no_mutation_performed is True
+        assert result.plan.no_mutation_performed is True
+        assert result.plan.proposed_branch_name == "docs/executor-dryrun-test"
+        assert ".reddog/worktrees/wo-exec-dryrun-001/" in result.plan.proposed_worktree_path
+        assert result.plan.lock_key == "wo-exec-dryrun-001"
+        assert len(result.phase_receipts) == 3
+        phases = [r.phase for r in result.phase_receipts]
+        assert phases == [PHASE_PLAN_BUILT, PHASE_LOCK_CHECKED, PHASE_CLEANUP_PLANNED]
+
+    def test_plan_digest_stable_and_json_serializable(self):
+        fixed = datetime(2026, 6, 28, 18, 0, 0, tzinfo=timezone.utc)
+        captured = (fixed - timedelta(seconds=60)).replace(microsecond=0).isoformat()
+        order = _base_order(
+            nonce="nonce-stable-plan",
+            repo_permission_snapshot={
+                "permission_level": "read",
+                "captured_at": captured,
+                "source": "mock",
+                "digest": "sha256:" + ("f" * 64),
+            },
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            with RedDogWorkOrderReceiptStore(Path(tmp) / "receipts.db") as store:
+                invocation = invoke_reddog_work_order_dryrun(
+                    order,
+                    permission_snapshot={
+                        "permission_level": "read",
+                        "captured_at": captured,
+                        "source": "mock",
+                    },
+                    seen_nonces=set(),
+                    receipt_store=store,
+                    now=fixed,
+                )
+        first = plan_wre_isolated_worktree_execution_dryrun(
+            invocation, order, now=fixed, repo_root="/repo"
+        )
+        second = plan_wre_isolated_worktree_execution_dryrun(
+            invocation, order, now=fixed, repo_root="/repo"
+        )
+        assert first.plan is not None
+        assert first.plan.plan_id == second.plan.plan_id
+        assert first.plan.plan_digest == second.plan.plan_digest
+        json.dumps(first.to_dict())
+
+
+class TestExecutorDryRunReject:
+    def test_rejected_invocation_fails_closed(self):
+        invocation, order = _accepted_invocation(nonce_suffix="reject-invoke")
+        rejected = type(invocation)(
+            decision=INVOCATION_REJECT,
+            work_order_id=invocation.work_order_id,
+            policy_gate_decision=invocation.policy_gate_decision,
+            receipt_id=invocation.receipt_id,
+            receipt_digest=invocation.receipt_digest,
+            no_execution_performed=True,
+            rejection_reasons=["policy_reject"],
+            gates_checked=invocation.gates_checked,
+            policy_gate_receipt_digest=invocation.policy_gate_receipt_digest,
+        )
+        result = plan_wre_isolated_worktree_execution_dryrun(rejected, order)
+        assert result.decision == EXECUTOR_PLAN_REJECT
+        assert result.plan is None
+        assert "invocation_rejected" in result.rejection_reasons
+        assert result.rejection_receipt_digest
+
+    def test_protected_branch_rejected(self):
+        invocation, order = _accepted_invocation(nonce_suffix="protected-branch")
+        order = dict(order)
+        order["branch_name"] = "main"
+        result = plan_wre_isolated_worktree_execution_dryrun(invocation, order)
+        assert result.decision == EXECUTOR_PLAN_REJECT
+        assert "protected_branch_forbidden" in result.rejection_reasons
+
+    def test_denied_path_overlap_rejected(self):
+        invocation, order = _accepted_invocation(nonce_suffix="denied-overlap")
+        order["allowed_paths"] = ["docs/**", ".env"]
+        result = plan_wre_isolated_worktree_execution_dryrun(invocation, order)
+        assert result.decision == EXECUTOR_PLAN_REJECT
+        assert "forbidden_path_in_allowed_paths" in result.rejection_reasons
+
+    def test_lock_collision_rejected(self):
+        invocation, order = _accepted_invocation(nonce_suffix="lock-collision")
+        locks = {"wo-exec-dryrun-001"}
+        result = plan_wre_isolated_worktree_execution_dryrun(invocation, order, locks=locks)
+        assert result.decision == EXECUTOR_PLAN_REJECT
+        assert "lock_collision" in result.rejection_reasons
+
+    def test_cleanup_plan_required(self):
+        invocation, order = _accepted_invocation(nonce_suffix="no-cleanup")
+        order["rollback_plan"] = ""
+        result = plan_wre_isolated_worktree_execution_dryrun(invocation, order)
+        assert result.decision == EXECUTOR_PLAN_REJECT
+        assert "cleanup_plan_missing" in result.rejection_reasons
+
+
+class TestNoExecutionBoundary:
+    def test_ast_denylist(self):
+        module_path = (
+            Path(__file__).resolve().parents[1] / "src" / "reddog_wre_executor_dryrun.py"
+        )
+        source = module_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imported: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.append(node.module)
+        forbidden = [
+            name
+            for name in imported
+            if any(
+                token in name
+                for token in ("subprocess", "github_integration", "wre_core", "skillz")
+            )
+        ]
+        assert forbidden == []
+        for token in (
+            "import subprocess",
+            "git worktree",
+            "worktree add",
+            "create_branch",
+            "merge_pull_request",
+            "git ",
+            "gh ",
+            "os.mkdir",
+            "Path.mkdir",
+        ):
+            assert token not in source


### PR DESCRIPTION
## Summary
- Adds `plan_wre_isolated_worktree_execution_dryrun()` — consumes accepted #896 invocation, validates #897 contract rules, emits `WREExecutorPlan` + phase receipts (`plan_built`, `lock_checked`, `cleanup_planned`).
- Zero mutation: no git, subprocess, worktree, branch, file edits, task commands, PR, or merge.
- Updates extension ROADMAP queue: dry-run planner → execution valve → first real worktree-create slice.

## WSP_97
| Claim | Label |
|-------|-------|
| Planner produces plan + receipts only | OBSERVED |
| No git/subprocess/worktree mutation | OBSERVED (AST denylist + module boundary) |
| HoloIndex semantic query for WRE executor plan dryrun | INDEX_GAP → HOLOINDEX_REDDOG_WRE_EXECUTOR_DRYRUN_INDEX_GAP_PHASE1 |

## Test plan
- [x] `pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_executor_dryrun.py` (8 tests)
- [x] Governance spine tests (#890/#892/#893/#894/#896) — 78 passed
- [x] `node extensions/foundups_advisory_workers/tests/verify_extension_contract.js`
- [x] `git diff --check`
- [ ] CI green

## Residual SPECIFIED_NOT_IMPLEMENTED
- Execution valve, real worktree create, executor receipts runtime, PR draft, janitor, F0 merge

**VERIFIED_READY** — draft only.
