### PR TITLE
feat(reddog): add resident queue runtime dependency bundle

### DIFF
--- a/main.py
+++ b/main.py
@@ -1468,6 +1468,10 @@ def run_reddog_resident_queue_next_stage_dispatch_preflight(repo_root: Path) -> 
         REDDOG_AUTHORITATIVE_WORK_STATE_PATH                 Existing work-state snapshot
         REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH             Outside-repo chain-results JSON
         REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH         Outside-repo authority profile JSON
+        REDDOG_AUTHORITY_RUNTIME_STATE_PATH                  Outside-repo authority-runtime JSON
+        REDDOG_PERMISSION_SNAPSHOTS_PATH                     Outside-repo permission snapshot JSON
+        REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH              Outside-repo principal authority JSON
+        REDDOG_RESIDENT_QUEUE_NOW_EPOCH                      Optional runtime epoch for authority checks
         REDDOG_WRE_QUEUE_ITEM_ID                             Optional exact queue item id
     """
 
@@ -1542,6 +1546,11 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
         max_steps = int(os.getenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_MAX_STEPS", "1"))
     except ValueError:
         max_steps = 0
+    try:
+        now_epoch_value = os.getenv("REDDOG_RESIDENT_QUEUE_NOW_EPOCH", "")
+        now_epoch = int(now_epoch_value) if now_epoch_value else None
+    except ValueError:
+        now_epoch = None
 
     try:
         from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_loop_bootstrap import (
@@ -1553,7 +1562,11 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             work_state_path=os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
             chain_results_path=os.getenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH", "") or None,
             authority_profile_path=os.getenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", "") or None,
+            authority_state_path=os.getenv("REDDOG_AUTHORITY_RUNTIME_STATE_PATH", "") or None,
+            permission_snapshots_path=os.getenv("REDDOG_PERMISSION_SNAPSHOTS_PATH", "") or None,
+            principal_authority_records_path=os.getenv("REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH", "") or None,
             requested_queue_item_id=os.getenv("REDDOG_WRE_QUEUE_ITEM_ID", "") or None,
+            now_epoch=now_epoch,
             max_steps=max_steps,
         )
     except Exception as exc:

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,34 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_RUNTIME_DEPENDENCY_BUNDLE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_main_resident_queue_runtime_dependency_bundle.py`: a
+  main-startup dependency bundle for the resident queue serial loop. It builds
+  only outside-repo authority-state storage, JSON-backed principal/permission
+  resolvers, and a fail-closed signer client.
+- Extended `src/reddog_main_resident_queue_serial_loop_bootstrap.py` and
+  `main.py` env plumbing so `REDDOG_AUTHORITY_RUNTIME_STATE_PATH`,
+  `REDDOG_PERMISSION_SNAPSHOTS_PATH`,
+  `REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH`, and
+  `REDDOG_RESIDENT_QUEUE_NOW_EPOCH` can register the existing
+  `authority_runtime` stage without constructing live execution dependencies.
+- Added tests proving default no-op behavior, partial/inside-repo rejection,
+  outside-repo resolver loading, fail-closed signer rejection, serial-loop
+  progression into `authority_runtime`, updated `main.py` env forwarding, and
+  AST denial of shell/network/HoloIndex/live runner imports.
+- Boundary: no private key, real signer, signature verification, worktree,
+  shell command, OpenClaw enqueue, Hermes dispatch, PR publish, reward
+  settlement, repo mutation, or HoloIndex runtime re-index is created by this
+  slice. The signer remains fail-closed until a later isolated signer runtime
+  authorization slice provides a real boundary.
+- HoloIndex read-only probe for `RedDog resident queue runtime dependency
+  bundle authority runtime main bootstrap` surfaced adjacent live-enqueue and
+  governed work-order docs, but not this new bundle before indexing. Recorded
+  as `HOLOINDEX_REDDOG_MAIN_RESIDENT_QUEUE_RUNTIME_DEPENDENCY_BUNDLE_INDEX_GAP_PHASE1`;
+  no runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_runtime_dependency_bundle.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_runtime_dependency_bundle.py
@@ -1,0 +1,306 @@
+"""Main-startup dependency bundle for the resident RedDog queue loop.
+
+Slice: REDDOG_MAIN_RESIDENT_QUEUE_RUNTIME_DEPENDENCY_BUNDLE_PHASE1
+
+This module constructs only the authority-runtime dependencies that ``main.py``
+may safely own today: outside-repo JSON stores/resolvers and fail-closed signer
+boundaries. It does not load private keys, configure a real signer, verify
+signatures, create worktrees, run shell commands, enqueue OpenClaw, dispatch
+Hermes, publish PRs, mutate repository files, or re-index HoloIndex.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    AtomicJsonAuthorityRuntimeStore,
+    FailClosedPrincipalAuthorityResolver,
+    FailClosedSignerClient,
+    PrincipalAuthorityRecord,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    PermissionSnapshot,
+)
+
+
+REDDOG_RUNTIME_DEPENDENCY_BUNDLE_READY = "REDDOG_RUNTIME_DEPENDENCY_BUNDLE_READY"
+REDDOG_RUNTIME_DEPENDENCY_BUNDLE_NOT_REQUESTED = "REDDOG_RUNTIME_DEPENDENCY_BUNDLE_NOT_REQUESTED"
+REDDOG_RUNTIME_DEPENDENCY_BUNDLE_REJECT = "REDDOG_RUNTIME_DEPENDENCY_BUNDLE_REJECT"
+
+
+class JsonPrincipalAuthorityResolver:
+    """Resolve token-verified principal records from a caller-owned JSON snapshot."""
+
+    def __init__(self, records: Mapping[str, PrincipalAuthorityRecord]) -> None:
+        self._records = dict(records)
+
+    def resolve(self, principal_id: str, principal_provider: str) -> Optional[PrincipalAuthorityRecord]:
+        return self._records.get(_principal_key(principal_id, principal_provider))
+
+
+class JsonPermissionSnapshotResolver:
+    """Resolve permission snapshots from a caller-owned JSON snapshot."""
+
+    def __init__(self, snapshots: Mapping[str, PermissionSnapshot]) -> None:
+        self._snapshots = dict(snapshots)
+
+    def resolve(self, digest: str) -> Optional[PermissionSnapshot]:
+        return self._snapshots.get(str(digest))
+
+
+@dataclass(frozen=True)
+class RedDogMainResidentQueueRuntimeDependencyBundle:
+    """Dependency bundle consumed by the serial-loop bootstrap."""
+
+    accepted: bool
+    status: str
+    requested: bool
+    rejection_reasons: tuple[str, ...]
+    authority_store: Any = None
+    signer: Any = None
+    principal_resolver: Any = None
+    snapshot_resolver: Any = None
+    now_epoch: Optional[int] = None
+    authority_state_path: Optional[str] = None
+    permission_snapshots_loaded: int = 0
+    principal_records_loaded: int = 0
+    signer_mode: str = "none"
+    no_real_signer_configured: bool = True
+    no_private_key_loaded: bool = True
+    no_signature_verification_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_worktree_created: bool = True
+    no_shell_command_executed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pr_created: bool = True
+    no_reward_settlement_performed: bool = True
+
+
+def load_reddog_main_resident_queue_runtime_dependency_bundle(
+    *,
+    repo_root: Path | str,
+    authority_state_path: Path | str | None,
+    permission_snapshots_path: Path | str | None = None,
+    principal_authority_records_path: Path | str | None = None,
+    now_epoch: int | None = None,
+) -> RedDogMainResidentQueueRuntimeDependencyBundle:
+    """Load safe queue-loop dependencies from outside-repo runtime artifacts."""
+
+    root = Path(repo_root).resolve()
+    if not authority_state_path:
+        if permission_snapshots_path or principal_authority_records_path or now_epoch is not None:
+            return _reject("runtime_dependency_bundle_partial_configuration")
+        return RedDogMainResidentQueueRuntimeDependencyBundle(
+            accepted=True,
+            status=REDDOG_RUNTIME_DEPENDENCY_BUNDLE_NOT_REQUESTED,
+            requested=False,
+            rejection_reasons=(),
+        )
+
+    authority_path, authority_reasons = _resolve_path_outside_repo(
+        root,
+        authority_state_path,
+        missing_reason="missing_authority_runtime_state_path",
+        inside_reason="authority_runtime_state_path_inside_repo",
+        must_exist=False,
+    )
+    if authority_reasons:
+        return _reject(*authority_reasons)
+    assert authority_path is not None
+
+    snapshots, snapshot_reasons = _load_permission_snapshots(root, permission_snapshots_path)
+    if snapshot_reasons:
+        return _reject(*snapshot_reasons)
+
+    principals, principal_reasons = _load_principal_records(root, principal_authority_records_path)
+    if principal_reasons:
+        return _reject(*principal_reasons)
+
+    return RedDogMainResidentQueueRuntimeDependencyBundle(
+        accepted=True,
+        status=REDDOG_RUNTIME_DEPENDENCY_BUNDLE_READY,
+        requested=True,
+        rejection_reasons=(),
+        authority_store=AtomicJsonAuthorityRuntimeStore(authority_path),
+        signer=FailClosedSignerClient(),
+        principal_resolver=(
+            JsonPrincipalAuthorityResolver(principals)
+            if principals
+            else FailClosedPrincipalAuthorityResolver()
+        ),
+        snapshot_resolver=JsonPermissionSnapshotResolver(snapshots),
+        now_epoch=now_epoch,
+        authority_state_path=str(authority_path),
+        permission_snapshots_loaded=len(snapshots),
+        principal_records_loaded=len(principals),
+        signer_mode="fail_closed",
+    )
+
+
+def _reject(*reasons: str) -> RedDogMainResidentQueueRuntimeDependencyBundle:
+    return RedDogMainResidentQueueRuntimeDependencyBundle(
+        accepted=False,
+        status=REDDOG_RUNTIME_DEPENDENCY_BUNDLE_REJECT,
+        requested=True,
+        rejection_reasons=tuple(dict.fromkeys(reason for reason in reasons if reason)),
+    )
+
+
+def _resolve_path_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    missing_reason: str,
+    inside_reason: str,
+    must_exist: bool,
+) -> tuple[Optional[Path], tuple[str, ...]]:
+    if not value:
+        return None, ()
+    path = Path(value)
+    if not path.is_absolute():
+        path = (repo_root / path).resolve()
+    else:
+        path = path.resolve()
+    if _is_inside(path, repo_root):
+        return None, (inside_reason,)
+    if must_exist and (not path.exists() or not path.is_file()):
+        return None, (missing_reason,)
+    return path, ()
+
+
+def _read_json_mapping(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    missing_reason: str,
+    inside_reason: str,
+    malformed_reason: str,
+) -> tuple[Optional[Mapping[str, Any]], tuple[str, ...]]:
+    path, reasons = _resolve_path_outside_repo(
+        repo_root,
+        value,
+        missing_reason=missing_reason,
+        inside_reason=inside_reason,
+        must_exist=True,
+    )
+    if reasons:
+        return None, reasons
+    if path is None:
+        return None, ()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None, (malformed_reason,)
+    if not isinstance(payload, Mapping):
+        return None, (malformed_reason,)
+    return payload, ()
+
+
+def _load_permission_snapshots(
+    repo_root: Path,
+    value: Path | str | None,
+) -> tuple[dict[str, PermissionSnapshot], tuple[str, ...]]:
+    payload, reasons = _read_json_mapping(
+        repo_root,
+        value,
+        missing_reason="missing_permission_snapshots_path",
+        inside_reason="permission_snapshots_path_inside_repo",
+        malformed_reason="malformed_permission_snapshots",
+    )
+    if reasons:
+        return {}, reasons
+    raw = payload.get("snapshots") if payload else {}
+    if raw in (None, ""):
+        raw = {}
+    if not isinstance(raw, Mapping):
+        return {}, ("malformed_permission_snapshots",)
+    snapshots: dict[str, PermissionSnapshot] = {}
+    try:
+        for digest, item in raw.items():
+            if not isinstance(item, Mapping):
+                return {}, ("malformed_permission_snapshots",)
+            evidence_digest = str(item.get("evidence_digest") or digest)
+            snapshots[str(digest)] = PermissionSnapshot(
+                evidence_digest=evidence_digest,
+                expires_at=int(item["expires_at"]),
+                can_write=bool(item.get("can_write", False)),
+                can_admin=bool(item.get("can_admin", False)),
+                repo_full_name=str(item.get("repo_full_name") or ""),
+            )
+    except Exception:
+        return {}, ("malformed_permission_snapshots",)
+    return snapshots, ()
+
+
+def _load_principal_records(
+    repo_root: Path,
+    value: Path | str | None,
+) -> tuple[dict[str, PrincipalAuthorityRecord], tuple[str, ...]]:
+    payload, reasons = _read_json_mapping(
+        repo_root,
+        value,
+        missing_reason="missing_principal_authority_records_path",
+        inside_reason="principal_authority_records_path_inside_repo",
+        malformed_reason="malformed_principal_authority_records",
+    )
+    if reasons:
+        return {}, reasons
+    raw = payload.get("principals") if payload else {}
+    if raw in (None, ""):
+        raw = {}
+    if not isinstance(raw, Mapping):
+        return {}, ("malformed_principal_authority_records",)
+    records: dict[str, PrincipalAuthorityRecord] = {}
+    try:
+        for key, item in raw.items():
+            if not isinstance(item, Mapping):
+                return {}, ("malformed_principal_authority_records",)
+            record = PrincipalAuthorityRecord(
+                principal_id=str(item["principal_id"]),
+                principal_provider=str(item["principal_provider"]),
+                principal_public_key=str(item["principal_public_key"]),
+                repo_scope=tuple(str(v) for v in item.get("repo_scope") or ()),
+                foundup_scope=tuple(str(v) for v in item.get("foundup_scope") or ()),
+                verified_subject_digest=str(item["verified_subject_digest"]),
+                reward_account=(
+                    str(item["reward_account"]) if item.get("reward_account") is not None else None
+                ),
+                owner_dae=str(item["owner_dae"]) if item.get("owner_dae") is not None else None,
+                principal_wallet=(
+                    str(item["principal_wallet"]) if item.get("principal_wallet") is not None else None
+                ),
+            )
+            records[_principal_key(record.principal_id, record.principal_provider)] = record
+            if str(key) not in {record.principal_id, _principal_key(record.principal_id, record.principal_provider)}:
+                return {}, ("malformed_principal_authority_records",)
+    except Exception:
+        return {}, ("malformed_principal_authority_records",)
+    return records, ()
+
+
+def _principal_key(principal_id: str, principal_provider: str) -> str:
+    return f"{principal_provider}|{principal_id}"
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+__all__ = [
+    "JsonPermissionSnapshotResolver",
+    "JsonPrincipalAuthorityResolver",
+    "REDDOG_RUNTIME_DEPENDENCY_BUNDLE_NOT_REQUESTED",
+    "REDDOG_RUNTIME_DEPENDENCY_BUNDLE_READY",
+    "REDDOG_RUNTIME_DEPENDENCY_BUNDLE_REJECT",
+    "RedDogMainResidentQueueRuntimeDependencyBundle",
+    "load_reddog_main_resident_queue_runtime_dependency_bundle",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -23,6 +23,10 @@ from typing import Any, Mapping, Optional
 from modules.communication.moltbot_bridge.src.reddog_resident_queue_chain_results_store import (
     AtomicJsonResidentQueueChainResultsStore,
 )
+from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_runtime_dependency_bundle import (
+    REDDOG_RUNTIME_DEPENDENCY_BUNDLE_NOT_REQUESTED,
+    load_reddog_main_resident_queue_runtime_dependency_bundle,
+)
 from modules.communication.moltbot_bridge.src.reddog_resident_queue_serial_loop import (
     ResidentQueueSerialLoopResult,
     run_reddog_resident_queue_serial_loop,
@@ -50,6 +54,8 @@ class RedDogMainResidentQueueSerialLoopBootstrapResult:
     chain_results_path: Optional[str]
     store_revision: Optional[str]
     rejection_reasons: tuple[str, ...]
+    runtime_dependency_bundle_status: str = REDDOG_RUNTIME_DEPENDENCY_BUNDLE_NOT_REQUESTED
+    runtime_dependency_bundle_requested: bool = False
     no_signing_performed: bool = True
     no_signature_verification_performed: bool = True
     no_worker_spawn_performed: bool = True
@@ -73,8 +79,12 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
     work_state_path: Path | str | None,
     chain_results_path: Path | str | None,
     authority_profile_path: Path | str | None,
+    authority_state_path: Path | str | None = None,
+    permission_snapshots_path: Path | str | None = None,
+    principal_authority_records_path: Path | str | None = None,
     requested_queue_item_id: str | None = None,
     now_iso: str | None = None,
+    now_epoch: int | None = None,
     max_steps: int = 1,
 ) -> RedDogMainResidentQueueSerialLoopBootstrapResult:
     """Load runtime inputs and run the bounded resident queue serial loop."""
@@ -112,12 +122,32 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
         return _not_ready(chain_reasons, chain_results_path=None)
     assert chain_path is not None
 
+    dependency_bundle = load_reddog_main_resident_queue_runtime_dependency_bundle(
+        repo_root=root,
+        authority_state_path=authority_state_path,
+        permission_snapshots_path=permission_snapshots_path,
+        principal_authority_records_path=principal_authority_records_path,
+        now_epoch=now_epoch,
+    )
+    if dependency_bundle.accepted is not True:
+        return _not_ready(
+            dependency_bundle.rejection_reasons,
+            chain_results_path=None,
+            runtime_dependency_bundle_status=dependency_bundle.status,
+            runtime_dependency_bundle_requested=dependency_bundle.requested,
+        )
+
     store = AtomicJsonResidentQueueChainResultsStore(chain_path)
     registry = build_reddog_resident_queue_stage_handler_registry(
         work_state_snapshot=snapshot,
         chain_results_store=store,
         authority_profile=profile,
         now_iso=now_iso or "",
+        authority_store=dependency_bundle.authority_store,
+        signer=dependency_bundle.signer,
+        principal_resolver=dependency_bundle.principal_resolver,
+        snapshot_resolver=dependency_bundle.snapshot_resolver,
+        now_epoch=dependency_bundle.now_epoch,
     )
     loop = run_reddog_resident_queue_serial_loop(
         explicit_resident_queue_serial_loop_requested=True,
@@ -134,6 +164,8 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
             accepted=False,
             status=REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_NOT_READY,
             chain_results_path=chain_path,
+            runtime_dependency_bundle_status=dependency_bundle.status,
+            runtime_dependency_bundle_requested=dependency_bundle.requested,
         )
 
     return _from_loop(
@@ -141,6 +173,8 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
         accepted=True,
         status=REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED,
         chain_results_path=chain_path,
+        runtime_dependency_bundle_status=dependency_bundle.status,
+        runtime_dependency_bundle_requested=dependency_bundle.requested,
     )
 
 
@@ -201,6 +235,8 @@ def _not_ready(
     reasons: tuple[str, ...],
     *,
     chain_results_path: Path | None,
+    runtime_dependency_bundle_status: str = REDDOG_RUNTIME_DEPENDENCY_BUNDLE_NOT_REQUESTED,
+    runtime_dependency_bundle_requested: bool = False,
 ) -> RedDogMainResidentQueueSerialLoopBootstrapResult:
     return RedDogMainResidentQueueSerialLoopBootstrapResult(
         accepted=False,
@@ -212,6 +248,8 @@ def _not_ready(
         next_action=None,
         chain_results_path=str(chain_results_path) if chain_results_path else None,
         store_revision=None,
+        runtime_dependency_bundle_status=runtime_dependency_bundle_status,
+        runtime_dependency_bundle_requested=runtime_dependency_bundle_requested,
         rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons if str(reason).strip())),
     )
 
@@ -222,6 +260,8 @@ def _from_loop(
     accepted: bool,
     status: str,
     chain_results_path: Path,
+    runtime_dependency_bundle_status: str = REDDOG_RUNTIME_DEPENDENCY_BUNDLE_NOT_REQUESTED,
+    runtime_dependency_bundle_requested: bool = False,
 ) -> RedDogMainResidentQueueSerialLoopBootstrapResult:
     final_plan = loop.final_plan
     last_dispatch = loop.dispatch_results[-1] if loop.dispatch_results else None
@@ -237,6 +277,8 @@ def _from_loop(
         next_action=loop.next_action,
         chain_results_path=str(chain_results_path),
         store_revision=receipt.store_revision if receipt else None,
+        runtime_dependency_bundle_status=runtime_dependency_bundle_status,
+        runtime_dependency_bundle_requested=runtime_dependency_bundle_requested,
         rejection_reasons=tuple(loop.rejection_reasons),
     )
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_runtime_dependency_bundle.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_runtime_dependency_bundle.py
@@ -1,0 +1,238 @@
+"""Tests for REDDOG_MAIN_RESIDENT_QUEUE_RUNTIME_DEPENDENCY_BUNDLE_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_runtime_dependency_bundle import (
+    JsonPermissionSnapshotResolver,
+    JsonPrincipalAuthorityResolver,
+    REDDOG_RUNTIME_DEPENDENCY_BUNDLE_NOT_REQUESTED,
+    REDDOG_RUNTIME_DEPENDENCY_BUNDLE_READY,
+    REDDOG_RUNTIME_DEPENDENCY_BUNDLE_REJECT,
+    load_reddog_main_resident_queue_runtime_dependency_bundle,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    RuntimeRejectCode,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authority_runtime_invoke import (
+    invoke_reddog_wre_queue_authority_runtime,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_main_resident_queue_runtime_dependency_bundle.py"
+)
+NOW = 1000
+REPO = "FOUNDUPS/Foundups-Agent"
+FID = "paccess_001"
+
+
+def _repo(tmp_path: Path) -> Path:
+    path = tmp_path / "repo"
+    path.mkdir()
+    return path
+
+
+def _write_json(tmp_path: Path, name: str, payload: object) -> Path:
+    path = tmp_path / "runtime" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _snapshots() -> dict[str, object]:
+    return {
+        "snapshots": {
+            "sha256:snap-1": {
+                "evidence_digest": "sha256:snap-1",
+                "expires_at": NOW + 600,
+                "can_write": True,
+                "repo_full_name": REPO,
+            }
+        }
+    }
+
+
+def _principals() -> dict[str, object]:
+    return {
+        "principals": {
+            "github:mjtrout": {
+                "principal_id": "github:mjtrout",
+                "principal_provider": "github",
+                "principal_public_key": "pub:principal",
+                "repo_scope": [REPO],
+                "foundup_scope": [FID],
+                "verified_subject_digest": "sha256:verified-subject",
+                "reward_account": "reward:012",
+                "owner_dae": "dae:012",
+            }
+        }
+    }
+
+
+def _authority_request_result() -> dict[str, object]:
+    return {
+        "accepted": True,
+        "status": "QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT",
+        "delegated_authority_request": {
+            "work_order_id": "wre-queue-1",
+            "principal_id": "github:mjtrout",
+            "principal_provider": "github",
+            "principal_public_key": "pub:principal",
+            "reddog_id": "reddog:abc123",
+            "reddog_public_key": "pub:reddog",
+            "repo_full_name": REPO,
+            "foundup_id": FID,
+            "allowed_paths": [f"modules/foundups/{FID}/**"],
+            "denied_paths": [],
+            "requested_operation": "create_foundup",
+            "permission_snapshot_digest": "sha256:snap-1",
+            "identity_nonce": "identity-nonce-0001",
+            "work_authority_nonce": "workauth-nonce-0001",
+            "issued_at": NOW - 5,
+            "identity_expires_at": NOW + 3600,
+            "work_authority_expires_at": NOW + 300,
+            "valve_state_required": "VALVE_OPEN_WORKTREE_CREATE",
+            "key_epoch": "epoch-1",
+            "consensus_receipt_digest": "sha256:consensus",
+            "sovereign_authorization_digest": "sha256:012-token",
+        },
+    }
+
+
+def test_bundle_not_requested_does_not_create_runtime_dependencies(tmp_path: Path) -> None:
+    bundle = load_reddog_main_resident_queue_runtime_dependency_bundle(
+        repo_root=_repo(tmp_path),
+        authority_state_path=None,
+    )
+
+    assert bundle.accepted is True
+    assert bundle.status == REDDOG_RUNTIME_DEPENDENCY_BUNDLE_NOT_REQUESTED
+    assert bundle.requested is False
+    assert bundle.authority_store is None
+    assert bundle.signer is None
+    assert bundle.no_real_signer_configured is True
+
+
+def test_bundle_rejects_partial_configuration(tmp_path: Path) -> None:
+    bundle = load_reddog_main_resident_queue_runtime_dependency_bundle(
+        repo_root=_repo(tmp_path),
+        authority_state_path=None,
+        now_epoch=NOW,
+    )
+
+    assert bundle.accepted is False
+    assert bundle.status == REDDOG_RUNTIME_DEPENDENCY_BUNDLE_REJECT
+    assert "runtime_dependency_bundle_partial_configuration" in bundle.rejection_reasons
+
+
+def test_bundle_rejects_paths_inside_repo(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    inside = repo / "authority.json"
+
+    bundle = load_reddog_main_resident_queue_runtime_dependency_bundle(
+        repo_root=repo,
+        authority_state_path=inside,
+    )
+
+    assert bundle.accepted is False
+    assert "authority_runtime_state_path_inside_repo" in bundle.rejection_reasons
+
+
+def test_bundle_loads_outside_repo_resolvers_and_fail_closed_signer(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    authority_state = tmp_path / "runtime" / "authority-state.json"
+    snapshot_path = _write_json(tmp_path, "snapshots.json", _snapshots())
+    principal_path = _write_json(tmp_path, "principals.json", _principals())
+
+    bundle = load_reddog_main_resident_queue_runtime_dependency_bundle(
+        repo_root=repo,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshot_path,
+        principal_authority_records_path=principal_path,
+        now_epoch=NOW,
+    )
+
+    assert bundle.accepted is True
+    assert bundle.status == REDDOG_RUNTIME_DEPENDENCY_BUNDLE_READY
+    assert bundle.signer_mode == "fail_closed"
+    assert bundle.permission_snapshots_loaded == 1
+    assert bundle.principal_records_loaded == 1
+    assert isinstance(bundle.snapshot_resolver, JsonPermissionSnapshotResolver)
+    assert isinstance(bundle.principal_resolver, JsonPrincipalAuthorityResolver)
+    assert bundle.no_private_key_loaded is True
+    assert bundle.no_holoindex_reindex_performed is True
+
+    result = invoke_reddog_wre_queue_authority_runtime(
+        explicit_queue_authority_runtime_requested=True,
+        queue_authority_request_dryrun=_authority_request_result(),
+        store=bundle.authority_store,
+        signer=bundle.signer,
+        principal_resolver=bundle.principal_resolver,
+        snapshot_resolver=bundle.snapshot_resolver,
+        now=NOW,
+    )
+    assert result.decision == "QUEUE_AUTHORITY_RUNTIME_INVOKE_REJECT"
+    assert RuntimeRejectCode.SIGNER_NOT_CONFIGURED in result.rejection_reasons
+    assert result.no_repo_mutation_performed is True
+
+
+def test_bundle_has_no_shell_network_holoindex_private_key_or_live_runner_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+        "hmac",
+        "secrets",
+    }
+    banned_import_fragments = {
+        "openclaw_supervisor",
+        "hermes_job_executor",
+        "worktree_pr_runner",
+        "reddog_wre_worktree_runner",
+        "pattern_memory",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    banned_attrs = {
+        "system",
+        "popen",
+        "spawn",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "unlink",
+        "remove",
+        "rmdir",
+        "rename",
+        "replace",
+    }
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+                assert all(fragment not in alias.name for fragment in banned_import_fragments)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+            assert all(fragment not in node.module for fragment in banned_import_fragments)
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -12,6 +12,12 @@ from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_
     REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_NOT_READY,
     run_reddog_main_resident_queue_serial_loop_bootstrap,
 )
+from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_runtime_dependency_bundle import (
+    REDDOG_RUNTIME_DEPENDENCY_BUNDLE_READY,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    RuntimeRejectCode,
+)
 from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
     VALVE_OPEN_WORKTREE_CREATE,
 )
@@ -85,6 +91,36 @@ def _profile(**overrides: object) -> dict[str, object]:
     return profile
 
 
+def _snapshots() -> dict[str, object]:
+    return {
+        "snapshots": {
+            "sha256:snap-1": {
+                "evidence_digest": "sha256:snap-1",
+                "expires_at": 1600,
+                "can_write": True,
+                "repo_full_name": "FOUNDUPS/Foundups-Agent",
+            }
+        }
+    }
+
+
+def _principals() -> dict[str, object]:
+    return {
+        "principals": {
+            "github:mjtrout": {
+                "principal_id": "github:mjtrout",
+                "principal_provider": "github",
+                "principal_public_key": "pub:principal",
+                "repo_scope": ["FOUNDUPS/Foundups-Agent"],
+                "foundup_scope": ["paccess_001"],
+                "verified_subject_digest": "sha256:verified-subject",
+                "reward_account": "reward:012",
+                "owner_dae": "dae:012",
+            }
+        }
+    }
+
+
 def _write_runtime_json(tmp_path: Path, name: str, payload: object) -> Path:
     path = tmp_path / "runtime" / name
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -151,6 +187,45 @@ def test_bootstrap_serial_loop_fails_closed_when_later_dependency_missing(tmp_pa
     assert "FAIL_DISPATCH_REJECTED" in result.rejection_reasons
     assert "FAIL_HANDLER_MISSING" in result.rejection_reasons
     assert "stage:authority_runtime" in result.rejection_reasons
+
+
+def test_bootstrap_serial_loop_invokes_fail_closed_authority_runtime_bundle(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(tmp_path, "profile.json", _profile())
+    snapshots = _write_runtime_json(tmp_path, "snapshots.json", _snapshots())
+    principals = _write_runtime_json(tmp_path, "principals.json", _principals())
+    chain = tmp_path / "runtime" / "chain_results.json"
+    authority_state = tmp_path / "runtime" / "authority_state.json"
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshots,
+        principal_authority_records_path=principals,
+        now_iso=NOW,
+        now_epoch=1000,
+        requested_queue_item_id="queue-1",
+        max_steps=2,
+    )
+
+    assert result.accepted is False
+    assert result.status == REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_NOT_READY
+    assert result.runtime_dependency_bundle_status == REDDOG_RUNTIME_DEPENDENCY_BUNDLE_READY
+    assert result.runtime_dependency_bundle_requested is True
+    assert result.steps_run == 1
+    assert result.dispatched_stages == ("authority_request",)
+    assert "FAIL_DISPATCH_REJECTED" in result.rejection_reasons
+    assert "FAIL_RECORD_REJECTED" in result.rejection_reasons
+    assert "FAIL_STAGE_REJECTED:authority_runtime" in result.rejection_reasons
+    assert "REJECT_DELEGATED_AUTHORITY_RUNTIME_REJECTED" in result.rejection_reasons
+    assert RuntimeRejectCode.SIGNER_NOT_CONFIGURED in result.rejection_reasons
+    stored = json.loads(chain.read_text(encoding="utf-8"))
+    assert "authority_runtime" not in stored["stage_results"]
+    assert stored["stage_results"]["authority_request"]["status"] == "QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT"
 
 
 def test_bootstrap_rejects_missing_authority_profile(tmp_path: Path) -> None:
@@ -223,6 +298,10 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
                 "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
                 "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
                 "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+                "REDDOG_AUTHORITY_RUNTIME_STATE_PATH": str(tmp_path / "authority_state.json"),
+                "REDDOG_PERMISSION_SNAPSHOTS_PATH": str(tmp_path / "snapshots.json"),
+                "REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH": str(tmp_path / "principals.json"),
+                "REDDOG_RESIDENT_QUEUE_NOW_EPOCH": "1000",
                 "REDDOG_WRE_QUEUE_ITEM_ID": "queue-1",
             },
             clear=True,
@@ -232,7 +311,11 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
     assert mocked.call_args.kwargs["work_state_path"] == str(tmp_path / "state.json")
     assert mocked.call_args.kwargs["chain_results_path"] == str(tmp_path / "chain.json")
     assert mocked.call_args.kwargs["authority_profile_path"] == str(tmp_path / "profile.json")
+    assert mocked.call_args.kwargs["authority_state_path"] == str(tmp_path / "authority_state.json")
+    assert mocked.call_args.kwargs["permission_snapshots_path"] == str(tmp_path / "snapshots.json")
+    assert mocked.call_args.kwargs["principal_authority_records_path"] == str(tmp_path / "principals.json")
     assert mocked.call_args.kwargs["requested_queue_item_id"] == "queue-1"
+    assert mocked.call_args.kwargs["now_epoch"] == 1000
     assert mocked.call_args.kwargs["max_steps"] == 1
 
 


### PR DESCRIPTION
## Summary
- Adds `reddog_main_resident_queue_runtime_dependency_bundle.py` for safe main-startup construction of resident queue authority-runtime dependencies.
- Extends the serial-loop bootstrap and `main.py` env plumbing so outside-repo authority state, permission snapshots, and principal authority records can register the existing `authority_runtime` stage.
- Keeps the signer fail-closed: no private key, no real signer, no signature verification, and no execution authority is created by this slice.

## WSP_97 Evidence
- OBSERVED: no runtime dependency bundle is created unless `REDDOG_AUTHORITY_RUNTIME_STATE_PATH` is supplied.
- OBSERVED: partial runtime dependency configuration rejects fail-closed.
- OBSERVED: authority state, permission snapshots, and principal records must be outside the repo checkout.
- OBSERVED: the bundle uses `AtomicJsonAuthorityRuntimeStore`, JSON-backed resolvers, and `FailClosedSignerClient`; it does not configure a production signer.
- OBSERVED: with valid outside-repo snapshots/principals, the serial loop reaches `authority_runtime` and rejects with `REJECT_SIGNER_NOT_CONFIGURED`; the rejected stage is not persisted into the chain-results store.
- SPECIFIED_NOT_IMPLEMENTED: real isolated signer service, private-key custody, signed authority acceptance, signature verification in the live chain, worktree/shell execution, PR publishing, OpenClaw/Hermes execution, PatternMemory admission, and reward settlement remain later slices.

## Validation
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_runtime_dependency_bundle.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_stage_handler_registry.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_serial_loop.py -q` -> 28 passed
- resident queue subset + main bootstrap/bundle tests -> 173 passed
- signer/runtime/verifier boundary tests -> 54 passed
- `git diff --check` -> clean (CRLF informational warning only)
- ASCII/NUL scan on new files -> 0 non-ASCII, 0 NUL

## HoloIndex Addendum
- Read-only query: `RedDog resident queue runtime dependency bundle authority runtime main bootstrap`.
- Top hits were adjacent live-enqueue/governed work-order docs, not this new module before indexing.
- INDEX_GAP recorded: `HOLOINDEX_REDDOG_MAIN_RESIDENT_QUEUE_RUNTIME_DEPENDENCY_BUNDLE_INDEX_GAP_PHASE1`.
- No runtime re-index is performed; index maintenance remains WRE/CI/operator-owned.

## Boundary
This is a startup dependency-bundle slice only. It improves the resident queue loop from `handler missing` to auditable fail-closed authority-runtime rejection when runtime dependency files exist. It does not remove RedDog's execution gate or grant shell, repo, merge, OpenClaw, Hermes, worktree, PatternMemory, reward, or live signer authority.