### PR TITLE
feat(reddog): readonly audit decision runtime

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,31 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_READONLY_AUDIT_DECISION_RUNTIME_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_readonly_audit_decision_runtime.py`: deterministic
+  post-collection decision receipt for RedDog read-only audit bundles. The
+  gate accepts only WSP_97-labeled semantic findings whose evidence refs are
+  bound to the validated report; `NEEDS_VERIFICATION` findings can only route
+  to `RESEARCH_MORE`.
+- Wired the main read-only bootstrap telemetry to emit the decision receipt
+  after accepted report collection. Reports with no semantic findings are
+  routed to `RESEARCH_MORE` with
+  `REDDOG_READONLY_AUDIT_SEMANTIC_FINDINGS_PHASE1`, preventing RedDog from
+  treating evidence collection as a completed audit.
+- Added tests for no-finding overclaim prevention, evidence-bound `FIX`
+  selection, rejected collection handling, count mismatch, unbound evidence,
+  `NEEDS_VERIFICATION` guardrails, bootstrap decision telemetry, and AST
+  no-execution/no-mutation coverage.
+- Boundary: no model call, no shell/subprocess, no repo mutation, no worktree
+  operation, no OpenClaw enqueue, no Hermes/WRE dispatch, no HoloIndex
+  mutation/re-index, and no live action-plane wiring. This emits a decision
+  receipt only.
+- HoloIndex read-only probe for
+  `REDDOG_READONLY_AUDIT_DECISION_RUNTIME_PHASE1 semantic findings next action decision`
+  is expected to require post-merge indexing; no runtime re-index performed.
+
 ## 2026-07-14: REDDOG_MAIN_READONLY_AUDIT_REPORT_COLLECTION_WIRE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
@@ -38,6 +38,10 @@ from modules.communication.moltbot_bridge.src.reddog_readonly_audit_report_colle
     ReadOnlyAuditReportStore,
     collect_reddog_readonly_audit_report_bundle,
 )
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_decision_runtime import (
+    ReadOnlyAuditDecisionReceipt,
+    decide_reddog_readonly_audit_next_action,
+)
 from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
     EvidenceBundle,
     OperationalContextSnapshot,
@@ -86,6 +90,12 @@ class RedDogMainReadonlyBootstrapResult:
     report_collection_report_count: int = 0
     report_bundle_id: Optional[str] = None
     report_collection_rejection_reasons: tuple[str, ...] = ()
+    readonly_audit_decision_attempted: bool = False
+    readonly_audit_decision_status: Optional[str] = None
+    readonly_audit_decision_action: Optional[str] = None
+    readonly_audit_decision_id: Optional[str] = None
+    readonly_audit_decision_next_slice: Optional[str] = None
+    readonly_audit_decision_rejection_reasons: tuple[str, ...] = ()
     enqueue_attempted: bool = False
     enqueue_decision: Optional[str] = None
     enqueue_receipt_id: Optional[str] = None
@@ -228,6 +238,7 @@ def run_reddog_main_readonly_operational_bootstrap(
         )
 
     collection_result: ReadOnlyAuditReportCollectionResult | None = None
+    decision_result: ReadOnlyAuditDecisionReceipt | None = None
     if collect_readonly_audit_reports:
         reader = report_store if report_store is not None else AgentDbReadOnlyAuditReportStore()
         collection_result = collect_reddog_readonly_audit_report_bundle(
@@ -235,6 +246,35 @@ def run_reddog_main_readonly_operational_bootstrap(
             store=reader,
         )
         if collection_result.accepted:
+            try:
+                decision_reports = tuple(reader.load_readonly_audit_reports(plan.receipt.swarm_id))
+            except Exception:
+                return _not_ready(
+                    reasons=("readonly_audit_decision_report_load_failed",),
+                    changed_paths=paths,
+                    allowed_read_targets=targets,
+                    snapshot=snapshot,
+                    evidence_bundle=evidence_bundle,
+                    gate=gate,
+                    swarm_plan=plan,
+                    collection_result=collection_result,
+                )
+            decision_result = decide_reddog_readonly_audit_next_action(
+                collection_result=collection_result,
+                reports=decision_reports,
+            )
+            if not decision_result.accepted:
+                return _not_ready(
+                    reasons=("readonly_audit_decision_rejected", *decision_result.rejection_reasons),
+                    changed_paths=paths,
+                    allowed_read_targets=targets,
+                    snapshot=snapshot,
+                    evidence_bundle=evidence_bundle,
+                    gate=gate,
+                    swarm_plan=plan,
+                    collection_result=collection_result,
+                    decision_result=decision_result,
+                )
             return _ready(
                 snapshot=snapshot,
                 context_view=context_view,
@@ -244,6 +284,7 @@ def run_reddog_main_readonly_operational_bootstrap(
                 changed_paths=paths,
                 allowed_read_targets=targets,
                 collection_result=collection_result,
+                decision_result=decision_result,
                 enqueue_result=None,
                 enqueue_attempted=False,
             )
@@ -257,6 +298,7 @@ def run_reddog_main_readonly_operational_bootstrap(
                 gate=gate,
                 swarm_plan=plan,
                 collection_result=collection_result,
+                decision_result=decision_result,
             )
 
     enqueue_result: ReadOnlyAuditSwarmEnqueueResult | None = None
@@ -277,6 +319,7 @@ def run_reddog_main_readonly_operational_bootstrap(
                 gate=gate,
                 swarm_plan=plan,
                 collection_result=collection_result,
+                decision_result=decision_result,
                 enqueue_result=enqueue_result,
             )
 
@@ -289,6 +332,7 @@ def run_reddog_main_readonly_operational_bootstrap(
         changed_paths=paths,
         allowed_read_targets=targets,
         collection_result=collection_result,
+        decision_result=decision_result,
         enqueue_result=enqueue_result,
         enqueue_attempted=enqueue_readonly_audit_tasks,
     )
@@ -304,6 +348,7 @@ def _ready(
     changed_paths: Sequence[str],
     allowed_read_targets: Sequence[str],
     collection_result: ReadOnlyAuditReportCollectionResult | None,
+    decision_result: ReadOnlyAuditDecisionReceipt | None,
     enqueue_result: ReadOnlyAuditSwarmEnqueueResult | None,
     enqueue_attempted: bool,
 ) -> RedDogMainReadonlyBootstrapResult:
@@ -327,6 +372,12 @@ def _ready(
         report_collection_report_count=collection_result.report_count if collection_result else 0,
         report_bundle_id=bundle.bundle_id if bundle else None,
         report_collection_rejection_reasons=collection_result.rejection_reasons if collection_result else (),
+        readonly_audit_decision_attempted=decision_result is not None,
+        readonly_audit_decision_status=decision_result.status if decision_result else None,
+        readonly_audit_decision_action=decision_result.action if decision_result else None,
+        readonly_audit_decision_id=decision_result.decision_id if decision_result else None,
+        readonly_audit_decision_next_slice=decision_result.next_slice_name if decision_result else None,
+        readonly_audit_decision_rejection_reasons=decision_result.rejection_reasons if decision_result else (),
         enqueue_attempted=enqueue_attempted,
         enqueue_decision=enqueue_result.decision if enqueue_result else None,
         enqueue_receipt_id=enqueue_result.receipt.enqueue_receipt_id if enqueue_result else None,
@@ -378,6 +429,7 @@ def _not_ready(
     gate: FusionAssignmentGateDecision | None = None,
     swarm_plan: ReadOnlyAuditSwarmPlan | None = None,
     collection_result: ReadOnlyAuditReportCollectionResult | None = None,
+    decision_result: ReadOnlyAuditDecisionReceipt | None = None,
     enqueue_result: ReadOnlyAuditSwarmEnqueueResult | None = None,
 ) -> RedDogMainReadonlyBootstrapResult:
     determination_id = None
@@ -405,6 +457,12 @@ def _not_ready(
             else None
         ),
         report_collection_rejection_reasons=collection_result.rejection_reasons if collection_result else (),
+        readonly_audit_decision_attempted=decision_result is not None,
+        readonly_audit_decision_status=decision_result.status if decision_result else None,
+        readonly_audit_decision_action=decision_result.action if decision_result else None,
+        readonly_audit_decision_id=decision_result.decision_id if decision_result else None,
+        readonly_audit_decision_next_slice=decision_result.next_slice_name if decision_result else None,
+        readonly_audit_decision_rejection_reasons=decision_result.rejection_reasons if decision_result else (),
         enqueue_attempted=enqueue_result is not None,
         enqueue_decision=enqueue_result.decision if enqueue_result else None,
         enqueue_receipt_id=enqueue_result.receipt.enqueue_receipt_id if enqueue_result else None,

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_audit_decision_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_audit_decision_runtime.py
@@ -1,0 +1,357 @@
+"""Deterministic decision gate for collected RedDog read-only audit reports.
+
+Slice: REDDOG_READONLY_AUDIT_DECISION_RUNTIME_PHASE1
+
+This module consumes an already validated read-only audit report collection and
+emits the next-action decision receipt RedDog can display at startup. It does
+not call models, execute commands, mutate repositories, enqueue OpenClaw work,
+dispatch Hermes/WRE, create worktrees, or mutate/re-index HoloIndex.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping, Optional, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_report_collection import (
+    ReadOnlyAuditReportCollectionResult,
+)
+
+
+READONLY_AUDIT_DECISION_ACCEPT = "READONLY_AUDIT_DECISION_ACCEPT"
+READONLY_AUDIT_DECISION_REJECT = "READONLY_AUDIT_DECISION_REJECT"
+
+ACTION_FIX = "FIX"
+ACTION_RESEARCH_MORE = "RESEARCH_MORE"
+ACTION_REVISE = "REVISE"
+ACTION_STOP = "STOP"
+ACTION_WAIT_FOR_REPORTS = "WAIT_FOR_REPORTS"
+
+DEFAULT_SEMANTIC_FINDINGS_SLICE = "REDDOG_READONLY_AUDIT_SEMANTIC_FINDINGS_PHASE1"
+
+ALLOWED_ACTIONS = (ACTION_FIX, ACTION_RESEARCH_MORE, ACTION_REVISE, ACTION_STOP)
+ALLOWED_WSP97_LABELS = ("OBSERVED", "INFERRED", "SPECIFIED_NOT_IMPLEMENTED", "NEEDS_VERIFICATION")
+ALLOWED_PRIORITIES = ("P0", "P1", "P2", "P3", "P4")
+ALLOWED_SEVERITIES = ("BLOCKER", "MAJOR", "MINOR", "INFO")
+
+_ACTION_RANK = {ACTION_FIX: 0, ACTION_REVISE: 1, ACTION_RESEARCH_MORE: 2, ACTION_STOP: 3}
+_PRIORITY_RANK = {priority: index for index, priority in enumerate(ALLOWED_PRIORITIES)}
+_SEVERITY_RANK = {severity: index for index, severity in enumerate(ALLOWED_SEVERITIES)}
+
+
+@dataclass(frozen=True)
+class ReadOnlyAuditSemanticFinding:
+    """Validated semantic finding extracted from one read-only audit report."""
+
+    finding_id: str
+    lane_id: str
+    claim: str
+    wsp97_label: str
+    recommended_action: str
+    wsp15_priority: str
+    severity: str
+    evidence_refs: tuple[str, ...]
+    next_slice_name: Optional[str]
+    finding_digest: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ReadOnlyAuditDecisionReceipt:
+    """Next-action decision emitted after read-only audit report collection."""
+
+    decision_id: str
+    accepted: bool
+    status: str
+    action: str
+    swarm_id: str
+    report_bundle_id: Optional[str]
+    report_count: int
+    finding_count: int
+    selected_finding_digest: Optional[str]
+    next_slice_name: Optional[str]
+    wsp15_priority: Optional[str]
+    decision_reasons: tuple[str, ...]
+    rejection_reasons: tuple[str, ...]
+    finding_digests: tuple[str, ...]
+    no_model_call_performed: bool = True
+    no_shell_command_executed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_worktree_operation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def decide_reddog_readonly_audit_next_action(
+    *,
+    collection_result: ReadOnlyAuditReportCollectionResult,
+    reports: Sequence[Mapping[str, Any]],
+) -> ReadOnlyAuditDecisionReceipt:
+    """Emit a deterministic next-action receipt from collected read-only reports."""
+
+    bundle = collection_result.validation.bundle if collection_result.validation else None
+    bundle_id = bundle.bundle_id if bundle else None
+    reasons: list[str] = []
+    decision_reasons: list[str] = []
+
+    if not collection_result.accepted:
+        reasons.extend(collection_result.rejection_reasons or ("collection_not_accepted",))
+        return _receipt(
+            accepted=False,
+            action=ACTION_WAIT_FOR_REPORTS,
+            swarm_id=collection_result.swarm_id,
+            report_bundle_id=bundle_id,
+            report_count=collection_result.report_count,
+            findings=(),
+            selected=None,
+            next_slice_name=None,
+            wsp15_priority=None,
+            decision_reasons=("report_collection_not_accepted",),
+            rejection_reasons=_dedupe(reasons),
+        )
+
+    if collection_result.report_count != len(reports):
+        reasons.append("report_count_mismatch")
+
+    findings: list[ReadOnlyAuditSemanticFinding] = []
+    for report_index, report in enumerate(reports):
+        if not isinstance(report, Mapping):
+            reasons.append(f"report_not_mapping:{report_index}")
+            continue
+        findings.extend(_extract_report_findings(report=report, report_index=report_index, reasons=reasons))
+
+    reasons = list(_dedupe(reasons))
+    if reasons:
+        return _receipt(
+            accepted=False,
+            action=ACTION_WAIT_FOR_REPORTS,
+            swarm_id=collection_result.swarm_id,
+            report_bundle_id=bundle_id,
+            report_count=collection_result.report_count,
+            findings=tuple(findings),
+            selected=None,
+            next_slice_name=None,
+            wsp15_priority=None,
+            decision_reasons=("semantic_finding_validation_failed",),
+            rejection_reasons=tuple(reasons),
+        )
+
+    if not findings:
+        return _receipt(
+            accepted=True,
+            action=ACTION_RESEARCH_MORE,
+            swarm_id=collection_result.swarm_id,
+            report_bundle_id=bundle_id,
+            report_count=collection_result.report_count,
+            findings=(),
+            selected=None,
+            next_slice_name=DEFAULT_SEMANTIC_FINDINGS_SLICE,
+            wsp15_priority="P1",
+            decision_reasons=("semantic_findings_missing",),
+            rejection_reasons=(),
+        )
+
+    selected = sorted(findings, key=_finding_sort_key)[0]
+    return _receipt(
+        accepted=True,
+        action=selected.recommended_action,
+        swarm_id=collection_result.swarm_id,
+        report_bundle_id=bundle_id,
+        report_count=collection_result.report_count,
+        findings=tuple(findings),
+        selected=selected,
+        next_slice_name=selected.next_slice_name,
+        wsp15_priority=selected.wsp15_priority,
+        decision_reasons=(f"selected:{selected.finding_id}",),
+        rejection_reasons=(),
+    )
+
+
+def _extract_report_findings(
+    *,
+    report: Mapping[str, Any],
+    report_index: int,
+    reasons: list[str],
+) -> tuple[ReadOnlyAuditSemanticFinding, ...]:
+    lane_id = str(report.get("lane_id") or "").strip()
+    report_refs = _normalize_refs(report.get("evidence_refs"))
+    raw_findings = report.get("findings") or ()
+    if isinstance(raw_findings, (str, bytes)) or not isinstance(raw_findings, Sequence):
+        reasons.append(f"findings_not_sequence:{lane_id or report_index}")
+        return ()
+
+    findings: list[ReadOnlyAuditSemanticFinding] = []
+    for finding_index, raw in enumerate(raw_findings):
+        if not isinstance(raw, Mapping):
+            reasons.append(f"finding_not_mapping:{lane_id or report_index}:{finding_index}")
+            continue
+        finding = _coerce_finding(raw, lane_id=lane_id, report_refs=report_refs, reasons=reasons)
+        if finding is not None:
+            findings.append(finding)
+    return tuple(findings)
+
+
+def _coerce_finding(
+    raw: Mapping[str, Any],
+    *,
+    lane_id: str,
+    report_refs: tuple[str, ...],
+    reasons: list[str],
+) -> Optional[ReadOnlyAuditSemanticFinding]:
+    finding_id = str(raw.get("finding_id") or "").strip()
+    claim = str(raw.get("claim") or "").strip()
+    wsp97_label = str(raw.get("wsp97_label") or "").strip().upper()
+    action = str(raw.get("recommended_action") or "").strip().upper()
+    priority = str(raw.get("wsp15_priority") or "").strip().upper()
+    severity = str(raw.get("severity") or "INFO").strip().upper()
+    next_slice = str(raw.get("next_slice_name") or "").strip() or None
+    evidence_refs = _normalize_refs(raw.get("evidence_refs"))
+    scope = finding_id or f"{lane_id}:unknown"
+    local_reasons: list[str] = []
+
+    if not finding_id:
+        local_reasons.append(f"finding_missing_id:{lane_id}")
+    if not lane_id:
+        local_reasons.append(f"finding_missing_lane:{scope}")
+    if not claim:
+        local_reasons.append(f"finding_missing_claim:{scope}")
+    if wsp97_label not in ALLOWED_WSP97_LABELS:
+        local_reasons.append(f"finding_bad_wsp97_label:{scope}")
+    if action not in ALLOWED_ACTIONS:
+        local_reasons.append(f"finding_bad_action:{scope}")
+    if priority not in ALLOWED_PRIORITIES:
+        local_reasons.append(f"finding_bad_wsp15_priority:{scope}")
+    if severity not in ALLOWED_SEVERITIES:
+        local_reasons.append(f"finding_bad_severity:{scope}")
+    if action in {ACTION_FIX, ACTION_RESEARCH_MORE, ACTION_REVISE} and not next_slice:
+        local_reasons.append(f"finding_missing_next_slice:{scope}")
+    if not evidence_refs and wsp97_label != "NEEDS_VERIFICATION":
+        local_reasons.append(f"finding_missing_evidence:{scope}")
+    if wsp97_label == "NEEDS_VERIFICATION" and action != ACTION_RESEARCH_MORE:
+        local_reasons.append(f"finding_needs_verification_not_research_more:{scope}")
+    if evidence_refs and not set(evidence_refs).issubset(set(report_refs)):
+        local_reasons.append(f"finding_evidence_not_in_report:{scope}")
+
+    if local_reasons:
+        reasons.extend(local_reasons)
+        return None
+
+    payload = {
+        "finding_id": finding_id,
+        "lane_id": lane_id,
+        "claim": claim,
+        "wsp97_label": wsp97_label,
+        "recommended_action": action,
+        "wsp15_priority": priority,
+        "severity": severity,
+        "evidence_refs": evidence_refs,
+        "next_slice_name": next_slice,
+    }
+    return ReadOnlyAuditSemanticFinding(
+        finding_id=finding_id,
+        lane_id=lane_id,
+        claim=claim,
+        wsp97_label=wsp97_label,
+        recommended_action=action,
+        wsp15_priority=priority,
+        severity=severity,
+        evidence_refs=evidence_refs,
+        next_slice_name=next_slice,
+        finding_digest=_digest(payload),
+    )
+
+
+def _receipt(
+    *,
+    accepted: bool,
+    action: str,
+    swarm_id: str,
+    report_bundle_id: Optional[str],
+    report_count: int,
+    findings: Sequence[ReadOnlyAuditSemanticFinding],
+    selected: Optional[ReadOnlyAuditSemanticFinding],
+    next_slice_name: Optional[str],
+    wsp15_priority: Optional[str],
+    decision_reasons: Sequence[str],
+    rejection_reasons: Sequence[str],
+) -> ReadOnlyAuditDecisionReceipt:
+    finding_digests = tuple(sorted(finding.finding_digest for finding in findings))
+    payload = {
+        "accepted": accepted,
+        "action": action,
+        "swarm_id": swarm_id,
+        "report_bundle_id": report_bundle_id,
+        "report_count": report_count,
+        "finding_digests": finding_digests,
+        "selected_finding_digest": selected.finding_digest if selected else None,
+        "next_slice_name": next_slice_name,
+        "wsp15_priority": wsp15_priority,
+        "decision_reasons": list(decision_reasons),
+        "rejection_reasons": list(rejection_reasons),
+    }
+    return ReadOnlyAuditDecisionReceipt(
+        decision_id=_digest(payload),
+        accepted=accepted,
+        status=READONLY_AUDIT_DECISION_ACCEPT if accepted else READONLY_AUDIT_DECISION_REJECT,
+        action=action,
+        swarm_id=swarm_id,
+        report_bundle_id=report_bundle_id,
+        report_count=report_count,
+        finding_count=len(findings),
+        selected_finding_digest=selected.finding_digest if selected else None,
+        next_slice_name=next_slice_name,
+        wsp15_priority=wsp15_priority,
+        decision_reasons=tuple(decision_reasons),
+        rejection_reasons=tuple(rejection_reasons),
+        finding_digests=finding_digests,
+    )
+
+
+def _finding_sort_key(finding: ReadOnlyAuditSemanticFinding) -> tuple[int, int, int, str]:
+    return (
+        _ACTION_RANK.get(finding.recommended_action, 99),
+        _PRIORITY_RANK.get(finding.wsp15_priority, 99),
+        _SEVERITY_RANK.get(finding.severity, 99),
+        finding.finding_id,
+    )
+
+
+def _normalize_refs(value: Any) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        return ()
+    return tuple(dict.fromkeys(str(item).strip() for item in value if str(item).strip()))
+
+
+def _dedupe(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(str(value) for value in values if str(value).strip()))
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def _digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "ACTION_FIX",
+    "ACTION_RESEARCH_MORE",
+    "ACTION_REVISE",
+    "ACTION_STOP",
+    "ACTION_WAIT_FOR_REPORTS",
+    "DEFAULT_SEMANTIC_FINDINGS_SLICE",
+    "READONLY_AUDIT_DECISION_ACCEPT",
+    "READONLY_AUDIT_DECISION_REJECT",
+    "ReadOnlyAuditDecisionReceipt",
+    "ReadOnlyAuditSemanticFinding",
+    "decide_reddog_readonly_audit_next_action",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -27,6 +27,11 @@ from modules.communication.moltbot_bridge.src.reddog_readonly_audit_report_colle
     READONLY_AUDIT_REPORT_COLLECTION_ACCEPT,
     READONLY_AUDIT_REPORT_COLLECTION_REJECT,
 )
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_decision_runtime import (
+    ACTION_FIX,
+    ACTION_RESEARCH_MORE,
+    DEFAULT_SEMANTIC_FINDINGS_SLICE,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -118,22 +123,42 @@ class _FakeReportStore:
         return {"ok": False, "reason": "not_used"}
 
 
-def _reports_for_bootstrap_result(result: RedDogMainReadonlyBootstrapResult) -> tuple[dict[str, object], ...]:
+def _reports_for_bootstrap_result(
+    result: RedDogMainReadonlyBootstrapResult,
+    *,
+    include_findings: bool = False,
+) -> tuple[dict[str, object], ...]:
     reports: list[dict[str, object]] = []
     assert result.snapshot_receipt_id is not None
     for assignment_id, lane_id in zip(result.assignment_ids, DEFAULT_AUDIT_LANES):
+        evidence_ref = f"file:docs/{lane_id}.md:sha256:{lane_id}:lines:1"
+        findings = []
+        if include_findings and lane_id == "repo_code_audit":
+            findings.append(
+                {
+                    "finding_id": "repo-code-finding-1",
+                    "claim": "Runtime reconciliation needs a follow-up slice.",
+                    "wsp97_label": "OBSERVED",
+                    "recommended_action": ACTION_FIX,
+                    "wsp15_priority": "P0",
+                    "severity": "BLOCKER",
+                    "evidence_refs": [evidence_ref],
+                    "next_slice_name": "REDDOG_RUNTIME_RECONCILER_PHASE1",
+                }
+            )
         reports.append(
             {
                 "assignment_id": assignment_id,
                 "lane_id": lane_id,
                 "snapshot_receipt_id": result.snapshot_receipt_id,
                 "summary": f"{lane_id} read-only audit evidence collected from 1 target.",
-                "evidence_refs": [f"file:docs/{lane_id}.md:sha256:{lane_id}:lines:1"],
+                "evidence_refs": [evidence_ref],
                 "repo_mutation_performed": False,
                 "execution_performed": False,
                 "openclaw_enqueue_performed": False,
                 "readonly_audit_performed": True,
                 "report_digest": f"sha256:{lane_id}",
+                "findings": findings,
             }
         )
     return tuple(reports)
@@ -200,9 +225,41 @@ def test_bootstrap_collects_existing_reports_and_skips_enqueue() -> None:
     assert result.report_collection_status == READONLY_AUDIT_REPORT_COLLECTION_ACCEPT
     assert result.report_collection_report_count == result.assignment_count == 5
     assert result.report_bundle_id and result.report_bundle_id.startswith("sha256:")
+    assert result.readonly_audit_decision_attempted is True
+    assert result.readonly_audit_decision_action == ACTION_RESEARCH_MORE
+    assert result.readonly_audit_decision_next_slice == DEFAULT_SEMANTIC_FINDINGS_SLICE
+    assert result.readonly_audit_decision_rejection_reasons == ()
     assert result.enqueue_attempted is False
     assert writer.calls == []
-    assert store.load_calls == [result.swarm_id]
+    assert store.load_calls == [result.swarm_id, result.swarm_id]
+
+
+def test_bootstrap_collects_semantic_findings_into_next_action_decision() -> None:
+    baseline = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+    )
+    store = _FakeReportStore(_reports_for_bootstrap_result(baseline, include_findings=True))
+
+    result = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+        collect_readonly_audit_reports=True,
+        report_store=store,
+    )
+
+    assert result.ready is True
+    assert result.report_collection_status == READONLY_AUDIT_REPORT_COLLECTION_ACCEPT
+    assert result.readonly_audit_decision_attempted is True
+    assert result.readonly_audit_decision_action == ACTION_FIX
+    assert result.readonly_audit_decision_next_slice == "REDDOG_RUNTIME_RECONCILER_PHASE1"
+    assert result.readonly_audit_decision_id and result.readonly_audit_decision_id.startswith("sha256:")
 
 
 def test_bootstrap_missing_reports_enqueue_when_enabled() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_decision_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_decision_runtime.py
@@ -1,0 +1,261 @@
+"""Tests for REDDOG_READONLY_AUDIT_DECISION_RUNTIME_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_runtime import (
+    READONLY_AUDIT_REPORTS_ACCEPTED,
+    READONLY_AUDIT_REPORTS_REJECTED,
+    READONLY_AUDIT_SWARM_PLANNED,
+    ReadOnlyAuditAssignment,
+    ReadOnlyAuditReportBundle,
+    ReadOnlyAuditReportValidationResult,
+    ReadOnlyAuditSwarmPlan,
+    ReadOnlyAuditSwarmReceipt,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_decision_runtime import (
+    ACTION_FIX,
+    ACTION_RESEARCH_MORE,
+    ACTION_WAIT_FOR_REPORTS,
+    DEFAULT_SEMANTIC_FINDINGS_SLICE,
+    READONLY_AUDIT_DECISION_ACCEPT,
+    READONLY_AUDIT_DECISION_REJECT,
+    decide_reddog_readonly_audit_next_action,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_report_collection import (
+    READONLY_AUDIT_REPORT_COLLECTION_ACCEPT,
+    READONLY_AUDIT_REPORT_COLLECTION_REJECT,
+    ReadOnlyAuditReportCollectionResult,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_readonly_audit_decision_runtime.py"
+)
+
+
+def _assignment() -> ReadOnlyAuditAssignment:
+    return ReadOnlyAuditAssignment(
+        assignment_id="readonly-assignment-1",
+        lane_id="repo_code_audit",
+        worker_role="readonly_repo_code_audit",
+        snapshot_receipt_id="sha256:snapshot",
+        snapshot_content_digest="sha256:snapshot-content",
+        context_view_id="sha256:view",
+        evidence_bundle_id="sha256:evidence",
+        determination_id="sha256:determination",
+        required_source="repo",
+        allowed_read_targets=("docs/work_ledger.schema.json",),
+    )
+
+
+def _plan() -> ReadOnlyAuditSwarmPlan:
+    assignment = _assignment()
+    receipt = ReadOnlyAuditSwarmReceipt(
+        swarm_id="readonly-swarm-1",
+        status=READONLY_AUDIT_SWARM_PLANNED,
+        snapshot_receipt_id=assignment.snapshot_receipt_id,
+        snapshot_content_digest=assignment.snapshot_content_digest,
+        context_view_id=assignment.context_view_id,
+        evidence_bundle_id=assignment.evidence_bundle_id,
+        determination_id=assignment.determination_id,
+        requested_operation="main_startup_readonly_operational_audit",
+        assignment_ids=(assignment.assignment_id,),
+        lanes=(assignment.lane_id,),
+        rejection_reasons=(),
+    )
+    return ReadOnlyAuditSwarmPlan(
+        accepted=True,
+        status=READONLY_AUDIT_SWARM_PLANNED,
+        receipt=receipt,
+        assignments=(assignment,),
+        rejection_reasons=(),
+    )
+
+
+def _report(*, findings=()) -> dict:
+    assignment = _assignment()
+    return {
+        "assignment_id": assignment.assignment_id,
+        "lane_id": assignment.lane_id,
+        "snapshot_receipt_id": assignment.snapshot_receipt_id,
+        "summary": "repo_code_audit read-only audit evidence collected from 1 target.",
+        "evidence_refs": ["file:docs/work_ledger.schema.json:sha256:abc:lines:1"],
+        "repo_mutation_performed": False,
+        "execution_performed": False,
+        "openclaw_enqueue_performed": False,
+        "readonly_audit_performed": True,
+        "report_digest": "sha256:report-1",
+        "findings": list(findings),
+    }
+
+
+def _accepted_collection() -> ReadOnlyAuditReportCollectionResult:
+    bundle = ReadOnlyAuditReportBundle(
+        bundle_id="sha256:bundle",
+        swarm_id=_plan().receipt.swarm_id,
+        report_digests=("sha256:report-1",),
+        lanes_reported=("repo_code_audit",),
+        missing_lanes=(),
+        rejection_reasons=(),
+    )
+    validation = ReadOnlyAuditReportValidationResult(
+        accepted=True,
+        status=READONLY_AUDIT_REPORTS_ACCEPTED,
+        bundle=bundle,
+        rejection_reasons=(),
+    )
+    return ReadOnlyAuditReportCollectionResult(
+        accepted=True,
+        status=READONLY_AUDIT_REPORT_COLLECTION_ACCEPT,
+        swarm_id=_plan().receipt.swarm_id,
+        report_count=1,
+        validation=validation,
+        rejection_reasons=(),
+    )
+
+
+def _rejected_collection() -> ReadOnlyAuditReportCollectionResult:
+    validation = ReadOnlyAuditReportValidationResult(
+        accepted=False,
+        status=READONLY_AUDIT_REPORTS_REJECTED,
+        bundle=None,
+        rejection_reasons=("missing_report_for_lane:repo_code_audit",),
+    )
+    return ReadOnlyAuditReportCollectionResult(
+        accepted=False,
+        status=READONLY_AUDIT_REPORT_COLLECTION_REJECT,
+        swarm_id=_plan().receipt.swarm_id,
+        report_count=0,
+        validation=validation,
+        rejection_reasons=("missing_report_for_lane:repo_code_audit",),
+    )
+
+
+def _fix_finding() -> dict:
+    return {
+        "finding_id": "repo-finding-1",
+        "claim": "Runtime reconciliation is missing.",
+        "wsp97_label": "OBSERVED",
+        "recommended_action": ACTION_FIX,
+        "wsp15_priority": "P0",
+        "severity": "BLOCKER",
+        "evidence_refs": ["file:docs/work_ledger.schema.json:sha256:abc:lines:1"],
+        "next_slice_name": "REDDOG_RUNTIME_RECONCILER_PHASE1",
+    }
+
+
+def test_no_semantic_findings_routes_to_research_more_without_overclaiming_fix() -> None:
+    decision = decide_reddog_readonly_audit_next_action(
+        collection_result=_accepted_collection(),
+        reports=(_report(),),
+    )
+
+    assert decision.accepted is True
+    assert decision.status == READONLY_AUDIT_DECISION_ACCEPT
+    assert decision.action == ACTION_RESEARCH_MORE
+    assert decision.next_slice_name == DEFAULT_SEMANTIC_FINDINGS_SLICE
+    assert decision.decision_reasons == ("semantic_findings_missing",)
+    assert decision.finding_count == 0
+    assert decision.no_model_call_performed is True
+    assert decision.no_repo_mutation_performed is True
+
+
+def test_selects_highest_priority_fix_finding_when_evidence_is_bound_to_report() -> None:
+    decision = decide_reddog_readonly_audit_next_action(
+        collection_result=_accepted_collection(),
+        reports=(_report(findings=(_fix_finding(),)),),
+    )
+
+    assert decision.accepted is True
+    assert decision.action == ACTION_FIX
+    assert decision.wsp15_priority == "P0"
+    assert decision.next_slice_name == "REDDOG_RUNTIME_RECONCILER_PHASE1"
+    assert decision.finding_count == 1
+    assert decision.selected_finding_digest in decision.finding_digests
+
+
+def test_rejected_collection_waits_for_reports() -> None:
+    decision = decide_reddog_readonly_audit_next_action(
+        collection_result=_rejected_collection(),
+        reports=(),
+    )
+
+    assert decision.accepted is False
+    assert decision.status == READONLY_AUDIT_DECISION_REJECT
+    assert decision.action == ACTION_WAIT_FOR_REPORTS
+    assert "missing_report_for_lane:repo_code_audit" in decision.rejection_reasons
+
+
+def test_rejects_report_count_mismatch() -> None:
+    decision = decide_reddog_readonly_audit_next_action(
+        collection_result=_accepted_collection(),
+        reports=(),
+    )
+
+    assert decision.accepted is False
+    assert "report_count_mismatch" in decision.rejection_reasons
+
+
+def test_rejects_finding_evidence_not_bound_to_report_refs() -> None:
+    bad = _fix_finding()
+    bad["evidence_refs"] = ["file:other.py:sha256:def:lines:1"]
+
+    decision = decide_reddog_readonly_audit_next_action(
+        collection_result=_accepted_collection(),
+        reports=(_report(findings=(bad,)),),
+    )
+
+    assert decision.accepted is False
+    assert "finding_evidence_not_in_report:repo-finding-1" in decision.rejection_reasons
+
+
+def test_needs_verification_finding_cannot_trigger_fix() -> None:
+    bad = _fix_finding()
+    bad["wsp97_label"] = "NEEDS_VERIFICATION"
+
+    decision = decide_reddog_readonly_audit_next_action(
+        collection_result=_accepted_collection(),
+        reports=(_report(findings=(bad,)),),
+    )
+
+    assert decision.accepted is False
+    assert "finding_needs_verification_not_research_more:repo-finding-1" in decision.rejection_reasons
+
+
+def test_decision_module_ast_has_no_execution_or_runtime_mutation() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    forbidden_import_roots = {
+        "subprocess",
+        "requests",
+        "httpx",
+        "socket",
+        "openclaw_supervisor",
+        "hermes_job_executor",
+    }
+    forbidden_tokens = (
+        "create_autonomous_task",
+        "execute_skill",
+        "holo_index.py --index",
+        "write_text",
+        "mkdir",
+        "git push",
+        "gh pr",
+    )
+    for token in forbidden_tokens:
+        assert token not in source
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".")[0] not in forbidden_import_roots
+        if isinstance(node, ast.ImportFrom):
+            assert (node.module or "").split(".")[0] not in forbidden_import_roots


### PR DESCRIPTION
## Summary
- Add REDDOG_READONLY_AUDIT_DECISION_RUNTIME_PHASE1 decision receipt for collected read-only audit bundles.
- Wire main read-only bootstrap telemetry to emit a deterministic next-action decision after accepted report collection.
- Route evidence-only reports with no semantic findings to RESEARCH_MORE instead of overclaiming FIX.

## WSP_97 Truth Boundary
- OBSERVED: Collection-only reports currently prove evidence acquisition, not semantic audit completion.
- OBSERVED: Evidence-bound semantic findings can deterministically select FIX/REVISE/RESEARCH_MORE/STOP.
- SPECIFIED_NOT_IMPLEMENTED: model Fusion synthesis, semantic audit worker generation, OpenClaw live enqueue, Hermes/WRE dispatch, repo mutation, worktree operation, HoloIndex re-index.

## Validation
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_decision_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_report_collection.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py -> 45 passed
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_decision_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_authoritative_work_state_refresh_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_enqueue.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_report_collection.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_runtime.py -> 62 passed
- git diff --check -> clean
- diff additions non-ASCII -> 0
- HoloIndex probe surfaced ModLog/adjacent results, not the new module -> HOLOINDEX_REDDOG_READONLY_AUDIT_DECISION_RUNTIME_INDEX_GAP_PHASE1

## Boundary
No model call, shell/subprocess, repo mutation, worktree operation, OpenClaw enqueue, Hermes/WRE dispatch, HoloIndex mutation/re-index, or live action-plane wiring.