### PR TITLE
feat(reddog): emit extension_version in Run Trace scorecard (0.3.37)

### DIFF
--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -125,7 +125,8 @@ Keyboard:
 
 Copy:
 
-- `Copy MD`: copies a markdown packet with `Run Trace` (role, tier, effort, mode, models, context, redaction, validation), `Work Trail` (allowlisted normalized events, cap 50), and 0102 output.
+- `Copy MD`: copies a markdown packet with `Run Trace` (extension_version, role, tier, effort, mode, models, context, redaction, validation), `Work Trail` (allowlisted normalized events, cap 50), and 0102 output.
+- Run Trace build-version field (REDDOG_RUN_TRACE_BUILD_VERSION_FIELD_PHASE1, v0.3.37): the `## Run Trace` block emits `- extension_version: <EXTENSION_VERSION>` near the top (after the header, before role/tier). It reads the real installed-build `EXTENSION_VERSION` constant, NOT any prompt/packet/model value, so build staleness is machine-checkable from telemetry and never masked by model output. 012/tooling gates build staleness on this field, not on model text.
 - Redaction-block runs include `## Redaction Gate Report` (`BLOCKED_LOCALLY`, WSP_97 truth labels, no raw snippets) before any model output.
 - Validation-failure runs include `OUTPUT_VALIDATION_FAILED` with local static footer (no extra network call).
 - Substantive tasks include `## Governed Handoff Recommendation` (`advisory_only`; bounded digest evidence refs only).

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,28 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-03 - REDDOG_RUN_TRACE_BUILD_VERSION_FIELD_PHASE1 (emit extension_version in Run Trace scorecard, 0.3.37)
+
+- Incident: a golden rerun was mistakenly run on a STALE 0.3.34 build, but the model OUTPUT header claimed
+  "Build: 0.3.36" because it parroted a "Version expected:" line from the prompt. The Run Trace scorecard
+  did NOT emit the actual installed build version as a telemetry field, so staleness could not be detected
+  from the trace itself (only from the UI footer). The model text masked the real build.
+- Fix: `buildRunTraceSection(...)` now emits `- extension_version: ` + `EXTENSION_VERSION` (the real
+  installed-build constant) near the TOP of the `## Run Trace` block, immediately after the header and
+  before the role/tier fields. It reads the constant, NOT any value from the prompt, packet, or model
+  output, so build staleness is machine-checkable from telemetry and can never be masked by model text.
+- Purely additive telemetry. No packing, redaction, fetch, or continuation logic changed. No new
+  file-read. No execution authority.
+- Tests (verify_extension_contract.js): (a) `buildRunTraceSection(...)` output contains
+  `- extension_version: ` followed by the current EXTENSION_VERSION; (b) that value equals the
+  package.json version (they must agree - the trace proves the build); (c) the source line reads the
+  EXTENSION_VERSION constant, not prompt/packet/model text. Full JS contract suite exit 0 on 0.3.37.
+- 012 note: the Run Trace now carries `extension_version` = the real installed build; use it (not model
+  text) as the staleness gate.
+- Version: LIVE-surface bump 0.3.36 -> 0.3.37.
+- Stacked on REDDOG_CONTINUATION_DEFAULT_OFF_PHASE1 (#915).
+- WSP: WSP_00, WSP_50, WSP_97, WSP_22.
+
 ## 2026-07-03 - REDDOG_CONTINUATION_DEFAULT_OFF_PHASE1 (default Use-last-packet checkbox OFF, opt-in continuation, 0.3.36)
 
 - Change: the webview "Use last RedDog packet" checkbox now defaults UNCHECKED. Continuation is opt-IN

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.36
+Version: 0.3.37
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -163,6 +163,21 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 - Add regression retrieval tests so extension bridge code ranks above adjacent WRE routers.
 - **Status:** **LANDED** #882 (`99d0e35c2`) — ranking + target recall telemetry only; not source-content inclusion.
 
+### REDDOG_RUN_TRACE_BUILD_VERSION_FIELD_PHASE1 (v0.3.37)
+
+- **Status:** VERIFIED_READY (this slice). The `## Run Trace` scorecard now emits
+  `- extension_version: <EXTENSION_VERSION>` near the top of the block (after the header, before the
+  role/tier fields). It reads the real installed-build constant, NOT any prompt/packet/model value.
+- Incident driving it: a golden rerun was mistakenly run on a STALE 0.3.34 build while the model OUTPUT
+  header claimed "Build: 0.3.36" (it parroted a "Version expected:" prompt line). The trace carried no
+  machine-checkable build field, so staleness was invisible from telemetry.
+- Purely additive telemetry. No packing/redaction/fetch/continuation change; no new file-read; no
+  execution authority.
+- Golden bar: `buildRunTraceSection(...)` output contains `- extension_version: ` == package.json version;
+  the source line reads the EXTENSION_VERSION constant. 012 gates build staleness on this field, not model
+  text.
+- Stacked on REDDOG_CONTINUATION_DEFAULT_OFF_PHASE1 (#915).
+
 ### REDDOG_CONTINUATION_DEFAULT_OFF_PHASE1 (v0.3.36)
 
 - **Status:** VERIFIED_READY (this slice). The webview "Use last RedDog packet" checkbox now defaults

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.36';
+const EXTENSION_VERSION = '0.3.37';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -802,6 +802,7 @@ function buildRunTraceSection(result, workerType, contextSummary, holoScorecard,
   const reddogEffort = String(rp.resolved_effort || resolvedEffort || 'unknown').toLowerCase();
   const lines = [
     '## Run Trace',
+    '- extension_version: ' + EXTENSION_VERSION,
     '- 0102 role: ' + workerLabel,
     '- WSP_15 tier: ' + (cls.tier || 'unknown'),
     '- reddog_effort: ' + reddogEffort,

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups®Agent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.36",
+    "version":  "0.3.37",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -197,8 +197,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.36', 'package version must be 0.3.36');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.36'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.37', 'package version must be 0.3.37');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.37'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups®Agent', 'display name must be Foundups®Agent');
 includes(JSON.stringify(pkg), 'Foundups®Agent: Open', 'command title must use Foundups®Agent');
@@ -215,7 +215,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.36', 'README version mismatch');
+includes(readme, 'Version: 0.3.37', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -549,6 +549,11 @@ const repairTraceFailed = orchestrator.buildRunTraceSection({
 includes(repairTraceFailed, 'repair_context_mode: repair_minimal', 'OSR-010: Run Trace must expose repair context on failed repair');
 includes(repairTraceFailed, 'repair_mode: openrouter_single', 'OSR-010: Run Trace must expose repair mode on failed repair');
 includes(repairTraceFailed, 'missing_sections_after_repair: Evidence, Next safest step', 'OSR-010: Run Trace must list remaining missing sections');
+
+// RTBV-001: Run Trace must emit the REAL installed build version (EXTENSION_VERSION constant),
+// so build staleness is machine-checkable from telemetry and never masked by model text.
+includes(repairTraceFailed, '- extension_version: ' + pkg.version, 'RTBV-001: Run Trace must emit extension_version = package version (the real build)');
+includes(extensionJs, "'- extension_version: ' + EXTENSION_VERSION", 'RTBV-001: Run Trace line must read the EXTENSION_VERSION constant, not prompt/packet/model text');
 
 const handoffContext = orchestrator.skillzWardrobeRolodexContext(root, 'process all youtube comments with existing skillz', 12000);
 includes(handoffContext, 'Skillz/Wardrobe/Rolodex discovery', 'handoff context header missing');
@@ -1408,7 +1413,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.36'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.37'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -1422,7 +1427,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.36'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.37'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -1434,7 +1439,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.36'", 'bounded context must include extension.js source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.37'", 'bounded context must include extension.js source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');


### PR DESCRIPTION
## Why (stale-build masking incident)

A golden rerun was mistakenly run on a **STALE 0.3.34 build**, but the model OUTPUT header claimed **"Build: 0.3.36"** because it parroted a `Version expected:` line from the prompt. The Run Trace scorecard did **not** emit the actual installed build version as a telemetry field, so staleness could not be detected from the trace itself (only from the UI footer). Model text masked the real build.

## Fix (purely additive telemetry)

`buildRunTraceSection(...)` now emits, near the top of the `## Run Trace` block (after the header, before the role/tier fields):

```
- extension_version: <EXTENSION_VERSION>
```

It reads the real installed-build `EXTENSION_VERSION` constant, **NOT** any value from the prompt, packet, or model output. Build staleness is now machine-checkable from telemetry and can never be masked by model text again.

No packing, redaction, fetch, or continuation logic changed. No new file-read. No execution authority.

## Tests (verify_extension_contract.js)

- RTBV-001: `buildRunTraceSection(...)` output contains `- extension_version: ` == `package.json` version (the trace proves the build).
- RTBV-001: the source line reads the `EXTENSION_VERSION` constant, not prompt/packet/model text.
- Negative test confirmed: injecting a wrong expected version makes the assertion fail (proves it is live).
- Full JS contract suite exit 0 on 0.3.37.

## Version

LIVE-surface bump 0.3.36 -> 0.3.37 (package.json, EXTENSION_VERSION, README, ModLog, INTERFACE, ROADMAP, all live 0.3.36 contract assertions incl. target-snippet content checks). Historical annotations untouched. Because the new test asserts `extension_version == package version`, the version bump and the new field are validated together.

## Stacked

Stacked on **REDDOG_CONTINUATION_DEFAULT_OFF_PHASE1 (#915)**. Base branch `feat/reddog-continuation-default-off-phase1`; auto-retargets to `main` as #914/#915 merge.

## 012 note

The Run Trace now carries `extension_version` = the real installed build. Use it (not model text) as the staleness gate.

Worker-Lane: telemetry
Slice: REDDOG_RUN_TRACE_BUILD_VERSION_FIELD_PHASE1