### PR TITLE
feat(reddog): add main resident queue serial loop bootstrap

### DIFF
--- a/main.py
+++ b/main.py
@@ -1519,6 +1519,74 @@ def run_reddog_resident_queue_next_stage_dispatch_preflight(repo_root: Path) -> 
     return True
 
 
+def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
+    """
+    Optionally run the bounded resident queue serial loop through injected handlers.
+
+    Env:
+        REDDOG_RESIDENT_QUEUE_SERIAL_LOOP=0                  Enable loop (default OFF)
+        REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_ENFORCED=0         Block startup if not applied
+        REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_MAX_STEPS=1        Bounded loop steps
+        REDDOG_AUTHORITATIVE_WORK_STATE_PATH                 Existing work-state snapshot
+        REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH             Outside-repo chain-results JSON
+        REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH         Outside-repo authority profile JSON
+        REDDOG_WRE_QUEUE_ITEM_ID                             Optional exact queue item id
+    """
+
+    if os.getenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP", "0") == "0":
+        logger.info("[REDDOG-QUEUE-LOOP] Startup serial loop disabled")
+        return True
+
+    enforced = os.getenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_ENFORCED", "0") != "0"
+    try:
+        max_steps = int(os.getenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_MAX_STEPS", "1"))
+    except ValueError:
+        max_steps = 0
+
+    try:
+        from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_loop_bootstrap import (
+            run_reddog_main_resident_queue_serial_loop_bootstrap,
+        )
+
+        result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+            repo_root=repo_root,
+            work_state_path=os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
+            chain_results_path=os.getenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH", "") or None,
+            authority_profile_path=os.getenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", "") or None,
+            requested_queue_item_id=os.getenv("REDDOG_WRE_QUEUE_ITEM_ID", "") or None,
+            max_steps=max_steps,
+        )
+    except Exception as exc:
+        logger.error(f"[REDDOG-QUEUE-LOOP] Startup serial loop failed: {exc}")
+        if enforced:
+            print(f"[REDDOG-QUEUE-LOOP] preflight=FAIL error={type(exc).__name__}")
+            return False
+        print(f"[REDDOG-QUEUE-LOOP] preflight=WARN error={type(exc).__name__}")
+        return True
+
+    status = "PASS" if result.accepted else "WARN"
+    reasons = ",".join(result.rejection_reasons) if result.rejection_reasons else "(none)"
+    print(
+        f"[REDDOG-QUEUE-LOOP] preflight={status} status={result.status} "
+        f"queue_item={result.queue_item_id or '(none)'} "
+        f"selected_slice={result.selected_slice or '(none)'} "
+        f"steps_run={result.steps_run} "
+        f"dispatched_stages={','.join(result.dispatched_stages) or '(none)'} "
+        f"next_action={result.next_action or '(none)'} reasons={reasons}"
+    )
+    if result.accepted:
+        print(
+            f"[REDDOG-QUEUE-LOOP] chain_results={result.chain_results_path or '(none)'} "
+            f"revision={result.store_revision or '(none)'}"
+        )
+        return True
+
+    if enforced:
+        print("[REDDOG-QUEUE-LOOP] Startup blocked by REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_ENFORCED=1")
+        return False
+    return True
+
+
 def bootstrap_runtime_dae_launches() -> None:
     """Register broker-managed DAE entrypoints for an already running system."""
     daemon = get_central_daemon()
@@ -1698,6 +1766,8 @@ def main():
     if not run_reddog_resident_queue_orchestration_plan_preflight(repo_root):
         return
     if not run_reddog_resident_queue_next_stage_dispatch_preflight(repo_root):
+        return
+    if not run_reddog_resident_queue_serial_loop_preflight(repo_root):
         return
     if not run_reddog_readonly_operational_bootstrap_preflight(repo_root):
         return

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,32 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_main_resident_queue_serial_loop_bootstrap.py`: an
+  off-by-default `main.py` adapter for the bounded resident queue serial loop.
+  It reads only outside-repo work-state, chain-results, and authority-profile
+  JSON, builds the handler registry with existing bootstrap-owned dependencies,
+  and advances up to `REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_MAX_STEPS`.
+- Updated `main.py` with `run_reddog_resident_queue_serial_loop_preflight`,
+  gated by `REDDOG_RESIDENT_QUEUE_SERIAL_LOOP=1` and nonblocking unless
+  `REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_ENFORCED=1`. Normal menu startup remains
+  unchanged when the flag is absent.
+- Added tests proving one-stage serial-loop application, fail-closed rejection
+  when later dependencies are missing, outside-repo input enforcement, disabled
+  default behavior, enforced blocking, and AST denial of shell/network/HoloIndex
+  and later-stage runtime imports.
+- Boundary: startup adapter only; no production signer, verifier, runner,
+  worktree, shell, OpenClaw enqueue, Hermes dispatch, PR publish,
+  PatternMemory client, reward settlement, repo mutation, or HoloIndex runtime
+  re-index is created by this slice.
+- HoloIndex read-only probe for `RedDog main resident queue serial loop
+  bootstrap preflight` surfaced adjacent preflight/WSP/live-enqueue docs, but
+  not this new bootstrap before indexing. Recorded as
+  `HOLOINDEX_REDDOG_MAIN_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_INDEX_GAP_PHASE1`;
+  no runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_RUNNER_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -1,0 +1,249 @@
+"""Main-startup adapter for the resident RedDog serial queue loop.
+
+Slice: REDDOG_MAIN_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_PHASE1
+
+This adapter lets ``main.py`` run the bounded serial queue loop behind an
+explicit environment flag. It reads existing runtime JSON artifacts from
+outside the repository checkout, builds the injected handler registry with the
+dependencies this bootstrap owns today, and advances through the serial loop up
+to a bounded max step count.
+
+This slice does not introduce production signer, verifier, runner, PR,
+PatternMemory, OpenClaw, Hermes, or HoloIndex dependencies. Missing later-stage
+dependencies fail closed through the registry and dispatcher.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_chain_results_store import (
+    AtomicJsonResidentQueueChainResultsStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_serial_loop import (
+    ResidentQueueSerialLoopResult,
+    run_reddog_resident_queue_serial_loop,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_stage_handler_registry import (
+    build_reddog_resident_queue_stage_handler_registry,
+)
+
+
+REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED = "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED"
+REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_NOT_READY = "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_NOT_READY"
+
+
+@dataclass(frozen=True)
+class RedDogMainResidentQueueSerialLoopBootstrapResult:
+    """Result emitted by the startup serial-loop adapter."""
+
+    accepted: bool
+    status: str
+    queue_item_id: Optional[str]
+    selected_slice: Optional[str]
+    steps_run: int
+    dispatched_stages: tuple[str, ...]
+    next_action: Optional[str]
+    chain_results_path: Optional[str]
+    store_revision: Optional[str]
+    rejection_reasons: tuple[str, ...]
+    no_signing_performed: bool = True
+    no_signature_verification_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_worktree_created: bool = True
+    no_shell_command_executed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pr_created: bool = True
+    no_pattern_memory_client_created: bool = True
+    no_reward_settlement_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_main_resident_queue_serial_loop_bootstrap(
+    *,
+    repo_root: Path | str,
+    work_state_path: Path | str | None,
+    chain_results_path: Path | str | None,
+    authority_profile_path: Path | str | None,
+    requested_queue_item_id: str | None = None,
+    now_iso: str | None = None,
+    max_steps: int = 1,
+) -> RedDogMainResidentQueueSerialLoopBootstrapResult:
+    """Load runtime inputs and run the bounded resident queue serial loop."""
+
+    root = Path(repo_root).resolve()
+    snapshot, snapshot_reasons = _read_json_outside_repo(
+        root,
+        work_state_path,
+        missing_reason="missing_authoritative_work_state_path",
+        inside_reason="work_state_path_inside_repo",
+        unreadable_reason="malformed_authoritative_work_state",
+    )
+    if snapshot_reasons:
+        return _not_ready(snapshot_reasons, chain_results_path=None)
+    assert snapshot is not None
+
+    profile, profile_reasons = _read_json_outside_repo(
+        root,
+        authority_profile_path,
+        missing_reason="missing_authority_profile_path",
+        inside_reason="authority_profile_path_inside_repo",
+        unreadable_reason="malformed_authority_profile",
+    )
+    if profile_reasons:
+        return _not_ready(profile_reasons, chain_results_path=None)
+    assert profile is not None
+
+    chain_path, chain_reasons = _resolve_output_outside_repo(
+        root,
+        chain_results_path,
+        missing_reason="missing_chain_results_path",
+        inside_reason="chain_results_path_inside_repo",
+    )
+    if chain_reasons:
+        return _not_ready(chain_reasons, chain_results_path=None)
+    assert chain_path is not None
+
+    store = AtomicJsonResidentQueueChainResultsStore(chain_path)
+    registry = build_reddog_resident_queue_stage_handler_registry(
+        work_state_snapshot=snapshot,
+        chain_results_store=store,
+        authority_profile=profile,
+        now_iso=now_iso or "",
+    )
+    loop = run_reddog_resident_queue_serial_loop(
+        explicit_resident_queue_serial_loop_requested=True,
+        work_state_snapshot=snapshot,
+        store=store,
+        handlers=registry.handlers,
+        now_iso=now_iso or "",
+        requested_queue_item_id=requested_queue_item_id,
+        max_steps=max_steps,
+    )
+    if loop.accepted is not True:
+        return _from_loop(
+            loop,
+            accepted=False,
+            status=REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_NOT_READY,
+            chain_results_path=chain_path,
+        )
+
+    return _from_loop(
+        loop,
+        accepted=True,
+        status=REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED,
+        chain_results_path=chain_path,
+    )
+
+
+def _read_json_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    missing_reason: str,
+    inside_reason: str,
+    unreadable_reason: str,
+) -> tuple[Optional[Mapping[str, Any]], tuple[str, ...]]:
+    if not value:
+        return None, (missing_reason,)
+    path = Path(value)
+    if not path.is_absolute():
+        path = (repo_root / path).resolve()
+    else:
+        path = path.resolve()
+    if _is_inside(path, repo_root):
+        return None, (inside_reason,)
+    if not path.exists() or not path.is_file():
+        return None, (missing_reason,)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None, (unreadable_reason,)
+    if not isinstance(payload, Mapping):
+        return None, (unreadable_reason,)
+    return payload, ()
+
+
+def _resolve_output_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    missing_reason: str,
+    inside_reason: str,
+) -> tuple[Optional[Path], tuple[str, ...]]:
+    if not value:
+        return None, (missing_reason,)
+    path = Path(value)
+    if not path.is_absolute():
+        path = (repo_root / path).resolve()
+    else:
+        path = path.resolve()
+    if _is_inside(path, repo_root):
+        return None, (inside_reason,)
+    return path, ()
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+def _not_ready(
+    reasons: tuple[str, ...],
+    *,
+    chain_results_path: Path | None,
+) -> RedDogMainResidentQueueSerialLoopBootstrapResult:
+    return RedDogMainResidentQueueSerialLoopBootstrapResult(
+        accepted=False,
+        status=REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_NOT_READY,
+        queue_item_id=None,
+        selected_slice=None,
+        steps_run=0,
+        dispatched_stages=(),
+        next_action=None,
+        chain_results_path=str(chain_results_path) if chain_results_path else None,
+        store_revision=None,
+        rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons if str(reason).strip())),
+    )
+
+
+def _from_loop(
+    loop: ResidentQueueSerialLoopResult,
+    *,
+    accepted: bool,
+    status: str,
+    chain_results_path: Path,
+) -> RedDogMainResidentQueueSerialLoopBootstrapResult:
+    final_plan = loop.final_plan
+    last_dispatch = loop.dispatch_results[-1] if loop.dispatch_results else None
+    record = last_dispatch.record_result if last_dispatch else None
+    receipt = record.receipt if record else None
+    return RedDogMainResidentQueueSerialLoopBootstrapResult(
+        accepted=accepted,
+        status=status,
+        queue_item_id=final_plan.selected_queue_item_id if final_plan else None,
+        selected_slice=final_plan.selected_slice if final_plan else None,
+        steps_run=loop.steps_run,
+        dispatched_stages=loop.dispatched_stages,
+        next_action=loop.next_action,
+        chain_results_path=str(chain_results_path),
+        store_revision=receipt.store_revision if receipt else None,
+        rejection_reasons=tuple(loop.rejection_reasons),
+    )
+
+
+__all__ = [
+    "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED",
+    "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_NOT_READY",
+    "RedDogMainResidentQueueSerialLoopBootstrapResult",
+    "run_reddog_main_resident_queue_serial_loop_bootstrap",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -1,0 +1,325 @@
+"""Tests for REDDOG_MAIN_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_loop_bootstrap import (
+    REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED,
+    REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_NOT_READY,
+    run_reddog_main_resident_queue_serial_loop_bootstrap,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    VALVE_OPEN_WORKTREE_CREATE,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_main_resident_queue_serial_loop_bootstrap.py"
+)
+NOW = "2026-07-14T00:00:00+00:00"
+EXPIRES = "2026-07-14T01:00:00+00:00"
+
+
+def _snapshot() -> dict[str, object]:
+    return {
+        "schema_version": "reddog_authoritative_work_state.v1",
+        "freshness_receipts": [{"receipt_id": "fresh-1", "fresh": True}],
+        "worker_claims": [
+            {
+                "claim_id": "claim-1",
+                "slice_id": "REDDOG_TEST_SLICE_PHASE1",
+                "worker_id": "reddog-0102",
+                "status": "ACTIVE",
+                "expires_at": EXPIRES,
+                "freshness_receipt_id": "fresh-1",
+            }
+        ],
+        "wre_queue_items": [
+            {
+                "queue_item_id": "queue-1",
+                "slice_id": "REDDOG_TEST_SLICE_PHASE1",
+                "claim_id": "claim-1",
+                "worker_id": "reddog-0102",
+                "status": "QUEUED",
+                "evidence_refs": ["claim:claim-1", "freshness:fresh-1"],
+                "no_execution_performed": True,
+            }
+        ],
+    }
+
+
+def _profile(**overrides: object) -> dict[str, object]:
+    profile = {
+        "principal_id": "github:mjtrout",
+        "principal_provider": "github",
+        "principal_public_key": "pub:principal",
+        "reddog_id": "reddog:abc123",
+        "reddog_public_key": "pub:reddog",
+        "repo_full_name": "FOUNDUPS/Foundups-Agent",
+        "foundup_id": "paccess_001",
+        "allowed_paths": ["modules/foundups/paccess_001/**"],
+        "denied_paths": ["modules/foundups/paccess_001/secrets/**"],
+        "requested_operation": "create_foundup",
+        "permission_snapshot_digest": "sha256:snap-1",
+        "identity_nonce": "identity-nonce-0001",
+        "work_authority_nonce": "workauth-nonce-0001",
+        "issued_at": 1000,
+        "identity_expires_at": 4600,
+        "work_authority_expires_at": 1300,
+        "valve_state_required": VALVE_OPEN_WORKTREE_CREATE,
+        "key_epoch": "epoch-1",
+        "consensus_receipt_digest": "sha256:consensus",
+        "sovereign_authorization_digest": "sha256:012-token",
+    }
+    profile.update(overrides)
+    return profile
+
+
+def _write_runtime_json(tmp_path: Path, name: str, payload: object) -> Path:
+    path = tmp_path / "runtime" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _repo(tmp_path: Path) -> Path:
+    path = tmp_path / "repo"
+    path.mkdir()
+    return path
+
+
+def test_bootstrap_serial_loop_applies_one_stage_with_existing_dependencies(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(tmp_path, "profile.json", _profile())
+    chain = tmp_path / "runtime" / "chain_results.json"
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        now_iso=NOW,
+        requested_queue_item_id="queue-1",
+        max_steps=1,
+    )
+
+    assert result.accepted is True
+    assert result.status == REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED
+    assert result.queue_item_id == "queue-1"
+    assert result.selected_slice == "REDDOG_TEST_SLICE_PHASE1"
+    assert result.steps_run == 1
+    assert result.dispatched_stages == ("authority_request",)
+    assert result.next_action == "RUN_QUEUE_AUTHORITY_RUNTIME_INVOKE"
+    assert result.store_revision is not None
+    assert result.no_repo_mutation_performed is True
+    assert result.no_holoindex_reindex_performed is True
+    stored = json.loads(chain.read_text(encoding="utf-8"))
+    assert stored["stage_results"]["authority_request"]["status"] == "QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT"
+
+
+def test_bootstrap_serial_loop_fails_closed_when_later_dependency_missing(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(tmp_path, "profile.json", _profile())
+    chain = tmp_path / "runtime" / "chain_results.json"
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        now_iso=NOW,
+        requested_queue_item_id="queue-1",
+        max_steps=2,
+    )
+
+    assert result.accepted is False
+    assert result.status == REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_NOT_READY
+    assert result.steps_run == 1
+    assert result.dispatched_stages == ("authority_request",)
+    assert "FAIL_DISPATCH_REJECTED" in result.rejection_reasons
+    assert "FAIL_HANDLER_MISSING" in result.rejection_reasons
+    assert "stage:authority_runtime" in result.rejection_reasons
+
+
+def test_bootstrap_rejects_missing_authority_profile(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=tmp_path / "runtime" / "chain_results.json",
+        authority_profile_path=None,
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert "missing_authority_profile_path" in result.rejection_reasons
+
+
+def test_bootstrap_rejects_inputs_inside_repo(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    inside_state = repo / "work_state.json"
+    inside_state.write_text(json.dumps(_snapshot()), encoding="utf-8")
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=inside_state,
+        chain_results_path=tmp_path / "runtime" / "chain_results.json",
+        authority_profile_path=tmp_path / "runtime" / "profile.json",
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert "work_state_path_inside_repo" in result.rejection_reasons
+
+
+def test_main_serial_loop_preflight_is_disabled_by_default() -> None:
+    import main
+
+    with patch.dict("os.environ", {}, clear=True):
+        assert main.run_reddog_resident_queue_serial_loop_preflight(REPO_ROOT) is True
+
+
+def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path) -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_loop_bootstrap.run_reddog_main_resident_queue_serial_loop_bootstrap",
+        return_value=type(
+            "Result",
+            (),
+            {
+                "accepted": True,
+                "status": REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED,
+                "queue_item_id": "queue-1",
+                "selected_slice": "REDDOG_TEST_SLICE_PHASE1",
+                "steps_run": 1,
+                "dispatched_stages": ("authority_request",),
+                "next_action": "RUN_QUEUE_AUTHORITY_RUNTIME_INVOKE",
+                "chain_results_path": str(tmp_path / "chain.json"),
+                "store_revision": "sha256:revision",
+                "rejection_reasons": (),
+            },
+        )(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP": "1",
+                "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_MAX_STEPS": "1",
+                "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+                "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
+                "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+                "REDDOG_WRE_QUEUE_ITEM_ID": "queue-1",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_queue_serial_loop_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["work_state_path"] == str(tmp_path / "state.json")
+    assert mocked.call_args.kwargs["chain_results_path"] == str(tmp_path / "chain.json")
+    assert mocked.call_args.kwargs["authority_profile_path"] == str(tmp_path / "profile.json")
+    assert mocked.call_args.kwargs["requested_queue_item_id"] == "queue-1"
+    assert mocked.call_args.kwargs["max_steps"] == 1
+
+
+def test_main_serial_loop_preflight_blocks_when_enforced() -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_loop_bootstrap.run_reddog_main_resident_queue_serial_loop_bootstrap",
+        return_value=type(
+            "Result",
+            (),
+            {
+                "accepted": False,
+                "status": REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_NOT_READY,
+                "queue_item_id": None,
+                "selected_slice": None,
+                "steps_run": 0,
+                "dispatched_stages": (),
+                "next_action": None,
+                "chain_results_path": None,
+                "store_revision": None,
+                "rejection_reasons": ("missing_authority_profile_path",),
+            },
+        )(),
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP": "1",
+                "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_ENFORCED": "1",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_queue_serial_loop_preflight(REPO_ROOT) is False
+
+
+def test_module_has_no_shell_network_holoindex_or_later_stage_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+        "hmac",
+        "secrets",
+    }
+    banned_import_fragments = {
+        "reddog_signer_delegated_authority_runtime",
+        "reddog_wre_queue_authority_runtime_invoke",
+        "reddog_wre_queue_authority_verification_invoke",
+        "reddog_wre_queue_authorized",
+        "reddog_wre_queue_verified_authority_work_order_invoke",
+        "reddog_wre_worktree_runner",
+        "worktree_pr_runner",
+        "pattern_memory",
+        "openclaw_supervisor",
+        "hermes_job_executor",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    banned_attrs = {
+        "system",
+        "popen",
+        "spawn",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "unlink",
+        "remove",
+        "rmdir",
+        "rename",
+    }
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+                assert all(fragment not in alias.name for fragment in banned_import_fragments)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+            assert all(fragment not in node.module for fragment in banned_import_fragments)
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs


### PR DESCRIPTION
## Summary
- Adds an off-by-default `main.py` preflight adapter for the RedDog resident queue serial loop.
- Runs the existing serial loop through the stage-handler registry with caller-supplied outside-repo runtime JSON paths.
- Persists chain results through the existing atomic chain-results store while keeping startup/menu behavior unchanged by default.

## WSP_97 Evidence
- OBSERVED: `REDDOG_RESIDENT_QUEUE_SERIAL_LOOP` defaults off, so normal `main.py` startup and menu loading remain unchanged unless explicitly enabled.
- OBSERVED: Runtime JSON paths are required to be outside the repository before any chain work is attempted.
- OBSERVED: The registry dependency set remains the existing bootstrap-owned authority-request-only shape; missing later runtime handlers fail closed.
- OBSERVED: No signer, verifier, shell runner, worktree runner, OpenClaw/Hermes execution, PR runner, PatternMemory write, reward mapping, or HoloIndex re-index is introduced.
- SPECIFIED_NOT_IMPLEMENTED: Real signer runtime, signed verifier enforcement, runtime worktree/shell execution, live enqueue, draft PR publishing, PatternMemory admission beyond the existing handler boundary, and governed HoloIndex indexing remain later slices.

## Validation
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_serial_loop.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_stage_handler_registry.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_next_stage_dispatch_bootstrap.py -q` -> 31 passed
- resident queue subset + main bootstrap tests -> 167 passed
- `git diff --check` -> clean (CRLF informational warnings only)
- ASCII/NUL scan on new files -> 0 non-ASCII, 0 NUL

## HoloIndex Addendum
- Pre-edit query for `RedDog main resident queue serial loop bootstrap preflight` returned adjacent RedDog preflight/live-enqueue docs, not this new bootstrap module.
- INDEX_GAP recorded: `HOLOINDEX_REDDOG_MAIN_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_INDEX_GAP_PHASE1`.
- No runtime re-index is performed; HoloIndex maintenance remains WRE/CI/operator-owned.

## Boundary
This slice only exposes a bounded, explicit, off-by-default serial loop preflight adapter in `main.py`. It does not make RedDog autonomous by itself and does not grant repo, shell, merge, OpenClaw, Hermes, or worktree authority.