### PR TITLE
feat(reddog): bootstrap authoritative work-state refresh

### DIFF
--- a/main.py
+++ b/main.py
@@ -1234,6 +1234,72 @@ def run_reddog_readonly_operational_bootstrap_preflight(repo_root: Path) -> bool
     return True
 
 
+def run_reddog_authoritative_work_state_refresh_preflight(repo_root: Path) -> bool:
+    """
+    Refresh RedDog authoritative work state from already-observed source files.
+
+    This is the producer for the read-only RedDog bootstrap. It performs no
+    GitHub/W10 fetch itself; callers must provide existing source-record files.
+    The output JSON is required to live outside the repo checkout.
+
+    Env:
+        REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH=1          Enable check (default ON)
+        REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH_ENFORCED=0 Block startup if not ready
+        REDDOG_AUTHORITATIVE_WORK_STATE_PATH               Output/read path for snapshot JSON
+        REDDOG_ACTIVE_SLICE_LEDGER_PATH                    Optional active ledger source
+        REDDOG_WORK_LEDGER_JSON_PATH                       Optional work ledger source
+        REDDOG_GITHUB_PR_RECORDS_PATH                      Required existing PR records JSON
+        REDDOG_W10_REPORT_RECORDS_PATH                     Required existing W10 records JSON
+    """
+
+    if os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH", "1") == "0":
+        logger.info("[REDDOG-WORK-STATE] Startup refresh disabled")
+        return True
+
+    enforced = os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH_ENFORCED", "0") != "0"
+
+    try:
+        from modules.communication.moltbot_bridge.src.reddog_main_authoritative_work_state_refresh_bootstrap import (
+            run_reddog_main_authoritative_work_state_refresh_bootstrap,
+        )
+
+        result = run_reddog_main_authoritative_work_state_refresh_bootstrap(
+            repo_root=repo_root,
+            active_slice_ledger_path=os.getenv("REDDOG_ACTIVE_SLICE_LEDGER_PATH", ""),
+            work_ledger_json_path=os.getenv("REDDOG_WORK_LEDGER_JSON_PATH", ""),
+            github_pr_records_path=os.getenv("REDDOG_GITHUB_PR_RECORDS_PATH", ""),
+            w10_report_records_path=os.getenv("REDDOG_W10_REPORT_RECORDS_PATH", ""),
+            work_state_output_path=os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
+            worker_id=os.getenv("REDDOG_WORK_STATE_REFRESH_WORKER_ID", "reddog-main-bootstrap"),
+        )
+    except Exception as exc:
+        logger.error(f"[REDDOG-WORK-STATE] Startup refresh failed: {exc}")
+        if enforced:
+            print(f"[REDDOG-WORK-STATE] preflight=FAIL error={type(exc).__name__}")
+            return False
+        print(f"[REDDOG-WORK-STATE] preflight=WARN error={type(exc).__name__}")
+        return True
+
+    status = "PASS" if result.accepted else "WARN"
+    reasons = ",".join(result.rejection_reasons) if result.rejection_reasons else "(none)"
+    print(
+        f"[REDDOG-WORK-STATE] preflight={status} status={result.status} "
+        f"queue_items={result.queue_item_count} reasons={reasons}"
+    )
+    if result.accepted and result.work_state_path:
+        os.environ["REDDOG_AUTHORITATIVE_WORK_STATE_PATH"] = result.work_state_path
+        print(
+            f"[REDDOG-WORK-STATE] refresh={result.refresh_id} "
+            f"revision={result.committed_revision}"
+        )
+        return True
+
+    if enforced:
+        print("[REDDOG-WORK-STATE] Startup blocked by REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH_ENFORCED=1")
+        return False
+    return True
+
+
 def bootstrap_runtime_dae_launches() -> None:
     """Register broker-managed DAE entrypoints for an already running system."""
     daemon = get_central_daemon()
@@ -1405,6 +1471,8 @@ def main():
     if not run_wsp_framework_preflight(repo_root, overseer=overseer):
         return
     if not run_git_main_merge_sentinel_preflight(repo_root):
+        return
+    if not run_reddog_authoritative_work_state_refresh_preflight(repo_root):
         return
     if not run_reddog_readonly_operational_bootstrap_preflight(repo_root):
         return

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,34 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_MAIN_AUTHORITATIVE_WORK_STATE_REFRESH_BOOTSTRAP_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_main_authoritative_work_state_refresh_bootstrap.py`: a
+  controlled `main.py` adapter around the existing authoritative work-state
+  refresh runtime. It reads existing local ledger, GitHub PR record, and W10
+  report artifacts, rejects stale embedded ledger state before commit, and
+  writes the authoritative work-state JSON only to an external runtime path.
+- Wired `main.py` with
+  `run_reddog_authoritative_work_state_refresh_preflight()` before the
+  read-only RedDog operational bootstrap. Accepted refreshes set
+  `REDDOG_AUTHORITATIVE_WORK_STATE_PATH` in-process so the next bootstrap step
+  can consume the exact committed snapshot.
+- Added `tests/test_reddog_main_authoritative_work_state_refresh_bootstrap.py`:
+  accepted external-path commit, missing GitHub/W10 source rejection, stale
+  ledger rejection, in-repo output rejection, main preflight nonblocking and
+  enforced modes, accepted path propagation, and AST no-fetch/no-execution
+  coverage.
+- Boundary: no GitHub fetch, no W10 fetch, no worker spawn, no OpenClaw
+  enqueue, no Hermes dispatch, no HoloIndex mutation/re-index, no execution,
+  and no repo mutation. Runtime writes are limited to an operator-configured
+  work-state JSON outside the repository checkout.
+- HoloIndex read-only probe for `REDDOG_MAIN_AUTHORITATIVE_WORK_STATE_REFRESH_BOOTSTRAP_PHASE1
+  main.py authoritative work state refresh bootstrap GitHub W10 records`
+  returned unknown locations and WSP 56, not the new adapter. Recorded
+  `HOLOINDEX_REDDOG_MAIN_AUTHORITATIVE_WORK_STATE_REFRESH_BOOTSTRAP_INDEX_GAP_PHASE1`;
+  no runtime re-index performed.
+
 ## 2026-07-14: REDDOG_MAIN_READONLY_OPERATIONAL_BOOTSTRAP_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_authoritative_work_state_refresh_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_authoritative_work_state_refresh_bootstrap.py
@@ -1,0 +1,258 @@
+"""RedDog main authoritative work-state refresh bootstrap.
+
+This adapter wires ``main.py`` to the existing authoritative work-state refresh
+runtime in a controlled way. It reads already-present source artifacts and
+commits a work-state JSON only outside the repository checkout. It does not
+fetch GitHub, create W10 reports, spawn workers, enqueue OpenClaw, dispatch
+Hermes, execute work, mutate HoloIndex, or write repository files.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_authoritative_work_state_refresh_runtime import (
+    AUTHORITATIVE_REFRESH_APPLIED,
+    AtomicJsonAuthoritativeWorkStateStore,
+    AuthoritativeWorkStateRefreshResult,
+    refresh_authoritative_work_state_runtime,
+)
+from modules.communication.moltbot_bridge.src.reddog_lane_state_reconciler import (
+    reconcile_active_and_json_ledgers,
+)
+
+
+REDDOG_WORK_STATE_BOOTSTRAP_APPLIED = "REDDOG_WORK_STATE_BOOTSTRAP_APPLIED"
+REDDOG_WORK_STATE_BOOTSTRAP_NOT_READY = "REDDOG_WORK_STATE_BOOTSTRAP_NOT_READY"
+REDDOG_WORK_STATE_BOOTSTRAP_DISABLED = "REDDOG_WORK_STATE_BOOTSTRAP_DISABLED"
+
+DEFAULT_ACTIVE_SLICE_LEDGER = "docs/0102_session_briefings/ACTIVE_SLICE_LEDGER.md"
+DEFAULT_WORK_LEDGER_JSON = "docs/0102_session_briefings/work_ledger.example.json"
+DEFAULT_RUNTIME_RELATIVE_PATH = "Foundups-Agent/reddog/authoritative_work_state.json"
+
+
+@dataclass(frozen=True)
+class RedDogMainWorkStateRefreshBootstrapResult:
+    """Result emitted by the main-startup work-state refresh adapter."""
+
+    accepted: bool
+    status: str
+    work_state_path: Optional[str]
+    refresh_id: Optional[str]
+    committed_revision: Optional[str]
+    selected_slice: Optional[str]
+    queue_item_count: int
+    rejection_reasons: tuple[str, ...]
+    no_github_fetch_performed: bool = True
+    no_w10_fetch_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_execution_performed: bool = True
+    no_repo_mutation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_main_authoritative_work_state_refresh_bootstrap(
+    *,
+    repo_root: Path | str,
+    active_slice_ledger_path: Path | str | None = None,
+    work_ledger_json_path: Path | str | None = None,
+    github_pr_records_path: Path | str | None = None,
+    w10_report_records_path: Path | str | None = None,
+    work_state_output_path: Path | str | None = None,
+    worker_id: str = "reddog-main-bootstrap",
+    now_iso: str | None = None,
+    requested_slice: str | None = None,
+    max_source_age_seconds: int = 3600,
+    stale_after_days: int = 30,
+) -> RedDogMainWorkStateRefreshBootstrapResult:
+    """Refresh authoritative work state from existing source artifacts."""
+
+    root = Path(repo_root).resolve()
+    now = now_iso or datetime.now(timezone.utc).isoformat()
+    active_path = _resolve_read_path(root, active_slice_ledger_path or DEFAULT_ACTIVE_SLICE_LEDGER)
+    ledger_path = _resolve_read_path(root, work_ledger_json_path or DEFAULT_WORK_LEDGER_JSON)
+    output_path = _resolve_output_path(root, work_state_output_path)
+    github_path = _resolve_optional_read_path(root, github_pr_records_path)
+    w10_path = _resolve_optional_read_path(root, w10_report_records_path)
+    reasons: list[str] = []
+
+    if output_path is None:
+        reasons.append("missing_work_state_output_path")
+    elif _is_inside(output_path, root):
+        reasons.append("work_state_output_inside_repo")
+
+    active_text = _read_required_text(active_path, "missing_active_slice_ledger", reasons)
+    ledger_text = _read_required_text(ledger_path, "missing_work_ledger_json", reasons)
+    github_records = _read_required_records(github_path, "missing_github_pr_records", reasons)
+    w10_records = _read_required_records(w10_path, "missing_w10_report_records", reasons)
+
+    if active_text and ledger_text:
+        ledger_report = reconcile_active_and_json_ledgers(
+            active_text,
+            ledger_text,
+            now_iso=now,
+            stale_after_days=stale_after_days,
+        )
+        if ledger_report.stale_sources:
+            reasons.extend(f"stale_ledger_source:{source}" for source in ledger_report.stale_sources)
+        if ledger_report.conflicts:
+            reasons.extend(f"ledger_conflict:{conflict.slice_id}" for conflict in ledger_report.conflicts)
+
+    if reasons:
+        return _not_ready(reasons=reasons, output_path=output_path)
+
+    assert output_path is not None
+    assert active_text is not None and ledger_text is not None
+    store = AtomicJsonAuthoritativeWorkStateStore(output_path)
+    result = refresh_authoritative_work_state_runtime(
+        active_slice_ledger_markdown=active_text,
+        work_ledger_json=ledger_text,
+        github_pr_records=github_records,
+        w10_report_records=w10_records,
+        store=store,
+        worker_id=worker_id,
+        now_iso=now,
+        requested_slice=requested_slice,
+        max_source_age_seconds=max_source_age_seconds,
+    )
+    if not result.accepted or result.receipt.status != AUTHORITATIVE_REFRESH_APPLIED:
+        return _not_ready(
+            reasons=result.receipt.rejection_reasons or ("authoritative_refresh_rejected",),
+            output_path=output_path,
+            runtime_result=result,
+        )
+
+    queue_count = 0
+    if result.snapshot:
+        queue_items = result.snapshot.get("wre_queue_items") or ()
+        queue_count = len(queue_items) if isinstance(queue_items, Sequence) else 0
+    return RedDogMainWorkStateRefreshBootstrapResult(
+        accepted=True,
+        status=REDDOG_WORK_STATE_BOOTSTRAP_APPLIED,
+        work_state_path=str(output_path),
+        refresh_id=result.receipt.refresh_id,
+        committed_revision=result.receipt.committed_revision,
+        selected_slice=result.receipt.selected_slice,
+        queue_item_count=queue_count,
+        rejection_reasons=(),
+    )
+
+
+def default_work_state_output_path() -> Path:
+    base = os.getenv("LOCALAPPDATA") or os.getenv("APPDATA") or str(Path.home() / ".foundups")
+    return Path(base) / DEFAULT_RUNTIME_RELATIVE_PATH
+
+
+def _resolve_read_path(repo_root: Path, value: Path | str) -> Path:
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root / path
+    return path.resolve()
+
+
+def _resolve_optional_read_path(repo_root: Path, value: Path | str | None) -> Path | None:
+    if not value:
+        return None
+    return _resolve_read_path(repo_root, value)
+
+
+def _resolve_output_path(repo_root: Path, value: Path | str | None) -> Path | None:
+    if value:
+        path = Path(value)
+        if not path.is_absolute():
+            path = repo_root / path
+        return path.resolve()
+    return default_work_state_output_path().resolve()
+
+
+def _read_required_text(path: Path, missing_reason: str, reasons: list[str]) -> Optional[str]:
+    if not path.exists() or not path.is_file():
+        reasons.append(missing_reason)
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception:
+        reasons.append(f"{missing_reason}:unreadable")
+        return None
+    if not text.strip():
+        reasons.append(f"{missing_reason}:empty")
+        return None
+    return text
+
+
+def _read_required_records(
+    path: Path | None,
+    missing_reason: str,
+    reasons: list[str],
+) -> tuple[Mapping[str, Any], ...]:
+    if path is None:
+        reasons.append(missing_reason)
+        return ()
+    if not path.exists() or not path.is_file():
+        reasons.append(missing_reason)
+        return ()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        reasons.append(f"{missing_reason}:malformed_json")
+        return ()
+    if isinstance(payload, Mapping):
+        raw_records = payload.get("records", ())
+    else:
+        raw_records = payload
+    if not isinstance(raw_records, Sequence) or isinstance(raw_records, (str, bytes)):
+        reasons.append(f"{missing_reason}:records_not_array")
+        return ()
+    records = tuple(record for record in raw_records if isinstance(record, Mapping))
+    if not records:
+        reasons.append(missing_reason)
+    return records
+
+
+def _is_inside(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _not_ready(
+    *,
+    reasons: Sequence[str],
+    output_path: Path | None,
+    runtime_result: AuthoritativeWorkStateRefreshResult | None = None,
+) -> RedDogMainWorkStateRefreshBootstrapResult:
+    return RedDogMainWorkStateRefreshBootstrapResult(
+        accepted=False,
+        status=REDDOG_WORK_STATE_BOOTSTRAP_NOT_READY,
+        work_state_path=str(output_path) if output_path else None,
+        refresh_id=runtime_result.receipt.refresh_id if runtime_result else None,
+        committed_revision=runtime_result.receipt.committed_revision if runtime_result else None,
+        selected_slice=runtime_result.receipt.selected_slice if runtime_result else None,
+        queue_item_count=0,
+        rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons if str(reason).strip())),
+    )
+
+
+__all__ = [
+    "DEFAULT_ACTIVE_SLICE_LEDGER",
+    "DEFAULT_RUNTIME_RELATIVE_PATH",
+    "DEFAULT_WORK_LEDGER_JSON",
+    "REDDOG_WORK_STATE_BOOTSTRAP_APPLIED",
+    "REDDOG_WORK_STATE_BOOTSTRAP_DISABLED",
+    "REDDOG_WORK_STATE_BOOTSTRAP_NOT_READY",
+    "RedDogMainWorkStateRefreshBootstrapResult",
+    "default_work_state_output_path",
+    "run_reddog_main_authoritative_work_state_refresh_bootstrap",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_authoritative_work_state_refresh_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_authoritative_work_state_refresh_bootstrap.py
@@ -1,0 +1,292 @@
+"""Tests for REDDOG_MAIN_AUTHORITATIVE_WORK_STATE_REFRESH_BOOTSTRAP_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+from modules.communication.moltbot_bridge.src.reddog_main_authoritative_work_state_refresh_bootstrap import (
+    REDDOG_WORK_STATE_BOOTSTRAP_APPLIED,
+    REDDOG_WORK_STATE_BOOTSTRAP_NOT_READY,
+    run_reddog_main_authoritative_work_state_refresh_bootstrap,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_main_authoritative_work_state_refresh_bootstrap.py"
+)
+NOW = "2026-07-14T00:00:00+00:00"
+SLICE_ID = "REDDOG_MAIN_AUTHORITATIVE_WORK_STATE_REFRESH_BOOTSTRAP_PHASE1"
+
+
+def _active_ledger(updated: str = NOW) -> str:
+    return f"""# Active Slice Ledger
+
+**Updated**: {updated}
+
+## Open Slices
+
+| Slice | Priority | Blocked By | Notes |
+|-------|----------|------------|-------|
+| `{SLICE_ID}` | P0 | - | refresh bootstrap |
+
+## Next Priority Order
+
+1. **{SLICE_ID}** - refresh bootstrap
+"""
+
+
+def _work_ledger(updated: str = NOW) -> dict[str, object]:
+    return {
+        "schema_version": "1.0.0",
+        "last_updated": updated,
+        "slices": [
+            {
+                "slice_id": SLICE_ID,
+                "title": "Refresh bootstrap",
+                "status": "IN_PROGRESS",
+                "priority": "P0",
+                "source": "audit",
+                "lane": "A",
+                "created_at": updated,
+                "wsp15_score": {"total": 18},
+            }
+        ],
+    }
+
+
+def _github_records() -> list[dict[str, object]]:
+    return [
+        {
+            "slice_id": SLICE_ID,
+            "status": "PR_OPEN",
+            "priority": "P0",
+            "lane": "A",
+            "pr_number": 1013,
+            "head_commit": "cfe916b5acbf1dfe606b3b5b5fc55a6f6f92c095",
+            "wsp15_score": {"total": 18},
+        }
+    ]
+
+
+def _w10_records() -> list[dict[str, object]]:
+    return [
+        {
+            "slice_id": SLICE_ID,
+            "status": "STAGED_FOR_W10",
+            "priority": "P0",
+            "lane": "A",
+            "evidence_refs": ["w10:local-fixture"],
+            "wsp15_score": {"total": 18},
+        }
+    ]
+
+
+def _write_sources(tmp_path: Path, *, stale: bool = False) -> dict[str, Path]:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    active = repo_root / "ACTIVE_SLICE_LEDGER.md"
+    ledger = repo_root / "work_ledger.json"
+    github = repo_root / "github_records.json"
+    w10 = repo_root / "w10_records.json"
+    updated = "2026-05-01T00:00:00+00:00" if stale else NOW
+    active.write_text(_active_ledger(updated), encoding="utf-8")
+    ledger.write_text(json.dumps(_work_ledger(updated), sort_keys=True), encoding="utf-8")
+    github.write_text(json.dumps(_github_records(), sort_keys=True), encoding="utf-8")
+    w10.write_text(json.dumps(_w10_records(), sort_keys=True), encoding="utf-8")
+    return {
+        "repo": repo_root,
+        "active": active,
+        "ledger": ledger,
+        "github": github,
+        "w10": w10,
+        "output": tmp_path / "runtime" / "authoritative_work_state.json",
+    }
+
+
+def test_refresh_bootstrap_commits_work_state_outside_repo_from_existing_sources(tmp_path: Path) -> None:
+    paths = _write_sources(tmp_path)
+
+    result = run_reddog_main_authoritative_work_state_refresh_bootstrap(
+        repo_root=paths["repo"],
+        active_slice_ledger_path=paths["active"],
+        work_ledger_json_path=paths["ledger"],
+        github_pr_records_path=paths["github"],
+        w10_report_records_path=paths["w10"],
+        work_state_output_path=paths["output"],
+        worker_id="reddog-test",
+        now_iso=NOW,
+    )
+
+    assert result.accepted is True
+    assert result.status == REDDOG_WORK_STATE_BOOTSTRAP_APPLIED
+    assert result.work_state_path == str(paths["output"].resolve())
+    assert result.refresh_id and re.fullmatch(r"[a-f0-9]{64}", result.refresh_id)
+    assert result.committed_revision and re.fullmatch(r"[a-f0-9]{64}", result.committed_revision)
+    assert result.selected_slice == SLICE_ID
+    assert result.queue_item_count == 1
+    assert paths["output"].exists()
+    data = json.loads(paths["output"].read_text(encoding="utf-8"))
+    assert data["schema_version"] == "reddog_authoritative_work_state.v1"
+    assert data["worker_claims"][0]["worker_id"] == "reddog-test"
+    assert data["no_execution_performed"] is True
+
+
+def test_refresh_bootstrap_rejects_missing_github_and_w10_sources_without_write(tmp_path: Path) -> None:
+    paths = _write_sources(tmp_path)
+    paths["github"].unlink()
+    paths["w10"].unlink()
+
+    result = run_reddog_main_authoritative_work_state_refresh_bootstrap(
+        repo_root=paths["repo"],
+        active_slice_ledger_path=paths["active"],
+        work_ledger_json_path=paths["ledger"],
+        github_pr_records_path=paths["github"],
+        w10_report_records_path=paths["w10"],
+        work_state_output_path=paths["output"],
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert result.status == REDDOG_WORK_STATE_BOOTSTRAP_NOT_READY
+    assert "missing_github_pr_records" in result.rejection_reasons
+    assert "missing_w10_report_records" in result.rejection_reasons
+    assert not paths["output"].exists()
+
+
+def test_refresh_bootstrap_rejects_stale_embedded_ledgers_before_commit(tmp_path: Path) -> None:
+    paths = _write_sources(tmp_path, stale=True)
+
+    result = run_reddog_main_authoritative_work_state_refresh_bootstrap(
+        repo_root=paths["repo"],
+        active_slice_ledger_path=paths["active"],
+        work_ledger_json_path=paths["ledger"],
+        github_pr_records_path=paths["github"],
+        w10_report_records_path=paths["w10"],
+        work_state_output_path=paths["output"],
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert any(reason.startswith("stale_ledger_source:") for reason in result.rejection_reasons)
+    assert not paths["output"].exists()
+
+
+def test_refresh_bootstrap_rejects_output_inside_repo(tmp_path: Path) -> None:
+    paths = _write_sources(tmp_path)
+    in_repo_output = paths["repo"] / "runtime" / "authoritative_work_state.json"
+
+    result = run_reddog_main_authoritative_work_state_refresh_bootstrap(
+        repo_root=paths["repo"],
+        active_slice_ledger_path=paths["active"],
+        work_ledger_json_path=paths["ledger"],
+        github_pr_records_path=paths["github"],
+        w10_report_records_path=paths["w10"],
+        work_state_output_path=in_repo_output,
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert "work_state_output_inside_repo" in result.rejection_reasons
+    assert not in_repo_output.exists()
+
+
+def test_main_preflight_is_nonblocking_when_refresh_not_ready() -> None:
+    import main
+
+    with patch.dict(
+        "os.environ",
+        {
+            "REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH": "1",
+            "REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH_ENFORCED": "0",
+            "REDDOG_GITHUB_PR_RECORDS_PATH": "",
+            "REDDOG_W10_REPORT_RECORDS_PATH": "",
+            "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": "",
+        },
+        clear=False,
+    ):
+        assert main.run_reddog_authoritative_work_state_refresh_preflight(REPO_ROOT) is True
+
+
+def test_main_preflight_blocks_when_enforced_and_refresh_not_ready() -> None:
+    import main
+
+    with patch.dict(
+        "os.environ",
+        {
+            "REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH": "1",
+            "REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH_ENFORCED": "1",
+            "REDDOG_GITHUB_PR_RECORDS_PATH": "",
+            "REDDOG_W10_REPORT_RECORDS_PATH": "",
+            "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": "",
+        },
+        clear=False,
+    ):
+        assert main.run_reddog_authoritative_work_state_refresh_preflight(REPO_ROOT) is False
+
+
+def test_main_preflight_sets_work_state_path_after_success(tmp_path: Path) -> None:
+    import main
+
+    paths = _write_sources(tmp_path)
+    with patch.dict(
+        "os.environ",
+        {
+            "REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH": "1",
+            "REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH_ENFORCED": "0",
+            "REDDOG_ACTIVE_SLICE_LEDGER_PATH": str(paths["active"]),
+            "REDDOG_WORK_LEDGER_JSON_PATH": str(paths["ledger"]),
+            "REDDOG_GITHUB_PR_RECORDS_PATH": str(paths["github"]),
+            "REDDOG_W10_REPORT_RECORDS_PATH": str(paths["w10"]),
+            "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(paths["output"]),
+        },
+        clear=False,
+    ):
+        assert main.run_reddog_authoritative_work_state_refresh_preflight(paths["repo"]) is True
+        import os
+
+        assert os.environ["REDDOG_AUTHORITATIVE_WORK_STATE_PATH"] == str(paths["output"].resolve())
+
+
+def test_refresh_bootstrap_module_has_no_fetch_execution_or_holoindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "httpx",
+        "urllib",
+        "socket",
+        "holo_index",
+        "openclaw_supervisor",
+        "hermes_job_executor",
+    }
+    banned_calls = {
+        "eval",
+        "exec",
+        "__import__",
+        "system",
+        "popen",
+        "run",
+        "call",
+        "check_call",
+        "check_output",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".")[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom):
+            assert (node.module or "").split(".")[0] not in banned_import_roots
+        if isinstance(node, ast.Call):
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else func.id if isinstance(func, ast.Name) else ""
+            assert name not in banned_calls


### PR DESCRIPTION
## Summary

Adds REDDOG_MAIN_AUTHORITATIVE_WORK_STATE_REFRESH_BOOTSTRAP_PHASE1 as a main.py preflight producer for the read-only RedDog operational bootstrap.

## What changed

- Adds a controlled adapter around the existing authoritative work-state refresh runtime.
- Reads existing local active-ledger, work-ledger JSON, GitHub PR record JSON, and W10 report JSON artifacts.
- Rejects stale embedded ledger state before commit.
- Writes the authoritative work-state JSON only to an external runtime path.
- Wires main.py so accepted refreshes set REDDOG_AUTHORITATIVE_WORK_STATE_PATH for the following read-only bootstrap preflight.

## Boundary

No GitHub fetch, no W10 fetch, no worker spawn, no OpenClaw enqueue, no Hermes dispatch, no HoloIndex mutation/re-index, no execution, and no repo mutation. Runtime writes are limited to an operator-configured work-state JSON outside the repository checkout.

## Local validation

- pytest modules\\communication\\moltbot_bridge\\tests\\test_reddog_main_authoritative_work_state_refresh_bootstrap.py modules\\communication\\moltbot_bridge\\tests\\test_reddog_authoritative_work_state_refresh_runtime.py modules\\communication\\moltbot_bridge\\tests\\test_reddog_main_readonly_operational_bootstrap.py -> 26 passed
- pytest modules\\ai_intelligence\\ai_overseer\\tests\\test_preflight_resolution.py -> 20 passed, 3 warnings
- python -m py_compile main.py modules\\communication\\moltbot_bridge\\src\\reddog_main_authoritative_work_state_refresh_bootstrap.py -> pass
- git diff --cached --check -> clean
- new files ASCII clean and NUL free

## HoloIndex

Read-only probe did not surface the new adapter. Recorded HOLOINDEX_REDDOG_MAIN_AUTHORITATIVE_WORK_STATE_REFRESH_BOOTSTRAP_INDEX_GAP_PHASE1. No runtime re-index performed.

## Residual SPECIFIED_NOT_IMPLEMENTED

- Producing fresh GitHub PR/W10 source-record artifacts is out of scope for this slice.
- HoloIndex re-index/freshness maintenance remains WRE/CI-owned, not RedDog runtime-owned.
- Live worker spawning, OpenClaw enqueue, Hermes dispatch, and work execution remain blocked downstream.