### PR TITLE
feat(reddog): bind grounding preflight to wardrobe selection

### DIFF
--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,13 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-12 - REDDOG_GROUNDING_TO_WARDROBE_SELECTION_RECEIPT_PHASE1 (grounded action-plane selection, 0.3.56)
+
+- Threaded typed grounding preflight into the RedDog operator wardrobe-selection payload and receipt.
+- Failed grounding now blocks action-plane selection before Python bridge invocation, preventing wardrobe/live-authority planning from ungrounded inputs.
+- Direct Python bridge calls also fail closed on failed grounding with `no_action_plane_selected` / `grounding_blocked`.
+- Version 0.3.55 -> 0.3.56 (package.json + EXTENSION_VERSION + README + contract-test assertions).
+
 ## 2026-07-12 - REDDOG_TYPED_GROUNDING_PREFLIGHT_PHASE1 (fail-closed grounding coverage gate, 0.3.55)
 
 - Added `buildTypedGroundingPreflight()` to block Fusion before any model call when typed grounding coverage is incomplete.

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.55
+Version: 0.3.56
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.55';
+const EXTENSION_VERSION = '0.3.56';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -2486,6 +2486,40 @@ function inferWardrobeAuthorityRequest(workFocus, handoffRecommendation) {
   return 'none';
 }
 
+function buildWardrobeGroundingPreflightReceipt(holoScorecard, options) {
+  const scorecard = holoScorecard && typeof holoScorecard === 'object' ? holoScorecard : {};
+  const opts = options && typeof options === 'object' ? options : {};
+  const explicit = opts.groundingPreflight && typeof opts.groundingPreflight === 'object'
+    ? opts.groundingPreflight
+    : null;
+  const source = explicit || scorecard;
+  const rawReasons = Array.isArray(source.grounding_preflight_rejection_reasons)
+    ? source.grounding_preflight_rejection_reasons
+    : (Array.isArray(source.rejection_reasons) ? source.rejection_reasons : []);
+  const reasons = uniqueStrings(
+    rawReasons
+  );
+  const applied = explicit
+    ? source.applied === true
+    : source.grounding_preflight_applied === true;
+  const passed = explicit
+    ? source.passed === true
+    : source.grounding_preflight_passed === true;
+  return {
+    applied: applied,
+    passed: applied ? passed : true,
+    rejection_reasons: reasons,
+    repo_file_targets_count: numberFromScorecard(source.repo_file_targets_count),
+    semantic_targets_count: numberFromScorecard(source.semantic_targets_count),
+    external_research_targets_count: numberFromScorecard(source.external_research_targets_count),
+    quoted_reference_blocks_count: numberFromScorecard(source.quoted_reference_blocks_count),
+    direct_read_required: source.direct_read_required === true || numberFromScorecard(source.repo_file_targets_count) > 0,
+    semantic_grounding_required: source.semantic_grounding_required === true || numberFromScorecard(source.semantic_targets_count) > 0,
+    external_research_required: source.external_research_required === true || numberFromScorecard(source.external_research_targets_count) > 0,
+    quoted_blocks_context_only: source.quoted_blocks_context_only === true || numberFromScorecard(source.quoted_reference_blocks_count) > 0
+  };
+}
+
 function buildWardrobeSelectionPayload(workFocus, holoScorecard, promptConstruction, handoffRecommendation, options) {
   const opts = options && typeof options === 'object' ? options : {};
   const construction = promptConstruction && typeof promptConstruction === 'object' ? promptConstruction : {};
@@ -2508,6 +2542,7 @@ function buildWardrobeSelectionPayload(workFocus, holoScorecard, promptConstruct
       ? construction.required_targets_authoritative_paths.slice()
       : [],
     target_recall_ok: scorecard.target_recall_ok === true,
+    grounding_preflight: buildWardrobeGroundingPreflightReceipt(scorecard, opts),
     wsp_refs: Array.isArray(opts.wspRefs) ? opts.wspRefs.slice() : ['WSP_00', 'WSP_15', 'WSP_46', 'WSP_95', 'WSP_97'],
     lane_refs: Array.isArray(opts.laneRefs) ? opts.laneRefs.slice() : [],
     continuation_packet_digest: opts.continuationPacketDigest || ''
@@ -2517,6 +2552,23 @@ function buildWardrobeSelectionPayload(workFocus, holoScorecard, promptConstruct
 function runOperatorWardrobeSelectionBridge(context, workFocus, holoScorecard, promptConstruction, handoffRecommendation, options) {
   const opts = options && typeof options === 'object' ? options : {};
   const payload = buildWardrobeSelectionPayload(workFocus, holoScorecard, promptConstruction, handoffRecommendation, opts);
+  if (
+    payload.grounding_preflight
+    && payload.grounding_preflight.applied === true
+    && payload.grounding_preflight.passed !== true
+  ) {
+    return {
+      slice_name: REDDOG_OPERATOR_WARDROBE_SELECTION_RUNTIME_SLICE,
+      decision: 'WARDROBE_SELECTION_REJECT',
+      receipt: null,
+      grounding_preflight_passed: false,
+      grounding_preflight_rejection_reasons: uniqueStrings(payload.grounding_preflight.rejection_reasons),
+      python_invocation_performed: false,
+      no_execution_performed: true,
+      no_enqueue_performed: true,
+      rejection_reasons: ['grounding_preflight_not_passed']
+    };
+  }
   if (typeof opts.selectionRunner === 'function') {
     const runnerResult = opts.selectionRunner(payload);
     return Object.assign({
@@ -2576,6 +2628,8 @@ function buildOperatorWardrobeSelectionSection(selectionResult) {
     '- selected_model_mode: ' + (receipt.selected_model_mode || 'unknown') + ' [OBSERVED]',
     '- selected_effort: ' + (receipt.selected_effort || 'unknown') + ' [OBSERVED]',
     '- wre_required: ' + (receipt.wre_required === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- grounding_preflight_applied: ' + (receipt.grounding_preflight_applied === true ? 'true' : (r.grounding_preflight_passed === false ? 'true' : 'false')) + ' [OBSERVED]',
+    '- grounding_preflight_passed: ' + (receipt.grounding_preflight_passed === true || r.grounding_preflight_passed === true ? 'true' : 'false') + ' [OBSERVED]',
     '- index_gap_detected: ' + (receipt.index_gap_detected === true ? 'true' : 'false') + ' [OBSERVED]',
     '- direct_read_required: ' + (receipt.direct_read_required === true ? 'true' : 'false') + ' [OBSERVED]',
     '- rejection_reasons: ' + JSON.stringify(receipt.rejection_reasons || r.rejection_reasons || []) + ' [OBSERVED]',
@@ -4094,13 +4148,18 @@ function wireFusionWebview(context, webview, worker, state) {
       workFocusDigest: promptConstruction.work_focus_digest && promptConstruction.work_focus_digest.hash,
       wspPromptDigest: promptConstruction.wsp_prompt_digest && promptConstruction.wsp_prompt_digest.hash
     });
-    const operatorWardrobeSelectionResult = substantiveTask && result.reason !== 'redaction_blocked'
-      ? runOperatorWardrobeSelectionBridge(context, workFocus, holoScorecard, promptConstruction, handoffRecommendation, {})
+    const actionPlanningAllowed = substantiveTask
+      && result.reason !== 'redaction_blocked'
+      && result.reason !== 'grounding_preflight_blocked';
+    const operatorWardrobeSelectionResult = actionPlanningAllowed
+      ? runOperatorWardrobeSelectionBridge(context, workFocus, holoScorecard, promptConstruction, handoffRecommendation, {
+        groundingPreflight: groundingPreflight
+      })
       : null;
-    const githubPermissionProbeResult = substantiveTask && result.reason !== 'redaction_blocked'
+    const githubPermissionProbeResult = actionPlanningAllowed
       ? runGithubPermissionProbeBridge(context, {})
       : null;
-    const wreSpineDryRunPreview = substantiveTask && result.reason !== 'redaction_blocked'
+    const wreSpineDryRunPreview = actionPlanningAllowed
       ? buildWreOperationalSpineDryRunPreview(workFocus, classification, handoffRecommendation, {
         promptConstruction: promptConstruction,
         contextMode: contextMode,

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups\u00aeAgent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.55",
+    "version":  "0.3.56",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -197,8 +197,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.55', 'package version must be 0.3.55');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.55'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.56', 'package version must be 0.3.56');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.56'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups\u00aeAgent', 'display name must be Foundups\u00aeAgent');
 includes(JSON.stringify(pkg), 'Foundups\u00aeAgent: Open', 'command title must use Foundups\u00aeAgent');
@@ -215,7 +215,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.55', 'README version mismatch');
+includes(readme, 'Version: 0.3.56', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -770,7 +770,7 @@ assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
 assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
 assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
-assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.55', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.56', 'candidate must bind extension version');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
 assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [
@@ -846,6 +846,57 @@ assert.deepStrictEqual(wardrobePayload.required_targets, [
 assert.strictEqual(wardrobePayload.holoindex_evidence.holoindex_status, 'bundle_json_ok', 'wardrobe payload carries HoloIndex status');
 assert.strictEqual(wardrobePayload.holoindex_evidence.direct_read_fallback_used, true, 'wardrobe payload carries direct-read status');
 assert.strictEqual(wardrobePayload.target_recall_ok, true, 'wardrobe payload carries target recall');
+assert.strictEqual(wardrobePayload.grounding_preflight.applied, false, 'wardrobe payload carries default grounding preflight state');
+const groundedWardrobePayload = orchestrator.buildWardrobeSelectionPayload(
+  'Implement a scoped RedDog slice',
+  {
+    holoindex_status: 'bundle_json_ok',
+    index_gap_detected: false,
+    target_recall_ok: true,
+    grounding_preflight_applied: true,
+    grounding_preflight_passed: true,
+    grounding_preflight_rejection_reasons: [],
+    repo_file_targets_count: 1,
+    semantic_targets_count: 0,
+    external_research_targets_count: 0,
+    quoted_reference_blocks_count: 0
+  },
+  { required_targets_authoritative_paths: ['extensions/foundups_advisory_workers/extension.js'] },
+  handoffRec,
+  { authorityRequest: 'draft_pr' }
+);
+assert.strictEqual(groundedWardrobePayload.grounding_preflight.applied, true, 'wardrobe payload carries applied grounding preflight');
+assert.strictEqual(groundedWardrobePayload.grounding_preflight.passed, true, 'wardrobe payload carries passed grounding preflight');
+assert.strictEqual(groundedWardrobePayload.grounding_preflight.repo_file_targets_count, 1, 'wardrobe payload carries grounding target counts');
+let failedGroundingRunnerCalled = false;
+const failedGroundingWardrobe = orchestrator.runOperatorWardrobeSelectionBridge(
+  null,
+  'Implement with ungrounded external research',
+  {
+    holoindex_status: 'bundle_json_ok',
+    index_gap_detected: false,
+    target_recall_ok: false,
+    grounding_preflight_applied: true,
+    grounding_preflight_passed: false,
+    grounding_preflight_rejection_reasons: ['external_research_retrieval_not_implemented'],
+    repo_file_targets_count: 0,
+    semantic_targets_count: 0,
+    external_research_targets_count: 1,
+    quoted_reference_blocks_count: 0
+  },
+  { required_targets_authoritative_paths: [] },
+  handoffRec,
+  {
+    selectionRunner: () => {
+      failedGroundingRunnerCalled = true;
+      return { decision: 'WARDROBE_SELECTION_ACCEPT' };
+    }
+  }
+);
+assert.strictEqual(failedGroundingRunnerCalled, false, 'failed grounding must not invoke wardrobe selection runner');
+assert.strictEqual(failedGroundingWardrobe.decision, 'WARDROBE_SELECTION_REJECT', 'failed grounding rejects wardrobe selection');
+assert.strictEqual(failedGroundingWardrobe.python_invocation_performed, false, 'failed grounding must not invoke Python wardrobe bridge');
+assert.deepStrictEqual(failedGroundingWardrobe.rejection_reasons, ['grounding_preflight_not_passed'], 'failed grounding carries stable rejection reason');
 const fakeWardrobeSelection = orchestrator.runOperatorWardrobeSelectionBridge(
   null,
   'Run governed worktree worker',
@@ -869,6 +920,8 @@ const fakeWardrobeSelection = orchestrator.runOperatorWardrobeSelectionBridge(
           wre_required: true,
           index_gap_detected: false,
           direct_read_required: true,
+          grounding_preflight_applied: true,
+          grounding_preflight_passed: true,
           rejection_reasons: [],
           no_execution_performed: true,
           no_enqueue_performed: true
@@ -2055,7 +2108,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.55'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.56'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -2069,7 +2122,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.55'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.56'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -2081,7 +2134,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.55'", 'bounded context must include source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.56'", 'bounded context must include source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');

--- a/modules/communication/moltbot_bridge/src/reddog_operator_loop_wardrobe_selection.py
+++ b/modules/communication/moltbot_bridge/src/reddog_operator_loop_wardrobe_selection.py
@@ -20,11 +20,13 @@ WARDROBE_SOLO_RETRIEVAL = "wsp97_solo_retrieval"
 WARDROBE_ARCHITECT_AUDIT = "wsp97_architect_audit"
 WARDROBE_IMPLEMENTATION_SLICE = "wsp97_implementation_slice"
 WARDROBE_SOVEREIGN_EXECUTION = "wsp97_sovereign_execution"
+WARDROBE_NO_ACTION_PLANE = "no_action_plane_selected"
 
 EXECUTION_ADVISORY_ONLY = "advisory_only"
 EXECUTION_AUDIT_ONLY = "audit_only"
 EXECUTION_WORKER_DRAFT_PR = "worker_draft_pr"
 EXECUTION_GOVERNED_CANDIDATE = "governed_execution_candidate"
+EXECUTION_GROUNDING_BLOCKED = "grounding_blocked"
 
 AUTHORITY_NONE = "no_authority"
 AUTHORITY_DRAFT_PR_ONLY = "draft_pr_only"
@@ -138,6 +140,10 @@ class RedDogOperatorLoopWardrobeSelectionReceipt:
     holoindex_freshness_label: str
     index_gap_detected: bool
     direct_read_required: bool
+    grounding_preflight_applied: bool
+    grounding_preflight_passed: bool
+    grounding_preflight_digest: str
+    grounding_preflight_rejection_reasons: List[str]
     skillz_candidates: List[str]
     lane_refs: List[str]
     rejection_reasons: List[str]
@@ -370,6 +376,34 @@ def _repo_sensitive_work(work_focus: str, authority_request: str, required_targe
     return bool(required_targets) or authority_request != "none" or _contains_any(work_focus, _REPO_TERMS)
 
 
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _grounding_preflight_state(value: Optional[Mapping[str, Any]]) -> Tuple[bool, bool, str, List[str]]:
+    if not isinstance(value, Mapping):
+        return (False, True, _canonical_digest({"grounding_preflight": "not_applied"}), [])
+    raw_reasons = value.get("rejection_reasons") or []
+    if isinstance(raw_reasons, (str, bytes)):
+        raw_reasons = [raw_reasons]
+    reasons = _dedupe(raw_reasons)
+    applied = value.get("applied") is True or "passed" in value or bool(reasons)
+    passed = value.get("passed") is True if applied else True
+    digest_payload = {
+        "applied": applied,
+        "passed": passed,
+        "rejection_reasons": reasons,
+        "repo_file_targets_count": _safe_int(value.get("repo_file_targets_count")),
+        "semantic_targets_count": _safe_int(value.get("semantic_targets_count")),
+        "external_research_targets_count": _safe_int(value.get("external_research_targets_count")),
+        "quoted_reference_blocks_count": _safe_int(value.get("quoted_reference_blocks_count")),
+    }
+    return (applied, passed, _canonical_digest(digest_payload), reasons)
+
+
 def select_reddog_operator_loop_wardrobe_dryrun(
     work_focus: str,
     *,
@@ -381,6 +415,7 @@ def select_reddog_operator_loop_wardrobe_dryrun(
     holoindex_evidence: Optional[Mapping[str, Any]] = None,
     required_targets: Optional[Sequence[str]] = None,
     target_recall_ok: Optional[bool] = None,
+    grounding_preflight: Optional[Mapping[str, Any]] = None,
     wsp_refs: Optional[Sequence[str]] = None,
     lane_refs: Optional[Sequence[str]] = None,
     continuation_packet_digest: Optional[str] = None,
@@ -404,8 +439,17 @@ def select_reddog_operator_loop_wardrobe_dryrun(
     index_gap = _index_gap_detected(holo)
     freshness = _holoindex_freshness_label(holo)
     repo_sensitive = _repo_sensitive_work(normalized_focus, normalized_authority, targets)
+    (
+        grounding_applied,
+        grounding_passed,
+        grounding_digest,
+        grounding_reasons,
+    ) = _grounding_preflight_state(grounding_preflight)
 
     rejection_reasons: List[str] = []
+    if grounding_applied and not grounding_passed:
+        rejection_reasons.append("grounding_preflight_not_passed")
+        rejection_reasons.extend(f"grounding:{reason}" for reason in grounding_reasons)
     if repo_sensitive and not holo:
         rejection_reasons.append("holoindex_evidence_missing_for_repo_work")
     if targets and target_recall_ok is False:
@@ -423,6 +467,16 @@ def select_reddog_operator_loop_wardrobe_dryrun(
     query_digest = _holoindex_query_digest(holo)
     candidates = _skillz_candidates(normalized_focus, holo)
 
+    if grounding_applied and not grounding_passed:
+        selected_wardrobe = WARDROBE_NO_ACTION_PLANE
+        wsp97_depth = "grounding_blocked"
+        execution_plane = EXECUTION_GROUNDING_BLOCKED
+        wre_required = False
+        context_mode = "none"
+        model_mode = "none"
+        effort = "none"
+        boundary = AUTHORITY_NONE
+
     receipt_payload: Dict[str, Any] = {
         "work_focus_digest": work_focus_digest,
         "principal_ref": str(principal_ref or "unknown"),
@@ -439,6 +493,10 @@ def select_reddog_operator_loop_wardrobe_dryrun(
         "holoindex_freshness_label": freshness,
         "index_gap_detected": index_gap,
         "direct_read_required": direct_read_required,
+        "grounding_preflight_applied": grounding_applied,
+        "grounding_preflight_passed": grounding_passed,
+        "grounding_preflight_digest": grounding_digest,
+        "grounding_preflight_rejection_reasons": grounding_reasons,
         "skillz_candidates": candidates,
         "lane_refs": lanes,
         "wsp_refs": governing_wsps,
@@ -465,6 +523,10 @@ def select_reddog_operator_loop_wardrobe_dryrun(
         holoindex_freshness_label=freshness,
         index_gap_detected=index_gap,
         direct_read_required=direct_read_required,
+        grounding_preflight_applied=grounding_applied,
+        grounding_preflight_passed=grounding_passed,
+        grounding_preflight_digest=grounding_digest,
+        grounding_preflight_rejection_reasons=grounding_reasons,
         skillz_candidates=candidates,
         lane_refs=lanes,
         rejection_reasons=_dedupe(rejection_reasons),

--- a/modules/communication/moltbot_bridge/tests/test_reddog_operator_loop_wardrobe_selection.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_operator_loop_wardrobe_selection.py
@@ -13,6 +13,7 @@ from modules.communication.moltbot_bridge.src.reddog_operator_loop_wardrobe_sele
     AUTHORITY_SOVEREIGN_TOKEN_REQUIRED,
     EXECUTION_ADVISORY_ONLY,
     EXECUTION_AUDIT_ONLY,
+    EXECUTION_GROUNDING_BLOCKED,
     EXECUTION_GOVERNED_CANDIDATE,
     EXECUTION_WORKER_DRAFT_PR,
     FRESHNESS_FRESH,
@@ -20,6 +21,7 @@ from modules.communication.moltbot_bridge.src.reddog_operator_loop_wardrobe_sele
     IMPLEMENTATION_STATUS_SPECIFIED_NOT_IMPLEMENTED,
     WARDROBE_ARCHITECT_AUDIT,
     WARDROBE_IMPLEMENTATION_SLICE,
+    WARDROBE_NO_ACTION_PLANE,
     WARDROBE_SELECTION_ACCEPT,
     WARDROBE_SELECTION_REJECT,
     WARDROBE_SOLO_RETRIEVAL,
@@ -93,6 +95,62 @@ def test_implementation_request_selects_draft_pr_plane() -> None:
     assert result.receipt.authority_boundary == AUTHORITY_DRAFT_PR_ONLY
     assert result.receipt.wre_required is True
     assert result.receipt.direct_read_required is True
+    assert result.receipt.grounding_preflight_applied is False
+    assert result.receipt.grounding_preflight_passed is True
+
+
+def test_passed_grounding_preflight_is_bound_into_receipt() -> None:
+    result = select_reddog_operator_loop_wardrobe_dryrun(
+        "Implement a scoped fix and open a draft PR.",
+        authority_request="draft_pr",
+        holoindex_evidence=_holo(),
+        required_targets=["modules/communication/moltbot_bridge/src/foo.py"],
+        target_recall_ok=True,
+        grounding_preflight={
+            "applied": True,
+            "passed": True,
+            "rejection_reasons": [],
+            "repo_file_targets_count": 1,
+            "semantic_targets_count": 0,
+            "external_research_targets_count": 0,
+            "quoted_reference_blocks_count": 0,
+        },
+    )
+    assert result.decision == WARDROBE_SELECTION_ACCEPT
+    assert result.receipt.selected_wardrobe == WARDROBE_IMPLEMENTATION_SLICE
+    assert result.receipt.grounding_preflight_applied is True
+    assert result.receipt.grounding_preflight_passed is True
+    assert len(result.receipt.grounding_preflight_digest) == 64
+    assert result.receipt.grounding_preflight_rejection_reasons == []
+
+
+def test_failed_grounding_preflight_blocks_action_plane_selection() -> None:
+    result = select_reddog_operator_loop_wardrobe_dryrun(
+        "Implement a slice using an ungrounded external paper.",
+        authority_request="draft_pr",
+        holoindex_evidence=_holo(),
+        grounding_preflight={
+            "applied": True,
+            "passed": False,
+            "rejection_reasons": ["external_research_retrieval_not_implemented"],
+            "repo_file_targets_count": 0,
+            "semantic_targets_count": 0,
+            "external_research_targets_count": 1,
+            "quoted_reference_blocks_count": 0,
+        },
+    )
+    assert result.decision == WARDROBE_SELECTION_REJECT
+    assert result.receipt.selected_wardrobe == WARDROBE_NO_ACTION_PLANE
+    assert result.receipt.execution_plane == EXECUTION_GROUNDING_BLOCKED
+    assert result.receipt.wre_required is False
+    assert result.receipt.authority_boundary == AUTHORITY_NONE
+    assert result.receipt.grounding_preflight_applied is True
+    assert result.receipt.grounding_preflight_passed is False
+    assert result.receipt.grounding_preflight_rejection_reasons == [
+        "external_research_retrieval_not_implemented"
+    ]
+    assert "grounding_preflight_not_passed" in result.receipt.rejection_reasons
+    assert "grounding:external_research_retrieval_not_implemented" in result.receipt.rejection_reasons
 
 
 def test_live_enqueue_request_selects_sovereign_execution_candidate() -> None:

--- a/scripts/reddog_operator_wardrobe_selection_once.py
+++ b/scripts/reddog_operator_wardrobe_selection_once.py
@@ -63,6 +63,7 @@ def _result(payload: Mapping[str, Any]) -> Dict[str, Any]:
         target_recall_ok=(
             payload.get("target_recall_ok") if isinstance(payload.get("target_recall_ok"), bool) else None
         ),
+        grounding_preflight=_mapping(payload.get("grounding_preflight")),
         wsp_refs=_list(payload.get("wsp_refs")),
         lane_refs=_list(payload.get("lane_refs")),
         continuation_packet_digest=(


### PR DESCRIPTION
## Summary
- Thread typed grounding preflight into the RedDog operator wardrobe-selection payload and receipt.
- Block wardrobe/action-plane selection before Python bridge invocation when grounding fails.
- Make the Python one-shot bridge fail closed on failed grounding with `no_action_plane_selected` / `grounding_blocked`.

## WSP_97 Truth Boundary
- OBSERVED: failed grounding emits `WARDROBE_SELECTION_REJECT` and performs no Python invocation in the extension guard.
- OBSERVED: direct bridge calls with failed grounding reject and select no action plane.
- OBSERVED: no OpenClaw/Hermes/WRE enqueue, worktree, shell, merge, RTK, or HoloIndex mutation is added.
- SPECIFIED_NOT_IMPLEMENTED: runtime consumption beyond the existing guarded receipt path remains blocked until grounding and quorum slices land.

## Validation
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_operator_loop_wardrobe_selection.py` -> 16 passed
- `node --check extensions/foundups_advisory_workers/extension.js` -> passed
- `node extensions/foundups_advisory_workers/tests/verify_extension_contract.js` -> passed (pre-existing surrogate stderr noise, exit 0)
- `git diff --check` -> clean (CRLF warnings only)