### PR TITLE
feat(reddog): governed direct-read-by-path fallback (slice 2/3)

### DIFF
--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -165,7 +165,11 @@ Run Trace HoloIndex scorecard fields (v0.3.22+):
 | `required_targets_total` | Count of paths parsed from an explicit "Required direct-read targets" prompt list (0 = none present) | OBSERVED |
 | `required_targets_recalled` | Required targets whose content-bearing path appeared in the bundle (self-file `extension.js` excluded) | OBSERVED |
 | `required_targets_missing` | Required target paths absent from content (drives `index_gap_detected`) | OBSERVED |
-| `direct_read_fallback_used` | Offline lexical fallback used | OBSERVED |
+| `direct_read_fallback_used` | Governed direct-read-by-path fetch ran (or offline lexical fallback used) | OBSERVED |
+| `direct_read_paths` | Repo-relative target paths actually fetched by the Python bundle layer | OBSERVED |
+| `direct_read_rejected` | `{path, reason}` for denied/traversal/absolute/secret/symlink-escape hits (never read) | OBSERVED |
+| `direct_read_bytes` | Total bytes injected across all fetched targets (bounded by total budget) | OBSERVED |
+| `direct_read_truncated` | `{path, bytes}` for targets clipped by the per-file byte cap | OBSERVED |
 | `target_content_included` | Target snippet section present in final bounded context | OBSERVED |
 | `target_content_paths` | Relative paths whose snippets were included | OBSERVED |
 | `target_content_chars` | Character count of included target snippets | OBSERVED |
@@ -189,7 +193,9 @@ Bridge child env (v0.3.25+): `PYTHONIOENCODING=utf-8`, `PYTHONUTF8=1`. Python br
 
 Target content egress (v0.3.22+): `buildTargetRecallContentSection(root, taskText, maxChars)` reads workspace-confined snippets for inferred recall targets after HoloIndex path ranking. Snippets pass through `sanitizeTargetSnippetForRedaction()` before inclusion (ADDENDUM F); placeholders use neutral `[SANITIZED_BLOCK:NN]` tokens so category names do not re-trigger the Fusion gate. Telemetry reflects the **final** bounded context string assembled by `buildBoundedRepoContext` (before the 42000-char slice). `buildWsp97ProtocolExcerpt(root, maxChars)` adds a bounded WSP_97 protocol excerpt when the task mentions WSP_97 or truth labels.
 
-Exported helpers for contract tests: `isTargetReadPathDenied`, `resolveSafeRepoFile`, `readBoundedTargetSnippet`, `readBoundedTargetSnippets`, `buildTargetRecallContentSection`, `sanitizeTargetSnippetForRedaction`, `taskMentionsWsp97`, `buildWsp97ProtocolExcerpt`, `parseRequiredTargetPaths`, `isSelfFileLocation`, `requiredTargetMatchesLocation`, `formatHoloIndexScorecardLines`.
+Governed direct-read-by-path (REDDOG_DIRECT_READ_FALLBACK_BY_PATH_PHASE1, slice 2/3): when slice-1's detector reports `index_gap_detected=true` with a non-empty `required_targets_missing`, `holoIndexOutput` re-invokes the bundle with `buildMustIncludeArgs(missing)` -> `--bundle-must-include <path>` so the **Python bundle layer** (`holo_index/cli/commands/bundle_json.py::_direct_read_fetch`) reads the named repo files and returns their content in the bundle. The extension does NOT read those files via raw fs; it only names the paths. Fetched hits are spliced into `task_retrieval.code_hits` (so slice-1 recall re-evaluates and flips `target_recall_ok`) and rendered by `buildDirectReadContentSection(bundleOutput)` into a bounded section. Hard security allowlist (all in the Python layer): repo-relative only; realpath must stay inside repo root (rejects absolute, `..` traversal, symlink-escape); hard-deny basenames/globs (`.env*`, `*.pem`, `*.key`, `id_rsa*`, `id_ed25519*`, `*.p12`, `*.keystore`, `*secret*`/`*credential*`/`*token*`, `.git/` and credential dot-dirs); per-file byte cap (12KB) plus a total fetch budget (96KB) spread across MANY targets ranked by prompt order; every denial is recorded in `direct_read_rejected` and never aborts the bundle. Fetched content passes through the EXISTING redaction gate unchanged (slice 3 owns audit-mode redaction). No execution authority, no write path, no shell-out.
+
+Exported helpers for contract tests: `isTargetReadPathDenied`, `resolveSafeRepoFile`, `readBoundedTargetSnippet`, `readBoundedTargetSnippets`, `buildTargetRecallContentSection`, `sanitizeTargetSnippetForRedaction`, `taskMentionsWsp97`, `buildWsp97ProtocolExcerpt`, `parseRequiredTargetPaths`, `isSelfFileLocation`, `requiredTargetMatchesLocation`, `formatHoloIndexScorecardLines`, `buildMustIncludeArgs`, `buildDirectReadContentSection`.
 
 ## WSP_97 Truth Boundary
 

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -11,6 +11,37 @@
 
 WSP: WSP_22.
 
+## 2026-07-01 - REDDOG_DIRECT_READ_FALLBACK_BY_PATH_PHASE1 (slice 2/3, governed fetch)
+
+- Files: `holo_index/cli/commands/bundle_json.py` (fetch + hard allowlist), `holo_index/_cli_main.py`
+  (`--bundle-must-include`), `extensions/foundups_advisory_workers/extension.js` (request paths + telemetry).
+- Goal: when slice-1's detector reports `index_gap_detected=true` and the prompt named required targets absent
+  from the bundle, FETCH those exact files' content so RedDog reasons on real source instead of HOLDing blind.
+- Architecture: the FETCH lives in the PYTHON bundle layer (`_direct_read_fetch`); the extension only REQUESTS
+  must-include paths via `--bundle-must-include` (no raw fs in extension.js, no shell-out, no model/router change).
+  Fetched hits are spliced into `task_retrieval.code_hits`; slice-1's `evaluateTargetRecall` re-runs so
+  `target_recall_ok` / `required_targets_recalled` reflect the now-present content.
+- HARD security allowlist (WSP_50): repo-relative only; realpath must stay inside repo root (rejects absolute,
+  `..` traversal, symlink-escape); hard-deny `.env*`, `*.pem`, `*.key`, `id_rsa*`, `id_ed25519*`, `*.p12`,
+  `*.keystore`, `*secret*`/`*credential*`/`*token*`, `.git/` and credential dot-dirs; per-file byte cap (12KB)
+  plus total fetch budget (96KB) spread across MANY targets (ranked by prompt order) so no single file starves
+  the rest; every rejection recorded and never aborts the bundle.
+- Telemetry: `direct_read_fallback_used`, `direct_read_paths`, `direct_read_rejected` (`{path, reason}`),
+  `direct_read_bytes`, `direct_read_truncated` (`{path, bytes}`) added to the Run Trace scorecard.
+- Boundary: NO redaction-category change and NO audit-mode change (slice 3). Fetched content passes through the
+  EXISTING redaction gate unchanged (governance content may still be over-sanitized until slice 3 - expected).
+  NO execution authority, NO write capability, NO shell-out added.
+- Acceptance (slice-2 bar): on the FoundUp-creation required-target list against a bundle lacking them, the
+  targets (WSP_109, openclaw_foundup_orchestrator, hermes_foundup_job_executor, foundup_job_contract,
+  reddog_governed_work_order_dryrun, reddog_wre_execution_valve, source_authority) are fetched + present,
+  `direct_read_fallback_used=true`, `target_recall_ok=true`.
+- Tests: `holo_index/tests/test_reddog_extension_bundle_recall.py` (deny-gate unit, real-target fetch,
+  recall-flip via node, traversal/absolute/secret-fixture/symlink-escape rejection, per-file cap + total budget
+  spread, CLI end-to-end) + `tests/verify_extension_contract.js` (DRF-001..007 incl. slice-boundary proof that
+  the existing redaction gate STILL blocks governance content, unchanged).
+- Stacked on slice 1 (#906). WSP: WSP_00, WSP_15, WSP_50, WSP_97, WSP_22.
+
+
 ## 2026-07-01 - REDDOG_TARGET_RECALL_PATH_AWARE_PHASE1 (slice 1/3, detector only)
 
 - File: `extensions/foundups_advisory_workers/extension.js`

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,14 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-02 - Version bump to 0.3.30 (REDDOG_DIRECT_READ_FALLBACK_BY_PATH_PHASE1, slice 2/3)
+
+- Mechanical build-label bump 0.3.29 -> 0.3.30 across LIVE version surfaces.
+- Surfaces: `package.json`, `extension.js` (`EXTENSION_VERSION`), `README.md` header,
+  `tests/verify_extension_contract.js` LIVE-version assertions.
+
+WSP: WSP_22.
+
 ## 2026-07-02 - Version bump to 0.3.29 (REDDOG_TARGET_RECALL_PATH_AWARE_PHASE1, slice 1/3)
 
 - Mechanical build-label bump 0.3.28 -> 0.3.29 across LIVE version surfaces so an installed

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.29
+Version: 0.3.30
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -163,6 +163,24 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 - Add regression retrieval tests so extension bridge code ranks above adjacent WRE routers.
 - **Status:** **LANDED** #882 (`99d0e35c2`) — ranking + target recall telemetry only; not source-content inclusion.
 
+### REDDOG_DIRECT_READ_FALLBACK_BY_PATH_PHASE1 (slice 2/3)
+
+- **Status:** GOVERNED FETCH (this slice), stacked on slice 1 (#906). When slice-1's detector reports
+  `index_gap_detected=true` with missing required targets, the extension asks the Python bundle layer to FETCH
+  those exact repo files (via `--bundle-must-include`) so RedDog reasons on real source instead of HOLDing blind.
+- Fetch lives in `holo_index/cli/commands/bundle_json.py::_direct_read_fetch` (NOT raw fs in extension.js; no
+  shell-out, no model/router change). Fetched hits splice into `code_hits`; slice-1 recall re-runs and flips
+  `target_recall_ok` true; `direct_read_fallback_used=true`.
+- HARD security allowlist: repo-relative only; realpath must stay in repo root (rejects absolute, `..` traversal,
+  symlink-escape); hard-deny `.env*`/`*.pem`/`*.key`/`id_rsa*`/`id_ed25519*`/`*.p12`/`*.keystore`/
+  `*secret*`/`*credential*`/`*token*`/`.git/`; per-file cap (12KB) + total budget (96KB) spread across many
+  targets; denials recorded (`direct_read_rejected`), never abort the bundle.
+- New telemetry: `direct_read_paths`, `direct_read_rejected`, `direct_read_bytes`, `direct_read_truncated`.
+- **Slice boundary:** NO redaction-category change, NO audit-mode change (slice 3); NO execution authority.
+  Fetched content passes the EXISTING redaction gate unchanged (governance content may still be over-sanitized
+  until slice 3 - that is the slice-3 deliverable). Slice-2 bar = targets fetched + present + recall satisfied,
+  NOT final answer quality.
+
 ### REDDOG_TARGET_RECALL_PATH_AWARE_PHASE1 (slice 1/3)
 
 - **Status:** DETECTOR ONLY (this slice). Parse an explicit "Required direct-read targets" prompt list; compare against

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.29';
+const EXTENSION_VERSION = '0.3.30';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -605,6 +605,10 @@ function extractHoloIndexScorecard(contextMode, holoMeta) {
     required_targets_recalled: meta.required_targets_recalled !== undefined ? meta.required_targets_recalled : 'unknown',
     required_targets_missing: Array.isArray(meta.required_targets_missing) ? meta.required_targets_missing : 'unknown',
     direct_read_fallback_used: meta.direct_read_fallback_used !== undefined ? meta.direct_read_fallback_used : 'unknown',
+    direct_read_paths: Array.isArray(meta.direct_read_paths) ? meta.direct_read_paths : 'unknown',
+    direct_read_rejected: Array.isArray(meta.direct_read_rejected) ? meta.direct_read_rejected : 'unknown',
+    direct_read_bytes: meta.direct_read_bytes !== undefined ? meta.direct_read_bytes : 'unknown',
+    direct_read_truncated: Array.isArray(meta.direct_read_truncated) ? meta.direct_read_truncated : 'unknown',
     target_content_included: meta.target_content_included !== undefined ? meta.target_content_included : 'unknown',
     target_content_paths: Array.isArray(meta.target_content_paths) ? meta.target_content_paths : 'unknown',
     target_content_chars: meta.target_content_chars !== undefined ? meta.target_content_chars : 'unknown',
@@ -632,6 +636,10 @@ function formatHoloIndexScorecardLines(scorecard) {
     '- required_targets_recalled: ' + scorecard.required_targets_recalled,
     '- required_targets_missing: ' + (Array.isArray(scorecard.required_targets_missing) ? (scorecard.required_targets_missing.length ? scorecard.required_targets_missing.join(', ') : '(none)') : scorecard.required_targets_missing),
     '- direct_read_fallback_used: ' + scorecard.direct_read_fallback_used,
+    '- direct_read_paths: ' + (Array.isArray(scorecard.direct_read_paths) ? (scorecard.direct_read_paths.length ? scorecard.direct_read_paths.join(', ') : '(none)') : scorecard.direct_read_paths),
+    '- direct_read_rejected: ' + (Array.isArray(scorecard.direct_read_rejected) ? (scorecard.direct_read_rejected.length ? scorecard.direct_read_rejected.map((r) => (r && r.path ? r.path + ' (' + r.reason + ')' : String(r))).join(', ') : '(none)') : scorecard.direct_read_rejected),
+    '- direct_read_bytes: ' + scorecard.direct_read_bytes,
+    '- direct_read_truncated: ' + (Array.isArray(scorecard.direct_read_truncated) ? (scorecard.direct_read_truncated.length ? scorecard.direct_read_truncated.map((t) => (t && t.path ? t.path + ' (' + t.bytes + 'B)' : String(t))).join(', ') : '(none)') : scorecard.direct_read_truncated),
     '- target_content_included: ' + scorecard.target_content_included,
     '- target_content_paths: ' + (Array.isArray(scorecard.target_content_paths) ? scorecard.target_content_paths.join(', ') : scorecard.target_content_paths),
     '- target_content_chars: ' + scorecard.target_content_chars,
@@ -2137,6 +2145,12 @@ function buildBoundedRepoContext(mode, taskText) {
     holoindex_meta = holo.meta || null;
     holoindex_scorecard = extractHoloIndexScorecard(mode, holoindex_meta);
     sections.push('### HoloIndex recall (WSP_00 bundle-json first; offline fallback only if needed)\n```text\n' + (holo.output || '(no HoloIndex output)') + '\n```');
+    // REDDOG_DIRECT_READ_FALLBACK_BY_PATH_PHASE1: surface the governed direct-read
+    // content as a dedicated bounded section so the truncated recall JSON does not
+    // drop the fetched source the model needs to reason on.
+    if (holo.direct_read_section && holo.direct_read_section.text) {
+      sections.push(holo.direct_read_section.text);
+    }
   }
   let targetContentMeta = null;
   if (mode !== 'none') {
@@ -2630,7 +2644,11 @@ function holoIndexMetaFromBundle(output, usedOfflineFallback, taskText) {
     direct_read_fallback_used: usedOfflineFallback ? true : false,
     required_targets_total: 0,
     required_targets_recalled: 0,
-    required_targets_missing: []
+    required_targets_missing: [],
+    direct_read_paths: [],
+    direct_read_rejected: [],
+    direct_read_bytes: 0,
+    direct_read_truncated: []
   };
   try {
     const data = JSON.parse(String(output || '{}'));
@@ -2642,15 +2660,50 @@ function holoIndexMetaFromBundle(output, usedOfflineFallback, taskText) {
     meta.skill_hits = bundleMeta.skill_count !== undefined ? Number(bundleMeta.skill_count) : 'unknown';
     meta.target_recall_ok = recall.target_recall_ok;
     meta.index_gap_detected = recall.index_gap_detected;
-    meta.direct_read_fallback_used = !!usedOfflineFallback;
     meta.recall_targets = recall.recall_targets;
     meta.required_targets_total = recall.required_targets_total;
     meta.required_targets_recalled = recall.required_targets_recalled;
     meta.required_targets_missing = recall.required_targets_missing;
+    // REDDOG_DIRECT_READ_FALLBACK_BY_PATH_PHASE1: surface the Python-side
+    // governed direct-read telemetry when the bundle carried a fetch.
+    const dr = data.direct_read && typeof data.direct_read === 'object' ? data.direct_read : null;
+    if (dr) {
+      meta.direct_read_fallback_used = !!dr.direct_read_fallback_used;
+      meta.direct_read_paths = Array.isArray(dr.direct_read_paths) ? dr.direct_read_paths : [];
+      meta.direct_read_rejected = Array.isArray(dr.direct_read_rejected) ? dr.direct_read_rejected : [];
+      meta.direct_read_bytes = Number(dr.direct_read_bytes || 0);
+      meta.direct_read_truncated = Array.isArray(dr.direct_read_truncated) ? dr.direct_read_truncated : [];
+    } else {
+      meta.direct_read_fallback_used = !!usedOfflineFallback;
+    }
   } catch (err) {
     meta.holoindex_status = usedOfflineFallback ? 'offline_fallback' : 'parse_error';
   }
   return meta;
+}
+
+// REDDOG_DIRECT_READ_FALLBACK_BY_PATH_PHASE1 (slice 2/3): when slice-1's
+// detector reports a required-target index gap, ask the Python bundle layer to
+// fetch the missing repo-relative targets (governed direct-read). The fetch and
+// the hard security allowlist live in bundle_json.py; the extension only names
+// the paths. Content flows back through the EXISTING redaction gate unchanged.
+function buildMustIncludeArgs(missingTargets) {
+  const args = [];
+  const seen = new Set();
+  for (const raw of (Array.isArray(missingTargets) ? missingTargets : [])) {
+    const target = String(raw || '').trim();
+    if (!target || target.startsWith('symbol:')) {
+      // Symbols cannot be direct-read by path; leave them for later retrieval.
+      continue;
+    }
+    const norm = target.toLowerCase();
+    if (seen.has(norm)) {
+      continue;
+    }
+    seen.add(norm);
+    args.push('--bundle-must-include', target);
+  }
+  return args;
 }
 
 function holoIndexOutput(root, taskText, maxChars) {
@@ -2658,7 +2711,8 @@ function holoIndexOutput(root, taskText, maxChars) {
   const moduleHint = moduleHintFromActive(root);
   try {
     const env = Object.assign({}, process.env, { HOLO_SKIP_MODEL: '1' });
-    const output = cp.execFileSync('python', ['-B', 'holo_index.py', '--bundle-json', '--search', query, '--bundle-module-hint', moduleHint, '--limit', '5', '--quiet-root-alerts'], {
+    const baseArgs = ['-B', 'holo_index.py', '--bundle-json', '--search', query, '--bundle-module-hint', moduleHint, '--limit', '5', '--quiet-root-alerts'];
+    let output = cp.execFileSync('python', baseArgs, {
       cwd: root,
       env,
       encoding: 'utf8',
@@ -2666,8 +2720,38 @@ function holoIndexOutput(root, taskText, maxChars) {
       maxBuffer: Math.max(maxChars * 4, 65536),
       windowsHide: true
     });
-    const meta = holoIndexMetaFromBundle(output, false, query);
-    return { output: String(output || '').slice(0, maxChars), quality: summarizeHoloBundle(output), meta: meta };
+    let meta = holoIndexMetaFromBundle(output, false, taskText);
+    // Direct-read fallback: if a required-target list was present and any target
+    // is missing from the semantic bundle, re-run once asking the Python layer
+    // to fetch exactly those paths, then re-evaluate recall on the enriched bundle.
+    const missing = Array.isArray(meta.required_targets_missing) ? meta.required_targets_missing : [];
+    if (meta.index_gap_detected === true && missing.length) {
+      const mustInclude = buildMustIncludeArgs(missing);
+      if (mustInclude.length) {
+        try {
+          const enrichedArgs = baseArgs.concat(mustInclude);
+          const enriched = cp.execFileSync('python', enrichedArgs, {
+            cwd: root,
+            env,
+            encoding: 'utf8',
+            timeout: 30000,
+            maxBuffer: Math.max(maxChars * 8, 131072),
+            windowsHide: true
+          });
+          output = enriched;
+          meta = holoIndexMetaFromBundle(enriched, false, taskText);
+        } catch (fetchErr) {
+          // Fetch failure must not abort recall; keep the pre-fetch bundle+meta.
+        }
+      }
+    }
+    const directReadSection = buildDirectReadContentSection(output);
+    return {
+      output: String(output || '').slice(0, maxChars),
+      quality: summarizeHoloBundle(output),
+      meta: meta,
+      direct_read_section: directReadSection
+    };
   } catch (bundleErr) {
     try {
       const output = cp.execFileSync('python', ['-B', 'holo_index.py', '--offline', '--search', query, '--limit', '5'], {
@@ -2691,6 +2775,46 @@ function holoIndexOutput(root, taskText, maxChars) {
       };
     }
   }
+}
+
+// Render the Python-fetched direct-read target content (already budget-bounded
+// and security-allowlisted by bundle_json.py) into a dedicated bounded section.
+// This does NOT re-read the filesystem and does NOT apply any redaction-category
+// logic (slice 3); the assembled context still passes through the existing
+// Python egress redaction gate unchanged before leaving the machine.
+function buildDirectReadContentSection(output) {
+  const empty = { text: '', paths: [], chars: 0 };
+  let data;
+  try {
+    data = JSON.parse(String(output || '{}'));
+  } catch (err) {
+    return empty;
+  }
+  const hits = data && data.task_retrieval && Array.isArray(data.task_retrieval.code_hits)
+    ? data.task_retrieval.code_hits
+    : [];
+  const directHits = hits.filter((h) => h && h.direct_read === true && typeof h.content === 'string' && h.content.length);
+  if (!directHits.length) {
+    return empty;
+  }
+  const sections = [];
+  const paths = [];
+  let used = 0;
+  for (const hit of directHits) {
+    const rel = String(hit.location || '').replace(/\\/g, '/');
+    const lang = targetSnippetLanguageId(rel);
+    const truncatedNote = hit.content_truncated ? ' (truncated to governed budget)' : '';
+    sections.push('#### ' + rel + truncatedNote + '\n```' + lang + '\n' + hit.content + '\n```');
+    paths.push(rel);
+    used += hit.content.length;
+  }
+  return {
+    text: '### Direct-read target content (governed fetch by path)\n'
+      + 'Fetched by the Python bundle layer under the direct-read allowlist; still redaction-gated before egress.\n\n'
+      + sections.join('\n\n'),
+    paths: paths,
+    chars: used
+  };
 }
 
 function summarizeHoloBundle(output) {
@@ -3187,6 +3311,8 @@ module.exports = {
   isSelfFileLocation,
   requiredTargetMatchesLocation,
   holoIndexMetaFromBundle,
+  buildMustIncludeArgs,
+  buildDirectReadContentSection,
   isTargetReadPathDenied,
   resolveSafeRepoFile,
   readBoundedTargetSnippet,

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups®Agent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.29",
+    "version":  "0.3.30",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -772,6 +772,118 @@ includes(trpScorecardLines, '- required_targets_total: 3', 'TRP-007: rendered sc
 includes(trpScorecardLines, '- required_targets_recalled: 0', 'TRP-007: rendered scorecard must show required_targets_recalled');
 includes(trpScorecardLines, '- required_targets_missing: ', 'TRP-007: rendered scorecard must show required_targets_missing');
 
+// REDDOG_DIRECT_READ_FALLBACK_BY_PATH_PHASE1 (slice 2/3): governed direct-read telemetry.
+includes(extensionJs, 'function buildMustIncludeArgs', 'DRF: must-include arg builder missing');
+includes(extensionJs, 'function buildDirectReadContentSection', 'DRF: direct-read content section builder missing');
+includes(extensionJs, '--bundle-must-include', 'DRF: extension must request must-include paths from the Python bundle layer');
+includes(extensionJs, 'direct_read_fallback_used', 'DRF: direct_read_fallback_used telemetry missing');
+includes(extensionJs, 'direct_read_paths', 'DRF: direct_read_paths telemetry missing');
+includes(extensionJs, 'direct_read_rejected', 'DRF: direct_read_rejected telemetry missing');
+includes(extensionJs, 'direct_read_bytes', 'DRF: direct_read_bytes telemetry missing');
+includes(extensionJs, 'direct_read_truncated', 'DRF: direct_read_truncated telemetry missing');
+
+// DRF-001: must-include args are built from missing targets, symbols excluded, deduped, path-quoted per --bundle-must-include.
+const drfArgs = orchestrator.buildMustIncludeArgs([
+  'WSP_framework/src/WSP_109_FoundUp_Onboarding_Intake_Protocol.md',
+  'symbol:createFoundUp',
+  'WSP_framework/src/WSP_109_FoundUp_Onboarding_Intake_Protocol.md',
+  'modules/foundups/agent/src/source_authority.py'
+]);
+assert.deepStrictEqual(drfArgs, [
+  '--bundle-must-include', 'WSP_framework/src/WSP_109_FoundUp_Onboarding_Intake_Protocol.md',
+  '--bundle-must-include', 'modules/foundups/agent/src/source_authority.py'
+], 'DRF-001: must-include args must dedup, drop symbols, and prefix each path with --bundle-must-include');
+assert.deepStrictEqual(orchestrator.buildMustIncludeArgs([]), [], 'DRF-001: empty missing list => no fetch args');
+assert.deepStrictEqual(orchestrator.buildMustIncludeArgs(['symbol:only']), [], 'DRF-001: symbol-only missing list => no fetch args');
+
+// DRF-002: direct-read telemetry from the Python bundle flows into meta + scorecard.
+const drfBundle = JSON.stringify({
+  task_retrieval: {
+    code_hits: [
+      { location: 'WSP_framework/src/WSP_109_FoundUp_Onboarding_Intake_Protocol.md', need: 'direct-read target', direct_read: true, content: '# WSP 109 onboarding', content_truncated: true },
+      { location: 'modules/foundups/agent/src/source_authority.py', need: 'direct-read target', direct_read: true, content: 'class SourceAuthority: pass', content_truncated: false }
+    ],
+    metadata: { code_count: 2, wsp_count: 0 }
+  },
+  direct_read: {
+    direct_read_fallback_used: true,
+    direct_read_paths: ['WSP_framework/src/WSP_109_FoundUp_Onboarding_Intake_Protocol.md', 'modules/foundups/agent/src/source_authority.py'],
+    direct_read_rejected: [{ path: '.env', reason: 'denied_basename' }, { path: '../../etc/passwd', reason: 'traversal' }],
+    direct_read_bytes: 4096,
+    direct_read_truncated: [{ path: 'WSP_framework/src/WSP_109_FoundUp_Onboarding_Intake_Protocol.md', bytes: 12000 }]
+  }
+});
+const drfPrompt = [
+  'Audit the FoundUp creation monorepo WSP_109 execution path.',
+  '',
+  'Required direct-read targets:',
+  '- WSP_framework/src/WSP_109_FoundUp_Onboarding_Intake_Protocol.md',
+  '- modules/foundups/agent/src/source_authority.py',
+  '',
+  'Produce required architect sections.'
+].join('\n');
+const drfMeta = orchestrator.holoIndexMetaFromBundle(drfBundle, false, drfPrompt);
+assert.strictEqual(drfMeta.direct_read_fallback_used, true, 'DRF-002: direct_read_fallback_used must reflect the Python fetch');
+assert.deepStrictEqual(drfMeta.direct_read_paths, ['WSP_framework/src/WSP_109_FoundUp_Onboarding_Intake_Protocol.md', 'modules/foundups/agent/src/source_authority.py'], 'DRF-002: direct_read_paths must pass through');
+assert.strictEqual(drfMeta.direct_read_bytes, 4096, 'DRF-002: direct_read_bytes must pass through');
+assert.strictEqual(drfMeta.direct_read_rejected.length, 2, 'DRF-002: direct_read_rejected must pass through');
+assert.strictEqual(drfMeta.direct_read_truncated.length, 1, 'DRF-002: direct_read_truncated must pass through');
+
+// DRF-003: after the fetch is present, slice-1 recall reports satisfied (gap resolved).
+assert.strictEqual(drfMeta.target_recall_ok, true, 'DRF-003: fetched targets must satisfy required recall');
+assert.strictEqual(drfMeta.index_gap_detected, false, 'DRF-003: index gap must clear once targets are fetched');
+assert.strictEqual(drfMeta.required_targets_recalled, 2, 'DRF-003: both required targets must count as recalled');
+
+// DRF-004: scorecard surfaces the direct-read vocabulary for the Work Trail.
+const drfScorecard = orchestrator.extractHoloIndexScorecard('wsp_holo', drfMeta);
+const drfLines = orchestrator.formatHoloIndexScorecardLines(drfScorecard).join('\n');
+includes(drfLines, '- direct_read_fallback_used: true', 'DRF-004: rendered scorecard must show direct_read_fallback_used');
+includes(drfLines, '- direct_read_paths: ', 'DRF-004: rendered scorecard must show direct_read_paths');
+includes(drfLines, '- direct_read_rejected: .env (denied_basename)', 'DRF-004: rendered scorecard must show rejected path + reason');
+includes(drfLines, '- direct_read_bytes: 4096', 'DRF-004: rendered scorecard must show direct_read_bytes');
+includes(drfLines, '- direct_read_truncated: ', 'DRF-004: rendered scorecard must show direct_read_truncated');
+
+// DRF-005: direct-read content section renders the fetched source (no fs re-read; from bundle JSON).
+const drfSection = orchestrator.buildDirectReadContentSection(drfBundle);
+assert(drfSection.text.length > 0, 'DRF-005: direct-read content section must render when direct_read hits exist');
+includes(drfSection.text, '# WSP 109 onboarding', 'DRF-005: fetched content must be present in the section');
+includes(drfSection.text, 'class SourceAuthority: pass', 'DRF-005: every fetched target content must be present');
+includes(drfSection.text, '(truncated to governed budget)', 'DRF-005: truncated targets must be labelled');
+assert.strictEqual(drfSection.paths.length, 2, 'DRF-005: section must list both fetched paths');
+const drfEmptySection = orchestrator.buildDirectReadContentSection(JSON.stringify({ task_retrieval: { code_hits: [] } }));
+assert.strictEqual(drfEmptySection.text, '', 'DRF-005: no direct_read hits => empty section (no fabricated content)');
+
+// DRF-006: benign fetched content passes the EXISTING redaction gate unchanged.
+// (This proves the direct-read section is normal context text; slice 2 adds no
+// new sanitizer and weakens none.)
+const drfBenignBundle = JSON.stringify({
+  task_retrieval: {
+    code_hits: [
+      { location: 'modules/foundups/agent/src/example_readme.md', need: 'direct-read target', direct_read: true, content: '# Example\nThis module wires the onboarding flow and returns a status dict.', content_truncated: false }
+    ],
+    metadata: { code_count: 1, wsp_count: 0 }
+  }
+});
+const drfBenignSection = orchestrator.buildDirectReadContentSection(drfBenignBundle);
+assertFusionRedactionGatePasses(drfBenignSection.text, 'DRF-006: benign direct-read content must pass the existing redaction gate');
+
+// DRF-007: SLICE BOUNDARY PROOF. Governance-adjacent fetched content is STILL
+// blocked by the EXISTING redaction gate (source_authority category), unchanged
+// by slice 2. Slice 3 owns audit-mode redaction relaxation; slice 2 must not
+// weaken (or expand) any redaction category. The gate behavior is identical to
+// before this slice for such content.
+const drfGovSection = orchestrator.buildDirectReadContentSection(drfBundle);
+let drfGovBlocked = false;
+let drfGovCategory = '';
+try {
+  assertFusionRedactionGatePasses(drfGovSection.text, 'probe');
+} catch (govErr) {
+  drfGovBlocked = true;
+  drfGovCategory = String((govErr && govErr.stdout) || '');
+}
+assert(drfGovBlocked, 'DRF-007: governance-adjacent fetched content must STILL be blocked by the unchanged redaction gate (slice-3 owns relaxation)');
+includes(drfGovCategory, 'source_authority', 'DRF-007: the existing source_authority category must still fire (no category change in slice 2)');
+
 includes(blockedCopy, '## Governed Handoff Recommendation', 'substantive task must include governed handoff recommendation');
 includes(blockedCopy, 'handoff_needed: unknown', 'blocked-local packet must use conservative handoff_needed');
 includes(blockedCopy, 'reason: blocked_context_needs_local_0102_review', 'blocked-local packet must include conservative handoff reason');

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -83,8 +83,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.29', 'package version must be 0.3.29');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.29'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.30', 'package version must be 0.3.30');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.30'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups®Agent', 'display name must be Foundups®Agent');
 includes(JSON.stringify(pkg), 'Foundups®Agent: Open', 'command title must use Foundups®Agent');
@@ -101,7 +101,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.29', 'README version mismatch');
+includes(readme, 'Version: 0.3.30', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -950,7 +950,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.29'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.30'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -964,7 +964,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.29'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.30'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -976,7 +976,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.29'", 'bounded context must include extension.js source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.30'", 'bounded context must include extension.js source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');

--- a/holo_index/_cli_main.py
+++ b/holo_index/_cli_main.py
@@ -643,6 +643,17 @@ def main():
         type=str,
         help='Override task string used for bundle generation (defaults to --search)'
     )
+    parser.add_argument(
+        '--bundle-must-include',
+        action='append',
+        default=None,
+        help=(
+            'Repo-relative target path(s) to fetch into the bundle under the '
+            'governed direct-read allowlist (repeatable or comma-separated). '
+            'Used when required direct-read targets are absent from the semantic '
+            'bundle. Read-only; hard-denies secrets/traversal/symlink-escape.'
+        )
+    )
     parser.add_argument('--index', action='store_true', help='Index both code and WSP (alias for --index-all)')
     parser.add_argument('--index-all', action='store_true', help='Index both code and WSP')
     parser.add_argument('--index-code', action='store_true', help='Index code (NAVIGATION.py)')

--- a/holo_index/cli/commands/bundle_json.py
+++ b/holo_index/cli/commands/bundle_json.py
@@ -17,6 +17,275 @@ def _env_truthy(key: str, default: str = "false") -> bool:
     return os.getenv(key, default).lower() in {"1", "true", "yes", "on"}
 
 
+# ---------------------------------------------------------------------------
+# REDDOG_DIRECT_READ_FALLBACK_BY_PATH_PHASE1 (slice 2/3): governed direct-read.
+#
+# When slice-1's detector reports an index gap on an explicit required-target
+# list, the extension asks the Python bundle layer (this module) to fetch those
+# exact repo files' content so RedDog reasons on real source instead of HOLDing
+# blind. This is a READ-ONLY capability with a HARD security allowlist. It adds
+# no execution authority, no write path, and no shell-out. Fetched content still
+# passes through the EXISTING extension.js redaction gate unchanged (slice 3
+# owns redaction-category behavior).
+# ---------------------------------------------------------------------------
+
+# Per-file byte cap: many targets each get a bounded snippet rather than one
+# file consuming the whole budget (the failing run truncated a single 24K/104K
+# file and dropped the rest).
+DIRECT_READ_PER_FILE_BYTES = 12000
+# Total fetch budget across ALL targets. Spread so many targets each land.
+DIRECT_READ_TOTAL_BUDGET_BYTES = 96000
+# Hard cap on how many targets we will even attempt (defensive; ranked by order).
+DIRECT_READ_MAX_TARGETS = 40
+
+# HARD-DENY basenames (exact match, case-insensitive).
+DIRECT_READ_DENY_BASENAMES = frozenset({
+    ".env",
+    "id_rsa",
+    "id_ed25519",
+})
+
+# HARD-DENY path segments: any path traversing one of these dirs is rejected.
+DIRECT_READ_DENY_SEGMENTS = frozenset({
+    ".git",
+    ".ssh",
+    ".gnupg",
+    ".aws",
+    ".azure",
+    ".gcloud",
+    "node_modules",
+    "__pycache__",
+    ".venv",
+})
+
+# HARD-DENY glob-ish suffix / substring rules applied to the lowercased basename
+# (and, for the *secret*/*credential*/*token* rules, any path segment).
+DIRECT_READ_DENY_SUFFIXES = (
+    ".pem",
+    ".key",
+    ".p12",
+    ".keystore",
+    ".pfx",
+    ".vsix",
+)
+# basename prefixes that hard-deny (covers .env.local, id_rsa.pub, etc.).
+DIRECT_READ_DENY_PREFIXES = (
+    ".env",
+    "id_rsa",
+    "id_ed25519",
+)
+# substring markers that hard-deny anywhere in a path segment.
+DIRECT_READ_DENY_SUBSTRINGS = (
+    "secret",
+    "credential",
+    "token",
+)
+
+
+def _direct_read_deny_reason(rel_norm: str) -> Optional[str]:
+    """Return a deny reason string for a normalized repo-relative path, else None.
+
+    Pure lexical gate (no filesystem access). Absolute paths, drive-letters and
+    `..` traversal are rejected here; realpath containment is checked separately.
+    """
+    if not rel_norm:
+        return "path_missing"
+    # Absolute POSIX path or Windows drive-letter path -> reject.
+    if rel_norm.startswith("/") or (len(rel_norm) >= 2 and rel_norm[1] == ":"):
+        return "absolute_path"
+    parts = rel_norm.lower().split("/")
+    if any(p == ".." for p in parts):
+        return "traversal"
+    # Deny by path segment (credential dirs, .git, caches).
+    for seg in parts:
+        if seg in DIRECT_READ_DENY_SEGMENTS:
+            return "denied_segment"
+        for marker in DIRECT_READ_DENY_SUBSTRINGS:
+            if marker in seg:
+                return "denied_secret_like"
+    base = parts[-1]
+    if base in DIRECT_READ_DENY_BASENAMES:
+        return "denied_basename"
+    for pref in DIRECT_READ_DENY_PREFIXES:
+        if base == pref or base.startswith(pref + "."):
+            return "denied_basename"
+    for suf in DIRECT_READ_DENY_SUFFIXES:
+        if base.endswith(suf):
+            return "denied_extension"
+    return None
+
+
+def _normalize_direct_read_path(raw: str) -> str:
+    """Normalize a requested target into a candidate path string.
+
+    IMPORTANT: this MUST preserve a leading '/' or a drive-letter prefix so the
+    deny gate can reject absolute paths. It only trims quotes/whitespace and
+    collapses a leading './'. It never strips a leading slash (doing so would
+    silently turn '/etc/passwd' into a relative 'etc/passwd' and defeat the
+    absolute-path rejection).
+    """
+    norm = str(raw or "").strip().replace("\\", "/")
+    # Strip surrounding quotes/backticks a prompt might carry through.
+    norm = norm.strip("`'\"")
+    if norm in ("", "."):
+        return ""
+    # Collapse a leading ./ but keep the rest verbatim (do NOT resolve here).
+    while norm.startswith("./"):
+        norm = norm[2:]
+    return norm
+
+
+def _resolve_within_repo(repo_root, rel_norm: str):
+    """Resolve rel_norm against repo_root and verify realpath containment.
+
+    Returns (real_path, None) on success or (None, reason) when the resolved
+    real path escapes the repo root (covers symlink-escape). Never raises.
+    """
+    from pathlib import Path as _Path
+    try:
+        root_real = _Path(os.path.realpath(str(repo_root)))
+        candidate = (root_real / rel_norm)
+        real = _Path(os.path.realpath(str(candidate)))
+    except Exception:
+        return None, "path_missing"
+    try:
+        real.relative_to(root_real)
+    except ValueError:
+        return None, "outside_root"
+    return real, None
+
+
+def _read_bounded_direct_read(real_path, per_file_cap: int, remaining_budget: int):
+    """Read a bounded UTF-8 snippet honoring per-file cap and remaining budget.
+
+    Returns dict: {content, bytes, truncated, omitted_reason}. Binary files and
+    read errors are omitted (never abort the bundle).
+    """
+    from pathlib import Path as _Path
+    p = _Path(real_path)
+    try:
+        if not p.is_file():
+            return {"content": "", "bytes": 0, "truncated": False, "omitted_reason": "not_a_file"}
+    except Exception:
+        return {"content": "", "bytes": 0, "truncated": False, "omitted_reason": "path_missing"}
+
+    cap = max(0, min(per_file_cap, remaining_budget))
+    if cap <= 0:
+        return {"content": "", "bytes": 0, "truncated": False, "omitted_reason": "budget_exhausted"}
+    try:
+        with open(p, "rb") as fh:
+            raw = fh.read(cap + 1)
+    except Exception:
+        return {"content": "", "bytes": 0, "truncated": False, "omitted_reason": "read_error"}
+    # Binary sniff: a NUL byte in the head means "not source we should inline".
+    if b"\x00" in raw:
+        return {"content": "", "bytes": 0, "truncated": False, "omitted_reason": "binary"}
+    truncated = len(raw) > cap
+    clipped = raw[:cap]
+    text = clipped.decode("utf-8", errors="replace")
+    return {
+        "content": text,
+        "bytes": len(clipped),
+        "truncated": truncated,
+        "omitted_reason": "none",
+    }
+
+
+def _direct_read_fetch(repo_root, requested_paths, seen_locations=None):
+    """Governed direct-read-by-path fetch (slice 2/3).
+
+    Given repo-relative target paths (ranked by caller / prompt order), read a
+    bounded snippet of each into the bundle. All security rejections are recorded
+    (never abort). Returns a telemetry dict plus the fetched hit records so the
+    caller can splice content-bearing locations into code_hits.
+    """
+    from pathlib import Path as _Path
+
+    seen = set(seen_locations or [])
+    telemetry = {
+        "direct_read_fallback_used": False,
+        "direct_read_paths": [],
+        "direct_read_rejected": [],
+        "direct_read_bytes": 0,
+        "direct_read_truncated": [],
+        "per_file_cap": DIRECT_READ_PER_FILE_BYTES,
+        "total_budget": DIRECT_READ_TOTAL_BUDGET_BYTES,
+    }
+    hits: List[Dict[str, Any]] = []
+
+    # De-duplicate while preserving prompt order; cap total attempted targets.
+    ordered: List[str] = []
+    ordered_seen = set()
+    for raw in (requested_paths or []):
+        rel = _normalize_direct_read_path(raw)
+        if not rel:
+            telemetry["direct_read_rejected"].append({"path": str(raw), "reason": "path_missing"})
+            continue
+        key = rel.lower()
+        if key in ordered_seen:
+            continue
+        ordered_seen.add(key)
+        ordered.append(rel)
+    if len(ordered) > DIRECT_READ_MAX_TARGETS:
+        for extra in ordered[DIRECT_READ_MAX_TARGETS:]:
+            telemetry["direct_read_rejected"].append({"path": extra, "reason": "too_many_targets"})
+        ordered = ordered[:DIRECT_READ_MAX_TARGETS]
+
+    remaining = DIRECT_READ_TOTAL_BUDGET_BYTES
+    for rel in ordered:
+        # 1) lexical hard-deny + traversal/absolute check.
+        deny = _direct_read_deny_reason(rel)
+        if deny:
+            telemetry["direct_read_rejected"].append({"path": rel, "reason": deny})
+            continue
+        # 2) realpath containment (covers symlink escape).
+        real, reason = _resolve_within_repo(repo_root, rel)
+        if real is None:
+            telemetry["direct_read_rejected"].append({"path": rel, "reason": reason})
+            continue
+        # 3) re-check deny rules against the resolved real basename (defense in
+        #    depth: a symlink named foo.txt could target bar.key inside repo).
+        try:
+            real_rel = str(_Path(os.path.realpath(str(repo_root))))
+            resolved_rel = os.path.relpath(str(real), real_rel).replace("\\", "/")
+        except Exception:
+            resolved_rel = rel
+        deny2 = _direct_read_deny_reason(resolved_rel)
+        if deny2:
+            telemetry["direct_read_rejected"].append({"path": rel, "reason": deny2})
+            continue
+        if remaining <= 0:
+            telemetry["direct_read_rejected"].append({"path": rel, "reason": "budget_exhausted"})
+            continue
+        # 4) bounded read.
+        snippet = _read_bounded_direct_read(real, DIRECT_READ_PER_FILE_BYTES, remaining)
+        if not snippet["content"]:
+            if snippet["omitted_reason"] not in ("none",):
+                telemetry["direct_read_rejected"].append({"path": rel, "reason": snippet["omitted_reason"]})
+            continue
+        remaining -= snippet["bytes"]
+        telemetry["direct_read_bytes"] += snippet["bytes"]
+        telemetry["direct_read_paths"].append(rel)
+        if snippet["truncated"]:
+            telemetry["direct_read_truncated"].append({"path": rel, "bytes": snippet["bytes"]})
+        if rel.lower() not in seen:
+            seen.add(rel.lower())
+            hits.append({
+                "need": "direct-read target: " + rel,
+                "location": rel,
+                "similarity": "100.0%",
+                "cube": None,
+                "type": "code",
+                "priority": 1,
+                "direct_read": True,
+                "content": snippet["content"],
+                "content_bytes": snippet["bytes"],
+                "content_truncated": snippet["truncated"],
+            })
+    telemetry["direct_read_fallback_used"] = len(telemetry["direct_read_paths"]) > 0
+    return {"telemetry": telemetry, "hits": hits}
+
+
 def _resolve_module_dir(repo_root, hint: str):
     """Resolve a module hint to an actual directory path."""
     from pathlib import Path as _Path
@@ -354,6 +623,45 @@ def handle_bundle_json(args):
     if module_dir is not None:
         structured_memory = _artifact_snapshot(module_dir)
 
+    # REDDOG_DIRECT_READ_FALLBACK_BY_PATH_PHASE1 (slice 2/3): governed direct-read.
+    # When the extension names must-include target paths (from an explicit
+    # "Required direct-read targets" prompt list) that the semantic bundle did
+    # not surface, fetch those exact files here under the hard security allowlist
+    # and splice them into code_hits so slice-1's recall check sees real content.
+    must_include_raw = getattr(args, "bundle_must_include", None)
+    must_include: List[str] = []
+    if must_include_raw:
+        if isinstance(must_include_raw, (list, tuple)):
+            for item in must_include_raw:
+                must_include.extend([p for p in str(item).split(",") if p.strip()])
+        else:
+            must_include.extend([p for p in str(must_include_raw).split(",") if p.strip()])
+
+    direct_read = None
+    if must_include:
+        existing_locations = set()
+        try:
+            for hit in (search_payload.get("code_hits") or []):
+                loc = str(hit.get("location") or "").replace("\\", "/").lower()
+                if loc:
+                    existing_locations.add(loc)
+        except Exception:
+            existing_locations = set()
+        fetched = _direct_read_fetch(repo_root, must_include, seen_locations=existing_locations)
+        direct_read = fetched["telemetry"]
+        if fetched["hits"]:
+            try:
+                # Prepend direct-read hits (highest priority) so recall + display
+                # both see the fetched content-bearing locations first.
+                search_payload["code_hits"] = fetched["hits"] + list(search_payload.get("code_hits") or [])
+                search_payload["code"] = search_payload["code_hits"]
+                meta = search_payload.get("metadata")
+                if isinstance(meta, dict):
+                    meta["code_count"] = len(search_payload["code_hits"])
+                    meta["direct_read_fallback_used"] = direct_read["direct_read_fallback_used"]
+            except Exception:
+                pass
+
     bundle = {
         "schema_version": "wsp_memory_bundle_v1",
         "generated_at": _dt.utcnow().isoformat() + "Z",
@@ -363,6 +671,7 @@ def handle_bundle_json(args):
         "module_path": module_path,
         "structured_memory": structured_memory,
         "task_retrieval": search_payload,
+        "direct_read": direct_read,
     }
 
     sys.stdout.write(_json.dumps(bundle, ensure_ascii=True) + "\n")

--- a/holo_index/tests/test_reddog_extension_bundle_recall.py
+++ b/holo_index/tests/test_reddog_extension_bundle_recall.py
@@ -13,7 +13,16 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
-from holo_index.cli.commands.bundle_json import _lexical_task_retrieval, _resolve_module_dir
+from holo_index.cli.commands.bundle_json import (
+    _lexical_task_retrieval,
+    _resolve_module_dir,
+    _direct_read_fetch,
+    _direct_read_deny_reason,
+    _normalize_direct_read_path,
+    _resolve_within_repo,
+    DIRECT_READ_PER_FILE_BYTES,
+    DIRECT_READ_TOTAL_BUDGET_BYTES,
+)
 
 EXTENSION_JS = REPO_ROOT / "extensions" / "foundups_advisory_workers" / "extension.js"
 
@@ -214,3 +223,223 @@ def test_no_required_list_preserves_prior_behavior():
     assert unknown["target_recall_ok"] == "unknown"
     assert unknown["index_gap_detected"] is False
     assert unknown["required_targets_total"] == 0
+
+
+# --- REDDOG_DIRECT_READ_FALLBACK_BY_PATH_PHASE1 (slice 2/3) governed direct-read ------
+
+# Real repo files that exist and mirror the FoundUp-creation audit required list.
+FOUNDUP_ACCEPTANCE_TARGETS = [
+    "WSP_framework/src/WSP_109_FoundUp_Onboarding_Intake_Protocol.md",
+    "modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py",
+    "modules/foundups/agent/src/hermes_foundup_job_executor.py",
+    "modules/communication/moltbot_bridge/src/foundup_job_contract.py",
+    "modules/communication/moltbot_bridge/src/reddog_governed_work_order_dryrun.py",
+    "modules/communication/moltbot_bridge/src/reddog_wre_execution_valve.py",
+    "modules/foundups/agent/src/source_authority.py",
+]
+
+
+def _rejected_reasons(telemetry: dict) -> dict:
+    return {r["path"]: r["reason"] for r in telemetry.get("direct_read_rejected", [])}
+
+
+def test_direct_read_deny_reason_lexical_gate():
+    """Hard-deny + traversal + absolute rules are pure-lexical and testable."""
+    assert _direct_read_deny_reason("../../etc/passwd") == "traversal"
+    assert _direct_read_deny_reason("/etc/passwd") == "absolute_path"
+    assert _direct_read_deny_reason("C:/Windows/system32/hosts") == "absolute_path"
+    assert _direct_read_deny_reason(".env") == "denied_basename"
+    assert _direct_read_deny_reason("modules/x/.env.local") == "denied_basename"
+    assert _direct_read_deny_reason("certs/server.key") == "denied_extension"
+    assert _direct_read_deny_reason("certs/server.pem") == "denied_extension"
+    assert _direct_read_deny_reason("keys/store.keystore") == "denied_extension"
+    assert _direct_read_deny_reason("home/id_rsa") == "denied_basename"
+    assert _direct_read_deny_reason(".git/config") == "denied_segment"
+    assert _direct_read_deny_reason("config/my_secret_thing.py") == "denied_secret_like"
+    assert _direct_read_deny_reason("auth/access_token.json") == "denied_secret_like"
+    assert _direct_read_deny_reason("vault/user_credential.yaml") == "denied_secret_like"
+    # A benign in-repo source file passes the lexical gate.
+    assert _direct_read_deny_reason("modules/foundups/agent/src/source_authority.py") is None
+
+
+def test_direct_read_fetch_real_targets_present():
+    """Acceptance: FoundUp required targets are fetched + present in bundle hits."""
+    result = _direct_read_fetch(REPO_ROOT, FOUNDUP_ACCEPTANCE_TARGETS)
+    tel = result["telemetry"]
+    fetched = set(tel["direct_read_paths"])
+    for target in FOUNDUP_ACCEPTANCE_TARGETS:
+        assert target in fetched, f"required target not fetched: {target}"
+    assert tel["direct_read_fallback_used"] is True
+    assert tel["direct_read_rejected"] == []
+    assert tel["direct_read_bytes"] > 0
+    # Each fetched target is a content-bearing hit.
+    hit_locs = {h["location"] for h in result["hits"]}
+    for target in FOUNDUP_ACCEPTANCE_TARGETS:
+        assert target in hit_locs
+    for hit in result["hits"]:
+        assert hit["direct_read"] is True
+        assert isinstance(hit["content"], str) and hit["content"]
+
+
+def test_direct_read_fetch_flips_recall_via_node():
+    """Slice-2 bar: after the fetch, slice-1's recall reports satisfied."""
+    if not _node_available():
+        pytest.skip("node runtime required for evaluateTargetRecall")
+    prompt = (
+        "Audit the FoundUp creation monorepo WSP_109 execution path.\n\n"
+        "Required direct-read targets:\n"
+        + "".join("- " + t + "\n" for t in FOUNDUP_ACCEPTANCE_TARGETS)
+        + "\nProduce required architect sections.\n"
+    )
+    # Pre-fetch: bundle has none of the targets => index gap.
+    before = _run_target_recall(prompt, _hits("docs/unrelated_note.md"))
+    assert before["index_gap_detected"] is True
+    assert before["target_recall_ok"] is False
+    # Fetch, then re-run recall on the now-present locations.
+    result = _direct_read_fetch(REPO_ROOT, FOUNDUP_ACCEPTANCE_TARGETS)
+    fetched_hits = [
+        {"location": h["location"], "need": h["need"]} for h in result["hits"]
+    ]
+    after = _run_target_recall(prompt, fetched_hits)
+    assert after["target_recall_ok"] is True, after
+    assert after["index_gap_detected"] is False
+    assert after["required_targets_recalled"] == len(FOUNDUP_ACCEPTANCE_TARGETS)
+    assert after["required_targets_missing"] == []
+
+
+def test_direct_read_traversal_rejected_bundle_still_returned():
+    """Path traversal is rejected + recorded; bundle fetch still completes."""
+    result = _direct_read_fetch(
+        REPO_ROOT,
+        ["../../etc/passwd", "..\\..\\windows\\system32\\config", "modules/foundups/agent/src/source_authority.py"],
+    )
+    tel = result["telemetry"]
+    reasons = _rejected_reasons(tel)
+    assert reasons.get("../../etc/passwd") == "traversal"
+    assert reasons.get("../../windows/system32/config") == "traversal"
+    # The benign target is still fetched (rejections do not abort the bundle).
+    assert "modules/foundups/agent/src/source_authority.py" in tel["direct_read_paths"]
+
+
+def test_direct_read_absolute_path_rejected():
+    result = _direct_read_fetch(REPO_ROOT, ["/etc/passwd", "C:/Windows/System32/drivers/etc/hosts"])
+    reasons = _rejected_reasons(result["telemetry"])
+    assert reasons.get("/etc/passwd") == "absolute_path"
+    assert reasons.get("C:/Windows/System32/drivers/etc/hosts") == "absolute_path"
+    assert result["telemetry"]["direct_read_paths"] == []
+    assert result["telemetry"]["direct_read_fallback_used"] is False
+
+
+def test_direct_read_secret_fixtures_never_read(tmp_path, monkeypatch):
+    """.env and *.key synthetic fixtures are hard-denied and never read."""
+    # Build a synthetic repo root so real repo secrets are never touched.
+    fake_root = tmp_path / "repo"
+    (fake_root / "modules").mkdir(parents=True)
+    # Synthetic dummy secret values ONLY (never a real credential).
+    (fake_root / ".env").write_text("DUMMY_TOKEN=synthetic-not-a-real-secret\n", encoding="utf-8")
+    (fake_root / "server.key").write_text("-----BEGIN PRIVATE KEY-----\nSYNTHETIC-DUMMY\n-----END PRIVATE KEY-----\n", encoding="utf-8")
+    (fake_root / "app_secret.py").write_text("VALUE = 'synthetic'\n", encoding="utf-8")
+    (fake_root / "modules" / "ok.py").write_text("SAFE = True\n", encoding="utf-8")
+
+    result = _direct_read_fetch(fake_root, [".env", "server.key", "app_secret.py", "modules/ok.py"])
+    tel = result["telemetry"]
+    reasons = _rejected_reasons(tel)
+    assert reasons.get(".env") == "denied_basename"
+    assert reasons.get("server.key") == "denied_extension"
+    assert reasons.get("app_secret.py") == "denied_secret_like"
+    # No secret content ever appears in any fetched hit.
+    joined = "\n".join(h.get("content", "") for h in result["hits"])
+    assert "synthetic-not-a-real-secret" not in joined
+    assert "BEGIN PRIVATE KEY" not in joined
+    # The one safe file is fetched.
+    assert "modules/ok.py" in tel["direct_read_paths"]
+
+
+def test_direct_read_per_file_cap_and_total_budget(tmp_path):
+    """Many large targets: each is bounded and total budget is not blown on one."""
+    fake_root = tmp_path / "repo"
+    (fake_root / "src").mkdir(parents=True)
+    # Create more-than-budget worth of large files so the spread matters.
+    big = "X" * 40000  # 40KB each, well over the per-file cap.
+    n_files = (DIRECT_READ_TOTAL_BUDGET_BYTES // DIRECT_READ_PER_FILE_BYTES) + 4
+    targets = []
+    for i in range(n_files):
+        rel = f"src/big_{i}.py"
+        (fake_root / rel).write_text(big, encoding="utf-8")
+        targets.append(rel)
+
+    result = _direct_read_fetch(fake_root, targets)
+    tel = result["telemetry"]
+    # No single fetched file exceeded the per-file cap.
+    for hit in result["hits"]:
+        assert hit["content_bytes"] <= DIRECT_READ_PER_FILE_BYTES, hit["location"]
+    # Total injected bytes never exceed the total budget.
+    assert tel["direct_read_bytes"] <= DIRECT_READ_TOTAL_BUDGET_BYTES
+    # Budget was spread across MANY targets, not consumed by one.
+    assert len(tel["direct_read_paths"]) > 1
+    # Every fetched large file records a per-file truncation.
+    truncated_paths = {t["path"] for t in tel["direct_read_truncated"]}
+    for rel in tel["direct_read_paths"]:
+        assert rel in truncated_paths
+
+
+def test_direct_read_symlink_escape_rejected(tmp_path):
+    """A symlink whose real target escapes the repo root is rejected."""
+    fake_root = tmp_path / "repo"
+    (fake_root).mkdir(parents=True)
+    outside = tmp_path / "outside_secret.txt"
+    outside.write_text("SYNTHETIC-outside-do-not-read\n", encoding="utf-8")
+    link = fake_root / "escape_link.txt"
+    try:
+        os.symlink(outside, link)
+    except (OSError, NotImplementedError):
+        # Runner cannot create symlinks: assert the realpath containment unit
+        # instead (equivalent guarantee: resolved real path must stay in root).
+        real, reason = _resolve_within_repo(fake_root, "../outside_secret.txt")
+        assert real is None
+        assert reason in ("traversal", "outside_root", "path_missing")
+        return
+    result = _direct_read_fetch(fake_root, ["escape_link.txt"])
+    tel = result["telemetry"]
+    reasons = _rejected_reasons(tel)
+    assert reasons.get("escape_link.txt") == "outside_root"
+    joined = "\n".join(h.get("content", "") for h in result["hits"])
+    assert "SYNTHETIC-outside-do-not-read" not in joined
+
+
+def test_direct_read_cli_end_to_end(monkeypatch):
+    """--bundle-must-include fetches real targets into the CLI bundle JSON."""
+    monkeypatch.chdir(REPO_ROOT)
+    env = os.environ.copy()
+    env["HOLO_SKIP_MODEL"] = "1"
+    cli = [
+        sys.executable,
+        "-B",
+        "holo_index.py",
+        "--bundle-json",
+        "--search",
+        "Audit FoundUp creation monorepo WSP_109 execution path",
+        "--limit",
+        "5",
+        "--quiet-root-alerts",
+    ]
+    for target in FOUNDUP_ACCEPTANCE_TARGETS:
+        cli += ["--bundle-must-include", target]
+    # Include a hard-deny + traversal to prove they are rejected, not read.
+    cli += ["--bundle-must-include", ".env", "--bundle-must-include", "../../etc/passwd"]
+    proc = subprocess.run(cli, cwd=REPO_ROOT, env=env, capture_output=True, text=True, check=True)
+    bundle = json.loads(proc.stdout.strip())
+    assert bundle.get("ok") is True
+    dr = bundle.get("direct_read") or {}
+    assert dr.get("direct_read_fallback_used") is True
+    fetched = set(dr.get("direct_read_paths") or [])
+    for target in FOUNDUP_ACCEPTANCE_TARGETS:
+        assert target in fetched, f"CLI did not fetch {target}"
+    reasons = {r["path"]: r["reason"] for r in dr.get("direct_read_rejected", [])}
+    assert reasons.get(".env") == "denied_basename"
+    assert reasons.get("../../etc/passwd") == "traversal"
+    # Fetched content is spliced into code_hits as direct-read hits.
+    dr_hits = [h for h in (bundle["task_retrieval"]["code_hits"]) if h.get("direct_read")]
+    dr_hit_locs = {h["location"] for h in dr_hits}
+    for target in FOUNDUP_ACCEPTANCE_TARGETS:
+        assert target in dr_hit_locs


### PR DESCRIPTION
## Slice 2/3 — governed direct-read-by-path fallback

Rebased onto #906 (`55b67b156`). Version **0.3.30**.

### What this does
- When slice-1 detector reports missing required targets, HoloIndex bundle layer fetches named paths via `--bundle-must-include` (hard allowlist, byte caps, deny secrets).
- Extension requests paths only; fetch lives in Python bundle layer.
- Telemetry: `direct_read_fallback_used`, `direct_read_paths`, etc.

### Boundary
- NO redaction change (slice 3). NO execution authority.

### Tests
- verify_extension_contract.js: pass
- test_reddog_extension_bundle_recall.py: 15 pass, 2 pre-existing lexical ranking failures (documented, same as #906)

### Pre-existing failures (non-blockers)
`test_extension_js_in_top_hits_for_review_query` and `test_bundle_json_cli_extension_js_recall` — lexical ranking bug, identical at base SHA.

Replaces closed #907 after rebase.
