### PR TITLE
feat(reddog): add daemon output local assessment

### DIFF
--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,13 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-13 - REDDOG_DAEMON_OUTPUT_LOCAL_ASSESSMENT_PHASE1 (local DAEmon/log diagnostics, 0.3.63)
+
+- Added a local DAEmon/log output assessment fast path for pasted operational diagnostics.
+- Treats pasted output as data, redacts secret-shaped values, and skips HoloIndex, OpenRouter, Fusion, repair, repo/shell work, enqueue, and worktree action.
+- Runtime consumption remains blocked with `local_daemon_output_assessment_not_actionable`; logs cannot become instructions or authority.
+- Version 0.3.62 -> 0.3.63 (package.json + EXTENSION_VERSION + README + contract-test assertions).
+
 ## 2026-07-13 - REDDOG_RUN_TRACE_LOCAL_ASSESSMENT_PHASE1 (local pasted-trace diagnostics, 0.3.62)
 
 - Added a local Run Trace assessment fast path for pasted `## Run Trace` diagnostics so RedDog can explain blocked/slow traces without sending raw trace text through HoloIndex/Fusion/OpenRouter.

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.62
+Version: 0.3.63
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 
@@ -61,6 +61,7 @@ The extension is a bounded 0102 advisory surface:
 - Prompt-authoring deliverable contract (v0.3.60): when 012 asks RedDog to create/evaluate/provide a worker prompt, RedDog receives bounded direct-read context for its prompt/judgment surfaces and must return a `## Worker Prompt` section with one fenced executable prompt. Missing definitions become a `DEFINITION_GAP` inside that prompt rather than a reason to omit the prompt artifact.
 - Simple identity fast path (v0.3.61): short identity/status questions such as "are you RedDog?" are answered locally with audited Run Trace telemetry. The fast path skips HoloIndex, OpenRouter, Fusion, repair, and downstream action planning; substantive RedDog audit/work prompts still route through the governed path.
 - Run Trace local assessment (v0.3.62): pasted `## Run Trace` diagnostics are parsed locally and scored with WSP_97 labels so raw trace text no longer needs to pass through Fusion/redaction just to explain why a run blocked or routed slowly. The path remains non-actionable and cannot trigger runtime planning.
+- DAEmon/log local assessment (v0.3.63): pasted DAEmon, daemon, service, worker, or runtime output can be interpreted locally as diagnostic data. The path redacts secret-shaped values, skips HoloIndex/OpenRouter/Fusion/repair, and remains non-actionable so logs cannot become instructions or authority.
 
 The extension does not grant repo authority. **012 supplies work focus only**; 0102 assembles a WSP task prompt before the bridge runs. Work focus and bounded repo context are sent through `scripts/advisory_model_once.py`, which runs the landed Fusion redaction gate before making OpenRouter requests. The webview receives only advisory text and redacted local history.
 

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.62';
+const EXTENSION_VERSION = '0.3.63';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -258,6 +258,9 @@ function buildRuntimeConsumptionGate(result, validationState, mode, substantiveT
   }
   if (rp.local_fast_path === 'run_trace_assessment') {
     reasons.push('local_run_trace_assessment_not_actionable');
+  }
+  if (rp.local_fast_path === 'daemon_output_assessment') {
+    reasons.push('local_daemon_output_assessment_not_actionable');
   }
   if (substantiveTask !== true) {
     reasons.push('non_substantive_worker');
@@ -3194,6 +3197,28 @@ const RUN_TRACE_ASSESSMENT_PATTERNS = [
 const RUN_TRACE_ACTION_BLOCKING_PATTERNS = [
   /\b(?:implement|fix|patch|author|provide|create|draft|enhance|write|merge|land|dispatch|assign|spawn|execute|start)\b/i
 ];
+const DAEMON_OUTPUT_LOCAL_ASSESSMENT_FAST_PATH_SLICE = 'REDDOG_DAEMON_OUTPUT_LOCAL_ASSESSMENT_PHASE1';
+const DAEMON_OUTPUT_TERMS = [
+  /\bdae?mon\b/i,
+  /\bdaemon\b/i,
+  /\bservice\b/i,
+  /\borchestrator\b/i,
+  /\bworker\b/i,
+  /\bruntime\b/i
+];
+const DAEMON_OUTPUT_CONTEXT_PATTERNS = [
+  /\b(?:output|log|trace|stderr|stdout|status|result|packet|copy md)\b/i,
+  /\b(?:blocked_locally|made_network_call|redaction gate|operator message|work trail|run trace|extension_version)\b/i,
+  /\b(?:traceback|exception|error|warn|warning|failed|timeout|exit code)\b/i
+];
+const DAEMON_OUTPUT_ASSESSMENT_PATTERNS = [
+  /\b(?:analy[sz]e|assess|evaluate|review|diagnose|explain|interpret|score|rate)\b/i,
+  /\bwhy\b[\s\S]{0,120}\b(?:can't|cant|cannot|blocked|failed|error|slow|stopped|no model output)\b/i,
+  /\bwhat\s+(?:happened|failed|blocked|is wrong)\b/i
+];
+const DAEMON_OUTPUT_ACTION_BLOCKING_PATTERNS = [
+  /\b(?:implement|patch|author|create\s+pr|open\s+pr|merge|land|dispatch|assign|spawn|execute|start\s+slice|write\s+code)\b/i
+];
 
 function normalizeSimpleIdentityQuestion(text) {
   return String(text || '')
@@ -3232,6 +3257,21 @@ function isRunTraceAssessmentRequest(text) {
   }
   return RUN_TRACE_ASSESSMENT_PATTERNS.some((pattern) => pattern.test(raw.slice(0, 2000)))
     || /\bredaction gate status\s*:\s*BLOCKED_LOCALLY/i.test(raw);
+}
+
+function isDaemonOutputAssessmentRequest(text) {
+  const raw = String(text || '');
+  const head = raw.slice(0, 2400);
+  if (raw.trim().length < 12) {
+    return false;
+  }
+  if (DAEMON_OUTPUT_ACTION_BLOCKING_PATTERNS.some((pattern) => pattern.test(head))) {
+    return false;
+  }
+  const mentionsDaemonSurface = DAEMON_OUTPUT_TERMS.some((pattern) => pattern.test(head));
+  const mentionsOutputContext = DAEMON_OUTPUT_CONTEXT_PATTERNS.some((pattern) => pattern.test(head));
+  const asksForAssessment = DAEMON_OUTPUT_ASSESSMENT_PATTERNS.some((pattern) => pattern.test(head));
+  return mentionsDaemonSurface && mentionsOutputContext && asksForAssessment;
 }
 
 function parseRunTraceAssessment(text) {
@@ -3359,6 +3399,164 @@ function buildRunTraceAssessmentFastPathResult(workFocus) {
   };
 }
 
+function sanitizeDaemonDiagnosticLine(line) {
+  let out = sanitizeCopyMdText(String(line || ''));
+  out = out.replace(/\bghp_[A-Za-z0-9_]+\b/g, 'ghp_[REDACTED]');
+  out = out.replace(/\bgithub_pat_[A-Za-z0-9_]+\b/g, 'github_pat_[REDACTED]');
+  out = out.replace(/\bgho_[A-Za-z0-9_]+\b/g, 'gho_[REDACTED]');
+  out = out.replace(/\b(?:api[_-]?key|token|secret|password|passwd|authorization)\s*[:=]\s*[^,\s\]]+/gi, '$1=[REDACTED]');
+  out = out.replace(/\s+/g, ' ').trim();
+  if (out.length > 220) {
+    out = out.slice(0, 220) + '...[truncated]';
+  }
+  return out;
+}
+
+function parseDaemonOutputAssessment(text) {
+  const src = String(text || '');
+  const lines = src.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  const signalPatterns = [
+    /\b(?:blocked_locally|redaction gate status|made_network_call|operator message|runtime_consumption_gate_rejection_reasons)\b/i,
+    /\b(?:error|exception|traceback|failed|failure|fatal|timeout|warn|warning)\b/i,
+    /\b(?:status|exit code|stopped|blocked|skipped)\b/i,
+    /\b(?:api[_-]?key|token|secret|password|passwd|authorization|Bearer\s+|sk-[A-Za-z0-9])\b/i
+  ];
+  const diagnosticSignals = [];
+  let errorCount = 0;
+  let warningCount = 0;
+  let secretRedactionCount = 0;
+  for (const line of lines) {
+    if (/\b(?:error|exception|traceback|failed|failure|fatal|timeout|blocked_locally)\b/i.test(line)) {
+      errorCount += 1;
+    }
+    if (/\b(?:warn|warning)\b/i.test(line)) {
+      warningCount += 1;
+    }
+    if (signalPatterns.some((pattern) => pattern.test(line)) && diagnosticSignals.length < 10) {
+      const sanitized = sanitizeDaemonDiagnosticLine(line);
+      if (sanitized !== line.replace(/\s+/g, ' ').trim()) {
+        secretRedactionCount += 1;
+      }
+      diagnosticSignals.push(sanitized);
+    }
+  }
+  const redactionGateStatus = extractRunTraceField(src, 'redaction gate status') || 'unknown';
+  const madeNetworkCall = extractRunTraceField(src, 'made_network_call') || 'unknown';
+  const outputValidation = extractRunTraceField(src, 'output_validation') || 'unknown';
+  const runtimeGateReasons = extractRunTraceField(src, 'runtime_consumption_gate_rejection_reasons') || 'unknown';
+  const requiredTargetsTotal = extractRunTraceField(src, 'required_targets_total') || 'unknown';
+  const directReadFallbackUsed = extractRunTraceField(src, 'direct_read_fallback_used') || 'unknown';
+  const blockedLocally = /BLOCKED_LOCALLY/i.test(redactionGateStatus)
+    || /redaction_blocked/i.test(runtimeGateReasons)
+    || /\bblocked_locally\b/i.test(src);
+  return {
+    extension_version: extractRunTraceField(src, 'extension_version') || 'unknown',
+    redaction_gate_status: redactionGateStatus,
+    made_network_call: madeNetworkCall,
+    output_validation: outputValidation,
+    runtime_consumption_gate_rejection_reasons: runtimeGateReasons,
+    required_targets_total: requiredTargetsTotal,
+    direct_read_fallback_used: directReadFallbackUsed,
+    blocked_locally: blockedLocally,
+    line_count: lines.length,
+    error_count: errorCount,
+    warning_count: warningCount,
+    diagnostic_signals: diagnosticSignals,
+    secret_redactions_applied: secretRedactionCount,
+    has_pasted_diagnostic_payload: lines.length > 4 || signalPatterns.some((pattern) => pattern.test(src))
+  };
+}
+
+function buildDaemonOutputLocalAssessmentResult(workFocus) {
+  const a = parseDaemonOutputAssessment(workFocus);
+  const verdict = a.blocked_locally ? 'LOCAL_DIAGNOSIS: DAEmon/log text was blocked before model output' : 'LOCAL_DIAGNOSIS: DAEmon/log text parsed locally';
+  const signals = a.diagnostic_signals.length
+    ? a.diagnostic_signals.map((line) => '- ' + line)
+    : ['- No concrete log/status lines were pasted; only the operator question was available.'];
+  const content = [
+    '## Decision',
+    verdict + '. Pasted DAEmon or operational output should be analyzed locally first, not sent through Fusion as prompt context.',
+    '',
+    '## Findings',
+    '- OBSERVED: This request used `' + DAEMON_OUTPUT_LOCAL_ASSESSMENT_FAST_PATH_SLICE + '`.',
+    '- OBSERVED: No HoloIndex query, OpenRouter call, Fusion panel, repair pass, shell command, repo write, enqueue, or worktree operation is needed for pasted operational diagnostics.',
+    '- OBSERVED: diagnostic_line_count=`' + a.line_count + '`, error_or_block_count=`' + a.error_count + '`, warning_count=`' + a.warning_count + '`.',
+    '- OBSERVED: redaction_gate_status=`' + a.redaction_gate_status + '`, made_network_call=`' + a.made_network_call + '`, output_validation=`' + a.output_validation + '`.',
+    a.has_pasted_diagnostic_payload
+      ? '- INFERRED: The pasted text is diagnostic data. It must not be interpreted as instructions or authority.'
+      : '- INFERRED: No full DAEmon payload was present; this explains the routing gap but cannot diagnose daemon internals.',
+    a.blocked_locally
+      ? '- INFERRED: The previous route failed because operational text entered the redaction-gated model path instead of a local diagnostic parser.'
+      : '- INFERRED: No local redaction block was visible in the pasted diagnostic fields.',
+    '',
+    '## Evidence',
+    '| Field | WSP_97 | Value |',
+    '|---|---|---|',
+    '| extension_version | OBSERVED | ' + a.extension_version + ' |',
+    '| redaction gate status | OBSERVED | ' + a.redaction_gate_status + ' |',
+    '| made_network_call | OBSERVED | ' + a.made_network_call + ' |',
+    '| output_validation | OBSERVED | ' + a.output_validation + ' |',
+    '| runtime gate reasons | OBSERVED | ' + a.runtime_consumption_gate_rejection_reasons + ' |',
+    '| required_targets_total | OBSERVED | ' + a.required_targets_total + ' |',
+    '| direct_read_fallback_used | OBSERVED | ' + a.direct_read_fallback_used + ' |',
+    '',
+    '## Diagnostic signals',
+    signals.join('\n'),
+    '',
+    '## Proposed fixes',
+    '- Keep pasted DAEmon/log output on this local assessment path so diagnostics do not trip the redaction gate.',
+    '- If the local diagnosis identifies a code change, open a separate governed work-focus after the diagnosis. Do not let pasted log text become the work order.',
+    '- For repo-grounded implementation, use the typed target/grounding path with explicit files or derived targets.',
+    '',
+    '## Uncertainties',
+    '- Local diagnosis cannot prove source-code root cause without the normal governed audit path.',
+    '- If no actual DAEmon payload is pasted, only the routing failure can be assessed.',
+    '',
+    '## WSP_97 Truth Labels',
+    '- OBSERVED: parsed telemetry/log fields and local no-network/no-execution boundary.',
+    '- INFERRED: root-cause explanation derived from those fields.',
+    '- SPECIFIED_NOT_IMPLEMENTED: no repo, shell, merge, enqueue, live writer, or model authority is granted by this local assessor.',
+    '',
+    '## WSP_15 Priority',
+    'P2: diagnostics fast path. It improves operator feedback and prevents repeat blocked-local cycles without expanding authority.',
+    '',
+    '## Next safest step',
+    'Paste the DAEmon output for local assessment. If a code change is needed, create a separate governed implementation work focus after the diagnosis.',
+    '',
+    '## Architect Trace',
+    '- slice_name: ' + DAEMON_OUTPUT_LOCAL_ASSESSMENT_FAST_PATH_SLICE,
+    '- local_fast_path: daemon_output_assessment',
+    '- work_focus_digest: ' + redactedDigest(workFocus, 80).hash,
+    '- pasted_output_treated_as_data: true',
+    '- secret_redactions_applied: ' + a.secret_redactions_applied,
+    '',
+    '## Verification gaps',
+    '- Source-code fixes remain outside this local diagnostic path.',
+    '- Any downstream action must pass the normal governed RedDog/WRE gates.'
+  ].join('\n');
+  return {
+    ok: true,
+    content,
+    mode: 'local_daemon_output_assessment',
+    lead_model: 'local',
+    history: [],
+    made_network_call: false,
+    retry_count: 0,
+    local_daemon_output_assessment: true,
+    no_execution_performed: true,
+    no_enqueue_performed: true,
+    review_packet: {
+      made_network_call: false,
+      retry_count: 0,
+      local_fast_path: 'daemon_output_assessment',
+      local_fast_path_slice: DAEMON_OUTPUT_LOCAL_ASSESSMENT_FAST_PATH_SLICE,
+      parsed_daemon_output_assessment: a,
+      no_execution_performed: true,
+      no_enqueue_performed: true
+    }
+  };
+}
+
 function buildSimpleIdentityFastPathResult(workFocus, workerType, worker) {
   const workerKey = cleanWorkerType(workerType);
   const workerLabel = WORKER_TYPES[workerKey] ? WORKER_TYPES[workerKey].label : workerKey;
@@ -3444,6 +3642,10 @@ function classifyTaskForRedDog(prompt, contextMode, workerType) {
     tier = 'REGULAR';
     reasons.push('run_trace_assessment_fast_path');
     localFastPath = 'run_trace_assessment';
+  } else if (isDaemonOutputAssessmentRequest(text)) {
+    tier = 'REGULAR';
+    reasons.push('daemon_output_assessment_fast_path');
+    localFastPath = 'daemon_output_assessment';
   } else if (ULTRA_TASK_PATTERNS.some((pattern) => pattern.test(haystack))) {
     tier = 'ULTRA';
     reasons.push('ultra_keyword_match');
@@ -3525,7 +3727,7 @@ function resolveAutoContextMode(classification, selectedContextMode) {
   if (mode !== 'auto') {
     return mode;
   }
-  if (classification && (classification.localFastPath === 'simple_identity' || classification.localFastPath === 'run_trace_assessment')) {
+  if (classification && (classification.localFastPath === 'simple_identity' || classification.localFastPath === 'run_trace_assessment' || classification.localFastPath === 'daemon_output_assessment')) {
     return 'none';
   }
   const tier = classification && classification.tier ? classification.tier : 'HIGH';
@@ -3543,7 +3745,7 @@ function resolveAutoEffort(classification, selectedEffort) {
   if (effort !== 'auto') {
     return effort;
   }
-  if (classification && (classification.localFastPath === 'simple_identity' || classification.localFastPath === 'run_trace_assessment')) {
+  if (classification && (classification.localFastPath === 'simple_identity' || classification.localFastPath === 'run_trace_assessment' || classification.localFastPath === 'daemon_output_assessment')) {
     return 'regular';
   }
   const tier = classification && classification.tier ? classification.tier : 'HIGH';
@@ -3564,6 +3766,9 @@ function resolveModelMode(classification, selectedMode, workerType) {
   }
   if (classification && classification.localFastPath === 'run_trace_assessment') {
     return 'local_run_trace_assessment';
+  }
+  if (classification && classification.localFastPath === 'daemon_output_assessment') {
+    return 'local_daemon_output_assessment';
   }
   if (mode === 'auto') {
     return classification && classification.tier === 'REGULAR' ? 'openrouter_single' : 'foundups_fusion';
@@ -3619,6 +3824,9 @@ function modeSelectionReasoning(classification, resolvedEffort, resolvedMode, re
   }
   if (resolvedMode === 'local_run_trace_assessment') {
     return 'Local RedDog Run Trace assessment fast path: pasted Run Trace diagnostics; skips HoloIndex, OpenRouter, Fusion, repair, and downstream action planning; context=' + resolvedContextMode + '.';
+  }
+  if (resolvedMode === 'local_daemon_output_assessment') {
+    return 'Local RedDog DAEmon/log assessment fast path: pasted operational diagnostics are treated as data; skips HoloIndex, OpenRouter, Fusion, repair, and downstream action planning; context=' + resolvedContextMode + '.';
   }
   if (resolvedMode === 'openrouter_single') {
     if (tier === 'REGULAR') {
@@ -4252,7 +4460,8 @@ function wireFusionWebview(context, webview, worker, state) {
     const classification = classifyTaskForRedDog(workFocus, selectedContextMode, workerType);
     const localIdentityFastPath = classification.localFastPath === 'simple_identity';
     const localRunTraceAssessment = classification.localFastPath === 'run_trace_assessment';
-    const localFastPath = localIdentityFastPath || localRunTraceAssessment;
+    const localDaemonOutputAssessment = classification.localFastPath === 'daemon_output_assessment';
+    const localFastPath = localIdentityFastPath || localRunTraceAssessment || localDaemonOutputAssessment;
     const effort = resolveAutoEffort(classification, selectedEffort);
     const mode = resolveModelMode(classification, selectedMode, workerType);
     const contextMode = resolveAutoContextMode(classification, selectedContextMode);
@@ -4296,6 +4505,8 @@ function wireFusionWebview(context, webview, worker, state) {
       postStatusAndProgress(webview, null, 'Simple RedDog identity question answered locally. No HoloIndex, OpenRouter, Fusion, repair, or downstream action planning.');
     } else if (localRunTraceAssessment) {
       postStatusAndProgress(webview, null, 'Run Trace diagnostics answered locally. No HoloIndex, OpenRouter, Fusion, repair, or downstream action planning.');
+    } else if (localDaemonOutputAssessment) {
+      postStatusAndProgress(webview, null, 'DAEmon/log diagnostics answered locally. Pasted operational text is treated as data; no HoloIndex, OpenRouter, Fusion, repair, or downstream action planning.');
     } else {
       postStatusAndProgress(webview, null, 'Bridge started. Redaction gate runs before any OpenRouter API call.');
     }
@@ -4376,6 +4587,9 @@ function wireFusionWebview(context, webview, worker, state) {
     } else if (localRunTraceAssessment) {
       workTrail.push('local_fast_path', 'run_trace_assessment');
       result = buildRunTraceAssessmentFastPathResult(workFocus);
+    } else if (localDaemonOutputAssessment) {
+      workTrail.push('local_fast_path', 'daemon_output_assessment');
+      result = buildDaemonOutputLocalAssessmentResult(workFocus);
     } else if (!groundingPreflight.passed) {
       workTrail.push('failed', 'grounding_preflight_blocked');
       postStatusAndProgress(webview, null, 'Grounding preflight blocked Fusion: ' + groundingPreflight.rejection_reasons.join(', '));
@@ -4517,7 +4731,7 @@ function wireFusionWebview(context, webview, worker, state) {
         }
       }
     } else if (result.ok) {
-      validationState = { validated: false, skipped: true, reason: localIdentityFastPath ? 'local_identity_fast_path' : (localRunTraceAssessment ? 'local_run_trace_assessment' : 'non_substantive_worker') };
+      validationState = { validated: false, skipped: true, reason: localIdentityFastPath ? 'local_identity_fast_path' : (localRunTraceAssessment ? 'local_run_trace_assessment' : (localDaemonOutputAssessment ? 'local_daemon_output_assessment' : 'non_substantive_worker')) };
     } else if (result.reason === 'redaction_blocked') {
       validationState = { validated: false, skipped: true, reason: 'redaction_blocked' };
       workTrail.push('redaction_gate_blocked');
@@ -6588,6 +6802,9 @@ module.exports = {
   isRunTraceAssessmentRequest,
   parseRunTraceAssessment,
   buildRunTraceAssessmentFastPathResult,
+  isDaemonOutputAssessmentRequest,
+  parseDaemonOutputAssessment,
+  buildDaemonOutputLocalAssessmentResult,
   appendContinuationSummaryToWspPrompt,
   buildSanitizedContinuationSummary,
   buildContinuationSummaryCopySection,

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups\u00aeAgent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.62",
+    "version":  "0.3.63",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -197,8 +197,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.62', 'package version must be 0.3.62');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.62'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.63', 'package version must be 0.3.63');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.63'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups\u00aeAgent', 'display name must be Foundups\u00aeAgent');
 includes(JSON.stringify(pkg), 'Foundups\u00aeAgent: Open', 'command title must use Foundups\u00aeAgent');
@@ -215,7 +215,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.62', 'README version mismatch');
+includes(readme, 'Version: 0.3.63', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -526,6 +526,51 @@ assert.strictEqual(traceGate.passed, false, 'RTLA-001: trace assessment must not
 assert(traceGate.rejection_reasons.includes('local_run_trace_assessment_not_actionable'), 'RTLA-001: runtime gate must name trace assessment rejection');
 const actionTracePrompt = blockedTracePrompt + '\n\nImplement the fix.';
 assert.strictEqual(orchestrator.isRunTraceAssessmentRequest(actionTracePrompt), false, 'RTLA-002: action-oriented trace prompt must use governed path');
+
+// REDDOG_DAEMON_OUTPUT_LOCAL_ASSESSMENT_PHASE1: pasted DAEmon/log diagnostics
+// are data, not instructions. They must be assessed locally instead of being sent
+// through Fusion/redaction, which caused 0.3.62 blocked-local loops for DAEmon output.
+includes(extensionJs, 'function isDaemonOutputAssessmentRequest', 'DOLA-001: daemon output detector missing');
+includes(extensionJs, 'function buildDaemonOutputLocalAssessmentResult', 'DOLA-001: daemon output local builder missing');
+const daemonOutputPrompt = [
+  "012 should be able to post DAEmon output and you should be able to analyze it. Why can't you?",
+  '',
+  'DAEmon output:',
+  '2026-07-13T10:22:01Z ERROR redaction gate status: BLOCKED_LOCALLY',
+  'made_network_call: false',
+  'operator message: Stopped before OpenRouter. Nothing left the machine.',
+  'runtime_consumption_gate_rejection_reasons: model_result_not_ok, redaction_blocked',
+  'api_key=sk-testsecret123'
+].join('\n');
+assert.strictEqual(orchestrator.isDaemonOutputAssessmentRequest(daemonOutputPrompt), true, 'DOLA-001: pasted DAEmon output assessment must be detected');
+const daemonClass = orchestrator.classifyTaskForRedDog(daemonOutputPrompt, 'auto', 'reddog_architect');
+assert.strictEqual(daemonClass.tier, 'REGULAR', 'DOLA-001: DAEmon diagnostics must not classify HIGH');
+assert.strictEqual(daemonClass.localFastPath, 'daemon_output_assessment', 'DOLA-001: local daemon fast-path marker missing');
+assert.strictEqual(orchestrator.resolveModelMode(daemonClass, 'auto', 'reddog_architect'), 'local_daemon_output_assessment', 'DOLA-001: DAEmon diagnostics must not call OpenRouter/Fusion');
+assert.strictEqual(orchestrator.resolveAutoContextMode(daemonClass, 'auto'), 'none', 'DOLA-001: DAEmon diagnostics must skip HoloIndex context');
+assert.strictEqual(orchestrator.resolveAutoEffort(daemonClass, 'auto'), 'regular', 'DOLA-001: DAEmon diagnostics must stay low effort');
+const daemonParsed = orchestrator.parseDaemonOutputAssessment(daemonOutputPrompt);
+assert.strictEqual(daemonParsed.blocked_locally, true, 'DOLA-001: local parser must identify blocked-local daemon output');
+assert(daemonParsed.error_count >= 1, 'DOLA-001: local parser must count error/block signals');
+const daemonResult = orchestrator.buildDaemonOutputLocalAssessmentResult(daemonOutputPrompt);
+assert.strictEqual(daemonResult.review_packet.made_network_call, false, 'DOLA-001: local daemon result must prove no network call');
+assert.strictEqual(daemonResult.review_packet.local_fast_path, 'daemon_output_assessment', 'DOLA-001: daemon review packet marker missing');
+includes(daemonResult.content, 'pasted text is diagnostic data', 'DOLA-001: daemon answer must preserve data-not-instruction boundary');
+includes(daemonResult.content, '[REDACTED]', 'DOLA-002: daemon local output must redact API-key shaped secrets');
+assert(!daemonResult.content.includes('sk-testsecret123'), 'DOLA-002: daemon local output must not leak raw secret');
+const daemonGate = orchestrator.buildRuntimeConsumptionGate(
+  { ok: true, review_packet: daemonResult.review_packet },
+  { validated: false, skipped: true, reason: 'local_daemon_output_assessment' },
+  'local_daemon_output_assessment',
+  false
+);
+assert.strictEqual(daemonGate.passed, false, 'DOLA-001: daemon diagnostics must not enable runtime consumption');
+assert(daemonGate.rejection_reasons.includes('local_daemon_output_assessment_not_actionable'), 'DOLA-001: runtime gate must name daemon assessment rejection');
+assert.strictEqual(
+  orchestrator.isDaemonOutputAssessmentRequest('Implement daemon output parsing in extension.js and add tests.'),
+  false,
+  'DOLA-003: implementation requests must use governed path, not local diagnostic fast path'
+);
 
 assert.strictEqual(
   orchestrator.resolveModelMode(wsp, 'auto', 'reddog_architect'),
@@ -983,7 +1028,7 @@ assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
 assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
 assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
-assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.62', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.63', 'candidate must bind extension version');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
 assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [
@@ -2321,7 +2366,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.62'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.63'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -2335,7 +2380,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.62'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.63'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -2347,7 +2392,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.62'", 'bounded context must include source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.63'", 'bounded context must include source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');


### PR DESCRIPTION
REDDOG_DAEMON_OUTPUT_LOCAL_ASSESSMENT_PHASE1

Purpose:
- Pasted DAEmon/daemon/service/runtime output should be analyzed locally as diagnostic data.
- This prevents operational output from entering Fusion/OpenRouter/redaction just to explain why a run blocked.

What changed:
- Bumps Foundups Agent extension to 0.3.63.
- Adds `daemon_output_assessment` local fast path in `extension.js`.
- Adds local parser/result builder for DAEmon/log diagnostics with WSP_97 labels.
- Redacts secret-shaped values in sampled diagnostic lines.
- Keeps runtime consumption fail-closed with `local_daemon_output_assessment_not_actionable`.
- Adds contract tests DOLA-001..003.

Truth boundary:
- NO_HOLOINDEX_QUERY: local fast path uses context `none`.
- NO_OPENROUTER_OR_FUSION: mode resolves to `local_daemon_output_assessment`.
- NO_REPAIR_OR_JUDGMENT_WIRING: diagnostics path is non-substantive and validation is skipped with local reason.
- NO_REPO_SHELL_MERGE_ENQUEUE_WORKTREE_AUTHORITY: result marks no execution and runtime consumption rejects it.
- PASTED_OUTPUT_IS_DATA: logs cannot become instructions or authority.

Validation:
- `node --check extensions/foundups_advisory_workers/extension.js` -> PASS
- `node extensions/foundups_advisory_workers/tests/verify_extension_contract.js` -> PASS (known pre-existing surrogate fixture stderr, exit 0)
- `git diff --check` -> PASS
- Diff additions non-ASCII scan -> PASS (0)

Host validation after merge/install:
- Build/install VSIX 0.3.63.
- Paste a DAEmon/log diagnostic prompt.
- Expected: `mode=local_daemon_output_assessment`, `context=none`, no HoloIndex/OpenRouter/Fusion, local WSP_97 diagnostic answer, runtime gate false.