### PR TITLE
feat(reddog): add signed receipt chain verifier

### DIFF
--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -815,6 +815,27 @@ the E1 verifier first, then binds the signed authority to the actual work-order 
 (`work_order_id`, repo, operation, permission snapshot digest, allowed paths, denied paths)
 before emitting the policy receipt.
 
+### RedDog Signed Receipt Chain (verification only)
+
+```python
+from modules.communication.moltbot_bridge.src.reddog_signed_receipt_chain import (
+    verify_signed_receipt_chain,       # verifies ordered externally signed receipts
+    build_receipt_payload_for_signing, # unsigned canonical payload for external signer
+    receipt_payload_hash,              # sha256 over reddog-receipt.v1 canonical input
+    SignedReceipt,
+    SignedReceiptChainVerificationResult,
+    SIGNED_RECEIPT_CHAIN_ACCEPT,
+    SIGNED_RECEIPT_CHAIN_REJECT,
+)
+```
+
+`REDDOG_SIGNED_RECEIPT_CHAIN_PHASE1` verifies `reddog-receipt.v1` records against an
+injected public-key verifier, then checks work-order identity, RedDog identity, optional
+reward-account binding, issued-at freshness, ASCII-only payloads, and `prev_receipt_hash`
+links. Empty chains are valid only as issuance-time "no reward yet"; unsigned receipts are
+rejected and cannot be reward-bearing. This module does not sign, generate keys, settle
+rewards, execute commands, enqueue OpenClaw/Hermes/WRE work, or mutate the repo.
+
 ### RedDog Work-Order Receipt (Hermes-compatible audit trail, no execution)
 
 ```python

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,14 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-11: REDDOG_SIGNED_RECEIPT_CHAIN_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_signed_receipt_chain.py`: verification-only SignedReceipt chain helper for the ratified principal identity/delegation contract. It verifies externally signed `reddog-receipt.v1` records, checks hash links, reward-account binding, receipt freshness, work-order identity, and RedDog identity.
+- Empty receipt chains can be accepted as issuance-time "no reward yet"; non-empty chains require every receipt to carry a valid injected signature and a correct `prev_receipt_hash` link. Unsigned receipts are rejected and therefore cannot become reward-bearing chain entries.
+- Boundary: no signing, no key generation, no private key handling, no reward settlement, no command execution, no repo mutation, no OpenClaw/Hermes/WRE wiring, and no chain/wallet integration. Production verification defaults fail-closed unless a verifier backend is injected.
+- HoloIndex read-only probes for this slice did not surface the new module in top results. Recorded as `HOLOINDEX_REDDOG_SIGNED_RECEIPT_CHAIN_INDEX_GAP_PHASE1`; no runtime re-index performed.
+
 ## 2026-07-11: REDDOG_WORK_ORDER_SIGNATURE_GATE_INTEGRATION_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_signed_receipt_chain.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_receipt_chain.py
@@ -1,0 +1,234 @@
+"""RedDog signed receipt chain verifier (no signing, no execution).
+
+Slice: REDDOG_SIGNED_RECEIPT_CHAIN_PHASE1
+
+Implements the SignedReceipt verifier from
+docs/contracts/REDDOG_PRINCIPAL_IDENTITY_AND_DELEGATION_CONTRACT_PHASE1.md.
+This module does NOT sign, generate keys, hold private keys, write rewards, execute
+commands, enqueue OpenClaw/Hermes work, or mutate the repo. It only verifies
+externally signed receipt records against an injected signature verifier.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Protocol, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    FailClosedSignatureVerifier,
+    PREFIX_RECEIPT,
+    canonical_signing_input,
+)
+
+SIGNED_RECEIPT_CHAIN_ACCEPT = "SIGNED_RECEIPT_CHAIN_ACCEPT"
+SIGNED_RECEIPT_CHAIN_REJECT = "SIGNED_RECEIPT_CHAIN_REJECT"
+
+
+class ReceiptChainReason:
+    MALFORMED_RECEIPT = "REJECT_MALFORMED_RECEIPT"
+    NON_ASCII = "REJECT_NON_ASCII_RECEIPT"
+    MISSING_SIGNATURE = "REJECT_MISSING_RECEIPT_SIGNATURE"
+    SIGNATURE_INVALID = "REJECT_RECEIPT_SIGNATURE_INVALID"
+    WORK_ORDER_MISMATCH = "REJECT_RECEIPT_WORK_ORDER_MISMATCH"
+    REDDOG_MISMATCH = "REJECT_RECEIPT_REDDOG_MISMATCH"
+    PREV_HASH_MISMATCH = "REJECT_RECEIPT_PREV_HASH_MISMATCH"
+    REWARD_ACCOUNT_MISMATCH = "REJECT_RECEIPT_REWARD_ACCOUNT_MISMATCH"
+    ISSUED_IN_FUTURE = "REJECT_RECEIPT_ISSUED_IN_FUTURE"
+    EMPTY_CHAIN = "REJECT_EMPTY_RECEIPT_CHAIN"
+    BACKEND_NOT_CONFIGURED = "REJECT_RECEIPT_SIGNATURE_BACKEND_NOT_CONFIGURED"
+
+
+class ReceiptSignatureVerifier(Protocol):
+    def verify(self, public_key: str, signing_input: str, signature: str) -> bool: ...
+
+
+@dataclass
+class SignedReceipt:
+    receipt_id: str
+    work_order_id: str
+    reddog_id: str
+    prev_receipt_hash: Optional[str]
+    covered_action_digest: str
+    reward_account: Optional[str]
+    issued_at: int
+    signature: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class SignedReceiptChainVerificationResult:
+    decision: str
+    accepted: bool
+    reason_codes: List[str] = field(default_factory=list)
+    verified_count: int = 0
+    receipt_hashes: List[str] = field(default_factory=list)
+    terminal_receipt_hash: Optional[str] = None
+    no_reward_settlement_performed: bool = True
+    no_execution_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def _is_ascii_deep(value: Any) -> bool:
+    if isinstance(value, str):
+        return all(ord(c) < 128 for c in value)
+    if isinstance(value, Mapping):
+        return all(isinstance(k, str) and _is_ascii_deep(k) and _is_ascii_deep(v) for k, v in value.items())
+    if isinstance(value, (list, tuple)):
+        return all(_is_ascii_deep(v) for v in value)
+    return True
+
+
+def signed_receipt_from_mapping(value: Mapping[str, Any]) -> Optional[SignedReceipt]:
+    try:
+        return SignedReceipt(
+            receipt_id=str(value["receipt_id"]),
+            work_order_id=str(value["work_order_id"]),
+            reddog_id=str(value["reddog_id"]),
+            prev_receipt_hash=None if value.get("prev_receipt_hash") is None else str(value.get("prev_receipt_hash")),
+            covered_action_digest=str(value["covered_action_digest"]),
+            reward_account=None if value.get("reward_account") is None else str(value.get("reward_account")),
+            issued_at=int(value["issued_at"]),
+            signature="" if value.get("signature") is None else str(value.get("signature", "")),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def build_receipt_payload_for_signing(
+    *,
+    receipt_id: str,
+    work_order_id: str,
+    reddog_id: str,
+    prev_receipt_hash: Optional[str],
+    covered_action_digest: str,
+    reward_account: Optional[str],
+    issued_at: int,
+) -> Dict[str, Any]:
+    """Return the canonical SignedReceipt fields before an external signer adds signature."""
+    return {
+        "receipt_id": receipt_id,
+        "work_order_id": work_order_id,
+        "reddog_id": reddog_id,
+        "prev_receipt_hash": prev_receipt_hash,
+        "covered_action_digest": covered_action_digest,
+        "reward_account": reward_account,
+        "issued_at": int(issued_at),
+    }
+
+
+def receipt_payload_hash(receipt: SignedReceipt | Mapping[str, Any]) -> str:
+    """Hash the canonical receipt signing input (prefix + JSON, excluding signature)."""
+    payload = receipt.to_dict() if isinstance(receipt, SignedReceipt) else dict(receipt)
+    signing_input = canonical_signing_input(payload, PREFIX_RECEIPT)
+    return hashlib.sha256(signing_input.encode("utf-8")).hexdigest()
+
+
+def verify_signed_receipt_chain(
+    receipts: Sequence[SignedReceipt | Mapping[str, Any]],
+    *,
+    reddog_public_key: str,
+    signature_verifier: Optional[ReceiptSignatureVerifier] = None,
+    work_order_id: str,
+    reddog_id: str,
+    identity_reward_account: Optional[str] = None,
+    now: Optional[int] = None,
+    max_future_skew_s: int = 60,
+    allow_empty: bool = True,
+) -> SignedReceiptChainVerificationResult:
+    """Verify ordered SignedReceipt records.
+
+    Empty chains are valid at work-authority issuance when allow_empty=True, but they
+    contain no reward-bearing receipts. Any non-empty chain must be fully signed and
+    hash-linked.
+    """
+    verifier = signature_verifier or FailClosedSignatureVerifier()
+    if not receipts:
+        if allow_empty:
+            return SignedReceiptChainVerificationResult(
+                decision=SIGNED_RECEIPT_CHAIN_ACCEPT,
+                accepted=True,
+                verified_count=0,
+            )
+        return SignedReceiptChainVerificationResult(
+            decision=SIGNED_RECEIPT_CHAIN_REJECT,
+            accepted=False,
+            reason_codes=[ReceiptChainReason.EMPTY_CHAIN],
+        )
+
+    reason_codes: List[str] = []
+    receipt_hashes: List[str] = []
+    expected_prev: Optional[str] = None
+    checked_now = int(now) if now is not None else None
+
+    for raw in receipts:
+        receipt = raw if isinstance(raw, SignedReceipt) else signed_receipt_from_mapping(raw)
+        if receipt is None:
+            reason_codes.append(ReceiptChainReason.MALFORMED_RECEIPT)
+            break
+        payload = receipt.to_dict()
+        if not _is_ascii_deep(payload):
+            reason_codes.append(ReceiptChainReason.NON_ASCII)
+        if not receipt.signature:
+            reason_codes.append(ReceiptChainReason.MISSING_SIGNATURE)
+        if receipt.work_order_id != work_order_id:
+            reason_codes.append(ReceiptChainReason.WORK_ORDER_MISMATCH)
+        if receipt.reddog_id != reddog_id:
+            reason_codes.append(ReceiptChainReason.REDDOG_MISMATCH)
+        if receipt.prev_receipt_hash != expected_prev:
+            reason_codes.append(ReceiptChainReason.PREV_HASH_MISMATCH)
+        if identity_reward_account is not None and receipt.reward_account is not None:
+            if receipt.reward_account != identity_reward_account:
+                reason_codes.append(ReceiptChainReason.REWARD_ACCOUNT_MISMATCH)
+        if checked_now is not None and receipt.issued_at > checked_now + max_future_skew_s:
+            reason_codes.append(ReceiptChainReason.ISSUED_IN_FUTURE)
+
+        try:
+            ok = verifier.verify(
+                reddog_public_key,
+                canonical_signing_input(payload, PREFIX_RECEIPT),
+                receipt.signature,
+            ) is True
+        except Exception:
+            ok = False
+        if not ok:
+            reason_codes.append(ReceiptChainReason.SIGNATURE_INVALID)
+
+        receipt_hash = receipt_payload_hash(payload)
+        receipt_hashes.append(receipt_hash)
+        expected_prev = receipt_hash
+
+    if reason_codes:
+        return SignedReceiptChainVerificationResult(
+            decision=SIGNED_RECEIPT_CHAIN_REJECT,
+            accepted=False,
+            reason_codes=list(dict.fromkeys(reason_codes)),
+            verified_count=0,
+            receipt_hashes=receipt_hashes,
+            terminal_receipt_hash=receipt_hashes[-1] if receipt_hashes else None,
+        )
+
+    return SignedReceiptChainVerificationResult(
+        decision=SIGNED_RECEIPT_CHAIN_ACCEPT,
+        accepted=True,
+        verified_count=len(receipt_hashes),
+        receipt_hashes=receipt_hashes,
+        terminal_receipt_hash=receipt_hashes[-1],
+    )
+
+
+__all__ = [
+    "ReceiptChainReason",
+    "SIGNED_RECEIPT_CHAIN_ACCEPT",
+    "SIGNED_RECEIPT_CHAIN_REJECT",
+    "SignedReceipt",
+    "SignedReceiptChainVerificationResult",
+    "build_receipt_payload_for_signing",
+    "receipt_payload_hash",
+    "signed_receipt_from_mapping",
+    "verify_signed_receipt_chain",
+]

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,14 @@
+## 2026-07-11: REDDOG_SIGNED_RECEIPT_CHAIN_PHASE1
+
+**File**: `test_reddog_signed_receipt_chain.py` (NEW - 15 tests)
+**Slice**: `REDDOG_SIGNED_RECEIPT_CHAIN_PHASE1` | **Predecessors**: #928 identity contract, #931 E0, #932 E1
+
+Signed receipt chain verification: empty issuance-time chain accepted as no-reward-yet,
+non-empty chains require injected signature verification, work-order/RedDog/reward-account
+binding, correct hash-link order, freshness, ASCII payloads, and no signing/execution imports.
+
+**Run**: `pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_receipt_chain.py -q`
+
 ## 2026-07-11: REDDOG_WORK_ORDER_SIGNATURE_GATE_INTEGRATION_PHASE1
 
 **Files**: `test_reddog_openclaw_work_order_policy_gate.py`, `test_reddog_wre_operational_spine.py` (UPDATED)

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_receipt_chain.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_receipt_chain.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Tests for REDDOG_SIGNED_RECEIPT_CHAIN_PHASE1.
+
+The mock signer below is TEST ONLY. Production code verifies externally signed
+receipts through an injected verifier and never signs, generates keys, executes
+commands, settles rewards, or mutates the repo.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import hmac
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_signed_receipt_chain import (
+    ReceiptChainReason,
+    SIGNED_RECEIPT_CHAIN_ACCEPT,
+    SIGNED_RECEIPT_CHAIN_REJECT,
+    build_receipt_payload_for_signing,
+    receipt_payload_hash,
+    verify_signed_receipt_chain,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    PREFIX_RECEIPT,
+    canonical_signing_input,
+)
+
+_PUB = "pub:reddog"
+_SECRET = b"test-only-secret"
+_WORK_ORDER = "wo-signed-receipts"
+_REDDOG = "reddog:paccess"
+_REWARD = "ups:012:paccess"
+
+
+class _MockReceiptCrypto:
+    def sign(self, public_key: str, signing_input: str) -> str:
+        assert public_key == _PUB
+        return hmac.new(_SECRET, signing_input.encode("utf-8"), hashlib.sha256).hexdigest()
+
+    def verify(self, public_key: str, signing_input: str, signature: str) -> bool:
+        if public_key != _PUB:
+            return False
+        expected = hmac.new(_SECRET, signing_input.encode("utf-8"), hashlib.sha256).hexdigest()
+        return hmac.compare_digest(expected, signature)
+
+
+def _receipt(
+    receipt_id: str = "rcpt-1",
+    *,
+    prev_receipt_hash=None,
+    covered_action_digest: str = "sha256:action-1",
+    work_order_id: str = _WORK_ORDER,
+    reddog_id: str = _REDDOG,
+    reward_account: str | None = _REWARD,
+    issued_at: int = 1000,
+) -> dict:
+    payload = build_receipt_payload_for_signing(
+        receipt_id=receipt_id,
+        work_order_id=work_order_id,
+        reddog_id=reddog_id,
+        prev_receipt_hash=prev_receipt_hash,
+        covered_action_digest=covered_action_digest,
+        reward_account=reward_account,
+        issued_at=issued_at,
+    )
+    payload["signature"] = _MockReceiptCrypto().sign(_PUB, canonical_signing_input(payload, PREFIX_RECEIPT))
+    return payload
+
+
+def _verify(receipts, **overrides):
+    params = dict(
+        reddog_public_key=_PUB,
+        signature_verifier=_MockReceiptCrypto(),
+        work_order_id=_WORK_ORDER,
+        reddog_id=_REDDOG,
+        identity_reward_account=_REWARD,
+        now=1100,
+    )
+    params.update(overrides)
+    return verify_signed_receipt_chain(receipts, **params)
+
+
+def test_empty_chain_accepts_as_no_reward_yet():
+    result = _verify([])
+
+    assert result.decision == SIGNED_RECEIPT_CHAIN_ACCEPT
+    assert result.accepted is True
+    assert result.verified_count == 0
+    assert result.terminal_receipt_hash is None
+    assert result.no_reward_settlement_performed is True
+    assert result.no_execution_performed is True
+
+
+def test_empty_chain_can_fail_closed_when_required():
+    result = _verify([], allow_empty=False)
+
+    assert result.decision == SIGNED_RECEIPT_CHAIN_REJECT
+    assert result.accepted is False
+    assert result.reason_codes == [ReceiptChainReason.EMPTY_CHAIN]
+
+
+def test_valid_first_signed_receipt_accepts():
+    receipt = _receipt()
+    result = _verify([receipt])
+
+    assert result.accepted is True
+    assert result.verified_count == 1
+    assert result.receipt_hashes == [receipt_payload_hash(receipt)]
+    assert result.terminal_receipt_hash == receipt_payload_hash(receipt)
+
+
+def test_two_receipt_hash_chain_accepts():
+    first = _receipt("rcpt-1")
+    second = _receipt("rcpt-2", prev_receipt_hash=receipt_payload_hash(first), covered_action_digest="sha256:action-2")
+
+    result = _verify([first, second])
+
+    assert result.accepted is True
+    assert result.verified_count == 2
+    assert result.receipt_hashes == [receipt_payload_hash(first), receipt_payload_hash(second)]
+    assert result.terminal_receipt_hash == receipt_payload_hash(second)
+
+
+def test_missing_signature_is_not_reward_bearing():
+    receipt = _receipt()
+    receipt["signature"] = ""
+
+    result = _verify([receipt])
+
+    assert result.accepted is False
+    assert ReceiptChainReason.MISSING_SIGNATURE in result.reason_codes
+    assert ReceiptChainReason.SIGNATURE_INVALID in result.reason_codes
+
+
+def test_tampered_covered_action_digest_rejects_signature():
+    receipt = _receipt()
+    receipt["covered_action_digest"] = "sha256:tampered"
+
+    result = _verify([receipt])
+
+    assert result.accepted is False
+    assert result.reason_codes == [ReceiptChainReason.SIGNATURE_INVALID]
+
+
+def test_wrong_previous_hash_rejects_chain():
+    first = _receipt("rcpt-1")
+    second = _receipt("rcpt-2", prev_receipt_hash="sha256:not-the-first")
+
+    result = _verify([first, second])
+
+    assert result.accepted is False
+    assert ReceiptChainReason.PREV_HASH_MISMATCH in result.reason_codes
+
+
+def test_work_order_mismatch_rejects_receipt():
+    receipt = _receipt(work_order_id="wo-other")
+
+    result = _verify([receipt])
+
+    assert result.accepted is False
+    assert ReceiptChainReason.WORK_ORDER_MISMATCH in result.reason_codes
+
+
+def test_reddog_mismatch_rejects_receipt():
+    receipt = _receipt(reddog_id="reddog:other")
+
+    result = _verify([receipt])
+
+    assert result.accepted is False
+    assert ReceiptChainReason.REDDOG_MISMATCH in result.reason_codes
+
+
+def test_reward_account_mismatch_rejects_receipt():
+    receipt = _receipt(reward_account="ups:attacker")
+
+    result = _verify([receipt])
+
+    assert result.accepted is False
+    assert ReceiptChainReason.REWARD_ACCOUNT_MISMATCH in result.reason_codes
+
+
+def test_issued_at_future_skew_rejects_receipt():
+    receipt = _receipt(issued_at=5000)
+
+    result = _verify([receipt], now=1000, max_future_skew_s=60)
+
+    assert result.accepted is False
+    assert ReceiptChainReason.ISSUED_IN_FUTURE in result.reason_codes
+
+
+def test_non_ascii_receipt_rejects():
+    receipt = _receipt(receipt_id="rcpt-1")
+    receipt["receipt_id"] = "rcpt-cafe-\u00e9"
+
+    result = _verify([receipt])
+
+    assert result.accepted is False
+    assert ReceiptChainReason.NON_ASCII in result.reason_codes
+
+
+def test_default_verifier_fails_closed_on_non_empty_chain():
+    receipt = _receipt()
+
+    result = verify_signed_receipt_chain(
+        [receipt],
+        reddog_public_key=_PUB,
+        work_order_id=_WORK_ORDER,
+        reddog_id=_REDDOG,
+        identity_reward_account=_REWARD,
+        now=1100,
+    )
+
+    assert result.accepted is False
+    assert result.reason_codes == [ReceiptChainReason.SIGNATURE_INVALID]
+
+
+def test_malformed_mapping_rejects():
+    result = _verify([{"receipt_id": "rcpt-missing-fields"}])
+
+    assert result.accepted is False
+    assert result.reason_codes == [ReceiptChainReason.MALFORMED_RECEIPT]
+
+
+def test_ast_boundary_no_signing_or_execution_surface():
+    path = Path("modules/communication/moltbot_bridge/src/reddog_signed_receipt_chain.py")
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imports = set()
+    calls = set()
+    names = set()
+    constants = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                calls.add(node.func.id)
+            elif isinstance(node.func, ast.Attribute):
+                calls.add(node.func.attr)
+        elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+            constants.append(node.value.lower())
+        elif isinstance(node, ast.Name):
+            names.add(node.id.lower())
+
+    forbidden_import_fragments = (
+        "subprocess",
+        "socket",
+        "os",
+        "secrets",
+        "cryptography",
+        "nacl",
+        "ecdsa",
+        "web3",
+        "wallet",
+        "hmac",
+    )
+    forbidden_calls = {"open", "eval", "exec", "system", "popen", "run", "check_call", "check_output"}
+    assert not any(fragment in imported for imported in imports for fragment in forbidden_import_fragments)
+    assert not (calls & forbidden_calls)
+    assert not any("begin private key" in value or "mock-secret" in value for value in constants)
+    assert not any(name in {"private_key", "secret", "sign"} for name in names)


### PR DESCRIPTION
## REDDOG_SIGNED_RECEIPT_CHAIN_PHASE1

Verification-only signed receipt chain slice. Adds `reddog_signed_receipt_chain.py` and focused tests for externally signed `reddog-receipt.v1` records.

### WSP_97 truth boundary

OBSERVED:
- Verifies ordered signed receipts against an injected public-key verifier.
- Checks `work_order_id`, `reddog_id`, optional `reward_account`, issued-at freshness, ASCII payloads, and `prev_receipt_hash` linkage.
- Empty chains can accept only as issuance-time no-reward-yet.
- Unsigned/non-verifying receipts reject and cannot become reward-bearing chain entries.

SPECIFIED_NOT_IMPLEMENTED:
- No signing backend, no key generation, no private key handling.
- No reward settlement, wallet, chain write, OpenClaw/Hermes/WRE wiring, shell, repo mutation, PR, or merge authority.

### Validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_receipt_chain.py -q` -> 15 passed
- Adjacent RedDog authority/spine subset -> 175 passed
- `git diff --check` -> clean (line-ending warnings only)
- Added diff lines ASCII-clean

### HoloIndex

Read-only probes for:
- `RedDog signed receipt chain`
- `reddog-receipt.v1 SignedReceipt`
- `verify_signed_receipt_chain reward_account`

The new module did not surface in top hits. Recorded `HOLOINDEX_REDDOG_SIGNED_RECEIPT_CHAIN_INDEX_GAP_PHASE1`; no runtime re-index performed.