### PR TITLE
feat(reddog): store resident queue chain results

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,28 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_STORE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_resident_queue_chain_results_store.py`: an atomic
+  outside-repo store for already-produced resident queue-chain stage results.
+- The store replays the current queue orchestration plan, records only the
+  exact current missing stage, replays the proposed plan, and commits only if
+  the chain advances cleanly.
+- Updated the resident queue plan bootstrap to read the governed
+  `reddog_resident_queue_chain_results.v1` schema in addition to raw stage
+  mappings.
+- Boundary: chain-result persistence only; no bridge invocation, authority
+  issuance, signature verification, worker spawn, worktree creation, file edit,
+  shell command, PR publishing, PatternMemory write, OpenClaw enqueue, Hermes
+  dispatch, reward settlement, or HoloIndex re-index.
+- HoloIndex read-only probe for `RedDog resident queue chain results store
+  atomic stage result` surfaced adjacent worker-queue, PQN orchestrator,
+  consensus, WSP, and live-enqueue docs, but not this new store before
+  indexing. Recorded as
+  `HOLOINDEX_REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_STORE_INDEX_GAP_PHASE1`; no
+  runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_ORCHESTRATION_PLAN_BOOTSTRAP_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_orchestration_plan_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_orchestration_plan_bootstrap.py
@@ -92,6 +92,11 @@ def run_reddog_main_resident_queue_orchestration_plan_bootstrap(
         raw_chain = chain_result[0]
         if not isinstance(raw_chain, Mapping):
             return _not_ready(("chain_results_not_mapping",))
+        if raw_chain.get("schema_version") == "reddog_resident_queue_chain_results.v1":
+            stage_results = raw_chain.get("stage_results")
+            if not isinstance(stage_results, Mapping):
+                return _not_ready(("chain_results_stage_results_not_mapping",))
+            raw_chain = stage_results
         chain_results = {
             str(key): value
             for key, value in raw_chain.items()

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_chain_results_store.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_chain_results_store.py
@@ -1,0 +1,377 @@
+"""Resident RedDog queue chain-results store.
+
+Slice: REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_STORE_PHASE1
+
+This module atomically records one already-produced queue-chain stage result
+for the resident RedDog loop. It does not invoke the stage. Before committing,
+it replays the current resident queue orchestration plan and verifies the stage
+being recorded is exactly the current missing stage. It then replays the plan
+with the proposed result and commits only if the plan advances cleanly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, Optional, Protocol, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_orchestration_plan import (
+    RESIDENT_QUEUE_ORCHESTRATION_PLAN_COMPLETE,
+    RESIDENT_QUEUE_ORCHESTRATION_PLAN_READY,
+    ResidentQueueOrchestrationPlan,
+    plan_reddog_resident_queue_orchestration,
+)
+
+
+CHAIN_RESULTS_SCHEMA_VERSION = "reddog_resident_queue_chain_results.v1"
+CHAIN_RESULT_RECORDED = "CHAIN_RESULT_RECORDED"
+CHAIN_RESULT_REJECTED = "CHAIN_RESULT_REJECTED"
+
+FAIL_STAGE_KEY_REQUIRED = "FAIL_STAGE_KEY_REQUIRED"
+FAIL_STAGE_RESULT_REQUIRED = "FAIL_STAGE_RESULT_REQUIRED"
+FAIL_STAGE_ALREADY_RECORDED = "FAIL_STAGE_ALREADY_RECORDED"
+FAIL_CURRENT_PLAN_NOT_READY = "FAIL_CURRENT_PLAN_NOT_READY"
+FAIL_STAGE_NOT_CURRENT = "FAIL_STAGE_NOT_CURRENT"
+FAIL_PROPOSED_PLAN_REJECTED = "FAIL_PROPOSED_PLAN_REJECTED"
+FAIL_ATOMIC_COMMIT_FAILED = "FAIL_ATOMIC_COMMIT_FAILED"
+
+
+class ResidentQueueChainResultsStore(Protocol):
+    """Atomic store for resident queue chain results."""
+
+    def load(self) -> Mapping[str, Any]:
+        """Return current chain-results state, or an empty mapping."""
+
+    def commit(self, snapshot: Mapping[str, Any], *, expected_revision: Optional[str]) -> str:
+        """Atomically commit snapshot and return revision."""
+
+
+class InMemoryResidentQueueChainResultsStore:
+    """In-memory implementation used by tests and dry-run callers."""
+
+    def __init__(self, initial: Optional[Mapping[str, Any]] = None, *, fail_commit: bool = False) -> None:
+        self._state = json.loads(json.dumps(initial or {}, sort_keys=True))
+        self.fail_commit = fail_commit
+
+    def load(self) -> Mapping[str, Any]:
+        return json.loads(json.dumps(self._state, sort_keys=True))
+
+    def commit(self, snapshot: Mapping[str, Any], *, expected_revision: Optional[str]) -> str:
+        if self.fail_commit:
+            raise RuntimeError("commit_failed")
+        current_revision = self._state.get("revision")
+        if current_revision != expected_revision:
+            raise RuntimeError("revision_conflict")
+        committed = json.loads(json.dumps(snapshot, sort_keys=True))
+        revision = _digest(committed)
+        committed["revision"] = revision
+        self._state = committed
+        return revision
+
+
+class AtomicJsonResidentQueueChainResultsStore:
+    """Single-file JSON store using atomic replace."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+
+    def load(self) -> Mapping[str, Any]:
+        if not self.path.exists():
+            return {}
+        return json.loads(self.path.read_text(encoding="utf-8"))
+
+    def commit(self, snapshot: Mapping[str, Any], *, expected_revision: Optional[str]) -> str:
+        current = self.load()
+        if current.get("revision") != expected_revision:
+            raise RuntimeError("revision_conflict")
+        committed = json.loads(json.dumps(snapshot, sort_keys=True))
+        revision = _digest(committed)
+        committed["revision"] = revision
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(prefix=f".{self.path.name}.", suffix=".tmp", dir=str(self.path.parent))
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+                json.dump(committed, handle, sort_keys=True, indent=2)
+                handle.write("\n")
+            os.replace(tmp_name, self.path)
+        finally:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
+        return revision
+
+
+@dataclass(frozen=True)
+class ResidentQueueChainResultReceipt:
+    receipt_id: str
+    queue_item_id: str
+    selected_slice: str
+    recorded_stage: str
+    previous_plan_id: str
+    next_plan_id: str
+    next_action: str
+    store_revision: Optional[str]
+    no_bridge_invoked: bool = True
+    no_authority_issued: bool = True
+    no_worker_spawn_performed: bool = True
+    no_worktree_created: bool = True
+    no_shell_command_executed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pr_created: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_reward_settlement_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ResidentQueueChainResultRecordResult:
+    accepted: bool
+    status: str
+    rejection_reasons: list[str] = field(default_factory=list)
+    receipt: Optional[ResidentQueueChainResultReceipt] = None
+    previous_plan: Optional[ResidentQueueOrchestrationPlan] = None
+    next_plan: Optional[ResidentQueueOrchestrationPlan] = None
+    snapshot: Optional[Dict[str, Any]] = None
+    no_bridge_invoked: bool = True
+    no_authority_issued: bool = True
+    no_worker_spawn_performed: bool = True
+    no_worktree_created: bool = True
+    no_shell_command_executed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pr_created: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_reward_settlement_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "accepted": self.accepted,
+            "status": self.status,
+            "rejection_reasons": self.rejection_reasons,
+            "receipt": self.receipt.to_dict() if self.receipt else None,
+            "previous_plan": self.previous_plan.to_dict() if self.previous_plan else None,
+            "next_plan": self.next_plan.to_dict() if self.next_plan else None,
+            "snapshot": self.snapshot,
+            "no_bridge_invoked": self.no_bridge_invoked,
+            "no_authority_issued": self.no_authority_issued,
+            "no_worker_spawn_performed": self.no_worker_spawn_performed,
+            "no_worktree_created": self.no_worktree_created,
+            "no_shell_command_executed": self.no_shell_command_executed,
+            "no_openclaw_enqueue_performed": self.no_openclaw_enqueue_performed,
+            "no_hermes_dispatch_performed": self.no_hermes_dispatch_performed,
+            "no_repo_mutation_performed": self.no_repo_mutation_performed,
+            "no_holoindex_reindex_performed": self.no_holoindex_reindex_performed,
+            "no_pr_created": self.no_pr_created,
+            "no_pattern_memory_write_performed": self.no_pattern_memory_write_performed,
+            "no_reward_settlement_performed": self.no_reward_settlement_performed,
+        }
+
+
+def _digest(payload: Any) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        candidate = value.to_dict()
+        return candidate if isinstance(candidate, Mapping) else {}
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _stage_results(state: Mapping[str, Any]) -> Dict[str, Mapping[str, Any]]:
+    if state.get("schema_version") == CHAIN_RESULTS_SCHEMA_VERSION:
+        raw = state.get("stage_results")
+    else:
+        raw = state
+    if not isinstance(raw, Mapping):
+        return {}
+    return {
+        str(key): value
+        for key, value in raw.items()
+        if isinstance(value, Mapping)
+    }
+
+
+def _receipts(state: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    raw = state.get("receipts") if state.get("schema_version") == CHAIN_RESULTS_SCHEMA_VERSION else ()
+    if not isinstance(raw, list):
+        return []
+    return [item for item in raw if isinstance(item, Mapping)]
+
+
+def _dedupe(values: Iterable[str]) -> list[str]:
+    return list(dict.fromkeys(str(value) for value in values if str(value or "").strip()))
+
+
+def _reject(
+    reasons: Sequence[str],
+    *,
+    previous_plan: Optional[ResidentQueueOrchestrationPlan] = None,
+    next_plan: Optional[ResidentQueueOrchestrationPlan] = None,
+) -> ResidentQueueChainResultRecordResult:
+    return ResidentQueueChainResultRecordResult(
+        accepted=False,
+        status=CHAIN_RESULT_REJECTED,
+        rejection_reasons=_dedupe(reasons),
+        previous_plan=previous_plan,
+        next_plan=next_plan,
+    )
+
+
+def record_resident_queue_stage_result(
+    *,
+    work_state_snapshot: Mapping[str, Any],
+    store: ResidentQueueChainResultsStore,
+    stage_key: str,
+    stage_result: Mapping[str, Any],
+    now_iso: str,
+    requested_queue_item_id: Optional[str] = None,
+) -> ResidentQueueChainResultRecordResult:
+    """Atomically record one stage result if it is the planner's current stage."""
+
+    clean_stage_key = str(stage_key or "").strip()
+    if not clean_stage_key:
+        return _reject((FAIL_STAGE_KEY_REQUIRED,))
+    clean_stage_result = _mapping(stage_result)
+    if not clean_stage_result:
+        return _reject((FAIL_STAGE_RESULT_REQUIRED,))
+
+    current = store.load()
+    existing = _stage_results(current)
+    if clean_stage_key in existing:
+        return _reject((FAIL_STAGE_ALREADY_RECORDED, f"stage:{clean_stage_key}"))
+
+    previous_plan = plan_reddog_resident_queue_orchestration(
+        work_state_snapshot,
+        chain_results=existing,
+        requested_queue_item_id=requested_queue_item_id,
+        now_iso=now_iso,
+    )
+    if (
+        previous_plan.accepted is not True
+        or previous_plan.status not in {
+            RESIDENT_QUEUE_ORCHESTRATION_PLAN_READY,
+            RESIDENT_QUEUE_ORCHESTRATION_PLAN_COMPLETE,
+        }
+        or previous_plan.current_stage is None
+    ):
+        return _reject(
+            (FAIL_CURRENT_PLAN_NOT_READY, *previous_plan.rejection_reasons),
+            previous_plan=previous_plan,
+        )
+    if previous_plan.current_stage != clean_stage_key:
+        return _reject(
+            (
+                FAIL_STAGE_NOT_CURRENT,
+                f"expected:{previous_plan.current_stage}",
+                f"actual:{clean_stage_key}",
+            ),
+            previous_plan=previous_plan,
+        )
+
+    proposed_results = {**existing, clean_stage_key: dict(clean_stage_result)}
+    next_plan = plan_reddog_resident_queue_orchestration(
+        work_state_snapshot,
+        chain_results=proposed_results,
+        requested_queue_item_id=requested_queue_item_id,
+        now_iso=now_iso,
+    )
+    if next_plan.accepted is not True:
+        return _reject(
+            (FAIL_PROPOSED_PLAN_REJECTED, *next_plan.rejection_reasons),
+            previous_plan=previous_plan,
+            next_plan=next_plan,
+        )
+
+    receipt_seed = {
+        "queue_item_id": previous_plan.selected_queue_item_id,
+        "selected_slice": previous_plan.selected_slice,
+        "recorded_stage": clean_stage_key,
+        "previous_plan_id": previous_plan.plan_id,
+        "next_plan_id": next_plan.plan_id,
+    }
+    receipt = ResidentQueueChainResultReceipt(
+        receipt_id=_digest(receipt_seed),
+        queue_item_id=str(previous_plan.selected_queue_item_id or ""),
+        selected_slice=str(previous_plan.selected_slice or ""),
+        recorded_stage=clean_stage_key,
+        previous_plan_id=previous_plan.plan_id,
+        next_plan_id=next_plan.plan_id,
+        next_action=next_plan.next_action,
+        store_revision=None,
+    )
+    snapshot = {
+        "schema_version": CHAIN_RESULTS_SCHEMA_VERSION,
+        "updated_at": now_iso,
+        "queue_item_id": previous_plan.selected_queue_item_id,
+        "selected_slice": previous_plan.selected_slice,
+        "stage_results": proposed_results,
+        "receipts": [*list(_receipts(current)), receipt.to_dict()],
+        "no_bridge_invoked": True,
+        "no_authority_issued": True,
+        "no_worker_spawn_performed": True,
+        "no_worktree_created": True,
+        "no_shell_command_executed": True,
+        "no_openclaw_enqueue_performed": True,
+        "no_hermes_dispatch_performed": True,
+        "no_repo_mutation_performed": True,
+        "no_holoindex_reindex_performed": True,
+        "no_pr_created": True,
+        "no_pattern_memory_write_performed": True,
+        "no_reward_settlement_performed": True,
+    }
+    try:
+        revision = store.commit(snapshot, expected_revision=_mapping(current).get("revision"))
+    except Exception as exc:  # noqa: BLE001 - store errors fail closed.
+        return _reject(
+            (FAIL_ATOMIC_COMMIT_FAILED, exc.__class__.__name__),
+            previous_plan=previous_plan,
+            next_plan=next_plan,
+        )
+    committed_receipt = ResidentQueueChainResultReceipt(
+        **{**receipt.to_dict(), "store_revision": revision}
+    )
+    snapshot["revision"] = revision
+    snapshot["receipts"][-1] = committed_receipt.to_dict()
+    return ResidentQueueChainResultRecordResult(
+        accepted=True,
+        status=CHAIN_RESULT_RECORDED,
+        rejection_reasons=[],
+        receipt=committed_receipt,
+        previous_plan=previous_plan,
+        next_plan=next_plan,
+        snapshot=snapshot,
+    )
+
+
+__all__ = [
+    "AtomicJsonResidentQueueChainResultsStore",
+    "CHAIN_RESULTS_SCHEMA_VERSION",
+    "CHAIN_RESULT_RECORDED",
+    "CHAIN_RESULT_REJECTED",
+    "FAIL_ATOMIC_COMMIT_FAILED",
+    "FAIL_CURRENT_PLAN_NOT_READY",
+    "FAIL_PROPOSED_PLAN_REJECTED",
+    "FAIL_STAGE_ALREADY_RECORDED",
+    "FAIL_STAGE_KEY_REQUIRED",
+    "FAIL_STAGE_NOT_CURRENT",
+    "FAIL_STAGE_RESULT_REQUIRED",
+    "InMemoryResidentQueueChainResultsStore",
+    "ResidentQueueChainResultReceipt",
+    "ResidentQueueChainResultRecordResult",
+    "ResidentQueueChainResultsStore",
+    "record_resident_queue_stage_result",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_chain_results_store.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_chain_results_store.py
@@ -1,0 +1,300 @@
+"""Tests for REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_STORE_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_orchestration_plan_bootstrap import (
+    run_reddog_main_resident_queue_orchestration_plan_bootstrap,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_chain_results_store import (
+    CHAIN_RESULT_RECORDED,
+    FAIL_ATOMIC_COMMIT_FAILED,
+    FAIL_PROPOSED_PLAN_REJECTED,
+    FAIL_STAGE_ALREADY_RECORDED,
+    FAIL_STAGE_NOT_CURRENT,
+    AtomicJsonResidentQueueChainResultsStore,
+    InMemoryResidentQueueChainResultsStore,
+    record_resident_queue_stage_result,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_orchestration_plan import (
+    NEXT_QUEUE_AUTHORITY_RUNTIME_INVOKE,
+    NEXT_QUEUE_WORKTREE_CREATE_INVOKE,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_resident_queue_chain_results_store.py"
+)
+NOW = "2026-07-14T00:00:00+00:00"
+EXPIRES = "2026-07-14T01:00:00+00:00"
+
+
+def _snapshot() -> dict[str, object]:
+    return {
+        "schema_version": "reddog_authoritative_work_state.v1",
+        "freshness_receipts": [{"receipt_id": "fresh-1", "fresh": True}],
+        "worker_claims": [
+            {
+                "claim_id": "claim-1",
+                "slice_id": "REDDOG_TEST_SLICE_PHASE1",
+                "worker_id": "reddog-0102",
+                "status": "ACTIVE",
+                "expires_at": EXPIRES,
+                "freshness_receipt_id": "fresh-1",
+            }
+        ],
+        "wre_queue_items": [
+            {
+                "queue_item_id": "queue-1",
+                "slice_id": "REDDOG_TEST_SLICE_PHASE1",
+                "claim_id": "claim-1",
+                "worker_id": "reddog-0102",
+                "status": "QUEUED",
+                "evidence_refs": ["claim:claim-1", "freshness:fresh-1"],
+                "no_execution_performed": True,
+            }
+        ],
+    }
+
+
+def _accepted(stage: str) -> dict[str, object]:
+    values = {
+        "authority_request": {"status": "QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT"},
+        "authority_runtime": {"decision": "QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT"},
+        "authority_verification": {"decision": "QUEUE_AUTHORITY_VERIFICATION_INVOKE_ACCEPT"},
+        "work_order_invocation": {"decision": "QUEUE_VERIFIED_AUTHORITY_WORK_ORDER_INVOKE_ACCEPT"},
+        "executor_plan": {"decision": "QUEUE_AUTHORIZED_EXECUTOR_PLAN_DRYRUN_ACCEPT"},
+        "execution_valve": {"decision": "QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_ACCEPT"},
+    }
+    return values[stage]
+
+
+def _seed_store_through(stage: str) -> InMemoryResidentQueueChainResultsStore:
+    order = (
+        "authority_request",
+        "authority_runtime",
+        "authority_verification",
+        "work_order_invocation",
+        "executor_plan",
+        "execution_valve",
+    )
+    store = InMemoryResidentQueueChainResultsStore()
+    for key in order:
+        result = record_resident_queue_stage_result(
+            work_state_snapshot=_snapshot(),
+            store=store,
+            stage_key=key,
+            stage_result=_accepted(key),
+            now_iso=NOW,
+        )
+        assert result.accepted is True
+        if key == stage:
+            break
+    return store
+
+
+def test_record_current_stage_advances_plan_and_persists_result() -> None:
+    store = InMemoryResidentQueueChainResultsStore()
+
+    result = record_resident_queue_stage_result(
+        work_state_snapshot=_snapshot(),
+        store=store,
+        stage_key="authority_request",
+        stage_result=_accepted("authority_request"),
+        now_iso=NOW,
+    )
+
+    assert result.accepted is True
+    assert result.status == CHAIN_RESULT_RECORDED
+    assert result.receipt is not None
+    assert result.receipt.recorded_stage == "authority_request"
+    assert result.next_plan is not None
+    assert result.next_plan.next_action == NEXT_QUEUE_AUTHORITY_RUNTIME_INVOKE
+    state = store.load()
+    assert state["schema_version"] == "reddog_resident_queue_chain_results.v1"
+    assert state["stage_results"]["authority_request"]["status"] == "QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT"
+    assert state["no_bridge_invoked"] is True
+    assert state["no_holoindex_reindex_performed"] is True
+
+
+def test_rejects_out_of_order_stage_without_commit() -> None:
+    store = InMemoryResidentQueueChainResultsStore()
+
+    result = record_resident_queue_stage_result(
+        work_state_snapshot=_snapshot(),
+        store=store,
+        stage_key="authority_runtime",
+        stage_result=_accepted("authority_runtime"),
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert FAIL_STAGE_NOT_CURRENT in result.rejection_reasons
+    assert store.load() == {}
+
+
+def test_rejects_duplicate_stage_without_overwrite() -> None:
+    store = _seed_store_through("authority_request")
+
+    result = record_resident_queue_stage_result(
+        work_state_snapshot=_snapshot(),
+        store=store,
+        stage_key="authority_request",
+        stage_result=_accepted("authority_request"),
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert FAIL_STAGE_ALREADY_RECORDED in result.rejection_reasons
+    assert store.load()["stage_results"]["authority_request"]["status"] == "QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT"
+
+
+def test_rejected_stage_result_does_not_commit() -> None:
+    store = InMemoryResidentQueueChainResultsStore()
+
+    result = record_resident_queue_stage_result(
+        work_state_snapshot=_snapshot(),
+        store=store,
+        stage_key="authority_request",
+        stage_result={
+            "status": "QUEUE_AUTHORITY_REQUEST_DRYRUN_REJECT",
+            "rejection_reasons": ["FAIL_PROFILE_MISSING"],
+        },
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert FAIL_PROPOSED_PLAN_REJECTED in result.rejection_reasons
+    assert "FAIL_PROFILE_MISSING" in result.rejection_reasons
+    assert store.load() == {}
+
+
+def test_commit_failure_fails_closed() -> None:
+    store = InMemoryResidentQueueChainResultsStore(fail_commit=True)
+
+    result = record_resident_queue_stage_result(
+        work_state_snapshot=_snapshot(),
+        store=store,
+        stage_key="authority_request",
+        stage_result=_accepted("authority_request"),
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert FAIL_ATOMIC_COMMIT_FAILED in result.rejection_reasons
+    assert store.load() == {}
+
+
+def test_atomic_json_store_writes_schema_for_bootstrap(tmp_path: Path) -> None:
+    path = tmp_path / "runtime" / "chain_results.json"
+    store = AtomicJsonResidentQueueChainResultsStore(path)
+
+    result = record_resident_queue_stage_result(
+        work_state_snapshot=_snapshot(),
+        store=store,
+        stage_key="authority_request",
+        stage_result=_accepted("authority_request"),
+        now_iso=NOW,
+    )
+
+    assert result.accepted is True
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["revision"] == result.receipt.store_revision
+    assert data["stage_results"]["authority_request"]["status"] == "QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT"
+    assert not list(path.parent.glob("*.tmp"))
+
+
+def test_bootstrap_reads_chain_results_store_schema(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    state_path = tmp_path / "runtime" / "work_state.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(_snapshot(), sort_keys=True), encoding="utf-8")
+    chain_path = tmp_path / "runtime" / "chain_results.json"
+    store = AtomicJsonResidentQueueChainResultsStore(chain_path)
+    record_resident_queue_stage_result(
+        work_state_snapshot=_snapshot(),
+        store=store,
+        stage_key="authority_request",
+        stage_result=_accepted("authority_request"),
+        now_iso=NOW,
+    )
+
+    result = run_reddog_main_resident_queue_orchestration_plan_bootstrap(
+        repo_root=repo,
+        work_state_path=state_path,
+        chain_results_path=chain_path,
+        now_iso=NOW,
+    )
+
+    assert result.ready is True
+    assert result.current_stage == "authority_runtime"
+    assert result.next_action == NEXT_QUEUE_AUTHORITY_RUNTIME_INVOKE
+    assert result.accepted_stage_count == 2
+
+
+def test_multi_stage_recording_keeps_serial_order() -> None:
+    store = _seed_store_through("executor_plan")
+
+    result = record_resident_queue_stage_result(
+        work_state_snapshot=_snapshot(),
+        store=store,
+        stage_key="execution_valve",
+        stage_result=_accepted("execution_valve"),
+        now_iso=NOW,
+    )
+
+    assert result.accepted is True
+    assert result.previous_plan is not None
+    assert result.previous_plan.current_stage == "execution_valve"
+    assert result.next_plan is not None
+    assert result.next_plan.next_action == NEXT_QUEUE_WORKTREE_CREATE_INVOKE
+    assert result.next_plan.current_stage == "worktree_create"
+
+
+def test_module_has_no_bridge_invocation_or_reindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    banned_attrs = {
+        "system",
+        "popen",
+        "spawn",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "remove",
+        "rmdir",
+        "rename",
+    }
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs


### PR DESCRIPTION
## REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_STORE_PHASE1

WSP_97 status: VERIFIED_READY draft PR.

### Purpose

Add an atomic outside-repo store for already-produced resident RedDog queue-chain stage results. This lets the resident startup planner remember serial progress without relying on 012 paste/memory.

### Files

| File | Role |
| --- | --- |
| `modules/communication/moltbot_bridge/src/reddog_resident_queue_chain_results_store.py` | Atomic chain-results store and stage-record guard |
| `modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_chain_results_store.py` | 9 tests + AST guard |
| `modules/communication/moltbot_bridge/src/reddog_main_resident_queue_orchestration_plan_bootstrap.py` | Reads governed store schema in addition to raw mapping |
| `modules/communication/moltbot_bridge/ModLog.md` | Slice evidence + HoloIndex INDEX_GAP |

### Behavior

- Loads existing stage results, replays the resident queue planner, and records only the exact current missing stage.
- Replays the planner with the proposed result and commits only if the plan advances cleanly.
- Uses in-memory and atomic JSON stores with optimistic revision checks.
- Keeps the bootstrap compatible with the raw mapping and the governed `reddog_resident_queue_chain_results.v1` schema.

### Boundary

Chain-result persistence only. No bridge invocation, authority issuance, signature verification, worker spawn, worktree creation, file edit, shell command, PR publishing, PatternMemory write, OpenClaw enqueue, Hermes dispatch, reward settlement, or HoloIndex re-index.

### Validation

```text
29 passed  chain-results store + planner/bootstrap tests
49 passed  adjacent startup/work-state/queue tests
git diff --check clean
new source/test files ASCII-clean; modified-file added lines ASCII-clean
HoloIndex read-only probe confirms INDEX_GAP for the new store
```

### HoloIndex

Read-only query `RedDog resident queue chain results store atomic stage result` surfaced adjacent worker-queue/PQN/consensus/live-enqueue artifacts but not this new store before indexing.

INDEX_GAP: `HOLOINDEX_REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_STORE_INDEX_GAP_PHASE1`

### Residual SPECIFIED_NOT_IMPLEMENTED

- No stage bridge is invoked by this store.
- No resident loop runtime writes to the store yet.
- No signer/worktree/worker runtime is started by this slice.
- HoloIndex re-index remains WRE/CI-owned, never RedDog runtime-owned.