### PR TITLE
feat(reddog): integrate signed work-order gate

### DIFF
--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -789,7 +789,8 @@ Higher-priority work (restarts, autonomous tasks, self-audit events) blocks skil
 
 ```python
 from modules.communication.moltbot_bridge.src.reddog_openclaw_work_order_policy_gate import (
-    evaluate_work_order_policy_gate,  # (order, *, now, seen_nonces, permission_ttl_seconds, permission_expires_at) -> PolicyGateReceipt
+    evaluate_work_order_policy_gate,  # (order, *, now, seen_nonces, permission_ttl_seconds, permission_expires_at, require_signed_authority, signature_verification_result) -> PolicyGateReceipt
+    evaluate_signed_work_order_policy_gate,  # verifies E1 identity/work-authority, then policy-gates
     PolicyGateReceipt,
     POLICY_ACCEPT,
     POLICY_REJECT,
@@ -802,6 +803,17 @@ Composes `#890` `validate_work_order_dryrun()` and embedded `repo_permission_sna
 (uses `#892` `permission_to_capabilities` only — does not call `probe_repo_permission` or `gh`).
 Returns Hermes-shaped receipt with `no_execution_performed: true`. Spec:
 `docs/audits/architecture/REDDOG_GOVERNED_REPO_WORK_ORDER_CONTRACT_PHASE1.md`.
+
+`REDDOG_WORK_ORDER_SIGNATURE_GATE_INTEGRATION_PHASE1`: callers that approach worktree
+authority set `require_signed_authority=True` and provide the E1 verifier result as
+`signature_verification_result`. The gate fails closed on missing, rejected, malformed,
+or work-order-mismatched verifier output. Receipts include `signature_gate_status` and
+`signature_gate_digest`.
+
+Future live callers should prefer `evaluate_signed_work_order_policy_gate(...)`: it invokes
+the E1 verifier first, then binds the signed authority to the actual work-order fields
+(`work_order_id`, repo, operation, permission snapshot digest, allowed paths, denied paths)
+before emitting the policy receipt.
 
 ### RedDog Work-Order Receipt (Hermes-compatible audit trail, no execution)
 
@@ -873,7 +885,7 @@ OpenClaw dispatch, or task command execution.
 
 ```python
 from modules.communication.moltbot_bridge.src.reddog_wre_operational_spine import (
-    run_reddog_wre_worktree_create_spine,  # (work_order, *, valve_environment, runner, repo_root, now, locks) -> RedDogWREOperationalSpineResult
+    run_reddog_wre_worktree_create_spine,  # (work_order, *, valve_environment, signature_verification_result, runner, repo_root, now, locks) -> RedDogWREOperationalSpineResult
     RedDogWREOperationalSpineResult,
     WORKTREE_SPINE_ACCEPT,
     WORKTREE_SPINE_REJECT,
@@ -882,6 +894,6 @@ from modules.communication.moltbot_bridge.src.reddog_wre_operational_spine impor
 
 Composes the governed RedDog path into one callable API:
 runtime invocation dry-run, executor plan dry-run, execution valve, then isolated
-worktree create. Requires `VALVE_OPEN_WORKTREE_CREATE` for acceptance. The result
-keeps WSP 97 truth fields explicit: no task execution, no file edits, no PR, no
-OpenClaw enqueue, no Hermes dispatch, no push, and no merge.
+worktree create. Requires accepted signed work authority and `VALVE_OPEN_WORKTREE_CREATE`
+for acceptance. The result keeps WSP 97 truth fields explicit: no task execution,
+no file edits, no PR, no OpenClaw enqueue, no Hermes dispatch, no push, and no merge.

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,16 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-11: REDDOG_WORK_ORDER_SIGNATURE_GATE_INTEGRATION_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Integrated the E1 `reddog_work_order_signature_verifier` result into the OpenClaw policy gate as an explicit `signed_work_order_authority` gate. The policy gate can now fail closed when signed authority is required but missing, rejected, malformed, or bound to a different `work_order_id`.
+- Added `evaluate_signed_work_order_policy_gate(...)`, the canonical no-execution helper that invokes E1 verification first and then binds the signed authority to the actual work-order fields: work_order_id, repo, operation, permission snapshot digest, allowed paths, and denied paths.
+- Added `signature_gate_status` and `signature_gate_digest` to `PolicyGateReceipt` so downstream receipts can prove whether signed work authority was accepted, rejected, or not required for advisory-only paths.
+- Threaded signed-authority requirements through `invoke_reddog_work_order_dryrun()` and made `run_reddog_wre_worktree_create_spine()` require accepted signed authority by default before it can reach worktree-create.
+- Boundary: no signing, no key generation, no private key handling, no shell, no OpenClaw enqueue, no Hermes dispatch, no PR/merge, and no new live execution. This slice consumes verifier output only.
+- HoloIndex read-only probes for `RedDog work order signature gate integration`, `evaluate_signed_work_order_policy_gate signed authority`, and `signed_work_order_authority policy gate` did not surface the new integration in top results. Recorded as `HOLOINDEX_REDDOG_WORK_ORDER_SIGNATURE_GATE_INTEGRATION_INDEX_GAP_PHASE1`; no runtime re-index performed.
+
 ## 2026-07-11: REDDOG_JUDGMENT_GENERATION_WIRING_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_openclaw_work_order_policy_gate.py
+++ b/modules/communication/moltbot_bridge/src/reddog_openclaw_work_order_policy_gate.py
@@ -50,6 +50,9 @@ from modules.communication.moltbot_bridge.src.reddog_governed_work_order_dryrun 
 from modules.platform_integration.github_integration.src.reddog_github_permission_probe import (
     permission_to_capabilities,
 )
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    verify_delegated_work_authority,
+)
 
 POLICY_ACCEPT = "POLICY_ACCEPT"
 POLICY_REJECT = "POLICY_REJECT"
@@ -57,6 +60,10 @@ POLICY_ACCEPT_WITH_RETRIEVAL_GAP = "POLICY_ACCEPT_WITH_RETRIEVAL_GAP"
 
 TRUTH_OBSERVED = "OBSERVED"
 TRUTH_NEEDS_VERIFICATION = "NEEDS_VERIFICATION"
+
+SIGNATURE_GATE_NOT_REQUIRED = "SIGNATURE_GATE_NOT_REQUIRED"
+SIGNATURE_GATE_ACCEPTED = "SIGNATURE_GATE_ACCEPTED"
+SIGNATURE_GATE_REJECTED = "SIGNATURE_GATE_REJECTED"
 
 DEFAULT_PERMISSION_TTL_SECONDS = 300
 TRUSTED_PERMISSION_SOURCES = frozenset({"gh_cli", "github_api", "mock"})
@@ -78,6 +85,8 @@ class PolicyGateReceipt:
     expires_at: Optional[str]
     next_required_check_at: Optional[str]
     receipt_digest: str
+    signature_gate_status: str = SIGNATURE_GATE_NOT_REQUIRED
+    signature_gate_digest: str = ""
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
@@ -197,6 +206,86 @@ def _evaluate_holoindex_policy(work_order: RedDogGovernedWorkOrder) -> List[str]
     return reasons
 
 
+def _signature_result_to_dict(signature_verification_result: Any) -> Optional[Dict[str, Any]]:
+    if signature_verification_result is None:
+        return None
+    if hasattr(signature_verification_result, "to_dict"):
+        candidate = signature_verification_result.to_dict()
+    elif isinstance(signature_verification_result, Mapping):
+        candidate = dict(signature_verification_result)
+    else:
+        return None
+    return candidate if isinstance(candidate, dict) else None
+
+
+def _evaluate_signature_gate(
+    work_order: RedDogGovernedWorkOrder,
+    *,
+    require_signed_authority: bool,
+    signature_verification_result: Any,
+) -> tuple[str, str, List[str]]:
+    """Fail-closed bridge from E1 verifier output into the policy gate.
+
+    This function does NOT verify signatures itself; it consumes the E1 verifier result
+    and makes signed authority a policy-gate precondition when requested. The verifier
+    remains the only module that knows signature semantics.
+    """
+    result = _signature_result_to_dict(signature_verification_result)
+    if result is None:
+        if require_signed_authority:
+            return SIGNATURE_GATE_REJECTED, "", ["signed_work_authority_required"]
+        return SIGNATURE_GATE_NOT_REQUIRED, "", []
+
+    digest = _canonical_digest(
+        {
+            "accepted": result.get("accepted") is True,
+            "reason_codes": list(result.get("reason_codes") or []),
+            "work_order_id": result.get("work_order_id"),
+        }
+    )
+    reasons: List[str] = []
+    if result.get("accepted") is not True:
+        reasons.append("signed_work_authority_not_accepted")
+        for code in result.get("reason_codes") or []:
+            reasons.append(f"signed_work_authority_reject:{code}")
+    if result.get("work_order_id") != work_order.work_order_id:
+        reasons.append("signed_work_authority_work_order_mismatch")
+
+    if reasons:
+        return SIGNATURE_GATE_REJECTED, digest, reasons
+    return SIGNATURE_GATE_ACCEPTED, digest, []
+
+
+def _signed_authority_binding_reasons(
+    work_order: RedDogGovernedWorkOrder,
+    work_authority: Mapping[str, Any],
+) -> List[str]:
+    """Verify the signed authority covers the exact work-order request."""
+    reasons: List[str] = []
+    checks = (
+        ("work_order_id", work_authority.get("work_order_id"), work_order.work_order_id),
+        ("repo_full_name", work_authority.get("repo_full_name"), work_order.repo_full_name),
+        ("requested_operation", work_authority.get("requested_operation"), work_order.requested_operation),
+        (
+            "permission_snapshot_digest",
+            work_authority.get("permission_snapshot_digest"),
+            work_order.repo_permission_snapshot.digest,
+        ),
+    )
+    for name, signed_value, order_value in checks:
+        if str(signed_value) != str(order_value):
+            reasons.append(f"REJECT_SIGNED_AUTHORITY_BINDING_MISMATCH:{name}")
+    signed_allowed = sorted(map(str, work_authority.get("allowed_paths") or []))
+    order_allowed = sorted(map(str, work_order.allowed_paths))
+    if signed_allowed != order_allowed:
+        reasons.append("REJECT_SIGNED_AUTHORITY_BINDING_MISMATCH:allowed_paths")
+    signed_denied = sorted(map(str, work_authority.get("denied_paths") or []))
+    order_denied = sorted(map(str, work_order.denied_paths))
+    if signed_denied != order_denied:
+        reasons.append("REJECT_SIGNED_AUTHORITY_BINDING_MISMATCH:denied_paths")
+    return reasons
+
+
 def _permission_supports_operation(permission_level: str, operation: str) -> bool:
     op_norm = _normalize_operation(operation)
     can_read, can_write, _ = permission_to_capabilities(permission_level)
@@ -214,6 +303,8 @@ def evaluate_work_order_policy_gate(
     seen_nonces: Optional[MutableSet[str]] = None,
     permission_ttl_seconds: int = DEFAULT_PERMISSION_TTL_SECONDS,
     permission_expires_at: Optional[str] = None,
+    require_signed_authority: bool = False,
+    signature_verification_result: Any = None,
 ) -> PolicyGateReceipt:
     """Evaluate OpenClaw policy gate for a governed work order. No execution performed."""
     if isinstance(order, Mapping):
@@ -233,6 +324,15 @@ def evaluate_work_order_policy_gate(
     gates_checked.append("holoindex_evidence_policy")
     holo_reasons = _evaluate_holoindex_policy(work_order)
     rejection_reasons.extend(holo_reasons)
+
+    signature_status, signature_digest, signature_reasons = _evaluate_signature_gate(
+        work_order,
+        require_signed_authority=require_signed_authority,
+        signature_verification_result=signature_verification_result,
+    )
+    if require_signed_authority or signature_verification_result is not None:
+        gates_checked.append("signed_work_order_authority")
+    rejection_reasons.extend(signature_reasons)
 
     snap = work_order.repo_permission_snapshot
     truth = permission_truth_label(snap.permission_level, snap.source)
@@ -316,10 +416,69 @@ def evaluate_work_order_policy_gate(
         "checked_at": _iso8601(checked),
         "expires_at": work_order.expiry,
         "next_required_check_at": next_required_check_at,
+        "signature_gate_status": signature_status,
+        "signature_gate_digest": signature_digest,
     }
     receipt_digest = _canonical_digest(receipt_core)
 
     return PolicyGateReceipt(
         receipt_digest=receipt_digest,
         **receipt_core,
+    )
+
+
+def evaluate_signed_work_order_policy_gate(
+    order: Union[RedDogGovernedWorkOrder, Mapping[str, Any]],
+    *,
+    identity: Mapping[str, Any],
+    work_authority: Mapping[str, Any],
+    signature_verifier: Any,
+    principal_key_resolver: Any,
+    nonce_store: Any,
+    snapshot_resolver: Any,
+    revocation_oracle: Any,
+    required_valve_state: str,
+    now: Optional[datetime] = None,
+    seen_nonces: Optional[MutableSet[str]] = None,
+    permission_ttl_seconds: int = DEFAULT_PERMISSION_TTL_SECONDS,
+    permission_expires_at: Optional[str] = None,
+    forbidden_operations: Optional[List[str]] = None,
+    revoked_key_epochs: Optional[List[str]] = None,
+    leeway_s: int = 60,
+) -> PolicyGateReceipt:
+    """Canonical signed-authority entrypoint: verify E1 payload, then policy-gate.
+
+    This avoids a live caller treating a self-asserted `accepted: true` structure as
+    authority. Verification remains no-execution and fail-closed.
+    """
+    checked = _utc_now(now)
+    work_order_obj = _work_order_from_mapping(order) if isinstance(order, Mapping) else order
+    verification = verify_delegated_work_authority(
+        work_authority=work_authority,
+        identity=identity,
+        signature_verifier=signature_verifier,
+        principal_key_resolver=principal_key_resolver,
+        nonce_store=nonce_store,
+        snapshot_resolver=snapshot_resolver,
+        revocation_oracle=revocation_oracle,
+        now=int(checked.timestamp()),
+        required_valve_state=required_valve_state,
+        forbidden_operations=tuple(forbidden_operations or ()),
+        revoked_key_epochs=tuple(revoked_key_epochs or ()),
+        leeway_s=leeway_s,
+    )
+    verification_payload = verification.to_dict()
+    if verification_payload.get("accepted") is True:
+        binding_reasons = _signed_authority_binding_reasons(work_order_obj, work_authority)
+        if binding_reasons:
+            verification_payload["accepted"] = False
+            verification_payload["reason_codes"] = list(verification_payload.get("reason_codes") or []) + binding_reasons
+    return evaluate_work_order_policy_gate(
+        work_order_obj,
+        now=checked,
+        seen_nonces=seen_nonces,
+        permission_ttl_seconds=permission_ttl_seconds,
+        permission_expires_at=permission_expires_at,
+        require_signed_authority=True,
+        signature_verification_result=verification_payload,
     )

--- a/modules/communication/moltbot_bridge/src/reddog_work_order_runtime_invocation.py
+++ b/modules/communication/moltbot_bridge/src/reddog_work_order_runtime_invocation.py
@@ -97,6 +97,8 @@ def invoke_reddog_work_order_dryrun(
     receipt_store: Optional[RedDogWorkOrderReceiptStore] = None,
     permission_ttl_seconds: int = 300,
     permission_expires_at: Optional[str] = None,
+    require_signed_authority: bool = False,
+    signature_verification_result: Optional[Any] = None,
 ) -> WorkOrderDryRunInvocationResult:
     """Run governed work-order dry-run invocation: policy gate + receipt, no execution."""
     order = _merge_permission_snapshot(work_order, permission_snapshot)
@@ -108,6 +110,8 @@ def invoke_reddog_work_order_dryrun(
         seen_nonces=seen_nonces,
         permission_ttl_seconds=permission_ttl_seconds,
         permission_expires_at=permission_expires_at,
+        require_signed_authority=require_signed_authority,
+        signature_verification_result=signature_verification_result,
     )
 
     emission = emit_work_order_receipt(policy_receipt, store=receipt_store, now=checked)

--- a/modules/communication/moltbot_bridge/src/reddog_wre_operational_spine.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_operational_spine.py
@@ -4,8 +4,9 @@ Slice: REDDOG_WRE_OPERATIONAL_SPINE_WORKTREE_CREATE_PHASE1
 
 This module composes the landed RedDog governance spine into one callable path:
 work-order invocation dry-run -> executor plan dry-run -> execution valve ->
-isolated worktree create. It stops before task execution, file edits, tests, PR,
-push, merge, OpenClaw enqueue, or Hermes dispatch.
+isolated worktree create. It requires accepted signed work authority by default,
+then stops before task execution, file edits, tests, PR, push, merge, OpenClaw
+enqueue, or Hermes dispatch.
 """
 
 from __future__ import annotations
@@ -203,6 +204,8 @@ def run_reddog_wre_worktree_create_spine(
     seen_nonces: Optional[MutableSet[str]] = None,
     receipt_store: Optional[RedDogWorkOrderReceiptStore] = None,
     valve_environment: Optional[ExecutionValveEnvironment | Mapping[str, Any]] = None,
+    signature_verification_result: Optional[Mapping[str, Any]] = None,
+    require_signed_authority: bool = True,
     runner: Optional[Any] = None,
     repo_root: Optional[Path] = None,
     now: Optional[datetime] = None,
@@ -224,6 +227,8 @@ def run_reddog_wre_worktree_create_spine(
         receipt_store=receipt_store,
         permission_ttl_seconds=permission_ttl_seconds,
         permission_expires_at=permission_expires_at,
+        require_signed_authority=require_signed_authority,
+        signature_verification_result=signature_verification_result,
     )
     invocation_dict = invocation.to_dict()
     policy_receipt = _minimal_policy_gate_receipt(invocation)

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,16 @@
+## 2026-07-11: REDDOG_WORK_ORDER_SIGNATURE_GATE_INTEGRATION_PHASE1
+
+**Files**: `test_reddog_openclaw_work_order_policy_gate.py`, `test_reddog_wre_operational_spine.py` (UPDATED)
+**Slice**: `REDDOG_WORK_ORDER_SIGNATURE_GATE_INTEGRATION_PHASE1` | **Predecessors**: #931 E0, #932 E1, #947 WRE operational spine
+
+Signed-authority gate integration: policy gate rejects missing/rejected/mismatched verifier results
+when signed authority is required; explicit rejected signature results cannot be ignored; worktree-create
+operational spine requires accepted signed authority by default before runner/worktree creation.
+Canonical helper coverage proves E1 verification is invoked and rejects a valid signature whose signed
+path scope does not match the actual work order.
+
+**Run**: `pytest modules/communication/moltbot_bridge/tests/test_reddog_openclaw_work_order_policy_gate.py modules/communication/moltbot_bridge/tests/test_reddog_wre_operational_spine.py modules/communication/moltbot_bridge/tests/test_reddog_work_order_signature_verifier.py -q`
+
 ## 2026-07-08: REDDOG_WRE_OPERATIONAL_SPINE_WORKTREE_CREATE_PHASE1
 
 **File**: `test_reddog_wre_operational_spine.py` (NEW - 6 tests)

--- a/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_work_order_policy_gate.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_work_order_policy_gate.py
@@ -11,6 +11,8 @@ from modules.communication.moltbot_bridge.src.reddog_openclaw_work_order_policy_
     POLICY_ACCEPT,
     POLICY_ACCEPT_WITH_RETRIEVAL_GAP,
     POLICY_REJECT,
+    SIGNATURE_GATE_ACCEPTED,
+    SIGNATURE_GATE_REJECTED,
     TRUTH_NEEDS_VERIFICATION,
     TRUTH_OBSERVED,
     evaluate_work_order_policy_gate,
@@ -254,6 +256,70 @@ class TestHoloIndexPolicy:
         assert "weak_wsp_recall_missing_direct_read_ref" in receipt.rejection_reasons
 
 
+class TestSignedAuthorityGate:
+    def test_signed_authority_required_rejects_when_missing(self):
+        receipt = evaluate_work_order_policy_gate(
+            _base_order(),
+            seen_nonces=set(),
+            require_signed_authority=True,
+        )
+
+        assert receipt.decision == POLICY_REJECT
+        assert receipt.signature_gate_status == SIGNATURE_GATE_REJECTED
+        assert "signed_work_authority_required" in receipt.rejection_reasons
+        assert "signed_work_order_authority" in receipt.gates_checked
+
+    def test_signed_authority_accepts_when_verifier_result_accepts(self):
+        order = _base_order()
+        receipt = evaluate_work_order_policy_gate(
+            order,
+            seen_nonces=set(),
+            require_signed_authority=True,
+            signature_verification_result={
+                "accepted": True,
+                "reason_codes": [],
+                "work_order_id": order["work_order_id"],
+            },
+        )
+
+        assert receipt.decision == POLICY_ACCEPT
+        assert receipt.signature_gate_status == SIGNATURE_GATE_ACCEPTED
+        assert receipt.signature_gate_digest
+
+    def test_rejected_signature_result_cannot_be_ignored(self):
+        order = _base_order()
+        receipt = evaluate_work_order_policy_gate(
+            order,
+            seen_nonces=set(),
+            require_signed_authority=False,
+            signature_verification_result={
+                "accepted": False,
+                "reason_codes": ["REJECT_WORKAUTH_SIGNATURE_INVALID"],
+                "work_order_id": order["work_order_id"],
+            },
+        )
+
+        assert receipt.decision == POLICY_REJECT
+        assert receipt.signature_gate_status == SIGNATURE_GATE_REJECTED
+        assert "signed_work_authority_not_accepted" in receipt.rejection_reasons
+        assert "signed_work_authority_reject:REJECT_WORKAUTH_SIGNATURE_INVALID" in receipt.rejection_reasons
+
+    def test_signed_authority_work_order_mismatch_rejects(self):
+        receipt = evaluate_work_order_policy_gate(
+            _base_order(),
+            seen_nonces=set(),
+            require_signed_authority=True,
+            signature_verification_result={
+                "accepted": True,
+                "reason_codes": [],
+                "work_order_id": "wo-other",
+            },
+        )
+
+        assert receipt.decision == POLICY_REJECT
+        assert "signed_work_authority_work_order_mismatch" in receipt.rejection_reasons
+
+
 class TestReceiptCompatibility:
     def test_receipt_digest_stable_for_same_input(self):
         fixed = datetime(2026, 6, 28, 14, 0, 0, tzinfo=timezone.utc)
@@ -305,6 +371,8 @@ class TestReceiptCompatibility:
             "expires_at",
             "next_required_check_at",
             "receipt_digest",
+            "signature_gate_status",
+            "signature_gate_digest",
         ):
             assert key in data
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_work_order_signature_verifier.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_work_order_signature_verifier.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import ast
 import hashlib
 import hmac
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -29,6 +30,12 @@ from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifi
     ReasonCode,
     canonical_signing_input,
     verify_delegated_work_authority,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_work_order_policy_gate import (
+    POLICY_ACCEPT,
+    POLICY_REJECT,
+    SIGNATURE_GATE_ACCEPTED,
+    evaluate_signed_work_order_policy_gate,
 )
 
 _VALVE = "VALVE_OPEN_WORKTREE_CREATE"
@@ -137,6 +144,63 @@ def _resign_wa(crypto, identity, workauth):
 
 def _run(identity, workauth, ctx):
     return verify_delegated_work_authority(work_authority=workauth, identity=identity, **ctx)
+
+
+def _policy_order_from_workauth(workauth, now: int = 1000, **overrides):
+    captured = datetime.fromtimestamp(now - 60, timezone.utc).replace(microsecond=0).isoformat()
+    expiry = datetime.fromtimestamp(now + 3600, timezone.utc).replace(microsecond=0).isoformat()
+    payload = {
+        "work_order_id": workauth["work_order_id"],
+        "created_at": captured,
+        "red_dog_instance_id": "reddog-test",
+        "authenticated_principal": workauth["principal_id"],
+        "principal_provider": "github",
+        "repo_full_name": workauth["repo_full_name"],
+        "repo_permission_snapshot": {
+            "permission_level": "write",
+            "captured_at": captured,
+            "source": "mock",
+            "digest": workauth["permission_snapshot_digest"],
+        },
+        "requested_operation": workauth["requested_operation"],
+        "authority_tier": "source",
+        "allowed_paths": list(workauth["allowed_paths"]),
+        "denied_paths": list(workauth["denied_paths"]),
+        "branch_name": "feat/signed-policy-test",
+        "base_ref": "main",
+        "task_summary": "Signed policy gate integration test.",
+        "wsp_applicability": ["WSP_50", "WSP_97"],
+        "holoindex_evidence_refs": ["docs/contracts/REDDOG_PRINCIPAL_IDENTITY_AND_DELEGATION_CONTRACT_PHASE1.md"],
+        "skillz_candidates": [],
+        "required_tests": ["modules/communication/moltbot_bridge/tests/test_reddog_work_order_signature_verifier.py"],
+        "required_policy_gates": ["openclaw_policy_gate", "signed_work_order_authority"],
+        "required_reviewers": [],
+        "sentinel_checks": [],
+        "rollback_plan": "No execution performed.",
+        "expiry": expiry,
+        "nonce": "policy-" + workauth["nonce"],
+        "evidence_digest": "sha256:" + ("b" * 64),
+        "advisory_only_source_packet": {
+            "work_focus_digest": "sha256:" + ("c" * 64),
+            "wsp_prompt_digest": "sha256:" + ("d" * 64),
+            "copy_md_run_trace_digest": "sha256:" + ("e" * 64),
+        },
+        "holoindex_evidence": {
+            "holoindex_query": "RedDog signed work order",
+            "holoindex_status": "bundle_json_ok",
+            "code_hits": ["modules/communication/moltbot_bridge/src/reddog_work_order_signature_verifier.py"],
+            "wsp_hits": ["WSP_framework/src/WSP_97_WSP_97_Truth_Boundary_Protocol.md"],
+            "skillz_hits": [],
+            "direct_read_fallback_used": False,
+            "index_gap_detected": False,
+            "applicable_wsps": ["WSP_97"],
+            "evidence_refs": ["docs/contracts/REDDOG_PRINCIPAL_IDENTITY_AND_DELEGATION_CONTRACT_PHASE1.md"],
+            "retrieval_quality": "HIGH",
+            "skillz_gap_detected": False,
+        },
+    }
+    payload.update(overrides)
+    return payload
 
 
 # 1 -------------------------------------------------------------------------- #
@@ -491,3 +555,59 @@ def test_non_serializable_payload_fails_closed() -> None:
     r = _run(identity, workauth, ctx)
     assert r.accepted is False  # rejected, never raised
     assert r.reason_codes  # a static code was recorded
+
+
+def test_signed_policy_gate_invokes_verifier_and_accepts_exact_binding() -> None:
+    _, identity, workauth, ctx = _build()
+    order = _policy_order_from_workauth(workauth, now=ctx["now"])
+
+    receipt = evaluate_signed_work_order_policy_gate(
+        order,
+        identity=identity,
+        work_authority=workauth,
+        signature_verifier=ctx["signature_verifier"],
+        principal_key_resolver=ctx["principal_key_resolver"],
+        nonce_store=ctx["nonce_store"],
+        snapshot_resolver=ctx["snapshot_resolver"],
+        revocation_oracle=ctx["revocation_oracle"],
+        required_valve_state=_VALVE,
+        now=datetime.fromtimestamp(ctx["now"], timezone.utc),
+        seen_nonces=set(),
+        forbidden_operations=["rm_rf"],
+    )
+
+    assert receipt.decision == POLICY_ACCEPT
+    assert receipt.signature_gate_status == SIGNATURE_GATE_ACCEPTED
+    assert receipt.signature_gate_digest
+    assert "signed_work_order_authority" in receipt.gates_checked
+
+
+def test_signed_policy_gate_rejects_valid_signature_for_different_path_scope() -> None:
+    _, identity, workauth, ctx = _build()
+    order = _policy_order_from_workauth(
+        workauth,
+        now=ctx["now"],
+        allowed_paths=["modules/foundups/other_002/**"],
+    )
+
+    receipt = evaluate_signed_work_order_policy_gate(
+        order,
+        identity=identity,
+        work_authority=workauth,
+        signature_verifier=ctx["signature_verifier"],
+        principal_key_resolver=ctx["principal_key_resolver"],
+        nonce_store=ctx["nonce_store"],
+        snapshot_resolver=ctx["snapshot_resolver"],
+        revocation_oracle=ctx["revocation_oracle"],
+        required_valve_state=_VALVE,
+        now=datetime.fromtimestamp(ctx["now"], timezone.utc),
+        seen_nonces=set(),
+        forbidden_operations=["rm_rf"],
+    )
+
+    assert receipt.decision == POLICY_REJECT
+    assert "signed_work_authority_not_accepted" in receipt.rejection_reasons
+    assert (
+        "signed_work_authority_reject:REJECT_SIGNED_AUTHORITY_BINDING_MISMATCH:allowed_paths"
+        in receipt.rejection_reasons
+    )

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_operational_spine.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_operational_spine.py
@@ -101,6 +101,14 @@ def _base_order(now: datetime, **overrides):
     return payload
 
 
+def _accepted_signature(order):
+    return {
+        "accepted": True,
+        "reason_codes": [],
+        "work_order_id": order["work_order_id"],
+    }
+
+
 class TestOperationalSpineAccept:
     def test_accept_runs_full_spine_to_worktree_create_only(self, tmp_path: Path):
         fixed = datetime(2026, 7, 8, 12, 0, 0, tzinfo=timezone.utc)
@@ -117,6 +125,7 @@ class TestOperationalSpineAccept:
                 valve_worktree_create_enabled=True,
                 sovereign_worktree_token=_TOKEN,
             ),
+            signature_verification_result=_accepted_signature(order),
             runner=runner,
             repo_root=repo_root,
             now=fixed,
@@ -151,6 +160,7 @@ class TestOperationalSpineAccept:
                 valve_worktree_create_enabled=True,
                 sovereign_worktree_token=_TOKEN,
             ),
+            signature_verification_result=_accepted_signature(order),
             runner=FakeRunner(),
             repo_root=repo_root,
             now=fixed,
@@ -163,6 +173,7 @@ class TestOperationalSpineAccept:
                 valve_worktree_create_enabled=True,
                 sovereign_worktree_token=_TOKEN,
             ),
+            signature_verification_result=_accepted_signature(order),
             runner=FakeRunner(),
             repo_root=repo_root,
             now=fixed,
@@ -184,6 +195,7 @@ class TestOperationalSpineReject:
         result = run_reddog_wre_worktree_create_spine(
             order,
             seen_nonces=set(),
+            signature_verification_result=_accepted_signature(order),
             runner=runner,
             repo_root=repo_root,
             now=fixed,
@@ -224,6 +236,7 @@ class TestOperationalSpineReject:
                 valve_worktree_create_enabled=True,
                 sovereign_worktree_token=_TOKEN,
             ),
+            signature_verification_result=_accepted_signature(order),
             runner=runner,
             repo_root=repo_root,
             now=fixed,
@@ -249,6 +262,7 @@ class TestOperationalSpineReject:
                 valve_worktree_create_enabled=True,
                 sovereign_worktree_token=_TOKEN,
             ),
+            signature_verification_result=_accepted_signature(order),
             runner=runner,
             repo_root=repo_root,
             now=fixed,
@@ -259,6 +273,31 @@ class TestOperationalSpineReject:
         assert "executor_plan_not_accepted" in result.rejection_reasons
         assert "lock_collision" in result.rejection_reasons
         assert result.valve_decision == {}
+        assert runner.calls == []
+
+    def test_missing_signed_authority_rejects_before_runner(self, tmp_path: Path):
+        fixed = datetime(2026, 7, 8, 12, 25, 0, tzinfo=timezone.utc)
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        order = _base_order(fixed)
+        runner = FakeRunner()
+
+        result = run_reddog_wre_worktree_create_spine(
+            order,
+            seen_nonces=set(),
+            valve_environment=ExecutionValveEnvironment(
+                valve_worktree_create_enabled=True,
+                sovereign_worktree_token=_TOKEN,
+            ),
+            runner=runner,
+            repo_root=repo_root,
+            now=fixed,
+        )
+
+        assert result.decision == WORKTREE_SPINE_REJECT
+        assert "invocation_not_accepted" in result.rejection_reasons
+        assert "signed_work_authority_required" in result.rejection_reasons
+        assert result.executor_plan_result == {}
         assert runner.calls == []
 
 


### PR DESCRIPTION
## Summary

REDDOG_WORK_ORDER_SIGNATURE_GATE_INTEGRATION_PHASE1.

This integrates the merged E1 work-order signature verifier into the OpenClaw policy gate without adding execution authority.

- Adds signed-authority gate status/digest to `PolicyGateReceipt`.
- Adds `evaluate_signed_work_order_policy_gate(...)` as the canonical no-execution helper: it invokes E1 verification, then binds the signed authority to the actual work-order fields (`work_order_id`, repo, operation, permission snapshot digest, allowed paths, denied paths).
- Threads `require_signed_authority` / `signature_verification_result` through runtime invocation.
- Makes `run_reddog_wre_worktree_create_spine()` require accepted signed authority by default before it can reach worktree-create.
- Adds tests proving missing/rejected/mismatched signed authority fails closed and that a valid signature for a different path scope cannot authorize a work order.

## WSP_97 Truth Boundary

OBSERVED:
- E1 verifier was already merged (#932).
- This slice consumes verifier output and adds a canonical helper that invokes E1 before policy-gating.
- Worktree-create spine now defaults to requiring accepted signed authority.

NO execution authority added:
- no signing
- no key generation
- no private key handling
- no shell or command execution
- no OpenClaw live enqueue
- no Hermes dispatch
- no PR/merge automation
- no file mutation beyond this code slice

SPECIFIED_NOT_IMPLEMENTED:
- signed receipt chain
- live enqueue implementation
- generic worktree writer
- governed shell runner
- merge authority

## HoloIndex Addendum

Read-only probes were run for:

- `RedDog work order signature gate integration`
- `evaluate_signed_work_order_policy_gate signed authority`
- `signed_work_order_authority policy gate`

The new integration did not surface in top results. Recorded as:

`HOLOINDEX_REDDOG_WORK_ORDER_SIGNATURE_GATE_INTEGRATION_INDEX_GAP_PHASE1`

No runtime re-index was performed; re-index remains WRE/CI-owned maintenance.

## Validation

```text
python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_openclaw_work_order_policy_gate.py modules/communication/moltbot_bridge/tests/test_reddog_work_order_receipt.py modules/communication/moltbot_bridge/tests/test_reddog_work_order_runtime_invocation.py modules/communication/moltbot_bridge/tests/test_reddog_wre_executor_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_wre_execution_valve.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_adapter_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_wre_worktree_create.py modules/communication/moltbot_bridge/tests/test_reddog_wre_operational_spine.py modules/communication/moltbot_bridge/tests/test_reddog_work_order_signature_verifier.py -q
125 passed in 1.25s

git diff --check
clean

slice-added non-ASCII
0

python -m pytest modules/foundups/simulator/tests/ -q --tb=short --ignore=modules/foundups/simulator/tests/test_sse_server.py
302 passed
```

Local note: `modules/foundups/agent_market/tests` could not collect in this environment because `sqlalchemy` is not installed locally; GitHub CI installs `requirements.txt` and is the authority for that job.