### PR TITLE
feat(reddog): gate runtime consumption on validated recommendations

### DIFF
--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,13 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-12 - REDDOG_EXTENSION_OPERATOR_LOOP_RUNTIME_CONSUMPTION_PHASE1 (validated recommendation gate, 0.3.58)
+
+- Added `buildRuntimeConsumptionGate()` so wardrobe selection, permission probing, WRE dry-run preview, and explicit WRE invocation are only planned after model result OK, output validation pass, Determine verifier pass when applied, and Fusion quorum pass.
+- Runtime action planning now stops on redaction, grounding, schema validation, judgment-verifier, or Fusion quorum failure.
+- Run Trace now emits `runtime_consumption_gate_passed` and gate rejection reasons.
+- Version 0.3.57 -> 0.3.58 (package.json + EXTENSION_VERSION + README + contract-test assertions).
+
 ## 2026-07-12 - REDDOG_FUSION_PANEL_QUORUM_PHASE1 (fail-closed Fusion synthesis quorum, 0.3.57)
 
 - Added deterministic Fusion panel quorum checks in `scripts/advisory_model_once.py`: required evidence must be present in packed evidence context, lead output cannot be empty/`None`, at least one critic must challenge framing and priority, and synthesis failure fails closed.

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.57
+Version: 0.3.58
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.57';
+const EXTENSION_VERSION = '0.3.58';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -238,6 +238,49 @@ function formatOutputValidationStatus(validationState) {
     return 'skipped';
   }
   return 'unknown';
+}
+
+function buildRuntimeConsumptionGate(result, validationState, mode, substantiveTask) {
+  const reasons = [];
+  const rp = result && result.review_packet && typeof result.review_packet === 'object'
+    ? result.review_packet
+    : {};
+  const validation = validationState && typeof validationState === 'object' ? validationState : {};
+  const judgment = validation.judgment_verification && typeof validation.judgment_verification === 'object'
+    ? validation.judgment_verification
+    : null;
+  const quorum = rp.fusion_panel_quorum && typeof rp.fusion_panel_quorum === 'object'
+    ? rp.fusion_panel_quorum
+    : null;
+
+  if (substantiveTask !== true) {
+    reasons.push('non_substantive_worker');
+  }
+  if (!result || result.ok !== true) {
+    reasons.push('model_result_not_ok');
+  }
+  if (result && (result.reason === 'redaction_blocked' || result.reason === 'grounding_preflight_blocked')) {
+    reasons.push(String(result.reason));
+  }
+  if (validation.output_validation_failed === true || validation.validated !== true) {
+    reasons.push('output_validation_not_passed');
+  }
+  if (judgment && judgment.applied === true && judgment.verified !== true) {
+    reasons.push('judgment_verification_not_passed');
+  }
+  if (mode === 'foundups_fusion' && (!quorum || quorum.passed !== true)) {
+    reasons.push('fusion_panel_quorum_not_passed');
+  }
+
+  return {
+    applied: true,
+    passed: reasons.length === 0,
+    rejection_reasons: uniqueStrings(reasons),
+    no_runtime_authority_when_failed: reasons.length > 0,
+    requires_output_validation: true,
+    requires_judgment_verification: judgment && judgment.applied === true,
+    requires_fusion_quorum: mode === 'foundups_fusion'
+  };
 }
 
 function formatJudgmentVerificationLines(validationState) {
@@ -1835,6 +1878,10 @@ function buildRunTraceSection(result, workerType, contextSummary, holoScorecard,
   lines.push.apply(lines, formatContinuationTelemetryLines(rp.continuation_telemetry || (result && result.continuation_telemetry)));
   lines.push('- output_validation: ' + formatOutputValidationStatus(rp.output_validation));
   lines.push.apply(lines, formatJudgmentVerificationLines(rp.output_validation));
+  if (rp.runtime_consumption_gate && typeof rp.runtime_consumption_gate === 'object') {
+    lines.push('- runtime_consumption_gate_passed: ' + (rp.runtime_consumption_gate.passed === true ? 'true' : 'false'));
+    lines.push('- runtime_consumption_gate_rejection_reasons: ' + (Array.isArray(rp.runtime_consumption_gate.rejection_reasons) && rp.runtime_consumption_gate.rejection_reasons.length ? rp.runtime_consumption_gate.rejection_reasons.join(', ') : '(none)'));
+  }
   if (rp.output_validation && rp.output_validation.repair_attempted) {
     lines.push('- repair_context_mode: ' + (rp.output_validation.repair_context_mode || 'unknown'));
     lines.push('- repair_mode: ' + (rp.output_validation.repair_mode || 'unknown'));
@@ -4148,9 +4195,8 @@ function wireFusionWebview(context, webview, worker, state) {
       workFocusDigest: promptConstruction.work_focus_digest && promptConstruction.work_focus_digest.hash,
       wspPromptDigest: promptConstruction.wsp_prompt_digest && promptConstruction.wsp_prompt_digest.hash
     });
-    const actionPlanningAllowed = substantiveTask
-      && result.reason !== 'redaction_blocked'
-      && result.reason !== 'grounding_preflight_blocked';
+    const runtimeConsumptionGate = buildRuntimeConsumptionGate(result, validationState, mode, substantiveTask);
+    const actionPlanningAllowed = runtimeConsumptionGate.passed === true;
     const operatorWardrobeSelectionResult = actionPlanningAllowed
       ? runOperatorWardrobeSelectionBridge(context, workFocus, holoScorecard, promptConstruction, handoffRecommendation, {
         groundingPreflight: groundingPreflight
@@ -4185,6 +4231,8 @@ function wireFusionWebview(context, webview, worker, state) {
       workTrail,
       unicodeMeta
     );
+    result.runtime_consumption_gate = runtimeConsumptionGate;
+    result.review_packet.runtime_consumption_gate = runtimeConsumptionGate;
     result.governed_handoff_recommendation = handoffRecommendation;
     if (operatorWardrobeSelectionResult) {
       result.operator_wardrobe_selection_result = operatorWardrobeSelectionResult;
@@ -6170,6 +6218,7 @@ module.exports = {
   createWorkTrail,
   buildRedactionGateReport,
   buildRedactionGateReportSection,
+  buildRuntimeConsumptionGate,
   buildGovernedHandoffRecommendation,
   buildGovernedHandoffSection,
   buildRedDogGovernedWorkOrderCandidate,

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups\u00aeAgent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.57",
+    "version":  "0.3.58",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -197,8 +197,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.57', 'package version must be 0.3.57');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.57'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.58', 'package version must be 0.3.58');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.58'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups\u00aeAgent', 'display name must be Foundups\u00aeAgent');
 includes(JSON.stringify(pkg), 'Foundups\u00aeAgent: Open', 'command title must use Foundups\u00aeAgent');
@@ -215,7 +215,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.57', 'README version mismatch');
+includes(readme, 'Version: 0.3.58', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -569,6 +569,49 @@ includes(repairTraceFailed, 'missing_sections_after_repair: Evidence, Next safes
 includes(repairTraceFailed, '- extension_version: ' + pkg.version, 'RTBV-001: Run Trace must emit extension_version = package version (the real build)');
 includes(extensionJs, "'- extension_version: ' + EXTENSION_VERSION", 'RTBV-001: Run Trace line must read the EXTENSION_VERSION constant, not prompt/packet/model text');
 
+// REDDOG_EXTENSION_OPERATOR_LOOP_RUNTIME_CONSUMPTION_PHASE1:
+// Runtime action planning may consume only validated, grounded, quorum-passed recommendations.
+const runtimeGatePass = orchestrator.buildRuntimeConsumptionGate(
+  { ok: true, reason: 'ok', review_packet: { fusion_panel_quorum: { passed: true } } },
+  { validated: true, judgment_verification: { applied: true, verified: true } },
+  'foundups_fusion',
+  true
+);
+assert.strictEqual(runtimeGatePass.passed, true, 'runtime gate should pass only after validation, judgment, and quorum pass');
+const runtimeGateNoQuorum = orchestrator.buildRuntimeConsumptionGate(
+  { ok: true, reason: 'ok', review_packet: {} },
+  { validated: true },
+  'foundups_fusion',
+  true
+);
+assert.strictEqual(runtimeGateNoQuorum.passed, false, 'runtime gate must block missing Fusion quorum');
+assert(runtimeGateNoQuorum.rejection_reasons.includes('fusion_panel_quorum_not_passed'), 'runtime gate must cite missing Fusion quorum');
+const runtimeGateValidationFail = orchestrator.buildRuntimeConsumptionGate(
+  { ok: true, reason: 'ok', review_packet: { fusion_panel_quorum: { passed: true } } },
+  { validated: false, output_validation_failed: true },
+  'foundups_fusion',
+  true
+);
+assert.strictEqual(runtimeGateValidationFail.passed, false, 'runtime gate must block failed output validation');
+assert(runtimeGateValidationFail.rejection_reasons.includes('output_validation_not_passed'), 'runtime gate must cite output validation failure');
+const runtimeGateTrace = orchestrator.buildRunTraceSection(
+  {
+    ok: true,
+    mode: 'foundups_fusion',
+    review_packet: {
+      task_classification: { tier: 'HIGH' },
+      output_validation: { validated: true },
+      runtime_consumption_gate: runtimeGateNoQuorum
+    }
+  },
+  'reddog_architect',
+  '',
+  {},
+  'high'
+);
+includes(runtimeGateTrace, 'runtime_consumption_gate_passed: false', 'Run Trace must expose runtime gate failure');
+includes(runtimeGateTrace, 'runtime_consumption_gate_rejection_reasons: fusion_panel_quorum_not_passed', 'Run Trace must expose runtime gate reasons');
+
 const handoffContext = orchestrator.skillzWardrobeRolodexContext(root, 'process all youtube comments with existing skillz', 12000);
 includes(handoffContext, 'Skillz/Wardrobe/Rolodex discovery', 'handoff context header missing');
 assert(/youtube|comments|skillz/i.test(handoffContext), 'handoff context must surface relevant YouTube/comment/Skillz paths');
@@ -775,7 +818,7 @@ assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
 assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
 assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
-assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.57', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.58', 'candidate must bind extension version');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
 assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [
@@ -2113,7 +2156,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.57'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.58'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -2127,7 +2170,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.57'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.58'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -2139,7 +2182,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.57'", 'bounded context must include source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.58'", 'bounded context must include source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');


### PR DESCRIPTION
## Summary
- Add `buildRuntimeConsumptionGate()` to require validated recommendations before action planning.
- Block wardrobe selection, permission probe, WRE preview, and explicit WRE invoke unless model result, output validation, Determine verification when applied, and Fusion quorum pass.
- Surface runtime gate status and rejection reasons in Run Trace.

## WSP_97 Truth Boundary
- OBSERVED: this consumes the now-landed typed grounding + Fusion quorum chain before existing runtime planning.
- OBSERVED: no new repo/shell/merge/worktree/OpenClaw/Hermes/WRE authority is added.
- OBSERVED: failed validation/quorum/judgment keeps runtime authority closed.
- SPECIFIED_NOT_IMPLEMENTED: recursive autonomous orchestration, generic writer, merge authority, and live execution remain downstream signed-authority slices.

## Validation
- `node --check extensions/foundups_advisory_workers/extension.js` -> passed
- `node extensions/foundups_advisory_workers/tests/verify_extension_contract.js` -> passed (pre-existing surrogate stderr noise, exit 0)
- `git diff --check` -> clean (CRLF warnings only)