### PR TITLE
feat(reddog): invoke bounded pilot from queue-authorized chain

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,27 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_WRE_QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_wre_queue_authorized_bounded_worker_pilot_invoke.py`:
+  an explicit bridge from accepted queue-authorized worktree-create, generic
+  writer dry-run, and governed shell dry-run receipts into the existing
+  bounded worktree worker execution pilot.
+- The bridge binds work-order IDs across the worktree-create result, writer
+  receipt, shell receipt, and work order before allowing the pilot to
+  materialize declared text artifacts inside the already-created isolated
+  worktree.
+- Boundary: this may perform the bounded pilot file materialization inside the
+  isolated worktree only. It does not execute shell commands, enqueue
+  OpenClaw, dispatch Hermes, create PRs, merge, settle rewards, or mutate
+  HoloIndex.
+- HoloIndex read-only probe for `RedDog queue authorized bounded worker pilot
+  invoke` surfaced worker-queue/runtime-invocation adjacent files and WSP docs,
+  but did not surface this new bridge before indexing. Recorded as
+  `HOLOINDEX_REDDOG_WRE_QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_INDEX_GAP_PHASE1`;
+  no runtime re-index performed.
+
 ## 2026-07-14: REDDOG_WRE_QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_bounded_worker_pilot_invoke.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_bounded_worker_pilot_invoke.py
@@ -1,0 +1,316 @@
+"""RedDog queue-authorized bounded worker pilot explicit invoke guard.
+
+Slice: REDDOG_WRE_QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_PHASE1
+
+This module consumes an accepted queue-authorized worktree-create result plus
+accepted generic-writer and governed-shell dry-run receipts, then invokes the
+existing bounded worktree worker pilot. It may materialize only the declared
+text artifacts inside the already-created isolated worktree. It does not run
+shell commands, enqueue OpenClaw, dispatch Hermes, create PRs, merge, settle
+rewards, or mutate HoloIndex.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_bounded_worktree_worker_execution_pilot import (
+    BOUNDED_WORKTREE_PILOT_ACCEPT,
+    BoundedWorktreeWorkerExecutionPilotResult,
+    run_bounded_worktree_worker_execution_pilot,
+)
+from modules.communication.moltbot_bridge.src.reddog_generic_agent_worktree_writer_dryrun import (
+    GENERIC_WRITER_DRYRUN_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_governed_shell_runner_dryrun import (
+    GOVERNED_SHELL_DRYRUN_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_operational_spine import (
+    WORKTREE_SPINE_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_worktree_create_invoke import (
+    QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_worktree_create import (
+    WORKTREE_CREATE_ACCEPT,
+)
+
+
+QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_ACCEPT = (
+    "QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_ACCEPT"
+)
+QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_REJECT = (
+    "QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_REJECT"
+)
+
+
+class QueueAuthorizedBoundedWorkerPilotInvokeReason:
+    EXPLICIT_INVOKE_MISSING = "REJECT_EXPLICIT_QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_MISSING"
+    WORKTREE_CREATE_NOT_ACCEPTED = "REJECT_QUEUE_WORKTREE_CREATE_NOT_ACCEPTED"
+    WORKTREE_CREATE_PAYLOAD_MISSING = "REJECT_WORKTREE_CREATE_PAYLOAD_MISSING"
+    WORKTREE_CREATE_PAYLOAD_NOT_ACCEPTED = "REJECT_WORKTREE_CREATE_PAYLOAD_NOT_ACCEPTED"
+    WORKTREE_CREATE_MUTATION_FLAGS_INVALID = "REJECT_WORKTREE_CREATE_MUTATION_FLAGS_INVALID"
+    GENERIC_WRITER_NOT_ACCEPTED = "REJECT_GENERIC_WRITER_DRYRUN_NOT_ACCEPTED"
+    GENERIC_WRITER_RECEIPT_MISSING = "REJECT_GENERIC_WRITER_RECEIPT_MISSING"
+    GOVERNED_SHELL_NOT_ACCEPTED = "REJECT_GOVERNED_SHELL_DRYRUN_NOT_ACCEPTED"
+    GOVERNED_SHELL_RECEIPT_MISSING = "REJECT_GOVERNED_SHELL_RECEIPT_MISSING"
+    WORK_ORDER_ID_MISMATCH = "REJECT_WORK_ORDER_ID_MISMATCH"
+    ARTIFACT_CONTENTS_INVALID = "REJECT_ARTIFACT_CONTENTS_INVALID"
+    PILOT_NOT_ACCEPTED = "REJECT_BOUNDED_WORKTREE_PILOT_NOT_ACCEPTED"
+
+
+@dataclass(frozen=True)
+class QueueAuthorizedBoundedWorkerPilotInvokeResult:
+    decision: str
+    rejection_reasons: List[str] = field(default_factory=list)
+    pilot_result: Optional[BoundedWorktreeWorkerExecutionPilotResult] = None
+    explicit_queue_authorized_bounded_worker_pilot_requested: bool = False
+    bounded_task_execution_performed: bool = False
+    bounded_file_edit_performed: bool = False
+    shell_command_executed: bool = False
+    draft_pr_created: bool = False
+    merge_performed: bool = False
+    openclaw_enqueue_performed: bool = False
+    hermes_dispatch_performed: bool = False
+    reward_settlement_performed: bool = False
+    holoindex_reindex_performed: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["pilot_result"] = self.pilot_result.to_dict() if self.pilot_result else None
+        return payload
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        candidate = value.to_dict()
+        return candidate if isinstance(candidate, Mapping) else {}
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _digest(payload: Any) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dedupe(values: Sequence[str]) -> List[str]:
+    return list(dict.fromkeys(str(v) for v in values if str(v or "").strip()))
+
+
+def _reject(
+    reasons: Sequence[str],
+    *,
+    explicit_requested: bool,
+    pilot_result: Optional[BoundedWorktreeWorkerExecutionPilotResult] = None,
+) -> QueueAuthorizedBoundedWorkerPilotInvokeResult:
+    return QueueAuthorizedBoundedWorkerPilotInvokeResult(
+        decision=QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_REJECT,
+        rejection_reasons=_dedupe(reasons),
+        pilot_result=pilot_result,
+        explicit_queue_authorized_bounded_worker_pilot_requested=explicit_requested,
+        bounded_task_execution_performed=bool(
+            pilot_result.task_execution_performed if pilot_result else False
+        ),
+        bounded_file_edit_performed=bool(
+            pilot_result.file_edit_performed if pilot_result else False
+        ),
+        shell_command_executed=bool(pilot_result.shell_command_executed if pilot_result else False),
+        draft_pr_created=bool(pilot_result.draft_pr_created if pilot_result else False),
+        merge_performed=bool(pilot_result.merge_performed if pilot_result else False),
+        openclaw_enqueue_performed=bool(
+            pilot_result.openclaw_enqueue_performed if pilot_result else False
+        ),
+        hermes_dispatch_performed=bool(pilot_result.hermes_dispatch_performed if pilot_result else False),
+        reward_settlement_performed=bool(
+            pilot_result.reward_settlement_performed if pilot_result else False
+        ),
+        holoindex_reindex_performed=bool(
+            pilot_result.holoindex_reindex_performed if pilot_result else False
+        ),
+    )
+
+
+def _writer_receipt(writer_result: Mapping[str, Any]) -> Mapping[str, Any]:
+    return _mapping(writer_result.get("receipt"))
+
+
+def _shell_receipt(shell_result: Mapping[str, Any]) -> Mapping[str, Any]:
+    return _mapping(shell_result.get("receipt"))
+
+
+def _work_order_ids(
+    *,
+    work_order: Mapping[str, Any],
+    worktree_create: Mapping[str, Any],
+    writer_receipt: Mapping[str, Any],
+    shell_receipt: Mapping[str, Any],
+) -> List[str]:
+    return [
+        str(work_order.get("work_order_id") or ""),
+        str(worktree_create.get("work_order_id") or ""),
+        str(writer_receipt.get("work_order_id") or ""),
+        str(shell_receipt.get("work_order_id") or ""),
+    ]
+
+
+def _ids_match(ids: Sequence[str]) -> bool:
+    return bool(ids) and bool(ids[0]) and all(value == ids[0] for value in ids)
+
+
+def _spine_payload(
+    *,
+    work_order_id: str,
+    queue_worktree_create_result: Mapping[str, Any],
+    worktree_create_result: Mapping[str, Any],
+) -> Dict[str, Any]:
+    return {
+        "decision": WORKTREE_SPINE_ACCEPT,
+        "work_order_id": work_order_id,
+        "result_digest": _digest(
+            {
+                "queue_worktree_create_result": queue_worktree_create_result,
+                "worktree_create_result": worktree_create_result,
+            }
+        ),
+        "no_task_execution_performed": True,
+        "no_file_edit_performed": True,
+        "no_pr_created": True,
+        "no_live_openclaw_enqueue": True,
+        "no_hermes_dispatch": True,
+        "merge_performed": False,
+        "worktree_create_result": dict(worktree_create_result),
+    }
+
+
+def invoke_reddog_wre_queue_authorized_bounded_worker_pilot(
+    *,
+    explicit_queue_authorized_bounded_worker_pilot_requested: bool,
+    queue_worktree_create_result: Mapping[str, Any],
+    generic_writer_dryrun_result: Mapping[str, Any],
+    governed_shell_dryrun_result: Mapping[str, Any],
+    artifact_contents: Mapping[str, Any],
+    work_order: Mapping[str, Any],
+    repo_root: Path,
+    operation_cwd: Optional[Path] = None,
+    holoindex_evidence: Optional[Mapping[str, Any]] = None,
+) -> QueueAuthorizedBoundedWorkerPilotInvokeResult:
+    """Materialize bounded artifacts only after the queue-authorized chain accepts."""
+
+    if explicit_queue_authorized_bounded_worker_pilot_requested is not True:
+        return _reject(
+            [QueueAuthorizedBoundedWorkerPilotInvokeReason.EXPLICIT_INVOKE_MISSING],
+            explicit_requested=False,
+        )
+
+    reasons: List[str] = []
+    queue_worktree = _mapping(queue_worktree_create_result)
+    if queue_worktree.get("decision") != QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_ACCEPT:
+        reasons.append(QueueAuthorizedBoundedWorkerPilotInvokeReason.WORKTREE_CREATE_NOT_ACCEPTED)
+
+    worktree_create = _mapping(queue_worktree.get("worktree_create_result"))
+    if not worktree_create:
+        reasons.append(QueueAuthorizedBoundedWorkerPilotInvokeReason.WORKTREE_CREATE_PAYLOAD_MISSING)
+    elif worktree_create.get("decision") != WORKTREE_CREATE_ACCEPT:
+        reasons.append(
+            QueueAuthorizedBoundedWorkerPilotInvokeReason.WORKTREE_CREATE_PAYLOAD_NOT_ACCEPTED
+        )
+
+    if worktree_create and (
+        worktree_create.get("no_task_execution_performed") is not True
+        or worktree_create.get("no_file_edit_performed") is not True
+        or worktree_create.get("no_pr_created") is not True
+        or worktree_create.get("merge_performed") is not False
+    ):
+        reasons.append(
+            QueueAuthorizedBoundedWorkerPilotInvokeReason.WORKTREE_CREATE_MUTATION_FLAGS_INVALID
+        )
+
+    writer = _mapping(generic_writer_dryrun_result)
+    writer_receipt = _writer_receipt(writer)
+    if writer.get("decision") != GENERIC_WRITER_DRYRUN_ACCEPT:
+        reasons.append(QueueAuthorizedBoundedWorkerPilotInvokeReason.GENERIC_WRITER_NOT_ACCEPTED)
+    if not writer_receipt:
+        reasons.append(QueueAuthorizedBoundedWorkerPilotInvokeReason.GENERIC_WRITER_RECEIPT_MISSING)
+
+    shell = _mapping(governed_shell_dryrun_result)
+    shell_receipt = _shell_receipt(shell)
+    if shell.get("decision") != GOVERNED_SHELL_DRYRUN_ACCEPT:
+        reasons.append(QueueAuthorizedBoundedWorkerPilotInvokeReason.GOVERNED_SHELL_NOT_ACCEPTED)
+    if not shell_receipt:
+        reasons.append(QueueAuthorizedBoundedWorkerPilotInvokeReason.GOVERNED_SHELL_RECEIPT_MISSING)
+
+    if worktree_create and writer_receipt and shell_receipt:
+        if not _ids_match(
+            _work_order_ids(
+                work_order=work_order,
+                worktree_create=worktree_create,
+                writer_receipt=writer_receipt,
+                shell_receipt=shell_receipt,
+            )
+        ):
+            reasons.append(QueueAuthorizedBoundedWorkerPilotInvokeReason.WORK_ORDER_ID_MISMATCH)
+
+    if not isinstance(artifact_contents, Mapping):
+        reasons.append(QueueAuthorizedBoundedWorkerPilotInvokeReason.ARTIFACT_CONTENTS_INVALID)
+
+    if reasons:
+        return _reject(reasons, explicit_requested=True)
+
+    work_order_id = str(work_order.get("work_order_id"))
+    request = {
+        "work_order_id": work_order_id,
+        "repo_root": str(Path(repo_root)),
+        "worktree_path": str(worktree_create.get("worktree_path") or ""),
+        "operation_cwd": str(operation_cwd or worktree_create.get("worktree_path") or ""),
+        "canonical_root": str(writer_receipt.get("canonical_root") or ""),
+        "worktree_spine_result": _spine_payload(
+            work_order_id=work_order_id,
+            queue_worktree_create_result=queue_worktree,
+            worktree_create_result=worktree_create,
+        ),
+        "generic_writer_dryrun_result": writer,
+        "governed_shell_dryrun_result": shell,
+        "artifact_contents": dict(artifact_contents),
+        "holoindex_evidence": dict(holoindex_evidence or work_order.get("holoindex_evidence") or {}),
+    }
+    pilot = run_bounded_worktree_worker_execution_pilot(request)
+    if pilot.decision != BOUNDED_WORKTREE_PILOT_ACCEPT:
+        return _reject(
+            [
+                QueueAuthorizedBoundedWorkerPilotInvokeReason.PILOT_NOT_ACCEPTED,
+                *pilot.rejection_reasons,
+            ],
+            explicit_requested=True,
+            pilot_result=pilot,
+        )
+
+    return QueueAuthorizedBoundedWorkerPilotInvokeResult(
+        decision=QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_ACCEPT,
+        rejection_reasons=[],
+        pilot_result=pilot,
+        explicit_queue_authorized_bounded_worker_pilot_requested=True,
+        bounded_task_execution_performed=pilot.task_execution_performed,
+        bounded_file_edit_performed=pilot.file_edit_performed,
+        shell_command_executed=pilot.shell_command_executed,
+        draft_pr_created=pilot.draft_pr_created,
+        merge_performed=pilot.merge_performed,
+        openclaw_enqueue_performed=pilot.openclaw_enqueue_performed,
+        hermes_dispatch_performed=pilot.hermes_dispatch_performed,
+        reward_settlement_performed=pilot.reward_settlement_performed,
+        holoindex_reindex_performed=pilot.holoindex_reindex_performed,
+    )
+
+
+__all__ = [
+    "QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_ACCEPT",
+    "QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_REJECT",
+    "QueueAuthorizedBoundedWorkerPilotInvokeReason",
+    "QueueAuthorizedBoundedWorkerPilotInvokeResult",
+    "invoke_reddog_wre_queue_authorized_bounded_worker_pilot",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_bounded_worker_pilot_invoke.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_bounded_worker_pilot_invoke.py
@@ -1,0 +1,489 @@
+"""Tests for REDDOG_WRE_QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_generic_agent_worktree_writer_dryrun import (
+    GENERIC_WRITER_DRYRUN_ACCEPT,
+    GenericAgentWorktreeDomainProfile,
+    plan_generic_agent_worktree_writer_dry_run,
+)
+from modules.communication.moltbot_bridge.src.reddog_operator_loop_wardrobe_selection import (
+    EXECUTION_GOVERNED_CANDIDATE,
+    WARDROBE_SELECTION_ACCEPT,
+    WARDROBE_SOVEREIGN_EXECUTION,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_work_order_policy_gate import (
+    SIGNATURE_GATE_ACCEPTED,
+)
+from modules.communication.moltbot_bridge.src.reddog_signed_receipt_chain import (
+    SIGNED_RECEIPT_CHAIN_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    VALVE_OPEN_WORKTREE_CREATE,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_governed_shell_runner_dryrun import (
+    GOVERNED_SHELL_DRYRUN_ACCEPT,
+    GovernedShellCommandProfile,
+    plan_governed_shell_runner_dry_run,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_bounded_worker_pilot_invoke import (
+    QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_ACCEPT,
+    QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_REJECT,
+    QueueAuthorizedBoundedWorkerPilotInvokeReason,
+    invoke_reddog_wre_queue_authorized_bounded_worker_pilot,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_worktree_create_invoke import (
+    QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_ACCEPT,
+    QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_REJECT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_worktree_create import (
+    WORKTREE_CREATE_ACCEPT,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_wre_queue_authorized_bounded_worker_pilot_invoke.py"
+)
+WORK_ORDER_ID = "wo-queue-bounded-pilot-1"
+DOMAIN_ID = "reddog_queue_pilot"
+ARTIFACT = (
+    "modules/communication/moltbot_bridge/tests/fixtures/"
+    f"{DOMAIN_ID}/README.md"
+)
+
+
+def _selection_receipt() -> dict:
+    return {
+        "decision": WARDROBE_SELECTION_ACCEPT,
+        "selected_wardrobe": WARDROBE_SOVEREIGN_EXECUTION,
+        "execution_plane": EXECUTION_GOVERNED_CANDIDATE,
+        "no_execution_performed": True,
+    }
+
+
+def _signed_authority(work_order_id: str = WORK_ORDER_ID) -> dict:
+    return {
+        "accepted": True,
+        "signature_gate_status": SIGNATURE_GATE_ACCEPTED,
+        "work_order_id": work_order_id,
+        "permission_snapshot_digest": "sha256:perm",
+        "signature_gate_digest": "sha256:signed-authority",
+    }
+
+
+def _receipt_chain() -> dict:
+    return {
+        "accepted": True,
+        "decision": SIGNED_RECEIPT_CHAIN_ACCEPT,
+        "terminal_receipt_hash": "sha256:terminal",
+        "no_execution_performed": True,
+        "no_reward_settlement_performed": True,
+    }
+
+
+def _valve() -> dict:
+    return {
+        "valve_state": VALVE_OPEN_WORKTREE_CREATE,
+        "decision_digest": "sha256:valve",
+        "rejection_reasons": [],
+        "no_execution_performed": True,
+    }
+
+
+def _domain_profile() -> GenericAgentWorktreeDomainProfile:
+    return GenericAgentWorktreeDomainProfile(
+        profile_id="queue_bounded_pilot_docs_patch",
+        operation="queue_bounded_pilot_docs_patch",
+        artifact_contract_type="text_patch",
+        domain_id_pattern=r"[a-z][a-z0-9_]{2,49}",
+        canonical_root_template=(
+            "modules/communication/moltbot_bridge/tests/fixtures/{domain_id}"
+        ),
+        allowed_path_patterns=[
+            "modules/communication/moltbot_bridge/tests/fixtures/{domain_id}/**"
+        ],
+        denied_path_patterns=["**/.env", "**/secrets/**"],
+        required_tests=[
+            "python -m pytest "
+            "modules/communication/moltbot_bridge/tests/"
+            "test_reddog_wre_queue_authorized_bounded_worker_pilot_invoke.py -q"
+        ],
+        branch_prefix="feat/",
+        draft_pr_only=True,
+        consensus_required=False,
+    )
+
+
+def _shell_profile() -> GovernedShellCommandProfile:
+    return GovernedShellCommandProfile(
+        profile_id="queue_bounded_pilot_pytest",
+        command_kind="test",
+        argv_prefix=["python", "-m", "pytest"],
+        allowed_arg_patterns=[r"modules/[A-Za-z0-9_./-]+\.py", r"-q"],
+        denied_arg_patterns=[r".*--index-all.*", r".*\.env.*", r".*WSP_framework.*"],
+        requires_cwd_guard=True,
+        requires_worktree=True,
+        timeout_seconds=300,
+        max_stdout_bytes=100000,
+        max_stderr_bytes=100000,
+        secret_env_refs=[],
+        output_redaction_policy="strict",
+        draft_pr_only=True,
+        consensus_required=False,
+        repo_sensitive=True,
+    )
+
+
+def _work_order() -> dict:
+    return {
+        "work_order_id": WORK_ORDER_ID,
+        "repo_full_name": "FOUNDUPS/Foundups-Agent",
+        "requested_operation": "queue_bounded_pilot_docs_patch",
+        "allowed_paths": [
+            f"modules/communication/moltbot_bridge/tests/fixtures/{DOMAIN_ID}/**"
+        ],
+        "denied_paths": [".env", ".git/**"],
+        "holoindex_evidence": {
+            "index_gap_detected": False,
+            "retrieval_quality": "HIGH",
+            "holoindex_freshness_receipt_digest": "sha256:holo-fresh",
+        },
+    }
+
+
+def _queue_worktree_result(worktree: Path, *, decision: str | None = None) -> dict:
+    return {
+        "decision": decision or QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_ACCEPT,
+        "rejection_reasons": [],
+        "explicit_queue_authorized_worktree_create_requested": True,
+        "worktree_create_result": {
+            "decision": WORKTREE_CREATE_ACCEPT,
+            "work_order_id": WORK_ORDER_ID,
+            "branch_name": "feat/reddog-queue-bounded-pilot",
+            "worktree_path": str(worktree),
+            "plan_id": "plan-queue-bounded-pilot",
+            "plan_digest": "sha256:plan",
+            "valve_decision_digest": "sha256:valve",
+            "rejection_reasons": [],
+            "phase_receipts": [],
+            "no_task_execution_performed": True,
+            "no_file_edit_performed": True,
+            "no_pr_created": True,
+            "merge_performed": False,
+            "main_checkout_untouched": True,
+            "cleanup_plan": {"status": "cleanup_planned"},
+            "result_digest": "sha256:worktree-create",
+        },
+        "no_task_execution_performed": True,
+        "no_file_edit_performed": True,
+        "no_shell_command_executed": True,
+        "no_openclaw_enqueue_performed": True,
+        "no_hermes_dispatch_performed": True,
+        "no_pr_created": True,
+        "no_reward_settlement_performed": True,
+        "no_holoindex_reindex_performed": True,
+    }
+
+
+def _valid_bundle(tmp_path: Path) -> dict:
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "isolated-worktree"
+    repo.mkdir()
+    worktree.mkdir()
+    writer = plan_generic_agent_worktree_writer_dry_run(
+        {
+            "work_order_id": WORK_ORDER_ID,
+            "operation": "queue_bounded_pilot_docs_patch",
+            "domain_id": DOMAIN_ID,
+            "domain_profile": _domain_profile(),
+            "planned_artifacts": [ARTIFACT],
+            "requested_allowed_paths": [
+                f"modules/communication/moltbot_bridge/tests/fixtures/{DOMAIN_ID}/**"
+            ],
+            "target_branch": "feat/reddog-queue-bounded-pilot",
+            "repo_root": str(repo),
+            "worktree_path": str(worktree),
+            "operation_cwd": str(worktree),
+            "selection_receipt": _selection_receipt(),
+            "signed_authority": _signed_authority(),
+            "signed_receipt_chain": _receipt_chain(),
+            "execution_valve_decision": _valve(),
+            "permission_snapshot_digest": "sha256:perm",
+            "holoindex_evidence": {"index_gap_detected": False},
+        }
+    )
+    assert writer.decision == GENERIC_WRITER_DRYRUN_ACCEPT
+    shell = plan_governed_shell_runner_dry_run(
+        {
+            "work_order_id": WORK_ORDER_ID,
+            "profile": _shell_profile(),
+            "argv": [
+                "python",
+                "-m",
+                "pytest",
+                "modules/communication/moltbot_bridge/tests/"
+                "test_reddog_wre_queue_authorized_bounded_worker_pilot_invoke.py",
+                "-q",
+            ],
+            "operation_cwd": str(worktree),
+            "worktree_path": str(worktree),
+            "repo_root": str(repo),
+            "selection_receipt": _selection_receipt(),
+            "signed_authority": _signed_authority(),
+            "signed_receipt_chain": _receipt_chain(),
+            "execution_valve_decision": _valve(),
+            "generic_writer_dryrun_receipt": writer.receipt.to_dict(),
+            "permission_snapshot_digest": "sha256:perm",
+            "stdin_policy": "none",
+            "env_policy": {"scrubbed": True},
+            "holoindex_evidence": {
+                "index_gap_detected": False,
+                "holoindex_freshness_receipt_digest": "sha256:holo-fresh",
+            },
+        }
+    )
+    assert shell.decision == GOVERNED_SHELL_DRYRUN_ACCEPT
+    return {
+        "repo_root": repo,
+        "worktree": worktree,
+        "work_order": _work_order(),
+        "queue_worktree_create_result": _queue_worktree_result(worktree),
+        "generic_writer_dryrun_result": writer.to_dict(),
+        "governed_shell_dryrun_result": shell.to_dict(),
+        "artifact_contents": {
+            ARTIFACT: (
+                "# RedDog Queue Pilot\n\n"
+                "This file exists only inside the queue-authorized worktree.\n"
+            )
+        },
+    }
+
+
+def _invoke(bundle: dict):
+    return invoke_reddog_wre_queue_authorized_bounded_worker_pilot(
+        explicit_queue_authorized_bounded_worker_pilot_requested=True,
+        queue_worktree_create_result=bundle["queue_worktree_create_result"],
+        generic_writer_dryrun_result=bundle["generic_writer_dryrun_result"],
+        governed_shell_dryrun_result=bundle["governed_shell_dryrun_result"],
+        artifact_contents=bundle["artifact_contents"],
+        work_order=bundle["work_order"],
+        repo_root=bundle["repo_root"],
+    )
+
+
+def test_queue_authorized_chain_materializes_declared_artifact_only(tmp_path: Path) -> None:
+    bundle = _valid_bundle(tmp_path)
+
+    result = _invoke(bundle)
+
+    assert result.decision == QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_ACCEPT
+    assert result.rejection_reasons == []
+    assert result.pilot_result is not None
+    assert result.bounded_task_execution_performed is True
+    assert result.bounded_file_edit_performed is True
+    assert result.shell_command_executed is False
+    assert result.draft_pr_created is False
+    assert result.merge_performed is False
+    assert result.openclaw_enqueue_performed is False
+    assert result.hermes_dispatch_performed is False
+    assert result.reward_settlement_performed is False
+    assert result.holoindex_reindex_performed is False
+    assert (bundle["worktree"] / ARTIFACT).exists()
+    assert not (bundle["repo_root"] / ARTIFACT).exists()
+
+
+def test_explicit_invoke_missing_rejects_before_write(tmp_path: Path) -> None:
+    bundle = _valid_bundle(tmp_path)
+
+    result = invoke_reddog_wre_queue_authorized_bounded_worker_pilot(
+        explicit_queue_authorized_bounded_worker_pilot_requested=False,
+        queue_worktree_create_result=bundle["queue_worktree_create_result"],
+        generic_writer_dryrun_result=bundle["generic_writer_dryrun_result"],
+        governed_shell_dryrun_result=bundle["governed_shell_dryrun_result"],
+        artifact_contents=bundle["artifact_contents"],
+        work_order=bundle["work_order"],
+        repo_root=bundle["repo_root"],
+    )
+
+    assert result.decision == QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_REJECT
+    assert (
+        QueueAuthorizedBoundedWorkerPilotInvokeReason.EXPLICIT_INVOKE_MISSING
+        in result.rejection_reasons
+    )
+    assert not (bundle["worktree"] / ARTIFACT).exists()
+
+
+def test_rejected_queue_worktree_blocks_before_write(tmp_path: Path) -> None:
+    bundle = _valid_bundle(tmp_path)
+    bundle["queue_worktree_create_result"] = _queue_worktree_result(
+        bundle["worktree"], decision=QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_REJECT
+    )
+
+    result = _invoke(bundle)
+
+    assert result.decision == QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_REJECT
+    assert (
+        QueueAuthorizedBoundedWorkerPilotInvokeReason.WORKTREE_CREATE_NOT_ACCEPTED
+        in result.rejection_reasons
+    )
+    assert not (bundle["worktree"] / ARTIFACT).exists()
+
+
+def test_mutation_flag_in_worktree_create_payload_blocks_before_write(tmp_path: Path) -> None:
+    bundle = _valid_bundle(tmp_path)
+    bundle["queue_worktree_create_result"]["worktree_create_result"][
+        "no_file_edit_performed"
+    ] = False
+
+    result = _invoke(bundle)
+
+    assert result.decision == QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_REJECT
+    assert (
+        QueueAuthorizedBoundedWorkerPilotInvokeReason.WORKTREE_CREATE_MUTATION_FLAGS_INVALID
+        in result.rejection_reasons
+    )
+    assert not (bundle["worktree"] / ARTIFACT).exists()
+
+
+def test_rejected_generic_writer_blocks_before_write(tmp_path: Path) -> None:
+    bundle = _valid_bundle(tmp_path)
+    bundle["generic_writer_dryrun_result"]["decision"] = "GENERIC_WRITER_DRYRUN_REJECT"
+
+    result = _invoke(bundle)
+
+    assert result.decision == QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_REJECT
+    assert (
+        QueueAuthorizedBoundedWorkerPilotInvokeReason.GENERIC_WRITER_NOT_ACCEPTED
+        in result.rejection_reasons
+    )
+    assert not (bundle["worktree"] / ARTIFACT).exists()
+
+
+def test_rejected_governed_shell_blocks_before_write(tmp_path: Path) -> None:
+    bundle = _valid_bundle(tmp_path)
+    bundle["governed_shell_dryrun_result"]["decision"] = "GOVERNED_SHELL_DRYRUN_REJECT"
+
+    result = _invoke(bundle)
+
+    assert result.decision == QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_REJECT
+    assert (
+        QueueAuthorizedBoundedWorkerPilotInvokeReason.GOVERNED_SHELL_NOT_ACCEPTED
+        in result.rejection_reasons
+    )
+    assert not (bundle["worktree"] / ARTIFACT).exists()
+
+
+def test_work_order_id_mismatch_blocks_before_write(tmp_path: Path) -> None:
+    bundle = _valid_bundle(tmp_path)
+    bundle["generic_writer_dryrun_result"]["receipt"]["work_order_id"] = "other-work"
+
+    result = _invoke(bundle)
+
+    assert result.decision == QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_REJECT
+    assert (
+        QueueAuthorizedBoundedWorkerPilotInvokeReason.WORK_ORDER_ID_MISMATCH
+        in result.rejection_reasons
+    )
+    assert not (bundle["worktree"] / ARTIFACT).exists()
+
+
+def test_holoindex_gap_is_preserved_and_blocks_pilot_write(tmp_path: Path) -> None:
+    bundle = _valid_bundle(tmp_path)
+    bundle["work_order"]["holoindex_evidence"] = {
+        "index_gap_detected": True,
+        "retrieval_quality": "INDEX_GAP",
+    }
+
+    result = _invoke(bundle)
+
+    assert result.decision == QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_REJECT
+    assert (
+        QueueAuthorizedBoundedWorkerPilotInvokeReason.PILOT_NOT_ACCEPTED
+        in result.rejection_reasons
+    )
+    assert "FAIL_HOLOINDEX_INDEX_GAP" in result.rejection_reasons
+    assert not (bundle["worktree"] / ARTIFACT).exists()
+
+
+def test_artifact_manifest_mismatch_is_preserved_and_blocks_write(tmp_path: Path) -> None:
+    bundle = _valid_bundle(tmp_path)
+    bundle["artifact_contents"] = {
+        **bundle["artifact_contents"],
+        (
+            "modules/communication/moltbot_bridge/tests/fixtures/"
+            f"{DOMAIN_ID}/EXTRA.md"
+        ): "extra",
+    }
+
+    result = _invoke(bundle)
+
+    assert result.decision == QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_REJECT
+    assert (
+        QueueAuthorizedBoundedWorkerPilotInvokeReason.PILOT_NOT_ACCEPTED
+        in result.rejection_reasons
+    )
+    assert "FAIL_ARTIFACTS_MISMATCH" in result.rejection_reasons
+    assert not (bundle["worktree"] / ARTIFACT).exists()
+
+
+def test_result_is_json_serializable(tmp_path: Path) -> None:
+    bundle = _valid_bundle(tmp_path)
+
+    result = _invoke(bundle)
+
+    payload = result.to_dict()
+    assert payload["decision"] == QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_ACCEPT
+    assert payload["pilot_result"]["decision"] == "BOUNDED_WORKTREE_PILOT_ACCEPT"
+    json.dumps(payload)
+
+
+def test_module_has_no_shell_git_openclaw_hermes_pr_reward_or_holoindex_authority() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    banned_import_roots = {
+        "subprocess",
+        "os",
+        "shutil",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__", "open"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls
+
+    forbidden_tokens = (
+        "create_reddog_wre_worktree(",
+        "RealRedDogWorktreeRunner",
+        "subprocess",
+        "git ",
+        "gh ",
+        "openclaw_supervisor",
+        "hermes_job_executor",
+        "create_pull_request",
+        "settle_reward",
+        "holo_index.py --index",
+    )
+    for token in forbidden_tokens:
+        assert token not in source


### PR DESCRIPTION
## Summary

Implements `REDDOG_WRE_QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_PHASE1`.

This bridge consumes:

- accepted queue-authorized worktree-create invoke result
- accepted generic agent worktree writer dry-run result
- accepted governed shell dry-run result
- declared artifact contents

It then invokes the existing bounded worktree worker pilot to materialize only the declared text artifacts inside the already-created isolated worktree.

## Boundary

- No shell command execution
- No OpenClaw enqueue
- No Hermes dispatch
- No PR creation
- No merge
- No reward settlement
- No HoloIndex re-index
- No additional worktree creation

The bridge only calls `run_bounded_worktree_worker_execution_pilot()` after binding work-order IDs across the worktree-create result, writer receipt, shell receipt, and work order.

## Validation

```text
pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_bounded_worker_pilot_invoke.py modules/communication/moltbot_bridge/tests/test_reddog_bounded_worktree_worker_execution_pilot.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_worktree_create_invoke.py modules/communication/moltbot_bridge/tests/test_reddog_generic_agent_worktree_writer_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_wre_governed_shell_runner_dryrun.py -q
82 passed

git diff --check
clean

ASCII/NUL scan
new files: non_ascii=0 nul=0
```

## HoloIndex

Read-only probe for `RedDog queue authorized bounded worker pilot invoke` did not surface this new bridge before indexing.

Recorded INDEX_GAP:

```text
HOLOINDEX_REDDOG_WRE_QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_INDEX_GAP_PHASE1
```

No runtime re-index performed.

## WSP_97 Truth Boundary

- OBSERVED: bounded pilot writes declared artifacts only inside isolated worktree.
- OBSERVED: rejected queue/worktree/writer/shell/HoloIndex paths block before write.
- OBSERVED: module imports no subprocess/git/gh/OpenClaw/Hermes/HoloIndex authority.
- SPECIFIED_NOT_IMPLEMENTED: shell execution, tests execution, draft PR publication, merge authority, reward settlement, HoloIndex re-index.