### PR TITLE
feat(holoindex): add CI main freshness gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,54 @@ jobs:
         run: |
           ! git ls-files | grep "^\.env$" || (echo "ERROR: .env is tracked!" && exit 1)
 
+  holoindex_freshness:
+    runs-on: ubuntu-latest
+    env:
+      HOLOINDEX_CI_FRESHNESS_ENFORCED: ${{ vars.HOLOINDEX_CI_FRESHNESS_ENFORCED }}
+      HOLOINDEX_FRESHNESS_RECEIPT: ${{ vars.HOLOINDEX_FRESHNESS_RECEIPT }}
+      HOLOINDEX_SSD_PATH: ${{ vars.HOLOINDEX_SSD_PATH }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Determine changed paths
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git diff --name-only --diff-filter=ACMRT \
+              "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" \
+              > .holoindex_changed_paths
+          elif [ -n "${{ github.event.before }}" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            git diff --name-only --diff-filter=ACMRT \
+              "${{ github.event.before }}" "${{ github.sha }}" \
+              > .holoindex_changed_paths
+          else
+            git diff-tree --no-commit-id --name-only -r "${{ github.sha }}" \
+              > .holoindex_changed_paths
+          fi
+          cat .holoindex_changed_paths
+
+      - name: Check HoloIndex freshness receipt
+        shell: bash
+        run: |
+          set -euo pipefail
+          enforce_flag=""
+          if [ "${HOLOINDEX_CI_FRESHNESS_ENFORCED:-0}" = "1" ]; then
+            enforce_flag="--enforce-configured"
+          fi
+          python -m holo_index.ci_main_freshness_gate \
+            --changed-paths-file .holoindex_changed_paths \
+            --head-sha "${{ github.sha }}" \
+            --pretty \
+            ${enforce_flag}
+
   redteam_observation:
     # FOUNDUPS_AGENT_REDTEAM_CI_OBSERVATION_PHASE1
     #

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,32 @@
 # HoloIndex Package ModLog
 
+## [2026-07-14] HOLOINDEX_CI_MAIN_FRESHNESS_GATE_PHASE1
+
+**Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice
+**WSP**: 00, 15, 22, 50, 97
+
+- ADD `holo_index/ci_main_freshness_gate.py`: thin CI/main wrapper that
+  discovers changed paths with read-only `git diff --name-only` and delegates
+  freshness evaluation to the existing `ci_freshness_gate.check_ci_freshness`.
+- UPDATE `.github/workflows/ci.yml`: adds `holoindex_freshness` job. The job
+  reports HoloIndex freshness on PR/push and becomes fail-closed when
+  `HOLOINDEX_CI_FRESHNESS_ENFORCED=1` is configured with a mounted freshness
+  receipt.
+- TEST `tests/test_holoindex_ci_main_freshness_gate.py`: configured fresh pass,
+  missing receipt nonblocking/default mode, missing receipt enforced failure,
+  stale receipt failure, read-only diff discovery, SHA validation, CLI JSON, and
+  AST guards against re-index/store mutation.
+- TEST `tests/test_holoindex_ci_freshness_gate.py`: fixed an existing
+  env-dependent test so a local `E:/HoloIndex` receipt cannot alter the expected
+  not-configured result.
+- Boundary: no indexer invocation, no HoloIndex mutation, no WRE enqueue, no
+  RedDog runtime re-index, and no store writes. The gate consumes receipts only.
+- Read-only post-edit probe for
+  `HOLOINDEX_CI_MAIN_FRESHNESS_GATE_PHASE1 CI main freshness receipt changed paths GitHub workflow`
+  surfaced adjacent governance modules, not the new wrapper; recorded
+  `HOLOINDEX_CI_MAIN_FRESHNESS_GATE_INDEX_GAP_PHASE1`. No runtime re-index
+  performed.
+
 ## [2026-07-12] HOLOINDEX_INCREMENTAL_PER_FOUNDUP_INDEX_PHASE1
 
 **Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice

--- a/holo_index/ci_main_freshness_gate.py
+++ b/holo_index/ci_main_freshness_gate.py
@@ -1,0 +1,176 @@
+"""CI main-branch HoloIndex freshness gate.
+
+This wrapper discovers changed paths for CI and delegates freshness evaluation
+to ``holo_index.ci_freshness_gate``. It never runs an indexer and never writes
+the HoloIndex store.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from holo_index.ci_freshness_gate import (
+    EXIT_OK,
+    EXIT_STALE,
+    HoloIndexCIFreshnessGateResult,
+    check_ci_freshness,
+)
+from holo_index.freshness_receipt import freshness_receipt_path
+
+
+def discover_changed_paths(
+    *,
+    repo_root: str | Path,
+    base_sha: str,
+    head_sha: str,
+) -> list[str]:
+    """Read changed paths with a read-only git diff command."""
+
+    _validate_sha(base_sha)
+    _validate_sha(head_sha)
+    completed = subprocess.run(
+        (
+            "git",
+            "-C",
+            str(Path(repo_root)),
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMRT",
+            base_sha,
+            head_sha,
+        ),
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if completed.returncode != 0:
+        raise RuntimeError("changed_path_discovery_failed")
+    return _normalize_paths(completed.stdout.splitlines())
+
+
+def run_ci_main_freshness_gate(
+    *,
+    changed_paths: Iterable[str | Path],
+    expected_repo_head_sha: str | None,
+    receipt_path: str | Path | None = None,
+    ssd_path: str | Path | None = None,
+    enforce_configured: bool = False,
+) -> HoloIndexCIFreshnessGateResult:
+    """Evaluate HoloIndex freshness for changed paths in CI."""
+
+    resolved_receipt = _resolve_receipt_path(receipt_path=receipt_path, ssd_path=ssd_path)
+    return check_ci_freshness(
+        receipt_path=resolved_receipt,
+        changed_paths=changed_paths,
+        expected_repo_head_sha=expected_repo_head_sha,
+        allow_not_configured=not enforce_configured,
+    )
+
+
+def _resolve_receipt_path(
+    *,
+    receipt_path: str | Path | None,
+    ssd_path: str | Path | None,
+) -> str | None:
+    if receipt_path:
+        return str(receipt_path)
+    env_receipt = os.getenv("HOLOINDEX_FRESHNESS_RECEIPT", "").strip()
+    if env_receipt:
+        return env_receipt
+    if ssd_path is not None:
+        env_ssd = str(ssd_path).strip()
+    else:
+        env_ssd = os.getenv("HOLOINDEX_SSD_PATH", "").strip()
+    if not env_ssd:
+        return None
+    return str(freshness_receipt_path(env_ssd))
+
+
+def _normalize_paths(paths: Iterable[str | Path]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for path in paths:
+        text = str(path).replace("\\", "/").strip()
+        while text.startswith("./"):
+            text = text[2:]
+        if not text:
+            continue
+        key = text.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(text)
+    return out
+
+
+def _validate_sha(value: str) -> None:
+    if not value or any(char not in "0123456789abcdefABCDEF" for char in value):
+        raise ValueError("invalid_git_sha")
+
+
+def _read_paths_file(path: str | Path) -> list[str]:
+    return _normalize_paths(Path(path).read_text(encoding="utf-8").splitlines())
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run HoloIndex CI main freshness gate.")
+    parser.add_argument("--receipt", help="Path to holoindex_freshness_receipt.json.")
+    parser.add_argument("--ssd", help="HoloIndex SSD root. Defaults to HOLOINDEX_SSD_PATH when set.")
+    parser.add_argument("--changed-path", action="append", default=[], help="Changed path. May repeat.")
+    parser.add_argument("--changed-paths-file", help="File with one changed path per line.")
+    parser.add_argument("--repo-root", default=".", help="Repository root for git diff discovery.")
+    parser.add_argument("--base-sha", help="Base SHA for git diff discovery.")
+    parser.add_argument("--head-sha", help="Head SHA for git diff discovery and freshness check.")
+    parser.add_argument(
+        "--enforce-configured",
+        action="store_true",
+        help="Fail when the freshness receipt is missing/not mounted.",
+    )
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    changed_paths = list(args.changed_path or [])
+    if args.changed_paths_file:
+        changed_paths.extend(_read_paths_file(args.changed_paths_file))
+    if not changed_paths and args.base_sha and args.head_sha:
+        changed_paths = discover_changed_paths(
+            repo_root=args.repo_root,
+            base_sha=args.base_sha,
+            head_sha=args.head_sha,
+        )
+
+    result = run_ci_main_freshness_gate(
+        changed_paths=changed_paths,
+        expected_repo_head_sha=args.head_sha,
+        receipt_path=args.receipt,
+        ssd_path=args.ssd,
+        enforce_configured=args.enforce_configured,
+    )
+    payload = result.to_dict()
+    if args.pretty:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(result.to_json())
+    return EXIT_OK if result.ok else EXIT_STALE
+
+
+__all__ = [
+    "discover_changed_paths",
+    "main",
+    "run_ci_main_freshness_gate",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/holo_index/tests/test_holoindex_ci_freshness_gate.py
+++ b/holo_index/tests/test_holoindex_ci_freshness_gate.py
@@ -106,9 +106,11 @@ def test_ci_gate_fails_closed_when_receipt_path_missing() -> None:
     assert result.reasons == ["missing_freshness_receipt_path"]
 
 
-def test_ci_gate_can_report_not_configured_without_claiming_freshness() -> None:
+def test_ci_gate_can_report_not_configured_without_claiming_freshness(tmp_path: Path) -> None:
+    missing_receipt = tmp_path / "missing" / "holoindex_freshness_receipt.json"
+
     result = check_ci_freshness(
-        receipt_path="E:/HoloIndex/indexes/holoindex_freshness_receipt.json",
+        receipt_path=missing_receipt,
         changed_paths=["modules/foundups/agent/src/create_foundup_dryrun.py"],
         expected_repo_head_sha="abc123",
         allow_not_configured=True,

--- a/holo_index/tests/test_holoindex_ci_main_freshness_gate.py
+++ b/holo_index/tests/test_holoindex_ci_main_freshness_gate.py
@@ -1,0 +1,190 @@
+"""Tests for CI main HoloIndex freshness gate wrapper."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from holo_index.ci_freshness_gate import STATUS_FAIL, STATUS_NOT_CONFIGURED, STATUS_PASS
+from holo_index.ci_main_freshness_gate import (
+    discover_changed_paths,
+    main,
+    run_ci_main_freshness_gate,
+)
+from holo_index.freshness_receipt import (
+    CollectionFreshness,
+    HoloIndexFreshnessReceipt,
+    freshness_receipt_path,
+    write_freshness_receipt,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE = REPO_ROOT / "holo_index" / "ci_main_freshness_gate.py"
+HEAD = "9c31512a8b4d6e1f0a2b3c4d5e6f708192a3b4c5"
+BASE = "7994990bcf1e2d3c4b5a69788776655443322110"
+
+
+def _write_receipt(tmp_path: Path, *, head: str = HEAD) -> Path:
+    receipt = HoloIndexFreshnessReceipt(
+        schema_version="holoindex_freshness_receipt.v1",
+        generated_at="2026-07-14T00:00:00+00:00",
+        repo_root=str(REPO_ROOT),
+        repo_head_sha=head,
+        ssd_path=str(tmp_path),
+        source="ci_targeted_reindex",
+        collections=[
+            CollectionFreshness(
+                name="navigation_work_ledger",
+                count=2,
+                status="indexed",
+                source="ci_targeted_reindex",
+                repo_head_sha=head,
+                last_indexed_at="2026-07-14T00:00:00+00:00",
+            )
+        ],
+    )
+    path = freshness_receipt_path(tmp_path)
+    write_freshness_receipt(receipt, path)
+    return path
+
+
+def test_run_ci_main_freshness_gate_passes_with_fresh_receipt(tmp_path: Path) -> None:
+    receipt_path = _write_receipt(tmp_path)
+
+    result = run_ci_main_freshness_gate(
+        receipt_path=receipt_path,
+        changed_paths=["docs/0102_session_briefings/work_ledger.schema.json"],
+        expected_repo_head_sha=HEAD,
+        enforce_configured=True,
+    )
+
+    assert result.ok is True
+    assert result.status == STATUS_PASS
+    assert result.no_reindex_performed is True
+    assert result.no_holoindex_mutation_performed is True
+
+
+def test_missing_receipt_is_nonblocking_when_not_configured() -> None:
+    result = run_ci_main_freshness_gate(
+        receipt_path=None,
+        ssd_path="",
+        changed_paths=["docs/0102_session_briefings/work_ledger.schema.json"],
+        expected_repo_head_sha=HEAD,
+        enforce_configured=False,
+    )
+
+    assert result.ok is True
+    assert result.status == STATUS_NOT_CONFIGURED
+    assert result.configured is False
+
+
+def test_unconfigured_env_does_not_use_local_default_holoindex() -> None:
+    with patch.dict("os.environ", {"HOLOINDEX_FRESHNESS_RECEIPT": "", "HOLOINDEX_SSD_PATH": ""}, clear=False):
+        result = run_ci_main_freshness_gate(
+            receipt_path=None,
+            ssd_path=None,
+            changed_paths=["docs/0102_session_briefings/work_ledger.schema.json"],
+            expected_repo_head_sha=HEAD,
+            enforce_configured=False,
+        )
+
+    assert result.ok is True
+    assert result.status == STATUS_NOT_CONFIGURED
+    assert result.configured is False
+    assert result.receipt_path is None
+
+
+def test_missing_receipt_fails_when_enforced() -> None:
+    result = run_ci_main_freshness_gate(
+        receipt_path=None,
+        ssd_path="",
+        changed_paths=["docs/0102_session_briefings/work_ledger.schema.json"],
+        expected_repo_head_sha=HEAD,
+        enforce_configured=True,
+    )
+
+    assert result.ok is False
+    assert result.status == STATUS_FAIL
+    assert "missing_freshness_receipt_path" in result.reasons
+
+
+def test_stale_receipt_fails_when_head_changes(tmp_path: Path) -> None:
+    receipt_path = _write_receipt(tmp_path, head="0" * 40)
+
+    result = run_ci_main_freshness_gate(
+        receipt_path=receipt_path,
+        changed_paths=["docs/0102_session_briefings/work_ledger.schema.json"],
+        expected_repo_head_sha=HEAD,
+        enforce_configured=True,
+    )
+
+    assert result.ok is False
+    assert "stale_repo_head_sha" in result.reasons
+
+
+def test_discover_changed_paths_uses_readonly_git_diff() -> None:
+    fake = type("Completed", (), {"returncode": 0, "stdout": "a.py\n./a.py\ndocs/x.md\n"})()
+    with patch("holo_index.ci_main_freshness_gate.subprocess.run", return_value=fake) as mock_run:
+        paths = discover_changed_paths(repo_root=REPO_ROOT, base_sha=BASE, head_sha=HEAD)
+
+    assert paths == ["a.py", "docs/x.md"]
+    args = mock_run.call_args.args[0]
+    assert args[:3] == ("git", "-C", str(REPO_ROOT))
+    assert "diff" in args
+    assert "--name-only" in args
+
+
+def test_discover_changed_paths_rejects_non_sha_input() -> None:
+    with pytest.raises(ValueError, match="invalid_git_sha"):
+        discover_changed_paths(repo_root=REPO_ROOT, base_sha="main;rm -rf", head_sha=HEAD)
+
+
+def test_cli_outputs_json_and_exit_code(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    receipt_path = _write_receipt(tmp_path)
+
+    code = main(
+        [
+            "--receipt",
+            str(receipt_path),
+            "--head-sha",
+            HEAD,
+            "--changed-path",
+            "docs/0102_session_briefings/work_ledger.schema.json",
+            "--enforce-configured",
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == STATUS_PASS
+
+
+def test_module_does_not_reindex_or_mutate_holoindex() -> None:
+    source = MODULE.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    forbidden_tokens = (
+        "--index",
+        "write_freshness_receipt",
+        "build_freshness_receipt",
+        "_reset_collection",
+        "index_code_entries",
+        "index_wsp_entries",
+        "index_all",
+    )
+    for token in forbidden_tokens:
+        assert token not in source
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            assert node.func.attr not in {"write_text", "mkdir"}
+            if isinstance(node.func.value, ast.Name) and node.func.value.id in {
+                "collection",
+                "collections",
+                "index",
+                "store",
+            }:
+                assert node.func.attr not in {"add", "append", "extend", "insert", "pop", "remove", "clear"}


### PR DESCRIPTION
## Summary
- Adds a CI/main wrapper around the existing HoloIndex freshness gate.
- Adds a GitHub Actions job that discovers changed paths with read-only git diff and checks a mounted freshness receipt when configured.
- Keeps default CI nonblocking when no HoloIndex receipt/SSD path is configured; enforced mode is opt-in with HOLOINDEX_CI_FRESHNESS_ENFORCED=1.

## WSP_97 Evidence
- Tests: pytest holo_index\\tests\\test_holoindex_ci_main_freshness_gate.py holo_index\\tests\\test_holoindex_ci_freshness_gate.py holo_index\\tests\\test_holoindex_freshness_receipt.py -> 28 passed.
- Smoke: unconfigured env returns NOT_CONFIGURED ok=true with no reindex/mutation.
- py_compile: holo_index\\ci_main_freshness_gate.py and holo_index\\ci_freshness_gate.py pass.
- git diff --check clean.

## Truth Boundary
- NO_RUNTIME_REINDEX: pass.
- NO_HOLOINDEX_MUTATION: pass.
- NO_WRE_ENQUEUE: pass.
- NO_REDDOG_RUNTIME_WRITE: pass.
- RECEIPT_CONSUMPTION_ONLY: pass.

## HoloIndex
Read-only post-edit probe did not surface the new wrapper; recorded HOLOINDEX_CI_MAIN_FRESHNESS_GATE_INDEX_GAP_PHASE1. No runtime re-index performed.