### PR TITLE
feat(reddog): work ledger refresh plan dryrun

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,13 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-13: REDDOG_WORK_LEDGER_REFRESH_PLAN_DRYRUN_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 60, 70, 97
+
+- Added `src/reddog_work_ledger_refresh_plan_dryrun.py`: read-only refresh planner that consumes `LaneReconciliationReport`, names stale/conflicted work-ledger sources, lists the governed refresh steps, and carries the next claim candidate forward for a later mutating refresh slice.
+- Added `tests/test_reddog_work_ledger_refresh_plan_dryrun.py`: stale-source ready plan, conflict-blocked plan, no-refresh-needed detection, deterministic digest, JSON serialization, invalid-input rejection, and AST no-mutation/no-execution coverage.
+- Boundary: no ledger mutation, no AgentDB write, no HoloIndex re-index, no worker assignment, no shell/subprocess/git/GitHub call, no extension runtime wiring, and no execution. This slice emits a dry-run refresh plan only.
+
 ## 2026-07-13: REDDOG_WORKER_CLAIM_GATE_DRYRUN_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 60, 70, 97

--- a/modules/communication/moltbot_bridge/src/reddog_work_ledger_refresh_plan_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_work_ledger_refresh_plan_dryrun.py
@@ -1,0 +1,122 @@
+"""RedDog work-ledger refresh plan dry-run.
+
+This module turns a stale/conflicted lane reconciliation report into an explicit
+refresh plan. It does not update any ledger source; it only names the governed
+steps required before worker claims can be trusted.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Optional, Tuple
+
+from modules.communication.moltbot_bridge.src.reddog_lane_state_reconciler import (
+    LaneReconciliationReport,
+)
+
+
+REFRESH_PLAN_READY = "REFRESH_PLAN_READY"
+REFRESH_PLAN_BLOCKED = "REFRESH_PLAN_BLOCKED"
+
+
+@dataclass(frozen=True)
+class WorkLedgerRefreshPlanDryRun:
+    """Dry-run plan for refreshing lane-state sources."""
+
+    plan_id: str
+    status: str
+    source_report_id: str
+    stale_sources: Tuple[str, ...]
+    conflict_slice_ids: Tuple[str, ...]
+    refresh_targets: Tuple[str, ...]
+    refresh_steps: Tuple[str, ...]
+    proposed_last_updated: str
+    proposed_next_claim_slice: Optional[str]
+    rejection_reasons: Tuple[str, ...]
+    no_ledger_mutation_performed: bool = True
+    no_agentdb_mutation_performed: bool = True
+    no_holoindex_mutation_performed: bool = True
+    no_worker_assignment_performed: bool = True
+    no_execution_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def _canonical_digest(payload: Dict[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def build_work_ledger_refresh_plan_dryrun(
+    report: LaneReconciliationReport,
+    *,
+    proposed_last_updated: str,
+) -> WorkLedgerRefreshPlanDryRun:
+    """Build a non-mutating plan to refresh stale work-ledger sources."""
+
+    if not isinstance(report, LaneReconciliationReport):
+        raise TypeError("report must be a LaneReconciliationReport")
+    if not isinstance(proposed_last_updated, str) or not proposed_last_updated.strip():
+        raise ValueError("proposed_last_updated is required")
+
+    conflict_ids = tuple(conflict.slice_id for conflict in report.conflicts)
+    rejection_reasons = []
+    if conflict_ids:
+        rejection_reasons.append("resolve_lane_state_conflicts_first")
+    if not report.stale_sources and not conflict_ids:
+        rejection_reasons.append("no_refresh_needed")
+
+    refresh_targets = []
+    for source in report.sources_checked:
+        if source == "ACTIVE_SLICE_LEDGER":
+            refresh_targets.append("docs/0102_session_briefings/ACTIVE_SLICE_LEDGER.md")
+        elif source == "work_ledger.example.json":
+            refresh_targets.append("docs/0102_session_briefings/work_ledger.example.json")
+        else:
+            refresh_targets.append(source)
+
+    refresh_steps = (
+        "read_current_repo_truth",
+        "merge_closed_open_blocked_deferred_state",
+        "preserve_active_ledger_next_priority_order",
+        "update_typed_work_ledger_snapshot",
+        "set_last_updated_to_proposed_timestamp",
+        "rerun_lane_state_reconciler",
+        "rerun_worker_claim_gate",
+    )
+    status = REFRESH_PLAN_BLOCKED if conflict_ids else REFRESH_PLAN_READY
+    proposed_next = report.prework_packet.chosen_slice if status == REFRESH_PLAN_READY else None
+    payload = {
+        "status": status,
+        "source_report_id": report.report_id,
+        "stale_sources": report.stale_sources,
+        "conflict_slice_ids": conflict_ids,
+        "refresh_targets": refresh_targets,
+        "refresh_steps": refresh_steps,
+        "proposed_last_updated": proposed_last_updated,
+        "proposed_next_claim_slice": proposed_next,
+        "rejection_reasons": rejection_reasons,
+    }
+    return WorkLedgerRefreshPlanDryRun(
+        plan_id=_canonical_digest(payload),
+        status=status,
+        source_report_id=report.report_id,
+        stale_sources=report.stale_sources,
+        conflict_slice_ids=conflict_ids,
+        refresh_targets=tuple(refresh_targets),
+        refresh_steps=refresh_steps,
+        proposed_last_updated=proposed_last_updated,
+        proposed_next_claim_slice=proposed_next,
+        rejection_reasons=tuple(rejection_reasons),
+    )
+
+
+__all__ = [
+    "REFRESH_PLAN_BLOCKED",
+    "REFRESH_PLAN_READY",
+    "WorkLedgerRefreshPlanDryRun",
+    "build_work_ledger_refresh_plan_dryrun",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_work_ledger_refresh_plan_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_work_ledger_refresh_plan_dryrun.py
@@ -1,0 +1,208 @@
+"""Tests for RedDog work-ledger refresh plan dry-run."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_lane_state_reconciler import (
+    parse_active_slice_ledger,
+    parse_work_ledger_json,
+    reconcile_active_and_json_ledgers,
+    reconcile_lane_sources,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_ledger_refresh_plan_dryrun import (
+    REFRESH_PLAN_BLOCKED,
+    REFRESH_PLAN_READY,
+    build_work_ledger_refresh_plan_dryrun,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_work_ledger_refresh_plan_dryrun.py"
+)
+
+
+ACTIVE_LEDGER = """# Active Slice Ledger
+
+**Updated**: 2026-04-01
+
+## Open Slices
+
+| Slice | Priority | Blocked By | Notes |
+|-------|----------|------------|-------|
+| `BH1_BRANCH_HYGIENE_FORENSICS` | HIGH | - | first |
+
+## Next Priority Order
+
+1. **BH1** - first
+"""
+
+
+WORK_LEDGER = {
+    "schema_version": "1.0.0",
+    "last_updated": "2026-04-01T00:00:00Z",
+    "slices": [
+        {
+            "slice_id": "DJ2_F_OPENCLAW_SECURITY_FAIL_DISPATCH",
+            "title": "security dispatch",
+            "status": "PROPOSED",
+            "priority": "P0",
+            "source": "audit",
+            "created_at": "2026-04-01T00:00:00Z",
+        }
+    ],
+}
+
+
+def test_stale_sources_produce_ready_refresh_plan_without_mutation() -> None:
+    report = reconcile_active_and_json_ledgers(
+        ACTIVE_LEDGER,
+        json.dumps(WORK_LEDGER),
+        now_iso="2026-07-13T00:00:00Z",
+    )
+    plan = build_work_ledger_refresh_plan_dryrun(
+        report,
+        proposed_last_updated="2026-07-13T00:00:00Z",
+    )
+
+    assert plan.status == REFRESH_PLAN_READY
+    assert plan.proposed_next_claim_slice == "BH1_BRANCH_HYGIENE_FORENSICS"
+    assert "docs/0102_session_briefings/ACTIVE_SLICE_LEDGER.md" in plan.refresh_targets
+    assert "docs/0102_session_briefings/work_ledger.example.json" in plan.refresh_targets
+    assert "rerun_worker_claim_gate" in plan.refresh_steps
+    assert plan.no_ledger_mutation_performed is True
+    assert plan.no_holoindex_mutation_performed is True
+    assert plan.no_worker_assignment_performed is True
+
+
+def test_conflicted_report_blocks_refresh_plan_until_conflict_resolved() -> None:
+    active = """# Active Slice Ledger
+**Updated**: 2026-07-13
+
+## Closed Slices
+
+| Slice | Commit | Evidence |
+|-------|--------|----------|
+| `REDDOG_DONE_PHASE1` | `abc1234` | landed |
+"""
+    conflict_json = {
+        "schema_version": "1.0.0",
+        "last_updated": "2026-07-13T00:00:00Z",
+        "slices": [
+            {
+                "slice_id": "REDDOG_DONE_PHASE1",
+                "title": "stale duplicate",
+                "status": "IN_PROGRESS",
+                "source": "manual",
+                "created_at": "2026-07-13T00:00:00Z",
+            }
+        ],
+    }
+    report = reconcile_lane_sources(
+        [
+            parse_active_slice_ledger(active),
+            parse_work_ledger_json(json.dumps(conflict_json)),
+        ],
+        now_iso="2026-07-13T00:00:00Z",
+    )
+    plan = build_work_ledger_refresh_plan_dryrun(
+        report,
+        proposed_last_updated="2026-07-13T00:00:00Z",
+    )
+
+    assert plan.status == REFRESH_PLAN_BLOCKED
+    assert plan.proposed_next_claim_slice is None
+    assert plan.conflict_slice_ids == ("REDDOG_DONE_PHASE1",)
+    assert "resolve_lane_state_conflicts_first" in plan.rejection_reasons
+
+
+def test_fresh_report_marks_no_refresh_needed() -> None:
+    fresh_active = ACTIVE_LEDGER.replace("2026-04-01", "2026-07-13")
+    fresh_work = {**WORK_LEDGER, "last_updated": "2026-07-13T00:00:00Z"}
+    report = reconcile_active_and_json_ledgers(
+        fresh_active,
+        json.dumps(fresh_work),
+        now_iso="2026-07-13T00:00:00Z",
+    )
+    plan = build_work_ledger_refresh_plan_dryrun(
+        report,
+        proposed_last_updated="2026-07-13T00:00:00Z",
+    )
+
+    assert plan.status == REFRESH_PLAN_READY
+    assert plan.stale_sources == ()
+    assert "no_refresh_needed" in plan.rejection_reasons
+
+
+def test_plan_digest_is_deterministic() -> None:
+    report = reconcile_active_and_json_ledgers(
+        ACTIVE_LEDGER,
+        json.dumps(WORK_LEDGER),
+        now_iso="2026-07-13T00:00:00Z",
+    )
+    first = build_work_ledger_refresh_plan_dryrun(report, proposed_last_updated="2026-07-13T00:00:00Z")
+    second = build_work_ledger_refresh_plan_dryrun(report, proposed_last_updated="2026-07-13T00:00:00Z")
+
+    assert first.plan_id == second.plan_id
+    assert len(first.plan_id) == 64
+
+
+def test_plan_json_serializable() -> None:
+    report = reconcile_active_and_json_ledgers(
+        ACTIVE_LEDGER,
+        json.dumps(WORK_LEDGER),
+        now_iso="2026-07-13T00:00:00Z",
+    )
+    plan = build_work_ledger_refresh_plan_dryrun(report, proposed_last_updated="2026-07-13T00:00:00Z")
+
+    json.dumps(plan.to_dict(), sort_keys=True)
+
+
+def test_rejects_invalid_inputs() -> None:
+    report = reconcile_active_and_json_ledgers(
+        ACTIVE_LEDGER,
+        json.dumps(WORK_LEDGER),
+        now_iso="2026-07-13T00:00:00Z",
+    )
+    with pytest.raises(TypeError):
+        build_work_ledger_refresh_plan_dryrun("not a report", proposed_last_updated="2026-07-13T00:00:00Z")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        build_work_ledger_refresh_plan_dryrun(report, proposed_last_updated="")
+
+
+def test_module_has_no_mutating_or_execution_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "os",
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "shutil",
+        "sqlite3",
+        "pathlib",
+    }
+    banned_calls = {"open", "eval", "exec", "compile", "__import__"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".")[0] not in banned_import_roots
+        elif isinstance(node, ast.ImportFrom):
+            assert (node.module or "").split(".")[0] not in banned_import_roots
+        elif isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name):
+                assert func.id not in banned_calls
+            if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+                assert func.value.id not in banned_import_roots


### PR DESCRIPTION
## Summary

Implements `REDDOG_WORK_LEDGER_REFRESH_PLAN_DRYRUN_PHASE1`: a read-only refresh planner for stale lane/work-ledger sources.

It consumes `LaneReconciliationReport`, names the stale/conflicted sources, lists the governed refresh steps, and carries the next claim candidate forward for a later mutating refresh slice.

## WSP_97 Truth Boundary

- `NO_LEDGER_MUTATION`
- `NO_AGENTDB_MUTATION`
- `NO_HOLOINDEX_MUTATION`
- `NO_WORKER_ASSIGNMENT`
- `NO_EXECUTION`
- `NO_SHELL_SUBPROCESS_GIT_GH`
- `NO_EXTENSION_RUNTIME_WIRING`

## Validation

```text
pytest modules/communication/moltbot_bridge/tests/test_reddog_work_ledger_refresh_plan_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_worker_claim_gate_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_lane_state_reconciler.py -q
32 passed

git diff --check
clean
```

Actual current-ledger proof:

```text
status=REFRESH_PLAN_READY
next=BH1_BRANCH_HYGIENE_FORENSICS
stale_sources=(ACTIVE_SLICE_LEDGER:stale:2026-04-21, work_ledger.example.json:stale:2026-05-21T12:00:00Z)
refresh_targets=(docs/0102_session_briefings/ACTIVE_SLICE_LEDGER.md, docs/0102_session_briefings/work_ledger.example.json)
no_mutation=True True True
```

## Residual SPECIFIED_NOT_IMPLEMENTED

- Actual ledger refresh/mutation
- HoloIndex work-ledger re-index/freshness update
- AgentDB sync
- worker claim persistence
- worker assignment/spawn