### PR TITLE
feat(reddog): guard queue authority runtime invoke

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,25 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_WRE_QUEUE_AUTHORITY_RUNTIME_INVOKE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_wre_queue_authority_runtime_invoke.py`: an explicit invoke
+  guard that calls the existing delegated-authority signer runtime only from an
+  accepted queue-authority request dry-run and only through injected signer,
+  principal resolver, permission snapshot resolver, and authority store
+  boundaries.
+- The guard preserves default fail-closed signer behavior, returns runtime
+  rejection reasons unchanged, and performs no worker spawn, worktree creation,
+  shell command, OpenClaw enqueue, Hermes dispatch, repo mutation, PR creation,
+  reward settlement, or HoloIndex re-index.
+- Boundary: this may issue signed authority records when an injected signer
+  accepts, but it still does not execute the authorized work.
+- HoloIndex read-only probe for `RedDog WRE queue authority runtime invoke`
+  did not surface the new module in top results before indexing. Recorded as
+  `HOLOINDEX_REDDOG_WRE_QUEUE_AUTHORITY_RUNTIME_INVOKE_INDEX_GAP_PHASE1`; no
+  runtime re-index performed.
+
 ## 2026-07-14: REDDOG_WRE_QUEUE_AUTHORITY_REQUEST_DRYRUN_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_wre_queue_authority_runtime_invoke.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_queue_authority_runtime_invoke.py
@@ -1,0 +1,199 @@
+"""RedDog WRE queue authority runtime explicit invoke guard.
+
+Slice: REDDOG_WRE_QUEUE_AUTHORITY_RUNTIME_INVOKE_PHASE1
+
+This module invokes the existing delegated-authority signer runtime from an
+accepted queue-authority request dry-run. It requires an explicit invoke flag
+and injected signer, principal resolver, snapshot resolver, and authority
+store. It may issue signed authority records through that injected signer
+boundary, but it never executes work, creates worktrees, runs shell commands,
+enqueues OpenClaw, dispatches Hermes, publishes PRs, settles rewards, or
+re-indexes HoloIndex.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    AUTHORITY_ISSUED,
+    AUTHORITY_REJECTED,
+    AuthorityRuntimeStore,
+    DelegatedAuthorityRuntimeRequest,
+    DelegatedAuthorityRuntimeResult,
+    IsolatedSignerClient,
+    PermissionSnapshotResolver,
+    PrincipalAuthorityResolver,
+    issue_delegated_authority_runtime,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authority_request_dryrun import (
+    QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT,
+)
+
+
+QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT = "QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT"
+QUEUE_AUTHORITY_RUNTIME_INVOKE_REJECT = "QUEUE_AUTHORITY_RUNTIME_INVOKE_REJECT"
+
+
+class QueueAuthorityRuntimeInvokeReason:
+    EXPLICIT_INVOKE_MISSING = "REJECT_EXPLICIT_QUEUE_AUTHORITY_RUNTIME_INVOKE_MISSING"
+    REQUEST_DRYRUN_NOT_ACCEPTED = "REJECT_QUEUE_AUTHORITY_REQUEST_DRYRUN_NOT_ACCEPTED"
+    REQUEST_PAYLOAD_MISSING = "REJECT_DELEGATED_AUTHORITY_REQUEST_MISSING"
+    REQUEST_PAYLOAD_INVALID = "REJECT_DELEGATED_AUTHORITY_REQUEST_INVALID"
+    AUTHORITY_RUNTIME_REJECTED = "REJECT_DELEGATED_AUTHORITY_RUNTIME_REJECTED"
+
+
+@dataclass(frozen=True)
+class QueueAuthorityRuntimeInvokeResult:
+    decision: str
+    rejection_reasons: List[str] = field(default_factory=list)
+    authority_result: Optional[DelegatedAuthorityRuntimeResult] = None
+    explicit_queue_authority_runtime_requested: bool = False
+    no_worker_spawn_performed: bool = True
+    no_worktree_created: bool = True
+    no_shell_command_executed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pr_created: bool = True
+    no_reward_settlement_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["authority_result"] = (
+            self.authority_result.to_dict() if self.authority_result else None
+        )
+        return payload
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        return value.to_dict()
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _reject(
+    reasons: Sequence[str],
+    *,
+    explicit_requested: bool,
+    authority_result: Optional[DelegatedAuthorityRuntimeResult] = None,
+) -> QueueAuthorityRuntimeInvokeResult:
+    return QueueAuthorityRuntimeInvokeResult(
+        decision=QUEUE_AUTHORITY_RUNTIME_INVOKE_REJECT,
+        rejection_reasons=list(dict.fromkeys(reasons)),
+        authority_result=authority_result,
+        explicit_queue_authority_runtime_requested=explicit_requested,
+    )
+
+
+def _request_from_payload(payload: Mapping[str, Any]) -> DelegatedAuthorityRuntimeRequest:
+    return DelegatedAuthorityRuntimeRequest(
+        work_order_id=str(payload["work_order_id"]),
+        principal_id=str(payload["principal_id"]),
+        principal_provider=str(payload["principal_provider"]),
+        principal_public_key=str(payload["principal_public_key"]),
+        reddog_id=str(payload["reddog_id"]),
+        reddog_public_key=str(payload["reddog_public_key"]),
+        repo_full_name=str(payload["repo_full_name"]),
+        foundup_id=str(payload["foundup_id"]),
+        allowed_paths=tuple(str(item) for item in payload["allowed_paths"]),
+        denied_paths=tuple(str(item) for item in payload.get("denied_paths") or ()),
+        requested_operation=str(payload["requested_operation"]),
+        permission_snapshot_digest=str(payload["permission_snapshot_digest"]),
+        identity_nonce=str(payload["identity_nonce"]),
+        work_authority_nonce=str(payload["work_authority_nonce"]),
+        issued_at=int(payload["issued_at"]),
+        identity_expires_at=int(payload["identity_expires_at"]),
+        work_authority_expires_at=int(payload["work_authority_expires_at"]),
+        valve_state_required=str(payload["valve_state_required"]),
+        key_epoch=str(payload["key_epoch"]),
+        consensus_receipt_digest=(
+            str(payload["consensus_receipt_digest"])
+            if payload.get("consensus_receipt_digest")
+            else None
+        ),
+        sovereign_authorization_digest=(
+            str(payload["sovereign_authorization_digest"])
+            if payload.get("sovereign_authorization_digest")
+            else None
+        ),
+    )
+
+
+def invoke_reddog_wre_queue_authority_runtime(
+    *,
+    explicit_queue_authority_runtime_requested: bool,
+    queue_authority_request_dryrun: Mapping[str, Any],
+    store: AuthorityRuntimeStore,
+    signer: Optional[IsolatedSignerClient],
+    principal_resolver: Optional[PrincipalAuthorityResolver],
+    snapshot_resolver: PermissionSnapshotResolver,
+    now: int,
+    leeway_s: int = 60,
+) -> QueueAuthorityRuntimeInvokeResult:
+    """Invoke delegated authority issuance for a queue-derived request."""
+
+    if explicit_queue_authority_runtime_requested is not True:
+        return _reject(
+            [QueueAuthorityRuntimeInvokeReason.EXPLICIT_INVOKE_MISSING],
+            explicit_requested=False,
+        )
+
+    dryrun = _mapping(queue_authority_request_dryrun)
+    if dryrun.get("accepted") is not True or dryrun.get("status") != QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT:
+        return _reject(
+            [QueueAuthorityRuntimeInvokeReason.REQUEST_DRYRUN_NOT_ACCEPTED],
+            explicit_requested=True,
+        )
+    request_payload = _mapping(dryrun.get("delegated_authority_request"))
+    if not request_payload:
+        return _reject(
+            [QueueAuthorityRuntimeInvokeReason.REQUEST_PAYLOAD_MISSING],
+            explicit_requested=True,
+        )
+    try:
+        request = _request_from_payload(request_payload)
+    except Exception:
+        return _reject(
+            [QueueAuthorityRuntimeInvokeReason.REQUEST_PAYLOAD_INVALID],
+            explicit_requested=True,
+        )
+
+    authority = issue_delegated_authority_runtime(
+        request=request,
+        store=store,
+        signer=signer,
+        principal_resolver=principal_resolver,
+        snapshot_resolver=snapshot_resolver,
+        now=now,
+        leeway_s=leeway_s,
+    )
+    if not authority.accepted or authority.receipt.status != AUTHORITY_ISSUED:
+        reasons = [QueueAuthorityRuntimeInvokeReason.AUTHORITY_RUNTIME_REJECTED]
+        if authority.receipt.status == AUTHORITY_REJECTED:
+            reasons.extend(authority.receipt.rejection_reasons)
+        return _reject(
+            reasons,
+            explicit_requested=True,
+            authority_result=authority,
+        )
+
+    return QueueAuthorityRuntimeInvokeResult(
+        decision=QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT,
+        rejection_reasons=[],
+        authority_result=authority,
+        explicit_queue_authority_runtime_requested=True,
+    )
+
+
+__all__ = [
+    "QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT",
+    "QUEUE_AUTHORITY_RUNTIME_INVOKE_REJECT",
+    "QueueAuthorityRuntimeInvokeReason",
+    "QueueAuthorityRuntimeInvokeResult",
+    "invoke_reddog_wre_queue_authority_runtime",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_runtime_invoke.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_runtime_invoke.py
@@ -1,0 +1,336 @@
+"""Tests for REDDOG_WRE_QUEUE_AUTHORITY_RUNTIME_INVOKE_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import hmac
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src import (
+    reddog_wre_queue_authority_request_dryrun as planner,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    AUTHORITY_ISSUED,
+    DelegatedAuthorityRuntimeRequest,
+    InMemoryAuthorityRuntimeStore,
+    PrincipalAuthorityRecord,
+    RuntimeRejectCode,
+    SigningResponse,
+    public_key_fingerprint,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    PermissionSnapshot,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    VALVE_OPEN_WORKTREE_CREATE,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authority_runtime_invoke import (
+    QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT,
+    QUEUE_AUTHORITY_RUNTIME_INVOKE_REJECT,
+    QueueAuthorityRuntimeInvokeReason,
+    invoke_reddog_wre_queue_authority_runtime,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_consumer_dryrun import (
+    NEXT_GATE_SIGNED_AUTHORITY_REQUIRED,
+    WRE_QUEUE_CONSUMER_DRYRUN_READY,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_wre_queue_authority_runtime_invoke.py"
+)
+NOW = 1000
+REPO = "FOUNDUPS/Foundups-Agent"
+FID = "paccess_001"
+
+
+class _MockSigner:
+    def __init__(self) -> None:
+        self.secrets = {
+            "pub:principal": b"principal-secret",
+            "pub:reddog": b"reddog-secret",
+        }
+        self.requests = []
+
+    def sign(self, request):
+        self.requests.append(request)
+        secret = self.secrets.get(request.signer_public_key)
+        if secret is None:
+            return SigningResponse(
+                accepted=False,
+                rejection_code=RuntimeRejectCode.SIGNER_NOT_CONFIGURED,
+            )
+        signature = hmac.new(secret, request.signing_input.encode("utf-8"), hashlib.sha256).hexdigest()
+        audit = hmac.new(secret, request.payload_digest.encode("utf-8"), hashlib.sha256).hexdigest()
+        return SigningResponse(
+            accepted=True,
+            signature=signature,
+            signer_public_key=request.signer_public_key,
+            key_fingerprint=public_key_fingerprint(request.signer_public_key),
+            key_epoch=request.key_epoch,
+            audit_mac="audit:" + audit,
+            boundary_attested=True,
+            requester_identity_attested=True,
+            signer_loads_no_untrusted_code=True,
+            no_secret_material_returned=True,
+        )
+
+
+class _PrincipalResolver:
+    def resolve(self, principal_id: str, principal_provider: str):
+        if principal_id == "github:mjtrout" and principal_provider == "github":
+            return PrincipalAuthorityRecord(
+                principal_id="github:mjtrout",
+                principal_provider="github",
+                principal_public_key="pub:principal",
+                repo_scope=(REPO,),
+                foundup_scope=(FID,),
+                verified_subject_digest="sha256:verified-subject",
+                reward_account="reward:012",
+                owner_dae="dae:012",
+            )
+        return None
+
+
+class _SnapshotResolver:
+    def resolve(self, digest: str):
+        if digest == "sha256:snap-1":
+            return PermissionSnapshot(
+                evidence_digest="sha256:snap-1",
+                expires_at=NOW + 600,
+                can_write=True,
+                repo_full_name=REPO,
+            )
+        return None
+
+
+def _queue_result():
+    receipt = {
+        "receipt_id": "wre_queue_consumer_1234",
+        "queue_item_id": "queue-1",
+        "slice_id": "FOUNDUP_SCOPED_SAMPLE_PHASE1",
+        "claim_id": "claim-1",
+        "worker_id": "reddog-main-bootstrap",
+        "freshness_receipt_id": "fresh-1",
+        "next_required_gate": NEXT_GATE_SIGNED_AUTHORITY_REQUIRED,
+        "execution_ready": False,
+        "no_queue_mutation_performed": True,
+    }
+    return {
+        "accepted": True,
+        "status": WRE_QUEUE_CONSUMER_DRYRUN_READY,
+        "rejection_reasons": [],
+        "receipt": receipt,
+        "selected_queue_item_id": "queue-1",
+        "selected_slice": "FOUNDUP_SCOPED_SAMPLE_PHASE1",
+        "next_required_gate": NEXT_GATE_SIGNED_AUTHORITY_REQUIRED,
+        "execution_ready": False,
+    }
+
+
+def _profile(**overrides):
+    profile = {
+        "principal_id": "github:mjtrout",
+        "principal_provider": "github",
+        "principal_public_key": "pub:principal",
+        "reddog_id": "reddog:abc123",
+        "reddog_public_key": "pub:reddog",
+        "repo_full_name": REPO,
+        "foundup_id": FID,
+        "allowed_paths": [f"modules/foundups/{FID}/**"],
+        "denied_paths": [],
+        "requested_operation": "create_foundup",
+        "permission_snapshot_digest": "sha256:snap-1",
+        "identity_nonce": "identity-nonce-0001",
+        "work_authority_nonce": "workauth-nonce-0001",
+        "issued_at": NOW - 5,
+        "identity_expires_at": NOW + 3600,
+        "work_authority_expires_at": NOW + 300,
+        "valve_state_required": VALVE_OPEN_WORKTREE_CREATE,
+        "key_epoch": "epoch-1",
+        "consensus_receipt_digest": "sha256:consensus",
+        "sovereign_authorization_digest": "sha256:012-token",
+    }
+    profile.update(overrides)
+    return profile
+
+
+def _dryrun():
+    return planner.plan_reddog_wre_queue_authority_request_dry_run(
+        queue_consumer_result=_queue_result(),
+        authority_profile=_profile(),
+    ).to_dict()
+
+
+def test_explicit_invoke_missing_rejects_before_signer_call() -> None:
+    signer = _MockSigner()
+
+    result = invoke_reddog_wre_queue_authority_runtime(
+        explicit_queue_authority_runtime_requested=False,
+        queue_authority_request_dryrun=_dryrun(),
+        store=InMemoryAuthorityRuntimeStore(),
+        signer=signer,
+        principal_resolver=_PrincipalResolver(),
+        snapshot_resolver=_SnapshotResolver(),
+        now=NOW,
+    )
+
+    assert result.decision == QUEUE_AUTHORITY_RUNTIME_INVOKE_REJECT
+    assert QueueAuthorityRuntimeInvokeReason.EXPLICIT_INVOKE_MISSING in result.rejection_reasons
+    assert signer.requests == []
+
+
+def test_rejected_dryrun_rejects_before_signer_call() -> None:
+    signer = _MockSigner()
+    dryrun = _dryrun()
+    dryrun["accepted"] = False
+
+    result = invoke_reddog_wre_queue_authority_runtime(
+        explicit_queue_authority_runtime_requested=True,
+        queue_authority_request_dryrun=dryrun,
+        store=InMemoryAuthorityRuntimeStore(),
+        signer=signer,
+        principal_resolver=_PrincipalResolver(),
+        snapshot_resolver=_SnapshotResolver(),
+        now=NOW,
+    )
+
+    assert result.decision == QUEUE_AUTHORITY_RUNTIME_INVOKE_REJECT
+    assert QueueAuthorityRuntimeInvokeReason.REQUEST_DRYRUN_NOT_ACCEPTED in result.rejection_reasons
+    assert signer.requests == []
+
+
+def test_invalid_request_payload_rejects_before_signer_call() -> None:
+    signer = _MockSigner()
+    dryrun = _dryrun()
+    dryrun["delegated_authority_request"] = {"work_order_id": "incomplete"}
+
+    result = invoke_reddog_wre_queue_authority_runtime(
+        explicit_queue_authority_runtime_requested=True,
+        queue_authority_request_dryrun=dryrun,
+        store=InMemoryAuthorityRuntimeStore(),
+        signer=signer,
+        principal_resolver=_PrincipalResolver(),
+        snapshot_resolver=_SnapshotResolver(),
+        now=NOW,
+    )
+
+    assert result.decision == QUEUE_AUTHORITY_RUNTIME_INVOKE_REJECT
+    assert QueueAuthorityRuntimeInvokeReason.REQUEST_PAYLOAD_INVALID in result.rejection_reasons
+    assert signer.requests == []
+
+
+def test_default_signer_rejection_is_preserved() -> None:
+    result = invoke_reddog_wre_queue_authority_runtime(
+        explicit_queue_authority_runtime_requested=True,
+        queue_authority_request_dryrun=_dryrun(),
+        store=InMemoryAuthorityRuntimeStore(),
+        signer=None,
+        principal_resolver=_PrincipalResolver(),
+        snapshot_resolver=_SnapshotResolver(),
+        now=NOW,
+    )
+
+    assert result.decision == QUEUE_AUTHORITY_RUNTIME_INVOKE_REJECT
+    assert QueueAuthorityRuntimeInvokeReason.AUTHORITY_RUNTIME_REJECTED in result.rejection_reasons
+    assert RuntimeRejectCode.SIGNER_NOT_CONFIGURED in result.rejection_reasons
+    assert result.authority_result is not None
+    assert result.authority_result.accepted is False
+
+
+def test_invokes_injected_signer_and_issues_authority_without_execution() -> None:
+    signer = _MockSigner()
+    store = InMemoryAuthorityRuntimeStore()
+
+    result = invoke_reddog_wre_queue_authority_runtime(
+        explicit_queue_authority_runtime_requested=True,
+        queue_authority_request_dryrun=_dryrun(),
+        store=store,
+        signer=signer,
+        principal_resolver=_PrincipalResolver(),
+        snapshot_resolver=_SnapshotResolver(),
+        now=NOW,
+    )
+
+    assert result.decision == QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT
+    assert result.rejection_reasons == []
+    assert result.authority_result is not None
+    assert result.authority_result.accepted is True
+    assert result.authority_result.receipt.status == AUTHORITY_ISSUED
+    assert result.authority_result.receipt.no_execution_performed is True
+    assert result.authority_result.receipt.no_worker_spawn_performed is True
+    assert result.authority_result.receipt.no_openclaw_enqueue_performed is True
+    assert len(signer.requests) == 2
+    state = store.load()
+    assert state["issued_authorities"]
+    assert result.no_worker_spawn_performed is True
+    assert result.no_worktree_created is True
+    assert result.no_shell_command_executed is True
+    assert result.no_openclaw_enqueue_performed is True
+    assert result.no_hermes_dispatch_performed is True
+    assert result.no_repo_mutation_performed is True
+    assert result.no_holoindex_reindex_performed is True
+    assert result.no_pr_created is True
+    assert result.no_reward_settlement_performed is True
+
+
+def test_payload_round_trips_into_runtime_request_type() -> None:
+    dryrun = _dryrun()
+    request = dryrun["delegated_authority_request"]
+
+    typed = DelegatedAuthorityRuntimeRequest(
+        work_order_id=str(request["work_order_id"]),
+        principal_id=str(request["principal_id"]),
+        principal_provider=str(request["principal_provider"]),
+        principal_public_key=str(request["principal_public_key"]),
+        reddog_id=str(request["reddog_id"]),
+        reddog_public_key=str(request["reddog_public_key"]),
+        repo_full_name=str(request["repo_full_name"]),
+        foundup_id=str(request["foundup_id"]),
+        allowed_paths=tuple(request["allowed_paths"]),
+        denied_paths=tuple(request["denied_paths"]),
+        requested_operation=str(request["requested_operation"]),
+        permission_snapshot_digest=str(request["permission_snapshot_digest"]),
+        identity_nonce=str(request["identity_nonce"]),
+        work_authority_nonce=str(request["work_authority_nonce"]),
+        issued_at=int(request["issued_at"]),
+        identity_expires_at=int(request["identity_expires_at"]),
+        work_authority_expires_at=int(request["work_authority_expires_at"]),
+        valve_state_required=str(request["valve_state_required"]),
+        key_epoch=str(request["key_epoch"]),
+        consensus_receipt_digest=str(request["consensus_receipt_digest"]),
+        sovereign_authorization_digest=str(request["sovereign_authorization_digest"]),
+    )
+
+    assert typed.to_dict() == request
+
+
+def test_module_has_no_shell_network_worktree_openclaw_hermes_or_holoindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls


### PR DESCRIPTION
## Summary

Implements `REDDOG_WRE_QUEUE_AUTHORITY_RUNTIME_INVOKE_PHASE1`.

This adds an explicit invoke guard that calls the existing delegated-authority signer runtime only from an accepted queue-authority request dry-run and only through injected signer, principal resolver, permission snapshot resolver, and authority store boundaries.

## Boundary

- Explicit invoke required
- Accepted queue-authority request dry-run required
- Default signer remains fail-closed
- May issue signed authority records only through injected signer boundary
- No worker spawn
- No worktree creation
- No shell command execution
- No OpenClaw enqueue
- No Hermes dispatch
- No repo mutation beyond this code change
- No HoloIndex re-index
- No PR creation/publish by this runtime
- No reward settlement
- No execution of authorized work

## Validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_runtime_invoke.py -q` -> 7 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_request_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_runtime_invoke.py modules/communication/moltbot_bridge/tests/test_reddog_signer_delegated_authority_runtime.py -q` -> 32 passed
- `git diff --check` -> clean, Windows autocrlf warnings only
- New module/test are ASCII-clean and NUL-free

## HoloIndex

Read-only probe for `RedDog WRE queue authority runtime invoke signer runtime` did not rank the new module. Recorded as `HOLOINDEX_REDDOG_WRE_QUEUE_AUTHORITY_RUNTIME_INVOKE_INDEX_GAP_PHASE1`. No runtime re-index performed.

## WSP_97 Truth Boundary

- OBSERVED: The delegated-authority signer runtime already exists and defaults fail-closed.
- OBSERVED: The queue-authority request dry-run now builds the signer-runtime request shape.
- OBSERVED: This slice invokes the signer runtime only behind an explicit flag and injected boundaries.
- SPECIFIED_NOT_IMPLEMENTED: automatic signer service provisioning, queue-driven worker execution, autonomous verification/publish, reward ratchet, and live code execution remain downstream.