### PR TITLE
feat(reddog): plan WRE queue authority requests

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,24 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_WRE_QUEUE_AUTHORITY_REQUEST_DRYRUN_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_wre_queue_authority_request_dryrun.py`: a dry-run bridge
+  from an accepted WRE queue-consumer receipt to the existing
+  `DelegatedAuthorityRuntimeRequest` signer-runtime schema.
+- The bridge requires an explicit FoundUp-scoped authority profile, rejects
+  repo-wide authority, rejects paths outside `modules/foundups/{foundup_id}/`,
+  and requires consensus plus sovereign authorization digests for high-authority
+  operations.
+- Boundary: no signing, signature verification, signer-store mutation, worker
+  spawn, worktree creation, shell command, OpenClaw enqueue, Hermes dispatch,
+  repo mutation, PR creation, reward settlement, or HoloIndex re-index.
+- HoloIndex read-only probe for `RedDog WRE queue delegated authority request
+  dryrun` did not surface the new module in top results before indexing.
+  Recorded as `HOLOINDEX_REDDOG_WRE_QUEUE_AUTHORITY_REQUEST_DRYRUN_INDEX_GAP_PHASE1`;
+  no runtime re-index performed.
+
 ## 2026-07-14: REDDOG_WRE_QUEUE_CONSUMER_DRYRUN_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_wre_queue_authority_request_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_queue_authority_request_dryrun.py
@@ -1,0 +1,310 @@
+"""RedDog WRE queue to delegated-authority request dry-run.
+
+Slice: REDDOG_WRE_QUEUE_AUTHORITY_REQUEST_DRYRUN_PHASE1
+
+This module bridges the accepted WRE queue consumer dry-run to the existing
+RedDog delegated-authority signer runtime by constructing a
+DelegatedAuthorityRuntimeRequest from an explicit FoundUp authority profile. It
+does not sign, verify signatures, mutate signer state, spawn workers, create
+worktrees, execute shell commands, enqueue OpenClaw, dispatch Hermes, publish
+PRs, settle rewards, or re-index HoloIndex.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    DelegatedAuthorityRuntimeRequest,
+    HIGH_AUTHORITY_OPERATIONS,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_consumer_dryrun import (
+    NEXT_GATE_SIGNED_AUTHORITY_REQUIRED,
+    WRE_QUEUE_CONSUMER_DRYRUN_READY,
+)
+
+
+QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT = "QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT"
+QUEUE_AUTHORITY_REQUEST_DRYRUN_REJECT = "QUEUE_AUTHORITY_REQUEST_DRYRUN_REJECT"
+
+FAIL_QUEUE_CONSUMER_NOT_READY = "FAIL_QUEUE_CONSUMER_NOT_READY"
+FAIL_PROFILE_MISSING = "FAIL_PROFILE_MISSING"
+FAIL_PROFILE_NON_ASCII = "FAIL_PROFILE_NON_ASCII"
+FAIL_REQUIRED_FIELD = "FAIL_REQUIRED_FIELD"
+FAIL_ALLOWED_PATH_SCOPE = "FAIL_ALLOWED_PATH_SCOPE"
+FAIL_DENIED_PATH_SCOPE = "FAIL_DENIED_PATH_SCOPE"
+FAIL_HIGH_AUTHORITY_COSIGN = "FAIL_HIGH_AUTHORITY_COSIGN"
+FAIL_UNSUPPORTED_REPO_WIDE_AUTHORITY = "FAIL_UNSUPPORTED_REPO_WIDE_AUTHORITY"
+
+_REQUIRED_PROFILE_FIELDS = (
+    "principal_id",
+    "principal_provider",
+    "principal_public_key",
+    "reddog_id",
+    "reddog_public_key",
+    "repo_full_name",
+    "foundup_id",
+    "allowed_paths",
+    "requested_operation",
+    "permission_snapshot_digest",
+    "identity_nonce",
+    "work_authority_nonce",
+    "issued_at",
+    "identity_expires_at",
+    "work_authority_expires_at",
+    "valve_state_required",
+    "key_epoch",
+)
+
+
+@dataclass(frozen=True)
+class QueueAuthorityRequestDryRunReceipt:
+    receipt_id: str
+    queue_consumer_receipt_digest: str
+    queue_item_id: str
+    slice_id: str
+    work_order_id: str
+    requested_operation: str
+    foundup_id: str
+    allowed_paths: Tuple[str, ...]
+    denied_paths: Tuple[str, ...]
+    delegated_authority_request_digest: str
+    signer_invoked: bool = False
+    signature_verified: bool = False
+    execution_ready: bool = False
+    no_signing_performed: bool = True
+    no_signer_state_mutation_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_worktree_created: bool = True
+    no_shell_command_executed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pr_created: bool = True
+    no_reward_settlement_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class QueueAuthorityRequestDryRunResult:
+    accepted: bool
+    status: str
+    rejection_reasons: List[str]
+    receipt: Optional[QueueAuthorityRequestDryRunReceipt]
+    delegated_authority_request: Optional[Dict[str, Any]]
+    execution_ready: bool = False
+    signer_invoked: bool = False
+    no_signing_performed: bool = True
+    no_signer_state_mutation_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_worktree_created: bool = True
+    no_shell_command_executed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pr_created: bool = True
+    no_reward_settlement_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["receipt"] = self.receipt.to_dict() if self.receipt else None
+        return payload
+
+
+def _digest(payload: Any) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dedupe(values: Iterable[str]) -> List[str]:
+    seen: set[str] = set()
+    ordered: List[str] = []
+    for value in values:
+        text = str(value or "").strip()
+        if text and text not in seen:
+            seen.add(text)
+            ordered.append(text)
+    return ordered
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        return value.to_dict()
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _is_ascii_deep(value: Any) -> bool:
+    if isinstance(value, str):
+        return all(ord(char) < 128 for char in value)
+    if isinstance(value, Mapping):
+        return all(isinstance(key, str) and _is_ascii_deep(key) and _is_ascii_deep(item) for key, item in value.items())
+    if isinstance(value, (list, tuple)):
+        return all(_is_ascii_deep(item) for item in value)
+    return True
+
+
+def _string_tuple(value: Any) -> Tuple[str, ...]:
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, (list, tuple)):
+        return tuple(str(item) for item in value)
+    return ()
+
+
+def _path_within_foundup(path: str, foundup_id: str) -> bool:
+    if not path or "\\" in path or ":" in path or path.startswith("/") or "\x00" in path:
+        return False
+    if path.startswith("//?/") or path.startswith("//./"):
+        return False
+    prefix = f"modules/foundups/{foundup_id}/"
+    if not path.startswith(prefix):
+        return False
+    for segment in path.split("/"):
+        if segment.strip(" \t") == ".." or segment.strip(" .\t") == "":
+            return False
+    return True
+
+
+def _work_order_id(queue_item_id: str) -> str:
+    return "wre-queue-" + hashlib.sha256(queue_item_id.encode("utf-8")).hexdigest()[:16]
+
+
+def _reject(reasons: Iterable[str]) -> QueueAuthorityRequestDryRunResult:
+    return QueueAuthorityRequestDryRunResult(
+        accepted=False,
+        status=QUEUE_AUTHORITY_REQUEST_DRYRUN_REJECT,
+        rejection_reasons=_dedupe(reasons),
+        receipt=None,
+        delegated_authority_request=None,
+    )
+
+
+def plan_reddog_wre_queue_authority_request_dry_run(
+    *,
+    queue_consumer_result: Mapping[str, Any],
+    authority_profile: Mapping[str, Any] | None,
+) -> QueueAuthorityRequestDryRunResult:
+    """Build a signer-runtime request from a validated queue-consumer receipt."""
+
+    queue = _mapping(queue_consumer_result)
+    queue_receipt = _mapping(queue.get("receipt"))
+    reasons: List[str] = []
+    if (
+        queue.get("accepted") is not True
+        or queue.get("status") != WRE_QUEUE_CONSUMER_DRYRUN_READY
+        or queue.get("next_required_gate") != NEXT_GATE_SIGNED_AUTHORITY_REQUIRED
+        or queue.get("execution_ready") is not False
+        or not queue_receipt
+    ):
+        reasons.append(FAIL_QUEUE_CONSUMER_NOT_READY)
+    profile = _mapping(authority_profile)
+    if not profile:
+        reasons.append(FAIL_PROFILE_MISSING)
+    elif not _is_ascii_deep(profile):
+        reasons.append(FAIL_PROFILE_NON_ASCII)
+
+    missing = [field for field in _REQUIRED_PROFILE_FIELDS if field not in profile or profile.get(field) in (None, "", ())]
+    if missing:
+        reasons.extend(f"{FAIL_REQUIRED_FIELD}:{field}" for field in missing)
+
+    foundup_id = str(profile.get("foundup_id") or "")
+    allowed_paths = _string_tuple(profile.get("allowed_paths"))
+    denied_paths = _string_tuple(profile.get("denied_paths"))
+    if allowed_paths and foundup_id and not all(_path_within_foundup(path, foundup_id) for path in allowed_paths):
+        reasons.append(FAIL_ALLOWED_PATH_SCOPE)
+    if denied_paths and foundup_id and not all(_path_within_foundup(path, foundup_id) for path in denied_paths):
+        reasons.append(FAIL_DENIED_PATH_SCOPE)
+    if not foundup_id or foundup_id in {"*", "repo", "root", "all"}:
+        reasons.append(FAIL_UNSUPPORTED_REPO_WIDE_AUTHORITY)
+
+    operation = str(profile.get("requested_operation") or "")
+    if operation in HIGH_AUTHORITY_OPERATIONS and not (
+        profile.get("consensus_receipt_digest") and profile.get("sovereign_authorization_digest")
+    ):
+        reasons.append(FAIL_HIGH_AUTHORITY_COSIGN)
+
+    deduped = _dedupe(reasons)
+    if deduped:
+        return _reject(deduped)
+
+    queue_item_id = str(queue_receipt.get("queue_item_id") or queue.get("selected_queue_item_id") or "")
+    request = DelegatedAuthorityRuntimeRequest(
+        work_order_id=str(profile.get("work_order_id") or _work_order_id(queue_item_id)),
+        principal_id=str(profile["principal_id"]),
+        principal_provider=str(profile["principal_provider"]),
+        principal_public_key=str(profile["principal_public_key"]),
+        reddog_id=str(profile["reddog_id"]),
+        reddog_public_key=str(profile["reddog_public_key"]),
+        repo_full_name=str(profile["repo_full_name"]),
+        foundup_id=foundup_id,
+        allowed_paths=allowed_paths,
+        denied_paths=denied_paths,
+        requested_operation=operation,
+        permission_snapshot_digest=str(profile["permission_snapshot_digest"]),
+        identity_nonce=str(profile["identity_nonce"]),
+        work_authority_nonce=str(profile["work_authority_nonce"]),
+        issued_at=int(profile["issued_at"]),
+        identity_expires_at=int(profile["identity_expires_at"]),
+        work_authority_expires_at=int(profile["work_authority_expires_at"]),
+        valve_state_required=str(profile["valve_state_required"]),
+        key_epoch=str(profile["key_epoch"]),
+        consensus_receipt_digest=(
+            str(profile["consensus_receipt_digest"]) if profile.get("consensus_receipt_digest") else None
+        ),
+        sovereign_authorization_digest=(
+            str(profile["sovereign_authorization_digest"]) if profile.get("sovereign_authorization_digest") else None
+        ),
+    )
+    request_dict = request.to_dict()
+    request_digest = _digest(request_dict)
+    receipt = QueueAuthorityRequestDryRunReceipt(
+        receipt_id="queue_auth_req_" + _digest(
+            {
+                "queue_receipt": queue_receipt,
+                "request_digest": request_digest,
+            }
+        ).removeprefix("sha256:")[:16],
+        queue_consumer_receipt_digest=_digest(queue_receipt),
+        queue_item_id=queue_item_id,
+        slice_id=str(queue_receipt.get("slice_id") or queue.get("selected_slice") or ""),
+        work_order_id=request.work_order_id,
+        requested_operation=request.requested_operation,
+        foundup_id=request.foundup_id,
+        allowed_paths=request.allowed_paths,
+        denied_paths=request.denied_paths,
+        delegated_authority_request_digest=request_digest,
+    )
+    return QueueAuthorityRequestDryRunResult(
+        accepted=True,
+        status=QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT,
+        rejection_reasons=[],
+        receipt=receipt,
+        delegated_authority_request=request_dict,
+        execution_ready=False,
+    )
+
+
+__all__ = [
+    "FAIL_ALLOWED_PATH_SCOPE",
+    "FAIL_DENIED_PATH_SCOPE",
+    "FAIL_HIGH_AUTHORITY_COSIGN",
+    "FAIL_PROFILE_MISSING",
+    "FAIL_PROFILE_NON_ASCII",
+    "FAIL_QUEUE_CONSUMER_NOT_READY",
+    "FAIL_REQUIRED_FIELD",
+    "FAIL_UNSUPPORTED_REPO_WIDE_AUTHORITY",
+    "QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT",
+    "QUEUE_AUTHORITY_REQUEST_DRYRUN_REJECT",
+    "QueueAuthorityRequestDryRunReceipt",
+    "QueueAuthorityRequestDryRunResult",
+    "plan_reddog_wre_queue_authority_request_dry_run",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_request_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_request_dryrun.py
@@ -1,0 +1,238 @@
+"""Tests for REDDOG_WRE_QUEUE_AUTHORITY_REQUEST_DRYRUN_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src import (
+    reddog_wre_queue_authority_request_dryrun as planner,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    VALVE_OPEN_WORKTREE_CREATE,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_consumer_dryrun import (
+    NEXT_GATE_SIGNED_AUTHORITY_REQUIRED,
+    WRE_QUEUE_CONSUMER_DRYRUN_READY,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_wre_queue_authority_request_dryrun.py"
+)
+
+
+def _queue_result(**overrides):
+    receipt = {
+        "receipt_id": "wre_queue_consumer_1234",
+        "queue_item_id": "queue-1",
+        "slice_id": "FOUNDUP_SCOPED_SAMPLE_PHASE1",
+        "claim_id": "claim-1",
+        "worker_id": "reddog-main-bootstrap",
+        "freshness_receipt_id": "fresh-1",
+        "next_required_gate": NEXT_GATE_SIGNED_AUTHORITY_REQUIRED,
+        "execution_ready": False,
+        "no_queue_mutation_performed": True,
+    }
+    result = {
+        "accepted": True,
+        "status": WRE_QUEUE_CONSUMER_DRYRUN_READY,
+        "rejection_reasons": [],
+        "receipt": receipt,
+        "selected_queue_item_id": "queue-1",
+        "selected_slice": "FOUNDUP_SCOPED_SAMPLE_PHASE1",
+        "next_required_gate": NEXT_GATE_SIGNED_AUTHORITY_REQUIRED,
+        "execution_ready": False,
+    }
+    result.update(overrides)
+    return result
+
+
+def _profile(**overrides):
+    profile = {
+        "principal_id": "github:mjtrout",
+        "principal_provider": "github",
+        "principal_public_key": "pub:principal",
+        "reddog_id": "reddog:abc123",
+        "reddog_public_key": "pub:reddog",
+        "repo_full_name": "FOUNDUPS/Foundups-Agent",
+        "foundup_id": "paccess_001",
+        "allowed_paths": ["modules/foundups/paccess_001/**"],
+        "denied_paths": ["modules/foundups/paccess_001/secrets/**"],
+        "requested_operation": "create_foundup",
+        "permission_snapshot_digest": "sha256:snap-1",
+        "identity_nonce": "identity-nonce-0001",
+        "work_authority_nonce": "workauth-nonce-0001",
+        "issued_at": 1000,
+        "identity_expires_at": 4600,
+        "work_authority_expires_at": 1300,
+        "valve_state_required": VALVE_OPEN_WORKTREE_CREATE,
+        "key_epoch": "epoch-1",
+        "consensus_receipt_digest": "sha256:consensus",
+        "sovereign_authorization_digest": "sha256:012-token",
+    }
+    profile.update(overrides)
+    return profile
+
+
+def test_builds_delegated_authority_runtime_request_without_signing() -> None:
+    result = planner.plan_reddog_wre_queue_authority_request_dry_run(
+        queue_consumer_result=_queue_result(),
+        authority_profile=_profile(),
+    )
+
+    assert result.accepted is True
+    assert result.status == planner.QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT
+    assert result.execution_ready is False
+    assert result.signer_invoked is False
+    assert result.no_signing_performed is True
+    assert result.no_signer_state_mutation_performed is True
+    assert result.no_worker_spawn_performed is True
+    assert result.no_worktree_created is True
+    assert result.no_shell_command_executed is True
+    assert result.no_openclaw_enqueue_performed is True
+    assert result.no_hermes_dispatch_performed is True
+    assert result.no_repo_mutation_performed is True
+    assert result.no_holoindex_reindex_performed is True
+    assert result.no_pr_created is True
+    assert result.no_reward_settlement_performed is True
+    assert result.receipt is not None
+    request = result.delegated_authority_request
+    assert request is not None
+    assert request["work_order_id"].startswith("wre-queue-")
+    assert request["foundup_id"] == "paccess_001"
+    assert request["allowed_paths"] == ("modules/foundups/paccess_001/**",)
+    assert request["requested_operation"] == "create_foundup"
+    assert request["valve_state_required"] == VALVE_OPEN_WORKTREE_CREATE
+    assert result.receipt.delegated_authority_request_digest.startswith("sha256:")
+
+
+def test_rejects_unaccepted_queue_consumer_result() -> None:
+    result = planner.plan_reddog_wre_queue_authority_request_dry_run(
+        queue_consumer_result=_queue_result(accepted=False),
+        authority_profile=_profile(),
+    )
+
+    assert result.accepted is False
+    assert planner.FAIL_QUEUE_CONSUMER_NOT_READY in result.rejection_reasons
+    assert result.delegated_authority_request is None
+
+
+def test_rejects_missing_profile() -> None:
+    result = planner.plan_reddog_wre_queue_authority_request_dry_run(
+        queue_consumer_result=_queue_result(),
+        authority_profile=None,
+    )
+
+    assert result.accepted is False
+    assert planner.FAIL_PROFILE_MISSING in result.rejection_reasons
+
+
+def test_rejects_missing_required_profile_field() -> None:
+    profile = _profile()
+    del profile["principal_public_key"]
+
+    result = planner.plan_reddog_wre_queue_authority_request_dry_run(
+        queue_consumer_result=_queue_result(),
+        authority_profile=profile,
+    )
+
+    assert result.accepted is False
+    assert f"{planner.FAIL_REQUIRED_FIELD}:principal_public_key" in result.rejection_reasons
+
+
+def test_rejects_non_ascii_profile() -> None:
+    result = planner.plan_reddog_wre_queue_authority_request_dry_run(
+        queue_consumer_result=_queue_result(),
+        authority_profile=_profile(principal_id="github:mjtrout-\u03c0"),
+    )
+
+    assert result.accepted is False
+    assert planner.FAIL_PROFILE_NON_ASCII in result.rejection_reasons
+
+
+def test_rejects_allowed_path_outside_foundup_scope() -> None:
+    result = planner.plan_reddog_wre_queue_authority_request_dry_run(
+        queue_consumer_result=_queue_result(),
+        authority_profile=_profile(allowed_paths=["modules/communication/moltbot_bridge/src/main.py"]),
+    )
+
+    assert result.accepted is False
+    assert planner.FAIL_ALLOWED_PATH_SCOPE in result.rejection_reasons
+
+
+def test_rejects_denied_path_outside_foundup_scope() -> None:
+    result = planner.plan_reddog_wre_queue_authority_request_dry_run(
+        queue_consumer_result=_queue_result(),
+        authority_profile=_profile(denied_paths=[".github/workflows/**"]),
+    )
+
+    assert result.accepted is False
+    assert planner.FAIL_DENIED_PATH_SCOPE in result.rejection_reasons
+
+
+def test_rejects_repo_wide_authority_until_generic_contract_exists() -> None:
+    result = planner.plan_reddog_wre_queue_authority_request_dry_run(
+        queue_consumer_result=_queue_result(),
+        authority_profile=_profile(foundup_id="repo", allowed_paths=["modules/foundups/repo/**"]),
+    )
+
+    assert result.accepted is False
+    assert planner.FAIL_UNSUPPORTED_REPO_WIDE_AUTHORITY in result.rejection_reasons
+
+
+def test_rejects_high_authority_without_consensus_and_sovereign_digest() -> None:
+    result = planner.plan_reddog_wre_queue_authority_request_dry_run(
+        queue_consumer_result=_queue_result(),
+        authority_profile=_profile(consensus_receipt_digest=None, sovereign_authorization_digest=None),
+    )
+
+    assert result.accepted is False
+    assert planner.FAIL_HIGH_AUTHORITY_COSIGN in result.rejection_reasons
+
+
+def test_low_authority_does_not_require_cosign() -> None:
+    result = planner.plan_reddog_wre_queue_authority_request_dry_run(
+        queue_consumer_result=_queue_result(),
+        authority_profile=_profile(
+            requested_operation="inspect_repo",
+            consensus_receipt_digest=None,
+            sovereign_authorization_digest=None,
+        ),
+    )
+
+    assert result.accepted is True
+    assert result.delegated_authority_request is not None
+    assert result.delegated_authority_request["requested_operation"] == "inspect_repo"
+
+
+def test_module_has_no_shell_network_signing_state_or_runtime_invocation_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+        "hmac",
+        "secrets",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls


### PR DESCRIPTION
## Summary

Implements `REDDOG_WRE_QUEUE_AUTHORITY_REQUEST_DRYRUN_PHASE1`.

This bridges an accepted WRE queue-consumer dry-run receipt to the existing `DelegatedAuthorityRuntimeRequest` signer-runtime schema. It is a planner only: no signing, no verifier call, and no signer-store mutation.

## Boundary

- No signing performed
- No signature verification performed
- No signer state mutation
- No worker spawn
- No worktree creation
- No shell command execution
- No OpenClaw enqueue
- No Hermes dispatch
- No repo mutation beyond this code change
- No HoloIndex re-index
- No PR creation/publish by this runtime
- No reward settlement

## Scope Controls

- Requires accepted queue-consumer receipt from #1029.
- Requires explicit authority profile.
- Rejects non-ASCII profile content.
- Rejects repo-wide authority until a generic repo authority contract exists.
- Rejects paths outside `modules/foundups/{foundup_id}/` to match the current signer runtime contract.
- Requires consensus and sovereign authorization digests for high-authority operations.

## Validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_request_dryrun.py -q` -> 11 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_request_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_signer_delegated_authority_runtime.py -q` -> 40 passed
- `git diff --check` -> clean, Windows autocrlf warnings only
- New module/test are ASCII-clean and NUL-free

## HoloIndex

Read-only probe for `RedDog WRE queue delegated authority request dryrun signer runtime` did not rank the new module. Recorded as `HOLOINDEX_REDDOG_WRE_QUEUE_AUTHORITY_REQUEST_DRYRUN_INDEX_GAP_PHASE1`. No runtime re-index performed.

## WSP_97 Truth Boundary

- OBSERVED: The signer runtime already exists and accepts `DelegatedAuthorityRuntimeRequest` through injected signer/principal/snapshot boundaries.
- OBSERVED: The signer runtime is currently FoundUp-path scoped; effective paths must be under `modules/foundups/{foundup_id}/`.
- OBSERVED: This slice builds that request shape only; it does not invoke the signer runtime.
- SPECIFIED_NOT_IMPLEMENTED: generic repo-wide authority, actual signing, queue-driven worker execution, autonomous verification/publish, and reward ratchet remain downstream.