### PR TITLE
feat(reddog): symbol-aware direct-read line windows (judgment lane 3)

### DIFF
--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,23 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-05 - REDDOG_SYMBOL_AWARE_EXCERPT_DEPTH_PHASE1 (symbol line windows reach the model, 0.3.43)
+
+- A required direct-read target may now be `path#symbol`. The Python bundle layer
+  (holo_index/cli/commands/bundle_json.py) returns a bounded LINE WINDOW around the symbol's
+  DEFINITION instead of the head-clip of the first 12KB, so a symbol defined deep in a large file
+  (e.g. `build_foundup` / `extract_foundup`) actually reaches the model.
+- Extension wiring: the full `path#symbol` token is forwarded to `--bundle-must-include` verbatim
+  (a pathless `symbol:` prefix is still excluded, unchanged). `stripSymbolSuffix(target)` normalizes
+  `path#symbol` -> the bare path for all recall/resolve comparisons (`requiredTargetMatchesLocation`,
+  the resolver, the required-target context-proof denominator), because the fetched hit's location is
+  the bare path. `extractTargetTokensFromLine` shape-checks the PATH portion so a `path#symbol` target
+  parses. `stripSymbolSuffix` is bounded/anchored (ReDoS-safe).
+- Extension contract test extended: stripSymbolSuffix behavior, recall-by-bare-path for a `path#symbol`
+  target, forwarded `--bundle-must-include` token, end-to-end `parseRequiredTargetPaths`, and the
+  unchanged `symbol:`-prefix exclusion.
+- Gate: VERIFIED_READY draft PR only (do NOT self-merge). Judgment-lane slice 3 (after #933/#934).
+
 ## 2026-07-05 - REDDOG_REPAIR_PRESERVES_EVIDENCE_PHASE1 (repair preserves Determine evidence, 0.3.42)
 
 - The schema-repair pass now PRESERVES a primary Determine answer block. A repair exists to ADD missing

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.42
+Version: 0.3.43
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.42';
+const EXTENSION_VERSION = '0.3.43';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -391,6 +391,16 @@ function normalizeTargetPath(raw) {
   return s.slice(start, end).trim();
 }
 
+// REDDOG_SYMBOL_AWARE_EXCERPT_DEPTH_PHASE1: a required direct-read target may be `path#symbol` (the
+// Python bundle layer returns a bounded line window around the symbol's DEFINITION). The full
+// `path#symbol` string is forwarded to --bundle-must-include, but the fetched hit's location is the
+// BARE path, so recall/resolve/denominator comparisons must strip a trailing `#<identifier>` suffix.
+// Only a valid identifier suffix is stripped (mirrors the Python _SYMBOL_RE); a real '#' inside a
+// path is left intact. The regex is bounded/anchored (ReDoS-safe).
+function stripSymbolSuffix(target) {
+  return String(target || '').replace(/#[A-Za-z_][A-Za-z0-9_]{0,127}$/, '');
+}
+
 // Extract repo-relative path/glob tokens from a single list line. A line may hold
 // one path or a slash-delimited "a / b / c" alternatives list (as prompts often
 // phrase them). Symbol tokens (symbol:foo) are preserved verbatim.
@@ -412,8 +422,11 @@ function extractTargetTokensFromLine(line) {
     if (!candidate) {
       continue;
     }
-    // A target must look like a path/glob or a bare source filename.
-    if (/[\/]/.test(candidate) || /\.[a-z0-9]{1,6}$/i.test(candidate) || /[*?]/.test(candidate)) {
+    // A target must look like a path/glob or a bare source filename. Shape-check the PATH portion
+    // (a `path#symbol` target's shape lives in the path, not the symbol suffix) but keep the FULL
+    // `path#symbol` token so the symbol is forwarded to the direct-read layer.
+    const pathPortion = stripSymbolSuffix(candidate);
+    if (/[\/]/.test(pathPortion) || /\.[a-z0-9]{1,6}$/i.test(pathPortion) || /[*?]/.test(pathPortion)) {
       tokens.push(candidate);
     }
   }
@@ -511,7 +524,7 @@ function inferRecallTargetPaths(taskText) {
 // actually present in the bundle. Self-file locations are excluded by the caller
 // before this runs so retrieving RedDog itself cannot satisfy a required target.
 function requiredTargetMatchesLocation(target, location) {
-  const want = normalizeTargetPath(target).toLowerCase();
+  const want = stripSymbolSuffix(normalizeTargetPath(target)).toLowerCase();
   const have = String(location || '').replace(/\\/g, '/').toLowerCase();
   if (!want || !have) {
     return false;
@@ -2455,7 +2468,7 @@ function buildRequiredTargetProtectedSection(requiredTargets, directReadSection)
     if (!target || target.toLowerCase().startsWith('symbol:')) {
       continue;
     }
-    const wantLower = target.toLowerCase();
+    const wantLower = stripSymbolSuffix(target).toLowerCase();  // `path#symbol` resolves by path
     let match = hitByPath.get(wantLower);
     if (!match) {
       // basename / suffix fallback so a directoried required token still resolves the
@@ -2577,7 +2590,7 @@ function assembleFinalBoundedContext(headSections, protectedText, lowerSections)
 // symbols excluded) so a phantom marker cannot inflate the denominator either.
 function computeRequiredTargetContextProof(finalText, requiredTargets, protectedMeta) {
   const targets = Array.isArray(requiredTargets)
-    ? requiredTargets.map((t) => normalizeTargetPath(t)).filter((t) => t && !t.toLowerCase().startsWith('symbol:'))
+    ? requiredTargets.map((t) => stripSymbolSuffix(normalizeTargetPath(t))).filter((t) => t && !t.toLowerCase().startsWith('symbol:'))
     : [];
   const text = String(finalText || '');
   // AUTHORITATIVE fetched/packed set: only paths the packer actually included get a section.
@@ -4035,6 +4048,8 @@ module.exports = {
   parseRequiredTargetPaths,
   isSelfFileLocation,
   requiredTargetMatchesLocation,
+  stripSymbolSuffix,
+  extractTargetTokensFromLine,
   holoIndexMetaFromBundle,
   holoIndexOutput,
   buildMustIncludeArgs,

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups®Agent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.42",
+    "version":  "0.3.43",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -197,8 +197,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.42', 'package version must be 0.3.42');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.42'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.43', 'package version must be 0.3.43');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.43'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups®Agent', 'display name must be Foundups®Agent');
 includes(JSON.stringify(pkg), 'Foundups®Agent: Open', 'command title must use Foundups®Agent');
@@ -215,7 +215,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.42', 'README version mismatch');
+includes(readme, 'Version: 0.3.43', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -1568,7 +1568,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.42'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.43'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -1582,7 +1582,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.42'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.43'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -1594,7 +1594,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.42'", 'bounded context must include extension.js source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.43'", 'bounded context must include extension.js source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');
@@ -1947,5 +1947,31 @@ if (rgProtect && rgProtect.ok) {
 } else {
   console.log('  repair-evidence guard bridge unavailable (python) -- source wiring + presence checks still enforced');
 }
+
+// REDDOG_SYMBOL_AWARE_EXCERPT_DEPTH_PHASE1: a required direct-read target may be `path#symbol`.
+// The extension forwards the FULL token to --bundle-must-include (so the Python bundle layer returns
+// a bounded line window around the symbol's definition) but matches recall/resolve by the BARE path.
+assert.strictEqual(orchestrator.stripSymbolSuffix('modules/x/foo.py#build_foundup'), 'modules/x/foo.py',
+  'stripSymbolSuffix removes a trailing #identifier');
+assert.strictEqual(orchestrator.stripSymbolSuffix('modules/x/foo.py'), 'modules/x/foo.py',
+  'stripSymbolSuffix leaves a plain path untouched');
+assert.strictEqual(orchestrator.stripSymbolSuffix('weird#name.md'), 'weird#name.md',
+  'stripSymbolSuffix leaves a non-identifier # suffix (real path) untouched');
+// recall: a path#symbol required target is satisfied by the fetched BARE-path location
+assert(orchestrator.requiredTargetMatchesLocation('modules/x/foo.py#build_foundup', 'modules/x/foo.py'),
+  'path#symbol recall matches the bare-path fetched location');
+// the token survives parsing (list marker stripped upstream) and end-to-end block parsing
+const symToks = orchestrator.extractTargetTokensFromLine('modules/x/hermes.py#build_foundup');
+assert(symToks.includes('modules/x/hermes.py#build_foundup'), 'path#symbol token is parsed and kept');
+const symBlock = orchestrator.parseRequiredTargetPaths(
+  'Audit.\n\nRequired direct-read targets:\n- modules/x/hermes.py#build_foundup\n- modules/x/plain.py\n');
+assert(symBlock.includes('modules/x/hermes.py#build_foundup') && symBlock.includes('modules/x/plain.py'),
+  'parseRequiredTargetPaths keeps a path#symbol target end-to-end');
+const symArgs = orchestrator.buildMustIncludeArgs(['modules/x/hermes.py#build_foundup']);
+assert(symArgs.includes('modules/x/hermes.py#build_foundup'),
+  'path#symbol is forwarded to --bundle-must-include (not dropped)');
+// a pathless `symbol:` prefix is still excluded (unchanged)
+assert(!orchestrator.buildMustIncludeArgs(['symbol:create_foundup']).includes('symbol:create_foundup'),
+  'pathless symbol: prefix is still excluded from direct-read');
 
 console.log('Foundups®Agent extension contract checks passed.');

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,19 @@
 # HoloIndex Package ModLog
 
+## [2026-07-05] REDDOG_SYMBOL_AWARE_EXCERPT_DEPTH_PHASE1 (judgment lane, slice 3)
+
+**Agent**: 0102 (RedDog Architect, Judgment lane) | Commander: 012 | Gate: VERIFIED_READY draft PR (do NOT self-merge)
+**WSP**: 00, 15, 22, 50, 64, 84, 97 | **Base**: `1cb605717`
+
+- `cli/commands/bundle_json.py`: the governed direct-read now supports a `path#symbol` target -- instead of the HEAD-CLIP of the first 12KB, it returns a bounded LINE WINDOW around the symbol's DEFINITION, so a symbol defined deep in a large file (e.g. `build_foundup` / `extract_foundup` past the 12KB head) actually reaches the model. Motivation: audit `REDDOG_FOUNDUP_CREATION_EXECUTION_PATH_AUDIT_PHASE1.md` s6 named this SPECIFIED_NOT_IMPLEMENTED ("misses build_foundup/extract_foundup line windows").
+- `_split_path_symbol` splits `path#symbol` -> (path, symbol) AFTER normalization; the symbol is an OPAQUE, validated identifier (`_SYMBOL_RE=^[A-Za-z_][A-Za-z0-9_]{0,127}$`) and is NEVER a path segment -- ALL security gates (deny basenames/extensions/segments, traversal, absolute, realpath containment/symlink-escape, resolved-basename re-deny, binary NUL sniff) run on the PATH ONLY.
+- `_locate_symbol_line`: bounded, DEFINITION-preferring, WORD-boundary locator (`build_foundup` != `build_foundup_v2`; prefers `def/class/function/const/... SYMBOL` or `SYMBOL =/:/(` over a call-site; case-sensitive). Prior art `core/introspection_engine.py:_find_symbol_line` NOT reused (it reads the WHOLE file + first-substring) because this module requires a BOUNDED scan (`DIRECT_READ_SYMBOL_SCAN_BYTES=262144`, transient, never inlined) + definition preference (WSP 84 note documented in-code).
+- `_read_symbol_window`: window grows from the def line FIRST then body forward then lead context, clamped to the per-file cap + total budget; the def line is ALWAYS present or it fail-closes `symbol_window_empty` -> head-clip fallback (never lead-only content labelled a success). Fallbacks (symbol invalid/not-found/binary/read-error) degrade to the head-clip, never crash. Dedup: a GENUINE window keys on case-sensitive `(path, symbol)`; a fallback keys on the bare path (so N absent symbols cannot redraw a per-file cap); `DIRECT_READ_MAX_SYMBOLS_PER_PATH=8` bounds slot exhaustion. Telemetry `direct_read_symbol_windows`. hit['location'] stays the bare path (recall stays path-based).
+- **4-lens adversarial CoR (symbol-injection / redos-scan / window-integrity / fallback-dedup-budget), 4 rounds, effort:high.** R1 def-line-exceeds-cap (false success w/ lead-only), R2 case-distinct-symbol collapse, R3 fallback-dedup budget + per-path target amplification -- all folded. **R4: all 4 lenses SAFE, 0 findings.**
+- TEST `tests/test_reddog_extension_bundle_recall.py` (+15 symbol tests): deep-past-head window; lead context; oversized-def fallback; not-found/invalid fallback; security-deny on the path portion; two-symbols + case-distinct both window; binary; scan-cap; fallback-dedups-on-path; amplification cannot blow the budget; split/locate units. 29 pass (2 unrelated pre-existing lexical-ranking failures).
+- WIRED into `extensions/foundups_advisory_workers/extension.js` (0.3.42 -> 0.3.43): `stripSymbolSuffix` normalizes `path#symbol` -> path for recall (`requiredTargetMatchesLocation`), resolve, and the context-proof denominator; `extractTargetTokensFromLine` shape-checks the path portion; the full `path#symbol` token is forwarded to `--bundle-must-include` (a pathless `symbol:` prefix stays excluded). Extension contract test extended (stripSymbolSuffix / recall-by-path / forwarded token / parse end-to-end).
+- Judgment lane: 1 DETERMINE_CONTRACT #933 -> 2 REPAIR_PRESERVES_EVIDENCE #934 -> **3 (this)** -> 4 ADVERSARIAL_VERIFIER_PANEL -> 5 FOUNDUP_INTAKE_PACKET_MODE. VERIFIED_READY draft PR only; not merged.
+
 ## [2026-05-30] HOLOINDEX_T1_RANKING_QUALITY_PHASE1 (W6 resume)
 
 **Agent**: W6 (0102)

--- a/holo_index/cli/commands/bundle_json.py
+++ b/holo_index/cli/commands/bundle_json.py
@@ -7,9 +7,10 @@ Self-contained lexical search + artifact snapshot + JSON bundle output.
 """
 
 import os
+import re
 import sys
 import logging
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any, Optional, Tuple
 
 
 def _env_truthy(key: str, default: str = "false") -> bool:
@@ -37,6 +38,21 @@ DIRECT_READ_PER_FILE_BYTES = 12000
 DIRECT_READ_TOTAL_BUDGET_BYTES = 96000
 # Hard cap on how many targets we will even attempt (defensive; ranked by order).
 DIRECT_READ_MAX_TARGETS = 40
+
+# REDDOG_SYMBOL_AWARE_EXCERPT_DEPTH_PHASE1: when a target is `path#symbol`, return a bounded LINE
+# WINDOW around the symbol's DEFINITION instead of the head-clip, so a symbol defined deep in a large
+# file (e.g. build_foundup / extract_foundup past the 12KB head) actually reaches the model. The
+# window is still clamped to DIRECT_READ_PER_FILE_BYTES + the total budget. To LOCATE the symbol we
+# may scan past the head, but only up to a hard cap (transient; never inlined) so a pathological file
+# cannot force an unbounded read. Symbol is an OPAQUE search key -- never a path segment.
+DIRECT_READ_SYMBOL_SCAN_BYTES = 262144   # max bytes scanned to LOCATE a symbol (not inlined)
+DIRECT_READ_SYMBOL_LEAD_LINES = 6        # context lines kept BEFORE the def line (decorators/docstring)
+# Cap symbol targets per file so a caller naming MANY (plausible-but-absent) symbols of ONE file
+# cannot consume all target slots (DIRECT_READ_MAX_TARGETS) and starve other required targets.
+DIRECT_READ_MAX_SYMBOLS_PER_PATH = 8
+# A valid symbol is a bounded identifier. Rejecting anything else keeps the symbol an opaque, safe
+# search key (no regex-injection, no path traversal via the '#' suffix).
+_SYMBOL_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
 
 # HARD-DENY basenames (exact match, case-insensitive).
 DIRECT_READ_DENY_BASENAMES = frozenset({
@@ -191,6 +207,111 @@ def _read_bounded_direct_read(real_path, per_file_cap: int, remaining_budget: in
     }
 
 
+def _split_path_symbol(normalized: str) -> Tuple[str, Optional[str]]:
+    """Split a normalized `path#symbol` target into (path, symbol).
+
+    The symbol is an OPAQUE search key -- it is returned separately and NEVER used as a path
+    segment (the deny/containment gates run on the path only). A target with no '#', or whose
+    suffix is not a valid identifier, is returned as (target, None) so the whole string is
+    treated as a path (backward-compatible; a real filename containing '#' is not a symbol).
+    """
+    s = str(normalized or "")
+    if "#" not in s:
+        return s, None
+    path_part, _, sym = s.partition("#")
+    sym = sym.strip()
+    if _SYMBOL_RE.match(sym):
+        return path_part, sym
+    return s, None
+
+
+def _locate_symbol_line(lines: List[str], symbol: str) -> Optional[int]:
+    """0-based index of the best line for `symbol`: PREFER a definition line (a def/class/function/
+    const/... keyword immediately followed by the symbol, or the symbol at line start followed by
+    '=' / ':' / '('), else the FIRST whole-word occurrence. Matching is WORD-boundary (not
+    substring) so 'build_foundup' does not match 'build_foundup_v2' or 'extract_build_foundup'.
+
+    Prior art: holo_index/core/introspection_engine.py:_find_symbol_line (first-substring, reads the
+    WHOLE file). Not reused here: this module requires a BOUNDED scan (the direct-read security model)
+    and a DEFINITION preference (head-clip already had the first mention).
+    """
+    esc = re.escape(symbol)
+    word = re.compile(r"(?<![A-Za-z0-9_])" + esc + r"(?![A-Za-z0-9_])")
+    kw_def = re.compile(
+        r"\b(?:async\s+def|def|class|function|func|fn|const|let|var|type|interface|struct|enum)\s+"
+        + esc + r"(?![A-Za-z0-9_])")
+    assign_def = re.compile(
+        r"^\s*(?:export\s+|default\s+|public\s+|private\s+|protected\s+|static\s+|final\s+)*"
+        + esc + r"\s*[=:(]")
+    first_occ: Optional[int] = None
+    for i, line in enumerate(lines):
+        if not word.search(line):
+            continue
+        if first_occ is None:
+            first_occ = i
+        if kw_def.search(line) or assign_def.search(line):
+            return i
+    return first_occ
+
+
+def _read_symbol_window(real_path, symbol, per_file_cap: int, remaining_budget: int):
+    """Read a bounded LINE WINDOW around `symbol`'s definition (same return contract as
+    _read_bounded_direct_read). Fail-closed omitted_reason values ('symbol_invalid',
+    'symbol_not_found', 'symbol_window_empty', 'binary', 'read_error', 'budget_exhausted') tell the
+    caller to fall back to the head-clip. The scan to LOCATE the symbol is bounded by
+    DIRECT_READ_SYMBOL_SCAN_BYTES; the returned window is clamped to the per-file/remaining cap and
+    ALWAYS includes the definition line (forward from the def line first, then lead context)."""
+    from pathlib import Path as _Path
+    if not (isinstance(symbol, str) and _SYMBOL_RE.match(symbol)):
+        return {"content": "", "bytes": 0, "truncated": False, "omitted_reason": "symbol_invalid"}
+    cap = max(0, min(per_file_cap, remaining_budget))
+    if cap <= 0:
+        return {"content": "", "bytes": 0, "truncated": False, "omitted_reason": "budget_exhausted"}
+    try:
+        with open(_Path(real_path), "rb") as fh:
+            raw = fh.read(DIRECT_READ_SYMBOL_SCAN_BYTES + 1)
+    except Exception:
+        return {"content": "", "bytes": 0, "truncated": False, "omitted_reason": "read_error"}
+    if b"\x00" in raw:  # binary sniff on the bytes we actually read
+        return {"content": "", "bytes": 0, "truncated": False, "omitted_reason": "binary"}
+    text = raw[:DIRECT_READ_SYMBOL_SCAN_BYTES].decode("utf-8", errors="replace")
+    lines = text.split("\n")
+    idx = _locate_symbol_line(lines, symbol)
+    if idx is None:
+        return {"content": "", "bytes": 0, "truncated": False, "omitted_reason": "symbol_not_found"}
+
+    last = len(lines) - 1
+
+    def _enc(j: int) -> Tuple[str, int]:
+        piece = lines[j] + ("\n" if j < last else "")
+        return piece, len(piece.encode("utf-8"))
+
+    chosen = {}
+    used = 0
+    for j in range(idx, len(lines)):            # def line FIRST (guaranteed), then body forward
+        piece, pb = _enc(j)
+        if used + pb > cap:
+            break
+        chosen[j] = piece
+        used += pb
+    for j in range(idx - 1, max(-1, idx - 1 - DIRECT_READ_SYMBOL_LEAD_LINES), -1):  # lead context
+        piece, pb = _enc(j)
+        if used + pb > cap:
+            break
+        chosen[j] = piece
+        used += pb
+    if idx not in chosen:
+        # The DEFINITION line itself did not fit the cap (e.g. a >12KB one-line def, a big inline
+        # literal, or a minified single-line file). The lead loop may have added shorter preceding
+        # lines, but shipping lead-ONLY context labeled as a successful symbol window would hide the
+        # very symbol RedDog asked for (and falsely satisfy recall). Fail-closed -> head-clip fallback.
+        return {"content": "", "bytes": 0, "truncated": False, "omitted_reason": "symbol_window_empty"}
+    lo, hi = min(chosen), max(chosen)           # contiguous by construction (grown from idx both ways)
+    content = "".join(chosen[j] for j in range(lo, hi + 1))
+    truncated = (lo > 0) or (hi < last)
+    return {"content": content, "bytes": used, "truncated": truncated, "omitted_reason": "none"}
+
+
 def _direct_read_fetch(repo_root, requested_paths, seen_locations=None):
     """Governed direct-read-by-path fetch (slice 2/3).
 
@@ -208,31 +329,47 @@ def _direct_read_fetch(repo_root, requested_paths, seen_locations=None):
         "direct_read_rejected": [],
         "direct_read_bytes": 0,
         "direct_read_truncated": [],
+        "direct_read_symbol_windows": [],  # {path, symbol} per symbol-windowed fetch (proof it fired)
         "per_file_cap": DIRECT_READ_PER_FILE_BYTES,
         "total_budget": DIRECT_READ_TOTAL_BUDGET_BYTES,
     }
     hits: List[Dict[str, Any]] = []
 
-    # De-duplicate while preserving prompt order; cap total attempted targets.
-    ordered: List[str] = []
+    # De-duplicate while preserving prompt order; cap total attempted targets. A `path#symbol` target
+    # is split into (path, symbol) HERE: the symbol is an opaque key, keyed alongside the path so two
+    # symbols of the same file each get their own window (and are not collapsed with a plain-path hit).
+    ordered: List[Tuple[str, Optional[str]]] = []
     ordered_seen = set()
+    per_path_symbols: Dict[str, int] = {}
     for raw in (requested_paths or []):
-        rel = _normalize_direct_read_path(raw)
+        norm = _normalize_direct_read_path(raw)
+        rel, symbol = _split_path_symbol(norm)
         if not rel:
             telemetry["direct_read_rejected"].append({"path": str(raw), "reason": "path_missing"})
             continue
-        key = rel.lower()
+        # Path is case-folded (Windows), but the symbol is CASE-SENSITIVE (the locator matches
+        # case-sensitively) -- 'Config' (class) and 'config' (var) are distinct symbols and must
+        # each get their own window; lowercasing the symbol would silently collapse them.
+        key = (rel.lower(), symbol or "")
         if key in ordered_seen:
             continue
+        # Bound how many symbol targets one file may contribute, so many (plausible-but-absent)
+        # symbols of one file cannot fill all target slots and starve other required targets.
+        if symbol:
+            if per_path_symbols.get(rel.lower(), 0) >= DIRECT_READ_MAX_SYMBOLS_PER_PATH:
+                telemetry["direct_read_rejected"].append(
+                    {"path": rel + "#" + symbol, "reason": "too_many_symbols_for_path"})
+                continue
+            per_path_symbols[rel.lower()] = per_path_symbols.get(rel.lower(), 0) + 1
         ordered_seen.add(key)
-        ordered.append(rel)
+        ordered.append((rel, symbol))
     if len(ordered) > DIRECT_READ_MAX_TARGETS:
-        for extra in ordered[DIRECT_READ_MAX_TARGETS:]:
-            telemetry["direct_read_rejected"].append({"path": extra, "reason": "too_many_targets"})
+        for extra_rel, _extra_sym in ordered[DIRECT_READ_MAX_TARGETS:]:
+            telemetry["direct_read_rejected"].append({"path": extra_rel, "reason": "too_many_targets"})
         ordered = ordered[:DIRECT_READ_MAX_TARGETS]
 
     remaining = DIRECT_READ_TOTAL_BUDGET_BYTES
-    for rel in ordered:
+    for rel, symbol in ordered:
         # 1) lexical hard-deny + traversal/absolute check.
         deny = _direct_read_deny_reason(rel)
         if deny:
@@ -257,31 +394,52 @@ def _direct_read_fetch(repo_root, requested_paths, seen_locations=None):
         if remaining <= 0:
             telemetry["direct_read_rejected"].append({"path": rel, "reason": "budget_exhausted"})
             continue
-        # 4) bounded read.
-        snippet = _read_bounded_direct_read(real, DIRECT_READ_PER_FILE_BYTES, remaining)
+        # 4) bounded read. A `path#symbol` target reads a bounded LINE WINDOW around the symbol's
+        #    definition; if the symbol is not locatable (or the window is unusable) it falls back to
+        #    the head-clip so nothing regresses. A plain path always head-clips (unchanged).
+        symbol_windowed = False
+        if symbol:
+            snippet = _read_symbol_window(real, symbol, DIRECT_READ_PER_FILE_BYTES, remaining)
+            if snippet["content"]:
+                symbol_windowed = True
+            else:
+                snippet = _read_bounded_direct_read(real, DIRECT_READ_PER_FILE_BYTES, remaining)
+        else:
+            snippet = _read_bounded_direct_read(real, DIRECT_READ_PER_FILE_BYTES, remaining)
         if not snippet["content"]:
             if snippet["omitted_reason"] not in ("none",):
                 telemetry["direct_read_rejected"].append({"path": rel, "reason": snippet["omitted_reason"]})
             continue
+        # Content dedup keys on the ACTUAL read MODE, not on whether a symbol was requested. A GENUINE
+        # symbol window keys on (path, symbol) [case-sensitive symbol] so two distinct real symbols of
+        # one file both land and neither collapses against a plain-path code_hit. A symbol target that
+        # FELL BACK to the head-clip produces path-based content identical to the plain path's, so it
+        # keys on the bare path -- colliding with the plain-path hit and with seen_locations (code_hits)
+        # -- so N absent symbols of one file cannot each redraw a per-file cap and blow the total budget.
+        seen_key = (rel.lower() + "#" + symbol) if symbol_windowed else rel.lower()
+        if seen_key in seen:
+            continue
+        seen.add(seen_key)
         remaining -= snippet["bytes"]
         telemetry["direct_read_bytes"] += snippet["bytes"]
         telemetry["direct_read_paths"].append(rel)
         if snippet["truncated"]:
             telemetry["direct_read_truncated"].append({"path": rel, "bytes": snippet["bytes"]})
-        if rel.lower() not in seen:
-            seen.add(rel.lower())
-            hits.append({
-                "need": "direct-read target: " + rel,
-                "location": rel,
-                "similarity": "100.0%",
-                "cube": None,
-                "type": "code",
-                "priority": 1,
-                "direct_read": True,
-                "content": snippet["content"],
-                "content_bytes": snippet["bytes"],
-                "content_truncated": snippet["truncated"],
-            })
+        if symbol_windowed:
+            telemetry["direct_read_symbol_windows"].append({"path": rel, "symbol": symbol})
+        hits.append({
+            "need": "direct-read target: " + rel + ("#" + symbol if symbol else ""),
+            "location": rel,
+            "similarity": "100.0%",
+            "cube": None,
+            "type": "code",
+            "priority": 1,
+            "direct_read": True,
+            "symbol": symbol if symbol_windowed else None,
+            "content": snippet["content"],
+            "content_bytes": snippet["bytes"],
+            "content_truncated": snippet["truncated"],
+        })
     telemetry["direct_read_fallback_used"] = len(telemetry["direct_read_paths"]) > 0
     return {"telemetry": telemetry, "hits": hits}
 

--- a/holo_index/tests/test_reddog_extension_bundle_recall.py
+++ b/holo_index/tests/test_reddog_extension_bundle_recall.py
@@ -20,8 +20,12 @@ from holo_index.cli.commands.bundle_json import (
     _direct_read_deny_reason,
     _normalize_direct_read_path,
     _resolve_within_repo,
+    _split_path_symbol,
+    _locate_symbol_line,
+    _read_symbol_window,
     DIRECT_READ_PER_FILE_BYTES,
     DIRECT_READ_TOTAL_BUDGET_BYTES,
+    DIRECT_READ_SYMBOL_SCAN_BYTES,
 )
 
 EXTENSION_JS = REPO_ROOT / "extensions" / "foundups_advisory_workers" / "extension.js"
@@ -405,6 +409,221 @@ def test_direct_read_symlink_escape_rejected(tmp_path):
     assert reasons.get("escape_link.txt") == "outside_root"
     joined = "\n".join(h.get("content", "") for h in result["hits"])
     assert "SYNTHETIC-outside-do-not-read" not in joined
+
+
+# --- REDDOG_SYMBOL_AWARE_EXCERPT_DEPTH_PHASE1 (slice 3/3): symbol line windows ----------------
+def _deep_symbol_repo(tmp_path):
+    """A synthetic repo with a file whose symbol is defined DEEP past the 12KB head-clip."""
+    fake_root = tmp_path / "repo"
+    (fake_root / "src").mkdir(parents=True)
+    rel = "src/hermes.py"
+    head = "# header\n" + ("# filler padding padding padding padding padding\n" * 400)  # ~18KB head
+    assert len(head.encode("utf-8")) > DIRECT_READ_PER_FILE_BYTES
+    body = ("def build_foundup(job):\n    return extract_foundup(job)  # DEEP-DEF-MARKER\n"
+            + ("# trailing filler\n" * 100))
+    (fake_root / rel).write_text(head + body, encoding="utf-8")
+    return fake_root, rel
+
+
+def test_split_path_symbol_forms():
+    assert _split_path_symbol("modules/x/y.py#build_foundup") == ("modules/x/y.py", "build_foundup")
+    assert _split_path_symbol("modules/x/y.py") == ("modules/x/y.py", None)
+    assert _split_path_symbol("notes#draft.md") == ("notes#draft.md", None)  # suffix not an identifier
+    assert _split_path_symbol("a#b#c") == ("a#b#c", None)                    # ambiguous -> whole path
+    # the symbol is opaque: an absolute/traversal PATH portion is preserved for the deny gate
+    assert _split_path_symbol("/etc/passwd#foo") == ("/etc/passwd", "foo")
+    assert _split_path_symbol("../../.env#foo") == ("../../.env", "foo")
+
+
+def test_locate_symbol_line_prefers_definition_word_boundary():
+    lines = [
+        "import build_foundup_v2            # substring, NOT this",
+        "x = build_foundup()                # a call-site (first occurrence)",
+        "def extract_build_foundup(): pass  # substring, NOT this",
+        "def build_foundup(job):            # THE definition",
+        "    return job",
+    ]
+    assert _locate_symbol_line(lines, "build_foundup") == 3          # def preferred over call-site
+    # word-boundary: a symbol only present as a substring is not matched
+    assert _locate_symbol_line(["build_foundup_v2 = 1"], "build_foundup") is None
+    # JS/TS style definitions
+    assert _locate_symbol_line(["const buildFoundup = () => {}"], "buildFoundup") == 0
+    assert _locate_symbol_line(["export function buildFoundup() {}"], "buildFoundup") == 0
+
+
+def test_symbol_window_reaches_symbol_deep_past_head(tmp_path):
+    """CORE FIX: a symbol defined past the 12KB head-clip reaches the model via a line window,
+    while the plain path (head-clip) misses it."""
+    fake_root, rel = _deep_symbol_repo(tmp_path)
+    result = _direct_read_fetch(fake_root, [rel + "#build_foundup", rel])
+    by_need = {h["need"]: h for h in result["hits"]}
+    win = by_need["direct-read target: " + rel + "#build_foundup"]
+    plain = by_need["direct-read target: " + rel]
+    assert "DEEP-DEF-MARKER" in win["content"] and win["symbol"] == "build_foundup"
+    assert win["content_bytes"] <= DIRECT_READ_PER_FILE_BYTES
+    assert "DEEP-DEF-MARKER" not in plain["content"] and plain["symbol"] is None  # head-clip misses it
+    assert {"path": rel, "symbol": "build_foundup"} in result["telemetry"]["direct_read_symbol_windows"]
+
+
+def test_symbol_window_lead_context_included(tmp_path):
+    """The window keeps a few lead lines (decorators/docstring) before the def and stays contiguous."""
+    fake_root = tmp_path / "repo"
+    (fake_root / "src").mkdir(parents=True)
+    rel = "src/w.py"
+    (fake_root / rel).write_text(
+        "\n".join([f"# lead {i}" for i in range(20)] + ["@decorator", "def target(x):", "    return x"])
+        + "\n", encoding="utf-8")
+    r = _direct_read_fetch(fake_root, [rel + "#target"])
+    content = r["hits"][0]["content"]
+    assert "@decorator" in content and "def target(x):" in content
+    assert "# lead 19" in content  # nearest lead line kept as context
+
+
+def test_symbol_not_found_falls_back_to_head_clip(tmp_path):
+    fake_root = tmp_path / "repo"
+    (fake_root / "src").mkdir(parents=True)
+    rel = "src/f.py"
+    (fake_root / rel).write_text("def other():\n    return 1\n", encoding="utf-8")
+    r = _direct_read_fetch(fake_root, [rel + "#nonexistent_symbol"])
+    assert len(r["hits"]) == 1
+    assert r["hits"][0]["content"].startswith("def other():")     # head-clip fallback
+    assert r["hits"][0]["symbol"] is None                          # not a symbol window
+    assert r["telemetry"]["direct_read_symbol_windows"] == []
+
+
+def test_invalid_symbol_falls_back_to_head_clip(tmp_path):
+    fake_root = tmp_path / "repo"
+    (fake_root / "src").mkdir(parents=True)
+    rel = "src/g.py"
+    (fake_root / rel).write_text("def build_foundup():\n    return 1\n", encoding="utf-8")
+    # a non-identifier suffix is not split as a symbol -> whole '#...' treated as a path -> not_a_file
+    r = _direct_read_fetch(fake_root, [rel + "#not a valid symbol!"])
+    assert r["telemetry"]["direct_read_symbol_windows"] == []
+
+
+def test_symbol_split_does_not_bypass_security_deny(tmp_path):
+    """The deny/containment gates run on the PATH portion only; a symbol suffix cannot smuggle a
+    denied path past them."""
+    fake_root = tmp_path / "repo"
+    (fake_root / "src").mkdir(parents=True)
+    (fake_root / ".env").write_text("DUMMY=synthetic-not-a-real-secret\n", encoding="utf-8")
+    (fake_root / "src" / "ok.py").write_text("def build_foundup():\n    return 1\n", encoding="utf-8")
+    r = _direct_read_fetch(fake_root, [".env#build_foundup", "/etc/passwd#x",
+                                       "../../outside.py#y", "src/ok.py#build_foundup"])
+    reasons = {t["path"]: t["reason"] for t in r["telemetry"]["direct_read_rejected"]}
+    assert reasons.get(".env") == "denied_basename"
+    assert reasons.get("/etc/passwd") == "absolute_path"
+    assert reasons.get("../../outside.py") == "traversal"
+    joined = "\n".join(h.get("content", "") for h in r["hits"])
+    assert "synthetic-not-a-real-secret" not in joined            # denied file never read
+    assert "def build_foundup():" in joined                        # the safe symbol target still fetched
+
+
+def test_two_symbols_same_file_both_windowed(tmp_path):
+    fake_root = tmp_path / "repo"
+    (fake_root / "src").mkdir(parents=True)
+    rel = "src/two.py"
+    (fake_root / rel).write_text(
+        "def build_foundup():\n    return 1\n\n\ndef extract_foundup():\n    return 2\n", encoding="utf-8")
+    r = _direct_read_fetch(fake_root, [rel + "#build_foundup", rel + "#extract_foundup"])
+    syms = {w["symbol"] for w in r["telemetry"]["direct_read_symbol_windows"]}
+    assert syms == {"build_foundup", "extract_foundup"}
+    assert len(r["hits"]) == 2
+    for h in r["hits"]:
+        assert h["location"] == rel                                # location stays the bare path
+
+
+def test_case_distinct_symbols_same_file_both_windowed(tmp_path):
+    """CoR R2 (major): case-differing symbols ('Config' class vs 'config' factory) are DISTINCT
+    (matching is case-sensitive) and must each get their own window -- the dedup key must not
+    lowercase the symbol."""
+    fake_root = tmp_path / "repo"
+    (fake_root / "src").mkdir(parents=True)
+    rel = "src/c.py"
+    (fake_root / rel).write_text(
+        "class Config:  # UPPER-CONFIG-MARKER\n    pass\n\n\ndef config():  # lower-config-marker\n    return 1\n",
+        encoding="utf-8")
+    r = _direct_read_fetch(fake_root, [rel + "#Config", rel + "#config"])
+    syms = {w["symbol"] for w in r["telemetry"]["direct_read_symbol_windows"]}
+    assert syms == {"Config", "config"}
+    joined = "\n".join(h["content"] for h in r["hits"])
+    assert "UPPER-CONFIG-MARKER" in joined and "lower-config-marker" in joined
+
+
+def test_symbol_window_binary_file_omitted(tmp_path):
+    fake_root = tmp_path / "repo"
+    (fake_root / "src").mkdir(parents=True)
+    rel = "src/b.py"
+    (fake_root / rel).write_bytes(b"def build_foundup():\x00\x01binary\n")
+    r = _direct_read_fetch(fake_root, [rel + "#build_foundup"])
+    assert r["hits"] == []
+    reasons = {t["path"]: t["reason"] for t in r["telemetry"]["direct_read_rejected"]}
+    assert reasons.get(rel) == "binary"
+
+
+def test_symbol_window_oversized_def_line_falls_back_not_lead_only(tmp_path):
+    """CoR R1 (blocker/major x3): a def line LONGER than the per-file cap must NOT ship lead-only
+    context labeled as a successful symbol window (the symbol would be absent while recall reads as
+    satisfied). It falls back to the head-clip and is NOT reported as a symbol window."""
+    fake_root = tmp_path / "repo"
+    (fake_root / "src").mkdir(parents=True)
+    rel = "src/f.py"
+    lead = "# leadA\n# leadB\n# leadC\n"
+    big_def = "def build_foundup(" + ("a," * 7000) + "):  # DEEP-DEF-MARKER\n"  # >12KB single def line
+    assert len(big_def.encode("utf-8")) > DIRECT_READ_PER_FILE_BYTES
+    (fake_root / rel).write_text(lead + big_def + "    return 1\n", encoding="utf-8")
+    # unit: the window read reports symbol_window_empty (def did not fit)
+    snip = _read_symbol_window(fake_root / rel, "build_foundup", DIRECT_READ_PER_FILE_BYTES,
+                               DIRECT_READ_TOTAL_BUDGET_BYTES)
+    assert snip["omitted_reason"] == "symbol_window_empty"
+    # end-to-end: falls back to head-clip, NOT a symbol window, and never ships lead-only content
+    r = _direct_read_fetch(fake_root, [rel + "#build_foundup"])
+    assert r["telemetry"]["direct_read_symbol_windows"] == []
+    assert len(r["hits"]) == 1 and r["hits"][0]["symbol"] is None
+    assert r["hits"][0]["content"].startswith("# leadA")  # deterministic head-clip, not lead-then-nothing
+
+
+def test_symbol_fallback_head_clip_dedups_on_path_not_symbol(tmp_path):
+    """CoR R3 (major): a symbol target that FALLS BACK to the head-clip produces path-based content;
+    it must dedup on the bare path (colliding with the plain-path hit), not on (path, symbol) -- else
+    the same head-clip is emitted twice and budget is double-charged."""
+    fake_root = tmp_path / "repo"
+    (fake_root / "src").mkdir(parents=True)
+    rel = "src/f.py"
+    (fake_root / rel).write_text("def other():\n    return 1\n", encoding="utf-8")
+    r = _direct_read_fetch(fake_root, [rel + "#absent_symbol", rel])
+    assert len(r["hits"]) == 1                                   # one head-clip, not two
+    assert r["telemetry"]["direct_read_paths"] == [rel]          # not double-counted
+
+
+def test_many_absent_symbols_one_file_cannot_blow_total_budget(tmp_path):
+    """CoR R3 (major, amplification): many absent symbols of ONE big file must NOT each redraw a
+    per-file cap and starve a distinct legitimate target of the total budget."""
+    fake_root = tmp_path / "repo"
+    (fake_root / "src").mkdir(parents=True)
+    big = "src/big.py"
+    (fake_root / big).write_text("# no matching symbols here\n" + ("X" * 60000), encoding="utf-8")
+    (fake_root / "src" / "important.py").write_text("IMPORTANT-CONTENT = 1\n", encoding="utf-8")
+    targets = [f"{big}#sym{i}" for i in range(40)] + ["src/important.py"]
+    r = _direct_read_fetch(fake_root, targets)
+    joined = "\n".join(h["content"] for h in r["hits"])
+    assert "IMPORTANT-CONTENT" in joined                          # the legit distinct target still lands
+    assert r["telemetry"]["direct_read_bytes"] <= DIRECT_READ_TOTAL_BUDGET_BYTES
+    assert len({h["location"] for h in r["hits"]}) >= 2           # budget spread, not consumed by one file
+
+
+def test_read_symbol_window_bounded_scan_cap(tmp_path):
+    """A symbol beyond the scan cap is not located (bounded scan) -> omitted 'symbol_not_found',
+    so a pathological file cannot force an unbounded read."""
+    fake_root = tmp_path / "repo"
+    (fake_root / "src").mkdir(parents=True)
+    rel = "src/huge.py"
+    filler = "# filler line to push the symbol beyond the scan cap zzzzzzzzzzzzzzzzzz\n"
+    reps = (DIRECT_READ_SYMBOL_SCAN_BYTES // len(filler.encode("utf-8"))) + 50
+    (fake_root / rel).write_text(filler * reps + "def build_foundup():\n    return 1\n", encoding="utf-8")
+    real = fake_root / rel
+    snip = _read_symbol_window(real, "build_foundup", DIRECT_READ_PER_FILE_BYTES, DIRECT_READ_TOTAL_BUDGET_BYTES)
+    assert snip["omitted_reason"] == "symbol_not_found"
 
 
 def test_direct_read_cli_end_to_end(monkeypatch):


### PR DESCRIPTION
## Slice: REDDOG_SYMBOL_AWARE_EXCERPT_DEPTH_PHASE1 (judgment lane, slice 3)

**Gate: VERIFIED_READY draft PR — do NOT self-merge.** Follows #933 (Determine contract) and #934 (repair preserves evidence).

### Why
RedDog's governed direct-read **head-clips the first 12KB** of each target. A symbol defined **deep in a large file** (`build_foundup` / `extract_foundup` past the head) never reached the model — the `SPECIFIED_NOT_IMPLEMENTED` "symbol-aware excerpt depth" gap named in the FoundUp-creation execution-path audit (§6). 012's framing: *make sure the relevant deep code lines actually reach the model.*

### What
A required direct-read target may now be **`path#symbol`**. When so, the fetch returns a **bounded line window around the symbol's DEFINITION** instead of the head-clip.

**`holo_index/cli/commands/bundle_json.py`:**
- **`_split_path_symbol`** splits `path#symbol` → (path, symbol) after normalization. The symbol is an **opaque, validated identifier** (`^[A-Za-z_][A-Za-z0-9_]{0,127}$`), **never a path segment** — every security gate (deny basenames/extensions/segments, traversal, absolute, realpath containment / symlink-escape, resolved-basename re-deny, binary NUL sniff) runs on the **path only**.
- **`_locate_symbol_line`** — bounded, **word-boundary** (`build_foundup` ≠ `build_foundup_v2`), **definition-preferring** (`def/class/function/const SYMBOL` or `SYMBOL =/:/(` over a call-site; case-sensitive). Not the unbounded first-substring prior art (`introspection_engine._find_symbol_line`) — this module needs a bounded scan (256KB, transient) + def preference (WSP 84 note in-code).
- **`_read_symbol_window`** — window includes the def line **first** (else fail-closes `symbol_window_empty` → head-clip; never lead-only content labeled a success); clamped to the per-file cap + total budget; fallbacks never crash; a genuine window keys dedup on `(path, symbol)` while a fallback keys on the bare path; a **per-path symbol cap** bounds slot exhaustion. `hit['location']` stays the bare path (recall stays path-based). Telemetry: `direct_read_symbol_windows`.

**`extension.js` (0.3.42 → 0.3.43):** forward the full `path#symbol` to `--bundle-must-include`; **`stripSymbolSuffix`** normalizes `path#symbol` → bare path for recall (`requiredTargetMatchesLocation`), resolve, and the context-proof denominator; a pathless `symbol:` prefix stays excluded (unchanged).

### Adversarial CoR — 4 rounds, 4 lenses (symbol-injection / ReDoS-scan / window-integrity / fallback-dedup-budget), effort:high
- **R1** — def line > 12KB cap → false "success" with lead-only content → fixed (require the def line, else head-clip).
- **R2** — case-distinct symbols (`Config`/`config`) collapsed by a lowercased dedup key → fixed (symbol is case-sensitive).
- **R3** — a fallback head-clip kept its `(path, symbol)` key (double budget) + N absent symbols filled all target slots → fixed (fallback dedups on path; per-path symbol cap).
- **R4: all 4 lenses SAFE, 0 findings.**

### Tests
`holo_index/tests/test_reddog_extension_bundle_recall.py` — **+15 symbol tests**: deep-past-head window; lead context; oversized-def fallback; not-found/invalid fallback; **security-deny on the path portion** (`.env#x` / `/etc/passwd#x` / `../../x#y`); two-symbols + case-distinct both window; binary; scan-cap; fallback-dedups-on-path; **amplification cannot blow the budget**; split/locate units. **29 pass** (2 pre-existing lexical-ranking failures, confirmed identical on the clean base, index-staleness, unrelated). Extension contract test extended; `node --check` clean; ASCII-clean.

### Scope / boundary
Read-only, bounded, fail-closed. No authority/signature/identity change; no HoloIndex ranking change. Verifying that a symbol window's content actually *supports the claim* is the next slice (**ADVERSARIAL_VERIFIER_PANEL**).

Judgment lane: 1 Determine contract (#933) → 2 repair preserves evidence (#934) → **3 (this)** → 4 ADVERSARIAL_VERIFIER_PANEL → 5 FOUNDUP_INTAKE_PACKET_MODE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
