### PR TITLE
feat(reddog): dispatch resident queue next stage

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,26 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_resident_queue_next_stage_dispatch.py`: an explicit
+  injected-handler dispatcher for exactly one resident queue-chain stage.
+- The dispatcher reads the chain-results store, plans the current stage, calls
+  only the handler supplied for that stage, and records the handler result
+  through the governed chain-results store.
+- Boundary: no default handlers and no concrete queue bridge imports; no
+  authority issuance, signature verification, worker spawn, worktree creation,
+  file edit, shell command, PR publishing, PatternMemory write, OpenClaw
+  enqueue, Hermes dispatch, reward settlement, or HoloIndex re-index by the
+  dispatcher.
+- HoloIndex read-only probe for `RedDog resident queue next stage dispatch
+  injected handler` surfaced adjacent extension live-enqueue, swarm-dispatch,
+  WSP, and RedDog work-order docs, but not this new dispatcher before indexing.
+  Recorded as
+  `HOLOINDEX_REDDOG_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_INDEX_GAP_PHASE1`; no
+  runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_STORE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_next_stage_dispatch.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_next_stage_dispatch.py
@@ -1,0 +1,264 @@
+"""Resident RedDog queue next-stage dispatcher.
+
+Slice: REDDOG_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_PHASE1
+
+This module invokes exactly one injected handler for the current resident
+queue-chain stage, then records the returned result through the governed
+chain-results store. It has no default handlers and imports no concrete bridge
+implementation. A caller must explicitly provide the handler map.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Mapping, Optional, Protocol
+
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_chain_results_store import (
+    ResidentQueueChainResultRecordResult,
+    ResidentQueueChainResultsStore,
+    record_resident_queue_stage_result,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_orchestration_plan import (
+    RESIDENT_QUEUE_ORCHESTRATION_PLAN_READY,
+    ResidentQueueOrchestrationPlan,
+    plan_reddog_resident_queue_orchestration,
+)
+
+
+RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_ACCEPT = "RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_ACCEPT"
+RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_REJECT = "RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_REJECT"
+
+FAIL_EXPLICIT_DISPATCH_MISSING = "FAIL_EXPLICIT_DISPATCH_MISSING"
+FAIL_PLAN_NOT_READY = "FAIL_PLAN_NOT_READY"
+FAIL_CURRENT_STAGE_MISSING = "FAIL_CURRENT_STAGE_MISSING"
+FAIL_HANDLER_MISSING = "FAIL_HANDLER_MISSING"
+FAIL_HANDLER_EXCEPTION = "FAIL_HANDLER_EXCEPTION"
+FAIL_HANDLER_RESULT_INVALID = "FAIL_HANDLER_RESULT_INVALID"
+FAIL_RECORD_REJECTED = "FAIL_RECORD_REJECTED"
+
+
+@dataclass(frozen=True)
+class ResidentQueueStageDispatchRequest:
+    """Payload passed to an injected stage handler."""
+
+    stage_key: str
+    next_action: str
+    queue_item_id: Optional[str]
+    selected_slice: Optional[str]
+    plan_id: str
+    accepted_stages: tuple[str, ...]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class ResidentQueueStageHandler(Protocol):
+    """Injected handler for one resident queue-chain stage."""
+
+    def __call__(self, request: ResidentQueueStageDispatchRequest) -> Mapping[str, Any]:
+        """Return the stage result to be recorded."""
+
+
+@dataclass(frozen=True)
+class ResidentQueueNextStageDispatchResult:
+    """Result returned by the injected-handler dispatcher."""
+
+    accepted: bool
+    decision: str
+    rejection_reasons: list[str] = field(default_factory=list)
+    dispatched_stage: Optional[str] = None
+    next_action: Optional[str] = None
+    plan: Optional[ResidentQueueOrchestrationPlan] = None
+    record_result: Optional[ResidentQueueChainResultRecordResult] = None
+    stage_handler_invoked: bool = False
+    no_default_handler_used: bool = True
+    no_authority_issued_by_dispatcher: bool = True
+    no_worker_spawned_by_dispatcher: bool = True
+    no_worktree_created_by_dispatcher: bool = True
+    no_shell_command_executed_by_dispatcher: bool = True
+    no_openclaw_enqueue_performed_by_dispatcher: bool = True
+    no_hermes_dispatch_performed_by_dispatcher: bool = True
+    no_repo_mutation_performed_by_dispatcher: bool = True
+    no_holoindex_reindex_performed_by_dispatcher: bool = True
+    no_pr_created_by_dispatcher: bool = True
+    no_pattern_memory_write_performed_by_dispatcher: bool = True
+    no_reward_settlement_performed_by_dispatcher: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "accepted": self.accepted,
+            "decision": self.decision,
+            "rejection_reasons": self.rejection_reasons,
+            "dispatched_stage": self.dispatched_stage,
+            "next_action": self.next_action,
+            "plan": self.plan.to_dict() if self.plan else None,
+            "record_result": self.record_result.to_dict() if self.record_result else None,
+            "stage_handler_invoked": self.stage_handler_invoked,
+            "no_default_handler_used": self.no_default_handler_used,
+            "no_authority_issued_by_dispatcher": self.no_authority_issued_by_dispatcher,
+            "no_worker_spawned_by_dispatcher": self.no_worker_spawned_by_dispatcher,
+            "no_worktree_created_by_dispatcher": self.no_worktree_created_by_dispatcher,
+            "no_shell_command_executed_by_dispatcher": self.no_shell_command_executed_by_dispatcher,
+            "no_openclaw_enqueue_performed_by_dispatcher": self.no_openclaw_enqueue_performed_by_dispatcher,
+            "no_hermes_dispatch_performed_by_dispatcher": self.no_hermes_dispatch_performed_by_dispatcher,
+            "no_repo_mutation_performed_by_dispatcher": self.no_repo_mutation_performed_by_dispatcher,
+            "no_holoindex_reindex_performed_by_dispatcher": self.no_holoindex_reindex_performed_by_dispatcher,
+            "no_pr_created_by_dispatcher": self.no_pr_created_by_dispatcher,
+            "no_pattern_memory_write_performed_by_dispatcher": self.no_pattern_memory_write_performed_by_dispatcher,
+            "no_reward_settlement_performed_by_dispatcher": self.no_reward_settlement_performed_by_dispatcher,
+        }
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        candidate = value.to_dict()
+        return candidate if isinstance(candidate, Mapping) else {}
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _stage_results(state: Mapping[str, Any]) -> Dict[str, Mapping[str, Any]]:
+    raw = state.get("stage_results") if state.get("schema_version") == "reddog_resident_queue_chain_results.v1" else state
+    if not isinstance(raw, Mapping):
+        return {}
+    return {str(key): value for key, value in raw.items() if isinstance(value, Mapping)}
+
+
+def _reject(
+    reasons: list[str],
+    *,
+    plan: Optional[ResidentQueueOrchestrationPlan] = None,
+    dispatched_stage: Optional[str] = None,
+    next_action: Optional[str] = None,
+    stage_handler_invoked: bool = False,
+    record_result: Optional[ResidentQueueChainResultRecordResult] = None,
+) -> ResidentQueueNextStageDispatchResult:
+    return ResidentQueueNextStageDispatchResult(
+        accepted=False,
+        decision=RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_REJECT,
+        rejection_reasons=list(dict.fromkeys(reasons)),
+        dispatched_stage=dispatched_stage,
+        next_action=next_action,
+        plan=plan,
+        record_result=record_result,
+        stage_handler_invoked=stage_handler_invoked,
+    )
+
+
+def invoke_reddog_resident_queue_next_stage_dispatch(
+    *,
+    explicit_resident_queue_stage_dispatch_requested: bool,
+    work_state_snapshot: Mapping[str, Any],
+    store: ResidentQueueChainResultsStore,
+    handlers: Mapping[str, ResidentQueueStageHandler],
+    now_iso: str,
+    requested_queue_item_id: Optional[str] = None,
+) -> ResidentQueueNextStageDispatchResult:
+    """Invoke one injected current-stage handler and record its result."""
+
+    if explicit_resident_queue_stage_dispatch_requested is not True:
+        return _reject([FAIL_EXPLICIT_DISPATCH_MISSING])
+
+    current_state = _mapping(store.load())
+    plan = plan_reddog_resident_queue_orchestration(
+        work_state_snapshot,
+        chain_results=_stage_results(current_state),
+        requested_queue_item_id=requested_queue_item_id,
+        now_iso=now_iso,
+    )
+    if plan.accepted is not True or plan.status != RESIDENT_QUEUE_ORCHESTRATION_PLAN_READY:
+        return _reject(
+            [FAIL_PLAN_NOT_READY, *plan.rejection_reasons],
+            plan=plan,
+            next_action=plan.next_action,
+        )
+    if not plan.current_stage:
+        return _reject(
+            [FAIL_CURRENT_STAGE_MISSING],
+            plan=plan,
+            next_action=plan.next_action,
+        )
+
+    handler = handlers.get(plan.current_stage)
+    if handler is None:
+        return _reject(
+            [FAIL_HANDLER_MISSING, f"stage:{plan.current_stage}"],
+            plan=plan,
+            dispatched_stage=plan.current_stage,
+            next_action=plan.next_action,
+        )
+
+    request = ResidentQueueStageDispatchRequest(
+        stage_key=plan.current_stage,
+        next_action=plan.next_action,
+        queue_item_id=plan.selected_queue_item_id,
+        selected_slice=plan.selected_slice,
+        plan_id=plan.plan_id,
+        accepted_stages=plan.accepted_stages,
+    )
+    try:
+        raw_stage_result = handler(request)
+    except Exception as exc:  # noqa: BLE001 - injected handler failures fail closed.
+        return _reject(
+            [FAIL_HANDLER_EXCEPTION, exc.__class__.__name__],
+            plan=plan,
+            dispatched_stage=plan.current_stage,
+            next_action=plan.next_action,
+            stage_handler_invoked=True,
+        )
+    stage_result = _mapping(raw_stage_result)
+    if not stage_result:
+        return _reject(
+            [FAIL_HANDLER_RESULT_INVALID],
+            plan=plan,
+            dispatched_stage=plan.current_stage,
+            next_action=plan.next_action,
+            stage_handler_invoked=True,
+        )
+
+    record = record_resident_queue_stage_result(
+        work_state_snapshot=work_state_snapshot,
+        store=store,
+        stage_key=plan.current_stage,
+        stage_result=stage_result,
+        now_iso=now_iso,
+        requested_queue_item_id=requested_queue_item_id,
+    )
+    if record.accepted is not True:
+        return _reject(
+            [FAIL_RECORD_REJECTED, *record.rejection_reasons],
+            plan=plan,
+            dispatched_stage=plan.current_stage,
+            next_action=plan.next_action,
+            stage_handler_invoked=True,
+            record_result=record,
+        )
+
+    return ResidentQueueNextStageDispatchResult(
+        accepted=True,
+        decision=RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_ACCEPT,
+        rejection_reasons=[],
+        dispatched_stage=plan.current_stage,
+        next_action=record.next_plan.next_action if record.next_plan else None,
+        plan=plan,
+        record_result=record,
+        stage_handler_invoked=True,
+    )
+
+
+__all__ = [
+    "FAIL_CURRENT_STAGE_MISSING",
+    "FAIL_EXPLICIT_DISPATCH_MISSING",
+    "FAIL_HANDLER_EXCEPTION",
+    "FAIL_HANDLER_MISSING",
+    "FAIL_HANDLER_RESULT_INVALID",
+    "FAIL_PLAN_NOT_READY",
+    "FAIL_RECORD_REJECTED",
+    "RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_ACCEPT",
+    "RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_REJECT",
+    "ResidentQueueNextStageDispatchResult",
+    "ResidentQueueStageDispatchRequest",
+    "ResidentQueueStageHandler",
+    "invoke_reddog_resident_queue_next_stage_dispatch",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_next_stage_dispatch.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_next_stage_dispatch.py
@@ -1,0 +1,294 @@
+"""Tests for REDDOG_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_chain_results_store import (
+    InMemoryResidentQueueChainResultsStore,
+    record_resident_queue_stage_result,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_next_stage_dispatch import (
+    FAIL_EXPLICIT_DISPATCH_MISSING,
+    FAIL_HANDLER_EXCEPTION,
+    FAIL_HANDLER_MISSING,
+    FAIL_HANDLER_RESULT_INVALID,
+    FAIL_RECORD_REJECTED,
+    RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_ACCEPT,
+    RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_REJECT,
+    ResidentQueueStageDispatchRequest,
+    invoke_reddog_resident_queue_next_stage_dispatch,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_orchestration_plan import (
+    NEXT_QUEUE_AUTHORITY_RUNTIME_INVOKE,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_resident_queue_next_stage_dispatch.py"
+)
+NOW = "2026-07-14T00:00:00+00:00"
+EXPIRES = "2026-07-14T01:00:00+00:00"
+
+
+def _snapshot() -> dict[str, object]:
+    return {
+        "schema_version": "reddog_authoritative_work_state.v1",
+        "freshness_receipts": [{"receipt_id": "fresh-1", "fresh": True}],
+        "worker_claims": [
+            {
+                "claim_id": "claim-1",
+                "slice_id": "REDDOG_TEST_SLICE_PHASE1",
+                "worker_id": "reddog-0102",
+                "status": "ACTIVE",
+                "expires_at": EXPIRES,
+                "freshness_receipt_id": "fresh-1",
+            }
+        ],
+        "wre_queue_items": [
+            {
+                "queue_item_id": "queue-1",
+                "slice_id": "REDDOG_TEST_SLICE_PHASE1",
+                "claim_id": "claim-1",
+                "worker_id": "reddog-0102",
+                "status": "QUEUED",
+                "evidence_refs": ["claim:claim-1", "freshness:fresh-1"],
+                "no_execution_performed": True,
+            }
+        ],
+    }
+
+
+def _authority_request_accept() -> dict[str, object]:
+    return {"status": "QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT"}
+
+
+def _authority_runtime_accept() -> dict[str, object]:
+    return {"decision": "QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT"}
+
+
+class _RecordingHandler:
+    def __init__(self, result: dict[str, object]) -> None:
+        self.result = result
+        self.requests: list[ResidentQueueStageDispatchRequest] = []
+
+    def __call__(self, request: ResidentQueueStageDispatchRequest) -> dict[str, object]:
+        self.requests.append(request)
+        return dict(self.result)
+
+
+def test_explicit_flag_required_before_handler_invocation() -> None:
+    handler = _RecordingHandler(_authority_request_accept())
+    result = invoke_reddog_resident_queue_next_stage_dispatch(
+        explicit_resident_queue_stage_dispatch_requested=False,
+        work_state_snapshot=_snapshot(),
+        store=InMemoryResidentQueueChainResultsStore(),
+        handlers={"authority_request": handler},
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert result.decision == RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_REJECT
+    assert FAIL_EXPLICIT_DISPATCH_MISSING in result.rejection_reasons
+    assert handler.requests == []
+
+
+def test_missing_handler_rejects_without_store_write() -> None:
+    store = InMemoryResidentQueueChainResultsStore()
+
+    result = invoke_reddog_resident_queue_next_stage_dispatch(
+        explicit_resident_queue_stage_dispatch_requested=True,
+        work_state_snapshot=_snapshot(),
+        store=store,
+        handlers={},
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert FAIL_HANDLER_MISSING in result.rejection_reasons
+    assert result.dispatched_stage == "authority_request"
+    assert store.load() == {}
+
+
+def test_dispatches_current_stage_handler_and_records_result() -> None:
+    store = InMemoryResidentQueueChainResultsStore()
+    handler = _RecordingHandler(_authority_request_accept())
+
+    result = invoke_reddog_resident_queue_next_stage_dispatch(
+        explicit_resident_queue_stage_dispatch_requested=True,
+        work_state_snapshot=_snapshot(),
+        store=store,
+        handlers={"authority_request": handler},
+        now_iso=NOW,
+    )
+
+    assert result.accepted is True
+    assert result.decision == RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_ACCEPT
+    assert result.dispatched_stage == "authority_request"
+    assert result.stage_handler_invoked is True
+    assert result.next_action == NEXT_QUEUE_AUTHORITY_RUNTIME_INVOKE
+    assert handler.requests[0].stage_key == "authority_request"
+    assert handler.requests[0].next_action == "RUN_QUEUE_AUTHORITY_REQUEST_DRYRUN"
+    state = store.load()
+    assert state["stage_results"]["authority_request"]["status"] == "QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT"
+    assert state["no_bridge_invoked"] is True
+
+
+def test_dispatch_uses_existing_chain_state_to_pick_next_stage() -> None:
+    store = InMemoryResidentQueueChainResultsStore()
+    seed = record_resident_queue_stage_result(
+        work_state_snapshot=_snapshot(),
+        store=store,
+        stage_key="authority_request",
+        stage_result=_authority_request_accept(),
+        now_iso=NOW,
+    )
+    assert seed.accepted is True
+    handler = _RecordingHandler(_authority_runtime_accept())
+
+    result = invoke_reddog_resident_queue_next_stage_dispatch(
+        explicit_resident_queue_stage_dispatch_requested=True,
+        work_state_snapshot=_snapshot(),
+        store=store,
+        handlers={"authority_runtime": handler},
+        now_iso=NOW,
+    )
+
+    assert result.accepted is True
+    assert result.dispatched_stage == "authority_runtime"
+    assert handler.requests[0].stage_key == "authority_runtime"
+    assert store.load()["stage_results"]["authority_runtime"]["decision"] == "QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT"
+
+
+def test_handler_exception_fails_closed_without_store_write() -> None:
+    def bad_handler(_: ResidentQueueStageDispatchRequest) -> dict[str, object]:
+        raise RuntimeError("boom")
+
+    store = InMemoryResidentQueueChainResultsStore()
+    result = invoke_reddog_resident_queue_next_stage_dispatch(
+        explicit_resident_queue_stage_dispatch_requested=True,
+        work_state_snapshot=_snapshot(),
+        store=store,
+        handlers={"authority_request": bad_handler},
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert FAIL_HANDLER_EXCEPTION in result.rejection_reasons
+    assert result.stage_handler_invoked is True
+    assert store.load() == {}
+
+
+def test_handler_non_mapping_result_fails_closed_without_store_write() -> None:
+    def bad_handler(_: ResidentQueueStageDispatchRequest):  # type: ignore[no-untyped-def]
+        return "bad"
+
+    store = InMemoryResidentQueueChainResultsStore()
+    result = invoke_reddog_resident_queue_next_stage_dispatch(
+        explicit_resident_queue_stage_dispatch_requested=True,
+        work_state_snapshot=_snapshot(),
+        store=store,
+        handlers={"authority_request": bad_handler},
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert FAIL_HANDLER_RESULT_INVALID in result.rejection_reasons
+    assert store.load() == {}
+
+
+def test_rejected_handler_result_is_not_persisted() -> None:
+    store = InMemoryResidentQueueChainResultsStore()
+    handler = _RecordingHandler(
+        {
+            "status": "QUEUE_AUTHORITY_REQUEST_DRYRUN_REJECT",
+            "rejection_reasons": ["FAIL_PROFILE_MISSING"],
+        }
+    )
+
+    result = invoke_reddog_resident_queue_next_stage_dispatch(
+        explicit_resident_queue_stage_dispatch_requested=True,
+        work_state_snapshot=_snapshot(),
+        store=store,
+        handlers={"authority_request": handler},
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert FAIL_RECORD_REJECTED in result.rejection_reasons
+    assert "FAIL_PROFILE_MISSING" in result.rejection_reasons
+    assert store.load() == {}
+
+
+def test_result_is_json_serializable() -> None:
+    store = InMemoryResidentQueueChainResultsStore()
+    handler = _RecordingHandler(_authority_request_accept())
+
+    result = invoke_reddog_resident_queue_next_stage_dispatch(
+        explicit_resident_queue_stage_dispatch_requested=True,
+        work_state_snapshot=_snapshot(),
+        store=store,
+        handlers={"authority_request": handler},
+        now_iso=NOW,
+    )
+
+    payload = result.to_dict()
+    assert payload["record_result"]["accepted"] is True
+    assert payload["plan"]["current_stage"] == "authority_request"
+
+
+def test_module_has_no_concrete_bridge_or_execution_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+    }
+    banned_import_fragments = {
+        "reddog_wre_queue_authority_request_dryrun",
+        "reddog_wre_queue_authority_runtime_invoke",
+        "reddog_wre_queue_authority_verification_invoke",
+        "reddog_wre_queue_authorized",
+        "reddog_wre_queue_verified_authority_work_order_invoke",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    banned_attrs = {
+        "system",
+        "popen",
+        "spawn",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "replace",
+        "unlink",
+        "remove",
+        "rmdir",
+        "rename",
+    }
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+                assert all(fragment not in alias.name for fragment in banned_import_fragments)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+            assert all(fragment not in node.module for fragment in banned_import_fragments)
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs


### PR DESCRIPTION
## REDDOG_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_PHASE1

WSP_97 status: VERIFIED_READY draft PR.

### Purpose

Add an explicit injected-handler dispatcher for the resident RedDog queue loop. It reads the current chain state, plans the current stage, invokes exactly one caller-supplied handler for that stage, and records the result through the governed chain-results store.

### Files

| File | Role |
| --- | --- |
| `modules/communication/moltbot_bridge/src/reddog_resident_queue_next_stage_dispatch.py` | Injected next-stage dispatcher |
| `modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_next_stage_dispatch.py` | 9 tests + AST guard |
| `modules/communication/moltbot_bridge/ModLog.md` | Slice evidence + HoloIndex INDEX_GAP |

### Behavior

- Requires `explicit_resident_queue_stage_dispatch_requested=True`.
- Reads current stage from planner + chain-results store.
- Rejects if no handler exists for the exact current stage.
- Invokes only that injected handler; no defaults and no concrete bridge imports.
- Records handler output through `record_resident_queue_stage_result`, so rejected/out-of-order output is not persisted.

### Boundary

No default handlers, no concrete queue bridge imports, no authority issuance by dispatcher, no signature verification by dispatcher, no worker spawn, no worktree creation, no file edit, no shell command, no PR publishing, no PatternMemory write, no OpenClaw enqueue, no Hermes dispatch, no reward settlement, no HoloIndex re-index.

### Validation

```text
29 passed  dispatcher + store + planner tests
37 passed  startup regression subset
git diff --check clean
new source/test files ASCII-clean; ModLog added lines ASCII-clean
HoloIndex read-only probe confirms INDEX_GAP for the new dispatcher
```

### HoloIndex

Read-only query `RedDog resident queue next stage dispatch injected handler` surfaced adjacent extension live-enqueue/swarm-dispatch/WSP/work-order artifacts but not this dispatcher before indexing.

INDEX_GAP: `HOLOINDEX_REDDOG_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_INDEX_GAP_PHASE1`

### Residual SPECIFIED_NOT_IMPLEMENTED

- No concrete stage handlers are registered by this slice.
- No `main.py` runtime dispatch loop calls this dispatcher yet.
- No OpenClaw/Hermes worker spawn.
- HoloIndex re-index remains WRE/CI-owned, never RedDog runtime-owned.