### PR TITLE
feat(reddog): evaluate valve from queue-authorized chain

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,25 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_WRE_QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_wre_queue_authorized_execution_valve_invoke.py`: an
+  explicit bridge that evaluates the existing RedDog execution valve from a
+  queue-authorized work-order invocation receipt and queue-authorized executor
+  dry-run plan.
+- The guard reconstructs the existing valve request shape, preserves
+  receipt-chain rejection reasons, and only accepts when the valve state matches
+  the expected explicit state, defaulting to `VALVE_OPEN_WORKTREE_CREATE`.
+- Boundary: no worker spawn, worktree creation, shell command, OpenClaw enqueue,
+  Hermes dispatch, repo mutation, PR creation, reward settlement, or HoloIndex
+  re-index.
+- HoloIndex read-only probe for `RedDog queue authorized execution valve invoke`
+  surfaced the existing valve and live-enqueue invoke modules, but did not
+  surface this new bridge before indexing. Recorded as
+  `HOLOINDEX_REDDOG_WRE_QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_INDEX_GAP_PHASE1`;
+  no runtime re-index performed.
+
 ## 2026-07-14: REDDOG_WRE_QUEUE_AUTHORIZED_EXECUTOR_PLAN_DRYRUN_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_execution_valve_invoke.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_execution_valve_invoke.py
@@ -1,0 +1,194 @@
+"""RedDog queue-authorized execution valve explicit invoke guard.
+
+Slice: REDDOG_WRE_QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_PHASE1
+
+This module evaluates the existing RedDog execution valve from a queue-derived,
+signed-authority work-order invocation and a queue-authorized executor-plan
+dry-run. It emits only an execution-valve decision. It does not create
+worktrees, spawn workers, run shell commands, enqueue OpenClaw, dispatch Hermes,
+mutate repository files, publish PRs, settle rewards, or re-index HoloIndex.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    INTAKE_FOUNDUP_JOB,
+    VALVE_CLOSED,
+    VALVE_OPEN_WORKTREE_CREATE,
+    ExecutionValveDecision,
+    ExecutionValveEnvironment,
+    ExecutionValveRequest,
+    evaluate_reddog_execution_valve,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_executor_plan_dryrun import (
+    QUEUE_AUTHORIZED_EXECUTOR_PLAN_DRYRUN_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_verified_authority_work_order_invoke import (
+    QUEUE_VERIFIED_AUTHORITY_WORK_ORDER_INVOKE_ACCEPT,
+)
+
+
+QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_ACCEPT = "QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_ACCEPT"
+QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_REJECT = "QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_REJECT"
+
+
+class QueueAuthorizedExecutionValveInvokeReason:
+    EXPLICIT_INVOKE_MISSING = "REJECT_EXPLICIT_QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_MISSING"
+    WORK_ORDER_INVOCATION_NOT_ACCEPTED = "REJECT_QUEUE_WORK_ORDER_INVOCATION_NOT_ACCEPTED"
+    EXECUTOR_PLAN_NOT_ACCEPTED = "REJECT_QUEUE_EXECUTOR_PLAN_NOT_ACCEPTED"
+    INVOCATION_PAYLOAD_MISSING = "REJECT_INVOCATION_PAYLOAD_MISSING"
+    EXECUTOR_PLAN_PAYLOAD_MISSING = "REJECT_EXECUTOR_PLAN_PAYLOAD_MISSING"
+    VALVE_STATE_NOT_EXPECTED = "REJECT_EXECUTION_VALVE_STATE_NOT_EXPECTED"
+
+
+@dataclass(frozen=True)
+class QueueAuthorizedExecutionValveInvokeResult:
+    decision: str
+    rejection_reasons: List[str] = field(default_factory=list)
+    valve_decision: Optional[ExecutionValveDecision] = None
+    explicit_queue_authorized_execution_valve_requested: bool = False
+    no_worker_spawn_performed: bool = True
+    no_worktree_created: bool = True
+    no_shell_command_executed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pr_created: bool = True
+    no_reward_settlement_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["valve_decision"] = self.valve_decision.to_dict() if self.valve_decision else None
+        return payload
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        candidate = value.to_dict()
+        return candidate if isinstance(candidate, Mapping) else {}
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _minimal_policy_gate_receipt(invocation: Mapping[str, Any]) -> Dict[str, Any]:
+    return {
+        "decision": invocation.get("policy_gate_decision"),
+        "receipt_digest": invocation.get("policy_gate_receipt_digest"),
+        "no_execution_performed": True,
+        "work_order_id": invocation.get("work_order_id"),
+    }
+
+
+def _minimal_reddog_work_order_receipt(invocation: Mapping[str, Any]) -> Dict[str, Any]:
+    return {
+        "receipt_id": invocation.get("receipt_id"),
+        "receipt_digest": invocation.get("receipt_digest"),
+        "policy_gate_receipt_digest": invocation.get("policy_gate_receipt_digest"),
+        "no_execution_performed": True,
+        "work_order_id": invocation.get("work_order_id"),
+    }
+
+
+def _reject(
+    reasons: Sequence[str],
+    *,
+    explicit_requested: bool,
+    valve_decision: Optional[ExecutionValveDecision] = None,
+) -> QueueAuthorizedExecutionValveInvokeResult:
+    return QueueAuthorizedExecutionValveInvokeResult(
+        decision=QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_REJECT,
+        rejection_reasons=list(dict.fromkeys(reasons)),
+        valve_decision=valve_decision,
+        explicit_queue_authorized_execution_valve_requested=explicit_requested,
+    )
+
+
+def invoke_reddog_wre_queue_authorized_execution_valve(
+    *,
+    explicit_queue_authorized_execution_valve_requested: bool,
+    queue_work_order_invocation_result: Mapping[str, Any],
+    queue_executor_plan_result: Mapping[str, Any],
+    work_order: Mapping[str, Any],
+    valve_environment: ExecutionValveEnvironment | Mapping[str, Any],
+    now: Optional[datetime] = None,
+    intake_target: str = INTAKE_FOUNDUP_JOB,
+    expected_valve_state: str = VALVE_OPEN_WORKTREE_CREATE,
+) -> QueueAuthorizedExecutionValveInvokeResult:
+    """Evaluate the execution valve from a queue-authorized receipt chain."""
+
+    if explicit_queue_authorized_execution_valve_requested is not True:
+        return _reject(
+            [QueueAuthorizedExecutionValveInvokeReason.EXPLICIT_INVOKE_MISSING],
+            explicit_requested=False,
+        )
+
+    queue_invocation = _mapping(queue_work_order_invocation_result)
+    if queue_invocation.get("decision") != QUEUE_VERIFIED_AUTHORITY_WORK_ORDER_INVOKE_ACCEPT:
+        return _reject(
+            [QueueAuthorizedExecutionValveInvokeReason.WORK_ORDER_INVOCATION_NOT_ACCEPTED],
+            explicit_requested=True,
+        )
+    invocation_payload = _mapping(queue_invocation.get("invocation_result"))
+    if not invocation_payload:
+        return _reject(
+            [QueueAuthorizedExecutionValveInvokeReason.INVOCATION_PAYLOAD_MISSING],
+            explicit_requested=True,
+        )
+
+    queue_executor = _mapping(queue_executor_plan_result)
+    if queue_executor.get("decision") != QUEUE_AUTHORIZED_EXECUTOR_PLAN_DRYRUN_ACCEPT:
+        return _reject(
+            [QueueAuthorizedExecutionValveInvokeReason.EXECUTOR_PLAN_NOT_ACCEPTED],
+            explicit_requested=True,
+        )
+    executor_payload = _mapping(queue_executor.get("executor_plan_result"))
+    if not executor_payload:
+        return _reject(
+            [QueueAuthorizedExecutionValveInvokeReason.EXECUTOR_PLAN_PAYLOAD_MISSING],
+            explicit_requested=True,
+        )
+
+    valve = evaluate_reddog_execution_valve(
+        ExecutionValveRequest(
+            work_order=work_order,
+            policy_gate_receipt=_minimal_policy_gate_receipt(invocation_payload),
+            reddog_work_order_receipt=_minimal_reddog_work_order_receipt(invocation_payload),
+            invocation_result=invocation_payload,
+            executor_plan_result=executor_payload,
+            intake_target=intake_target,
+            permission_snapshot=_mapping(work_order.get("repo_permission_snapshot")),
+        ),
+        valve_environment,
+        now=now,
+    )
+    if valve.valve_state != expected_valve_state:
+        return _reject(
+            [
+                QueueAuthorizedExecutionValveInvokeReason.VALVE_STATE_NOT_EXPECTED,
+                *valve.rejection_reasons,
+            ],
+            explicit_requested=True,
+            valve_decision=valve,
+        )
+
+    return QueueAuthorizedExecutionValveInvokeResult(
+        decision=QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_ACCEPT,
+        rejection_reasons=[],
+        valve_decision=valve,
+        explicit_queue_authorized_execution_valve_requested=True,
+    )
+
+
+__all__ = [
+    "QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_ACCEPT",
+    "QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_REJECT",
+    "QueueAuthorizedExecutionValveInvokeReason",
+    "QueueAuthorizedExecutionValveInvokeResult",
+    "invoke_reddog_wre_queue_authorized_execution_valve",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_execution_valve_invoke.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_execution_valve_invoke.py
@@ -1,0 +1,384 @@
+"""Tests for REDDOG_WRE_QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    INTAKE_ASSIGNMENT_DISPATCHER,
+    INTAKE_FOUNDUP_JOB,
+    VALVE_CLOSED,
+    VALVE_OPEN_WORKTREE_CREATE,
+    ExecutionValveEnvironment,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_execution_valve_invoke import (
+    QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_ACCEPT,
+    QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_REJECT,
+    QueueAuthorizedExecutionValveInvokeReason,
+    invoke_reddog_wre_queue_authorized_execution_valve,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_executor_plan_dryrun import (
+    QUEUE_AUTHORIZED_EXECUTOR_PLAN_DRYRUN_ACCEPT,
+    QUEUE_AUTHORIZED_EXECUTOR_PLAN_DRYRUN_REJECT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_verified_authority_work_order_invoke import (
+    QUEUE_VERIFIED_AUTHORITY_WORK_ORDER_INVOKE_ACCEPT,
+    QUEUE_VERIFIED_AUTHORITY_WORK_ORDER_INVOKE_REJECT,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_wre_queue_authorized_execution_valve_invoke.py"
+)
+NOW = datetime(2026, 7, 14, 13, 0, 0, tzinfo=timezone.utc)
+WORK_ORDER_ID = "wre-queue-authorized-valve-001"
+REPO = "FOUNDUPS/Foundups-Agent"
+FID = "paccess_001"
+INVOCATION_DIGEST = "sha256:" + ("e" * 64)
+POLICY_DIGEST = "sha256:" + ("f" * 64)
+
+
+def _future_expiry(minutes: int = 30) -> str:
+    return (NOW + timedelta(minutes=minutes)).replace(microsecond=0).isoformat()
+
+
+def _fresh_captured() -> str:
+    return (NOW - timedelta(seconds=30)).replace(microsecond=0).isoformat()
+
+
+def _work_order(**overrides):
+    payload = {
+        "work_order_id": WORK_ORDER_ID,
+        "created_at": _fresh_captured(),
+        "red_dog_instance_id": "reddog-main-bootstrap",
+        "authenticated_principal": "github:mjtrout",
+        "principal_provider": "github",
+        "repo_full_name": REPO,
+        "repo_permission_snapshot": {
+            "permission_level": "write",
+            "captured_at": _fresh_captured(),
+            "source": "mock",
+            "digest": "sha256:snap-1",
+        },
+        "requested_operation": "feature_slice",
+        "authority_tier": "source",
+        "allowed_paths": [f"modules/foundups/{FID}/**"],
+        "denied_paths": [".env", ".git/**"],
+        "branch_name": "feat/paccess-001-valve",
+        "base_ref": "main",
+        "task_summary": "Evaluate queue-authorized execution valve.",
+        "wsp_applicability": ["WSP_34", "WSP_50", "WSP_97"],
+        "holoindex_evidence_refs": [
+            "modules/communication/moltbot_bridge/src/reddog_wre_execution_valve.py"
+        ],
+        "skillz_candidates": [],
+        "required_tests": ["pytest modules/communication/moltbot_bridge/tests"],
+        "required_policy_gates": ["openclaw_policy_gate", "signed_work_order_authority"],
+        "required_reviewers": [],
+        "sentinel_checks": [],
+        "rollback_plan": "Remove worktree and delete branch on abort.",
+        "expiry": _future_expiry(),
+        "nonce": "work-order-nonce-valve",
+        "evidence_digest": "sha256:" + ("a" * 64),
+        "advisory_only_source_packet": {
+            "work_focus_digest": "sha256:" + ("b" * 64),
+            "wsp_prompt_digest": "sha256:" + ("c" * 64),
+            "copy_md_run_trace_digest": "sha256:" + ("d" * 64),
+        },
+        "holoindex_evidence": {
+            "holoindex_query": "RedDog queue authorized execution valve",
+            "holoindex_status": "bundle_json_ok",
+            "code_hits": ["modules/communication/moltbot_bridge/src/reddog_wre_execution_valve.py"],
+            "wsp_hits": ["WSP_framework/src/WSP_34_Git_Operations_Protocol.md"],
+            "skillz_hits": [],
+            "direct_read_fallback_used": True,
+            "index_gap_detected": False,
+            "applicable_wsps": ["WSP_34", "WSP_97"],
+            "evidence_refs": [
+                "modules/communication/moltbot_bridge/src/reddog_wre_execution_valve.py"
+            ],
+            "retrieval_quality": "HIGH",
+            "skillz_gap_detected": False,
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _invocation_payload(**overrides):
+    payload = {
+        "decision": "INVOCATION_ACCEPT",
+        "work_order_id": WORK_ORDER_ID,
+        "policy_gate_decision": "POLICY_ACCEPT",
+        "receipt_id": "reddog-work-order-receipt-001",
+        "receipt_digest": INVOCATION_DIGEST,
+        "no_execution_performed": True,
+        "rejection_reasons": [],
+        "gates_checked": ["signed_work_order_authority"],
+        "idempotent_replay": False,
+        "policy_gate_receipt_digest": POLICY_DIGEST,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _queue_work_order_result(**overrides):
+    payload = {
+        "decision": QUEUE_VERIFIED_AUTHORITY_WORK_ORDER_INVOKE_ACCEPT,
+        "rejection_reasons": [],
+        "invocation_result": _invocation_payload(),
+        "explicit_queue_work_order_invocation_requested": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _executor_payload(**overrides):
+    payload = {
+        "decision": "EXECUTOR_PLAN_ACCEPT",
+        "work_order_id": WORK_ORDER_ID,
+        "plan": {
+            "plan_id": "plan-001",
+            "work_order_id": WORK_ORDER_ID,
+            "proposed_branch_name": "feat/paccess-001-valve",
+            "proposed_worktree_path": "/tmp/.reddog/worktrees/repo/work/nonce/",
+            "lock_key": WORK_ORDER_ID,
+            "allowed_paths": [f"modules/foundups/{FID}/**"],
+            "denied_paths": [".env", ".git/**"],
+            "required_tests": ["pytest modules/communication/moltbot_bridge/tests"],
+            "cleanup_plan": {"on_failure": "remove_worktree_delete_branch"},
+            "phase_receipts": [],
+            "no_mutation_performed": True,
+            "invocation_receipt_digest": INVOCATION_DIGEST,
+            "plan_digest": "sha256:" + ("1" * 64),
+        },
+        "rejection_reasons": [],
+        "rejection_receipt_digest": "",
+        "no_mutation_performed": True,
+        "phase_receipts": [],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _queue_executor_result(**overrides):
+    payload = {
+        "decision": QUEUE_AUTHORIZED_EXECUTOR_PLAN_DRYRUN_ACCEPT,
+        "rejection_reasons": [],
+        "executor_plan_result": _executor_payload(),
+        "explicit_queue_authorized_executor_plan_requested": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _open_env() -> ExecutionValveEnvironment:
+    return ExecutionValveEnvironment(
+        valve_worktree_create_enabled=True,
+        sovereign_worktree_token="012-sovereign-worktree-token",
+    )
+
+
+def test_queue_authorized_chain_opens_expected_worktree_valve_only() -> None:
+    result = invoke_reddog_wre_queue_authorized_execution_valve(
+        explicit_queue_authorized_execution_valve_requested=True,
+        queue_work_order_invocation_result=_queue_work_order_result(),
+        queue_executor_plan_result=_queue_executor_result(),
+        work_order=_work_order(),
+        valve_environment=_open_env(),
+        now=NOW,
+    )
+
+    assert result.decision == QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_ACCEPT
+    assert result.rejection_reasons == []
+    assert result.valve_decision is not None
+    assert result.valve_decision.valve_state == VALVE_OPEN_WORKTREE_CREATE
+    assert result.valve_decision.no_execution_performed is True
+    assert result.no_worktree_created is True
+    assert result.no_shell_command_executed is True
+    assert result.no_openclaw_enqueue_performed is True
+    assert result.no_hermes_dispatch_performed is True
+    assert result.no_repo_mutation_performed is True
+    assert result.no_holoindex_reindex_performed is True
+    assert result.no_pr_created is True
+
+
+def test_explicit_invoke_missing_rejects() -> None:
+    result = invoke_reddog_wre_queue_authorized_execution_valve(
+        explicit_queue_authorized_execution_valve_requested=False,
+        queue_work_order_invocation_result=_queue_work_order_result(),
+        queue_executor_plan_result=_queue_executor_result(),
+        work_order=_work_order(),
+        valve_environment=_open_env(),
+    )
+
+    assert result.decision == QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_REJECT
+    assert QueueAuthorizedExecutionValveInvokeReason.EXPLICIT_INVOKE_MISSING in result.rejection_reasons
+    assert result.valve_decision is None
+
+
+def test_default_closed_valve_rejects_with_decision() -> None:
+    result = invoke_reddog_wre_queue_authorized_execution_valve(
+        explicit_queue_authorized_execution_valve_requested=True,
+        queue_work_order_invocation_result=_queue_work_order_result(),
+        queue_executor_plan_result=_queue_executor_result(),
+        work_order=_work_order(),
+        valve_environment=ExecutionValveEnvironment(),
+        now=NOW,
+    )
+
+    assert result.decision == QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_REJECT
+    assert QueueAuthorizedExecutionValveInvokeReason.VALVE_STATE_NOT_EXPECTED in result.rejection_reasons
+    assert "explicit_valve_flag_missing" in result.rejection_reasons
+    assert result.valve_decision is not None
+    assert result.valve_decision.valve_state == VALVE_CLOSED
+
+
+def test_worktree_valve_without_token_rejects() -> None:
+    result = invoke_reddog_wre_queue_authorized_execution_valve(
+        explicit_queue_authorized_execution_valve_requested=True,
+        queue_work_order_invocation_result=_queue_work_order_result(),
+        queue_executor_plan_result=_queue_executor_result(),
+        work_order=_work_order(),
+        valve_environment=ExecutionValveEnvironment(valve_worktree_create_enabled=True),
+        now=NOW,
+    )
+
+    assert result.decision == QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_REJECT
+    assert "worktree_valve_missing_sovereign_token" in result.rejection_reasons
+    assert result.valve_decision is not None
+    assert result.valve_decision.valve_state == VALVE_CLOSED
+
+
+def test_rejected_queue_work_order_invocation_blocks_before_valve() -> None:
+    result = invoke_reddog_wre_queue_authorized_execution_valve(
+        explicit_queue_authorized_execution_valve_requested=True,
+        queue_work_order_invocation_result=_queue_work_order_result(
+            decision=QUEUE_VERIFIED_AUTHORITY_WORK_ORDER_INVOKE_REJECT
+        ),
+        queue_executor_plan_result=_queue_executor_result(),
+        work_order=_work_order(),
+        valve_environment=_open_env(),
+        now=NOW,
+    )
+
+    assert result.decision == QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_REJECT
+    assert (
+        QueueAuthorizedExecutionValveInvokeReason.WORK_ORDER_INVOCATION_NOT_ACCEPTED
+        in result.rejection_reasons
+    )
+    assert result.valve_decision is None
+
+
+def test_rejected_queue_executor_plan_blocks_before_valve() -> None:
+    result = invoke_reddog_wre_queue_authorized_execution_valve(
+        explicit_queue_authorized_execution_valve_requested=True,
+        queue_work_order_invocation_result=_queue_work_order_result(),
+        queue_executor_plan_result=_queue_executor_result(
+            decision=QUEUE_AUTHORIZED_EXECUTOR_PLAN_DRYRUN_REJECT
+        ),
+        work_order=_work_order(),
+        valve_environment=_open_env(),
+        now=NOW,
+    )
+
+    assert result.decision == QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_REJECT
+    assert QueueAuthorizedExecutionValveInvokeReason.EXECUTOR_PLAN_NOT_ACCEPTED in result.rejection_reasons
+    assert result.valve_decision is None
+
+
+def test_receipt_chain_mismatch_rejects_through_valve() -> None:
+    bad_executor = _executor_payload()
+    bad_executor["plan"] = dict(bad_executor["plan"])
+    bad_executor["plan"]["invocation_receipt_digest"] = "sha256:" + ("9" * 64)
+    result = invoke_reddog_wre_queue_authorized_execution_valve(
+        explicit_queue_authorized_execution_valve_requested=True,
+        queue_work_order_invocation_result=_queue_work_order_result(),
+        queue_executor_plan_result=_queue_executor_result(executor_plan_result=bad_executor),
+        work_order=_work_order(),
+        valve_environment=_open_env(),
+        now=NOW,
+    )
+
+    assert result.decision == QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_REJECT
+    assert "executor_plan_invocation_digest_mismatch" in result.rejection_reasons
+    assert result.valve_decision is not None
+    assert result.valve_decision.valve_state == VALVE_CLOSED
+
+
+def test_forbidden_assignment_dispatcher_target_rejects() -> None:
+    result = invoke_reddog_wre_queue_authorized_execution_valve(
+        explicit_queue_authorized_execution_valve_requested=True,
+        queue_work_order_invocation_result=_queue_work_order_result(),
+        queue_executor_plan_result=_queue_executor_result(),
+        work_order=_work_order(),
+        valve_environment=_open_env(),
+        intake_target=INTAKE_ASSIGNMENT_DISPATCHER,
+        now=NOW,
+    )
+
+    assert result.decision == QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_REJECT
+    assert "assignment_dispatcher_forbidden_target" in result.rejection_reasons
+
+
+def test_result_is_json_serializable() -> None:
+    result = invoke_reddog_wre_queue_authorized_execution_valve(
+        explicit_queue_authorized_execution_valve_requested=True,
+        queue_work_order_invocation_result=_queue_work_order_result(),
+        queue_executor_plan_result=_queue_executor_result(),
+        work_order=_work_order(),
+        valve_environment=_open_env(),
+        intake_target=INTAKE_FOUNDUP_JOB,
+        now=NOW,
+    )
+
+    payload = result.to_dict()
+    assert payload["decision"] == QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_ACCEPT
+    assert payload["valve_decision"]["valve_state"] == VALVE_OPEN_WORKTREE_CREATE
+    json.dumps(payload)
+
+
+def test_module_has_no_worktree_shell_openclaw_hermes_or_holoindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls
+
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    forbidden_tokens = (
+        "create_reddog_wre_worktree(",
+        "git ",
+        "gh ",
+        "worktree add",
+        "openclaw_supervisor",
+        "hermes_job_executor",
+        "holo_index.py --index",
+    )
+    for token in forbidden_tokens:
+        assert token not in source


### PR DESCRIPTION
## Summary
- add explicit queue-authorized receipt-chain -> execution valve bridge
- reuse existing evaluate_reddog_execution_valve
- require accepted queue work-order invocation and queue executor dry-run plan before valve evaluation
- accept only the expected explicit valve state, defaulting to VALVE_OPEN_WORKTREE_CREATE

## Validation
- pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_execution_valve_invoke.py modules/communication/moltbot_bridge/tests/test_reddog_wre_execution_valve.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_executor_plan_dryrun.py -q
- git diff --check
- new files ASCII/NUL check

## Truth boundary
- no worker spawn, worktree creation, shell command, OpenClaw enqueue, Hermes dispatch, repo mutation, PR creation, reward settlement, or HoloIndex re-index

Worker-Lane: red-dog-operational-spine
Slice: REDDOG_WRE_QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_PHASE1