### PR TITLE
fix(reddog): guard operational output target derivation

### DIFF
--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,13 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-13 - REDDOG_OPERATIONAL_OUTPUT_TARGET_DERIVATION_GUARD_PHASE1 (browser/DAEmon log target guard, 0.3.64)
+
+- Added an operational-output shape detector for browser/DAEmon diagnostics with URLs, timing values, screenshot filenames, ratios, and status/error tokens.
+- Suppresses operational diagnostic payloads from repo-file and external-research target extraction unless an explicit required-target block is present.
+- Tightened slashless extension detection so timing values such as `11.7s` and `100.0` cannot become repo-file targets.
+- Version 0.3.63 -> 0.3.64 (package.json + EXTENSION_VERSION + README + contract-test assertions).
+
 ## 2026-07-13 - REDDOG_DAEMON_OUTPUT_LOCAL_ASSESSMENT_PHASE1 (local DAEmon/log diagnostics, 0.3.63)
 
 - Added a local DAEmon/log output assessment fast path for pasted operational diagnostics.

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.63
+Version: 0.3.64
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 
@@ -62,6 +62,7 @@ The extension is a bounded 0102 advisory surface:
 - Simple identity fast path (v0.3.61): short identity/status questions such as "are you RedDog?" are answered locally with audited Run Trace telemetry. The fast path skips HoloIndex, OpenRouter, Fusion, repair, and downstream action planning; substantive RedDog audit/work prompts still route through the governed path.
 - Run Trace local assessment (v0.3.62): pasted `## Run Trace` diagnostics are parsed locally and scored with WSP_97 labels so raw trace text no longer needs to pass through Fusion/redaction just to explain why a run blocked or routed slowly. The path remains non-actionable and cannot trigger runtime planning.
 - DAEmon/log local assessment (v0.3.63): pasted DAEmon, daemon, service, worker, or runtime output can be interpreted locally as diagnostic data. The path redacts secret-shaped values, skips HoloIndex/OpenRouter/Fusion/repair, and remains non-actionable so logs cannot become instructions or authority.
+- Operational-output target guard (v0.3.64): browser/DAEmon diagnostic payloads with URLs, timing values, screenshot filenames, and status ratios are routed to local assessment and suppressed from repo/external target extraction so log fragments cannot block typed grounding.
 
 The extension does not grant repo authority. **012 supplies work focus only**; 0102 assembles a WSP task prompt before the bridge runs. Work focus and bounded repo context are sent through `scripts/advisory_model_once.py`, which runs the landed Fusion redaction gate before making OpenRouter requests. The webview receives only advisory text and redacted local history.
 

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.63';
+const EXTENSION_VERSION = '0.3.64';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -714,6 +714,74 @@ const WORK_FOCUS_COMMAND_FENCE_LANGS = ['powershell', 'bash', 'sh', 'shell', 'ps
 // carries no language tag (```...``` with `git diff --check` inside, etc.).
 const WORK_FOCUS_COMMAND_SHAPE_RE = /(?:^|\s)(?:git|node|python|py|pytest|rg|grep|npm|npx|node\s+--check|python\s+holo_index\.py)\b/i;
 
+const OPERATIONAL_OUTPUT_CONTEXT_TERMS = [
+  /\bdaemons?\b/i,
+  /\bdaemons?\s+output\b/i,
+  /\bdae(?:mon)?\b/i,
+  /\bdaemon\b/i,
+  /\bbrowser\b/i,
+  /\bpage\b/i,
+  /\bservice\b/i,
+  /\bworker\b/i,
+  /\bruntime\b/i,
+  /\byoutube\b/i,
+  /\bstudio\.youtube\.com\b/i
+];
+const OPERATIONAL_OUTPUT_SIGNAL_PATTERNS = [
+  /\bdiag_[A-Za-z0-9_.-]+\.png\b/i,
+  /\b(?:timeout|failed|blocked|error|warning|warn|stopped|loaded|content_timeout|page_load_failed)\b/i,
+  /\b\d+(?:\.\d+)?s\b/i,
+  /\b\d+\/\d+\b/i,
+  /\b(?:ops\/min|avg\/video|pass\/fail)\b/i,
+  /^[-\s]*(?:status|stdout|stderr|result|output|trace|run trace|operator message)\s*:/i
+];
+
+function countPatternMatches(text, pattern, limit) {
+  const src = String(text || '');
+  const max = limit || 200;
+  let count = 0;
+  const re = new RegExp(pattern.source, pattern.flags.indexOf('g') === -1 ? pattern.flags + 'g' : pattern.flags);
+  while (re.exec(src) !== null) {
+    count += 1;
+    if (count >= max) {
+      return count;
+    }
+  }
+  return count;
+}
+
+function analyzeOperationalDiagnosticShape(text) {
+  const src = String(text || '');
+  const head = src.slice(0, 6000);
+  const lineCount = src.split(/\r?\n/).filter((line) => line.trim()).length;
+  const contextTermCount = OPERATIONAL_OUTPUT_CONTEXT_TERMS.reduce((n, pattern) => n + (pattern.test(head) ? 1 : 0), 0);
+  const signalCount = OPERATIONAL_OUTPUT_SIGNAL_PATTERNS.reduce((n, pattern) => n + countPatternMatches(head, pattern, 40), 0);
+  const timingCount = countPatternMatches(head, /\b\d+(?:\.\d+)?s\b/i, 80);
+  const urlCount = countPatternMatches(head, /https?:\/\/|(?:^|\s)(?:www\.|studio\.youtube\.com|youtube\.com)\S*/i, 80);
+  const screenshotCount = countPatternMatches(head, /\bdiag_[A-Za-z0-9_.-]+\.png\b/i, 80);
+  const ratioCount = countPatternMatches(head, /\b\d+\/\d+\b/i, 80);
+  const payload = (
+    (contextTermCount > 0 && signalCount >= 2)
+    || (timingCount >= 5 && (urlCount > 0 || screenshotCount > 0 || ratioCount >= 2))
+    || (screenshotCount >= 2)
+    || (lineCount >= 8 && signalCount >= 5)
+  );
+  return {
+    context_term_count: contextTermCount,
+    signal_count: signalCount,
+    timing_count: timingCount,
+    url_count: urlCount,
+    screenshot_count: screenshotCount,
+    ratio_count: ratioCount,
+    line_count: lineCount,
+    operational_diagnostic_payload: payload
+  };
+}
+
+function isOperationalDiagnosticPayload(text) {
+  return analyzeOperationalDiagnosticShape(text).operational_diagnostic_payload === true;
+}
+
 function looksLikeCommandFence(lang, body) {
   const l = String(lang || '').trim().toLowerCase();
   if (WORK_FOCUS_COMMAND_FENCE_LANGS.indexOf(l) !== -1) {
@@ -749,7 +817,7 @@ function extractInlinePathTokens(line) {
     // Tokens that DO contain a '/' keep the case-insensitive rule (path segments may be mixed
     // case). This is stricter than extractTargetTokensFromLine on purpose: prose is untrusted.
     const hasSlash = /[\/]/.test(pathPortion);
-    const hasLowerExt = /\.[a-z0-9]{1,6}$/.test(pathPortion);
+    const hasLowerExt = /\.[a-z][a-z0-9]{0,5}$/.test(pathPortion);
     if (!(hasSlash || hasLowerExt)) {
       continue;
     }
@@ -1092,6 +1160,14 @@ function deriveWorkFocusTargets(taskText) {
 // { targets, derived, derivation_sources } so callers can both drive recall AND emit telemetry.
 function collectRequiredTargets(taskText) {
   const explicit = parseRequiredTargetPaths(taskText);
+  if (!explicit.length && isOperationalDiagnosticPayload(taskText)) {
+    return {
+      targets: [],
+      derived: false,
+      derivation_sources: [],
+      dropped_low_confidence: []
+    };
+  }
   const derivedInfo = deriveWorkFocusTargets(taskText);
   const targets = [];
   const seen = new Set();
@@ -1370,6 +1446,18 @@ function extractSemanticTargets(taskText, repoTargets, externalTargets) {
 
 function extractTypedTargets(taskText) {
   const textWithoutQuotes = removeQuotedReferenceBlocks(taskText);
+  if (!parseRequiredTargetPaths(textWithoutQuotes).length && isOperationalDiagnosticPayload(textWithoutQuotes)) {
+    return {
+      repo_file_targets: [],
+      semantic_targets: [],
+      external_research_targets: [],
+      quoted_reference_blocks: extractQuotedReferenceBlocks(taskText),
+      repo_file_derivation_sources: [],
+      repo_file_targets_derived: false,
+      dropped_low_confidence: [],
+      operational_diagnostic_payload: true
+    };
+  }
   const collected = collectRequiredTargets(textWithoutQuotes);
   const repoTargets = collected.targets.slice();
   const externalTargets = extractExternalResearchTargets(taskText);
@@ -3201,6 +3289,11 @@ const DAEMON_OUTPUT_LOCAL_ASSESSMENT_FAST_PATH_SLICE = 'REDDOG_DAEMON_OUTPUT_LOC
 const DAEMON_OUTPUT_TERMS = [
   /\bdae?mon\b/i,
   /\bdaemon\b/i,
+  /\bdae\b/i,
+  /\bbrowser\b/i,
+  /\bpage\b/i,
+  /\byoutube\b/i,
+  /\bstudio\.youtube\.com\b/i,
   /\bservice\b/i,
   /\borchestrator\b/i,
   /\bworker\b/i,
@@ -3271,7 +3364,9 @@ function isDaemonOutputAssessmentRequest(text) {
   const mentionsDaemonSurface = DAEMON_OUTPUT_TERMS.some((pattern) => pattern.test(head));
   const mentionsOutputContext = DAEMON_OUTPUT_CONTEXT_PATTERNS.some((pattern) => pattern.test(head));
   const asksForAssessment = DAEMON_OUTPUT_ASSESSMENT_PATTERNS.some((pattern) => pattern.test(head));
-  return mentionsDaemonSurface && mentionsOutputContext && asksForAssessment;
+  const operationalShape = analyzeOperationalDiagnosticShape(raw);
+  return (mentionsDaemonSurface && mentionsOutputContext && asksForAssessment)
+    || (operationalShape.operational_diagnostic_payload === true && (asksForAssessment || mentionsOutputContext || mentionsDaemonSurface));
 }
 
 function parseRunTraceAssessment(text) {
@@ -3414,6 +3509,7 @@ function sanitizeDaemonDiagnosticLine(line) {
 
 function parseDaemonOutputAssessment(text) {
   const src = String(text || '');
+  const operationalShape = analyzeOperationalDiagnosticShape(src);
   const lines = src.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
   const signalPatterns = [
     /\b(?:blocked_locally|redaction gate status|made_network_call|operator message|runtime_consumption_gate_rejection_reasons)\b/i,
@@ -3463,7 +3559,8 @@ function parseDaemonOutputAssessment(text) {
     warning_count: warningCount,
     diagnostic_signals: diagnosticSignals,
     secret_redactions_applied: secretRedactionCount,
-    has_pasted_diagnostic_payload: lines.length > 4 || signalPatterns.some((pattern) => pattern.test(src))
+    operational_shape: operationalShape,
+    has_pasted_diagnostic_payload: lines.length > 4 || signalPatterns.some((pattern) => pattern.test(src)) || operationalShape.operational_diagnostic_payload === true
   };
 }
 
@@ -6799,6 +6896,8 @@ module.exports = {
   constructWspTaskPrompt,
   isSimpleIdentityQuestion,
   buildSimpleIdentityFastPathResult,
+  analyzeOperationalDiagnosticShape,
+  isOperationalDiagnosticPayload,
   isRunTraceAssessmentRequest,
   parseRunTraceAssessment,
   buildRunTraceAssessmentFastPathResult,

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups\u00aeAgent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.63",
+    "version":  "0.3.64",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -197,8 +197,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.63', 'package version must be 0.3.63');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.63'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.64', 'package version must be 0.3.64');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.64'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups\u00aeAgent', 'display name must be Foundups\u00aeAgent');
 includes(JSON.stringify(pkg), 'Foundups\u00aeAgent: Open', 'command title must use Foundups\u00aeAgent');
@@ -215,7 +215,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.63', 'README version mismatch');
+includes(readme, 'Version: 0.3.64', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -571,6 +571,33 @@ assert.strictEqual(
   false,
   'DOLA-003: implementation requests must use governed path, not local diagnostic fast path'
 );
+// REDDOG_OPERATIONAL_OUTPUT_TARGET_DERIVATION_GUARD_PHASE1: the 0.3.63 host run
+// still blocked because browser/DAEmon output was converted into 57 repo targets
+// (`11.7s`, `www.youtube.com`, screenshots, `SKILL.md`, etc.). Operational output
+// must route locally and must not enter repo/external grounding as targets.
+includes(extensionJs, 'function analyzeOperationalDiagnosticShape', 'OOTG-001: operational diagnostic shape detector missing');
+const noisyOperationalOutputPrompt = [
+  'Please analyze this browser DAEmon output.',
+  'antifaFM/live 1/3 2/3 3/3 UnDaoDu/live FoundUps/live MOVE2JAPAN/live',
+  'www.youtube.com studio.youtube.com/channel/UCSNTUXjAgpd4sgWYP0xoJgw/videos/short',
+  '11.7s 17.0s 17.4s 84.6s 94.1s 519.7s 824.0s 100.0 0.7',
+  'diag_page_content_timeout_20260713_171947.png',
+  'diag_page_content_timeout_20260713_172004.png',
+  'diag_page_load_failed_20260713_172112.png',
+  'SKILLz.md SKILL.md Avg/video 8/pass ops/min',
+  'operator message: page content timeout and browser status failed'
+].join('\n');
+assert.strictEqual(orchestrator.isDaemonOutputAssessmentRequest(noisyOperationalOutputPrompt), true, 'OOTG-001: noisy browser/DAEmon output must use local diagnostic route');
+const noisyClass = orchestrator.classifyTaskForRedDog(noisyOperationalOutputPrompt, 'auto', 'reddog_architect');
+assert.strictEqual(noisyClass.localFastPath, 'daemon_output_assessment', 'OOTG-001: noisy operational output local fast-path marker missing');
+assert.strictEqual(orchestrator.resolveAutoContextMode(noisyClass, 'auto'), 'none', 'OOTG-001: noisy operational output must skip HoloIndex');
+const noisyCollected = orchestrator.collectRequiredTargets(noisyOperationalOutputPrompt);
+assert.strictEqual(noisyCollected.targets.length, 0, 'OOTG-002: operational timings/URLs/screenshots must not become required repo targets');
+const noisyTyped = orchestrator.extractTypedTargets(noisyOperationalOutputPrompt);
+assert.strictEqual(noisyTyped.repo_file_targets.length, 0, 'OOTG-002: operational output must produce zero repo_file_targets');
+assert.strictEqual(noisyTyped.external_research_targets.length, 0, 'OOTG-002: operational output URLs are log data, not external research targets');
+assert.strictEqual(noisyTyped.operational_diagnostic_payload, true, 'OOTG-002: typed extraction must mark operational diagnostic payload');
+assert.deepStrictEqual(orchestrator.extractInlinePathTokens('11.7s 100.0 0.7'), [], 'OOTG-003: numeric timings/decimals must not be slashless file targets');
 
 assert.strictEqual(
   orchestrator.resolveModelMode(wsp, 'auto', 'reddog_architect'),
@@ -1028,7 +1055,7 @@ assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
 assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
 assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
-assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.63', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.64', 'candidate must bind extension version');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
 assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [
@@ -2366,7 +2393,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.63'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.64'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -2380,7 +2407,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.63'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.64'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -2392,7 +2419,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.63'", 'bounded context must include source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.64'", 'bounded context must include source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');


### PR DESCRIPTION
REDDOG_OPERATIONAL_OUTPUT_TARGET_DERIVATION_GUARD_PHASE1

Root cause from 0.3.63 host run:
- The DAEmon/log fast path did not catch noisy browser/operational output.
- Work-focus target derivation promoted log fragments into 57 repo targets (`www.youtube.com`, `11.7s`, screenshot PNGs, `SKILL.md`, etc.).
- Typed grounding blocked before Fusion with `repo_file_grounding_incomplete`, `repo_file_targets_missing`, and `external_research_retrieval_not_implemented`.

What changed:
- Bumps Foundups Agent extension to 0.3.64.
- Adds deterministic operational-output shape detector for browser/DAEmon diagnostics with URLs, timing values, screenshot filenames, ratios, and status/error tokens.
- Routes noisy operational output to local daemon assessment.
- Suppresses operational diagnostic payloads from repo-file and external-research target extraction unless an explicit required-target block is present.
- Tightens slashless extension detection so numeric timings/decimals like `11.7s`, `100.0`, `0.7` do not become file targets.
- Adds OOTG regression tests for the 0.3.63 noisy browser/DAEmon output shape.

Truth boundary:
- PASTED_OUTPUT_IS_DATA: log text is not instruction or authority.
- NO_HOLOINDEX_QUERY_ON_LOCAL_ROUTE: context resolves to `none` for the local assessment route.
- NO_OPENROUTER_OR_FUSION_ON_LOCAL_ROUTE: mode resolves to `local_daemon_output_assessment`.
- NO_REPO_TARGET_FOR_LOG_FRAGMENTS: operational timings, URLs, screenshots, and ratios produce zero repo_file_targets.
- NO_EXTERNAL_RESEARCH_FOR_LOG_URLS: operational URLs are log data, not research requests.
- NO_REPO_SHELL_MERGE_ENQUEUE_WORKTREE_AUTHORITY.

Validation:
- `node --check extensions/foundups_advisory_workers/extension.js` -> PASS
- `node extensions/foundups_advisory_workers/tests/verify_extension_contract.js` -> PASS (known pre-existing surrogate fixture stderr, exit 0)
- `git diff --check` -> PASS
- Diff additions non-ASCII scan -> PASS (0)

Host validation after merge/install:
- Build/install VSIX 0.3.64.
- Retest the same noisy browser/DAEmon output.
- Expected: `mode=local_daemon_output_assessment`, `context=none`, no HoloIndex/Fusion/OpenRouter, no 57 repo targets, runtime gate false/non-actionable.