### PR TITLE
feat(reddog): invoke held-out regression gate from queue ratchet

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,27 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_WRE_QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_wre_queue_authorized_held_out_regression_gate_invoke.py`:
+  an explicit bridge from an accepted queue-authorized verified outcome
+  ratchet result to the existing WRE held-out recursive-improvement regression
+  gate.
+- The guard binds the authoritative ratchet receipt to the verifier receipt and
+  work-order ID before evaluating held-out regression evidence.
+- Boundary: deterministic held-out gate evaluation only; no test execution,
+  PatternMemory write, PR publish, mark-ready, merge, reward settlement,
+  OpenClaw enqueue, Hermes dispatch, or HoloIndex re-index.
+- HoloIndex read-only probe for `RedDog queue authorized held out regression
+  gate invoke` surfaced adjacent policy, runtime-invocation, receipt, WSP, and
+  recursive self-governance documents, but did not surface this new held-out
+  bridge before indexing. Recorded as
+  `HOLOINDEX_REDDOG_WRE_QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_INDEX_GAP_PHASE1`;
+  no runtime re-index performed. The probe also reported a pre-existing
+  `WSP-GUARDIAN` suspicious-Unicode warning unrelated to the new ASCII-clean
+  files.
+
 ## 2026-07-14: REDDOG_WRE_QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_held_out_regression_gate_invoke.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_held_out_regression_gate_invoke.py
@@ -1,0 +1,196 @@
+"""RedDog queue-authorized held-out regression gate explicit invoke guard.
+
+Slice: REDDOG_WRE_QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_PHASE1
+
+This module consumes an accepted queue-authorized verified outcome ratchet
+result, then invokes the existing WRE held-out recursive-improvement regression
+gate. It emits only a deterministic gate receipt; it never runs tests, writes
+PatternMemory, publishes PRs, merges, executes commands, or mutates HoloIndex.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_verified_outcome_ratchet_invoke import (
+    QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_ACCEPT,
+)
+from modules.infrastructure.wre_core.src.reddog_held_out_recursive_improvement_regression_gate import (
+    HELD_OUT_RECURSIVE_IMPROVEMENT_REGRESSION_GATE_ACCEPT,
+    HeldOutRecursiveImprovementRegressionResult,
+    evaluate_held_out_recursive_improvement_regression_gate,
+)
+from modules.infrastructure.wre_core.src.reddog_verified_outcome_ratchet import (
+    OUTCOME_RATCHET_RECORDED,
+)
+
+
+QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_ACCEPT = (
+    "QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_ACCEPT"
+)
+QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_REJECT = (
+    "QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_REJECT"
+)
+
+
+class QueueAuthorizedHeldOutRegressionGateInvokeReason:
+    EXPLICIT_INVOKE_MISSING = "REJECT_EXPLICIT_QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_MISSING"
+    RATCHET_INVOKE_NOT_ACCEPTED = "REJECT_QUEUE_VERIFIED_OUTCOME_RATCHET_INVOKE_NOT_ACCEPTED"
+    RATCHET_PAYLOAD_MISSING = "REJECT_RATCHET_PAYLOAD_MISSING"
+    RATCHET_PAYLOAD_NOT_RECORDED = "REJECT_RATCHET_PAYLOAD_NOT_RECORDED"
+    RATCHET_RECEIPT_MISSING = "REJECT_RATCHET_RECEIPT_MISSING"
+    GATE_REQUEST_INVALID = "REJECT_HELD_OUT_GATE_REQUEST_INVALID"
+    VERIFICATION_PAYLOAD_MISSING = "REJECT_VERIFICATION_PAYLOAD_MISSING"
+    VERIFIER_RECEIPT_MISMATCH = "REJECT_VERIFIER_RECEIPT_MISMATCH"
+    WORK_ORDER_ID_MISMATCH = "REJECT_WORK_ORDER_ID_MISMATCH"
+    GATE_NOT_ACCEPTED = "REJECT_HELD_OUT_REGRESSION_GATE_NOT_ACCEPTED"
+
+
+@dataclass(frozen=True)
+class QueueAuthorizedHeldOutRegressionGateInvokeResult:
+    decision: str
+    rejection_reasons: List[str] = field(default_factory=list)
+    gate_result: Optional[HeldOutRecursiveImprovementRegressionResult] = None
+    explicit_queue_authorized_held_out_regression_gate_requested: bool = False
+    no_command_execution_performed: bool = True
+    no_test_execution_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_pr_publish_performed: bool = True
+    no_merge_performed: bool = True
+    no_reward_settlement_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["gate_result"] = self.gate_result.to_dict() if self.gate_result else None
+        return payload
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        candidate = value.to_dict()
+        return candidate if isinstance(candidate, Mapping) else {}
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _dedupe(values: Sequence[str]) -> List[str]:
+    return list(dict.fromkeys(str(v) for v in values if str(v or "").strip()))
+
+
+def _reject(
+    reasons: Sequence[str],
+    *,
+    explicit_requested: bool,
+    gate_result: Optional[HeldOutRecursiveImprovementRegressionResult] = None,
+) -> QueueAuthorizedHeldOutRegressionGateInvokeResult:
+    return QueueAuthorizedHeldOutRegressionGateInvokeResult(
+        decision=QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_REJECT,
+        rejection_reasons=_dedupe(reasons),
+        gate_result=gate_result,
+        explicit_queue_authorized_held_out_regression_gate_requested=explicit_requested,
+    )
+
+
+def _same_nonempty(left: Any, right: Any) -> bool:
+    left_text = str(left or "")
+    return bool(left_text) and left_text == str(right or "")
+
+
+def _enrich_gate_request(
+    gate_request: Mapping[str, Any],
+    ratchet_result: Mapping[str, Any],
+) -> Dict[str, Any]:
+    enriched = dict(gate_request)
+    enriched["ratchet_result"] = dict(ratchet_result)
+    return enriched
+
+
+def invoke_reddog_wre_queue_authorized_held_out_regression_gate(
+    *,
+    explicit_queue_authorized_held_out_regression_gate_requested: bool,
+    queue_verified_outcome_ratchet_result: Mapping[str, Any],
+    held_out_gate_request: Mapping[str, Any],
+) -> QueueAuthorizedHeldOutRegressionGateInvokeResult:
+    """Evaluate held-out regression only after accepted queue outcome ratchet."""
+
+    if explicit_queue_authorized_held_out_regression_gate_requested is not True:
+        return _reject(
+            [QueueAuthorizedHeldOutRegressionGateInvokeReason.EXPLICIT_INVOKE_MISSING],
+            explicit_requested=False,
+        )
+
+    reasons: List[str] = []
+    queue_ratchet = _mapping(queue_verified_outcome_ratchet_result)
+    if queue_ratchet.get("decision") != QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_ACCEPT:
+        reasons.append(QueueAuthorizedHeldOutRegressionGateInvokeReason.RATCHET_INVOKE_NOT_ACCEPTED)
+
+    ratchet_payload = _mapping(queue_ratchet.get("ratchet_result"))
+    if not ratchet_payload:
+        reasons.append(QueueAuthorizedHeldOutRegressionGateInvokeReason.RATCHET_PAYLOAD_MISSING)
+    elif (
+        ratchet_payload.get("decision") != OUTCOME_RATCHET_RECORDED
+        or ratchet_payload.get("accepted") is not True
+    ):
+        reasons.append(QueueAuthorizedHeldOutRegressionGateInvokeReason.RATCHET_PAYLOAD_NOT_RECORDED)
+
+    ratchet_receipt = _mapping(ratchet_payload.get("receipt"))
+    if not ratchet_receipt:
+        reasons.append(QueueAuthorizedHeldOutRegressionGateInvokeReason.RATCHET_RECEIPT_MISSING)
+
+    request = _mapping(held_out_gate_request)
+    if not request:
+        reasons.append(QueueAuthorizedHeldOutRegressionGateInvokeReason.GATE_REQUEST_INVALID)
+
+    verification_result = _mapping(request.get("verification_result"))
+    verification_receipt = _mapping(verification_result.get("receipt"))
+    if not verification_result or not verification_receipt:
+        reasons.append(QueueAuthorizedHeldOutRegressionGateInvokeReason.VERIFICATION_PAYLOAD_MISSING)
+    elif ratchet_receipt:
+        if not _same_nonempty(
+            verification_receipt.get("receipt_id"),
+            ratchet_receipt.get("verifier_receipt_id"),
+        ):
+            reasons.append(QueueAuthorizedHeldOutRegressionGateInvokeReason.VERIFIER_RECEIPT_MISMATCH)
+        if not _same_nonempty(
+            request.get("work_order_id") or verification_receipt.get("work_order_id"),
+            ratchet_receipt.get("work_order_id"),
+        ):
+            reasons.append(QueueAuthorizedHeldOutRegressionGateInvokeReason.WORK_ORDER_ID_MISMATCH)
+
+    if reasons:
+        return _reject(reasons, explicit_requested=True)
+
+    gated = evaluate_held_out_recursive_improvement_regression_gate(
+        _enrich_gate_request(request, ratchet_payload)
+    )
+    if (
+        gated.decision != HELD_OUT_RECURSIVE_IMPROVEMENT_REGRESSION_GATE_ACCEPT
+        or gated.accepted is not True
+    ):
+        return _reject(
+            [
+                QueueAuthorizedHeldOutRegressionGateInvokeReason.GATE_NOT_ACCEPTED,
+                *gated.rejection_reasons,
+            ],
+            explicit_requested=True,
+            gate_result=gated,
+        )
+
+    return QueueAuthorizedHeldOutRegressionGateInvokeResult(
+        decision=QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_ACCEPT,
+        rejection_reasons=[],
+        gate_result=gated,
+        explicit_queue_authorized_held_out_regression_gate_requested=True,
+    )
+
+
+__all__ = [
+    "QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_ACCEPT",
+    "QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_REJECT",
+    "QueueAuthorizedHeldOutRegressionGateInvokeReason",
+    "QueueAuthorizedHeldOutRegressionGateInvokeResult",
+    "invoke_reddog_wre_queue_authorized_held_out_regression_gate",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_held_out_regression_gate_invoke.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_held_out_regression_gate_invoke.py
@@ -1,0 +1,314 @@
+"""Tests for REDDOG_WRE_QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_held_out_regression_gate_invoke import (
+    QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_ACCEPT,
+    QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_REJECT,
+    QueueAuthorizedHeldOutRegressionGateInvokeReason,
+    invoke_reddog_wre_queue_authorized_held_out_regression_gate,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_verified_outcome_ratchet_invoke import (
+    QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_ACCEPT,
+    QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_REJECT,
+)
+from modules.infrastructure.wre_core.src import (
+    reddog_held_out_recursive_improvement_regression_gate as gate,
+)
+from modules.infrastructure.wre_core.src.reddog_verified_outcome_ratchet import (
+    OUTCOME_RATCHET_RECORDED,
+    OUTCOME_RATCHET_REJECT,
+)
+from modules.infrastructure.wre_core.src.wre_autonomous_slice_verifier_runtime import (
+    AUTONOMOUS_SLICE_VERIFIER_ACCEPT,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_wre_queue_authorized_held_out_regression_gate_invoke.py"
+)
+WORK_ORDER_ID = "wo-held-out-queue-1"
+SLICE_NAME = "REDDOG_WRE_QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_PHASE1"
+VERIFIER_RECEIPT_ID = "wre_slice_verify_1234"
+RATCHET_ID = "outcome_ratchet_1234"
+HEAD_SHA = "a" * 40
+
+
+def _digest(ch: str) -> str:
+    return "sha256:" + ch * 64
+
+
+def _queue_ratchet_result(*, accepted: bool = True, decision: str | None = None) -> dict:
+    return {
+        "decision": decision or QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_ACCEPT,
+        "rejection_reasons": [] if accepted else ["FAIL_HOLOINDEX_EVIDENCE"],
+        "explicit_queue_authorized_verified_outcome_ratchet_requested": True,
+        "ratchet_result": {
+            "decision": OUTCOME_RATCHET_RECORDED if accepted else OUTCOME_RATCHET_REJECT,
+            "accepted": accepted,
+            "rejection_reasons": [] if accepted else ["FAIL_HOLOINDEX_EVIDENCE"],
+            "receipt": {
+                "ratchet_id": RATCHET_ID,
+                "work_order_id": WORK_ORDER_ID,
+                "slice_name": SLICE_NAME,
+                "outcome_status": "accepted",
+                "verifier_receipt_id": VERIFIER_RECEIPT_ID,
+                "publish_receipt_id": "verified_draft_pr_1234",
+                "pattern_memory_eligible": accepted,
+                "pattern_memory_write_performed": False,
+                "pattern_memory_record_id": None,
+                "rejection_reasons": [] if accepted else ["FAIL_HOLOINDEX_EVIDENCE"],
+            },
+        },
+    }
+
+
+def _gate_request() -> dict:
+    return {
+        "work_order_id": WORK_ORDER_ID,
+        "slice_name": SLICE_NAME,
+        "worker_id": "worker-0102",
+        "enable_pattern_memory_admission": True,
+        "improvement_job": {
+            "job_id": "imp_wsp_violation_1234_abcd",
+            "finding_id": "fmas-1",
+            "improvement_type": "wsp_violation",
+            "status": "pending",
+            "dry_run": True,
+        },
+        "verification_result": {
+            "accepted": True,
+            "decision": AUTONOMOUS_SLICE_VERIFIER_ACCEPT,
+            "receipt": {
+                "receipt_id": VERIFIER_RECEIPT_ID,
+                "work_order_id": WORK_ORDER_ID,
+                "slice_name": SLICE_NAME,
+                "worker_id": "worker-0102",
+                "verifier_id": "verifier-0102",
+                "head_sha": HEAD_SHA,
+            },
+        },
+        "ratchet_result": {
+            "accepted": False,
+            "decision": OUTCOME_RATCHET_REJECT,
+            "receipt": {
+                "ratchet_id": "tampered-ratchet",
+                "pattern_memory_write_performed": True,
+            },
+        },
+        "held_out_regression": {
+            "suite_id": "heldout-wre-recursive-001",
+            "is_held_out": True,
+            "independent": True,
+            "generated_by_author": False,
+            "evidence_author_id": "verifier-0102",
+            "passed": True,
+            "test_count": 12,
+            "failure_count": 0,
+            "suite_digest": _digest("1"),
+            "baseline_digest": _digest("2"),
+            "candidate_digest": _digest("3"),
+            "candidate_head_sha": HEAD_SHA,
+        },
+        "holoindex_evidence": {
+            "index_gap_detected": False,
+            "holoindex_freshness_receipt_digest": _digest("4"),
+        },
+    }
+
+
+def _invoke(*, queue_ratchet: dict | None = None, request: dict | None = None):
+    return invoke_reddog_wre_queue_authorized_held_out_regression_gate(
+        explicit_queue_authorized_held_out_regression_gate_requested=True,
+        queue_verified_outcome_ratchet_result=queue_ratchet or _queue_ratchet_result(),
+        held_out_gate_request=request or _gate_request(),
+    )
+
+
+def test_accepts_held_out_gate_after_queue_outcome_ratchet() -> None:
+    result = _invoke()
+
+    assert result.decision == QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_ACCEPT
+    assert result.rejection_reasons == []
+    assert result.gate_result is not None
+    assert result.gate_result.decision == gate.HELD_OUT_RECURSIVE_IMPROVEMENT_REGRESSION_GATE_ACCEPT
+    assert result.gate_result.pattern_memory_admission_allowed is True
+    assert result.gate_result.receipt.ratchet_id == RATCHET_ID
+    assert result.gate_result.receipt.no_pattern_memory_write_performed is True
+    assert result.no_command_execution_performed is True
+    assert result.no_test_execution_performed is True
+    assert result.no_pattern_memory_write_performed is True
+    assert result.no_pr_publish_performed is True
+    assert result.no_merge_performed is True
+    assert result.no_reward_settlement_performed is True
+    assert result.no_holoindex_reindex_performed is True
+
+
+def test_explicit_invoke_missing_rejects() -> None:
+    result = invoke_reddog_wre_queue_authorized_held_out_regression_gate(
+        explicit_queue_authorized_held_out_regression_gate_requested=False,
+        queue_verified_outcome_ratchet_result=_queue_ratchet_result(),
+        held_out_gate_request=_gate_request(),
+    )
+
+    assert result.decision == QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_REJECT
+    assert (
+        QueueAuthorizedHeldOutRegressionGateInvokeReason.EXPLICIT_INVOKE_MISSING
+        in result.rejection_reasons
+    )
+    assert result.gate_result is None
+
+
+def test_unaccepted_queue_ratchet_rejects_before_gate() -> None:
+    result = _invoke(
+        queue_ratchet=_queue_ratchet_result(
+            accepted=False,
+            decision=QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_REJECT,
+        )
+    )
+
+    assert result.decision == QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_REJECT
+    assert (
+        QueueAuthorizedHeldOutRegressionGateInvokeReason.RATCHET_INVOKE_NOT_ACCEPTED
+        in result.rejection_reasons
+    )
+    assert (
+        QueueAuthorizedHeldOutRegressionGateInvokeReason.RATCHET_PAYLOAD_NOT_RECORDED
+        in result.rejection_reasons
+    )
+    assert result.gate_result is None
+
+
+def test_missing_verification_payload_rejects_before_gate() -> None:
+    request = _gate_request()
+    request["verification_result"] = {}
+
+    result = _invoke(request=request)
+
+    assert result.decision == QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_REJECT
+    assert (
+        QueueAuthorizedHeldOutRegressionGateInvokeReason.VERIFICATION_PAYLOAD_MISSING
+        in result.rejection_reasons
+    )
+    assert result.gate_result is None
+
+
+def test_verifier_receipt_mismatch_rejects_before_gate() -> None:
+    request = _gate_request()
+    request["verification_result"]["receipt"]["receipt_id"] = "other-verifier"
+
+    result = _invoke(request=request)
+
+    assert result.decision == QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_REJECT
+    assert (
+        QueueAuthorizedHeldOutRegressionGateInvokeReason.VERIFIER_RECEIPT_MISMATCH
+        in result.rejection_reasons
+    )
+    assert result.gate_result is None
+
+
+def test_work_order_mismatch_rejects_before_gate() -> None:
+    request = _gate_request()
+    request["work_order_id"] = "other-work-order"
+
+    result = _invoke(request=request)
+
+    assert result.decision == QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_REJECT
+    assert (
+        QueueAuthorizedHeldOutRegressionGateInvokeReason.WORK_ORDER_ID_MISMATCH
+        in result.rejection_reasons
+    )
+    assert result.gate_result is None
+
+
+def test_gate_rejection_is_preserved() -> None:
+    request = _gate_request()
+    request["held_out_regression"]["generated_by_author"] = True
+
+    result = _invoke(request=request)
+
+    assert result.decision == QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_REJECT
+    assert (
+        QueueAuthorizedHeldOutRegressionGateInvokeReason.GATE_NOT_ACCEPTED
+        in result.rejection_reasons
+    )
+    assert gate.FAIL_AUTHOR_GENERATED_SUITE in result.rejection_reasons
+    assert result.gate_result is not None
+    assert result.gate_result.decision == gate.HELD_OUT_RECURSIVE_IMPROVEMENT_REGRESSION_GATE_REJECT
+
+
+def test_ratchet_with_prior_pattern_memory_write_is_rejected_by_gate() -> None:
+    queue_ratchet = _queue_ratchet_result()
+    queue_ratchet["ratchet_result"]["receipt"]["pattern_memory_write_performed"] = True
+
+    result = _invoke(queue_ratchet=queue_ratchet)
+
+    assert result.decision == QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_REJECT
+    assert gate.FAIL_RATCHET_RECEIPT in result.rejection_reasons
+    assert gate.FAIL_PATTERN_MEMORY_ALREADY_WRITTEN in result.rejection_reasons
+
+
+def test_result_is_json_serializable() -> None:
+    result = _invoke()
+
+    payload = result.to_dict()
+    assert payload["decision"] == QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_ACCEPT
+    assert (
+        payload["gate_result"]["decision"]
+        == gate.HELD_OUT_RECURSIVE_IMPROVEMENT_REGRESSION_GATE_ACCEPT
+    )
+    json.dumps(payload, sort_keys=True)
+
+
+def test_module_has_no_direct_shell_git_pr_test_memory_reward_or_holoindex_authority() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    banned_import_roots = {
+        "subprocess",
+        "os",
+        "shutil",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+        "pattern_memory",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__", "open"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls
+
+    forbidden_tokens = (
+        "subprocess",
+        "git ",
+        "gh pr",
+        "pytest",
+        "create_draft_pr",
+        "push_branch",
+        "mark_ready",
+        "merge_pr",
+        "store_verified_outcome",
+        "settle_reward",
+        "holo_index.py --index",
+    )
+    for token in forbidden_tokens:
+        assert token not in source


### PR DESCRIPTION
## Summary

Implements `REDDOG_WRE_QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_PHASE1` as an explicit non-mutating bridge from an accepted queue-authorized verified outcome ratchet result to the existing WRE held-out recursive-improvement regression gate.

## Scope

- Adds `reddog_wre_queue_authorized_held_out_regression_gate_invoke.py`.
- Requires explicit invoke, accepted queue outcome ratchet result, accepted embedded ratchet receipt, matching verifier receipt, and matching work order.
- Uses the accepted queue ratchet result as authoritative ratchet evidence; caller-supplied ratchet data in the held-out request cannot override it.
- Boundary: deterministic held-out gate evaluation only; no test execution, PatternMemory write, PR publish, mark-ready, merge, reward settlement, OpenClaw enqueue, Hermes dispatch, or HoloIndex re-index.

## Validation

- `pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_held_out_regression_gate_invoke.py modules/infrastructure/wre_core/tests/test_reddog_held_out_recursive_improvement_regression_gate.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_outcome_ratchet_invoke.py -q` -> 35 passed.
- `git diff --check` -> clean, with pre-existing autocrlf warning only.
- New files and diff additions ASCII/NUL clean.
- HoloIndex read-only probe surfaced adjacent policy/runtime/receipt/governance files but not the new bridge before indexing. Recorded as `HOLOINDEX_REDDOG_WRE_QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_INDEX_GAP_PHASE1`; no runtime re-index performed.

## Truth Boundary

- No direct shell, git, gh, test execution, PR publish, mark-ready, merge, OpenClaw, Hermes, reward, PatternMemory write, or HoloIndex mutation authority.
- Held-out regression evidence is evaluated, not generated or executed, by this slice.
- This slice does not automatically invoke from RedDog model output or extension runtime.