### PR TITLE
feat(reddog): emit governed work-order candidate from extension

### DIFF
--- a/extensions/foundups_advisory_workers/INTERFACE.md
+++ b/extensions/foundups_advisory_workers/INTERFACE.md
@@ -96,6 +96,8 @@ RedDog is the 0102 architect interface — **not an authority owner**. RedDog re
 
 **WRE operational spine dry-run preview (extension v0.3.46):** `buildWreOperationalSpineDryRunPreview()` emits `review_packet.wre_operational_spine_dryrun_preview` and Copy MD section `## WRE Operational Spine Dry-Run Preview`. It references `modules/communication/moltbot_bridge/src/reddog_wre_operational_spine.py::run_reddog_wre_worktree_create_spine` as a future call target only. The extension does **not** invoke Python for this preview and records `python_invocation_performed=false`, `wre_spine_invoked=false`, `worktree_create_performed=false`, `task_execution_performed=false`, `openclaw_enqueue_performed=false`, `hermes_dispatch_performed=false`, `pr_created=false`, and `merge_performed=false`. Future live use requires `VALVE_OPEN_WORKTREE_CREATE` and `012_sovereign`.
 
+**Governed work-order candidate emission (extension v0.3.49):** `buildRedDogGovernedWorkOrderCandidate()` emits a full `RedDogGovernedWorkOrder` candidate inside the WRE dry-run preview and Copy MD section `## RedDog Governed Work Order Candidate`. It binds extension version, work-focus digest, WSP prompt digest, HoloIndex evidence posture, derived path scope, nonce, expiry, rollback plan, and safe advisory source digests. The candidate is explicitly not invocation-ready unless a later slice supplies a fresh permission snapshot, signed work authority, and explicit worktree valve request. No Python invocation, worktree create, task execution, OpenClaw enqueue, Hermes dispatch, PR, push, merge, or reward settlement is performed by this emission slice.
+
 **Judgment generation verifier wiring (extension v0.3.47):** when a work focus contains a top-level `Determine:` numbered list, `constructWspTaskPrompt()` instructs RedDog to emit a canonical `## Determine Answers` fenced JSON block. After any schema repair, `runJudgmentVerifier()` invokes `scripts/reddog_judgment_verifier_once.py`, which reuses `reddog_adversarial_verifier_panel.verify_answer_set()` against already-fetched direct-read hit bodies and the HoloIndex scorecard. The verifier is deterministic/local only: no HoloIndex re-index, WRE enqueue, shell, repo mutation, OpenClaw/Hermes dispatch, or network call. Run Trace / Copy MD expose `judgment_verifier_applied`, `judgment_verifier_verified`, verified/refuted/NEEDS_VERIFICATION counts, support-note counts, and advisory `index_gap_event` metadata.
 
 **Specified flow (not implemented in extension v0.3.27):**
@@ -382,7 +384,7 @@ Formal contract:
 | OpenClaw FoundUpJob adapter | SPECIFIED_NOT_IMPLEMENTED (contract doc only) |
 | AssignmentDispatcher as worker launcher | FORBIDDEN (simulated scaffold only) |
 | Governed repo work order dry-run validator | OBSERVED (OpenClaw bridge module) |
-| Governed repo work order (`RedDogGovernedWorkOrder`) | SPECIFIED_NOT_IMPLEMENTED (runtime emission from extension) |
+| Governed repo work order (`RedDogGovernedWorkOrder`) | OBSERVED (candidate runtime emission from extension; authority binding still required) |
 | WRE operational spine dry-run preview | OBSERVED (extension v0.3.46); metadata only, no invocation |
 | Extension invokes `reddog_wre_operational_spine.py` | SPECIFIED_NOT_IMPLEMENTED |
 | GitHub permission snapshot per work order | SPECIFIED_NOT_IMPLEMENTED |

--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,14 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-12 - REDDOG_EXTENSION_GOVERNED_WORK_ORDER_RUNTIME_EMISSION_PHASE1 (governed work-order candidate, 0.3.49)
+
+- `buildWreOperationalSpineDryRunPreview()` now embeds a full `RedDogGovernedWorkOrder` candidate under `governed_work_order_runtime_emission`.
+- The candidate binds extension version, work-focus digest, WSP prompt digest, HoloIndex evidence posture, derived path scope, rollback plan, nonce, expiry, and safe advisory source digests without storing raw work focus.
+- Fail-closed boundary: the candidate uses `repo_permission_snapshot.source=extension_runtime_candidate`, `permission_level=needs_verification`, `signed_authority_verified=false`, and `explicit_valve_requested=false`, so it is not WRE-invocation-ready until later authority gates land.
+- HoloIndex query-only preflight found the existing RedDog work-order spine and contracts, but not the new extension runtime-emission surface itself; recorded follow-up `HOLOINDEX_REDDOG_EXTENSION_GOVERNED_WORK_ORDER_EMISSION_INDEX_GAP_PHASE1`.
+- Version 0.3.48 -> 0.3.49 (package.json + EXTENSION_VERSION + README + contract-test assertions).
+
 ## 2026-07-11 - REDDOG_OPENCLAW_LIVE_ENQUEUE_CONTRACT_PHASE1 (refreshed contract pointer)
 
 - Refresh stale #905 contract on current main after signed authority (#950) and signed receipt chain (#951).

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.48
+Version: 0.3.49
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 

--- a/extensions/foundups_advisory_workers/ROADMAP.md
+++ b/extensions/foundups_advisory_workers/ROADMAP.md
@@ -21,6 +21,7 @@ Current implementation:
 - REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_DRYRUN_WIRE_PHASE1 (v0.3.46): Copy MD/review packet emits typed WRE operational spine dry-run preview; no Python spine invocation, worktree create, task execution, OpenClaw enqueue, Hermes dispatch, PR, push, merge, or repo mutation.
 - REDDOG_JUDGMENT_GENERATION_WIRING_PHASE1 (v0.3.47): Determine prompts now request canonical `## Determine Answers` JSON and run a local deterministic verifier against already-fetched direct-read evidence; Run Trace/Copy MD expose verifier verdicts and advisory INDEX_GAP metadata. No re-index, WRE enqueue, shell, repo mutation, or network authority is added.
 - HOLOINDEX_READONLY_QUERY_GUARD_PHASE1 (v0.3.48): RedDog launches HoloIndex with `HOLOINDEX_QUERY_READONLY=1`; HoloIndex search/query mode is read-only by default, search-time auto-refresh requires explicit `--allow-auto-refresh`, and collection reset refuses read-only query contexts.
+- REDDOG_EXTENSION_GOVERNED_WORK_ORDER_RUNTIME_EMISSION_PHASE1 (v0.3.49): WRE preview embeds a full `RedDogGovernedWorkOrder` candidate with digest, derived path scope, HoloIndex evidence posture, nonce, expiry, and fail-closed authority readiness flags. It still does not invoke Python, create a worktree, run tasks, enqueue, push, merge, or settle rewards.
 
 ## Architecture Direction
 
@@ -478,7 +479,9 @@ Add slice spec section before WSP_15 table or after - actually add to ROADMAP wi
 
 - **Status:** **IMPLEMENTED (extension dry-run preview only, v0.3.46)** -- `buildWreOperationalSpineDryRunPreview()` emits a typed candidate envelope into Copy MD and `review_packet.wre_operational_spine_dryrun_preview`.
 - **Boundary:** no `cp.execFileSync` call to `reddog_wre_operational_spine.py`, no worktree create, no task execution, no file edit, no PR, no OpenClaw enqueue, no Hermes dispatch, no push, no merge. Blocked-local packets skip the preview.
-- **Next gate:** `REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_EXPLICIT_VALVE_INVOKE_PHASE1` -- only after `012_sovereign` + `VALVE_OPEN_WORKTREE_CREATE` are explicit and tests prove no raw work focus/API key leakage.
+- **Runtime emission:** **IMPLEMENTED (candidate only, v0.3.49)** -- `governed_work_order_runtime_emission` embeds a full `RedDogGovernedWorkOrder` candidate with digest and not-ready reasons. It is not executable authority.
+- **Next gate:** `REDDOG_EXTENSION_WORK_ORDER_PERMISSION_AND_SIGNATURE_BINDING_PHASE1` -- attach fresh permission snapshot + signed work authority before invoking `REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_EXPLICIT_VALVE_INVOKE_PHASE1`.
+- **Discoverability:** `HOLOINDEX_REDDOG_EXTENSION_GOVERNED_WORK_ORDER_EMISSION_INDEX_GAP_PHASE1` -- query-only preflight finds adjacent RedDog work-order modules/contracts but not the extension runtime-emission surface; WRE/CI re-index remains the maintenance owner.
 
 ### REDDOG_REVIEW_CONSENSUS_RECEIPTS_PHASE1
 

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.48';
+const EXTENSION_VERSION = '0.3.49';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -29,6 +29,7 @@ const BRIDGE_MAX_STDERR_BYTES = 65536;
 const BRIDGE_MAX_CONTEXT_CHARS = 48000;
 const BRIDGE_MAX_PROMPT_CHARS = 12000;
 const WRE_OPERATIONAL_SPINE_DRYRUN_SLICE = 'REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_DRYRUN_WIRE_PHASE1';
+const WRE_GOVERNED_WORK_ORDER_EMISSION_SLICE = 'REDDOG_EXTENSION_GOVERNED_WORK_ORDER_RUNTIME_EMISSION_PHASE1';
 const WRE_OPERATIONAL_SPINE_TARGET = 'reddog_wre_operational_spine';
 const WRE_OPERATIONAL_SPINE_CALL = 'modules/communication/moltbot_bridge/src/reddog_wre_operational_spine.py::run_reddog_wre_worktree_create_spine';
 const WRE_OPERATIONAL_SPINE_REQUIRED_VALVE = 'VALVE_OPEN_WORKTREE_CREATE';
@@ -1625,6 +1626,223 @@ function buildGovernedHandoffSection(recommendation) {
   return lines.join('\n');
 }
 
+function uniqueStrings(values) {
+  const seen = new Set();
+  const out = [];
+  for (const value of Array.isArray(values) ? values : []) {
+    const text = String(value || '').trim();
+    if (!text || seen.has(text)) continue;
+    seen.add(text);
+    out.push(text);
+  }
+  return out;
+}
+
+function canonicalWorkOrderDigest(payload) {
+  const normalize = (value) => {
+    if (Array.isArray(value)) {
+      return value.map(normalize);
+    }
+    if (value && typeof value === 'object') {
+      const out = {};
+      for (const key of Object.keys(value).sort()) {
+        out[key] = normalize(value[key]);
+      }
+      return out;
+    }
+    return value;
+  };
+  return 'sha256:' + crypto.createHash('sha256')
+    .update(JSON.stringify(normalize(payload)), 'utf8')
+    .digest('hex');
+}
+
+function toIsoTimestampOrNow(value) {
+  const parsed = Date.parse(String(value || ''));
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : new Date().toISOString();
+}
+
+function addHoursIsoTimestamp(value, hours) {
+  const parsed = Date.parse(String(value || ''));
+  const base = Number.isFinite(parsed) ? parsed : Date.now();
+  return new Date(base + hours * 60 * 60 * 1000).toISOString();
+}
+
+function deriveAllowedPathsFromTargets(targets) {
+  const scopes = [];
+  for (const target of Array.isArray(targets) ? targets : []) {
+    const normalized = stripSymbolSuffix(normalizeTargetPath(target));
+    if (!normalized || normalized.toLowerCase().startsWith('symbol:')) continue;
+    if (isTargetReadPathDenied(normalized)) continue;
+    const slash = normalized.lastIndexOf('/');
+    if (slash <= 0) continue;
+    scopes.push(normalized.slice(0, slash + 1) + '**');
+  }
+  return uniqueStrings(scopes).slice(0, 12);
+}
+
+function buildRedDogGovernedWorkOrderCandidate(workFocus, classification, handoffRecommendation, options) {
+  const opts = options && typeof options === 'object' ? options : {};
+  const rec = handoffRecommendation && typeof handoffRecommendation === 'object' ? handoffRecommendation : {};
+  const construction = opts.promptConstruction && typeof opts.promptConstruction === 'object' ? opts.promptConstruction : {};
+  const rawFocus = String(workFocus || '');
+  const createdAt = toIsoTimestampOrNow(opts.createdAt);
+  const expiresAt = opts.expiresAt ? toIsoTimestampOrNow(opts.expiresAt) : addHoursIsoTimestamp(createdAt, 1);
+  const requiredTargets = Array.isArray(opts.requiredTargets)
+    ? opts.requiredTargets.slice()
+    : (Array.isArray(construction.required_targets_authoritative_paths)
+      ? construction.required_targets_authoritative_paths.slice()
+      : []);
+  const allowedPaths = uniqueStrings(opts.allowedPaths || deriveAllowedPathsFromTargets(requiredTargets));
+  const deniedPaths = uniqueStrings(opts.deniedPaths || ['.env', '.env.*', '**/.env', '**/.git/**']);
+  const workFocusDigest = construction.work_focus_digest && construction.work_focus_digest.hash
+    ? construction.work_focus_digest.hash
+    : (opts.workFocusDigest || canonicalWorkOrderDigest({ work_focus: rawFocus }));
+  const wspPromptDigest = construction.wsp_prompt_digest && construction.wsp_prompt_digest.hash
+    ? construction.wsp_prompt_digest.hash
+    : (opts.wspPromptDigest || 'unknown');
+  const workOrderId = 'rdog-wo-' + canonicalWorkOrderDigest({
+    work_focus_digest: workFocusDigest,
+    created_at: createdAt,
+    slice: WRE_GOVERNED_WORK_ORDER_EMISSION_SLICE
+  }).slice('sha256:'.length, 'sha256:'.length + 16);
+  const permissionLevel = String(opts.permissionLevel || 'needs_verification');
+  const permissionSource = String(opts.permissionSource || 'extension_runtime_candidate');
+  const permissionSnapshot = {
+    permission_level: permissionLevel,
+    captured_at: String(opts.permissionCapturedAt || createdAt),
+    source: permissionSource,
+    digest: canonicalWorkOrderDigest({
+      principal: opts.authenticatedPrincipal || 'external_principal:012',
+      repo: opts.repoFullName || 'FOUNDUPS/Foundups-Agent',
+      permission_level: permissionLevel,
+      source: permissionSource,
+      captured_at: opts.permissionCapturedAt || createdAt
+    })
+  };
+  const commandDigest = canonicalWorkOrderDigest({ work_focus: rawFocus });
+  const holoScorecard = opts.holoScorecard && typeof opts.holoScorecard === 'object' ? opts.holoScorecard : {};
+  const holoindexEvidence = opts.holoindexEvidence || {
+    holoindex_query: String(opts.holoindexQuery || 'RedDog governed work order runtime emission'),
+    holoindex_status: String(holoScorecard.holoindex_status || 'unknown'),
+    code_hits: [],
+    wsp_hits: [],
+    skillz_hits: [],
+    direct_read_fallback_used: holoScorecard.direct_read_fallback_used === true,
+    index_gap_detected: holoScorecard.index_gap_detected === true,
+    applicable_wsps: uniqueStrings(opts.wspApplicability || ['WSP_00', 'WSP_15', 'WSP_46', 'WSP_50', 'WSP_97']),
+    evidence_refs: uniqueStrings(opts.evidenceRefs || []),
+    retrieval_quality: holoScorecard.index_gap_detected === true ? 'INDEX_GAP' : 'LOW',
+    skillz_gap_detected: false
+  };
+  const workOrder = {
+    work_order_id: workOrderId,
+    created_at: createdAt,
+    red_dog_instance_id: 'foundups-agent-' + EXTENSION_VERSION,
+    authenticated_principal: String(opts.authenticatedPrincipal || 'external_principal:012'),
+    principal_provider: String(opts.principalProvider || 'extension'),
+    repo_full_name: String(opts.repoFullName || 'FOUNDUPS/Foundups-Agent'),
+    repo_permission_snapshot: permissionSnapshot,
+    requested_operation: String(opts.requestedOperation || 'feature_slice'),
+    authority_tier: String(opts.authorityTier || 'source'),
+    allowed_paths: allowedPaths,
+    denied_paths: deniedPaths,
+    branch_name: String(opts.branchName || ('feat/reddog-' + workOrderId.slice('rdog-wo-'.length))),
+    base_ref: String(opts.baseRef || 'main'),
+    task_summary: sanitizeContinuationField(rawFocus, 240),
+    wsp_applicability: uniqueStrings(opts.wspApplicability || ['WSP_00', 'WSP_15', 'WSP_46', 'WSP_50', 'WSP_97']),
+    holoindex_evidence_refs: uniqueStrings(opts.holoindexEvidenceRefs || opts.evidenceRefs || []),
+    skillz_candidates: uniqueStrings(opts.skillzCandidates || []),
+    required_tests: uniqueStrings(opts.requiredTests || []),
+    required_policy_gates: uniqueStrings(opts.requiredPolicyGates || [
+      'reddog_work_order_signature_gate',
+      'reddog_wre_execution_valve',
+      'reddog_wre_cwd_guard'
+    ]),
+    required_reviewers: uniqueStrings(opts.requiredReviewers || []),
+    sentinel_checks: uniqueStrings(opts.sentinelChecks || ['wsp97_truth_boundary', 'no_secret_leakage']),
+    rollback_plan: String(opts.rollbackPlan || 'Remove isolated worktree and delete branch on abort.'),
+    expiry: expiresAt,
+    nonce: String(opts.nonce || ('nonce-' + workOrderId.slice('rdog-wo-'.length))),
+    evidence_digest: canonicalWorkOrderDigest({
+      command_digest: commandDigest,
+      work_focus_digest: workFocusDigest,
+      wsp_prompt_digest: wspPromptDigest,
+      handoff_target: rec.target || 'none'
+    }),
+    advisory_only_source_packet: {
+      work_focus_digest: workFocusDigest,
+      wsp_prompt_digest: wspPromptDigest,
+      copy_md_run_trace_digest: String(opts.copyMdRunTraceDigest || 'unknown')
+    },
+    holoindex_evidence: holoindexEvidence
+  };
+  const readyForInvocation = (
+    permissionLevel !== 'needs_verification'
+    && permissionSource !== 'extension_runtime_candidate'
+    && allowedPaths.length > 0
+    && opts.signedAuthorityVerified === true
+    && opts.explicitValveRequested === true
+  );
+  return {
+    slice_name: WRE_GOVERNED_WORK_ORDER_EMISSION_SLICE,
+    work_order: workOrder,
+    work_order_digest: canonicalWorkOrderDigest(workOrder),
+    runtime_emission_performed: true,
+    raw_work_focus_stored: false,
+    github_permission_probe_performed: false,
+    signed_authority_verified: opts.signedAuthorityVerified === true,
+    explicit_valve_requested: opts.explicitValveRequested === true,
+    ready_for_wre_invocation: readyForInvocation,
+    not_ready_reasons: readyForInvocation ? [] : uniqueStrings([
+      permissionLevel === 'needs_verification' ? 'permission_snapshot_needs_verification' : '',
+      permissionSource === 'extension_runtime_candidate' ? 'fresh_github_permission_probe_missing' : '',
+      allowedPaths.length === 0 ? 'allowed_paths_missing_or_unverified' : '',
+      opts.signedAuthorityVerified === true ? '' : 'signed_work_authority_not_verified',
+      opts.explicitValveRequested === true ? '' : 'explicit_worktree_valve_not_requested'
+    ]),
+    no_python_invocation_performed: true,
+    no_worktree_create_performed: true,
+    no_task_execution_performed: true,
+    no_file_edit_performed: true,
+    no_pr_created: true,
+    no_openclaw_enqueue_performed: true,
+    no_hermes_dispatch_performed: true,
+    no_merge_performed: true,
+    no_reward_settlement_performed: true
+  };
+}
+
+function buildRedDogGovernedWorkOrderCandidateSection(candidate) {
+  const c = candidate && typeof candidate === 'object' ? candidate : {};
+  const order = c.work_order && typeof c.work_order === 'object' ? c.work_order : {};
+  return [
+    '## RedDog Governed Work Order Candidate',
+    '- slice_name: ' + (c.slice_name || WRE_GOVERNED_WORK_ORDER_EMISSION_SLICE) + ' [OBSERVED]',
+    '- work_order_id: ' + (order.work_order_id || 'unknown') + ' [OBSERVED]',
+    '- work_order_digest: ' + (c.work_order_digest || 'unknown') + ' [OBSERVED]',
+    '- requested_operation: ' + (order.requested_operation || 'unknown') + ' [OBSERVED]',
+    '- branch_name: ' + (order.branch_name || 'unknown') + ' [OBSERVED]',
+    '- allowed_paths: ' + JSON.stringify(order.allowed_paths || []) + ' [OBSERVED]',
+    '- denied_paths: ' + JSON.stringify(order.denied_paths || []) + ' [OBSERVED]',
+    '- permission_snapshot_source: ' + ((order.repo_permission_snapshot && order.repo_permission_snapshot.source) || 'unknown') + ' [OBSERVED]',
+    '- github_permission_probe_performed: ' + (c.github_permission_probe_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- signed_authority_verified: ' + (c.signed_authority_verified === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- ready_for_wre_invocation: ' + (c.ready_for_wre_invocation === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- not_ready_reasons: ' + JSON.stringify(c.not_ready_reasons || []) + ' [OBSERVED]',
+    '- raw_work_focus_stored: ' + (c.raw_work_focus_stored === false ? 'false' : 'unknown') + ' [OBSERVED]',
+    '- no_python_invocation_performed: ' + (c.no_python_invocation_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- no_worktree_create_performed: ' + (c.no_worktree_create_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- no_task_execution_performed: ' + (c.no_task_execution_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- no_file_edit_performed: ' + (c.no_file_edit_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- no_pr_created: ' + (c.no_pr_created === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- no_openclaw_enqueue_performed: ' + (c.no_openclaw_enqueue_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- no_hermes_dispatch_performed: ' + (c.no_hermes_dispatch_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- no_merge_performed: ' + (c.no_merge_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- no_reward_settlement_performed: ' + (c.no_reward_settlement_performed === true ? 'true' : 'false') + ' [OBSERVED]'
+  ].join('\n');
+}
+
 function buildWreOperationalSpineDryRunPreview(workFocus, classification, handoffRecommendation, options) {
   const opts = options && typeof options === 'object' ? options : {};
   const rec = handoffRecommendation && typeof handoffRecommendation === 'object' ? handoffRecommendation : {};
@@ -1651,6 +1869,15 @@ function buildWreOperationalSpineDryRunPreview(workFocus, classification, handof
   if (rec.target) {
     evidenceRefs.push('handoff_target:' + String(rec.target));
   }
+  const workOrderCandidate = buildRedDogGovernedWorkOrderCandidate(
+    rawFocus,
+    classification,
+    rec,
+    Object.assign({}, opts, {
+      evidenceRefs: evidenceRefs,
+      requiredTargets: construction.required_targets_authoritative_paths || []
+    })
+  );
   return {
     preview_kind: 'RedDogWREOperationalSpineDryRunPreview',
     slice_name: WRE_OPERATIONAL_SPINE_DRYRUN_SLICE,
@@ -1658,6 +1885,9 @@ function buildWreOperationalSpineDryRunPreview(workFocus, classification, handof
     dry_run_only: true,
     candidate_work_order_emitted: true,
     work_order_type: 'RedDogGovernedWorkOrder',
+    governed_work_order_candidate: workOrderCandidate.work_order,
+    governed_work_order_candidate_digest: workOrderCandidate.work_order_digest,
+    governed_work_order_runtime_emission: workOrderCandidate,
     command_digest: commandDigest,
     command_redacted_summary: sanitizeContinuationField(rawFocus, 180),
     raw_work_focus_stored: false,
@@ -1670,6 +1900,8 @@ function buildWreOperationalSpineDryRunPreview(workFocus, classification, handof
     would_call: WRE_OPERATIONAL_SPINE_CALL,
     python_invocation_performed: false,
     wre_spine_invoked: false,
+    governed_work_order_ready_for_invocation: workOrderCandidate.ready_for_wre_invocation === true,
+    governed_work_order_not_ready_reasons: workOrderCandidate.not_ready_reasons,
     worktree_create_performed: false,
     task_execution_performed: false,
     file_edit_performed: false,
@@ -1694,6 +1926,9 @@ function buildWreOperationalSpineDryRunPreviewSection(preview) {
     '- dry_run_only: ' + (p.dry_run_only === true ? 'true' : 'false') + ' [OBSERVED]',
     '- candidate_work_order_emitted: ' + (p.candidate_work_order_emitted === true ? 'true' : 'false') + ' [OBSERVED]',
     '- work_order_type: ' + (p.work_order_type || 'unknown') + ' [OBSERVED]',
+    '- governed_work_order_candidate_digest: ' + (p.governed_work_order_candidate_digest || 'unknown') + ' [OBSERVED]',
+    '- governed_work_order_ready_for_invocation: ' + (p.governed_work_order_ready_for_invocation === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- governed_work_order_not_ready_reasons: ' + JSON.stringify(p.governed_work_order_not_ready_reasons || []) + ' [OBSERVED]',
     '- command_digest: ' + (p.command_digest || 'unknown') + ' [OBSERVED]',
     '- command_redacted_summary: ' + (p.command_redacted_summary || '(empty)') + ' [OBSERVED]',
     '- raw_work_focus_stored: ' + (p.raw_work_focus_stored === false ? 'false' : 'unknown') + ' [OBSERVED]',
@@ -1739,6 +1974,9 @@ function buildCopyMarkdown(result, workerType, contextSummary, workTrail, holoSc
     sections.push(buildGovernedHandoffSection(ctx.handoffRecommendation || packet.governed_handoff_recommendation));
     const spinePreview = ctx.wreSpineDryRunPreview || packet.wre_operational_spine_dryrun_preview;
     if (spinePreview) {
+      if (spinePreview.governed_work_order_runtime_emission) {
+        sections.push(buildRedDogGovernedWorkOrderCandidateSection(spinePreview.governed_work_order_runtime_emission));
+      }
       sections.push(buildWreOperationalSpineDryRunPreviewSection(spinePreview));
     }
   }
@@ -2915,7 +3153,8 @@ function wireFusionWebview(context, webview, worker, state) {
     const wreSpineDryRunPreview = substantiveTask && result.reason !== 'redaction_blocked'
       ? buildWreOperationalSpineDryRunPreview(workFocus, classification, handoffRecommendation, {
         promptConstruction: promptConstruction,
-        contextMode: contextMode
+        contextMode: contextMode,
+        holoScorecard: holoScorecard
       })
       : null;
     result.review_packet = attachOrchestratorMetadata(
@@ -4891,6 +5130,9 @@ module.exports = {
   buildRedactionGateReportSection,
   buildGovernedHandoffRecommendation,
   buildGovernedHandoffSection,
+  buildRedDogGovernedWorkOrderCandidate,
+  buildRedDogGovernedWorkOrderCandidateSection,
+  deriveAllowedPathsFromTargets,
   buildWreOperationalSpineDryRunPreview,
   buildWreOperationalSpineDryRunPreviewSection,
   compositePayloadDigest,

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups\u00aeAgent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.48",
+    "version":  "0.3.49",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -197,8 +197,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.48', 'package version must be 0.3.48');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.48'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.49', 'package version must be 0.3.49');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.49'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups\u00aeAgent', 'display name must be Foundups\u00aeAgent');
 includes(JSON.stringify(pkg), 'Foundups\u00aeAgent: Open', 'command title must use Foundups\u00aeAgent');
@@ -215,7 +215,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.48', 'README version mismatch');
+includes(readme, 'Version: 0.3.49', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -711,6 +711,8 @@ includes(extensionJs, 'function buildRunTraceSection', 'buildRunTraceSection mis
 includes(extensionJs, 'function buildWorkTrailSection', 'buildWorkTrailSection missing');
 includes(extensionJs, 'function buildRedactionGateReport', 'buildRedactionGateReport missing');
 includes(extensionJs, 'function buildGovernedHandoffRecommendation', 'buildGovernedHandoffRecommendation missing');
+includes(extensionJs, 'function buildRedDogGovernedWorkOrderCandidate', 'governed work-order candidate builder missing');
+includes(extensionJs, 'function buildRedDogGovernedWorkOrderCandidateSection', 'governed work-order candidate section builder missing');
 includes(extensionJs, 'function buildWreOperationalSpineDryRunPreview', 'WRE spine dry-run preview builder missing');
 includes(extensionJs, 'function buildWreOperationalSpineDryRunPreviewSection', 'WRE spine dry-run preview section builder missing');
 includes(extensionJs, 'function detectMojibake', 'detectMojibake missing');
@@ -749,7 +751,14 @@ const spinePreview = orchestrator.buildWreOperationalSpineDryRunPreview(
   { tier: 'ULTRA' },
   handoffRec,
   {
-    promptConstruction: { work_focus_digest: { hash: 'abc123' }, wsp_prompt_digest: { hash: 'def456' } },
+    promptConstruction: {
+      work_focus_digest: { hash: 'abc123' },
+      wsp_prompt_digest: { hash: 'def456' },
+      required_targets_authoritative_paths: [
+        'modules/communication/moltbot_bridge/src/reddog_wre_operational_spine.py',
+        'modules/communication/moltbot_bridge/tests/test_reddog_wre_operational_spine.py'
+      ]
+    },
     contextMode: 'wsp_holo_git_skillz'
   }
 );
@@ -757,6 +766,21 @@ assert.strictEqual(spinePreview.slice_name, 'REDDOG_EXTENSION_TO_WRE_OPERATIONAL
 assert.strictEqual(spinePreview.target, 'reddog_wre_operational_spine', 'WRE preview target');
 assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run only');
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
+assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
+assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.49', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
+assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
+assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [
+  'modules/communication/moltbot_bridge/src/**',
+  'modules/communication/moltbot_bridge/tests/**'
+], 'candidate should derive allowed paths from authoritative target paths');
+assert.strictEqual(spinePreview.governed_work_order_runtime_emission.runtime_emission_performed, true, 'candidate emission flag');
+assert.strictEqual(spinePreview.governed_work_order_runtime_emission.ready_for_wre_invocation, false, 'candidate must not be invocation-ready without authority');
+assert(spinePreview.governed_work_order_runtime_emission.not_ready_reasons.includes('fresh_github_permission_probe_missing'), 'candidate must require fresh permission probe');
+assert(spinePreview.governed_work_order_runtime_emission.not_ready_reasons.includes('signed_work_authority_not_verified'), 'candidate must require signed authority');
+assert(spinePreview.governed_work_order_runtime_emission.not_ready_reasons.includes('explicit_worktree_valve_not_requested'), 'candidate must require explicit valve request');
+assert(/^sha256:[a-f0-9]{64}$/.test(spinePreview.governed_work_order_candidate_digest), 'candidate digest must be full SHA256');
 assert.strictEqual(spinePreview.raw_work_focus_stored, false, 'WRE preview must not store raw work focus');
 assert.strictEqual(spinePreview.python_invocation_performed, false, 'WRE preview must not invoke Python');
 assert.strictEqual(spinePreview.wre_spine_invoked, false, 'WRE preview must not invoke the spine');
@@ -771,6 +795,7 @@ assert(!spinePreview.command_redacted_summary.includes('OPENROUTER_API_KEY'), 'W
 includes(spinePreview.command_redacted_summary, 'key_env_present: true', 'WRE preview summary should carry safe key-presence fact');
 const spinePreviewSection = orchestrator.buildWreOperationalSpineDryRunPreviewSection(spinePreview);
 includes(spinePreviewSection, '## WRE Operational Spine Dry-Run Preview', 'WRE preview section header');
+includes(spinePreviewSection, 'governed_work_order_ready_for_invocation: false [OBSERVED]', 'WRE preview section must show candidate is not invocation-ready');
 includes(spinePreviewSection, 'python_invocation_performed: false [OBSERVED]', 'WRE preview section must show no Python invocation');
 includes(spinePreviewSection, 'worktree_create_performed: false [OBSERVED]', 'WRE preview section must show no worktree creation');
 includes(spinePreviewSection, 'required_future_valve: VALVE_OPEN_WORKTREE_CREATE [OBSERVED]', 'WRE preview section must show valve');
@@ -796,9 +821,23 @@ const wrePreviewCopy = orchestrator.buildCopyMarkdown(
   }
 );
 includes(wrePreviewCopy, '## Governed Handoff Recommendation', 'WRE preview Copy MD keeps governed handoff section');
+includes(wrePreviewCopy, '## RedDog Governed Work Order Candidate', 'WRE preview Copy MD must include candidate section');
 includes(wrePreviewCopy, '## WRE Operational Spine Dry-Run Preview', 'WRE preview Copy MD must include preview section');
 includes(wrePreviewCopy, 'raw_work_focus_stored: false [OBSERVED]', 'WRE preview Copy MD must state raw focus is not stored');
+
+const candidateSection = orchestrator.buildRedDogGovernedWorkOrderCandidateSection(spinePreview.governed_work_order_runtime_emission);
+includes(candidateSection, 'permission_snapshot_source: extension_runtime_candidate [OBSERVED]', 'candidate section must show unverified permission source');
+includes(candidateSection, 'ready_for_wre_invocation: false [OBSERVED]', 'candidate section must show not ready');
 assert(!wrePreviewCopy.includes('OPENROUTER_API_KEY'), 'WRE preview Copy MD must not leak env key name');
+
+const timestampHardenedCandidate = orchestrator.buildRedDogGovernedWorkOrderCandidate(
+  'Fix a narrow RedDog slice',
+  {},
+  handoffRec,
+  { createdAt: 'not-a-date', expiresAt: 'also-not-a-date' }
+);
+assert(/^\d{4}-\d{2}-\d{2}T/.test(timestampHardenedCandidate.work_order.created_at), 'candidate builder must normalize invalid created_at');
+assert(/^\d{4}-\d{2}-\d{2}T/.test(timestampHardenedCandidate.work_order.expiry), 'candidate builder must normalize invalid expiry');
 
 const dedupeTrail = orchestrator.createWorkTrail();
 dedupeTrail.push('redaction_gate_blocked', 'Redaction gate blocked before network.');
@@ -1637,7 +1676,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.48'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.49'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -1651,7 +1690,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.48'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.49'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -1663,7 +1702,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.48'", 'bounded context must include extension.js source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.49'", 'bounded context must include extension.js source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');


### PR DESCRIPTION
## Slice

`REDDOG_EXTENSION_GOVERNED_WORK_ORDER_RUNTIME_EMISSION_PHASE1`

## Summary

Adds extension-side runtime emission of a full `RedDogGovernedWorkOrder` candidate inside the existing WRE operational spine dry-run preview and Copy MD output.

The candidate binds:

- extension version (`0.3.49`)
- work-focus digest and WSP prompt digest
- HoloIndex evidence posture
- derived path scope
- nonce and expiry
- rollback plan
- safe advisory source digests

## Authority boundary

This slice does **not** invoke WRE/OpenClaw/Hermes or create execution authority.

Fail-closed fields are explicit:

- `repo_permission_snapshot.source = extension_runtime_candidate`
- `permission_level = needs_verification`
- `signed_authority_verified = false`
- `explicit_valve_requested = false`
- `ready_for_wre_invocation = false`

No Python invocation, worktree create, task execution, OpenClaw enqueue, Hermes dispatch, PR creation, push, merge, or reward settlement is performed.

## Validation

- `node --check extensions/foundups_advisory_workers/extension.js` -> PASS
- `node extensions/foundups_advisory_workers/tests/verify_extension_contract.js` -> PASS
  - Known existing surrogate stderr fixture remains, exit code 0 and contract checks pass.
- `git diff --check` -> PASS
- Added-line byte scan -> 0 non-ASCII additions
- HoloIndex query-only preflight -> adjacent RedDog work-order spine/contracts found; extension runtime-emission surface not semantically ranked, recorded as `HOLOINDEX_REDDOG_EXTENSION_GOVERNED_WORK_ORDER_EMISSION_INDEX_GAP_PHASE1`.

## Truth boundary checklist

- NO_PYTHON_INVOCATION: PASS
- NO_WORKTREE_CREATE: PASS
- NO_TASK_EXECUTION: PASS
- NO_OPENCLAW_ENQUEUE: PASS
- NO_HERMES_DISPATCH: PASS
- NO_PR_OR_MERGE_AUTHORITY: PASS
- NO_REWARD_SETTLEMENT: PASS
- CANDIDATE_RUNTIME_EMISSION_ONLY: PASS

## Next gate

`REDDOG_EXTENSION_WORK_ORDER_PERMISSION_AND_SIGNATURE_BINDING_PHASE1` -- attach fresh permission snapshot and signed work authority before invoking `REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_EXPLICIT_VALVE_INVOKE_PHASE1`.