### PR TITLE
feat(reddog): wire readonly audit report collection

### DIFF
--- a/main.py
+++ b/main.py
@@ -1190,6 +1190,7 @@ def run_reddog_readonly_operational_bootstrap_preflight(repo_root: Path) -> bool
     Env:
         REDDOG_READONLY_OPERATIONAL_BOOTSTRAP=1           Enable check (default ON)
         REDDOG_READONLY_OPERATIONAL_BOOTSTRAP_ENFORCED=0  Block startup if not ready
+        REDDOG_READONLY_AUDIT_REPORT_COLLECTION_ENABLED   Override audit report collection bridge
         REDDOG_READONLY_AUDIT_SWARM_ENQUEUE_ENABLED       Override audit task enqueue bridge
         OPENCLAW_AUTO_TASKS_ENABLED                       Enables audit task enqueue if no override
         REDDOG_AUTHORITATIVE_WORK_STATE_PATH              Existing work-state JSON
@@ -1207,6 +1208,11 @@ def run_reddog_readonly_operational_bootstrap_preflight(repo_root: Path) -> bool
         enqueue_requested = os.getenv("OPENCLAW_AUTO_TASKS_ENABLED", "0") != "0"
     else:
         enqueue_requested = enqueue_override != "0"
+    collection_override = os.getenv("REDDOG_READONLY_AUDIT_REPORT_COLLECTION_ENABLED")
+    if collection_override is None:
+        collection_requested = os.getenv("OPENCLAW_AUTO_TASKS_ENABLED", "0") != "0"
+    else:
+        collection_requested = collection_override != "0"
 
     try:
         from modules.communication.moltbot_bridge.src.reddog_main_readonly_operational_bootstrap import (
@@ -1218,6 +1224,7 @@ def run_reddog_readonly_operational_bootstrap_preflight(repo_root: Path) -> bool
             work_state_path=os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
             holoindex_receipt_path=os.getenv("HOLOINDEX_FRESHNESS_RECEIPT", ""),
             holoindex_ssd_path=os.getenv("HOLOINDEX_SSD_PATH", ""),
+            collect_readonly_audit_reports=collection_requested,
             enqueue_readonly_audit_tasks=enqueue_requested,
         )
     except Exception as exc:
@@ -1232,7 +1239,9 @@ def run_reddog_readonly_operational_bootstrap_preflight(repo_root: Path) -> bool
     reasons = ",".join(result.rejection_reasons) if result.rejection_reasons else "(none)"
     print(
         f"[REDDOG-BOOTSTRAP] preflight={status} status={result.status} "
-        f"assignments={result.assignment_count} enqueue_attempted={result.enqueue_attempted} "
+        f"assignments={result.assignment_count} report_collection_attempted={result.report_collection_attempted} "
+        f"report_collection_status={result.report_collection_status or '(none)'} "
+        f"reports={result.report_collection_report_count} enqueue_attempted={result.enqueue_attempted} "
         f"enqueue_decision={result.enqueue_decision or '(none)'} "
         f"enqueue_tasks={result.enqueue_task_count} reasons={reasons}"
     )

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,31 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_MAIN_READONLY_AUDIT_REPORT_COLLECTION_WIRE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Extended `src/reddog_main_readonly_operational_bootstrap.py` with optional
+  read-only audit report collection against the persisted AgentDB report table.
+  Accepted report bundles skip task re-enqueue; missing/rejected bundles enqueue
+  only when the existing audit-task enqueue bridge is also authorized.
+- Wired `main.py` to pass `collect_readonly_audit_reports=True` when
+  `REDDOG_READONLY_AUDIT_REPORT_COLLECTION_ENABLED=1`, or when
+  `OPENCLAW_AUTO_TASKS_ENABLED=1` and no RedDog collection override is set.
+- Added bootstrap tests for accepted report collection, missing-report
+  fail-closed behavior without enqueue authority, missing-report enqueue when
+  enqueue authority is present, and main preflight env override behavior.
+- Boundary: no model call, no worker spawn from the bootstrap, no shell/subprocess,
+  no repo mutation, no worktree operation, no Hermes/WRE dispatch, no HoloIndex
+  mutation/re-index, and no live FoundUp queue write. Collection reads the
+  RedDog read-only audit report store; enqueue remains limited to pending
+  read-only AgentDB audit tasks when explicitly enabled.
+- HoloIndex read-only probe for
+  `REDDOG_MAIN_READONLY_AUDIT_REPORT_COLLECTION_WIRE_PHASE1 main.py read-only audit report collection`
+  surfaced this ModLog pointer and unknown locations, not the runtime path.
+  Recorded
+  `HOLOINDEX_REDDOG_MAIN_READONLY_AUDIT_REPORT_COLLECTION_WIRE_INDEX_GAP_PHASE1`;
+  no runtime re-index performed.
+
 ## 2026-07-14: REDDOG_READONLY_AUDIT_REPORT_COLLECTION_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
@@ -32,6 +32,12 @@ from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swa
     ReadOnlyAuditTaskWriter,
     enqueue_reddog_readonly_audit_swarm,
 )
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_report_collection import (
+    AgentDbReadOnlyAuditReportStore,
+    ReadOnlyAuditReportCollectionResult,
+    ReadOnlyAuditReportStore,
+    collect_reddog_readonly_audit_report_bundle,
+)
 from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
     EvidenceBundle,
     OperationalContextSnapshot,
@@ -74,6 +80,12 @@ class RedDogMainReadonlyBootstrapResult:
     rejection_reasons: tuple[str, ...]
     changed_paths: tuple[str, ...]
     allowed_read_targets: tuple[str, ...]
+    assignment_ids: tuple[str, ...] = ()
+    report_collection_attempted: bool = False
+    report_collection_status: Optional[str] = None
+    report_collection_report_count: int = 0
+    report_bundle_id: Optional[str] = None
+    report_collection_rejection_reasons: tuple[str, ...] = ()
     enqueue_attempted: bool = False
     enqueue_decision: Optional[str] = None
     enqueue_receipt_id: Optional[str] = None
@@ -109,6 +121,8 @@ def run_reddog_main_readonly_operational_bootstrap(
     enqueue_readonly_audit_tasks: bool = False,
     enqueue_writer: ReadOnlyAuditTaskWriter | None = None,
     seen_assignment_ids: Optional[set[str]] = None,
+    collect_readonly_audit_reports: bool = False,
+    report_store: ReadOnlyAuditReportStore | None = None,
 ) -> RedDogMainReadonlyBootstrapResult:
     """Build a read-only startup plan or explain why it is not ready."""
 
@@ -213,6 +227,38 @@ def run_reddog_main_readonly_operational_bootstrap(
             swarm_plan=plan,
         )
 
+    collection_result: ReadOnlyAuditReportCollectionResult | None = None
+    if collect_readonly_audit_reports:
+        reader = report_store if report_store is not None else AgentDbReadOnlyAuditReportStore()
+        collection_result = collect_reddog_readonly_audit_report_bundle(
+            plan=plan,
+            store=reader,
+        )
+        if collection_result.accepted:
+            return _ready(
+                snapshot=snapshot,
+                context_view=context_view,
+                evidence_bundle=evidence_bundle,
+                gate=gate,
+                plan=plan,
+                changed_paths=paths,
+                allowed_read_targets=targets,
+                collection_result=collection_result,
+                enqueue_result=None,
+                enqueue_attempted=False,
+            )
+        if not enqueue_readonly_audit_tasks:
+            return _not_ready(
+                reasons=("readonly_audit_report_collection_rejected", *collection_result.rejection_reasons),
+                changed_paths=paths,
+                allowed_read_targets=targets,
+                snapshot=snapshot,
+                evidence_bundle=evidence_bundle,
+                gate=gate,
+                swarm_plan=plan,
+                collection_result=collection_result,
+            )
+
     enqueue_result: ReadOnlyAuditSwarmEnqueueResult | None = None
     if enqueue_readonly_audit_tasks:
         writer = enqueue_writer if enqueue_writer is not None else AgentDbReadOnlyAuditTaskWriter()
@@ -230,9 +276,39 @@ def run_reddog_main_readonly_operational_bootstrap(
                 evidence_bundle=evidence_bundle,
                 gate=gate,
                 swarm_plan=plan,
+                collection_result=collection_result,
                 enqueue_result=enqueue_result,
             )
 
+    return _ready(
+        snapshot=snapshot,
+        context_view=context_view,
+        evidence_bundle=evidence_bundle,
+        gate=gate,
+        plan=plan,
+        changed_paths=paths,
+        allowed_read_targets=targets,
+        collection_result=collection_result,
+        enqueue_result=enqueue_result,
+        enqueue_attempted=enqueue_readonly_audit_tasks,
+    )
+
+
+def _ready(
+    *,
+    snapshot: OperationalContextSnapshot,
+    context_view: Any,
+    evidence_bundle: EvidenceBundle,
+    gate: FusionAssignmentGateDecision,
+    plan: ReadOnlyAuditSwarmPlan,
+    changed_paths: Sequence[str],
+    allowed_read_targets: Sequence[str],
+    collection_result: ReadOnlyAuditReportCollectionResult | None,
+    enqueue_result: ReadOnlyAuditSwarmEnqueueResult | None,
+    enqueue_attempted: bool,
+) -> RedDogMainReadonlyBootstrapResult:
+    assert gate.determination_binding is not None
+    bundle = collection_result.validation.bundle if collection_result and collection_result.validation else None
     return RedDogMainReadonlyBootstrapResult(
         ready=True,
         status=REDDOG_MAIN_BOOTSTRAP_READY,
@@ -242,10 +318,16 @@ def run_reddog_main_readonly_operational_bootstrap(
         determination_id=gate.determination_binding.determination_id,
         swarm_id=plan.receipt.swarm_id,
         assignment_count=len(plan.assignments),
+        assignment_ids=tuple(assignment.assignment_id for assignment in plan.assignments),
         rejection_reasons=(),
-        changed_paths=paths,
-        allowed_read_targets=targets,
-        enqueue_attempted=enqueue_readonly_audit_tasks,
+        changed_paths=tuple(changed_paths),
+        allowed_read_targets=tuple(allowed_read_targets),
+        report_collection_attempted=collection_result is not None,
+        report_collection_status=collection_result.status if collection_result else None,
+        report_collection_report_count=collection_result.report_count if collection_result else 0,
+        report_bundle_id=bundle.bundle_id if bundle else None,
+        report_collection_rejection_reasons=collection_result.rejection_reasons if collection_result else (),
+        enqueue_attempted=enqueue_attempted,
         enqueue_decision=enqueue_result.decision if enqueue_result else None,
         enqueue_receipt_id=enqueue_result.receipt.enqueue_receipt_id if enqueue_result else None,
         enqueue_task_count=len(enqueue_result.tasks) if enqueue_result else 0,
@@ -295,6 +377,7 @@ def _not_ready(
     evidence_bundle: EvidenceBundle | None = None,
     gate: FusionAssignmentGateDecision | None = None,
     swarm_plan: ReadOnlyAuditSwarmPlan | None = None,
+    collection_result: ReadOnlyAuditReportCollectionResult | None = None,
     enqueue_result: ReadOnlyAuditSwarmEnqueueResult | None = None,
 ) -> RedDogMainReadonlyBootstrapResult:
     determination_id = None
@@ -309,9 +392,19 @@ def _not_ready(
         determination_id=determination_id,
         swarm_id=swarm_plan.receipt.swarm_id if swarm_plan else None,
         assignment_count=len(swarm_plan.assignments) if swarm_plan else 0,
+        assignment_ids=tuple(assignment.assignment_id for assignment in swarm_plan.assignments) if swarm_plan else (),
         rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons if str(reason).strip())),
         changed_paths=tuple(changed_paths),
         allowed_read_targets=tuple(allowed_read_targets),
+        report_collection_attempted=collection_result is not None,
+        report_collection_status=collection_result.status if collection_result else None,
+        report_collection_report_count=collection_result.report_count if collection_result else 0,
+        report_bundle_id=(
+            collection_result.validation.bundle.bundle_id
+            if collection_result and collection_result.validation.bundle
+            else None
+        ),
+        report_collection_rejection_reasons=collection_result.rejection_reasons if collection_result else (),
         enqueue_attempted=enqueue_result is not None,
         enqueue_decision=enqueue_result.decision if enqueue_result else None,
         enqueue_receipt_id=enqueue_result.receipt.enqueue_receipt_id if enqueue_result else None,

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -20,6 +20,13 @@ from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swa
     READONLY_AUDIT_SWARM_ENQUEUE_REJECT,
     ReadOnlyAuditEnqueueReason,
 )
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_runtime import (
+    DEFAULT_AUDIT_LANES,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_report_collection import (
+    READONLY_AUDIT_REPORT_COLLECTION_ACCEPT,
+    READONLY_AUDIT_REPORT_COLLECTION_REJECT,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -98,6 +105,40 @@ class _FakeEnqueueWriter:
         return {"ok": True, "created_task_ids": [task.task_id for task in copied]}
 
 
+class _FakeReportStore:
+    def __init__(self, reports=()) -> None:
+        self.reports = tuple(reports)
+        self.load_calls: list[str] = []
+
+    def load_readonly_audit_reports(self, swarm_id: str):
+        self.load_calls.append(swarm_id)
+        return self.reports
+
+    def store_readonly_audit_report(self, record):
+        return {"ok": False, "reason": "not_used"}
+
+
+def _reports_for_bootstrap_result(result: RedDogMainReadonlyBootstrapResult) -> tuple[dict[str, object], ...]:
+    reports: list[dict[str, object]] = []
+    assert result.snapshot_receipt_id is not None
+    for assignment_id, lane_id in zip(result.assignment_ids, DEFAULT_AUDIT_LANES):
+        reports.append(
+            {
+                "assignment_id": assignment_id,
+                "lane_id": lane_id,
+                "snapshot_receipt_id": result.snapshot_receipt_id,
+                "summary": f"{lane_id} read-only audit evidence collected from 1 target.",
+                "evidence_refs": [f"file:docs/{lane_id}.md:sha256:{lane_id}:lines:1"],
+                "repo_mutation_performed": False,
+                "execution_performed": False,
+                "openclaw_enqueue_performed": False,
+                "readonly_audit_performed": True,
+                "report_digest": f"sha256:{lane_id}",
+            }
+        )
+    return tuple(reports)
+
+
 def test_bootstrap_plans_default_readonly_audit_swarm_from_fresh_context() -> None:
     result = run_reddog_main_readonly_operational_bootstrap(
         repo_root=REPO_ROOT,
@@ -122,9 +163,90 @@ def test_bootstrap_plans_default_readonly_audit_swarm_from_fresh_context() -> No
     assert result.no_repo_mutation_performed is True
     assert result.no_holoindex_reindex_performed is True
     assert result.no_queue_mutation_performed is True
+    assert result.assignment_ids
+    assert result.report_collection_attempted is False
+    assert result.report_collection_status is None
+    assert result.report_collection_report_count == 0
     assert result.enqueue_attempted is False
     assert result.enqueue_decision is None
     assert result.enqueue_task_count == 0
+
+
+def test_bootstrap_collects_existing_reports_and_skips_enqueue() -> None:
+    baseline = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+    )
+    writer = _FakeEnqueueWriter()
+    store = _FakeReportStore(_reports_for_bootstrap_result(baseline))
+
+    result = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+        collect_readonly_audit_reports=True,
+        report_store=store,
+        enqueue_readonly_audit_tasks=True,
+        enqueue_writer=writer,
+    )
+
+    assert result.ready is True
+    assert result.report_collection_attempted is True
+    assert result.report_collection_status == READONLY_AUDIT_REPORT_COLLECTION_ACCEPT
+    assert result.report_collection_report_count == result.assignment_count == 5
+    assert result.report_bundle_id and result.report_bundle_id.startswith("sha256:")
+    assert result.enqueue_attempted is False
+    assert writer.calls == []
+    assert store.load_calls == [result.swarm_id]
+
+
+def test_bootstrap_missing_reports_enqueue_when_enabled() -> None:
+    writer = _FakeEnqueueWriter()
+
+    result = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+        collect_readonly_audit_reports=True,
+        report_store=_FakeReportStore(()),
+        enqueue_readonly_audit_tasks=True,
+        enqueue_writer=writer,
+    )
+
+    assert result.ready is True
+    assert result.report_collection_attempted is True
+    assert result.report_collection_status == READONLY_AUDIT_REPORT_COLLECTION_REJECT
+    assert result.report_collection_report_count == 0
+    assert result.report_collection_rejection_reasons
+    assert result.enqueue_attempted is True
+    assert result.enqueue_decision == READONLY_AUDIT_SWARM_ENQUEUE_ACCEPT
+    assert len(writer.calls) == 1
+
+
+def test_bootstrap_missing_reports_not_ready_without_enqueue_authority() -> None:
+    result = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+        collect_readonly_audit_reports=True,
+        report_store=_FakeReportStore(()),
+    )
+
+    assert result.ready is False
+    assert result.status == REDDOG_MAIN_BOOTSTRAP_NOT_READY
+    assert "readonly_audit_report_collection_rejected" in result.rejection_reasons
+    assert result.report_collection_attempted is True
+    assert result.report_collection_status == READONLY_AUDIT_REPORT_COLLECTION_REJECT
+    assert result.enqueue_attempted is False
 
 
 def test_bootstrap_enqueue_opt_in_publishes_readonly_audit_tasks() -> None:
@@ -358,6 +480,7 @@ def test_main_preflight_enables_enqueue_when_openclaw_auto_tasks_enabled() -> No
             assert main.run_reddog_readonly_operational_bootstrap_preflight(REPO_ROOT) is True
 
     assert mocked.call_args.kwargs["enqueue_readonly_audit_tasks"] is True
+    assert mocked.call_args.kwargs["collect_readonly_audit_reports"] is True
 
 
 def test_main_preflight_explicit_enqueue_disable_overrides_openclaw_auto_tasks() -> None:
@@ -392,6 +515,42 @@ def test_main_preflight_explicit_enqueue_disable_overrides_openclaw_auto_tasks()
             assert main.run_reddog_readonly_operational_bootstrap_preflight(REPO_ROOT) is True
 
     assert mocked.call_args.kwargs["enqueue_readonly_audit_tasks"] is False
+    assert mocked.call_args.kwargs["collect_readonly_audit_reports"] is True
+
+
+def test_main_preflight_explicit_collection_disable_overrides_openclaw_auto_tasks() -> None:
+    import main
+
+    ready_result = RedDogMainReadonlyBootstrapResult(
+        ready=True,
+        status=REDDOG_MAIN_BOOTSTRAP_READY,
+        snapshot_receipt_id="sha256:snapshot",
+        context_view_id="sha256:view",
+        evidence_bundle_id="sha256:evidence",
+        determination_id="sha256:determination",
+        swarm_id="sha256:swarm",
+        assignment_count=5,
+        rejection_reasons=(),
+        changed_paths=DEFAULT_BOOTSTRAP_CHANGED_PATHS,
+        allowed_read_targets=DEFAULT_BOOTSTRAP_CHANGED_PATHS,
+    )
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_readonly_operational_bootstrap.run_reddog_main_readonly_operational_bootstrap",
+        return_value=ready_result,
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_READONLY_OPERATIONAL_BOOTSTRAP": "1",
+                "OPENCLAW_AUTO_TASKS_ENABLED": "1",
+                "REDDOG_READONLY_AUDIT_REPORT_COLLECTION_ENABLED": "0",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_readonly_operational_bootstrap_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["collect_readonly_audit_reports"] is False
+    assert mocked.call_args.kwargs["enqueue_readonly_audit_tasks"] is True
 
 
 def test_bootstrap_module_has_no_runtime_mutation_or_execution_imports() -> None:


### PR DESCRIPTION
## Summary

Implements `REDDOG_MAIN_READONLY_AUDIT_REPORT_COLLECTION_WIRE_PHASE1`.

This wires report collection into the `main.py` read-only operational bootstrap. RedDog now checks for persisted read-only audit reports before re-enqueueing the same swarm.

## Behavior

- `run_reddog_main_readonly_operational_bootstrap()` can optionally collect persisted reports for the planned read-only audit swarm.
- Accepted report bundles skip task re-enqueue.
- Missing/rejected report bundles fail closed unless audit-task enqueue is also authorized.
- If reports are missing and enqueue is authorized, the bootstrap enqueues the read-only AgentDB audit tasks as before.
- `main.py` enables collection when `REDDOG_READONLY_AUDIT_REPORT_COLLECTION_ENABLED=1`, or when `OPENCLAW_AUTO_TASKS_ENABLED=1` and no RedDog collection override is set.

## WSP_97 Boundary

OBSERVED:
- Reuses the existing report persistence and swarm report validator.
- Adds bootstrap telemetry for report collection status, report count, and report bundle id.
- Keeps default startup plan-only unless runtime flags are enabled.

SPECIFIED_NOT_IMPLEMENTED / explicitly not performed:
- No model call.
- No worker spawn from bootstrap.
- No shell/subprocess.
- No repo mutation or worktree operation.
- No Hermes/WRE dispatch.
- No HoloIndex mutation/re-index.
- No live FoundUp queue write.
- No Fusion synthesis or autonomous next-slice decision yet.

## Validation

```text
python -m pytest modules\communication\moltbot_bridge\tests\test_reddog_main_authoritative_work_state_refresh_bootstrap.py modules\communication\moltbot_bridge\tests\test_reddog_main_readonly_operational_bootstrap.py modules\communication\moltbot_bridge\tests\test_reddog_openclaw_readonly_audit_swarm_runtime.py modules\communication\moltbot_bridge\tests\test_reddog_openclaw_readonly_audit_swarm_enqueue.py modules\communication\moltbot_bridge\tests\test_reddog_readonly_audit_task_executor.py modules\communication\moltbot_bridge\tests\test_reddog_readonly_audit_report_collection.py -q
54 passed

python -m py_compile main.py modules\communication\moltbot_bridge\src\reddog_main_readonly_operational_bootstrap.py
PASS

git diff --check
PASS (Windows autocrlf warnings only)
```

## HoloIndex

Read-only probe for `REDDOG_MAIN_READONLY_AUDIT_REPORT_COLLECTION_WIRE_PHASE1 main.py read-only audit report collection` surfaced the ModLog pointer and unknown locations, not the runtime path. Recorded `HOLOINDEX_REDDOG_MAIN_READONLY_AUDIT_REPORT_COLLECTION_WIRE_INDEX_GAP_PHASE1`; no runtime re-index performed.