### PR TITLE
fix(reddog): answer simple identity prompts locally

### DIFF
--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,13 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-13 - REDDOG_SIMPLE_IDENTITY_FAST_PATH_PHASE1 (local identity/status answer, 0.3.61)
+
+- Added a narrow local fast path for short identity/status questions such as `are you RedDog?` so they do not escalate through HIGH-tier Fusion routing merely because the prompt contains `RedDog`.
+- The fast path answers locally, sets `made_network_call=false`, uses context `none`, skips HoloIndex/OpenRouter/Fusion/repair/judgment verifier, and blocks downstream runtime consumption as non-actionable.
+- Added contract coverage proving substantive RedDog audit prompts still classify HIGH and stay on the governed path.
+- Version 0.3.60 -> 0.3.61 (package.json + EXTENSION_VERSION + README + contract-test assertions).
+
 ## 2026-07-13 - REDDOG_PROMPT_AUTHORING_DELIVERABLE_CONTRACT_PHASE1 (worker prompt artifact gate, 0.3.60)
 
 - Added prompt-authoring detection so requests to create/evaluate/provide worker prompts receive bounded RedDog prompt/judgment context even when no explicit repo paths are named.

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.60
+Version: 0.3.61
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 
@@ -59,6 +59,7 @@ The extension is a bounded 0102 advisory surface:
 - Flowing-prose read-capture tokenization + tiered strictness (v0.3.45): a `Read first:` prompt that names files in flowing PROSE (e.g. `Read first: a.md, b.json, and c.py. Determine ... the breadcrumb/handoff layer`) is now tokenized with the bounded path-token regex, so a path followed by prose (`c.py. Determine ...`) and an embedded-slash English fragment (`breadcrumb/handoff`) no longer corrupt the derived targets. Confidence tiers: FLOWING-PROSE-derived tokens (Read-first prose, inline prose, backtick prose) become required targets ONLY if they have a lowercase file extension (a file shape); a prose token with a slash but no extension is dropped from the required list and reported in the new `work_focus_targets_dropped_low_confidence` telemetry field, so it can never flip `target_recall_ok` to false. The explicit `Required direct-read targets:` header, M2M `READ:` / `CTX.FILES`, and CLEAN BULLETS keep the broader slash-OR-extension behavior (a named directory path is still accepted) -- only flowing prose is stricter. Trailing prose punctuation (`.` `,` `;` `:` `)` `]` `}`) is trimmed from derived paths. The governed direct-read gate (`bundle_json.py`) is unchanged; derived paths still flow through it.
 - Determine-block target derivation guard (v0.3.59): `Determine:` numbered questions are treated as answer/output obligations, not repo-file target intent. Slash-bearing conceptual phrases inside questions (for example `ledger/runtime`) no longer become `repo_file_targets` or block typed grounding. Explicit `Read first:` / required-target sections still drive direct read normally.
 - Prompt-authoring deliverable contract (v0.3.60): when 012 asks RedDog to create/evaluate/provide a worker prompt, RedDog receives bounded direct-read context for its prompt/judgment surfaces and must return a `## Worker Prompt` section with one fenced executable prompt. Missing definitions become a `DEFINITION_GAP` inside that prompt rather than a reason to omit the prompt artifact.
+- Simple identity fast path (v0.3.61): short identity/status questions such as "are you RedDog?" are answered locally with audited Run Trace telemetry. The fast path skips HoloIndex, OpenRouter, Fusion, repair, and downstream action planning; substantive RedDog audit/work prompts still route through the governed path.
 
 The extension does not grant repo authority. **012 supplies work focus only**; 0102 assembles a WSP task prompt before the bridge runs. Work focus and bounded repo context are sent through `scripts/advisory_model_once.py`, which runs the landed Fusion redaction gate before making OpenRouter requests. The webview receives only advisory text and redacted local history.
 

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.60';
+const EXTENSION_VERSION = '0.3.61';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -253,6 +253,9 @@ function buildRuntimeConsumptionGate(result, validationState, mode, substantiveT
     ? rp.fusion_panel_quorum
     : null;
 
+  if (rp.local_fast_path === 'simple_identity') {
+    reasons.push('local_identity_fast_path_not_actionable');
+  }
   if (substantiveTask !== true) {
     reasons.push('non_substantive_worker');
   }
@@ -3167,6 +3170,107 @@ const REGULAR_TASK_PATTERNS = [
   /\bregular mode works\b/i
 ];
 
+const SIMPLE_IDENTITY_FAST_PATH_SLICE = 'REDDOG_SIMPLE_IDENTITY_FAST_PATH_PHASE1';
+const SIMPLE_IDENTITY_BLOCKING_PATTERNS = [
+  /\b(?:audit|review|evaluate|fix|implement|author|provide|create|draft|enhance|investigate|compare|test|run|merge|land|dispatch|assign|spawn|execute|work|slice|phase1|phase_1|wsp[_\s-]?\d+|holoindex|openclaw|hermes|wre|authority|permission|valve|pr|pull request)\b/i,
+  /\n/
+];
+const SIMPLE_IDENTITY_PATTERNS = [
+  /^(?:are|r)\s+you\s+(?:the\s+)?(?:0102\s+)?(?:reddog|red dog)(?:\s+architect)?$/,
+  /^(?:is\s+this|is\s+that)\s+(?:the\s+)?(?:0102\s+)?(?:reddog|red dog)(?:\s+architect)?$/,
+  /^(?:who|what)\s+are\s+you$/,
+  /^(?:what\s+is\s+your\s+role|what\s+role\s+are\s+you|who\s+am\s+i\s+talking\s+to)$/,
+  /^(?:what\s+version\s+are\s+you|what\s+build\s+are\s+you|version|build)$/
+];
+
+function normalizeSimpleIdentityQuestion(text) {
+  return String(text || '')
+    .trim()
+    .replace(/[?!.]+$/g, '')
+    .replace(/\s+/g, ' ')
+    .toLowerCase();
+}
+
+function isSimpleIdentityQuestion(text) {
+  const raw = String(text || '').trim();
+  if (!raw || raw.length > 180) {
+    return false;
+  }
+  if (SIMPLE_IDENTITY_BLOCKING_PATTERNS.some((pattern) => pattern.test(raw))) {
+    return false;
+  }
+  const normalized = normalizeSimpleIdentityQuestion(raw);
+  return SIMPLE_IDENTITY_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+function buildSimpleIdentityFastPathResult(workFocus, workerType, worker) {
+  const workerKey = cleanWorkerType(workerType);
+  const workerLabel = WORKER_TYPES[workerKey] ? WORKER_TYPES[workerKey].label : workerKey;
+  const content = [
+    '## Decision',
+    'Yes. I am RedDog, the 0102 RedDog Architect advisory surface inside Foundups Agent.',
+    '',
+    '## Findings',
+    '- OBSERVED: This was a simple identity/status question and used `' + SIMPLE_IDENTITY_FAST_PATH_SLICE + '`.',
+    '- OBSERVED: No HoloIndex query, OpenRouter call, Fusion panel, repo read, shell command, or downstream action-planning bridge was invoked.',
+    '- OBSERVED: Installed extension version is `' + EXTENSION_VERSION + '`.',
+    '',
+    '## Evidence',
+    '| Check | WSP_97 | Result |',
+    '|---|---|---|',
+    '| 0102 role | OBSERVED | ' + workerLabel + ' |',
+    '| local fast path | OBSERVED | simple_identity |',
+    '| extension_version | OBSERVED | ' + EXTENSION_VERSION + ' |',
+    '| made_network_call | OBSERVED | false |',
+    '| no_execution_performed | OBSERVED | true |',
+    '',
+    '## Proposed fixes',
+    'No fix is needed for this identity question. For audits or implementation work, provide the work focus and RedDog will use the governed retrieval path.',
+    '',
+    '## Uncertainties',
+    'None for local identity fields. Capability and authority claims beyond this local surface require a normal governed audit.',
+    '',
+    '## WSP_97 Truth Labels',
+    '- OBSERVED: extension version, worker role, local fast-path selection, and no network/execution.',
+    '- SPECIFIED_NOT_IMPLEMENTED: This fast path does not grant repo, shell, merge, enqueue, or worktree authority.',
+    '',
+    '## WSP_15 Priority',
+    'P3: identity/status response only.',
+    '',
+    '## Next safest step',
+    'Ask the actual work focus when you want RedDog to audit, plan, or route work.',
+    '',
+    '## Architect Trace',
+    '- slice_name: ' + SIMPLE_IDENTITY_FAST_PATH_SLICE,
+    '- local_fast_path: simple_identity',
+    '- work_focus_digest: ' + redactedDigest(workFocus, 80).hash,
+    '',
+    '## Verification gaps',
+    '- None for the local identity response.',
+    '- Repo-level capability claims were intentionally not made.'
+  ].join('\n');
+  return {
+    ok: true,
+    content,
+    mode: 'local_identity_fast_path',
+    lead_model: 'local',
+    history: [],
+    made_network_call: false,
+    retry_count: 0,
+    local_identity_fast_path: true,
+    no_execution_performed: true,
+    no_enqueue_performed: true,
+    review_packet: {
+      made_network_call: false,
+      retry_count: 0,
+      local_fast_path: 'simple_identity',
+      local_fast_path_slice: SIMPLE_IDENTITY_FAST_PATH_SLICE,
+      no_execution_performed: true,
+      no_enqueue_performed: true
+    }
+  };
+}
+
 function classifyTaskForRedDog(prompt, contextMode, workerType) {
   const text = String(prompt || '');
   const worker = cleanWorkerType(workerType);
@@ -3174,8 +3278,13 @@ function classifyTaskForRedDog(prompt, contextMode, workerType) {
   const haystack = text + ' ' + mode + ' ' + worker;
   let tier = 'HIGH';
   let reasons = [];
+  let localFastPath = null;
 
-  if (ULTRA_TASK_PATTERNS.some((pattern) => pattern.test(haystack))) {
+  if (isSimpleIdentityQuestion(text)) {
+    tier = 'REGULAR';
+    reasons.push('simple_identity_fast_path');
+    localFastPath = 'simple_identity';
+  } else if (ULTRA_TASK_PATTERNS.some((pattern) => pattern.test(haystack))) {
     tier = 'ULTRA';
     reasons.push('ultra_keyword_match');
   } else if (REGULAR_TASK_PATTERNS.some((pattern) => pattern.test(haystack)) && worker === 'smoke_tester') {
@@ -3192,12 +3301,13 @@ function classifyTaskForRedDog(prompt, contextMode, workerType) {
     reasons.push('uncertain_default_high');
   }
 
-  const preferManualPanel = tier !== 'REGULAR' || worker !== 'smoke_tester';
+  const preferManualPanel = localFastPath ? false : (tier !== 'REGULAR' || worker !== 'smoke_tester');
   return {
     tier,
     reasons,
     worker,
     contextMode: mode,
+    localFastPath,
     preferManualPanel,
     prefersAuditablePanel: preferManualPanel && worker !== 'smoke_tester'
   };
@@ -3255,6 +3365,9 @@ function resolveAutoContextMode(classification, selectedContextMode) {
   if (mode !== 'auto') {
     return mode;
   }
+  if (classification && classification.localFastPath === 'simple_identity') {
+    return 'none';
+  }
   const tier = classification && classification.tier ? classification.tier : 'HIGH';
   if (tier === 'REGULAR') {
     return 'wsp_holo';
@@ -3270,6 +3383,9 @@ function resolveAutoEffort(classification, selectedEffort) {
   if (effort !== 'auto') {
     return effort;
   }
+  if (classification && classification.localFastPath === 'simple_identity') {
+    return 'regular';
+  }
   const tier = classification && classification.tier ? classification.tier : 'HIGH';
   if (tier === 'ULTRA') {
     return 'ultra';
@@ -3283,6 +3399,9 @@ function resolveAutoEffort(classification, selectedEffort) {
 function resolveModelMode(classification, selectedMode, workerType) {
   const mode = cleanMode(selectedMode);
   const worker = cleanWorkerType(workerType);
+  if (classification && classification.localFastPath === 'simple_identity') {
+    return 'local_identity_fast_path';
+  }
   if (mode === 'auto') {
     return classification && classification.tier === 'REGULAR' ? 'openrouter_single' : 'foundups_fusion';
   }
@@ -3332,6 +3451,9 @@ function validateRedDogOutput(markdown, options) {
 
 function modeSelectionReasoning(classification, resolvedEffort, resolvedMode, resolvedContextMode) {
   const tier = classification && classification.tier ? classification.tier : 'HIGH';
+  if (resolvedMode === 'local_identity_fast_path') {
+    return 'Local RedDog identity fast path: short identity/status question; skips HoloIndex, OpenRouter, Fusion, repair, and downstream action planning; context=' + resolvedContextMode + '.';
+  }
   if (resolvedMode === 'openrouter_single') {
     if (tier === 'REGULAR') {
       return 'Single-model GLM principal: REGULAR-tier work; HoloIndex-grounded wsp_holo (no Fusion panel, Skillz, or git); context=' + resolvedContextMode + '.';
@@ -3962,6 +4084,7 @@ function wireFusionWebview(context, webview, worker, state) {
     // Missing/stale useLastPacket => OFF (do not carry a stale packet into redaction/acceptance scoring).
     const continuationEnabled = message.useLastPacket === true;
     const classification = classifyTaskForRedDog(workFocus, selectedContextMode, workerType);
+    const localIdentityFastPath = classification.localFastPath === 'simple_identity';
     const effort = resolveAutoEffort(classification, selectedEffort);
     const mode = resolveModelMode(classification, selectedMode, workerType);
     const contextMode = resolveAutoContextMode(classification, selectedContextMode);
@@ -4001,7 +4124,11 @@ function wireFusionWebview(context, webview, worker, state) {
     const systemPrompt = buildSystemPrompt(workerType, effort, contextPacket.quality);
 
     postStatusAndProgress(webview, null, 'Orchestrator: effort=' + effort + ' mode=' + mode + ' tier=' + classification.tier + ' context=' + contextMode + ' principal=' + worker.lead + ' panel=' + worker.panel.join(' + ') + ' (' + classification.reasons.join(', ') + ')');
-    postStatusAndProgress(webview, null, 'Bridge started. Redaction gate runs before any OpenRouter API call.');
+    if (localIdentityFastPath) {
+      postStatusAndProgress(webview, null, 'Simple RedDog identity question answered locally. No HoloIndex, OpenRouter, Fusion, repair, or downstream action planning.');
+    } else {
+      postStatusAndProgress(webview, null, 'Bridge started. Redaction gate runs before any OpenRouter API call.');
+    }
     if (contextPacket.summary) {
       postStatusAndProgress(webview, null, contextPacket.summary);
     }
@@ -4073,7 +4200,10 @@ function wireFusionWebview(context, webview, worker, state) {
       }
     };
     let result;
-    if (!groundingPreflight.passed) {
+    if (localIdentityFastPath) {
+      workTrail.push('local_fast_path', 'simple_identity');
+      result = buildSimpleIdentityFastPathResult(workFocus, workerType, worker);
+    } else if (!groundingPreflight.passed) {
       workTrail.push('failed', 'grounding_preflight_blocked');
       postStatusAndProgress(webview, null, 'Grounding preflight blocked Fusion: ' + groundingPreflight.rejection_reasons.join(', '));
       result = buildGroundingPreflightBlockedResult(groundingPreflight);
@@ -4105,7 +4235,7 @@ function wireFusionWebview(context, webview, worker, state) {
       }
     }
     absorbUnicodeMeta(result);
-    const substantiveTask = isSubstantiveRedDogWorker(workerType);
+    const substantiveTask = isSubstantiveRedDogWorker(workerType) && !localIdentityFastPath;
     if (result.ok && substantiveTask) {
       workTrail.push('validator_started');
       const outputValidationOptions = {
@@ -4214,7 +4344,7 @@ function wireFusionWebview(context, webview, worker, state) {
         }
       }
     } else if (result.ok) {
-      validationState = { validated: false, skipped: true, reason: 'non_substantive_worker' };
+      validationState = { validated: false, skipped: true, reason: localIdentityFastPath ? 'local_identity_fast_path' : 'non_substantive_worker' };
     } else if (result.reason === 'redaction_blocked') {
       validationState = { validated: false, skipped: true, reason: 'redaction_blocked' };
       workTrail.push('redaction_gate_blocked');
@@ -6280,6 +6410,8 @@ module.exports = {
   normalizeRepairBridgeStageToWorkTrail,
   BRIDGE_REPAIR_STAGE_WORK_TRAIL,
   constructWspTaskPrompt,
+  isSimpleIdentityQuestion,
+  buildSimpleIdentityFastPathResult,
   appendContinuationSummaryToWspPrompt,
   buildSanitizedContinuationSummary,
   buildContinuationSummaryCopySection,

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups\u00aeAgent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.60",
+    "version":  "0.3.61",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -197,8 +197,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.60', 'package version must be 0.3.60');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.60'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.61', 'package version must be 0.3.61');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.61'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups\u00aeAgent', 'display name must be Foundups\u00aeAgent');
 includes(JSON.stringify(pkg), 'Foundups\u00aeAgent: Open', 'command title must use Foundups\u00aeAgent');
@@ -215,7 +215,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.60', 'README version mismatch');
+includes(readme, 'Version: 0.3.61', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -446,6 +446,36 @@ assert(wsp.tier === 'HIGH' || wsp.tier === 'ULTRA', 'WSP/architecture prompts mu
 
 const regular = orchestrator.classifyTaskForRedDog('Reply with exactly: regular mode works', 'auto', 'smoke_tester');
 assert.strictEqual(regular.tier, 'REGULAR', 'simple smoke prompts must classify REGULAR');
+
+// REDDOG_SIMPLE_IDENTITY_FAST_PATH_PHASE1: "are you RedDog?" is not architecture work.
+// It must answer locally instead of paying the HIGH-tier Fusion/HoloIndex/repair path just
+// because the short question contains the token "RedDog".
+includes(extensionJs, 'function isSimpleIdentityQuestion', 'SIFP-001: simple identity detector missing');
+includes(extensionJs, 'function buildSimpleIdentityFastPathResult', 'SIFP-001: simple identity result builder missing');
+const identityClass = orchestrator.classifyTaskForRedDog('are you reddog?', 'auto', 'reddog_architect');
+assert.strictEqual(orchestrator.isSimpleIdentityQuestion('are you reddog?'), true, 'SIFP-001: exact user prompt must be detected');
+assert.strictEqual(identityClass.tier, 'REGULAR', 'SIFP-001: simple identity prompt must not classify HIGH');
+assert.strictEqual(identityClass.localFastPath, 'simple_identity', 'SIFP-001: local fast-path marker missing');
+assert.strictEqual(orchestrator.resolveModelMode(identityClass, 'auto', 'reddog_architect'), 'local_identity_fast_path', 'SIFP-001: identity prompt must not call OpenRouter/Fusion');
+assert.strictEqual(orchestrator.resolveAutoContextMode(identityClass, 'auto'), 'none', 'SIFP-001: identity prompt must skip HoloIndex context');
+assert.strictEqual(orchestrator.resolveAutoEffort(identityClass, 'auto'), 'regular', 'SIFP-001: identity prompt must stay low effort');
+const identityResult = orchestrator.buildSimpleIdentityFastPathResult('are you reddog?', 'reddog_architect', { lead: 'local', panel: [] });
+assert.strictEqual(identityResult.ok, true, 'SIFP-001: identity result must be OK');
+assert.strictEqual(identityResult.review_packet.made_network_call, false, 'SIFP-001: identity result must prove no network call');
+assert.strictEqual(identityResult.review_packet.local_fast_path, 'simple_identity', 'SIFP-001: identity review packet must carry local marker');
+includes(identityResult.content, 'Yes. I am RedDog', 'SIFP-001: identity answer must be direct');
+const identityGate = orchestrator.buildRuntimeConsumptionGate(
+  { ok: true, review_packet: identityResult.review_packet },
+  { validated: false, skipped: true, reason: 'local_identity_fast_path' },
+  'local_identity_fast_path',
+  false
+);
+assert.strictEqual(identityGate.passed, false, 'SIFP-001: identity fast path must not enable runtime consumption');
+assert(identityGate.rejection_reasons.includes('local_identity_fast_path_not_actionable'), 'SIFP-001: runtime gate must name local fast path rejection');
+assert.strictEqual(orchestrator.isSimpleIdentityQuestion('audit RedDog architecture and HoloIndex routing'), false, 'SIFP-002: substantive RedDog audit must not use identity fast path');
+const reddogAuditClass = orchestrator.classifyTaskForRedDog('audit RedDog architecture and HoloIndex routing', 'auto', 'reddog_architect');
+assert.strictEqual(reddogAuditClass.localFastPath, null, 'SIFP-002: substantive audit must not carry local fast path');
+assert(reddogAuditClass.tier === 'HIGH' || reddogAuditClass.tier === 'ULTRA', 'SIFP-002: substantive RedDog audit must stay governed HIGH/ULTRA');
 
 assert.strictEqual(
   orchestrator.resolveModelMode(wsp, 'auto', 'reddog_architect'),
@@ -903,7 +933,7 @@ assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
 assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
 assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
-assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.60', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.61', 'candidate must bind extension version');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
 assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [
@@ -2241,7 +2271,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.60'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.61'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -2255,7 +2285,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.60'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.61'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -2267,7 +2297,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.60'", 'bounded context must include source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.61'", 'bounded context must include source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');


### PR DESCRIPTION
## Summary

Implements `REDDOG_SIMPLE_IDENTITY_FAST_PATH_PHASE1` for short identity/status prompts such as `are you RedDog?`.

The 0.3.59 traces showed that this exact prompt classified HIGH and routed through `foundups_fusion` + `wsp_holo_skillz`, causing HoloIndex/Fusion/repair latency for a local identity answer. This slice adds a narrow local fast path before model/context work.

## WSP_97 Evidence

- OBSERVED: `are you reddog?` now classifies REGULAR with `localFastPath= simple_identity`.
- OBSERVED: `resolveModelMode(...)` returns `local_identity_fast_path` and `resolveAutoContextMode(...)` returns `none`.
- OBSERVED: local result sets `made_network_call=false`, `retry_count=0`, `no_execution_performed=true`, `no_enqueue_performed=true`.
- OBSERVED: runtime consumption gate rejects the result with `local_identity_fast_path_not_actionable`.
- OBSERVED: substantive prompts like `audit RedDog architecture and HoloIndex routing` do not use the fast path and remain HIGH/ULTRA governed work.
- SPECIFIED_NOT_IMPLEMENTED: this fast path grants no repo, shell, merge, enqueue, worktree, HoloIndex, or OpenRouter authority.

## Validation

- `node --check extensions/foundups_advisory_workers/extension.js` -> PASS
- `node extensions/foundups_advisory_workers/tests/verify_extension_contract.js` -> PASS
- `git diff --check` -> PASS
- ASCII additions/diff scan -> PASS

Known noise: the existing surrogate fixture still prints a Python `UnicodeEncodeError` on stderr while the JS contract suite exits 0 and prints the success line.

## Scope Boundary

Extension runtime only. No Python bridge, HoloIndex, OpenClaw, Hermes, WRE, shell, git, merge, or live authority wiring changed.