### PR TITLE
feat(holoindex): enforce readonly query guard

### DIFF
--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -8,6 +8,13 @@
 - Contract remains docs/static-test only: no extension runtime call, no OpenClaw enqueue, no AgentDB write, no Hermes/WRE dispatch.
 - Future live enqueue requires `VALVE_OPEN_LIVE_ENQUEUE`, accepted signed work authority, and signed receipt-chain verification.
 
+## 2026-07-12 - HOLOINDEX_READONLY_QUERY_GUARD_PHASE1 (RedDog HoloIndex query posture, 0.3.48)
+
+- RedDog HoloIndex calls now pass `HOLOINDEX_QUERY_READONLY=1` for bundle-json and offline fallback paths.
+- HoloIndex CLI now defaults plain query/search mode to read-only and gates search-time auto-refresh behind explicit `--allow-auto-refresh`.
+- HoloIndex collection reset refuses to run when `HOLOINDEX_QUERY_READONLY=1`, so a RedDog query process cannot mutate the semantic store even if a write path is accidentally reached.
+- Version 0.3.47 -> 0.3.48 (package.json + EXTENSION_VERSION + README + contract-test assertions).
+
 ## 2026-07-11 - REDDOG_JUDGMENT_GENERATION_WIRING_PHASE1 (Determine verifier wiring, 0.3.47)
 
 - Wire the landed Determine contract plus adversarial verifier panel into the live RedDog extension path.

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.47
+Version: 0.3.48
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -20,6 +20,7 @@ Current implementation:
 - REDDOG_WORK_FOCUS_READ_CAPTURE_PROSE_TOKENIZATION_PHASE1 (v0.3.45): flowing-prose `Read first:` lines are tokenized with the bounded path-token regex (not the comma-splitter), so a path followed by prose and an embedded-slash English fragment (`breadcrumb/handoff`) no longer corrupt derived targets; tiered strictness (flowing prose requires a file extension, explicit/M2M/bullet tiers keep slash-OR-extension); slash-only prose fragments reported in `work_focus_targets_dropped_low_confidence` and never flip `target_recall_ok`; `}` added to trailing-punctuation trim.
 - REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_DRYRUN_WIRE_PHASE1 (v0.3.46): Copy MD/review packet emits typed WRE operational spine dry-run preview; no Python spine invocation, worktree create, task execution, OpenClaw enqueue, Hermes dispatch, PR, push, merge, or repo mutation.
 - REDDOG_JUDGMENT_GENERATION_WIRING_PHASE1 (v0.3.47): Determine prompts now request canonical `## Determine Answers` JSON and run a local deterministic verifier against already-fetched direct-read evidence; Run Trace/Copy MD expose verifier verdicts and advisory INDEX_GAP metadata. No re-index, WRE enqueue, shell, repo mutation, or network authority is added.
+- HOLOINDEX_READONLY_QUERY_GUARD_PHASE1 (v0.3.48): RedDog launches HoloIndex with `HOLOINDEX_QUERY_READONLY=1`; HoloIndex search/query mode is read-only by default, search-time auto-refresh requires explicit `--allow-auto-refresh`, and collection reset refuses read-only query contexts.
 
 ## Architecture Direction
 

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.47';
+const EXTENSION_VERSION = '0.3.48';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -4229,7 +4229,7 @@ function holoIndexOutput(root, taskText, maxChars) {
   const query = String(taskText || '').replace(/\s+/g, ' ').trim().slice(0, 500) || 'FoundUps RedDog WSP_00 WSP_97 WSP_15 current task';
   const moduleHint = moduleHintFromActive(root);
   try {
-    const env = Object.assign({}, process.env, { HOLO_SKIP_MODEL: '1' });
+    const env = Object.assign({}, process.env, { HOLO_SKIP_MODEL: '1', HOLOINDEX_QUERY_READONLY: '1' });
     const baseArgs = ['-B', 'holo_index.py', '--bundle-json', '--search', query, '--bundle-module-hint', moduleHint, '--limit', '5', '--quiet-root-alerts'];
     let output = cp.execFileSync('python', baseArgs, {
       cwd: root,
@@ -4305,6 +4305,7 @@ function holoIndexOutput(root, taskText, maxChars) {
     try {
       const output = cp.execFileSync('python', ['-B', 'holo_index.py', '--offline', '--search', query, '--limit', '5'], {
         cwd: root,
+        env,
         encoding: 'utf8',
         timeout: 20000,
         maxBuffer: Math.max(maxChars * 4, 65536),

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups\u00aeAgent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.47",
+    "version":  "0.3.48",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -197,8 +197,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.47', 'package version must be 0.3.47');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.47'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.48', 'package version must be 0.3.48');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.48'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups\u00aeAgent', 'display name must be Foundups\u00aeAgent');
 includes(JSON.stringify(pkg), 'Foundups\u00aeAgent: Open', 'command title must use Foundups\u00aeAgent');
@@ -215,7 +215,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.47', 'README version mismatch');
+includes(readme, 'Version: 0.3.48', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -1637,7 +1637,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.47'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.48'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -1651,7 +1651,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.47'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.48'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -1663,7 +1663,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.47'", 'bounded context must include extension.js source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.48'", 'bounded context must include extension.js source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -8290,3 +8290,11 @@ The complete DAE Memory System has been implemented:
 - Fixed the `AgentDB` schema/runtime mismatch that was breaking adaptive-learning startup on older databases (`agents_autonomous_tasks` missing `status`).
 - Fixed coordination-event ID collisions in `holo_index/adaptive_learning/breadcrumb_tracer.py` by replacing second-resolution IDs with UUID-backed runtime IDs.
 - Verified live HoloIndex searches no longer emit database errors on repeated generic queries such as `AionUI`.
+## 2026-07-12: HOLOINDEX_READONLY_QUERY_GUARD_PHASE1
+
+- Added a read-only query posture for HoloIndex runtime calls used by RedDog (`HOLOINDEX_QUERY_READONLY=1`).
+- Query/search mode now disables search-time auto-refresh by default; auto-refresh requires explicit `--allow-auto-refresh` and is never enabled under the read-only posture.
+- Guarded collection reset with `HOLOINDEX_READONLY_QUERY_GUARD` so a read-only query context cannot mutate the semantic store even if a write path is accidentally reached.
+- Updated Foundups(R)Agent RedDog HoloIndex invocations to pass `HOLOINDEX_QUERY_READONLY=1` for both bundle-json and offline fallback calls.
+- Read-only post-edit probe for `HOLOINDEX_READONLY_QUERY_GUARD_PHASE1 RedDog query read-only auto refresh guard` did not surface the new guard module/test as a canonical hit; recorded `HOLOINDEX_READONLY_QUERY_GUARD_INDEX_GAP_PHASE1`. No runtime re-index performed.
+- Tests: `holo_index/tests/test_holoindex_readonly_query_guard.py`.

--- a/holo_index/_cli_main.py
+++ b/holo_index/_cli_main.py
@@ -107,6 +107,52 @@ if "--fast-search" in sys.argv:
 def _env_truthy(name: str, default: str = "false") -> bool:
     return os.getenv(name, default).strip().lower() in ("1", "true", "yes", "y", "on")
 
+READONLY_QUERY_ENV = "HOLOINDEX_QUERY_READONLY"
+READONLY_GUARD_CODE = "HOLOINDEX_READONLY_QUERY_GUARD"
+_INDEX_FLAG_ATTRS = (
+    "index",
+    "index_all",
+    "index_code",
+    "index_wsp",
+    "index_symbols",
+    "index_skills",
+    "index_cli",
+    "index_work_ledger",
+    "index_docs",
+    "index_knowledge",
+)
+
+
+def _indexing_flags_requested(args) -> bool:
+    return any(bool(getattr(args, attr, False)) for attr in _INDEX_FLAG_ATTRS)
+
+
+def _query_only_requested(args) -> bool:
+    return bool(getattr(args, "bundle_json", False) or getattr(args, "search", None) or getattr(args, "offline", False) or getattr(args, "fast_search", False))
+
+
+def _readonly_query_env_enabled() -> bool:
+    return _env_truthy(READONLY_QUERY_ENV, "false")
+
+
+def _activate_readonly_query_posture(args) -> None:
+    if _query_only_requested(args) and not _indexing_flags_requested(args):
+        os.environ.setdefault(READONLY_QUERY_ENV, "1")
+
+
+def _reject_readonly_indexing(args) -> bool:
+    if _readonly_query_env_enabled() and _indexing_flags_requested(args):
+        safe_print(
+            f"[{READONLY_GUARD_CODE}] Refusing HoloIndex write/index flags in read-only query context. "
+            "Run indexing from WRE/CI/operator maintenance without HOLOINDEX_QUERY_READONLY=1."
+        )
+        return True
+    return False
+
+
+def _auto_refresh_allowed(args) -> bool:
+    return bool(getattr(args, "allow_auto_refresh", False)) and not _readonly_query_env_enabled()
+
 # 0102 speed knob: allow bundle-json/offline/fast-search fastpath without importing Chroma/model stack.
 _skip_heavy_imports = (
     ("--bundle-json" in sys.argv and _env_truthy("HOLO_SKIP_MODEL", "false")) or
@@ -680,6 +726,7 @@ def main():
     parser.add_argument('--ssd', type=str, default='E:/HoloIndex', help='SSD base path (default: E:/HoloIndex)')
     parser.add_argument('--offline', action='store_true', help='Disable model downloads and pip installs; use offline lexical search if needed')
     parser.add_argument('--fast-search', action='store_true', help='Fast retrieval-only mode (skips heavy advisory/orchestration steps)')
+    parser.add_argument('--allow-auto-refresh', action='store_true', help='Explicitly allow search-time index auto-refresh; never used by RedDog query/runtime paths')
 
     parser.add_argument('--llm-advisor', action='store_true', help='Force enable Qwen advisor guidance')
     parser.add_argument('--init-dae', type=str, nargs='?', const='auto', help='Initialize DAE context (auto-detect or specify DAE focus)')
@@ -740,6 +787,9 @@ def main():
     parser.add_argument('--collection-health-json', action='store_true', help='Output collection health as JSON')
 
     args = parser.parse_args()
+    _activate_readonly_query_posture(args)
+    if _reject_readonly_indexing(args):
+        raise SystemExit(2)
 
     # --- Bundle JSON (extracted to holo_index/cli/commands/bundle_json.py) ---
     from holo_index.cli.commands.bundle_json import handle_bundle_json
@@ -1134,7 +1184,7 @@ def main():
     # Check if indexes need automatic refresh (only if not explicitly indexing)
     auto_refreshed = False
     # WSP 97: Skip auto-refresh when holo is None (offline/fast mode)
-    if holo is not None and not (index_code or index_wsp or indexing_awarded):
+    if holo is not None and _auto_refresh_allowed(args) and not (index_code or index_wsp or indexing_awarded):
         try:
             from modules.infrastructure.database.src.agent_db import AgentDB
             db = AgentDB()

--- a/holo_index/core/holo_index.py
+++ b/holo_index/core/holo_index.py
@@ -463,6 +463,10 @@ class HoloIndex:
             return self.client.create_collection(name)
 
     def _reset_collection(self, name: str):
+        if os.getenv("HOLOINDEX_QUERY_READONLY", "").strip().lower() in {"1", "true", "yes", "y", "on"}:
+            raise RuntimeError(
+                "HOLOINDEX_READONLY_QUERY_GUARD: refusing collection reset in read-only query context"
+            )
         try:
             self.client.delete_collection(name)
         except Exception:

--- a/holo_index/tests/test_holoindex_readonly_query_guard.py
+++ b/holo_index/tests/test_holoindex_readonly_query_guard.py
@@ -1,0 +1,124 @@
+"""Tests for HOLOINDEX_READONLY_QUERY_GUARD_PHASE1."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+os.environ.setdefault("HOLO_SKIP_MODEL", "1")
+
+from holo_index import _cli_main
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _args(**overrides):
+    values = {
+        "bundle_json": False,
+        "search": None,
+        "offline": False,
+        "fast_search": False,
+        "allow_auto_refresh": False,
+        "index": False,
+        "index_all": False,
+        "index_code": False,
+        "index_wsp": False,
+        "index_symbols": False,
+        "index_skills": False,
+        "index_cli": False,
+        "index_work_ledger": False,
+        "index_docs": False,
+        "index_knowledge": False,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_query_mode_sets_readonly_env(monkeypatch) -> None:
+    monkeypatch.delenv(_cli_main.READONLY_QUERY_ENV, raising=False)
+
+    _cli_main._activate_readonly_query_posture(_args(search="RedDog WSP"))
+
+    assert os.environ[_cli_main.READONLY_QUERY_ENV] == "1"
+
+
+def test_manual_index_without_readonly_env_is_allowed(monkeypatch) -> None:
+    monkeypatch.delenv(_cli_main.READONLY_QUERY_ENV, raising=False)
+
+    _cli_main._activate_readonly_query_posture(_args(index_code=True))
+
+    assert _cli_main.READONLY_QUERY_ENV not in os.environ
+    assert _cli_main._reject_readonly_indexing(_args(index_code=True)) is False
+
+
+def test_readonly_env_rejects_index_flags(monkeypatch) -> None:
+    monkeypatch.setenv(_cli_main.READONLY_QUERY_ENV, "1")
+
+    assert _cli_main._reject_readonly_indexing(_args(index_docs=True)) is True
+
+
+def test_auto_refresh_requires_explicit_flag_and_non_readonly_env(monkeypatch) -> None:
+    monkeypatch.delenv(_cli_main.READONLY_QUERY_ENV, raising=False)
+    assert _cli_main._auto_refresh_allowed(_args(search="foo")) is False
+    assert _cli_main._auto_refresh_allowed(_args(search="foo", allow_auto_refresh=True)) is True
+
+    monkeypatch.setenv(_cli_main.READONLY_QUERY_ENV, "1")
+    assert _cli_main._auto_refresh_allowed(_args(search="foo", allow_auto_refresh=True)) is False
+
+
+def test_cli_rejects_readonly_indexing_before_writes() -> None:
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
+    env[_cli_main.READONLY_QUERY_ENV] = "1"
+    result = subprocess.run(
+        [sys.executable, "-B", "holo_index.py", "--offline", "--index-code"],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        timeout=30,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+    assert result.returncode == 2
+    assert _cli_main.READONLY_GUARD_CODE in (result.stdout + result.stderr)
+
+
+def test_cli_help_advertises_auto_refresh_opt_in() -> None:
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
+    env.setdefault("HOLO_SKIP_MODEL", "1")
+    result = subprocess.run(
+        [sys.executable, "-B", "holo_index.py", "--help"],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        timeout=30,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+    assert result.returncode == 0
+    assert "--allow-auto-refresh" in (result.stdout + result.stderr)
+
+
+def test_auto_refresh_branch_is_gated_in_cli_source() -> None:
+    source = (REPO_ROOT / "holo_index" / "_cli_main.py").read_text(encoding="utf-8")
+    assert "if holo is not None and _auto_refresh_allowed(args)" in source
+    assert "if holo is not None and not (index_code or index_wsp or indexing_awarded)" not in source
+
+
+def test_collection_reset_refuses_readonly_context() -> None:
+    source = (REPO_ROOT / "holo_index" / "core" / "holo_index.py").read_text(encoding="utf-8")
+    assert "HOLOINDEX_QUERY_READONLY" in source
+    assert "HOLOINDEX_READONLY_QUERY_GUARD" in source
+    assert "refusing collection reset in read-only query context" in source
+
+
+def test_reddog_extension_sets_readonly_env_for_holoindex_calls() -> None:
+    source = (REPO_ROOT / "extensions" / "foundups_advisory_workers" / "extension.js").read_text(encoding="utf-8")
+    assert "HOLOINDEX_QUERY_READONLY: '1'" in source
+    assert "HOLO_SKIP_MODEL: '1', HOLOINDEX_QUERY_READONLY: '1'" in source


### PR DESCRIPTION
## Summary

Implements `HOLOINDEX_READONLY_QUERY_GUARD_PHASE1` to harden the evidence-substrate boundary before further RedDog live authority.

- Adds `HOLOINDEX_QUERY_READONLY=1` read-only posture and `HOLOINDEX_READONLY_QUERY_GUARD` rejection for index/write attempts in query context.
- Gates search-time auto-refresh behind explicit `--allow-auto-refresh`; plain query/search no longer writes by default.
- Guards `HoloIndex._reset_collection()` so read-only query processes cannot reset/write collections even if a write path is accidentally reached.
- Threads `HOLOINDEX_QUERY_READONLY=1` into Foundups(R)Agent RedDog HoloIndex bundle-json and offline fallback calls.
- Bumps Foundups(R)Agent extension build label to `0.3.48` so host validation can prove the new runtime posture is installed.

## Verification

- `python -m pytest holo_index\tests\test_holoindex_readonly_query_guard.py` -> 9 passed
- `python -m pytest holo_index\tests\test_holoindex_readonly_query_guard.py holo_index\tests\test_holoindex_freshness_governance_doc.py holo_index\tests\test_work_ledger_indexing.py::TestCLITargetedReindex holo_index\tests\test_work_ledger_indexing.py::TestCLIFlagParsing` -> 44 passed
- `node extensions\foundups_advisory_workers\tests\verify_extension_contract.js` -> passed (pre-existing UnicodeEncodeError stderr noise remains; exit 0 and success line emitted)
- `git diff --check` -> clean (autocrlf warnings only)
- Diff additions ASCII scan -> 0 non-ASCII

## HoloIndex

Read-only post-edit probe:

`HOLOINDEX_QUERY_READONLY=1 python holo_index.py --search "HOLOINDEX_READONLY_QUERY_GUARD_PHASE1 RedDog query read-only auto refresh guard" --bundle-json --limit 8`

The probe succeeded without re-indexing. It did not surface the new guard module/test as a canonical hit, so `HOLOINDEX_READONLY_QUERY_GUARD_INDEX_GAP_PHASE1` is recorded in `holo_index/ModLog.md`.

## Truth Boundary Checklist

- REDDOG_QUERY_PATH_READONLY: PASS
- SEARCH_AUTO_REFRESH_DEFAULT_DISABLED: PASS
- AUTO_REFRESH_REQUIRES_EXPLICIT_FLAG: PASS
- COLLECTION_RESET_GUARDED_IN_READONLY_CONTEXT: PASS
- NO_RUNTIME_REINDEX_PERFORMED: PASS
- NO_RANKING_CODE_CHANGE: PASS
- NO_WRE_CI_INDEX_WORKITEM: PASS (future slice)
- NO_LIVE_MERGE_AUTHORITY: PASS

## Residual SPECIFIED_NOT_IMPLEMENTED

- `HOLOINDEX_FRESHNESS_RECEIPT_PHASE1`
- `HOLOINDEX_INDEX_GAP_TO_WRE_WORKITEM_PHASE1`
- `HOLOINDEX_CI_FRESHNESS_GATE_PHASE1`
- `HOLOINDEX_INCREMENTAL_PER_FOUNDUP_INDEX_PHASE1`
- Host install/reload of Foundups(R)Agent `0.3.48`

Worker-Lane: codex
Slice: HOLOINDEX_READONLY_QUERY_GUARD_PHASE1