### PR TITLE
fix(reddog): default Use-last-packet checkbox OFF (opt-in continuation) (0.3.36)

### DIFF
--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -296,7 +296,7 @@ Review packet additions:
 In-memory WSP_97-safe continuation from the last successful or `BLOCKED_LOCALLY` run:
 
 - `buildSanitizedContinuationSummary()` — extracts Decision/Findings/WSP_97/WSP_15/Next step summaries; strips secrets and blocked-policy literals.
-- `appendContinuationSummaryToWspPrompt()` — appends sanitized summary to the next WSP task prompt when **Use last RedDog packet** is enabled (default ON).
+- `appendContinuationSummaryToWspPrompt()` — appends sanitized summary to the next WSP task prompt when **Use last RedDog packet** is enabled (default OFF as of v0.3.36 — continuation is opt-in; 012 checks the box to enable).
 - `state.lastContinuationSummary` — per-tab in-memory only; no disk persistence in Phase 1.
 - Copy MD may include a safe **Continuation Summary** section for the stored packet (not raw prior model output).
 

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,31 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-03 - REDDOG_CONTINUATION_DEFAULT_OFF_PHASE1 (default Use-last-packet checkbox OFF, opt-in continuation, 0.3.36)
+
+- Change: the webview "Use last RedDog packet" checkbox now defaults UNCHECKED. Continuation is opt-IN
+  instead of opt-out. The feature stays manually available (012 can check the box to append the prior
+  WSP_97-safe summary). One-line HTML edit: removed the `checked` attribute from
+  `<input id="useLastPacket" type="checkbox">`.
+- No backend logic change. The #911 fail-closed backend (`const continuationEnabled = message.useLastPacket
+  === true`) already treats missing/false as OFF, so an unchecked default yields
+  `continuation_enabled=false` AND `continuation_appended=false` with no new code. The frontend still sends
+  `useLastPacket: continuationOn` where `continuationOn = !!(useLastPacket && useLastPacket.checked)`.
+- The "Continuation: disabled for this run." status line (from #911) now renders by default (unchecked run),
+  which is the intended opt-in signal.
+- No packing change (#914), no direct-read change, no redaction change, no new telemetry (continuation
+  telemetry already exists from #911).
+- Tests (verify_extension_contract.js): (a) the useLastPacket checkbox HTML default has NO `checked`
+  attribute; (b) default submit (useLastPacket false/absent) yields continuation_enabled=false AND
+  continuation_appended=false and Copy MD does NOT append the summary even when a prior packet exists;
+  (c) manual check (useLastPacket=true) still appends when a summary is present (feature not removed). Full
+  JS contract suite exit 0 on 0.3.36.
+- Golden rerun note: default-off is now the shipped behavior; the golden rerun no longer needs a manual
+  uncheck of the box.
+- Version: LIVE-surface bump 0.3.35 -> 0.3.36.
+- Stacked on REDDOG_REQUIRED_TARGET_CONTEXT_PACKING_PHASE1 (#914).
+- WSP: WSP_00, WSP_50, WSP_97, WSP_22.
+
 ## 2026-07-03 - REDDOG_REQUIRED_TARGET_CONTEXT_PACKING_PHASE1 (protect required-target excerpts in final model context, 0.3.35)
 
 - Problem (golden 6-file FoundUp-creation audit on 0.3.34): senses stack PASS

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.35
+Version: 0.3.36
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -163,6 +163,20 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 - Add regression retrieval tests so extension bridge code ranks above adjacent WRE routers.
 - **Status:** **LANDED** #882 (`99d0e35c2`) — ranking + target recall telemetry only; not source-content inclusion.
 
+### REDDOG_CONTINUATION_DEFAULT_OFF_PHASE1 (v0.3.36)
+
+- **Status:** VERIFIED_READY (this slice). The webview "Use last RedDog packet" checkbox now defaults
+  UNCHECKED — continuation is opt-IN, not opt-out. One-line HTML edit removed the `checked` attribute; the
+  feature stays manually available (012 checks the box to append the prior WSP_97-safe summary).
+- No backend logic change: the #911 fail-closed backend (`message.useLastPacket === true`) already treats
+  missing/false as OFF, so an unchecked default yields `continuation_enabled=false` AND
+  `continuation_appended=false` with no new code. The "Continuation: disabled for this run." status line
+  (from #911) renders by default.
+- No packing change (#914), no direct-read change, no redaction change, no new telemetry.
+- Golden bar: default submit yields continuation_enabled=false AND continuation_appended=false; manual
+  check still appends when a prior packet exists. Golden rerun no longer needs a manual uncheck.
+- Stacked on REDDOG_REQUIRED_TARGET_CONTEXT_PACKING_PHASE1 (#914).
+
 ### REDDOG_REQUIRED_TARGET_CONTEXT_PACKING_PHASE1 (v0.3.35)
 
 - **Status:** PACKING COMPLETE (this slice). Golden 6-file FoundUp-creation audit on 0.3.34 proved senses
@@ -365,7 +379,7 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 
 ### REDDOG_REVIEW_PACKET_MEMORY_AND_FOLLOWUP_PHASE1
 
-- **Status:** **PR-READY** — in-memory WSP_97-safe continuation summary; "Use last RedDog packet" toggle (default ON).
+- **Status:** **PR-READY** — in-memory WSP_97-safe continuation summary; "Use last RedDog packet" toggle (default OFF as of v0.3.36 — opt-in; see REDDOG_CONTINUATION_DEFAULT_OFF_PHASE1).
 - Sanitized follow-up memory from last run; appends to WSP task prompt without raw Copy MD paste.
 - No disk persistence, no WRE/OpenClaw runtime wiring.
 

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.35';
+const EXTENSION_VERSION = '0.3.36';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -3387,7 +3387,7 @@ function renderHtml(worker, surface, logoUri) {
         <span class="pill">Routing: Auto via WSP_15</span>
         <span class="pill">Context: Auto WSP + HoloIndex + Skillz/Rolodex</span>
         <label for="testWorkFocus">Tests</label><select id="testWorkFocus"><option value="">Select test...</option><option value="regular">Regular smoke</option><option value="fusion">Fusion smoke</option><option value="wsp97">WSP_97 repo review</option><option value="reddog">RedDog architect review</option></select>
-        <label for="useLastPacket"><input id="useLastPacket" type="checkbox" checked> Use last RedDog packet</label>
+        <label for="useLastPacket"><input id="useLastPacket" type="checkbox"> Use last RedDog packet</label>
         <button id="copyMd" type="button">Copy MD</button>
       </div>
       <textarea id="workFocus" placeholder="Describe your work focus (012). 0102 converts this to a WSP task prompt for RedDog." aria-label="012 work focus"></textarea>

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups®Agent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.35",
+    "version":  "0.3.36",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -197,8 +197,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.35', 'package version must be 0.3.35');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.35'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.36', 'package version must be 0.3.36');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.36'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups®Agent', 'display name must be Foundups®Agent');
 includes(JSON.stringify(pkg), 'Foundups®Agent: Open', 'command title must use Foundups®Agent');
@@ -215,7 +215,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.35', 'README version mismatch');
+includes(readme, 'Version: 0.3.36', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -1408,7 +1408,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.35'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.36'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -1422,7 +1422,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.35'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.36'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -1434,7 +1434,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.35'", 'bounded context must include extension.js source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.36'", 'bounded context must include extension.js source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');
@@ -1539,6 +1539,8 @@ assert(!unicodeTrace.includes('\udc94'), 'UNI-007: Run Trace must not echo raw m
 includes(extensionJs, 'buildSanitizedContinuationSummary', 'continuation summary builder missing');
 includes(extensionJs, 'appendContinuationSummaryToWspPrompt', 'continuation append helper missing');
 includes(extensionJs, 'Use last RedDog packet', 'continuation UI toggle missing');
+includes(extensionJs, '<input id="useLastPacket" type="checkbox"> Use last RedDog packet', 'continuation checkbox must default OFF');
+assert(!extensionJs.includes('<input id="useLastPacket" type="checkbox" checked>'), 'continuation checkbox must not default checked');
 includes(extensionJs, 'lastContinuationSummary', 'in-memory continuation store missing');
 includes(roadmap, 'REDDOG_REVIEW_PACKET_MEMORY_AND_FOLLOWUP_PHASE1', 'continuation memory roadmap slice missing');
 
@@ -1701,5 +1703,52 @@ const copyMissing = orchestrator.buildCopyMarkdown(
   { substantive: true, continuationSummary: successSummary }
 );
 assert(!copyMissing.includes('Continuation from last RedDog packet'), 'missing/undefined continuationEnabled must NOT include continuation summary (fail-closed)');
+
+// REDDOG_CONTINUATION_DEFAULT_OFF_PHASE1 (v0.3.36) - continuation is opt-IN.
+// (a) Webview checkbox default is UNCHECKED (no `checked` attribute); feature stays manually available.
+const useLastPacketInputMatch = extensionJs.match(/<input id="useLastPacket" type="checkbox"([^>]*)>/);
+assert(useLastPacketInputMatch, 'useLastPacket checkbox input must exist (feature stays manually available)');
+assert(
+  !/\bchecked\b/.test(useLastPacketInputMatch[1]),
+  'useLastPacket checkbox must default OFF (no `checked` attribute) - continuation is opt-in'
+);
+// Frontend still sends the deterministic boolean from the checkbox state.
+includes(extensionJs, 'useLastPacket: continuationOn', 'frontend must send useLastPacket from checkbox state');
+includes(extensionJs, 'const continuationOn = !!(useLastPacket && useLastPacket.checked)', 'frontend continuation flag must derive from checkbox.checked');
+
+// (b) Default submit: useLastPacket false/absent => continuation_enabled=false AND continuation_appended=false.
+//     Mirrors the backend fail-closed derivation (message.useLastPacket === true), reusing #911's telemetry path.
+const defaultOffFromFalse = orchestrator.normalizeContinuationTelemetry(
+  { continuation_enabled: (false === true), continuation_appended: ((false === true) && true) }
+);
+assert.strictEqual(defaultOffFromFalse.continuation_enabled, false, 'default off (useLastPacket=false): continuation_enabled must be false');
+assert.strictEqual(defaultOffFromFalse.continuation_appended, false, 'default off (useLastPacket=false): continuation_appended must be false');
+const defaultOffFromAbsent = orchestrator.normalizeContinuationTelemetry(
+  { continuation_enabled: (undefined === true), continuation_appended: ((undefined === true) && true) }
+);
+assert.strictEqual(defaultOffFromAbsent.continuation_enabled, false, 'default off (useLastPacket absent): continuation_enabled must be false');
+assert.strictEqual(defaultOffFromAbsent.continuation_appended, false, 'default off (useLastPacket absent): continuation_appended must be false');
+const copyDefaultOff = orchestrator.buildCopyMarkdown(
+  { ok: true, content: sampleArchitectOutput, review_packet: { task_classification: { tier: 'HIGH' }, output_validation: { validated: true }, continuation_telemetry: defaultOffFromFalse } },
+  'reddog_architect', 'Repo context attached', [], null, 'high',
+  { substantive: true, continuationEnabled: false, continuationSummary: successSummary, continuationTelemetry: defaultOffFromFalse }
+);
+assert(!copyDefaultOff.includes('Continuation from last RedDog packet'), 'default off: Copy MD must NOT append continuation summary even when a prior packet exists');
+includes(copyDefaultOff, 'continuation_enabled: false', 'default off: Copy MD telemetry must report enabled=false');
+includes(copyDefaultOff, 'continuation_appended: false', 'default off: Copy MD telemetry must report appended=false');
+
+// (c) Manual check (useLastPacket=true) still appends when a summary is present (feature not removed).
+const manualCheckTelemetry = orchestrator.normalizeContinuationTelemetry(
+  { continuation_enabled: (true === true), continuation_appended: ((true === true) && true), continuation_source_run_id: successSummary.previous_run_id }
+);
+assert.strictEqual(manualCheckTelemetry.continuation_enabled, true, 'manual check (useLastPacket=true): continuation_enabled must be true');
+assert.strictEqual(manualCheckTelemetry.continuation_appended, true, 'manual check + prior packet: continuation_appended must be true');
+const copyManualCheck = orchestrator.buildCopyMarkdown(
+  { ok: true, content: sampleArchitectOutput, review_packet: { task_classification: { tier: 'HIGH' }, output_validation: { validated: true }, continuation_telemetry: manualCheckTelemetry } },
+  'reddog_architect', 'Repo context attached', [], null, 'high',
+  { substantive: true, continuationEnabled: true, continuationSummary: successSummary, continuationTelemetry: manualCheckTelemetry }
+);
+includes(copyManualCheck, 'Continuation from last RedDog packet', 'manual check: Copy MD must still append continuation summary (feature available on opt-in)');
+includes(copyManualCheck, 'continuation_enabled: true', 'manual check: Copy MD telemetry must report enabled=true');
 
 console.log('Foundups®Agent extension contract checks passed.');


### PR DESCRIPTION
## Summary

- Defaults the Foundups Agent "Use last RedDog packet" checkbox OFF.
- Keeps the feature manually available; checking the box still sends useLastPacket=true and appends the prior WSP_97-safe continuation summary when present.
- Bumps Foundups Agent live surfaces to 0.3.36.

## Stack note

Stacked on #914 / feat/reddog-required-target-context-packing-phase1. After #914 lands, rebase/retarget this PR onto main.

## Validation

- node --check extensions/foundups_advisory_workers/extension.js: PASS
- node extensions/foundups_advisory_workers/tests/verify_extension_contract.js: PASS (known surrogate stderr noise still prints; process exits 0)
- git diff --check: PASS
- diff mojibake scan: PASS (no matches)

## Contract proofs

- Checkbox HTML default has no checked attribute.
- Default/false/absent useLastPacket yields continuation_enabled=false and continuation_appended=false.
- Manual opt-in with useLastPacket=true still appends when a prior summary exists.
- No backend continuation, packing, direct-read, redaction, or telemetry logic changes.

## 012 note

After #914 and this PR land, build/install 0.3.36. Golden rerun no longer needs a manual uncheck; default shipped behavior should produce continuation_enabled=false and continuation_appended=false.
