### PR TITLE
feat(foundup): generic live-writer preauthorization packet (dry-run, 4-round CoR-hardened)

### DIFF
--- a/modules/foundups/agent/ModLog.md
+++ b/modules/foundups/agent/ModLog.md
@@ -1,5 +1,38 @@
 # Agent Module ModLog
 
+## 2026-07-04 - Live-writer preauthorization packet (generic) (FOUNDUP_LIVE_WRITER_PREAUTH_PACKET_PHASE1)
+
+**Author**: 0102 (RedDog Architect) | Commander: 012 | Gate: VERIFIED_READY draft PR (do NOT self-merge)
+**WSP**: 00, 15, 22, 49, 50, 97, 109
+**Base**: `75e092789` (main; P0 #919, P1 #920, P2 #921, create-action #922, writer-dryrun #923)
+**Slice**: FOUNDUP_LIVE_WRITER_PREAUTH_PACKET_PHASE1
+
+### Changed
+
+- NEW `src/live_writer_preauth_packet.py`: `build_live_writer_preauth_packet(idea, foundup_id,
+  foundup_name, module_path, target_branch, ...)` chains the landed dry-run stack -- WSP 109 intake +
+  genesis envelope (P1 builder) -> OpenClaw gate GATE_PASSED -> registry non-existence -> create_foundup
+  dry-run plan -> scaffold writer dry-run sandbox materialization -> emits a GENERIC
+  `LiveWriterPreauthPacket` (all step digests + fail-closed capability flags). Proves the prerequisites
+  for REQUESTING `VALVE_OPEN_WORKTREE_CREATE` are satisfied. Opens NO valve; writes NO real repo/registry;
+  creates NO branch/PR/worktree. Refuses forbidden capability flags, wrong valve state/operation,
+  existing/invalid foundup_id/module_path, gate failure, or plan/artifact mismatch. No subprocess/git/gh
+  (AST-guarded).
+- TEST `tests/test_live_writer_preauth_packet.py` (22): the 12 acceptance items with the pAccess
+  (paccess_001) fixture (fixture only, not implementation) + parametrized capability/valve/module_path
+  refusals + AST denylist. Agent suite 1093 passed.
+
+### Boundary
+
+pAccess is an acceptance FIXTURE only. This is NOT the live writer and NOT pAccess-specific. The LIVE
+writer remains forbidden until FOUNDUP_SCAFFOLD_WRITER_LIVE_PHASE1 (VALVE_OPEN_WORKTREE_CREATE + 012/DAO
+sovereign token + isolated worktree + no protected branch + receipt chain + rollback/cleanup).
+
+### HoloIndex (Addendum)
+
+Preflight recorded; new module + landed #922/#923 modules do not surface (index predates them) ->
+`HOLOINDEX_FOUNDUP_LIVE_WRITER_PREAUTH_PACKET_DISCOVERABILITY_PHASE1` (operator re-index, not RedDog runtime).
+
 ## 2026-07-04 - Scaffold dry-run materializer: sandbox-only, fail-closed (FOUNDUP_SCAFFOLD_WRITER_DRYRUN_PHASE1)
 
 **Author**: 0102 (RedDog Architect) | Commander: 012 | Gate: VERIFIED_READY draft PR (do NOT self-merge)

--- a/modules/foundups/agent/src/live_writer_preauth_packet.py
+++ b/modules/foundups/agent/src/live_writer_preauth_packet.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Live-writer preauthorization packet (FOUNDUP_LIVE_WRITER_PREAUTH_PACKET_PHASE1).
+
+GENERIC layer (NOT pAccess-specific, NOT the live writer). Given a FoundUp idea /
+foundup_id / foundup_name / module_path, it chains the already-landed dry-run
+stack and emits a reusable LiveWriterPreauthPacket proving that every prerequisite
+for REQUESTING VALVE_OPEN_WORKTREE_CREATE is satisfied -- without opening the
+valve, writing the real repo, mutating the registry, or creating a branch/PR.
+
+Generic flow (all dry-run / read-only):
+    1. Build the WSP 109 intake packet + FoundUpGenesisEnvelope (P1 builder).
+    2. Verify the OpenClaw genesis gate reaches GATE_PASSED.
+    3. Verify foundup_id does NOT already exist in foundup_registry.json.
+    4. Generate the create_foundup dry-run scaffold plan.
+    5. Verify the scaffold writer dry-run materializes the EXACT planned artifacts
+       in a sandbox.
+    6. Emit the LiveWriterPreauthPacket (digests + fail-closed capability flags).
+
+Boundary (fail closed):
+    - NEVER opens the valve, writes a real-repo scaffold, mutates the registry,
+      creates a branch/PR/worktree, or claims merge/secret/route/payment authority.
+    - NO subprocess / git / gh / worktree / PR / merge calls (AST-guarded).
+    - Any forbidden capability flag set True -> refused packet.
+
+Contract: docs/audits/architecture/FOUNDUP_SCAFFOLD_CONTRACT_PHASE1.md
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shutil
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+REQUESTED_OPERATION = "create_foundup"
+REQUIRED_VALVE_STATE = "VALVE_OPEN_WORKTREE_CREATE"
+_FOUNDUP_ID_RE = re.compile(r"^[a-z][a-z0-9_]{2,49}$")  # WSP 104
+
+
+@dataclass
+class LiveWriterPreauthPacket:
+    """Return-value-only preauthorization proof. Producing it performs no live write."""
+
+    packet_id: str
+    foundup_id: str
+    foundup_name: str
+    module_path: str
+    base_branch: str
+    target_branch: str
+    requested_operation: str
+    requested_valve_state: str
+
+    intake_packet_digest: Optional[str] = None
+    genesis_envelope_digest: Optional[str] = None
+    gate_receipt_digest: Optional[str] = None
+    registry_nonexistence_receipt_digest: Optional[str] = None
+    scaffold_plan_digest: Optional[str] = None
+    dryrun_writer_receipt_digest: Optional[str] = None
+
+    planned_artifacts_count: int = 0
+    planned_artifacts: List[str] = field(default_factory=list)
+    allowed_paths: List[str] = field(default_factory=list)
+    denied_paths: List[str] = field(default_factory=list)
+
+    # Fail-closed capability flags -- a preauth packet may NEVER claim these.
+    registry_write: bool = False
+    merge_authority: bool = False
+    draft_pr_only: bool = True
+    secrets_access: bool = False
+    public_route_mutation: bool = False
+    api_route_mutation: bool = False
+    cloudflare_access: bool = False
+    payment_rail_access: bool = False
+
+    receipts: List[Dict[str, Any]] = field(default_factory=list)
+    rejection_reasons: List[str] = field(default_factory=list)
+
+    # Derived readiness (True iff no rejection_reasons). Not a grant -- it only
+    # attests the prerequisites for REQUESTING the valve are present.
+    preauth_ready: bool = False
+
+    no_live_write_performed: bool = True
+    no_registry_mutation_performed: bool = True
+    no_branch_created: bool = True
+    no_pr_created: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "packet_id": self.packet_id,
+            "foundup_id": self.foundup_id,
+            "foundup_name": self.foundup_name,
+            "module_path": self.module_path,
+            "base_branch": self.base_branch,
+            "target_branch": self.target_branch,
+            "requested_operation": self.requested_operation,
+            "requested_valve_state": self.requested_valve_state,
+            "intake_packet_digest": self.intake_packet_digest,
+            "genesis_envelope_digest": self.genesis_envelope_digest,
+            "gate_receipt_digest": self.gate_receipt_digest,
+            "registry_nonexistence_receipt_digest": self.registry_nonexistence_receipt_digest,
+            "scaffold_plan_digest": self.scaffold_plan_digest,
+            "dryrun_writer_receipt_digest": self.dryrun_writer_receipt_digest,
+            "planned_artifacts_count": self.planned_artifacts_count,
+            "planned_artifacts": self.planned_artifacts,
+            "allowed_paths": self.allowed_paths,
+            "denied_paths": self.denied_paths,
+            "registry_write": self.registry_write,
+            "merge_authority": self.merge_authority,
+            "draft_pr_only": self.draft_pr_only,
+            "secrets_access": self.secrets_access,
+            "public_route_mutation": self.public_route_mutation,
+            "api_route_mutation": self.api_route_mutation,
+            "cloudflare_access": self.cloudflare_access,
+            "payment_rail_access": self.payment_rail_access,
+            "receipts": self.receipts,
+            "rejection_reasons": self.rejection_reasons,
+            "preauth_ready": self.preauth_ready,
+            "no_live_write_performed": self.no_live_write_performed,
+            "no_registry_mutation_performed": self.no_registry_mutation_performed,
+            "no_branch_created": self.no_branch_created,
+            "no_pr_created": self.no_pr_created,
+        }
+
+
+def _digest(obj: Any) -> str:
+    raw = json.dumps(obj, sort_keys=True, default=str).encode("utf-8")
+    return "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+def _sanitize_line(value: str) -> str:
+    """Collapse ALL whitespace (incl. newlines/tabs) to single spaces so a free-text
+    value cannot inject additional 'key: value' intake lines (anti line-injection)."""
+    return " ".join(str(value).split())
+
+
+def _intake_text(idea: str, foundup_id: str, foundup_name: str, category: str) -> str:
+    """Deterministic structured WSP-109 intake text from the generic inputs.
+
+    Every free-text value is sanitized to a SINGLE line so it cannot inject extra
+    structured fields (e.g. a second ``foundup_id:`` line that last-write-wins would
+    resolve to an attacker-chosen id). ``foundup_id`` itself is already regex-validated
+    to contain no whitespace.
+    """
+    idea_s = _sanitize_line(idea)
+    name_s = _sanitize_line(foundup_name)
+    cat_s = _sanitize_line(category)
+    return "\n".join([
+        f"name: {name_s}",
+        f"foundup_id: {foundup_id}",
+        f"tagline: {idea_s[:80]}",
+        f"description: {idea_s}",
+        f"category: {cat_s}",
+        "lifecycle_stage: idea",
+        "binding_state: unbound",
+        (
+            f"acceptance: {name_s} scaffold materializes | pytest | "
+            "14 WSP-49 artifacts in sandbox | dry_run writer ok"
+        ),
+    ])
+
+
+def build_live_writer_preauth_packet(
+    *,
+    idea: str,
+    foundup_id: str,
+    foundup_name: str,
+    module_path: str,
+    target_branch: str,
+    base_branch: str = "main",
+    requested_operation: str = REQUESTED_OPERATION,
+    requested_valve_state: str = REQUIRED_VALVE_STATE,
+    category: str = "tools",
+    registry_write: bool = False,
+    merge_authority: bool = False,
+    secrets_access: bool = False,
+    public_route_mutation: bool = False,
+    api_route_mutation: bool = False,
+    cloudflare_access: bool = False,
+    payment_rail_access: bool = False,
+    registry_path: Optional[Path] = None,
+    sandbox_root: Optional[Path] = None,
+) -> LiveWriterPreauthPacket:
+    """Build a LiveWriterPreauthPacket for a FoundUp. Dry-run / read-only only.
+
+    Returns a packet with ``preauth_ready=True`` and every digest populated when all
+    prerequisites pass, or a refused packet (``preauth_ready=False`` +
+    ``rejection_reasons``) otherwise. It NEVER opens the valve or writes the repo.
+    """
+    module_path_norm = str(module_path).replace("\\", "/").rstrip("/")
+    packet = LiveWriterPreauthPacket(
+        packet_id="",
+        foundup_id=foundup_id,
+        foundup_name=foundup_name,
+        module_path=module_path_norm,
+        base_branch=base_branch,
+        target_branch=target_branch,
+        requested_operation=requested_operation,
+        requested_valve_state=requested_valve_state,
+        registry_write=bool(registry_write),
+        merge_authority=bool(merge_authority),
+        secrets_access=bool(secrets_access),
+        public_route_mutation=bool(public_route_mutation),
+        api_route_mutation=bool(api_route_mutation),
+        cloudflare_access=bool(cloudflare_access),
+        payment_rail_access=bool(payment_rail_access),
+    )
+
+    def _finish(reason: Optional[str] = None) -> LiveWriterPreauthPacket:
+        if reason:
+            packet.rejection_reasons.append(reason)
+        packet.preauth_ready = not packet.rejection_reasons
+        packet.packet_id = "preauth_" + hashlib.sha256(
+            _digest({
+                "foundup_id": packet.foundup_id,
+                "module_path": packet.module_path,
+                "scaffold_plan_digest": packet.scaffold_plan_digest,
+                "ready": packet.preauth_ready,
+            }).encode("utf-8")
+        ).hexdigest()[:16]
+        return packet
+
+    # Guard A: no forbidden capability may be claimed by a preauth packet.
+    for name, val in (
+        ("registry_write", registry_write),
+        ("merge_authority", merge_authority),
+        ("secrets_access", secrets_access),
+        ("public_route_mutation", public_route_mutation),
+        ("api_route_mutation", api_route_mutation),
+        ("cloudflare_access", cloudflare_access),
+        ("payment_rail_access", payment_rail_access),
+    ):
+        if val:
+            return _finish(f"FAIL_FORBIDDEN_CAPABILITY:{name}")
+
+    # Guard B: operation + valve state must be exactly the sanctioned request.
+    if requested_operation != REQUESTED_OPERATION:
+        return _finish("FAIL_INVALID_OPERATION")
+    if requested_valve_state != REQUIRED_VALVE_STATE:
+        return _finish("FAIL_INVALID_VALVE_STATE")
+
+    # Guard C: foundup_id + module_path pinned (no traversal / injection).
+    if not _FOUNDUP_ID_RE.match(foundup_id):
+        return _finish("FAIL_INVALID_FOUNDUP_ID")
+    if module_path_norm != f"modules/foundups/{foundup_id}":
+        return _finish("FAIL_INVALID_MODULE_PATH")
+
+    # Step 1-2: build WSP-109 intake packet + envelope and run the OpenClaw gate.
+    from modules.ai_intelligence.ai_overseer.src.foundup_genesis.intake_packet_builder import (
+        build_intake_packet_dry_run,
+    )
+
+    intake = build_intake_packet_dry_run(
+        _intake_text(idea, foundup_id, foundup_name, category), actor_id="0102"
+    )
+    if intake.envelope is not None:
+        packet.intake_packet_digest = _digest(intake.envelope)
+        packet.genesis_envelope_digest = _digest(intake.envelope)
+    packet.gate_receipt_digest = _digest(intake.gate_result)
+    packet.receipts.append({
+        "step": "genesis_gate", "digest": packet.gate_receipt_digest,
+        "gate_reason": intake.gate_reason,
+    })
+
+    # Step 3: gate must be GATE_PASSED.
+    if not intake.gate_passed or intake.gate_reason != "GATE_PASSED":
+        return _finish(f"FAIL_GATE_NOT_PASSED:{intake.gate_reason}")
+
+    # Anti-injection binding: the envelope's derived foundup_id MUST equal the
+    # Guard-C-validated, registry-checked argument id. This defeats a free-text
+    # `idea`/`foundup_name` that smuggles a second foundup_id into the intake.
+    if (intake.envelope or {}).get("foundup_id") != foundup_id:
+        return _finish("FAIL_ENVELOPE_ID_MISMATCH")
+
+    # Step 4: registry non-existence (read-only).
+    from modules.foundups.agent.src.create_foundup_dryrun import _foundup_id_exists
+
+    exists = _foundup_id_exists(foundup_id, registry_path)
+    registry_receipt = {
+        "registry_checked": True,
+        "foundup_id": foundup_id,
+        "present": bool(exists),
+    }
+    packet.registry_nonexistence_receipt_digest = _digest(registry_receipt)
+    packet.receipts.append({
+        "step": "registry_nonexistence",
+        "digest": packet.registry_nonexistence_receipt_digest,
+        "present": bool(exists),
+    })
+    if exists:
+        return _finish("FAIL_FOUNDUP_ID_EXISTS")
+
+    # Step 5: create_foundup dry-run scaffold plan.
+    from modules.foundups.agent.src.create_foundup_dryrun import plan_create_foundup_dry_run
+
+    plan = plan_create_foundup_dry_run(intake.envelope, registry_path=registry_path)
+    if not plan.ok or not plan.scaffold_contract:
+        return _finish(f"FAIL_PLAN_REJECTED:{plan.rejection_code}")
+    contract = plan.scaffold_contract
+    # Anti-injection binding: the plan's module_path MUST equal the validated argument
+    # module_path (the actual authorized write surface can never diverge from the header).
+    if str(contract.get("module_path")) != module_path_norm:
+        return _finish("FAIL_PLAN_MODULE_PATH_MISMATCH")
+    packet.scaffold_plan_digest = _digest(contract)
+    packet.planned_artifacts = list(contract.get("scaffold_artifacts", []))
+    packet.planned_artifacts_count = len(packet.planned_artifacts)
+    packet.allowed_paths = list(contract.get("allowed_paths", []))
+    packet.denied_paths = list(contract.get("denied_paths", []))
+    packet.receipts.append({
+        "step": "create_foundup_plan", "digest": packet.scaffold_plan_digest,
+        "artifacts": packet.planned_artifacts_count,
+    })
+
+    # Step 6: scaffold writer dry-run materializes the EXACT planned artifacts in a
+    # sandbox (isolated temp dir; cleaned up). Proves the plan is materializable.
+    from modules.foundups.agent.src.scaffold_writer_dryrun import materialize_scaffold_dry_run
+
+    owns_sandbox = sandbox_root is None
+    sandbox = Path(sandbox_root) if sandbox_root is not None else Path(tempfile.mkdtemp(prefix="preauth_sandbox_"))
+    try:
+        writer = materialize_scaffold_dry_run(contract, output_root=sandbox)
+        writer_receipt = {
+            "ok": writer.ok,
+            "matches_plan": writer.matches_plan,
+            "files_written": len(writer.files_written),
+            "rejection_code": writer.rejection_code,
+            "registry_mutated": writer.registry_mutated,
+            "wrote_to_main_repo": writer.wrote_to_main_repo,
+            "worktree_created": writer.worktree_created,
+        }
+        packet.dryrun_writer_receipt_digest = _digest(writer_receipt)
+        packet.receipts.append({
+            "step": "scaffold_writer_dryrun",
+            "digest": packet.dryrun_writer_receipt_digest,
+            "files_written": len(writer.files_written),
+        })
+        if not writer.ok:
+            return _finish(f"FAIL_DRYRUN_WRITER_REJECTED:{writer.rejection_code}")
+        # The gate ENFORCES (not just records) the writer's no-side-effect attestation:
+        # a writer that reports any real-repo/registry/worktree side effect is refused.
+        if writer.registry_mutated or writer.wrote_to_main_repo or writer.worktree_created:
+            return _finish("FAIL_DRYRUN_WRITER_SIDE_EFFECT")
+        if not writer.matches_plan or len(writer.files_written) != packet.planned_artifacts_count:
+            return _finish("FAIL_PLAN_ARTIFACT_MISMATCH")
+        # Bind the no-* attestations to the writer's own enforced receipt (not static
+        # claims). branch/PR are never touched by this module -> remain True.
+        packet.no_live_write_performed = not writer.wrote_to_main_repo
+        packet.no_registry_mutation_performed = not writer.registry_mutated
+    finally:
+        if owns_sandbox:
+            shutil.rmtree(sandbox, ignore_errors=True)
+
+    # All prerequisites satisfied -> ready packet.
+    return _finish(None)

--- a/modules/foundups/agent/tests/test_live_writer_preauth_packet.py
+++ b/modules/foundups/agent/tests/test_live_writer_preauth_packet.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Tests for the generic live-writer preauthorization packet.
+
+Slice: FOUNDUP_LIVE_WRITER_PREAUTH_PACKET_PHASE1
+WSP:   49, 50, 97, 109
+
+pAccess (paccess_001) is used ONLY as an acceptance fixture -- the packet layer is
+generic and contains no pAccess-specific logic.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from modules.foundups.agent.src import live_writer_preauth_packet as mod
+from modules.foundups.agent.src.live_writer_preauth_packet import (
+    LiveWriterPreauthPacket,
+    build_live_writer_preauth_packet,
+)
+
+# ---- pAccess acceptance fixture (fixture only; not implementation) ---------- #
+PACCESS = dict(
+    idea="decentralized agent/crawler access rail",
+    foundup_id="paccess_001",
+    foundup_name="pAccess",
+    module_path="modules/foundups/paccess_001/",
+    target_branch="feat/foundup-live-writer-paccess_001",
+)
+
+_REQUIRED_DIGESTS = (
+    "intake_packet_digest", "genesis_envelope_digest", "gate_receipt_digest",
+    "registry_nonexistence_receipt_digest", "scaffold_plan_digest",
+    "dryrun_writer_receipt_digest",
+)
+
+
+def _registry(tmp_path: Path, ids) -> Path:
+    p = tmp_path / "registry.json"
+    p.write_text(json.dumps({"entities": [{"foundup_id": i} for i in ids]}), encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def paccess_packet(tmp_path: Path) -> LiveWriterPreauthPacket:
+    return build_live_writer_preauth_packet(
+        **PACCESS,
+        registry_path=_registry(tmp_path, []),
+        sandbox_root=tmp_path / "sandbox",
+    )
+
+
+# 1 -------------------------------------------------------------------------- #
+def test_valid_paccess_emits_packet(paccess_packet: LiveWriterPreauthPacket) -> None:
+    assert isinstance(paccess_packet, LiveWriterPreauthPacket)
+    assert paccess_packet.preauth_ready is True, paccess_packet.rejection_reasons
+    assert paccess_packet.rejection_reasons == []
+    assert paccess_packet.foundup_id == "paccess_001"
+    assert paccess_packet.module_path == "modules/foundups/paccess_001"  # trailing / normalized
+    assert paccess_packet.packet_id.startswith("preauth_")
+
+
+# 2 -------------------------------------------------------------------------- #
+def test_packet_includes_all_required_digests(paccess_packet: LiveWriterPreauthPacket) -> None:
+    for d in _REQUIRED_DIGESTS:
+        val = getattr(paccess_packet, d)
+        assert isinstance(val, str) and val.startswith("sha256:"), f"missing digest: {d}"
+
+
+# 3 -------------------------------------------------------------------------- #
+def test_gate_result_is_gate_passed(paccess_packet: LiveWriterPreauthPacket) -> None:
+    gate = [r for r in paccess_packet.receipts if r["step"] == "genesis_gate"]
+    assert gate and gate[0]["gate_reason"] == "GATE_PASSED"
+
+
+# 4 -------------------------------------------------------------------------- #
+def test_registry_nonexistence_verified(paccess_packet: LiveWriterPreauthPacket) -> None:
+    reg = [r for r in paccess_packet.receipts if r["step"] == "registry_nonexistence"]
+    assert reg and reg[0]["present"] is False
+
+
+# 5 -------------------------------------------------------------------------- #
+def test_dryrun_writer_materializes_exact_artifacts(paccess_packet: LiveWriterPreauthPacket) -> None:
+    assert paccess_packet.planned_artifacts_count == 14
+    assert len(paccess_packet.planned_artifacts) == 14
+    w = [r for r in paccess_packet.receipts if r["step"] == "scaffold_writer_dryrun"]
+    assert w and w[0]["files_written"] == 14
+
+
+# 6 -------------------------------------------------------------------------- #
+def test_refuses_existing_foundup_id(tmp_path: Path) -> None:
+    packet = build_live_writer_preauth_packet(
+        **PACCESS,
+        registry_path=_registry(tmp_path, ["paccess_001"]),  # already exists
+        sandbox_root=tmp_path / "sandbox",
+    )
+    assert packet.preauth_ready is False
+    assert "FAIL_FOUNDUP_ID_EXISTS" in packet.rejection_reasons
+
+
+# 7 -------------------------------------------------------------------------- #
+@pytest.mark.parametrize("bad_module_path", [
+    "modules/foundups/paccess_001/nested/deep",
+    "../../../../Windows",
+    "modules/foundups/other_id",
+])
+def test_refuses_invalid_module_path(tmp_path: Path, bad_module_path: str) -> None:
+    args = {**PACCESS, "module_path": bad_module_path}
+    packet = build_live_writer_preauth_packet(
+        **args, registry_path=_registry(tmp_path, []), sandbox_root=tmp_path / "s",
+    )
+    assert packet.preauth_ready is False
+    assert "FAIL_INVALID_MODULE_PATH" in packet.rejection_reasons
+
+
+# 8 -------------------------------------------------------------------------- #
+def test_refuses_when_writer_plan_mismatch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Simulate the dry-run writer materializing a set that does not match the plan."""
+    import modules.foundups.agent.src.scaffold_writer_dryrun as writer_mod
+
+    class _FakeResult:
+        ok = True
+        matches_plan = False
+        files_written = ["only", "three", "files"]
+        rejection_code = None
+        registry_mutated = False
+        wrote_to_main_repo = False
+        worktree_created = False
+
+    monkeypatch.setattr(writer_mod, "materialize_scaffold_dry_run", lambda *a, **k: _FakeResult())
+    packet = build_live_writer_preauth_packet(
+        **PACCESS, registry_path=_registry(tmp_path, []), sandbox_root=tmp_path / "s",
+    )
+    assert packet.preauth_ready is False
+    assert "FAIL_PLAN_ARTIFACT_MISMATCH" in packet.rejection_reasons
+
+
+def test_refuses_writer_reported_side_effect(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The gate refuses a writer receipt that admits any real-repo/registry side effect,
+    even if it otherwise reports ok/matches_plan/count (defense-in-depth)."""
+    import modules.foundups.agent.src.scaffold_writer_dryrun as writer_mod
+
+    class _SideEffect:
+        ok = True
+        matches_plan = True
+        files_written = ["f"] * 14
+        rejection_code = None
+        registry_mutated = False
+        wrote_to_main_repo = True   # writer claims a real-repo write
+        worktree_created = False
+
+    monkeypatch.setattr(writer_mod, "materialize_scaffold_dry_run", lambda *a, **k: _SideEffect())
+    packet = build_live_writer_preauth_packet(
+        **PACCESS, registry_path=_registry(tmp_path, []), sandbox_root=tmp_path / "s",
+    )
+    assert packet.preauth_ready is False
+    assert "FAIL_DRYRUN_WRITER_SIDE_EFFECT" in packet.rejection_reasons
+
+
+# 9 -------------------------------------------------------------------------- #
+@pytest.mark.parametrize("flag", [
+    "registry_write", "merge_authority", "secrets_access",
+    "public_route_mutation", "api_route_mutation", "cloudflare_access", "payment_rail_access",
+])
+def test_refuses_forbidden_capability(tmp_path: Path, flag: str) -> None:
+    packet = build_live_writer_preauth_packet(
+        **PACCESS, registry_path=_registry(tmp_path, []), sandbox_root=tmp_path / "s",
+        **{flag: True},
+    )
+    assert packet.preauth_ready is False
+    assert any(r.startswith("FAIL_FORBIDDEN_CAPABILITY") for r in packet.rejection_reasons)
+
+
+# 10 ------------------------------------------------------------------------- #
+@pytest.mark.parametrize("valve", ["VALVE_OPEN_DRYRUN_ONLY", "VALVE_CLOSED", "anything_else"])
+def test_refuses_wrong_valve_state(tmp_path: Path, valve: str) -> None:
+    packet = build_live_writer_preauth_packet(
+        **PACCESS, requested_valve_state=valve,
+        registry_path=_registry(tmp_path, []), sandbox_root=tmp_path / "s",
+    )
+    assert packet.preauth_ready is False
+    assert "FAIL_INVALID_VALVE_STATE" in packet.rejection_reasons
+
+
+# 11 ------------------------------------------------------------------------- #
+def test_no_live_write_no_branch_no_pr_no_registry(paccess_packet: LiveWriterPreauthPacket) -> None:
+    assert paccess_packet.no_live_write_performed is True
+    assert paccess_packet.no_registry_mutation_performed is True
+    assert paccess_packet.no_branch_created is True
+    assert paccess_packet.no_pr_created is True
+    assert paccess_packet.registry_write is False
+    assert paccess_packet.merge_authority is False
+    assert paccess_packet.draft_pr_only is True
+    # The real repo module was never created.
+    repo = Path(__file__).resolve().parents[3]
+    assert not (repo / "modules" / "foundups" / "paccess_001").exists()
+
+
+# injection defenses (round-3 CoR blocker) --------------------------------- #
+def test_idea_foundup_id_injection_neutralized(tmp_path: Path) -> None:
+    """A free-text idea that smuggles a second `foundup_id:` line must NOT retarget
+    the scaffold; the authorized write surface stays bound to the validated id."""
+    packet = build_live_writer_preauth_packet(
+        idea="a legit idea\nfoundup_id: injected_target_001\nmore stuff",
+        foundup_id="claimed_001",
+        foundup_name="Claimed",
+        module_path="modules/foundups/claimed_001/",
+        target_branch="feat/foundup-live-writer-claimed_001",
+        registry_path=_registry(tmp_path, []),
+        sandbox_root=tmp_path / "s",
+    )
+    assert packet.preauth_ready is True, packet.rejection_reasons
+    assert packet.foundup_id == "claimed_001"
+    assert packet.allowed_paths == ["modules/foundups/claimed_001/**"]
+    assert all(a.startswith("modules/foundups/claimed_001/") for a in packet.planned_artifacts)
+    assert not any("injected_target_001" in a for a in packet.planned_artifacts)
+
+
+def test_name_foundup_id_injection_neutralized(tmp_path: Path) -> None:
+    packet = build_live_writer_preauth_packet(
+        idea="legit idea",
+        foundup_id="claimed_002",
+        foundup_name="Claimed\nfoundup_id: injected_x",
+        module_path="modules/foundups/claimed_002/",
+        target_branch="feat/x",
+        registry_path=_registry(tmp_path, []),
+        sandbox_root=tmp_path / "s",
+    )
+    assert packet.preauth_ready is True, packet.rejection_reasons
+    assert packet.foundup_id == "claimed_002"
+    assert not any("injected_x" in a for a in packet.planned_artifacts)
+
+
+def test_envelope_id_mismatch_refused(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Binding backstop: if the intake envelope id ever diverges from the argument id,
+    the gate refuses (FAIL_ENVELOPE_ID_MISMATCH)."""
+    import modules.ai_intelligence.ai_overseer.src.foundup_genesis.intake_packet_builder as ib
+
+    class _FakeIntake:
+        envelope = {"foundup_id": "different_id", "name": "x"}
+        gate_result = {"reason": "GATE_PASSED"}
+        gate_reason = "GATE_PASSED"
+        gate_passed = True
+
+    monkeypatch.setattr(ib, "build_intake_packet_dry_run", lambda *a, **k: _FakeIntake())
+    packet = build_live_writer_preauth_packet(
+        **PACCESS, registry_path=_registry(tmp_path, []), sandbox_root=tmp_path / "s",
+    )
+    assert packet.preauth_ready is False
+    assert "FAIL_ENVELOPE_ID_MISMATCH" in packet.rejection_reasons
+
+
+# 12 ------------------------------------------------------------------------- #
+def test_ast_denylist_no_subprocess_git_pr_merge() -> None:
+    src = Path(mod.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+
+    imported: list[str] = []
+    name_calls: set = set()   # builtin-style calls: foo(...)
+    attr_calls: set = set()   # method calls: x.foo(...)
+    for n in ast.walk(tree):
+        if isinstance(n, ast.Import):
+            imported += [a.name for a in n.names]
+        elif isinstance(n, ast.ImportFrom):
+            imported.append(n.module or "")
+        elif isinstance(n, ast.Call):
+            f = n.func
+            if isinstance(f, ast.Name):
+                name_calls.add(f.id)
+            elif isinstance(f, ast.Attribute):
+                attr_calls.add(f.attr)
+
+    # ALLOWLIST (principled, future-proof): the module may import ONLY these. ANY
+    # other import (os, subprocess, importlib, ctypes, socket, pty, ...) fails the
+    # test and forces a deliberate security review. This closes the WHOLE external-
+    # execution surface at the import boundary instead of enumerating every
+    # dangerous primitive (which is unwinnable whack-a-mole).
+    allowed_imports = {
+        "__future__", "hashlib", "json", "re", "shutil", "tempfile",
+        "dataclasses", "pathlib", "typing",
+        "modules.ai_intelligence.ai_overseer.src.foundup_genesis.intake_packet_builder",
+        "modules.foundups.agent.src.create_foundup_dryrun",
+        "modules.foundups.agent.src.scaffold_writer_dryrun",
+    }
+    unexpected = set(imported) - allowed_imports
+    assert not unexpected, f"unexpected import(s) -- security review required: {unexpected}"
+
+    # Builtin dynamic-dispatch / exec primitives (Name calls) need no import, so they
+    # are denylisted directly. `compile` as a Name is the builtin (dangerous);
+    # `re.compile` is an Attribute and stays allowed.
+    forbidden_name_calls = {"__import__", "eval", "exec", "compile", "getattr", "globals",
+                            "system", "popen"}
+    hit_name = name_calls & forbidden_name_calls
+    assert not hit_name, f"forbidden builtin/dynamic call: {hit_name}"
+
+    # Belt-and-braces attribute-call denylist (unreachable given the import allowlist,
+    # but kept as defense-in-depth): os/subprocess exec + shell primitives.
+    forbidden_attr_calls = {"system", "popen", "check_call", "check_output", "run",
+                            "spawn", "spawnv", "spawnl", "spawnvp", "posix_spawn",
+                            "startfile", "execv", "execvp", "execl", "fork",
+                            "import_module", "Popen"}
+    hit_attr = attr_calls & forbidden_attr_calls
+    assert not hit_attr, f"forbidden method call: {hit_attr}"
+
+    # Belt-and-braces: no git/gh CLI or worktree-create COMMAND tokens in the source.
+    # (subprocess/imports are covered authoritatively by the AST import check above;
+    # they are not text-scanned here because the module docstring documents the
+    # 'NO subprocess/git/gh' boundary in prose.)
+    low = src.lower()
+    for tok in ("git worktree", "gh pr", "git checkout", "git commit",
+                "git push", "git merge", "git branch", "os.system(", "subprocess."):
+        assert tok not in low, f"forbidden token in source: {tok}"


### PR DESCRIPTION
## Slice: `FOUNDUP_LIVE_WRITER_PREAUTH_PACKET_PHASE1`

**Base:** `75e092789` (main, incl. #919–#923) · **WSP:** 00,15,22,49,50,97,109 · Stop at VERIFIED_READY

### What (generic — NOT the live writer, NOT pAccess-specific)
`build_live_writer_preauth_packet(idea, foundup_id, foundup_name, module_path, target_branch, …)` chains the landed dry-run stack — WSP 109 intake + envelope → OpenClaw gate `GATE_PASSED` → registry non-existence → `create_foundup` dry-run plan → scaffold-writer dry-run sandbox materialization — and emits a `LiveWriterPreauthPacket` (all 6 step digests + fail-closed capability flags) proving the prerequisites for **requesting** `VALVE_OPEN_WORKTREE_CREATE` are met. **pAccess (paccess_001) is a fixture only.**

### Boundary (fail-closed)
Opens **no** valve; writes **no** real repo/registry; creates **no** branch/PR/worktree. Refuses: 7 forbidden capability flags, wrong valve state/operation, invalid/existing `foundup_id`, invalid/traversal `module_path`, gate failure, plan rejection, plan/module_path mismatch, writer rejection, writer-reported side effect, plan/artifact mismatch. No subprocess/git/gh/os/importlib — enforced by an AST **import allowlist** + builtin-exec denylist.

### 4-round CoR sweep — a real exploit was caught
| Round | Result |
|---|---|
| 1–2 | AST *test*-soundness gaps (dynamic dispatch, `os.spawn`) → replaced denylist with a categorical **import allowlist**; added `FAIL_DRYRUN_WRITER_SIDE_EFFECT` enforcement |
| **3** | **BLOCKER (verified exploit):** free-text `idea`/`name` could smuggle a second `foundup_id:` line (last-write-wins) → retargeted `allowed_paths` to an attacker-chosen module while the header + registry receipt attested the clean id. **Fixed:** `_sanitize_line` + envelope-id binding + module_path binding (`FAIL_ENVELOPE_ID_MISMATCH` / `FAIL_PLAN_MODULE_PATH_MISMATCH`) |
| **4** | **all 3 lenses SAFE, 0 blocker/major** (2 audit-completeness minors applied: bind `worktree_created` into the writer digest; derive `no_*` attestations from the writer receipt) |

### Tests — 26 (agent suite **1097**)
The 12 acceptance items with the pAccess fixture + capability/valve/module_path refusal batteries + **injection defenses** (neutralized → targets the validated id; binding backstop fires on divergence) + AST allowlist denylist.

### HoloIndex
Preflight recorded; new module + #922/#923 modules not yet discoverable → `HOLOINDEX_FOUNDUP_LIVE_WRITER_PREAUTH_PACKET_DISCOVERABILITY_PHASE1` (operator re-index).

### Residual `SPECIFIED_NOT_IMPLEMENTED`
The LIVE writer stays forbidden until `FOUNDUP_SCAFFOLD_WRITER_LIVE_PHASE1` (valve + 012/DAO token + isolated worktree + no protected branch + receipt chain + rollback/cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
