### PR TITLE
feat(reddog): add verified outcome ratchet

### DIFF
--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -2,6 +2,45 @@
 
 ## Chronological Change Log
 
+### [2026-07-14] - REDDOG_VERIFIED_OUTCOME_RATCHET_PHASE1
+
+**WSP Protocol References**: WSP 00 (Operational Grounding), WSP 15 (Priority),
+WSP 50 (Pre-Action), WSP 97 (Truth Boundary), WSP 22 (ModLog)
+
+**Type**: Runtime outcome ratchet. Verifier-gated persistence and optional
+PatternMemory admission through injected sinks only.
+
+**Deliverable**:
+- Added `src/reddog_verified_outcome_ratchet.py`: persists request, execution,
+  verification, cost, latency, acceptance, and failure receipts. It records
+  rejected/failure outcomes for audit, blocks secret-bearing receipts before
+  persistence, and only allows PatternMemory admission when the independent
+  autonomous-slice verifier accepted the work and the verified draft PR publish
+  receipt accepted the draft-only publication.
+- Added `tests/test_reddog_verified_outcome_ratchet.py`: accepted outcome,
+  optional PatternMemory write, rejected-verification recording, missing publish
+  receipt, failed outcome recording, missing receipt set, bad cost/latency,
+  HoloIndex gap/freshness rejection, secret non-persistence, store/sink failure,
+  JSONL append, deterministic receipt, JSON serialization, and AST boundary
+  coverage.
+
+**Boundary**: This slice does not execute commands, publish PRs, merge, settle
+rewards, call GitHub, write PatternMemory directly, or re-index HoloIndex. Both
+the ratchet store and PatternMemory sink are injected interfaces.
+
+**HoloIndex**: Read-only probes surfaced adjacent receipt/verifier surfaces but
+not the new ratchet module. Recorded
+`HOLOINDEX_REDDOG_VERIFIED_OUTCOME_RATCHET_INDEX_GAP_PHASE1`; no runtime
+re-index performed.
+
+**Verification**: ratchet + draft publish + autonomous verifier tests 39 passed;
+py_compile passed; git diff --check clean; new files line-length, ASCII, and
+NUL clean. A broader WRE suite run still has pre-existing environment-sensitive
+failures around missing `vendor/hermes-agent`, worktree repo-name assumptions,
+and cwd-sensitive older AST tests; none are introduced by this slice.
+
+---
+
 ### [2026-07-14] - REDDOG_VERIFIED_DRAFT_PR_PUBLISH_PHASE1
 
 **WSP Protocol References**: WSP 00 (Operational Grounding), WSP 15 (Priority),

--- a/modules/infrastructure/wre_core/src/reddog_verified_outcome_ratchet.py
+++ b/modules/infrastructure/wre_core/src/reddog_verified_outcome_ratchet.py
@@ -1,0 +1,428 @@
+"""Verified outcome ratchet for RedDog/WRE autonomous work.
+
+Slice: REDDOG_VERIFIED_OUTCOME_RATCHET_PHASE1
+
+The ratchet persists request, execution, verification, cost, latency, acceptance,
+and failure receipts. It may forward an outcome to an injected PatternMemory sink
+only when the independent autonomous-slice verifier accepted the outcome. This
+module does not import PatternMemory, run commands, publish PRs, merge, settle
+rewards, call GitHub, or mutate HoloIndex.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Protocol
+
+from modules.infrastructure.wre_core.src.reddog_verified_draft_pr_publish import (
+    VERIFIED_DRAFT_PR_PUBLISH_ACCEPT,
+)
+from modules.infrastructure.wre_core.src.wre_autonomous_slice_verifier_runtime import (
+    AUTONOMOUS_SLICE_VERIFIER_ACCEPT,
+)
+
+OUTCOME_RATCHET_RECORDED = "OUTCOME_RATCHET_RECORDED"
+OUTCOME_RATCHET_REJECT = "OUTCOME_RATCHET_REJECT"
+
+FAIL_REQUIRED_FIELD = "FAIL_REQUIRED_FIELD"
+FAIL_VERIFICATION_RECEIPT = "FAIL_VERIFICATION_RECEIPT"
+FAIL_PUBLISH_RECEIPT = "FAIL_PUBLISH_RECEIPT"
+FAIL_RECEIPT_SET = "FAIL_RECEIPT_SET"
+FAIL_COST_LATENCY = "FAIL_COST_LATENCY"
+FAIL_HOLOINDEX_EVIDENCE = "FAIL_HOLOINDEX_EVIDENCE"
+FAIL_SECRET_IN_RECEIPT = "FAIL_SECRET_IN_RECEIPT"
+FAIL_PATTERN_MEMORY_UNVERIFIED = "FAIL_PATTERN_MEMORY_UNVERIFIED"
+FAIL_STORE_WRITE = "FAIL_STORE_WRITE"
+FAIL_PATTERN_MEMORY_WRITE = "FAIL_PATTERN_MEMORY_WRITE"
+
+SECRET_MARKERS = (
+    "authorization:",
+    "bearer ",
+    "api_key",
+    "apikey",
+    "private_key",
+    "begin private key",
+    "secret=",
+    "token=",
+    "password=",
+)
+
+
+class OutcomeRatchetStore(Protocol):
+    def append(self, record: Mapping[str, Any]) -> str:
+        ...
+
+
+class PatternMemorySink(Protocol):
+    def store_verified_outcome(self, record: Mapping[str, Any]) -> str:
+        ...
+
+
+class InMemoryOutcomeRatchetStore:
+    """Test/local store for ratchet records."""
+
+    def __init__(self) -> None:
+        self.records: List[Dict[str, Any]] = []
+
+    def append(self, record: Mapping[str, Any]) -> str:
+        payload = dict(record)
+        self.records.append(payload)
+        return str(payload["ratchet_id"])
+
+
+class JsonlOutcomeRatchetStore:
+    """Append-only JSONL store for ratchet records."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+
+    def append(self, record: Mapping[str, Any]) -> str:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(record, sort_keys=True, separators=(",", ":"), default=str)
+        with self.path.open("a", encoding="utf-8", newline="\n") as handle:
+            handle.write(line + "\n")
+        return str(record["ratchet_id"])
+
+
+@dataclass(frozen=True)
+class VerifiedOutcomeRatchetReceipt:
+    ratchet_id: str
+    work_order_id: str
+    slice_name: str
+    outcome_status: str
+    verifier_receipt_id: str
+    publish_receipt_id: Optional[str]
+    request_digest: str
+    execution_receipts_digest: str
+    verification_digest: str
+    cost_receipt_digest: str
+    latency_receipt_digest: str
+    acceptance_receipt_digest: str
+    failure_receipt_digest: Optional[str]
+    holoindex_freshness_receipt_digest: str
+    pattern_memory_eligible: bool
+    pattern_memory_write_performed: bool
+    pattern_memory_record_id: Optional[str]
+    rejection_reasons: List[str]
+    no_command_execution_performed: bool = True
+    no_pr_publish_performed: bool = True
+    no_merge_performed: bool = True
+    no_reward_settlement_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class VerifiedOutcomeRatchetResult:
+    decision: str
+    accepted: bool
+    receipt: VerifiedOutcomeRatchetReceipt
+    rejection_reasons: List[str] = field(default_factory=list)
+    store_record_id: Optional[str] = None
+    no_command_execution_performed: bool = True
+    no_pr_publish_performed: bool = True
+    no_merge_performed: bool = True
+    no_reward_settlement_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["receipt"] = self.receipt.to_dict()
+        return payload
+
+
+def _digest(payload: Any) -> str:
+    raw = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        default=str,
+    )
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        return value.to_dict()
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _list(value: Any) -> List[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _dedupe(values: List[str]) -> List[str]:
+    seen = set()
+    ordered: List[str] = []
+    for value in values:
+        text = str(value or "").strip()
+        if text and text not in seen:
+            seen.add(text)
+            ordered.append(text)
+    return ordered
+
+
+def _contains_secret(value: Any) -> bool:
+    text = json.dumps(value, sort_keys=True, default=str).lower()
+    return any(marker in text for marker in SECRET_MARKERS)
+
+
+def _receipt_digest(value: Any) -> str:
+    return _digest(_mapping(value) if isinstance(value, Mapping) else value)
+
+
+def _verification_accepted(verification_result: Mapping[str, Any]) -> bool:
+    return (
+        verification_result.get("accepted") is True
+        and verification_result.get("decision") == AUTONOMOUS_SLICE_VERIFIER_ACCEPT
+        and bool(_mapping(verification_result.get("receipt")).get("receipt_id"))
+    )
+
+
+def _publish_accepted(publish_result: Mapping[str, Any]) -> bool:
+    if not publish_result:
+        return False
+    return (
+        publish_result.get("accepted") is True
+        and publish_result.get("decision") == VERIFIED_DRAFT_PR_PUBLISH_ACCEPT
+        and bool(_mapping(publish_result.get("receipt")).get("receipt_id"))
+    )
+
+
+def _holoindex_ok(holoindex_evidence: Mapping[str, Any]) -> bool:
+    if holoindex_evidence.get("index_gap_detected") is True:
+        return False
+    if str(holoindex_evidence.get("retrieval_quality") or "").upper() == "INDEX_GAP":
+        return False
+    return bool(str(holoindex_evidence.get("holoindex_freshness_receipt_digest") or ""))
+
+
+def _cost_latency_ok(cost: Mapping[str, Any], latency: Mapping[str, Any]) -> bool:
+    for key in ("total_tokens", "estimated_cost_usd"):
+        if key not in cost:
+            return False
+        if float(cost.get(key) or 0) < 0:
+            return False
+    for key in ("wall_time_ms", "queue_time_ms"):
+        if key not in latency:
+            return False
+        if int(latency.get(key) or 0) < 0:
+            return False
+    return True
+
+
+def _build_receipt(
+    *,
+    request: Mapping[str, Any],
+    reasons: List[str],
+    pattern_memory_eligible: bool,
+    pattern_memory_write_performed: bool,
+    pattern_memory_record_id: Optional[str],
+) -> VerifiedOutcomeRatchetReceipt:
+    verification_result = _mapping(request.get("verification_result"))
+    verification_receipt = _mapping(verification_result.get("receipt"))
+    publish_result = _mapping(request.get("publish_result"))
+    publish_receipt = _mapping(publish_result.get("receipt"))
+    cost = _mapping(request.get("cost_receipt"))
+    latency = _mapping(request.get("latency_receipt"))
+    acceptance = _mapping(request.get("acceptance_receipt"))
+    failure = _mapping(request.get("failure_receipt"))
+    holoindex = _mapping(request.get("holoindex_evidence"))
+    execution_receipts = _list(request.get("execution_receipts"))
+    work_order_id = str(
+        request.get("work_order_id") or verification_receipt.get("work_order_id") or ""
+    )
+    slice_name = str(
+        request.get("slice_name") or verification_receipt.get("slice_name") or ""
+    )
+    outcome_status = str(request.get("outcome_status") or "")
+    seed = {
+        "work_order_id": work_order_id,
+        "slice_name": slice_name,
+        "outcome_status": outcome_status,
+        "verifier_receipt_id": str(verification_receipt.get("receipt_id") or ""),
+        "publish_receipt_id": str(publish_receipt.get("receipt_id") or ""),
+        "request_digest": _receipt_digest(request.get("request_receipt")),
+        "execution_receipts_digest": _digest(execution_receipts),
+        "verification_digest": _receipt_digest(verification_result),
+        "acceptance_receipt_digest": _receipt_digest(acceptance),
+        "failure_receipt_digest": _receipt_digest(failure) if failure else None,
+        "rejection_reasons": reasons,
+    }
+    return VerifiedOutcomeRatchetReceipt(
+        ratchet_id="outcome_ratchet_" + _digest(seed).removeprefix("sha256:")[:16],
+        work_order_id=work_order_id,
+        slice_name=slice_name,
+        outcome_status=outcome_status,
+        verifier_receipt_id=str(verification_receipt.get("receipt_id") or ""),
+        publish_receipt_id=str(publish_receipt.get("receipt_id") or "") or None,
+        request_digest=_receipt_digest(request.get("request_receipt")),
+        execution_receipts_digest=_digest(execution_receipts),
+        verification_digest=_receipt_digest(verification_result),
+        cost_receipt_digest=_receipt_digest(cost),
+        latency_receipt_digest=_receipt_digest(latency),
+        acceptance_receipt_digest=_receipt_digest(acceptance),
+        failure_receipt_digest=_receipt_digest(failure) if failure else None,
+        holoindex_freshness_receipt_digest=str(
+            holoindex.get("holoindex_freshness_receipt_digest") or ""
+        ),
+        pattern_memory_eligible=pattern_memory_eligible,
+        pattern_memory_write_performed=pattern_memory_write_performed,
+        pattern_memory_record_id=pattern_memory_record_id,
+        rejection_reasons=reasons,
+    )
+
+
+def ratchet_verified_outcome(
+    request: Mapping[str, Any],
+    *,
+    store: OutcomeRatchetStore,
+    pattern_memory_sink: Optional[PatternMemorySink] = None,
+) -> VerifiedOutcomeRatchetResult:
+    """Persist an autonomous-work outcome and gate PatternMemory admission."""
+    req = _mapping(request)
+    verification_result = _mapping(req.get("verification_result"))
+    publish_result = _mapping(req.get("publish_result"))
+    execution_receipts = _list(req.get("execution_receipts"))
+    cost = _mapping(req.get("cost_receipt"))
+    latency = _mapping(req.get("latency_receipt"))
+    acceptance = _mapping(req.get("acceptance_receipt"))
+    failure = _mapping(req.get("failure_receipt"))
+    holoindex = _mapping(req.get("holoindex_evidence"))
+    outcome_status = str(req.get("outcome_status") or "")
+    reasons: List[str] = []
+
+    if (
+        not str(req.get("work_order_id") or "").strip()
+        or not str(req.get("slice_name") or "").strip()
+    ):
+        reasons.append(FAIL_REQUIRED_FIELD)
+    verified = _verification_accepted(verification_result)
+    published = _publish_accepted(publish_result)
+    if not verified:
+        reasons.append(FAIL_VERIFICATION_RECEIPT)
+    if outcome_status == "accepted" and not published:
+        reasons.append(FAIL_PUBLISH_RECEIPT)
+    if not execution_receipts or not _mapping(req.get("request_receipt")):
+        reasons.append(FAIL_RECEIPT_SET)
+    if not acceptance and not failure:
+        reasons.append(FAIL_RECEIPT_SET)
+    if not _cost_latency_ok(cost, latency):
+        reasons.append(FAIL_COST_LATENCY)
+    if not _holoindex_ok(holoindex):
+        reasons.append(FAIL_HOLOINDEX_EVIDENCE)
+    if _contains_secret(
+        {
+            "request": req.get("request_receipt"),
+            "execution": execution_receipts,
+            "acceptance": acceptance,
+            "failure": failure,
+        }
+    ):
+        reasons.append(FAIL_SECRET_IN_RECEIPT)
+
+    pattern_requested = req.get("enable_pattern_memory_write") is True
+    pattern_eligible = verified and published and outcome_status == "accepted"
+    if pattern_requested and not pattern_eligible:
+        reasons.append(FAIL_PATTERN_MEMORY_UNVERIFIED)
+
+    deduped = _dedupe(reasons)
+    pattern_memory_record_id: Optional[str] = None
+    pattern_memory_write_performed = False
+    receipt = _build_receipt(
+        request=req,
+        reasons=deduped,
+        pattern_memory_eligible=pattern_eligible,
+        pattern_memory_write_performed=False,
+        pattern_memory_record_id=None,
+    )
+    if FAIL_SECRET_IN_RECEIPT in deduped:
+        return VerifiedOutcomeRatchetResult(
+            decision=OUTCOME_RATCHET_REJECT,
+            accepted=False,
+            receipt=receipt,
+            rejection_reasons=deduped,
+            store_record_id=None,
+        )
+    record = {
+        "ratchet_id": receipt.ratchet_id,
+        "ratchet_receipt": receipt.to_dict(),
+        "request_receipt": _mapping(req.get("request_receipt")),
+        "execution_receipts": execution_receipts,
+        "verification_result": verification_result,
+        "publish_result": publish_result,
+        "cost_receipt": cost,
+        "latency_receipt": latency,
+        "acceptance_receipt": acceptance,
+        "failure_receipt": failure,
+    }
+
+    try:
+        store_record_id = store.append(record)
+    except Exception:
+        deduped = _dedupe([*deduped, FAIL_STORE_WRITE])
+        receipt = _build_receipt(
+            request=req,
+            reasons=deduped,
+            pattern_memory_eligible=pattern_eligible,
+            pattern_memory_write_performed=False,
+            pattern_memory_record_id=None,
+        )
+        return VerifiedOutcomeRatchetResult(
+            decision=OUTCOME_RATCHET_REJECT,
+            accepted=False,
+            receipt=receipt,
+            rejection_reasons=deduped,
+            store_record_id=None,
+        )
+
+    if not deduped and pattern_requested and pattern_memory_sink is not None:
+        try:
+            pattern_memory_record_id = pattern_memory_sink.store_verified_outcome(record)
+            pattern_memory_write_performed = True
+        except Exception:
+            deduped = [FAIL_PATTERN_MEMORY_WRITE]
+
+    receipt = _build_receipt(
+        request=req,
+        reasons=deduped,
+        pattern_memory_eligible=pattern_eligible,
+        pattern_memory_write_performed=pattern_memory_write_performed,
+        pattern_memory_record_id=pattern_memory_record_id,
+    )
+    return VerifiedOutcomeRatchetResult(
+        decision=OUTCOME_RATCHET_RECORDED if not deduped else OUTCOME_RATCHET_REJECT,
+        accepted=not deduped,
+        receipt=receipt,
+        rejection_reasons=deduped,
+        store_record_id=store_record_id,
+    )
+
+
+__all__ = [
+    "FAIL_COST_LATENCY",
+    "FAIL_HOLOINDEX_EVIDENCE",
+    "FAIL_PATTERN_MEMORY_UNVERIFIED",
+    "FAIL_PATTERN_MEMORY_WRITE",
+    "FAIL_PUBLISH_RECEIPT",
+    "FAIL_RECEIPT_SET",
+    "FAIL_REQUIRED_FIELD",
+    "FAIL_SECRET_IN_RECEIPT",
+    "FAIL_STORE_WRITE",
+    "FAIL_VERIFICATION_RECEIPT",
+    "InMemoryOutcomeRatchetStore",
+    "JsonlOutcomeRatchetStore",
+    "OUTCOME_RATCHET_RECORDED",
+    "OUTCOME_RATCHET_REJECT",
+    "VerifiedOutcomeRatchetReceipt",
+    "VerifiedOutcomeRatchetResult",
+    "ratchet_verified_outcome",
+]

--- a/modules/infrastructure/wre_core/tests/test_reddog_verified_outcome_ratchet.py
+++ b/modules/infrastructure/wre_core/tests/test_reddog_verified_outcome_ratchet.py
@@ -1,0 +1,307 @@
+"""Tests for REDDOG_VERIFIED_OUTCOME_RATCHET_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.infrastructure.wre_core.src import reddog_verified_outcome_ratchet as ratchet
+from modules.infrastructure.wre_core.src.reddog_verified_draft_pr_publish import (
+    VERIFIED_DRAFT_PR_PUBLISH_ACCEPT,
+)
+from modules.infrastructure.wre_core.src.wre_autonomous_slice_verifier_runtime import (
+    AUTONOMOUS_SLICE_VERIFIER_ACCEPT,
+    AUTONOMOUS_SLICE_VERIFIER_REJECT,
+)
+
+
+def _digest(ch: str) -> str:
+    return "sha256:" + ch * 64
+
+
+class FakePatternMemorySink:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.records: list = []
+
+    def store_verified_outcome(self, record):
+        if self.fail:
+            raise RuntimeError("sink failed")
+        self.records.append(dict(record))
+        return "pattern-record-1"
+
+
+class FailingStore:
+    def append(self, record):
+        raise RuntimeError("store failed")
+
+
+def valid_request() -> dict:
+    return {
+        "work_order_id": "wo-ratchet-1",
+        "slice_name": "REDDOG_VERIFIED_OUTCOME_RATCHET_PHASE1",
+        "outcome_status": "accepted",
+        "request_receipt": {
+            "request_id": "req-1",
+            "principal_id": "012",
+            "work_focus_digest": _digest("1"),
+        },
+        "execution_receipts": [
+            {"step": "worktree_created", "receipt_id": "exec-1"},
+            {"step": "tests_run", "receipt_id": "exec-2"},
+        ],
+        "verification_result": {
+            "accepted": True,
+            "decision": AUTONOMOUS_SLICE_VERIFIER_ACCEPT,
+            "receipt": {
+                "receipt_id": "wre_slice_verify_1234",
+                "work_order_id": "wo-ratchet-1",
+                "slice_name": "REDDOG_VERIFIED_OUTCOME_RATCHET_PHASE1",
+            },
+        },
+        "publish_result": {
+            "accepted": True,
+            "decision": VERIFIED_DRAFT_PR_PUBLISH_ACCEPT,
+            "receipt": {
+                "receipt_id": "verified_draft_pr_1234",
+                "draft_pr_url": "https://github.com/FOUNDUPS/Foundups-Agent/pull/1000",
+            },
+        },
+        "cost_receipt": {
+            "total_tokens": 1234,
+            "estimated_cost_usd": 0.12,
+        },
+        "latency_receipt": {
+            "wall_time_ms": 1000,
+            "queue_time_ms": 10,
+        },
+        "acceptance_receipt": {
+            "accepted": True,
+            "reason": "verifier and draft PR publish accepted",
+        },
+        "failure_receipt": None,
+        "holoindex_evidence": {
+            "index_gap_detected": False,
+            "holoindex_freshness_receipt_digest": _digest("2"),
+        },
+        "enable_pattern_memory_write": False,
+    }
+
+
+def assert_reject(req: dict, code: str) -> ratchet.VerifiedOutcomeRatchetResult:
+    store = ratchet.InMemoryOutcomeRatchetStore()
+    result = ratchet.ratchet_verified_outcome(req, store=store)
+    assert result.accepted is False
+    assert result.decision == ratchet.OUTCOME_RATCHET_REJECT
+    assert code in result.rejection_reasons
+    assert code in result.receipt.rejection_reasons
+    assert result.no_command_execution_performed is True
+    assert result.no_pr_publish_performed is True
+    assert result.no_merge_performed is True
+    assert result.no_reward_settlement_performed is True
+    return result
+
+
+def test_records_verified_outcome_without_pattern_memory_by_default() -> None:
+    store = ratchet.InMemoryOutcomeRatchetStore()
+    result = ratchet.ratchet_verified_outcome(valid_request(), store=store)
+
+    assert result.accepted is True
+    assert result.decision == ratchet.OUTCOME_RATCHET_RECORDED
+    assert result.receipt.pattern_memory_eligible is True
+    assert result.receipt.pattern_memory_write_performed is False
+    assert result.receipt.pattern_memory_record_id is None
+    assert result.store_record_id == result.receipt.ratchet_id
+    assert len(store.records) == 1
+    assert store.records[0]["ratchet_receipt"]["ratchet_id"] == result.receipt.ratchet_id
+
+
+def test_pattern_memory_sink_receives_only_verified_accepted_outcome() -> None:
+    req = valid_request()
+    req["enable_pattern_memory_write"] = True
+    sink = FakePatternMemorySink()
+    store = ratchet.InMemoryOutcomeRatchetStore()
+
+    result = ratchet.ratchet_verified_outcome(req, store=store, pattern_memory_sink=sink)
+
+    assert result.accepted is True
+    assert result.receipt.pattern_memory_write_performed is True
+    assert result.receipt.pattern_memory_record_id == "pattern-record-1"
+    assert len(sink.records) == 1
+
+
+def test_rejected_verification_records_failure_but_blocks_pattern_memory() -> None:
+    req = valid_request()
+    req["verification_result"]["accepted"] = False
+    req["verification_result"]["decision"] = AUTONOMOUS_SLICE_VERIFIER_REJECT
+    req["enable_pattern_memory_write"] = True
+    store = ratchet.InMemoryOutcomeRatchetStore()
+    result = ratchet.ratchet_verified_outcome(req, store=store)
+
+    assert result.accepted is False
+    assert ratchet.FAIL_VERIFICATION_RECEIPT in result.rejection_reasons
+    assert ratchet.FAIL_PATTERN_MEMORY_UNVERIFIED in result.rejection_reasons
+    assert len(store.records) == 1
+    assert result.receipt.pattern_memory_write_performed is False
+
+
+def test_accepted_outcome_requires_publish_receipt() -> None:
+    req = valid_request()
+    req["publish_result"]["accepted"] = False
+    assert_reject(req, ratchet.FAIL_PUBLISH_RECEIPT)
+
+
+def test_failed_outcome_can_be_recorded_without_publish_or_pattern_memory() -> None:
+    req = valid_request()
+    req["outcome_status"] = "failed"
+    req["publish_result"] = {}
+    req["acceptance_receipt"] = {}
+    req["failure_receipt"] = {"failed": True, "reason": "tests failed"}
+    store = ratchet.InMemoryOutcomeRatchetStore()
+
+    result = ratchet.ratchet_verified_outcome(req, store=store)
+
+    assert result.accepted is True
+    assert result.receipt.pattern_memory_eligible is False
+    assert result.receipt.failure_receipt_digest
+    assert len(store.records) == 1
+
+
+def test_rejects_missing_receipt_set() -> None:
+    req = valid_request()
+    req["execution_receipts"] = []
+    assert_reject(req, ratchet.FAIL_RECEIPT_SET)
+
+    req = valid_request()
+    req["request_receipt"] = {}
+    assert_reject(req, ratchet.FAIL_RECEIPT_SET)
+
+
+def test_rejects_missing_or_negative_cost_latency() -> None:
+    req = valid_request()
+    req["cost_receipt"]["total_tokens"] = -1
+    assert_reject(req, ratchet.FAIL_COST_LATENCY)
+
+    req = valid_request()
+    req["latency_receipt"]["wall_time_ms"] = -1
+    assert_reject(req, ratchet.FAIL_COST_LATENCY)
+
+
+def test_rejects_holoindex_gap_or_missing_freshness() -> None:
+    req = valid_request()
+    req["holoindex_evidence"]["index_gap_detected"] = True
+    assert_reject(req, ratchet.FAIL_HOLOINDEX_EVIDENCE)
+
+    req = valid_request()
+    req["holoindex_evidence"]["holoindex_freshness_receipt_digest"] = ""
+    assert_reject(req, ratchet.FAIL_HOLOINDEX_EVIDENCE)
+
+
+def test_secret_receipt_rejects_and_is_not_persisted() -> None:
+    req = valid_request()
+    req["execution_receipts"][0]["detail"] = "api_key = leak"
+    store = ratchet.InMemoryOutcomeRatchetStore()
+
+    result = ratchet.ratchet_verified_outcome(req, store=store)
+
+    assert result.accepted is False
+    assert ratchet.FAIL_SECRET_IN_RECEIPT in result.rejection_reasons
+    assert store.records == []
+
+
+def test_store_failure_rejects() -> None:
+    result = ratchet.ratchet_verified_outcome(valid_request(), store=FailingStore())
+
+    assert result.accepted is False
+    assert result.decision == ratchet.OUTCOME_RATCHET_REJECT
+    assert result.rejection_reasons == [ratchet.FAIL_STORE_WRITE]
+    assert result.store_record_id is None
+
+
+def test_pattern_memory_sink_failure_rejects_after_store() -> None:
+    req = valid_request()
+    req["enable_pattern_memory_write"] = True
+    store = ratchet.InMemoryOutcomeRatchetStore()
+    sink = FakePatternMemorySink(fail=True)
+
+    result = ratchet.ratchet_verified_outcome(req, store=store, pattern_memory_sink=sink)
+
+    assert result.accepted is False
+    assert result.rejection_reasons == [ratchet.FAIL_PATTERN_MEMORY_WRITE]
+    assert len(store.records) == 1
+
+
+def test_jsonl_store_appends_records(tmp_path: Path) -> None:
+    path = tmp_path / "ratchet" / "outcomes.jsonl"
+    store = ratchet.JsonlOutcomeRatchetStore(path)
+
+    result = ratchet.ratchet_verified_outcome(valid_request(), store=store)
+
+    assert result.accepted is True
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["ratchet_receipt"]["ratchet_id"] == result.receipt.ratchet_id
+
+
+def test_ratchet_receipt_is_deterministic_and_serializable() -> None:
+    first = ratchet.ratchet_verified_outcome(
+        valid_request(),
+        store=ratchet.InMemoryOutcomeRatchetStore(),
+    )
+    second = ratchet.ratchet_verified_outcome(
+        valid_request(),
+        store=ratchet.InMemoryOutcomeRatchetStore(),
+    )
+
+    assert first.receipt.ratchet_id == second.receipt.ratchet_id
+    dumped = json.dumps(first.to_dict(), sort_keys=True)
+    assert "outcome_ratchet_" in dumped
+
+
+def test_ast_boundary_no_commands_github_holoindex_or_pattern_memory_import() -> None:
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "reddog_verified_outcome_ratchet.py"
+    )
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imports = set()
+    calls = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                calls.add(node.func.id)
+            elif isinstance(node.func, ast.Attribute):
+                calls.add(node.func.attr)
+
+    forbidden_imports = {
+        "os",
+        "subprocess",
+        "socket",
+        "requests",
+        "sqlite3",
+        "modules.infrastructure.wre_core.src.pattern_memory",
+        "holo_index",
+    }
+    forbidden_calls = {
+        "eval",
+        "exec",
+        "system",
+        "popen",
+        "run",
+        "check_call",
+        "check_output",
+        "merge",
+        "create_draft_pr",
+        "push_branch",
+    }
+
+    assert imports.isdisjoint(forbidden_imports)
+    assert calls.isdisjoint(forbidden_calls)


### PR DESCRIPTION
## Summary

Implements REDDOG_VERIFIED_OUTCOME_RATCHET_PHASE1 for the RedDog/WRE execution spine.

- Adds an injected outcome ratchet that persists request, execution, verification, cost, latency, acceptance, and failure receipts.
- Records rejected/failure outcomes for audit while blocking secret-bearing receipts before persistence.
- Allows PatternMemory admission only when the independent autonomous-slice verifier accepted the work and the verified draft PR publisher accepted draft-only publication.
- Keeps store and PatternMemory writes behind injected interfaces; no command execution, GitHub call, PR publish, merge, reward settlement, or HoloIndex runtime mutation.

## Validation

- `pytest modules/infrastructure/wre_core/tests/test_reddog_verified_outcome_ratchet.py modules/infrastructure/wre_core/tests/test_reddog_verified_draft_pr_publish.py modules/infrastructure/wre_core/tests/test_wre_autonomous_slice_verifier_runtime.py -q` -> 39 passed
- `python -m py_compile modules/infrastructure/wre_core/src/reddog_verified_outcome_ratchet.py modules/infrastructure/wre_core/tests/test_reddog_verified_outcome_ratchet.py` -> passed
- `git diff --check` -> clean
- Byte scan: new ratchet source/test + WRE ModLog -> 0 non-ASCII, 0 NUL

## HoloIndex

Read-only probes surfaced adjacent receipt/verifier surfaces but not the new ratchet module. Recorded `HOLOINDEX_REDDOG_VERIFIED_OUTCOME_RATCHET_INDEX_GAP_PHASE1`; no runtime re-index performed.

## Broad-suite note

A broader `modules/infrastructure/wre_core/tests` run still has pre-existing environment-sensitive failures around missing `vendor/hermes-agent`, worktree repo-name assumptions, and cwd-sensitive older AST tests. The focused slice and adjacent runtime path are green.

## Truth Boundary Checklist

- NO_COMMAND_EXECUTION
- NO_PR_PUBLISH_PERFORMED
- NO_MERGE_PERFORMED
- NO_REWARD_SETTLEMENT
- NO_HOLOINDEX_REINDEX
- PATTERN_MEMORY_INJECTED_ONLY
- VERIFIED_OUTCOMES_ONLY_FOR_PATTERN_MEMORY

Worker-Lane: execution-spine
Slice: REDDOG_VERIFIED_OUTCOME_RATCHET_PHASE1