### PR TITLE
feat(reddog): add live OpenClaw enqueue seam

### DIFF
--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -836,6 +836,25 @@ links. Empty chains are valid only as issuance-time "no reward yet"; unsigned re
 rejected and cannot be reward-bearing. This module does not sign, generate keys, settle
 rewards, execute commands, enqueue OpenClaw/Hermes/WRE work, or mutate the repo.
 
+### RedDog OpenClaw Live Enqueue (valve-gated queue-write seam)
+
+```python
+from modules.communication.moltbot_bridge.src.reddog_openclaw_live_enqueue import (
+    perform_reddog_openclaw_live_enqueue,  # adapter + policy + receipt-chain + valve + writer -> result
+    RedDogOpenClawLiveEnqueueResult,
+    RedDogOpenClawLiveEnqueueReceipt,
+    LIVE_ENQUEUE_ACCEPT,
+    LIVE_ENQUEUE_REJECT,
+)
+```
+
+`REDDOG_OPENCLAW_LIVE_ENQUEUE_IMPLEMENTATION_PHASE1` is the first live OpenClaw
+queue-write seam, but only through an injected writer and only when `VALVE_OPEN_LIVE_ENQUEUE`
+is present. It requires accepted #904 adapter dry-run output, #950 signed work authority,
+#951 signed receipt-chain verification, and a live enqueue writer. It does not import
+AgentDB/OpenClaw queue modules directly, execute Hermes/WRE work, create worktrees, edit files,
+create PRs, push, merge, or settle rewards.
+
 ### RedDog Work-Order Receipt (Hermes-compatible audit trail, no execution)
 
 ```python

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,14 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-11: REDDOG_OPENCLAW_LIVE_ENQUEUE_IMPLEMENTATION_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_openclaw_live_enqueue.py`: valve-gated live enqueue seam that validates #904 adapter dry-run output, #950 signed work authority, #951 signed receipt-chain verification, and `VALVE_OPEN_LIVE_ENQUEUE` before calling an injected writer.
+- Extended `reddog_wre_execution_valve.py` with `VALVE_OPEN_LIVE_ENQUEUE`, `valve_live_enqueue_enabled`, and `sovereign_live_enqueue_token`; dry-run and worktree-create valves do not authorize live enqueue.
+- Boundary: no direct AgentDB/OpenClaw imports, no Hermes/WRE execution, no worktree creation, no file edits, no PR/push/merge, and no reward settlement. Queue writes occur only through the injected writer after all gates pass.
+- HoloIndex read-only probes for `RedDog OpenClaw live enqueue implementation`, `VALVE_OPEN_LIVE_ENQUEUE`, and `perform_reddog_openclaw_live_enqueue` did not surface the new module in top results. Recorded as `HOLOINDEX_REDDOG_OPENCLAW_LIVE_ENQUEUE_IMPLEMENTATION_INDEX_GAP_PHASE1`; no runtime re-index performed.
+
 ## 2026-07-11: REDDOG_OPENCLAW_LIVE_ENQUEUE_CONTRACT_PHASE1 (refreshed)
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_openclaw_live_enqueue.py
+++ b/modules/communication/moltbot_bridge/src/reddog_openclaw_live_enqueue.py
@@ -1,0 +1,304 @@
+"""RedDog OpenClaw live enqueue implementation seam.
+
+Slice: REDDOG_OPENCLAW_LIVE_ENQUEUE_IMPLEMENTATION_PHASE1
+
+This module is the first live OpenClaw queue-write seam, but it is intentionally
+small and valve-gated. It validates the #904 adapter dry-run output, #950 signed
+authority gate, #951 signed receipt-chain status, and `VALVE_OPEN_LIVE_ENQUEUE`
+before calling an injected writer. It does NOT execute Hermes/WRE work, create
+worktrees, edit files, push, create PRs, merge, or settle rewards.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Mapping, Optional, Protocol, Sequence, Union
+
+from modules.communication.moltbot_bridge.src.reddog_openclaw_adapter_dryrun import (
+    ADAPTER_DRYRUN_ACCEPT,
+    TARGET_AUTONOMOUS_TASK,
+    TARGET_FOUNDUP_JOB,
+    ProposedOpenClawIntakeRecord,
+    RedDogOpenClawAdapterDryRunResult,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_work_order_policy_gate import (
+    POLICY_ACCEPT,
+    SIGNATURE_GATE_ACCEPTED,
+)
+from modules.communication.moltbot_bridge.src.reddog_signed_receipt_chain import (
+    SIGNED_RECEIPT_CHAIN_ACCEPT,
+    SignedReceiptChainVerificationResult,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    VALVE_OPEN_LIVE_ENQUEUE,
+    ExecutionValveDecision,
+)
+
+LIVE_ENQUEUE_ACCEPT = "LIVE_ENQUEUE_ACCEPT"
+LIVE_ENQUEUE_REJECT = "LIVE_ENQUEUE_REJECT"
+
+
+class LiveEnqueueReason:
+    ADAPTER_NOT_ACCEPTED = "REJECT_ADAPTER_NOT_ACCEPTED"
+    MISSING_PROPOSED_INTAKE = "REJECT_MISSING_PROPOSED_INTAKE"
+    INTAKE_ALREADY_ENQUEUED = "REJECT_INTAKE_ALREADY_ENQUEUED"
+    POLICY_NOT_ACCEPTED = "REJECT_POLICY_NOT_ACCEPTED"
+    SIGNATURE_GATE_NOT_ACCEPTED = "REJECT_SIGNATURE_GATE_NOT_ACCEPTED"
+    RECEIPT_CHAIN_NOT_ACCEPTED = "REJECT_SIGNED_RECEIPT_CHAIN_NOT_ACCEPTED"
+    VALVE_NOT_OPEN = "REJECT_VALVE_NOT_OPEN_LIVE_ENQUEUE"
+    TARGET_NOT_CANONICAL = "REJECT_TARGET_NOT_CANONICAL"
+    IDEMPOTENCY_REPLAY = "REJECT_LIVE_ENQUEUE_REPLAY"
+    WRITER_MISSING = "REJECT_LIVE_ENQUEUE_WRITER_MISSING"
+    WRITER_REJECTED = "REJECT_LIVE_ENQUEUE_WRITER_REJECTED"
+
+
+class LiveEnqueueWriter(Protocol):
+    def enqueue_foundup_job(self, intake: Mapping[str, Any], receipt: Mapping[str, Any]) -> Mapping[str, Any]: ...
+
+    def enqueue_autonomous_task(self, intake: Mapping[str, Any], receipt: Mapping[str, Any]) -> Mapping[str, Any]: ...
+
+
+@dataclass
+class RedDogOpenClawLiveEnqueueReceipt:
+    live_enqueue_id: str
+    work_order_id: str
+    target_type: str
+    proposed_intake_digest: str
+    adapter_dryrun_receipt_digest: str
+    policy_gate_receipt_digest: str
+    signature_gate_digest: str
+    signed_receipt_chain_terminal_hash: Optional[str]
+    valve_decision_digest: str
+    openclaw_queue_item_id: Optional[str]
+    agentdb_task_id: Optional[str]
+    live_enqueue_performed: bool
+    no_execution_performed: bool
+    no_reward_settlement_performed: bool
+    created_at: str
+    receipt_digest: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class RedDogOpenClawLiveEnqueueResult:
+    decision: str
+    work_order_id: str
+    target_type: str
+    rejection_reasons: List[str] = field(default_factory=list)
+    receipt: Optional[RedDogOpenClawLiveEnqueueReceipt] = None
+    live_enqueue_performed: bool = False
+    no_execution_performed: bool = True
+    no_reward_settlement_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        if self.receipt is not None:
+            payload["receipt"] = self.receipt.to_dict()
+        return payload
+
+
+def _utc_now(now: Optional[datetime] = None) -> datetime:
+    value = now or datetime.now(timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _iso8601(dt: datetime) -> str:
+    return dt.replace(microsecond=0).isoformat()
+
+
+def _canonical_digest(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        return value.to_dict()
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _intake_mapping(adapter: Mapping[str, Any]) -> Mapping[str, Any]:
+    intake = adapter.get("proposed_intake")
+    if hasattr(intake, "to_dict"):
+        return intake.to_dict()
+    if isinstance(intake, Mapping):
+        return intake
+    return {}
+
+
+def _adapter_receipt_mapping(adapter: Mapping[str, Any]) -> Mapping[str, Any]:
+    receipt = adapter.get("adapter_receipt")
+    if hasattr(receipt, "to_dict"):
+        return receipt.to_dict()
+    if isinstance(receipt, Mapping):
+        return receipt
+    return {}
+
+
+def _live_enqueue_key(work_order_id: str, adapter_receipt_digest: str) -> str:
+    return f"{work_order_id}:{adapter_receipt_digest}"
+
+
+def _reject(work_order_id: str, target_type: str, reasons: Sequence[str]) -> RedDogOpenClawLiveEnqueueResult:
+    return RedDogOpenClawLiveEnqueueResult(
+        decision=LIVE_ENQUEUE_REJECT,
+        work_order_id=work_order_id or "unknown",
+        target_type=target_type or "",
+        rejection_reasons=list(dict.fromkeys(reasons)),
+        live_enqueue_performed=False,
+        no_execution_performed=True,
+        no_reward_settlement_performed=True,
+    )
+
+
+def _validate_inputs(
+    adapter_result: Mapping[str, Any],
+    policy_gate_receipt: Mapping[str, Any],
+    signed_receipt_chain_result: Mapping[str, Any],
+    valve_decision: Mapping[str, Any],
+    intake: Mapping[str, Any],
+) -> List[str]:
+    reasons: List[str] = []
+    if adapter_result.get("decision") != ADAPTER_DRYRUN_ACCEPT:
+        reasons.append(LiveEnqueueReason.ADAPTER_NOT_ACCEPTED)
+    if not intake:
+        reasons.append(LiveEnqueueReason.MISSING_PROPOSED_INTAKE)
+    else:
+        if intake.get("no_enqueue_performed") is not True:
+            reasons.append(LiveEnqueueReason.INTAKE_ALREADY_ENQUEUED)
+        if intake.get("target_type") not in {TARGET_FOUNDUP_JOB, TARGET_AUTONOMOUS_TASK}:
+            reasons.append(LiveEnqueueReason.TARGET_NOT_CANONICAL)
+    if policy_gate_receipt.get("decision") != POLICY_ACCEPT:
+        reasons.append(LiveEnqueueReason.POLICY_NOT_ACCEPTED)
+    if policy_gate_receipt.get("signature_gate_status") != SIGNATURE_GATE_ACCEPTED:
+        reasons.append(LiveEnqueueReason.SIGNATURE_GATE_NOT_ACCEPTED)
+    if signed_receipt_chain_result.get("decision") != SIGNED_RECEIPT_CHAIN_ACCEPT:
+        reasons.append(LiveEnqueueReason.RECEIPT_CHAIN_NOT_ACCEPTED)
+    if signed_receipt_chain_result.get("accepted") is not True:
+        reasons.append(LiveEnqueueReason.RECEIPT_CHAIN_NOT_ACCEPTED)
+    if valve_decision.get("valve_state") != VALVE_OPEN_LIVE_ENQUEUE:
+        reasons.append(LiveEnqueueReason.VALVE_NOT_OPEN)
+    if valve_decision.get("no_execution_performed") is not True:
+        reasons.append(LiveEnqueueReason.VALVE_NOT_OPEN)
+    return list(dict.fromkeys(reasons))
+
+
+def perform_reddog_openclaw_live_enqueue(
+    adapter_result: Union[RedDogOpenClawAdapterDryRunResult, Mapping[str, Any]],
+    policy_gate_receipt: Mapping[str, Any],
+    signed_receipt_chain_result: Union[SignedReceiptChainVerificationResult, Mapping[str, Any]],
+    valve_decision: Union[ExecutionValveDecision, Mapping[str, Any]],
+    *,
+    writer: Optional[LiveEnqueueWriter],
+    seen_live_enqueue_keys: Optional[set] = None,
+    now: Optional[datetime] = None,
+) -> RedDogOpenClawLiveEnqueueResult:
+    """Validate and enqueue a proposed OpenClaw intake item through an injected writer."""
+    adapter = _mapping(adapter_result)
+    policy = _mapping(policy_gate_receipt)
+    chain = _mapping(signed_receipt_chain_result)
+    valve = _mapping(valve_decision)
+    intake = _intake_mapping(adapter)
+    adapter_receipt = _adapter_receipt_mapping(adapter)
+
+    work_order_id = str(adapter.get("work_order_id") or intake.get("work_order_id") or "unknown")
+    target_type = str(intake.get("target_type") or adapter_receipt.get("target_type") or "")
+    reasons = _validate_inputs(adapter, policy, chain, valve, intake)
+    if writer is None:
+        reasons.append(LiveEnqueueReason.WRITER_MISSING)
+
+    adapter_digest = str(adapter_receipt.get("adapter_receipt_digest") or "")
+    replay_key = _live_enqueue_key(work_order_id, adapter_digest)
+    if seen_live_enqueue_keys is not None and replay_key in seen_live_enqueue_keys:
+        reasons.append(LiveEnqueueReason.IDEMPOTENCY_REPLAY)
+
+    deduped = list(dict.fromkeys(reasons))
+    if deduped:
+        return _reject(work_order_id, target_type, deduped)
+
+    assert writer is not None
+    checked_at = _iso8601(_utc_now(now))
+    proposed_intake_digest = _canonical_digest(dict(intake))
+    receipt_seed = {
+        "work_order_id": work_order_id,
+        "target_type": target_type,
+        "proposed_intake_digest": proposed_intake_digest,
+        "adapter_dryrun_receipt_digest": adapter_digest,
+        "policy_gate_receipt_digest": str(policy.get("receipt_digest") or ""),
+        "signature_gate_digest": str(policy.get("signature_gate_digest") or ""),
+        "signed_receipt_chain_terminal_hash": chain.get("terminal_receipt_hash"),
+        "valve_decision_digest": str(valve.get("decision_digest") or ""),
+        "created_at": checked_at,
+    }
+    live_enqueue_id = "live-enqueue-" + _canonical_digest(receipt_seed)[:16]
+    provisional_receipt = {
+        **receipt_seed,
+        "live_enqueue_id": live_enqueue_id,
+        "live_enqueue_performed": False,
+        "no_execution_performed": True,
+        "no_reward_settlement_performed": True,
+    }
+
+    try:
+        if target_type == TARGET_AUTONOMOUS_TASK:
+            write_result = writer.enqueue_autonomous_task(dict(intake), provisional_receipt)
+        else:
+            write_result = writer.enqueue_foundup_job(dict(intake), provisional_receipt)
+    except Exception:
+        return _reject(work_order_id, target_type, [LiveEnqueueReason.WRITER_REJECTED])
+
+    if not isinstance(write_result, Mapping) or write_result.get("ok") is not True:
+        return _reject(work_order_id, target_type, [LiveEnqueueReason.WRITER_REJECTED])
+
+    if seen_live_enqueue_keys is not None:
+        seen_live_enqueue_keys.add(replay_key)
+
+    receipt = RedDogOpenClawLiveEnqueueReceipt(
+        live_enqueue_id=live_enqueue_id,
+        work_order_id=work_order_id,
+        target_type=target_type,
+        proposed_intake_digest=proposed_intake_digest,
+        adapter_dryrun_receipt_digest=adapter_digest,
+        policy_gate_receipt_digest=str(policy.get("receipt_digest") or ""),
+        signature_gate_digest=str(policy.get("signature_gate_digest") or ""),
+        signed_receipt_chain_terminal_hash=(
+            None if chain.get("terminal_receipt_hash") is None else str(chain.get("terminal_receipt_hash"))
+        ),
+        valve_decision_digest=str(valve.get("decision_digest") or ""),
+        openclaw_queue_item_id=None if write_result.get("openclaw_queue_item_id") is None else str(write_result.get("openclaw_queue_item_id")),
+        agentdb_task_id=None if write_result.get("agentdb_task_id") is None else str(write_result.get("agentdb_task_id")),
+        live_enqueue_performed=True,
+        no_execution_performed=True,
+        no_reward_settlement_performed=True,
+        created_at=checked_at,
+    )
+    receipt.receipt_digest = _canonical_digest({k: v for k, v in receipt.to_dict().items() if k != "receipt_digest"})
+
+    return RedDogOpenClawLiveEnqueueResult(
+        decision=LIVE_ENQUEUE_ACCEPT,
+        work_order_id=work_order_id,
+        target_type=target_type,
+        rejection_reasons=[],
+        receipt=receipt,
+        live_enqueue_performed=True,
+        no_execution_performed=True,
+        no_reward_settlement_performed=True,
+    )
+
+
+__all__ = [
+    "LIVE_ENQUEUE_ACCEPT",
+    "LIVE_ENQUEUE_REJECT",
+    "LiveEnqueueReason",
+    "LiveEnqueueWriter",
+    "RedDogOpenClawLiveEnqueueReceipt",
+    "RedDogOpenClawLiveEnqueueResult",
+    "perform_reddog_openclaw_live_enqueue",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_wre_execution_valve.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_execution_valve.py
@@ -48,6 +48,7 @@ from modules.communication.moltbot_bridge.src.reddog_wre_executor_dryrun import 
 
 VALVE_CLOSED = "VALVE_CLOSED"
 VALVE_OPEN_DRYRUN_ONLY = "VALVE_OPEN_DRYRUN_ONLY"
+VALVE_OPEN_LIVE_ENQUEUE = "VALVE_OPEN_LIVE_ENQUEUE"
 VALVE_OPEN_WORKTREE_CREATE = "VALVE_OPEN_WORKTREE_CREATE"
 
 INTAKE_FOUNDUP_JOB = "foundup_job"
@@ -79,7 +80,9 @@ class ExecutionValveRequest:
 @dataclass
 class ExecutionValveEnvironment:
     valve_dryrun_enabled: bool = False
+    valve_live_enqueue_enabled: bool = False
     valve_worktree_create_enabled: bool = False
+    sovereign_live_enqueue_token: Optional[str] = None
     sovereign_worktree_token: Optional[str] = None
     permission_ttl_seconds: int = DEFAULT_PERMISSION_TTL_SECONDS
     permission_expires_at: Optional[str] = None
@@ -304,12 +307,18 @@ def _resolve_valve_state(
     if reasons:
         return VALVE_CLOSED
     dryrun = bool(environment.get("valve_dryrun_enabled"))
+    live_enqueue = bool(environment.get("valve_live_enqueue_enabled"))
     worktree = bool(environment.get("valve_worktree_create_enabled"))
+    live_token = str(environment.get("sovereign_live_enqueue_token") or "").strip()
     token = str(environment.get("sovereign_worktree_token") or "").strip()
 
     if worktree:
         if token:
             return VALVE_OPEN_WORKTREE_CREATE
+        return VALVE_CLOSED
+    if live_enqueue:
+        if live_token:
+            return VALVE_OPEN_LIVE_ENQUEUE
         return VALVE_CLOSED
     if dryrun:
         return VALVE_OPEN_DRYRUN_ONLY
@@ -347,6 +356,10 @@ def evaluate_reddog_execution_valve(
             env.get("sovereign_worktree_token") or ""
         ).strip():
             rejection_reasons.append("worktree_valve_missing_sovereign_token")
+        elif env.get("valve_live_enqueue_enabled") and not str(
+            env.get("sovereign_live_enqueue_token") or ""
+        ).strip():
+            rejection_reasons.append("live_enqueue_valve_missing_sovereign_token")
         else:
             rejection_reasons.append("explicit_valve_flag_missing")
 
@@ -385,6 +398,7 @@ __all__ = [
     "INTAKE_FOUNDUP_JOB",
     "VALVE_CLOSED",
     "VALVE_OPEN_DRYRUN_ONLY",
+    "VALVE_OPEN_LIVE_ENQUEUE",
     "VALVE_OPEN_WORKTREE_CREATE",
     "evaluate_reddog_execution_valve",
 ]

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,15 @@
+## 2026-07-11: REDDOG_OPENCLAW_LIVE_ENQUEUE_IMPLEMENTATION_PHASE1
+
+**File**: `test_reddog_openclaw_live_enqueue.py` (NEW - 12 tests), `test_reddog_wre_execution_valve.py` (UPDATED)
+**Slice**: `REDDOG_OPENCLAW_LIVE_ENQUEUE_IMPLEMENTATION_PHASE1` | **Predecessors**: #904 adapter dry-run, #905 contract, #950 signature gate, #951 signed receipt chain
+
+Live enqueue seam: accepts only with `VALVE_OPEN_LIVE_ENQUEUE`, accepted signed work authority,
+accepted signed receipt-chain verification, accepted adapter dry-run output, and an injected
+writer. Tests prove dry-run/worktree/closed valves reject before writer call, replay protection,
+writer rejection, autonomous_task and foundup_job routing, and no direct execution/queue imports.
+
+**Run**: `pytest modules/communication/moltbot_bridge/tests/test_reddog_openclaw_live_enqueue.py modules/communication/moltbot_bridge/tests/test_reddog_wre_execution_valve.py -q`
+
 ## 2026-07-11: REDDOG_SIGNED_RECEIPT_CHAIN_PHASE1
 
 **File**: `test_reddog_signed_receipt_chain.py` (NEW - 15 tests)

--- a/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_live_enqueue.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_live_enqueue.py
@@ -1,0 +1,292 @@
+"""Tests for REDDOG_OPENCLAW_LIVE_ENQUEUE_IMPLEMENTATION_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+from datetime import datetime, timezone
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_openclaw_live_enqueue import (
+    LIVE_ENQUEUE_ACCEPT,
+    LIVE_ENQUEUE_REJECT,
+    LiveEnqueueReason,
+    perform_reddog_openclaw_live_enqueue,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_adapter_dryrun import (
+    ADAPTER_DRYRUN_ACCEPT,
+    ADAPTER_DRYRUN_REJECT,
+    TARGET_AUTONOMOUS_TASK,
+    TARGET_FOUNDUP_JOB,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_work_order_policy_gate import (
+    POLICY_ACCEPT,
+    POLICY_REJECT,
+    SIGNATURE_GATE_ACCEPTED,
+    SIGNATURE_GATE_REJECTED,
+)
+from modules.communication.moltbot_bridge.src.reddog_signed_receipt_chain import (
+    SIGNED_RECEIPT_CHAIN_ACCEPT,
+    SIGNED_RECEIPT_CHAIN_REJECT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    VALVE_CLOSED,
+    VALVE_OPEN_DRYRUN_ONLY,
+    VALVE_OPEN_LIVE_ENQUEUE,
+    VALVE_OPEN_WORKTREE_CREATE,
+)
+
+
+class _FakeWriter:
+    def __init__(self, ok=True) -> None:
+        self.ok = ok
+        self.calls = []
+
+    def enqueue_foundup_job(self, intake, receipt):
+        self.calls.append(("foundup_job", dict(intake), dict(receipt)))
+        if not self.ok:
+            return {"ok": False}
+        return {"ok": True, "openclaw_queue_item_id": intake["proposed_job_id"], "agentdb_task_id": None}
+
+    def enqueue_autonomous_task(self, intake, receipt):
+        self.calls.append(("autonomous_task", dict(intake), dict(receipt)))
+        if not self.ok:
+            return {"ok": False}
+        return {"ok": True, "openclaw_queue_item_id": None, "agentdb_task_id": intake["proposed_task_id"]}
+
+
+def _intake(target_type=TARGET_FOUNDUP_JOB):
+    return {
+        "target_type": target_type,
+        "proposed_job_id": "reddog-fj-1234" if target_type == TARGET_FOUNDUP_JOB else None,
+        "proposed_task_id": "reddog-wo-1234" if target_type == TARGET_AUTONOMOUS_TASK else None,
+        "work_order_id": "wo-live-enqueue-001",
+        "operation": "feature_slice",
+        "requested_action": "build_foundup" if target_type == TARGET_FOUNDUP_JOB else None,
+        "repo_scope": "FOUNDUPS/Foundups-Agent",
+        "allowed_paths": ["modules/communication/moltbot_bridge/**"],
+        "denied_paths": [".env"],
+        "required_tests": ["modules/communication/moltbot_bridge/tests/test_reddog_openclaw_live_enqueue.py"],
+        "evidence_refs": ["policy_gate:sha256:policy"],
+        "policy_receipt_digest": "sha256:policy",
+        "work_order_receipt_digest": "sha256:work-order",
+        "invocation_receipt_digest": "sha256:invocation",
+        "executor_plan_id": "plan-live-enqueue",
+        "valve_decision_digest": "sha256:dryrun-valve",
+        "no_enqueue_performed": True,
+        "no_execution_performed": True,
+    }
+
+
+def _adapter(target_type=TARGET_FOUNDUP_JOB, decision=ADAPTER_DRYRUN_ACCEPT):
+    return {
+        "decision": decision,
+        "work_order_id": "wo-live-enqueue-001",
+        "proposed_intake": _intake(target_type) if decision == ADAPTER_DRYRUN_ACCEPT else None,
+        "adapter_receipt": {
+            "adapter_receipt_id": "adapter-dryrun-001",
+            "adapter_receipt_digest": "sha256:adapter",
+            "decision": decision,
+            "rejection_reasons": [],
+            "target_type": target_type,
+            "work_order_id": "wo-live-enqueue-001",
+            "created_at": "2026-07-11T00:00:00+00:00",
+        },
+        "rejection_reasons": [],
+        "no_enqueue_performed": True,
+        "no_execution_performed": True,
+    }
+
+
+def _policy(decision=POLICY_ACCEPT, signature_status=SIGNATURE_GATE_ACCEPTED):
+    return {
+        "decision": decision,
+        "receipt_digest": "sha256:policy",
+        "signature_gate_status": signature_status,
+        "signature_gate_digest": "sha256:signed-authority",
+        "no_execution_performed": True,
+        "work_order_id": "wo-live-enqueue-001",
+    }
+
+
+def _chain(decision=SIGNED_RECEIPT_CHAIN_ACCEPT, accepted=True):
+    return {
+        "decision": decision,
+        "accepted": accepted,
+        "verified_count": 1 if accepted else 0,
+        "terminal_receipt_hash": "sha256:terminal-receipt" if accepted else None,
+        "no_reward_settlement_performed": True,
+        "no_execution_performed": True,
+    }
+
+
+def _valve(state=VALVE_OPEN_LIVE_ENQUEUE):
+    return {
+        "valve_state": state,
+        "work_order_id": "wo-live-enqueue-001",
+        "rejection_reasons": [],
+        "gates_checked": ["execution_valve_evaluator"],
+        "no_execution_performed": True,
+        "decision_digest": "sha256:live-enqueue-valve",
+        "intake_target": TARGET_FOUNDUP_JOB,
+    }
+
+
+def test_live_enqueue_foundup_job_calls_injected_writer_only():
+    writer = _FakeWriter()
+    result = perform_reddog_openclaw_live_enqueue(
+        _adapter(),
+        _policy(),
+        _chain(),
+        _valve(),
+        writer=writer,
+        seen_live_enqueue_keys=set(),
+        now=datetime(2026, 7, 11, tzinfo=timezone.utc),
+    )
+
+    assert result.decision == LIVE_ENQUEUE_ACCEPT
+    assert result.live_enqueue_performed is True
+    assert result.no_execution_performed is True
+    assert result.no_reward_settlement_performed is True
+    assert result.receipt is not None
+    assert result.receipt.openclaw_queue_item_id == "reddog-fj-1234"
+    assert result.receipt.agentdb_task_id is None
+    assert writer.calls[0][0] == "foundup_job"
+
+
+def test_live_enqueue_autonomous_task_calls_task_writer():
+    writer = _FakeWriter()
+    result = perform_reddog_openclaw_live_enqueue(
+        _adapter(TARGET_AUTONOMOUS_TASK),
+        _policy(),
+        _chain(),
+        _valve(),
+        writer=writer,
+    )
+
+    assert result.decision == LIVE_ENQUEUE_ACCEPT
+    assert result.target_type == TARGET_AUTONOMOUS_TASK
+    assert result.receipt is not None
+    assert result.receipt.agentdb_task_id == "reddog-wo-1234"
+    assert writer.calls[0][0] == "autonomous_task"
+
+
+def test_rejects_dryrun_valve_before_writer_call():
+    writer = _FakeWriter()
+    result = perform_reddog_openclaw_live_enqueue(
+        _adapter(), _policy(), _chain(), _valve(VALVE_OPEN_DRYRUN_ONLY), writer=writer
+    )
+
+    assert result.decision == LIVE_ENQUEUE_REJECT
+    assert LiveEnqueueReason.VALVE_NOT_OPEN in result.rejection_reasons
+    assert writer.calls == []
+
+
+def test_rejects_worktree_valve_as_wrong_authority():
+    writer = _FakeWriter()
+    result = perform_reddog_openclaw_live_enqueue(
+        _adapter(), _policy(), _chain(), _valve(VALVE_OPEN_WORKTREE_CREATE), writer=writer
+    )
+
+    assert result.decision == LIVE_ENQUEUE_REJECT
+    assert result.rejection_reasons == [LiveEnqueueReason.VALVE_NOT_OPEN]
+    assert writer.calls == []
+
+
+def test_rejects_closed_valve():
+    result = perform_reddog_openclaw_live_enqueue(
+        _adapter(), _policy(), _chain(), _valve(VALVE_CLOSED), writer=_FakeWriter()
+    )
+
+    assert result.decision == LIVE_ENQUEUE_REJECT
+    assert LiveEnqueueReason.VALVE_NOT_OPEN in result.rejection_reasons
+
+
+def test_rejects_missing_signed_authority():
+    result = perform_reddog_openclaw_live_enqueue(
+        _adapter(), _policy(signature_status=SIGNATURE_GATE_REJECTED), _chain(), _valve(), writer=_FakeWriter()
+    )
+
+    assert result.decision == LIVE_ENQUEUE_REJECT
+    assert LiveEnqueueReason.SIGNATURE_GATE_NOT_ACCEPTED in result.rejection_reasons
+
+
+def test_rejects_rejected_policy():
+    result = perform_reddog_openclaw_live_enqueue(
+        _adapter(), _policy(decision=POLICY_REJECT), _chain(), _valve(), writer=_FakeWriter()
+    )
+
+    assert result.decision == LIVE_ENQUEUE_REJECT
+    assert LiveEnqueueReason.POLICY_NOT_ACCEPTED in result.rejection_reasons
+
+
+def test_rejects_unsigned_or_rejected_receipt_chain():
+    result = perform_reddog_openclaw_live_enqueue(
+        _adapter(), _policy(), _chain(SIGNED_RECEIPT_CHAIN_REJECT, accepted=False), _valve(), writer=_FakeWriter()
+    )
+
+    assert result.decision == LIVE_ENQUEUE_REJECT
+    assert LiveEnqueueReason.RECEIPT_CHAIN_NOT_ACCEPTED in result.rejection_reasons
+
+
+def test_rejects_adapter_rejection_and_missing_intake():
+    result = perform_reddog_openclaw_live_enqueue(
+        _adapter(decision=ADAPTER_DRYRUN_REJECT), _policy(), _chain(), _valve(), writer=_FakeWriter()
+    )
+
+    assert result.decision == LIVE_ENQUEUE_REJECT
+    assert LiveEnqueueReason.ADAPTER_NOT_ACCEPTED in result.rejection_reasons
+    assert LiveEnqueueReason.MISSING_PROPOSED_INTAKE in result.rejection_reasons
+
+
+def test_rejects_replay_before_second_writer_call():
+    writer = _FakeWriter()
+    seen = set()
+    first = perform_reddog_openclaw_live_enqueue(_adapter(), _policy(), _chain(), _valve(), writer=writer, seen_live_enqueue_keys=seen)
+    second = perform_reddog_openclaw_live_enqueue(_adapter(), _policy(), _chain(), _valve(), writer=writer, seen_live_enqueue_keys=seen)
+
+    assert first.decision == LIVE_ENQUEUE_ACCEPT
+    assert second.decision == LIVE_ENQUEUE_REJECT
+    assert LiveEnqueueReason.IDEMPOTENCY_REPLAY in second.rejection_reasons
+    assert len(writer.calls) == 1
+
+
+def test_rejects_writer_missing_or_writer_rejected():
+    missing = perform_reddog_openclaw_live_enqueue(_adapter(), _policy(), _chain(), _valve(), writer=None)
+    rejected = perform_reddog_openclaw_live_enqueue(_adapter(), _policy(), _chain(), _valve(), writer=_FakeWriter(ok=False))
+
+    assert missing.decision == LIVE_ENQUEUE_REJECT
+    assert LiveEnqueueReason.WRITER_MISSING in missing.rejection_reasons
+    assert rejected.decision == LIVE_ENQUEUE_REJECT
+    assert rejected.rejection_reasons == [LiveEnqueueReason.WRITER_REJECTED]
+
+
+def test_ast_boundary_no_direct_execution_or_queue_imports():
+    path = Path("modules/communication/moltbot_bridge/src/reddog_openclaw_live_enqueue.py")
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imports = set()
+    calls = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                calls.add(node.func.id)
+            elif isinstance(node.func, ast.Attribute):
+                calls.add(node.func.attr)
+
+    forbidden_import_fragments = (
+        "subprocess",
+        "socket",
+        "agent_db",
+        "openclaw_foundup_orchestrator",
+        "hermes",
+        "wre_core",
+        "skillz",
+        "github",
+    )
+    forbidden_calls = {"open", "eval", "exec", "system", "popen", "run", "check_call", "check_output"}
+    assert not any(fragment in imported for imported in imports for fragment in forbidden_import_fragments)
+    assert not (calls & forbidden_calls)

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_execution_valve.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_execution_valve.py
@@ -20,6 +20,7 @@ from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import 
     INTAKE_FOUNDUP_JOB,
     VALVE_CLOSED,
     VALVE_OPEN_DRYRUN_ONLY,
+    VALVE_OPEN_LIVE_ENQUEUE,
     VALVE_OPEN_WORKTREE_CREATE,
     ExecutionValveEnvironment,
     ExecutionValveRequest,
@@ -180,6 +181,25 @@ class TestValveOpenPaths:
         decision = evaluate_reddog_execution_valve(req, env)
         assert decision.valve_state == VALVE_CLOSED
         assert "worktree_valve_missing_sovereign_token" in decision.rejection_reasons
+
+    def test_live_enqueue_requires_live_enqueue_token(self):
+        order, policy, receipt, invocation, executor = _full_spine_bundle()
+        req = _request_from_spine(order, policy, receipt, invocation, executor)
+        env = ExecutionValveEnvironment(valve_live_enqueue_enabled=True)
+        decision = evaluate_reddog_execution_valve(req, env)
+        assert decision.valve_state == VALVE_CLOSED
+        assert "live_enqueue_valve_missing_sovereign_token" in decision.rejection_reasons
+
+    def test_live_enqueue_with_token_opens_live_enqueue_state(self):
+        order, policy, receipt, invocation, executor = _full_spine_bundle()
+        req = _request_from_spine(order, policy, receipt, invocation, executor)
+        env = ExecutionValveEnvironment(
+            valve_live_enqueue_enabled=True,
+            sovereign_live_enqueue_token="012-sovereign-live-enqueue-token",
+        )
+        decision = evaluate_reddog_execution_valve(req, env)
+        assert decision.valve_state == VALVE_OPEN_LIVE_ENQUEUE
+        assert decision.rejection_reasons == []
 
     def test_worktree_create_with_token_opens(self):
         order, policy, receipt, invocation, executor = _full_spine_bundle()


### PR DESCRIPTION
## REDDOG_OPENCLAW_LIVE_ENQUEUE_IMPLEMENTATION_PHASE1

Adds the first live OpenClaw queue-write seam for RedDog, gated by the refreshed #905 contract.

### What it does

- Adds `VALVE_OPEN_LIVE_ENQUEUE` to the pure execution valve evaluator.
- Adds `perform_reddog_openclaw_live_enqueue(...)`.
- Requires accepted #904 adapter dry-run output, #950 signed work authority, #951 signed receipt-chain verification, and `VALVE_OPEN_LIVE_ENQUEUE`.
- Calls only an injected writer after all checks pass.
- Emits `RedDogOpenClawLiveEnqueueReceipt` with no execution and no reward settlement.

### WSP_97 boundaries

OBSERVED:
- Dry-run, worktree-create, and closed valves reject before writer call.
- Signed authority and signed receipt-chain are mandatory.
- Replay protection blocks duplicate live enqueue keys before a second writer call.
- Both `foundup_job` and `autonomous_task` target routing are tested.

SPECIFIED_NOT_IMPLEMENTED:
- No direct AgentDB/OpenClaw queue adapter in this slice.
- No Hermes/WRE task execution.
- No worktree create, file edit, PR, push, merge, wallet, chain, or reward settlement.

### Validation

- Focused live enqueue + valve tests -> 26 passed
- Broader RedDog authority/spine subset -> 120 passed
- `git diff --check` -> clean (line-ending warnings only)
- Added diff lines ASCII-clean

### HoloIndex

Read-only probes for:
- `RedDog OpenClaw live enqueue implementation`
- `VALVE_OPEN_LIVE_ENQUEUE`
- `perform_reddog_openclaw_live_enqueue`

The new module did not surface in top hits. Recorded `HOLOINDEX_REDDOG_OPENCLAW_LIVE_ENQUEUE_IMPLEMENTATION_INDEX_GAP_PHASE1`; no runtime re-index performed.