### PR TITLE
fix(reddog): assess pasted run traces locally

### DIFF
--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,13 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-13 - REDDOG_RUN_TRACE_LOCAL_ASSESSMENT_PHASE1 (local pasted-trace diagnostics, 0.3.62)
+
+- Added a local Run Trace assessment fast path for pasted `## Run Trace` diagnostics so RedDog can explain blocked/slow traces without sending raw trace text through HoloIndex/Fusion/OpenRouter.
+- The assessor parses telemetry fields such as `extension_version`, `mode`, `redaction gate status`, `made_network_call`, target recall counts, output validation, and runtime gate reasons, then returns a WSP_97-labeled diagnostic response.
+- Runtime consumption remains blocked with `local_run_trace_assessment_not_actionable`; no downstream action planning, repo reads, shell, HoloIndex mutation, or model call is performed.
+- Version 0.3.61 -> 0.3.62 (package.json + EXTENSION_VERSION + README + contract-test assertions).
+
 ## 2026-07-13 - REDDOG_SIMPLE_IDENTITY_FAST_PATH_PHASE1 (local identity/status answer, 0.3.61)
 
 - Added a narrow local fast path for short identity/status questions such as `are you RedDog?` so they do not escalate through HIGH-tier Fusion routing merely because the prompt contains `RedDog`.

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.61
+Version: 0.3.62
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 
@@ -60,6 +60,7 @@ The extension is a bounded 0102 advisory surface:
 - Determine-block target derivation guard (v0.3.59): `Determine:` numbered questions are treated as answer/output obligations, not repo-file target intent. Slash-bearing conceptual phrases inside questions (for example `ledger/runtime`) no longer become `repo_file_targets` or block typed grounding. Explicit `Read first:` / required-target sections still drive direct read normally.
 - Prompt-authoring deliverable contract (v0.3.60): when 012 asks RedDog to create/evaluate/provide a worker prompt, RedDog receives bounded direct-read context for its prompt/judgment surfaces and must return a `## Worker Prompt` section with one fenced executable prompt. Missing definitions become a `DEFINITION_GAP` inside that prompt rather than a reason to omit the prompt artifact.
 - Simple identity fast path (v0.3.61): short identity/status questions such as "are you RedDog?" are answered locally with audited Run Trace telemetry. The fast path skips HoloIndex, OpenRouter, Fusion, repair, and downstream action planning; substantive RedDog audit/work prompts still route through the governed path.
+- Run Trace local assessment (v0.3.62): pasted `## Run Trace` diagnostics are parsed locally and scored with WSP_97 labels so raw trace text no longer needs to pass through Fusion/redaction just to explain why a run blocked or routed slowly. The path remains non-actionable and cannot trigger runtime planning.
 
 The extension does not grant repo authority. **012 supplies work focus only**; 0102 assembles a WSP task prompt before the bridge runs. Work focus and bounded repo context are sent through `scripts/advisory_model_once.py`, which runs the landed Fusion redaction gate before making OpenRouter requests. The webview receives only advisory text and redacted local history.
 

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.61';
+const EXTENSION_VERSION = '0.3.62';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -255,6 +255,9 @@ function buildRuntimeConsumptionGate(result, validationState, mode, substantiveT
 
   if (rp.local_fast_path === 'simple_identity') {
     reasons.push('local_identity_fast_path_not_actionable');
+  }
+  if (rp.local_fast_path === 'run_trace_assessment') {
+    reasons.push('local_run_trace_assessment_not_actionable');
   }
   if (substantiveTask !== true) {
     reasons.push('non_substantive_worker');
@@ -3182,6 +3185,15 @@ const SIMPLE_IDENTITY_PATTERNS = [
   /^(?:what\s+is\s+your\s+role|what\s+role\s+are\s+you|who\s+am\s+i\s+talking\s+to)$/,
   /^(?:what\s+version\s+are\s+you|what\s+build\s+are\s+you|version|build)$/
 ];
+const RUN_TRACE_ASSESSMENT_FAST_PATH_SLICE = 'REDDOG_RUN_TRACE_LOCAL_ASSESSMENT_PHASE1';
+const RUN_TRACE_ASSESSMENT_PATTERNS = [
+  /\b(?:assess|evaluate|review|diagnose|score|rate)\b[\s\S]{0,160}\brun trace\b/i,
+  /\brun trace\b[\s\S]{0,160}\b(?:assess|evaluate|review|diagnose|score|rate|why|blocked|slow|failed)\b/i,
+  /\bwhy\b[\s\S]{0,120}\b(?:blocked|slow|failed|took forever)\b/i
+];
+const RUN_TRACE_ACTION_BLOCKING_PATTERNS = [
+  /\b(?:implement|fix|patch|author|provide|create|draft|enhance|write|merge|land|dispatch|assign|spawn|execute|start)\b/i
+];
 
 function normalizeSimpleIdentityQuestion(text) {
   return String(text || '')
@@ -3201,6 +3213,150 @@ function isSimpleIdentityQuestion(text) {
   }
   const normalized = normalizeSimpleIdentityQuestion(raw);
   return SIMPLE_IDENTITY_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+function extractRunTraceField(text, fieldName) {
+  const escaped = String(fieldName || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp('^\\s*-\\s*' + escaped + '\\s*:\\s*(.*)$', 'im');
+  const match = pattern.exec(String(text || ''));
+  return match ? match[1].trim() : '';
+}
+
+function isRunTraceAssessmentRequest(text) {
+  const raw = String(text || '');
+  if (!/##\s*Run Trace\b/i.test(raw) || !/\bextension_version\s*:/i.test(raw)) {
+    return false;
+  }
+  if (RUN_TRACE_ACTION_BLOCKING_PATTERNS.some((pattern) => pattern.test(raw.slice(0, 1200)))) {
+    return false;
+  }
+  return RUN_TRACE_ASSESSMENT_PATTERNS.some((pattern) => pattern.test(raw.slice(0, 2000)))
+    || /\bredaction gate status\s*:\s*BLOCKED_LOCALLY/i.test(raw);
+}
+
+function parseRunTraceAssessment(text) {
+  const src = String(text || '');
+  const get = (field) => extractRunTraceField(src, field);
+  const extensionVersion = get('extension_version') || 'unknown';
+  const mode = get('mode') || 'unknown';
+  const contextMode = get('context mode') || 'unknown';
+  const tier = get('WSP_15 tier') || 'unknown';
+  const redactionGateStatus = get('redaction gate status') || 'unknown';
+  const madeNetworkCall = get('made_network_call') || 'unknown';
+  const directReadFallbackUsed = get('direct_read_fallback_used') || 'unknown';
+  const directReadFetchAttempted = get('direct_read_fetch_attempted') || 'unknown';
+  const targetRecallOk = get('target_recall_ok') || 'unknown';
+  const requiredTargetsTotal = get('required_targets_total') || 'unknown';
+  const requiredTargetsRecalled = get('required_targets_recalled') || 'unknown';
+  const workFocusTargetsDerived = get('work_focus_targets_derived') || 'unknown';
+  const outputValidation = get('output_validation') || 'unknown';
+  const runtimeGateReasons = get('runtime_consumption_gate_rejection_reasons') || 'unknown';
+  const staleIdentityBuild = /^0\.3\.(?:[0-9]|[1-5][0-9]|60)$/.test(extensionVersion);
+  const blockedLocally = /BLOCKED_LOCALLY/i.test(redactionGateStatus) || /redaction_blocked/i.test(runtimeGateReasons);
+  const highFusion = /foundups_fusion/i.test(mode) && /HIGH|ULTRA/i.test(tier);
+  return {
+    extension_version: extensionVersion,
+    mode,
+    context_mode: contextMode,
+    tier,
+    redaction_gate_status: redactionGateStatus,
+    made_network_call: madeNetworkCall,
+    direct_read_fallback_used: directReadFallbackUsed,
+    direct_read_fetch_attempted: directReadFetchAttempted,
+    target_recall_ok: targetRecallOk,
+    required_targets_total: requiredTargetsTotal,
+    required_targets_recalled: requiredTargetsRecalled,
+    work_focus_targets_derived: workFocusTargetsDerived,
+    output_validation: outputValidation,
+    runtime_consumption_gate_rejection_reasons: runtimeGateReasons,
+    stale_identity_build: staleIdentityBuild,
+    blocked_locally: blockedLocally,
+    high_fusion_route: highFusion
+  };
+}
+
+function buildRunTraceAssessmentFastPathResult(workFocus) {
+  const a = parseRunTraceAssessment(workFocus);
+  const verdict = a.blocked_locally ? 'BLOCKED_LOCALLY before model output' : 'TRACE_PARSED';
+  const staleLine = a.stale_identity_build
+    ? '- OBSERVED: The trace is from extension `' + a.extension_version + '`, before the 0.3.61 simple-identity fast path.'
+    : '- OBSERVED: The trace extension version is `' + a.extension_version + '`.';
+  const content = [
+    '## Decision',
+    verdict + '. The pasted Run Trace was assessed locally; no model call is needed to explain it.',
+    '',
+    '## Findings',
+    staleLine,
+    '- OBSERVED: mode=`' + a.mode + '`, tier=`' + a.tier + '`, context=`' + a.context_mode + '`.',
+    '- OBSERVED: redaction gate status=`' + a.redaction_gate_status + '`, made_network_call=`' + a.made_network_call + '`.',
+    '- OBSERVED: required_targets_total=`' + a.required_targets_total + '`, required_targets_recalled=`' + a.required_targets_recalled + '`, direct_read_fetch_attempted=`' + a.direct_read_fetch_attempted + '`.',
+    a.high_fusion_route
+      ? '- INFERRED: The prompt routed through HIGH-tier Fusion, which is expensive and unnecessary for a local trace explanation.'
+      : '- INFERRED: The trace did not show a HIGH-tier Fusion route.',
+    a.blocked_locally
+      ? '- OBSERVED: No 0102 model output exists because the local redaction gate stopped the request before OpenRouter.'
+      : '- OBSERVED: The trace does not show a local redaction block.',
+    '',
+    '## Evidence',
+    '| Field | WSP_97 | Value |',
+    '|---|---|---|',
+    '| extension_version | OBSERVED | ' + a.extension_version + ' |',
+    '| mode | OBSERVED | ' + a.mode + ' |',
+    '| context mode | OBSERVED | ' + a.context_mode + ' |',
+    '| redaction gate status | OBSERVED | ' + a.redaction_gate_status + ' |',
+    '| made_network_call | OBSERVED | ' + a.made_network_call + ' |',
+    '| output_validation | OBSERVED | ' + a.output_validation + ' |',
+    '| runtime gate reasons | OBSERVED | ' + a.runtime_consumption_gate_rejection_reasons + ' |',
+    '',
+    '## Proposed fixes',
+    '- Use installed build 0.3.61+ for simple identity questions so `are you RedDog?` takes the local identity fast path.',
+    '- Use this local Run Trace assessment path for pasted Run Trace diagnostics instead of sending raw trace text through Fusion.',
+    '- For substantive code/audit work, keep the governed retrieval/Fusion path.',
+    '',
+    '## Uncertainties',
+    '- The local assessor explains telemetry fields only. It does not infer source-code facts that are absent from the trace.',
+    '',
+    '## WSP_97 Truth Labels',
+    '- OBSERVED: telemetry fields parsed from the pasted Run Trace.',
+    '- INFERRED: routing cost/root-cause statements derived from those fields.',
+    '- SPECIFIED_NOT_IMPLEMENTED: no repo, shell, merge, enqueue, or worktree authority is granted by this local assessor.',
+    '',
+    '## WSP_15 Priority',
+    'P2: diagnostics fast path. It prevents repeat local blocks on pasted traces and keeps action planning disabled.',
+    '',
+    '## Next safest step',
+    'Reload Cursor after installing the latest VSIX, then retest with the original question or paste a trace for local assessment.',
+    '',
+    '## Architect Trace',
+    '- slice_name: ' + RUN_TRACE_ASSESSMENT_FAST_PATH_SLICE,
+    '- local_fast_path: run_trace_assessment',
+    '- work_focus_digest: ' + redactedDigest(workFocus, 80).hash,
+    '',
+    '## Verification gaps',
+    '- None for the telemetry assessment.',
+    '- Any code-level fix beyond the parsed trace requires the normal governed audit path.'
+  ].join('\n');
+  return {
+    ok: true,
+    content,
+    mode: 'local_run_trace_assessment',
+    lead_model: 'local',
+    history: [],
+    made_network_call: false,
+    retry_count: 0,
+    local_run_trace_assessment: true,
+    no_execution_performed: true,
+    no_enqueue_performed: true,
+    review_packet: {
+      made_network_call: false,
+      retry_count: 0,
+      local_fast_path: 'run_trace_assessment',
+      local_fast_path_slice: RUN_TRACE_ASSESSMENT_FAST_PATH_SLICE,
+      parsed_run_trace_assessment: a,
+      no_execution_performed: true,
+      no_enqueue_performed: true
+    }
+  };
 }
 
 function buildSimpleIdentityFastPathResult(workFocus, workerType, worker) {
@@ -3284,6 +3440,10 @@ function classifyTaskForRedDog(prompt, contextMode, workerType) {
     tier = 'REGULAR';
     reasons.push('simple_identity_fast_path');
     localFastPath = 'simple_identity';
+  } else if (isRunTraceAssessmentRequest(text)) {
+    tier = 'REGULAR';
+    reasons.push('run_trace_assessment_fast_path');
+    localFastPath = 'run_trace_assessment';
   } else if (ULTRA_TASK_PATTERNS.some((pattern) => pattern.test(haystack))) {
     tier = 'ULTRA';
     reasons.push('ultra_keyword_match');
@@ -3365,7 +3525,7 @@ function resolveAutoContextMode(classification, selectedContextMode) {
   if (mode !== 'auto') {
     return mode;
   }
-  if (classification && classification.localFastPath === 'simple_identity') {
+  if (classification && (classification.localFastPath === 'simple_identity' || classification.localFastPath === 'run_trace_assessment')) {
     return 'none';
   }
   const tier = classification && classification.tier ? classification.tier : 'HIGH';
@@ -3383,7 +3543,7 @@ function resolveAutoEffort(classification, selectedEffort) {
   if (effort !== 'auto') {
     return effort;
   }
-  if (classification && classification.localFastPath === 'simple_identity') {
+  if (classification && (classification.localFastPath === 'simple_identity' || classification.localFastPath === 'run_trace_assessment')) {
     return 'regular';
   }
   const tier = classification && classification.tier ? classification.tier : 'HIGH';
@@ -3401,6 +3561,9 @@ function resolveModelMode(classification, selectedMode, workerType) {
   const worker = cleanWorkerType(workerType);
   if (classification && classification.localFastPath === 'simple_identity') {
     return 'local_identity_fast_path';
+  }
+  if (classification && classification.localFastPath === 'run_trace_assessment') {
+    return 'local_run_trace_assessment';
   }
   if (mode === 'auto') {
     return classification && classification.tier === 'REGULAR' ? 'openrouter_single' : 'foundups_fusion';
@@ -3453,6 +3616,9 @@ function modeSelectionReasoning(classification, resolvedEffort, resolvedMode, re
   const tier = classification && classification.tier ? classification.tier : 'HIGH';
   if (resolvedMode === 'local_identity_fast_path') {
     return 'Local RedDog identity fast path: short identity/status question; skips HoloIndex, OpenRouter, Fusion, repair, and downstream action planning; context=' + resolvedContextMode + '.';
+  }
+  if (resolvedMode === 'local_run_trace_assessment') {
+    return 'Local RedDog Run Trace assessment fast path: pasted Run Trace diagnostics; skips HoloIndex, OpenRouter, Fusion, repair, and downstream action planning; context=' + resolvedContextMode + '.';
   }
   if (resolvedMode === 'openrouter_single') {
     if (tier === 'REGULAR') {
@@ -4085,6 +4251,8 @@ function wireFusionWebview(context, webview, worker, state) {
     const continuationEnabled = message.useLastPacket === true;
     const classification = classifyTaskForRedDog(workFocus, selectedContextMode, workerType);
     const localIdentityFastPath = classification.localFastPath === 'simple_identity';
+    const localRunTraceAssessment = classification.localFastPath === 'run_trace_assessment';
+    const localFastPath = localIdentityFastPath || localRunTraceAssessment;
     const effort = resolveAutoEffort(classification, selectedEffort);
     const mode = resolveModelMode(classification, selectedMode, workerType);
     const contextMode = resolveAutoContextMode(classification, selectedContextMode);
@@ -4126,6 +4294,8 @@ function wireFusionWebview(context, webview, worker, state) {
     postStatusAndProgress(webview, null, 'Orchestrator: effort=' + effort + ' mode=' + mode + ' tier=' + classification.tier + ' context=' + contextMode + ' principal=' + worker.lead + ' panel=' + worker.panel.join(' + ') + ' (' + classification.reasons.join(', ') + ')');
     if (localIdentityFastPath) {
       postStatusAndProgress(webview, null, 'Simple RedDog identity question answered locally. No HoloIndex, OpenRouter, Fusion, repair, or downstream action planning.');
+    } else if (localRunTraceAssessment) {
+      postStatusAndProgress(webview, null, 'Run Trace diagnostics answered locally. No HoloIndex, OpenRouter, Fusion, repair, or downstream action planning.');
     } else {
       postStatusAndProgress(webview, null, 'Bridge started. Redaction gate runs before any OpenRouter API call.');
     }
@@ -4203,6 +4373,9 @@ function wireFusionWebview(context, webview, worker, state) {
     if (localIdentityFastPath) {
       workTrail.push('local_fast_path', 'simple_identity');
       result = buildSimpleIdentityFastPathResult(workFocus, workerType, worker);
+    } else if (localRunTraceAssessment) {
+      workTrail.push('local_fast_path', 'run_trace_assessment');
+      result = buildRunTraceAssessmentFastPathResult(workFocus);
     } else if (!groundingPreflight.passed) {
       workTrail.push('failed', 'grounding_preflight_blocked');
       postStatusAndProgress(webview, null, 'Grounding preflight blocked Fusion: ' + groundingPreflight.rejection_reasons.join(', '));
@@ -4235,7 +4408,7 @@ function wireFusionWebview(context, webview, worker, state) {
       }
     }
     absorbUnicodeMeta(result);
-    const substantiveTask = isSubstantiveRedDogWorker(workerType) && !localIdentityFastPath;
+    const substantiveTask = isSubstantiveRedDogWorker(workerType) && !localFastPath;
     if (result.ok && substantiveTask) {
       workTrail.push('validator_started');
       const outputValidationOptions = {
@@ -4344,7 +4517,7 @@ function wireFusionWebview(context, webview, worker, state) {
         }
       }
     } else if (result.ok) {
-      validationState = { validated: false, skipped: true, reason: localIdentityFastPath ? 'local_identity_fast_path' : 'non_substantive_worker' };
+      validationState = { validated: false, skipped: true, reason: localIdentityFastPath ? 'local_identity_fast_path' : (localRunTraceAssessment ? 'local_run_trace_assessment' : 'non_substantive_worker') };
     } else if (result.reason === 'redaction_blocked') {
       validationState = { validated: false, skipped: true, reason: 'redaction_blocked' };
       workTrail.push('redaction_gate_blocked');
@@ -6412,6 +6585,9 @@ module.exports = {
   constructWspTaskPrompt,
   isSimpleIdentityQuestion,
   buildSimpleIdentityFastPathResult,
+  isRunTraceAssessmentRequest,
+  parseRunTraceAssessment,
+  buildRunTraceAssessmentFastPathResult,
   appendContinuationSummaryToWspPrompt,
   buildSanitizedContinuationSummary,
   buildContinuationSummaryCopySection,

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups\u00aeAgent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.61",
+    "version":  "0.3.62",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -197,8 +197,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.61', 'package version must be 0.3.61');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.61'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.62', 'package version must be 0.3.62');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.62'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups\u00aeAgent', 'display name must be Foundups\u00aeAgent');
 includes(JSON.stringify(pkg), 'Foundups\u00aeAgent: Open', 'command title must use Foundups\u00aeAgent');
@@ -215,7 +215,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.61', 'README version mismatch');
+includes(readme, 'Version: 0.3.62', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -476,6 +476,56 @@ assert.strictEqual(orchestrator.isSimpleIdentityQuestion('audit RedDog architect
 const reddogAuditClass = orchestrator.classifyTaskForRedDog('audit RedDog architecture and HoloIndex routing', 'auto', 'reddog_architect');
 assert.strictEqual(reddogAuditClass.localFastPath, null, 'SIFP-002: substantive audit must not carry local fast path');
 assert(reddogAuditClass.tier === 'HIGH' || reddogAuditClass.tier === 'ULTRA', 'SIFP-002: substantive RedDog audit must stay governed HIGH/ULTRA');
+
+// REDDOG_RUN_TRACE_LOCAL_ASSESSMENT_PHASE1: pasted Copy-MD/Run Trace diagnostics
+// should be scored locally. Sending raw trace telemetry through Fusion can re-trigger
+// the redaction gate just to explain that the redaction gate blocked.
+includes(extensionJs, 'function isRunTraceAssessmentRequest', 'RTLA-001: run trace assessment detector missing');
+includes(extensionJs, 'function buildRunTraceAssessmentFastPathResult', 'RTLA-001: run trace assessment builder missing');
+const blockedTracePrompt = [
+  'Please assess this Run Trace.',
+  '',
+  '## Run Trace',
+  '- extension_version: 0.3.59',
+  '- 0102 role: RedDog Architect',
+  '- WSP_15 tier: HIGH',
+  '- mode: foundups_fusion',
+  '- context mode: wsp_holo_skillz',
+  '- target_recall_ok: unknown',
+  '- required_targets_total: 0',
+  '- required_targets_recalled: 0',
+  '- work_focus_targets_derived: false',
+  '- direct_read_fallback_used: false',
+  '- direct_read_fetch_attempted: false',
+  '- redaction gate status: BLOCKED_LOCALLY',
+  '- made_network_call: false',
+  '- output_validation: skipped',
+  '- runtime_consumption_gate_rejection_reasons: model_result_not_ok, redaction_blocked, output_validation_not_passed, fusion_panel_quorum_not_passed'
+].join('\n');
+assert.strictEqual(orchestrator.isRunTraceAssessmentRequest(blockedTracePrompt), true, 'RTLA-001: pasted blocked Run Trace must be detected');
+const traceClass = orchestrator.classifyTaskForRedDog(blockedTracePrompt, 'auto', 'reddog_architect');
+assert.strictEqual(traceClass.tier, 'REGULAR', 'RTLA-001: Run Trace diagnostics must not stay HIGH');
+assert.strictEqual(traceClass.localFastPath, 'run_trace_assessment', 'RTLA-001: local trace fast-path marker missing');
+assert.strictEqual(orchestrator.resolveModelMode(traceClass, 'auto', 'reddog_architect'), 'local_run_trace_assessment', 'RTLA-001: Run Trace diagnostics must not call OpenRouter/Fusion');
+assert.strictEqual(orchestrator.resolveAutoContextMode(traceClass, 'auto'), 'none', 'RTLA-001: Run Trace diagnostics must skip HoloIndex context');
+const parsedTrace = orchestrator.parseRunTraceAssessment(blockedTracePrompt);
+assert.strictEqual(parsedTrace.extension_version, '0.3.59', 'RTLA-001: extension version must parse');
+assert.strictEqual(parsedTrace.blocked_locally, true, 'RTLA-001: blocked trace must be identified');
+assert.strictEqual(parsedTrace.high_fusion_route, true, 'RTLA-001: high Fusion route must be identified');
+const traceResult = orchestrator.buildRunTraceAssessmentFastPathResult(blockedTracePrompt);
+assert.strictEqual(traceResult.review_packet.made_network_call, false, 'RTLA-001: local trace result must prove no network call');
+assert.strictEqual(traceResult.review_packet.local_fast_path, 'run_trace_assessment', 'RTLA-001: local trace review packet marker missing');
+includes(traceResult.content, 'BLOCKED_LOCALLY before model output', 'RTLA-001: local trace answer must explain block');
+const traceGate = orchestrator.buildRuntimeConsumptionGate(
+  { ok: true, review_packet: traceResult.review_packet },
+  { validated: false, skipped: true, reason: 'local_run_trace_assessment' },
+  'local_run_trace_assessment',
+  false
+);
+assert.strictEqual(traceGate.passed, false, 'RTLA-001: trace assessment must not enable runtime consumption');
+assert(traceGate.rejection_reasons.includes('local_run_trace_assessment_not_actionable'), 'RTLA-001: runtime gate must name trace assessment rejection');
+const actionTracePrompt = blockedTracePrompt + '\n\nImplement the fix.';
+assert.strictEqual(orchestrator.isRunTraceAssessmentRequest(actionTracePrompt), false, 'RTLA-002: action-oriented trace prompt must use governed path');
 
 assert.strictEqual(
   orchestrator.resolveModelMode(wsp, 'auto', 'reddog_architect'),
@@ -933,7 +983,7 @@ assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
 assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
 assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
-assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.61', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.62', 'candidate must bind extension version');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
 assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [
@@ -2271,7 +2321,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.61'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.62'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -2285,7 +2335,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.61'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.62'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -2297,7 +2347,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.61'", 'bounded context must include source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.62'", 'bounded context must include source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');


### PR DESCRIPTION
## Summary

Implements `REDDOG_RUN_TRACE_LOCAL_ASSESSMENT_PHASE1` so pasted `## Run Trace` diagnostics are parsed and scored locally instead of being sent through HoloIndex/Fusion/OpenRouter.

The triggering case was a 0.3.59 trace assessment prompt that routed HIGH/Fusion and then blocked locally before OpenRouter. A trace that already says `redaction gate status: BLOCKED_LOCALLY` should not require another model/redaction pass just to explain the telemetry.

## WSP_97 Evidence

- OBSERVED: pasted blocked Run Trace with `extension_version: 0.3.59`, `mode: foundups_fusion`, and `redaction gate status: BLOCKED_LOCALLY` now detects `localFastPath=run_trace_assessment`.
- OBSERVED: `resolveModelMode(...)` returns `local_run_trace_assessment` and `resolveAutoContextMode(...)` returns `none`.
- OBSERVED: local result sets `made_network_call=false`, `retry_count=0`, `no_execution_performed=true`, `no_enqueue_performed=true`.
- OBSERVED: runtime consumption gate rejects with `local_run_trace_assessment_not_actionable`.
- OBSERVED: action-oriented trace prompts like `Implement the fix` are not eligible for the local diagnostic shortcut.
- SPECIFIED_NOT_IMPLEMENTED: this parser grants no repo, shell, merge, enqueue, worktree, HoloIndex, OpenRouter, or authority change.

## Validation

- `node --check extensions/foundups_advisory_workers/extension.js` -> PASS
- `node extensions/foundups_advisory_workers/tests/verify_extension_contract.js` -> PASS
- `git diff --check` -> PASS
- ASCII additions/diff scan -> PASS

Known noise: the existing surrogate fixture still prints a Python `UnicodeEncodeError` on stderr while the JS contract suite exits 0 and prints the success line.

## Scope Boundary

Extension runtime only. No Python bridge, HoloIndex, OpenClaw, Hermes, WRE, shell, git, merge, or live authority wiring changed.