### PR TITLE
feat(wre): route daemon self-audit through dry-run proposals

### DIFF
--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -2,6 +2,41 @@
 
 ## Chronological Change Log
 
+### [2026-07-14] - REDDOG_DAEMON_SELF_AUDIT_DRYRUN_PROPOSAL_PHASE1
+
+**WSP Protocol References**: WSP 00 (Operational Grounding), WSP 15 (Priority),
+WSP 48 (Recursive Self-Improvement), WSP 50 (Pre-Action), WSP 97 (Truth
+Boundary), WSP 22 (ModLog)
+
+**Type**: Daemon self-audit L1b. Observe -> propose only by default.
+
+**Deliverable**:
+- Updated `src/daemon_self_audit_loop.py`: daemon self-audit findings now emit
+  PENDING/dry-run `ImprovementJob` proposals plus RedDog direction receipts to
+  `daemon_self_audit_improvement_jobs.jsonl` by default.
+- Legacy auto-fix dispatch now requires both `OPENCLAW_SELF_AUDIT_AUTO_FIX=1`
+  and `OPENCLAW_SELF_AUDIT_ALLOW_LEGACY_AUTO_FIX=1`.
+- Legacy escalation command dispatch now requires
+  `OPENCLAW_SELF_AUDIT_ALLOW_LEGACY_ESCALATION_DISPATCH=1`.
+- Updated `tests/test_daemon_self_audit_loop.py`: default proposal-only path,
+  dual-opt-in legacy dispatch, escalation dispatch guard, and existing
+  diagnostic coverage.
+
+**Boundary**: The default daemon self-audit path does not run subprocesses,
+start daemons, verify SQLite stores, write diagnostic reports as fixes, mutate
+queues, write PatternMemory, or execute repairs. It records dry-run proposals
+for the RedDog/WRE improvement lane.
+
+**HoloIndex**: Read-only probe for `daemon self audit dryrun improvement
+proposal RedDog direction` surfaced adjacent RedDog execution surfaces but not
+the updated daemon self-audit proposal path. Recorded
+`HOLOINDEX_REDDOG_DAEMON_SELF_AUDIT_DRYRUN_PROPOSAL_INDEX_GAP_PHASE1`; no
+runtime re-index performed.
+
+**Verification**: daemon self-audit + RedDog direction tests 19 passed.
+
+---
+
 ### [2026-07-14] - REDDOG_HELD_OUT_RECURSIVE_IMPROVEMENT_REGRESSION_GATE_PHASE1
 
 **WSP Protocol References**: WSP 00 (Operational Grounding), WSP 15 (Priority),

--- a/modules/infrastructure/wre_core/src/daemon_self_audit_loop.py
+++ b/modules/infrastructure/wre_core/src/daemon_self_audit_loop.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -13,9 +14,18 @@ import sqlite3
 import subprocess
 import threading
 import time
+from dataclasses import asdict
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+
+from modules.infrastructure.wre_core.src.improvement_job_contract import (
+    ImprovementRiskLevel,
+    ImprovementScope,
+    ImprovementType,
+    create_improvement_job,
+)
+from modules.infrastructure.wre_core.src.reddog_direction import RedDogDirector
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +39,8 @@ class SelfAuditEvent:
     recommended_fix: str
     auto_fix_attempted: bool
     auto_fix_result: str
+    improvement_job_id: str = ""
+    improvement_direction: str = ""
 
 
 @dataclass
@@ -44,7 +56,7 @@ class SelfAuditEscalation:
 
 
 class DaemonSelfAuditLoop:
-    """Tails daemon logs, opens fix tasks, and executes safe fixes under policy."""
+    """Tails daemon logs and proposes RedDog-directed dry-run improvement jobs."""
 
     ERROR_PATTERNS = [
         re.compile(r"\[ERROR\]", re.IGNORECASE),
@@ -57,7 +69,7 @@ class DaemonSelfAuditLoop:
         re.compile(r"unique constraint failed", re.IGNORECASE),
     ]
 
-    # Noise signatures to ignore — these match ERROR_PATTERNS but are not actionable
+    # Noise signatures to ignore -- these match ERROR_PATTERNS but are not actionable
     NOISE_SIGNATURES = [
         "traceback (most recent call last):",  # generic traceback header
         "raise exception_class(message, screen, stacktrace)",  # Selenium generic raise
@@ -70,7 +82,13 @@ class DaemonSelfAuditLoop:
         self.interval_sec = float(os.getenv("OPENCLAW_SELF_AUDIT_INTERVAL_SEC", "5"))
         self.max_read_bytes = int(os.getenv("OPENCLAW_SELF_AUDIT_MAX_READ_BYTES", "65536"))
         self.dedupe_window_sec = int(os.getenv("OPENCLAW_SELF_AUDIT_DEDUPE_WINDOW_SEC", "120"))
-        self.auto_fix_enabled = os.getenv("OPENCLAW_SELF_AUDIT_AUTO_FIX", "1") == "1"
+        self.improvement_proposals_enabled = (
+            os.getenv("OPENCLAW_SELF_AUDIT_IMPROVEMENT_PROPOSALS", "1").strip() == "1"
+        )
+        self.auto_fix_enabled = (
+            os.getenv("OPENCLAW_SELF_AUDIT_AUTO_FIX", "0").strip() == "1"
+            and os.getenv("OPENCLAW_SELF_AUDIT_ALLOW_LEGACY_AUTO_FIX", "0").strip() == "1"
+        )
         self.allowed_fixes = {
             part.strip().lower()
             for part in os.getenv(
@@ -98,6 +116,10 @@ class DaemonSelfAuditLoop:
             os.getenv("OPENCLAW_SELF_AUDIT_ESCALATION_COOLDOWN_SEC", "600")
         )
         self.escalation_cmd = os.getenv("OPENCLAW_SELF_AUDIT_ESCALATE_CMD", "").strip()
+        self.escalation_dispatch_enabled = (
+            os.getenv("OPENCLAW_SELF_AUDIT_ALLOW_LEGACY_ESCALATION_DISPATCH", "0").strip()
+            == "1"
+        )
         self.escalation_allow_shell = (
             os.getenv("OPENCLAW_SELF_AUDIT_ESCALATE_ALLOW_SHELL_CMD", "0").strip() == "1"
         )
@@ -105,6 +127,10 @@ class DaemonSelfAuditLoop:
         self.task_log_path = (
             self.repo_root
             / "modules/infrastructure/wre_core/reports/daemon_self_audit_tasks.jsonl"
+        )
+        self.improvement_job_log_path = (
+            self.repo_root
+            / "modules/infrastructure/wre_core/reports/daemon_self_audit_improvement_jobs.jsonl"
         )
         self.escalation_log_path = (
             self.repo_root
@@ -232,7 +258,10 @@ class DaemonSelfAuditLoop:
             or "connectionerror" in signature
         ):
             candidates = ["start_ironclaw_gateway"]
-        elif "paerrorcode -9984" in signature or "incompatible host api specific stream info" in signature:
+        elif (
+            "paerrorcode -9984" in signature
+            or "incompatible host api specific stream info" in signature
+        ):
             candidates = ["diagnose_microphone_device"]
         elif "unique constraint failed" in signature and "dae_events.sequence_id" in signature:
             candidates = ["verify_dae_event_store"]
@@ -259,6 +288,17 @@ class DaemonSelfAuditLoop:
         recommended = self._recommend_fix(signature)
         attempted = False
         result = "not_attempted"
+        improvement_job_id = ""
+        improvement_direction = ""
+        if self.improvement_proposals_enabled:
+            improvement_job_id, improvement_direction = self._emit_improvement_proposal(
+                source_file=source_file,
+                signature=signature,
+                line=line,
+                recommended_fix=recommended,
+            )
+            if improvement_job_id:
+                result = f"improvement_job_proposed:{improvement_job_id}"
         if self.auto_fix_enabled and recommended in self.allowed_fixes:
             self._increment_counter("self_audit_auto_fix_attempts")
             attempted, result = self._apply_policy_fix(recommended)
@@ -275,7 +315,68 @@ class DaemonSelfAuditLoop:
             recommended_fix=recommended,
             auto_fix_attempted=attempted,
             auto_fix_result=result,
+            improvement_job_id=improvement_job_id,
+            improvement_direction=improvement_direction,
         )
+
+    def _emit_improvement_proposal(
+        self,
+        *,
+        source_file: Path,
+        signature: str,
+        line: str,
+        recommended_fix: str,
+    ) -> Tuple[str, str]:
+        rel_source = self._relative_source_path(source_file)
+        improvement_type = self._improvement_type_for_fix(recommended_fix)
+        scope = ImprovementScope(
+            module_path="modules/infrastructure/wre_core",
+            file_paths=[rel_source],
+            wsp_refs=["WSP 15", "WSP 48", "WSP 50", "WSP 97"],
+        )
+        finding_digest = hashlib.sha256(signature.encode("utf-8")).hexdigest()[:16]
+        job = create_improvement_job(
+            finding_id=f"daemon_self_audit:{finding_digest}",
+            improvement_type=improvement_type,
+            scope=scope,
+            risk_level=ImprovementRiskLevel.LOW,
+            requested_by="daemon_self_audit_loop",
+            payload={
+                "source_file": rel_source,
+                "signature": signature,
+                "line": line[:600],
+                "recommended_fix": recommended_fix,
+                "legacy_auto_fix_attempted": False,
+            },
+        )
+        directed = RedDogDirector(requested_by="daemon_self_audit_loop").direct([job])[0]
+        row = {
+            "timestamp": time.time(),
+            "job": job.to_dict(),
+            "direction": directed.to_dict(),
+            "no_execution_performed": True,
+            "no_subprocess_performed": True,
+            "no_queue_mutation_performed": True,
+            "no_pattern_memory_write_performed": True,
+        }
+        self.improvement_job_log_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.improvement_job_log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(row, ensure_ascii=True, default=str) + "\n")
+        return job.job_id, directed.direction.value
+
+    def _relative_source_path(self, source_file: Path) -> str:
+        try:
+            return str(source_file.resolve().relative_to(self.repo_root)).replace("\\", "/")
+        except ValueError:
+            return str(source_file.resolve()).replace("\\", "/")
+
+    @staticmethod
+    def _improvement_type_for_fix(recommended_fix: str) -> ImprovementType:
+        if recommended_fix == "verify_dae_event_store":
+            return ImprovementType.DRIFT_CORRECTION
+        if recommended_fix == "diagnose_microphone_device":
+            return ImprovementType.FMAS_SCAN
+        return ImprovementType.MODULE_REPAIR
 
     def _record_signature_event(self, event: SelfAuditEvent) -> None:
         now = event.timestamp
@@ -317,13 +418,16 @@ class DaemonSelfAuditLoop:
         dispatch_attempted = False
         dispatch_result = "not_configured"
         if self.escalation_cmd:
-            dispatch_attempted, dispatch_result = self._dispatch_escalation_command(
-                self.escalation_cmd
-            )
-            if dispatch_attempted and dispatch_result.startswith("dispatched"):
-                self._increment_counter("self_audit_escalation_dispatch_success")
-            elif dispatch_attempted:
-                self._increment_counter("self_audit_escalation_dispatch_fail")
+            if self.escalation_dispatch_enabled:
+                dispatch_attempted, dispatch_result = self._dispatch_escalation_command(
+                    self.escalation_cmd
+                )
+                if dispatch_attempted and dispatch_result.startswith("dispatched"):
+                    self._increment_counter("self_audit_escalation_dispatch_success")
+                elif dispatch_attempted:
+                    self._increment_counter("self_audit_escalation_dispatch_fail")
+            else:
+                dispatch_result = "legacy_escalation_dispatch_disabled"
 
         escalation = SelfAuditEscalation(
             timestamp=now,
@@ -443,7 +547,7 @@ class DaemonSelfAuditLoop:
         if not dispatched:
             return False, f"dispatch_failed:{detail}"
 
-        # Dispatch succeeded → fix was attempted. Health polling annotates
+        # Dispatch succeeded -> fix was attempted. Health polling annotates
         # the result string but does not flip the "attempted" flag.
         if self.ironclaw_start_retry_count <= 0:
             return True, detail
@@ -590,17 +694,9 @@ class DaemonSelfAuditLoop:
 
     def _persist_event(self, event: SelfAuditEvent) -> None:
         self.task_log_path.parent.mkdir(parents=True, exist_ok=True)
-        row = {
-            "timestamp": event.timestamp,
-            "source_file": event.source_file,
-            "signature": event.signature,
-            "line": event.line,
-            "recommended_fix": event.recommended_fix,
-            "auto_fix_attempted": event.auto_fix_attempted,
-            "auto_fix_result": event.auto_fix_result,
-        }
+        row = asdict(event)
         with self.task_log_path.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+            handle.write(json.dumps(row, ensure_ascii=True) + "\n")
 
     def _persist_escalation(self, escalation: SelfAuditEscalation) -> None:
         self.escalation_log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/modules/infrastructure/wre_core/tests/test_daemon_self_audit_loop.py
+++ b/modules/infrastructure/wre_core/tests/test_daemon_self_audit_loop.py
@@ -13,6 +13,8 @@ from modules.infrastructure.wre_core.src.daemon_self_audit_loop import (
     DaemonSelfAuditLoop,
 )
 
+POPEN_TARGET = "modules.infrastructure.wre_core.src.daemon_self_audit_loop.subprocess.Popen"
+
 
 def _read_jsonl(path: Path):
     rows = []
@@ -43,9 +45,17 @@ def test_self_audit_opens_task_on_error_line(tmp_path: Path, monkeypatch):
     assert len(rows) == 1
     assert rows[0]["recommended_fix"] == "start_ironclaw_gateway"
     assert rows[0]["auto_fix_attempted"] is False
+    assert rows[0]["auto_fix_result"].startswith("improvement_job_proposed:")
+    assert rows[0]["improvement_job_id"].startswith("imp_")
+
+    proposals = _read_jsonl(loop.improvement_job_log_path)
+    assert len(proposals) == 1
+    assert proposals[0]["job"]["status"] == "pending"
+    assert proposals[0]["job"]["dry_run"] is True
+    assert proposals[0]["no_execution_performed"] is True
 
 
-def test_self_audit_policy_fix_dispatches_gateway_start(tmp_path: Path, monkeypatch):
+def test_self_audit_auto_fix_requires_legacy_opt_in(tmp_path: Path, monkeypatch):
     logs = tmp_path / "logs"
     logs.mkdir(parents=True)
     log_file = logs / "daemon.log"
@@ -63,7 +73,36 @@ def test_self_audit_policy_fix_dispatches_gateway_start(tmp_path: Path, monkeypa
     monkeypatch.setenv("IRONCLAW_START_RETRY_COUNT", "0")
 
     loop = DaemonSelfAuditLoop(repo_root=tmp_path)
-    with patch("modules.infrastructure.wre_core.src.daemon_self_audit_loop.subprocess.Popen") as mock_popen:
+    with patch(POPEN_TARGET) as mock_popen:
+        events = loop.scan_once()
+
+    assert events == 1
+    assert mock_popen.call_count == 0
+    rows = _read_jsonl(loop.task_log_path)
+    assert rows[0]["auto_fix_attempted"] is False
+    assert rows[0]["auto_fix_result"].startswith("improvement_job_proposed:")
+
+
+def test_self_audit_legacy_policy_fix_dispatches_with_dual_opt_in(
+    tmp_path: Path, monkeypatch
+):
+    logs = tmp_path / "logs"
+    logs.mkdir(parents=True)
+    log_file = logs / "daemon.log"
+    log_file.write_text(
+        "IronClaw runtime is unavailable, health endpoint unavailable\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("OPENCLAW_SELF_AUDIT_LOG_GLOBS", "logs/**/*.log")
+    monkeypatch.setenv("OPENCLAW_SELF_AUDIT_AUTO_FIX", "1")
+    monkeypatch.setenv("OPENCLAW_SELF_AUDIT_ALLOW_LEGACY_AUTO_FIX", "1")
+    monkeypatch.setenv("OPENCLAW_SELF_AUDIT_ALLOWED_FIXES", "start_ironclaw_gateway")
+    monkeypatch.setenv("IRONCLAW_START_CMD", "echo start")
+    monkeypatch.setenv("IRONCLAW_START_RETRY_COUNT", "0")
+
+    loop = DaemonSelfAuditLoop(repo_root=tmp_path)
+    with patch(POPEN_TARGET) as mock_popen:
         events = loop.scan_once()
 
     assert events == 1
@@ -74,7 +113,7 @@ def test_self_audit_policy_fix_dispatches_gateway_start(tmp_path: Path, monkeypa
 
 
 def test_ironclaw_retry_reports_attempted_but_unhealthy(tmp_path: Path, monkeypatch):
-    """Dispatch succeeds, health polling never does → attempted=True, result flags unhealthy."""
+    """Dispatch succeeds, health polling never does -> attempted=True, result flags unhealthy."""
     logs = tmp_path / "logs"
     logs.mkdir(parents=True)
     log_file = logs / "daemon.log"
@@ -85,20 +124,24 @@ def test_ironclaw_retry_reports_attempted_but_unhealthy(tmp_path: Path, monkeypa
 
     monkeypatch.setenv("OPENCLAW_SELF_AUDIT_LOG_GLOBS", "logs/**/*.log")
     monkeypatch.setenv("OPENCLAW_SELF_AUDIT_AUTO_FIX", "1")
+    monkeypatch.setenv("OPENCLAW_SELF_AUDIT_ALLOW_LEGACY_AUTO_FIX", "1")
     monkeypatch.setenv("OPENCLAW_SELF_AUDIT_ALLOWED_FIXES", "start_ironclaw_gateway")
     monkeypatch.setenv("IRONCLAW_START_CMD", "echo start")
     monkeypatch.setenv("IRONCLAW_START_RETRY_COUNT", "2")
     monkeypatch.setenv("IRONCLAW_START_RETRY_DELAY_SEC", "0")
 
     loop = DaemonSelfAuditLoop(repo_root=tmp_path)
-    with patch("modules.infrastructure.wre_core.src.daemon_self_audit_loop.subprocess.Popen") as mock_popen, \
-         patch.object(DaemonSelfAuditLoop, "_verify_ironclaw_health", return_value=(False, "health_error:URLError")):
+    with patch(POPEN_TARGET) as mock_popen, patch.object(
+        DaemonSelfAuditLoop,
+        "_verify_ironclaw_health",
+        return_value=(False, "health_error:URLError"),
+    ):
         events = loop.scan_once()
 
     assert events == 1
     assert mock_popen.call_count == 1
     rows = _read_jsonl(loop.task_log_path)
-    # Dispatch ran → attempted=True, even though health never came up.
+    # Dispatch ran -> attempted=True, even though health never came up.
     assert rows[0]["auto_fix_attempted"] is True
     result = rows[0]["auto_fix_result"]
     assert result.startswith("attempted_but_unhealthy_after_2_attempt(s):")
@@ -106,7 +149,7 @@ def test_ironclaw_retry_reports_attempted_but_unhealthy(tmp_path: Path, monkeypa
 
 
 def test_ironclaw_retry_reports_healthy_when_health_endpoint_responds(tmp_path: Path, monkeypatch):
-    """Dispatch succeeds; health passes on first poll → attempted=True, result contains dispatch marker."""
+    """Dispatch succeeds; health passes on first poll and keeps the marker."""
     logs = tmp_path / "logs"
     logs.mkdir(parents=True)
     log_file = logs / "daemon.log"
@@ -117,14 +160,18 @@ def test_ironclaw_retry_reports_healthy_when_health_endpoint_responds(tmp_path: 
 
     monkeypatch.setenv("OPENCLAW_SELF_AUDIT_LOG_GLOBS", "logs/**/*.log")
     monkeypatch.setenv("OPENCLAW_SELF_AUDIT_AUTO_FIX", "1")
+    monkeypatch.setenv("OPENCLAW_SELF_AUDIT_ALLOW_LEGACY_AUTO_FIX", "1")
     monkeypatch.setenv("OPENCLAW_SELF_AUDIT_ALLOWED_FIXES", "start_ironclaw_gateway")
     monkeypatch.setenv("IRONCLAW_START_CMD", "echo start")
     monkeypatch.setenv("IRONCLAW_START_RETRY_COUNT", "3")
     monkeypatch.setenv("IRONCLAW_START_RETRY_DELAY_SEC", "0")
 
     loop = DaemonSelfAuditLoop(repo_root=tmp_path)
-    with patch("modules.infrastructure.wre_core.src.daemon_self_audit_loop.subprocess.Popen") as mock_popen, \
-         patch.object(DaemonSelfAuditLoop, "_verify_ironclaw_health", return_value=(True, "health_ok:200")):
+    with patch(POPEN_TARGET) as mock_popen, patch.object(
+        DaemonSelfAuditLoop,
+        "_verify_ironclaw_health",
+        return_value=(True, "health_ok:200"),
+    ):
         events = loop.scan_once()
 
     assert events == 1
@@ -162,6 +209,7 @@ def test_self_audit_verifies_event_store_when_sequence_error_seen(tmp_path: Path
 
     monkeypatch.setenv("OPENCLAW_SELF_AUDIT_LOG_GLOBS", "logs/**/*.log")
     monkeypatch.setenv("OPENCLAW_SELF_AUDIT_AUTO_FIX", "1")
+    monkeypatch.setenv("OPENCLAW_SELF_AUDIT_ALLOW_LEGACY_AUTO_FIX", "1")
     monkeypatch.setenv("OPENCLAW_SELF_AUDIT_ALLOWED_FIXES", "verify_dae_event_store")
 
     loop = DaemonSelfAuditLoop(repo_root=tmp_path)
@@ -230,7 +278,9 @@ def test_self_audit_escalates_repeated_signature(tmp_path: Path, monkeypatch):
     assert escalations[0]["dispatch_attempted"] is False
 
 
-def test_self_audit_escalation_dispatches_configured_command(tmp_path: Path, monkeypatch):
+def test_self_audit_escalation_command_requires_legacy_dispatch_flag(
+    tmp_path: Path, monkeypatch
+):
     logs = tmp_path / "logs"
     logs.mkdir(parents=True)
     log_file = logs / "daemon.log"
@@ -245,7 +295,43 @@ def test_self_audit_escalation_dispatches_configured_command(tmp_path: Path, mon
     monkeypatch.setenv("OPENCLAW_SELF_AUDIT_ESCALATE_CMD", "echo escalate")
 
     loop = DaemonSelfAuditLoop(repo_root=tmp_path)
-    with patch("modules.infrastructure.wre_core.src.daemon_self_audit_loop.subprocess.Popen") as mock_popen:
+    with patch(POPEN_TARGET) as mock_popen:
+        loop.scan_once()
+        with log_file.open("a", encoding="utf-8") as handle:
+            handle.write(line)
+        loop._seen.clear()
+        loop.scan_once()
+        with log_file.open("a", encoding="utf-8") as handle:
+            handle.write(line)
+        loop._seen.clear()
+        loop.scan_once()
+
+    assert mock_popen.call_count == 0
+    escalations = _read_jsonl(loop.escalation_log_path)
+    assert len(escalations) == 1
+    assert escalations[0]["dispatch_attempted"] is False
+    assert escalations[0]["dispatch_result"] == "legacy_escalation_dispatch_disabled"
+
+
+def test_self_audit_legacy_escalation_dispatches_configured_command(
+    tmp_path: Path, monkeypatch
+):
+    logs = tmp_path / "logs"
+    logs.mkdir(parents=True)
+    log_file = logs / "daemon.log"
+    line = "IronClaw runtime is unavailable, health endpoint unavailable\n"
+    log_file.write_text(line, encoding="utf-8")
+
+    monkeypatch.setenv("OPENCLAW_SELF_AUDIT_LOG_GLOBS", "logs/**/*.log")
+    monkeypatch.setenv("OPENCLAW_SELF_AUDIT_AUTO_FIX", "0")
+    monkeypatch.setenv("OPENCLAW_SELF_AUDIT_ESCALATE_AFTER", "3")
+    monkeypatch.setenv("OPENCLAW_SELF_AUDIT_ESCALATION_WINDOW_SEC", "900")
+    monkeypatch.setenv("OPENCLAW_SELF_AUDIT_ESCALATION_COOLDOWN_SEC", "600")
+    monkeypatch.setenv("OPENCLAW_SELF_AUDIT_ESCALATE_CMD", "echo escalate")
+    monkeypatch.setenv("OPENCLAW_SELF_AUDIT_ALLOW_LEGACY_ESCALATION_DISPATCH", "1")
+
+    loop = DaemonSelfAuditLoop(repo_root=tmp_path)
+    with patch(POPEN_TARGET) as mock_popen:
         loop.scan_once()
         with log_file.open("a", encoding="utf-8") as handle:
             handle.write(line)
@@ -283,7 +369,7 @@ def test_self_audit_filters_noise_signatures(tmp_path: Path, monkeypatch):
     loop = DaemonSelfAuditLoop(repo_root=tmp_path)
     events = loop.scan_once()
 
-    # All lines should be filtered as noise — no events opened
+    # All lines should be filtered as noise -- no events opened
     assert events == 0
     rows = _read_jsonl(loop.task_log_path)
     assert len(rows) == 0


### PR DESCRIPTION
## Summary

REDDOG_DAEMON_SELF_AUDIT_DRYRUN_PROPOSAL_PHASE1.

Routes daemon self-audit findings into PENDING/dry-run `ImprovementJob` proposals with RedDog direction receipts by default. Legacy auto-fix and escalation dispatch remain present only behind explicit legacy opt-in flags.

## WSP_97 Evidence

- OBSERVED: default `DaemonSelfAuditLoop` now emits `daemon_self_audit_improvement_jobs.jsonl` proposal receipts with `no_execution_performed`, `no_subprocess_performed`, `no_queue_mutation_performed`, and `no_pattern_memory_write_performed` attestations.
- OBSERVED: `OPENCLAW_SELF_AUDIT_AUTO_FIX=1` alone no longer dispatches a subprocess; legacy auto-fix requires `OPENCLAW_SELF_AUDIT_ALLOW_LEGACY_AUTO_FIX=1` as a second opt-in.
- OBSERVED: configured escalation commands no longer dispatch by default; legacy escalation requires `OPENCLAW_SELF_AUDIT_ALLOW_LEGACY_ESCALATION_DISPATCH=1`.
- OBSERVED: existing diagnostic policy fix paths remain test-covered under explicit legacy opt-in.
- SPECIFIED_NOT_IMPLEMENTED: live autonomous repair execution, queue mutation, PatternMemory retention, and recursive improvement promotion remain outside this slice.

## Verification

- `pytest modules/infrastructure/wre_core/tests/test_daemon_self_audit_loop.py modules/infrastructure/wre_core/tests/test_reddog_direction.py modules/infrastructure/wre_core/tests/test_improvement_job_contract.py -q` -> 55 passed.
- `python -m py_compile modules/infrastructure/wre_core/src/daemon_self_audit_loop.py modules/infrastructure/wre_core/tests/test_daemon_self_audit_loop.py` -> pass.
- `git diff --check` -> clean (CRLF warnings only).
- Byte hygiene on changed files -> 0 non-ASCII, 0 NUL.

## HoloIndex

Read-only probe for `daemon self audit dryrun improvement proposal RedDog direction` did not surface the updated daemon self-audit proposal path. Recorded `HOLOINDEX_REDDOG_DAEMON_SELF_AUDIT_DRYRUN_PROPOSAL_INDEX_GAP_PHASE1`; no runtime re-index performed.

## Boundary

No OpenClaw enqueue, WRE execution, PatternMemory write, HoloIndex re-index, or default subprocess dispatch is introduced. This slice is observe -> propose by default.