### PR TITLE
feat(reddog): execute readonly audit task reports

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,34 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_READONLY_AUDIT_TASK_REPORT_EXECUTOR_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_readonly_audit_task_executor.py`: deterministic local
+  executor for AgentDB tasks emitted by the read-only audit swarm enqueue
+  seam. It reads only allowlisted repository file targets, computes evidence
+  digests, and emits a report shape compatible with the existing read-only
+  audit report validator.
+- Updated `scripts/run_task.py`: exact
+  `source=reddog_openclaw_readonly_audit_swarm` and
+  `required_skills=["reddog_readonly_audit"]` tasks now dispatch to the
+  RedDog read-only audit executor before WRE skill dispatch, so a registered
+  WRE skill cannot widen these audit tasks.
+- Added `tests/test_reddog_readonly_audit_task_executor.py`: allowlisted read
+  evidence collection, wrong-source/missing-assignment rejection,
+  traversal/secret/missing-target rejection, AgentDB assigned-task execution
+  through `run_task.py`, and AST no-mutation/no-network/no-runtime-wiring
+  coverage.
+- Boundary: no model call, no shell/subprocess, no repo write, no OpenClaw
+  enqueue, no Hermes/WRE dispatch, no worktree operation, no HoloIndex
+  mutation/re-index, and no report artifact write. It completes only the
+  assigned AgentDB task and returns structured report data.
+- HoloIndex read-only probe for `RedDog readonly audit task report executor
+  AgentDB run_task` surfaced `run_task.py` and adjacent audit surfaces but not
+  the new executor module. Recorded
+  `HOLOINDEX_REDDOG_READONLY_AUDIT_TASK_REPORT_EXECUTOR_INDEX_GAP_PHASE1`;
+  no runtime re-index performed.
+
 ## 2026-07-14: REDDOG_OPENCLAW_READONLY_AUDIT_SWARM_AGENTDB_ENQUEUE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/scripts/run_task.py
+++ b/modules/communication/moltbot_bridge/scripts/run_task.py
@@ -74,11 +74,18 @@ def execute_task(task_id: str, repo_root: Path | None = None) -> Dict[str, Any]:
 
     result: Dict[str, Any] = {"ok": False, "detail": "no_executor_matched", "executor": "none"}
 
-    # ── Dispatch path 1: WRE skill execution ──
+    # Dispatch path 1: exact RedDog read-only audit report execution.
+    if "reddog_readonly_audit" in required_skills and source == "reddog_openclaw_readonly_audit_swarm":
+        readonly_result = _try_reddog_readonly_audit_dispatch(repo_root, task_id, context)
+        if readonly_result is not None:
+            result = readonly_result
+
+    # Dispatch path 2: WRE skill execution.
     if required_skills:
-        wre_result = _try_wre_dispatch(repo_root, task_id, required_skills, context, description)
-        if wre_result is not None:
-            result = wre_result
+        if not result["ok"] and result["detail"] == "no_executor_matched":
+            wre_result = _try_wre_dispatch(repo_root, task_id, required_skills, context, description)
+            if wre_result is not None:
+                result = wre_result
 
     # ── Dispatch path 2: Self-audit policy fix ──
     if not result["ok"] and result["detail"] == "no_executor_matched" and source == "self_audit":
@@ -131,6 +138,41 @@ def execute_task(task_id: str, repo_root: Path | None = None) -> Dict[str, Any]:
                 pass
 
     return result
+
+
+def _try_reddog_readonly_audit_dispatch(
+    repo_root: Path,
+    task_id: str,
+    context: dict,
+) -> Dict[str, Any] | None:
+    """Execute an exact RedDog read-only audit task. Returns result or None."""
+    try:
+        from modules.communication.moltbot_bridge.src.reddog_readonly_audit_task_executor import (
+            execute_reddog_readonly_audit_task,
+        )
+    except ImportError as e:
+        logger.debug("[RUN_TASK] RedDog read-only audit executor unavailable: %s", e)
+        return None
+
+    try:
+        audit_result = execute_reddog_readonly_audit_task(
+            task_context=context,
+            repo_root=repo_root,
+        )
+        payload = audit_result.to_dict()
+        return {
+            "ok": bool(audit_result.accepted),
+            "detail": json.dumps(payload, default=str)[:1000],
+            "executor": "reddog:readonly_audit",
+            "structured_result": payload,
+        }
+    except Exception as e:
+        logger.warning("[RUN_TASK] RedDog read-only audit dispatch error: %s", e)
+        return {
+            "ok": False,
+            "detail": f"reddog_readonly_audit_error: {e}",
+            "executor": "reddog:readonly_audit",
+        }
 
 
 def _try_wre_dispatch(

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_audit_task_executor.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_audit_task_executor.py
@@ -1,0 +1,231 @@
+"""Deterministic executor for RedDog read-only audit tasks.
+
+Slice: REDDOG_READONLY_AUDIT_TASK_REPORT_EXECUTOR_PHASE1
+
+This module consumes one AgentDB task context produced by
+`reddog_openclaw_readonly_audit_swarm_enqueue` and emits a read-only audit
+report shape accepted by `validate_reddog_openclaw_readonly_audit_reports`.
+
+It reads only allowlisted repository files, computes evidence digests, and
+returns a structured report. It does not call models, execute shell commands,
+dispatch Hermes/WRE, create worktrees, mutate repository files, mutate
+HoloIndex, enqueue OpenClaw work, or write reports to disk.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
+    READONLY_AUDIT_TASK_SOURCE,
+)
+
+
+READONLY_AUDIT_TASK_REPORT_ACCEPT = "READONLY_AUDIT_TASK_REPORT_ACCEPT"
+READONLY_AUDIT_TASK_REPORT_REJECT = "READONLY_AUDIT_TASK_REPORT_REJECT"
+
+MAX_READ_TARGETS = 32
+MAX_READ_BYTES_PER_TARGET = 12_000
+DENIED_BASENAMES = frozenset({".env", ".env.local", ".env.production", "id_rsa", "id_dsa"})
+DENIED_SEGMENTS = frozenset({".git", ".ssh", ".aws", ".azure", ".gcp", "__pycache__"})
+
+
+class ReadOnlyAuditTaskRejectReason:
+    INVALID_CONTEXT = "REJECT_INVALID_CONTEXT"
+    WRONG_SOURCE = "REJECT_WRONG_SOURCE"
+    MISSING_ASSIGNMENT = "REJECT_MISSING_ASSIGNMENT"
+    TOO_MANY_TARGETS = "REJECT_TOO_MANY_TARGETS"
+    UNSAFE_TARGET = "REJECT_UNSAFE_TARGET"
+    TARGET_READ_FAILED = "REJECT_TARGET_READ_FAILED"
+
+
+@dataclass(frozen=True)
+class ReadOnlyTargetEvidence:
+    path: str
+    digest: str
+    bytes_read: int
+    line_count: int
+    truncated: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ReadOnlyAuditTaskExecutionResult:
+    accepted: bool
+    decision: str
+    report: Optional[Mapping[str, Any]]
+    evidence: tuple[ReadOnlyTargetEvidence, ...]
+    rejection_reasons: tuple[str, ...]
+    no_model_call_performed: bool = True
+    no_shell_command_executed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_worktree_operation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "accepted": self.accepted,
+            "decision": self.decision,
+            "report": dict(self.report) if self.report else None,
+            "evidence": [item.to_dict() for item in self.evidence],
+            "rejection_reasons": list(self.rejection_reasons),
+            "no_model_call_performed": self.no_model_call_performed,
+            "no_shell_command_executed": self.no_shell_command_executed,
+            "no_repo_mutation_performed": self.no_repo_mutation_performed,
+            "no_holoindex_reindex_performed": self.no_holoindex_reindex_performed,
+            "no_openclaw_enqueue_performed": self.no_openclaw_enqueue_performed,
+            "no_hermes_dispatch_performed": self.no_hermes_dispatch_performed,
+            "no_worktree_operation_performed": self.no_worktree_operation_performed,
+        }
+
+
+def execute_reddog_readonly_audit_task(
+    *,
+    task_context: Mapping[str, Any],
+    repo_root: str | Path,
+) -> ReadOnlyAuditTaskExecutionResult:
+    """Execute a RedDog read-only audit task using local file evidence only."""
+
+    if not isinstance(task_context, Mapping):
+        return _reject([ReadOnlyAuditTaskRejectReason.INVALID_CONTEXT])
+    if task_context.get("source") != READONLY_AUDIT_TASK_SOURCE:
+        return _reject([ReadOnlyAuditTaskRejectReason.WRONG_SOURCE])
+    assignment = task_context.get("assignment")
+    if not isinstance(assignment, Mapping):
+        return _reject([ReadOnlyAuditTaskRejectReason.MISSING_ASSIGNMENT])
+
+    targets = tuple(str(value) for value in assignment.get("allowed_read_targets", ()) if str(value).strip())
+    if not targets:
+        return _reject([ReadOnlyAuditTaskRejectReason.MISSING_ASSIGNMENT])
+    if len(targets) > MAX_READ_TARGETS:
+        return _reject([ReadOnlyAuditTaskRejectReason.TOO_MANY_TARGETS])
+
+    root = Path(repo_root).resolve()
+    evidence: list[ReadOnlyTargetEvidence] = []
+    for target in targets:
+        safe_path = _resolve_safe_target(root, target)
+        if safe_path is None:
+            return _reject([ReadOnlyAuditTaskRejectReason.UNSAFE_TARGET])
+        try:
+            evidence.append(_read_target_evidence(root, safe_path))
+        except Exception:
+            return _reject([ReadOnlyAuditTaskRejectReason.TARGET_READ_FAILED])
+
+    report = _build_report(assignment=assignment, evidence=evidence)
+    return ReadOnlyAuditTaskExecutionResult(
+        accepted=True,
+        decision=READONLY_AUDIT_TASK_REPORT_ACCEPT,
+        report=report,
+        evidence=tuple(evidence),
+        rejection_reasons=(),
+    )
+
+
+def _resolve_safe_target(root: Path, target: str) -> Optional[Path]:
+    normalized = str(target).replace("\\", "/").strip()
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    if not normalized or normalized.startswith("/") or normalized.startswith("../") or "/../" in normalized:
+        return None
+    if ":" in normalized or "\x00" in normalized:
+        return None
+    segments = tuple(segment for segment in normalized.split("/") if segment)
+    if any(segment in DENIED_SEGMENTS for segment in segments):
+        return None
+    if not segments or segments[-1] in DENIED_BASENAMES:
+        return None
+    candidate = (root / normalized).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None
+    if not candidate.is_file() or candidate.is_symlink():
+        return None
+    return candidate
+
+
+def _read_target_evidence(root: Path, path: Path) -> ReadOnlyTargetEvidence:
+    raw = path.read_bytes()
+    truncated = len(raw) > MAX_READ_BYTES_PER_TARGET
+    payload = raw[:MAX_READ_BYTES_PER_TARGET]
+    digest = "sha256:" + hashlib.sha256(payload).hexdigest()
+    try:
+        text = payload.decode("utf-8")
+    except UnicodeDecodeError:
+        text = payload.decode("utf-8", errors="replace")
+    relative = path.relative_to(root).as_posix()
+    return ReadOnlyTargetEvidence(
+        path=relative,
+        digest=digest,
+        bytes_read=len(payload),
+        line_count=text.count("\n") + (1 if text else 0),
+        truncated=truncated,
+    )
+
+
+def _build_report(
+    *,
+    assignment: Mapping[str, Any],
+    evidence: Sequence[ReadOnlyTargetEvidence],
+) -> Mapping[str, Any]:
+    lane_id = str(assignment.get("lane_id") or "")
+    assignment_id = str(assignment.get("assignment_id") or "")
+    evidence_refs = tuple(
+        f"file:{item.path}:{item.digest}:lines:{item.line_count}"
+        for item in evidence
+    )
+    return {
+        "assignment_id": assignment_id,
+        "lane_id": lane_id,
+        "snapshot_receipt_id": str(assignment.get("snapshot_receipt_id") or ""),
+        "summary": (
+            f"{lane_id} read-only audit evidence collected from {len(evidence)} target(s); "
+            "no mutation, shell, model, enqueue, or re-index performed."
+        ),
+        "evidence_refs": list(evidence_refs),
+        "repo_mutation_performed": False,
+        "execution_performed": False,
+        "openclaw_enqueue_performed": False,
+        "readonly_audit_performed": True,
+        "target_evidence": [item.to_dict() for item in evidence],
+        "report_digest": "sha256:" + _digest(
+            {
+                "assignment_id": assignment_id,
+                "lane_id": lane_id,
+                "evidence_refs": evidence_refs,
+            }
+        ),
+    }
+
+
+def _reject(reasons: Sequence[str]) -> ReadOnlyAuditTaskExecutionResult:
+    return ReadOnlyAuditTaskExecutionResult(
+        accepted=False,
+        decision=READONLY_AUDIT_TASK_REPORT_REJECT,
+        report=None,
+        evidence=(),
+        rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons)),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "READONLY_AUDIT_TASK_REPORT_ACCEPT",
+    "READONLY_AUDIT_TASK_REPORT_REJECT",
+    "ReadOnlyAuditTaskExecutionResult",
+    "ReadOnlyAuditTaskRejectReason",
+    "ReadOnlyTargetEvidence",
+    "execute_reddog_readonly_audit_task",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
@@ -1,0 +1,205 @@
+"""Tests for REDDOG_READONLY_AUDIT_TASK_REPORT_EXECUTOR_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.scripts.run_task import execute_task
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
+    READONLY_AUDIT_TASK_SKILL,
+    READONLY_AUDIT_TASK_SOURCE,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_task_executor import (
+    READONLY_AUDIT_TASK_REPORT_ACCEPT,
+    READONLY_AUDIT_TASK_REPORT_REJECT,
+    ReadOnlyAuditTaskRejectReason,
+    execute_reddog_readonly_audit_task,
+)
+from modules.infrastructure.database.src.agent_db import AgentDB
+from modules.infrastructure.database.src.db_manager import DatabaseManager
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_readonly_audit_task_executor.py"
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_agent_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("FOUNDUPS_DB_PATH", str(tmp_path / "foundups.db"))
+    DatabaseManager.reset_for_tests()
+    yield
+    DatabaseManager.reset_for_tests()
+
+
+def _repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    target = root / "docs" / "work_ledger.schema.json"
+    target.parent.mkdir(parents=True)
+    target.write_text('{"schema": "work-ledger", "version": 1}\n', encoding="utf-8")
+    other = root / "modules" / "communication" / "moltbot_bridge" / "src" / "sample.py"
+    other.parent.mkdir(parents=True)
+    other.write_text("VALUE = 1\n", encoding="utf-8")
+    return root
+
+
+def _context() -> dict:
+    return {
+        "source": READONLY_AUDIT_TASK_SOURCE,
+        "swarm_receipt": {
+            "swarm_id": "swarm-1",
+            "snapshot_receipt_id": "snapshot-1",
+            "determination_id": "det-1",
+        },
+        "assignment": {
+            "assignment_id": "assignment-1",
+            "lane_id": "repo_code_audit",
+            "snapshot_receipt_id": "snapshot-1",
+            "allowed_read_targets": [
+                "docs/work_ledger.schema.json",
+                "modules/communication/moltbot_bridge/src/sample.py",
+            ],
+        },
+        "forbidden_actions": [
+            "repo_write",
+            "shell_execute",
+            "git_push",
+            "openclaw_enqueue",
+            "holoindex_reindex",
+        ],
+    }
+
+
+def test_readonly_audit_executor_reads_only_allowlisted_targets(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+
+    result = execute_reddog_readonly_audit_task(task_context=_context(), repo_root=root)
+
+    assert result.accepted is True
+    assert result.decision == READONLY_AUDIT_TASK_REPORT_ACCEPT
+    assert result.no_repo_mutation_performed is True
+    assert result.no_shell_command_executed is True
+    assert result.no_holoindex_reindex_performed is True
+    assert result.report is not None
+    assert result.report["repo_mutation_performed"] is False
+    assert result.report["execution_performed"] is False
+    assert result.report["openclaw_enqueue_performed"] is False
+    assert len(result.report["evidence_refs"]) == 2
+    assert all(ref.startswith("file:") for ref in result.report["evidence_refs"])
+
+
+def test_readonly_audit_executor_rejects_wrong_source_or_missing_assignment(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    wrong = dict(_context())
+    wrong["source"] = "other"
+    missing = dict(_context())
+    missing.pop("assignment")
+
+    wrong_result = execute_reddog_readonly_audit_task(task_context=wrong, repo_root=root)
+    missing_result = execute_reddog_readonly_audit_task(task_context=missing, repo_root=root)
+
+    assert wrong_result.accepted is False
+    assert wrong_result.decision == READONLY_AUDIT_TASK_REPORT_REJECT
+    assert ReadOnlyAuditTaskRejectReason.WRONG_SOURCE in wrong_result.rejection_reasons
+    assert missing_result.accepted is False
+    assert ReadOnlyAuditTaskRejectReason.MISSING_ASSIGNMENT in missing_result.rejection_reasons
+
+
+def test_readonly_audit_executor_rejects_traversal_secret_and_missing_targets(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    traversal = _context()
+    traversal["assignment"] = dict(traversal["assignment"])
+    traversal["assignment"]["allowed_read_targets"] = ["../secret.txt"]
+    secret = _context()
+    secret["assignment"] = dict(secret["assignment"])
+    secret["assignment"]["allowed_read_targets"] = [".env"]
+    missing = _context()
+    missing["assignment"] = dict(missing["assignment"])
+    missing["assignment"]["allowed_read_targets"] = ["docs/missing.md"]
+
+    assert ReadOnlyAuditTaskRejectReason.UNSAFE_TARGET in execute_reddog_readonly_audit_task(
+        task_context=traversal,
+        repo_root=root,
+    ).rejection_reasons
+    assert ReadOnlyAuditTaskRejectReason.UNSAFE_TARGET in execute_reddog_readonly_audit_task(
+        task_context=secret,
+        repo_root=root,
+    ).rejection_reasons
+    assert ReadOnlyAuditTaskRejectReason.UNSAFE_TARGET in execute_reddog_readonly_audit_task(
+        task_context=missing,
+        repo_root=root,
+    ).rejection_reasons
+
+
+def test_run_task_executes_reddog_readonly_audit_before_wre(tmp_path: Path, monkeypatch) -> None:
+    root = _repo(tmp_path)
+    monkeypatch.setenv("WRE_MOCK_SKILLS", READONLY_AUDIT_TASK_SKILL)
+    db = AgentDB()
+    task_id = "readonly-audit-task-1"
+    assert db.create_autonomous_task(
+        task_id=task_id,
+        description="RedDog read-only audit lane: repo_code_audit",
+        required_skills=[READONLY_AUDIT_TASK_SKILL],
+        estimated_complexity=0.35,
+        priority_score=0.85,
+        context=_context(),
+        origin_continuity_id="det-1",
+    )
+    assert db.assign_autonomous_task(task_id, "openclaw_supervisor")
+
+    result = execute_task(task_id, repo_root=root)
+
+    assert result["ok"] is True
+    assert result["executor"] == "reddog:readonly_audit"
+    assert result["structured_result"]["accepted"] is True
+    assert db.get_autonomous_task_by_id(task_id)["status"] == "completed"
+
+
+def test_executor_module_ast_has_no_mutation_network_or_runtime_wiring() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    forbidden_text = (
+        "subprocess",
+        "requests",
+        "socket",
+        "openclaw_supervisor",
+        "hermes_job_executor",
+        "execute_skill",
+        "holo_index.py --index",
+        "create_autonomous_task",
+        "write_text",
+        "mkdir",
+        "git push",
+        "gh pr",
+    )
+    for token in forbidden_text:
+        assert token not in source
+
+    imported = set()
+    calls = set()
+    attrs = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.add((node.module or "").split(".")[0])
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                calls.add(node.func.id)
+            elif isinstance(node.func, ast.Attribute):
+                calls.add(node.func.attr)
+        elif isinstance(node, ast.Attribute):
+            attrs.add(node.attr)
+
+    assert not (imported & {"subprocess", "requests", "socket", "urllib", "shutil"})
+    assert not (calls & {"eval", "exec", "compile", "system", "popen", "run", "Popen"})
+    assert not (attrs & {"write_text", "mkdir", "unlink", "rmdir"})


### PR DESCRIPTION
## Summary

Implements `REDDOG_READONLY_AUDIT_TASK_REPORT_EXECUTOR_PHASE1`.

This is the next operational step after #1018. AgentDB tasks emitted from RedDog's read-only audit swarm now have a deterministic `run_task.py` executor that reads only allowlisted repo files and returns report data compatible with the existing read-only audit report validator.

## WSP_97 Truth Boundary

- OBSERVED: exact `source=reddog_openclaw_readonly_audit_swarm` and `required_skills=[reddog_readonly_audit]` tasks dispatch before WRE skill execution.
- OBSERVED: executor reads only safe allowlisted repo file paths and emits evidence digests.
- OBSERVED: AgentDB assigned task completes through `run_task.py` with executor `reddog:readonly_audit`.
- OBSERVED: traversal, secret basename, wrong source, missing assignment, and missing target fail closed.
- OBSERVED: no model call, shell/subprocess, repo write, OpenClaw enqueue, Hermes/WRE dispatch, worktree operation, HoloIndex mutation/re-index, or report file write.
- SPECIFIED_NOT_IMPLEMENTED: report bundle collection from multiple completed tasks and automatic `main.py` runtime execution loop wiring.

## Validation

```text
python -m pytest modules\communication\moltbot_bridge\tests\test_reddog_readonly_audit_task_executor.py -q
5 passed

python -m pytest modules\communication\moltbot_bridge\tests\test_reddog_openclaw_readonly_audit_swarm_enqueue.py modules\communication\moltbot_bridge\tests\test_reddog_readonly_audit_task_executor.py modules\communication\moltbot_bridge\tests\test_reddog_openclaw_readonly_audit_swarm_runtime.py modules\communication\moltbot_bridge\tests\test_openclaw_supervisor.py -q
41 passed

python -m py_compile modules\communication\moltbot_bridge\src\reddog_readonly_audit_task_executor.py modules\communication\moltbot_bridge\scripts\run_task.py modules\communication\moltbot_bridge\tests\test_reddog_readonly_audit_task_executor.py
PASS

git diff --check
PASS (CRLF warnings only)

ASCII/NUL scan
new files: non_ascii=0, nul=0
```

## HoloIndex

Read-only probe for `RedDog readonly audit task report executor AgentDB run_task` surfaced `run_task.py` and adjacent audit surfaces, but not the new executor module. Recorded:

```text
HOLOINDEX_REDDOG_READONLY_AUDIT_TASK_REPORT_EXECUTOR_INDEX_GAP_PHASE1
```

No runtime re-index performed.