### PR TITLE
feat(reddog): add signer key provider dry-run

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,30 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_SIGNER_KEY_PROVIDER_DRYRUN_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 71, 95, 97
+
+- Added `src/reddog_signer_key_provider_dryrun.py`: a test-only signer
+  key-provider adapter that validates the #1072 contract with injected
+  resolver results and can construct the existing `Ed25519SignerBackend` only
+  under explicit `TEST_ONLY_DRYRUN` mode with a fresh permission snapshot.
+- Added tests proving default fail-closed behavior, test-only acceptance,
+  signer backend interoperability, stale permission rejection, same-reference
+  rejection, invalid reference rejection, resolver failure rejection, TTL
+  rejection, key/audit format rejection, public-key/fingerprint mismatch
+  rejection, non-ASCII/incomplete profile rejection, receipt non-leakage, and
+  an AST denylist for shell, sockets, repo mutation, OpenClaw, Hermes, and
+  HoloIndex runtime mutation surfaces.
+- Boundary: dry-run/test-only provider. No production vault resolution, no
+  environment or argv secret path, no file key loading, no socket binding, no
+  signer process launch, no shell command, no repository mutation, no OpenClaw
+  enqueue, no Hermes dispatch, no WRE queue write, no reward settlement, and
+  no HoloIndex runtime re-index.
+- HoloIndex read-only probe for `RedDog signer key provider dryrun WSP71
+  Ed25519 audit mac` is recorded as
+  `HOLOINDEX_REDDOG_SIGNER_KEY_PROVIDER_DRYRUN_INDEX_GAP_PHASE1`; no runtime
+  re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_SIGNER_KEY_PROVIDER_CONTRACT_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 71, 95, 97

--- a/modules/communication/moltbot_bridge/src/reddog_signer_key_provider_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_key_provider_dryrun.py
@@ -1,0 +1,381 @@
+"""Test-only RedDog signer key provider dry-run boundary.
+
+Slice: REDDOG_SIGNER_KEY_PROVIDER_DRYRUN_PHASE1
+
+This module validates the signer key-provider contract with injected test-only
+resolver output. It can construct an ``Ed25519SignerBackend`` only when the
+caller explicitly enables the test-only dry-run mode and supplies a fresh
+permission snapshot. It does not connect to a real vault, read environment
+variables, load files, bind sockets, spawn processes, mutate repository state,
+enqueue OpenClaw, dispatch Hermes, or re-index HoloIndex.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+from dataclasses import asdict, dataclass, field
+from typing import Any, Optional, Protocol
+
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    encode_ed25519_public_key,
+)
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signer_backend import (
+    Ed25519SignerBackend,
+    SignerAuditMacBuilder,
+)
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_protocol import (
+    SignerPeerAttestation,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    SigningRequest,
+    public_key_fingerprint,
+)
+from modules.infrastructure.secrets_mcp.src.vault_resolver import (
+    ResolveResult,
+    hash_reference,
+    parse_op_reference,
+)
+
+
+PROVIDER_MODE_TEST_ONLY_DRYRUN = "TEST_ONLY_DRYRUN"
+
+FAIL_PROVIDER_PROFILE_INVALID = "FAIL_PROVIDER_PROFILE_INVALID"
+FAIL_PROVIDER_PERMISSION_DENIED = "FAIL_PROVIDER_PERMISSION_DENIED"
+FAIL_PROVIDER_RESOLVER_UNAVAILABLE = "FAIL_PROVIDER_RESOLVER_UNAVAILABLE"
+FAIL_PROVIDER_REFERENCE_INVALID = "FAIL_PROVIDER_REFERENCE_INVALID"
+FAIL_PROVIDER_REFERENCE_FORBIDDEN = "FAIL_PROVIDER_REFERENCE_FORBIDDEN"
+FAIL_PROVIDER_TTL_EXPIRED = "FAIL_PROVIDER_TTL_EXPIRED"
+FAIL_PROVIDER_KEY_FORMAT = "FAIL_PROVIDER_KEY_FORMAT"
+FAIL_PROVIDER_PUBLIC_KEY_MISMATCH = "FAIL_PROVIDER_PUBLIC_KEY_MISMATCH"
+FAIL_PROVIDER_FINGERPRINT_MISMATCH = "FAIL_PROVIDER_FINGERPRINT_MISMATCH"
+FAIL_PROVIDER_AUDIT_KEY_MISSING = "FAIL_PROVIDER_AUDIT_KEY_MISSING"
+FAIL_PROVIDER_MOCK_IN_PRODUCTION = "FAIL_PROVIDER_MOCK_IN_PRODUCTION"
+
+SIGNING_KEY_PREFIX = "ed25519-private-raw-b64-v1:"
+AUDIT_KEY_PREFIX = "audit-mac-test-key-b64-v1:"
+ED25519_PRIVATE_KEY_BYTES = 32
+MIN_AUDIT_KEY_BYTES = 16
+
+
+class SignerKeyResolver(Protocol):
+    """Injected WSP 71-like resolver boundary."""
+
+    def resolve(self, reference: str, requester_id: Optional[str] = None) -> ResolveResult:
+        """Resolve an op:// reference or return a fail-closed result."""
+
+
+@dataclass(frozen=True)
+class SignerKeyProviderProfile:
+    """Signer-owned key-provider profile for the dry-run provider."""
+
+    signer_profile_id: str
+    signer_agent_id: str
+    signing_key_ref: str
+    audit_mac_key_ref: str
+    expected_public_key: str
+    expected_key_fingerprint: str
+    expected_key_epoch: str
+    permission_snapshot_digest: str
+    ttl_seconds: int
+
+
+@dataclass(frozen=True)
+class SignerKeyProviderDryRunResult:
+    """Dry-run provider result. ``backend`` is intentionally non-serializable."""
+
+    ok: bool
+    rejection_code: Optional[str]
+    signer_profile_id: str
+    key_epoch: Optional[str]
+    public_key: Optional[str]
+    key_fingerprint: Optional[str]
+    signing_key_ref_hash: Optional[str]
+    audit_mac_key_ref_hash: Optional[str]
+    ttl_remaining_seconds: Optional[int]
+    secret_values_returned: bool
+    backend: Optional[Ed25519SignerBackend] = field(default=None, repr=False, compare=False)
+
+    def to_receipt(self) -> dict[str, Any]:
+        """Return an audit-safe receipt with no backend or secret values."""
+
+        return {
+            "ok": self.ok,
+            "rejection_code": self.rejection_code,
+            "signer_profile_id": self.signer_profile_id,
+            "key_epoch": self.key_epoch,
+            "public_key": self.public_key,
+            "key_fingerprint": self.key_fingerprint,
+            "reference_hashes": {
+                "signing_key_ref_hash": self.signing_key_ref_hash,
+                "audit_mac_key_ref_hash": self.audit_mac_key_ref_hash,
+            },
+            "ttl_remaining_seconds": self.ttl_remaining_seconds,
+            "secret_values_returned": False,
+        }
+
+
+@dataclass(frozen=True)
+class _HmacAuditMacBuilder(SignerAuditMacBuilder):
+    _audit_key: bytes = field(repr=False)
+
+    def build(self, request: SigningRequest, signature: str, peer: SignerPeerAttestation) -> str:
+        message = "|".join(
+            [
+                request.payload_digest,
+                request.nonce,
+                request.requested_operation,
+                peer.peer_principal_id,
+                signature,
+            ]
+        ).encode("utf-8")
+        digest = hmac.new(self._audit_key, message, hashlib.sha256).hexdigest()
+        return "audit-mac-v1:" + digest
+
+
+def build_test_only_signer_backend_from_provider(
+    profile: SignerKeyProviderProfile,
+    resolver: SignerKeyResolver,
+    *,
+    provider_mode: str = "",
+    allow_test_only_key_material: bool = False,
+    permission_snapshot_fresh: bool = False,
+) -> SignerKeyProviderDryRunResult:
+    """Validate a signer profile and build a test-only Ed25519 signer backend.
+
+    The default path rejects. A caller must explicitly opt into
+    ``TEST_ONLY_DRYRUN`` and provide a fresh permission snapshot. This prevents
+    accidental production use while allowing contract-driven tests to prove the
+    existing signer backend can be supplied from an injected resolver boundary.
+    """
+
+    if not isinstance(profile, SignerKeyProviderProfile):
+        return _reject(FAIL_PROVIDER_PROFILE_INVALID)
+    if provider_mode != PROVIDER_MODE_TEST_ONLY_DRYRUN or not allow_test_only_key_material:
+        return _reject(FAIL_PROVIDER_MOCK_IN_PRODUCTION, profile=profile)
+    if not _profile_ascii_and_complete(profile):
+        return _reject(FAIL_PROVIDER_PROFILE_INVALID, profile=profile)
+    if not permission_snapshot_fresh:
+        return _reject(FAIL_PROVIDER_PERMISSION_DENIED, profile=profile)
+    if profile.signing_key_ref == profile.audit_mac_key_ref:
+        return _reject(FAIL_PROVIDER_REFERENCE_FORBIDDEN, profile=profile)
+    if not parse_op_reference(profile.signing_key_ref) or not parse_op_reference(profile.audit_mac_key_ref):
+        return _reject(FAIL_PROVIDER_REFERENCE_INVALID, profile=profile)
+    if profile.ttl_seconds <= 0:
+        return _reject(FAIL_PROVIDER_TTL_EXPIRED, profile=profile)
+
+    signing_result = _resolve(profile.signing_key_ref, profile.signer_agent_id, resolver)
+    if not signing_result.success:
+        return _reject(_resolve_rejection(signing_result), profile=profile, signing=signing_result)
+    audit_result = _resolve(profile.audit_mac_key_ref, profile.signer_agent_id, resolver)
+    if not audit_result.success:
+        return _reject(_resolve_rejection(audit_result), profile=profile, signing=signing_result, audit=audit_result)
+    if not _ttl_valid(signing_result, profile.ttl_seconds) or not _ttl_valid(audit_result, profile.ttl_seconds):
+        return _reject(FAIL_PROVIDER_TTL_EXPIRED, profile=profile, signing=signing_result, audit=audit_result)
+
+    signing_secret = signing_result.get_value()
+    audit_secret = audit_result.get_value()
+    private_key = _decode_ed25519_private_key(signing_secret)
+    if private_key is None:
+        return _reject(FAIL_PROVIDER_KEY_FORMAT, profile=profile, signing=signing_result, audit=audit_result)
+    audit_key = _decode_audit_key(audit_secret)
+    if audit_key is None:
+        return _reject(FAIL_PROVIDER_AUDIT_KEY_MISSING, profile=profile, signing=signing_result, audit=audit_result)
+
+    public_key = _public_key_text(private_key)
+    if public_key != profile.expected_public_key:
+        return _reject(FAIL_PROVIDER_PUBLIC_KEY_MISMATCH, profile=profile, signing=signing_result, audit=audit_result)
+    fingerprint = public_key_fingerprint(public_key)
+    if fingerprint != profile.expected_key_fingerprint:
+        return _reject(FAIL_PROVIDER_FINGERPRINT_MISMATCH, profile=profile, signing=signing_result, audit=audit_result)
+
+    return SignerKeyProviderDryRunResult(
+        ok=True,
+        rejection_code=None,
+        signer_profile_id=profile.signer_profile_id,
+        key_epoch=profile.expected_key_epoch,
+        public_key=public_key,
+        key_fingerprint=fingerprint,
+        signing_key_ref_hash=signing_result.reference_hash,
+        audit_mac_key_ref_hash=audit_result.reference_hash,
+        ttl_remaining_seconds=min(int(signing_result.ttl_remaining or 0), int(audit_result.ttl_remaining or 0)),
+        secret_values_returned=False,
+        backend=Ed25519SignerBackend(
+            private_key=private_key,
+            public_key=public_key,
+            key_epoch=profile.expected_key_epoch,
+            audit_mac_builder=_HmacAuditMacBuilder(audit_key),
+        ),
+    )
+
+
+def _resolve(reference: str, requester_id: str, resolver: SignerKeyResolver) -> ResolveResult:
+    try:
+        result = resolver.resolve(reference, requester_id=requester_id)
+    except Exception:
+        return ResolveResult(
+            success=False,
+            reference=reference,
+            reference_hash=hash_reference(reference),
+            error_message="resolver unavailable",
+        )
+    if not isinstance(result, ResolveResult):
+        return ResolveResult(
+            success=False,
+            reference=reference,
+            reference_hash=hash_reference(reference),
+            error_message="resolver unavailable",
+        )
+    return result
+
+
+def _resolve_rejection(result: ResolveResult) -> str:
+    value = result.error_code.value if result.error_code else ""
+    if value in {"RESOLVER_UNAVAILABLE", "SESSION_INVALID"}:
+        return FAIL_PROVIDER_RESOLVER_UNAVAILABLE
+    if value == "TTL_EXPIRED":
+        return FAIL_PROVIDER_TTL_EXPIRED
+    if value in {"INVALID_REFERENCE", "UNKNOWN_REFERENCE"}:
+        return FAIL_PROVIDER_REFERENCE_INVALID
+    return FAIL_PROVIDER_RESOLVER_UNAVAILABLE
+
+
+def _ttl_valid(result: ResolveResult, profile_ttl: int) -> bool:
+    if result.ttl_remaining is None:
+        return False
+    try:
+        ttl = int(result.ttl_remaining)
+    except Exception:
+        return False
+    return 0 < ttl <= profile_ttl
+
+
+def _decode_ed25519_private_key(secret: object) -> Any | None:
+    if not isinstance(secret, str) or not secret.startswith(SIGNING_KEY_PREFIX):
+        return None
+    try:
+        raw = base64.b64decode(secret[len(SIGNING_KEY_PREFIX):], validate=True)
+    except (binascii.Error, ValueError):
+        return None
+    if len(raw) != ED25519_PRIVATE_KEY_BYTES:
+        return None
+    try:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+        return Ed25519PrivateKey.from_private_bytes(raw)
+    except Exception:
+        return None
+
+
+def _decode_audit_key(secret: object) -> bytes | None:
+    if not isinstance(secret, str) or not secret.startswith(AUDIT_KEY_PREFIX):
+        return None
+    try:
+        raw = base64.b64decode(secret[len(AUDIT_KEY_PREFIX):], validate=True)
+    except (binascii.Error, ValueError):
+        return None
+    if len(raw) < MIN_AUDIT_KEY_BYTES:
+        return None
+    return raw
+
+
+def _public_key_text(private_key: Any) -> str:
+    from cryptography.hazmat.primitives import serialization
+
+    return encode_ed25519_public_key(
+        private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+    )
+
+
+def _reject(
+    code: str,
+    *,
+    profile: Optional[SignerKeyProviderProfile] = None,
+    signing: Optional[ResolveResult] = None,
+    audit: Optional[ResolveResult] = None,
+) -> SignerKeyProviderDryRunResult:
+    return SignerKeyProviderDryRunResult(
+        ok=False,
+        rejection_code=str(code),
+        signer_profile_id=profile.signer_profile_id if isinstance(profile, SignerKeyProviderProfile) else "",
+        key_epoch=None,
+        public_key=None,
+        key_fingerprint=None,
+        signing_key_ref_hash=(
+            signing.reference_hash
+            if isinstance(signing, ResolveResult)
+            else hash_reference(profile.signing_key_ref)
+            if isinstance(profile, SignerKeyProviderProfile)
+            else None
+        ),
+        audit_mac_key_ref_hash=(
+            audit.reference_hash
+            if isinstance(audit, ResolveResult)
+            else hash_reference(profile.audit_mac_key_ref)
+            if isinstance(profile, SignerKeyProviderProfile)
+            else None
+        ),
+        ttl_remaining_seconds=None,
+        secret_values_returned=False,
+        backend=None,
+    )
+
+
+def _profile_ascii_and_complete(profile: SignerKeyProviderProfile) -> bool:
+    payload = asdict(profile)
+    required = (
+        "signer_profile_id",
+        "signer_agent_id",
+        "signing_key_ref",
+        "audit_mac_key_ref",
+        "expected_public_key",
+        "expected_key_fingerprint",
+        "expected_key_epoch",
+        "permission_snapshot_digest",
+    )
+    if not all(isinstance(payload.get(key), str) and payload[key] for key in required):
+        return False
+    if not isinstance(profile.ttl_seconds, int):
+        return False
+    return _assert_ascii_deep(payload)
+
+
+def _assert_ascii_deep(value: object) -> bool:
+    if isinstance(value, str):
+        return all(ord(char) < 128 for char in value)
+    if isinstance(value, dict):
+        return all(
+            isinstance(key, str) and _assert_ascii_deep(key) and _assert_ascii_deep(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple)):
+        return all(_assert_ascii_deep(item) for item in value)
+    if value is None or isinstance(value, (bool, int, float)):
+        return True
+    return False
+
+
+__all__ = [
+    "AUDIT_KEY_PREFIX",
+    "FAIL_PROVIDER_AUDIT_KEY_MISSING",
+    "FAIL_PROVIDER_FINGERPRINT_MISMATCH",
+    "FAIL_PROVIDER_KEY_FORMAT",
+    "FAIL_PROVIDER_MOCK_IN_PRODUCTION",
+    "FAIL_PROVIDER_PERMISSION_DENIED",
+    "FAIL_PROVIDER_PROFILE_INVALID",
+    "FAIL_PROVIDER_PUBLIC_KEY_MISMATCH",
+    "FAIL_PROVIDER_REFERENCE_FORBIDDEN",
+    "FAIL_PROVIDER_REFERENCE_INVALID",
+    "FAIL_PROVIDER_RESOLVER_UNAVAILABLE",
+    "FAIL_PROVIDER_TTL_EXPIRED",
+    "PROVIDER_MODE_TEST_ONLY_DRYRUN",
+    "SIGNING_KEY_PREFIX",
+    "SignerKeyProviderDryRunResult",
+    "SignerKeyProviderProfile",
+    "build_test_only_signer_backend_from_provider",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_key_provider_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_key_provider_dryrun.py
@@ -1,0 +1,423 @@
+"""Tests for REDDOG_SIGNER_KEY_PROVIDER_DRYRUN_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import base64
+import json
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    Ed25519SignatureVerifier,
+    encode_ed25519_public_key,
+)
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_protocol import (
+    SignerPeerAttestation,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    SigningRequest,
+    public_key_fingerprint,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
+    AUDIT_KEY_PREFIX,
+    FAIL_PROVIDER_AUDIT_KEY_MISSING,
+    FAIL_PROVIDER_FINGERPRINT_MISMATCH,
+    FAIL_PROVIDER_KEY_FORMAT,
+    FAIL_PROVIDER_MOCK_IN_PRODUCTION,
+    FAIL_PROVIDER_PERMISSION_DENIED,
+    FAIL_PROVIDER_PROFILE_INVALID,
+    FAIL_PROVIDER_PUBLIC_KEY_MISMATCH,
+    FAIL_PROVIDER_REFERENCE_FORBIDDEN,
+    FAIL_PROVIDER_REFERENCE_INVALID,
+    FAIL_PROVIDER_RESOLVER_UNAVAILABLE,
+    FAIL_PROVIDER_TTL_EXPIRED,
+    PROVIDER_MODE_TEST_ONLY_DRYRUN,
+    SIGNING_KEY_PREFIX,
+    SignerKeyProviderProfile,
+    build_test_only_signer_backend_from_provider,
+)
+from modules.infrastructure.secrets_mcp.src.vault_resolver import (
+    ResolveErrorCode,
+    ResolveResult,
+    hash_reference,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_signer_key_provider_dryrun.py"
+)
+
+
+pytest.importorskip("cryptography")
+
+
+class FakeResolver:
+    def __init__(self, values: dict[str, str], ttl: int = 60) -> None:
+        self.values = values
+        self.ttl = ttl
+        self.calls: list[tuple[str, str | None]] = []
+
+    def resolve(self, reference: str, requester_id: str | None = None) -> ResolveResult:
+        self.calls.append((reference, requester_id))
+        value = self.values.get(reference)
+        if value is None:
+            return ResolveResult(
+                success=False,
+                reference=reference,
+                reference_hash=hash_reference(reference),
+                error_code=ResolveErrorCode.UNKNOWN_REFERENCE,
+                error_message="unknown",
+            )
+        return ResolveResult(
+            success=True,
+            reference=reference,
+            reference_hash=hash_reference(reference),
+            ttl_remaining=self.ttl,
+            session_id="test-session",
+            _secret_value=value,
+        )
+
+
+class RaisingResolver:
+    def resolve(self, reference: str, requester_id: str | None = None) -> ResolveResult:
+        raise RuntimeError("resolver down")
+
+
+class WrongTypeResolver:
+    def resolve(self, reference: str, requester_id: str | None = None) -> object:
+        return {"success": True}
+
+
+def _private_key():
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    return Ed25519PrivateKey.generate()
+
+
+def _private_key_secret(private_key) -> str:
+    from cryptography.hazmat.primitives import serialization
+
+    raw = private_key.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return SIGNING_KEY_PREFIX + base64.b64encode(raw).decode("ascii")
+
+
+def _public_text(private_key) -> str:
+    from cryptography.hazmat.primitives import serialization
+
+    public_bytes = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return encode_ed25519_public_key(public_bytes)
+
+
+def _audit_secret(raw: bytes = b"0123456789abcdef0123456789abcdef") -> str:
+    return AUDIT_KEY_PREFIX + base64.b64encode(raw).decode("ascii")
+
+
+def _profile(public_key: str, **overrides: object) -> SignerKeyProviderProfile:
+    values = {
+        "signer_profile_id": "signer-profile-1",
+        "signer_agent_id": "signer:reddog-authority",
+        "signing_key_ref": "op://test-vault/reddog-signing/private",
+        "audit_mac_key_ref": "op://test-vault/reddog-audit/mac",
+        "expected_public_key": public_key,
+        "expected_key_fingerprint": public_key_fingerprint(public_key),
+        "expected_key_epoch": "epoch-1",
+        "permission_snapshot_digest": "sha256:permission",
+        "ttl_seconds": 60,
+    }
+    values.update(overrides)
+    return SignerKeyProviderProfile(**values)
+
+
+def _resolver(private_key, audit_secret: str | None = None, ttl: int = 60) -> FakeResolver:
+    return FakeResolver(
+        {
+            "op://test-vault/reddog-signing/private": _private_key_secret(private_key),
+            "op://test-vault/reddog-audit/mac": audit_secret or _audit_secret(),
+        },
+        ttl=ttl,
+    )
+
+
+def _request(public_key: str) -> SigningRequest:
+    return SigningRequest(
+        signing_input='reddog-workauth.v1.{"work_order_id":"wo-1"}',
+        payload_digest="sha256:payload",
+        signer_role="reddog",
+        signer_public_key=public_key,
+        requester_principal_id="github:mjtrout",
+        nonce="nonce-1",
+        key_epoch="epoch-1",
+        requested_operation="create_foundup",
+        authority_tier="HIGH",
+        consensus_receipt_digest="sha256:consensus",
+    )
+
+
+def _peer() -> SignerPeerAttestation:
+    return SignerPeerAttestation(
+        peer_principal_id="github:mjtrout",
+        transport="unix_socket",
+        credential_source="kernel_peer_credential",
+        boundary_attested=True,
+    )
+
+
+def _build(profile: SignerKeyProviderProfile, resolver: object):
+    return build_test_only_signer_backend_from_provider(
+        profile,
+        resolver,  # type: ignore[arg-type]
+        provider_mode=PROVIDER_MODE_TEST_ONLY_DRYRUN,
+        allow_test_only_key_material=True,
+        permission_snapshot_fresh=True,
+    )
+
+
+def test_default_path_rejects_without_explicit_test_only_mode() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+
+    result = build_test_only_signer_backend_from_provider(_profile(public_key), _resolver(private_key))
+
+    assert result.ok is False
+    assert result.rejection_code == FAIL_PROVIDER_MOCK_IN_PRODUCTION
+    assert result.backend is None
+
+
+def test_acceptance_builds_backend_and_receipt_excludes_secret_values() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    resolver = _resolver(private_key)
+
+    result = _build(_profile(public_key), resolver)
+
+    assert result.ok is True
+    assert result.backend is not None
+    receipt = result.to_receipt()
+    assert receipt["secret_values_returned"] is False
+    assert "backend" not in receipt
+    dumped = json.dumps(receipt, sort_keys=True)
+    assert SIGNING_KEY_PREFIX not in dumped
+    assert AUDIT_KEY_PREFIX not in dumped
+    assert "0123456789abcdef" not in dumped
+    assert resolver.calls == [
+        ("op://test-vault/reddog-signing/private", "signer:reddog-authority"),
+        ("op://test-vault/reddog-audit/mac", "signer:reddog-authority"),
+    ]
+
+
+def test_backend_signs_and_public_verifier_accepts() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    result = _build(_profile(public_key), _resolver(private_key))
+
+    response = result.backend.sign(_request(public_key), _peer())  # type: ignore[union-attr]
+
+    assert response.accepted is True
+    assert response.audit_mac.startswith("audit-mac-v1:")
+    assert response.no_secret_material_returned is True
+    assert Ed25519SignatureVerifier().verify(public_key, _request(public_key).signing_input, response.signature) is True
+
+
+def test_permission_snapshot_must_be_fresh() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    result = build_test_only_signer_backend_from_provider(
+        _profile(public_key),
+        _resolver(private_key),
+        provider_mode=PROVIDER_MODE_TEST_ONLY_DRYRUN,
+        allow_test_only_key_material=True,
+        permission_snapshot_fresh=False,
+    )
+
+    assert result.ok is False
+    assert result.rejection_code == FAIL_PROVIDER_PERMISSION_DENIED
+
+
+def test_signing_and_audit_reference_must_differ() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    profile = _profile(public_key, audit_mac_key_ref="op://test-vault/reddog-signing/private")
+
+    result = _build(profile, _resolver(private_key))
+
+    assert result.ok is False
+    assert result.rejection_code == FAIL_PROVIDER_REFERENCE_FORBIDDEN
+
+
+def test_invalid_reference_rejects_before_resolver_call() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    resolver = _resolver(private_key)
+    profile = _profile(public_key, signing_key_ref="../bad")
+
+    result = _build(profile, resolver)
+
+    assert result.ok is False
+    assert result.rejection_code == FAIL_PROVIDER_REFERENCE_INVALID
+    assert resolver.calls == []
+
+
+def test_resolver_exception_or_wrong_type_rejects() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+
+    raised = _build(_profile(public_key), RaisingResolver())
+    wrong_type = _build(_profile(public_key), WrongTypeResolver())
+
+    assert raised.ok is False
+    assert raised.rejection_code == FAIL_PROVIDER_RESOLVER_UNAVAILABLE
+    assert wrong_type.ok is False
+    assert wrong_type.rejection_code == FAIL_PROVIDER_RESOLVER_UNAVAILABLE
+
+
+def test_missing_resolved_value_rejects_as_reference_invalid() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    result = _build(_profile(public_key), FakeResolver({}))
+
+    assert result.ok is False
+    assert result.rejection_code == FAIL_PROVIDER_REFERENCE_INVALID
+
+
+def test_ttl_expired_or_too_large_rejects() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    expired = _build(_profile(public_key), _resolver(private_key, ttl=0))
+    stale = _build(_profile(public_key, ttl_seconds=30), _resolver(private_key, ttl=31))
+
+    assert expired.ok is False
+    assert expired.rejection_code == FAIL_PROVIDER_TTL_EXPIRED
+    assert stale.ok is False
+    assert stale.rejection_code == FAIL_PROVIDER_TTL_EXPIRED
+
+
+def test_bad_signing_key_format_rejects() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    resolver = FakeResolver(
+        {
+            "op://test-vault/reddog-signing/private": SIGNING_KEY_PREFIX + "not-base64",
+            "op://test-vault/reddog-audit/mac": _audit_secret(),
+        }
+    )
+
+    result = _build(_profile(public_key), resolver)
+
+    assert result.ok is False
+    assert result.rejection_code == FAIL_PROVIDER_KEY_FORMAT
+
+
+def test_missing_or_short_audit_key_rejects() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+
+    missing = _build(_profile(public_key), _resolver(private_key, audit_secret="wrong-prefix"))
+    short = _build(_profile(public_key), _resolver(private_key, audit_secret=_audit_secret(b"short")))
+
+    assert missing.ok is False
+    assert missing.rejection_code == FAIL_PROVIDER_AUDIT_KEY_MISSING
+    assert short.ok is False
+    assert short.rejection_code == FAIL_PROVIDER_AUDIT_KEY_MISSING
+
+
+def test_public_key_and_fingerprint_mismatches_reject() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    other_public = _public_text(_private_key())
+
+    wrong_public = _build(_profile(other_public), _resolver(private_key))
+    wrong_fingerprint = _build(
+        _profile(public_key, expected_key_fingerprint=public_key_fingerprint(other_public)),
+        _resolver(private_key),
+    )
+
+    assert wrong_public.ok is False
+    assert wrong_public.rejection_code == FAIL_PROVIDER_PUBLIC_KEY_MISMATCH
+    assert wrong_fingerprint.ok is False
+    assert wrong_fingerprint.rejection_code == FAIL_PROVIDER_FINGERPRINT_MISMATCH
+
+
+def test_non_ascii_or_incomplete_profile_rejects() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    non_ascii = _build(_profile(public_key, signer_profile_id="bad-\u2603"), _resolver(private_key))
+    incomplete = _build(_profile(public_key, expected_key_epoch=""), _resolver(private_key))
+
+    assert non_ascii.ok is False
+    assert non_ascii.rejection_code == FAIL_PROVIDER_PROFILE_INVALID
+    assert incomplete.ok is False
+    assert incomplete.rejection_code == FAIL_PROVIDER_PROFILE_INVALID
+
+
+def test_result_repr_and_receipt_do_not_expose_secret_material() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    result = _build(_profile(public_key), _resolver(private_key))
+    text = repr(result) + json.dumps(result.to_receipt(), sort_keys=True)
+
+    assert SIGNING_KEY_PREFIX not in text
+    assert AUDIT_KEY_PREFIX not in text
+    assert "PRIVATE KEY" not in text.upper()
+    assert "0123456789abcdef" not in text
+
+
+def test_module_has_no_repo_shell_socket_openclaw_hermes_or_holoindex_runtime_surface() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "os",
+        "subprocess",
+        "socket",
+        "requests",
+        "urllib",
+        "http",
+        "git",
+        "holo_index",
+    }
+    banned_name_calls = {"eval", "exec", "compile", "__import__"}
+    banned_attrs = {
+        "getenv",
+        "environ",
+        "system",
+        "popen",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "spawn",
+        "bind",
+        "connect",
+        "read_text",
+        "read_bytes",
+        "write_text",
+        "write_bytes",
+        "private_bytes",
+    }
+    banned_name_fragments = ("openclaw", "hermes", "worktree", "holoindex")
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+            assert not any(fragment in node.module.lower() for fragment in banned_name_fragments)
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_name_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs


### PR DESCRIPTION
## Summary

Adds `REDDOG_SIGNER_KEY_PROVIDER_DRYRUN_PHASE1`, a test-only key-provider adapter that validates the #1072 signer key-provider contract with injected resolver results.

It can construct the existing `Ed25519SignerBackend` only when all of these are true:

- `provider_mode == TEST_ONLY_DRYRUN`
- `allow_test_only_key_material=True`
- `permission_snapshot_fresh=True`
- signing and audit key references are distinct valid `op://` references
- resolver returns bounded TTL test-only values
- decoded Ed25519 private key derives the expected public key and fingerprint
- audit-MAC key material is present and distinct

## Validation

- `pytest modules/communication/moltbot_bridge/tests/test_reddog_signer_key_provider_dryrun.py -q` -> 15 passed
- signer/socket/contract band -> 54 passed, 3 skipped (Windows AF_UNIX live-socket skips)
- `git diff --check` -> clean (LF/CRLF warning only)
- New module/test: 0 non-ASCII, 0 NUL
- Diff additions: 0 non-ASCII
- `python -m py_compile` on new module/test -> pass
- Local `ruff` unavailable in this environment; CI lint is the authority

## HoloIndex

Read-only probe for `RedDog signer key provider dryrun WSP71 Ed25519 audit mac` surfaced adjacent signer isolation, merge authority, and verifier modules, but not this new dry-run provider before indexing.

Recorded INDEX_GAP: `HOLOINDEX_REDDOG_SIGNER_KEY_PROVIDER_DRYRUN_INDEX_GAP_PHASE1`.

No runtime re-index is performed.

## Truth Boundary Checklist

- NO_PRODUCTION_VAULT_RESOLUTION: PASS
- NO_ENV_OR_ARGV_SECRET_PATH: PASS
- NO_FILE_KEY_LOADING: PASS
- NO_SOCKET_BINDING: PASS
- NO_SIGNER_PROCESS_LAUNCH: PASS
- NO_SHELL_COMMAND: PASS
- NO_REPO_MUTATION: PASS
- NO_OPENCLAW_HERMES_WRE_WIRING: PASS
- NO_HOLOINDEX_REINDEX: PASS
- TEST_ONLY_DRYRUN: PASS

## Residual SPECIFIED_NOT_IMPLEMENTED

- signer socket peer credential attestor
- isolated signer process entrypoint
- production WSP71 vault resolver integration
- signer service runtime wiring
- live authority pilot