### PR TITLE
feat(reddog): persist readonly audit reports

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,31 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_READONLY_AUDIT_REPORT_COLLECTION_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_readonly_audit_report_collection.py`: AgentDB-backed
+  persistence and collection for accepted RedDog read-only audit task reports.
+  The collector feeds persisted reports into the existing read-only audit swarm
+  report validator.
+- Updated `scripts/run_task.py`: exact `reddog:readonly_audit` tasks now must
+  persist their structured report before the AgentDB task is marked completed;
+  persistence failure fails the task closed.
+- Added `tests/test_reddog_readonly_audit_report_collection.py`: accepted
+  persistence, missing-report rejection, binding/mutation rejection,
+  conflicting duplicate rejection, real `run_task.py` persistence before task
+  completion, and AST no-execution/no-repo-mutation coverage.
+- Boundary: no model call, no shell/subprocess, no repo mutation, no OpenClaw
+  enqueue, no Hermes/WRE dispatch, no worktree operation, no HoloIndex
+  mutation/re-index, and no report file write. Runtime write scope is limited
+  to the RedDog read-only audit report table in AgentDB.
+- HoloIndex read-only probe for
+  `REDDOG_READONLY_AUDIT_REPORT_COLLECTION_PHASE1 AgentDB read-only audit report collection`
+  surfaced this ModLog pointer and adjacent audit assets, not the new
+  collector module. Recorded
+  `HOLOINDEX_REDDOG_READONLY_AUDIT_REPORT_COLLECTION_INDEX_GAP_PHASE1`; no
+  runtime re-index performed.
+
 ## 2026-07-14: REDDOG_MAIN_READONLY_AUDIT_SWARM_ENQUEUE_WIRE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/scripts/run_task.py
+++ b/modules/communication/moltbot_bridge/scripts/run_task.py
@@ -109,6 +109,12 @@ def execute_task(task_id: str, repo_root: Path | None = None) -> Dict[str, Any]:
     # ── Finalize in AgentDB ──
     elapsed_ms = int((time.monotonic() - start) * 1000)
     result["execution_time_ms"] = elapsed_ms
+    if result["ok"] and result.get("executor") == "reddog:readonly_audit":
+        persist_result = _try_reddog_readonly_audit_report_persist(task_id, context, result)
+        result["readonly_audit_report_persist"] = persist_result
+        if not persist_result.get("accepted", False):
+            result["ok"] = False
+            result["detail"] = json.dumps(persist_result, default=str)[:1000]
 
     if result["ok"]:
         db.complete_autonomous_task(task_id)
@@ -172,6 +178,39 @@ def _try_reddog_readonly_audit_dispatch(
             "ok": False,
             "detail": f"reddog_readonly_audit_error: {e}",
             "executor": "reddog:readonly_audit",
+        }
+
+
+def _try_reddog_readonly_audit_report_persist(
+    task_id: str,
+    context: dict,
+    result: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Persist exact RedDog read-only audit task reports before completion."""
+    try:
+        from modules.communication.moltbot_bridge.src.reddog_readonly_audit_report_collection import (
+            persist_reddog_readonly_audit_task_report,
+        )
+    except ImportError as e:
+        logger.warning("[RUN_TASK] RedDog read-only audit report store unavailable: %s", e)
+        return {
+            "accepted": False,
+            "status": "READONLY_AUDIT_REPORT_PERSIST_REJECT",
+            "rejection_reasons": ["report_store_unavailable"],
+        }
+
+    try:
+        return persist_reddog_readonly_audit_task_report(
+            task_id=task_id,
+            task_context=context,
+            task_result=result,
+        ).to_dict()
+    except Exception as e:
+        logger.warning("[RUN_TASK] RedDog read-only audit report persist error: %s", e)
+        return {
+            "accepted": False,
+            "status": "READONLY_AUDIT_REPORT_PERSIST_REJECT",
+            "rejection_reasons": ["report_store_error"],
         }
 
 

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_audit_report_collection.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_audit_report_collection.py
@@ -1,0 +1,416 @@
+"""Persist and collect RedDog read-only audit reports.
+
+Slice: REDDOG_READONLY_AUDIT_REPORT_COLLECTION_PHASE1
+
+This module stores accepted read-only audit task reports in AgentDB and
+collects them back into the existing read-only audit swarm report validator.
+It performs no model calls, shell commands, task execution, repository writes,
+worktree operations, OpenClaw enqueue, Hermes/WRE dispatch, or HoloIndex
+mutation/re-index.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Optional, Protocol, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
+    READONLY_AUDIT_TASK_SOURCE,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_runtime import (
+    ReadOnlyAuditReportValidationResult,
+    ReadOnlyAuditSwarmPlan,
+    validate_reddog_openclaw_readonly_audit_reports,
+)
+
+
+READONLY_AUDIT_REPORT_PERSIST_ACCEPT = "READONLY_AUDIT_REPORT_PERSIST_ACCEPT"
+READONLY_AUDIT_REPORT_PERSIST_REJECT = "READONLY_AUDIT_REPORT_PERSIST_REJECT"
+READONLY_AUDIT_REPORT_COLLECTION_ACCEPT = "READONLY_AUDIT_REPORT_COLLECTION_ACCEPT"
+READONLY_AUDIT_REPORT_COLLECTION_REJECT = "READONLY_AUDIT_REPORT_COLLECTION_REJECT"
+
+
+class ReadOnlyAuditReportReason:
+    WRONG_SOURCE = "REJECT_READONLY_AUDIT_REPORT_WRONG_SOURCE"
+    TASK_NOT_ACCEPTED = "REJECT_READONLY_AUDIT_REPORT_TASK_NOT_ACCEPTED"
+    MISSING_STRUCTURED_RESULT = "REJECT_READONLY_AUDIT_REPORT_MISSING_STRUCTURED_RESULT"
+    REPORT_NOT_ACCEPTED = "REJECT_READONLY_AUDIT_REPORT_NOT_ACCEPTED"
+    MISSING_SWARM_RECEIPT = "REJECT_READONLY_AUDIT_REPORT_MISSING_SWARM_RECEIPT"
+    MISSING_ASSIGNMENT = "REJECT_READONLY_AUDIT_REPORT_MISSING_ASSIGNMENT"
+    MISSING_REPORT = "REJECT_READONLY_AUDIT_REPORT_MISSING_REPORT"
+    REPORT_BINDING_MISMATCH = "REJECT_READONLY_AUDIT_REPORT_BINDING_MISMATCH"
+    REPORT_CLAIMS_MUTATION = "REJECT_READONLY_AUDIT_REPORT_CLAIMS_MUTATION"
+    REPORT_MISSING_EVIDENCE = "REJECT_READONLY_AUDIT_REPORT_MISSING_EVIDENCE"
+    STORE_REJECTED = "REJECT_READONLY_AUDIT_REPORT_STORE_REJECTED"
+
+
+@dataclass(frozen=True)
+class ReadOnlyAuditReportRecord:
+    task_id: str
+    swarm_id: str
+    assignment_id: str
+    lane_id: str
+    snapshot_receipt_id: str
+    report_digest: str
+    report: Mapping[str, Any]
+    stored_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "swarm_id": self.swarm_id,
+            "assignment_id": self.assignment_id,
+            "lane_id": self.lane_id,
+            "snapshot_receipt_id": self.snapshot_receipt_id,
+            "report_digest": self.report_digest,
+            "report": dict(self.report),
+            "stored_at": self.stored_at,
+        }
+
+
+@dataclass(frozen=True)
+class ReadOnlyAuditReportPersistResult:
+    accepted: bool
+    status: str
+    task_id: str
+    swarm_id: Optional[str]
+    assignment_id: Optional[str]
+    report_digest: Optional[str]
+    rejection_reasons: tuple[str, ...]
+    no_model_call_performed: bool = True
+    no_shell_command_executed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_worktree_operation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ReadOnlyAuditReportCollectionResult:
+    accepted: bool
+    status: str
+    swarm_id: str
+    report_count: int
+    validation: ReadOnlyAuditReportValidationResult
+    rejection_reasons: tuple[str, ...]
+    no_model_call_performed: bool = True
+    no_shell_command_executed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_worktree_operation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "accepted": self.accepted,
+            "status": self.status,
+            "swarm_id": self.swarm_id,
+            "report_count": self.report_count,
+            "validation": self.validation.to_dict(),
+            "rejection_reasons": list(self.rejection_reasons),
+            "no_model_call_performed": self.no_model_call_performed,
+            "no_shell_command_executed": self.no_shell_command_executed,
+            "no_repo_mutation_performed": self.no_repo_mutation_performed,
+            "no_holoindex_reindex_performed": self.no_holoindex_reindex_performed,
+            "no_openclaw_enqueue_performed": self.no_openclaw_enqueue_performed,
+            "no_hermes_dispatch_performed": self.no_hermes_dispatch_performed,
+            "no_worktree_operation_performed": self.no_worktree_operation_performed,
+        }
+
+
+class ReadOnlyAuditReportStore(Protocol):
+    def store_readonly_audit_report(self, record: ReadOnlyAuditReportRecord) -> Mapping[str, Any]: ...
+
+    def load_readonly_audit_reports(self, swarm_id: str) -> Sequence[Mapping[str, Any]]: ...
+
+
+class AgentDbReadOnlyAuditReportStore:
+    """AgentDB-backed store for read-only audit report records."""
+
+    def __init__(self, agent_db_factory: Optional[Any] = None) -> None:
+        self._agent_db_factory = agent_db_factory
+
+    def store_readonly_audit_report(self, record: ReadOnlyAuditReportRecord) -> Mapping[str, Any]:
+        db = self._agent_db()
+        self._ensure_table(db)
+        report_json = _canonical_json(record.report)
+        with db.db.get_connection() as conn:
+            existing = conn.execute(
+                """
+                SELECT report_digest FROM reddog_readonly_audit_reports
+                WHERE assignment_id = ?
+                """,
+                (record.assignment_id,),
+            ).fetchone()
+            if existing:
+                existing_digest = existing["report_digest"] if hasattr(existing, "keys") else existing[0]
+                if existing_digest == record.report_digest:
+                    return {"ok": True, "stored": False, "idempotent": True}
+                return {"ok": False, "reason": "conflicting_assignment_report"}
+
+            conn.execute(
+                """
+                INSERT INTO reddog_readonly_audit_reports
+                (assignment_id, task_id, swarm_id, lane_id, snapshot_receipt_id,
+                 report_digest, report_json, stored_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.assignment_id,
+                    record.task_id,
+                    record.swarm_id,
+                    record.lane_id,
+                    record.snapshot_receipt_id,
+                    record.report_digest,
+                    report_json,
+                    record.stored_at,
+                ),
+            )
+        return {"ok": True, "stored": True}
+
+    def load_readonly_audit_reports(self, swarm_id: str) -> Sequence[Mapping[str, Any]]:
+        db = self._agent_db()
+        self._ensure_table(db)
+        rows = db.db.execute_query(
+            """
+            SELECT report_json FROM reddog_readonly_audit_reports
+            WHERE swarm_id = ?
+            ORDER BY lane_id ASC, assignment_id ASC
+            """,
+            (swarm_id,),
+        )
+        reports: list[Mapping[str, Any]] = []
+        for row in rows:
+            value = row["report_json"] if isinstance(row, Mapping) else row[0]
+            reports.append(json.loads(value))
+        return tuple(reports)
+
+    def _agent_db(self) -> Any:
+        factory = self._agent_db_factory
+        if factory is None:
+            from modules.infrastructure.database.src.agent_db import AgentDB
+
+            factory = AgentDB
+        return factory()
+
+    @staticmethod
+    def _ensure_table(db: Any) -> None:
+        with db.db.get_connection() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS reddog_readonly_audit_reports (
+                    assignment_id TEXT PRIMARY KEY,
+                    task_id TEXT NOT NULL,
+                    swarm_id TEXT NOT NULL,
+                    lane_id TEXT NOT NULL,
+                    snapshot_receipt_id TEXT NOT NULL,
+                    report_digest TEXT NOT NULL,
+                    report_json TEXT NOT NULL,
+                    stored_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_reddog_readonly_audit_reports_swarm
+                ON reddog_readonly_audit_reports(swarm_id)
+                """
+            )
+
+
+def persist_reddog_readonly_audit_task_report(
+    *,
+    task_id: str,
+    task_context: Mapping[str, Any],
+    task_result: Mapping[str, Any],
+    store: ReadOnlyAuditReportStore | None = None,
+    now: datetime | None = None,
+) -> ReadOnlyAuditReportPersistResult:
+    """Persist an accepted RedDog read-only audit task report."""
+
+    reasons: list[str] = []
+    if task_context.get("source") != READONLY_AUDIT_TASK_SOURCE:
+        reasons.append(ReadOnlyAuditReportReason.WRONG_SOURCE)
+    if task_result.get("ok") is not True:
+        reasons.append(ReadOnlyAuditReportReason.TASK_NOT_ACCEPTED)
+
+    structured = task_result.get("structured_result")
+    if not isinstance(structured, Mapping):
+        reasons.append(ReadOnlyAuditReportReason.MISSING_STRUCTURED_RESULT)
+        structured = {}
+    elif structured.get("accepted") is not True:
+        reasons.append(ReadOnlyAuditReportReason.REPORT_NOT_ACCEPTED)
+
+    swarm_receipt = task_context.get("swarm_receipt")
+    if not isinstance(swarm_receipt, Mapping):
+        reasons.append(ReadOnlyAuditReportReason.MISSING_SWARM_RECEIPT)
+        swarm_receipt = {}
+    assignment = task_context.get("assignment")
+    if not isinstance(assignment, Mapping):
+        reasons.append(ReadOnlyAuditReportReason.MISSING_ASSIGNMENT)
+        assignment = {}
+    report = structured.get("report") if isinstance(structured, Mapping) else None
+    if not isinstance(report, Mapping):
+        reasons.append(ReadOnlyAuditReportReason.MISSING_REPORT)
+        report = {}
+
+    swarm_id = str(swarm_receipt.get("swarm_id") or "").strip()
+    assignment_id = str(assignment.get("assignment_id") or "").strip()
+    lane_id = str(assignment.get("lane_id") or "").strip()
+    snapshot_receipt_id = str(assignment.get("snapshot_receipt_id") or "").strip()
+    report_digest = str(report.get("report_digest") or "").strip()
+
+    if not _report_matches_assignment(
+        report=report,
+        assignment_id=assignment_id,
+        lane_id=lane_id,
+        snapshot_receipt_id=snapshot_receipt_id,
+    ):
+        reasons.append(ReadOnlyAuditReportReason.REPORT_BINDING_MISMATCH)
+    if report.get("repo_mutation_performed") is True or report.get("execution_performed") is True:
+        reasons.append(ReadOnlyAuditReportReason.REPORT_CLAIMS_MUTATION)
+    if report.get("openclaw_enqueue_performed") is True:
+        reasons.append(ReadOnlyAuditReportReason.REPORT_CLAIMS_MUTATION)
+    evidence_refs = report.get("evidence_refs")
+    if not isinstance(evidence_refs, Sequence) or isinstance(evidence_refs, (str, bytes)) or not evidence_refs:
+        reasons.append(ReadOnlyAuditReportReason.REPORT_MISSING_EVIDENCE)
+    if not swarm_id or not assignment_id or not lane_id or not snapshot_receipt_id or not report_digest:
+        reasons.append(ReadOnlyAuditReportReason.REPORT_BINDING_MISMATCH)
+
+    deduped = _dedupe(reasons)
+    if deduped:
+        return _persist_result(
+            accepted=False,
+            task_id=task_id,
+            swarm_id=swarm_id or None,
+            assignment_id=assignment_id or None,
+            report_digest=report_digest or None,
+            reasons=deduped,
+        )
+
+    writer = store if store is not None else AgentDbReadOnlyAuditReportStore()
+    record = ReadOnlyAuditReportRecord(
+        task_id=str(task_id),
+        swarm_id=swarm_id,
+        assignment_id=assignment_id,
+        lane_id=lane_id,
+        snapshot_receipt_id=snapshot_receipt_id,
+        report_digest=report_digest,
+        report=report,
+        stored_at=_iso8601(now),
+    )
+    try:
+        write_result = writer.store_readonly_audit_report(record)
+    except Exception:
+        write_result = {"ok": False, "reason": "store_exception"}
+    if not isinstance(write_result, Mapping) or write_result.get("ok") is not True:
+        return _persist_result(
+            accepted=False,
+            task_id=task_id,
+            swarm_id=swarm_id,
+            assignment_id=assignment_id,
+            report_digest=report_digest,
+            reasons=(ReadOnlyAuditReportReason.STORE_REJECTED,),
+        )
+
+    return _persist_result(
+        accepted=True,
+        task_id=task_id,
+        swarm_id=swarm_id,
+        assignment_id=assignment_id,
+        report_digest=report_digest,
+        reasons=(),
+    )
+
+
+def collect_reddog_readonly_audit_report_bundle(
+    *,
+    plan: ReadOnlyAuditSwarmPlan,
+    store: ReadOnlyAuditReportStore | None = None,
+) -> ReadOnlyAuditReportCollectionResult:
+    """Load persisted reports for a swarm plan and validate the bundle."""
+
+    reader = store if store is not None else AgentDbReadOnlyAuditReportStore()
+    reports = tuple(reader.load_readonly_audit_reports(plan.receipt.swarm_id))
+    validation = validate_reddog_openclaw_readonly_audit_reports(plan=plan, reports=reports)
+    status = READONLY_AUDIT_REPORT_COLLECTION_ACCEPT if validation.accepted else READONLY_AUDIT_REPORT_COLLECTION_REJECT
+    return ReadOnlyAuditReportCollectionResult(
+        accepted=validation.accepted,
+        status=status,
+        swarm_id=plan.receipt.swarm_id,
+        report_count=len(reports),
+        validation=validation,
+        rejection_reasons=validation.rejection_reasons,
+    )
+
+
+def _report_matches_assignment(
+    *,
+    report: Mapping[str, Any],
+    assignment_id: str,
+    lane_id: str,
+    snapshot_receipt_id: str,
+) -> bool:
+    return (
+        str(report.get("assignment_id") or "").strip() == assignment_id
+        and str(report.get("lane_id") or "").strip() == lane_id
+        and str(report.get("snapshot_receipt_id") or "").strip() == snapshot_receipt_id
+    )
+
+
+def _persist_result(
+    *,
+    accepted: bool,
+    task_id: str,
+    swarm_id: Optional[str],
+    assignment_id: Optional[str],
+    report_digest: Optional[str],
+    reasons: Sequence[str],
+) -> ReadOnlyAuditReportPersistResult:
+    return ReadOnlyAuditReportPersistResult(
+        accepted=accepted,
+        status=READONLY_AUDIT_REPORT_PERSIST_ACCEPT if accepted else READONLY_AUDIT_REPORT_PERSIST_REJECT,
+        task_id=str(task_id),
+        swarm_id=swarm_id,
+        assignment_id=assignment_id,
+        report_digest=report_digest,
+        rejection_reasons=tuple(reasons),
+    )
+
+
+def _iso8601(now: datetime | None = None) -> str:
+    value = now or datetime.now(timezone.utc)
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def _dedupe(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(str(value) for value in values if str(value).strip()))
+
+
+__all__ = [
+    "AgentDbReadOnlyAuditReportStore",
+    "READONLY_AUDIT_REPORT_COLLECTION_ACCEPT",
+    "READONLY_AUDIT_REPORT_COLLECTION_REJECT",
+    "READONLY_AUDIT_REPORT_PERSIST_ACCEPT",
+    "READONLY_AUDIT_REPORT_PERSIST_REJECT",
+    "ReadOnlyAuditReportCollectionResult",
+    "ReadOnlyAuditReportPersistResult",
+    "ReadOnlyAuditReportReason",
+    "ReadOnlyAuditReportRecord",
+    "ReadOnlyAuditReportStore",
+    "collect_reddog_readonly_audit_report_bundle",
+    "persist_reddog_readonly_audit_task_report",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_report_collection.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_report_collection.py
@@ -1,0 +1,272 @@
+"""Tests for REDDOG_READONLY_AUDIT_REPORT_COLLECTION_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.scripts.run_task import execute_task
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
+    READONLY_AUDIT_TASK_SKILL,
+    READONLY_AUDIT_TASK_SOURCE,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_runtime import (
+    READONLY_AUDIT_REPORTS_ACCEPTED,
+    READONLY_AUDIT_REPORTS_REJECTED,
+    READONLY_AUDIT_SWARM_PLANNED,
+    ReadOnlyAuditAssignment,
+    ReadOnlyAuditSwarmPlan,
+    ReadOnlyAuditSwarmReceipt,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_report_collection import (
+    READONLY_AUDIT_REPORT_COLLECTION_ACCEPT,
+    READONLY_AUDIT_REPORT_COLLECTION_REJECT,
+    READONLY_AUDIT_REPORT_PERSIST_ACCEPT,
+    READONLY_AUDIT_REPORT_PERSIST_REJECT,
+    AgentDbReadOnlyAuditReportStore,
+    ReadOnlyAuditReportReason,
+    collect_reddog_readonly_audit_report_bundle,
+    persist_reddog_readonly_audit_task_report,
+)
+from modules.infrastructure.database.src.agent_db import AgentDB
+from modules.infrastructure.database.src.db_manager import DatabaseManager
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_readonly_audit_report_collection.py"
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_agent_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("FOUNDUPS_DB_PATH", str(tmp_path / "foundups.db"))
+    DatabaseManager.reset_for_tests()
+    yield
+    DatabaseManager.reset_for_tests()
+
+
+def _repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    target = root / "docs" / "work_ledger.schema.json"
+    target.parent.mkdir(parents=True)
+    target.write_text('{"schema": "work-ledger", "version": 1}\n', encoding="utf-8")
+    return root
+
+
+def _assignment() -> ReadOnlyAuditAssignment:
+    return ReadOnlyAuditAssignment(
+        assignment_id="readonly-assignment-1",
+        lane_id="repo_code_audit",
+        worker_role="readonly_repo_code_audit",
+        snapshot_receipt_id="sha256:snapshot",
+        snapshot_content_digest="sha256:snapshot-content",
+        context_view_id="sha256:view",
+        evidence_bundle_id="sha256:evidence",
+        determination_id="sha256:determination",
+        required_source="repo",
+        allowed_read_targets=("docs/work_ledger.schema.json",),
+    )
+
+
+def _plan() -> ReadOnlyAuditSwarmPlan:
+    assignment = _assignment()
+    receipt = ReadOnlyAuditSwarmReceipt(
+        swarm_id="readonly-swarm-1",
+        status=READONLY_AUDIT_SWARM_PLANNED,
+        snapshot_receipt_id=assignment.snapshot_receipt_id,
+        snapshot_content_digest=assignment.snapshot_content_digest,
+        context_view_id=assignment.context_view_id,
+        evidence_bundle_id=assignment.evidence_bundle_id,
+        determination_id=assignment.determination_id,
+        requested_operation="main_startup_readonly_operational_audit",
+        assignment_ids=(assignment.assignment_id,),
+        lanes=(assignment.lane_id,),
+        rejection_reasons=(),
+    )
+    return ReadOnlyAuditSwarmPlan(
+        accepted=True,
+        status=READONLY_AUDIT_SWARM_PLANNED,
+        receipt=receipt,
+        assignments=(assignment,),
+        rejection_reasons=(),
+    )
+
+
+def _context(plan: ReadOnlyAuditSwarmPlan | None = None) -> dict:
+    active_plan = plan or _plan()
+    return {
+        "source": READONLY_AUDIT_TASK_SOURCE,
+        "swarm_receipt": active_plan.receipt.to_dict(),
+        "assignment": active_plan.assignments[0].to_dict(),
+        "forbidden_actions": [
+            "repo_write",
+            "shell_execute",
+            "git_push",
+            "openclaw_enqueue",
+            "holoindex_reindex",
+        ],
+    }
+
+
+def _report(plan: ReadOnlyAuditSwarmPlan | None = None) -> dict:
+    assignment = (plan or _plan()).assignments[0]
+    return {
+        "assignment_id": assignment.assignment_id,
+        "lane_id": assignment.lane_id,
+        "snapshot_receipt_id": assignment.snapshot_receipt_id,
+        "summary": "repo_code_audit read-only audit evidence collected from 1 target.",
+        "evidence_refs": ["file:docs/work_ledger.schema.json:sha256:abc:lines:1"],
+        "repo_mutation_performed": False,
+        "execution_performed": False,
+        "openclaw_enqueue_performed": False,
+        "readonly_audit_performed": True,
+        "report_digest": "sha256:report-1",
+    }
+
+
+def _task_result(report: dict | None = None) -> dict:
+    return {
+        "ok": True,
+        "executor": "reddog:readonly_audit",
+        "structured_result": {
+            "accepted": True,
+            "decision": "READONLY_AUDIT_TASK_REPORT_ACCEPT",
+            "report": report or _report(),
+            "evidence": [],
+            "rejection_reasons": [],
+        },
+    }
+
+
+def test_persisted_report_collects_into_existing_swarm_validator() -> None:
+    plan = _plan()
+
+    persist = persist_reddog_readonly_audit_task_report(
+        task_id="task-1",
+        task_context=_context(plan),
+        task_result=_task_result(_report(plan)),
+    )
+    collected = collect_reddog_readonly_audit_report_bundle(plan=plan)
+
+    assert persist.accepted is True
+    assert persist.status == READONLY_AUDIT_REPORT_PERSIST_ACCEPT
+    assert collected.accepted is True
+    assert collected.status == READONLY_AUDIT_REPORT_COLLECTION_ACCEPT
+    assert collected.validation.status == READONLY_AUDIT_REPORTS_ACCEPTED
+    assert collected.validation.bundle is not None
+    assert collected.validation.bundle.lanes_reported == ("repo_code_audit",)
+    assert collected.no_repo_mutation_performed is True
+
+
+def test_collection_rejects_missing_persisted_report() -> None:
+    collected = collect_reddog_readonly_audit_report_bundle(plan=_plan())
+
+    assert collected.accepted is False
+    assert collected.status == READONLY_AUDIT_REPORT_COLLECTION_REJECT
+    assert collected.validation.status == READONLY_AUDIT_REPORTS_REJECTED
+    assert "missing_report_for_lane:repo_code_audit" in collected.rejection_reasons
+
+
+def test_persist_rejects_binding_mismatch_and_mutation_claim() -> None:
+    report = _report()
+    report["assignment_id"] = "other"
+    report["repo_mutation_performed"] = True
+
+    result = persist_reddog_readonly_audit_task_report(
+        task_id="task-1",
+        task_context=_context(),
+        task_result=_task_result(report),
+    )
+
+    assert result.accepted is False
+    assert result.status == READONLY_AUDIT_REPORT_PERSIST_REJECT
+    assert ReadOnlyAuditReportReason.REPORT_BINDING_MISMATCH in result.rejection_reasons
+    assert ReadOnlyAuditReportReason.REPORT_CLAIMS_MUTATION in result.rejection_reasons
+
+
+def test_store_rejects_conflicting_duplicate_assignment_report() -> None:
+    plan = _plan()
+    store = AgentDbReadOnlyAuditReportStore()
+    first = persist_reddog_readonly_audit_task_report(
+        task_id="task-1",
+        task_context=_context(plan),
+        task_result=_task_result(_report(plan)),
+        store=store,
+    )
+    changed = _report(plan)
+    changed["report_digest"] = "sha256:changed"
+    second = persist_reddog_readonly_audit_task_report(
+        task_id="task-2",
+        task_context=_context(plan),
+        task_result=_task_result(changed),
+        store=store,
+    )
+
+    assert first.accepted is True
+    assert second.accepted is False
+    assert second.rejection_reasons == (ReadOnlyAuditReportReason.STORE_REJECTED,)
+
+
+def test_run_task_persists_report_before_marking_complete(tmp_path: Path, monkeypatch) -> None:
+    root = _repo(tmp_path)
+    monkeypatch.setenv("WRE_MOCK_SKILLS", READONLY_AUDIT_TASK_SKILL)
+    plan = _plan()
+    db = AgentDB()
+    task_id = "readonly-audit-task-collection"
+    assert db.create_autonomous_task(
+        task_id=task_id,
+        description="RedDog read-only audit lane: repo_code_audit",
+        required_skills=[READONLY_AUDIT_TASK_SKILL],
+        estimated_complexity=0.35,
+        priority_score=0.85,
+        context=_context(plan),
+        origin_continuity_id="sha256:determination",
+    )
+    assert db.assign_autonomous_task(task_id, "openclaw_supervisor")
+
+    result = execute_task(task_id, repo_root=root)
+    collected = collect_reddog_readonly_audit_report_bundle(plan=plan)
+
+    assert result["ok"] is True
+    assert result["readonly_audit_report_persist"]["accepted"] is True
+    assert db.get_autonomous_task_by_id(task_id)["status"] == "completed"
+    assert collected.accepted is True
+    assert collected.report_count == 1
+
+
+def test_report_collection_module_ast_has_no_execution_or_repo_mutation() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    forbidden_import_roots = {
+        "subprocess",
+        "requests",
+        "httpx",
+        "socket",
+        "openclaw_supervisor",
+        "hermes_job_executor",
+    }
+    forbidden_text = (
+        "execute_skill",
+        "holo_index.py --index",
+        "create_autonomous_task",
+        "write_text",
+        "mkdir",
+        "git push",
+        "gh pr",
+    )
+    for token in forbidden_text:
+        assert token not in source
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".")[0] not in forbidden_import_roots
+        if isinstance(node, ast.ImportFrom):
+            assert (node.module or "").split(".")[0] not in forbidden_import_roots


### PR DESCRIPTION
## Summary

Implements `REDDOG_READONLY_AUDIT_REPORT_COLLECTION_PHASE1`.

This closes the next read-only operational-loop seam: RedDog read-only audit tasks can already be enqueued and executed; this slice persists accepted task reports to AgentDB and collects them back through the existing swarm report validator.

## Behavior

- Adds `reddog_readonly_audit_report_collection.py` with:
  - AgentDB-backed read-only audit report persistence.
  - Conflict rejection for duplicate assignment reports with different digests.
  - Collection into `validate_reddog_openclaw_readonly_audit_reports()`.
- Updates `run_task.py` so exact `reddog:readonly_audit` tasks must persist their structured report before the task is marked completed.
- Persistence failure fails the task closed instead of producing a completed task with no durable report.

## WSP_97 Boundary

OBSERVED:
- Reuses the existing read-only audit task executor and swarm report validator.
- Persists only accepted RedDog read-only audit task reports.
- Runtime write scope is limited to the RedDog read-only audit report table in AgentDB.

SPECIFIED_NOT_IMPLEMENTED / explicitly not performed:
- No model call.
- No shell/subprocess.
- No repo mutation or worktree operation.
- No OpenClaw enqueue.
- No Hermes/WRE dispatch.
- No HoloIndex mutation/re-index.
- No report file write.
- No Fusion synthesis or autonomous next-slice decision yet.

## Validation

```text
python -m pytest modules\communication\moltbot_bridge\tests\test_reddog_main_authoritative_work_state_refresh_bootstrap.py modules\communication\moltbot_bridge\tests\test_reddog_main_readonly_operational_bootstrap.py modules\communication\moltbot_bridge\tests\test_reddog_openclaw_readonly_audit_swarm_runtime.py modules\communication\moltbot_bridge\tests\test_reddog_openclaw_readonly_audit_swarm_enqueue.py modules\communication\moltbot_bridge\tests\test_reddog_readonly_audit_task_executor.py modules\communication\moltbot_bridge\tests\test_reddog_readonly_audit_report_collection.py -q
50 passed

python -m py_compile modules\communication\moltbot_bridge\src\reddog_readonly_audit_report_collection.py modules\communication\moltbot_bridge\scripts\run_task.py modules\communication\moltbot_bridge\tests\test_reddog_readonly_audit_report_collection.py
PASS

git diff --check
PASS (Windows autocrlf warnings only)

ASCII/NUL scan on new files
PASS
```

Note: `python -m ruff` is not available in this local environment; CI lint is the authoritative lint check.

## HoloIndex

Read-only probe for `REDDOG_READONLY_AUDIT_REPORT_COLLECTION_PHASE1 AgentDB read-only audit report collection` surfaced the ModLog pointer and adjacent audit assets, not the new collector module. Recorded `HOLOINDEX_REDDOG_READONLY_AUDIT_REPORT_COLLECTION_INDEX_GAP_PHASE1`; no runtime re-index performed.