### PR TITLE
feat(reddog): worker claim gate dryrun

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,13 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-13: REDDOG_WORKER_CLAIM_GATE_DRYRUN_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 60, 70, 97
+
+- Added `src/reddog_worker_claim_gate_dryrun.py`: dry-run claim gate that consumes `LaneReconciliationReport` and emits a claim-ready receipt only when the lane state is fresh, non-contradictory, and the selected slice is open.
+- Added `tests/test_reddog_worker_claim_gate_dryrun.py`: fresh acceptance, stale-source rejection, explicit stale override, conflict rejection, closed/unknown/open requested-slice behavior, no-open-work, digest, serialization, and AST no-mutation/no-execution coverage.
+- Boundary: no worker assignment, no worker spawn, no ledger mutation, no AgentDB write, no HoloIndex re-index, no shell/subprocess/git/GitHub call, no extension runtime wiring, and no execution. This slice emits a dry-run claim receipt only.
+
 ## 2026-07-13: REDDOG_LANE_STATE_RECONCILER_DRYRUN_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 60, 70, 97

--- a/modules/communication/moltbot_bridge/src/reddog_worker_claim_gate_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_worker_claim_gate_dryrun.py
@@ -1,0 +1,185 @@
+"""RedDog worker-claim gate dry-run.
+
+This is the layer between lane reconciliation and future worker assignment. It
+turns a LaneReconciliationReport into a claim-ready receipt only when the work
+state is fresh, non-contradictory, and the selected slice is actually open.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from modules.communication.moltbot_bridge.src.reddog_lane_state_reconciler import (
+    LaneReconciliationReport,
+    LaneSliceRecord,
+)
+
+
+CLAIM_READY_DRYRUN = "CLAIM_READY_DRYRUN"
+CLAIM_REJECTED = "CLAIM_REJECTED"
+
+
+@dataclass(frozen=True)
+class RedDogWorkerClaimDryRunReceipt:
+    """Dry-run claim receipt. No durable claim or worker assignment is made."""
+
+    claim_id: str
+    decision: str
+    selected_slice: Optional[str]
+    worker_id: Optional[str]
+    lane_id: Optional[str]
+    reconciliation_report_id: str
+    recommended_action: str
+    rejection_reasons: Tuple[str, ...]
+    stale_sources: Tuple[str, ...]
+    conflict_slice_ids: Tuple[str, ...]
+    closed_groundwork: Tuple[str, ...]
+    open_target: Tuple[str, ...]
+    not_this_slice: Tuple[str, ...]
+    no_ledger_mutation_performed: bool = True
+    no_agentdb_mutation_performed: bool = True
+    no_holoindex_mutation_performed: bool = True
+    no_worker_assignment_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_execution_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RedDogWorkerClaimDryRunDecision:
+    """Decision wrapper returned by the claim gate."""
+
+    accepted: bool
+    receipt: RedDogWorkerClaimDryRunReceipt
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "accepted": self.accepted,
+            "receipt": self.receipt.to_dict(),
+        }
+
+
+def _canonical_digest(payload: Dict[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _open_slice_ids(report: LaneReconciliationReport) -> Tuple[str, ...]:
+    return tuple(dict.fromkeys(record.slice_id for record in report.open_slices))
+
+
+def _closed_slice_ids(report: LaneReconciliationReport) -> Tuple[str, ...]:
+    return tuple(dict.fromkeys(record.slice_id for record in report.closed_slices))
+
+
+def _slice_by_id(records: Sequence[LaneSliceRecord], slice_id: str) -> Optional[LaneSliceRecord]:
+    for record in records:
+        if record.slice_id == slice_id:
+            return record
+    return None
+
+
+def evaluate_reddog_worker_claim_dryrun(
+    report: LaneReconciliationReport,
+    *,
+    requested_slice: Optional[str] = None,
+    worker_id: Optional[str] = None,
+    lane_id: Optional[str] = None,
+    allow_stale_sources: bool = False,
+) -> RedDogWorkerClaimDryRunDecision:
+    """Evaluate whether a future worker claim would be allowed.
+
+    The default is fail-closed on stale sources. `allow_stale_sources=True` is
+    reserved for a future verification-only caller and still performs no claim.
+    """
+
+    rejection_reasons: List[str] = []
+    if not isinstance(report, LaneReconciliationReport):
+        raise TypeError("report must be a LaneReconciliationReport")
+
+    if not report.no_ledger_mutation_performed:
+        rejection_reasons.append("reconciliation_report_mutated_ledger")
+    if not report.no_agentdb_mutation_performed:
+        rejection_reasons.append("reconciliation_report_mutated_agentdb")
+    if not report.no_holoindex_mutation_performed:
+        rejection_reasons.append("reconciliation_report_mutated_holoindex")
+    if not report.no_worker_assignment_performed:
+        rejection_reasons.append("reconciliation_report_already_assigned_worker")
+    if not report.no_execution_performed:
+        rejection_reasons.append("reconciliation_report_executed")
+
+    if report.conflicts:
+        rejection_reasons.append("lane_state_conflict")
+    if report.recommended_action == "RECONCILE_LEDGER_BEFORE_WORK":
+        rejection_reasons.append("reconcile_ledger_before_claim")
+    if report.stale_sources and not allow_stale_sources:
+        rejection_reasons.append("ledger_sources_stale")
+    if report.recommended_action == "NO_OPEN_WORK":
+        rejection_reasons.append("no_open_work")
+
+    open_ids = _open_slice_ids(report)
+    closed_ids = _closed_slice_ids(report)
+    requested = requested_slice.strip().upper() if isinstance(requested_slice, str) and requested_slice.strip() else None
+    selected = requested or report.prework_packet.chosen_slice
+
+    if requested and requested in closed_ids:
+        rejection_reasons.append("requested_slice_already_closed")
+    elif requested and requested not in open_ids:
+        rejection_reasons.append("requested_slice_not_in_open_queue")
+
+    if not selected:
+        rejection_reasons.append("no_selected_slice")
+    elif selected in report.prework_packet.not_this_slice and selected != requested:
+        rejection_reasons.append("selected_slice_marked_not_this_slice")
+    elif selected not in open_ids:
+        rejection_reasons.append("selected_slice_not_open")
+
+    selected_record = _slice_by_id(report.open_slices, selected) if selected else None
+    if selected and selected_record is None:
+        rejection_reasons.append("selected_slice_record_missing")
+
+    reasons = tuple(dict.fromkeys(rejection_reasons))
+    accepted = not reasons
+    decision = CLAIM_READY_DRYRUN if accepted else CLAIM_REJECTED
+    payload = {
+        "decision": decision,
+        "selected_slice": selected if accepted else None,
+        "worker_id": worker_id,
+        "lane_id": lane_id or (selected_record.lane if selected_record else None),
+        "reconciliation_report_id": report.report_id,
+        "recommended_action": report.recommended_action,
+        "rejection_reasons": reasons,
+        "stale_sources": report.stale_sources,
+        "conflict_slice_ids": [conflict.slice_id for conflict in report.conflicts],
+    }
+
+    receipt = RedDogWorkerClaimDryRunReceipt(
+        claim_id=_canonical_digest(payload),
+        decision=decision,
+        selected_slice=selected if accepted else None,
+        worker_id=worker_id,
+        lane_id=lane_id or (selected_record.lane if selected_record else None),
+        reconciliation_report_id=report.report_id,
+        recommended_action=report.recommended_action,
+        rejection_reasons=reasons,
+        stale_sources=report.stale_sources,
+        conflict_slice_ids=tuple(conflict.slice_id for conflict in report.conflicts),
+        closed_groundwork=report.prework_packet.closed_groundwork,
+        open_target=report.prework_packet.open_target,
+        not_this_slice=report.prework_packet.not_this_slice,
+    )
+    return RedDogWorkerClaimDryRunDecision(accepted=accepted, receipt=receipt)
+
+
+__all__ = [
+    "CLAIM_READY_DRYRUN",
+    "CLAIM_REJECTED",
+    "RedDogWorkerClaimDryRunDecision",
+    "RedDogWorkerClaimDryRunReceipt",
+    "evaluate_reddog_worker_claim_dryrun",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_worker_claim_gate_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_worker_claim_gate_dryrun.py
@@ -1,0 +1,265 @@
+"""Tests for RedDog worker-claim gate dry-run."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_lane_state_reconciler import (
+    parse_active_slice_ledger,
+    parse_work_ledger_json,
+    reconcile_active_and_json_ledgers,
+    reconcile_lane_sources,
+)
+from modules.communication.moltbot_bridge.src.reddog_worker_claim_gate_dryrun import (
+    CLAIM_READY_DRYRUN,
+    CLAIM_REJECTED,
+    evaluate_reddog_worker_claim_dryrun,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_worker_claim_gate_dryrun.py"
+)
+
+
+ACTIVE_LEDGER = """# Active Slice Ledger
+
+**Updated**: 2026-07-13
+
+## Closed Slices
+
+| Slice | Commit | Evidence |
+|-------|--------|----------|
+| `REDDOG_DONE_PHASE1` | `abc1234` | landed |
+
+## Open Slices
+
+| Slice | Priority | Blocked By | Notes |
+|-------|----------|------------|-------|
+| `REDDOG_NEXT_PHASE1` | P0 | - | next |
+| `REDDOG_OTHER_PHASE1` | P1 | - | other |
+
+## Next Priority Order
+
+1. **REDDOG-NEXT** - first
+2. **REDDOG-OTHER** - second
+"""
+
+
+WORK_LEDGER = {
+    "schema_version": "1.0.0",
+    "last_updated": "2026-07-13T00:00:00Z",
+    "slices": [
+        {
+            "slice_id": "REDDOG_JSON_PHASE1",
+            "title": "JSON slice",
+            "status": "PROPOSED",
+            "priority": "P2",
+            "source": "audit",
+            "created_at": "2026-07-13T00:00:00Z",
+            "lane": "B",
+            "owner_worker": "W2",
+        }
+    ],
+}
+
+
+def _fresh_report():
+    return reconcile_active_and_json_ledgers(
+        ACTIVE_LEDGER,
+        json.dumps(WORK_LEDGER),
+        now_iso="2026-07-13T00:00:00Z",
+        stale_after_days=30,
+    )
+
+
+def test_accepts_fresh_non_conflicting_selected_slice_dryrun_only() -> None:
+    decision = evaluate_reddog_worker_claim_dryrun(
+        _fresh_report(),
+        worker_id="reddog-0102",
+        lane_id="A",
+    )
+
+    assert decision.accepted is True
+    assert decision.receipt.decision == CLAIM_READY_DRYRUN
+    assert decision.receipt.selected_slice == "REDDOG_NEXT_PHASE1"
+    assert decision.receipt.worker_id == "reddog-0102"
+    assert decision.receipt.lane_id == "A"
+    assert decision.receipt.rejection_reasons == ()
+    assert decision.receipt.no_worker_assignment_performed is True
+    assert decision.receipt.no_worker_spawn_performed is True
+    assert decision.receipt.no_execution_performed is True
+
+
+def test_rejects_stale_sources_by_default() -> None:
+    stale = reconcile_active_and_json_ledgers(
+        ACTIVE_LEDGER.replace("2026-07-13", "2026-04-01"),
+        json.dumps({**WORK_LEDGER, "last_updated": "2026-04-01T00:00:00Z"}),
+        now_iso="2026-07-13T00:00:00Z",
+    )
+    decision = evaluate_reddog_worker_claim_dryrun(stale, worker_id="reddog-0102")
+
+    assert decision.accepted is False
+    assert decision.receipt.decision == CLAIM_REJECTED
+    assert "ledger_sources_stale" in decision.receipt.rejection_reasons
+    assert decision.receipt.selected_slice is None
+
+
+def test_allow_stale_sources_is_explicit_and_still_dryrun() -> None:
+    stale = reconcile_active_and_json_ledgers(
+        ACTIVE_LEDGER.replace("2026-07-13", "2026-04-01"),
+        json.dumps({**WORK_LEDGER, "last_updated": "2026-04-01T00:00:00Z"}),
+        now_iso="2026-07-13T00:00:00Z",
+    )
+    decision = evaluate_reddog_worker_claim_dryrun(
+        stale,
+        worker_id="reddog-0102",
+        allow_stale_sources=True,
+    )
+
+    assert decision.accepted is True
+    assert decision.receipt.selected_slice == "REDDOG_NEXT_PHASE1"
+    assert decision.receipt.stale_sources
+    assert decision.receipt.no_worker_assignment_performed is True
+
+
+def test_rejects_lane_state_conflict() -> None:
+    active = parse_active_slice_ledger(ACTIVE_LEDGER)
+    conflict_json = {
+        "schema_version": "1.0.0",
+        "last_updated": "2026-07-13T00:00:00Z",
+        "slices": [
+            {
+                "slice_id": "REDDOG_DONE_PHASE1",
+                "title": "stale duplicate",
+                "status": "IN_PROGRESS",
+                "source": "manual",
+                "created_at": "2026-07-13T00:00:00Z",
+            }
+        ],
+    }
+    report = reconcile_lane_sources(
+        [active, parse_work_ledger_json(json.dumps(conflict_json))],
+        now_iso="2026-07-13T00:00:00Z",
+    )
+    decision = evaluate_reddog_worker_claim_dryrun(report)
+
+    assert decision.accepted is False
+    assert "lane_state_conflict" in decision.receipt.rejection_reasons
+    assert "reconcile_ledger_before_claim" in decision.receipt.rejection_reasons
+    assert decision.receipt.conflict_slice_ids == ("REDDOG_DONE_PHASE1",)
+
+
+def test_rejects_requested_closed_slice() -> None:
+    decision = evaluate_reddog_worker_claim_dryrun(
+        _fresh_report(),
+        requested_slice="REDDOG_DONE_PHASE1",
+    )
+
+    assert decision.accepted is False
+    assert "requested_slice_already_closed" in decision.receipt.rejection_reasons
+    assert decision.receipt.selected_slice is None
+
+
+def test_rejects_requested_slice_not_in_open_queue() -> None:
+    decision = evaluate_reddog_worker_claim_dryrun(
+        _fresh_report(),
+        requested_slice="REDDOG_UNKNOWN_PHASE1",
+    )
+
+    assert decision.accepted is False
+    assert "requested_slice_not_in_open_queue" in decision.receipt.rejection_reasons
+    assert "selected_slice_not_open" in decision.receipt.rejection_reasons
+
+
+def test_requested_open_slice_can_override_default_candidate() -> None:
+    decision = evaluate_reddog_worker_claim_dryrun(
+        _fresh_report(),
+        requested_slice="REDDOG_OTHER_PHASE1",
+        worker_id="reddog-0102",
+    )
+
+    assert decision.accepted is True
+    assert decision.receipt.selected_slice == "REDDOG_OTHER_PHASE1"
+
+
+def test_rejects_no_open_work() -> None:
+    closed_only = """# Active Slice Ledger
+**Updated**: 2026-07-13
+
+## Closed Slices
+
+| Slice | Commit | Evidence |
+|-------|--------|----------|
+| `REDDOG_DONE_PHASE1` | `abc1234` | landed |
+"""
+    report = reconcile_active_and_json_ledgers(
+        closed_only,
+        json.dumps({"schema_version": "1.0.0", "last_updated": "2026-07-13T00:00:00Z", "slices": []}),
+        now_iso="2026-07-13T00:00:00Z",
+    )
+    decision = evaluate_reddog_worker_claim_dryrun(report)
+
+    assert decision.accepted is False
+    assert "no_open_work" in decision.receipt.rejection_reasons
+    assert "no_selected_slice" in decision.receipt.rejection_reasons
+
+
+def test_receipt_digest_is_deterministic() -> None:
+    kwargs = {"report": _fresh_report(), "worker_id": "reddog-0102", "lane_id": "A"}
+    first = evaluate_reddog_worker_claim_dryrun(**kwargs)
+    second = evaluate_reddog_worker_claim_dryrun(**kwargs)
+
+    assert first.receipt.claim_id == second.receipt.claim_id
+    assert len(first.receipt.claim_id) == 64
+
+
+def test_receipt_is_json_serializable() -> None:
+    decision = evaluate_reddog_worker_claim_dryrun(_fresh_report())
+
+    payload = decision.to_dict()
+    assert payload["receipt"]["no_ledger_mutation_performed"] is True
+    json.dumps(payload, sort_keys=True)
+
+
+def test_type_error_for_non_report_input() -> None:
+    with pytest.raises(TypeError):
+        evaluate_reddog_worker_claim_dryrun("not a report")  # type: ignore[arg-type]
+
+
+def test_module_has_no_mutating_or_execution_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "os",
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "shutil",
+        "sqlite3",
+        "pathlib",
+    }
+    banned_calls = {"open", "eval", "exec", "compile", "__import__"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".")[0] not in banned_import_roots
+        elif isinstance(node, ast.ImportFrom):
+            assert (node.module or "").split(".")[0] not in banned_import_roots
+        elif isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name):
+                assert func.id not in banned_calls
+            if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+                assert func.value.id not in banned_import_roots


### PR DESCRIPTION
## Summary

Implements `REDDOG_WORKER_CLAIM_GATE_DRYRUN_PHASE1`: a dry-run gate between lane reconciliation and any future worker assignment.

The gate consumes `LaneReconciliationReport` from #984 and emits a `RedDogWorkerClaimDryRunReceipt` only when:

- lane state has no open-vs-closed contradictions
- selected slice is open
- ledger sources are fresh by default
- no prior mutation/assignment/execution is claimed by the reconciliation report

This does not assign or spawn a worker.

## WSP_97 Truth Boundary

- `NO_WORKER_ASSIGNMENT`
- `NO_WORKER_SPAWN`
- `NO_LEDGER_MUTATION`
- `NO_AGENTDB_MUTATION`
- `NO_HOLOINDEX_MUTATION`
- `NO_SHELL_SUBPROCESS_GIT_GH`
- `NO_EXTENSION_RUNTIME_WIRING`
- `NO_EXECUTION`

## Validation

```text
pytest modules/communication/moltbot_bridge/tests/test_reddog_worker_claim_gate_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_lane_state_reconciler.py modules/communication/moltbot_bridge/tests/test_reddog_operator_loop_wardrobe_selection.py -q
41 passed

git diff --check
clean

py_compile reddog_worker_claim_gate_dryrun.py
pass
```

Actual current-ledger proof:

```text
candidate=BH1_BRANCH_HYGIENE_FORENSICS
accepted=False
decision=CLAIM_REJECTED
rejection_reasons=('ledger_sources_stale',)
stale_sources=(ACTIVE_SLICE_LEDGER:stale:2026-04-21, work_ledger.example.json:stale:2026-05-21T12:00:00Z)
```

## Residual SPECIFIED_NOT_IMPLEMENTED

- Durable worker claim persistence
- AgentDB / WRE queue assignment
- worker spawn
- ledger refresh/mutation
- HoloIndex re-index/freshness update
- extension runtime wiring