### PR TITLE
feat(reddog): add resident queue worktree-create handler

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,24 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_RESIDENT_QUEUE_WORKTREE_CREATE_HANDLER_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_resident_queue_worktree_create_handler.py`: a concrete
+  injected handler for the resident queue `worktree_create` stage.
+- The handler reads the already-recorded `executor_plan` and `execution_valve`
+  results from the chain-results store, resolves the bound work order through
+  an injected resolver, and invokes the existing queue-authorized worktree
+  create guard with an injected runner.
+- Boundary: isolated worktree create gate only; no task execution, file edit,
+  shell command, PR publishing, PatternMemory write, OpenClaw enqueue, Hermes
+  dispatch, reward settlement, or HoloIndex re-index.
+- HoloIndex read-only probe for `RedDog resident queue worktree create handler`
+  surfaced the underlying worktree create/runner modules and worktree-related
+  docs, but not this new handler before indexing. Recorded as
+  `HOLOINDEX_REDDOG_RESIDENT_QUEUE_WORKTREE_CREATE_HANDLER_INDEX_GAP_PHASE1`;
+  no runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_RESIDENT_QUEUE_EXECUTION_VALVE_HANDLER_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_worktree_create_handler.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_worktree_create_handler.py
@@ -1,0 +1,195 @@
+"""Resident RedDog worktree-create stage handler.
+
+Slice: REDDOG_RESIDENT_QUEUE_WORKTREE_CREATE_HANDLER_PHASE1
+
+This module adapts the existing queue-authorized worktree-create explicit
+invoke guard to the resident queue next-stage dispatcher. It reads recorded
+`executor_plan` and `execution_valve` stage results from the chain-results
+store, resolves the bound work order through an injected resolver, and calls the
+existing worktree-create guard with an injected runner.
+
+The handler does not edit files, execute task commands, enqueue OpenClaw,
+dispatch Hermes, publish PRs, settle rewards, or re-index HoloIndex.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Mapping, MutableSet, Optional, Protocol
+
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_chain_results_store import (
+    ResidentQueueChainResultsStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_next_stage_dispatch import (
+    ResidentQueueStageDispatchRequest,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_orchestration_plan import (
+    NEXT_QUEUE_WORKTREE_CREATE_INVOKE,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_worktree_create_invoke import (
+    QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_REJECT,
+    invoke_reddog_wre_queue_authorized_worktree_create,
+)
+
+
+EXECUTION_VALVE_STAGE_KEY = "execution_valve"
+EXECUTOR_PLAN_STAGE_KEY = "executor_plan"
+WORKTREE_CREATE_STAGE_KEY = "worktree_create"
+
+FAIL_DISPATCH_STAGE_MISMATCH = "FAIL_DISPATCH_STAGE_MISMATCH"
+FAIL_DISPATCH_NEXT_ACTION_MISMATCH = "FAIL_DISPATCH_NEXT_ACTION_MISMATCH"
+FAIL_EXECUTOR_PLAN_STAGE_MISSING = "FAIL_EXECUTOR_PLAN_STAGE_MISSING"
+FAIL_EXECUTION_VALVE_STAGE_MISSING = "FAIL_EXECUTION_VALVE_STAGE_MISSING"
+FAIL_WORK_ORDER_ID_MISSING = "FAIL_WORK_ORDER_ID_MISSING"
+FAIL_WORK_ORDER_MISSING = "FAIL_WORK_ORDER_MISSING"
+
+
+class ResidentQueueWorktreeCreateWorkOrderResolver(Protocol):
+    """Injected resolver for the work order bound to executor plan."""
+
+    def resolve(
+        self,
+        *,
+        work_order_id: str,
+        queue_item_id: Optional[str],
+        selected_slice: Optional[str],
+    ) -> Mapping[str, Any]:
+        """Return the work order mapping for an accepted executor plan."""
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        candidate = value.to_dict()
+        return candidate if isinstance(candidate, Mapping) else {}
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _stage_results(state: Mapping[str, Any]) -> Mapping[str, Mapping[str, Any]]:
+    raw = state.get("stage_results") if state.get("schema_version") == "reddog_resident_queue_chain_results.v1" else state
+    if not isinstance(raw, Mapping):
+        return {}
+    return {str(key): value for key, value in raw.items() if isinstance(value, Mapping)}
+
+
+def _work_order_id_from_executor_plan(executor_plan: Mapping[str, Any]) -> str:
+    executor = _mapping(executor_plan.get("executor_plan_result"))
+    if executor.get("work_order_id"):
+        return str(executor.get("work_order_id") or "").strip()
+    plan = _mapping(executor.get("plan"))
+    return str(plan.get("work_order_id") or "").strip()
+
+
+def _reject(*reasons: str) -> dict[str, Any]:
+    return {
+        "decision": QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_REJECT,
+        "rejection_reasons": list(dict.fromkeys(reason for reason in reasons if reason)),
+        "worktree_create_result": None,
+        "explicit_queue_authorized_worktree_create_requested": False,
+        "no_task_execution_performed": True,
+        "no_file_edit_performed": True,
+        "no_shell_command_executed": True,
+        "no_openclaw_enqueue_performed": True,
+        "no_hermes_dispatch_performed": True,
+        "no_pr_created": True,
+        "no_reward_settlement_performed": True,
+        "no_holoindex_reindex_performed": True,
+    }
+
+
+@dataclass(frozen=True)
+class ResidentQueueWorktreeCreateStageHandler:
+    """Callable handler for the resident queue `worktree_create` stage."""
+
+    chain_results_store: ResidentQueueChainResultsStore
+    work_order_resolver: ResidentQueueWorktreeCreateWorkOrderResolver
+    runner: Any
+    repo_root: Path
+    now: Optional[datetime] = None
+    locks: Optional[MutableSet[str]] = None
+
+    def __call__(self, request: ResidentQueueStageDispatchRequest) -> Mapping[str, Any]:
+        if request.stage_key != WORKTREE_CREATE_STAGE_KEY:
+            return _reject(
+                FAIL_DISPATCH_STAGE_MISMATCH,
+                f"expected:{WORKTREE_CREATE_STAGE_KEY}",
+                f"actual:{request.stage_key}",
+            )
+        if request.next_action != NEXT_QUEUE_WORKTREE_CREATE_INVOKE:
+            return _reject(
+                FAIL_DISPATCH_NEXT_ACTION_MISMATCH,
+                f"expected:{NEXT_QUEUE_WORKTREE_CREATE_INVOKE}",
+                f"actual:{request.next_action}",
+            )
+
+        stage_results = _stage_results(_mapping(self.chain_results_store.load()))
+        executor_plan = _mapping(stage_results.get(EXECUTOR_PLAN_STAGE_KEY))
+        if not executor_plan:
+            return _reject(FAIL_EXECUTOR_PLAN_STAGE_MISSING)
+        execution_valve = _mapping(stage_results.get(EXECUTION_VALVE_STAGE_KEY))
+        if not execution_valve:
+            return _reject(FAIL_EXECUTION_VALVE_STAGE_MISSING)
+
+        work_order_id = _work_order_id_from_executor_plan(executor_plan)
+        if not work_order_id:
+            return _reject(FAIL_WORK_ORDER_ID_MISSING)
+        work_order = _mapping(
+            self.work_order_resolver.resolve(
+                work_order_id=work_order_id,
+                queue_item_id=request.queue_item_id,
+                selected_slice=request.selected_slice,
+            )
+        )
+        if not work_order:
+            return _reject(FAIL_WORK_ORDER_MISSING, f"work_order_id:{work_order_id}")
+
+        return invoke_reddog_wre_queue_authorized_worktree_create(
+            explicit_queue_authorized_worktree_create_requested=True,
+            queue_executor_plan_result=executor_plan,
+            queue_execution_valve_result=execution_valve,
+            work_order=work_order,
+            runner=self.runner,
+            repo_root=self.repo_root,
+            now=self.now,
+            locks=self.locks,
+        ).to_dict()
+
+
+def build_reddog_resident_queue_worktree_create_stage_handler(
+    *,
+    chain_results_store: ResidentQueueChainResultsStore,
+    work_order_resolver: ResidentQueueWorktreeCreateWorkOrderResolver,
+    runner: Any,
+    repo_root: Path,
+    now: Optional[datetime] = None,
+    locks: Optional[MutableSet[str]] = None,
+) -> ResidentQueueWorktreeCreateStageHandler:
+    """Build the injected worktree-create handler for the dispatcher."""
+
+    return ResidentQueueWorktreeCreateStageHandler(
+        chain_results_store=chain_results_store,
+        work_order_resolver=work_order_resolver,
+        runner=runner,
+        repo_root=repo_root,
+        now=now,
+        locks=locks,
+    )
+
+
+__all__ = [
+    "EXECUTION_VALVE_STAGE_KEY",
+    "EXECUTOR_PLAN_STAGE_KEY",
+    "FAIL_DISPATCH_NEXT_ACTION_MISMATCH",
+    "FAIL_DISPATCH_STAGE_MISMATCH",
+    "FAIL_EXECUTION_VALVE_STAGE_MISSING",
+    "FAIL_EXECUTOR_PLAN_STAGE_MISSING",
+    "FAIL_WORK_ORDER_ID_MISSING",
+    "FAIL_WORK_ORDER_MISSING",
+    "ResidentQueueWorktreeCreateStageHandler",
+    "ResidentQueueWorktreeCreateWorkOrderResolver",
+    "WORKTREE_CREATE_STAGE_KEY",
+    "build_reddog_resident_queue_worktree_create_stage_handler",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_worktree_create_handler.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_worktree_create_handler.py
@@ -1,0 +1,551 @@
+"""Tests for REDDOG_RESIDENT_QUEUE_WORKTREE_CREATE_HANDLER_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_chain_results_store import (
+    CHAIN_RESULTS_SCHEMA_VERSION,
+    InMemoryResidentQueueChainResultsStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_next_stage_dispatch import (
+    FAIL_RECORD_REJECTED,
+    RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_ACCEPT,
+    ResidentQueueStageDispatchRequest,
+    invoke_reddog_resident_queue_next_stage_dispatch,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_orchestration_plan import (
+    NEXT_QUEUE_BOUNDED_WORKER_PILOT_INVOKE,
+    NEXT_QUEUE_WORKTREE_CREATE_INVOKE,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_worktree_create_handler import (
+    EXECUTION_VALVE_STAGE_KEY,
+    EXECUTOR_PLAN_STAGE_KEY,
+    FAIL_DISPATCH_NEXT_ACTION_MISMATCH,
+    FAIL_DISPATCH_STAGE_MISMATCH,
+    FAIL_EXECUTION_VALVE_STAGE_MISSING,
+    FAIL_EXECUTOR_PLAN_STAGE_MISSING,
+    FAIL_WORK_ORDER_MISSING,
+    WORKTREE_CREATE_STAGE_KEY,
+    build_reddog_resident_queue_worktree_create_stage_handler,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authority_request_dryrun import (
+    QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authority_runtime_invoke import (
+    QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authority_verification_invoke import (
+    QUEUE_AUTHORITY_VERIFICATION_INVOKE_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_execution_valve_invoke import (
+    QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_executor_plan_dryrun import (
+    QUEUE_AUTHORIZED_EXECUTOR_PLAN_DRYRUN_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_worktree_create_invoke import (
+    QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_ACCEPT,
+    QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_REJECT,
+    QueueAuthorizedWorktreeCreateInvokeReason,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_verified_authority_work_order_invoke import (
+    QUEUE_VERIFIED_AUTHORITY_WORK_ORDER_INVOKE_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_worktree_create import (
+    WORKTREE_CREATE_ACCEPT,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_resident_queue_worktree_create_handler.py"
+)
+NOW_ISO = "2026-07-14T00:00:00+00:00"
+NOW = datetime(2026, 7, 14, 13, 30, 0, tzinfo=timezone.utc)
+EXPIRES = "2026-07-14T01:00:00+00:00"
+WORK_ORDER_ID = "wre-queue-resident-worktree-create-001"
+FID = "paccess_001"
+INVOCATION_DIGEST = "sha256:" + ("e" * 64)
+PLAN_DIGEST = "sha256:" + ("1" * 64)
+VALVE_DIGEST = "sha256:" + ("2" * 64)
+
+
+class FakeRunner:
+    def __init__(self, *, ok: bool = True) -> None:
+        self.ok = ok
+        self.calls: list[tuple[str, str, str | None, str | None]] = []
+
+    def create_worktree(self, *, worktree_path, branch_name, base_ref):
+        self.calls.append(("create_worktree", str(worktree_path), branch_name, base_ref))
+        if self.ok:
+            Path(worktree_path).mkdir(parents=True, exist_ok=True)
+        return {"ok": self.ok, "returncode": 0 if self.ok else 1}
+
+    def cleanup_worktree(self, *, worktree_path):
+        self.calls.append(("cleanup_worktree", str(worktree_path), None, None))
+        return {"ok": True}
+
+
+class _Resolver:
+    def __init__(self, work_order: dict[str, object] | None) -> None:
+        self.work_order = work_order
+        self.calls: list[dict[str, object | None]] = []
+
+    def resolve(self, *, work_order_id: str, queue_item_id: str | None, selected_slice: str | None):
+        self.calls.append(
+            {
+                "work_order_id": work_order_id,
+                "queue_item_id": queue_item_id,
+                "selected_slice": selected_slice,
+            }
+        )
+        return self.work_order or {}
+
+
+def _future_expiry(minutes: int = 30) -> str:
+    return (NOW + timedelta(minutes=minutes)).replace(microsecond=0).isoformat()
+
+
+def _fresh_captured() -> str:
+    return (NOW - timedelta(seconds=30)).replace(microsecond=0).isoformat()
+
+
+def _repo_root(tmp_path: Path) -> Path:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    return repo_root
+
+
+def _worktree_path(repo_root: Path) -> str:
+    return str(repo_root.parent / ".reddog" / "worktrees" / repo_root.name / WORK_ORDER_ID / "nonce")
+
+
+def _snapshot() -> dict[str, object]:
+    return {
+        "schema_version": "reddog_authoritative_work_state.v1",
+        "freshness_receipts": [{"receipt_id": "fresh-1", "fresh": True}],
+        "worker_claims": [
+            {
+                "claim_id": "claim-1",
+                "slice_id": "REDDOG_TEST_SLICE_PHASE1",
+                "worker_id": "reddog-0102",
+                "status": "ACTIVE",
+                "expires_at": EXPIRES,
+                "freshness_receipt_id": "fresh-1",
+            }
+        ],
+        "wre_queue_items": [
+            {
+                "queue_item_id": "queue-1",
+                "slice_id": "REDDOG_TEST_SLICE_PHASE1",
+                "claim_id": "claim-1",
+                "worker_id": "reddog-0102",
+                "status": "QUEUED",
+                "evidence_refs": ["claim:claim-1", "freshness:fresh-1"],
+                "no_execution_performed": True,
+            }
+        ],
+    }
+
+
+def _work_order(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "work_order_id": WORK_ORDER_ID,
+        "created_at": _fresh_captured(),
+        "red_dog_instance_id": "reddog-main-bootstrap",
+        "authenticated_principal": "github:mjtrout",
+        "principal_provider": "github",
+        "repo_full_name": "FOUNDUPS/Foundups-Agent",
+        "repo_permission_snapshot": {
+            "permission_level": "write",
+            "captured_at": _fresh_captured(),
+            "source": "mock",
+            "digest": "sha256:snap-1",
+        },
+        "requested_operation": "feature_slice",
+        "authority_tier": "source",
+        "allowed_paths": [f"modules/foundups/{FID}/**"],
+        "denied_paths": [".env", ".git/**"],
+        "branch_name": "feat/paccess-001-worktree",
+        "base_ref": "main",
+        "task_summary": "Create isolated worktree from resident queue.",
+        "wsp_applicability": ["WSP_34", "WSP_50", "WSP_97"],
+        "holoindex_evidence_refs": [
+            "modules/communication/moltbot_bridge/src/reddog_wre_worktree_create.py"
+        ],
+        "skillz_candidates": [],
+        "required_tests": ["pytest modules/communication/moltbot_bridge/tests"],
+        "required_policy_gates": ["openclaw_policy_gate", "signed_work_order_authority"],
+        "required_reviewers": [],
+        "sentinel_checks": [],
+        "rollback_plan": "Remove worktree and delete branch on abort.",
+        "expiry": _future_expiry(),
+        "nonce": "work-order-nonce-worktree",
+        "evidence_digest": "sha256:" + ("a" * 64),
+        "advisory_only_source_packet": {
+            "work_focus_digest": "sha256:" + ("b" * 64),
+            "wsp_prompt_digest": "sha256:" + ("c" * 64),
+            "copy_md_run_trace_digest": "sha256:" + ("d" * 64),
+        },
+        "holoindex_evidence": {
+            "holoindex_query": "RedDog resident queue worktree create handler",
+            "holoindex_status": "bundle_json_ok",
+            "code_hits": ["modules/communication/moltbot_bridge/src/reddog_wre_worktree_create.py"],
+            "wsp_hits": ["WSP_framework/src/WSP_34_Git_Operations_Protocol.md"],
+            "skillz_hits": [],
+            "direct_read_fallback_used": True,
+            "index_gap_detected": False,
+            "applicable_wsps": ["WSP_34", "WSP_97"],
+            "evidence_refs": [
+                "modules/communication/moltbot_bridge/src/reddog_wre_worktree_create.py"
+            ],
+            "retrieval_quality": "HIGH",
+            "skillz_gap_detected": False,
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _work_order_invocation_result() -> dict[str, object]:
+    return {
+        "decision": QUEUE_VERIFIED_AUTHORITY_WORK_ORDER_INVOKE_ACCEPT,
+        "rejection_reasons": [],
+        "invocation_result": {
+            "decision": "INVOCATION_ACCEPT",
+            "work_order_id": WORK_ORDER_ID,
+            "receipt_digest": INVOCATION_DIGEST,
+            "policy_gate_receipt_digest": "sha256:" + ("f" * 64),
+            "no_execution_performed": True,
+        },
+        "explicit_queue_work_order_invocation_requested": True,
+    }
+
+
+def _executor_payload(repo_root: Path, **overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "decision": "EXECUTOR_PLAN_ACCEPT",
+        "work_order_id": WORK_ORDER_ID,
+        "plan": {
+            "plan_id": "plan-001",
+            "work_order_id": WORK_ORDER_ID,
+            "proposed_branch_name": "feat/paccess-001-worktree",
+            "proposed_worktree_path": _worktree_path(repo_root),
+            "lock_key": WORK_ORDER_ID,
+            "allowed_paths": [f"modules/foundups/{FID}/**"],
+            "denied_paths": [".env", ".git/**"],
+            "required_tests": ["pytest modules/communication/moltbot_bridge/tests"],
+            "cleanup_plan": {"on_failure": "remove_worktree_delete_branch"},
+            "phase_receipts": [],
+            "no_mutation_performed": True,
+            "invocation_receipt_digest": INVOCATION_DIGEST,
+            "plan_digest": PLAN_DIGEST,
+        },
+        "rejection_reasons": [],
+        "rejection_receipt_digest": "",
+        "no_mutation_performed": True,
+        "phase_receipts": [],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _executor_plan_result(repo_root: Path, **overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "decision": QUEUE_AUTHORIZED_EXECUTOR_PLAN_DRYRUN_ACCEPT,
+        "rejection_reasons": [],
+        "executor_plan_result": _executor_payload(repo_root),
+        "explicit_queue_authorized_executor_plan_requested": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _execution_valve_result(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "decision": "QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_ACCEPT",
+        "rejection_reasons": [],
+        "valve_decision": {
+            "valve_state": "VALVE_OPEN_WORKTREE_CREATE",
+            "work_order_id": WORK_ORDER_ID,
+            "rejection_reasons": [],
+            "gates_checked": ["execution_valve_evaluator"],
+            "no_execution_performed": True,
+            "decision_digest": VALVE_DIGEST,
+            "intake_target": "foundup_job",
+        },
+        "explicit_queue_authorized_execution_valve_requested": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _seeded_store(repo_root: Path, **stage_overrides: object) -> InMemoryResidentQueueChainResultsStore:
+    stage_results: dict[str, object] = {
+        "authority_request": {"status": QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT},
+        "authority_runtime": {"decision": QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT},
+        "authority_verification": {"decision": QUEUE_AUTHORITY_VERIFICATION_INVOKE_ACCEPT},
+        "work_order_invocation": _work_order_invocation_result(),
+        EXECUTOR_PLAN_STAGE_KEY: _executor_plan_result(repo_root),
+        EXECUTION_VALVE_STAGE_KEY: _execution_valve_result(),
+    }
+    stage_results.update(stage_overrides)
+    return InMemoryResidentQueueChainResultsStore(
+        {
+            "schema_version": CHAIN_RESULTS_SCHEMA_VERSION,
+            "queue_item_id": "queue-1",
+            "selected_slice": "REDDOG_TEST_SLICE_PHASE1",
+            "stage_results": stage_results,
+            "receipts": [],
+        }
+    )
+
+
+def _handler(
+    *,
+    chain_store: InMemoryResidentQueueChainResultsStore,
+    repo_root: Path,
+    runner: FakeRunner | None = None,
+    resolver: _Resolver | None = None,
+    locks: set[str] | None = None,
+):
+    return build_reddog_resident_queue_worktree_create_stage_handler(
+        chain_results_store=chain_store,
+        work_order_resolver=resolver or _Resolver(_work_order()),
+        runner=runner or FakeRunner(),
+        repo_root=repo_root,
+        now=NOW,
+        locks=locks,
+    )
+
+
+def test_dispatcher_records_worktree_create_and_advances_to_bounded_worker_pilot(tmp_path: Path) -> None:
+    repo_root = _repo_root(tmp_path)
+    chain_store = _seeded_store(repo_root)
+    runner = FakeRunner()
+    resolver = _Resolver(_work_order())
+
+    result = invoke_reddog_resident_queue_next_stage_dispatch(
+        explicit_resident_queue_stage_dispatch_requested=True,
+        work_state_snapshot=_snapshot(),
+        store=chain_store,
+        handlers={
+            WORKTREE_CREATE_STAGE_KEY: _handler(
+                chain_store=chain_store,
+                repo_root=repo_root,
+                runner=runner,
+                resolver=resolver,
+            )
+        },
+        now_iso=NOW_ISO,
+    )
+
+    assert result.accepted is True
+    assert result.decision == RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_ACCEPT
+    assert result.dispatched_stage == WORKTREE_CREATE_STAGE_KEY
+    assert result.next_action == NEXT_QUEUE_BOUNDED_WORKER_PILOT_INVOKE
+    assert resolver.calls == [
+        {
+            "work_order_id": WORK_ORDER_ID,
+            "queue_item_id": "queue-1",
+            "selected_slice": "REDDOG_TEST_SLICE_PHASE1",
+        }
+    ]
+    stage = chain_store.load()["stage_results"][WORKTREE_CREATE_STAGE_KEY]
+    assert stage["decision"] == QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_ACCEPT
+    assert stage["worktree_create_result"]["decision"] == WORKTREE_CREATE_ACCEPT
+    assert stage["no_task_execution_performed"] is True
+    assert stage["no_file_edit_performed"] is True
+    assert stage["no_shell_command_executed"] is True
+    assert stage["no_openclaw_enqueue_performed"] is True
+    assert stage["no_hermes_dispatch_performed"] is True
+    assert [call[0] for call in runner.calls] == ["create_worktree"]
+    assert Path(stage["worktree_create_result"]["worktree_path"]).exists()
+
+
+def test_missing_executor_plan_stage_rejects_direct_handler_call(tmp_path: Path) -> None:
+    repo_root = _repo_root(tmp_path)
+    handler = _handler(
+        chain_store=_seeded_store(repo_root, **{EXECUTOR_PLAN_STAGE_KEY: {}}),
+        repo_root=repo_root,
+    )
+    request = ResidentQueueStageDispatchRequest(
+        stage_key=WORKTREE_CREATE_STAGE_KEY,
+        next_action=NEXT_QUEUE_WORKTREE_CREATE_INVOKE,
+        queue_item_id="queue-1",
+        selected_slice="REDDOG_TEST_SLICE_PHASE1",
+        plan_id="plan-1",
+        accepted_stages=(),
+    )
+
+    result = dict(handler(request))
+
+    assert result["decision"] == QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_REJECT
+    assert FAIL_EXECUTOR_PLAN_STAGE_MISSING in result["rejection_reasons"]
+
+
+def test_missing_execution_valve_stage_rejects_direct_handler_call(tmp_path: Path) -> None:
+    repo_root = _repo_root(tmp_path)
+    handler = _handler(
+        chain_store=_seeded_store(repo_root, **{EXECUTION_VALVE_STAGE_KEY: {}}),
+        repo_root=repo_root,
+    )
+    request = ResidentQueueStageDispatchRequest(
+        stage_key=WORKTREE_CREATE_STAGE_KEY,
+        next_action=NEXT_QUEUE_WORKTREE_CREATE_INVOKE,
+        queue_item_id="queue-1",
+        selected_slice="REDDOG_TEST_SLICE_PHASE1",
+        plan_id="plan-1",
+        accepted_stages=(),
+    )
+
+    result = dict(handler(request))
+
+    assert result["decision"] == QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_REJECT
+    assert FAIL_EXECUTION_VALVE_STAGE_MISSING in result["rejection_reasons"]
+
+
+def test_missing_work_order_rejects_direct_handler_call(tmp_path: Path) -> None:
+    repo_root = _repo_root(tmp_path)
+    handler = _handler(
+        chain_store=_seeded_store(repo_root),
+        repo_root=repo_root,
+        resolver=_Resolver(None),
+    )
+    request = ResidentQueueStageDispatchRequest(
+        stage_key=WORKTREE_CREATE_STAGE_KEY,
+        next_action=NEXT_QUEUE_WORKTREE_CREATE_INVOKE,
+        queue_item_id="queue-1",
+        selected_slice="REDDOG_TEST_SLICE_PHASE1",
+        plan_id="plan-1",
+        accepted_stages=(),
+    )
+
+    result = dict(handler(request))
+
+    assert result["decision"] == QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_REJECT
+    assert FAIL_WORK_ORDER_MISSING in result["rejection_reasons"]
+
+
+def test_wrong_stage_rejects_direct_handler_call(tmp_path: Path) -> None:
+    repo_root = _repo_root(tmp_path)
+    handler = _handler(chain_store=_seeded_store(repo_root), repo_root=repo_root)
+    request = ResidentQueueStageDispatchRequest(
+        stage_key=EXECUTION_VALVE_STAGE_KEY,
+        next_action=NEXT_QUEUE_WORKTREE_CREATE_INVOKE,
+        queue_item_id="queue-1",
+        selected_slice="REDDOG_TEST_SLICE_PHASE1",
+        plan_id="plan-1",
+        accepted_stages=(),
+    )
+
+    result = dict(handler(request))
+
+    assert result["decision"] == QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_REJECT
+    assert FAIL_DISPATCH_STAGE_MISMATCH in result["rejection_reasons"]
+
+
+def test_wrong_next_action_rejects_direct_handler_call(tmp_path: Path) -> None:
+    repo_root = _repo_root(tmp_path)
+    handler = _handler(chain_store=_seeded_store(repo_root), repo_root=repo_root)
+    request = ResidentQueueStageDispatchRequest(
+        stage_key=WORKTREE_CREATE_STAGE_KEY,
+        next_action="RUN_QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE",
+        queue_item_id="queue-1",
+        selected_slice="REDDOG_TEST_SLICE_PHASE1",
+        plan_id="plan-1",
+        accepted_stages=(),
+    )
+
+    result = dict(handler(request))
+
+    assert result["decision"] == QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_REJECT
+    assert FAIL_DISPATCH_NEXT_ACTION_MISMATCH in result["rejection_reasons"]
+
+
+def test_runner_failure_is_not_recorded_by_dispatcher(tmp_path: Path) -> None:
+    repo_root = _repo_root(tmp_path)
+    chain_store = _seeded_store(repo_root)
+    runner = FakeRunner(ok=False)
+
+    result = invoke_reddog_resident_queue_next_stage_dispatch(
+        explicit_resident_queue_stage_dispatch_requested=True,
+        work_state_snapshot=_snapshot(),
+        store=chain_store,
+        handlers={
+            WORKTREE_CREATE_STAGE_KEY: _handler(
+                chain_store=chain_store,
+                repo_root=repo_root,
+                runner=runner,
+            )
+        },
+        now_iso=NOW_ISO,
+    )
+
+    assert result.accepted is False
+    assert FAIL_RECORD_REJECTED in result.rejection_reasons
+    assert QueueAuthorizedWorktreeCreateInvokeReason.WORKTREE_CREATE_NOT_ACCEPTED in result.rejection_reasons
+    assert "worktree_create_failed" in result.rejection_reasons
+    assert WORKTREE_CREATE_STAGE_KEY not in chain_store.load()["stage_results"]
+    assert [call[0] for call in runner.calls] == ["create_worktree", "cleanup_worktree"]
+
+
+def test_module_has_no_shell_openclaw_hermes_pr_reward_or_holoindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+        "hmac",
+        "secrets",
+    }
+    banned_import_fragments = {
+        "reddog_wre_queue_authorized_bounded_worker_pilot_invoke",
+        "reddog_wre_queue_authorized_slice_verifier_invoke",
+        "reddog_wre_queue_authorized_verified_draft_pr_publish_invoke",
+        "reddog_wre_queue_authorized_verified_outcome_ratchet_invoke",
+        "reddog_wre_queue_authorized_held_out_regression_gate_invoke",
+        "reddog_wre_queue_authorized_pattern_memory_admission_invoke",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    banned_attrs = {
+        "system",
+        "popen",
+        "spawn",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "replace",
+        "unlink",
+        "remove",
+        "rmdir",
+        "rename",
+    }
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+                assert all(fragment not in alias.name for fragment in banned_import_fragments)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+            assert all(fragment not in node.module for fragment in banned_import_fragments)
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs


### PR DESCRIPTION
## Summary
- add the resident queue worktree-create stage handler
- read recorded executor-plan and execution-valve results from the chain store
- resolve the bound work order through an injected resolver and invoke the existing queue-authorized worktree-create guard with an injected runner

## Boundaries
- worktree-create gate only via injected runner
- no task execution, file edit, shell command, OpenClaw enqueue, Hermes dispatch, PR publishing, reward settlement, or HoloIndex re-index
- no bounded-worker or later resident queue stage wiring

## Validation
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_worktree_create_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_execution_valve_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_orchestration_plan.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_next_stage_dispatch.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_chain_results_store.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_worktree_create_invoke.py modules/communication/moltbot_bridge/tests/test_reddog_wre_worktree_create.py -q
- git diff --check
- HoloIndex read-only search recorded INDEX_GAP: HOLOINDEX_REDDOG_RESIDENT_QUEUE_WORKTREE_CREATE_HANDLER_INDEX_GAP_PHASE1

Worker-Lane: resident-queue
Slice: REDDOG_RESIDENT_QUEUE_WORKTREE_CREATE_HANDLER_PHASE1