### PR TITLE
feat(holoindex): plan WRE work items for index gaps

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,15 @@
 # HoloIndex Package ModLog
 
+## [2026-07-12] HOLOINDEX_INDEX_GAP_TO_WRE_WORKITEM_PHASE1
+
+**Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice
+**WSP**: 00, 15, 22, 50, 97 | **Base**: `af86b77b`
+
+- ADD `holo_index/index_gap_workitem.py`: deterministic, non-mutating planner that classifies INDEX_GAP into the four recorded taxonomy classes and emits a WRE-owned work-item envelope. Only `HOLOINDEX_STALE_INDEX` plans `targeted_reindex`; `HOLOINDEX_LOW_SIGNAL` routes to retrieval-quality work, runtime failures route to runtime repair, and tool-classifier failures route to classifier repair.
+- UPDATE `reddog_adversarial_verifier_panel.build_index_gap_event`: the advisory INDEX_GAP event now carries a planned `wre_work_item` payload while preserving `live_wre_enqueue_performed=false`, `no_reindex_performed=true`, and `no_agentdb_mutation_performed=true`.
+- TEST `tests/test_holoindex_index_gap_workitem.py` and verifier panel regression: deterministic IDs, changed-path collection mapping, taxonomy routing, receipt digesting, no AgentDB/subprocess/OpenClaw imports, and non-mutating advisory event boundaries.
+- HoloIndex read-only probe for `HOLOINDEX_INDEX_GAP_TO_WRE_WORKITEM_PHASE1 INDEX_GAP WRE work item freshness receipt RedDog verifier` did not surface a canonical work-item planner before re-index. Recorded as `HOLOINDEX_INDEX_GAP_TO_WRE_WORKITEM_INDEX_GAP_PHASE1`; no runtime re-index performed.
+
 ## [2026-07-12] HOLOINDEX_FRESHNESS_RECEIPT_PHASE1
 
 **Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice

--- a/holo_index/index_gap_workitem.py
+++ b/holo_index/index_gap_workitem.py
@@ -1,0 +1,253 @@
+"""Plan WRE work items from HoloIndex INDEX_GAP evidence.
+
+This module does not enqueue tasks or run HoloIndex indexing. It turns an
+already-observed gap into a deterministic work-item envelope that a later WRE/CI
+owner can consume under its own gate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any, Iterable, Mapping
+
+from holo_index.freshness_receipt import collections_for_changed_paths
+
+
+GAP_TOOL_CLASSIFIER_UNAVAILABLE = "TOOL_CLASSIFIER_UNAVAILABLE"
+GAP_HOLOINDEX_LOW_SIGNAL = "HOLOINDEX_LOW_SIGNAL"
+GAP_HOLOINDEX_STALE_INDEX = "HOLOINDEX_STALE_INDEX"
+GAP_HOLOINDEX_RUNTIME_FAILURE = "HOLOINDEX_RUNTIME_FAILURE"
+
+ACTION_TARGETED_REINDEX = "targeted_reindex"
+ACTION_RETRIEVAL_QUALITY_SLICE = "retrieval_quality_slice"
+ACTION_RUNTIME_REPAIR = "runtime_repair"
+ACTION_TOOL_CLASSIFIER_REPAIR = "tool_classifier_repair"
+
+WORKITEM_PLANNED = "WORKITEM_PLANNED"
+NO_INDEX_GAP = "NO_INDEX_GAP"
+WORKITEM_REJECTED = "WORKITEM_REJECTED"
+
+WRE_OWNER = "WRE_CI_INDEX_MAINTENANCE"
+
+
+@dataclass(frozen=True)
+class HoloIndexIndexGapWorkItem:
+    """Typed, non-mutating WRE intake envelope for an INDEX_GAP."""
+
+    work_item_id: str
+    gap_class: str
+    recommended_action: str
+    owner: str
+    query: str
+    target_paths: list[str] = field(default_factory=list)
+    target_collections: list[str] = field(default_factory=list)
+    required_targets_missing: list[str] = field(default_factory=list)
+    observed_hits: list[str] = field(default_factory=list)
+    priority: str = "P2"
+    freshness_receipt_digest: str | None = None
+    scorecard_digest: str = ""
+    live_wre_enqueue_performed: bool = False
+    no_reindex_performed: bool = True
+    no_agentdb_mutation_performed: bool = True
+    no_runtime_reindex_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class HoloIndexIndexGapWorkItemResult:
+    decision: str
+    gap_class: str | None = None
+    work_item: HoloIndexIndexGapWorkItem | None = None
+    rejection_reasons: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        if self.work_item is not None:
+            payload["work_item"] = self.work_item.to_dict()
+        return payload
+
+
+def _as_list(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, (list, tuple)) else []
+
+
+def _dedupe_str(values: Iterable[Any]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if isinstance(value, Mapping):
+            value = value.get("path") or value.get("location") or value.get("target")
+        text = str(value or "").strip()
+        if not text:
+            continue
+        key = text.replace("\\", "/").lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(text.replace("\\", "/"))
+    return out
+
+
+def _canonical_digest(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _scorecard_digest(scorecard: Mapping[str, Any]) -> str:
+    return _canonical_digest(dict(scorecard))
+
+
+def _receipt_digest(receipt: Mapping[str, Any] | None) -> str | None:
+    if not receipt:
+        return None
+    return _canonical_digest(dict(receipt))
+
+
+def _observed_hit_paths(scorecard: Mapping[str, Any]) -> list[str]:
+    hits: list[Any] = []
+    for key in ("code_hits", "wsp_hits", "skill_hits", "docs_hits", "symbol_hits", "work_ledger_hits"):
+        hits.extend(_as_list(scorecard.get(key)))
+    return _dedupe_str(hits)
+
+
+def _target_paths(scorecard: Mapping[str, Any], index_gap_event: Mapping[str, Any] | None) -> list[str]:
+    values: list[Any] = []
+    values.extend(_as_list(scorecard.get("direct_read_paths")))
+    values.extend(_as_list(scorecard.get("required_targets_missing")))
+    values.extend(_as_list(scorecard.get("required_targets_context_missing")))
+    if index_gap_event:
+        values.extend(_as_list(index_gap_event.get("stale_targets")))
+    return _dedupe_str(values)
+
+
+def index_gap_detected(scorecard: Mapping[str, Any]) -> bool:
+    return (
+        bool(scorecard.get("index_gap_detected"))
+        or str(scorecard.get("retrieval_quality") or "").upper() == "INDEX_GAP"
+        or bool(scorecard.get("direct_read_fallback_used"))
+    )
+
+
+def classify_index_gap(scorecard: Mapping[str, Any]) -> str | None:
+    """Classify an INDEX_GAP into the governance taxonomy."""
+
+    if not isinstance(scorecard, Mapping):
+        return None
+
+    tool_status = str(scorecard.get("tool_classifier_status") or "").lower()
+    if tool_status in {"unavailable", "missing", "failed"} or scorecard.get("tool_classifier_unavailable") is True:
+        return GAP_TOOL_CLASSIFIER_UNAVAILABLE
+
+    fetch_error = str(scorecard.get("direct_read_fetch_error") or "").strip()
+    holo_status = str(scorecard.get("holoindex_status") or "").lower()
+    if fetch_error not in {"", "(none)", "none"} or holo_status in {"error", "runtime_failure", "failed"}:
+        return GAP_HOLOINDEX_RUNTIME_FAILURE
+
+    if not index_gap_detected(scorecard):
+        return None
+
+    direct_paths = _dedupe_str(_as_list(scorecard.get("direct_read_paths")))
+    if direct_paths and (scorecard.get("direct_read_fallback_used") is True or scorecard.get("target_recall_ok") is True):
+        return GAP_HOLOINDEX_STALE_INDEX
+
+    if direct_paths and str(scorecard.get("retrieval_quality") or "").upper() == "INDEX_GAP":
+        return GAP_HOLOINDEX_STALE_INDEX
+
+    return GAP_HOLOINDEX_LOW_SIGNAL
+
+
+def _action_for_gap(gap_class: str) -> str:
+    if gap_class == GAP_HOLOINDEX_STALE_INDEX:
+        return ACTION_TARGETED_REINDEX
+    if gap_class == GAP_HOLOINDEX_RUNTIME_FAILURE:
+        return ACTION_RUNTIME_REPAIR
+    if gap_class == GAP_TOOL_CLASSIFIER_UNAVAILABLE:
+        return ACTION_TOOL_CLASSIFIER_REPAIR
+    return ACTION_RETRIEVAL_QUALITY_SLICE
+
+
+def _priority_for_gap(gap_class: str) -> str:
+    if gap_class in {GAP_HOLOINDEX_STALE_INDEX, GAP_HOLOINDEX_RUNTIME_FAILURE}:
+        return "P1"
+    return "P2"
+
+
+def plan_index_gap_work_item(
+    scorecard: Mapping[str, Any] | None,
+    *,
+    index_gap_event: Mapping[str, Any] | None = None,
+    freshness_receipt: Mapping[str, Any] | None = None,
+) -> HoloIndexIndexGapWorkItemResult:
+    """Plan a non-mutating WRE work item for a HoloIndex gap."""
+
+    if not isinstance(scorecard, Mapping):
+        return HoloIndexIndexGapWorkItemResult(
+            decision=WORKITEM_REJECTED,
+            rejection_reasons=["malformed_scorecard"],
+        )
+
+    gap_class = classify_index_gap(scorecard)
+    if not gap_class:
+        return HoloIndexIndexGapWorkItemResult(decision=NO_INDEX_GAP)
+
+    target_paths = _target_paths(scorecard, index_gap_event)
+    target_collections = collections_for_changed_paths(target_paths)
+    required_missing = _dedupe_str(_as_list(scorecard.get("required_targets_missing")))
+    observed_hits = _observed_hit_paths(scorecard)
+    action = _action_for_gap(gap_class)
+    query = str(scorecard.get("query") or scorecard.get("task") or "")
+    score_digest = _scorecard_digest(scorecard)
+    seed = {
+        "gap_class": gap_class,
+        "recommended_action": action,
+        "query": query,
+        "target_paths": target_paths,
+        "target_collections": target_collections,
+        "scorecard_digest": score_digest,
+    }
+    item_id = "holoindex-gap-" + _canonical_digest(seed)[:16]
+
+    item = HoloIndexIndexGapWorkItem(
+        work_item_id=item_id,
+        gap_class=gap_class,
+        recommended_action=action,
+        owner=WRE_OWNER,
+        query=query,
+        target_paths=target_paths,
+        target_collections=target_collections,
+        required_targets_missing=required_missing,
+        observed_hits=observed_hits,
+        priority=_priority_for_gap(gap_class),
+        freshness_receipt_digest=_receipt_digest(freshness_receipt),
+        scorecard_digest=score_digest,
+    )
+    return HoloIndexIndexGapWorkItemResult(
+        decision=WORKITEM_PLANNED,
+        gap_class=gap_class,
+        work_item=item,
+    )
+
+
+__all__ = [
+    "ACTION_RETRIEVAL_QUALITY_SLICE",
+    "ACTION_RUNTIME_REPAIR",
+    "ACTION_TARGETED_REINDEX",
+    "ACTION_TOOL_CLASSIFIER_REPAIR",
+    "GAP_HOLOINDEX_LOW_SIGNAL",
+    "GAP_HOLOINDEX_RUNTIME_FAILURE",
+    "GAP_HOLOINDEX_STALE_INDEX",
+    "GAP_TOOL_CLASSIFIER_UNAVAILABLE",
+    "HoloIndexIndexGapWorkItem",
+    "HoloIndexIndexGapWorkItemResult",
+    "NO_INDEX_GAP",
+    "WORKITEM_PLANNED",
+    "WORKITEM_REJECTED",
+    "WRE_OWNER",
+    "classify_index_gap",
+    "index_gap_detected",
+    "plan_index_gap_work_item",
+]

--- a/holo_index/tests/test_holoindex_index_gap_workitem.py
+++ b/holo_index/tests/test_holoindex_index_gap_workitem.py
@@ -1,0 +1,161 @@
+"""Tests for HOLOINDEX_INDEX_GAP_TO_WRE_WORKITEM_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from holo_index.index_gap_workitem import (
+    ACTION_RETRIEVAL_QUALITY_SLICE,
+    ACTION_RUNTIME_REPAIR,
+    ACTION_TARGETED_REINDEX,
+    ACTION_TOOL_CLASSIFIER_REPAIR,
+    GAP_HOLOINDEX_LOW_SIGNAL,
+    GAP_HOLOINDEX_RUNTIME_FAILURE,
+    GAP_HOLOINDEX_STALE_INDEX,
+    GAP_TOOL_CLASSIFIER_UNAVAILABLE,
+    NO_INDEX_GAP,
+    WORKITEM_PLANNED,
+    classify_index_gap,
+    plan_index_gap_work_item,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _scorecard(**overrides):
+    base = {
+        "query": "RedDog work focus",
+        "index_gap_detected": True,
+        "direct_read_fallback_used": True,
+        "target_recall_ok": True,
+        "direct_read_paths": [
+            "modules/foundups/agent/src/create_foundup_dryrun.py",
+            "docs/0102_session_briefings/work_ledger.schema.json",
+        ],
+        "required_targets_missing": [],
+        "code_hits": [{"path": "modules/foundups/agent/src/context_bundle_builder.py"}],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_stale_index_gap_plans_targeted_reindex_work_item() -> None:
+    result = plan_index_gap_work_item(_scorecard())
+
+    assert result.decision == WORKITEM_PLANNED
+    assert result.gap_class == GAP_HOLOINDEX_STALE_INDEX
+    assert result.work_item is not None
+    item = result.work_item
+    assert item.recommended_action == ACTION_TARGETED_REINDEX
+    assert item.owner == "WRE_CI_INDEX_MAINTENANCE"
+    assert item.priority == "P1"
+    assert item.target_paths == [
+        "modules/foundups/agent/src/create_foundup_dryrun.py",
+        "docs/0102_session_briefings/work_ledger.schema.json",
+    ]
+    assert item.target_collections == ["navigation_symbols", "navigation_work_ledger"]
+    assert item.live_wre_enqueue_performed is False
+    assert item.no_reindex_performed is True
+    assert item.no_agentdb_mutation_performed is True
+    assert item.no_runtime_reindex_performed is True
+
+
+def test_low_signal_gap_routes_to_retrieval_quality_not_reindex() -> None:
+    scorecard = _scorecard(
+        direct_read_fallback_used=False,
+        target_recall_ok=False,
+        direct_read_paths=[],
+        required_targets_missing=["modules/x/missing.py"],
+    )
+    result = plan_index_gap_work_item(scorecard)
+
+    assert result.decision == WORKITEM_PLANNED
+    assert result.gap_class == GAP_HOLOINDEX_LOW_SIGNAL
+    assert result.work_item is not None
+    assert result.work_item.recommended_action == ACTION_RETRIEVAL_QUALITY_SLICE
+    assert result.work_item.priority == "P2"
+
+
+def test_runtime_failure_gap_routes_to_runtime_repair() -> None:
+    result = plan_index_gap_work_item(
+        _scorecard(direct_read_fetch_error="ENOBUFS", direct_read_paths=[]),
+    )
+
+    assert result.gap_class == GAP_HOLOINDEX_RUNTIME_FAILURE
+    assert result.work_item is not None
+    assert result.work_item.recommended_action == ACTION_RUNTIME_REPAIR
+
+
+def test_tool_classifier_gap_routes_to_classifier_repair() -> None:
+    result = plan_index_gap_work_item(
+        _scorecard(tool_classifier_unavailable=True, direct_read_paths=[]),
+    )
+
+    assert result.gap_class == GAP_TOOL_CLASSIFIER_UNAVAILABLE
+    assert result.work_item is not None
+    assert result.work_item.recommended_action == ACTION_TOOL_CLASSIFIER_REPAIR
+
+
+def test_no_gap_produces_no_work_item() -> None:
+    result = plan_index_gap_work_item(
+        _scorecard(index_gap_detected=False, direct_read_fallback_used=False, direct_read_paths=[]),
+    )
+
+    assert result.decision == NO_INDEX_GAP
+    assert result.work_item is None
+
+
+def test_result_id_is_deterministic_for_same_scorecard() -> None:
+    first = plan_index_gap_work_item(_scorecard())
+    second = plan_index_gap_work_item(_scorecard())
+
+    assert first.work_item is not None and second.work_item is not None
+    assert first.work_item.work_item_id == second.work_item.work_item_id
+    assert first.work_item.scorecard_digest == second.work_item.scorecard_digest
+
+
+def test_freshness_receipt_digest_is_recorded_without_receipt_body() -> None:
+    receipt = {"schema_version": "holoindex_freshness_receipt.v1", "repo_head_sha": "abc123"}
+
+    result = plan_index_gap_work_item(_scorecard(), freshness_receipt=receipt)
+
+    assert result.work_item is not None
+    assert result.work_item.freshness_receipt_digest
+    assert "abc123" not in result.work_item.freshness_receipt_digest
+
+
+def test_index_gap_event_stale_targets_are_merged_and_deduped() -> None:
+    result = plan_index_gap_work_item(
+        _scorecard(direct_read_paths=["modules/a.py"]),
+        index_gap_event={"stale_targets": ["modules/a.py", "modules/b.py"]},
+    )
+
+    assert result.work_item is not None
+    assert result.work_item.target_paths == ["modules/a.py", "modules/b.py"]
+    assert result.work_item.target_collections == ["navigation_symbols"]
+
+
+def test_classification_helpers_fail_closed_on_non_gap() -> None:
+    assert classify_index_gap({}) is None
+    assert classify_index_gap({"index_gap_detected": False}) is None
+
+
+def test_module_has_no_live_execution_or_enqueue_imports() -> None:
+    source = (REPO_ROOT / "holo_index" / "index_gap_workitem.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    banned_imports = {
+        "subprocess",
+        "requests",
+        "modules.infrastructure.database.src.agent_db",
+        "modules.communication.moltbot_bridge.src.openclaw_supervisor",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name not in banned_imports
+        if isinstance(node, ast.ImportFrom):
+            assert (node.module or "") not in banned_imports
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in {"create_autonomous_task", "get_autonomous_tasks"}

--- a/modules/communication/moltbot_bridge/src/reddog_adversarial_verifier_panel.py
+++ b/modules/communication/moltbot_bridge/src/reddog_adversarial_verifier_panel.py
@@ -39,6 +39,7 @@ from modules.communication.moltbot_bridge.src.reddog_determine_answer_contract i
     _is_file_line,
     normalize_evidence_ref,
 )
+from holo_index.index_gap_workitem import plan_index_gap_work_item
 
 
 # Per-claim verdicts. OBSERVED_VERIFIED / INFERRED are the answer's own WSP_97 label AFTER the
@@ -280,6 +281,8 @@ def build_index_gap_event(scorecard: Mapping[str, Any]) -> Optional[dict]:
     if not gap:
         return None
     stale = [p for p in _as_list(scorecard.get("direct_read_paths")) if isinstance(p, str)]
+    work_item_result = plan_index_gap_work_item(scorecard)
+    work_item_payload = work_item_result.to_dict()
     return {
         "event": "INDEX_GAP",
         "severity": "advisory",
@@ -289,6 +292,7 @@ def build_index_gap_event(scorecard: Mapping[str, Any]) -> Optional[dict]:
                           "governed WRE/CI maintenance action -- NOT performed here.",
         "boundary": "advisory-only; no live WRE enqueue / CI mutation / re-index in this slice; "
                     "direct-read success is not HoloIndex freshness success",
+        "wre_work_item": work_item_payload,
     }
 
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_adversarial_verifier_panel.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_adversarial_verifier_panel.py
@@ -178,15 +178,22 @@ def test_malformed_scorecard_fields_do_not_crash(bad):
 # --- INDEX_GAP: advisory, non-mutating --------------------------------------
 def test_index_gap_event_emitted_advisory_non_mutating():
     ev = build_index_gap_event({"index_gap_detected": True,
+                                "direct_read_fallback_used": True,
                                 "direct_read_paths": ["modules/x/f1.py", "modules/x/f2.py"]})
     assert ev is not None
     assert ev["event"] == "INDEX_GAP" and ev["severity"] == "advisory"
     assert ev["stale_targets"] == ["modules/x/f1.py", "modules/x/f2.py"]
     assert "not performed here" in ev["recommendation"].lower()
     assert "no live wre enqueue" in ev["boundary"].lower()
-    # the event carries NO enqueue/mutation directive -- it is a pure advisory record
+    assert ev["wre_work_item"]["decision"] == "WORKITEM_PLANNED"
+    item = ev["wre_work_item"]["work_item"]
+    assert item["recommended_action"] == "targeted_reindex"
+    assert item["live_wre_enqueue_performed"] is False
+    assert item["no_reindex_performed"] is True
+    assert item["no_agentdb_mutation_performed"] is True
+    # the event carries NO live enqueue/mutation directive -- it is a pure advisory record
     assert set(ev.keys()) == {"event", "severity", "index_gap_detected", "stale_targets",
-                              "recommendation", "boundary"}
+                              "recommendation", "boundary", "wre_work_item"}
 
 
 def test_no_index_gap_no_event():


### PR DESCRIPTION
## Summary
- add `holo_index/index_gap_workitem.py`, a deterministic non-mutating planner for HoloIndex INDEX_GAP work items
- classify gaps into the recorded taxonomy: `TOOL_CLASSIFIER_UNAVAILABLE`, `HOLOINDEX_LOW_SIGNAL`, `HOLOINDEX_STALE_INDEX`, `HOLOINDEX_RUNTIME_FAILURE`
- wire `reddog_adversarial_verifier_panel.build_index_gap_event()` to carry a planned WRE work-item envelope while preserving advisory-only/no-mutation boundaries

## WSP_97 Truth Boundary
- OBSERVED: only `HOLOINDEX_STALE_INDEX` plans `targeted_reindex`
- OBSERVED: `HOLOINDEX_LOW_SIGNAL` routes to retrieval-quality work, not re-index
- OBSERVED: no AgentDB, OpenClaw, subprocess, WRE enqueue, CI mutation, or HoloIndex re-index is invoked
- OBSERVED: work item carries `live_wre_enqueue_performed=false`, `no_reindex_performed=true`, `no_agentdb_mutation_performed=true`, `no_runtime_reindex_performed=true`
- SPECIFIED_NOT_IMPLEMENTED: live WRE work-item enqueue, CI freshness gate, incremental per-FoundUp indexing

## Validation
- `python -m pytest holo_index\tests\test_holoindex_index_gap_workitem.py` -> 10 passed
- `python -m pytest modules\communication\moltbot_bridge\tests\test_reddog_adversarial_verifier_panel.py` -> 42 passed
- `python -m pytest modules\communication\moltbot_bridge\tests\test_reddog_judgment_verifier_bridge.py modules\communication\moltbot_bridge\tests\test_reddog_adversarial_verifier_panel.py` -> 47 passed
- `python -m pytest holo_index\tests\test_holoindex_index_gap_workitem.py holo_index\tests\test_holoindex_freshness_receipt.py holo_index\tests\test_holoindex_readonly_query_guard.py` -> 27 passed
- `node extensions\foundups_advisory_workers\tests\verify_extension_contract.js` -> passed (known UnicodeEncodeError stderr noise, exit 0)
- `python -m pytest modules\communication\moltbot_bridge\tests\test_reddog_determine_answer_contract.py modules\communication\moltbot_bridge\tests\test_reddog_judgment_verifier_bridge.py modules\communication\moltbot_bridge\tests\test_reddog_adversarial_verifier_panel.py holo_index\tests\test_holoindex_index_gap_workitem.py` -> 152 passed
- `python -m compileall -q holo_index\index_gap_workitem.py modules\communication\moltbot_bridge\src\reddog_adversarial_verifier_panel.py` -> passed
- `git diff --check` -> clean (autocrlf warnings only)
- added/new-file byte scan -> 0 non-ASCII / 0 NUL

## HoloIndex
- Pre/post read-only probe: `HOLOINDEX_INDEX_GAP_TO_WRE_WORKITEM_PHASE1 plan_index_gap_work_item WRE targeted reindex`
- Result: adjacent reindex docs and RedDog valve surfaces; new planner module not semantically indexed yet
- Recorded follow-up: `HOLOINDEX_INDEX_GAP_TO_WRE_WORKITEM_INDEX_GAP_PHASE1`