### PR TITLE
feat(reddog): add isolated signer socket client

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,27 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_ISOLATED_SIGNER_SOCKET_CLIENT_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 71, 97
+
+- Added `src/reddog_isolated_signer_socket_client.py`: a fail-closed client
+  for an already-running isolated signer service. It sends existing
+  `SigningRequest` payloads over a validated local socket and converts signer
+  JSON responses into existing `SigningResponse` records.
+- Added tests proving missing/relative/inside-repo/device socket paths reject,
+  request JSON is deterministic and bounded, accepted attested responses
+  round-trip, malformed/oversized/connector failures reject, signer rejections
+  preserve no-secret-material guarantees, and AST denial of shell/env/HoloIndex
+  /OpenClaw/Hermes/vault/key-loading imports.
+- Boundary: client side only. No signer daemon is spawned, no private key or
+  vault secret is loaded, no command is executed, no repository file is mutated,
+  and no signature is treated as execution authority by this slice.
+- HoloIndex read-only probe for `RedDog isolated signer socket client
+  SigningRequest SigningResponse` surfaced signed-receipt/signature-verifier
+  code and the E0 contract, but not this new client before indexing. Recorded
+  as `HOLOINDEX_REDDOG_ISOLATED_SIGNER_SOCKET_CLIENT_INDEX_GAP_PHASE1`; no
+  runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_RUNTIME_DEPENDENCY_BUNDLE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_isolated_signer_socket_client.py
+++ b/modules/communication/moltbot_bridge/src/reddog_isolated_signer_socket_client.py
@@ -1,0 +1,248 @@
+"""Fail-closed client for an isolated RedDog signer service.
+
+Slice: REDDOG_ISOLATED_SIGNER_SOCKET_CLIENT_PHASE1
+
+This module implements the client side of the E0 signing-key isolation
+boundary. RedDog may connect to an already-running signer over a caller-provided
+local socket path, send a ``SigningRequest``, and receive a ``SigningResponse``.
+
+It never spawns the signer, never loads a private key or vault secret, never
+executes shell commands, never mutates repository files, and never treats a
+socket reply as execution authority by itself.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    IsolatedSignerClient,
+    RuntimeRejectCode,
+    SigningRequest,
+    SigningResponse,
+)
+
+
+SIGNER_SOCKET_CLIENT_READY = "SIGNER_SOCKET_CLIENT_READY"
+SIGNER_SOCKET_CLIENT_REJECT = "SIGNER_SOCKET_CLIENT_REJECT"
+
+FAIL_SIGNER_SOCKET_PATH_MISSING = "FAIL_SIGNER_SOCKET_PATH_MISSING"
+FAIL_SIGNER_SOCKET_PATH_RELATIVE = "FAIL_SIGNER_SOCKET_PATH_RELATIVE"
+FAIL_SIGNER_SOCKET_PATH_INSIDE_REPO = "FAIL_SIGNER_SOCKET_PATH_INSIDE_REPO"
+FAIL_SIGNER_SOCKET_DEVICE_PREFIX = "FAIL_SIGNER_SOCKET_DEVICE_PREFIX"
+FAIL_SIGNER_SOCKET_TIMEOUT_INVALID = "FAIL_SIGNER_SOCKET_TIMEOUT_INVALID"
+FAIL_SIGNER_SOCKET_RESPONSE_LIMIT_INVALID = "FAIL_SIGNER_SOCKET_RESPONSE_LIMIT_INVALID"
+
+REJECT_SIGNER_SOCKET_CONNECT_FAILED = "REJECT_SIGNER_SOCKET_CONNECT_FAILED"
+REJECT_SIGNER_SOCKET_RESPONSE_TOO_LARGE = "REJECT_SIGNER_SOCKET_RESPONSE_TOO_LARGE"
+REJECT_SIGNER_SOCKET_RESPONSE_INVALID = "REJECT_SIGNER_SOCKET_RESPONSE_INVALID"
+
+DEFAULT_SIGNER_SOCKET_TIMEOUT_S = 5.0
+DEFAULT_SIGNER_SOCKET_MAX_RESPONSE_BYTES = 16384
+
+SignerSocketConnector = Callable[[Path, bytes, float, int], bytes]
+
+
+@dataclass(frozen=True)
+class SignerSocketClientBuildResult:
+    """Result from guarded signer-socket client construction."""
+
+    accepted: bool
+    status: str
+    rejection_reasons: tuple[str, ...]
+    client: Optional["RedDogIsolatedSignerSocketClient"] = None
+    socket_path: Optional[str] = None
+    no_private_key_loaded: bool = True
+    no_signer_spawned: bool = True
+    no_shell_command_executed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+
+@dataclass(frozen=True)
+class RedDogIsolatedSignerSocketClient(IsolatedSignerClient):
+    """Client for an already-running isolated signer service."""
+
+    socket_path: Path
+    timeout_s: float = DEFAULT_SIGNER_SOCKET_TIMEOUT_S
+    max_response_bytes: int = DEFAULT_SIGNER_SOCKET_MAX_RESPONSE_BYTES
+    connector: Optional[SignerSocketConnector] = None
+
+    def sign(self, request: SigningRequest) -> SigningResponse:
+        """Send request to the isolated signer and return its response."""
+
+        if not isinstance(request, SigningRequest):
+            return _reject(RuntimeRejectCode.MALFORMED_REQUEST)
+        try:
+            payload = {
+                "schema_version": "reddog_signer_socket_request.v1",
+                "request": request.to_dict(),
+            }
+            request_bytes = (
+                json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+                + "\n"
+            ).encode("utf-8")
+            raw = (
+                self.connector(self.socket_path, request_bytes, self.timeout_s, self.max_response_bytes)
+                if self.connector
+                else _unix_socket_roundtrip(
+                    self.socket_path,
+                    request_bytes,
+                    self.timeout_s,
+                    self.max_response_bytes,
+                )
+            )
+        except Exception:
+            return _reject(REJECT_SIGNER_SOCKET_CONNECT_FAILED)
+        if len(raw) > self.max_response_bytes:
+            return _reject(REJECT_SIGNER_SOCKET_RESPONSE_TOO_LARGE)
+        try:
+            decoded = json.loads(raw.decode("utf-8").strip())
+        except Exception:
+            return _reject(REJECT_SIGNER_SOCKET_RESPONSE_INVALID)
+        return _response_from_mapping(decoded)
+
+
+def build_reddog_isolated_signer_socket_client(
+    *,
+    repo_root: Path | str,
+    socket_path: Path | str | None,
+    timeout_s: float = DEFAULT_SIGNER_SOCKET_TIMEOUT_S,
+    max_response_bytes: int = DEFAULT_SIGNER_SOCKET_MAX_RESPONSE_BYTES,
+    connector: Optional[SignerSocketConnector] = None,
+) -> SignerSocketClientBuildResult:
+    """Validate socket path and construct a fail-closed signer client."""
+
+    root = Path(repo_root).resolve()
+    if not socket_path:
+        return _build_reject(FAIL_SIGNER_SOCKET_PATH_MISSING)
+    path_text = str(socket_path)
+    if "\x00" in path_text or path_text.startswith("\\\\?\\") or path_text.startswith("//?/"):
+        return _build_reject(FAIL_SIGNER_SOCKET_DEVICE_PREFIX)
+    path = Path(socket_path)
+    if not path.is_absolute():
+        return _build_reject(FAIL_SIGNER_SOCKET_PATH_RELATIVE)
+    resolved = path.resolve()
+    if _is_inside(resolved, root):
+        return _build_reject(FAIL_SIGNER_SOCKET_PATH_INSIDE_REPO)
+    if timeout_s <= 0 or timeout_s > 30:
+        return _build_reject(FAIL_SIGNER_SOCKET_TIMEOUT_INVALID)
+    if max_response_bytes < 1024 or max_response_bytes > 262144:
+        return _build_reject(FAIL_SIGNER_SOCKET_RESPONSE_LIMIT_INVALID)
+    return SignerSocketClientBuildResult(
+        accepted=True,
+        status=SIGNER_SOCKET_CLIENT_READY,
+        rejection_reasons=(),
+        client=RedDogIsolatedSignerSocketClient(
+            socket_path=resolved,
+            timeout_s=float(timeout_s),
+            max_response_bytes=int(max_response_bytes),
+            connector=connector,
+        ),
+        socket_path=str(resolved),
+    )
+
+
+def _unix_socket_roundtrip(
+    socket_path: Path,
+    request_bytes: bytes,
+    timeout_s: float,
+    max_response_bytes: int,
+) -> bytes:
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as handle:
+        handle.settimeout(timeout_s)
+        handle.connect(str(socket_path))
+        handle.sendall(request_bytes)
+        handle.shutdown(socket.SHUT_WR)
+        chunks: list[bytes] = []
+        total = 0
+        while True:
+            chunk = handle.recv(4096)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > max_response_bytes:
+                raise ValueError(REJECT_SIGNER_SOCKET_RESPONSE_TOO_LARGE)
+            chunks.append(chunk)
+        return b"".join(chunks)
+
+
+def _response_from_mapping(value: object) -> SigningResponse:
+    if not isinstance(value, dict):
+        return _reject(REJECT_SIGNER_SOCKET_RESPONSE_INVALID)
+    accepted = value.get("accepted")
+    if not isinstance(accepted, bool):
+        return _reject(REJECT_SIGNER_SOCKET_RESPONSE_INVALID)
+    if accepted is not True:
+        return SigningResponse(
+            accepted=False,
+            rejection_code=str(value.get("rejection_code") or REJECT_SIGNER_SOCKET_RESPONSE_INVALID),
+            no_secret_material_returned=True,
+        )
+    required = (
+        "signature",
+        "signer_public_key",
+        "key_fingerprint",
+        "key_epoch",
+        "audit_mac",
+    )
+    if any(not isinstance(value.get(field), str) or not value.get(field) for field in required):
+        return _reject(REJECT_SIGNER_SOCKET_RESPONSE_INVALID)
+    return SigningResponse(
+        accepted=True,
+        signature=str(value["signature"]),
+        signer_public_key=str(value["signer_public_key"]),
+        key_fingerprint=str(value["key_fingerprint"]),
+        key_epoch=str(value["key_epoch"]),
+        audit_mac=str(value["audit_mac"]),
+        boundary_attested=value.get("boundary_attested") is True,
+        requester_identity_attested=value.get("requester_identity_attested") is True,
+        signer_loads_no_untrusted_code=value.get("signer_loads_no_untrusted_code") is True,
+        no_secret_material_returned=value.get("no_secret_material_returned") is not False,
+    )
+
+
+def _reject(code: str) -> SigningResponse:
+    return SigningResponse(
+        accepted=False,
+        rejection_code=str(code),
+        no_secret_material_returned=True,
+    )
+
+
+def _build_reject(*reasons: str) -> SignerSocketClientBuildResult:
+    return SignerSocketClientBuildResult(
+        accepted=False,
+        status=SIGNER_SOCKET_CLIENT_REJECT,
+        rejection_reasons=tuple(dict.fromkeys(reason for reason in reasons if reason)),
+    )
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+__all__ = [
+    "DEFAULT_SIGNER_SOCKET_MAX_RESPONSE_BYTES",
+    "DEFAULT_SIGNER_SOCKET_TIMEOUT_S",
+    "FAIL_SIGNER_SOCKET_DEVICE_PREFIX",
+    "FAIL_SIGNER_SOCKET_PATH_INSIDE_REPO",
+    "FAIL_SIGNER_SOCKET_PATH_MISSING",
+    "FAIL_SIGNER_SOCKET_PATH_RELATIVE",
+    "FAIL_SIGNER_SOCKET_RESPONSE_LIMIT_INVALID",
+    "FAIL_SIGNER_SOCKET_TIMEOUT_INVALID",
+    "REJECT_SIGNER_SOCKET_CONNECT_FAILED",
+    "REJECT_SIGNER_SOCKET_RESPONSE_INVALID",
+    "REJECT_SIGNER_SOCKET_RESPONSE_TOO_LARGE",
+    "SIGNER_SOCKET_CLIENT_READY",
+    "SIGNER_SOCKET_CLIENT_REJECT",
+    "RedDogIsolatedSignerSocketClient",
+    "SignerSocketClientBuildResult",
+    "build_reddog_isolated_signer_socket_client",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_isolated_signer_socket_client.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_isolated_signer_socket_client.py
@@ -1,0 +1,242 @@
+"""Tests for REDDOG_ISOLATED_SIGNER_SOCKET_CLIENT_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_client import (
+    FAIL_SIGNER_SOCKET_DEVICE_PREFIX,
+    FAIL_SIGNER_SOCKET_PATH_INSIDE_REPO,
+    FAIL_SIGNER_SOCKET_PATH_MISSING,
+    FAIL_SIGNER_SOCKET_PATH_RELATIVE,
+    REJECT_SIGNER_SOCKET_CONNECT_FAILED,
+    REJECT_SIGNER_SOCKET_RESPONSE_INVALID,
+    REJECT_SIGNER_SOCKET_RESPONSE_TOO_LARGE,
+    SIGNER_SOCKET_CLIENT_READY,
+    SIGNER_SOCKET_CLIENT_REJECT,
+    build_reddog_isolated_signer_socket_client,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    SigningRequest,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_isolated_signer_socket_client.py"
+)
+
+
+def _repo(tmp_path: Path) -> Path:
+    path = tmp_path / "repo"
+    path.mkdir()
+    return path
+
+
+def _socket_path(tmp_path: Path) -> Path:
+    path = tmp_path / "runtime" / "signer.sock"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _request() -> SigningRequest:
+    return SigningRequest(
+        signing_input='reddog-workauth.v1.{"work_order_id":"wo-1"}',
+        payload_digest="sha256:payload",
+        signer_role="reddog",
+        signer_public_key="pub:reddog",
+        requester_principal_id="github:mjtrout",
+        nonce="nonce-1",
+        key_epoch="epoch-1",
+        requested_operation="create_foundup",
+        authority_tier="HIGH",
+        consensus_receipt_digest="sha256:consensus",
+    )
+
+
+def _accepted_response() -> bytes:
+    return (
+        json.dumps(
+            {
+                "accepted": True,
+                "signature": "sig:abc",
+                "signer_public_key": "pub:reddog",
+                "key_fingerprint": "sha256:fingerprint",
+                "key_epoch": "epoch-1",
+                "audit_mac": "audit:mac",
+                "boundary_attested": True,
+                "requester_identity_attested": True,
+                "signer_loads_no_untrusted_code": True,
+                "no_secret_material_returned": True,
+            },
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def test_build_rejects_missing_relative_inside_repo_and_device_paths(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+
+    missing = build_reddog_isolated_signer_socket_client(repo_root=repo, socket_path=None)
+    assert missing.accepted is False
+    assert missing.status == SIGNER_SOCKET_CLIENT_REJECT
+    assert FAIL_SIGNER_SOCKET_PATH_MISSING in missing.rejection_reasons
+
+    relative = build_reddog_isolated_signer_socket_client(repo_root=repo, socket_path="signer.sock")
+    assert relative.accepted is False
+    assert FAIL_SIGNER_SOCKET_PATH_RELATIVE in relative.rejection_reasons
+
+    inside = build_reddog_isolated_signer_socket_client(repo_root=repo, socket_path=repo / "signer.sock")
+    assert inside.accepted is False
+    assert FAIL_SIGNER_SOCKET_PATH_INSIDE_REPO in inside.rejection_reasons
+
+    device = build_reddog_isolated_signer_socket_client(repo_root=repo, socket_path="\\\\?\\C:\\tmp\\signer.sock")
+    assert device.accepted is False
+    assert FAIL_SIGNER_SOCKET_DEVICE_PREFIX in device.rejection_reasons
+
+
+def test_client_sends_signing_request_and_returns_attested_response(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    socket_path = _socket_path(tmp_path)
+    observed: dict[str, object] = {}
+
+    def connector(path: Path, payload: bytes, timeout_s: float, max_response_bytes: int) -> bytes:
+        observed["path"] = str(path)
+        observed["timeout_s"] = timeout_s
+        observed["max_response_bytes"] = max_response_bytes
+        observed["payload"] = json.loads(payload.decode("utf-8"))
+        return _accepted_response()
+
+    built = build_reddog_isolated_signer_socket_client(
+        repo_root=repo,
+        socket_path=socket_path,
+        connector=connector,
+    )
+    assert built.accepted is True
+    assert built.status == SIGNER_SOCKET_CLIENT_READY
+    assert built.client is not None
+    response = built.client.sign(_request())
+
+    assert response.accepted is True
+    assert response.signature == "sig:abc"
+    assert response.boundary_attested is True
+    assert response.requester_identity_attested is True
+    assert response.signer_loads_no_untrusted_code is True
+    assert response.no_secret_material_returned is True
+    assert observed["path"] == str(socket_path.resolve())
+    payload = observed["payload"]
+    assert isinstance(payload, dict)
+    assert payload["schema_version"] == "reddog_signer_socket_request.v1"
+    assert payload["request"]["signer_role"] == "reddog"
+
+
+def test_client_rejects_malformed_oversized_and_connector_failures(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    socket_path = _socket_path(tmp_path)
+
+    malformed = build_reddog_isolated_signer_socket_client(
+        repo_root=repo,
+        socket_path=socket_path,
+        connector=lambda *_: b"not-json",
+    )
+    assert malformed.client is not None
+    assert malformed.client.sign(_request()).rejection_code == REJECT_SIGNER_SOCKET_RESPONSE_INVALID
+
+    oversized = build_reddog_isolated_signer_socket_client(
+        repo_root=repo,
+        socket_path=socket_path,
+        max_response_bytes=1024,
+        connector=lambda *_: b"{" + (b" " * 2048) + b"}",
+    )
+    assert oversized.client is not None
+    assert oversized.client.sign(_request()).rejection_code == REJECT_SIGNER_SOCKET_RESPONSE_TOO_LARGE
+
+    def failing_connector(*_: object) -> bytes:
+        raise OSError("connect failed")
+
+    failed = build_reddog_isolated_signer_socket_client(
+        repo_root=repo,
+        socket_path=socket_path,
+        connector=failing_connector,
+    )
+    assert failed.client is not None
+    assert failed.client.sign(_request()).rejection_code == REJECT_SIGNER_SOCKET_CONNECT_FAILED
+
+
+def test_client_preserves_signer_rejection_without_secret_material(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    socket_path = _socket_path(tmp_path)
+
+    built = build_reddog_isolated_signer_socket_client(
+        repo_root=repo,
+        socket_path=socket_path,
+        connector=lambda *_: b'{"accepted":false,"rejection_code":"REJECT_RATE_LIMIT"}\n',
+    )
+
+    assert built.client is not None
+    response = built.client.sign(_request())
+    assert response.accepted is False
+    assert response.rejection_code == "REJECT_RATE_LIMIT"
+    assert response.no_secret_material_returned is True
+
+
+def test_module_has_no_shell_env_holoindex_openclaw_hermes_or_key_loading() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "holo_index",
+        "git",
+        "hmac",
+        "secrets",
+        "os",
+    }
+    banned_import_fragments = {
+        "openclaw_supervisor",
+        "hermes_job_executor",
+        "worktree_pr_runner",
+        "reddog_wre_worktree_runner",
+        "pattern_memory",
+        "vault_resolver",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    banned_attrs = {
+        "system",
+        "popen",
+        "spawn",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "getenv",
+        "environ",
+        "unlink",
+        "remove",
+        "rmdir",
+        "rename",
+        "replace",
+    }
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+                assert all(fragment not in alias.name for fragment in banned_import_fragments)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+            assert all(fragment not in node.module for fragment in banned_import_fragments)
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs


### PR DESCRIPTION
## Summary
- Adds `reddog_isolated_signer_socket_client.py`, a fail-closed client for an already-running isolated signer service.
- Validates signer socket paths outside the repo and sends existing `SigningRequest` records over a local socket without spawning a signer.
- Converts bounded signer JSON replies into existing `SigningResponse` records.

## WSP_97 Evidence
- OBSERVED: socket path must be absolute, outside repo, and not a device-prefix path.
- OBSERVED: client sends only the existing `SigningRequest.to_dict()` payload and receives bounded JSON.
- OBSERVED: malformed, oversized, connector failure, and signer rejection all fail closed.
- OBSERVED: no private key, vault secret, env secret, shell command, signer spawn, repo mutation, OpenClaw/Hermes execution, PR publish, or HoloIndex re-index is introduced.
- SPECIFIED_NOT_IMPLEMENTED: signer daemon/service, OS principal creation, key custody, vault resolution, peer-credential enforcement, signer-side rate limits, and wiring into `main.py` runtime dependency bundle remain later slices.

## Validation
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_isolated_signer_socket_client.py modules/communication/moltbot_bridge/tests/test_reddog_signer_delegated_authority_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_runtime_invoke.py -q` -> 26 passed
- broader signing boundary suite -> 74 passed
- `git diff --check` -> clean (CRLF informational warning only)
- ASCII/NUL scan on new files -> 0 non-ASCII, 0 NUL

## HoloIndex Addendum
- Read-only query: `RedDog isolated signer socket client SigningRequest SigningResponse`.
- Top hits surfaced signed-receipt/signature-verifier code and the E0 contract, not this new client before indexing.
- INDEX_GAP recorded: `HOLOINDEX_REDDOG_ISOLATED_SIGNER_SOCKET_CLIENT_INDEX_GAP_PHASE1`.
- No runtime re-index is performed; index maintenance remains WRE/CI/operator-owned.

## Boundary
This is the client side only. It does not make RedDog authority-capable by itself. A real signer daemon under a distinct OS principal remains required before signatures can be issued in production.