### PR TITLE
feat(reddog): surface readonly audit decision telemetry

### DIFF
--- a/main.py
+++ b/main.py
@@ -1241,7 +1241,11 @@ def run_reddog_readonly_operational_bootstrap_preflight(repo_root: Path) -> bool
         f"[REDDOG-BOOTSTRAP] preflight={status} status={result.status} "
         f"assignments={result.assignment_count} report_collection_attempted={result.report_collection_attempted} "
         f"report_collection_status={result.report_collection_status or '(none)'} "
-        f"reports={result.report_collection_report_count} enqueue_attempted={result.enqueue_attempted} "
+        f"reports={result.report_collection_report_count} "
+        f"decision_attempted={result.readonly_audit_decision_attempted} "
+        f"decision_action={result.readonly_audit_decision_action or '(none)'} "
+        f"decision_next_slice={result.readonly_audit_decision_next_slice or '(none)'} "
+        f"enqueue_attempted={result.enqueue_attempted} "
         f"enqueue_decision={result.enqueue_decision or '(none)'} "
         f"enqueue_tasks={result.enqueue_task_count} reasons={reasons}"
     )

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,18 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_MAIN_READONLY_AUDIT_DECISION_TELEMETRY_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Updated `main.py` RedDog bootstrap output to print read-only audit decision
+  telemetry: whether decision generation ran, the selected action, and the
+  selected next slice.
+- Added stdout regression coverage proving the main menu/preflight surface
+  exposes `decision_action` and `decision_next_slice` without blocking startup.
+- Boundary: telemetry only. No model call, no shell/subprocess, no repo
+  mutation, no worktree operation, no OpenClaw enqueue, no Hermes/WRE dispatch,
+  no HoloIndex mutation/re-index, and no live action-plane wiring.
+
 ## 2026-07-14: REDDOG_READONLY_AUDIT_LANE_ANALYZER_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -482,7 +482,7 @@ def test_main_preflight_blocks_only_when_enforced_and_not_ready() -> None:
         assert main.run_reddog_readonly_operational_bootstrap_preflight(REPO_ROOT) is False
 
 
-def test_main_preflight_reports_ready_without_blocking_menu() -> None:
+def test_main_preflight_reports_ready_without_blocking_menu(capsys) -> None:
     import main
 
     ready_result = RedDogMainReadonlyBootstrapResult(
@@ -497,6 +497,9 @@ def test_main_preflight_reports_ready_without_blocking_menu() -> None:
         rejection_reasons=(),
         changed_paths=DEFAULT_BOOTSTRAP_CHANGED_PATHS,
         allowed_read_targets=DEFAULT_BOOTSTRAP_CHANGED_PATHS,
+        readonly_audit_decision_attempted=True,
+        readonly_audit_decision_action=ACTION_FIX,
+        readonly_audit_decision_next_slice="REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
     )
     with patch(
         "modules.communication.moltbot_bridge.src.reddog_main_readonly_operational_bootstrap.run_reddog_main_readonly_operational_bootstrap",
@@ -504,6 +507,10 @@ def test_main_preflight_reports_ready_without_blocking_menu() -> None:
     ):
         with patch.dict("os.environ", {"REDDOG_READONLY_OPERATIONAL_BOOTSTRAP": "1"}, clear=False):
             assert main.run_reddog_readonly_operational_bootstrap_preflight(REPO_ROOT) is True
+    output = capsys.readouterr().out
+    assert "decision_attempted=True" in output
+    assert "decision_action=FIX" in output
+    assert "decision_next_slice=REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1" in output
 
 
 def test_main_preflight_enables_enqueue_when_openclaw_auto_tasks_enabled() -> None:


### PR DESCRIPTION
## Summary
- Add REDDOG_MAIN_READONLY_AUDIT_DECISION_TELEMETRY_PHASE1 to the startup surface.
- main.py now prints decision_attempted, decision_action, and decision_next_slice for the RedDog read-only audit bootstrap.
- Add stdout regression coverage for the main preflight surface.

## WSP_97 Truth Boundary
- OBSERVED: The decision receipt exists after report collection, but main.py did not surface it to 012/operators.
- SPECIFIED_NOT_IMPLEMENTED: action execution from the decision, live enqueue, Hermes/WRE dispatch, repo mutation, worktree operation, HoloIndex re-index.

## Validation
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_report_collection.py -> 31 passed
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_report_collection.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_decision_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_authoritative_work_state_refresh_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_enqueue.py modules/communication/moltbot_bridge/tests/test_reddog_lane_state_reconciler.py -> 77 passed
- git diff --check -> clean
- diff additions non-ASCII -> 0
- HoloIndex probe missed the new main.py telemetry -> HOLOINDEX_REDDOG_MAIN_READONLY_AUDIT_DECISION_TELEMETRY_INDEX_GAP_PHASE1

## Boundary
Telemetry only. No model call, shell/subprocess, repo mutation, worktree operation, OpenClaw enqueue, Hermes/WRE dispatch, HoloIndex mutation/re-index, or live action-plane wiring.