### PR TITLE
feat(reddog): signer delegated authority runtime

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,13 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_SIGNER_AND_DELEGATED_AUTHORITY_RUNTIME_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 71, 96, 97, 100
+
+- Added `src/reddog_signer_delegated_authority_runtime.py`: runtime authority producer that validates a token-verified principal record, fresh permission snapshot, scoped FoundUp paths, nonce uniqueness, revocation state, and high-authority co-sign evidence before requesting principal + RedDog signatures from an injected isolated signer client.
+- Added `tests/test_reddog_signer_delegated_authority_runtime.py`: verifier-compatible happy path, default signer fail-closed, unknown principal, high-authority co-sign requirement, low-authority autonomous issuance, stale/insufficient snapshot rejection, scope/path rejection, nonce replay, revocation, signer-boundary attestation, JSON durability, no-signing-material evidence, and AST no-execution/no-crypto/no-runtime-wiring coverage.
+- Boundary: no key generation, no crypto/signing library, no vault access, no shell/subprocess/network, no extension runtime wiring, no OpenClaw/Hermes enqueue, no worker spawn, no HoloIndex mutation/re-index, and no execution. Production defaults fail closed unless an isolated signer and verified principal resolver are injected.
+
 ## 2026-07-14: REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH_RUNTIME_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 60, 70, 97

--- a/modules/communication/moltbot_bridge/src/reddog_signer_delegated_authority_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_delegated_authority_runtime.py
@@ -1,0 +1,716 @@
+"""RedDog signer and delegated-authority runtime.
+
+This module produces signed RedDogPrincipalIdentity and
+RedDogDelegatedWorkAuthority records through injected boundaries only. It does
+not implement cryptography, generate keys, load vault secrets, execute work,
+enqueue OpenClaw, invoke Hermes, mutate HoloIndex, or call the extension
+runtime. The default signer and principal resolver fail closed.
+
+The purpose is to bridge the gap after the E0/E1 contracts:
+
+* E0 specified the isolated signer boundary.
+* E1 verifies signed work authority.
+* This module prepares authority records by validating scope, freshness,
+  revocation, nonce uniqueness, and high-authority co-sign evidence before
+  requesting signatures from an injected signer client.
+
+The signer response is treated as authority only when it carries the boundary
+attestations required by E0. All emitted receipts are evidence for later gates;
+they do not execute work by themselves.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional, Protocol, Sequence, Tuple
+
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    PermissionSnapshot,
+    PermissionSnapshotResolver,
+    PREFIX_IDENTITY,
+    PREFIX_WORKAUTH,
+    canonical_signing_input,
+)
+
+
+AUTHORITY_ISSUED = "DELEGATED_AUTHORITY_ISSUED"
+AUTHORITY_REJECTED = "DELEGATED_AUTHORITY_REJECTED"
+AUTHORITY_SCHEMA_VERSION = "reddog_delegated_authority_runtime.v1"
+
+LOW_AUTHORITY_TIER = "LOW"
+HIGH_AUTHORITY_TIER = "HIGH"
+
+HIGH_AUTHORITY_OPERATIONS = frozenset(
+    {
+        "create_foundup",
+        "live_enqueue",
+        "worktree_create",
+        "write_repo",
+        "run_shell",
+        "publish_draft_pr",
+        "merge_pr",
+        "promote",
+        "manage_permissions",
+        "delete_repo",
+        "force_push",
+    }
+)
+
+_FOUNDUP_PATH_PREFIX = "modules/foundups/"
+
+
+class RuntimeRejectCode:
+    MALFORMED_REQUEST = "REJECT_MALFORMED_REQUEST"
+    NON_ASCII = "REJECT_NON_ASCII_FIELD"
+    PRINCIPAL_NOT_VERIFIED = "REJECT_PRINCIPAL_NOT_VERIFIED"
+    PRINCIPAL_KEY_MISMATCH = "REJECT_PRINCIPAL_KEY_MISMATCH"
+    SCOPE_EXCEEDED = "REJECT_SCOPE_EXCEEDED"
+    SNAPSHOT_STALE_OR_MISSING = "REJECT_SNAPSHOT_STALE_OR_MISSING"
+    SNAPSHOT_DIGEST_MISMATCH = "REJECT_SNAPSHOT_DIGEST_MISMATCH"
+    SNAPSHOT_INSUFFICIENT = "REJECT_SNAPSHOT_DOES_NOT_GRANT_OP"
+    PATH_OUT_OF_SCOPE = "REJECT_PATH_OUT_OF_FOUNDUP_SCOPE"
+    NONCE_REPLAY = "REJECT_NONCE_REPLAY"
+    REVOKED = "REJECT_REVOKED"
+    HIGH_AUTHORITY_NEEDS_COSIGN = "REJECT_HIGH_AUTHORITY_NEEDS_COSIGN"
+    SIGNER_NOT_CONFIGURED = "REJECT_SIGNER_NOT_CONFIGURED"
+    SIGNER_BOUNDARY_NOT_ATTESTED = "REJECT_SIGNER_BOUNDARY_NOT_ATTESTED"
+    SIGNER_KEY_MISMATCH = "REJECT_SIGNER_KEY_MISMATCH"
+    SIGNER_RESPONSE_INVALID = "REJECT_SIGNER_RESPONSE_INVALID"
+    STORE_COMMIT_FAILED = "REJECT_STORE_COMMIT_FAILED"
+
+
+def _is_ascii(value: Any) -> bool:
+    return isinstance(value, str) and all(ord(char) < 128 for char in value)
+
+
+def _assert_ascii_deep(value: Any) -> bool:
+    if isinstance(value, str):
+        return _is_ascii(value)
+    if isinstance(value, Mapping):
+        return all(_is_ascii(key) and _assert_ascii_deep(item) for key, item in value.items())
+    if isinstance(value, (list, tuple)):
+        return all(_assert_ascii_deep(item) for item in value)
+    return True
+
+
+def _canonical_digest(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def public_key_fingerprint(public_key: str) -> str:
+    """Derive a public-only fingerprint. Never pass signing material here."""
+
+    if not _is_ascii(public_key):
+        raise ValueError("public key must be ASCII")
+    return "sha256:" + hashlib.sha256(public_key.encode("utf-8")).hexdigest()
+
+
+def _path_within_foundup(path: str, foundup_id: str) -> bool:
+    if not isinstance(path, str) or not path or not _is_ascii(path):
+        return False
+    if "\x00" in path or "\\" in path or ":" in path or path.startswith("/"):
+        return False
+    if path.startswith("//?/") or path.startswith("//./"):
+        return False
+    prefix = f"{_FOUNDUP_PATH_PREFIX}{foundup_id}/"
+    if not path.startswith(prefix):
+        return False
+    for segment in path.split("/"):
+        if segment.strip(" \t") == ".." or segment.strip(" .\t") == "":
+            return False
+    return True
+
+
+@dataclass(frozen=True)
+class PrincipalAuthorityRecord:
+    """Token-verified principal basis supplied by an external resolver."""
+
+    principal_id: str
+    principal_provider: str
+    principal_public_key: str
+    repo_scope: Tuple[str, ...]
+    foundup_scope: Tuple[str, ...]
+    verified_subject_digest: str
+    reward_account: Optional[str] = None
+    owner_dae: Optional[str] = None
+    principal_wallet: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class PrincipalAuthorityResolver(Protocol):
+    def resolve(self, principal_id: str, principal_provider: str) -> Optional[PrincipalAuthorityRecord]:
+        """Return token-verified principal authority, or None to fail closed."""
+
+
+class FailClosedPrincipalAuthorityResolver:
+    def resolve(self, principal_id: str, principal_provider: str) -> Optional[PrincipalAuthorityRecord]:
+        return None
+
+
+@dataclass(frozen=True)
+class SigningRequest:
+    """Request sent to an isolated signer. The body id is audit-only."""
+
+    signing_input: str
+    payload_digest: str
+    signer_role: str
+    signer_public_key: str
+    requester_principal_id: str
+    nonce: str
+    key_epoch: str
+    requested_operation: str
+    authority_tier: str
+    consensus_receipt_digest: Optional[str]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class SigningResponse:
+    """Response from an isolated signer. It must not include signing material."""
+
+    accepted: bool
+    signature: str = ""
+    signer_public_key: str = ""
+    key_fingerprint: str = ""
+    key_epoch: str = ""
+    audit_mac: str = ""
+    rejection_code: str = ""
+    boundary_attested: bool = False
+    requester_identity_attested: bool = False
+    signer_loads_no_untrusted_code: bool = False
+    no_secret_material_returned: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class IsolatedSignerClient(Protocol):
+    def sign(self, request: SigningRequest) -> SigningResponse:
+        """Return a signature over request.signing_input, or reject fail-closed."""
+
+
+class FailClosedSignerClient:
+    def sign(self, request: SigningRequest) -> SigningResponse:
+        return SigningResponse(
+            accepted=False,
+            rejection_code=RuntimeRejectCode.SIGNER_NOT_CONFIGURED,
+            no_secret_material_returned=True,
+        )
+
+
+class AuthorityRuntimeStore(Protocol):
+    def load(self) -> Dict[str, Any]:
+        """Return the current runtime state snapshot."""
+
+    def commit(self, snapshot: Mapping[str, Any], *, expected_revision: Optional[str]) -> str:
+        """Atomically commit snapshot and return the committed revision."""
+
+
+class InMemoryAuthorityRuntimeStore:
+    """In-memory optimistic store for tests and local dry runtime composition."""
+
+    def __init__(self, initial: Optional[Mapping[str, Any]] = None, *, fail_commit: bool = False) -> None:
+        self._state: Dict[str, Any] = dict(initial or {})
+        self.fail_commit = fail_commit
+
+    def load(self) -> Dict[str, Any]:
+        return json.loads(json.dumps(self._state, sort_keys=True))
+
+    def commit(self, snapshot: Mapping[str, Any], *, expected_revision: Optional[str]) -> str:
+        if self.fail_commit:
+            raise RuntimeError("commit_failed")
+        if self._state.get("revision") != expected_revision:
+            raise RuntimeError("revision_conflict")
+        committed = json.loads(json.dumps(snapshot, sort_keys=True))
+        revision = _canonical_digest(committed)
+        committed["revision"] = revision
+        self._state = committed
+        return revision
+
+
+class AtomicJsonAuthorityRuntimeStore:
+    """Single-file authority store using atomic replace."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+
+    def load(self) -> Dict[str, Any]:
+        if not self.path.exists():
+            return {}
+        return json.loads(self.path.read_text(encoding="utf-8"))
+
+    def commit(self, snapshot: Mapping[str, Any], *, expected_revision: Optional[str]) -> str:
+        current = self.load()
+        if current.get("revision") != expected_revision:
+            raise RuntimeError("revision_conflict")
+        committed = json.loads(json.dumps(snapshot, sort_keys=True))
+        revision = _canonical_digest(committed)
+        committed["revision"] = revision
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(prefix=f".{self.path.name}.", suffix=".tmp", dir=str(self.path.parent))
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+                json.dump(committed, handle, sort_keys=True, indent=2)
+                handle.write("\n")
+            os.replace(tmp_name, self.path)
+        finally:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
+        return revision
+
+
+@dataclass(frozen=True)
+class DelegatedAuthorityRuntimeRequest:
+    work_order_id: str
+    principal_id: str
+    principal_provider: str
+    principal_public_key: str
+    reddog_id: str
+    reddog_public_key: str
+    repo_full_name: str
+    foundup_id: str
+    allowed_paths: Tuple[str, ...]
+    denied_paths: Tuple[str, ...]
+    requested_operation: str
+    permission_snapshot_digest: str
+    identity_nonce: str
+    work_authority_nonce: str
+    issued_at: int
+    identity_expires_at: int
+    work_authority_expires_at: int
+    valve_state_required: str
+    key_epoch: str
+    consensus_receipt_digest: Optional[str] = None
+    sovereign_authorization_digest: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DelegatedAuthorityRuntimeReceipt:
+    receipt_id: str
+    status: str
+    generated_at: int
+    work_order_id: Optional[str]
+    principal_id: Optional[str]
+    reddog_id: Optional[str]
+    identity_digest: Optional[str]
+    work_authority_digest: Optional[str]
+    store_revision: Optional[str]
+    signer_audit_macs: Tuple[str, ...]
+    rejection_reasons: Tuple[str, ...]
+    no_signing_material_observed: bool = True
+    no_execution_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_holoindex_mutation_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DelegatedAuthorityRuntimeResult:
+    accepted: bool
+    receipt: DelegatedAuthorityRuntimeReceipt
+    identity: Optional[Dict[str, Any]] = None
+    work_authority: Optional[Dict[str, Any]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "accepted": self.accepted,
+            "receipt": self.receipt.to_dict(),
+            "identity": self.identity,
+            "work_authority": self.work_authority,
+        }
+
+
+def _rejection_result(
+    *,
+    now: int,
+    request: Optional[DelegatedAuthorityRuntimeRequest],
+    reasons: Sequence[str],
+) -> DelegatedAuthorityRuntimeResult:
+    payload = {
+        "status": AUTHORITY_REJECTED,
+        "work_order_id": request.work_order_id if request else None,
+        "reasons": list(reasons),
+        "generated_at": now,
+    }
+    receipt = DelegatedAuthorityRuntimeReceipt(
+        receipt_id="authority-runtime-" + _canonical_digest(payload)[:16],
+        status=AUTHORITY_REJECTED,
+        generated_at=now,
+        work_order_id=request.work_order_id if request else None,
+        principal_id=request.principal_id if request else None,
+        reddog_id=request.reddog_id if request else None,
+        identity_digest=None,
+        work_authority_digest=None,
+        store_revision=None,
+        signer_audit_macs=(),
+        rejection_reasons=tuple(reasons),
+    )
+    return DelegatedAuthorityRuntimeResult(accepted=False, receipt=receipt)
+
+
+def _snapshot_fresh(snapshot: PermissionSnapshot, *, now: int, leeway_s: int) -> bool:
+    try:
+        return snapshot.is_fresh(now, leeway_s)
+    except Exception:
+        return False
+
+
+def _store_nonce_used(state: Mapping[str, Any], nonce: str) -> bool:
+    nonces = state.get("nonces", {})
+    if not isinstance(nonces, Mapping):
+        return False
+    identity_nonces = set(map(str, nonces.get("identity", [])))
+    work_nonces = set(map(str, nonces.get("work_authority", [])))
+    return nonce in identity_nonces or nonce in work_nonces
+
+
+def _store_revoked(
+    state: Mapping[str, Any],
+    *,
+    principal_id: str,
+    reddog_id: str,
+    reddog_fingerprint: str,
+    key_epoch: str,
+) -> bool:
+    revocations = state.get("revocations", {})
+    if not isinstance(revocations, Mapping):
+        return False
+    return (
+        principal_id in set(map(str, revocations.get("principal_ids", [])))
+        or reddog_id in set(map(str, revocations.get("reddog_ids", [])))
+        or reddog_fingerprint in set(map(str, revocations.get("reddog_fingerprints", [])))
+        or key_epoch in set(map(str, revocations.get("key_epochs", [])))
+    )
+
+
+def _validate_signing_response(
+    response: SigningResponse,
+    *,
+    expected_public_key: str,
+    expected_fingerprint: str,
+    expected_key_epoch: str,
+) -> Optional[str]:
+    if not response.accepted:
+        return response.rejection_code or RuntimeRejectCode.SIGNER_NOT_CONFIGURED
+    if not response.signature or not _is_ascii(response.signature):
+        return RuntimeRejectCode.SIGNER_RESPONSE_INVALID
+    if response.signer_public_key != expected_public_key:
+        return RuntimeRejectCode.SIGNER_KEY_MISMATCH
+    if response.key_fingerprint != expected_fingerprint or response.key_epoch != expected_key_epoch:
+        return RuntimeRejectCode.SIGNER_KEY_MISMATCH
+    if not (
+        response.boundary_attested
+        and response.requester_identity_attested
+        and response.signer_loads_no_untrusted_code
+        and response.no_secret_material_returned
+    ):
+        return RuntimeRejectCode.SIGNER_BOUNDARY_NOT_ATTESTED
+    if not response.audit_mac or not _is_ascii(response.audit_mac):
+        return RuntimeRejectCode.SIGNER_RESPONSE_INVALID
+    return None
+
+
+def _append_unique(items: Sequence[str], item: str) -> Tuple[str, ...]:
+    seen = list(map(str, items))
+    if item not in seen:
+        seen.append(item)
+    return tuple(seen)
+
+
+def _commit_issued_authority(
+    store: AuthorityRuntimeStore,
+    *,
+    request: DelegatedAuthorityRuntimeRequest,
+    identity_digest: str,
+    work_authority_digest: str,
+    receipt_id: str,
+) -> str:
+    current = store.load()
+    expected_revision = current.get("revision")
+    nonces = current.get("nonces") if isinstance(current.get("nonces"), Mapping) else {}
+    identity_nonces = tuple(map(str, nonces.get("identity", [])))
+    work_nonces = tuple(map(str, nonces.get("work_authority", [])))
+    issued = current.get("issued_authorities") if isinstance(current.get("issued_authorities"), Mapping) else {}
+    if request.work_order_id in issued:
+        raise RuntimeError("duplicate_work_order")
+    next_state = json.loads(json.dumps(current, sort_keys=True))
+    next_state.setdefault("schema_version", AUTHORITY_SCHEMA_VERSION)
+    next_state["nonces"] = {
+        "identity": list(_append_unique(identity_nonces, request.identity_nonce)),
+        "work_authority": list(_append_unique(work_nonces, request.work_authority_nonce)),
+    }
+    issued_next = dict(issued)
+    issued_next[request.work_order_id] = {
+        "receipt_id": receipt_id,
+        "identity_digest": identity_digest,
+        "work_authority_digest": work_authority_digest,
+        "principal_id": request.principal_id,
+        "reddog_id": request.reddog_id,
+        "foundup_id": request.foundup_id,
+        "repo_full_name": request.repo_full_name,
+        "status": AUTHORITY_ISSUED,
+    }
+    next_state["issued_authorities"] = issued_next
+    return store.commit(next_state, expected_revision=expected_revision)
+
+
+def issue_delegated_authority_runtime(
+    *,
+    request: DelegatedAuthorityRuntimeRequest,
+    store: AuthorityRuntimeStore,
+    signer: Optional[IsolatedSignerClient] = None,
+    principal_resolver: Optional[PrincipalAuthorityResolver] = None,
+    snapshot_resolver: PermissionSnapshotResolver,
+    now: int,
+    leeway_s: int = 60,
+) -> DelegatedAuthorityRuntimeResult:
+    """Issue signed authority records through an injected isolated signer.
+
+    The function performs no execution. It writes only the issued-authority
+    receipt and nonce reservation through the provided store after both signing
+    responses pass the E0 boundary-attestation checks.
+    """
+
+    signer_client = signer or FailClosedSignerClient()
+    principal_lookup = principal_resolver or FailClosedPrincipalAuthorityResolver()
+
+    if not isinstance(request, DelegatedAuthorityRuntimeRequest):
+        return _rejection_result(now=now, request=None, reasons=[RuntimeRejectCode.MALFORMED_REQUEST])
+    if not _assert_ascii_deep(request.to_dict()):
+        return _rejection_result(now=now, request=request, reasons=[RuntimeRejectCode.NON_ASCII])
+    if request.issued_at > now + leeway_s:
+        return _rejection_result(now=now, request=request, reasons=[RuntimeRejectCode.MALFORMED_REQUEST])
+    if request.identity_expires_at <= now or request.work_authority_expires_at <= now:
+        return _rejection_result(now=now, request=request, reasons=[RuntimeRejectCode.MALFORMED_REQUEST])
+    if request.principal_public_key == request.reddog_public_key:
+        return _rejection_result(now=now, request=request, reasons=[RuntimeRejectCode.PRINCIPAL_KEY_MISMATCH])
+
+    try:
+        principal = principal_lookup.resolve(request.principal_id, request.principal_provider)
+    except Exception:
+        principal = None
+    if principal is None:
+        return _rejection_result(now=now, request=request, reasons=[RuntimeRejectCode.PRINCIPAL_NOT_VERIFIED])
+    if principal.principal_public_key != request.principal_public_key:
+        return _rejection_result(now=now, request=request, reasons=[RuntimeRejectCode.PRINCIPAL_KEY_MISMATCH])
+    repo_out = request.repo_full_name not in set(principal.repo_scope)
+    foundup_out = request.foundup_id not in set(principal.foundup_scope)
+    if repo_out or foundup_out:
+        return _rejection_result(now=now, request=request, reasons=[RuntimeRejectCode.SCOPE_EXCEEDED])
+
+    try:
+        snapshot = snapshot_resolver.resolve(request.permission_snapshot_digest)
+    except Exception:
+        snapshot = None
+    if snapshot is None or not _snapshot_fresh(snapshot, now=now, leeway_s=leeway_s):
+        return _rejection_result(now=now, request=request, reasons=[RuntimeRejectCode.SNAPSHOT_STALE_OR_MISSING])
+    if snapshot.evidence_digest != request.permission_snapshot_digest:
+        return _rejection_result(now=now, request=request, reasons=[RuntimeRejectCode.SNAPSHOT_DIGEST_MISMATCH])
+    if not snapshot.grants(request.requested_operation, request.repo_full_name):
+        return _rejection_result(now=now, request=request, reasons=[RuntimeRejectCode.SNAPSHOT_INSUFFICIENT])
+
+    effective_paths = set(request.allowed_paths) - set(request.denied_paths)
+    if not effective_paths or not all(_path_within_foundup(path, request.foundup_id) for path in effective_paths):
+        return _rejection_result(now=now, request=request, reasons=[RuntimeRejectCode.PATH_OUT_OF_SCOPE])
+
+    authority_tier = (
+        HIGH_AUTHORITY_TIER
+        if request.requested_operation in HIGH_AUTHORITY_OPERATIONS
+        else LOW_AUTHORITY_TIER
+    )
+    if authority_tier == HIGH_AUTHORITY_TIER and not (
+        request.consensus_receipt_digest and request.sovereign_authorization_digest
+    ):
+        return _rejection_result(
+            now=now,
+            request=request,
+            reasons=[RuntimeRejectCode.HIGH_AUTHORITY_NEEDS_COSIGN],
+        )
+
+    state = store.load()
+    if _store_nonce_used(state, request.identity_nonce) or _store_nonce_used(state, request.work_authority_nonce):
+        return _rejection_result(now=now, request=request, reasons=[RuntimeRejectCode.NONCE_REPLAY])
+
+    reddog_fingerprint = public_key_fingerprint(request.reddog_public_key)
+    principal_fingerprint = public_key_fingerprint(request.principal_public_key)
+    if _store_revoked(
+        state,
+        principal_id=request.principal_id,
+        reddog_id=request.reddog_id,
+        reddog_fingerprint=reddog_fingerprint,
+        key_epoch=request.key_epoch,
+    ):
+        return _rejection_result(now=now, request=request, reasons=[RuntimeRejectCode.REVOKED])
+
+    identity = {
+        "principal_id": request.principal_id,
+        "principal_provider": request.principal_provider,
+        "principal_public_key": request.principal_public_key,
+        "principal_key_fingerprint": principal_fingerprint,
+        "principal_wallet": principal.principal_wallet,
+        "reddog_id": request.reddog_id,
+        "reddog_public_key": request.reddog_public_key,
+        "reddog_key_fingerprint": reddog_fingerprint,
+        "repo_scope": list(principal.repo_scope),
+        "foundup_scope": list(principal.foundup_scope),
+        "reward_account": principal.reward_account,
+        "owner_dae": principal.owner_dae,
+        "revocation_policy": {
+            "ttl_seconds": max(0, request.identity_expires_at - request.issued_at),
+            "allowlist_bound": True,
+            "kill_switch_ref": f"reddog_revocation:{request.reddog_id}",
+        },
+        "identity_nonce": request.identity_nonce,
+        "issued_at": request.issued_at,
+        "expires_at": request.identity_expires_at,
+    }
+    identity_input = canonical_signing_input(identity, PREFIX_IDENTITY)
+    identity_sign = signer_client.sign(
+        SigningRequest(
+            signing_input=identity_input,
+            payload_digest="sha256:" + _canonical_digest({"signing_input": identity_input}),
+            signer_role="principal",
+            signer_public_key=request.principal_public_key,
+            requester_principal_id=request.principal_id,
+            nonce=request.identity_nonce,
+            key_epoch=request.key_epoch,
+            requested_operation="delegate_reddog_identity",
+            authority_tier=authority_tier,
+            consensus_receipt_digest=request.consensus_receipt_digest,
+        )
+    )
+    reject = _validate_signing_response(
+        identity_sign,
+        expected_public_key=request.principal_public_key,
+        expected_fingerprint=principal_fingerprint,
+        expected_key_epoch=request.key_epoch,
+    )
+    if reject:
+        return _rejection_result(now=now, request=request, reasons=[reject])
+    identity["signature"] = identity_sign.signature
+
+    work_authority = {
+        "work_order_id": request.work_order_id,
+        "principal_id": request.principal_id,
+        "reddog_id": request.reddog_id,
+        "repo_full_name": request.repo_full_name,
+        "foundup_id": request.foundup_id,
+        "allowed_paths": list(request.allowed_paths),
+        "denied_paths": list(request.denied_paths),
+        "requested_operation": request.requested_operation,
+        "permission_snapshot_digest": request.permission_snapshot_digest,
+        "nonce": request.work_authority_nonce,
+        "issued_at": request.issued_at,
+        "expires_at": request.work_authority_expires_at,
+        "valve_state_required": request.valve_state_required,
+        "key_epoch": request.key_epoch,
+        "signer_public_key": request.reddog_public_key,
+        "authority_tier": authority_tier,
+        "consensus_receipt_digest": request.consensus_receipt_digest,
+        "sovereign_authorization_digest": request.sovereign_authorization_digest,
+        "receipt_chain": [],
+    }
+    workauth_input = canonical_signing_input(work_authority, PREFIX_WORKAUTH)
+    workauth_sign = signer_client.sign(
+        SigningRequest(
+            signing_input=workauth_input,
+            payload_digest="sha256:" + _canonical_digest({"signing_input": workauth_input}),
+            signer_role="reddog",
+            signer_public_key=request.reddog_public_key,
+            requester_principal_id=request.principal_id,
+            nonce=request.work_authority_nonce,
+            key_epoch=request.key_epoch,
+            requested_operation=request.requested_operation,
+            authority_tier=authority_tier,
+            consensus_receipt_digest=request.consensus_receipt_digest,
+        )
+    )
+    reject = _validate_signing_response(
+        workauth_sign,
+        expected_public_key=request.reddog_public_key,
+        expected_fingerprint=reddog_fingerprint,
+        expected_key_epoch=request.key_epoch,
+    )
+    if reject:
+        return _rejection_result(now=now, request=request, reasons=[reject])
+    work_authority["signature"] = workauth_sign.signature
+
+    identity_digest = "sha256:" + _canonical_digest(identity)
+    workauth_digest = "sha256:" + _canonical_digest(work_authority)
+    receipt_payload = {
+        "status": AUTHORITY_ISSUED,
+        "work_order_id": request.work_order_id,
+        "identity_digest": identity_digest,
+        "work_authority_digest": workauth_digest,
+        "generated_at": now,
+    }
+    receipt_id = "authority-runtime-" + _canonical_digest(receipt_payload)[:16]
+    try:
+        revision = _commit_issued_authority(
+            store,
+            request=request,
+            identity_digest=identity_digest,
+            work_authority_digest=workauth_digest,
+            receipt_id=receipt_id,
+        )
+    except Exception:
+        return _rejection_result(now=now, request=request, reasons=[RuntimeRejectCode.STORE_COMMIT_FAILED])
+
+    receipt = DelegatedAuthorityRuntimeReceipt(
+        receipt_id=receipt_id,
+        status=AUTHORITY_ISSUED,
+        generated_at=now,
+        work_order_id=request.work_order_id,
+        principal_id=request.principal_id,
+        reddog_id=request.reddog_id,
+        identity_digest=identity_digest,
+        work_authority_digest=workauth_digest,
+        store_revision=revision,
+        signer_audit_macs=(identity_sign.audit_mac, workauth_sign.audit_mac),
+        rejection_reasons=(),
+    )
+    return DelegatedAuthorityRuntimeResult(
+        accepted=True,
+        receipt=receipt,
+        identity=identity,
+        work_authority=work_authority,
+    )
+
+
+__all__ = [
+    "AUTHORITY_ISSUED",
+    "AUTHORITY_REJECTED",
+    "AUTHORITY_SCHEMA_VERSION",
+    "AtomicJsonAuthorityRuntimeStore",
+    "DelegatedAuthorityRuntimeReceipt",
+    "DelegatedAuthorityRuntimeRequest",
+    "DelegatedAuthorityRuntimeResult",
+    "FailClosedPrincipalAuthorityResolver",
+    "FailClosedSignerClient",
+    "HIGH_AUTHORITY_OPERATIONS",
+    "InMemoryAuthorityRuntimeStore",
+    "IsolatedSignerClient",
+    "PrincipalAuthorityRecord",
+    "PrincipalAuthorityResolver",
+    "RuntimeRejectCode",
+    "SigningRequest",
+    "SigningResponse",
+    "issue_delegated_authority_runtime",
+    "public_key_fingerprint",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_delegated_authority_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_delegated_authority_runtime.py
@@ -1,0 +1,421 @@
+"""Tests for REDDOG_SIGNER_AND_DELEGATED_AUTHORITY_RUNTIME_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import hmac
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src import reddog_signer_delegated_authority_runtime as r
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    AUTHORITY_ISSUED,
+    AtomicJsonAuthorityRuntimeStore,
+    DelegatedAuthorityRuntimeRequest,
+    InMemoryAuthorityRuntimeStore,
+    PrincipalAuthorityRecord,
+    RuntimeRejectCode,
+    SigningResponse,
+    issue_delegated_authority_runtime,
+    public_key_fingerprint,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    InMemoryNonceStore,
+    PermissionSnapshot,
+    PrincipalKeyResolver,
+    RevocationOracle,
+    SignatureVerifier,
+    verify_delegated_work_authority,
+)
+
+_NOW = 1000
+_REPO = "FOUNDUPS/Foundups-Agent"
+_FID = "paccess_001"
+_VALVE = "VALVE_OPEN_WORKTREE_CREATE"
+
+
+class _MockSigner(SignatureVerifier):
+    """Test-only signer/verifier. Production module never signs or imports crypto."""
+
+    def __init__(self) -> None:
+        self._secrets = {
+            "pub:principal": b"test-principal-secret",
+            "pub:reddog": b"test-reddog-secret",
+        }
+        self.requests = []
+
+    def sign(self, request):
+        self.requests.append(request)
+        secret = self._secrets.get(request.signer_public_key)
+        if secret is None:
+            return SigningResponse(
+                accepted=False,
+                rejection_code=RuntimeRejectCode.SIGNER_NOT_CONFIGURED,
+            )
+        signature = hmac.new(secret, request.signing_input.encode("utf-8"), hashlib.sha256).hexdigest()
+        audit = hmac.new(secret, request.payload_digest.encode("utf-8"), hashlib.sha256).hexdigest()
+        return SigningResponse(
+            accepted=True,
+            signature=signature,
+            signer_public_key=request.signer_public_key,
+            key_fingerprint=public_key_fingerprint(request.signer_public_key),
+            key_epoch=request.key_epoch,
+            audit_mac="audit:" + audit,
+            boundary_attested=True,
+            requester_identity_attested=True,
+            signer_loads_no_untrusted_code=True,
+            no_secret_material_returned=True,
+        )
+
+    def verify(self, public_key: str, signing_input: str, signature: str) -> bool:
+        secret = self._secrets.get(public_key)
+        if secret is None or not isinstance(signature, str):
+            return False
+        expected = hmac.new(secret, signing_input.encode("utf-8"), hashlib.sha256).hexdigest()
+        return hmac.compare_digest(expected, signature)
+
+
+class _BoundarylessSigner(_MockSigner):
+    def sign(self, request):
+        response = super().sign(request)
+        return SigningResponse(
+            accepted=response.accepted,
+            signature=response.signature,
+            signer_public_key=response.signer_public_key,
+            key_fingerprint=response.key_fingerprint,
+            key_epoch=response.key_epoch,
+            audit_mac=response.audit_mac,
+            boundary_attested=False,
+            requester_identity_attested=True,
+            signer_loads_no_untrusted_code=True,
+            no_secret_material_returned=True,
+        )
+
+
+class _PrincipalResolver(PrincipalKeyResolver):
+    def __init__(self, record: PrincipalAuthorityRecord) -> None:
+        self.record = record
+
+    def resolve(self, principal_id: str, principal_provider: str):
+        if principal_id == self.record.principal_id and principal_provider == self.record.principal_provider:
+            return self.record
+        return None
+
+
+class _PrincipalKeyResolver(PrincipalKeyResolver):
+    def resolve(self, principal_id: str, principal_provider: str):
+        if principal_id == "github:mjtrout" and principal_provider == "github":
+            return "pub:principal"
+        return None
+
+
+class _SnapshotResolver:
+    def __init__(self, mapping) -> None:
+        self.mapping = mapping
+
+    def resolve(self, digest: str):
+        return self.mapping.get(digest)
+
+
+class _NoRevocation(RevocationOracle):
+    def is_revoked(self, *, reddog_id: str, fingerprint: str, principal_id: str, key_epoch: str) -> bool:
+        return False
+
+
+def _principal() -> PrincipalAuthorityRecord:
+    return PrincipalAuthorityRecord(
+        principal_id="github:mjtrout",
+        principal_provider="github",
+        principal_public_key="pub:principal",
+        repo_scope=(_REPO,),
+        foundup_scope=(_FID,),
+        verified_subject_digest="sha256:verified-subject",
+        reward_account="reward:012",
+        owner_dae="dae:012",
+        principal_wallet=None,
+    )
+
+
+def _request(**overrides) -> DelegatedAuthorityRuntimeRequest:
+    payload = {
+        "work_order_id": "wo-paccess-001",
+        "principal_id": "github:mjtrout",
+        "principal_provider": "github",
+        "principal_public_key": "pub:principal",
+        "reddog_id": "reddog:abc123",
+        "reddog_public_key": "pub:reddog",
+        "repo_full_name": _REPO,
+        "foundup_id": _FID,
+        "allowed_paths": (f"modules/foundups/{_FID}/**",),
+        "denied_paths": (),
+        "requested_operation": "create_foundup",
+        "permission_snapshot_digest": "sha256:snap-1",
+        "identity_nonce": "identity-nonce-0001",
+        "work_authority_nonce": "workauth-nonce-0001",
+        "issued_at": _NOW - 5,
+        "identity_expires_at": _NOW + 3600,
+        "work_authority_expires_at": _NOW + 300,
+        "valve_state_required": _VALVE,
+        "key_epoch": "epoch-1",
+        "consensus_receipt_digest": "sha256:consensus",
+        "sovereign_authorization_digest": "sha256:012-dao-token",
+    }
+    payload.update(overrides)
+    return DelegatedAuthorityRuntimeRequest(**payload)
+
+
+def _snapshot(can_write=True, digest="sha256:snap-1", expires_at=_NOW + 600):
+    return PermissionSnapshot(
+        evidence_digest=digest,
+        expires_at=expires_at,
+        can_write=can_write,
+        can_admin=False,
+        repo_full_name=_REPO,
+    )
+
+
+def _issue(**overrides):
+    request = _request(**overrides)
+    signer = _MockSigner()
+    store = InMemoryAuthorityRuntimeStore()
+    snapshot_resolver = _SnapshotResolver({request.permission_snapshot_digest: _snapshot()})
+    result = issue_delegated_authority_runtime(
+        request=request,
+        store=store,
+        signer=signer,
+        principal_resolver=_PrincipalResolver(_principal()),
+        snapshot_resolver=snapshot_resolver,
+        now=_NOW,
+    )
+    return result, signer, store, snapshot_resolver
+
+
+def test_runtime_issues_records_accepted_by_existing_verifier() -> None:
+    result, signer, _, snapshot_resolver = _issue()
+
+    assert result.accepted is True
+    assert result.receipt.status == AUTHORITY_ISSUED
+    assert result.identity and result.work_authority
+    assert result.receipt.signer_audit_macs and len(result.receipt.signer_audit_macs) == 2
+    assert result.receipt.no_execution_performed is True
+    assert result.receipt.no_openclaw_enqueue_performed is True
+    assert signer.requests[0].signer_role == "principal"
+    assert signer.requests[1].signer_role == "reddog"
+
+    verified = verify_delegated_work_authority(
+        work_authority=result.work_authority,
+        identity=result.identity,
+        signature_verifier=signer,
+        principal_key_resolver=_PrincipalKeyResolver(),
+        nonce_store=InMemoryNonceStore(),
+        snapshot_resolver=snapshot_resolver,
+        revocation_oracle=_NoRevocation(),
+        now=_NOW,
+        required_valve_state=_VALVE,
+    )
+    assert verified.accepted is True, verified.reason_codes
+
+
+def test_default_signer_fails_closed() -> None:
+    request = _request()
+    result = issue_delegated_authority_runtime(
+        request=request,
+        store=InMemoryAuthorityRuntimeStore(),
+        principal_resolver=_PrincipalResolver(_principal()),
+        snapshot_resolver=_SnapshotResolver({request.permission_snapshot_digest: _snapshot()}),
+        now=_NOW,
+    )
+    assert result.accepted is False
+    assert RuntimeRejectCode.SIGNER_NOT_CONFIGURED in result.receipt.rejection_reasons
+
+
+def test_unknown_principal_fails_closed() -> None:
+    request = _request(principal_id="github:attacker")
+    result = issue_delegated_authority_runtime(
+        request=request,
+        store=InMemoryAuthorityRuntimeStore(),
+        signer=_MockSigner(),
+        principal_resolver=_PrincipalResolver(_principal()),
+        snapshot_resolver=_SnapshotResolver({request.permission_snapshot_digest: _snapshot()}),
+        now=_NOW,
+    )
+    assert result.accepted is False
+    assert RuntimeRejectCode.PRINCIPAL_NOT_VERIFIED in result.receipt.rejection_reasons
+
+
+def test_high_authority_requires_consensus_and_sovereign_authorization() -> None:
+    result, _, _, _ = _issue(consensus_receipt_digest=None)
+    assert result.accepted is False
+    assert RuntimeRejectCode.HIGH_AUTHORITY_NEEDS_COSIGN in result.receipt.rejection_reasons
+
+
+def test_low_authority_can_issue_without_cosign() -> None:
+    result, _, _, _ = _issue(
+        requested_operation="inspect_repo",
+        consensus_receipt_digest=None,
+        sovereign_authorization_digest=None,
+    )
+    assert result.accepted is True, result.receipt.rejection_reasons
+    assert result.work_authority["authority_tier"] == "LOW"
+
+
+def test_stale_permission_snapshot_rejects() -> None:
+    request = _request()
+    result = issue_delegated_authority_runtime(
+        request=request,
+        store=InMemoryAuthorityRuntimeStore(),
+        signer=_MockSigner(),
+        principal_resolver=_PrincipalResolver(_principal()),
+        snapshot_resolver=_SnapshotResolver({request.permission_snapshot_digest: _snapshot(expires_at=_NOW - 120)}),
+        now=_NOW,
+    )
+    assert result.accepted is False
+    assert RuntimeRejectCode.SNAPSHOT_STALE_OR_MISSING in result.receipt.rejection_reasons
+
+
+def test_permission_snapshot_must_grant_operation() -> None:
+    request = _request()
+    result = issue_delegated_authority_runtime(
+        request=request,
+        store=InMemoryAuthorityRuntimeStore(),
+        signer=_MockSigner(),
+        principal_resolver=_PrincipalResolver(_principal()),
+        snapshot_resolver=_SnapshotResolver({request.permission_snapshot_digest: _snapshot(can_write=False)}),
+        now=_NOW,
+    )
+    assert result.accepted is False
+    assert RuntimeRejectCode.SNAPSHOT_INSUFFICIENT in result.receipt.rejection_reasons
+
+
+def test_scope_and_path_validation_fail_closed() -> None:
+    result, _, _, _ = _issue(allowed_paths=(".github/workflows/deploy.yml",))
+    assert result.accepted is False
+    assert RuntimeRejectCode.PATH_OUT_OF_SCOPE in result.receipt.rejection_reasons
+
+    result, _, _, _ = _issue(foundup_id="other_002")
+    assert result.accepted is False
+    assert RuntimeRejectCode.SCOPE_EXCEEDED in result.receipt.rejection_reasons
+
+
+def test_nonce_replay_rejects_before_second_issue() -> None:
+    request = _request()
+    store = InMemoryAuthorityRuntimeStore()
+    kwargs = dict(
+        store=store,
+        signer=_MockSigner(),
+        principal_resolver=_PrincipalResolver(_principal()),
+        snapshot_resolver=_SnapshotResolver({request.permission_snapshot_digest: _snapshot()}),
+        now=_NOW,
+    )
+    first = issue_delegated_authority_runtime(request=request, **kwargs)
+    second = issue_delegated_authority_runtime(request=request, **kwargs)
+    assert first.accepted is True
+    assert second.accepted is False
+    assert RuntimeRejectCode.NONCE_REPLAY in second.receipt.rejection_reasons
+
+
+def test_revoked_reddog_or_epoch_rejects() -> None:
+    fingerprint = public_key_fingerprint("pub:reddog")
+    store = InMemoryAuthorityRuntimeStore(
+        {
+            "revocations": {
+                "principal_ids": [],
+                "reddog_ids": [],
+                "reddog_fingerprints": [fingerprint],
+                "key_epochs": [],
+            }
+        }
+    )
+    request = _request()
+    result = issue_delegated_authority_runtime(
+        request=request,
+        store=store,
+        signer=_MockSigner(),
+        principal_resolver=_PrincipalResolver(_principal()),
+        snapshot_resolver=_SnapshotResolver({request.permission_snapshot_digest: _snapshot()}),
+        now=_NOW,
+    )
+    assert result.accepted is False
+    assert RuntimeRejectCode.REVOKED in result.receipt.rejection_reasons
+
+
+def test_signer_boundary_attestation_is_required() -> None:
+    request = _request()
+    result = issue_delegated_authority_runtime(
+        request=request,
+        store=InMemoryAuthorityRuntimeStore(),
+        signer=_BoundarylessSigner(),
+        principal_resolver=_PrincipalResolver(_principal()),
+        snapshot_resolver=_SnapshotResolver({request.permission_snapshot_digest: _snapshot()}),
+        now=_NOW,
+    )
+    assert result.accepted is False
+    assert RuntimeRejectCode.SIGNER_BOUNDARY_NOT_ATTESTED in result.receipt.rejection_reasons
+
+
+def test_json_store_commits_authority_receipt(tmp_path) -> None:
+    request = _request()
+    path = tmp_path / "authority-state.json"
+    result = issue_delegated_authority_runtime(
+        request=request,
+        store=AtomicJsonAuthorityRuntimeStore(path),
+        signer=_MockSigner(),
+        principal_resolver=_PrincipalResolver(_principal()),
+        snapshot_resolver=_SnapshotResolver({request.permission_snapshot_digest: _snapshot()}),
+        now=_NOW,
+    )
+    assert result.accepted is True
+    assert path.exists()
+    content = path.read_text(encoding="utf-8")
+    assert request.work_order_id in content
+    assert result.receipt.store_revision
+
+
+def test_result_contains_no_secret_or_signing_material_labels() -> None:
+    result, _, _, _ = _issue()
+    blob = str(result.to_dict()).lower()
+    assert "test-principal-secret" not in blob
+    assert "test-reddog-secret" not in blob
+    assert "private_key" not in blob
+    assert result.receipt.no_signing_material_observed is True
+
+
+def test_ast_denies_execution_crypto_keygen_network_and_runtime_wiring() -> None:
+    src = Path(r.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported |= {alias.name.split(".")[0] for alias in node.names}
+        elif isinstance(node, ast.ImportFrom):
+            imported.add((node.module or "").split(".")[0])
+    forbidden_imports = {
+        "subprocess",
+        "socket",
+        "requests",
+        "urllib",
+        "cryptography",
+        "nacl",
+        "ecdsa",
+        "web3",
+        "eth_account",
+        "bitcoin",
+        "wallet",
+        "secrets",
+    }
+    assert not (imported & forbidden_imports), f"forbidden import(s): {imported & forbidden_imports}"
+
+    called = set()
+    attrs = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                called.add(node.func.id)
+            elif isinstance(node.func, ast.Attribute):
+                called.add(node.func.attr)
+        if isinstance(node, ast.Attribute):
+            attrs.add(node.attr)
+    forbidden_calls = {"eval", "exec", "compile", "__import__", "system", "popen", "run", "Popen"}
+    assert not (called & forbidden_calls)
+    forbidden_attrs = {"execute", "enqueue", "openclaw_supervisor", "hermes_job_executor", "wre_core"}
+    assert not (attrs & forbidden_attrs)


### PR DESCRIPTION
## REDDOG_SIGNER_AND_DELEGATED_AUTHORITY_RUNTIME_PHASE1

Runtime authority producer after E0/E1: validates principal/scope/fresh permission/nonce/revocation/co-sign inputs, then requests principal + RedDog signatures through an injected isolated signer client. Production defaults fail closed.

### Scope
- Adds `reddog_signer_delegated_authority_runtime.py`
- Adds focused tests for issuance, rejection paths, verifier compatibility, JSON durability, and AST denylist
- Updates moltbot_bridge ModLog

### Boundary
- No key generation
- No crypto/signing library in production code
- No vault access
- No shell/subprocess/network
- No extension runtime wiring
- No OpenClaw/Hermes enqueue
- No worker spawn
- No HoloIndex mutation/re-index
- No execution

### Validation
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_signer_delegated_authority_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_work_order_signature_verifier.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_work_order_policy_gate.py -q` -> 73 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_authoritative_work_state_refresh_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_signer_delegated_authority_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_work_order_signature_verifier.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_work_order_policy_gate.py -q` -> 82 passed
- `python -m py_compile ...` -> pass
- `git diff --check` -> clean (CRLF warning only)
- New runtime/test files: 0 non-ASCII, 0 NUL, 0 long lines over 120
- Local `ruff` unavailable: `No module named ruff`; CI lint is required

### HoloIndex addendum
Read-only HoloIndex probe was attempted. Query `RedDog principal identity delegation signer authority` surfaced the existing verifier and identity contract. Two other read-only searches failed inside HoloIndex with `duplicate column name: status` followed by `KeyError: need`; no runtime re-index was performed. Record as `HOLOINDEX_REDDOG_SIGNER_DELEGATED_AUTHORITY_RUNTIME_INDEX_GAP_PHASE1` / HoloIndex tooling gap.

### Residual SPECIFIED_NOT_IMPLEMENTED
- Real isolated signer daemon / OS-principal boundary
- Actual asymmetric signature backend / curve selection
- WSP_71 vault-backed signer key retrieval
- Durable multi-process nonce database
- Consensus/co-sign authority service
- Signed receipt chain integration
- Live enqueue/runtime consumption wiring

Worker-Lane: Identity / Delegation / Signing
Slice: REDDOG_SIGNER_AND_DELEGATED_AUTHORITY_RUNTIME_PHASE1