### PR TITLE
feat(reddog): enqueue readonly audit swarm tasks

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,30 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_OPENCLAW_READONLY_AUDIT_SWARM_AGENTDB_ENQUEUE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_openclaw_readonly_audit_swarm_enqueue.py`: a
+  governed bridge from an accepted read-only audit swarm plan to durable
+  AgentDB autonomous-task assignments for OpenClaw pickup.
+- Added `tests/test_reddog_openclaw_readonly_audit_swarm_enqueue.py`:
+  accepted publication, plan/writer/unsafe-assignment/replay rejection,
+  isolated AgentDB publication, duplicate rejection without second-batch
+  pollution, deterministic JSON, and AST no-execution/no-runtime-wiring
+  coverage.
+- The concrete writer uses a single AgentDB transaction and writes pending
+  tasks with `required_skills=["reddog_readonly_audit"]`, source
+  `reddog_openclaw_readonly_audit_swarm`, and the original assignment and
+  swarm receipt in task context.
+- Boundary: no model call, no task execution, no OpenClaw supervisor call, no
+  Hermes/WRE dispatch, no shell/subprocess, no worktree operation, no repo
+  mutation, no HoloIndex runtime mutation/re-index, and no live FoundUp queue
+  write. The report executor/collector is a later slice.
+- HoloIndex read-only probe for `RedDog read-only audit swarm AgentDB enqueue`
+  surfaced adjacent tests/docs but not the new enqueue module. Recorded
+  `HOLOINDEX_REDDOG_OPENCLAW_READONLY_AUDIT_SWARM_AGENTDB_ENQUEUE_INDEX_GAP_PHASE1`;
+  no runtime re-index performed.
+
 ## 2026-07-14: REDDOG_MAIN_AUTHORITATIVE_WORK_STATE_REFRESH_BOOTSTRAP_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_openclaw_readonly_audit_swarm_enqueue.py
+++ b/modules/communication/moltbot_bridge/src/reddog_openclaw_readonly_audit_swarm_enqueue.py
@@ -1,0 +1,432 @@
+"""RedDog read-only audit swarm AgentDB enqueue seam.
+
+Slice: REDDOG_OPENCLAW_READONLY_AUDIT_SWARM_AGENTDB_ENQUEUE_PHASE1
+
+This module turns an accepted read-only audit swarm plan into durable
+OpenClaw/AgentDB autonomous-task assignments. It does not execute the audit
+tasks, call models, dispatch Hermes/WRE, create worktrees, edit files, run
+shell commands, mutate HoloIndex, or enqueue live FoundUp work.
+
+The concrete AgentDB writer is intentionally narrow: it writes only pending
+autonomous-task records for already-planned read-only audit assignments. Actual
+worker execution/report collection remains a later slice.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Optional, Protocol, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_runtime import (
+    FORBIDDEN_ACTIONS,
+    READONLY_AUDIT_SWARM_PLANNED,
+    ReadOnlyAuditAssignment,
+    ReadOnlyAuditSwarmPlan,
+)
+
+
+READONLY_AUDIT_SWARM_ENQUEUE_ACCEPT = "READONLY_AUDIT_SWARM_ENQUEUE_ACCEPT"
+READONLY_AUDIT_SWARM_ENQUEUE_REJECT = "READONLY_AUDIT_SWARM_ENQUEUE_REJECT"
+
+READONLY_AUDIT_TASK_SKILL = "reddog_readonly_audit"
+READONLY_AUDIT_TASK_SOURCE = "reddog_openclaw_readonly_audit_swarm"
+
+
+class ReadOnlyAuditEnqueueReason:
+    PLAN_NOT_ACCEPTED = "REJECT_SWARM_PLAN_NOT_ACCEPTED"
+    MISSING_ASSIGNMENTS = "REJECT_MISSING_ASSIGNMENTS"
+    ASSIGNMENT_UNSAFE = "REJECT_ASSIGNMENT_UNSAFE"
+    WRITER_MISSING = "REJECT_READONLY_AUDIT_WRITER_MISSING"
+    WRITER_REJECTED = "REJECT_READONLY_AUDIT_WRITER_REJECTED"
+    IDEMPOTENCY_REPLAY = "REJECT_READONLY_AUDIT_ASSIGNMENT_REPLAY"
+
+
+@dataclass(frozen=True)
+class ReadOnlyAuditTaskSpec:
+    """Pending AgentDB task derived from one read-only audit assignment."""
+
+    task_id: str
+    description: str
+    required_skills: tuple[str, ...]
+    estimated_complexity: float
+    priority_score: float
+    context: Mapping[str, Any]
+    origin_continuity_id: str
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["required_skills"] = list(self.required_skills)
+        payload["context"] = dict(self.context)
+        return payload
+
+
+@dataclass(frozen=True)
+class ReadOnlyAuditSwarmEnqueueReceipt:
+    """Receipt for durable publication of read-only audit assignments."""
+
+    enqueue_receipt_id: str
+    status: str
+    swarm_id: Optional[str]
+    snapshot_receipt_id: Optional[str]
+    determination_id: Optional[str]
+    task_ids: tuple[str, ...]
+    assignment_ids: tuple[str, ...]
+    rejection_reasons: tuple[str, ...]
+    created_at: str
+    receipt_digest: str
+    no_model_call_performed: bool = True
+    no_task_execution_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_worktree_operation_performed: bool = True
+    no_live_foundup_enqueue_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ReadOnlyAuditSwarmEnqueueResult:
+    """Result from publishing read-only audit assignments."""
+
+    accepted: bool
+    decision: str
+    receipt: ReadOnlyAuditSwarmEnqueueReceipt
+    tasks: tuple[ReadOnlyAuditTaskSpec, ...]
+    rejection_reasons: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "accepted": self.accepted,
+            "decision": self.decision,
+            "receipt": self.receipt.to_dict(),
+            "tasks": [task.to_dict() for task in self.tasks],
+            "rejection_reasons": list(self.rejection_reasons),
+        }
+
+
+class ReadOnlyAuditTaskWriter(Protocol):
+    """Injected writer for durable task publication."""
+
+    def enqueue_readonly_audit_tasks(
+        self,
+        tasks: Sequence[ReadOnlyAuditTaskSpec],
+        receipt: ReadOnlyAuditSwarmEnqueueReceipt,
+    ) -> Mapping[str, Any]: ...
+
+
+class AgentDbReadOnlyAuditTaskWriter:
+    """Concrete AgentDB writer for pending read-only audit tasks.
+
+    Construction is side-effect free; AgentDB is imported and opened only when
+    enqueueing. The batch is preflighted and inserted inside one DB transaction
+    to avoid partial publication when a task id already exists.
+    """
+
+    def __init__(self, agent_db_factory: Optional[Any] = None) -> None:
+        self._agent_db_factory = agent_db_factory
+
+    def enqueue_readonly_audit_tasks(
+        self,
+        tasks: Sequence[ReadOnlyAuditTaskSpec],
+        receipt: ReadOnlyAuditSwarmEnqueueReceipt,
+    ) -> Mapping[str, Any]:
+        factory = self._agent_db_factory
+        if factory is None:
+            from modules.infrastructure.database.src.agent_db import AgentDB
+
+            factory = AgentDB
+
+        db = factory()
+        task_ids = tuple(task.task_id for task in tasks)
+        try:
+            with db.db.get_connection() as conn:
+                for task_id in task_ids:
+                    existing = conn.execute(
+                        "SELECT task_id FROM agents_autonomous_tasks WHERE task_id = ?",
+                        (task_id,),
+                    ).fetchone()
+                    if existing:
+                        return {
+                            "ok": False,
+                            "reason": "task_already_exists",
+                            "task_id": task_id,
+                            "created_task_ids": [],
+                        }
+
+                for task in tasks:
+                    conn.execute(
+                        """
+                        INSERT INTO agents_autonomous_tasks
+                        (task_id, description, required_skills, estimated_complexity,
+                         priority_score, discovered_by, context, origin_continuity_id, status)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending')
+                        """,
+                        (
+                            task.task_id,
+                            task.description,
+                            json.dumps(list(task.required_skills), sort_keys=True),
+                            float(task.estimated_complexity),
+                            float(task.priority_score),
+                            READONLY_AUDIT_TASK_SOURCE,
+                            json.dumps(dict(task.context), sort_keys=True),
+                            task.origin_continuity_id,
+                        ),
+                    )
+        except Exception as exc:
+            return {
+                "ok": False,
+                "reason": "agentdb_write_failed",
+                "error": str(exc)[:200],
+                "created_task_ids": [],
+            }
+
+        return {"ok": True, "created_task_ids": list(task_ids)}
+
+
+def enqueue_reddog_readonly_audit_swarm(
+    *,
+    plan: ReadOnlyAuditSwarmPlan,
+    writer: Optional[ReadOnlyAuditTaskWriter],
+    seen_assignment_ids: Optional[set[str]] = None,
+    now: Optional[datetime] = None,
+) -> ReadOnlyAuditSwarmEnqueueResult:
+    """Publish an accepted read-only audit swarm plan as pending tasks."""
+
+    checked_at = _iso8601(now)
+    reasons = _validate_plan(plan)
+    if writer is None:
+        reasons.append(ReadOnlyAuditEnqueueReason.WRITER_MISSING)
+
+    assignment_ids = tuple(assignment.assignment_id for assignment in getattr(plan, "assignments", ()))
+    if seen_assignment_ids is not None:
+        for assignment_id in assignment_ids:
+            if assignment_id in seen_assignment_ids:
+                reasons.append(ReadOnlyAuditEnqueueReason.IDEMPOTENCY_REPLAY)
+                break
+
+    tasks = tuple(_build_task_spec(plan, assignment) for assignment in getattr(plan, "assignments", ()))
+    deduped_reasons = _dedupe(reasons)
+    if deduped_reasons:
+        return _result(
+            accepted=False,
+            plan=plan,
+            tasks=(),
+            reasons=deduped_reasons,
+            created_at=checked_at,
+        )
+
+    assert writer is not None
+    provisional = _receipt(
+        status=READONLY_AUDIT_SWARM_ENQUEUE_ACCEPT,
+        plan=plan,
+        tasks=tasks,
+        reasons=(),
+        created_at=checked_at,
+    )
+    try:
+        writer_result = writer.enqueue_readonly_audit_tasks(tasks, provisional)
+    except Exception:
+        writer_result = {"ok": False, "reason": "writer_exception"}
+    if not isinstance(writer_result, Mapping) or writer_result.get("ok") is not True:
+        return _result(
+            accepted=False,
+            plan=plan,
+            tasks=(),
+            reasons=[ReadOnlyAuditEnqueueReason.WRITER_REJECTED],
+            created_at=checked_at,
+        )
+
+    created = tuple(str(value) for value in writer_result.get("created_task_ids", ()))
+    expected = tuple(task.task_id for task in tasks)
+    if created != expected:
+        return _result(
+            accepted=False,
+            plan=plan,
+            tasks=(),
+            reasons=[ReadOnlyAuditEnqueueReason.WRITER_REJECTED],
+            created_at=checked_at,
+        )
+
+    if seen_assignment_ids is not None:
+        seen_assignment_ids.update(assignment_ids)
+
+    return _result(
+        accepted=True,
+        plan=plan,
+        tasks=tasks,
+        reasons=(),
+        created_at=checked_at,
+    )
+
+
+def _validate_plan(plan: ReadOnlyAuditSwarmPlan) -> list[str]:
+    reasons: list[str] = []
+    if not isinstance(plan, ReadOnlyAuditSwarmPlan) or not plan.accepted:
+        return [ReadOnlyAuditEnqueueReason.PLAN_NOT_ACCEPTED]
+    if plan.status != READONLY_AUDIT_SWARM_PLANNED or plan.receipt.status != READONLY_AUDIT_SWARM_PLANNED:
+        reasons.append(ReadOnlyAuditEnqueueReason.PLAN_NOT_ACCEPTED)
+    if not plan.assignments:
+        reasons.append(ReadOnlyAuditEnqueueReason.MISSING_ASSIGNMENTS)
+    for assignment in plan.assignments:
+        if not _assignment_safe(assignment, plan):
+            reasons.append(ReadOnlyAuditEnqueueReason.ASSIGNMENT_UNSAFE)
+            break
+    return reasons
+
+
+def _assignment_safe(assignment: ReadOnlyAuditAssignment, plan: ReadOnlyAuditSwarmPlan) -> bool:
+    if assignment.assignment_id not in set(plan.receipt.assignment_ids):
+        return False
+    if assignment.snapshot_receipt_id != plan.receipt.snapshot_receipt_id:
+        return False
+    if assignment.context_view_id != plan.receipt.context_view_id:
+        return False
+    if assignment.evidence_bundle_id != plan.receipt.evidence_bundle_id:
+        return False
+    if assignment.determination_id != plan.receipt.determination_id:
+        return False
+    if assignment.no_worker_spawn_performed is not True:
+        return False
+    if assignment.no_execution_performed is not True:
+        return False
+    if assignment.no_repo_mutation_performed is not True:
+        return False
+    if tuple(assignment.forbidden_actions) != tuple(FORBIDDEN_ACTIONS):
+        return False
+    return bool(assignment.lane_id and assignment.allowed_read_targets)
+
+
+def _build_task_spec(plan: ReadOnlyAuditSwarmPlan, assignment: ReadOnlyAuditAssignment) -> ReadOnlyAuditTaskSpec:
+    task_id = "reddog-readonly-audit-" + _digest(
+        {
+            "swarm_id": plan.receipt.swarm_id,
+            "assignment_id": assignment.assignment_id,
+            "lane_id": assignment.lane_id,
+        }
+    )[:16]
+    context = {
+        "source": READONLY_AUDIT_TASK_SOURCE,
+        "slice_name": "REDDOG_OPENCLAW_READONLY_AUDIT_SWARM_AGENTDB_ENQUEUE_PHASE1",
+        "swarm_receipt": plan.receipt.to_dict(),
+        "assignment": assignment.to_dict(),
+        "forbidden_actions": list(FORBIDDEN_ACTIONS),
+        "report_contract": {
+            "repo_mutation_performed": False,
+            "execution_performed": False,
+            "openclaw_enqueue_performed": False,
+            "requires_evidence_refs": True,
+        },
+    }
+    priority = {
+        "security_governance_audit": 0.95,
+        "runtime_freshness_audit": 0.90,
+        "repo_code_audit": 0.85,
+        "external_research_audit": 0.80,
+        "skill_gap_audit": 0.75,
+    }.get(assignment.lane_id, 0.70)
+    return ReadOnlyAuditTaskSpec(
+        task_id=task_id,
+        description=f"RedDog read-only audit lane: {assignment.lane_id}",
+        required_skills=(READONLY_AUDIT_TASK_SKILL,),
+        estimated_complexity=0.35,
+        priority_score=priority,
+        context=context,
+        origin_continuity_id=assignment.determination_id,
+    )
+
+
+def _result(
+    *,
+    accepted: bool,
+    plan: ReadOnlyAuditSwarmPlan,
+    tasks: Sequence[ReadOnlyAuditTaskSpec],
+    reasons: Sequence[str],
+    created_at: str,
+) -> ReadOnlyAuditSwarmEnqueueResult:
+    decision = READONLY_AUDIT_SWARM_ENQUEUE_ACCEPT if accepted else READONLY_AUDIT_SWARM_ENQUEUE_REJECT
+    receipt = _receipt(
+        status=decision,
+        plan=plan,
+        tasks=tasks,
+        reasons=tuple(reasons),
+        created_at=created_at,
+    )
+    return ReadOnlyAuditSwarmEnqueueResult(
+        accepted=accepted,
+        decision=decision,
+        receipt=receipt,
+        tasks=tuple(tasks),
+        rejection_reasons=tuple(reasons),
+    )
+
+
+def _receipt(
+    *,
+    status: str,
+    plan: ReadOnlyAuditSwarmPlan,
+    tasks: Sequence[ReadOnlyAuditTaskSpec],
+    reasons: Sequence[str],
+    created_at: str,
+) -> ReadOnlyAuditSwarmEnqueueReceipt:
+    payload = {
+        "status": status,
+        "swarm_id": getattr(plan.receipt, "swarm_id", None),
+        "task_ids": [task.task_id for task in tasks],
+        "assignment_ids": [assignment.assignment_id for assignment in getattr(plan, "assignments", ())],
+        "rejection_reasons": list(reasons),
+        "created_at": created_at,
+    }
+    receipt_id = "readonly-audit-enqueue-" + _digest(payload)[:16]
+    receipt_payload = {
+        **payload,
+        "enqueue_receipt_id": receipt_id,
+        "snapshot_receipt_id": getattr(plan.receipt, "snapshot_receipt_id", None),
+        "determination_id": getattr(plan.receipt, "determination_id", None),
+    }
+    receipt_digest = "sha256:" + _digest(receipt_payload)
+    return ReadOnlyAuditSwarmEnqueueReceipt(
+        enqueue_receipt_id=receipt_id,
+        status=status,
+        swarm_id=getattr(plan.receipt, "swarm_id", None),
+        snapshot_receipt_id=getattr(plan.receipt, "snapshot_receipt_id", None),
+        determination_id=getattr(plan.receipt, "determination_id", None),
+        task_ids=tuple(task.task_id for task in tasks),
+        assignment_ids=tuple(assignment.assignment_id for assignment in getattr(plan, "assignments", ())),
+        rejection_reasons=tuple(reasons),
+        created_at=created_at,
+        receipt_digest=receipt_digest,
+    )
+
+
+def _dedupe(items: Sequence[str]) -> list[str]:
+    return list(dict.fromkeys(str(item) for item in items if str(item).strip()))
+
+
+def _iso8601(value: Optional[datetime]) -> str:
+    current = value or datetime.now(timezone.utc)
+    return current.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "AgentDbReadOnlyAuditTaskWriter",
+    "READONLY_AUDIT_SWARM_ENQUEUE_ACCEPT",
+    "READONLY_AUDIT_SWARM_ENQUEUE_REJECT",
+    "READONLY_AUDIT_TASK_SKILL",
+    "READONLY_AUDIT_TASK_SOURCE",
+    "ReadOnlyAuditEnqueueReason",
+    "ReadOnlyAuditSwarmEnqueueReceipt",
+    "ReadOnlyAuditSwarmEnqueueResult",
+    "ReadOnlyAuditTaskSpec",
+    "ReadOnlyAuditTaskWriter",
+    "enqueue_reddog_readonly_audit_swarm",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_enqueue.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_enqueue.py
@@ -1,0 +1,329 @@
+"""Tests for REDDOG_OPENCLAW_READONLY_AUDIT_SWARM_AGENTDB_ENQUEUE_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from holo_index.freshness_receipt import CollectionFreshness, HoloIndexFreshnessReceipt
+from modules.communication.moltbot_bridge.src.reddog_context_snapshot_fusion_assignment_gate import (
+    evaluate_context_snapshot_fusion_assignment_gate,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
+    READONLY_AUDIT_SWARM_ENQUEUE_ACCEPT,
+    READONLY_AUDIT_SWARM_ENQUEUE_REJECT,
+    READONLY_AUDIT_TASK_SKILL,
+    READONLY_AUDIT_TASK_SOURCE,
+    AgentDbReadOnlyAuditTaskWriter,
+    ReadOnlyAuditEnqueueReason,
+    enqueue_reddog_readonly_audit_swarm,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_runtime import (
+    DEFAULT_AUDIT_LANES,
+    plan_reddog_openclaw_readonly_audit_swarm,
+)
+from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
+    build_evidence_bundle,
+    build_operational_context_snapshot,
+)
+from modules.infrastructure.database.src.agent_db import AgentDB
+from modules.infrastructure.database.src.db_manager import DatabaseManager
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_openclaw_readonly_audit_swarm_enqueue.py"
+)
+NOW = "2026-07-14T00:00:00+00:00"
+HEAD = "eda98c8a9evidence"
+REVISION = "sha256:work-state-refresh"
+
+
+@pytest.fixture(autouse=True)
+def isolated_agent_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("FOUNDUPS_DB_PATH", str(tmp_path / "foundups.db"))
+    DatabaseManager.reset_for_tests()
+    yield
+    DatabaseManager.reset_for_tests()
+
+
+class _FakeWriter:
+    def __init__(self, *, ok=True, created_override=None) -> None:
+        self.ok = ok
+        self.created_override = created_override
+        self.calls = []
+
+    def enqueue_readonly_audit_tasks(self, tasks, receipt):
+        self.calls.append((list(tasks), receipt))
+        if not self.ok:
+            return {"ok": False, "reason": "writer_rejected", "created_task_ids": []}
+        created = self.created_override
+        if created is None:
+            created = [task.task_id for task in tasks]
+        return {"ok": True, "created_task_ids": created}
+
+
+def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
+    return HoloIndexFreshnessReceipt(
+        schema_version="holoindex_freshness_receipt.v1",
+        generated_at=NOW,
+        repo_root=str(REPO_ROOT),
+        repo_head_sha=HEAD,
+        ssd_path="E:/HoloIndex",
+        source="ci_targeted_reindex",
+        collections=[
+            CollectionFreshness(
+                name="navigation_work_ledger",
+                count=2,
+                status="indexed",
+                source="ci_targeted_reindex",
+                repo_head_sha=HEAD,
+                last_indexed_at=NOW,
+            ),
+            CollectionFreshness(
+                name="navigation_symbols",
+                count=8,
+                status="indexed",
+                source="ci_targeted_reindex",
+                repo_head_sha=HEAD,
+                last_indexed_at=NOW,
+            ),
+        ],
+    )
+
+
+def _valid_plan():
+    snapshot_result = build_operational_context_snapshot(
+        repo_state={
+            "head_sha": HEAD,
+            "dirty_paths": (),
+            "dirty_digest": "sha256:clean",
+            "worktree_digest": "sha256:worktrees",
+        },
+        work_state_snapshot={
+            "schema_version": "reddog_authoritative_work_state.v1",
+            "revision": REVISION,
+            "selected_slice": "REDDOG_OPENCLAW_READONLY_AUDIT_SWARM_AGENTDB_ENQUEUE_PHASE1",
+            "refresh_receipt_id": "sha256:refresh",
+            "worker_claims": [{"claim_id": "claim-1", "status": "ACTIVE"}],
+            "wre_queue_items": [{"queue_item_id": "queue-1"}],
+        },
+        holoindex_receipt=_fresh_holo_receipt(),
+        changed_paths=[
+            "docs/0102_session_briefings/work_ledger.schema.json",
+            "modules/communication/moltbot_bridge/src/reddog_openclaw_readonly_audit_swarm_runtime.py",
+        ],
+        breadcrumbs=[
+            {
+                "breadcrumb_id": "b1",
+                "continuity_id": "cont-1",
+                "timestamp": NOW,
+            }
+        ],
+        breadcrumb_scope="cont-1",
+        now_iso=NOW,
+    )
+    assert snapshot_result.accepted is True
+    assert snapshot_result.snapshot is not None
+    assert snapshot_result.context_view is not None
+    evidence_bundle = build_evidence_bundle(
+        snapshot=snapshot_result.snapshot,
+        context_view=snapshot_result.context_view,
+        report_digests=["sha256:repo-audit", "sha256:security-audit"],
+    )
+    gate = evaluate_context_snapshot_fusion_assignment_gate(
+        snapshot=snapshot_result.snapshot,
+        context_view=snapshot_result.context_view,
+        evidence_bundle=evidence_bundle,
+        current_repo_head_sha=HEAD,
+        current_work_state_revision=REVISION,
+        current_breadcrumb_high_watermark=snapshot_result.snapshot.breadcrumbs_state["high_watermark"],
+        requested_operation="readonly_audit_swarm",
+        prompt_text="audit current RedDog operational loop",
+        now_iso="2026-07-14T00:01:00+00:00",
+    )
+    assert gate.accepted is True
+    plan = plan_reddog_openclaw_readonly_audit_swarm(
+        snapshot=snapshot_result.snapshot,
+        context_view=snapshot_result.context_view,
+        evidence_bundle=evidence_bundle,
+        gate_decision=gate,
+        allowed_read_targets=[
+            "docs/0102_session_briefings/work_ledger.schema.json",
+            "modules/communication/moltbot_bridge/src/reddog_operational_context_snapshot.py",
+        ],
+    )
+    assert plan.accepted is True
+    return plan
+
+
+def test_enqueue_accepts_plan_and_builds_pending_readonly_tasks() -> None:
+    plan = _valid_plan()
+    writer = _FakeWriter()
+
+    result = enqueue_reddog_readonly_audit_swarm(
+        plan=plan,
+        writer=writer,
+        now=datetime(2026, 7, 14, tzinfo=timezone.utc),
+    )
+
+    assert result.accepted is True
+    assert result.decision == READONLY_AUDIT_SWARM_ENQUEUE_ACCEPT
+    assert result.receipt.status == READONLY_AUDIT_SWARM_ENQUEUE_ACCEPT
+    assert result.receipt.no_task_execution_performed is True
+    assert result.receipt.no_repo_mutation_performed is True
+    assert result.receipt.no_live_foundup_enqueue_performed is True
+    assert tuple(task.context["assignment"]["lane_id"] for task in result.tasks) == DEFAULT_AUDIT_LANES
+    assert all(task.required_skills == (READONLY_AUDIT_TASK_SKILL,) for task in result.tasks)
+    assert all(task.context["source"] == READONLY_AUDIT_TASK_SOURCE for task in result.tasks)
+    assert writer.calls and len(writer.calls[0][0]) == 5
+
+
+def test_rejects_rejected_plan_and_missing_writer_before_publication() -> None:
+    plan = _valid_plan()
+    rejected = replace(plan, accepted=False)
+
+    result = enqueue_reddog_readonly_audit_swarm(plan=rejected, writer=_FakeWriter())
+    missing_writer = enqueue_reddog_readonly_audit_swarm(plan=plan, writer=None)
+
+    assert result.accepted is False
+    assert result.decision == READONLY_AUDIT_SWARM_ENQUEUE_REJECT
+    assert ReadOnlyAuditEnqueueReason.PLAN_NOT_ACCEPTED in result.rejection_reasons
+    assert result.tasks == ()
+    assert missing_writer.accepted is False
+    assert ReadOnlyAuditEnqueueReason.WRITER_MISSING in missing_writer.rejection_reasons
+
+
+def test_rejects_unsafe_assignment_binding() -> None:
+    plan = _valid_plan()
+    bad_assignment = replace(plan.assignments[0], determination_id="wrong")
+    bad_plan = replace(plan, assignments=(bad_assignment,) + plan.assignments[1:])
+    writer = _FakeWriter()
+
+    result = enqueue_reddog_readonly_audit_swarm(plan=bad_plan, writer=writer)
+
+    assert result.accepted is False
+    assert ReadOnlyAuditEnqueueReason.ASSIGNMENT_UNSAFE in result.rejection_reasons
+    assert writer.calls == []
+
+
+def test_rejects_assignment_id_replay_before_writer_call() -> None:
+    plan = _valid_plan()
+    seen = {plan.assignments[0].assignment_id}
+    writer = _FakeWriter()
+
+    result = enqueue_reddog_readonly_audit_swarm(plan=plan, writer=writer, seen_assignment_ids=seen)
+
+    assert result.accepted is False
+    assert ReadOnlyAuditEnqueueReason.IDEMPOTENCY_REPLAY in result.rejection_reasons
+    assert writer.calls == []
+
+
+def test_writer_rejection_or_bad_created_ids_rejects() -> None:
+    plan = _valid_plan()
+    rejected = enqueue_reddog_readonly_audit_swarm(plan=plan, writer=_FakeWriter(ok=False))
+    bad_created = enqueue_reddog_readonly_audit_swarm(
+        plan=plan,
+        writer=_FakeWriter(created_override=["wrong"]),
+    )
+
+    assert rejected.accepted is False
+    assert bad_created.accepted is False
+    assert rejected.rejection_reasons == (ReadOnlyAuditEnqueueReason.WRITER_REJECTED,)
+    assert bad_created.rejection_reasons == (ReadOnlyAuditEnqueueReason.WRITER_REJECTED,)
+
+
+def test_agentdb_writer_publishes_tasks_atomically() -> None:
+    plan = _valid_plan()
+    result = enqueue_reddog_readonly_audit_swarm(
+        plan=plan,
+        writer=AgentDbReadOnlyAuditTaskWriter(),
+        now=datetime(2026, 7, 14, tzinfo=timezone.utc),
+    )
+
+    assert result.accepted is True
+    db = AgentDB()
+    pending = db.get_autonomous_tasks(status="pending", limit=10)
+    assert len(pending) == 5
+    task_ids = {task["task_id"] for task in pending}
+    assert task_ids == set(result.receipt.task_ids)
+    for task in pending:
+        assert task["required_skills"] == [READONLY_AUDIT_TASK_SKILL]
+        assert task["context"]["source"] == READONLY_AUDIT_TASK_SOURCE
+        assert task["context"]["swarm_receipt"]["swarm_id"] == plan.receipt.swarm_id
+        assert task["origin_continuity_id"] == plan.receipt.determination_id
+
+
+def test_agentdb_writer_rejects_duplicate_without_partial_second_batch() -> None:
+    plan = _valid_plan()
+    writer = AgentDbReadOnlyAuditTaskWriter()
+    first = enqueue_reddog_readonly_audit_swarm(plan=plan, writer=writer)
+    second = enqueue_reddog_readonly_audit_swarm(plan=plan, writer=writer)
+
+    assert first.accepted is True
+    assert second.accepted is False
+    assert second.rejection_reasons == (ReadOnlyAuditEnqueueReason.WRITER_REJECTED,)
+    pending = AgentDB().get_autonomous_tasks(status="pending", limit=20)
+    assert len(pending) == 5
+
+
+def test_result_is_deterministic_and_json_serializable() -> None:
+    plan = _valid_plan()
+    first = enqueue_reddog_readonly_audit_swarm(
+        plan=plan,
+        writer=_FakeWriter(),
+        now=datetime(2026, 7, 14, tzinfo=timezone.utc),
+    )
+    second = enqueue_reddog_readonly_audit_swarm(
+        plan=plan,
+        writer=_FakeWriter(),
+        now=datetime(2026, 7, 14, tzinfo=timezone.utc),
+    )
+
+    assert first.receipt.receipt_digest == second.receipt.receipt_digest
+    json.dumps(first.to_dict(), sort_keys=True)
+
+
+def test_module_ast_boundaries() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    forbidden_text = (
+        "subprocess",
+        "requests",
+        "openclaw_supervisor",
+        "hermes_job_executor",
+        "execute_skill",
+        "worktree_create",
+        "git push",
+        "gh pr",
+        "holo_index.py --index",
+        "run_task.py",
+    )
+    for token in forbidden_text:
+        assert token not in source
+
+    imported = set()
+    calls = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.add((node.module or "").split(".")[0])
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                calls.add(node.func.id)
+            elif isinstance(node.func, ast.Attribute):
+                calls.add(node.func.attr)
+
+    assert not (imported & {"subprocess", "requests", "socket", "urllib", "shutil"})
+    assert not (calls & {"eval", "exec", "compile", "system", "popen", "run", "Popen"})


### PR DESCRIPTION
## Summary

Implements `REDDOG_OPENCLAW_READONLY_AUDIT_SWARM_AGENTDB_ENQUEUE_PHASE1`.

This is the next operational seam after RedDog can build a read-only audit swarm plan: it publishes accepted read-only audit assignments as pending AgentDB autonomous tasks for OpenClaw pickup. It does not execute those tasks or wire `main.py`/OpenClaw supervisor runtime consumption.

## WSP_97 Truth Boundary

- OBSERVED: accepted `ReadOnlyAuditSwarmPlan` -> five deterministic pending task specs.
- OBSERVED: concrete writer uses one AgentDB transaction and rejects duplicates before inserting a second batch.
- OBSERVED: task context carries the original assignment, swarm receipt, forbidden actions, and report contract.
- OBSERVED: no model call, task execution, OpenClaw supervisor call, Hermes/WRE dispatch, shell/subprocess, worktree operation, repo mutation, HoloIndex mutation/re-index, or live FoundUp queue write.
- SPECIFIED_NOT_IMPLEMENTED: read-only audit task executor, report collector, report validation loop, and `main.py` runtime wiring.

## Validation

```text
python -m pytest modules\communication\moltbot_bridge\tests\test_reddog_openclaw_readonly_audit_swarm_enqueue.py -q
9 passed

python -m pytest modules\communication\moltbot_bridge\tests\test_reddog_openclaw_readonly_audit_swarm_enqueue.py modules\communication\moltbot_bridge\tests\test_reddog_openclaw_readonly_audit_swarm_runtime.py modules\infrastructure\database\tests\test_agent_db_schema_compatibility.py -q
20 passed

python -m py_compile modules\communication\moltbot_bridge\src\reddog_openclaw_readonly_audit_swarm_enqueue.py modules\communication\moltbot_bridge\tests\test_reddog_openclaw_readonly_audit_swarm_enqueue.py
PASS

git diff --check
PASS (CRLF warnings only)

ASCII/NUL scan
new files: non_ascii=0, nul=0
```

## HoloIndex

Read-only probe for `RedDog read-only audit swarm AgentDB enqueue` missed the new module and surfaced adjacent tests/docs. Recorded:

```text
HOLOINDEX_REDDOG_OPENCLAW_READONLY_AUDIT_SWARM_AGENTDB_ENQUEUE_INDEX_GAP_PHASE1
```

No runtime re-index performed.