### PR TITLE
feat(reddog): invoke verified outcome ratchet from queue publish

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,29 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_WRE_QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_wre_queue_authorized_verified_outcome_ratchet_invoke.py`:
+  an explicit bridge from an accepted queue-authorized verified draft PR
+  publish result to the existing WRE verified outcome ratchet.
+- The guard requires an injected outcome ratchet store, binds the publish
+  receipt to the verifier receipt and work-order ID, and uses the accepted
+  queue publish result as authoritative publish evidence.
+- PatternMemory writes are blocked unless the request asks for them, a
+  separate explicit PatternMemory flag is true, and an injected sink is present.
+- Boundary: outcome receipt recording only; no command execution, PR publish,
+  mark-ready, merge, reward settlement, OpenClaw enqueue, Hermes dispatch, or
+  HoloIndex re-index.
+- HoloIndex read-only probe for `RedDog queue authorized verified outcome
+  ratchet invoke` surfaced adjacent policy, runtime-invocation, signature, and
+  governance files, but did not surface this new ratchet bridge before
+  indexing. Recorded as
+  `HOLOINDEX_REDDOG_WRE_QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_INDEX_GAP_PHASE1`;
+  no runtime re-index performed. The probe also reported a pre-existing
+  `WSP-GUARDIAN` suspicious-Unicode warning unrelated to the new ASCII-clean
+  files.
+
 ## 2026-07-14: REDDOG_WRE_QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_verified_outcome_ratchet_invoke.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_verified_outcome_ratchet_invoke.py
@@ -1,0 +1,240 @@
+"""RedDog queue-authorized verified outcome ratchet explicit invoke guard.
+
+Slice: REDDOG_WRE_QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_PHASE1
+
+This module consumes an accepted queue-authorized verified draft PR publish
+result, then invokes the existing WRE verified outcome ratchet through an
+injected store. It records outcome receipts only; it never executes commands,
+publishes PRs, marks ready, merges, settles rewards, or mutates HoloIndex.
+PatternMemory writes require a separate explicit flag and injected sink.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_verified_draft_pr_publish_invoke import (
+    QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_ACCEPT,
+)
+from modules.infrastructure.wre_core.src.reddog_verified_draft_pr_publish import (
+    VERIFIED_DRAFT_PR_PUBLISH_ACCEPT,
+)
+from modules.infrastructure.wre_core.src.reddog_verified_outcome_ratchet import (
+    OUTCOME_RATCHET_RECORDED,
+    OutcomeRatchetStore,
+    PatternMemorySink,
+    VerifiedOutcomeRatchetResult,
+    ratchet_verified_outcome,
+)
+
+
+QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_ACCEPT = (
+    "QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_ACCEPT"
+)
+QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_REJECT = (
+    "QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_REJECT"
+)
+
+
+class QueueAuthorizedVerifiedOutcomeRatchetInvokeReason:
+    EXPLICIT_INVOKE_MISSING = "REJECT_EXPLICIT_QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_MISSING"
+    STORE_REQUIRED = "REJECT_INJECTED_OUTCOME_RATCHET_STORE_REQUIRED"
+    PUBLISH_INVOKE_NOT_ACCEPTED = "REJECT_QUEUE_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_NOT_ACCEPTED"
+    PUBLISH_PAYLOAD_MISSING = "REJECT_PUBLISH_PAYLOAD_MISSING"
+    PUBLISH_PAYLOAD_NOT_ACCEPTED = "REJECT_PUBLISH_PAYLOAD_NOT_ACCEPTED"
+    PUBLISH_RECEIPT_MISSING = "REJECT_PUBLISH_RECEIPT_MISSING"
+    RATCHET_REQUEST_INVALID = "REJECT_OUTCOME_RATCHET_REQUEST_INVALID"
+    VERIFIER_RECEIPT_MISMATCH = "REJECT_VERIFIER_RECEIPT_MISMATCH"
+    WORK_ORDER_ID_MISMATCH = "REJECT_WORK_ORDER_ID_MISMATCH"
+    PATTERN_MEMORY_EXPLICIT_MISSING = "REJECT_PATTERN_MEMORY_EXPLICIT_MISSING"
+    PATTERN_MEMORY_SINK_REQUIRED = "REJECT_PATTERN_MEMORY_SINK_REQUIRED"
+    RATCHET_NOT_ACCEPTED = "REJECT_VERIFIED_OUTCOME_RATCHET_NOT_ACCEPTED"
+
+
+@dataclass(frozen=True)
+class QueueAuthorizedVerifiedOutcomeRatchetInvokeResult:
+    decision: str
+    rejection_reasons: List[str] = field(default_factory=list)
+    ratchet_result: Optional[VerifiedOutcomeRatchetResult] = None
+    explicit_queue_authorized_verified_outcome_ratchet_requested: bool = False
+    explicit_pattern_memory_write_requested: bool = False
+    no_command_execution_performed: bool = True
+    no_pr_publish_performed: bool = True
+    no_ready_performed: bool = True
+    no_merge_performed: bool = True
+    no_reward_settlement_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["ratchet_result"] = self.ratchet_result.to_dict() if self.ratchet_result else None
+        return payload
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        candidate = value.to_dict()
+        return candidate if isinstance(candidate, Mapping) else {}
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _dedupe(values: Sequence[str]) -> List[str]:
+    return list(dict.fromkeys(str(v) for v in values if str(v or "").strip()))
+
+
+def _reject(
+    reasons: Sequence[str],
+    *,
+    explicit_requested: bool,
+    explicit_pattern_requested: bool,
+    ratchet_result: Optional[VerifiedOutcomeRatchetResult] = None,
+) -> QueueAuthorizedVerifiedOutcomeRatchetInvokeResult:
+    return QueueAuthorizedVerifiedOutcomeRatchetInvokeResult(
+        decision=QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_REJECT,
+        rejection_reasons=_dedupe(reasons),
+        ratchet_result=ratchet_result,
+        explicit_queue_authorized_verified_outcome_ratchet_requested=explicit_requested,
+        explicit_pattern_memory_write_requested=explicit_pattern_requested,
+    )
+
+
+def _same_nonempty(left: Any, right: Any) -> bool:
+    left_text = str(left or "")
+    return bool(left_text) and left_text == str(right or "")
+
+
+def _enrich_ratchet_request(
+    ratchet_request: Mapping[str, Any],
+    publish_result: Mapping[str, Any],
+    *,
+    enable_pattern_memory_write: bool,
+) -> Dict[str, Any]:
+    enriched = dict(ratchet_request)
+    enriched["publish_result"] = dict(publish_result)
+    enriched["enable_pattern_memory_write"] = enable_pattern_memory_write
+    return enriched
+
+
+def invoke_reddog_wre_queue_authorized_verified_outcome_ratchet(
+    *,
+    explicit_queue_authorized_verified_outcome_ratchet_requested: bool,
+    queue_verified_draft_pr_publish_result: Mapping[str, Any],
+    ratchet_request: Mapping[str, Any],
+    store: Optional[OutcomeRatchetStore],
+    explicit_pattern_memory_write_requested: bool = False,
+    pattern_memory_sink: Optional[PatternMemorySink] = None,
+) -> QueueAuthorizedVerifiedOutcomeRatchetInvokeResult:
+    """Record a verified outcome only after queue-authorized draft PR publish."""
+
+    if explicit_queue_authorized_verified_outcome_ratchet_requested is not True:
+        return _reject(
+            [QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.EXPLICIT_INVOKE_MISSING],
+            explicit_requested=False,
+            explicit_pattern_requested=explicit_pattern_memory_write_requested,
+        )
+    if store is None:
+        return _reject(
+            [QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.STORE_REQUIRED],
+            explicit_requested=True,
+            explicit_pattern_requested=explicit_pattern_memory_write_requested,
+        )
+
+    reasons: List[str] = []
+    publish_invoke = _mapping(queue_verified_draft_pr_publish_result)
+    if (
+        publish_invoke.get("decision")
+        != QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_ACCEPT
+    ):
+        reasons.append(
+            QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.PUBLISH_INVOKE_NOT_ACCEPTED
+        )
+
+    publish_payload = _mapping(publish_invoke.get("publish_result"))
+    if not publish_payload:
+        reasons.append(QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.PUBLISH_PAYLOAD_MISSING)
+    elif (
+        publish_payload.get("decision") != VERIFIED_DRAFT_PR_PUBLISH_ACCEPT
+        or publish_payload.get("accepted") is not True
+    ):
+        reasons.append(QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.PUBLISH_PAYLOAD_NOT_ACCEPTED)
+
+    publish_receipt = _mapping(publish_payload.get("receipt"))
+    if not publish_receipt:
+        reasons.append(QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.PUBLISH_RECEIPT_MISSING)
+
+    request = _mapping(ratchet_request)
+    if not request:
+        reasons.append(QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.RATCHET_REQUEST_INVALID)
+
+    verifier_result = _mapping(request.get("verification_result"))
+    verifier_receipt = _mapping(verifier_result.get("receipt"))
+    if publish_receipt and verifier_receipt:
+        if not _same_nonempty(
+            verifier_receipt.get("receipt_id"),
+            publish_receipt.get("verifier_receipt_id"),
+        ):
+            reasons.append(QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.VERIFIER_RECEIPT_MISMATCH)
+        if not _same_nonempty(
+            request.get("work_order_id") or verifier_receipt.get("work_order_id"),
+            publish_receipt.get("work_order_id"),
+        ):
+            reasons.append(QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.WORK_ORDER_ID_MISMATCH)
+    elif publish_receipt and request:
+        reasons.append(QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.VERIFIER_RECEIPT_MISMATCH)
+
+    pattern_requested_by_request = request.get("enable_pattern_memory_write") is True
+    if pattern_requested_by_request and explicit_pattern_memory_write_requested is not True:
+        reasons.append(QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.PATTERN_MEMORY_EXPLICIT_MISSING)
+    if (
+        pattern_requested_by_request
+        and explicit_pattern_memory_write_requested is True
+        and pattern_memory_sink is None
+    ):
+        reasons.append(QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.PATTERN_MEMORY_SINK_REQUIRED)
+
+    if reasons:
+        return _reject(
+            reasons,
+            explicit_requested=True,
+            explicit_pattern_requested=explicit_pattern_memory_write_requested,
+        )
+
+    ratcheted = ratchet_verified_outcome(
+        _enrich_ratchet_request(
+            request,
+            publish_payload,
+            enable_pattern_memory_write=pattern_requested_by_request,
+        ),
+        store=store,
+        pattern_memory_sink=pattern_memory_sink,
+    )
+    if ratcheted.decision != OUTCOME_RATCHET_RECORDED or ratcheted.accepted is not True:
+        return _reject(
+            [
+                QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.RATCHET_NOT_ACCEPTED,
+                *ratcheted.rejection_reasons,
+            ],
+            explicit_requested=True,
+            explicit_pattern_requested=explicit_pattern_memory_write_requested,
+            ratchet_result=ratcheted,
+        )
+
+    return QueueAuthorizedVerifiedOutcomeRatchetInvokeResult(
+        decision=QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_ACCEPT,
+        rejection_reasons=[],
+        ratchet_result=ratcheted,
+        explicit_queue_authorized_verified_outcome_ratchet_requested=True,
+        explicit_pattern_memory_write_requested=explicit_pattern_memory_write_requested,
+    )
+
+
+__all__ = [
+    "QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_ACCEPT",
+    "QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_REJECT",
+    "QueueAuthorizedVerifiedOutcomeRatchetInvokeReason",
+    "QueueAuthorizedVerifiedOutcomeRatchetInvokeResult",
+    "invoke_reddog_wre_queue_authorized_verified_outcome_ratchet",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_outcome_ratchet_invoke.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_outcome_ratchet_invoke.py
@@ -1,0 +1,370 @@
+"""Tests for REDDOG_WRE_QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_verified_draft_pr_publish_invoke import (
+    QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_ACCEPT,
+    QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_REJECT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_verified_outcome_ratchet_invoke import (
+    QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_ACCEPT,
+    QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_REJECT,
+    QueueAuthorizedVerifiedOutcomeRatchetInvokeReason,
+    invoke_reddog_wre_queue_authorized_verified_outcome_ratchet,
+)
+from modules.infrastructure.wre_core.src import reddog_verified_outcome_ratchet as ratchet
+from modules.infrastructure.wre_core.src.reddog_verified_draft_pr_publish import (
+    VERIFIED_DRAFT_PR_PUBLISH_ACCEPT,
+    VERIFIED_DRAFT_PR_PUBLISH_REJECT,
+)
+from modules.infrastructure.wre_core.src.wre_autonomous_slice_verifier_runtime import (
+    AUTONOMOUS_SLICE_VERIFIER_ACCEPT,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_wre_queue_authorized_verified_outcome_ratchet_invoke.py"
+)
+WORK_ORDER_ID = "wo-queue-ratchet-1"
+SLICE_NAME = "REDDOG_WRE_QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_PHASE1"
+VERIFIER_RECEIPT_ID = "wre_slice_verify_1234"
+PUBLISH_RECEIPT_ID = "verified_draft_pr_1234"
+HEAD_SHA = "a" * 40
+ARTIFACT = "modules/communication/moltbot_bridge/tests/fixtures/reddog_queue_ratchet/README.md"
+
+
+class FakePatternMemorySink:
+    def __init__(self) -> None:
+        self.records: list[dict] = []
+
+    def store_verified_outcome(self, record):
+        self.records.append(dict(record))
+        return "pattern-memory-record-1"
+
+
+def _digest(ch: str) -> str:
+    return "sha256:" + ch * 64
+
+
+def _queue_publish_result(*, accepted: bool = True, decision: str | None = None) -> dict:
+    return {
+        "decision": decision or QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_ACCEPT,
+        "rejection_reasons": [] if accepted else ["FAIL_PUSH_BRANCH"],
+        "explicit_queue_authorized_verified_draft_pr_publish_requested": True,
+        "publish_result": {
+            "decision": (
+                VERIFIED_DRAFT_PR_PUBLISH_ACCEPT
+                if accepted
+                else VERIFIED_DRAFT_PR_PUBLISH_REJECT
+            ),
+            "accepted": accepted,
+            "rejection_reasons": [] if accepted else ["FAIL_PUSH_BRANCH"],
+            "receipt": {
+                "receipt_id": PUBLISH_RECEIPT_ID,
+                "work_order_id": WORK_ORDER_ID,
+                "slice_name": SLICE_NAME,
+                "verifier_receipt_id": VERIFIER_RECEIPT_ID,
+                "branch_name": "feat/reddog-queue-ratchet",
+                "base_branch": "main",
+                "verified_head_sha": HEAD_SHA,
+                "draft_pr_url": "https://github.com/FOUNDUPS/Foundups-Agent/pull/3000",
+                "changed_paths": [ARTIFACT],
+                "accepted": accepted,
+                "rejection_reasons": [] if accepted else ["FAIL_PUSH_BRANCH"],
+            },
+        },
+    }
+
+
+def _ratchet_request() -> dict:
+    return {
+        "work_order_id": WORK_ORDER_ID,
+        "slice_name": SLICE_NAME,
+        "outcome_status": "accepted",
+        "request_receipt": {
+            "request_id": "request-1",
+            "principal_id": "012",
+            "work_focus_digest": _digest("1"),
+        },
+        "execution_receipts": [
+            {"step": "worktree_created", "receipt_id": "exec-1"},
+            {"step": "bounded_worker_pilot", "receipt_id": "exec-2"},
+            {"step": "draft_pr_published", "receipt_id": PUBLISH_RECEIPT_ID},
+        ],
+        "verification_result": {
+            "accepted": True,
+            "decision": AUTONOMOUS_SLICE_VERIFIER_ACCEPT,
+            "receipt": {
+                "receipt_id": VERIFIER_RECEIPT_ID,
+                "work_order_id": WORK_ORDER_ID,
+                "slice_name": SLICE_NAME,
+                "worker_id": "worker:author",
+                "verifier_id": "worker:verifier",
+                "head_sha": HEAD_SHA,
+                "changed_paths": [ARTIFACT],
+            },
+        },
+        "publish_result": {
+            "accepted": False,
+            "decision": VERIFIED_DRAFT_PR_PUBLISH_REJECT,
+            "receipt": {},
+        },
+        "cost_receipt": {
+            "total_tokens": 1234,
+            "estimated_cost_usd": 0.12,
+        },
+        "latency_receipt": {
+            "wall_time_ms": 1000,
+            "queue_time_ms": 10,
+        },
+        "acceptance_receipt": {
+            "accepted": True,
+            "reason": "queue verifier and draft PR publish accepted",
+        },
+        "failure_receipt": None,
+        "holoindex_evidence": {
+            "index_gap_detected": False,
+            "holoindex_freshness_receipt_digest": _digest("2"),
+        },
+        "enable_pattern_memory_write": False,
+    }
+
+
+def _invoke(
+    *,
+    queue_publish: dict | None = None,
+    request: dict | None = None,
+    store: ratchet.InMemoryOutcomeRatchetStore | None = None,
+    explicit_pattern: bool = False,
+    sink: FakePatternMemorySink | None = None,
+):
+    return invoke_reddog_wre_queue_authorized_verified_outcome_ratchet(
+        explicit_queue_authorized_verified_outcome_ratchet_requested=True,
+        queue_verified_draft_pr_publish_result=queue_publish or _queue_publish_result(),
+        ratchet_request=request or _ratchet_request(),
+        store=store or ratchet.InMemoryOutcomeRatchetStore(),
+        explicit_pattern_memory_write_requested=explicit_pattern,
+        pattern_memory_sink=sink,
+    )
+
+
+def test_records_outcome_from_accepted_queue_publish_result() -> None:
+    store = ratchet.InMemoryOutcomeRatchetStore()
+
+    result = _invoke(store=store)
+
+    assert result.decision == QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_ACCEPT
+    assert result.rejection_reasons == []
+    assert result.ratchet_result is not None
+    assert result.ratchet_result.decision == ratchet.OUTCOME_RATCHET_RECORDED
+    assert result.ratchet_result.accepted is True
+    assert result.ratchet_result.receipt.publish_receipt_id == PUBLISH_RECEIPT_ID
+    assert result.ratchet_result.receipt.pattern_memory_write_performed is False
+    assert len(store.records) == 1
+    assert store.records[0]["publish_result"]["decision"] == VERIFIED_DRAFT_PR_PUBLISH_ACCEPT
+    assert result.no_command_execution_performed is True
+    assert result.no_pr_publish_performed is True
+    assert result.no_ready_performed is True
+    assert result.no_merge_performed is True
+    assert result.no_reward_settlement_performed is True
+    assert result.no_holoindex_reindex_performed is True
+
+
+def test_explicit_invoke_missing_rejects_before_store() -> None:
+    store = ratchet.InMemoryOutcomeRatchetStore()
+
+    result = invoke_reddog_wre_queue_authorized_verified_outcome_ratchet(
+        explicit_queue_authorized_verified_outcome_ratchet_requested=False,
+        queue_verified_draft_pr_publish_result=_queue_publish_result(),
+        ratchet_request=_ratchet_request(),
+        store=store,
+    )
+
+    assert result.decision == QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_REJECT
+    assert (
+        QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.EXPLICIT_INVOKE_MISSING
+        in result.rejection_reasons
+    )
+    assert store.records == []
+
+
+def test_store_required_rejects() -> None:
+    result = invoke_reddog_wre_queue_authorized_verified_outcome_ratchet(
+        explicit_queue_authorized_verified_outcome_ratchet_requested=True,
+        queue_verified_draft_pr_publish_result=_queue_publish_result(),
+        ratchet_request=_ratchet_request(),
+        store=None,
+    )
+
+    assert result.decision == QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_REJECT
+    assert QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.STORE_REQUIRED in result.rejection_reasons
+
+
+def test_unaccepted_queue_publish_rejects_before_store() -> None:
+    store = ratchet.InMemoryOutcomeRatchetStore()
+
+    result = _invoke(
+        queue_publish=_queue_publish_result(
+            accepted=False,
+            decision=QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_REJECT,
+        ),
+        store=store,
+    )
+
+    assert result.decision == QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_REJECT
+    assert (
+        QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.PUBLISH_INVOKE_NOT_ACCEPTED
+        in result.rejection_reasons
+    )
+    assert (
+        QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.PUBLISH_PAYLOAD_NOT_ACCEPTED
+        in result.rejection_reasons
+    )
+    assert store.records == []
+
+
+def test_verifier_receipt_mismatch_rejects_before_store() -> None:
+    request = _ratchet_request()
+    request["verification_result"]["receipt"]["receipt_id"] = "other-verifier"
+    store = ratchet.InMemoryOutcomeRatchetStore()
+
+    result = _invoke(request=request, store=store)
+
+    assert result.decision == QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_REJECT
+    assert (
+        QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.VERIFIER_RECEIPT_MISMATCH
+        in result.rejection_reasons
+    )
+    assert store.records == []
+
+
+def test_work_order_mismatch_rejects_before_store() -> None:
+    request = _ratchet_request()
+    request["work_order_id"] = "other-work-order"
+    store = ratchet.InMemoryOutcomeRatchetStore()
+
+    result = _invoke(request=request, store=store)
+
+    assert result.decision == QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_REJECT
+    assert (
+        QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.WORK_ORDER_ID_MISMATCH
+        in result.rejection_reasons
+    )
+    assert store.records == []
+
+
+def test_pattern_memory_requires_explicit_flag_and_sink() -> None:
+    request = _ratchet_request()
+    request["enable_pattern_memory_write"] = True
+    store = ratchet.InMemoryOutcomeRatchetStore()
+
+    result = _invoke(request=request, store=store)
+
+    assert result.decision == QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_REJECT
+    assert (
+        QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.PATTERN_MEMORY_EXPLICIT_MISSING
+        in result.rejection_reasons
+    )
+    assert store.records == []
+
+    result = _invoke(request=request, store=store, explicit_pattern=True)
+
+    assert result.decision == QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_REJECT
+    assert (
+        QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.PATTERN_MEMORY_SINK_REQUIRED
+        in result.rejection_reasons
+    )
+    assert store.records == []
+
+
+def test_pattern_memory_write_can_be_explicitly_allowed_after_verification() -> None:
+    request = _ratchet_request()
+    request["enable_pattern_memory_write"] = True
+    store = ratchet.InMemoryOutcomeRatchetStore()
+    sink = FakePatternMemorySink()
+
+    result = _invoke(request=request, store=store, explicit_pattern=True, sink=sink)
+
+    assert result.decision == QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_ACCEPT
+    assert result.ratchet_result is not None
+    assert result.ratchet_result.receipt.pattern_memory_write_performed is True
+    assert result.ratchet_result.receipt.pattern_memory_record_id == "pattern-memory-record-1"
+    assert len(store.records) == 1
+    assert len(sink.records) == 1
+
+
+def test_ratchet_rejection_is_preserved() -> None:
+    request = _ratchet_request()
+    request["holoindex_evidence"]["index_gap_detected"] = True
+    store = ratchet.InMemoryOutcomeRatchetStore()
+
+    result = _invoke(request=request, store=store)
+
+    assert result.decision == QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_REJECT
+    assert (
+        QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.RATCHET_NOT_ACCEPTED
+        in result.rejection_reasons
+    )
+    assert ratchet.FAIL_HOLOINDEX_EVIDENCE in result.rejection_reasons
+    assert result.ratchet_result is not None
+    assert result.ratchet_result.decision == ratchet.OUTCOME_RATCHET_REJECT
+
+
+def test_result_is_json_serializable() -> None:
+    result = _invoke()
+
+    payload = result.to_dict()
+    assert payload["decision"] == QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_ACCEPT
+    assert payload["ratchet_result"]["decision"] == ratchet.OUTCOME_RATCHET_RECORDED
+    json.dumps(payload, sort_keys=True)
+
+
+def test_module_has_no_direct_shell_git_gh_pr_publish_merge_reward_or_holoindex_authority() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    banned_import_roots = {
+        "subprocess",
+        "os",
+        "shutil",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__", "open"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls
+
+    forbidden_tokens = (
+        "subprocess",
+        "git ",
+        "gh pr",
+        "create_draft_pr",
+        "push_branch",
+        "mark_ready",
+        "merge_pr",
+        "settle_reward",
+        "holo_index.py --index",
+    )
+    for token in forbidden_tokens:
+        assert token not in source


### PR DESCRIPTION
## Summary

Implements `REDDOG_WRE_QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_PHASE1` as an explicit bridge from an accepted queue-authorized verified draft PR publish result to the existing WRE verified outcome ratchet.

## Scope

- Adds `reddog_wre_queue_authorized_verified_outcome_ratchet_invoke.py`.
- Requires explicit invoke, injected outcome-ratchet store, accepted queue-authorized draft PR publish result, accepted embedded publish receipt, matching verifier receipt, and matching work order.
- Uses the accepted queue publish result as authoritative publish evidence; request-supplied publish results cannot override it.
- PatternMemory writes remain separately gated: request asks, explicit PatternMemory flag is true, and an injected sink is present.
- Boundary: outcome receipt recording only; no command execution, PR publish, mark-ready, merge, reward settlement, OpenClaw enqueue, Hermes dispatch, or HoloIndex re-index.

## Validation

- `pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_outcome_ratchet_invoke.py modules/infrastructure/wre_core/tests/test_reddog_verified_outcome_ratchet.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_draft_pr_publish_invoke.py -q` -> 35 passed.
- `git diff --check` -> clean, with pre-existing autocrlf warning only.
- New files and diff additions ASCII/NUL clean.
- HoloIndex read-only probe surfaced adjacent policy/runtime/signature/governance files but not the new bridge before indexing. Recorded as `HOLOINDEX_REDDOG_WRE_QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_INDEX_GAP_PHASE1`; no runtime re-index performed.

## Truth Boundary

- No direct shell, git, gh, PR publish, mark-ready, merge, OpenClaw, Hermes, reward, or HoloIndex mutation authority.
- Store and PatternMemory are injected dependencies; PatternMemory requires an extra explicit flag and verified accepted outcome.
- This slice does not automatically invoke from RedDog model output or extension runtime.