### PR TITLE
feat(reddog): add governed shell runner dry-run

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,14 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-12: REDDOG_WRE_GOVERNED_SHELL_RUNNER_DRYRUN_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 11, 15, 50, 53, 71, 95, 97
+
+- Added `src/reddog_wre_governed_shell_runner_dryrun.py`: pure dry-run validator for the governed shell runner contract. It validates argv-only command profiles, allowed/denied args, shell metacharacter rejection, WSP_71 secret boundaries, sovereign wardrobe selection, signed work authority, signed receipt-chain verification, `VALVE_OPEN_WORKTREE_CREATE`, generic writer dry-run receipt binding, HoloIndex freshness/INDEX_GAP, and WRE cwd guard.
+- Added `tests/test_reddog_wre_governed_shell_runner_dryrun.py`: acceptance, fail-closed, cwd isolation, HoloIndex freshness, no-execution receipt, JSON serialization, and AST no-subprocess/no-file-write coverage.
+- Boundary: no command execution, no subprocess/git/gh, no file writes, no worktree creation, no PR/merge/release/deploy/publish, no reward settlement, no extension runtime wiring, and no HoloIndex re-index. This emits a dry-run receipt only.
+- HoloIndex read-only probe for `RedDog WRE governed shell runner dryrun argv cwd receipt valve` did not surface a canonical dry-run runner. Recorded as `HOLOINDEX_REDDOG_WRE_GOVERNED_SHELL_RUNNER_DRYRUN_INDEX_GAP_PHASE1`; no runtime re-index performed.
+
 ## 2026-07-12: REDDOG_WRE_GOVERNED_SHELL_RUNNER_CONTRACT_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 11, 15, 50, 53, 71, 95, 97

--- a/modules/communication/moltbot_bridge/src/reddog_wre_governed_shell_runner_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_governed_shell_runner_dryrun.py
@@ -1,0 +1,582 @@
+"""Governed shell runner dry-run.
+
+Slice: REDDOG_WRE_GOVERNED_SHELL_RUNNER_DRYRUN_PHASE1
+Contract: docs/audits/architecture/REDDOG_WRE_GOVERNED_SHELL_RUNNER_CONTRACT_PHASE1.md
+
+This module validates whether a future WRE shell command would be authorized by
+the RedDog execution spine. It never executes commands, opens files, creates
+worktrees, mutates HoloIndex, or invokes subprocesses. It emits a dry-run
+receipt only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Union
+
+from modules.communication.moltbot_bridge.src.reddog_generic_agent_worktree_writer_dryrun import (
+    GENERIC_WRITER_DRYRUN_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_operator_loop_wardrobe_selection import (
+    EXECUTION_GOVERNED_CANDIDATE,
+    WARDROBE_SELECTION_ACCEPT,
+    WARDROBE_SOVEREIGN_EXECUTION,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_work_order_policy_gate import (
+    SIGNATURE_GATE_ACCEPTED,
+)
+from modules.communication.moltbot_bridge.src.reddog_signed_receipt_chain import (
+    SIGNED_RECEIPT_CHAIN_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_cwd_guard import (
+    WreCwdGuardResult,
+    validate_wre_worker_operation_cwd,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    VALVE_OPEN_WORKTREE_CREATE,
+)
+
+GOVERNED_SHELL_DRYRUN_ACCEPT = "GOVERNED_SHELL_DRYRUN_ACCEPT"
+GOVERNED_SHELL_DRYRUN_REJECT = "GOVERNED_SHELL_DRYRUN_REJECT"
+
+FAIL_PROFILE_INVALID = "FAIL_PROFILE_INVALID"
+FAIL_ARGV_INVALID = "FAIL_ARGV_INVALID"
+FAIL_ARGV_PREFIX = "FAIL_ARGV_PREFIX"
+FAIL_DENIED_ARG = "FAIL_DENIED_ARG"
+FAIL_ARG_NOT_ALLOWED = "FAIL_ARG_NOT_ALLOWED"
+FAIL_SHELL_METACHARACTER = "FAIL_SHELL_METACHARACTER"
+FAIL_SELECTION_RECEIPT = "FAIL_SELECTION_RECEIPT"
+FAIL_SIGNED_AUTHORITY = "FAIL_SIGNED_AUTHORITY"
+FAIL_RECEIPT_CHAIN = "FAIL_RECEIPT_CHAIN"
+FAIL_VALVE_DECISION = "FAIL_VALVE_DECISION"
+FAIL_CWD_GUARD = "FAIL_CWD_GUARD"
+FAIL_GENERIC_WRITER_RECEIPT = "FAIL_GENERIC_WRITER_RECEIPT"
+FAIL_CONSENSUS_REQUIRED = "FAIL_CONSENSUS_REQUIRED"
+FAIL_SECRET_IN_REQUEST = "FAIL_SECRET_IN_REQUEST"
+FAIL_HOLOINDEX_INDEX_GAP = "FAIL_HOLOINDEX_INDEX_GAP"
+FAIL_HOLOINDEX_FRESHNESS_RECEIPT = "FAIL_HOLOINDEX_FRESHNESS_RECEIPT"
+FAIL_TIMEOUT_INVALID = "FAIL_TIMEOUT_INVALID"
+FAIL_OUTPUT_CAP_INVALID = "FAIL_OUTPUT_CAP_INVALID"
+
+COMMAND_KINDS = frozenset(
+    {
+        "test",
+        "lint",
+        "format_check",
+        "static_analysis",
+        "build_check",
+        "readonly_probe",
+    }
+)
+OUTPUT_REDACTION_POLICIES = frozenset({"strict", "secret_safe", "none_forbidden"})
+MAX_TIMEOUT_SECONDS = 3600
+MAX_OUTPUT_BYTES = 2_000_000
+
+SHELL_METACHARACTERS = (";", "&&", "||", "|", ">", "<", "`", "$(", "\n", "\r")
+FORBIDDEN_COMMAND_PATTERNS = (
+    "git push",
+    "git merge",
+    "git reset",
+    "git checkout",
+    "gh pr ready",
+    "gh pr merge",
+    "npm publish",
+    "twine upload",
+    "python -m build",
+    "holo_index.py --index",
+    "holo_index.py --reindex",
+)
+SECRET_MARKERS = (
+    "bearer ",
+    "authorization:",
+    "api_key",
+    "apikey",
+    "private_key",
+    "begin private key",
+    "token=",
+    "secret=",
+    "password=",
+)
+
+
+@dataclass(frozen=True)
+class GovernedShellCommandProfile:
+    profile_id: str
+    command_kind: str
+    argv_prefix: List[str]
+    allowed_arg_patterns: List[str]
+    denied_arg_patterns: List[str]
+    requires_cwd_guard: bool
+    requires_worktree: bool
+    timeout_seconds: int
+    max_stdout_bytes: int
+    max_stderr_bytes: int
+    secret_env_refs: List[str]
+    output_redaction_policy: str
+    draft_pr_only: bool = True
+    consensus_required: bool = False
+    repo_sensitive: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class GovernedShellRunDryRunRequest:
+    work_order_id: str
+    profile: Union[GovernedShellCommandProfile, Mapping[str, Any]]
+    argv: List[str]
+    operation_cwd: str
+    worktree_path: str
+    repo_root: str
+    selection_receipt: Mapping[str, Any]
+    signed_authority: Mapping[str, Any]
+    signed_receipt_chain: Mapping[str, Any]
+    execution_valve_decision: Mapping[str, Any]
+    generic_writer_dryrun_receipt: Mapping[str, Any] = field(default_factory=dict)
+    permission_snapshot_digest: str = ""
+    consensus_receipt_digest: Optional[str] = None
+    stdin_policy: Union[str, Mapping[str, Any]] = "none"
+    env_policy: Mapping[str, Any] = field(default_factory=dict)
+    holoindex_evidence: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        if isinstance(self.profile, GovernedShellCommandProfile):
+            payload["profile"] = self.profile.to_dict()
+        return payload
+
+
+@dataclass(frozen=True)
+class GovernedShellRunDryRunReceipt:
+    run_receipt_id: str
+    work_order_id: str
+    profile_id: str
+    argv_digest: str
+    cwd_guard_receipt_digest: str
+    signed_authority_digest: str
+    receipt_chain_terminal_hash: str
+    execution_valve_decision_digest: str
+    generic_writer_dryrun_receipt_digest: Optional[str]
+    holoindex_freshness_receipt_digest: str
+    exit_code: Optional[int] = None
+    timed_out: bool = False
+    stdout_digest: str = ""
+    stderr_digest: str = ""
+    output_truncated: bool = False
+    no_merge_performed: bool = True
+    no_reward_settlement_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_command_executed: bool = True
+    no_subprocess_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class GovernedShellRunDryRunResult:
+    decision: str
+    accepted: bool
+    rejection_reasons: List[str]
+    receipt: Optional[GovernedShellRunDryRunReceipt]
+    cwd_guard: Optional[WreCwdGuardResult]
+    no_execution_performed: bool = True
+    no_command_executed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["receipt"] = self.receipt.to_dict() if self.receipt else None
+        payload["cwd_guard"] = self.cwd_guard.to_dict() if self.cwd_guard else None
+        return payload
+
+
+def _mapping(
+    request: Union[GovernedShellRunDryRunRequest, Mapping[str, Any]],
+) -> Mapping[str, Any]:
+    if isinstance(request, GovernedShellRunDryRunRequest):
+        return request.to_dict()
+    return request
+
+
+def _digest(payload: Any) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dedupe(values: Iterable[str]) -> List[str]:
+    seen = set()
+    ordered: List[str] = []
+    for value in values:
+        text = str(value or "").strip()
+        if text and text not in seen:
+            seen.add(text)
+            ordered.append(text)
+    return ordered
+
+
+def _as_profile(
+    profile: Union[GovernedShellCommandProfile, Mapping[str, Any]],
+) -> Optional[GovernedShellCommandProfile]:
+    if isinstance(profile, GovernedShellCommandProfile):
+        return profile
+    if not isinstance(profile, Mapping):
+        return None
+    try:
+        return GovernedShellCommandProfile(
+            profile_id=str(profile["profile_id"]),
+            command_kind=str(profile["command_kind"]),
+            argv_prefix=[str(v) for v in profile.get("argv_prefix", [])],
+            allowed_arg_patterns=[str(v) for v in profile.get("allowed_arg_patterns", [])],
+            denied_arg_patterns=[str(v) for v in profile.get("denied_arg_patterns", [])],
+            requires_cwd_guard=bool(profile.get("requires_cwd_guard", True)),
+            requires_worktree=bool(profile.get("requires_worktree", True)),
+            timeout_seconds=int(profile["timeout_seconds"]),
+            max_stdout_bytes=int(profile["max_stdout_bytes"]),
+            max_stderr_bytes=int(profile["max_stderr_bytes"]),
+            secret_env_refs=[str(v) for v in profile.get("secret_env_refs", [])],
+            output_redaction_policy=str(profile["output_redaction_policy"]),
+            draft_pr_only=bool(profile.get("draft_pr_only", True)),
+            consensus_required=bool(profile.get("consensus_required", False)),
+            repo_sensitive=bool(profile.get("repo_sensitive", True)),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def _profile_invalid(profile: GovernedShellCommandProfile) -> bool:
+    if not profile.profile_id or profile.command_kind not in COMMAND_KINDS:
+        return True
+    if not profile.argv_prefix or not all(isinstance(arg, str) and arg for arg in profile.argv_prefix):
+        return True
+    if not profile.draft_pr_only:
+        return True
+    if profile.output_redaction_policy not in OUTPUT_REDACTION_POLICIES:
+        return True
+    return False
+
+
+def _timeout_invalid(profile: GovernedShellCommandProfile) -> bool:
+    return profile.timeout_seconds <= 0 or profile.timeout_seconds > MAX_TIMEOUT_SECONDS
+
+
+def _output_caps_invalid(profile: GovernedShellCommandProfile) -> bool:
+    return (
+        profile.max_stdout_bytes <= 0
+        or profile.max_stderr_bytes <= 0
+        or profile.max_stdout_bytes > MAX_OUTPUT_BYTES
+        or profile.max_stderr_bytes > MAX_OUTPUT_BYTES
+    )
+
+
+def _argv_list(value: Any) -> Optional[List[str]]:
+    if not isinstance(value, list) or not value:
+        return None
+    argv: List[str] = []
+    for item in value:
+        if not isinstance(item, str) or item == "":
+            return None
+        argv.append(item)
+    return argv
+
+
+def _has_shell_metacharacter(argv: Sequence[str]) -> bool:
+    return any(any(marker in arg for marker in SHELL_METACHARACTERS) for arg in argv)
+
+
+def _joined_argv(argv: Sequence[str]) -> str:
+    return " ".join(argv).lower()
+
+
+def _matches(pattern: str, value: str) -> bool:
+    text = str(pattern or "")
+    if not text:
+        return False
+    try:
+        return re.fullmatch(text, value) is not None
+    except re.error:
+        return False
+
+
+def _searches(pattern: str, value: str) -> bool:
+    text = str(pattern or "")
+    if not text:
+        return False
+    try:
+        return re.search(text, value) is not None
+    except re.error:
+        return False
+
+
+def _argv_policy_reasons(profile: GovernedShellCommandProfile, argv: Sequence[str]) -> List[str]:
+    reasons: List[str] = []
+    if list(argv[: len(profile.argv_prefix)]) != list(profile.argv_prefix):
+        reasons.append(FAIL_ARGV_PREFIX)
+        return reasons
+    if _has_shell_metacharacter(argv):
+        reasons.append(FAIL_SHELL_METACHARACTER)
+    joined = _joined_argv(argv)
+    if any(pattern in joined for pattern in FORBIDDEN_COMMAND_PATTERNS):
+        reasons.append(FAIL_DENIED_ARG)
+    trailing = list(argv[len(profile.argv_prefix) :])
+    for arg in trailing:
+        if any(_searches(pattern, arg) for pattern in profile.denied_arg_patterns):
+            reasons.append(FAIL_DENIED_ARG)
+            continue
+        if profile.allowed_arg_patterns and not any(_matches(pattern, arg) for pattern in profile.allowed_arg_patterns):
+            reasons.append(FAIL_ARG_NOT_ALLOWED)
+    return reasons
+
+
+def _selection_ok(selection: Mapping[str, Any]) -> bool:
+    return (
+        selection.get("decision") in (None, WARDROBE_SELECTION_ACCEPT)
+        and selection.get("selected_wardrobe") == WARDROBE_SOVEREIGN_EXECUTION
+        and selection.get("execution_plane") == EXECUTION_GOVERNED_CANDIDATE
+        and selection.get("no_execution_performed") is True
+    )
+
+
+def _signed_authority_ok(authority: Mapping[str, Any], work_order_id: str, permission_digest: str) -> bool:
+    accepted = authority.get("accepted") is True or authority.get("signature_gate_status") == SIGNATURE_GATE_ACCEPTED
+    if not accepted:
+        return False
+    if authority.get("work_order_id") not in (None, work_order_id):
+        return False
+    supplied_digest = authority.get("permission_snapshot_digest")
+    if permission_digest and supplied_digest not in (None, permission_digest):
+        return False
+    return True
+
+
+def _receipt_chain_ok(chain: Mapping[str, Any]) -> bool:
+    return (
+        chain.get("accepted") is True
+        and chain.get("decision") == SIGNED_RECEIPT_CHAIN_ACCEPT
+        and chain.get("no_execution_performed") is not False
+        and chain.get("no_reward_settlement_performed") is not False
+    )
+
+
+def _valve_ok(valve: Mapping[str, Any]) -> bool:
+    return (
+        valve.get("valve_state") == VALVE_OPEN_WORKTREE_CREATE
+        and valve.get("no_execution_performed") is True
+        and not list(valve.get("rejection_reasons") or [])
+        and bool(valve.get("decision_digest"))
+    )
+
+
+def _generic_writer_receipt_ok(receipt: Mapping[str, Any]) -> bool:
+    decision = receipt.get("decision")
+    return (
+        decision in (None, GENERIC_WRITER_DRYRUN_ACCEPT)
+        and receipt.get("no_write_performed") is True
+        and receipt.get("no_worktree_created") is True
+        and receipt.get("no_shell_performed") is True
+        and bool(receipt.get("canonical_root_digest"))
+        and bool(receipt.get("artifact_manifest_digest"))
+    )
+
+
+def _holoindex_gap_blocks_command(holoindex_evidence: Mapping[str, Any]) -> bool:
+    return (
+        holoindex_evidence.get("index_gap_detected") is True
+        or str(holoindex_evidence.get("retrieval_quality") or "").upper() == "INDEX_GAP"
+    )
+
+
+def _holoindex_freshness_digest(holoindex_evidence: Mapping[str, Any]) -> str:
+    return str(
+        holoindex_evidence.get("holoindex_freshness_receipt_digest")
+        or holoindex_evidence.get("freshness_receipt_digest")
+        or ""
+    )
+
+
+def _contains_raw_secret(payload: Any, parent_key: str = "") -> bool:
+    if parent_key == "secret_env_refs":
+        return False
+    if isinstance(payload, Mapping):
+        for key, value in payload.items():
+            key_text = str(key).lower()
+            if key_text != "secret_env_refs" and any(marker.rstrip(" =:") in key_text for marker in SECRET_MARKERS):
+                return True
+            if _contains_raw_secret(value, key_text):
+                return True
+        return False
+    if isinstance(payload, (list, tuple)):
+        return any(_contains_raw_secret(value, parent_key) for value in payload)
+    text = str(payload or "").lower()
+    if not text:
+        return False
+    if parent_key == "secret_env_refs":
+        return False
+    return any(marker in text for marker in SECRET_MARKERS)
+
+
+def _secret_in_request(req: Mapping[str, Any], profile: Optional[GovernedShellCommandProfile]) -> bool:
+    inspected = {
+        "argv": req.get("argv"),
+        "stdin_policy": req.get("stdin_policy"),
+        "env_policy": req.get("env_policy"),
+    }
+    if _contains_raw_secret(inspected):
+        return True
+    if profile is None:
+        return False
+    for ref in profile.secret_env_refs:
+        text = str(ref or "")
+        if not text or _has_shell_metacharacter([text]):
+            return True
+        if text.lower().startswith(("bearer ", "token=", "secret=", "password=")):
+            return True
+    return False
+
+
+def _authority_digest(authority: Mapping[str, Any]) -> str:
+    return str(authority.get("signature_gate_digest") or authority.get("verification_digest") or "") or _digest(authority)
+
+
+def plan_governed_shell_runner_dry_run(
+    request: Union[GovernedShellRunDryRunRequest, Mapping[str, Any]],
+) -> GovernedShellRunDryRunResult:
+    """Validate a future governed shell run and emit a dry-run receipt only."""
+    req = _mapping(request)
+    reasons: List[str] = []
+    cwd_guard: Optional[WreCwdGuardResult] = None
+
+    work_order_id = str(req.get("work_order_id") or "")
+    profile = _as_profile(req.get("profile") or {})
+    argv = _argv_list(req.get("argv"))
+
+    if profile is None or _profile_invalid(profile):
+        reasons.append(FAIL_PROFILE_INVALID)
+    else:
+        if _timeout_invalid(profile):
+            reasons.append(FAIL_TIMEOUT_INVALID)
+        if _output_caps_invalid(profile):
+            reasons.append(FAIL_OUTPUT_CAP_INVALID)
+
+    if argv is None:
+        reasons.append(FAIL_ARGV_INVALID)
+    elif profile is not None:
+        reasons.extend(_argv_policy_reasons(profile, argv))
+
+    if _secret_in_request(req, profile):
+        reasons.append(FAIL_SECRET_IN_REQUEST)
+
+    selection = dict(req.get("selection_receipt") or {})
+    if not _selection_ok(selection):
+        reasons.append(FAIL_SELECTION_RECEIPT)
+
+    authority = dict(req.get("signed_authority") or {})
+    if not _signed_authority_ok(authority, work_order_id, str(req.get("permission_snapshot_digest") or "")):
+        reasons.append(FAIL_SIGNED_AUTHORITY)
+
+    chain = dict(req.get("signed_receipt_chain") or {})
+    if not _receipt_chain_ok(chain):
+        reasons.append(FAIL_RECEIPT_CHAIN)
+
+    valve = dict(req.get("execution_valve_decision") or {})
+    if not _valve_ok(valve):
+        reasons.append(FAIL_VALVE_DECISION)
+
+    if profile is not None and profile.consensus_required and not req.get("consensus_receipt_digest"):
+        reasons.append(FAIL_CONSENSUS_REQUIRED)
+
+    writer_receipt = dict(req.get("generic_writer_dryrun_receipt") or {})
+    if profile is not None and profile.requires_worktree and not _generic_writer_receipt_ok(writer_receipt):
+        reasons.append(FAIL_GENERIC_WRITER_RECEIPT)
+
+    holoindex_evidence = dict(req.get("holoindex_evidence") or {})
+    if profile is not None and profile.repo_sensitive:
+        if _holoindex_gap_blocks_command(holoindex_evidence):
+            reasons.append(FAIL_HOLOINDEX_INDEX_GAP)
+        if not _holoindex_freshness_digest(holoindex_evidence):
+            reasons.append(FAIL_HOLOINDEX_FRESHNESS_RECEIPT)
+
+    if profile is not None and (profile.requires_cwd_guard or profile.requires_worktree):
+        try:
+            cwd_guard = validate_wre_worker_operation_cwd(
+                repo_root=Path(str(req.get("repo_root") or "")),
+                worktree_path=Path(str(req.get("worktree_path") or "")),
+                operation_cwd=Path(str(req.get("operation_cwd") or req.get("worktree_path") or "")),
+            )
+            if not cwd_guard.ok:
+                reasons.append(FAIL_CWD_GUARD)
+        except Exception:
+            reasons.append(FAIL_CWD_GUARD)
+
+    deduped = _dedupe(reasons)
+    if deduped:
+        return GovernedShellRunDryRunResult(
+            decision=GOVERNED_SHELL_DRYRUN_REJECT,
+            accepted=False,
+            rejection_reasons=deduped,
+            receipt=None,
+            cwd_guard=cwd_guard,
+        )
+
+    assert profile is not None
+    assert argv is not None
+    argv_digest = _digest({"argv": argv})
+    empty_output_digest = _digest("")
+    receipt = GovernedShellRunDryRunReceipt(
+        run_receipt_id="governed_shell_dryrun_" + hashlib.sha256(
+            _digest({"work_order_id": work_order_id, "profile_id": profile.profile_id, "argv": argv}).encode("utf-8")
+        ).hexdigest()[:16],
+        work_order_id=work_order_id,
+        profile_id=profile.profile_id,
+        argv_digest=argv_digest,
+        cwd_guard_receipt_digest=_digest(cwd_guard.to_dict() if cwd_guard else {}),
+        signed_authority_digest=_authority_digest(authority),
+        receipt_chain_terminal_hash=str(chain.get("terminal_receipt_hash") or ""),
+        execution_valve_decision_digest=str(valve.get("decision_digest") or ""),
+        generic_writer_dryrun_receipt_digest=(
+            None if not writer_receipt else str(writer_receipt.get("receipt_id") or _digest(writer_receipt))
+        ),
+        holoindex_freshness_receipt_digest=_holoindex_freshness_digest(holoindex_evidence),
+        stdout_digest=empty_output_digest,
+        stderr_digest=empty_output_digest,
+    )
+    return GovernedShellRunDryRunResult(
+        decision=GOVERNED_SHELL_DRYRUN_ACCEPT,
+        accepted=True,
+        rejection_reasons=[],
+        receipt=receipt,
+        cwd_guard=cwd_guard,
+    )
+
+
+__all__ = [
+    "FAIL_ARGV_INVALID",
+    "FAIL_ARGV_PREFIX",
+    "FAIL_ARG_NOT_ALLOWED",
+    "FAIL_CONSENSUS_REQUIRED",
+    "FAIL_CWD_GUARD",
+    "FAIL_DENIED_ARG",
+    "FAIL_GENERIC_WRITER_RECEIPT",
+    "FAIL_HOLOINDEX_FRESHNESS_RECEIPT",
+    "FAIL_HOLOINDEX_INDEX_GAP",
+    "FAIL_OUTPUT_CAP_INVALID",
+    "FAIL_PROFILE_INVALID",
+    "FAIL_RECEIPT_CHAIN",
+    "FAIL_SECRET_IN_REQUEST",
+    "FAIL_SELECTION_RECEIPT",
+    "FAIL_SHELL_METACHARACTER",
+    "FAIL_SIGNED_AUTHORITY",
+    "FAIL_TIMEOUT_INVALID",
+    "FAIL_VALVE_DECISION",
+    "GOVERNED_SHELL_DRYRUN_ACCEPT",
+    "GOVERNED_SHELL_DRYRUN_REJECT",
+    "GovernedShellCommandProfile",
+    "GovernedShellRunDryRunReceipt",
+    "GovernedShellRunDryRunRequest",
+    "GovernedShellRunDryRunResult",
+    "plan_governed_shell_runner_dry_run",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_governed_shell_runner_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_governed_shell_runner_dryrun.py
@@ -1,0 +1,457 @@
+"""Tests for REDDOG_WRE_GOVERNED_SHELL_RUNNER_DRYRUN_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_generic_agent_worktree_writer_dryrun import (
+    GENERIC_WRITER_DRYRUN_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_operator_loop_wardrobe_selection import (
+    EXECUTION_GOVERNED_CANDIDATE,
+    WARDROBE_SELECTION_ACCEPT,
+    WARDROBE_SOVEREIGN_EXECUTION,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_work_order_policy_gate import (
+    SIGNATURE_GATE_ACCEPTED,
+)
+from modules.communication.moltbot_bridge.src.reddog_signed_receipt_chain import (
+    SIGNED_RECEIPT_CHAIN_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    VALVE_OPEN_WORKTREE_CREATE,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_governed_shell_runner_dryrun import (
+    FAIL_ARGV_INVALID,
+    FAIL_ARGV_PREFIX,
+    FAIL_ARG_NOT_ALLOWED,
+    FAIL_CONSENSUS_REQUIRED,
+    FAIL_CWD_GUARD,
+    FAIL_DENIED_ARG,
+    FAIL_GENERIC_WRITER_RECEIPT,
+    FAIL_HOLOINDEX_FRESHNESS_RECEIPT,
+    FAIL_HOLOINDEX_INDEX_GAP,
+    FAIL_OUTPUT_CAP_INVALID,
+    FAIL_PROFILE_INVALID,
+    FAIL_RECEIPT_CHAIN,
+    FAIL_SECRET_IN_REQUEST,
+    FAIL_SELECTION_RECEIPT,
+    FAIL_SHELL_METACHARACTER,
+    FAIL_SIGNED_AUTHORITY,
+    FAIL_TIMEOUT_INVALID,
+    FAIL_VALVE_DECISION,
+    GOVERNED_SHELL_DRYRUN_ACCEPT,
+    GOVERNED_SHELL_DRYRUN_REJECT,
+    GovernedShellCommandProfile,
+    plan_governed_shell_runner_dry_run,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_wre_governed_shell_runner_dryrun.py"
+)
+
+
+@pytest.fixture()
+def pytest_profile() -> GovernedShellCommandProfile:
+    return GovernedShellCommandProfile(
+        profile_id="pytest_scoped",
+        command_kind="test",
+        argv_prefix=["python", "-m", "pytest"],
+        allowed_arg_patterns=[
+            r"modules/[A-Za-z0-9_./-]+",
+            r"tests/[A-Za-z0-9_./-]+",
+            r"-q",
+            r"--maxfail=\d+",
+        ],
+        denied_arg_patterns=[
+            r".*--index-all.*",
+            r".*--reindex.*",
+            r".*\.env.*",
+            r".*WSP_framework.*",
+        ],
+        requires_cwd_guard=True,
+        requires_worktree=True,
+        timeout_seconds=300,
+        max_stdout_bytes=100000,
+        max_stderr_bytes=100000,
+        secret_env_refs=[],
+        output_redaction_policy="strict",
+        draft_pr_only=True,
+        consensus_required=False,
+        repo_sensitive=True,
+    )
+
+
+def valid_request(tmp_path: Path, profile: GovernedShellCommandProfile) -> dict:
+    worktree = tmp_path / "governed-shell-worktree"
+    return {
+        "work_order_id": "wo-shell-1",
+        "profile": profile,
+        "argv": ["python", "-m", "pytest", "modules/foundups/tests", "-q"],
+        "operation_cwd": str(worktree),
+        "worktree_path": str(worktree),
+        "repo_root": str(REPO_ROOT),
+        "selection_receipt": {
+            "decision": WARDROBE_SELECTION_ACCEPT,
+            "selected_wardrobe": WARDROBE_SOVEREIGN_EXECUTION,
+            "execution_plane": EXECUTION_GOVERNED_CANDIDATE,
+            "no_execution_performed": True,
+        },
+        "signed_authority": {
+            "accepted": True,
+            "signature_gate_status": SIGNATURE_GATE_ACCEPTED,
+            "work_order_id": "wo-shell-1",
+            "permission_snapshot_digest": "sha256:perm",
+            "signature_gate_digest": "sha256:signed-authority",
+        },
+        "signed_receipt_chain": {
+            "accepted": True,
+            "decision": SIGNED_RECEIPT_CHAIN_ACCEPT,
+            "terminal_receipt_hash": "sha256:terminal",
+            "no_execution_performed": True,
+            "no_reward_settlement_performed": True,
+        },
+        "execution_valve_decision": {
+            "valve_state": VALVE_OPEN_WORKTREE_CREATE,
+            "decision_digest": "sha256:valve",
+            "rejection_reasons": [],
+            "no_execution_performed": True,
+        },
+        "generic_writer_dryrun_receipt": {
+            "decision": GENERIC_WRITER_DRYRUN_ACCEPT,
+            "receipt_id": "generic_wt_dryrun_1234",
+            "canonical_root_digest": "sha256:root",
+            "artifact_manifest_digest": "sha256:artifacts",
+            "no_write_performed": True,
+            "no_worktree_created": True,
+            "no_shell_performed": True,
+        },
+        "permission_snapshot_digest": "sha256:perm",
+        "consensus_receipt_digest": None,
+        "stdin_policy": "none",
+        "env_policy": {"scrubbed": True},
+        "holoindex_evidence": {
+            "index_gap_detected": False,
+            "holoindex_freshness_receipt_digest": "sha256:holo-fresh",
+        },
+    }
+
+
+def assert_reject(req: dict, code: str) -> None:
+    result = plan_governed_shell_runner_dry_run(req)
+    assert result.decision == GOVERNED_SHELL_DRYRUN_REJECT
+    assert result.accepted is False
+    assert code in result.rejection_reasons
+    assert result.receipt is None
+    assert result.no_execution_performed is True
+    assert result.no_command_executed is True
+
+
+def test_governed_shell_dryrun_accepts_valid_pytest_request(
+    tmp_path: Path,
+    pytest_profile: GovernedShellCommandProfile,
+) -> None:
+    result = plan_governed_shell_runner_dry_run(valid_request(tmp_path, pytest_profile))
+
+    assert result.decision == GOVERNED_SHELL_DRYRUN_ACCEPT
+    assert result.accepted is True
+    assert result.rejection_reasons == []
+    assert result.cwd_guard is not None
+    assert result.cwd_guard.ok is True
+    assert result.receipt is not None
+    receipt = result.receipt
+    assert receipt.work_order_id == "wo-shell-1"
+    assert receipt.profile_id == "pytest_scoped"
+    assert receipt.signed_authority_digest == "sha256:signed-authority"
+    assert receipt.receipt_chain_terminal_hash == "sha256:terminal"
+    assert receipt.execution_valve_decision_digest == "sha256:valve"
+    assert receipt.holoindex_freshness_receipt_digest == "sha256:holo-fresh"
+    assert receipt.no_command_executed is True
+    assert receipt.no_subprocess_performed is True
+    assert receipt.no_merge_performed is True
+    assert receipt.no_reward_settlement_performed is True
+    assert receipt.no_holoindex_reindex_performed is True
+    assert receipt.exit_code is None
+
+
+def test_accepts_mapping_profile(tmp_path: Path, pytest_profile: GovernedShellCommandProfile) -> None:
+    req = valid_request(tmp_path, pytest_profile)
+    req["profile"] = pytest_profile.to_dict()
+
+    result = plan_governed_shell_runner_dry_run(req)
+
+    assert result.accepted is True
+    assert result.receipt is not None
+    assert result.receipt.profile_id == "pytest_scoped"
+
+
+def test_rejects_profile_not_draft_pr_only(tmp_path: Path, pytest_profile: GovernedShellCommandProfile) -> None:
+    req = valid_request(tmp_path, pytest_profile)
+    req["profile"] = {**pytest_profile.to_dict(), "draft_pr_only": False}
+
+    assert_reject(req, FAIL_PROFILE_INVALID)
+
+
+def test_rejects_invalid_timeout_and_output_caps(
+    tmp_path: Path,
+    pytest_profile: GovernedShellCommandProfile,
+) -> None:
+    req = valid_request(tmp_path, pytest_profile)
+    req["profile"] = {**pytest_profile.to_dict(), "timeout_seconds": 0, "max_stdout_bytes": 0}
+
+    result = plan_governed_shell_runner_dry_run(req)
+
+    assert result.accepted is False
+    assert FAIL_TIMEOUT_INVALID in result.rejection_reasons
+    assert FAIL_OUTPUT_CAP_INVALID in result.rejection_reasons
+
+
+def test_rejects_empty_or_non_string_argv(tmp_path: Path, pytest_profile: GovernedShellCommandProfile) -> None:
+    req = valid_request(tmp_path, pytest_profile)
+    req["argv"] = []
+    assert_reject(req, FAIL_ARGV_INVALID)
+
+    req = valid_request(tmp_path, pytest_profile)
+    req["argv"] = ["python", 1]
+    assert_reject(req, FAIL_ARGV_INVALID)
+
+
+def test_rejects_prefix_mismatch(tmp_path: Path, pytest_profile: GovernedShellCommandProfile) -> None:
+    req = valid_request(tmp_path, pytest_profile)
+    req["argv"] = ["pytest", "modules/foundups/tests"]
+
+    assert_reject(req, FAIL_ARGV_PREFIX)
+
+
+@pytest.mark.parametrize("bad_arg", ["modules/foundups/tests; rm -rf .", "modules/a && whoami", "$(whoami)", "x\ny"])
+def test_rejects_shell_metacharacters(
+    tmp_path: Path,
+    pytest_profile: GovernedShellCommandProfile,
+    bad_arg: str,
+) -> None:
+    req = valid_request(tmp_path, pytest_profile)
+    req["argv"] = ["python", "-m", "pytest", bad_arg]
+
+    assert_reject(req, FAIL_SHELL_METACHARACTER)
+
+
+def test_rejects_denied_arg_pattern(tmp_path: Path, pytest_profile: GovernedShellCommandProfile) -> None:
+    req = valid_request(tmp_path, pytest_profile)
+    req["argv"] = ["python", "-m", "pytest", "modules/foundups/tests", "--index-all"]
+
+    assert_reject(req, FAIL_DENIED_ARG)
+
+
+def test_rejects_trailing_arg_not_allowed(tmp_path: Path, pytest_profile: GovernedShellCommandProfile) -> None:
+    req = valid_request(tmp_path, pytest_profile)
+    req["argv"] = ["python", "-m", "pytest", "--capture=sys"]
+
+    assert_reject(req, FAIL_ARG_NOT_ALLOWED)
+
+
+def test_rejects_secret_like_argv_or_env(tmp_path: Path, pytest_profile: GovernedShellCommandProfile) -> None:
+    req = valid_request(tmp_path, pytest_profile)
+    req["argv"] = ["python", "-m", "pytest", "modules/foundups/tests", "token=abc"]
+    assert_reject(req, FAIL_SECRET_IN_REQUEST)
+
+    req = valid_request(tmp_path, pytest_profile)
+    req["env_policy"] = {"API_KEY": "abc"}
+    assert_reject(req, FAIL_SECRET_IN_REQUEST)
+
+
+def test_rejects_bad_selection_receipt(tmp_path: Path, pytest_profile: GovernedShellCommandProfile) -> None:
+    req = valid_request(tmp_path, pytest_profile)
+    req["selection_receipt"]["selected_wardrobe"] = "wsp97_architect_audit"
+
+    assert_reject(req, FAIL_SELECTION_RECEIPT)
+
+
+def test_rejects_unsigned_authority(tmp_path: Path, pytest_profile: GovernedShellCommandProfile) -> None:
+    req = valid_request(tmp_path, pytest_profile)
+    req["signed_authority"] = {"accepted": False, "signature_gate_status": "SIGNATURE_GATE_REJECTED"}
+
+    assert_reject(req, FAIL_SIGNED_AUTHORITY)
+
+
+def test_rejects_authority_work_order_mismatch(
+    tmp_path: Path,
+    pytest_profile: GovernedShellCommandProfile,
+) -> None:
+    req = valid_request(tmp_path, pytest_profile)
+    req["signed_authority"]["work_order_id"] = "wo-other"
+
+    assert_reject(req, FAIL_SIGNED_AUTHORITY)
+
+
+def test_rejects_receipt_chain_failure(tmp_path: Path, pytest_profile: GovernedShellCommandProfile) -> None:
+    req = valid_request(tmp_path, pytest_profile)
+    req["signed_receipt_chain"] = {"accepted": False, "decision": "SIGNED_RECEIPT_CHAIN_REJECT"}
+
+    assert_reject(req, FAIL_RECEIPT_CHAIN)
+
+
+def test_rejects_closed_valve(tmp_path: Path, pytest_profile: GovernedShellCommandProfile) -> None:
+    req = valid_request(tmp_path, pytest_profile)
+    req["execution_valve_decision"] = {
+        "valve_state": "VALVE_CLOSED",
+        "decision_digest": "sha256:valve",
+        "rejection_reasons": ["explicit_valve_flag_missing"],
+        "no_execution_performed": True,
+    }
+
+    assert_reject(req, FAIL_VALVE_DECISION)
+
+
+def test_rejects_missing_generic_writer_receipt_when_worktree_required(
+    tmp_path: Path,
+    pytest_profile: GovernedShellCommandProfile,
+) -> None:
+    req = valid_request(tmp_path, pytest_profile)
+    req["generic_writer_dryrun_receipt"] = {}
+
+    assert_reject(req, FAIL_GENERIC_WRITER_RECEIPT)
+
+
+def test_rejects_generic_writer_receipt_that_performed_shell(
+    tmp_path: Path,
+    pytest_profile: GovernedShellCommandProfile,
+) -> None:
+    req = valid_request(tmp_path, pytest_profile)
+    req["generic_writer_dryrun_receipt"]["no_shell_performed"] = False
+
+    assert_reject(req, FAIL_GENERIC_WRITER_RECEIPT)
+
+
+def test_rejects_consensus_required_missing(
+    tmp_path: Path,
+    pytest_profile: GovernedShellCommandProfile,
+) -> None:
+    profile = GovernedShellCommandProfile(**{**pytest_profile.to_dict(), "consensus_required": True})
+    req = valid_request(tmp_path, profile)
+
+    assert_reject(req, FAIL_CONSENSUS_REQUIRED)
+
+
+def test_accepts_consensus_when_required_and_present(
+    tmp_path: Path,
+    pytest_profile: GovernedShellCommandProfile,
+) -> None:
+    profile = GovernedShellCommandProfile(**{**pytest_profile.to_dict(), "consensus_required": True})
+    req = valid_request(tmp_path, profile)
+    req["consensus_receipt_digest"] = "sha256:consensus"
+
+    result = plan_governed_shell_runner_dry_run(req)
+
+    assert result.accepted is True
+
+
+def test_rejects_holoindex_index_gap_and_missing_freshness(
+    tmp_path: Path,
+    pytest_profile: GovernedShellCommandProfile,
+) -> None:
+    req = valid_request(tmp_path, pytest_profile)
+    req["holoindex_evidence"] = {"index_gap_detected": True}
+
+    result = plan_governed_shell_runner_dry_run(req)
+
+    assert result.accepted is False
+    assert FAIL_HOLOINDEX_INDEX_GAP in result.rejection_reasons
+    assert FAIL_HOLOINDEX_FRESHNESS_RECEIPT in result.rejection_reasons
+
+
+def test_rejects_worktree_inside_repo(tmp_path: Path, pytest_profile: GovernedShellCommandProfile) -> None:
+    req = valid_request(tmp_path, pytest_profile)
+    req["worktree_path"] = str(REPO_ROOT / ".worktrees" / "bad")
+    req["operation_cwd"] = req["worktree_path"]
+
+    assert_reject(req, FAIL_CWD_GUARD)
+
+
+def test_rejects_relative_operation_cwd(tmp_path: Path, pytest_profile: GovernedShellCommandProfile) -> None:
+    req = valid_request(tmp_path, pytest_profile)
+    req["operation_cwd"] = "relative/cwd"
+
+    assert_reject(req, FAIL_CWD_GUARD)
+
+
+def test_readonly_probe_can_skip_worktree_receipt(tmp_path: Path, pytest_profile: GovernedShellCommandProfile) -> None:
+    profile = GovernedShellCommandProfile(
+        **{
+            **pytest_profile.to_dict(),
+            "profile_id": "readonly_probe",
+            "command_kind": "readonly_probe",
+            "argv_prefix": ["python", "--version"],
+            "allowed_arg_patterns": [],
+            "requires_cwd_guard": False,
+            "requires_worktree": False,
+            "repo_sensitive": False,
+        }
+    )
+    req = valid_request(tmp_path, profile)
+    req["argv"] = ["python", "--version"]
+    req["generic_writer_dryrun_receipt"] = {}
+    req["holoindex_evidence"] = {}
+
+    result = plan_governed_shell_runner_dry_run(req)
+
+    assert result.accepted is True
+    assert result.receipt is not None
+    assert result.receipt.generic_writer_dryrun_receipt_digest is None
+
+
+def test_result_is_json_serializable(tmp_path: Path, pytest_profile: GovernedShellCommandProfile) -> None:
+    result = plan_governed_shell_runner_dry_run(valid_request(tmp_path, pytest_profile))
+
+    payload = result.to_dict()
+
+    json.dumps(payload, sort_keys=True)
+    assert payload["accepted"] is True
+    assert payload["receipt"]["no_command_executed"] is True
+
+
+def test_governed_shell_dryrun_module_ast_forbids_execution_and_file_write() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_imports = {"subprocess", "os", "shutil"}
+    banned_calls = {
+        "open",
+        "exec",
+        "eval",
+        "mkdir",
+        "write_text",
+        "write_bytes",
+        "create_worktree",
+        "commit_all",
+        "push_branch",
+        "create_draft_pr",
+        "run",
+        "Popen",
+        "call",
+        "check_call",
+        "check_output",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported = {alias.name.split(".")[0] for alias in node.names}
+            assert imported.isdisjoint(banned_imports)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".")[0] not in banned_imports
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_calls
+
+
+def test_governed_shell_dryrun_module_ascii_only() -> None:
+    text = MODULE_PATH.read_text(encoding="utf-8")
+    assert [hex(ord(ch)) for ch in text if ord(ch) > 127] == []


### PR DESCRIPTION
## Summary

Implements `REDDOG_WRE_GOVERNED_SHELL_RUNNER_DRYRUN_PHASE1` as a pure validator/receipt layer for the governed shell runner contract.

- Adds `reddog_wre_governed_shell_runner_dryrun.py` with `GovernedShellCommandProfile`, dry-run request/result/receipt schemas, argv-only validation, WSP_71 secret checks, signed authority and signed receipt-chain checks, `VALVE_OPEN_WORKTREE_CREATE` binding, generic writer dry-run receipt binding, HoloIndex freshness/INDEX_GAP checks, and WRE cwd guard validation.
- Adds fail-closed tests for profile/argv/prefix/metacharacters/denied args/secrets/selection/signed authority/receipt chain/valve/generic writer receipt/consensus/HoloIndex/cwd boundaries.
- Updates `modules/communication/moltbot_bridge/ModLog.md` with the WSP_97 and HoloIndex boundary.

## Verification

- `pytest modules\communication\moltbot_bridge\tests\test_reddog_wre_governed_shell_runner_dryrun.py modules\communication\moltbot_bridge\tests\test_reddog_wre_governed_shell_runner_contract_doc.py` -> 81 passed
- `pytest modules\communication\moltbot_bridge\tests\test_reddog_operator_loop_wardrobe_selection.py modules\communication\moltbot_bridge\tests\test_reddog_openclaw_work_order_policy_gate.py modules\communication\moltbot_bridge\tests\test_reddog_signed_receipt_chain.py modules\communication\moltbot_bridge\tests\test_reddog_wre_execution_valve.py modules\communication\moltbot_bridge\tests\test_reddog_generic_agent_worktree_writer_dryrun.py modules\communication\moltbot_bridge\tests\test_reddog_wre_governed_shell_runner_contract_doc.py modules\communication\moltbot_bridge\tests\test_reddog_wre_governed_shell_runner_dryrun.py` -> 173 passed
- `git diff --check` -> clean (autocrlf warning only)
- Byte scan on new Python files -> 0 non-ASCII, 0 NUL

## Truth Boundary Checklist

- NO_SUBPROCESS: PASS
- NO_COMMAND_EXECUTION: PASS
- NO_FILE_WRITE: PASS
- NO_WORKTREE_CREATE: PASS
- NO_PR_MERGE_RELEASE_DEPLOY: PASS
- NO_REWARD_SETTLEMENT: PASS
- NO_EXTENSION_RUNTIME_WIRING: PASS
- NO_HOLOINDEX_REINDEX: PASS

## HoloIndex

Read-only probe for `RedDog WRE governed shell runner dryrun argv cwd receipt valve` surfaced adjacent valve/work-order/adapter surfaces and WSP_11/WSP_46/WSP_CORE, but no canonical governed shell runner dry-run module. Recorded follow-up: `HOLOINDEX_REDDOG_WRE_GOVERNED_SHELL_RUNNER_DRYRUN_INDEX_GAP_PHASE1`.

## Residual SPECIFIED_NOT_IMPLEMENTED

- Live shell execution
- Actual subprocess runner
- Output redaction implementation for live stdout/stderr
- Merge authority
- HoloIndex WRE/CI freshness maintenance

Worker-Lane: codex
Slice: REDDOG_WRE_GOVERNED_SHELL_RUNNER_DRYRUN_PHASE1