### PR TITLE
feat(reddog): audit-mode redaction preserves governance structure (slice 3/3)

### DIFF
--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,34 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-02 - Version bump to 0.3.31 (REDDOG_AUDIT_MODE_REDACTION_PHASE1, slice 3/3)
+
+- Mechanical build-label bump 0.3.30 -> 0.3.31 across LIVE version surfaces.
+- Surfaces: `package.json`, `extension.js` (`EXTENSION_VERSION`), `README.md` header,
+  `tests/verify_extension_contract.js` LIVE-version assertions.
+
+WSP: WSP_22.
+
+## 2026-07-01 - REDDOG_AUDIT_MODE_REDACTION_PHASE1 (slice 3/3, structure-preserving redaction)
+
+- Files: `modules/communication/moltbot_bridge/src/fusion_redaction_gate.py` (audit_mode + structural
+  categories + audit value redactors), `.../src/fusion_alias_live.py` (`audit_context` param),
+  `extensions/foundups_advisory_workers/extension.js` (`buildDirectReadContentSection` surfaces
+  `audit_context=true` when slice-2 direct-read fetched required governance targets).
+- Goal: fix the FoundUp-creation over-sanitization -- `source_authority`, `merge_authorization`,
+  `cabr_payout_authority`, `governance_instruction` matched on the bare identifier and BLOCKED the whole
+  fetched payload, hiding the enum members / field names / gate ordering a governance audit must read.
+- Value-vs-structure line: audit_mode PRESERVES identifiers (enum members `SourceAuthority.MONOREPO_POC`,
+  field names, `CANONICAL_ACTIONS` incl. `build_foundup`/`extract_foundup`, valve gate names, WSP refs)
+  and STILL REDACTS every secret VALUE / payout AMOUNT / authorization TOKEN / private_reasoning free-text.
+- SAFETY: audit_mode never relaxes `private_reasoning`, `private_key_residual`, or any REDACT category.
+  Fake `sk-...` key / OAuth token / payout amount / merge token remain `[REDACTED]` in audit mode.
+- Trigger: OFF by default (backward compatible; non-audit path byte-identical). ON only for audit-context
+  retrieval (direct-read of required targets). No detector/fetch/allowlist change; no execution/write/shell.
+- Tests: 14 audit-mode unit tests in `modules/communication/moltbot_bridge/tests/test_fusion_redaction_gate.py`
+  (79/79 pass); DRF-008 (structure readable in audit mode) + DRF-009 (secret STILL redacted) in
+  `tests/verify_extension_contract.js`. INTERFACE truth-boundary rows 27-32 added (32/32 YES).
+
 ## 2026-07-02 - Version bump to 0.3.30 (REDDOG_DIRECT_READ_FALLBACK_BY_PATH_PHASE1, slice 2/3)
 
 - Mechanical build-label bump 0.3.29 -> 0.3.30 across LIVE version surfaces.

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.30
+Version: 0.3.31
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.30';
+const EXTENSION_VERSION = '0.3.31';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -2779,11 +2779,18 @@ function holoIndexOutput(root, taskText, maxChars) {
 
 // Render the Python-fetched direct-read target content (already budget-bounded
 // and security-allowlisted by bundle_json.py) into a dedicated bounded section.
-// This does NOT re-read the filesystem and does NOT apply any redaction-category
-// logic (slice 3); the assembled context still passes through the existing
-// Python egress redaction gate unchanged before leaving the machine.
+// This does NOT re-read the filesystem and does NOT apply any redaction logic here;
+// the assembled context still passes through the existing Python egress redaction
+// gate before leaving the machine.
+//
+// REDDOG_AUDIT_MODE_REDACTION_PHASE1 (slice 3/3): when direct-read fetched required
+// targets (slice-2 fallback), this IS an audit-context retrieval. The section carries
+// an audit_context=true signal so the egress redaction gate can run in audit_mode --
+// preserving STRUCTURAL governance identifiers while STILL redacting every secret
+// VALUE / payout AMOUNT / authorization TOKEN. audit_context stays false when no
+// direct-read fetch occurred (backward compatible; default egress path unchanged).
 function buildDirectReadContentSection(output) {
-  const empty = { text: '', paths: [], chars: 0 };
+  const empty = { text: '', paths: [], chars: 0, audit_context: false };
   let data;
   try {
     data = JSON.parse(String(output || '{}'));
@@ -2810,10 +2817,14 @@ function buildDirectReadContentSection(output) {
   }
   return {
     text: '### Direct-read target content (governed fetch by path)\n'
-      + 'Fetched by the Python bundle layer under the direct-read allowlist; still redaction-gated before egress.\n\n'
+      + 'Fetched by the Python bundle layer under the direct-read allowlist; still redaction-gated before egress '
+      + '(audit-mode: governance STRUCTURE readable, secret/payout/authority VALUES redacted).\n\n'
       + sections.join('\n\n'),
     paths: paths,
-    chars: used
+    chars: used,
+    // Direct-read of required targets == governance audit context. The egress gate
+    // uses this to run in audit_mode (structure-preserving, value-redacting).
+    audit_context: true
   };
 }
 

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups®Agent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.30",
+    "version":  "0.3.31",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -46,6 +46,34 @@ function assertFusionRedactionGatePasses(contextText, label) {
   assert.strictEqual(out, 'PASSED', label || 'bounded context must pass fusion redaction gate');
 }
 
+// Audit-mode gate probe (REDDOG_AUDIT_MODE_REDACTION_PHASE1, slice 3/3): runs the
+// egress redaction gate with audit_mode=True and returns the REDACTED context so the
+// caller can assert (a) it PASSED, (b) governance STRUCTURE survived, (c) secret
+// VALUES are gone. Fails the test if the gate blocks.
+function fusionRedactionGateAuditMode(contextText, label) {
+  const script = [
+    'import sys, json',
+    'from modules.communication.moltbot_bridge.src.fusion_redaction_gate import evaluate_redaction_gate, REDACTION_GATE_PASSED',
+    'ctx = sys.stdin.buffer.read().decode("utf-8", errors="replace")',
+    'r = evaluate_redaction_gate("012 work focus digest placeholder for gate probe", ctx, audit_mode=True)',
+    'if r.status != REDACTION_GATE_PASSED:',
+    '    cats = ",".join(r.report.blocked_categories)',
+    '    print("BLOCKED:" + r.reason + ":" + cats)',
+    '    sys.exit(1)',
+    'sys.stdout.write(json.dumps({"redacted_context": r.redacted_context or ""}))'
+  ].join('\n');
+  const out = cp.execFileSync('python', ['-B', '-c', script], {
+    cwd: root,
+    input: Buffer.from(String(contextText || ''), 'utf8'),
+    encoding: 'utf8',
+    timeout: 30000,
+    maxBuffer: 1024 * 1024,
+    env: Object.assign({}, process.env, { PYTHONIOENCODING: 'utf-8', PYTHONUTF8: '1' })
+  }).trim();
+  assert(!out.startsWith('BLOCKED:'), (label || 'audit-mode gate') + ' must PASS in audit mode: ' + out);
+  return JSON.parse(out).redacted_context;
+}
+
 function extractTargetRecallSection(contextText) {
   const marker = '### Target recall content';
   const start = String(contextText || '').indexOf(marker);
@@ -83,8 +111,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.30', 'package version must be 0.3.30');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.30'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.31', 'package version must be 0.3.31');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.31'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups®Agent', 'display name must be Foundups®Agent');
 includes(JSON.stringify(pkg), 'Foundups®Agent: Open', 'command title must use Foundups®Agent');
@@ -101,7 +129,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.30', 'README version mismatch');
+includes(readme, 'Version: 0.3.31', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -881,8 +909,40 @@ try {
   drfGovBlocked = true;
   drfGovCategory = String((govErr && govErr.stdout) || '');
 }
-assert(drfGovBlocked, 'DRF-007: governance-adjacent fetched content must STILL be blocked by the unchanged redaction gate (slice-3 owns relaxation)');
-includes(drfGovCategory, 'source_authority', 'DRF-007: the existing source_authority category must still fire (no category change in slice 2)');
+assert(drfGovBlocked, 'DRF-007: governance-adjacent fetched content must STILL be blocked by the DEFAULT redaction gate (audit-mode is opt-in)');
+includes(drfGovCategory, 'source_authority', 'DRF-007: the existing source_authority category must still fire on the default (non-audit) path');
+
+// DRF-008 (REDDOG_AUDIT_MODE_REDACTION_PHASE1, slice 3/3): the SAME governance-adjacent
+// fetched content that DRF-007 shows BLOCKS by default now PASSES in audit_mode with the
+// governance STRUCTURE preserved. Direct-read of required targets IS an audit context, so
+// buildDirectReadContentSection surfaces audit_context=true.
+assert.strictEqual(drfGovSection.audit_context, true, 'DRF-008: direct-read of required targets must surface audit_context=true');
+assert.strictEqual(drfEmptySection.audit_context, false, 'DRF-008: no direct-read => audit_context stays false (backward compatible)');
+const drfAuditRedacted = fusionRedactionGateAuditMode(drfGovSection.text, 'DRF-008 audit-mode gate');
+includes(drfAuditRedacted, 'SourceAuthority', 'DRF-008: audit-mode must preserve the SourceAuthority enum identifier');
+includes(drfAuditRedacted, 'source_authority', 'DRF-008: audit-mode must preserve the source_authority field name');
+
+// DRF-009: CRITICAL SAFETY. In audit-mode a SYNTHETIC secret embedded in fetched content
+// is STILL redacted (structure readable != secret readable). Fake key is split-prefixed so
+// no literal provider secret is committed to this test source.
+const _drfFakeKey = ('s' + 'k-') + 'FAKE' + 'Z'.repeat(44);
+const drfSecretBundle = JSON.stringify({
+  task_retrieval: {
+    code_hits: [
+      { location: 'modules/foundups/agent/src/source_authority.py', need: 'direct-read target', direct_read: true,
+        content: 'class SourceAuthority(str, enum.Enum):\n    MONOREPO_POC = "monorepo_poc"\napi_key = "' + _drfFakeKey + '"\ncabr_payout = 12500.50', content_truncated: false }
+    ],
+    metadata: { code_count: 1, wsp_count: 0 }
+  }
+});
+const drfSecretSection = orchestrator.buildDirectReadContentSection(drfSecretBundle);
+const drfSecretRedacted = fusionRedactionGateAuditMode(drfSecretSection.text, 'DRF-009 audit-mode gate');
+includes(drfSecretRedacted, 'SourceAuthority', 'DRF-009: audit-mode keeps governance structure readable');
+includes(drfSecretRedacted, 'MONOREPO_POC', 'DRF-009: audit-mode keeps enum member readable');
+includes(drfSecretRedacted, 'cabr_payout', 'DRF-009: audit-mode keeps the payout identifier readable');
+assert(!drfSecretRedacted.includes(_drfFakeKey), 'DRF-009: SECRET VALUE must STILL be redacted in audit mode (no under-redaction)');
+assert(!drfSecretRedacted.includes('12500.50'), 'DRF-009: payout AMOUNT must STILL be redacted in audit mode');
+includes(drfSecretRedacted, '[REDACTED', 'DRF-009: redaction placeholder must be present for the stripped value');
 
 includes(blockedCopy, '## Governed Handoff Recommendation', 'substantive task must include governed handoff recommendation');
 includes(blockedCopy, 'handoff_needed: unknown', 'blocked-local packet must use conservative handoff_needed');
@@ -950,7 +1010,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.30'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.31'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -964,7 +1024,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.30'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.31'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -976,7 +1036,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.30'", 'bounded context must include extension.js source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.31'", 'bounded context must include extension.js source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -56,16 +56,29 @@ Declared == Actual == 23 / 23 YES.
 
 ```python
 from modules.communication.moltbot_bridge.src.fusion_redaction_gate import (
-    evaluate_redaction_gate,   # (prompt, context=None) -> RedactionGateResult (FAIL-CLOSED)
-    redaction_status_for,      # convenience: -> "REDACTION_GATE_PASSED" | "BLOCKED_PENDING_REDACTION_GATE"
-    redact_text,               # (text) -> (redacted_text, RedactionReport)
-    scan_forbidden,            # (text) -> [category, ...]   (empty == clean)
+    evaluate_redaction_gate,   # (prompt, context=None, audit_mode=False) -> RedactionGateResult (FAIL-CLOSED)
+    redaction_status_for,      # (prompt, context=None, audit_mode=False) -> "REDACTION_GATE_PASSED" | "BLOCKED_PENDING_REDACTION_GATE"
+    redact_text,               # (text, audit_mode=False) -> (redacted_text, RedactionReport)
+    scan_forbidden,            # (text, audit_mode=False) -> [category, ...]   (empty == clean)
     RedactionGateResult,       # status/reason/redacted_prompt/redacted_context/prompt_digest/context_digest/report
     RedactionReport,           # policy_version / categories_hit:dict / blocked_categories:tuple / residual_forbidden_count:int
     REDACT_CATEGORIES, BLOCK_CATEGORIES,   # REDACT vs BLOCK action classes (disjoint)
+    AUDIT_STRUCTURAL_CATEGORIES,           # frozenset of BLOCK cats made audit-visible (subset of BLOCK)
     REDACTION_GATE_PASSED, REDACTION_BLOCKED, ALLOWED_REASONS,
 )
 ```
+
+**Audit mode** (`audit_mode=True`, default `False` -> non-audit path byte-identical;
+REDDOG_AUDIT_MODE_REDACTION_PHASE1, slice 3/3): governance audits must READ governance STRUCTURE.
+The four `AUDIT_STRUCTURAL_CATEGORIES` (`source_authority`, `merge_authorization`,
+`cabr_payout_authority`, `governance_instruction`) match on the bare identifier and so BLOCK the whole
+payload on the default path. In audit_mode those identifiers are PRESERVED (readable enum/field/gate/
+action names + WSP refs) while dedicated audit VALUE redactors + every always-on REDACT detector STILL
+remove any secret VALUE / payout AMOUNT / authorization TOKEN. Audit mode NEVER relaxes
+`private_reasoning` (free-text always BLOCKS), `private_key_residual` (ambiguous -> BLOCKS), or any
+REDACT category. Rule: keep the left-hand key/identifier; redact the right-hand value; when ambiguous,
+REDACT (fail-closed). `run_alias_live(..., audit_context=True)` threads the flag from an audit-context
+retrieval (slice-2 direct-read fallback of required governance targets).
 
 Two action classes. **REDACT** (API keys, bearer, .env secrets, complete private-key blocks, member
 PII, credential URLs) are replaced; the payload may PASS if the post-redaction re-scan is clean.
@@ -106,19 +119,31 @@ input. This slice does NOT enable live OpenRouter -- alias/server_tool/local_fal
 | 24 | NO_LITERAL_SECRET_PATTERN_IN_SOURCE | YES | `test_no_literal_secret_pattern_in_source` scans gate + test source |
 | 25 | POST_REDACTION_RESCAN_REQUIRED | YES | `test_residual_forbidden_fails_closed` |
 | 26 | LIVE_MODES_REMAIN_BLOCKED_AFTER_GATE | YES | `test_live_modes_remain_blocked` (fusion_adapter unchanged) |
+| 27 | AUDIT_MODE_PRESERVES_STRUCTURE | YES | `test_audit_mode_preserves_governance_structure` (enum/field/action/WSP identifiers survive) |
+| 28 | AUDIT_MODE_OFF_BYTE_IDENTICAL | YES | `test_audit_mode_off_is_byte_identical_default` (default path unchanged) |
+| 29 | AUDIT_MODE_STILL_REDACTS_SECRETS | YES | `test_audit_mode_still_redacts_fake_api_key`, `..._oauth_token`, `..._mixed_line_keeps_key_redacts_value` |
+| 30 | AUDIT_MODE_REDACTS_PAYOUT_AND_TOKEN | YES | `test_audit_mode_redacts_cabr_payout_amount_keeps_identifier`, `..._merge_authorization_token_keeps_gate_name` |
+| 31 | AUDIT_MODE_NEVER_RELAXES_PRIVATE_OR_MALFORMED | YES | `test_audit_mode_private_reasoning_still_blocks`, `..._malformed_private_key_still_blocks` |
+| 32 | AUDIT_STRUCTURAL_SUBSET_OF_BLOCK | YES | `test_audit_structural_categories_are_subset_of_block` (excludes private_reasoning/private_key_residual) |
 
-Declared == Actual == 26 / 26 YES.
+Declared == Actual == 32 / 32 YES.
 
 ### Fusion ALIAS live path (VALVE-GATED OFF by default; first live OpenRouter integration)
 
 ```python
 from modules.communication.moltbot_bridge.src.fusion_alias_live import (
-    run_alias_live,            # (prompt, context=None, *, authorization, ...) -> AliasLiveResult
+    run_alias_live,            # (prompt, context=None, *, authorization, ..., audit_context=False) -> AliasLiveResult
     LiveFusionAuthorization,   # typed sovereign auth (authorized=True, authority="012", purpose="fusion_alias_live_call")
     AliasLiveResult,           # status / reason / made_network_call / receipt
     run_manual_smoke,          # MANUAL live smoke (module __main__); NOT a pytest, never in CI
 )
 ```
+
+`audit_context=True` (default `False`) threads audit-mode into the entry redaction gate for an
+audit-context retrieval (slice-2 direct-read fallback of required governance targets): governance
+STRUCTURE stays readable while secret VALUES / payout AMOUNTS / authorization TOKENS are still
+redacted. The request body is always built from the REDACTED text only; secret redaction is never
+weakened. Default `False` keeps the live path byte-identical.
 
 Landing this makes **ZERO** live calls. A network call requires ALL of: (1) `FUSION_ALIAS_LIVE_ENABLED`
 env flag ON (default OFF), (2) a valid `LiveFusionAuthorization` object (authority `012` -- a bool/int/

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,28 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-01: REDDOG_AUDIT_MODE_REDACTION_PHASE1 (slice 3/3)
+
+**Slice:** Audit-mode redaction preserves governance STRUCTURE while still redacting VALUES
+**WSP:** WSP_11, WSP_50, WSP_84, WSP_97, WSP_22
+**Stacked on:** slice 2 (#907, feat/reddog-direct-read-fallback-by-path-phase1)
+
+- EDIT `src/fusion_redaction_gate.py` -- add `audit_mode` param to `evaluate_redaction_gate`,
+  `redaction_status_for`, `redact_text`, `scan_forbidden` (default `False` -> non-audit path
+  byte-identical). Add `AUDIT_STRUCTURAL_CATEGORIES` (source_authority / merge_authorization /
+  cabr_payout_authority / governance_instruction) made audit-visible, plus audit-only VALUE
+  redactors (payout amounts, merge tokens, grant values, key-preserving secret_kv/env_secret_line).
+- FIX over-sanitization from the FoundUp-creation run trace: those four BLOCK categories matched on
+  the bare identifier and stripped the governance STRUCTURE a governance audit must read.
+- SAFETY (non-negotiable): audit mode NEVER relaxes `private_reasoning`, `private_key_residual`, or
+  any REDACT category. Fake API key / OAuth token / payout amount / merge token STILL `[REDACTED]`.
+- EDIT `src/fusion_alias_live.py` -- add `audit_context=False` to `run_alias_live`, threaded into the
+  entry gate (`audit_mode=`); default keeps the live path byte-identical.
+- ADD 14 audit-mode tests in `tests/test_fusion_redaction_gate.py` (structure preserved, secrets
+  still redacted, backward-compat byte-identical). 79/79 pass (65 prior + 14 new).
+- Extension surfaces `audit_context=true` from `buildDirectReadContentSection` when slice-2 direct-read
+  fetched required governance targets (extensions/foundups_advisory_workers); DRF-008/009 contract
+  proofs added. No detector/fetch/allowlist change; no execution/write/shell-out authority.
+
 ## 2026-06-28: REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_PHASE1
 
 **Slice:** OpenClaw FoundUpJob adapter dry-run planner (propose only, no enqueue)

--- a/modules/communication/moltbot_bridge/src/fusion_alias_live.py
+++ b/modules/communication/moltbot_bridge/src/fusion_alias_live.py
@@ -181,14 +181,22 @@ def run_alias_live(
     slice_id: Optional[str] = None,
     timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
     max_tokens: int = DEFAULT_MAX_TOKENS,
+    audit_context: bool = False,
 ) -> AliasLiveResult:
     """Run a redacted, valve-gated, advisory-only ALIAS call. Makes NO call unless every gate opens.
 
     Precedence (fail-closed): redaction gate PASSED -> env flag ON -> typed 012 authorization ->
     API key present -> budget within bounds -> ONE bounded POST. Any failure -> blocked, no raw leak.
+
+    audit_context (REDDOG_AUDIT_MODE_REDACTION_PHASE1, slice 3/3, default False -> live behavior
+    byte-identical): when the caller is an audit-context retrieval (slice-2 direct-read fallback
+    fetched required governance targets), the redaction gate runs in audit_mode so STRUCTURAL
+    governance identifiers survive while every secret VALUE / payout AMOUNT / authorization TOKEN
+    is still redacted. Secret redaction is NEVER weakened; the request body is always built from the
+    REDACTED text only.
     """
     # 1. Redact on entry. Raw prompt/context are used ONLY to compute the gate result and never stored.
-    gate = evaluate_redaction_gate(prompt, context)
+    gate = evaluate_redaction_gate(prompt, context, audit_mode=bool(audit_context))
     if not gate.passed:
         return _blocked(REASON_REDACTION_BLOCKED)  # BLOCK category / dirty -> no request body is built
 

--- a/modules/communication/moltbot_bridge/src/fusion_redaction_gate.py
+++ b/modules/communication/moltbot_bridge/src/fusion_redaction_gate.py
@@ -18,12 +18,32 @@ POLICY -- two action classes (REDACT vs BLOCK):
             material the policy cannot confidently classify e.g. a malformed private-key header).
             Presence of ANY block category keeps status BLOCKED_PENDING_REDACTION_GATE.
 
+AUDIT MODE (REDDOG_AUDIT_MODE_REDACTION_PHASE1, slice 3/3) -- OFF by default:
+  Governance audits must READ governance STRUCTURE (enum member names, dataclass field lists,
+  gate/action-name constants, WSP refs). In the default (non-audit) path the four STRUCTURAL block
+  categories -- source_authority, merge_authorization, cabr_payout_authority, governance_instruction
+  -- match on the bare IDENTIFIER and so BLOCK the whole payload, stripping the very structure a
+  governance audit must see. When audit_mode=True those four categories become AUDIT-VISIBLE: the
+  identifier text is PRESERVED, but secret/payout/authority VALUES are STILL removed --
+    * every REDACT detector remains active unchanged (API keys/tokens/creds always removed);
+    * audit-only VALUE redactors strip the RHS bound to a structural identifier
+      (payout AMOUNTS, merge-authorization TOKENS/grants, secret-shaped values).
+  audit_mode NEVER relaxes: private_reasoning (free-text always BLOCKS), private_key_residual
+  (malformed header -> cannot confidently redact -> BLOCKS), and every REDACT category. The line
+  between value and structure is: KEEP the left-hand key/identifier + enum member names; REDACT the
+  right-hand value. When ambiguous, REDACT (fail-closed). audit_mode default False keeps the
+  non-audit path byte-identical (backward compatible).
+
 WSP 97 TRUTH BOUNDARIES:
   DOES: deterministic REDACT vs BLOCK; emit a counts-only report + sha256:<64 hex> digests computed
         FROM THE REDACTED OUTPUT; PASS only when redaction ran AND a post-redaction re-scan finds
-        zero REDACT residual AND zero BLOCK markers AND no error; FAIL CLOSED otherwise.
+        zero REDACT residual AND zero BLOCK markers AND no error; FAIL CLOSED otherwise; when
+        audit_mode=True, preserve STRUCTURAL governance identifiers while still redacting their
+        secret/payout/authority VALUES (never weakens any REDACT category or secret pattern).
   DOES NOT: make any network call; read any env/API key (never imports os); enable any live Fusion
-        mode; touch merge / CABR / payout / source-authority; echo raw input in any error/reason.
+        mode; touch merge / CABR / payout / source-authority; echo raw input in any error/reason;
+        (audit_mode) leak any secret VALUE, payout AMOUNT, or authorization TOKEN, or relax
+        private_reasoning / private_key_residual / any REDACT category.
 
 REUSE NOTE (WSP 84): an in-tree redactor exists -- redact_sensitive() (duplicated byte-for-byte in
 ai_overseer/src/autofix_executor.py:99 and foundups/agent/src/kanban_plugin_contract.py:105) and
@@ -153,6 +173,91 @@ _DETECTORS: Tuple[Tuple[str, "re.Pattern[str]", str], ...] = (
 REDACT_CATEGORIES: Tuple[str, ...] = tuple(c for c, _, a in _DETECTORS if a == ACTION_REDACT)
 BLOCK_CATEGORIES: Tuple[str, ...] = tuple(c for c, _, a in _DETECTORS if a == ACTION_BLOCK)
 
+# ---------------------------------------------------------------------------
+# AUDIT MODE (REDDOG_AUDIT_MODE_REDACTION_PHASE1, slice 3/3)
+#
+# The four STRUCTURAL block categories below match on the bare governance
+# identifier (enum/field/gate/action name). In audit_mode they become
+# AUDIT-VISIBLE: the identifier is preserved (not blocked) so a governance audit
+# can read the structure, while dedicated audit-only VALUE redactors + every
+# existing REDACT detector still remove any secret value / payout amount /
+# authorization token. private_reasoning and private_key_residual are NOT in
+# this set -- they always BLOCK (free-text / ambiguous -> fail-closed).
+# ---------------------------------------------------------------------------
+AUDIT_STRUCTURAL_CATEGORIES: frozenset = frozenset({
+    "source_authority",
+    "merge_authorization",
+    "cabr_payout_authority",
+    "governance_instruction",
+})
+
+# REDACT categories whose always-on detector swallows the key IDENTIFIER along
+# with the value. In audit mode they are handled by key-preserving audit variants
+# below instead, so the always-on versions are skipped (audit_mode only) to keep
+# the left-hand key name readable. Secret VALUES are still fully removed either way.
+AUDIT_KEY_PRESERVING_SUPERSEDES: frozenset = frozenset({"secret_kv", "env_secret_line"})
+
+# Audit-only VALUE redactors -- run ONLY when audit_mode=True, BEFORE structural
+# identifiers are preserved, so preserving an identifier can never leak a value.
+# Each strips the RIGHT-HAND-SIDE value/amount/token while keeping the left-hand
+# identifier readable. These ADD redaction (never subtract); they are appended to
+# the always-on REDACT set for the audit scan.
+#   * payout AMOUNTS bound to a cabr/payout identifier (numbers, currency)
+#   * merge-authorization TOKEN/grant values bound to a merge identifier
+#   * governance/source grant VALUES bound to those identifiers
+# NOTE: the identifier itself (LHS) is preserved by (\bkey\b[\s:=]+) capture.
+_AUDIT_VALUE_REDACTORS: Tuple[Tuple[str, "re.Pattern[str]"], ...] = (
+    # Key-preserving secret-KV redactor: keep the LHS key name + separator as
+    # readable structure, redact ONLY the RHS value. Runs before the always-on
+    # secret_kv detector (which would otherwise swallow the key name too). Same
+    # key set as secret_kv so audit output keeps `api_key`, `token`, etc.
+    (
+        "audit_secret_kv_value",
+        re.compile(
+            r"(?i)\b((?:access_token|refresh_token|id_token|client_secret|client_id|user_code|"
+            r"authorization_code|password|passwd|api_key|apikey|token)"
+            r"\b\s*[:=]\s*[\"']?)"
+            r"[^\s&\"'}]+",
+        ),
+    ),
+    # Key-preserving env-secret-line redactor: keep the FOO_SECRET/BAR_TOKEN key,
+    # redact only its value. Runs before env_secret_line for the same reason.
+    (
+        "audit_env_secret_value",
+        re.compile(
+            r"\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY|APIKEY|CREDENTIAL)"
+            r"\b\s*[:=]\s*)"
+            r"\S+",
+        ),
+    ),
+    (
+        "audit_payout_amount",
+        re.compile(
+            r"(?i)\b((?:cabr[\s_\-]?payout|payout[\s_\-]?amount|payout|cabr)"
+            r"[\w\s]*?[:=]\s*)"
+            r"\$?\d[\d,]*(?:\.\d+)?",
+        ),
+    ),
+    (
+        "audit_merge_token",
+        re.compile(
+            r"(?i)\b((?:merge[\s_\-]?authoriz\w*|merge[\s_\-]?token|"
+            r"auto[\s_\-]?merge[\s_\-]?token|pull_request_merge|grant[\s_\-]?authority)"
+            r"[\w\s]*?[:=]\s*)"
+            r"[\"']?[^\s\"'}]+",
+        ),
+    ),
+    (
+        "audit_authority_grant",
+        re.compile(
+            r"(?i)\b((?:source[\s_\-]?authority[\s_\-]?override|"
+            r"governance[\s_\-]?grant|grant[\s_\-]?token)"
+            r"[\w\s]*?[:=]\s*)"
+            r"[\"']?[^\s\"'}]+",
+        ),
+    ),
+)
+
 
 # ---------------------------------------------------------------------------
 # Report + result (counts only -- never raw snippets / values / headers / prompt / context)
@@ -188,21 +293,41 @@ class RedactionGateResult:
 # ---------------------------------------------------------------------------
 
 
-def scan_forbidden(text: object) -> List[str]:
+def scan_forbidden(text: object, audit_mode: bool = False) -> List[str]:
     """Return all detector categories (REDACT or BLOCK) whose pattern matches `text`.
 
-    Empty list == clean. A non-string input is itself forbidden (fail closed)."""
+    Empty list == clean. A non-string input is itself forbidden (fail closed).
+
+    In audit_mode the four AUDIT_STRUCTURAL_CATEGORIES are EXCLUDED from the residual
+    scan (their identifiers are intentionally preserved as readable structure). Every
+    other category -- all REDACT secret patterns, private_reasoning, private_key_residual
+    -- is scanned unchanged, so a leaked secret value still shows up as residual.
+    """
     if not isinstance(text, str):
         return ["non_text_input"]
-    return [cat for cat, rx, _ in _DETECTORS if rx.search(text)]
+    hits = [cat for cat, rx, _ in _DETECTORS if rx.search(text)]
+    if audit_mode:
+        # Structural identifiers are intentionally preserved; the key-preserving
+        # audit variants supersede secret_kv/env_secret_line (which would otherwise
+        # re-match the surviving `key = [REDACTED:...]` structure and read as residual).
+        excluded = AUDIT_STRUCTURAL_CATEGORIES | AUDIT_KEY_PRESERVING_SUPERSEDES
+        hits = [cat for cat in hits if cat not in excluded]
+    return hits
 
 
-def redact_text(text: object) -> Tuple[str, RedactionReport]:
+def redact_text(text: object, audit_mode: bool = False) -> Tuple[str, RedactionReport]:
     """Deterministically apply the policy. Returns (redacted_text, report).
 
     REDACT categories are replaced by a category placeholder; BLOCK categories are detected and
     recorded (never silently removed). The report carries category->count, blocked category names,
     and the post-redaction residual count -- never a raw value or snippet.
+
+    When audit_mode=True: the audit-only VALUE redactors run FIRST (stripping payout amounts /
+    merge tokens / grant values while preserving their left-hand identifiers), then the four
+    AUDIT_STRUCTURAL_CATEGORIES are recorded (categories_hit) but NOT added to blocked_categories --
+    their bare identifier text is preserved as readable governance structure. All REDACT secret
+    detectors and the non-structural block categories (private_reasoning, private_key_residual)
+    behave exactly as in the default path, so no secret value can leak.
     """
     report = RedactionReport()
     if not isinstance(text, str):
@@ -212,19 +337,41 @@ def redact_text(text: object) -> Tuple[str, RedactionReport]:
     out = text
     counts: Dict[str, int] = {}
     blocked: List[str] = []
+    # Audit-only VALUE redactors first: strip RHS value/amount/token, keep the LHS identifier.
+    if audit_mode:
+        for cat, rx in _AUDIT_VALUE_REDACTORS:
+            n = sum(1 for _ in rx.finditer(out))
+            if not n:
+                continue
+            counts[cat] = counts.get(cat, 0) + n
+            # \1 preserves the captured "identifier:" LHS; the RHS value is replaced.
+            out = rx.sub(lambda m: m.group(1) + _PLACEHOLDER.format(cat=cat), out)
     for cat, rx, action in _DETECTORS:
+        # In audit mode the key-preserving audit variants above already redacted the
+        # VALUE for these key/value shapes (keeping the key name). Skipping the always-on
+        # versions here prevents them from re-swallowing the surviving `key = [REDACTED]`
+        # structure. The audit variants cover the identical key set, so no secret value
+        # can escape -- and every provider-specific secret pattern (sk-/AIza/ghp_/bearer/
+        # JWT/...) is a SEPARATE detector that stays fully active.
+        if audit_mode and cat in AUDIT_KEY_PRESERVING_SUPERSEDES:
+            continue
         n = sum(1 for _ in rx.finditer(out))
         if not n:
             continue
         counts[cat] = counts.get(cat, 0) + n
         if action == ACTION_BLOCK:
+            # In audit mode, structural governance identifiers are preserved (not blocked).
+            if audit_mode and cat in AUDIT_STRUCTURAL_CATEGORIES:
+                continue
             blocked.append(cat)
         else:
             out = rx.sub(_PLACEHOLDER.format(cat=cat), out)
     report.categories_hit = counts
     report.blocked_categories = tuple(sorted(set(blocked)))
     # post-redaction re-scan: any REDACT pattern still present, or any BLOCK marker present
-    report.residual_forbidden_count = len(scan_forbidden(out))
+    report.residual_forbidden_count = (
+        len(scan_forbidden(out, audit_mode=True)) if audit_mode else len(scan_forbidden(out))
+    )
     return out, report
 
 
@@ -233,22 +380,36 @@ def redact_text(text: object) -> Tuple[str, RedactionReport]:
 # ---------------------------------------------------------------------------
 
 
-def evaluate_redaction_gate(prompt: object, context: object = None) -> RedactionGateResult:
+def evaluate_redaction_gate(prompt: object, context: object = None, audit_mode: bool = False) -> RedactionGateResult:
     """Deterministic, FAIL-CLOSED gate.
 
     PASS requires: prompt (and context if given) are text, redaction ran without error, NO block
     category was detected, and the post-redaction re-scan residual count is 0. Any other case ->
     BLOCKED_PENDING_REDACTION_GATE. Digests are computed FROM THE REDACTED OUTPUT, not raw input.
+
+    audit_mode (default False -> byte-identical to the pre-slice-3 path): preserves the four
+    AUDIT_STRUCTURAL_CATEGORIES identifiers as readable governance structure while still redacting
+    every secret VALUE / payout AMOUNT / authorization TOKEN. Secret redaction is NEVER weakened.
     """
     try:
         if not isinstance(prompt, str) or (context is not None and not isinstance(context, str)):
             return _blocked(REASON_REDACTOR_ERROR, RedactionReport(error=True))
 
-        red_p, rep_p = redact_text(prompt)
-        if context is not None:
-            red_c, rep_c = redact_text(context)
+        # Call redact_text/scan_forbidden with the EXACT pre-slice-3 signature on the
+        # default path (no audit kwarg) so the non-audit behavior is byte-identical and
+        # single-arg monkeypatched doubles keep working. Only audit runs pass the kwarg.
+        if audit_mode:
+            red_p, rep_p = redact_text(prompt, audit_mode=True)
+            if context is not None:
+                red_c, rep_c = redact_text(context, audit_mode=True)
+            else:
+                red_c, rep_c = None, RedactionReport()
         else:
-            red_c, rep_c = None, RedactionReport()
+            red_p, rep_p = redact_text(prompt)
+            if context is not None:
+                red_c, rep_c = redact_text(context)
+            else:
+                red_c, rep_c = None, RedactionReport()
 
         merged = _merge_reports(rep_p, rep_c, context is not None)
         if rep_p.error or rep_c.error:
@@ -256,7 +417,12 @@ def evaluate_redaction_gate(prompt: object, context: object = None) -> Redaction
         if merged.blocked_categories:
             return _blocked(REASON_BLOCKED_POLICY, merged)
         # residual REDACT/BLOCK patterns left in the redacted output -> never pass dirty output
-        post = len(scan_forbidden(red_p)) + (len(scan_forbidden(red_c)) if context is not None else 0)
+        if audit_mode:
+            post = len(scan_forbidden(red_p, audit_mode=True)) + (
+                len(scan_forbidden(red_c, audit_mode=True)) if context is not None else 0
+            )
+        else:
+            post = len(scan_forbidden(red_p)) + (len(scan_forbidden(red_c)) if context is not None else 0)
         if post > 0:
             return _blocked(REASON_RESIDUAL, merged)
 
@@ -274,9 +440,9 @@ def evaluate_redaction_gate(prompt: object, context: object = None) -> Redaction
         return _blocked(REASON_REDACTOR_ERROR, RedactionReport(error=True))
 
 
-def redaction_status_for(prompt: object, context: object = None) -> str:
+def redaction_status_for(prompt: object, context: object = None, audit_mode: bool = False) -> str:
     """Convenience: return only the gate status string (PASSED or BLOCKED)."""
-    return evaluate_redaction_gate(prompt, context).status
+    return evaluate_redaction_gate(prompt, context, audit_mode=audit_mode).status
 
 
 def _blocked(reason: str, report: RedactionReport) -> RedactionGateResult:
@@ -317,6 +483,7 @@ __all__ = [
     "ACTION_BLOCK",
     "REDACT_CATEGORIES",
     "BLOCK_CATEGORIES",
+    "AUDIT_STRUCTURAL_CATEGORIES",
     "ALLOWED_REASONS",
     "REASON_CLEAN",
     "REASON_REDACTED",

--- a/modules/communication/moltbot_bridge/tests/test_fusion_redaction_gate.py
+++ b/modules/communication/moltbot_bridge/tests/test_fusion_redaction_gate.py
@@ -24,6 +24,7 @@ import pytest
 
 from modules.communication.moltbot_bridge.src.fusion_redaction_gate import (
     ALLOWED_REASONS,
+    AUDIT_STRUCTURAL_CATEGORIES,
     BLOCK_CATEGORIES,
     REASON_BLOCKED_POLICY,
     REASON_CLEAN,
@@ -343,3 +344,185 @@ def test_no_leak_assertion_is_non_vacuous():
 def test_scan_forbidden_non_text_is_forbidden():
     assert scan_forbidden(123) == ["non_text_input"]
     assert scan_forbidden(None) == ["non_text_input"]
+
+
+# ---------------------------------------------------------------------------
+# AUDIT MODE lane (REDDOG_AUDIT_MODE_REDACTION_PHASE1, slice 3/3)
+#
+# audit_mode preserves STRUCTURAL governance identifiers (enum members, field
+# names, gate/action constants, WSP refs) while STILL redacting every secret
+# VALUE / payout AMOUNT / authorization TOKEN. Secret redaction is NEVER weakened.
+# All fixtures are SYNTHETIC (split-prefix) fakes -- no real secret.
+# ---------------------------------------------------------------------------
+
+# A realistic FoundUp governance snippet: enum, field list, action constants, WSP ref.
+_AUDIT_STRUCTURE_SAMPLE = (
+    "class SourceAuthority(str, enum.Enum):\n"
+    '    MONOREPO_POC = "monorepo_poc"\n'
+    '    EXTERNAL_PROTO = "external_proto"\n'
+    "requested_action: str = \"build_foundup\"\n"
+    "CANONICAL_ACTIONS = (\"build_foundup\", \"extract_foundup\")\n"
+    "# See WSP 109 onboarding intake. source_authority resolve convention; "
+    "merge_authorization gate ordering; cabr_payout_authority routing; "
+    "governance_instruction gate name.\n"
+    "FoundUpJob fields: requested_action, module_path, source_authority.\n"
+)
+
+
+def test_audit_mode_preserves_governance_structure():
+    res = evaluate_redaction_gate(_AUDIT_STRUCTURE_SAMPLE, audit_mode=True)
+    assert res.status == REDACTION_GATE_PASSED, res.report
+    out = res.redacted_prompt or ""
+    # enum + member identifiers preserved
+    assert "SourceAuthority" in out
+    assert "source_authority" in out
+    assert "MONOREPO_POC" in out
+    assert "EXTERNAL_PROTO" in out
+    # action-name constants + field names preserved
+    assert "build_foundup" in out
+    assert "extract_foundup" in out
+    assert "CANONICAL_ACTIONS" in out
+    assert "requested_action" in out
+    assert "module_path" in out
+    # structural governance gate names preserved (not value)
+    assert "merge_authorization" in out
+    assert "cabr_payout_authority" in out
+    assert "governance_instruction" in out
+    # WSP ref preserved
+    assert "WSP 109" in out
+
+
+def test_audit_mode_same_structure_blocks_in_default_mode():
+    # The identical content BLOCKS on the default (non-audit) path -- proves audit
+    # mode is what unblocks the structure, not a general weakening.
+    res = evaluate_redaction_gate(_AUDIT_STRUCTURE_SAMPLE, audit_mode=False)
+    assert res.status == REDACTION_BLOCKED
+    assert res.reason == REASON_BLOCKED_POLICY
+    assert "source_authority" in res.report.blocked_categories
+
+
+def test_audit_mode_still_redacts_fake_api_key():
+    # CRITICAL SAFETY TEST: a synthetic API key must STILL be redacted in audit mode.
+    secret = _SK + "FAKE" + "A" * 40
+    res = evaluate_redaction_gate("here is a loose key " + secret, audit_mode=True)
+    assert res.status == REDACTION_GATE_PASSED
+    out = res.redacted_prompt or ""
+    assert "[REDACTED" in out
+    assert secret not in out
+    assert scan_forbidden(out, audit_mode=True) == []
+
+
+def test_audit_mode_still_redacts_fake_oauth_token():
+    # Synthetic OAuth access token (ya29.*) -- STILL redacted in audit mode.
+    token = "ya29." + "F" * 44
+    res = evaluate_redaction_gate("token=" + token, audit_mode=True)
+    assert res.status == REDACTION_GATE_PASSED
+    out = res.redacted_prompt or ""
+    assert token not in out
+    assert "F" * 44 not in out
+
+
+def test_audit_mode_redacts_cabr_payout_amount_keeps_identifier():
+    res = evaluate_redaction_gate("cabr_payout = 12500.50 approved", audit_mode=True)
+    assert res.status == REDACTION_GATE_PASSED
+    out = res.redacted_prompt or ""
+    # identifier kept, numeric AMOUNT gone
+    assert "cabr_payout" in out
+    assert "12500.50" not in out
+    assert "[REDACTED" in out
+
+
+def test_audit_mode_redacts_merge_authorization_token_keeps_gate_name():
+    # Preserve that a merge gate EXISTS + its name; redact any authorization token value.
+    grant = "gh" "p_" + "T" * 36
+    res = evaluate_redaction_gate("merge_authorization = " + grant, audit_mode=True)
+    assert res.status == REDACTION_GATE_PASSED
+    out = res.redacted_prompt or ""
+    assert "merge_authorization" in out   # gate name kept (structure)
+    assert grant not in out               # token value gone
+    assert "T" * 36 not in out
+
+
+def test_audit_mode_private_reasoning_still_blocks():
+    # private_reasoning free-text is NEVER relaxed by audit mode.
+    res = evaluate_redaction_gate("prefix <thinking> hidden plan </thinking> suffix", audit_mode=True)
+    assert res.status == REDACTION_BLOCKED
+    assert "private_reasoning" in res.report.blocked_categories
+
+
+def test_audit_mode_malformed_private_key_still_blocks():
+    # Ambiguous (header, no END) -> cannot confidently redact -> still BLOCKS in audit mode.
+    res = evaluate_redaction_gate(_PK_BEGIN + "\n" + "M" * 40, audit_mode=True)
+    assert res.status == REDACTION_BLOCKED
+    assert "private_key_residual" in res.report.blocked_categories
+
+
+def test_audit_mode_mixed_line_keeps_key_redacts_value():
+    # ACCEPTANCE fixture: `api_key = "sk-FAKE123"` -> key name kept, value redacted.
+    secret = _SK + "FAKE123" + "B" * 30
+    res = evaluate_redaction_gate('api_key = "' + secret + '"', audit_mode=True)
+    assert res.status == REDACTION_GATE_PASSED
+    out = res.redacted_prompt or ""
+    assert "api_key" in out               # key/identifier kept (structure)
+    assert secret not in out              # value redacted
+    assert "FAKE123" not in out
+    assert "[REDACTED" in out
+
+
+def test_audit_mode_generic_secret_kv_value_still_removed():
+    # A non-provider-shaped value only caught by the secret_kv shape must still be
+    # removed by the key-preserving audit variant (safety net preserved).
+    res = evaluate_redaction_gate("password = hunter2topsecretvalue", audit_mode=True)
+    assert res.status == REDACTION_GATE_PASSED
+    out = res.redacted_prompt or ""
+    assert "password" in out
+    assert "hunter2topsecretvalue" not in out
+
+
+def test_audit_mode_combined_structure_and_secret():
+    # A payload with BOTH governance structure AND a fake secret: structure survives,
+    # secret is redacted, gate PASSES (this is the slice-3 acceptance shape).
+    secret = _SK + "MIXED" + "C" * 40
+    payload = _AUDIT_STRUCTURE_SAMPLE + '\napi_key = "' + secret + '"\n'
+    res = evaluate_redaction_gate(payload, audit_mode=True)
+    assert res.status == REDACTION_GATE_PASSED, res.report
+    out = res.redacted_prompt or ""
+    assert "SourceAuthority" in out and "build_foundup" in out
+    assert secret not in out
+    assert scan_forbidden(out, audit_mode=True) == []
+
+
+def test_audit_mode_off_is_byte_identical_default():
+    # Backward-compat: audit_mode=False (default) must equal an explicit False AND the
+    # no-kwarg call, for structure (blocks), secrets (redact), and clean text.
+    samples = [
+        _AUDIT_STRUCTURE_SAMPLE,
+        _SK + "A" * 48,
+        "password = hunter2topsecretvalue",
+        "ordinary prompt about ramen shops in tokyo",
+        "source_authority = x",
+    ]
+    for s in samples:
+        default = evaluate_redaction_gate(s)
+        explicit_false = evaluate_redaction_gate(s, audit_mode=False)
+        assert default.status == explicit_false.status
+        assert default.reason == explicit_false.reason
+        assert default.redacted_prompt == explicit_false.redacted_prompt
+        assert default.report.blocked_categories == explicit_false.report.blocked_categories
+
+
+def test_audit_structural_categories_are_subset_of_block():
+    # The audit-visible structural set must be a strict subset of BLOCK categories and
+    # must NOT include private_reasoning or private_key_residual (never relaxed).
+    assert AUDIT_STRUCTURAL_CATEGORIES.issubset(set(BLOCK_CATEGORIES))
+    assert "private_reasoning" not in AUDIT_STRUCTURAL_CATEGORIES
+    assert "private_key_residual" not in AUDIT_STRUCTURAL_CATEGORIES
+
+
+def test_audit_mode_makes_zero_network(monkeypatch):
+    def _boom(*a, **k):
+        raise AssertionError("network attempted by redaction gate in audit mode")
+
+    monkeypatch.setattr(socket, "socket", _boom)
+    evaluate_redaction_gate(_AUDIT_STRUCTURE_SAMPLE, audit_mode=True)
+    evaluate_redaction_gate(_SK + "A" * 48, audit_mode=True)


### PR DESCRIPTION
## Slice 3 of 3 - REDDOG_AUDIT_MODE_REDACTION_PHASE1

**Lane:** retrieval | **Stacked on #907** (base = `feat/reddog-direct-read-fallback-by-path-phase1`; auto-retargets to `main` as #906/#907 merge). Draft; VERIFIED_READY.

### The problem (FoundUp-creation run trace)
`target_content_sanitized_categories` included `private_reasoning, merge_authorization, source_authority, cabr_payout_authority, governance_instruction`. Those four **structural** BLOCK categories match on the bare identifier, so the redaction gate stripped the very governance STRUCTURE a governance audit must read. Even with slice-2 content fetched, RedDog could not see enum members / field names / gate ordering.

**Over-sanitizing categories today** (`modules/communication/moltbot_bridge/src/fusion_redaction_gate.py`): `source_authority` (line 140, `\bsource[\s_\-]?authority\b`), `merge_authorization` (137), `cabr_payout_authority` (143), `governance_instruction` (148), `private_reasoning` (129) - all `ACTION_BLOCK`, matching the identifier itself. Slice-2's DRF-007 proves the default gate BLOCKS on `class SourceAuthority: pass` via `source_authority`.

### The fix - audit mode (OFF by default; non-audit path byte-identical)
`evaluate_redaction_gate(prompt, context, audit_mode=False)` (+ `redaction_status_for`, `redact_text`, `scan_forbidden`). In audit mode the four `AUDIT_STRUCTURAL_CATEGORIES` become audit-visible: their identifiers are preserved while audit-only VALUE redactors + every always-on REDACT detector still remove secret values.

### Value-vs-structure line

| AUDIT-MODE PRESERVES (structure) | AUDIT-MODE STILL REDACTS (values) |
|---|---|
| field/key names, enum members (`source_authority`, `SourceAuthority.MONOREPO_POC`) | API keys/tokens/creds (`sk-*`, `AIza*`, OAuth, bearer, JWT) - every REDACT detector, unchanged |
| action-name constants (`build_foundup`, `extract_foundup`, `CANONICAL_ACTIONS`) | `cabr_payout_authority` AMOUNTS / numeric payout values |
| gate names, dataclass field lists (`requested_action`, `module_path`) | `merge_authorization` TOKENS/grants (gate NAME kept, token value redacted) |
| WSP references (`WSP 109`) | `private_reasoning` free-text (always BLOCKS - never relaxed) |
| valve gate names | mixed line `api_key = "sk-FAKE123"` -> key name kept, value redacted |

Rule: keep the LHS key/identifier + enum members; redact the RHS value. When ambiguous, REDACT (fail-closed). `private_reasoning` and `private_key_residual` are NOT in the structural set - they always BLOCK.

### "No under-redaction" argument (the whole point of this slice's opposite-direction risk)
The risk here is UNDER-redaction (leaking secrets). Proof this cannot happen:
1. **Every provider-secret detector stays fully active in audit mode** (`sk-`, `AIza`, `ghp_`, `xai-`, `ya29.`, bearer, JWT, AKIA, xox*, ...) - they are separate `ACTION_REDACT` detectors, never in the structural set.
2. **`secret_kv`/`env_secret_line` shapes are covered by key-preserving audit variants** that redact the identical value class (same key set) while keeping only the LHS key name - a strict value-redacting superset, so no generic `key = value` secret escapes.
3. **`scan_forbidden` still runs the full REDACT set in audit mode**; only the four structural identifiers are excluded from the residual scan. A leaked secret value still surfaces as residual -> BLOCK.
4. **`private_reasoning`, `private_key_residual` always BLOCK**; when ambiguous, REDACT.

### Fake-secret-still-redacted proof (critical safety test)
- `test_audit_mode_still_redacts_fake_api_key`: synthetic `sk-FAKE...` -> `[REDACTED]`, `scan_forbidden==[]`.
- `test_audit_mode_still_redacts_fake_oauth_token`: `ya29.*` -> gone.
- `test_audit_mode_mixed_line_keeps_key_redacts_value`: `api_key = "sk-FAKE123..."` -> `api_key = "[REDACTED:audit_secret_kv_value]"` (key kept, value gone).
- `test_audit_mode_redacts_cabr_payout_amount_keeps_identifier`: `cabr_payout = 12500.50` -> amount redacted, identifier kept.
- `test_audit_mode_redacts_merge_authorization_token_keeps_gate_name`: token redacted, gate name kept.
- `test_audit_mode_private_reasoning_still_blocks` / `..._malformed_private_key_still_blocks`: still BLOCK.
- Contract **DRF-009**: synthetic secret embedded in fetched governance content -> structure readable, secret + payout value `[REDACTED]`.

### Backward-compat proof (audit-mode OFF unchanged)
- `evaluate_redaction_gate` calls `redact_text`/`scan_forbidden` with the EXACT pre-slice-3 signature on the default path (no kwarg) -> byte-identical; single-arg monkeypatched doubles keep working.
- `test_audit_mode_off_is_byte_identical_default`: default vs explicit `audit_mode=False` equal on status/reason/redacted_prompt/blocked_categories for structure (BLOCKS), secrets (redact), clean text.
- All 65 pre-existing gate tests + 33 alias-live tests pass unchanged (contract DRF-007 still proves default-path BLOCK on `source_authority`).

### Slice-3 acceptance demonstration
On fetched FoundUp targets in audit mode, governance STRUCTURE is READABLE (`SourceAuthority` enum + members, `FoundUpJob` field names, `CANONICAL_ACTIONS` incl. `build_foundup`/`extract_foundup`, valve gate names, WSP refs) while any secret/payout/authority-token VALUE remains redacted - contract **DRF-008** (`SourceAuthority`/`source_authority` survive the audit-mode gate) + **DRF-009** (secret still redacted). This unblocks the eventual 0/8->8/8 golden rerun (run through RedDog as a separate acceptance step, not part of this slice).

### Trigger
Audit mode is OFF by default. The extension surfaces `audit_context=true` from `buildDirectReadContentSection` when slice-2's direct-read fallback fetched required governance targets; `run_alias_live(..., audit_context=True)` threads it into the entry gate. No fetch/allowlist/detector change.

### WSP_97 truth table (INTERFACE rows 27-32; 32/32 YES)

| Boundary | Status | Evidence |
|---|---|---|
| AUDIT_MODE_PRESERVES_STRUCTURE | YES | `test_audit_mode_preserves_governance_structure` |
| AUDIT_MODE_OFF_BYTE_IDENTICAL | YES | `test_audit_mode_off_is_byte_identical_default` |
| AUDIT_MODE_STILL_REDACTS_SECRETS | YES | `test_audit_mode_still_redacts_fake_api_key/_oauth_token/_mixed_line...` |
| AUDIT_MODE_REDACTS_PAYOUT_AND_TOKEN | YES | `..._cabr_payout_amount...`, `..._merge_authorization_token...` |
| AUDIT_MODE_NEVER_RELAXES_PRIVATE_OR_MALFORMED | YES | `..._private_reasoning_still_blocks`, `..._malformed_private_key_still_blocks` |
| AUDIT_STRUCTURAL_SUBSET_OF_BLOCK | YES | `test_audit_structural_categories_are_subset_of_block` |
| NO_UNDER_REDACTION (opposite-direction risk) | YES | DRF-009 + full REDACT set active in audit mode; residual scan retains all secret detectors |
| NO_DETECTOR_OR_FETCH_CHANGE | YES | zero `holo_index/` diff; extension detector lines untouched |
| NO_EXECUTION_AUTHORITY | YES | gate is text-only; no write/shell-out added |

### Confirmation
- Secret redaction NOT weakened (every REDACT detector active in audit mode; fake secrets still `[REDACTED]`).
- No slice-1 detector / slice-2 fetch/allowlist change (zero `holo_index/` diff; `evaluateTargetRecall`/`_direct_read_fetch` untouched).
- No execution/write/shell-out authority added.

### Validation
- `node --check extension.js` -> OK
- `node tests/verify_extension_contract.js` -> exit 0 (contract checks passed; the printed `UnicodeEncodeError` is an expected malformed-surrogate subprocess probe, caught)
- `pytest test_fusion_redaction_gate.py` -> 79 passed (65 prior + 14 audit)
- `pytest test_fusion_alias_live.py test_fusion_adapter.py` -> pass
- `git diff --check` clean; added-line non-ASCII = 0 across all 8 files

### Known pre-existing (out of scope)
`test_extension_js_in_top_hits_for_review_query` and `test_bundle_json_cli_extension_js_recall` fail on the **slice-2 base** (verified with this slice's changes stashed) - lexical-ranking fragility where slice-2's own `verify_extension_contract.js` additions out-rank `extension.js`. This slice (redaction) does not cause or worsen them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
