### PR TITLE
feat(reddog): bootstrap resident queue stage dispatch

### DIFF
--- a/main.py
+++ b/main.py
@@ -1458,6 +1458,67 @@ def run_reddog_resident_queue_orchestration_plan_preflight(repo_root: Path) -> b
     return True
 
 
+def run_reddog_resident_queue_next_stage_dispatch_preflight(repo_root: Path) -> bool:
+    """
+    Optionally dispatch the current resident queue stage through an injected handler.
+
+    Env:
+        REDDOG_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH=0          Enable dispatch (default OFF)
+        REDDOG_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_ENFORCED=0 Block startup if not applied
+        REDDOG_AUTHORITATIVE_WORK_STATE_PATH                 Existing work-state snapshot
+        REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH             Outside-repo chain-results JSON
+        REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH         Outside-repo authority profile JSON
+        REDDOG_WRE_QUEUE_ITEM_ID                             Optional exact queue item id
+    """
+
+    if os.getenv("REDDOG_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH", "0") == "0":
+        logger.info("[REDDOG-QUEUE-DISPATCH] Startup next-stage dispatch disabled")
+        return True
+
+    enforced = os.getenv("REDDOG_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_ENFORCED", "0") != "0"
+
+    try:
+        from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_next_stage_dispatch_bootstrap import (
+            run_reddog_main_resident_queue_next_stage_dispatch_bootstrap,
+        )
+
+        result = run_reddog_main_resident_queue_next_stage_dispatch_bootstrap(
+            repo_root=repo_root,
+            work_state_path=os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
+            chain_results_path=os.getenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH", "") or None,
+            authority_profile_path=os.getenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", "") or None,
+            requested_queue_item_id=os.getenv("REDDOG_WRE_QUEUE_ITEM_ID", "") or None,
+        )
+    except Exception as exc:
+        logger.error(f"[REDDOG-QUEUE-DISPATCH] Startup next-stage dispatch failed: {exc}")
+        if enforced:
+            print(f"[REDDOG-QUEUE-DISPATCH] preflight=FAIL error={type(exc).__name__}")
+            return False
+        print(f"[REDDOG-QUEUE-DISPATCH] preflight=WARN error={type(exc).__name__}")
+        return True
+
+    status = "PASS" if result.accepted else "WARN"
+    reasons = ",".join(result.rejection_reasons) if result.rejection_reasons else "(none)"
+    print(
+        f"[REDDOG-QUEUE-DISPATCH] preflight={status} status={result.status} "
+        f"queue_item={result.queue_item_id or '(none)'} "
+        f"selected_slice={result.selected_slice or '(none)'} "
+        f"dispatched_stage={result.dispatched_stage or '(none)'} "
+        f"next_action={result.next_action or '(none)'} reasons={reasons}"
+    )
+    if result.accepted:
+        print(
+            f"[REDDOG-QUEUE-DISPATCH] chain_results={result.chain_results_path or '(none)'} "
+            f"revision={result.store_revision or '(none)'}"
+        )
+        return True
+
+    if enforced:
+        print("[REDDOG-QUEUE-DISPATCH] Startup blocked by REDDOG_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_ENFORCED=1")
+        return False
+    return True
+
+
 def bootstrap_runtime_dae_launches() -> None:
     """Register broker-managed DAE entrypoints for an already running system."""
     daemon = get_central_daemon()
@@ -1635,6 +1696,8 @@ def main():
     if not run_reddog_wre_queue_consumer_preflight(repo_root):
         return
     if not run_reddog_resident_queue_orchestration_plan_preflight(repo_root):
+        return
+    if not run_reddog_resident_queue_next_stage_dispatch_preflight(repo_root):
         return
     if not run_reddog_readonly_operational_bootstrap_preflight(repo_root):
         return

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,26 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_BOOTSTRAP_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_main_resident_queue_next_stage_dispatch_bootstrap.py`:
+  an opt-in `main.py` adapter that invokes the resident queue dispatcher with
+  only the `authority_request` handler registered.
+- Wired `main.py` behind `REDDOG_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH=1`
+  (default OFF) to write the first-stage dry-run result into the outside-repo
+  resident queue chain-results store.
+- Boundary: external runtime state only; no signing, signature verification,
+  valve opening, worker spawn, worktree creation, file edit, shell command,
+  PR publishing, PatternMemory write, OpenClaw enqueue, Hermes dispatch,
+  reward settlement, or HoloIndex re-index.
+- HoloIndex read-only probe for `RedDog main resident queue next stage
+  dispatch bootstrap` surfaced adjacent swarm/build-plan, WSP, RedDog
+  bootstrap/governance docs, and knowledge papers, but not this new bootstrap
+  before indexing. Recorded as
+  `HOLOINDEX_REDDOG_MAIN_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_BOOTSTRAP_INDEX_GAP_PHASE1`;
+  no runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_RESIDENT_QUEUE_AUTHORITY_REQUEST_HANDLER_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_next_stage_dispatch_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_next_stage_dispatch_bootstrap.py
@@ -1,0 +1,240 @@
+"""Main-startup adapter for resident queue next-stage dispatch.
+
+Slice: REDDOG_MAIN_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_BOOTSTRAP_PHASE1
+
+This adapter lets ``main.py`` invoke exactly one already-built resident queue
+stage handler behind an explicit environment flag. In this slice the only
+registered handler is `authority_request`, which emits a dry-run delegated
+authority request and records it to the outside-repo chain-results store.
+
+It does not sign, verify signatures, open valves, spawn workers, create
+worktrees, execute shell commands, enqueue OpenClaw, dispatch Hermes, publish
+PRs, settle rewards, mutate repository files, or re-index HoloIndex.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_authority_request_handler import (
+    AUTHORITY_REQUEST_STAGE_KEY,
+    build_reddog_resident_queue_authority_request_stage_handler,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_chain_results_store import (
+    AtomicJsonResidentQueueChainResultsStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_next_stage_dispatch import (
+    RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_ACCEPT,
+    invoke_reddog_resident_queue_next_stage_dispatch,
+)
+
+
+REDDOG_RESIDENT_QUEUE_DISPATCH_BOOTSTRAP_APPLIED = "REDDOG_RESIDENT_QUEUE_DISPATCH_BOOTSTRAP_APPLIED"
+REDDOG_RESIDENT_QUEUE_DISPATCH_BOOTSTRAP_NOT_READY = "REDDOG_RESIDENT_QUEUE_DISPATCH_BOOTSTRAP_NOT_READY"
+
+
+@dataclass(frozen=True)
+class RedDogMainResidentQueueNextStageDispatchBootstrapResult:
+    """Result emitted by the startup next-stage dispatch adapter."""
+
+    accepted: bool
+    status: str
+    queue_item_id: Optional[str]
+    selected_slice: Optional[str]
+    dispatched_stage: Optional[str]
+    next_action: Optional[str]
+    chain_results_path: Optional[str]
+    store_revision: Optional[str]
+    rejection_reasons: tuple[str, ...]
+    no_signing_performed: bool = True
+    no_signature_verification_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_worktree_created: bool = True
+    no_shell_command_executed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pr_created: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_reward_settlement_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_main_resident_queue_next_stage_dispatch_bootstrap(
+    *,
+    repo_root: Path | str,
+    work_state_path: Path | str | None,
+    chain_results_path: Path | str | None,
+    authority_profile_path: Path | str | None,
+    requested_queue_item_id: str | None = None,
+    now_iso: str | None = None,
+) -> RedDogMainResidentQueueNextStageDispatchBootstrapResult:
+    """Load runtime inputs and dispatch the first resident queue stage."""
+
+    root = Path(repo_root).resolve()
+    snapshot, snapshot_reasons = _read_json_outside_repo(
+        root,
+        work_state_path,
+        missing_reason="missing_authoritative_work_state_path",
+        inside_reason="work_state_path_inside_repo",
+        unreadable_reason="malformed_authoritative_work_state",
+    )
+    if snapshot_reasons:
+        return _not_ready(snapshot_reasons, chain_results_path=None)
+    assert snapshot is not None
+
+    profile, profile_reasons = _read_json_outside_repo(
+        root,
+        authority_profile_path,
+        missing_reason="missing_authority_profile_path",
+        inside_reason="authority_profile_path_inside_repo",
+        unreadable_reason="malformed_authority_profile",
+    )
+    if profile_reasons:
+        return _not_ready(profile_reasons, chain_results_path=None)
+    assert profile is not None
+
+    chain_path, chain_reasons = _resolve_output_outside_repo(
+        root,
+        chain_results_path,
+        missing_reason="missing_chain_results_path",
+        inside_reason="chain_results_path_inside_repo",
+    )
+    if chain_reasons:
+        return _not_ready(chain_reasons, chain_results_path=None)
+    assert chain_path is not None
+
+    handler = build_reddog_resident_queue_authority_request_stage_handler(
+        work_state_snapshot=snapshot,
+        authority_profile=profile,
+        now_iso=now_iso or "",
+    )
+    store = AtomicJsonResidentQueueChainResultsStore(chain_path)
+    result = invoke_reddog_resident_queue_next_stage_dispatch(
+        explicit_resident_queue_stage_dispatch_requested=True,
+        work_state_snapshot=snapshot,
+        store=store,
+        handlers={AUTHORITY_REQUEST_STAGE_KEY: handler},
+        now_iso=now_iso or "",
+        requested_queue_item_id=requested_queue_item_id,
+    )
+    if result.accepted is not True or result.decision != RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_ACCEPT:
+        return _not_ready(
+            tuple(result.rejection_reasons or ("resident_queue_dispatch_rejected",)),
+            chain_results_path=chain_path,
+            queue_item_id=_plan_text(result.to_dict(), ("plan", "selected_queue_item_id")),
+            selected_slice=_plan_text(result.to_dict(), ("plan", "selected_slice")),
+            dispatched_stage=result.dispatched_stage,
+            next_action=result.next_action,
+        )
+
+    record = result.record_result
+    receipt = record.receipt if record else None
+    return RedDogMainResidentQueueNextStageDispatchBootstrapResult(
+        accepted=True,
+        status=REDDOG_RESIDENT_QUEUE_DISPATCH_BOOTSTRAP_APPLIED,
+        queue_item_id=receipt.queue_item_id if receipt else None,
+        selected_slice=receipt.selected_slice if receipt else None,
+        dispatched_stage=result.dispatched_stage,
+        next_action=result.next_action,
+        chain_results_path=str(chain_path),
+        store_revision=receipt.store_revision if receipt else None,
+        rejection_reasons=(),
+    )
+
+
+def _read_json_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    missing_reason: str,
+    inside_reason: str,
+    unreadable_reason: str,
+) -> tuple[Optional[Mapping[str, Any]], tuple[str, ...]]:
+    if not value:
+        return None, (missing_reason,)
+    path = Path(value)
+    if not path.is_absolute():
+        path = (repo_root / path).resolve()
+    else:
+        path = path.resolve()
+    if _is_inside(path, repo_root):
+        return None, (inside_reason,)
+    if not path.exists() or not path.is_file():
+        return None, (missing_reason,)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None, (unreadable_reason,)
+    if not isinstance(payload, Mapping):
+        return None, (unreadable_reason,)
+    return payload, ()
+
+
+def _resolve_output_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    missing_reason: str,
+    inside_reason: str,
+) -> tuple[Optional[Path], tuple[str, ...]]:
+    if not value:
+        return None, (missing_reason,)
+    path = Path(value)
+    if not path.is_absolute():
+        path = (repo_root / path).resolve()
+    else:
+        path = path.resolve()
+    if _is_inside(path, repo_root):
+        return None, (inside_reason,)
+    return path, ()
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+def _not_ready(
+    reasons: tuple[str, ...],
+    *,
+    chain_results_path: Path | None,
+    queue_item_id: Optional[str] = None,
+    selected_slice: Optional[str] = None,
+    dispatched_stage: Optional[str] = None,
+    next_action: Optional[str] = None,
+) -> RedDogMainResidentQueueNextStageDispatchBootstrapResult:
+    return RedDogMainResidentQueueNextStageDispatchBootstrapResult(
+        accepted=False,
+        status=REDDOG_RESIDENT_QUEUE_DISPATCH_BOOTSTRAP_NOT_READY,
+        queue_item_id=queue_item_id,
+        selected_slice=selected_slice,
+        dispatched_stage=dispatched_stage,
+        next_action=next_action,
+        chain_results_path=str(chain_results_path) if chain_results_path else None,
+        store_revision=None,
+        rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons if str(reason).strip())),
+    )
+
+
+def _plan_text(payload: Mapping[str, Any], path: tuple[str, str]) -> Optional[str]:
+    parent = payload.get(path[0])
+    if not isinstance(parent, Mapping):
+        return None
+    value = str(parent.get(path[1]) or "").strip()
+    return value or None
+
+
+__all__ = [
+    "REDDOG_RESIDENT_QUEUE_DISPATCH_BOOTSTRAP_APPLIED",
+    "REDDOG_RESIDENT_QUEUE_DISPATCH_BOOTSTRAP_NOT_READY",
+    "RedDogMainResidentQueueNextStageDispatchBootstrapResult",
+    "run_reddog_main_resident_queue_next_stage_dispatch_bootstrap",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_next_stage_dispatch_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_next_stage_dispatch_bootstrap.py
@@ -1,0 +1,336 @@
+"""Tests for REDDOG_MAIN_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_BOOTSTRAP_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_next_stage_dispatch_bootstrap import (
+    REDDOG_RESIDENT_QUEUE_DISPATCH_BOOTSTRAP_APPLIED,
+    REDDOG_RESIDENT_QUEUE_DISPATCH_BOOTSTRAP_NOT_READY,
+    run_reddog_main_resident_queue_next_stage_dispatch_bootstrap,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_authority_request_handler import (
+    AUTHORITY_REQUEST_STAGE_KEY,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_orchestration_plan import (
+    NEXT_QUEUE_AUTHORITY_RUNTIME_INVOKE,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    VALVE_OPEN_WORKTREE_CREATE,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_main_resident_queue_next_stage_dispatch_bootstrap.py"
+)
+NOW = "2026-07-14T00:00:00+00:00"
+EXPIRES = "2026-07-14T01:00:00+00:00"
+
+
+def _snapshot() -> dict[str, object]:
+    return {
+        "schema_version": "reddog_authoritative_work_state.v1",
+        "freshness_receipts": [{"receipt_id": "fresh-1", "fresh": True}],
+        "worker_claims": [
+            {
+                "claim_id": "claim-1",
+                "slice_id": "REDDOG_TEST_SLICE_PHASE1",
+                "worker_id": "reddog-0102",
+                "status": "ACTIVE",
+                "expires_at": EXPIRES,
+                "freshness_receipt_id": "fresh-1",
+            }
+        ],
+        "wre_queue_items": [
+            {
+                "queue_item_id": "queue-1",
+                "slice_id": "REDDOG_TEST_SLICE_PHASE1",
+                "claim_id": "claim-1",
+                "worker_id": "reddog-0102",
+                "status": "QUEUED",
+                "evidence_refs": ["claim:claim-1", "freshness:fresh-1"],
+                "no_execution_performed": True,
+            }
+        ],
+    }
+
+
+def _profile(**overrides: object) -> dict[str, object]:
+    profile = {
+        "principal_id": "github:mjtrout",
+        "principal_provider": "github",
+        "principal_public_key": "pub:principal",
+        "reddog_id": "reddog:abc123",
+        "reddog_public_key": "pub:reddog",
+        "repo_full_name": "FOUNDUPS/Foundups-Agent",
+        "foundup_id": "paccess_001",
+        "allowed_paths": ["modules/foundups/paccess_001/**"],
+        "denied_paths": ["modules/foundups/paccess_001/secrets/**"],
+        "requested_operation": "create_foundup",
+        "permission_snapshot_digest": "sha256:snap-1",
+        "identity_nonce": "identity-nonce-0001",
+        "work_authority_nonce": "workauth-nonce-0001",
+        "issued_at": 1000,
+        "identity_expires_at": 4600,
+        "work_authority_expires_at": 1300,
+        "valve_state_required": VALVE_OPEN_WORKTREE_CREATE,
+        "key_epoch": "epoch-1",
+        "consensus_receipt_digest": "sha256:consensus",
+        "sovereign_authorization_digest": "sha256:012-token",
+    }
+    profile.update(overrides)
+    return profile
+
+
+def _write_runtime_json(tmp_path: Path, name: str, payload: object) -> Path:
+    path = tmp_path / "runtime" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _repo(tmp_path: Path) -> Path:
+    path = tmp_path / "repo"
+    path.mkdir()
+    return path
+
+
+def test_bootstrap_dispatches_authority_request_and_writes_outside_repo_chain_store(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(tmp_path, "profile.json", _profile())
+    chain = tmp_path / "runtime" / "chain_results.json"
+
+    result = run_reddog_main_resident_queue_next_stage_dispatch_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        now_iso=NOW,
+        requested_queue_item_id="queue-1",
+    )
+
+    assert result.accepted is True
+    assert result.status == REDDOG_RESIDENT_QUEUE_DISPATCH_BOOTSTRAP_APPLIED
+    assert result.queue_item_id == "queue-1"
+    assert result.selected_slice == "REDDOG_TEST_SLICE_PHASE1"
+    assert result.dispatched_stage == AUTHORITY_REQUEST_STAGE_KEY
+    assert result.next_action == NEXT_QUEUE_AUTHORITY_RUNTIME_INVOKE
+    assert result.store_revision is not None
+    assert result.no_signing_performed is True
+    assert result.no_repo_mutation_performed is True
+    assert result.no_holoindex_reindex_performed is True
+    stored = json.loads(chain.read_text(encoding="utf-8"))
+    stage = stored["stage_results"][AUTHORITY_REQUEST_STAGE_KEY]
+    assert stage["status"] == "QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT"
+    assert stage["delegated_authority_request"]["foundup_id"] == "paccess_001"
+
+
+def test_bootstrap_rejects_missing_authority_profile(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+
+    result = run_reddog_main_resident_queue_next_stage_dispatch_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=tmp_path / "runtime" / "chain_results.json",
+        authority_profile_path=None,
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert result.status == REDDOG_RESIDENT_QUEUE_DISPATCH_BOOTSTRAP_NOT_READY
+    assert "missing_authority_profile_path" in result.rejection_reasons
+
+
+def test_bootstrap_rejects_inputs_inside_repo(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    inside_state = repo / "work_state.json"
+    inside_state.write_text(json.dumps(_snapshot()), encoding="utf-8")
+
+    result = run_reddog_main_resident_queue_next_stage_dispatch_bootstrap(
+        repo_root=repo,
+        work_state_path=inside_state,
+        chain_results_path=tmp_path / "runtime" / "chain_results.json",
+        authority_profile_path=tmp_path / "runtime" / "profile.json",
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert "work_state_path_inside_repo" in result.rejection_reasons
+
+
+def test_bootstrap_rejects_chain_output_inside_repo(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(tmp_path, "profile.json", _profile())
+
+    result = run_reddog_main_resident_queue_next_stage_dispatch_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=repo / "chain_results.json",
+        authority_profile_path=profile,
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert "chain_results_path_inside_repo" in result.rejection_reasons
+
+
+def test_bootstrap_rejects_invalid_profile_without_store_write(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(tmp_path, "profile.json", _profile(principal_public_key=""))
+    chain = tmp_path / "runtime" / "chain_results.json"
+
+    result = run_reddog_main_resident_queue_next_stage_dispatch_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert "FAIL_RECORD_REJECTED" in result.rejection_reasons
+    assert "FAIL_REQUIRED_FIELD:principal_public_key" in result.rejection_reasons
+    assert not chain.exists()
+
+
+def test_main_next_stage_dispatch_preflight_is_disabled_by_default() -> None:
+    import main
+
+    with patch.dict("os.environ", {}, clear=True):
+        assert main.run_reddog_resident_queue_next_stage_dispatch_preflight(REPO_ROOT) is True
+
+
+def test_main_next_stage_dispatch_preflight_passes_when_bootstrap_applies(tmp_path: Path) -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_resident_queue_next_stage_dispatch_bootstrap.run_reddog_main_resident_queue_next_stage_dispatch_bootstrap",
+        return_value=type(
+            "Result",
+            (),
+            {
+                "accepted": True,
+                "status": REDDOG_RESIDENT_QUEUE_DISPATCH_BOOTSTRAP_APPLIED,
+                "queue_item_id": "queue-1",
+                "selected_slice": "REDDOG_TEST_SLICE_PHASE1",
+                "dispatched_stage": AUTHORITY_REQUEST_STAGE_KEY,
+                "next_action": NEXT_QUEUE_AUTHORITY_RUNTIME_INVOKE,
+                "chain_results_path": str(tmp_path / "chain.json"),
+                "store_revision": "sha256:revision",
+                "rejection_reasons": (),
+            },
+        )(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH": "1",
+                "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+                "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
+                "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+                "REDDOG_WRE_QUEUE_ITEM_ID": "queue-1",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_queue_next_stage_dispatch_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["work_state_path"] == str(tmp_path / "state.json")
+    assert mocked.call_args.kwargs["chain_results_path"] == str(tmp_path / "chain.json")
+    assert mocked.call_args.kwargs["authority_profile_path"] == str(tmp_path / "profile.json")
+    assert mocked.call_args.kwargs["requested_queue_item_id"] == "queue-1"
+
+
+def test_main_next_stage_dispatch_preflight_blocks_when_enforced() -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_resident_queue_next_stage_dispatch_bootstrap.run_reddog_main_resident_queue_next_stage_dispatch_bootstrap",
+        return_value=type(
+            "Result",
+            (),
+            {
+                "accepted": False,
+                "status": REDDOG_RESIDENT_QUEUE_DISPATCH_BOOTSTRAP_NOT_READY,
+                "queue_item_id": None,
+                "selected_slice": None,
+                "dispatched_stage": None,
+                "next_action": None,
+                "chain_results_path": None,
+                "store_revision": None,
+                "rejection_reasons": ("missing_authority_profile_path",),
+            },
+        )(),
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH": "1",
+                "REDDOG_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_ENFORCED": "1",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_queue_next_stage_dispatch_preflight(REPO_ROOT) is False
+
+
+def test_module_has_no_shell_network_holoindex_or_later_stage_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+        "hmac",
+        "secrets",
+    }
+    banned_import_fragments = {
+        "reddog_signer_delegated_authority_runtime",
+        "reddog_wre_queue_authority_runtime_invoke",
+        "reddog_wre_queue_authority_verification_invoke",
+        "reddog_wre_queue_authorized",
+        "reddog_wre_queue_verified_authority_work_order_invoke",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    banned_attrs = {
+        "system",
+        "popen",
+        "spawn",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "unlink",
+        "remove",
+        "rmdir",
+        "rename",
+    }
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+                assert all(fragment not in alias.name for fragment in banned_import_fragments)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+            assert all(fragment not in node.module for fragment in banned_import_fragments)
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs


### PR DESCRIPTION
## Summary

- adds an opt-in `main.py` bootstrap for resident queue next-stage dispatch
- registers only the `authority_request` handler and writes only the outside-repo chain-results JSON
- keeps signing, verification, later stages, OpenClaw/Hermes, shell, worktree, repo mutation, PR, reward, PatternMemory, and HoloIndex re-index out of scope

## Validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_next_stage_dispatch_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_authority_request_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_next_stage_dispatch.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_chain_results_store.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_orchestration_plan.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_orchestration_plan_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_main_authoritative_work_state_refresh_bootstrap.py -q` -> 82 passed
- `git diff --check` -> clean
- new bootstrap/test files ASCII/NUL clean

## HoloIndex

Read-only probe for `RedDog main resident queue next stage dispatch bootstrap` did not surface the new bootstrap before indexing. Recorded as `HOLOINDEX_REDDOG_MAIN_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_BOOTSTRAP_INDEX_GAP_PHASE1`; no runtime re-index performed.