### PR TITLE
fix(reddog): require per-target semantic grounding proof

### DIFF
--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,13 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-13 - REDDOG_SEMANTIC_GROUNDING_PER_TARGET_PROOF_PHASE1 (semantic coverage proof, 0.3.66)
+
+- Replaced aggregate semantic grounding (`code_hits + wsp_hits > 0`) with per-target `SemanticTargetCoverage` records.
+- Each semantic target now requires independent content-bearing HoloIndex evidence refs; unrelated global hits, backend errors, and ref-less hits fail closed.
+- Run Trace and wardrobe grounding receipts now carry semantic required/grounded/missing counts plus a coverage digest.
+- Version 0.3.65 -> 0.3.66 (package.json + EXTENSION_VERSION + README + contract-test assertions).
+
 ## 2026-07-13 - REDDOG_DAEMON_PROMPT_AUTHORING_OVERRIDE_PHASE1 (prompt requests override log fast path, 0.3.65)
 
 - Fixed prompt-authoring requests that include DAEmon/log output so they no longer route to the instant local diagnostic fast path.

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.65
+Version: 0.3.66
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 
@@ -64,6 +64,7 @@ The extension is a bounded 0102 advisory surface:
 - DAEmon/log local assessment (v0.3.63): pasted DAEmon, daemon, service, worker, or runtime output can be interpreted locally as diagnostic data. The path redacts secret-shaped values, skips HoloIndex/OpenRouter/Fusion/repair, and remains non-actionable so logs cannot become instructions or authority.
 - Operational-output target guard (v0.3.64): browser/DAEmon diagnostic payloads with URLs, timing values, screenshot filenames, and status ratios are routed to local assessment and suppressed from repo/external target extraction so log fragments cannot block typed grounding.
 - Prompt-authoring override (v0.3.65): requests for worker/slice/M2M prompts override the DAEmon/log local diagnostic fast path, so pasted logs can be used as context for governed prompt generation instead of being answered instantly as non-actionable diagnostics.
+- Semantic grounding per-target proof (v0.3.66): semantic targets now require independent content-bearing HoloIndex evidence refs before Fusion or wardrobe selection may proceed. Aggregate `code_hits` / `wsp_hits` no longer satisfy unrelated semantic targets; missing, errored, or ref-less semantic evidence fails closed and is surfaced through `semantic_targets_required`, `semantic_targets_grounded`, `semantic_targets_missing`, and `semantic_target_coverage_digest` telemetry.
 
 The extension does not grant repo authority. **012 supplies work focus only**; 0102 assembles a WSP task prompt before the bridge runs. Work focus and bounded repo context are sent through `scripts/advisory_model_once.py`, which runs the landed Fusion redaction gate before making OpenRouter requests. The webview receives only advisory text and redacted local history.
 

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.65';
+const EXTENSION_VERSION = '0.3.66';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -1499,6 +1499,236 @@ function numberFromScorecard(value) {
   return Number.isFinite(n) ? n : 0;
 }
 
+const SEMANTIC_GROUNDING_STOPWORDS = new Set([
+  'about', 'after', 'against', 'agent', 'audit', 'based', 'before', 'build', 'code',
+  'compare', 'concept', 'current', 'does', 'evaluate', 'foundups', 'from', 'governance',
+  'grounding', 'implementation', 'into', 'mapping', 'module', 'need', 'needs', 'paper',
+  'pipeline', 'question', 'read', 'repo', 'research', 'review', 'selection', 'should',
+  'system', 'that', 'the', 'this', 'through', 'topic', 'using', 'whether', 'with',
+  'workflow', 'wsp'
+]);
+
+function normalizeSemanticQuery(value) {
+  return collapseAsciiWhitespace(String(value || '')
+    .toLowerCase()
+    .replace(/[`"'()[\]{}<>]/g, ' ')
+    .replace(/[_./\\:-]+/g, ' '));
+}
+
+function tokenizeSemanticQuery(value) {
+  const normalized = normalizeSemanticQuery(value);
+  const tokens = normalized.match(/[a-z0-9]+/g) || [];
+  return uniqueStrings(tokens.filter((token) => token.length >= 3 && !SEMANTIC_GROUNDING_STOPWORDS.has(token)));
+}
+
+function semanticEvidenceRef(hit) {
+  const h = hit && typeof hit === 'object' ? hit : {};
+  const raw = h.evidence_ref || h.ref || h.location || h.path || h.file || h.uri || h.id;
+  return String(raw || '').trim();
+}
+
+function semanticHitText(hit) {
+  if (!hit || typeof hit !== 'object') {
+    return String(hit || '');
+  }
+  const fields = [
+    hit.need,
+    hit.title,
+    hit.summary,
+    hit.preview,
+    hit.snippet,
+    hit.content,
+    hit.text,
+    hit.location,
+    hit.path,
+    hit.file,
+    hit.module,
+    hit.kind,
+    hit.type
+  ];
+  return fields.map((field) => String(field || '')).join(' ');
+}
+
+function normalizeSemanticEvidenceHit(hit, index, bucket) {
+  if (!hit || typeof hit !== 'object') {
+    return null;
+  }
+  const evidenceRef = semanticEvidenceRef(hit, index);
+  const text = collapseAsciiWhitespace(semanticHitText(hit)).slice(0, 4000);
+  if (!evidenceRef || !text) {
+    return null;
+  }
+  return {
+    evidence_ref: evidenceRef,
+    bucket: String(bucket || hit.bucket || hit.type || 'holoindex'),
+    text: text
+  };
+}
+
+function appendSemanticEvidenceHits(out, hits, bucket) {
+  if (!Array.isArray(hits)) {
+    return;
+  }
+  for (let i = 0; i < hits.length; i++) {
+    const normalized = normalizeSemanticEvidenceHit(hits[i], out.length, bucket);
+    if (normalized) {
+      out.push(normalized);
+    }
+  }
+}
+
+function semanticEvidenceHitsFromBundleData(data) {
+  const out = [];
+  const task = data && data.task_retrieval && typeof data.task_retrieval === 'object'
+    ? data.task_retrieval
+    : {};
+  appendSemanticEvidenceHits(out, task.code_hits, 'code');
+  appendSemanticEvidenceHits(out, task.wsp_hits, 'wsp');
+  appendSemanticEvidenceHits(out, task.doc_hits, 'docs');
+  appendSemanticEvidenceHits(out, task.docs_hits, 'docs');
+  appendSemanticEvidenceHits(out, task.skill_hits, 'skill');
+  appendSemanticEvidenceHits(out, data && data.code_hits, 'code');
+  appendSemanticEvidenceHits(out, data && data.wsp_hits, 'wsp');
+  appendSemanticEvidenceHits(out, data && data.docs_hits, 'docs');
+  appendSemanticEvidenceHits(out, data && data.skill_hits, 'skill');
+  return out;
+}
+
+function collectSemanticEvidenceHits(contextPacket, scorecard) {
+  const out = [];
+  const packet = contextPacket && typeof contextPacket === 'object' ? contextPacket : {};
+  const meta = packet.holoindex_meta && typeof packet.holoindex_meta === 'object' ? packet.holoindex_meta : {};
+  const directScorecard = packet.holoindex_scorecard && typeof packet.holoindex_scorecard === 'object'
+    ? packet.holoindex_scorecard
+    : {};
+  appendSemanticEvidenceHits(out, packet.semantic_evidence_hits, 'semantic');
+  appendSemanticEvidenceHits(out, meta.semantic_evidence_hits, 'semantic');
+  appendSemanticEvidenceHits(out, directScorecard.semantic_evidence_hits, 'semantic');
+  appendSemanticEvidenceHits(out, scorecard && scorecard.semantic_evidence_hits, 'semantic');
+  const seen = new Set();
+  return out.filter((hit) => {
+    const key = hit.evidence_ref + '\n' + hit.text;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function semanticBackendErrorForTarget(target, contextPacket, scorecard) {
+  const normalized = normalizeSemanticQuery(target);
+  const candidates = [
+    contextPacket && contextPacket.semantic_target_errors,
+    contextPacket && contextPacket.semantic_grounding_errors,
+    scorecard && scorecard.semantic_target_errors,
+    scorecard && scorecard.semantic_grounding_errors
+  ];
+  for (const item of candidates) {
+    if (!item) {
+      continue;
+    }
+    if (Array.isArray(item)) {
+      if (item.some((value) => normalizeSemanticQuery(value) === normalized)) {
+        return true;
+      }
+      continue;
+    }
+    if (typeof item === 'object') {
+      for (const key of Object.keys(item)) {
+        if (normalizeSemanticQuery(key) === normalized && item[key]) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+function semanticHitSupportsTarget(hit, targetTokens, normalizedQuery) {
+  const normalizedText = normalizeSemanticQuery(hit && hit.text);
+  if (!normalizedText) {
+    return null;
+  }
+  if (normalizedQuery && normalizedText.includes(normalizedQuery)) {
+    return {
+      matched_tokens: targetTokens.slice(),
+      exact_phrase: true
+    };
+  }
+  const matched = targetTokens.filter((token) => normalizedText.includes(token));
+  const required = targetTokens.length <= 2
+    ? targetTokens.length
+    : Math.max(2, Math.ceil(targetTokens.length * 0.6));
+  const hasAnchor = matched.some((token) => token.length >= 6) || targetTokens.every((token) => token.length < 6);
+  if (targetTokens.length && matched.length >= required && hasAnchor) {
+    return {
+      matched_tokens: matched,
+      exact_phrase: false
+    };
+  }
+  return null;
+}
+
+function buildSemanticTargetCoverage(targets, contextMode, contextPacket, scorecard) {
+  const semanticTargets = Array.isArray(targets) ? targets : [];
+  const hasHolo = !!(contextMode && String(contextMode).includes('holo'));
+  const evidenceHits = collectSemanticEvidenceHits(contextPacket, scorecard);
+  return semanticTargets.map((target) => {
+    const normalizedQuery = normalizeSemanticQuery(target);
+    const tokens = tokenizeSemanticQuery(target);
+    const rejectionReasons = [];
+    const contentBearingHits = [];
+    const evidenceRefs = [];
+    if (!hasHolo) {
+      rejectionReasons.push('semantic_grounding_holoindex_required');
+    }
+    if (semanticBackendErrorForTarget(target, contextPacket, scorecard)) {
+      rejectionReasons.push('semantic_grounding_backend_error');
+    }
+    if (!tokens.length) {
+      rejectionReasons.push('semantic_target_unparseable');
+    }
+    if (!evidenceHits.length) {
+      rejectionReasons.push('semantic_grounding_no_evidence_hits');
+    }
+    if (hasHolo && tokens.length && evidenceHits.length) {
+      for (const hit of evidenceHits) {
+        const support = semanticHitSupportsTarget(hit, tokens, normalizedQuery);
+        if (!support) {
+          continue;
+        }
+        evidenceRefs.push(hit.evidence_ref);
+        contentBearingHits.push({
+          evidence_ref: hit.evidence_ref,
+          bucket: hit.bucket,
+          matched_tokens: support.matched_tokens,
+          exact_phrase: support.exact_phrase === true
+        });
+      }
+    }
+    if (!evidenceRefs.length) {
+      rejectionReasons.push('semantic_target_evidence_missing');
+    }
+    const uniqueEvidenceRefs = uniqueStrings(evidenceRefs);
+    return {
+      target: String(target || ''),
+      normalized_query: normalizedQuery,
+      verdict: rejectionReasons.length === 0 ? 'SUFFICIENT' : 'UNSAFE_TO_ACT',
+      evidence_refs: uniqueEvidenceRefs,
+      content_bearing_hits: contentBearingHits.filter((hit, index) => uniqueEvidenceRefs.indexOf(hit.evidence_ref) !== -1
+        && contentBearingHits.findIndex((other) => other.evidence_ref === hit.evidence_ref) === index),
+      rejection_reasons: uniqueStrings(rejectionReasons)
+    };
+  });
+}
+
+function semanticTargetCoverageDigest(coverage) {
+  return canonicalWorkOrderDigest({
+    semantic_target_coverage: Array.isArray(coverage) ? coverage : []
+  });
+}
+
 function buildTypedGroundingPreflight(taskText, contextMode, contextPacket) {
   const typedTargets = extractTypedTargets(taskText);
   const scorecard = (contextPacket && contextPacket.holoindex_scorecard)
@@ -1518,11 +1748,16 @@ function buildTypedGroundingPreflight(taskText, contextMode, contextPacket) {
     }
   }
 
-  if (semantic.length) {
-    const hasHolo = !!(contextMode && String(contextMode).includes('holo'));
-    const hits = numberFromScorecard(scorecard && scorecard.code_hits_count) + numberFromScorecard(scorecard && scorecard.wsp_hits);
-    if (!hasHolo || hits <= 0) {
-      rejectionReasons.push('semantic_grounding_missing_holoindex_hits');
+  const semanticCoverage = buildSemanticTargetCoverage(semantic, contextMode, contextPacket, scorecard);
+  const semanticMissing = semanticCoverage
+    .filter((record) => record.verdict !== 'SUFFICIENT')
+    .map((record) => record.target);
+  if (semantic.length && semanticMissing.length) {
+    rejectionReasons.push('semantic_target_grounding_incomplete');
+    for (const record of semanticCoverage) {
+      if (record.verdict !== 'SUFFICIENT') {
+        rejectionReasons.push.apply(rejectionReasons, record.rejection_reasons);
+      }
     }
   }
 
@@ -1536,6 +1771,11 @@ function buildTypedGroundingPreflight(taskText, contextMode, contextPacket) {
     rejection_reasons: Array.from(new Set(rejectionReasons)),
     repo_file_targets_count: repoFiles.length,
     semantic_targets_count: semantic.length,
+    semantic_targets_required: semantic.length,
+    semantic_targets_grounded: semanticCoverage.filter((record) => record.verdict === 'SUFFICIENT').length,
+    semantic_targets_missing: semanticMissing,
+    semantic_target_coverage: semanticCoverage,
+    semantic_target_coverage_digest: semanticTargetCoverageDigest(semanticCoverage),
     external_research_targets_count: external.length,
     quoted_reference_blocks_count: quoted.length,
     direct_read_required: repoFiles.length > 0,
@@ -1786,6 +2026,12 @@ function extractHoloIndexScorecard(contextMode, holoMeta) {
     typed_target_extraction_applied: meta.typed_target_extraction_applied !== undefined ? meta.typed_target_extraction_applied : 'unknown',
     repo_file_targets_count: meta.repo_file_targets_count !== undefined ? meta.repo_file_targets_count : 'unknown',
     semantic_targets_count: meta.semantic_targets_count !== undefined ? meta.semantic_targets_count : 'unknown',
+    semantic_targets_required: meta.semantic_targets_required !== undefined ? meta.semantic_targets_required : 'unknown',
+    semantic_targets_grounded: meta.semantic_targets_grounded !== undefined ? meta.semantic_targets_grounded : 'unknown',
+    semantic_targets_missing: Array.isArray(meta.semantic_targets_missing) ? meta.semantic_targets_missing : 'unknown',
+    semantic_target_coverage: Array.isArray(meta.semantic_target_coverage) ? meta.semantic_target_coverage : 'unknown',
+    semantic_target_coverage_digest: meta.semantic_target_coverage_digest !== undefined ? meta.semantic_target_coverage_digest : 'unknown',
+    semantic_evidence_hits: Array.isArray(meta.semantic_evidence_hits) ? meta.semantic_evidence_hits : [],
     external_research_targets_count: meta.external_research_targets_count !== undefined ? meta.external_research_targets_count : 'unknown',
     quoted_reference_blocks_count: meta.quoted_reference_blocks_count !== undefined ? meta.quoted_reference_blocks_count : 'unknown',
     grounding_preflight_applied: meta.grounding_preflight_applied !== undefined ? meta.grounding_preflight_applied : 'unknown',
@@ -1854,6 +2100,10 @@ function formatHoloIndexScorecardLines(scorecard) {
     '- typed_target_extraction_applied: ' + scorecard.typed_target_extraction_applied,
     '- repo_file_targets_count: ' + scorecard.repo_file_targets_count,
     '- semantic_targets_count: ' + scorecard.semantic_targets_count,
+    '- semantic_targets_required: ' + scorecard.semantic_targets_required,
+    '- semantic_targets_grounded: ' + scorecard.semantic_targets_grounded,
+    '- semantic_targets_missing: ' + (Array.isArray(scorecard.semantic_targets_missing) ? (scorecard.semantic_targets_missing.length ? scorecard.semantic_targets_missing.join(', ') : '(none)') : scorecard.semantic_targets_missing),
+    '- semantic_target_coverage_digest: ' + scorecard.semantic_target_coverage_digest,
     '- external_research_targets_count: ' + scorecard.external_research_targets_count,
     '- quoted_reference_blocks_count: ' + scorecard.quoted_reference_blocks_count,
     '- grounding_preflight_applied: ' + scorecard.grounding_preflight_applied,
@@ -2706,6 +2956,10 @@ function buildWardrobeGroundingPreflightReceipt(holoScorecard, options) {
     rejection_reasons: reasons,
     repo_file_targets_count: numberFromScorecard(source.repo_file_targets_count),
     semantic_targets_count: numberFromScorecard(source.semantic_targets_count),
+    semantic_targets_required: numberFromScorecard(source.semantic_targets_required),
+    semantic_targets_grounded: numberFromScorecard(source.semantic_targets_grounded),
+    semantic_targets_missing: Array.isArray(source.semantic_targets_missing) ? source.semantic_targets_missing.slice() : [],
+    semantic_target_coverage_digest: source.semantic_target_coverage_digest || '',
     external_research_targets_count: numberFromScorecard(source.external_research_targets_count),
     quoted_reference_blocks_count: numberFromScorecard(source.quoted_reference_blocks_count),
     direct_read_required: source.direct_read_required === true || numberFromScorecard(source.repo_file_targets_count) > 0,
@@ -4659,6 +4913,15 @@ function wireFusionWebview(context, webview, worker, state) {
         : [];
       holoScorecard.repo_file_targets_count = groundingPreflight.repo_file_targets_count;
       holoScorecard.semantic_targets_count = groundingPreflight.semantic_targets_count;
+      holoScorecard.semantic_targets_required = groundingPreflight.semantic_targets_required;
+      holoScorecard.semantic_targets_grounded = groundingPreflight.semantic_targets_grounded;
+      holoScorecard.semantic_targets_missing = Array.isArray(groundingPreflight.semantic_targets_missing)
+        ? groundingPreflight.semantic_targets_missing.slice()
+        : [];
+      holoScorecard.semantic_target_coverage = Array.isArray(groundingPreflight.semantic_target_coverage)
+        ? groundingPreflight.semantic_target_coverage.slice()
+        : [];
+      holoScorecard.semantic_target_coverage_digest = groundingPreflight.semantic_target_coverage_digest;
       holoScorecard.external_research_targets_count = groundingPreflight.external_research_targets_count;
       holoScorecard.quoted_reference_blocks_count = groundingPreflight.quoted_reference_blocks_count;
     }
@@ -6186,6 +6449,12 @@ function holoIndexMetaFromBundle(output, usedOfflineFallback, taskText) {
     typed_target_extraction_applied: false,
     repo_file_targets_count: 0,
     semantic_targets_count: 0,
+    semantic_targets_required: 0,
+    semantic_targets_grounded: 0,
+    semantic_targets_missing: [],
+    semantic_target_coverage: [],
+    semantic_target_coverage_digest: semanticTargetCoverageDigest([]),
+    semantic_evidence_hits: [],
     external_research_targets_count: 0,
     quoted_reference_blocks_count: 0,
     direct_read_paths: [],
@@ -6226,6 +6495,7 @@ function holoIndexMetaFromBundle(output, usedOfflineFallback, taskText) {
     meta.typed_target_extraction_applied = recall.typed_target_extraction_applied === true;
     meta.repo_file_targets_count = Number(recall.repo_file_targets_count || 0);
     meta.semantic_targets_count = Number(recall.semantic_targets_count || 0);
+    meta.semantic_evidence_hits = semanticEvidenceHitsFromBundleData(data);
     meta.external_research_targets_count = Number(recall.external_research_targets_count || 0);
     meta.quoted_reference_blocks_count = Number(recall.quoted_reference_blocks_count || 0);
     // REDDOG_DIRECT_READ_FALLBACK_BY_PATH_PHASE1: surface the Python-side

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups\u00aeAgent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.65",
+    "version":  "0.3.66",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -197,8 +197,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.65', 'package version must be 0.3.65');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.65'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.66', 'package version must be 0.3.66');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.66'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups\u00aeAgent', 'display name must be Foundups\u00aeAgent');
 includes(JSON.stringify(pkg), 'Foundups\u00aeAgent: Open', 'command title must use Foundups\u00aeAgent');
@@ -215,7 +215,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.65', 'README version mismatch');
+includes(readme, 'Version: 0.3.66', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -1080,7 +1080,7 @@ assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
 assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
 assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
-assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.65', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.66', 'candidate must bind extension version');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
 assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [
@@ -2418,7 +2418,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.65'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.66'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -2432,7 +2432,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.65'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.66'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -2444,7 +2444,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.65'", 'bounded context must include source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.66'", 'bounded context must include source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');
@@ -3162,6 +3162,7 @@ const repoOnlyPreflight = orchestrator.buildTypedGroundingPreflight(repoOnlyProm
 });
 assert.strictEqual(repoOnlyPreflight.passed, true, 'TGP-002: repo-only prompt passes when direct-read recall is green');
 assert.strictEqual(repoOnlyPreflight.direct_read_required, true, 'TGP-002: repo-only prompt requires direct read');
+assert.strictEqual(repoOnlyPreflight.semantic_targets_required, 0, 'TGP-002: repo-only prompt has zero semantic targets required');
 
 const missingRepoPreflight = orchestrator.buildTypedGroundingPreflight(repoOnlyPrompt, 'wsp_holo', {
   holoindex_scorecard: {
@@ -3187,5 +3188,130 @@ assert(externalPreflight.rejection_reasons.includes('external_research_retrieval
 const blockedResult = orchestrator.buildGroundingPreflightBlockedResult(externalPreflight);
 assert.strictEqual(blockedResult.made_network_call, false, 'TGP-005: blocked preflight does not call model/network');
 assert.strictEqual(blockedResult.reason, 'grounding_preflight_blocked', 'TGP-005: blocked reason stable');
+
+// REDDOG_SEMANTIC_GROUNDING_PER_TARGET_PROOF_PHASE1 (SGP-001..012): every semantic target
+// needs its own content-bearing HoloIndex evidence. Aggregate code_hits/wsp_hits cannot ground
+// unrelated semantic targets.
+includes(extensionJs, 'function buildSemanticTargetCoverage', 'SGP-001: per-target semantic coverage builder missing');
+const semanticPrompt = [
+  'Research topic: alpha lane ledger reconciliation; beta prompt library governance',
+  'Determine whether both concepts are grounded.'
+].join('\n');
+const alphaSemanticHit = {
+  location: 'docs/audits/alpha_lane_ledger_reconciliation.md',
+  need: 'alpha lane ledger reconciliation evidence',
+  title: 'Alpha lane ledger reconciliation'
+};
+const betaSemanticHit = {
+  location: 'docs/contracts/beta_prompt_library_governance.md',
+  need: 'beta prompt library governance evidence',
+  title: 'Beta prompt library governance'
+};
+const semanticPartial = orchestrator.buildTypedGroundingPreflight(semanticPrompt, 'wsp_holo', {
+  semantic_evidence_hits: [alphaSemanticHit]
+});
+assert.strictEqual(semanticPartial.passed, false, 'SGP-002: evidence for one of two semantic targets must fail');
+assert.strictEqual(semanticPartial.semantic_targets_required, 2, 'SGP-002: both semantic targets are required');
+assert.strictEqual(semanticPartial.semantic_targets_grounded, 1, 'SGP-002: only one semantic target is grounded');
+assert.deepStrictEqual(semanticPartial.semantic_targets_missing, ['beta prompt library governance'], 'SGP-002: missing semantic target is named');
+assert(semanticPartial.rejection_reasons.includes('semantic_target_grounding_incomplete'), 'SGP-002: semantic incomplete reason present');
+assert.strictEqual(semanticPartial.semantic_target_coverage[0].verdict, 'SUFFICIENT', 'SGP-002: first target has sufficient coverage');
+assert.strictEqual(semanticPartial.semantic_target_coverage[1].verdict, 'UNSAFE_TO_ACT', 'SGP-002: second target fails closed');
+assert(semanticPartial.semantic_target_coverage_digest.startsWith('sha256:'), 'SGP-002: coverage digest is bound');
+
+const semanticUnrelated = orchestrator.buildTypedGroundingPreflight(semanticPrompt, 'wsp_holo', {
+  holoindex_scorecard: {
+    code_hits_count: 1,
+    wsp_hits: 4,
+    semantic_evidence_hits: [
+      { location: 'docs/global_architecture.md', need: 'global architecture overview unrelated to requested targets' }
+    ]
+  }
+});
+assert.strictEqual(semanticUnrelated.passed, false, 'SGP-003: unrelated global hits cannot satisfy semantic targets');
+assert.strictEqual(semanticUnrelated.semantic_targets_grounded, 0, 'SGP-003: unrelated hit grounds zero targets');
+
+const semanticPass = orchestrator.buildTypedGroundingPreflight(semanticPrompt, 'wsp_holo', {
+  semantic_evidence_hits: [alphaSemanticHit, betaSemanticHit]
+});
+assert.strictEqual(semanticPass.passed, true, 'SGP-004: each semantic target with independent evidence passes');
+assert.strictEqual(semanticPass.semantic_targets_grounded, 2, 'SGP-004: both targets are grounded');
+assert.deepStrictEqual(semanticPass.semantic_targets_missing, [], 'SGP-004: no missing semantic targets');
+assert(semanticPass.semantic_target_coverage.every((record) => record.evidence_refs.length === 1), 'SGP-004: each target carries evidence refs');
+
+const semanticBackendError = orchestrator.buildTypedGroundingPreflight(semanticPrompt, 'wsp_holo', {
+  semantic_evidence_hits: [alphaSemanticHit, betaSemanticHit],
+  semantic_target_errors: {
+    'beta prompt library governance': 'backend_error'
+  }
+});
+assert.strictEqual(semanticBackendError.passed, false, 'SGP-005: backend error for one semantic target fails closed');
+assert(semanticBackendError.rejection_reasons.includes('semantic_grounding_backend_error'), 'SGP-005: backend error reason present');
+assert.deepStrictEqual(semanticBackendError.semantic_targets_missing, ['beta prompt library governance'], 'SGP-005: errored semantic target is missing');
+
+const semanticEmptyRef = orchestrator.buildTypedGroundingPreflight(semanticPrompt, 'wsp_holo', {
+  semantic_evidence_hits: [
+    { need: 'alpha lane ledger reconciliation beta prompt library governance evidence without location' }
+  ]
+});
+assert.strictEqual(semanticEmptyRef.passed, false, 'SGP-006: empty evidence_refs cannot pass');
+assert.strictEqual(semanticEmptyRef.semantic_targets_grounded, 0, 'SGP-006: evidence without refs grounds zero targets');
+
+const semanticBundleOutput = JSON.stringify({
+  task_retrieval: {
+    code_hits: [alphaSemanticHit, betaSemanticHit],
+    metadata: { code_count: 2, wsp_count: 0, skill_count: 0 }
+  }
+});
+const semanticBundleMeta = orchestrator.holoIndexMetaFromBundle(semanticBundleOutput, false, semanticPrompt);
+assert.strictEqual(Array.isArray(semanticBundleMeta.semantic_evidence_hits), true, 'SGP-007: bundle meta projects semantic evidence hits');
+assert.strictEqual(semanticBundleMeta.semantic_evidence_hits.length, 2, 'SGP-007: projected semantic evidence hit count');
+const semanticBundlePreflight = orchestrator.buildTypedGroundingPreflight(semanticPrompt, 'wsp_holo', {
+  holoindex_meta: semanticBundleMeta
+});
+assert.strictEqual(semanticBundlePreflight.passed, true, 'SGP-007: projected bundle evidence grounds semantic targets');
+
+const semanticNoHolo = orchestrator.buildTypedGroundingPreflight(semanticPrompt, 'plain_context', {
+  semantic_evidence_hits: [alphaSemanticHit, betaSemanticHit]
+});
+assert.strictEqual(semanticNoHolo.passed, false, 'SGP-008: semantic targets require a HoloIndex context');
+assert(semanticNoHolo.rejection_reasons.includes('semantic_grounding_holoindex_required'), 'SGP-008: HoloIndex required reason present');
+
+const semanticWardrobePayload = orchestrator.buildWardrobeSelectionPayload(semanticPrompt, {}, {}, {}, {
+  groundingPreflight: semanticPartial
+});
+assert.strictEqual(semanticWardrobePayload.grounding_preflight.passed, false, 'SGP-009: wardrobe receipt preserves failed grounding');
+assert.strictEqual(semanticWardrobePayload.grounding_preflight.semantic_targets_required, 2, 'SGP-009: wardrobe receipt carries semantic required count');
+assert.strictEqual(semanticWardrobePayload.grounding_preflight.semantic_targets_grounded, 1, 'SGP-009: wardrobe receipt carries semantic grounded count');
+assert.deepStrictEqual(semanticWardrobePayload.grounding_preflight.semantic_targets_missing, ['beta prompt library governance'], 'SGP-009: wardrobe receipt carries semantic missing list');
+assert.strictEqual(semanticWardrobePayload.grounding_preflight.semantic_target_coverage_digest, semanticPartial.semantic_target_coverage_digest, 'SGP-009: wardrobe receipt binds semantic coverage digest');
+let semanticSelectionRunnerCalled = false;
+const semanticSelectionBlocked = orchestrator.runOperatorWardrobeSelectionBridge(null, semanticPrompt, {}, {}, {}, {
+  groundingPreflight: semanticPartial,
+  selectionRunner: () => {
+    semanticSelectionRunnerCalled = true;
+    return { decision: 'SHOULD_NOT_RUN' };
+  }
+});
+assert.strictEqual(semanticSelectionRunnerCalled, false, 'SGP-010: wardrobe selection runner is not invoked after grounding failure');
+assert.strictEqual(semanticSelectionBlocked.decision, 'WARDROBE_SELECTION_REJECT', 'SGP-010: wardrobe selection blocks on failed semantic grounding');
+const semanticBlockedResult = orchestrator.buildGroundingPreflightBlockedResult(semanticPartial);
+const semanticRuntimeGate = orchestrator.buildRuntimeConsumptionGate(semanticBlockedResult, { validated: false }, 'foundups_fusion', true);
+assert.strictEqual(semanticRuntimeGate.passed, false, 'SGP-011: runtime gate blocks after grounding failure result');
+assert(semanticRuntimeGate.rejection_reasons.includes('grounding_preflight_blocked'), 'SGP-011: runtime gate carries grounding failure reason');
+
+const semanticExternalStillBlocked = orchestrator.buildTypedGroundingPreflight(typedPrompt, 'wsp_holo', {
+  semantic_evidence_hits: [
+    { location: 'docs/research/autoresearch_git_loop.md', need: 'autoresearch git-centric edit evaluate loop' }
+  ],
+  holoindex_scorecard: {
+    target_recall_ok: true,
+    required_targets_missing: [],
+    code_hits_count: 2,
+    wsp_hits: 1
+  }
+});
+assert.strictEqual(semanticExternalStillBlocked.passed, false, 'SGP-012: external research remains fail-closed even when semantic evidence exists');
+assert(semanticExternalStillBlocked.rejection_reasons.includes('external_research_retrieval_not_implemented'), 'SGP-012: external research fail-closed reason preserved');
 
 console.log('Foundups\u00aeAgent extension contract checks passed.');


### PR DESCRIPTION
## REDDOG_SEMANTIC_GROUNDING_PER_TARGET_PROOF_PHASE1

WSP_97 status: VERIFIED_READY draft PR. This slice fixes the typed grounding preflight defect where aggregate `code_hits + wsp_hits > 0` could satisfy every semantic target.

### What changed

- Added per-target `SemanticTargetCoverage` records in `extensions/foundups_advisory_workers/extension.js`.
- Every semantic target now carries:
  - `target`
  - `normalized_query`
  - `verdict`
  - `evidence_refs`
  - `content_bearing_hits`
  - `rejection_reasons`
- Semantic grounding now fails closed when:
  - only one of multiple semantic targets has evidence
  - global unrelated HoloIndex hits exist
  - one target has a backend error
  - a hit has no authoritative evidence ref/location
  - HoloIndex context is absent
- Run Trace now exposes:
  - `semantic_targets_required`
  - `semantic_targets_grounded`
  - `semantic_targets_missing`
  - `semantic_target_coverage_digest`
- Wardrobe grounding receipts carry semantic required/grounded/missing counts and the coverage digest.
- Version bumped to `0.3.66` across live extension surfaces.

### Tests / validation

- `node --check extensions/foundups_advisory_workers/extension.js` -> PASS
- `node extensions/foundups_advisory_workers/tests/verify_extension_contract.js` -> PASS
  - Existing UnicodeEncodeError stderr fixture remains, but node exits 0 and prints the success line.
- `python -m pytest holo_index/tests/test_agentic_rag_baseline_gate.py -q` -> 24 passed
- `python -m pytest scripts/tests/test_advisory_model_once_hardening.py -q` -> 22 passed
- `git diff --check` -> clean
- Added-line byte scan -> 0 non-ASCII

### Focused coverage added

- Two semantic targets with evidence for only one -> FAIL
- Two semantic targets with unrelated global hit -> FAIL
- Each target independently receives sufficient evidence -> PASS
- Backend error for one semantic target -> FAIL
- Ref-less evidence cannot pass
- Explicit repo-file grounding remains unchanged
- External research remains `external_research_retrieval_not_implemented`
- Wardrobe selection runner is not invoked after grounding failure
- Runtime consumption gate blocks a grounding failure result

### Truth boundary

- OBSERVED: per-target semantic proof is enforced before Fusion.
- OBSERVED: wardrobe selection receives the failed grounding receipt and rejects before invoking the selector.
- OBSERVED: runtime consumption remains blocked for `grounding_preflight_blocked`.
- SPECIFIED_NOT_IMPLEMENTED: external research retrieval remains blocked.
- SPECIFIED_NOT_IMPLEMENTED: no runtime execution, OpenClaw enqueue, WRE planning, shell, merge, or live authority is added in this slice.

### Residuals

- HoloIndex still supplies the underlying hit corpus; this slice evaluates per-target coverage from available bundle evidence and does not re-index or mutate HoloIndex.
- External research retrieval remains a future governed retrieval slice.
- Prompt-library draft stack remains untouched.
