### PR TITLE
feat(reddog): invoke verified draft pr publish from queue verifier

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,25 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_WRE_QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_wre_queue_authorized_verified_draft_pr_publish_invoke.py`:
+  an explicit bridge from an accepted queue-authorized autonomous verifier
+  result to the existing WRE verified draft PR publish gate.
+- The guard requires an injected draft-PR runner, injects the accepted verifier
+  result into the publish request, and preserves publish-gate rejection reasons.
+- Boundary: draft PR publishing only after verification; no mark-ready, merge,
+  command execution, PatternMemory write, reward settlement, OpenClaw enqueue,
+  Hermes dispatch, or HoloIndex re-index.
+- HoloIndex read-only probe for `RedDog queue authorized verified draft PR
+  publish invoke` surfaced adjacent identity, policy, and governance files, but
+  did not surface this new publish bridge before indexing. Recorded as
+  `HOLOINDEX_REDDOG_WRE_QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_INDEX_GAP_PHASE1`;
+  no runtime re-index performed. The probe also reported a pre-existing
+  `WSP-GUARDIAN` suspicious-Unicode warning unrelated to the new ASCII-clean
+  files.
+
 ## 2026-07-14: REDDOG_WRE_QUEUE_AUTHORIZED_SLICE_VERIFIER_INVOKE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_verified_draft_pr_publish_invoke.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_verified_draft_pr_publish_invoke.py
@@ -1,0 +1,181 @@
+"""RedDog queue-authorized verified draft PR publish explicit invoke guard.
+
+Slice: REDDOG_WRE_QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_PHASE1
+
+This module consumes an accepted queue-authorized autonomous slice verifier
+result, then invokes the existing WRE verified draft PR publish gate through an
+injected runner. It publishes draft PRs only; it never marks ready, merges,
+executes commands, writes PatternMemory, settles rewards, or mutates HoloIndex.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_slice_verifier_invoke import (
+    QUEUE_AUTHORIZED_SLICE_VERIFIER_INVOKE_ACCEPT,
+)
+from modules.infrastructure.wre_core.src.reddog_verified_draft_pr_publish import (
+    VERIFIED_DRAFT_PR_PUBLISH_ACCEPT,
+    VerifiedDraftPrPublishResult,
+    publish_verified_draft_pr,
+)
+from modules.infrastructure.wre_core.src.wre_autonomous_slice_verifier_runtime import (
+    AUTONOMOUS_SLICE_VERIFIER_ACCEPT,
+)
+
+
+QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_ACCEPT = (
+    "QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_ACCEPT"
+)
+QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_REJECT = (
+    "QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_REJECT"
+)
+
+
+class QueueAuthorizedVerifiedDraftPrPublishInvokeReason:
+    EXPLICIT_INVOKE_MISSING = "REJECT_EXPLICIT_QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_MISSING"
+    RUNNER_REQUIRED = "REJECT_INJECTED_DRAFT_PR_RUNNER_REQUIRED"
+    SLICE_VERIFIER_NOT_ACCEPTED = "REJECT_QUEUE_SLICE_VERIFIER_NOT_ACCEPTED"
+    VERIFIER_PAYLOAD_MISSING = "REJECT_VERIFIER_PAYLOAD_MISSING"
+    VERIFIER_PAYLOAD_NOT_ACCEPTED = "REJECT_VERIFIER_PAYLOAD_NOT_ACCEPTED"
+    VERIFIER_RECEIPT_MISSING = "REJECT_VERIFIER_RECEIPT_MISSING"
+    PUBLISH_REQUEST_INVALID = "REJECT_DRAFT_PR_PUBLISH_REQUEST_INVALID"
+    WORK_ORDER_ID_MISMATCH = "REJECT_WORK_ORDER_ID_MISMATCH"
+    PUBLISH_NOT_ACCEPTED = "REJECT_VERIFIED_DRAFT_PR_PUBLISH_NOT_ACCEPTED"
+
+
+@dataclass(frozen=True)
+class QueueAuthorizedVerifiedDraftPrPublishInvokeResult:
+    decision: str
+    rejection_reasons: List[str] = field(default_factory=list)
+    publish_result: Optional[VerifiedDraftPrPublishResult] = None
+    explicit_queue_authorized_verified_draft_pr_publish_requested: bool = False
+    no_ready_performed: bool = True
+    no_merge_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_reward_settlement_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["publish_result"] = self.publish_result.to_dict() if self.publish_result else None
+        return payload
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        candidate = value.to_dict()
+        return candidate if isinstance(candidate, Mapping) else {}
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _dedupe(values: Sequence[str]) -> List[str]:
+    return list(dict.fromkeys(str(v) for v in values if str(v or "").strip()))
+
+
+def _reject(
+    reasons: Sequence[str],
+    *,
+    explicit_requested: bool,
+    publish_result: Optional[VerifiedDraftPrPublishResult] = None,
+) -> QueueAuthorizedVerifiedDraftPrPublishInvokeResult:
+    return QueueAuthorizedVerifiedDraftPrPublishInvokeResult(
+        decision=QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_REJECT,
+        rejection_reasons=_dedupe(reasons),
+        publish_result=publish_result,
+        explicit_queue_authorized_verified_draft_pr_publish_requested=explicit_requested,
+    )
+
+
+def _enrich_publish_request(
+    publish_request: Mapping[str, Any],
+    verifier_result: Mapping[str, Any],
+) -> Dict[str, Any]:
+    enriched = dict(publish_request)
+    enriched["verifier_result"] = dict(verifier_result)
+    return enriched
+
+
+def invoke_reddog_wre_queue_authorized_verified_draft_pr_publish(
+    *,
+    explicit_queue_authorized_verified_draft_pr_publish_requested: bool,
+    queue_slice_verifier_result: Mapping[str, Any],
+    publish_request: Mapping[str, Any],
+    runner: Optional[Any],
+) -> QueueAuthorizedVerifiedDraftPrPublishInvokeResult:
+    """Publish a draft PR only after accepted queue-authorized verification."""
+
+    if explicit_queue_authorized_verified_draft_pr_publish_requested is not True:
+        return _reject(
+            [QueueAuthorizedVerifiedDraftPrPublishInvokeReason.EXPLICIT_INVOKE_MISSING],
+            explicit_requested=False,
+        )
+    if runner is None:
+        return _reject(
+            [QueueAuthorizedVerifiedDraftPrPublishInvokeReason.RUNNER_REQUIRED],
+            explicit_requested=True,
+        )
+
+    reasons: List[str] = []
+    queue_verifier = _mapping(queue_slice_verifier_result)
+    if queue_verifier.get("decision") != QUEUE_AUTHORIZED_SLICE_VERIFIER_INVOKE_ACCEPT:
+        reasons.append(QueueAuthorizedVerifiedDraftPrPublishInvokeReason.SLICE_VERIFIER_NOT_ACCEPTED)
+
+    verifier_payload = _mapping(queue_verifier.get("verifier_result"))
+    if not verifier_payload:
+        reasons.append(QueueAuthorizedVerifiedDraftPrPublishInvokeReason.VERIFIER_PAYLOAD_MISSING)
+    elif (
+        verifier_payload.get("decision") != AUTONOMOUS_SLICE_VERIFIER_ACCEPT
+        or verifier_payload.get("accepted") is not True
+    ):
+        reasons.append(QueueAuthorizedVerifiedDraftPrPublishInvokeReason.VERIFIER_PAYLOAD_NOT_ACCEPTED)
+
+    verifier_receipt = _mapping(verifier_payload.get("receipt"))
+    if not verifier_receipt:
+        reasons.append(QueueAuthorizedVerifiedDraftPrPublishInvokeReason.VERIFIER_RECEIPT_MISSING)
+
+    request = _mapping(publish_request)
+    if not request:
+        reasons.append(QueueAuthorizedVerifiedDraftPrPublishInvokeReason.PUBLISH_REQUEST_INVALID)
+
+    if verifier_receipt and request:
+        request_work_order = str(request.get("work_order_id") or verifier_receipt.get("work_order_id") or "")
+        if request_work_order != str(verifier_receipt.get("work_order_id") or ""):
+            reasons.append(QueueAuthorizedVerifiedDraftPrPublishInvokeReason.WORK_ORDER_ID_MISMATCH)
+
+    if reasons:
+        return _reject(reasons, explicit_requested=True)
+
+    published = publish_verified_draft_pr(
+        _enrich_publish_request(request, verifier_payload),
+        runner=runner,
+    )
+    if published.decision != VERIFIED_DRAFT_PR_PUBLISH_ACCEPT:
+        return _reject(
+            [
+                QueueAuthorizedVerifiedDraftPrPublishInvokeReason.PUBLISH_NOT_ACCEPTED,
+                *published.rejection_reasons,
+            ],
+            explicit_requested=True,
+            publish_result=published,
+        )
+
+    return QueueAuthorizedVerifiedDraftPrPublishInvokeResult(
+        decision=QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_ACCEPT,
+        rejection_reasons=[],
+        publish_result=published,
+        explicit_queue_authorized_verified_draft_pr_publish_requested=True,
+    )
+
+
+__all__ = [
+    "QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_ACCEPT",
+    "QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_REJECT",
+    "QueueAuthorizedVerifiedDraftPrPublishInvokeReason",
+    "QueueAuthorizedVerifiedDraftPrPublishInvokeResult",
+    "invoke_reddog_wre_queue_authorized_verified_draft_pr_publish",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_draft_pr_publish_invoke.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_draft_pr_publish_invoke.py
@@ -1,0 +1,290 @@
+"""Tests for REDDOG_WRE_QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_slice_verifier_invoke import (
+    QUEUE_AUTHORIZED_SLICE_VERIFIER_INVOKE_ACCEPT,
+    QUEUE_AUTHORIZED_SLICE_VERIFIER_INVOKE_REJECT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_verified_draft_pr_publish_invoke import (
+    QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_ACCEPT,
+    QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_REJECT,
+    QueueAuthorizedVerifiedDraftPrPublishInvokeReason,
+    invoke_reddog_wre_queue_authorized_verified_draft_pr_publish,
+)
+from modules.infrastructure.wre_core.src.reddog_verified_draft_pr_publish import (
+    VERIFIED_DRAFT_PR_PUBLISH_ACCEPT,
+    VERIFIED_DRAFT_PR_PUBLISH_REJECT,
+)
+from modules.infrastructure.wre_core.src.wre_autonomous_slice_verifier_runtime import (
+    AUTONOMOUS_SLICE_VERIFIER_ACCEPT,
+    AUTONOMOUS_SLICE_VERIFIER_REJECT,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_wre_queue_authorized_verified_draft_pr_publish_invoke.py"
+)
+WORK_ORDER_ID = "wo-queue-draft-pr-1"
+HEAD_SHA = "a" * 40
+ARTIFACT = "modules/communication/moltbot_bridge/tests/fixtures/reddog_queue_pilot/README.md"
+
+
+class FakeDraftPrRunner:
+    def __init__(self, *, push_ok: bool = True, pr_url: str | None = None) -> None:
+        self.push_ok = push_ok
+        self.pr_url = pr_url or "https://github.com/FOUNDUPS/Foundups-Agent/pull/2000"
+        self.calls: list[tuple] = []
+
+    def push_branch(self, *, worktree_path: Path, branch_name: str):
+        self.calls.append(("push_branch", str(worktree_path), branch_name))
+        return {"ok": self.push_ok, "stdout": "", "stderr": "" if self.push_ok else "push failed"}
+
+    def create_draft_pr(self, *, branch_name: str, base_branch: str, title: str, body: str):
+        self.calls.append(("create_draft_pr", branch_name, base_branch, title, body))
+        if self.pr_url == "RAISE":
+            raise RuntimeError("draft pr failed")
+        return self.pr_url
+
+
+def _queue_verifier_result(*, decision: str | None = None, verifier_decision: str | None = None) -> dict:
+    accepted = (verifier_decision or AUTONOMOUS_SLICE_VERIFIER_ACCEPT) == AUTONOMOUS_SLICE_VERIFIER_ACCEPT
+    return {
+        "decision": decision or QUEUE_AUTHORIZED_SLICE_VERIFIER_INVOKE_ACCEPT,
+        "rejection_reasons": [],
+        "explicit_queue_authorized_slice_verifier_requested": True,
+        "verifier_result": {
+            "decision": verifier_decision or AUTONOMOUS_SLICE_VERIFIER_ACCEPT,
+            "accepted": accepted,
+            "rejection_reasons": [] if accepted else ["FAIL_TEST_EVIDENCE"],
+            "receipt": {
+                "receipt_id": "wre_slice_verify_1234",
+                "work_order_id": WORK_ORDER_ID,
+                "slice_name": "REDDOG_WRE_QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_PHASE1",
+                "worker_id": "worker:author",
+                "verifier_id": "worker:verifier",
+                "head_sha": HEAD_SHA,
+                "changed_paths": [ARTIFACT],
+            },
+        },
+    }
+
+
+def _publish_request() -> dict:
+    return {
+        "work_order_id": WORK_ORDER_ID,
+        "pre_publish_branch_head_sha": HEAD_SHA,
+        "branch_name": "feat/reddog-queue-draft-pr-publish",
+        "base_branch": "main",
+        "pr_title": "feat(reddog): verified queue draft pr publish",
+        "pr_body": "Verified by WRE autonomous slice verifier.",
+        "worktree_path": "O:/tmp/reddog-worker",
+        "draft_pr_only": True,
+        "mark_ready": False,
+        "merge": False,
+    }
+
+
+def _invoke(
+    *,
+    queue_verifier: dict | None = None,
+    publish_request: dict | None = None,
+    runner: FakeDraftPrRunner | None = None,
+):
+    return invoke_reddog_wre_queue_authorized_verified_draft_pr_publish(
+        explicit_queue_authorized_verified_draft_pr_publish_requested=True,
+        queue_slice_verifier_result=queue_verifier or _queue_verifier_result(),
+        publish_request=publish_request or _publish_request(),
+        runner=runner or FakeDraftPrRunner(),
+    )
+
+
+def test_invokes_verified_draft_pr_publish_from_accepted_verifier() -> None:
+    runner = FakeDraftPrRunner()
+
+    result = _invoke(runner=runner)
+
+    assert result.decision == QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_ACCEPT
+    assert result.rejection_reasons == []
+    assert result.publish_result is not None
+    assert result.publish_result.decision == VERIFIED_DRAFT_PR_PUBLISH_ACCEPT
+    assert result.publish_result.receipt.draft_pr_url.endswith("/pull/2000")
+    assert result.publish_result.receipt.no_ready_performed is True
+    assert result.publish_result.receipt.no_merge_performed is True
+    assert result.no_ready_performed is True
+    assert result.no_merge_performed is True
+    assert result.no_pattern_memory_write_performed is True
+    assert result.no_reward_settlement_performed is True
+    assert result.no_holoindex_reindex_performed is True
+    assert [call[0] for call in runner.calls] == ["push_branch", "create_draft_pr"]
+
+
+def test_explicit_invoke_missing_rejects_before_runner() -> None:
+    runner = FakeDraftPrRunner()
+
+    result = invoke_reddog_wre_queue_authorized_verified_draft_pr_publish(
+        explicit_queue_authorized_verified_draft_pr_publish_requested=False,
+        queue_slice_verifier_result=_queue_verifier_result(),
+        publish_request=_publish_request(),
+        runner=runner,
+    )
+
+    assert result.decision == QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_REJECT
+    assert (
+        QueueAuthorizedVerifiedDraftPrPublishInvokeReason.EXPLICIT_INVOKE_MISSING
+        in result.rejection_reasons
+    )
+    assert result.publish_result is None
+    assert runner.calls == []
+
+
+def test_runner_required_rejects() -> None:
+    result = invoke_reddog_wre_queue_authorized_verified_draft_pr_publish(
+        explicit_queue_authorized_verified_draft_pr_publish_requested=True,
+        queue_slice_verifier_result=_queue_verifier_result(),
+        publish_request=_publish_request(),
+        runner=None,
+    )
+
+    assert result.decision == QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_REJECT
+    assert QueueAuthorizedVerifiedDraftPrPublishInvokeReason.RUNNER_REQUIRED in result.rejection_reasons
+    assert result.publish_result is None
+
+
+def test_unaccepted_queue_verifier_rejects_before_runner() -> None:
+    runner = FakeDraftPrRunner()
+    result = _invoke(
+        queue_verifier=_queue_verifier_result(
+            decision=QUEUE_AUTHORIZED_SLICE_VERIFIER_INVOKE_REJECT
+        ),
+        runner=runner,
+    )
+
+    assert result.decision == QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_REJECT
+    assert (
+        QueueAuthorizedVerifiedDraftPrPublishInvokeReason.SLICE_VERIFIER_NOT_ACCEPTED
+        in result.rejection_reasons
+    )
+    assert runner.calls == []
+
+
+def test_unaccepted_verifier_payload_rejects_before_runner() -> None:
+    runner = FakeDraftPrRunner()
+    result = _invoke(
+        queue_verifier=_queue_verifier_result(verifier_decision=AUTONOMOUS_SLICE_VERIFIER_REJECT),
+        runner=runner,
+    )
+
+    assert result.decision == QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_REJECT
+    assert (
+        QueueAuthorizedVerifiedDraftPrPublishInvokeReason.VERIFIER_PAYLOAD_NOT_ACCEPTED
+        in result.rejection_reasons
+    )
+    assert runner.calls == []
+
+
+def test_work_order_id_mismatch_rejects_before_runner() -> None:
+    request = _publish_request()
+    request["work_order_id"] = "other-work-order"
+    runner = FakeDraftPrRunner()
+
+    result = _invoke(publish_request=request, runner=runner)
+
+    assert result.decision == QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_REJECT
+    assert (
+        QueueAuthorizedVerifiedDraftPrPublishInvokeReason.WORK_ORDER_ID_MISMATCH
+        in result.rejection_reasons
+    )
+    assert runner.calls == []
+
+
+def test_publish_rejection_is_preserved_without_pr_creation() -> None:
+    request = _publish_request()
+    request["pre_publish_branch_head_sha"] = "b" * 40
+    runner = FakeDraftPrRunner()
+
+    result = _invoke(publish_request=request, runner=runner)
+
+    assert result.decision == QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_REJECT
+    assert (
+        QueueAuthorizedVerifiedDraftPrPublishInvokeReason.PUBLISH_NOT_ACCEPTED
+        in result.rejection_reasons
+    )
+    assert "FAIL_HEAD_MISMATCH" in result.rejection_reasons
+    assert result.publish_result is not None
+    assert result.publish_result.decision == VERIFIED_DRAFT_PR_PUBLISH_REJECT
+    assert runner.calls == []
+
+
+def test_push_failure_is_preserved() -> None:
+    runner = FakeDraftPrRunner(push_ok=False)
+
+    result = _invoke(runner=runner)
+
+    assert result.decision == QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_REJECT
+    assert (
+        QueueAuthorizedVerifiedDraftPrPublishInvokeReason.PUBLISH_NOT_ACCEPTED
+        in result.rejection_reasons
+    )
+    assert "FAIL_PUSH_BRANCH" in result.rejection_reasons
+    assert [call[0] for call in runner.calls] == ["push_branch"]
+
+
+def test_result_is_json_serializable() -> None:
+    result = _invoke()
+
+    payload = result.to_dict()
+    assert payload["decision"] == QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_ACCEPT
+    assert payload["publish_result"]["decision"] == VERIFIED_DRAFT_PR_PUBLISH_ACCEPT
+    json.dumps(payload)
+
+
+def test_module_has_no_direct_shell_git_gh_merge_memory_reward_or_holoindex_authority() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    banned_import_roots = {
+        "subprocess",
+        "os",
+        "shutil",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__", "open"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls
+
+    forbidden_tokens = (
+        "subprocess",
+        "git ",
+        "gh pr",
+        "mark_ready",
+        "merge_pr",
+        "PatternMemory(",
+        "store_outcome",
+        "settle_reward",
+        "holo_index.py --index",
+    )
+    for token in forbidden_tokens:
+        assert token not in source


### PR DESCRIPTION
## Summary

Implements `REDDOG_WRE_QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_PHASE1` as an explicit queue-authorized bridge from an accepted autonomous slice verifier result to the existing WRE verified draft PR publish gate.

## Scope

- Adds `reddog_wre_queue_authorized_verified_draft_pr_publish_invoke.py`.
- Requires explicit invoke, accepted queue slice verifier result, accepted embedded autonomous verifier receipt, matching work order, and an injected draft-PR runner.
- Injects the accepted verifier result into the publish request and preserves downstream publish-gate rejection reasons.
- Boundary: draft PR publishing only; no mark-ready, merge, command execution, PatternMemory write, reward settlement, OpenClaw enqueue, Hermes dispatch, or HoloIndex re-index.

## Validation

- `pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_draft_pr_publish_invoke.py modules/infrastructure/wre_core/tests/test_reddog_verified_draft_pr_publish.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_slice_verifier_invoke.py -q` -> 31 passed.
- `git diff --check` -> clean, with pre-existing autocrlf warning only.
- New diff additions ASCII/NUL clean.
- HoloIndex read-only probe surfaced adjacent identity/policy/governance files but not the new bridge before indexing. Recorded as `HOLOINDEX_REDDOG_WRE_QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_INDEX_GAP_PHASE1`; no runtime re-index performed.

## Truth Boundary

- No direct shell, git, gh, network, SQLite, HoloIndex mutation, PatternMemory, reward settlement, mark-ready, or merge authority.
- Draft PR creation remains delegated to the injected runner inside the existing WRE publish gate.
- This slice does not automatically invoke from RedDog model output or extension runtime.