### PR TITLE
feat(reddog): gate fusion on context snapshots

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,29 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_CONTEXT_SNAPSHOT_FUSION_AND_ASSIGNMENT_GATE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_context_snapshot_fusion_assignment_gate.py`: pure
+  fail-closed gate that consumes an operational snapshot, context view,
+  evidence bundle, current repo/work-state markers, and requested operation
+  before allowing Fusion or worker assignment.
+- Added `tests/test_reddog_context_snapshot_fusion_assignment_gate.py`:
+  exact-binding acceptance, missing snapshot/view/bundle rejection, mismatched
+  context/evidence rejection, repo/work-state/breadcrumb stale rejection, empty
+  evidence-bundle rejection, expiry rejection, deterministic determination
+  binding, and AST no-runtime-wiring coverage.
+- Boundary: no model call, no worker spawn, no queue mutation, no OpenClaw or
+  Hermes dispatch, no extension runtime wiring, and no execution. This slice
+  emits a `determination_id` binding that downstream model output/work orders
+  must carry; it does not consume model output.
+- HoloIndex read-only probe for `RedDog context snapshot Fusion assignment
+  gate determination binding evidence bundle` surfaced adjacent context bundle,
+  Fusion redaction, bootstrap-context, and operator-loop surfaces but not the
+  new gate module. Recorded
+  `HOLOINDEX_REDDOG_CONTEXT_SNAPSHOT_FUSION_ASSIGNMENT_GATE_INDEX_GAP_PHASE1`;
+  no runtime re-index performed.
+
 ## 2026-07-14: REDDOG_OPERATIONAL_CONTEXT_SNAPSHOT_RUNTIME_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_context_snapshot_fusion_assignment_gate.py
+++ b/modules/communication/moltbot_bridge/src/reddog_context_snapshot_fusion_assignment_gate.py
@@ -1,0 +1,232 @@
+"""RedDog context snapshot Fusion and assignment gate.
+
+This pure gate consumes a previously built operational context snapshot and
+decides whether Fusion and worker assignment may proceed. It does not call a
+model, spawn workers, enqueue OpenClaw, dispatch Hermes, or mutate work state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping, Optional, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
+    ASSIGNMENT_CONTEXT_VALID,
+    ContextView,
+    EvidenceBundle,
+    OperationalContextSnapshot,
+    SourceReceipt,
+    validate_context_before_assignment,
+)
+
+
+FUSION_ASSIGNMENT_GATE_PASSED = "FUSION_ASSIGNMENT_GATE_PASSED"
+FUSION_ASSIGNMENT_GATE_REJECTED = "FUSION_ASSIGNMENT_GATE_REJECTED"
+
+
+@dataclass(frozen=True)
+class DeterminationContextBinding:
+    """Binding that every downstream model result/work order must carry."""
+
+    determination_id: str
+    snapshot_receipt_id: str
+    snapshot_content_digest: str
+    context_view_id: str
+    evidence_bundle_id: str
+    requested_operation: str
+    prompt_digest: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class FusionAssignmentGateDecision:
+    """Fail-closed decision for Fusion and assignment."""
+
+    accepted: bool
+    status: str
+    fusion_allowed: bool
+    assignment_allowed: bool
+    determination_binding: Optional[DeterminationContextBinding]
+    rejection_reasons: tuple[str, ...]
+    source_receipt_digests: tuple[str, ...]
+    no_model_call_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_queue_mutation_performed: bool = True
+    no_execution_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "accepted": self.accepted,
+            "status": self.status,
+            "fusion_allowed": self.fusion_allowed,
+            "assignment_allowed": self.assignment_allowed,
+            "determination_binding": (
+                self.determination_binding.to_dict() if self.determination_binding else None
+            ),
+            "rejection_reasons": list(self.rejection_reasons),
+            "source_receipt_digests": list(self.source_receipt_digests),
+            "no_model_call_performed": self.no_model_call_performed,
+            "no_worker_spawn_performed": self.no_worker_spawn_performed,
+            "no_queue_mutation_performed": self.no_queue_mutation_performed,
+            "no_execution_performed": self.no_execution_performed,
+        }
+
+
+def evaluate_context_snapshot_fusion_assignment_gate(
+    *,
+    snapshot: OperationalContextSnapshot | None,
+    context_view: ContextView | None,
+    evidence_bundle: EvidenceBundle | None,
+    current_repo_head_sha: str,
+    current_work_state_revision: str,
+    current_breadcrumb_high_watermark: str | None = None,
+    requested_operation: str,
+    prompt_text: str = "",
+    now_iso: str | None = None,
+    require_assignment: bool = True,
+) -> FusionAssignmentGateDecision:
+    """Return a deterministic gate decision before Fusion or assignment."""
+
+    reasons: list[str] = []
+    if snapshot is None:
+        reasons.append("missing_snapshot")
+    if context_view is None:
+        reasons.append("missing_context_view")
+    if evidence_bundle is None:
+        reasons.append("missing_evidence_bundle")
+    if not requested_operation.strip():
+        reasons.append("missing_requested_operation")
+
+    if reasons or snapshot is None or context_view is None or evidence_bundle is None:
+        return _reject(reasons, snapshot)
+
+    _validate_binding_shapes(
+        snapshot=snapshot,
+        context_view=context_view,
+        evidence_bundle=evidence_bundle,
+        reasons=reasons,
+    )
+    _validate_source_receipts(snapshot.source_receipts, reasons)
+    if not evidence_bundle.report_digests and not evidence_bundle.external_research_receipts:
+        reasons.append("empty_evidence_bundle")
+
+    assignment_check = validate_context_before_assignment(
+        snapshot=snapshot,
+        context_view=context_view,
+        evidence_bundle=evidence_bundle,
+        current_repo_head_sha=current_repo_head_sha,
+        current_work_state_revision=current_work_state_revision,
+        current_breadcrumb_high_watermark=current_breadcrumb_high_watermark,
+        now_iso=now_iso,
+    )
+    if assignment_check.status != ASSIGNMENT_CONTEXT_VALID:
+        reasons.extend(assignment_check.rejection_reasons)
+
+    if reasons:
+        return _reject(reasons, snapshot)
+
+    prompt_digest = _digest(
+        {
+            "prompt_text": prompt_text,
+            "requested_operation": requested_operation,
+            "context_view_id": context_view.context_view_id,
+            "evidence_bundle_id": evidence_bundle.evidence_bundle_id,
+        }
+    )
+    determination_id = _digest(
+        {
+            "snapshot_receipt_id": snapshot.snapshot_receipt_id,
+            "snapshot_content_digest": snapshot.snapshot_content_digest,
+            "context_view_id": context_view.context_view_id,
+            "evidence_bundle_id": evidence_bundle.evidence_bundle_id,
+            "requested_operation": requested_operation,
+            "prompt_digest": prompt_digest,
+        }
+    )
+    binding = DeterminationContextBinding(
+        determination_id=determination_id,
+        snapshot_receipt_id=snapshot.snapshot_receipt_id,
+        snapshot_content_digest=snapshot.snapshot_content_digest,
+        context_view_id=context_view.context_view_id,
+        evidence_bundle_id=evidence_bundle.evidence_bundle_id,
+        requested_operation=requested_operation,
+        prompt_digest=prompt_digest,
+    )
+    return FusionAssignmentGateDecision(
+        accepted=True,
+        status=FUSION_ASSIGNMENT_GATE_PASSED,
+        fusion_allowed=True,
+        assignment_allowed=require_assignment,
+        determination_binding=binding,
+        rejection_reasons=(),
+        source_receipt_digests=tuple(receipt.content_digest for receipt in snapshot.source_receipts),
+    )
+
+
+def _validate_binding_shapes(
+    *,
+    snapshot: OperationalContextSnapshot,
+    context_view: ContextView,
+    evidence_bundle: EvidenceBundle,
+    reasons: list[str],
+) -> None:
+    if context_view.snapshot_receipt_id != snapshot.snapshot_receipt_id:
+        reasons.append("context_view_snapshot_mismatch")
+    if context_view.snapshot_content_digest != snapshot.snapshot_content_digest:
+        reasons.append("context_view_content_mismatch")
+    if evidence_bundle.snapshot_receipt_id != snapshot.snapshot_receipt_id:
+        reasons.append("evidence_bundle_snapshot_mismatch")
+    if evidence_bundle.context_view_id != context_view.context_view_id:
+        reasons.append("evidence_bundle_context_view_mismatch")
+
+
+def _validate_source_receipts(receipts: Sequence[SourceReceipt], reasons: list[str]) -> None:
+    if not receipts:
+        reasons.append("missing_source_receipts")
+        return
+    for receipt in receipts:
+        if receipt.required and receipt.freshness != "FRESH":
+            reasons.append(f"required_source_not_fresh:{receipt.source}")
+        if receipt.required and receipt.rejection_reasons:
+            for reason in receipt.rejection_reasons:
+                reasons.append(f"{receipt.source}:{reason}")
+
+
+def _reject(
+    reasons: Sequence[str],
+    snapshot: OperationalContextSnapshot | None,
+) -> FusionAssignmentGateDecision:
+    return FusionAssignmentGateDecision(
+        accepted=False,
+        status=FUSION_ASSIGNMENT_GATE_REJECTED,
+        fusion_allowed=False,
+        assignment_allowed=False,
+        determination_binding=None,
+        rejection_reasons=tuple(dict.fromkeys(reasons)),
+        source_receipt_digests=tuple(
+            receipt.content_digest for receipt in snapshot.source_receipts
+        )
+        if snapshot
+        else (),
+    )
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def _digest(value: Mapping[str, Any]) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "FUSION_ASSIGNMENT_GATE_PASSED",
+    "FUSION_ASSIGNMENT_GATE_REJECTED",
+    "DeterminationContextBinding",
+    "FusionAssignmentGateDecision",
+    "evaluate_context_snapshot_fusion_assignment_gate",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_context_snapshot_fusion_assignment_gate.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_context_snapshot_fusion_assignment_gate.py
@@ -1,0 +1,255 @@
+"""Tests for RedDog context snapshot Fusion/assignment gate."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import replace
+from pathlib import Path
+
+from holo_index.freshness_receipt import CollectionFreshness, HoloIndexFreshnessReceipt
+from modules.communication.moltbot_bridge.src.reddog_context_snapshot_fusion_assignment_gate import (
+    FUSION_ASSIGNMENT_GATE_PASSED,
+    FUSION_ASSIGNMENT_GATE_REJECTED,
+    evaluate_context_snapshot_fusion_assignment_gate,
+)
+from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
+    build_evidence_bundle,
+    build_operational_context_snapshot,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_context_snapshot_fusion_assignment_gate.py"
+)
+NOW = "2026-07-14T00:00:00+00:00"
+HEAD = "9c31512a8b4d6e1f0a2b3c4d5e6f708192a3b4c5"
+REVISION = "sha256:work-state-revision"
+
+
+def _fresh_holo_receipt():
+    return HoloIndexFreshnessReceipt(
+        schema_version="holoindex_freshness_receipt.v1",
+        generated_at=NOW,
+        repo_root=str(REPO_ROOT),
+        repo_head_sha=HEAD,
+        ssd_path="E:/HoloIndex",
+        source="ci_targeted_reindex",
+        collections=[
+            CollectionFreshness(
+                name="navigation_work_ledger",
+                count=2,
+                status="indexed",
+                source="ci_targeted_reindex",
+                repo_head_sha=HEAD,
+                last_indexed_at=NOW,
+            )
+        ],
+    )
+
+
+def _snapshot_bundle():
+    result = build_operational_context_snapshot(
+        repo_state={
+            "head_sha": HEAD,
+            "dirty_paths": (),
+            "dirty_digest": "sha256:clean",
+            "worktree_digest": "sha256:worktrees",
+        },
+        work_state_snapshot={
+            "schema_version": "reddog_authoritative_work_state.v1",
+            "revision": REVISION,
+            "selected_slice": "REDDOG_CONTEXT_SNAPSHOT_FUSION_AND_ASSIGNMENT_GATE_PHASE1",
+            "refresh_receipt_id": "sha256:refresh",
+            "worker_claims": [{"claim_id": "claim-1", "status": "ACTIVE"}],
+            "wre_queue_items": [{"queue_item_id": "queue-1"}],
+        },
+        holoindex_receipt=_fresh_holo_receipt(),
+        changed_paths=["docs/0102_session_briefings/work_ledger.schema.json"],
+        breadcrumbs=[
+            {
+                "breadcrumb_id": "b1",
+                "continuity_id": "cont-1",
+                "timestamp": NOW,
+            }
+        ],
+        breadcrumb_scope="cont-1",
+        now_iso=NOW,
+    )
+    assert result.accepted is True
+    assert result.snapshot is not None and result.context_view is not None
+    bundle = build_evidence_bundle(
+        snapshot=result.snapshot,
+        context_view=result.context_view,
+        report_digests=["sha256:repo-audit"],
+    )
+    return result.snapshot, result.context_view, bundle
+
+
+def test_gate_accepts_exact_snapshot_context_and_evidence_binding() -> None:
+    snapshot, context_view, bundle = _snapshot_bundle()
+
+    decision = evaluate_context_snapshot_fusion_assignment_gate(
+        snapshot=snapshot,
+        context_view=context_view,
+        evidence_bundle=bundle,
+        current_repo_head_sha=HEAD,
+        current_work_state_revision=REVISION,
+        current_breadcrumb_high_watermark=snapshot.breadcrumbs_state["high_watermark"],
+        requested_operation="audit_and_assign",
+        prompt_text="audit current RedDog work state",
+        now_iso="2026-07-14T00:01:00+00:00",
+    )
+
+    assert decision.accepted is True
+    assert decision.status == FUSION_ASSIGNMENT_GATE_PASSED
+    assert decision.fusion_allowed is True
+    assert decision.assignment_allowed is True
+    assert decision.determination_binding is not None
+    assert decision.determination_binding.context_view_id == context_view.context_view_id
+    assert decision.determination_binding.evidence_bundle_id == bundle.evidence_bundle_id
+    assert decision.no_model_call_performed is True
+    assert decision.no_worker_spawn_performed is True
+
+
+def test_gate_rejects_before_fusion_when_snapshot_view_or_bundle_missing() -> None:
+    decision = evaluate_context_snapshot_fusion_assignment_gate(
+        snapshot=None,
+        context_view=None,
+        evidence_bundle=None,
+        current_repo_head_sha=HEAD,
+        current_work_state_revision=REVISION,
+        requested_operation="audit",
+    )
+
+    assert decision.accepted is False
+    assert decision.status == FUSION_ASSIGNMENT_GATE_REJECTED
+    assert decision.fusion_allowed is False
+    assert "missing_snapshot" in decision.rejection_reasons
+    assert "missing_context_view" in decision.rejection_reasons
+    assert "missing_evidence_bundle" in decision.rejection_reasons
+
+
+def test_gate_rejects_mismatched_context_view_and_evidence_bundle() -> None:
+    snapshot, context_view, bundle = _snapshot_bundle()
+    bad_view = replace(context_view, snapshot_receipt_id="sha256:wrong")
+    bad_bundle = replace(bundle, context_view_id="sha256:wrong-context")
+
+    decision = evaluate_context_snapshot_fusion_assignment_gate(
+        snapshot=snapshot,
+        context_view=bad_view,
+        evidence_bundle=bad_bundle,
+        current_repo_head_sha=HEAD,
+        current_work_state_revision=REVISION,
+        requested_operation="audit",
+        now_iso="2026-07-14T00:01:00+00:00",
+    )
+
+    assert decision.accepted is False
+    assert "context_view_snapshot_mismatch" in decision.rejection_reasons
+    assert "evidence_bundle_context_view_mismatch" in decision.rejection_reasons
+
+
+def test_gate_rejects_head_work_state_or_breadcrumb_change() -> None:
+    snapshot, context_view, bundle = _snapshot_bundle()
+
+    decision = evaluate_context_snapshot_fusion_assignment_gate(
+        snapshot=snapshot,
+        context_view=context_view,
+        evidence_bundle=bundle,
+        current_repo_head_sha="new-head",
+        current_work_state_revision="new-revision",
+        current_breadcrumb_high_watermark="new-watermark",
+        requested_operation="audit",
+        now_iso="2026-07-14T00:01:00+00:00",
+    )
+
+    assert decision.accepted is False
+    assert "repo_head_changed" in decision.rejection_reasons
+    assert "work_state_revision_changed" in decision.rejection_reasons
+    assert "breadcrumb_high_watermark_changed" in decision.rejection_reasons
+
+
+def test_gate_rejects_empty_evidence_bundle() -> None:
+    snapshot, context_view, bundle = _snapshot_bundle()
+    empty_bundle = replace(bundle, report_digests=(), external_research_receipts=())
+
+    decision = evaluate_context_snapshot_fusion_assignment_gate(
+        snapshot=snapshot,
+        context_view=context_view,
+        evidence_bundle=empty_bundle,
+        current_repo_head_sha=HEAD,
+        current_work_state_revision=REVISION,
+        current_breadcrumb_high_watermark=snapshot.breadcrumbs_state["high_watermark"],
+        requested_operation="audit",
+        now_iso="2026-07-14T00:01:00+00:00",
+    )
+
+    assert decision.accepted is False
+    assert "empty_evidence_bundle" in decision.rejection_reasons
+
+
+def test_gate_rejects_expired_snapshot() -> None:
+    snapshot, context_view, bundle = _snapshot_bundle()
+
+    decision = evaluate_context_snapshot_fusion_assignment_gate(
+        snapshot=snapshot,
+        context_view=context_view,
+        evidence_bundle=bundle,
+        current_repo_head_sha=HEAD,
+        current_work_state_revision=REVISION,
+        current_breadcrumb_high_watermark=snapshot.breadcrumbs_state["high_watermark"],
+        requested_operation="audit",
+        now_iso="2026-07-14T00:20:00+00:00",
+    )
+
+    assert decision.accepted is False
+    assert "snapshot_expired" in decision.rejection_reasons
+
+
+def test_gate_determination_id_is_deterministic_for_same_inputs() -> None:
+    snapshot, context_view, bundle = _snapshot_bundle()
+    kwargs = {
+        "snapshot": snapshot,
+        "context_view": context_view,
+        "evidence_bundle": bundle,
+        "current_repo_head_sha": HEAD,
+        "current_work_state_revision": REVISION,
+        "current_breadcrumb_high_watermark": snapshot.breadcrumbs_state["high_watermark"],
+        "requested_operation": "audit",
+        "prompt_text": "same prompt",
+        "now_iso": "2026-07-14T00:01:00+00:00",
+    }
+
+    first = evaluate_context_snapshot_fusion_assignment_gate(**kwargs)
+    second = evaluate_context_snapshot_fusion_assignment_gate(**kwargs)
+
+    assert first.determination_binding is not None
+    assert second.determination_binding is not None
+    assert first.determination_binding.determination_id == second.determination_binding.determination_id
+    assert first.to_dict() == second.to_dict()
+
+
+def test_gate_module_has_no_runtime_wiring_or_execution() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    forbidden_tokens = (
+        "openclaw_supervisor",
+        "hermes_job_executor",
+        "create_autonomous_task",
+        "subprocess",
+        "requests",
+        "execute_skill",
+        "callFusion",
+        "extension.js",
+    )
+    for token in forbidden_tokens:
+        assert token not in source
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            assert node.func.attr not in {"write_text", "mkdir", "commit"}


### PR DESCRIPTION
﻿## Summary

- Adds `reddog_context_snapshot_fusion_assignment_gate.py`, a pure fail-closed gate before Fusion or worker assignment.
- Consumes a snapshot, context view, evidence bundle, current repo/work-state/breadcrumb markers, and requested operation.
- Emits a deterministic `determination_id` binding that downstream model output/work orders must carry.
- Rejects missing/mismatched snapshot/view/evidence, stale repo HEAD, stale work-state revision, changed breadcrumbs, expired snapshots, and empty evidence bundles.

## WSP_97 Truth Boundary

OBSERVED:
- Fusion is allowed only when `snapshot_receipt_id`, `snapshot_content_digest`, `context_view_id`, and `evidence_bundle_id` agree.
- Assignment is allowed only when current repo HEAD, work-state revision, and breadcrumb high-watermark still match the snapshot.
- Determination binding is deterministic for identical inputs.

SPECIFIED_NOT_IMPLEMENTED:
- No generation-time wiring into RedDog output path.
- No model call.
- No worker spawn.
- No OpenClaw/Hermes enqueue or execution.
- No extension runtime wiring.

## Validation

- `pytest modules/communication/moltbot_bridge/tests/test_reddog_context_snapshot_fusion_assignment_gate.py` -> 8 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_context_snapshot_fusion_assignment_gate.py modules/communication/moltbot_bridge/tests/test_reddog_operational_context_snapshot.py` -> 19 passed
- `python -m py_compile modules/communication/moltbot_bridge/src/reddog_context_snapshot_fusion_assignment_gate.py modules/communication/moltbot_bridge/src/reddog_operational_context_snapshot.py` -> passed
- `git diff --check` -> clean (autocrlf informational warning only)

## HoloIndex Addendum

Read-only probe:
`python holo_index.py --search "RedDog context snapshot Fusion assignment gate determination binding evidence bundle" --limit 10`

Result surfaced adjacent context bundle, Fusion redaction, bootstrap-context, and operator-loop surfaces but not this new gate module. Recorded `HOLOINDEX_REDDOG_CONTEXT_SNAPSHOT_FUSION_ASSIGNMENT_GATE_INDEX_GAP_PHASE1`. No runtime re-index performed.
