### PR TITLE
fix(main): keep WRE dashboard preflight nonblocking for menu

### DIFF
--- a/main.py
+++ b/main.py
@@ -933,14 +933,18 @@ def run_connect_wre(repo_root: Path) -> dict:
     return result
 
 
-def _wre_dashboard_auto_enforce_enabled() -> bool:
+def _wre_dashboard_auto_enforce_enabled(*, interactive_menu: bool = False) -> bool:
     """Default dashboard auto-enforcement to autonomous runtimes, not menu startup."""
 
-    default = "1" if os.getenv("OPENCLAW_24X7", "0") != "0" else "0"
-    return os.getenv("WRE_DASHBOARD_AUTO_ENFORCE", default) != "0"
+    explicit = os.getenv("WRE_DASHBOARD_AUTO_ENFORCE")
+    if explicit is not None:
+        return explicit != "0"
+    if interactive_menu:
+        return False
+    return os.getenv("OPENCLAW_24X7", "0") != "0"
 
 
-def run_wre_dashboard_preflight(repo_root: Path) -> bool:
+def run_wre_dashboard_preflight(repo_root: Path, *, interactive_menu: bool = True) -> bool:
     """
     Run WRE dashboard preflight at startup.
 
@@ -950,8 +954,8 @@ def run_wre_dashboard_preflight(repo_root: Path) -> bool:
     Env controls:
       WRE_DASHBOARD_PREFLIGHT=1             Enable startup warning checks
       WRE_DASHBOARD_PREFLIGHT_ENFORCED=0    Manual override to block startup
-      WRE_DASHBOARD_AUTO_ENFORCE            Default follows OPENCLAW_24X7
-      OPENCLAW_24X7=1                       Autonomous runtime defaults to enforced
+      WRE_DASHBOARD_AUTO_ENFORCE            Explicit override to auto-block on criticals
+      OPENCLAW_24X7=1                       Autonomous runtime defaults to enforced outside menu startup
     """
     enabled = os.getenv("WRE_DASHBOARD_PREFLIGHT", "1") != "0"
     if not enabled:
@@ -959,7 +963,7 @@ def run_wre_dashboard_preflight(repo_root: Path) -> bool:
         return True
 
     manual_enforced = os.getenv("WRE_DASHBOARD_PREFLIGHT_ENFORCED", "0") != "0"
-    auto_enforce = _wre_dashboard_auto_enforce_enabled()
+    auto_enforce = _wre_dashboard_auto_enforce_enabled(interactive_menu=interactive_menu)
 
     try:
         from modules.infrastructure.wre_core.src.dashboard_alerts import (

--- a/modules/ai_intelligence/ai_overseer/ModLog.md
+++ b/modules/ai_intelligence/ai_overseer/ModLog.md
@@ -6,6 +6,20 @@
 
 ---
 
+## 2026-07-14 - MAIN_MENU_WRE_DASHBOARD_PREFLIGHT_CONTEXT_GUARD_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 50, 97
+
+- Hardened the `main.py` WRE dashboard startup preflight so ambient
+  `OPENCLAW_24X7=1` no longer blocks the interactive menu by default.
+- Preserved fail-closed behavior for autonomous/headless context via
+  `interactive_menu=False` and for explicit menu enforcement via
+  `WRE_DASHBOARD_AUTO_ENFORCE=1` or `WRE_DASHBOARD_PREFLIGHT_ENFORCED=1`.
+- Added regression coverage for menu warning behavior under ambient 24x7,
+  explicit menu enforcement, and autonomous 24x7 enforcement.
+
+---
+
 ## 2026-07-04 - WSP 109 intake packet builder (dry-run): chat idea -> genesis envelope -> gate (WSP109_INTAKE_PACKET_BUILDER_PHASE1)
 
 **Author**: 0102 (RedDog Architect) | Commander: 012 | Gate: VERIFIED_READY draft PR (do NOT self-merge)

--- a/modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py
+++ b/modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py
@@ -295,8 +295,8 @@ def test_main_py_wre_dashboard_critical_alert_warns_by_default_for_menu_startup(
     assert "Startup blocked" not in printed
 
 
-def test_main_py_wre_dashboard_critical_alert_blocks_for_24x7_runtime():
-    """Autonomous 24x7 runtime preserves the fail-closed dashboard gate."""
+def test_main_py_wre_dashboard_critical_alert_warns_for_menu_even_with_ambient_24x7():
+    """Ambient 24x7 env must not prevent the interactive menu from loading."""
     import main
 
     fake_health = {
@@ -324,6 +324,78 @@ def test_main_py_wre_dashboard_critical_alert_blocks_for_24x7_runtime():
                     clear=True,
                 ):
                     result = main.run_wre_dashboard_preflight(Path("."))
+
+    assert result is True
+    printed = "\n".join(str(call.args[0]) for call in mock_print.call_args_list)
+    assert "preflight=FAIL (STABLE)" in printed
+    assert "Startup blocked" not in printed
+
+
+def test_main_py_wre_dashboard_critical_alert_blocks_for_explicit_menu_enforcement():
+    """Explicit dashboard enforcement remains available for interactive startup."""
+    import main
+
+    fake_health = {
+        "insufficient_data": False,
+        "total_executions": 36,
+        "min_samples": 25,
+        "healthy": False,
+        "alerts": [{"severity": "critical", "message": "critical sample"}],
+    }
+    with patch(
+        "modules.infrastructure.wre_core.src.dashboard_alerts.check_dashboard_health",
+        return_value=fake_health,
+    ):
+        with patch(
+            "modules.infrastructure.wre_core.src.dashboard_alerts.DashboardAlertMonitor"
+        ) as mock_monitor:
+            mock_monitor.return_value.is_in_watch_period.return_value = False
+            with patch("builtins.print") as mock_print:
+                with patch.dict(
+                    "os.environ",
+                    {
+                        "WRE_DASHBOARD_PREFLIGHT": "1",
+                        "WRE_DASHBOARD_AUTO_ENFORCE": "1",
+                    },
+                    clear=True,
+                ):
+                    result = main.run_wre_dashboard_preflight(Path("."))
+
+    assert result is False
+    printed = "\n".join(str(call.args[0]) for call in mock_print.call_args_list)
+    assert "preflight=FAIL (STABLE, ENFORCED)" in printed
+    assert "Startup blocked by AUTO enforcement" in printed
+
+
+def test_main_py_wre_dashboard_critical_alert_blocks_for_autonomous_24x7_runtime():
+    """Autonomous 24x7 runtime preserves the fail-closed dashboard gate."""
+    import main
+
+    fake_health = {
+        "insufficient_data": False,
+        "total_executions": 36,
+        "min_samples": 25,
+        "healthy": False,
+        "alerts": [{"severity": "critical", "message": "critical sample"}],
+    }
+    with patch(
+        "modules.infrastructure.wre_core.src.dashboard_alerts.check_dashboard_health",
+        return_value=fake_health,
+    ):
+        with patch(
+            "modules.infrastructure.wre_core.src.dashboard_alerts.DashboardAlertMonitor"
+        ) as mock_monitor:
+            mock_monitor.return_value.is_in_watch_period.return_value = False
+            with patch("builtins.print") as mock_print:
+                with patch.dict(
+                    "os.environ",
+                    {
+                        "WRE_DASHBOARD_PREFLIGHT": "1",
+                        "OPENCLAW_24X7": "1",
+                    },
+                    clear=True,
+                ):
+                    result = main.run_wre_dashboard_preflight(Path("."), interactive_menu=False)
 
     assert result is False
     printed = "\n".join(str(call.args[0]) for call in mock_print.call_args_list)


### PR DESCRIPTION
## Summary

Fixes the menu-load regression where ambient autonomous runtime state (OPENCLAW_24X7=1) could make python main.py fail closed before the interactive menu.

## What changed

- un_wre_dashboard_preflight() now treats interactive menu startup as warning-only unless explicit dashboard enforcement is set.
- WRE_DASHBOARD_AUTO_ENFORCE=1 and WRE_DASHBOARD_PREFLIGHT_ENFORCED=1 still block the menu on critical dashboard alerts.
- Autonomous/headless checks preserve strict behavior via interactive_menu=False and the existing un_connect_wre() path.

## Why

Recent RedDog main.py bootstraps were warning-only by default, so they were not the menu blocker. The observed startup block matched the WRE dashboard auto-enforcement path. This patch separates interactive menu startup from autonomous runtime enforcement.

## Local validation

- pytest modules\\ai_intelligence\\ai_overseer\\tests\\test_preflight_resolution.py -> 22 passed, 3 warnings
- pytest modules\\communication\\moltbot_bridge\\tests\\test_reddog_main_authoritative_work_state_refresh_bootstrap.py modules\\communication\\moltbot_bridge\\tests\\test_reddog_main_readonly_operational_bootstrap.py -> 17 passed
- python -m py_compile main.py -> pass
- git diff --check -> clean
- diff additions ASCII clean

## Boundary

No RedDog authority expansion, no OpenClaw enqueue, no Hermes dispatch, no worker spawn, no repo mutation at runtime. This is only startup preflight context separation.