### PR TITLE
feat(reddog): wire readonly audit swarm enqueue bootstrap

### DIFF
--- a/main.py
+++ b/main.py
@@ -1182,13 +1182,16 @@ def run_reddog_readonly_operational_bootstrap_preflight(repo_root: Path) -> bool
     Run RedDog's read-only operational bootstrap before DAE autostart.
 
     This binds current work-state and HoloIndex freshness receipts to a
-    read-only OpenClaw audit-swarm plan. It never spawns workers or enqueues
-    OpenClaw. Missing receipts are warning-only by default so the menu still
-    loads while the authoritative runtime wiring is incomplete.
+    read-only OpenClaw audit-swarm plan. It never spawns workers. It publishes
+    read-only audit tasks to AgentDB only when the host explicitly enables
+    the queue bridge. Missing receipts are warning-only by default so the menu
+    still loads while the authoritative runtime wiring is incomplete.
 
     Env:
         REDDOG_READONLY_OPERATIONAL_BOOTSTRAP=1           Enable check (default ON)
         REDDOG_READONLY_OPERATIONAL_BOOTSTRAP_ENFORCED=0  Block startup if not ready
+        REDDOG_READONLY_AUDIT_SWARM_ENQUEUE_ENABLED       Override audit task enqueue bridge
+        OPENCLAW_AUTO_TASKS_ENABLED                       Enables audit task enqueue if no override
         REDDOG_AUTHORITATIVE_WORK_STATE_PATH              Existing work-state JSON
         HOLOINDEX_FRESHNESS_RECEIPT                       Existing HoloIndex receipt
         HOLOINDEX_SSD_PATH                                Derive receipt path if set
@@ -1199,6 +1202,11 @@ def run_reddog_readonly_operational_bootstrap_preflight(repo_root: Path) -> bool
         return True
 
     enforced = os.getenv("REDDOG_READONLY_OPERATIONAL_BOOTSTRAP_ENFORCED", "0") != "0"
+    enqueue_override = os.getenv("REDDOG_READONLY_AUDIT_SWARM_ENQUEUE_ENABLED")
+    if enqueue_override is None:
+        enqueue_requested = os.getenv("OPENCLAW_AUTO_TASKS_ENABLED", "0") != "0"
+    else:
+        enqueue_requested = enqueue_override != "0"
 
     try:
         from modules.communication.moltbot_bridge.src.reddog_main_readonly_operational_bootstrap import (
@@ -1210,6 +1218,7 @@ def run_reddog_readonly_operational_bootstrap_preflight(repo_root: Path) -> bool
             work_state_path=os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
             holoindex_receipt_path=os.getenv("HOLOINDEX_FRESHNESS_RECEIPT", ""),
             holoindex_ssd_path=os.getenv("HOLOINDEX_SSD_PATH", ""),
+            enqueue_readonly_audit_tasks=enqueue_requested,
         )
     except Exception as exc:
         logger.error(f"[REDDOG-BOOTSTRAP] Startup preflight failed: {exc}")
@@ -1223,7 +1232,9 @@ def run_reddog_readonly_operational_bootstrap_preflight(repo_root: Path) -> bool
     reasons = ",".join(result.rejection_reasons) if result.rejection_reasons else "(none)"
     print(
         f"[REDDOG-BOOTSTRAP] preflight={status} status={result.status} "
-        f"assignments={result.assignment_count} reasons={reasons}"
+        f"assignments={result.assignment_count} enqueue_attempted={result.enqueue_attempted} "
+        f"enqueue_decision={result.enqueue_decision or '(none)'} "
+        f"enqueue_tasks={result.enqueue_task_count} reasons={reasons}"
     )
     if result.ready:
         print(

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,32 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_MAIN_READONLY_AUDIT_SWARM_ENQUEUE_WIRE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Extended `src/reddog_main_readonly_operational_bootstrap.py` so an accepted
+  read-only audit swarm plan can be published to AgentDB through the existing
+  read-only audit swarm enqueue module, but only when the host explicitly
+  enables the bridge.
+- Wired `main.py` to pass `enqueue_readonly_audit_tasks=True` when
+  `REDDOG_READONLY_AUDIT_SWARM_ENQUEUE_ENABLED=1`, or when
+  `OPENCLAW_AUTO_TASKS_ENABLED=1` and no RedDog override is set. The default
+  path remains plan-only and menu-safe.
+- Added bootstrap tests for default no-enqueue behavior, injected-writer
+  accepted publication, writer rejection fail-closed behavior, and main
+  preflight env flag/override handling.
+- Boundary: no model call, no worker spawn from the bootstrap, no OpenClaw
+  supervisor call, no Hermes/WRE dispatch, no shell/subprocess, no repo
+  mutation, no worktree operation, no HoloIndex mutation/re-index, and no live
+  FoundUp queue write. Queue mutation is limited to pending read-only AgentDB
+  audit tasks when explicitly enabled.
+- HoloIndex read-only probe for
+  `REDDOG_MAIN_READONLY_AUDIT_SWARM_ENQUEUE_WIRE_PHASE1 main.py AgentDB read-only audit swarm enqueue`
+  surfaced this ModLog pointer and unknown locations, not the runtime module.
+  Recorded
+  `HOLOINDEX_REDDOG_MAIN_READONLY_AUDIT_SWARM_ENQUEUE_WIRE_INDEX_GAP_PHASE1`;
+  no runtime re-index performed.
+
 ## 2026-07-14: REDDOG_READONLY_AUDIT_TASK_REPORT_EXECUTOR_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
@@ -2,9 +2,10 @@
 
 This module composes the already-built RedDog context snapshot, Fusion
 assignment gate, and OpenClaw read-only audit swarm planner into a startup
-check for ``main.py``. It plans only; it does not call models, spawn workers,
-enqueue OpenClaw, dispatch Hermes, mutate queues, write files, or re-index
-HoloIndex.
+check for ``main.py``. By default it plans only; when explicitly enabled by
+the host it publishes the accepted read-only audit plan as pending AgentDB
+tasks. It does not call models, spawn workers, dispatch Hermes, write repo
+files, create worktrees, or re-index HoloIndex.
 """
 
 from __future__ import annotations
@@ -24,6 +25,12 @@ from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swa
     DEFAULT_AUDIT_LANES,
     ReadOnlyAuditSwarmPlan,
     plan_reddog_openclaw_readonly_audit_swarm,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
+    AgentDbReadOnlyAuditTaskWriter,
+    ReadOnlyAuditSwarmEnqueueResult,
+    ReadOnlyAuditTaskWriter,
+    enqueue_reddog_readonly_audit_swarm,
 )
 from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
     EvidenceBundle,
@@ -67,6 +74,11 @@ class RedDogMainReadonlyBootstrapResult:
     rejection_reasons: tuple[str, ...]
     changed_paths: tuple[str, ...]
     allowed_read_targets: tuple[str, ...]
+    enqueue_attempted: bool = False
+    enqueue_decision: Optional[str] = None
+    enqueue_receipt_id: Optional[str] = None
+    enqueue_task_count: int = 0
+    enqueue_rejection_reasons: tuple[str, ...] = ()
     no_model_call_performed: bool = True
     no_worker_spawn_performed: bool = True
     no_openclaw_enqueue_performed: bool = True
@@ -94,6 +106,9 @@ def run_reddog_main_readonly_operational_bootstrap(
     work_state_snapshot_override: Mapping[str, Any] | None = None,
     holoindex_receipt_override: HoloIndexFreshnessReceipt | Mapping[str, Any] | None = None,
     audit_lanes: Sequence[str] = DEFAULT_AUDIT_LANES,
+    enqueue_readonly_audit_tasks: bool = False,
+    enqueue_writer: ReadOnlyAuditTaskWriter | None = None,
+    seen_assignment_ids: Optional[set[str]] = None,
 ) -> RedDogMainReadonlyBootstrapResult:
     """Build a read-only startup plan or explain why it is not ready."""
 
@@ -198,6 +213,26 @@ def run_reddog_main_readonly_operational_bootstrap(
             swarm_plan=plan,
         )
 
+    enqueue_result: ReadOnlyAuditSwarmEnqueueResult | None = None
+    if enqueue_readonly_audit_tasks:
+        writer = enqueue_writer if enqueue_writer is not None else AgentDbReadOnlyAuditTaskWriter()
+        enqueue_result = enqueue_reddog_readonly_audit_swarm(
+            plan=plan,
+            writer=writer,
+            seen_assignment_ids=seen_assignment_ids,
+        )
+        if not enqueue_result.accepted:
+            return _not_ready(
+                reasons=("readonly_audit_enqueue_rejected", *enqueue_result.rejection_reasons),
+                changed_paths=paths,
+                allowed_read_targets=targets,
+                snapshot=snapshot,
+                evidence_bundle=evidence_bundle,
+                gate=gate,
+                swarm_plan=plan,
+                enqueue_result=enqueue_result,
+            )
+
     return RedDogMainReadonlyBootstrapResult(
         ready=True,
         status=REDDOG_MAIN_BOOTSTRAP_READY,
@@ -210,6 +245,13 @@ def run_reddog_main_readonly_operational_bootstrap(
         rejection_reasons=(),
         changed_paths=paths,
         allowed_read_targets=targets,
+        enqueue_attempted=enqueue_readonly_audit_tasks,
+        enqueue_decision=enqueue_result.decision if enqueue_result else None,
+        enqueue_receipt_id=enqueue_result.receipt.enqueue_receipt_id if enqueue_result else None,
+        enqueue_task_count=len(enqueue_result.tasks) if enqueue_result else 0,
+        enqueue_rejection_reasons=enqueue_result.rejection_reasons if enqueue_result else (),
+        no_openclaw_enqueue_performed=not bool(enqueue_result and enqueue_result.accepted),
+        no_queue_mutation_performed=not bool(enqueue_result and enqueue_result.accepted),
     )
 
 
@@ -253,6 +295,7 @@ def _not_ready(
     evidence_bundle: EvidenceBundle | None = None,
     gate: FusionAssignmentGateDecision | None = None,
     swarm_plan: ReadOnlyAuditSwarmPlan | None = None,
+    enqueue_result: ReadOnlyAuditSwarmEnqueueResult | None = None,
 ) -> RedDogMainReadonlyBootstrapResult:
     determination_id = None
     if gate and gate.determination_binding:
@@ -269,6 +312,11 @@ def _not_ready(
         rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons if str(reason).strip())),
         changed_paths=tuple(changed_paths),
         allowed_read_targets=tuple(allowed_read_targets),
+        enqueue_attempted=enqueue_result is not None,
+        enqueue_decision=enqueue_result.decision if enqueue_result else None,
+        enqueue_receipt_id=enqueue_result.receipt.enqueue_receipt_id if enqueue_result else None,
+        enqueue_task_count=len(enqueue_result.tasks) if enqueue_result and enqueue_result.accepted else 0,
+        enqueue_rejection_reasons=enqueue_result.rejection_reasons if enqueue_result else (),
     )
 
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -15,6 +15,11 @@ from modules.communication.moltbot_bridge.src.reddog_main_readonly_operational_b
     RedDogMainReadonlyBootstrapResult,
     run_reddog_main_readonly_operational_bootstrap,
 )
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
+    READONLY_AUDIT_SWARM_ENQUEUE_ACCEPT,
+    READONLY_AUDIT_SWARM_ENQUEUE_REJECT,
+    ReadOnlyAuditEnqueueReason,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -80,6 +85,19 @@ def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
     )
 
 
+class _FakeEnqueueWriter:
+    def __init__(self, *, ok: bool = True) -> None:
+        self.ok = ok
+        self.calls: list[tuple[list[object], object]] = []
+
+    def enqueue_readonly_audit_tasks(self, tasks, receipt):
+        copied = list(tasks)
+        self.calls.append((copied, receipt))
+        if not self.ok:
+            return {"ok": False, "reason": "writer_rejected", "created_task_ids": []}
+        return {"ok": True, "created_task_ids": [task.task_id for task in copied]}
+
+
 def test_bootstrap_plans_default_readonly_audit_swarm_from_fresh_context() -> None:
     result = run_reddog_main_readonly_operational_bootstrap(
         repo_root=REPO_ROOT,
@@ -103,6 +121,61 @@ def test_bootstrap_plans_default_readonly_audit_swarm_from_fresh_context() -> No
     assert result.no_hermes_dispatch_performed is True
     assert result.no_repo_mutation_performed is True
     assert result.no_holoindex_reindex_performed is True
+    assert result.no_queue_mutation_performed is True
+    assert result.enqueue_attempted is False
+    assert result.enqueue_decision is None
+    assert result.enqueue_task_count == 0
+
+
+def test_bootstrap_enqueue_opt_in_publishes_readonly_audit_tasks() -> None:
+    writer = _FakeEnqueueWriter()
+
+    result = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+        enqueue_readonly_audit_tasks=True,
+        enqueue_writer=writer,
+        seen_assignment_ids=set(),
+    )
+
+    assert result.ready is True
+    assert result.status == REDDOG_MAIN_BOOTSTRAP_READY
+    assert len(writer.calls) == 1
+    assert len(writer.calls[0][0]) == result.assignment_count == 5
+    assert result.enqueue_attempted is True
+    assert result.enqueue_decision == READONLY_AUDIT_SWARM_ENQUEUE_ACCEPT
+    assert result.enqueue_receipt_id and result.enqueue_receipt_id.startswith("readonly-audit-enqueue-")
+    assert result.enqueue_task_count == 5
+    assert result.enqueue_rejection_reasons == ()
+    assert result.no_openclaw_enqueue_performed is False
+    assert result.no_queue_mutation_performed is False
+
+
+def test_bootstrap_enqueue_rejection_is_not_ready_without_spawning_workers() -> None:
+    writer = _FakeEnqueueWriter(ok=False)
+
+    result = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+        enqueue_readonly_audit_tasks=True,
+        enqueue_writer=writer,
+    )
+
+    assert result.ready is False
+    assert result.status == REDDOG_MAIN_BOOTSTRAP_NOT_READY
+    assert "readonly_audit_enqueue_rejected" in result.rejection_reasons
+    assert ReadOnlyAuditEnqueueReason.WRITER_REJECTED in result.rejection_reasons
+    assert result.enqueue_attempted is True
+    assert result.enqueue_decision == READONLY_AUDIT_SWARM_ENQUEUE_REJECT
+    assert result.enqueue_task_count == 0
+    assert result.enqueue_rejection_reasons == (ReadOnlyAuditEnqueueReason.WRITER_REJECTED,)
+    assert result.no_worker_spawn_performed is True
     assert result.no_queue_mutation_performed is True
 
 
@@ -252,6 +325,73 @@ def test_main_preflight_reports_ready_without_blocking_menu() -> None:
     ):
         with patch.dict("os.environ", {"REDDOG_READONLY_OPERATIONAL_BOOTSTRAP": "1"}, clear=False):
             assert main.run_reddog_readonly_operational_bootstrap_preflight(REPO_ROOT) is True
+
+
+def test_main_preflight_enables_enqueue_when_openclaw_auto_tasks_enabled() -> None:
+    import main
+
+    ready_result = RedDogMainReadonlyBootstrapResult(
+        ready=True,
+        status=REDDOG_MAIN_BOOTSTRAP_READY,
+        snapshot_receipt_id="sha256:snapshot",
+        context_view_id="sha256:view",
+        evidence_bundle_id="sha256:evidence",
+        determination_id="sha256:determination",
+        swarm_id="sha256:swarm",
+        assignment_count=5,
+        rejection_reasons=(),
+        changed_paths=DEFAULT_BOOTSTRAP_CHANGED_PATHS,
+        allowed_read_targets=DEFAULT_BOOTSTRAP_CHANGED_PATHS,
+    )
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_readonly_operational_bootstrap.run_reddog_main_readonly_operational_bootstrap",
+        return_value=ready_result,
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_READONLY_OPERATIONAL_BOOTSTRAP": "1",
+                "OPENCLAW_AUTO_TASKS_ENABLED": "1",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_readonly_operational_bootstrap_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["enqueue_readonly_audit_tasks"] is True
+
+
+def test_main_preflight_explicit_enqueue_disable_overrides_openclaw_auto_tasks() -> None:
+    import main
+
+    ready_result = RedDogMainReadonlyBootstrapResult(
+        ready=True,
+        status=REDDOG_MAIN_BOOTSTRAP_READY,
+        snapshot_receipt_id="sha256:snapshot",
+        context_view_id="sha256:view",
+        evidence_bundle_id="sha256:evidence",
+        determination_id="sha256:determination",
+        swarm_id="sha256:swarm",
+        assignment_count=5,
+        rejection_reasons=(),
+        changed_paths=DEFAULT_BOOTSTRAP_CHANGED_PATHS,
+        allowed_read_targets=DEFAULT_BOOTSTRAP_CHANGED_PATHS,
+    )
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_readonly_operational_bootstrap.run_reddog_main_readonly_operational_bootstrap",
+        return_value=ready_result,
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_READONLY_OPERATIONAL_BOOTSTRAP": "1",
+                "OPENCLAW_AUTO_TASKS_ENABLED": "1",
+                "REDDOG_READONLY_AUDIT_SWARM_ENQUEUE_ENABLED": "0",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_readonly_operational_bootstrap_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["enqueue_readonly_audit_tasks"] is False
 
 
 def test_bootstrap_module_has_no_runtime_mutation_or_execution_imports() -> None:


### PR DESCRIPTION
## Summary

Implements `REDDOG_MAIN_READONLY_AUDIT_SWARM_ENQUEUE_WIRE_PHASE1`.

This wires the existing `main.py` read-only operational bootstrap to the existing RedDog read-only audit swarm AgentDB enqueue bridge, but only behind an explicit host gate.

## Behavior

- Default startup remains plan-only and menu-safe.
- `REDDOG_READONLY_AUDIT_SWARM_ENQUEUE_ENABLED=1` enables AgentDB publication of accepted read-only audit assignments.
- If no RedDog override is set, `OPENCLAW_AUTO_TASKS_ENABLED=1` also enables the bridge.
- `REDDOG_READONLY_AUDIT_SWARM_ENQUEUE_ENABLED=0` overrides OpenClaw auto-tasks and keeps this bootstrap plan-only.
- Enqueue rejection returns `REDDOG_MAIN_BOOTSTRAP_NOT_READY`; default startup remains warning-only unless `REDDOG_READONLY_OPERATIONAL_BOOTSTRAP_ENFORCED=1`.

## WSP_97 Boundary

OBSERVED:
- Reuses the already landed read-only audit swarm planner and AgentDB enqueue module.
- Uses injected writer support for tests and the concrete `AgentDbReadOnlyAuditTaskWriter` only when the host enables enqueue.
- Main preflight now prints enqueue attempt/decision/task-count telemetry.

SPECIFIED_NOT_IMPLEMENTED / explicitly not performed:
- No model call.
- No worker spawn from bootstrap.
- No OpenClaw supervisor call.
- No Hermes/WRE dispatch.
- No shell/subprocess.
- No repo mutation or worktree operation.
- No HoloIndex mutation/re-index.
- No live FoundUp queue write.

## Validation

```text
python -m pytest modules\communication\moltbot_bridge\tests\test_reddog_main_authoritative_work_state_refresh_bootstrap.py modules\communication\moltbot_bridge\tests\test_reddog_main_readonly_operational_bootstrap.py modules\communication\moltbot_bridge\tests\test_reddog_openclaw_readonly_audit_swarm_runtime.py modules\communication\moltbot_bridge\tests\test_reddog_openclaw_readonly_audit_swarm_enqueue.py modules\communication\moltbot_bridge\tests\test_reddog_readonly_audit_task_executor.py -q
44 passed

python -m py_compile main.py modules\communication\moltbot_bridge\src\reddog_main_readonly_operational_bootstrap.py
PASS

git diff --check
PASS (Windows autocrlf warnings only)
```

## HoloIndex

Read-only probe for `REDDOG_MAIN_READONLY_AUDIT_SWARM_ENQUEUE_WIRE_PHASE1 main.py AgentDB read-only audit swarm enqueue` surfaced the ModLog pointer and unknown locations, not the runtime module. Recorded `HOLOINDEX_REDDOG_MAIN_READONLY_AUDIT_SWARM_ENQUEUE_WIRE_INDEX_GAP_PHASE1`; no runtime re-index performed.