### PR TITLE
feat(reddog): typed target extraction preprocessing

### DIFF
--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,13 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-12 - REDDOG_TYPED_TARGET_EXTRACTION_PHASE1 (typed grounding input channels, 0.3.54)
+
+- Added `extractTypedTargets()` to split preprocessing into `repo_file_targets`, `semantic_targets`, `external_research_targets`, and `quoted_reference_blocks`.
+- Direct-read recall/packing now consumes only `repo_file_targets`; URLs, conceptual research phrases, and quoted/reference blocks are not sent to the governed file reader.
+- Run Trace scorecard now reports typed target counts without emitting raw external research snippets.
+- Version 0.3.53 -> 0.3.54 (package.json + EXTENSION_VERSION + README + contract-test assertions).
+
 ## 2026-07-12 - REDDOG_EXTENSION_GITHUB_PERMISSION_PROBE_RUNTIME_BRIDGE_PHASE1 (read-only permission snapshot, 0.3.53)
 
 - Added `runGithubPermissionProbeBridge()` and `scripts/reddog_github_permission_probe_once.py` to emit a fresh read-only GitHub `repo_permission_snapshot` from the live extension path.

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.53
+Version: 0.3.54
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.53';
+const EXTENSION_VERSION = '0.3.54';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -880,6 +880,10 @@ function deriveWorkFocusTargets(taskText) {
     if (WORK_FOCUS_READ_HEADER_PATTERNS.some((p) => p.test(stripped))) {
       readCapture = true;
       scopeOut = false;
+      const colonIdx = stripped.indexOf(':');
+      if (colonIdx !== -1 && colonIdx < stripped.length - 1) {
+        addProse(stripped.slice(colonIdx + 1), 'read_first');
+      }
       continue;
     }
     if (!stripped) {
@@ -1049,6 +1053,256 @@ function collectRequiredTargets(taskText) {
   };
 }
 
+// REDDOG_TYPED_TARGET_EXTRACTION_PHASE1: pre-grounding classification. The direct-file reader
+// must receive only repo-file targets; URLs, paper/research descriptors, semantic concepts, and
+// quoted reference material are routed to their own typed channels for later grounding slices.
+function extractExternalResearchTargets(taskText) {
+  const text = String(taskText || '');
+  const targets = [];
+  const seen = new Set();
+  const add = (raw) => {
+    const value = normalizeTargetPath(raw);
+    if (!value) {
+      return;
+    }
+    const norm = value.toLowerCase();
+    if (!seen.has(norm)) {
+      seen.add(norm);
+      targets.push(value);
+    }
+  };
+  for (const rawPart of splitWhitespaceWords(text)) {
+    const part = normalizeTargetPath(rawPart);
+    if (/^https?:\/\//i.test(part)) {
+      add(part);
+    }
+  }
+  const lines = text.split(/\r?\n/);
+  for (const line of lines) {
+    const stripped = line.trim();
+    if (!stripped || stripped.length > 280) {
+      continue;
+    }
+    if (lineHasAnyLowerPhrase(stripped, ['arxiv', 'doi', 'paper', 'repository', 'github repo', 'github repository', 'external source', 'web source'])
+        && !extractInlinePathTokens(stripped).length) {
+      add(stripped);
+    }
+  }
+  return targets;
+}
+
+function splitWhitespaceWords(text) {
+  const words = [];
+  const s = String(text || '');
+  let current = '';
+  for (let i = 0; i < s.length; i++) {
+    const ch = s.charAt(i);
+    if (/\s/.test(ch)) {
+      if (current) {
+        words.push(current);
+        current = '';
+      }
+    } else {
+      current += ch;
+    }
+  }
+  if (current) {
+    words.push(current);
+  }
+  return words;
+}
+
+function collapseAsciiWhitespace(text) {
+  const s = String(text || '');
+  let out = '';
+  let pendingSpace = false;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s.charAt(i);
+    if (/\s/.test(ch)) {
+      pendingSpace = true;
+      continue;
+    }
+    if (pendingSpace && out) {
+      out += ' ';
+    }
+    out += ch;
+    pendingSpace = false;
+  }
+  return out.trim();
+}
+
+function lineHasAnyLowerPhrase(line, phrases) {
+  const lower = String(line || '').toLowerCase();
+  for (const phrase of phrases) {
+    if (lower.includes(phrase)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function splitSemanticParts(text) {
+  const parts = [];
+  const s = String(text || '');
+  let current = '';
+  for (let i = 0; i < s.length; i++) {
+    const ch = s.charAt(i);
+    if (ch === ',' || ch === ';') {
+      if (current.trim()) {
+        parts.push(current.trim());
+      }
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  if (current.trim()) {
+    parts.push(current.trim());
+  }
+  return parts;
+}
+
+function semanticHeaderBody(line) {
+  const s = String(line || '');
+  const colon = s.indexOf(':');
+  if (colon === -1) {
+    return null;
+  }
+  const key = collapseAsciiWhitespace(s.slice(0, colon)).toLowerCase();
+  if (['semantic target', 'semantic targets', 'concept', 'concepts', 'research topic', 'topic', 'question'].indexOf(key) === -1) {
+    return null;
+  }
+  return s.slice(colon + 1);
+}
+
+function extractQuotedReferenceBlocks(taskText) {
+  const text = String(taskText || '');
+  const blocks = [];
+  let inFence = false;
+  let current = [];
+  const lines = text.split(/\r?\n/);
+  const flush = (kind) => {
+    const body = current.join('\n').trim();
+    current = [];
+    if (!body) {
+      return;
+    }
+    blocks.push({
+      kind: kind,
+      chars: body.length,
+      digest: crypto.createHash('sha256').update(body, 'utf8').digest('hex').slice(0, 16),
+      instructional: false
+    });
+  };
+  for (const line of lines) {
+    const stripped = line.trim();
+    if (stripped.startsWith('```')) {
+      if (inFence) {
+        flush('fenced_block');
+        inFence = false;
+      } else {
+        inFence = true;
+        current = [];
+      }
+      continue;
+    }
+    if (inFence) {
+      current.push(line);
+      continue;
+    }
+    if (stripped.startsWith('>')) {
+      current.push(stripped.replace(/^>\s?/, ''));
+      continue;
+    }
+    if (current.length) {
+      flush('blockquote');
+    }
+  }
+  if (inFence || current.length) {
+    flush(inFence ? 'fenced_block' : 'blockquote');
+  }
+  return blocks;
+}
+
+function removeQuotedReferenceBlocks(taskText) {
+  const lines = String(taskText || '').split(/\r?\n/);
+  const kept = [];
+  let inFence = false;
+  for (const line of lines) {
+    const stripped = line.trim();
+    if (stripped.startsWith('```')) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence || stripped.startsWith('>')) {
+      continue;
+    }
+    kept.push(line);
+  }
+  return kept.join('\n');
+}
+
+function extractSemanticTargets(taskText, repoTargets, externalTargets) {
+  const text = removeQuotedReferenceBlocks(taskText);
+  const repoSet = new Set((repoTargets || []).map((t) => String(t || '').toLowerCase()));
+  const externalSet = new Set((externalTargets || []).map((t) => String(t || '').toLowerCase()));
+  const targets = [];
+  const seen = new Set();
+  const add = (raw) => {
+    let value = String(raw || '').trim();
+    if (!value || value.length < 4 || value.length > 180) {
+      return;
+    }
+    value = collapseAsciiWhitespace(value);
+    const norm = value.toLowerCase();
+    if (repoSet.has(norm) || externalSet.has(norm) || seen.has(norm)) {
+      return;
+    }
+    seen.add(norm);
+    targets.push(value);
+  };
+  const lines = text.split(/\r?\n/);
+  for (const line of lines) {
+    const stripped = line.trim();
+    if (!stripped || stripped.startsWith('- ') || stripped.startsWith('* ')) {
+      continue;
+    }
+    if (/^https?:\/\//i.test(stripped) || extractInlinePathTokens(stripped).length) {
+      continue;
+    }
+    const conceptBody = semanticHeaderBody(stripped);
+    if (conceptBody !== null) {
+      for (const part of splitSemanticParts(conceptBody)) {
+        add(part);
+      }
+      continue;
+    }
+    if (lineHasAnyLowerPhrase(stripped, ['audit', 'evaluate', 'assess', 'compare', 'research', 'investigate'])
+        && lineHasAnyLowerPhrase(stripped, ['architecture', 'workflow', 'orchestration', 'grounding', 'authority', 'selection', 'pipeline', 'concept', 'paper', 'repo'])) {
+      add(stripped);
+    }
+  }
+  return targets;
+}
+
+function extractTypedTargets(taskText) {
+  const textWithoutQuotes = removeQuotedReferenceBlocks(taskText);
+  const collected = collectRequiredTargets(textWithoutQuotes);
+  const repoTargets = collected.targets.slice();
+  const externalTargets = extractExternalResearchTargets(taskText);
+  const quotedBlocks = extractQuotedReferenceBlocks(taskText);
+  const semanticTargets = extractSemanticTargets(taskText, repoTargets, externalTargets);
+  return {
+    repo_file_targets: repoTargets,
+    semantic_targets: semanticTargets,
+    external_research_targets: externalTargets,
+    quoted_reference_blocks: quotedBlocks,
+    repo_file_derivation_sources: Array.isArray(collected.derivation_sources) ? collected.derivation_sources.slice() : [],
+    repo_file_targets_derived: collected.derived === true,
+    dropped_low_confidence: Array.isArray(collected.dropped_low_confidence) ? collected.dropped_low_confidence.slice() : []
+  };
+}
+
 function isSelfFileLocation(location) {
   const loc = String(location || '').replace(/\\/g, '/').toLowerCase();
   if (!loc) {
@@ -1119,14 +1373,14 @@ function evaluateTargetRecall(taskText, bundleData) {
   // non-empty, so required_targets_total > 0 and the governed direct-read fetch fires regardless of
   // HoloIndex semantic recall. Compare each required path against content-bearing locations,
   // excluding self-file hits (extension.js / module-under-audit shell).
-  const collected = collectRequiredTargets(taskText);
-  const required = collected.targets;
-  const workFocusDerived = collected.derived;
-  const workFocusSources = collected.derivation_sources;
+  const typedTargets = extractTypedTargets(taskText);
+  const required = typedTargets.repo_file_targets;
+  const workFocusDerived = typedTargets.repo_file_targets_derived;
+  const workFocusSources = typedTargets.repo_file_derivation_sources;
   // REDDOG_WORK_FOCUS_READ_CAPTURE_PROSE_TOKENIZATION_PHASE1 (Fix B): low-confidence prose
   // fragments dropped from the required list. These are excluded from required_targets_total /
   // _missing (so they CANNOT flip target_recall_ok) and reported here for honest telemetry.
-  const workFocusDropped = Array.isArray(collected.dropped_low_confidence) ? collected.dropped_low_confidence : [];
+  const workFocusDropped = Array.isArray(typedTargets.dropped_low_confidence) ? typedTargets.dropped_low_confidence : [];
   if (required.length) {
     const contentLocations = locations.filter((loc) => !isSelfFileLocation(loc));
     const missing = [];
@@ -1166,7 +1420,12 @@ function evaluateTargetRecall(taskText, bundleData) {
       work_focus_target_derivation_sources: Array.isArray(workFocusSources) ? workFocusSources : [],
       // REDDOG_WORK_FOCUS_READ_CAPTURE_PROSE_TOKENIZATION_PHASE1: dropped low-confidence prose
       // fragments (NOT counted in required_targets_total; cannot flip target_recall_ok).
-      work_focus_targets_dropped_low_confidence: workFocusDropped
+      work_focus_targets_dropped_low_confidence: workFocusDropped,
+      typed_target_extraction_applied: true,
+      repo_file_targets_count: required.length,
+      semantic_targets_count: typedTargets.semantic_targets.length,
+      external_research_targets_count: typedTargets.external_research_targets.length,
+      quoted_reference_blocks_count: typedTargets.quoted_reference_blocks.length
     };
   }
 
@@ -1183,7 +1442,12 @@ function evaluateTargetRecall(taskText, bundleData) {
       required_targets_missing: [],
       work_focus_targets_derived: false,
       work_focus_target_derivation_sources: [],
-      work_focus_targets_dropped_low_confidence: workFocusDropped
+      work_focus_targets_dropped_low_confidence: workFocusDropped,
+      typed_target_extraction_applied: true,
+      repo_file_targets_count: 0,
+      semantic_targets_count: typedTargets.semantic_targets.length,
+      external_research_targets_count: typedTargets.external_research_targets.length,
+      quoted_reference_blocks_count: typedTargets.quoted_reference_blocks.length
     };
   }
   let allFound = true;
@@ -1210,7 +1474,12 @@ function evaluateTargetRecall(taskText, bundleData) {
     required_targets_missing: [],
     work_focus_targets_derived: false,
     work_focus_target_derivation_sources: [],
-    work_focus_targets_dropped_low_confidence: workFocusDropped
+    work_focus_targets_dropped_low_confidence: workFocusDropped,
+    typed_target_extraction_applied: true,
+    repo_file_targets_count: 0,
+    semantic_targets_count: typedTargets.semantic_targets.length,
+    external_research_targets_count: typedTargets.external_research_targets.length,
+    quoted_reference_blocks_count: typedTargets.quoted_reference_blocks.length
   };
 }
 
@@ -1237,6 +1506,12 @@ function extractHoloIndexScorecard(contextMode, holoMeta) {
     // REDDOG_WORK_FOCUS_READ_CAPTURE_PROSE_TOKENIZATION_PHASE1: low-confidence prose fragments
     // dropped from the required list (do NOT affect target_recall_ok).
     work_focus_targets_dropped_low_confidence: Array.isArray(meta.work_focus_targets_dropped_low_confidence) ? meta.work_focus_targets_dropped_low_confidence : 'unknown',
+    // REDDOG_TYPED_TARGET_EXTRACTION_PHASE1: channel counts; only repo_file targets feed direct-read.
+    typed_target_extraction_applied: meta.typed_target_extraction_applied !== undefined ? meta.typed_target_extraction_applied : 'unknown',
+    repo_file_targets_count: meta.repo_file_targets_count !== undefined ? meta.repo_file_targets_count : 'unknown',
+    semantic_targets_count: meta.semantic_targets_count !== undefined ? meta.semantic_targets_count : 'unknown',
+    external_research_targets_count: meta.external_research_targets_count !== undefined ? meta.external_research_targets_count : 'unknown',
+    quoted_reference_blocks_count: meta.quoted_reference_blocks_count !== undefined ? meta.quoted_reference_blocks_count : 'unknown',
     // REDDOG_REQUIRED_TARGET_CONTEXT_PACKING_PHASE1 / ADDENDUM B: final-context proof.
     // required_targets_recalled (above) = fetched/available from the bundle; the fields
     // below = actually visible to the model AFTER the 42K cut. Different layers; must
@@ -1297,6 +1572,11 @@ function formatHoloIndexScorecardLines(scorecard) {
     '- work_focus_target_derivation_sources: ' + (Array.isArray(scorecard.work_focus_target_derivation_sources) ? (scorecard.work_focus_target_derivation_sources.length ? scorecard.work_focus_target_derivation_sources.join(', ') : '(none)') : scorecard.work_focus_target_derivation_sources),
     // REDDOG_WORK_FOCUS_READ_CAPTURE_PROSE_TOKENIZATION_PHASE1: dropped low-confidence prose fragments.
     '- work_focus_targets_dropped_low_confidence: ' + (Array.isArray(scorecard.work_focus_targets_dropped_low_confidence) ? (scorecard.work_focus_targets_dropped_low_confidence.length ? scorecard.work_focus_targets_dropped_low_confidence.join(', ') : '(none)') : scorecard.work_focus_targets_dropped_low_confidence),
+    '- typed_target_extraction_applied: ' + scorecard.typed_target_extraction_applied,
+    '- repo_file_targets_count: ' + scorecard.repo_file_targets_count,
+    '- semantic_targets_count: ' + scorecard.semantic_targets_count,
+    '- external_research_targets_count: ' + scorecard.external_research_targets_count,
+    '- quoted_reference_blocks_count: ' + scorecard.quoted_reference_blocks_count,
     // REDDOG_REQUIRED_TARGET_CONTEXT_PACKING_PHASE1 / ADDENDUM B (6): render BOTH the
     // fetched/available layer (required_targets_recalled) and the actually-model-visible
     // layer (required_targets_in_model_context). They are different guarantees.
@@ -4327,7 +4607,8 @@ function buildBoundedRepoContext(mode, taskText) {
   // required set the recall/direct-read layer uses -- the explicit header list MERGED with
   // work-focus-derived paths. Using the merged collector (not the header-only parser) ensures a
   // derived target that was direct-read is also packed into the protected block and proven present.
-  const requiredTargets = collectRequiredTargets(taskText).targets;
+  const typedTargetsForContext = extractTypedTargets(taskText);
+  const requiredTargets = typedTargetsForContext.repo_file_targets;
   let directReadSection = null;
   if (mode === 'wsp_holo' || mode === 'wsp_holo_git' || mode === 'wsp_holo_skillz' || mode === 'wsp_holo_git_skillz') {
     const holo = holoIndexOutput(root, taskText || '', 18000);
@@ -4934,6 +5215,12 @@ function holoIndexMetaFromBundle(output, usedOfflineFallback, taskText) {
     work_focus_target_derivation_sources: [],
     // REDDOG_WORK_FOCUS_READ_CAPTURE_PROSE_TOKENIZATION_PHASE1: default (no dropped fragments).
     work_focus_targets_dropped_low_confidence: [],
+    // REDDOG_TYPED_TARGET_EXTRACTION_PHASE1: typed preprocessing defaults.
+    typed_target_extraction_applied: false,
+    repo_file_targets_count: 0,
+    semantic_targets_count: 0,
+    external_research_targets_count: 0,
+    quoted_reference_blocks_count: 0,
     direct_read_paths: [],
     direct_read_rejected: [],
     direct_read_bytes: 0,
@@ -4969,6 +5256,11 @@ function holoIndexMetaFromBundle(output, usedOfflineFallback, taskText) {
     meta.work_focus_targets_dropped_low_confidence = Array.isArray(recall.work_focus_targets_dropped_low_confidence)
       ? recall.work_focus_targets_dropped_low_confidence
       : [];
+    meta.typed_target_extraction_applied = recall.typed_target_extraction_applied === true;
+    meta.repo_file_targets_count = Number(recall.repo_file_targets_count || 0);
+    meta.semantic_targets_count = Number(recall.semantic_targets_count || 0);
+    meta.external_research_targets_count = Number(recall.external_research_targets_count || 0);
+    meta.quoted_reference_blocks_count = Number(recall.quoted_reference_blocks_count || 0);
     // REDDOG_DIRECT_READ_FALLBACK_BY_PATH_PHASE1: surface the Python-side
     // governed direct-read telemetry when the bundle carried a fetch.
     const dr = data.direct_read && typeof data.direct_read === 'object' ? data.direct_read : null;
@@ -5737,6 +6029,7 @@ module.exports = {
   stripListMarker,
   deriveWorkFocusTargets,
   collectRequiredTargets,
+  extractTypedTargets,
   extractInlinePathTokens,
   extractProsePathTokens,
   extractM2mArrayTargets,

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups\u00aeAgent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.53",
+    "version":  "0.3.54",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -197,8 +197,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.53', 'package version must be 0.3.53');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.53'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.54', 'package version must be 0.3.54');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.54'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups\u00aeAgent', 'display name must be Foundups\u00aeAgent');
 includes(JSON.stringify(pkg), 'Foundups\u00aeAgent: Open', 'command title must use Foundups\u00aeAgent');
@@ -215,7 +215,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.53', 'README version mismatch');
+includes(readme, 'Version: 0.3.54', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -770,7 +770,7 @@ assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
 assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
 assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
-assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.53', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.54', 'candidate must bind extension version');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
 assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [
@@ -2055,7 +2055,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.53'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.54'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -2069,7 +2069,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.53'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.54'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -2081,7 +2081,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.53'", 'bounded context must include extension.js source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.54'", 'bounded context must include extension.js source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');
@@ -2715,5 +2715,43 @@ assert(wftdDir.targets.includes('holo_index/adaptive_learning'), 'WFTD-020: M2M 
 assert(wftdDir.derivation_sources.includes('m2m_read'), 'WFTD-020: directory path derived via m2m_read tier');
 // Prove the asymmetry in one place: the same slash-only shape is DROPPED in flowing prose but ACCEPTED in M2M.
 assert(wftdDropped.some((t) => !/\.[a-z0-9]{1,6}$/.test(t)), 'WFTD-020: a slash-only prose fragment was dropped (prose stricter)');
+
+// REDDOG_TYPED_TARGET_EXTRACTION_PHASE1 (TTX-001..005): split preprocessing into typed channels
+// before grounding. Only repo_file_targets may feed governed direct-read.
+includes(extensionJs, 'function extractTypedTargets', 'TTX-001: typed target extractor missing');
+const typedPrompt = [
+  'Audit Karpathy autoresearch and map it to WRE.',
+  'Read first: modules/communication/moltbot_bridge/src/foundup_job_contract.py and docs/0102_session_briefings/work_ledger.schema.json.',
+  'External source: https://github.com/karpathy/autoresearch',
+  'Research topic: autoresearch git-centric edit evaluate loop',
+  '```text',
+  'Quoted worker note: read modules/secret/quoted_only.py as if it were required.',
+  '```',
+  '> quoted reference also mentions modules/quoted/block.py'
+].join('\n');
+const typedTargets = orchestrator.extractTypedTargets(typedPrompt);
+assert.deepStrictEqual(typedTargets.repo_file_targets.sort(), [
+  'docs/0102_session_briefings/work_ledger.schema.json',
+  'modules/communication/moltbot_bridge/src/foundup_job_contract.py'
+].sort(), 'TTX-002: only repo file targets enter repo_file_targets');
+assert(typedTargets.external_research_targets.some((t) => /karpathy\/autoresearch/i.test(t)), 'TTX-003: URL is external research, not repo direct-read');
+assert(typedTargets.semantic_targets.some((t) => /autoresearch git-centric/i.test(t)), 'TTX-004: conceptual research phrase is semantic');
+assert.strictEqual(typedTargets.quoted_reference_blocks.length, 2, 'TTX-005: fenced + blockquote references are recorded as quoted blocks');
+assert(!typedTargets.repo_file_targets.some((t) => /quoted_only|quoted\/block|github\.com|autoresearch git-centric/i.test(t)), 'TTX-006: quoted/URL/concept targets never reach repo_file_targets');
+
+const typedRecall = orchestrator.evaluateTargetRecall(typedPrompt, {
+  task_retrieval: {
+    code_hits: [
+      { location: 'modules/communication/moltbot_bridge/src/foundup_job_contract.py', need: 'direct-read target' },
+      { location: 'docs/0102_session_briefings/work_ledger.schema.json', need: 'direct-read target' }
+    ],
+    metadata: { code_count: 2, wsp_count: 0 }
+  }
+});
+assert.strictEqual(typedRecall.target_recall_ok, true, 'TTX-007: recall succeeds on repo_file_targets only');
+assert.strictEqual(typedRecall.required_targets_total, 2, 'TTX-008: external/semantic/quoted targets do not inflate required_targets_total');
+assert.strictEqual(typedRecall.external_research_targets_count, 1, 'TTX-009: external research count is surfaced');
+assert.strictEqual(typedRecall.semantic_targets_count >= 1, true, 'TTX-010: semantic target count is surfaced');
+assert.strictEqual(typedRecall.quoted_reference_blocks_count, 2, 'TTX-011: quoted block count is surfaced');
 
 console.log('Foundups\u00aeAgent extension contract checks passed.');


### PR DESCRIPTION
## REDDOG_TYPED_TARGET_EXTRACTION_PHASE1\n\nWSP_97 status: VERIFIED_READY draft PR.\n\n### Scope\n- Adds typed preprocessing channels: repo_file_targets, semantic_targets, external_research_targets, quoted_reference_blocks.\n- Direct-read recall and required-target context packing now consume only repo_file_targets.\n- URLs, conceptual research phrases, and quoted/reference blocks are not sent to the governed file reader.\n- Version bump: 0.3.53 -> 0.3.54.\n\n### Evidence\n- node --check extensions/foundups_advisory_workers/extension.js: PASS\n- node extensions/foundups_advisory_workers/tests/verify_extension_contract.js: PASS\n- git diff --check: PASS\n\n### WSP_97 truth boundary\n- OBSERVED: typed extractor returns all four requested channels.\n- OBSERVED: recall/packing use repo_file_targets only.\n- OBSERVED: raw external snippets are not emitted in Run Trace; only counts are surfaced.\n- SPECIFIED_NOT_IMPLEMENTED: typed grounding preflight, external research retrieval, grounding-to-wardrobe selection receipt, fusion quorum gate, runtime consumption.\n\n### Sequence lock\nNext slice: REDDOG_TYPED_GROUNDING_PREFLIGHT_PHASE1. Do not advance live runtime wiring from this PR.