### PR TITLE
feat(reddog): add OpenClaw FoundUpJob adapter dry-run

### DIFF
--- a/docs/audits/architecture/REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_CONTRACT_PHASE1.md
+++ b/docs/audits/architecture/REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_CONTRACT_PHASE1.md
@@ -1,0 +1,130 @@
+# REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_CONTRACT_PHASE1
+
+**Retrieval tags:** RedDog OpenClaw adapter dryrun | FoundUpJob intake RedDog | AgentDB autonomous_task RedDog | adapter dryrun receipt
+
+**Slice:** OpenClaw intake adapter dry-run planner (propose only, no enqueue)  
+**Type:** Module + contract -- **no live OpenClaw intake, no execution**  
+**Date:** 2026-06-28  
+**Base:** `2761f2e65` (post-#903 execution valve land)  
+**Status:** PR-READY -- draft PR only  
+**WSP lock:** WSP_00, WSP_15, WSP_34, WSP_50, WSP_91, WSP_97, WSP_22
+
+---
+
+## Purpose
+
+Translate a fully gated RedDog spine plus `VALVE_OPEN_DRYRUN_ONLY` into a **proposed**
+OpenClaw intake record (`FoundUpJob` or AgentDB `autonomous_task`).
+
+**Key invariant:** propose the intake record; **do not enqueue it anywhere**.
+
+Parent mapping: `REDDOG_WORK_ORDER_TO_OPENCLAW_FOUNDUPJOB_ADAPTER_CONTRACT_PHASE1.md`
+
+---
+
+## Module
+
+| Symbol | Path |
+|--------|------|
+| `plan_reddog_openclaw_adapter_dryrun()` | `modules/communication/moltbot_bridge/src/reddog_openclaw_adapter_dryrun.py` |
+
+---
+
+## Required inputs
+
+| Input | Source |
+|-------|--------|
+| `RedDogGovernedWorkOrder` | #889/#890 |
+| `PolicyGateReceipt` | #893 |
+| `RedDogWorkOrderReceipt` | #894 |
+| `WorkOrderDryRunInvocationResult` | #896 |
+| `WREExecutorPlan` (via #898 result) | #898 |
+| `ExecutionValveDecision` | #903 -- must be `VALVE_OPEN_DRYRUN_ONLY` |
+
+---
+
+## Required outputs
+
+### `RedDogOpenClawAdapterDryRunResult`
+
+- `decision`: `ADAPTER_DRYRUN_ACCEPT` | `ADAPTER_DRYRUN_REJECT`
+- `proposed_intake`: `ProposedOpenClawIntakeRecord` or null
+- `adapter_receipt`: `AdapterDryRunReceipt`
+- `no_enqueue_performed: true`
+- `no_execution_performed: true`
+
+### Proposed intake record fields
+
+| Field | Notes |
+|-------|-------|
+| `target_type` | `foundup_job` or `autonomous_task` |
+| `proposed_job_id` | Deterministic when target is FoundUpJob |
+| `proposed_task_id` | `reddog-wo-{work_order_id}` when autonomous_task |
+| `work_order_id` | Correlation |
+| `operation` | Normalized RedDog operation |
+| `requested_action` | FoundUpJob canonical action when applicable |
+| `repo_scope` | `repo_full_name` |
+| `allowed_paths` / `denied_paths` | From executor plan / work order |
+| `required_tests` | Propagated |
+| `evidence_refs` | Digest-prefixed receipt refs |
+| `policy_receipt_digest` | From #893 |
+| `work_order_receipt_digest` | From #894 |
+| `invocation_receipt_digest` | From #896 |
+| `executor_plan_id` | From #898 |
+| `valve_decision_digest` | From #903 |
+| `no_enqueue_performed` | Always true |
+| `no_execution_performed` | Always true |
+
+---
+
+## Rejection rules (fail closed)
+
+| Code | Condition |
+|------|-----------|
+| A1 | Valve `VALVE_CLOSED` |
+| A2 | Valve `VALVE_OPEN_WORKTREE_CREATE` (wrong authority for this slice) |
+| A3 | Valve not `VALVE_OPEN_DRYRUN_ONLY` |
+| A4 | AssignmentDispatcher target |
+| A5 | Missing / mismatched receipt chain |
+| A6 | Missing executor plan |
+| A7 | Path outside allowed scope |
+| A8 | Forbidden adapter operation (merge/pr/repo write) |
+
+---
+
+## Gate ordering
+
+```text
+1-7. RedDog spine (#890-#898)
+8. Execution valve (#903) -- VALVE_OPEN_DRYRUN_ONLY
+9. THIS ADAPTER DRY-RUN (propose only)
+10. OpenClaw Supervisor enqueue (future)
+11. Hermes / WRE execution (future)
+```
+
+---
+
+## WSP_97 truth table
+
+| # | Claim | Label |
+|---|-------|-------|
+| 1 | Adapter proposes intake only; no enqueue | **OBSERVED** |
+| 2 | Requires VALVE_OPEN_DRYRUN_ONLY | **OBSERVED** |
+| 3 | Rejects worktree-create valve authority | **OBSERVED** |
+| 4 | AssignmentDispatcher forbidden | **OBSERVED** |
+| 5 | Live OpenClaw enqueue remains future | **SPECIFIED_NOT_IMPLEMENTED** |
+| 6 | AgentDB writes remain future | **SPECIFIED_NOT_IMPLEMENTED** |
+
+---
+
+## Explicit non-goals
+
+| Non-goal | Status |
+|----------|--------|
+| OpenClaw Supervisor enqueue | **FORBIDDEN** |
+| FoundUpJob queue append | **FORBIDDEN** |
+| AgentDB writes | **FORBIDDEN** |
+| Hermes / WRE execute | **FORBIDDEN** |
+| Worktree / branch / file mutation | **FORBIDDEN** |
+
+**No runtime mutation performed in authoring this contract or module.**

--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -89,6 +89,8 @@ RedDog is the 0102 architect interface — **not an authority owner**. RedDog re
 
 **WRE execution valve:** `modules/communication/moltbot_bridge/src/reddog_wre_execution_valve.py` -- `evaluate_reddog_execution_valve()`; default `VALVE_CLOSED`; pure evaluation only. Contract: `docs/audits/architecture/REDDOG_WRE_EXECUTION_VALVE_CONTRACT_PHASE1.md`.
 
+**OpenClaw adapter dry-run:** `modules/communication/moltbot_bridge/src/reddog_openclaw_adapter_dryrun.py` -- `plan_reddog_openclaw_adapter_dryrun()`; proposes FoundUpJob / `autonomous_task` intake only; **no enqueue**. Contract: `docs/audits/architecture/REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_CONTRACT_PHASE1.md`.
+
 **Specified flow (not implemented in extension v0.3.27):**
 
 ```text

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,14 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-06-28 - REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_PHASE1 (extension pointers)
+
+- Module: `modules/communication/moltbot_bridge/src/reddog_openclaw_adapter_dryrun.py`
+- `plan_reddog_openclaw_adapter_dryrun()` -- propose FoundUpJob / autonomous_task intake; no enqueue.
+- Contract: `docs/audits/architecture/REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_CONTRACT_PHASE1.md`
+
+WSP: WSP_00, WSP_15, WSP_50, WSP_97, WSP_22.
+
 ## 2026-06-28 - REDDOG_WRE_EXECUTION_VALVE_PHASE1 (extension pointers)
 
 - Module: `modules/communication/moltbot_bridge/src/reddog_wre_execution_valve.py`

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -85,11 +85,11 @@ DONE
 11. #898 WRE executor plan dry-run (e215bf890)
 12. #899 RedDog continuation memory (c70433d7d)
 13. #901 OpenClaw FoundUpJob adapter contract (2c8df23dd)
+14. #903 WRE execution valve (2761f2e65)
 
 P0 NEXT (execution track)
-14. REDDOG_WRE_EXECUTION_VALVE_PHASE1
-    - default CLOSED valve before first real worktree create
 15. REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_PHASE1
+    - propose FoundUpJob / autonomous_task intake; no live enqueue
 
 P1
 16. REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_WORKTREE_CREATE_PHASE1
@@ -240,13 +240,19 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 
 ### REDDOG_WRE_EXECUTION_VALVE_PHASE1
 
-- **Status:** **PR-READY** -- `evaluate_reddog_execution_valve()`; default `VALVE_CLOSED`.
+- **Status:** **LANDED** #903 (`2761f2e65`) -- `evaluate_reddog_execution_valve()`; default `VALVE_CLOSED`.
 - **Module:** `modules/communication/moltbot_bridge/src/reddog_wre_execution_valve.py`
 - **Contract:** `docs/audits/architecture/REDDOG_WRE_EXECUTION_VALVE_CONTRACT_PHASE1.md`
 
+### REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_PHASE1
+
+- **Status:** **PR-READY** -- `plan_reddog_openclaw_adapter_dryrun()`; propose only, no enqueue.
+- **Module:** `modules/communication/moltbot_bridge/src/reddog_openclaw_adapter_dryrun.py`
+- **Contract:** `docs/audits/architecture/REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_CONTRACT_PHASE1.md`
+
 ### REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_WORKTREE_CREATE_PHASE1
 
-- **Status:** **BLOCKED** -- until execution valve lands and opens with sovereign token.
+- **Status:** **BLOCKED** -- until adapter dry-run lands; worktree requires `VALVE_OPEN_WORKTREE_CREATE`.
 
 ### REDDOG_REVIEW_CONSENSUS_RECEIPTS_PHASE1
 

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -246,6 +246,17 @@ includes(valvePy, 'evaluate_reddog_execution_valve', 'execution valve evaluator 
 includes(valvePy, 'no_execution_performed', 'execution valve no_execution_performed missing');
 includes(iface, 'reddog_wre_execution_valve.py', 'INTERFACE execution valve pointer missing');
 includes(roadmap, 'REDDOG_WRE_EXECUTION_VALVE_PHASE1', 'execution valve slice missing');
+const adapterDryrunContractDocPath = path.join(root, 'docs', 'audits', 'architecture', 'REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_CONTRACT_PHASE1.md');
+const adapterDryrunContractDoc = fs.readFileSync(adapterDryrunContractDocPath, 'utf8');
+includes(adapterDryrunContractDoc, 'no_enqueue_performed', 'adapter dryrun contract no_enqueue missing');
+includes(adapterDryrunContractDoc, 'VALVE_OPEN_DRYRUN_ONLY', 'adapter dryrun contract valve requirement missing');
+includes(adapterDryrunContractDoc, 'foundup_job', 'adapter dryrun contract foundup_job target missing');
+includes(adapterDryrunContractDoc, 'autonomous_task', 'adapter dryrun contract autonomous_task target missing');
+const adapterDryrunPy = fs.readFileSync(path.join(root, 'modules', 'communication', 'moltbot_bridge', 'src', 'reddog_openclaw_adapter_dryrun.py'), 'utf8');
+includes(adapterDryrunPy, 'plan_reddog_openclaw_adapter_dryrun', 'adapter dryrun planner missing');
+includes(adapterDryrunPy, 'no_enqueue_performed', 'adapter dryrun no_enqueue_performed missing');
+includes(iface, 'reddog_openclaw_adapter_dryrun.py', 'INTERFACE adapter dryrun pointer missing');
+includes(roadmap, 'REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_PHASE1', 'adapter dryrun slice missing');
 includes(roadmap, 'External RedDog Lane Queue (post-#888)', 'post-#888 external lane queue missing');
 includes(roadmap, 'REDDOG_GOVERNED_REPO_WORK_ORDER_DRYRUN_PHASE1', 'governed work order dryrun slice missing');
 includes(roadmap, 'REDDOG_RUN_TRACE_TELEMETRY_CORRECTION_PHASE1', 'run trace telemetry correction slice missing');

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,15 @@
 # ModLog - moltbot_bridge
 
+## 2026-06-28: REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_PHASE1
+
+**Slice:** OpenClaw FoundUpJob adapter dry-run planner (propose only, no enqueue)
+**WSP:** WSP_15, WSP_34, WSP_50, WSP_91, WSP_97, WSP_22
+
+- ADD `src/reddog_openclaw_adapter_dryrun.py` -- `plan_reddog_openclaw_adapter_dryrun()`, `RedDogOpenClawAdapterDryRunResult`.
+- ADD `tests/test_reddog_openclaw_adapter_dryrun.py` -- FoundUpJob/autonomous_task propose, valve rejects, AST denylist.
+- ADD `docs/audits/architecture/REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_CONTRACT_PHASE1.md`.
+- Requires `VALVE_OPEN_DRYRUN_ONLY`; always `no_enqueue_performed` + `no_execution_performed`.
+
 ## 2026-06-28: REDDOG_WRE_EXECUTION_VALVE_PHASE1
 
 **Slice:** Closed-by-default WRE execution valve evaluator (pure evaluation)

--- a/modules/communication/moltbot_bridge/src/reddog_openclaw_adapter_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_openclaw_adapter_dryrun.py
@@ -1,0 +1,541 @@
+"""RedDog OpenClaw FoundUpJob adapter dry-run planner (no enqueue).
+
+Slice: REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_PHASE1
+Contract: docs/audits/architecture/REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_CONTRACT_PHASE1.md
+Mapping: docs/audits/architecture/REDDOG_WORK_ORDER_TO_OPENCLAW_FOUNDUPJOB_ADAPTER_CONTRACT_PHASE1.md
+
+Translates a fully gated RedDog spine plus open dry-run valve into a proposed
+FoundUpJob or AgentDB autonomous_task intake record. Proposes only -- no enqueue,
+no AgentDB writes, no Hermes/WRE execution.
+
+WSP 97 TRUTH BOUNDARIES:
+  DOES:
+    - Require VALVE_OPEN_DRYRUN_ONLY (reject CLOSED / WORKTREE_CREATE)
+    - Map spine fields to proposed intake per #901 contract
+    - Emit adapter dry-run receipt with deterministic digests
+    - Always set no_enqueue_performed and no_execution_performed
+
+  DOES NOT:
+    - Enqueue OpenClaw Supervisor, append FoundUpJob queue, or write AgentDB
+    - Invoke Hermes, WRE executor, Skillz, subprocess, git, or gh
+    - Create worktrees, branches, PRs, or mutate repository content
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
+
+from modules.communication.moltbot_bridge.src.reddog_governed_work_order_dryrun import (
+    _normalize_operation,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_work_order_policy_gate import (
+    POLICY_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    INTAKE_ASSIGNMENT_DISPATCHER,
+    INTAKE_AUTONOMOUS_TASK,
+    INTAKE_FOUNDUP_JOB,
+    VALVE_CLOSED,
+    VALVE_OPEN_DRYRUN_ONLY,
+    VALVE_OPEN_WORKTREE_CREATE,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_runtime_invocation import (
+    INVOCATION_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_executor_dryrun import (
+    EXECUTOR_PLAN_ACCEPT,
+)
+
+ADAPTER_DRYRUN_ACCEPT = "ADAPTER_DRYRUN_ACCEPT"
+ADAPTER_DRYRUN_REJECT = "ADAPTER_DRYRUN_REJECT"
+
+TARGET_FOUNDUP_JOB = "foundup_job"
+TARGET_AUTONOMOUS_TASK = "autonomous_task"
+
+FORBIDDEN_ADAPTER_OPERATIONS = frozenset(
+    {"repo", "write", "pr", "merge_request", "merge", "push", "pull_request"}
+)
+
+OPERATION_TO_REQUESTED_ACTION: Dict[str, str] = {
+    "audit_only": "validate_foundup",
+    "docs_audit": "validate_foundup",
+    "docs_only": "validate_foundup",
+    "feature_slice": "build_foundup",
+    "docs_patch": "build_foundup",
+    "test_fix": "build_foundup",
+}
+
+_TASK_SUMMARY_MAX_LEN = 512
+_TASK_ID_PREFIX = "reddog-wo-"
+_JOB_ID_PREFIX = "reddog-fj-"
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+@dataclass
+class ProposedOpenClawIntakeRecord:
+    target_type: str
+    proposed_job_id: Optional[str]
+    proposed_task_id: Optional[str]
+    work_order_id: str
+    operation: str
+    requested_action: Optional[str]
+    repo_scope: str
+    allowed_paths: List[str]
+    denied_paths: List[str]
+    required_tests: List[str]
+    evidence_refs: List[str]
+    policy_receipt_digest: str
+    work_order_receipt_digest: str
+    invocation_receipt_digest: str
+    executor_plan_id: str
+    valve_decision_digest: str
+    no_enqueue_performed: bool
+    no_execution_performed: bool
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class AdapterDryRunReceipt:
+    adapter_receipt_id: str
+    adapter_receipt_digest: str
+    decision: str
+    rejection_reasons: List[str]
+    target_type: str
+    work_order_id: str
+    created_at: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class RedDogOpenClawAdapterDryRunResult:
+    decision: str
+    work_order_id: str
+    proposed_intake: Optional[ProposedOpenClawIntakeRecord]
+    adapter_receipt: AdapterDryRunReceipt
+    rejection_reasons: List[str]
+    no_enqueue_performed: bool
+    no_execution_performed: bool
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        if self.proposed_intake is not None:
+            payload["proposed_intake"] = self.proposed_intake.to_dict()
+        payload["adapter_receipt"] = self.adapter_receipt.to_dict()
+        return payload
+
+
+def _utc_now(now: Optional[datetime] = None) -> datetime:
+    value = now or datetime.now(timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _iso8601(dt: datetime) -> str:
+    return dt.replace(microsecond=0).isoformat()
+
+
+def _canonical_digest(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _work_order_id(work_order: Mapping[str, Any]) -> str:
+    return str(work_order.get("work_order_id") or "unknown")
+
+
+def _sanitize_task_summary(text: str) -> str:
+    cleaned = _WHITESPACE_RE.sub(" ", (text or "").strip())
+    if len(cleaned) > _TASK_SUMMARY_MAX_LEN:
+        return cleaned[: _TASK_SUMMARY_MAX_LEN - 3] + "..."
+    return cleaned
+
+
+def _path_covered_by_allowed(path: str, allowed_patterns: Sequence[str]) -> bool:
+    normalized = path.replace("\\", "/")
+    for pattern in allowed_patterns:
+        pat = pattern.replace("\\", "/")
+        if fnmatch.fnmatch(normalized, pat) or fnmatch.fnmatch(normalized, f"**/{pat}"):
+            return True
+    return False
+
+
+def _build_evidence_refs(
+    policy_digest: str,
+    work_order_digest: str,
+    invocation_digest: str,
+    work_order: Mapping[str, Any],
+) -> List[str]:
+    refs: List[str] = []
+    if policy_digest:
+        refs.append(f"policy_gate:{policy_digest}")
+    if work_order_digest:
+        refs.append(f"reddog_receipt:{work_order_digest}")
+    if invocation_digest:
+        refs.append(f"invocation:{invocation_digest}")
+    holo = work_order.get("holoindex_evidence")
+    if isinstance(holo, Mapping):
+        for ref in holo.get("evidence_refs") or []:
+            text = str(ref).strip()
+            if text and text not in refs:
+                refs.append(text)
+    for ref in work_order.get("holoindex_evidence_refs") or []:
+        text = str(ref).strip()
+        if text and text not in refs:
+            refs.append(text)
+    return refs
+
+
+def _validate_valve(valve_decision: Mapping[str, Any]) -> List[str]:
+    reasons: List[str] = []
+    state = str(valve_decision.get("valve_state") or "")
+    if state == VALVE_CLOSED:
+        reasons.append("execution_valve_closed")
+    elif state == VALVE_OPEN_WORKTREE_CREATE:
+        reasons.append("worktree_valve_not_allowed_for_adapter_dryrun")
+    elif state != VALVE_OPEN_DRYRUN_ONLY:
+        reasons.append("execution_valve_not_dryrun_only")
+    if valve_decision.get("no_execution_performed") is not True:
+        reasons.append("valve_execution_detected")
+    if not valve_decision.get("decision_digest"):
+        reasons.append("missing_valve_decision_digest")
+    if valve_decision.get("rejection_reasons"):
+        reasons.append("valve_has_rejection_reasons")
+    return reasons
+
+
+def _validate_spine(
+    work_order: Mapping[str, Any],
+    policy_gate_receipt: Mapping[str, Any],
+    reddog_work_order_receipt: Mapping[str, Any],
+    invocation_result: Mapping[str, Any],
+    executor_plan_result: Mapping[str, Any],
+) -> List[str]:
+    reasons: List[str] = []
+
+    if policy_gate_receipt.get("decision") != POLICY_ACCEPT:
+        reasons.append("policy_gate_not_accepted")
+    if policy_gate_receipt.get("no_execution_performed") is not True:
+        reasons.append("policy_gate_execution_detected")
+
+    if not reddog_work_order_receipt.get("receipt_id") or not reddog_work_order_receipt.get(
+        "receipt_digest"
+    ):
+        reasons.append("missing_reddog_work_order_receipt")
+    if reddog_work_order_receipt.get("no_execution_performed") is not True:
+        reasons.append("receipt_execution_detected")
+
+    policy_digest = str(policy_gate_receipt.get("receipt_digest") or "")
+    if policy_digest and reddog_work_order_receipt.get("policy_gate_receipt_digest") != policy_digest:
+        reasons.append("receipt_policy_digest_mismatch")
+
+    if invocation_result.get("decision") != INVOCATION_ACCEPT:
+        reasons.append("invocation_not_accepted")
+    if invocation_result.get("no_execution_performed") is not True:
+        reasons.append("invocation_execution_detected")
+    if not invocation_result.get("receipt_digest"):
+        reasons.append("missing_invocation_receipt_digest")
+
+    if executor_plan_result.get("decision") != EXECUTOR_PLAN_ACCEPT:
+        reasons.append("executor_plan_not_accepted")
+    if executor_plan_result.get("no_mutation_performed") is not True:
+        reasons.append("executor_mutation_detected")
+
+    plan = executor_plan_result.get("plan")
+    if not isinstance(plan, Mapping):
+        reasons.append("missing_executor_plan")
+    elif not plan.get("plan_id") or not plan.get("plan_digest"):
+        reasons.append("incomplete_executor_plan")
+
+    op_norm = _normalize_operation(str(work_order.get("requested_operation") or ""))
+    if op_norm in FORBIDDEN_ADAPTER_OPERATIONS:
+        reasons.append("forbidden_adapter_operation")
+
+    return reasons
+
+
+def _validate_target(target_type: str) -> List[str]:
+    normalized = (target_type or "").strip().lower()
+    if normalized == INTAKE_ASSIGNMENT_DISPATCHER:
+        return ["assignment_dispatcher_forbidden_target"]
+    if normalized not in {INTAKE_FOUNDUP_JOB, INTAKE_AUTONOMOUS_TASK}:
+        return ["intake_target_not_canonical"]
+    return []
+
+
+def _validate_path_scope(work_order: Mapping[str, Any], plan: Mapping[str, Any]) -> List[str]:
+    reasons: List[str] = []
+    wo_allowed = list(work_order.get("allowed_paths") or [])
+    plan_allowed = list(plan.get("allowed_paths") or [])
+    denied = {
+        str(p)
+        for p in list(work_order.get("denied_paths") or []) + list(plan.get("denied_paths") or [])
+    }
+
+    if wo_allowed:
+        for path in plan_allowed:
+            if not _path_covered_by_allowed(str(path), wo_allowed):
+                reasons.append("path_outside_allowed_scope")
+                break
+
+    for path in plan_allowed:
+        norm = str(path).replace("\\", "/")
+        if norm.startswith("../") or "/../" in norm:
+            reasons.append("path_escapes_repo_scope")
+            break
+        if str(path) in denied:
+            reasons.append("path_in_denied_scope")
+            break
+
+    worktree = str(plan.get("proposed_worktree_path") or "")
+    work_order_id = _work_order_id(work_order)
+    if worktree and f"/.reddog/worktrees/{work_order_id}/" not in worktree.replace("\\", "/"):
+        reasons.append("worktree_path_outside_scope")
+
+    return reasons
+
+
+def _proposed_job_id(work_order_id: str, plan_id: str) -> str:
+    seed = _canonical_digest({"work_order_id": work_order_id, "plan_id": plan_id})
+    return f"{_JOB_ID_PREFIX}{seed[:16]}"
+
+
+def _proposed_task_id(work_order_id: str) -> str:
+    safe_id = re.sub(r"[^a-zA-Z0-9_-]+", "-", work_order_id.strip())[:64].strip("-") or "unknown"
+    return f"{_TASK_ID_PREFIX}{safe_id}"
+
+
+def _build_foundup_job_intake(
+    work_order: Mapping[str, Any],
+    plan: Mapping[str, Any],
+    *,
+    policy_digest: str,
+    work_order_digest: str,
+    invocation_digest: str,
+    valve_digest: str,
+) -> ProposedOpenClawIntakeRecord:
+    work_order_id = _work_order_id(work_order)
+    op_norm = _normalize_operation(str(work_order.get("requested_operation") or ""))
+    requested_action = OPERATION_TO_REQUESTED_ACTION.get(op_norm, "")
+    plan_id = str(plan.get("plan_id") or "")
+    job_id = _proposed_job_id(work_order_id, plan_id)
+    repo_scope = str(work_order.get("repo_full_name") or "")
+    return ProposedOpenClawIntakeRecord(
+        target_type=TARGET_FOUNDUP_JOB,
+        proposed_job_id=job_id,
+        proposed_task_id=None,
+        work_order_id=work_order_id,
+        operation=op_norm,
+        requested_action=requested_action or None,
+        repo_scope=repo_scope,
+        allowed_paths=list(plan.get("allowed_paths") or work_order.get("allowed_paths") or []),
+        denied_paths=list(plan.get("denied_paths") or work_order.get("denied_paths") or []),
+        required_tests=list(work_order.get("required_tests") or []),
+        evidence_refs=_build_evidence_refs(
+            policy_digest, work_order_digest, invocation_digest, work_order
+        ),
+        policy_receipt_digest=policy_digest,
+        work_order_receipt_digest=work_order_digest,
+        invocation_receipt_digest=invocation_digest,
+        executor_plan_id=plan_id,
+        valve_decision_digest=valve_digest,
+        no_enqueue_performed=True,
+        no_execution_performed=True,
+    )
+
+
+def _build_autonomous_task_intake(
+    work_order: Mapping[str, Any],
+    plan: Mapping[str, Any],
+    *,
+    policy_digest: str,
+    work_order_digest: str,
+    invocation_digest: str,
+    valve_digest: str,
+) -> ProposedOpenClawIntakeRecord:
+    work_order_id = _work_order_id(work_order)
+    op_norm = _normalize_operation(str(work_order.get("requested_operation") or ""))
+    plan_id = str(plan.get("plan_id") or "")
+    task_id = _proposed_task_id(work_order_id)
+    repo_scope = str(work_order.get("repo_full_name") or "")
+    return ProposedOpenClawIntakeRecord(
+        target_type=TARGET_AUTONOMOUS_TASK,
+        proposed_job_id=None,
+        proposed_task_id=task_id,
+        work_order_id=work_order_id,
+        operation=op_norm,
+        requested_action=None,
+        repo_scope=repo_scope,
+        allowed_paths=list(plan.get("allowed_paths") or work_order.get("allowed_paths") or []),
+        denied_paths=list(plan.get("denied_paths") or work_order.get("denied_paths") or []),
+        required_tests=list(work_order.get("required_tests") or []),
+        evidence_refs=_build_evidence_refs(
+            policy_digest, work_order_digest, invocation_digest, work_order
+        ),
+        policy_receipt_digest=policy_digest,
+        work_order_receipt_digest=work_order_digest,
+        invocation_receipt_digest=invocation_digest,
+        executor_plan_id=plan_id,
+        valve_decision_digest=valve_digest,
+        no_enqueue_performed=True,
+        no_execution_performed=True,
+    )
+
+
+def _rejection_result(
+    work_order_id: str,
+    target_type: str,
+    reasons: List[str],
+    checked_at: str,
+) -> RedDogOpenClawAdapterDryRunResult:
+    receipt_core = {
+        "decision": ADAPTER_DRYRUN_REJECT,
+        "work_order_id": work_order_id,
+        "rejection_reasons": reasons,
+        "target_type": target_type,
+        "no_enqueue_performed": True,
+        "no_execution_performed": True,
+        "created_at": checked_at,
+    }
+    receipt_digest = _canonical_digest(receipt_core)
+    receipt_id = f"adapter-dryrun-{work_order_id}-{receipt_digest[:12]}"
+    receipt = AdapterDryRunReceipt(
+        adapter_receipt_id=receipt_id,
+        adapter_receipt_digest=receipt_digest,
+        decision=ADAPTER_DRYRUN_REJECT,
+        rejection_reasons=reasons,
+        target_type=target_type,
+        work_order_id=work_order_id,
+        created_at=checked_at,
+    )
+    return RedDogOpenClawAdapterDryRunResult(
+        decision=ADAPTER_DRYRUN_REJECT,
+        work_order_id=work_order_id,
+        proposed_intake=None,
+        adapter_receipt=receipt,
+        rejection_reasons=reasons,
+        no_enqueue_performed=True,
+        no_execution_performed=True,
+    )
+
+
+def plan_reddog_openclaw_adapter_dryrun(
+    work_order: Mapping[str, Any],
+    policy_gate_receipt: Mapping[str, Any],
+    reddog_work_order_receipt: Mapping[str, Any],
+    invocation_result: Mapping[str, Any],
+    executor_plan_result: Mapping[str, Any],
+    valve_decision: Mapping[str, Any],
+    *,
+    target_type: str = INTAKE_FOUNDUP_JOB,
+    now: Optional[datetime] = None,
+) -> RedDogOpenClawAdapterDryRunResult:
+    """Plan OpenClaw intake translation without enqueue or execution."""
+    checked = _utc_now(now)
+    checked_at = _iso8601(checked)
+    work_order_id = _work_order_id(work_order)
+    normalized_target = (target_type or INTAKE_FOUNDUP_JOB).strip().lower()
+
+    reasons: List[str] = []
+    reasons.extend(_validate_valve(valve_decision))
+    reasons.extend(_validate_target(normalized_target))
+    reasons.extend(
+        _validate_spine(
+            work_order,
+            policy_gate_receipt,
+            reddog_work_order_receipt,
+            invocation_result,
+            executor_plan_result,
+        )
+    )
+
+    plan = executor_plan_result.get("plan")
+    if isinstance(plan, Mapping):
+        reasons.extend(_validate_path_scope(work_order, plan))
+
+    op_norm = _normalize_operation(str(work_order.get("requested_operation") or ""))
+    if normalized_target == INTAKE_FOUNDUP_JOB and op_norm not in OPERATION_TO_REQUESTED_ACTION:
+        reasons.append("unsupported_operation_for_foundup_job")
+
+    deduped = list(dict.fromkeys(reasons))
+    if deduped:
+        return _rejection_result(work_order_id, normalized_target, deduped, checked_at)
+
+    assert isinstance(plan, Mapping)
+    policy_digest = str(policy_gate_receipt.get("receipt_digest") or "")
+    work_order_digest = str(reddog_work_order_receipt.get("receipt_digest") or "")
+    invocation_digest = str(invocation_result.get("receipt_digest") or "")
+    valve_digest = str(valve_decision.get("decision_digest") or "")
+
+    if normalized_target == INTAKE_AUTONOMOUS_TASK:
+        proposed = _build_autonomous_task_intake(
+            work_order,
+            plan,
+            policy_digest=policy_digest,
+            work_order_digest=work_order_digest,
+            invocation_digest=invocation_digest,
+            valve_digest=valve_digest,
+        )
+    else:
+        proposed = _build_foundup_job_intake(
+            work_order,
+            plan,
+            policy_digest=policy_digest,
+            work_order_digest=work_order_digest,
+            invocation_digest=invocation_digest,
+            valve_digest=valve_digest,
+        )
+
+    intake_digest = _canonical_digest(proposed.to_dict())
+    receipt_core = {
+        "decision": ADAPTER_DRYRUN_ACCEPT,
+        "work_order_id": work_order_id,
+        "target_type": normalized_target,
+        "proposed_intake_digest": intake_digest,
+        "rejection_reasons": [],
+        "no_enqueue_performed": True,
+        "no_execution_performed": True,
+        "created_at": checked_at,
+    }
+    receipt_digest = _canonical_digest(receipt_core)
+    receipt_id = f"adapter-dryrun-{work_order_id}-{receipt_digest[:12]}"
+    receipt = AdapterDryRunReceipt(
+        adapter_receipt_id=receipt_id,
+        adapter_receipt_digest=receipt_digest,
+        decision=ADAPTER_DRYRUN_ACCEPT,
+        rejection_reasons=[],
+        target_type=normalized_target,
+        work_order_id=work_order_id,
+        created_at=checked_at,
+    )
+
+    return RedDogOpenClawAdapterDryRunResult(
+        decision=ADAPTER_DRYRUN_ACCEPT,
+        work_order_id=work_order_id,
+        proposed_intake=proposed,
+        adapter_receipt=receipt,
+        rejection_reasons=[],
+        no_enqueue_performed=True,
+        no_execution_performed=True,
+    )
+
+
+__all__ = [
+    "ADAPTER_DRYRUN_ACCEPT",
+    "ADAPTER_DRYRUN_REJECT",
+    "AdapterDryRunReceipt",
+    "ProposedOpenClawIntakeRecord",
+    "RedDogOpenClawAdapterDryRunResult",
+    "TARGET_AUTONOMOUS_TASK",
+    "TARGET_FOUNDUP_JOB",
+    "plan_reddog_openclaw_adapter_dryrun",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_adapter_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_adapter_dryrun.py
@@ -1,0 +1,425 @@
+"""Tests for RedDog OpenClaw FoundUpJob adapter dry-run planner."""
+
+from __future__ import annotations
+
+import ast
+import json
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_openclaw_adapter_dryrun import (
+    ADAPTER_DRYRUN_ACCEPT,
+    ADAPTER_DRYRUN_REJECT,
+    plan_reddog_openclaw_adapter_dryrun,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    INTAKE_ASSIGNMENT_DISPATCHER,
+    INTAKE_AUTONOMOUS_TASK,
+    INTAKE_FOUNDUP_JOB,
+    VALVE_CLOSED,
+    VALVE_OPEN_DRYRUN_ONLY,
+    VALVE_OPEN_WORKTREE_CREATE,
+    ExecutionValveEnvironment,
+    ExecutionValveRequest,
+    evaluate_reddog_execution_valve,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_receipt import (
+    RedDogWorkOrderReceiptStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_runtime_invocation import (
+    invoke_reddog_work_order_dryrun,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_executor_dryrun import (
+    plan_wre_isolated_worktree_execution_dryrun,
+)
+
+
+def _future_expiry(hours: int = 2) -> str:
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).replace(microsecond=0).isoformat()
+
+
+def _fresh_captured() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _base_order(**overrides):
+    payload = {
+        "work_order_id": "wo-adapter-dryrun-001",
+        "created_at": _fresh_captured(),
+        "red_dog_instance_id": "reddog-ext-0.3.28",
+        "authenticated_principal": "principal-012",
+        "principal_provider": "github",
+        "repo_full_name": "FOUNDUPS/Foundups-Agent",
+        "repo_permission_snapshot": {
+            "permission_level": "write",
+            "captured_at": _fresh_captured(),
+            "source": "mock",
+            "digest": "sha256:" + ("a" * 64),
+        },
+        "requested_operation": "feature_slice",
+        "authority_tier": "source",
+        "allowed_paths": ["modules/communication/moltbot_bridge/**"],
+        "denied_paths": [".env"],
+        "branch_name": "feat/reddog-adapter-dryrun-test",
+        "base_ref": "main",
+        "task_summary": "Adapter dry-run validation slice",
+        "wsp_applicability": ["WSP_34", "WSP_50", "WSP_97"],
+        "holoindex_evidence_refs": [
+            "docs/audits/architecture/REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_CONTRACT_PHASE1.md",
+        ],
+        "skillz_candidates": [],
+        "required_tests": [
+            "modules/communication/moltbot_bridge/tests/test_reddog_openclaw_adapter_dryrun.py"
+        ],
+        "required_policy_gates": ["openclaw_policy_gate"],
+        "required_reviewers": [],
+        "sentinel_checks": [],
+        "rollback_plan": "Remove worktree and delete branch on abort.",
+        "expiry": _future_expiry(),
+        "nonce": "nonce-adapter-dryrun-001",
+        "evidence_digest": "sha256:" + ("b" * 64),
+        "advisory_only_source_packet": {
+            "work_focus_digest": "sha256:" + ("c" * 64),
+            "wsp_prompt_digest": "sha256:" + ("d" * 64),
+            "copy_md_run_trace_digest": "sha256:" + ("e" * 64),
+        },
+        "holoindex_evidence": {
+            "holoindex_query": "RedDog OpenClaw adapter dryrun",
+            "holoindex_status": "bundle_json_ok",
+            "code_hits": [],
+            "wsp_hits": ["WSP_framework/src/WSP_34_Git_Operations_Protocol.md"],
+            "skillz_hits": [],
+            "direct_read_fallback_used": False,
+            "index_gap_detected": False,
+            "applicable_wsps": ["WSP_34"],
+            "evidence_refs": [
+                "docs/audits/architecture/REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_CONTRACT_PHASE1.md"
+            ],
+            "retrieval_quality": "HIGH",
+            "skillz_gap_detected": False,
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _full_spine_with_open_valve(*, order=None, intake_target=INTAKE_FOUNDUP_JOB):
+    order = order or _base_order()
+    with tempfile.TemporaryDirectory() as tmp:
+        with RedDogWorkOrderReceiptStore(Path(tmp) / "receipts.db") as store:
+            invocation = invoke_reddog_work_order_dryrun(
+                order,
+                permission_snapshot={
+                    "permission_level": "write",
+                    "captured_at": _fresh_captured(),
+                    "source": "mock",
+                    "digest": order["repo_permission_snapshot"]["digest"],
+                },
+                seen_nonces=set(),
+                receipt_store=store,
+            )
+    executor = plan_wre_isolated_worktree_execution_dryrun(invocation, order)
+    policy_receipt = {
+        "decision": "POLICY_ACCEPT",
+        "receipt_digest": invocation.policy_gate_receipt_digest,
+        "no_execution_performed": True,
+        "work_order_id": order["work_order_id"],
+    }
+    work_order_receipt = {
+        "receipt_id": invocation.receipt_id,
+        "receipt_digest": invocation.receipt_digest,
+        "policy_gate_receipt_digest": invocation.policy_gate_receipt_digest,
+        "no_execution_performed": True,
+        "work_order_id": order["work_order_id"],
+    }
+    valve_request = ExecutionValveRequest(
+        work_order=order,
+        policy_gate_receipt=policy_receipt,
+        reddog_work_order_receipt=work_order_receipt,
+        invocation_result=invocation.to_dict(),
+        executor_plan_result=executor.to_dict(),
+        intake_target=intake_target,
+        permission_snapshot=order["repo_permission_snapshot"],
+    )
+    valve = evaluate_reddog_execution_valve(
+        valve_request, ExecutionValveEnvironment(valve_dryrun_enabled=True)
+    )
+    assert valve.valve_state == VALVE_OPEN_DRYRUN_ONLY
+    return order, policy_receipt, work_order_receipt, invocation, executor, valve
+
+
+class TestAdapterDryRunAccept:
+    def test_foundup_job_proposed_with_open_dryrun_valve(self):
+        order, policy, receipt, invocation, executor, valve = _full_spine_with_open_valve()
+        result = plan_reddog_openclaw_adapter_dryrun(
+            order,
+            policy,
+            receipt,
+            invocation.to_dict(),
+            executor.to_dict(),
+            valve.to_dict(),
+            target_type=INTAKE_FOUNDUP_JOB,
+        )
+        assert result.decision == ADAPTER_DRYRUN_ACCEPT
+        assert result.proposed_intake is not None
+        assert result.proposed_intake.target_type == "foundup_job"
+        assert result.proposed_intake.proposed_job_id.startswith("reddog-fj-")
+        assert result.proposed_intake.requested_action == "build_foundup"
+        assert result.proposed_intake.no_enqueue_performed is True
+        assert result.proposed_intake.no_execution_performed is True
+        assert result.no_enqueue_performed is True
+        assert result.no_execution_performed is True
+        assert result.adapter_receipt.decision == ADAPTER_DRYRUN_ACCEPT
+
+    def test_autonomous_task_proposed_with_open_dryrun_valve(self):
+        order, policy, receipt, invocation, executor, valve = _full_spine_with_open_valve(
+            intake_target=INTAKE_AUTONOMOUS_TASK
+        )
+        result = plan_reddog_openclaw_adapter_dryrun(
+            order,
+            policy,
+            receipt,
+            invocation.to_dict(),
+            executor.to_dict(),
+            valve.to_dict(),
+            target_type=INTAKE_AUTONOMOUS_TASK,
+        )
+        assert result.decision == ADAPTER_DRYRUN_ACCEPT
+        assert result.proposed_intake is not None
+        assert result.proposed_intake.target_type == "autonomous_task"
+        assert result.proposed_intake.proposed_task_id == "reddog-wo-wo-adapter-dryrun-001"
+        assert result.proposed_intake.proposed_job_id is None
+
+
+class TestAdapterDryRunReject:
+    def test_closed_valve_rejects(self):
+        order, policy, receipt, invocation, executor, valve = _full_spine_with_open_valve()
+        closed_valve = valve.to_dict()
+        closed_valve["valve_state"] = VALVE_CLOSED
+        result = plan_reddog_openclaw_adapter_dryrun(
+            order,
+            policy,
+            receipt,
+            invocation.to_dict(),
+            executor.to_dict(),
+            closed_valve,
+        )
+        assert result.decision == ADAPTER_DRYRUN_REJECT
+        assert "execution_valve_closed" in result.rejection_reasons
+
+    def test_worktree_create_valve_rejects(self):
+        order, policy, receipt, invocation, executor, valve = _full_spine_with_open_valve()
+        worktree_valve = valve.to_dict()
+        worktree_valve["valve_state"] = VALVE_OPEN_WORKTREE_CREATE
+        result = plan_reddog_openclaw_adapter_dryrun(
+            order,
+            policy,
+            receipt,
+            invocation.to_dict(),
+            executor.to_dict(),
+            worktree_valve,
+        )
+        assert result.decision == ADAPTER_DRYRUN_REJECT
+        assert "worktree_valve_not_allowed_for_adapter_dryrun" in result.rejection_reasons
+
+    def test_assignment_dispatcher_target_rejects(self):
+        order, policy, receipt, invocation, executor, valve = _full_spine_with_open_valve()
+        result = plan_reddog_openclaw_adapter_dryrun(
+            order,
+            policy,
+            receipt,
+            invocation.to_dict(),
+            executor.to_dict(),
+            valve.to_dict(),
+            target_type=INTAKE_ASSIGNMENT_DISPATCHER,
+        )
+        assert result.decision == ADAPTER_DRYRUN_REJECT
+        assert "assignment_dispatcher_forbidden_target" in result.rejection_reasons
+
+    def test_missing_receipt_chain_rejects(self):
+        order, policy, receipt, invocation, executor, valve = _full_spine_with_open_valve()
+        receipt = dict(receipt)
+        receipt["receipt_digest"] = ""
+        result = plan_reddog_openclaw_adapter_dryrun(
+            order,
+            policy,
+            receipt,
+            invocation.to_dict(),
+            executor.to_dict(),
+            valve.to_dict(),
+        )
+        assert result.decision == ADAPTER_DRYRUN_REJECT
+        assert "missing_reddog_work_order_receipt" in result.rejection_reasons
+
+    def test_missing_executor_plan_rejects(self):
+        order, policy, receipt, invocation, executor, valve = _full_spine_with_open_valve()
+        executor_payload = executor.to_dict()
+        executor_payload["plan"] = None
+        executor_payload["decision"] = "EXECUTOR_PLAN_REJECT"
+        result = plan_reddog_openclaw_adapter_dryrun(
+            order,
+            policy,
+            receipt,
+            invocation.to_dict(),
+            executor_payload,
+            valve.to_dict(),
+        )
+        assert result.decision == ADAPTER_DRYRUN_REJECT
+        assert "executor_plan_not_accepted" in result.rejection_reasons
+        assert "missing_executor_plan" in result.rejection_reasons
+
+    def test_path_scope_violation_rejects(self):
+        order, policy, receipt, invocation, executor, valve = _full_spine_with_open_valve()
+        order = dict(order)
+        order["allowed_paths"] = ["docs/**"]
+        executor_payload = executor.to_dict()
+        result = plan_reddog_openclaw_adapter_dryrun(
+            order,
+            policy,
+            receipt,
+            invocation.to_dict(),
+            executor_payload,
+            valve.to_dict(),
+        )
+        assert result.decision == ADAPTER_DRYRUN_REJECT
+        assert "path_outside_allowed_scope" in result.rejection_reasons
+
+
+class TestAdapterDryRunStability:
+    def test_deterministic_digest_and_json_serializable(self):
+        fixed = datetime(2026, 6, 28, 20, 0, 0, tzinfo=timezone.utc)
+        captured = (fixed - timedelta(seconds=60)).replace(microsecond=0).isoformat()
+        order = _base_order(
+            nonce="nonce-stable-adapter",
+            repo_permission_snapshot={
+                "permission_level": "write",
+                "captured_at": captured,
+                "source": "mock",
+                "digest": "sha256:" + ("f" * 64),
+            },
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            with RedDogWorkOrderReceiptStore(Path(tmp) / "receipts.db") as store:
+                invocation = invoke_reddog_work_order_dryrun(
+                    order,
+                    permission_snapshot={
+                        "permission_level": "write",
+                        "captured_at": captured,
+                        "source": "mock",
+                        "digest": order["repo_permission_snapshot"]["digest"],
+                    },
+                    seen_nonces=set(),
+                    receipt_store=store,
+                    now=fixed,
+                )
+        executor = plan_wre_isolated_worktree_execution_dryrun(invocation, order, now=fixed)
+        policy = {
+            "decision": "POLICY_ACCEPT",
+            "receipt_digest": invocation.policy_gate_receipt_digest,
+            "no_execution_performed": True,
+        }
+        receipt = {
+            "receipt_id": invocation.receipt_id,
+            "receipt_digest": invocation.receipt_digest,
+            "policy_gate_receipt_digest": invocation.policy_gate_receipt_digest,
+            "no_execution_performed": True,
+        }
+        valve = evaluate_reddog_execution_valve(
+            ExecutionValveRequest(
+                work_order=order,
+                policy_gate_receipt=policy,
+                reddog_work_order_receipt=receipt,
+                invocation_result=invocation.to_dict(),
+                executor_plan_result=executor.to_dict(),
+                intake_target=INTAKE_FOUNDUP_JOB,
+                permission_snapshot=order["repo_permission_snapshot"],
+            ),
+            ExecutionValveEnvironment(valve_dryrun_enabled=True),
+            now=fixed,
+        )
+        first = plan_reddog_openclaw_adapter_dryrun(
+            order,
+            policy,
+            receipt,
+            invocation.to_dict(),
+            executor.to_dict(),
+            valve.to_dict(),
+            now=fixed,
+        )
+        second = plan_reddog_openclaw_adapter_dryrun(
+            order,
+            policy,
+            receipt,
+            invocation.to_dict(),
+            executor.to_dict(),
+            valve.to_dict(),
+            now=fixed,
+        )
+        assert first.proposed_intake is not None
+        assert first.proposed_intake.proposed_job_id == second.proposed_intake.proposed_job_id
+        assert first.adapter_receipt.adapter_receipt_id == second.adapter_receipt.adapter_receipt_id
+        assert first.adapter_receipt.adapter_receipt_digest == second.adapter_receipt.adapter_receipt_digest
+        json.dumps(first.to_dict())
+
+
+class TestNoEnqueueBoundary:
+    def test_no_enqueue_no_execution_always(self):
+        order, policy, receipt, invocation, executor, valve = _full_spine_with_open_valve()
+        result = plan_reddog_openclaw_adapter_dryrun(
+            order,
+            policy,
+            receipt,
+            invocation.to_dict(),
+            executor.to_dict(),
+            valve.to_dict(),
+        )
+        assert result.no_enqueue_performed is True
+        assert result.no_execution_performed is True
+
+    def test_ast_denylist(self):
+        module_path = (
+            Path(__file__).resolve().parents[1] / "src" / "reddog_openclaw_adapter_dryrun.py"
+        )
+        source = module_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imported: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.append(node.module)
+        forbidden = [
+            name
+            for name in imported
+            if any(
+                token in name
+                for token in (
+                    "subprocess",
+                    "github_integration",
+                    "wre_core",
+                    "skillz",
+                    "agent_db",
+                    "hermes_job_executor",
+                    "openclaw_supervisor",
+                )
+            )
+        ]
+        assert forbidden == []
+        for token in (
+            "import subprocess",
+            "git worktree",
+            "worktree add",
+            "create_branch",
+            "merge_pull_request",
+            "git ",
+            "gh ",
+            "os.mkdir",
+            "Path.mkdir",
+            "execute_skill",
+            "create_autonomous_task(",
+            "get_autonomous_tasks(",
+            "queue.append(",
+            "supervisor.enqueue",
+        ):
+            assert token not in source


### PR DESCRIPTION
## Summary
- Add `plan_reddog_openclaw_adapter_dryrun()` to translate gated RedDog spine + `VALVE_OPEN_DRYRUN_ONLY` into proposed FoundUpJob or AgentDB `autonomous_task` intake records.
- Emit `RedDogOpenClawAdapterDryRunResult` with adapter receipt; always `no_enqueue_performed` and `no_execution_performed`.
- Contract doc + 11 pytest cases + AST denylist; extension/moltbot_bridge pointers updated.

## Key invariant
Propose the OpenClaw intake record; **do not enqueue it anywhere**.

## Test plan
- [x] `pytest modules/communication/moltbot_bridge/tests/test_reddog_openclaw_adapter_dryrun.py` (11 passed)
- [x] Governance spine tests (108 passed)
- [x] `verify_extension_contract.js`
- [x] `git diff --check` + byte scan clean

## Residual SPECIFIED_NOT_IMPLEMENTED
- Live OpenClaw Supervisor enqueue
- AgentDB writes / FoundUpJob queue append
- Worktree create slice
- HoloIndex ranking (`HOLOINDEX_REDDOG_OPENCLAW_ADAPTER_DRYRUN_INDEX_GAP_PHASE1`)
