### PR TITLE
feat(reddog): readonly audit lane analyzer

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,25 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_READONLY_AUDIT_LANE_ANALYZER_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Extended `src/reddog_readonly_audit_task_executor.py` with the first
+  deterministic lane analyzer. When a read-only audit task includes
+  `ACTIVE_SLICE_LEDGER.md` and `work_ledger.schema.json`, the executor reuses
+  `reddog_lane_state_reconciler.reconcile_active_and_json_ledgers()` and emits
+  an `OBSERVED` semantic finding for the selected next slice, stale ledger, or
+  ledger conflict state.
+- Preserved the missing-analyzer fallback for lanes/target sets that do not yet
+  have a deterministic analyzer, keeping unimplemented audit lanes explicit
+  instead of silently treating evidence collection as audit completion.
+- Added tests for selected-next-slice findings, conflict-to-refresh-runtime
+  routing, existing missing-analyzer fallback, and the persisted report ->
+  collection -> decision path.
+- Boundary: no model call, no shell/subprocess, no repo mutation, no worktree
+  operation, no OpenClaw enqueue, no Hermes/WRE dispatch, no HoloIndex
+  mutation/re-index, and no live action-plane wiring.
+
 ## 2026-07-14: REDDOG_READONLY_AUDIT_SEMANTIC_FINDINGS_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_audit_task_executor.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_audit_task_executor.py
@@ -20,6 +20,9 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Mapping, Optional, Sequence
 
+from modules.communication.moltbot_bridge.src.reddog_lane_state_reconciler import (
+    reconcile_active_and_json_ledgers,
+)
 from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
     READONLY_AUDIT_TASK_SOURCE,
 )
@@ -28,11 +31,15 @@ from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swa
 READONLY_AUDIT_TASK_REPORT_ACCEPT = "READONLY_AUDIT_TASK_REPORT_ACCEPT"
 READONLY_AUDIT_TASK_REPORT_REJECT = "READONLY_AUDIT_TASK_REPORT_REJECT"
 READONLY_AUDIT_LANE_ANALYZER_SLICE = "REDDOG_READONLY_AUDIT_LANE_ANALYZER_PHASE1"
+AUTHORITATIVE_WORK_STATE_REFRESH_SLICE = "REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH_RUNTIME_PHASE1"
 
 MAX_READ_TARGETS = 32
 MAX_READ_BYTES_PER_TARGET = 12_000
 DENIED_BASENAMES = frozenset({".env", ".env.local", ".env.production", "id_rsa", "id_dsa"})
 DENIED_SEGMENTS = frozenset({".git", ".ssh", ".aws", ".azure", ".gcp", "__pycache__"})
+ACTIVE_SLICE_LEDGER_TARGET = "docs/0102_session_briefings/ACTIVE_SLICE_LEDGER.md"
+WORK_LEDGER_TARGET = "docs/0102_session_briefings/work_ledger.schema.json"
+LANE_RECONCILER_AUDIT_LANES = frozenset({"repo_code_audit", "runtime_freshness_audit"})
 
 
 class ReadOnlyAuditTaskRejectReason:
@@ -54,6 +61,12 @@ class ReadOnlyTargetEvidence:
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
+
+
+@dataclass(frozen=True)
+class _ReadOnlyTargetSnapshot:
+    evidence: ReadOnlyTargetEvidence
+    text: str
 
 
 @dataclass(frozen=True)
@@ -110,22 +123,23 @@ def execute_reddog_readonly_audit_task(
         return _reject([ReadOnlyAuditTaskRejectReason.TOO_MANY_TARGETS])
 
     root = Path(repo_root).resolve()
-    evidence: list[ReadOnlyTargetEvidence] = []
+    snapshots: list[_ReadOnlyTargetSnapshot] = []
     for target in targets:
         safe_path = _resolve_safe_target(root, target)
         if safe_path is None:
             return _reject([ReadOnlyAuditTaskRejectReason.UNSAFE_TARGET])
         try:
-            evidence.append(_read_target_evidence(root, safe_path))
+            snapshots.append(_read_target_snapshot(root, safe_path))
         except Exception:
             return _reject([ReadOnlyAuditTaskRejectReason.TARGET_READ_FAILED])
 
-    report = _build_report(assignment=assignment, evidence=evidence)
+    evidence = tuple(item.evidence for item in snapshots)
+    report = _build_report(assignment=assignment, snapshots=snapshots)
     return ReadOnlyAuditTaskExecutionResult(
         accepted=True,
         decision=READONLY_AUDIT_TASK_REPORT_ACCEPT,
         report=report,
-        evidence=tuple(evidence),
+        evidence=evidence,
         rejection_reasons=(),
     )
 
@@ -153,7 +167,7 @@ def _resolve_safe_target(root: Path, target: str) -> Optional[Path]:
     return candidate
 
 
-def _read_target_evidence(root: Path, path: Path) -> ReadOnlyTargetEvidence:
+def _read_target_snapshot(root: Path, path: Path) -> _ReadOnlyTargetSnapshot:
     raw = path.read_bytes()
     truncated = len(raw) > MAX_READ_BYTES_PER_TARGET
     payload = raw[:MAX_READ_BYTES_PER_TARGET]
@@ -163,27 +177,31 @@ def _read_target_evidence(root: Path, path: Path) -> ReadOnlyTargetEvidence:
     except UnicodeDecodeError:
         text = payload.decode("utf-8", errors="replace")
     relative = path.relative_to(root).as_posix()
-    return ReadOnlyTargetEvidence(
-        path=relative,
-        digest=digest,
-        bytes_read=len(payload),
-        line_count=text.count("\n") + (1 if text else 0),
-        truncated=truncated,
+    return _ReadOnlyTargetSnapshot(
+        evidence=ReadOnlyTargetEvidence(
+            path=relative,
+            digest=digest,
+            bytes_read=len(payload),
+            line_count=text.count("\n") + (1 if text else 0),
+            truncated=truncated,
+        ),
+        text=text,
     )
 
 
 def _build_report(
     *,
     assignment: Mapping[str, Any],
-    evidence: Sequence[ReadOnlyTargetEvidence],
+    snapshots: Sequence[_ReadOnlyTargetSnapshot],
 ) -> Mapping[str, Any]:
     lane_id = str(assignment.get("lane_id") or "")
     assignment_id = str(assignment.get("assignment_id") or "")
+    evidence = tuple(item.evidence for item in snapshots)
     evidence_refs = tuple(
         f"file:{item.path}:{item.digest}:lines:{item.line_count}"
         for item in evidence
     )
-    findings = _build_semantic_findings(lane_id=lane_id, evidence_refs=evidence_refs)
+    findings = _build_semantic_findings(lane_id=lane_id, snapshots=snapshots)
     return {
         "assignment_id": assignment_id,
         "lane_id": lane_id,
@@ -213,10 +231,14 @@ def _build_report(
 def _build_semantic_findings(
     *,
     lane_id: str,
-    evidence_refs: Sequence[str],
+    snapshots: Sequence[_ReadOnlyTargetSnapshot],
 ) -> list[Mapping[str, Any]]:
+    evidence_refs = tuple(_evidence_ref(item.evidence) for item in snapshots)
     if not lane_id or not evidence_refs:
         return []
+    reconciler_finding = _build_lane_reconciler_finding(lane_id=lane_id, snapshots=snapshots)
+    if reconciler_finding is not None:
+        return [reconciler_finding]
     return [
         {
             "finding_id": f"{lane_id}:lane_analyzer_missing",
@@ -232,6 +254,72 @@ def _build_semantic_findings(
             "next_slice_name": READONLY_AUDIT_LANE_ANALYZER_SLICE,
         }
     ]
+
+
+def _build_lane_reconciler_finding(
+    *,
+    lane_id: str,
+    snapshots: Sequence[_ReadOnlyTargetSnapshot],
+) -> Optional[Mapping[str, Any]]:
+    if lane_id not in LANE_RECONCILER_AUDIT_LANES:
+        return None
+    by_path = {item.evidence.path: item for item in snapshots}
+    active = by_path.get(ACTIVE_SLICE_LEDGER_TARGET)
+    ledger = by_path.get(WORK_LEDGER_TARGET)
+    if active is None or ledger is None:
+        return None
+
+    report = reconcile_active_and_json_ledgers(
+        active.text,
+        ledger.text,
+        now_iso="2026-07-14T00:00:00+00:00",
+        stale_after_days=30,
+    )
+    evidence_refs = [_evidence_ref(active.evidence), _evidence_ref(ledger.evidence)]
+    selected = report.prework_packet.chosen_slice
+    if report.recommended_action == "NO_OPEN_WORK":
+        action = "STOP"
+        priority = "P4"
+        severity = "INFO"
+        next_slice = None
+        claim = "Lane-state reconciliation found no open work in the provided ledgers."
+    elif report.recommended_action == "CLAIM_NEXT_SLICE" and selected:
+        action = "FIX"
+        priority = "P1"
+        severity = "MAJOR"
+        next_slice = selected
+        claim = f"Lane-state reconciliation selected next slice {selected}."
+    elif report.recommended_action == "RECONCILE_LEDGER_BEFORE_WORK":
+        action = "REVISE"
+        priority = "P0"
+        severity = "BLOCKER"
+        next_slice = AUTHORITATIVE_WORK_STATE_REFRESH_SLICE
+        claim = "Lane-state reconciliation found ledger conflicts that block worker assignment."
+    else:
+        action = "REVISE"
+        priority = "P1"
+        severity = "MAJOR"
+        next_slice = AUTHORITATIVE_WORK_STATE_REFRESH_SLICE
+        claim = f"Lane-state reconciliation returned {report.recommended_action} before work can continue."
+
+    return {
+        "finding_id": f"{lane_id}:lane_state_reconciliation:{report.recommended_action.lower()}",
+        "claim": claim,
+        "wsp97_label": "OBSERVED",
+        "recommended_action": action,
+        "wsp15_priority": priority,
+        "severity": severity,
+        "evidence_refs": evidence_refs,
+        "next_slice_name": next_slice,
+        "reconciliation_report_id": report.report_id,
+        "next_wsp15_queue": list(report.next_wsp15_queue),
+        "stale_sources": list(report.stale_sources),
+        "conflict_count": len(report.conflicts),
+    }
+
+
+def _evidence_ref(item: ReadOnlyTargetEvidence) -> str:
+    return f"file:{item.path}:{item.digest}:lines:{item.line_count}"
 
 
 def _reject(reasons: Sequence[str]) -> ReadOnlyAuditTaskExecutionResult:
@@ -253,6 +341,7 @@ __all__ = [
     "READONLY_AUDIT_TASK_REPORT_ACCEPT",
     "READONLY_AUDIT_TASK_REPORT_REJECT",
     "READONLY_AUDIT_LANE_ANALYZER_SLICE",
+    "AUTHORITATIVE_WORK_STATE_REFRESH_SLICE",
     "ReadOnlyAuditTaskExecutionResult",
     "ReadOnlyAuditTaskRejectReason",
     "ReadOnlyTargetEvidence",

--- a/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import json
 from pathlib import Path
 
 import pytest
@@ -13,6 +14,7 @@ from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swa
     READONLY_AUDIT_TASK_SOURCE,
 )
 from modules.communication.moltbot_bridge.src.reddog_readonly_audit_task_executor import (
+    AUTHORITATIVE_WORK_STATE_REFRESH_SLICE,
     READONLY_AUDIT_LANE_ANALYZER_SLICE,
     READONLY_AUDIT_TASK_REPORT_ACCEPT,
     READONLY_AUDIT_TASK_REPORT_REJECT,
@@ -53,6 +55,45 @@ def _repo(tmp_path: Path) -> Path:
     return root
 
 
+def _repo_with_ledgers(tmp_path: Path) -> Path:
+    root = tmp_path / "repo-ledgers"
+    active = root / "docs" / "0102_session_briefings" / "ACTIVE_SLICE_LEDGER.md"
+    active.parent.mkdir(parents=True)
+    active.write_text(
+        """# Active Slice Ledger
+
+**Updated**: 2026-07-14
+
+## Open Slices
+
+| Slice | Priority | Blocked By | Notes |
+|-------|----------|------------|-------|
+| `REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1` | P0 | - | next |
+""",
+        encoding="utf-8",
+    )
+    ledger = root / "docs" / "0102_session_briefings" / "work_ledger.schema.json"
+    ledger.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0.0",
+                "last_updated": "2026-07-14T00:00:00Z",
+                "slices": [
+                    {
+                        "slice_id": "REDDOG_JSON_SECONDARY_PHASE1",
+                        "status": "PROPOSED",
+                        "priority": "P1",
+                        "wsp15_score": {"total": 16},
+                    }
+                ],
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    return root
+
+
 def _context() -> dict:
     return {
         "source": READONLY_AUDIT_TASK_SOURCE,
@@ -80,6 +121,16 @@ def _context() -> dict:
     }
 
 
+def _ledger_context() -> dict:
+    context = _context()
+    context["assignment"] = dict(context["assignment"])
+    context["assignment"]["allowed_read_targets"] = [
+        "docs/0102_session_briefings/ACTIVE_SLICE_LEDGER.md",
+        "docs/0102_session_briefings/work_ledger.schema.json",
+    ]
+    return context
+
+
 def test_readonly_audit_executor_reads_only_allowlisted_targets(tmp_path: Path) -> None:
     root = _repo(tmp_path)
 
@@ -103,6 +154,64 @@ def test_readonly_audit_executor_reads_only_allowlisted_targets(tmp_path: Path) 
     assert finding["recommended_action"] == "FIX"
     assert finding["next_slice_name"] == READONLY_AUDIT_LANE_ANALYZER_SLICE
     assert set(finding["evidence_refs"]) == set(result.report["evidence_refs"])
+
+
+def test_readonly_audit_executor_uses_lane_reconciler_when_ledgers_are_available(tmp_path: Path) -> None:
+    root = _repo_with_ledgers(tmp_path)
+
+    result = execute_reddog_readonly_audit_task(task_context=_ledger_context(), repo_root=root)
+
+    assert result.accepted is True
+    assert result.report is not None
+    assert len(result.report["findings"]) == 1
+    finding = result.report["findings"][0]
+    assert finding["wsp97_label"] == "OBSERVED"
+    assert finding["recommended_action"] == "FIX"
+    assert finding["next_slice_name"] == "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1"
+    assert finding["reconciliation_report_id"]
+    assert finding["next_wsp15_queue"][0] == "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1"
+    assert set(finding["evidence_refs"]) == set(result.report["evidence_refs"])
+
+
+def test_readonly_audit_executor_routes_conflicted_ledgers_to_refresh_runtime(tmp_path: Path) -> None:
+    root = _repo_with_ledgers(tmp_path)
+    active = root / "docs" / "0102_session_briefings" / "ACTIVE_SLICE_LEDGER.md"
+    active.write_text(
+        """# Active Slice Ledger
+
+**Updated**: 2026-07-14
+
+## Closed Slices
+
+| Slice | Commit | Evidence |
+|-------|--------|----------|
+| `REDDOG_DONE_PHASE1` | `abc1234` | done |
+""",
+        encoding="utf-8",
+    )
+    ledger = root / "docs" / "0102_session_briefings" / "work_ledger.schema.json"
+    ledger.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0.0",
+                "last_updated": "2026-07-14T00:00:00Z",
+                "slices": [{"slice_id": "REDDOG_DONE_PHASE1", "status": "IN_PROGRESS"}],
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    result = execute_reddog_readonly_audit_task(task_context=_ledger_context(), repo_root=root)
+
+    assert result.accepted is True
+    assert result.report is not None
+    finding = result.report["findings"][0]
+    assert finding["recommended_action"] == "REVISE"
+    assert finding["wsp15_priority"] == "P0"
+    assert finding["severity"] == "BLOCKER"
+    assert finding["next_slice_name"] == AUTHORITATIVE_WORK_STATE_REFRESH_SLICE
+    assert finding["conflict_count"] == 1
 
 
 def test_readonly_audit_executor_rejects_wrong_source_or_missing_assignment(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add REDDOG_READONLY_AUDIT_LANE_ANALYZER_PHASE1 behavior to the read-only audit task executor.
- Reuse the existing lane-state reconciler when ACTIVE_SLICE_LEDGER.md and work_ledger.schema.json are present.
- Emit OBSERVED semantic findings for selected next slice, stale/refresh-required state, ledger conflicts, or no-open-work state; preserve the missing-analyzer fallback for unsupported lanes/targets.

## WSP_97 Truth Boundary
- OBSERVED: Lane ledgers can be reconciled deterministically without model calls or mutation.
- OBSERVED: Unsupported lanes remain SPECIFIED_NOT_IMPLEMENTED instead of being treated as audited.
- SPECIFIED_NOT_IMPLEMENTED: external research analyzer, runtime version freshness analyzer, skill-gap analyzer, security/governance analyzer, model Fusion synthesis, OpenClaw live enqueue, Hermes/WRE dispatch, HoloIndex re-index.

## Validation
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_report_collection.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_decision_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_lane_state_reconciler.py -> 60 passed
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_report_collection.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_decision_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_authoritative_work_state_refresh_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_enqueue.py modules/communication/moltbot_bridge/tests/test_reddog_lane_state_reconciler.py -> 77 passed
- git diff --check -> clean
- diff additions non-ASCII -> 0
- HoloIndex probe did not surface the new runtime path -> HOLOINDEX_REDDOG_READONLY_AUDIT_LANE_ANALYZER_INDEX_GAP_PHASE1

## Boundary
No model call, shell/subprocess, repo mutation, worktree operation, OpenClaw enqueue, Hermes/WRE dispatch, HoloIndex mutation/re-index, or live action-plane wiring.