### PR TITLE
feat(reddog): add main readonly operational bootstrap

### DIFF
--- a/main.py
+++ b/main.py
@@ -1173,6 +1173,67 @@ def run_git_main_merge_sentinel_preflight(repo_root: Path) -> bool:
         return True
 
 
+def run_reddog_readonly_operational_bootstrap_preflight(repo_root: Path) -> bool:
+    """
+    Run RedDog's read-only operational bootstrap before DAE autostart.
+
+    This binds current work-state and HoloIndex freshness receipts to a
+    read-only OpenClaw audit-swarm plan. It never spawns workers or enqueues
+    OpenClaw. Missing receipts are warning-only by default so the menu still
+    loads while the authoritative runtime wiring is incomplete.
+
+    Env:
+        REDDOG_READONLY_OPERATIONAL_BOOTSTRAP=1           Enable check (default ON)
+        REDDOG_READONLY_OPERATIONAL_BOOTSTRAP_ENFORCED=0  Block startup if not ready
+        REDDOG_AUTHORITATIVE_WORK_STATE_PATH              Existing work-state JSON
+        HOLOINDEX_FRESHNESS_RECEIPT                       Existing HoloIndex receipt
+        HOLOINDEX_SSD_PATH                                Derive receipt path if set
+    """
+
+    if os.getenv("REDDOG_READONLY_OPERATIONAL_BOOTSTRAP", "1") == "0":
+        logger.info("[REDDOG-BOOTSTRAP] Startup preflight disabled")
+        return True
+
+    enforced = os.getenv("REDDOG_READONLY_OPERATIONAL_BOOTSTRAP_ENFORCED", "0") != "0"
+
+    try:
+        from modules.communication.moltbot_bridge.src.reddog_main_readonly_operational_bootstrap import (
+            run_reddog_main_readonly_operational_bootstrap,
+        )
+
+        result = run_reddog_main_readonly_operational_bootstrap(
+            repo_root=repo_root,
+            work_state_path=os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
+            holoindex_receipt_path=os.getenv("HOLOINDEX_FRESHNESS_RECEIPT", ""),
+            holoindex_ssd_path=os.getenv("HOLOINDEX_SSD_PATH", ""),
+        )
+    except Exception as exc:
+        logger.error(f"[REDDOG-BOOTSTRAP] Startup preflight failed: {exc}")
+        if enforced:
+            print(f"[REDDOG-BOOTSTRAP] preflight=FAIL error={type(exc).__name__}")
+            return False
+        print(f"[REDDOG-BOOTSTRAP] preflight=WARN error={type(exc).__name__}")
+        return True
+
+    status = "PASS" if result.ready else "WARN"
+    reasons = ",".join(result.rejection_reasons) if result.rejection_reasons else "(none)"
+    print(
+        f"[REDDOG-BOOTSTRAP] preflight={status} status={result.status} "
+        f"assignments={result.assignment_count} reasons={reasons}"
+    )
+    if result.ready:
+        print(
+            f"[REDDOG-BOOTSTRAP] snapshot={result.snapshot_receipt_id} "
+            f"swarm={result.swarm_id}"
+        )
+        return True
+
+    if enforced:
+        print("[REDDOG-BOOTSTRAP] Startup blocked by REDDOG_READONLY_OPERATIONAL_BOOTSTRAP_ENFORCED=1")
+        return False
+    return True
+
+
 def bootstrap_runtime_dae_launches() -> None:
     """Register broker-managed DAE entrypoints for an already running system."""
     daemon = get_central_daemon()
@@ -1344,6 +1405,8 @@ def main():
     if not run_wsp_framework_preflight(repo_root, overseer=overseer):
         return
     if not run_git_main_merge_sentinel_preflight(repo_root):
+        return
+    if not run_reddog_readonly_operational_bootstrap_preflight(repo_root):
         return
 
     bootstrap_runtime_dae_launches()

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,30 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_MAIN_READONLY_OPERATIONAL_BOOTSTRAP_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_main_readonly_operational_bootstrap.py`: read-only
+  startup composition layer for RedDog's operational context snapshot,
+  Fusion/assignment gate, and OpenClaw read-only audit swarm planner.
+- Wired `main.py` with
+  `run_reddog_readonly_operational_bootstrap_preflight()` before runtime DAE
+  autostart. The hook is enabled by default but warning-only; it blocks startup
+  only when `REDDOG_READONLY_OPERATIONAL_BOOTSTRAP_ENFORCED=1`.
+- Added `tests/test_reddog_main_readonly_operational_bootstrap.py`: fresh
+  context acceptance, missing work-state/HoloIndex receipt warning behavior,
+  stale HoloIndex rejection, file-based receipt loading, read-target
+  normalization, main preflight nonblocking/enforced behavior, ready-result
+  reporting, and AST no-runtime-mutation coverage.
+- Boundary: no model call, no worker spawn, no OpenClaw enqueue, no Hermes
+  dispatch, no repo mutation, no queue mutation, and no HoloIndex re-index.
+  This slice plans read-only audit assignments only; it does not execute them.
+- HoloIndex read-only probe for `REDDOG_MAIN_READONLY_OPERATIONAL_BOOTSTRAP_PHASE1
+  main.py read-only RedDog operational bootstrap audit swarm` surfaced
+  unrelated web assets and unknown locations, not the new bootstrap module.
+  Recorded `HOLOINDEX_REDDOG_MAIN_READONLY_OPERATIONAL_BOOTSTRAP_INDEX_GAP_PHASE1`;
+  no runtime re-index performed.
+
 ## 2026-07-14: REDDOG_OPENCLAW_READONLY_AUDIT_SWARM_RUNTIME_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
@@ -1,0 +1,302 @@
+"""RedDog main read-only operational bootstrap.
+
+This module composes the already-built RedDog context snapshot, Fusion
+assignment gate, and OpenClaw read-only audit swarm planner into a startup
+check for ``main.py``. It plans only; it does not call models, spawn workers,
+enqueue OpenClaw, dispatch Hermes, mutate queues, write files, or re-index
+HoloIndex.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence
+
+from holo_index.freshness_receipt import HoloIndexFreshnessReceipt, freshness_receipt_path
+from modules.communication.moltbot_bridge.src.reddog_context_snapshot_fusion_assignment_gate import (
+    FusionAssignmentGateDecision,
+    evaluate_context_snapshot_fusion_assignment_gate,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_runtime import (
+    DEFAULT_AUDIT_LANES,
+    ReadOnlyAuditSwarmPlan,
+    plan_reddog_openclaw_readonly_audit_swarm,
+)
+from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
+    EvidenceBundle,
+    OperationalContextSnapshot,
+    build_evidence_bundle,
+    build_operational_context_snapshot,
+    load_authoritative_work_state,
+    load_existing_holoindex_receipt,
+    observe_repo_state,
+)
+
+
+REDDOG_MAIN_BOOTSTRAP_READY = "REDDOG_MAIN_BOOTSTRAP_READY"
+REDDOG_MAIN_BOOTSTRAP_NOT_READY = "REDDOG_MAIN_BOOTSTRAP_NOT_READY"
+REDDOG_MAIN_BOOTSTRAP_DISABLED = "REDDOG_MAIN_BOOTSTRAP_DISABLED"
+
+DEFAULT_BOOTSTRAP_CHANGED_PATHS = (
+    "docs/0102_session_briefings/ACTIVE_SLICE_LEDGER.md",
+    "docs/0102_session_briefings/work_ledger.schema.json",
+    "holo_index/adaptive_learning/breadcrumb_tracer.py",
+    "modules/communication/moltbot_bridge/src/reddog_operational_context_snapshot.py",
+    "modules/communication/moltbot_bridge/src/reddog_context_snapshot_fusion_assignment_gate.py",
+    "modules/communication/moltbot_bridge/src/reddog_openclaw_readonly_audit_swarm_runtime.py",
+)
+
+DEFAULT_BOOTSTRAP_READ_TARGETS = DEFAULT_BOOTSTRAP_CHANGED_PATHS
+
+
+@dataclass(frozen=True)
+class RedDogMainReadonlyBootstrapResult:
+    """Result emitted by the startup bootstrap check."""
+
+    ready: bool
+    status: str
+    snapshot_receipt_id: Optional[str]
+    context_view_id: Optional[str]
+    evidence_bundle_id: Optional[str]
+    determination_id: Optional[str]
+    swarm_id: Optional[str]
+    assignment_count: int
+    rejection_reasons: tuple[str, ...]
+    changed_paths: tuple[str, ...]
+    allowed_read_targets: tuple[str, ...]
+    no_model_call_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_queue_mutation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_main_readonly_operational_bootstrap(
+    *,
+    repo_root: Path | str,
+    work_state_path: Path | str | None = None,
+    holoindex_receipt_path: Path | str | None = None,
+    holoindex_ssd_path: Path | str | None = None,
+    changed_paths: Sequence[str] = DEFAULT_BOOTSTRAP_CHANGED_PATHS,
+    allowed_read_targets: Sequence[str] = DEFAULT_BOOTSTRAP_READ_TARGETS,
+    requested_operation: str = "main_startup_readonly_operational_audit",
+    prompt_text: str = "main.py read-only RedDog operational bootstrap",
+    now_iso: str | None = None,
+    repo_state_override: Mapping[str, Any] | None = None,
+    work_state_snapshot_override: Mapping[str, Any] | None = None,
+    holoindex_receipt_override: HoloIndexFreshnessReceipt | Mapping[str, Any] | None = None,
+    audit_lanes: Sequence[str] = DEFAULT_AUDIT_LANES,
+) -> RedDogMainReadonlyBootstrapResult:
+    """Build a read-only startup plan or explain why it is not ready."""
+
+    paths = _normalize_paths(changed_paths)
+    targets = _normalize_paths(allowed_read_targets)
+    reasons: list[str] = []
+
+    work_state_snapshot = work_state_snapshot_override
+    if work_state_snapshot is None:
+        if not work_state_path:
+            reasons.append("missing_authoritative_work_state_path")
+        else:
+            path = Path(work_state_path)
+            if not path.exists() or not path.is_file():
+                reasons.append("missing_authoritative_work_state")
+            else:
+                try:
+                    work_state_snapshot = load_authoritative_work_state(path)
+                except Exception:
+                    reasons.append("malformed_authoritative_work_state")
+
+    holo_receipt = holoindex_receipt_override
+    if holo_receipt is None:
+        receipt_path = _resolve_holoindex_receipt_path(
+            receipt_path=holoindex_receipt_path,
+            ssd_path=holoindex_ssd_path,
+        )
+        if receipt_path is None:
+            reasons.append("missing_holoindex_freshness_receipt_path")
+        elif not receipt_path.exists() or not receipt_path.is_file():
+            reasons.append("missing_holoindex_freshness_receipt")
+        else:
+            try:
+                holo_receipt = load_existing_holoindex_receipt(receipt_path)
+            except Exception:
+                reasons.append("malformed_holoindex_freshness_receipt")
+
+    if reasons:
+        return _not_ready(
+            reasons=reasons,
+            changed_paths=paths,
+            allowed_read_targets=targets,
+        )
+
+    assert work_state_snapshot is not None
+    repo_state = dict(repo_state_override) if repo_state_override is not None else observe_repo_state(Path(repo_root))
+    snapshot_result = build_operational_context_snapshot(
+        repo_state=repo_state,
+        work_state_snapshot=work_state_snapshot,
+        holoindex_receipt=holo_receipt,
+        changed_paths=paths,
+        now_iso=now_iso,
+        breadcrumb_scope=str(work_state_snapshot.get("selected_slice") or "main_startup"),
+    )
+    if not snapshot_result.accepted or snapshot_result.snapshot is None or snapshot_result.context_view is None:
+        return _not_ready(
+            reasons=snapshot_result.rejection_reasons or ("snapshot_rejected",),
+            changed_paths=paths,
+            allowed_read_targets=targets,
+        )
+
+    snapshot = snapshot_result.snapshot
+    context_view = snapshot_result.context_view
+    evidence_bundle = _build_bootstrap_evidence_bundle(snapshot=snapshot, context_view=context_view)
+    gate = evaluate_context_snapshot_fusion_assignment_gate(
+        snapshot=snapshot,
+        context_view=context_view,
+        evidence_bundle=evidence_bundle,
+        current_repo_head_sha=str(repo_state.get("head_sha", "unknown")),
+        current_work_state_revision=str(work_state_snapshot.get("revision", "")),
+        current_breadcrumb_high_watermark=snapshot.breadcrumbs_state.get("high_watermark"),
+        requested_operation=requested_operation,
+        prompt_text=prompt_text,
+        now_iso=now_iso,
+    )
+    if not gate.accepted or gate.determination_binding is None:
+        return _not_ready(
+            reasons=gate.rejection_reasons or ("fusion_assignment_gate_rejected",),
+            changed_paths=paths,
+            allowed_read_targets=targets,
+            snapshot=snapshot,
+            evidence_bundle=evidence_bundle,
+            gate=gate,
+        )
+
+    plan = plan_reddog_openclaw_readonly_audit_swarm(
+        snapshot=snapshot,
+        context_view=context_view,
+        evidence_bundle=evidence_bundle,
+        gate_decision=gate,
+        audit_lanes=audit_lanes,
+        allowed_read_targets=targets,
+    )
+    if not plan.accepted:
+        return _not_ready(
+            reasons=plan.rejection_reasons or ("readonly_audit_swarm_rejected",),
+            changed_paths=paths,
+            allowed_read_targets=targets,
+            snapshot=snapshot,
+            evidence_bundle=evidence_bundle,
+            gate=gate,
+            swarm_plan=plan,
+        )
+
+    return RedDogMainReadonlyBootstrapResult(
+        ready=True,
+        status=REDDOG_MAIN_BOOTSTRAP_READY,
+        snapshot_receipt_id=snapshot.snapshot_receipt_id,
+        context_view_id=context_view.context_view_id,
+        evidence_bundle_id=evidence_bundle.evidence_bundle_id,
+        determination_id=gate.determination_binding.determination_id,
+        swarm_id=plan.receipt.swarm_id,
+        assignment_count=len(plan.assignments),
+        rejection_reasons=(),
+        changed_paths=paths,
+        allowed_read_targets=targets,
+    )
+
+
+def _build_bootstrap_evidence_bundle(
+    *,
+    snapshot: OperationalContextSnapshot,
+    context_view: Any,
+) -> EvidenceBundle:
+    evidence_digest = _digest(
+        {
+            "source_receipt_digests": [receipt.content_digest for receipt in snapshot.source_receipts],
+            "snapshot_receipt_id": snapshot.snapshot_receipt_id,
+            "bootstrap_kind": "source_receipts_bound",
+        }
+    )
+    return build_evidence_bundle(
+        snapshot=snapshot,
+        context_view=context_view,
+        report_digests=(evidence_digest,),
+    )
+
+
+def _resolve_holoindex_receipt_path(
+    *,
+    receipt_path: Path | str | None,
+    ssd_path: Path | str | None,
+) -> Path | None:
+    if receipt_path:
+        return Path(receipt_path)
+    if ssd_path:
+        return freshness_receipt_path(ssd_path)
+    return None
+
+
+def _not_ready(
+    *,
+    reasons: Sequence[str],
+    changed_paths: Sequence[str],
+    allowed_read_targets: Sequence[str],
+    snapshot: OperationalContextSnapshot | None = None,
+    evidence_bundle: EvidenceBundle | None = None,
+    gate: FusionAssignmentGateDecision | None = None,
+    swarm_plan: ReadOnlyAuditSwarmPlan | None = None,
+) -> RedDogMainReadonlyBootstrapResult:
+    determination_id = None
+    if gate and gate.determination_binding:
+        determination_id = gate.determination_binding.determination_id
+    return RedDogMainReadonlyBootstrapResult(
+        ready=False,
+        status=REDDOG_MAIN_BOOTSTRAP_NOT_READY,
+        snapshot_receipt_id=snapshot.snapshot_receipt_id if snapshot else None,
+        context_view_id=gate.determination_binding.context_view_id if gate and gate.determination_binding else None,
+        evidence_bundle_id=evidence_bundle.evidence_bundle_id if evidence_bundle else None,
+        determination_id=determination_id,
+        swarm_id=swarm_plan.receipt.swarm_id if swarm_plan else None,
+        assignment_count=len(swarm_plan.assignments) if swarm_plan else 0,
+        rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons if str(reason).strip())),
+        changed_paths=tuple(changed_paths),
+        allowed_read_targets=tuple(allowed_read_targets),
+    )
+
+
+def _normalize_paths(paths: Sequence[str]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    for value in paths:
+        text = str(value or "").replace("\\", "/").strip()
+        while text.startswith("./"):
+            text = text[2:]
+        if text and not text.startswith("/") and not text.startswith("../") and "/../" not in text:
+            normalized.append(text)
+    return tuple(dict.fromkeys(normalized))
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def _digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "DEFAULT_BOOTSTRAP_CHANGED_PATHS",
+    "DEFAULT_BOOTSTRAP_READ_TARGETS",
+    "REDDOG_MAIN_BOOTSTRAP_DISABLED",
+    "REDDOG_MAIN_BOOTSTRAP_NOT_READY",
+    "REDDOG_MAIN_BOOTSTRAP_READY",
+    "RedDogMainReadonlyBootstrapResult",
+    "run_reddog_main_readonly_operational_bootstrap",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -1,0 +1,289 @@
+"""Tests for REDDOG_MAIN_READONLY_OPERATIONAL_BOOTSTRAP_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from holo_index.freshness_receipt import CollectionFreshness, HoloIndexFreshnessReceipt
+from modules.communication.moltbot_bridge.src.reddog_main_readonly_operational_bootstrap import (
+    DEFAULT_BOOTSTRAP_CHANGED_PATHS,
+    REDDOG_MAIN_BOOTSTRAP_NOT_READY,
+    REDDOG_MAIN_BOOTSTRAP_READY,
+    RedDogMainReadonlyBootstrapResult,
+    run_reddog_main_readonly_operational_bootstrap,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_main_readonly_operational_bootstrap.py"
+)
+NOW = "2026-07-14T00:00:00+00:00"
+HEAD = "bd1fe7f6ccb0964107b58d1fb93148f9f6ef7223"
+REVISION = "sha256:work-state-bootstrap"
+
+
+def _repo_state() -> dict[str, object]:
+    return {
+        "head_sha": HEAD,
+        "dirty_paths": (),
+        "dirty_digest": "sha256:clean",
+        "worktree_digest": "sha256:worktrees",
+    }
+
+
+def _work_state() -> dict[str, object]:
+    return {
+        "schema_version": "reddog_authoritative_work_state.v1",
+        "revision": REVISION,
+        "selected_slice": "REDDOG_MAIN_READONLY_OPERATIONAL_BOOTSTRAP_PHASE1",
+        "refresh_receipt_id": "sha256:refresh",
+        "worker_claims": [{"claim_id": "claim-1", "slice_id": "REDDOG_MAIN_READONLY_OPERATIONAL_BOOTSTRAP_PHASE1"}],
+        "wre_queue_items": [{"queue_item_id": "queue-1", "claim_id": "claim-1"}],
+    }
+
+
+def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
+    return HoloIndexFreshnessReceipt(
+        schema_version="holoindex_freshness_receipt.v1",
+        generated_at=NOW,
+        repo_root=str(REPO_ROOT),
+        repo_head_sha=HEAD,
+        ssd_path="E:/HoloIndex",
+        source="ci_targeted_reindex",
+        collections=[
+            CollectionFreshness(
+                name="navigation_work_ledger",
+                count=4,
+                status="indexed",
+                source="ci_targeted_reindex",
+                repo_head_sha=HEAD,
+                last_indexed_at=NOW,
+            ),
+            CollectionFreshness(
+                name="navigation_symbols",
+                count=9,
+                status="indexed",
+                source="ci_targeted_reindex",
+                repo_head_sha=HEAD,
+                last_indexed_at=NOW,
+            ),
+        ],
+    )
+
+
+def test_bootstrap_plans_default_readonly_audit_swarm_from_fresh_context() -> None:
+    result = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+    )
+
+    assert result.ready is True
+    assert result.status == REDDOG_MAIN_BOOTSTRAP_READY
+    assert result.snapshot_receipt_id and result.snapshot_receipt_id.startswith("sha256:")
+    assert result.evidence_bundle_id and result.evidence_bundle_id.startswith("sha256:")
+    assert result.determination_id and result.determination_id.startswith("sha256:")
+    assert result.swarm_id and result.swarm_id.startswith("sha256:")
+    assert result.assignment_count == 5
+    assert result.rejection_reasons == ()
+    assert result.no_model_call_performed is True
+    assert result.no_worker_spawn_performed is True
+    assert result.no_openclaw_enqueue_performed is True
+    assert result.no_hermes_dispatch_performed is True
+    assert result.no_repo_mutation_performed is True
+    assert result.no_holoindex_reindex_performed is True
+    assert result.no_queue_mutation_performed is True
+
+
+def test_bootstrap_not_ready_without_authoritative_work_state_or_holoindex_receipt() -> None:
+    result = run_reddog_main_readonly_operational_bootstrap(repo_root=REPO_ROOT)
+
+    assert result.ready is False
+    assert result.status == REDDOG_MAIN_BOOTSTRAP_NOT_READY
+    assert "missing_authoritative_work_state_path" in result.rejection_reasons
+    assert "missing_holoindex_freshness_receipt_path" in result.rejection_reasons
+    assert result.assignment_count == 0
+    assert result.no_repo_mutation_performed is True
+    assert result.no_holoindex_reindex_performed is True
+
+
+def test_bootstrap_rejects_stale_holoindex_receipt() -> None:
+    stale = HoloIndexFreshnessReceipt(
+        schema_version="holoindex_freshness_receipt.v1",
+        generated_at=NOW,
+        repo_root=str(REPO_ROOT),
+        repo_head_sha="old-head",
+        ssd_path="E:/HoloIndex",
+        source="ci_targeted_reindex",
+        collections=[
+            CollectionFreshness(
+                name="navigation_work_ledger",
+                count=4,
+                status="indexed",
+                source="ci_targeted_reindex",
+                repo_head_sha="old-head",
+                last_indexed_at=NOW,
+            ),
+            CollectionFreshness(
+                name="navigation_symbols",
+                count=9,
+                status="indexed",
+                source="ci_targeted_reindex",
+                repo_head_sha="old-head",
+                last_indexed_at=NOW,
+            ),
+        ],
+    )
+
+    result = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=stale,
+        now_iso=NOW,
+    )
+
+    assert result.ready is False
+    assert "mandatory_source_not_fresh:holoindex" in result.rejection_reasons
+    assert "holoindex:stale_repo_head_sha" in result.rejection_reasons
+
+
+def test_bootstrap_loads_existing_work_state_and_holoindex_receipt_files(tmp_path: Path) -> None:
+    work_state_path = tmp_path / "authoritative_work_state.json"
+    work_state_path.write_text(json.dumps(_work_state(), sort_keys=True), encoding="utf-8")
+    receipt_path = tmp_path / "holoindex_freshness_receipt.json"
+    receipt_path.write_text(_fresh_holo_receipt().to_json(), encoding="utf-8")
+
+    result = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_path=work_state_path,
+        holoindex_receipt_path=receipt_path,
+        now_iso=NOW,
+    )
+
+    assert result.ready is True
+    assert result.assignment_count == 5
+
+
+def test_bootstrap_normalizes_and_drops_unsafe_read_targets() -> None:
+    result = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        allowed_read_targets=[
+            "./docs/0102_session_briefings/work_ledger.schema.json",
+            "../escape.txt",
+            "/absolute/path.txt",
+            "docs/0102_session_briefings/work_ledger.schema.json",
+        ],
+        now_iso=NOW,
+    )
+
+    assert result.ready is True
+    assert result.allowed_read_targets == ("docs/0102_session_briefings/work_ledger.schema.json",)
+
+
+def test_main_preflight_is_nonblocking_by_default_when_bootstrap_not_ready() -> None:
+    import main
+
+    with patch.dict(
+        "os.environ",
+        {
+            "REDDOG_READONLY_OPERATIONAL_BOOTSTRAP": "1",
+            "REDDOG_READONLY_OPERATIONAL_BOOTSTRAP_ENFORCED": "0",
+            "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": "",
+            "HOLOINDEX_FRESHNESS_RECEIPT": "",
+            "HOLOINDEX_SSD_PATH": "",
+        },
+        clear=False,
+    ):
+        assert main.run_reddog_readonly_operational_bootstrap_preflight(REPO_ROOT) is True
+
+
+def test_main_preflight_blocks_only_when_enforced_and_not_ready() -> None:
+    import main
+
+    with patch.dict(
+        "os.environ",
+        {
+            "REDDOG_READONLY_OPERATIONAL_BOOTSTRAP": "1",
+            "REDDOG_READONLY_OPERATIONAL_BOOTSTRAP_ENFORCED": "1",
+            "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": "",
+            "HOLOINDEX_FRESHNESS_RECEIPT": "",
+            "HOLOINDEX_SSD_PATH": "",
+        },
+        clear=False,
+    ):
+        assert main.run_reddog_readonly_operational_bootstrap_preflight(REPO_ROOT) is False
+
+
+def test_main_preflight_reports_ready_without_blocking_menu() -> None:
+    import main
+
+    ready_result = RedDogMainReadonlyBootstrapResult(
+        ready=True,
+        status=REDDOG_MAIN_BOOTSTRAP_READY,
+        snapshot_receipt_id="sha256:snapshot",
+        context_view_id="sha256:view",
+        evidence_bundle_id="sha256:evidence",
+        determination_id="sha256:determination",
+        swarm_id="sha256:swarm",
+        assignment_count=5,
+        rejection_reasons=(),
+        changed_paths=DEFAULT_BOOTSTRAP_CHANGED_PATHS,
+        allowed_read_targets=DEFAULT_BOOTSTRAP_CHANGED_PATHS,
+    )
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_readonly_operational_bootstrap.run_reddog_main_readonly_operational_bootstrap",
+        return_value=ready_result,
+    ):
+        with patch.dict("os.environ", {"REDDOG_READONLY_OPERATIONAL_BOOTSTRAP": "1"}, clear=False):
+            assert main.run_reddog_readonly_operational_bootstrap_preflight(REPO_ROOT) is True
+
+
+def test_bootstrap_module_has_no_runtime_mutation_or_execution_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    forbidden_import_roots = {
+        "subprocess",
+        "requests",
+        "httpx",
+        "openclaw_supervisor",
+        "hermes_job_executor",
+    }
+    forbidden_calls = {
+        "write_text",
+        "open",
+        "mkdir",
+        "unlink",
+        "rmdir",
+        "remove",
+        "system",
+        "popen",
+        "run",
+        "call",
+        "check_call",
+        "check_output",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".")[0] not in forbidden_import_roots
+        if isinstance(node, ast.ImportFrom):
+            assert (node.module or "").split(".")[0] not in forbidden_import_roots
+        if isinstance(node, ast.Call):
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else func.id if isinstance(func, ast.Name) else ""
+            assert name not in forbidden_calls


### PR DESCRIPTION
﻿## Summary

REDDOG_MAIN_READONLY_OPERATIONAL_BOOTSTRAP_PHASE1

Adds a read-only RedDog startup bootstrap for `main.py` that composes the existing operational context snapshot, Fusion/assignment gate, and OpenClaw read-only audit swarm planner. The hook runs before runtime DAE autostart and is warning-only by default so the menu still loads when authoritative receipts are not yet wired.

## WSP_97 Truth Boundary

OBSERVED:
- `main.py` now calls `run_reddog_readonly_operational_bootstrap_preflight()` before DAE autostart.
- Missing authoritative work-state or HoloIndex freshness receipts produce `REDDOG_MAIN_BOOTSTRAP_NOT_READY` and do not block startup unless `REDDOG_READONLY_OPERATIONAL_BOOTSTRAP_ENFORCED=1`.
- Fresh receipts produce a read-only audit swarm plan with five assignments.

SPECIFIED_NOT_IMPLEMENTED:
- No worker spawn.
- No OpenClaw enqueue.
- No Hermes dispatch.
- No model call.
- No queue mutation.
- No repo mutation.
- No HoloIndex re-index.
- No live execution.

## Validation

- `pytest modules\communication\moltbot_bridge\tests\test_reddog_main_readonly_operational_bootstrap.py modules\communication\moltbot_bridge\tests\test_reddog_openclaw_readonly_audit_swarm_runtime.py modules\communication\moltbot_bridge\tests\test_reddog_context_snapshot_fusion_assignment_gate.py modules\communication\moltbot_bridge\tests\test_reddog_operational_context_snapshot.py` -> 37 passed
- `pytest modules\ai_intelligence\ai_overseer\tests\test_preflight_resolution.py` -> 20 passed, 3 warnings
- `python -m py_compile main.py modules\communication\moltbot_bridge\src\reddog_main_readonly_operational_bootstrap.py` -> pass
- `git diff --check` -> clean (autocrlf warnings only)
- Startup smoke: missing receipts prints `[REDDOG-BOOTSTRAP] preflight=WARN ...` and returns `True`

## HoloIndex Addendum

Read-only probe for `REDDOG_MAIN_READONLY_OPERATIONAL_BOOTSTRAP_PHASE1 main.py read-only RedDog operational bootstrap audit swarm` did not surface the new module. Recorded `HOLOINDEX_REDDOG_MAIN_READONLY_OPERATIONAL_BOOTSTRAP_INDEX_GAP_PHASE1`. No runtime re-index performed.
