### PR TITLE
feat(reddog): add isolated signer socket service

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,28 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_ISOLATED_SIGNER_SOCKET_SERVICE_ONCE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 71, 97
+
+- Added `src/reddog_isolated_signer_socket_service.py`: a one-request local
+  socket service boundary for an isolated RedDog signer. It binds only an
+  absolute outside-repo socket path, serves one bounded request through the
+  existing signer protocol, and removes the socket path after closing.
+- Added tests for guarded path validation, invalid limit rejection, default
+  peer-attestor fail-closed behavior, default backend fail-closed behavior, and
+  a real client-to-service Ed25519 round-trip when AF_UNIX sockets are
+  available. Windows Python builds without AF_UNIX skip only the live socket
+  round-trip tests.
+- Boundary: socket service only. No private key loading, no vault secret
+  resolution, no signer spawn, no shell command, no repository mutation, no
+  OpenClaw enqueue, no Hermes dispatch, no PR creation, no reward settlement,
+  and no HoloIndex runtime re-index.
+- HoloIndex read-only probe for `RedDog isolated signer socket service serve
+  once peer attestor` surfaced signer-isolation contracts and adjacent tests,
+  but not this new service module before indexing. Recorded as
+  `HOLOINDEX_REDDOG_ISOLATED_SIGNER_SOCKET_SERVICE_ONCE_INDEX_GAP_PHASE1`; no
+  runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_RESIDENT_QUEUE_ED25519_VERIFICATION_BUNDLE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 71, 97

--- a/modules/communication/moltbot_bridge/src/reddog_isolated_signer_socket_service.py
+++ b/modules/communication/moltbot_bridge/src/reddog_isolated_signer_socket_service.py
@@ -1,0 +1,284 @@
+"""One-request socket service for the isolated RedDog signer boundary.
+
+Slice: REDDOG_ISOLATED_SIGNER_SOCKET_SERVICE_ONCE_PHASE1
+
+This module binds a caller-provided local socket path outside the repository,
+serves exactly one bounded signer request through the existing signer protocol,
+and closes the socket. It does not load private keys, resolve vault secrets,
+spawn processes, execute shell commands, mutate repository files, enqueue
+OpenClaw, dispatch Hermes, publish PRs, settle rewards, or re-index HoloIndex.
+
+The signing backend and peer attestor are injected by the isolated signer
+process owner. Defaults fail closed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import socket
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Callable, Optional, Protocol
+
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_protocol import (
+    DEFAULT_SIGNER_SOCKET_MAX_REQUEST_BYTES,
+    FailClosedSignerBackend,
+    IsolatedSignerBackend,
+    SignerPeerAttestation,
+    handle_reddog_isolated_signer_socket_request,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    RuntimeRejectCode,
+    SigningResponse,
+)
+
+
+SIGNER_SOCKET_SERVICE_SERVED = "SIGNER_SOCKET_SERVICE_SERVED"
+SIGNER_SOCKET_SERVICE_REJECT = "SIGNER_SOCKET_SERVICE_REJECT"
+
+FAIL_SIGNER_SERVICE_SOCKET_PATH_MISSING = "FAIL_SIGNER_SERVICE_SOCKET_PATH_MISSING"
+FAIL_SIGNER_SERVICE_SOCKET_PATH_RELATIVE = "FAIL_SIGNER_SERVICE_SOCKET_PATH_RELATIVE"
+FAIL_SIGNER_SERVICE_SOCKET_PATH_INSIDE_REPO = "FAIL_SIGNER_SERVICE_SOCKET_PATH_INSIDE_REPO"
+FAIL_SIGNER_SERVICE_SOCKET_DEVICE_PREFIX = "FAIL_SIGNER_SERVICE_SOCKET_DEVICE_PREFIX"
+FAIL_SIGNER_SERVICE_SOCKET_PARENT_MISSING = "FAIL_SIGNER_SERVICE_SOCKET_PARENT_MISSING"
+FAIL_SIGNER_SERVICE_SOCKET_PATH_EXISTS = "FAIL_SIGNER_SERVICE_SOCKET_PATH_EXISTS"
+FAIL_SIGNER_SERVICE_TIMEOUT_INVALID = "FAIL_SIGNER_SERVICE_TIMEOUT_INVALID"
+FAIL_SIGNER_SERVICE_REQUEST_LIMIT_INVALID = "FAIL_SIGNER_SERVICE_REQUEST_LIMIT_INVALID"
+FAIL_SIGNER_SERVICE_RESPONSE_LIMIT_INVALID = "FAIL_SIGNER_SERVICE_RESPONSE_LIMIT_INVALID"
+FAIL_SIGNER_SERVICE_SOCKET_UNAVAILABLE = "FAIL_SIGNER_SERVICE_SOCKET_UNAVAILABLE"
+FAIL_SIGNER_SERVICE_RUNTIME_ERROR = "FAIL_SIGNER_SERVICE_RUNTIME_ERROR"
+FAIL_SIGNER_SERVICE_RESPONSE_TOO_LARGE = "FAIL_SIGNER_SERVICE_RESPONSE_TOO_LARGE"
+
+DEFAULT_SIGNER_SOCKET_SERVICE_TIMEOUT_S = 5.0
+DEFAULT_SIGNER_SOCKET_SERVICE_MAX_RESPONSE_BYTES = 16384
+
+
+class SignerSocketPeerAttestor(Protocol):
+    """Injected peer attestor owned by the isolated signer process."""
+
+    def attest(self, connection: socket.socket) -> SignerPeerAttestation:
+        """Return peer identity from the socket boundary, or fail closed."""
+
+
+class FailClosedSignerSocketPeerAttestor:
+    """Default peer attestor: never attests a requester."""
+
+    def attest(self, connection: socket.socket) -> SignerPeerAttestation:
+        return SignerPeerAttestation(
+            peer_principal_id="",
+            transport="local_socket",
+            credential_source="fail_closed",
+            boundary_attested=False,
+        )
+
+
+@dataclass(frozen=True)
+class IsolatedSignerSocketServiceResult:
+    """Audit-safe result for one signer service request."""
+
+    accepted: bool
+    status: str
+    rejection_reasons: tuple[str, ...]
+    socket_path: Optional[str] = None
+    request_bytes: int = 0
+    response_bytes: int = 0
+    response_digest: Optional[str] = None
+    request_handled: bool = False
+    socket_removed: bool = False
+    no_private_key_loaded: bool = True
+    no_vault_secret_resolved: bool = True
+    no_signer_spawned: bool = True
+    no_shell_command_executed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_pr_created: bool = True
+    no_reward_settlement_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def serve_reddog_isolated_signer_socket_once(
+    *,
+    repo_root: Path | str,
+    socket_path: Path | str | None,
+    backend: Optional[IsolatedSignerBackend] = None,
+    peer_attestor: Optional[SignerSocketPeerAttestor] = None,
+    timeout_s: float = DEFAULT_SIGNER_SOCKET_SERVICE_TIMEOUT_S,
+    max_request_bytes: int = DEFAULT_SIGNER_SOCKET_MAX_REQUEST_BYTES,
+    max_response_bytes: int = DEFAULT_SIGNER_SOCKET_SERVICE_MAX_RESPONSE_BYTES,
+    ready_callback: Optional[Callable[[], None]] = None,
+) -> IsolatedSignerSocketServiceResult:
+    """Serve exactly one signer request on a guarded local socket."""
+
+    resolved, reasons = _resolve_socket_path(repo_root=repo_root, socket_path=socket_path)
+    if reasons:
+        return _reject(*reasons)
+    assert resolved is not None
+    limit_reasons = _validate_limits(timeout_s, max_request_bytes, max_response_bytes)
+    if limit_reasons:
+        return _reject(*limit_reasons, socket_path=str(resolved))
+    if not hasattr(socket, "AF_UNIX"):
+        return _reject(FAIL_SIGNER_SERVICE_SOCKET_UNAVAILABLE, socket_path=str(resolved))
+
+    server: Optional[socket.socket] = None
+    socket_removed = False
+    try:
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server.settimeout(float(timeout_s))
+        server.bind(str(resolved))
+        server.listen(1)
+        if ready_callback:
+            ready_callback()
+        connection, _ = server.accept()
+        with connection:
+            connection.settimeout(float(timeout_s))
+            request_bytes = _read_bounded(connection, max_request_bytes)
+            peer = (peer_attestor or FailClosedSignerSocketPeerAttestor()).attest(connection)
+            response = handle_reddog_isolated_signer_socket_request(
+                request_bytes,
+                peer=peer,
+                backend=backend or FailClosedSignerBackend(),
+                max_request_bytes=max_request_bytes,
+            )
+            if len(response) > max_response_bytes:
+                response = _response_bytes(RuntimeRejectCode.MALFORMED_REQUEST)
+                if len(response) > max_response_bytes:
+                    return _reject(FAIL_SIGNER_SERVICE_RESPONSE_TOO_LARGE, socket_path=str(resolved))
+            connection.sendall(response)
+        server.close()
+        server = None
+        socket_removed = _cleanup_socket(resolved)
+        return IsolatedSignerSocketServiceResult(
+            accepted=True,
+            status=SIGNER_SOCKET_SERVICE_SERVED,
+            rejection_reasons=(),
+            socket_path=str(resolved),
+            request_bytes=len(request_bytes),
+            response_bytes=len(response),
+            response_digest=_digest(response),
+            request_handled=True,
+            socket_removed=socket_removed,
+        )
+    except Exception:
+        return _reject(FAIL_SIGNER_SERVICE_RUNTIME_ERROR, socket_path=str(resolved))
+    finally:
+        if server is not None:
+            server.close()
+        if not socket_removed:
+            _cleanup_socket(resolved)
+
+
+def _resolve_socket_path(
+    *, repo_root: Path | str, socket_path: Path | str | None
+) -> tuple[Optional[Path], tuple[str, ...]]:
+    root = Path(repo_root).resolve()
+    if not socket_path:
+        return None, (FAIL_SIGNER_SERVICE_SOCKET_PATH_MISSING,)
+    path_text = str(socket_path)
+    if "\x00" in path_text or path_text.startswith("\\\\?\\") or path_text.startswith("//?/"):
+        return None, (FAIL_SIGNER_SERVICE_SOCKET_DEVICE_PREFIX,)
+    path = Path(socket_path)
+    if not path.is_absolute():
+        return None, (FAIL_SIGNER_SERVICE_SOCKET_PATH_RELATIVE,)
+    resolved = path.resolve()
+    if _is_inside(resolved, root):
+        return None, (FAIL_SIGNER_SERVICE_SOCKET_PATH_INSIDE_REPO,)
+    if not resolved.parent.exists() or not resolved.parent.is_dir():
+        return None, (FAIL_SIGNER_SERVICE_SOCKET_PARENT_MISSING,)
+    if resolved.exists():
+        return None, (FAIL_SIGNER_SERVICE_SOCKET_PATH_EXISTS,)
+    return resolved, ()
+
+
+def _validate_limits(
+    timeout_s: float, max_request_bytes: int, max_response_bytes: int
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if timeout_s <= 0 or timeout_s > 30:
+        reasons.append(FAIL_SIGNER_SERVICE_TIMEOUT_INVALID)
+    if max_request_bytes < 1024 or max_request_bytes > 262144:
+        reasons.append(FAIL_SIGNER_SERVICE_REQUEST_LIMIT_INVALID)
+    if max_response_bytes < 1024 or max_response_bytes > 262144:
+        reasons.append(FAIL_SIGNER_SERVICE_RESPONSE_LIMIT_INVALID)
+    return tuple(reasons)
+
+
+def _read_bounded(connection: socket.socket, max_request_bytes: int) -> bytes:
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = connection.recv(4096)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > max_request_bytes:
+            raise ValueError(FAIL_SIGNER_SERVICE_REQUEST_LIMIT_INVALID)
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _response_bytes(code: str) -> bytes:
+    response = SigningResponse(
+        accepted=False,
+        rejection_code=str(code),
+        no_secret_material_returned=True,
+    )
+    return (
+        json.dumps(response.to_dict(), sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        + "\n"
+    ).encode("utf-8")
+
+
+def _digest(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def _cleanup_socket(path: Path) -> bool:
+    try:
+        path.unlink(missing_ok=True)
+        return not path.exists()
+    except Exception:
+        return False
+
+
+def _reject(*reasons: str, socket_path: Optional[str] = None) -> IsolatedSignerSocketServiceResult:
+    return IsolatedSignerSocketServiceResult(
+        accepted=False,
+        status=SIGNER_SOCKET_SERVICE_REJECT,
+        rejection_reasons=tuple(dict.fromkeys(reason for reason in reasons if reason)),
+        socket_path=socket_path,
+    )
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+__all__ = [
+    "DEFAULT_SIGNER_SOCKET_SERVICE_MAX_RESPONSE_BYTES",
+    "DEFAULT_SIGNER_SOCKET_SERVICE_TIMEOUT_S",
+    "FAIL_SIGNER_SERVICE_REQUEST_LIMIT_INVALID",
+    "FAIL_SIGNER_SERVICE_RESPONSE_LIMIT_INVALID",
+    "FAIL_SIGNER_SERVICE_RESPONSE_TOO_LARGE",
+    "FAIL_SIGNER_SERVICE_RUNTIME_ERROR",
+    "FAIL_SIGNER_SERVICE_SOCKET_DEVICE_PREFIX",
+    "FAIL_SIGNER_SERVICE_SOCKET_PARENT_MISSING",
+    "FAIL_SIGNER_SERVICE_SOCKET_PATH_EXISTS",
+    "FAIL_SIGNER_SERVICE_SOCKET_PATH_INSIDE_REPO",
+    "FAIL_SIGNER_SERVICE_SOCKET_PATH_MISSING",
+    "FAIL_SIGNER_SERVICE_SOCKET_PATH_RELATIVE",
+    "FAIL_SIGNER_SERVICE_SOCKET_UNAVAILABLE",
+    "FAIL_SIGNER_SERVICE_TIMEOUT_INVALID",
+    "FailClosedSignerSocketPeerAttestor",
+    "IsolatedSignerSocketServiceResult",
+    "SIGNER_SOCKET_SERVICE_REJECT",
+    "SIGNER_SOCKET_SERVICE_SERVED",
+    "SignerSocketPeerAttestor",
+    "serve_reddog_isolated_signer_socket_once",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_isolated_signer_socket_service.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_isolated_signer_socket_service.py
@@ -1,0 +1,308 @@
+"""Tests for REDDOG_ISOLATED_SIGNER_SOCKET_SERVICE_ONCE_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import socket
+import tempfile
+import threading
+import uuid
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    Ed25519SignatureVerifier,
+    encode_ed25519_public_key,
+)
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signer_backend import (
+    Ed25519SignerBackend,
+)
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_client import (
+    RedDogIsolatedSignerSocketClient,
+)
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_protocol import (
+    REJECT_SIGNER_SOCKET_PEER_NOT_ATTESTED,
+    SignerPeerAttestation,
+)
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_service import (
+    FAIL_SIGNER_SERVICE_REQUEST_LIMIT_INVALID,
+    FAIL_SIGNER_SERVICE_SOCKET_PARENT_MISSING,
+    FAIL_SIGNER_SERVICE_SOCKET_PATH_EXISTS,
+    FAIL_SIGNER_SERVICE_SOCKET_PATH_INSIDE_REPO,
+    FAIL_SIGNER_SERVICE_SOCKET_PATH_MISSING,
+    FAIL_SIGNER_SERVICE_SOCKET_PATH_RELATIVE,
+    SIGNER_SOCKET_SERVICE_REJECT,
+    SIGNER_SOCKET_SERVICE_SERVED,
+    serve_reddog_isolated_signer_socket_once,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    RuntimeRejectCode,
+    SigningRequest,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_isolated_signer_socket_service.py"
+)
+
+
+class _AuditMacBuilder:
+    def build(self, request: SigningRequest, signature: str, peer: SignerPeerAttestation) -> str:
+        return "audit:" + request.payload_digest
+
+
+class _StaticPeerAttestor:
+    def __init__(self, principal_id: str = "github:mjtrout", *, attested: bool = True) -> None:
+        self.principal_id = principal_id
+        self.attested = attested
+
+    def attest(self, connection):
+        return SignerPeerAttestation(
+            peer_principal_id=self.principal_id,
+            transport="unix_socket",
+            credential_source="test_peer_credential",
+            boundary_attested=self.attested,
+        )
+
+
+def _repo(tmp_path: Path) -> Path:
+    path = tmp_path / "repo"
+    path.mkdir()
+    return path
+
+
+def _socket_path(tmp_path: Path) -> Path:
+    return Path(tempfile.gettempdir()) / f"rdog-{uuid.uuid4().hex}.sock"
+
+
+def _public_key(private_key) -> str:
+    from cryptography.hazmat.primitives import serialization
+
+    return encode_ed25519_public_key(
+        private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+    )
+
+
+def _backend():
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    private_key = Ed25519PrivateKey.generate()
+    public_key = _public_key(private_key)
+    return (
+        public_key,
+        Ed25519SignerBackend(
+            private_key=private_key,
+            public_key=public_key,
+            key_epoch="epoch-1",
+            audit_mac_builder=_AuditMacBuilder(),
+        ),
+    )
+
+
+def _request(public_key: str, **overrides: object) -> SigningRequest:
+    payload = {
+        "signing_input": 'reddog-workauth.v1.{"work_order_id":"wo-1"}',
+        "payload_digest": "sha256:payload",
+        "signer_role": "reddog",
+        "signer_public_key": public_key,
+        "requester_principal_id": "github:mjtrout",
+        "nonce": "nonce-1",
+        "key_epoch": "epoch-1",
+        "requested_operation": "create_foundup",
+        "authority_tier": "HIGH",
+        "consensus_receipt_digest": "sha256:consensus",
+    }
+    payload.update(overrides)
+    return SigningRequest(**payload)
+
+
+def _serve_async(*, repo: Path, socket_path: Path, backend, peer_attestor=None):
+    if not hasattr(socket, "AF_UNIX"):
+        pytest.skip("AF_UNIX sockets are unavailable in this Python build")
+    ready = threading.Event()
+    result_box = {}
+
+    def target() -> None:
+        result_box["result"] = serve_reddog_isolated_signer_socket_once(
+            repo_root=repo,
+            socket_path=socket_path,
+            backend=backend,
+            peer_attestor=peer_attestor,
+            timeout_s=5.0,
+            ready_callback=ready.set,
+        )
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    assert ready.wait(5.0)
+    return thread, result_box
+
+
+def test_socket_service_round_trips_real_client_and_ed25519_backend(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    socket_path = _socket_path(tmp_path)
+    public_key, backend = _backend()
+    thread, result_box = _serve_async(
+        repo=repo,
+        socket_path=socket_path,
+        backend=backend,
+        peer_attestor=_StaticPeerAttestor(),
+    )
+
+    response = RedDogIsolatedSignerSocketClient(
+        socket_path=socket_path,
+        timeout_s=5.0,
+    ).sign(_request(public_key))
+    thread.join(5.0)
+
+    assert response.accepted is True
+    assert Ed25519SignatureVerifier().verify(
+        public_key,
+        _request(public_key).signing_input,
+        response.signature,
+    ) is True
+    result = result_box["result"]
+    assert result.accepted is True
+    assert result.status == SIGNER_SOCKET_SERVICE_SERVED
+    assert result.request_handled is True
+    assert result.response_digest.startswith("sha256:")
+    assert result.socket_removed is True
+    assert not socket_path.exists()
+    assert result.no_private_key_loaded is True
+    assert result.no_repo_mutation_performed is True
+    assert result.no_holoindex_reindex_performed is True
+
+
+def test_socket_service_default_peer_attestor_fails_closed(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    socket_path = _socket_path(tmp_path)
+    public_key, backend = _backend()
+    thread, result_box = _serve_async(repo=repo, socket_path=socket_path, backend=backend)
+
+    response = RedDogIsolatedSignerSocketClient(
+        socket_path=socket_path,
+        timeout_s=5.0,
+    ).sign(_request(public_key))
+    thread.join(5.0)
+
+    assert response.accepted is False
+    assert response.rejection_code == REJECT_SIGNER_SOCKET_PEER_NOT_ATTESTED
+    assert result_box["result"].accepted is True
+    assert result_box["result"].request_handled is True
+
+
+def test_socket_service_default_backend_fails_closed(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    socket_path = _socket_path(tmp_path)
+    public_key, _backend_obj = _backend()
+    thread, result_box = _serve_async(
+        repo=repo,
+        socket_path=socket_path,
+        backend=None,
+        peer_attestor=_StaticPeerAttestor(),
+    )
+
+    response = RedDogIsolatedSignerSocketClient(
+        socket_path=socket_path,
+        timeout_s=5.0,
+    ).sign(_request(public_key))
+    thread.join(5.0)
+
+    assert response.accepted is False
+    assert response.rejection_code == RuntimeRejectCode.SIGNER_NOT_CONFIGURED
+    assert result_box["result"].accepted is True
+
+
+def test_socket_service_path_guards_fail_before_binding(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    parent_missing = tmp_path / "missing" / "signer.sock"
+    existing = _socket_path(tmp_path)
+    existing.write_text("occupied", encoding="utf-8")
+
+    cases = (
+        (None, FAIL_SIGNER_SERVICE_SOCKET_PATH_MISSING),
+        ("relative.sock", FAIL_SIGNER_SERVICE_SOCKET_PATH_RELATIVE),
+        (repo / "signer.sock", FAIL_SIGNER_SERVICE_SOCKET_PATH_INSIDE_REPO),
+        (parent_missing, FAIL_SIGNER_SERVICE_SOCKET_PARENT_MISSING),
+        (existing, FAIL_SIGNER_SERVICE_SOCKET_PATH_EXISTS),
+    )
+
+    for value, reason in cases:
+        result = serve_reddog_isolated_signer_socket_once(
+            repo_root=repo,
+            socket_path=value,
+            timeout_s=0.01,
+        )
+        assert result.accepted is False
+        assert result.status == SIGNER_SOCKET_SERVICE_REJECT
+        assert reason in result.rejection_reasons
+
+
+def test_socket_service_rejects_invalid_limits(tmp_path: Path) -> None:
+    result = serve_reddog_isolated_signer_socket_once(
+        repo_root=_repo(tmp_path),
+        socket_path=_socket_path(tmp_path),
+        max_request_bytes=16,
+    )
+
+    assert result.accepted is False
+    assert FAIL_SIGNER_SERVICE_REQUEST_LIMIT_INVALID in result.rejection_reasons
+
+
+def test_socket_service_module_has_no_spawn_repo_holoindex_or_key_loading_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "holo_index",
+        "git",
+        "hmac",
+        "secrets",
+    }
+    banned_import_fragments = {
+        "openclaw_supervisor",
+        "hermes_job_executor",
+        "vault_resolver",
+        "reddog_wre_worktree_runner",
+        "worktree_pr_runner",
+        "cryptography",
+        "ed25519_signer_backend",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    banned_attrs = {
+        "system",
+        "popen",
+        "spawn",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "rmdir",
+        "replace",
+    }
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+                assert all(fragment not in alias.name for fragment in banned_import_fragments)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+            assert all(fragment not in node.module for fragment in banned_import_fragments)
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs


### PR DESCRIPTION
## Summary

REDDOG_ISOLATED_SIGNER_SOCKET_SERVICE_ONCE_PHASE1

Adds a one-request local socket service boundary for the isolated RedDog signer. This gives the already-built signer client and protocol a service-side runtime without allowing `main.py` to spawn or own the signer.

## What changed

- Adds `reddog_isolated_signer_socket_service.py`.
- The service binds only an absolute socket path outside the repo, serves exactly one bounded signer request, sends the existing signer protocol response, closes, and removes the socket path.
- Signing backend and peer attestor are injected by the isolated signer owner.
- Defaults fail closed: no backend signs nothing; no peer attestor means no boundary attestation.

## WSP_97 truth boundary

OBSERVED:
- Path guards reject missing, relative, inside-repo, parent-missing, and pre-existing socket paths before binding.
- Invalid limits reject before binding.
- A real client-to-service Ed25519 round-trip is tested when AF_UNIX sockets are available.
- Default peer attestor and default backend fail closed.

SPECIFIED_NOT_IMPLEMENTED:
- No private key loading or key generation.
- No vault secret resolution.
- No signer process spawn or service manager.
- No main.py auto-start of the signer.
- No OpenClaw enqueue, Hermes dispatch, shell execution, worktree creation, PR publication, repo mutation, reward settlement, or HoloIndex runtime re-index.

## Validation

- `pytest modules/communication/moltbot_bridge/tests/test_reddog_isolated_signer_socket_service.py -q` -> 3 passed, 3 skipped locally because this Windows Python build lacks AF_UNIX.
- Related signer/socket band -> 28 passed, 3 skipped:
  - `test_reddog_isolated_signer_socket_service.py`
  - `test_reddog_isolated_signer_socket_client.py`
  - `test_reddog_isolated_signer_socket_protocol.py`
  - `test_reddog_ed25519_signer_backend.py`
  - `test_reddog_ed25519_signature_verifier_backend.py`
- `python -m py_compile` on new module and tests -> pass
- `git diff --check` -> clean
- Diff additions ASCII-clean

## HoloIndex

Read-only probe for `RedDog isolated signer socket service serve once peer attestor` surfaced signer-isolation contracts and adjacent tests, but not this new service module before indexing.

INDEX_GAP: `HOLOINDEX_REDDOG_ISOLATED_SIGNER_SOCKET_SERVICE_ONCE_INDEX_GAP_PHASE1`

No runtime re-index performed.