### PR TITLE
feat(reddog): dry-run consume WRE queue items

### DIFF
--- a/main.py
+++ b/main.py
@@ -1346,6 +1346,60 @@ def run_reddog_authoritative_work_state_refresh_preflight(repo_root: Path) -> bo
     return True
 
 
+def run_reddog_wre_queue_consumer_preflight(repo_root: Path) -> bool:
+    """
+    Dry-run consume the authoritative WRE queue item produced by work-state refresh.
+
+    Env:
+        REDDOG_WRE_QUEUE_CONSUMER_DRYRUN=1          Enable check (default ON)
+        REDDOG_WRE_QUEUE_CONSUMER_DRYRUN_ENFORCED=0 Block startup if not ready
+        REDDOG_AUTHORITATIVE_WORK_STATE_PATH         Existing work-state snapshot
+        REDDOG_WRE_QUEUE_ITEM_ID                     Optional exact queue item id
+    """
+
+    if os.getenv("REDDOG_WRE_QUEUE_CONSUMER_DRYRUN", "1") == "0":
+        logger.info("[REDDOG-WRE-QUEUE] Startup queue consumer dry-run disabled")
+        return True
+
+    enforced = os.getenv("REDDOG_WRE_QUEUE_CONSUMER_DRYRUN_ENFORCED", "0") != "0"
+
+    try:
+        from modules.communication.moltbot_bridge.src.reddog_main_wre_queue_consumer_bootstrap import (
+            run_reddog_main_wre_queue_consumer_bootstrap,
+        )
+
+        result = run_reddog_main_wre_queue_consumer_bootstrap(
+            repo_root=repo_root,
+            work_state_path=os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
+            requested_queue_item_id=os.getenv("REDDOG_WRE_QUEUE_ITEM_ID", "") or None,
+        )
+    except Exception as exc:
+        logger.error(f"[REDDOG-WRE-QUEUE] Startup queue consumer failed: {exc}")
+        if enforced:
+            print(f"[REDDOG-WRE-QUEUE] preflight=FAIL error={type(exc).__name__}")
+            return False
+        print(f"[REDDOG-WRE-QUEUE] preflight=WARN error={type(exc).__name__}")
+        return True
+
+    status = "PASS" if result.ready else "WARN"
+    reasons = ",".join(result.rejection_reasons) if result.rejection_reasons else "(none)"
+    print(
+        f"[REDDOG-WRE-QUEUE] preflight={status} status={result.status} "
+        f"queue_item={result.queue_item_id or '(none)'} "
+        f"selected_slice={result.selected_slice or '(none)'} "
+        f"next_gate={result.next_required_gate or '(none)'} "
+        f"execution_ready={result.execution_ready} reasons={reasons}"
+    )
+    if result.ready:
+        print(f"[REDDOG-WRE-QUEUE] receipt={result.receipt_id}")
+        return True
+
+    if enforced:
+        print("[REDDOG-WRE-QUEUE] Startup blocked by REDDOG_WRE_QUEUE_CONSUMER_DRYRUN_ENFORCED=1")
+        return False
+    return True
+
+
 def bootstrap_runtime_dae_launches() -> None:
     """Register broker-managed DAE entrypoints for an already running system."""
     daemon = get_central_daemon()
@@ -1519,6 +1573,8 @@ def main():
     if not run_git_main_merge_sentinel_preflight(repo_root):
         return
     if not run_reddog_authoritative_work_state_refresh_preflight(repo_root):
+        return
+    if not run_reddog_wre_queue_consumer_preflight(repo_root):
         return
     if not run_reddog_readonly_operational_bootstrap_preflight(repo_root):
         return

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,25 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_WRE_QUEUE_CONSUMER_DRYRUN_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_wre_queue_consumer_dryrun.py`: a fail-closed WRE queue
+  consumer dry-run that validates one authoritative work-state queue item
+  against its durable worker claim, freshness receipt, status, expiry, and
+  evidence refs.
+- Added `src/reddog_main_wre_queue_consumer_bootstrap.py` and `main.py`
+  telemetry. Startup now reports whether the queued slice is ready for the
+  next gate, while keeping `execution_ready=false` until signed authority and
+  downstream execution receipts exist.
+- Boundary: no queue mutation, worker spawn, worktree creation, shell command,
+  OpenClaw enqueue, Hermes dispatch, repo mutation, PR creation, reward
+  settlement, or HoloIndex re-index.
+- HoloIndex read-only probe for `RedDog WRE queue consumer dryrun` did not
+  surface the new module in top results before indexing. Recorded as
+  `HOLOINDEX_REDDOG_WRE_QUEUE_CONSUMER_DRYRUN_INDEX_GAP_PHASE1`; no runtime
+  re-index performed.
+
 ## 2026-07-14: REDDOG_PERSISTED_DECISION_TO_WORK_STATE_REFRESH_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_wre_queue_consumer_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_wre_queue_consumer_bootstrap.py
@@ -1,0 +1,122 @@
+"""Main-startup adapter for the RedDog WRE queue consumer dry-run."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_consumer_dryrun import (
+    WRE_QUEUE_CONSUMER_DRYRUN_READY,
+    plan_reddog_wre_queue_consumer_dry_run,
+)
+
+
+REDDOG_WRE_QUEUE_BOOTSTRAP_READY = "REDDOG_WRE_QUEUE_BOOTSTRAP_READY"
+REDDOG_WRE_QUEUE_BOOTSTRAP_NOT_READY = "REDDOG_WRE_QUEUE_BOOTSTRAP_NOT_READY"
+
+
+@dataclass(frozen=True)
+class RedDogMainWREQueueConsumerBootstrapResult:
+    ready: bool
+    status: str
+    queue_item_id: Optional[str]
+    selected_slice: Optional[str]
+    next_required_gate: Optional[str]
+    execution_ready: bool
+    rejection_reasons: tuple[str, ...]
+    receipt_id: Optional[str] = None
+    no_queue_mutation_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_worktree_created: bool = True
+    no_shell_command_executed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pr_created: bool = True
+    no_reward_settlement_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_main_wre_queue_consumer_bootstrap(
+    *,
+    repo_root: Path | str,
+    work_state_path: Path | str | None,
+    now_iso: str | None = None,
+    requested_queue_item_id: str | None = None,
+) -> RedDogMainWREQueueConsumerBootstrapResult:
+    """Load authoritative work state and dry-run consume one WRE queue item."""
+
+    root = Path(repo_root).resolve()
+    if not work_state_path:
+        return _not_ready(("missing_authoritative_work_state_path",))
+    path = Path(work_state_path)
+    if not path.is_absolute():
+        path = (root / path).resolve()
+    else:
+        path = path.resolve()
+    if _is_inside(path, root):
+        return _not_ready(("work_state_path_inside_repo",))
+    if not path.exists() or not path.is_file():
+        return _not_ready(("missing_authoritative_work_state",))
+    try:
+        snapshot = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return _not_ready(("malformed_authoritative_work_state",))
+
+    result = plan_reddog_wre_queue_consumer_dry_run(
+        snapshot,
+        now_iso=now_iso,
+        requested_queue_item_id=requested_queue_item_id,
+    )
+    if not result.accepted or result.status != WRE_QUEUE_CONSUMER_DRYRUN_READY:
+        return RedDogMainWREQueueConsumerBootstrapResult(
+            ready=False,
+            status=REDDOG_WRE_QUEUE_BOOTSTRAP_NOT_READY,
+            queue_item_id=result.selected_queue_item_id,
+            selected_slice=result.selected_slice,
+            next_required_gate=result.next_required_gate,
+            execution_ready=False,
+            rejection_reasons=tuple(result.rejection_reasons),
+        )
+    receipt_id = result.receipt.receipt_id if result.receipt else None
+    return RedDogMainWREQueueConsumerBootstrapResult(
+        ready=True,
+        status=REDDOG_WRE_QUEUE_BOOTSTRAP_READY,
+        queue_item_id=result.selected_queue_item_id,
+        selected_slice=result.selected_slice,
+        next_required_gate=result.next_required_gate,
+        execution_ready=result.execution_ready,
+        rejection_reasons=(),
+        receipt_id=receipt_id,
+    )
+
+
+def _not_ready(reasons: tuple[str, ...]) -> RedDogMainWREQueueConsumerBootstrapResult:
+    return RedDogMainWREQueueConsumerBootstrapResult(
+        ready=False,
+        status=REDDOG_WRE_QUEUE_BOOTSTRAP_NOT_READY,
+        queue_item_id=None,
+        selected_slice=None,
+        next_required_gate=None,
+        execution_ready=False,
+        rejection_reasons=reasons,
+    )
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+__all__ = [
+    "REDDOG_WRE_QUEUE_BOOTSTRAP_NOT_READY",
+    "REDDOG_WRE_QUEUE_BOOTSTRAP_READY",
+    "RedDogMainWREQueueConsumerBootstrapResult",
+    "run_reddog_main_wre_queue_consumer_bootstrap",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_wre_queue_consumer_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_queue_consumer_dryrun.py
@@ -1,0 +1,296 @@
+"""RedDog WRE queue consumer dry-run.
+
+Slice: REDDOG_WRE_QUEUE_CONSUMER_DRYRUN_PHASE1
+
+This module consumes the authoritative work-state WRE queue as evidence only.
+It validates that one queued item is bound to a fresh durable worker claim and
+emits the next required gate for runtime execution. It does not spawn workers,
+create worktrees, execute shell commands, invoke OpenClaw or Hermes, mutate the
+queue, edit repository files, publish PRs, settle rewards, or re-index HoloIndex.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+
+WRE_QUEUE_CONSUMER_DRYRUN_READY = "WRE_QUEUE_CONSUMER_DRYRUN_READY"
+WRE_QUEUE_CONSUMER_DRYRUN_REJECT = "WRE_QUEUE_CONSUMER_DRYRUN_REJECT"
+
+NEXT_GATE_SIGNED_AUTHORITY_REQUIRED = "SIGNED_AUTHORITY_REQUIRED"
+
+FAIL_SCHEMA_VERSION = "FAIL_SCHEMA_VERSION"
+FAIL_NO_QUEUE_ITEM = "FAIL_NO_QUEUE_ITEM"
+FAIL_QUEUE_ITEM_STATUS = "FAIL_QUEUE_ITEM_STATUS"
+FAIL_QUEUE_ALREADY_EXECUTED = "FAIL_QUEUE_ALREADY_EXECUTED"
+FAIL_QUEUE_CLAIM_MISMATCH = "FAIL_QUEUE_CLAIM_MISMATCH"
+FAIL_CLAIM_MISSING = "FAIL_CLAIM_MISSING"
+FAIL_CLAIM_STATUS = "FAIL_CLAIM_STATUS"
+FAIL_CLAIM_EXPIRED = "FAIL_CLAIM_EXPIRED"
+FAIL_FRESHNESS_RECEIPT = "FAIL_FRESHNESS_RECEIPT"
+FAIL_QUEUE_EVIDENCE_REFS = "FAIL_QUEUE_EVIDENCE_REFS"
+FAIL_REQUESTED_QUEUE_NOT_FOUND = "FAIL_REQUESTED_QUEUE_NOT_FOUND"
+
+WORK_STATE_SCHEMA_VERSION = "reddog_authoritative_work_state.v1"
+
+
+@dataclass(frozen=True)
+class WREQueueConsumerDryRunReceipt:
+    """Receipt for one validated authoritative queue item."""
+
+    receipt_id: str
+    queue_item_id: str
+    slice_id: str
+    claim_id: str
+    worker_id: str
+    freshness_receipt_id: str
+    next_required_gate: str
+    execution_ready: bool = False
+    no_queue_mutation_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_worktree_created: bool = True
+    no_shell_command_executed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pr_created: bool = True
+    no_reward_settlement_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class WREQueueConsumerDryRunResult:
+    """Result emitted by the WRE queue consumer dry-run."""
+
+    accepted: bool
+    status: str
+    rejection_reasons: List[str]
+    receipt: Optional[WREQueueConsumerDryRunReceipt]
+    selected_queue_item_id: Optional[str]
+    selected_slice: Optional[str]
+    next_required_gate: Optional[str]
+    execution_ready: bool = False
+    no_queue_mutation_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_worktree_created: bool = True
+    no_shell_command_executed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pr_created: bool = True
+    no_reward_settlement_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["receipt"] = self.receipt.to_dict() if self.receipt else None
+        return payload
+
+
+def _digest(payload: Any) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dedupe(values: Iterable[str]) -> List[str]:
+    seen: set[str] = set()
+    ordered: List[str] = []
+    for value in values:
+        text = str(value or "").strip()
+        if text and text not in seen:
+            seen.add(text)
+            ordered.append(text)
+    return ordered
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _list_of_mappings(value: Any) -> List[Mapping[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, Mapping)]
+
+
+def _parse_iso(value: Any) -> Optional[datetime]:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _now(now_iso: Optional[str]) -> datetime:
+    parsed = _parse_iso(now_iso)
+    return parsed if parsed is not None else datetime.now(timezone.utc)
+
+
+def _select_queue_item(
+    queue_items: List[Mapping[str, Any]],
+    requested_queue_item_id: Optional[str],
+) -> tuple[Optional[Mapping[str, Any]], List[str]]:
+    if requested_queue_item_id:
+        for item in queue_items:
+            if str(item.get("queue_item_id") or "") == requested_queue_item_id:
+                return item, []
+        return None, [FAIL_REQUESTED_QUEUE_NOT_FOUND]
+    for item in queue_items:
+        if str(item.get("status") or "").upper() == "QUEUED":
+            return item, []
+    return None, [FAIL_NO_QUEUE_ITEM]
+
+
+def _find_by_id(items: List[Mapping[str, Any]], key: str, expected: str) -> Optional[Mapping[str, Any]]:
+    for item in items:
+        if str(item.get(key) or "") == expected:
+            return item
+    return None
+
+
+def _reject(reasons: Iterable[str]) -> WREQueueConsumerDryRunResult:
+    return WREQueueConsumerDryRunResult(
+        accepted=False,
+        status=WRE_QUEUE_CONSUMER_DRYRUN_REJECT,
+        rejection_reasons=_dedupe(reasons),
+        receipt=None,
+        selected_queue_item_id=None,
+        selected_slice=None,
+        next_required_gate=None,
+    )
+
+
+def plan_reddog_wre_queue_consumer_dry_run(
+    work_state_snapshot: Mapping[str, Any],
+    *,
+    now_iso: Optional[str] = None,
+    requested_queue_item_id: Optional[str] = None,
+) -> WREQueueConsumerDryRunResult:
+    """Validate one authoritative WRE queue item without executing it."""
+
+    snapshot = _mapping(work_state_snapshot)
+    reasons: List[str] = []
+    if snapshot.get("schema_version") != WORK_STATE_SCHEMA_VERSION:
+        reasons.append(FAIL_SCHEMA_VERSION)
+
+    queue_items = _list_of_mappings(snapshot.get("wre_queue_items"))
+    claims = _list_of_mappings(snapshot.get("worker_claims"))
+    freshness_receipts = _list_of_mappings(snapshot.get("freshness_receipts"))
+    selected, select_reasons = _select_queue_item(queue_items, requested_queue_item_id)
+    reasons.extend(select_reasons)
+    if selected is None:
+        return _reject(reasons)
+
+    queue_item_id = str(selected.get("queue_item_id") or "")
+    slice_id = str(selected.get("slice_id") or "")
+    claim_id = str(selected.get("claim_id") or "")
+    worker_id = str(selected.get("worker_id") or "")
+    status = str(selected.get("status") or "").upper()
+    evidence_refs = [str(ref) for ref in selected.get("evidence_refs") or []]
+
+    if status != "QUEUED":
+        reasons.append(FAIL_QUEUE_ITEM_STATUS)
+    if selected.get("no_execution_performed") is not True:
+        reasons.append(FAIL_QUEUE_ALREADY_EXECUTED)
+
+    claim = _find_by_id(claims, "claim_id", claim_id)
+    if claim is None:
+        reasons.append(FAIL_CLAIM_MISSING)
+        claim = {}
+    if claim and str(claim.get("status") or "").upper() != "ACTIVE":
+        reasons.append(FAIL_CLAIM_STATUS)
+    if claim and (
+        str(claim.get("slice_id") or "") != slice_id
+        or str(claim.get("worker_id") or "") != worker_id
+    ):
+        reasons.append(FAIL_QUEUE_CLAIM_MISMATCH)
+
+    expires_at = _parse_iso(claim.get("expires_at")) if claim else None
+    if expires_at is None or expires_at <= _now(now_iso):
+        reasons.append(FAIL_CLAIM_EXPIRED)
+
+    freshness_receipt_id = str(claim.get("freshness_receipt_id") or "") if claim else ""
+    freshness = _find_by_id(freshness_receipts, "receipt_id", freshness_receipt_id)
+    if not freshness or freshness.get("fresh") is not True:
+        reasons.append(FAIL_FRESHNESS_RECEIPT)
+
+    expected_refs = {f"claim:{claim_id}", f"freshness:{freshness_receipt_id}"}
+    if not expected_refs.issubset(set(evidence_refs)):
+        reasons.append(FAIL_QUEUE_EVIDENCE_REFS)
+
+    deduped = _dedupe(reasons)
+    if deduped:
+        return WREQueueConsumerDryRunResult(
+            accepted=False,
+            status=WRE_QUEUE_CONSUMER_DRYRUN_REJECT,
+            rejection_reasons=deduped,
+            receipt=None,
+            selected_queue_item_id=queue_item_id or None,
+            selected_slice=slice_id or None,
+            next_required_gate=None,
+        )
+
+    receipt_seed = {
+        "queue_item_id": queue_item_id,
+        "slice_id": slice_id,
+        "claim_id": claim_id,
+        "worker_id": worker_id,
+        "freshness_receipt_id": freshness_receipt_id,
+        "next_required_gate": NEXT_GATE_SIGNED_AUTHORITY_REQUIRED,
+    }
+    receipt = WREQueueConsumerDryRunReceipt(
+        receipt_id="wre_queue_consumer_" + _digest(receipt_seed).removeprefix("sha256:")[:16],
+        queue_item_id=queue_item_id,
+        slice_id=slice_id,
+        claim_id=claim_id,
+        worker_id=worker_id,
+        freshness_receipt_id=freshness_receipt_id,
+        next_required_gate=NEXT_GATE_SIGNED_AUTHORITY_REQUIRED,
+    )
+    return WREQueueConsumerDryRunResult(
+        accepted=True,
+        status=WRE_QUEUE_CONSUMER_DRYRUN_READY,
+        rejection_reasons=[],
+        receipt=receipt,
+        selected_queue_item_id=queue_item_id,
+        selected_slice=slice_id,
+        next_required_gate=NEXT_GATE_SIGNED_AUTHORITY_REQUIRED,
+        execution_ready=False,
+    )
+
+
+__all__ = [
+    "FAIL_CLAIM_EXPIRED",
+    "FAIL_CLAIM_MISSING",
+    "FAIL_CLAIM_STATUS",
+    "FAIL_FRESHNESS_RECEIPT",
+    "FAIL_NO_QUEUE_ITEM",
+    "FAIL_QUEUE_ALREADY_EXECUTED",
+    "FAIL_QUEUE_CLAIM_MISMATCH",
+    "FAIL_QUEUE_EVIDENCE_REFS",
+    "FAIL_QUEUE_ITEM_STATUS",
+    "FAIL_REQUESTED_QUEUE_NOT_FOUND",
+    "FAIL_SCHEMA_VERSION",
+    "NEXT_GATE_SIGNED_AUTHORITY_REQUIRED",
+    "WREQueueConsumerDryRunReceipt",
+    "WREQueueConsumerDryRunResult",
+    "WRE_QUEUE_CONSUMER_DRYRUN_READY",
+    "WRE_QUEUE_CONSUMER_DRYRUN_REJECT",
+    "plan_reddog_wre_queue_consumer_dry_run",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py
@@ -1,0 +1,314 @@
+"""Tests for REDDOG_WRE_QUEUE_CONSUMER_DRYRUN_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from modules.communication.moltbot_bridge.src import (
+    reddog_wre_queue_consumer_dryrun as consumer,
+)
+from modules.communication.moltbot_bridge.src.reddog_main_wre_queue_consumer_bootstrap import (
+    REDDOG_WRE_QUEUE_BOOTSTRAP_READY,
+    run_reddog_main_wre_queue_consumer_bootstrap,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_wre_queue_consumer_dryrun.py"
+)
+BOOTSTRAP_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_main_wre_queue_consumer_bootstrap.py"
+)
+NOW = "2026-07-14T00:00:00+00:00"
+
+
+def _snapshot(**overrides):
+    claim_id = "claim-1"
+    freshness_id = "fresh-1"
+    base = {
+        "schema_version": "reddog_authoritative_work_state.v1",
+        "revision": "sha256:revision",
+        "freshness_receipts": [
+            {
+                "receipt_id": freshness_id,
+                "fresh": True,
+            }
+        ],
+        "worker_claims": [
+            {
+                "claim_id": claim_id,
+                "slice_id": "REDDOG_SAMPLE_SLICE_PHASE1",
+                "worker_id": "reddog-main-bootstrap",
+                "status": "ACTIVE",
+                "expires_at": "2026-07-14T01:00:00+00:00",
+                "freshness_receipt_id": freshness_id,
+            }
+        ],
+        "wre_queue_items": [
+            {
+                "queue_item_id": "queue-1",
+                "slice_id": "REDDOG_SAMPLE_SLICE_PHASE1",
+                "claim_id": claim_id,
+                "worker_id": "reddog-main-bootstrap",
+                "status": "QUEUED",
+                "enqueued_at": NOW,
+                "evidence_refs": [f"claim:{claim_id}", f"freshness:{freshness_id}"],
+                "no_execution_performed": True,
+            }
+        ],
+        "no_holoindex_mutation_performed": True,
+        "no_worker_spawn_performed": True,
+        "no_execution_performed": True,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_accepts_one_fresh_queued_item_without_execution() -> None:
+    result = consumer.plan_reddog_wre_queue_consumer_dry_run(_snapshot(), now_iso=NOW)
+
+    assert result.accepted is True
+    assert result.status == consumer.WRE_QUEUE_CONSUMER_DRYRUN_READY
+    assert result.selected_queue_item_id == "queue-1"
+    assert result.selected_slice == "REDDOG_SAMPLE_SLICE_PHASE1"
+    assert result.next_required_gate == consumer.NEXT_GATE_SIGNED_AUTHORITY_REQUIRED
+    assert result.execution_ready is False
+    assert result.receipt is not None
+    assert result.receipt.no_queue_mutation_performed is True
+    assert result.receipt.no_worker_spawn_performed is True
+    assert result.receipt.no_worktree_created is True
+    assert result.receipt.no_shell_command_executed is True
+    assert result.receipt.no_openclaw_enqueue_performed is True
+    assert result.receipt.no_hermes_dispatch_performed is True
+    assert result.receipt.no_repo_mutation_performed is True
+    assert result.receipt.no_holoindex_reindex_performed is True
+    assert result.receipt.no_pr_created is True
+    assert result.receipt.no_reward_settlement_performed is True
+
+
+def test_rejects_malformed_schema_before_queue_selection() -> None:
+    snapshot = _snapshot(schema_version="wrong")
+
+    result = consumer.plan_reddog_wre_queue_consumer_dry_run(snapshot, now_iso=NOW)
+
+    assert result.accepted is False
+    assert consumer.FAIL_SCHEMA_VERSION in result.rejection_reasons
+
+
+def test_rejects_missing_queue_item() -> None:
+    snapshot = _snapshot(wre_queue_items=[])
+
+    result = consumer.plan_reddog_wre_queue_consumer_dry_run(snapshot, now_iso=NOW)
+
+    assert result.accepted is False
+    assert result.rejection_reasons == [consumer.FAIL_NO_QUEUE_ITEM]
+
+
+def test_rejects_requested_queue_item_not_found() -> None:
+    result = consumer.plan_reddog_wre_queue_consumer_dry_run(
+        _snapshot(),
+        now_iso=NOW,
+        requested_queue_item_id="missing",
+    )
+
+    assert result.accepted is False
+    assert consumer.FAIL_REQUESTED_QUEUE_NOT_FOUND in result.rejection_reasons
+
+
+def test_rejects_non_queued_status_and_prior_execution() -> None:
+    snapshot = _snapshot()
+    snapshot["wre_queue_items"][0]["status"] = "RUNNING"
+    snapshot["wre_queue_items"][0]["no_execution_performed"] = False
+
+    result = consumer.plan_reddog_wre_queue_consumer_dry_run(
+        snapshot,
+        now_iso=NOW,
+        requested_queue_item_id="queue-1",
+    )
+
+    assert result.accepted is False
+    assert consumer.FAIL_QUEUE_ITEM_STATUS in result.rejection_reasons
+    assert consumer.FAIL_QUEUE_ALREADY_EXECUTED in result.rejection_reasons
+
+
+def test_rejects_missing_claim() -> None:
+    snapshot = _snapshot(worker_claims=[])
+
+    result = consumer.plan_reddog_wre_queue_consumer_dry_run(snapshot, now_iso=NOW)
+
+    assert result.accepted is False
+    assert consumer.FAIL_CLAIM_MISSING in result.rejection_reasons
+
+
+def test_rejects_claim_mismatch() -> None:
+    snapshot = _snapshot()
+    snapshot["worker_claims"][0]["worker_id"] = "other-worker"
+
+    result = consumer.plan_reddog_wre_queue_consumer_dry_run(snapshot, now_iso=NOW)
+
+    assert result.accepted is False
+    assert consumer.FAIL_QUEUE_CLAIM_MISMATCH in result.rejection_reasons
+
+
+def test_rejects_expired_claim() -> None:
+    snapshot = _snapshot()
+    snapshot["worker_claims"][0]["expires_at"] = "2026-07-13T23:59:59+00:00"
+
+    result = consumer.plan_reddog_wre_queue_consumer_dry_run(snapshot, now_iso=NOW)
+
+    assert result.accepted is False
+    assert consumer.FAIL_CLAIM_EXPIRED in result.rejection_reasons
+
+
+def test_rejects_stale_freshness_receipt() -> None:
+    snapshot = _snapshot()
+    snapshot["freshness_receipts"][0]["fresh"] = False
+
+    result = consumer.plan_reddog_wre_queue_consumer_dry_run(snapshot, now_iso=NOW)
+
+    assert result.accepted is False
+    assert consumer.FAIL_FRESHNESS_RECEIPT in result.rejection_reasons
+
+
+def test_rejects_missing_queue_evidence_refs() -> None:
+    snapshot = _snapshot()
+    snapshot["wre_queue_items"][0]["evidence_refs"] = ["claim:claim-1"]
+
+    result = consumer.plan_reddog_wre_queue_consumer_dry_run(snapshot, now_iso=NOW)
+
+    assert result.accepted is False
+    assert consumer.FAIL_QUEUE_EVIDENCE_REFS in result.rejection_reasons
+
+
+def test_bootstrap_loads_work_state_outside_repo(tmp_path: Path) -> None:
+    path = tmp_path / "authoritative_work_state.json"
+    path.write_text(json.dumps(_snapshot()), encoding="utf-8")
+
+    result = run_reddog_main_wre_queue_consumer_bootstrap(
+        repo_root=REPO_ROOT,
+        work_state_path=path,
+        now_iso=NOW,
+    )
+
+    assert result.ready is True
+    assert result.status == REDDOG_WRE_QUEUE_BOOTSTRAP_READY
+    assert result.queue_item_id == "queue-1"
+    assert result.selected_slice == "REDDOG_SAMPLE_SLICE_PHASE1"
+    assert result.next_required_gate == consumer.NEXT_GATE_SIGNED_AUTHORITY_REQUIRED
+    assert result.execution_ready is False
+    assert result.receipt_id is not None
+
+
+def test_bootstrap_rejects_work_state_inside_repo() -> None:
+    result = run_reddog_main_wre_queue_consumer_bootstrap(
+        repo_root=REPO_ROOT,
+        work_state_path=REPO_ROOT / "inside-repo.json",
+        now_iso=NOW,
+    )
+
+    assert result.ready is False
+    assert "work_state_path_inside_repo" in result.rejection_reasons
+
+
+def test_main_queue_consumer_preflight_passes_when_bootstrap_ready(tmp_path: Path) -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_wre_queue_consumer_bootstrap.run_reddog_main_wre_queue_consumer_bootstrap",
+        return_value=type(
+            "Result",
+            (),
+            {
+                "ready": True,
+                "status": REDDOG_WRE_QUEUE_BOOTSTRAP_READY,
+                "queue_item_id": "queue-1",
+                "selected_slice": "REDDOG_SAMPLE_SLICE_PHASE1",
+                "next_required_gate": consumer.NEXT_GATE_SIGNED_AUTHORITY_REQUIRED,
+                "execution_ready": False,
+                "rejection_reasons": (),
+                "receipt_id": "receipt-1",
+            },
+        )(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_WRE_QUEUE_CONSUMER_DRYRUN": "1",
+                "REDDOG_WRE_QUEUE_CONSUMER_DRYRUN_ENFORCED": "0",
+                "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+            },
+            clear=False,
+        ):
+            assert main.run_reddog_wre_queue_consumer_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["work_state_path"] == str(tmp_path / "state.json")
+
+
+def test_main_queue_consumer_preflight_blocks_when_enforced() -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_wre_queue_consumer_bootstrap.run_reddog_main_wre_queue_consumer_bootstrap",
+        return_value=type(
+            "Result",
+            (),
+            {
+                "ready": False,
+                "status": "REDDOG_WRE_QUEUE_BOOTSTRAP_NOT_READY",
+                "queue_item_id": None,
+                "selected_slice": None,
+                "next_required_gate": None,
+                "execution_ready": False,
+                "rejection_reasons": ("missing_authoritative_work_state_path",),
+                "receipt_id": None,
+            },
+        )(),
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_WRE_QUEUE_CONSUMER_DRYRUN": "1",
+                "REDDOG_WRE_QUEUE_CONSUMER_DRYRUN_ENFORCED": "1",
+                "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": "",
+            },
+            clear=False,
+        ):
+            assert main.run_reddog_wre_queue_consumer_preflight(REPO_ROOT) is False
+
+
+def test_modules_have_no_shell_network_git_execution_or_holoindex_mutation_imports() -> None:
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    for path in (MODULE_PATH, BOOTSTRAP_PATH):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert alias.name.split(".", 1)[0] not in banned_import_roots
+            if isinstance(node, ast.ImportFrom) and node.module:
+                assert node.module.split(".", 1)[0] not in banned_import_roots
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls


### PR DESCRIPTION
## Summary

Implements `REDDOG_WRE_QUEUE_CONSUMER_DRYRUN_PHASE1`.

This adds a fail-closed WRE queue consumer dry-run that validates one authoritative work-state queue item against its durable worker claim, freshness receipt, status, expiry, and evidence refs. It wires startup telemetry in `main.py` so RedDog can report the next required gate after work-state refresh without spawning workers or executing work.

## Boundary

- No queue mutation
- No worker spawn
- No worktree creation
- No shell command execution
- No OpenClaw enqueue
- No Hermes dispatch
- No repo mutation beyond this code change
- No HoloIndex re-index
- No PR creation/publish by this runtime
- No reward settlement

## Validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py -q` -> 15 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_authoritative_work_state_refresh_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py -q` -> 49 passed
- `git diff --cached --check` -> clean, Windows autocrlf warnings only
- New module/adapter/tests are ASCII-clean and NUL-free

## HoloIndex

Read-only probe for `RedDog WRE queue consumer dryrun authoritative queue claim freshness` did not rank the new module. Recorded as `HOLOINDEX_REDDOG_WRE_QUEUE_CONSUMER_DRYRUN_INDEX_GAP_PHASE1`. No runtime re-index performed.

## WSP_97 Truth Boundary

- OBSERVED: Work-state refresh emits `wre_queue_items` bound to durable worker claims.
- OBSERVED: Existing bounded worker pilot requires authority and downstream receipts; queue items alone are insufficient for execution.
- OBSERVED: This slice consumes the queue only as dry-run evidence and keeps `execution_ready=false`.
- SPECIFIED_NOT_IMPLEMENTED: signed authority production, bounded worker execution from the queue, autonomous verification/publish, reward ratchet, and live worker spawn remain downstream.