### PR TITLE
feat(reddog): add Ed25519 signature verifier backend

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,28 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_ED25519_SIGNATURE_VERIFIER_BACKEND_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 71, 97
+
+- Added `src/reddog_ed25519_signature_verifier_backend.py`: an optional
+  injected `SignatureVerifier` backend for RedDog work-order authority records.
+  It verifies self-describing `ed25519-pub-v1:` public keys and
+  `ed25519-sig-v1:` signatures using public material only.
+- Added tests proving valid Ed25519 verification, tamper/key/signature
+  rejection, malformed/non-ASCII rejection, strict encode/decode helpers,
+  oversized signing-input rejection, and AST denial of signer/keygen/shell/env/
+  network/HoloIndex/runtime mutation imports.
+- Boundary: verifier backend only. No signing, key generation, private-key
+  loading, vault access, signer daemon startup, command execution, repository
+  mutation, OpenClaw enqueue, Hermes dispatch, or HoloIndex runtime re-index.
+  The backend fails closed if `cryptography` is unavailable or verification
+  raises.
+- HoloIndex read-only probe for `RedDog work order signature verifier
+  cryptographic backend Ed25519` surfaced the core verifier and contracts, but
+  not this backend before indexing. Recorded as
+  `HOLOINDEX_REDDOG_ED25519_SIGNATURE_VERIFIER_BACKEND_INDEX_GAP_PHASE1`; no
+  runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_ISOLATED_SIGNER_SOCKET_PROTOCOL_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 71, 97

--- a/modules/communication/moltbot_bridge/src/reddog_ed25519_signature_verifier_backend.py
+++ b/modules/communication/moltbot_bridge/src/reddog_ed25519_signature_verifier_backend.py
@@ -1,0 +1,116 @@
+"""Ed25519 public signature verifier backend for RedDog authority records.
+
+Slice: REDDOG_ED25519_SIGNATURE_VERIFIER_BACKEND_PHASE1
+
+This module supplies an optional injected ``SignatureVerifier`` backend for
+``reddog_work_order_signature_verifier``. It verifies Ed25519 signatures using
+public key material only. It does not sign, generate keys, load private keys or
+vault secrets, execute work, mutate repository files, enqueue OpenClaw, dispatch
+Hermes, or re-index HoloIndex.
+
+The dependency on ``cryptography`` is imported lazily inside ``verify``. If the
+package is unavailable, malformed, or verification fails, the backend returns
+False fail-closed.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from typing import Optional
+
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    SignatureVerifier,
+)
+
+
+ED25519_PUBLIC_KEY_PREFIX = "ed25519-pub-v1:"
+ED25519_SIGNATURE_PREFIX = "ed25519-sig-v1:"
+ED25519_PUBLIC_KEY_BYTES = 32
+ED25519_SIGNATURE_BYTES = 64
+MAX_SIGNING_INPUT_BYTES = 65536
+
+
+class Ed25519SignatureVerifier(SignatureVerifier):
+    """Verify Ed25519 signatures using public key material only."""
+
+    def verify(self, public_key: str, signing_input: str, signature: str) -> bool:
+        if not _is_ascii(public_key) or not _is_ascii(signing_input) or not _is_ascii(signature):
+            return False
+        if len(signing_input.encode("utf-8")) > MAX_SIGNING_INPUT_BYTES:
+            return False
+        public_key_bytes = decode_ed25519_public_key(public_key)
+        signature_bytes = decode_ed25519_signature(signature)
+        if public_key_bytes is None or signature_bytes is None:
+            return False
+        try:
+            from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+            Ed25519PublicKey.from_public_bytes(public_key_bytes).verify(
+                signature_bytes,
+                signing_input.encode("utf-8"),
+            )
+            return True
+        except Exception:
+            return False
+
+
+def encode_ed25519_public_key(public_key_bytes: bytes) -> str:
+    """Encode 32 public key bytes into the contract's self-describing text form."""
+
+    if not isinstance(public_key_bytes, bytes) or len(public_key_bytes) != ED25519_PUBLIC_KEY_BYTES:
+        raise ValueError("Ed25519 public key must be 32 bytes")
+    return ED25519_PUBLIC_KEY_PREFIX + _b64url_no_padding(public_key_bytes)
+
+
+def encode_ed25519_signature(signature_bytes: bytes) -> str:
+    """Encode 64 signature bytes into the contract's self-describing text form."""
+
+    if not isinstance(signature_bytes, bytes) or len(signature_bytes) != ED25519_SIGNATURE_BYTES:
+        raise ValueError("Ed25519 signature must be 64 bytes")
+    return ED25519_SIGNATURE_PREFIX + _b64url_no_padding(signature_bytes)
+
+
+def decode_ed25519_public_key(value: str) -> Optional[bytes]:
+    if not _is_ascii(value) or not value.startswith(ED25519_PUBLIC_KEY_PREFIX):
+        return None
+    return _decode_with_size(value[len(ED25519_PUBLIC_KEY_PREFIX) :], ED25519_PUBLIC_KEY_BYTES)
+
+
+def decode_ed25519_signature(value: str) -> Optional[bytes]:
+    if not _is_ascii(value) or not value.startswith(ED25519_SIGNATURE_PREFIX):
+        return None
+    return _decode_with_size(value[len(ED25519_SIGNATURE_PREFIX) :], ED25519_SIGNATURE_BYTES)
+
+
+def _decode_with_size(value: str, expected_size: int) -> Optional[bytes]:
+    if not value or not _is_ascii(value):
+        return None
+    try:
+        decoded = base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+    except (binascii.Error, ValueError):
+        return None
+    if len(decoded) != expected_size:
+        return None
+    return decoded
+
+
+def _b64url_no_padding(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _is_ascii(value: object) -> bool:
+    return isinstance(value, str) and all(ord(char) < 128 for char in value)
+
+
+__all__ = [
+    "ED25519_PUBLIC_KEY_BYTES",
+    "ED25519_PUBLIC_KEY_PREFIX",
+    "ED25519_SIGNATURE_BYTES",
+    "ED25519_SIGNATURE_PREFIX",
+    "Ed25519SignatureVerifier",
+    "decode_ed25519_public_key",
+    "decode_ed25519_signature",
+    "encode_ed25519_public_key",
+    "encode_ed25519_signature",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_ed25519_signature_verifier_backend.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_ed25519_signature_verifier_backend.py
@@ -1,0 +1,147 @@
+"""Tests for REDDOG_ED25519_SIGNATURE_VERIFIER_BACKEND_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    ED25519_PUBLIC_KEY_PREFIX,
+    ED25519_SIGNATURE_PREFIX,
+    Ed25519SignatureVerifier,
+    decode_ed25519_public_key,
+    decode_ed25519_signature,
+    encode_ed25519_public_key,
+    encode_ed25519_signature,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_ed25519_signature_verifier_backend.py"
+)
+
+
+cryptography = pytest.importorskip("cryptography")
+
+
+def _keypair() -> tuple[str, str, str]:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    private_key = Ed25519PrivateKey.generate()
+    public_key = private_key.public_key()
+    public_bytes = public_key.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    signing_input = 'reddog-workauth.v1.{"work_order_id":"wo-1"}'
+    signature = private_key.sign(signing_input.encode("utf-8"))
+    return (
+        encode_ed25519_public_key(public_bytes),
+        signing_input,
+        encode_ed25519_signature(signature),
+    )
+
+
+def test_ed25519_verifier_accepts_valid_signature() -> None:
+    public_key, signing_input, signature = _keypair()
+
+    assert Ed25519SignatureVerifier().verify(public_key, signing_input, signature) is True
+    assert public_key.startswith(ED25519_PUBLIC_KEY_PREFIX)
+    assert signature.startswith(ED25519_SIGNATURE_PREFIX)
+
+
+def test_ed25519_verifier_rejects_tampered_input_signature_or_key() -> None:
+    public_key, signing_input, signature = _keypair()
+    other_public_key, _, other_signature = _keypair()
+    verifier = Ed25519SignatureVerifier()
+
+    assert verifier.verify(public_key, signing_input + "x", signature) is False
+    assert verifier.verify(public_key, signing_input, other_signature) is False
+    assert verifier.verify(other_public_key, signing_input, signature) is False
+
+
+def test_ed25519_verifier_rejects_malformed_or_non_ascii_inputs() -> None:
+    public_key, signing_input, signature = _keypair()
+    verifier = Ed25519SignatureVerifier()
+
+    assert verifier.verify("not-a-key", signing_input, signature) is False
+    assert verifier.verify(public_key, signing_input, "not-a-signature") is False
+    assert verifier.verify(public_key + "\u2603", signing_input, signature) is False
+    assert verifier.verify(public_key, signing_input + "\u2603", signature) is False
+
+
+def test_ed25519_encode_decode_helpers_are_strict() -> None:
+    public_key, _, signature = _keypair()
+
+    assert decode_ed25519_public_key(public_key) is not None
+    assert decode_ed25519_signature(signature) is not None
+    assert decode_ed25519_public_key(public_key[:-2]) is None
+    assert decode_ed25519_signature(signature[:-2]) is None
+
+    with pytest.raises(ValueError):
+        encode_ed25519_public_key(b"short")
+    with pytest.raises(ValueError):
+        encode_ed25519_signature(b"short")
+
+
+def test_ed25519_verifier_rejects_oversized_signing_input() -> None:
+    public_key, _, signature = _keypair()
+
+    assert Ed25519SignatureVerifier().verify(public_key, "x" * 70000, signature) is False
+
+
+def test_backend_module_does_not_sign_generate_keys_or_touch_runtime_surfaces() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "socket",
+        "os",
+        "requests",
+        "urllib",
+        "http",
+        "holo_index",
+        "git",
+        "secrets",
+    }
+    banned_calls = {
+        "eval",
+        "exec",
+        "compile",
+        "__import__",
+        "generate",
+        "from_private_bytes",
+    }
+    banned_attrs = {
+        "system",
+        "popen",
+        "spawn",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "getenv",
+        "environ",
+        "sign",
+        "private_bytes",
+    }
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs


### PR DESCRIPTION
## Summary
- adds an optional Ed25519 public signature verifier backend for RedDog delegated work authority verification
- uses self-describing `ed25519-pub-v1:` and `ed25519-sig-v1:` text forms
- keeps the core verifier unchanged and fail-closed unless this backend is injected

## WSP_97 Evidence
- verifier/backend focused tests: `39 passed`
- broader signing/resident subset: `105 passed`
- `git diff --check` clean; new files ASCII/NUL clean
- HoloIndex read-only probe did not rank this backend: `HOLOINDEX_REDDOG_ED25519_SIGNATURE_VERIFIER_BACKEND_INDEX_GAP_PHASE1`

## Truth Boundary
- verifier only: no signing and no key generation in production code
- no private key or vault access
- no command execution, repo mutation, OpenClaw enqueue, Hermes dispatch, PR publish, reward settlement, or HoloIndex runtime re-index
- `cryptography` is imported lazily in `verify`; if unavailable or verification raises, the backend returns False fail-closed