### PR TITLE
feat(reddog): add gated worktree operational spine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ env/
 
 # Git worktrees (local working directories)
 .worktrees/
+.reddog/
 
 # Claude Code worktrees (local runtime artifacts)
 .claude/worktrees/

--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -92,7 +92,7 @@ RedDog is the 0102 architect interface — **not an authority owner**. RedDog re
 
 **OpenClaw adapter dry-run:** `modules/communication/moltbot_bridge/src/reddog_openclaw_adapter_dryrun.py` -- `plan_reddog_openclaw_adapter_dryrun()`; proposes FoundUpJob / `autonomous_task` intake only; **no enqueue**. Contract: `docs/audits/architecture/REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_CONTRACT_PHASE1.md`.
 
-**WRE operational spine dry-run preview (extension v0.3.45):** `buildWreOperationalSpineDryRunPreview()` emits `review_packet.wre_operational_spine_dryrun_preview` and Copy MD section `## WRE Operational Spine Dry-Run Preview`. It references `modules/communication/moltbot_bridge/src/reddog_wre_operational_spine.py::run_reddog_wre_worktree_create_spine` as a future call target only. The extension does **not** invoke Python for this preview and records `python_invocation_performed=false`, `wre_spine_invoked=false`, `worktree_create_performed=false`, `task_execution_performed=false`, `openclaw_enqueue_performed=false`, `hermes_dispatch_performed=false`, `pr_created=false`, and `merge_performed=false`. Future live use requires `VALVE_OPEN_WORKTREE_CREATE` and `012_sovereign`.
+**WRE operational spine dry-run preview (extension v0.3.46):** `buildWreOperationalSpineDryRunPreview()` emits `review_packet.wre_operational_spine_dryrun_preview` and Copy MD section `## WRE Operational Spine Dry-Run Preview`. It references `modules/communication/moltbot_bridge/src/reddog_wre_operational_spine.py::run_reddog_wre_worktree_create_spine` as a future call target only. The extension does **not** invoke Python for this preview and records `python_invocation_performed=false`, `wre_spine_invoked=false`, `worktree_create_performed=false`, `task_execution_performed=false`, `openclaw_enqueue_performed=false`, `hermes_dispatch_performed=false`, `pr_created=false`, and `merge_performed=false`. Future live use requires `VALVE_OPEN_WORKTREE_CREATE` and `012_sovereign`.
 
 **Specified flow (not implemented in extension v0.3.27):**
 
@@ -379,7 +379,7 @@ Formal contract:
 | AssignmentDispatcher as worker launcher | FORBIDDEN (simulated scaffold only) |
 | Governed repo work order dry-run validator | OBSERVED (OpenClaw bridge module) |
 | Governed repo work order (`RedDogGovernedWorkOrder`) | SPECIFIED_NOT_IMPLEMENTED (runtime emission from extension) |
-| WRE operational spine dry-run preview | OBSERVED (extension v0.3.45); metadata only, no invocation |
+| WRE operational spine dry-run preview | OBSERVED (extension v0.3.46); metadata only, no invocation |
 | Extension invokes `reddog_wre_operational_spine.py` | SPECIFIED_NOT_IMPLEMENTED |
 | GitHub permission snapshot per work order | SPECIFIED_NOT_IMPLEMENTED |
 | F0 autonomous merge | SPECIFIED_NOT_IMPLEMENTED |
@@ -434,7 +434,7 @@ Redaction-block-only runs default to `handoff_needed: unknown`, `wsp15_priority:
 
 Extension retains no repo/shell/merge authority.
 
-## WRE Operational Spine Dry-Run Preview (v0.3.45)
+## WRE Operational Spine Dry-Run Preview (v0.3.46)
 
 Substantive non-blocked Copy MD packets append `## WRE Operational Spine Dry-Run Preview` after the governed handoff section. The preview is a typed candidate envelope for the WRE spine path and includes only digests, redacted summary text, target labels, and no-execution booleans. Blocked-local packets skip this preview so blocked payload content is not summarized.
 

--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -49,6 +49,7 @@ Autonomous WRE/DAE agents are NOT 012 work. 012 provides work focus, testing, so
 | WSP_00/WSP_97/WSP_15 prompting | YES | System prompt requires role lock, truth labels, proposed fixes, and MPS priority |
 | Repo edits | NO | No write tool exposed to model |
 | Shell execution by model | NO | Extension host runs only bounded local context/bridge commands; model cannot execute Skillz/OpenClaw/Hermes |
+| WRE operational spine dry-run preview | YES | Copy MD/review packet metadata only; no Python spine call, worktree create, task execution, OpenClaw enqueue, Hermes dispatch, PR, push, merge, or repo mutation |
 | Merge/PR authority | NO | Advisory output only |
 | CABR/payout/source authority | NO | Blocked by Fusion redaction gate and prompt contract |
 | pfMALL integration | SPECIFIED_NOT_IMPLEMENTED | Roadmap only |
@@ -91,6 +92,8 @@ RedDog is the 0102 architect interface — **not an authority owner**. RedDog re
 
 **OpenClaw adapter dry-run:** `modules/communication/moltbot_bridge/src/reddog_openclaw_adapter_dryrun.py` -- `plan_reddog_openclaw_adapter_dryrun()`; proposes FoundUpJob / `autonomous_task` intake only; **no enqueue**. Contract: `docs/audits/architecture/REDDOG_OPENCLAW_FOUNDUPJOB_ADAPTER_DRYRUN_CONTRACT_PHASE1.md`.
 
+**WRE operational spine dry-run preview (extension v0.3.45):** `buildWreOperationalSpineDryRunPreview()` emits `review_packet.wre_operational_spine_dryrun_preview` and Copy MD section `## WRE Operational Spine Dry-Run Preview`. It references `modules/communication/moltbot_bridge/src/reddog_wre_operational_spine.py::run_reddog_wre_worktree_create_spine` as a future call target only. The extension does **not** invoke Python for this preview and records `python_invocation_performed=false`, `wre_spine_invoked=false`, `worktree_create_performed=false`, `task_execution_performed=false`, `openclaw_enqueue_performed=false`, `hermes_dispatch_performed=false`, `pr_created=false`, and `merge_performed=false`. Future live use requires `VALVE_OPEN_WORKTREE_CREATE` and `012_sovereign`.
+
 **Specified flow (not implemented in extension v0.3.27):**
 
 ```text
@@ -129,7 +132,7 @@ Copy:
 - Run Trace build-version field (REDDOG_RUN_TRACE_BUILD_VERSION_FIELD_PHASE1, v0.3.37): the `## Run Trace` block emits `- extension_version: <EXTENSION_VERSION>` near the top (after the header, before role/tier). It reads the real installed-build `EXTENSION_VERSION` constant, NOT any prompt/packet/model value, so build staleness is machine-checkable from telemetry and never masked by model output. 012/tooling gates build staleness on this field, not on model text.
 - Redaction-block runs include `## Redaction Gate Report` (`BLOCKED_LOCALLY`, WSP_97 truth labels, no raw snippets) before any model output.
 - Validation-failure runs include `OUTPUT_VALIDATION_FAILED` with local static footer (no extra network call).
-- Substantive tasks include `## Governed Handoff Recommendation` (`advisory_only`; bounded digest evidence refs only).
+- Substantive tasks include `## Governed Handoff Recommendation` (`advisory_only`; bounded digest evidence refs only). Non-blocked substantive packets also include `## WRE Operational Spine Dry-Run Preview` (metadata only; no invocation).
 - Status/progress scrollback lines are summarized in Run Trace / Work Trail; raw status lines are not duplicated verbatim unless needed for trace fields.
 
 ## 0102 Roles
@@ -376,6 +379,8 @@ Formal contract:
 | AssignmentDispatcher as worker launcher | FORBIDDEN (simulated scaffold only) |
 | Governed repo work order dry-run validator | OBSERVED (OpenClaw bridge module) |
 | Governed repo work order (`RedDogGovernedWorkOrder`) | SPECIFIED_NOT_IMPLEMENTED (runtime emission from extension) |
+| WRE operational spine dry-run preview | OBSERVED (extension v0.3.45); metadata only, no invocation |
+| Extension invokes `reddog_wre_operational_spine.py` | SPECIFIED_NOT_IMPLEMENTED |
 | GitHub permission snapshot per work order | SPECIFIED_NOT_IMPLEMENTED |
 | F0 autonomous merge | SPECIFIED_NOT_IMPLEMENTED |
 | WSP Applicability Preflight | SPECIFIED_NOT_IMPLEMENTED |
@@ -428,6 +433,24 @@ Substantive Copy MD packets append `## Governed Handoff Recommendation`:
 Redaction-block-only runs default to `handoff_needed: unknown`, `wsp15_priority: P1`, and `suggested_slice_name: none` unless concrete fix evidence exists.
 
 Extension retains no repo/shell/merge authority.
+
+## WRE Operational Spine Dry-Run Preview (v0.3.45)
+
+Substantive non-blocked Copy MD packets append `## WRE Operational Spine Dry-Run Preview` after the governed handoff section. The preview is a typed candidate envelope for the WRE spine path and includes only digests, redacted summary text, target labels, and no-execution booleans. Blocked-local packets skip this preview so blocked payload content is not summarized.
+
+| Field | Meaning |
+| --- | --- |
+| `slice_name` | `REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_DRYRUN_WIRE_PHASE1` |
+| `target` | `reddog_wre_operational_spine` |
+| `would_call` | Future spine function reference only; not invoked by extension |
+| `command_digest` | SHA256 of the work focus; raw work focus is not stored |
+| `command_redacted_summary` | Bounded sanitized summary |
+| `dry_run_only` | Always `true` |
+| `python_invocation_performed` / `wre_spine_invoked` | Always `false` in this slice |
+| `worktree_create_performed` / `task_execution_performed` / `file_edit_performed` / `pr_created` / `merge_performed` | Always `false` in this slice |
+| `openclaw_enqueue_performed` / `hermes_dispatch_performed` | Always `false` in this slice |
+| `required_future_valve` | `VALVE_OPEN_WORKTREE_CREATE` |
+| `required_human_gate` | `012_sovereign` |
 
 ## External Acceptance Baseline (v0.3.21+)
 

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,7 +2,7 @@
 
 # ModLog - Foundups®Agent Extension
 
-## 2026-07-09 - REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_DRYRUN_WIRE_PHASE1 (extension dry-run preview, 0.3.45)
+## 2026-07-09 - REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_DRYRUN_WIRE_PHASE1 (extension dry-run preview, 0.3.46)
 
 - Added `buildWreOperationalSpineDryRunPreview()` and `buildWreOperationalSpineDryRunPreviewSection()`.
   Substantive non-blocked RedDog packets now emit `review_packet.wre_operational_spine_dryrun_preview`
@@ -14,8 +14,8 @@
 - Safety: raw work focus is not stored in the preview; it records a full SHA256 `command_digest`, bounded
   sanitized `command_redacted_summary`, digest evidence refs, `required_future_valve: VALVE_OPEN_WORKTREE_CREATE`,
   and `required_human_gate: 012_sovereign`.
-- Version remains 0.3.45 (stacked after the prose-tokenization hotfix; package.json, EXTENSION_VERSION,
-  README, and contract-test version assertions stay aligned).
+- Version 0.3.45 -> 0.3.46 (package.json + EXTENSION_VERSION + README + contract-test version assertions)
+  so this dry-run preview build is distinguishable from the prior prose-tokenization 0.3.45 build.
 - Next gate: `REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_EXPLICIT_VALVE_INVOKE_PHASE1` only after explicit
   `012_sovereign` + `VALVE_OPEN_WORKTREE_CREATE` and leak/non-mutation tests.
 

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,23 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-09 - REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_DRYRUN_WIRE_PHASE1 (extension dry-run preview, 0.3.45)
+
+- Added `buildWreOperationalSpineDryRunPreview()` and `buildWreOperationalSpineDryRunPreviewSection()`.
+  Substantive non-blocked RedDog packets now emit `review_packet.wre_operational_spine_dryrun_preview`
+  and a Copy MD `## WRE Operational Spine Dry-Run Preview` section after the governed handoff section.
+- Boundary: preview metadata only. The extension does NOT call
+  `modules/communication/moltbot_bridge/src/reddog_wre_operational_spine.py`, does NOT create a worktree,
+  does NOT execute tasks, does NOT edit files, does NOT create PRs, does NOT enqueue OpenClaw, does NOT
+  dispatch Hermes, and does NOT push or merge. Blocked-local packets skip the preview.
+- Safety: raw work focus is not stored in the preview; it records a full SHA256 `command_digest`, bounded
+  sanitized `command_redacted_summary`, digest evidence refs, `required_future_valve: VALVE_OPEN_WORKTREE_CREATE`,
+  and `required_human_gate: 012_sovereign`.
+- Version remains 0.3.45 (stacked after the prose-tokenization hotfix; package.json, EXTENSION_VERSION,
+  README, and contract-test version assertions stay aligned).
+- Next gate: `REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_EXPLICIT_VALVE_INVOKE_PHASE1` only after explicit
+  `012_sovereign` + `VALVE_OPEN_WORKTREE_CREATE` and leak/non-mutation tests.
+
 ## 2026-07-07 - REDDOG_WORK_FOCUS_READ_CAPTURE_PROSE_TOKENIZATION_PHASE1 (P0 hotfix, 0.3.44 -> 0.3.45)
 
 - Problem (OBSERVED, real 0.3.44 run on a free-form prose prompt): a `Read first:` prompt naming three

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.45
+Version: 0.3.46
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 
@@ -88,7 +88,7 @@ Canonical architecture contract (docs only, v0.3.27):
 
 Future RedDog runtime must run **WSP Applicability Preflight** before emitting any work order (identify WSPs + Skillz from HoloIndex; block if recall is weak).
 
-## WRE Operational Spine Dry-Run Preview (v0.3.45)
+## WRE Operational Spine Dry-Run Preview (v0.3.46)
 
 Substantive non-blocked RedDog packets now include a typed `## WRE Operational Spine Dry-Run Preview` section in Copy MD and `review_packet.wre_operational_spine_dryrun_preview`. This is a bridge contract only: it names the future `reddog_wre_operational_spine` target, stores SHA256 digests plus a redacted work-focus summary, and records that no Python spine invocation, worktree create, task execution, OpenClaw enqueue, Hermes dispatch, PR creation, or merge occurred.
 

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -72,6 +72,7 @@ Current behavior is advisory-only:
 - no CABR, payout, source-authority, or verification claims
 - no direct Skillz/OpenClaw/Hermes/WRE execution from the extension
 - redaction gate runs before any OpenRouter egress
+- WRE operational spine preview is dry-run metadata only; the extension does not call the spine, create a worktree, run tests, enqueue OpenClaw, dispatch Hermes, create a PR, or merge.
 
 External repositories can be assessed for FoundUps integration through advisory WSP intake, not automatic execution. The future path is FoundUps Agent Intake Mode: WSP readiness audit, FoundUp intake packet, Skillz map, integration risk report, and governed WRE handoff recommendation.
 
@@ -86,6 +87,12 @@ Canonical architecture contract (docs only, v0.3.27):
 - F0 autonomous merge: **SPECIFIED_NOT_IMPLEMENTED** — not planned until prior gates land
 
 Future RedDog runtime must run **WSP Applicability Preflight** before emitting any work order (identify WSPs + Skillz from HoloIndex; block if recall is weak).
+
+## WRE Operational Spine Dry-Run Preview (v0.3.45)
+
+Substantive non-blocked RedDog packets now include a typed `## WRE Operational Spine Dry-Run Preview` section in Copy MD and `review_packet.wre_operational_spine_dryrun_preview`. This is a bridge contract only: it names the future `reddog_wre_operational_spine` target, stores SHA256 digests plus a redacted work-focus summary, and records that no Python spine invocation, worktree create, task execution, OpenClaw enqueue, Hermes dispatch, PR creation, or merge occurred.
+
+The preview requires a future explicit `VALVE_OPEN_WORKTREE_CREATE` and `012_sovereign` gate before any live spine call.
 
 ## Work Focus Contract (v0.3.15)
 

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -18,7 +18,7 @@ Current implementation:
 - REDDOG_EXTERNAL_ACCEPTANCE_BASELINE_PHASE1 (docs): fixed 15-prompt pack, rubric, runbook, artifact template for 012 replacement scoreboard.
 - REDDOG_WORK_FOCUS_TARGET_DERIVATION_PHASE1 (v0.3.44): repo paths named with read-intent in free-form prose / WSP_99 M2M / "Read first" sections (not only under the exact `Required direct-read targets:` header) are promoted to required direct-read targets so the governed fetch fires even on HoloIndex semantic miss; command/validation fences and scope-out sections excluded.
 - REDDOG_WORK_FOCUS_READ_CAPTURE_PROSE_TOKENIZATION_PHASE1 (v0.3.45): flowing-prose `Read first:` lines are tokenized with the bounded path-token regex (not the comma-splitter), so a path followed by prose and an embedded-slash English fragment (`breadcrumb/handoff`) no longer corrupt derived targets; tiered strictness (flowing prose requires a file extension, explicit/M2M/bullet tiers keep slash-OR-extension); slash-only prose fragments reported in `work_focus_targets_dropped_low_confidence` and never flip `target_recall_ok`; `}` added to trailing-punctuation trim.
-- REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_DRYRUN_WIRE_PHASE1 (v0.3.45): Copy MD/review packet emits typed WRE operational spine dry-run preview; no Python spine invocation, worktree create, task execution, OpenClaw enqueue, Hermes dispatch, PR, push, merge, or repo mutation.
+- REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_DRYRUN_WIRE_PHASE1 (v0.3.46): Copy MD/review packet emits typed WRE operational spine dry-run preview; no Python spine invocation, worktree create, task execution, OpenClaw enqueue, Hermes dispatch, PR, push, merge, or repo mutation.
 
 ## Architecture Direction
 
@@ -472,7 +472,7 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 
 ### REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_DRYRUN_WIRE_PHASE1
 
-- **Status:** **IMPLEMENTED (extension dry-run preview only, v0.3.45)** -- `buildWreOperationalSpineDryRunPreview()` emits a typed candidate envelope into Copy MD and `review_packet.wre_operational_spine_dryrun_preview`.
+- **Status:** **IMPLEMENTED (extension dry-run preview only, v0.3.46)** -- `buildWreOperationalSpineDryRunPreview()` emits a typed candidate envelope into Copy MD and `review_packet.wre_operational_spine_dryrun_preview`.
 - **Boundary:** no `cp.execFileSync` call to `reddog_wre_operational_spine.py`, no worktree create, no task execution, no file edit, no PR, no OpenClaw enqueue, no Hermes dispatch, no push, no merge. Blocked-local packets skip the preview.
 - **Next gate:** `REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_EXPLICIT_VALVE_INVOKE_PHASE1` -- only after `012_sovereign` + `VALVE_OPEN_WORKTREE_CREATE` are explicit and tests prove no raw work focus/API key leakage.
 

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -96,16 +96,18 @@ P0 NEXT (execution track)
 P1
 16. REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_WORKTREE_CREATE_PHASE1
     - first real isolated worktree; valve OPEN only
-17. REDDOG_SANITIZED_TARGET_CONTEXT_PROVENANCE_PHASE1
-18. REDDOG_RUN_TRACE_TELEMETRY_CORRECTION_PHASE1
-19. HOLOINDEX_REDDOG_GOVERNED_WORK_ORDER_INDEX_GAP_PHASE1
-20. HOLOINDEX_REDDOG_WRE_EXECUTOR_CONTRACT_INDEX_GAP_PHASE1
-21. HOLOINDEX_REDDOG_WRE_EXECUTOR_DRYRUN_INDEX_GAP_PHASE1
-22. HOLOINDEX_REDDOG_OPENCLAW_ADAPTER_CONTRACT_INDEX_GAP_PHASE1
+17. REDDOG_WRE_OPERATIONAL_SPINE_WORKTREE_CREATE_PHASE1
+    - compose invocation dry-run -> executor plan -> valve -> worktree create; no task execution
+18. REDDOG_SANITIZED_TARGET_CONTEXT_PROVENANCE_PHASE1
+19. REDDOG_RUN_TRACE_TELEMETRY_CORRECTION_PHASE1
+20. HOLOINDEX_REDDOG_GOVERNED_WORK_ORDER_INDEX_GAP_PHASE1
+21. HOLOINDEX_REDDOG_WRE_EXECUTOR_CONTRACT_INDEX_GAP_PHASE1
+22. HOLOINDEX_REDDOG_WRE_EXECUTOR_DRYRUN_INDEX_GAP_PHASE1
+23. HOLOINDEX_REDDOG_OPENCLAW_ADAPTER_CONTRACT_INDEX_GAP_PHASE1
 
 P2/P3
-23. REDDOG_REVIEW_CONSENSUS_RECEIPTS_PHASE1
-24. REDDOG_AUTONOMOUS_MERGE_POLICY_PHASE1 (blocked)
+24. REDDOG_REVIEW_CONSENSUS_RECEIPTS_PHASE1
+25. REDDOG_AUTONOMOUS_MERGE_POLICY_PHASE1 (blocked)
 ```
 
 **Rationale:** Sanitized provenance and telemetry are real polish issues, but the strategic blocker is that RedDog still cannot safely become a worker. The work-order contract is the missing bridge between “advisory RedDog” and “RedDog can direct WRE to do meaningful code work.”
@@ -457,7 +459,15 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 
 ### REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_WORKTREE_CREATE_PHASE1
 
-- **Status:** **BLOCKED** -- until adapter dry-run lands; worktree requires `VALVE_OPEN_WORKTREE_CREATE`.
+- **Status:** **IMPLEMENTED (worktree-create only)** -- `create_reddog_wre_worktree()` consumes an accepted executor dry-run plan plus `VALVE_OPEN_WORKTREE_CREATE`, creates the isolated worktree through an injected runner, and stops before edits/tests/PR/merge.
+- **Module:** `modules/communication/moltbot_bridge/src/reddog_wre_worktree_create.py`
+- **Runner:** `modules/communication/moltbot_bridge/src/reddog_wre_worktree_runner.py`
+
+### REDDOG_WRE_OPERATIONAL_SPINE_WORKTREE_CREATE_PHASE1
+
+- **Status:** **IMPLEMENTED (worktree-create spine only)** -- `run_reddog_wre_worktree_create_spine()` composes #896 invocation dry-run, #898 executor plan, #903 execution valve, and `create_reddog_wre_worktree()` into one callable API.
+- **Module:** `modules/communication/moltbot_bridge/src/reddog_wre_operational_spine.py`
+- **Boundary:** no task execution, file edits, tests, PR, OpenClaw enqueue, Hermes dispatch, push, or merge. VS Code extension runtime wiring is a future gated slice.
 
 ### REDDOG_REVIEW_CONSENSUS_RECEIPTS_PHASE1
 

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -18,6 +18,7 @@ Current implementation:
 - REDDOG_EXTERNAL_ACCEPTANCE_BASELINE_PHASE1 (docs): fixed 15-prompt pack, rubric, runbook, artifact template for 012 replacement scoreboard.
 - REDDOG_WORK_FOCUS_TARGET_DERIVATION_PHASE1 (v0.3.44): repo paths named with read-intent in free-form prose / WSP_99 M2M / "Read first" sections (not only under the exact `Required direct-read targets:` header) are promoted to required direct-read targets so the governed fetch fires even on HoloIndex semantic miss; command/validation fences and scope-out sections excluded.
 - REDDOG_WORK_FOCUS_READ_CAPTURE_PROSE_TOKENIZATION_PHASE1 (v0.3.45): flowing-prose `Read first:` lines are tokenized with the bounded path-token regex (not the comma-splitter), so a path followed by prose and an embedded-slash English fragment (`breadcrumb/handoff`) no longer corrupt derived targets; tiered strictness (flowing prose requires a file extension, explicit/M2M/bullet tiers keep slash-OR-extension); slash-only prose fragments reported in `work_focus_targets_dropped_low_confidence` and never flip `target_recall_ok`; `}` added to trailing-punctuation trim.
+- REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_DRYRUN_WIRE_PHASE1 (v0.3.45): Copy MD/review packet emits typed WRE operational spine dry-run preview; no Python spine invocation, worktree create, task execution, OpenClaw enqueue, Hermes dispatch, PR, push, merge, or repo mutation.
 
 ## Architecture Direction
 
@@ -467,7 +468,13 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 
 - **Status:** **IMPLEMENTED (worktree-create spine only)** -- `run_reddog_wre_worktree_create_spine()` composes #896 invocation dry-run, #898 executor plan, #903 execution valve, and `create_reddog_wre_worktree()` into one callable API.
 - **Module:** `modules/communication/moltbot_bridge/src/reddog_wre_operational_spine.py`
-- **Boundary:** no task execution, file edits, tests, PR, OpenClaw enqueue, Hermes dispatch, push, or merge. VS Code extension runtime wiring is a future gated slice.
+- **Boundary:** no task execution, file edits, tests, PR, OpenClaw enqueue, Hermes dispatch, push, or merge. VS Code extension live invocation is a future gated slice.
+
+### REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_DRYRUN_WIRE_PHASE1
+
+- **Status:** **IMPLEMENTED (extension dry-run preview only, v0.3.45)** -- `buildWreOperationalSpineDryRunPreview()` emits a typed candidate envelope into Copy MD and `review_packet.wre_operational_spine_dryrun_preview`.
+- **Boundary:** no `cp.execFileSync` call to `reddog_wre_operational_spine.py`, no worktree create, no task execution, no file edit, no PR, no OpenClaw enqueue, no Hermes dispatch, no push, no merge. Blocked-local packets skip the preview.
+- **Next gate:** `REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_EXPLICIT_VALVE_INVOKE_PHASE1` -- only after `012_sovereign` + `VALVE_OPEN_WORKTREE_CREATE` are explicit and tests prove no raw work focus/API key leakage.
 
 ### REDDOG_REVIEW_CONSENSUS_RECEIPTS_PHASE1
 

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -28,6 +28,10 @@ const BRIDGE_MAX_STDOUT_BYTES = 262144;
 const BRIDGE_MAX_STDERR_BYTES = 65536;
 const BRIDGE_MAX_CONTEXT_CHARS = 48000;
 const BRIDGE_MAX_PROMPT_CHARS = 12000;
+const WRE_OPERATIONAL_SPINE_DRYRUN_SLICE = 'REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_DRYRUN_WIRE_PHASE1';
+const WRE_OPERATIONAL_SPINE_TARGET = 'reddog_wre_operational_spine';
+const WRE_OPERATIONAL_SPINE_CALL = 'modules/communication/moltbot_bridge/src/reddog_wre_operational_spine.py::run_reddog_wre_worktree_create_spine';
+const WRE_OPERATIONAL_SPINE_REQUIRED_VALVE = 'VALVE_OPEN_WORKTREE_CREATE';
 const MOJIBAKE_MARKERS = ['\u7aa6', '\u7aaa'];
 const WORK_TRAIL_MAX_EVENTS = 50;
 const VALIDATION_FAILED_FOOTER = [
@@ -1550,6 +1554,98 @@ function buildGovernedHandoffSection(recommendation) {
   return lines.join('\n');
 }
 
+function buildWreOperationalSpineDryRunPreview(workFocus, classification, handoffRecommendation, options) {
+  const opts = options && typeof options === 'object' ? options : {};
+  const rec = handoffRecommendation && typeof handoffRecommendation === 'object' ? handoffRecommendation : {};
+  const construction = opts.promptConstruction && typeof opts.promptConstruction === 'object' ? opts.promptConstruction : {};
+  const rawFocus = String(workFocus || '');
+  const workFocusDigest = construction.work_focus_digest && construction.work_focus_digest.hash
+    ? construction.work_focus_digest.hash
+    : (opts.workFocusDigest || 'unknown');
+  const wspPromptDigest = construction.wsp_prompt_digest && construction.wsp_prompt_digest.hash
+    ? construction.wsp_prompt_digest.hash
+    : (opts.wspPromptDigest || 'unknown');
+  const commandDigest = 'sha256:' + crypto.createHash('sha256').update(rawFocus, 'utf8').digest('hex');
+  const tier = classification && classification.tier ? classification.tier : 'HIGH';
+  const evidenceRefs = [];
+  if (workFocusDigest && workFocusDigest !== 'unknown') {
+    evidenceRefs.push('work_focus_digest:' + workFocusDigest);
+  }
+  if (wspPromptDigest && wspPromptDigest !== 'unknown') {
+    evidenceRefs.push('wsp_prompt_digest:' + wspPromptDigest);
+  }
+  if (opts.contextMode) {
+    evidenceRefs.push('context_mode:' + String(opts.contextMode));
+  }
+  if (rec.target) {
+    evidenceRefs.push('handoff_target:' + String(rec.target));
+  }
+  return {
+    preview_kind: 'RedDogWREOperationalSpineDryRunPreview',
+    slice_name: WRE_OPERATIONAL_SPINE_DRYRUN_SLICE,
+    target: WRE_OPERATIONAL_SPINE_TARGET,
+    dry_run_only: true,
+    candidate_work_order_emitted: true,
+    work_order_type: 'RedDogGovernedWorkOrder',
+    command_digest: commandDigest,
+    command_redacted_summary: sanitizeContinuationField(rawFocus, 180),
+    raw_work_focus_stored: false,
+    work_focus_digest: workFocusDigest,
+    wsp_prompt_digest: wspPromptDigest,
+    classification_tier: tier,
+    context_mode: opts.contextMode || 'unknown',
+    handoff_target: rec.target || 'none',
+    handoff_authority_level: rec.authority_level || 'advisory_only',
+    would_call: WRE_OPERATIONAL_SPINE_CALL,
+    python_invocation_performed: false,
+    wre_spine_invoked: false,
+    worktree_create_performed: false,
+    task_execution_performed: false,
+    file_edit_performed: false,
+    pr_created: false,
+    openclaw_enqueue_performed: false,
+    hermes_dispatch_performed: false,
+    merge_performed: false,
+    required_future_valve: WRE_OPERATIONAL_SPINE_REQUIRED_VALVE,
+    required_human_gate: '012_sovereign',
+    not_invoked_reason: 'extension_dry_run_preview_only',
+    evidence_refs: evidenceRefs.length ? evidenceRefs : ['unknown']
+  };
+}
+
+function buildWreOperationalSpineDryRunPreviewSection(preview) {
+  const p = preview && typeof preview === 'object' ? preview : {};
+  const lines = [
+    '## WRE Operational Spine Dry-Run Preview',
+    '- preview_kind: ' + (p.preview_kind || 'unknown') + ' [OBSERVED]',
+    '- slice_name: ' + (p.slice_name || WRE_OPERATIONAL_SPINE_DRYRUN_SLICE) + ' [OBSERVED]',
+    '- target: ' + (p.target || WRE_OPERATIONAL_SPINE_TARGET) + ' [OBSERVED]',
+    '- dry_run_only: ' + (p.dry_run_only === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- candidate_work_order_emitted: ' + (p.candidate_work_order_emitted === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- work_order_type: ' + (p.work_order_type || 'unknown') + ' [OBSERVED]',
+    '- command_digest: ' + (p.command_digest || 'unknown') + ' [OBSERVED]',
+    '- command_redacted_summary: ' + (p.command_redacted_summary || '(empty)') + ' [OBSERVED]',
+    '- raw_work_focus_stored: ' + (p.raw_work_focus_stored === false ? 'false' : 'unknown') + ' [OBSERVED]',
+    '- handoff_target: ' + (p.handoff_target || 'none') + ' [INFERRED]',
+    '- handoff_authority_level: ' + (p.handoff_authority_level || 'advisory_only') + ' [OBSERVED]',
+    '- would_call: ' + (p.would_call || WRE_OPERATIONAL_SPINE_CALL) + ' [OBSERVED]',
+    '- python_invocation_performed: ' + (p.python_invocation_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- wre_spine_invoked: ' + (p.wre_spine_invoked === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- worktree_create_performed: ' + (p.worktree_create_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- task_execution_performed: ' + (p.task_execution_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- file_edit_performed: ' + (p.file_edit_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- pr_created: ' + (p.pr_created === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- openclaw_enqueue_performed: ' + (p.openclaw_enqueue_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- hermes_dispatch_performed: ' + (p.hermes_dispatch_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- merge_performed: ' + (p.merge_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- required_future_valve: ' + (p.required_future_valve || WRE_OPERATIONAL_SPINE_REQUIRED_VALVE) + ' [OBSERVED]',
+    '- required_human_gate: ' + (p.required_human_gate || '012_sovereign') + ' [OBSERVED]',
+    '- not_invoked_reason: ' + (p.not_invoked_reason || 'extension_dry_run_preview_only') + ' [OBSERVED]',
+    '- evidence_refs: ' + JSON.stringify(p.evidence_refs || ['unknown']) + ' [OBSERVED]'
+  ];
+  return lines.join('\n');
+}
+
 function buildCopyMarkdown(result, workerType, contextSummary, workTrail, holoScorecard, resolvedEffort, copyContext) {
   const packet = result && typeof result === 'object' ? result : {};
   const ctx = copyContext && typeof copyContext === 'object' ? copyContext : {};
@@ -1566,6 +1662,10 @@ function buildCopyMarkdown(result, workerType, contextSummary, workTrail, holoSc
   }
   if (ctx.substantive) {
     sections.push(buildGovernedHandoffSection(ctx.handoffRecommendation || packet.governed_handoff_recommendation));
+    const spinePreview = ctx.wreSpineDryRunPreview || packet.wre_operational_spine_dryrun_preview;
+    if (spinePreview) {
+      sections.push(buildWreOperationalSpineDryRunPreviewSection(spinePreview));
+    }
   }
   sections.push(buildContinuationTelemetrySection(ctx.continuationTelemetry || packet.continuation_telemetry));
   // Gate Copy MD continuation inclusion on the toggle (continuationEnabled), not merely on summary existence.
@@ -2616,6 +2716,12 @@ function wireFusionWebview(context, webview, worker, state) {
       workFocusDigest: promptConstruction.work_focus_digest && promptConstruction.work_focus_digest.hash,
       wspPromptDigest: promptConstruction.wsp_prompt_digest && promptConstruction.wsp_prompt_digest.hash
     });
+    const wreSpineDryRunPreview = substantiveTask && result.reason !== 'redaction_blocked'
+      ? buildWreOperationalSpineDryRunPreview(workFocus, classification, handoffRecommendation, {
+        promptConstruction: promptConstruction,
+        contextMode: contextMode
+      })
+      : null;
     result.review_packet = attachOrchestratorMetadata(
       result.review_packet || {},
       classification,
@@ -2630,6 +2736,10 @@ function wireFusionWebview(context, webview, worker, state) {
       unicodeMeta
     );
     result.governed_handoff_recommendation = handoffRecommendation;
+    if (wreSpineDryRunPreview) {
+      result.wre_operational_spine_dryrun_preview = wreSpineDryRunPreview;
+      result.review_packet.wre_operational_spine_dryrun_preview = wreSpineDryRunPreview;
+    }
     if (result.reason === 'redaction_blocked') {
       result.redaction_gate_report = buildRedactionGateReport(result, promptConstruction, contextMode);
       result.review_packet.redaction_gate_report = result.redaction_gate_report;
@@ -2681,6 +2791,7 @@ function wireFusionWebview(context, webview, worker, state) {
       contextMode: contextMode,
       substantive: substantiveTask,
       handoffRecommendation: handoffRecommendation,
+      wreSpineDryRunPreview: wreSpineDryRunPreview,
       continuationEnabled: continuationEnabled,
       continuationTelemetry: continuationTelemetry,
       // Only pass the summary for Copy MD inclusion when appended this run (fail-closed).
@@ -4569,6 +4680,8 @@ module.exports = {
   buildRedactionGateReportSection,
   buildGovernedHandoffRecommendation,
   buildGovernedHandoffSection,
+  buildWreOperationalSpineDryRunPreview,
+  buildWreOperationalSpineDryRunPreviewSection,
   compositePayloadDigest,
   extractHoloIndexScorecard,
   formatHoloIndexScorecardLines,

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.45';
+const EXTENSION_VERSION = '0.3.46';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups®Agent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.45",
+    "version":  "0.3.46",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/README.md
+++ b/extensions/foundups_advisory_workers/tests/README.md
@@ -31,7 +31,7 @@ python -m pytest holo_index/tests/test_reddog_extension_bundle_recall.py -q
 
 ## TEST_REGISTRY
 
-See `TestModLog.md` for TCI-001 through TCI-010, THG-001 through THG-006, UNI-001 through UNI-007, WFTD-001 through WFTD-013 (free-form work-focus target derivation), and WFTD-015 through WFTD-020 (flowing-prose read-capture tokenization + tiered strictness, v0.3.45).
+See `TestModLog.md` for TCI-001 through TCI-010, THG-001 through THG-006, UNI-001 through UNI-007, WFTD-001 through WFTD-014 (free-form work-focus target derivation), WFTD-015 through WFTD-020 (flowing-prose read-capture tokenization + tiered strictness, v0.3.45), and WRE-DRY-001 through WRE-DRY-010 (WRE operational spine dry-run preview).
 
 ## Expected behavior
 

--- a/extensions/foundups_advisory_workers/tests/TestModLog.md
+++ b/extensions/foundups_advisory_workers/tests/TestModLog.md
@@ -1,5 +1,22 @@
 # Foundups®Agent TestModLog
 
+## 2026-07-09 - REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_DRYRUN_WIRE_PHASE1 (WRE-DRY-001..WRE-DRY-010)
+
+| ID | Asserts |
+| --- | --- |
+| WRE-DRY-001 | `buildWreOperationalSpineDryRunPreview` / section builder exported and reachable |
+| WRE-DRY-002 | Preview emits `REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_DRYRUN_WIRE_PHASE1` and target `reddog_wre_operational_spine` |
+| WRE-DRY-003 | Preview records `dry_run_only=true`, no Python invocation, no spine invocation, no worktree create, no task execution |
+| WRE-DRY-004 | Preview records no OpenClaw enqueue, no Hermes dispatch, no PR, no merge |
+| WRE-DRY-005 | Preview uses full SHA256 `command_digest` and does not store raw work focus |
+| WRE-DRY-006 | Secret-adjacent env-name text is sanitized in `command_redacted_summary` and Copy MD |
+| WRE-DRY-007 | Copy MD includes `## WRE Operational Spine Dry-Run Preview` after governed handoff |
+| WRE-DRY-008 | Source has no `execFileSync(...reddog_wre_operational_spine.py...)` call in this slice |
+| WRE-DRY-009 | Blocked-local packets skip WRE preview wiring |
+| WRE-DRY-010 | Future live use is gated by `VALVE_OPEN_WORKTREE_CREATE` and `012_sovereign` |
+
+**Run:** `node extensions/foundups_advisory_workers/tests/verify_extension_contract.js`
+
 ## 2026-07-07 - REDDOG_WORK_FOCUS_READ_CAPTURE_PROSE_TOKENIZATION_PHASE1 (WFTD-015..WFTD-020, v0.3.45)
 
 | ID | Asserts |
@@ -13,7 +30,7 @@
 
 **Run:** `node extensions/foundups_advisory_workers/tests/verify_extension_contract.js`
 
-## 2026-07-07 - REDDOG_WORK_FOCUS_TARGET_DERIVATION_PHASE1 (WFTD-001..WFTD-013)
+## 2026-07-07 - REDDOG_WORK_FOCUS_TARGET_DERIVATION_PHASE1 (WFTD-001..WFTD-014)
 
 | ID | Asserts |
 | --- | --- |

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -702,6 +702,8 @@ includes(extensionJs, 'function buildRunTraceSection', 'buildRunTraceSection mis
 includes(extensionJs, 'function buildWorkTrailSection', 'buildWorkTrailSection missing');
 includes(extensionJs, 'function buildRedactionGateReport', 'buildRedactionGateReport missing');
 includes(extensionJs, 'function buildGovernedHandoffRecommendation', 'buildGovernedHandoffRecommendation missing');
+includes(extensionJs, 'function buildWreOperationalSpineDryRunPreview', 'WRE spine dry-run preview builder missing');
+includes(extensionJs, 'function buildWreOperationalSpineDryRunPreviewSection', 'WRE spine dry-run preview section builder missing');
 includes(extensionJs, 'function detectMojibake', 'detectMojibake missing');
 includes(extensionJs, 'copy_markdown', 'copy_markdown payload missing');
 
@@ -730,6 +732,64 @@ assert.strictEqual(blockedHandoffRec.target, 'WRE', 'target may remain inferred 
 assert.strictEqual(blockedHandoffRec.reason, 'blocked_context_needs_local_0102_review', 'blocked-local handoff must include conservative reason');
 assert.strictEqual(blockedHandoffRec.wsp15_priority, 'P1', 'blocked-local handoff must default to P1');
 assert.strictEqual(blockedHandoffRec.suggested_slice_name, 'none', 'blocked-local handoff must not invent slice name');
+
+// REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_DRYRUN_WIRE_PHASE1:
+// extension emits a typed dry-run preview only; it does NOT call the WRE spine or create a worktree.
+const spinePreview = orchestrator.buildWreOperationalSpineDryRunPreview(
+  'continue the WRE worker slice; OPENROUTER_API_KEY visible to bridge: yes; dry-run only',
+  { tier: 'ULTRA' },
+  handoffRec,
+  {
+    promptConstruction: { work_focus_digest: { hash: 'abc123' }, wsp_prompt_digest: { hash: 'def456' } },
+    contextMode: 'wsp_holo_git_skillz'
+  }
+);
+assert.strictEqual(spinePreview.slice_name, 'REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_DRYRUN_WIRE_PHASE1', 'WRE preview slice name');
+assert.strictEqual(spinePreview.target, 'reddog_wre_operational_spine', 'WRE preview target');
+assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run only');
+assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
+assert.strictEqual(spinePreview.raw_work_focus_stored, false, 'WRE preview must not store raw work focus');
+assert.strictEqual(spinePreview.python_invocation_performed, false, 'WRE preview must not invoke Python');
+assert.strictEqual(spinePreview.wre_spine_invoked, false, 'WRE preview must not invoke the spine');
+assert.strictEqual(spinePreview.worktree_create_performed, false, 'WRE preview must not create a worktree');
+assert.strictEqual(spinePreview.task_execution_performed, false, 'WRE preview must not execute tasks');
+assert.strictEqual(spinePreview.openclaw_enqueue_performed, false, 'WRE preview must not enqueue OpenClaw');
+assert.strictEqual(spinePreview.hermes_dispatch_performed, false, 'WRE preview must not dispatch Hermes');
+assert.strictEqual(spinePreview.required_future_valve, 'VALVE_OPEN_WORKTREE_CREATE', 'WRE preview requires future valve');
+assert.strictEqual(spinePreview.required_human_gate, '012_sovereign', 'WRE preview keeps 012 gate');
+assert(/^sha256:[a-f0-9]{64}$/.test(spinePreview.command_digest), 'WRE preview command_digest must be full SHA256');
+assert(!spinePreview.command_redacted_summary.includes('OPENROUTER_API_KEY'), 'WRE preview summary must sanitize secret-adjacent env name');
+includes(spinePreview.command_redacted_summary, 'key_env_present: true', 'WRE preview summary should carry safe key-presence fact');
+const spinePreviewSection = orchestrator.buildWreOperationalSpineDryRunPreviewSection(spinePreview);
+includes(spinePreviewSection, '## WRE Operational Spine Dry-Run Preview', 'WRE preview section header');
+includes(spinePreviewSection, 'python_invocation_performed: false [OBSERVED]', 'WRE preview section must show no Python invocation');
+includes(spinePreviewSection, 'worktree_create_performed: false [OBSERVED]', 'WRE preview section must show no worktree creation');
+includes(spinePreviewSection, 'required_future_valve: VALVE_OPEN_WORKTREE_CREATE [OBSERVED]', 'WRE preview section must show valve');
+assert(!/execFileSync\([^;]*reddog_wre_operational_spine\.py/s.test(extensionJs), 'extension must not execFileSync the WRE operational spine in dry-run wire slice');
+includes(extensionJs, "result.reason !== 'redaction_blocked'", 'blocked-local packets must not receive WRE dry-run preview');
+
+const wrePreviewCopy = orchestrator.buildCopyMarkdown(
+  {
+    ok: true,
+    content: '## Decision\nProceed with preview only.',
+    review_packet: { task_classification: { tier: 'ULTRA' }, output_validation: { validated: true } },
+    wre_operational_spine_dryrun_preview: spinePreview
+  },
+  'reddog_architect',
+  'Repo context attached',
+  [],
+  null,
+  'ultra',
+  {
+    substantive: true,
+    handoffRecommendation: handoffRec,
+    wreSpineDryRunPreview: spinePreview
+  }
+);
+includes(wrePreviewCopy, '## Governed Handoff Recommendation', 'WRE preview Copy MD keeps governed handoff section');
+includes(wrePreviewCopy, '## WRE Operational Spine Dry-Run Preview', 'WRE preview Copy MD must include preview section');
+includes(wrePreviewCopy, 'raw_work_focus_stored: false [OBSERVED]', 'WRE preview Copy MD must state raw focus is not stored');
+assert(!wrePreviewCopy.includes('OPENROUTER_API_KEY'), 'WRE preview Copy MD must not leak env key name');
 
 const dedupeTrail = orchestrator.createWorkTrail();
 dedupeTrail.push('redaction_gate_blocked', 'Redaction gate blocked before network.');

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -197,8 +197,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.45', 'package version must be 0.3.45');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.45'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.46', 'package version must be 0.3.46');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.46'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups®Agent', 'display name must be Foundups®Agent');
 includes(JSON.stringify(pkg), 'Foundups®Agent: Open', 'command title must use Foundups®Agent');
@@ -215,7 +215,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.45', 'README version mismatch');
+includes(readme, 'Version: 0.3.46', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -1628,7 +1628,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.45'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.46'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -1642,7 +1642,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.45'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.46'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -1654,7 +1654,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.45'", 'bounded context must include extension.js source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.46'", 'bounded context must include extension.js source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -849,3 +849,39 @@ from modules.communication.moltbot_bridge.src.reddog_wre_executor_dryrun import 
 Consumes accepted #896 `WorkOrderDryRunInvocationResult`; validates #897 contract rules;
 emits phase receipts (`plan_built`, `lock_checked`, `cleanup_planned`). No git, worktree,
 file edits, task commands, PR, or merge.
+
+### RedDog WRE Worktree Create (worktree only, no task execution)
+
+```python
+from modules.communication.moltbot_bridge.src.reddog_wre_worktree_create import (
+    create_reddog_wre_worktree,  # (work_order, executor_plan_result, valve_decision, *, runner, repo_root, now, locks) -> RedDogWorktreeCreateResult
+    RedDogWorktreeCreateResult,
+    WORKTREE_CREATE_ACCEPT,
+    WORKTREE_CREATE_REJECT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_worktree_runner import (
+    RealRedDogWorktreeRunner,    # argv-only git worktree add/remove helper
+)
+```
+
+Consumes an accepted executor dry-run plan plus `VALVE_OPEN_WORKTREE_CREATE`.
+Creates only the isolated `.reddog/worktrees/<work_order_id>/<nonce>/` worktree through an
+injected runner. No file edits, tests, PR, push, merge, Skillz execution, Hermes queue,
+OpenClaw dispatch, or task command execution.
+
+### RedDog WRE Worktree Operational Spine (worktree-create only)
+
+```python
+from modules.communication.moltbot_bridge.src.reddog_wre_operational_spine import (
+    run_reddog_wre_worktree_create_spine,  # (work_order, *, valve_environment, runner, repo_root, now, locks) -> RedDogWREOperationalSpineResult
+    RedDogWREOperationalSpineResult,
+    WORKTREE_SPINE_ACCEPT,
+    WORKTREE_SPINE_REJECT,
+)
+```
+
+Composes the governed RedDog path into one callable API:
+runtime invocation dry-run, executor plan dry-run, execution valve, then isolated
+worktree create. Requires `VALVE_OPEN_WORKTREE_CREATE` for acceptance. The result
+keeps WSP 97 truth fields explicit: no task execution, no file edits, no PR, no
+OpenClaw enqueue, no Hermes dispatch, no push, and no merge.

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,21 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-08: REDDOG_WRE_OPERATIONAL_SPINE_WORKTREE_CREATE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 22, 34, 50, 97
+
+- Added `src/reddog_wre_operational_spine.py`: composes the governed RedDog path into one callable API: work-order invocation dry-run, WRE executor plan dry-run, execution valve, then isolated worktree create. It requires `VALVE_OPEN_WORKTREE_CREATE` for acceptance and stops before task execution, file edits, tests, PR, OpenClaw enqueue, Hermes dispatch, push, or merge.
+- Added `tests/test_reddog_wre_operational_spine.py`: full-spine accept path, default-closed valve rejection, invocation rejection on write-sensitive index gap, lock-collision rejection before runner, digest stability, sovereign-token non-egress, and AST boundary checks.
+- Focused validation: `test_reddog_wre_operational_spine.py` passed (6 tests); adjacent invocation / executor dry-run / valve / worktree-create suites passed (35 tests).
+
+## 2026-07-08: REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_WORKTREE_CREATE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 22, 34, 50, 97
+
+- Added `src/reddog_wre_worktree_create.py`: consumes an accepted RedDog executor dry-run plan plus `VALVE_OPEN_WORKTREE_CREATE`, validates branch/worktree/receipt boundaries, and creates only the isolated `.reddog/worktrees/<work_order_id>/<nonce>/` worktree through an injected runner. It emits deterministic receipts and preserves invariants: no task execution, no file edits, no PR, no push, no merge, and main checkout untouched.
+- Added `src/reddog_wre_worktree_runner.py`: argv-only `git worktree add/remove` helper. Authorization remains outside the helper in the orchestration module.
+- Added `tests/test_reddog_wre_worktree_create.py`: accept path, closed-valve/path-scope rejects, cleanup on create failure, digest stability, token non-leak, and AST boundary checks. Focused validation: 8 new tests passed; adjacent RedDog execution valve / executor dry-run / OpenClaw adapter dry-run suites still pass.
+
 ## 2026-07-05: REDDOG_REPAIR_PRESERVES_EVIDENCE_PHASE1 (judgment lane, slice 2)
 
 **Author**: 0102 (RedDog Architect, Judgment lane) | Commander: 012 | Gate: VERIFIED_READY draft PR (do NOT self-merge)

--- a/modules/communication/moltbot_bridge/src/reddog_wre_operational_spine.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_operational_spine.py
@@ -1,0 +1,350 @@
+"""RedDog WRE worktree-create operational spine.
+
+Slice: REDDOG_WRE_OPERATIONAL_SPINE_WORKTREE_CREATE_PHASE1
+
+This module composes the landed RedDog governance spine into one callable path:
+work-order invocation dry-run -> executor plan dry-run -> execution valve ->
+isolated worktree create. It stops before task execution, file edits, tests, PR,
+push, merge, OpenClaw enqueue, or Hermes dispatch.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, MutableSet, Optional
+
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    INTAKE_FOUNDUP_JOB,
+    VALVE_OPEN_WORKTREE_CREATE,
+    ExecutionValveEnvironment,
+    ExecutionValveRequest,
+    evaluate_reddog_execution_valve,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_receipt import (
+    RedDogWorkOrderReceiptStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_runtime_invocation import (
+    INVOCATION_ACCEPT,
+    WorkOrderDryRunInvocationResult,
+    invoke_reddog_work_order_dryrun,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_executor_dryrun import (
+    EXECUTOR_PLAN_ACCEPT,
+    WREExecutorDryRunResult,
+    plan_wre_isolated_worktree_execution_dryrun,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_worktree_create import (
+    WORKTREE_CREATE_ACCEPT,
+    RedDogWorktreeCreateResult,
+    create_reddog_wre_worktree,
+)
+
+WORKTREE_SPINE_ACCEPT = "WORKTREE_SPINE_ACCEPT"
+WORKTREE_SPINE_REJECT = "WORKTREE_SPINE_REJECT"
+
+
+@dataclass
+class RedDogWREOperationalSpineResult:
+    decision: str
+    work_order_id: str
+    invocation_result: Dict[str, Any]
+    executor_plan_result: Dict[str, Any]
+    valve_decision: Dict[str, Any]
+    worktree_create_result: Dict[str, Any]
+    policy_gate_receipt: Dict[str, Any]
+    reddog_work_order_receipt: Dict[str, Any]
+    rejection_reasons: List[str]
+    no_task_execution_performed: bool
+    no_file_edit_performed: bool
+    no_pr_created: bool
+    no_live_openclaw_enqueue: bool
+    no_hermes_dispatch: bool
+    merge_performed: bool
+    main_checkout_untouched: bool
+    created_at: str
+    result_digest: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def _utc_now(now: Optional[datetime] = None) -> datetime:
+    value = now or datetime.now(timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _iso8601(dt: datetime) -> str:
+    return dt.replace(microsecond=0).isoformat()
+
+
+def _canonical_digest(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _work_order_id(work_order: Mapping[str, Any]) -> str:
+    return str(work_order.get("work_order_id") or "unknown")
+
+
+def _minimal_policy_gate_receipt(
+    invocation: WorkOrderDryRunInvocationResult,
+) -> Dict[str, Any]:
+    return {
+        "decision": invocation.policy_gate_decision,
+        "receipt_digest": invocation.policy_gate_receipt_digest,
+        "no_execution_performed": True,
+        "work_order_id": invocation.work_order_id,
+    }
+
+
+def _minimal_reddog_work_order_receipt(
+    invocation: WorkOrderDryRunInvocationResult,
+) -> Dict[str, Any]:
+    return {
+        "receipt_id": invocation.receipt_id,
+        "receipt_digest": invocation.receipt_digest,
+        "policy_gate_receipt_digest": invocation.policy_gate_receipt_digest,
+        "no_execution_performed": True,
+        "work_order_id": invocation.work_order_id,
+    }
+
+
+def _empty_spine_dict() -> Dict[str, Any]:
+    return {}
+
+
+def _result_digest(
+    *,
+    decision: str,
+    work_order_id: str,
+    invocation_result: Mapping[str, Any],
+    executor_plan_result: Mapping[str, Any],
+    valve_decision: Mapping[str, Any],
+    worktree_create_result: Mapping[str, Any],
+    rejection_reasons: List[str],
+    created_at: str,
+) -> str:
+    return _canonical_digest(
+        {
+            "decision": decision,
+            "work_order_id": work_order_id,
+            "invocation_decision": invocation_result.get("decision"),
+            "invocation_receipt_digest": invocation_result.get("receipt_digest"),
+            "executor_plan_decision": executor_plan_result.get("decision"),
+            "executor_plan_digest": (
+                dict(executor_plan_result.get("plan") or {}).get("plan_digest")
+                if isinstance(executor_plan_result.get("plan"), Mapping)
+                else ""
+            ),
+            "valve_state": valve_decision.get("valve_state"),
+            "valve_decision_digest": valve_decision.get("decision_digest"),
+            "worktree_create_decision": worktree_create_result.get("decision"),
+            "worktree_create_digest": worktree_create_result.get("result_digest"),
+            "rejection_reasons": rejection_reasons,
+            "created_at": created_at,
+        }
+    )
+
+
+def _build_result(
+    *,
+    decision: str,
+    work_order_id: str,
+    invocation_result: Mapping[str, Any],
+    executor_plan_result: Mapping[str, Any],
+    valve_decision: Mapping[str, Any],
+    worktree_create_result: Mapping[str, Any],
+    policy_gate_receipt: Mapping[str, Any],
+    reddog_work_order_receipt: Mapping[str, Any],
+    rejection_reasons: List[str],
+    created_at: str,
+) -> RedDogWREOperationalSpineResult:
+    deduped = list(dict.fromkeys(rejection_reasons))
+    digest = _result_digest(
+        decision=decision,
+        work_order_id=work_order_id,
+        invocation_result=invocation_result,
+        executor_plan_result=executor_plan_result,
+        valve_decision=valve_decision,
+        worktree_create_result=worktree_create_result,
+        rejection_reasons=deduped,
+        created_at=created_at,
+    )
+    return RedDogWREOperationalSpineResult(
+        decision=decision,
+        work_order_id=work_order_id,
+        invocation_result=dict(invocation_result),
+        executor_plan_result=dict(executor_plan_result),
+        valve_decision=dict(valve_decision),
+        worktree_create_result=dict(worktree_create_result),
+        policy_gate_receipt=dict(policy_gate_receipt),
+        reddog_work_order_receipt=dict(reddog_work_order_receipt),
+        rejection_reasons=deduped,
+        no_task_execution_performed=True,
+        no_file_edit_performed=True,
+        no_pr_created=True,
+        no_live_openclaw_enqueue=True,
+        no_hermes_dispatch=True,
+        merge_performed=False,
+        main_checkout_untouched=True,
+        created_at=created_at,
+        result_digest=digest,
+    )
+
+
+def run_reddog_wre_worktree_create_spine(
+    work_order: Mapping[str, Any],
+    *,
+    permission_snapshot: Optional[Mapping[str, Any]] = None,
+    seen_nonces: Optional[MutableSet[str]] = None,
+    receipt_store: Optional[RedDogWorkOrderReceiptStore] = None,
+    valve_environment: Optional[ExecutionValveEnvironment | Mapping[str, Any]] = None,
+    runner: Optional[Any] = None,
+    repo_root: Optional[Path] = None,
+    now: Optional[datetime] = None,
+    locks: Optional[MutableSet[str]] = None,
+    intake_target: str = INTAKE_FOUNDUP_JOB,
+    permission_ttl_seconds: int = 300,
+    permission_expires_at: Optional[str] = None,
+) -> RedDogWREOperationalSpineResult:
+    """Run the RedDog worktree-create spine and stop before task execution."""
+    checked = _utc_now(now)
+    created_at = _iso8601(checked)
+    work_order_id = _work_order_id(work_order)
+
+    invocation = invoke_reddog_work_order_dryrun(
+        work_order,
+        permission_snapshot=permission_snapshot,
+        now=checked,
+        seen_nonces=seen_nonces,
+        receipt_store=receipt_store,
+        permission_ttl_seconds=permission_ttl_seconds,
+        permission_expires_at=permission_expires_at,
+    )
+    invocation_dict = invocation.to_dict()
+    policy_receipt = _minimal_policy_gate_receipt(invocation)
+    work_order_receipt = _minimal_reddog_work_order_receipt(invocation)
+
+    if invocation.decision != INVOCATION_ACCEPT:
+        return _build_result(
+            decision=WORKTREE_SPINE_REJECT,
+            work_order_id=work_order_id,
+            invocation_result=invocation_dict,
+            executor_plan_result=_empty_spine_dict(),
+            valve_decision=_empty_spine_dict(),
+            worktree_create_result=_empty_spine_dict(),
+            policy_gate_receipt=policy_receipt,
+            reddog_work_order_receipt=work_order_receipt,
+            rejection_reasons=["invocation_not_accepted", *invocation.rejection_reasons],
+            created_at=created_at,
+        )
+
+    executor_plan = plan_wre_isolated_worktree_execution_dryrun(
+        invocation,
+        work_order,
+        now=checked,
+        locks=locks,
+        repo_root=str(Path(repo_root).resolve()) if repo_root is not None else ".",
+    )
+    executor_dict = executor_plan.to_dict()
+    if executor_plan.decision != EXECUTOR_PLAN_ACCEPT:
+        return _build_result(
+            decision=WORKTREE_SPINE_REJECT,
+            work_order_id=work_order_id,
+            invocation_result=invocation_dict,
+            executor_plan_result=executor_dict,
+            valve_decision=_empty_spine_dict(),
+            worktree_create_result=_empty_spine_dict(),
+            policy_gate_receipt=policy_receipt,
+            reddog_work_order_receipt=work_order_receipt,
+            rejection_reasons=[
+                "executor_plan_not_accepted",
+                *executor_plan.rejection_reasons,
+            ],
+            created_at=created_at,
+        )
+
+    env = valve_environment or ExecutionValveEnvironment()
+    snapshot = dict(permission_snapshot or work_order.get("repo_permission_snapshot") or {})
+    valve = evaluate_reddog_execution_valve(
+        ExecutionValveRequest(
+            work_order=work_order,
+            policy_gate_receipt=policy_receipt,
+            reddog_work_order_receipt=work_order_receipt,
+            invocation_result=invocation_dict,
+            executor_plan_result=executor_dict,
+            intake_target=intake_target,
+            permission_snapshot=snapshot,
+        ),
+        env,
+        now=checked,
+    )
+    valve_dict = valve.to_dict()
+    if valve.valve_state != VALVE_OPEN_WORKTREE_CREATE:
+        return _build_result(
+            decision=WORKTREE_SPINE_REJECT,
+            work_order_id=work_order_id,
+            invocation_result=invocation_dict,
+            executor_plan_result=executor_dict,
+            valve_decision=valve_dict,
+            worktree_create_result=_empty_spine_dict(),
+            policy_gate_receipt=policy_receipt,
+            reddog_work_order_receipt=work_order_receipt,
+            rejection_reasons=[
+                "execution_valve_not_open_for_worktree_create",
+                *valve.rejection_reasons,
+            ],
+            created_at=created_at,
+        )
+
+    worktree = create_reddog_wre_worktree(
+        work_order,
+        executor_dict,
+        valve_dict,
+        runner=runner,
+        repo_root=repo_root,
+        now=checked,
+        locks=locks,
+    )
+    worktree_dict = worktree.to_dict()
+    if worktree.decision != WORKTREE_CREATE_ACCEPT:
+        return _build_result(
+            decision=WORKTREE_SPINE_REJECT,
+            work_order_id=work_order_id,
+            invocation_result=invocation_dict,
+            executor_plan_result=executor_dict,
+            valve_decision=valve_dict,
+            worktree_create_result=worktree_dict,
+            policy_gate_receipt=policy_receipt,
+            reddog_work_order_receipt=work_order_receipt,
+            rejection_reasons=[
+                "worktree_create_not_accepted",
+                *worktree.rejection_reasons,
+            ],
+            created_at=created_at,
+        )
+
+    return _build_result(
+        decision=WORKTREE_SPINE_ACCEPT,
+        work_order_id=work_order_id,
+        invocation_result=invocation_dict,
+        executor_plan_result=executor_dict,
+        valve_decision=valve_dict,
+        worktree_create_result=worktree_dict,
+        policy_gate_receipt=policy_receipt,
+        reddog_work_order_receipt=work_order_receipt,
+        rejection_reasons=[],
+        created_at=created_at,
+    )
+
+
+__all__ = [
+    "RedDogWREOperationalSpineResult",
+    "WORKTREE_SPINE_ACCEPT",
+    "WORKTREE_SPINE_REJECT",
+    "run_reddog_wre_worktree_create_spine",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_wre_worktree_create.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_worktree_create.py
@@ -1,0 +1,445 @@
+"""RedDog WRE isolated worktree create orchestration.
+
+Slice: REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_WORKTREE_CREATE_PHASE1
+
+Consumes an accepted RedDog executor dry-run plan plus an explicit
+VALVE_OPEN_WORKTREE_CREATE decision and materializes only the isolated git
+worktree. It does not edit files, run task commands, run tests, create PRs,
+push branches, invoke Skillz, or merge.
+
+WSP 97 truth boundary:
+  DOES:
+    - Validate the accepted dry-run plan and execution valve
+    - Create one isolated worktree through an injected runner
+    - Emit deterministic receipts and result digests
+  DOES NOT:
+    - Execute task code, edit files, run shell commands directly, call gh, or
+      invoke Hermes/OpenClaw/WRE workers
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, MutableSet, Optional
+
+from modules.communication.moltbot_bridge.src.reddog_governed_work_order_dryrun import (
+    PROTECTED_BASE_REFS,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    VALVE_OPEN_WORKTREE_CREATE,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_executor_dryrun import (
+    EXECUTOR_PLAN_ACCEPT,
+)
+
+WORKTREE_CREATE_ACCEPT = "WORKTREE_CREATE_ACCEPT"
+WORKTREE_CREATE_REJECT = "WORKTREE_CREATE_REJECT"
+
+PHASE_WORKTREE_PREFLIGHT = "worktree_create_preflight"
+PHASE_WORKTREE_CREATED = "worktree_created"
+PHASE_WORKTREE_CLEANUP_PLANNED = "cleanup_planned"
+
+
+@dataclass
+class WorktreeCreateReceipt:
+    phase: str
+    work_order_id: str
+    receipt_digest: str
+    no_task_execution_performed: bool
+    no_file_edit_performed: bool
+    created_at: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class RedDogWorktreeCreateResult:
+    decision: str
+    work_order_id: str
+    branch_name: str
+    worktree_path: str
+    plan_id: str
+    plan_digest: str
+    valve_decision_digest: str
+    rejection_reasons: List[str]
+    phase_receipts: List[WorktreeCreateReceipt]
+    no_task_execution_performed: bool
+    no_file_edit_performed: bool
+    no_pr_created: bool
+    merge_performed: bool
+    main_checkout_untouched: bool
+    cleanup_plan: Dict[str, Any]
+    result_digest: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["phase_receipts"] = [r.to_dict() for r in self.phase_receipts]
+        return payload
+
+
+def _utc_now(now: Optional[datetime] = None) -> datetime:
+    value = now or datetime.now(timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _iso8601(dt: datetime) -> str:
+    return dt.replace(microsecond=0).isoformat()
+
+
+def _canonical_digest(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _work_order_id(work_order: Mapping[str, Any]) -> str:
+    return str(work_order.get("work_order_id") or "unknown")
+
+
+def _receipt(
+    phase: str,
+    work_order_id: str,
+    payload: Mapping[str, Any],
+    created_at: str,
+) -> WorktreeCreateReceipt:
+    body = {
+        "phase": phase,
+        "work_order_id": work_order_id,
+        "no_task_execution_performed": True,
+        "no_file_edit_performed": True,
+        "created_at": created_at,
+        **dict(payload),
+    }
+    return WorktreeCreateReceipt(
+        phase=phase,
+        work_order_id=work_order_id,
+        receipt_digest=_canonical_digest(body),
+        no_task_execution_performed=True,
+        no_file_edit_performed=True,
+        created_at=created_at,
+    )
+
+
+def _default_repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+def _reject(
+    *,
+    work_order_id: str,
+    reasons: List[str],
+    created_at: str,
+    branch_name: str = "",
+    worktree_path: str = "",
+    plan_id: str = "",
+    plan_digest: str = "",
+    valve_decision_digest: str = "",
+    phase_receipts: Optional[List[WorktreeCreateReceipt]] = None,
+    cleanup_plan: Optional[Mapping[str, Any]] = None,
+) -> RedDogWorktreeCreateResult:
+    deduped = list(dict.fromkeys(reasons))
+    receipts = list(phase_receipts or [])
+    cleanup = dict(cleanup_plan or {"status": "no_worktree_created"})
+    body = {
+        "decision": WORKTREE_CREATE_REJECT,
+        "work_order_id": work_order_id,
+        "rejection_reasons": deduped,
+        "created_at": created_at,
+        "plan_id": plan_id,
+        "valve_decision_digest": valve_decision_digest,
+    }
+    return RedDogWorktreeCreateResult(
+        decision=WORKTREE_CREATE_REJECT,
+        work_order_id=work_order_id,
+        branch_name=branch_name,
+        worktree_path=worktree_path,
+        plan_id=plan_id,
+        plan_digest=plan_digest,
+        valve_decision_digest=valve_decision_digest,
+        rejection_reasons=deduped,
+        phase_receipts=receipts,
+        no_task_execution_performed=True,
+        no_file_edit_performed=True,
+        no_pr_created=True,
+        merge_performed=False,
+        main_checkout_untouched=True,
+        cleanup_plan=cleanup,
+        result_digest=_canonical_digest(body),
+    )
+
+
+def _validate_valve(valve_decision: Mapping[str, Any]) -> List[str]:
+    reasons: List[str] = []
+    if valve_decision.get("valve_state") != VALVE_OPEN_WORKTREE_CREATE:
+        reasons.append("execution_valve_not_open_for_worktree_create")
+    if valve_decision.get("no_execution_performed") is not True:
+        reasons.append("valve_execution_detected")
+    if not valve_decision.get("decision_digest"):
+        reasons.append("missing_valve_decision_digest")
+    if valve_decision.get("rejection_reasons"):
+        reasons.append("valve_has_rejection_reasons")
+    return reasons
+
+
+def _plan_from_result(executor_plan_result: Mapping[str, Any]) -> Mapping[str, Any]:
+    plan = executor_plan_result.get("plan")
+    return plan if isinstance(plan, Mapping) else {}
+
+
+def _validate_plan(
+    work_order: Mapping[str, Any],
+    executor_plan_result: Mapping[str, Any],
+    plan: Mapping[str, Any],
+) -> List[str]:
+    reasons: List[str] = []
+    work_order_id = _work_order_id(work_order)
+    if executor_plan_result.get("decision") != EXECUTOR_PLAN_ACCEPT:
+        reasons.append("executor_plan_not_accepted")
+    if executor_plan_result.get("no_mutation_performed") is not True:
+        reasons.append("executor_plan_mutation_detected")
+    if not plan:
+        reasons.append("missing_executor_plan")
+        return reasons
+
+    if plan.get("work_order_id") != work_order_id:
+        reasons.append("plan_work_order_mismatch")
+    if not plan.get("plan_id"):
+        reasons.append("missing_plan_id")
+    if not plan.get("plan_digest"):
+        reasons.append("missing_plan_digest")
+    if plan.get("no_mutation_performed") is not True:
+        reasons.append("plan_mutation_detected")
+
+    branch = str(work_order.get("branch_name") or "").strip()
+    if not branch:
+        reasons.append("missing_branch_name")
+    elif branch.lower() in PROTECTED_BASE_REFS:
+        reasons.append("protected_branch_forbidden")
+    if plan.get("proposed_branch_name") != branch:
+        reasons.append("plan_branch_mismatch")
+
+    if plan.get("lock_key") != work_order_id:
+        reasons.append("plan_lock_key_mismatch")
+
+    return reasons
+
+
+def _validate_worktree_path(
+    work_order_id: str,
+    worktree_path: Path,
+    *,
+    repo_root: Path,
+) -> List[str]:
+    reasons: List[str] = []
+    if not worktree_path.is_absolute():
+        reasons.append("worktree_path_not_absolute")
+        return reasons
+
+    raw = str(worktree_path)
+    resolved = str(worktree_path.resolve())
+    for prefix in ("\\\\?\\", "\\\\.\\", "//?/", "//./"):
+        if raw.startswith(prefix) or resolved.startswith(prefix):
+            reasons.append("worktree_path_device_prefix_forbidden")
+            return reasons
+
+    expected_root = (repo_root / ".reddog" / "worktrees" / work_order_id).resolve()
+    if not _is_inside(worktree_path, expected_root):
+        reasons.append("worktree_path_not_under_reddog_root")
+    if worktree_path.resolve() == repo_root.resolve():
+        reasons.append("worktree_equals_repo_root")
+    return reasons
+
+
+def create_reddog_wre_worktree(
+    work_order: Mapping[str, Any],
+    executor_plan_result: Mapping[str, Any],
+    valve_decision: Mapping[str, Any],
+    *,
+    runner: Optional[Any] = None,
+    repo_root: Optional[Path] = None,
+    now: Optional[datetime] = None,
+    locks: Optional[MutableSet[str]] = None,
+) -> RedDogWorktreeCreateResult:
+    """Create the isolated RedDog WRE worktree and stop before task execution."""
+    checked = _utc_now(now)
+    created_at = _iso8601(checked)
+    repo = (Path(repo_root) if repo_root is not None else _default_repo_root()).resolve()
+    work_order_id = _work_order_id(work_order)
+    plan = _plan_from_result(executor_plan_result)
+    branch_name = str(plan.get("proposed_branch_name") or work_order.get("branch_name") or "")
+    worktree_path_text = str(plan.get("proposed_worktree_path") or "")
+    plan_id = str(plan.get("plan_id") or "")
+    plan_digest = str(plan.get("plan_digest") or "")
+    valve_digest = str(valve_decision.get("decision_digest") or "")
+    cleanup_plan = dict(plan.get("cleanup_plan") or {"status": "no_plan_cleanup"})
+
+    phase_receipts: List[WorktreeCreateReceipt] = []
+    reasons: List[str] = []
+    reasons.extend(_validate_valve(valve_decision))
+    reasons.extend(_validate_plan(work_order, executor_plan_result, plan))
+
+    if locks is not None and work_order_id in locks:
+        reasons.append("lock_collision")
+
+    worktree_path = Path(worktree_path_text)
+    if worktree_path_text:
+        reasons.extend(_validate_worktree_path(work_order_id, worktree_path, repo_root=repo))
+    else:
+        reasons.append("missing_worktree_path")
+
+    if reasons:
+        return _reject(
+            work_order_id=work_order_id,
+            reasons=reasons,
+            created_at=created_at,
+            branch_name=branch_name,
+            worktree_path=worktree_path_text,
+            plan_id=plan_id,
+            plan_digest=plan_digest,
+            valve_decision_digest=valve_digest,
+            phase_receipts=phase_receipts,
+            cleanup_plan={"status": "no_worktree_created", **cleanup_plan},
+        )
+
+    phase_receipts.append(
+        _receipt(
+            PHASE_WORKTREE_PREFLIGHT,
+            work_order_id,
+            {
+                "plan_id": plan_id,
+                "plan_digest": plan_digest,
+                "valve_decision_digest": valve_digest,
+                "branch_name": branch_name,
+            },
+            created_at,
+        )
+    )
+
+    if runner is None:
+        from modules.communication.moltbot_bridge.src.reddog_wre_worktree_runner import (
+            RealRedDogWorktreeRunner,
+        )
+
+        runner = RealRedDogWorktreeRunner(repo)
+
+    if locks is not None:
+        locks.add(work_order_id)
+
+    created = False
+    try:
+        create_result = runner.create_worktree(
+            worktree_path=worktree_path,
+            branch_name=branch_name,
+            base_ref=str(work_order.get("base_ref") or "main"),
+        )
+        created = True
+    except Exception as exc:
+        created = True
+        create_result = {"ok": False, "error": type(exc).__name__}
+
+    if not isinstance(create_result, Mapping) or create_result.get("ok") is not True:
+        cleanup_result: Mapping[str, Any] = {"status": "not_attempted"}
+        if created:
+            try:
+                cleanup_result = runner.cleanup_worktree(worktree_path=worktree_path)
+            except Exception as exc:
+                cleanup_result = {"ok": False, "error": type(exc).__name__}
+        if locks is not None:
+            locks.discard(work_order_id)
+        phase_receipts.append(
+            _receipt(
+                PHASE_WORKTREE_CLEANUP_PLANNED,
+                work_order_id,
+                {"cleanup_attempted": bool(created), "cleanup_digest": _canonical_digest(cleanup_result)},
+                created_at,
+            )
+        )
+        return _reject(
+            work_order_id=work_order_id,
+            reasons=["worktree_create_failed"],
+            created_at=created_at,
+            branch_name=branch_name,
+            worktree_path=worktree_path_text,
+            plan_id=plan_id,
+            plan_digest=plan_digest,
+            valve_decision_digest=valve_digest,
+            phase_receipts=phase_receipts,
+            cleanup_plan={"status": "cleanup_planned_after_create_failure", **cleanup_plan},
+        )
+
+    phase_receipts.append(
+        _receipt(
+            PHASE_WORKTREE_CREATED,
+            work_order_id,
+            {
+                "branch_name": branch_name,
+                "worktree_path": worktree_path_text,
+                "runner_result_digest": _canonical_digest(create_result),
+            },
+            created_at,
+        )
+    )
+    phase_receipts.append(
+        _receipt(
+            PHASE_WORKTREE_CLEANUP_PLANNED,
+            work_order_id,
+            {"cleanup_plan_digest": _canonical_digest(cleanup_plan)},
+            created_at,
+        )
+    )
+
+    body = {
+        "decision": WORKTREE_CREATE_ACCEPT,
+        "work_order_id": work_order_id,
+        "branch_name": branch_name,
+        "worktree_path": worktree_path_text,
+        "plan_id": plan_id,
+        "plan_digest": plan_digest,
+        "valve_decision_digest": valve_digest,
+        "phase_receipts": [r.receipt_digest for r in phase_receipts],
+        "no_task_execution_performed": True,
+        "no_file_edit_performed": True,
+        "no_pr_created": True,
+        "merge_performed": False,
+        "main_checkout_untouched": True,
+    }
+    return RedDogWorktreeCreateResult(
+        decision=WORKTREE_CREATE_ACCEPT,
+        work_order_id=work_order_id,
+        branch_name=branch_name,
+        worktree_path=worktree_path_text,
+        plan_id=plan_id,
+        plan_digest=plan_digest,
+        valve_decision_digest=valve_digest,
+        rejection_reasons=[],
+        phase_receipts=phase_receipts,
+        no_task_execution_performed=True,
+        no_file_edit_performed=True,
+        no_pr_created=True,
+        merge_performed=False,
+        main_checkout_untouched=True,
+        cleanup_plan=cleanup_plan,
+        result_digest=_canonical_digest(body),
+    )
+
+
+__all__ = [
+    "PHASE_WORKTREE_CLEANUP_PLANNED",
+    "PHASE_WORKTREE_CREATED",
+    "PHASE_WORKTREE_PREFLIGHT",
+    "RedDogWorktreeCreateResult",
+    "WORKTREE_CREATE_ACCEPT",
+    "WORKTREE_CREATE_REJECT",
+    "WorktreeCreateReceipt",
+    "create_reddog_wre_worktree",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_wre_worktree_runner.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_worktree_runner.py
@@ -1,0 +1,88 @@
+"""RedDog WRE worktree side-effect runner.
+
+Approved helper for REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_WORKTREE_CREATE_PHASE1.
+It performs only argv-list git worktree create/remove operations. Authorization
+and policy checks live in reddog_wre_worktree_create.py before this runner is
+constructed or called.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class RedDogWorktreeRunner(Protocol):
+    """Side-effect interface used by the worktree-create orchestration."""
+
+    def create_worktree(
+        self,
+        *,
+        worktree_path: Path,
+        branch_name: str,
+        base_ref: str,
+    ) -> Dict[str, Any]: ...
+
+    def cleanup_worktree(self, *, worktree_path: Path) -> Dict[str, Any]: ...
+
+
+class RealRedDogWorktreeRunner:
+    """Runs real git worktree commands after upstream authorization.
+
+    This class deliberately does no policy work. Callers must validate RedDog
+    work-order receipts, the OpenClaw policy gate, the execution valve, path
+    confinement, and branch safety before invoking it.
+    """
+
+    def __init__(self, repo_root: Path, *, timeout_s: int = 120) -> None:
+        self.repo_root = Path(repo_root)
+        self.timeout_s = int(timeout_s)
+
+    def _run(self, argv: list[str]) -> Dict[str, Any]:
+        proc = subprocess.run(
+            argv,
+            cwd=str(self.repo_root),
+            capture_output=True,
+            text=True,
+            timeout=self.timeout_s,
+        )
+        return {
+            "ok": proc.returncode == 0,
+            "returncode": proc.returncode,
+            "stdout": proc.stdout.strip(),
+            "stderr": proc.stderr.strip(),
+        }
+
+    def create_worktree(
+        self,
+        *,
+        worktree_path: Path,
+        branch_name: str,
+        base_ref: str,
+    ) -> Dict[str, Any]:
+        if not Path(worktree_path).is_absolute():
+            return {
+                "ok": False,
+                "returncode": -1,
+                "stdout": "",
+                "stderr": "worktree_path must be absolute",
+            }
+        return self._run(
+            [
+                "git",
+                "worktree",
+                "add",
+                "-b",
+                branch_name,
+                str(worktree_path),
+                base_ref,
+            ]
+        )
+
+    def cleanup_worktree(self, *, worktree_path: Path) -> Dict[str, Any]:
+        return self._run(["git", "worktree", "remove", str(worktree_path), "--force"])
+
+
+__all__ = ["RealRedDogWorktreeRunner", "RedDogWorktreeRunner"]

--- a/modules/communication/moltbot_bridge/tests/README.md
+++ b/modules/communication/moltbot_bridge/tests/README.md
@@ -27,3 +27,8 @@ Optional custom args:
 ```powershell
 .\modules\communication\moltbot_bridge\tests\run_tests.ps1 -PytestArgs @("-q", "-k", "skill_safety")
 ```
+
+Focused RedDog WRE operational spine:
+```powershell
+python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_operational_spine.py modules/communication/moltbot_bridge/tests/test_reddog_wre_worktree_create.py modules/communication/moltbot_bridge/tests/test_reddog_wre_execution_valve.py modules/communication/moltbot_bridge/tests/test_reddog_wre_executor_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_work_order_runtime_invocation.py -q
+```

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,16 @@
+## 2026-07-08: REDDOG_WRE_OPERATIONAL_SPINE_WORKTREE_CREATE_PHASE1
+
+**File**: `test_reddog_wre_operational_spine.py` (NEW - 6 tests)
+**Slice**: `REDDOG_WRE_OPERATIONAL_SPINE_WORKTREE_CREATE_PHASE1` | **Predecessors**: #896 invocation, #898 executor plan, #903 valve, worktree-create slice
+
+Operational spine composer: governed work order -> invocation dry-run -> executor plan -> execution
+valve -> isolated worktree create. Tests prove acceptance with `VALVE_OPEN_WORKTREE_CREATE`,
+default-closed valve rejection before runner, write-sensitive index-gap rejection at invocation,
+lock-collision rejection at plan, digest stability, no sovereign-token egress, and no subprocess/live
+dispatch imports in the composer.
+
+**Run**: `pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_operational_spine.py -q`
+
 ## 2026-06-28: REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_DRYRUN_PHASE1
 
 **File**: `test_reddog_wre_executor_dryrun.py` (NEW — 8 tests)

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_operational_spine.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_operational_spine.py
@@ -1,0 +1,295 @@
+"""Tests for RedDog WRE worktree-create operational spine."""
+
+from __future__ import annotations
+
+import ast
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    ExecutionValveEnvironment,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_operational_spine import (
+    WORKTREE_SPINE_ACCEPT,
+    WORKTREE_SPINE_REJECT,
+    run_reddog_wre_worktree_create_spine,
+)
+
+_TOKEN = "SOVEREIGN-WORKTREE-SPINE-TEST"
+
+
+class FakeRunner:
+    def __init__(self, *, ok: bool = True) -> None:
+        self.ok = ok
+        self.calls: list[tuple] = []
+
+    def create_worktree(self, *, worktree_path, branch_name, base_ref):
+        self.calls.append(("create_worktree", str(worktree_path), branch_name, base_ref))
+        if self.ok:
+            Path(worktree_path).mkdir(parents=True, exist_ok=True)
+        return {"ok": self.ok, "returncode": 0 if self.ok else 1}
+
+    def cleanup_worktree(self, *, worktree_path):
+        self.calls.append(("cleanup_worktree", str(worktree_path)))
+        return {"ok": True}
+
+
+def _future_expiry(now: datetime, hours: int = 2) -> str:
+    return (now + timedelta(hours=hours)).replace(microsecond=0).isoformat()
+
+
+def _base_order(now: datetime, **overrides):
+    captured = (now - timedelta(seconds=60)).replace(microsecond=0).isoformat()
+    payload = {
+        "work_order_id": "wo-operational-spine-001",
+        "created_at": captured,
+        "red_dog_instance_id": "reddog-ext-0.3.45",
+        "authenticated_principal": "principal-012",
+        "principal_provider": "github",
+        "repo_full_name": "FOUNDUPS/Foundups-Agent",
+        "repo_permission_snapshot": {
+            "permission_level": "write",
+            "captured_at": captured,
+            "source": "mock",
+            "digest": "sha256:" + ("a" * 64),
+        },
+        "requested_operation": "feature_slice",
+        "authority_tier": "source",
+        "allowed_paths": ["modules/communication/moltbot_bridge/**"],
+        "denied_paths": [".env"],
+        "branch_name": "feat/reddog-operational-spine-test",
+        "base_ref": "main",
+        "task_summary": "Create the first isolated RedDog WRE worktree.",
+        "wsp_applicability": ["WSP_34", "WSP_50", "WSP_97"],
+        "holoindex_evidence_refs": [
+            "docs/audits/architecture/REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_CONTRACT_PHASE1.md"
+        ],
+        "skillz_candidates": [],
+        "required_tests": [
+            "modules/communication/moltbot_bridge/tests/test_reddog_wre_operational_spine.py"
+        ],
+        "required_policy_gates": ["openclaw_policy_gate"],
+        "required_reviewers": [],
+        "sentinel_checks": [],
+        "rollback_plan": "Remove worktree and delete branch on abort.",
+        "expiry": _future_expiry(now),
+        "nonce": "nonce-operational-spine-001",
+        "evidence_digest": "sha256:" + ("b" * 64),
+        "advisory_only_source_packet": {
+            "work_focus_digest": "sha256:" + ("c" * 64),
+            "wsp_prompt_digest": "sha256:" + ("d" * 64),
+            "copy_md_run_trace_digest": "sha256:" + ("e" * 64),
+        },
+        "holoindex_evidence": {
+            "holoindex_query": "RedDog WRE operational spine",
+            "holoindex_status": "bundle_json_ok",
+            "code_hits": [],
+            "wsp_hits": ["WSP_framework/src/WSP_34_Git_Operations_Protocol.md"],
+            "skillz_hits": [],
+            "direct_read_fallback_used": False,
+            "index_gap_detected": False,
+            "applicable_wsps": ["WSP_34"],
+            "evidence_refs": [
+                "docs/audits/architecture/REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_CONTRACT_PHASE1.md"
+            ],
+            "retrieval_quality": "HIGH",
+            "skillz_gap_detected": False,
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestOperationalSpineAccept:
+    def test_accept_runs_full_spine_to_worktree_create_only(self, tmp_path: Path):
+        fixed = datetime(2026, 7, 8, 12, 0, 0, tzinfo=timezone.utc)
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        order = _base_order(fixed)
+        runner = FakeRunner()
+        locks: set[str] = set()
+
+        result = run_reddog_wre_worktree_create_spine(
+            order,
+            seen_nonces=set(),
+            valve_environment=ExecutionValveEnvironment(
+                valve_worktree_create_enabled=True,
+                sovereign_worktree_token=_TOKEN,
+            ),
+            runner=runner,
+            repo_root=repo_root,
+            now=fixed,
+            locks=locks,
+        )
+
+        assert result.decision == WORKTREE_SPINE_ACCEPT
+        assert result.invocation_result["decision"] == "INVOCATION_ACCEPT"
+        assert result.executor_plan_result["decision"] == "EXECUTOR_PLAN_ACCEPT"
+        assert result.valve_decision["valve_state"] == "VALVE_OPEN_WORKTREE_CREATE"
+        assert result.worktree_create_result["decision"] == "WORKTREE_CREATE_ACCEPT"
+        assert result.no_task_execution_performed is True
+        assert result.no_file_edit_performed is True
+        assert result.no_pr_created is True
+        assert result.no_live_openclaw_enqueue is True
+        assert result.no_hermes_dispatch is True
+        assert result.merge_performed is False
+        assert result.main_checkout_untouched is True
+        assert [call[0] for call in runner.calls] == ["create_worktree"]
+        assert locks == {order["work_order_id"]}
+
+    def test_digest_stable_and_sovereign_token_not_emitted(self, tmp_path: Path):
+        fixed = datetime(2026, 7, 8, 12, 5, 0, tzinfo=timezone.utc)
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        order = _base_order(fixed, nonce="nonce-operational-spine-stable")
+
+        first = run_reddog_wre_worktree_create_spine(
+            order,
+            seen_nonces=set(),
+            valve_environment=ExecutionValveEnvironment(
+                valve_worktree_create_enabled=True,
+                sovereign_worktree_token=_TOKEN,
+            ),
+            runner=FakeRunner(),
+            repo_root=repo_root,
+            now=fixed,
+            locks=set(),
+        )
+        second = run_reddog_wre_worktree_create_spine(
+            order,
+            seen_nonces=set(),
+            valve_environment=ExecutionValveEnvironment(
+                valve_worktree_create_enabled=True,
+                sovereign_worktree_token=_TOKEN,
+            ),
+            runner=FakeRunner(),
+            repo_root=repo_root,
+            now=fixed,
+            locks=set(),
+        )
+
+        assert first.result_digest == second.result_digest
+        assert _TOKEN not in json.dumps(first.to_dict())
+
+
+class TestOperationalSpineReject:
+    def test_default_closed_valve_rejects_before_runner(self, tmp_path: Path):
+        fixed = datetime(2026, 7, 8, 12, 10, 0, tzinfo=timezone.utc)
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        order = _base_order(fixed)
+        runner = FakeRunner()
+
+        result = run_reddog_wre_worktree_create_spine(
+            order,
+            seen_nonces=set(),
+            runner=runner,
+            repo_root=repo_root,
+            now=fixed,
+        )
+
+        assert result.decision == WORKTREE_SPINE_REJECT
+        assert "execution_valve_not_open_for_worktree_create" in result.rejection_reasons
+        assert "explicit_valve_flag_missing" in result.rejection_reasons
+        assert result.worktree_create_result == {}
+        assert runner.calls == []
+
+    def test_index_gap_write_rejects_at_invocation_before_runner(self, tmp_path: Path):
+        fixed = datetime(2026, 7, 8, 12, 15, 0, tzinfo=timezone.utc)
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        order = _base_order(
+            fixed,
+            holoindex_evidence={
+                "holoindex_query": "RedDog WRE operational spine",
+                "holoindex_status": "bundle_json_ok",
+                "code_hits": [],
+                "wsp_hits": [],
+                "skillz_hits": [],
+                "direct_read_fallback_used": False,
+                "index_gap_detected": True,
+                "applicable_wsps": ["WSP_34"],
+                "evidence_refs": [],
+                "retrieval_quality": "INDEX_GAP",
+                "skillz_gap_detected": True,
+            },
+        )
+        runner = FakeRunner()
+
+        result = run_reddog_wre_worktree_create_spine(
+            order,
+            seen_nonces=set(),
+            valve_environment=ExecutionValveEnvironment(
+                valve_worktree_create_enabled=True,
+                sovereign_worktree_token=_TOKEN,
+            ),
+            runner=runner,
+            repo_root=repo_root,
+            now=fixed,
+        )
+
+        assert result.decision == WORKTREE_SPINE_REJECT
+        assert "invocation_not_accepted" in result.rejection_reasons
+        assert "index_gap_blocks_write_operation" in result.rejection_reasons
+        assert result.executor_plan_result == {}
+        assert runner.calls == []
+
+    def test_lock_collision_rejects_at_plan_before_runner(self, tmp_path: Path):
+        fixed = datetime(2026, 7, 8, 12, 20, 0, tzinfo=timezone.utc)
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        order = _base_order(fixed)
+        runner = FakeRunner()
+
+        result = run_reddog_wre_worktree_create_spine(
+            order,
+            seen_nonces=set(),
+            valve_environment=ExecutionValveEnvironment(
+                valve_worktree_create_enabled=True,
+                sovereign_worktree_token=_TOKEN,
+            ),
+            runner=runner,
+            repo_root=repo_root,
+            now=fixed,
+            locks={order["work_order_id"]},
+        )
+
+        assert result.decision == WORKTREE_SPINE_REJECT
+        assert "executor_plan_not_accepted" in result.rejection_reasons
+        assert "lock_collision" in result.rejection_reasons
+        assert result.valve_decision == {}
+        assert runner.calls == []
+
+
+class TestOperationalSpineBoundaries:
+    def test_orchestration_module_has_no_live_dispatch_or_shell_imports(self):
+        module_path = (
+            Path(__file__).resolve().parents[1] / "src" / "reddog_wre_operational_spine.py"
+        )
+        source = module_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imported: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.append(node.module)
+
+        assert "subprocess" not in imported
+        for token in (
+            "shell=True",
+            "git worktree",
+            "worktree add",
+            "gh pr",
+            '"commit"',
+            "'commit'",
+            '"push"',
+            "'push'",
+            "merge_pull_request",
+            "openclaw_supervisor",
+            "hermes_job_executor",
+            "execute_skill",
+            "AgentDB",
+        ):
+            assert token not in source

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_worktree_create.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_worktree_create.py
@@ -1,0 +1,344 @@
+"""Tests for RedDog WRE isolated worktree create orchestration."""
+
+from __future__ import annotations
+
+import ast
+import json
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_work_order_receipt import (
+    RedDogWorkOrderReceiptStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_runtime_invocation import (
+    invoke_reddog_work_order_dryrun,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    INTAKE_FOUNDUP_JOB,
+    VALVE_CLOSED,
+    VALVE_OPEN_WORKTREE_CREATE,
+    ExecutionValveEnvironment,
+    ExecutionValveRequest,
+    evaluate_reddog_execution_valve,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_executor_dryrun import (
+    plan_wre_isolated_worktree_execution_dryrun,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_worktree_create import (
+    PHASE_WORKTREE_CLEANUP_PLANNED,
+    PHASE_WORKTREE_CREATED,
+    PHASE_WORKTREE_PREFLIGHT,
+    WORKTREE_CREATE_ACCEPT,
+    WORKTREE_CREATE_REJECT,
+    create_reddog_wre_worktree,
+)
+
+_TOKEN = "SOVEREIGN-WORKTREE-CREATE-TEST"
+
+
+class FakeRunner:
+    def __init__(self, *, ok: bool = True, raises: bool = False) -> None:
+        self.ok = ok
+        self.raises = raises
+        self.calls: list[tuple] = []
+
+    def create_worktree(self, *, worktree_path, branch_name, base_ref):
+        self.calls.append(("create_worktree", str(worktree_path), branch_name, base_ref))
+        if self.raises:
+            raise RuntimeError("simulated create failure")
+        Path(worktree_path).mkdir(parents=True, exist_ok=True)
+        return {"ok": self.ok, "returncode": 0 if self.ok else 1}
+
+    def cleanup_worktree(self, *, worktree_path):
+        self.calls.append(("cleanup_worktree", str(worktree_path)))
+        return {"ok": True}
+
+
+def _future_expiry(hours: int = 2) -> str:
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).replace(microsecond=0).isoformat()
+
+
+def _fresh_captured() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _base_order(**overrides):
+    payload = {
+        "work_order_id": "wo-worktree-create-001",
+        "created_at": _fresh_captured(),
+        "red_dog_instance_id": "reddog-ext-0.3.45",
+        "authenticated_principal": "principal-012",
+        "principal_provider": "github",
+        "repo_full_name": "FOUNDUPS/Foundups-Agent",
+        "repo_permission_snapshot": {
+            "permission_level": "write",
+            "captured_at": _fresh_captured(),
+            "source": "mock",
+            "digest": "sha256:" + ("a" * 64),
+        },
+        "requested_operation": "feature_slice",
+        "authority_tier": "source",
+        "allowed_paths": ["modules/communication/moltbot_bridge/**"],
+        "denied_paths": [".env"],
+        "branch_name": "feat/reddog-worktree-create-test",
+        "base_ref": "main",
+        "task_summary": "Create an isolated worktree for a RedDog worker slice",
+        "wsp_applicability": ["WSP_34", "WSP_50", "WSP_97"],
+        "holoindex_evidence_refs": [
+            "docs/audits/architecture/REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_CONTRACT_PHASE1.md"
+        ],
+        "skillz_candidates": [],
+        "required_tests": [
+            "modules/communication/moltbot_bridge/tests/test_reddog_wre_worktree_create.py"
+        ],
+        "required_policy_gates": ["openclaw_policy_gate"],
+        "required_reviewers": [],
+        "sentinel_checks": [],
+        "rollback_plan": "Remove worktree and delete branch on abort.",
+        "expiry": _future_expiry(),
+        "nonce": "nonce-worktree-create-001",
+        "evidence_digest": "sha256:" + ("b" * 64),
+        "advisory_only_source_packet": {
+            "work_focus_digest": "sha256:" + ("c" * 64),
+            "wsp_prompt_digest": "sha256:" + ("d" * 64),
+            "copy_md_run_trace_digest": "sha256:" + ("e" * 64),
+        },
+        "holoindex_evidence": {
+            "holoindex_query": "RedDog WRE worktree create",
+            "holoindex_status": "bundle_json_ok",
+            "code_hits": [],
+            "wsp_hits": ["WSP_framework/src/WSP_34_Git_Operations_Protocol.md"],
+            "skillz_hits": [],
+            "direct_read_fallback_used": False,
+            "index_gap_detected": False,
+            "applicable_wsps": ["WSP_34"],
+            "evidence_refs": [
+                "docs/audits/architecture/REDDOG_WRE_ISOLATED_WORKTREE_EXECUTOR_CONTRACT_PHASE1.md"
+            ],
+            "retrieval_quality": "HIGH",
+            "skillz_gap_detected": False,
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _accepted_spine(tmp_path: Path, *, now: datetime | None = None):
+    fixed = now or datetime.now(timezone.utc).replace(microsecond=0)
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    captured = (fixed - timedelta(seconds=60)).replace(microsecond=0).isoformat()
+    order = _base_order(
+        repo_permission_snapshot={
+            "permission_level": "write",
+            "captured_at": captured,
+            "source": "mock",
+            "digest": "sha256:" + ("f" * 64),
+        }
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        with RedDogWorkOrderReceiptStore(Path(tmp) / "receipts.db") as store:
+            invocation = invoke_reddog_work_order_dryrun(
+                order,
+                permission_snapshot=order["repo_permission_snapshot"],
+                seen_nonces=set(),
+                receipt_store=store,
+                now=fixed,
+            )
+    executor = plan_wre_isolated_worktree_execution_dryrun(
+        invocation,
+        order,
+        now=fixed,
+        repo_root=str(repo_root),
+    )
+    policy = {
+        "decision": "POLICY_ACCEPT",
+        "receipt_digest": invocation.policy_gate_receipt_digest,
+        "no_execution_performed": True,
+        "work_order_id": order["work_order_id"],
+    }
+    receipt = {
+        "receipt_id": invocation.receipt_id,
+        "receipt_digest": invocation.receipt_digest,
+        "policy_gate_receipt_digest": invocation.policy_gate_receipt_digest,
+        "no_execution_performed": True,
+        "work_order_id": order["work_order_id"],
+    }
+    valve = evaluate_reddog_execution_valve(
+        ExecutionValveRequest(
+            work_order=order,
+            policy_gate_receipt=policy,
+            reddog_work_order_receipt=receipt,
+            invocation_result=invocation.to_dict(),
+            executor_plan_result=executor.to_dict(),
+            intake_target=INTAKE_FOUNDUP_JOB,
+            permission_snapshot=order["repo_permission_snapshot"],
+        ),
+        ExecutionValveEnvironment(
+            valve_worktree_create_enabled=True,
+            sovereign_worktree_token=_TOKEN,
+        ),
+        now=fixed,
+    )
+    assert valve.valve_state == VALVE_OPEN_WORKTREE_CREATE
+    return order, executor, valve, repo_root, fixed
+
+
+class TestWorktreeCreateAccept:
+    def test_accept_creates_only_worktree(self, tmp_path: Path):
+        order, executor, valve, repo_root, fixed = _accepted_spine(tmp_path)
+        runner = FakeRunner()
+        result = create_reddog_wre_worktree(
+            order,
+            executor.to_dict(),
+            valve.to_dict(),
+            runner=runner,
+            repo_root=repo_root,
+            now=fixed,
+        )
+        assert result.decision == WORKTREE_CREATE_ACCEPT
+        assert result.no_task_execution_performed is True
+        assert result.no_file_edit_performed is True
+        assert result.no_pr_created is True
+        assert result.merge_performed is False
+        assert result.main_checkout_untouched is True
+        assert len(runner.calls) == 1
+        assert runner.calls[0][0] == "create_worktree"
+        assert Path(runner.calls[0][1]).resolve() == Path(result.worktree_path).resolve()
+        assert runner.calls[0][2:] == ("feat/reddog-worktree-create-test", "main")
+        phases = [receipt.phase for receipt in result.phase_receipts]
+        assert phases == [
+            PHASE_WORKTREE_PREFLIGHT,
+            PHASE_WORKTREE_CREATED,
+            PHASE_WORKTREE_CLEANUP_PLANNED,
+        ]
+        assert Path(result.worktree_path).exists()
+
+    def test_digest_stable_and_no_token_leak(self, tmp_path: Path):
+        fixed = datetime(2026, 7, 8, 12, 0, 0, tzinfo=timezone.utc)
+        order, executor, valve, repo_root, _ = _accepted_spine(tmp_path, now=fixed)
+        first = create_reddog_wre_worktree(
+            order,
+            executor.to_dict(),
+            valve.to_dict(),
+            runner=FakeRunner(),
+            repo_root=repo_root,
+            now=fixed,
+        )
+        second = create_reddog_wre_worktree(
+            order,
+            executor.to_dict(),
+            valve.to_dict(),
+            runner=FakeRunner(),
+            repo_root=repo_root,
+            now=fixed,
+        )
+        assert first.result_digest == second.result_digest
+        blob = json.dumps(first.to_dict())
+        assert _TOKEN not in blob
+
+
+class TestWorktreeCreateReject:
+    def test_closed_valve_rejects_before_runner(self, tmp_path: Path):
+        order, executor, valve, repo_root, fixed = _accepted_spine(tmp_path)
+        closed = valve.to_dict()
+        closed["valve_state"] = VALVE_CLOSED
+        runner = FakeRunner()
+        result = create_reddog_wre_worktree(
+            order,
+            executor.to_dict(),
+            closed,
+            runner=runner,
+            repo_root=repo_root,
+            now=fixed,
+        )
+        assert result.decision == WORKTREE_CREATE_REJECT
+        assert "execution_valve_not_open_for_worktree_create" in result.rejection_reasons
+        assert runner.calls == []
+
+    def test_relative_plan_path_rejects_before_runner(self, tmp_path: Path):
+        order, executor, valve, repo_root, fixed = _accepted_spine(tmp_path)
+        payload = executor.to_dict()
+        payload["plan"]["proposed_worktree_path"] = ".reddog/worktrees/wo/nonce/"
+        runner = FakeRunner()
+        result = create_reddog_wre_worktree(
+            order,
+            payload,
+            valve.to_dict(),
+            runner=runner,
+            repo_root=repo_root,
+            now=fixed,
+        )
+        assert result.decision == WORKTREE_CREATE_REJECT
+        assert "worktree_path_not_absolute" in result.rejection_reasons
+        assert runner.calls == []
+
+    def test_outside_reddog_root_rejects_before_runner(self, tmp_path: Path):
+        order, executor, valve, repo_root, fixed = _accepted_spine(tmp_path)
+        payload = executor.to_dict()
+        payload["plan"]["proposed_worktree_path"] = str(tmp_path / "outside")
+        runner = FakeRunner()
+        result = create_reddog_wre_worktree(
+            order,
+            payload,
+            valve.to_dict(),
+            runner=runner,
+            repo_root=repo_root,
+            now=fixed,
+        )
+        assert result.decision == WORKTREE_CREATE_REJECT
+        assert "worktree_path_not_under_reddog_root" in result.rejection_reasons
+        assert runner.calls == []
+
+    def test_create_failure_attempts_cleanup(self, tmp_path: Path):
+        order, executor, valve, repo_root, fixed = _accepted_spine(tmp_path)
+        runner = FakeRunner(ok=False)
+        result = create_reddog_wre_worktree(
+            order,
+            executor.to_dict(),
+            valve.to_dict(),
+            runner=runner,
+            repo_root=repo_root,
+            now=fixed,
+        )
+        assert result.decision == WORKTREE_CREATE_REJECT
+        assert "worktree_create_failed" in result.rejection_reasons
+        assert [call[0] for call in runner.calls] == ["create_worktree", "cleanup_worktree"]
+
+
+class TestWorktreeCreateBoundaries:
+    def test_orchestration_module_delegates_side_effects(self):
+        module_path = (
+            Path(__file__).resolve().parents[1] / "src" / "reddog_wre_worktree_create.py"
+        )
+        source = module_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imported: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.append(node.module)
+        assert "subprocess" not in imported
+        for token in (
+            "git worktree",
+            "worktree add",
+            "gh pr",
+            "commit",
+            "push_branch",
+            "create_draft_pr",
+            "shell=True",
+        ):
+            assert token not in source
+
+    def test_runner_uses_argv_only_and_no_gh(self):
+        module_path = (
+            Path(__file__).resolve().parents[1] / "src" / "reddog_wre_worktree_runner.py"
+        )
+        source = module_path.read_text(encoding="utf-8")
+        assert "shell=True" not in source
+        assert '"gh"' not in source and "'gh'" not in source
+        assert '"commit"' not in source and "'commit'" not in source
+        assert '"push"' not in source and "'push'" not in source
+        assert '"worktree"' in source and '"add"' in source


### PR DESCRIPTION
## Summary

Adds the first callable RedDog WRE operational spine for the governed worktree path:

- adds `create_reddog_wre_worktree()` and argv-only `RealRedDogWorktreeRunner`
- adds `run_reddog_wre_worktree_create_spine()` to compose invocation dry-run -> executor plan -> valve -> isolated worktree create
- updates RedDog and moltbot_bridge memory docs with the worktree-only boundary

## Boundary

This is worktree-create only. It does not execute task commands, edit files, run tests, create PRs, enqueue OpenClaw, dispatch Hermes, push, or merge.

## Validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_operational_spine.py modules/communication/moltbot_bridge/tests/test_reddog_wre_worktree_create.py modules/communication/moltbot_bridge/tests/test_reddog_wre_execution_valve.py modules/communication/moltbot_bridge/tests/test_reddog_wre_executor_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_work_order_runtime_invocation.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_adapter_dryrun.py -q` -> 52 passed
- `python -m py_compile modules/communication/moltbot_bridge/src/reddog_wre_operational_spine.py modules/communication/moltbot_bridge/src/reddog_wre_worktree_create.py modules/communication/moltbot_bridge/src/reddog_wre_worktree_runner.py`
- `git diff --check` on touched files