### PR TITLE
feat(reddog): add extension live enqueue invoke guard

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,14 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-12: REDDOG_EXTENSION_TO_LIVE_ENQUEUE_EXPLICIT_VALVE_INVOKE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 95, 97
+
+- Added `src/reddog_extension_live_enqueue_invoke.py`: extension-facing explicit invoke guard that validates a `RedDogOperatorLoopWardrobeSelectionReceipt` before delegating to the existing live enqueue seam.
+- Corrected the operator-loop selector boundary: `wsp97_sovereign_execution` is an accepted governed-execution candidate when downstream signed valve authority is required; actual live enqueue acceptance remains enforced by this guard plus `perform_reddog_openclaw_live_enqueue`.
+- Boundary: no `extension.js` runtime wiring, no concrete writer construction, no HoloIndex re-index, no shell/worktree/merge/reward action, and no task execution. The guard reaches an injected writer only after explicit request, sovereign selection receipt, `VALVE_OPEN_LIVE_ENQUEUE`, accepted signature gate, and accepted signed receipt chain.
+- HoloIndex read-only probe for `RedDog extension live enqueue explicit valve invoke selector receipt` missed the new invoke guard and surfaced adjacent receipt/valve docs instead. Recorded as `HOLOINDEX_REDDOG_EXTENSION_LIVE_ENQUEUE_INVOKE_INDEX_GAP_PHASE1`; no runtime re-index performed.
+
 ## 2026-07-12: REDDOG_OPERATOR_LOOP_WARDROBE_SELECTION_DRYRUN_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 45, 50, 95, 97, 99

--- a/modules/communication/moltbot_bridge/src/reddog_extension_live_enqueue_invoke.py
+++ b/modules/communication/moltbot_bridge/src/reddog_extension_live_enqueue_invoke.py
@@ -1,0 +1,181 @@
+"""Extension-facing RedDog live-enqueue explicit invoke guard.
+
+Slice: REDDOG_EXTENSION_TO_LIVE_ENQUEUE_EXPLICIT_VALVE_INVOKE_PHASE1
+
+This module is the narrow bridge between a RedDog operator-loop selection receipt and the
+already-gated OpenClaw live enqueue seam. It does not wire `extension.js`, construct the
+concrete writer, execute queued tasks, run shell commands, create worktrees, push, merge,
+or settle rewards.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
+
+from modules.communication.moltbot_bridge.src.reddog_openclaw_live_enqueue import (
+    LIVE_ENQUEUE_ACCEPT,
+    LIVE_ENQUEUE_REJECT,
+    LiveEnqueueWriter,
+    RedDogOpenClawLiveEnqueueResult,
+    perform_reddog_openclaw_live_enqueue,
+)
+from modules.communication.moltbot_bridge.src.reddog_operator_loop_wardrobe_selection import (
+    AUTHORITY_SIGNED_VALVE_REQUIRED,
+    AUTHORITY_SOVEREIGN_TOKEN_REQUIRED,
+    EXECUTION_GOVERNED_CANDIDATE,
+    WARDROBE_SOVEREIGN_EXECUTION,
+    RedDogOperatorLoopWardrobeSelectionReceipt,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    VALVE_OPEN_LIVE_ENQUEUE,
+)
+
+EXTENSION_LIVE_ENQUEUE_INVOKE_ACCEPT = "EXTENSION_LIVE_ENQUEUE_INVOKE_ACCEPT"
+EXTENSION_LIVE_ENQUEUE_INVOKE_REJECT = "EXTENSION_LIVE_ENQUEUE_INVOKE_REJECT"
+
+
+class ExtensionLiveEnqueueInvokeReason:
+    EXPLICIT_INVOKE_MISSING = "REJECT_EXPLICIT_LIVE_ENQUEUE_INVOKE_MISSING"
+    SELECTION_RECEIPT_MISSING = "REJECT_SELECTION_RECEIPT_MISSING"
+    SELECTION_HAS_REJECTIONS = "REJECT_SELECTION_RECEIPT_HAS_REJECTIONS"
+    SELECTION_NOT_SOVEREIGN = "REJECT_SELECTION_NOT_SOVEREIGN"
+    SELECTION_PLANE_NOT_GOVERNED = "REJECT_SELECTION_PLANE_NOT_GOVERNED"
+    SELECTION_AUTHORITY_BOUNDARY_INVALID = "REJECT_SELECTION_AUTHORITY_BOUNDARY_INVALID"
+    SELECTION_ALREADY_EXECUTED = "REJECT_SELECTION_ALREADY_EXECUTED"
+    VALVE_NOT_LIVE_ENQUEUE = "REJECT_VALVE_NOT_OPEN_LIVE_ENQUEUE"
+    LIVE_ENQUEUE_REJECTED = "REJECT_LIVE_ENQUEUE_SEAM_REJECTED"
+
+
+@dataclass(frozen=True)
+class RedDogExtensionLiveEnqueueInvokeResult:
+    decision: str
+    rejection_reasons: List[str] = field(default_factory=list)
+    live_enqueue_result: Optional[RedDogOpenClawLiveEnqueueResult] = None
+    explicit_live_enqueue_requested: bool = False
+    no_execution_performed: bool = True
+    no_reward_settlement_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        if self.live_enqueue_result is not None:
+            payload["live_enqueue_result"] = self.live_enqueue_result.to_dict()
+        return payload
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        return value.to_dict()
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _selection_mapping(
+    value: Union[RedDogOperatorLoopWardrobeSelectionReceipt, Mapping[str, Any], None],
+) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    return _mapping(value)
+
+
+def _reject(reasons: Sequence[str], explicit_requested: bool) -> RedDogExtensionLiveEnqueueInvokeResult:
+    return RedDogExtensionLiveEnqueueInvokeResult(
+        decision=EXTENSION_LIVE_ENQUEUE_INVOKE_REJECT,
+        rejection_reasons=list(dict.fromkeys(reasons)),
+        live_enqueue_result=None,
+        explicit_live_enqueue_requested=explicit_requested,
+        no_execution_performed=True,
+        no_reward_settlement_performed=True,
+    )
+
+
+def _validate_selection_receipt(
+    selection_receipt: Mapping[str, Any],
+    valve_decision: Mapping[str, Any],
+) -> List[str]:
+    reasons: List[str] = []
+    if not selection_receipt:
+        return [ExtensionLiveEnqueueInvokeReason.SELECTION_RECEIPT_MISSING]
+    if selection_receipt.get("rejection_reasons"):
+        reasons.append(ExtensionLiveEnqueueInvokeReason.SELECTION_HAS_REJECTIONS)
+    if selection_receipt.get("selected_wardrobe") != WARDROBE_SOVEREIGN_EXECUTION:
+        reasons.append(ExtensionLiveEnqueueInvokeReason.SELECTION_NOT_SOVEREIGN)
+    if selection_receipt.get("execution_plane") != EXECUTION_GOVERNED_CANDIDATE:
+        reasons.append(ExtensionLiveEnqueueInvokeReason.SELECTION_PLANE_NOT_GOVERNED)
+    if selection_receipt.get("authority_boundary") not in {
+        AUTHORITY_SIGNED_VALVE_REQUIRED,
+        AUTHORITY_SOVEREIGN_TOKEN_REQUIRED,
+    }:
+        reasons.append(ExtensionLiveEnqueueInvokeReason.SELECTION_AUTHORITY_BOUNDARY_INVALID)
+    if selection_receipt.get("no_execution_performed") is not True:
+        reasons.append(ExtensionLiveEnqueueInvokeReason.SELECTION_ALREADY_EXECUTED)
+    if selection_receipt.get("no_enqueue_performed") is not True:
+        reasons.append(ExtensionLiveEnqueueInvokeReason.SELECTION_ALREADY_EXECUTED)
+    if valve_decision.get("valve_state") != VALVE_OPEN_LIVE_ENQUEUE:
+        reasons.append(ExtensionLiveEnqueueInvokeReason.VALVE_NOT_LIVE_ENQUEUE)
+    return list(dict.fromkeys(reasons))
+
+
+def invoke_reddog_extension_live_enqueue_explicit_valve(
+    *,
+    explicit_live_enqueue_requested: bool,
+    selection_receipt: Union[RedDogOperatorLoopWardrobeSelectionReceipt, Mapping[str, Any], None],
+    adapter_result: Mapping[str, Any],
+    policy_gate_receipt: Mapping[str, Any],
+    signed_receipt_chain_result: Mapping[str, Any],
+    valve_decision: Mapping[str, Any],
+    writer: Optional[LiveEnqueueWriter],
+    seen_live_enqueue_keys: Optional[set] = None,
+) -> RedDogExtensionLiveEnqueueInvokeResult:
+    """Invoke live enqueue only after explicit request and selection-receipt validation."""
+
+    if explicit_live_enqueue_requested is not True:
+        return _reject(
+            [ExtensionLiveEnqueueInvokeReason.EXPLICIT_INVOKE_MISSING],
+            explicit_requested=False,
+        )
+
+    selection = _selection_mapping(selection_receipt)
+    valve = _mapping(valve_decision)
+    reasons = _validate_selection_receipt(selection, valve)
+    if reasons:
+        return _reject(reasons, explicit_requested=True)
+
+    live_result = perform_reddog_openclaw_live_enqueue(
+        adapter_result,
+        policy_gate_receipt,
+        signed_receipt_chain_result,
+        valve,
+        writer=writer,
+        seen_live_enqueue_keys=seen_live_enqueue_keys,
+    )
+    if live_result.decision != LIVE_ENQUEUE_ACCEPT:
+        reasons = [ExtensionLiveEnqueueInvokeReason.LIVE_ENQUEUE_REJECTED]
+        reasons.extend(live_result.rejection_reasons)
+        return RedDogExtensionLiveEnqueueInvokeResult(
+            decision=EXTENSION_LIVE_ENQUEUE_INVOKE_REJECT,
+            rejection_reasons=list(dict.fromkeys(reasons)),
+            live_enqueue_result=live_result,
+            explicit_live_enqueue_requested=True,
+            no_execution_performed=True,
+            no_reward_settlement_performed=True,
+        )
+
+    return RedDogExtensionLiveEnqueueInvokeResult(
+        decision=EXTENSION_LIVE_ENQUEUE_INVOKE_ACCEPT,
+        rejection_reasons=[],
+        live_enqueue_result=live_result,
+        explicit_live_enqueue_requested=True,
+        no_execution_performed=True,
+        no_reward_settlement_performed=True,
+    )
+
+
+__all__ = [
+    "EXTENSION_LIVE_ENQUEUE_INVOKE_ACCEPT",
+    "EXTENSION_LIVE_ENQUEUE_INVOKE_REJECT",
+    "ExtensionLiveEnqueueInvokeReason",
+    "RedDogExtensionLiveEnqueueInvokeResult",
+    "invoke_reddog_extension_live_enqueue_explicit_valve",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_operator_loop_wardrobe_selection.py
+++ b/modules/communication/moltbot_bridge/src/reddog_operator_loop_wardrobe_selection.py
@@ -415,8 +415,6 @@ def select_reddog_operator_loop_wardrobe_dryrun(
         WARDROBE_SOVEREIGN_EXECUTION,
     }:
         rejection_reasons.append("write_sensitive_index_gap")
-    if selected_wardrobe == WARDROBE_SOVEREIGN_EXECUTION:
-        rejection_reasons.append("sovereign_authority_requires_downstream_signed_valve")
     if not governing_wsps and normalized_authority != "none":
         rejection_reasons.append("missing_governing_wsp_for_authority_request")
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_extension_live_enqueue_invoke.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_extension_live_enqueue_invoke.py
@@ -1,0 +1,297 @@
+"""Tests for RedDog extension-to-live-enqueue explicit valve invoke guard."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_extension_live_enqueue_invoke import (
+    EXTENSION_LIVE_ENQUEUE_INVOKE_ACCEPT,
+    EXTENSION_LIVE_ENQUEUE_INVOKE_REJECT,
+    ExtensionLiveEnqueueInvokeReason,
+    invoke_reddog_extension_live_enqueue_explicit_valve,
+)
+from modules.communication.moltbot_bridge.src.reddog_operator_loop_wardrobe_selection import (
+    WARDROBE_ARCHITECT_AUDIT,
+    select_reddog_operator_loop_wardrobe_dryrun,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    VALVE_CLOSED,
+    VALVE_OPEN_LIVE_ENQUEUE,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_extension_live_enqueue_invoke.py"
+)
+EXTENSION_JS = REPO_ROOT / "extensions" / "foundups_advisory_workers" / "extension.js"
+
+
+class _FakeWriter:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def enqueue_foundup_job(self, intake, receipt):
+        self.calls.append(("foundup_job", dict(intake), dict(receipt)))
+        return {"ok": True, "openclaw_queue_item_id": intake["proposed_job_id"], "agentdb_task_id": None}
+
+    def enqueue_autonomous_task(self, intake, receipt):
+        self.calls.append(("autonomous_task", dict(intake), dict(receipt)))
+        return {"ok": True, "openclaw_queue_item_id": None, "agentdb_task_id": intake["proposed_task_id"]}
+
+
+def _holo():
+    return {
+        "holoindex_query": "RedDog extension live enqueue explicit valve invoke",
+        "holoindex_status": "bundle_json_ok",
+        "index_gap_detected": False,
+        "skill_hits": [{"skill_name": "autonomous_slice_worker"}],
+    }
+
+
+def _selection_receipt(**overrides):
+    result = select_reddog_operator_loop_wardrobe_dryrun(
+        "Invoke RedDog live enqueue through the explicit valve path.",
+        authority_request="live_enqueue",
+        holoindex_evidence=_holo(),
+    )
+    payload = result.receipt.to_dict()
+    payload.update(overrides)
+    return payload
+
+
+def _adapter():
+    return {
+        "decision": "ADAPTER_DRYRUN_ACCEPT",
+        "work_order_id": "wo-extension-live-enqueue-001",
+        "proposed_intake": {
+            "target_type": "foundup_job",
+            "proposed_job_id": "reddog-fj-extension-001",
+            "proposed_task_id": None,
+            "work_order_id": "wo-extension-live-enqueue-001",
+            "operation": "feature_slice",
+            "requested_action": "build_foundup",
+            "repo_scope": "FOUNDUPS/Foundups-Agent",
+            "allowed_paths": ["modules/communication/moltbot_bridge/**"],
+            "denied_paths": [".env"],
+            "required_tests": [
+                "modules/communication/moltbot_bridge/tests/test_reddog_extension_live_enqueue_invoke.py"
+            ],
+            "evidence_refs": ["policy_gate:sha256:policy"],
+            "no_enqueue_performed": True,
+            "no_execution_performed": True,
+        },
+        "adapter_receipt": {
+            "adapter_receipt_id": "adapter-extension-live-enqueue-001",
+            "adapter_receipt_digest": "sha256:adapter-extension",
+            "decision": "ADAPTER_DRYRUN_ACCEPT",
+            "target_type": "foundup_job",
+            "work_order_id": "wo-extension-live-enqueue-001",
+            "created_at": "2026-07-12T00:00:00+00:00",
+            "rejection_reasons": [],
+        },
+        "rejection_reasons": [],
+        "no_enqueue_performed": True,
+        "no_execution_performed": True,
+    }
+
+
+def _policy():
+    return {
+        "decision": "POLICY_ACCEPT",
+        "receipt_digest": "sha256:policy",
+        "signature_gate_status": "SIGNATURE_GATE_ACCEPTED",
+        "signature_gate_digest": "sha256:signed-authority",
+        "no_execution_performed": True,
+        "work_order_id": "wo-extension-live-enqueue-001",
+    }
+
+
+def _chain():
+    return {
+        "decision": "SIGNED_RECEIPT_CHAIN_ACCEPT",
+        "accepted": True,
+        "terminal_receipt_hash": "sha256:terminal-receipt",
+        "no_execution_performed": True,
+        "no_reward_settlement_performed": True,
+    }
+
+
+def _valve(state=VALVE_OPEN_LIVE_ENQUEUE):
+    return {
+        "valve_state": state,
+        "work_order_id": "wo-extension-live-enqueue-001",
+        "decision_digest": "sha256:live-enqueue-valve",
+        "rejection_reasons": [],
+        "gates_checked": ["execution_valve_evaluator"],
+        "no_execution_performed": True,
+        "intake_target": "foundup_job",
+    }
+
+
+def test_accepts_only_explicit_sovereign_selection_and_calls_injected_writer() -> None:
+    writer = _FakeWriter()
+    result = invoke_reddog_extension_live_enqueue_explicit_valve(
+        explicit_live_enqueue_requested=True,
+        selection_receipt=_selection_receipt(),
+        adapter_result=_adapter(),
+        policy_gate_receipt=_policy(),
+        signed_receipt_chain_result=_chain(),
+        valve_decision=_valve(),
+        writer=writer,
+        seen_live_enqueue_keys=set(),
+    )
+
+    assert result.decision == EXTENSION_LIVE_ENQUEUE_INVOKE_ACCEPT
+    assert result.live_enqueue_result is not None
+    assert result.live_enqueue_result.live_enqueue_performed is True
+    assert result.live_enqueue_result.no_execution_performed is True
+    assert writer.calls[0][0] == "foundup_job"
+
+
+def test_rejects_when_explicit_request_missing_before_writer_call() -> None:
+    writer = _FakeWriter()
+    result = invoke_reddog_extension_live_enqueue_explicit_valve(
+        explicit_live_enqueue_requested=False,
+        selection_receipt=_selection_receipt(),
+        adapter_result=_adapter(),
+        policy_gate_receipt=_policy(),
+        signed_receipt_chain_result=_chain(),
+        valve_decision=_valve(),
+        writer=writer,
+    )
+
+    assert result.decision == EXTENSION_LIVE_ENQUEUE_INVOKE_REJECT
+    assert result.rejection_reasons == [ExtensionLiveEnqueueInvokeReason.EXPLICIT_INVOKE_MISSING]
+    assert writer.calls == []
+
+
+def test_rejects_missing_selection_receipt_before_writer_call() -> None:
+    writer = _FakeWriter()
+    result = invoke_reddog_extension_live_enqueue_explicit_valve(
+        explicit_live_enqueue_requested=True,
+        selection_receipt=None,
+        adapter_result=_adapter(),
+        policy_gate_receipt=_policy(),
+        signed_receipt_chain_result=_chain(),
+        valve_decision=_valve(),
+        writer=writer,
+    )
+
+    assert result.decision == EXTENSION_LIVE_ENQUEUE_INVOKE_REJECT
+    assert result.rejection_reasons == [ExtensionLiveEnqueueInvokeReason.SELECTION_RECEIPT_MISSING]
+    assert writer.calls == []
+
+
+def test_rejects_non_sovereign_selection_before_writer_call() -> None:
+    writer = _FakeWriter()
+    selection = _selection_receipt(
+        selected_wardrobe=WARDROBE_ARCHITECT_AUDIT,
+        execution_plane="audit_only",
+        authority_boundary="no_authority",
+    )
+    result = invoke_reddog_extension_live_enqueue_explicit_valve(
+        explicit_live_enqueue_requested=True,
+        selection_receipt=selection,
+        adapter_result=_adapter(),
+        policy_gate_receipt=_policy(),
+        signed_receipt_chain_result=_chain(),
+        valve_decision=_valve(),
+        writer=writer,
+    )
+
+    assert result.decision == EXTENSION_LIVE_ENQUEUE_INVOKE_REJECT
+    assert ExtensionLiveEnqueueInvokeReason.SELECTION_NOT_SOVEREIGN in result.rejection_reasons
+    assert ExtensionLiveEnqueueInvokeReason.SELECTION_PLANE_NOT_GOVERNED in result.rejection_reasons
+    assert writer.calls == []
+
+
+def test_rejects_selection_with_rejection_reasons_before_writer_call() -> None:
+    writer = _FakeWriter()
+    result = invoke_reddog_extension_live_enqueue_explicit_valve(
+        explicit_live_enqueue_requested=True,
+        selection_receipt=_selection_receipt(rejection_reasons=["write_sensitive_index_gap"]),
+        adapter_result=_adapter(),
+        policy_gate_receipt=_policy(),
+        signed_receipt_chain_result=_chain(),
+        valve_decision=_valve(),
+        writer=writer,
+    )
+
+    assert result.decision == EXTENSION_LIVE_ENQUEUE_INVOKE_REJECT
+    assert ExtensionLiveEnqueueInvokeReason.SELECTION_HAS_REJECTIONS in result.rejection_reasons
+    assert writer.calls == []
+
+
+def test_rejects_wrong_valve_before_writer_call() -> None:
+    writer = _FakeWriter()
+    result = invoke_reddog_extension_live_enqueue_explicit_valve(
+        explicit_live_enqueue_requested=True,
+        selection_receipt=_selection_receipt(),
+        adapter_result=_adapter(),
+        policy_gate_receipt=_policy(),
+        signed_receipt_chain_result=_chain(),
+        valve_decision=_valve(VALVE_CLOSED),
+        writer=writer,
+    )
+
+    assert result.decision == EXTENSION_LIVE_ENQUEUE_INVOKE_REJECT
+    assert result.rejection_reasons == [ExtensionLiveEnqueueInvokeReason.VALVE_NOT_LIVE_ENQUEUE]
+    assert writer.calls == []
+
+
+def test_lower_live_enqueue_rejection_is_preserved() -> None:
+    result = invoke_reddog_extension_live_enqueue_explicit_valve(
+        explicit_live_enqueue_requested=True,
+        selection_receipt=_selection_receipt(),
+        adapter_result=_adapter(),
+        policy_gate_receipt=_policy(),
+        signed_receipt_chain_result=_chain(),
+        valve_decision=_valve(),
+        writer=None,
+    )
+
+    assert result.decision == EXTENSION_LIVE_ENQUEUE_INVOKE_REJECT
+    assert ExtensionLiveEnqueueInvokeReason.LIVE_ENQUEUE_REJECTED in result.rejection_reasons
+    assert "REJECT_LIVE_ENQUEUE_WRITER_MISSING" in result.rejection_reasons
+
+
+def test_ast_boundary_no_extension_runtime_concrete_writer_or_command_execution() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    imports = set()
+    calls = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                calls.add(node.func.id)
+            elif isinstance(node.func, ast.Attribute):
+                calls.add(node.func.attr)
+
+    forbidden_import_fragments = (
+        "subprocess",
+        "reddog_openclaw_live_enqueue_writer",
+        "openclaw_foundup_orchestrator",
+        "agent_db",
+        "hermes",
+        "wre_core",
+        "skillz",
+    )
+    forbidden_calls = {"open", "eval", "exec", "system", "popen", "run", "check_call", "check_output"}
+    assert not any(fragment in imported for imported in imports for fragment in forbidden_import_fragments)
+    assert not (calls & forbidden_calls)
+
+
+def test_extension_runtime_not_modified_by_this_slice() -> None:
+    text = EXTENSION_JS.read_text(encoding="utf-8")
+    assert "invoke_reddog_extension_live_enqueue_explicit_valve" not in text
+    assert "reddog_extension_live_enqueue_invoke.py" not in text

--- a/modules/communication/moltbot_bridge/tests/test_reddog_operator_loop_wardrobe_selection.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_operator_loop_wardrobe_selection.py
@@ -95,17 +95,17 @@ def test_implementation_request_selects_draft_pr_plane() -> None:
     assert result.receipt.direct_read_required is True
 
 
-def test_live_enqueue_request_selects_sovereign_execution_and_rejects_until_valve() -> None:
+def test_live_enqueue_request_selects_sovereign_execution_candidate() -> None:
     result = select_reddog_operator_loop_wardrobe_dryrun(
         "Invoke RedDog live enqueue for the next worker.",
         authority_request="live_enqueue",
         holoindex_evidence=_holo(),
     )
-    assert result.decision == WARDROBE_SELECTION_REJECT
+    assert result.decision == WARDROBE_SELECTION_ACCEPT
     assert result.receipt.selected_wardrobe == WARDROBE_SOVEREIGN_EXECUTION
     assert result.receipt.execution_plane == EXECUTION_GOVERNED_CANDIDATE
     assert result.receipt.authority_boundary == AUTHORITY_SIGNED_VALVE_REQUIRED
-    assert "sovereign_authority_requires_downstream_signed_valve" in result.receipt.rejection_reasons
+    assert result.receipt.rejection_reasons == []
 
 
 def test_shell_or_merge_request_requires_sovereign_token_boundary() -> None:


### PR DESCRIPTION
## Summary

- Adds `reddog_extension_live_enqueue_invoke.py`, an extension-facing explicit invoke guard for the RedDog -> live enqueue boundary.
- Requires explicit live-enqueue request, sovereign operator-loop wardrobe selection receipt, `VALVE_OPEN_LIVE_ENQUEUE`, accepted signed work authority, and accepted signed receipt chain before delegating to the existing live enqueue seam.
- Corrects the wardrobe selector so sovereign execution is an accepted governed-execution candidate; downstream authority gates now own final acceptance.

## WSP_97 Evidence

- HoloIndex preflight missed the exact new surface and returned adjacent receipt/valve docs; recorded as `HOLOINDEX_REDDOG_EXTENSION_LIVE_ENQUEUE_INVOKE_INDEX_GAP_PHASE1`.
- Direct-read confirmed `perform_reddog_openclaw_live_enqueue()` already enforces adapter, policy, signature gate, signed receipt chain, and `VALVE_OPEN_LIVE_ENQUEUE` before writer call.
- Direct-read confirmed concrete writer is separate; this slice does not import or construct it.

## Validation

- `pytest modules\communication\moltbot_bridge\tests\test_reddog_extension_live_enqueue_invoke.py modules\communication\moltbot_bridge\tests\test_reddog_operator_loop_wardrobe_selection.py modules\communication\moltbot_bridge\tests\test_reddog_openclaw_live_enqueue.py modules\communication\moltbot_bridge\tests\test_reddog_openclaw_live_enqueue_writer.py` -> 41 passed
- `git diff --check` -> clean (Windows LF/CRLF warning only)
- ASCII byte scan on touched module/test files -> 0 non-ASCII

## Truth Boundary Checklist

- EXPLICIT_INVOKE_REQUIRED: YES
- SELECTION_RECEIPT_REQUIRED: YES
- VALVE_OPEN_LIVE_ENQUEUE_REQUIRED: YES
- SIGNATURE_GATE_AND_RECEIPT_CHAIN_REQUIRED: YES
- NO_EXTENSION_JS_WIRING: YES
- NO_CONCRETE_WRITER_CONSTRUCTION: YES
- NO_HOLOINDEX_REINDEX: YES
- NO_SHELL_WORKTREE_MERGE_REWARD: YES
- NO_TASK_EXECUTION: YES

## Residual SPECIFIED_NOT_IMPLEMENTED

- VS Code extension runtime call site remains unwired.
- Operator/DAO UI flow for explicit live enqueue remains future work.
- WRE/CI HoloIndex freshness/re-index follow-up remains future work.