### PR TITLE
feat(extension): add redaction-safe RedDog follow-up memory

### DIFF
--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -264,6 +264,17 @@ Review packet additions:
 - `prompt_construction`: `0102_generated_from_work_focus`
 - `output_validation` (`validated`, `missing_sections`, `repair_attempted`, `repair_ok`, `repair_context_mode`, `repair_mode`, `fusion_panel_ok`)
 
+## RedDog Follow-Up Memory (v0.3.28)
+
+In-memory WSP_97-safe continuation from the last successful or `BLOCKED_LOCALLY` run:
+
+- `buildSanitizedContinuationSummary()` — extracts Decision/Findings/WSP_97/WSP_15/Next step summaries; strips secrets and blocked-policy literals.
+- `appendContinuationSummaryToWspPrompt()` — appends sanitized summary to the next WSP task prompt when **Use last RedDog packet** is enabled (default ON).
+- `state.lastContinuationSummary` — per-tab in-memory only; no disk persistence in Phase 1.
+- Copy MD may include a safe **Continuation Summary** section for the stored packet (not raw prior model output).
+
+Does **not** paste raw Copy MD, bounded context, or blocked snippets into follow-up prompts.
+
 ## Bridge Hardening (v0.3.16)
 
 | Control | Status |

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -1,5 +1,16 @@
 # Foundups®Agent ModLog
 
+# ModLog - Foundups®Agent Extension
+
+## 2026-06-28 - REDDOG_REVIEW_PACKET_MEMORY_AND_FOLLOWUP_PHASE1 (v0.3.28)
+
+- ADD `buildSanitizedContinuationSummary()` — WSP_97-safe packet memory from last run (success or BLOCKED_LOCALLY).
+- ADD `appendContinuationSummaryToWspPrompt()` — follow-up path without pasting raw Copy MD.
+- UI: "Use last RedDog packet" checkbox (default ON); in-memory `state.lastContinuationSummary` only.
+- Copy MD optional safe Continuation Summary section; fusion redaction gate tested on continuation block.
+
+WSP: WSP_00, WSP_50, WSP_97, WSP_22. Version 0.3.27 -> 0.3.28.
+
 ## 2026-06-28 - REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_DRYRUN_PHASE1 (extension pointers)
 
 - Module: `modules/communication/moltbot_bridge/src/reddog_wre_executor_dryrun.py`

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.27
+Version: 0.3.28
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 
@@ -186,6 +186,8 @@ The worker has no direct filesystem authority. The extension automatically attac
 ## Review Packet
 
 After a successful run, focus the work focus composer and press `Ctrl+Shift+C` to copy a redacted review packet. Paste that packet into Codex for 0102 review. The packet contains digested work focus and WSP prompt excerpts (not full raw context), model slugs, bounded excerpts, task classification, resolved effort/mode, and output validator/repair status; it does not contain the OpenRouter key.
+
+**Follow-up memory (v0.3.28):** Enable **Use last RedDog packet** (default ON) to append a WSP_97-safe continuation summary to the next prompt instead of pasting raw Copy MD back into the composer. In-memory per tab only; no cross-reload persistence yet.
 
 ## Setup
 

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -276,10 +276,16 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 - Classify public vs member-gated flows.
 - No automatic publication without verification gate.
 
+### REDDOG_REVIEW_PACKET_MEMORY_AND_FOLLOWUP_PHASE1
+
+- **Status:** **PR-READY** — in-memory WSP_97-safe continuation summary; "Use last RedDog packet" toggle (default ON).
+- Sanitized follow-up memory from last run; appends to WSP task prompt without raw Copy MD paste.
+- No disk persistence, no WRE/OpenClaw runtime wiring.
+
 ### REDDOG_REVIEW_PACKET_MEMORY_PHASE1
 
-- Persist redacted review packets for HoloIndex recall and 0102 continuity.
-- Bounded storage; no raw prompt leakage beyond redaction gate.
+- **Status:** **PARTIAL** — Phase 1 in-memory continuation only (`REDDOG_REVIEW_PACKET_MEMORY_AND_FOLLOWUP_PHASE1`).
+- Persist redacted review packets for HoloIndex recall and cross-session continuity (future).
 
 ### REDDOG_FUSION_ORCHESTRATOR_PHASE2
 

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.27';
+const EXTENSION_VERSION = '0.3.28';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -751,6 +751,9 @@ function buildCopyMarkdown(result, workerType, contextSummary, workTrail, holoSc
   if (ctx.substantive) {
     sections.push(buildGovernedHandoffSection(ctx.handoffRecommendation || packet.governed_handoff_recommendation));
   }
+  if (ctx.continuationSummary) {
+    sections.push(buildContinuationSummaryCopySection(ctx.continuationSummary));
+  }
   const mojibake = detectMojibake(packet.content || '');
   const flagged = (validation && validation.mojibake_detected) || mojibake.detected;
   if (flagged) {
@@ -1026,6 +1029,201 @@ function constructWspTaskPrompt(workFocus, classification, contextQuality, worke
   return lines.join('\n');
 }
 
+const CONTINUATION_FIELD_MAX_CHARS = 480;
+const CONTINUATION_TOTAL_MAX_CHARS = 3200;
+const CONTINUATION_SECRET_PATTERNS = [
+  /\bghp_[A-Za-z0-9_]+\b/g,
+  /\bgithub_pat_[A-Za-z0-9_]+\b/g,
+  /\bgho_[A-Za-z0-9_]+\b/g,
+  /\bsk-[A-Za-z0-9_]+\b/gi,
+  /Bearer\s+[A-Za-z0-9._-]+/gi
+];
+
+function sanitizeContinuationField(text, maxChars) {
+  const limit = maxChars || CONTINUATION_FIELD_MAX_CHARS;
+  let out = sanitizeCopyMdText(String(text || ''));
+  const sanitized = sanitizeTargetSnippetForRedaction(out);
+  out = sanitized.text;
+  for (const pattern of CONTINUATION_SECRET_PATTERNS) {
+    out = out.replace(pattern, '[REDACTED_SECRET]');
+  }
+  out = out.replace(/\s+/g, ' ').trim();
+  if (out.length > limit) {
+    out = out.slice(0, limit) + '...[truncated]';
+  }
+  return out;
+}
+
+function extractContinuationRefs(text) {
+  const src = String(text || '');
+  const prRefs = [];
+  const prSeen = new Set();
+  let match;
+  const prPattern = /#(\d{1,5})\b/g;
+  while ((match = prPattern.exec(src)) !== null) {
+    const label = '#' + match[1];
+    if (!prSeen.has(label)) {
+      prSeen.add(label);
+      prRefs.push(label);
+    }
+  }
+  const commitRefs = [];
+  const commitSeen = new Set();
+  const commitPattern = /\b(?:commit|landed|merge|sha)[:\s]+([0-9a-f]{7,40})\b/gi;
+  while ((match = commitPattern.exec(src)) !== null) {
+    const hash = match[1].toLowerCase();
+    if (!commitSeen.has(hash)) {
+      commitSeen.add(hash);
+      commitRefs.push(hash);
+    }
+  }
+  return { pr_refs: prRefs.slice(0, 8), commit_refs: commitRefs.slice(0, 4) };
+}
+
+function extractResidualSpecifiedNotImplemented(text) {
+  const src = String(text || '');
+  const lines = src.split('\n');
+  const hits = [];
+  for (const line of lines) {
+    if (/SPECIFIED_NOT_IMPLEMENTED/i.test(line)) {
+      hits.push(sanitizeContinuationField(line, 160));
+    }
+  }
+  if (!hits.length && /specified[- ]not[- ]implemented/i.test(src)) {
+    hits.push('SPECIFIED_NOT_IMPLEMENTED mentioned in prior run (details omitted).');
+  }
+  return hits.slice(0, 6).join(' | ');
+}
+
+function continuationPreviousRunId(reviewPacket, promptConstruction, timestamp) {
+  const rp = reviewPacket && typeof reviewPacket === 'object' ? reviewPacket : {};
+  const parts = [
+    String(timestamp || ''),
+    rp.work_focus_digest || '',
+    rp.wsp_prompt_digest || '',
+    rp.resolved_mode || '',
+    rp.resolved_context || ''
+  ];
+  return 'run_' + crypto.createHash('sha256').update(parts.join('|'), 'utf8').digest('hex').slice(0, 16);
+}
+
+function buildSanitizedContinuationSummary(params) {
+  const p = params && typeof params === 'object' ? params : {};
+  const reviewPacket = p.review_packet && typeof p.review_packet === 'object' ? p.review_packet : {};
+  const cls = reviewPacket.task_classification && typeof reviewPacket.task_classification === 'object'
+    ? reviewPacket.task_classification
+    : (p.classification && typeof p.classification === 'object' ? p.classification : {});
+  const workerType = cleanWorkerType(p.workerType || reviewPacket.worker_type || 'reddog_architect');
+  const workerLabel = WORKER_TYPES[workerType] ? WORKER_TYPES[workerType].label : workerType;
+  const timestamp = p.timestamp || new Date().toISOString();
+  const blocked = p.blocked === true || p.reason === 'redaction_blocked';
+  const base = {
+    previous_run_id: continuationPreviousRunId(reviewPacket, p.promptConstruction, timestamp),
+    timestamp: timestamp,
+    role_0102: workerLabel,
+    wsp15_tier: cls.tier || reviewPacket.resolved_effort || 'unknown',
+    mode: reviewPacket.resolved_mode || p.mode || 'unknown',
+    context_mode: reviewPacket.resolved_context || p.contextMode || 'unknown',
+    blocked_locally: blocked,
+    source: blocked ? 'blocked_locally' : 'successful_run',
+    pr_refs: [],
+    commit_refs: []
+  };
+
+  if (blocked) {
+    const report = p.redaction_gate_report && typeof p.redaction_gate_report === 'object'
+      ? p.redaction_gate_report
+      : (reviewPacket.redaction_gate_report && typeof reviewPacket.redaction_gate_report === 'object'
+        ? reviewPacket.redaction_gate_report
+        : buildRedactionGateReport(p.result || p, p.promptConstruction, p.contextMode));
+    base.decision_summary = 'BLOCKED_LOCALLY before OpenRouter';
+    base.findings_summary = sanitizeContinuationField(report.safe_summary || 'Redaction gate blocked egress.', 320);
+    base.wsp97_labels_summary = sanitizeContinuationField(
+      report.truth_labels ? JSON.stringify(report.truth_labels) : 'blocked_stage: OBSERVED',
+      240
+    );
+    base.wsp15_priorities_summary = 'none (blocked locally)';
+    base.next_safest_step = sanitizeContinuationField(
+      'Review blocked context locally. next_safe_context: ' + (report.next_safe_context || 'local_0102_review'),
+      240
+    );
+    base.residual_specified_not_implemented = 'Prior run blocked; no architect output to carry forward.';
+    base.redaction_gate_summary = sanitizeContinuationField(
+      'rule_classes: ' + JSON.stringify(report.rule_classes || ['unknown'])
+        + '; blocked_stage: ' + (report.blocked_stage || 'pre_openrouter_request'),
+      320
+    );
+    return base;
+  }
+
+  const content = String(p.content || '');
+  base.decision_summary = sanitizeContinuationField(extractMarkdownSection(content, 'Decision'), 360);
+  base.findings_summary = sanitizeContinuationField(extractMarkdownSection(content, 'Findings'), 360);
+  base.wsp97_labels_summary = sanitizeContinuationField(extractMarkdownSection(content, 'WSP_97 Truth Labels'), 360);
+  base.wsp15_priorities_summary = sanitizeContinuationField(extractMarkdownSection(content, 'WSP_15 Priority'), 360);
+  base.next_safest_step = sanitizeContinuationField(extractMarkdownSection(content, 'Next safest step'), 360);
+  base.residual_specified_not_implemented = sanitizeContinuationField(
+    extractResidualSpecifiedNotImplemented(content),
+    360
+  );
+  const refs = extractContinuationRefs(content);
+  base.pr_refs = refs.pr_refs;
+  base.commit_refs = refs.commit_refs;
+  base.redaction_gate_summary = null;
+  if (!base.decision_summary) {
+    base.decision_summary = sanitizeContinuationField('Prior run completed; decision section not extracted.', 160);
+  }
+  return base;
+}
+
+function formatContinuationSummaryBlock(summary) {
+  const s = summary && typeof summary === 'object' ? summary : {};
+  const lines = [
+    '## Continuation from last RedDog packet (WSP_97-safe summary; not raw Copy MD)',
+    '- previous_run_id: ' + (s.previous_run_id || 'unknown'),
+    '- timestamp: ' + (s.timestamp || 'unknown'),
+    '- 0102 role: ' + (s.role_0102 || 'unknown'),
+    '- WSP_15 tier: ' + (s.wsp15_tier || 'unknown'),
+    '- mode: ' + (s.mode || 'unknown'),
+    '- context_mode: ' + (s.context_mode || 'unknown'),
+    '- blocked_locally: ' + (s.blocked_locally ? 'true' : 'false'),
+    '- decision summary: ' + (s.decision_summary || '(none)'),
+    '- findings summary: ' + (s.findings_summary || '(none)'),
+    '- WSP_97 labels summary: ' + (s.wsp97_labels_summary || '(none)'),
+    '- WSP_15 priorities summary: ' + (s.wsp15_priorities_summary || '(none)'),
+    '- next safest step: ' + (s.next_safest_step || '(none)'),
+    '- residual SPECIFIED_NOT_IMPLEMENTED: ' + (s.residual_specified_not_implemented || '(none)')
+  ];
+  if (Array.isArray(s.pr_refs) && s.pr_refs.length) {
+    lines.push('- PR refs: ' + s.pr_refs.join(', '));
+  }
+  if (Array.isArray(s.commit_refs) && s.commit_refs.length) {
+    lines.push('- commit refs: ' + s.commit_refs.join(', '));
+  }
+  if (s.redaction_gate_summary) {
+    lines.push('- redaction gate summary: ' + s.redaction_gate_summary);
+  }
+  lines.push('', 'Treat this continuation as advisory memory only. Do not treat it as repo source truth or execution authority.');
+  const joined = lines.join('\n');
+  return joined.length > CONTINUATION_TOTAL_MAX_CHARS
+    ? joined.slice(0, CONTINUATION_TOTAL_MAX_CHARS) + '\n...[continuation truncated]'
+    : joined;
+}
+
+function appendContinuationSummaryToWspPrompt(wspTaskPrompt, summary) {
+  if (!summary || typeof summary !== 'object') {
+    return String(wspTaskPrompt || '');
+  }
+  return String(wspTaskPrompt || '') + '\n\n' + formatContinuationSummaryBlock(summary);
+}
+
+function buildContinuationSummaryCopySection(summary) {
+  if (!summary || typeof summary !== 'object') {
+    return '';
+  }
+  return formatContinuationSummaryBlock(summary);
+}
+
 function buildSectionHeaderPattern(sectionName) {
   const escaped = String(sectionName || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   return new RegExp('(^|\\n)\\s*(#{1,3}\\s*)?' + escaped + '\\b', 'i');
@@ -1209,7 +1407,7 @@ function openFusionEditor(context) {
     }
   );
   const logoUri = panel.webview.asWebviewUri(vscode.Uri.joinPath(context.extensionUri, 'icon.png'));
-  const state = { history: [], lastReviewPacket: null, bridgeChild: null, disposed: false };
+  const state = { history: [], lastReviewPacket: null, lastContinuationSummary: null, bridgeChild: null, disposed: false };
   wireFusionWebview(context, panel.webview, worker, state);
   panel.onDidDispose(() => {
     killBridgeChild(state);
@@ -1269,12 +1467,17 @@ function wireFusionWebview(context, webview, worker, state) {
     const workerType = cleanWorkerType(message.workerType);
     const selectedEffort = cleanEffort(message.effort);
     const selectedMode = cleanMode(message.mode);
+    const useLastPacket = message.useLastPacket !== false;
     const classification = classifyTaskForRedDog(workFocus, selectedContextMode, workerType);
     const effort = resolveAutoEffort(classification, selectedEffort);
     const mode = resolveModelMode(classification, selectedMode, workerType);
     const contextMode = resolveAutoContextMode(classification, selectedContextMode);
     const contextPacket = buildBoundedRepoContext(contextMode, workFocus);
-    const wspTaskPrompt = constructWspTaskPrompt(workFocus, classification, contextPacket.quality, workerType);
+    let wspTaskPrompt = constructWspTaskPrompt(workFocus, classification, contextPacket.quality, workerType);
+    if (useLastPacket && state.lastContinuationSummary) {
+      wspTaskPrompt = appendContinuationSummaryToWspPrompt(wspTaskPrompt, state.lastContinuationSummary);
+      postStatusAndProgress(webview, null, 'Continuation: appended WSP_97-safe summary from last RedDog packet (not raw Copy MD).');
+    }
     const promptConstruction = {
       work_focus_digest: redactedDigest(workFocus, 180),
       wsp_prompt_digest: redactedDigest(wspTaskPrompt, 320)
@@ -1448,11 +1651,28 @@ function wireFusionWebview(context, webview, worker, state) {
     if (result.review_packet) {
       state.lastReviewPacket = result.review_packet;
     }
+    const continuationSummary = buildSanitizedContinuationSummary({
+      blocked: result.reason === 'redaction_blocked',
+      reason: result.reason,
+      content: result.content,
+      review_packet: result.review_packet,
+      redaction_gate_report: result.redaction_gate_report,
+      workerType: workerType,
+      classification: classification,
+      mode: mode,
+      contextMode: contextMode,
+      promptConstruction: promptConstruction,
+      result: result,
+      timestamp: new Date().toISOString()
+    });
+    state.lastContinuationSummary = continuationSummary;
+    result.continuation_summary = continuationSummary;
     result.copy_markdown = buildCopyMarkdown(result, workerType, contextPacket.summary, workTrail, holoScorecard, effort, {
       promptConstruction: promptConstruction,
       contextMode: contextMode,
       substantive: substantiveTask,
-      handoffRecommendation: handoffRecommendation
+      handoffRecommendation: handoffRecommendation,
+      continuationSummary: continuationSummary
     });
     webview.postMessage({ command: 'result', result });
   });
@@ -2390,6 +2610,7 @@ function renderHtml(worker, surface, logoUri) {
         <span class="pill">Routing: Auto via WSP_15</span>
         <span class="pill">Context: Auto WSP + HoloIndex + Skillz/Rolodex</span>
         <label for="testWorkFocus">Tests</label><select id="testWorkFocus"><option value="">Select test...</option><option value="regular">Regular smoke</option><option value="fusion">Fusion smoke</option><option value="wsp97">WSP_97 repo review</option><option value="reddog">RedDog architect review</option></select>
+        <label for="useLastPacket"><input id="useLastPacket" type="checkbox" checked> Use last RedDog packet</label>
         <button id="copyMd" type="button">Copy MD</button>
       </div>
       <textarea id="workFocus" placeholder="Describe your work focus (012). 0102 converts this to a WSP task prompt for RedDog." aria-label="012 work focus"></textarea>
@@ -2404,6 +2625,7 @@ function renderHtml(worker, surface, logoUri) {
     const workerType = document.getElementById('workerType');
     const testWorkFocus = document.getElementById('testWorkFocus');
     const copyMd = document.getElementById('copyMd');
+    const useLastPacket = document.getElementById('useLastPacket');
     const trailEl = document.getElementById('reddogWorkingTrail');
     let lastAssistantMarkdown = '';
     const log = document.getElementById('log');
@@ -2604,7 +2826,15 @@ function renderHtml(worker, surface, logoUri) {
       addStatus('Work focus sent. 0102 will assemble WSP task prompt...');
       add('user', text, '012 work focus');
       workFocus.value = '';
-      vscode.postMessage({ command: 'ask', text, mode: 'auto', contextMode: 'auto', workerType: workerType.value, effort: 'auto' });
+      vscode.postMessage({
+        command: 'ask',
+        text,
+        mode: 'auto',
+        contextMode: 'auto',
+        workerType: workerType.value,
+        effort: 'auto',
+        useLastPacket: !!(useLastPacket && useLastPacket.checked)
+      });
     }
 
     function failureText(result) {
@@ -2695,6 +2925,11 @@ module.exports = {
   normalizeRepairBridgeStageToWorkTrail,
   BRIDGE_REPAIR_STAGE_WORK_TRAIL,
   constructWspTaskPrompt,
+  appendContinuationSummaryToWspPrompt,
+  buildSanitizedContinuationSummary,
+  buildContinuationSummaryCopySection,
+  formatContinuationSummaryBlock,
+  sanitizeContinuationField,
   redactedDigest,
   resolvePythonInterpreter,
   buildBridgePythonEnv,

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups®Agent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.27",
+    "version":  "0.3.28",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/TestModLog.md
+++ b/extensions/foundups_advisory_workers/tests/TestModLog.md
@@ -1,5 +1,18 @@
 # Foundups®Agent TestModLog
 
+## 2026-06-28 - REDDOG_REVIEW_PACKET_MEMORY_AND_FOLLOWUP_PHASE1 (Addendum G)
+
+| ID | Asserts |
+| --- | --- |
+| G-001 | `buildSanitizedContinuationSummary` success path captures decision + PR refs |
+| G-002 | Poisoned output strips private reasoning markers |
+| G-003 | Blocked run stores safe redaction gate summary only |
+| G-004 | `appendContinuationSummaryToWspPrompt` includes continuation block |
+| G-005 | Continuation-augmented prompt passes fusion redaction gate |
+| G-006 | Copy MD includes safe Continuation Summary section when provided |
+
+**Run:** `node extensions/foundups_advisory_workers/tests/verify_extension_contract.js`
+
 ## 2026-06-14 - REDDOG_OUTPUT_SCHEMA_REPAIR_HARDENING addendum (OSR-007..OSR-010)
 
 | ID | Asserts |

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -83,8 +83,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.27', 'package version must be 0.3.27');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.27'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.28', 'package version must be 0.3.28');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.28'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups®Agent', 'display name must be Foundups®Agent');
 includes(JSON.stringify(pkg), 'Foundups®Agent: Open', 'command title must use Foundups®Agent');
@@ -101,7 +101,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.27', 'README version mismatch');
+includes(readme, 'Version: 0.3.28', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -722,7 +722,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.27'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.28'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -736,7 +736,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.27'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.28'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -748,7 +748,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.27'", 'bounded context must include extension.js source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.28'", 'bounded context must include extension.js source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');
@@ -848,5 +848,100 @@ includes(unicodeTrace, 'unicode_replacements_count: 1', 'UNI-006: Run Trace must
 includes(unicodeTrace, 'unicode_normalization_sources: context', 'UNI-006: Run Trace must expose normalization sources');
 includes(unicodeTrace, 'unicode_normalization_form: NFC', 'UNI-006: Run Trace must expose normalization form');
 assert(!unicodeTrace.includes('\udc94'), 'UNI-007: Run Trace must not echo raw malformed surrogate');
+
+// ADDENDUM G - redaction-safe continuation memory (REDDOG_REVIEW_PACKET_MEMORY_AND_FOLLOWUP_PHASE1)
+includes(extensionJs, 'buildSanitizedContinuationSummary', 'continuation summary builder missing');
+includes(extensionJs, 'appendContinuationSummaryToWspPrompt', 'continuation append helper missing');
+includes(extensionJs, 'Use last RedDog packet', 'continuation UI toggle missing');
+includes(extensionJs, 'lastContinuationSummary', 'in-memory continuation store missing');
+includes(roadmap, 'REDDOG_REVIEW_PACKET_MEMORY_AND_FOLLOWUP_PHASE1', 'continuation memory roadmap slice missing');
+
+const sampleArchitectOutput = [
+  '## Decision',
+  'Proceed with gate review for #898; land when CI is green.',
+  '',
+  '## Findings',
+  'Executor dry-run planner proves plan layer before valve.',
+  '',
+  '## WSP_97 Truth Labels',
+  'Dry-run scope: OBSERVED; valve: SPECIFIED_NOT_IMPLEMENTED',
+  '',
+  '## WSP_15 Priority',
+  'Execution valve slice: P0 NEXT',
+  '',
+  '## Next safest step',
+  'Gate and land #898, then queue execution valve slice.',
+  '',
+  'Persistent disk memory: SPECIFIED_NOT_IMPLEMENTED in Phase 1.'
+].join('\n');
+
+const successSummary = orchestrator.buildSanitizedContinuationSummary({
+  blocked: false,
+  content: sampleArchitectOutput,
+  workerType: 'reddog_architect',
+  classification: { tier: 'HIGH' },
+  mode: 'openrouter_single',
+  contextMode: 'wsp_holo',
+  review_packet: { task_classification: { tier: 'HIGH' }, resolved_mode: 'openrouter_single', resolved_context: 'wsp_holo' },
+  promptConstruction: { work_focus_digest: { hash: 'abc' }, wsp_prompt_digest: { hash: 'def' } },
+  timestamp: '2026-06-28T20:00:00.000Z'
+});
+assert.strictEqual(successSummary.blocked_locally, false, 'successful continuation must not be blocked_locally');
+assert(successSummary.decision_summary.length > 0, 'continuation must include decision summary');
+assert(successSummary.pr_refs.includes('#898'), 'continuation must capture PR refs');
+assert(!JSON.stringify(successSummary).includes('private_reasoning'), 'continuation must not retain private_reasoning category text raw');
+
+const poisonedOutput = sampleArchitectOutput + '\n\nhidden chain-of-thought leak';
+const poisonedSummary = orchestrator.buildSanitizedContinuationSummary({
+  blocked: false,
+  content: poisonedOutput,
+  workerType: 'reddog_architect',
+  classification: { tier: 'HIGH' },
+  review_packet: { task_classification: { tier: 'HIGH' } },
+  timestamp: '2026-06-28T20:01:00.000Z'
+});
+assert(!JSON.stringify(poisonedSummary).toLowerCase().includes('chain-of-thought'), 'continuation must strip private reasoning markers');
+
+const blockedSummary = orchestrator.buildSanitizedContinuationSummary({
+  blocked: true,
+  reason: 'redaction_blocked',
+  workerType: 'reddog_architect',
+  classification: { tier: 'HIGH' },
+  contextMode: 'wsp_holo_git',
+  redaction_gate_report: {
+    decision: 'BLOCKED_LOCALLY',
+    safe_summary: 'Redaction gate blocked egress before OpenRouter.',
+    rule_classes: ['blocked_policy'],
+    blocked_stage: 'pre_openrouter_request',
+    next_safe_context: 'local_0102_review',
+    truth_labels: { decision: 'OBSERVED' }
+  },
+  promptConstruction: { work_focus_digest: { hash: 'abc' }, wsp_prompt_digest: { hash: 'def' } },
+  timestamp: '2026-06-28T20:02:00.000Z'
+});
+assert.strictEqual(blockedSummary.blocked_locally, true, 'blocked continuation must set blocked_locally');
+assert.strictEqual(blockedSummary.source, 'blocked_locally', 'blocked continuation source label');
+assert(blockedSummary.redaction_gate_summary.includes('blocked_policy'), 'blocked continuation must include safe gate summary');
+assert(!blockedSummary.findings_summary.includes('OPENROUTER_API_KEY'), 'blocked continuation must not include secrets');
+
+const followupPrompt = orchestrator.appendContinuationSummaryToWspPrompt(
+  orchestrator.constructWspTaskPrompt('Follow up on executor dry-run land status.', { tier: 'HIGH', reasons: ['architecture'] }, 'bundle_json_ok', 'reddog_architect'),
+  successSummary
+);
+includes(followupPrompt, 'Continuation from last RedDog packet', 'follow-up prompt must include continuation block');
+includes(followupPrompt, 'previous_run_id:', 'follow-up prompt must include previous_run_id');
+assertFusionRedactionGatePasses(followupPrompt, 'continuation-augmented WSP prompt must pass fusion redaction gate');
+assertFusionRedactionGatePasses(orchestrator.formatContinuationSummaryBlock(successSummary), 'continuation summary block must pass fusion redaction gate');
+
+const continuationCopy = orchestrator.buildCopyMarkdown(
+  { ok: true, content: sampleArchitectOutput, review_packet: { task_classification: { tier: 'HIGH' }, output_validation: { validated: true } } },
+  'reddog_architect',
+  'Repo context attached',
+  [],
+  null,
+  'high',
+  { substantive: true, continuationSummary: successSummary }
+);
+includes(continuationCopy, 'Continuation from last RedDog packet', 'Copy MD may include safe continuation summary section');
 
 console.log('Foundups®Agent extension contract checks passed.');


### PR DESCRIPTION
## Summary
- Adds WSP_97-safe in-memory continuation from the last RedDog run (`buildSanitizedContinuationSummary`).
- Appends sanitized summary to the next WSP task prompt when **Use last RedDog packet** is enabled (default ON) — no raw Copy MD paste.
- Blocked runs store Redaction Gate Report summary only; continuation block tested against fusion redaction gate.
- v0.3.28

## WSP_97
| Claim | Label |
|-------|-------|
| Continuation strips secrets/blocked-policy literals | OBSERVED (sanitizers + gate test) |
| In-memory per tab only | OBSERVED |
| HoloIndex semantic query for review packet memory | INDEX_GAP follow-up |
| Cross-reload disk persistence | SPECIFIED_NOT_IMPLEMENTED |

## Test plan
- [x] `node --check extension.js`
- [x] `node extensions/foundups_advisory_workers/tests/verify_extension_contract.js` (Addendum G)
- [x] `git diff --check`
- [ ] CI green

**VERIFIED_READY** — draft only.
