### PR TITLE
fix(reddog): let prompt authoring override daemon diagnostics

### DIFF
--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,13 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-13 - REDDOG_DAEMON_PROMPT_AUTHORING_OVERRIDE_PHASE1 (prompt requests override log fast path, 0.3.65)
+
+- Fixed prompt-authoring requests that include DAEmon/log output so they no longer route to the instant local diagnostic fast path.
+- Requests for worker/slice/M2M prompts now stay on the governed prompt-authoring path and retain bounded prompt-authoring context.
+- Operational diagnostic payload suppression still applies to pure log assessment requests.
+- Version 0.3.64 -> 0.3.65 (package.json + EXTENSION_VERSION + README + contract-test assertions).
+
 ## 2026-07-13 - REDDOG_OPERATIONAL_OUTPUT_TARGET_DERIVATION_GUARD_PHASE1 (browser/DAEmon log target guard, 0.3.64)
 
 - Added an operational-output shape detector for browser/DAEmon diagnostics with URLs, timing values, screenshot filenames, ratios, and status/error tokens.

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.64
+Version: 0.3.65
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 
@@ -63,6 +63,7 @@ The extension is a bounded 0102 advisory surface:
 - Run Trace local assessment (v0.3.62): pasted `## Run Trace` diagnostics are parsed locally and scored with WSP_97 labels so raw trace text no longer needs to pass through Fusion/redaction just to explain why a run blocked or routed slowly. The path remains non-actionable and cannot trigger runtime planning.
 - DAEmon/log local assessment (v0.3.63): pasted DAEmon, daemon, service, worker, or runtime output can be interpreted locally as diagnostic data. The path redacts secret-shaped values, skips HoloIndex/OpenRouter/Fusion/repair, and remains non-actionable so logs cannot become instructions or authority.
 - Operational-output target guard (v0.3.64): browser/DAEmon diagnostic payloads with URLs, timing values, screenshot filenames, and status ratios are routed to local assessment and suppressed from repo/external target extraction so log fragments cannot block typed grounding.
+- Prompt-authoring override (v0.3.65): requests for worker/slice/M2M prompts override the DAEmon/log local diagnostic fast path, so pasted logs can be used as context for governed prompt generation instead of being answered instantly as non-actionable diagnostics.
 
 The extension does not grant repo authority. **012 supplies work focus only**; 0102 assembles a WSP task prompt before the bridge runs. Work focus and bounded repo context are sent through `scripts/advisory_model_once.py`, which runs the landed Fusion redaction gate before making OpenRouter requests. The webview receives only advisory text and redacted local history.
 

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.64';
+const EXTENSION_VERSION = '0.3.65';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -1160,6 +1160,14 @@ function deriveWorkFocusTargets(taskText) {
 // { targets, derived, derivation_sources } so callers can both drive recall AND emit telemetry.
 function collectRequiredTargets(taskText) {
   const explicit = parseRequiredTargetPaths(taskText);
+  if (!explicit.length && isOperationalDiagnosticPayload(taskText) && isPromptAuthoringRequest(taskText)) {
+    return {
+      targets: PROMPT_AUTHORING_CONTEXT_TARGETS.slice(),
+      derived: true,
+      derivation_sources: ['prompt_authoring_context'],
+      dropped_low_confidence: []
+    };
+  }
   if (!explicit.length && isOperationalDiagnosticPayload(taskText)) {
     return {
       targets: [],
@@ -1446,6 +1454,18 @@ function extractSemanticTargets(taskText, repoTargets, externalTargets) {
 
 function extractTypedTargets(taskText) {
   const textWithoutQuotes = removeQuotedReferenceBlocks(taskText);
+  if (!parseRequiredTargetPaths(textWithoutQuotes).length && isOperationalDiagnosticPayload(textWithoutQuotes) && isPromptAuthoringRequest(taskText)) {
+    return {
+      repo_file_targets: PROMPT_AUTHORING_CONTEXT_TARGETS.slice(),
+      semantic_targets: [],
+      external_research_targets: [],
+      quoted_reference_blocks: extractQuotedReferenceBlocks(taskText),
+      repo_file_derivation_sources: ['prompt_authoring_context'],
+      repo_file_targets_derived: true,
+      dropped_low_confidence: [],
+      operational_diagnostic_payload: true
+    };
+  }
   if (!parseRequiredTargetPaths(textWithoutQuotes).length && isOperationalDiagnosticPayload(textWithoutQuotes)) {
     return {
       repo_file_targets: [],
@@ -3310,7 +3330,8 @@ const DAEMON_OUTPUT_ASSESSMENT_PATTERNS = [
   /\bwhat\s+(?:happened|failed|blocked|is wrong)\b/i
 ];
 const DAEMON_OUTPUT_ACTION_BLOCKING_PATTERNS = [
-  /\b(?:implement|patch|author|create\s+pr|open\s+pr|merge|land|dispatch|assign|spawn|execute|start\s+slice|write\s+code)\b/i
+  /\b(?:implement|patch|author|create\s+pr|open\s+pr|merge|land|dispatch|assign|spawn|execute|start\s+slice|write\s+code)\b/i,
+  /\b(?:prompt|worker\s+prompt|slice\s+prompt|next\s+prompt|m2m\s+prompt)\b/i
 ];
 
 function normalizeSimpleIdentityQuestion(text) {
@@ -3356,6 +3377,9 @@ function isDaemonOutputAssessmentRequest(text) {
   const raw = String(text || '');
   const head = raw.slice(0, 2400);
   if (raw.trim().length < 12) {
+    return false;
+  }
+  if (isPromptAuthoringRequest(raw)) {
     return false;
   }
   if (DAEMON_OUTPUT_ACTION_BLOCKING_PATTERNS.some((pattern) => pattern.test(head))) {

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups\u00aeAgent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.64",
+    "version":  "0.3.65",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -197,8 +197,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.64', 'package version must be 0.3.64');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.64'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.65', 'package version must be 0.3.65');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.65'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups\u00aeAgent', 'display name must be Foundups\u00aeAgent');
 includes(JSON.stringify(pkg), 'Foundups\u00aeAgent: Open', 'command title must use Foundups\u00aeAgent');
@@ -215,7 +215,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.64', 'README version mismatch');
+includes(readme, 'Version: 0.3.65', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -671,6 +671,31 @@ for (const p of [
 ]) {
   assert(promptAuthoringTargets.targets.includes(p), 'PAD-003: prompt-authoring direct-read target missing: ' + p);
 }
+// REDDOG_DAEMON_PROMPT_AUTHORING_OVERRIDE_PHASE1: when 012 asks for a worker prompt
+// and includes pasted DAEmon/log output as context, prompt-authoring wins. The local
+// daemon diagnostic fast path is only for assessment, not prompt generation.
+const promptAuthoringWithDaemonOutput = [
+  'Provide the worker prompt for REDDOG_DAEMON_OUTPUT_DIAGNOSTIC_SUMMARY_PHASE1.',
+  '',
+  'Use this DAEmon output as context:',
+  'WARNING: Failed to set date Jul 15, 2026',
+  'ERROR: Step set_date returned False',
+  'www.youtube.com 11.7s 84.6s diag_page_content_timeout_20260713_171947.png SKILL.md'
+].join('\n');
+assert.strictEqual(orchestrator.isPromptAuthoringRequest(promptAuthoringWithDaemonOutput), true, 'DPAO-001: DAEmon prompt-authoring request must be detected');
+assert.strictEqual(orchestrator.isDaemonOutputAssessmentRequest(promptAuthoringWithDaemonOutput), false, 'DPAO-001: prompt-authoring must override local daemon assessment');
+const promptDaemonClass = orchestrator.classifyTaskForRedDog(promptAuthoringWithDaemonOutput, 'auto', 'reddog_architect');
+assert.strictEqual(promptDaemonClass.localFastPath, null, 'DPAO-001: prompt-authoring with logs must not carry local fast path');
+assert.notStrictEqual(orchestrator.resolveModelMode(promptDaemonClass, 'auto', 'reddog_architect'), 'local_daemon_output_assessment', 'DPAO-001: prompt-authoring must not resolve to local daemon mode');
+const promptDaemonTargets = orchestrator.collectRequiredTargets(promptAuthoringWithDaemonOutput);
+assert(promptDaemonTargets.derivation_sources.includes('prompt_authoring_context'), 'DPAO-002: prompt-authoring context source must be retained');
+assert(promptDaemonTargets.targets.includes('extensions/foundups_advisory_workers/INTERFACE.md'), 'DPAO-002: prompt-authoring context targets must be present');
+assert(!promptDaemonTargets.targets.includes('SKILL.md'), 'DPAO-002: pasted log filenames must not become prompt-authoring repo targets');
+assert(!promptDaemonTargets.targets.some((t) => /diag_page_content_timeout|11\.7s|www\.youtube\.com/i.test(t)), 'DPAO-002: pasted log fragments must not become prompt-authoring repo targets');
+const promptDaemonTyped = orchestrator.extractTypedTargets(promptAuthoringWithDaemonOutput);
+assert.strictEqual(promptDaemonTyped.operational_diagnostic_payload, true, 'DPAO-003: typed extraction still records operational diagnostic payload');
+assert.strictEqual(promptDaemonTyped.external_research_targets.length, 0, 'DPAO-003: log URL must not become external research target during prompt authoring');
+assert(promptDaemonTyped.repo_file_targets.includes('scripts/reddog_judgment_verifier_once.py'), 'DPAO-003: typed extraction must carry prompt-authoring repo context');
 const promptAuthoringProseOnly = [
   '## Decision',
   'I can draft a scaffold prompt but need clarification.',
@@ -1055,7 +1080,7 @@ assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
 assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
 assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
-assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.64', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.65', 'candidate must bind extension version');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
 assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [
@@ -2393,7 +2418,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.64'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.65'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -2407,7 +2432,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.64'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.65'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -2419,7 +2444,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.64'", 'bounded context must include source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.65'", 'bounded context must include source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');


### PR DESCRIPTION
REDDOG_DAEMON_PROMPT_AUTHORING_OVERRIDE_PHASE1

Root cause from 0.3.64 host run:
- 012 asked for a prompt while including DAEmon/log diagnostic text.
- The DAEmon local-assessment fast path over-triggered.
- RedDog answered instantly as `local_daemon_output_assessment` and skipped the governed prompt-authoring contract.

What changed:
- Bumps Foundups Agent extension to 0.3.65.
- Prompt-authoring requests now override DAEmon/log local diagnostic assessment.
- `prompt`, `worker prompt`, `slice prompt`, `next prompt`, and `m2m prompt` are explicit blockers for the DAEmon fast path.
- Operational payload + prompt-authoring requests keep bounded prompt-authoring context targets.
- Pasted log fragments (`SKILL.md`, screenshots, timings, URLs) do not become prompt-authoring repo/external targets.

Truth boundary:
- PROMPT_AUTHORING_WINS: prompt requests route to governed RedDog prompt generation, not local diagnosis.
- LOG_TEXT_IS_CONTEXT_NOT_AUTHORITY: pasted logs remain context only.
- NO_LOG_FRAGMENT_TARGETS: operational log filenames/timings/URLs are not direct-read targets.
- NO_REPO_SHELL_MERGE_ENQUEUE_WORKTREE_AUTHORITY.

Validation:
- `node --check extensions/foundups_advisory_workers/extension.js` -> PASS
- `node extensions/foundups_advisory_workers/tests/verify_extension_contract.js` -> PASS (known pre-existing surrogate fixture stderr, exit 0)
- `git diff --check` -> PASS
- Diff additions non-ASCII scan -> PASS (0)

Host validation after merge/install:
- Build/install VSIX 0.3.65.
- Ask for a worker prompt while including DAEmon/log output.
- Expected: mode is not `local_daemon_output_assessment`; `localFastPath=null`; prompt-authoring deliverable contract is active and RedDog must produce `## Worker Prompt`.