### PR TITLE
fix(reddog): align WRE worktree create with cwd guard

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,16 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-12: REDDOG_WRE_WORKTREE_CREATE_CWD_GUARD_ALIGNMENT_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 53, 85, 97
+
+- Updated `src/reddog_wre_executor_dryrun.py`: proposed worktree paths now live under a sibling external root (`<repo-parent>/.reddog/worktrees/<repo-slug>/...`) instead of inside the shared repo checkout.
+- Updated `src/reddog_wre_worktree_create.py`: worktree-create validation rejects legacy in-repo `.reddog/worktrees/...` paths, requires the external root, and runs the shared WRE cwd guard before any runner call.
+- Updated `src/reddog_wre_worktree_runner.py`: the approved `git worktree` subprocess helper now applies `validate_wre_worker_operation_cwd()` before create/remove operations, so direct runner use also refuses shared-main or nested-main paths.
+- Updated worktree-create, operational-spine, and executor dry-run tests to lock the external-root invariant and prove in-repo worktree paths reject before subprocess.
+- Boundary: no task execution, no file edits, no commit, no PR, no merge, no OpenClaw/Hermes dispatch, no extension runtime wiring, and no HoloIndex re-index.
+- HoloIndex read-only probe for `RedDog WRE operational spine worktree create cwd guard external worktree root` surfaced the executor dry-run and CWD guard surfaces. No runtime re-index performed.
+
 ## 2026-07-12: REDDOG_MERGE_AUTHORITY_DRYRUN_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 71, 95, 96, 97, 100

--- a/modules/communication/moltbot_bridge/src/reddog_wre_executor_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_executor_dryrun.py
@@ -29,6 +29,7 @@ import json
 import re
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, List, Mapping, MutableSet, Optional, Sequence, Union
 
 from modules.communication.moltbot_bridge.src.reddog_governed_work_order_dryrun import (
@@ -156,6 +157,16 @@ def _nonce_suffix(nonce: str) -> str:
     return cleaned or "nonce"
 
 
+def _repo_slug(repo_root: Path) -> str:
+    cleaned = _NONCE_SUFFIX_RE.sub("-", repo_root.name.strip())[:48].strip("-")
+    return cleaned or "repo"
+
+
+def _external_worktree_root(repo_root: str) -> Path:
+    root = Path(repo_root or ".").resolve()
+    return root.parent / ".reddog" / "worktrees" / _repo_slug(root)
+
+
 def _invocation_from_any(
     invocation_result: Union[WorkOrderDryRunInvocationResult, Mapping[str, Any]],
 ) -> WorkOrderDryRunInvocationResult:
@@ -180,9 +191,9 @@ def _build_cleanup_plan(work_order: Mapping[str, Any]) -> Dict[str, Any]:
 
 
 def _proposed_worktree_path(repo_root: str, work_order_id: str, nonce: str) -> str:
-    root = _normalize_posix(repo_root) or "."
     suffix = _nonce_suffix(nonce)
-    return f"{root}/.reddog/worktrees/{work_order_id}/{suffix}/"
+    root = _external_worktree_root(repo_root)
+    return f"{_normalize_posix(str(root))}/{work_order_id}/{suffix}/"
 
 
 def _phase_receipt(
@@ -276,7 +287,7 @@ def _validate_contract_rules(
         reasons.append("cleanup_plan_missing")
 
     worktree_path = _proposed_worktree_path(repo_root, work_order_id, nonce or "missing")
-    expected_prefix = f"{_normalize_posix(repo_root) or '.'}/.reddog/worktrees/{work_order_id}/"
+    expected_prefix = f"{_normalize_posix(str(_external_worktree_root(repo_root)))}/{work_order_id}/"
     if not worktree_path.startswith(expected_prefix):
         reasons.append("worktree_path_not_confined")
 

--- a/modules/communication/moltbot_bridge/src/reddog_wre_worktree_create.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_worktree_create.py
@@ -29,6 +29,9 @@ from typing import Any, Dict, List, Mapping, MutableSet, Optional
 from modules.communication.moltbot_bridge.src.reddog_governed_work_order_dryrun import (
     PROTECTED_BASE_REFS,
 )
+from modules.communication.moltbot_bridge.src.reddog_wre_cwd_guard import (
+    validate_wre_worker_operation_cwd,
+)
 from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
     VALVE_OPEN_WORKTREE_CREATE,
 )
@@ -132,6 +135,16 @@ def _is_inside(child: Path, parent: Path) -> bool:
     child_r = child.resolve()
     parent_r = parent.resolve()
     return child_r == parent_r or parent_r in child_r.parents
+
+
+def _repo_slug(repo_root: Path) -> str:
+    text = "".join(ch if ch.isalnum() or ch in ("-", "_") else "-" for ch in repo_root.name.strip())
+    return text[:48].strip("-_") or "repo"
+
+
+def _external_worktree_root(repo_root: Path) -> Path:
+    root = repo_root.resolve()
+    return root.parent / ".reddog" / "worktrees" / _repo_slug(root)
 
 
 def _reject(
@@ -252,11 +265,20 @@ def _validate_worktree_path(
             reasons.append("worktree_path_device_prefix_forbidden")
             return reasons
 
-    expected_root = (repo_root / ".reddog" / "worktrees" / work_order_id).resolve()
+    if _is_inside(worktree_path, repo_root):
+        reasons.append("worktree_path_inside_repo_root")
+    expected_root = (_external_worktree_root(repo_root) / work_order_id).resolve()
     if not _is_inside(worktree_path, expected_root):
         reasons.append("worktree_path_not_under_reddog_root")
     if worktree_path.resolve() == repo_root.resolve():
         reasons.append("worktree_equals_repo_root")
+    guard = validate_wre_worker_operation_cwd(
+        repo_root=repo_root,
+        worktree_path=worktree_path,
+        operation_cwd=worktree_path,
+    )
+    if not guard.ok:
+        reasons.append(f"cwd_guard_failed:{guard.code}")
     return reasons
 
 

--- a/modules/communication/moltbot_bridge/src/reddog_wre_worktree_runner.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_worktree_runner.py
@@ -12,6 +12,10 @@ import subprocess
 from pathlib import Path
 from typing import Any, Dict, Protocol, runtime_checkable
 
+from modules.communication.moltbot_bridge.src.reddog_wre_cwd_guard import (
+    validate_wre_worker_operation_cwd,
+)
+
 
 @runtime_checkable
 class RedDogWorktreeRunner(Protocol):
@@ -39,6 +43,21 @@ class RealRedDogWorktreeRunner:
     def __init__(self, repo_root: Path, *, timeout_s: int = 120) -> None:
         self.repo_root = Path(repo_root)
         self.timeout_s = int(timeout_s)
+
+    def _guard_worktree(self, worktree_path: Path) -> Dict[str, Any] | None:
+        guard = validate_wre_worker_operation_cwd(
+            repo_root=self.repo_root,
+            worktree_path=worktree_path,
+            operation_cwd=worktree_path,
+        )
+        if guard.ok:
+            return None
+        return {
+            "ok": False,
+            "returncode": -1,
+            "stdout": "",
+            "stderr": f"{guard.code}: {guard.reason}",
+        }
 
     def _run(self, argv: list[str]) -> Dict[str, Any]:
         proc = subprocess.run(
@@ -69,6 +88,9 @@ class RealRedDogWorktreeRunner:
                 "stdout": "",
                 "stderr": "worktree_path must be absolute",
             }
+        guard = self._guard_worktree(Path(worktree_path))
+        if guard is not None:
+            return guard
         return self._run(
             [
                 "git",
@@ -82,6 +104,9 @@ class RealRedDogWorktreeRunner:
         )
 
     def cleanup_worktree(self, *, worktree_path: Path) -> Dict[str, Any]:
+        guard = self._guard_worktree(Path(worktree_path))
+        if guard is not None:
+            return guard
         return self._run(["git", "worktree", "remove", str(worktree_path), "--force"])
 
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_executor_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_executor_dryrun.py
@@ -121,7 +121,9 @@ class TestExecutorDryRunAccept:
         assert result.no_mutation_performed is True
         assert result.plan.no_mutation_performed is True
         assert result.plan.proposed_branch_name == "docs/executor-dryrun-test"
-        assert ".reddog/worktrees/wo-exec-dryrun-001/" in result.plan.proposed_worktree_path
+        assert "/.reddog/worktrees/" in result.plan.proposed_worktree_path
+        assert "/wo-exec-dryrun-001/" in result.plan.proposed_worktree_path
+        assert "/Foundups-Agent/.reddog/worktrees/" not in result.plan.proposed_worktree_path
         assert result.plan.lock_key == "wo-exec-dryrun-001"
         assert len(result.phase_receipts) == 3
         phases = [r.phase for r in result.phase_receipts]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_operational_spine.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_operational_spine.py
@@ -35,6 +35,12 @@ class FakeRunner:
         return {"ok": True}
 
 
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
 def _future_expiry(now: datetime, hours: int = 2) -> str:
     return (now + timedelta(hours=hours)).replace(microsecond=0).isoformat()
 
@@ -145,6 +151,8 @@ class TestOperationalSpineAccept:
         assert result.merge_performed is False
         assert result.main_checkout_untouched is True
         assert [call[0] for call in runner.calls] == ["create_worktree"]
+        assert not _is_inside(Path(runner.calls[0][1]), repo_root)
+        assert _is_inside(Path(runner.calls[0][1]), repo_root.parent / ".reddog" / "worktrees" / "repo")
         assert locks == {order["work_order_id"]}
 
     def test_digest_stable_and_sovereign_token_not_emitted(self, tmp_path: Path):

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_worktree_create.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_worktree_create.py
@@ -55,6 +55,12 @@ class FakeRunner:
         return {"ok": True}
 
 
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
 def _future_expiry(hours: int = 2) -> str:
     return (datetime.now(timezone.utc) + timedelta(hours=hours)).replace(microsecond=0).isoformat()
 
@@ -207,6 +213,8 @@ class TestWorktreeCreateAccept:
         assert runner.calls[0][0] == "create_worktree"
         assert Path(runner.calls[0][1]).resolve() == Path(result.worktree_path).resolve()
         assert runner.calls[0][2:] == ("feat/reddog-worktree-create-test", "main")
+        assert not _is_inside(Path(result.worktree_path), repo_root)
+        assert _is_inside(Path(result.worktree_path), repo_root.parent / ".reddog" / "worktrees" / "repo")
         phases = [receipt.phase for receipt in result.phase_receipts]
         assert phases == [
             PHASE_WORKTREE_PREFLIGHT,
@@ -291,6 +299,26 @@ class TestWorktreeCreateReject:
         assert "worktree_path_not_under_reddog_root" in result.rejection_reasons
         assert runner.calls == []
 
+    def test_legacy_in_repo_reddog_worktree_rejects_before_runner(self, tmp_path: Path):
+        order, executor, valve, repo_root, fixed = _accepted_spine(tmp_path)
+        payload = executor.to_dict()
+        payload["plan"]["proposed_worktree_path"] = str(
+            repo_root / ".reddog" / "worktrees" / order["work_order_id"] / "nonce"
+        )
+        runner = FakeRunner()
+        result = create_reddog_wre_worktree(
+            order,
+            payload,
+            valve.to_dict(),
+            runner=runner,
+            repo_root=repo_root,
+            now=fixed,
+        )
+        assert result.decision == WORKTREE_CREATE_REJECT
+        assert "worktree_path_inside_repo_root" in result.rejection_reasons
+        assert any(reason.startswith("cwd_guard_failed:") for reason in result.rejection_reasons)
+        assert runner.calls == []
+
     def test_create_failure_attempts_cleanup(self, tmp_path: Path):
         order, executor, valve, repo_root, fixed = _accepted_spine(tmp_path)
         runner = FakeRunner(ok=False)
@@ -337,8 +365,33 @@ class TestWorktreeCreateBoundaries:
             Path(__file__).resolve().parents[1] / "src" / "reddog_wre_worktree_runner.py"
         )
         source = module_path.read_text(encoding="utf-8")
+        assert "validate_wre_worker_operation_cwd" in source
         assert "shell=True" not in source
         assert '"gh"' not in source and "'gh'" not in source
         assert '"commit"' not in source and "'commit'" not in source
         assert '"push"' not in source and "'push'" not in source
         assert '"worktree"' in source and '"add"' in source
+
+    def test_real_runner_rejects_in_repo_worktree_before_subprocess(self, tmp_path: Path, monkeypatch):
+        import modules.communication.moltbot_bridge.src.reddog_wre_worktree_runner as runner_module
+
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        blocked_path = repo_root / ".reddog" / "worktrees" / "wo" / "nonce"
+        called = {"subprocess": False}
+
+        def fake_run(*args, **kwargs):
+            called["subprocess"] = True
+            raise AssertionError("subprocess must not run for in-repo worktree path")
+
+        monkeypatch.setattr(runner_module.subprocess, "run", fake_run)
+        runner = runner_module.RealRedDogWorktreeRunner(repo_root)
+        result = runner.create_worktree(
+            worktree_path=blocked_path,
+            branch_name="feat/blocked",
+            base_ref="main",
+        )
+
+        assert result["ok"] is False
+        assert "FAIL_WORKTREE_INSIDE_REPO_ROOT" in result["stderr"]
+        assert called["subprocess"] is False


### PR DESCRIPTION
## Summary

REDDOG_WRE_WORKTREE_CREATE_CWD_GUARD_ALIGNMENT_PHASE1

Aligns the RedDog WRE worktree-create spine with the landed WRE CWD guard. The old planner proposed `<repo>/.reddog/worktrees/...` inside the shared checkout; this slice moves planned worktrees to a sibling external root and fail-closes legacy in-repo paths before any runner call.

## Changes

- `reddog_wre_executor_dryrun.py`: proposes `<repo-parent>/.reddog/worktrees/<repo-slug>/<work_order_id>/<nonce>/`.
- `reddog_wre_worktree_create.py`: rejects in-repo worktree paths and validates with `validate_wre_worker_operation_cwd()`.
- `reddog_wre_worktree_runner.py`: applies the shared CWD guard before real `git worktree add/remove` subprocess calls.
- Tests updated to lock external-root behavior and prove in-repo `.reddog/worktrees` paths reject before subprocess.

## Validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_executor_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_wre_worktree_create.py modules/communication/moltbot_bridge/tests/test_reddog_wre_operational_spine.py modules/communication/moltbot_bridge/tests/test_reddog_wre_cwd_guard.py -q` -> 30 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_executor_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_wre_worktree_create.py modules/communication/moltbot_bridge/tests/test_reddog_wre_operational_spine.py modules/communication/moltbot_bridge/tests/test_reddog_wre_cwd_guard.py modules/communication/moltbot_bridge/tests/test_reddog_wre_execution_valve.py modules/communication/moltbot_bridge/tests/test_reddog_wre_governed_shell_runner_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_generic_agent_worktree_writer_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_merge_authority_dryrun.py -q` -> 116 passed
- `git diff --check` -> clean (Windows LF/CRLF informational warnings only)
- Added lines byte scan -> 0 non-ASCII

## Full-suite caveat

A full `python -m pytest modules/communication/moltbot_bridge/tests -q` run is not usable as this slice gate in this environment: it collapses into broad pytest capture/tempfile setup/teardown errors after supervisor/skill fixtures (`ValueError: I/O operation on closed file`, plus missing `logs/foundups_agent.log`). The directly affected and adjacent authority subset above is green.

## Truth Boundary Checklist

- NO task execution
- NO file edits by RedDog worker
- NO PR creation
- NO push/merge
- NO OpenClaw/Hermes dispatch
- NO extension runtime wiring
- NO HoloIndex re-index
- WRE worktree-create path only; explicit extension invoke remains next after this safety fix lands

Worker-Lane: codex
Slice: REDDOG_WRE_WORKTREE_CREATE_CWD_GUARD_ALIGNMENT_PHASE1