### PR TITLE
feat(reddog): add read-only OpenClaw audit swarm runtime

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,30 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_OPENCLAW_READONLY_AUDIT_SWARM_RUNTIME_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_openclaw_readonly_audit_swarm_runtime.py`: deterministic
+  read-only audit swarm planner that consumes an accepted context snapshot
+  Fusion/assignment gate decision and emits five audit assignment packets
+  (`repo_code_audit`, `external_research_audit`, `runtime_freshness_audit`,
+  `skill_gap_audit`, and `security_governance_audit`).
+- Added `tests/test_reddog_openclaw_readonly_audit_swarm_runtime.py`:
+  accepted plan from exact snapshot/gate binding, rejected gate handling,
+  binding mismatch rejection, required-lane rejection, complete report bundle
+  acceptance, missing-report rejection, mutation/execution report rejection,
+  missing-evidence rejection, and AST no-runtime-wiring coverage.
+- Boundary: no model call, no worker spawn, no OpenClaw enqueue, no Hermes
+  dispatch, no shell command, no queue mutation, no repo mutation, no
+  HoloIndex re-index, and no extension runtime wiring. This slice creates
+  assignment packets and validates returned report metadata only.
+- HoloIndex read-only probe for
+  `REDDOG_OPENCLAW_READONLY_AUDIT_SWARM_RUNTIME_PHASE1 read-only audit swarm snapshot Fusion assignment gate`
+  surfaced adjacent fusion redaction, work-order policy, and capability-audit
+  surfaces but not the new runtime module. Recorded
+  `HOLOINDEX_REDDOG_OPENCLAW_READONLY_AUDIT_SWARM_RUNTIME_INDEX_GAP_PHASE1`;
+  no runtime re-index performed.
+
 ## 2026-07-14: REDDOG_CONTEXT_SNAPSHOT_FUSION_AND_ASSIGNMENT_GATE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_openclaw_readonly_audit_swarm_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_openclaw_readonly_audit_swarm_runtime.py
@@ -1,0 +1,525 @@
+"""RedDog OpenClaw read-only audit swarm runtime.
+
+This module turns an accepted context-snapshot Fusion/assignment gate decision
+into deterministic read-only audit assignments. It does not spawn workers, call
+models, enqueue OpenClaw, dispatch Hermes, execute shell commands, mutate work
+state, or write repository files.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping, Optional, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_context_snapshot_fusion_assignment_gate import (
+    FUSION_ASSIGNMENT_GATE_PASSED,
+    DeterminationContextBinding,
+    FusionAssignmentGateDecision,
+)
+from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
+    ContextView,
+    EvidenceBundle,
+    OperationalContextSnapshot,
+)
+
+
+READONLY_AUDIT_SWARM_PLANNED = "READONLY_AUDIT_SWARM_PLANNED"
+READONLY_AUDIT_SWARM_REJECTED = "READONLY_AUDIT_SWARM_REJECTED"
+READONLY_AUDIT_REPORTS_ACCEPTED = "READONLY_AUDIT_REPORTS_ACCEPTED"
+READONLY_AUDIT_REPORTS_REJECTED = "READONLY_AUDIT_REPORTS_REJECTED"
+
+DEFAULT_AUDIT_LANES = (
+    "repo_code_audit",
+    "external_research_audit",
+    "runtime_freshness_audit",
+    "skill_gap_audit",
+    "security_governance_audit",
+)
+
+LANE_REQUIRED_SOURCE = {
+    "repo_code_audit": "repo",
+    "external_research_audit": "holoindex",
+    "runtime_freshness_audit": "work_state",
+    "skill_gap_audit": "holoindex",
+    "security_governance_audit": "work_state",
+}
+
+FORBIDDEN_ACTIONS = (
+    "repo_write",
+    "shell_execute",
+    "git_push",
+    "git_commit",
+    "openclaw_enqueue",
+    "hermes_dispatch",
+    "holoindex_reindex",
+    "queue_mutation",
+    "worker_spawn",
+)
+
+MAX_ASSIGNMENT_TARGETS = 32
+MAX_REPORT_BYTES = 48_000
+
+
+@dataclass(frozen=True)
+class ReadOnlyAuditAssignment:
+    """One read-only worker assignment packet."""
+
+    assignment_id: str
+    lane_id: str
+    worker_role: str
+    snapshot_receipt_id: str
+    snapshot_content_digest: str
+    context_view_id: str
+    evidence_bundle_id: str
+    determination_id: str
+    required_source: str
+    allowed_read_targets: tuple[str, ...]
+    forbidden_actions: tuple[str, ...] = FORBIDDEN_ACTIONS
+    no_worker_spawn_performed: bool = True
+    no_execution_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_queue_mutation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ReadOnlyAuditSwarmReceipt:
+    """Receipt proving a read-only audit swarm was planned, not executed."""
+
+    swarm_id: str
+    status: str
+    snapshot_receipt_id: str
+    snapshot_content_digest: str
+    context_view_id: str
+    evidence_bundle_id: str
+    determination_id: str
+    requested_operation: str
+    assignment_ids: tuple[str, ...]
+    lanes: tuple[str, ...]
+    rejection_reasons: tuple[str, ...]
+    no_model_call_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_shell_command_executed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_queue_mutation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ReadOnlyAuditSwarmPlan:
+    """Planning result for the read-only audit swarm."""
+
+    accepted: bool
+    status: str
+    receipt: ReadOnlyAuditSwarmReceipt
+    assignments: tuple[ReadOnlyAuditAssignment, ...]
+    rejection_reasons: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "accepted": self.accepted,
+            "status": self.status,
+            "receipt": self.receipt.to_dict(),
+            "assignments": [assignment.to_dict() for assignment in self.assignments],
+            "rejection_reasons": list(self.rejection_reasons),
+        }
+
+
+@dataclass(frozen=True)
+class ReadOnlyAuditReportBundle:
+    """Verified shape of returned read-only audit reports."""
+
+    bundle_id: str
+    swarm_id: str
+    report_digests: tuple[str, ...]
+    lanes_reported: tuple[str, ...]
+    missing_lanes: tuple[str, ...]
+    rejection_reasons: tuple[str, ...]
+    no_report_execution_claimed: bool = True
+    no_report_repo_mutation_claimed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ReadOnlyAuditReportValidationResult:
+    """Validation result for returned read-only audit reports."""
+
+    accepted: bool
+    status: str
+    bundle: Optional[ReadOnlyAuditReportBundle]
+    rejection_reasons: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "accepted": self.accepted,
+            "status": self.status,
+            "bundle": self.bundle.to_dict() if self.bundle else None,
+            "rejection_reasons": list(self.rejection_reasons),
+        }
+
+
+def plan_reddog_openclaw_readonly_audit_swarm(
+    *,
+    snapshot: OperationalContextSnapshot | None,
+    context_view: ContextView | None,
+    evidence_bundle: EvidenceBundle | None,
+    gate_decision: FusionAssignmentGateDecision | None,
+    audit_lanes: Sequence[str] = DEFAULT_AUDIT_LANES,
+    allowed_read_targets: Sequence[str] = (),
+) -> ReadOnlyAuditSwarmPlan:
+    """Plan read-only audit assignments from an already accepted context gate."""
+
+    reasons: list[str] = []
+    if snapshot is None:
+        reasons.append("missing_snapshot")
+    if context_view is None:
+        reasons.append("missing_context_view")
+    if evidence_bundle is None:
+        reasons.append("missing_evidence_bundle")
+    if gate_decision is None:
+        reasons.append("missing_gate_decision")
+    binding = gate_decision.determination_binding if gate_decision else None
+    if gate_decision and (not gate_decision.accepted or gate_decision.status != FUSION_ASSIGNMENT_GATE_PASSED):
+        reasons.append("fusion_assignment_gate_not_passed")
+    if binding is None:
+        reasons.append("missing_determination_binding")
+
+    normalized_lanes = _normalize_lanes(audit_lanes)
+    if not normalized_lanes:
+        reasons.append("missing_audit_lanes")
+    unknown_lanes = tuple(lane for lane in normalized_lanes if lane not in LANE_REQUIRED_SOURCE)
+    for lane in unknown_lanes:
+        reasons.append(f"unknown_audit_lane:{lane}")
+    missing_default = tuple(lane for lane in DEFAULT_AUDIT_LANES if lane not in normalized_lanes)
+    for lane in missing_default:
+        reasons.append(f"missing_required_audit_lane:{lane}")
+
+    targets = _normalize_targets(allowed_read_targets)
+    if len(targets) > MAX_ASSIGNMENT_TARGETS:
+        reasons.append("too_many_allowed_read_targets")
+
+    if not reasons and snapshot and context_view and evidence_bundle and binding:
+        _validate_binding(
+            snapshot=snapshot,
+            context_view=context_view,
+            evidence_bundle=evidence_bundle,
+            binding=binding,
+            reasons=reasons,
+        )
+        fresh_sources = {
+            receipt.source
+            for receipt in snapshot.source_receipts
+            if receipt.required and receipt.freshness == "FRESH"
+        }
+        for lane in normalized_lanes:
+            required_source = LANE_REQUIRED_SOURCE[lane]
+            if required_source not in fresh_sources:
+                reasons.append(f"lane_required_source_not_fresh:{lane}:{required_source}")
+
+    reasons = _dedupe(reasons)
+    if reasons:
+        return _rejected_plan(
+            reasons=reasons,
+            snapshot=snapshot,
+            context_view=context_view,
+            evidence_bundle=evidence_bundle,
+            binding=binding,
+            lanes=normalized_lanes,
+        )
+
+    assert snapshot is not None
+    assert context_view is not None
+    assert evidence_bundle is not None
+    assert binding is not None
+    assignments = tuple(
+        _build_assignment(
+            lane_id=lane,
+            snapshot=snapshot,
+            context_view=context_view,
+            evidence_bundle=evidence_bundle,
+            binding=binding,
+            allowed_read_targets=targets,
+        )
+        for lane in normalized_lanes
+    )
+    swarm_id = _digest(
+        {
+            "snapshot_receipt_id": snapshot.snapshot_receipt_id,
+            "context_view_id": context_view.context_view_id,
+            "evidence_bundle_id": evidence_bundle.evidence_bundle_id,
+            "determination_id": binding.determination_id,
+            "assignment_ids": [assignment.assignment_id for assignment in assignments],
+        }
+    )
+    receipt = ReadOnlyAuditSwarmReceipt(
+        swarm_id=swarm_id,
+        status=READONLY_AUDIT_SWARM_PLANNED,
+        snapshot_receipt_id=snapshot.snapshot_receipt_id,
+        snapshot_content_digest=snapshot.snapshot_content_digest,
+        context_view_id=context_view.context_view_id,
+        evidence_bundle_id=evidence_bundle.evidence_bundle_id,
+        determination_id=binding.determination_id,
+        requested_operation=binding.requested_operation,
+        assignment_ids=tuple(assignment.assignment_id for assignment in assignments),
+        lanes=tuple(assignment.lane_id for assignment in assignments),
+        rejection_reasons=(),
+    )
+    return ReadOnlyAuditSwarmPlan(
+        accepted=True,
+        status=READONLY_AUDIT_SWARM_PLANNED,
+        receipt=receipt,
+        assignments=assignments,
+        rejection_reasons=(),
+    )
+
+
+def validate_reddog_openclaw_readonly_audit_reports(
+    *,
+    plan: ReadOnlyAuditSwarmPlan,
+    reports: Sequence[Mapping[str, Any]],
+) -> ReadOnlyAuditReportValidationResult:
+    """Validate returned audit report metadata without executing or trusting it."""
+
+    reasons: list[str] = []
+    if not plan.accepted:
+        reasons.append("swarm_plan_not_accepted")
+    report_by_assignment: dict[str, Mapping[str, Any]] = {}
+    for index, report in enumerate(reports):
+        if not isinstance(report, Mapping):
+            reasons.append(f"report_not_mapping:{index}")
+            continue
+        assignment_id = str(report.get("assignment_id") or "").strip()
+        if not assignment_id:
+            reasons.append(f"report_missing_assignment_id:{index}")
+            continue
+        if assignment_id in report_by_assignment:
+            reasons.append(f"duplicate_assignment_report:{assignment_id}")
+            continue
+        report_by_assignment[assignment_id] = report
+
+    report_digests: list[str] = []
+    lanes_reported: list[str] = []
+    missing_lanes: list[str] = []
+    for assignment in plan.assignments:
+        report = report_by_assignment.get(assignment.assignment_id)
+        if not report:
+            missing_lanes.append(assignment.lane_id)
+            reasons.append(f"missing_report_for_lane:{assignment.lane_id}")
+            continue
+        reasons.extend(_validate_report(assignment, report))
+        lanes_reported.append(assignment.lane_id)
+        report_digests.append(_digest(_report_digest_payload(report)))
+
+    reasons = _dedupe(reasons)
+    bundle = ReadOnlyAuditReportBundle(
+        bundle_id=_digest(
+            {
+                "swarm_id": plan.receipt.swarm_id,
+                "report_digests": sorted(report_digests),
+                "lanes_reported": sorted(lanes_reported),
+                "missing_lanes": sorted(missing_lanes),
+                "rejection_reasons": reasons,
+            }
+        ),
+        swarm_id=plan.receipt.swarm_id,
+        report_digests=tuple(sorted(report_digests)),
+        lanes_reported=tuple(sorted(lanes_reported)),
+        missing_lanes=tuple(sorted(missing_lanes)),
+        rejection_reasons=tuple(reasons),
+    )
+    return ReadOnlyAuditReportValidationResult(
+        accepted=not reasons,
+        status=READONLY_AUDIT_REPORTS_ACCEPTED if not reasons else READONLY_AUDIT_REPORTS_REJECTED,
+        bundle=bundle,
+        rejection_reasons=tuple(reasons),
+    )
+
+
+def _build_assignment(
+    *,
+    lane_id: str,
+    snapshot: OperationalContextSnapshot,
+    context_view: ContextView,
+    evidence_bundle: EvidenceBundle,
+    binding: DeterminationContextBinding,
+    allowed_read_targets: tuple[str, ...],
+) -> ReadOnlyAuditAssignment:
+    payload = {
+        "lane_id": lane_id,
+        "snapshot_receipt_id": snapshot.snapshot_receipt_id,
+        "snapshot_content_digest": snapshot.snapshot_content_digest,
+        "context_view_id": context_view.context_view_id,
+        "evidence_bundle_id": evidence_bundle.evidence_bundle_id,
+        "determination_id": binding.determination_id,
+        "required_source": LANE_REQUIRED_SOURCE[lane_id],
+        "allowed_read_targets": allowed_read_targets,
+    }
+    return ReadOnlyAuditAssignment(
+        assignment_id="readonly_audit_" + _digest(payload).removeprefix("sha256:")[:16],
+        lane_id=lane_id,
+        worker_role=f"readonly_{lane_id}",
+        snapshot_receipt_id=snapshot.snapshot_receipt_id,
+        snapshot_content_digest=snapshot.snapshot_content_digest,
+        context_view_id=context_view.context_view_id,
+        evidence_bundle_id=evidence_bundle.evidence_bundle_id,
+        determination_id=binding.determination_id,
+        required_source=LANE_REQUIRED_SOURCE[lane_id],
+        allowed_read_targets=allowed_read_targets,
+    )
+
+
+def _rejected_plan(
+    *,
+    reasons: Sequence[str],
+    snapshot: OperationalContextSnapshot | None,
+    context_view: ContextView | None,
+    evidence_bundle: EvidenceBundle | None,
+    binding: DeterminationContextBinding | None,
+    lanes: Sequence[str],
+) -> ReadOnlyAuditSwarmPlan:
+    receipt = ReadOnlyAuditSwarmReceipt(
+        swarm_id=_digest(
+            {
+                "status": READONLY_AUDIT_SWARM_REJECTED,
+                "snapshot_receipt_id": snapshot.snapshot_receipt_id if snapshot else "",
+                "context_view_id": context_view.context_view_id if context_view else "",
+                "evidence_bundle_id": evidence_bundle.evidence_bundle_id if evidence_bundle else "",
+                "determination_id": binding.determination_id if binding else "",
+                "lanes": list(lanes),
+                "rejection_reasons": list(reasons),
+            }
+        ),
+        status=READONLY_AUDIT_SWARM_REJECTED,
+        snapshot_receipt_id=snapshot.snapshot_receipt_id if snapshot else "",
+        snapshot_content_digest=snapshot.snapshot_content_digest if snapshot else "",
+        context_view_id=context_view.context_view_id if context_view else "",
+        evidence_bundle_id=evidence_bundle.evidence_bundle_id if evidence_bundle else "",
+        determination_id=binding.determination_id if binding else "",
+        requested_operation=binding.requested_operation if binding else "",
+        assignment_ids=(),
+        lanes=tuple(lanes),
+        rejection_reasons=tuple(reasons),
+    )
+    return ReadOnlyAuditSwarmPlan(
+        accepted=False,
+        status=READONLY_AUDIT_SWARM_REJECTED,
+        receipt=receipt,
+        assignments=(),
+        rejection_reasons=tuple(reasons),
+    )
+
+
+def _validate_binding(
+    *,
+    snapshot: OperationalContextSnapshot,
+    context_view: ContextView,
+    evidence_bundle: EvidenceBundle,
+    binding: DeterminationContextBinding,
+    reasons: list[str],
+) -> None:
+    if binding.snapshot_receipt_id != snapshot.snapshot_receipt_id:
+        reasons.append("binding_snapshot_mismatch")
+    if binding.snapshot_content_digest != snapshot.snapshot_content_digest:
+        reasons.append("binding_snapshot_content_mismatch")
+    if binding.context_view_id != context_view.context_view_id:
+        reasons.append("binding_context_view_mismatch")
+    if binding.evidence_bundle_id != evidence_bundle.evidence_bundle_id:
+        reasons.append("binding_evidence_bundle_mismatch")
+    if context_view.snapshot_receipt_id != snapshot.snapshot_receipt_id:
+        reasons.append("context_view_snapshot_mismatch")
+    if evidence_bundle.snapshot_receipt_id != snapshot.snapshot_receipt_id:
+        reasons.append("evidence_bundle_snapshot_mismatch")
+    if evidence_bundle.context_view_id != context_view.context_view_id:
+        reasons.append("evidence_bundle_context_view_mismatch")
+
+
+def _validate_report(assignment: ReadOnlyAuditAssignment, report: Mapping[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    if str(report.get("lane_id") or "") != assignment.lane_id:
+        reasons.append(f"report_lane_mismatch:{assignment.lane_id}")
+    if str(report.get("snapshot_receipt_id") or "") != assignment.snapshot_receipt_id:
+        reasons.append(f"report_snapshot_mismatch:{assignment.lane_id}")
+    if report.get("repo_mutation_performed") is True:
+        reasons.append(f"report_claims_repo_mutation:{assignment.lane_id}")
+    if report.get("execution_performed") is True:
+        reasons.append(f"report_claims_execution:{assignment.lane_id}")
+    if report.get("openclaw_enqueue_performed") is True:
+        reasons.append(f"report_claims_openclaw_enqueue:{assignment.lane_id}")
+    evidence_refs = report.get("evidence_refs") or ()
+    if isinstance(evidence_refs, str) or not isinstance(evidence_refs, Sequence) or not evidence_refs:
+        reasons.append(f"report_missing_evidence_refs:{assignment.lane_id}")
+    report_text = str(report.get("summary") or "")
+    if len(report_text.encode("utf-8")) > MAX_REPORT_BYTES:
+        reasons.append(f"report_too_large:{assignment.lane_id}")
+    return reasons
+
+
+def _report_digest_payload(report: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "assignment_id": str(report.get("assignment_id") or ""),
+        "lane_id": str(report.get("lane_id") or ""),
+        "snapshot_receipt_id": str(report.get("snapshot_receipt_id") or ""),
+        "evidence_refs": tuple(str(ref) for ref in (report.get("evidence_refs") or ())),
+        "summary_digest": _digest(str(report.get("summary") or "")),
+    }
+
+
+def _normalize_lanes(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(_dedupe(str(value or "").strip().lower() for value in values if str(value or "").strip()))
+
+
+def _normalize_targets(values: Sequence[str]) -> tuple[str, ...]:
+    targets = []
+    for value in values:
+        text = str(value or "").replace("\\", "/").strip()
+        if not text or text.startswith("/") or text.startswith("../") or "/../" in text:
+            continue
+        targets.append(text)
+    return tuple(_dedupe(targets))
+
+
+def _dedupe(values: Sequence[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        text = str(value or "").strip()
+        if text and text not in seen:
+            seen.add(text)
+            ordered.append(text)
+    return tuple(ordered)
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def _digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "DEFAULT_AUDIT_LANES",
+    "FORBIDDEN_ACTIONS",
+    "READONLY_AUDIT_REPORTS_ACCEPTED",
+    "READONLY_AUDIT_REPORTS_REJECTED",
+    "READONLY_AUDIT_SWARM_PLANNED",
+    "READONLY_AUDIT_SWARM_REJECTED",
+    "ReadOnlyAuditAssignment",
+    "ReadOnlyAuditReportBundle",
+    "ReadOnlyAuditReportValidationResult",
+    "ReadOnlyAuditSwarmPlan",
+    "ReadOnlyAuditSwarmReceipt",
+    "plan_reddog_openclaw_readonly_audit_swarm",
+    "validate_reddog_openclaw_readonly_audit_reports",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_runtime.py
@@ -1,0 +1,310 @@
+"""Tests for REDDOG_OPENCLAW_READONLY_AUDIT_SWARM_RUNTIME_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import replace
+from pathlib import Path
+
+from holo_index.freshness_receipt import CollectionFreshness, HoloIndexFreshnessReceipt
+from modules.communication.moltbot_bridge.src.reddog_context_snapshot_fusion_assignment_gate import (
+    evaluate_context_snapshot_fusion_assignment_gate,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_runtime import (
+    DEFAULT_AUDIT_LANES,
+    FORBIDDEN_ACTIONS,
+    READONLY_AUDIT_REPORTS_ACCEPTED,
+    READONLY_AUDIT_REPORTS_REJECTED,
+    READONLY_AUDIT_SWARM_PLANNED,
+    READONLY_AUDIT_SWARM_REJECTED,
+    plan_reddog_openclaw_readonly_audit_swarm,
+    validate_reddog_openclaw_readonly_audit_reports,
+)
+from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
+    build_evidence_bundle,
+    build_operational_context_snapshot,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_openclaw_readonly_audit_swarm_runtime.py"
+)
+NOW = "2026-07-14T00:00:00+00:00"
+HEAD = "a764551a89068f57affff47350c5537d849a4564"
+REVISION = "sha256:work-state-refresh"
+
+
+def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
+    return HoloIndexFreshnessReceipt(
+        schema_version="holoindex_freshness_receipt.v1",
+        generated_at=NOW,
+        repo_root=str(REPO_ROOT),
+        repo_head_sha=HEAD,
+        ssd_path="E:/HoloIndex",
+        source="ci_targeted_reindex",
+        collections=[
+            CollectionFreshness(
+                name="navigation_work_ledger",
+                count=2,
+                status="indexed",
+                source="ci_targeted_reindex",
+                repo_head_sha=HEAD,
+                last_indexed_at=NOW,
+            ),
+            CollectionFreshness(
+                name="navigation_symbols",
+                count=8,
+                status="indexed",
+                source="ci_targeted_reindex",
+                repo_head_sha=HEAD,
+                last_indexed_at=NOW,
+            ),
+        ],
+    )
+
+
+def _accepted_gate_bundle():
+    snapshot_result = build_operational_context_snapshot(
+        repo_state={
+            "head_sha": HEAD,
+            "dirty_paths": (),
+            "dirty_digest": "sha256:clean",
+            "worktree_digest": "sha256:worktrees",
+        },
+        work_state_snapshot={
+            "schema_version": "reddog_authoritative_work_state.v1",
+            "revision": REVISION,
+            "selected_slice": "REDDOG_OPENCLAW_READONLY_AUDIT_SWARM_RUNTIME_PHASE1",
+            "refresh_receipt_id": "sha256:refresh",
+            "worker_claims": [{"claim_id": "claim-1", "status": "ACTIVE"}],
+            "wre_queue_items": [{"queue_item_id": "queue-1"}],
+        },
+        holoindex_receipt=_fresh_holo_receipt(),
+        changed_paths=[
+            "docs/0102_session_briefings/work_ledger.schema.json",
+            "modules/communication/moltbot_bridge/src/reddog_openclaw_readonly_audit_swarm_runtime.py",
+        ],
+        breadcrumbs=[
+            {
+                "breadcrumb_id": "b1",
+                "continuity_id": "cont-1",
+                "timestamp": NOW,
+            }
+        ],
+        breadcrumb_scope="cont-1",
+        now_iso=NOW,
+    )
+    assert snapshot_result.accepted is True
+    assert snapshot_result.snapshot is not None
+    assert snapshot_result.context_view is not None
+    evidence_bundle = build_evidence_bundle(
+        snapshot=snapshot_result.snapshot,
+        context_view=snapshot_result.context_view,
+        report_digests=["sha256:repo-audit", "sha256:security-audit"],
+    )
+    gate = evaluate_context_snapshot_fusion_assignment_gate(
+        snapshot=snapshot_result.snapshot,
+        context_view=snapshot_result.context_view,
+        evidence_bundle=evidence_bundle,
+        current_repo_head_sha=HEAD,
+        current_work_state_revision=REVISION,
+        current_breadcrumb_high_watermark=snapshot_result.snapshot.breadcrumbs_state["high_watermark"],
+        requested_operation="readonly_audit_swarm",
+        prompt_text="audit current RedDog operational loop",
+        now_iso="2026-07-14T00:01:00+00:00",
+    )
+    assert gate.accepted is True
+    return snapshot_result.snapshot, snapshot_result.context_view, evidence_bundle, gate
+
+
+def _valid_plan():
+    snapshot, context_view, evidence_bundle, gate = _accepted_gate_bundle()
+    plan = plan_reddog_openclaw_readonly_audit_swarm(
+        snapshot=snapshot,
+        context_view=context_view,
+        evidence_bundle=evidence_bundle,
+        gate_decision=gate,
+        allowed_read_targets=[
+            "docs/0102_session_briefings/work_ledger.schema.json",
+            "modules/communication/moltbot_bridge/src/reddog_operational_context_snapshot.py",
+        ],
+    )
+    return snapshot, context_view, evidence_bundle, gate, plan
+
+
+def _reports_for_plan(plan):
+    return [
+        {
+            "assignment_id": assignment.assignment_id,
+            "lane_id": assignment.lane_id,
+            "snapshot_receipt_id": assignment.snapshot_receipt_id,
+            "summary": f"{assignment.lane_id} report: WSP_97 evidence retained.",
+            "evidence_refs": [f"assignment:{assignment.assignment_id}", "snapshot:bound"],
+            "repo_mutation_performed": False,
+            "execution_performed": False,
+            "openclaw_enqueue_performed": False,
+        }
+        for assignment in plan.assignments
+    ]
+
+
+def test_plans_default_readonly_audit_swarm_from_accepted_context_gate() -> None:
+    _, _, _, _, plan = _valid_plan()
+
+    assert plan.accepted is True
+    assert plan.status == READONLY_AUDIT_SWARM_PLANNED
+    assert plan.receipt.status == READONLY_AUDIT_SWARM_PLANNED
+    assert tuple(assignment.lane_id for assignment in plan.assignments) == DEFAULT_AUDIT_LANES
+    assert len(plan.assignments) == 5
+    assert plan.receipt.no_worker_spawn_performed is True
+    assert plan.receipt.no_openclaw_enqueue_performed is True
+    assert plan.receipt.no_hermes_dispatch_performed is True
+    assert plan.receipt.no_shell_command_executed is True
+    assert plan.receipt.no_repo_mutation_performed is True
+    assert plan.receipt.no_holoindex_reindex_performed is True
+    for assignment in plan.assignments:
+        assert assignment.forbidden_actions == FORBIDDEN_ACTIONS
+        assert assignment.no_worker_spawn_performed is True
+        assert assignment.no_execution_performed is True
+        assert assignment.snapshot_receipt_id == plan.receipt.snapshot_receipt_id
+
+
+def test_rejects_when_fusion_assignment_gate_rejected() -> None:
+    snapshot, context_view, evidence_bundle, gate = _accepted_gate_bundle()
+    rejected_gate = replace(gate, accepted=False, status="FUSION_ASSIGNMENT_GATE_REJECTED")
+
+    plan = plan_reddog_openclaw_readonly_audit_swarm(
+        snapshot=snapshot,
+        context_view=context_view,
+        evidence_bundle=evidence_bundle,
+        gate_decision=rejected_gate,
+    )
+
+    assert plan.accepted is False
+    assert plan.status == READONLY_AUDIT_SWARM_REJECTED
+    assert "fusion_assignment_gate_not_passed" in plan.rejection_reasons
+    assert plan.assignments == ()
+
+
+def test_rejects_binding_mismatch_before_assignment_packets() -> None:
+    snapshot, context_view, evidence_bundle, gate = _accepted_gate_bundle()
+    bad_binding = replace(gate.determination_binding, context_view_id="sha256:wrong")
+    bad_gate = replace(gate, determination_binding=bad_binding)
+
+    plan = plan_reddog_openclaw_readonly_audit_swarm(
+        snapshot=snapshot,
+        context_view=context_view,
+        evidence_bundle=evidence_bundle,
+        gate_decision=bad_gate,
+    )
+
+    assert plan.accepted is False
+    assert "binding_context_view_mismatch" in plan.rejection_reasons
+    assert plan.assignments == ()
+
+
+def test_rejects_missing_required_lane() -> None:
+    snapshot, context_view, evidence_bundle, gate = _accepted_gate_bundle()
+
+    plan = plan_reddog_openclaw_readonly_audit_swarm(
+        snapshot=snapshot,
+        context_view=context_view,
+        evidence_bundle=evidence_bundle,
+        gate_decision=gate,
+        audit_lanes=("repo_code_audit", "security_governance_audit"),
+    )
+
+    assert plan.accepted is False
+    assert "missing_required_audit_lane:external_research_audit" in plan.rejection_reasons
+    assert "missing_required_audit_lane:runtime_freshness_audit" in plan.rejection_reasons
+    assert "missing_required_audit_lane:skill_gap_audit" in plan.rejection_reasons
+
+
+def test_report_validation_accepts_complete_readonly_reports() -> None:
+    _, _, _, _, plan = _valid_plan()
+
+    result = validate_reddog_openclaw_readonly_audit_reports(
+        plan=plan,
+        reports=_reports_for_plan(plan),
+    )
+
+    assert result.accepted is True
+    assert result.status == READONLY_AUDIT_REPORTS_ACCEPTED
+    assert result.bundle is not None
+    assert result.bundle.swarm_id == plan.receipt.swarm_id
+    assert result.bundle.missing_lanes == ()
+    assert tuple(sorted(result.bundle.lanes_reported)) == tuple(sorted(DEFAULT_AUDIT_LANES))
+
+
+def test_report_validation_rejects_missing_report() -> None:
+    _, _, _, _, plan = _valid_plan()
+    reports = _reports_for_plan(plan)[:-1]
+
+    result = validate_reddog_openclaw_readonly_audit_reports(plan=plan, reports=reports)
+
+    assert result.accepted is False
+    assert result.status == READONLY_AUDIT_REPORTS_REJECTED
+    assert "missing_report_for_lane:security_governance_audit" in result.rejection_reasons
+    assert result.bundle is not None
+    assert result.bundle.missing_lanes == ("security_governance_audit",)
+
+
+def test_report_validation_rejects_mutation_or_execution_claims() -> None:
+    _, _, _, _, plan = _valid_plan()
+    reports = _reports_for_plan(plan)
+    reports[0]["repo_mutation_performed"] = True
+    reports[1]["execution_performed"] = True
+    reports[2]["openclaw_enqueue_performed"] = True
+
+    result = validate_reddog_openclaw_readonly_audit_reports(plan=plan, reports=reports)
+
+    assert result.accepted is False
+    assert "report_claims_repo_mutation:repo_code_audit" in result.rejection_reasons
+    assert "report_claims_execution:external_research_audit" in result.rejection_reasons
+    assert "report_claims_openclaw_enqueue:runtime_freshness_audit" in result.rejection_reasons
+
+
+def test_report_validation_rejects_missing_evidence_refs() -> None:
+    _, _, _, _, plan = _valid_plan()
+    reports = _reports_for_plan(plan)
+    reports[0]["evidence_refs"] = []
+
+    result = validate_reddog_openclaw_readonly_audit_reports(plan=plan, reports=reports)
+
+    assert result.accepted is False
+    assert "report_missing_evidence_refs:repo_code_audit" in result.rejection_reasons
+
+
+def test_module_ast_has_no_execution_or_runtime_wiring() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    forbidden_tokens = (
+        "openclaw_supervisor",
+        "hermes_job_executor",
+        "subprocess",
+        "requests",
+        "create_autonomous_task",
+        "execute_skill",
+        "callFusion",
+        "extension.js",
+        "git push",
+        "gh pr",
+        "write_text",
+        "mkdir",
+    )
+    for token in forbidden_tokens:
+        assert token not in source
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".")[0] not in {"subprocess", "requests", "os", "shutil"}
+        if isinstance(node, ast.ImportFrom):
+            assert (node.module or "").split(".")[0] not in {"subprocess", "requests", "os", "shutil"}
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            assert node.func.attr not in {"write_text", "mkdir", "commit"}


### PR DESCRIPTION
## Summary
- Adds REDDOG_OPENCLAW_READONLY_AUDIT_SWARM_RUNTIME_PHASE1.
- Produces deterministic read-only audit assignment packets from an accepted operational snapshot + Fusion/assignment gate binding.
- Validates returned report metadata without trusting reports as execution authority.

## WSP_97 Evidence
- Tests: pytest modules\\communication\\moltbot_bridge\\tests\\test_reddog_openclaw_readonly_audit_swarm_runtime.py modules\\communication\\moltbot_bridge\\tests\\test_reddog_context_snapshot_fusion_assignment_gate.py modules\\communication\\moltbot_bridge\\tests\\test_reddog_operational_context_snapshot.py -> 28 passed.
- py_compile: new runtime plus context gate and snapshot modules pass.
- git diff --check clean.
- HoloIndex read-only probe recorded HOLOINDEX_REDDOG_OPENCLAW_READONLY_AUDIT_SWARM_RUNTIME_INDEX_GAP_PHASE1; no runtime re-index performed.

## Truth Boundary
- NO_MODEL_CALL: pass.
- NO_WORKER_SPAWN: pass.
- NO_OPENCLAW_ENQUEUE: pass.
- NO_HERMES_DISPATCH: pass.
- NO_SHELL_COMMAND: pass.
- NO_REPO_MUTATION: pass.
- NO_HOLOINDEX_REINDEX: pass.
- NO_QUEUE_MUTATION: pass.

## Residual SPECIFIED_NOT_IMPLEMENTED
- Actual worker spawning/claiming remains downstream.
- OpenClaw live enqueue remains downstream and signed-gated.
- Hermes/WRE code execution remains downstream and signed-gated.