### PR TITLE
fix(wre): guard shared main commits from worker cwd pollution

### DIFF
--- a/tools/ModLog.md
+++ b/tools/ModLog.md
@@ -1,0 +1,7 @@
+# Tools ModLog
+
+## 2026-07-13 - WRE_WORKTREE_CWD_HAZARD_GUARD_PHASE1
+
+- Added `tools/hooks/pre_commit_worktree_cwd_guard.py`, a local pre-commit guard that blocks direct commits from the shared `main` checkout unless `FOUNDUPS_ALLOW_SHARED_MAIN_COMMIT=1` is set.
+- Added focused tests for shared-main rejection, explicit override, worker worktrees, Claude worktrees, detached unsafe checkouts, and detached clean build worktrees.
+- Documented that the hook complements existing governed WRE `validate_wre_worker_operation_cwd(...)` checks and cannot intercept raw `git add`.

--- a/tools/hooks/README.md
+++ b/tools/hooks/README.md
@@ -1,0 +1,20 @@
+# Tools Hooks
+
+Repo-local hook helpers for preventing operational mistakes in 0102/WRE work.
+
+## Worktree CWD Guard
+
+`pre_commit_worktree_cwd_guard.py` blocks direct commits from the shared
+`O:/Foundups-Agent` `main` checkout. Worker commits must happen from an isolated
+worktree. Intentional shared-main commits require an explicit override:
+
+```powershell
+$env:FOUNDUPS_ALLOW_SHARED_MAIN_COMMIT = "1"
+git commit ...
+```
+
+The hook is a last-resort protection. Governed WRE work still uses
+`validate_wre_worker_operation_cwd(...)` before worktree, shell, and writer
+operations. Raw `git add` cannot be intercepted by Git hooks, so workers must
+still run from the intended worktree and stage explicit paths only.
+

--- a/tools/hooks/pre_commit_worktree_cwd_guard.py
+++ b/tools/hooks/pre_commit_worktree_cwd_guard.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Pre-commit guard against worker CWD pollution of the shared main checkout.
+
+This hook is intentionally narrow. It does not authorize work; it only blocks
+accidental direct commits from the shared repo checkout and detached integration
+worktrees unless an explicit override is present.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+PASS = "PASS"
+FAIL_SHARED_MAIN_CHECKOUT = "FAIL_SHARED_MAIN_CHECKOUT"
+FAIL_DETACHED_UNSAFE_CHECKOUT = "FAIL_DETACHED_UNSAFE_CHECKOUT"
+FAIL_GIT_CONTEXT = "FAIL_GIT_CONTEXT"
+
+ALLOW_ENV = "FOUNDUPS_ALLOW_SHARED_MAIN_COMMIT"
+SHARED_ROOT_ENV = "FOUNDUPS_SHARED_REPO_ROOT"
+
+WORKTREE_MARKERS = (
+    "/.worktrees/",
+    "/.claude/worktrees/",
+    "/Foundups-Agent-worktrees/",
+    "/tmp/",
+)
+
+
+@dataclass(frozen=True)
+class WorktreeCwdGuardDecision:
+    ok: bool
+    code: str
+    reason: str
+    repo_root: str
+    shared_repo_root: str
+    branch: str
+
+
+def _normalize(path: Path | str) -> str:
+    return str(Path(path).resolve()).replace("\\", "/")
+
+
+def _run_git(args: Iterable[str], cwd: Optional[Path] = None) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd) if cwd is not None else None,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError((proc.stderr or proc.stdout or "git command failed").strip())
+    return proc.stdout.strip()
+
+
+def _is_marked_worker_tree(repo_root: str) -> bool:
+    root = repo_root.replace("\\", "/")
+    return any(marker in root for marker in WORKTREE_MARKERS)
+
+
+def evaluate_pre_commit_cwd(
+    *,
+    repo_root: Path | str,
+    shared_repo_root: Path | str,
+    branch: str,
+    allow_override: bool = False,
+) -> WorktreeCwdGuardDecision:
+    repo = _normalize(repo_root)
+    shared = _normalize(shared_repo_root)
+    current_branch = str(branch or "").strip()
+
+    if allow_override:
+        return WorktreeCwdGuardDecision(
+            ok=True,
+            code=PASS,
+            reason="explicit shared-main override present",
+            repo_root=repo,
+            shared_repo_root=shared,
+            branch=current_branch or "(detached)",
+        )
+
+    if repo == shared and current_branch == "main":
+        return WorktreeCwdGuardDecision(
+            ok=False,
+            code=FAIL_SHARED_MAIN_CHECKOUT,
+            reason=(
+                "direct commit from the shared main checkout is blocked; use an "
+                "isolated worktree or set FOUNDUPS_ALLOW_SHARED_MAIN_COMMIT=1"
+            ),
+            repo_root=repo,
+            shared_repo_root=shared,
+            branch=current_branch,
+        )
+
+    if not current_branch and not _is_marked_worker_tree(repo):
+        return WorktreeCwdGuardDecision(
+            ok=False,
+            code=FAIL_DETACHED_UNSAFE_CHECKOUT,
+            reason=(
+                "detached checkout is not a marked worker/build worktree; use an "
+                "isolated branch worktree or set FOUNDUPS_ALLOW_SHARED_MAIN_COMMIT=1"
+            ),
+            repo_root=repo,
+            shared_repo_root=shared,
+            branch="(detached)",
+        )
+
+    return WorktreeCwdGuardDecision(
+        ok=True,
+        code=PASS,
+        reason="commit cwd is not the shared main checkout",
+        repo_root=repo,
+        shared_repo_root=shared,
+        branch=current_branch or "(detached)",
+    )
+
+
+def current_git_decision(cwd: Optional[Path] = None) -> WorktreeCwdGuardDecision:
+    try:
+        repo_root = Path(_run_git(["rev-parse", "--show-toplevel"], cwd=cwd))
+        branch = _run_git(["branch", "--show-current"], cwd=cwd)
+    except Exception as exc:  # pragma: no cover - exercised through CLI behavior.
+        return WorktreeCwdGuardDecision(
+            ok=False,
+            code=FAIL_GIT_CONTEXT,
+            reason=f"could not resolve git context: {type(exc).__name__}",
+            repo_root="",
+            shared_repo_root="",
+            branch="",
+        )
+
+    shared_root = Path(os.environ.get(SHARED_ROOT_ENV, "O:/Foundups-Agent"))
+    return evaluate_pre_commit_cwd(
+        repo_root=repo_root,
+        shared_repo_root=shared_root,
+        branch=branch,
+        allow_override=os.environ.get(ALLOW_ENV) == "1",
+    )
+
+
+def main() -> int:
+    decision = current_git_decision()
+    if decision.ok:
+        return 0
+    sys.stderr.write(
+        "\n".join(
+            [
+                f"[WRE-CWD-GUARD] {decision.code}: {decision.reason}",
+                f"[WRE-CWD-GUARD] repo_root={decision.repo_root or 'unknown'}",
+                f"[WRE-CWD-GUARD] shared_repo_root={decision.shared_repo_root or 'unknown'}",
+                f"[WRE-CWD-GUARD] branch={decision.branch or 'unknown'}",
+            ]
+        )
+        + "\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/tools/hooks/tests/test_pre_commit_worktree_cwd_guard.py
+++ b/tools/hooks/tests/test_pre_commit_worktree_cwd_guard.py
@@ -1,0 +1,104 @@
+"""Tests for the shared-main pre-commit cwd guard."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.hooks.pre_commit_worktree_cwd_guard import (
+    FAIL_DETACHED_UNSAFE_CHECKOUT,
+    FAIL_SHARED_MAIN_CHECKOUT,
+    PASS,
+    evaluate_pre_commit_cwd,
+)
+
+
+def test_blocks_shared_main_checkout(tmp_path: Path) -> None:
+    shared = tmp_path / "Foundups-Agent"
+    shared.mkdir()
+
+    decision = evaluate_pre_commit_cwd(
+        repo_root=shared,
+        shared_repo_root=shared,
+        branch="main",
+    )
+
+    assert decision.ok is False
+    assert decision.code == FAIL_SHARED_MAIN_CHECKOUT
+
+
+def test_override_allows_shared_main_checkout(tmp_path: Path) -> None:
+    shared = tmp_path / "Foundups-Agent"
+    shared.mkdir()
+
+    decision = evaluate_pre_commit_cwd(
+        repo_root=shared,
+        shared_repo_root=shared,
+        branch="main",
+        allow_override=True,
+    )
+
+    assert decision.ok is True
+    assert decision.code == PASS
+
+
+def test_allows_feature_worktree_under_repo_worktrees(tmp_path: Path) -> None:
+    shared = tmp_path / "Foundups-Agent"
+    worker = shared / ".worktrees" / "feature-x"
+    worker.mkdir(parents=True)
+
+    decision = evaluate_pre_commit_cwd(
+        repo_root=worker,
+        shared_repo_root=shared,
+        branch="feat/example",
+    )
+
+    assert decision.ok is True
+    assert decision.code == PASS
+
+
+def test_allows_claude_agent_worktree(tmp_path: Path) -> None:
+    shared = tmp_path / "Foundups-Agent"
+    worker = shared / ".claude" / "worktrees" / "agent-123"
+    worker.mkdir(parents=True)
+
+    decision = evaluate_pre_commit_cwd(
+        repo_root=worker,
+        shared_repo_root=shared,
+        branch="worktree-agent-123",
+    )
+
+    assert decision.ok is True
+    assert decision.code == PASS
+
+
+def test_blocks_unmarked_detached_checkout(tmp_path: Path) -> None:
+    shared = tmp_path / "Foundups-Agent"
+    detached = tmp_path / "detached-copy"
+    shared.mkdir()
+    detached.mkdir()
+
+    decision = evaluate_pre_commit_cwd(
+        repo_root=detached,
+        shared_repo_root=shared,
+        branch="",
+    )
+
+    assert decision.ok is False
+    assert decision.code == FAIL_DETACHED_UNSAFE_CHECKOUT
+
+
+def test_allows_detached_clean_build_worktree(tmp_path: Path) -> None:
+    shared = tmp_path / "Foundups-Agent"
+    build = shared / ".worktrees" / "reddog-build"
+    shared.mkdir()
+    build.mkdir(parents=True)
+
+    decision = evaluate_pre_commit_cwd(
+        repo_root=build,
+        shared_repo_root=shared,
+        branch="",
+    )
+
+    assert decision.ok is True
+    assert decision.code == PASS
+


### PR DESCRIPTION
## WRE_WORKTREE_CWD_HAZARD_GUARD_PHASE1

WSP_97 status: VERIFIED_READY. This slice adds a repo-local pre-commit guard for the operational hazard where worker git commands accidentally target the shared `main` checkout.

### What changed

- Added `tools/hooks/pre_commit_worktree_cwd_guard.py`.
- Added `tools/hooks/tests/test_pre_commit_worktree_cwd_guard.py`.
- Added `tools/hooks/README.md` with install/override notes.
- Initialized `tools/ModLog.md` with the guard slice entry.

### Guard behavior

- Blocks commits from the shared `main` checkout unless `FOUNDUPS_ALLOW_SHARED_MAIN_COMMIT=1` is set.
- Allows feature branches in marked worker worktrees such as `.worktrees/` and `.claude/worktrees/`.
- Allows detached clean build worktrees under `.worktrees/`.
- Blocks unmarked detached checkouts.
- Does not claim to intercept raw `git add`; Git hooks cannot do that. This is a final commit gate plus the existing WRE runtime cwd guard.

### Existing governed WRE guard status

OBSERVED on `origin/main`: `validate_wre_worker_operation_cwd(...)` is already used by:

- `reddog_wre_worktree_create.py`
- `reddog_wre_worktree_runner.py`
- `reddog_wre_governed_shell_runner_dryrun.py`
- `reddog_generic_agent_worktree_writer_dryrun.py`
- `modules/foundups/agent/src/worktree_pr_runner.py`

This slice covers the remaining local hook/harness layer for accidental shared-main commits.

### Validation

- `python -m pytest tools/hooks/tests/test_pre_commit_worktree_cwd_guard.py -q` -> 6 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_cwd_guard.py modules/communication/moltbot_bridge/tests/test_reddog_wre_worktree_create.py modules/communication/moltbot_bridge/tests/test_reddog_wre_governed_shell_runner_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_generic_agent_worktree_writer_dryrun.py -q` -> 67 passed
- `git diff --check` -> clean
- Added-line non-ASCII scan -> 0

### Residuals

- Raw `git add` cannot be intercepted by a Git hook. Future RedDog/WRE shell paths must continue to use the governed shell runner and isolated worktree cwd guard.
- Local hook installation is an operator/workspace action; this PR provides the tracked guard script and tests.
