### PR TITLE
feat(token-efficiency): telemetry service for token savings measurement (P3)

### DIFF
--- a/modules/infrastructure/token_efficiency/INTERFACE.md
+++ b/modules/infrastructure/token_efficiency/INTERFACE.md
@@ -103,12 +103,74 @@ Get or create the bypass classifier singleton.
 4. **No raw storage**: Only hashes and lengths, never raw content
 5. **M2M output**: All decisions in WSP-99 M2M format
 
+## Public API (P3: Telemetry Service)
+
+### Classes
+
+#### `TokenCompressionEvent`
+
+Telemetry event for token compression measurement.
+
+```python
+@dataclass
+class TokenCompressionEvent:
+    event_id: str
+    timestamp: int
+    source_layer: SourceLayer
+    operation: Operation
+    content_type: ContentType
+    input_bytes: int
+    input_estimated_tokens: int
+    output_bytes: int
+    output_estimated_tokens: int
+    bytes_saved: int
+    tokens_saved: int
+    savings_ratio: float
+    compression_status: CompressionStatus
+    bypass_decision: str | None
+    fidelity_status: str | None
+    raw_ref_present: bool
+    ctx_holo_present: bool
+    index_gap_detected: bool
+    runtime_reindex_allowed: bool  # Always False
+    no_command_execution: bool     # Always True
+    no_rtk_invocation: bool        # Always True
+    no_secret_persistence: bool    # Always True
+    
+    def to_m2m_compact(self) -> str: ...
+    def to_m2m_yaml(self) -> str: ...
+    def to_dict(self) -> dict: ...
+```
+
+### Functions
+
+#### `estimate_tokens(text: str) -> int`
+
+Estimate token count from text (4 chars/token).
+
+#### `build_token_compression_event(...) -> TokenCompressionEvent`
+
+Build validated event with computed savings.
+
+#### `validate_token_event(event) -> ValidationResult`
+
+Validate event against invariants.
+
+#### `summarize_token_events(events) -> TelemetrySummary`
+
+Aggregate metrics from event list.
+
+### Enums
+
+- `SourceLayer`: WSP99_M2M, RTK_EVALUATION, BYPASS_CLASSIFIER, FIDELITY_GATE, UNKNOWN
+- `Operation`: COMPILE, DECOMPILE, CLASSIFY, EVALUATE, BYPASS, FIDELITY_CHECK
+- `ContentType`: M2M_PROMPT, TOOL_OUTPUT, RAW_REF, UNKNOWN
+- `CompressionStatus`: COMPRESSED, BYPASSED, UNCHANGED, ERROR, NOT_APPLICABLE
+
 ## Not Implemented (Future Phases)
 
 | Component | Phase | Status |
 |-----------|-------|--------|
-| M2M fidelity gate | P2 | SPECIFIED_NOT_IMPLEMENTED |
-| Token telemetry | P3 | SPECIFIED_NOT_IMPLEMENTED |
 | Compute governor | P4 | SPECIFIED_NOT_IMPLEMENTED |
 | RTK adapter | P5 | SPECIFIED_NOT_IMPLEMENTED |
 | Compression seam | P6 | SPECIFIED_NOT_IMPLEMENTED |

--- a/modules/infrastructure/token_efficiency/README.md
+++ b/modules/infrastructure/token_efficiency/README.md
@@ -1,6 +1,6 @@
 # Token Efficiency Module
 
-**Status**: P1 (Bypass Classifier) ACTIVE
+**Status**: P3 (Telemetry Service) ACTIVE
 **Contract**: `docs/contracts/REDDOG_WSP99_RTK_TOKEN_EFFICIENCY_CONTRACT_PHASE1.md`
 **WSP**: WSP_97, WSP_99
 
@@ -71,9 +71,9 @@ The classifier always fails closed:
 
 | Phase | Slice | Status |
 |-------|-------|--------|
-| P1 | BYPASS_CLASSIFIER_SECURITY_GATE_PHASE1 | ACTIVE |
-| P2 | WSP99_COMPILER_FIDELITY_GATE_PHASE1 | Planned |
-| P3 | TOKEN_EFFICIENCY_TELEMETRY_SERVICE_PHASE1 | Planned |
+| P1 | BYPASS_CLASSIFIER_SECURITY_GATE_PHASE1 | LANDED (#940) |
+| P2 | WSP99_COMPILER_FIDELITY_GATE_PHASE1 | LANDED (#943) |
+| P3 | TOKEN_EFFICIENCY_TELEMETRY_SERVICE_PHASE1 | ACTIVE |
 | P4 | REDDOG_COMPUTE_GOVERNOR_PHASE1 | Planned |
 | P5 | RTK_EVALUATION_DRY_RUN_PHASE1 | Planned |
 | P6 | RTK_OPENCLAW_HERMES_ADAPTER_DRYRUN_PHASE1 | Planned |
@@ -85,8 +85,13 @@ modules/infrastructure/token_efficiency/
   src/
     __init__.py
     bypass_classifier.py      # P1: Bypass classification
+    m2m_fidelity_gate.py      # P2: Round-trip validation
+    telemetry_service.py      # P3: Token savings measurement
   tests/
     test_bypass_classifier.py # Unit + adversarial tests
+    test_m2m_fidelity.py      # Fidelity + CTX.HOLO tests
+    test_m2m_compiler_compat.py # Compiler backward-compat
+    test_telemetry_service.py # Telemetry service tests
   config/
     bypass_patterns.yaml      # Pattern definitions
   README.md                   # This file

--- a/modules/infrastructure/token_efficiency/src/__init__.py
+++ b/modules/infrastructure/token_efficiency/src/__init__.py
@@ -33,6 +33,26 @@ from .m2m_fidelity_gate import (
     HOLO_REQUIRED_MODES,
 )
 
+from .telemetry_service import (
+    TokenCompressionEvent,
+    TelemetrySummary,
+    TelemetryValidationError,
+    ValidationResult,
+    SourceLayer,
+    Operation,
+    ContentType,
+    CompressionStatus,
+    InMemoryTelemetryStore,
+    estimate_tokens,
+    compute_content_hash,
+    generate_event_id,
+    build_token_compression_event,
+    validate_token_event,
+    summarize_token_events,
+    get_telemetry_store,
+    reset_telemetry_store,
+)
+
 __all__ = [
     # Bypass classifier (P1)
     "BypassClass",
@@ -53,4 +73,22 @@ __all__ = [
     "to_m2m_compact",
     "to_m2m_yaml",
     "HOLO_REQUIRED_MODES",
+    # Telemetry service (P3)
+    "TokenCompressionEvent",
+    "TelemetrySummary",
+    "TelemetryValidationError",
+    "ValidationResult",
+    "SourceLayer",
+    "Operation",
+    "ContentType",
+    "CompressionStatus",
+    "InMemoryTelemetryStore",
+    "estimate_tokens",
+    "compute_content_hash",
+    "generate_event_id",
+    "build_token_compression_event",
+    "validate_token_event",
+    "summarize_token_events",
+    "get_telemetry_store",
+    "reset_telemetry_store",
 ]

--- a/modules/infrastructure/token_efficiency/src/telemetry_service.py
+++ b/modules/infrastructure/token_efficiency/src/telemetry_service.py
@@ -1,0 +1,653 @@
+# -*- coding: utf-8 -*-
+"""
+Token Efficiency Telemetry Service (P3)
+
+Records compression/fidelity events for token efficiency measurement.
+In-memory only; no persistent storage in this slice.
+
+Contract: docs/contracts/REDDOG_WSP99_RTK_TOKEN_EFFICIENCY_CONTRACT_PHASE1.md Section 8
+WSP: WSP_97 (truth boundary), WSP_99 (M2M protocol)
+
+WSP_97 Truth Labels:
+- OBSERVED: Contract Section 8a TokenCompressionEvent schema
+- SPECIFIED_NOT_IMPLEMENTED: persistence (in-memory only for this slice)
+
+Truth Boundary Checklist:
+- NO_RTK_DEPENDENCY: no RTK binary or subprocess
+- NO_COMMAND_EXECUTION: no shell/subprocess calls
+- NO_SECRET_PERSISTENCE: only hashes/lengths, never raw content
+- NO_HOLOINDEX_MUTATION: query-only reference
+- NO_OPENCLAW_HERMES_WRE_WIRING: no execution integration
+- IN_MEMORY_ONLY: no disk persistence
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from dataclasses import dataclass, field, asdict
+from enum import Enum
+from typing import Any
+
+
+class SourceLayer(Enum):
+    """Source layer for telemetry events."""
+    WSP99_M2M = "WSP99_M2M"
+    RTK_EVALUATION = "RTK_EVALUATION"
+    BYPASS_CLASSIFIER = "BYPASS_CLASSIFIER"
+    FIDELITY_GATE = "FIDELITY_GATE"
+    UNKNOWN = "UNKNOWN"
+
+
+class Operation(Enum):
+    """Operation type for telemetry events."""
+    COMPILE = "compile"
+    DECOMPILE = "decompile"
+    CLASSIFY = "classify"
+    EVALUATE = "evaluate"
+    BYPASS = "bypass"
+    FIDELITY_CHECK = "fidelity_check"
+
+
+class ContentType(Enum):
+    """Content type for telemetry events."""
+    M2M_PROMPT = "m2m_prompt"
+    TOOL_OUTPUT = "tool_output"
+    RAW_REF = "raw_ref"
+    UNKNOWN = "unknown"
+
+
+class CompressionStatus(Enum):
+    """Compression status."""
+    COMPRESSED = "compressed"
+    BYPASSED = "bypassed"
+    UNCHANGED = "unchanged"
+    ERROR = "error"
+    NOT_APPLICABLE = "not_applicable"
+
+
+# Token estimation: ~4 chars per token (conservative estimate)
+CHARS_PER_TOKEN = 4
+
+
+def estimate_tokens(text: str) -> int:
+    """
+    Estimate token count from text.
+
+    Uses a conservative 4 chars per token estimate.
+    Returns 0 for empty text, never negative.
+
+    Args:
+        text: Input text to estimate
+
+    Returns:
+        Estimated token count (non-negative integer)
+    """
+    if not text:
+        return 0
+    # Ceiling division for conservative estimate
+    return max(0, (len(text) + CHARS_PER_TOKEN - 1) // CHARS_PER_TOKEN)
+
+
+def compute_content_hash(content: str) -> str:
+    """
+    Compute SHA256 hash of content.
+
+    Args:
+        content: Content to hash
+
+    Returns:
+        Hex digest of SHA256 hash
+    """
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+@dataclass
+class TokenCompressionEvent:
+    """
+    Telemetry event for token compression/efficiency measurement.
+
+    Per Contract Section 8a TokenCompressionEvent schema.
+
+    INVARIANTS (Section 8b):
+    - NO_NEGATIVE_SAVINGS: bytes_saved/tokens_saved >= 0 for compressed
+    - NO_CONTENT_IN_TELEMETRY: only hashes/lengths, never raw content
+    - BYPASS_BEFORE_TELEMETRY: bypass decision recorded before metrics
+    """
+    # Identity
+    event_id: str
+    timestamp: int  # Unix timestamp
+
+    # Source
+    source_layer: SourceLayer
+    operation: Operation
+    content_type: ContentType
+
+    # Input metrics (no raw content)
+    input_bytes: int
+    input_estimated_tokens: int
+
+    # Output metrics
+    output_bytes: int
+    output_estimated_tokens: int
+
+    # Savings (computed)
+    bytes_saved: int
+    tokens_saved: int
+    savings_ratio: float  # 0.0 to 1.0
+
+    # Status
+    compression_status: CompressionStatus
+    bypass_decision: str | None = None  # Bypass class if bypassed
+    fidelity_status: str | None = None  # Fidelity check result
+
+    # Context flags
+    raw_ref_present: bool = False
+    ctx_holo_present: bool = False
+    index_gap_detected: bool = False
+
+    # Safety invariants (must always be these values)
+    runtime_reindex_allowed: bool = False
+    no_command_execution: bool = True
+    no_rtk_invocation: bool = True
+    no_secret_persistence: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dictionary."""
+        d = asdict(self)
+        d["source_layer"] = self.source_layer.value
+        d["operation"] = self.operation.value
+        d["content_type"] = self.content_type.value
+        d["compression_status"] = self.compression_status.value
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "TokenCompressionEvent":
+        """Deserialize from dictionary."""
+        return cls(
+            event_id=d["event_id"],
+            timestamp=d["timestamp"],
+            source_layer=SourceLayer(d["source_layer"]),
+            operation=Operation(d["operation"]),
+            content_type=ContentType(d["content_type"]),
+            input_bytes=d["input_bytes"],
+            input_estimated_tokens=d["input_estimated_tokens"],
+            output_bytes=d["output_bytes"],
+            output_estimated_tokens=d["output_estimated_tokens"],
+            bytes_saved=d["bytes_saved"],
+            tokens_saved=d["tokens_saved"],
+            savings_ratio=d["savings_ratio"],
+            compression_status=CompressionStatus(d["compression_status"]),
+            bypass_decision=d.get("bypass_decision"),
+            fidelity_status=d.get("fidelity_status"),
+            raw_ref_present=d.get("raw_ref_present", False),
+            ctx_holo_present=d.get("ctx_holo_present", False),
+            index_gap_detected=d.get("index_gap_detected", False),
+            runtime_reindex_allowed=d.get("runtime_reindex_allowed", False),
+            no_command_execution=d.get("no_command_execution", True),
+            no_rtk_invocation=d.get("no_rtk_invocation", True),
+            no_secret_persistence=d.get("no_secret_persistence", True),
+        )
+
+    def to_m2m_compact(self) -> str:
+        """Emit as M2M compact format."""
+        status = self.compression_status.value.upper()
+        return (
+            f"TELEMETRY:{self.event_id[:8]} "
+            f"SRC:{self.source_layer.value} "
+            f"OP:{self.operation.value} "
+            f"STATUS:{status} "
+            f"IN_TOK:{self.input_estimated_tokens} "
+            f"OUT_TOK:{self.output_estimated_tokens} "
+            f"SAVED:{self.tokens_saved} "
+            f"RATIO:{self.savings_ratio:.3f}"
+        )
+
+    def to_m2m_yaml(self) -> str:
+        """Emit as M2M YAML format."""
+        lines = [
+            "TOKEN_COMPRESSION_EVENT:",
+            f"  event_id: {self.event_id}",
+            f"  timestamp: {self.timestamp}",
+            f"  source_layer: {self.source_layer.value}",
+            f"  operation: {self.operation.value}",
+            f"  content_type: {self.content_type.value}",
+            f"  compression_status: {self.compression_status.value}",
+            "  metrics:",
+            f"    input_bytes: {self.input_bytes}",
+            f"    input_tokens: {self.input_estimated_tokens}",
+            f"    output_bytes: {self.output_bytes}",
+            f"    output_tokens: {self.output_estimated_tokens}",
+            f"    bytes_saved: {self.bytes_saved}",
+            f"    tokens_saved: {self.tokens_saved}",
+            f"    savings_ratio: {self.savings_ratio:.4f}",
+            "  context:",
+            f"    bypass_decision: {self.bypass_decision}",
+            f"    fidelity_status: {self.fidelity_status}",
+            f"    raw_ref_present: {self.raw_ref_present}",
+            f"    ctx_holo_present: {self.ctx_holo_present}",
+            f"    index_gap_detected: {self.index_gap_detected}",
+            "  invariants:",
+            f"    runtime_reindex_allowed: {self.runtime_reindex_allowed}",
+            f"    no_command_execution: {self.no_command_execution}",
+            f"    no_rtk_invocation: {self.no_rtk_invocation}",
+            f"    no_secret_persistence: {self.no_secret_persistence}",
+        ]
+        return "\n".join(lines)
+
+
+class TelemetryValidationError(Exception):
+    """Raised when telemetry event validation fails."""
+
+    def __init__(self, field: str, value: Any, reason: str):
+        self.field = field
+        self.value = value
+        self.reason = reason
+        super().__init__(f"Telemetry validation failed: {field}={value} - {reason}")
+
+
+@dataclass
+class ValidationResult:
+    """Result of event validation."""
+    valid: bool
+    errors: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"valid": self.valid, "errors": self.errors}
+
+
+def generate_event_id(
+    source_layer: SourceLayer,
+    operation: Operation,
+    content_type: ContentType,
+    input_bytes: int,
+    output_bytes: int,
+    bypass_decision: str | None = None,
+) -> str:
+    """
+    Generate deterministic event ID from canonical content.
+
+    Excludes timestamp for stable test assertions.
+
+    Args:
+        source_layer: Event source
+        operation: Operation type
+        content_type: Content type
+        input_bytes: Input size
+        output_bytes: Output size
+        bypass_decision: Bypass class if any
+
+    Returns:
+        Deterministic event ID (32 chars hex)
+    """
+    canonical = (
+        f"{source_layer.value}:"
+        f"{operation.value}:"
+        f"{content_type.value}:"
+        f"{input_bytes}:"
+        f"{output_bytes}:"
+        f"{bypass_decision or 'none'}"
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:32]
+
+
+def build_token_compression_event(
+    source_layer: SourceLayer,
+    operation: Operation,
+    content_type: ContentType,
+    input_bytes: int,
+    output_bytes: int,
+    *,
+    bypass_decision: str | None = None,
+    fidelity_status: str | None = None,
+    raw_ref_present: bool = False,
+    ctx_holo_present: bool = False,
+    index_gap_detected: bool = False,
+    timestamp: int | None = None,
+) -> TokenCompressionEvent:
+    """
+    Build a TokenCompressionEvent with computed fields.
+
+    Validates invariants and computes savings.
+
+    Args:
+        source_layer: Source of the event
+        operation: Operation performed
+        content_type: Type of content
+        input_bytes: Input size in bytes
+        output_bytes: Output size in bytes
+        bypass_decision: Bypass class if bypassed
+        fidelity_status: Fidelity check result
+        raw_ref_present: Whether raw_ref exists
+        ctx_holo_present: Whether CTX.HOLO exists
+        index_gap_detected: Whether index gap was detected
+        timestamp: Unix timestamp (defaults to now)
+
+    Returns:
+        Validated TokenCompressionEvent
+
+    Raises:
+        TelemetryValidationError: If invariants violated
+    """
+    # Validate non-negative counts
+    if input_bytes < 0:
+        raise TelemetryValidationError("input_bytes", input_bytes, "must be non-negative")
+    if output_bytes < 0:
+        raise TelemetryValidationError("output_bytes", output_bytes, "must be non-negative")
+
+    # Estimate tokens
+    input_tokens = estimate_tokens("x" * input_bytes)  # Approximate
+    output_tokens = estimate_tokens("x" * output_bytes)
+
+    # Compute savings
+    bytes_saved = input_bytes - output_bytes
+    tokens_saved = input_tokens - output_tokens
+
+    # Compute ratio (safe division)
+    if input_bytes > 0:
+        savings_ratio = bytes_saved / input_bytes
+    else:
+        savings_ratio = 0.0
+
+    # Determine status
+    if bypass_decision:
+        compression_status = CompressionStatus.BYPASSED
+        # Bypassed content must not claim positive savings
+        if bytes_saved > 0:
+            bytes_saved = 0
+            tokens_saved = 0
+            savings_ratio = 0.0
+    elif output_bytes > input_bytes:
+        # Output larger than input - this is a negative savings scenario
+        compression_status = CompressionStatus.UNCHANGED
+        # Don't fake positive savings
+        bytes_saved = input_bytes - output_bytes  # Will be negative
+        savings_ratio = bytes_saved / input_bytes if input_bytes > 0 else 0.0
+    elif output_bytes == input_bytes:
+        compression_status = CompressionStatus.UNCHANGED
+    else:
+        compression_status = CompressionStatus.COMPRESSED
+
+    # Generate event ID (deterministic, excludes timestamp)
+    event_id = generate_event_id(
+        source_layer, operation, content_type,
+        input_bytes, output_bytes, bypass_decision
+    )
+
+    # Timestamp
+    ts = timestamp if timestamp is not None else int(time.time())
+
+    return TokenCompressionEvent(
+        event_id=event_id,
+        timestamp=ts,
+        source_layer=source_layer,
+        operation=operation,
+        content_type=content_type,
+        input_bytes=input_bytes,
+        input_estimated_tokens=input_tokens,
+        output_bytes=output_bytes,
+        output_estimated_tokens=output_tokens,
+        bytes_saved=bytes_saved,
+        tokens_saved=tokens_saved,
+        savings_ratio=savings_ratio,
+        compression_status=compression_status,
+        bypass_decision=bypass_decision,
+        fidelity_status=fidelity_status,
+        raw_ref_present=raw_ref_present,
+        ctx_holo_present=ctx_holo_present,
+        index_gap_detected=index_gap_detected,
+        runtime_reindex_allowed=False,  # Invariant: always False
+        no_command_execution=True,  # Invariant: always True
+        no_rtk_invocation=True,  # Invariant: always True
+        no_secret_persistence=True,  # Invariant: always True
+    )
+
+
+def validate_token_event(event: TokenCompressionEvent) -> ValidationResult:
+    """
+    Validate a TokenCompressionEvent against invariants.
+
+    Args:
+        event: Event to validate
+
+    Returns:
+        ValidationResult with errors if any
+    """
+    errors = []
+
+    # Invariant: runtime_reindex_allowed must be False
+    if event.runtime_reindex_allowed:
+        errors.append("runtime_reindex_allowed must be False")
+
+    # Invariant: no_command_execution must be True
+    if not event.no_command_execution:
+        errors.append("no_command_execution must be True")
+
+    # Invariant: no_rtk_invocation must be True
+    if not event.no_rtk_invocation:
+        errors.append("no_rtk_invocation must be True")
+
+    # Invariant: no_secret_persistence must be True
+    if not event.no_secret_persistence:
+        errors.append("no_secret_persistence must be True")
+
+    # Invariant: non-negative input counts
+    if event.input_bytes < 0:
+        errors.append(f"input_bytes cannot be negative: {event.input_bytes}")
+    if event.input_estimated_tokens < 0:
+        errors.append(f"input_estimated_tokens cannot be negative: {event.input_estimated_tokens}")
+
+    # Invariant: non-negative output counts
+    if event.output_bytes < 0:
+        errors.append(f"output_bytes cannot be negative: {event.output_bytes}")
+    if event.output_estimated_tokens < 0:
+        errors.append(f"output_estimated_tokens cannot be negative: {event.output_estimated_tokens}")
+
+    # Invariant: bypassed content cannot claim compression
+    if event.compression_status == CompressionStatus.BYPASSED:
+        if event.bytes_saved > 0 or event.tokens_saved > 0:
+            errors.append("Bypassed event cannot claim positive savings")
+
+    # Invariant: UNKNOWN content must not claim compression
+    if event.content_type == ContentType.UNKNOWN:
+        if event.compression_status == CompressionStatus.COMPRESSED:
+            errors.append("UNKNOWN content type cannot be marked as compressed")
+
+    # Invariant: event_id must be non-empty
+    if not event.event_id:
+        errors.append("event_id cannot be empty")
+
+    return ValidationResult(valid=len(errors) == 0, errors=errors)
+
+
+@dataclass
+class TelemetrySummary:
+    """Summary of telemetry events."""
+    total_events: int
+    total_input_bytes: int
+    total_output_bytes: int
+    total_input_tokens: int
+    total_output_tokens: int
+    total_bytes_saved: int
+    total_tokens_saved: int
+    overall_savings_ratio: float
+    events_by_status: dict[str, int]
+    events_by_source: dict[str, int]
+    events_by_operation: dict[str, int]
+    bypassed_count: int
+    compressed_count: int
+    error_count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def to_m2m_yaml(self) -> str:
+        """Emit as M2M YAML format."""
+        lines = [
+            "TELEMETRY_SUMMARY:",
+            f"  total_events: {self.total_events}",
+            f"  total_input_bytes: {self.total_input_bytes}",
+            f"  total_output_bytes: {self.total_output_bytes}",
+            f"  total_input_tokens: {self.total_input_tokens}",
+            f"  total_output_tokens: {self.total_output_tokens}",
+            f"  total_bytes_saved: {self.total_bytes_saved}",
+            f"  total_tokens_saved: {self.total_tokens_saved}",
+            f"  overall_savings_ratio: {self.overall_savings_ratio:.4f}",
+            f"  bypassed_count: {self.bypassed_count}",
+            f"  compressed_count: {self.compressed_count}",
+            f"  error_count: {self.error_count}",
+            "  events_by_status:",
+        ]
+        for status, count in sorted(self.events_by_status.items()):
+            lines.append(f"    {status}: {count}")
+        lines.append("  events_by_source:")
+        for src, count in sorted(self.events_by_source.items()):
+            lines.append(f"    {src}: {count}")
+        return "\n".join(lines)
+
+
+def summarize_token_events(events: list[TokenCompressionEvent]) -> TelemetrySummary:
+    """
+    Summarize a list of telemetry events.
+
+    Args:
+        events: List of events to summarize
+
+    Returns:
+        TelemetrySummary with aggregated metrics
+    """
+    if not events:
+        return TelemetrySummary(
+            total_events=0,
+            total_input_bytes=0,
+            total_output_bytes=0,
+            total_input_tokens=0,
+            total_output_tokens=0,
+            total_bytes_saved=0,
+            total_tokens_saved=0,
+            overall_savings_ratio=0.0,
+            events_by_status={},
+            events_by_source={},
+            events_by_operation={},
+            bypassed_count=0,
+            compressed_count=0,
+            error_count=0,
+        )
+
+    total_input_bytes = sum(e.input_bytes for e in events)
+    total_output_bytes = sum(e.output_bytes for e in events)
+    total_input_tokens = sum(e.input_estimated_tokens for e in events)
+    total_output_tokens = sum(e.output_estimated_tokens for e in events)
+    total_bytes_saved = sum(e.bytes_saved for e in events)
+    total_tokens_saved = sum(e.tokens_saved for e in events)
+
+    overall_ratio = total_bytes_saved / total_input_bytes if total_input_bytes > 0 else 0.0
+
+    # Count by status
+    events_by_status: dict[str, int] = {}
+    for e in events:
+        key = e.compression_status.value
+        events_by_status[key] = events_by_status.get(key, 0) + 1
+
+    # Count by source
+    events_by_source: dict[str, int] = {}
+    for e in events:
+        key = e.source_layer.value
+        events_by_source[key] = events_by_source.get(key, 0) + 1
+
+    # Count by operation
+    events_by_operation: dict[str, int] = {}
+    for e in events:
+        key = e.operation.value
+        events_by_operation[key] = events_by_operation.get(key, 0) + 1
+
+    bypassed = sum(1 for e in events if e.compression_status == CompressionStatus.BYPASSED)
+    compressed = sum(1 for e in events if e.compression_status == CompressionStatus.COMPRESSED)
+    errors = sum(1 for e in events if e.compression_status == CompressionStatus.ERROR)
+
+    return TelemetrySummary(
+        total_events=len(events),
+        total_input_bytes=total_input_bytes,
+        total_output_bytes=total_output_bytes,
+        total_input_tokens=total_input_tokens,
+        total_output_tokens=total_output_tokens,
+        total_bytes_saved=total_bytes_saved,
+        total_tokens_saved=total_tokens_saved,
+        overall_savings_ratio=overall_ratio,
+        events_by_status=events_by_status,
+        events_by_source=events_by_source,
+        events_by_operation=events_by_operation,
+        bypassed_count=bypassed,
+        compressed_count=compressed,
+        error_count=errors,
+    )
+
+
+class InMemoryTelemetryStore:
+    """
+    In-memory telemetry storage (no persistence).
+
+    Per Contract Section 8b: NO_CONTENT_IN_TELEMETRY - stores events, not raw content.
+    """
+
+    def __init__(self, max_events: int = 10000):
+        self._events: list[TokenCompressionEvent] = []
+        self._max_events = max_events
+
+    def record(self, event: TokenCompressionEvent) -> None:
+        """
+        Record a telemetry event.
+
+        Validates before recording.
+
+        Args:
+            event: Event to record
+
+        Raises:
+            TelemetryValidationError: If validation fails
+        """
+        result = validate_token_event(event)
+        if not result.valid:
+            raise TelemetryValidationError(
+                "event", event.event_id, "; ".join(result.errors)
+            )
+
+        self._events.append(event)
+
+        # Rotate if over limit (FIFO)
+        if len(self._events) > self._max_events:
+            self._events = self._events[-self._max_events:]
+
+    def get_all(self) -> list[TokenCompressionEvent]:
+        """Get all recorded events."""
+        return list(self._events)
+
+    def get_summary(self) -> TelemetrySummary:
+        """Get summary of all events."""
+        return summarize_token_events(self._events)
+
+    def clear(self) -> None:
+        """Clear all events."""
+        self._events.clear()
+
+    def count(self) -> int:
+        """Get event count."""
+        return len(self._events)
+
+
+# Module-level singleton (in-memory only)
+_telemetry_store: InMemoryTelemetryStore | None = None
+
+
+def get_telemetry_store() -> InMemoryTelemetryStore:
+    """Get or create the telemetry store singleton."""
+    global _telemetry_store
+    if _telemetry_store is None:
+        _telemetry_store = InMemoryTelemetryStore()
+    return _telemetry_store
+
+
+def reset_telemetry_store() -> None:
+    """Reset the telemetry store (for tests)."""
+    global _telemetry_store
+    _telemetry_store = None

--- a/modules/infrastructure/token_efficiency/tests/test_telemetry_service.py
+++ b/modules/infrastructure/token_efficiency/tests/test_telemetry_service.py
@@ -1,0 +1,568 @@
+# -*- coding: utf-8 -*-
+"""
+Token Efficiency Telemetry Service Tests (P3)
+
+Contract: docs/contracts/REDDOG_WSP99_RTK_TOKEN_EFFICIENCY_CONTRACT_PHASE1.md Section 8
+WSP: WSP_97, WSP_99
+
+Tests per M2M prompt TESTS section:
+- token estimate deterministic and non-negative
+- bytes/tokens saved computed correctly
+- savings ratio handles zero safely
+- event_id stable for same semantic content
+- timestamp does not destabilize deterministic digest if excluded
+- bypassed event cannot claim compression
+- unknown content fails closed / needs review
+- ctx_holo_present and index_gap_detected fields survive serialization
+- runtime_reindex_allowed true is rejected
+- negative counts rejected
+- output larger than input produces negative savings
+- raw_ref does not contain secret-like material
+- no RTK imports / subprocess / command execution AST denylist
+- no extension runtime files touched
+"""
+
+import pytest
+import ast
+import sys
+from pathlib import Path
+
+# Add module to path
+sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
+
+from telemetry_service import (
+    estimate_tokens,
+    compute_content_hash,
+    generate_event_id,
+    build_token_compression_event,
+    validate_token_event,
+    summarize_token_events,
+    TokenCompressionEvent,
+    TelemetrySummary,
+    TelemetryValidationError,
+    ValidationResult,
+    SourceLayer,
+    Operation,
+    ContentType,
+    CompressionStatus,
+    InMemoryTelemetryStore,
+    get_telemetry_store,
+    reset_telemetry_store,
+    CHARS_PER_TOKEN,
+)
+
+
+class TestEstimateTokens:
+    """Token estimation tests."""
+
+    def test_estimate_deterministic(self):
+        """estimate_tokens is deterministic."""
+        text = "Hello world, this is a test."
+        assert estimate_tokens(text) == estimate_tokens(text)
+
+    def test_estimate_non_negative(self):
+        """estimate_tokens always returns non-negative."""
+        assert estimate_tokens("") >= 0
+        assert estimate_tokens("a") >= 0
+        assert estimate_tokens("a" * 1000) >= 0
+
+    def test_estimate_empty_is_zero(self):
+        """Empty text estimates to 0 tokens."""
+        assert estimate_tokens("") == 0
+
+    def test_estimate_proportional(self):
+        """Longer text estimates more tokens."""
+        short = "Hello"
+        long = "Hello" * 100
+        assert estimate_tokens(long) > estimate_tokens(short)
+
+    def test_estimate_uses_char_ratio(self):
+        """Token estimate uses CHARS_PER_TOKEN ratio."""
+        text = "x" * 100
+        expected = (100 + CHARS_PER_TOKEN - 1) // CHARS_PER_TOKEN
+        assert estimate_tokens(text) == expected
+
+
+class TestComputeHash:
+    """Hash computation tests."""
+
+    def test_hash_deterministic(self):
+        """compute_content_hash is deterministic."""
+        content = "Test content"
+        assert compute_content_hash(content) == compute_content_hash(content)
+
+    def test_hash_different_for_different_content(self):
+        """Different content produces different hashes."""
+        assert compute_content_hash("a") != compute_content_hash("b")
+
+    def test_hash_sha256_length(self):
+        """Hash is SHA256 hex (64 chars)."""
+        h = compute_content_hash("test")
+        assert len(h) == 64
+        assert all(c in "0123456789abcdef" for c in h)
+
+
+class TestEventIdGeneration:
+    """Event ID generation tests."""
+
+    def test_event_id_deterministic(self):
+        """event_id stable for same semantic content."""
+        id1 = generate_event_id(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, 100, 50
+        )
+        id2 = generate_event_id(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, 100, 50
+        )
+        assert id1 == id2
+
+    def test_event_id_excludes_timestamp(self):
+        """event_id does not include timestamp (verified by determinism)."""
+        id1 = generate_event_id(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, 100, 50
+        )
+        # If timestamp were included, calling again would differ
+        id2 = generate_event_id(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, 100, 50
+        )
+        assert id1 == id2
+
+    def test_event_id_different_for_different_params(self):
+        """Different parameters produce different event IDs."""
+        id1 = generate_event_id(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, 100, 50
+        )
+        id2 = generate_event_id(
+            SourceLayer.BYPASS_CLASSIFIER, Operation.CLASSIFY,
+            ContentType.TOOL_OUTPUT, 200, 200
+        )
+        assert id1 != id2
+
+
+class TestBuildEvent:
+    """Event building tests."""
+
+    def test_bytes_saved_computed_correctly(self):
+        """bytes_saved = input_bytes - output_bytes."""
+        event = build_token_compression_event(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, input_bytes=100, output_bytes=50
+        )
+        assert event.bytes_saved == 50
+        assert event.compression_status == CompressionStatus.COMPRESSED
+
+    def test_tokens_saved_computed_correctly(self):
+        """tokens_saved based on byte estimation."""
+        event = build_token_compression_event(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, input_bytes=100, output_bytes=50
+        )
+        assert event.tokens_saved >= 0
+
+    def test_savings_ratio_handles_zero_safely(self):
+        """savings_ratio handles zero input safely."""
+        event = build_token_compression_event(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, input_bytes=0, output_bytes=0
+        )
+        assert event.savings_ratio == 0.0
+
+    def test_savings_ratio_computed(self):
+        """savings_ratio = bytes_saved / input_bytes."""
+        event = build_token_compression_event(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, input_bytes=100, output_bytes=50
+        )
+        assert event.savings_ratio == 0.5
+
+    def test_bypassed_cannot_claim_compression(self):
+        """Bypassed event cannot claim positive savings."""
+        event = build_token_compression_event(
+            SourceLayer.BYPASS_CLASSIFIER, Operation.BYPASS,
+            ContentType.TOOL_OUTPUT, input_bytes=100, output_bytes=50,
+            bypass_decision="BYPASS_SECURITY"
+        )
+        assert event.compression_status == CompressionStatus.BYPASSED
+        assert event.bytes_saved == 0
+        assert event.tokens_saved == 0
+        assert event.savings_ratio == 0.0
+
+    def test_negative_input_bytes_rejected(self):
+        """Negative input_bytes raises error."""
+        with pytest.raises(TelemetryValidationError) as exc_info:
+            build_token_compression_event(
+                SourceLayer.WSP99_M2M, Operation.COMPILE,
+                ContentType.M2M_PROMPT, input_bytes=-1, output_bytes=50
+            )
+        assert "non-negative" in str(exc_info.value)
+
+    def test_negative_output_bytes_rejected(self):
+        """Negative output_bytes raises error."""
+        with pytest.raises(TelemetryValidationError) as exc_info:
+            build_token_compression_event(
+                SourceLayer.WSP99_M2M, Operation.COMPILE,
+                ContentType.M2M_PROMPT, input_bytes=100, output_bytes=-1
+            )
+        assert "non-negative" in str(exc_info.value)
+
+    def test_output_larger_than_input_not_fake_positive(self):
+        """Output > input produces negative savings, not fake positive."""
+        event = build_token_compression_event(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, input_bytes=50, output_bytes=100
+        )
+        assert event.compression_status == CompressionStatus.UNCHANGED
+        assert event.bytes_saved == -50  # Negative
+        assert event.savings_ratio < 0
+
+    def test_ctx_holo_present_field(self):
+        """ctx_holo_present field set correctly."""
+        event = build_token_compression_event(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, input_bytes=100, output_bytes=50,
+            ctx_holo_present=True
+        )
+        assert event.ctx_holo_present is True
+
+    def test_index_gap_detected_field(self):
+        """index_gap_detected field set correctly."""
+        event = build_token_compression_event(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, input_bytes=100, output_bytes=50,
+            index_gap_detected=True
+        )
+        assert event.index_gap_detected is True
+
+    def test_runtime_reindex_always_false(self):
+        """runtime_reindex_allowed always False in built event."""
+        event = build_token_compression_event(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, input_bytes=100, output_bytes=50
+        )
+        assert event.runtime_reindex_allowed is False
+
+
+class TestValidateEvent:
+    """Event validation tests."""
+
+    def test_valid_event_passes(self):
+        """Valid event passes validation."""
+        event = build_token_compression_event(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, input_bytes=100, output_bytes=50
+        )
+        result = validate_token_event(event)
+        assert result.valid
+        assert len(result.errors) == 0
+
+    def test_runtime_reindex_true_rejected(self):
+        """runtime_reindex_allowed=True is rejected."""
+        event = build_token_compression_event(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, input_bytes=100, output_bytes=50
+        )
+        # Manually set to True (violation)
+        event.runtime_reindex_allowed = True
+        result = validate_token_event(event)
+        assert not result.valid
+        assert any("runtime_reindex_allowed" in e for e in result.errors)
+
+    def test_no_command_execution_false_rejected(self):
+        """no_command_execution=False is rejected."""
+        event = build_token_compression_event(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, input_bytes=100, output_bytes=50
+        )
+        event.no_command_execution = False
+        result = validate_token_event(event)
+        assert not result.valid
+
+    def test_bypassed_with_positive_savings_rejected(self):
+        """Bypassed event with positive savings rejected."""
+        event = build_token_compression_event(
+            SourceLayer.BYPASS_CLASSIFIER, Operation.BYPASS,
+            ContentType.TOOL_OUTPUT, input_bytes=100, output_bytes=100,
+            bypass_decision="BYPASS_SECURITY"
+        )
+        # Manually set positive savings (violation)
+        event.bytes_saved = 50
+        result = validate_token_event(event)
+        assert not result.valid
+        assert any("Bypassed event cannot claim positive savings" in e for e in result.errors)
+
+    def test_unknown_content_cannot_be_compressed(self):
+        """UNKNOWN content type cannot be marked as compressed."""
+        event = build_token_compression_event(
+            SourceLayer.UNKNOWN, Operation.EVALUATE,
+            ContentType.UNKNOWN, input_bytes=100, output_bytes=50
+        )
+        # Manually set to compressed (violation)
+        event.compression_status = CompressionStatus.COMPRESSED
+        result = validate_token_event(event)
+        assert not result.valid
+        assert any("UNKNOWN content type cannot be marked as compressed" in e for e in result.errors)
+
+    def test_empty_event_id_rejected(self):
+        """Empty event_id is rejected."""
+        event = build_token_compression_event(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, input_bytes=100, output_bytes=50
+        )
+        event.event_id = ""
+        result = validate_token_event(event)
+        assert not result.valid
+
+
+class TestSerialization:
+    """Serialization/deserialization tests."""
+
+    def test_ctx_holo_survives_serialization(self):
+        """ctx_holo_present survives to_dict/from_dict."""
+        event = build_token_compression_event(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, input_bytes=100, output_bytes=50,
+            ctx_holo_present=True
+        )
+        d = event.to_dict()
+        restored = TokenCompressionEvent.from_dict(d)
+        assert restored.ctx_holo_present is True
+
+    def test_index_gap_survives_serialization(self):
+        """index_gap_detected survives to_dict/from_dict."""
+        event = build_token_compression_event(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, input_bytes=100, output_bytes=50,
+            index_gap_detected=True
+        )
+        d = event.to_dict()
+        restored = TokenCompressionEvent.from_dict(d)
+        assert restored.index_gap_detected is True
+
+    def test_to_m2m_compact_format(self):
+        """to_m2m_compact produces valid format."""
+        event = build_token_compression_event(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, input_bytes=100, output_bytes=50
+        )
+        compact = event.to_m2m_compact()
+        assert "TELEMETRY:" in compact
+        assert "SRC:WSP99_M2M" in compact
+        assert "OP:compile" in compact
+
+    def test_to_m2m_yaml_format(self):
+        """to_m2m_yaml produces valid YAML format."""
+        event = build_token_compression_event(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, input_bytes=100, output_bytes=50
+        )
+        yaml = event.to_m2m_yaml()
+        assert "TOKEN_COMPRESSION_EVENT:" in yaml
+        assert "source_layer: WSP99_M2M" in yaml
+
+
+class TestSummarize:
+    """Summarization tests."""
+
+    def test_empty_events_summary(self):
+        """Empty events produce zero summary."""
+        summary = summarize_token_events([])
+        assert summary.total_events == 0
+        assert summary.total_bytes_saved == 0
+        assert summary.overall_savings_ratio == 0.0
+
+    def test_summary_aggregates_bytes(self):
+        """Summary aggregates bytes correctly."""
+        events = [
+            build_token_compression_event(
+                SourceLayer.WSP99_M2M, Operation.COMPILE,
+                ContentType.M2M_PROMPT, input_bytes=100, output_bytes=50
+            ),
+            build_token_compression_event(
+                SourceLayer.WSP99_M2M, Operation.COMPILE,
+                ContentType.M2M_PROMPT, input_bytes=200, output_bytes=100
+            ),
+        ]
+        summary = summarize_token_events(events)
+        assert summary.total_events == 2
+        assert summary.total_input_bytes == 300
+        assert summary.total_output_bytes == 150
+        assert summary.total_bytes_saved == 150
+
+    def test_summary_counts_by_status(self):
+        """Summary counts events by status."""
+        events = [
+            build_token_compression_event(
+                SourceLayer.WSP99_M2M, Operation.COMPILE,
+                ContentType.M2M_PROMPT, input_bytes=100, output_bytes=50
+            ),
+            build_token_compression_event(
+                SourceLayer.BYPASS_CLASSIFIER, Operation.BYPASS,
+                ContentType.TOOL_OUTPUT, input_bytes=100, output_bytes=100,
+                bypass_decision="BYPASS_SECURITY"
+            ),
+        ]
+        summary = summarize_token_events(events)
+        assert summary.compressed_count == 1
+        assert summary.bypassed_count == 1
+
+
+class TestInMemoryStore:
+    """In-memory telemetry store tests."""
+
+    def setup_method(self):
+        """Reset store before each test."""
+        reset_telemetry_store()
+
+    def test_store_records_events(self):
+        """Store records and retrieves events."""
+        store = InMemoryTelemetryStore()
+        event = build_token_compression_event(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, input_bytes=100, output_bytes=50
+        )
+        store.record(event)
+        assert store.count() == 1
+        assert store.get_all()[0].event_id == event.event_id
+
+    def test_store_validates_on_record(self):
+        """Store validates events before recording."""
+        store = InMemoryTelemetryStore()
+        event = build_token_compression_event(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, input_bytes=100, output_bytes=50
+        )
+        # Make invalid
+        event.runtime_reindex_allowed = True
+        with pytest.raises(TelemetryValidationError):
+            store.record(event)
+
+    def test_store_rotates_at_max(self):
+        """Store rotates events at max capacity."""
+        store = InMemoryTelemetryStore(max_events=3)
+        for i in range(5):
+            event = build_token_compression_event(
+                SourceLayer.WSP99_M2M, Operation.COMPILE,
+                ContentType.M2M_PROMPT, input_bytes=100 + i, output_bytes=50
+            )
+            store.record(event)
+        assert store.count() == 3
+
+    def test_singleton_pattern(self):
+        """get_telemetry_store returns singleton."""
+        store1 = get_telemetry_store()
+        store2 = get_telemetry_store()
+        assert store1 is store2
+
+
+class TestRawRefNoSecrets:
+    """Verify raw_ref does not contain secret-like material."""
+
+    def test_event_has_no_raw_content_field(self):
+        """TokenCompressionEvent has no raw content field."""
+        event = build_token_compression_event(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, input_bytes=100, output_bytes=50
+        )
+        # Check dataclass fields
+        field_names = [f for f in event.__dataclass_fields__]
+        # Should not have 'raw_content', 'content', 'secret', etc.
+        forbidden = ["raw_content", "content", "secret", "password", "token", "key"]
+        for f in forbidden:
+            assert f not in field_names, f"Field '{f}' should not exist"
+
+    def test_raw_ref_present_is_bool_only(self):
+        """raw_ref_present is a boolean, not actual content."""
+        event = build_token_compression_event(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, input_bytes=100, output_bytes=50,
+            raw_ref_present=True
+        )
+        assert isinstance(event.raw_ref_present, bool)
+
+
+class TestNoRTKOrSubprocess:
+    """AST denylist tests for forbidden imports."""
+
+    def test_no_subprocess_import(self):
+        """telemetry_service.py has no subprocess import."""
+        module_path = Path(__file__).parents[1] / "src" / "telemetry_service.py"
+        source = module_path.read_text()
+        tree = ast.parse(source)
+
+        forbidden = {"subprocess", "os.system", "os.popen"}
+        imports = []
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    imports.append(alias.name)
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    imports.append(node.module)
+
+        for imp in imports:
+            for f in forbidden:
+                assert f not in imp, f"Forbidden import found: {imp}"
+
+    def test_no_rtk_import(self):
+        """telemetry_service.py has no RTK import."""
+        module_path = Path(__file__).parents[1] / "src" / "telemetry_service.py"
+        source = module_path.read_text()
+        assert "import rtk" not in source.lower()
+        assert "from rtk" not in source.lower()
+
+    def test_no_eval_exec(self):
+        """telemetry_service.py has no eval/exec calls."""
+        module_path = Path(__file__).parents[1] / "src" / "telemetry_service.py"
+        source = module_path.read_text()
+        tree = ast.parse(source)
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                if isinstance(node.func, ast.Name):
+                    assert node.func.id not in ("eval", "exec"), \
+                        f"Forbidden call: {node.func.id}"
+
+    def test_no_socket_or_requests(self):
+        """telemetry_service.py has no network imports."""
+        module_path = Path(__file__).parents[1] / "src" / "telemetry_service.py"
+        source = module_path.read_text()
+        forbidden = ["import socket", "import requests", "import aiohttp", "import urllib"]
+        for f in forbidden:
+            assert f not in source, f"Forbidden import: {f}"
+
+
+class TestNoExtensionRuntimeFiles:
+    """Verify no extension runtime files touched."""
+
+    def test_no_extension_js_in_module(self):
+        """Module does not reference extension.js."""
+        module_path = Path(__file__).parents[1] / "src" / "telemetry_service.py"
+        source = module_path.read_text()
+        assert "extension.js" not in source
+        assert "package.json" not in source
+
+    def test_no_vsix_reference(self):
+        """Module does not reference VSIX."""
+        module_path = Path(__file__).parents[1] / "src" / "telemetry_service.py"
+        source = module_path.read_text()
+        assert ".vsix" not in source
+
+
+class TestInvariants:
+    """Invariant safety tests."""
+
+    def test_invariants_always_safe_values(self):
+        """Built events always have safe invariant values."""
+        event = build_token_compression_event(
+            SourceLayer.WSP99_M2M, Operation.COMPILE,
+            ContentType.M2M_PROMPT, input_bytes=100, output_bytes=50
+        )
+        assert event.runtime_reindex_allowed is False
+        assert event.no_command_execution is True
+        assert event.no_rtk_invocation is True
+        assert event.no_secret_persistence is True


### PR DESCRIPTION
## Summary

Implements TOKEN_EFFICIENCY_TELEMETRY_SERVICE_PHASE1 per Contract Section 8.

- **telemetry_service.py**: TokenCompressionEvent, estimate_tokens(), build/validate/summarize functions
- **test_telemetry_service.py**: 48 tests including AST denylist for subprocess/RTK/eval

## Telemetry Schema (Contract Section 8a)

| Field | Type | Description |
|-------|------|-------------|
| event_id | string | Deterministic from content (excludes timestamp) |
| source_layer | enum | WSP99_M2M, RTK_EVALUATION, BYPASS_CLASSIFIER, FIDELITY_GATE |
| operation | enum | compile, decompile, classify, evaluate, bypass |
| input_bytes/tokens | int | Input size metrics |
| output_bytes/tokens | int | Output size metrics |
| bytes_saved | int | input - output (can be negative) |
| savings_ratio | float | bytes_saved / input_bytes |
| compression_status | enum | COMPRESSED, BYPASSED, UNCHANGED, ERROR |
| ctx_holo_present | bool | Whether CTX.HOLO exists |
| index_gap_detected | bool | Whether index gap was detected |

## Invariants (Contract Section 8b)

- [x] NO_NEGATIVE_SAVINGS: bypassed events cannot claim positive savings
- [x] NO_CONTENT_IN_TELEMETRY: only hashes/lengths, never raw content
- [x] runtime_reindex_allowed always False
- [x] no_command_execution always True
- [x] no_rtk_invocation always True

## Truth Boundary Checklist

- [x] NO_RTK_DEPENDENCY
- [x] NO_COMMAND_EXECUTION
- [x] NO_TELEMETRY_PERSISTENCE_BEYOND_IN_MEMORY
- [x] NO_SECRET_PERSISTENCE
- [x] NO_EXTENSION_RUNTIME_CHANGE
- [x] NO_HOLOINDEX_MUTATION
- [x] NO_OPENCLAW_HERMES_WRE_WIRING

## Test Results

```
155 module tests passed (bypass: 56, fidelity: 51, telemetry: 48)
22 contract tests passed
```

## HoloIndex Pre/Post

- Pre-edit: 0 hits for "telemetry_service" in token_efficiency module
- Post-edit: module created, INDEX_GAP recorded
- HOLOINDEX_TOKEN_EFFICIENCY_TELEMETRY_INDEX_GAP_PHASE1 (reindex is WRE/CI action)

---

WSP: WSP_97, WSP_99, WSP_50, WSP_22
Slice: TOKEN_EFFICIENCY_TELEMETRY_SERVICE_PHASE1
Worker-Lane: token-efficiency-P3

🤖 Generated with [Claude Code](https://claude.com/claude-code)