### PR TITLE
feat(reddog): add operational context snapshot runtime

### DIFF
--- a/main.py
+++ b/main.py
@@ -118,6 +118,7 @@ if sys.platform.startswith('win'):
 
 # Initialize logger at module level for all functions to use
 # CRITICAL: Log to logs/foundups_agent.log for AI_overseer heartbeat monitoring
+Path("logs").mkdir(exist_ok=True)
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
@@ -898,7 +899,7 @@ def run_connect_wre(repo_root: Path) -> dict:
         in_watch = monitor.is_in_watch_period()
 
         manual_enforced = os.getenv("WRE_DASHBOARD_PREFLIGHT_ENFORCED", "0") != "0"
-        auto_enforce = os.getenv("WRE_DASHBOARD_AUTO_ENFORCE", "1") != "0"
+        auto_enforce = _wre_dashboard_auto_enforce_enabled()
         auto_enforced_now = bool(auto_enforce and not in_watch and not insufficient_data)
 
         alerts = health.get("alerts", []) if isinstance(health.get("alerts"), list) else []
@@ -932,12 +933,25 @@ def run_connect_wre(repo_root: Path) -> dict:
     return result
 
 
+def _wre_dashboard_auto_enforce_enabled() -> bool:
+    """Default dashboard auto-enforcement to autonomous runtimes, not menu startup."""
+
+    default = "1" if os.getenv("OPENCLAW_24X7", "0") != "0" else "0"
+    return os.getenv("WRE_DASHBOARD_AUTO_ENFORCE", default) != "0"
+
+
 def run_wre_dashboard_preflight(repo_root: Path) -> bool:
     """
     Run WRE dashboard preflight at startup.
 
     This mirrors DAE-level enforcement logic so `python main.py` has the same
     health gate semantics as individual DAE launchers.
+
+    Env controls:
+      WRE_DASHBOARD_PREFLIGHT=1             Enable startup warning checks
+      WRE_DASHBOARD_PREFLIGHT_ENFORCED=0    Manual override to block startup
+      WRE_DASHBOARD_AUTO_ENFORCE            Default follows OPENCLAW_24X7
+      OPENCLAW_24X7=1                       Autonomous runtime defaults to enforced
     """
     enabled = os.getenv("WRE_DASHBOARD_PREFLIGHT", "1") != "0"
     if not enabled:
@@ -945,7 +959,7 @@ def run_wre_dashboard_preflight(repo_root: Path) -> bool:
         return True
 
     manual_enforced = os.getenv("WRE_DASHBOARD_PREFLIGHT_ENFORCED", "0") != "0"
-    auto_enforce = os.getenv("WRE_DASHBOARD_AUTO_ENFORCE", "1") != "0"
+    auto_enforce = _wre_dashboard_auto_enforce_enabled()
 
     try:
         from modules.infrastructure.wre_core.src.dashboard_alerts import (

--- a/modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py
+++ b/modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py
@@ -259,6 +259,78 @@ def test_main_py_wre_dashboard_insufficient_data_calls_dispatcher():
     assert call_kwargs["payload"]["automation_candidate"] is True
 
 
+def test_main_py_wre_dashboard_critical_alert_warns_by_default_for_menu_startup():
+    """Interactive menu startup should keep dashboard signal but not auto-block by default."""
+    import main
+
+    fake_health = {
+        "insufficient_data": False,
+        "total_executions": 36,
+        "min_samples": 25,
+        "healthy": False,
+        "alerts": [{"severity": "critical", "message": "critical sample"}],
+    }
+    with patch(
+        "modules.infrastructure.wre_core.src.dashboard_alerts.check_dashboard_health",
+        return_value=fake_health,
+    ):
+        with patch(
+            "modules.infrastructure.wre_core.src.dashboard_alerts.DashboardAlertMonitor"
+        ) as mock_monitor:
+            mock_monitor.return_value.is_in_watch_period.return_value = False
+            with patch("builtins.print") as mock_print:
+                with patch.dict(
+                    "os.environ",
+                    {
+                        "WRE_DASHBOARD_PREFLIGHT": "1",
+                        "OPENCLAW_24X7": "0",
+                    },
+                    clear=True,
+                ):
+                    result = main.run_wre_dashboard_preflight(Path("."))
+
+    assert result is True
+    printed = "\n".join(str(call.args[0]) for call in mock_print.call_args_list)
+    assert "preflight=FAIL (STABLE)" in printed
+    assert "Startup blocked" not in printed
+
+
+def test_main_py_wre_dashboard_critical_alert_blocks_for_24x7_runtime():
+    """Autonomous 24x7 runtime preserves the fail-closed dashboard gate."""
+    import main
+
+    fake_health = {
+        "insufficient_data": False,
+        "total_executions": 36,
+        "min_samples": 25,
+        "healthy": False,
+        "alerts": [{"severity": "critical", "message": "critical sample"}],
+    }
+    with patch(
+        "modules.infrastructure.wre_core.src.dashboard_alerts.check_dashboard_health",
+        return_value=fake_health,
+    ):
+        with patch(
+            "modules.infrastructure.wre_core.src.dashboard_alerts.DashboardAlertMonitor"
+        ) as mock_monitor:
+            mock_monitor.return_value.is_in_watch_period.return_value = False
+            with patch("builtins.print") as mock_print:
+                with patch.dict(
+                    "os.environ",
+                    {
+                        "WRE_DASHBOARD_PREFLIGHT": "1",
+                        "OPENCLAW_24X7": "1",
+                    },
+                    clear=True,
+                ):
+                    result = main.run_wre_dashboard_preflight(Path("."))
+
+    assert result is False
+    printed = "\n".join(str(call.args[0]) for call in mock_print.call_args_list)
+    assert "preflight=FAIL (STABLE, ENFORCED)" in printed
+    assert "Startup blocked by AUTO enforcement" in printed
+
+
 # === DJ2-C OAuth preflight dispatch tests ===
 
 
@@ -273,7 +345,7 @@ def test_main_py_oauth_no_healthy_tokens_calls_dispatcher():
         fake_oauth_status = {
             "healthy": [],  # No healthy tokens
             "reauth_needed": False,  # Set False to skip interactive input prompt
-            "expired": ["set1", "set2"],
+            "expired": [1, 10],
         }
         with patch(
             "modules.platform_integration.youtube_auth.src.youtube_auth.preflight_oauth_check",
@@ -369,7 +441,7 @@ def test_main_py_oauth_healthy_does_not_dispatch():
         "modules.ai_intelligence.ai_overseer.src.preflight_resolution.on_preflight_fail"
     ) as mock_dispatch:
         fake_oauth_status = {
-            "healthy": ["set1", "set10"],  # Healthy tokens
+            "healthy": [1, 10],  # Healthy tokens
             "reauth_needed": False,
             "expired": [],
         }

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,31 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_OPERATIONAL_CONTEXT_SNAPSHOT_RUNTIME_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_operational_context_snapshot.py`: read-only runtime
+  snapshot builder for repo HEAD, authoritative work state, HoloIndex freshness
+  receipts, scoped breadcrumbs, Brain artifact metadata, and workspace memory
+  metadata.
+- Added `tests/test_reddog_operational_context_snapshot.py`: source receipt
+  schema checks, HoloIndex stale/missing fail-closed behavior, optional Brain
+  absence handling, bootstrap/Brain conflict recording without override,
+  context-view redaction, evidence-bundle derivation, assignment invalidation,
+  existing work-state file loading, repo observation, and AST no-mutation
+  coverage.
+- Boundary: no repo mutation, no HoloIndex mutation or re-index, no queue
+  mutation, no worker spawn, no OpenClaw/Hermes execution, and no extension
+  runtime wiring. The snapshot binds `snapshot_receipt_id`,
+  `snapshot_content_digest`, `context_view_id`, and derived evidence bundles
+  before downstream assignment.
+- HoloIndex read-only probe for `RedDog operational context snapshot HoloIndex
+  freshness Brain breadcrumbs authoritative work state` surfaced adjacent
+  policy-gate, wardrobe-selection, continuity-context, and freshness-governance
+  surfaces but not the new snapshot runtime. Recorded
+  `HOLOINDEX_REDDOG_OPERATIONAL_CONTEXT_SNAPSHOT_INDEX_GAP_PHASE1`; no runtime
+  re-index performed.
+
 ## 2026-07-14: REDDOG_RESEARCH_HOLOINDEX_PROMOTION_GATE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 77, 97

--- a/modules/communication/moltbot_bridge/src/reddog_operational_context_snapshot.py
+++ b/modules/communication/moltbot_bridge/src/reddog_operational_context_snapshot.py
@@ -1,0 +1,738 @@
+"""RedDog operational context snapshot runtime.
+
+This module builds the read-only context boundary RedDog must bind before
+Fusion, worker assignment, or execution authority. It consumes authoritative
+work state, repo HEAD evidence, HoloIndex freshness receipts, breadcrumbs,
+Brain artifacts, and workspace memory metadata without mutating any source.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Optional, Sequence
+
+from holo_index.freshness_receipt import (
+    FreshnessCheck,
+    HoloIndexFreshnessReceipt,
+    evaluate_freshness_for_paths,
+    load_freshness_receipt,
+    read_git_head_sha,
+)
+
+
+SNAPSHOT_SCHEMA_VERSION = "reddog_operational_context_snapshot.v1"
+CONTEXT_POLICY_VERSION = "reddog_context_view_policy.v1"
+
+SOURCE_REPO = "repo"
+SOURCE_WORK_STATE = "work_state"
+SOURCE_HOLOINDEX = "holoindex"
+SOURCE_BREADCRUMBS = "breadcrumbs"
+SOURCE_BRAIN = "brain"
+SOURCE_WORKSPACE_MEMORY = "workspace_memory"
+SOURCE_BOOTSTRAP_PROJECTION = "bootstrap_projection"
+
+AUTHORITY_AUTHORITATIVE = "AUTHORITATIVE"
+AUTHORITY_VERIFIED = "VERIFIED"
+AUTHORITY_OBSERVATIONAL = "OBSERVATIONAL"
+AUTHORITY_HISTORICAL = "HISTORICAL"
+
+FRESH = "FRESH"
+STALE = "STALE"
+UNKNOWN = "UNKNOWN"
+MISSING = "MISSING"
+
+SNAPSHOT_ACCEPTED = "SNAPSHOT_ACCEPTED"
+SNAPSHOT_REJECTED = "SNAPSHOT_REJECTED"
+ASSIGNMENT_CONTEXT_VALID = "ASSIGNMENT_CONTEXT_VALID"
+ASSIGNMENT_CONTEXT_STALE = "ASSIGNMENT_CONTEXT_STALE"
+
+_ABSOLUTE_PATH_RE = re.compile(r"(?:[A-Za-z]:[\\/][^\s,\]\)}]+|[\\/][A-Za-z0-9_.-]+(?:[\\/][^\s,\]\)}]+)+)")
+_SECRET_RE = re.compile(r"(?i)(api[_-]?key|secret|token|password|private[_-]?key|sk-[A-Za-z0-9_-]+)")
+
+
+@dataclass(frozen=True)
+class SourceReceipt:
+    """Evidence receipt for one context source."""
+
+    source: str
+    authority_class: str
+    required: bool
+    observed_at: str
+    source_version: str
+    content_digest: str
+    freshness: str
+    rejection_reasons: tuple[str, ...] = ()
+    record_count: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class OperationalContextSnapshot:
+    """Canonical RedDog runtime context snapshot."""
+
+    schema_version: str
+    policy_version: str
+    snapshot_receipt_id: str
+    snapshot_content_digest: str
+    created_at: str
+    valid_until: str
+    repo_state: dict[str, Any]
+    work_state: dict[str, Any]
+    holoindex_state: dict[str, Any]
+    breadcrumbs_state: dict[str, Any]
+    brain_state: dict[str, Any]
+    workspace_memory_state: dict[str, Any]
+    source_receipts: tuple[SourceReceipt, ...]
+    conflicts: tuple[str, ...] = ()
+    rejection_reasons: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["source_receipts"] = [receipt.to_dict() for receipt in self.source_receipts]
+        return data
+
+
+@dataclass(frozen=True)
+class ContextView:
+    """Filtered model-visible view derived from an exact snapshot."""
+
+    context_view_id: str
+    snapshot_receipt_id: str
+    snapshot_content_digest: str
+    policy_version: str
+    text: str
+    included_sources: tuple[str, ...]
+    omitted_sources: tuple[str, ...]
+    redaction_reasons: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class EvidenceBundle:
+    """Derived evidence bundle that augments, but never mutates, a snapshot."""
+
+    evidence_bundle_id: str
+    snapshot_receipt_id: str
+    context_view_id: str
+    report_digests: tuple[str, ...]
+    external_research_receipts: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class SnapshotBuildResult:
+    """Result returned by snapshot construction."""
+
+    accepted: bool
+    status: str
+    snapshot: Optional[OperationalContextSnapshot]
+    context_view: Optional[ContextView]
+    source_receipts: tuple[SourceReceipt, ...]
+    rejection_reasons: tuple[str, ...]
+    conflicts: tuple[str, ...]
+    no_repo_mutation_performed: bool = True
+    no_holoindex_mutation_performed: bool = True
+    no_queue_mutation_performed: bool = True
+    no_worker_spawn_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "accepted": self.accepted,
+            "status": self.status,
+            "snapshot": self.snapshot.to_dict() if self.snapshot else None,
+            "context_view": self.context_view.to_dict() if self.context_view else None,
+            "source_receipts": [receipt.to_dict() for receipt in self.source_receipts],
+            "rejection_reasons": list(self.rejection_reasons),
+            "conflicts": list(self.conflicts),
+            "no_repo_mutation_performed": self.no_repo_mutation_performed,
+            "no_holoindex_mutation_performed": self.no_holoindex_mutation_performed,
+            "no_queue_mutation_performed": self.no_queue_mutation_performed,
+            "no_worker_spawn_performed": self.no_worker_spawn_performed,
+        }
+
+
+@dataclass(frozen=True)
+class AssignmentContextCheck:
+    """Gate result before assignment/work-order promotion."""
+
+    accepted: bool
+    status: str
+    snapshot_receipt_id: str
+    context_view_id: str
+    evidence_bundle_id: Optional[str]
+    rejection_reasons: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def observe_repo_state(repo_root: Path | str) -> dict[str, Any]:
+    """Read repo HEAD and dirty/worktree metadata without mutating git state."""
+
+    root = Path(repo_root)
+    head_sha = read_git_head_sha(root)
+    dirty_paths = _git_readonly_lines(root, ("status", "--porcelain=v1"))
+    worktrees = _git_readonly_lines(root, ("worktree", "list", "--porcelain"))
+    return {
+        "repo_root_digest": _digest({"repo_root": str(root.resolve())}),
+        "head_sha": head_sha,
+        "dirty_paths": tuple(_normalize_status_path(line) for line in dirty_paths if line.strip()),
+        "dirty_digest": _digest(tuple(dirty_paths)),
+        "worktree_digest": _digest(tuple(worktrees)),
+    }
+
+
+def load_authoritative_work_state(path: Path | str) -> dict[str, Any]:
+    """Load an already-materialized authoritative work-state snapshot."""
+
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def load_existing_holoindex_receipt(path: Path | str) -> HoloIndexFreshnessReceipt:
+    """Load a HoloIndex freshness receipt; this never writes or refreshes the index."""
+
+    return load_freshness_receipt(path)
+
+
+def build_operational_context_snapshot(
+    *,
+    repo_state: Mapping[str, Any],
+    work_state_snapshot: Mapping[str, Any],
+    holoindex_receipt: HoloIndexFreshnessReceipt | Mapping[str, Any] | None,
+    changed_paths: Sequence[str],
+    now_iso: str | None = None,
+    ttl_seconds: int = 600,
+    breadcrumbs: Sequence[Mapping[str, Any]] = (),
+    breadcrumb_scope: str | None = None,
+    brain_state: Mapping[str, Any] | None = None,
+    workspace_memory_notes: Sequence[Mapping[str, Any]] = (),
+    bootstrap_projection: Mapping[str, Any] | None = None,
+    required_sources: Sequence[str] = (SOURCE_REPO, SOURCE_WORK_STATE, SOURCE_HOLOINDEX),
+    context_view_max_chars: int = 12000,
+) -> SnapshotBuildResult:
+    """Build an operational snapshot and its exact model-visible view."""
+
+    observed_at = now_iso or utc_now_iso()
+    valid_until = (datetime.fromisoformat(observed_at) + timedelta(seconds=ttl_seconds)).isoformat()
+    required = set(required_sources)
+    repo_clean = _normalize_repo_state(repo_state)
+    work_clean = _normalize_work_state(work_state_snapshot)
+    scoped_breadcrumbs = tuple(_filter_breadcrumbs(breadcrumbs, breadcrumb_scope))
+    brain_clean = _normalize_brain_state(brain_state)
+    workspace_clean = _normalize_workspace_memory(workspace_memory_notes)
+    holo_state = _normalize_holoindex_state(
+        holoindex_receipt,
+        repo_head_sha=str(repo_clean.get("head_sha", "unknown")),
+        changed_paths=changed_paths,
+    )
+
+    receipts = (
+        _source_receipt(
+            source=SOURCE_REPO,
+            authority_class=AUTHORITY_AUTHORITATIVE,
+            required=SOURCE_REPO in required,
+            observed_at=observed_at,
+            source_version=str(repo_clean.get("head_sha", "unknown")),
+            payload=repo_clean,
+            freshness=FRESH if repo_clean.get("head_sha") and repo_clean.get("head_sha") != "unknown" else UNKNOWN,
+        ),
+        _source_receipt(
+            source=SOURCE_WORK_STATE,
+            authority_class=AUTHORITY_AUTHORITATIVE,
+            required=SOURCE_WORK_STATE in required,
+            observed_at=observed_at,
+            source_version=str(work_clean.get("revision", "")),
+            payload=work_clean,
+            freshness=FRESH if work_clean.get("revision") else MISSING,
+            rejection_reasons=() if work_clean.get("revision") else ("missing_work_state_revision",),
+            record_count=len(work_clean.get("worker_claims", ())) + len(work_clean.get("wre_queue_items", ())),
+        ),
+        _source_receipt(
+            source=SOURCE_HOLOINDEX,
+            authority_class=AUTHORITY_VERIFIED,
+            required=SOURCE_HOLOINDEX in required,
+            observed_at=observed_at,
+            source_version=str(holo_state.get("repo_head_sha", "")),
+            payload=holo_state,
+            freshness=FRESH if holo_state.get("freshness_ok") else (MISSING if holoindex_receipt is None else STALE),
+            rejection_reasons=tuple(holo_state.get("rejection_reasons", ())),
+            record_count=int(holo_state.get("required_collection_count", 0)),
+        ),
+        _source_receipt(
+            source=SOURCE_BREADCRUMBS,
+            authority_class=AUTHORITY_OBSERVATIONAL,
+            required=SOURCE_BREADCRUMBS in required,
+            observed_at=observed_at,
+            source_version=str(breadcrumb_scope or "unscoped"),
+            payload=scoped_breadcrumbs,
+            freshness=FRESH if scoped_breadcrumbs or SOURCE_BREADCRUMBS not in required else MISSING,
+            record_count=len(scoped_breadcrumbs),
+        ),
+        _source_receipt(
+            source=SOURCE_BRAIN,
+            authority_class=AUTHORITY_HISTORICAL,
+            required=SOURCE_BRAIN in required,
+            observed_at=observed_at,
+            source_version=str(brain_clean.get("signature_digest", "")),
+            payload=brain_clean,
+            freshness=FRESH if brain_clean.get("available") else MISSING,
+            rejection_reasons=() if brain_clean.get("available") or SOURCE_BRAIN not in required else ("missing_brain_artifacts",),
+        ),
+        _source_receipt(
+            source=SOURCE_WORKSPACE_MEMORY,
+            authority_class=AUTHORITY_HISTORICAL,
+            required=SOURCE_WORKSPACE_MEMORY in required,
+            observed_at=observed_at,
+            source_version=str(workspace_clean.get("memory_digest", "")),
+            payload=workspace_clean,
+            freshness=FRESH if workspace_clean.get("record_count", 0) else UNKNOWN,
+            record_count=int(workspace_clean.get("record_count", 0)),
+        ),
+    )
+
+    conflicts = tuple(_derive_conflicts(repo_clean, work_clean, brain_clean, bootstrap_projection))
+    rejection_reasons = tuple(_mandatory_source_rejections(receipts))
+    content = {
+        "schema_version": SNAPSHOT_SCHEMA_VERSION,
+        "policy_version": CONTEXT_POLICY_VERSION,
+        "repo_state": repo_clean,
+        "work_state": work_clean,
+        "holoindex_state": holo_state,
+        "breadcrumbs_state": _breadcrumb_state(scoped_breadcrumbs, breadcrumb_scope),
+        "brain_state": brain_clean,
+        "workspace_memory_state": workspace_clean,
+        "source_receipts": [receipt.to_dict() for receipt in receipts],
+        "conflicts": conflicts,
+        "rejection_reasons": rejection_reasons,
+    }
+    content_digest = _digest(content)
+    receipt_id = _digest(
+        {
+            "snapshot_content_digest": content_digest,
+            "created_at": observed_at,
+            "valid_until": valid_until,
+            "source_receipt_ids": [receipt.content_digest for receipt in receipts],
+        }
+    )
+
+    if rejection_reasons:
+        return SnapshotBuildResult(
+            accepted=False,
+            status=SNAPSHOT_REJECTED,
+            snapshot=None,
+            context_view=None,
+            source_receipts=receipts,
+            rejection_reasons=rejection_reasons,
+            conflicts=conflicts,
+        )
+
+    snapshot = OperationalContextSnapshot(
+        schema_version=SNAPSHOT_SCHEMA_VERSION,
+        policy_version=CONTEXT_POLICY_VERSION,
+        snapshot_receipt_id=receipt_id,
+        snapshot_content_digest=content_digest,
+        created_at=observed_at,
+        valid_until=valid_until,
+        repo_state=repo_clean,
+        work_state=work_clean,
+        holoindex_state=holo_state,
+        breadcrumbs_state=_breadcrumb_state(scoped_breadcrumbs, breadcrumb_scope),
+        brain_state=brain_clean,
+        workspace_memory_state=workspace_clean,
+        source_receipts=receipts,
+        conflicts=conflicts,
+        rejection_reasons=rejection_reasons,
+    )
+    context_view = build_context_view(snapshot, max_chars=context_view_max_chars)
+    return SnapshotBuildResult(
+        accepted=True,
+        status=SNAPSHOT_ACCEPTED,
+        snapshot=snapshot,
+        context_view=context_view,
+        source_receipts=receipts,
+        rejection_reasons=(),
+        conflicts=conflicts,
+    )
+
+
+def build_context_view(snapshot: OperationalContextSnapshot, *, max_chars: int = 12000) -> ContextView:
+    """Build the exact sanitized model-visible context view for a snapshot."""
+
+    lines = [
+        "REDDOG_OPERATIONAL_CONTEXT_VIEW",
+        f"schema_version: {snapshot.schema_version}",
+        f"policy_version: {snapshot.policy_version}",
+        f"snapshot_receipt_id: {snapshot.snapshot_receipt_id}",
+        f"snapshot_content_digest: {snapshot.snapshot_content_digest}",
+        f"repo_head_sha: {snapshot.repo_state.get('head_sha', 'unknown')}",
+        f"work_state_revision: {snapshot.work_state.get('revision', '')}",
+        f"holoindex_freshness: {snapshot.holoindex_state.get('freshness_ok', False)}",
+        f"breadcrumb_scope: {snapshot.breadcrumbs_state.get('scope', 'none')}",
+        f"brain_available: {snapshot.brain_state.get('available', False)}",
+        f"conflicts: {','.join(snapshot.conflicts) if snapshot.conflicts else '(none)'}",
+        "source_receipts:",
+    ]
+    for receipt in snapshot.source_receipts:
+        lines.append(
+            "- "
+            + json.dumps(
+                {
+                    "source": receipt.source,
+                    "authority_class": receipt.authority_class,
+                    "required": receipt.required,
+                    "freshness": receipt.freshness,
+                    "content_digest": receipt.content_digest,
+                    "rejection_reasons": receipt.rejection_reasons,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        )
+    text = _sanitize_context_text("\n".join(lines))
+    if len(text) > max_chars:
+        text = text[:max_chars] + "\n[TRUNCATED_CONTEXT_VIEW]"
+    view_id = _digest(
+        {
+            "snapshot_receipt_id": snapshot.snapshot_receipt_id,
+            "snapshot_content_digest": snapshot.snapshot_content_digest,
+            "policy_version": snapshot.policy_version,
+            "text": text,
+        }
+    )
+    return ContextView(
+        context_view_id=view_id,
+        snapshot_receipt_id=snapshot.snapshot_receipt_id,
+        snapshot_content_digest=snapshot.snapshot_content_digest,
+        policy_version=snapshot.policy_version,
+        text=text,
+        included_sources=tuple(receipt.source for receipt in snapshot.source_receipts),
+        omitted_sources=("raw_brain", "raw_breadcrumbs", "raw_workspace_memory"),
+        redaction_reasons=("no_raw_historical_memory", "absolute_paths", "secret_like_values"),
+    )
+
+
+def build_evidence_bundle(
+    *,
+    snapshot: OperationalContextSnapshot,
+    context_view: ContextView,
+    report_digests: Sequence[str],
+    external_research_receipts: Sequence[str] = (),
+) -> EvidenceBundle:
+    """Bind reports/research to a snapshot without changing the snapshot."""
+
+    bundle_id = _digest(
+        {
+            "snapshot_receipt_id": snapshot.snapshot_receipt_id,
+            "context_view_id": context_view.context_view_id,
+            "report_digests": sorted(report_digests),
+            "external_research_receipts": sorted(external_research_receipts),
+        }
+    )
+    return EvidenceBundle(
+        evidence_bundle_id=bundle_id,
+        snapshot_receipt_id=snapshot.snapshot_receipt_id,
+        context_view_id=context_view.context_view_id,
+        report_digests=tuple(sorted(report_digests)),
+        external_research_receipts=tuple(sorted(external_research_receipts)),
+    )
+
+
+def validate_context_before_assignment(
+    *,
+    snapshot: OperationalContextSnapshot,
+    context_view: ContextView,
+    current_repo_head_sha: str,
+    current_work_state_revision: str,
+    current_breadcrumb_high_watermark: str | None = None,
+    evidence_bundle: EvidenceBundle | None = None,
+    now_iso: str | None = None,
+) -> AssignmentContextCheck:
+    """Fail closed when the assignment-time world no longer matches the snapshot."""
+
+    reasons: list[str] = []
+    now = datetime.fromisoformat(now_iso or utc_now_iso())
+    if now > datetime.fromisoformat(snapshot.valid_until):
+        reasons.append("snapshot_expired")
+    if context_view.snapshot_receipt_id != snapshot.snapshot_receipt_id:
+        reasons.append("context_view_snapshot_mismatch")
+    if context_view.snapshot_content_digest != snapshot.snapshot_content_digest:
+        reasons.append("context_view_content_mismatch")
+    if current_repo_head_sha != snapshot.repo_state.get("head_sha"):
+        reasons.append("repo_head_changed")
+    if current_work_state_revision != snapshot.work_state.get("revision"):
+        reasons.append("work_state_revision_changed")
+    expected_high_watermark = snapshot.breadcrumbs_state.get("high_watermark")
+    if current_breadcrumb_high_watermark and expected_high_watermark:
+        if current_breadcrumb_high_watermark != expected_high_watermark:
+            reasons.append("breadcrumb_high_watermark_changed")
+    if evidence_bundle and evidence_bundle.context_view_id != context_view.context_view_id:
+        reasons.append("evidence_bundle_context_view_mismatch")
+
+    return AssignmentContextCheck(
+        accepted=not reasons,
+        status=ASSIGNMENT_CONTEXT_VALID if not reasons else ASSIGNMENT_CONTEXT_STALE,
+        snapshot_receipt_id=snapshot.snapshot_receipt_id,
+        context_view_id=context_view.context_view_id,
+        evidence_bundle_id=evidence_bundle.evidence_bundle_id if evidence_bundle else None,
+        rejection_reasons=tuple(reasons),
+    )
+
+
+def _git_readonly_lines(repo_root: Path, args: tuple[str, ...]) -> tuple[str, ...]:
+    allowed = {
+        ("status", "--porcelain=v1"),
+        ("worktree", "list", "--porcelain"),
+    }
+    if args not in allowed:
+        raise ValueError("unsupported_git_readonly_command")
+    completed = subprocess.run(
+        ("git", "-C", str(repo_root), *args),
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if completed.returncode != 0:
+        return ()
+    return tuple(line for line in completed.stdout.splitlines() if line.strip())
+
+
+def _normalize_status_path(line: str) -> str:
+    text = line[3:] if len(line) > 3 else line
+    return text.replace("\\", "/").strip()
+
+
+def _normalize_repo_state(repo_state: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "head_sha": str(repo_state.get("head_sha", "unknown")),
+        "dirty_paths": tuple(sorted(str(path).replace("\\", "/") for path in repo_state.get("dirty_paths", ()))),
+        "dirty_digest": str(repo_state.get("dirty_digest", _digest(tuple(repo_state.get("dirty_paths", ()))))),
+        "worktree_digest": str(repo_state.get("worktree_digest", "")),
+    }
+
+
+def _normalize_work_state(work_state: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": str(work_state.get("schema_version", "")),
+        "revision": str(work_state.get("revision", "")),
+        "selected_slice": str(work_state.get("selected_slice", "")),
+        "worker_claims": tuple(_stable_mapping(entry) for entry in work_state.get("worker_claims", ())),
+        "wre_queue_items": tuple(_stable_mapping(entry) for entry in work_state.get("wre_queue_items", ())),
+        "refresh_receipt_id": str(work_state.get("refresh_receipt_id", "")),
+    }
+
+
+def _normalize_holoindex_state(
+    receipt: HoloIndexFreshnessReceipt | Mapping[str, Any] | None,
+    *,
+    repo_head_sha: str,
+    changed_paths: Sequence[str],
+) -> dict[str, Any]:
+    check: FreshnessCheck = evaluate_freshness_for_paths(
+        receipt,
+        changed_paths,
+        expected_repo_head_sha=repo_head_sha if repo_head_sha != "unknown" else None,
+    )
+    receipt_digest = _digest(receipt.to_dict() if hasattr(receipt, "to_dict") else receipt or {})
+    receipt_head = ""
+    if isinstance(receipt, HoloIndexFreshnessReceipt):
+        receipt_head = receipt.repo_head_sha
+    elif isinstance(receipt, Mapping):
+        receipt_head = str(receipt.get("repo_head_sha", ""))
+    return {
+        "receipt_digest": receipt_digest,
+        "repo_head_sha": receipt_head,
+        "freshness_ok": check.ok,
+        "required_collections": tuple(check.required_collections),
+        "required_collection_count": len(check.required_collections),
+        "stale_collections": tuple(check.stale_collections),
+        "rejection_reasons": tuple(check.reasons),
+        "changed_paths": tuple(sorted(path.replace("\\", "/") for path in changed_paths)),
+    }
+
+
+def _normalize_brain_state(brain_state: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not brain_state:
+        return {"available": False, "signature_digest": "", "summary_digest": "", "record_count": 0}
+    sanitized = {
+        "available": bool(brain_state.get("available", True)),
+        "signature_digest": str(brain_state.get("signature_digest", brain_state.get("signature", ""))),
+        "summary_digest": str(brain_state.get("summary_digest", _digest(brain_state.get("summary", "")))),
+        "record_count": int(brain_state.get("record_count", brain_state.get("conversation_count", 0) or 0)),
+        "reported_repo_head_sha": str(brain_state.get("repo_head_sha", "")),
+        "reported_work_state_revision": str(brain_state.get("work_state_revision", "")),
+    }
+    return sanitized
+
+
+def _normalize_workspace_memory(notes: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    metadata = []
+    for entry in notes:
+        metadata.append(
+            {
+                "note_id": str(entry.get("note_id", entry.get("id", ""))),
+                "topic": _safe_short_text(str(entry.get("topic", ""))),
+                "digest": _digest(entry),
+            }
+        )
+    return {
+        "record_count": len(metadata),
+        "memory_digest": _digest(metadata),
+        "records": tuple(metadata),
+    }
+
+
+def _filter_breadcrumbs(
+    breadcrumbs: Sequence[Mapping[str, Any]],
+    scope: str | None,
+) -> Iterable[dict[str, Any]]:
+    for entry in breadcrumbs:
+        continuity = str(entry.get("continuity_id", entry.get("root_continuity_id", "")))
+        task_id = str(entry.get("task_id", ""))
+        if scope and scope not in {continuity, task_id}:
+            continue
+        yield {
+            "breadcrumb_id": str(entry.get("breadcrumb_id", entry.get("id", ""))),
+            "continuity_id": continuity,
+            "task_id": task_id,
+            "observed_at": str(entry.get("timestamp", entry.get("created_at", ""))),
+            "digest": _digest(entry),
+        }
+
+
+def _breadcrumb_state(records: Sequence[Mapping[str, Any]], scope: str | None) -> dict[str, Any]:
+    high_watermark = ""
+    if records:
+        high_watermark = _digest(tuple(record.get("digest", "") for record in records))
+    return {
+        "scope": scope or "none",
+        "record_count": len(records),
+        "high_watermark": high_watermark,
+        "records": tuple(_stable_mapping(record) for record in records),
+    }
+
+
+def _derive_conflicts(
+    repo_state: Mapping[str, Any],
+    work_state: Mapping[str, Any],
+    brain_state: Mapping[str, Any],
+    bootstrap_projection: Mapping[str, Any] | None,
+) -> Iterable[str]:
+    if bootstrap_projection:
+        bootstrap_head = str(bootstrap_projection.get("repo_head_sha", ""))
+        if bootstrap_head and bootstrap_head != repo_state.get("head_sha"):
+            yield "bootstrap_head_stale"
+        bootstrap_revision = str(bootstrap_projection.get("work_state_revision", ""))
+        if bootstrap_revision and bootstrap_revision != work_state.get("revision"):
+            yield "bootstrap_work_state_stale"
+    brain_head = str(brain_state.get("reported_repo_head_sha", ""))
+    if brain_head and brain_head != repo_state.get("head_sha"):
+        yield "brain_head_historical_conflict"
+    brain_revision = str(brain_state.get("reported_work_state_revision", ""))
+    if brain_revision and brain_revision != work_state.get("revision"):
+        yield "brain_work_state_historical_conflict"
+
+
+def _mandatory_source_rejections(receipts: Sequence[SourceReceipt]) -> Iterable[str]:
+    for receipt in receipts:
+        if not receipt.required:
+            continue
+        if receipt.freshness in {MISSING, STALE, UNKNOWN}:
+            yield f"mandatory_source_not_fresh:{receipt.source}"
+        for reason in receipt.rejection_reasons:
+            yield f"{receipt.source}:{reason}"
+
+
+def _source_receipt(
+    *,
+    source: str,
+    authority_class: str,
+    required: bool,
+    observed_at: str,
+    source_version: str,
+    payload: Any,
+    freshness: str,
+    rejection_reasons: Sequence[str] = (),
+    record_count: int = 0,
+) -> SourceReceipt:
+    return SourceReceipt(
+        source=source,
+        authority_class=authority_class,
+        required=required,
+        observed_at=observed_at,
+        source_version=source_version,
+        content_digest=_digest(payload),
+        freshness=freshness,
+        rejection_reasons=tuple(rejection_reasons),
+        record_count=record_count,
+    )
+
+
+def _sanitize_context_text(text: str) -> str:
+    text = _ABSOLUTE_PATH_RE.sub("[ABS_PATH_REDACTED]", text)
+    text = _SECRET_RE.sub("[SENSITIVE_VALUE_REDACTED]", text)
+    return text
+
+
+def _safe_short_text(text: str) -> str:
+    return _sanitize_context_text(text.replace("\n", " ").strip())[:120]
+
+
+def _stable_mapping(entry: Mapping[str, Any]) -> dict[str, Any]:
+    return {str(key): entry[key] for key in sorted(entry)}
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def _digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "ASSIGNMENT_CONTEXT_STALE",
+    "ASSIGNMENT_CONTEXT_VALID",
+    "AUTHORITY_AUTHORITATIVE",
+    "AUTHORITY_HISTORICAL",
+    "AUTHORITY_OBSERVATIONAL",
+    "AUTHORITY_VERIFIED",
+    "CONTEXT_POLICY_VERSION",
+    "FRESH",
+    "MISSING",
+    "SNAPSHOT_ACCEPTED",
+    "SNAPSHOT_REJECTED",
+    "SNAPSHOT_SCHEMA_VERSION",
+    "STALE",
+    "UNKNOWN",
+    "AssignmentContextCheck",
+    "ContextView",
+    "EvidenceBundle",
+    "OperationalContextSnapshot",
+    "SnapshotBuildResult",
+    "SourceReceipt",
+    "build_context_view",
+    "build_evidence_bundle",
+    "build_operational_context_snapshot",
+    "load_authoritative_work_state",
+    "load_existing_holoindex_receipt",
+    "observe_repo_state",
+    "validate_context_before_assignment",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_operational_context_snapshot.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_operational_context_snapshot.py
@@ -1,0 +1,333 @@
+"""Tests for RedDog operational context snapshot runtime."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from holo_index.freshness_receipt import CollectionFreshness, HoloIndexFreshnessReceipt
+from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
+    ASSIGNMENT_CONTEXT_STALE,
+    ASSIGNMENT_CONTEXT_VALID,
+    AUTHORITY_AUTHORITATIVE,
+    FRESH,
+    MISSING,
+    SOURCE_BRAIN,
+    SOURCE_HOLOINDEX,
+    SOURCE_REPO,
+    SOURCE_WORK_STATE,
+    SNAPSHOT_ACCEPTED,
+    SNAPSHOT_REJECTED,
+    build_evidence_bundle,
+    build_operational_context_snapshot,
+    load_authoritative_work_state,
+    observe_repo_state,
+    validate_context_before_assignment,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_operational_context_snapshot.py"
+)
+NOW = "2026-07-14T00:00:00+00:00"
+HEAD = "9c31512a8b4d6e1f0a2b3c4d5e6f708192a3b4c5"
+REVISION = "sha256:work-state-revision"
+
+
+def _repo_state(head: str = HEAD):
+    return {
+        "head_sha": head,
+        "dirty_paths": (),
+        "dirty_digest": "sha256:clean",
+        "worktree_digest": "sha256:worktrees",
+    }
+
+
+def _work_state(revision: str = REVISION):
+    return {
+        "schema_version": "reddog_authoritative_work_state.v1",
+        "revision": revision,
+        "selected_slice": "REDDOG_OPERATIONAL_CONTEXT_SNAPSHOT_RUNTIME_PHASE1",
+        "refresh_receipt_id": "sha256:refresh",
+        "worker_claims": [
+            {
+                "claim_id": "claim-1",
+                "slice_id": "REDDOG_OPERATIONAL_CONTEXT_SNAPSHOT_RUNTIME_PHASE1",
+                "worker_id": "reddog",
+                "status": "ACTIVE",
+            }
+        ],
+        "wre_queue_items": [
+            {
+                "queue_item_id": "queue-1",
+                "slice_id": "REDDOG_OPERATIONAL_CONTEXT_SNAPSHOT_RUNTIME_PHASE1",
+                "claim_id": "claim-1",
+            }
+        ],
+    }
+
+
+def _fresh_holo_receipt(head: str = HEAD):
+    return HoloIndexFreshnessReceipt(
+        schema_version="holoindex_freshness_receipt.v1",
+        generated_at=NOW,
+        repo_root=str(REPO_ROOT),
+        repo_head_sha=head,
+        ssd_path="E:/HoloIndex",
+        source="ci_targeted_reindex",
+        collections=[
+            CollectionFreshness(
+                name="navigation_work_ledger",
+                count=3,
+                status="indexed",
+                source="ci_targeted_reindex",
+                repo_head_sha=head,
+                last_indexed_at=NOW,
+            ),
+            CollectionFreshness(
+                name="navigation_symbols",
+                count=4,
+                status="indexed",
+                source="ci_targeted_reindex",
+                repo_head_sha=head,
+                last_indexed_at=NOW,
+            ),
+        ],
+    )
+
+
+def _accepted_snapshot(**overrides):
+    kwargs = {
+        "repo_state": _repo_state(),
+        "work_state_snapshot": _work_state(),
+        "holoindex_receipt": _fresh_holo_receipt(),
+        "changed_paths": [
+            "docs/0102_session_briefings/work_ledger.schema.json",
+            "holo_index/adaptive_learning/breadcrumb_tracer.py",
+        ],
+        "now_iso": NOW,
+        "breadcrumbs": [
+            {
+                "breadcrumb_id": "b1",
+                "continuity_id": "cont-1",
+                "task_id": "task-1",
+                "timestamp": NOW,
+                "body": "raw breadcrumb body with C:/Users/user/secret.txt",
+            },
+            {
+                "breadcrumb_id": "b2",
+                "continuity_id": "other",
+                "task_id": "other",
+                "timestamp": NOW,
+            },
+        ],
+        "breadcrumb_scope": "cont-1",
+        "brain_state": {
+            "available": True,
+            "signature_digest": "sha256:brain",
+            "summary": "raw brain transcript sk-test should never appear",
+            "repo_head_sha": HEAD,
+            "work_state_revision": REVISION,
+        },
+        "workspace_memory_notes": [
+            {
+                "note_id": "m1",
+                "topic": "lane note",
+                "body": "raw workspace note with O:/Foundups-Agent/.env",
+            }
+        ],
+    }
+    kwargs.update(overrides)
+    return build_operational_context_snapshot(**kwargs)
+
+
+def test_snapshot_builds_source_receipts_context_view_and_identity_chain() -> None:
+    result = _accepted_snapshot()
+
+    assert result.accepted is True
+    assert result.status == SNAPSHOT_ACCEPTED
+    assert result.snapshot is not None
+    assert result.context_view is not None
+    snapshot = result.snapshot
+    context_view = result.context_view
+    assert snapshot.snapshot_content_digest.startswith("sha256:")
+    assert snapshot.snapshot_receipt_id.startswith("sha256:")
+    assert context_view.snapshot_receipt_id == snapshot.snapshot_receipt_id
+    assert context_view.snapshot_content_digest == snapshot.snapshot_content_digest
+    assert context_view.context_view_id.startswith("sha256:")
+    receipts = {receipt.source: receipt for receipt in snapshot.source_receipts}
+    assert receipts[SOURCE_REPO].authority_class == AUTHORITY_AUTHORITATIVE
+    assert receipts[SOURCE_REPO].freshness == FRESH
+    assert receipts[SOURCE_WORK_STATE].source_version == REVISION
+    assert receipts[SOURCE_HOLOINDEX].freshness == FRESH
+    assert snapshot.breadcrumbs_state["record_count"] == 1
+
+
+def test_missing_required_work_state_rejects_before_context_view() -> None:
+    result = _accepted_snapshot(work_state_snapshot={"schema_version": "reddog_authoritative_work_state.v1"})
+
+    assert result.accepted is False
+    assert result.status == SNAPSHOT_REJECTED
+    assert result.snapshot is None
+    assert result.context_view is None
+    assert "mandatory_source_not_fresh:work_state" in result.rejection_reasons
+    assert "work_state:missing_work_state_revision" in result.rejection_reasons
+
+
+def test_stale_holoindex_receipt_rejects_when_mandatory() -> None:
+    result = _accepted_snapshot(holoindex_receipt=_fresh_holo_receipt(head="old-head"))
+
+    assert result.accepted is False
+    assert "mandatory_source_not_fresh:holoindex" in result.rejection_reasons
+    assert "holoindex:stale_repo_head_sha" in result.rejection_reasons
+
+
+def test_missing_brain_is_recorded_without_blocking_unrelated_work() -> None:
+    result = _accepted_snapshot(brain_state=None)
+
+    assert result.accepted is True
+    assert result.snapshot is not None
+    receipts = {receipt.source: receipt for receipt in result.snapshot.source_receipts}
+    assert receipts[SOURCE_BRAIN].freshness == MISSING
+    assert receipts[SOURCE_BRAIN].required is False
+
+
+def test_bootstrap_and_brain_conflicts_do_not_override_current_authoritative_state() -> None:
+    result = _accepted_snapshot(
+        bootstrap_projection={
+            "repo_head_sha": "stale-bootstrap-head",
+            "work_state_revision": "stale-bootstrap-revision",
+        },
+        brain_state={
+            "available": True,
+            "signature_digest": "sha256:brain",
+            "repo_head_sha": "historical-head",
+            "work_state_revision": "historical-revision",
+        },
+    )
+
+    assert result.accepted is True
+    assert result.snapshot is not None
+    assert result.snapshot.repo_state["head_sha"] == HEAD
+    assert result.snapshot.work_state["revision"] == REVISION
+    assert "bootstrap_head_stale" in result.conflicts
+    assert "bootstrap_work_state_stale" in result.conflicts
+    assert "brain_head_historical_conflict" in result.conflicts
+    assert "brain_work_state_historical_conflict" in result.conflicts
+
+
+def test_context_view_redacts_raw_memory_secrets_and_absolute_paths() -> None:
+    result = _accepted_snapshot()
+
+    assert result.context_view is not None
+    text = result.context_view.text
+    assert "raw breadcrumb body" not in text
+    assert "raw brain transcript" not in text
+    assert "raw workspace note" not in text
+    assert "C:/Users/user" not in text
+    assert "O:/Foundups-Agent" not in text
+    assert "sk-test" not in text
+
+
+def test_evidence_bundle_derives_from_snapshot_without_mutating_it() -> None:
+    result = _accepted_snapshot()
+    assert result.snapshot is not None and result.context_view is not None
+    before = result.snapshot.to_dict()
+
+    bundle = build_evidence_bundle(
+        snapshot=result.snapshot,
+        context_view=result.context_view,
+        report_digests=["sha256:repo-audit", "sha256:external-research"],
+        external_research_receipts=["sha256:external-source"],
+    )
+
+    assert bundle.evidence_bundle_id.startswith("sha256:")
+    assert bundle.snapshot_receipt_id == result.snapshot.snapshot_receipt_id
+    assert bundle.context_view_id == result.context_view.context_view_id
+    assert result.snapshot.to_dict() == before
+
+
+def test_assignment_gate_rejects_head_work_state_or_breadcrumb_changes() -> None:
+    result = _accepted_snapshot()
+    assert result.snapshot is not None and result.context_view is not None
+
+    accepted = validate_context_before_assignment(
+        snapshot=result.snapshot,
+        context_view=result.context_view,
+        current_repo_head_sha=HEAD,
+        current_work_state_revision=REVISION,
+        current_breadcrumb_high_watermark=result.snapshot.breadcrumbs_state["high_watermark"],
+        now_iso="2026-07-14T00:01:00+00:00",
+    )
+    assert accepted.accepted is True
+    assert accepted.status == ASSIGNMENT_CONTEXT_VALID
+
+    stale = validate_context_before_assignment(
+        snapshot=result.snapshot,
+        context_view=result.context_view,
+        current_repo_head_sha="new-head",
+        current_work_state_revision="new-revision",
+        current_breadcrumb_high_watermark="new-breadcrumb-mark",
+        now_iso="2026-07-14T00:01:00+00:00",
+    )
+    assert stale.accepted is False
+    assert stale.status == ASSIGNMENT_CONTEXT_STALE
+    assert "repo_head_changed" in stale.rejection_reasons
+    assert "work_state_revision_changed" in stale.rejection_reasons
+    assert "breadcrumb_high_watermark_changed" in stale.rejection_reasons
+
+
+def test_load_authoritative_work_state_uses_existing_snapshot_file(tmp_path: Path) -> None:
+    path = tmp_path / "authoritative_work_state.json"
+    path.write_text(json.dumps(_work_state(), sort_keys=True), encoding="utf-8")
+
+    loaded = load_authoritative_work_state(path)
+
+    assert loaded["revision"] == REVISION
+    assert loaded["worker_claims"][0]["slice_id"] == "REDDOG_OPERATIONAL_CONTEXT_SNAPSHOT_RUNTIME_PHASE1"
+
+
+def test_observe_repo_state_reads_head_without_repo_mutation() -> None:
+    state = observe_repo_state(REPO_ROOT)
+
+    assert state["head_sha"]
+    assert "dirty_digest" in state
+    assert "worktree_digest" in state
+
+
+def test_snapshot_module_has_no_mutating_calls_or_runtime_authority() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    forbidden_names = {
+        "write_freshness_receipt",
+        "refresh_authoritative_work_state_runtime",
+        "create_autonomous_task",
+        "openclaw_supervisor",
+        "hermes_job_executor",
+    }
+    forbidden_attrs = {
+        "write_text",
+        "commit",
+        "mkdir",
+        "unlink",
+        "remove",
+    }
+    forbidden_git_words = {"add", "commit", "push", "merge", "checkout", "reset", "restore"}
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    for name in forbidden_names:
+        assert name not in source
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            assert node.func.attr not in forbidden_attrs
+            if node.func.attr == "replace" and isinstance(node.func.value, ast.Name):
+                assert node.func.value.id != "os"
+    assert "subprocess.run" in source
+    for word in forbidden_git_words:
+        assert f'"{word}"' not in source
+        assert f"'{word}'" not in source


### PR DESCRIPTION
﻿## Summary

- Adds `reddog_operational_context_snapshot.py`, a read-only runtime snapshot builder for RedDog operational context.
- Binds `snapshot_content_digest -> snapshot_receipt_id -> context_view_id -> evidence_bundle_id` before downstream assignment.
- Consumes authoritative work-state snapshots, repo HEAD evidence, HoloIndex freshness receipts, scoped breadcrumbs, Brain artifact metadata, and workspace-memory metadata without mutating any source.
- Fixes `main.py` startup regression: WRE dashboard critical alerts remain visible but no longer block interactive menu startup by default; explicit enforcement and `OPENCLAW_24X7=1` still fail closed.

## WSP_97 Truth Boundary

OBSERVED:
- Source receipts are emitted per source with authority class, freshness, digest, observed time, and rejection reasons.
- Mandatory repo/work-state/HoloIndex sources fail closed when missing or stale.
- Brain and workspace memory are historical/optional by default and cannot override current repo/work-state evidence.
- Context view excludes raw Brain, breadcrumb, and workspace-memory note bodies and redacts secret-like values/absolute paths.
- Assignment gate rejects when repo HEAD, work-state revision, breadcrumb high-watermark, context view, or evidence bundle no longer matches the snapshot.

SPECIFIED_NOT_IMPLEMENTED:
- No Fusion/runtime consumption wiring yet.
- No OpenClaw/Hermes worker spawn or live enqueue.
- No HoloIndex re-index or WRE/CI freshness work-item emission.
- No queue mutation or work-state refresh mutation in this module.

## Validation

- `pytest modules/communication/moltbot_bridge/tests/test_reddog_operational_context_snapshot.py` -> 11 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_authoritative_work_state_refresh_runtime.py` -> 9 passed
- `pytest modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py` -> 20 passed, 3 warnings
- `python -m py_compile main.py modules/communication/moltbot_bridge/src/reddog_operational_context_snapshot.py` -> passed
- `git diff --check` -> clean (autocrlf informational warnings only)

## HoloIndex Addendum

Read-only probe:
`python holo_index.py --search "RedDog operational context snapshot HoloIndex freshness Brain breadcrumbs authoritative work state" --limit 10`

Result surfaced adjacent policy-gate, wardrobe-selection, continuity-context, and HoloIndex freshness-governance surfaces, but not this new snapshot runtime. Recorded `HOLOINDEX_REDDOG_OPERATIONAL_CONTEXT_SNAPSHOT_INDEX_GAP_PHASE1`. No runtime re-index performed.
