### PR TITLE
feat(reddog): enforce fusion panel quorum

### DIFF
--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,13 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-12 - REDDOG_FUSION_PANEL_QUORUM_PHASE1 (fail-closed Fusion synthesis quorum, 0.3.57)
+
+- Added deterministic Fusion panel quorum checks in `scripts/advisory_model_once.py`: required evidence must be present in packed evidence context, lead output cannot be empty/`None`, at least one critic must challenge framing and priority, and synthesis failure fails closed.
+- Removed the previous synthesis fallback that could convert missing synthesis into a usable answer.
+- Added bridge hardening tests for missing evidence, missing lead, missing critic challenge, synthesis failure, and successful quorum.
+- Version 0.3.56 -> 0.3.57 (package.json + EXTENSION_VERSION + README + contract-test assertions).
+
 ## 2026-07-12 - REDDOG_GROUNDING_TO_WARDROBE_SELECTION_RECEIPT_PHASE1 (grounded action-plane selection, 0.3.56)
 
 - Threaded typed grounding preflight into the RedDog operator wardrobe-selection payload and receipt.

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.56
+Version: 0.3.57
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.56';
+const EXTENSION_VERSION = '0.3.57';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups\u00aeAgent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.56",
+    "version":  "0.3.57",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -197,8 +197,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.56', 'package version must be 0.3.56');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.56'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.57', 'package version must be 0.3.57');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.57'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups\u00aeAgent', 'display name must be Foundups\u00aeAgent');
 includes(JSON.stringify(pkg), 'Foundups\u00aeAgent: Open', 'command title must use Foundups\u00aeAgent');
@@ -215,7 +215,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.56', 'README version mismatch');
+includes(readme, 'Version: 0.3.57', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -284,6 +284,11 @@ includes(extensionJs, 'repair_minimal', 'repair context mode telemetry missing')
 includes(extensionJs, 'egress-safe placeholders', 'repair prompt placeholder provenance missing');
 includes(extensionJs, 'repair_single_started', 'repair single trail event missing');
 includes(extensionJs, 'normalizeRepairBridgeStageToWorkTrail', 'repair trail normalizer missing');
+includes(bridgePy, 'fusion_quorum_missing_required_evidence', 'Fusion quorum must block missing required evidence');
+includes(bridgePy, 'fusion_quorum_lead_missing', 'Fusion quorum must block empty/None lead output');
+includes(bridgePy, 'fusion_quorum_challenging_critic_missing', 'Fusion quorum must require a critic challenge');
+includes(bridgePy, 'fusion_quorum_synthesis_unavailable', 'Fusion quorum must fail closed on synthesis failure');
+includes(bridgePy, '_critic_challenges_framing_and_priority', 'Fusion quorum must check framing and priority challenge');
 includes(extensionJs, 'function extractMarkdownSection', 'extractMarkdownSection missing');
 includes(extensionJs, 'function modeSelectionReasoning', 'mode selection reasoning missing');
 includes(extensionJs, 'Architect Trace', 'architect trace schema missing');
@@ -770,7 +775,7 @@ assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
 assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
 assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
-assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.56', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.57', 'candidate must bind extension version');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
 assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [
@@ -2108,7 +2113,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.56'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.57'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -2122,7 +2127,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.56'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.57'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -2134,7 +2139,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.56'", 'bounded context must include source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.57'", 'bounded context must include source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');

--- a/scripts/advisory_model_once.py
+++ b/scripts/advisory_model_once.py
@@ -212,6 +212,87 @@ def _format_panel(lead_model: str, lead_text: str, panel_results: dict[str, str]
     return "\n\n".join(parts)
 
 
+def _none_like_model_text(value: object) -> bool:
+    text = str(value or "").strip()
+    lowered = text.lower()
+    return not text or lowered in {"none", "null", "n/a", "na"} or lowered.startswith("[blocked:")
+
+
+def _missing_required_evidence(required_paths: object, evidence_context: object) -> list[str]:
+    if not isinstance(required_paths, list) or not required_paths:
+        return []
+    context = str(evidence_context or "").replace("\\", "/")
+    missing: list[str] = []
+    for item in required_paths:
+        if not isinstance(item, str):
+            continue
+        path = item.strip().replace("\\", "/")
+        if path and path not in context:
+            missing.append(path)
+    return missing
+
+
+def _critic_challenges_framing_and_priority(text: object) -> bool:
+    lowered = str(text or "").lower()
+    if _none_like_model_text(lowered):
+        return False
+    challenge_terms = (
+        "challenge",
+        "disagree",
+        "unsupported",
+        "missing",
+        "overclaim",
+        "risk",
+        "wrong",
+        "blocker",
+        "major",
+        "fail",
+        "needs_verification",
+    )
+    framing_terms = ("framing", "frame", "assumption", "scope", "premise", "question")
+    priority_terms = ("priority", "wsp_15", "p0", "p1", "p2", "next safest", "sequence", "order")
+    return (
+        any(term in lowered for term in challenge_terms)
+        and any(term in lowered for term in framing_terms)
+        and any(term in lowered for term in priority_terms)
+    )
+
+
+def _fusion_quorum_packet(
+    *,
+    ok: bool,
+    reason: str,
+    lead_model: str,
+    panel_models: list[str],
+    panel_models_truncated: bool,
+    missing_required_evidence: list[str] | None = None,
+    challenging_critics: list[str] | None = None,
+) -> dict[str, Any]:
+    quorum = {
+        "applied": True,
+        "passed": ok,
+        "reason": reason,
+        "missing_required_evidence": list(missing_required_evidence or []),
+        "challenging_critics": list(challenging_critics or []),
+        "lead_required": True,
+        "synthesis_requires_quorum": True,
+    }
+    return {
+        "ok": ok,
+        "reason": reason,
+        "mode": "foundups_fusion",
+        "lead_model": lead_model,
+        "panel_models": panel_models,
+        "review_packet": {
+            "mode": "foundups_fusion",
+            "lead_model": lead_model,
+            "panel_models": panel_models,
+            "panel_models_truncated": panel_models_truncated,
+            "fusion_panel_quorum": quorum,
+        },
+    }
+
+
 def _openrouter_fusion_alias(
     api_key: str,
     redacted_prompt: str,
@@ -283,6 +364,19 @@ def _run_foundups_fusion(
     lead_model = _model_slug(payload.get("lead_model"), DEFAULT_LEAD_MODEL)
     panel_models, panel_models_truncated = _panel_models_with_meta(payload.get("panel_models"))
     base_system = _system_prompt(payload)
+    missing_evidence = _missing_required_evidence(
+        payload.get("required_target_paths"),
+        payload.get("_redacted_evidence_context"),
+    )
+    if missing_evidence:
+        return _fusion_quorum_packet(
+            ok=False,
+            reason="fusion_quorum_missing_required_evidence",
+            lead_model=lead_model,
+            panel_models=panel_models,
+            panel_models_truncated=panel_models_truncated,
+            missing_required_evidence=missing_evidence,
+        )
 
     lead_system = (
         base_system
@@ -309,6 +403,14 @@ def _run_foundups_fusion(
         return {"ok": False, "reason": "timeout", "lead_model": lead_model}
     except (KeyError, IndexError, TypeError, json.JSONDecodeError):
         return {"ok": False, "reason": "lead_malformed_response", "lead_model": lead_model}
+    if _none_like_model_text(lead_text):
+        return _fusion_quorum_packet(
+            ok=False,
+            reason="fusion_quorum_lead_missing",
+            lead_model=lead_model,
+            panel_models=panel_models,
+            panel_models_truncated=panel_models_truncated,
+        )
 
     _progress("lead_done", "Lead response received: " + lead_model)
     critic_system = (
@@ -350,6 +452,19 @@ def _run_foundups_fusion(
                 panel_results[model] = "[blocked: malformed_response]"
                 _progress("panel_blocked", "Panel malformed response: " + model)
 
+    challenging_critics = [
+        model for model, text in panel_results.items() if _critic_challenges_framing_and_priority(text)
+    ]
+    if not challenging_critics:
+        return _fusion_quorum_packet(
+            ok=False,
+            reason="fusion_quorum_challenging_critic_missing",
+            lead_model=lead_model,
+            panel_models=panel_models,
+            panel_models_truncated=panel_models_truncated,
+            challenging_critics=[],
+        )
+
     synthesis_system = (
         base_system
         + "\n\nSynthesis pass: resolve panel disagreement, preserve useful dissent, and return the best actionable WSP-compliant recommendation. The final section must be WSP_15 Priority followed by Next safest step."
@@ -380,7 +495,14 @@ def _run_foundups_fusion(
             timeout=timeout,
         )
     except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, KeyError, IndexError, TypeError, json.JSONDecodeError):
-        synthesis = "Synthesis unavailable. Use the lead answer and panel critiques above."
+        return _fusion_quorum_packet(
+            ok=False,
+            reason="fusion_quorum_synthesis_unavailable",
+            lead_model=lead_model,
+            panel_models=panel_models,
+            panel_models_truncated=panel_models_truncated,
+            challenging_critics=challenging_critics,
+        )
 
     _progress("synthesis_done", "Synthesis complete.")
     content = _format_panel(lead_model, lead_text, panel_results, synthesis)
@@ -405,6 +527,15 @@ def _run_foundups_fusion(
             "lead_excerpt": lead_text[:4000],
             "panel_excerpts": {model: text[:3000] for model, text in panel_results.items()},
             "synthesis_excerpt": synthesis[:4000],
+            "fusion_panel_quorum": {
+                "applied": True,
+                "passed": True,
+                "reason": "fusion_quorum_passed",
+                "missing_required_evidence": [],
+                "challenging_critics": challenging_critics,
+                "lead_required": True,
+                "synthesis_requires_quorum": True,
+            },
             "retry_count": lead_retry.get("retry_count", 0),
             "final_retry_reason": lead_retry.get("final_retry_reason"),
         },
@@ -520,6 +651,8 @@ def main() -> int:
     redacted_user_message = gate.redacted_prompt
     if gate.redacted_context:
         redacted_user_message = gate.redacted_prompt + "\n\n" + gate.redacted_context
+    model_payload = dict(payload)
+    model_payload["_redacted_evidence_context"] = gate.redacted_context or ""
 
     history = _clean_history(payload.get("history"))
     messages = [{"role": "system", "content": system_prompt}]
@@ -527,7 +660,7 @@ def main() -> int:
     messages.append({"role": "user", "content": redacted_user_message})
 
     if payload.get("mode") == "openrouter_fusion_alias":
-        result = _openrouter_fusion_alias(api_key, redacted_user_message, history, payload)
+        result = _openrouter_fusion_alias(api_key, redacted_user_message, history, model_payload)
         if bridge_meta:
             packet = result.get("review_packet")
             if isinstance(packet, dict):
@@ -535,7 +668,7 @@ def main() -> int:
         return _json_result(**{**result, **audit_telemetry, **redaction_telemetry})
 
     if payload.get("mode") == "foundups_fusion":
-        result = _run_foundups_fusion(api_key, redacted_user_message, history, payload)
+        result = _run_foundups_fusion(api_key, redacted_user_message, history, model_payload)
         if bridge_meta:
             packet = result.get("review_packet")
             if isinstance(packet, dict):

--- a/scripts/tests/test_advisory_model_once_hardening.py
+++ b/scripts/tests/test_advisory_model_once_hardening.py
@@ -223,6 +223,137 @@ class AdvisoryBridgeHardeningTests(unittest.TestCase):
         self.assertEqual(packet.get("python_interpreter_source"), "system")
         self.assertLessEqual(len(packet.get("panel_models") or []), bridge.MAX_PANEL_MODELS)
 
+    def test_fusion_quorum_blocks_missing_required_evidence_before_network(self) -> None:
+        chat_mock = mock.Mock()
+        with mock.patch.object(bridge, "_chat_completion", chat_mock):
+            result = bridge._run_foundups_fusion(
+                "key",
+                "prompt that names docs/missing.md but has no evidence context",
+                [],
+                {
+                    "lead_model": "lead-model",
+                    "panel_models": ["critic-a"],
+                    "required_target_paths": ["docs/missing.md"],
+                    "_redacted_evidence_context": "### Required direct-read target: docs/present.md\ncontent",
+                },
+            )
+        chat_mock.assert_not_called()
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["reason"], "fusion_quorum_missing_required_evidence")
+        quorum = result["review_packet"]["fusion_panel_quorum"]
+        self.assertEqual(quorum["missing_required_evidence"], ["docs/missing.md"])
+
+    def test_fusion_quorum_blocks_none_lead_before_panel(self) -> None:
+        calls: list[str] = []
+
+        def fake_chat(api_key, model, messages, **kwargs):  # noqa: ANN001, ARG001
+            calls.append(str(messages[0]["content"]))
+            return "None", {"retry_count": 0}
+
+        with mock.patch.object(bridge, "_chat_completion", side_effect=fake_chat):
+            result = bridge._run_foundups_fusion(
+                "key",
+                "prompt\n\n### Required direct-read target: docs/present.md\ncontent",
+                [],
+                {
+                    "lead_model": "lead-model",
+                    "panel_models": ["critic-a"],
+                    "required_target_paths": ["docs/present.md"],
+                    "_redacted_evidence_context": "### Required direct-read target: docs/present.md\ncontent",
+                },
+            )
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["reason"], "fusion_quorum_lead_missing")
+        self.assertEqual(len(calls), 1)
+
+    def test_fusion_quorum_requires_critic_challenge_to_framing_and_priority(self) -> None:
+        def fake_chat(api_key, model, messages, **kwargs):  # noqa: ANN001, ARG001
+            system = str(messages[0]["content"])
+            if "Lead pass" in system:
+                return "## Decision\nProceed\n\nEvidence docs/present.md:1", {"retry_count": 0}
+            if "Panel critic pass" in system:
+                return "Looks generally reasonable.", {"retry_count": 0}
+            return "Synthesis should not run", {"retry_count": 0}
+
+        with mock.patch.object(bridge, "_chat_completion", side_effect=fake_chat):
+            result = bridge._run_foundups_fusion(
+                "key",
+                "prompt\n\n### Required direct-read target: docs/present.md\ncontent",
+                [],
+                {
+                    "lead_model": "lead-model",
+                    "panel_models": ["critic-a", "critic-b"],
+                    "required_target_paths": ["docs/present.md"],
+                    "_redacted_evidence_context": "### Required direct-read target: docs/present.md\ncontent",
+                },
+            )
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["reason"], "fusion_quorum_challenging_critic_missing")
+        quorum = result["review_packet"]["fusion_panel_quorum"]
+        self.assertEqual(quorum["challenging_critics"], [])
+
+    def test_fusion_quorum_passes_with_challenge_and_blocks_synthesis_failure(self) -> None:
+        def fake_chat(api_key, model, messages, **kwargs):  # noqa: ANN001, ARG001
+            system = str(messages[0]["content"])
+            if "Lead pass" in system:
+                return "## Decision\nProceed\n\nEvidence docs/present.md:1", {"retry_count": 0}
+            if "Panel critic pass" in system:
+                return (
+                    "I challenge the framing and the WSP_15 priority order because the "
+                    "scope may overclaim evidence.",
+                    {"retry_count": 0},
+                )
+            raise TimeoutError("synthesis unavailable")
+
+        with mock.patch.object(bridge, "_chat_completion", side_effect=fake_chat):
+            result = bridge._run_foundups_fusion(
+                "key",
+                "prompt\n\n### Required direct-read target: docs/present.md\ncontent",
+                [],
+                {
+                    "lead_model": "lead-model",
+                    "panel_models": ["critic-a"],
+                    "required_target_paths": ["docs/present.md"],
+                    "_redacted_evidence_context": "### Required direct-read target: docs/present.md\ncontent",
+                },
+            )
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["reason"], "fusion_quorum_synthesis_unavailable")
+        quorum = result["review_packet"]["fusion_panel_quorum"]
+        self.assertEqual(quorum["challenging_critics"], ["critic-a"])
+
+    def test_fusion_quorum_success_records_challenging_critic(self) -> None:
+        def fake_chat(api_key, model, messages, **kwargs):  # noqa: ANN001, ARG001
+            system = str(messages[0]["content"])
+            if "Lead pass" in system:
+                return "## Decision\nProceed\n\nEvidence docs/present.md:1", {"retry_count": 0}
+            if "Panel critic pass" in system:
+                return (
+                    "I challenge the framing and WSP_15 priority because the sequence "
+                    "could hide a missing gate.",
+                    {"retry_count": 0},
+                )
+            return "## Decision\nProceed\n\n## WSP_15 Priority\nP1\n\n## Next safest step\nVerify.", {
+                "retry_count": 0
+            }
+
+        with mock.patch.object(bridge, "_chat_completion", side_effect=fake_chat):
+            result = bridge._run_foundups_fusion(
+                "key",
+                "prompt\n\n### Required direct-read target: docs/present.md\ncontent",
+                [],
+                {
+                    "lead_model": "lead-model",
+                    "panel_models": ["critic-a"],
+                    "required_target_paths": ["docs/present.md"],
+                    "_redacted_evidence_context": "### Required direct-read target: docs/present.md\ncontent",
+                },
+            )
+        self.assertTrue(result["ok"])
+        quorum = result["review_packet"]["fusion_panel_quorum"]
+        self.assertTrue(quorum["passed"])
+        self.assertEqual(quorum["challenging_critics"], ["critic-a"])
+
     def test_read_stdin_json_em_dash(self) -> None:
         payload = {"prompt": "safe", "context": "PR #718 \u2014 `WSP_109_FOUNDUP_ONBOARDI"}
         stdin_buffer = io.BytesIO(json.dumps(payload, ensure_ascii=False).encode("utf-8"))


### PR DESCRIPTION
## Summary
- Add deterministic Fusion panel quorum checks in `scripts/advisory_model_once.py`.
- Block Fusion before network if required evidence paths are missing from the redacted evidence context.
- Block synthesis when lead output is empty/`None`, when no critic challenges both framing and WSP_15 priority, or when synthesis fails.
- Record `fusion_panel_quorum` in the review packet on pass/fail.

## WSP_97 Truth Boundary
- OBSERVED: no repo/shell/merge/worktree/OpenClaw/Hermes/WRE execution wiring is added.
- OBSERVED: missing evidence, missing lead, missing critic challenge, and synthesis failure fail closed.
- OBSERVED: this only affects Fusion model-call orchestration; runtime action wiring remains blocked by earlier grounding/wardrobe gates.
- SPECIFIED_NOT_IMPLEMENTED: downstream runtime consumption of verified recommendations remains a later slice.

## Validation
- `python -m pytest scripts/tests/test_advisory_model_once_hardening.py` -> 22 passed
- `node --check extensions/foundups_advisory_workers/extension.js` -> passed
- `node extensions/foundups_advisory_workers/tests/verify_extension_contract.js` -> passed (pre-existing surrogate stderr noise, exit 0)
- `git diff --check` -> clean (CRLF warnings only)