### PR TITLE
feat(reddog): wire ed25519 authority verification bundle

### DIFF
--- a/main.py
+++ b/main.py
@@ -1536,6 +1536,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
         REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH         Outside-repo authority profile JSON
         REDDOG_WRE_QUEUE_ITEM_ID                             Optional exact queue item id
         REDDOG_SIGNER_SOCKET_PATH                            Optional outside-repo isolated signer socket
+        REDDOG_SIGNATURE_VERIFIER_BACKEND                    Optional verifier backend (`ed25519`)
     """
 
     if os.getenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP", "0") == "0":
@@ -1579,6 +1580,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             signer_socket_path=os.getenv("REDDOG_SIGNER_SOCKET_PATH", "") or None,
             signer_socket_timeout_s=signer_socket_timeout_s,
             signer_socket_max_response_bytes=signer_socket_max_response_bytes,
+            signature_verifier_backend=os.getenv("REDDOG_SIGNATURE_VERIFIER_BACKEND", "") or None,
             requested_queue_item_id=os.getenv("REDDOG_WRE_QUEUE_ITEM_ID", "") or None,
             now_epoch=now_epoch,
             max_steps=max_steps,

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,29 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_RESIDENT_QUEUE_ED25519_VERIFICATION_BUNDLE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 71, 97
+
+- Extended the `main.py` resident serial-loop dependency bundle so an explicit
+  `REDDOG_SIGNATURE_VERIFIER_BACKEND=ed25519` setting wires the public
+  `Ed25519SignatureVerifier`, token-verified principal key resolver, durable
+  outside-repo work-authority nonce consumption, and authority-state revocation
+  oracle into the `authority_verification` stage.
+- Added tests proving default verification remains unregistered, explicit
+  Ed25519 verification advances the serial loop through
+  `authority_verification`, work-authority nonce replay is durably rejected,
+  revocations are read from the authority runtime state, unsupported verifier
+  backends reject, and `main.py` passes the verifier backend setting through.
+- Boundary: public verification wiring only. No private key loading, no key
+  generation, no signer spawn, no shell command, no worktree, no OpenClaw
+  enqueue, no Hermes dispatch, no PR publication, no repository mutation, and
+  no HoloIndex runtime re-index.
+- HoloIndex read-only probe for `RedDog resident queue Ed25519 verification
+  backend bundle signature verifier` surfaced the core verifier and adjacent
+  docs, but not this new bundle wiring before indexing. Recorded as
+  `HOLOINDEX_REDDOG_RESIDENT_QUEUE_ED25519_VERIFICATION_BUNDLE_INDEX_GAP_PHASE1`;
+  no runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_ED25519_SIGNER_BACKEND_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 71, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_runtime_dependency_bundle.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_runtime_dependency_bundle.py
@@ -2,12 +2,12 @@
 
 Slice: REDDOG_MAIN_RESIDENT_QUEUE_RUNTIME_DEPENDENCY_BUNDLE_PHASE1
 
-This module constructs only the authority-runtime dependencies that ``main.py``
-may safely own today: outside-repo JSON stores/resolvers and an optional client
-for an already-running isolated signer. It does not load private keys, spawn a
-signer, verify signatures, create worktrees, run shell commands, enqueue
-OpenClaw, dispatch Hermes, publish PRs, mutate repository files, or re-index
-HoloIndex.
+This module constructs only the queue dependencies that ``main.py`` may safely
+own today: outside-repo JSON stores/resolvers, an optional client for an
+already-running isolated signer, and an optional public-key signature verifier.
+It does not load private keys, spawn a signer, create worktrees, run shell
+commands, enqueue OpenClaw, dispatch Hermes, publish PRs, mutate repository
+files, or re-index HoloIndex.
 """
 
 from __future__ import annotations
@@ -19,6 +19,7 @@ from typing import Any, Mapping, Optional
 
 from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
     AtomicJsonAuthorityRuntimeStore,
+    AuthorityRuntimeStore,
     FailClosedPrincipalAuthorityResolver,
     FailClosedSignerClient,
     PrincipalAuthorityRecord,
@@ -34,6 +35,7 @@ from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifi
 )
 
 
+REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519 = "ed25519"
 REDDOG_RUNTIME_DEPENDENCY_BUNDLE_READY = "REDDOG_RUNTIME_DEPENDENCY_BUNDLE_READY"
 REDDOG_RUNTIME_DEPENDENCY_BUNDLE_NOT_REQUESTED = "REDDOG_RUNTIME_DEPENDENCY_BUNDLE_NOT_REQUESTED"
 REDDOG_RUNTIME_DEPENDENCY_BUNDLE_REJECT = "REDDOG_RUNTIME_DEPENDENCY_BUNDLE_REJECT"
@@ -49,6 +51,17 @@ class JsonPrincipalAuthorityResolver:
         return self._records.get(_principal_key(principal_id, principal_provider))
 
 
+class JsonPrincipalKeyResolver:
+    """Resolve token-verified principal public keys for signature verification."""
+
+    def __init__(self, records: Mapping[str, PrincipalAuthorityRecord]) -> None:
+        self._records = dict(records)
+
+    def resolve(self, principal_id: str, principal_provider: str) -> Optional[str]:
+        record = self._records.get(_principal_key(principal_id, principal_provider))
+        return record.principal_public_key if record is not None else None
+
+
 class JsonPermissionSnapshotResolver:
     """Resolve permission snapshots from a caller-owned JSON snapshot."""
 
@@ -57,6 +70,48 @@ class JsonPermissionSnapshotResolver:
 
     def resolve(self, digest: str) -> Optional[PermissionSnapshot]:
         return self._snapshots.get(str(digest))
+
+
+class AuthorityRuntimeWorkAuthorityNonceStore:
+    """Durably consume work-authority nonces in the outside-repo authority state."""
+
+    def __init__(self, store: AuthorityRuntimeStore) -> None:
+        self._store = store
+
+    def consume(self, nonce: str) -> bool:
+        if not isinstance(nonce, str) or not nonce.strip():
+            return False
+        state = self._store.load()
+        seen = state.get("verified_work_authority_nonces", [])
+        if not isinstance(seen, list):
+            return False
+        if nonce in set(map(str, seen)):
+            return False
+        updated = dict(state)
+        updated["verified_work_authority_nonces"] = [*seen, nonce]
+        self._store.commit(updated, expected_revision=state.get("revision"))
+        return True
+
+
+class AuthorityRuntimeRevocationOracle:
+    """Read revocation lists from the outside-repo authority runtime state."""
+
+    def __init__(self, store: AuthorityRuntimeStore) -> None:
+        self._store = store
+
+    def is_revoked(
+        self, *, reddog_id: str, fingerprint: str, principal_id: str, key_epoch: str
+    ) -> bool:
+        state = self._store.load()
+        revocations = state.get("revocations", {})
+        if not isinstance(revocations, Mapping):
+            return True
+        return (
+            principal_id in set(map(str, revocations.get("principal_ids", [])))
+            or reddog_id in set(map(str, revocations.get("reddog_ids", [])))
+            or fingerprint in set(map(str, revocations.get("reddog_fingerprints", [])))
+            or key_epoch in set(map(str, revocations.get("key_epochs", [])))
+        )
 
 
 @dataclass(frozen=True)
@@ -71,12 +126,18 @@ class RedDogMainResidentQueueRuntimeDependencyBundle:
     signer: Any = None
     principal_resolver: Any = None
     snapshot_resolver: Any = None
+    signature_verifier: Any = None
+    principal_key_resolver: Any = None
+    nonce_store: Any = None
+    revocation_oracle: Any = None
     now_epoch: Optional[int] = None
     authority_state_path: Optional[str] = None
     signer_socket_path: Optional[str] = None
+    signature_verifier_backend: str = "none"
     permission_snapshots_loaded: int = 0
     principal_records_loaded: int = 0
     signer_mode: str = "none"
+    signature_verifier_mode: str = "none"
     no_real_signer_configured: bool = True
     no_private_key_loaded: bool = True
     no_signature_verification_performed: bool = True
@@ -101,6 +162,7 @@ def load_reddog_main_resident_queue_runtime_dependency_bundle(
     signer_socket_timeout_s: float = DEFAULT_SIGNER_SOCKET_TIMEOUT_S,
     signer_socket_max_response_bytes: int = DEFAULT_SIGNER_SOCKET_MAX_RESPONSE_BYTES,
     signer_socket_connector: Optional[SignerSocketConnector] = None,
+    signature_verifier_backend: str | None = None,
     now_epoch: int | None = None,
 ) -> RedDogMainResidentQueueRuntimeDependencyBundle:
     """Load safe queue-loop dependencies from outside-repo runtime artifacts."""
@@ -111,6 +173,7 @@ def load_reddog_main_resident_queue_runtime_dependency_bundle(
             permission_snapshots_path
             or principal_authority_records_path
             or signer_socket_path
+            or signature_verifier_backend
             or now_epoch is not None
         ):
             return _reject("runtime_dependency_bundle_partial_configuration")
@@ -140,6 +203,7 @@ def load_reddog_main_resident_queue_runtime_dependency_bundle(
     if principal_reasons:
         return _reject(*principal_reasons)
 
+    authority_store = AtomicJsonAuthorityRuntimeStore(authority_path)
     signer = FailClosedSignerClient()
     signer_mode = "fail_closed"
     signer_socket_resolved: Optional[str] = None
@@ -159,12 +223,28 @@ def load_reddog_main_resident_queue_runtime_dependency_bundle(
         signer_socket_resolved = signer_result.socket_path
         no_real_signer_configured = False
 
+    (
+        signature_verifier,
+        principal_key_resolver,
+        nonce_store,
+        revocation_oracle,
+        verifier_mode,
+        verifier_backend,
+        verifier_reasons,
+    ) = _build_signature_verification_dependencies(
+        backend=signature_verifier_backend,
+        authority_store=authority_store,
+        principals=principals,
+    )
+    if verifier_reasons:
+        return _reject(*verifier_reasons)
+
     return RedDogMainResidentQueueRuntimeDependencyBundle(
         accepted=True,
         status=REDDOG_RUNTIME_DEPENDENCY_BUNDLE_READY,
         requested=True,
         rejection_reasons=(),
-        authority_store=AtomicJsonAuthorityRuntimeStore(authority_path),
+        authority_store=authority_store,
         signer=signer,
         principal_resolver=(
             JsonPrincipalAuthorityResolver(principals)
@@ -172,12 +252,18 @@ def load_reddog_main_resident_queue_runtime_dependency_bundle(
             else FailClosedPrincipalAuthorityResolver()
         ),
         snapshot_resolver=JsonPermissionSnapshotResolver(snapshots),
+        signature_verifier=signature_verifier,
+        principal_key_resolver=principal_key_resolver,
+        nonce_store=nonce_store,
+        revocation_oracle=revocation_oracle,
         now_epoch=now_epoch,
         authority_state_path=str(authority_path),
         signer_socket_path=signer_socket_resolved,
+        signature_verifier_backend=verifier_backend,
         permission_snapshots_loaded=len(snapshots),
         principal_records_loaded=len(principals),
         signer_mode=signer_mode,
+        signature_verifier_mode=verifier_mode,
         no_real_signer_configured=no_real_signer_configured,
     )
 
@@ -323,6 +409,36 @@ def _load_principal_records(
     return records, ()
 
 
+def _build_signature_verification_dependencies(
+    *,
+    backend: str | None,
+    authority_store: AuthorityRuntimeStore,
+    principals: Mapping[str, PrincipalAuthorityRecord],
+) -> tuple[Any, Any, Any, Any, str, str, tuple[str, ...]]:
+    requested = str(backend or "").strip().lower()
+    if not requested or requested in {"none", "fail_closed"}:
+        return None, None, None, None, "none", "none", ()
+    if requested != REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519:
+        return None, None, None, None, "none", requested, ("unsupported_signature_verifier_backend",)
+    if not principals:
+        return None, None, None, None, "none", requested, (
+            "missing_principal_authority_records_for_signature_verification",
+        )
+    from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+        Ed25519SignatureVerifier,
+    )
+
+    return (
+        Ed25519SignatureVerifier(),
+        JsonPrincipalKeyResolver(principals),
+        AuthorityRuntimeWorkAuthorityNonceStore(authority_store),
+        AuthorityRuntimeRevocationOracle(authority_store),
+        REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        (),
+    )
+
+
 def _principal_key(principal_id: str, principal_provider: str) -> str:
     return f"{principal_provider}|{principal_id}"
 
@@ -334,11 +450,15 @@ def _is_inside(child: Path, parent: Path) -> bool:
 
 
 __all__ = [
+    "AuthorityRuntimeRevocationOracle",
+    "AuthorityRuntimeWorkAuthorityNonceStore",
     "JsonPermissionSnapshotResolver",
     "JsonPrincipalAuthorityResolver",
+    "JsonPrincipalKeyResolver",
     "REDDOG_RUNTIME_DEPENDENCY_BUNDLE_NOT_REQUESTED",
     "REDDOG_RUNTIME_DEPENDENCY_BUNDLE_READY",
     "REDDOG_RUNTIME_DEPENDENCY_BUNDLE_REJECT",
+    "REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519",
     "RedDogMainResidentQueueRuntimeDependencyBundle",
     "load_reddog_main_resident_queue_runtime_dependency_bundle",
 ]

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -8,8 +8,9 @@ outside the repository checkout, builds the injected handler registry with the
 dependencies this bootstrap owns today, and advances through the serial loop up
 to a bounded max step count.
 
-This slice does not introduce production signer, verifier, runner, PR,
-PatternMemory, OpenClaw, Hermes, or HoloIndex dependencies. Missing later-stage
+This slice does not introduce a production signer, runner, PR, PatternMemory,
+OpenClaw, Hermes, or HoloIndex dependency. Public signature verification can be
+enabled only through the explicit runtime dependency bundle. Missing later-stage
 dependencies fail closed through the registry and dispatcher.
 """
 
@@ -91,6 +92,7 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
     signer_socket_timeout_s: float = DEFAULT_SIGNER_SOCKET_TIMEOUT_S,
     signer_socket_max_response_bytes: int = DEFAULT_SIGNER_SOCKET_MAX_RESPONSE_BYTES,
     signer_socket_connector: Optional[SignerSocketConnector] = None,
+    signature_verifier_backend: str | None = None,
     requested_queue_item_id: str | None = None,
     now_iso: str | None = None,
     now_epoch: int | None = None,
@@ -140,6 +142,7 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
         signer_socket_timeout_s=signer_socket_timeout_s,
         signer_socket_max_response_bytes=signer_socket_max_response_bytes,
         signer_socket_connector=signer_socket_connector,
+        signature_verifier_backend=signature_verifier_backend,
         now_epoch=now_epoch,
     )
     if dependency_bundle.accepted is not True:
@@ -161,6 +164,10 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
         principal_resolver=dependency_bundle.principal_resolver,
         snapshot_resolver=dependency_bundle.snapshot_resolver,
         now_epoch=dependency_bundle.now_epoch,
+        signature_verifier=dependency_bundle.signature_verifier,
+        principal_key_resolver=dependency_bundle.principal_key_resolver,
+        nonce_store=dependency_bundle.nonce_store,
+        revocation_oracle=dependency_bundle.revocation_oracle,
     )
     loop = run_reddog_resident_queue_serial_loop(
         explicit_resident_queue_serial_loop_requested=True,
@@ -293,6 +300,7 @@ def _from_loop(
         runtime_dependency_bundle_status=runtime_dependency_bundle_status,
         runtime_dependency_bundle_requested=runtime_dependency_bundle_requested,
         rejection_reasons=tuple(loop.rejection_reasons),
+        no_signature_verification_performed="authority_verification" not in loop.dispatched_stages,
     )
 
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_runtime_dependency_bundle.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_runtime_dependency_bundle.py
@@ -7,6 +7,8 @@ import json
 from pathlib import Path
 
 from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_runtime_dependency_bundle import (
+    JsonPrincipalKeyResolver,
+    REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
     JsonPermissionSnapshotResolver,
     JsonPrincipalAuthorityResolver,
     REDDOG_RUNTIME_DEPENDENCY_BUNDLE_NOT_REQUESTED,
@@ -63,13 +65,13 @@ def _snapshots() -> dict[str, object]:
     }
 
 
-def _principals() -> dict[str, object]:
+def _principals(principal_public_key: str = "pub:principal") -> dict[str, object]:
     return {
         "principals": {
             "github:mjtrout": {
                 "principal_id": "github:mjtrout",
                 "principal_provider": "github",
-                "principal_public_key": "pub:principal",
+                "principal_public_key": principal_public_key,
                 "repo_scope": [REPO],
                 "foundup_scope": [FID],
                 "verified_subject_digest": "sha256:verified-subject",
@@ -255,6 +257,103 @@ def test_bundle_uses_isolated_socket_signer_when_explicitly_configured(tmp_path:
     assert authority_state.exists()
     stored = json.loads(authority_state.read_text(encoding="utf-8"))
     assert stored["issued_authorities"]["wre-queue-1"]["status"] == "DELEGATED_AUTHORITY_ISSUED"
+
+
+def test_bundle_configures_ed25519_verification_dependencies_when_explicit(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    authority_state = tmp_path / "runtime" / "authority-state.json"
+    snapshot_path = _write_json(tmp_path, "snapshots.json", _snapshots())
+    principal_path = _write_json(tmp_path, "principals.json", _principals())
+
+    bundle = load_reddog_main_resident_queue_runtime_dependency_bundle(
+        repo_root=repo,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshot_path,
+        principal_authority_records_path=principal_path,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        now_epoch=NOW,
+    )
+
+    assert bundle.accepted is True
+    assert bundle.signature_verifier_backend == REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519
+    assert bundle.signature_verifier_mode == REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519
+    assert bundle.signature_verifier is not None
+    assert isinstance(bundle.principal_key_resolver, JsonPrincipalKeyResolver)
+    assert bundle.principal_key_resolver.resolve("github:mjtrout", "github") == "pub:principal"
+    assert bundle.nonce_store.consume("workauth-nonce-1") is True
+    assert bundle.nonce_store.consume("workauth-nonce-1") is False
+    stored = json.loads(authority_state.read_text(encoding="utf-8"))
+    assert stored["verified_work_authority_nonces"] == ["workauth-nonce-1"]
+
+
+def test_bundle_ed25519_revocation_oracle_reads_authority_state(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    authority_state = _write_json(
+        tmp_path,
+        "authority-state.json",
+        {"revocations": {"key_epochs": ["epoch-1"]}},
+    )
+    snapshot_path = _write_json(tmp_path, "snapshots.json", _snapshots())
+    principal_path = _write_json(tmp_path, "principals.json", _principals())
+
+    bundle = load_reddog_main_resident_queue_runtime_dependency_bundle(
+        repo_root=repo,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshot_path,
+        principal_authority_records_path=principal_path,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        now_epoch=NOW,
+    )
+
+    assert bundle.accepted is True
+    assert bundle.revocation_oracle.is_revoked(
+        reddog_id="reddog:abc123",
+        fingerprint="sha256:abc",
+        principal_id="github:mjtrout",
+        key_epoch="epoch-1",
+    ) is True
+    assert bundle.revocation_oracle.is_revoked(
+        reddog_id="reddog:abc123",
+        fingerprint="sha256:abc",
+        principal_id="github:mjtrout",
+        key_epoch="epoch-2",
+    ) is False
+
+
+def test_bundle_rejects_unsupported_signature_verifier_backend(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    authority_state = tmp_path / "runtime" / "authority-state.json"
+    snapshot_path = _write_json(tmp_path, "snapshots.json", _snapshots())
+    principal_path = _write_json(tmp_path, "principals.json", _principals())
+
+    bundle = load_reddog_main_resident_queue_runtime_dependency_bundle(
+        repo_root=repo,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshot_path,
+        principal_authority_records_path=principal_path,
+        signature_verifier_backend="hmac",
+        now_epoch=NOW,
+    )
+
+    assert bundle.accepted is False
+    assert "unsupported_signature_verifier_backend" in bundle.rejection_reasons
+
+
+def test_bundle_rejects_ed25519_verification_without_principal_records(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    authority_state = tmp_path / "runtime" / "authority-state.json"
+    snapshot_path = _write_json(tmp_path, "snapshots.json", _snapshots())
+
+    bundle = load_reddog_main_resident_queue_runtime_dependency_bundle(
+        repo_root=repo,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshot_path,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        now_epoch=NOW,
+    )
+
+    assert bundle.accepted is False
+    assert "missing_principal_authority_records_for_signature_verification" in bundle.rejection_reasons
 
 
 def test_bundle_rejects_invalid_signer_socket_without_falling_back(tmp_path: Path) -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -13,9 +13,20 @@ from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_
     run_reddog_main_resident_queue_serial_loop_bootstrap,
 )
 from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_runtime_dependency_bundle import (
+    REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
     REDDOG_RUNTIME_DEPENDENCY_BUNDLE_READY,
 )
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    encode_ed25519_public_key,
+)
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signer_backend import (
+    Ed25519SignerBackend,
+)
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_protocol import (
+    SignerPeerAttestation,
+)
 from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    SigningRequest,
     RuntimeRejectCode,
     public_key_fingerprint,
 )
@@ -105,13 +116,13 @@ def _snapshots() -> dict[str, object]:
     }
 
 
-def _principals() -> dict[str, object]:
+def _principals(principal_public_key: str = "pub:principal") -> dict[str, object]:
     return {
         "principals": {
             "github:mjtrout": {
                 "principal_id": "github:mjtrout",
                 "principal_provider": "github",
-                "principal_public_key": "pub:principal",
+                "principal_public_key": principal_public_key,
                 "repo_scope": ["FOUNDUPS/Foundups-Agent"],
                 "foundup_scope": ["paccess_001"],
                 "verified_subject_digest": "sha256:verified-subject",
@@ -154,6 +165,62 @@ def _accepted_socket_signer(
         "no_secret_material_returned": True,
     }
     return json.dumps(response, sort_keys=True).encode("utf-8")
+
+
+class _AuditMacBuilder:
+    def build(self, request: SigningRequest, signature: str, peer: SignerPeerAttestation) -> str:
+        return "audit:" + request.payload_digest
+
+
+def _ed25519_signing_material():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    principal_key = Ed25519PrivateKey.generate()
+    reddog_key = Ed25519PrivateKey.generate()
+    principal_public = encode_ed25519_public_key(
+        principal_key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+    )
+    reddog_public = encode_ed25519_public_key(
+        reddog_key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+    )
+    peer = SignerPeerAttestation(
+        peer_principal_id="github:mjtrout",
+        transport="test_connector",
+        credential_source="test_peer_attestation",
+        boundary_attested=True,
+    )
+    backends = {
+        principal_public: Ed25519SignerBackend(
+            private_key=principal_key,
+            public_key=principal_public,
+            key_epoch="epoch-1",
+            audit_mac_builder=_AuditMacBuilder(),
+        ),
+        reddog_public: Ed25519SignerBackend(
+            private_key=reddog_key,
+            public_key=reddog_public,
+            key_epoch="epoch-1",
+            audit_mac_builder=_AuditMacBuilder(),
+        ),
+    }
+
+    def connector(socket_path: Path, request_bytes: bytes, timeout_s: float, max_response_bytes: int) -> bytes:
+        assert socket_path.is_absolute()
+        assert timeout_s > 0
+        assert max_response_bytes >= 1024
+        decoded = json.loads(request_bytes.decode("utf-8").strip())
+        request = SigningRequest(**decoded["request"])
+        response = backends[request.signer_public_key].sign(request, peer)
+        return json.dumps(response.to_dict(), sort_keys=True).encode("utf-8")
+
+    return principal_public, reddog_public, connector
 
 
 def _repo(tmp_path: Path) -> Path:
@@ -300,6 +367,61 @@ def test_bootstrap_serial_loop_uses_socket_signer_for_authority_runtime(tmp_path
     assert next(iter(issued.values()))["status"] == "DELEGATED_AUTHORITY_ISSUED"
 
 
+def test_bootstrap_serial_loop_verifies_ed25519_authority_when_configured(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    principal_public, reddog_public, connector = _ed25519_signing_material()
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(
+        tmp_path,
+        "profile.json",
+        _profile(principal_public_key=principal_public, reddog_public_key=reddog_public),
+    )
+    snapshots = _write_runtime_json(tmp_path, "snapshots.json", _snapshots())
+    principals = _write_runtime_json(tmp_path, "principals.json", _principals(principal_public))
+    chain = tmp_path / "runtime" / "chain_results.json"
+    authority_state = tmp_path / "runtime" / "authority_state.json"
+    socket_path = tmp_path / "runtime" / "signer.sock"
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshots,
+        principal_authority_records_path=principals,
+        signer_socket_path=socket_path,
+        signer_socket_connector=connector,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        now_iso=NOW,
+        now_epoch=1000,
+        requested_queue_item_id="queue-1",
+        max_steps=3,
+    )
+
+    assert result.accepted is True
+    assert result.status == REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED
+    assert result.runtime_dependency_bundle_status == REDDOG_RUNTIME_DEPENDENCY_BUNDLE_READY
+    assert result.steps_run == 3
+    assert result.dispatched_stages == (
+        "authority_request",
+        "authority_runtime",
+        "authority_verification",
+    )
+    assert result.next_action == "RUN_QUEUE_VERIFIED_AUTHORITY_WORK_ORDER_INVOKE"
+    assert result.no_signature_verification_performed is False
+    assert result.no_worktree_created is True
+    assert result.no_shell_command_executed is True
+    assert result.no_openclaw_enqueue_performed is True
+
+    stored = json.loads(chain.read_text(encoding="utf-8"))
+    verification = stored["stage_results"]["authority_verification"]
+    assert verification["decision"] == "QUEUE_AUTHORITY_VERIFICATION_INVOKE_ACCEPT"
+    assert verification["verification_result"]["accepted"] is True
+    authority = json.loads(authority_state.read_text(encoding="utf-8"))
+    assert authority["verified_work_authority_nonces"] == ["workauth-nonce-0001"]
+
+
 def test_bootstrap_rejects_missing_authority_profile(tmp_path: Path) -> None:
     repo = _repo(tmp_path)
     state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
@@ -376,6 +498,7 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
                 "REDDOG_SIGNER_SOCKET_PATH": str(tmp_path / "signer.sock"),
                 "REDDOG_SIGNER_SOCKET_TIMEOUT_S": "2.5",
                 "REDDOG_SIGNER_SOCKET_MAX_RESPONSE_BYTES": "8192",
+                "REDDOG_SIGNATURE_VERIFIER_BACKEND": REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
                 "REDDOG_RESIDENT_QUEUE_NOW_EPOCH": "1000",
                 "REDDOG_WRE_QUEUE_ITEM_ID": "queue-1",
             },
@@ -392,6 +515,7 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
     assert mocked.call_args.kwargs["signer_socket_path"] == str(tmp_path / "signer.sock")
     assert mocked.call_args.kwargs["signer_socket_timeout_s"] == 2.5
     assert mocked.call_args.kwargs["signer_socket_max_response_bytes"] == 8192
+    assert mocked.call_args.kwargs["signature_verifier_backend"] == REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519
     assert mocked.call_args.kwargs["requested_queue_item_id"] == "queue-1"
     assert mocked.call_args.kwargs["now_epoch"] == 1000
     assert mocked.call_args.kwargs["max_steps"] == 1


### PR DESCRIPTION
## Summary

REDDOG_RESIDENT_QUEUE_ED25519_VERIFICATION_BUNDLE_PHASE1

Wires explicit public Ed25519 authority verification into the resident RedDog serial-loop dependency bundle.

## What changed

- Adds `REDDOG_SIGNATURE_VERIFIER_BACKEND=ed25519` plumbing from `main.py` into the resident serial-loop bootstrap.
- Extends the runtime dependency bundle with:
  - `Ed25519SignatureVerifier` public verifier backend when explicitly requested.
  - `JsonPrincipalKeyResolver` over token-verified principal records.
  - durable outside-repo work-authority nonce consumption in the authority runtime state.
  - authority-state revocation oracle.
- Passes verifier, principal-key resolver, nonce store, and revocation oracle into the resident queue stage-handler registry.
- Corrects bootstrap telemetry so `no_signature_verification_performed` is false when the authority-verification stage actually runs.

## WSP_97 truth boundary

OBSERVED:
- Default startup path remains unchanged: no verifier backend configured means the authority-verification stage is not registered.
- Explicit `ed25519` config advances the serial loop through `authority_request -> authority_runtime -> authority_verification` using real Ed25519 signatures in tests.
- Work-authority nonce replay is durably rejected through outside-repo authority state.
- Revocations are read from outside-repo authority runtime state.
- Unsupported verifier backends reject fail-closed.

SPECIFIED_NOT_IMPLEMENTED:
- No private key loading or generation.
- No signer process spawn or socket daemon binding.
- No OpenClaw enqueue, Hermes dispatch, shell execution, worktree creation, PR publication, repo mutation, reward settlement, or HoloIndex runtime re-index.
- No live work-order invocation or execution authority is granted by this slice.

## Validation

- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_runtime_dependency_bundle.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q` -> 22 passed
- Authority/signing band -> 98 passed:
  - `test_reddog_work_order_signature_verifier.py`
  - `test_reddog_ed25519_signature_verifier_backend.py`
  - `test_reddog_ed25519_signer_backend.py`
  - `test_reddog_isolated_signer_socket_client.py`
  - `test_reddog_isolated_signer_socket_protocol.py`
  - `test_reddog_main_resident_queue_runtime_dependency_bundle.py`
  - `test_reddog_main_resident_queue_serial_loop_bootstrap.py`
  - `test_reddog_resident_queue_stage_handler_registry.py`
  - `test_reddog_resident_queue_authority_verification_handler.py`
  - `test_reddog_wre_queue_authority_verification_invoke.py`
- `git diff --check` -> clean
- Diff additions ASCII-clean

Note: A full `pytest modules/communication/moltbot_bridge/tests -q` run was attempted but ended in a pytest capture/tempfile cascade (`ValueError: I/O operation on closed file`) across unrelated tests. Focused and authority/signing suites are green; PR CI should provide the repository-level signal.

## HoloIndex

Read-only probe for `RedDog resident queue Ed25519 verification backend bundle signature verifier` surfaced the core verifier and adjacent docs, but not this new bundle wiring before indexing.

INDEX_GAP: `HOLOINDEX_REDDOG_RESIDENT_QUEUE_ED25519_VERIFICATION_BUNDLE_INDEX_GAP_PHASE1`

No runtime re-index performed.