### PR TITLE
fix(wre): make git main merge sentinel opt-in

### DIFF
--- a/main.py
+++ b/main.py
@@ -1123,14 +1123,14 @@ def run_git_main_merge_sentinel_preflight(repo_root: Path) -> bool:
     """
     Run git main-merge sentinel at startup.
 
-    Auto-merges feature branches to main to prevent drift.
+    Optionally auto-merges feature branches to main to prevent drift.
 
     Env:
-        GIT_MAIN_MERGE_SENTINEL=1           Enable sentinel (default ON)
+        GIT_MAIN_MERGE_SENTINEL=1           Enable sentinel (default OFF)
         GIT_MAIN_MERGE_SENTINEL_ENFORCED=0  If 1, block startup on failure
         GIT_MAIN_MERGE_SENTINEL_DELETE_BRANCH=1  Delete merged branch (default ON)
     """
-    if os.getenv("GIT_MAIN_MERGE_SENTINEL", "1") == "0":
+    if os.getenv("GIT_MAIN_MERGE_SENTINEL", "0") != "1":
         logger.info("[GIT-MERGE-SENTINEL] Startup preflight disabled")
         return True
 

--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -2,6 +2,40 @@
 
 ## Chronological Change Log
 
+### [2026-07-14] - WRE_GIT_MAIN_MERGE_SENTINEL_OPT_IN_GUARD_PHASE1
+
+**WSP Protocol References**: WSP 00 (Operational Grounding), WSP 15 (Priority),
+WSP 34 (Git Operations), WSP 50 (Pre-Action), WSP 97 (Truth Boundary),
+WSP 22 (ModLog)
+
+**Type**: Worktree/cwd pollution guard. Startup sentinel hardening.
+
+**Deliverable**:
+- Updated `src/git_main_merge_sentinel.py`: startup merge sentinel is now
+  explicit opt-in (`GIT_MAIN_MERGE_SENTINEL=1`) instead of ambient default-on.
+- Added a multi-worktree guard that refuses to auto-merge before any
+  fetch/push/PR/merge when `main` is checked out in another worktree.
+- Updated `main.py`: sentinel preflight remains available, but disabled unless
+  explicitly requested.
+- Added `tests/test_git_main_merge_sentinel.py`: default-disabled no-git path,
+  main-branch skip, multi-worktree block, and enforced failure coverage.
+
+**Boundary**: This slice reduces ambient git authority. It does not remove the
+sentinel, create workers, run OpenClaw/Hermes, mutate queues, or grant merge
+authority to RedDog. Explicit opt-in remains available for controlled operator
+use.
+
+**HoloIndex**: Read-only/fast probes for "git main merge sentinel worktree
+cwd hazard" and "WRE worktree cwd guard main checkout pollution" surfaced
+adjacent sentinel/WRE concepts but not the load-bearing sentinel or cwd guard
+files. Recorded
+`HOLOINDEX_WRE_GIT_MAIN_MERGE_SENTINEL_OPT_IN_GUARD_INDEX_GAP_PHASE1`; no
+runtime re-index performed.
+
+**Verification**: focused sentinel tests pending at author time.
+
+---
+
 ### [2026-07-14] - WRE_AUTORESEARCH_GIT_RUNNER_CONTRACT_PHASE1
 
 **WSP Protocol References**: WSP 00 (Operational Grounding), WSP 15 (Priority),

--- a/modules/infrastructure/wre_core/src/git_main_merge_sentinel.py
+++ b/modules/infrastructure/wre_core/src/git_main_merge_sentinel.py
@@ -13,16 +13,17 @@ Purpose:
 
 Flow:
     1. If on main -> skip (nothing to do)
-    2. git fetch --all --quiet
-    3. Push current branch to both remotes (ensure nothing lost)
-    4. Try fast-forward: git push origin HEAD:main
-    5. If fails (diverged) -> create PR via gh, merge via gh pr merge
-    6. Update local main: git branch -f main origin/main
-    7. Checkout main
-    8. Delete old feature branch (local + both remotes)
+    2. Refuse if main is checked out in another worktree
+    3. git fetch --all --quiet
+    4. Push current branch to both remotes (ensure nothing lost)
+    5. Try fast-forward: git push origin HEAD:main
+    6. If fails (diverged) -> create PR via gh, merge via gh pr merge
+    7. Update local main: git branch -f main origin/main
+    8. Checkout main
+    9. Delete old feature branch (local + both remotes)
 
 Environment:
-    GIT_MAIN_MERGE_SENTINEL=1           Enable sentinel (default ON)
+    GIT_MAIN_MERGE_SENTINEL=1           Enable sentinel (default OFF)
     GIT_MAIN_MERGE_SENTINEL_ENFORCED=0  If 1, block startup on failure
     GIT_MAIN_MERGE_SENTINEL_DELETE_BRANCH=1  Delete merged branch (default ON)
 """
@@ -98,6 +99,34 @@ def _gh(args: list[str], repo_root: Path, timeout: int = 60) -> tuple[bool, str]
         return False, str(e)
 
 
+def _branch_checkout_paths(repo_root: Path, branch: str) -> list[Path]:
+    """Return other worktree paths where the branch is checked out."""
+
+    ok, output = _git(["worktree", "list", "--porcelain"], repo_root, timeout=15)
+    if not ok:
+        return []
+
+    root = repo_root.resolve()
+    branch_ref = f"refs/heads/{branch}"
+    current_path: Path | None = None
+    matches: list[Path] = []
+    for raw in output.splitlines():
+        line = raw.strip()
+        if line.startswith("worktree "):
+            current_path = Path(line.split(" ", 1)[1])
+            continue
+        if line.startswith("branch ") and current_path is not None:
+            if line.split(" ", 1)[1] == branch_ref:
+                try:
+                    resolved = current_path.resolve()
+                except OSError:
+                    resolved = current_path
+                if resolved != root:
+                    matches.append(resolved)
+            current_path = None
+    return matches
+
+
 def run_main_merge_sentinel(repo_root: Path, force: bool = False) -> dict[str, Any]:
     """
     Run git main-merge sentinel: merge current branch to main if needed.
@@ -123,7 +152,7 @@ def run_main_merge_sentinel(repo_root: Path, force: bool = False) -> dict[str, A
     }
 
     # Check if enabled
-    if not force and not _env_bool("GIT_MAIN_MERGE_SENTINEL", default=True):
+    if not force and not _env_bool("GIT_MAIN_MERGE_SENTINEL", default=False):
         result["actions"].append("skip (disabled)")
         return result
 
@@ -141,6 +170,14 @@ def run_main_merge_sentinel(repo_root: Path, force: bool = False) -> dict[str, A
 
     result["branch"] = current_branch
     logger.info(f"[GIT-MERGE-SENTINEL] Merging {current_branch} -> main")
+
+    main_paths = _branch_checkout_paths(repo_root, "main")
+    if main_paths:
+        result["actions"].append("blocked: main checked out in another worktree")
+        result["error"] = "main_checked_out_in_another_worktree"
+        result["main_worktree_paths"] = [str(path) for path in main_paths]
+        result["passed"] = not _env_bool("GIT_MAIN_MERGE_SENTINEL_ENFORCED", default=False)
+        return result
 
     # Fetch from all remotes
     ok, output = _git(["fetch", "--all", "--quiet"], repo_root, timeout=15)

--- a/modules/infrastructure/wre_core/tests/test_git_main_merge_sentinel.py
+++ b/modules/infrastructure/wre_core/tests/test_git_main_merge_sentinel.py
@@ -1,0 +1,117 @@
+"""Tests for git main-merge sentinel startup safety."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from modules.infrastructure.wre_core.src import git_main_merge_sentinel as sentinel
+
+
+def test_sentinel_disabled_by_default_does_not_call_git(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("GIT_MAIN_MERGE_SENTINEL", raising=False)
+
+    def fail_git(*args, **kwargs):
+        raise AssertionError("git must not be called when sentinel is disabled by default")
+
+    monkeypatch.setattr(sentinel, "_git", fail_git)
+
+    result = sentinel.run_main_merge_sentinel(tmp_path)
+
+    assert result["passed"] is True
+    assert result["merged"] is False
+    assert result["actions"] == ["skip (disabled)"]
+
+
+def test_enabled_sentinel_skips_on_main(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("GIT_MAIN_MERGE_SENTINEL", "1")
+    calls: list[list[str]] = []
+
+    def fake_git(args, repo_root, timeout=30):
+        calls.append(args)
+        assert args == ["rev-parse", "--abbrev-ref", "HEAD"]
+        return True, "main"
+
+    monkeypatch.setattr(sentinel, "_git", fake_git)
+
+    result = sentinel.run_main_merge_sentinel(tmp_path)
+
+    assert result["passed"] is True
+    assert result["merged"] is False
+    assert result["actions"] == ["skip (already on main)"]
+    assert calls == [["rev-parse", "--abbrev-ref", "HEAD"]]
+
+
+def test_enabled_sentinel_blocks_when_main_checked_out_elsewhere(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("GIT_MAIN_MERGE_SENTINEL", "1")
+    feature = tmp_path / "feature"
+    main = tmp_path / "main"
+    feature.mkdir()
+    main.mkdir()
+    calls: list[list[str]] = []
+
+    worktree_output = "\n".join(
+        [
+            f"worktree {feature}",
+            "HEAD " + "a" * 40,
+            "branch refs/heads/feature/demo",
+            "",
+            f"worktree {main}",
+            "HEAD " + "b" * 40,
+            "branch refs/heads/main",
+            "",
+        ]
+    )
+
+    def fake_git(args, repo_root, timeout=30):
+        calls.append(args)
+        if args == ["rev-parse", "--abbrev-ref", "HEAD"]:
+            return True, "feature/demo"
+        if args == ["worktree", "list", "--porcelain"]:
+            return True, worktree_output
+        raise AssertionError(f"unexpected git call after worktree block: {args}")
+
+    monkeypatch.setattr(sentinel, "_git", fake_git)
+
+    result = sentinel.run_main_merge_sentinel(feature)
+
+    assert result["passed"] is True
+    assert result["merged"] is False
+    assert result["error"] == "main_checked_out_in_another_worktree"
+    assert result["main_worktree_paths"] == [str(main.resolve())]
+    assert result["actions"] == ["blocked: main checked out in another worktree"]
+    assert calls == [
+        ["rev-parse", "--abbrev-ref", "HEAD"],
+        ["worktree", "list", "--porcelain"],
+    ]
+
+
+def test_enforced_sentinel_fails_when_main_checked_out_elsewhere(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("GIT_MAIN_MERGE_SENTINEL", "1")
+    monkeypatch.setenv("GIT_MAIN_MERGE_SENTINEL_ENFORCED", "1")
+    feature = tmp_path / "feature"
+    main = tmp_path / "main"
+    feature.mkdir()
+    main.mkdir()
+
+    def fake_git(args, repo_root, timeout=30):
+        if args == ["rev-parse", "--abbrev-ref", "HEAD"]:
+            return True, "feature/demo"
+        if args == ["worktree", "list", "--porcelain"]:
+            return True, f"worktree {main}\nbranch refs/heads/main\n"
+        raise AssertionError(f"unexpected git call after worktree block: {args}")
+
+    monkeypatch.setattr(sentinel, "_git", fake_git)
+
+    result = sentinel.run_main_merge_sentinel(feature)
+
+    assert result["passed"] is False
+    assert result["merged"] is False
+    assert result["error"] == "main_checked_out_in_another_worktree"


### PR DESCRIPTION
﻿## Summary

Hardens the git main-merge sentinel that runs from `main.py` startup.

The sentinel was ambient default-on and could attempt feature-branch -> main promotion from whatever checkout invoked startup. In a multi-worktree RedDog/WRE workflow, that is a cwd-pollution amplifier: if a worker is in the wrong checkout, startup git automation can push/merge from the wrong place.

This PR makes the sentinel explicit opt-in and adds a multi-worktree guard:

- `GIT_MAIN_MERGE_SENTINEL` now defaults OFF in `main.py` and the sentinel module
- when explicitly enabled, the sentinel refuses before fetch/push/PR/merge if `main` is checked out in another worktree
- enforced mode still fails closed for that condition
- focused tests prove default disabled performs zero git calls and the multi-worktree block stops before any push path

## Boundary

This PR reduces ambient git authority. It does not:

- remove the sentinel
- grant RedDog merge authority
- spawn workers
- enqueue OpenClaw
- dispatch Hermes
- mutate queues
- re-index HoloIndex

Explicit operator opt-in remains available with `GIT_MAIN_MERGE_SENTINEL=1`.

## Validation

```text
pytest modules\infrastructure\wre_core\tests\test_git_main_merge_sentinel.py
# 4 passed

python -m py_compile main.py modules\infrastructure\wre_core\src\git_main_merge_sentinel.py modules\infrastructure\wre_core\tests\test_git_main_merge_sentinel.py
# passed

git diff --check
# clean; Windows LF->CRLF warning only

diff-added ASCII/NUL scan
# non_ascii=0 nul=0
```

## HoloIndex

Read-only/fast probes did not surface the load-bearing sentinel/cwd guard files for the worktree pollution query.

Recorded index gap:

```text
HOLOINDEX_WRE_GIT_MAIN_MERGE_SENTINEL_OPT_IN_GUARD_INDEX_GAP_PHASE1
```

No runtime re-index was performed.

## WSP_97 Truth Boundary

- OBSERVED: startup sentinel is disabled unless `GIT_MAIN_MERGE_SENTINEL=1`.
- OBSERVED: enabled sentinel blocks before fetch/push/merge when `main` is checked out in another worktree.
- OBSERVED: focused tests cover disabled, main-skip, multi-worktree block, and enforced failure.
- SPECIFIED_NOT_IMPLEMENTED: RedDog autonomous merge authority.
- SPECIFIED_NOT_IMPLEMENTED: worker launch harness cwd enforcement beyond this sentinel.
