### PR TITLE
feat(reddog): add bounded worktree worker execution pilot

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,14 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_BOUNDED_WORKTREE_WORKER_EXECUTION_PILOT_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_bounded_worktree_worker_execution_pilot.py`: bounded worker execution pilot that consumes accepted WRE worktree spine, generic writer dry-run, governed shell dry-run, CWD guard, and HoloIndex evidence before materializing exact planned text artifacts inside an already-created isolated worktree.
+- Added `tests/test_reddog_bounded_worktree_worker_execution_pilot.py`: happy path, fail-closed receipt/spine checks, shared-main CWD rejection, artifact mismatch, denied path, governed-shell rejection, HoloIndex gap rejection, secret-content rejection, and AST no-shell/no-git/no-queue/no-runtime-authority coverage.
+- Boundary: no subprocess/shell command execution, no git/gh operation, no PR creation, no merge, no OpenClaw enqueue, no Hermes dispatch, no reward settlement, no HoloIndex runtime mutation/re-index, and no extension runtime wiring. This slice proves one bounded text-artifact materialization path in an isolated worktree only.
+- HoloIndex read-only probes surfaced adjacent worktree, generic writer, governed shell, and contract surfaces, but not the new pilot module. Recorded `HOLOINDEX_REDDOG_BOUNDED_WORKTREE_WORKER_EXECUTION_PILOT_INDEX_GAP_PHASE1`; no runtime re-index performed.
+
 ## 2026-07-14: REDDOG_SIGNER_AND_DELEGATED_AUTHORITY_RUNTIME_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 71, 96, 97, 100

--- a/modules/communication/moltbot_bridge/src/reddog_bounded_worktree_worker_execution_pilot.py
+++ b/modules/communication/moltbot_bridge/src/reddog_bounded_worktree_worker_execution_pilot.py
@@ -1,0 +1,439 @@
+"""Bounded RedDog worktree worker execution pilot.
+
+Slice: REDDOG_BOUNDED_WORKTREE_WORKER_EXECUTION_PILOT_PHASE1
+
+This module is the first narrow pilot that may materialize a scoped text change
+inside an already-created isolated worktree. It requires the existing WRE
+worktree spine, generic writer dry-run, and governed shell dry-run receipts to
+have accepted first. It does not execute shell commands, push, create PRs,
+merge, enqueue OpenClaw, dispatch Hermes, settle rewards, or mutate HoloIndex.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+from modules.communication.moltbot_bridge.src.reddog_generic_agent_worktree_writer_dryrun import (
+    GENERIC_WRITER_DRYRUN_ACCEPT,
+    PIN_INDEPENDENT_DENYLIST,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_cwd_guard import (
+    WreCwdGuardResult,
+    validate_wre_worker_operation_cwd,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_governed_shell_runner_dryrun import (
+    GOVERNED_SHELL_DRYRUN_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_operational_spine import (
+    WORKTREE_SPINE_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_worktree_create import (
+    WORKTREE_CREATE_ACCEPT,
+)
+
+BOUNDED_WORKTREE_PILOT_ACCEPT = "BOUNDED_WORKTREE_PILOT_ACCEPT"
+BOUNDED_WORKTREE_PILOT_REJECT = "BOUNDED_WORKTREE_PILOT_REJECT"
+
+FAIL_WORKTREE_SPINE = "FAIL_WORKTREE_SPINE"
+FAIL_GENERIC_WRITER_DRYRUN = "FAIL_GENERIC_WRITER_DRYRUN"
+FAIL_GOVERNED_SHELL_DRYRUN = "FAIL_GOVERNED_SHELL_DRYRUN"
+FAIL_CWD_GUARD = "FAIL_CWD_GUARD"
+FAIL_WORKTREE_MISSING = "FAIL_WORKTREE_MISSING"
+FAIL_CANONICAL_ROOT_INVALID = "FAIL_CANONICAL_ROOT_INVALID"
+FAIL_ARTIFACTS_MISMATCH = "FAIL_ARTIFACTS_MISMATCH"
+FAIL_ARTIFACT_OUTSIDE_ROOT = "FAIL_ARTIFACT_OUTSIDE_ROOT"
+FAIL_DENIED_ARTIFACT = "FAIL_DENIED_ARTIFACT"
+FAIL_CONTENT_INVALID = "FAIL_CONTENT_INVALID"
+FAIL_SYMLINK_PATH = "FAIL_SYMLINK_PATH"
+FAIL_HOLOINDEX_INDEX_GAP = "FAIL_HOLOINDEX_INDEX_GAP"
+
+MAX_PILOT_FILES = 8
+MAX_FILE_BYTES = 64 * 1024
+MAX_TOTAL_BYTES = 256 * 1024
+SECRET_MARKERS = (
+    "api_key",
+    "apikey",
+    "authorization:",
+    "bearer ",
+    "begin private key",
+    "private_key",
+    "password=",
+    "secret=",
+    "token=",
+)
+
+
+@dataclass(frozen=True)
+class BoundedWorktreePilotReceipt:
+    receipt_id: str
+    work_order_id: str
+    worktree_path: str
+    canonical_root: str
+    written_artifacts: List[str]
+    artifact_manifest_digest: str
+    written_artifact_digest: str
+    worktree_spine_result_digest: str
+    generic_writer_receipt_digest: str
+    governed_shell_receipt_digest: str
+    cwd_guard_receipt_digest: str
+    validation_command_executed: bool = False
+    draft_pr_created: bool = False
+    merge_performed: bool = False
+    openclaw_enqueue_performed: bool = False
+    hermes_dispatch_performed: bool = False
+    reward_settlement_performed: bool = False
+    holoindex_reindex_performed: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class BoundedWorktreeWorkerExecutionPilotResult:
+    decision: str
+    accepted: bool
+    rejection_reasons: List[str]
+    receipt: Optional[BoundedWorktreePilotReceipt]
+    cwd_guard: Optional[WreCwdGuardResult]
+    task_execution_performed: bool
+    file_edit_performed: bool
+    shell_command_executed: bool = False
+    draft_pr_created: bool = False
+    merge_performed: bool = False
+    openclaw_enqueue_performed: bool = False
+    hermes_dispatch_performed: bool = False
+    reward_settlement_performed: bool = False
+    holoindex_reindex_performed: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["receipt"] = self.receipt.to_dict() if self.receipt else None
+        payload["cwd_guard"] = self.cwd_guard.to_dict() if self.cwd_guard else None
+        return payload
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        return value.to_dict()
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _digest(payload: Any) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dedupe(values: Iterable[str]) -> List[str]:
+    seen = set()
+    ordered: List[str] = []
+    for value in values:
+        text = str(value or "").strip()
+        if text and text not in seen:
+            seen.add(text)
+            ordered.append(text)
+    return ordered
+
+
+def _normalize_repo_path(value: str) -> Optional[str]:
+    text = str(value or "").replace("\\", "/").strip()
+    if not text or text.startswith("/") or text.startswith(("\\\\?\\", "\\\\.\\", "//?/", "//./")):
+        return None
+    parts: List[str] = []
+    for raw in text.split("/"):
+        part = raw.strip(" \t").rstrip(" .")
+        if not part or part in {".", ".."} or ":" in part:
+            return None
+        parts.append(part)
+    return "/".join(parts)
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+def _path_denied(path: str) -> bool:
+    base = path.rsplit("/", 1)[-1].rstrip(" .").lower()
+    if base in {".env", "foundup_registry.json"}:
+        return True
+    for pattern in PIN_INDEPENDENT_DENYLIST:
+        pat = pattern.replace("\\", "/").strip()
+        if fnmatch.fnmatch(path.lower(), pat.lower()):
+            return True
+        if pat.endswith("/**"):
+            stem = pat[:-3].lower().rstrip("/")
+            if path.lower() == stem or path.lower().startswith(stem + "/"):
+                return True
+    return False
+
+
+def _content_reasons(contents: Mapping[str, Any]) -> List[str]:
+    reasons: List[str] = []
+    if not contents or len(contents) > MAX_PILOT_FILES:
+        reasons.append(FAIL_ARTIFACTS_MISMATCH)
+    total = 0
+    for value in contents.values():
+        if not isinstance(value, str) or "\x00" in value:
+            reasons.append(FAIL_CONTENT_INVALID)
+            continue
+        lower = value.lower()
+        if any(marker in lower for marker in SECRET_MARKERS):
+            reasons.append(FAIL_CONTENT_INVALID)
+        size = len(value.encode("utf-8"))
+        total += size
+        if size > MAX_FILE_BYTES:
+            reasons.append(FAIL_CONTENT_INVALID)
+    if total > MAX_TOTAL_BYTES:
+        reasons.append(FAIL_CONTENT_INVALID)
+    return reasons
+
+
+def _parent_has_symlink(path: Path, stop_at: Path) -> bool:
+    current = path
+    stop = stop_at.resolve()
+    while current != stop and current != current.parent:
+        if current.exists() and current.is_symlink():
+            return True
+        current = current.parent
+    return False
+
+
+def _validate_receipts(
+    req: Mapping[str, Any],
+) -> tuple[List[str], Mapping[str, Any], Mapping[str, Any], Mapping[str, Any]]:
+    reasons: List[str] = []
+    spine = _mapping(req.get("worktree_spine_result"))
+    worktree_create = _mapping(spine.get("worktree_create_result"))
+    writer = _mapping(req.get("generic_writer_dryrun_result"))
+    writer_receipt = _mapping(writer.get("receipt"))
+    shell = _mapping(req.get("governed_shell_dryrun_result"))
+    shell_receipt = _mapping(shell.get("receipt"))
+
+    if spine.get("decision") != WORKTREE_SPINE_ACCEPT:
+        reasons.append(FAIL_WORKTREE_SPINE)
+    if worktree_create.get("decision") != WORKTREE_CREATE_ACCEPT:
+        reasons.append(FAIL_WORKTREE_SPINE)
+    if (
+        spine.get("no_file_edit_performed") is not True
+        or spine.get("no_task_execution_performed") is not True
+    ):
+        reasons.append(FAIL_WORKTREE_SPINE)
+    if writer.get("decision") != GENERIC_WRITER_DRYRUN_ACCEPT or not writer_receipt:
+        reasons.append(FAIL_GENERIC_WRITER_DRYRUN)
+    if writer_receipt and (
+        writer_receipt.get("no_write_performed") is not True
+        or writer_receipt.get("no_worktree_created") is not True
+        or writer_receipt.get("no_shell_performed") is not True
+    ):
+        reasons.append(FAIL_GENERIC_WRITER_DRYRUN)
+    if shell.get("decision") != GOVERNED_SHELL_DRYRUN_ACCEPT or not shell_receipt:
+        reasons.append(FAIL_GOVERNED_SHELL_DRYRUN)
+    if shell_receipt and shell_receipt.get("no_command_executed") is not True:
+        reasons.append(FAIL_GOVERNED_SHELL_DRYRUN)
+    return reasons, spine, writer_receipt, shell_receipt
+
+
+def _validate_artifacts(
+    *,
+    contents: Mapping[str, Any],
+    writer_receipt: Mapping[str, Any],
+    canonical_root: str,
+) -> tuple[List[str], List[str]]:
+    reasons = _content_reasons(contents)
+    normalized_contents: Dict[str, Any] = {}
+    for raw, value in contents.items():
+        normalized = _normalize_repo_path(str(raw))
+        if normalized is None:
+            reasons.append(FAIL_ARTIFACTS_MISMATCH)
+            continue
+        normalized_contents[normalized] = value
+    planned = sorted(str(v) for v in writer_receipt.get("planned_artifacts") or [])
+    supplied = sorted(normalized_contents)
+    if planned != supplied:
+        reasons.append(FAIL_ARTIFACTS_MISMATCH)
+    for rel in supplied:
+        if not (rel == canonical_root or rel.startswith(canonical_root.rstrip("/") + "/")):
+            reasons.append(FAIL_ARTIFACT_OUTSIDE_ROOT)
+        if _path_denied(rel):
+            reasons.append(FAIL_DENIED_ARTIFACT)
+    return reasons, supplied
+
+
+def _materialize_text_artifacts(
+    *,
+    worktree_path: Path,
+    canonical_root: str,
+    artifact_contents: Mapping[str, Any],
+) -> Dict[str, str]:
+    written: Dict[str, str] = {}
+    root = (worktree_path / canonical_root).resolve()
+    for raw, content in artifact_contents.items():
+        rel = _normalize_repo_path(str(raw))
+        if rel is None:
+            raise ValueError("invalid_artifact_path")
+        target = (worktree_path / rel).resolve()
+        if not _is_inside(target, root):
+            raise ValueError("artifact_outside_root")
+        if _parent_has_symlink(target.parent, worktree_path):
+            raise ValueError("symlink_parent")
+        if target.exists() and target.is_symlink():
+            raise ValueError("symlink_target")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(str(content), encoding="utf-8", newline="\n")
+        if not _is_inside(target.resolve(), root):
+            raise ValueError("artifact_escape_after_write")
+        written[rel] = _digest(target.read_text(encoding="utf-8"))
+    return written
+
+
+def run_bounded_worktree_worker_execution_pilot(
+    request: Mapping[str, Any],
+) -> BoundedWorktreeWorkerExecutionPilotResult:
+    """Run one bounded text-materialization pilot inside an isolated worktree."""
+    req = _mapping(request)
+    reasons, spine, writer_receipt, shell_receipt = _validate_receipts(req)
+
+    work_order_id = str(req.get("work_order_id") or spine.get("work_order_id") or "")
+    repo_root = Path(str(req.get("repo_root") or ""))
+    worktree_path = Path(str(req.get("worktree_path") or ""))
+    operation_cwd = Path(str(req.get("operation_cwd") or req.get("worktree_path") or ""))
+    cwd_guard: Optional[WreCwdGuardResult] = None
+
+    try:
+        cwd_guard = validate_wre_worker_operation_cwd(
+            repo_root=repo_root,
+            worktree_path=worktree_path,
+            operation_cwd=operation_cwd,
+        )
+        if not cwd_guard.ok:
+            reasons.append(FAIL_CWD_GUARD)
+    except Exception:
+        reasons.append(FAIL_CWD_GUARD)
+
+    if not worktree_path.exists() or not worktree_path.is_dir():
+        reasons.append(FAIL_WORKTREE_MISSING)
+
+    canonical_root = _normalize_repo_path(
+        str(req.get("canonical_root") or writer_receipt.get("canonical_root") or "")
+    )
+    if not canonical_root:
+        reasons.append(FAIL_CANONICAL_ROOT_INVALID)
+
+    contents = (
+        req.get("artifact_contents")
+        if isinstance(req.get("artifact_contents"), Mapping)
+        else {}
+    )
+    supplied: List[str] = []
+    if canonical_root:
+        artifact_reasons, supplied = _validate_artifacts(
+            contents=contents,
+            writer_receipt=writer_receipt,
+            canonical_root=canonical_root,
+        )
+        reasons.extend(artifact_reasons)
+
+    holo = _mapping(req.get("holoindex_evidence"))
+    if (
+        holo.get("index_gap_detected") is True
+        or str(holo.get("retrieval_quality") or "").upper() == "INDEX_GAP"
+    ):
+        reasons.append(FAIL_HOLOINDEX_INDEX_GAP)
+
+    deduped = _dedupe(reasons)
+    if deduped:
+        return BoundedWorktreeWorkerExecutionPilotResult(
+            decision=BOUNDED_WORKTREE_PILOT_REJECT,
+            accepted=False,
+            rejection_reasons=deduped,
+            receipt=None,
+            cwd_guard=cwd_guard,
+            task_execution_performed=False,
+            file_edit_performed=False,
+        )
+
+    assert canonical_root is not None
+    try:
+        written = _materialize_text_artifacts(
+            worktree_path=worktree_path,
+            canonical_root=canonical_root,
+            artifact_contents=contents,
+        )
+    except ValueError as exc:
+        code = FAIL_SYMLINK_PATH if "symlink" in str(exc) else FAIL_ARTIFACT_OUTSIDE_ROOT
+        return BoundedWorktreeWorkerExecutionPilotResult(
+            decision=BOUNDED_WORKTREE_PILOT_REJECT,
+            accepted=False,
+            rejection_reasons=[code],
+            receipt=None,
+            cwd_guard=cwd_guard,
+            task_execution_performed=False,
+            file_edit_performed=False,
+        )
+
+    artifact_digest = _digest({"written": written})
+    receipt_seed = {
+        "work_order_id": work_order_id,
+        "canonical_root": canonical_root,
+        "written_artifacts": sorted(written),
+        "artifact_digest": artifact_digest,
+        "worktree_spine_result_digest": str(spine.get("result_digest") or _digest(spine)),
+    }
+    receipt = BoundedWorktreePilotReceipt(
+        receipt_id=(
+            "bounded_wt_pilot_"
+            + hashlib.sha256(_digest(receipt_seed).encode("utf-8")).hexdigest()[:16]
+        ),
+        work_order_id=work_order_id,
+        worktree_path=str(worktree_path.resolve()),
+        canonical_root=canonical_root,
+        written_artifacts=sorted(supplied),
+        artifact_manifest_digest=str(writer_receipt.get("artifact_manifest_digest") or ""),
+        written_artifact_digest=artifact_digest,
+        worktree_spine_result_digest=str(spine.get("result_digest") or _digest(spine)),
+        generic_writer_receipt_digest=str(
+            writer_receipt.get("receipt_id") or _digest(writer_receipt)
+        ),
+        governed_shell_receipt_digest=str(
+            shell_receipt.get("run_receipt_id") or _digest(shell_receipt)
+        ),
+        cwd_guard_receipt_digest=_digest(cwd_guard.to_dict() if cwd_guard else {}),
+    )
+    return BoundedWorktreeWorkerExecutionPilotResult(
+        decision=BOUNDED_WORKTREE_PILOT_ACCEPT,
+        accepted=True,
+        rejection_reasons=[],
+        receipt=receipt,
+        cwd_guard=cwd_guard,
+        task_execution_performed=True,
+        file_edit_performed=True,
+    )
+
+
+__all__ = [
+    "BOUNDED_WORKTREE_PILOT_ACCEPT",
+    "BOUNDED_WORKTREE_PILOT_REJECT",
+    "BoundedWorktreePilotReceipt",
+    "BoundedWorktreeWorkerExecutionPilotResult",
+    "FAIL_ARTIFACTS_MISMATCH",
+    "FAIL_ARTIFACT_OUTSIDE_ROOT",
+    "FAIL_CANONICAL_ROOT_INVALID",
+    "FAIL_CONTENT_INVALID",
+    "FAIL_CWD_GUARD",
+    "FAIL_DENIED_ARTIFACT",
+    "FAIL_GENERIC_WRITER_DRYRUN",
+    "FAIL_GOVERNED_SHELL_DRYRUN",
+    "FAIL_HOLOINDEX_INDEX_GAP",
+    "FAIL_SYMLINK_PATH",
+    "FAIL_WORKTREE_MISSING",
+    "FAIL_WORKTREE_SPINE",
+    "run_bounded_worktree_worker_execution_pilot",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_bounded_worktree_worker_execution_pilot.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_bounded_worktree_worker_execution_pilot.py
@@ -1,0 +1,369 @@
+"""Tests for REDDOG_BOUNDED_WORKTREE_WORKER_EXECUTION_PILOT_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src import (
+    reddog_bounded_worktree_worker_execution_pilot as pilot,
+)
+from modules.communication.moltbot_bridge.src.reddog_generic_agent_worktree_writer_dryrun import (
+    GENERIC_WRITER_DRYRUN_ACCEPT,
+    GenericAgentWorktreeDomainProfile,
+    plan_generic_agent_worktree_writer_dry_run,
+)
+from modules.communication.moltbot_bridge.src.reddog_operator_loop_wardrobe_selection import (
+    EXECUTION_GOVERNED_CANDIDATE,
+    WARDROBE_SELECTION_ACCEPT,
+    WARDROBE_SOVEREIGN_EXECUTION,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_work_order_policy_gate import (
+    SIGNATURE_GATE_ACCEPTED,
+)
+from modules.communication.moltbot_bridge.src.reddog_signed_receipt_chain import (
+    SIGNED_RECEIPT_CHAIN_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    VALVE_OPEN_WORKTREE_CREATE,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_governed_shell_runner_dryrun import (
+    GOVERNED_SHELL_DRYRUN_ACCEPT,
+    GovernedShellCommandProfile,
+    plan_governed_shell_runner_dry_run,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_bounded_worktree_worker_execution_pilot.py"
+)
+BOUNDED_WORKTREE_PILOT_ACCEPT = pilot.BOUNDED_WORKTREE_PILOT_ACCEPT
+BOUNDED_WORKTREE_PILOT_REJECT = pilot.BOUNDED_WORKTREE_PILOT_REJECT
+FAIL_ARTIFACTS_MISMATCH = pilot.FAIL_ARTIFACTS_MISMATCH
+FAIL_CWD_GUARD = pilot.FAIL_CWD_GUARD
+FAIL_DENIED_ARTIFACT = pilot.FAIL_DENIED_ARTIFACT
+FAIL_GOVERNED_SHELL_DRYRUN = pilot.FAIL_GOVERNED_SHELL_DRYRUN
+FAIL_HOLOINDEX_INDEX_GAP = pilot.FAIL_HOLOINDEX_INDEX_GAP
+FAIL_WORKTREE_SPINE = pilot.FAIL_WORKTREE_SPINE
+run_bounded_worktree_worker_execution_pilot = (
+    pilot.run_bounded_worktree_worker_execution_pilot
+)
+
+
+def _selection_receipt() -> dict:
+    return {
+        "decision": WARDROBE_SELECTION_ACCEPT,
+        "selected_wardrobe": WARDROBE_SOVEREIGN_EXECUTION,
+        "execution_plane": EXECUTION_GOVERNED_CANDIDATE,
+        "no_execution_performed": True,
+    }
+
+
+def _signed_authority(work_order_id: str = "wo-pilot-1") -> dict:
+    return {
+        "accepted": True,
+        "signature_gate_status": SIGNATURE_GATE_ACCEPTED,
+        "work_order_id": work_order_id,
+        "permission_snapshot_digest": "sha256:perm",
+        "signature_gate_digest": "sha256:signed-authority",
+    }
+
+
+def _receipt_chain() -> dict:
+    return {
+        "accepted": True,
+        "decision": SIGNED_RECEIPT_CHAIN_ACCEPT,
+        "terminal_receipt_hash": "sha256:terminal",
+        "no_execution_performed": True,
+        "no_reward_settlement_performed": True,
+    }
+
+
+def _valve() -> dict:
+    return {
+        "valve_state": VALVE_OPEN_WORKTREE_CREATE,
+        "decision_digest": "sha256:valve",
+        "rejection_reasons": [],
+        "no_execution_performed": True,
+    }
+
+
+def _domain_profile() -> GenericAgentWorktreeDomainProfile:
+    return GenericAgentWorktreeDomainProfile(
+        profile_id="pilot_docs_patch",
+        operation="pilot_docs_patch",
+        artifact_contract_type="text_patch",
+        domain_id_pattern=r"[a-z][a-z0-9_]{2,49}",
+        canonical_root_template="modules/communication/moltbot_bridge/tests/fixtures/{domain_id}",
+        allowed_path_patterns=[
+            "modules/communication/moltbot_bridge/tests/fixtures/{domain_id}/**"
+        ],
+        denied_path_patterns=["**/.env", "**/secrets/**"],
+        required_tests=[
+            "python -m pytest "
+            "modules/communication/moltbot_bridge/tests/"
+            "test_reddog_bounded_worktree_worker_execution_pilot.py -q"
+        ],
+        branch_prefix="feat/",
+        draft_pr_only=True,
+        consensus_required=False,
+    )
+
+
+def _shell_profile() -> GovernedShellCommandProfile:
+    return GovernedShellCommandProfile(
+        profile_id="pilot_pytest",
+        command_kind="test",
+        argv_prefix=["python", "-m", "pytest"],
+        allowed_arg_patterns=[r"modules/[A-Za-z0-9_./-]+\.py", r"-q"],
+        denied_arg_patterns=[r".*--index-all.*", r".*\.env.*", r".*WSP_framework.*"],
+        requires_cwd_guard=True,
+        requires_worktree=True,
+        timeout_seconds=300,
+        max_stdout_bytes=100000,
+        max_stderr_bytes=100000,
+        secret_env_refs=[],
+        output_redaction_policy="strict",
+        draft_pr_only=True,
+        consensus_required=False,
+        repo_sensitive=True,
+    )
+
+
+def _spine_result(work_order_id: str, worktree: Path) -> dict:
+    return {
+        "decision": "WORKTREE_SPINE_ACCEPT",
+        "work_order_id": work_order_id,
+        "result_digest": "sha256:spine",
+        "no_task_execution_performed": True,
+        "no_file_edit_performed": True,
+        "no_pr_created": True,
+        "no_live_openclaw_enqueue": True,
+        "no_hermes_dispatch": True,
+        "merge_performed": False,
+        "worktree_create_result": {
+            "decision": "WORKTREE_CREATE_ACCEPT",
+            "work_order_id": work_order_id,
+            "worktree_path": str(worktree),
+            "branch_name": "feat/reddog-bounded-worker-pilot",
+            "result_digest": "sha256:worktree-create",
+            "no_task_execution_performed": True,
+            "no_file_edit_performed": True,
+            "no_pr_created": True,
+            "merge_performed": False,
+        },
+    }
+
+
+def _valid_request(tmp_path: Path) -> dict:
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "isolated-worktree"
+    repo.mkdir()
+    worktree.mkdir()
+    work_order_id = "wo-pilot-1"
+    artifact = "modules/communication/moltbot_bridge/tests/fixtures/reddog_pilot/README.md"
+    writer = plan_generic_agent_worktree_writer_dry_run(
+        {
+            "work_order_id": work_order_id,
+            "operation": "pilot_docs_patch",
+            "domain_id": "reddog_pilot",
+            "domain_profile": _domain_profile(),
+            "planned_artifacts": [artifact],
+            "requested_allowed_paths": [
+                "modules/communication/moltbot_bridge/tests/fixtures/reddog_pilot/**"
+            ],
+            "target_branch": "feat/reddog-bounded-worker-pilot",
+            "repo_root": str(repo),
+            "worktree_path": str(worktree),
+            "operation_cwd": str(worktree),
+            "selection_receipt": _selection_receipt(),
+            "signed_authority": _signed_authority(work_order_id),
+            "signed_receipt_chain": _receipt_chain(),
+            "execution_valve_decision": _valve(),
+            "permission_snapshot_digest": "sha256:perm",
+            "holoindex_evidence": {"index_gap_detected": False},
+        }
+    )
+    assert writer.decision == GENERIC_WRITER_DRYRUN_ACCEPT
+    shell = plan_governed_shell_runner_dry_run(
+        {
+            "work_order_id": work_order_id,
+            "profile": _shell_profile(),
+            "argv": [
+                "python",
+                "-m",
+                "pytest",
+                "modules/communication/moltbot_bridge/tests/"
+                "test_reddog_bounded_worktree_worker_execution_pilot.py",
+                "-q",
+            ],
+            "operation_cwd": str(worktree),
+            "worktree_path": str(worktree),
+            "repo_root": str(repo),
+            "selection_receipt": _selection_receipt(),
+            "signed_authority": _signed_authority(work_order_id),
+            "signed_receipt_chain": _receipt_chain(),
+            "execution_valve_decision": _valve(),
+            "generic_writer_dryrun_receipt": writer.receipt.to_dict(),
+            "permission_snapshot_digest": "sha256:perm",
+            "stdin_policy": "none",
+            "env_policy": {"scrubbed": True},
+            "holoindex_evidence": {
+                "index_gap_detected": False,
+                "holoindex_freshness_receipt_digest": "sha256:holo-fresh",
+            },
+        }
+    )
+    assert shell.decision == GOVERNED_SHELL_DRYRUN_ACCEPT
+    return {
+        "work_order_id": work_order_id,
+        "repo_root": str(repo),
+        "worktree_path": str(worktree),
+        "operation_cwd": str(worktree),
+        "canonical_root": "modules/communication/moltbot_bridge/tests/fixtures/reddog_pilot",
+        "worktree_spine_result": _spine_result(work_order_id, worktree),
+        "generic_writer_dryrun_result": writer.to_dict(),
+        "governed_shell_dryrun_result": shell.to_dict(),
+        "artifact_contents": {
+            artifact: "# RedDog Pilot\n\nThis file exists only inside the isolated worktree.\n"
+        },
+        "holoindex_evidence": {
+            "index_gap_detected": False,
+            "holoindex_freshness_receipt_digest": "sha256:holo-fresh",
+        },
+    }
+
+
+def test_pilot_materializes_one_bounded_artifact_inside_isolated_worktree(tmp_path: Path) -> None:
+    req = _valid_request(tmp_path)
+
+    result = run_bounded_worktree_worker_execution_pilot(req)
+
+    assert result.decision == BOUNDED_WORKTREE_PILOT_ACCEPT
+    assert result.accepted is True
+    assert result.rejection_reasons == []
+    assert result.task_execution_performed is True
+    assert result.file_edit_performed is True
+    assert result.shell_command_executed is False
+    assert result.draft_pr_created is False
+    assert result.merge_performed is False
+    assert result.openclaw_enqueue_performed is False
+    assert result.hermes_dispatch_performed is False
+    assert result.holoindex_reindex_performed is False
+    assert result.receipt is not None
+    artifact = result.receipt.written_artifacts[0]
+    assert (Path(req["worktree_path"]) / artifact).exists()
+    assert not (Path(req["repo_root"]) / artifact).exists()
+    assert result.receipt.validation_command_executed is False
+    assert result.receipt.draft_pr_created is False
+    assert result.receipt.merge_performed is False
+
+
+def test_rejects_without_accepted_worktree_spine_before_writing(tmp_path: Path) -> None:
+    req = _valid_request(tmp_path)
+    req["worktree_spine_result"]["decision"] = "WORKTREE_SPINE_REJECT"
+
+    result = run_bounded_worktree_worker_execution_pilot(req)
+
+    assert result.decision == BOUNDED_WORKTREE_PILOT_REJECT
+    assert FAIL_WORKTREE_SPINE in result.rejection_reasons
+    artifact = next(iter(req["artifact_contents"]))
+    assert not (Path(req["worktree_path"]) / artifact).exists()
+
+
+def test_rejects_shared_repo_cwd_before_writing(tmp_path: Path) -> None:
+    req = _valid_request(tmp_path)
+    req["worktree_path"] = req["repo_root"]
+    req["operation_cwd"] = req["repo_root"]
+
+    result = run_bounded_worktree_worker_execution_pilot(req)
+
+    assert result.accepted is False
+    assert FAIL_CWD_GUARD in result.rejection_reasons
+    artifact = next(iter(req["artifact_contents"]))
+    assert not (Path(req["repo_root"]) / artifact).exists()
+
+
+def test_rejects_missing_or_extra_artifact_content(tmp_path: Path) -> None:
+    req = _valid_request(tmp_path)
+    req["artifact_contents"] = {
+        **req["artifact_contents"],
+        "modules/communication/moltbot_bridge/tests/fixtures/reddog_pilot/EXTRA.md": "extra",
+    }
+
+    result = run_bounded_worktree_worker_execution_pilot(req)
+
+    assert result.accepted is False
+    assert FAIL_ARTIFACTS_MISMATCH in result.rejection_reasons
+
+
+def test_rejects_denied_artifact_even_if_receipt_is_tampered(tmp_path: Path) -> None:
+    req = _valid_request(tmp_path)
+    denied = "modules/communication/moltbot_bridge/tests/fixtures/reddog_pilot/.env"
+    req["generic_writer_dryrun_result"]["receipt"]["planned_artifacts"] = [denied]
+    req["artifact_contents"] = {denied: "SAFE_PLACEHOLDER=1\n"}
+
+    result = run_bounded_worktree_worker_execution_pilot(req)
+
+    assert result.accepted is False
+    assert FAIL_DENIED_ARTIFACT in result.rejection_reasons
+    assert not (Path(req["worktree_path"]) / denied).exists()
+
+
+def test_rejects_governed_shell_dryrun_failure(tmp_path: Path) -> None:
+    req = _valid_request(tmp_path)
+    req["governed_shell_dryrun_result"]["decision"] = "GOVERNED_SHELL_DRYRUN_REJECT"
+
+    result = run_bounded_worktree_worker_execution_pilot(req)
+
+    assert result.accepted is False
+    assert FAIL_GOVERNED_SHELL_DRYRUN in result.rejection_reasons
+
+
+def test_rejects_holoindex_index_gap_before_writing(tmp_path: Path) -> None:
+    req = _valid_request(tmp_path)
+    req["holoindex_evidence"] = {"index_gap_detected": True, "retrieval_quality": "INDEX_GAP"}
+
+    result = run_bounded_worktree_worker_execution_pilot(req)
+
+    assert result.accepted is False
+    assert FAIL_HOLOINDEX_INDEX_GAP in result.rejection_reasons
+    artifact = next(iter(req["artifact_contents"]))
+    assert not (Path(req["worktree_path"]) / artifact).exists()
+
+
+def test_rejects_secret_like_content(tmp_path: Path) -> None:
+    req = _valid_request(tmp_path)
+    artifact = next(iter(req["artifact_contents"]))
+    req["artifact_contents"][artifact] = "api_key = 'abc'\n"
+
+    result = run_bounded_worktree_worker_execution_pilot(req)
+
+    assert result.accepted is False
+    assert result.rejection_reasons == ["FAIL_CONTENT_INVALID"]
+    assert not (Path(req["worktree_path"]) / artifact).exists()
+
+
+def test_module_ast_has_no_shell_git_or_queue_authority() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_imports = {"subprocess", "os", "shutil", "requests", "git", "gh"}
+    banned_calls = {"eval", "exec", "open"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".")[0] not in banned_imports
+        if isinstance(node, ast.ImportFrom):
+            assert (node.module or "").split(".")[0] not in banned_imports
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    assert "from modules.communication.moltbot_bridge.src.openclaw" not in source
+    assert "from modules.foundups.agent.src.hermes" not in source
+    assert "subprocess" not in source
+    assert "gh pr" not in source
+    assert "git push" not in source


### PR DESCRIPTION
## Summary

Implements `REDDOG_BOUNDED_WORKTREE_WORKER_EXECUTION_PILOT_PHASE1` as the first bounded coding-task pilot after the live-enqueue runtime binding.

The pilot consumes already-accepted receipts from the existing WRE worktree spine, generic writer dry-run, governed shell dry-run, CWD guard, and HoloIndex evidence. It can materialize exact planned text artifacts inside an already-created isolated worktree only after all guards pass.

## WSP_97 Boundary

OBSERVED:
- Writes are limited to exact planned text artifacts under the canonical root inside the isolated worktree.
- The pilot rejects bad worktree spine receipts, generic writer mismatches, governed shell rejections, shared-main CWD, denied paths, HoloIndex gaps, and secret-like content before writing.
- The pilot emits a deterministic receipt and keeps explicit no-authority flags.

SPECIFIED_NOT_IMPLEMENTED:
- No shell/subprocess execution.
- No git/gh operation.
- No PR creation, push, merge, or protected-ref mutation.
- No OpenClaw enqueue or Hermes dispatch.
- No reward settlement.
- No HoloIndex runtime mutation or re-index.
- No extension runtime wiring.

## Local Validation

```text
68 passed  test_reddog_bounded_worktree_worker_execution_pilot.py + adjacent WRE spine/generic writer/governed shell tests
py_compile  PASS
git diff --check  PASS
diff additions ASCII scan  PASS
new Python files NUL/ASCII scan  PASS
```

## HoloIndex

Read-only probes surfaced adjacent worktree, generic writer, governed shell, and contract surfaces, but not the new pilot module. Recorded:

```text
HOLOINDEX_REDDOG_BOUNDED_WORKTREE_WORKER_EXECUTION_PILOT_INDEX_GAP_PHASE1
```

No runtime re-index performed.

## Next Slice

`WRE_AUTONOMOUS_SLICE_VERIFIER_RUNTIME_PHASE1` should follow before any verified draft PR publishing or recursive operational loop expansion.