### PR TITLE
feat(holoindex): add incremental FoundUp index planner

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,15 @@
 # HoloIndex Package ModLog
 
+## [2026-07-12] HOLOINDEX_INCREMENTAL_PER_FOUNDUP_INDEX_PHASE1
+
+**Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice
+**WSP**: 00, 15, 22, 50, 97 | **Base**: `c22792312`
+
+- ADD `holo_index/incremental_foundup_index.py`: stable non-positional ID helper, strict FoundUp scope validator, foundup-scoped delete filter, and non-mutating incremental plan for changed/removed FoundUp paths.
+- Boundary: this phase creates the deterministic planning primitive only. It does not modify live ChromaDB IDs, run HoloIndex indexing, delete collections, remove symbol caps, or perform segment garbage collection.
+- TEST `tests/test_holoindex_incremental_foundup_index.py`: foundup_id validation, path containment, stable IDs, collection mapping, upsert/delete-id planning, traversal/absolute/out-of-scope rejection, no-indexable-changes, and AST guards against live index/subprocess imports.
+- HoloIndex read-only probe for `HOLOINDEX_INCREMENTAL_PER_FOUNDUP_INDEX_PHASE1 stable ids delete by foundup_id symbol caps segment gc` did not surface a canonical incremental FoundUp index primitive before re-index. Recorded as `HOLOINDEX_INCREMENTAL_PER_FOUNDUP_INDEX_INDEX_GAP_PHASE1`; no runtime re-index performed.
+
 ## [2026-07-12] HOLOINDEX_CI_FRESHNESS_GATE_PHASE1
 
 **Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice

--- a/holo_index/incremental_foundup_index.py
+++ b/holo_index/incremental_foundup_index.py
@@ -1,0 +1,261 @@
+"""Incremental per-FoundUp HoloIndex planning primitives.
+
+This phase creates deterministic IDs and scoped plans only. It does not call
+ChromaDB, run HoloIndex indexing, delete collections, or mutate any semantic
+store.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import PurePosixPath
+from typing import Iterable, Mapping
+
+from holo_index.freshness_receipt import ALL_COLLECTIONS, collections_for_path
+
+
+SCHEMA_VERSION = "holoindex_incremental_foundup_index.v1"
+
+DECISION_PLANNED = "PLANNED"
+DECISION_NO_INDEXABLE_CHANGES = "NO_INDEXABLE_CHANGES"
+DECISION_REJECTED = "REJECTED"
+
+OP_UPSERT_PATH = "upsert_path"
+OP_DELETE_PATH_ID = "delete_path_id"
+
+FOUNDUP_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+SYMBOL_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
+
+
+@dataclass(frozen=True)
+class IncrementalFoundUpIndexOperation:
+    """A non-mutating operation for a future incremental index writer."""
+
+    operation: str
+    collection: str
+    foundup_id: str
+    repo_relative_path: str
+    stable_id: str
+    delete_where: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class IncrementalFoundUpIndexPlan:
+    """Plan for refreshing a FoundUp-scoped subset of HoloIndex."""
+
+    schema_version: str
+    decision: str
+    foundup_id: str
+    foundup_root: str
+    changed_paths: list[str] = field(default_factory=list)
+    removed_paths: list[str] = field(default_factory=list)
+    target_collections: list[str] = field(default_factory=list)
+    operations: list[IncrementalFoundUpIndexOperation] = field(default_factory=list)
+    rejection_reasons: list[str] = field(default_factory=list)
+    no_reindex_performed: bool = True
+    no_collection_mutation_performed: bool = True
+    no_runtime_reindex_performed: bool = True
+
+    def to_dict(self) -> dict[str, object]:
+        payload = asdict(self)
+        payload["operations"] = [operation.to_dict() for operation in self.operations]
+        return payload
+
+
+def validate_foundup_id(foundup_id: str) -> bool:
+    return bool(FOUNDUP_ID_RE.fullmatch(str(foundup_id or "")))
+
+
+def foundup_root_for_id(foundup_id: str) -> str:
+    if not validate_foundup_id(foundup_id):
+        raise ValueError("invalid_foundup_id")
+    return f"modules/foundups/{foundup_id}"
+
+
+def _normalize_repo_path(path: str) -> str:
+    text = str(path or "").replace("\\", "/").strip()
+    while text.startswith("./"):
+        text = text[2:]
+    if not text:
+        raise ValueError("empty_path")
+    if text.startswith("/") or re.match(r"^[A-Za-z]:/", text):
+        raise ValueError("absolute_path")
+    parts = PurePosixPath(text).parts
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ValueError("path_traversal")
+    return "/".join(parts)
+
+
+def path_is_under_foundup(path: str, foundup_id: str) -> bool:
+    normalized = _normalize_repo_path(path)
+    root = foundup_root_for_id(foundup_id)
+    return normalized == root or normalized.startswith(root + "/")
+
+
+def stable_index_id(
+    collection: str,
+    repo_relative_path: str,
+    *,
+    foundup_id: str,
+    symbol: str | None = None,
+    kind: str | None = None,
+) -> str:
+    """Return a deterministic non-positional HoloIndex ID."""
+
+    if collection not in ALL_COLLECTIONS:
+        raise ValueError("unknown_collection")
+    if not validate_foundup_id(foundup_id):
+        raise ValueError("invalid_foundup_id")
+    path = _normalize_repo_path(repo_relative_path)
+    if symbol is not None and not SYMBOL_RE.fullmatch(symbol):
+        raise ValueError("invalid_symbol")
+    payload = {
+        "collection": collection,
+        "foundup_id": foundup_id,
+        "kind": kind or "",
+        "path": path,
+        "symbol": symbol or "",
+    }
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
+    short_collection = collection.replace("navigation_", "nav_")
+    return f"hidx_{short_collection}_{digest}"
+
+
+def delete_filter_for_foundup(foundup_id: str) -> dict[str, str]:
+    if not validate_foundup_id(foundup_id):
+        raise ValueError("invalid_foundup_id")
+    return {"foundup_id": foundup_id}
+
+
+def _dedupe_paths(paths: Iterable[str]) -> tuple[list[str], list[str]]:
+    normalized: list[str] = []
+    rejected: list[str] = []
+    seen: set[str] = set()
+    for path in paths:
+        try:
+            clean = _normalize_repo_path(path)
+        except ValueError as exc:
+            rejected.append(f"{exc.args[0]}:{path}")
+            continue
+        key = clean.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(clean)
+    return normalized, rejected
+
+
+def _collections_for_scoped_paths(paths: Iterable[str], foundup_id: str) -> tuple[dict[str, list[str]], list[str]]:
+    by_path: dict[str, list[str]] = {}
+    rejected: list[str] = []
+    root = foundup_root_for_id(foundup_id)
+    for path in paths:
+        if not (path == root or path.startswith(root + "/")):
+            rejected.append(f"path_outside_foundup_scope:{path}")
+            continue
+        collections = sorted(collections_for_path(path))
+        if collections:
+            by_path[path] = collections
+    return by_path, rejected
+
+
+def plan_incremental_foundup_index(
+    *,
+    foundup_id: str,
+    changed_paths: Iterable[str] = (),
+    removed_paths: Iterable[str] = (),
+) -> IncrementalFoundUpIndexPlan:
+    """Plan a scoped incremental FoundUp index refresh without executing it."""
+
+    if not validate_foundup_id(foundup_id):
+        return IncrementalFoundUpIndexPlan(
+            schema_version=SCHEMA_VERSION,
+            decision=DECISION_REJECTED,
+            foundup_id=str(foundup_id or ""),
+            foundup_root="",
+            rejection_reasons=["invalid_foundup_id"],
+        )
+
+    root = foundup_root_for_id(foundup_id)
+    normalized_changed, rejected_changed = _dedupe_paths(changed_paths)
+    normalized_removed, rejected_removed = _dedupe_paths(removed_paths)
+    changed_by_path, changed_rejections = _collections_for_scoped_paths(normalized_changed, foundup_id)
+    removed_by_path, removed_rejections = _collections_for_scoped_paths(normalized_removed, foundup_id)
+    rejections = rejected_changed + rejected_removed + changed_rejections + removed_rejections
+    if rejections:
+        return IncrementalFoundUpIndexPlan(
+            schema_version=SCHEMA_VERSION,
+            decision=DECISION_REJECTED,
+            foundup_id=foundup_id,
+            foundup_root=root,
+            changed_paths=normalized_changed,
+            removed_paths=normalized_removed,
+            rejection_reasons=rejections,
+        )
+
+    operations: list[IncrementalFoundUpIndexOperation] = []
+    target_collections: set[str] = set()
+    delete_where = delete_filter_for_foundup(foundup_id)
+    for path, collections in changed_by_path.items():
+        for collection in collections:
+            target_collections.add(collection)
+            operations.append(
+                IncrementalFoundUpIndexOperation(
+                    operation=OP_UPSERT_PATH,
+                    collection=collection,
+                    foundup_id=foundup_id,
+                    repo_relative_path=path,
+                    stable_id=stable_index_id(collection, path, foundup_id=foundup_id),
+                    delete_where=delete_where,
+                )
+            )
+    for path, collections in removed_by_path.items():
+        for collection in collections:
+            target_collections.add(collection)
+            operations.append(
+                IncrementalFoundUpIndexOperation(
+                    operation=OP_DELETE_PATH_ID,
+                    collection=collection,
+                    foundup_id=foundup_id,
+                    repo_relative_path=path,
+                    stable_id=stable_index_id(collection, path, foundup_id=foundup_id),
+                    delete_where=delete_where,
+                )
+            )
+
+    decision = DECISION_PLANNED if operations else DECISION_NO_INDEXABLE_CHANGES
+    return IncrementalFoundUpIndexPlan(
+        schema_version=SCHEMA_VERSION,
+        decision=decision,
+        foundup_id=foundup_id,
+        foundup_root=root,
+        changed_paths=normalized_changed,
+        removed_paths=normalized_removed,
+        target_collections=sorted(target_collections),
+        operations=operations,
+    )
+
+
+__all__ = [
+    "DECISION_NO_INDEXABLE_CHANGES",
+    "DECISION_PLANNED",
+    "DECISION_REJECTED",
+    "IncrementalFoundUpIndexOperation",
+    "IncrementalFoundUpIndexPlan",
+    "OP_DELETE_PATH_ID",
+    "OP_UPSERT_PATH",
+    "SCHEMA_VERSION",
+    "delete_filter_for_foundup",
+    "foundup_root_for_id",
+    "path_is_under_foundup",
+    "plan_incremental_foundup_index",
+    "stable_index_id",
+    "validate_foundup_id",
+]

--- a/holo_index/tests/test_holoindex_incremental_foundup_index.py
+++ b/holo_index/tests/test_holoindex_incremental_foundup_index.py
@@ -1,0 +1,232 @@
+"""Tests for HOLOINDEX_INCREMENTAL_PER_FOUNDUP_INDEX_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from holo_index.incremental_foundup_index import (
+    DECISION_NO_INDEXABLE_CHANGES,
+    DECISION_PLANNED,
+    DECISION_REJECTED,
+    OP_DELETE_PATH_ID,
+    OP_UPSERT_PATH,
+    delete_filter_for_foundup,
+    foundup_root_for_id,
+    path_is_under_foundup,
+    plan_incremental_foundup_index,
+    stable_index_id,
+    validate_foundup_id,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE = REPO_ROOT / "holo_index" / "incremental_foundup_index.py"
+
+
+def test_foundup_id_validation_is_strict() -> None:
+    assert validate_foundup_id("paccess_001") is True
+    assert validate_foundup_id("gotjunk") is True
+    assert validate_foundup_id("Bad") is False
+    assert validate_foundup_id("../escape") is False
+    assert validate_foundup_id("") is False
+
+
+def test_foundup_root_is_deterministic() -> None:
+    assert foundup_root_for_id("paccess_001") == "modules/foundups/paccess_001"
+    with pytest.raises(ValueError):
+        foundup_root_for_id("../escape")
+
+
+def test_path_scope_requires_modules_foundups_id() -> None:
+    assert path_is_under_foundup(
+        "modules/foundups/paccess_001/src/main.py",
+        "paccess_001",
+    )
+    assert not path_is_under_foundup(
+        "modules/foundups/other/src/main.py",
+        "paccess_001",
+    )
+    with pytest.raises(ValueError):
+        path_is_under_foundup("../modules/foundups/paccess_001/src/main.py", "paccess_001")
+
+
+def test_stable_id_is_non_positional_and_deterministic() -> None:
+    first = stable_index_id(
+        "navigation_symbols",
+        "modules/foundups/paccess_001/src/main.py",
+        foundup_id="paccess_001",
+    )
+    second = stable_index_id(
+        "navigation_symbols",
+        "./modules\\foundups\\paccess_001\\src\\main.py",
+        foundup_id="paccess_001",
+    )
+
+    assert first == second
+    assert first.startswith("hidx_nav_symbols_")
+    assert "sym_" not in first
+    assert "doc_" not in first
+
+
+def test_stable_id_changes_by_collection_and_symbol() -> None:
+    base = stable_index_id(
+        "navigation_symbols",
+        "modules/foundups/paccess_001/src/main.py",
+        foundup_id="paccess_001",
+        symbol="create_foundup",
+    )
+    other_symbol = stable_index_id(
+        "navigation_symbols",
+        "modules/foundups/paccess_001/src/main.py",
+        foundup_id="paccess_001",
+        symbol="validate_foundup",
+    )
+    docs = stable_index_id(
+        "navigation_docs",
+        "modules/foundups/paccess_001/src/main.py",
+        foundup_id="paccess_001",
+        symbol="create_foundup",
+    )
+
+    assert base != other_symbol
+    assert base != docs
+
+
+def test_delete_filter_is_foundup_scoped_only() -> None:
+    assert delete_filter_for_foundup("paccess_001") == {"foundup_id": "paccess_001"}
+    with pytest.raises(ValueError):
+        delete_filter_for_foundup("bad/id")
+
+
+def test_plan_maps_changed_foundup_paths_to_collections() -> None:
+    plan = plan_incremental_foundup_index(
+        foundup_id="paccess_001",
+        changed_paths=[
+            "modules/foundups/paccess_001/src/main.py",
+            "modules/foundups/paccess_001/README.md",
+            "modules/foundups/paccess_001/tests/test_main.py",
+            "modules/foundups/paccess_001/SKILLz.md",
+        ],
+    )
+
+    assert plan.decision == DECISION_PLANNED
+    assert plan.target_collections == [
+        "navigation_docs",
+        "navigation_skills",
+        "navigation_symbols",
+        "navigation_tests",
+    ]
+    assert {operation.operation for operation in plan.operations} == {OP_UPSERT_PATH}
+    assert all(operation.delete_where == {"foundup_id": "paccess_001"} for operation in plan.operations)
+    assert all(operation.stable_id.startswith("hidx_") for operation in plan.operations)
+    assert plan.no_reindex_performed is True
+    assert plan.no_collection_mutation_performed is True
+
+
+def test_plan_dedupes_changed_paths() -> None:
+    plan = plan_incremental_foundup_index(
+        foundup_id="paccess_001",
+        changed_paths=[
+            "./modules/foundups/paccess_001/src/main.py",
+            "modules\\foundups\\paccess_001\\src\\main.py",
+        ],
+    )
+
+    assert plan.decision == DECISION_PLANNED
+    assert plan.changed_paths == ["modules/foundups/paccess_001/src/main.py"]
+    assert len(plan.operations) == 1
+
+
+def test_plan_rejects_out_of_scope_paths() -> None:
+    plan = plan_incremental_foundup_index(
+        foundup_id="paccess_001",
+        changed_paths=["modules/foundups/other/src/main.py"],
+    )
+
+    assert plan.decision == DECISION_REJECTED
+    assert plan.operations == []
+    assert plan.rejection_reasons == [
+        "path_outside_foundup_scope:modules/foundups/other/src/main.py"
+    ]
+
+
+def test_plan_rejects_traversal_and_absolute_paths() -> None:
+    plan = plan_incremental_foundup_index(
+        foundup_id="paccess_001",
+        changed_paths=[
+            "../modules/foundups/paccess_001/src/main.py",
+            "C:/repo/modules/foundups/paccess_001/src/main.py",
+        ],
+    )
+
+    assert plan.decision == DECISION_REJECTED
+    assert "path_traversal:../modules/foundups/paccess_001/src/main.py" in plan.rejection_reasons
+    assert "absolute_path:C:/repo/modules/foundups/paccess_001/src/main.py" in plan.rejection_reasons
+
+
+def test_plan_handles_removed_paths_as_delete_id_operations() -> None:
+    plan = plan_incremental_foundup_index(
+        foundup_id="paccess_001",
+        removed_paths=[
+            "modules/foundups/paccess_001/src/main.py",
+            "modules/foundups/paccess_001/README.md",
+        ],
+    )
+
+    assert plan.decision == DECISION_PLANNED
+    assert {operation.operation for operation in plan.operations} == {OP_DELETE_PATH_ID}
+    assert plan.target_collections == ["navigation_docs", "navigation_symbols"]
+
+
+def test_no_indexable_changes_is_explicit_not_successful_reindex() -> None:
+    plan = plan_incremental_foundup_index(
+        foundup_id="paccess_001",
+        changed_paths=["modules/foundups/paccess_001/.gitkeep"],
+    )
+
+    assert plan.decision == DECISION_NO_INDEXABLE_CHANGES
+    assert plan.operations == []
+    assert plan.target_collections == []
+    assert plan.no_reindex_performed is True
+
+
+def test_invalid_foundup_id_rejects_without_normalizing_scope() -> None:
+    plan = plan_incremental_foundup_index(
+        foundup_id="../paccess_001",
+        changed_paths=["modules/foundups/paccess_001/src/main.py"],
+    )
+
+    assert plan.decision == DECISION_REJECTED
+    assert plan.foundup_root == ""
+    assert plan.rejection_reasons == ["invalid_foundup_id"]
+
+
+def test_module_has_no_live_index_or_subprocess_imports() -> None:
+    source = MODULE.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    banned_imports = {"subprocess", "requests", "holo_index.core.holo_index"}
+    banned_calls = {
+        "delete",
+        "delete_collection",
+        "get_collection",
+        "index_code_entries",
+        "index_docs_entries",
+        "index_symbol_entries",
+        "run",
+        "system",
+    }
+    assert ".collection.add(" not in source
+    assert "_reset_collection(" not in source
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name not in banned_imports
+        if isinstance(node, ast.ImportFrom):
+            assert (node.module or "") not in banned_imports
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            assert node.func.attr not in banned_calls
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls


### PR DESCRIPTION
## Summary

Implements `HOLOINDEX_INCREMENTAL_PER_FOUNDUP_INDEX_PHASE1` as the first safe scaling primitive for per-FoundUp indexing.

- Adds `holo_index/incremental_foundup_index.py`.
- Provides deterministic non-positional stable IDs for future HoloIndex entries.
- Provides strict `foundup_id` and path-scope validation for `modules/foundups/{foundup_id}`.
- Plans changed-path upserts and removed-path delete-by-ID operations without executing them.
- Emits foundup-scoped delete filters (`{foundup_id: ...}`) for future WRE/CI index writers.

## WSP_97 Truth Boundary

OBSERVED:
- Current indexers already attach `foundup_id` metadata through `resolve_foundup_metadata()`.
- Current live writes still use positional IDs such as `doc_{idx}` / `sym_{n}` and full collection reset.
- The governance doc requires stable IDs + per-FoundUp scope as the scaling primitive.

IMPLEMENTED HERE:
- Stable ID primitive.
- Per-FoundUp scope validation.
- Non-mutating incremental plan for changed/removed FoundUp paths.
- AST guards proving no live index mutation or subprocess surface.

SPECIFIED_NOT_IMPLEMENTED:
- Wiring stable IDs into live indexers.
- ChromaDB delete/upsert execution.
- Cap removal/sharding and segment garbage collection.
- Any runtime re-index.

## Validation

```text
python -m pytest holo_index\tests\test_holoindex_incremental_foundup_index.py -q
  14 passed

python -m pytest holo_index\tests\test_holoindex_incremental_foundup_index.py holo_index\tests\test_holoindex_ci_freshness_gate.py holo_index\tests\test_holoindex_freshness_receipt.py holo_index\tests\test_holoindex_index_gap_workitem.py holo_index\tests\test_holoindex_readonly_query_guard.py holo_index\tests\test_holoindex_freshness_governance_doc.py holo_index\tests\test_collection_health.py -q
  104 passed

python -m compileall -q holo_index\incremental_foundup_index.py holo_index\tests\test_holoindex_incremental_foundup_index.py
  PASS

git diff --check
  PASS

ASCII/NUL scan on new files
  0 bad bytes
```

## HoloIndex Addendum

Read-only probe was run with `HOLOINDEX_QUERY_READONLY=1` for:

```text
HOLOINDEX_INCREMENTAL_PER_FOUNDUP_INDEX_PHASE1 incremental_foundup_index stable id delete filter
```

The new module/test did not surface before re-index, so this records `HOLOINDEX_INCREMENTAL_PER_FOUNDUP_INDEX_INDEX_GAP_PHASE1`. No runtime re-index was performed.