### PR TITLE
feat(holoindex): add CI freshness receipt gate

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,15 @@
 # HoloIndex Package ModLog
 
+## [2026-07-12] HOLOINDEX_CI_FRESHNESS_GATE_PHASE1
+
+**Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice
+**WSP**: 00, 15, 22, 50, 97 | **Base**: `d80ec0582`
+
+- ADD `holo_index/ci_freshness_gate.py`: deterministic CI checker that compares caller-supplied changed paths against `holoindex_freshness_receipt.json` and fails closed on missing/stale/malformed freshness evidence when configured.
+- Boundary: the checker does not discover git diffs, execute commands, invoke HoloIndex, run re-index, enqueue WRE work, or mutate any semantic store. CI/WRE must supply the receipt path, changed paths, and expected repo SHA.
+- TEST `tests/test_holoindex_ci_freshness_gate.py`: fresh/stale/missing receipt paths, `NOT_CONFIGURED` reporting mode, no-relevant-changes pass, changed-path file input, CLI exit codes, JSON output, and AST guards against git/reindex/execution imports.
+- HoloIndex read-only probe for `HOLOINDEX_CI_FRESHNESS_GATE_PHASE1 CI freshness receipt changed paths post merge targeted reindex` did not surface a canonical CI freshness gate before re-index. Recorded as `HOLOINDEX_CI_FRESHNESS_GATE_INDEX_GAP_PHASE1`; no runtime re-index performed.
+
 ## [2026-07-12] HOLOINDEX_INDEX_GAP_TO_WRE_WORKITEM_PHASE1
 
 **Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice

--- a/holo_index/ci_freshness_gate.py
+++ b/holo_index/ci_freshness_gate.py
@@ -1,0 +1,276 @@
+"""CI freshness gate for HoloIndex receipts.
+
+WSP 97: freshness must be checked from evidence. This module only evaluates a
+receipt against caller-supplied changed paths. It never runs git, never reindexes,
+and never mutates the HoloIndex store.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from holo_index.freshness_receipt import (
+    FreshnessCheck,
+    collections_for_changed_paths,
+    evaluate_freshness_for_paths,
+    load_freshness_receipt,
+)
+
+
+SCHEMA_VERSION = "holoindex_ci_freshness_gate.v1"
+
+STATUS_PASS = "PASS"
+STATUS_FAIL = "FAIL"
+STATUS_NOT_CONFIGURED = "NOT_CONFIGURED"
+STATUS_NO_RELEVANT_CHANGES = "NO_RELEVANT_CHANGES"
+
+EXIT_OK = 0
+EXIT_STALE = 2
+
+
+@dataclass(frozen=True)
+class HoloIndexCIFreshnessGateResult:
+    """Result emitted by the CI freshness gate."""
+
+    schema_version: str
+    status: str
+    ok: bool
+    configured: bool
+    receipt_path: str | None
+    expected_repo_head_sha: str | None
+    changed_paths: list[str] = field(default_factory=list)
+    required_collections: list[str] = field(default_factory=list)
+    stale_collections: list[str] = field(default_factory=list)
+    reasons: list[str] = field(default_factory=list)
+    no_reindex_performed: bool = True
+    no_runtime_reindex_performed: bool = True
+    no_holoindex_mutation_performed: bool = True
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+
+
+def _normalize_paths(paths: Iterable[str | Path]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for path in paths:
+        text = str(path).replace("\\", "/").strip()
+        while text.startswith("./"):
+            text = text[2:]
+        if not text or text.startswith("#"):
+            continue
+        key = text.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(text)
+    return out
+
+
+def _read_changed_paths_file(path: str | Path) -> list[str]:
+    return _normalize_paths(Path(path).read_text(encoding="utf-8").splitlines())
+
+
+def _missing_receipt_result(
+    *,
+    receipt_path: str | None,
+    changed_paths: list[str],
+    expected_repo_head_sha: str | None,
+    reason: str,
+    allow_not_configured: bool,
+) -> HoloIndexCIFreshnessGateResult:
+    required = collections_for_changed_paths(changed_paths)
+    if allow_not_configured:
+        return HoloIndexCIFreshnessGateResult(
+            schema_version=SCHEMA_VERSION,
+            status=STATUS_NOT_CONFIGURED,
+            ok=True,
+            configured=False,
+            receipt_path=receipt_path,
+            expected_repo_head_sha=expected_repo_head_sha,
+            changed_paths=changed_paths,
+            required_collections=required,
+            stale_collections=[],
+            reasons=[reason],
+        )
+    return HoloIndexCIFreshnessGateResult(
+        schema_version=SCHEMA_VERSION,
+        status=STATUS_FAIL,
+        ok=False,
+        configured=False,
+        receipt_path=receipt_path,
+        expected_repo_head_sha=expected_repo_head_sha,
+        changed_paths=changed_paths,
+        required_collections=required,
+        stale_collections=required,
+        reasons=[reason],
+    )
+
+
+def _from_freshness_check(
+    *,
+    check: FreshnessCheck,
+    receipt_path: str,
+    changed_paths: list[str],
+    expected_repo_head_sha: str | None,
+) -> HoloIndexCIFreshnessGateResult:
+    status = STATUS_PASS if check.ok else STATUS_FAIL
+    if check.ok and not check.required_collections:
+        status = STATUS_NO_RELEVANT_CHANGES
+    return HoloIndexCIFreshnessGateResult(
+        schema_version=SCHEMA_VERSION,
+        status=status,
+        ok=check.ok,
+        configured=True,
+        receipt_path=receipt_path,
+        expected_repo_head_sha=expected_repo_head_sha,
+        changed_paths=changed_paths,
+        required_collections=check.required_collections,
+        stale_collections=check.stale_collections,
+        reasons=check.reasons,
+    )
+
+
+def check_ci_freshness(
+    *,
+    receipt_path: str | Path | None,
+    changed_paths: Iterable[str | Path],
+    expected_repo_head_sha: str | None = None,
+    allow_not_configured: bool = False,
+) -> HoloIndexCIFreshnessGateResult:
+    """Check whether a HoloIndex receipt covers changed paths for CI.
+
+    The caller supplies the changed paths and expected SHA. This function is
+    intentionally not a git wrapper; CI or WRE owns diff discovery.
+    """
+
+    normalized_paths = _normalize_paths(changed_paths)
+    required = collections_for_changed_paths(normalized_paths)
+    if not required:
+        return HoloIndexCIFreshnessGateResult(
+            schema_version=SCHEMA_VERSION,
+            status=STATUS_NO_RELEVANT_CHANGES,
+            ok=True,
+            configured=bool(receipt_path),
+            receipt_path=str(receipt_path) if receipt_path else None,
+            expected_repo_head_sha=expected_repo_head_sha,
+            changed_paths=normalized_paths,
+            required_collections=[],
+            stale_collections=[],
+            reasons=[],
+        )
+    if not receipt_path:
+        return _missing_receipt_result(
+            receipt_path=None,
+            changed_paths=normalized_paths,
+            expected_repo_head_sha=expected_repo_head_sha,
+            reason="missing_freshness_receipt_path",
+            allow_not_configured=allow_not_configured,
+        )
+
+    receipt_file = Path(receipt_path)
+    if not receipt_file.exists():
+        return _missing_receipt_result(
+            receipt_path=str(receipt_file),
+            changed_paths=normalized_paths,
+            expected_repo_head_sha=expected_repo_head_sha,
+            reason="missing_freshness_receipt_file",
+            allow_not_configured=allow_not_configured,
+        )
+
+    try:
+        receipt = load_freshness_receipt(receipt_file)
+    except Exception:
+        required = collections_for_changed_paths(normalized_paths)
+        return HoloIndexCIFreshnessGateResult(
+            schema_version=SCHEMA_VERSION,
+            status=STATUS_FAIL,
+            ok=False,
+            configured=True,
+            receipt_path=str(receipt_file),
+            expected_repo_head_sha=expected_repo_head_sha,
+            changed_paths=normalized_paths,
+            required_collections=required,
+            stale_collections=required,
+            reasons=["malformed_freshness_receipt"],
+        )
+
+    check = evaluate_freshness_for_paths(
+        receipt,
+        normalized_paths,
+        expected_repo_head_sha=expected_repo_head_sha,
+    )
+    return _from_freshness_check(
+        check=check,
+        receipt_path=str(receipt_file),
+        changed_paths=normalized_paths,
+        expected_repo_head_sha=expected_repo_head_sha,
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Check HoloIndex freshness receipt for CI.")
+    parser.add_argument("--receipt", help="Path to holoindex_freshness_receipt.json.")
+    parser.add_argument(
+        "--changed-path",
+        action="append",
+        default=[],
+        help="Changed repository path. May be repeated.",
+    )
+    parser.add_argument(
+        "--changed-paths-file",
+        help="File containing one changed repository path per line.",
+    )
+    parser.add_argument("--expected-repo-head-sha", help="Expected repository HEAD SHA.")
+    parser.add_argument(
+        "--allow-not-configured",
+        action="store_true",
+        help="Return ok=true with NOT_CONFIGURED when the receipt is absent.",
+    )
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    changed_paths = list(args.changed_path or [])
+    if args.changed_paths_file:
+        changed_paths.extend(_read_changed_paths_file(args.changed_paths_file))
+
+    result = check_ci_freshness(
+        receipt_path=args.receipt,
+        changed_paths=changed_paths,
+        expected_repo_head_sha=args.expected_repo_head_sha,
+        allow_not_configured=args.allow_not_configured,
+    )
+    if args.pretty:
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+    else:
+        print(result.to_json())
+    return EXIT_OK if result.ok else EXIT_STALE
+
+
+__all__ = [
+    "EXIT_OK",
+    "EXIT_STALE",
+    "HoloIndexCIFreshnessGateResult",
+    "SCHEMA_VERSION",
+    "STATUS_FAIL",
+    "STATUS_NOT_CONFIGURED",
+    "STATUS_NO_RELEVANT_CHANGES",
+    "STATUS_PASS",
+    "check_ci_freshness",
+    "main",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/holo_index/tests/test_holoindex_ci_freshness_gate.py
+++ b/holo_index/tests/test_holoindex_ci_freshness_gate.py
@@ -1,0 +1,267 @@
+"""Tests for HOLOINDEX_CI_FRESHNESS_GATE_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from holo_index.ci_freshness_gate import (
+    EXIT_OK,
+    EXIT_STALE,
+    STATUS_FAIL,
+    STATUS_NOT_CONFIGURED,
+    STATUS_NO_RELEVANT_CHANGES,
+    STATUS_PASS,
+    check_ci_freshness,
+    main,
+)
+from holo_index.freshness_receipt import (
+    build_freshness_receipt,
+    freshness_receipt_path,
+    write_freshness_receipt,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE = REPO_ROOT / "holo_index" / "ci_freshness_gate.py"
+
+
+class CountCollection:
+    def __init__(self, count: int = 3):
+        self._count = count
+
+    def count(self) -> int:
+        return self._count
+
+
+def _holo(**counts: int):
+    attr_map = {
+        "navigation_code": "code_collection",
+        "navigation_wsp": "wsp_collection",
+        "navigation_tests": "test_collection",
+        "navigation_skills": "skill_collection",
+        "navigation_symbols": "symbol_collection",
+        "navigation_docs": "docs_collection",
+        "navigation_knowledge": "knowledge_collection",
+        "navigation_work_ledger": "work_ledger_collection",
+        "navigation_vocabulary": "vocabulary_collection",
+    }
+    values = {}
+    for collection_name, attr_name in attr_map.items():
+        values[attr_name] = CountCollection(counts.get(collection_name, 3))
+    return SimpleNamespace(**values)
+
+
+def _write_receipt(tmp_path: Path, *, sha: str = "abc123", **counts: int) -> Path:
+    receipt = build_freshness_receipt(
+        _holo(**counts),
+        ssd_path=tmp_path,
+        repo_root=REPO_ROOT,
+        source="ci_test",
+        generated_at="2026-07-12T00:00:00+00:00",
+        repo_head_sha=sha,
+    )
+    path = freshness_receipt_path(tmp_path)
+    write_freshness_receipt(receipt, path)
+    return path
+
+
+def test_ci_gate_passes_when_receipt_covers_changed_collections(tmp_path: Path) -> None:
+    receipt = _write_receipt(tmp_path)
+
+    result = check_ci_freshness(
+        receipt_path=receipt,
+        changed_paths=[
+            "modules/foundups/agent/src/create_foundup_dryrun.py",
+            "docs/0102_session_briefings/work_ledger.schema.json",
+        ],
+        expected_repo_head_sha="abc123",
+    )
+
+    assert result.ok is True
+    assert result.status == STATUS_PASS
+    assert result.configured is True
+    assert result.required_collections == ["navigation_symbols", "navigation_work_ledger"]
+    assert result.stale_collections == []
+    assert result.no_reindex_performed is True
+    assert result.no_runtime_reindex_performed is True
+    assert result.no_holoindex_mutation_performed is True
+
+
+def test_ci_gate_fails_closed_when_receipt_path_missing() -> None:
+    result = check_ci_freshness(
+        receipt_path=None,
+        changed_paths=["modules/foundups/agent/src/create_foundup_dryrun.py"],
+        expected_repo_head_sha="abc123",
+    )
+
+    assert result.ok is False
+    assert result.status == STATUS_FAIL
+    assert result.configured is False
+    assert result.stale_collections == ["navigation_symbols"]
+    assert result.reasons == ["missing_freshness_receipt_path"]
+
+
+def test_ci_gate_can_report_not_configured_without_claiming_freshness() -> None:
+    result = check_ci_freshness(
+        receipt_path="E:/HoloIndex/indexes/holoindex_freshness_receipt.json",
+        changed_paths=["modules/foundups/agent/src/create_foundup_dryrun.py"],
+        expected_repo_head_sha="abc123",
+        allow_not_configured=True,
+    )
+
+    assert result.ok is True
+    assert result.status == STATUS_NOT_CONFIGURED
+    assert result.configured is False
+    assert result.required_collections == ["navigation_symbols"]
+    assert result.stale_collections == []
+    assert result.reasons == ["missing_freshness_receipt_file"]
+
+
+def test_ci_gate_fails_on_stale_repo_sha(tmp_path: Path) -> None:
+    receipt = _write_receipt(tmp_path, sha="old")
+
+    result = check_ci_freshness(
+        receipt_path=receipt,
+        changed_paths=[
+            "WSP_framework/src/WSP_97_System_Execution_Prompting_Protocol.md",
+            "docs/0102_session_briefings/ACTIVE_SLICE_LEDGER.md",
+        ],
+        expected_repo_head_sha="new",
+    )
+
+    assert result.ok is False
+    assert result.status == STATUS_FAIL
+    assert result.stale_collections == ["navigation_work_ledger", "navigation_wsp"]
+    assert "stale_repo_head_sha" in result.reasons
+
+
+def test_ci_gate_fails_on_empty_required_collection(tmp_path: Path) -> None:
+    receipt = _write_receipt(tmp_path, navigation_docs=0)
+
+    result = check_ci_freshness(
+        receipt_path=receipt,
+        changed_paths=["docs/audits/infrastructure/HOLOINDEX_FRESHNESS_AND_SCALING_GOVERNANCE_PHASE1.md"],
+        expected_repo_head_sha="abc123",
+    )
+
+    assert result.ok is False
+    assert result.status == STATUS_FAIL
+    assert result.stale_collections == ["navigation_docs"]
+    assert "collection_not_indexed:navigation_docs" in result.reasons
+
+
+def test_ci_gate_dedupes_and_normalizes_changed_paths(tmp_path: Path) -> None:
+    receipt = _write_receipt(tmp_path)
+
+    result = check_ci_freshness(
+        receipt_path=receipt,
+        changed_paths=[
+            ".\\modules\\foundups\\agent\\src\\create_foundup_dryrun.py",
+            "modules/foundups/agent/src/create_foundup_dryrun.py",
+            "",
+            "# comment",
+        ],
+        expected_repo_head_sha="abc123",
+    )
+
+    assert result.ok is True
+    assert result.changed_paths == ["modules/foundups/agent/src/create_foundup_dryrun.py"]
+    assert result.required_collections == ["navigation_symbols"]
+
+
+def test_ci_gate_allows_no_relevant_changes(tmp_path: Path) -> None:
+    receipt = _write_receipt(tmp_path)
+
+    result = check_ci_freshness(
+        receipt_path=receipt,
+        changed_paths=[".gitignore"],
+        expected_repo_head_sha="abc123",
+    )
+
+    assert result.ok is True
+    assert result.status == STATUS_NO_RELEVANT_CHANGES
+    assert result.required_collections == []
+
+
+def test_ci_gate_allows_no_relevant_changes_without_receipt() -> None:
+    result = check_ci_freshness(
+        receipt_path=None,
+        changed_paths=[".gitignore"],
+        expected_repo_head_sha="abc123",
+    )
+
+    assert result.ok is True
+    assert result.status == STATUS_NO_RELEVANT_CHANGES
+    assert result.configured is False
+    assert result.required_collections == []
+    assert result.reasons == []
+
+
+def test_cli_returns_zero_and_json_for_fresh_receipt(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    receipt = _write_receipt(tmp_path)
+
+    code = main([
+        "--receipt",
+        str(receipt),
+        "--changed-path",
+        "modules/foundups/agent/src/create_foundup_dryrun.py",
+        "--expected-repo-head-sha",
+        "abc123",
+    ])
+
+    assert code == EXIT_OK
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == STATUS_PASS
+    assert payload["required_collections"] == ["navigation_symbols"]
+    assert payload["no_reindex_performed"] is True
+
+
+def test_cli_changed_paths_file_and_failure_exit(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    receipt = _write_receipt(tmp_path, sha="old")
+    paths = tmp_path / "changed.txt"
+    paths.write_text("docs/0102_session_briefings/work_ledger.schema.json\n", encoding="utf-8")
+
+    code = main([
+        "--receipt",
+        str(receipt),
+        "--changed-paths-file",
+        str(paths),
+        "--expected-repo-head-sha",
+        "new",
+    ])
+
+    assert code == EXIT_STALE
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == STATUS_FAIL
+    assert payload["stale_collections"] == ["navigation_work_ledger"]
+
+
+def test_module_has_no_git_reindex_or_execution_imports() -> None:
+    source = MODULE.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    banned_imports = {"subprocess", "requests", "git", "holo_index.core.holo_index"}
+    banned_calls = {
+        "system",
+        "popen",
+        "run",
+        "check_call",
+        "check_output",
+        "index_code_entries",
+        "index_wsp_entries",
+        "write_freshness_receipt",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name not in banned_imports
+        if isinstance(node, ast.ImportFrom):
+            assert (node.module or "") not in banned_imports
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            assert node.func.attr not in banned_calls
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls


### PR DESCRIPTION
## Summary

Implements `HOLOINDEX_CI_FRESHNESS_GATE_PHASE1` as a pure CI/WRE checker for HoloIndex freshness receipts.

- Adds `holo_index/ci_freshness_gate.py` with `check_ci_freshness()` and a JSON CLI.
- Compares caller-supplied changed paths against `holoindex_freshness_receipt.json` using the existing freshness receipt evaluator.
- Fails closed on missing, malformed, stale, or empty required collection evidence when configured.
- Supports explicit `NOT_CONFIGURED` reporting without claiming freshness when CI has no receipt path yet.
- Does not discover git diffs, run commands, invoke HoloIndex, enqueue WRE work, or perform any re-index.

## WSP_97 Truth Boundary

OBSERVED:
- `HOLOINDEX_READONLY_QUERY_GUARD_PHASE1`, `HOLOINDEX_FRESHNESS_RECEIPT_PHASE1`, and `HOLOINDEX_INDEX_GAP_TO_WRE_WORKITEM_PHASE1` are already on main.
- The governance doc sequences this slice as step 4: CI checks receipt vs changed paths.
- The checker is deterministic and non-mutating.

SPECIFIED_NOT_IMPLEMENTED:
- Actual CI environment wiring to a production receipt path.
- Any targeted re-index execution.
- Incremental per-FoundUp indexing.

## Validation

```text
python -m pytest holo_index\tests\test_holoindex_ci_freshness_gate.py -q
  11 passed

python -m pytest holo_index\tests\test_holoindex_ci_freshness_gate.py holo_index\tests\test_holoindex_freshness_receipt.py holo_index\tests\test_holoindex_index_gap_workitem.py holo_index\tests\test_holoindex_readonly_query_guard.py holo_index\tests\test_holoindex_freshness_governance_doc.py -q
  63 passed

python -m pytest holo_index\tests\test_collection_health.py -q
  27 passed

python -m compileall -q holo_index\ci_freshness_gate.py holo_index\tests\test_holoindex_ci_freshness_gate.py
  PASS

git diff --cached --check
  PASS

ASCII/NUL scan on new files
  0 bad bytes
```

## HoloIndex Addendum

Read-only probe was run with `HOLOINDEX_QUERY_READONLY=1` for:

```text
HOLOINDEX_CI_FRESHNESS_GATE_PHASE1 ci_freshness_gate freshness receipt changed paths
```

The new module/test did not surface before re-index, so this records `HOLOINDEX_CI_FRESHNESS_GATE_INDEX_GAP_PHASE1`. No runtime re-index was performed.