### PR TITLE
feat(reddog): add resident queue stage handler registry

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,32 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_RESIDENT_QUEUE_STAGE_HANDLER_REGISTRY_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_resident_queue_stage_handler_registry.py`: a centralized
+  dependency-injected registry for all already-built resident queue stage
+  handlers, from `authority_request` through `pattern_memory_admission`.
+- Updated the `main.py` next-stage dispatch bootstrap to construct its handler
+  map through the registry while injecting only the dependencies it already
+  owns. Default startup behavior remains unchanged: dispatch is still
+  off-by-default, and later stages remain unavailable until a dedicated runtime
+  dependency slice supplies explicit dependencies.
+- Added tests proving default bootstrap dependency scope registers only
+  `authority_request`, full injected dependencies register all 13 queue stages,
+  callable handlers are omitted from telemetry payloads, empty mapping
+  dependencies fail closed, and the registry has no shell/network/HoloIndex or
+  default client construction surface.
+- Boundary: registry composition only; no signer, runner, worktree, shell,
+  OpenClaw enqueue, Hermes dispatch, PR publish, PatternMemory client,
+  reward settlement, repo mutation, or HoloIndex runtime re-index is created by
+  this slice.
+- HoloIndex read-only probe for `RedDog resident queue stage handler registry
+  bootstrap` surfaced adjacent queue/live-enqueue/WSP/docs results, but not
+  this new registry before indexing. Recorded as
+  `HOLOINDEX_REDDOG_RESIDENT_QUEUE_STAGE_HANDLER_REGISTRY_INDEX_GAP_PHASE1`;
+  no runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_RESIDENT_QUEUE_PATTERN_MEMORY_ADMISSION_HANDLER_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_next_stage_dispatch_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_next_stage_dispatch_bootstrap.py
@@ -3,9 +3,11 @@
 Slice: REDDOG_MAIN_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_BOOTSTRAP_PHASE1
 
 This adapter lets ``main.py`` invoke exactly one already-built resident queue
-stage handler behind an explicit environment flag. In this slice the only
-registered handler is `authority_request`, which emits a dry-run delegated
-authority request and records it to the outside-repo chain-results store.
+stage handler behind an explicit environment flag. Runtime handler selection is
+assembled through the resident queue handler registry, but this bootstrap only
+injects the dependencies it already owns. Later stages therefore fail closed as
+missing-dependency registry entries until a dedicated runtime dependency slice
+binds them.
 
 It does not sign, verify signatures, open valves, spawn workers, create
 worktrees, execute shell commands, enqueue OpenClaw, dispatch Hermes, publish
@@ -19,16 +21,15 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
-from modules.communication.moltbot_bridge.src.reddog_resident_queue_authority_request_handler import (
-    AUTHORITY_REQUEST_STAGE_KEY,
-    build_reddog_resident_queue_authority_request_stage_handler,
-)
 from modules.communication.moltbot_bridge.src.reddog_resident_queue_chain_results_store import (
     AtomicJsonResidentQueueChainResultsStore,
 )
 from modules.communication.moltbot_bridge.src.reddog_resident_queue_next_stage_dispatch import (
     RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_ACCEPT,
     invoke_reddog_resident_queue_next_stage_dispatch,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_stage_handler_registry import (
+    build_reddog_resident_queue_stage_handler_registry,
 )
 
 
@@ -110,17 +111,18 @@ def run_reddog_main_resident_queue_next_stage_dispatch_bootstrap(
         return _not_ready(chain_reasons, chain_results_path=None)
     assert chain_path is not None
 
-    handler = build_reddog_resident_queue_authority_request_stage_handler(
+    store = AtomicJsonResidentQueueChainResultsStore(chain_path)
+    registry = build_reddog_resident_queue_stage_handler_registry(
         work_state_snapshot=snapshot,
+        chain_results_store=store,
         authority_profile=profile,
         now_iso=now_iso or "",
     )
-    store = AtomicJsonResidentQueueChainResultsStore(chain_path)
     result = invoke_reddog_resident_queue_next_stage_dispatch(
         explicit_resident_queue_stage_dispatch_requested=True,
         work_state_snapshot=snapshot,
         store=store,
-        handlers={AUTHORITY_REQUEST_STAGE_KEY: handler},
+        handlers=registry.handlers,
         now_iso=now_iso or "",
         requested_queue_item_id=requested_queue_item_id,
     )

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_stage_handler_registry.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_stage_handler_registry.py
@@ -1,0 +1,416 @@
+"""Resident RedDog queue stage-handler registry.
+
+Slice: REDDOG_RESIDENT_QUEUE_STAGE_HANDLER_REGISTRY_PHASE1
+
+This module centralizes construction of the already-built resident queue stage
+handlers. It performs dependency presence checks and returns only handlers whose
+dependencies were explicitly injected by the caller. It does not create default
+signers, runners, stores, shells, worktrees, PR clients, PatternMemory clients,
+OpenClaw clients, Hermes clients, or HoloIndex indexers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Mapping, MutableSet, Optional, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_authority_request_handler import (
+    AUTHORITY_REQUEST_STAGE_KEY,
+    build_reddog_resident_queue_authority_request_stage_handler,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_authority_runtime_handler import (
+    AUTHORITY_RUNTIME_STAGE_KEY,
+    build_reddog_resident_queue_authority_runtime_stage_handler,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_authority_verification_handler import (
+    AUTHORITY_VERIFICATION_STAGE_KEY,
+    build_reddog_resident_queue_authority_verification_stage_handler,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_bounded_worker_pilot_handler import (
+    BOUNDED_WORKER_PILOT_STAGE_KEY,
+    build_reddog_resident_queue_bounded_worker_pilot_stage_handler,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_chain_results_store import (
+    ResidentQueueChainResultsStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_execution_valve_handler import (
+    EXECUTION_VALVE_STAGE_KEY,
+    build_reddog_resident_queue_execution_valve_stage_handler,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_executor_plan_handler import (
+    EXECUTOR_PLAN_STAGE_KEY,
+    build_reddog_resident_queue_executor_plan_stage_handler,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_held_out_regression_gate_handler import (
+    HELD_OUT_REGRESSION_GATE_STAGE_KEY,
+    build_reddog_resident_queue_held_out_regression_gate_stage_handler,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_next_stage_dispatch import (
+    ResidentQueueStageHandler,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_pattern_memory_admission_handler import (
+    PATTERN_MEMORY_ADMISSION_STAGE_KEY,
+    build_reddog_resident_queue_pattern_memory_admission_stage_handler,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_slice_verifier_handler import (
+    SLICE_VERIFIER_STAGE_KEY,
+    build_reddog_resident_queue_slice_verifier_stage_handler,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_verified_draft_pr_publish_handler import (
+    VERIFIED_DRAFT_PR_PUBLISH_STAGE_KEY,
+    build_reddog_resident_queue_verified_draft_pr_publish_stage_handler,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_verified_outcome_ratchet_handler import (
+    VERIFIED_OUTCOME_RATCHET_STAGE_KEY,
+    build_reddog_resident_queue_verified_outcome_ratchet_stage_handler,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_work_order_invocation_handler import (
+    WORK_ORDER_INVOCATION_STAGE_KEY,
+    build_reddog_resident_queue_work_order_invocation_stage_handler,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_worktree_create_handler import (
+    WORKTREE_CREATE_STAGE_KEY,
+    build_reddog_resident_queue_worktree_create_stage_handler,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    VALVE_OPEN_WORKTREE_CREATE,
+    ExecutionValveEnvironment,
+)
+
+
+RESIDENT_QUEUE_STAGE_HANDLER_REGISTRY_READY = "RESIDENT_QUEUE_STAGE_HANDLER_REGISTRY_READY"
+
+
+@dataclass(frozen=True)
+class ResidentQueueStageHandlerRegistry:
+    """Registry result returned to startup/runtime callers."""
+
+    handlers: Mapping[str, ResidentQueueStageHandler]
+    missing_stage_reasons: Mapping[str, tuple[str, ...]] = field(default_factory=dict)
+    no_default_signer_created: bool = True
+    no_default_runner_created: bool = True
+    no_shell_command_executed: bool = True
+    no_worktree_created: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pr_created: bool = True
+    no_pattern_memory_client_created: bool = True
+    no_reward_settlement_performed: bool = True
+
+    @property
+    def status(self) -> str:
+        return RESIDENT_QUEUE_STAGE_HANDLER_REGISTRY_READY
+
+    @property
+    def registered_stage_keys(self) -> tuple[str, ...]:
+        return tuple(self.handlers.keys())
+
+    @property
+    def registered_stage_count(self) -> int:
+        return len(self.handlers)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "status": self.status,
+            "registered_stage_keys": self.registered_stage_keys,
+            "registered_stage_count": self.registered_stage_count,
+            "missing_stage_reasons": dict(self.missing_stage_reasons),
+            "no_default_signer_created": self.no_default_signer_created,
+            "no_default_runner_created": self.no_default_runner_created,
+            "no_shell_command_executed": self.no_shell_command_executed,
+            "no_worktree_created": self.no_worktree_created,
+            "no_openclaw_enqueue_performed": self.no_openclaw_enqueue_performed,
+            "no_hermes_dispatch_performed": self.no_hermes_dispatch_performed,
+            "no_repo_mutation_performed": self.no_repo_mutation_performed,
+            "no_holoindex_reindex_performed": self.no_holoindex_reindex_performed,
+            "no_pr_created": self.no_pr_created,
+            "no_pattern_memory_client_created": self.no_pattern_memory_client_created,
+            "no_reward_settlement_performed": self.no_reward_settlement_performed,
+        }
+
+
+def _missing(*pairs: tuple[str, Any]) -> tuple[str, ...]:
+    reasons: list[str] = []
+    for name, value in pairs:
+        if value is None:
+            reasons.append(f"missing_dependency:{name}")
+        elif isinstance(value, Mapping) and not value:
+            reasons.append(f"missing_dependency:{name}")
+    return tuple(reasons)
+
+
+def _add_if_ready(
+    handlers: Dict[str, ResidentQueueStageHandler],
+    missing: Dict[str, tuple[str, ...]],
+    stage_key: str,
+    reasons: tuple[str, ...],
+    builder: Any,
+) -> None:
+    if reasons:
+        missing[stage_key] = reasons
+        return
+    handlers[stage_key] = builder()
+
+
+def build_reddog_resident_queue_stage_handler_registry(
+    *,
+    work_state_snapshot: Mapping[str, Any],
+    chain_results_store: ResidentQueueChainResultsStore,
+    now_iso: str,
+    authority_profile: Optional[Mapping[str, Any]] = None,
+    authority_store: Any = None,
+    signer: Any = None,
+    principal_resolver: Any = None,
+    snapshot_resolver: Any = None,
+    now_epoch: Optional[int] = None,
+    signature_verifier: Any = None,
+    principal_key_resolver: Any = None,
+    nonce_store: Any = None,
+    revocation_oracle: Any = None,
+    required_valve_state: str = VALVE_OPEN_WORKTREE_CREATE,
+    forbidden_operations: Sequence[str] = (),
+    revoked_key_epochs: Sequence[str] = (),
+    leeway_s: int = 60,
+    work_order_resolver: Any = None,
+    permission_snapshot: Optional[Mapping[str, Any]] = None,
+    now_datetime: Optional[datetime] = None,
+    seen_nonces: Optional[MutableSet[str]] = None,
+    receipt_store: Any = None,
+    permission_ttl_seconds: int = 300,
+    permission_expires_at: Optional[str] = None,
+    locks: Optional[MutableSet[str]] = None,
+    repo_root: Optional[Path | str] = None,
+    valve_environment: Optional[ExecutionValveEnvironment | Mapping[str, Any]] = None,
+    intake_target: str = "foundup_job",
+    expected_valve_state: str = VALVE_OPEN_WORKTREE_CREATE,
+    worktree_runner: Any = None,
+    generic_writer_dryrun_result: Optional[Mapping[str, Any]] = None,
+    governed_shell_dryrun_result: Optional[Mapping[str, Any]] = None,
+    artifact_contents: Optional[Mapping[str, Any]] = None,
+    operation_cwd: Optional[Path] = None,
+    holoindex_evidence: Optional[Mapping[str, Any]] = None,
+    verifier_request: Optional[Mapping[str, Any]] = None,
+    publish_request: Optional[Mapping[str, Any]] = None,
+    draft_pr_runner: Any = None,
+    ratchet_request: Optional[Mapping[str, Any]] = None,
+    outcome_ratchet_store: Any = None,
+    explicit_pattern_memory_write_requested: bool = False,
+    ratchet_pattern_memory_sink: Any = None,
+    held_out_gate_request: Optional[Mapping[str, Any]] = None,
+    admission_request: Optional[Mapping[str, Any]] = None,
+    pattern_memory_admission_sink: Any = None,
+) -> ResidentQueueStageHandlerRegistry:
+    """Build a handler map from explicitly injected dependencies."""
+
+    handlers: Dict[str, ResidentQueueStageHandler] = {}
+    missing: Dict[str, tuple[str, ...]] = {}
+    root = Path(repo_root) if repo_root is not None else None
+
+    _add_if_ready(
+        handlers,
+        missing,
+        AUTHORITY_REQUEST_STAGE_KEY,
+        _missing(("authority_profile", authority_profile)),
+        lambda: build_reddog_resident_queue_authority_request_stage_handler(
+            work_state_snapshot=work_state_snapshot,
+            authority_profile=authority_profile or {},
+            now_iso=now_iso,
+        ),
+    )
+    _add_if_ready(
+        handlers,
+        missing,
+        AUTHORITY_RUNTIME_STAGE_KEY,
+        _missing(
+            ("authority_store", authority_store),
+            ("signer", signer),
+            ("principal_resolver", principal_resolver),
+            ("snapshot_resolver", snapshot_resolver),
+            ("now_epoch", now_epoch),
+        ),
+        lambda: build_reddog_resident_queue_authority_runtime_stage_handler(
+            chain_results_store=chain_results_store,
+            authority_store=authority_store,
+            signer=signer,
+            principal_resolver=principal_resolver,
+            snapshot_resolver=snapshot_resolver,
+            now=int(now_epoch or 0),
+            leeway_s=leeway_s,
+        ),
+    )
+    _add_if_ready(
+        handlers,
+        missing,
+        AUTHORITY_VERIFICATION_STAGE_KEY,
+        _missing(
+            ("signature_verifier", signature_verifier),
+            ("principal_key_resolver", principal_key_resolver),
+            ("nonce_store", nonce_store),
+            ("snapshot_resolver", snapshot_resolver),
+            ("revocation_oracle", revocation_oracle),
+            ("now_epoch", now_epoch),
+        ),
+        lambda: build_reddog_resident_queue_authority_verification_stage_handler(
+            chain_results_store=chain_results_store,
+            signature_verifier=signature_verifier,
+            principal_key_resolver=principal_key_resolver,
+            nonce_store=nonce_store,
+            snapshot_resolver=snapshot_resolver,
+            revocation_oracle=revocation_oracle,
+            now=int(now_epoch or 0),
+            required_valve_state=required_valve_state,
+            forbidden_operations=forbidden_operations,
+            revoked_key_epochs=revoked_key_epochs,
+            leeway_s=leeway_s,
+        ),
+    )
+    _add_if_ready(
+        handlers,
+        missing,
+        WORK_ORDER_INVOCATION_STAGE_KEY,
+        _missing(("work_order_resolver", work_order_resolver)),
+        lambda: build_reddog_resident_queue_work_order_invocation_stage_handler(
+            chain_results_store=chain_results_store,
+            work_order_resolver=work_order_resolver,
+            permission_snapshot=permission_snapshot,
+            now=now_datetime,
+            seen_nonces=seen_nonces,
+            receipt_store=receipt_store,
+            permission_ttl_seconds=permission_ttl_seconds,
+            permission_expires_at=permission_expires_at,
+        ),
+    )
+    _add_if_ready(
+        handlers,
+        missing,
+        EXECUTOR_PLAN_STAGE_KEY,
+        _missing(("work_order_resolver", work_order_resolver), ("repo_root", root)),
+        lambda: build_reddog_resident_queue_executor_plan_stage_handler(
+            chain_results_store=chain_results_store,
+            work_order_resolver=work_order_resolver,
+            now=now_datetime,
+            locks=locks,
+            repo_root=root or ".",
+        ),
+    )
+    _add_if_ready(
+        handlers,
+        missing,
+        EXECUTION_VALVE_STAGE_KEY,
+        _missing(("work_order_resolver", work_order_resolver), ("valve_environment", valve_environment)),
+        lambda: build_reddog_resident_queue_execution_valve_stage_handler(
+            chain_results_store=chain_results_store,
+            work_order_resolver=work_order_resolver,
+            valve_environment=valve_environment or {},
+            now=now_datetime,
+            intake_target=intake_target,
+            expected_valve_state=expected_valve_state,
+        ),
+    )
+    _add_if_ready(
+        handlers,
+        missing,
+        WORKTREE_CREATE_STAGE_KEY,
+        _missing(("work_order_resolver", work_order_resolver), ("worktree_runner", worktree_runner), ("repo_root", root)),
+        lambda: build_reddog_resident_queue_worktree_create_stage_handler(
+            chain_results_store=chain_results_store,
+            work_order_resolver=work_order_resolver,
+            runner=worktree_runner,
+            repo_root=root or Path("."),
+            now=now_datetime,
+            locks=locks,
+        ),
+    )
+    _add_if_ready(
+        handlers,
+        missing,
+        BOUNDED_WORKER_PILOT_STAGE_KEY,
+        _missing(
+            ("work_order_resolver", work_order_resolver),
+            ("generic_writer_dryrun_result", generic_writer_dryrun_result),
+            ("governed_shell_dryrun_result", governed_shell_dryrun_result),
+            ("artifact_contents", artifact_contents),
+            ("repo_root", root),
+        ),
+        lambda: build_reddog_resident_queue_bounded_worker_pilot_stage_handler(
+            chain_results_store=chain_results_store,
+            work_order_resolver=work_order_resolver,
+            generic_writer_dryrun_result=generic_writer_dryrun_result or {},
+            governed_shell_dryrun_result=governed_shell_dryrun_result or {},
+            artifact_contents=artifact_contents or {},
+            repo_root=root or Path("."),
+            operation_cwd=operation_cwd,
+            holoindex_evidence=holoindex_evidence,
+        ),
+    )
+    _add_if_ready(
+        handlers,
+        missing,
+        SLICE_VERIFIER_STAGE_KEY,
+        _missing(("verifier_request", verifier_request)),
+        lambda: build_reddog_resident_queue_slice_verifier_stage_handler(
+            chain_results_store=chain_results_store,
+            verifier_request=verifier_request or {},
+        ),
+    )
+    _add_if_ready(
+        handlers,
+        missing,
+        VERIFIED_DRAFT_PR_PUBLISH_STAGE_KEY,
+        _missing(("publish_request", publish_request), ("draft_pr_runner", draft_pr_runner)),
+        lambda: build_reddog_resident_queue_verified_draft_pr_publish_stage_handler(
+            chain_results_store=chain_results_store,
+            publish_request=publish_request or {},
+            runner=draft_pr_runner,
+        ),
+    )
+    _add_if_ready(
+        handlers,
+        missing,
+        VERIFIED_OUTCOME_RATCHET_STAGE_KEY,
+        _missing(("ratchet_request", ratchet_request), ("outcome_ratchet_store", outcome_ratchet_store)),
+        lambda: build_reddog_resident_queue_verified_outcome_ratchet_stage_handler(
+            chain_results_store=chain_results_store,
+            ratchet_request=ratchet_request or {},
+            store=outcome_ratchet_store,
+            explicit_pattern_memory_write_requested=explicit_pattern_memory_write_requested,
+            pattern_memory_sink=ratchet_pattern_memory_sink,
+        ),
+    )
+    _add_if_ready(
+        handlers,
+        missing,
+        HELD_OUT_REGRESSION_GATE_STAGE_KEY,
+        _missing(("held_out_gate_request", held_out_gate_request)),
+        lambda: build_reddog_resident_queue_held_out_regression_gate_stage_handler(
+            chain_results_store=chain_results_store,
+            held_out_gate_request=held_out_gate_request or {},
+        ),
+    )
+    _add_if_ready(
+        handlers,
+        missing,
+        PATTERN_MEMORY_ADMISSION_STAGE_KEY,
+        _missing(("admission_request", admission_request), ("pattern_memory_admission_sink", pattern_memory_admission_sink)),
+        lambda: build_reddog_resident_queue_pattern_memory_admission_stage_handler(
+            chain_results_store=chain_results_store,
+            admission_request=admission_request or {},
+            sink=pattern_memory_admission_sink,
+        ),
+    )
+
+    return ResidentQueueStageHandlerRegistry(
+        handlers=handlers,
+        missing_stage_reasons=missing,
+    )
+
+
+__all__ = [
+    "RESIDENT_QUEUE_STAGE_HANDLER_REGISTRY_READY",
+    "ResidentQueueStageHandlerRegistry",
+    "build_reddog_resident_queue_stage_handler_registry",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_stage_handler_registry.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_stage_handler_registry.py
@@ -1,0 +1,221 @@
+"""Tests for REDDOG_RESIDENT_QUEUE_STAGE_HANDLER_REGISTRY_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_chain_results_store import (
+    InMemoryResidentQueueChainResultsStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_stage_handler_registry import (
+    RESIDENT_QUEUE_STAGE_HANDLER_REGISTRY_READY,
+    build_reddog_resident_queue_stage_handler_registry,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_resident_queue_stage_handler_registry.py"
+)
+NOW_ISO = "2026-07-14T00:00:00+00:00"
+ALL_STAGE_KEYS = (
+    "authority_request",
+    "authority_runtime",
+    "authority_verification",
+    "work_order_invocation",
+    "executor_plan",
+    "execution_valve",
+    "worktree_create",
+    "bounded_worker_pilot",
+    "slice_verifier",
+    "verified_draft_pr_publish",
+    "verified_outcome_ratchet",
+    "held_out_regression_gate",
+    "pattern_memory_admission",
+)
+
+
+class Dummy:
+    def __call__(self, *args: object, **kwargs: object) -> object:
+        return {}
+
+    def load(self) -> dict[str, object]:
+        return {}
+
+    def commit(self, snapshot: object, *, expected_revision: object) -> str:
+        return "sha256:dummy"
+
+
+def _store() -> InMemoryResidentQueueChainResultsStore:
+    return InMemoryResidentQueueChainResultsStore()
+
+
+def _snapshot() -> dict[str, object]:
+    return {
+        "schema_version": "reddog_authoritative_work_state.v1",
+        "freshness_receipts": [{"receipt_id": "fresh-1", "fresh": True}],
+        "worker_claims": [],
+        "wre_queue_items": [],
+    }
+
+
+def test_registry_registers_only_authority_request_with_default_bootstrap_dependencies() -> None:
+    registry = build_reddog_resident_queue_stage_handler_registry(
+        work_state_snapshot=_snapshot(),
+        chain_results_store=_store(),
+        authority_profile={"principal_id": "github:mjtrout"},
+        now_iso=NOW_ISO,
+    )
+
+    assert registry.status == RESIDENT_QUEUE_STAGE_HANDLER_REGISTRY_READY
+    assert registry.registered_stage_keys == ("authority_request",)
+    assert registry.registered_stage_count == 1
+    assert set(registry.missing_stage_reasons) == set(ALL_STAGE_KEYS[1:])
+    assert "missing_dependency:signer" in registry.missing_stage_reasons["authority_runtime"]
+    assert registry.no_default_signer_created is True
+    assert registry.no_default_runner_created is True
+    assert registry.no_holoindex_reindex_performed is True
+
+
+def test_registry_registers_all_stages_when_every_dependency_is_injected(tmp_path: Path) -> None:
+    dummy = Dummy()
+    registry = build_reddog_resident_queue_stage_handler_registry(
+        work_state_snapshot=_snapshot(),
+        chain_results_store=_store(),
+        authority_profile={"principal_id": "github:mjtrout"},
+        authority_store=dummy,
+        signer=dummy,
+        principal_resolver=dummy,
+        snapshot_resolver=dummy,
+        now_epoch=1783984309,
+        signature_verifier=dummy,
+        principal_key_resolver=dummy,
+        nonce_store=dummy,
+        revocation_oracle=dummy,
+        work_order_resolver=dummy,
+        repo_root=tmp_path,
+        valve_environment={"valve_worktree_create_enabled": True},
+        worktree_runner=dummy,
+        generic_writer_dryrun_result={"accepted": True},
+        governed_shell_dryrun_result={"accepted": True},
+        artifact_contents={"README.md": "content"},
+        verifier_request={"verifier_id": "verifier-1"},
+        publish_request={"publish_id": "publish-1"},
+        draft_pr_runner=dummy,
+        ratchet_request={"ratchet_id": "ratchet-1"},
+        outcome_ratchet_store=dummy,
+        held_out_gate_request={"gate_id": "gate-1"},
+        admission_request={"admission_id": "admission-1"},
+        pattern_memory_admission_sink=dummy,
+        now_iso=NOW_ISO,
+    )
+
+    assert registry.registered_stage_keys == ALL_STAGE_KEYS
+    assert registry.registered_stage_count == len(ALL_STAGE_KEYS)
+    assert registry.missing_stage_reasons == {}
+
+
+def test_registry_to_dict_omits_callable_handlers(tmp_path: Path) -> None:
+    registry = build_reddog_resident_queue_stage_handler_registry(
+        work_state_snapshot=_snapshot(),
+        chain_results_store=_store(),
+        authority_profile={"principal_id": "github:mjtrout"},
+        now_iso=NOW_ISO,
+    )
+
+    payload = registry.to_dict()
+
+    assert "handlers" not in payload
+    assert payload["status"] == RESIDENT_QUEUE_STAGE_HANDLER_REGISTRY_READY
+    assert payload["registered_stage_keys"] == ("authority_request",)
+    assert payload["no_repo_mutation_performed"] is True
+
+
+def test_registry_rejects_empty_mapping_dependencies() -> None:
+    registry = build_reddog_resident_queue_stage_handler_registry(
+        work_state_snapshot=_snapshot(),
+        chain_results_store=_store(),
+        authority_profile={},
+        generic_writer_dryrun_result={},
+        governed_shell_dryrun_result={},
+        artifact_contents={},
+        verifier_request={},
+        publish_request={},
+        ratchet_request={},
+        held_out_gate_request={},
+        admission_request={},
+        now_iso=NOW_ISO,
+    )
+
+    assert registry.registered_stage_keys == ()
+    assert "missing_dependency:authority_profile" in registry.missing_stage_reasons["authority_request"]
+    assert "missing_dependency:generic_writer_dryrun_result" in registry.missing_stage_reasons["bounded_worker_pilot"]
+    assert "missing_dependency:verifier_request" in registry.missing_stage_reasons["slice_verifier"]
+
+
+def test_registry_has_no_shell_network_holoindex_or_default_client_construction() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+        "hmac",
+        "secrets",
+    }
+    banned_import_fragments = {
+        "openclaw_supervisor",
+        "hermes_job_executor",
+        "modules.infrastructure.wre_core.src.pattern_memory",
+        "worktree_pr_runner",
+        "reddog_wre_worktree_runner",
+    }
+    banned_calls = {
+        "eval",
+        "exec",
+        "compile",
+        "__import__",
+        "open",
+        "AtomicJsonAuthorityRuntimeStore",
+        "AtomicJsonResidentQueueChainResultsStore",
+        "RealRedDogWorktreeRunner",
+        "PatternMemory",
+    }
+    banned_attrs = {
+        "system",
+        "popen",
+        "spawn",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "unlink",
+        "remove",
+        "rmdir",
+        "rename",
+        "replace",
+    }
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+                assert all(fragment not in alias.name for fragment in banned_import_fragments)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+            assert all(fragment not in node.module for fragment in banned_import_fragments)
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs


### PR DESCRIPTION
## Summary

- Adds `reddog_resident_queue_stage_handler_registry.py`, a dependency-injected registry for all 13 already-built resident queue stages.
- Routes the existing `main.py` next-stage dispatch bootstrap through the registry while injecting only its existing authority-request dependencies.
- Keeps dispatch opt-in only; later stages remain unavailable until a dedicated runtime dependency slice supplies explicit dependency objects.

## WSP_97 Evidence

- OBSERVED: default bootstrap dependency scope registers only `authority_request`.
- OBSERVED: full injected test dependency set registers all 13 resident queue stages through `pattern_memory_admission`.
- OBSERVED: registry telemetry omits callable handlers.
- OBSERVED: empty mapping dependencies fail closed.
- OBSERVED: AST guard blocks shell/network/HoloIndex/default client construction surfaces.
- SPECIFIED_NOT_IMPLEMENTED: production signer, production signature verifier, worktree runner, draft PR runner, PatternMemory sink, and runtime dependency packet binding.

## Validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_stage_handler_registry.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_next_stage_dispatch_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_next_stage_dispatch.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_orchestration_plan.py -q` -> 34 passed
- PowerShell-expanded resident queue/main bootstrap subset -> 150 passed
- `git diff --check` -> clean (CRLF informational warnings only)
- ASCII/NUL scan on new files -> 0 non-ASCII, 0 NUL

## Full-Suite Note

`python -m pytest modules/communication/moltbot_bridge/tests -q` was attempted and fails in unrelated OpenClaw/ROC/skill tests with pytest capture/tempfile `ValueError: I/O operation on closed file` after cascading setup/teardown errors. The resident queue subset that covers this slice is green.

## HoloIndex

Read-only probe for `RedDog resident queue stage handler registry bootstrap` surfaced adjacent queue/live-enqueue/WSP/docs results but not the new registry before indexing. Recorded as `HOLOINDEX_REDDOG_RESIDENT_QUEUE_STAGE_HANDLER_REGISTRY_INDEX_GAP_PHASE1`; no runtime re-index is performed.

## Boundary

No signer, runner, worktree, shell, OpenClaw enqueue, Hermes dispatch, PR publish, PatternMemory client, reward settlement, repo mutation, or HoloIndex runtime re-index is created by this slice.
