### PR TITLE
feat(token-efficiency): add RTK evaluation dry-run

### DIFF
--- a/modules/infrastructure/token_efficiency/INTERFACE.md
+++ b/modules/infrastructure/token_efficiency/INTERFACE.md
@@ -167,10 +167,57 @@ Aggregate metrics from event list.
 - `ContentType`: M2M_PROMPT, TOOL_OUTPUT, RAW_REF, UNKNOWN
 - `CompressionStatus`: COMPRESSED, BYPASSED, UNCHANGED, ERROR, NOT_APPLICABLE
 
+## Public API (P5: RTK Evaluation Dry-Run)
+
+P5 evaluates caller-supplied candidate output. It does not invoke RTK, execute a
+command, or authorize runtime compression.
+
+### Classes
+
+#### `RtkEvaluationDryRunResult`
+
+```python
+@dataclass
+class RtkEvaluationDryRunResult:
+    evaluation_id: str
+    decision: RtkDryRunDecision
+    command_digest: str
+    raw_output_digest: str
+    candidate_output_digest: str
+    raw_ref_digest: str
+    telemetry_event_id: str | None
+    input_bytes: int
+    candidate_bytes: int
+    bytes_saved: int
+    tokens_saved: int
+    savings_ratio: float
+    bypass_class: str | None
+    rejection_reasons: list[str]
+    dry_run_only: bool            # Always True
+    rtk_invoked: bool             # Always False
+    command_executed: bool        # Always False
+    compression_performed: bool   # Always False
+    raw_content_persisted: bool   # Always False
+    runtime_reindex_allowed: bool # Always False
+```
+
+### Functions
+
+#### `evaluate_rtk_candidate_dry_run(...) -> RtkEvaluationDryRunResult`
+
+Evaluates a candidate compressed output using:
+
+- a P4 compute decision whose routing is `ALLOW_EVALUATION_DRY_RUN`
+- content-level bypass classification over both raw and candidate output
+- a mandatory `raw_ref` recovery path
+- in-memory `RTK_EVALUATION` telemetry
+
+Acceptance means the candidate is measurable and safe for dry-run evaluation.
+It is not permission to wire RTK into OpenClaw, Hermes, WRE, or extension runtime.
+
 ## Not Implemented (Future Phases)
 
 | Component | Phase | Status |
 |-----------|-------|--------|
-| Compute governor | P4 | SPECIFIED_NOT_IMPLEMENTED |
-| RTK adapter | P5 | SPECIFIED_NOT_IMPLEMENTED |
+| RTK adapter | P6 | SPECIFIED_NOT_IMPLEMENTED |
 | Compression seam | P6 | SPECIFIED_NOT_IMPLEMENTED |

--- a/modules/infrastructure/token_efficiency/README.md
+++ b/modules/infrastructure/token_efficiency/README.md
@@ -1,6 +1,6 @@
 # Token Efficiency Module
 
-**Status**: P4 (Compute Governor) ACTIVE
+**Status**: P5 (RTK Evaluation Dry-Run) ACTIVE
 **Contract**: `docs/contracts/REDDOG_WSP99_RTK_TOKEN_EFFICIENCY_CONTRACT_PHASE1.md`
 **WSP**: WSP_97, WSP_99
 
@@ -10,6 +10,8 @@ Provides token efficiency services for the RedDog/WRE stack:
 - Bypass classification (which outputs must remain raw)
 - M2M fidelity validation (round-trip preservation)
 - Token savings telemetry (measurement, not claims)
+- Compute governor routing decisions before tool execution
+- RTK evaluation dry-runs over caller-supplied candidate output
 - RTK integration seam (when ready)
 
 ## Current State (P1)
@@ -74,8 +76,8 @@ The classifier always fails closed:
 | P1 | BYPASS_CLASSIFIER_SECURITY_GATE_PHASE1 | LANDED (#940) |
 | P2 | WSP99_COMPILER_FIDELITY_GATE_PHASE1 | LANDED (#943) |
 | P3 | TOKEN_EFFICIENCY_TELEMETRY_SERVICE_PHASE1 | LANDED (#944) |
-| P4 | REDDOG_COMPUTE_GOVERNOR_PHASE1 | ACTIVE |
-| P5 | RTK_EVALUATION_DRY_RUN_PHASE1 | Planned |
+| P4 | REDDOG_COMPUTE_GOVERNOR_PHASE1 | LANDED (#946) |
+| P5 | RTK_EVALUATION_DRY_RUN_PHASE1 | ACTIVE |
 | P6 | RTK_OPENCLAW_HERMES_ADAPTER_DRYRUN_PHASE1 | Planned |
 
 ## Files
@@ -88,12 +90,14 @@ modules/infrastructure/token_efficiency/
     m2m_fidelity_gate.py      # P2: Round-trip validation
     telemetry_service.py      # P3: Token savings measurement
     compute_governor.py       # P4: Routing decisions (not compression authority)
+    rtk_evaluation_dryrun.py  # P5: Candidate evaluation, no RTK invocation
   tests/
     test_bypass_classifier.py # Unit + adversarial tests
     test_m2m_fidelity.py      # Fidelity + CTX.HOLO tests
     test_m2m_compiler_compat.py # Compiler backward-compat
     test_telemetry_service.py # Telemetry service tests
     test_compute_governor.py  # Routing + invariant tests
+    test_rtk_evaluation_dryrun.py # Dry-run candidate evaluation tests
   config/
     bypass_patterns.yaml      # Pattern definitions
   README.md                   # This file
@@ -102,8 +106,12 @@ modules/infrastructure/token_efficiency/
 
 ## No Runtime RTK Yet
 
-This module does NOT include RTK integration. RTK is planned for P5/P6 after:
+This module does NOT include RTK integration. P5 only evaluates caller-supplied
+candidate output and records in-memory telemetry; it does not invoke an RTK
+binary, execute commands, or perform runtime compression. RTK adapter integration
+is planned for P6 after:
 - Bypass classifier proven (P1)
 - M2M fidelity proven (P2)
 - Telemetry operational (P3)
 - Compute governor wired (P4)
+- RTK evaluation dry-run accepted (P5)

--- a/modules/infrastructure/token_efficiency/src/__init__.py
+++ b/modules/infrastructure/token_efficiency/src/__init__.py
@@ -72,6 +72,13 @@ from .compute_governor import (
     reset_compute_governor,
 )
 
+from .rtk_evaluation_dryrun import (
+    RtkDryRunDecision,
+    RtkDryRunRejection,
+    RtkEvaluationDryRunResult,
+    evaluate_rtk_candidate_dry_run,
+)
+
 __all__ = [
     # Bypass classifier (P1)
     "BypassClass",
@@ -127,4 +134,9 @@ __all__ = [
     "validate_decision",
     "get_compute_governor",
     "reset_compute_governor",
+    # RTK evaluation dry-run (P5)
+    "RtkDryRunDecision",
+    "RtkDryRunRejection",
+    "RtkEvaluationDryRunResult",
+    "evaluate_rtk_candidate_dry_run",
 ]

--- a/modules/infrastructure/token_efficiency/src/rtk_evaluation_dryrun.py
+++ b/modules/infrastructure/token_efficiency/src/rtk_evaluation_dryrun.py
@@ -1,0 +1,259 @@
+# -*- coding: utf-8 -*-
+"""RTK evaluation dry-run for token-efficiency measurement.
+
+Slice: RTK_EVALUATION_DRY_RUN_PHASE1
+
+This module evaluates a caller-supplied compression candidate. It never invokes
+RTK, never executes commands, and never performs runtime compression. Acceptance
+means "the supplied candidate is safe enough to measure", not "wire RTK".
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any, Mapping
+
+from .bypass_classifier import BypassClassifier, get_bypass_classifier
+from .compute_governor import RedDogComputeDecision, Routing
+from .telemetry_service import (
+    ContentType,
+    Operation,
+    SourceLayer,
+    TokenCompressionEvent,
+    build_token_compression_event,
+    get_telemetry_store,
+)
+
+
+class RtkDryRunDecision(Enum):
+    """RTK dry-run evaluation result."""
+
+    ACCEPT = "RTK_DRY_RUN_ACCEPT"
+    REJECT = "RTK_DRY_RUN_REJECT"
+
+
+class RtkDryRunRejection(Enum):
+    """Fail-closed rejection reasons."""
+
+    COMPUTE_DECISION_NOT_ALLOW_EVALUATION = "COMPUTE_DECISION_NOT_ALLOW_EVALUATION"
+    RAW_OUTPUT_REQUIRES_BYPASS = "RAW_OUTPUT_REQUIRES_BYPASS"
+    CANDIDATE_OUTPUT_REQUIRES_BYPASS = "CANDIDATE_OUTPUT_REQUIRES_BYPASS"
+    RAW_REF_REQUIRED = "RAW_REF_REQUIRED"
+    CANDIDATE_OUTPUT_REQUIRED = "CANDIDATE_OUTPUT_REQUIRED"
+    NO_POSITIVE_SAVINGS = "NO_POSITIVE_SAVINGS"
+    RUNTIME_REINDEX_FORBIDDEN = "RUNTIME_REINDEX_FORBIDDEN"
+
+
+@dataclass(frozen=True)
+class RtkEvaluationDryRunResult:
+    """Dry-run result for one caller-supplied RTK candidate."""
+
+    evaluation_id: str
+    decision: RtkDryRunDecision
+    command_digest: str
+    raw_output_digest: str
+    candidate_output_digest: str
+    raw_ref_digest: str
+    telemetry_event_id: str | None
+    input_bytes: int
+    candidate_bytes: int
+    bytes_saved: int
+    tokens_saved: int
+    savings_ratio: float
+    bypass_class: str | None
+    rejection_reasons: list[str]
+    dry_run_only: bool = True
+    rtk_invoked: bool = False
+    command_executed: bool = False
+    compression_performed: bool = False
+    raw_content_persisted: bool = False
+    runtime_reindex_allowed: bool = False
+
+    @property
+    def accepted(self) -> bool:
+        return self.decision == RtkDryRunDecision.ACCEPT
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["decision"] = self.decision.value
+        return payload
+
+    def to_m2m_compact(self) -> str:
+        status = "ACCEPT" if self.accepted else "REJECT"
+        return (
+            f"RTK_EVAL:{self.evaluation_id[:8]} "
+            f"STATUS:{status} "
+            f"SAVED:{self.tokens_saved} "
+            f"RATIO:{self.savings_ratio:.3f} "
+            f"BYPASS:{self.bypass_class or 'none'}"
+        )
+
+    def to_m2m_yaml(self) -> str:
+        lines = [
+            "RTK_EVALUATION_DRY_RUN:",
+            f"  evaluation_id: {self.evaluation_id}",
+            f"  decision: {self.decision.value}",
+            f"  command_digest: {self.command_digest}",
+            f"  raw_output_digest: {self.raw_output_digest}",
+            f"  candidate_output_digest: {self.candidate_output_digest}",
+            f"  raw_ref_digest: {self.raw_ref_digest}",
+            f"  telemetry_event_id: {self.telemetry_event_id}",
+            "  metrics:",
+            f"    input_bytes: {self.input_bytes}",
+            f"    candidate_bytes: {self.candidate_bytes}",
+            f"    bytes_saved: {self.bytes_saved}",
+            f"    tokens_saved: {self.tokens_saved}",
+            f"    savings_ratio: {self.savings_ratio:.4f}",
+            "  invariants:",
+            f"    dry_run_only: {self.dry_run_only}",
+            f"    rtk_invoked: {self.rtk_invoked}",
+            f"    command_executed: {self.command_executed}",
+            f"    compression_performed: {self.compression_performed}",
+            f"    raw_content_persisted: {self.raw_content_persisted}",
+            f"    runtime_reindex_allowed: {self.runtime_reindex_allowed}",
+            f"  rejection_reasons: {self.rejection_reasons}",
+        ]
+        return "\n".join(lines)
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _decision_to_mapping(decision: RedDogComputeDecision | Mapping[str, Any]) -> dict[str, Any]:
+    if isinstance(decision, RedDogComputeDecision):
+        return decision.to_dict()
+    return dict(decision)
+
+
+def _routing_value(decision: Mapping[str, Any]) -> str:
+    routing = decision.get("routing")
+    if isinstance(routing, Routing):
+        return routing.value
+    return str(routing or "")
+
+
+def _command_digest(decision: Mapping[str, Any], command: str) -> str:
+    value = str(decision.get("command_digest") or "")
+    return value or _sha256(command)
+
+
+def _event_for(
+    *,
+    raw_output: str,
+    candidate_output: str,
+    bypass_decision: str | None,
+    ctx_holo_present: bool,
+    index_gap_detected: bool,
+) -> TokenCompressionEvent:
+    output_bytes = len(candidate_output.encode("utf-8"))
+    if bypass_decision:
+        output_bytes = len(raw_output.encode("utf-8"))
+    return build_token_compression_event(
+        source_layer=SourceLayer.RTK_EVALUATION,
+        operation=Operation.EVALUATE,
+        content_type=ContentType.TOOL_OUTPUT,
+        input_bytes=len(raw_output.encode("utf-8")),
+        output_bytes=output_bytes,
+        bypass_decision=bypass_decision,
+        raw_ref_present=True,
+        ctx_holo_present=ctx_holo_present,
+        index_gap_detected=index_gap_detected,
+    )
+
+
+def evaluate_rtk_candidate_dry_run(
+    *,
+    command: str,
+    raw_output: str,
+    candidate_output: str,
+    raw_ref: str,
+    compute_decision: RedDogComputeDecision | Mapping[str, Any],
+    bypass_classifier: BypassClassifier | None = None,
+    record_telemetry: bool = True,
+) -> RtkEvaluationDryRunResult:
+    """Evaluate a caller-supplied RTK candidate without invoking RTK."""
+
+    decision = _decision_to_mapping(compute_decision)
+    classifier = bypass_classifier or get_bypass_classifier()
+    reasons: list[str] = []
+    bypass_class: str | None = None
+
+    if _routing_value(decision) != Routing.ALLOW_EVALUATION_DRY_RUN.value:
+        reasons.append(RtkDryRunRejection.COMPUTE_DECISION_NOT_ALLOW_EVALUATION.value)
+    if decision.get("runtime_reindex_allowed") is True:
+        reasons.append(RtkDryRunRejection.RUNTIME_REINDEX_FORBIDDEN.value)
+    if not raw_ref:
+        reasons.append(RtkDryRunRejection.RAW_REF_REQUIRED.value)
+    if not candidate_output:
+        reasons.append(RtkDryRunRejection.CANDIDATE_OUTPUT_REQUIRED.value)
+
+    raw_bypass = classifier.classify(command=command, output=raw_output)
+    if raw_bypass.bypassed:
+        bypass_class = raw_bypass.classification.value
+        reasons.append(RtkDryRunRejection.RAW_OUTPUT_REQUIRES_BYPASS.value)
+
+    if candidate_output:
+        candidate_bypass = classifier.classify(command=command, output=candidate_output)
+        if candidate_bypass.bypassed:
+            bypass_class = bypass_class or candidate_bypass.classification.value
+            reasons.append(RtkDryRunRejection.CANDIDATE_OUTPUT_REQUIRES_BYPASS.value)
+
+    input_bytes = len(raw_output.encode("utf-8"))
+    candidate_bytes = len(candidate_output.encode("utf-8"))
+    bytes_saved = input_bytes - candidate_bytes
+
+    event = _event_for(
+        raw_output=raw_output,
+        candidate_output=candidate_output,
+        bypass_decision=bypass_class,
+        ctx_holo_present=bool(decision.get("ctx_holo_present")),
+        index_gap_detected=bool(decision.get("index_gap_detected")),
+    )
+    if not bypass_class and bytes_saved <= 0:
+        reasons.append(RtkDryRunRejection.NO_POSITIVE_SAVINGS.value)
+
+    if record_telemetry:
+        get_telemetry_store().record(event)
+
+    accepted = not reasons
+    if not accepted:
+        bytes_saved = max(0, bytes_saved) if not bypass_class else 0
+    savings_ratio = (bytes_saved / input_bytes) if input_bytes > 0 else 0.0
+    evaluation_seed = {
+        "command_digest": _command_digest(decision, command),
+        "raw_output_digest": _sha256(raw_output),
+        "candidate_output_digest": _sha256(candidate_output),
+        "raw_ref_digest": _sha256(raw_ref),
+        "reasons": reasons,
+    }
+    evaluation_id = hashlib.sha256(
+        json.dumps(evaluation_seed, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:32]
+    return RtkEvaluationDryRunResult(
+        evaluation_id=evaluation_id,
+        decision=RtkDryRunDecision.ACCEPT if accepted else RtkDryRunDecision.REJECT,
+        command_digest=_command_digest(decision, command),
+        raw_output_digest=_sha256(raw_output),
+        candidate_output_digest=_sha256(candidate_output),
+        raw_ref_digest=_sha256(raw_ref),
+        telemetry_event_id=event.event_id,
+        input_bytes=input_bytes,
+        candidate_bytes=candidate_bytes,
+        bytes_saved=bytes_saved,
+        tokens_saved=max(0, event.tokens_saved) if accepted else 0,
+        savings_ratio=savings_ratio,
+        bypass_class=bypass_class,
+        rejection_reasons=reasons,
+    )
+
+
+__all__ = [
+    "RtkDryRunDecision",
+    "RtkDryRunRejection",
+    "RtkEvaluationDryRunResult",
+    "evaluate_rtk_candidate_dry_run",
+]

--- a/modules/infrastructure/token_efficiency/tests/test_rtk_evaluation_dryrun.py
+++ b/modules/infrastructure/token_efficiency/tests/test_rtk_evaluation_dryrun.py
@@ -1,0 +1,280 @@
+# -*- coding: utf-8 -*-
+"""Tests for RTK_EVALUATION_DRY_RUN_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.infrastructure.token_efficiency.src.compute_governor import (
+    Routing,
+    get_compute_governor,
+    reset_compute_governor,
+)
+from modules.infrastructure.token_efficiency.src.rtk_evaluation_dryrun import (
+    RtkDryRunDecision,
+    RtkDryRunRejection,
+    evaluate_rtk_candidate_dry_run,
+)
+from modules.infrastructure.token_efficiency.src.telemetry_service import (
+    CompressionStatus,
+    SourceLayer,
+    get_telemetry_store,
+    reset_telemetry_store,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "infrastructure"
+    / "token_efficiency"
+    / "src"
+    / "rtk_evaluation_dryrun.py"
+)
+
+
+def _decision(command: str = "ls -la"):
+    reset_compute_governor()
+    return get_compute_governor().get_routing_recommendation(
+        command=command,
+        output_preview="alpha.txt\nbeta.txt\n",
+        ctx_holo_present=True,
+        index_gap_detected=False,
+    )
+
+
+def setup_function() -> None:
+    reset_telemetry_store()
+    reset_compute_governor()
+
+
+def test_accepts_safe_candidate_and_records_measurement_telemetry() -> None:
+    raw = "\n".join(f"file_{idx}.py" for idx in range(80))
+    candidate = "80 python files"
+
+    result = evaluate_rtk_candidate_dry_run(
+        command="ls -la",
+        raw_output=raw,
+        candidate_output=candidate,
+        raw_ref="raw_ref:ls-output:sha256",
+        compute_decision=_decision(),
+    )
+
+    assert result.accepted is True
+    assert result.decision == RtkDryRunDecision.ACCEPT
+    assert result.bytes_saved > 0
+    assert result.tokens_saved > 0
+    assert result.savings_ratio > 0
+    assert result.dry_run_only is True
+    assert result.rtk_invoked is False
+    assert result.command_executed is False
+    assert result.compression_performed is False
+    assert result.raw_content_persisted is False
+
+    events = get_telemetry_store().get_all()
+    assert len(events) == 1
+    assert events[0].source_layer == SourceLayer.RTK_EVALUATION
+    assert events[0].compression_status == CompressionStatus.COMPRESSED
+    assert events[0].raw_ref_present is True
+
+
+def test_rejects_when_compute_governor_did_not_allow_evaluation() -> None:
+    decision = get_compute_governor().classify_command_for_evaluation("npm audit")
+    assert decision.routing == Routing.BYPASS_REQUIRED
+
+    result = evaluate_rtk_candidate_dry_run(
+        command="npm audit",
+        raw_output="audit output",
+        candidate_output="summary",
+        raw_ref="raw_ref:audit",
+        compute_decision=decision,
+    )
+
+    assert result.accepted is False
+    assert (
+        RtkDryRunRejection.COMPUTE_DECISION_NOT_ALLOW_EVALUATION.value
+        in result.rejection_reasons
+    )
+
+
+def test_rejects_raw_output_that_requires_bypass() -> None:
+    result = evaluate_rtk_candidate_dry_run(
+        command="cat .env",
+        raw_output="API_KEY=sk-secret123456",
+        candidate_output="config summary",
+        raw_ref="raw_ref:env",
+        compute_decision=_decision("cat .env"),
+    )
+
+    assert result.accepted is False
+    assert RtkDryRunRejection.RAW_OUTPUT_REQUIRES_BYPASS.value in result.rejection_reasons
+    assert result.bypass_class is not None
+    assert get_telemetry_store().get_all()[0].compression_status == CompressionStatus.BYPASSED
+
+
+def test_rejects_candidate_output_that_requires_bypass() -> None:
+    result = evaluate_rtk_candidate_dry_run(
+        command="echo hello",
+        raw_output="hello world\n" * 20,
+        candidate_output="token=sk-secret123456",
+        raw_ref="raw_ref:echo",
+        compute_decision=_decision("echo hello"),
+    )
+
+    assert result.accepted is False
+    assert (
+        RtkDryRunRejection.CANDIDATE_OUTPUT_REQUIRES_BYPASS.value
+        in result.rejection_reasons
+    )
+
+
+def test_rejects_without_raw_ref_recovery_path() -> None:
+    result = evaluate_rtk_candidate_dry_run(
+        command="ls -la",
+        raw_output="a\nb\nc\n",
+        candidate_output="3 files",
+        raw_ref="",
+        compute_decision=_decision(),
+    )
+
+    assert result.accepted is False
+    assert RtkDryRunRejection.RAW_REF_REQUIRED.value in result.rejection_reasons
+
+
+def test_rejects_empty_candidate_output() -> None:
+    result = evaluate_rtk_candidate_dry_run(
+        command="ls -la",
+        raw_output="a\nb\nc\n",
+        candidate_output="",
+        raw_ref="raw_ref:ls",
+        compute_decision=_decision(),
+    )
+
+    assert result.accepted is False
+    assert RtkDryRunRejection.CANDIDATE_OUTPUT_REQUIRED.value in result.rejection_reasons
+
+
+def test_rejects_candidate_with_no_positive_savings() -> None:
+    result = evaluate_rtk_candidate_dry_run(
+        command="ls -la",
+        raw_output="tiny",
+        candidate_output="longer than tiny",
+        raw_ref="raw_ref:tiny",
+        compute_decision=_decision(),
+    )
+
+    assert result.accepted is False
+    assert RtkDryRunRejection.NO_POSITIVE_SAVINGS.value in result.rejection_reasons
+
+
+def test_rejects_runtime_reindex_flag_on_compute_decision() -> None:
+    decision = _decision().to_dict()
+    decision["runtime_reindex_allowed"] = True
+
+    result = evaluate_rtk_candidate_dry_run(
+        command="ls -la",
+        raw_output="a\nb\nc\n",
+        candidate_output="3 files",
+        raw_ref="raw_ref:ls",
+        compute_decision=decision,
+    )
+
+    assert result.accepted is False
+    assert RtkDryRunRejection.RUNTIME_REINDEX_FORBIDDEN.value in result.rejection_reasons
+
+
+def test_result_does_not_serialize_raw_output_or_candidate_output() -> None:
+    result = evaluate_rtk_candidate_dry_run(
+        command="ls -la",
+        raw_output="very specific raw payload",
+        candidate_output="specific candidate payload",
+        raw_ref="raw_ref:payload",
+        compute_decision=_decision(),
+    )
+    encoded = json.dumps(result.to_dict(), sort_keys=True)
+
+    assert "very specific raw payload" not in encoded
+    assert "specific candidate payload" not in encoded
+    assert "raw_ref:payload" not in encoded
+
+
+def test_result_is_deterministic_for_same_inputs() -> None:
+    first = evaluate_rtk_candidate_dry_run(
+        command="ls -la",
+        raw_output="a\nb\nc\n",
+        candidate_output="3 files",
+        raw_ref="raw_ref:ls",
+        compute_decision=_decision(),
+    )
+    second = evaluate_rtk_candidate_dry_run(
+        command="ls -la",
+        raw_output="a\nb\nc\n",
+        candidate_output="3 files",
+        raw_ref="raw_ref:ls",
+        compute_decision=_decision(),
+    )
+
+    assert first.evaluation_id == second.evaluation_id
+    assert first.raw_output_digest == second.raw_output_digest
+    assert first.candidate_output_digest == second.candidate_output_digest
+
+
+def test_m2m_outputs_include_dry_run_status() -> None:
+    result = evaluate_rtk_candidate_dry_run(
+        command="ls -la",
+        raw_output="a\nb\nc\n",
+        candidate_output="3 files",
+        raw_ref="raw_ref:ls",
+        compute_decision=_decision(),
+    )
+
+    compact = result.to_m2m_compact()
+    yaml_text = result.to_m2m_yaml()
+    assert "RTK_EVAL" in compact
+    assert "dry_run_only: True" in yaml_text
+    assert "rtk_invoked: False" in yaml_text
+
+
+def test_ast_boundary_no_rtk_subprocess_command_execution_or_persistence() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    forbidden_imports = {
+        "subprocess",
+        "os",
+        "socket",
+        "requests",
+        "httpx",
+        "sqlite3",
+        "rtk",
+        "holo_index",
+        "agent_db",
+    }
+    forbidden_calls = {
+        "run",
+        "Popen",
+        "system",
+        "popen",
+        "open",
+        "index_all",
+        "index_code",
+        "index_docs",
+        "compress",
+        "execute",
+        "create_autonomous_task",
+    }
+    imports = set()
+    calls = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                calls.add(node.func.id)
+            elif isinstance(node.func, ast.Attribute):
+                calls.add(node.func.attr)
+
+    assert imports.isdisjoint(forbidden_imports)
+    assert calls.isdisjoint(forbidden_calls)


### PR DESCRIPTION
## Summary

RTK_EVALUATION_DRY_RUN_PHASE1.

Adds a dry-run evaluator for caller-supplied RTK candidate output. The evaluator composes P1 bypass classification, P3 telemetry, and P4 compute-governor routing. It does not invoke RTK, execute commands, or authorize runtime compression.

## WSP_97 Evidence

- OBSERVED: P4 `ALLOW_EVALUATION_DRY_RUN` is treated as evaluation candidacy only, not compression authority.
- OBSERVED: raw output and candidate output are both classified before acceptance; content bypass overrides command safety.
- OBSERVED: `raw_ref` is mandatory and raw/candidate content is not serialized in the result.
- OBSERVED: telemetry is in-memory and records `SourceLayer.RTK_EVALUATION` with `raw_ref_present=true`.
- SPECIFIED_NOT_IMPLEMENTED: RTK binary invocation, OpenClaw/Hermes/WRE adapter integration, command-output seam wiring, and runtime compression remain blocked until P6.

## Verification

- `pytest modules/infrastructure/token_efficiency/tests/ tests/contracts/test_token_efficiency_contract.py -q` -> 237 passed.
- `python -m py_compile modules/infrastructure/token_efficiency/src/rtk_evaluation_dryrun.py modules/infrastructure/token_efficiency/tests/test_rtk_evaluation_dryrun.py` -> pass.
- `git diff --check` -> clean (CRLF warnings only).
- Touched files -> 0 non-ASCII, 0 NUL.
- New source/test files -> no >120-char lines.

## HoloIndex

Read-only probe for `RTK evaluation dry run token efficiency candidate raw_ref` surfaced the token-efficiency interface and contract, but not the new evaluator module before indexing. Recorded `HOLOINDEX_RTK_EVALUATION_DRY_RUN_INDEX_GAP_PHASE1`; no runtime re-index performed.

## Boundary

No RTK dependency, no RTK binary/subprocess invocation, no command execution, no compression performed, no extension runtime change, no OpenClaw/Hermes/WRE wiring, no HoloIndex mutation, and no telemetry persistence beyond the existing in-memory store.