### PR TITLE
feat(reddog): add verified draft pr publish gate

### DIFF
--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -2,6 +2,41 @@
 
 ## Chronological Change Log
 
+### [2026-07-14] - REDDOG_VERIFIED_DRAFT_PR_PUBLISH_PHASE1
+
+**WSP Protocol References**: WSP 00 (Operational Grounding), WSP 15 (Priority),
+WSP 50 (Pre-Action), WSP 97 (Truth Boundary), WSP 22 (ModLog)
+
+**Type**: Runtime draft-PR publisher. Exact-head verifier-gated. Draft only.
+
+**Deliverable**:
+- Added `src/reddog_verified_draft_pr_publish.py`: consumes an accepted
+  autonomous-slice verifier result and publishes only when the caller's
+  pre-publish branch head equals the verified head. It validates branch policy,
+  draft-only flags, PR metadata, secret-free PR text, and then delegates only
+  `push_branch` + `create_draft_pr` to an injected runner compatible with the
+  existing `worktree_pr_runner.py` draft-PR helper.
+- Added `tests/test_reddog_verified_draft_pr_publish.py`: happy path, rejected
+  verifier result, head mismatch, branch/base policy, non-draft/ready/merge
+  request, missing metadata, secret metadata, push failure, draft-PR exception,
+  invalid PR URL, deterministic receipt, JSON serialization, and AST
+  no-direct-git/no-ready/no-merge/no-PatternMemory coverage.
+
+**Boundary**: This slice does not author code, run tests, compute diffs, call
+GitHub directly, mark PRs ready, merge, write PatternMemory, settle rewards, or
+re-index HoloIndex. It is a narrow bridge from verifier `ACCEPT` to draft PR
+creation through an injected runner.
+
+**HoloIndex**: Read-only probes surfaced adjacent verifier, draft PR, and
+workflow concepts but not the new publish seam. Recorded
+`HOLOINDEX_REDDOG_VERIFIED_DRAFT_PR_PUBLISH_INDEX_GAP_PHASE1`; no runtime
+re-index performed.
+
+**Verification**: publish + verifier tests 25 passed; py_compile passed; git
+diff --check clean; new files ASCII/NUL clean.
+
+---
+
 ### [2026-07-14] - WRE_AUTONOMOUS_SLICE_VERIFIER_RUNTIME_PHASE1
 
 **WSP Protocol References**: WSP 00 (Operational Grounding), WSP 15 (Priority),

--- a/modules/infrastructure/wre_core/src/reddog_verified_draft_pr_publish.py
+++ b/modules/infrastructure/wre_core/src/reddog_verified_draft_pr_publish.py
@@ -1,0 +1,373 @@
+"""Verified draft PR publish gate for RedDog/WRE coding slices.
+
+Slice: REDDOG_VERIFIED_DRAFT_PR_PUBLISH_PHASE1
+
+This module publishes a draft PR only after the independent autonomous-slice
+verifier has accepted the exact branch head. It delegates side effects to an
+injected runner with the same draft-PR interface used by the existing
+`worktree_pr_runner.py` helper. It never marks ready, merges, settles rewards,
+writes PatternMemory, executes tests, or mutates HoloIndex.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Protocol
+
+from modules.infrastructure.wre_core.src.wre_autonomous_slice_verifier_runtime import (
+    AUTONOMOUS_SLICE_VERIFIER_ACCEPT,
+)
+
+VERIFIED_DRAFT_PR_PUBLISH_ACCEPT = "VERIFIED_DRAFT_PR_PUBLISH_ACCEPT"
+VERIFIED_DRAFT_PR_PUBLISH_REJECT = "VERIFIED_DRAFT_PR_PUBLISH_REJECT"
+
+FAIL_VERIFIER_NOT_ACCEPTED = "FAIL_VERIFIER_NOT_ACCEPTED"
+FAIL_HEAD_MISMATCH = "FAIL_HEAD_MISMATCH"
+FAIL_BRANCH_POLICY = "FAIL_BRANCH_POLICY"
+FAIL_DRAFT_ONLY = "FAIL_DRAFT_ONLY"
+FAIL_PR_METADATA = "FAIL_PR_METADATA"
+FAIL_SECRET_IN_PR_METADATA = "FAIL_SECRET_IN_PR_METADATA"
+FAIL_PUSH_BRANCH = "FAIL_PUSH_BRANCH"
+FAIL_CREATE_DRAFT_PR = "FAIL_CREATE_DRAFT_PR"
+FAIL_PR_URL = "FAIL_PR_URL"
+
+ALLOWED_BRANCH_PREFIXES = ("feat/", "fix/", "docs/", "test/", "chore/")
+SECRET_MARKERS = (
+    "authorization:",
+    "bearer ",
+    "api_key",
+    "apikey",
+    "private_key",
+    "begin private key",
+    "secret=",
+    "token=",
+    "password=",
+)
+
+
+class DraftPrRunner(Protocol):
+    def push_branch(self, *, worktree_path: Path, branch_name: str) -> Mapping[str, Any]:
+        ...
+
+    def create_draft_pr(
+        self,
+        *,
+        branch_name: str,
+        base_branch: str,
+        title: str,
+        body: str,
+    ) -> str:
+        ...
+
+
+@dataclass(frozen=True)
+class VerifiedDraftPrPublishReceipt:
+    receipt_id: str
+    work_order_id: str
+    slice_name: str
+    verifier_receipt_id: str
+    branch_name: str
+    base_branch: str
+    verified_head_sha: str
+    draft_pr_url: str
+    changed_paths: List[str]
+    rejection_reasons: List[str]
+    accepted: bool
+    no_ready_performed: bool = True
+    no_merge_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_reward_settlement_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class VerifiedDraftPrPublishResult:
+    decision: str
+    accepted: bool
+    receipt: VerifiedDraftPrPublishReceipt
+    rejection_reasons: List[str] = field(default_factory=list)
+    push_result: Mapping[str, Any] = field(default_factory=dict)
+    no_ready_performed: bool = True
+    no_merge_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_reward_settlement_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["receipt"] = self.receipt.to_dict()
+        payload["push_result"] = dict(self.push_result)
+        return payload
+
+
+def _digest(payload: Any) -> str:
+    raw = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        default=str,
+    )
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        return value.to_dict()
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _list(value: Any) -> List[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _dedupe(values: List[str]) -> List[str]:
+    seen = set()
+    ordered: List[str] = []
+    for value in values:
+        text = str(value or "").strip()
+        if text and text not in seen:
+            seen.add(text)
+            ordered.append(text)
+    return ordered
+
+
+def _contains_secret(value: Any) -> bool:
+    text = json.dumps(value, sort_keys=True, default=str).lower()
+    return any(marker in text for marker in SECRET_MARKERS)
+
+
+def _draft_url_ok(url: str) -> bool:
+    return url.startswith("https://github.com/") and "/pull/" in url
+
+
+def _receipt_seed(
+    *,
+    work_order_id: str,
+    slice_name: str,
+    verifier_receipt_id: str,
+    branch_name: str,
+    base_branch: str,
+    verified_head_sha: str,
+    draft_pr_url: str,
+    changed_paths: List[str],
+    rejection_reasons: List[str],
+) -> Dict[str, Any]:
+    return {
+        "work_order_id": work_order_id,
+        "slice_name": slice_name,
+        "verifier_receipt_id": verifier_receipt_id,
+        "branch_name": branch_name,
+        "base_branch": base_branch,
+        "verified_head_sha": verified_head_sha,
+        "draft_pr_url": draft_pr_url,
+        "changed_paths": changed_paths,
+        "rejection_reasons": rejection_reasons,
+    }
+
+
+def _result(
+    *,
+    accepted: bool,
+    reasons: List[str],
+    work_order_id: str,
+    slice_name: str,
+    verifier_receipt_id: str,
+    branch_name: str,
+    base_branch: str,
+    verified_head_sha: str,
+    draft_pr_url: str,
+    changed_paths: List[str],
+    push_result: Mapping[str, Any] | None = None,
+) -> VerifiedDraftPrPublishResult:
+    deduped = _dedupe(reasons)
+    seed = _receipt_seed(
+        work_order_id=work_order_id,
+        slice_name=slice_name,
+        verifier_receipt_id=verifier_receipt_id,
+        branch_name=branch_name,
+        base_branch=base_branch,
+        verified_head_sha=verified_head_sha,
+        draft_pr_url=draft_pr_url,
+        changed_paths=changed_paths,
+        rejection_reasons=deduped,
+    )
+    receipt = VerifiedDraftPrPublishReceipt(
+        receipt_id="verified_draft_pr_" + _digest(seed).removeprefix("sha256:")[:16],
+        work_order_id=work_order_id,
+        slice_name=slice_name,
+        verifier_receipt_id=verifier_receipt_id,
+        branch_name=branch_name,
+        base_branch=base_branch,
+        verified_head_sha=verified_head_sha,
+        draft_pr_url=draft_pr_url,
+        changed_paths=changed_paths,
+        rejection_reasons=deduped,
+        accepted=accepted,
+    )
+    return VerifiedDraftPrPublishResult(
+        decision=(
+            VERIFIED_DRAFT_PR_PUBLISH_ACCEPT
+            if accepted
+            else VERIFIED_DRAFT_PR_PUBLISH_REJECT
+        ),
+        accepted=accepted,
+        receipt=receipt,
+        rejection_reasons=deduped,
+        push_result=dict(push_result or {}),
+    )
+
+
+def publish_verified_draft_pr(
+    request: Mapping[str, Any],
+    *,
+    runner: DraftPrRunner,
+) -> VerifiedDraftPrPublishResult:
+    """Push a verified branch and create a draft PR only.
+
+    The caller must provide an accepted autonomous-slice verifier result. This
+    function refuses to publish if the pre-publish branch head does not match the
+    verifier receipt's head SHA.
+    """
+    req = _mapping(request)
+    verifier_result = _mapping(req.get("verifier_result"))
+    verifier_receipt = _mapping(verifier_result.get("receipt"))
+    work_order_id = str(verifier_receipt.get("work_order_id") or req.get("work_order_id") or "")
+    slice_name = str(verifier_receipt.get("slice_name") or req.get("slice_name") or "")
+    verifier_receipt_id = str(verifier_receipt.get("receipt_id") or "")
+    verified_head_sha = str(verifier_receipt.get("head_sha") or "")
+    changed_paths = [str(path) for path in _list(verifier_receipt.get("changed_paths"))]
+    branch_name = str(req.get("branch_name") or "")
+    base_branch = str(req.get("base_branch") or "main")
+    title = str(req.get("pr_title") or "")
+    body = str(req.get("pr_body") or "")
+    worktree_path = Path(str(req.get("worktree_path") or ""))
+    reasons: List[str] = []
+
+    if (
+        verifier_result.get("accepted") is not True
+        or verifier_result.get("decision") != AUTONOMOUS_SLICE_VERIFIER_ACCEPT
+        or not verifier_receipt_id
+    ):
+        reasons.append(FAIL_VERIFIER_NOT_ACCEPTED)
+    if str(req.get("pre_publish_branch_head_sha") or "") != verified_head_sha:
+        reasons.append(FAIL_HEAD_MISMATCH)
+    if base_branch != "main" or not branch_name.startswith(ALLOWED_BRANCH_PREFIXES):
+        reasons.append(FAIL_BRANCH_POLICY)
+    if (
+        req.get("draft_pr_only") is not True
+        or req.get("mark_ready") is True
+        or req.get("merge") is True
+    ):
+        reasons.append(FAIL_DRAFT_ONLY)
+    if not title.strip() or not body.strip() or not changed_paths:
+        reasons.append(FAIL_PR_METADATA)
+    if _contains_secret({"title": title, "body": body}):
+        reasons.append(FAIL_SECRET_IN_PR_METADATA)
+
+    if reasons:
+        return _result(
+            accepted=False,
+            reasons=reasons,
+            work_order_id=work_order_id,
+            slice_name=slice_name,
+            verifier_receipt_id=verifier_receipt_id,
+            branch_name=branch_name,
+            base_branch=base_branch,
+            verified_head_sha=verified_head_sha,
+            draft_pr_url="",
+            changed_paths=changed_paths,
+        )
+
+    push_result = dict(runner.push_branch(worktree_path=worktree_path, branch_name=branch_name))
+    if push_result.get("ok") is not True:
+        return _result(
+            accepted=False,
+            reasons=[FAIL_PUSH_BRANCH],
+            work_order_id=work_order_id,
+            slice_name=slice_name,
+            verifier_receipt_id=verifier_receipt_id,
+            branch_name=branch_name,
+            base_branch=base_branch,
+            verified_head_sha=verified_head_sha,
+            draft_pr_url="",
+            changed_paths=changed_paths,
+            push_result=push_result,
+        )
+
+    try:
+        draft_pr_url = runner.create_draft_pr(
+            branch_name=branch_name,
+            base_branch=base_branch,
+            title=title,
+            body=body,
+        )
+    except Exception:
+        return _result(
+            accepted=False,
+            reasons=[FAIL_CREATE_DRAFT_PR],
+            work_order_id=work_order_id,
+            slice_name=slice_name,
+            verifier_receipt_id=verifier_receipt_id,
+            branch_name=branch_name,
+            base_branch=base_branch,
+            verified_head_sha=verified_head_sha,
+            draft_pr_url="",
+            changed_paths=changed_paths,
+            push_result=push_result,
+        )
+
+    if not _draft_url_ok(str(draft_pr_url)):
+        return _result(
+            accepted=False,
+            reasons=[FAIL_PR_URL],
+            work_order_id=work_order_id,
+            slice_name=slice_name,
+            verifier_receipt_id=verifier_receipt_id,
+            branch_name=branch_name,
+            base_branch=base_branch,
+            verified_head_sha=verified_head_sha,
+            draft_pr_url=str(draft_pr_url or ""),
+            changed_paths=changed_paths,
+            push_result=push_result,
+        )
+
+    return _result(
+        accepted=True,
+        reasons=[],
+        work_order_id=work_order_id,
+        slice_name=slice_name,
+        verifier_receipt_id=verifier_receipt_id,
+        branch_name=branch_name,
+        base_branch=base_branch,
+        verified_head_sha=verified_head_sha,
+        draft_pr_url=str(draft_pr_url),
+        changed_paths=changed_paths,
+        push_result=push_result,
+    )
+
+
+__all__ = [
+    "FAIL_BRANCH_POLICY",
+    "FAIL_CREATE_DRAFT_PR",
+    "FAIL_DRAFT_ONLY",
+    "FAIL_HEAD_MISMATCH",
+    "FAIL_PR_METADATA",
+    "FAIL_PR_URL",
+    "FAIL_PUSH_BRANCH",
+    "FAIL_SECRET_IN_PR_METADATA",
+    "FAIL_VERIFIER_NOT_ACCEPTED",
+    "VERIFIED_DRAFT_PR_PUBLISH_ACCEPT",
+    "VERIFIED_DRAFT_PR_PUBLISH_REJECT",
+    "VerifiedDraftPrPublishReceipt",
+    "VerifiedDraftPrPublishResult",
+    "publish_verified_draft_pr",
+]

--- a/modules/infrastructure/wre_core/tests/test_reddog_verified_draft_pr_publish.py
+++ b/modules/infrastructure/wre_core/tests/test_reddog_verified_draft_pr_publish.py
@@ -1,0 +1,239 @@
+"""Tests for REDDOG_VERIFIED_DRAFT_PR_PUBLISH_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.infrastructure.wre_core.src import reddog_verified_draft_pr_publish as publish
+from modules.infrastructure.wre_core.src import wre_autonomous_slice_verifier_runtime as verify
+
+HEAD_SHA = "a" * 40
+PATH = "modules/communication/moltbot_bridge/tests/fixtures/reddog_pilot/README.md"
+
+
+class FakeRunner:
+    def __init__(self, *, push_ok: bool = True, pr_url: str | None = None) -> None:
+        self.push_ok = push_ok
+        self.pr_url = pr_url or "https://github.com/FOUNDUPS/Foundups-Agent/pull/1000"
+        self.calls: list = []
+
+    def push_branch(self, *, worktree_path: Path, branch_name: str):
+        self.calls.append(("push_branch", str(worktree_path), branch_name))
+        return {"ok": self.push_ok, "stdout": "", "stderr": "" if self.push_ok else "fail"}
+
+    def create_draft_pr(self, *, branch_name: str, base_branch: str, title: str, body: str):
+        self.calls.append(("create_draft_pr", branch_name, base_branch, title, body))
+        if self.pr_url == "RAISE":
+            raise RuntimeError("draft pr failed")
+        return self.pr_url
+
+
+def _verifier_result(*, accepted: bool = True) -> dict:
+    return {
+        "decision": (
+            verify.AUTONOMOUS_SLICE_VERIFIER_ACCEPT
+            if accepted
+            else verify.AUTONOMOUS_SLICE_VERIFIER_REJECT
+        ),
+        "accepted": accepted,
+        "receipt": {
+            "receipt_id": "wre_slice_verify_1234",
+            "work_order_id": "wo-publish-1",
+            "slice_name": "REDDOG_VERIFIED_DRAFT_PR_PUBLISH_PHASE1",
+            "worker_id": "worker:author",
+            "verifier_id": "worker:verifier",
+            "head_sha": HEAD_SHA,
+            "changed_paths": [PATH],
+        },
+    }
+
+
+def valid_request() -> dict:
+    return {
+        "verifier_result": _verifier_result(),
+        "pre_publish_branch_head_sha": HEAD_SHA,
+        "branch_name": "feat/reddog-verified-draft-pr-publish-phase1",
+        "base_branch": "main",
+        "pr_title": "feat(reddog): verified draft pr publish",
+        "pr_body": "Verified by WRE autonomous slice verifier.",
+        "worktree_path": "O:/tmp/reddog-worker",
+        "draft_pr_only": True,
+        "mark_ready": False,
+        "merge": False,
+    }
+
+
+def assert_reject(req: dict, code: str) -> None:
+    runner = FakeRunner()
+    result = publish.publish_verified_draft_pr(req, runner=runner)
+
+    assert result.accepted is False
+    assert result.decision == publish.VERIFIED_DRAFT_PR_PUBLISH_REJECT
+    assert code in result.rejection_reasons
+    assert code in result.receipt.rejection_reasons
+    assert result.no_ready_performed is True
+    assert result.no_merge_performed is True
+    assert result.no_pattern_memory_write_performed is True
+
+
+def test_publishes_draft_pr_only_after_accepted_verifier_result() -> None:
+    runner = FakeRunner()
+    result = publish.publish_verified_draft_pr(valid_request(), runner=runner)
+
+    assert result.accepted is True
+    assert result.decision == publish.VERIFIED_DRAFT_PR_PUBLISH_ACCEPT
+    assert result.rejection_reasons == []
+    assert result.receipt.draft_pr_url.endswith("/pull/1000")
+    assert result.receipt.verified_head_sha == HEAD_SHA
+    assert result.receipt.changed_paths == [PATH]
+    assert result.receipt.no_ready_performed is True
+    assert result.receipt.no_merge_performed is True
+    assert result.receipt.no_pattern_memory_write_performed is True
+    assert [call[0] for call in runner.calls] == ["push_branch", "create_draft_pr"]
+
+
+def test_rejects_unaccepted_or_malformed_verifier_result_before_runner() -> None:
+    req = valid_request()
+    req["verifier_result"] = _verifier_result(accepted=False)
+    runner = FakeRunner()
+    result = publish.publish_verified_draft_pr(req, runner=runner)
+
+    assert result.accepted is False
+    assert publish.FAIL_VERIFIER_NOT_ACCEPTED in result.rejection_reasons
+    assert runner.calls == []
+
+
+def test_rejects_head_mismatch_before_push() -> None:
+    req = valid_request()
+    req["pre_publish_branch_head_sha"] = "b" * 40
+    runner = FakeRunner()
+    result = publish.publish_verified_draft_pr(req, runner=runner)
+
+    assert result.accepted is False
+    assert publish.FAIL_HEAD_MISMATCH in result.rejection_reasons
+    assert runner.calls == []
+
+
+def test_rejects_bad_branch_policy() -> None:
+    req = valid_request()
+    req["branch_name"] = "main"
+    assert_reject(req, publish.FAIL_BRANCH_POLICY)
+
+    req = valid_request()
+    req["base_branch"] = "release"
+    assert_reject(req, publish.FAIL_BRANCH_POLICY)
+
+
+def test_rejects_non_draft_or_ready_merge_request() -> None:
+    req = valid_request()
+    req["draft_pr_only"] = False
+    assert_reject(req, publish.FAIL_DRAFT_ONLY)
+
+    req = valid_request()
+    req["mark_ready"] = True
+    assert_reject(req, publish.FAIL_DRAFT_ONLY)
+
+    req = valid_request()
+    req["merge"] = True
+    assert_reject(req, publish.FAIL_DRAFT_ONLY)
+
+
+def test_rejects_missing_metadata_or_secret_in_body() -> None:
+    req = valid_request()
+    req["pr_title"] = ""
+    assert_reject(req, publish.FAIL_PR_METADATA)
+
+    req = valid_request()
+    req["verifier_result"]["receipt"]["changed_paths"] = []
+    assert_reject(req, publish.FAIL_PR_METADATA)
+
+    req = valid_request()
+    req["pr_body"] = "api_key = leak"
+    assert_reject(req, publish.FAIL_SECRET_IN_PR_METADATA)
+
+
+def test_rejects_push_failure_without_creating_pr() -> None:
+    runner = FakeRunner(push_ok=False)
+    result = publish.publish_verified_draft_pr(valid_request(), runner=runner)
+
+    assert result.accepted is False
+    assert result.rejection_reasons == [publish.FAIL_PUSH_BRANCH]
+    assert [call[0] for call in runner.calls] == ["push_branch"]
+
+
+def test_rejects_create_draft_pr_exception() -> None:
+    runner = FakeRunner(pr_url="RAISE")
+    result = publish.publish_verified_draft_pr(valid_request(), runner=runner)
+
+    assert result.accepted is False
+    assert result.rejection_reasons == [publish.FAIL_CREATE_DRAFT_PR]
+    assert [call[0] for call in runner.calls] == ["push_branch", "create_draft_pr"]
+
+
+def test_rejects_non_github_pr_url() -> None:
+    runner = FakeRunner(pr_url="not-a-pr-url")
+    result = publish.publish_verified_draft_pr(valid_request(), runner=runner)
+
+    assert result.accepted is False
+    assert result.rejection_reasons == [publish.FAIL_PR_URL]
+
+
+def test_receipt_is_deterministic_and_json_serializable() -> None:
+    first = publish.publish_verified_draft_pr(valid_request(), runner=FakeRunner())
+    second = publish.publish_verified_draft_pr(valid_request(), runner=FakeRunner())
+
+    assert first.receipt.receipt_id == second.receipt.receipt_id
+    dumped = json.dumps(first.to_dict(), sort_keys=True)
+    assert "verified_draft_pr_" in dumped
+    assert first.receipt.no_merge_performed is True
+    assert first.no_merge_performed is True
+
+
+def test_ast_boundary_no_direct_git_gh_merge_or_memory_write() -> None:
+    path = Path("modules/infrastructure/wre_core/src/reddog_verified_draft_pr_publish.py")
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imports = set()
+    calls = set()
+    constants = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                calls.add(node.func.id)
+            elif isinstance(node.func, ast.Attribute):
+                calls.add(node.func.attr)
+        elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+            constants.append(node.value.lower())
+
+    forbidden_imports = {
+        "os",
+        "subprocess",
+        "socket",
+        "requests",
+        "sqlite3",
+        "modules.infrastructure.wre_core.src.pattern_memory",
+    }
+    forbidden_calls = {
+        "open",
+        "eval",
+        "exec",
+        "system",
+        "popen",
+        "run",
+        "check_call",
+        "check_output",
+        "store_outcome",
+        "merge_pr",
+        "mark_ready",
+    }
+    forbidden_strings = ("gh pr ready", "gh pr merge", "--merge", "store_outcome(")
+
+    assert imports.isdisjoint(forbidden_imports)
+    assert calls.isdisjoint(forbidden_calls)
+    assert not any(item in text for text in constants for item in forbidden_strings)


### PR DESCRIPTION
## Summary

Implements `REDDOG_VERIFIED_DRAFT_PR_PUBLISH_PHASE1` as the narrow bridge from an accepted WRE autonomous slice verifier result to a draft PR.

The gate validates verifier `ACCEPT`, exact pre-publish branch head, branch/base policy, draft-only flags, PR metadata, secret-free PR text, and then delegates only `push_branch` + `create_draft_pr` to an injected runner compatible with the existing `worktree_pr_runner.py` helper.

## WSP_97 Boundary

OBSERVED:
- Draft PR publishing is blocked unless the verifier receipt accepted the exact head SHA.
- Push failure prevents PR creation.
- The runner is injected; tests use a fake runner and no git/GitHub call happens in CI.
- Result and receipt permanently state no-ready/no-merge/no-PatternMemory/no-reward/no-HoloIndex-reindex.

SPECIFIED_NOT_IMPLEMENTED:
- No authoring/editing/commit creation.
- No test execution or diff computation.
- No direct GitHub or gh call in this module.
- No PR ready, merge, reward settlement, PatternMemory write, or HoloIndex re-index.

## Local Validation

```text
25 passed  verified draft PR publish + autonomous verifier tests
py_compile  PASS
git diff --check  PASS
diff additions ASCII scan  PASS
new files NUL scan  PASS
```

## HoloIndex

Read-only probes surfaced adjacent verifier/draft PR concepts but not the new publish seam. Recorded:

```text
HOLOINDEX_REDDOG_VERIFIED_DRAFT_PR_PUBLISH_INDEX_GAP_PHASE1
```

No runtime re-index performed.

## Next Slice

`REDDOG_VERIFIED_OUTCOME_RATCHET_PHASE1` should persist request/execution/verification/cost/latency/acceptance/failure receipts and only allow independently verified outcomes into PatternMemory.