### PR TITLE
fix(reddog): deterministic Use-last-packet toggle + continuation telemetry (0.3.32)

### DIFF
--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,37 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-02 - REDDOG_CONTINUATION_TOGGLE_HARDENING_PHASE1 (deterministic Use-last-packet toggle + telemetry, 0.3.32)
+
+- Problem (012-observed): 012 unchecked "Use last RedDog packet" but Copy MD still emitted the
+  "Continuation from last RedDog packet" block. Two independent defects in landed 0.3.31 `extension.js`:
+  1. Backend default too permissive: `const useLastPacket = message.useLastPacket !== false` defaulted
+     ON unless the field was exactly `false` (missing/stale field => ON).
+  2. Copy MD continuation append was gated only on `ctx.continuationSummary` EXISTING, not on the toggle;
+     and the summary is always built + stored, so even a correct `false` would not strip Copy MD.
+- Fix (fail-closed): continuation is included THIS run ONLY when `message.useLastPacket === true`.
+  Single boolean `continuationEnabled` drives both append sites. `continuationAppended = continuationEnabled
+  && !!state.lastContinuationSummary`. Missing/stale toggle => OFF (a stale packet no longer contaminates
+  redaction or acceptance scoring).
+- Both append sites now gated on the toggle: the model-prompt append (`appendContinuationSummaryToWspPrompt`)
+  and the Copy MD append (`buildContinuationSummaryCopySection`, now requires `ctx.continuationEnabled`).
+  Building/storing the summary for the NEXT run is unchanged; only INCLUDING it this run is gated.
+- Telemetry (Run Trace + Copy MD "## Continuation Telemetry"): `continuation_enabled`, `continuation_appended`,
+  `continuation_source_run_id` (`run_xxx` when appended, else `none`). New helpers:
+  `normalizeContinuationTelemetry`, `formatContinuationTelemetryLines`, `buildContinuationTelemetrySection`.
+- UI: when disabled, webview shows status line "Continuation: disabled for this run." (frontend on send +
+  backend on assemble).
+- Version: mechanical LIVE-surface bump 0.3.31 -> 0.3.32 (`package.json`, `EXTENSION_VERSION`, README header,
+  every LIVE 0.3.31 assertion in `tests/verify_extension_contract.js` incl. target-snippet content checks).
+  Historical `vX.Y.Z` annotations untouched.
+- Tests: ADDENDUM H in `tests/verify_extension_contract.js` - enabled+stored => appended (prompt + Copy MD)
+  with `continuation_appended=true`; disabled+stored => NOT appended with `continuation_enabled=false`;
+  missing toggle => fail-closed NOT appended; telemetry fields present in Run Trace + Copy MD. Full suite PASS.
+- Out of scope (unchanged): no model/routing/redaction policy change; no direct-read fallback change; no
+  cross-session memory; no mid-run steering.
+
+WSP: WSP_22, WSP_50, WSP_97.
+
 ## 2026-07-02 - Version bump to 0.3.31 (REDDOG_AUDIT_MODE_REDACTION_PHASE1, slice 3/3)
 
 - Mechanical build-label bump 0.3.30 -> 0.3.31 across LIVE version surfaces.

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.31
+Version: 0.3.32
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.31';
+const EXTENSION_VERSION = '0.3.32';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -777,6 +777,7 @@ function buildRunTraceSection(result, workerType, contextSummary, holoScorecard,
       lines.push('- retry_count: ' + rp.retry_count);
     }
   }
+  lines.push.apply(lines, formatContinuationTelemetryLines(rp.continuation_telemetry || (result && result.continuation_telemetry)));
   lines.push('- output_validation: ' + formatOutputValidationStatus(rp.output_validation));
   if (rp.output_validation && rp.output_validation.repair_attempted) {
     lines.push('- repair_context_mode: ' + (rp.output_validation.repair_context_mode || 'unknown'));
@@ -966,7 +967,9 @@ function buildCopyMarkdown(result, workerType, contextSummary, workTrail, holoSc
   if (ctx.substantive) {
     sections.push(buildGovernedHandoffSection(ctx.handoffRecommendation || packet.governed_handoff_recommendation));
   }
-  if (ctx.continuationSummary) {
+  sections.push(buildContinuationTelemetrySection(ctx.continuationTelemetry || packet.continuation_telemetry));
+  // Gate Copy MD continuation inclusion on the toggle (continuationEnabled), not merely on summary existence.
+  if (ctx.continuationEnabled && ctx.continuationSummary) {
     sections.push(buildContinuationSummaryCopySection(ctx.continuationSummary));
   }
   const mojibake = detectMojibake(packet.content || '');
@@ -1439,6 +1442,30 @@ function buildContinuationSummaryCopySection(summary) {
   return formatContinuationSummaryBlock(summary);
 }
 
+function normalizeContinuationTelemetry(telemetry) {
+  const t = telemetry && typeof telemetry === 'object' ? telemetry : {};
+  return {
+    continuation_enabled: t.continuation_enabled === true,
+    continuation_appended: t.continuation_appended === true,
+    continuation_source_run_id: typeof t.continuation_source_run_id === 'string' && t.continuation_source_run_id.length
+      ? t.continuation_source_run_id
+      : 'none'
+  };
+}
+
+function formatContinuationTelemetryLines(telemetry) {
+  const t = normalizeContinuationTelemetry(telemetry);
+  return [
+    '- continuation_enabled: ' + (t.continuation_enabled ? 'true' : 'false'),
+    '- continuation_appended: ' + (t.continuation_appended ? 'true' : 'false'),
+    '- continuation_source_run_id: ' + t.continuation_source_run_id
+  ];
+}
+
+function buildContinuationTelemetrySection(telemetry) {
+  return ['## Continuation Telemetry'].concat(formatContinuationTelemetryLines(telemetry)).join('\n');
+}
+
 function buildSectionHeaderPattern(sectionName) {
   const escaped = String(sectionName || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   return new RegExp('(^|\\n)\\s*(#{1,3}\\s*)?' + escaped + '\\b', 'i');
@@ -1682,16 +1709,32 @@ function wireFusionWebview(context, webview, worker, state) {
     const workerType = cleanWorkerType(message.workerType);
     const selectedEffort = cleanEffort(message.effort);
     const selectedMode = cleanMode(message.mode);
-    const useLastPacket = message.useLastPacket !== false;
+    // Fail-closed: continuation is included this run ONLY when 012 explicitly enabled it.
+    // Missing/stale useLastPacket => OFF (do not carry a stale packet into redaction/acceptance scoring).
+    const continuationEnabled = message.useLastPacket === true;
     const classification = classifyTaskForRedDog(workFocus, selectedContextMode, workerType);
     const effort = resolveAutoEffort(classification, selectedEffort);
     const mode = resolveModelMode(classification, selectedMode, workerType);
     const contextMode = resolveAutoContextMode(classification, selectedContextMode);
     const contextPacket = buildBoundedRepoContext(contextMode, workFocus);
     let wspTaskPrompt = constructWspTaskPrompt(workFocus, classification, contextPacket.quality, workerType);
-    if (useLastPacket && state.lastContinuationSummary) {
+    // continuation_appended is true only when 012 enabled it AND a stored summary exists.
+    const continuationAppended = continuationEnabled && !!state.lastContinuationSummary;
+    const continuationSourceRunId = continuationAppended && state.lastContinuationSummary
+      ? (state.lastContinuationSummary.previous_run_id || 'unknown')
+      : 'none';
+    const continuationTelemetry = {
+      continuation_enabled: continuationEnabled,
+      continuation_appended: continuationAppended,
+      continuation_source_run_id: continuationSourceRunId
+    };
+    if (continuationAppended) {
       wspTaskPrompt = appendContinuationSummaryToWspPrompt(wspTaskPrompt, state.lastContinuationSummary);
-      postStatusAndProgress(webview, null, 'Continuation: appended WSP_97-safe summary from last RedDog packet (not raw Copy MD).');
+      postStatusAndProgress(webview, null, 'Continuation: appended WSP_97-safe summary from last RedDog packet (not raw Copy MD). source_run_id=' + continuationSourceRunId);
+    } else if (!continuationEnabled) {
+      postStatusAndProgress(webview, null, 'Continuation: disabled for this run.');
+    } else {
+      postStatusAndProgress(webview, null, 'Continuation: enabled but no prior RedDog packet stored yet; nothing appended.');
     }
     const promptConstruction = {
       work_focus_digest: redactedDigest(workFocus, 180),
@@ -1880,14 +1923,22 @@ function wireFusionWebview(context, webview, worker, state) {
       result: result,
       timestamp: new Date().toISOString()
     });
+    // Building/storing the summary for the NEXT run is always fine; INCLUDING it THIS run is gated above.
     state.lastContinuationSummary = continuationSummary;
     result.continuation_summary = continuationSummary;
+    result.continuation_telemetry = continuationTelemetry;
+    if (result.review_packet) {
+      result.review_packet.continuation_telemetry = continuationTelemetry;
+    }
     result.copy_markdown = buildCopyMarkdown(result, workerType, contextPacket.summary, workTrail, holoScorecard, effort, {
       promptConstruction: promptConstruction,
       contextMode: contextMode,
       substantive: substantiveTask,
       handoffRecommendation: handoffRecommendation,
-      continuationSummary: continuationSummary
+      continuationEnabled: continuationEnabled,
+      continuationTelemetry: continuationTelemetry,
+      // Only pass the summary for Copy MD inclusion when appended this run (fail-closed).
+      continuationSummary: continuationTelemetry.continuation_appended ? continuationSummary : null
     });
     webview.postMessage({ command: 'result', result });
   });
@@ -3172,6 +3223,10 @@ function renderHtml(worker, surface, logoUri) {
       }
       setRunning(true);
       addStatus('Work focus sent. 0102 will assemble WSP task prompt...');
+      const continuationOn = !!(useLastPacket && useLastPacket.checked);
+      if (!continuationOn) {
+        addStatus('Continuation: disabled for this run.');
+      }
       add('user', text, '012 work focus');
       workFocus.value = '';
       vscode.postMessage({
@@ -3181,7 +3236,7 @@ function renderHtml(worker, surface, logoUri) {
         contextMode: 'auto',
         workerType: workerType.value,
         effort: 'auto',
-        useLastPacket: !!(useLastPacket && useLastPacket.checked)
+        useLastPacket: continuationOn
       });
     }
 
@@ -3277,6 +3332,9 @@ module.exports = {
   buildSanitizedContinuationSummary,
   buildContinuationSummaryCopySection,
   formatContinuationSummaryBlock,
+  buildContinuationTelemetrySection,
+  formatContinuationTelemetryLines,
+  normalizeContinuationTelemetry,
   sanitizeContinuationField,
   redactedDigest,
   resolvePythonInterpreter,

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups®Agent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.31",
+    "version":  "0.3.32",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -111,8 +111,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.31', 'package version must be 0.3.31');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.31'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.32', 'package version must be 0.3.32');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.32'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups®Agent', 'display name must be Foundups®Agent');
 includes(JSON.stringify(pkg), 'Foundups®Agent: Open', 'command title must use Foundups®Agent');
@@ -129,7 +129,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.31', 'README version mismatch');
+includes(readme, 'Version: 0.3.32', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -1010,7 +1010,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.31'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.32'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -1024,7 +1024,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.31'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.32'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -1036,7 +1036,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.31'", 'bounded context must include extension.js source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.32'", 'bounded context must include extension.js source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');
@@ -1228,8 +1228,80 @@ const continuationCopy = orchestrator.buildCopyMarkdown(
   [],
   null,
   'high',
-  { substantive: true, continuationSummary: successSummary }
+  {
+    substantive: true,
+    continuationEnabled: true,
+    continuationSummary: successSummary,
+    continuationTelemetry: { continuation_enabled: true, continuation_appended: true, continuation_source_run_id: successSummary.previous_run_id }
+  }
 );
 includes(continuationCopy, 'Continuation from last RedDog packet', 'Copy MD may include safe continuation summary section');
+
+// ADDENDUM H - deterministic Use-last-packet toggle + continuation telemetry
+// (REDDOG_CONTINUATION_TOGGLE_HARDENING_PHASE1)
+// Backend fail-closed default: continuation is included ONLY on explicit useLastPacket === true.
+includes(extensionJs, 'const continuationEnabled = message.useLastPacket === true', 'backend must fail closed (useLastPacket === true)');
+assert(!extensionJs.includes('message.useLastPacket !== false'), 'legacy permissive default must be removed');
+includes(extensionJs, 'const continuationAppended = continuationEnabled', 'single continuation_appended boolean must gate inclusion');
+includes(extensionJs, 'Continuation: disabled for this run.', 'UI must show disabled status line');
+includes(extensionJs, 'buildContinuationTelemetrySection', 'Copy MD continuation telemetry section missing');
+includes(extensionJs, 'formatContinuationTelemetryLines', 'Run Trace continuation telemetry lines missing');
+
+// Telemetry section (Copy MD) shape.
+const telemetryOnSection = orchestrator.buildContinuationTelemetrySection({
+  continuation_enabled: true,
+  continuation_appended: true,
+  continuation_source_run_id: 'run_abc123'
+});
+includes(telemetryOnSection, '## Continuation Telemetry', 'telemetry section header missing');
+includes(telemetryOnSection, 'continuation_enabled: true', 'telemetry must report continuation_enabled');
+includes(telemetryOnSection, 'continuation_appended: true', 'telemetry must report continuation_appended');
+includes(telemetryOnSection, 'continuation_source_run_id: run_abc123', 'telemetry must report source run id');
+
+// Telemetry appears in Run Trace section too.
+const runTraceWithTelemetry = orchestrator.buildRunTraceSection(
+  { review_packet: { task_classification: { tier: 'HIGH' }, continuation_telemetry: { continuation_enabled: true, continuation_appended: true, continuation_source_run_id: 'run_xyz789' } } },
+  'reddog_architect', null, null, 'high'
+);
+includes(runTraceWithTelemetry, 'continuation_enabled: true', 'Run Trace must include continuation_enabled');
+includes(runTraceWithTelemetry, 'continuation_appended: true', 'Run Trace must include continuation_appended');
+includes(runTraceWithTelemetry, 'continuation_source_run_id: run_xyz789', 'Run Trace must include continuation_source_run_id');
+
+// Case 1: enabled + stored summary => appended in Copy MD (prompt-side parity via appendContinuationSummaryToWspPrompt).
+const enabledTelemetry = { continuation_enabled: true, continuation_appended: true, continuation_source_run_id: successSummary.previous_run_id };
+const copyEnabled = orchestrator.buildCopyMarkdown(
+  { ok: true, content: sampleArchitectOutput, review_packet: { task_classification: { tier: 'HIGH' }, output_validation: { validated: true }, continuation_telemetry: enabledTelemetry } },
+  'reddog_architect', 'Repo context attached', [], null, 'high',
+  { substantive: true, continuationEnabled: true, continuationSummary: successSummary, continuationTelemetry: enabledTelemetry }
+);
+includes(copyEnabled, 'Continuation from last RedDog packet', 'enabled: Copy MD must include continuation summary');
+includes(copyEnabled, 'continuation_appended: true', 'enabled: Copy MD telemetry must report appended=true');
+includes(copyEnabled, 'continuation_enabled: true', 'enabled: Copy MD telemetry must report enabled=true');
+const promptEnabled = orchestrator.appendContinuationSummaryToWspPrompt('WSP task prompt body', successSummary);
+includes(promptEnabled, 'Continuation from last RedDog packet', 'enabled: model prompt must include continuation block');
+
+// Case 2: disabled + stored summary => NOT appended (Copy MD) and telemetry enabled=false, appended=false.
+const disabledTelemetry = { continuation_enabled: false, continuation_appended: false, continuation_source_run_id: 'none' };
+const copyDisabled = orchestrator.buildCopyMarkdown(
+  { ok: true, content: sampleArchitectOutput, review_packet: { task_classification: { tier: 'HIGH' }, output_validation: { validated: true }, continuation_telemetry: disabledTelemetry } },
+  'reddog_architect', 'Repo context attached', [], null, 'high',
+  { substantive: true, continuationEnabled: false, continuationSummary: null, continuationTelemetry: disabledTelemetry }
+);
+assert(!copyDisabled.includes('Continuation from last RedDog packet'), 'disabled: Copy MD must NOT include continuation summary');
+includes(copyDisabled, 'continuation_enabled: false', 'disabled: Copy MD telemetry must report enabled=false');
+includes(copyDisabled, 'continuation_appended: false', 'disabled: Copy MD telemetry must report appended=false');
+includes(copyDisabled, 'continuation_source_run_id: none', 'disabled: Copy MD telemetry must report source=none');
+
+// Case 3: missing toggle (fail-closed) mirrors disabled: enabled false when summary passed as null.
+const missingTelemetry = orchestrator.normalizeContinuationTelemetry(undefined);
+assert.strictEqual(missingTelemetry.continuation_enabled, false, 'missing toggle must normalize to enabled=false (fail-closed)');
+assert.strictEqual(missingTelemetry.continuation_appended, false, 'missing toggle must normalize to appended=false');
+assert.strictEqual(missingTelemetry.continuation_source_run_id, 'none', 'missing toggle must normalize source to none');
+const copyMissing = orchestrator.buildCopyMarkdown(
+  { ok: true, content: sampleArchitectOutput, review_packet: { task_classification: { tier: 'HIGH' }, output_validation: { validated: true } } },
+  'reddog_architect', 'Repo context attached', [], null, 'high',
+  { substantive: true, continuationSummary: successSummary }
+);
+assert(!copyMissing.includes('Continuation from last RedDog packet'), 'missing/undefined continuationEnabled must NOT include continuation summary (fail-closed)');
 
 console.log('Foundups®Agent extension contract checks passed.');


### PR DESCRIPTION
## Slice
`REDDOG_CONTINUATION_TOGGLE_HARDENING_PHASE1` (retrieval/UX). Fail-closed fix BEFORE any golden rerun -- a stale continuation block was contaminating redaction + acceptance scoring.

Base: `97726bef8` (origin/main, 0.3.31). Draft; stop at VERIFIED_READY.

## Two defects (landed 0.3.31 `extension.js`)
1. **Backend default too permissive** (`extension.js:1685`): `const useLastPacket = message.useLastPacket !== false;` defaulted continuation **ON** unless the field was exactly `false`. A missing/stale field => ON.
2. **Copy MD append not gated on the toggle at all** (`extension.js:969`): `if (ctx.continuationSummary) { ... }` gated only on the summary **existing**, not on the toggle. And `continuationSummary` is **always** built + stored (`:1883-1884`) for the next run -- so even a correct `false` would not strip the Copy MD continuation section.

Net effect: 012 unchecked "Use last RedDog packet" but Copy MD still contained "## Continuation from last RedDog packet".

## Fix (fail-closed)
- Backend now includes continuation THIS run **only** when `message.useLastPacket === true`. Missing/stale => OFF.
- One boolean `continuationEnabled` (plus derived `continuationAppended = continuationEnabled && !!state.lastContinuationSummary`) gates **both** append sites:
  - model-prompt append (`appendContinuationSummaryToWspPrompt`)
  - Copy MD append (`buildContinuationSummaryCopySection`, now requires `ctx.continuationEnabled`)
- Building/storing the summary for the **NEXT** run is unchanged; only **including** it this run is gated. The summary is passed to `buildCopyMarkdown` as `null` unless appended this run.

## New telemetry (Run Trace + Copy MD `## Continuation Telemetry`)
- `continuation_enabled: true|false`
- `continuation_appended: true|false`
- `continuation_source_run_id: run_xxx | none` (the `previous_run_id` of the carried-forward packet)

New helpers: `normalizeContinuationTelemetry`, `formatContinuationTelemetryLines`, `buildContinuationTelemetrySection` (all exported).

## UI
When disabled, webview shows a status line **"Continuation: disabled for this run."** (frontend on send + backend on assemble).

## Version + tests
- Mechanical LIVE-surface bump 0.3.31 -> 0.3.32: `package.json`, `EXTENSION_VERSION`, README header, and **every** LIVE 0.3.31 assertion in `tests/verify_extension_contract.js` incl. the three target-snippet content checks. Historical `vX.Y.Z` annotations untouched.
- ADDENDUM H contract tests: enabled+stored => appended (prompt + Copy MD, `continuation_appended=true`); disabled+stored => NOT appended (`continuation_enabled=false`); missing toggle => fail-closed NOT appended; telemetry present in Run Trace + Copy MD.

## Validation
- `node --check extension.js` OK
- `node tests/verify_extension_contract.js` PASS (exit 0)
- `git diff --check` clean; 0 non-ASCII on added lines across all edited files
- (The Python `UnicodeEncodeError` traceback in test stderr is the pre-existing lone-surrogate negative fixture at `tests/verify_extension_contract.js:1075`, not a failure.)

## Out of scope
- No model/routing/redaction policy change.
- No direct-read fallback change (separate slice `REDDOG_DIRECT_READ_FALLBACK_TRIGGER_DIAGNOSTIC_PHASE1` stacks on this).
- No cross-session memory, no mid-run steering.

## 012 rerun card
1. Reload the extension (build shows **0.3.32**).
2. **Uncheck** "Use last RedDog packet", send a work focus. Expect:
   - status line "Continuation: disabled for this run."
   - Copy MD has **no** "## Continuation from last RedDog packet" section.
   - Run Trace + Copy MD "## Continuation Telemetry": `continuation_enabled: false`, `continuation_appended: false`, `continuation_source_run_id: none`.
3. **Check** the box, send again. Expect the continuation block present, `continuation_enabled: true`, `continuation_appended: true`, `continuation_source_run_id: run_...`.
4. Only after this passes, proceed to the golden rerun.

Worker-Lane: retrieval | Slice: REDDOG_CONTINUATION_TOGGLE_HARDENING_PHASE1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
