### PR TITLE
feat(reddog): route persisted decisions into work-state refresh

### DIFF
--- a/main.py
+++ b/main.py
@@ -1287,6 +1287,7 @@ def run_reddog_authoritative_work_state_refresh_preflight(repo_root: Path) -> bo
         REDDOG_WORK_LEDGER_JSON_PATH                       Optional work ledger source
         REDDOG_GITHUB_PR_RECORDS_PATH                      Required existing PR records JSON
         REDDOG_W10_REPORT_RECORDS_PATH                     Required existing W10 records JSON
+        REDDOG_WORK_STATE_USE_LATEST_READONLY_AUDIT_DECISION  Use persisted RedDog decision as requested slice
     """
 
     if os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH", "1") == "0":
@@ -1294,6 +1295,11 @@ def run_reddog_authoritative_work_state_refresh_preflight(repo_root: Path) -> bo
         return True
 
     enforced = os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH_ENFORCED", "0") != "0"
+    use_decision_override = os.getenv("REDDOG_WORK_STATE_USE_LATEST_READONLY_AUDIT_DECISION")
+    if use_decision_override is None:
+        use_latest_decision = os.getenv("OPENCLAW_AUTO_TASKS_ENABLED", "0") != "0"
+    else:
+        use_latest_decision = use_decision_override != "0"
 
     try:
         from modules.communication.moltbot_bridge.src.reddog_main_authoritative_work_state_refresh_bootstrap import (
@@ -1308,6 +1314,7 @@ def run_reddog_authoritative_work_state_refresh_preflight(repo_root: Path) -> bo
             w10_report_records_path=os.getenv("REDDOG_W10_REPORT_RECORDS_PATH", ""),
             work_state_output_path=os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
             worker_id=os.getenv("REDDOG_WORK_STATE_REFRESH_WORKER_ID", "reddog-main-bootstrap"),
+            use_latest_readonly_audit_decision=use_latest_decision,
         )
     except Exception as exc:
         logger.error(f"[REDDOG-WORK-STATE] Startup refresh failed: {exc}")
@@ -1321,6 +1328,8 @@ def run_reddog_authoritative_work_state_refresh_preflight(repo_root: Path) -> bo
     reasons = ",".join(result.rejection_reasons) if result.rejection_reasons else "(none)"
     print(
         f"[REDDOG-WORK-STATE] preflight={status} status={result.status} "
+        f"latest_decision_attempted={result.latest_decision_attempted} "
+        f"latest_decision_next_slice={result.latest_decision_next_slice or '(none)'} "
         f"queue_items={result.queue_item_count} reasons={reasons}"
     )
     if result.accepted and result.work_state_path:

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,24 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_PERSISTED_DECISION_TO_WORK_STATE_REFRESH_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Wired `src/reddog_main_authoritative_work_state_refresh_bootstrap.py` to
+  optionally load the latest persisted RedDog read-only audit decision and use
+  its `next_slice_name` as the requested slice for the existing authoritative
+  work-state refresh runtime.
+- The bridge validates the persisted decision through the existing
+  `evaluate_reddog_worker_claim_dryrun()` gate before the refresh runtime can
+  commit a durable claim or synchronized WRE queue item.
+- Added `main.py` telemetry and env control:
+  `REDDOG_WORK_STATE_USE_LATEST_READONLY_AUDIT_DECISION=0/1`; default follows
+  `OPENCLAW_AUTO_TASKS_ENABLED`.
+- Boundary: no model call, no shell/subprocess, no GitHub/W10 fetch, no
+  HoloIndex re-index, no OpenClaw enqueue, no Hermes/WRE execution, and no repo
+  mutation. This only selects the requested slice for the already-gated
+  authoritative work-state refresh.
+
 ## 2026-07-14: REDDOG_READONLY_AUDIT_DECISION_PERSISTENCE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_authoritative_work_state_refresh_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_authoritative_work_state_refresh_bootstrap.py
@@ -25,6 +25,13 @@ from modules.communication.moltbot_bridge.src.reddog_authoritative_work_state_re
 from modules.communication.moltbot_bridge.src.reddog_lane_state_reconciler import (
     reconcile_active_and_json_ledgers,
 )
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_decision_persistence import (
+    AgentDbReadOnlyAuditDecisionStore,
+    ReadOnlyAuditDecisionStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_worker_claim_gate_dryrun import (
+    evaluate_reddog_worker_claim_dryrun,
+)
 
 
 REDDOG_WORK_STATE_BOOTSTRAP_APPLIED = "REDDOG_WORK_STATE_BOOTSTRAP_APPLIED"
@@ -48,6 +55,12 @@ class RedDogMainWorkStateRefreshBootstrapResult:
     selected_slice: Optional[str]
     queue_item_count: int
     rejection_reasons: tuple[str, ...]
+    latest_decision_attempted: bool = False
+    latest_decision_id: Optional[str] = None
+    latest_decision_action: Optional[str] = None
+    latest_decision_next_slice: Optional[str] = None
+    latest_decision_claim_gate_decision: Optional[str] = None
+    latest_decision_rejection_reasons: tuple[str, ...] = ()
     no_github_fetch_performed: bool = True
     no_w10_fetch_performed: bool = True
     no_worker_spawn_performed: bool = True
@@ -72,6 +85,8 @@ def run_reddog_main_authoritative_work_state_refresh_bootstrap(
     worker_id: str = "reddog-main-bootstrap",
     now_iso: str | None = None,
     requested_slice: str | None = None,
+    use_latest_readonly_audit_decision: bool = False,
+    decision_store: ReadOnlyAuditDecisionStore | None = None,
     max_source_age_seconds: int = 3600,
     stale_after_days: int = 30,
 ) -> RedDogMainWorkStateRefreshBootstrapResult:
@@ -95,6 +110,9 @@ def run_reddog_main_authoritative_work_state_refresh_bootstrap(
     ledger_text = _read_required_text(ledger_path, "missing_work_ledger_json", reasons)
     github_records = _read_required_records(github_path, "missing_github_pr_records", reasons)
     w10_records = _read_required_records(w10_path, "missing_w10_report_records", reasons)
+    latest_decision: Mapping[str, Any] | None = None
+    latest_decision_claim_gate_decision: Optional[str] = None
+    effective_requested_slice = requested_slice
 
     if active_text and ledger_text:
         ledger_report = reconcile_active_and_json_ledgers(
@@ -107,9 +125,29 @@ def run_reddog_main_authoritative_work_state_refresh_bootstrap(
             reasons.extend(f"stale_ledger_source:{source}" for source in ledger_report.stale_sources)
         if ledger_report.conflicts:
             reasons.extend(f"ledger_conflict:{conflict.slice_id}" for conflict in ledger_report.conflicts)
+        if use_latest_readonly_audit_decision and requested_slice is None:
+            latest_decision, decision_reasons = _load_latest_decision(decision_store)
+            reasons.extend(decision_reasons)
+            if latest_decision and not decision_reasons and not ledger_report.stale_sources and not ledger_report.conflicts:
+                effective_requested_slice = str(latest_decision.get("next_slice_name") or "").strip().upper()
+                claim_gate = evaluate_reddog_worker_claim_dryrun(
+                    ledger_report,
+                    requested_slice=effective_requested_slice,
+                    worker_id=worker_id,
+                )
+                latest_decision_claim_gate_decision = claim_gate.receipt.decision
+                if not claim_gate.accepted:
+                    reasons.append("persisted_decision_claim_gate_rejected")
+                    reasons.extend(f"persisted_decision_claim_gate:{reason}" for reason in claim_gate.receipt.rejection_reasons)
 
     if reasons:
-        return _not_ready(reasons=reasons, output_path=output_path)
+        return _not_ready(
+            reasons=reasons,
+            output_path=output_path,
+            latest_decision=latest_decision,
+            latest_decision_attempted=use_latest_readonly_audit_decision and requested_slice is None,
+            latest_decision_claim_gate_decision=latest_decision_claim_gate_decision,
+        )
 
     assert output_path is not None
     assert active_text is not None and ledger_text is not None
@@ -122,7 +160,7 @@ def run_reddog_main_authoritative_work_state_refresh_bootstrap(
         store=store,
         worker_id=worker_id,
         now_iso=now,
-        requested_slice=requested_slice,
+        requested_slice=effective_requested_slice,
         max_source_age_seconds=max_source_age_seconds,
     )
     if not result.accepted or result.receipt.status != AUTHORITATIVE_REFRESH_APPLIED:
@@ -130,6 +168,9 @@ def run_reddog_main_authoritative_work_state_refresh_bootstrap(
             reasons=result.receipt.rejection_reasons or ("authoritative_refresh_rejected",),
             output_path=output_path,
             runtime_result=result,
+            latest_decision=latest_decision,
+            latest_decision_attempted=use_latest_readonly_audit_decision and requested_slice is None,
+            latest_decision_claim_gate_decision=latest_decision_claim_gate_decision,
         )
 
     queue_count = 0
@@ -145,6 +186,12 @@ def run_reddog_main_authoritative_work_state_refresh_bootstrap(
         selected_slice=result.receipt.selected_slice,
         queue_item_count=queue_count,
         rejection_reasons=(),
+        latest_decision_attempted=use_latest_readonly_audit_decision and requested_slice is None,
+        latest_decision_id=_decision_text(latest_decision, "decision_id"),
+        latest_decision_action=_decision_text(latest_decision, "action"),
+        latest_decision_next_slice=_decision_text(latest_decision, "next_slice_name"),
+        latest_decision_claim_gate_decision=latest_decision_claim_gate_decision,
+        latest_decision_rejection_reasons=(),
     )
 
 
@@ -219,6 +266,36 @@ def _read_required_records(
     return records
 
 
+def _load_latest_decision(
+    store: ReadOnlyAuditDecisionStore | None,
+) -> tuple[Mapping[str, Any] | None, tuple[str, ...]]:
+    reader = store if store is not None else AgentDbReadOnlyAuditDecisionStore()
+    try:
+        decision = reader.load_latest_readonly_audit_decision()
+    except Exception:
+        return None, ("latest_readonly_audit_decision_load_failed",)
+    if decision is None:
+        return None, ("latest_readonly_audit_decision_missing",)
+    reasons: list[str] = []
+    if decision.get("accepted") is not True:
+        reasons.append("latest_readonly_audit_decision_not_accepted")
+    action = str(decision.get("action") or "").strip().upper()
+    if action not in {"FIX", "REVISE", "RESEARCH_MORE"}:
+        reasons.append("latest_readonly_audit_decision_action_not_work")
+    if not str(decision.get("decision_id") or "").strip():
+        reasons.append("latest_readonly_audit_decision_missing_id")
+    if not str(decision.get("next_slice_name") or "").strip():
+        reasons.append("latest_readonly_audit_decision_missing_next_slice")
+    return decision, tuple(reasons)
+
+
+def _decision_text(decision: Mapping[str, Any] | None, key: str) -> Optional[str]:
+    if not decision:
+        return None
+    value = str(decision.get(key) or "").strip()
+    return value or None
+
+
 def _is_inside(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -232,7 +309,16 @@ def _not_ready(
     reasons: Sequence[str],
     output_path: Path | None,
     runtime_result: AuthoritativeWorkStateRefreshResult | None = None,
+    latest_decision: Mapping[str, Any] | None = None,
+    latest_decision_attempted: bool = False,
+    latest_decision_claim_gate_decision: Optional[str] = None,
 ) -> RedDogMainWorkStateRefreshBootstrapResult:
+    latest_reasons = tuple(
+        reason
+        for reason in reasons
+        if str(reason).startswith("latest_readonly_audit_decision")
+        or str(reason).startswith("persisted_decision_claim_gate")
+    )
     return RedDogMainWorkStateRefreshBootstrapResult(
         accepted=False,
         status=REDDOG_WORK_STATE_BOOTSTRAP_NOT_READY,
@@ -242,6 +328,12 @@ def _not_ready(
         selected_slice=runtime_result.receipt.selected_slice if runtime_result else None,
         queue_item_count=0,
         rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons if str(reason).strip())),
+        latest_decision_attempted=latest_decision_attempted,
+        latest_decision_id=_decision_text(latest_decision, "decision_id"),
+        latest_decision_action=_decision_text(latest_decision, "action"),
+        latest_decision_next_slice=_decision_text(latest_decision, "next_slice_name"),
+        latest_decision_claim_gate_decision=latest_decision_claim_gate_decision,
+        latest_decision_rejection_reasons=latest_reasons,
     )
 
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_authoritative_work_state_refresh_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_authoritative_work_state_refresh_bootstrap.py
@@ -26,6 +26,7 @@ MODULE_PATH = (
 )
 NOW = "2026-07-14T00:00:00+00:00"
 SLICE_ID = "REDDOG_MAIN_AUTHORITATIVE_WORK_STATE_REFRESH_BOOTSTRAP_PHASE1"
+DECISION_SLICE_ID = "REDDOG_DECISION_SELECTED_PHASE1"
 
 
 def _active_ledger(updated: str = NOW) -> str:
@@ -42,6 +43,25 @@ def _active_ledger(updated: str = NOW) -> str:
 ## Next Priority Order
 
 1. **{SLICE_ID}** - refresh bootstrap
+"""
+
+
+def _active_ledger_with_decision_slice(updated: str = NOW) -> str:
+    return f"""# Active Slice Ledger
+
+**Updated**: {updated}
+
+## Open Slices
+
+| Slice | Priority | Blocked By | Notes |
+|-------|----------|------------|-------|
+| `{SLICE_ID}` | P0 | - | refresh bootstrap |
+| `{DECISION_SLICE_ID}` | P1 | - | selected by persisted decision |
+
+## Next Priority Order
+
+1. **{SLICE_ID}** - refresh bootstrap
+2. **{DECISION_SLICE_ID}** - selected by persisted decision
 """
 
 
@@ -64,6 +84,24 @@ def _work_ledger(updated: str = NOW) -> dict[str, object]:
     }
 
 
+def _work_ledger_with_decision_slice(updated: str = NOW) -> dict[str, object]:
+    payload = _work_ledger(updated)
+    payload["slices"] = [
+        *payload["slices"],  # type: ignore[index]
+        {
+            "slice_id": DECISION_SLICE_ID,
+            "title": "Decision selected slice",
+            "status": "PROPOSED",
+            "priority": "P1",
+            "source": "audit",
+            "lane": "B",
+            "created_at": updated,
+            "wsp15_score": {"total": 15},
+        },
+    ]
+    return payload
+
+
 def _github_records() -> list[dict[str, object]]:
     return [
         {
@@ -78,6 +116,20 @@ def _github_records() -> list[dict[str, object]]:
     ]
 
 
+def _github_records_with_decision_slice() -> list[dict[str, object]]:
+    return [
+        *_github_records(),
+        {
+            "slice_id": DECISION_SLICE_ID,
+            "status": "PROPOSED",
+            "priority": "P1",
+            "lane": "B",
+            "head_commit": "d" * 40,
+            "wsp15_score": {"total": 15},
+        },
+    ]
+
+
 def _w10_records() -> list[dict[str, object]]:
     return [
         {
@@ -88,6 +140,20 @@ def _w10_records() -> list[dict[str, object]]:
             "evidence_refs": ["w10:local-fixture"],
             "wsp15_score": {"total": 18},
         }
+    ]
+
+
+def _w10_records_with_decision_slice() -> list[dict[str, object]]:
+    return [
+        *_w10_records(),
+        {
+            "slice_id": DECISION_SLICE_ID,
+            "status": "PROPOSED",
+            "priority": "P1",
+            "lane": "B",
+            "evidence_refs": ["w10:decision-fixture"],
+            "wsp15_score": {"total": 15},
+        },
     ]
 
 
@@ -110,6 +176,41 @@ def _write_sources(tmp_path: Path, *, stale: bool = False) -> dict[str, Path]:
         "github": github,
         "w10": w10,
         "output": tmp_path / "runtime" / "authoritative_work_state.json",
+    }
+
+
+def _write_sources_with_decision_slice(tmp_path: Path) -> dict[str, Path]:
+    paths = _write_sources(tmp_path)
+    paths["active"].write_text(_active_ledger_with_decision_slice(), encoding="utf-8")
+    paths["ledger"].write_text(json.dumps(_work_ledger_with_decision_slice(), sort_keys=True), encoding="utf-8")
+    paths["github"].write_text(json.dumps(_github_records_with_decision_slice(), sort_keys=True), encoding="utf-8")
+    paths["w10"].write_text(json.dumps(_w10_records_with_decision_slice(), sort_keys=True), encoding="utf-8")
+    return paths
+
+
+class _FakeDecisionStore:
+    def __init__(self, decision: dict[str, object] | None) -> None:
+        self.decision = decision
+
+    def load_latest_readonly_audit_decision(self):
+        return self.decision
+
+    def load_readonly_audit_decision(self, decision_id: str):
+        return self.decision if self.decision and self.decision.get("decision_id") == decision_id else None
+
+    def store_readonly_audit_decision(self, record):
+        return {"ok": False, "reason": "not_used"}
+
+
+def _persisted_decision(next_slice: str = DECISION_SLICE_ID) -> dict[str, object]:
+    return {
+        "accepted": True,
+        "decision_id": "sha256:persisted-decision-1",
+        "action": "FIX",
+        "swarm_id": "sha256:swarm-1",
+        "report_bundle_id": "sha256:bundle-1",
+        "next_slice_name": next_slice,
+        "wsp15_priority": "P1",
     }
 
 
@@ -139,6 +240,80 @@ def test_refresh_bootstrap_commits_work_state_outside_repo_from_existing_sources
     assert data["schema_version"] == "reddog_authoritative_work_state.v1"
     assert data["worker_claims"][0]["worker_id"] == "reddog-test"
     assert data["no_execution_performed"] is True
+
+
+def test_refresh_bootstrap_uses_persisted_decision_after_claim_gate_accepts(tmp_path: Path) -> None:
+    paths = _write_sources_with_decision_slice(tmp_path)
+
+    result = run_reddog_main_authoritative_work_state_refresh_bootstrap(
+        repo_root=paths["repo"],
+        active_slice_ledger_path=paths["active"],
+        work_ledger_json_path=paths["ledger"],
+        github_pr_records_path=paths["github"],
+        w10_report_records_path=paths["w10"],
+        work_state_output_path=paths["output"],
+        worker_id="reddog-test",
+        now_iso=NOW,
+        use_latest_readonly_audit_decision=True,
+        decision_store=_FakeDecisionStore(_persisted_decision()),
+    )
+
+    assert result.accepted is True
+    assert result.status == REDDOG_WORK_STATE_BOOTSTRAP_APPLIED
+    assert result.selected_slice == DECISION_SLICE_ID
+    assert result.latest_decision_attempted is True
+    assert result.latest_decision_id == "sha256:persisted-decision-1"
+    assert result.latest_decision_next_slice == DECISION_SLICE_ID
+    assert result.latest_decision_claim_gate_decision == "CLAIM_READY_DRYRUN"
+    data = json.loads(paths["output"].read_text(encoding="utf-8"))
+    assert data["worker_claims"][0]["slice_id"] == DECISION_SLICE_ID
+
+
+def test_refresh_bootstrap_rejects_persisted_decision_for_non_open_slice(tmp_path: Path) -> None:
+    paths = _write_sources_with_decision_slice(tmp_path)
+
+    result = run_reddog_main_authoritative_work_state_refresh_bootstrap(
+        repo_root=paths["repo"],
+        active_slice_ledger_path=paths["active"],
+        work_ledger_json_path=paths["ledger"],
+        github_pr_records_path=paths["github"],
+        w10_report_records_path=paths["w10"],
+        work_state_output_path=paths["output"],
+        worker_id="reddog-test",
+        now_iso=NOW,
+        use_latest_readonly_audit_decision=True,
+        decision_store=_FakeDecisionStore(_persisted_decision("REDDOG_MISSING_PHASE1")),
+    )
+
+    assert result.accepted is False
+    assert "persisted_decision_claim_gate_rejected" in result.rejection_reasons
+    assert "persisted_decision_claim_gate:requested_slice_not_in_open_queue" in result.rejection_reasons
+    assert result.latest_decision_attempted is True
+    assert result.latest_decision_claim_gate_decision == "CLAIM_REJECTED"
+    assert not paths["output"].exists()
+
+
+def test_refresh_bootstrap_rejects_missing_latest_decision_when_enabled(tmp_path: Path) -> None:
+    paths = _write_sources_with_decision_slice(tmp_path)
+
+    result = run_reddog_main_authoritative_work_state_refresh_bootstrap(
+        repo_root=paths["repo"],
+        active_slice_ledger_path=paths["active"],
+        work_ledger_json_path=paths["ledger"],
+        github_pr_records_path=paths["github"],
+        w10_report_records_path=paths["w10"],
+        work_state_output_path=paths["output"],
+        worker_id="reddog-test",
+        now_iso=NOW,
+        use_latest_readonly_audit_decision=True,
+        decision_store=_FakeDecisionStore(None),
+    )
+
+    assert result.accepted is False
+    assert "latest_readonly_audit_decision_missing" in result.rejection_reasons
+    assert result.latest_decision_attempted is True
+    assert result.latest_decision_rejection_reasons == ("latest_readonly_audit_decision_missing",)
+    assert not paths["output"].exists()
 
 
 def test_refresh_bootstrap_rejects_missing_github_and_w10_sources_without_write(tmp_path: Path) -> None:
@@ -255,6 +430,79 @@ def test_main_preflight_sets_work_state_path_after_success(tmp_path: Path) -> No
         import os
 
         assert os.environ["REDDOG_AUTHORITATIVE_WORK_STATE_PATH"] == str(paths["output"].resolve())
+
+
+def test_main_preflight_enables_latest_decision_bridge_with_openclaw_auto_tasks(tmp_path: Path) -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_authoritative_work_state_refresh_bootstrap.run_reddog_main_authoritative_work_state_refresh_bootstrap",
+        return_value=type(
+            "Result",
+            (),
+            {
+                "accepted": True,
+                "status": REDDOG_WORK_STATE_BOOTSTRAP_APPLIED,
+                "work_state_path": str(tmp_path / "state.json"),
+                "refresh_id": "refresh",
+                "committed_revision": "revision",
+                "selected_slice": SLICE_ID,
+                "queue_item_count": 1,
+                "rejection_reasons": (),
+                "latest_decision_attempted": True,
+                "latest_decision_next_slice": SLICE_ID,
+            },
+        )(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH": "1",
+                "OPENCLAW_AUTO_TASKS_ENABLED": "1",
+                "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_authoritative_work_state_refresh_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["use_latest_readonly_audit_decision"] is True
+
+
+def test_main_preflight_explicit_latest_decision_disable_overrides_openclaw_auto_tasks(tmp_path: Path) -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_authoritative_work_state_refresh_bootstrap.run_reddog_main_authoritative_work_state_refresh_bootstrap",
+        return_value=type(
+            "Result",
+            (),
+            {
+                "accepted": True,
+                "status": REDDOG_WORK_STATE_BOOTSTRAP_APPLIED,
+                "work_state_path": str(tmp_path / "state.json"),
+                "refresh_id": "refresh",
+                "committed_revision": "revision",
+                "selected_slice": SLICE_ID,
+                "queue_item_count": 1,
+                "rejection_reasons": (),
+                "latest_decision_attempted": False,
+                "latest_decision_next_slice": None,
+            },
+        )(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH": "1",
+                "OPENCLAW_AUTO_TASKS_ENABLED": "1",
+                "REDDOG_WORK_STATE_USE_LATEST_READONLY_AUDIT_DECISION": "0",
+                "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_authoritative_work_state_refresh_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["use_latest_readonly_audit_decision"] is False
 
 
 def test_refresh_bootstrap_module_has_no_fetch_execution_or_holoindex_imports() -> None:


### PR DESCRIPTION
## REDDOG_PERSISTED_DECISION_TO_WORK_STATE_REFRESH_PHASE1

WSP_97 status: VERIFIED_READY draft PR.

### Scope
Use the latest persisted RedDog read-only audit decision as the requested slice for the existing authoritative work-state refresh runtime, but only after the existing worker-claim dry-run gate accepts it against current ledgers.

### Files changed
- `modules/communication/moltbot_bridge/src/reddog_main_authoritative_work_state_refresh_bootstrap.py`
- `modules/communication/moltbot_bridge/tests/test_reddog_main_authoritative_work_state_refresh_bootstrap.py`
- `main.py`
- `modules/communication/moltbot_bridge/ModLog.md`

### Behavior
- Adds optional `use_latest_readonly_audit_decision` bridge.
- Loads latest persisted decision through `AgentDbReadOnlyAuditDecisionStore`.
- Requires accepted decision with work action and `next_slice_name`.
- Validates the selected slice through `evaluate_reddog_worker_claim_dryrun()` before refresh commit.
- Main env: `REDDOG_WORK_STATE_USE_LATEST_READONLY_AUDIT_DECISION=0/1`; default follows `OPENCLAW_AUTO_TASKS_ENABLED`.

### Validation
- Focused suite: 30 passed
- Combined startup/read-only spine: 117 passed
- `git diff --check` -> clean (autocrlf warnings only)
- staged diff ASCII scan -> 0 non-ASCII

### HoloIndex
Read-only probe for `RedDog persisted readonly audit decision work state refresh requested slice` did not rank this bridge in top results. Recorded as INDEX_GAP in ModLog. No runtime re-index performed.

### Truth boundary
- No model calls
- No shell/subprocess execution
- No GitHub/W10 fetch
- No repo file mutation
- No OpenClaw enqueue
- No Hermes/WRE execution
- No HoloIndex mutation/re-index
- Uses the existing work-state refresh runtime and existing worker-claim dry-run gate.

### Residual SPECIFIED_NOT_IMPLEMENTED
- No direct execution from persisted decisions.
- No model Fusion synthesis over reports.
- No external research/runtime freshness/skill/security analyzers added in this slice.
- No live worktree worker execution.