### PR TITLE
feat(token-efficiency): add RTK OpenClaw Hermes adapter dryrun

### DIFF
--- a/docs/contracts/REDDOG_WSP99_RTK_TOKEN_EFFICIENCY_CONTRACT_PHASE1.md
+++ b/docs/contracts/REDDOG_WSP99_RTK_TOKEN_EFFICIENCY_CONTRACT_PHASE1.md
@@ -205,35 +205,39 @@ the result is consumed by the caller. Candidate locations:
 | WRE gateway response handler | Centralized | Far from execution |
 
 Contract decision: RTK seam at `execute_command()` result handler level. This allows:
-- Bypass classifier to run before compression
-- Raw result preserved if bypass triggers
+- Bypass classifier to run before any future compression
+- Raw result to remain recoverable and preserved
 - Single integration point for all command types
+
+Current implementation status: P6 is a dry-run seam planner only. It does not
+call RTK, install an RTK binary, rewrite command output, or wire into
+OpenClaw/Hermes/WRE/extension runtime.
 
 ### 4c. Seam interface [SPECIFIED_NOT_IMPLEMENTED]
 
 ```python
-def maybe_compress_command_output(
+def plan_rtk_openclaw_hermes_adapter_dry_run(
     command: str,
-    result: str,
-    bypass_classifier: BypassClassifier,
-    telemetry: TokenTelemetry | None,
-) -> CompressedOutput:
+    command_output: str,
+    candidate_output: str,
+    raw_ref: str,
+) -> RtkOpenClawHermesAdapterDryRunResult:
     """
-    RTK compression seam contract.
+    RTK dry-run seam contract.
     
     Args:
         command: The executed command string
-        result: Raw stdout/stderr from execution
-        bypass_classifier: Determines if result should bypass compression
-        telemetry: Optional telemetry recorder (None = no recording)
+        command_output: Raw stdout/stderr from execution
+        candidate_output: Caller-supplied candidate output
+        raw_ref: Reference to recover original raw output
     
     Returns:
-        CompressedOutput with:
-            - compressed: The (possibly) compressed result
-            - raw_ref: Reference to recover original if needed
-            - bypassed: True if compression was skipped
-            - bypass_reason: Why compression was skipped (if bypassed)
-            - savings_tokens: Estimated token savings (if compressed)
+        RtkOpenClawHermesAdapterDryRunResult with:
+            - dry_run_only: True
+            - output_rewritten: False
+            - raw_output_preserved: True
+            - rtk_invoked: False
+            - telemetry_event_id: in-memory measurement event id, if evaluated
     
     Invariants:
         - If bypass_classifier.should_bypass(result) -> return raw, bypassed=True
@@ -405,9 +409,9 @@ Per 012 adjustment, bypass/security gate comes BEFORE telemetry:
 | P1 | BYPASS_CLASSIFIER_SECURITY_GATE_PHASE1 | BypassClassifier, patterns, tests | This contract |
 | P2 | WSP99_COMPILER_FIDELITY_GATE_PHASE1 | assert_m2m_fidelity(), roundtrip tests | P1 |
 | P3 | TOKEN_EFFICIENCY_TELEMETRY_SERVICE_PHASE1 | TokenTelemetry, schema, storage | P1, P2 |
-| P4 | RTK_EVALUATION_DRY_RUN_PHASE1 | RTK subprocess eval, benchmark | P1, P2, P3 |
-| P5 | RTK_OPENCLAW_HERMES_ADAPTER_DRYRUN_PHASE1 | Seam integration, dry-run | P4 |
-| P6 | REDDOG_COMPUTE_GOVERNOR_PHASE1 | RedDogComputeDecision, routing | P5 |
+| P4 | REDDOG_COMPUTE_GOVERNOR_PHASE1 | RedDogComputeDecision, routing | P1, P2, P3 |
+| P5 | RTK_EVALUATION_DRY_RUN_PHASE1 | Caller-supplied candidate evaluation, dry-run | P4 |
+| P6 | RTK_OPENCLAW_HERMES_ADAPTER_DRYRUN_PHASE1 | Seam planner, dry-run, no rewrite | P5 |
 
 Rationale: Telemetry might record compressed output. If bypass classifier is broken,
 telemetry could record secrets. Therefore bypass MUST be proven before telemetry starts.
@@ -424,15 +428,17 @@ modules/
         __init__.py
         bypass_classifier.py      # P1: Bypass class detection
         m2m_fidelity_gate.py      # P2: Round-trip validation
-        telemetry_recorder.py     # P3: Token savings measurement
-        rtk_adapter.py            # P4: RTK subprocess wrapper
-        compression_seam.py       # P5: OpenClaw/Hermes integration
+        telemetry_service.py      # P3: Token savings measurement
+        compute_governor.py       # P4: Routing decisions
+        rtk_evaluation_dryrun.py  # P5: Caller-supplied candidate evaluation
+        rtk_openclaw_hermes_adapter_dryrun.py # P6: Seam planner, no rewrite
       tests/
         test_bypass_classifier.py
         test_m2m_fidelity.py
-        test_telemetry.py
-        test_rtk_adapter.py       # Dry-run only
-        test_compression_seam.py  # Integration tests
+        test_telemetry_service.py
+        test_compute_governor.py
+        test_rtk_evaluation_dryrun.py
+        test_rtk_openclaw_hermes_adapter_dryrun.py # Seam dry-run tests
       config/
         bypass_patterns.yaml      # Bypass class definitions
       README.md
@@ -454,8 +460,8 @@ These rules are FROZEN by this contract. Violation is a contract breach.
 | ORCH_COMPILES | ORCH (not RedDog, not Worker) compiles M2M | Code review |
 | RTK_OUTPUT_ONLY | RTK only touches post-execution output | Static test |
 | BYPASS_DEFAULT | Security/auth/provenance/signing/permission/receipt bypass by default | Unit tests |
-| NO_RUNTIME_RTK_YET | No RTK runtime integration until P5 | CI gate |
-| NO_COMMAND_REWRITE_YET | No OpenClaw/Hermes command rewrite until P5 | CI gate |
+| NO_RUNTIME_RTK_YET | No RTK runtime integration in P6 | CI gate |
+| NO_COMMAND_REWRITE_YET | No OpenClaw/Hermes command rewrite in P6 | CI gate |
 | NO_DEP_INSTALL | No new dependencies in P1-P3 | requirements.txt diff |
 | NO_EXTERNAL_EXEC | No external command execution except read-only checks | Code review |
 | NO_LIVE_TELEMETRY_YET | No telemetry store until P3 | CI gate |
@@ -492,9 +498,9 @@ def test_wsp99_schema_unchanged():
     assert required_fields.issubset(actual_fields)
 
 def test_no_rtk_binary_present():
-    """RTK binary must not be present until P4."""
+    """RTK binary must not be required by P6 dry-run planning."""
     import shutil
-    assert shutil.which("rtk") is None, "RTK binary found but not allowed until P4"
+    assert shutil.which("rtk") is None, "RTK binary found but P6 does not use it"
 
 def test_no_rtk_dependency():
     """No RTK-related dependencies in requirements."""
@@ -519,8 +525,8 @@ Items defined by this contract but not implemented:
 | M2M round-trip tests | Section 7a | WSP99_COMPILER_FIDELITY_GATE_PHASE1 |
 | TokenCompressionEvent | Section 8a | TOKEN_EFFICIENCY_TELEMETRY_SERVICE_PHASE1 |
 | TokenTelemetry class | Section 8 | TOKEN_EFFICIENCY_TELEMETRY_SERVICE_PHASE1 |
-| RTK subprocess wrapper | Section 4 | RTK_EVALUATION_DRY_RUN_PHASE1 |
-| maybe_compress_command_output() | Section 4c | RTK_OPENCLAW_HERMES_ADAPTER_DRYRUN_PHASE1 |
+| Caller-supplied RTK candidate evaluation | Section 4 | RTK_EVALUATION_DRY_RUN_PHASE1 |
+| plan_rtk_openclaw_hermes_adapter_dry_run() | Section 4c | RTK_OPENCLAW_HERMES_ADAPTER_DRYRUN_PHASE1 |
 | RedDogComputeDecision | Section 2b | REDDOG_COMPUTE_GOVERNOR_PHASE1 |
 | RawRef schema | Section 5c | WSP99_COMPILER_FIDELITY_GATE_PHASE1 |
 

--- a/modules/infrastructure/token_efficiency/INTERFACE.md
+++ b/modules/infrastructure/token_efficiency/INTERFACE.md
@@ -215,9 +215,66 @@ Evaluates a candidate compressed output using:
 Acceptance means the candidate is measurable and safe for dry-run evaluation.
 It is not permission to wire RTK into OpenClaw, Hermes, WRE, or extension runtime.
 
+## Public API (P6: OpenClaw/Hermes RTK Adapter Dry-Run)
+
+P6 models the OpenClaw/Hermes command-output seam. It does not call OpenClaw,
+Hermes, WRE, extension runtime, an RTK binary, or any shell. It always preserves
+raw command output and emits a receipt that says whether a caller-supplied
+candidate passed the P4/P5 dry-run chain.
+
+### Classes
+
+#### `RtkOpenClawHermesAdapterDryRunResult`
+
+```python
+@dataclass
+class RtkOpenClawHermesAdapterDryRunResult:
+    adapter_receipt_id: str
+    decision: RtkAdapterDryRunDecision
+    surface: RtkAdapterSurface | None
+    output_mode: RtkAdapterOutputMode
+    command_digest: str
+    raw_output_digest: str
+    candidate_output_digest: str
+    raw_ref_digest: str
+    compute_decision_id: str | None
+    compute_routing: str | None
+    evaluation_id: str | None
+    evaluation_decision: str | None
+    telemetry_event_id: str | None
+    bytes_saved: int
+    tokens_saved: int
+    savings_ratio: float
+    rejection_reasons: list[str]
+    dry_run_only: bool             # Always True
+    rtk_invoked: bool              # Always False
+    command_executed: bool         # Always False
+    compression_performed: bool    # Always False
+    output_rewritten: bool         # Always False
+    raw_output_preserved: bool     # Always True
+    runtime_reindex_allowed: bool  # Always False
+```
+
+### Functions
+
+#### `plan_rtk_openclaw_hermes_adapter_dry_run(...) -> RtkOpenClawHermesAdapterDryRunResult`
+
+Plans a dry-run seam result using:
+
+- a supported surface: `OPENCLAW` or `HERMES`
+- P4 compute-governor routing over the command and output preview
+- P5 candidate evaluation over caller-supplied raw/candidate output
+- mandatory `raw_ref` recovery path
+- hashes only in the result; raw command/output/candidate/raw_ref are not serialized
+
+Acceptance means the candidate passed the dry-run measurement chain. It still is
+not permission to rewrite command output, invoke RTK, or wire into OpenClaw,
+Hermes, WRE, or extension runtime.
+
 ## Not Implemented (Future Phases)
 
 | Component | Phase | Status |
 |-----------|-------|--------|
-| RTK adapter | P6 | SPECIFIED_NOT_IMPLEMENTED |
-| Compression seam | P6 | SPECIFIED_NOT_IMPLEMENTED |
+| Runtime RTK binary invocation | Future | SPECIFIED_NOT_IMPLEMENTED |
+| OpenClaw/Hermes output rewrite | Future | SPECIFIED_NOT_IMPLEMENTED |
+| Extension/WRE/OpenClaw/Hermes runtime wiring | Future | SPECIFIED_NOT_IMPLEMENTED |

--- a/modules/infrastructure/token_efficiency/README.md
+++ b/modules/infrastructure/token_efficiency/README.md
@@ -1,6 +1,6 @@
 # Token Efficiency Module
 
-**Status**: P5 (RTK Evaluation Dry-Run) ACTIVE
+**Status**: P6 (OpenClaw/Hermes RTK Adapter Dry-Run) ACTIVE
 **Contract**: `docs/contracts/REDDOG_WSP99_RTK_TOKEN_EFFICIENCY_CONTRACT_PHASE1.md`
 **WSP**: WSP_97, WSP_99
 
@@ -12,7 +12,7 @@ Provides token efficiency services for the RedDog/WRE stack:
 - Token savings telemetry (measurement, not claims)
 - Compute governor routing decisions before tool execution
 - RTK evaluation dry-runs over caller-supplied candidate output
-- RTK integration seam (when ready)
+- OpenClaw/Hermes RTK seam dry-runs that never rewrite output
 
 ## Current State (P1)
 
@@ -77,8 +77,8 @@ The classifier always fails closed:
 | P2 | WSP99_COMPILER_FIDELITY_GATE_PHASE1 | LANDED (#943) |
 | P3 | TOKEN_EFFICIENCY_TELEMETRY_SERVICE_PHASE1 | LANDED (#944) |
 | P4 | REDDOG_COMPUTE_GOVERNOR_PHASE1 | LANDED (#946) |
-| P5 | RTK_EVALUATION_DRY_RUN_PHASE1 | ACTIVE |
-| P6 | RTK_OPENCLAW_HERMES_ADAPTER_DRYRUN_PHASE1 | Planned |
+| P5 | RTK_EVALUATION_DRY_RUN_PHASE1 | LANDED (#1006) |
+| P6 | RTK_OPENCLAW_HERMES_ADAPTER_DRYRUN_PHASE1 | ACTIVE |
 
 ## Files
 
@@ -91,6 +91,7 @@ modules/infrastructure/token_efficiency/
     telemetry_service.py      # P3: Token savings measurement
     compute_governor.py       # P4: Routing decisions (not compression authority)
     rtk_evaluation_dryrun.py  # P5: Candidate evaluation, no RTK invocation
+    rtk_openclaw_hermes_adapter_dryrun.py # P6: Seam planner, no rewrite
   tests/
     test_bypass_classifier.py # Unit + adversarial tests
     test_m2m_fidelity.py      # Fidelity + CTX.HOLO tests
@@ -98,6 +99,7 @@ modules/infrastructure/token_efficiency/
     test_telemetry_service.py # Telemetry service tests
     test_compute_governor.py  # Routing + invariant tests
     test_rtk_evaluation_dryrun.py # Dry-run candidate evaluation tests
+    test_rtk_openclaw_hermes_adapter_dryrun.py # Seam dry-run tests
   config/
     bypass_patterns.yaml      # Pattern definitions
   README.md                   # This file
@@ -106,12 +108,16 @@ modules/infrastructure/token_efficiency/
 
 ## No Runtime RTK Yet
 
-This module does NOT include RTK integration. P5 only evaluates caller-supplied
-candidate output and records in-memory telemetry; it does not invoke an RTK
-binary, execute commands, or perform runtime compression. RTK adapter integration
-is planned for P6 after:
+This module does NOT include runtime RTK integration. P6 only plans the
+OpenClaw/Hermes command-output seam over caller-supplied raw output and a
+caller-supplied candidate. It records hashes, dry-run receipts, and in-memory
+telemetry IDs, but it does not invoke an RTK binary, execute commands, rewrite
+OpenClaw/Hermes output, enqueue work, or mutate HoloIndex.
+
+Live RTK integration remains blocked until a future slice proves:
 - Bypass classifier proven (P1)
 - M2M fidelity proven (P2)
 - Telemetry operational (P3)
 - Compute governor wired (P4)
 - RTK evaluation dry-run accepted (P5)
+- OpenClaw/Hermes seam dry-run accepted (P6)

--- a/modules/infrastructure/token_efficiency/src/__init__.py
+++ b/modules/infrastructure/token_efficiency/src/__init__.py
@@ -79,6 +79,15 @@ from .rtk_evaluation_dryrun import (
     evaluate_rtk_candidate_dry_run,
 )
 
+from .rtk_openclaw_hermes_adapter_dryrun import (
+    RtkAdapterDryRunDecision,
+    RtkAdapterDryRunRejection,
+    RtkAdapterOutputMode,
+    RtkAdapterSurface,
+    RtkOpenClawHermesAdapterDryRunResult,
+    plan_rtk_openclaw_hermes_adapter_dry_run,
+)
+
 __all__ = [
     # Bypass classifier (P1)
     "BypassClass",
@@ -139,4 +148,11 @@ __all__ = [
     "RtkDryRunRejection",
     "RtkEvaluationDryRunResult",
     "evaluate_rtk_candidate_dry_run",
+    # OpenClaw/Hermes RTK adapter dry-run (P6)
+    "RtkAdapterDryRunDecision",
+    "RtkAdapterDryRunRejection",
+    "RtkAdapterOutputMode",
+    "RtkAdapterSurface",
+    "RtkOpenClawHermesAdapterDryRunResult",
+    "plan_rtk_openclaw_hermes_adapter_dry_run",
 ]

--- a/modules/infrastructure/token_efficiency/src/rtk_openclaw_hermes_adapter_dryrun.py
+++ b/modules/infrastructure/token_efficiency/src/rtk_openclaw_hermes_adapter_dryrun.py
@@ -1,0 +1,354 @@
+# -*- coding: utf-8 -*-
+"""OpenClaw/Hermes RTK seam dry-run planner.
+
+Slice: RTK_OPENCLAW_HERMES_ADAPTER_DRYRUN_PHASE1
+
+This module models the command-output seam without wiring into OpenClaw,
+Hermes, WRE, extension runtime, or an RTK binary. It evaluates whether a
+caller-supplied candidate could be measured by the token-efficiency stack while
+always preserving the original command output.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping
+
+from .compute_governor import RedDogComputeDecision, Routing, get_compute_governor
+from .rtk_evaluation_dryrun import (
+    RtkDryRunDecision,
+    RtkEvaluationDryRunResult,
+    evaluate_rtk_candidate_dry_run,
+)
+
+
+class RtkAdapterSurface(Enum):
+    """Supported command-output seam sources."""
+
+    OPENCLAW = "OPENCLAW"
+    HERMES = "HERMES"
+
+
+class RtkAdapterDryRunDecision(Enum):
+    """Adapter dry-run decision."""
+
+    ACCEPT = "RTK_ADAPTER_DRY_RUN_ACCEPT"
+    REJECT = "RTK_ADAPTER_DRY_RUN_REJECT"
+
+
+class RtkAdapterDryRunRejection(Enum):
+    """Fail-closed adapter rejection reasons."""
+
+    UNSUPPORTED_SURFACE = "UNSUPPORTED_SURFACE"
+    COMMAND_REQUIRED = "COMMAND_REQUIRED"
+    RAW_REF_REQUIRED = "RAW_REF_REQUIRED"
+    CANDIDATE_OUTPUT_REQUIRED = "CANDIDATE_OUTPUT_REQUIRED"
+    COMPUTE_DECISION_NOT_ALLOW_EVALUATION = "COMPUTE_DECISION_NOT_ALLOW_EVALUATION"
+    RTK_EVALUATION_REJECTED = "RTK_EVALUATION_REJECTED"
+    RUNTIME_REINDEX_FORBIDDEN = "RUNTIME_REINDEX_FORBIDDEN"
+
+
+class RtkAdapterOutputMode(Enum):
+    """Output handling mode for the dry-run seam."""
+
+    RAW_OUTPUT_PRESERVED = "RAW_OUTPUT_PRESERVED"
+    DRY_RUN_CANDIDATE_MEASURED_RAW_OUTPUT_PRESERVED = (
+        "DRY_RUN_CANDIDATE_MEASURED_RAW_OUTPUT_PRESERVED"
+    )
+
+
+@dataclass(frozen=True)
+class RtkOpenClawHermesAdapterDryRunResult:
+    """Dry-run receipt for the OpenClaw/Hermes command-output seam."""
+
+    adapter_receipt_id: str
+    decision: RtkAdapterDryRunDecision
+    surface: RtkAdapterSurface | None
+    output_mode: RtkAdapterOutputMode
+    command_digest: str
+    raw_output_digest: str
+    candidate_output_digest: str
+    raw_ref_digest: str
+    compute_decision_id: str | None
+    compute_routing: str | None
+    evaluation_id: str | None
+    evaluation_decision: str | None
+    telemetry_event_id: str | None
+    bytes_saved: int
+    tokens_saved: int
+    savings_ratio: float
+    rejection_reasons: list[str]
+    dry_run_only: bool = True
+    rtk_invoked: bool = False
+    command_executed: bool = False
+    compression_performed: bool = False
+    output_rewritten: bool = False
+    raw_output_preserved: bool = True
+    openclaw_wired: bool = False
+    hermes_wired: bool = False
+    wre_wired: bool = False
+    extension_wired: bool = False
+    runtime_reindex_allowed: bool = False
+    telemetry_in_memory_only: bool = True
+    raw_content_persisted: bool = False
+
+    @property
+    def accepted(self) -> bool:
+        return self.decision == RtkAdapterDryRunDecision.ACCEPT
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize without raw command, output, candidate, or raw_ref content."""
+
+        return {
+            "adapter_receipt_id": self.adapter_receipt_id,
+            "decision": self.decision.value,
+            "surface": self.surface.value if self.surface else None,
+            "output_mode": self.output_mode.value,
+            "command_digest": self.command_digest,
+            "raw_output_digest": self.raw_output_digest,
+            "candidate_output_digest": self.candidate_output_digest,
+            "raw_ref_digest": self.raw_ref_digest,
+            "compute_decision_id": self.compute_decision_id,
+            "compute_routing": self.compute_routing,
+            "evaluation_id": self.evaluation_id,
+            "evaluation_decision": self.evaluation_decision,
+            "telemetry_event_id": self.telemetry_event_id,
+            "bytes_saved": self.bytes_saved,
+            "tokens_saved": self.tokens_saved,
+            "savings_ratio": self.savings_ratio,
+            "rejection_reasons": list(self.rejection_reasons),
+            "dry_run_only": self.dry_run_only,
+            "rtk_invoked": self.rtk_invoked,
+            "command_executed": self.command_executed,
+            "compression_performed": self.compression_performed,
+            "output_rewritten": self.output_rewritten,
+            "raw_output_preserved": self.raw_output_preserved,
+            "openclaw_wired": self.openclaw_wired,
+            "hermes_wired": self.hermes_wired,
+            "wre_wired": self.wre_wired,
+            "extension_wired": self.extension_wired,
+            "runtime_reindex_allowed": self.runtime_reindex_allowed,
+            "telemetry_in_memory_only": self.telemetry_in_memory_only,
+            "raw_content_persisted": self.raw_content_persisted,
+        }
+
+    def to_m2m_compact(self) -> str:
+        status = "ACCEPT" if self.accepted else "REJECT"
+        surface = self.surface.value if self.surface else "unsupported"
+        return (
+            f"RTK_SEAM:{self.adapter_receipt_id[:8]} "
+            f"SURFACE:{surface} "
+            f"STATUS:{status} "
+            f"MODE:{self.output_mode.value} "
+            f"REWRITE:{str(self.output_rewritten).lower()}"
+        )
+
+    def to_m2m_yaml(self) -> str:
+        surface = self.surface.value if self.surface else None
+        return "\n".join(
+            [
+                "RTK_OPENCLAW_HERMES_ADAPTER_DRY_RUN:",
+                f"  adapter_receipt_id: {self.adapter_receipt_id}",
+                f"  decision: {self.decision.value}",
+                f"  surface: {surface}",
+                f"  output_mode: {self.output_mode.value}",
+                f"  compute_decision_id: {self.compute_decision_id}",
+                f"  compute_routing: {self.compute_routing}",
+                f"  evaluation_id: {self.evaluation_id}",
+                f"  evaluation_decision: {self.evaluation_decision}",
+                f"  telemetry_event_id: {self.telemetry_event_id}",
+                "  metrics:",
+                f"    bytes_saved: {self.bytes_saved}",
+                f"    tokens_saved: {self.tokens_saved}",
+                f"    savings_ratio: {self.savings_ratio:.4f}",
+                "  invariants:",
+                f"    dry_run_only: {self.dry_run_only}",
+                f"    rtk_invoked: {self.rtk_invoked}",
+                f"    command_executed: {self.command_executed}",
+                f"    compression_performed: {self.compression_performed}",
+                f"    output_rewritten: {self.output_rewritten}",
+                f"    raw_output_preserved: {self.raw_output_preserved}",
+                f"    runtime_reindex_allowed: {self.runtime_reindex_allowed}",
+                f"    raw_content_persisted: {self.raw_content_persisted}",
+                f"  rejection_reasons: {self.rejection_reasons}",
+            ]
+        )
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _normalize_surface(surface: RtkAdapterSurface | str) -> RtkAdapterSurface | None:
+    if isinstance(surface, RtkAdapterSurface):
+        return surface
+    normalized = str(surface or "").strip().upper()
+    for candidate in RtkAdapterSurface:
+        if normalized == candidate.value:
+            return candidate
+    return None
+
+
+def _routing_value(decision: RedDogComputeDecision | Mapping[str, Any]) -> str | None:
+    routing = decision.routing if isinstance(decision, RedDogComputeDecision) else decision.get("routing")
+    if isinstance(routing, Routing):
+        return routing.value
+    return str(routing) if routing is not None else None
+
+
+def _decision_id(decision: RedDogComputeDecision | Mapping[str, Any]) -> str | None:
+    if isinstance(decision, RedDogComputeDecision):
+        return decision.decision_id
+    value = decision.get("decision_id")
+    return str(value) if value is not None else None
+
+
+def _runtime_reindex_allowed(decision: RedDogComputeDecision | Mapping[str, Any]) -> bool:
+    if isinstance(decision, RedDogComputeDecision):
+        return decision.runtime_reindex_allowed
+    return bool(decision.get("runtime_reindex_allowed"))
+
+
+def _build_receipt_id(
+    *,
+    surface: RtkAdapterSurface | None,
+    command_digest: str,
+    raw_output_digest: str,
+    candidate_output_digest: str,
+    raw_ref_digest: str,
+    compute_decision_id: str | None,
+    evaluation_id: str | None,
+    rejection_reasons: list[str],
+) -> str:
+    payload = {
+        "candidate_output_digest": candidate_output_digest,
+        "command_digest": command_digest,
+        "compute_decision_id": compute_decision_id,
+        "evaluation_id": evaluation_id,
+        "raw_output_digest": raw_output_digest,
+        "raw_ref_digest": raw_ref_digest,
+        "rejection_reasons": rejection_reasons,
+        "surface": surface.value if surface else None,
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:32]
+
+
+def plan_rtk_openclaw_hermes_adapter_dry_run(
+    *,
+    surface: RtkAdapterSurface | str,
+    command: str,
+    command_output: str,
+    candidate_output: str,
+    raw_ref: str,
+    compute_decision: RedDogComputeDecision | Mapping[str, Any] | None = None,
+    ctx_holo_present: bool = False,
+    index_gap_detected: bool = False,
+    record_telemetry: bool = True,
+) -> RtkOpenClawHermesAdapterDryRunResult:
+    """Plan a dry-run RTK seam result without rewriting command output."""
+
+    normalized_surface = _normalize_surface(surface)
+    command_digest = _sha256(command)
+    raw_output_digest = _sha256(command_output)
+    candidate_output_digest = _sha256(candidate_output)
+    raw_ref_digest = _sha256(raw_ref)
+    reasons: list[str] = []
+    evaluation: RtkEvaluationDryRunResult | None = None
+
+    if normalized_surface is None:
+        reasons.append(RtkAdapterDryRunRejection.UNSUPPORTED_SURFACE.value)
+    if not command:
+        reasons.append(RtkAdapterDryRunRejection.COMMAND_REQUIRED.value)
+    if not raw_ref:
+        reasons.append(RtkAdapterDryRunRejection.RAW_REF_REQUIRED.value)
+    if not candidate_output:
+        reasons.append(RtkAdapterDryRunRejection.CANDIDATE_OUTPUT_REQUIRED.value)
+
+    decision = compute_decision
+    if decision is None and normalized_surface is not None and command:
+        decision = get_compute_governor().get_routing_recommendation(
+            command=command,
+            output_preview=command_output,
+            ctx_holo_present=ctx_holo_present,
+            index_gap_detected=index_gap_detected,
+        )
+
+    compute_id = _decision_id(decision) if decision is not None else None
+    compute_routing = _routing_value(decision) if decision is not None else None
+    if decision is not None:
+        if compute_routing != Routing.ALLOW_EVALUATION_DRY_RUN.value:
+            reasons.append(
+                RtkAdapterDryRunRejection.COMPUTE_DECISION_NOT_ALLOW_EVALUATION.value
+            )
+        if _runtime_reindex_allowed(decision):
+            reasons.append(RtkAdapterDryRunRejection.RUNTIME_REINDEX_FORBIDDEN.value)
+
+    if normalized_surface is not None and decision is not None:
+        evaluation = evaluate_rtk_candidate_dry_run(
+            command=command,
+            raw_output=command_output,
+            candidate_output=candidate_output,
+            raw_ref=raw_ref,
+            compute_decision=decision,
+            record_telemetry=record_telemetry,
+        )
+        if evaluation.decision != RtkDryRunDecision.ACCEPT:
+            reasons.append(RtkAdapterDryRunRejection.RTK_EVALUATION_REJECTED.value)
+            reasons.extend(evaluation.rejection_reasons)
+
+    # Preserve first-seen order while removing duplicate reasons.
+    rejection_reasons = list(dict.fromkeys(reasons))
+    accepted = not rejection_reasons
+    output_mode = (
+        RtkAdapterOutputMode.DRY_RUN_CANDIDATE_MEASURED_RAW_OUTPUT_PRESERVED
+        if accepted
+        else RtkAdapterOutputMode.RAW_OUTPUT_PRESERVED
+    )
+    adapter_receipt_id = _build_receipt_id(
+        surface=normalized_surface,
+        command_digest=command_digest,
+        raw_output_digest=raw_output_digest,
+        candidate_output_digest=candidate_output_digest,
+        raw_ref_digest=raw_ref_digest,
+        compute_decision_id=compute_id,
+        evaluation_id=evaluation.evaluation_id if evaluation else None,
+        rejection_reasons=rejection_reasons,
+    )
+    return RtkOpenClawHermesAdapterDryRunResult(
+        adapter_receipt_id=adapter_receipt_id,
+        decision=(
+            RtkAdapterDryRunDecision.ACCEPT
+            if accepted
+            else RtkAdapterDryRunDecision.REJECT
+        ),
+        surface=normalized_surface,
+        output_mode=output_mode,
+        command_digest=command_digest,
+        raw_output_digest=raw_output_digest,
+        candidate_output_digest=candidate_output_digest,
+        raw_ref_digest=raw_ref_digest,
+        compute_decision_id=compute_id,
+        compute_routing=compute_routing,
+        evaluation_id=evaluation.evaluation_id if evaluation else None,
+        evaluation_decision=evaluation.decision.value if evaluation else None,
+        telemetry_event_id=evaluation.telemetry_event_id if evaluation else None,
+        bytes_saved=evaluation.bytes_saved if evaluation and accepted else 0,
+        tokens_saved=evaluation.tokens_saved if evaluation and accepted else 0,
+        savings_ratio=evaluation.savings_ratio if evaluation and accepted else 0.0,
+        rejection_reasons=rejection_reasons,
+    )
+
+
+__all__ = [
+    "RtkAdapterDryRunDecision",
+    "RtkAdapterDryRunRejection",
+    "RtkAdapterOutputMode",
+    "RtkAdapterSurface",
+    "RtkOpenClawHermesAdapterDryRunResult",
+    "plan_rtk_openclaw_hermes_adapter_dry_run",
+]

--- a/modules/infrastructure/token_efficiency/tests/test_rtk_openclaw_hermes_adapter_dryrun.py
+++ b/modules/infrastructure/token_efficiency/tests/test_rtk_openclaw_hermes_adapter_dryrun.py
@@ -1,0 +1,322 @@
+# -*- coding: utf-8 -*-
+"""Tests for RTK_OPENCLAW_HERMES_ADAPTER_DRYRUN_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.infrastructure.token_efficiency.src.compute_governor import (
+    Routing,
+    get_compute_governor,
+    reset_compute_governor,
+)
+from modules.infrastructure.token_efficiency.src.rtk_openclaw_hermes_adapter_dryrun import (
+    RtkAdapterDryRunDecision,
+    RtkAdapterDryRunRejection,
+    RtkAdapterOutputMode,
+    RtkAdapterSurface,
+    plan_rtk_openclaw_hermes_adapter_dry_run,
+)
+from modules.infrastructure.token_efficiency.src.telemetry_service import (
+    SourceLayer,
+    get_telemetry_store,
+    reset_telemetry_store,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "infrastructure"
+    / "token_efficiency"
+    / "src"
+    / "rtk_openclaw_hermes_adapter_dryrun.py"
+)
+
+
+def setup_function() -> None:
+    reset_compute_governor()
+    reset_telemetry_store()
+
+
+def _raw_output() -> str:
+    return "\n".join(f"module_{idx}.py" for idx in range(100))
+
+
+def test_accepts_openclaw_candidate_without_rewriting_output() -> None:
+    result = plan_rtk_openclaw_hermes_adapter_dry_run(
+        surface=RtkAdapterSurface.OPENCLAW,
+        command="ls -la",
+        command_output=_raw_output(),
+        candidate_output="100 python modules",
+        raw_ref="raw_ref:openclaw-output:sha256",
+        ctx_holo_present=True,
+    )
+
+    assert result.accepted is True
+    assert result.decision == RtkAdapterDryRunDecision.ACCEPT
+    assert result.surface == RtkAdapterSurface.OPENCLAW
+    assert result.output_mode == (
+        RtkAdapterOutputMode.DRY_RUN_CANDIDATE_MEASURED_RAW_OUTPUT_PRESERVED
+    )
+    assert result.compute_routing == Routing.ALLOW_EVALUATION_DRY_RUN.value
+    assert result.evaluation_decision is not None
+    assert result.bytes_saved > 0
+    assert result.tokens_saved > 0
+    assert result.output_rewritten is False
+    assert result.raw_output_preserved is True
+    assert result.openclaw_wired is False
+    assert result.command_executed is False
+    assert result.rtk_invoked is False
+
+    events = get_telemetry_store().get_all()
+    assert len(events) == 1
+    assert events[0].source_layer == SourceLayer.RTK_EVALUATION
+
+
+def test_accepts_hermes_candidate_without_hermes_wiring() -> None:
+    result = plan_rtk_openclaw_hermes_adapter_dry_run(
+        surface="hermes",
+        command="echo scaffold",
+        command_output="scaffold line\n" * 50,
+        candidate_output="scaffold repeated 50 times",
+        raw_ref="raw_ref:hermes-output:sha256",
+    )
+
+    assert result.accepted is True
+    assert result.surface == RtkAdapterSurface.HERMES
+    assert result.hermes_wired is False
+    assert result.wre_wired is False
+    assert result.extension_wired is False
+
+
+def test_rejects_unsupported_surface_before_telemetry() -> None:
+    result = plan_rtk_openclaw_hermes_adapter_dry_run(
+        surface="WRE_LIVE",
+        command="ls -la",
+        command_output=_raw_output(),
+        candidate_output="100 files",
+        raw_ref="raw_ref:wre-output",
+    )
+
+    assert result.accepted is False
+    assert result.surface is None
+    assert RtkAdapterDryRunRejection.UNSUPPORTED_SURFACE.value in result.rejection_reasons
+    assert result.output_mode == RtkAdapterOutputMode.RAW_OUTPUT_PRESERVED
+    assert get_telemetry_store().count() == 0
+
+
+def test_rejects_missing_raw_ref() -> None:
+    result = plan_rtk_openclaw_hermes_adapter_dry_run(
+        surface=RtkAdapterSurface.OPENCLAW,
+        command="ls -la",
+        command_output=_raw_output(),
+        candidate_output="100 files",
+        raw_ref="",
+    )
+
+    assert result.accepted is False
+    assert RtkAdapterDryRunRejection.RAW_REF_REQUIRED.value in result.rejection_reasons
+    assert RtkAdapterDryRunRejection.RTK_EVALUATION_REJECTED.value in result.rejection_reasons
+
+
+def test_rejects_empty_candidate_output() -> None:
+    result = plan_rtk_openclaw_hermes_adapter_dry_run(
+        surface=RtkAdapterSurface.OPENCLAW,
+        command="ls -la",
+        command_output=_raw_output(),
+        candidate_output="",
+        raw_ref="raw_ref:empty-candidate",
+    )
+
+    assert result.accepted is False
+    assert (
+        RtkAdapterDryRunRejection.CANDIDATE_OUTPUT_REQUIRED.value
+        in result.rejection_reasons
+    )
+
+
+def test_rejects_sensitive_raw_output_via_governor_and_evaluator() -> None:
+    result = plan_rtk_openclaw_hermes_adapter_dry_run(
+        surface=RtkAdapterSurface.OPENCLAW,
+        command="cat .env",
+        command_output="token=sk-secret123456789",
+        candidate_output="environment variables summary",
+        raw_ref="raw_ref:env",
+    )
+
+    assert result.accepted is False
+    assert (
+        RtkAdapterDryRunRejection.COMPUTE_DECISION_NOT_ALLOW_EVALUATION.value
+        in result.rejection_reasons
+    )
+    assert RtkAdapterDryRunRejection.RTK_EVALUATION_REJECTED.value in result.rejection_reasons
+    assert result.bytes_saved == 0
+    assert result.output_rewritten is False
+
+
+def test_rejects_security_command_even_with_short_candidate() -> None:
+    result = plan_rtk_openclaw_hermes_adapter_dry_run(
+        surface=RtkAdapterSurface.HERMES,
+        command="npm audit",
+        command_output="0 vulnerabilities",
+        candidate_output="clean",
+        raw_ref="raw_ref:npm-audit",
+    )
+
+    assert result.accepted is False
+    assert result.compute_routing == Routing.BYPASS_REQUIRED.value
+    assert (
+        RtkAdapterDryRunRejection.COMPUTE_DECISION_NOT_ALLOW_EVALUATION.value
+        in result.rejection_reasons
+    )
+
+
+def test_rejects_no_positive_savings_from_p5_evaluator() -> None:
+    result = plan_rtk_openclaw_hermes_adapter_dry_run(
+        surface=RtkAdapterSurface.OPENCLAW,
+        command="ls -la",
+        command_output="tiny",
+        candidate_output="longer than tiny",
+        raw_ref="raw_ref:tiny",
+    )
+
+    assert result.accepted is False
+    assert RtkAdapterDryRunRejection.RTK_EVALUATION_REJECTED.value in result.rejection_reasons
+    assert "NO_POSITIVE_SAVINGS" in result.rejection_reasons
+
+
+def test_rejects_injected_compute_decision_with_runtime_reindex_enabled() -> None:
+    decision = get_compute_governor().get_routing_recommendation(
+        command="ls -la",
+        output_preview=_raw_output(),
+    ).to_dict()
+    decision["runtime_reindex_allowed"] = True
+
+    result = plan_rtk_openclaw_hermes_adapter_dry_run(
+        surface=RtkAdapterSurface.OPENCLAW,
+        command="ls -la",
+        command_output=_raw_output(),
+        candidate_output="100 files",
+        raw_ref="raw_ref:reindex",
+        compute_decision=decision,
+    )
+
+    assert result.accepted is False
+    assert RtkAdapterDryRunRejection.RUNTIME_REINDEX_FORBIDDEN.value in result.rejection_reasons
+
+
+def test_result_does_not_serialize_raw_command_output_candidate_or_raw_ref() -> None:
+    result = plan_rtk_openclaw_hermes_adapter_dry_run(
+        surface=RtkAdapterSurface.OPENCLAW,
+        command="echo secret phrase",
+        command_output="raw command output unique phrase",
+        candidate_output="candidate unique phrase",
+        raw_ref="raw_ref:unique-secret-reference",
+    )
+
+    encoded = json.dumps(result.to_dict(), sort_keys=True)
+    assert "echo secret phrase" not in encoded
+    assert "raw command output unique phrase" not in encoded
+    assert "candidate unique phrase" not in encoded
+    assert "raw_ref:unique-secret-reference" not in encoded
+
+
+def test_receipt_id_deterministic_for_same_inputs() -> None:
+    first = plan_rtk_openclaw_hermes_adapter_dry_run(
+        surface=RtkAdapterSurface.OPENCLAW,
+        command="ls -la",
+        command_output=_raw_output(),
+        candidate_output="100 files",
+        raw_ref="raw_ref:deterministic",
+    )
+    second = plan_rtk_openclaw_hermes_adapter_dry_run(
+        surface=RtkAdapterSurface.OPENCLAW,
+        command="ls -la",
+        command_output=_raw_output(),
+        candidate_output="100 files",
+        raw_ref="raw_ref:deterministic",
+    )
+
+    assert first.adapter_receipt_id == second.adapter_receipt_id
+    assert first.command_digest == second.command_digest
+    assert first.raw_output_digest == second.raw_output_digest
+
+
+def test_m2m_outputs_preserve_dry_run_invariants() -> None:
+    result = plan_rtk_openclaw_hermes_adapter_dry_run(
+        surface=RtkAdapterSurface.OPENCLAW,
+        command="ls -la",
+        command_output=_raw_output(),
+        candidate_output="100 files",
+        raw_ref="raw_ref:m2m",
+    )
+
+    compact = result.to_m2m_compact()
+    yaml_text = result.to_m2m_yaml()
+    assert "RTK_SEAM" in compact
+    assert "REWRITE:false" in compact
+    assert "RTK_OPENCLAW_HERMES_ADAPTER_DRY_RUN:" in yaml_text
+    assert "output_rewritten: False" in yaml_text
+    assert "raw_output_preserved: True" in yaml_text
+
+
+def test_to_dict_is_json_serializable() -> None:
+    result = plan_rtk_openclaw_hermes_adapter_dry_run(
+        surface=RtkAdapterSurface.HERMES,
+        command="echo hello",
+        command_output="hello\n" * 20,
+        candidate_output="hello repeated",
+        raw_ref="raw_ref:json",
+    )
+
+    encoded = json.dumps(result.to_dict(), sort_keys=True)
+    assert result.adapter_receipt_id in encoded
+
+
+def test_ast_boundary_no_runtime_execution_live_wiring_or_holoindex_mutation() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    forbidden_imports = {
+        "subprocess",
+        "os",
+        "socket",
+        "requests",
+        "httpx",
+        "sqlite3",
+        "holo_index",
+        "agent_db",
+        "openclaw_supervisor",
+        "hermes_job_executor",
+        "wre_core",
+    }
+    forbidden_calls = {
+        "Popen",
+        "system",
+        "popen",
+        "open",
+        "index_all",
+        "index_code",
+        "index_docs",
+        "execute",
+        "create_autonomous_task",
+        "enqueue",
+    }
+    imports = set()
+    calls = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                calls.add(node.func.id)
+            elif isinstance(node.func, ast.Attribute):
+                calls.add(node.func.attr)
+
+    assert imports.isdisjoint(forbidden_imports)
+    assert all(not item.startswith("rtk.") for item in imports)
+    assert "rtk" not in imports
+    assert calls.isdisjoint(forbidden_calls)

--- a/tests/contracts/test_token_efficiency_contract.py
+++ b/tests/contracts/test_token_efficiency_contract.py
@@ -250,7 +250,7 @@ class TestContractAsciiClean:
         content = contract_path.read_text(encoding="utf-8")
         # Check for problematic non-ASCII that shouldn't be in technical specs
         # Allow common ones like em-dash in prose but flag encoding errors
-        forbidden = ["�", "\x00"]  # Replacement char, null
+        forbidden = ["\ufffd", "\x00"]  # Replacement char, null
         for char in forbidden:
             assert char not in content, f"Forbidden character {repr(char)} in contract"
 
@@ -261,22 +261,38 @@ class TestContractAsciiClean:
 class TestModulePlacement:
     """Verify module placement follows contract (Section 10)."""
 
-    def test_token_efficiency_module_not_premature(self):
-        """token_efficiency module must not exist until P1 implementation."""
+    def test_token_efficiency_module_boundary(self):
+        """Implemented token_efficiency modules must not cross runtime boundaries."""
         module_path = Path("modules/infrastructure/token_efficiency")
-        # Module should NOT exist yet - this is contract phase
-        # When P1 starts, this test will be updated
-        if module_path.exists():
-            # If it exists, verify it's just stubs
-            src_path = module_path / "src"
-            if src_path.exists():
-                py_files = list(src_path.glob("*.py"))
-                for py_file in py_files:
-                    if py_file.name != "__init__.py":
-                        content = py_file.read_text(encoding="utf-8")
-                        assert "SPECIFIED_NOT_IMPLEMENTED" in content or "pass" in content, (
-                            f"Premature implementation in {py_file}"
-                        )
+        src_path = module_path / "src"
+        assert src_path.exists(), "token_efficiency src directory missing after P1-P6"
+
+        forbidden_import_text = [
+            "import subprocess",
+            "from subprocess",
+            "import requests",
+            "import httpx",
+            "import socket",
+            "import rtk",
+            "from rtk",
+            "import holo_index",
+            "from holo_index",
+        ]
+        forbidden_runtime_text = [
+            "Popen(",
+            "os.system(",
+            "os.popen(",
+            "--index-all",
+            "--index-code",
+            "--index-docs",
+            "create_autonomous_task(",
+        ]
+        for py_file in src_path.glob("*.py"):
+            content = py_file.read_text(encoding="utf-8")
+            for forbidden in forbidden_import_text + forbidden_runtime_text:
+                assert forbidden not in content, (
+                    f"Token-efficiency boundary violation in {py_file}: {forbidden}"
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements RTK_OPENCLAW_HERMES_ADAPTER_DRYRUN_PHASE1 as a dry-run command-output seam planner for OpenClaw/Hermes surfaces.

This slice composes the landed token-efficiency stack:

- P4 RedDogComputeDecision / compute governor
- P5 evaluate_rtk_candidate_dry_run()
- P3 in-memory telemetry
- P1 bypass classifier

It does not invoke RTK, execute commands, rewrite command output, enqueue work, wire OpenClaw/Hermes/WRE/extension runtime, or mutate HoloIndex.

## Files changed

- modules/infrastructure/token_efficiency/src/rtk_openclaw_hermes_adapter_dryrun.py
- modules/infrastructure/token_efficiency/tests/test_rtk_openclaw_hermes_adapter_dryrun.py
- modules/infrastructure/token_efficiency/src/__init__.py
- modules/infrastructure/token_efficiency/README.md
- modules/infrastructure/token_efficiency/INTERFACE.md
- docs/contracts/REDDOG_WSP99_RTK_TOKEN_EFFICIENCY_CONTRACT_PHASE1.md
- tests/contracts/test_token_efficiency_contract.py

## Behavior

plan_rtk_openclaw_hermes_adapter_dry_run() accepts a supported surface (OPENCLAW or HERMES), command, raw command output, caller-supplied candidate output, and raw_ref. It returns a deterministic receipt with digests, compute decision ID/routing, P5 evaluation ID, telemetry event ID, metrics, rejection reasons, and hard invariants:

- dry_run_only: true
- rtk_invoked: false
- command_executed: false
- compression_performed: false
- output_rewritten: false
- raw_output_preserved: true
- runtime_reindex_allowed: false
- raw_content_persisted: false

## Validation

pytest modules/infrastructure/token_efficiency/tests/ tests/contracts/test_token_efficiency_contract.py -q
251 passed in 0.75s

python -m py_compile modules/infrastructure/token_efficiency/src/rtk_openclaw_hermes_adapter_dryrun.py modules/infrastructure/token_efficiency/tests/test_rtk_openclaw_hermes_adapter_dryrun.py tests/contracts/test_token_efficiency_contract.py
PASS

git diff --check
PASS (CRLF warnings only)

byte scan touched files
0 non-ASCII / 0 NUL

## HoloIndex

Read-only probe:

python holo_index.py --search "RTK OpenClaw Hermes adapter dry-run seam planner" --limit 5

Result: HoloIndex returned adjacent RedDog/OpenClaw docs and modules, but did not surface the new P6 module before indexing.

Recorded INDEX_GAP: HOLOINDEX_RTK_OPENCLAW_HERMES_ADAPTER_DRYRUN_INDEX_GAP_PHASE1.

No runtime re-index was performed. Re-index remains WRE/CI/operator-owned, never RedDog runtime.

## Truth boundary

- NO_RTK_BINARY: pass
- NO_RTK_INVOCATION: pass
- NO_COMMAND_EXECUTION: pass
- NO_OUTPUT_REWRITE: pass
- NO_OPENCLAW_HERMES_WRE_WIRING: pass
- NO_EXTENSION_RUNTIME_CHANGE: pass
- NO_HOLOINDEX_MUTATION: pass
- IN_MEMORY_TELEMETRY_ONLY: pass

## Residual SPECIFIED_NOT_IMPLEMENTED

- Runtime RTK binary integration
- Actual OpenClaw/Hermes output rewrite
- WRE/OpenClaw/Hermes/extension runtime wiring
- HoloIndex re-index for this new module
