### PR TITLE
feat(holoindex): emit freshness receipt

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,15 @@
 # HoloIndex Package ModLog
 
+## [2026-07-12] HOLOINDEX_FRESHNESS_RECEIPT_PHASE1
+
+**Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice
+**WSP**: 00, 15, 22, 50, 97 | **Base**: `dde962bb5`
+
+- ADD `holo_index/freshness_receipt.py`: durable `holoindex_freshness_receipt.json` schema with per-collection counts/status/source/repo SHA, path-to-collection freshness mapping, JSON roundtrip, and fail-closed `evaluate_freshness_for_paths`.
+- UPDATE `_cli_main.py`: existing `_write_index_state(source)` now also writes the freshness receipt beside `index_state.json` after manual index or explicitly allowed auto-refresh. Query/search paths remain read-only and no runtime re-index is introduced.
+- TEST `tests/test_holoindex_freshness_receipt.py`: all expected collections, roundtrip, changed-path routing, missing/stale/empty receipt failures, and CLI writer contract anchors.
+- HoloIndex read-only probe for `HOLOINDEX_FRESHNESS_RECEIPT_PHASE1 index_state freshness receipt collection SHA changed paths` did not surface the new receipt module before re-index. Recorded as `HOLOINDEX_FRESHNESS_RECEIPT_INDEX_GAP_PHASE1`; no runtime re-index performed.
+
 ## [2026-07-06] HOLOINDEX_FRESHNESS_AND_SCALING_GOVERNANCE_PHASE1 (decision-only audit)
 
 **Agent**: 0102 (RedDog Architect) | Commander: 012 | Gate: VERIFIED_READY draft PR (do NOT self-merge)

--- a/holo_index/_cli_main.py
+++ b/holo_index/_cli_main.py
@@ -41,6 +41,11 @@ if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
 from typing import Any, Dict, List, Optional, Tuple
 from dataclasses import asdict
+from holo_index.freshness_receipt import (
+    build_freshness_receipt,
+    freshness_receipt_path,
+    write_freshness_receipt,
+)
 from holo_index.utils.helpers import safe_print
 # WSP 97: Lazy import codeindex_reporter (4s+ startup cost) - only needed for --code-index-report
 CodeIndexReporter = None  # Lazy loaded
@@ -996,6 +1001,13 @@ def main():
         try:
             state_path = Path(args.ssd) / "indexes" / "index_state.json"
             state_path.parent.mkdir(parents=True, exist_ok=True)
+            receipt_path = freshness_receipt_path(Path(args.ssd))
+            receipt = build_freshness_receipt(
+                holo,
+                ssd_path=Path(args.ssd),
+                repo_root=project_root,
+                source=source,
+            )
             state = {
                 "last_indexed_at": datetime.now(timezone.utc).isoformat(),
                 "ssd_path": str(Path(args.ssd)),
@@ -1004,8 +1016,10 @@ def main():
                 "wsp_count": holo.get_wsp_entry_count(),
                 "test_count": _safe_count(getattr(holo, "test_collection", None)),
                 "skillz_count": _safe_count(getattr(holo, "skill_collection", None)),
+                "freshness_receipt_path": str(receipt_path),
             }
             state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+            write_freshness_receipt(receipt, receipt_path)
         except Exception as e:
             if verbose:
                 safe_print(f"[WARN] Failed to write index state: {e}")

--- a/holo_index/freshness_receipt.py
+++ b/holo_index/freshness_receipt.py
@@ -1,0 +1,349 @@
+"""HoloIndex freshness receipt helpers.
+
+WSP 97: freshness is evidence, not an assumption. Missing receipts or missing
+collection entries fail closed for write-sensitive RedDog/WRE gates.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+
+SCHEMA_VERSION = "holoindex_freshness_receipt.v1"
+FRESHNESS_RECEIPT_FILENAME = "holoindex_freshness_receipt.json"
+
+COLLECTION_ATTRS: dict[str, str] = {
+    "navigation_code": "code_collection",
+    "navigation_wsp": "wsp_collection",
+    "navigation_tests": "test_collection",
+    "navigation_skills": "skill_collection",
+    "navigation_symbols": "symbol_collection",
+    "navigation_docs": "docs_collection",
+    "navigation_knowledge": "knowledge_collection",
+    "navigation_work_ledger": "work_ledger_collection",
+    "navigation_vocabulary": "vocabulary_collection",
+}
+
+ALL_COLLECTIONS: tuple[str, ...] = tuple(COLLECTION_ATTRS)
+
+
+@dataclass(frozen=True)
+class CollectionFreshness:
+    """Freshness metadata for one HoloIndex collection."""
+
+    name: str
+    count: int
+    status: str
+    source: str
+    repo_head_sha: str
+    last_indexed_at: str
+
+
+@dataclass(frozen=True)
+class HoloIndexFreshnessReceipt:
+    """Durable receipt emitted after HoloIndex maintenance writes."""
+
+    schema_version: str
+    generated_at: str
+    repo_root: str
+    repo_head_sha: str
+    ssd_path: str
+    source: str
+    collections: list[CollectionFreshness] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True)
+
+
+@dataclass(frozen=True)
+class FreshnessCheck:
+    """Result of checking whether a receipt covers changed paths."""
+
+    ok: bool
+    required_collections: list[str]
+    stale_collections: list[str]
+    reasons: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def freshness_receipt_path(ssd_path: Path | str) -> Path:
+    return Path(ssd_path) / "indexes" / FRESHNESS_RECEIPT_FILENAME
+
+
+def _safe_count(collection: Any) -> int:
+    if collection is None:
+        return 0
+    try:
+        return int(collection.count())
+    except Exception:
+        return 0
+
+
+def _collection_status(collection: Any, count: int) -> str:
+    if collection is None:
+        return "missing"
+    if count <= 0:
+        return "empty"
+    return "indexed"
+
+
+def _resolve_git_dir(repo_root: Path) -> Path | None:
+    git_entry = repo_root / ".git"
+    if git_entry.is_dir():
+        return git_entry
+    if git_entry.is_file():
+        try:
+            text = git_entry.read_text(encoding="utf-8").strip()
+        except Exception:
+            return None
+        prefix = "gitdir:"
+        if text.lower().startswith(prefix):
+            raw_path = text[len(prefix):].strip()
+            git_dir = Path(raw_path)
+            if not git_dir.is_absolute():
+                git_dir = (repo_root / git_dir).resolve()
+            return git_dir
+    return None
+
+
+def read_git_head_sha(repo_root: Path | str) -> str:
+    """Read the current git HEAD SHA without invoking git."""
+
+    root = Path(repo_root)
+    git_dir = _resolve_git_dir(root)
+    if git_dir is None:
+        return "unknown"
+    head_path = git_dir / "HEAD"
+    try:
+        head = head_path.read_text(encoding="utf-8").strip()
+    except Exception:
+        return "unknown"
+    ref_prefix = "ref:"
+    if not head.startswith(ref_prefix):
+        return head or "unknown"
+    ref_name = head[len(ref_prefix):].strip()
+    ref_path = git_dir / ref_name
+    try:
+        sha = ref_path.read_text(encoding="utf-8").strip()
+        if sha:
+            return sha
+    except Exception:
+        pass
+    packed_refs = git_dir / "packed-refs"
+    try:
+        for line in packed_refs.read_text(encoding="utf-8").splitlines():
+            if not line or line.startswith("#") or line.startswith("^"):
+                continue
+            parts = line.split(" ", 1)
+            if len(parts) == 2 and parts[1].strip() == ref_name:
+                return parts[0].strip()
+    except Exception:
+        pass
+    return "unknown"
+
+
+def build_freshness_receipt(
+    holo: Any,
+    *,
+    ssd_path: Path | str,
+    repo_root: Path | str,
+    source: str,
+    generated_at: str | None = None,
+    repo_head_sha: str | None = None,
+) -> HoloIndexFreshnessReceipt:
+    """Build a receipt from the current HoloIndex collection handles."""
+
+    generated = generated_at or utc_now_iso()
+    head_sha = repo_head_sha or read_git_head_sha(repo_root)
+    collections: list[CollectionFreshness] = []
+    for name, attr_name in COLLECTION_ATTRS.items():
+        collection = getattr(holo, attr_name, None)
+        if collection is None and name == "navigation_vocabulary":
+            client = getattr(holo, "client", None)
+            if client is not None:
+                try:
+                    collection = client.get_collection(name)
+                except Exception:
+                    collection = None
+        count = _safe_count(collection)
+        collections.append(
+            CollectionFreshness(
+                name=name,
+                count=count,
+                status=_collection_status(collection, count),
+                source=source,
+                repo_head_sha=head_sha,
+                last_indexed_at=generated,
+            )
+        )
+
+    return HoloIndexFreshnessReceipt(
+        schema_version=SCHEMA_VERSION,
+        generated_at=generated,
+        repo_root=str(Path(repo_root)),
+        repo_head_sha=head_sha,
+        ssd_path=str(Path(ssd_path)),
+        source=source,
+        collections=collections,
+    )
+
+
+def write_freshness_receipt(receipt: HoloIndexFreshnessReceipt, path: Path | str) -> None:
+    receipt_path = Path(path)
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_text(receipt.to_json() + "\n", encoding="utf-8")
+
+
+def load_freshness_receipt(path: Path | str) -> HoloIndexFreshnessReceipt:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    collections = [CollectionFreshness(**entry) for entry in data.get("collections", [])]
+    return HoloIndexFreshnessReceipt(
+        schema_version=data.get("schema_version", ""),
+        generated_at=data.get("generated_at", ""),
+        repo_root=data.get("repo_root", ""),
+        repo_head_sha=data.get("repo_head_sha", ""),
+        ssd_path=data.get("ssd_path", ""),
+        source=data.get("source", ""),
+        collections=collections,
+    )
+
+
+def _norm_path(path: str | Path) -> str:
+    text = str(path).replace("\\", "/").strip()
+    while text.startswith("./"):
+        text = text[2:]
+    return text
+
+
+def collections_for_path(path: str | Path) -> set[str]:
+    """Return collections that should be fresh for a changed path."""
+
+    p = _norm_path(path)
+    lower = p.lower()
+    name = Path(p).name
+    collections: set[str] = set()
+
+    if not p or p.startswith("../") or p.startswith("/"):
+        return collections
+
+    if p.startswith("WSP_framework/src/") and name.startswith("WSP_") and lower.endswith(".md"):
+        collections.add("navigation_wsp")
+    elif p.startswith("WSP_knowledge/docs/Papers/"):
+        collections.add("navigation_knowledge")
+    elif p.startswith("docs/0102_session_briefings/") or name in {
+        "ACTIVE_SLICE_LEDGER.md",
+        "work_ledger.schema.json",
+    }:
+        collections.add("navigation_work_ledger")
+    elif name == "SKILLz.md":
+        collections.add("navigation_skills")
+    elif "/tests/" in p or name.startswith("test_"):
+        collections.add("navigation_tests")
+    elif lower.endswith("navigation.py") or lower.endswith((".js", ".ts", ".tsx", ".jsx", ".html", ".css")):
+        collections.add("navigation_code")
+    elif lower.endswith(".py"):
+        collections.add("navigation_symbols")
+    elif lower.endswith((".md", ".json", ".yaml", ".yml", ".txt")):
+        collections.add("navigation_docs")
+
+    return collections
+
+
+def collections_for_changed_paths(paths: Iterable[str | Path]) -> list[str]:
+    collections: set[str] = set()
+    for path in paths:
+        collections.update(collections_for_path(path))
+    return sorted(collections)
+
+
+def evaluate_freshness_for_paths(
+    receipt: HoloIndexFreshnessReceipt | Mapping[str, Any] | None,
+    changed_paths: Iterable[str | Path],
+    *,
+    expected_repo_head_sha: str | None = None,
+) -> FreshnessCheck:
+    """Fail-closed freshness check for write-sensitive consumers."""
+
+    required = collections_for_changed_paths(changed_paths)
+    if receipt is None:
+        return FreshnessCheck(False, required, required, ["missing_freshness_receipt"])
+
+    if isinstance(receipt, Mapping):
+        try:
+            receipt = HoloIndexFreshnessReceipt(
+                schema_version=str(receipt.get("schema_version", "")),
+                generated_at=str(receipt.get("generated_at", "")),
+                repo_root=str(receipt.get("repo_root", "")),
+                repo_head_sha=str(receipt.get("repo_head_sha", "")),
+                ssd_path=str(receipt.get("ssd_path", "")),
+                source=str(receipt.get("source", "")),
+                collections=[
+                    CollectionFreshness(**entry)
+                    for entry in receipt.get("collections", [])
+                    if isinstance(entry, Mapping)
+                ],
+            )
+        except Exception:
+            return FreshnessCheck(False, required, required, ["malformed_freshness_receipt"])
+
+    reasons: list[str] = []
+    stale: set[str] = set()
+    if receipt.schema_version != SCHEMA_VERSION:
+        reasons.append("unsupported_freshness_receipt_schema")
+        stale.update(required)
+    if expected_repo_head_sha and receipt.repo_head_sha != expected_repo_head_sha:
+        reasons.append("stale_repo_head_sha")
+        stale.update(required)
+
+    by_name = {entry.name: entry for entry in receipt.collections}
+    for name in required:
+        entry = by_name.get(name)
+        if entry is None:
+            stale.add(name)
+            reasons.append(f"missing_collection_receipt:{name}")
+            continue
+        if entry.status != "indexed" or entry.count <= 0:
+            stale.add(name)
+            reasons.append(f"collection_not_indexed:{name}")
+        if expected_repo_head_sha and entry.repo_head_sha != expected_repo_head_sha:
+            stale.add(name)
+            reasons.append(f"stale_collection_sha:{name}")
+
+    return FreshnessCheck(
+        ok=not stale and not reasons,
+        required_collections=required,
+        stale_collections=sorted(stale),
+        reasons=reasons,
+    )
+
+
+__all__ = [
+    "ALL_COLLECTIONS",
+    "COLLECTION_ATTRS",
+    "CollectionFreshness",
+    "FreshnessCheck",
+    "FRESHNESS_RECEIPT_FILENAME",
+    "HoloIndexFreshnessReceipt",
+    "SCHEMA_VERSION",
+    "build_freshness_receipt",
+    "collections_for_changed_paths",
+    "collections_for_path",
+    "evaluate_freshness_for_paths",
+    "freshness_receipt_path",
+    "load_freshness_receipt",
+    "read_git_head_sha",
+    "write_freshness_receipt",
+]

--- a/holo_index/tests/test_holoindex_freshness_receipt.py
+++ b/holo_index/tests/test_holoindex_freshness_receipt.py
@@ -1,0 +1,199 @@
+"""Tests for HOLOINDEX_FRESHNESS_RECEIPT_PHASE1."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from holo_index.freshness_receipt import (
+    ALL_COLLECTIONS,
+    SCHEMA_VERSION,
+    build_freshness_receipt,
+    collections_for_changed_paths,
+    evaluate_freshness_for_paths,
+    freshness_receipt_path,
+    load_freshness_receipt,
+    write_freshness_receipt,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class CountCollection:
+    def __init__(self, count: int):
+        self._count = count
+
+    def count(self) -> int:
+        return self._count
+
+
+def _holo(**counts: int):
+    attr_map = {
+        "navigation_code": "code_collection",
+        "navigation_wsp": "wsp_collection",
+        "navigation_tests": "test_collection",
+        "navigation_skills": "skill_collection",
+        "navigation_symbols": "symbol_collection",
+        "navigation_docs": "docs_collection",
+        "navigation_knowledge": "knowledge_collection",
+        "navigation_work_ledger": "work_ledger_collection",
+        "navigation_vocabulary": "vocabulary_collection",
+    }
+    values = {}
+    for collection_name, attr_name in attr_map.items():
+        values[attr_name] = CountCollection(counts.get(collection_name, 3))
+    return SimpleNamespace(**values)
+
+
+def test_receipt_contains_all_expected_collections(tmp_path: Path) -> None:
+    receipt = build_freshness_receipt(
+        _holo(),
+        ssd_path=tmp_path,
+        repo_root=REPO_ROOT,
+        source="manual_index",
+        generated_at="2026-07-12T00:00:00+00:00",
+        repo_head_sha="abc123",
+    )
+
+    assert receipt.schema_version == SCHEMA_VERSION
+    assert receipt.repo_head_sha == "abc123"
+    assert receipt.source == "manual_index"
+    assert [entry.name for entry in receipt.collections] == list(ALL_COLLECTIONS)
+    assert all(entry.status == "indexed" for entry in receipt.collections)
+
+
+def test_receipt_roundtrip_json(tmp_path: Path) -> None:
+    receipt = build_freshness_receipt(
+        _holo(**{"navigation_skills": 0}),
+        ssd_path=tmp_path,
+        repo_root=REPO_ROOT,
+        source="manual_index",
+        generated_at="2026-07-12T00:00:00+00:00",
+        repo_head_sha="abc123",
+    )
+    path = freshness_receipt_path(tmp_path)
+
+    write_freshness_receipt(receipt, path)
+    loaded = load_freshness_receipt(path)
+
+    assert loaded.to_dict() == receipt.to_dict()
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    assert raw["collections"][3]["name"] == "navigation_skills"
+    assert raw["collections"][3]["status"] == "empty"
+
+
+def test_changed_paths_map_to_freshness_collections() -> None:
+    paths = [
+        "WSP_framework/src/WSP_97_System_Execution_Prompting_Protocol.md",
+        "modules/foundups/agent/src/create_foundup_dryrun.py",
+        "modules/foundups/agent/tests/test_create_foundup_dryrun.py",
+        "modules/foundups/agent/README.md",
+        "modules/foundups/agent/SKILLz.md",
+        "docs/0102_session_briefings/work_ledger.schema.json",
+        "WSP_knowledge/docs/Papers/PQN_Deep_Dive.md",
+        "extensions/foundups_advisory_workers/extension.js",
+    ]
+
+    assert collections_for_changed_paths(paths) == [
+        "navigation_code",
+        "navigation_docs",
+        "navigation_knowledge",
+        "navigation_skills",
+        "navigation_symbols",
+        "navigation_tests",
+        "navigation_work_ledger",
+        "navigation_wsp",
+    ]
+
+
+def test_missing_receipt_fails_closed_for_changed_paths() -> None:
+    check = evaluate_freshness_for_paths(
+        None,
+        ["modules/foundups/agent/src/create_foundup_dryrun.py"],
+        expected_repo_head_sha="abc123",
+    )
+
+    assert check.ok is False
+    assert check.required_collections == ["navigation_symbols"]
+    assert check.stale_collections == ["navigation_symbols"]
+    assert "missing_freshness_receipt" in check.reasons
+
+
+def test_missing_required_collection_receipt_fails_closed(tmp_path: Path) -> None:
+    receipt = build_freshness_receipt(
+        _holo(),
+        ssd_path=tmp_path,
+        repo_root=REPO_ROOT,
+        source="manual_index",
+        generated_at="2026-07-12T00:00:00+00:00",
+        repo_head_sha="abc123",
+    )
+    partial = receipt.to_dict()
+    partial["collections"] = [
+        entry for entry in partial["collections"] if entry["name"] != "navigation_symbols"
+    ]
+
+    check = evaluate_freshness_for_paths(
+        partial,
+        ["modules/foundups/agent/src/create_foundup_dryrun.py"],
+        expected_repo_head_sha="abc123",
+    )
+
+    assert check.ok is False
+    assert check.stale_collections == ["navigation_symbols"]
+    assert "missing_collection_receipt:navigation_symbols" in check.reasons
+
+
+def test_stale_repo_sha_fails_closed_for_required_collections(tmp_path: Path) -> None:
+    receipt = build_freshness_receipt(
+        _holo(),
+        ssd_path=tmp_path,
+        repo_root=REPO_ROOT,
+        source="manual_index",
+        generated_at="2026-07-12T00:00:00+00:00",
+        repo_head_sha="old",
+    )
+
+    check = evaluate_freshness_for_paths(
+        receipt,
+        [
+            "WSP_framework/src/WSP_97_System_Execution_Prompting_Protocol.md",
+            "docs/0102_session_briefings/ACTIVE_SLICE_LEDGER.md",
+        ],
+        expected_repo_head_sha="new",
+    )
+
+    assert check.ok is False
+    assert check.stale_collections == ["navigation_work_ledger", "navigation_wsp"]
+    assert "stale_repo_head_sha" in check.reasons
+
+
+def test_empty_collection_fails_closed_when_path_requires_it(tmp_path: Path) -> None:
+    receipt = build_freshness_receipt(
+        _holo(**{"navigation_work_ledger": 0}),
+        ssd_path=tmp_path,
+        repo_root=REPO_ROOT,
+        source="manual_index",
+        generated_at="2026-07-12T00:00:00+00:00",
+        repo_head_sha="abc123",
+    )
+
+    check = evaluate_freshness_for_paths(
+        receipt,
+        ["docs/0102_session_briefings/ACTIVE_SLICE_LEDGER.md"],
+        expected_repo_head_sha="abc123",
+    )
+
+    assert check.ok is False
+    assert check.stale_collections == ["navigation_work_ledger"]
+    assert "collection_not_indexed:navigation_work_ledger" in check.reasons
+
+
+def test_cli_index_state_writer_emits_freshness_receipt_contract() -> None:
+    source = (REPO_ROOT / "holo_index" / "_cli_main.py").read_text(encoding="utf-8")
+
+    assert "build_freshness_receipt(" in source
+    assert "write_freshness_receipt(receipt, receipt_path)" in source
+    assert '"freshness_receipt_path": str(receipt_path)' in source
+    assert "HOLOINDEX_QUERY_READONLY" in source


### PR DESCRIPTION
## Summary
- add `holo_index/freshness_receipt.py` with a durable per-collection freshness receipt schema
- write `holoindex_freshness_receipt.json` beside `index_state.json` after manual index or explicitly allowed auto-refresh
- add fail-closed freshness evaluation for changed paths and tests for missing/stale/empty receipts

## WSP_97 Truth Boundary
- OBSERVED: query/read-only paths remain non-mutating; this slice only writes during the existing index-state write path
- OBSERVED: no runtime re-index, ranking-code change, RedDog self-reindex, or WRE enqueue added
- OBSERVED: post-edit read-only HoloIndex probe did not surface the new receipt module/test as canonical semantic hits
- SPECIFIED_NOT_IMPLEMENTED: `HOLOINDEX_INDEX_GAP_TO_WRE_WORKITEM_PHASE1`, `HOLOINDEX_CI_FRESHNESS_GATE_PHASE1`, and incremental per-FoundUp indexing

## Validation
- `python -m pytest holo_index\tests\test_holoindex_freshness_receipt.py` -> 8 passed
- `python -m pytest holo_index\tests\test_holoindex_readonly_query_guard.py` -> 9 passed
- `python -m pytest holo_index\tests\test_holoindex_freshness_receipt.py holo_index\tests\test_holoindex_readonly_query_guard.py holo_index\tests\test_holoindex_freshness_governance_doc.py holo_index\tests\test_work_ledger_indexing.py::TestCLITargetedReindex holo_index\tests\test_work_ledger_indexing.py::TestCLIFlagParsing` -> 52 passed
- `python -m pytest holo_index\tests\test_collection_health.py` -> 27 passed
- `python -m compileall -q holo_index\freshness_receipt.py` -> passed
- `git diff --check` -> clean (autocrlf warnings only)
- added/new-file byte scan -> 0 non-ASCII / 0 NUL

## HoloIndex
- Pre/post read-only probe: `HOLOINDEX_FRESHNESS_RECEIPT_PHASE1 index_state freshness receipt collection SHA changed paths`
- Result: ModLog anchor surfaced; new receipt module/test not semantically indexed yet
- Recorded follow-up: `HOLOINDEX_FRESHNESS_RECEIPT_INDEX_GAP_PHASE1`