### PR TITLE
feat(wre): guard worktree operation cwd

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,14 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-09: WRE_WORKTREE_CWD_HAZARD_GUARD_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 34, 50, 97
+
+- Added `src/reddog_wre_cwd_guard.py`: reusable WRE guard for mutating worker commands after worktree creation. It fail-closes unless the operation cwd resolves inside the isolated worktree and outside the shared repo checkout; rejects relative paths, device/extended-length prefixes, nested-main worktrees, filesystem roots, and cwd drift back into the main worktree.
+- Added `tests/test_reddog_wre_cwd_guard.py`: isolated accept/reject coverage for safe worktree cwd, shared repo cwd, worktree-inside-main, cwd-outside-worktree, and relative path failures.
+- Purpose: prevent the repeated worker-lane cwd hazard where git staging/branch operations can accidentally target the shared main worktree instead of the isolated worker checkout.
+- HoloIndex read-only probe: `WRE worktree cwd hazard guard` and `worktree current directory guard git add shared main` did not surface this new guard or runner integration in top results. Recorded as `HOLOINDEX_WRE_WORKTREE_CWD_GUARD_DISCOVERABILITY_PHASE1`; no runtime re-index performed.
+
 ## 2026-07-08: REDDOG_WRE_OPERATIONAL_SPINE_WORKTREE_CREATE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 22, 34, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_wre_cwd_guard.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_cwd_guard.py
@@ -1,0 +1,204 @@
+"""WRE worktree current-directory guard.
+
+This guard is for commands that mutate files or git state after an isolated
+worktree has been created. It deliberately does not authorize the work. It only
+answers whether the operation cwd is inside the isolated worktree and outside
+the shared repository checkout.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict, Optional
+
+WRE_CWD_GUARD_PASS = "WRE_CWD_GUARD_PASS"
+FAIL_REPO_ROOT_NOT_ABSOLUTE = "FAIL_REPO_ROOT_NOT_ABSOLUTE"
+FAIL_WORKTREE_NOT_ABSOLUTE = "FAIL_WORKTREE_NOT_ABSOLUTE"
+FAIL_WORKTREE_DEVICE_PREFIX = "FAIL_WORKTREE_DEVICE_PREFIX"
+FAIL_WORKTREE_INSIDE_REPO_ROOT = "FAIL_WORKTREE_INSIDE_REPO_ROOT"
+FAIL_WORKTREE_EQUALS_FILESYSTEM_ROOT = "FAIL_WORKTREE_EQUALS_FILESYSTEM_ROOT"
+FAIL_OPERATION_CWD_NOT_ABSOLUTE = "FAIL_OPERATION_CWD_NOT_ABSOLUTE"
+FAIL_OPERATION_CWD_DEVICE_PREFIX = "FAIL_OPERATION_CWD_DEVICE_PREFIX"
+FAIL_OPERATION_CWD_OUTSIDE_WORKTREE = "FAIL_OPERATION_CWD_OUTSIDE_WORKTREE"
+FAIL_OPERATION_CWD_INSIDE_REPO_ROOT = "FAIL_OPERATION_CWD_INSIDE_REPO_ROOT"
+
+_DEVICE_PREFIXES = ("\\\\?\\", "\\\\.\\", "//?/", "//./")
+
+
+@dataclass(frozen=True)
+class WreCwdGuardResult:
+    ok: bool
+    code: str
+    reason: str
+    repo_root: str
+    worktree_path: str
+    operation_cwd: str
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+def _as_path(value: Path | str) -> Path:
+    return value if isinstance(value, Path) else Path(str(value))
+
+
+def _has_device_prefix(path: Path) -> bool:
+    raw = str(path)
+    resolved = str(path.resolve())
+    return any(raw.startswith(prefix) or resolved.startswith(prefix) for prefix in _DEVICE_PREFIXES)
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+def _result(
+    *,
+    ok: bool,
+    code: str,
+    reason: str,
+    repo_root: Path,
+    worktree_path: Path,
+    operation_cwd: Path,
+) -> WreCwdGuardResult:
+    return WreCwdGuardResult(
+        ok=ok,
+        code=code,
+        reason=reason,
+        repo_root=str(repo_root),
+        worktree_path=str(worktree_path),
+        operation_cwd=str(operation_cwd),
+    )
+
+
+def validate_wre_worker_operation_cwd(
+    *,
+    repo_root: Path | str,
+    worktree_path: Path | str,
+    operation_cwd: Optional[Path | str] = None,
+) -> WreCwdGuardResult:
+    """Fail closed unless a mutating worker operation runs inside the worktree.
+
+    `repo_root` is the shared checkout. `worktree_path` is the isolated checkout.
+    `operation_cwd` defaults to `worktree_path`, which is the expected cwd for
+    git add/commit/test/edit commands inside a worker lane.
+    """
+
+    repo = _as_path(repo_root)
+    worktree = _as_path(worktree_path)
+    cwd = _as_path(operation_cwd) if operation_cwd is not None else worktree
+
+    if not repo.is_absolute():
+        return _result(
+            ok=False,
+            code=FAIL_REPO_ROOT_NOT_ABSOLUTE,
+            reason="repo_root must be absolute",
+            repo_root=repo,
+            worktree_path=worktree,
+            operation_cwd=cwd,
+        )
+    if not worktree.is_absolute():
+        return _result(
+            ok=False,
+            code=FAIL_WORKTREE_NOT_ABSOLUTE,
+            reason="worktree_path must be absolute",
+            repo_root=repo,
+            worktree_path=worktree,
+            operation_cwd=cwd,
+        )
+    if _has_device_prefix(worktree):
+        return _result(
+            ok=False,
+            code=FAIL_WORKTREE_DEVICE_PREFIX,
+            reason="worktree_path must not use a device or extended-length prefix",
+            repo_root=repo,
+            worktree_path=worktree,
+            operation_cwd=cwd,
+        )
+    if not cwd.is_absolute():
+        return _result(
+            ok=False,
+            code=FAIL_OPERATION_CWD_NOT_ABSOLUTE,
+            reason="operation_cwd must be absolute",
+            repo_root=repo,
+            worktree_path=worktree,
+            operation_cwd=cwd,
+        )
+    if _has_device_prefix(cwd):
+        return _result(
+            ok=False,
+            code=FAIL_OPERATION_CWD_DEVICE_PREFIX,
+            reason="operation_cwd must not use a device or extended-length prefix",
+            repo_root=repo,
+            worktree_path=worktree,
+            operation_cwd=cwd,
+        )
+
+    repo_r = repo.resolve()
+    worktree_r = worktree.resolve()
+    cwd_r = cwd.resolve()
+
+    if worktree_r == Path(worktree_r.anchor):
+        return _result(
+            ok=False,
+            code=FAIL_WORKTREE_EQUALS_FILESYSTEM_ROOT,
+            reason="worktree_path must not be a filesystem root",
+            repo_root=repo_r,
+            worktree_path=worktree_r,
+            operation_cwd=cwd_r,
+        )
+    if _is_inside(worktree_r, repo_r) or _is_inside(repo_r, worktree_r):
+        return _result(
+            ok=False,
+            code=FAIL_WORKTREE_INSIDE_REPO_ROOT,
+            reason="worktree_path must be outside the shared repo root",
+            repo_root=repo_r,
+            worktree_path=worktree_r,
+            operation_cwd=cwd_r,
+        )
+    if _is_inside(cwd_r, repo_r):
+        return _result(
+            ok=False,
+            code=FAIL_OPERATION_CWD_INSIDE_REPO_ROOT,
+            reason="operation_cwd must not be inside the shared repo root",
+            repo_root=repo_r,
+            worktree_path=worktree_r,
+            operation_cwd=cwd_r,
+        )
+    if not _is_inside(cwd_r, worktree_r):
+        return _result(
+            ok=False,
+            code=FAIL_OPERATION_CWD_OUTSIDE_WORKTREE,
+            reason="operation_cwd must be inside the isolated worktree",
+            repo_root=repo_r,
+            worktree_path=worktree_r,
+            operation_cwd=cwd_r,
+        )
+
+    return _result(
+        ok=True,
+        code=WRE_CWD_GUARD_PASS,
+        reason="operation_cwd is isolated inside worktree",
+        repo_root=repo_r,
+        worktree_path=worktree_r,
+        operation_cwd=cwd_r,
+    )
+
+
+__all__ = [
+    "FAIL_OPERATION_CWD_DEVICE_PREFIX",
+    "FAIL_OPERATION_CWD_INSIDE_REPO_ROOT",
+    "FAIL_OPERATION_CWD_NOT_ABSOLUTE",
+    "FAIL_OPERATION_CWD_OUTSIDE_WORKTREE",
+    "FAIL_REPO_ROOT_NOT_ABSOLUTE",
+    "FAIL_WORKTREE_DEVICE_PREFIX",
+    "FAIL_WORKTREE_EQUALS_FILESYSTEM_ROOT",
+    "FAIL_WORKTREE_INSIDE_REPO_ROOT",
+    "FAIL_WORKTREE_NOT_ABSOLUTE",
+    "WRE_CWD_GUARD_PASS",
+    "WreCwdGuardResult",
+    "validate_wre_worker_operation_cwd",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_cwd_guard.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_cwd_guard.py
@@ -1,0 +1,104 @@
+"""Tests for WRE worktree current-directory guard."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_wre_cwd_guard import (
+    FAIL_OPERATION_CWD_INSIDE_REPO_ROOT,
+    FAIL_OPERATION_CWD_NOT_ABSOLUTE,
+    FAIL_OPERATION_CWD_OUTSIDE_WORKTREE,
+    FAIL_WORKTREE_INSIDE_REPO_ROOT,
+    FAIL_WORKTREE_NOT_ABSOLUTE,
+    WRE_CWD_GUARD_PASS,
+    validate_wre_worker_operation_cwd,
+)
+
+
+def test_accepts_cwd_inside_isolated_worktree(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "wt"
+    cwd = worktree / "modules" / "foundups" / "demo"
+    repo.mkdir()
+    cwd.mkdir(parents=True)
+
+    result = validate_wre_worker_operation_cwd(
+        repo_root=repo,
+        worktree_path=worktree,
+        operation_cwd=cwd,
+    )
+
+    assert result.ok is True
+    assert result.code == WRE_CWD_GUARD_PASS
+    assert Path(result.operation_cwd).resolve() == cwd.resolve()
+
+
+def test_rejects_mutating_cwd_at_shared_repo_root(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "wt"
+    repo.mkdir()
+    worktree.mkdir()
+
+    result = validate_wre_worker_operation_cwd(
+        repo_root=repo,
+        worktree_path=worktree,
+        operation_cwd=repo,
+    )
+
+    assert result.ok is False
+    assert result.code == FAIL_OPERATION_CWD_INSIDE_REPO_ROOT
+
+
+def test_rejects_worktree_inside_shared_repo_root(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    worktree = repo / ".reddog" / "worktrees" / "wo" / "nonce"
+    repo.mkdir(parents=True)
+    worktree.mkdir(parents=True)
+
+    result = validate_wre_worker_operation_cwd(
+        repo_root=repo,
+        worktree_path=worktree,
+    )
+
+    assert result.ok is False
+    assert result.code == FAIL_WORKTREE_INSIDE_REPO_ROOT
+
+
+def test_rejects_operation_cwd_outside_worktree(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "wt"
+    other = tmp_path / "other"
+    repo.mkdir()
+    worktree.mkdir()
+    other.mkdir()
+
+    result = validate_wre_worker_operation_cwd(
+        repo_root=repo,
+        worktree_path=worktree,
+        operation_cwd=other,
+    )
+
+    assert result.ok is False
+    assert result.code == FAIL_OPERATION_CWD_OUTSIDE_WORKTREE
+
+
+def test_rejects_relative_worktree_and_cwd(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    relative_worktree = validate_wre_worker_operation_cwd(
+        repo_root=repo,
+        worktree_path=Path("relative-wt"),
+    )
+    assert relative_worktree.ok is False
+    assert relative_worktree.code == FAIL_WORKTREE_NOT_ABSOLUTE
+
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    relative_cwd = validate_wre_worker_operation_cwd(
+        repo_root=repo,
+        worktree_path=worktree,
+        operation_cwd=Path("relative-cwd"),
+    )
+    assert relative_cwd.ok is False
+    assert relative_cwd.code == FAIL_OPERATION_CWD_NOT_ABSOLUTE

--- a/modules/foundups/agent/ModLog.md
+++ b/modules/foundups/agent/ModLog.md
@@ -1,5 +1,19 @@
 # Agent Module ModLog
 
+## 2026-07-09 - WRE worktree cwd hazard guard integration
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 34, 50, 97
+**Slice**: WRE_WORKTREE_CWD_HAZARD_GUARD_PHASE1
+
+### Changed
+
+- Updated `src/worktree_pr_runner.py`: before `git add`, `git commit`, `git push`, or worktree cleanup, `RealWorktreeRunner` now calls the shared WRE cwd guard and refuses to run subprocess if the supplied worktree path resolves to the shared repo root or a nested path inside it. Mutating git commands now execute with the process cwd set to the isolated worktree rather than the main checkout.
+- Extended `tests/test_foundup_scaffold_writer_live.py`: verifies valid mutating git calls run from the worktree cwd, and shared-root / nested-main paths are rejected before subprocess is invoked.
+
+### Boundary
+
+No new live writer authority, no merge authority, no PR-ready path, and no task execution. This slice only hardens the approved runner against lane-cwd contamination.
+
 ## 2026-07-04 - FIRST live scaffold writer: isolated worktree + draft PR only (FOUNDUP_SCAFFOLD_WRITER_LIVE_PHASE1)
 
 **Author**: 0102 (RedDog Architect) | Commander: 012 | Gate: VERIFIED_READY draft PR (do NOT self-merge)

--- a/modules/foundups/agent/src/worktree_pr_runner.py
+++ b/modules/foundups/agent/src/worktree_pr_runner.py
@@ -26,6 +26,10 @@ import subprocess
 from pathlib import Path
 from typing import Any, Dict, Protocol, runtime_checkable
 
+from modules.communication.moltbot_bridge.src.reddog_wre_cwd_guard import (
+    validate_wre_worker_operation_cwd,
+)
+
 
 @runtime_checkable
 class WorktreeRunner(Protocol):
@@ -50,6 +54,21 @@ class RealWorktreeRunner:
         self.repo_root = Path(repo_root)
         self.timeout_s = timeout_s
 
+    def _guard_worktree_cwd(self, worktree_path: Path) -> Dict[str, Any] | None:
+        guard = validate_wre_worker_operation_cwd(
+            repo_root=self.repo_root,
+            worktree_path=worktree_path,
+            operation_cwd=worktree_path,
+        )
+        if guard.ok:
+            return None
+        return {
+            "ok": False,
+            "returncode": -1,
+            "stdout": "",
+            "stderr": f"{guard.code}: {guard.reason}",
+        }
+
     def _run(self, argv, cwd=None) -> Dict[str, Any]:
         proc = subprocess.run(  # noqa: S603 -- argv list, no shell, approved helper
             argv, cwd=str(cwd or self.repo_root),
@@ -67,23 +86,34 @@ class RealWorktreeRunner:
         # would be resolved against this runner's cwd (repo_root), risking an in-repo worktree.
         if not Path(worktree_path).is_absolute():
             return {"ok": False, "returncode": -1, "stdout": "", "stderr": "worktree_path must be absolute"}
+        guard = self._guard_worktree_cwd(Path(worktree_path))
+        if guard is not None:
+            return guard
         return self._run(
             ["git", "worktree", "add", "-b", branch_name, str(worktree_path), base_branch],
         )
 
     def commit_all(self, *, worktree_path: Path, add_paths, message: str) -> Dict[str, Any]:
+        guard = self._guard_worktree_cwd(Path(worktree_path))
+        if guard is not None:
+            return guard
         # Stage ONLY the explicit module path(s) -- never `git add -A` -- so nothing
         # outside the scaffolded module can be committed even if the worktree is dirty.
         add = self._run(
-            ["git", "-C", str(worktree_path), "add", "--"] + [str(p) for p in add_paths],
+            ["git", "add", "--"] + [str(p) for p in add_paths],
+            cwd=worktree_path,
         )
         if not add["ok"]:
             return add
-        return self._run(["git", "-C", str(worktree_path), "commit", "-m", message])
+        return self._run(["git", "commit", "-m", message], cwd=worktree_path)
 
     def push_branch(self, *, worktree_path: Path, branch_name: str) -> Dict[str, Any]:
+        guard = self._guard_worktree_cwd(Path(worktree_path))
+        if guard is not None:
+            return guard
         return self._run(
-            ["git", "-C", str(worktree_path), "push", "-u", "origin", branch_name],
+            ["git", "push", "-u", "origin", branch_name],
+            cwd=worktree_path,
         )
 
     def create_draft_pr(self, *, branch_name: str, base_branch: str, title: str, body: str) -> str:
@@ -98,4 +128,7 @@ class RealWorktreeRunner:
         return res["stdout"]
 
     def cleanup_worktree(self, *, worktree_path: Path) -> Dict[str, Any]:
+        guard = self._guard_worktree_cwd(Path(worktree_path))
+        if guard is not None:
+            return guard
         return self._run(["git", "worktree", "remove", str(worktree_path), "--force"])

--- a/modules/foundups/agent/tests/test_foundup_scaffold_writer_live.py
+++ b/modules/foundups/agent/tests/test_foundup_scaffold_writer_live.py
@@ -433,6 +433,122 @@ def test_real_runner_create_draft_pr_only(monkeypatch: pytest.MonkeyPatch) -> No
     assert not any(hasattr(runner, m) for m in ("mark_ready", "ready", "merge", "merge_pr"))
 
 
+def test_real_runner_mutating_git_uses_worktree_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import modules.foundups.agent.src.worktree_pr_runner as wr
+
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worker-wt"
+    repo.mkdir()
+    worktree.mkdir()
+    captured: list = []
+
+    class _Proc:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def _run(argv, **kw):
+        captured.append((argv, kw))
+        return _Proc()
+
+    monkeypatch.setattr(wr.subprocess, "run", _run)
+    runner = wr.RealWorktreeRunner(repo_root=repo)
+
+    result = runner.commit_all(
+        worktree_path=worktree,
+        add_paths=["modules/foundups/paccess_001"],
+        message="test",
+    )
+
+    assert result["ok"] is True
+    assert len(captured) == 2
+    assert captured[0][0] == ["git", "add", "--", "modules/foundups/paccess_001"]
+    assert captured[1][0] == ["git", "commit", "-m", "test"]
+    assert Path(captured[0][1]["cwd"]).resolve() == worktree.resolve()
+    assert Path(captured[1][1]["cwd"]).resolve() == worktree.resolve()
+
+
+def test_real_runner_refuses_shared_repo_cwd_before_subprocess(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import modules.foundups.agent.src.worktree_pr_runner as wr
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    captured: list = []
+
+    def _run(argv, **kw):
+        captured.append((argv, kw))
+        raise AssertionError("subprocess must not run when worktree path is repo root")
+
+    monkeypatch.setattr(wr.subprocess, "run", _run)
+    runner = wr.RealWorktreeRunner(repo_root=repo)
+
+    result = runner.commit_all(
+        worktree_path=repo,
+        add_paths=["modules/foundups/paccess_001"],
+        message="test",
+    )
+
+    assert result["ok"] is False
+    assert "FAIL_WORKTREE_INSIDE_REPO_ROOT" in result["stderr"]
+    assert captured == []
+
+
+def test_real_runner_refuses_in_repo_worktree_create_before_subprocess(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import modules.foundups.agent.src.worktree_pr_runner as wr
+
+    repo = tmp_path / "repo"
+    nested = repo / ".reddog" / "worktrees" / "wo" / "nonce"
+    repo.mkdir()
+    captured: list = []
+
+    def _run(argv, **kw):
+        captured.append((argv, kw))
+        raise AssertionError("subprocess must not create an in-repo worktree")
+
+    monkeypatch.setattr(wr.subprocess, "run", _run)
+    runner = wr.RealWorktreeRunner(repo_root=repo)
+
+    result = runner.create_worktree(
+        worktree_path=nested,
+        branch_name="feat/demo",
+        base_branch="main",
+    )
+
+    assert result["ok"] is False
+    assert "FAIL_WORKTREE_INSIDE_REPO_ROOT" in result["stderr"]
+    assert captured == []
+
+
+def test_real_runner_refuses_nested_main_worktree_before_push(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import modules.foundups.agent.src.worktree_pr_runner as wr
+
+    repo = tmp_path / "repo"
+    nested = repo / ".reddog" / "worktrees" / "wo" / "nonce"
+    nested.mkdir(parents=True)
+    captured: list = []
+
+    def _run(argv, **kw):
+        captured.append((argv, kw))
+        raise AssertionError("subprocess must not run for nested main worktree")
+
+    monkeypatch.setattr(wr.subprocess, "run", _run)
+    runner = wr.RealWorktreeRunner(repo_root=repo)
+
+    result = runner.push_branch(worktree_path=nested, branch_name="feat/demo")
+
+    assert result["ok"] is False
+    assert "FAIL_WORKTREE_INSIDE_REPO_ROOT" in result["stderr"]
+    assert captured == []
+
+
 # schema-compat: the real preauth packet exposes every field the live writer reads
 def test_real_preauth_packet_is_field_compatible(tmp_path: Path) -> None:
     from modules.foundups.agent.src.live_writer_preauth_packet import (


### PR DESCRIPTION
## Summary

Implements WRE_WORKTREE_CWD_HAZARD_GUARD_PHASE1.

- Adds a reusable WRE current-directory guard for mutating worker operations after a worktree exists.
- Integrates the guard into the approved FoundUp live writer side-effect runner before worktree creation, git add/commit, push, and cleanup.
- Forces mutating git calls to run with the OS cwd set to the isolated worktree, not the shared main checkout.
- Refuses shared-root, nested-main, relative, filesystem-root, and device/extended-length-prefixed worktree/cwd inputs before subprocess.

## WSP_97 Truth Boundary

- OBSERVED: the repeated worker-lane cwd hazard can put git staging/branch operations in the shared main worktree.
- OBSERVED: this slice adds guard logic and tests only; it does not expand RedDog authority.
- OBSERVED: runner integration still uses argv-list subprocess only and draft-PR-only semantics from the existing live writer lane.
- SPECIFIED_NOT_IMPLEMENTED: generic governed shell runner, RedDog recursive orchestration, merge authority, and live pAccess execution remain separately gated.

## HoloIndex Addendum

Read-only HoloIndex probes were run:

- `WRE worktree cwd hazard guard`
- `worktree current directory guard git add shared main`

The new guard/runner integration did not appear in top results. Recorded as `HOLOINDEX_WRE_WORKTREE_CWD_GUARD_DISCOVERABILITY_PHASE1`. No runtime re-index was performed.

## Validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_cwd_guard.py modules/communication/moltbot_bridge/tests/test_reddog_wre_worktree_create.py modules/communication/moltbot_bridge/tests/test_reddog_wre_operational_spine.py -q` -> 19 passed
- `python -m pytest modules/foundups/agent/tests/test_foundup_scaffold_writer_live.py modules/foundups/agent/tests/test_live_writer_preauth_packet.py modules/foundups/agent/tests/test_scaffold_writer_dryrun.py -q` -> 91 passed
- `python -m pytest modules/foundups/agent/tests -q` -> 1132 passed
- scoped `git diff --check` -> clean
- added-line non-ASCII scan -> 0

Global `git diff --check` is not used as the gate because an unrelated pre-existing dirty file, `modules/ai_intelligence/ai_overseer/ModLog.md`, contains trailing whitespace and is intentionally untouched by this slice.

## Boundary

No live writer invocation, no task execution, no merge, no PR-ready path, no HoloIndex re-index, and no changes to unrelated local WIP.