### PR TITLE
feat(reddog): add OpenClaw live enqueue writer adapter

### DIFF
--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -855,6 +855,17 @@ is present. It requires accepted #904 adapter dry-run output, #950 signed work a
 AgentDB/OpenClaw queue modules directly, execute Hermes/WRE work, create worktrees, edit files,
 create PRs, push, merge, or settle rewards.
 
+```python
+from modules.communication.moltbot_bridge.src.reddog_openclaw_live_enqueue_writer import (
+    OpenClawLiveEnqueueWriter,  # concrete writer adapter: FoundUpJob queue or AgentDB task only
+)
+```
+
+`REDDOG_OPENCLAW_LIVE_ENQUEUE_WRITER_ADAPTER_PHASE1` supplies the concrete writer for the
+injected seam. `foundup_job` appends a typed `FoundUpJob` to OpenClaw's queue; `autonomous_task`
+calls `AgentDB.create_autonomous_task()`. It does not drain the queue, execute tasks, dispatch
+Hermes/WRE, create worktrees, edit files, create PRs, push, merge, or settle rewards.
+
 ### RedDog Work-Order Receipt (Hermes-compatible audit trail, no execution)
 
 ```python

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,13 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-11: REDDOG_OPENCLAW_LIVE_ENQUEUE_WRITER_ADAPTER_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_openclaw_live_enqueue_writer.py`: concrete writer for the #952 live enqueue seam. `foundup_job` appends a typed `FoundUpJob` to OpenClaw's in-memory queue; `autonomous_task` calls `AgentDB.create_autonomous_task()` through a lazy/injectable DB factory.
+- Boundary: queue/task creation only. No queue drain, no Hermes/WRE execution, no worktree creation, no file edits, no PR/push/merge, and no reward settlement.
+- HoloIndex read-only probes for `RedDog OpenClaw live enqueue writer adapter` and `OpenClawLiveEnqueueWriter AgentDB FoundUpJob` did not surface the new module in top results. Recorded as `HOLOINDEX_REDDOG_OPENCLAW_LIVE_ENQUEUE_WRITER_ADAPTER_INDEX_GAP_PHASE1`; no runtime re-index performed.
+
 ## 2026-07-11: REDDOG_OPENCLAW_LIVE_ENQUEUE_IMPLEMENTATION_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_openclaw_live_enqueue_writer.py
+++ b/modules/communication/moltbot_bridge/src/reddog_openclaw_live_enqueue_writer.py
@@ -1,0 +1,94 @@
+"""Concrete OpenClaw live enqueue writer for RedDog.
+
+Slice: REDDOG_OPENCLAW_LIVE_ENQUEUE_WRITER_ADAPTER_PHASE1
+
+This adapter implements the writer protocol consumed by
+`perform_reddog_openclaw_live_enqueue`. It writes only the queue/task intake record:
+
+- `foundup_job` -> append a typed FoundUpJob to OpenClaw's in-memory queue.
+- `autonomous_task` -> call AgentDB.create_autonomous_task().
+
+It does NOT execute queued tasks, dispatch Hermes/WRE, create worktrees, edit files,
+create PRs, push, merge, or settle rewards.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Mapping, Optional
+
+from modules.communication.moltbot_bridge.src.foundup_job_contract import FoundUpJob
+from modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator import get_job_queue
+
+
+def _safe_str(value: Any, default: str = "") -> str:
+    text = str(value or "").strip()
+    return text or default
+
+
+def _payload(intake: Mapping[str, Any], receipt: Mapping[str, Any]) -> Dict[str, Any]:
+    return {
+        "source": "reddog_openclaw_live_enqueue",
+        "proposed_intake": dict(intake),
+        "live_enqueue_receipt": dict(receipt),
+        "no_execution_performed": True,
+        "no_reward_settlement_performed": True,
+    }
+
+
+class OpenClawLiveEnqueueWriter:
+    """Concrete queue writer. Construction is side-effect free.
+
+    `agent_db_factory` is injectable so tests can avoid touching the real DB while the
+    production adapter can construct AgentDB lazily only when autonomous_task is used.
+    """
+
+    def __init__(self, agent_db_factory: Optional[Callable[[], Any]] = None) -> None:
+        self._agent_db_factory = agent_db_factory
+
+    def enqueue_foundup_job(self, intake: Mapping[str, Any], receipt: Mapping[str, Any]) -> Mapping[str, Any]:
+        job_id = _safe_str(intake.get("proposed_job_id"))
+        if not job_id:
+            return {"ok": False, "reason": "missing_proposed_job_id"}
+
+        job = FoundUpJob(
+            job_id=job_id,
+            tenant_id="reddog",
+            foundup_id=None,
+            intent_id=_safe_str(intake.get("work_order_id"), default=job_id),
+            requested_action=_safe_str(intake.get("requested_action"), default="validate_foundup"),
+            payload=_payload(intake, receipt),
+        )
+        job.status_reason_human = "RedDog live enqueue created FoundUpJob; execution not started."
+        job.evidence_refs = list(intake.get("evidence_refs") or [])
+        get_job_queue().append(job)
+        return {"ok": True, "openclaw_queue_item_id": job.job_id, "agentdb_task_id": None}
+
+    def enqueue_autonomous_task(self, intake: Mapping[str, Any], receipt: Mapping[str, Any]) -> Mapping[str, Any]:
+        task_id = _safe_str(intake.get("proposed_task_id"))
+        if not task_id:
+            return {"ok": False, "reason": "missing_proposed_task_id"}
+
+        factory = self._agent_db_factory
+        if factory is None:
+            from modules.infrastructure.database.src.agent_db import AgentDB
+
+            factory = AgentDB
+
+        db = factory()
+        ok = db.create_autonomous_task(
+            task_id=task_id,
+            description=f"RedDog live enqueue for {_safe_str(intake.get('work_order_id'), default=task_id)}",
+            required_skills=["reddog_work_order"],
+            estimated_complexity=0.5,
+            priority_score=1.0,
+            context=_payload(intake, receipt),
+            origin_continuity_id=_safe_str(intake.get("work_order_id")) or None,
+        )
+        return {
+            "ok": bool(ok),
+            "openclaw_queue_item_id": None,
+            "agentdb_task_id": task_id if ok else None,
+        }
+
+
+__all__ = ["OpenClawLiveEnqueueWriter"]

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,14 @@
+## 2026-07-11: REDDOG_OPENCLAW_LIVE_ENQUEUE_WRITER_ADAPTER_PHASE1
+
+**File**: `test_reddog_openclaw_live_enqueue_writer.py` (NEW - 6 tests)
+**Slice**: `REDDOG_OPENCLAW_LIVE_ENQUEUE_WRITER_ADAPTER_PHASE1` | **Predecessors**: #952 live enqueue seam
+
+Concrete writer adapter: foundup_job appends one typed FoundUpJob to OpenClaw queue without
+execution; autonomous_task calls injected AgentDB factory; #952 seam + concrete writer integration
+appends a queue item; missing ids reject before mutation; AST guard blocks shell/Hermes/WRE execution imports.
+
+**Run**: `pytest modules/communication/moltbot_bridge/tests/test_reddog_openclaw_live_enqueue_writer.py -q`
+
 ## 2026-07-11: REDDOG_OPENCLAW_LIVE_ENQUEUE_IMPLEMENTATION_PHASE1
 
 **File**: `test_reddog_openclaw_live_enqueue.py` (NEW - 12 tests), `test_reddog_wre_execution_valve.py` (UPDATED)

--- a/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_live_enqueue_writer.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_live_enqueue_writer.py
@@ -1,0 +1,209 @@
+"""Tests for REDDOG_OPENCLAW_LIVE_ENQUEUE_WRITER_ADAPTER_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.openclaw_foundup_orchestrator import (
+    clear_job_queue,
+    get_job_queue,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_live_enqueue import (
+    LIVE_ENQUEUE_ACCEPT,
+    perform_reddog_openclaw_live_enqueue,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_live_enqueue_writer import (
+    OpenClawLiveEnqueueWriter,
+)
+
+
+def _intake(target_type="foundup_job"):
+    return {
+        "target_type": target_type,
+        "proposed_job_id": "reddog-fj-writer-001" if target_type == "foundup_job" else None,
+        "proposed_task_id": "reddog-wo-writer-001" if target_type == "autonomous_task" else None,
+        "work_order_id": "wo-writer-001",
+        "operation": "feature_slice",
+        "requested_action": "build_foundup" if target_type == "foundup_job" else None,
+        "repo_scope": "FOUNDUPS/Foundups-Agent",
+        "allowed_paths": ["modules/communication/moltbot_bridge/**"],
+        "denied_paths": [".env"],
+        "required_tests": ["modules/communication/moltbot_bridge/tests/test_reddog_openclaw_live_enqueue_writer.py"],
+        "evidence_refs": ["policy_gate:sha256:policy"],
+        "no_enqueue_performed": True,
+        "no_execution_performed": True,
+    }
+
+
+def _receipt():
+    return {
+        "live_enqueue_id": "live-enqueue-writer-001",
+        "work_order_id": "wo-writer-001",
+        "receipt_digest": "sha256:receipt",
+        "no_execution_performed": True,
+        "no_reward_settlement_performed": True,
+    }
+
+
+def _adapter():
+    return {
+        "decision": "ADAPTER_DRYRUN_ACCEPT",
+        "work_order_id": "wo-writer-001",
+        "proposed_intake": _intake("foundup_job"),
+        "adapter_receipt": {
+            "adapter_receipt_id": "adapter-writer-001",
+            "adapter_receipt_digest": "sha256:adapter",
+            "decision": "ADAPTER_DRYRUN_ACCEPT",
+            "target_type": "foundup_job",
+            "work_order_id": "wo-writer-001",
+            "created_at": "2026-07-11T00:00:00+00:00",
+            "rejection_reasons": [],
+        },
+        "rejection_reasons": [],
+        "no_enqueue_performed": True,
+        "no_execution_performed": True,
+    }
+
+
+def _policy():
+    return {
+        "decision": "POLICY_ACCEPT",
+        "receipt_digest": "sha256:policy",
+        "signature_gate_status": "SIGNATURE_GATE_ACCEPTED",
+        "signature_gate_digest": "sha256:signed-authority",
+        "no_execution_performed": True,
+        "work_order_id": "wo-writer-001",
+    }
+
+
+def _chain():
+    return {
+        "decision": "SIGNED_RECEIPT_CHAIN_ACCEPT",
+        "accepted": True,
+        "terminal_receipt_hash": "sha256:receipt-chain",
+        "no_execution_performed": True,
+        "no_reward_settlement_performed": True,
+    }
+
+
+def _valve():
+    return {
+        "valve_state": "VALVE_OPEN_LIVE_ENQUEUE",
+        "work_order_id": "wo-writer-001",
+        "decision_digest": "sha256:valve",
+        "rejection_reasons": [],
+        "gates_checked": ["execution_valve_evaluator"],
+        "no_execution_performed": True,
+        "intake_target": "foundup_job",
+    }
+
+
+class _FakeAgentDB:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def create_autonomous_task(self, **kwargs):
+        self.calls.append(kwargs)
+        return True
+
+
+def test_foundup_job_writer_appends_typed_job_without_execution():
+    clear_job_queue()
+
+
+def test_live_enqueue_seam_with_concrete_writer_appends_queue_item():
+    clear_job_queue()
+    result = perform_reddog_openclaw_live_enqueue(
+        _adapter(),
+        _policy(),
+        _chain(),
+        _valve(),
+        writer=OpenClawLiveEnqueueWriter(),
+        seen_live_enqueue_keys=set(),
+    )
+
+    assert result.decision == LIVE_ENQUEUE_ACCEPT
+    assert result.receipt is not None
+    assert result.receipt.openclaw_queue_item_id == "reddog-fj-writer-001"
+    assert len(get_job_queue()) == 1
+    assert get_job_queue()[0].payload["live_enqueue_receipt"]["live_enqueue_id"] == result.receipt.live_enqueue_id
+    assert get_job_queue()[0].started_at is None
+    clear_job_queue()
+    writer = OpenClawLiveEnqueueWriter()
+
+    result = writer.enqueue_foundup_job(_intake("foundup_job"), _receipt())
+
+    queue = get_job_queue()
+    assert result == {"ok": True, "openclaw_queue_item_id": "reddog-fj-writer-001", "agentdb_task_id": None}
+    assert len(queue) == 1
+    job = queue[0]
+    assert job.job_id == "reddog-fj-writer-001"
+    assert job.requested_action == "build_foundup"
+    assert job.intent_id == "wo-writer-001"
+    assert job.payload["no_execution_performed"] is True
+    assert job.payload["source"] == "reddog_openclaw_live_enqueue"
+    assert job.started_at is None
+    assert job.worker_id is None
+    clear_job_queue()
+
+
+def test_foundup_job_writer_rejects_missing_proposed_job_id():
+    clear_job_queue()
+    intake = _intake("foundup_job")
+    intake["proposed_job_id"] = ""
+
+    result = OpenClawLiveEnqueueWriter().enqueue_foundup_job(intake, _receipt())
+
+    assert result == {"ok": False, "reason": "missing_proposed_job_id"}
+    assert get_job_queue() == []
+
+
+def test_autonomous_task_writer_calls_agentdb_factory_only_when_used():
+    fake_db = _FakeAgentDB()
+    writer = OpenClawLiveEnqueueWriter(agent_db_factory=lambda: fake_db)
+
+    result = writer.enqueue_autonomous_task(_intake("autonomous_task"), _receipt())
+
+    assert result == {"ok": True, "openclaw_queue_item_id": None, "agentdb_task_id": "reddog-wo-writer-001"}
+    assert len(fake_db.calls) == 1
+    call = fake_db.calls[0]
+    assert call["task_id"] == "reddog-wo-writer-001"
+    assert call["required_skills"] == ["reddog_work_order"]
+    assert call["origin_continuity_id"] == "wo-writer-001"
+    assert call["context"]["no_execution_performed"] is True
+
+
+def test_autonomous_task_writer_rejects_missing_task_id_before_db_factory():
+    calls = []
+    intake = _intake("autonomous_task")
+    intake["proposed_task_id"] = ""
+    writer = OpenClawLiveEnqueueWriter(agent_db_factory=lambda: calls.append("called"))
+
+    result = writer.enqueue_autonomous_task(intake, _receipt())
+
+    assert result == {"ok": False, "reason": "missing_proposed_task_id"}
+    assert calls == []
+
+
+def test_ast_boundary_no_subprocess_hermes_wre_or_execution_calls():
+    path = Path("modules/communication/moltbot_bridge/src/reddog_openclaw_live_enqueue_writer.py")
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imports = set()
+    calls = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                calls.add(node.func.id)
+            elif isinstance(node.func, ast.Attribute):
+                calls.add(node.func.attr)
+
+    forbidden_import_fragments = ("subprocess", "hermes", "wre_core", "skillz", "github")
+    forbidden_calls = {"open", "eval", "exec", "system", "popen", "run", "check_call", "check_output"}
+    assert not any(fragment in imported for imported in imports for fragment in forbidden_import_fragments)
+    assert not (calls & forbidden_calls)


### PR DESCRIPTION
## REDDOG_OPENCLAW_LIVE_ENQUEUE_WRITER_ADAPTER_PHASE1

Adds the concrete writer adapter for the #952 live enqueue seam.

### What it does

- `foundup_job` -> appends a typed `FoundUpJob` to OpenClaw's in-memory queue.
- `autonomous_task` -> calls `AgentDB.create_autonomous_task()` through lazy/injectable DB factory.
- Includes an end-to-end seam test: #952 `perform_reddog_openclaw_live_enqueue()` + concrete writer appends one queued FoundUpJob.

### WSP_97 boundaries

OBSERVED:
- Queue/task creation only.
- No queue drain or task execution.
- Missing proposed job/task ids reject before mutation.
- AgentDB factory is lazy and injectable; tests avoid real DB writes for autonomous_task.

SPECIFIED_NOT_IMPLEMENTED:
- No Hermes/WRE execution.
- No worktree creation, file edits, PR, push, merge, wallet, chain, or reward settlement.

### Validation

- Writer + seam + OpenClaw orchestrator tests -> 40 passed
- RedDog authority/adapter/valve/receipt subset -> 101 passed
- `git diff --check` -> clean (line-ending warnings only)
- Added diff lines ASCII-clean
- `test_openclaw_supervisor_p0.py` currently fails when run alone in this environment; observed unrelated to this slice and not used as gate.

### HoloIndex

Read-only probes for:
- `RedDog OpenClaw live enqueue writer adapter`
- `OpenClawLiveEnqueueWriter AgentDB FoundUpJob`

The new module did not surface in top hits. Recorded `HOLOINDEX_REDDOG_OPENCLAW_LIVE_ENQUEUE_WRITER_ADAPTER_INDEX_GAP_PHASE1`; no runtime re-index performed.