### PR TITLE
feat(reddog): add isolated signer socket protocol

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,29 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_ISOLATED_SIGNER_SOCKET_PROTOCOL_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 71, 97
+
+- Added `src/reddog_isolated_signer_socket_protocol.py`: a fail-closed
+  signer-side protocol core for the isolated signer socket client. It parses a
+  bounded client request, binds requester identity to an out-of-band peer
+  attestation, invokes an injected signing backend, and serializes an existing
+  `SigningResponse`.
+- Added tests proving accepted backend responses, default fail-closed backend,
+  malformed/schema/oversized request rejection, peer-spoof rejection before
+  backend invocation, peer-attestation rejection, non-ASCII rejection, backend
+  exception rejection, invalid accepted-response rejection, and AST denial of
+  socket/subprocess/env/HoloIndex/crypto/vault/key-loading imports.
+- Boundary: protocol core only. No socket is bound, no signer process is
+  spawned, no kernel peer credential is discovered, no private key or vault
+  secret is loaded, no shell command is executed, no repository file is
+  mutated, and no HoloIndex runtime re-index is performed.
+- HoloIndex read-only probe for `RedDog isolated signer service runtime socket
+  signing backend` surfaced signature-verifier/signed-receipt code and the E0
+  contract, but no signer-side protocol module before indexing. Recorded as
+  `HOLOINDEX_REDDOG_ISOLATED_SIGNER_SOCKET_PROTOCOL_INDEX_GAP_PHASE1`; no
+  runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_SIGNER_SOCKET_CLIENT_BUNDLE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 71, 97

--- a/modules/communication/moltbot_bridge/src/reddog_isolated_signer_socket_protocol.py
+++ b/modules/communication/moltbot_bridge/src/reddog_isolated_signer_socket_protocol.py
@@ -1,0 +1,220 @@
+"""Fail-closed protocol core for an isolated RedDog signer socket service.
+
+Slice: REDDOG_ISOLATED_SIGNER_SOCKET_PROTOCOL_PHASE1
+
+This module implements the signer-side JSON protocol used by
+``reddog_isolated_signer_socket_client``. It parses one request, binds it to an
+already-attested peer identity, calls an injected signing backend, and serializes
+a bounded ``SigningResponse``.
+
+It does not bind a socket, discover kernel peer credentials, spawn a process,
+load private keys or vault secrets, execute shell commands, mutate repository
+files, enqueue OpenClaw, dispatch Hermes, or re-index HoloIndex. The default
+backend fails closed.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping, Optional, Protocol
+
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    FailClosedSignerClient,
+    RuntimeRejectCode,
+    SigningRequest,
+    SigningResponse,
+)
+
+
+SIGNER_SOCKET_REQUEST_SCHEMA_VERSION = "reddog_signer_socket_request.v1"
+
+REJECT_SIGNER_SOCKET_REQUEST_TOO_LARGE = "REJECT_SIGNER_SOCKET_REQUEST_TOO_LARGE"
+REJECT_SIGNER_SOCKET_REQUEST_INVALID = "REJECT_SIGNER_SOCKET_REQUEST_INVALID"
+REJECT_SIGNER_SOCKET_SCHEMA_INVALID = "REJECT_SIGNER_SOCKET_SCHEMA_INVALID"
+REJECT_SIGNER_SOCKET_PEER_MISMATCH = "REJECT_SIGNER_SOCKET_PEER_MISMATCH"
+REJECT_SIGNER_SOCKET_PEER_NOT_ATTESTED = "REJECT_SIGNER_SOCKET_PEER_NOT_ATTESTED"
+REJECT_SIGNER_SOCKET_BACKEND_EXCEPTION = "REJECT_SIGNER_SOCKET_BACKEND_EXCEPTION"
+REJECT_SIGNER_SOCKET_RESPONSE_INVALID = "REJECT_SIGNER_SOCKET_RESPONSE_INVALID"
+REJECT_SIGNER_SOCKET_NON_ASCII = "REJECT_SIGNER_SOCKET_NON_ASCII"
+
+DEFAULT_SIGNER_SOCKET_MAX_REQUEST_BYTES = 16384
+
+
+@dataclass(frozen=True)
+class SignerPeerAttestation:
+    """Peer identity supplied by the future socket daemon boundary."""
+
+    peer_principal_id: str
+    transport: str
+    credential_source: str
+    boundary_attested: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class IsolatedSignerBackend(Protocol):
+    """Injected signer backend used by the protocol core."""
+
+    def sign(self, request: SigningRequest, peer: SignerPeerAttestation) -> SigningResponse:
+        """Sign a validated request or reject fail-closed."""
+
+
+class FailClosedSignerBackend:
+    """Default backend: never signs."""
+
+    def __init__(self) -> None:
+        self._client = FailClosedSignerClient()
+
+    def sign(self, request: SigningRequest, peer: SignerPeerAttestation) -> SigningResponse:
+        return self._client.sign(request)
+
+
+def handle_reddog_isolated_signer_socket_request(
+    request_bytes: bytes,
+    *,
+    peer: SignerPeerAttestation,
+    backend: Optional[IsolatedSignerBackend] = None,
+    max_request_bytes: int = DEFAULT_SIGNER_SOCKET_MAX_REQUEST_BYTES,
+) -> bytes:
+    """Handle one signer-socket request payload.
+
+    The peer identity is intentionally supplied out-of-band. Request-body
+    ``requester_principal_id`` is audit-only and must match the attested peer.
+    """
+
+    if not isinstance(request_bytes, bytes) or len(request_bytes) > max_request_bytes:
+        return _response_bytes(_reject(REJECT_SIGNER_SOCKET_REQUEST_TOO_LARGE))
+    if not isinstance(peer, SignerPeerAttestation) or not peer.boundary_attested:
+        return _response_bytes(_reject(REJECT_SIGNER_SOCKET_PEER_NOT_ATTESTED))
+    if not _assert_ascii_deep(peer.to_dict()):
+        return _response_bytes(_reject(REJECT_SIGNER_SOCKET_NON_ASCII))
+
+    request = _parse_request(request_bytes)
+    if not isinstance(request, SigningRequest):
+        return _response_bytes(request)
+    if not _assert_ascii_deep(request.to_dict()):
+        return _response_bytes(_reject(REJECT_SIGNER_SOCKET_NON_ASCII))
+    if request.requester_principal_id != peer.peer_principal_id:
+        return _response_bytes(_reject(REJECT_SIGNER_SOCKET_PEER_MISMATCH))
+
+    signer = backend or FailClosedSignerBackend()
+    try:
+        response = signer.sign(request, peer)
+    except Exception:
+        return _response_bytes(_reject(REJECT_SIGNER_SOCKET_BACKEND_EXCEPTION))
+    if not isinstance(response, SigningResponse):
+        return _response_bytes(_reject(REJECT_SIGNER_SOCKET_RESPONSE_INVALID))
+    checked = _validate_response(response)
+    return _response_bytes(checked)
+
+
+def _parse_request(request_bytes: bytes) -> SigningRequest | SigningResponse:
+    try:
+        payload = json.loads(request_bytes.decode("utf-8").strip())
+    except Exception:
+        return _reject(REJECT_SIGNER_SOCKET_REQUEST_INVALID)
+    if not isinstance(payload, Mapping):
+        return _reject(REJECT_SIGNER_SOCKET_REQUEST_INVALID)
+    if payload.get("schema_version") != SIGNER_SOCKET_REQUEST_SCHEMA_VERSION:
+        return _reject(REJECT_SIGNER_SOCKET_SCHEMA_INVALID)
+    raw = payload.get("request")
+    if not isinstance(raw, Mapping):
+        return _reject(REJECT_SIGNER_SOCKET_REQUEST_INVALID)
+    try:
+        return SigningRequest(
+            signing_input=str(raw["signing_input"]),
+            payload_digest=str(raw["payload_digest"]),
+            signer_role=str(raw["signer_role"]),
+            signer_public_key=str(raw["signer_public_key"]),
+            requester_principal_id=str(raw["requester_principal_id"]),
+            nonce=str(raw["nonce"]),
+            key_epoch=str(raw["key_epoch"]),
+            requested_operation=str(raw["requested_operation"]),
+            authority_tier=str(raw["authority_tier"]),
+            consensus_receipt_digest=(
+                str(raw["consensus_receipt_digest"])
+                if raw.get("consensus_receipt_digest")
+                else None
+            ),
+        )
+    except Exception:
+        return _reject(REJECT_SIGNER_SOCKET_REQUEST_INVALID)
+
+
+def _validate_response(response: SigningResponse) -> SigningResponse:
+    payload = response.to_dict()
+    if not _assert_ascii_deep(payload):
+        return _reject(REJECT_SIGNER_SOCKET_NON_ASCII)
+    if response.no_secret_material_returned is not True:
+        return _reject(REJECT_SIGNER_SOCKET_RESPONSE_INVALID)
+    if response.accepted is not True:
+        return response
+    required = (
+        response.signature,
+        response.signer_public_key,
+        response.key_fingerprint,
+        response.key_epoch,
+        response.audit_mac,
+    )
+    if not all(isinstance(value, str) and value for value in required):
+        return _reject(REJECT_SIGNER_SOCKET_RESPONSE_INVALID)
+    if not (
+        response.boundary_attested
+        and response.requester_identity_attested
+        and response.signer_loads_no_untrusted_code
+    ):
+        return _reject(REJECT_SIGNER_SOCKET_RESPONSE_INVALID)
+    return response
+
+
+def _response_bytes(response: SigningResponse) -> bytes:
+    payload = response.to_dict()
+    return (
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        + "\n"
+    ).encode("utf-8")
+
+
+def _reject(code: str) -> SigningResponse:
+    return SigningResponse(
+        accepted=False,
+        rejection_code=str(code),
+        no_secret_material_returned=True,
+    )
+
+
+def _assert_ascii_deep(value: Any) -> bool:
+    if isinstance(value, str):
+        return all(ord(char) < 128 for char in value)
+    if isinstance(value, Mapping):
+        return all(
+            isinstance(key, str)
+            and all(ord(char) < 128 for char in key)
+            and _assert_ascii_deep(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple)):
+        return all(_assert_ascii_deep(item) for item in value)
+    if value is None or isinstance(value, (bool, int, float)):
+        return True
+    return False
+
+
+__all__ = [
+    "DEFAULT_SIGNER_SOCKET_MAX_REQUEST_BYTES",
+    "FailClosedSignerBackend",
+    "IsolatedSignerBackend",
+    "REJECT_SIGNER_SOCKET_BACKEND_EXCEPTION",
+    "REJECT_SIGNER_SOCKET_NON_ASCII",
+    "REJECT_SIGNER_SOCKET_PEER_MISMATCH",
+    "REJECT_SIGNER_SOCKET_PEER_NOT_ATTESTED",
+    "REJECT_SIGNER_SOCKET_REQUEST_INVALID",
+    "REJECT_SIGNER_SOCKET_REQUEST_TOO_LARGE",
+    "REJECT_SIGNER_SOCKET_RESPONSE_INVALID",
+    "REJECT_SIGNER_SOCKET_SCHEMA_INVALID",
+    "SIGNER_SOCKET_REQUEST_SCHEMA_VERSION",
+    "SignerPeerAttestation",
+    "handle_reddog_isolated_signer_socket_request",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_isolated_signer_socket_protocol.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_isolated_signer_socket_protocol.py
@@ -1,0 +1,287 @@
+"""Tests for REDDOG_ISOLATED_SIGNER_SOCKET_PROTOCOL_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_protocol import (
+    REJECT_SIGNER_SOCKET_BACKEND_EXCEPTION,
+    REJECT_SIGNER_SOCKET_NON_ASCII,
+    REJECT_SIGNER_SOCKET_PEER_MISMATCH,
+    REJECT_SIGNER_SOCKET_PEER_NOT_ATTESTED,
+    REJECT_SIGNER_SOCKET_REQUEST_INVALID,
+    REJECT_SIGNER_SOCKET_REQUEST_TOO_LARGE,
+    REJECT_SIGNER_SOCKET_RESPONSE_INVALID,
+    REJECT_SIGNER_SOCKET_SCHEMA_INVALID,
+    SIGNER_SOCKET_REQUEST_SCHEMA_VERSION,
+    SignerPeerAttestation,
+    handle_reddog_isolated_signer_socket_request,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    RuntimeRejectCode,
+    SigningRequest,
+    SigningResponse,
+    public_key_fingerprint,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_isolated_signer_socket_protocol.py"
+)
+
+
+class AcceptingBackend:
+    def __init__(self) -> None:
+        self.requests: list[tuple[SigningRequest, SignerPeerAttestation]] = []
+
+    def sign(self, request: SigningRequest, peer: SignerPeerAttestation) -> SigningResponse:
+        self.requests.append((request, peer))
+        return SigningResponse(
+            accepted=True,
+            signature="sig:" + request.nonce,
+            signer_public_key=request.signer_public_key,
+            key_fingerprint=public_key_fingerprint(request.signer_public_key),
+            key_epoch=request.key_epoch,
+            audit_mac="audit:" + request.payload_digest,
+            boundary_attested=True,
+            requester_identity_attested=True,
+            signer_loads_no_untrusted_code=True,
+            no_secret_material_returned=True,
+        )
+
+
+class RaisingBackend:
+    def sign(self, request: SigningRequest, peer: SignerPeerAttestation) -> SigningResponse:
+        raise RuntimeError("boom")
+
+
+class InvalidBackend:
+    def sign(self, request: SigningRequest, peer: SignerPeerAttestation) -> SigningResponse:
+        return SigningResponse(
+            accepted=True,
+            signature="sig",
+            signer_public_key=request.signer_public_key,
+            key_fingerprint=public_key_fingerprint(request.signer_public_key),
+            key_epoch=request.key_epoch,
+            audit_mac="audit",
+            boundary_attested=True,
+            requester_identity_attested=True,
+            signer_loads_no_untrusted_code=True,
+            no_secret_material_returned=False,
+        )
+
+
+def _peer(**overrides: object) -> SignerPeerAttestation:
+    payload = {
+        "peer_principal_id": "github:mjtrout",
+        "transport": "unix_socket",
+        "credential_source": "kernel_peer_credential",
+        "boundary_attested": True,
+    }
+    payload.update(overrides)
+    return SignerPeerAttestation(**payload)
+
+
+def _request_payload(**overrides: object) -> bytes:
+    request = {
+        "signing_input": "reddog-workauth.v1.{}",
+        "payload_digest": "sha256:payload",
+        "signer_role": "reddog",
+        "signer_public_key": "pub:reddog",
+        "requester_principal_id": "github:mjtrout",
+        "nonce": "workauth-nonce-0001",
+        "key_epoch": "epoch-1",
+        "requested_operation": "create_foundup",
+        "authority_tier": "HIGH",
+        "consensus_receipt_digest": "sha256:consensus",
+    }
+    request.update(overrides)
+    payload = {
+        "schema_version": SIGNER_SOCKET_REQUEST_SCHEMA_VERSION,
+        "request": request,
+    }
+    return (json.dumps(payload, sort_keys=True) + "\n").encode("utf-8")
+
+
+def _decode(response: bytes) -> dict[str, object]:
+    decoded = json.loads(response.decode("utf-8"))
+    assert isinstance(decoded, dict)
+    return decoded
+
+
+def test_protocol_accepts_attested_peer_and_backend_response() -> None:
+    backend = AcceptingBackend()
+
+    response = _decode(
+        handle_reddog_isolated_signer_socket_request(
+            _request_payload(),
+            peer=_peer(),
+            backend=backend,
+        )
+    )
+
+    assert response["accepted"] is True
+    assert response["signature"] == "sig:workauth-nonce-0001"
+    assert response["signer_public_key"] == "pub:reddog"
+    assert response["no_secret_material_returned"] is True
+    assert len(backend.requests) == 1
+    assert backend.requests[0][1].peer_principal_id == "github:mjtrout"
+
+
+def test_protocol_default_backend_fails_closed() -> None:
+    response = _decode(
+        handle_reddog_isolated_signer_socket_request(
+            _request_payload(),
+            peer=_peer(),
+        )
+    )
+
+    assert response["accepted"] is False
+    assert response["rejection_code"] == RuntimeRejectCode.SIGNER_NOT_CONFIGURED
+
+
+def test_protocol_rejects_malformed_schema_and_oversized_request() -> None:
+    malformed = _decode(
+        handle_reddog_isolated_signer_socket_request(b"{", peer=_peer(), backend=AcceptingBackend())
+    )
+    wrong_schema = _decode(
+        handle_reddog_isolated_signer_socket_request(
+            json.dumps({"schema_version": "wrong", "request": {}}).encode("utf-8"),
+            peer=_peer(),
+            backend=AcceptingBackend(),
+        )
+    )
+    too_large = _decode(
+        handle_reddog_isolated_signer_socket_request(
+            b"x" * 20,
+            peer=_peer(),
+            backend=AcceptingBackend(),
+            max_request_bytes=8,
+        )
+    )
+
+    assert malformed["rejection_code"] == REJECT_SIGNER_SOCKET_REQUEST_INVALID
+    assert wrong_schema["rejection_code"] == REJECT_SIGNER_SOCKET_SCHEMA_INVALID
+    assert too_large["rejection_code"] == REJECT_SIGNER_SOCKET_REQUEST_TOO_LARGE
+
+
+def test_protocol_rejects_peer_spoofing_before_backend() -> None:
+    backend = AcceptingBackend()
+
+    response = _decode(
+        handle_reddog_isolated_signer_socket_request(
+            _request_payload(requester_principal_id="github:attacker"),
+            peer=_peer(peer_principal_id="github:mjtrout"),
+            backend=backend,
+        )
+    )
+
+    assert response["accepted"] is False
+    assert response["rejection_code"] == REJECT_SIGNER_SOCKET_PEER_MISMATCH
+    assert backend.requests == []
+
+
+def test_protocol_requires_peer_boundary_attestation() -> None:
+    response = _decode(
+        handle_reddog_isolated_signer_socket_request(
+            _request_payload(),
+            peer=_peer(boundary_attested=False),
+            backend=AcceptingBackend(),
+        )
+    )
+
+    assert response["accepted"] is False
+    assert response["rejection_code"] == REJECT_SIGNER_SOCKET_PEER_NOT_ATTESTED
+
+
+def test_protocol_rejects_non_ascii_request_or_peer() -> None:
+    bad_request = _decode(
+        handle_reddog_isolated_signer_socket_request(
+            _request_payload(nonce="nonce-\u2603"),
+            peer=_peer(),
+            backend=AcceptingBackend(),
+        )
+    )
+    bad_peer = _decode(
+        handle_reddog_isolated_signer_socket_request(
+            _request_payload(),
+            peer=_peer(peer_principal_id="github:\u2603"),
+            backend=AcceptingBackend(),
+        )
+    )
+
+    assert bad_request["rejection_code"] == REJECT_SIGNER_SOCKET_NON_ASCII
+    assert bad_peer["rejection_code"] == REJECT_SIGNER_SOCKET_NON_ASCII
+
+
+def test_protocol_rejects_backend_exception_or_invalid_accepted_response() -> None:
+    failed = _decode(
+        handle_reddog_isolated_signer_socket_request(
+            _request_payload(),
+            peer=_peer(),
+            backend=RaisingBackend(),
+        )
+    )
+    invalid = _decode(
+        handle_reddog_isolated_signer_socket_request(
+            _request_payload(),
+            peer=_peer(),
+            backend=InvalidBackend(),
+        )
+    )
+
+    assert failed["rejection_code"] == REJECT_SIGNER_SOCKET_BACKEND_EXCEPTION
+    assert invalid["rejection_code"] == REJECT_SIGNER_SOCKET_RESPONSE_INVALID
+
+
+def test_protocol_has_no_socket_subprocess_env_holoindex_or_private_key_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "socket",
+        "os",
+        "requests",
+        "urllib",
+        "http",
+        "holo_index",
+        "git",
+        "secrets",
+        "hmac",
+        "cryptography",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    banned_attrs = {
+        "system",
+        "popen",
+        "spawn",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "getenv",
+        "environ",
+        "open",
+        "unlink",
+        "remove",
+        "replace",
+        "rename",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs


### PR DESCRIPTION
## Summary
- adds a signer-side protocol core for the isolated RedDog signer socket path
- binds request-body `requester_principal_id` to an out-of-band peer attestation before any backend can sign
- defaults to a fail-closed backend; real key custody, socket binding, and peer credential discovery remain future slices

## WSP_97 Evidence
- focused tests: `27 passed` for protocol, socket client, and signer runtime
- wider signing/resident subset: `57 passed`
- `git diff --check` clean; new files ASCII/NUL clean
- HoloIndex read-only probe did not rank this new protocol module: `HOLOINDEX_REDDOG_ISOLATED_SIGNER_SOCKET_PROTOCOL_INDEX_GAP_PHASE1`

## Truth Boundary
- no socket is bound and no daemon is started
- no private key or vault secret is loaded
- no command is executed
- no OpenClaw enqueue, Hermes dispatch, worktree creation, PR publish, repo mutation, reward settlement, or HoloIndex runtime re-index is performed
- this is protocol core only; production signer custody remains blocked