### PR TITLE
fix(reddog): wire audit_context through bridge to audit-mode redaction gate (0.3.34)

### DIFF
--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -170,7 +170,10 @@ Run Trace HoloIndex scorecard fields (v0.3.22+):
 | `direct_read_rejected` | `{path, reason}` for denied/traversal/absolute/secret/symlink-escape hits (never read) | OBSERVED |
 | `direct_read_bytes` | Total bytes injected across all fetched targets (bounded by total budget) | OBSERVED |
 | `direct_read_truncated` | `{path, bytes}` for targets clipped by the per-file byte cap | OBSERVED |
-| `target_content_included` | Target snippet section present in final bounded context | OBSERVED |
+| `direct_read_fetch_attempted` | Enriched direct-read subprocess was invoked (v0.3.33+) | OBSERVED |
+| `direct_read_fetch_error` | Classified fetch failure (`timeout`, `max_buffer`, `process_error`, `unknown`, or none) | OBSERVED |
+| `audit_context_requested` | Extension requested audit-mode redaction for governance direct-read context (v0.3.34+) | OBSERVED |
+| `audit_context_applied` | Bridge passed `audit_mode=True` into `evaluate_redaction_gate()` (v0.3.34+) | OBSERVED |
 | `target_content_paths` | Relative paths whose snippets were included | OBSERVED |
 | `target_content_chars` | Character count of included target snippets | OBSERVED |
 | `target_content_omitted_reason` | Why snippets omitted when `target_content_included=false` | OBSERVED |
@@ -196,6 +199,8 @@ Target content egress (v0.3.22+): `buildTargetRecallContentSection(root, taskTex
 Governed direct-read-by-path (REDDOG_DIRECT_READ_FALLBACK_BY_PATH_PHASE1, slice 2/3): when slice-1's detector reports `index_gap_detected=true` with a non-empty `required_targets_missing`, `holoIndexOutput` re-invokes the bundle with `buildMustIncludeArgs(missing)` -> `--bundle-must-include <path>` so the **Python bundle layer** (`holo_index/cli/commands/bundle_json.py::_direct_read_fetch`) reads the named repo files and returns their content in the bundle. The extension does NOT read those files via raw fs; it only names the paths. Fetched hits are spliced into `task_retrieval.code_hits` (so slice-1 recall re-evaluates and flips `target_recall_ok`) and rendered by `buildDirectReadContentSection(bundleOutput)` into a bounded section. Hard security allowlist (all in the Python layer): repo-relative only; realpath must stay inside repo root (rejects absolute, `..` traversal, symlink-escape); hard-deny basenames/globs (`.env*`, `*.pem`, `*.key`, `id_rsa*`, `id_ed25519*`, `*.p12`, `*.keystore`, `*secret*`/`*credential*`/`*token*`, `.git/` and credential dot-dirs); per-file byte cap (12KB) plus a total fetch budget (96KB) spread across MANY targets ranked by prompt order; every denial is recorded in `direct_read_rejected` and never aborts the bundle. Fetched content passes through the EXISTING redaction gate unchanged (slice 3 owns audit-mode redaction). No execution authority, no write path, no shell-out.
 
 Exported helpers for contract tests: `isTargetReadPathDenied`, `resolveSafeRepoFile`, `readBoundedTargetSnippet`, `readBoundedTargetSnippets`, `buildTargetRecallContentSection`, `sanitizeTargetSnippetForRedaction`, `taskMentionsWsp97`, `buildWsp97ProtocolExcerpt`, `parseRequiredTargetPaths`, `isSelfFileLocation`, `requiredTargetMatchesLocation`, `formatHoloIndexScorecardLines`, `buildMustIncludeArgs`, `buildDirectReadContentSection`.
+
+Audit-context bridge wire (REDDOG_AUDIT_CONTEXT_BRIDGE_WIRE_PHASE1, v0.3.34): when `buildDirectReadContentSection()` sets `audit_context: true` (governance direct-read fetch), `buildBoundedRepoContext()` preserves the flag; `callFusion()` sends `audit_context: true` in the bridge stdin payload; `scripts/advisory_model_once.py` passes `audit_mode=True` into `evaluate_redaction_gate()` **only** when explicitly requested. Default path (no governance direct-read) remains byte-identical strict blocking. HoloIndex anchor terms: `audit_context bridge wire`, `advisory_model_once audit_mode`, `buildDirectReadContentSection audit_context`, `fusion_redaction_gate audit_mode`, `RedDog golden FoundUp creation audit`. Follow-up if not indexed: `HOLOINDEX_REDDOG_AUDIT_CONTEXT_BRIDGE_WIRE_INDEX_GAP_PHASE1`.
 
 ## WSP_97 Truth Boundary
 

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,29 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-02 - REDDOG_AUDIT_CONTEXT_BRIDGE_WIRE_PHASE1 (audit_context bridge wire, 0.3.34)
+
+- Problem (golden rerun on 0.3.33): **senses stack PASS** (7/7 recall, direct_read_fallback_used=true,
+  continuation off) but **model pass FAIL** — `redaction gate status: BLOCKED_LOCALLY`,
+  `made_network_call: false`. Root cause: slice-3 `audit_mode` exists in `fusion_redaction_gate.py` and
+  `buildDirectReadContentSection()` surfaces `audit_context: true`, but the live path
+  `extension.js` -> `scripts/advisory_model_once.py` never passed the flag into
+  `evaluate_redaction_gate()`.
+- Fix: `buildBoundedRepoContext()` preserves `audit_context` from `holo.direct_read_section`;
+  `callFusion()` payload carries `audit_context: true` when `promptConstruction.audit_context_requested`;
+  `advisory_model_once.py` passes `audit_mode=audit_context_requested` into the entry gate only.
+  Run Trace telemetry: `audit_context_requested`, `audit_context_applied`.
+- Default path byte-identical: no direct-read governance context => `audit_context=false` => strict gate unchanged.
+- Tests: ACB-001..005 in `verify_extension_contract.js`; 3 bridge tests in
+  `scripts/tests/test_advisory_model_once_hardening.py`.
+- HoloIndex discoverability (ADDENDUM A, pre-edit): queries for bridge wire / audit_mode did NOT surface
+  `extension.js`, `advisory_model_once.py`, or `fusion_redaction_gate.py` in top code hits
+  (INDEX_GAP — OBSERVED). Static anchors added to INTERFACE.md / ROADMAP.md. Follow-up indexing slice:
+  `HOLOINDEX_REDDOG_AUDIT_CONTEXT_BRIDGE_WIRE_INDEX_GAP_PHASE1` (SPECIFIED_NOT_IMPLEMENTED — no ranking
+  code changed in this slice).
+- Version: mechanical LIVE-surface bump 0.3.33 -> 0.3.34.
+- WSP: WSP_00, WSP_15, WSP_50, WSP_97, WSP_22.
+
 ## 2026-07-02 - REDDOG_DIRECT_READ_FALLBACK_TRIGGER_DIAGNOSTIC_PHASE1 (enriched-fetch buffer + fetch-error telemetry, 0.3.33)
 
 - Problem (golden rerun on landed 0.3.31): slice-1 detector WORKED (index_gap_detected=true,

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.33
+Version: 0.3.34
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -163,6 +163,17 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 - Add regression retrieval tests so extension bridge code ranks above adjacent WRE routers.
 - **Status:** **LANDED** #882 (`99d0e35c2`) — ranking + target recall telemetry only; not source-content inclusion.
 
+### REDDOG_AUDIT_CONTEXT_BRIDGE_WIRE_PHASE1 (v0.3.34)
+
+- **Status:** WIRE COMPLETE (this slice). Golden 0.3.33 proved senses stack PASS but egress FAIL
+  (`BLOCKED_LOCALLY`) because `audit_mode` never reached `advisory_model_once.py`.
+- Wire path: `buildDirectReadContentSection().audit_context` -> `buildBoundedRepoContext().audit_context`
+  -> `callFusion()` payload `audit_context` -> `evaluate_redaction_gate(..., audit_mode=True)`.
+- Run Trace: `audit_context_requested`, `audit_context_applied`.
+- Default path unchanged: no governance direct-read => strict gate unchanged.
+- HoloIndex: static anchors in INTERFACE/ModLog; indexing follow-up
+  `HOLOINDEX_REDDOG_AUDIT_CONTEXT_BRIDGE_WIRE_INDEX_GAP_PHASE1` if queries still miss implementation files.
+
 ### REDDOG_DIRECT_READ_FALLBACK_BY_PATH_PHASE1 (slice 2/3)
 
 - **Status:** GOVERNED FETCH (this slice), stacked on slice 1 (#906). When slice-1's detector reports

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.33';
+const EXTENSION_VERSION = '0.3.34';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -656,7 +656,9 @@ function formatHoloIndexScorecardLines(scorecard) {
     '- target_content_sanitized: ' + scorecard.target_content_sanitized,
     '- target_content_sanitized_categories: ' + (Array.isArray(scorecard.target_content_sanitized_categories)
       ? scorecard.target_content_sanitized_categories.join(', ')
-      : scorecard.target_content_sanitized_categories)
+      : scorecard.target_content_sanitized_categories),
+    '- audit_context_requested: ' + scorecard.audit_context_requested,
+    '- audit_context_applied: ' + scorecard.audit_context_applied
   ];
 }
 
@@ -1746,7 +1748,8 @@ function wireFusionWebview(context, webview, worker, state) {
     }
     const promptConstruction = {
       work_focus_digest: redactedDigest(workFocus, 180),
-      wsp_prompt_digest: redactedDigest(wspTaskPrompt, 320)
+      wsp_prompt_digest: redactedDigest(wspTaskPrompt, 320),
+      audit_context_requested: contextPacket.audit_context === true
     };
     const systemPrompt = buildSystemPrompt(workerType, effort, contextPacket.quality);
 
@@ -1756,7 +1759,14 @@ function wireFusionWebview(context, webview, worker, state) {
       postStatusAndProgress(webview, null, contextPacket.summary);
     }
     postStatusAndProgress(webview, null, '0102 assembled WSP task prompt from 012 work focus (bridge receives WSP task prompt, not raw focus alone).');
-    const holoScorecard = contextPacket.holoindex_scorecard || extractHoloIndexScorecard(contextMode, contextPacket.holoindex_meta);
+    const holoScorecard = Object.assign(
+      {},
+      contextPacket.holoindex_scorecard || extractHoloIndexScorecard(contextMode, contextPacket.holoindex_meta),
+      {
+        audit_context_requested: contextPacket.audit_context === true,
+        audit_context_applied: false
+      }
+    );
     const workTrail = createWorkTrail();
     workTrail.push('orchestrator_started');
     if (contextPacket.summary) {
@@ -1797,6 +1807,12 @@ function wireFusionWebview(context, webview, worker, state) {
       }
     };
     let result = await callFusion(context, worker, wspTaskPrompt, contextPacket.text, systemPrompt, state.history, mode, onBridgeProgress, state, promptConstruction);
+    if (holoScorecard) {
+      holoScorecard.audit_context_applied = result && result.audit_context_applied === true;
+      if (result && result.audit_context_requested !== undefined) {
+        holoScorecard.audit_context_requested = result.audit_context_requested === true;
+      }
+    }
     absorbUnicodeMeta(result);
     if (result.ok && isSubstantiveRedDogWorker(workerType)) {
       workTrail.push('validator_started');
@@ -2088,6 +2104,7 @@ function callFusion(context, worker, prompt, boundedContext, systemPrompt, histo
       max_tokens: callOptions.maxTokens || 2200,
       temperature: 0.2,
       timeout: mode === 'foundups_fusion' ? 120 : 90,
+      audit_context: bridgeMeta && bridgeMeta.audit_context_requested === true,
       bridge_meta: Object.assign({}, bridgeMeta || {}, {
         python_interpreter: interpreter.path,
         python_interpreter_source: interpreter.source,
@@ -2194,9 +2211,10 @@ function buildBoundedRepoContext(mode, taskText) {
   let quality = 'No HoloIndex requested for this context mode.';
   let holoindex_meta = null;
   let holoindex_scorecard = null;
+  let audit_context = false;
   if (mode === 'none') {
     const text = sections.join('\n');
-    return { text, summary: 'Repo context: WSP operating contract only.', quality, holoindex_meta, holoindex_scorecard };
+    return { text, summary: 'Repo context: WSP operating contract only.', quality, holoindex_meta, holoindex_scorecard, audit_context };
   }
   if (mode === 'wsp_holo' || mode === 'wsp_holo_git' || mode === 'wsp_holo_skillz' || mode === 'wsp_holo_git_skillz') {
     const holo = holoIndexOutput(root, taskText || '', 18000);
@@ -2209,6 +2227,11 @@ function buildBoundedRepoContext(mode, taskText) {
     // drop the fetched source the model needs to reason on.
     if (holo.direct_read_section && holo.direct_read_section.text) {
       sections.push(holo.direct_read_section.text);
+    }
+    // REDDOG_AUDIT_CONTEXT_BRIDGE_WIRE_PHASE1: preserve audit_context from slice-3
+    // direct-read section so the bridge can run audit-mode redaction on egress.
+    if (holo.direct_read_section && holo.direct_read_section.audit_context === true) {
+      audit_context = true;
     }
   }
   let targetContentMeta = null;
@@ -2249,7 +2272,7 @@ function buildBoundedRepoContext(mode, taskText) {
     sections.push('### git diff -- . (bounded)\n```diff\n' + (diff || '(no diff)') + '\n```');
   }
   const text = sections.join('\n\n').slice(0, 42000);
-  return { text, summary: 'Repo context attached: ' + mode + ' (' + text.length + ' chars). ' + quality, quality, holoindex_meta, holoindex_scorecard };
+  return { text, summary: 'Repo context attached: ' + mode + ' (' + text.length + ' chars). ' + quality, quality, holoindex_meta, holoindex_scorecard, audit_context };
 }
 
 function activeEditorContext(root) {

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups®Agent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.33",
+    "version":  "0.3.34",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -51,6 +51,48 @@ const GOLDEN_FOUNDUP_PROMPT = [
   'Produce required RedDog architect output sections per contract.'
 ].join('\n');
 
+// REDDOG_AUDIT_CONTEXT_BRIDGE_WIRE_PHASE1: golden 7-file FoundUp creation audit prompt
+// (file paths only — no symbol targets that direct-read-by-path cannot fetch).
+const GOLDEN_7FILE_TARGETS = [
+  'WSP_framework/src/WSP_109_FoundUp_Onboarding_Intake_Protocol.md',
+  'WSP_framework/src/WSP_95_WRE_SKILLz_Wardrobe_Protocol.md',
+  'modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py',
+  'modules/foundups/agent/src/hermes_foundup_job_executor.py',
+  'modules/communication/moltbot_bridge/src/foundup_job_contract.py',
+  'modules/communication/moltbot_bridge/src/reddog_governed_work_order_dryrun.py',
+  'modules/communication/moltbot_bridge/src/reddog_wre_execution_valve.py'
+];
+const GOLDEN_7FILE_FOUNDUP_PROMPT = [
+  'Audit the FoundUp creation monorepo WSP_109 execution path.',
+  '',
+  'Required direct-read targets:',
+  ...GOLDEN_7FILE_TARGETS.map((t) => '- ' + t),
+  '',
+  'Determine:',
+  '1. Whether WSP_109 intake is specified, implemented, or missing.',
+  '2. Whether a FoundUpCreationWorkOrder exists or is still missing.',
+  '3. Whether RedDogGovernedWorkOrder can represent FoundUp creation.',
+  '4. Whether FoundUpJob can represent FoundUp creation.',
+  '5. Whether build_foundup creates a new FoundUp or aliases extract_foundup.',
+  '6. Whether OpenClaw genesis/onboarding gates are built.',
+  '7. Whether Hermes/WRE can write production FoundUp scaffolds today or only dry-run/evidence scaffolds.',
+  '8. Whether the correct next slice is WSP_109 intake packet generation, Skillz authoring, scaffold writer, or live execution.',
+  '',
+  'Use WSP_97 labels for every claim.',
+  'End with WSP_15 priority and the next safest slice.'
+].join('\n');
+
+// WSP_95 contains fail-closed "chain-of-thought" literals (private_reasoning BLOCK even in audit_mode).
+// Golden wire proof uses the 6 governance/code targets that pass audit-mode egress.
+const GOLDEN_6FILE_AUDIT_PROMPT = [
+  'Audit the FoundUp creation monorepo WSP_109 execution path.',
+  '',
+  'Required direct-read targets:',
+  ...GOLDEN_7FILE_TARGETS.filter((t) => !t.includes('WSP_95')).map((t) => '- ' + t),
+  '',
+  'Use WSP_97 labels for every claim.'
+].join('\n');
+
 function assertFusionRedactionGatePasses(contextText, label) {
   const script = [
     'import sys',
@@ -139,8 +181,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.33', 'package version must be 0.3.33');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.33'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.34', 'package version must be 0.3.34');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.34'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups®Agent', 'display name must be Foundups®Agent');
 includes(JSON.stringify(pkg), 'Foundups®Agent: Open', 'command title must use Foundups®Agent');
@@ -157,7 +199,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.33', 'README version mismatch');
+includes(readme, 'Version: 0.3.34', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -201,7 +243,8 @@ includes(extensionJs, '--bundle-json', 'bundle-json retrieval missing');
 includes(extensionJs, '--offline', 'offline fallback missing');
 includes(extensionJs, 'Skillz/Wardrobe/Rolodex discovery', 'Skillz/Rolodex discovery context missing');
 
-includes(bridgePy, 'evaluate_redaction_gate(prompt, context_for_gate)', 'prompt/context redaction gate missing');
+includes(bridgePy, 'evaluate_redaction_gate(', 'prompt/context redaction gate missing');
+includes(bridgePy, 'audit_mode=audit_context_requested', 'audit_context bridge wire missing');
 includes(bridgePy, 'redacted_user_message = gate.redacted_prompt', 'redacted user assembly missing');
 includes(bridgePy, 'messages = [{"role": "system", "content": _system_prompt(payload)}]', 'Fusion alias system prompt missing');
 includes(bridgePy, 'base_system = _system_prompt(payload)', 'manual panel system prompt missing');
@@ -973,6 +1016,58 @@ assert(!drfSecretRedacted.includes('12500.50'), 'DRF-009: payout AMOUNT must STI
 includes(drfSecretRedacted, '[REDACTED', 'DRF-009: redaction placeholder must be present for the stripped value');
 
 // ===================================================================================
+// REDDOG_AUDIT_CONTEXT_BRIDGE_WIRE_PHASE1 (ACB-001..ACB-005)
+// Slice 3 added audit_mode to fusion_redaction_gate + audit_context on direct-read
+// sections, but advisory_model_once.py never received the flag. Golden 0.3.33 run:
+// recall PASS, BLOCKED_LOCALLY because default gate ran on governance context.
+// ===================================================================================
+includes(extensionJs, 'audit_context: bridgeMeta && bridgeMeta.audit_context_requested === true', 'ACB-001: bridge payload must carry audit_context from promptConstruction');
+includes(extensionJs, 'audit_context_requested: contextPacket.audit_context === true', 'ACB-001: promptConstruction must record audit_context_requested from direct-read section');
+includes(extensionJs, 'holo.direct_read_section.audit_context === true', 'ACB-001: buildBoundedRepoContext must read audit_context from buildDirectReadContentSection');
+includes(extensionJs, '- audit_context_requested:', 'ACB-001: Run Trace scorecard must surface audit_context_requested');
+includes(extensionJs, '- audit_context_applied:', 'ACB-001: Run Trace scorecard must surface audit_context_applied');
+includes(bridgePy, 'audit_mode=audit_context_requested', 'ACB-001: advisory_model_once must pass audit_mode when audit_context is true');
+includes(bridgePy, 'audit_context_requested', 'ACB-001: bridge must emit audit_context_requested telemetry');
+
+// ACB-002: golden 7-file prompt with direct-read fetch sets audit_context on bounded context packet.
+const acbBounded = orchestrator.buildBoundedRepoContext('wsp_holo_git_skillz', GOLDEN_7FILE_FOUNDUP_PROMPT);
+assert.strictEqual(acbBounded.audit_context, true, 'ACB-002: golden 7-file direct-read must set audit_context=true on bounded context packet');
+assert(acbBounded.text && acbBounded.text.length > 1000, 'ACB-002: bounded context must include fetched governance content');
+
+// ACB-003: default (non-audit) gate still blocks governance direct-read section (byte-identical default path).
+let acbDefaultBlocked = false;
+try {
+  assertFusionRedactionGatePasses(drfGovSection.text, 'ACB-003 default gate probe');
+} catch (acbDefaultErr) {
+  acbDefaultBlocked = true;
+}
+assert(acbDefaultBlocked, 'ACB-003: audit_context=false/default gate must still block governance structure content');
+
+// ACB-004: golden direct-read section (6 governance/code targets; excludes WSP_95 chain-of-thought literal) passes audit-mode gate.
+const acbHolo = orchestrator.holoIndexOutput(root, GOLDEN_6FILE_AUDIT_PROMPT, 18000);
+assert.strictEqual(acbHolo.direct_read_section && acbHolo.direct_read_section.audit_context, true, 'ACB-004: governance direct-read must set audit_context on direct-read section');
+fusionRedactionGateAuditMode(acbHolo.direct_read_section.text, 'ACB-004 golden direct-read section audit-mode gate');
+
+// ACB-006: WSP_95 direct-read content STILL blocks in audit_mode (private_reasoning fail-closed; not relaxed by this slice).
+const wsp95Path = 'WSP_framework/src/WSP_95_WRE_SKILLz_Wardrobe_Protocol.md';
+const wsp95Snippet = fs.readFileSync(path.join(root, wsp95Path), 'utf8').slice(0, 12000);
+let acbWsp95Blocked = false;
+try {
+  fusionRedactionGateAuditMode(wsp95Snippet, 'ACB-006 WSP_95 audit-mode probe');
+} catch (wsp95Err) {
+  acbWsp95Blocked = true;
+  includes(String((wsp95Err && wsp95Err.stdout) || ''), 'private_reasoning', 'ACB-006: WSP_95 must block on private_reasoning even in audit mode');
+}
+assert(acbWsp95Blocked, 'ACB-006: WSP_95 chain-of-thought literal must remain fail-closed in audit mode');
+
+// ACB-005: audit-mode still redacts synthetic secrets embedded in golden direct-read probe.
+const _acbFakeKey = ('s' + 'k-') + 'FAKE' + 'Y'.repeat(44);
+const acbSecretProbe = acbHolo.direct_read_section.text + '\napi_key = "' + _acbFakeKey + '"\ncabr_payout = 99999.99';
+const acbSecretRedacted = fusionRedactionGateAuditMode(acbSecretProbe, 'ACB-005 audit-mode secret safety');
+assert(!acbSecretRedacted.includes(_acbFakeKey), 'ACB-005: secret VALUE must be redacted in audit mode');
+assert(!acbSecretRedacted.includes('99999.99'), 'ACB-005: payout amount must be redacted in audit mode');
+
+// ===================================================================================
 // REDDOG_DIRECT_READ_FALLBACK_TRIGGER_DIAGNOSTIC_PHASE1 (DRT-001..DRT-008)
 // Golden rerun on 0.3.31 proved slice-1 detected the gap (index_gap_detected=true,
 // required_targets_total=8, recalled=0) but slice-2's enriched fetch NEVER fired in
@@ -1185,7 +1280,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.33'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.34'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -1199,7 +1294,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.33'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.34'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -1211,7 +1306,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.33'", 'bounded context must include extension.js source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.34'", 'bounded context must include extension.js source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');

--- a/scripts/advisory_model_once.py
+++ b/scripts/advisory_model_once.py
@@ -3,6 +3,9 @@
 
 Reads JSON from stdin and writes JSON to stdout. Raw prompt and bounded
 context are evaluated by the Fusion redaction gate before any external request.
+When `audit_context` is true in the payload (REDDOG_AUDIT_CONTEXT_BRIDGE_WIRE_PHASE1),
+the gate runs in audit_mode so governance direct-read structure survives egress while
+secret values remain redacted. Default path (audit_context absent/false) is unchanged.
 The caller should store only the returned redacted history/review packet.
 """
 
@@ -437,17 +440,35 @@ def main() -> int:
     context = payload.get("context")
     context_for_gate = context if isinstance(context, str) and context.strip() else None
     bridge_meta = payload.get("bridge_meta") if isinstance(payload.get("bridge_meta"), dict) else {}
+    audit_context_requested = payload.get("audit_context") is True
+    audit_context_applied = audit_context_requested
+    audit_telemetry = {
+        "audit_context_requested": audit_context_requested,
+        "audit_context_applied": audit_context_applied,
+    }
     _panel_input = payload.get("panel_models")
     _panel_truncated = isinstance(_panel_input, list) and len(_panel_input) > MAX_PANEL_MODELS
     if _panel_truncated:
         bridge_meta = dict(bridge_meta)
         bridge_meta["panel_models_truncated"] = True
+    bridge_meta = dict(bridge_meta)
+    bridge_meta.update(audit_telemetry)
 
     _progress("redaction_start", "Redaction gate started.")
-    gate = evaluate_redaction_gate(prompt, context_for_gate)
+    gate = evaluate_redaction_gate(
+        prompt,
+        context_for_gate,
+        audit_mode=audit_context_requested,
+    )
     if gate.status != REDACTION_GATE_PASSED or not gate.redacted_prompt:
         _progress("redaction_blocked", "Redaction gate blocked before network.")
-        return _json_result(ok=False, reason="redaction_blocked", redaction_reason=gate.reason, retry_count=0)
+        return _json_result(
+            ok=False,
+            reason="redaction_blocked",
+            redaction_reason=gate.reason,
+            retry_count=0,
+            **audit_telemetry,
+        )
 
     _progress("redaction_pass", "Redaction gate passed.")
     system_prompt = _system_prompt(payload)
@@ -466,7 +487,7 @@ def main() -> int:
             packet = result.get("review_packet")
             if isinstance(packet, dict):
                 packet.update(bridge_meta)
-        return _json_result(**result)
+        return _json_result(**{**result, **audit_telemetry})
 
     if payload.get("mode") == "foundups_fusion":
         result = _run_foundups_fusion(api_key, redacted_user_message, history, payload)
@@ -474,7 +495,7 @@ def main() -> int:
             packet = result.get("review_packet")
             if isinstance(packet, dict):
                 packet.update(bridge_meta)
-        return _json_result(**result)
+        return _json_result(**{**result, **audit_telemetry})
 
     if payload.get("mode") == "openrouter_single":
         model = payload.get("lead_model") or model
@@ -526,6 +547,7 @@ def main() -> int:
             "final_retry_reason": retry_meta.get("final_retry_reason"),
             **bridge_meta,
         },
+        **audit_telemetry,
     )
 
 

--- a/scripts/tests/test_advisory_model_once_hardening.py
+++ b/scripts/tests/test_advisory_model_once_hardening.py
@@ -177,6 +177,7 @@ class AdvisoryBridgeHardeningTests(unittest.TestCase):
             )
 
         post_mock.assert_not_called()
+        gate_mock.assert_called_once_with("secret material", None, audit_mode=False)
         self.assertFalse(out.get("ok"))
         self.assertEqual(out.get("reason"), "redaction_blocked")
         self.assertEqual(out.get("retry_count"), 0)
@@ -246,6 +247,85 @@ class AdvisoryBridgeHardeningTests(unittest.TestCase):
         self.assertNotEqual(out.get("reason"), "redaction_blocked")
         self.assertNotEqual(out.get("redaction_reason"), "redactor_error")
         self.assertTrue(out.get("ok"))
+
+    def test_audit_context_false_strict_blocks_governance_sample(self) -> None:
+        from modules.communication.moltbot_bridge.tests.test_fusion_redaction_gate import (  # noqa: WPS433
+            _AUDIT_STRUCTURE_SAMPLE,
+        )
+
+        _rc, out = self._invoke_main(
+            {
+                "mode": "openrouter_single",
+                "prompt": "012 work focus",
+                "context": _AUDIT_STRUCTURE_SAMPLE,
+                "lead_model": "z-ai/glm-5.2",
+                "audit_context": False,
+            }
+        )
+
+        self.assertFalse(out.get("ok"))
+        self.assertEqual(out.get("reason"), "redaction_blocked")
+        self.assertFalse(out.get("audit_context_requested"))
+        self.assertFalse(out.get("audit_context_applied"))
+
+    def test_audit_context_true_preserves_governance_structure(self) -> None:
+        from modules.communication.moltbot_bridge.tests.test_fusion_redaction_gate import (  # noqa: WPS433
+            _AUDIT_STRUCTURE_SAMPLE,
+        )
+
+        responses = [
+            json.dumps({"choices": [{"message": {"content": "ok"}}]}).encode("utf-8"),
+        ]
+
+        def fake_urlopen(request, timeout=0):  # noqa: ARG001
+            return io.BytesIO(responses.pop(0))
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _rc, out = self._invoke_main(
+                {
+                    "mode": "openrouter_single",
+                    "prompt": "012 work focus",
+                    "context": _AUDIT_STRUCTURE_SAMPLE,
+                    "lead_model": "z-ai/glm-5.2",
+                    "audit_context": True,
+                }
+            )
+
+        self.assertTrue(out.get("ok"))
+        self.assertTrue(out.get("audit_context_requested"))
+        self.assertTrue(out.get("audit_context_applied"))
+        self.assertIn("SourceAuthority", out.get("redacted_prompt") or "")
+
+    def test_audit_context_true_still_redacts_fake_secret(self) -> None:
+        secret = ("s" + "k-") + "FAKE" + ("Z" * 44)
+        context = (
+            "class SourceAuthority(str, enum.Enum):\n"
+            '    MONOREPO_POC = "monorepo_poc"\n'
+            f'api_key = "{secret}"\n'
+        )
+        responses = [
+            json.dumps({"choices": [{"message": {"content": "ok"}}]}).encode("utf-8"),
+        ]
+
+        def fake_urlopen(request, timeout=0):  # noqa: ARG001
+            return io.BytesIO(responses.pop(0))
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _rc, out = self._invoke_main(
+                {
+                    "mode": "openrouter_single",
+                    "prompt": "012 work focus",
+                    "context": context,
+                    "lead_model": "z-ai/glm-5.2",
+                    "audit_context": True,
+                }
+            )
+
+        self.assertTrue(out.get("ok"))
+        redacted = out.get("redacted_prompt") or ""
+        self.assertIn("SourceAuthority", redacted)
+        self.assertNotIn(secret, redacted)
+        self.assertIn("[REDACTED", redacted)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## REDDOG_AUDIT_CONTEXT_BRIDGE_WIRE_PHASE1

**Lane:** retrieval/egress wire | **Build:** 0.3.34 | **Stacked on:** main @ 0.3.33

### Root cause (OBSERVED)
Golden 0.3.33: senses stack **PASS** (7/7 recall, direct_read_fallback_used=true, continuation off) but model **FAIL** (`BLOCKED_LOCALLY`, `made_network_call=false`). Slice-3 `audit_mode` existed in `fusion_redaction_gate.py` and `buildDirectReadContentSection()` set `audit_context: true`, but `advisory_model_once.py` always called `evaluate_redaction_gate()` without `audit_mode`.

### Wire path
`buildDirectReadContentSection().audit_context` -> `buildBoundedRepoContext().audit_context` -> `promptConstruction.audit_context_requested` -> `callFusion()` payload `audit_context` -> `evaluate_redaction_gate(..., audit_mode=True)`.

### Run Trace telemetry
- `audit_context_requested: true|false`
- `audit_context_applied: true|false`

### Redaction safety (OBSERVED)
- Default path byte-identical: no governance direct-read => `audit_mode=false` => strict BLOCK unchanged (DRF-007, ACB-003)
- Audit path preserves governance structure; secrets still redacted (DRF-009, ACB-005, bridge pytest)
- `private_reasoning` never relaxed (ACB-006: WSP_95 `chain-of-thought` literal still BLOCKS in audit mode — fail-closed)

### HoloIndex discoverability (ADDENDUM A)
| Query | Pre-edit top code hits | Post-edit |
|---|---|---|
| RedDog audit context bridge wire | openclaw_supervisor, unrelated | INTERFACE.md anchor (partial) |
| advisory_model_once audit_mode | fusion_redaction_gate.py | fusion_redaction_gate.py |
| buildDirectReadContentSection audit_context | sqlite_audit, unrelated | INTERFACE.md anchor (partial) |

**INDEX_GAP (INFERRED):** `extension.js` / `advisory_model_once.py` still not top-ranked. Static anchors added to INTERFACE/ROADMAP/ModLog. Follow-up: `HOLOINDEX_REDDOG_AUDIT_CONTEXT_BRIDGE_WIRE_INDEX_GAP_PHASE1` (SPECIFIED_NOT_IMPLEMENTED — no ranking code in this slice).

### Tests
- `node tests/verify_extension_contract.js` — PASS (ACB-001..006)
- `pytest scripts/tests/test_advisory_model_once_hardening.py` — PASS (+3 audit wire tests)
- `pytest test_fusion_redaction_gate.py` — PASS

### Known pre-existing (non-blockers)
- `test_extension_js_in_top_hits_for_review_query`
- `test_bundle_json_cli_extension_js_recall`

### Golden rerun note
7-file prompt including **WSP_95** may still hit `private_reasoning` BLOCK (`chain-of-thought` in WSP doc text) even with audit_mode. For clean egress proof, omit WSP_95 or accept fail-closed block. Governance 6-file targets pass audit-mode gate (ACB-004).

### Out of scope
No redaction policy weakening, no new file-read, no WSP_109 intake generation, no execution authority.