### PR TITLE
feat(reddog): resident queue authority runtime handler

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,26 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_RESIDENT_QUEUE_AUTHORITY_RUNTIME_HANDLER_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_resident_queue_authority_runtime_handler.py`: a concrete
+  injected handler for the resident queue `authority_runtime` stage.
+- The handler reads the already-recorded `authority_request` result from the
+  chain-results store and invokes the existing queue authority-runtime guard
+  with injected signer, resolver, snapshot, and authority-store boundaries.
+- Boundary: signed authority issuance may occur only through injected
+  boundaries; no signature verification for execution, valve opening, worker
+  spawn, worktree creation, file edit, shell command, PR publishing,
+  PatternMemory write, OpenClaw enqueue, Hermes dispatch, reward settlement,
+  or HoloIndex re-index.
+- HoloIndex read-only probe for `RedDog resident queue authority runtime
+  handler` surfaced adjacent live-enqueue, queue-observability, AI overseer,
+  WSP, and governance docs, but not this new handler before indexing.
+  Recorded as
+  `HOLOINDEX_REDDOG_RESIDENT_QUEUE_AUTHORITY_RUNTIME_HANDLER_INDEX_GAP_PHASE1`;
+  no runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_BOOTSTRAP_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_authority_runtime_handler.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_authority_runtime_handler.py
@@ -1,0 +1,154 @@
+"""Resident RedDog authority-runtime stage handler.
+
+Slice: REDDOG_RESIDENT_QUEUE_AUTHORITY_RUNTIME_HANDLER_PHASE1
+
+This module adapts the existing queue authority-runtime explicit invoke guard
+to the resident queue next-stage dispatcher. It reads the already-recorded
+`authority_request` stage result from the chain-results store and invokes the
+runtime guard with injected signer, resolver, snapshot, and authority-store
+boundaries.
+
+It may produce signed delegated-authority records through those injected
+boundaries. It does not verify signatures for execution, open valves, spawn
+workers, create worktrees, execute shell commands, enqueue OpenClaw, dispatch
+Hermes, publish PRs, settle rewards, mutate repository files, or re-index
+HoloIndex.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_chain_results_store import (
+    ResidentQueueChainResultsStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_next_stage_dispatch import (
+    ResidentQueueStageDispatchRequest,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_orchestration_plan import (
+    NEXT_QUEUE_AUTHORITY_RUNTIME_INVOKE,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authority_runtime_invoke import (
+    QUEUE_AUTHORITY_RUNTIME_INVOKE_REJECT,
+    invoke_reddog_wre_queue_authority_runtime,
+)
+
+
+AUTHORITY_RUNTIME_STAGE_KEY = "authority_runtime"
+AUTHORITY_REQUEST_STAGE_KEY = "authority_request"
+
+FAIL_DISPATCH_STAGE_MISMATCH = "FAIL_DISPATCH_STAGE_MISMATCH"
+FAIL_DISPATCH_NEXT_ACTION_MISMATCH = "FAIL_DISPATCH_NEXT_ACTION_MISMATCH"
+FAIL_AUTHORITY_REQUEST_STAGE_MISSING = "FAIL_AUTHORITY_REQUEST_STAGE_MISSING"
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        candidate = value.to_dict()
+        return candidate if isinstance(candidate, Mapping) else {}
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _stage_results(state: Mapping[str, Any]) -> Mapping[str, Mapping[str, Any]]:
+    raw = state.get("stage_results") if state.get("schema_version") == "reddog_resident_queue_chain_results.v1" else state
+    if not isinstance(raw, Mapping):
+        return {}
+    return {str(key): value for key, value in raw.items() if isinstance(value, Mapping)}
+
+
+def _reject(*reasons: str) -> dict[str, Any]:
+    return {
+        "decision": QUEUE_AUTHORITY_RUNTIME_INVOKE_REJECT,
+        "rejection_reasons": list(dict.fromkeys(reason for reason in reasons if reason)),
+        "authority_result": None,
+        "explicit_queue_authority_runtime_requested": False,
+        "no_worker_spawn_performed": True,
+        "no_worktree_created": True,
+        "no_shell_command_executed": True,
+        "no_openclaw_enqueue_performed": True,
+        "no_hermes_dispatch_performed": True,
+        "no_repo_mutation_performed": True,
+        "no_holoindex_reindex_performed": True,
+        "no_pr_created": True,
+        "no_reward_settlement_performed": True,
+    }
+
+
+@dataclass(frozen=True)
+class ResidentQueueAuthorityRuntimeStageHandler:
+    """Callable handler for the resident queue `authority_runtime` stage."""
+
+    chain_results_store: ResidentQueueChainResultsStore
+    authority_store: Any
+    signer: Any
+    principal_resolver: Any
+    snapshot_resolver: Any
+    now: int
+    leeway_s: int = 60
+
+    def __call__(self, request: ResidentQueueStageDispatchRequest) -> Mapping[str, Any]:
+        if request.stage_key != AUTHORITY_RUNTIME_STAGE_KEY:
+            return _reject(
+                FAIL_DISPATCH_STAGE_MISMATCH,
+                f"expected:{AUTHORITY_RUNTIME_STAGE_KEY}",
+                f"actual:{request.stage_key}",
+            )
+        if request.next_action != NEXT_QUEUE_AUTHORITY_RUNTIME_INVOKE:
+            return _reject(
+                FAIL_DISPATCH_NEXT_ACTION_MISMATCH,
+                f"expected:{NEXT_QUEUE_AUTHORITY_RUNTIME_INVOKE}",
+                f"actual:{request.next_action}",
+            )
+
+        stage_results = _stage_results(_mapping(self.chain_results_store.load()))
+        authority_request = _mapping(stage_results.get(AUTHORITY_REQUEST_STAGE_KEY))
+        if not authority_request:
+            return _reject(FAIL_AUTHORITY_REQUEST_STAGE_MISSING)
+
+        return invoke_reddog_wre_queue_authority_runtime(
+            explicit_queue_authority_runtime_requested=True,
+            queue_authority_request_dryrun=authority_request,
+            store=self.authority_store,
+            signer=self.signer,
+            principal_resolver=self.principal_resolver,
+            snapshot_resolver=self.snapshot_resolver,
+            now=self.now,
+            leeway_s=self.leeway_s,
+        ).to_dict()
+
+
+def build_reddog_resident_queue_authority_runtime_stage_handler(
+    *,
+    chain_results_store: ResidentQueueChainResultsStore,
+    authority_store: Any,
+    signer: Any,
+    principal_resolver: Any,
+    snapshot_resolver: Any,
+    now: int,
+    leeway_s: int = 60,
+) -> ResidentQueueAuthorityRuntimeStageHandler:
+    """Build the injected handler for the resident queue dispatcher."""
+
+    return ResidentQueueAuthorityRuntimeStageHandler(
+        chain_results_store=chain_results_store,
+        authority_store=authority_store,
+        signer=signer,
+        principal_resolver=principal_resolver,
+        snapshot_resolver=snapshot_resolver,
+        now=now,
+        leeway_s=leeway_s,
+    )
+
+
+__all__ = [
+    "AUTHORITY_REQUEST_STAGE_KEY",
+    "AUTHORITY_RUNTIME_STAGE_KEY",
+    "FAIL_AUTHORITY_REQUEST_STAGE_MISSING",
+    "FAIL_DISPATCH_NEXT_ACTION_MISMATCH",
+    "FAIL_DISPATCH_STAGE_MISMATCH",
+    "ResidentQueueAuthorityRuntimeStageHandler",
+    "build_reddog_resident_queue_authority_runtime_stage_handler",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_authority_runtime_handler.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_authority_runtime_handler.py
@@ -1,0 +1,371 @@
+"""Tests for REDDOG_RESIDENT_QUEUE_AUTHORITY_RUNTIME_HANDLER_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import hmac
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_authority_request_handler import (
+    build_reddog_resident_queue_authority_request_stage_handler,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_authority_runtime_handler import (
+    AUTHORITY_REQUEST_STAGE_KEY,
+    AUTHORITY_RUNTIME_STAGE_KEY,
+    FAIL_AUTHORITY_REQUEST_STAGE_MISSING,
+    FAIL_DISPATCH_NEXT_ACTION_MISMATCH,
+    FAIL_DISPATCH_STAGE_MISMATCH,
+    build_reddog_resident_queue_authority_runtime_stage_handler,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_chain_results_store import (
+    InMemoryResidentQueueChainResultsStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_next_stage_dispatch import (
+    FAIL_RECORD_REJECTED,
+    RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_ACCEPT,
+    ResidentQueueStageDispatchRequest,
+    invoke_reddog_resident_queue_next_stage_dispatch,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_orchestration_plan import (
+    NEXT_QUEUE_AUTHORITY_RUNTIME_INVOKE,
+    NEXT_QUEUE_AUTHORITY_VERIFICATION_INVOKE,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    AUTHORITY_ISSUED,
+    InMemoryAuthorityRuntimeStore,
+    PrincipalAuthorityRecord,
+    RuntimeRejectCode,
+    SigningResponse,
+    public_key_fingerprint,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    PermissionSnapshot,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    VALVE_OPEN_WORKTREE_CREATE,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authority_runtime_invoke import (
+    QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT,
+    QUEUE_AUTHORITY_RUNTIME_INVOKE_REJECT,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_resident_queue_authority_runtime_handler.py"
+)
+NOW_ISO = "2026-07-14T00:00:00+00:00"
+NOW = 1000
+EXPIRES = "2026-07-14T01:00:00+00:00"
+REPO = "FOUNDUPS/Foundups-Agent"
+FID = "paccess_001"
+_DEFAULT_SIGNER = object()
+
+
+class _MockSigner:
+    def __init__(self) -> None:
+        self.secrets = {
+            "pub:principal": b"principal-secret",
+            "pub:reddog": b"reddog-secret",
+        }
+        self.requests = []
+
+    def sign(self, request):
+        self.requests.append(request)
+        secret = self.secrets.get(request.signer_public_key)
+        if secret is None:
+            return SigningResponse(
+                accepted=False,
+                rejection_code=RuntimeRejectCode.SIGNER_NOT_CONFIGURED,
+            )
+        signature = hmac.new(secret, request.signing_input.encode("utf-8"), hashlib.sha256).hexdigest()
+        audit = hmac.new(secret, request.payload_digest.encode("utf-8"), hashlib.sha256).hexdigest()
+        return SigningResponse(
+            accepted=True,
+            signature=signature,
+            signer_public_key=request.signer_public_key,
+            key_fingerprint=public_key_fingerprint(request.signer_public_key),
+            key_epoch=request.key_epoch,
+            audit_mac="audit:" + audit,
+            boundary_attested=True,
+            requester_identity_attested=True,
+            signer_loads_no_untrusted_code=True,
+            no_secret_material_returned=True,
+        )
+
+
+class _PrincipalResolver:
+    def resolve(self, principal_id: str, principal_provider: str):
+        if principal_id == "github:mjtrout" and principal_provider == "github":
+            return PrincipalAuthorityRecord(
+                principal_id="github:mjtrout",
+                principal_provider="github",
+                principal_public_key="pub:principal",
+                repo_scope=(REPO,),
+                foundup_scope=(FID,),
+                verified_subject_digest="sha256:verified-subject",
+                reward_account="reward:012",
+                owner_dae="dae:012",
+            )
+        return None
+
+
+class _SnapshotResolver:
+    def resolve(self, digest: str):
+        if digest == "sha256:snap-1":
+            return PermissionSnapshot(
+                evidence_digest="sha256:snap-1",
+                expires_at=NOW + 600,
+                can_write=True,
+                repo_full_name=REPO,
+            )
+        return None
+
+
+def _snapshot() -> dict[str, object]:
+    return {
+        "schema_version": "reddog_authoritative_work_state.v1",
+        "freshness_receipts": [{"receipt_id": "fresh-1", "fresh": True}],
+        "worker_claims": [
+            {
+                "claim_id": "claim-1",
+                "slice_id": "REDDOG_TEST_SLICE_PHASE1",
+                "worker_id": "reddog-0102",
+                "status": "ACTIVE",
+                "expires_at": EXPIRES,
+                "freshness_receipt_id": "fresh-1",
+            }
+        ],
+        "wre_queue_items": [
+            {
+                "queue_item_id": "queue-1",
+                "slice_id": "REDDOG_TEST_SLICE_PHASE1",
+                "claim_id": "claim-1",
+                "worker_id": "reddog-0102",
+                "status": "QUEUED",
+                "evidence_refs": ["claim:claim-1", "freshness:fresh-1"],
+                "no_execution_performed": True,
+            }
+        ],
+    }
+
+
+def _profile() -> dict[str, object]:
+    return {
+        "principal_id": "github:mjtrout",
+        "principal_provider": "github",
+        "principal_public_key": "pub:principal",
+        "reddog_id": "reddog:abc123",
+        "reddog_public_key": "pub:reddog",
+        "repo_full_name": REPO,
+        "foundup_id": FID,
+        "allowed_paths": [f"modules/foundups/{FID}/**"],
+        "denied_paths": [],
+        "requested_operation": "create_foundup",
+        "permission_snapshot_digest": "sha256:snap-1",
+        "identity_nonce": "identity-nonce-0001",
+        "work_authority_nonce": "workauth-nonce-0001",
+        "issued_at": NOW - 5,
+        "identity_expires_at": NOW + 3600,
+        "work_authority_expires_at": NOW + 300,
+        "valve_state_required": VALVE_OPEN_WORKTREE_CREATE,
+        "key_epoch": "epoch-1",
+        "consensus_receipt_digest": "sha256:consensus",
+        "sovereign_authorization_digest": "sha256:012-token",
+    }
+
+
+def _seed_authority_request(store: InMemoryResidentQueueChainResultsStore) -> None:
+    handler = build_reddog_resident_queue_authority_request_stage_handler(
+        work_state_snapshot=_snapshot(),
+        authority_profile=_profile(),
+        now_iso=NOW_ISO,
+    )
+    result = invoke_reddog_resident_queue_next_stage_dispatch(
+        explicit_resident_queue_stage_dispatch_requested=True,
+        work_state_snapshot=_snapshot(),
+        store=store,
+        handlers={AUTHORITY_REQUEST_STAGE_KEY: handler},
+        now_iso=NOW_ISO,
+    )
+    assert result.accepted is True
+
+
+def _runtime_handler(
+    *,
+    chain_store: InMemoryResidentQueueChainResultsStore,
+    authority_store: InMemoryAuthorityRuntimeStore | None = None,
+    signer: object | None = _DEFAULT_SIGNER,
+):
+    return build_reddog_resident_queue_authority_runtime_stage_handler(
+        chain_results_store=chain_store,
+        authority_store=authority_store or InMemoryAuthorityRuntimeStore(),
+        signer=_MockSigner() if signer is _DEFAULT_SIGNER else signer,
+        principal_resolver=_PrincipalResolver(),
+        snapshot_resolver=_SnapshotResolver(),
+        now=NOW,
+    )
+
+
+def test_dispatcher_records_authority_runtime_result_and_advances_to_verification() -> None:
+    chain_store = InMemoryResidentQueueChainResultsStore()
+    _seed_authority_request(chain_store)
+    authority_store = InMemoryAuthorityRuntimeStore()
+    signer = _MockSigner()
+
+    result = invoke_reddog_resident_queue_next_stage_dispatch(
+        explicit_resident_queue_stage_dispatch_requested=True,
+        work_state_snapshot=_snapshot(),
+        store=chain_store,
+        handlers={
+            AUTHORITY_RUNTIME_STAGE_KEY: _runtime_handler(
+                chain_store=chain_store,
+                authority_store=authority_store,
+                signer=signer,
+            )
+        },
+        now_iso=NOW_ISO,
+    )
+
+    assert result.accepted is True
+    assert result.decision == RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_ACCEPT
+    assert result.dispatched_stage == AUTHORITY_RUNTIME_STAGE_KEY
+    assert result.next_action == NEXT_QUEUE_AUTHORITY_VERIFICATION_INVOKE
+    assert len(signer.requests) == 2
+    state = chain_store.load()
+    stage = state["stage_results"][AUTHORITY_RUNTIME_STAGE_KEY]
+    assert stage["decision"] == QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT
+    assert stage["authority_result"]["receipt"]["status"] == AUTHORITY_ISSUED
+    assert stage["no_worker_spawn_performed"] is True
+    assert stage["no_openclaw_enqueue_performed"] is True
+    assert state["no_repo_mutation_performed"] is True
+
+
+def test_missing_authority_request_stage_rejects_direct_handler_call() -> None:
+    handler = _runtime_handler(chain_store=InMemoryResidentQueueChainResultsStore())
+    request = ResidentQueueStageDispatchRequest(
+        stage_key=AUTHORITY_RUNTIME_STAGE_KEY,
+        next_action=NEXT_QUEUE_AUTHORITY_RUNTIME_INVOKE,
+        queue_item_id="queue-1",
+        selected_slice="REDDOG_TEST_SLICE_PHASE1",
+        plan_id="plan-1",
+        accepted_stages=(AUTHORITY_REQUEST_STAGE_KEY,),
+    )
+
+    result = dict(handler(request))
+
+    assert result["decision"] == QUEUE_AUTHORITY_RUNTIME_INVOKE_REJECT
+    assert FAIL_AUTHORITY_REQUEST_STAGE_MISSING in result["rejection_reasons"]
+
+
+def test_wrong_stage_rejects_direct_handler_call() -> None:
+    handler = _runtime_handler(chain_store=InMemoryResidentQueueChainResultsStore())
+    request = ResidentQueueStageDispatchRequest(
+        stage_key="authority_request",
+        next_action=NEXT_QUEUE_AUTHORITY_RUNTIME_INVOKE,
+        queue_item_id="queue-1",
+        selected_slice="REDDOG_TEST_SLICE_PHASE1",
+        plan_id="plan-1",
+        accepted_stages=(),
+    )
+
+    result = dict(handler(request))
+
+    assert result["decision"] == QUEUE_AUTHORITY_RUNTIME_INVOKE_REJECT
+    assert FAIL_DISPATCH_STAGE_MISMATCH in result["rejection_reasons"]
+
+
+def test_wrong_next_action_rejects_direct_handler_call() -> None:
+    handler = _runtime_handler(chain_store=InMemoryResidentQueueChainResultsStore())
+    request = ResidentQueueStageDispatchRequest(
+        stage_key=AUTHORITY_RUNTIME_STAGE_KEY,
+        next_action="RUN_QUEUE_AUTHORITY_REQUEST_DRYRUN",
+        queue_item_id="queue-1",
+        selected_slice="REDDOG_TEST_SLICE_PHASE1",
+        plan_id="plan-1",
+        accepted_stages=(AUTHORITY_REQUEST_STAGE_KEY,),
+    )
+
+    result = dict(handler(request))
+
+    assert result["decision"] == QUEUE_AUTHORITY_RUNTIME_INVOKE_REJECT
+    assert FAIL_DISPATCH_NEXT_ACTION_MISMATCH in result["rejection_reasons"]
+
+
+def test_runtime_rejection_is_not_recorded_by_dispatcher() -> None:
+    chain_store = InMemoryResidentQueueChainResultsStore()
+    _seed_authority_request(chain_store)
+
+    result = invoke_reddog_resident_queue_next_stage_dispatch(
+        explicit_resident_queue_stage_dispatch_requested=True,
+        work_state_snapshot=_snapshot(),
+        store=chain_store,
+        handlers={
+            AUTHORITY_RUNTIME_STAGE_KEY: _runtime_handler(
+                chain_store=chain_store,
+                signer=None,
+            )
+        },
+        now_iso=NOW_ISO,
+    )
+
+    assert result.accepted is False
+    assert FAIL_RECORD_REJECTED in result.rejection_reasons
+    assert RuntimeRejectCode.SIGNER_NOT_CONFIGURED in result.rejection_reasons
+    assert AUTHORITY_RUNTIME_STAGE_KEY not in chain_store.load()["stage_results"]
+
+
+def test_module_has_no_shell_network_worktree_openclaw_hermes_holoindex_or_later_stage_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+        "hmac",
+        "secrets",
+    }
+    banned_import_fragments = {
+        "reddog_wre_queue_authority_verification_invoke",
+        "reddog_wre_queue_authorized",
+        "reddog_wre_queue_verified_authority_work_order_invoke",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    banned_attrs = {
+        "system",
+        "popen",
+        "spawn",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "replace",
+        "unlink",
+        "remove",
+        "rmdir",
+        "rename",
+    }
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+                assert all(fragment not in alias.name for fragment in banned_import_fragments)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+            assert all(fragment not in node.module for fragment in banned_import_fragments)
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs


### PR DESCRIPTION
## Summary

- adds a concrete injected handler for the resident queue `authority_runtime` stage
- reads the already-recorded `authority_request` result from the chain store and invokes the existing queue authority-runtime guard
- keeps signature verification for execution, valves, later stages, OpenClaw/Hermes, shell, worktree, repo mutation, PR, reward, PatternMemory, and HoloIndex re-index out of scope

## Validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_authority_runtime_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_authority_request_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_next_stage_dispatch.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_chain_results_store.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_orchestration_plan.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_runtime_invoke.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_request_dryrun.py -q` -> 60 passed
- `git diff --check` -> clean
- new handler/test files ASCII/NUL clean

## HoloIndex

Read-only probe for `RedDog resident queue authority runtime handler` did not surface the new handler before indexing. Recorded as `HOLOINDEX_REDDOG_RESIDENT_QUEUE_AUTHORITY_RUNTIME_HANDLER_INDEX_GAP_PHASE1`; no runtime re-index performed.