### PR TITLE
feat(reddog): work-order signature verifier E1 (VERIFIED_READY, draft)

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,17 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-05: REDDOG_WORK_ORDER_SIGNATURE_VERIFIER_PHASE1 (E1 -- first implementation)
+
+**Author**: 0102 (RedDog Architect, Lane A Identity/Delegation/Signing) | Commander: 012 | Gate: VERIFIED_READY draft PR (do NOT self-merge)
+**WSP**: 00, 15, 22, 50, 54, 71, 96, 97 | **Base**: `1a2412c0d` (after #925-#931; E0 merged)
+
+- NEW `src/reddog_work_order_signature_verifier.py`: VERIFICATION ONLY. Validates a signed `RedDogDelegatedWorkAuthority` against its `RedDogPrincipalIdentity` per the ratified contract #928 (canonicalization Section 2, order Section 11) + E0. Implements canonical_signing_input (sorted-key compact JSON + LITERAL domain-prefix strip, ASCII-only, exclude {signature, receipt_chain}) and the full pipeline: revocation-first -> anti-self-mint anchors -> two signatures (identity by principal key, work order by reddog key) -> freshness (single shared time gate) -> snapshot fresh+digest-bound+grants -> repo/foundup scope -> forbidden-op + effective-path IN-FOUNDUP-SCOPE -> valve -> nonce-consume-LAST. Returns `VerificationResult(accepted, reason_codes)` (static codes, no expected-value/key leak). Raw asymmetric verify is INJECTED (algorithm deferred by contract); default `FailClosedSignatureVerifier`. NO signing, NO keygen, NO private key, NO execution side effect, NO subprocess/os/secrets import.
+- Generalizes the proven intake_auth_provider pattern: verified-subject-not-payload, literal prefix strip, durable single-use nonce (consumed only after signature success), fail-closed, `hmac.compare_digest` constant-time.
+- Enforcement seam: `require_authorized(result)` raises `WorkOrderRejected`; `VerificationResult.__bool__` == accepted (a bare `if result:` cannot mean "object exists").
+- TEST `tests/test_reddog_work_order_signature_verifier.py` (29): the 17 required (valid; tamper; non-canonical; expiry; nonce replay; revoked key_epoch; wrong principal; wrong reddog_id; changed allowed_paths; changed foundup_scope; snapshot stale+mismatch; missing signature; free-text "012"; no-leak; constant-time; no-private-key; AST denylist) + CoR regressions (path-out-of-scope; traversal; untrusted/mismatched principal key; key-reuse self-mint; empty key_epoch; nonce-not-burned-on-transient-reject; bool/require_authorized; admin-verb-needs-can_admin; non-bool-verifier; non-serializable-fail-closed). 74 spine tests green, no regression.
+- **9-lens adversarial CoR, 2 rounds: R1 found 3 blocker (path widening, principal self-mint, key-reuse self-mint) + 4 major (nonce lockout, key_epoch omission bypass, unwrapped deps, truthy-result misuse) + 2 minor -- ALL folded; R2 all 9 lenses SAFE, 0 blocker/0 major (2 residual minors: identity_nonce intentionally not consumed at work-order time = reusable identity; caller-enforcement is require_authorized).**
+- **E0/E1 Sequence Lock honored: E0 is merged (#931); no signature is authority until BOTH E0+E1 land + gate review. This slice = VERIFIED_READY draft PR only; not merged.** INDEX_GAP: new verifier + E0/E1 docs unindexed (operator re-index).
+
 ## 2026-07-05: REDDOG_SIGNING_KEY_ISOLATION_CONTRACT_PHASE1 (E0 decision doc, pointer)
 
 **Author**: 0102 (RedDog Architect) | Commander: 012 | Gate: decision-only PR (no code, no keys, no authority change)

--- a/modules/communication/moltbot_bridge/src/reddog_work_order_signature_verifier.py
+++ b/modules/communication/moltbot_bridge/src/reddog_work_order_signature_verifier.py
@@ -14,6 +14,16 @@ generalizing the proven intake_auth_provider pattern:
     - bounded expiry via a single shared time gate with fixed leeway
     - fail-closed on any miss; reason CODES only (never expected-value / key material)
 
+NONCE SEMANTICS (two distinct nonces; contract Section 3):
+    - The IDENTITY credential (RedDogPrincipalIdentity) is a longer-lived, REUSABLE
+      delegation instrument bounded by its TTL; its identity_nonce is an ISSUANCE-time
+      concern and is NOT consumed here. The same identity may authorize many work orders
+      within its TTL. (Consuming it per work order would wrongly lock out legitimate reuse.)
+    - The WORK-AUTHORITY nonce is CONSUME-ONCE: it is durably consumed on a full ACCEPT
+      (the terminal step, still AFTER signature success), so a work order cannot be replayed.
+    In short: identity credential nonce != work-authority nonce; the identity is reusable
+    within TTL, the work authority is single-use.
+
 The raw asymmetric signature check is DEFERRED per contract Section 2 (no curve/library
 chosen, no key generated here). It is provided by an injected `SignatureVerifier`; the
 default is fail-closed. Tests inject a mock backend. `constant_time_compare` wraps

--- a/modules/communication/moltbot_bridge/src/reddog_work_order_signature_verifier.py
+++ b/modules/communication/moltbot_bridge/src/reddog_work_order_signature_verifier.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+RedDog work-order signature VERIFIER (E1: REDDOG_WORK_ORDER_SIGNATURE_VERIFIER_PHASE1).
+
+VERIFICATION ONLY. This module does NOT sign, does NOT generate keys, does NOT store a
+private key, does NOT execute anything. It validates a `RedDogDelegatedWorkAuthority`
+against the ratified contract (REDDOG_PRINCIPAL_IDENTITY_AND_DELEGATION_CONTRACT_PHASE1)
+and the key-isolation boundary (REDDOG_SIGNING_KEY_ISOLATION_CONTRACT_PHASE1, E0), by
+generalizing the proven intake_auth_provider pattern:
+    - verified SUBJECT (the signed payload), never free prompt text
+    - canonical signing_input with a LITERAL domain-prefix strip (not delimiter split)
+    - single-use durable nonce, consumed only AFTER signature success
+    - bounded expiry via a single shared time gate with fixed leeway
+    - fail-closed on any miss; reason CODES only (never expected-value / key material)
+
+The raw asymmetric signature check is DEFERRED per contract Section 2 (no curve/library
+chosen, no key generated here). It is provided by an injected `SignatureVerifier`; the
+default is fail-closed. Tests inject a mock backend. `constant_time_compare` wraps
+`hmac.compare_digest` for the signature/digest byte comparisons this module performs.
+
+E0/E1 Sequence Lock: this verifier's ACCEPT is authority ONLY once E0's isolated signer
+has landed; no signature is treated as authority until both E0 and E1 have landed and
+passed gate review.
+
+NAVIGATION:
+    -> Verifies: RedDogDelegatedWorkAuthority (contract 1b) against its RedDogPrincipalIdentity (1a)
+    -> Order: contract Section 11 (revocation-first -> two signatures -> freshness -> snapshot -> scope -> verb -> valve)
+    -> Does NOT import: crypto keygen / signing libraries, subprocess, os, wallet, chain (AST-guarded by tests).
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+from dataclasses import dataclass, field
+from typing import Any, List, Mapping, Optional, Protocol, Sequence, runtime_checkable
+
+# Domain-separation prefixes (contract Section 2, frozen).
+PREFIX_IDENTITY = "reddog-identity.v1"
+PREFIX_WORKAUTH = "reddog-workauth.v1"
+PREFIX_RECEIPT = "reddog-receipt.v1"
+
+# Fields EXCLUDED from any signed payload (contract Addendum A). Everything else present
+# in the record is INCLUDED, so any added/removed/changed authority field breaks the
+# signature (tamper-evident by construction).
+_EXCLUDED_FROM_SIGNED = frozenset({"signature", "receipt_chain"})
+
+ALLOWED_PRINCIPAL_PROVIDERS = frozenset({"github", "intake_session", "intake_invite"})
+
+
+class ReasonCode:
+    """Static rejection codes. NEVER carry secret / expected-signature / key material."""
+
+    MALFORMED_PAYLOAD = "REJECT_MALFORMED_PAYLOAD"
+    NON_ASCII = "REJECT_NON_ASCII_FIELD"
+    MISSING_SIGNATURE = "REJECT_MISSING_SIGNATURE"
+    IDENTITY_MISSING = "REJECT_IDENTITY_MISSING"
+    IDENTITY_PROVIDER_INVALID = "REJECT_IDENTITY_PROVIDER_INVALID"
+    REVOKED = "REJECT_REVOKED"
+    KEY_EPOCH_REVOKED = "REJECT_KEY_EPOCH_REVOKED"
+    IDENTITY_SIGNATURE_INVALID = "REJECT_IDENTITY_SIGNATURE_INVALID"
+    WORKAUTH_SIGNATURE_INVALID = "REJECT_WORKAUTH_SIGNATURE_INVALID"
+    PRINCIPAL_MISMATCH = "REJECT_PRINCIPAL_MISMATCH"
+    REDDOG_ID_MISMATCH = "REJECT_REDDOG_ID_MISMATCH"
+    REDDOG_KEY_MISMATCH = "REJECT_REDDOG_KEY_MISMATCH"
+    EXPIRED_IDENTITY = "REJECT_EXPIRED_IDENTITY"
+    EXPIRED_WORKAUTH = "REJECT_EXPIRED_WORKAUTH"
+    ISSUED_IN_FUTURE = "REJECT_ISSUED_IN_FUTURE"
+    NONCE_REPLAY = "REJECT_NONCE_REPLAY"
+    SNAPSHOT_STALE = "REJECT_SNAPSHOT_STALE_OR_MISSING"
+    SNAPSHOT_DIGEST_MISMATCH = "REJECT_SNAPSHOT_DIGEST_MISMATCH"
+    SNAPSHOT_INSUFFICIENT = "REJECT_SNAPSHOT_DOES_NOT_GRANT_OP"
+    REPO_OUT_OF_SCOPE = "REJECT_REPO_OUT_OF_SCOPE"
+    FOUNDUP_OUT_OF_SCOPE = "REJECT_FOUNDUP_OUT_OF_SCOPE"
+    FORBIDDEN_OPERATION = "REJECT_FORBIDDEN_OPERATION"
+    EMPTY_EFFECTIVE_PATHS = "REJECT_EMPTY_EFFECTIVE_PATHS"
+    VALVE_STATE = "REJECT_VALVE_STATE_UNSATISFIED"
+    BACKEND_NOT_CONFIGURED = "REJECT_SIGNATURE_BACKEND_NOT_CONFIGURED"
+    KEY_EPOCH_MISSING = "REJECT_KEY_EPOCH_MISSING"
+    PATH_OUT_OF_SCOPE = "REJECT_PATH_OUT_OF_FOUNDUP_SCOPE"
+    PRINCIPAL_KEY_UNTRUSTED = "REJECT_PRINCIPAL_KEY_NOT_TOKEN_VERIFIED"
+    SELF_MINT_KEY_REUSE = "REJECT_PRINCIPAL_AND_REDDOG_KEY_IDENTICAL"
+
+
+# Verbs that require admin (not merely write) permission on the snapshot (contract s7).
+ADMIN_OPERATIONS = frozenset({"admin", "delete_repo", "manage_permissions", "force_push"})
+
+
+def _is_ascii(value: Any) -> bool:
+    return isinstance(value, str) and all(ord(c) < 128 for c in value)
+
+
+def _assert_ascii_deep(obj: Any) -> bool:
+    """Every string in the record (keys + values, nested) must be ASCII (contract s20)."""
+    if isinstance(obj, str):
+        return _is_ascii(obj)
+    if isinstance(obj, Mapping):
+        return all(_is_ascii(k) and _assert_ascii_deep(v) for k, v in obj.items())
+    if isinstance(obj, (list, tuple)):
+        return all(_assert_ascii_deep(v) for v in obj)
+    return True  # ints / bools / None
+
+
+def constant_time_compare(a: str, b: str) -> bool:
+    """Constant-time equality for signature / digest strings (wraps hmac.compare_digest).
+
+    Used wherever this module compares provided-vs-expected signature or digest bytes, so
+    a mismatch position never leaks via timing (mirrors intake_auth `_verify_sig`).
+    """
+    if not isinstance(a, str) or not isinstance(b, str):
+        return False
+    return hmac.compare_digest(a.encode("utf-8"), b.encode("utf-8"))
+
+
+def canonical_signing_input(record: Mapping[str, Any], prefix: str) -> str:
+    """Contract Section 2 canonical form: <prefix-literal> + "." + canonical-json.
+
+    Canonical JSON = UTF-8, keys sorted by code point, no whitespace, arrays in order,
+    integers base-10, ASCII-only. INCLUDED = all present fields minus _EXCLUDED_FROM_SIGNED.
+    The prefix is a LITERAL that the verify side prepends (not a delimiter split), so a
+    "." inside a field can never change the parsed field set.
+    """
+    included = {k: v for k, v in record.items() if k not in _EXCLUDED_FROM_SIGNED}
+    body = json.dumps(included, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return prefix + "." + body
+
+
+@runtime_checkable
+class SignatureVerifier(Protocol):
+    """Injected raw signature check (asymmetric algorithm DEFERRED per contract Section 2).
+
+    verify(public_key, signing_input, signature) -> bool. Implementations MUST use PUBLIC
+    material only, MUST compare in constant time, and MUST NOT leak the expected value in
+    any return / exception. This module never holds a private/signing secret.
+    """
+
+    def verify(self, public_key: str, signing_input: str, signature: str) -> bool: ...
+
+
+class FailClosedSignatureVerifier:
+    """Default backend: no algorithm configured -> reject everything (fail-closed)."""
+
+    def verify(self, public_key: str, signing_input: str, signature: str) -> bool:
+        return False
+
+
+@runtime_checkable
+class NonceStore(Protocol):
+    def consume(self, nonce: str) -> bool:
+        """Atomically record `nonce`. Return True if newly consumed, False if already present (replay)."""
+        ...
+
+
+class InMemoryNonceStore:
+    """Single-process durable-consume stand-in (contract Section 3). SQLite-backed reuse
+    is a later slice; this suffices for the verifier's atomic check-and-insert semantics."""
+
+    def __init__(self) -> None:
+        self._seen: set = set()
+
+    def consume(self, nonce: str) -> bool:
+        if not isinstance(nonce, str) or not nonce or nonce in self._seen:
+            return False
+        self._seen.add(nonce)
+        return True
+
+
+@runtime_checkable
+class PermissionSnapshotResolver(Protocol):
+    def resolve(self, digest: str) -> Optional["PermissionSnapshot"]: ...
+
+
+@runtime_checkable
+class RevocationOracle(Protocol):
+    def is_revoked(
+        self, *, reddog_id: str, fingerprint: str, principal_id: str, key_epoch: str
+    ) -> bool: ...
+
+
+@dataclass
+class PermissionSnapshot:
+    """Minimal fresh-permission snapshot (contract Section 7 / audit 2d)."""
+
+    evidence_digest: str
+    expires_at: int
+    can_write: bool = False
+    can_admin: bool = False
+    repo_full_name: str = ""
+
+    def is_fresh(self, now: int, leeway_s: int) -> bool:
+        return now <= int(self.expires_at) + int(leeway_s)
+
+    def grants(self, operation: str, repo_full_name: str) -> bool:
+        if self.repo_full_name and self.repo_full_name != repo_full_name:
+            return False
+        # Verb-tier: admin operations require can_admin; others require write (contract s7).
+        if str(operation) in ADMIN_OPERATIONS:
+            return bool(self.can_admin)
+        return bool(self.can_write or self.can_admin)
+
+
+@runtime_checkable
+class PrincipalKeyResolver(Protocol):
+    def resolve(self, principal_id: str, principal_provider: str) -> Optional[str]:
+        """Return the token-verified principal PUBLIC key on record for this subject, or None.
+
+        This is the anti-self-mint trust anchor (contract Section 5 issuance basis): the
+        principal_public_key in an untrusted identity record is accepted ONLY if it equals
+        the key this resolver returns for a token-verified principal_id. Default is
+        fail-closed (None -> reject)."""
+        ...
+
+
+class FailClosedPrincipalKeyResolver:
+    """Default: no principal is token-verified -> reject every identity (fail-closed)."""
+
+    def resolve(self, principal_id: str, principal_provider: str) -> Optional[str]:
+        return None
+
+
+@dataclass
+class VerificationResult:
+    accepted: bool
+    reason_codes: List[str] = field(default_factory=list)
+    work_order_id: Optional[str] = None
+
+    def __bool__(self) -> bool:
+        # A bare `if result:` must mean "authorized", never "an object exists" (fail-safe).
+        return bool(self.accepted)
+
+    def to_dict(self) -> dict:
+        return {"accepted": self.accepted, "reason_codes": list(self.reason_codes),
+                "work_order_id": self.work_order_id}
+
+
+class WorkOrderRejected(Exception):
+    """Raised by require_authorized when a work authority is not ACCEPTED. Carries only
+    static reason codes (never secret / expected-signature material)."""
+
+    def __init__(self, reason_codes: Sequence[str]) -> None:
+        self.reason_codes = tuple(reason_codes)
+        super().__init__("work order rejected: " + ",".join(self.reason_codes))
+
+
+def require_authorized(result: VerificationResult) -> None:
+    """Enforcement helper the CALLER MUST use: fail-closed unless result.accepted is True.
+    A caller that ignores this and reads reason_codes truthiness (a non-empty list) would
+    invert the decision; use this instead."""
+    if not result.accepted:
+        raise WorkOrderRejected(result.reason_codes)
+
+
+def _path_within_foundup(path: str, foundup_id: str) -> bool:
+    """True iff `path` is a safe, in-scope path under modules/foundups/<foundup_id>/.
+
+    Rejects absolute, backslash, drive-colon, NUL, device-prefix, and any '..'/'.' or
+    empty (Win32-normalized) segment -- the same class the live scaffold writer hardened.
+    """
+    if not isinstance(path, str) or not path or not _is_ascii(path):
+        return False
+    if "\x00" in path or "\\" in path or ":" in path or path.startswith("/"):
+        return False
+    for dp in ("//?/", "//./"):
+        if path.startswith(dp):
+            return False
+    norm = path.replace("\\", "/")
+    ceiling = f"modules/foundups/{foundup_id}/"
+    if not norm.startswith(ceiling):
+        return False
+    for seg in norm.split("/"):
+        if seg.strip(" \t") == ".." or seg.strip(" .\t") == "":
+            return False
+    return True
+
+
+_REQUIRED_WORKAUTH_FIELDS = (
+    "work_order_id", "principal_id", "reddog_id", "repo_full_name", "foundup_id",
+    "allowed_paths", "denied_paths", "requested_operation", "permission_snapshot_digest",
+    "nonce", "issued_at", "expires_at", "valve_state_required", "key_epoch", "signature",
+)
+_REQUIRED_IDENTITY_FIELDS = (
+    "principal_id", "principal_provider", "principal_public_key", "reddog_id",
+    "reddog_public_key", "repo_scope", "foundup_scope", "issued_at", "expires_at", "signature",
+)
+
+
+def verify_delegated_work_authority(
+    *,
+    work_authority: Mapping[str, Any],
+    identity: Mapping[str, Any],
+    signature_verifier: SignatureVerifier,
+    principal_key_resolver: PrincipalKeyResolver,
+    nonce_store: NonceStore,
+    snapshot_resolver: PermissionSnapshotResolver,
+    revocation_oracle: RevocationOracle,
+    now: int,
+    required_valve_state: str,
+    forbidden_operations: Sequence[str] = (),
+    revoked_key_epochs: Sequence[str] = (),
+    leeway_s: int = 60,
+) -> VerificationResult:
+    """Verify a signed RedDogDelegatedWorkAuthority. ACCEPT / REJECT with reason codes.
+
+    Order = contract Section 11 (revocation-first). No execution side effect; the only
+    state change is the atomic nonce consume, performed AFTER signature success.
+    """
+    wo_id = work_authority.get("work_order_id") if isinstance(work_authority, Mapping) else None
+    result = VerificationResult(accepted=False, work_order_id=wo_id if isinstance(wo_id, str) else None)
+
+    def reject(code: str) -> VerificationResult:
+        result.accepted = False
+        result.reason_codes.append(code)
+        return result
+
+    # ---- Structural + ASCII (contract s2/s20) -------------------------------
+    if not isinstance(work_authority, Mapping) or not isinstance(identity, Mapping):
+        return reject(ReasonCode.MALFORMED_PAYLOAD)
+    for f in _REQUIRED_WORKAUTH_FIELDS:
+        if work_authority.get(f) is None:
+            return reject(ReasonCode.MISSING_SIGNATURE if f == "signature" else ReasonCode.MALFORMED_PAYLOAD)
+    for f in _REQUIRED_IDENTITY_FIELDS:
+        if identity.get(f) is None:
+            return reject(ReasonCode.IDENTITY_MISSING)
+    if not (_assert_ascii_deep(work_authority) and _assert_ascii_deep(identity)):
+        return reject(ReasonCode.NON_ASCII)
+    if str(identity.get("principal_provider")) not in ALLOWED_PRINCIPAL_PROVIDERS:
+        return reject(ReasonCode.IDENTITY_PROVIDER_INVALID)
+
+    principal_id = str(identity["principal_id"])
+    reddog_id = str(identity["reddog_id"])
+    reddog_public_key = str(identity["reddog_public_key"])
+    principal_public_key = str(identity["principal_public_key"])
+    fingerprint = str(identity.get("reddog_key_fingerprint", ""))
+    key_epoch = str(work_authority.get("key_epoch", ""))
+    if not key_epoch:
+        return reject(ReasonCode.KEY_EPOCH_MISSING)
+
+    # ---- 1. Revocation FIRST (contract s9/s11): wins over a valid signature --
+    try:
+        if revocation_oracle.is_revoked(
+            reddog_id=reddog_id, fingerprint=fingerprint,
+            principal_id=principal_id, key_epoch=key_epoch,
+        ):
+            return reject(ReasonCode.REVOKED)
+    except Exception:
+        return reject(ReasonCode.REVOKED)  # fail-closed
+    if key_epoch in set(str(e) for e in revoked_key_epochs):
+        return reject(ReasonCode.KEY_EPOCH_REVOKED)
+
+    # ---- 2 (pre): anti-self-mint trust anchors -------------------------------
+    # The principal key and the RedDog key MUST differ: the identity is signed by the
+    # PRINCIPAL and the work order by the RedDog; one key signing both is a self-grant.
+    if constant_time_compare(principal_public_key, reddog_public_key):
+        return reject(ReasonCode.SELF_MINT_KEY_REUSE)
+    # principal_public_key is trusted ONLY if it is the token-verified key on record for
+    # this principal_id (contract Section 5 issuance basis). Fail-closed if unknown.
+    try:
+        trusted_principal_key = principal_key_resolver.resolve(
+            principal_id, str(identity["principal_provider"])
+        )
+    except Exception:
+        trusted_principal_key = None
+    if not trusted_principal_key or not constant_time_compare(str(trusted_principal_key), principal_public_key):
+        return reject(ReasonCode.PRINCIPAL_KEY_UNTRUSTED)
+
+    # ---- 2a. Parent identity signature: PRINCIPAL-signed (anti-self-grant) ---
+    try:
+        id_input = canonical_signing_input(identity, PREFIX_IDENTITY)
+        # strict `is True`: a lax backend returning a truthy non-bool must NOT accept.
+        id_ok = signature_verifier.verify(principal_public_key, id_input, str(identity["signature"])) is True
+    except Exception:
+        id_ok = False
+    if not id_ok:
+        return reject(ReasonCode.IDENTITY_SIGNATURE_INVALID)
+
+    # ---- 2b. Binding: work order must match its parent identity --------------
+    if not constant_time_compare(str(work_authority["principal_id"]), principal_id):
+        return reject(ReasonCode.PRINCIPAL_MISMATCH)
+    if not constant_time_compare(str(work_authority["reddog_id"]), reddog_id):
+        return reject(ReasonCode.REDDOG_ID_MISMATCH)
+    wa_signer_key = work_authority.get("signer_public_key")
+    if wa_signer_key is not None and not constant_time_compare(str(wa_signer_key), reddog_public_key):
+        return reject(ReasonCode.REDDOG_KEY_MISMATCH)
+
+    # ---- 2c. Work-order signature: by the delegated reddog key ---------------
+    try:
+        wa_input = canonical_signing_input(work_authority, PREFIX_WORKAUTH)
+        wa_ok = signature_verifier.verify(reddog_public_key, wa_input, str(work_authority["signature"])) is True
+    except Exception:
+        wa_ok = False
+    if not wa_ok:
+        # covers payload tampering, non-canonical/field-reorder, changed allowed_paths /
+        # foundup_id / permission_snapshot_digest / valve_state_required, wrong signer key.
+        return reject(ReasonCode.WORKAUTH_SIGNATURE_INVALID)
+
+    # ---- 3. Freshness (single shared time gate, contract s3) -----------------
+    try:
+        id_iat, id_exp = int(identity["issued_at"]), int(identity["expires_at"])
+        wa_iat, wa_exp = int(work_authority["issued_at"]), int(work_authority["expires_at"])
+    except (TypeError, ValueError):
+        return reject(ReasonCode.MALFORMED_PAYLOAD)
+    if now + leeway_s < id_iat or now + leeway_s < wa_iat:
+        return reject(ReasonCode.ISSUED_IN_FUTURE)
+    if now > id_exp + leeway_s:
+        return reject(ReasonCode.EXPIRED_IDENTITY)
+    if now > wa_exp + leeway_s:
+        return reject(ReasonCode.EXPIRED_WORKAUTH)
+
+    # ---- 5. Permission snapshot: fresh + digest-bound + grants verb (s7) -----
+    #        (Nonce consume is DEFERRED to the terminal step 9 so a transient reject here
+    #         cannot permanently burn a legitimate order's single-use nonce.)
+    snap_digest = str(work_authority["permission_snapshot_digest"])
+    try:
+        snap = snapshot_resolver.resolve(snap_digest)
+    except Exception:
+        snap = None
+    try:
+        fresh = snap is not None and snap.is_fresh(now, leeway_s)
+    except Exception:
+        fresh = False
+    if not fresh:
+        return reject(ReasonCode.SNAPSHOT_STALE)
+    if not constant_time_compare(str(snap.evidence_digest), snap_digest):
+        return reject(ReasonCode.SNAPSHOT_DIGEST_MISMATCH)
+    try:
+        granted = snap.grants(str(work_authority["requested_operation"]), str(work_authority["repo_full_name"]))
+    except Exception:
+        granted = False
+    if not granted:
+        return reject(ReasonCode.SNAPSHOT_INSUFFICIENT)
+
+    # ---- 6. Scope: repo + foundup within the identity ceiling (s5/s6) --------
+    if str(work_authority["repo_full_name"]) not in set(map(str, identity["repo_scope"])):
+        return reject(ReasonCode.REPO_OUT_OF_SCOPE)
+    if str(work_authority["foundup_id"]) not in set(map(str, identity["foundup_scope"])):
+        return reject(ReasonCode.FOUNDUP_OUT_OF_SCOPE)
+
+    # ---- 7. Verb + path: forbidden ops; deny wins; effective set IN-SCOPE -----
+    try:
+        allowed = set(map(str, work_authority["allowed_paths"]))
+        denied = set(map(str, work_authority["denied_paths"]))
+    except Exception:
+        return reject(ReasonCode.MALFORMED_PAYLOAD)
+    if str(work_authority["requested_operation"]) in set(map(str, forbidden_operations)):
+        return reject(ReasonCode.FORBIDDEN_OPERATION)
+    effective = allowed - denied
+    if not effective:
+        return reject(ReasonCode.EMPTY_EFFECTIVE_PATHS)
+    # Bind every effective path to the FoundUp's canonical ceiling: an in-scope,
+    # validly-signed order still cannot target .github/workflows, secrets, or ../../.env.
+    foundup_id = str(work_authority["foundup_id"])
+    if not all(_path_within_foundup(p, foundup_id) for p in effective):
+        return reject(ReasonCode.PATH_OUT_OF_SCOPE)
+
+    # ---- 8. Valve: required state bound into the signed payload (s2/s7) ------
+    if not constant_time_compare(str(work_authority["valve_state_required"]), str(required_valve_state)):
+        return reject(ReasonCode.VALVE_STATE)
+
+    # ---- 9. Nonce consume LAST: burn only on a full ACCEPT (still AFTER signature
+    #         success), so a transient later-gate reject never locks out a valid order.
+    try:
+        consumed = nonce_store.consume(str(work_authority["nonce"]))
+    except Exception:
+        consumed = False
+    if not consumed:
+        return reject(ReasonCode.NONCE_REPLAY)
+
+    result.accepted = True
+    return result

--- a/modules/communication/moltbot_bridge/tests/test_reddog_work_order_signature_verifier.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_work_order_signature_verifier.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Tests for the RedDog work-order signature VERIFIER (E1).
+
+A TEST-ONLY mock crypto backend SIGNS (production only verifies). The mock maps each
+"public key" string to a secret and HMAC-signs the canonical signing_input; its verify
+recomputes and constant-time-compares. No real keys, no real crypto, no network.
+
+Slice: REDDOG_WORK_ORDER_SIGNATURE_VERIFIER_PHASE1
+WSP:   50, 54, 71, 96, 97
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import hmac
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src import reddog_work_order_signature_verifier as v
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    InMemoryNonceStore,
+    PermissionSnapshot,
+    PREFIX_IDENTITY,
+    PREFIX_WORKAUTH,
+    ReasonCode,
+    canonical_signing_input,
+    verify_delegated_work_authority,
+)
+
+_VALVE = "VALVE_OPEN_WORKTREE_CREATE"
+_REPO = "FOUNDUPS/Foundups-Agent"
+_FID = "paccess_001"
+
+
+# --- test-only mock crypto (SIGNS; production never does) --------------------
+class _MockCrypto:
+    def __init__(self) -> None:
+        self._secrets: dict = {}
+
+    def keypair(self, name: str) -> str:
+        pub = f"pub:{name}"
+        self._secrets[pub] = (f"mock-secret-{name}").encode("utf-8")
+        return pub
+
+    def sign(self, public_key: str, signing_input: str) -> str:
+        return hmac.new(self._secrets[public_key], signing_input.encode("utf-8"), hashlib.sha256).hexdigest()
+
+    def verify(self, public_key: str, signing_input: str, signature: str) -> bool:
+        secret = self._secrets.get(public_key)
+        if secret is None or not isinstance(signature, str):
+            return False
+        expected = hmac.new(secret, signing_input.encode("utf-8"), hashlib.sha256).hexdigest()
+        return hmac.compare_digest(expected, signature)  # constant-time (test 15)
+
+
+class _MockResolver:
+    def __init__(self, mapping: dict) -> None:
+        self._m = mapping
+
+    def resolve(self, digest: str):
+        return self._m.get(digest)
+
+
+class _NoRevocation:
+    def is_revoked(self, *, reddog_id, fingerprint, principal_id, key_epoch) -> bool:
+        return False
+
+
+class _MockPrincipalKeyResolver:
+    """Maps a token-verified principal_id -> its trusted principal public key."""
+
+    def __init__(self, mapping: dict) -> None:
+        self._m = mapping
+
+    def resolve(self, principal_id: str, principal_provider: str):
+        return self._m.get(principal_id)
+
+
+def _build(now: int = 1000):
+    crypto = _MockCrypto()
+    ppub = crypto.keypair("principal")
+    rpub = crypto.keypair("reddog")
+    identity = {
+        "principal_id": "github:mjtrout",
+        "principal_provider": "github",
+        "principal_public_key": ppub,
+        "principal_key_fingerprint": "fp:principal",
+        "reddog_id": "reddog:abc123",
+        "reddog_public_key": rpub,
+        "reddog_key_fingerprint": "fp:reddog",
+        "repo_scope": [_REPO],
+        "foundup_scope": [_FID],
+        "issued_at": now - 10,
+        "expires_at": now + 3600,
+    }
+    identity["signature"] = crypto.sign(ppub, canonical_signing_input(identity, PREFIX_IDENTITY))
+    digest = "sha256:snap-1"
+    workauth = {
+        "work_order_id": "wo-1",
+        "principal_id": "github:mjtrout",
+        "reddog_id": "reddog:abc123",
+        "repo_full_name": _REPO,
+        "foundup_id": _FID,
+        "allowed_paths": [f"modules/foundups/{_FID}/**"],
+        "denied_paths": [],
+        "requested_operation": "create_foundup",
+        "permission_snapshot_digest": digest,
+        "nonce": "nonce-unique-0001",
+        "issued_at": now - 5,
+        "expires_at": now + 120,
+        "valve_state_required": _VALVE,
+        "key_epoch": "epoch-1",
+    }
+    workauth["signature"] = crypto.sign(rpub, canonical_signing_input(workauth, PREFIX_WORKAUTH))
+    snap = PermissionSnapshot(evidence_digest=digest, expires_at=now + 300, can_write=True, repo_full_name=_REPO)
+    ctx = dict(
+        signature_verifier=crypto,
+        principal_key_resolver=_MockPrincipalKeyResolver({"github:mjtrout": ppub}),
+        nonce_store=InMemoryNonceStore(),
+        snapshot_resolver=_MockResolver({digest: snap}),
+        revocation_oracle=_NoRevocation(),
+        now=now,
+        required_valve_state=_VALVE,
+        forbidden_operations=("rm_rf",),
+    )
+    return crypto, identity, workauth, ctx
+
+
+def _resign_wa(crypto, identity, workauth):
+    workauth["signature"] = crypto.sign(identity["reddog_public_key"], canonical_signing_input(workauth, PREFIX_WORKAUTH))
+    return workauth
+
+
+def _run(identity, workauth, ctx):
+    return verify_delegated_work_authority(work_authority=workauth, identity=identity, **ctx)
+
+
+# 1 -------------------------------------------------------------------------- #
+def test_valid_signed_authority_verifies() -> None:
+    _, identity, workauth, ctx = _build()
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is True, r.reason_codes
+    assert r.reason_codes == []
+    assert r.work_order_id == "wo-1"
+
+
+# 2 -------------------------------------------------------------------------- #
+def test_payload_tampering_rejects() -> None:
+    _, identity, workauth, ctx = _build()
+    workauth["allowed_paths"] = ["**"]  # widen after signing
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False and ReasonCode.WORKAUTH_SIGNATURE_INVALID in r.reason_codes
+
+
+# 3 -------------------------------------------------------------------------- #
+def test_non_canonical_serialization_rejects() -> None:
+    crypto, identity, workauth, ctx = _build()
+    # attacker signs over a NON-canonical input (extra prefix noise); verifier recomputes canonical.
+    bad_input = PREFIX_WORKAUTH + ".{ }" + canonical_signing_input(workauth, PREFIX_WORKAUTH)
+    workauth["signature"] = crypto.sign(identity["reddog_public_key"], bad_input)
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False and ReasonCode.WORKAUTH_SIGNATURE_INVALID in r.reason_codes
+
+
+# 4 -------------------------------------------------------------------------- #
+def test_expired_authority_rejects() -> None:
+    _, identity, workauth, ctx = _build()
+    ctx["now"] = 1000 + 100000  # well past expires_at + leeway
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False
+    assert ReasonCode.EXPIRED_WORKAUTH in r.reason_codes or ReasonCode.EXPIRED_IDENTITY in r.reason_codes
+
+
+# 5 -------------------------------------------------------------------------- #
+def test_replayed_nonce_rejects() -> None:
+    _, identity, workauth, ctx = _build()
+    first = _run(identity, workauth, ctx)
+    assert first.accepted is True
+    # same nonce store, resubmit the identical (still valid) order -> replay
+    second = _run(identity, workauth, ctx)
+    assert second.accepted is False and ReasonCode.NONCE_REPLAY in second.reason_codes
+
+
+# 6 -------------------------------------------------------------------------- #
+def test_revoked_key_epoch_rejects() -> None:
+    _, identity, workauth, ctx = _build()
+    ctx["revoked_key_epochs"] = ("epoch-1",)
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False and ReasonCode.KEY_EPOCH_REVOKED in r.reason_codes
+
+
+# 7 -------------------------------------------------------------------------- #
+def test_wrong_principal_rejects() -> None:
+    crypto, identity, workauth, ctx = _build()
+    workauth["principal_id"] = "github:attacker"
+    workauth["signature"] = crypto.sign(identity["reddog_public_key"], canonical_signing_input(workauth, PREFIX_WORKAUTH))
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False and ReasonCode.PRINCIPAL_MISMATCH in r.reason_codes
+
+
+# 8 -------------------------------------------------------------------------- #
+def test_wrong_reddog_id_rejects() -> None:
+    crypto, identity, workauth, ctx = _build()
+    workauth["reddog_id"] = "reddog:evil"
+    workauth["signature"] = crypto.sign(identity["reddog_public_key"], canonical_signing_input(workauth, PREFIX_WORKAUTH))
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False and ReasonCode.REDDOG_ID_MISMATCH in r.reason_codes
+
+
+# 9 -------------------------------------------------------------------------- #
+def test_changed_allowed_paths_rejects() -> None:
+    _, identity, workauth, ctx = _build()
+    workauth["allowed_paths"] = workauth["allowed_paths"] + [".github/workflows/**"]
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False and ReasonCode.WORKAUTH_SIGNATURE_INVALID in r.reason_codes
+
+
+# 10 ------------------------------------------------------------------------- #
+def test_changed_foundup_scope_rejects() -> None:
+    _, identity, workauth, ctx = _build()
+    identity["foundup_scope"] = [_FID, "evil_002"]  # tamper the principal-signed identity
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False and ReasonCode.IDENTITY_SIGNATURE_INVALID in r.reason_codes
+
+
+# 11 ------------------------------------------------------------------------- #
+def test_permission_snapshot_stale_or_missing_rejects() -> None:
+    _, identity, workauth, ctx = _build()
+    ctx["snapshot_resolver"] = _MockResolver({})  # digest resolves to nothing
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False and ReasonCode.SNAPSHOT_STALE in r.reason_codes
+
+
+def test_permission_snapshot_digest_mismatch_rejects() -> None:
+    _, identity, workauth, ctx = _build()
+    d = workauth["permission_snapshot_digest"]
+    ctx["snapshot_resolver"] = _MockResolver(
+        {d: PermissionSnapshot(evidence_digest="sha256:OTHER", expires_at=1000 + 300, can_write=True, repo_full_name=_REPO)}
+    )
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False and ReasonCode.SNAPSHOT_DIGEST_MISMATCH in r.reason_codes
+
+
+# 12 ------------------------------------------------------------------------- #
+def test_missing_signature_rejects() -> None:
+    _, identity, workauth, ctx = _build()
+    workauth["signature"] = None
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False and ReasonCode.MISSING_SIGNATURE in r.reason_codes
+
+
+# 13 ------------------------------------------------------------------------- #
+def test_prompt_text_i_am_012_without_signature_rejects() -> None:
+    """A packet asserting authority in free text but not PRINCIPAL-signed is inert:
+    principal_id '012' is not a token-verified subject and its key is not on record."""
+    crypto, identity, workauth, ctx = _build()
+    identity["principal_id"] = "012"
+    identity["signature"] = crypto.sign(identity["reddog_public_key"], canonical_signing_input(identity, PREFIX_IDENTITY))
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False
+    assert (ReasonCode.PRINCIPAL_KEY_UNTRUSTED in r.reason_codes
+            or ReasonCode.IDENTITY_SIGNATURE_INVALID in r.reason_codes
+            or ReasonCode.PRINCIPAL_MISMATCH in r.reason_codes)
+
+
+# 14 ------------------------------------------------------------------------- #
+def test_failure_reasons_never_leak_expected_material() -> None:
+    crypto, identity, workauth, ctx = _build()
+    workauth["allowed_paths"] = ["**"]
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False
+    blob = " ".join(r.reason_codes)
+    # reason codes are static enums: no signature, secret, or key bytes leak
+    assert workauth["signature"] not in blob
+    assert "mock-secret" not in blob
+    for code in r.reason_codes:
+        assert code.startswith("REJECT_")
+
+
+# 15 ------------------------------------------------------------------------- #
+def test_constant_time_compare_used_for_signature_bytes() -> None:
+    # production helper is constant-time (wraps hmac.compare_digest)
+    assert v.constant_time_compare("abc", "abc") is True
+    assert v.constant_time_compare("abc", "abd") is False
+    src = Path(v.__file__).read_text(encoding="utf-8")
+    assert "hmac.compare_digest" in src
+    # the mock verifier (the MAC/signature byte comparison) uses constant-time compare too
+    msrc = Path(__file__).read_text(encoding="utf-8")
+    assert "hmac.compare_digest" in msrc
+
+
+# 16 ------------------------------------------------------------------------- #
+def test_no_private_key_material_in_production_module() -> None:
+    src = Path(v.__file__).read_text(encoding="utf-8").lower()
+    for banned in ("private_key", "privatekey", "-----begin", "secret =", "signing_secret", "os.urandom", "token_bytes"):
+        assert banned not in src, f"possible key material in production module: {banned!r}"
+
+
+# 17 ------------------------------------------------------------------------- #
+def test_ast_denylist_no_keygen_signing_subprocess_shell_wallet_chain() -> None:
+    src = Path(v.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    imported: set = set()
+    for n in ast.walk(tree):
+        if isinstance(n, ast.Import):
+            imported |= {a.name.split(".")[0] for a in n.names}
+        elif isinstance(n, ast.ImportFrom):
+            imported.add((n.module or "").split(".")[0])
+    forbidden = {
+        "subprocess", "os", "secrets", "socket", "pty", "shutil", "importlib",
+        "cryptography", "nacl", "ecdsa", "web3", "eth_account", "bitcoin", "wallet",
+    }
+    assert not (imported & forbidden), f"forbidden import(s): {imported & forbidden}"
+    # no dynamic dispatch, no MAC/keygen calls (verification delegates to the injected backend)
+    called = set()
+    for n in ast.walk(tree):
+        if isinstance(n, ast.Call):
+            fn = n.func
+            if isinstance(fn, ast.Name):
+                called.add(fn.id)
+            elif isinstance(fn, ast.Attribute):
+                called.add(fn.attr)
+    assert not (called & {"eval", "exec", "compile", "__import__", "system", "Popen", "run"})
+    # hmac is imported ONLY for compare_digest -- never hmac.new (which would compute a MAC = sign)
+    assert "new" not in called or "hmac" not in imported or "compare_digest" in called
+    assert "compare_digest" in called, "verifier must use constant-time compare_digest"
+
+
+# ---- CoR regression: path-scope binding (BLOCKER) --------------------------- #
+def test_path_outside_foundup_scope_rejects() -> None:
+    """A validly-signed, in-scope order still cannot target paths outside its FoundUp."""
+    crypto, identity, workauth, ctx = _build()
+    workauth["allowed_paths"] = [".github/workflows/deploy.yml"]
+    _resign_wa(crypto, identity, workauth)
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False and ReasonCode.PATH_OUT_OF_SCOPE in r.reason_codes
+
+
+def test_path_traversal_rejects() -> None:
+    crypto, identity, workauth, ctx = _build()
+    workauth["allowed_paths"] = [f"modules/foundups/{_FID}/../../.env"]
+    _resign_wa(crypto, identity, workauth)
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False and ReasonCode.PATH_OUT_OF_SCOPE in r.reason_codes
+
+
+# ---- CoR regression: principal-key trust anchor (BLOCKER) ------------------- #
+def test_untrusted_principal_key_rejects() -> None:
+    """A self-supplied principal_public_key not on record for the principal is rejected."""
+    _, identity, workauth, ctx = _build()
+    ctx["principal_key_resolver"] = _MockPrincipalKeyResolver({})  # nothing token-verified
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False and ReasonCode.PRINCIPAL_KEY_UNTRUSTED in r.reason_codes
+
+
+def test_principal_key_mismatch_rejects() -> None:
+    _, identity, workauth, ctx = _build()
+    ctx["principal_key_resolver"] = _MockPrincipalKeyResolver({"github:mjtrout": "pub:someone-else"})
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False and ReasonCode.PRINCIPAL_KEY_UNTRUSTED in r.reason_codes
+
+
+# ---- CoR regression: key-reuse self-mint (BLOCKER) ------------------------- #
+def test_self_mint_key_reuse_rejects() -> None:
+    """principal_public_key == reddog_public_key is a self-grant and must be refused."""
+    crypto, identity, workauth, ctx = _build()
+    shared = identity["reddog_public_key"]
+    identity["principal_public_key"] = shared
+    identity["signature"] = crypto.sign(shared, canonical_signing_input(identity, PREFIX_IDENTITY))
+    ctx["principal_key_resolver"] = _MockPrincipalKeyResolver({"github:mjtrout": shared})
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False and ReasonCode.SELF_MINT_KEY_REUSE in r.reason_codes
+
+
+# ---- CoR regression: key_epoch required (MAJOR) ---------------------------- #
+def test_empty_key_epoch_rejects() -> None:
+    crypto, identity, workauth, ctx = _build()
+    workauth["key_epoch"] = ""
+    _resign_wa(crypto, identity, workauth)
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False and ReasonCode.KEY_EPOCH_MISSING in r.reason_codes
+
+
+# ---- CoR regression: nonce NOT burned on a transient later-gate reject (MAJOR) #
+def test_nonce_not_burned_on_transient_reject() -> None:
+    _, identity, workauth, ctx = _build()
+    # 1st attempt: valve transiently CLOSED -> reject at the valve gate (after nonce would
+    # previously have been consumed). Nonce must survive.
+    ctx["required_valve_state"] = "VALVE_CLOSED"
+    first = _run(identity, workauth, ctx)
+    assert first.accepted is False and ReasonCode.VALVE_STATE in first.reason_codes
+    # operator opens the valve; the SAME signed order retries against the SAME nonce store.
+    ctx["required_valve_state"] = _VALVE
+    second = _run(identity, workauth, ctx)
+    assert second.accepted is True, second.reason_codes  # not locked out
+
+
+# ---- CoR regression: enforcement helper / truthiness (MAJOR) --------------- #
+def test_result_bool_and_require_authorized() -> None:
+    from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+        require_authorized, WorkOrderRejected,
+    )
+    _, identity, workauth, ctx = _build()
+    ok = _run(identity, workauth, ctx)
+    assert bool(ok) is True
+    require_authorized(ok)  # does not raise
+    _, identity2, workauth2, ctx2 = _build()
+    workauth2["allowed_paths"] = ["**"]  # tamper -> reject
+    bad = _run(identity2, workauth2, ctx2)
+    assert bool(bad) is False
+    with pytest.raises(WorkOrderRejected):
+        require_authorized(bad)
+
+
+# ---- CoR regression: admin verb requires can_admin (MINOR) ----------------- #
+def test_admin_verb_requires_can_admin() -> None:
+    crypto, identity, workauth, ctx = _build()
+    workauth["requested_operation"] = "manage_permissions"  # admin-tier
+    _resign_wa(crypto, identity, workauth)
+    # snapshot grants write but NOT admin
+    d = workauth["permission_snapshot_digest"]
+    ctx["snapshot_resolver"] = _MockResolver(
+        {d: PermissionSnapshot(evidence_digest=d, expires_at=1000 + 300, can_write=True, can_admin=False, repo_full_name=_REPO)}
+    )
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False and ReasonCode.SNAPSHOT_INSUFFICIENT in r.reason_codes
+
+
+# ---- CoR-R2 regression: lax backend returning a truthy non-bool must reject - #
+def test_non_bool_truthy_verifier_result_rejects() -> None:
+    class _LaxVerifier:
+        def verify(self, public_key, signing_input, signature):
+            return 1  # truthy, not True
+
+    _, identity, workauth, ctx = _build()
+    ctx["signature_verifier"] = _LaxVerifier()
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False and ReasonCode.IDENTITY_SIGNATURE_INVALID in r.reason_codes
+
+
+# ---- CoR-R2 regression: non-serializable payload fails closed (no crash) ---- #
+def test_non_serializable_payload_fails_closed() -> None:
+    _, identity, workauth, ctx = _build()
+    workauth["allowed_paths"] = [{"unhashable-nonjson"}]  # a set -> json.dumps raises
+    r = _run(identity, workauth, ctx)
+    assert r.accepted is False  # rejected, never raised
+    assert r.reason_codes  # a static code was recorded

--- a/modules/communication/moltbot_bridge/tests/test_reddog_work_order_signature_verifier.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_work_order_signature_verifier.py
@@ -442,6 +442,48 @@ def test_non_bool_truthy_verifier_result_rejects() -> None:
     assert r.accepted is False and ReasonCode.IDENTITY_SIGNATURE_INVALID in r.reason_codes
 
 
+# ---- 012 review point 1: nonce semantics (identity reusable; work-auth once) --- #
+def test_identity_reusable_but_work_authority_nonce_consume_once() -> None:
+    """The SAME identity authorizes multiple work orders (reusable within TTL); each
+    work-authority nonce is single-use; reusing a work-auth nonce replays."""
+    crypto, identity, wa1, ctx = _build()
+    store = ctx["nonce_store"]  # one store shared across all submissions
+
+    # wo-1 with its own nonce -> ACCEPT (identity used once)
+    assert _run(identity, wa1, ctx).accepted is True
+
+    # wo-2: SAME identity, DIFFERENT work order + DIFFERENT nonce -> ACCEPT (identity reused)
+    wa2 = dict(wa1)
+    wa2["work_order_id"] = "wo-2"
+    wa2["nonce"] = "nonce-unique-0002"
+    _resign_wa(crypto, identity, wa2)
+    assert _run(identity, wa2, ctx).accepted is True, "identity must be reusable within TTL"
+
+    # wo-3: SAME identity but REUSE wo-1's nonce -> REPLAY (work-auth nonce is consume-once)
+    wa3 = dict(wa1)
+    wa3["work_order_id"] = "wo-3"
+    wa3["nonce"] = wa1["nonce"]  # reused
+    _resign_wa(crypto, identity, wa3)
+    r3 = _run(identity, wa3, ctx)
+    assert r3.accepted is False and ReasonCode.NONCE_REPLAY in r3.reason_codes
+
+
+# ---- 012 review point 2: a rejected result must be falsey (cannot authorize) --- #
+def test_rejected_result_is_falsey_and_cannot_authorize() -> None:
+    from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+        require_authorized, WorkOrderRejected,
+    )
+    _, identity, workauth, ctx = _build()
+    workauth["allowed_paths"] = ["**"]  # tamper -> rejected
+    rejected = _run(identity, workauth, ctx)
+    assert rejected.accepted is False
+    assert bool(rejected) is False              # accidental `if result:` cannot authorize
+    assert not rejected                          # explicit falsiness
+    assert rejected.reason_codes                 # ...even though reason_codes is a NON-empty (truthy) list
+    with pytest.raises(WorkOrderRejected):
+        require_authorized(rejected)
+
+
 # ---- CoR-R2 regression: non-serializable payload fails closed (no crash) ---- #
 def test_non_serializable_payload_fails_closed() -> None:
     _, identity, workauth, ctx = _build()


### PR DESCRIPTION
## REDDOG_WORK_ORDER_SIGNATURE_VERIFIER_PHASE1 (E1 — first implementation, draft only)

Lane A (Identity/Delegation/Signing). **Verification only** — validates a signed `RedDogDelegatedWorkAuthority` against its `RedDogPrincipalIdentity` per the ratified contract **#928** (canonicalization §2, verification order §11) and the **E0** key-isolation boundary. **No signing, no keygen, no private key, no execution side effect.** Draft PR — stops at VERIFIED_READY.

### Module — `src/reddog_work_order_signature_verifier.py`
- **Canonicalization (§2):** sorted-key compact JSON + **literal** domain-prefix strip (never delimiter split) + ASCII-only; excludes `{signature, receipt_chain}` — any add/remove/change of an authority field breaks the signature.
- **Pipeline (§11, revocation-first):** revocation → anti-self-mint anchors (principal≠reddog key; principal key must be the **token-verified key on record** via an injected `principal_key_resolver`) → two signatures (identity by principal key, work order by reddog key) → freshness (single shared time gate) → snapshot fresh + digest-bound + grants-verb → repo/foundup scope → forbidden-op + **every effective path bound to `modules/foundups/<foundup_id>/`** → valve → **nonce consume LAST** (burned only on full ACCEPT, still after signature success).
- **Result:** `VerificationResult(accepted, reason_codes)` — static codes, no expected-value/key leakage. `__bool__ == accepted`; `require_authorized()` raises `WorkOrderRejected` so a caller can't misread a truthy object as pass.
- **Algorithm deferred** per contract §2: the raw asymmetric verify is **injected**; default `FailClosedSignatureVerifier`. `hmac` used only for `compare_digest`.
- Generalizes `intake_auth_provider`: verified-subject-not-payload, literal prefix, durable single-use nonce (consumed only after signature success), fail-closed.

### Tests — `tests/test_...verifier.py` (29)
The 17 required (valid · tamper · non-canonical · expiry · nonce replay · revoked key_epoch · wrong principal · wrong reddog_id · changed allowed_paths · changed foundup_scope · snapshot stale+mismatch · missing signature · free-text "012" · no-leak · constant-time · no-private-key · AST denylist) **+** CoR regressions (path-out-of-scope · traversal · untrusted/mismatched principal key · key-reuse self-mint · empty key_epoch · **nonce-not-burned-on-transient-reject** · bool/require_authorized · admin-verb-needs-can_admin · non-bool-verifier · non-serializable-fail-closed). **74 spine tests green** — no regression.

### Adversarial CoR — 9 lenses, 2 rounds
- **R1:** 3 blocker (path widening; principal self-mint via inline key; key-reuse self-mint) + 4 major (nonce lockout on transient reject; key_epoch-omission revocation bypass; unwrapped dependency calls; truthy-result misuse) + 2 minor — **all folded**.
- **R2:** all 9 lenses **SAFE, 0 blocker / 0 major**. Residual minors (disclosed): `identity_nonce` intentionally not consumed at work-order time (reusable identity); caller enforcement is `require_authorized` (integration slice).

### Boundary
**E0/E1 Sequence Lock honored:** E0 merged (#931). No signature is authority until **both E0 and E1** land and pass gate review. **Draft only — do not merge.**

WSP: 00, 15, 22, 50, 54, 71, 96, 97 · Base `1a2412c0d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Nonce semantics (review note)
```
identity credential nonce != work authority nonce
identity credential may be reusable within TTL   (identity_nonce NOT consumed at work-order time)
work authority nonce is consume-once             (durably burned on ACCEPT, after signature success)
```
Documented in the module docstring; proven by `test_identity_reusable_but_work_authority_nonce_consume_once`. A rejected `VerificationResult` is falsey (`bool(rejected) is False`) even though `reason_codes` is a non-empty list — proven by `test_rejected_result_is_falsey_and_cannot_authorize`.

### Next slice (after land — do NOT auto-wire)
`REDDOG_WORK_ORDER_SIGNATURE_GATE_INTEGRATION_PHASE1`: consume the verifier result in the work-order/policy-gate path, fail-closed on missing/invalid signature. Still no live-writer broadening, no signed receipts/rewards.
