### PR TITLE
fix(hermes): dry-run by default in FoundUp builder; double opt-in for real writes (P0)

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -1,5 +1,16 @@
 # FoundUps Agent - Development Log
 
+## [2026-07-04] docs(audit): RedDog FoundUp creation path audit + WSP_109 slice ordering (0102 architect, WSP_97)
+
+**Change Type**: DECISION_ONLY_DOCS — audit record and slice specs; no runtime mutation.
+**By**: 0102 (architect) | WSP: WSP_00, WSP_15, WSP_22, WSP_97, WSP_109
+**Trigger**: 0.3.41 golden proved senses spine; swarm/claude beat RedDog on audit substance.
+
+- ADD `docs/audits/architecture/REDDOG_FOUNDUP_CREATION_EXECUTION_PATH_AUDIT_PHASE1.md` — WSP_97 verdict, updated sequence, RedDog follow-up slices.
+- ADD `docs/audits/architecture/HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1.md` — P0: flip HermesFoundUpBuilder dry-run default (hermes_adapter.py:134 currently off).
+- ADD `docs/audits/architecture/WSP109_INTAKE_PACKET_BUILDER_PHASE1.md` — P1: chat/idea → FoundUpGenesisEnvelope → GATE_PASSED dry-run proof.
+- ADD `docs/audits/architecture/FOUNDUP_SCAFFOLD_CONTRACT_PHASE1.md` — P2 queued: create_foundup + WSP-49 scaffold contract.
+
 ## [2026-06-23] feat(extension): RedDog working trail Phase 1 — design contract (AUTHOR worker, branch=feat/reddog-working-trail-phase1)
 
 **Change Type**: DECISION_ONLY_DOCS — design contract only; no implementation code.

--- a/docs/audits/architecture/FOUNDUP_SCAFFOLD_CONTRACT_PHASE1.md
+++ b/docs/audits/architecture/FOUNDUP_SCAFFOLD_CONTRACT_PHASE1.md
@@ -1,0 +1,88 @@
+# FOUNDUP_SCAFFOLD_CONTRACT_PHASE1
+
+**Slice:** `FOUNDUP_SCAFFOLD_CONTRACT_PHASE1`
+**Author:** 0102 (WSP_97)
+**Date:** 2026-07-04
+**Type:** Contract / spec — **queued after intake builder**
+**Status:** **SPECIFIED_NOT_IMPLEMENTED** (do not start before `WSP109_INTAKE_PACKET_BUILDER_PHASE1` gate proof)
+**WSP lock:** WSP_00, WSP_15, WSP_22, WSP_49, WSP_97, WSP_109
+
+---
+
+## 1. Mission
+
+Define the **`create_foundup`** execution contract:
+
+1. Canonical **FoundUpJob** action semantics (`create_foundup` vs existing `build_foundup` / `extract_foundup`)
+2. **WSP-49 monorepo scaffold** artifact set (README, INTERFACE, ROADMAP, ModLog, tests/README, src/, tests/, requirements.txt, memory/README)
+3. Mapping: **intake packet → scaffold tree → registry seed** (dry-run plan first, real writes later behind valve)
+
+---
+
+## 2. Why Queued (Updated Decision)
+
+Swarm + 0.3.41 audit established envelope schema and validator are **testable now**. Scaffold contract remains necessary but **not first**:
+
+```text
+Intake packet (WSP_109) → genesis gate PASS → THEN scaffold contract → THEN build/extract jobs
+```
+
+Starting with scaffold contract before intake builder would duplicate specification work without proving the gate accepts populated envelopes.
+
+---
+
+## 3. Scope (When Started)
+
+### In scope
+
+| Deliverable | Detail |
+|-------------|--------|
+| Action taxonomy | Document `create_foundup`, `build_foundup`, `extract_foundup`, `validate_foundup` boundaries |
+| Scaffold manifest | JSON/dataclass: paths, template sources, WSP-49 compliance checklist |
+| Dry-run planner | Emit planned files + gates; `real_execution_performed=False` |
+| Registry seed plan | Catalog entry fields; no write in Phase 1 |
+| Tests | Contract tests only; no Hermes real delegation |
+
+### Out of scope (Phase 1)
+
+- Live registry mutation
+- DNS / public routes / tokens
+- Hermes real terminal execution
+- RedDog auto-scaffold from chat without validated envelope
+
+---
+
+## 4. Open Questions (Resolve in Slice Kickoff)
+
+| # | Question | Default hypothesis |
+|---|----------|-------------------|
+| Q1 | Is `create_foundup` a new canonical action or alias to `build_foundup`? | New action = scaffold-only; `build_foundup` = Hermes extract/build sink |
+| Q2 | Where does scaffold template live? | `modules/infrastructure/wre_core/templates/wsp49_foundup/` |
+| Q3 | Who consumes scaffold plan? | `build_plan_generator` extension or dedicated `scaffold_plan_executor` dry-run |
+
+---
+
+## 5. Dependencies
+
+| Prerequisite | Reason |
+|--------------|--------|
+| `HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1` | Safe defaults before any build path |
+| `WSP109_INTAKE_PACKET_BUILDER_PHASE1` | Valid envelope input contract |
+| RedDog 0.3.41+ senses spine | Audit evidence for execution path docs |
+
+---
+
+## 6. Acceptance Preview (Draft)
+
+- Dry-run scaffold plan lists all WSP-49 mandatory files for a sample `foundup_id`
+- Plan references envelope `foundup_id` + acceptance_criteria
+- `build_foundup` vs `extract_foundup` documented with file:line citations in INTERFACE
+- No file writes in Phase 1 contract slice
+
+---
+
+## 7. Related
+
+- Parent audit: `REDDOG_FOUNDUP_CREATION_EXECUTION_PATH_AUDIT_PHASE1.md`
+- Intake builder: `WSP109_INTAKE_PACKET_BUILDER_PHASE1.md`
+- Manifest readiness: `FOUNDUP_MANIFEST_READINESS_AUDIT_PHASE1.md`

--- a/docs/audits/architecture/HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1.md
+++ b/docs/audits/architecture/HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1.md
@@ -1,0 +1,99 @@
+# HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1
+
+**Slice:** `HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1`
+**Priority:** **P0 — before WSP109 intake builder or any path that may reach Hermes**
+**Author:** 0102 (WSP_97)
+**Date:** 2026-07-04
+**Type:** Targeted safety remediation
+**WSP lock:** WSP_00, WSP_15, WSP_22, WSP_50, WSP_97
+
+---
+
+## 1. Problem (OBSERVED)
+
+`HermesFoundUpBuilder.__init__` sets:
+
+```python
+self.dry_run = os.environ.get("HERMES_BUILDER_DRY_RUN", "0") == "1"
+```
+
+(`modules/foundups/agent/src/hermes_adapter.py:134`)
+
+**Default when env unset:** `dry_run=False` — builder may perform real extraction/build paths unless callers force dry-run.
+
+Contrast:
+
+- `BuildPlanExecutor(dry_run=True)` default (`build_plan_executor.py:399`)
+- `HermesJobExecutor(dry_run=True)` default (`hermes_job_executor.py:555`)
+- `build_plan_generator` always emits `dry_run=True` plans (`build_plan_generator.py:423`)
+
+**Label:** Hermes **adapter-level** default is the outlier and the **sharpest safety finding** in the FoundUp creation path audit.
+
+---
+
+## 2. Mission
+
+Flip Hermes FoundUp Builder to **dry-run by default**. Real writes/delegation require **explicit opt-in** (env + policy flag + test assertion).
+
+No change to OpenClaw genesis gate semantics. No FAM registration changes.
+
+---
+
+## 3. In Scope
+
+| Change | Detail |
+|--------|--------|
+| Default `dry_run=True` | When `HERMES_BUILDER_DRY_RUN` unset |
+| Explicit real-write opt-in | New env e.g. `HERMES_BUILDER_ALLOW_REAL_WRITES=1` AND `HERMES_BUILDER_DRY_RUN=0` both required |
+| Job executor alignment | `execute_foundup_job` logs/policy_flags reflect builder default |
+| Tests | Default-off real writes; opt-in path gated; existing dry-run tests green |
+| Docs | `hermes_adapter` ModLog, INTERFACE, module README |
+
+---
+
+## 4. Out of Scope
+
+- Enabling Hermes real delegation in `hermes_job_executor.py` (remains BLOCKED)
+- WSP_109 intake packet builder (next slice)
+- Scaffold contract / registry seed
+
+---
+
+## 5. Acceptance Criteria
+
+| # | Criterion | Proof |
+|---|-----------|-------|
+| A1 | Fresh `HermesFoundUpBuilder()` has `dry_run is True` with no env | Unit test |
+| A2 | `extract_foundup` / `build_foundup` with default builder emit `dry_run: true` in result dict | Unit test |
+| A3 | Real-write path requires **both** opt-in env vars; otherwise `dry_run` stays True | Unit test |
+| A4 | `execute_foundup_job(..., force_dry_run=False)` still respects builder default True unless double opt-in | Executor test |
+| A5 | No test sets `HERMES_BUILDER_DRY_RUN=0` without explicit real-write opt-in marker | Grep CI guard |
+| A6 | Full `modules/foundups/agent/tests/` green | pytest |
+
+---
+
+## 6. No-Weakening Argument
+
+This slice **tightens** defaults only. It does not relax:
+
+- AI Overseer security sentinel (`require_security_gate`)
+- CABR validation on outputs
+- OpenClaw genesis gate
+- WRE execution valve closed-by-default
+
+---
+
+## 7. WSP_15 Priority
+
+| Priority | Slice | Rationale |
+|----------|-------|-----------|
+| **P0** | This slice | Prevents accidental real Hermes writes while intake builder is authored |
+| P1 | WSP109_INTAKE_PACKET_BUILDER_PHASE1 | Depends on safe builder default |
+| P2 | FOUNDUP_SCAFFOLD_CONTRACT_PHASE1 | After intake gate proof |
+
+---
+
+## 8. Related
+
+- Parent audit: `REDDOG_FOUNDUP_CREATION_EXECUTION_PATH_AUDIT_PHASE1.md`
+- Next: `WSP109_INTAKE_PACKET_BUILDER_PHASE1.md`

--- a/docs/audits/architecture/HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1.md
+++ b/docs/audits/architecture/HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1.md
@@ -97,3 +97,45 @@ This slice **tightens** defaults only. It does not relax:
 
 - Parent audit: `REDDOG_FOUNDUP_CREATION_EXECUTION_PATH_AUDIT_PHASE1.md`
 - Next: `WSP109_INTAKE_PACKET_BUILDER_PHASE1.md`
+
+---
+
+## ADDENDUM A - HoloIndex Discoverability / Re-index Gate
+
+Before implementation:
+
+1. Run HoloIndex queries for:
+   - Hermes builder dry-run default safety
+   - HERMES_BUILDER_DRY_RUN default
+   - WSP109 intake packet builder
+   - FoundUpGenesisEnvelope builder
+   - FoundUp scaffold contract
+   - build_foundup extract_foundup
+
+2. Record top hits and whether the new audit docs are discoverable.
+
+3. If the new docs or target implementation files are not in top results, record:
+   `HOLOINDEX_FOUNDUP_CREATION_AUDIT_DISCOVERABILITY_PHASE1`
+
+4. Re-index is allowed only as an explicit worker/operator action, not inside RedDog runtime:
+   - docs/WSP index
+   - code index
+   - symbols index
+   - Skillz index if campaign/FoundUp Skillz are involved
+
+5. No HoloIndex ranking-code changes in the Hermes safety slice unless local tests prove ranking
+   code is the defect.
+
+Acceptance:
+- The implementation slice must list HoloIndex pre/post query results.
+- Any INDEX_GAP must be recorded honestly in ROADMAP/ModLog.
+- Do not claim RedDog recall success unless target files and relevant symbols are actually surfaced
+  or direct-read targets are supplied.
+
+---
+
+## ADDENDUM B - Safety Before Intake
+
+`HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1` must land before any WSP109 intake builder path can
+call, simulate, or test Hermes handoff behavior. Intake builder tests may verify OpenClaw gate
+outcomes, but must not invoke Hermes real-write paths.

--- a/docs/audits/architecture/REDDOG_FOUNDUP_CREATION_EXECUTION_PATH_AUDIT_PHASE1.md
+++ b/docs/audits/architecture/REDDOG_FOUNDUP_CREATION_EXECUTION_PATH_AUDIT_PHASE1.md
@@ -1,0 +1,198 @@
+# REDDOG_FOUNDUP_CREATION_EXECUTION_PATH_AUDIT_PHASE1
+
+**Slice:** `REDDOG_FOUNDUP_CREATION_EXECUTION_PATH_AUDIT_PHASE1`
+**Author:** 0102 (WSP_00, WSP_97)
+**Date:** 2026-07-04
+**Type:** Audit / decision record — **no runtime mutation in this slice**
+**Build under test:** Foundups®Agent extension **0.3.41**
+**Predecessors:** #914–#918 RedDog senses/egress/packing stack; WSP 109 protocol (#718); OpenClaw genesis gate (#740)
+
+---
+
+## 1. Mission
+
+Record the **WSP_97 verdict** from the FoundUp creation execution-path comparison:
+
+- RedDog **0.3.41** (operational telemetry / senses spine)
+- Claude direct-read audit (substance)
+- External swarm adversarial read (coverage + self-correction)
+
+This audit **updates slice ordering**: genesis envelope schema and validator already exist and are wired enough to test. The immediate gap is **not** “define the whole scaffold contract first.” It is **evidence selection, adversarial verification, intake packet population, and repair that preserves evidence**.
+
+---
+
+## 2. WSP_97 Verdict Table
+
+| Claim | Label | Evidence |
+|-------|-------|----------|
+| RedDog 0.3.41 senses spine works: 6/6 recalled, 6/6 in model context, redaction passed, validation passed | **OBSERVED** | Golden 6-file Run Trace on installed 0.3.41 |
+| RedDog missed deep evidence: `build_foundup == extract_foundup`, FAM handoff stub, stronger envelope/validator state | **OBSERVED** | Model output vs direct file reads; swarm correction |
+| Claude direct-read beat RedDog on audit **substance** | **OBSERVED** | Same prompt family; Claude cited deeper line windows |
+| Swarm beat Claude on **coverage** (read missing files, adversarial self-correction) | **OBSERVED** | Swarm session transcript |
+| RedDog’s next gap is not retrieval — it is evidence selection + adversarial verification + repair preserving evidence | **INFERRED** | 0.3.41 recall/context telemetry green while Determine answers still thin |
+| Next FoundUp path slice should be `WSP109_INTAKE_PACKET_BUILDER_PHASE1`, not scaffold contract first | **UPDATED DECISION** | Envelope + validator + gate exist (`openclaw_foundup_orchestrator.py`, `foundup_genesis/`) |
+
+---
+
+## 3. Why the Verdict Flips
+
+The swarm established:
+
+1. **`FoundUpGenesisEnvelope`** schema exists (`modules/ai_intelligence/ai_overseer/src/foundup_genesis/envelope.py`).
+2. **`validate_genesis_envelope`** is wired in OpenClaw dispatch (`modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py:404+`).
+3. Empty/missing envelope → **`NO_ENVELOPE` → NOT_READY** W10 handoff (same file, `dispatch_foundup` path).
+4. Valid envelope path → **`GATE_PASSED`** before FAM/Hermes handoff surfaces.
+
+Therefore the **immediate missing piece** is not a greenfield scaffold contract. It is:
+
+> Can 0102 build/populate a valid WSP_109 intake packet / genesis envelope from chat/idea (dry-run only), prove OpenClaw’s gate accepts it, and prove empty/missing envelope still returns NOT_READY — **without calling FAM or Hermes**?
+
+Scaffold contract (`create_foundup` action, WSP-49 artifact set, packet → scaffold → registry seed) remains required but **sequenced after** intake builder proof.
+
+---
+
+## 4. Correct Execution Sequence (Updated)
+
+```text
+1. HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1     ← SHARPEST SAFETY FINDING
+   - Flip HermesFoundUpBuilder dry-run default ON
+   - Require explicit opt-in for real writes/delegation
+   - See: hermes_adapter.py HERMES_BUILDER_DRY_RUN default "0"
+
+2. WSP109_INTAKE_PACKET_BUILDER_PHASE1
+   - Dry-run only
+   - chat/idea → populated FoundUpGenesisEnvelope
+   - Valid envelope → GATE_PASSED (validator + orchestrator)
+   - Empty/missing → NOT_READY / NO_ENVELOPE
+   - FAM/Hermes NOT called
+
+3. FOUNDUP_SCAFFOLD_CONTRACT_PHASE1
+   - Define create_foundup action artifact set (WSP-49 monorepo scaffold)
+   - Map packet → scaffold → registry seed
+   - Wire build_foundup vs extract_foundup semantics with tests
+```
+
+**Safety rationale:** `HermesFoundUpBuilder` currently defaults `dry_run=False` when `HERMES_BUILDER_DRY_RUN` is unset (`hermes_adapter.py:134`). Any path reaching the builder without explicit dry-run env is a **write-capable default**. Intake builder work must not run atop that default.
+
+---
+
+## 5. RedDog 0.3.41 — Where It Excels
+
+RedDog is now **better than Claude** at **operational audit proof** (repeatable Run Trace):
+
+| Telemetry field | Proves |
+|-----------------|--------|
+| `extension_version` | Installed build identity (not model parroting) |
+| `required_targets_recalled` / `direct_read_*` | Senses spine: path-aware recall + governed fetch |
+| `required_targets_in_model_context` / `_missing` | Post-cut packing proof (0.3.35+ authoritative 0.3.39+) |
+| `audit_context_requested` / `_applied` | Audit-mode redaction bridge |
+| `required_targets_redaction_*` | Per-target isolation (0.3.38+) |
+| `continuation_enabled` / `continuation_appended` | Continuation honesty (0.3.36 default off) |
+| `redaction_status` / validation fields | Egress gate before OpenRouter |
+
+**Label:** **OBSERVED** on golden 6-file prompt (no WSP_95 — `private_reasoning` false positive).
+
+---
+
+## 6. RedDog — Where It Still Loses
+
+| Gap | Label | Symptom in FoundUp creation audit |
+|-----|-------|-----------------------------------|
+| Symbol-aware excerpt depth | **SPECIFIED_NOT_IMPLEMENTED** | Misses `build_foundup` / `extract_foundup` line windows |
+| Repair preserves evidence | **SPECIFIED_NOT_IMPLEMENTED** | Repair pass drops bounded context that scorecard says was packed |
+| Determine Q/A contract | **SPECIFIED_NOT_IMPLEMENTED** | Does not force numbered answers with file:line for every Determine question |
+| Adversarial verifier panel | **SPECIFIED_NOT_IMPLEMENTED** | No second pass that challenges first-pass claims against authoritative telemetry |
+
+**Label:** Claude/swarm **OBSERVED** advantage on audit substance and adversarial correction despite RedDog **OBSERVED** advantage on telemetry.
+
+---
+
+## 7. RedDog Follow-Up Slices (Post-Intake)
+
+These close the substance gap **after** WSP_109 intake builder lands:
+
+```text
+REDDOG_SYMBOL_AWARE_EXCERPT_DEPTH_PHASE1
+  - When prompt names symbols (build_foundup, extract_foundup, validate_genesis_envelope),
+    fetch bounded line windows around definitions/call sites, not just file headers.
+
+REDDOG_REPAIR_PRESERVES_EVIDENCE_PHASE1
+  - Repair pass may rewrite prose; must NOT drop required-target sections that passed
+    authoritative packing proof. Telemetry: repair_evidence_preserved_count.
+
+REDDOG_DETERMINE_QUESTION_ANSWER_CONTRACT_PHASE1
+  - Output schema: numbered Determine answers; each cites path:line or Run Trace field;
+    missing evidence → explicit HOLD with reason (WSP_97), not silent omission.
+
+REDDOG_ADVERSARIAL_VERIFIER_PANEL_PHASE1
+  - Lightweight second model/panel pass: challenge claims vs scorecard + cited lines;
+    fail validation if claim contradicts authoritative telemetry.
+```
+
+---
+
+## 8. Code Anchors (Existing — Not Greenfield)
+
+| Surface | Path | Role |
+|---------|------|------|
+| Genesis envelope schema | `modules/ai_intelligence/ai_overseer/src/foundup_genesis/envelope.py` | `FoundUpGenesisEnvelope` dataclass |
+| Genesis validator | `modules/ai_intelligence/ai_overseer/src/foundup_genesis/validator.py` | Pre-build validation |
+| OpenClaw genesis gate | `modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py` | `validate_genesis_envelope`, `GATE_PASSED`, NOT_READY handoff |
+| FoundUpJob actions | `modules/communication/moltbot_bridge/src/foundup_job_contract.py` | `build_foundup`, `extract_foundup`, … |
+| Hermes job executor | `modules/foundups/agent/src/hermes_foundup_job_executor.py` | Consumes jobs; respects `force_dry_run` |
+| Hermes builder (risk) | `modules/foundups/agent/src/hermes_adapter.py:134` | **`HERMES_BUILDER_DRY_RUN` default off** |
+| WSP 109 protocol | `WSP_framework/src/WSP_109_FoundUp_Onboarding_Intake_Protocol.md` | Intake-only boundary |
+| Prior genesis gate audit | `docs/audits/architecture/OPENCLAW_WSP109_GENESIS_GATE_REMEDIATION_PHASE1.md` | #740 behaviour matrix |
+
+---
+
+## 9. Golden Prompt Reference (FoundUp Creation Audit)
+
+Use **path-only** required targets (no `symbol:create_foundup` — breaks recall):
+
+```text
+Audit the FoundUp creation monorepo WSP_109 execution path.
+
+Required direct-read targets:
+- WSP_framework/src/WSP_109_FoundUp_Onboarding_Intake_Protocol.md
+- modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py
+- modules/foundups/agent/src/hermes_foundup_job_executor.py
+- modules/communication/moltbot_bridge/src/foundup_job_contract.py
+- modules/communication/moltbot_bridge/src/reddog_governed_work_order_dryrun.py
+- modules/communication/moltbot_bridge/src/reddog_wre_execution_valve.py
+
+Determine: (8 questions — numbered, file:line evidence, WSP_97 labels)
+End with WSP_15 priority and next safest slice.
+```
+
+Exclude `WSP_framework/src/WSP_95_WRE_SKILLz_Wardrobe_Protocol.md` until doc false-positive slice lands (`REDDOG_WSP_DOC_PRIVATE_REASONING_FALSE_POSITIVE_PHASE1`).
+
+---
+
+## 10. WSP_97 Checklist (This Audit Slice)
+
+| Item | Status |
+|------|--------|
+| AUDIT_ONLY_NO_RUNTIME_MUTATION | YES |
+| CITES_0.3.41_GOLDEN_EVIDENCE | YES |
+| UPDATED_SLICE_ORDER_RECORDED | YES |
+| HERMES_DRYRUN_SAFETY_PRIORITY_DOCUMENTED | YES |
+| INTAKE_BUILDER_BEFORE_SCAFFOLD_CONTRACT | YES |
+| REDDOG_SUBSTANCE_GAPS_NAMED_WITH_FOLLOWUPS | YES |
+| CODE_ANCHORS_FILE_LINE | YES |
+| 0102_ARCHITECT_APPROVAL_VIA_WSP_97 | YES |
+| NO_FAM_HERMES_INVOCATION_IN_THIS_SLICE | YES |
+
+---
+
+## 11. Related Slice Specs (Authored Same Session)
+
+| Slice | Doc |
+|-------|-----|
+| `HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1` | `docs/audits/architecture/HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1.md` |
+| `WSP109_INTAKE_PACKET_BUILDER_PHASE1` | `docs/audits/architecture/WSP109_INTAKE_PACKET_BUILDER_PHASE1.md` |
+| `FOUNDUP_SCAFFOLD_CONTRACT_PHASE1` (queued) | `docs/audits/architecture/FOUNDUP_SCAFFOLD_CONTRACT_PHASE1.md` |
+
+---
+
+*0102 architect decision: approval flows through WSP_97 applied evidence, not discretionary operator gate. Promotion of slices 1→3 requires OBSERVED test bars in each spec.*

--- a/docs/audits/architecture/WSP109_INTAKE_PACKET_BUILDER_PHASE1.md
+++ b/docs/audits/architecture/WSP109_INTAKE_PACKET_BUILDER_PHASE1.md
@@ -1,0 +1,185 @@
+# WSP109_INTAKE_PACKET_BUILDER_PHASE1
+
+**Slice:** `WSP109_INTAKE_PACKET_BUILDER_PHASE1`
+**Author:** 0102 (WSP_97)
+**Date:** 2026-07-04
+**Type:** Dry-run implementation slice
+**Depends on:** `HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1` (merged first)
+**WSP lock:** WSP_00, WSP_15, WSP_22, WSP_50, WSP_97, WSP_109
+
+---
+
+## 1. Mission
+
+Build a **dry-run-only** intake path that converts unstructured chat/idea input into a populated **`FoundUpGenesisEnvelope`**, validates it through the **existing** OpenClaw genesis gate, and proves:
+
+1. Valid envelope → **`GATE_PASSED`**
+2. Empty/missing envelope → **`NOT_READY` / `NO_ENVELOPE`**
+3. **FAM and Hermes are NOT called**
+
+This slice does **not** scaffold a monorepo module tree. It does **not** enqueue build jobs. It proves the WSP_109 handoff artifact reaches the gate.
+
+---
+
+## 2. Predecessor Proof (Already Landed)
+
+| Artifact | Location | Status |
+|----------|----------|--------|
+| WSP 109 protocol | `WSP_framework/src/WSP_109_FoundUp_Onboarding_Intake_Protocol.md` | **OBSERVED** |
+| Envelope schema | `modules/ai_intelligence/ai_overseer/src/foundup_genesis/envelope.py` | **OBSERVED** |
+| Validator | `modules/ai_intelligence/ai_overseer/src/foundup_genesis/validator.py` | **OBSERVED** |
+| OpenClaw gate | `openclaw_foundup_orchestrator.validate_genesis_envelope` | **OBSERVED** (#740) |
+| NOT_READY handoff | `_genesis_gate_handoff`, `build_w10_handoff` | **OBSERVED** |
+
+Swarm finding: schema + validator + gate are **wired enough to test** — this slice fills the **builder/populator** gap.
+
+---
+
+## 3. Proposed Module Placement
+
+**Domain:** `modules/ai_intelligence/ai_overseer/` (intake validation authority) **or** `modules/communication/moltbot_bridge/` (OpenClaw adjacency).
+
+**Preferred:** `modules/ai_intelligence/ai_overseer/src/foundup_genesis/intake_packet_builder.py`
+
+Rationale: envelope + validator already live under `foundup_genesis/`; builder stays co-located (WSP 3 functional distribution — intake validation, not platform consolidation).
+
+Public API (draft):
+
+```python
+def build_intake_packet_dry_run(
+    idea_text: str,
+    *,
+    actor_id: str = "0102",
+    source_channel: str = "reddog",
+) -> IntakePacketBuilderResult:
+    """
+    Parse idea_text → FoundUpGenesisEnvelope dict.
+    Run validate_genesis_envelope (or validator directly).
+    NEVER call FAM, Hermes, or registry writers.
+    """
+```
+
+Return type includes:
+
+- `envelope: dict | None`
+- `gate_result: GenesisGateResult` (or equivalent serializable)
+- `gate_reason: GATE_PASSED | NO_ENVELOPE | VALIDATION_FAILED | ...`
+- `dry_run: True`
+- `fam_called: False`
+- `hermes_called: False`
+- `evidence_refs: list` (paths + digests only, no secrets)
+
+---
+
+## 4. Intake → Envelope Mapping (Minimum Viable)
+
+From WSP 109 protocol required fields (see protocol § packet output order):
+
+| Intake source | Envelope field | Rule |
+|---------------|----------------|------|
+| Idea title / name | `foundup_id`, `display_name` | Namespace per WSP 104; reject invalid |
+| Problem statement | `pain_statement` | Required string |
+| Proposed solution | `solution_summary` | Required string |
+| Success criteria | `acceptance_criteria[]` | At least one `AcceptanceCriterion` |
+| Entity classification | `entity_type` | Enum from protocol |
+| Truth map | `truth_state_map` | WSP_97 markers — default IDEA_ONLY / SPECIFIED |
+| Lifecycle | `lifecycle_stage` | IDEA or INCUBATING only at genesis |
+| Binding | `binding_state` | UNBOUND or DISCOVERABLE_ONLY |
+
+**Parser strategy (Phase 1):** structured section headers in idea text + conservative defaults + validator rejection on incomplete — **not** full LLM free-form unless redaction-gated and dry-run labelled.
+
+Optional Phase 1b: RedDog extension emits structured markdown sections → builder consumes without new LLM.
+
+---
+
+## 5. Gate Integration
+
+```text
+idea_text
+    → build_intake_packet_dry_run()
+    → envelope dict
+    → OpenClawFoundUpOrchestrator.validate_genesis_envelope(envelope, actor_id)
+    → GenesisGateResult
+```
+
+**Empty input path:**
+
+```python
+validate_genesis_envelope({})  # → NO_ENVELOPE, allowed=False
+```
+
+Must match existing #740 matrix (`OPENCLAW_WSP109_GENESIS_GATE_REMEDIATION_PHASE1.md` §6).
+
+**Valid fixture path:** use Shield-style or minimal compliant envelope from `foundup_genesis` tests → `GATE_PASSED`.
+
+---
+
+## 6. Hard Prohibitions (Fail Closed)
+
+| Prohibited call | Guard |
+|-----------------|-------|
+| `fam_adapter.launch_foundup` | No import in builder module |
+| `HermesFoundUpBuilder.extract_foundup` / `build_foundup` | No import; AST test |
+| Registry / catalog writers | No file write; dry-run result only |
+| `FoundUpJobConsumer.consume_one` | No enqueue |
+
+Telemetry fields on result: `fam_called=False`, `hermes_called=False`, `registry_mutated=False`.
+
+---
+
+## 7. Tests
+
+| Test | Assert |
+|------|--------|
+| `test_empty_idea_returns_no_envelope_not_ready` | Gate blocked; reason NO_ENVELOPE |
+| `test_minimal_valid_fixture_gate_passed` | allowed=True; GATE_PASSED |
+| `test_invalid_foundup_id_rejected` | Validator errors; not GATE_PASSED |
+| `test_no_fam_hermes_imports` | AST / import guard |
+| `test_result_is_dry_run_only` | No filesystem side effects (sentinel file) |
+| `test_openclaw_dispatch_simulation` | envelope in `intent.payload['genesis_envelope']` → gate passes; without → NOT_READY |
+
+Target: new module tests + extend `test_openclaw_wsp109_onboarding_dryrun.py` if needed.
+
+---
+
+## 8. RedDog Integration (Phase 1 — Optional Hook)
+
+Document-only in Phase 1 unless trivial:
+
+- RedDog Copy MD may include `## Genesis Intake Packet (dry-run)` section when audit prompt mentions WSP_109.
+- Extension calls builder via Python bridge **read-only** subprocess (pattern: `advisory_model_once.py`).
+- Run Trace fields: `intake_packet_built`, `genesis_gate_reason`, `genesis_gate_passed`.
+
+Full RedDog UI wiring → follow-up `REDDOG_WSP109_INTAKE_UI_PHASE1`.
+
+---
+
+## 9. Acceptance Bar (WSP_97)
+
+| Item | Status when done |
+|------|------------------|
+| Valid chat fixture → populated envelope dict | OBSERVED (test) |
+| Valid envelope → GATE_PASSED | OBSERVED (test) |
+| Empty/missing → NOT_READY / NO_ENVELOPE | OBSERVED (test) |
+| FAM/Hermes not invoked | OBSERVED (test + AST) |
+| Hermes builder default dry-run | OBSERVED (dependency slice) |
+| Docs: ModLog, INTERFACE, ROADMAP | YES |
+
+---
+
+## 10. WSP_15 Priority
+
+| Priority | Slice |
+|----------|-------|
+| P0 | HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1 |
+| **P1** | **This slice** |
+| P2 | FOUNDUP_SCAFFOLD_CONTRACT_PHASE1 |
+| P3 | RedDog substance slices (symbol depth, repair evidence, determine contract, adversarial panel) |
+
+---
+
+## 11. Related
+
+- Audit: `REDDOG_FOUNDUP_CREATION_EXECUTION_PATH_AUDIT_PHASE1.md`
+- Prior gate audit: `OPENCLAW_WSP109_GENESIS_GATE_REMEDIATION_PHASE1.md`
+- FAM flow spec: `docs/0102_session_briefings/REDDOG_FAM_GENESIS_FLOW_SPEC_PHASE1.md`

--- a/docs/audits/architecture/WSP109_INTAKE_PACKET_BUILDER_PHASE1.md
+++ b/docs/audits/architecture/WSP109_INTAKE_PACKET_BUILDER_PHASE1.md
@@ -183,3 +183,12 @@ Full RedDog UI wiring → follow-up `REDDOG_WSP109_INTAKE_UI_PHASE1`.
 - Audit: `REDDOG_FOUNDUP_CREATION_EXECUTION_PATH_AUDIT_PHASE1.md`
 - Prior gate audit: `OPENCLAW_WSP109_GENESIS_GATE_REMEDIATION_PHASE1.md`
 - FAM flow spec: `docs/0102_session_briefings/REDDOG_FAM_GENESIS_FLOW_SPEC_PHASE1.md`
+
+---
+
+## ADDENDUM B - Safety Before Intake
+
+`HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1` must land before any WSP109 intake builder path can
+call, simulate, or test Hermes handoff behavior. Intake builder tests may verify OpenClaw gate
+outcomes, but must **not** invoke Hermes real-write paths (no import of
+`HermesFoundUpBuilder.extract_foundup` / `build_foundup`; AST guard per Section 6).

--- a/modules/foundups/agent/INTERFACE.md
+++ b/modules/foundups/agent/INTERFACE.md
@@ -991,3 +991,21 @@ agent_ranked:   "founder_001 rank UP: 2→3 (Contributor)"
 agent_earned:   "founder_001 earned 50 F₁"
 agent_leaves:   "0xfound001... logs off (1250 F_i)"
 ```
+
+---
+
+## HermesFoundUpBuilder Environment Contract (HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1)
+
+`HermesFoundUpBuilder` (`src/hermes_adapter.py`) is **dry-run by default**. Real filesystem writes
+(e.g. `generate_adapters` adapter stubs) require an explicit **double opt-in**:
+
+| Env var | Default | Meaning |
+|---------|---------|---------|
+| `HERMES_BUILDER_ALLOW_REAL_WRITES` | `0` | Must be `1` to permit any real write |
+| `HERMES_BUILDER_DRY_RUN` | unset = dry-run | Must be explicitly `0` to permit any real write |
+
+`self.dry_run` is `False` **only** when `HERMES_BUILDER_ALLOW_REAL_WRITES=1` AND
+`HERMES_BUILDER_DRY_RUN=0`. Every other combination (including all-unset) is dry-run. `self.dry_run`
+is surfaced in `extract_foundup` / `build_foundup` / `generate_adapters` result dicts and written
+back to `FoundUpJob.policy_flags.dry_run_mode` by the executor. Callers that already force dry-run
+(`execute_foundup_job(..., force_dry_run=True)`, or `HERMES_BUILDER_DRY_RUN=1`) are unchanged.

--- a/modules/foundups/agent/ModLog.md
+++ b/modules/foundups/agent/ModLog.md
@@ -1,5 +1,45 @@
 # Agent Module ModLog
 
+## 2026-07-04 - Hermes builder dry-run by DEFAULT: double opt-in for real writes (HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1)
+
+**Author**: 0102 (RedDog Architect) | Commander: 012 | Gate: VERIFIED_READY draft PR (do NOT self-merge)
+**WSP References**: WSP 00, WSP 15, WSP 22, WSP 50, WSP 97
+**Base**: `ac1cc611a` (main)
+**Slice**: HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1
+
+### Why (OBSERVED safety finding)
+
+The RedDog FoundUp-creation execution-path audit found `HermesFoundUpBuilder.__init__` set
+`self.dry_run = os.environ.get("HERMES_BUILDER_DRY_RUN", "0") == "1"` -- dry_run defaulted to FALSE
+(real writes ON) when the env var was unset. This was the outlier: `BuildPlanExecutor` and
+`HermesJobExecutor` both default `dry_run=True`, and `build_plan_generator` always emits dry-run
+plans. The default-on adapter-level write (`generate_adapters` mkdir + write_text) was reachable via
+the extract/build path, gated only by an env flag plus the security sentinel.
+
+### Changed (safety tightening only; no gate weakened)
+
+- EDIT `src/hermes_adapter.py` (`HermesFoundUpBuilder.__init__`): dry-run is now the DEFAULT. Real
+  writes require an explicit DOUBLE opt-in -- BOTH `HERMES_BUILDER_ALLOW_REAL_WRITES=1` AND
+  `HERMES_BUILDER_DRY_RUN=0`. Any other combination (including all-unset) stays dry-run/safe. Added
+  `self.allow_real_writes` for observability. No change to the security sentinel, CABR, OpenClaw
+  genesis gate, or the WRE execution valve.
+- TEST `tests/test_hermes_foundup_builder.py::TestDryRunDefaultSafety` (A1/A2/A3/A5) and
+  `tests/test_hermes_foundup_job_executor.py::test_a4_executor_respects_builder_dry_run_default` (A4).
+  Full agent suite green: 1031 passed.
+- DOCS INTERFACE.md (env contract) + README.md (safety defaults).
+
+### HoloIndex (Addendum A)
+
+Pre-run recall surfaced `hermes_adapter.py` at #1 for "HERMES_BUILDER_DRY_RUN default". The four new
+audit docs committed at `ac1cc611a` are NOT yet discoverable (code index predates the commit):
+recorded as `HOLOINDEX_FOUNDUP_CREATION_AUDIT_DISCOVERABILITY_PHASE1`. Re-index is an explicit
+operator action, out of scope for this code slice.
+
+### Residual (SPECIFIED_NOT_IMPLEMENTED)
+
+- Hermes real delegation in `hermes_job_executor.py` remains BLOCKED (out of scope).
+- Re-index for the new audit docs pending (operator/worker action, not RedDog runtime).
+
 ## 2026-06-20 - Package __init__ lazy import: close the no-vendor boundary at the IMPORT boundary (FOUNDUP_AGENT_PACKAGE_INIT_LAZY_IMPORT_PHASE1)
 
 **Author**: 0102 (AUTHOR worker) | Commander: 012 | Gate: independent SENTINEL (do NOT self-merge)

--- a/modules/foundups/agent/README.md
+++ b/modules/foundups/agent/README.md
@@ -103,8 +103,15 @@ daemon.emit(
 - `modules/foundups/simulator/`: Mesa model agent simulation
 - `modules/ai_intelligence/0102_orchestrator/`: 0102 orchestration
 
+## Safety Defaults
+
+`HermesFoundUpBuilder` is **dry-run by default**. Real filesystem writes require BOTH
+`HERMES_BUILDER_ALLOW_REAL_WRITES=1` and `HERMES_BUILDER_DRY_RUN=0` (double opt-in). See
+[INTERFACE.md](INTERFACE.md) and
+`docs/audits/architecture/HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1.md`.
+
 ## Status
 
 - **Phase**: PoC
 - **Version**: 0.1.0
-- **Last Updated**: 2026-02-15
+- **Last Updated**: 2026-07-04

--- a/modules/foundups/agent/src/hermes_adapter.py
+++ b/modules/foundups/agent/src/hermes_adapter.py
@@ -131,7 +131,21 @@ class HermesFoundUpBuilder:
 
         # Environment controls
         self.enabled = os.environ.get("HERMES_BUILDER_ENABLED", "1") == "1"
-        self.dry_run = os.environ.get("HERMES_BUILDER_DRY_RUN", "0") == "1"
+        # HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1: dry-run by DEFAULT.
+        # Real writes require an explicit DOUBLE opt-in -- BOTH must be set:
+        #   HERMES_BUILDER_ALLOW_REAL_WRITES=1  AND  HERMES_BUILDER_DRY_RUN=0
+        # Any other combination (including all-unset) stays dry-run/safe. This
+        # aligns the adapter-level default with BuildPlanExecutor(dry_run=True)
+        # and HermesJobExecutor(dry_run=True), closing the OBSERVED default-on
+        # write risk found in the RedDog FoundUp-creation execution-path audit
+        # (docs/audits/architecture/HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1.md).
+        self.allow_real_writes = (
+            os.environ.get("HERMES_BUILDER_ALLOW_REAL_WRITES", "0") == "1"
+        )
+        self.dry_run = not (
+            self.allow_real_writes
+            and os.environ.get("HERMES_BUILDER_DRY_RUN", "1") == "0"
+        )
         self.require_security_gate = os.environ.get("HERMES_BUILDER_SECURITY_GATE", "1") == "1"
 
         # MCP Bridge perception layer (v1.4)

--- a/modules/foundups/agent/tests/test_hermes_foundup_builder.py
+++ b/modules/foundups/agent/tests/test_hermes_foundup_builder.py
@@ -433,3 +433,99 @@ class TestRealRepoReadOnly:
             "Kosei manifest declares entry_url and launch_readiness=ready; "
             "deploy surface should be recognized after Phase 1 detection fix."
         )
+
+
+# --------------------------------------------------------------------------- #
+# HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1 acceptance (A1-A3, A5)
+# --------------------------------------------------------------------------- #
+
+class TestDryRunDefaultSafety:
+    """Builder must default to dry-run; real writes need an explicit double opt-in.
+
+    Acceptance criteria per
+    docs/audits/architecture/HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1.md:
+      A1 fresh builder with no env -> dry_run is True
+      A2 default builder extract/generate_adapters emit dry_run: true, write nothing
+      A3 real-write path requires BOTH opt-in env vars; otherwise dry_run stays True
+      A5 no test enables real writes (DRY_RUN=0) without a real-write opt-in marker
+    """
+
+    def test_a1_default_is_dry_run_with_no_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("HERMES_BUILDER_DRY_RUN", raising=False)
+        monkeypatch.delenv("HERMES_BUILDER_ALLOW_REAL_WRITES", raising=False)
+        builder = HermesFoundUpBuilder(repo_root=tmp_path)
+        assert builder.dry_run is True
+        assert builder.allow_real_writes is False
+
+    def test_a2_default_builder_writes_nothing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("HERMES_BUILDER_DRY_RUN", raising=False)
+        monkeypatch.delenv("HERMES_BUILDER_ALLOW_REAL_WRITES", raising=False)
+        monkeypatch.setenv("HERMES_BUILDER_SECURITY_GATE", "0")
+        _make_module(
+            tmp_path,
+            "modules/foundups/widget",
+            manifest=_ready_manifest("widget"),
+            deploy_kind="firebase",
+        )
+        _write(
+            tmp_path / "modules/foundups/widget/src/uses_fam.py",
+            "from modules.foundups.agent_market import fam_daemon\n",
+        )
+        builder = HermesFoundUpBuilder(repo_root=tmp_path)
+        assert builder.dry_run is True
+
+        extract = builder.extract_foundup("modules/foundups/widget")
+        assert extract["dry_run"] is True
+
+        gen = builder.generate_adapters("modules/foundups/widget")
+        assert gen["dry_run"] is True
+        assert gen["adapters_created"] == []
+        # No adapter directory materialised on disk in the default (safe) path.
+        assert not (tmp_path / "modules/foundups/widget/adapters").exists()
+
+    def test_a3_dry_run_zero_alone_stays_safe(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # HERMES_BUILDER_DRY_RUN=0 WITHOUT the allow flag must NOT enable writes.
+        monkeypatch.setenv("HERMES_BUILDER_DRY_RUN", "0")
+        monkeypatch.delenv("HERMES_BUILDER_ALLOW_REAL_WRITES", raising=False)
+        assert HermesFoundUpBuilder(repo_root=tmp_path).dry_run is True
+
+    def test_a3_allow_flag_alone_stays_safe(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # allow flag alone (DRY_RUN not explicitly 0) must NOT enable writes.
+        monkeypatch.setenv("HERMES_BUILDER_ALLOW_REAL_WRITES", "1")
+        monkeypatch.delenv("HERMES_BUILDER_DRY_RUN", raising=False)
+        assert HermesFoundUpBuilder(repo_root=tmp_path).dry_run is True
+
+    def test_a3_double_opt_in_enables_real_writes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # BOTH flags -> dry_run False (explicit, deliberate real-write opt-in).
+        monkeypatch.setenv("HERMES_BUILDER_ALLOW_REAL_WRITES", "1")
+        monkeypatch.setenv("HERMES_BUILDER_DRY_RUN", "0")
+        builder = HermesFoundUpBuilder(repo_root=tmp_path)
+        assert builder.allow_real_writes is True
+        assert builder.dry_run is False
+
+    def test_a5_no_test_enables_real_writes_without_opt_in_marker(self) -> None:
+        """CI tripwire: a test file that forces HERMES_BUILDER_DRY_RUN=0 must also
+        carry the HERMES_BUILDER_ALLOW_REAL_WRITES marker (deliberate opt-in)."""
+        import re
+
+        tests_dir = Path(__file__).resolve().parent
+        pattern = re.compile(r"HERMES_BUILDER_DRY_RUN[\"'],\s*[\"']0[\"']")
+        offenders = []
+        for pyf in sorted(tests_dir.glob("*.py")):
+            text = pyf.read_text(encoding="utf-8")
+            if pattern.search(text) and "HERMES_BUILDER_ALLOW_REAL_WRITES" not in text:
+                offenders.append(pyf.name)
+        assert offenders == [], (
+            "test files set HERMES_BUILDER_DRY_RUN=0 without a real-write opt-in "
+            f"marker: {offenders}"
+        )

--- a/modules/foundups/agent/tests/test_hermes_foundup_job_executor.py
+++ b/modules/foundups/agent/tests/test_hermes_foundup_job_executor.py
@@ -130,6 +130,37 @@ def mock_hermes_security_failed() -> Dict[str, Any]:
     }
 
 
+# ---------------------------------------------------------------------------
+# HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1 acceptance A4
+# ---------------------------------------------------------------------------
+
+
+def test_a4_executor_respects_builder_dry_run_default(
+    queued_validate_job: FoundUpJob, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A4: execute_foundup_job(..., force_dry_run=False) with no env opt-in must
+    still run dry-run, because the builder now defaults to dry-run. The executor
+    must not silently enable real writes when the caller merely declines to force
+    dry-run.
+
+    Ref: docs/audits/architecture/HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1.md
+    """
+    monkeypatch.delenv("HERMES_BUILDER_DRY_RUN", raising=False)
+    monkeypatch.delenv("HERMES_BUILDER_ALLOW_REAL_WRITES", raising=False)
+    monkeypatch.setenv("HERMES_BUILDER_SECURITY_GATE", "0")
+
+    repo_root = Path(__file__).resolve().parents[4]
+    result = execute_foundup_job(
+        queued_validate_job, repo_root=repo_root, force_dry_run=False
+    )
+
+    # Builder default (dry-run) is reflected in the job's policy flags...
+    assert result.job.policy_flags.dry_run_mode is True
+    # ...and in the Hermes result payload when the action dispatched.
+    if result.hermes_result is not None:
+        assert result.hermes_result.get("dry_run") is True
+
+
 @pytest.fixture
 def mock_hermes_exfoliation_failed() -> Dict[str, Any]:
     """Mock Hermes result with exfoliation gate failure."""


### PR DESCRIPTION
## Slice: `HERMES_BUILDER_DRYRUN_DEFAULT_SAFETY_PHASE1` (P0)

**Base:** `ac1cc611a` (main) · **WSP:** 00, 15, 22, 50, 97 · Stop at VERIFIED_READY (do not self-merge)

### Problem (OBSERVED)
`HermesFoundUpBuilder.__init__` set `self.dry_run = os.environ.get("HERMES_BUILDER_DRY_RUN","0")=="1"` — dry_run defaulted **False** (real writes ON) when unset. Outlier vs `BuildPlanExecutor(dry_run=True)` and `HermesJobExecutor(dry_run=True)`. The default-on adapter write (`generate_adapters` mkdir + `write_text`) was reachable via extract/build, gated only by an env flag + security sentinel. Sharpest safety finding of the RedDog FoundUp-creation execution-path audit.

### Fix (tightening only)
Dry-run is now the **default**. Real writes require an explicit **double opt-in** — BOTH `HERMES_BUILDER_ALLOW_REAL_WRITES=1` AND `HERMES_BUILDER_DRY_RUN=0`. Any other combination (including all-unset) stays dry-run. No security sentinel / CABR / OpenClaw genesis gate / WRE valve behavior changed. Callers that already force dry-run are unchanged.

### Before / After
| Env | Before `dry_run` | After `dry_run` |
|-----|------|------|
| unset | **False (writes)** | **True (safe)** |
| `DRY_RUN=1` | True | True |
| `DRY_RUN=0` only | False (writes) | **True (safe)** |
| `ALLOW_REAL_WRITES=1` only | False (writes) | **True (safe)** |
| `ALLOW_REAL_WRITES=1` + `DRY_RUN=0` | False | False (deliberate) |

### Acceptance (OBSERVED)
| # | Criterion | Test | Result |
|---|-----------|------|--------|
| A1 | fresh builder, no env → dry_run True | `test_a1_default_is_dry_run_with_no_env` | PASS |
| A2 | default builder writes nothing; result `dry_run: true` | `test_a2_default_builder_writes_nothing` | PASS |
| A3 | single flag stays safe; double opt-in enables | `test_a3_*` (x3) | PASS |
| A4 | `execute_foundup_job(force_dry_run=False)` respects default | `test_a4_executor_respects_builder_dry_run_default` | PASS |
| A5 | no test sets `DRY_RUN=0` w/o opt-in marker | `test_a5_no_test_enables_real_writes_without_opt_in_marker` | PASS |
| A6 | full `modules/foundups/agent/tests/` green | pytest | **1031 passed** |

### HoloIndex (Addendum A)
Preflight ran 6 queries. `hermes_adapter.py` surfaces **#1** for "HERMES_BUILDER_DRY_RUN default"; `envelope.py` surfaces for the genesis queries. The four audit docs committed at `ac1cc611a` are **NOT** discoverable (code index predates the commit) → recorded **`HOLOINDEX_FOUNDUP_CREATION_AUDIT_DISCOVERABILITY_PHASE1`**. Re-index is an explicit operator action (out of scope here); no re-index performed, so post == pre.

### Residual (SPECIFIED_NOT_IMPLEMENTED)
- Hermes real delegation in `hermes_job_executor.py` remains BLOCKED (out of scope).
- Audit-doc re-index pending (operator/worker action, not RedDog runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
