### PR TITLE
feat(reddog): bootstrap resident queue plan

### DIFF
--- a/main.py
+++ b/main.py
@@ -1400,6 +1400,64 @@ def run_reddog_wre_queue_consumer_preflight(repo_root: Path) -> bool:
     return True
 
 
+def run_reddog_resident_queue_orchestration_plan_preflight(repo_root: Path) -> bool:
+    """
+    Plan the next resident RedDog queue bridge from the authoritative snapshot.
+
+    Env:
+        REDDOG_RESIDENT_QUEUE_ORCHESTRATION_PLAN=1          Enable check (default ON)
+        REDDOG_RESIDENT_QUEUE_ORCHESTRATION_PLAN_ENFORCED=0 Block startup if not ready
+        REDDOG_AUTHORITATIVE_WORK_STATE_PATH                Existing work-state snapshot
+        REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH            Optional existing chain-results JSON
+        REDDOG_WRE_QUEUE_ITEM_ID                            Optional exact queue item id
+    """
+
+    if os.getenv("REDDOG_RESIDENT_QUEUE_ORCHESTRATION_PLAN", "1") == "0":
+        logger.info("[REDDOG-QUEUE-PLAN] Startup queue plan disabled")
+        return True
+
+    enforced = os.getenv("REDDOG_RESIDENT_QUEUE_ORCHESTRATION_PLAN_ENFORCED", "0") != "0"
+
+    try:
+        from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_orchestration_plan_bootstrap import (
+            run_reddog_main_resident_queue_orchestration_plan_bootstrap,
+        )
+
+        result = run_reddog_main_resident_queue_orchestration_plan_bootstrap(
+            repo_root=repo_root,
+            work_state_path=os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
+            chain_results_path=os.getenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH", "") or None,
+            requested_queue_item_id=os.getenv("REDDOG_WRE_QUEUE_ITEM_ID", "") or None,
+        )
+    except Exception as exc:
+        logger.error(f"[REDDOG-QUEUE-PLAN] Startup queue plan failed: {exc}")
+        if enforced:
+            print(f"[REDDOG-QUEUE-PLAN] preflight=FAIL error={type(exc).__name__}")
+            return False
+        print(f"[REDDOG-QUEUE-PLAN] preflight=WARN error={type(exc).__name__}")
+        return True
+
+    status = "PASS" if result.ready else "WARN"
+    reasons = ",".join(result.rejection_reasons) if result.rejection_reasons else "(none)"
+    print(
+        f"[REDDOG-QUEUE-PLAN] preflight={status} status={result.status} "
+        f"queue_item={result.queue_item_id or '(none)'} "
+        f"selected_slice={result.selected_slice or '(none)'} "
+        f"current_stage={result.current_stage or '(none)'} "
+        f"next_action={result.next_action or '(none)'} "
+        f"accepted_stages={result.accepted_stage_count} "
+        f"chain_complete={result.chain_complete} reasons={reasons}"
+    )
+    if result.ready:
+        print(f"[REDDOG-QUEUE-PLAN] plan={result.plan_id}")
+        return True
+
+    if enforced:
+        print("[REDDOG-QUEUE-PLAN] Startup blocked by REDDOG_RESIDENT_QUEUE_ORCHESTRATION_PLAN_ENFORCED=1")
+        return False
+    return True
+
+
 def bootstrap_runtime_dae_launches() -> None:
     """Register broker-managed DAE entrypoints for an already running system."""
     daemon = get_central_daemon()
@@ -1575,6 +1633,8 @@ def main():
     if not run_reddog_authoritative_work_state_refresh_preflight(repo_root):
         return
     if not run_reddog_wre_queue_consumer_preflight(repo_root):
+        return
+    if not run_reddog_resident_queue_orchestration_plan_preflight(repo_root):
         return
     if not run_reddog_readonly_operational_bootstrap_preflight(repo_root):
         return

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,26 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_ORCHESTRATION_PLAN_BOOTSTRAP_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added
+  `src/reddog_main_resident_queue_orchestration_plan_bootstrap.py`: a guarded
+  `main.py` adapter for the resident queue orchestration planner.
+- Wired `main.py` to print the next queue-chain bridge after authoritative
+  work-state refresh and WRE queue-consumer dry-run, warning-only by default
+  unless `REDDOG_RESIDENT_QUEUE_ORCHESTRATION_PLAN_ENFORCED=1`.
+- The adapter reads existing work-state and optional chain-results JSON only
+  from outside the repository checkout, then calls the pure planner from
+  `REDDOG_RESIDENT_QUEUE_ORCHESTRATION_PLAN_PHASE1`.
+- Boundary: startup reporting only; no bridge invocation, authority issuance,
+  signature verification, worker spawn, worktree creation, file edit, shell
+  command, PR publishing, PatternMemory write, OpenClaw enqueue, Hermes
+  dispatch, reward settlement, or HoloIndex re-index.
+- HoloIndex discoverability is covered by the prior planner INDEX_GAP
+  (`HOLOINDEX_REDDOG_RESIDENT_QUEUE_ORCHESTRATION_PLAN_INDEX_GAP_PHASE1`);
+  this bootstrap slice performs no runtime re-index.
+
 ## 2026-07-14: REDDOG_RESIDENT_QUEUE_ORCHESTRATION_PLAN_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_orchestration_plan_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_orchestration_plan_bootstrap.py
@@ -1,0 +1,192 @@
+"""Main-startup adapter for the RedDog resident queue orchestration planner.
+
+This adapter wires ``main.py`` to the non-mutating resident queue planner. It
+reads an existing authoritative work-state snapshot and optional chain-results
+JSON from outside the repository checkout, then reports the next guarded bridge
+RedDog should run. It does not invoke that bridge.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_orchestration_plan import (
+    RESIDENT_QUEUE_ORCHESTRATION_PLAN_COMPLETE,
+    RESIDENT_QUEUE_ORCHESTRATION_PLAN_READY,
+    plan_reddog_resident_queue_orchestration,
+)
+
+
+REDDOG_RESIDENT_QUEUE_PLAN_BOOTSTRAP_READY = "REDDOG_RESIDENT_QUEUE_PLAN_BOOTSTRAP_READY"
+REDDOG_RESIDENT_QUEUE_PLAN_BOOTSTRAP_NOT_READY = "REDDOG_RESIDENT_QUEUE_PLAN_BOOTSTRAP_NOT_READY"
+
+
+@dataclass(frozen=True)
+class RedDogMainResidentQueuePlanBootstrapResult:
+    """Result returned to ``main.py`` for startup reporting."""
+
+    ready: bool
+    status: str
+    plan_id: Optional[str]
+    queue_item_id: Optional[str]
+    selected_slice: Optional[str]
+    next_action: Optional[str]
+    current_stage: Optional[str]
+    accepted_stage_count: int
+    rejection_reasons: tuple[str, ...]
+    chain_complete: bool = False
+    no_bridge_invoked: bool = True
+    no_authority_issued: bool = True
+    no_worker_spawn_performed: bool = True
+    no_worktree_created: bool = True
+    no_shell_command_executed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pr_created: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_reward_settlement_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_main_resident_queue_orchestration_plan_bootstrap(
+    *,
+    repo_root: Path | str,
+    work_state_path: Path | str | None,
+    chain_results_path: Path | str | None = None,
+    requested_queue_item_id: str | None = None,
+    now_iso: str | None = None,
+) -> RedDogMainResidentQueuePlanBootstrapResult:
+    """Load queue state and emit the next resident RedDog bridge action."""
+
+    root = Path(repo_root).resolve()
+    snapshot_result = _read_json_outside_repo(
+        root,
+        work_state_path,
+        missing_reason="missing_authoritative_work_state_path",
+        inside_reason="work_state_path_inside_repo",
+        unreadable_reason="malformed_authoritative_work_state",
+    )
+    if snapshot_result[1]:
+        return _not_ready(snapshot_result[1])
+    snapshot = snapshot_result[0]
+    assert snapshot is not None
+
+    chain_results: Mapping[str, Mapping[str, Any]] = {}
+    if chain_results_path:
+        chain_result = _read_json_outside_repo(
+            root,
+            chain_results_path,
+            missing_reason="missing_chain_results",
+            inside_reason="chain_results_path_inside_repo",
+            unreadable_reason="malformed_chain_results",
+        )
+        if chain_result[1]:
+            return _not_ready(chain_result[1])
+        raw_chain = chain_result[0]
+        if not isinstance(raw_chain, Mapping):
+            return _not_ready(("chain_results_not_mapping",))
+        chain_results = {
+            str(key): value
+            for key, value in raw_chain.items()
+            if isinstance(value, Mapping)
+        }
+        if len(chain_results) != len(raw_chain):
+            return _not_ready(("chain_results_contains_non_mapping_stage",))
+
+    plan = plan_reddog_resident_queue_orchestration(
+        snapshot,
+        chain_results=chain_results,
+        requested_queue_item_id=requested_queue_item_id,
+        now_iso=now_iso,
+    )
+    if not plan.accepted or plan.status not in {
+        RESIDENT_QUEUE_ORCHESTRATION_PLAN_READY,
+        RESIDENT_QUEUE_ORCHESTRATION_PLAN_COMPLETE,
+    }:
+        return RedDogMainResidentQueuePlanBootstrapResult(
+            ready=False,
+            status=REDDOG_RESIDENT_QUEUE_PLAN_BOOTSTRAP_NOT_READY,
+            plan_id=plan.plan_id,
+            queue_item_id=plan.selected_queue_item_id,
+            selected_slice=plan.selected_slice,
+            next_action=plan.next_action,
+            current_stage=plan.current_stage,
+            accepted_stage_count=len(plan.accepted_stages),
+            rejection_reasons=tuple(plan.rejection_reasons),
+        )
+
+    return RedDogMainResidentQueuePlanBootstrapResult(
+        ready=True,
+        status=REDDOG_RESIDENT_QUEUE_PLAN_BOOTSTRAP_READY,
+        plan_id=plan.plan_id,
+        queue_item_id=plan.selected_queue_item_id,
+        selected_slice=plan.selected_slice,
+        next_action=plan.next_action,
+        current_stage=plan.current_stage,
+        accepted_stage_count=len(plan.accepted_stages),
+        rejection_reasons=(),
+        chain_complete=plan.status == RESIDENT_QUEUE_ORCHESTRATION_PLAN_COMPLETE,
+    )
+
+
+def _read_json_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    missing_reason: str,
+    inside_reason: str,
+    unreadable_reason: str,
+) -> tuple[Optional[Mapping[str, Any]], tuple[str, ...]]:
+    if not value:
+        return None, (missing_reason,)
+    path = Path(value)
+    if not path.is_absolute():
+        path = (repo_root / path).resolve()
+    else:
+        path = path.resolve()
+    if _is_inside(path, repo_root):
+        return None, (inside_reason,)
+    if not path.exists() or not path.is_file():
+        return None, (missing_reason,)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None, (unreadable_reason,)
+    if not isinstance(payload, Mapping):
+        return None, (unreadable_reason,)
+    return payload, ()
+
+
+def _not_ready(reasons: tuple[str, ...]) -> RedDogMainResidentQueuePlanBootstrapResult:
+    return RedDogMainResidentQueuePlanBootstrapResult(
+        ready=False,
+        status=REDDOG_RESIDENT_QUEUE_PLAN_BOOTSTRAP_NOT_READY,
+        plan_id=None,
+        queue_item_id=None,
+        selected_slice=None,
+        next_action=None,
+        current_stage=None,
+        accepted_stage_count=0,
+        rejection_reasons=reasons,
+    )
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+__all__ = [
+    "REDDOG_RESIDENT_QUEUE_PLAN_BOOTSTRAP_NOT_READY",
+    "REDDOG_RESIDENT_QUEUE_PLAN_BOOTSTRAP_READY",
+    "RedDogMainResidentQueuePlanBootstrapResult",
+    "run_reddog_main_resident_queue_orchestration_plan_bootstrap",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_orchestration_plan_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_orchestration_plan_bootstrap.py
@@ -1,0 +1,291 @@
+"""Tests for REDDOG_MAIN_RESIDENT_QUEUE_ORCHESTRATION_PLAN_BOOTSTRAP_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_orchestration_plan_bootstrap import (
+    REDDOG_RESIDENT_QUEUE_PLAN_BOOTSTRAP_NOT_READY,
+    REDDOG_RESIDENT_QUEUE_PLAN_BOOTSTRAP_READY,
+    run_reddog_main_resident_queue_orchestration_plan_bootstrap,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_orchestration_plan import (
+    NEXT_QUEUE_AUTHORITY_REQUEST_DRYRUN,
+    NEXT_QUEUE_AUTHORITY_RUNTIME_INVOKE,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_main_resident_queue_orchestration_plan_bootstrap.py"
+)
+NOW = "2026-07-14T00:00:00+00:00"
+EXPIRES = "2026-07-14T01:00:00+00:00"
+
+
+def _snapshot() -> dict[str, object]:
+    return {
+        "schema_version": "reddog_authoritative_work_state.v1",
+        "freshness_receipts": [{"receipt_id": "fresh-1", "fresh": True}],
+        "worker_claims": [
+            {
+                "claim_id": "claim-1",
+                "slice_id": "REDDOG_TEST_SLICE_PHASE1",
+                "worker_id": "reddog-0102",
+                "status": "ACTIVE",
+                "expires_at": EXPIRES,
+                "freshness_receipt_id": "fresh-1",
+            }
+        ],
+        "wre_queue_items": [
+            {
+                "queue_item_id": "queue-1",
+                "slice_id": "REDDOG_TEST_SLICE_PHASE1",
+                "claim_id": "claim-1",
+                "worker_id": "reddog-0102",
+                "status": "QUEUED",
+                "evidence_refs": ["claim:claim-1", "freshness:fresh-1"],
+                "no_execution_performed": True,
+            }
+        ],
+    }
+
+
+def _write_runtime_json(tmp_path: Path, name: str, payload: object) -> Path:
+    path = tmp_path / "runtime" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _repo(tmp_path: Path) -> Path:
+    path = tmp_path / "repo"
+    path.mkdir()
+    return path
+
+
+def test_bootstrap_reports_next_bridge_from_authoritative_snapshot(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+
+    result = run_reddog_main_resident_queue_orchestration_plan_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        now_iso=NOW,
+    )
+
+    assert result.ready is True
+    assert result.status == REDDOG_RESIDENT_QUEUE_PLAN_BOOTSTRAP_READY
+    assert result.queue_item_id == "queue-1"
+    assert result.selected_slice == "REDDOG_TEST_SLICE_PHASE1"
+    assert result.current_stage == "authority_request"
+    assert result.next_action == NEXT_QUEUE_AUTHORITY_REQUEST_DRYRUN
+    assert result.accepted_stage_count == 1
+    assert result.chain_complete is False
+    assert result.no_bridge_invoked is True
+    assert result.no_holoindex_reindex_performed is True
+
+
+def test_bootstrap_uses_chain_results_to_advance_next_bridge(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    chain = _write_runtime_json(
+        tmp_path,
+        "chain_results.json",
+        {"authority_request": {"status": "QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT"}},
+    )
+
+    result = run_reddog_main_resident_queue_orchestration_plan_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        now_iso=NOW,
+    )
+
+    assert result.ready is True
+    assert result.next_action == NEXT_QUEUE_AUTHORITY_RUNTIME_INVOKE
+    assert result.current_stage == "authority_runtime"
+    assert result.accepted_stage_count == 2
+
+
+def test_bootstrap_rejects_missing_work_state_path() -> None:
+    result = run_reddog_main_resident_queue_orchestration_plan_bootstrap(
+        repo_root=REPO_ROOT,
+        work_state_path=None,
+        now_iso=NOW,
+    )
+
+    assert result.ready is False
+    assert result.status == REDDOG_RESIDENT_QUEUE_PLAN_BOOTSTRAP_NOT_READY
+    assert "missing_authoritative_work_state_path" in result.rejection_reasons
+
+
+def test_bootstrap_rejects_work_state_inside_repo(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    inside = repo / "work_state.json"
+    inside.write_text(json.dumps(_snapshot()), encoding="utf-8")
+
+    result = run_reddog_main_resident_queue_orchestration_plan_bootstrap(
+        repo_root=repo,
+        work_state_path=inside,
+        now_iso=NOW,
+    )
+
+    assert result.ready is False
+    assert "work_state_path_inside_repo" in result.rejection_reasons
+
+
+def test_bootstrap_rejects_chain_results_inside_repo(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    inside_chain = repo / "chain_results.json"
+    inside_chain.write_text("{}", encoding="utf-8")
+
+    result = run_reddog_main_resident_queue_orchestration_plan_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=inside_chain,
+        now_iso=NOW,
+    )
+
+    assert result.ready is False
+    assert "chain_results_path_inside_repo" in result.rejection_reasons
+
+
+def test_bootstrap_rejects_malformed_chain_results(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    chain = _write_runtime_json(tmp_path, "chain_results.json", {"authority_request": "bad"})
+
+    result = run_reddog_main_resident_queue_orchestration_plan_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        now_iso=NOW,
+    )
+
+    assert result.ready is False
+    assert "chain_results_contains_non_mapping_stage" in result.rejection_reasons
+
+
+def test_main_resident_queue_plan_preflight_passes_when_bootstrap_ready(tmp_path: Path) -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_resident_queue_orchestration_plan_bootstrap.run_reddog_main_resident_queue_orchestration_plan_bootstrap",
+        return_value=type(
+            "Result",
+            (),
+            {
+                "ready": True,
+                "status": REDDOG_RESIDENT_QUEUE_PLAN_BOOTSTRAP_READY,
+                "plan_id": "plan-1",
+                "queue_item_id": "queue-1",
+                "selected_slice": "REDDOG_TEST_SLICE_PHASE1",
+                "current_stage": "authority_request",
+                "next_action": NEXT_QUEUE_AUTHORITY_REQUEST_DRYRUN,
+                "accepted_stage_count": 1,
+                "chain_complete": False,
+                "rejection_reasons": (),
+            },
+        )(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_QUEUE_ORCHESTRATION_PLAN": "1",
+                "REDDOG_RESIDENT_QUEUE_ORCHESTRATION_PLAN_ENFORCED": "0",
+                "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+                "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
+                "REDDOG_WRE_QUEUE_ITEM_ID": "queue-1",
+            },
+            clear=False,
+        ):
+            assert main.run_reddog_resident_queue_orchestration_plan_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["work_state_path"] == str(tmp_path / "state.json")
+    assert mocked.call_args.kwargs["chain_results_path"] == str(tmp_path / "chain.json")
+    assert mocked.call_args.kwargs["requested_queue_item_id"] == "queue-1"
+
+
+def test_main_resident_queue_plan_preflight_blocks_when_enforced() -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_resident_queue_orchestration_plan_bootstrap.run_reddog_main_resident_queue_orchestration_plan_bootstrap",
+        return_value=type(
+            "Result",
+            (),
+            {
+                "ready": False,
+                "status": REDDOG_RESIDENT_QUEUE_PLAN_BOOTSTRAP_NOT_READY,
+                "plan_id": None,
+                "queue_item_id": None,
+                "selected_slice": None,
+                "current_stage": None,
+                "next_action": None,
+                "accepted_stage_count": 0,
+                "chain_complete": False,
+                "rejection_reasons": ("missing_authoritative_work_state_path",),
+            },
+        )(),
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_QUEUE_ORCHESTRATION_PLAN": "1",
+                "REDDOG_RESIDENT_QUEUE_ORCHESTRATION_PLAN_ENFORCED": "1",
+                "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": "",
+            },
+            clear=False,
+        ):
+            assert main.run_reddog_resident_queue_orchestration_plan_preflight(REPO_ROOT) is False
+
+
+def test_module_has_no_execution_network_or_reindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    banned_attrs = {
+        "system",
+        "popen",
+        "spawn",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "replace",
+        "unlink",
+        "remove",
+        "rmdir",
+        "rename",
+    }
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs


### PR DESCRIPTION
## REDDOG_MAIN_RESIDENT_QUEUE_ORCHESTRATION_PLAN_BOOTSTRAP_PHASE1

WSP_97 status: VERIFIED_READY draft PR.

### Purpose

Wire `main.py` to the non-mutating resident queue orchestration planner so startup can report the next guarded RedDog bridge after authoritative work-state refresh and WRE queue-consumer dry-run.

### Files

| File | Role |
| --- | --- |
| `main.py` | Adds warning-only resident queue plan preflight |
| `modules/communication/moltbot_bridge/src/reddog_main_resident_queue_orchestration_plan_bootstrap.py` | Startup adapter that reads outside-repo JSON and calls planner |
| `modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_orchestration_plan_bootstrap.py` | 9 tests + AST guard |
| `modules/communication/moltbot_bridge/ModLog.md` | Slice evidence |

### Behavior

- Reads `REDDOG_AUTHORITATIVE_WORK_STATE_PATH` from outside the repo checkout.
- Optionally reads `REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH` from outside the repo checkout.
- Calls the pure planner from `REDDOG_RESIDENT_QUEUE_ORCHESTRATION_PLAN_PHASE1`.
- Prints queue item, selected slice, current stage, next action, accepted stage count, and plan id.
- Warning-only by default; blocks only with `REDDOG_RESIDENT_QUEUE_ORCHESTRATION_PLAN_ENFORCED=1`.

### Boundary

Startup reporting only. No bridge invocation, authority issuance, signature verification, worker spawn, worktree creation, file edit, shell command, PR publishing, PatternMemory write, OpenClaw enqueue, Hermes dispatch, reward settlement, or HoloIndex re-index.

### Validation

```text
20 passed  bootstrap + planner tests
49 passed  adjacent main/work-state/queue bootstrap tests
git diff --check clean
new source/test files ASCII-clean; main.py and ModLog added lines ASCII-clean
HoloIndex read-only probe confirms the new bootstrap module is not yet discoverable
```

### HoloIndex

Read-only query `RedDog main resident queue orchestration plan bootstrap next action` surfaced adjacent/irrelevant queue and RedDog docs but not this new bootstrap module before indexing.

INDEX_GAP: `HOLOINDEX_REDDOG_RESIDENT_QUEUE_ORCHESTRATION_PLAN_INDEX_GAP_PHASE1`

### Residual SPECIFIED_NOT_IMPLEMENTED

- No automatic bridge invocation from startup output.
- No signer/worktree/worker runtime is started by this preflight.
- No OpenClaw/Hermes worker spawn.
- HoloIndex re-index remains WRE/CI-owned, never RedDog runtime-owned.