### PR TITLE
feat(reddog): add generic agent worktree writer dryrun

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,14 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-12: REDDOG_GENERIC_AGENT_WORKTREE_WRITER_DRYRUN_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 95, 97
+
+- Added `src/reddog_generic_agent_worktree_writer_dryrun.py`: pure dry-run validator for the generic agent worktree-write spine defined by the landed contract. It re-derives canonical roots from a domain profile and domain id, validates planned artifacts, pin-independent denylist, signed authority, signed receipt chain, full `VALVE_OPEN_WORKTREE_CREATE` decision, consensus receipt when required, and WRE cwd guard.
+- Added `tests/test_reddog_generic_agent_worktree_writer_dryrun.py`: acceptance, fail-closed, HoloIndex INDEX_GAP, cwd isolation, protected-branch, JSON serialization, and AST no-execution/no-file-write tests.
+- Boundary: no file writes, no worktree creation, no subprocess/git/gh, no shell runner, no PR/merge, no reward settlement, no extension runtime wiring, and no HoloIndex re-index. This emits a dry-run receipt only.
+- HoloIndex read-only probe for `RedDog generic agent worktree writer dryrun domain profile materialize canonical root cwd guard` surfaced adjacent executor/governed-work-order surfaces plus the prior generic spine audit, but not the new module. Recorded as `HOLOINDEX_REDDOG_GENERIC_AGENT_WORKTREE_WRITER_DRYRUN_INDEX_GAP_PHASE1`; no runtime re-index performed.
+
 ## 2026-07-12: REDDOG_GENERIC_AGENT_WORKTREE_WRITE_SPINE_CONTRACT_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 95, 97

--- a/modules/communication/moltbot_bridge/src/reddog_generic_agent_worktree_writer_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_generic_agent_worktree_writer_dryrun.py
@@ -1,0 +1,492 @@
+"""Generic agent worktree writer dry-run.
+
+Slice: REDDOG_GENERIC_AGENT_WORKTREE_WRITER_DRYRUN_PHASE1
+Contract: docs/audits/architecture/REDDOG_GENERIC_AGENT_WORKTREE_WRITE_SPINE_CONTRACT_PHASE1.md
+
+This module proves the generic worktree-write spine without writing files, creating a
+worktree, running shell/git/gh, opening PRs, merging, or settling rewards. It validates
+that a signed authority, receipt chain, full execution-valve decision, domain profile,
+re-derived root, pin-independent denylist, and WRE cwd guard would authorize a future
+writer. It emits a dry-run receipt only.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Union
+
+from modules.communication.moltbot_bridge.src.reddog_operator_loop_wardrobe_selection import (
+    EXECUTION_GOVERNED_CANDIDATE,
+    WARDROBE_SELECTION_ACCEPT,
+    WARDROBE_SOVEREIGN_EXECUTION,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_work_order_policy_gate import (
+    SIGNATURE_GATE_ACCEPTED,
+)
+from modules.communication.moltbot_bridge.src.reddog_signed_receipt_chain import (
+    SIGNED_RECEIPT_CHAIN_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_cwd_guard import (
+    WreCwdGuardResult,
+    validate_wre_worker_operation_cwd,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    VALVE_OPEN_WORKTREE_CREATE,
+)
+
+GENERIC_WRITER_DRYRUN_ACCEPT = "GENERIC_WRITER_DRYRUN_ACCEPT"
+GENERIC_WRITER_DRYRUN_REJECT = "GENERIC_WRITER_DRYRUN_REJECT"
+
+FAIL_PROFILE_INVALID = "FAIL_PROFILE_INVALID"
+FAIL_OPERATION_MISMATCH = "FAIL_OPERATION_MISMATCH"
+FAIL_DOMAIN_ID_INVALID = "FAIL_DOMAIN_ID_INVALID"
+FAIL_CANONICAL_ROOT_INVALID = "FAIL_CANONICAL_ROOT_INVALID"
+FAIL_CALLER_PATHS_WIDEN_PROFILE = "FAIL_CALLER_PATHS_WIDEN_PROFILE"
+FAIL_ARTIFACTS_INVALID = "FAIL_ARTIFACTS_INVALID"
+FAIL_DENIED_PATH = "FAIL_DENIED_PATH"
+FAIL_SELECTION_RECEIPT = "FAIL_SELECTION_RECEIPT"
+FAIL_SIGNED_AUTHORITY = "FAIL_SIGNED_AUTHORITY"
+FAIL_RECEIPT_CHAIN = "FAIL_RECEIPT_CHAIN"
+FAIL_VALVE_DECISION = "FAIL_VALVE_DECISION"
+FAIL_CONSENSUS_REQUIRED = "FAIL_CONSENSUS_REQUIRED"
+FAIL_CWD_GUARD = "FAIL_CWD_GUARD"
+FAIL_PROTECTED_BRANCH = "FAIL_PROTECTED_BRANCH"
+FAIL_HOLOINDEX_INDEX_GAP = "FAIL_HOLOINDEX_INDEX_GAP"
+
+PIN_INDEPENDENT_DENYLIST = (
+    ".env",
+    ".env.*",
+    ".github/workflows/**",
+    "WSP_framework/**",
+    "holo_index/**",
+    "modules/communication/moltbot_bridge/src/reddog_wre_execution_valve.py",
+    "modules/communication/moltbot_bridge/src/reddog_openclaw_work_order_policy_gate.py",
+    "modules/communication/moltbot_bridge/src/reddog_work_order_signature_verifier.py",
+    "modules/communication/moltbot_bridge/src/reddog_signed_receipt_chain.py",
+    "modules/communication/moltbot_bridge/src/reddog_operator_loop_wardrobe_selection.py",
+    "modules/**/secrets/**",
+    "modules/**/wallet/**",
+    "modules/**/nonce/**",
+    "modules/**/permission/**",
+)
+
+_DEVICE_PREFIXES = ("\\\\?\\", "\\\\.\\", "//?/", "//./")
+_PROTECTED_BRANCHES = frozenset({"main", "master"})
+
+
+@dataclass(frozen=True)
+class GenericAgentWorktreeDomainProfile:
+    profile_id: str
+    operation: str
+    artifact_contract_type: str
+    domain_id_pattern: str
+    canonical_root_template: str
+    allowed_path_patterns: List[str]
+    denied_path_patterns: List[str]
+    required_tests: List[str]
+    branch_prefix: str
+    draft_pr_only: bool = True
+    consensus_required: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class GenericAgentWorktreeWriterDryRunRequest:
+    work_order_id: str
+    operation: str
+    domain_id: str
+    domain_profile: Union[GenericAgentWorktreeDomainProfile, Mapping[str, Any]]
+    planned_artifacts: List[str]
+    requested_allowed_paths: List[str]
+    target_branch: str
+    repo_root: str
+    worktree_path: str
+    selection_receipt: Mapping[str, Any]
+    signed_authority: Mapping[str, Any]
+    signed_receipt_chain: Mapping[str, Any]
+    execution_valve_decision: Mapping[str, Any]
+    permission_snapshot_digest: str = ""
+    consensus_receipt_digest: Optional[str] = None
+    operation_cwd: Optional[str] = None
+    holoindex_evidence: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        if isinstance(self.domain_profile, GenericAgentWorktreeDomainProfile):
+            payload["domain_profile"] = self.domain_profile.to_dict()
+        return payload
+
+
+@dataclass(frozen=True)
+class GenericAgentWorktreeWriterDryRunReceipt:
+    receipt_id: str
+    work_order_id: str
+    domain_profile_id: str
+    canonical_root: str
+    canonical_root_digest: str
+    artifact_manifest_digest: str
+    selection_receipt_digest: str
+    signed_authority_digest: str
+    receipt_chain_terminal_hash: str
+    execution_valve_decision_digest: str
+    consensus_receipt_digest: Optional[str]
+    cwd_guard_receipt_digest: str
+    planned_artifacts: List[str]
+    allowed_paths: List[str]
+    denied_paths: List[str]
+    target_branch: str
+    no_write_performed: bool = True
+    no_worktree_created: bool = True
+    no_shell_performed: bool = True
+    no_merge_performed: bool = True
+    no_reward_settlement_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class GenericAgentWorktreeWriterDryRunResult:
+    decision: str
+    accepted: bool
+    rejection_reasons: List[str]
+    receipt: Optional[GenericAgentWorktreeWriterDryRunReceipt]
+    cwd_guard: Optional[WreCwdGuardResult]
+    no_execution_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["receipt"] = self.receipt.to_dict() if self.receipt else None
+        payload["cwd_guard"] = self.cwd_guard.to_dict() if self.cwd_guard else None
+        return payload
+
+
+def _as_profile(
+    profile: Union[GenericAgentWorktreeDomainProfile, Mapping[str, Any]],
+) -> Optional[GenericAgentWorktreeDomainProfile]:
+    if isinstance(profile, GenericAgentWorktreeDomainProfile):
+        return profile
+    if not isinstance(profile, Mapping):
+        return None
+    try:
+        return GenericAgentWorktreeDomainProfile(
+            profile_id=str(profile["profile_id"]),
+            operation=str(profile["operation"]),
+            artifact_contract_type=str(profile["artifact_contract_type"]),
+            domain_id_pattern=str(profile["domain_id_pattern"]),
+            canonical_root_template=str(profile["canonical_root_template"]),
+            allowed_path_patterns=[str(v) for v in profile.get("allowed_path_patterns", [])],
+            denied_path_patterns=[str(v) for v in profile.get("denied_path_patterns", [])],
+            required_tests=[str(v) for v in profile.get("required_tests", [])],
+            branch_prefix=str(profile["branch_prefix"]),
+            draft_pr_only=bool(profile.get("draft_pr_only", True)),
+            consensus_required=bool(profile.get("consensus_required", False)),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def _mapping(
+    request: Union[GenericAgentWorktreeWriterDryRunRequest, Mapping[str, Any]],
+) -> Mapping[str, Any]:
+    if isinstance(request, GenericAgentWorktreeWriterDryRunRequest):
+        return request.to_dict()
+    return request
+
+
+def _digest(payload: Any) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dedupe(values: Iterable[str]) -> List[str]:
+    seen = set()
+    ordered: List[str] = []
+    for value in values:
+        text = str(value or "").strip()
+        if text and text not in seen:
+            seen.add(text)
+            ordered.append(text)
+    return ordered
+
+
+def _has_device_prefix(value: str) -> bool:
+    return any(str(value).startswith(prefix) for prefix in _DEVICE_PREFIXES)
+
+
+def _normalize_repo_path(value: str) -> Optional[str]:
+    text = str(value or "").replace("\\", "/").strip()
+    if not text or text.startswith("/") or _has_device_prefix(text):
+        return None
+    parts: List[str] = []
+    for raw in text.split("/"):
+        part = raw.strip(" \t").rstrip(" .")
+        if not part or part in {".", ".."} or ":" in part:
+            return None
+        parts.append(part)
+    return "/".join(parts)
+
+
+def _derive_canonical_root(profile: GenericAgentWorktreeDomainProfile, domain_id: str) -> Optional[str]:
+    try:
+        if re.fullmatch(profile.domain_id_pattern, domain_id) is None:
+            return None
+    except re.error:
+        return None
+    try:
+        rendered = profile.canonical_root_template.format(domain_id=domain_id)
+    except Exception:
+        return None
+    return _normalize_repo_path(rendered)
+
+
+def _is_under(path: str, root: str) -> bool:
+    return path == root or path.startswith(root.rstrip("/") + "/")
+
+
+def _pattern_matches(path: str, pattern: str) -> bool:
+    pat = str(pattern or "").replace("\\", "/").strip()
+    return bool(pat) and fnmatch.fnmatch(path.lower(), pat.lower())
+
+
+def _path_denied(path: str, denied_patterns: Sequence[str]) -> bool:
+    base = path.rsplit("/", 1)[-1].rstrip(" .").lower()
+    if base in {".env", "foundup_registry.json"}:
+        return True
+    for pattern in list(PIN_INDEPENDENT_DENYLIST) + [str(v) for v in denied_patterns]:
+        pat = pattern.replace("\\", "/").strip()
+        if _pattern_matches(path, pat):
+            return True
+        if pat.endswith("/**") and _is_under(path.lower(), pat[:-3].lower().rstrip("/")):
+            return True
+    return False
+
+
+def _allowed_paths_subset(requested: Sequence[str], canonical_root: str) -> bool:
+    if not requested:
+        return True
+    for raw in requested:
+        text = str(raw or "").replace("\\", "/").strip()
+        if text.endswith("/**"):
+            normalized = _normalize_repo_path(text[:-3])
+            if normalized is None or not _is_under(normalized, canonical_root):
+                return False
+            continue
+        normalized = _normalize_repo_path(text)
+        if normalized is None or not _is_under(normalized, canonical_root):
+            return False
+    return True
+
+
+def _selection_ok(selection: Mapping[str, Any]) -> bool:
+    return (
+        selection.get("decision") in (None, WARDROBE_SELECTION_ACCEPT)
+        and selection.get("selected_wardrobe") == WARDROBE_SOVEREIGN_EXECUTION
+        and selection.get("execution_plane") == EXECUTION_GOVERNED_CANDIDATE
+        and selection.get("no_execution_performed") is True
+    )
+
+
+def _signed_authority_ok(authority: Mapping[str, Any], work_order_id: str, permission_digest: str) -> bool:
+    accepted = authority.get("accepted") is True or authority.get("signature_gate_status") == SIGNATURE_GATE_ACCEPTED
+    if not accepted:
+        return False
+    if authority.get("work_order_id") not in (None, work_order_id):
+        return False
+    supplied_digest = authority.get("permission_snapshot_digest")
+    if permission_digest and supplied_digest not in (None, permission_digest):
+        return False
+    return True
+
+
+def _receipt_chain_ok(chain: Mapping[str, Any]) -> bool:
+    return (
+        chain.get("accepted") is True
+        and chain.get("decision") == SIGNED_RECEIPT_CHAIN_ACCEPT
+        and chain.get("no_execution_performed") is not False
+        and chain.get("no_reward_settlement_performed") is not False
+    )
+
+
+def _valve_ok(valve: Mapping[str, Any]) -> bool:
+    return (
+        valve.get("valve_state") == VALVE_OPEN_WORKTREE_CREATE
+        and valve.get("no_execution_performed") is True
+        and not list(valve.get("rejection_reasons") or [])
+        and bool(valve.get("decision_digest"))
+    )
+
+
+def _holoindex_gap_blocks_write(holoindex_evidence: Mapping[str, Any]) -> bool:
+    return (
+        holoindex_evidence.get("index_gap_detected") is True
+        or str(holoindex_evidence.get("retrieval_quality") or "").upper() == "INDEX_GAP"
+    )
+
+
+def plan_generic_agent_worktree_writer_dry_run(
+    request: Union[GenericAgentWorktreeWriterDryRunRequest, Mapping[str, Any]],
+) -> GenericAgentWorktreeWriterDryRunResult:
+    """Validate a future generic worktree write and emit a dry-run receipt only."""
+    req = _mapping(request)
+    reasons: List[str] = []
+    cwd_guard: Optional[WreCwdGuardResult] = None
+
+    work_order_id = str(req.get("work_order_id") or "")
+    operation = str(req.get("operation") or "")
+    domain_id = str(req.get("domain_id") or "")
+    profile = _as_profile(req.get("domain_profile") or {})
+
+    if profile is None or not profile.draft_pr_only or not profile.branch_prefix.startswith("feat/"):
+        reasons.append(FAIL_PROFILE_INVALID)
+        canonical_root = ""
+    else:
+        if operation != profile.operation:
+            reasons.append(FAIL_OPERATION_MISMATCH)
+        canonical_root = _derive_canonical_root(profile, domain_id) or ""
+        if not canonical_root:
+            reasons.append(FAIL_DOMAIN_ID_INVALID)
+
+    planned: List[str] = []
+    if canonical_root:
+        for raw in req.get("planned_artifacts") or []:
+            normalized = _normalize_repo_path(str(raw))
+            if normalized is None:
+                reasons.append(FAIL_ARTIFACTS_INVALID)
+                continue
+            if not _is_under(normalized, canonical_root):
+                reasons.append(FAIL_ARTIFACTS_INVALID)
+            if profile is not None and _path_denied(normalized, profile.denied_path_patterns):
+                reasons.append(FAIL_DENIED_PATH)
+            planned.append(normalized)
+        if not planned:
+            reasons.append(FAIL_ARTIFACTS_INVALID)
+        if not _allowed_paths_subset(req.get("requested_allowed_paths") or [], canonical_root):
+            reasons.append(FAIL_CALLER_PATHS_WIDEN_PROFILE)
+    else:
+        reasons.append(FAIL_CANONICAL_ROOT_INVALID)
+
+    if not _selection_ok(dict(req.get("selection_receipt") or {})):
+        reasons.append(FAIL_SELECTION_RECEIPT)
+    if not _signed_authority_ok(
+        dict(req.get("signed_authority") or {}),
+        work_order_id,
+        str(req.get("permission_snapshot_digest") or ""),
+    ):
+        reasons.append(FAIL_SIGNED_AUTHORITY)
+    chain = dict(req.get("signed_receipt_chain") or {})
+    if not _receipt_chain_ok(chain):
+        reasons.append(FAIL_RECEIPT_CHAIN)
+    valve = dict(req.get("execution_valve_decision") or {})
+    if not _valve_ok(valve):
+        reasons.append(FAIL_VALVE_DECISION)
+    if profile is not None and profile.consensus_required and not req.get("consensus_receipt_digest"):
+        reasons.append(FAIL_CONSENSUS_REQUIRED)
+    if _holoindex_gap_blocks_write(dict(req.get("holoindex_evidence") or {})):
+        reasons.append(FAIL_HOLOINDEX_INDEX_GAP)
+
+    branch = str(req.get("target_branch") or "")
+    if profile is not None:
+        if branch in _PROTECTED_BRANCHES or not branch.startswith(profile.branch_prefix):
+            reasons.append(FAIL_PROTECTED_BRANCH)
+
+    repo_root = str(req.get("repo_root") or "")
+    worktree_path = str(req.get("worktree_path") or "")
+    operation_cwd = str(req.get("operation_cwd") or worktree_path)
+    try:
+        cwd_guard = validate_wre_worker_operation_cwd(
+            repo_root=Path(repo_root),
+            worktree_path=Path(worktree_path),
+            operation_cwd=Path(operation_cwd),
+        )
+        if not cwd_guard.ok:
+            reasons.append(FAIL_CWD_GUARD)
+    except Exception:
+        reasons.append(FAIL_CWD_GUARD)
+
+    deduped = _dedupe(reasons)
+    if deduped:
+        return GenericAgentWorktreeWriterDryRunResult(
+            decision=GENERIC_WRITER_DRYRUN_REJECT,
+            accepted=False,
+            rejection_reasons=deduped,
+            receipt=None,
+            cwd_guard=cwd_guard,
+        )
+
+    assert profile is not None
+    root_payload = {
+        "domain_profile_id": profile.profile_id,
+        "canonical_root": canonical_root,
+        "allowed_paths": req.get("requested_allowed_paths") or [canonical_root + "/**"],
+        "denied_paths": list(PIN_INDEPENDENT_DENYLIST) + list(profile.denied_path_patterns),
+    }
+    artifact_payload = {"canonical_root": canonical_root, "planned_artifacts": sorted(planned)}
+    receipt = GenericAgentWorktreeWriterDryRunReceipt(
+        receipt_id="generic_wt_dryrun_" + hashlib.sha256(
+            _digest({"work_order_id": work_order_id, "root": canonical_root, "artifacts": planned}).encode("utf-8")
+        ).hexdigest()[:16],
+        work_order_id=work_order_id,
+        domain_profile_id=profile.profile_id,
+        canonical_root=canonical_root,
+        canonical_root_digest=_digest(root_payload),
+        artifact_manifest_digest=_digest(artifact_payload),
+        selection_receipt_digest=_digest(req.get("selection_receipt") or {}),
+        signed_authority_digest=(
+            str((req.get("signed_authority") or {}).get("signature_gate_digest") or "")
+            or str((req.get("signed_authority") or {}).get("verification_digest") or "")
+            or _digest(req.get("signed_authority") or {})
+        ),
+        receipt_chain_terminal_hash=str(chain.get("terminal_receipt_hash") or ""),
+        execution_valve_decision_digest=str(valve.get("decision_digest")),
+        consensus_receipt_digest=(
+            None if req.get("consensus_receipt_digest") is None else str(req.get("consensus_receipt_digest"))
+        ),
+        cwd_guard_receipt_digest=_digest(cwd_guard.to_dict() if cwd_guard else {}),
+        planned_artifacts=sorted(planned),
+        allowed_paths=list(req.get("requested_allowed_paths") or [canonical_root + "/**"]),
+        denied_paths=list(PIN_INDEPENDENT_DENYLIST) + list(profile.denied_path_patterns),
+        target_branch=branch,
+    )
+    return GenericAgentWorktreeWriterDryRunResult(
+        decision=GENERIC_WRITER_DRYRUN_ACCEPT,
+        accepted=True,
+        rejection_reasons=[],
+        receipt=receipt,
+        cwd_guard=cwd_guard,
+    )
+
+
+__all__ = [
+    "FAIL_ARTIFACTS_INVALID",
+    "FAIL_CALLER_PATHS_WIDEN_PROFILE",
+    "FAIL_CANONICAL_ROOT_INVALID",
+    "FAIL_CONSENSUS_REQUIRED",
+    "FAIL_CWD_GUARD",
+    "FAIL_DENIED_PATH",
+    "FAIL_DOMAIN_ID_INVALID",
+    "FAIL_HOLOINDEX_INDEX_GAP",
+    "FAIL_OPERATION_MISMATCH",
+    "FAIL_PROFILE_INVALID",
+    "FAIL_PROTECTED_BRANCH",
+    "FAIL_RECEIPT_CHAIN",
+    "FAIL_SELECTION_RECEIPT",
+    "FAIL_SIGNED_AUTHORITY",
+    "FAIL_VALVE_DECISION",
+    "GENERIC_WRITER_DRYRUN_ACCEPT",
+    "GENERIC_WRITER_DRYRUN_REJECT",
+    "GenericAgentWorktreeDomainProfile",
+    "GenericAgentWorktreeWriterDryRunReceipt",
+    "GenericAgentWorktreeWriterDryRunRequest",
+    "GenericAgentWorktreeWriterDryRunResult",
+    "PIN_INDEPENDENT_DENYLIST",
+    "plan_generic_agent_worktree_writer_dry_run",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_generic_agent_worktree_writer_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_generic_agent_worktree_writer_dryrun.py
@@ -1,0 +1,397 @@
+"""Tests for REDDOG_GENERIC_AGENT_WORKTREE_WRITER_DRYRUN_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_generic_agent_worktree_writer_dryrun import (
+    FAIL_ARTIFACTS_INVALID,
+    FAIL_CALLER_PATHS_WIDEN_PROFILE,
+    FAIL_CONSENSUS_REQUIRED,
+    FAIL_CWD_GUARD,
+    FAIL_DENIED_PATH,
+    FAIL_DOMAIN_ID_INVALID,
+    FAIL_HOLOINDEX_INDEX_GAP,
+    FAIL_OPERATION_MISMATCH,
+    FAIL_PROFILE_INVALID,
+    FAIL_PROTECTED_BRANCH,
+    FAIL_RECEIPT_CHAIN,
+    FAIL_SELECTION_RECEIPT,
+    FAIL_SIGNED_AUTHORITY,
+    FAIL_VALVE_DECISION,
+    GENERIC_WRITER_DRYRUN_ACCEPT,
+    GENERIC_WRITER_DRYRUN_REJECT,
+    GenericAgentWorktreeDomainProfile,
+    plan_generic_agent_worktree_writer_dry_run,
+)
+from modules.communication.moltbot_bridge.src.reddog_operator_loop_wardrobe_selection import (
+    EXECUTION_GOVERNED_CANDIDATE,
+    WARDROBE_SELECTION_ACCEPT,
+    WARDROBE_SOVEREIGN_EXECUTION,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_work_order_policy_gate import (
+    SIGNATURE_GATE_ACCEPTED,
+)
+from modules.communication.moltbot_bridge.src.reddog_signed_receipt_chain import (
+    SIGNED_RECEIPT_CHAIN_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    VALVE_OPEN_WORKTREE_CREATE,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_generic_agent_worktree_writer_dryrun.py"
+)
+
+
+@pytest.fixture()
+def domain_profile() -> GenericAgentWorktreeDomainProfile:
+    return GenericAgentWorktreeDomainProfile(
+        profile_id="docs_patch",
+        operation="write_docs",
+        artifact_contract_type="docs_patch_contract",
+        domain_id_pattern=r"[a-z][a-z0-9_]{2,49}",
+        canonical_root_template="docs/audits/{domain_id}",
+        allowed_path_patterns=["docs/audits/{domain_id}/**"],
+        denied_path_patterns=["**/secrets/**", "**/.env"],
+        required_tests=["pytest modules/communication/moltbot_bridge/tests/test_docs_patch.py"],
+        branch_prefix="feat/",
+        draft_pr_only=True,
+        consensus_required=False,
+    )
+
+
+def valid_request(tmp_path: Path, domain_profile: GenericAgentWorktreeDomainProfile) -> dict:
+    worktree = tmp_path / "generic-writer-worktree"
+    return {
+        "work_order_id": "wo-generic-1",
+        "operation": "write_docs",
+        "domain_id": "test_thing",
+        "domain_profile": domain_profile,
+        "planned_artifacts": [
+            "docs/audits/test_thing/README.md",
+            "docs/audits/test_thing/ModLog.md",
+        ],
+        "requested_allowed_paths": ["docs/audits/test_thing/**"],
+        "target_branch": "feat/generic-agent-test-thing",
+        "repo_root": str(REPO_ROOT),
+        "worktree_path": str(worktree),
+        "operation_cwd": str(worktree),
+        "selection_receipt": {
+            "decision": WARDROBE_SELECTION_ACCEPT,
+            "selected_wardrobe": WARDROBE_SOVEREIGN_EXECUTION,
+            "execution_plane": EXECUTION_GOVERNED_CANDIDATE,
+            "no_execution_performed": True,
+        },
+        "signed_authority": {
+            "accepted": True,
+            "signature_gate_status": SIGNATURE_GATE_ACCEPTED,
+            "work_order_id": "wo-generic-1",
+            "permission_snapshot_digest": "sha256:perm",
+            "signature_gate_digest": "sha256:signed-authority",
+        },
+        "signed_receipt_chain": {
+            "accepted": True,
+            "decision": SIGNED_RECEIPT_CHAIN_ACCEPT,
+            "terminal_receipt_hash": "sha256:terminal",
+            "no_execution_performed": True,
+            "no_reward_settlement_performed": True,
+        },
+        "execution_valve_decision": {
+            "valve_state": VALVE_OPEN_WORKTREE_CREATE,
+            "decision_digest": "sha256:valve",
+            "rejection_reasons": [],
+            "no_execution_performed": True,
+        },
+        "permission_snapshot_digest": "sha256:perm",
+        "consensus_receipt_digest": None,
+        "holoindex_evidence": {"index_gap_detected": False},
+    }
+
+
+def assert_reject(req: dict, code: str) -> None:
+    result = plan_generic_agent_worktree_writer_dry_run(req)
+    assert result.decision == GENERIC_WRITER_DRYRUN_REJECT
+    assert result.accepted is False
+    assert code in result.rejection_reasons
+    assert result.receipt is None
+    assert result.no_execution_performed is True
+
+
+def test_generic_writer_dryrun_accepts_valid_scoped_request(
+    tmp_path: Path,
+    domain_profile: GenericAgentWorktreeDomainProfile,
+) -> None:
+    result = plan_generic_agent_worktree_writer_dry_run(valid_request(tmp_path, domain_profile))
+
+    assert result.decision == GENERIC_WRITER_DRYRUN_ACCEPT
+    assert result.accepted is True
+    assert result.rejection_reasons == []
+    assert result.cwd_guard is not None
+    assert result.cwd_guard.ok is True
+    assert result.receipt is not None
+    receipt = result.receipt
+    assert receipt.canonical_root == "docs/audits/test_thing"
+    assert receipt.planned_artifacts == [
+        "docs/audits/test_thing/ModLog.md",
+        "docs/audits/test_thing/README.md",
+    ]
+    assert receipt.no_write_performed is True
+    assert receipt.no_worktree_created is True
+    assert receipt.no_shell_performed is True
+    assert receipt.no_merge_performed is True
+    assert receipt.no_reward_settlement_performed is True
+    assert receipt.no_holoindex_reindex_performed is True
+    assert receipt.execution_valve_decision_digest == "sha256:valve"
+    assert receipt.signed_authority_digest == "sha256:signed-authority"
+
+
+def test_generic_writer_dryrun_accepts_mapping_profile(
+    tmp_path: Path,
+    domain_profile: GenericAgentWorktreeDomainProfile,
+) -> None:
+    req = valid_request(tmp_path, domain_profile)
+    req["domain_profile"] = domain_profile.to_dict()
+
+    result = plan_generic_agent_worktree_writer_dry_run(req)
+
+    assert result.accepted is True
+    assert result.receipt is not None
+    assert result.receipt.domain_profile_id == "docs_patch"
+
+
+def test_rejects_profile_not_draft_pr_only(
+    tmp_path: Path,
+    domain_profile: GenericAgentWorktreeDomainProfile,
+) -> None:
+    req = valid_request(tmp_path, domain_profile)
+    req["domain_profile"] = {**domain_profile.to_dict(), "draft_pr_only": False}
+
+    assert_reject(req, FAIL_PROFILE_INVALID)
+
+
+def test_rejects_operation_mismatch(tmp_path: Path, domain_profile: GenericAgentWorktreeDomainProfile) -> None:
+    req = valid_request(tmp_path, domain_profile)
+    req["operation"] = "shell"
+
+    assert_reject(req, FAIL_OPERATION_MISMATCH)
+
+
+def test_rejects_invalid_domain_id(tmp_path: Path, domain_profile: GenericAgentWorktreeDomainProfile) -> None:
+    req = valid_request(tmp_path, domain_profile)
+    req["domain_id"] = "../escape"
+
+    assert_reject(req, FAIL_DOMAIN_ID_INVALID)
+
+
+def test_rejects_caller_allowed_path_widening(
+    tmp_path: Path,
+    domain_profile: GenericAgentWorktreeDomainProfile,
+) -> None:
+    req = valid_request(tmp_path, domain_profile)
+    req["requested_allowed_paths"] = ["docs/**"]
+
+    assert_reject(req, FAIL_CALLER_PATHS_WIDEN_PROFILE)
+
+
+def test_rejects_artifact_outside_canonical_root(
+    tmp_path: Path,
+    domain_profile: GenericAgentWorktreeDomainProfile,
+) -> None:
+    req = valid_request(tmp_path, domain_profile)
+    req["planned_artifacts"] = ["docs/audits/other/README.md"]
+
+    assert_reject(req, FAIL_ARTIFACTS_INVALID)
+
+
+def test_rejects_traversal_artifact(
+    tmp_path: Path,
+    domain_profile: GenericAgentWorktreeDomainProfile,
+) -> None:
+    req = valid_request(tmp_path, domain_profile)
+    req["planned_artifacts"] = ["docs/audits/test_thing/../escape.md"]
+
+    assert_reject(req, FAIL_ARTIFACTS_INVALID)
+
+
+def test_rejects_pin_independent_denied_path(
+    tmp_path: Path,
+    domain_profile: GenericAgentWorktreeDomainProfile,
+) -> None:
+    req = valid_request(tmp_path, domain_profile)
+    req["planned_artifacts"] = [
+        "docs/audits/test_thing/README.md",
+        "docs/audits/test_thing/.env",
+    ]
+
+    assert_reject(req, FAIL_DENIED_PATH)
+
+
+def test_rejects_non_sovereign_selection_receipt(
+    tmp_path: Path,
+    domain_profile: GenericAgentWorktreeDomainProfile,
+) -> None:
+    req = valid_request(tmp_path, domain_profile)
+    req["selection_receipt"] = {
+        "decision": WARDROBE_SELECTION_ACCEPT,
+        "selected_wardrobe": "wsp97_implementation_slice",
+        "execution_plane": "worker_draft_pr",
+        "no_execution_performed": True,
+    }
+
+    assert_reject(req, FAIL_SELECTION_RECEIPT)
+
+
+def test_rejects_unsigned_authority(tmp_path: Path, domain_profile: GenericAgentWorktreeDomainProfile) -> None:
+    req = valid_request(tmp_path, domain_profile)
+    req["signed_authority"] = {"accepted": False, "signature_gate_status": "SIGNATURE_GATE_REJECTED"}
+
+    assert_reject(req, FAIL_SIGNED_AUTHORITY)
+
+
+def test_rejects_authority_bound_to_other_work_order(
+    tmp_path: Path,
+    domain_profile: GenericAgentWorktreeDomainProfile,
+) -> None:
+    req = valid_request(tmp_path, domain_profile)
+    req["signed_authority"]["work_order_id"] = "wo-other"
+
+    assert_reject(req, FAIL_SIGNED_AUTHORITY)
+
+
+def test_rejects_receipt_chain_failure(tmp_path: Path, domain_profile: GenericAgentWorktreeDomainProfile) -> None:
+    req = valid_request(tmp_path, domain_profile)
+    req["signed_receipt_chain"] = {"accepted": False, "decision": "SIGNED_RECEIPT_CHAIN_REJECT"}
+
+    assert_reject(req, FAIL_RECEIPT_CHAIN)
+
+
+def test_rejects_closed_valve(tmp_path: Path, domain_profile: GenericAgentWorktreeDomainProfile) -> None:
+    req = valid_request(tmp_path, domain_profile)
+    req["execution_valve_decision"] = {
+        "valve_state": "VALVE_CLOSED",
+        "decision_digest": "sha256:valve",
+        "rejection_reasons": ["explicit_valve_flag_missing"],
+        "no_execution_performed": True,
+    }
+
+    assert_reject(req, FAIL_VALVE_DECISION)
+
+
+def test_rejects_consensus_required_missing(
+    tmp_path: Path,
+    domain_profile: GenericAgentWorktreeDomainProfile,
+) -> None:
+    profile = GenericAgentWorktreeDomainProfile(
+        **{**domain_profile.to_dict(), "consensus_required": True}
+    )
+    req = valid_request(tmp_path, profile)
+
+    assert_reject(req, FAIL_CONSENSUS_REQUIRED)
+
+
+def test_accepts_consensus_when_required_and_present(
+    tmp_path: Path,
+    domain_profile: GenericAgentWorktreeDomainProfile,
+) -> None:
+    profile = GenericAgentWorktreeDomainProfile(
+        **{**domain_profile.to_dict(), "consensus_required": True}
+    )
+    req = valid_request(tmp_path, profile)
+    req["consensus_receipt_digest"] = "sha256:consensus"
+
+    result = plan_generic_agent_worktree_writer_dry_run(req)
+
+    assert result.accepted is True
+    assert result.receipt is not None
+    assert result.receipt.consensus_receipt_digest == "sha256:consensus"
+
+
+def test_rejects_holoindex_index_gap_on_write(
+    tmp_path: Path,
+    domain_profile: GenericAgentWorktreeDomainProfile,
+) -> None:
+    req = valid_request(tmp_path, domain_profile)
+    req["holoindex_evidence"] = {"index_gap_detected": True}
+
+    assert_reject(req, FAIL_HOLOINDEX_INDEX_GAP)
+
+
+def test_rejects_worktree_inside_repo(
+    tmp_path: Path,
+    domain_profile: GenericAgentWorktreeDomainProfile,
+) -> None:
+    req = valid_request(tmp_path, domain_profile)
+    req["worktree_path"] = str(REPO_ROOT / ".worktrees" / "bad")
+    req["operation_cwd"] = req["worktree_path"]
+
+    assert_reject(req, FAIL_CWD_GUARD)
+
+
+def test_rejects_relative_worktree_path(
+    tmp_path: Path,
+    domain_profile: GenericAgentWorktreeDomainProfile,
+) -> None:
+    req = valid_request(tmp_path, domain_profile)
+    req["worktree_path"] = "relative/worktree"
+    req["operation_cwd"] = "relative/worktree"
+
+    assert_reject(req, FAIL_CWD_GUARD)
+
+
+def test_rejects_protected_branch(tmp_path: Path, domain_profile: GenericAgentWorktreeDomainProfile) -> None:
+    req = valid_request(tmp_path, domain_profile)
+    req["target_branch"] = "main"
+
+    assert_reject(req, FAIL_PROTECTED_BRANCH)
+
+
+def test_result_is_json_serializable(tmp_path: Path, domain_profile: GenericAgentWorktreeDomainProfile) -> None:
+    result = plan_generic_agent_worktree_writer_dry_run(valid_request(tmp_path, domain_profile))
+
+    payload = result.to_dict()
+
+    assert payload["accepted"] is True
+    assert payload["receipt"]["no_write_performed"] is True
+
+
+def test_generic_writer_module_ast_forbids_execution_and_file_write() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_imports = {"subprocess", "os", "shutil"}
+    banned_calls = {
+        "open",
+        "exec",
+        "eval",
+        "mkdir",
+        "write_text",
+        "write_bytes",
+        "create_worktree",
+        "commit_all",
+        "push_branch",
+        "create_draft_pr",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported = {alias.name.split(".")[0] for alias in node.names}
+            assert imported.isdisjoint(banned_imports)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".")[0] not in banned_imports
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_calls
+
+
+def test_generic_writer_module_ascii_only() -> None:
+    text = MODULE_PATH.read_text(encoding="utf-8")
+    assert [hex(ord(ch)) for ch in text if ord(ch) > 127] == []


### PR DESCRIPTION
## REDDOG_GENERIC_AGENT_WORKTREE_WRITER_DRYRUN_PHASE1

Implements the generic agent worktree writer dry-run specified by the landed spine contract (#957).

### Scope
- Adds `reddog_generic_agent_worktree_writer_dryrun.py`, a pure validator/planner that emits a dry-run receipt only.
- Re-derives the canonical root from `GenericAgentWorktreeDomainProfile` + `domain_id`.
- Validates caller paths cannot widen the profile, planned artifacts stay inside the root, pin-independent denylist is enforced, signed authority is accepted, signed receipt chain is accepted, full `VALVE_OPEN_WORKTREE_CREATE` decision is present, consensus receipt is present when required, and WRE cwd guard passes.
- Records HoloIndex boundary: new module is expected to be an INDEX_GAP until WRE/CI re-indexes.

### Boundaries
- No file writes.
- No worktree creation.
- No subprocess/git/gh/shell.
- No PR/merge.
- No reward settlement.
- No extension runtime wiring.
- No HoloIndex re-index.

### Validation
- `pytest modules\communication\moltbot_bridge\tests\test_reddog_generic_agent_worktree_writer_dryrun.py modules\communication\moltbot_bridge\tests\test_reddog_generic_agent_worktree_write_spine_contract_doc.py` -> 66 passed.
- `pytest modules\communication\moltbot_bridge\tests\test_reddog_work_order_signature_verifier.py modules\communication\moltbot_bridge\tests\test_reddog_signed_receipt_chain.py modules\communication\moltbot_bridge\tests\test_reddog_wre_execution_valve.py modules\communication\moltbot_bridge\tests\test_reddog_operator_loop_wardrobe_selection.py modules\communication\moltbot_bridge\tests\test_reddog_generic_agent_worktree_writer_dryrun.py` -> 99 passed.
- `git diff --check` -> clean.
- New module/test byte scan -> 0 non-ASCII.
- Diff additions byte scan -> 0 non-ASCII.

### WSP_97
- OBSERVED: #957 contract defines this dry-run as the next WSP_15 slice.
- OBSERVED: existing WRE cwd guard and execution valve are consumed as evidence surfaces.
- SPECIFIED_NOT_IMPLEMENTED: live generic writer, shell runner, merge authority, and reward settlement remain future slices.

Worker-Lane: codex
Slice: REDDOG_GENERIC_AGENT_WORKTREE_WRITER_DRYRUN_PHASE1