### PR TITLE
feat(reddog): bind extension to guarded live enqueue invoke

### DIFF
--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,14 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-14 - REDDOG_EXTENSION_TO_OPENCLAW_LIVE_ENQUEUE_RUNTIME_BINDING_PHASE1 (guarded live-enqueue binding, 0.3.67)
+
+- Added a guarded extension runtime binding for `live_enqueue` wardrobe-selection receipts after grounding, fusion quorum, output validation, and runtime-consumption gates pass.
+- Added the `scripts/reddog_extension_live_enqueue_invoke_once.py` one-shot bridge, which delegates to the existing explicit live-enqueue invoke guard but keeps the concrete writer disabled in this slice.
+- Copy MD now reports the OpenClaw live-enqueue runtime binding result with no worktree, shell, Hermes dispatch, file edit, PR, merge, or reward settlement authority.
+- HoloIndex query-only preflight surfaced the existing live-enqueue seam and contract, but the new one-shot script is not indexed yet; no runtime reindex performed.
+- Version 0.3.66 -> 0.3.67 (package.json + EXTENSION_VERSION + README + contract-test assertions).
+
 ## 2026-07-13 - REDDOG_SEMANTIC_GROUNDING_PER_TARGET_PROOF_PHASE1 (semantic coverage proof, 0.3.66)
 
 - Replaced aggregate semantic grounding (`code_hits + wsp_hits > 0`) with per-target `SemanticTargetCoverage` records.

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.66
+Version: 0.3.67
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 
@@ -65,6 +65,7 @@ The extension is a bounded 0102 advisory surface:
 - Operational-output target guard (v0.3.64): browser/DAEmon diagnostic payloads with URLs, timing values, screenshot filenames, and status ratios are routed to local assessment and suppressed from repo/external target extraction so log fragments cannot block typed grounding.
 - Prompt-authoring override (v0.3.65): requests for worker/slice/M2M prompts override the DAEmon/log local diagnostic fast path, so pasted logs can be used as context for governed prompt generation instead of being answered instantly as non-actionable diagnostics.
 - Semantic grounding per-target proof (v0.3.66): semantic targets now require independent content-bearing HoloIndex evidence refs before Fusion or wardrobe selection may proceed. Aggregate `code_hits` / `wsp_hits` no longer satisfy unrelated semantic targets; missing, errored, or ref-less semantic evidence fails closed and is surfaced through `semantic_targets_required`, `semantic_targets_grounded`, `semantic_targets_missing`, and `semantic_target_coverage_digest` telemetry.
+- OpenClaw live-enqueue runtime binding (v0.3.67): after grounding, fusion quorum, output validation, wardrobe selection, and runtime-consumption gates pass, the extension may call the one-shot explicit live-enqueue invoke bridge for `live_enqueue` authority requests. This slice keeps `enableConcreteWriter=false`, so the editor subprocess can prove the guarded path is reachable but cannot perform a durable OpenClaw queue write.
 
 The extension does not grant repo authority. **012 supplies work focus only**; 0102 assembles a WSP task prompt before the bridge runs. Work focus and bounded repo context are sent through `scripts/advisory_model_once.py`, which runs the landed Fusion redaction gate before making OpenRouter requests. The webview receives only advisory text and redacted local history.
 

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.66';
+const EXTENSION_VERSION = '0.3.67';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -37,10 +37,13 @@ const WRE_WORK_ORDER_AUTHORITY_BINDING_SLICE = 'REDDOG_EXTENSION_WORK_ORDER_PERM
 const WRE_OPERATIONAL_SPINE_TARGET = 'reddog_wre_operational_spine';
 const WRE_OPERATIONAL_SPINE_CALL = 'modules/communication/moltbot_bridge/src/reddog_wre_operational_spine.py::run_reddog_wre_worktree_create_spine';
 const WRE_OPERATIONAL_SPINE_INVOKE_SCRIPT = 'scripts/reddog_extension_wre_spine_invoke_once.py';
+const REDDOG_EXTENSION_LIVE_ENQUEUE_INVOKE_SCRIPT = 'scripts/reddog_extension_live_enqueue_invoke_once.py';
 const REDDOG_OPERATOR_WARDROBE_SELECTION_SCRIPT = 'scripts/reddog_operator_wardrobe_selection_once.py';
 const REDDOG_GITHUB_PERMISSION_PROBE_SCRIPT = 'scripts/reddog_github_permission_probe_once.py';
 const WRE_OPERATIONAL_SPINE_INVOKE_MAX_BYTES = 262144;
 const WRE_OPERATIONAL_SPINE_REQUIRED_VALVE = 'VALVE_OPEN_WORKTREE_CREATE';
+const REDDOG_EXTENSION_OPENCLAW_LIVE_ENQUEUE_RUNTIME_BINDING_SLICE = 'REDDOG_EXTENSION_TO_OPENCLAW_LIVE_ENQUEUE_RUNTIME_BINDING_PHASE1';
+const REDDOG_OPENCLAW_LIVE_ENQUEUE_TARGET = 'reddog_openclaw_live_enqueue';
 const TRUSTED_PERMISSION_SNAPSHOT_SOURCES = new Set(['gh_cli', 'github_api', 'mock']);
 const MOJIBAKE_MARKERS = ['\u7aa6', '\u7aaa'];
 const WORK_TRAIL_MAX_EVENTS = 50;
@@ -3368,6 +3371,189 @@ function buildWreOperationalSpineInvokeSection(invokeResult) {
   ].join('\n');
 }
 
+function _firstRuntimeArtifact(packet, options, keys) {
+  const pkt = packet && typeof packet === 'object' ? packet : {};
+  const opts = options && typeof options === 'object' ? options : {};
+  const review = pkt.review_packet && typeof pkt.review_packet === 'object' ? pkt.review_packet : {};
+  for (const key of keys) {
+    if (opts[key] && typeof opts[key] === 'object') {
+      return opts[key];
+    }
+    if (pkt[key] && typeof pkt[key] === 'object') {
+      return pkt[key];
+    }
+    if (review[key] && typeof review[key] === 'object') {
+      return review[key];
+    }
+  }
+  return null;
+}
+
+function buildOpenClawLiveEnqueueRuntimeBindingPayload(packet, selectionResult, runtimeGate, options) {
+  const pkt = packet && typeof packet === 'object' ? packet : {};
+  const selection = selectionResult && typeof selectionResult === 'object' ? selectionResult : {};
+  const gate = runtimeGate && typeof runtimeGate === 'object' ? runtimeGate : {};
+  const opts = options && typeof options === 'object' ? options : {};
+  const receipt = selection.receipt && typeof selection.receipt === 'object' ? selection.receipt : null;
+  const reasons = [];
+
+  if (gate.passed !== true) {
+    reasons.push('runtime_consumption_gate_not_passed');
+  }
+  if (selection.authority_request !== 'live_enqueue') {
+    reasons.push('authority_request_not_live_enqueue');
+  }
+  if (!receipt) {
+    reasons.push('selection_receipt_missing');
+  }
+
+  const adapterResult = _firstRuntimeArtifact(pkt, opts, ['adapterResult', 'openclaw_adapter_result', 'adapter_result']);
+  const policyGateReceipt = _firstRuntimeArtifact(pkt, opts, ['policyGateReceipt', 'policy_gate_receipt']);
+  const signedReceiptChainResult = _firstRuntimeArtifact(
+    pkt,
+    opts,
+    ['signedReceiptChainResult', 'signed_receipt_chain_result']
+  );
+  const valveDecision = _firstRuntimeArtifact(
+    pkt,
+    opts,
+    ['valveDecision', 'live_enqueue_valve_decision', 'valve_decision']
+  );
+  if (!adapterResult) {
+    reasons.push('adapter_result_missing');
+  }
+  if (!policyGateReceipt) {
+    reasons.push('policy_gate_receipt_missing');
+  }
+  if (!signedReceiptChainResult) {
+    reasons.push('signed_receipt_chain_result_missing');
+  }
+  if (!valveDecision) {
+    reasons.push('valve_decision_missing');
+  }
+
+  if (reasons.length) {
+    return {
+      ok: false,
+      rejection_reasons: uniqueStrings(reasons),
+      payload: null
+    };
+  }
+
+  return {
+    ok: true,
+    rejection_reasons: [],
+    payload: {
+      explicit_live_enqueue_requested: true,
+      selection_receipt: _safeJsonClone(receipt),
+      adapter_result: _safeJsonClone(adapterResult),
+      policy_gate_receipt: _safeJsonClone(policyGateReceipt),
+      signed_receipt_chain_result: _safeJsonClone(signedReceiptChainResult),
+      valve_decision: _safeJsonClone(valveDecision),
+      enable_concrete_writer: opts.enableConcreteWriter === true,
+      seen_live_enqueue_keys: opts.seenLiveEnqueueKeys instanceof Set
+        ? Array.from(opts.seenLiveEnqueueKeys)
+        : []
+    }
+  };
+}
+
+function buildOpenClawLiveEnqueueRuntimeBindingResult(decision, fields) {
+  const payload = fields && typeof fields === 'object' ? fields : {};
+  return Object.assign({
+    slice_name: REDDOG_EXTENSION_OPENCLAW_LIVE_ENQUEUE_RUNTIME_BINDING_SLICE,
+    target: REDDOG_OPENCLAW_LIVE_ENQUEUE_TARGET,
+    decision: decision,
+    python_invocation_performed: false,
+    openclaw_enqueue_performed: false,
+    hermes_dispatch_performed: false,
+    worktree_create_performed: false,
+    task_execution_performed: false,
+    file_edit_performed: false,
+    pr_created: false,
+    merge_performed: false,
+    reward_settlement_performed: false,
+    concrete_writer_enabled: false,
+    script: REDDOG_EXTENSION_LIVE_ENQUEUE_INVOKE_SCRIPT,
+    rejection_reasons: []
+  }, payload);
+}
+
+function invokeOpenClawLiveEnqueueRuntimeBindingBridge(context, packet, selectionResult, runtimeGate, options) {
+  const opts = options && typeof options === 'object' ? options : {};
+  const payloadResult = buildOpenClawLiveEnqueueRuntimeBindingPayload(
+    packet,
+    selectionResult,
+    runtimeGate,
+    opts
+  );
+  if (!payloadResult.ok) {
+    return buildOpenClawLiveEnqueueRuntimeBindingResult('EXTENSION_OPENCLAW_LIVE_ENQUEUE_SKIPPED', {
+      rejection_reasons: payloadResult.rejection_reasons,
+      not_invoked_reason: payloadResult.rejection_reasons[0] || 'missing_required_live_enqueue_metadata'
+    });
+  }
+  if (typeof opts.invokeRunner === 'function') {
+    const runnerResult = opts.invokeRunner(payloadResult.payload);
+    const parsed = typeof runnerResult === 'string' ? JSON.parse(runnerResult) : (runnerResult || {});
+    return buildOpenClawLiveEnqueueRuntimeBindingResult(
+      parsed.decision || 'EXTENSION_OPENCLAW_LIVE_ENQUEUE_BRIDGE_RESULT',
+      parsed
+    );
+  }
+  const root = workspaceRoot();
+  const script = path.join(root, REDDOG_EXTENSION_LIVE_ENQUEUE_INVOKE_SCRIPT);
+  const config = vscode.workspace.getConfiguration('foundupsFusion');
+  const configuredPython = config.get('pythonPath') || 'python';
+  const interpreter = resolvePythonInterpreter(root, configuredPython);
+  try {
+    const stdout = cp.execFileSync(interpreter.path, ['-B', script], {
+      cwd: root,
+      input: JSON.stringify(payloadResult.payload),
+      encoding: 'utf8',
+      env: buildBridgePythonEnv(process.env),
+      windowsHide: true,
+      maxBuffer: WRE_OPERATIONAL_SPINE_INVOKE_MAX_BYTES
+    });
+    const parsed = JSON.parse(stdout);
+    return buildOpenClawLiveEnqueueRuntimeBindingResult(
+      parsed.decision || 'EXTENSION_OPENCLAW_LIVE_ENQUEUE_BRIDGE_RESULT',
+      Object.assign({}, parsed, {
+        python_invocation_performed: true,
+        python_interpreter_source: interpreter.source
+      })
+    );
+  } catch (err) {
+    return buildOpenClawLiveEnqueueRuntimeBindingResult('EXTENSION_OPENCLAW_LIVE_ENQUEUE_REJECT', {
+      python_invocation_performed: true,
+      rejection_reasons: ['live_enqueue_bridge_invocation_failed'],
+      bridge_error_class: err && err.code ? String(err.code) : (err && err.name ? String(err.name) : 'Error')
+    });
+  }
+}
+
+function buildOpenClawLiveEnqueueRuntimeBindingSection(invokeResult) {
+  const r = invokeResult && typeof invokeResult === 'object' ? invokeResult : {};
+  return [
+    '## OpenClaw Live Enqueue Runtime Binding',
+    '- slice_name: ' + (r.slice_name || REDDOG_EXTENSION_OPENCLAW_LIVE_ENQUEUE_RUNTIME_BINDING_SLICE) + ' [OBSERVED]',
+    '- target: ' + (r.target || REDDOG_OPENCLAW_LIVE_ENQUEUE_TARGET) + ' [OBSERVED]',
+    '- decision: ' + (r.decision || 'unknown') + ' [OBSERVED]',
+    '- python_invocation_performed: ' + (r.python_invocation_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- concrete_writer_enabled: ' + (r.concrete_writer_enabled === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- openclaw_enqueue_performed: ' + (r.openclaw_enqueue_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- hermes_dispatch_performed: ' + (r.hermes_dispatch_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- worktree_create_performed: ' + (r.worktree_create_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- task_execution_performed: ' + (r.task_execution_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- file_edit_performed: ' + (r.file_edit_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- pr_created: ' + (r.pr_created === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- merge_performed: ' + (r.merge_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- reward_settlement_performed: ' + (r.reward_settlement_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- rejection_reasons: ' + JSON.stringify(r.rejection_reasons || []) + ' [OBSERVED]',
+    '- not_invoked_reason: ' + (r.not_invoked_reason || 'none') + ' [OBSERVED]'
+  ].join('\n');
+}
+
 function buildCopyMarkdown(result, workerType, contextSummary, workTrail, holoScorecard, resolvedEffort, copyContext) {
   const packet = result && typeof result === 'object' ? result : {};
   const ctx = copyContext && typeof copyContext === 'object' ? copyContext : {};
@@ -3406,6 +3592,13 @@ function buildCopyMarkdown(result, workerType, contextSummary, workTrail, holoSc
       if (invokeResult) {
         sections.push(buildWreOperationalSpineInvokeSection(invokeResult));
       }
+    }
+    const liveEnqueueInvoke = (
+      ctx.openClawLiveEnqueueInvokeResult
+      || packet.openclaw_live_enqueue_runtime_binding_result
+    );
+    if (liveEnqueueInvoke) {
+      sections.push(buildOpenClawLiveEnqueueRuntimeBindingSection(liveEnqueueInvoke));
     }
   }
   sections.push(buildContinuationTelemetrySection(ctx.continuationTelemetry || packet.continuation_telemetry));
@@ -4768,7 +4961,14 @@ function openFusionEditor(context) {
     }
   );
   const logoUri = panel.webview.asWebviewUri(vscode.Uri.joinPath(context.extensionUri, 'icon.png'));
-  const state = { history: [], lastReviewPacket: null, lastContinuationSummary: null, bridgeChild: null, disposed: false };
+  const state = {
+    history: [],
+    lastReviewPacket: null,
+    lastContinuationSummary: null,
+    bridgeChild: null,
+    disposed: false,
+    liveEnqueueKeys: new Set()
+  };
   wireFusionWebview(context, panel.webview, worker, state);
   panel.onDidDispose(() => {
     killBridgeChild(state);
@@ -5231,6 +5431,23 @@ function wireFusionWebview(context, webview, worker, state) {
         selectionReceipt: operatorWardrobeSelectionResult && operatorWardrobeSelectionResult.receipt
       })
       : null;
+    const openClawLiveEnqueueInvokeResult = (
+      actionPlanningAllowed
+      && operatorWardrobeSelectionResult
+      && operatorWardrobeSelectionResult.authority_request === 'live_enqueue'
+    )
+      ? invokeOpenClawLiveEnqueueRuntimeBindingBridge(context, result, operatorWardrobeSelectionResult, runtimeConsumptionGate, {
+        seenLiveEnqueueKeys: state.liveEnqueueKeys,
+        enableConcreteWriter: false
+      })
+      : null;
+    if (
+      openClawLiveEnqueueInvokeResult
+      && openClawLiveEnqueueInvokeResult.openclaw_enqueue_performed === true
+      && openClawLiveEnqueueInvokeResult.live_enqueue_key
+    ) {
+      state.liveEnqueueKeys.add(String(openClawLiveEnqueueInvokeResult.live_enqueue_key));
+    }
     result.review_packet = attachOrchestratorMetadata(
       result.review_packet || {},
       classification,
@@ -5262,6 +5479,10 @@ function wireFusionWebview(context, webview, worker, state) {
     if (wreSpineInvokeResult) {
       result.wre_operational_spine_invoke_result = wreSpineInvokeResult;
       result.review_packet.wre_operational_spine_invoke_result = wreSpineInvokeResult;
+    }
+    if (openClawLiveEnqueueInvokeResult) {
+      result.openclaw_live_enqueue_runtime_binding_result = openClawLiveEnqueueInvokeResult;
+      result.review_packet.openclaw_live_enqueue_runtime_binding_result = openClawLiveEnqueueInvokeResult;
     }
     if (result.reason === 'redaction_blocked') {
       result.redaction_gate_report = buildRedactionGateReport(result, promptConstruction, contextMode);
@@ -5318,6 +5539,7 @@ function wireFusionWebview(context, webview, worker, state) {
       githubPermissionProbeResult: githubPermissionProbeResult,
       wreSpineDryRunPreview: wreSpineDryRunPreview,
       wreSpineInvokeResult: wreSpineInvokeResult,
+      openClawLiveEnqueueInvokeResult: openClawLiveEnqueueInvokeResult,
       continuationEnabled: continuationEnabled,
       continuationTelemetry: continuationTelemetry,
       // Only pass the summary for Copy MD inclusion when appended this run (fail-closed).
@@ -7270,6 +7492,9 @@ module.exports = {
   buildWreOperationalSpineInvokePayload,
   invokeWreOperationalSpineExplicitValveBridge,
   buildWreOperationalSpineInvokeSection,
+  buildOpenClawLiveEnqueueRuntimeBindingPayload,
+  invokeOpenClawLiveEnqueueRuntimeBindingBridge,
+  buildOpenClawLiveEnqueueRuntimeBindingSection,
   compositePayloadDigest,
   extractHoloIndexScorecard,
   formatHoloIndexScorecardLines,

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups\u00aeAgent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.66",
+    "version":  "0.3.67",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -197,8 +197,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.66', 'package version must be 0.3.66');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.66'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.67', 'package version must be 0.3.67');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.67'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups\u00aeAgent', 'display name must be Foundups\u00aeAgent');
 includes(JSON.stringify(pkg), 'Foundups\u00aeAgent: Open', 'command title must use Foundups\u00aeAgent');
@@ -215,7 +215,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.66', 'README version mismatch');
+includes(readme, 'Version: 0.3.67', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -1080,7 +1080,7 @@ assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
 assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
 assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
-assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.66', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.67', 'candidate must bind extension version');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
 assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [
@@ -1263,6 +1263,160 @@ assert.strictEqual(realWardrobeSelection.no_enqueue_performed, true, 'one-shot w
 assert.strictEqual(realWardrobeSelection.receipt.selected_wardrobe, 'wsp97_sovereign_execution', 'one-shot wardrobe bridge selects sovereign wardrobe');
 assert.strictEqual(realWardrobeSelection.receipt.authority_boundary, 'sovereign_token_required', 'one-shot wardrobe bridge preserves sovereign boundary');
 assert.strictEqual(realWardrobeSelection.receipt.wre_required, true, 'one-shot wardrobe bridge marks WRE required for worktree authority');
+
+// REDDOG_EXTENSION_TO_OPENCLAW_LIVE_ENQUEUE_RUNTIME_BINDING_PHASE1:
+// extension may reach the explicit live-enqueue invoke guard only after runtime gating,
+// with structured artifacts and the concrete writer disabled in this slice.
+includes(extensionJs, "scripts/reddog_extension_live_enqueue_invoke_once.py", 'live enqueue runtime binding must use one-shot invoke bridge');
+includes(extensionJs, "operatorWardrobeSelectionResult.authority_request === 'live_enqueue'", 'live enqueue binding must require live_enqueue authority request');
+includes(extensionJs, 'enableConcreteWriter: false', 'live enqueue binding must disable concrete writer from extension runtime');
+includes(extensionJs, 'openclaw_live_enqueue_runtime_binding_result', 'live enqueue binding result must be attached to review packet');
+const liveBindingFunctionStart = extensionJs.indexOf('function buildOpenClawLiveEnqueueRuntimeBindingPayload');
+const liveBindingFunctionEnd = extensionJs.indexOf('function buildOpenClawLiveEnqueueRuntimeBindingResult');
+assert(liveBindingFunctionStart > 0 && liveBindingFunctionEnd > liveBindingFunctionStart, 'live enqueue payload builder must exist');
+const liveBindingPayloadBuilder = extensionJs.slice(liveBindingFunctionStart, liveBindingFunctionEnd);
+assert(!liveBindingPayloadBuilder.includes('result.content'), 'live enqueue binding must not mine model output prose for runtime artifacts');
+
+const liveSelectionReceipt = {
+  selected_wardrobe: 'wsp97_sovereign_execution',
+  execution_plane: 'governed_execution_candidate',
+  authority_boundary: 'signed_valve_required',
+  rejection_reasons: [],
+  no_execution_performed: true,
+  no_enqueue_performed: true
+};
+const liveSelectionResult = {
+  authority_request: 'live_enqueue',
+  receipt: liveSelectionReceipt
+};
+const liveAdapterResult = {
+  decision: 'ADAPTER_DRYRUN_ACCEPT',
+  work_order_id: 'wo-live-extension-001',
+  proposed_intake: {
+    target_type: 'foundup_job',
+    proposed_job_id: 'reddog-fj-live-extension-001',
+    proposed_task_id: null,
+    work_order_id: 'wo-live-extension-001',
+    operation: 'feature_slice',
+    requested_action: 'validate_foundup',
+    repo_scope: 'FOUNDUPS/Foundups-Agent',
+    allowed_paths: ['modules/communication/moltbot_bridge/**'],
+    denied_paths: ['.env'],
+    required_tests: ['modules/communication/moltbot_bridge/tests/test_reddog_openclaw_live_enqueue.py'],
+    evidence_refs: ['policy_gate:sha256:policy-live'],
+    no_enqueue_performed: true,
+    no_execution_performed: true
+  },
+  adapter_receipt: {
+    adapter_receipt_digest: 'sha256:adapter-live',
+    target_type: 'foundup_job',
+    work_order_id: 'wo-live-extension-001',
+    rejection_reasons: []
+  },
+  no_enqueue_performed: true,
+  no_execution_performed: true
+};
+const livePolicyReceipt = {
+  decision: 'POLICY_ACCEPT',
+  receipt_digest: 'sha256:policy-live',
+  signature_gate_status: 'SIGNATURE_GATE_ACCEPTED',
+  signature_gate_digest: 'sha256:signed-live',
+  no_execution_performed: true
+};
+const liveSignedReceiptChain = {
+  decision: 'SIGNED_RECEIPT_CHAIN_ACCEPT',
+  accepted: true,
+  terminal_receipt_hash: 'sha256:terminal-live',
+  no_execution_performed: true,
+  no_reward_settlement_performed: true
+};
+const liveValveDecision = {
+  valve_state: 'VALVE_OPEN_LIVE_ENQUEUE',
+  decision_digest: 'sha256:valve-live',
+  no_execution_performed: true,
+  rejection_reasons: []
+};
+const liveRuntimeGate = { passed: true, rejection_reasons: [] };
+const blockedLivePayload = orchestrator.buildOpenClawLiveEnqueueRuntimeBindingPayload(
+  {},
+  liveSelectionResult,
+  { passed: false, rejection_reasons: ['fusion_panel_quorum_not_passed'] },
+  {}
+);
+assert.strictEqual(blockedLivePayload.ok, false, 'failed runtime consumption gate blocks live enqueue payload');
+assert(blockedLivePayload.rejection_reasons.includes('runtime_consumption_gate_not_passed'), 'live enqueue payload carries runtime gate rejection');
+const missingLiveArtifacts = orchestrator.buildOpenClawLiveEnqueueRuntimeBindingPayload(
+  {},
+  liveSelectionResult,
+  liveRuntimeGate,
+  {}
+);
+assert.strictEqual(missingLiveArtifacts.ok, false, 'live enqueue payload requires structured artifacts');
+assert(missingLiveArtifacts.rejection_reasons.includes('adapter_result_missing'), 'live enqueue payload requires adapter result');
+assert(missingLiveArtifacts.rejection_reasons.includes('signed_receipt_chain_result_missing'), 'live enqueue payload requires signed receipt chain');
+const livePayload = orchestrator.buildOpenClawLiveEnqueueRuntimeBindingPayload(
+  {
+    openclaw_adapter_result: liveAdapterResult,
+    policy_gate_receipt: livePolicyReceipt,
+    signed_receipt_chain_result: liveSignedReceiptChain,
+    live_enqueue_valve_decision: liveValveDecision
+  },
+  liveSelectionResult,
+  liveRuntimeGate,
+  { enableConcreteWriter: false, seenLiveEnqueueKeys: new Set(['existing:key']) }
+);
+assert.strictEqual(livePayload.ok, true, 'valid live enqueue metadata builds bridge payload');
+assert.strictEqual(livePayload.payload.enable_concrete_writer, false, 'bridge payload disables concrete writer');
+assert.deepStrictEqual(livePayload.payload.seen_live_enqueue_keys, ['existing:key'], 'bridge payload carries idempotency keys');
+const fakeLiveInvoke = orchestrator.invokeOpenClawLiveEnqueueRuntimeBindingBridge(
+  null,
+  {
+    openclaw_adapter_result: liveAdapterResult,
+    policy_gate_receipt: livePolicyReceipt,
+    signed_receipt_chain_result: liveSignedReceiptChain,
+    live_enqueue_valve_decision: liveValveDecision
+  },
+  liveSelectionResult,
+  liveRuntimeGate,
+  {
+    enableConcreteWriter: false,
+    invokeRunner: (payload) => {
+      assert.strictEqual(payload.enable_concrete_writer, false, 'fake live enqueue runner sees disabled writer');
+      return {
+        decision: 'EXTENSION_LIVE_ENQUEUE_INVOKE_REJECT',
+        rejection_reasons: ['REJECT_LIVE_ENQUEUE_WRITER_MISSING'],
+        concrete_writer_enabled: false,
+        openclaw_enqueue_performed: false,
+        hermes_dispatch_performed: false,
+        worktree_create_performed: false,
+        task_execution_performed: false,
+        file_edit_performed: false,
+        pr_created: false,
+        merge_performed: false,
+        reward_settlement_performed: false
+      };
+    }
+  }
+);
+assert.strictEqual(fakeLiveInvoke.decision, 'EXTENSION_LIVE_ENQUEUE_INVOKE_REJECT', 'fake live enqueue bridge preserves guard rejection');
+assert.strictEqual(fakeLiveInvoke.openclaw_enqueue_performed, false, 'fake live enqueue bridge performs no enqueue');
+assert.strictEqual(fakeLiveInvoke.concrete_writer_enabled, false, 'fake live enqueue bridge keeps writer disabled');
+const fakeLiveInvokeSection = orchestrator.buildOpenClawLiveEnqueueRuntimeBindingSection(fakeLiveInvoke);
+includes(fakeLiveInvokeSection, '## OpenClaw Live Enqueue Runtime Binding', 'live enqueue section header');
+includes(fakeLiveInvokeSection, 'concrete_writer_enabled: false [OBSERVED]', 'live enqueue section shows disabled writer');
+includes(fakeLiveInvokeSection, 'openclaw_enqueue_performed: false [OBSERVED]', 'live enqueue section shows no enqueue');
+const realLiveInvoke = JSON.parse(cp.execFileSync('python', ['-B', path.join(root, 'scripts', 'reddog_extension_live_enqueue_invoke_once.py')], {
+  cwd: root,
+  input: JSON.stringify(livePayload.payload),
+  encoding: 'utf8',
+  env: Object.assign({}, process.env, { PYTHONIOENCODING: 'utf-8', PYTHONUTF8: '1' }),
+  maxBuffer: 262144
+}));
+assert.strictEqual(realLiveInvoke.decision, 'EXTENSION_LIVE_ENQUEUE_INVOKE_REJECT', 'one-shot live enqueue bridge rejects without concrete writer');
+assert.strictEqual(realLiveInvoke.python_invocation_performed, true, 'one-shot live enqueue bridge marks Python invocation');
+assert.strictEqual(realLiveInvoke.concrete_writer_enabled, false, 'one-shot live enqueue bridge keeps writer disabled');
+assert.strictEqual(realLiveInvoke.openclaw_enqueue_performed, false, 'one-shot live enqueue bridge performs no enqueue');
+assert(realLiveInvoke.rejection_reasons.includes('REJECT_LIVE_ENQUEUE_WRITER_MISSING'), 'one-shot live enqueue bridge preserves writer-missing rejection');
 
 // REDDOG_EXTENSION_GITHUB_PERMISSION_PROBE_RUNTIME_BRIDGE_PHASE1:
 // extension obtains a read-only GitHub permission snapshot and feeds it to the work-order candidate.
@@ -2418,7 +2572,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.66'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.67'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -2432,7 +2586,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.66'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.67'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -2444,7 +2598,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.66'", 'bounded context must include source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.67'", 'bounded context must include source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');

--- a/scripts/reddog_extension_live_enqueue_invoke_once.py
+++ b/scripts/reddog_extension_live_enqueue_invoke_once.py
@@ -1,0 +1,114 @@
+"""One-shot bridge for RedDog extension OpenClaw live-enqueue invocation.
+
+Slice: REDDOG_EXTENSION_TO_OPENCLAW_LIVE_ENQUEUE_RUNTIME_BINDING_PHASE1
+
+The editor runtime may call this script only after grounding, fusion quorum,
+output validation, wardrobe selection, and runtime-consumption gates have
+passed. This bridge delegates to the existing explicit live-enqueue invoke
+guard, but it intentionally does not construct the concrete OpenClaw writer in
+this slice. That keeps the extension runtime connected to the guarded seam
+without making an editor subprocess the owner of durable live queue mutation.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from modules.communication.moltbot_bridge.src.reddog_extension_live_enqueue_invoke import (  # noqa: E402
+    EXTENSION_LIVE_ENQUEUE_INVOKE_REJECT,
+    invoke_reddog_extension_live_enqueue_explicit_valve,
+)
+
+
+def _read_payload() -> Dict[str, Any]:
+    raw = sys.stdin.buffer.read()
+    if not raw:
+        return {}
+    payload = json.loads(raw.decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("payload_must_be_json_object")
+    return payload
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _bool(value: Any) -> bool:
+    return value is True
+
+
+def _seen_keys(value: Any) -> set[str]:
+    if not isinstance(value, list):
+        return set()
+    return {str(item) for item in value if item is not None}
+
+
+def _with_runtime_flags(output: Dict[str, Any]) -> Dict[str, Any]:
+    live = output.get("live_enqueue_result")
+    live_payload = live if isinstance(live, Mapping) else {}
+    receipt = live_payload.get("receipt")
+    receipt_payload = receipt if isinstance(receipt, Mapping) else {}
+    work_order_id = str(live_payload.get("work_order_id") or receipt_payload.get("work_order_id") or "")
+    adapter_digest = str(receipt_payload.get("adapter_dryrun_receipt_digest") or "")
+    live_enqueue_key = f"{work_order_id}:{adapter_digest}" if work_order_id and adapter_digest else ""
+    output.update(
+        {
+            "python_invocation_performed": True,
+            "concrete_writer_enabled": False,
+            "openclaw_enqueue_performed": live_payload.get("live_enqueue_performed") is True,
+            "hermes_dispatch_performed": False,
+            "worktree_create_performed": False,
+            "task_execution_performed": False,
+            "file_edit_performed": False,
+            "pr_created": False,
+            "merge_performed": False,
+            "reward_settlement_performed": False,
+        }
+    )
+    if live_enqueue_key:
+        output["live_enqueue_key"] = live_enqueue_key
+    return output
+
+
+def _reject(reason: str) -> Dict[str, Any]:
+    return _with_runtime_flags(
+        {
+            "decision": EXTENSION_LIVE_ENQUEUE_INVOKE_REJECT,
+            "rejection_reasons": [reason],
+            "explicit_live_enqueue_requested": False,
+            "no_execution_performed": True,
+            "no_reward_settlement_performed": True,
+        }
+    )
+
+
+def main() -> int:
+    try:
+        payload = _read_payload()
+        result = invoke_reddog_extension_live_enqueue_explicit_valve(
+            explicit_live_enqueue_requested=_bool(payload.get("explicit_live_enqueue_requested")),
+            selection_receipt=_mapping(payload.get("selection_receipt")),
+            adapter_result=_mapping(payload.get("adapter_result")),
+            policy_gate_receipt=_mapping(payload.get("policy_gate_receipt")),
+            signed_receipt_chain_result=_mapping(payload.get("signed_receipt_chain_result")),
+            valve_decision=_mapping(payload.get("valve_decision")),
+            writer=None,
+            seen_live_enqueue_keys=_seen_keys(payload.get("seen_live_enqueue_keys")),
+        )
+        sys.stdout.write(json.dumps(_with_runtime_flags(result.to_dict()), sort_keys=True))
+        return 0
+    except Exception as exc:
+        sys.stdout.write(json.dumps(_reject(type(exc).__name__), sort_keys=True))
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements `REDDOG_EXTENSION_TO_OPENCLAW_LIVE_ENQUEUE_RUNTIME_BINDING_PHASE1` for Foundups Agent 0.3.67.

- Adds a guarded extension runtime binding that only runs for `live_enqueue` wardrobe-selection receipts after grounding, fusion quorum, output validation, and runtime-consumption gates pass.
- Adds `scripts/reddog_extension_live_enqueue_invoke_once.py`, a one-shot Python bridge to the existing explicit live-enqueue invoke guard.
- Keeps `enableConcreteWriter=false` from the editor runtime, so this slice proves reachability of the guarded seam without durable OpenClaw queue mutation.
- Adds Copy MD reporting and contract tests for rejection, structured-artifact requirements, writer-disabled behavior, and version surfaces.

## Truth Boundary

- No automatic model-output enqueue.
- No concrete OpenClaw writer from the extension process.
- No Hermes dispatch.
- No worktree creation, shell execution, file edit, PR creation, merge, or reward settlement.
- HoloIndex query-only preflight was run; no runtime reindex performed.

## Validation

- `node extensions/foundups_advisory_workers/tests/verify_extension_contract.js` (passes; pre-existing surrogate fixture prints a UnicodeEncodeError trace while exit code remains 0)
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_extension_live_enqueue_invoke.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_live_enqueue.py -q` -> 21 passed
- `python -m py_compile scripts/reddog_extension_live_enqueue_invoke_once.py`
- `git diff --check`
- Diff-addition ASCII check for runtime/test/script/package files

## HoloIndex

Read-only HoloIndex queries surfaced the existing live-enqueue seam and contract. The new one-shot script is not indexed yet, and one query hit the existing output-throttler `KeyError: need` path. This is recorded as an index/tooling gap; no reindex was performed in this runtime slice.