### PR TITLE
feat(reddog): wire signer socket into resident queue bundle

### DIFF
--- a/main.py
+++ b/main.py
@@ -1535,6 +1535,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
         REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH             Outside-repo chain-results JSON
         REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH         Outside-repo authority profile JSON
         REDDOG_WRE_QUEUE_ITEM_ID                             Optional exact queue item id
+        REDDOG_SIGNER_SOCKET_PATH                            Optional outside-repo isolated signer socket
     """
 
     if os.getenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP", "0") == "0":
@@ -1551,6 +1552,16 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
         now_epoch = int(now_epoch_value) if now_epoch_value else None
     except ValueError:
         now_epoch = None
+    try:
+        signer_socket_timeout_value = os.getenv("REDDOG_SIGNER_SOCKET_TIMEOUT_S", "")
+        signer_socket_timeout_s = float(signer_socket_timeout_value) if signer_socket_timeout_value else 5.0
+    except ValueError:
+        signer_socket_timeout_s = 0.0
+    try:
+        signer_socket_max_value = os.getenv("REDDOG_SIGNER_SOCKET_MAX_RESPONSE_BYTES", "")
+        signer_socket_max_response_bytes = int(signer_socket_max_value) if signer_socket_max_value else 16384
+    except ValueError:
+        signer_socket_max_response_bytes = 0
 
     try:
         from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_loop_bootstrap import (
@@ -1565,6 +1576,9 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             authority_state_path=os.getenv("REDDOG_AUTHORITY_RUNTIME_STATE_PATH", "") or None,
             permission_snapshots_path=os.getenv("REDDOG_PERMISSION_SNAPSHOTS_PATH", "") or None,
             principal_authority_records_path=os.getenv("REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH", "") or None,
+            signer_socket_path=os.getenv("REDDOG_SIGNER_SOCKET_PATH", "") or None,
+            signer_socket_timeout_s=signer_socket_timeout_s,
+            signer_socket_max_response_bytes=signer_socket_max_response_bytes,
             requested_queue_item_id=os.getenv("REDDOG_WRE_QUEUE_ITEM_ID", "") or None,
             now_epoch=now_epoch,
             max_steps=max_steps,

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,26 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_SIGNER_SOCKET_CLIENT_BUNDLE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 71, 97
+
+- Extended the resident queue runtime dependency bundle so an explicit
+  outside-repo `REDDOG_SIGNER_SOCKET_PATH` can provide the already-built
+  isolated signer socket client to the `authority_runtime` stage.
+- Updated the serial-loop bootstrap and `main.py` env plumbing with signer
+  socket path, timeout, and response-size settings. Default behavior remains
+  fail-closed through `FailClosedSignerClient` when the socket path is absent.
+- Added tests proving invalid signer socket paths reject without fallback,
+  a connector-backed isolated signer can issue delegated authority through the
+  existing resident loop, `main.py` forwards the new env settings, and the
+  boundary still performs no private-key loading, signer spawning, shell work,
+  repo mutation, OpenClaw enqueue, Hermes dispatch, or HoloIndex re-index.
+- HoloIndex read-only probe for `RedDog main resident queue signer socket
+  runtime dependency bundle` surfaced adjacent live-enqueue/worktree docs and
+  WSP entries, but not this new wiring before indexing. Recorded as
+  `HOLOINDEX_REDDOG_MAIN_RESIDENT_QUEUE_SIGNER_SOCKET_CLIENT_BUNDLE_INDEX_GAP_PHASE1`;
+  no runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_ISOLATED_SIGNER_SOCKET_CLIENT_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 71, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_runtime_dependency_bundle.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_runtime_dependency_bundle.py
@@ -3,10 +3,11 @@
 Slice: REDDOG_MAIN_RESIDENT_QUEUE_RUNTIME_DEPENDENCY_BUNDLE_PHASE1
 
 This module constructs only the authority-runtime dependencies that ``main.py``
-may safely own today: outside-repo JSON stores/resolvers and fail-closed signer
-boundaries. It does not load private keys, configure a real signer, verify
-signatures, create worktrees, run shell commands, enqueue OpenClaw, dispatch
-Hermes, publish PRs, mutate repository files, or re-index HoloIndex.
+may safely own today: outside-repo JSON stores/resolvers and an optional client
+for an already-running isolated signer. It does not load private keys, spawn a
+signer, verify signatures, create worktrees, run shell commands, enqueue
+OpenClaw, dispatch Hermes, publish PRs, mutate repository files, or re-index
+HoloIndex.
 """
 
 from __future__ import annotations
@@ -21,6 +22,12 @@ from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_
     FailClosedPrincipalAuthorityResolver,
     FailClosedSignerClient,
     PrincipalAuthorityRecord,
+)
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_client import (
+    DEFAULT_SIGNER_SOCKET_MAX_RESPONSE_BYTES,
+    DEFAULT_SIGNER_SOCKET_TIMEOUT_S,
+    SignerSocketConnector,
+    build_reddog_isolated_signer_socket_client,
 )
 from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
     PermissionSnapshot,
@@ -66,6 +73,7 @@ class RedDogMainResidentQueueRuntimeDependencyBundle:
     snapshot_resolver: Any = None
     now_epoch: Optional[int] = None
     authority_state_path: Optional[str] = None
+    signer_socket_path: Optional[str] = None
     permission_snapshots_loaded: int = 0
     principal_records_loaded: int = 0
     signer_mode: str = "none"
@@ -89,13 +97,22 @@ def load_reddog_main_resident_queue_runtime_dependency_bundle(
     authority_state_path: Path | str | None,
     permission_snapshots_path: Path | str | None = None,
     principal_authority_records_path: Path | str | None = None,
+    signer_socket_path: Path | str | None = None,
+    signer_socket_timeout_s: float = DEFAULT_SIGNER_SOCKET_TIMEOUT_S,
+    signer_socket_max_response_bytes: int = DEFAULT_SIGNER_SOCKET_MAX_RESPONSE_BYTES,
+    signer_socket_connector: Optional[SignerSocketConnector] = None,
     now_epoch: int | None = None,
 ) -> RedDogMainResidentQueueRuntimeDependencyBundle:
     """Load safe queue-loop dependencies from outside-repo runtime artifacts."""
 
     root = Path(repo_root).resolve()
     if not authority_state_path:
-        if permission_snapshots_path or principal_authority_records_path or now_epoch is not None:
+        if (
+            permission_snapshots_path
+            or principal_authority_records_path
+            or signer_socket_path
+            or now_epoch is not None
+        ):
             return _reject("runtime_dependency_bundle_partial_configuration")
         return RedDogMainResidentQueueRuntimeDependencyBundle(
             accepted=True,
@@ -123,13 +140,32 @@ def load_reddog_main_resident_queue_runtime_dependency_bundle(
     if principal_reasons:
         return _reject(*principal_reasons)
 
+    signer = FailClosedSignerClient()
+    signer_mode = "fail_closed"
+    signer_socket_resolved: Optional[str] = None
+    no_real_signer_configured = True
+    if signer_socket_path:
+        signer_result = build_reddog_isolated_signer_socket_client(
+            repo_root=root,
+            socket_path=signer_socket_path,
+            timeout_s=signer_socket_timeout_s,
+            max_response_bytes=signer_socket_max_response_bytes,
+            connector=signer_socket_connector,
+        )
+        if signer_result.accepted is not True or signer_result.client is None:
+            return _reject(*signer_result.rejection_reasons)
+        signer = signer_result.client
+        signer_mode = "isolated_socket"
+        signer_socket_resolved = signer_result.socket_path
+        no_real_signer_configured = False
+
     return RedDogMainResidentQueueRuntimeDependencyBundle(
         accepted=True,
         status=REDDOG_RUNTIME_DEPENDENCY_BUNDLE_READY,
         requested=True,
         rejection_reasons=(),
         authority_store=AtomicJsonAuthorityRuntimeStore(authority_path),
-        signer=FailClosedSignerClient(),
+        signer=signer,
         principal_resolver=(
             JsonPrincipalAuthorityResolver(principals)
             if principals
@@ -138,9 +174,11 @@ def load_reddog_main_resident_queue_runtime_dependency_bundle(
         snapshot_resolver=JsonPermissionSnapshotResolver(snapshots),
         now_epoch=now_epoch,
         authority_state_path=str(authority_path),
+        signer_socket_path=signer_socket_resolved,
         permission_snapshots_loaded=len(snapshots),
         principal_records_loaded=len(principals),
-        signer_mode="fail_closed",
+        signer_mode=signer_mode,
+        no_real_signer_configured=no_real_signer_configured,
     )
 
 

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -27,6 +27,11 @@ from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_runtime
     REDDOG_RUNTIME_DEPENDENCY_BUNDLE_NOT_REQUESTED,
     load_reddog_main_resident_queue_runtime_dependency_bundle,
 )
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_client import (
+    DEFAULT_SIGNER_SOCKET_MAX_RESPONSE_BYTES,
+    DEFAULT_SIGNER_SOCKET_TIMEOUT_S,
+    SignerSocketConnector,
+)
 from modules.communication.moltbot_bridge.src.reddog_resident_queue_serial_loop import (
     ResidentQueueSerialLoopResult,
     run_reddog_resident_queue_serial_loop,
@@ -82,6 +87,10 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
     authority_state_path: Path | str | None = None,
     permission_snapshots_path: Path | str | None = None,
     principal_authority_records_path: Path | str | None = None,
+    signer_socket_path: Path | str | None = None,
+    signer_socket_timeout_s: float = DEFAULT_SIGNER_SOCKET_TIMEOUT_S,
+    signer_socket_max_response_bytes: int = DEFAULT_SIGNER_SOCKET_MAX_RESPONSE_BYTES,
+    signer_socket_connector: Optional[SignerSocketConnector] = None,
     requested_queue_item_id: str | None = None,
     now_iso: str | None = None,
     now_epoch: int | None = None,
@@ -127,6 +136,10 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
         authority_state_path=authority_state_path,
         permission_snapshots_path=permission_snapshots_path,
         principal_authority_records_path=principal_authority_records_path,
+        signer_socket_path=signer_socket_path,
+        signer_socket_timeout_s=signer_socket_timeout_s,
+        signer_socket_max_response_bytes=signer_socket_max_response_bytes,
+        signer_socket_connector=signer_socket_connector,
         now_epoch=now_epoch,
     )
     if dependency_bundle.accepted is not True:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_runtime_dependency_bundle.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_runtime_dependency_bundle.py
@@ -16,6 +16,7 @@ from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_runtime
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
     RuntimeRejectCode,
+    public_key_fingerprint,
 )
 from modules.communication.moltbot_bridge.src.reddog_wre_queue_authority_runtime_invoke import (
     invoke_reddog_wre_queue_authority_runtime,
@@ -109,6 +110,33 @@ def _authority_request_result() -> dict[str, object]:
     }
 
 
+def _accepted_socket_signer(
+    socket_path: Path,
+    request_bytes: bytes,
+    timeout_s: float,
+    max_response_bytes: int,
+) -> bytes:
+    assert socket_path.is_absolute()
+    assert timeout_s > 0
+    assert max_response_bytes >= 1024
+    decoded = json.loads(request_bytes.decode("utf-8").strip())
+    request = decoded["request"]
+    public_key = str(request["signer_public_key"])
+    response = {
+        "accepted": True,
+        "signature": "sig:" + str(request["nonce"]),
+        "signer_public_key": public_key,
+        "key_fingerprint": public_key_fingerprint(public_key),
+        "key_epoch": str(request["key_epoch"]),
+        "audit_mac": "audit:" + str(request["payload_digest"]),
+        "boundary_attested": True,
+        "requester_identity_attested": True,
+        "signer_loads_no_untrusted_code": True,
+        "no_secret_material_returned": True,
+    }
+    return json.dumps(response, sort_keys=True).encode("utf-8")
+
+
 def test_bundle_not_requested_does_not_create_runtime_dependencies(tmp_path: Path) -> None:
     bundle = load_reddog_main_resident_queue_runtime_dependency_bundle(
         repo_root=_repo(tmp_path),
@@ -184,6 +212,70 @@ def test_bundle_loads_outside_repo_resolvers_and_fail_closed_signer(tmp_path: Pa
     assert result.decision == "QUEUE_AUTHORITY_RUNTIME_INVOKE_REJECT"
     assert RuntimeRejectCode.SIGNER_NOT_CONFIGURED in result.rejection_reasons
     assert result.no_repo_mutation_performed is True
+
+
+def test_bundle_uses_isolated_socket_signer_when_explicitly_configured(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    authority_state = tmp_path / "runtime" / "authority-state.json"
+    socket_path = tmp_path / "runtime" / "signer.sock"
+    snapshot_path = _write_json(tmp_path, "snapshots.json", _snapshots())
+    principal_path = _write_json(tmp_path, "principals.json", _principals())
+
+    bundle = load_reddog_main_resident_queue_runtime_dependency_bundle(
+        repo_root=repo,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshot_path,
+        principal_authority_records_path=principal_path,
+        signer_socket_path=socket_path,
+        signer_socket_connector=_accepted_socket_signer,
+        now_epoch=NOW,
+    )
+
+    assert bundle.accepted is True
+    assert bundle.status == REDDOG_RUNTIME_DEPENDENCY_BUNDLE_READY
+    assert bundle.signer_mode == "isolated_socket"
+    assert bundle.signer_socket_path == str(socket_path.resolve())
+    assert bundle.no_real_signer_configured is False
+    assert bundle.no_private_key_loaded is True
+    assert bundle.no_worker_spawn_performed is True
+
+    result = invoke_reddog_wre_queue_authority_runtime(
+        explicit_queue_authority_runtime_requested=True,
+        queue_authority_request_dryrun=_authority_request_result(),
+        store=bundle.authority_store,
+        signer=bundle.signer,
+        principal_resolver=bundle.principal_resolver,
+        snapshot_resolver=bundle.snapshot_resolver,
+        now=NOW,
+    )
+    assert result.decision == "QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT"
+    assert result.authority_result is not None
+    assert result.authority_result.accepted is True
+    assert result.no_openclaw_enqueue_performed is True
+    assert authority_state.exists()
+    stored = json.loads(authority_state.read_text(encoding="utf-8"))
+    assert stored["issued_authorities"]["wre-queue-1"]["status"] == "DELEGATED_AUTHORITY_ISSUED"
+
+
+def test_bundle_rejects_invalid_signer_socket_without_falling_back(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    authority_state = tmp_path / "runtime" / "authority-state.json"
+    snapshot_path = _write_json(tmp_path, "snapshots.json", _snapshots())
+    principal_path = _write_json(tmp_path, "principals.json", _principals())
+
+    bundle = load_reddog_main_resident_queue_runtime_dependency_bundle(
+        repo_root=repo,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshot_path,
+        principal_authority_records_path=principal_path,
+        signer_socket_path=repo / "signer.sock",
+        now_epoch=NOW,
+    )
+
+    assert bundle.accepted is False
+    assert bundle.status == REDDOG_RUNTIME_DEPENDENCY_BUNDLE_REJECT
+    assert "FAIL_SIGNER_SOCKET_PATH_INSIDE_REPO" in bundle.rejection_reasons
+    assert bundle.signer is None
 
 
 def test_bundle_has_no_shell_network_holoindex_private_key_or_live_runner_imports() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -17,6 +17,7 @@ from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_runtime
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
     RuntimeRejectCode,
+    public_key_fingerprint,
 )
 from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
     VALVE_OPEN_WORKTREE_CREATE,
@@ -128,6 +129,33 @@ def _write_runtime_json(tmp_path: Path, name: str, payload: object) -> Path:
     return path
 
 
+def _accepted_socket_signer(
+    socket_path: Path,
+    request_bytes: bytes,
+    timeout_s: float,
+    max_response_bytes: int,
+) -> bytes:
+    assert socket_path.is_absolute()
+    assert timeout_s > 0
+    assert max_response_bytes >= 1024
+    decoded = json.loads(request_bytes.decode("utf-8").strip())
+    request = decoded["request"]
+    public_key = str(request["signer_public_key"])
+    response = {
+        "accepted": True,
+        "signature": "sig:" + str(request["nonce"]),
+        "signer_public_key": public_key,
+        "key_fingerprint": public_key_fingerprint(public_key),
+        "key_epoch": str(request["key_epoch"]),
+        "audit_mac": "audit:" + str(request["payload_digest"]),
+        "boundary_attested": True,
+        "requester_identity_attested": True,
+        "signer_loads_no_untrusted_code": True,
+        "no_secret_material_returned": True,
+    }
+    return json.dumps(response, sort_keys=True).encode("utf-8")
+
+
 def _repo(tmp_path: Path) -> Path:
     path = tmp_path / "repo"
     path.mkdir()
@@ -228,6 +256,50 @@ def test_bootstrap_serial_loop_invokes_fail_closed_authority_runtime_bundle(tmp_
     assert stored["stage_results"]["authority_request"]["status"] == "QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT"
 
 
+def test_bootstrap_serial_loop_uses_socket_signer_for_authority_runtime(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(tmp_path, "profile.json", _profile())
+    snapshots = _write_runtime_json(tmp_path, "snapshots.json", _snapshots())
+    principals = _write_runtime_json(tmp_path, "principals.json", _principals())
+    chain = tmp_path / "runtime" / "chain_results.json"
+    authority_state = tmp_path / "runtime" / "authority_state.json"
+    socket_path = tmp_path / "runtime" / "signer.sock"
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshots,
+        principal_authority_records_path=principals,
+        signer_socket_path=socket_path,
+        signer_socket_connector=_accepted_socket_signer,
+        now_iso=NOW,
+        now_epoch=1000,
+        requested_queue_item_id="queue-1",
+        max_steps=2,
+    )
+
+    assert result.accepted is True
+    assert result.status == REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED
+    assert result.runtime_dependency_bundle_status == REDDOG_RUNTIME_DEPENDENCY_BUNDLE_READY
+    assert result.runtime_dependency_bundle_requested is True
+    assert result.steps_run == 2
+    assert result.dispatched_stages == ("authority_request", "authority_runtime")
+    assert result.next_action == "RUN_QUEUE_AUTHORITY_VERIFICATION_INVOKE"
+    assert result.no_shell_command_executed is True
+    assert result.no_openclaw_enqueue_performed is True
+
+    stored = json.loads(chain.read_text(encoding="utf-8"))
+    assert stored["stage_results"]["authority_runtime"]["decision"] == "QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT"
+    authority = json.loads(authority_state.read_text(encoding="utf-8"))
+    issued = authority["issued_authorities"]
+    assert len(issued) == 1
+    assert next(iter(issued.values()))["status"] == "DELEGATED_AUTHORITY_ISSUED"
+
+
 def test_bootstrap_rejects_missing_authority_profile(tmp_path: Path) -> None:
     repo = _repo(tmp_path)
     state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
@@ -301,6 +373,9 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
                 "REDDOG_AUTHORITY_RUNTIME_STATE_PATH": str(tmp_path / "authority_state.json"),
                 "REDDOG_PERMISSION_SNAPSHOTS_PATH": str(tmp_path / "snapshots.json"),
                 "REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH": str(tmp_path / "principals.json"),
+                "REDDOG_SIGNER_SOCKET_PATH": str(tmp_path / "signer.sock"),
+                "REDDOG_SIGNER_SOCKET_TIMEOUT_S": "2.5",
+                "REDDOG_SIGNER_SOCKET_MAX_RESPONSE_BYTES": "8192",
                 "REDDOG_RESIDENT_QUEUE_NOW_EPOCH": "1000",
                 "REDDOG_WRE_QUEUE_ITEM_ID": "queue-1",
             },
@@ -314,6 +389,9 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
     assert mocked.call_args.kwargs["authority_state_path"] == str(tmp_path / "authority_state.json")
     assert mocked.call_args.kwargs["permission_snapshots_path"] == str(tmp_path / "snapshots.json")
     assert mocked.call_args.kwargs["principal_authority_records_path"] == str(tmp_path / "principals.json")
+    assert mocked.call_args.kwargs["signer_socket_path"] == str(tmp_path / "signer.sock")
+    assert mocked.call_args.kwargs["signer_socket_timeout_s"] == 2.5
+    assert mocked.call_args.kwargs["signer_socket_max_response_bytes"] == 8192
     assert mocked.call_args.kwargs["requested_queue_item_id"] == "queue-1"
     assert mocked.call_args.kwargs["now_epoch"] == 1000
     assert mocked.call_args.kwargs["max_steps"] == 1


### PR DESCRIPTION
## Summary
- wires the merged isolated signer socket client into the resident queue runtime dependency bundle behind explicit outside-repo socket configuration
- threads `REDDOG_SIGNER_SOCKET_PATH`, timeout, and response-size env settings through the off-by-default main.py resident serial-loop preflight
- preserves fail-closed default signer behavior when no socket path is configured

## WSP_97 Evidence
- focused tests: `22 passed` for runtime bundle, serial-loop bootstrap, and socket client
- wider resident/signing subset: `111 passed`
- `git diff --check` clean; diff-added lines ASCII-clean
- HoloIndex read-only probe did not rank this new wiring: `HOLOINDEX_REDDOG_MAIN_RESIDENT_QUEUE_SIGNER_SOCKET_CLIENT_BUNDLE_INDEX_GAP_PHASE1`

## Truth Boundary
- no signer daemon is spawned
- no private key or vault secret is loaded
- no shell command is executed
- no OpenClaw enqueue, Hermes dispatch, worktree creation, PR publish, reward settlement, repo mutation, or HoloIndex runtime re-index is performed
- socket signer output can issue signed delegated authority records only through the existing authority runtime; execution remains downstream-gated