### PR TITLE
feat(reddog): readonly audit semantic findings

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,25 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_READONLY_AUDIT_SEMANTIC_FINDINGS_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Extended `src/reddog_readonly_audit_task_executor.py` so accepted
+  read-only audit reports include a WSP_97-labeled semantic finding when the
+  lane-specific analyzer is still missing. The finding is evidence-bound to
+  the report refs and routes to `REDDOG_READONLY_AUDIT_LANE_ANALYZER_PHASE1`
+  instead of silently presenting evidence collection as finished audit work.
+- Extended the read-only report bundle digest payload in
+  `src/reddog_openclaw_readonly_audit_swarm_runtime.py` so report findings
+  affect the validated bundle identity.
+- Added executor test coverage proving the missing-analyzer finding is present,
+  `SPECIFIED_NOT_IMPLEMENTED`, evidence-bound, and routes to the next lane
+  analyzer slice.
+- Boundary: no model call, no shell/subprocess, no repo mutation, no worktree
+  operation, no OpenClaw enqueue, no Hermes/WRE dispatch, no HoloIndex
+  mutation/re-index, and no live action-plane wiring. This adds report
+  semantics only.
+
 ## 2026-07-14: REDDOG_READONLY_AUDIT_DECISION_RUNTIME_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_openclaw_readonly_audit_swarm_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_openclaw_readonly_audit_swarm_runtime.py
@@ -471,6 +471,7 @@ def _report_digest_payload(report: Mapping[str, Any]) -> dict[str, Any]:
         "lane_id": str(report.get("lane_id") or ""),
         "snapshot_receipt_id": str(report.get("snapshot_receipt_id") or ""),
         "evidence_refs": tuple(str(ref) for ref in (report.get("evidence_refs") or ())),
+        "findings_digest": _digest(report.get("findings") or ()),
         "summary_digest": _digest(str(report.get("summary") or "")),
     }
 

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_audit_task_executor.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_audit_task_executor.py
@@ -27,6 +27,7 @@ from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swa
 
 READONLY_AUDIT_TASK_REPORT_ACCEPT = "READONLY_AUDIT_TASK_REPORT_ACCEPT"
 READONLY_AUDIT_TASK_REPORT_REJECT = "READONLY_AUDIT_TASK_REPORT_REJECT"
+READONLY_AUDIT_LANE_ANALYZER_SLICE = "REDDOG_READONLY_AUDIT_LANE_ANALYZER_PHASE1"
 
 MAX_READ_TARGETS = 32
 MAX_READ_BYTES_PER_TARGET = 12_000
@@ -182,6 +183,7 @@ def _build_report(
         f"file:{item.path}:{item.digest}:lines:{item.line_count}"
         for item in evidence
     )
+    findings = _build_semantic_findings(lane_id=lane_id, evidence_refs=evidence_refs)
     return {
         "assignment_id": assignment_id,
         "lane_id": lane_id,
@@ -196,14 +198,40 @@ def _build_report(
         "openclaw_enqueue_performed": False,
         "readonly_audit_performed": True,
         "target_evidence": [item.to_dict() for item in evidence],
+        "findings": findings,
         "report_digest": "sha256:" + _digest(
             {
                 "assignment_id": assignment_id,
                 "lane_id": lane_id,
                 "evidence_refs": evidence_refs,
+                "findings": findings,
             }
         ),
     }
+
+
+def _build_semantic_findings(
+    *,
+    lane_id: str,
+    evidence_refs: Sequence[str],
+) -> list[Mapping[str, Any]]:
+    if not lane_id or not evidence_refs:
+        return []
+    return [
+        {
+            "finding_id": f"{lane_id}:lane_analyzer_missing",
+            "claim": (
+                f"{lane_id} collected read-only evidence, but the lane-specific "
+                "semantic analyzer is not implemented in the deterministic executor."
+            ),
+            "wsp97_label": "SPECIFIED_NOT_IMPLEMENTED",
+            "recommended_action": "FIX",
+            "wsp15_priority": "P1",
+            "severity": "MAJOR",
+            "evidence_refs": list(evidence_refs),
+            "next_slice_name": READONLY_AUDIT_LANE_ANALYZER_SLICE,
+        }
+    ]
 
 
 def _reject(reasons: Sequence[str]) -> ReadOnlyAuditTaskExecutionResult:
@@ -224,6 +252,7 @@ def _digest(value: Any) -> str:
 __all__ = [
     "READONLY_AUDIT_TASK_REPORT_ACCEPT",
     "READONLY_AUDIT_TASK_REPORT_REJECT",
+    "READONLY_AUDIT_LANE_ANALYZER_SLICE",
     "ReadOnlyAuditTaskExecutionResult",
     "ReadOnlyAuditTaskRejectReason",
     "ReadOnlyTargetEvidence",

--- a/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_report_collection.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_report_collection.py
@@ -30,6 +30,13 @@ from modules.communication.moltbot_bridge.src.reddog_readonly_audit_report_colle
     collect_reddog_readonly_audit_report_bundle,
     persist_reddog_readonly_audit_task_report,
 )
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_decision_runtime import (
+    ACTION_FIX,
+    decide_reddog_readonly_audit_next_action,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_task_executor import (
+    READONLY_AUDIT_LANE_ANALYZER_SLICE,
+)
 from modules.infrastructure.database.src.agent_db import AgentDB
 from modules.infrastructure.database.src.db_manager import DatabaseManager
 
@@ -233,13 +240,21 @@ def test_run_task_persists_report_before_marking_complete(tmp_path: Path, monkey
     assert db.assign_autonomous_task(task_id, "openclaw_supervisor")
 
     result = execute_task(task_id, repo_root=root)
-    collected = collect_reddog_readonly_audit_report_bundle(plan=plan)
+    store = AgentDbReadOnlyAuditReportStore()
+    collected = collect_reddog_readonly_audit_report_bundle(plan=plan, store=store)
+    decision = decide_reddog_readonly_audit_next_action(
+        collection_result=collected,
+        reports=store.load_readonly_audit_reports(plan.receipt.swarm_id),
+    )
 
     assert result["ok"] is True
     assert result["readonly_audit_report_persist"]["accepted"] is True
     assert db.get_autonomous_task_by_id(task_id)["status"] == "completed"
     assert collected.accepted is True
     assert collected.report_count == 1
+    assert decision.accepted is True
+    assert decision.action == ACTION_FIX
+    assert decision.next_slice_name == READONLY_AUDIT_LANE_ANALYZER_SLICE
 
 
 def test_report_collection_module_ast_has_no_execution_or_repo_mutation() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
@@ -13,6 +13,7 @@ from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swa
     READONLY_AUDIT_TASK_SOURCE,
 )
 from modules.communication.moltbot_bridge.src.reddog_readonly_audit_task_executor import (
+    READONLY_AUDIT_LANE_ANALYZER_SLICE,
     READONLY_AUDIT_TASK_REPORT_ACCEPT,
     READONLY_AUDIT_TASK_REPORT_REJECT,
     ReadOnlyAuditTaskRejectReason,
@@ -95,6 +96,13 @@ def test_readonly_audit_executor_reads_only_allowlisted_targets(tmp_path: Path) 
     assert result.report["openclaw_enqueue_performed"] is False
     assert len(result.report["evidence_refs"]) == 2
     assert all(ref.startswith("file:") for ref in result.report["evidence_refs"])
+    assert len(result.report["findings"]) == 1
+    finding = result.report["findings"][0]
+    assert finding["finding_id"] == "repo_code_audit:lane_analyzer_missing"
+    assert finding["wsp97_label"] == "SPECIFIED_NOT_IMPLEMENTED"
+    assert finding["recommended_action"] == "FIX"
+    assert finding["next_slice_name"] == READONLY_AUDIT_LANE_ANALYZER_SLICE
+    assert set(finding["evidence_refs"]) == set(result.report["evidence_refs"])
 
 
 def test_readonly_audit_executor_rejects_wrong_source_or_missing_assignment(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add REDDOG_READONLY_AUDIT_SEMANTIC_FINDINGS_PHASE1 behavior to the deterministic read-only audit task executor.
- Accepted reports now include a WSP_97-labeled, evidence-bound finding when lane-specific semantic analyzers are missing.
- Include report findings in the read-only report bundle digest payload.

## WSP_97 Truth Boundary
- OBSERVED: Existing read-only tasks collected evidence but did not produce semantic audit findings.
- OBSERVED: The new finding is SPECIFIED_NOT_IMPLEMENTED and routes to REDDOG_READONLY_AUDIT_LANE_ANALYZER_PHASE1.
- SPECIFIED_NOT_IMPLEMENTED: actual lane-specific repo/external/runtime/skill/security analyzers, model Fusion synthesis, OpenClaw live enqueue, Hermes/WRE dispatch, repo mutation, worktree operation, HoloIndex re-index.

## Validation
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_report_collection.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_decision_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py -> 45 passed
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_report_collection.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_decision_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_authoritative_work_state_refresh_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_enqueue.py -> 62 passed
- git diff --check -> clean
- diff additions non-ASCII -> 0
- HoloIndex probe did not surface the new runtime path -> HOLOINDEX_REDDOG_READONLY_AUDIT_SEMANTIC_FINDINGS_INDEX_GAP_PHASE1

## Boundary
No model call, shell/subprocess, repo mutation, worktree operation, OpenClaw enqueue, Hermes/WRE dispatch, HoloIndex mutation/re-index, or live action-plane wiring.