### PR TITLE
feat(reddog): add closed-by-default WRE execution valve

### DIFF
--- a/docs/audits/architecture/REDDOG_WRE_EXECUTION_VALVE_CONTRACT_PHASE1.md
+++ b/docs/audits/architecture/REDDOG_WRE_EXECUTION_VALVE_CONTRACT_PHASE1.md
@@ -1,0 +1,120 @@
+# REDDOG_WRE_EXECUTION_VALVE_CONTRACT_PHASE1
+
+**Retrieval tags:** RedDog execution valve | WRE worktree valve | OpenClaw execution gate | closed by default
+
+**Slice:** Closed-by-default execution valve evaluator (pure evaluation)  
+**Type:** Module + contract -- **no execution, no worktree, no worker launch**  
+**Date:** 2026-06-28  
+**Base:** `2c8df23dd` (post-#901 OpenClaw adapter contract land)  
+**Status:** PR-READY -- draft PR only  
+**WSP lock:** WSP_00, WSP_15, WSP_34, WSP_50, WSP_91, WSP_97, WSP_22
+
+---
+
+## Purpose
+
+Provide an explicit **closed-by-default execution valve** between the landed RedDog spine
+(#889-#898) and any future OpenClaw intake, adapter dry-run, or worktree-create slices.
+
+Default: `VALVE_CLOSED`. No implicit open path.
+
+---
+
+## Module
+
+| Symbol | Path |
+|--------|------|
+| `evaluate_reddog_execution_valve()` | `modules/communication/moltbot_bridge/src/reddog_wre_execution_valve.py` |
+
+---
+
+## Valve states
+
+| State | Meaning | Required environment |
+|-------|---------|---------------------|
+| `VALVE_CLOSED` | Hard default; reject or hold | No flag, failed checks, or missing token |
+| `VALVE_OPEN_DRYRUN_ONLY` | Adapter/planner dry-run only | `valve_dryrun_enabled=true` + full spine |
+| `VALVE_OPEN_WORKTREE_CREATE` | First real worktree slice may proceed | `valve_worktree_create_enabled=true` + `sovereign_worktree_token` + full spine |
+
+---
+
+## Mandatory spine prerequisites
+
+All must pass before any non-`VALVE_CLOSED` state:
+
+1. `PolicyGateReceipt.decision == POLICY_ACCEPT`
+2. `RedDogWorkOrderReceipt` present with matching policy digest
+3. `WorkOrderDryRunInvocationResult.decision == INVOCATION_ACCEPT`
+4. `WREExecutorDryRunResult.decision == EXECUTOR_PLAN_ACCEPT` with plan
+5. Fresh permission snapshot digest
+6. #901 canonical intake target: `foundup_job` or `autonomous_task`
+7. Reject `assignment_dispatcher` target
+
+---
+
+## Forbidden paths (fail closed)
+
+| Code | Condition |
+|------|-----------|
+| V1 | Direct worker launch |
+| V2 | Direct model / OpenRouter worker launch |
+| V3 | Direct WRE executor call |
+| V4 | Protected branch mutation request |
+| V5 | Missing or mismatched receipt chain |
+| V6 | Stale permission snapshot |
+| V7 | INDEX_GAP on write-sensitive operation |
+| V8 | AssignmentDispatcher intake target |
+
+---
+
+## Gate ordering (spine + valve)
+
+```text
+1. RedDog advisory (extension) -- no execution
+2. #890 dry-run validation
+3. #892 permission snapshot
+4. #893 policy gate
+5. #894 receipt
+6. #896 invocation dry-run
+7. #898 executor plan dry-run
+8. THIS VALVE (evaluate only)
+9. #901 adapter dry-run (future)
+10. OpenClaw intake (future)
+11. Worktree create (future; valve OPEN_WORKTREE_CREATE only)
+```
+
+---
+
+## WSP_97 truth table
+
+| # | Claim | Label |
+|---|-------|-------|
+| 1 | Default valve state is CLOSED | **OBSERVED** |
+| 2 | Evaluator performs no git/subprocess/worktree mutation | **OBSERVED** |
+| 3 | AssignmentDispatcher is forbidden intake target | **OBSERVED** |
+| 4 | FoundUpJob / autonomous_task are canonical targets per #901 | **OBSERVED** |
+| 5 | Adapter implementation remains future slice | **SPECIFIED_NOT_IMPLEMENTED** |
+| 6 | Worktree create remains future slice | **SPECIFIED_NOT_IMPLEMENTED** |
+
+---
+
+## WSP_15 next slices (ordered)
+
+| Order | Slice | Depends on |
+|-------|-------|------------|
+| 1 | `REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_PHASE1` | This valve + #901 contract |
+| 2 | `REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_WORKTREE_CREATE_PHASE1` | Valve OPEN_WORKTREE_CREATE |
+| 3 | `REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_POC_PHASE1` | Adapter dry-run |
+
+---
+
+## Explicit non-goals
+
+| Non-goal | Status |
+|----------|--------|
+| Worktree / branch creation | **FORBIDDEN** |
+| File edits / PR / merge | **FORBIDDEN** |
+| OpenClaw / Hermes runtime dispatch | **FORBIDDEN** |
+| Extension runtime wiring | **SPECIFIED_NOT_IMPLEMENTED** |
+
+**No runtime mutation performed in authoring this contract or module.**

--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -87,6 +87,8 @@ RedDog is the 0102 architect interface — **not an authority owner**. RedDog re
 
 **OpenClaw handoff adapter (contract only):** `docs/audits/architecture/REDDOG_WORK_ORDER_TO_OPENCLAW_FOUNDUPJOB_ADAPTER_CONTRACT_PHASE1.md` — RedDog → FoundUpJob mapping; OpenClaw owns worker loop; **AssignmentDispatcher not canonical**.
 
+**WRE execution valve:** `modules/communication/moltbot_bridge/src/reddog_wre_execution_valve.py` -- `evaluate_reddog_execution_valve()`; default `VALVE_CLOSED`; pure evaluation only. Contract: `docs/audits/architecture/REDDOG_WRE_EXECUTION_VALVE_CONTRACT_PHASE1.md`.
+
 **Specified flow (not implemented in extension v0.3.27):**
 
 ```text

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,7 +2,15 @@
 
 # ModLog - Foundups®Agent Extension
 
-## 2026-06-28 - REDDOG_WORK_ORDER_TO_OPENCLAW_FOUNDUPJOB_ADAPTER_CONTRACT_PHASE1 (audit doc)
+## 2026-06-28 - REDDOG_WRE_EXECUTION_VALVE_PHASE1 (extension pointers)
+
+- Module: `modules/communication/moltbot_bridge/src/reddog_wre_execution_valve.py`
+- `evaluate_reddog_execution_valve()` -- closed-by-default; pure evaluation only.
+- Contract: `docs/audits/architecture/REDDOG_WRE_EXECUTION_VALVE_CONTRACT_PHASE1.md`
+
+WSP: WSP_00, WSP_15, WSP_50, WSP_97, WSP_22.
+
+## 2026-06-28 - REDDOG_WORK_ORDER_TO_OPENCLAW_FOUNDUPJOB_ADAPTER_CONTRACT_PHASE1 (LANDED #901)
 
 - Canonical: `docs/audits/architecture/REDDOG_WORK_ORDER_TO_OPENCLAW_FOUNDUPJOB_ADAPTER_CONTRACT_PHASE1.md`
 - Ruling: OpenClaw Supervisor / FoundUpJob intake is canonical; AssignmentDispatcher is simulated scaffold only.

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -84,15 +84,14 @@ DONE
 10. #897 WRE isolated worktree executor contract (2fe60a280)
 11. #898 WRE executor plan dry-run (e215bf890)
 12. #899 RedDog continuation memory (c70433d7d)
+13. #901 OpenClaw FoundUpJob adapter contract (2c8df23dd)
 
 P0 NEXT (execution track)
-13. REDDOG_WRE_EXECUTION_VALVE_PHASE1
+14. REDDOG_WRE_EXECUTION_VALVE_PHASE1
     - default CLOSED valve before first real worktree create
-14. REDDOG_WORK_ORDER_TO_OPENCLAW_FOUNDUPJOB_ADAPTER_CONTRACT_PHASE1
-    - OpenClaw ownership + field mapping; no AssignmentDispatcher binding
+15. REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_PHASE1
 
 P1
-15. REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_PHASE1
 16. REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_WORKTREE_CREATE_PHASE1
     - first real isolated worktree; valve OPEN only
 17. REDDOG_SANITIZED_TARGET_CONTEXT_PROVENANCE_PHASE1
@@ -235,13 +234,19 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 
 ### REDDOG_WORK_ORDER_TO_OPENCLAW_FOUNDUPJOB_ADAPTER_CONTRACT_PHASE1
 
-- **Status:** **PR-READY** — contract-only audit doc; OpenClaw owns worker loop.
+- **Status:** **LANDED** #901 (`2c8df23dd`) -- contract-only audit doc; OpenClaw owns worker loop.
 - **Canonical:** `docs/audits/architecture/REDDOG_WORK_ORDER_TO_OPENCLAW_FOUNDUPJOB_ADAPTER_CONTRACT_PHASE1.md`
-- **Ruling:** `AssignmentDispatcher` is simulated scaffold — **not** canonical intake target.
+- **Ruling:** `AssignmentDispatcher` is simulated scaffold -- **not** canonical intake target.
+
+### REDDOG_WRE_EXECUTION_VALVE_PHASE1
+
+- **Status:** **PR-READY** -- `evaluate_reddog_execution_valve()`; default `VALVE_CLOSED`.
+- **Module:** `modules/communication/moltbot_bridge/src/reddog_wre_execution_valve.py`
+- **Contract:** `docs/audits/architecture/REDDOG_WRE_EXECUTION_VALVE_CONTRACT_PHASE1.md`
 
 ### REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_WORKTREE_CREATE_PHASE1
 
-- **Status:** **BLOCKED** — until dry-run planner + execution valve land.
+- **Status:** **BLOCKED** -- until execution valve lands and opens with sovereign token.
 
 ### REDDOG_REVIEW_CONSENSUS_RECEIPTS_PHASE1
 

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -235,6 +235,17 @@ includes(adapterContractDoc, 'Receipt reconciliation', 'adapter contract receipt
 includes(adapterContractDoc, 'WSP_97 truth table', 'adapter contract WSP_97 table missing');
 includes(iface, 'REDDOG_WORK_ORDER_TO_OPENCLAW_FOUNDUPJOB_ADAPTER_CONTRACT_PHASE1.md', 'INTERFACE OpenClaw adapter pointer missing');
 includes(roadmap, 'REDDOG_WORK_ORDER_TO_OPENCLAW_FOUNDUPJOB_ADAPTER_CONTRACT_PHASE1', 'OpenClaw adapter contract slice missing');
+const valveContractDocPath = path.join(root, 'docs', 'audits', 'architecture', 'REDDOG_WRE_EXECUTION_VALVE_CONTRACT_PHASE1.md');
+const valveContractDoc = fs.readFileSync(valveContractDocPath, 'utf8');
+includes(valveContractDoc, 'VALVE_CLOSED', 'execution valve contract default state missing');
+includes(valveContractDoc, 'VALVE_OPEN_DRYRUN_ONLY', 'execution valve dryrun state missing');
+includes(valveContractDoc, 'VALVE_OPEN_WORKTREE_CREATE', 'execution valve worktree state missing');
+includes(valveContractDoc, 'assignment_dispatcher', 'execution valve AssignmentDispatcher reject missing');
+const valvePy = fs.readFileSync(path.join(root, 'modules', 'communication', 'moltbot_bridge', 'src', 'reddog_wre_execution_valve.py'), 'utf8');
+includes(valvePy, 'evaluate_reddog_execution_valve', 'execution valve evaluator missing');
+includes(valvePy, 'no_execution_performed', 'execution valve no_execution_performed missing');
+includes(iface, 'reddog_wre_execution_valve.py', 'INTERFACE execution valve pointer missing');
+includes(roadmap, 'REDDOG_WRE_EXECUTION_VALVE_PHASE1', 'execution valve slice missing');
 includes(roadmap, 'External RedDog Lane Queue (post-#888)', 'post-#888 external lane queue missing');
 includes(roadmap, 'REDDOG_GOVERNED_REPO_WORK_ORDER_DRYRUN_PHASE1', 'governed work order dryrun slice missing');
 includes(roadmap, 'REDDOG_RUN_TRACE_TELEMETRY_CORRECTION_PHASE1', 'run trace telemetry correction slice missing');

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,15 @@
 # ModLog - moltbot_bridge
 
+## 2026-06-28: REDDOG_WRE_EXECUTION_VALVE_PHASE1
+
+**Slice:** Closed-by-default WRE execution valve evaluator (pure evaluation)
+**WSP:** WSP_15, WSP_34, WSP_50, WSP_91, WSP_97, WSP_22
+
+- ADD `src/reddog_wre_execution_valve.py` -- `evaluate_reddog_execution_valve()`, `ExecutionValveDecision`.
+- ADD `tests/test_reddog_wre_execution_valve.py` -- default closed, dry-run open, worktree token, rejections, AST denylist.
+- ADD `docs/audits/architecture/REDDOG_WRE_EXECUTION_VALVE_CONTRACT_PHASE1.md` -- contract + gate ordering.
+- Default `VALVE_CLOSED`; requires full #889-#898 spine + #901 canonical intake target.
+
 ## 2026-06-28: REDDOG_WORK_ORDER_TO_OPENCLAW_FOUNDUPJOB_ADAPTER_CONTRACT_PHASE1 (pointer)
 
 **Slice:** OpenClaw FoundUpJob adapter **contract only** (audit doc)

--- a/modules/communication/moltbot_bridge/src/reddog_wre_execution_valve.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_execution_valve.py
@@ -1,0 +1,390 @@
+"""RedDog WRE execution valve evaluator (closed by default, pure evaluation).
+
+Slice: REDDOG_WRE_EXECUTION_VALVE_PHASE1
+Contract: docs/audits/architecture/REDDOG_WRE_EXECUTION_VALVE_CONTRACT_PHASE1.md
+
+Evaluates whether a fully gated RedDog spine may proceed to adapter dry-run or
+worktree-create slices. Default is VALVE_CLOSED unless explicit environment flags
+are set. No worktrees, branches, file edits, subprocess, git, or WRE execution.
+
+WSP 97 TRUTH BOUNDARIES:
+  DOES:
+    - Require accepted spine artifacts (#893-#898)
+    - Enforce #901 intake targets (FoundUpJob / autonomous_task)
+    - Reject AssignmentDispatcher and direct launch paths
+    - Emit valve_state, gates_checked, rejection_reasons, decision_digest
+    - Always set no_execution_performed: true
+
+  DOES NOT:
+    - Create worktrees, branches, PRs, or mutate repository content
+    - Invoke OpenClaw, Hermes, WRE executor, Skillz, or subprocess/git/gh
+    - Wire extension runtime or dispatch live workers
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Mapping, Optional, Union
+
+from modules.communication.moltbot_bridge.src.reddog_governed_work_order_dryrun import (
+    _is_write_sensitive_operation,
+    _normalize_operation,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_work_order_policy_gate import (
+    DEFAULT_PERMISSION_TTL_SECONDS,
+    POLICY_ACCEPT,
+    TRUTH_NEEDS_VERIFICATION,
+    permission_truth_label,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_runtime_invocation import (
+    INVOCATION_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_executor_dryrun import (
+    EXECUTOR_PLAN_ACCEPT,
+)
+
+VALVE_CLOSED = "VALVE_CLOSED"
+VALVE_OPEN_DRYRUN_ONLY = "VALVE_OPEN_DRYRUN_ONLY"
+VALVE_OPEN_WORKTREE_CREATE = "VALVE_OPEN_WORKTREE_CREATE"
+
+INTAKE_FOUNDUP_JOB = "foundup_job"
+INTAKE_AUTONOMOUS_TASK = "autonomous_task"
+INTAKE_ASSIGNMENT_DISPATCHER = "assignment_dispatcher"
+
+CANONICAL_INTAKE_TARGETS = frozenset({INTAKE_FOUNDUP_JOB, INTAKE_AUTONOMOUS_TASK})
+FORBIDDEN_INTAKE_TARGETS = frozenset({INTAKE_ASSIGNMENT_DISPATCHER})
+
+
+@dataclass
+class ExecutionValveRequest:
+    work_order: Mapping[str, Any]
+    policy_gate_receipt: Mapping[str, Any]
+    reddog_work_order_receipt: Mapping[str, Any]
+    invocation_result: Mapping[str, Any]
+    executor_plan_result: Mapping[str, Any]
+    intake_target: str
+    permission_snapshot: Mapping[str, Any]
+    direct_worker_launch: bool = False
+    direct_model_launch: bool = False
+    direct_wre_executor_call: bool = False
+    protected_branch_mutation: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ExecutionValveEnvironment:
+    valve_dryrun_enabled: bool = False
+    valve_worktree_create_enabled: bool = False
+    sovereign_worktree_token: Optional[str] = None
+    permission_ttl_seconds: int = DEFAULT_PERMISSION_TTL_SECONDS
+    permission_expires_at: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ExecutionValveDecision:
+    valve_state: str
+    work_order_id: str
+    rejection_reasons: List[str]
+    gates_checked: List[str]
+    no_execution_performed: bool
+    decision_digest: str
+    intake_target: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def _utc_now(now: Optional[datetime] = None) -> datetime:
+    value = now or datetime.now(timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _iso8601(dt: datetime) -> str:
+    return dt.replace(microsecond=0).isoformat()
+
+
+def _parse_iso8601(value: str) -> datetime:
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _canonical_digest(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _mapping(value: Union[ExecutionValveRequest, Mapping[str, Any]]) -> Mapping[str, Any]:
+    if isinstance(value, ExecutionValveRequest):
+        return value.to_dict()
+    return value
+
+
+def _env_mapping(value: Union[ExecutionValveEnvironment, Mapping[str, Any]]) -> Mapping[str, Any]:
+    if isinstance(value, ExecutionValveEnvironment):
+        return value.to_dict()
+    return value
+
+
+def _permission_snapshot_fresh(
+    captured_at: str,
+    *,
+    now: datetime,
+    ttl_seconds: int = DEFAULT_PERMISSION_TTL_SECONDS,
+    expires_at: Optional[str] = None,
+) -> bool:
+    if expires_at:
+        try:
+            return now <= _parse_iso8601(expires_at)
+        except ValueError:
+            return False
+    try:
+        captured = _parse_iso8601(captured_at)
+        return now <= captured + timedelta(seconds=max(1, ttl_seconds))
+    except ValueError:
+        return False
+
+
+def _work_order_id(work_order: Mapping[str, Any]) -> str:
+    return str(work_order.get("work_order_id") or "unknown")
+
+
+def _holoindex_index_gap_write_blocked(work_order: Mapping[str, Any]) -> bool:
+    holo = work_order.get("holoindex_evidence")
+    if not isinstance(holo, Mapping):
+        return False
+    op_norm = _normalize_operation(str(work_order.get("requested_operation") or ""))
+    gap = holo.get("index_gap_detected") is True or holo.get("retrieval_quality") == "INDEX_GAP"
+    return gap and _is_write_sensitive_operation(op_norm)
+
+
+def _validate_spine_chain(
+    request: Mapping[str, Any],
+    gates_checked: List[str],
+) -> List[str]:
+    reasons: List[str] = []
+    work_order = dict(request.get("work_order") or {})
+    policy = dict(request.get("policy_gate_receipt") or {})
+    receipt = dict(request.get("reddog_work_order_receipt") or {})
+    invocation = dict(request.get("invocation_result") or {})
+    executor = dict(request.get("executor_plan_result") or {})
+
+    gates_checked.append("policy_gate_accepted")
+    if policy.get("decision") != POLICY_ACCEPT:
+        reasons.append("policy_gate_not_accepted")
+    if policy.get("no_execution_performed") is not True:
+        reasons.append("policy_gate_execution_detected")
+
+    gates_checked.append("reddog_work_order_receipt_present")
+    if not receipt.get("receipt_id") or not receipt.get("receipt_digest"):
+        reasons.append("missing_reddog_work_order_receipt")
+    if receipt.get("no_execution_performed") is not True:
+        reasons.append("receipt_execution_detected")
+    policy_digest = str(policy.get("receipt_digest") or "")
+    if policy_digest and receipt.get("policy_gate_receipt_digest") != policy_digest:
+        reasons.append("receipt_policy_digest_mismatch")
+
+    gates_checked.append("invocation_dryrun_accepted")
+    if invocation.get("decision") != INVOCATION_ACCEPT:
+        reasons.append("invocation_not_accepted")
+    if invocation.get("no_execution_performed") is not True:
+        reasons.append("invocation_execution_detected")
+    if not invocation.get("receipt_digest"):
+        reasons.append("missing_invocation_receipt_digest")
+    if policy_digest and invocation.get("policy_gate_receipt_digest") != policy_digest:
+        reasons.append("invocation_policy_digest_mismatch")
+
+    gates_checked.append("executor_plan_accepted")
+    if executor.get("decision") != EXECUTOR_PLAN_ACCEPT:
+        reasons.append("executor_plan_not_accepted")
+    if executor.get("no_mutation_performed") is not True:
+        reasons.append("executor_mutation_detected")
+    plan = executor.get("plan")
+    if not isinstance(plan, Mapping):
+        reasons.append("missing_executor_plan")
+    else:
+        if not plan.get("plan_id") or not plan.get("plan_digest"):
+            reasons.append("incomplete_executor_plan")
+        inv_digest = str(invocation.get("receipt_digest") or "")
+        if inv_digest and plan.get("invocation_receipt_digest") != inv_digest:
+            reasons.append("executor_plan_invocation_digest_mismatch")
+
+    gates_checked.append("receipt_chain_complete")
+    if not policy_digest:
+        reasons.append("missing_policy_gate_receipt_digest")
+
+    gates_checked.append("index_gap_write_policy")
+    if _holoindex_index_gap_write_blocked(work_order):
+        reasons.append("index_gap_blocks_write_operation")
+
+    return reasons
+
+
+def _validate_intake_and_launch(request: Mapping[str, Any], gates_checked: List[str]) -> List[str]:
+    reasons: List[str] = []
+    intake = str(request.get("intake_target") or "").strip().lower()
+
+    gates_checked.append("intake_target_canonical")
+    if intake in FORBIDDEN_INTAKE_TARGETS:
+        reasons.append("assignment_dispatcher_forbidden_target")
+    elif intake not in CANONICAL_INTAKE_TARGETS:
+        reasons.append("intake_target_not_canonical")
+
+    gates_checked.append("direct_launch_forbidden")
+    if request.get("direct_worker_launch") is True:
+        reasons.append("direct_worker_launch_forbidden")
+    if request.get("direct_model_launch") is True:
+        reasons.append("direct_model_launch_forbidden")
+    if request.get("direct_wre_executor_call") is True:
+        reasons.append("direct_wre_executor_call_forbidden")
+    if request.get("protected_branch_mutation") is True:
+        reasons.append("protected_branch_mutation_forbidden")
+
+    return reasons
+
+
+def _validate_permission(
+    request: Mapping[str, Any],
+    environment: Mapping[str, Any],
+    *,
+    now: datetime,
+    gates_checked: List[str],
+) -> List[str]:
+    reasons: List[str] = []
+    work_order = dict(request.get("work_order") or {})
+    snap = dict(request.get("permission_snapshot") or {})
+    if not snap:
+        snap = dict(work_order.get("repo_permission_snapshot") or {})
+
+    gates_checked.append("permission_snapshot_present")
+    if not snap.get("captured_at"):
+        reasons.append("missing_permission_snapshot")
+    if not snap.get("digest"):
+        reasons.append("missing_permission_snapshot_digest")
+
+    gates_checked.append("permission_snapshot_freshness")
+    ttl = int(environment.get("permission_ttl_seconds") or DEFAULT_PERMISSION_TTL_SECONDS)
+    expires_at = environment.get("permission_expires_at")
+    captured_at = str(snap.get("captured_at") or "")
+    if captured_at and not _permission_snapshot_fresh(
+        captured_at,
+        now=now,
+        ttl_seconds=ttl,
+        expires_at=str(expires_at) if expires_at else None,
+    ):
+        reasons.append("stale_permission_snapshot")
+
+    gates_checked.append("permission_truth_for_write")
+    level = str(snap.get("permission_level") or "")
+    source = str(snap.get("source") or "")
+    truth = permission_truth_label(level, source)
+    op_norm = _normalize_operation(str(work_order.get("requested_operation") or ""))
+    if truth == TRUTH_NEEDS_VERIFICATION and _is_write_sensitive_operation(op_norm):
+        reasons.append("permission_needs_verification")
+
+    return reasons
+
+
+def _resolve_valve_state(
+    environment: Mapping[str, Any],
+    reasons: List[str],
+) -> str:
+    if reasons:
+        return VALVE_CLOSED
+    dryrun = bool(environment.get("valve_dryrun_enabled"))
+    worktree = bool(environment.get("valve_worktree_create_enabled"))
+    token = str(environment.get("sovereign_worktree_token") or "").strip()
+
+    if worktree:
+        if token:
+            return VALVE_OPEN_WORKTREE_CREATE
+        return VALVE_CLOSED
+    if dryrun:
+        return VALVE_OPEN_DRYRUN_ONLY
+    return VALVE_CLOSED
+
+
+def evaluate_reddog_execution_valve(
+    request: Union[ExecutionValveRequest, Mapping[str, Any]],
+    environment: Union[ExecutionValveEnvironment, Mapping[str, Any]],
+    *,
+    now: Optional[datetime] = None,
+) -> ExecutionValveDecision:
+    """Evaluate RedDog execution valve state. Pure evaluation; no execution performed."""
+    req = _mapping(request)
+    env = _env_mapping(environment)
+    checked = _utc_now(now)
+    checked_at = _iso8601(checked)
+    work_order = dict(req.get("work_order") or {})
+    work_order_id = _work_order_id(work_order)
+    intake_target = str(req.get("intake_target") or "").strip().lower()
+
+    gates_checked: List[str] = ["execution_valve_evaluator"]
+    rejection_reasons: List[str] = []
+
+    rejection_reasons.extend(_validate_spine_chain(req, gates_checked))
+    rejection_reasons.extend(_validate_intake_and_launch(req, gates_checked))
+    rejection_reasons.extend(
+        _validate_permission(req, env, now=checked, gates_checked=gates_checked)
+    )
+
+    gates_checked.append("explicit_valve_flag_required")
+    valve_state = _resolve_valve_state(env, rejection_reasons)
+    if not rejection_reasons and valve_state == VALVE_CLOSED:
+        if env.get("valve_worktree_create_enabled") and not str(
+            env.get("sovereign_worktree_token") or ""
+        ).strip():
+            rejection_reasons.append("worktree_valve_missing_sovereign_token")
+        else:
+            rejection_reasons.append("explicit_valve_flag_missing")
+
+    deduped = list(dict.fromkeys(rejection_reasons))
+    if deduped:
+        valve_state = VALVE_CLOSED
+
+    body = {
+        "valve_state": valve_state,
+        "work_order_id": work_order_id,
+        "intake_target": intake_target,
+        "rejection_reasons": deduped,
+        "gates_checked": gates_checked,
+        "no_execution_performed": True,
+        "checked_at": checked_at,
+    }
+    return ExecutionValveDecision(
+        valve_state=valve_state,
+        work_order_id=work_order_id,
+        rejection_reasons=deduped,
+        gates_checked=gates_checked,
+        no_execution_performed=True,
+        decision_digest=_canonical_digest(body),
+        intake_target=intake_target,
+    )
+
+
+__all__ = [
+    "CANONICAL_INTAKE_TARGETS",
+    "ExecutionValveDecision",
+    "ExecutionValveEnvironment",
+    "ExecutionValveRequest",
+    "FORBIDDEN_INTAKE_TARGETS",
+    "INTAKE_ASSIGNMENT_DISPATCHER",
+    "INTAKE_AUTONOMOUS_TASK",
+    "INTAKE_FOUNDUP_JOB",
+    "VALVE_CLOSED",
+    "VALVE_OPEN_DRYRUN_ONLY",
+    "VALVE_OPEN_WORKTREE_CREATE",
+    "evaluate_reddog_execution_valve",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_execution_valve.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_execution_valve.py
@@ -1,0 +1,328 @@
+"""Tests for RedDog WRE execution valve evaluator."""
+
+from __future__ import annotations
+
+import ast
+import json
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_work_order_receipt import (
+    RedDogWorkOrderReceiptStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_runtime_invocation import (
+    invoke_reddog_work_order_dryrun,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    INTAKE_ASSIGNMENT_DISPATCHER,
+    INTAKE_AUTONOMOUS_TASK,
+    INTAKE_FOUNDUP_JOB,
+    VALVE_CLOSED,
+    VALVE_OPEN_DRYRUN_ONLY,
+    VALVE_OPEN_WORKTREE_CREATE,
+    ExecutionValveEnvironment,
+    ExecutionValveRequest,
+    evaluate_reddog_execution_valve,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_executor_dryrun import (
+    plan_wre_isolated_worktree_execution_dryrun,
+)
+
+
+def _future_expiry(hours: int = 2) -> str:
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).replace(microsecond=0).isoformat()
+
+
+def _fresh_captured() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _base_order(**overrides):
+    payload = {
+        "work_order_id": "wo-valve-001",
+        "created_at": _fresh_captured(),
+        "red_dog_instance_id": "reddog-ext-0.3.28",
+        "authenticated_principal": "principal-012",
+        "principal_provider": "github",
+        "repo_full_name": "FOUNDUPS/Foundups-Agent",
+        "repo_permission_snapshot": {
+            "permission_level": "write",
+            "captured_at": _fresh_captured(),
+            "source": "mock",
+            "digest": "sha256:" + ("a" * 64),
+        },
+        "requested_operation": "feature_slice",
+        "authority_tier": "source",
+        "allowed_paths": ["modules/communication/moltbot_bridge/**"],
+        "denied_paths": [".env"],
+        "branch_name": "feat/reddog-valve-test",
+        "base_ref": "main",
+        "task_summary": "Execution valve validation",
+        "wsp_applicability": ["WSP_34", "WSP_50", "WSP_97"],
+        "holoindex_evidence_refs": [
+            "docs/audits/architecture/REDDOG_WRE_EXECUTION_VALVE_CONTRACT_PHASE1.md",
+        ],
+        "skillz_candidates": [],
+        "required_tests": [
+            "modules/communication/moltbot_bridge/tests/test_reddog_wre_execution_valve.py"
+        ],
+        "required_policy_gates": ["openclaw_policy_gate"],
+        "required_reviewers": [],
+        "sentinel_checks": [],
+        "rollback_plan": "Remove worktree and delete branch on abort.",
+        "expiry": _future_expiry(),
+        "nonce": "nonce-valve-001",
+        "evidence_digest": "sha256:" + ("b" * 64),
+        "advisory_only_source_packet": {
+            "work_focus_digest": "sha256:" + ("c" * 64),
+            "wsp_prompt_digest": "sha256:" + ("d" * 64),
+            "copy_md_run_trace_digest": "sha256:" + ("e" * 64),
+        },
+        "holoindex_evidence": {
+            "holoindex_query": "RedDog execution valve",
+            "holoindex_status": "bundle_json_ok",
+            "code_hits": [],
+            "wsp_hits": ["WSP_framework/src/WSP_34_Git_Operations_Protocol.md"],
+            "skillz_hits": [],
+            "direct_read_fallback_used": False,
+            "index_gap_detected": False,
+            "applicable_wsps": ["WSP_34"],
+            "evidence_refs": [
+                "docs/audits/architecture/REDDOG_WRE_EXECUTION_VALVE_CONTRACT_PHASE1.md"
+            ],
+            "retrieval_quality": "HIGH",
+            "skillz_gap_detected": False,
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _full_spine_bundle(*, order=None):
+    order = order or _base_order()
+    with tempfile.TemporaryDirectory() as tmp:
+        with RedDogWorkOrderReceiptStore(Path(tmp) / "receipts.db") as store:
+            invocation = invoke_reddog_work_order_dryrun(
+                order,
+                permission_snapshot={
+                    "permission_level": "write",
+                    "captured_at": _fresh_captured(),
+                    "source": "mock",
+                    "digest": order["repo_permission_snapshot"]["digest"],
+                },
+                seen_nonces=set(),
+                receipt_store=store,
+            )
+    executor = plan_wre_isolated_worktree_execution_dryrun(invocation, order)
+    policy_receipt = {
+        "decision": "POLICY_ACCEPT",
+        "receipt_digest": invocation.policy_gate_receipt_digest,
+        "no_execution_performed": True,
+        "work_order_id": order["work_order_id"],
+    }
+    work_order_receipt = {
+        "receipt_id": invocation.receipt_id,
+        "receipt_digest": invocation.receipt_digest,
+        "policy_gate_receipt_digest": invocation.policy_gate_receipt_digest,
+        "no_execution_performed": True,
+        "work_order_id": order["work_order_id"],
+    }
+    return order, policy_receipt, work_order_receipt, invocation, executor
+
+
+def _request_from_spine(
+    order,
+    policy_receipt,
+    work_order_receipt,
+    invocation,
+    executor,
+    *,
+    intake_target=INTAKE_FOUNDUP_JOB,
+    **flags,
+):
+    return ExecutionValveRequest(
+        work_order=order,
+        policy_gate_receipt=policy_receipt,
+        reddog_work_order_receipt=work_order_receipt,
+        invocation_result=invocation.to_dict(),
+        executor_plan_result=executor.to_dict(),
+        intake_target=intake_target,
+        permission_snapshot=order["repo_permission_snapshot"],
+        **flags,
+    )
+
+
+class TestValveDefaultClosed:
+    def test_default_closed_without_explicit_flag(self):
+        order, policy, receipt, invocation, executor = _full_spine_bundle()
+        req = _request_from_spine(order, policy, receipt, invocation, executor)
+        decision = evaluate_reddog_execution_valve(req, ExecutionValveEnvironment())
+        assert decision.valve_state == VALVE_CLOSED
+        assert "explicit_valve_flag_missing" in decision.rejection_reasons
+        assert decision.no_execution_performed is True
+        assert len(decision.decision_digest) == 64
+
+
+class TestValveOpenPaths:
+    def test_explicit_dryrun_only_opens_dryrun_state(self):
+        order, policy, receipt, invocation, executor = _full_spine_bundle()
+        req = _request_from_spine(order, policy, receipt, invocation, executor)
+        env = ExecutionValveEnvironment(valve_dryrun_enabled=True)
+        decision = evaluate_reddog_execution_valve(req, env)
+        assert decision.valve_state == VALVE_OPEN_DRYRUN_ONLY
+        assert decision.rejection_reasons == []
+
+    def test_worktree_create_requires_stronger_valve_and_token(self):
+        order, policy, receipt, invocation, executor = _full_spine_bundle()
+        req = _request_from_spine(order, policy, receipt, invocation, executor)
+        env = ExecutionValveEnvironment(valve_worktree_create_enabled=True)
+        decision = evaluate_reddog_execution_valve(req, env)
+        assert decision.valve_state == VALVE_CLOSED
+        assert "worktree_valve_missing_sovereign_token" in decision.rejection_reasons
+
+    def test_worktree_create_with_token_opens(self):
+        order, policy, receipt, invocation, executor = _full_spine_bundle()
+        req = _request_from_spine(order, policy, receipt, invocation, executor)
+        env = ExecutionValveEnvironment(
+            valve_worktree_create_enabled=True,
+            sovereign_worktree_token="012-sovereign-valve-token",
+        )
+        decision = evaluate_reddog_execution_valve(req, env)
+        assert decision.valve_state == VALVE_OPEN_WORKTREE_CREATE
+        assert decision.rejection_reasons == []
+
+
+class TestValveRejections:
+    def test_missing_receipt_chain_rejects(self):
+        order, policy, receipt, invocation, executor = _full_spine_bundle()
+        policy = dict(policy)
+        policy["receipt_digest"] = ""
+        req = _request_from_spine(order, policy, receipt, invocation, executor)
+        env = ExecutionValveEnvironment(valve_dryrun_enabled=True)
+        decision = evaluate_reddog_execution_valve(req, env)
+        assert decision.valve_state == VALVE_CLOSED
+        assert "missing_policy_gate_receipt_digest" in decision.rejection_reasons
+
+    def test_stale_permission_rejects(self):
+        order, policy, receipt, invocation, executor = _full_spine_bundle()
+        stale = (datetime.now(timezone.utc) - timedelta(hours=2)).replace(microsecond=0).isoformat()
+        order = dict(order)
+        order["repo_permission_snapshot"] = {
+            "permission_level": "write",
+            "captured_at": stale,
+            "source": "mock",
+            "digest": "sha256:" + ("a" * 64),
+        }
+        req = _request_from_spine(order, policy, receipt, invocation, executor)
+        req = ExecutionValveRequest(
+            work_order=order,
+            policy_gate_receipt=policy,
+            reddog_work_order_receipt=receipt,
+            invocation_result=invocation.to_dict(),
+            executor_plan_result=executor.to_dict(),
+            intake_target=INTAKE_FOUNDUP_JOB,
+            permission_snapshot=order["repo_permission_snapshot"],
+        )
+        env = ExecutionValveEnvironment(valve_dryrun_enabled=True, permission_ttl_seconds=300)
+        decision = evaluate_reddog_execution_valve(req, env)
+        assert decision.valve_state == VALVE_CLOSED
+        assert "stale_permission_snapshot" in decision.rejection_reasons
+
+    def test_assignment_dispatcher_target_rejects(self):
+        order, policy, receipt, invocation, executor = _full_spine_bundle()
+        req = _request_from_spine(
+            order, policy, receipt, invocation, executor, intake_target=INTAKE_ASSIGNMENT_DISPATCHER
+        )
+        env = ExecutionValveEnvironment(valve_dryrun_enabled=True)
+        decision = evaluate_reddog_execution_valve(req, env)
+        assert decision.valve_state == VALVE_CLOSED
+        assert "assignment_dispatcher_forbidden_target" in decision.rejection_reasons
+
+    def test_direct_worker_and_model_launch_reject(self):
+        order, policy, receipt, invocation, executor = _full_spine_bundle()
+        req = _request_from_spine(
+            order,
+            policy,
+            receipt,
+            invocation,
+            executor,
+            direct_worker_launch=True,
+            direct_model_launch=True,
+        )
+        env = ExecutionValveEnvironment(valve_dryrun_enabled=True)
+        decision = evaluate_reddog_execution_valve(req, env)
+        assert decision.valve_state == VALVE_CLOSED
+        assert "direct_worker_launch_forbidden" in decision.rejection_reasons
+        assert "direct_model_launch_forbidden" in decision.rejection_reasons
+
+    def test_autonomous_task_target_passes_with_valve(self):
+        order, policy, receipt, invocation, executor = _full_spine_bundle()
+        req = _request_from_spine(
+            order, policy, receipt, invocation, executor, intake_target=INTAKE_AUTONOMOUS_TASK
+        )
+        env = ExecutionValveEnvironment(valve_dryrun_enabled=True)
+        decision = evaluate_reddog_execution_valve(req, env)
+        assert decision.valve_state == VALVE_OPEN_DRYRUN_ONLY
+        assert decision.intake_target == INTAKE_AUTONOMOUS_TASK
+
+
+class TestNoExecutionBoundary:
+    def test_no_execution_performed_always(self):
+        order, policy, receipt, invocation, executor = _full_spine_bundle()
+        req = _request_from_spine(order, policy, receipt, invocation, executor)
+        for env in (
+            ExecutionValveEnvironment(),
+            ExecutionValveEnvironment(valve_dryrun_enabled=True),
+            ExecutionValveEnvironment(
+                valve_worktree_create_enabled=True,
+                sovereign_worktree_token="token",
+            ),
+        ):
+            decision = evaluate_reddog_execution_valve(req, env)
+            assert decision.no_execution_performed is True
+
+    def test_decision_json_serializable(self):
+        order, policy, receipt, invocation, executor = _full_spine_bundle()
+        req = _request_from_spine(order, policy, receipt, invocation, executor)
+        decision = evaluate_reddog_execution_valve(
+            req, ExecutionValveEnvironment(valve_dryrun_enabled=True)
+        )
+        json.dumps(decision.to_dict())
+
+    def test_ast_denylist(self):
+        module_path = (
+            Path(__file__).resolve().parents[1] / "src" / "reddog_wre_execution_valve.py"
+        )
+        source = module_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imported: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.append(node.module)
+        forbidden = [
+            name
+            for name in imported
+            if any(
+                token in name
+                for token in ("subprocess", "github_integration", "wre_core", "skillz")
+            )
+        ]
+        assert forbidden == []
+        for token in (
+            "import subprocess",
+            "git worktree",
+            "worktree add",
+            "create_branch",
+            "merge_pull_request",
+            "git ",
+            "gh ",
+            "os.mkdir",
+            "Path.mkdir",
+            "execute_skill",
+            "hermes_job_executor",
+            "openclaw_supervisor",
+        ):
+            assert token not in source


### PR DESCRIPTION
## Summary
- Add `evaluate_reddog_execution_valve()` pure evaluator in `reddog_wre_execution_valve.py` (default `VALVE_CLOSED`).
- Add contract doc `REDDOG_WRE_EXECUTION_VALVE_CONTRACT_PHASE1.md` and 12 pytest cases including AST denylist.
- Update extension/moltbot_bridge pointers; no runtime wiring, no git/worktree/worker launch.

## Gate ordering
Spine #889-#898 -> **this valve** -> adapter dry-run (future) -> worktree create (future).

## Test plan
- [x] `pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_execution_valve.py` (12 passed)
- [x] Governance spine tests (97 passed)
- [x] `verify_extension_contract.js`
- [x] `git diff --check` + byte scan on new files

## Residual SPECIFIED_NOT_IMPLEMENTED
- OpenClaw adapter dry-run
- Worktree create slice
- Extension runtime spine wiring
- HoloIndex ranking for new module (INDEX_GAP follow-up)
