### PR TITLE
feat(reddog): add resident queue serial loop runner

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,28 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_RUNNER_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_resident_queue_serial_loop.py`: a bounded serial loop
+  runner that repeatedly invokes the existing resident queue next-stage
+  dispatcher with caller-injected handlers until the queue chain completes,
+  rejects, or reaches the configured step bound.
+- Added tests proving full 13-stage completion with fake injected handlers,
+  explicit-loop gating, max-step rejection, bounded progress reporting,
+  missing-handler fail-close after progress, already-complete no-op behavior,
+  handler-exception rejection, serializable nested result output, and AST
+  denial of shell/network/HoloIndex/concrete stage imports.
+- Boundary: loop orchestration only; no default handler, signer, runner,
+  worktree, shell, OpenClaw enqueue, Hermes dispatch, PR publish,
+  PatternMemory client, reward settlement, repo mutation, or HoloIndex runtime
+  re-index is created by this slice.
+- HoloIndex read-only probe for `RedDog resident queue serial loop runner
+  dispatcher` surfaced adjacent swarm/WSP/session-continuity results, but not
+  this new runner before indexing. Recorded as
+  `HOLOINDEX_REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_RUNNER_INDEX_GAP_PHASE1`; no
+  runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_RESIDENT_QUEUE_STAGE_HANDLER_REGISTRY_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_serial_loop.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_serial_loop.py
@@ -1,0 +1,248 @@
+"""Bounded serial loop for resident RedDog queue dispatch.
+
+Slice: REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_RUNNER_PHASE1
+
+This module repeatedly invokes the already-built resident queue next-stage
+dispatcher with an injected handler map until the selected queue chain is
+complete, rejected, or a caller-supplied step bound is reached.
+
+It creates no default handlers and no runtime dependencies. It does not sign,
+verify signatures, spawn workers, create worktrees, run shell commands, enqueue
+OpenClaw, dispatch Hermes, publish PRs, admit PatternMemory, settle rewards,
+mutate repository files, or re-index HoloIndex. Any stage effect comes only
+from explicit caller-provided handlers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Mapping, Optional
+
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_chain_results_store import (
+    ResidentQueueChainResultsStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_next_stage_dispatch import (
+    RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_ACCEPT,
+    ResidentQueueNextStageDispatchResult,
+    ResidentQueueStageHandler,
+    invoke_reddog_resident_queue_next_stage_dispatch,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_orchestration_plan import (
+    RESIDENT_QUEUE_ORCHESTRATION_PLAN_COMPLETE,
+    RESIDENT_QUEUE_ORCHESTRATION_PLAN_READY,
+    ResidentQueueOrchestrationPlan,
+    plan_reddog_resident_queue_orchestration,
+)
+
+
+RESIDENT_QUEUE_SERIAL_LOOP_COMPLETE = "RESIDENT_QUEUE_SERIAL_LOOP_COMPLETE"
+RESIDENT_QUEUE_SERIAL_LOOP_LIMIT_REACHED = "RESIDENT_QUEUE_SERIAL_LOOP_LIMIT_REACHED"
+RESIDENT_QUEUE_SERIAL_LOOP_REJECT = "RESIDENT_QUEUE_SERIAL_LOOP_REJECT"
+
+MAX_RESIDENT_QUEUE_SERIAL_LOOP_STEPS = 13
+
+FAIL_EXPLICIT_LOOP_MISSING = "FAIL_EXPLICIT_RESIDENT_QUEUE_SERIAL_LOOP_MISSING"
+FAIL_MAX_STEPS_INVALID = "FAIL_MAX_STEPS_INVALID"
+FAIL_PLAN_NOT_READY = "FAIL_PLAN_NOT_READY"
+FAIL_DISPATCH_REJECTED = "FAIL_DISPATCH_REJECTED"
+
+
+@dataclass(frozen=True)
+class ResidentQueueSerialLoopResult:
+    """Result returned by the bounded serial queue loop."""
+
+    accepted: bool
+    status: str
+    rejection_reasons: list[str] = field(default_factory=list)
+    steps_run: int = 0
+    dispatched_stages: tuple[str, ...] = ()
+    next_action: Optional[str] = None
+    final_plan: Optional[ResidentQueueOrchestrationPlan] = None
+    dispatch_results: tuple[ResidentQueueNextStageDispatchResult, ...] = ()
+    no_default_handler_used: bool = True
+    no_dependency_created_by_loop: bool = True
+    no_signing_performed_by_loop: bool = True
+    no_worker_spawned_by_loop: bool = True
+    no_worktree_created_by_loop: bool = True
+    no_shell_command_executed_by_loop: bool = True
+    no_openclaw_enqueue_performed_by_loop: bool = True
+    no_hermes_dispatch_performed_by_loop: bool = True
+    no_repo_mutation_performed_by_loop: bool = True
+    no_holoindex_reindex_performed_by_loop: bool = True
+    no_pr_created_by_loop: bool = True
+    no_pattern_memory_client_created_by_loop: bool = True
+    no_reward_settlement_performed_by_loop: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["final_plan"] = self.final_plan.to_dict() if self.final_plan else None
+        payload["dispatch_results"] = tuple(result.to_dict() for result in self.dispatch_results)
+        return payload
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        candidate = value.to_dict()
+        return candidate if isinstance(candidate, Mapping) else {}
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _stage_results(state: Mapping[str, Any]) -> Mapping[str, Mapping[str, Any]]:
+    raw = state.get("stage_results") if state.get("schema_version") == "reddog_resident_queue_chain_results.v1" else state
+    if not isinstance(raw, Mapping):
+        return {}
+    return {str(key): value for key, value in raw.items() if isinstance(value, Mapping)}
+
+
+def _plan(
+    *,
+    work_state_snapshot: Mapping[str, Any],
+    store: ResidentQueueChainResultsStore,
+    requested_queue_item_id: Optional[str],
+    now_iso: str,
+) -> ResidentQueueOrchestrationPlan:
+    state = _mapping(store.load())
+    return plan_reddog_resident_queue_orchestration(
+        work_state_snapshot,
+        chain_results=_stage_results(state),
+        requested_queue_item_id=requested_queue_item_id,
+        now_iso=now_iso,
+    )
+
+
+def _reject(
+    reasons: list[str],
+    *,
+    steps_run: int = 0,
+    dispatched_stages: tuple[str, ...] = (),
+    final_plan: Optional[ResidentQueueOrchestrationPlan] = None,
+    dispatch_results: tuple[ResidentQueueNextStageDispatchResult, ...] = (),
+) -> ResidentQueueSerialLoopResult:
+    return ResidentQueueSerialLoopResult(
+        accepted=False,
+        status=RESIDENT_QUEUE_SERIAL_LOOP_REJECT,
+        rejection_reasons=list(dict.fromkeys(reasons)),
+        steps_run=steps_run,
+        dispatched_stages=dispatched_stages,
+        next_action=final_plan.next_action if final_plan else None,
+        final_plan=final_plan,
+        dispatch_results=dispatch_results,
+    )
+
+
+def run_reddog_resident_queue_serial_loop(
+    *,
+    explicit_resident_queue_serial_loop_requested: bool,
+    work_state_snapshot: Mapping[str, Any],
+    store: ResidentQueueChainResultsStore,
+    handlers: Mapping[str, ResidentQueueStageHandler],
+    now_iso: str,
+    requested_queue_item_id: Optional[str] = None,
+    max_steps: int = MAX_RESIDENT_QUEUE_SERIAL_LOOP_STEPS,
+) -> ResidentQueueSerialLoopResult:
+    """Advance one resident queue item through injected handlers."""
+
+    if explicit_resident_queue_serial_loop_requested is not True:
+        return _reject([FAIL_EXPLICIT_LOOP_MISSING])
+    if (
+        not isinstance(max_steps, int)
+        or max_steps < 1
+        or max_steps > MAX_RESIDENT_QUEUE_SERIAL_LOOP_STEPS
+    ):
+        return _reject([FAIL_MAX_STEPS_INVALID])
+
+    dispatched: list[str] = []
+    dispatch_results: list[ResidentQueueNextStageDispatchResult] = []
+    current_plan = _plan(
+        work_state_snapshot=work_state_snapshot,
+        store=store,
+        requested_queue_item_id=requested_queue_item_id,
+        now_iso=now_iso,
+    )
+    if current_plan.accepted is True and current_plan.status == RESIDENT_QUEUE_ORCHESTRATION_PLAN_COMPLETE:
+        return ResidentQueueSerialLoopResult(
+            accepted=True,
+            status=RESIDENT_QUEUE_SERIAL_LOOP_COMPLETE,
+            steps_run=0,
+            dispatched_stages=(),
+            next_action=current_plan.next_action,
+            final_plan=current_plan,
+            dispatch_results=(),
+        )
+    if current_plan.accepted is not True or current_plan.status != RESIDENT_QUEUE_ORCHESTRATION_PLAN_READY:
+        return _reject(
+            [FAIL_PLAN_NOT_READY, *current_plan.rejection_reasons],
+            final_plan=current_plan,
+        )
+
+    for _ in range(max_steps):
+        dispatch = invoke_reddog_resident_queue_next_stage_dispatch(
+            explicit_resident_queue_stage_dispatch_requested=True,
+            work_state_snapshot=work_state_snapshot,
+            store=store,
+            handlers=handlers,
+            now_iso=now_iso,
+            requested_queue_item_id=requested_queue_item_id,
+        )
+        if dispatch.accepted is not True or dispatch.decision != RESIDENT_QUEUE_NEXT_STAGE_DISPATCH_ACCEPT:
+            return _reject(
+                [FAIL_DISPATCH_REJECTED, *dispatch.rejection_reasons],
+                steps_run=len(dispatch_results),
+                dispatched_stages=tuple(dispatched),
+                final_plan=dispatch.plan or current_plan,
+                dispatch_results=tuple(dispatch_results),
+            )
+        dispatch_results.append(dispatch)
+        if dispatch.dispatched_stage:
+            dispatched.append(dispatch.dispatched_stage)
+
+        current_plan = _plan(
+            work_state_snapshot=work_state_snapshot,
+            store=store,
+            requested_queue_item_id=requested_queue_item_id,
+            now_iso=now_iso,
+        )
+        if current_plan.accepted is True and current_plan.status == RESIDENT_QUEUE_ORCHESTRATION_PLAN_COMPLETE:
+            return ResidentQueueSerialLoopResult(
+                accepted=True,
+                status=RESIDENT_QUEUE_SERIAL_LOOP_COMPLETE,
+                steps_run=len(dispatch_results),
+                dispatched_stages=tuple(dispatched),
+                next_action=current_plan.next_action,
+                final_plan=current_plan,
+                dispatch_results=tuple(dispatch_results),
+            )
+        if current_plan.accepted is not True or current_plan.status != RESIDENT_QUEUE_ORCHESTRATION_PLAN_READY:
+            return _reject(
+                [FAIL_PLAN_NOT_READY, *current_plan.rejection_reasons],
+                steps_run=len(dispatch_results),
+                dispatched_stages=tuple(dispatched),
+                final_plan=current_plan,
+                dispatch_results=tuple(dispatch_results),
+            )
+
+    return ResidentQueueSerialLoopResult(
+        accepted=True,
+        status=RESIDENT_QUEUE_SERIAL_LOOP_LIMIT_REACHED,
+        steps_run=len(dispatch_results),
+        dispatched_stages=tuple(dispatched),
+        next_action=current_plan.next_action,
+        final_plan=current_plan,
+        dispatch_results=tuple(dispatch_results),
+    )
+
+
+__all__ = [
+    "FAIL_DISPATCH_REJECTED",
+    "FAIL_EXPLICIT_LOOP_MISSING",
+    "FAIL_MAX_STEPS_INVALID",
+    "FAIL_PLAN_NOT_READY",
+    "MAX_RESIDENT_QUEUE_SERIAL_LOOP_STEPS",
+    "RESIDENT_QUEUE_SERIAL_LOOP_COMPLETE",
+    "RESIDENT_QUEUE_SERIAL_LOOP_LIMIT_REACHED",
+    "RESIDENT_QUEUE_SERIAL_LOOP_REJECT",
+    "ResidentQueueSerialLoopResult",
+    "run_reddog_resident_queue_serial_loop",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_serial_loop.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_serial_loop.py
@@ -1,0 +1,372 @@
+"""Tests for REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_RUNNER_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_chain_results_store import (
+    InMemoryResidentQueueChainResultsStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_next_stage_dispatch import (
+    ResidentQueueStageDispatchRequest,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_orchestration_plan import (
+    NEXT_QUEUE_CHAIN_COMPLETE,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_serial_loop import (
+    FAIL_DISPATCH_REJECTED,
+    FAIL_EXPLICIT_LOOP_MISSING,
+    FAIL_MAX_STEPS_INVALID,
+    MAX_RESIDENT_QUEUE_SERIAL_LOOP_STEPS,
+    RESIDENT_QUEUE_SERIAL_LOOP_COMPLETE,
+    RESIDENT_QUEUE_SERIAL_LOOP_LIMIT_REACHED,
+    RESIDENT_QUEUE_SERIAL_LOOP_REJECT,
+    run_reddog_resident_queue_serial_loop,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authority_request_dryrun import (
+    QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authority_runtime_invoke import (
+    QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authority_verification_invoke import (
+    QUEUE_AUTHORITY_VERIFICATION_INVOKE_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_bounded_worker_pilot_invoke import (
+    QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_execution_valve_invoke import (
+    QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_executor_plan_dryrun import (
+    QUEUE_AUTHORIZED_EXECUTOR_PLAN_DRYRUN_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_held_out_regression_gate_invoke import (
+    QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_pattern_memory_admission_invoke import (
+    QUEUE_AUTHORIZED_PATTERN_MEMORY_ADMISSION_INVOKE_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_slice_verifier_invoke import (
+    QUEUE_AUTHORIZED_SLICE_VERIFIER_INVOKE_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_verified_draft_pr_publish_invoke import (
+    QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_verified_outcome_ratchet_invoke import (
+    QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_worktree_create_invoke import (
+    QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_verified_authority_work_order_invoke import (
+    QUEUE_VERIFIED_AUTHORITY_WORK_ORDER_INVOKE_ACCEPT,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_resident_queue_serial_loop.py"
+)
+NOW = "2026-07-14T00:00:00+00:00"
+EXPIRES = "2026-07-14T01:00:00+00:00"
+STAGE_ACCEPT_VALUES = {
+    "authority_request": ("status", QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT),
+    "authority_runtime": ("decision", QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT),
+    "authority_verification": ("decision", QUEUE_AUTHORITY_VERIFICATION_INVOKE_ACCEPT),
+    "work_order_invocation": ("decision", QUEUE_VERIFIED_AUTHORITY_WORK_ORDER_INVOKE_ACCEPT),
+    "executor_plan": ("decision", QUEUE_AUTHORIZED_EXECUTOR_PLAN_DRYRUN_ACCEPT),
+    "execution_valve": ("decision", QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_ACCEPT),
+    "worktree_create": ("decision", QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_ACCEPT),
+    "bounded_worker_pilot": ("decision", QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_ACCEPT),
+    "slice_verifier": ("decision", QUEUE_AUTHORIZED_SLICE_VERIFIER_INVOKE_ACCEPT),
+    "verified_draft_pr_publish": ("decision", QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_ACCEPT),
+    "verified_outcome_ratchet": ("decision", QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_ACCEPT),
+    "held_out_regression_gate": ("decision", QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_ACCEPT),
+    "pattern_memory_admission": ("decision", QUEUE_AUTHORIZED_PATTERN_MEMORY_ADMISSION_INVOKE_ACCEPT),
+}
+
+
+def _snapshot() -> dict[str, object]:
+    return {
+        "schema_version": "reddog_authoritative_work_state.v1",
+        "freshness_receipts": [{"receipt_id": "fresh-1", "fresh": True}],
+        "worker_claims": [
+            {
+                "claim_id": "claim-1",
+                "slice_id": "REDDOG_TEST_SLICE_PHASE1",
+                "worker_id": "reddog-0102",
+                "status": "ACTIVE",
+                "expires_at": EXPIRES,
+                "freshness_receipt_id": "fresh-1",
+            }
+        ],
+        "wre_queue_items": [
+            {
+                "queue_item_id": "queue-1",
+                "slice_id": "REDDOG_TEST_SLICE_PHASE1",
+                "claim_id": "claim-1",
+                "worker_id": "reddog-0102",
+                "status": "QUEUED",
+                "evidence_refs": ["claim:claim-1", "freshness:fresh-1"],
+                "no_execution_performed": True,
+            }
+        ],
+    }
+
+
+def _handler(stage_key: str):
+    field_name, accepted_value = STAGE_ACCEPT_VALUES[stage_key]
+
+    def call(request: ResidentQueueStageDispatchRequest) -> dict[str, object]:
+        assert request.stage_key == stage_key
+        return {
+            field_name: accepted_value,
+            "queue_item_id": request.queue_item_id,
+            "selected_slice": request.selected_slice,
+            "stage_key": stage_key,
+        }
+
+    return call
+
+
+def _handlers(*stage_keys: str):
+    keys = stage_keys or tuple(STAGE_ACCEPT_VALUES)
+    return {key: _handler(key) for key in keys}
+
+
+def _complete_store() -> InMemoryResidentQueueChainResultsStore:
+    return InMemoryResidentQueueChainResultsStore(
+        {
+            "schema_version": "reddog_resident_queue_chain_results.v1",
+            "stage_results": {
+                key: {field: value}
+                for key, (field, value) in STAGE_ACCEPT_VALUES.items()
+            },
+        }
+    )
+
+
+def test_serial_loop_runs_all_injected_stages_to_chain_complete() -> None:
+    store = InMemoryResidentQueueChainResultsStore()
+
+    result = run_reddog_resident_queue_serial_loop(
+        explicit_resident_queue_serial_loop_requested=True,
+        work_state_snapshot=_snapshot(),
+        store=store,
+        handlers=_handlers(),
+        now_iso=NOW,
+        requested_queue_item_id="queue-1",
+    )
+
+    assert result.accepted is True
+    assert result.status == RESIDENT_QUEUE_SERIAL_LOOP_COMPLETE
+    assert result.steps_run == len(STAGE_ACCEPT_VALUES)
+    assert result.dispatched_stages == tuple(STAGE_ACCEPT_VALUES)
+    assert result.next_action == NEXT_QUEUE_CHAIN_COMPLETE
+    assert result.final_plan is not None
+    assert result.final_plan.status == "RESIDENT_QUEUE_ORCHESTRATION_PLAN_COMPLETE"
+    assert result.no_default_handler_used is True
+    assert result.no_holoindex_reindex_performed_by_loop is True
+    stored = store.load()
+    assert set(stored["stage_results"]) == set(STAGE_ACCEPT_VALUES)
+    assert len(stored["stage_results"]) == len(STAGE_ACCEPT_VALUES)
+
+
+def test_serial_loop_is_explicitly_requested() -> None:
+    store = InMemoryResidentQueueChainResultsStore()
+
+    result = run_reddog_resident_queue_serial_loop(
+        explicit_resident_queue_serial_loop_requested=False,
+        work_state_snapshot=_snapshot(),
+        store=store,
+        handlers=_handlers(),
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert result.status == RESIDENT_QUEUE_SERIAL_LOOP_REJECT
+    assert result.rejection_reasons == [FAIL_EXPLICIT_LOOP_MISSING]
+    assert result.steps_run == 0
+    assert store.load() == {}
+
+
+def test_serial_loop_rejects_invalid_max_steps() -> None:
+    result = run_reddog_resident_queue_serial_loop(
+        explicit_resident_queue_serial_loop_requested=True,
+        work_state_snapshot=_snapshot(),
+        store=InMemoryResidentQueueChainResultsStore(),
+        handlers=_handlers(),
+        now_iso=NOW,
+        max_steps=MAX_RESIDENT_QUEUE_SERIAL_LOOP_STEPS + 1,
+    )
+
+    assert result.accepted is False
+    assert result.rejection_reasons == [FAIL_MAX_STEPS_INVALID]
+
+
+def test_serial_loop_stops_at_step_limit_with_next_action() -> None:
+    store = InMemoryResidentQueueChainResultsStore()
+
+    result = run_reddog_resident_queue_serial_loop(
+        explicit_resident_queue_serial_loop_requested=True,
+        work_state_snapshot=_snapshot(),
+        store=store,
+        handlers=_handlers(),
+        now_iso=NOW,
+        requested_queue_item_id="queue-1",
+        max_steps=2,
+    )
+
+    assert result.accepted is True
+    assert result.status == RESIDENT_QUEUE_SERIAL_LOOP_LIMIT_REACHED
+    assert result.steps_run == 2
+    assert result.dispatched_stages == ("authority_request", "authority_runtime")
+    assert result.next_action == "RUN_QUEUE_AUTHORITY_VERIFICATION_INVOKE"
+
+
+def test_serial_loop_rejects_when_next_handler_missing_after_progress() -> None:
+    store = InMemoryResidentQueueChainResultsStore()
+
+    result = run_reddog_resident_queue_serial_loop(
+        explicit_resident_queue_serial_loop_requested=True,
+        work_state_snapshot=_snapshot(),
+        store=store,
+        handlers=_handlers("authority_request"),
+        now_iso=NOW,
+        requested_queue_item_id="queue-1",
+        max_steps=2,
+    )
+
+    assert result.accepted is False
+    assert result.status == RESIDENT_QUEUE_SERIAL_LOOP_REJECT
+    assert result.steps_run == 1
+    assert result.dispatched_stages == ("authority_request",)
+    assert FAIL_DISPATCH_REJECTED in result.rejection_reasons
+    assert "FAIL_HANDLER_MISSING" in result.rejection_reasons
+    assert "stage:authority_runtime" in result.rejection_reasons
+
+
+def test_serial_loop_accepts_already_complete_chain_without_invoking_handler() -> None:
+    calls: list[str] = []
+
+    def should_not_run(request: ResidentQueueStageDispatchRequest) -> dict[str, object]:
+        calls.append(request.stage_key)
+        return {}
+
+    result = run_reddog_resident_queue_serial_loop(
+        explicit_resident_queue_serial_loop_requested=True,
+        work_state_snapshot=_snapshot(),
+        store=_complete_store(),
+        handlers={"authority_request": should_not_run},
+        now_iso=NOW,
+        requested_queue_item_id="queue-1",
+    )
+
+    assert result.accepted is True
+    assert result.status == RESIDENT_QUEUE_SERIAL_LOOP_COMPLETE
+    assert result.steps_run == 0
+    assert calls == []
+
+
+def test_serial_loop_rejects_handler_exception_without_recording_stage() -> None:
+    store = InMemoryResidentQueueChainResultsStore()
+
+    def broken(request: ResidentQueueStageDispatchRequest) -> dict[str, object]:
+        raise RuntimeError("boom")
+
+    result = run_reddog_resident_queue_serial_loop(
+        explicit_resident_queue_serial_loop_requested=True,
+        work_state_snapshot=_snapshot(),
+        store=store,
+        handlers={"authority_request": broken},
+        now_iso=NOW,
+        requested_queue_item_id="queue-1",
+    )
+
+    assert result.accepted is False
+    assert result.steps_run == 0
+    assert FAIL_DISPATCH_REJECTED in result.rejection_reasons
+    assert "FAIL_HANDLER_EXCEPTION" in result.rejection_reasons
+    assert store.load() == {}
+
+
+def test_serial_loop_to_dict_serializes_nested_results() -> None:
+    result = run_reddog_resident_queue_serial_loop(
+        explicit_resident_queue_serial_loop_requested=True,
+        work_state_snapshot=_snapshot(),
+        store=InMemoryResidentQueueChainResultsStore(),
+        handlers=_handlers(),
+        now_iso=NOW,
+        requested_queue_item_id="queue-1",
+        max_steps=1,
+    )
+
+    payload = result.to_dict()
+
+    assert payload["status"] == RESIDENT_QUEUE_SERIAL_LOOP_LIMIT_REACHED
+    assert payload["final_plan"]["current_stage"] == "authority_runtime"
+    assert payload["dispatch_results"][0]["dispatched_stage"] == "authority_request"
+
+
+def test_serial_loop_has_no_shell_network_holoindex_or_concrete_stage_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "os",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+        "hmac",
+        "secrets",
+    }
+    banned_import_fragments = {
+        "reddog_resident_queue_authority_request_handler",
+        "reddog_resident_queue_authority_runtime_handler",
+        "reddog_resident_queue_authority_verification_handler",
+        "reddog_resident_queue_worktree_create_handler",
+        "reddog_resident_queue_verified_draft_pr_publish_handler",
+        "reddog_resident_queue_pattern_memory_admission_handler",
+        "openclaw_supervisor",
+        "hermes_job_executor",
+        "pattern_memory",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__", "open"}
+    banned_attrs = {
+        "system",
+        "popen",
+        "spawn",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "unlink",
+        "remove",
+        "rmdir",
+        "rename",
+        "replace",
+    }
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+                assert all(fragment not in alias.name for fragment in banned_import_fragments)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+            assert all(fragment not in node.module for fragment in banned_import_fragments)
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs


### PR DESCRIPTION
## Summary

- Adds `reddog_resident_queue_serial_loop.py`, a bounded serial loop runner for resident RedDog queue dispatch.
- The loop repeatedly invokes the existing next-stage dispatcher with an injected handler map until the selected queue chain completes, rejects, or reaches the configured step bound.
- No default handlers or runtime dependencies are created; any stage effect can only come from explicit caller-provided handlers.

## WSP_97 Evidence

- OBSERVED: full 13-stage queue chain completes with fake injected handlers.
- OBSERVED: explicit loop request is required.
- OBSERVED: invalid max steps fail closed; bounded progress stops with `RESIDENT_QUEUE_SERIAL_LOOP_LIMIT_REACHED`.
- OBSERVED: missing next handler after progress rejects cleanly with dispatcher reasons.
- OBSERVED: already-complete chain is a no-op and invokes no handler.
- OBSERVED: handler exceptions reject without recording the stage.
- OBSERVED: result `to_dict()` serializes nested final plan and dispatch results.
- OBSERVED: AST guard denies shell/network/HoloIndex/concrete stage imports.

## Validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_serial_loop.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_next_stage_dispatch.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_chain_results_store.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_orchestration_plan.py -q` -> 38 passed
- PowerShell-expanded resident queue/main bootstrap subset -> 159 passed
- `git diff --check` -> clean (CRLF informational warning only)
- ASCII/NUL scan on new files -> 0 non-ASCII, 0 NUL

## HoloIndex

Read-only probe for `RedDog resident queue serial loop runner dispatcher` surfaced adjacent swarm/WSP/session-continuity results but not this new runner before indexing. Recorded as `HOLOINDEX_REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_RUNNER_INDEX_GAP_PHASE1`; no runtime re-index is performed.

## Boundary

Loop orchestration only. No signer, runner, worktree, shell, OpenClaw enqueue, Hermes dispatch, PR publish, PatternMemory client, reward settlement, repo mutation, or HoloIndex runtime re-index is created by this slice.
