### PR TITLE
feat(reddog): path-aware target-recall detector (slice 1/3)

### DIFF
--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -160,8 +160,11 @@ Run Trace HoloIndex scorecard fields (v0.3.22+):
 | --- | --- | --- |
 | `holoindex_status` | Bundle transport result (e.g. `bundle_json_ok`) | OBSERVED |
 | `code_hits_count` | Count of code hits returned | OBSERVED |
-| `target_recall_ok` | Requested target file/symbol appeared in hits | OBSERVED |
-| `index_gap_detected` | Target-specific miss (may be true when `code_hits_count > 0`) | OBSERVED |
+| `target_recall_ok` | Requested target file/symbol appeared in hits (never `unknown` when a required list exists) | OBSERVED |
+| `index_gap_detected` | Target-specific miss (true whenever `required_targets_missing` is non-empty, even when `code_hits_count > 0`) | OBSERVED |
+| `required_targets_total` | Count of paths parsed from an explicit "Required direct-read targets" prompt list (0 = none present) | OBSERVED |
+| `required_targets_recalled` | Required targets whose content-bearing path appeared in the bundle (self-file `extension.js` excluded) | OBSERVED |
+| `required_targets_missing` | Required target paths absent from content (drives `index_gap_detected`) | OBSERVED |
 | `direct_read_fallback_used` | Offline lexical fallback used | OBSERVED |
 | `target_content_included` | Target snippet section present in final bounded context | OBSERVED |
 | `target_content_paths` | Relative paths whose snippets were included | OBSERVED |
@@ -182,11 +185,11 @@ Run Trace Unicode normalization fields (v0.3.24+) and bridge UTF-8 invariant (v0
 
 Bridge child env (v0.3.25+): `PYTHONIOENCODING=utf-8`, `PYTHONUTF8=1`. Python bridge reads stdin via `sys.stdin.buffer` UTF-8 decode so valid Unicode (e.g. U+2014 em dash) is not mis-decoded on Windows before the redaction gate.
 
-`evaluateTargetRecall(taskText, bundleOutput)` and `inferRecallTargetPaths(taskText)` implement target-specific recall inference from bundle `task_retrieval.code_hits`.
+`evaluateTargetRecall(taskText, bundleOutput)` and `inferRecallTargetPaths(taskText)` implement target-specific recall from bundle `task_retrieval.code_hits`. Path-aware detector (REDDOG_TARGET_RECALL_PATH_AWARE_PHASE1, slice 1/3): when the prompt carries an explicit "Required direct-read targets" list, `parseRequiredTargetPaths(taskText)` parses it into repo-relative paths/globs and `evaluateTargetRecall` compares each required path against content-bearing bundle locations, using `isSelfFileLocation()` so retrieving `extension.js` (RedDog itself) can never satisfy a required target. This closes the `content_included(any file) != required_targets_recalled` false negative: `index_gap_detected` is honestly `true` when required targets are absent. Prompts without a required list keep prior inferred-target behavior. This slice is detector-only: it does NOT read required files (slice 2) or change redaction (slice 3).
 
 Target content egress (v0.3.22+): `buildTargetRecallContentSection(root, taskText, maxChars)` reads workspace-confined snippets for inferred recall targets after HoloIndex path ranking. Snippets pass through `sanitizeTargetSnippetForRedaction()` before inclusion (ADDENDUM F); placeholders use neutral `[SANITIZED_BLOCK:NN]` tokens so category names do not re-trigger the Fusion gate. Telemetry reflects the **final** bounded context string assembled by `buildBoundedRepoContext` (before the 42000-char slice). `buildWsp97ProtocolExcerpt(root, maxChars)` adds a bounded WSP_97 protocol excerpt when the task mentions WSP_97 or truth labels.
 
-Exported helpers for contract tests: `isTargetReadPathDenied`, `resolveSafeRepoFile`, `readBoundedTargetSnippet`, `readBoundedTargetSnippets`, `buildTargetRecallContentSection`, `sanitizeTargetSnippetForRedaction`, `taskMentionsWsp97`, `buildWsp97ProtocolExcerpt`.
+Exported helpers for contract tests: `isTargetReadPathDenied`, `resolveSafeRepoFile`, `readBoundedTargetSnippet`, `readBoundedTargetSnippets`, `buildTargetRecallContentSection`, `sanitizeTargetSnippetForRedaction`, `taskMentionsWsp97`, `buildWsp97ProtocolExcerpt`, `parseRequiredTargetPaths`, `isSelfFileLocation`, `requiredTargetMatchesLocation`, `formatHoloIndexScorecardLines`.
 
 ## WSP_97 Truth Boundary
 

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,26 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-01 - REDDOG_TARGET_RECALL_PATH_AWARE_PHASE1 (slice 1/3, detector only)
+
+- File: `extensions/foundups_advisory_workers/extension.js`
+- Problem: on the FoundUp-creation audit run, the run trace reported `index_gap_detected: false` even though
+  none of the 20+ required direct-read targets were retrieved. The only retrieved file was `extension.js`
+  (RedDog itself), and that "content included" falsely satisfied the recall check
+  (`content_included(any file) != required_targets_recalled`).
+- Fix (detector only): `parseRequiredTargetPaths()` parses an explicit "Required direct-read targets" prompt
+  list into repo-relative paths/globs; `evaluateTargetRecall()` now compares that list against content-bearing
+  bundle locations, with a self-file guard (`isSelfFileLocation()`) so retrieving `extension.js` never counts.
+- New truthful scorecard/telemetry fields: `required_targets_total`, `required_targets_recalled`,
+  `required_targets_missing`, honest `target_recall_ok` and `index_gap_detected`
+  (never `unknown` when a required list exists).
+- Backward compatible: prompts with no required-target list preserve prior inferred-target behavior.
+- No file-read added (slice 2), no redaction-category change (slice 3). Advisory boundary preserved.
+- Tests: `holo_index/tests/test_reddog_extension_bundle_recall.py` (4 new: 0/N gap, self-file guard, all-present,
+  backward-compat) + `tests/verify_extension_contract.js` (TRP-001..007 scorecard vocabulary).
+
+WSP: WSP_00, WSP_15, WSP_50, WSP_97, WSP_22.
+
 ## 2026-06-28 - REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_PHASE1 (extension pointers)
 
 - Module: `modules/communication/moltbot_bridge/src/reddog_openclaw_adapter_dryrun.py`

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,15 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-02 - Version bump to 0.3.29 (REDDOG_TARGET_RECALL_PATH_AWARE_PHASE1, slice 1/3)
+
+- Mechanical build-label bump 0.3.28 -> 0.3.29 across LIVE version surfaces so an installed
+  host does not stay stale on this senses-spine slice. No runtime logic change.
+- Surfaces: `package.json`, `extension.js` (`EXTENSION_VERSION`), `README.md` header,
+  `tests/verify_extension_contract.js` LIVE-version assertions.
+
+WSP: WSP_22.
+
 ## 2026-07-01 - REDDOG_TARGET_RECALL_PATH_AWARE_PHASE1 (slice 1/3, detector only)
 
 - File: `extensions/foundups_advisory_workers/extension.js`

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.28
+Version: 0.3.29
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -163,6 +163,19 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 - Add regression retrieval tests so extension bridge code ranks above adjacent WRE routers.
 - **Status:** **LANDED** #882 (`99d0e35c2`) — ranking + target recall telemetry only; not source-content inclusion.
 
+### REDDOG_TARGET_RECALL_PATH_AWARE_PHASE1 (slice 1/3)
+
+- **Status:** DETECTOR ONLY (this slice). Parse an explicit "Required direct-read targets" prompt list; compare against
+  content-bearing bundle locations (path-aware), with a self-file guard so retrieving `extension.js` (RedDog itself)
+  cannot satisfy a required target.
+- Fixes the `content_included(any file) != required_targets_recalled` false negative: RedDog now HONESTLY reports
+  `index_gap_detected=true` when required targets are absent instead of falsely reporting no gap.
+- New scorecard fields: `required_targets_total`, `required_targets_recalled`, `required_targets_missing`,
+  and honest `target_recall_ok` / `index_gap_detected` (never `unknown` when a required list exists).
+- Backward compatible: prompts with no required-target list keep prior inferred-target behavior.
+- **Slice split:** 1/3 = this detector; 2 = direct-read-by-path fetch (0/8 -> 8/8 recall); 3 = audit-mode redaction.
+  This slice makes the blindness VISIBLE; it does NOT add any file-read or change redaction.
+
 ### REDDOG_ALWAYS_HOLOINDEX_GROUNDING_PHASE1
 
 - **Status:** **LANDED** #885 (`888d0c9cc`) — REGULAR auto context `none` -> `wsp_holo`.

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -337,6 +337,128 @@ function resolveProviderReasoningReport(resolvedEffort) {
   };
 }
 
+// Self-file guard: retrieving RedDog itself (or the module-under-audit shell)
+// must never count toward required-target recall. This was the false-positive
+// source in REDDOG_HOLOINDEX_INDEX_GAP_ARCHITECT_REVIEW_PHASE1 where retrieving
+// extension.js falsely satisfied the recall check.
+const TARGET_RECALL_SELF_FILE_BASENAMES = ['extension.js'];
+const TARGET_RECALL_SELF_FILE_PATHS = ['extensions/foundups_advisory_workers/extension.js'];
+
+// Header lines that introduce an explicit required-direct-read-target list in a
+// 012 work focus / prompt. Matched case-insensitively; list items follow until a
+// blank line or a non-list line.
+const REQUIRED_TARGET_HEADER_PATTERNS = [
+  /required\s+direct[\s_-]?read\s+targets?/i,
+  /required\s+read\s+targets?/i,
+  /direct[\s_-]?read\s+targets?\s*(?:\(required\))?/i
+];
+
+function normalizeTargetPath(raw) {
+  return String(raw || '')
+    .replace(/\\/g, '/')
+    .replace(/^[`'"(\[]+/, '')
+    .replace(/[`'")\].,;:]+$/, '')
+    .trim();
+}
+
+// Extract repo-relative path/glob tokens from a single list line. A line may hold
+// one path or a slash-delimited "a / b / c" alternatives list (as prompts often
+// phrase them). Symbol tokens (symbol:foo) are preserved verbatim.
+function extractTargetTokensFromLine(line) {
+  const tokens = [];
+  const body = normalizeTargetPath(line);
+  if (!body) {
+    return tokens;
+  }
+  if (/^symbol:/i.test(body)) {
+    tokens.push('symbol:' + body.slice(7).trim());
+    return tokens;
+  }
+  // Split on whitespace-padded slashes used as "or" separators, or on commas,
+  // while keeping intra-path slashes intact (those have no surrounding spaces).
+  const parts = body.split(/\s*(?:,|\s\/\s|\bor\b)\s*/i);
+  for (const part of parts) {
+    const candidate = normalizeTargetPath(part);
+    if (!candidate) {
+      continue;
+    }
+    // A target must look like a path/glob or a bare source filename.
+    if (/[\/]/.test(candidate) || /\.[a-z0-9]{1,6}$/i.test(candidate) || /[*?]/.test(candidate)) {
+      tokens.push(candidate);
+    }
+  }
+  return tokens;
+}
+
+// Parse an explicit "Required direct-read targets" section from prompt text into
+// a de-duplicated list of repo-relative paths/globs. Returns [] when no such
+// section is present (backward compatible: callers then fall back to inference).
+function parseRequiredTargetPaths(taskText) {
+  const text = String(taskText || '');
+  const lines = text.split(/\r?\n/);
+  const targets = [];
+  const seen = new Set();
+  let capturing = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const stripped = line.trim();
+    if (!capturing) {
+      if (REQUIRED_TARGET_HEADER_PATTERNS.some((pattern) => pattern.test(stripped))) {
+        capturing = true;
+        // Header may itself carry inline targets after a colon.
+        const colonIdx = stripped.indexOf(':');
+        if (colonIdx !== -1) {
+          const inline = stripped.slice(colonIdx + 1);
+          for (const token of extractTargetTokensFromLine(inline)) {
+            const norm = token.toLowerCase();
+            if (!seen.has(norm)) {
+              seen.add(norm);
+              targets.push(token);
+            }
+          }
+        }
+      }
+      continue;
+    }
+    // Capturing mode: stop at a blank line (end of list block).
+    if (!stripped) {
+      break;
+    }
+    // Only consume list-style lines (-, *, digit., or bare path). Stop if a new
+    // prose header appears before any list content is a paragraph, not a target.
+    const listMatch = stripped.match(/^(?:[-*+]|\d+[.)])\s+(.*)$/);
+    const itemText = listMatch ? listMatch[1] : stripped;
+    const tokens = extractTargetTokensFromLine(itemText);
+    if (!tokens.length) {
+      // A non-list, non-path line ends the section.
+      if (!listMatch) {
+        break;
+      }
+      continue;
+    }
+    for (const token of tokens) {
+      const norm = token.toLowerCase();
+      if (!seen.has(norm)) {
+        seen.add(norm);
+        targets.push(token);
+      }
+    }
+  }
+  return targets;
+}
+
+function isSelfFileLocation(location) {
+  const loc = String(location || '').replace(/\\/g, '/').toLowerCase();
+  if (!loc) {
+    return false;
+  }
+  if (TARGET_RECALL_SELF_FILE_PATHS.some((p) => loc === p.toLowerCase() || loc.endsWith('/' + p.toLowerCase()))) {
+    return true;
+  }
+  const base = loc.split('/').pop();
+  return TARGET_RECALL_SELF_FILE_BASENAMES.includes(base);
+}
+
 function inferRecallTargetPaths(taskText) {
   const task = String(taskText || '').toLowerCase();
   const targets = [];
@@ -355,16 +477,92 @@ function inferRecallTargetPaths(taskText) {
   return targets;
 }
 
-function evaluateTargetRecall(taskText, bundleData) {
-  const targets = inferRecallTargetPaths(taskText);
-  if (!targets.length) {
-    return { target_recall_ok: 'unknown', index_gap_detected: false, recall_targets: [] };
+// Match a required repo-relative path/glob against the content-bearing locations
+// actually present in the bundle. Self-file locations are excluded by the caller
+// before this runs so retrieving RedDog itself cannot satisfy a required target.
+function requiredTargetMatchesLocation(target, location) {
+  const want = normalizeTargetPath(target).toLowerCase();
+  const have = String(location || '').replace(/\\/g, '/').toLowerCase();
+  if (!want || !have) {
+    return false;
   }
+  if (have === want) {
+    return true;
+  }
+  // Glob support: translate * and ? to a bounded regex (path-segment safe).
+  if (/[*?]/.test(want)) {
+    const escaped = want.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '[^/]*').replace(/\?/g, '[^/]');
+    const re = new RegExp('(^|/)' + escaped + '$');
+    return re.test(have);
+  }
+  // Basename fallback only when the required token is a bare filename (no dir),
+  // so a required directoried path is not satisfied by an unrelated same-name file.
+  if (!want.includes('/')) {
+    return have.split('/').pop() === want;
+  }
+  return have.endsWith('/' + want);
+}
+
+function evaluateTargetRecall(taskText, bundleData) {
   const hits = bundleData && bundleData.task_retrieval && Array.isArray(bundleData.task_retrieval.code_hits)
     ? bundleData.task_retrieval.code_hits
     : [];
   const locations = hits.map((h) => String(h.location || '').replace(/\\/g, '/').toLowerCase());
   const needs = hits.map((h) => String(h.need || '').toLowerCase());
+
+  // Slice 1: an explicit "Required direct-read targets" list, when present, is the
+  // authoritative recall contract. Compare each required path against content-bearing
+  // locations, excluding self-file hits (extension.js / module-under-audit shell).
+  const required = parseRequiredTargetPaths(taskText);
+  if (required.length) {
+    const contentLocations = locations.filter((loc) => !isSelfFileLocation(loc));
+    const missing = [];
+    let recalled = 0;
+    for (const target of required) {
+      let found = false;
+      if (target.startsWith('symbol:')) {
+        // Symbols cannot be honestly resolved from a path-only bundle; a symbol in
+        // a required list is only satisfied by a non-self content location whose
+        // need/location names it. It must NOT be satisfied by the self-file.
+        const symbol = target.slice(7).toLowerCase();
+        found = hits.some((h) => {
+          const loc = String(h.location || '').replace(/\\/g, '/').toLowerCase();
+          if (isSelfFileLocation(loc)) {
+            return false;
+          }
+          return String(h.need || '').toLowerCase().includes(symbol);
+        });
+      } else {
+        found = contentLocations.some((loc) => requiredTargetMatchesLocation(target, loc));
+      }
+      if (found) {
+        recalled += 1;
+      } else {
+        missing.push(target);
+      }
+    }
+    return {
+      target_recall_ok: missing.length === 0,
+      index_gap_detected: missing.length > 0,
+      recall_targets: required,
+      required_targets_total: required.length,
+      required_targets_recalled: recalled,
+      required_targets_missing: missing
+    };
+  }
+
+  // Backward-compatible inference path (no explicit required list in prompt).
+  const targets = inferRecallTargetPaths(taskText);
+  if (!targets.length) {
+    return {
+      target_recall_ok: 'unknown',
+      index_gap_detected: false,
+      recall_targets: [],
+      required_targets_total: 0,
+      required_targets_recalled: 0,
+      required_targets_missing: []
+    };
+  }
   let allFound = true;
   for (const target of targets) {
     if (target.startsWith('symbol:')) {
@@ -383,7 +581,10 @@ function evaluateTargetRecall(taskText, bundleData) {
   return {
     target_recall_ok: allFound,
     index_gap_detected: !allFound,
-    recall_targets: targets
+    recall_targets: targets,
+    required_targets_total: 0,
+    required_targets_recalled: 0,
+    required_targets_missing: []
   };
 }
 
@@ -400,6 +601,9 @@ function extractHoloIndexScorecard(contextMode, holoMeta) {
     skill_hits: meta.skill_hits !== undefined ? meta.skill_hits : 'unknown',
     target_recall_ok: meta.target_recall_ok !== undefined ? meta.target_recall_ok : 'unknown',
     index_gap_detected: meta.index_gap_detected !== undefined ? meta.index_gap_detected : 'unknown',
+    required_targets_total: meta.required_targets_total !== undefined ? meta.required_targets_total : 'unknown',
+    required_targets_recalled: meta.required_targets_recalled !== undefined ? meta.required_targets_recalled : 'unknown',
+    required_targets_missing: Array.isArray(meta.required_targets_missing) ? meta.required_targets_missing : 'unknown',
     direct_read_fallback_used: meta.direct_read_fallback_used !== undefined ? meta.direct_read_fallback_used : 'unknown',
     target_content_included: meta.target_content_included !== undefined ? meta.target_content_included : 'unknown',
     target_content_paths: Array.isArray(meta.target_content_paths) ? meta.target_content_paths : 'unknown',
@@ -424,6 +628,9 @@ function formatHoloIndexScorecardLines(scorecard) {
     '- skill_hits: ' + scorecard.skill_hits,
     '- target_recall_ok: ' + scorecard.target_recall_ok,
     '- index_gap_detected: ' + scorecard.index_gap_detected,
+    '- required_targets_total: ' + scorecard.required_targets_total,
+    '- required_targets_recalled: ' + scorecard.required_targets_recalled,
+    '- required_targets_missing: ' + (Array.isArray(scorecard.required_targets_missing) ? (scorecard.required_targets_missing.length ? scorecard.required_targets_missing.join(', ') : '(none)') : scorecard.required_targets_missing),
     '- direct_read_fallback_used: ' + scorecard.direct_read_fallback_used,
     '- target_content_included: ' + scorecard.target_content_included,
     '- target_content_paths: ' + (Array.isArray(scorecard.target_content_paths) ? scorecard.target_content_paths.join(', ') : scorecard.target_content_paths),
@@ -2420,7 +2627,10 @@ function holoIndexMetaFromBundle(output, usedOfflineFallback, taskText) {
     skill_hits: 'unknown',
     target_recall_ok: 'unknown',
     index_gap_detected: 'unknown',
-    direct_read_fallback_used: usedOfflineFallback ? true : false
+    direct_read_fallback_used: usedOfflineFallback ? true : false,
+    required_targets_total: 0,
+    required_targets_recalled: 0,
+    required_targets_missing: []
   };
   try {
     const data = JSON.parse(String(output || '{}'));
@@ -2434,6 +2644,9 @@ function holoIndexMetaFromBundle(output, usedOfflineFallback, taskText) {
     meta.index_gap_detected = recall.index_gap_detected;
     meta.direct_read_fallback_used = !!usedOfflineFallback;
     meta.recall_targets = recall.recall_targets;
+    meta.required_targets_total = recall.required_targets_total;
+    meta.required_targets_recalled = recall.required_targets_recalled;
+    meta.required_targets_missing = recall.required_targets_missing;
   } catch (err) {
     meta.holoindex_status = usedOfflineFallback ? 'offline_fallback' : 'parse_error';
   }
@@ -2967,8 +3180,12 @@ module.exports = {
   buildGovernedHandoffSection,
   compositePayloadDigest,
   extractHoloIndexScorecard,
+  formatHoloIndexScorecardLines,
   evaluateTargetRecall,
   inferRecallTargetPaths,
+  parseRequiredTargetPaths,
+  isSelfFileLocation,
+  requiredTargetMatchesLocation,
   holoIndexMetaFromBundle,
   isTargetReadPathDenied,
   resolveSafeRepoFile,

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.28';
+const EXTENSION_VERSION = '0.3.29';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups®Agent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.28",
+    "version":  "0.3.29",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/fixtures.js
+++ b/extensions/foundups_advisory_workers/tests/fixtures.js
@@ -59,6 +59,26 @@ const REPAIR_TAIL_SUPPLEMENT = [
   '012 confirms Run Trace shows repair_minimal + openrouter_single, then land if validation passes.'
 ].join('\n\n');
 
+// REDDOG_TARGET_RECALL_PATH_AWARE_PHASE1 (slice 1/3): a FoundUp-creation audit
+// prompt carrying an explicit "Required direct-read targets" list. The detector
+// must honestly report index_gap_detected when none of these are recalled.
+const FOUNDUP_REQUIRED_TARGETS = [
+  'WSP_framework/src/WSP_109_FoundUp_Onboarding_Protocol.md',
+  'modules/infrastructure/openclaw/src/openclaw_foundup_orchestrator.py',
+  'modules/communication/moltbot_bridge/src/hermes_foundup_job_executor.py'
+];
+
+const FOUNDUP_CREATION_PROMPT = [
+  'Audit the FoundUp creation monorepo WSP_109 execution path.',
+  '',
+  'Required direct-read targets:',
+  '- ' + FOUNDUP_REQUIRED_TARGETS[0],
+  '- ' + FOUNDUP_REQUIRED_TARGETS[1],
+  '- ' + FOUNDUP_REQUIRED_TARGETS[2],
+  '',
+  'Produce required RedDog architect output sections per contract.'
+].join('\n');
+
 const TARGET_READ_DENIED_PATHS = [
   ['C:/Windows/System32/drivers/etc/hosts', 'absolute path'],
   ['../outside.txt', 'traversal'],
@@ -79,5 +99,7 @@ module.exports = {
   REPAIR_DRAFT_WITH_BLOCK_LITERALS,
   REPAIR_SUPPLEMENT_SECTIONS,
   REPAIR_TAIL_SUPPLEMENT,
-  TARGET_READ_DENIED_PATHS
+  TARGET_READ_DENIED_PATHS,
+  FOUNDUP_REQUIRED_TARGETS,
+  FOUNDUP_CREATION_PROMPT
 };

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -687,6 +687,91 @@ const recallMiss = orchestrator.evaluateTargetRecall('Review extensions/foundups
 });
 assert.strictEqual(recallMiss.target_recall_ok, false, 'target recall must fail when only adjacent paths hit');
 assert.strictEqual(recallMiss.index_gap_detected, true, 'index_gap must be true on target-specific miss');
+
+// REDDOG_TARGET_RECALL_PATH_AWARE_PHASE1 (slice 1/3): path-aware required-target detector.
+includes(extensionJs, 'function parseRequiredTargetPaths', 'required-target parser missing');
+includes(extensionJs, 'function isSelfFileLocation', 'self-file guard missing');
+includes(extensionJs, 'required_targets_total', 'required_targets_total scorecard field missing');
+includes(extensionJs, 'required_targets_recalled', 'required_targets_recalled scorecard field missing');
+includes(extensionJs, 'required_targets_missing', 'required_targets_missing scorecard field missing');
+
+// TRP-001: explicit required list is parsed into repo-relative paths.
+const trpParsed = orchestrator.parseRequiredTargetPaths(fixtures.FOUNDUP_CREATION_PROMPT);
+assert.strictEqual(trpParsed.length, fixtures.FOUNDUP_REQUIRED_TARGETS.length, 'TRP-001: parser must recover every required target');
+for (const req of fixtures.FOUNDUP_REQUIRED_TARGETS) {
+  assert(trpParsed.includes(req), 'TRP-001: parser must include ' + req);
+}
+assert.strictEqual(orchestrator.parseRequiredTargetPaths('Review extension.js for WSP_97').length, 0, 'TRP-001: no required list => empty parse (backward compatible)');
+
+// TRP-002: 0 of N required targets in bundle => honest blind report.
+const trpMissAll = orchestrator.evaluateTargetRecall(fixtures.FOUNDUP_CREATION_PROMPT, {
+  task_retrieval: { code_hits: [{ location: 'docs/unrelated.md', need: 'path match: unrelated.md' }] }
+});
+assert.strictEqual(trpMissAll.index_gap_detected, true, 'TRP-002: 0/N required must set index_gap_detected=true');
+assert.strictEqual(trpMissAll.target_recall_ok, false, 'TRP-002: 0/N required must set target_recall_ok=false');
+assert.strictEqual(trpMissAll.required_targets_total, fixtures.FOUNDUP_REQUIRED_TARGETS.length, 'TRP-002: required_targets_total must equal N');
+assert.strictEqual(trpMissAll.required_targets_recalled, 0, 'TRP-002: required_targets_recalled must be 0');
+assert.strictEqual(trpMissAll.required_targets_missing.length, fixtures.FOUNDUP_REQUIRED_TARGETS.length, 'TRP-002: all required must be missing');
+for (const req of fixtures.FOUNDUP_REQUIRED_TARGETS) {
+  assert(trpMissAll.required_targets_missing.includes(req), 'TRP-002: missing list must name ' + req);
+}
+
+// TRP-003: self-file guard - retrieving ONLY extension.js must NOT satisfy required targets.
+const trpSelfOnly = orchestrator.evaluateTargetRecall(fixtures.FOUNDUP_CREATION_PROMPT, {
+  task_retrieval: { code_hits: [{ location: 'extensions/foundups_advisory_workers/extension.js', need: 'path match: extension.js' }] }
+});
+assert.strictEqual(trpSelfOnly.index_gap_detected, true, 'TRP-003: self-file only must set index_gap_detected=true');
+assert.strictEqual(trpSelfOnly.required_targets_recalled, 0, 'TRP-003: self-file must not count toward required recall');
+assert(orchestrator.isSelfFileLocation('extensions/foundups_advisory_workers/extension.js'), 'TRP-003: extension.js path must be self-file');
+assert(orchestrator.isSelfFileLocation('some/other/extension.js'), 'TRP-003: extension.js basename must be self-file');
+assert(!orchestrator.isSelfFileLocation('WSP_framework/src/WSP_109_FoundUp_Onboarding_Protocol.md'), 'TRP-003: required target must not be self-file');
+
+// TRP-004: all required targets present in content => honest satisfied report.
+const trpAllPresent = orchestrator.evaluateTargetRecall(fixtures.FOUNDUP_CREATION_PROMPT, {
+  task_retrieval: { code_hits: fixtures.FOUNDUP_REQUIRED_TARGETS.map((p) => ({ location: p, need: 'path match: ' + p })) }
+});
+assert.strictEqual(trpAllPresent.index_gap_detected, false, 'TRP-004: all required present must set index_gap_detected=false');
+assert.strictEqual(trpAllPresent.target_recall_ok, true, 'TRP-004: all required present must set target_recall_ok=true');
+assert.strictEqual(trpAllPresent.required_targets_recalled, fixtures.FOUNDUP_REQUIRED_TARGETS.length, 'TRP-004: required_targets_recalled must equal N');
+assert.strictEqual(trpAllPresent.required_targets_missing.length, 0, 'TRP-004: no required target may be missing');
+
+// TRP-005: self-file plus required targets present => required still satisfied (self-file ignored, not penalized).
+const trpMixed = orchestrator.evaluateTargetRecall(fixtures.FOUNDUP_CREATION_PROMPT, {
+  task_retrieval: { code_hits: [{ location: 'extensions/foundups_advisory_workers/extension.js', need: 'self' }].concat(
+    fixtures.FOUNDUP_REQUIRED_TARGETS.map((p) => ({ location: p, need: 'path match: ' + p }))
+  ) }
+});
+assert.strictEqual(trpMixed.target_recall_ok, true, 'TRP-005: self-file alongside required targets must still satisfy recall');
+assert.strictEqual(trpMixed.required_targets_recalled, fixtures.FOUNDUP_REQUIRED_TARGETS.length, 'TRP-005: self-file must not reduce recalled count');
+
+// TRP-006: backward-compat - no required list preserves prior inference behavior and never claims unknown as a gap.
+const trpLegacy = orchestrator.evaluateTargetRecall('Review extensions/foundups_advisory_workers/extension.js for WSP_97', {
+  task_retrieval: { code_hits: [{ location: 'extensions/foundups_advisory_workers/extension.js', need: 'path match: extension.js' }] }
+});
+assert.strictEqual(trpLegacy.target_recall_ok, true, 'TRP-006: legacy inferred recall must still pass');
+assert.strictEqual(trpLegacy.index_gap_detected, false, 'TRP-006: legacy inferred recall must not flag gap');
+assert.strictEqual(trpLegacy.required_targets_total, 0, 'TRP-006: legacy path reports zero required targets');
+
+const trpEmptyMeta = orchestrator.evaluateTargetRecall('generic task with no targets', { task_retrieval: { code_hits: [] } });
+assert.strictEqual(trpEmptyMeta.target_recall_ok, 'unknown', 'TRP-006: no targets at all must remain unknown, not a false gap');
+assert.strictEqual(trpEmptyMeta.index_gap_detected, false, 'TRP-006: unknown recall must not fabricate a gap');
+
+// TRP-007: scorecard surfaces the truthful required-target vocabulary for the blind case.
+const trpScorecard = orchestrator.extractHoloIndexScorecard('wsp_holo', {
+  target_recall_ok: false,
+  index_gap_detected: true,
+  required_targets_total: 3,
+  required_targets_recalled: 0,
+  required_targets_missing: fixtures.FOUNDUP_REQUIRED_TARGETS.slice()
+});
+const trpScorecardLines = orchestrator.formatHoloIndexScorecardLines(trpScorecard).join('\n');
+assert.strictEqual(trpScorecard.required_targets_total, 3, 'TRP-007: scorecard required_targets_total must pass through');
+assert.strictEqual(trpScorecard.required_targets_recalled, 0, 'TRP-007: scorecard required_targets_recalled must pass through');
+assert(Array.isArray(trpScorecard.required_targets_missing) && trpScorecard.required_targets_missing.length === 3, 'TRP-007: scorecard required_targets_missing must be preserved');
+includes(trpScorecardLines, '- required_targets_total: 3', 'TRP-007: rendered scorecard must show required_targets_total');
+includes(trpScorecardLines, '- required_targets_recalled: 0', 'TRP-007: rendered scorecard must show required_targets_recalled');
+includes(trpScorecardLines, '- required_targets_missing: ', 'TRP-007: rendered scorecard must show required_targets_missing');
+
 includes(blockedCopy, '## Governed Handoff Recommendation', 'substantive task must include governed handoff recommendation');
 includes(blockedCopy, 'handoff_needed: unknown', 'blocked-local packet must use conservative handoff_needed');
 includes(blockedCopy, 'reason: blocked_context_needs_local_0102_review', 'blocked-local packet must include conservative handoff reason');

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -83,8 +83,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.28', 'package version must be 0.3.28');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.28'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.29', 'package version must be 0.3.29');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.29'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups®Agent', 'display name must be Foundups®Agent');
 includes(JSON.stringify(pkg), 'Foundups®Agent: Open', 'command title must use Foundups®Agent');
@@ -101,7 +101,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.28', 'README version mismatch');
+includes(readme, 'Version: 0.3.29', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -838,7 +838,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.28'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.29'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -852,7 +852,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.28'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.29'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -864,7 +864,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.28'", 'bounded context must include extension.js source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.29'", 'bounded context must include extension.js source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');

--- a/holo_index/tests/test_reddog_extension_bundle_recall.py
+++ b/holo_index/tests/test_reddog_extension_bundle_recall.py
@@ -3,6 +3,8 @@
 
 import json
 import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -12,6 +14,68 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
 from holo_index.cli.commands.bundle_json import _lexical_task_retrieval, _resolve_module_dir
+
+EXTENSION_JS = REPO_ROOT / "extensions" / "foundups_advisory_workers" / "extension.js"
+
+# REDDOG_TARGET_RECALL_PATH_AWARE_PHASE1 (slice 1/3): the detector under test is
+# evaluateTargetRecall in extension.js. These required targets mirror the
+# FoundUp-creation audit prompt whose run trace falsely reported no index gap.
+FOUNDUP_REQUIRED_TARGETS = [
+    "WSP_framework/src/WSP_109_FoundUp_Onboarding_Protocol.md",
+    "modules/infrastructure/openclaw/src/openclaw_foundup_orchestrator.py",
+    "modules/communication/moltbot_bridge/src/hermes_foundup_job_executor.py",
+]
+
+FOUNDUP_CREATION_PROMPT = (
+    "Audit the FoundUp creation monorepo WSP_109 execution path.\n"
+    "\n"
+    "Required direct-read targets:\n"
+    "- " + FOUNDUP_REQUIRED_TARGETS[0] + "\n"
+    "- " + FOUNDUP_REQUIRED_TARGETS[1] + "\n"
+    "- " + FOUNDUP_REQUIRED_TARGETS[2] + "\n"
+    "\n"
+    "Produce required RedDog architect output sections per contract.\n"
+)
+
+
+def _node_available() -> bool:
+    return shutil.which("node") is not None
+
+
+def _run_target_recall(task_text: str, code_hits: list[dict]) -> dict:
+    """Invoke evaluateTargetRecall (extension.js) via node and return its JSON."""
+    driver = (
+        "const path=require('path');const Module=require('module');"
+        "const root=process.argv[1];"
+        "const extDir=path.join(root,'extensions','foundups_advisory_workers');"
+        "const vscodeMock={window:{activeTextEditor:null,visibleTextEditors:[]},"
+        "workspace:{workspaceFolders:[{uri:{fsPath:root}}],getConfiguration:()=>({get:(_k,f)=>f})},"
+        "commands:{registerCommand:()=>({dispose(){}})},env:{clipboard:{writeText:async()=>{}}},"
+        "Uri:{joinPath:()=>({fsPath:''})},ViewColumn:{Beside:2}};"
+        "const vscodePath=path.join(extDir,'node_modules','vscode','index.js');"
+        "require.cache[vscodePath]={exports:vscodeMock,loaded:true,id:vscodePath};"
+        "const origResolve=Module._resolveFilename;"
+        "Module._resolveFilename=function(r,p,m,o){if(r==='vscode')return vscodePath;"
+        "return origResolve.call(this,r,p,m,o);};"
+        "const orch=require(path.join(extDir,'extension.js'));"
+        "Module._resolveFilename=origResolve;"
+        "const input=JSON.parse(require('fs').readFileSync(0,'utf8'));"
+        "const out=orch.evaluateTargetRecall(input.task,{task_retrieval:{code_hits:input.code_hits}});"
+        "process.stdout.write(JSON.stringify(out));"
+    )
+    proc = subprocess.run(
+        ["node", "-e", driver, str(REPO_ROOT)],
+        input=json.dumps({"task": task_text, "code_hits": code_hits}),
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(proc.stdout.strip())
+
+
+def _hits(*locations: str) -> list[dict]:
+    return [{"location": loc, "need": "path match: " + loc.split("/")[-1]} for loc in locations]
 
 
 def _code_locations(payload: dict) -> list[str]:
@@ -92,3 +156,61 @@ def test_bundle_json_cli_extension_js_recall(ssd_path, tmp_path, monkeypatch):
     locs = _code_locations(bundle.get("task_retrieval") or {})
     assert bundle.get("ok") is True
     assert "extensions/foundups_advisory_workers/extension.js" in locs[:3]
+
+
+# --- REDDOG_TARGET_RECALL_PATH_AWARE_PHASE1 (slice 1/3) path-aware detector -------------
+
+requires_node = pytest.mark.skipif(not _node_available(), reason="node runtime required for evaluateTargetRecall")
+
+
+@requires_node
+def test_required_targets_zero_recalled_flags_index_gap():
+    """0 of N required direct-read targets in bundle => honest blind report."""
+    result = _run_target_recall(FOUNDUP_CREATION_PROMPT, _hits("docs/unrelated_note.md"))
+    assert result["index_gap_detected"] is True
+    assert result["target_recall_ok"] is False
+    assert result["required_targets_total"] == len(FOUNDUP_REQUIRED_TARGETS)
+    assert result["required_targets_recalled"] == 0
+    assert sorted(result["required_targets_missing"]) == sorted(FOUNDUP_REQUIRED_TARGETS)
+
+
+@requires_node
+def test_self_file_only_does_not_satisfy_required_recall():
+    """A bundle containing ONLY extension.js must not count toward required recall."""
+    result = _run_target_recall(
+        FOUNDUP_CREATION_PROMPT,
+        _hits("extensions/foundups_advisory_workers/extension.js"),
+    )
+    assert result["index_gap_detected"] is True
+    assert result["target_recall_ok"] is False
+    assert result["required_targets_recalled"] == 0
+    assert sorted(result["required_targets_missing"]) == sorted(FOUNDUP_REQUIRED_TARGETS)
+
+
+@requires_node
+def test_all_required_targets_present_no_index_gap():
+    """All required targets present in content => index_gap_detected=false."""
+    result = _run_target_recall(FOUNDUP_CREATION_PROMPT, _hits(*FOUNDUP_REQUIRED_TARGETS))
+    assert result["index_gap_detected"] is False
+    assert result["target_recall_ok"] is True
+    assert result["required_targets_recalled"] == len(FOUNDUP_REQUIRED_TARGETS)
+    assert result["required_targets_missing"] == []
+
+
+@requires_node
+def test_no_required_list_preserves_prior_behavior():
+    """Backward-compat: no required-target list => prior inference behavior."""
+    result = _run_target_recall(
+        "Review extensions/foundups_advisory_workers/extension.js for WSP_97",
+        _hits("extensions/foundups_advisory_workers/extension.js"),
+    )
+    # Inference path: extension.js is the inferred target and it was recalled.
+    assert result["target_recall_ok"] is True
+    assert result["index_gap_detected"] is False
+    assert result["required_targets_total"] == 0
+
+    unknown = _run_target_recall("generic task with no recall targets", [])
+    # No explicit list AND no inferred targets => unknown, never a fabricated gap.
+    assert unknown["target_recall_ok"] == "unknown"
+    assert unknown["index_gap_detected"] is False
+    assert unknown["required_targets_total"] == 0


### PR DESCRIPTION
## Slice 1/3 — detector only (no fetch, no redaction change)

Make RedDog **honestly report when it is blind**. This is slice 1 of a 3-slice split (architect-mandated).

### False-negative evidence
On the RedDog run of `REDDOG_FOUNDUP_CREATION_MONOREPO_WSP109_EXECUTION_PATH_AUDIT_PHASE1`, the run trace reported `index_gap_detected: false` even though **none** of the 20+ required direct-read targets were retrieved. The only retrieved file was `extension.js` (RedDog itself), and that "content included" falsely satisfied the recall check.

Root cause (`extensions/foundups_advisory_workers/extension.js`, pre-change):
- `inferRecallTargetPaths` only maps a few hardcoded keyword patterns to targets; it never parses an explicit "Required direct-read targets" list, so a FoundUp-creation prompt listing WSP_109 / `openclaw_foundup_orchestrator.py` / `hermes_foundup_job_executor.py` produced **zero** inferred targets -> `evaluateTargetRecall` returned `target_recall_ok: 'unknown'`, `index_gap_detected: false`.
- The symbol path had a self-file false positive: `locations.some((loc) => loc.endsWith('extension.js'))` — retrieving RedDog itself satisfied recall.

This is `bundle_json_ok != target_recall_ok` (ref `REDDOG_HOLOINDEX_INDEX_GAP_ARCHITECT_REVIEW_PHASE1`) resurfacing as `content_included(any file) != required_targets_recalled`.

### What slice 1 does
- `parseRequiredTargetPaths(taskText)` — parse an explicit "Required direct-read targets" prompt list into repo-relative paths/globs. No list -> `[]` (backward compatible).
- `evaluateTargetRecall` — when a required list exists, compare each required path against **content-bearing** bundle locations (path-aware, glob-aware), with `isSelfFileLocation()` self-file guard so `extension.js` (or the module shell) never counts toward required recall.
- Truthful scorecard/telemetry fields (added, existing preserved): `required_targets_total`, `required_targets_recalled`, `required_targets_missing`, honest `target_recall_ok` and `index_gap_detected` (never `unknown` when a required list exists).
- **No file-read added** (that is slice 2). **No redaction-category change** (that is slice 3). If retrieval missed targets, the correct slice-1 outcome is `index_gap_detected=true` + honest scorecard, NOT a fetch.

### Slice split
1. **This PR** — path-aware target-recall detector (make blindness VISIBLE).
2. direct-read-by-path fetch (0/8 -> 8/8 recall).
3. audit-mode redaction.

### Slice-1 acceptance (demonstrated)
Simulating the FoundUp target list against a bundle that lacks them (only `extension.js` retrieved):

```
index_gap_detected: true
target_recall_ok: false
required_targets_total: 3
required_targets_recalled: 0
required_targets_missing:
  - WSP_framework/src/WSP_109_FoundUp_Onboarding_Protocol.md
  - modules/infrastructure/openclaw/src/openclaw_foundup_orchestrator.py
  - modules/communication/moltbot_bridge/src/hermes_foundup_job_executor.py
```

Blindness is now VISIBLE. (0/8 -> 8/8 is the slice-2+3 golden bar, not slice 1.)

### Tests
- `holo_index/tests/test_reddog_extension_bundle_recall.py`: 4 new (0/N gap, self-file guard, all-present, backward-compat) — all pass.
- `tests/verify_extension_contract.js`: TRP-001..007 for the new scorecard vocabulary — passes.

### Pre-existing failures (NOT introduced here, out of slice-1 scope)
`test_extension_js_in_top_hits_for_review_query` and `test_bundle_json_cli_extension_js_recall` fail **identically at the base SHA** before any change in this branch — a lexical-ranking bug in the Python `_lexical_task_retrieval` scorer (`verify_extension_contract.js` / `package.json` outrank `extension.js`). Top-5 ranking is byte-identical with and without this diff. Fixing retrieval ranking is explicitly out of slice-1 scope ("detector only — do NOT fix retrieval yet"); these failures are exactly the blindness this arc exists to surface.

### Validation
- `node --check extension.js`: OK
- `node tests/verify_extension_contract.js`: passed
- `pytest test_reddog_extension_bundle_recall.py`: 4 new pass (+2 pre-existing lexical failures, see above)
- `git diff --check`: clean
- mojibake scan on added lines: 0 non-ASCII

🤖 Generated with [Claude Code](https://claude.com/claude-code)
