### PR TITLE
docs(reddog): define governed shell runner contract

### DIFF
--- a/docs/audits/architecture/REDDOG_WRE_GOVERNED_SHELL_RUNNER_CONTRACT_PHASE1.md
+++ b/docs/audits/architecture/REDDOG_WRE_GOVERNED_SHELL_RUNNER_CONTRACT_PHASE1.md
@@ -1,0 +1,274 @@
+# REDDOG_WRE_GOVERNED_SHELL_RUNNER_CONTRACT_PHASE1
+
+Status: SPECIFIED_NOT_IMPLEMENTED
+Slice type: docs/static contract only
+Authority: no runtime authority change
+WSP: 00, 11, 15, 50, 53, 71, 95, 97
+
+## Purpose
+
+This contract defines the future WRE-owned governed shell runner RedDog needs before
+it can safely execute tests, linters, formatters, or bounded worker commands inside an
+isolated worktree.
+
+The contract does not implement command execution. It freezes the invariants that a
+future `REDDOG_WRE_GOVERNED_SHELL_RUNNER_DRYRUN_PHASE1` must satisfy.
+
+Hard rule:
+
+```text
+SHELL AUTHORITY IS NOT A STRING. IT IS A SIGNED, SCOPED, CWD-GUARDED, RECEIPTED COMMAND.
+```
+
+## Direct-read evidence (WSP_50)
+
+OBSERVED:
+
+- `WSP_framework/src/WSP_11_WRE_Standard_Command_Protocol.md` defines WRE command
+  interaction as standardized command intent, not arbitrary shell text.
+- `WSP_framework/src/WSP_53_Symbiotic_Environment_Integration_Protocol.md` makes host
+  environment interaction a WRE-mediated execution layer.
+- `WSP_framework/src/WSP_71_Secrets_Management_Protocol.md` requires permission-bound
+  secret access, no repository secret persistence, and auditable secret handling.
+- `modules/communication/moltbot_bridge/src/reddog_wre_cwd_guard.py` already provides
+  the cwd isolation predicate for mutating worker operations.
+- `modules/communication/moltbot_bridge/src/reddog_generic_agent_worktree_writer_dryrun.py`
+  proves the generic worktree-write spine up to a dry-run receipt without running shell.
+- Repository search finds many legacy `subprocess` call sites. Those are OBSERVED legacy
+  execution surfaces, not authority precedents for RedDog.
+
+INFERRED:
+
+- The governed shell runner must be a single WRE-owned seam with explicit command
+  profiles. It must not bless scattered legacy subprocess usage as RedDog authority.
+
+## 1. Governed shell command profile
+
+Future runtime must define `GovernedShellCommandProfile`.
+
+Required fields:
+
+| Field | Type | Rule |
+| --- | --- | --- |
+| `profile_id` | string | Stable id such as `pytest_readonly`, `node_contract_test`, `python_format_check` |
+| `command_kind` | string | test, lint, format_check, static_analysis, build_check, or readonly_probe |
+| `argv_prefix` | list[string] | Exact argv prefix allowlist; no shell string |
+| `allowed_arg_patterns` | list[string] | Bounded patterns for trailing args |
+| `denied_arg_patterns` | list[string] | Destructive, network, secret, merge, publish, and authority-substrate denies |
+| `requires_cwd_guard` | bool | Must be true for any worktree command |
+| `requires_worktree` | bool | Must be true for mutating or repo-sensitive command |
+| `timeout_seconds` | int | Positive bounded timeout |
+| `max_stdout_bytes` | int | Bounded capture size |
+| `max_stderr_bytes` | int | Bounded capture size |
+| `secret_env_refs` | list[string] | Secret handles only; raw secret values forbidden |
+| `output_redaction_policy` | string | Redacts secrets before receipt/log/telemetry |
+| `draft_pr_only` | bool | Must be true until merge authority exists |
+
+`argv_prefix` is an argv-list prefix, not a shell command string. `shell=True` is
+forbidden.
+
+## 2. Governed shell run request
+
+Future runtime must define `GovernedShellRunRequest`.
+
+Required fields:
+
+| Field | Rule |
+| --- | --- |
+| `work_order_id` | Bound to signed authority |
+| `profile_id` | Must match a known `GovernedShellCommandProfile` |
+| `argv` | List of strings; exact prefix + allowed trailing args only |
+| `operation_cwd` | Absolute cwd inside isolated worktree |
+| `worktree_path` | Absolute isolated worktree path |
+| `repo_root` | Absolute shared repo path |
+| `stdin_policy` | `none` by default; bounded explicit input only |
+| `env_policy` | Minimal scrubbed env plus secret refs resolved by WSP_71 boundary |
+| `generic_writer_dryrun_receipt_digest` | Required for write/test flows after generic writer dry-run |
+| `signed_authority_digest` | Required |
+| `signed_receipt_chain_terminal_hash` | Required |
+| `execution_valve_decision_digest` | Required |
+| `cwd_guard_receipt_digest` | Required before execution |
+| `holoindex_freshness_receipt_digest` | Required for repo-sensitive command |
+
+The request must not contain raw secrets, private keys, or bearer tokens.
+
+## 3. Required authority inputs
+
+Future governed shell runner dry-run or live implementation must require:
+
+| Input | Required | Rule |
+| --- | --- | --- |
+| `RedDogOperatorLoopWardrobeSelectionReceipt` | yes | `wsp97_sovereign_execution` and governed execution plane |
+| `RedDogDelegatedWorkAuthority` verification | yes | Accepted, fresh permission snapshot, command scope-bound |
+| `SignedReceiptChainVerificationResult` | yes | Accepted before command receipt can be reward-bearing |
+| `ExecutionValveDecision` | yes | Full `evaluate_reddog_execution_valve(...)` result |
+| `VALVE_OPEN_WORKTREE_CREATE` | yes | Shell may run only inside the worktree authority window |
+| `WreCwdGuardResult` | yes | Must pass for the exact `operation_cwd` |
+| `GenericAgentWorktreeWriterDryRunReceipt` | conditional | Required for commands that validate or test generated artifacts |
+| `consensus_receipt_digest` | tiered | Required for high-authority or 012-out-of-loop commands |
+
+Environment flags and role text are not authority.
+
+## 4. Command policy
+
+Allowed classes for the first dry-run implementation:
+
+- readonly probes that do not mutate the worktree
+- test commands such as `python -m pytest ...`
+- static checks such as `git diff --check` only if implemented through an approved
+  no-mutation profile and scoped cwd guard
+- package-local contract checks that do not publish, install globally, or alter locks
+
+Forbidden classes:
+
+- shell strings, shell metacharacter interpretation, `shell=True`
+- destructive commands: delete, move, chmod/chown, disk format, registry edits
+- network transfer commands unless a later contract explicitly allows them
+- `git push`, `git merge`, `git reset`, `git checkout`, protected branch mutation
+- `gh pr ready`, `gh pr merge`, release, publish, deploy, or package registry write
+- HoloIndex `--index-*`, `--reindex-*`, or freshness-store mutation from RedDog runtime
+- secret inspection commands, env dumps, token print, wallet/key export
+- editing WSP framework, valve source, signature verifier, receipt-chain, permissions,
+  nonce stores, HoloIndex config, CI workflows, or merge automation
+
+The shell runner is not the merge authority and not the HoloIndex maintenance owner.
+
+## 5. CWD and worktree boundary
+
+Future implementation must call `validate_wre_worker_operation_cwd(...)` before every
+command that can touch filesystem or git state.
+
+Required:
+
+- `repo_root` absolute
+- `worktree_path` absolute
+- `operation_cwd` absolute
+- operation_cwd inside isolated worktree
+- operation_cwd outside shared repo root
+- no Windows device or extended-length prefix
+- no filesystem-root worktree
+
+Failure is fail-closed before any subprocess is reached.
+
+## 6. Secret and environment boundary
+
+WSP_71 is mandatory.
+
+Rules:
+
+- raw secret values are never accepted in request JSON
+- private keys are never accepted
+- env is scrubbed by default
+- secret use is by reference handle only
+- secret resolver must permission-check the requesting RedDog identity
+- secret values are never logged, echoed, hashed into public receipts, or sent to
+  command argv
+- output is redacted before receipt, telemetry, Copy MD, or model context
+
+## 7. Receipt contract
+
+Future `GovernedShellRunReceipt` must include:
+
+| Field | Rule |
+| --- | --- |
+| `run_receipt_id` | Deterministic receipt id |
+| `work_order_id` | Bound work order |
+| `profile_id` | Command profile used |
+| `argv_digest` | Digest of argv; raw argv optional only if safe |
+| `cwd_guard_receipt_digest` | Exact cwd guard result |
+| `signed_authority_digest` | Accepted delegated work authority |
+| `receipt_chain_terminal_hash` | Accepted receipt chain terminal |
+| `execution_valve_decision_digest` | Full valve decision digest |
+| `generic_writer_dryrun_receipt_digest` | Required when artifact validation command |
+| `holoindex_freshness_receipt_digest` | Repo-sensitive query freshness evidence |
+| `exit_code` | Captured after command in future live runner |
+| `timed_out` | Captured after command in future live runner |
+| `stdout_digest` | Digest of redacted bounded stdout |
+| `stderr_digest` | Digest of redacted bounded stderr |
+| `output_truncated` | True when byte caps apply |
+| `no_merge_performed` | Always true |
+| `no_reward_settlement_performed` | Always true |
+| `no_holoindex_reindex_performed` | Always true |
+
+Unsigned shell receipts are advisory only.
+
+## 8. HoloIndex boundary
+
+OBSERVED:
+
+- Query `RedDog WRE governed shell runner contract command execution cwd guard signed authority`
+  surfaced WSP_11, WSP_53, WSP_71, RedDog policy/receipt surfaces, and legacy subprocess
+  call sites.
+- No canonical governed shell runner exists yet.
+
+Recorded follow-up:
+
+`HOLOINDEX_REDDOG_WRE_GOVERNED_SHELL_RUNNER_CONTRACT_INDEX_GAP_PHASE1`
+
+RedDog runtime must not re-index HoloIndex. WRE/CI owns freshness receipts and targeted
+re-index after merge.
+
+## 9. Fail-closed rejection rules
+
+Reject if any of these are true:
+
+- missing accepted signed work authority
+- missing accepted signed receipt chain
+- missing sovereign wardrobe selection receipt
+- valve state is not `VALVE_OPEN_WORKTREE_CREATE`
+- cwd guard fails
+- profile is unknown or not draft-pr-only
+- argv is empty, not a list, or does not match profile prefix
+- argv contains shell metacharacters or forbidden args
+- request contains raw secrets, private keys, bearer tokens, or env dump intent
+- command attempts git push/merge/reset/protected branch mutation
+- command attempts `gh pr ready`, `gh pr merge`, release, publish, deploy, or reward
+- command attempts HoloIndex re-index from RedDog runtime
+- output cannot be redacted or bounded
+- write-sensitive INDEX_GAP is unresolved
+
+## 10. WSP_15 sequence
+
+Ordered next slices:
+
+1. `REDDOG_WRE_GOVERNED_SHELL_RUNNER_DRYRUN_PHASE1`
+2. `REDDOG_MERGE_AUTHORITY_CONTRACT_PHASE1`
+
+Do not implement live shell execution until the dry-run proves argv classification,
+cwd guard, redaction, output caps, and receipt generation.
+
+## 11. WSP_97 truth table
+
+| Claim | Label | Evidence |
+| --- | --- | --- |
+| Existing repo has many subprocess call sites | OBSERVED | `rg subprocess` direct search |
+| Existing subprocess call sites are RedDog authority | FALSE | No signed authority/cwd/receipt binding |
+| WRE cwd guard exists | OBSERVED | `reddog_wre_cwd_guard.py` |
+| Generic writer dry-run exists | OBSERVED | `reddog_generic_agent_worktree_writer_dryrun.py` |
+| Governed shell runner exists today | FALSE | No canonical module found |
+| Future runner must be argv-only | SPECIFIED_NOT_IMPLEMENTED | This contract |
+| Future runner must not re-index HoloIndex | SPECIFIED_NOT_IMPLEMENTED | This contract |
+
+## Explicit non-goals
+
+- No shell runner implementation.
+- No subprocess invocation.
+- No file mutation.
+- No worktree creation.
+- No PR/merge/release/deploy/publish.
+- No reward settlement.
+- No extension runtime wiring.
+- No HoloIndex re-index.
+
+## Truth Boundary Checklist
+
+- DOCS_ONLY: YES
+- NO_RUNTIME_CODE: YES
+- NO_SUBPROCESS: YES
+- NO_SHELL: YES
+- NO_FILE_MUTATION: YES
+- NO_MERGE_AUTHORITY: YES
+- NO_REWARD_SETTLEMENT: YES
+- NO_HOLOINDEX_REINDEX: YES
+- WSP_97_LABELS_USED: YES
+- SPECIFIED_NOT_IMPLEMENTED_EXPLICIT: YES

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,14 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-12: REDDOG_WRE_GOVERNED_SHELL_RUNNER_CONTRACT_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 11, 15, 50, 53, 71, 95, 97
+
+- Added `docs/audits/architecture/REDDOG_WRE_GOVERNED_SHELL_RUNNER_CONTRACT_PHASE1.md`: decision-only contract for a future WRE-owned governed shell runner.
+- Defined `GovernedShellCommandProfile`, `GovernedShellRunRequest`, future `GovernedShellRunReceipt`, argv-only command policy, WSP_71 secret boundary, WRE cwd guard requirements, full execution-valve binding, signed authority/receipt inputs, output redaction/caps, and HoloIndex no-reindex boundary.
+- Boundary: docs/static tests only. No shell runner implementation, no subprocess invocation, no file mutation, no worktree creation, no PR/merge/release/deploy/publish, no reward settlement, no extension runtime wiring, and no HoloIndex re-index.
+- HoloIndex read-only probe for `RedDog WRE governed shell runner contract command execution cwd guard signed authority` surfaced WSP_11/WSP_53/WSP_71, RedDog policy/receipt surfaces, and legacy subprocess call sites. Recorded as `HOLOINDEX_REDDOG_WRE_GOVERNED_SHELL_RUNNER_CONTRACT_INDEX_GAP_PHASE1`; no runtime re-index performed.
+
 ## 2026-07-12: REDDOG_GENERIC_AGENT_WORKTREE_WRITER_DRYRUN_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 95, 97

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_governed_shell_runner_contract_doc.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_governed_shell_runner_contract_doc.py
@@ -1,0 +1,143 @@
+"""Static tests for REDDOG_WRE_GOVERNED_SHELL_RUNNER_CONTRACT_PHASE1."""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CONTRACT_DOC = (
+    REPO_ROOT
+    / "docs"
+    / "audits"
+    / "architecture"
+    / "REDDOG_WRE_GOVERNED_SHELL_RUNNER_CONTRACT_PHASE1.md"
+)
+
+REQUIRED_SECTIONS = (
+    "## Purpose",
+    "## Direct-read evidence (WSP_50)",
+    "## 1. Governed shell command profile",
+    "## 2. Governed shell run request",
+    "## 3. Required authority inputs",
+    "## 4. Command policy",
+    "## 5. CWD and worktree boundary",
+    "## 6. Secret and environment boundary",
+    "## 7. Receipt contract",
+    "## 8. HoloIndex boundary",
+    "## 9. Fail-closed rejection rules",
+    "## 10. WSP_15 sequence",
+    "## 11. WSP_97 truth table",
+    "## Explicit non-goals",
+    "## Truth Boundary Checklist",
+)
+
+REQUIRED_MARKERS = (
+    "SHELL AUTHORITY IS NOT A STRING",
+    "GovernedShellCommandProfile",
+    "GovernedShellRunRequest",
+    "GovernedShellRunReceipt",
+    "argv_prefix",
+    "shell=True",
+    "RedDogDelegatedWorkAuthority",
+    "SignedReceiptChainVerificationResult",
+    "ExecutionValveDecision",
+    "VALVE_OPEN_WORKTREE_CREATE",
+    "WreCwdGuardResult",
+    "GenericAgentWorktreeWriterDryRunReceipt",
+    "WSP_71",
+    "secret_env_refs",
+    "stdout_digest",
+    "stderr_digest",
+    "no_merge_performed",
+    "no_reward_settlement_performed",
+    "no_holoindex_reindex_performed",
+    "HOLOINDEX_REDDOG_WRE_GOVERNED_SHELL_RUNNER_CONTRACT_INDEX_GAP_PHASE1",
+    "SPECIFIED_NOT_IMPLEMENTED",
+    "OBSERVED",
+)
+
+NON_GOALS = (
+    "No shell runner implementation.",
+    "No subprocess invocation.",
+    "No file mutation.",
+    "No worktree creation.",
+    "No PR/merge/release/deploy/publish.",
+    "No reward settlement.",
+    "No extension runtime wiring.",
+    "No HoloIndex re-index.",
+)
+
+
+@pytest.fixture(scope="module")
+def contract_text() -> str:
+    assert CONTRACT_DOC.is_file(), "governed shell runner contract missing"
+    return CONTRACT_DOC.read_text(encoding="utf-8")
+
+
+def test_governed_shell_runner_contract_doc_exists(contract_text: str) -> None:
+    assert len(contract_text) > 8500
+
+
+@pytest.mark.parametrize("section", REQUIRED_SECTIONS)
+def test_governed_shell_runner_contract_sections(section: str, contract_text: str) -> None:
+    assert section in contract_text, f"missing section: {section}"
+
+
+@pytest.mark.parametrize("marker", REQUIRED_MARKERS)
+def test_governed_shell_runner_contract_markers(marker: str, contract_text: str) -> None:
+    assert marker in contract_text, f"missing marker: {marker}"
+
+
+@pytest.mark.parametrize("line", NON_GOALS)
+def test_governed_shell_runner_contract_non_goals(line: str, contract_text: str) -> None:
+    assert line in contract_text
+
+
+def test_governed_shell_runner_contract_requires_argv_only_no_shell(contract_text: str) -> None:
+    assert "argv-list prefix" in contract_text
+    assert "shell command string" in contract_text
+    assert "shell metacharacter interpretation" in contract_text
+
+
+def test_governed_shell_runner_contract_forbids_merge_and_publish(contract_text: str) -> None:
+    for marker in (
+        "git push",
+        "git merge",
+        "gh pr ready",
+        "gh pr merge",
+        "release",
+        "publish",
+        "deploy",
+    ):
+        assert marker in contract_text
+
+
+def test_governed_shell_runner_contract_requires_cwd_guard(contract_text: str) -> None:
+    for marker in (
+        "validate_wre_worker_operation_cwd(...)",
+        "operation_cwd inside isolated worktree",
+        "operation_cwd outside shared repo root",
+        "no Windows device or extended-length prefix",
+    ):
+        assert marker in contract_text
+
+
+def test_governed_shell_runner_contract_requires_secret_boundary(contract_text: str) -> None:
+    for marker in (
+        "raw secret values are never accepted",
+        "private keys are never accepted",
+        "secret resolver must permission-check",
+        "output is redacted before receipt",
+    ):
+        assert marker in contract_text
+
+
+def test_governed_shell_runner_contract_forbids_runtime_holoindex_reindex(contract_text: str) -> None:
+    assert "RedDog runtime must not re-index HoloIndex" in contract_text
+    assert "HoloIndex `--index-*`, `--reindex-*`" in contract_text
+    assert "WRE/CI owns freshness receipts" in contract_text
+
+
+def test_governed_shell_runner_contract_ascii_only(contract_text: str) -> None:
+    non_ascii = [hex(ord(char)) for char in contract_text if ord(char) > 127]
+    assert non_ascii == [], f"non-ASCII chars found: {non_ascii[:5]}"


### PR DESCRIPTION
## REDDOG_WRE_GOVERNED_SHELL_RUNNER_CONTRACT_PHASE1

Decision-only contract for the future WRE-owned governed shell runner.

### Scope
- Defines `GovernedShellCommandProfile`, `GovernedShellRunRequest`, and future `GovernedShellRunReceipt`.
- Freezes argv-only command policy, WSP_71 secret boundary, WRE cwd guard, signed authority/receipt-chain inputs, full `VALVE_OPEN_WORKTREE_CREATE` binding, output caps/redaction, and HoloIndex no-reindex boundary.
- Records legacy subprocess call sites as OBSERVED legacy surfaces, not RedDog authority.

### Boundaries
- No shell runner implementation.
- No subprocess invocation.
- No file mutation.
- No worktree creation.
- No PR/merge/release/deploy/publish.
- No reward settlement.
- No extension runtime wiring.
- No HoloIndex re-index.

### Validation
- `pytest modules\communication\moltbot_bridge\tests\test_reddog_wre_governed_shell_runner_contract_doc.py` -> 52 passed.
- `git diff --check` -> clean.
- Contract + test byte scan -> 0 non-ASCII.
- Diff additions byte scan -> 0 non-ASCII.

### WSP_97
- OBSERVED: WSP_11/WSP_53/WSP_71 govern command/environment/secret boundaries.
- OBSERVED: WRE cwd guard and generic writer dry-run now exist as prerequisite surfaces.
- FALSE: existing scattered subprocess call sites are RedDog authority.
- SPECIFIED_NOT_IMPLEMENTED: governed shell runner dry-run and live shell execution remain future slices.

Worker-Lane: codex
Slice: REDDOG_WRE_GOVERNED_SHELL_RUNNER_CONTRACT_PHASE1