### PR TITLE
feat(reddog): persist readonly audit decisions

### DIFF
--- a/main.py
+++ b/main.py
@@ -1191,6 +1191,7 @@ def run_reddog_readonly_operational_bootstrap_preflight(repo_root: Path) -> bool
         REDDOG_READONLY_OPERATIONAL_BOOTSTRAP=1           Enable check (default ON)
         REDDOG_READONLY_OPERATIONAL_BOOTSTRAP_ENFORCED=0  Block startup if not ready
         REDDOG_READONLY_AUDIT_REPORT_COLLECTION_ENABLED   Override audit report collection bridge
+        REDDOG_READONLY_AUDIT_DECISION_PERSIST_ENABLED    Override audit decision persistence bridge
         REDDOG_READONLY_AUDIT_SWARM_ENQUEUE_ENABLED       Override audit task enqueue bridge
         OPENCLAW_AUTO_TASKS_ENABLED                       Enables audit task enqueue if no override
         REDDOG_AUTHORITATIVE_WORK_STATE_PATH              Existing work-state JSON
@@ -1213,6 +1214,11 @@ def run_reddog_readonly_operational_bootstrap_preflight(repo_root: Path) -> bool
         collection_requested = os.getenv("OPENCLAW_AUTO_TASKS_ENABLED", "0") != "0"
     else:
         collection_requested = collection_override != "0"
+    decision_persist_override = os.getenv("REDDOG_READONLY_AUDIT_DECISION_PERSIST_ENABLED")
+    if decision_persist_override is None:
+        decision_persist_requested = os.getenv("OPENCLAW_AUTO_TASKS_ENABLED", "0") != "0"
+    else:
+        decision_persist_requested = decision_persist_override != "0"
 
     try:
         from modules.communication.moltbot_bridge.src.reddog_main_readonly_operational_bootstrap import (
@@ -1226,6 +1232,7 @@ def run_reddog_readonly_operational_bootstrap_preflight(repo_root: Path) -> bool
             holoindex_ssd_path=os.getenv("HOLOINDEX_SSD_PATH", ""),
             collect_readonly_audit_reports=collection_requested,
             enqueue_readonly_audit_tasks=enqueue_requested,
+            persist_readonly_audit_decision=decision_persist_requested,
         )
     except Exception as exc:
         logger.error(f"[REDDOG-BOOTSTRAP] Startup preflight failed: {exc}")
@@ -1245,6 +1252,8 @@ def run_reddog_readonly_operational_bootstrap_preflight(repo_root: Path) -> bool
         f"decision_attempted={result.readonly_audit_decision_attempted} "
         f"decision_action={result.readonly_audit_decision_action or '(none)'} "
         f"decision_next_slice={result.readonly_audit_decision_next_slice or '(none)'} "
+        f"decision_persist_attempted={result.readonly_audit_decision_persist_attempted} "
+        f"decision_persist_status={result.readonly_audit_decision_persist_status or '(none)'} "
         f"enqueue_attempted={result.enqueue_attempted} "
         f"enqueue_decision={result.enqueue_decision or '(none)'} "
         f"enqueue_tasks={result.enqueue_task_count} reasons={reasons}"

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,26 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_READONLY_AUDIT_DECISION_PERSISTENCE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_readonly_audit_decision_persistence.py`: an AgentDB-backed
+  durable store for accepted RedDog read-only audit next-action receipts.
+- Wired `src/reddog_main_readonly_operational_bootstrap.py` and `main.py` with an
+  opt-in decision persistence bridge. `OPENCLAW_AUTO_TASKS_ENABLED=1` enables it
+  by default, and `REDDOG_READONLY_AUDIT_DECISION_PERSIST_ENABLED=0/1` overrides
+  that default.
+- Added tests for accepted receipt persistence, idempotent duplicate writes,
+  same-swarm conflict rejection, rejected/side-effect receipt refusal, bootstrap
+  persistence wiring, and main preflight environment routing.
+- Boundary: this persists accepted decision receipts only. It does not execute
+  the decision, enqueue new work from the decision, call models, run shell/git,
+  dispatch Hermes/WRE, create worktrees, mutate repo files, or re-index HoloIndex.
+- HoloIndex read-only probe for `RedDog read-only audit decision persistence`
+  did not surface the new module in top results before indexing. Recorded as
+  `HOLOINDEX_REDDOG_READONLY_AUDIT_DECISION_PERSISTENCE_INDEX_GAP_PHASE1`; no
+  runtime re-index performed.
+
 ## 2026-07-14: REDDOG_MAIN_READONLY_AUDIT_DECISION_TELEMETRY_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
@@ -42,6 +42,12 @@ from modules.communication.moltbot_bridge.src.reddog_readonly_audit_decision_run
     ReadOnlyAuditDecisionReceipt,
     decide_reddog_readonly_audit_next_action,
 )
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_decision_persistence import (
+    AgentDbReadOnlyAuditDecisionStore,
+    ReadOnlyAuditDecisionPersistResult,
+    ReadOnlyAuditDecisionStore,
+    persist_reddog_readonly_audit_decision,
+)
 from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
     EvidenceBundle,
     OperationalContextSnapshot,
@@ -96,6 +102,10 @@ class RedDogMainReadonlyBootstrapResult:
     readonly_audit_decision_id: Optional[str] = None
     readonly_audit_decision_next_slice: Optional[str] = None
     readonly_audit_decision_rejection_reasons: tuple[str, ...] = ()
+    readonly_audit_decision_persist_attempted: bool = False
+    readonly_audit_decision_persist_status: Optional[str] = None
+    readonly_audit_decision_persist_stored: bool = False
+    readonly_audit_decision_persist_rejection_reasons: tuple[str, ...] = ()
     enqueue_attempted: bool = False
     enqueue_decision: Optional[str] = None
     enqueue_receipt_id: Optional[str] = None
@@ -133,6 +143,8 @@ def run_reddog_main_readonly_operational_bootstrap(
     seen_assignment_ids: Optional[set[str]] = None,
     collect_readonly_audit_reports: bool = False,
     report_store: ReadOnlyAuditReportStore | None = None,
+    persist_readonly_audit_decision: bool = False,
+    decision_store: ReadOnlyAuditDecisionStore | None = None,
 ) -> RedDogMainReadonlyBootstrapResult:
     """Build a read-only startup plan or explain why it is not ready."""
 
@@ -239,6 +251,7 @@ def run_reddog_main_readonly_operational_bootstrap(
 
     collection_result: ReadOnlyAuditReportCollectionResult | None = None
     decision_result: ReadOnlyAuditDecisionReceipt | None = None
+    decision_persist_result: ReadOnlyAuditDecisionPersistResult | None = None
     if collect_readonly_audit_reports:
         reader = report_store if report_store is not None else AgentDbReadOnlyAuditReportStore()
         collection_result = collect_reddog_readonly_audit_report_bundle(
@@ -274,7 +287,30 @@ def run_reddog_main_readonly_operational_bootstrap(
                     swarm_plan=plan,
                     collection_result=collection_result,
                     decision_result=decision_result,
+                    decision_persist_result=decision_persist_result,
                 )
+            if persist_readonly_audit_decision:
+                decision_writer = decision_store if decision_store is not None else AgentDbReadOnlyAuditDecisionStore()
+                decision_persist_result = persist_reddog_readonly_audit_decision(
+                    decision=decision_result,
+                    store=decision_writer,
+                )
+                if not decision_persist_result.accepted:
+                    return _not_ready(
+                        reasons=(
+                            "readonly_audit_decision_persist_rejected",
+                            *decision_persist_result.rejection_reasons,
+                        ),
+                        changed_paths=paths,
+                        allowed_read_targets=targets,
+                        snapshot=snapshot,
+                        evidence_bundle=evidence_bundle,
+                        gate=gate,
+                        swarm_plan=plan,
+                        collection_result=collection_result,
+                        decision_result=decision_result,
+                        decision_persist_result=decision_persist_result,
+                    )
             return _ready(
                 snapshot=snapshot,
                 context_view=context_view,
@@ -285,6 +321,7 @@ def run_reddog_main_readonly_operational_bootstrap(
                 allowed_read_targets=targets,
                 collection_result=collection_result,
                 decision_result=decision_result,
+                decision_persist_result=decision_persist_result,
                 enqueue_result=None,
                 enqueue_attempted=False,
             )
@@ -299,6 +336,7 @@ def run_reddog_main_readonly_operational_bootstrap(
                 swarm_plan=plan,
                 collection_result=collection_result,
                 decision_result=decision_result,
+                decision_persist_result=decision_persist_result,
             )
 
     enqueue_result: ReadOnlyAuditSwarmEnqueueResult | None = None
@@ -320,6 +358,7 @@ def run_reddog_main_readonly_operational_bootstrap(
                 swarm_plan=plan,
                 collection_result=collection_result,
                 decision_result=decision_result,
+                decision_persist_result=decision_persist_result,
                 enqueue_result=enqueue_result,
             )
 
@@ -333,6 +372,7 @@ def run_reddog_main_readonly_operational_bootstrap(
         allowed_read_targets=targets,
         collection_result=collection_result,
         decision_result=decision_result,
+        decision_persist_result=decision_persist_result,
         enqueue_result=enqueue_result,
         enqueue_attempted=enqueue_readonly_audit_tasks,
     )
@@ -349,6 +389,7 @@ def _ready(
     allowed_read_targets: Sequence[str],
     collection_result: ReadOnlyAuditReportCollectionResult | None,
     decision_result: ReadOnlyAuditDecisionReceipt | None,
+    decision_persist_result: ReadOnlyAuditDecisionPersistResult | None,
     enqueue_result: ReadOnlyAuditSwarmEnqueueResult | None,
     enqueue_attempted: bool,
 ) -> RedDogMainReadonlyBootstrapResult:
@@ -378,6 +419,12 @@ def _ready(
         readonly_audit_decision_id=decision_result.decision_id if decision_result else None,
         readonly_audit_decision_next_slice=decision_result.next_slice_name if decision_result else None,
         readonly_audit_decision_rejection_reasons=decision_result.rejection_reasons if decision_result else (),
+        readonly_audit_decision_persist_attempted=decision_persist_result is not None,
+        readonly_audit_decision_persist_status=decision_persist_result.status if decision_persist_result else None,
+        readonly_audit_decision_persist_stored=decision_persist_result.stored if decision_persist_result else False,
+        readonly_audit_decision_persist_rejection_reasons=(
+            decision_persist_result.rejection_reasons if decision_persist_result else ()
+        ),
         enqueue_attempted=enqueue_attempted,
         enqueue_decision=enqueue_result.decision if enqueue_result else None,
         enqueue_receipt_id=enqueue_result.receipt.enqueue_receipt_id if enqueue_result else None,
@@ -430,6 +477,7 @@ def _not_ready(
     swarm_plan: ReadOnlyAuditSwarmPlan | None = None,
     collection_result: ReadOnlyAuditReportCollectionResult | None = None,
     decision_result: ReadOnlyAuditDecisionReceipt | None = None,
+    decision_persist_result: ReadOnlyAuditDecisionPersistResult | None = None,
     enqueue_result: ReadOnlyAuditSwarmEnqueueResult | None = None,
 ) -> RedDogMainReadonlyBootstrapResult:
     determination_id = None
@@ -463,6 +511,12 @@ def _not_ready(
         readonly_audit_decision_id=decision_result.decision_id if decision_result else None,
         readonly_audit_decision_next_slice=decision_result.next_slice_name if decision_result else None,
         readonly_audit_decision_rejection_reasons=decision_result.rejection_reasons if decision_result else (),
+        readonly_audit_decision_persist_attempted=decision_persist_result is not None,
+        readonly_audit_decision_persist_status=decision_persist_result.status if decision_persist_result else None,
+        readonly_audit_decision_persist_stored=decision_persist_result.stored if decision_persist_result else False,
+        readonly_audit_decision_persist_rejection_reasons=(
+            decision_persist_result.rejection_reasons if decision_persist_result else ()
+        ),
         enqueue_attempted=enqueue_result is not None,
         enqueue_decision=enqueue_result.decision if enqueue_result else None,
         enqueue_receipt_id=enqueue_result.receipt.enqueue_receipt_id if enqueue_result else None,

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_audit_decision_persistence.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_audit_decision_persistence.py
@@ -1,0 +1,355 @@
+"""Persist RedDog read-only audit decision receipts.
+
+Slice: REDDOG_READONLY_AUDIT_DECISION_PERSISTENCE_PHASE1
+
+This module stores accepted read-only audit decision receipts in AgentDB so
+RedDog can remember its selected next action across startup cycles. It does not
+execute the decision, enqueue new work, call models, run shell commands, mutate
+repository files, dispatch Hermes/WRE, create worktrees, or re-index HoloIndex.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Optional, Protocol, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_decision_runtime import (
+    ReadOnlyAuditDecisionReceipt,
+)
+
+
+READONLY_AUDIT_DECISION_PERSIST_ACCEPT = "READONLY_AUDIT_DECISION_PERSIST_ACCEPT"
+READONLY_AUDIT_DECISION_PERSIST_REJECT = "READONLY_AUDIT_DECISION_PERSIST_REJECT"
+
+
+class ReadOnlyAuditDecisionPersistReason:
+    DECISION_NOT_ACCEPTED = "REJECT_READONLY_AUDIT_DECISION_NOT_ACCEPTED"
+    MISSING_DECISION_ID = "REJECT_READONLY_AUDIT_DECISION_MISSING_DECISION_ID"
+    MISSING_SWARM_ID = "REJECT_READONLY_AUDIT_DECISION_MISSING_SWARM_ID"
+    MISSING_ACTION = "REJECT_READONLY_AUDIT_DECISION_MISSING_ACTION"
+    MISSING_NEXT_SLICE = "REJECT_READONLY_AUDIT_DECISION_MISSING_NEXT_SLICE"
+    DECISION_CLAIMS_SIDE_EFFECT = "REJECT_READONLY_AUDIT_DECISION_CLAIMS_SIDE_EFFECT"
+    STORE_REJECTED = "REJECT_READONLY_AUDIT_DECISION_STORE_REJECTED"
+
+
+@dataclass(frozen=True)
+class ReadOnlyAuditDecisionRecord:
+    decision_id: str
+    swarm_id: str
+    report_bundle_id: Optional[str]
+    action: str
+    next_slice_name: Optional[str]
+    wsp15_priority: Optional[str]
+    decision: Mapping[str, Any]
+    stored_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "decision_id": self.decision_id,
+            "swarm_id": self.swarm_id,
+            "report_bundle_id": self.report_bundle_id,
+            "action": self.action,
+            "next_slice_name": self.next_slice_name,
+            "wsp15_priority": self.wsp15_priority,
+            "decision": dict(self.decision),
+            "stored_at": self.stored_at,
+        }
+
+
+@dataclass(frozen=True)
+class ReadOnlyAuditDecisionPersistResult:
+    accepted: bool
+    status: str
+    decision_id: Optional[str]
+    swarm_id: Optional[str]
+    action: Optional[str]
+    next_slice_name: Optional[str]
+    stored: bool
+    idempotent: bool
+    rejection_reasons: tuple[str, ...]
+    no_model_call_performed: bool = True
+    no_shell_command_executed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_worktree_operation_performed: bool = True
+    no_decision_execution_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class ReadOnlyAuditDecisionStore(Protocol):
+    def store_readonly_audit_decision(self, record: ReadOnlyAuditDecisionRecord) -> Mapping[str, Any]: ...
+
+    def load_latest_readonly_audit_decision(self) -> Optional[Mapping[str, Any]]: ...
+
+    def load_readonly_audit_decision(self, decision_id: str) -> Optional[Mapping[str, Any]]: ...
+
+
+class AgentDbReadOnlyAuditDecisionStore:
+    """AgentDB-backed store for read-only audit decision receipts."""
+
+    def __init__(self, agent_db_factory: Optional[Any] = None) -> None:
+        self._agent_db_factory = agent_db_factory
+
+    def store_readonly_audit_decision(self, record: ReadOnlyAuditDecisionRecord) -> Mapping[str, Any]:
+        db = self._agent_db()
+        self._ensure_table(db)
+        decision_json = _canonical_json(record.decision)
+        with db.db.get_connection() as conn:
+            existing_by_id = conn.execute(
+                """
+                SELECT decision_json FROM reddog_readonly_audit_decisions
+                WHERE decision_id = ?
+                """,
+                (record.decision_id,),
+            ).fetchone()
+            if existing_by_id:
+                existing_json = (
+                    existing_by_id["decision_json"] if hasattr(existing_by_id, "keys") else existing_by_id[0]
+                )
+                if existing_json == decision_json:
+                    return {"ok": True, "stored": False, "idempotent": True}
+                return {"ok": False, "reason": "conflicting_decision_id"}
+
+            existing_for_swarm = conn.execute(
+                """
+                SELECT decision_id FROM reddog_readonly_audit_decisions
+                WHERE swarm_id = ?
+                """,
+                (record.swarm_id,),
+            ).fetchone()
+            if existing_for_swarm:
+                return {"ok": False, "reason": "conflicting_swarm_decision"}
+
+            conn.execute(
+                """
+                INSERT INTO reddog_readonly_audit_decisions
+                (decision_id, swarm_id, report_bundle_id, action, next_slice_name,
+                 wsp15_priority, decision_json, stored_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.decision_id,
+                    record.swarm_id,
+                    record.report_bundle_id,
+                    record.action,
+                    record.next_slice_name,
+                    record.wsp15_priority,
+                    decision_json,
+                    record.stored_at,
+                ),
+            )
+        return {"ok": True, "stored": True, "idempotent": False}
+
+    def load_latest_readonly_audit_decision(self) -> Optional[Mapping[str, Any]]:
+        db = self._agent_db()
+        self._ensure_table(db)
+        rows = db.db.execute_query(
+            """
+            SELECT decision_json FROM reddog_readonly_audit_decisions
+            ORDER BY stored_at DESC, decision_id DESC
+            LIMIT 1
+            """
+        )
+        if not rows:
+            return None
+        value = rows[0]["decision_json"] if isinstance(rows[0], Mapping) else rows[0][0]
+        return json.loads(value)
+
+    def load_readonly_audit_decision(self, decision_id: str) -> Optional[Mapping[str, Any]]:
+        db = self._agent_db()
+        self._ensure_table(db)
+        rows = db.db.execute_query(
+            """
+            SELECT decision_json FROM reddog_readonly_audit_decisions
+            WHERE decision_id = ?
+            """,
+            (decision_id,),
+        )
+        if not rows:
+            return None
+        value = rows[0]["decision_json"] if isinstance(rows[0], Mapping) else rows[0][0]
+        return json.loads(value)
+
+    def _agent_db(self) -> Any:
+        factory = self._agent_db_factory
+        if factory is None:
+            from modules.infrastructure.database.src.agent_db import AgentDB
+
+            factory = AgentDB
+        return factory()
+
+    @staticmethod
+    def _ensure_table(db: Any) -> None:
+        with db.db.get_connection() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS reddog_readonly_audit_decisions (
+                    decision_id TEXT PRIMARY KEY,
+                    swarm_id TEXT NOT NULL UNIQUE,
+                    report_bundle_id TEXT,
+                    action TEXT NOT NULL,
+                    next_slice_name TEXT,
+                    wsp15_priority TEXT,
+                    decision_json TEXT NOT NULL,
+                    stored_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_reddog_readonly_audit_decisions_action
+                ON reddog_readonly_audit_decisions(action)
+                """
+            )
+
+
+def persist_reddog_readonly_audit_decision(
+    *,
+    decision: ReadOnlyAuditDecisionReceipt | Mapping[str, Any],
+    store: ReadOnlyAuditDecisionStore | None = None,
+    now: datetime | None = None,
+) -> ReadOnlyAuditDecisionPersistResult:
+    """Persist an accepted read-only audit decision receipt."""
+
+    decision_payload = decision.to_dict() if hasattr(decision, "to_dict") else dict(decision)
+    reasons: list[str] = []
+    accepted = bool(decision_payload.get("accepted") is True)
+    decision_id = str(decision_payload.get("decision_id") or "").strip()
+    swarm_id = str(decision_payload.get("swarm_id") or "").strip()
+    action = str(decision_payload.get("action") or "").strip()
+    next_slice = str(decision_payload.get("next_slice_name") or "").strip() or None
+    priority = str(decision_payload.get("wsp15_priority") or "").strip() or None
+
+    if not accepted:
+        reasons.append(ReadOnlyAuditDecisionPersistReason.DECISION_NOT_ACCEPTED)
+    if not decision_id:
+        reasons.append(ReadOnlyAuditDecisionPersistReason.MISSING_DECISION_ID)
+    if not swarm_id:
+        reasons.append(ReadOnlyAuditDecisionPersistReason.MISSING_SWARM_ID)
+    if not action:
+        reasons.append(ReadOnlyAuditDecisionPersistReason.MISSING_ACTION)
+    if action in {"FIX", "REVISE", "RESEARCH_MORE"} and not next_slice:
+        reasons.append(ReadOnlyAuditDecisionPersistReason.MISSING_NEXT_SLICE)
+    if _claims_side_effect(decision_payload):
+        reasons.append(ReadOnlyAuditDecisionPersistReason.DECISION_CLAIMS_SIDE_EFFECT)
+
+    deduped = _dedupe(reasons)
+    if deduped:
+        return _result(
+            accepted=False,
+            decision_id=decision_id or None,
+            swarm_id=swarm_id or None,
+            action=action or None,
+            next_slice_name=next_slice,
+            stored=False,
+            idempotent=False,
+            reasons=deduped,
+        )
+
+    writer = store if store is not None else AgentDbReadOnlyAuditDecisionStore()
+    record = ReadOnlyAuditDecisionRecord(
+        decision_id=decision_id,
+        swarm_id=swarm_id,
+        report_bundle_id=str(decision_payload.get("report_bundle_id") or "").strip() or None,
+        action=action,
+        next_slice_name=next_slice,
+        wsp15_priority=priority,
+        decision=decision_payload,
+        stored_at=_iso8601(now),
+    )
+    try:
+        write_result = writer.store_readonly_audit_decision(record)
+    except Exception:
+        write_result = {"ok": False, "reason": "store_exception"}
+
+    if not isinstance(write_result, Mapping) or write_result.get("ok") is not True:
+        return _result(
+            accepted=False,
+            decision_id=decision_id,
+            swarm_id=swarm_id,
+            action=action,
+            next_slice_name=next_slice,
+            stored=False,
+            idempotent=False,
+            reasons=(ReadOnlyAuditDecisionPersistReason.STORE_REJECTED,),
+        )
+
+    return _result(
+        accepted=True,
+        decision_id=decision_id,
+        swarm_id=swarm_id,
+        action=action,
+        next_slice_name=next_slice,
+        stored=bool(write_result.get("stored")),
+        idempotent=bool(write_result.get("idempotent")),
+        reasons=(),
+    )
+
+
+def _claims_side_effect(decision: Mapping[str, Any]) -> bool:
+    return not (
+        decision.get("no_model_call_performed") is True
+        and decision.get("no_shell_command_executed") is True
+        and decision.get("no_repo_mutation_performed") is True
+        and decision.get("no_holoindex_reindex_performed") is True
+        and decision.get("no_openclaw_enqueue_performed") is True
+        and decision.get("no_hermes_dispatch_performed") is True
+        and decision.get("no_worktree_operation_performed") is True
+    )
+
+
+def _result(
+    *,
+    accepted: bool,
+    decision_id: Optional[str],
+    swarm_id: Optional[str],
+    action: Optional[str],
+    next_slice_name: Optional[str],
+    stored: bool,
+    idempotent: bool,
+    reasons: Sequence[str],
+) -> ReadOnlyAuditDecisionPersistResult:
+    return ReadOnlyAuditDecisionPersistResult(
+        accepted=accepted,
+        status=READONLY_AUDIT_DECISION_PERSIST_ACCEPT if accepted else READONLY_AUDIT_DECISION_PERSIST_REJECT,
+        decision_id=decision_id,
+        swarm_id=swarm_id,
+        action=action,
+        next_slice_name=next_slice_name,
+        stored=stored,
+        idempotent=idempotent,
+        rejection_reasons=tuple(reasons),
+    )
+
+
+def _iso8601(now: datetime | None = None) -> str:
+    value = now or datetime.now(timezone.utc)
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def _dedupe(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(str(value) for value in values if str(value).strip()))
+
+
+__all__ = [
+    "AgentDbReadOnlyAuditDecisionStore",
+    "READONLY_AUDIT_DECISION_PERSIST_ACCEPT",
+    "READONLY_AUDIT_DECISION_PERSIST_REJECT",
+    "ReadOnlyAuditDecisionPersistReason",
+    "ReadOnlyAuditDecisionPersistResult",
+    "ReadOnlyAuditDecisionRecord",
+    "ReadOnlyAuditDecisionStore",
+    "persist_reddog_readonly_audit_decision",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -27,6 +27,11 @@ from modules.communication.moltbot_bridge.src.reddog_readonly_audit_report_colle
     READONLY_AUDIT_REPORT_COLLECTION_ACCEPT,
     READONLY_AUDIT_REPORT_COLLECTION_REJECT,
 )
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_decision_persistence import (
+    READONLY_AUDIT_DECISION_PERSIST_ACCEPT,
+    READONLY_AUDIT_DECISION_PERSIST_REJECT,
+    ReadOnlyAuditDecisionPersistReason,
+)
 from modules.communication.moltbot_bridge.src.reddog_readonly_audit_decision_runtime import (
     ACTION_FIX,
     ACTION_RESEARCH_MORE,
@@ -121,6 +126,24 @@ class _FakeReportStore:
 
     def store_readonly_audit_report(self, record):
         return {"ok": False, "reason": "not_used"}
+
+
+class _FakeDecisionStore:
+    def __init__(self, *, ok: bool = True) -> None:
+        self.ok = ok
+        self.records: list[object] = []
+
+    def store_readonly_audit_decision(self, record):
+        self.records.append(record)
+        if not self.ok:
+            return {"ok": False, "reason": "writer_rejected"}
+        return {"ok": True, "stored": True, "idempotent": False}
+
+    def load_latest_readonly_audit_decision(self):
+        return None
+
+    def load_readonly_audit_decision(self, decision_id: str):
+        return None
 
 
 def _reports_for_bootstrap_result(
@@ -260,6 +283,69 @@ def test_bootstrap_collects_semantic_findings_into_next_action_decision() -> Non
     assert result.readonly_audit_decision_action == ACTION_FIX
     assert result.readonly_audit_decision_next_slice == "REDDOG_RUNTIME_RECONCILER_PHASE1"
     assert result.readonly_audit_decision_id and result.readonly_audit_decision_id.startswith("sha256:")
+
+
+def test_bootstrap_persists_accepted_next_action_decision_when_enabled() -> None:
+    baseline = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+    )
+    report_store = _FakeReportStore(_reports_for_bootstrap_result(baseline, include_findings=True))
+    decision_store = _FakeDecisionStore()
+
+    result = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+        collect_readonly_audit_reports=True,
+        report_store=report_store,
+        persist_readonly_audit_decision=True,
+        decision_store=decision_store,
+    )
+
+    assert result.ready is True
+    assert result.readonly_audit_decision_action == ACTION_FIX
+    assert result.readonly_audit_decision_persist_attempted is True
+    assert result.readonly_audit_decision_persist_status == READONLY_AUDIT_DECISION_PERSIST_ACCEPT
+    assert result.readonly_audit_decision_persist_stored is True
+    assert result.readonly_audit_decision_persist_rejection_reasons == ()
+    assert len(decision_store.records) == 1
+    assert decision_store.records[0].action == ACTION_FIX
+
+
+def test_bootstrap_fails_closed_when_decision_persistence_rejects() -> None:
+    baseline = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+    )
+    report_store = _FakeReportStore(_reports_for_bootstrap_result(baseline, include_findings=True))
+    decision_store = _FakeDecisionStore(ok=False)
+
+    result = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+        collect_readonly_audit_reports=True,
+        report_store=report_store,
+        persist_readonly_audit_decision=True,
+        decision_store=decision_store,
+    )
+
+    assert result.ready is False
+    assert result.readonly_audit_decision_persist_attempted is True
+    assert result.readonly_audit_decision_persist_status == READONLY_AUDIT_DECISION_PERSIST_REJECT
+    assert ReadOnlyAuditDecisionPersistReason.STORE_REJECTED in result.readonly_audit_decision_persist_rejection_reasons
+    assert "readonly_audit_decision_persist_rejected" in result.rejection_reasons
 
 
 def test_bootstrap_missing_reports_enqueue_when_enabled() -> None:
@@ -511,6 +597,7 @@ def test_main_preflight_reports_ready_without_blocking_menu(capsys) -> None:
     assert "decision_attempted=True" in output
     assert "decision_action=FIX" in output
     assert "decision_next_slice=REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1" in output
+    assert "decision_persist_attempted=False" in output
 
 
 def test_main_preflight_enables_enqueue_when_openclaw_auto_tasks_enabled() -> None:
@@ -545,6 +632,7 @@ def test_main_preflight_enables_enqueue_when_openclaw_auto_tasks_enabled() -> No
 
     assert mocked.call_args.kwargs["enqueue_readonly_audit_tasks"] is True
     assert mocked.call_args.kwargs["collect_readonly_audit_reports"] is True
+    assert mocked.call_args.kwargs["persist_readonly_audit_decision"] is True
 
 
 def test_main_preflight_explicit_enqueue_disable_overrides_openclaw_auto_tasks() -> None:
@@ -580,6 +668,7 @@ def test_main_preflight_explicit_enqueue_disable_overrides_openclaw_auto_tasks()
 
     assert mocked.call_args.kwargs["enqueue_readonly_audit_tasks"] is False
     assert mocked.call_args.kwargs["collect_readonly_audit_reports"] is True
+    assert mocked.call_args.kwargs["persist_readonly_audit_decision"] is True
 
 
 def test_main_preflight_explicit_collection_disable_overrides_openclaw_auto_tasks() -> None:
@@ -615,6 +704,43 @@ def test_main_preflight_explicit_collection_disable_overrides_openclaw_auto_task
 
     assert mocked.call_args.kwargs["collect_readonly_audit_reports"] is False
     assert mocked.call_args.kwargs["enqueue_readonly_audit_tasks"] is True
+    assert mocked.call_args.kwargs["persist_readonly_audit_decision"] is True
+
+
+def test_main_preflight_explicit_decision_persist_disable_overrides_openclaw_auto_tasks() -> None:
+    import main
+
+    ready_result = RedDogMainReadonlyBootstrapResult(
+        ready=True,
+        status=REDDOG_MAIN_BOOTSTRAP_READY,
+        snapshot_receipt_id="sha256:snapshot",
+        context_view_id="sha256:view",
+        evidence_bundle_id="sha256:evidence",
+        determination_id="sha256:determination",
+        swarm_id="sha256:swarm",
+        assignment_count=5,
+        rejection_reasons=(),
+        changed_paths=DEFAULT_BOOTSTRAP_CHANGED_PATHS,
+        allowed_read_targets=DEFAULT_BOOTSTRAP_CHANGED_PATHS,
+    )
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_readonly_operational_bootstrap.run_reddog_main_readonly_operational_bootstrap",
+        return_value=ready_result,
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_READONLY_OPERATIONAL_BOOTSTRAP": "1",
+                "OPENCLAW_AUTO_TASKS_ENABLED": "1",
+                "REDDOG_READONLY_AUDIT_DECISION_PERSIST_ENABLED": "0",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_readonly_operational_bootstrap_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["collect_readonly_audit_reports"] is True
+    assert mocked.call_args.kwargs["enqueue_readonly_audit_tasks"] is True
+    assert mocked.call_args.kwargs["persist_readonly_audit_decision"] is False
 
 
 def test_bootstrap_module_has_no_runtime_mutation_or_execution_imports() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_decision_persistence.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_decision_persistence.py
@@ -1,0 +1,156 @@
+"""Tests for REDDOG_READONLY_AUDIT_DECISION_PERSISTENCE_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_decision_persistence import (
+    READONLY_AUDIT_DECISION_PERSIST_ACCEPT,
+    READONLY_AUDIT_DECISION_PERSIST_REJECT,
+    AgentDbReadOnlyAuditDecisionStore,
+    ReadOnlyAuditDecisionPersistReason,
+    persist_reddog_readonly_audit_decision,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_decision_runtime import (
+    ACTION_FIX,
+    READONLY_AUDIT_DECISION_ACCEPT,
+    READONLY_AUDIT_DECISION_REJECT,
+    ReadOnlyAuditDecisionReceipt,
+)
+from modules.infrastructure.database.src.db_manager import DatabaseManager
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_readonly_audit_decision_persistence.py"
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_agent_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("FOUNDUPS_DB_PATH", str(tmp_path / "foundups.db"))
+    DatabaseManager.reset_for_tests()
+    yield
+    DatabaseManager.reset_for_tests()
+
+
+def _decision(
+    *,
+    decision_id: str = "sha256:decision-1",
+    swarm_id: str = "sha256:swarm-1",
+    accepted: bool = True,
+) -> ReadOnlyAuditDecisionReceipt:
+    return ReadOnlyAuditDecisionReceipt(
+        decision_id=decision_id,
+        accepted=accepted,
+        status=READONLY_AUDIT_DECISION_ACCEPT if accepted else READONLY_AUDIT_DECISION_REJECT,
+        action=ACTION_FIX,
+        swarm_id=swarm_id,
+        report_bundle_id="sha256:bundle-1",
+        report_count=5,
+        finding_count=1,
+        selected_finding_digest="sha256:finding-1",
+        next_slice_name="REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+        wsp15_priority="P1",
+        decision_reasons=("selected:repo-code-finding-1",),
+        rejection_reasons=(),
+        finding_digests=("sha256:finding-1",),
+    )
+
+
+def test_persisted_decision_loads_by_id_and_latest() -> None:
+    store = AgentDbReadOnlyAuditDecisionStore()
+    decision = _decision()
+
+    result = persist_reddog_readonly_audit_decision(decision=decision, store=store)
+    loaded = store.load_readonly_audit_decision(decision.decision_id)
+    latest = store.load_latest_readonly_audit_decision()
+
+    assert result.accepted is True
+    assert result.status == READONLY_AUDIT_DECISION_PERSIST_ACCEPT
+    assert result.stored is True
+    assert result.idempotent is False
+    assert loaded is not None
+    assert loaded["decision_id"] == decision.decision_id
+    assert latest is not None
+    assert latest["next_slice_name"] == "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1"
+    assert result.no_decision_execution_performed is True
+
+
+def test_persisted_decision_is_idempotent_for_same_payload() -> None:
+    store = AgentDbReadOnlyAuditDecisionStore()
+    decision = _decision()
+
+    first = persist_reddog_readonly_audit_decision(decision=decision, store=store)
+    second = persist_reddog_readonly_audit_decision(decision=decision, store=store)
+
+    assert first.accepted is True
+    assert second.accepted is True
+    assert second.stored is False
+    assert second.idempotent is True
+
+
+def test_persist_rejects_conflicting_decision_for_same_swarm() -> None:
+    store = AgentDbReadOnlyAuditDecisionStore()
+    first = _decision(decision_id="sha256:decision-1", swarm_id="sha256:swarm-1")
+    second = _decision(decision_id="sha256:decision-2", swarm_id="sha256:swarm-1")
+
+    accepted = persist_reddog_readonly_audit_decision(decision=first, store=store)
+    rejected = persist_reddog_readonly_audit_decision(decision=second, store=store)
+
+    assert accepted.accepted is True
+    assert rejected.accepted is False
+    assert rejected.status == READONLY_AUDIT_DECISION_PERSIST_REJECT
+    assert rejected.rejection_reasons == (ReadOnlyAuditDecisionPersistReason.STORE_REJECTED,)
+
+
+def test_persist_rejects_unaccepted_or_side_effect_claiming_decision() -> None:
+    rejected_decision = _decision(accepted=False)
+    side_effect = _decision().to_dict()
+    side_effect["no_repo_mutation_performed"] = False
+
+    rejected = persist_reddog_readonly_audit_decision(decision=rejected_decision)
+    side_effect_result = persist_reddog_readonly_audit_decision(decision=side_effect)
+
+    assert rejected.accepted is False
+    assert ReadOnlyAuditDecisionPersistReason.DECISION_NOT_ACCEPTED in rejected.rejection_reasons
+    assert side_effect_result.accepted is False
+    assert ReadOnlyAuditDecisionPersistReason.DECISION_CLAIMS_SIDE_EFFECT in side_effect_result.rejection_reasons
+
+
+def test_decision_persistence_module_has_no_execution_or_repo_mutation() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    forbidden_import_roots = {
+        "subprocess",
+        "requests",
+        "httpx",
+        "socket",
+        "openclaw_supervisor",
+        "hermes_job_executor",
+    }
+    forbidden_text = (
+        "execute_skill",
+        "holo_index.py --index",
+        "create_autonomous_task",
+        "write_text",
+        "mkdir",
+        "git push",
+        "gh pr",
+    )
+    for token in forbidden_text:
+        assert token not in source
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".")[0] not in forbidden_import_roots
+        if isinstance(node, ast.ImportFrom):
+            assert (node.module or "").split(".")[0] not in forbidden_import_roots


### PR DESCRIPTION
## REDDOG_READONLY_AUDIT_DECISION_PERSISTENCE_PHASE1

WSP_97 status: VERIFIED_READY draft PR.

### Scope
Persist accepted RedDog read-only audit next-action receipts into AgentDB so the operational loop can remember the selected next slice across startup cycles.

### Files changed
- `modules/communication/moltbot_bridge/src/reddog_readonly_audit_decision_persistence.py`
- `modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_decision_persistence.py`
- `modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py`
- `modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py`
- `main.py`
- `modules/communication/moltbot_bridge/ModLog.md`

### Behavior
- Adds `AgentDbReadOnlyAuditDecisionStore` table `reddog_readonly_audit_decisions`.
- Persists accepted decision receipts idempotently by `decision_id`.
- Rejects conflicting decisions for the same `swarm_id`.
- Rejects unaccepted or side-effect-claiming decisions.
- Wires bootstrap optional persistence via `persist_readonly_audit_decision`.
- Wires main env override `REDDOG_READONLY_AUDIT_DECISION_PERSIST_ENABLED`; default follows `OPENCLAW_AUTO_TASKS_ENABLED`.

### Validation
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_decision_persistence.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_report_collection.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py` -> 39 passed
- Read-only chain suite -> 83 passed
- `git diff --check` -> clean (autocrlf warnings only)
- staged diff ASCII scan -> 0 non-ASCII

### HoloIndex
Read-only probe for `RedDog read-only audit decision persistence AgentDB` did not rank the new module. Recorded `HOLOINDEX_REDDOG_READONLY_AUDIT_DECISION_PERSISTENCE_INDEX_GAP_PHASE1`. No runtime re-index performed.

### Truth boundary
- No model calls
- No shell/subprocess execution
- No repo/worktree mutation
- No OpenClaw enqueue from the decision
- No Hermes/WRE dispatch
- No HoloIndex mutation/re-index
- No decision execution

### Residual SPECIFIED_NOT_IMPLEMENTED
- Decision-to-claim/work-item promotion remains future work.
- No autonomous execution from the persisted decision.
- No external research/runtime freshness/skill/security analyzers added in this slice.