### PR TITLE
feat(reddog): add signer socket peer credential attestor

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,28 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_SIGNER_SOCKET_PEER_CREDENTIAL_ATTESTOR_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 71, 95, 97
+
+- Added `src/reddog_signer_socket_peer_credential_attestor.py`: a
+  fail-closed local-socket peer credential attestor for the isolated signer
+  service. It maps kernel UID/GID evidence from `SO_PEERCRED` or `getpeereid`
+  through an injected signer-owned policy into the existing
+  `SignerPeerAttestation` record.
+- Added tests proving successful UID/GID mapping, `getpeereid` fallback,
+  unsupported-platform fail-closed behavior, malformed/exception credential
+  rejection, UID/GID allowlist rejection, policy validation, no request-body
+  identity parameter, and AST denial of shell, file, repo, OpenClaw, Hermes,
+  and HoloIndex runtime mutation surfaces.
+- Boundary: peer attestation only. No request payload identity is trusted, no
+  OS user lookup, no file read, no signer launch, no socket binding, no shell
+  command, no repository mutation, no OpenClaw enqueue, no Hermes dispatch, no
+  WRE queue write, no reward settlement, and no HoloIndex runtime re-index.
+- HoloIndex read-only probe for `RedDog signer socket peer credential attestor
+  SO_PEERCRED getpeereid` is recorded as
+  `HOLOINDEX_REDDOG_SIGNER_SOCKET_PEER_CREDENTIAL_ATTESTOR_INDEX_GAP_PHASE1`;
+  no runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_SIGNER_KEY_PROVIDER_DRYRUN_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 71, 95, 97

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_peer_credential_attestor.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_peer_credential_attestor.py
@@ -1,0 +1,151 @@
+"""Kernel peer-credential attestor for the isolated RedDog signer socket.
+
+Slice: REDDOG_SIGNER_SOCKET_PEER_CREDENTIAL_ATTESTOR_PHASE1
+
+This module converts local socket peer credentials into the existing
+``SignerPeerAttestation`` record using an injected UID/GID policy. It never
+reads request-body identity, spawns processes, shells out, reads files, mutates
+the repository, enqueues OpenClaw, dispatches Hermes, or re-indexes HoloIndex.
+Unsupported platforms fail closed.
+"""
+
+from __future__ import annotations
+
+import socket
+import struct
+from dataclasses import dataclass, field
+from typing import Mapping, Optional, Protocol
+
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_protocol import (
+    SignerPeerAttestation,
+)
+
+
+PEER_CREDENTIAL_SOURCE_SO_PEERCRED = "kernel_so_peercred"
+PEER_CREDENTIAL_SOURCE_GETPEEREID = "kernel_getpeereid"
+
+FAIL_PEER_CREDENTIAL_POLICY_INVALID = "FAIL_PEER_CREDENTIAL_POLICY_INVALID"
+FAIL_PEER_CREDENTIAL_UNAVAILABLE = "FAIL_PEER_CREDENTIAL_UNAVAILABLE"
+FAIL_PEER_CREDENTIAL_READ_FAILED = "FAIL_PEER_CREDENTIAL_READ_FAILED"
+FAIL_PEER_CREDENTIAL_MALFORMED = "FAIL_PEER_CREDENTIAL_MALFORMED"
+FAIL_PEER_CREDENTIAL_UID_NOT_ALLOWED = "FAIL_PEER_CREDENTIAL_UID_NOT_ALLOWED"
+FAIL_PEER_CREDENTIAL_GID_NOT_ALLOWED = "FAIL_PEER_CREDENTIAL_GID_NOT_ALLOWED"
+
+_SO_PEERCRED: Optional[int] = getattr(socket, "SO_PEERCRED", None)
+_PEERCRED_STRUCT = "3i"
+
+
+class PeerCredentialSocket(Protocol):
+    """Small subset of socket APIs needed for peer credential attestation."""
+
+    def getsockopt(self, level: int, optname: int, buflen: int) -> bytes:
+        """Return socket option bytes."""
+
+
+@dataclass(frozen=True)
+class PeerCredentialPolicy:
+    """Signer-owned mapping from kernel UID/GID to RedDog principal id."""
+
+    uid_to_principal: Mapping[int, str]
+    allowed_gids: tuple[int, ...] = ()
+    transport: str = "unix_socket"
+    credential_source_prefix: str = "kernel_peer_credential"
+
+
+@dataclass(frozen=True)
+class KernelPeerCredentialAttestor:
+    """Attest requester identity from kernel peer credentials."""
+
+    policy: PeerCredentialPolicy = field(default_factory=lambda: PeerCredentialPolicy({}))
+
+    def attest(self, connection: PeerCredentialSocket) -> SignerPeerAttestation:
+        if not _policy_valid(self.policy):
+            return _reject(FAIL_PEER_CREDENTIAL_POLICY_INVALID, self.policy)
+        credential = _read_peer_credential(connection)
+        if credential is None:
+            return _reject(FAIL_PEER_CREDENTIAL_UNAVAILABLE, self.policy)
+        source, pid, uid, gid = credential
+        if uid < 0 or gid < 0 or pid < 0:
+            return _reject(FAIL_PEER_CREDENTIAL_MALFORMED, self.policy)
+        principal = self.policy.uid_to_principal.get(uid)
+        if not principal:
+            return _reject(FAIL_PEER_CREDENTIAL_UID_NOT_ALLOWED, self.policy)
+        if self.policy.allowed_gids and gid not in self.policy.allowed_gids:
+            return _reject(FAIL_PEER_CREDENTIAL_GID_NOT_ALLOWED, self.policy)
+        if not _is_ascii(principal):
+            return _reject(FAIL_PEER_CREDENTIAL_POLICY_INVALID, self.policy)
+        return SignerPeerAttestation(
+            peer_principal_id=principal,
+            transport=self.policy.transport,
+            credential_source=(
+                f"{self.policy.credential_source_prefix}:{source}:pid={pid}:uid={uid}:gid={gid}"
+            ),
+            boundary_attested=True,
+        )
+
+
+def _read_peer_credential(connection: PeerCredentialSocket) -> tuple[str, int, int, int] | None:
+    if _SO_PEERCRED is not None:
+        try:
+            raw = connection.getsockopt(
+                socket.SOL_SOCKET,
+                int(_SO_PEERCRED),
+                struct.calcsize(_PEERCRED_STRUCT),
+            )
+            if not isinstance(raw, (bytes, bytearray)) or len(raw) != struct.calcsize(_PEERCRED_STRUCT):
+                return None
+            pid, uid, gid = struct.unpack(_PEERCRED_STRUCT, raw)
+            return (PEER_CREDENTIAL_SOURCE_SO_PEERCRED, int(pid), int(uid), int(gid))
+        except Exception:
+            return None
+    getpeereid = getattr(connection, "getpeereid", None)
+    if callable(getpeereid):
+        try:
+            uid, gid = getpeereid()
+            return (PEER_CREDENTIAL_SOURCE_GETPEEREID, 0, int(uid), int(gid))
+        except Exception:
+            return None
+    return None
+
+
+def _policy_valid(policy: PeerCredentialPolicy) -> bool:
+    if not isinstance(policy, PeerCredentialPolicy) or not policy.uid_to_principal:
+        return False
+    if not _is_ascii(policy.transport) or not _is_ascii(policy.credential_source_prefix):
+        return False
+    for uid, principal in policy.uid_to_principal.items():
+        if not isinstance(uid, int) or uid < 0 or not _is_ascii(principal) or not principal:
+            return False
+    return all(isinstance(gid, int) and gid >= 0 for gid in policy.allowed_gids)
+
+
+def _reject(code: str, policy: PeerCredentialPolicy) -> SignerPeerAttestation:
+    transport = (
+        policy.transport
+        if isinstance(policy, PeerCredentialPolicy) and _is_ascii(policy.transport)
+        else "local_socket"
+    )
+    return SignerPeerAttestation(
+        peer_principal_id="",
+        transport=transport,
+        credential_source=str(code),
+        boundary_attested=False,
+    )
+
+
+def _is_ascii(value: object) -> bool:
+    return isinstance(value, str) and all(ord(char) < 128 for char in value)
+
+
+__all__ = [
+    "FAIL_PEER_CREDENTIAL_GID_NOT_ALLOWED",
+    "FAIL_PEER_CREDENTIAL_MALFORMED",
+    "FAIL_PEER_CREDENTIAL_POLICY_INVALID",
+    "FAIL_PEER_CREDENTIAL_READ_FAILED",
+    "FAIL_PEER_CREDENTIAL_UID_NOT_ALLOWED",
+    "FAIL_PEER_CREDENTIAL_UNAVAILABLE",
+    "KernelPeerCredentialAttestor",
+    "PEER_CREDENTIAL_SOURCE_GETPEEREID",
+    "PEER_CREDENTIAL_SOURCE_SO_PEERCRED",
+    "PeerCredentialPolicy",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_peer_credential_attestor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_peer_credential_attestor.py
@@ -1,0 +1,219 @@
+"""Tests for REDDOG_SIGNER_SOCKET_PEER_CREDENTIAL_ATTESTOR_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import struct
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src import (
+    reddog_signer_socket_peer_credential_attestor as attestor_module,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_peer_credential_attestor import (
+    FAIL_PEER_CREDENTIAL_GID_NOT_ALLOWED,
+    FAIL_PEER_CREDENTIAL_MALFORMED,
+    FAIL_PEER_CREDENTIAL_POLICY_INVALID,
+    FAIL_PEER_CREDENTIAL_UID_NOT_ALLOWED,
+    FAIL_PEER_CREDENTIAL_UNAVAILABLE,
+    KernelPeerCredentialAttestor,
+    PEER_CREDENTIAL_SOURCE_GETPEEREID,
+    PEER_CREDENTIAL_SOURCE_SO_PEERCRED,
+    PeerCredentialPolicy,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_signer_socket_peer_credential_attestor.py"
+)
+
+
+class FakePeerCredSocket:
+    def __init__(self, *, pid: int = 123, uid: int = 1001, gid: int = 1002) -> None:
+        self.pid = pid
+        self.uid = uid
+        self.gid = gid
+        self.calls: list[tuple[int, int, int]] = []
+
+    def getsockopt(self, level: int, optname: int, buflen: int) -> bytes:
+        self.calls.append((level, optname, buflen))
+        return struct.pack("3i", self.pid, self.uid, self.gid)
+
+
+class ShortPeerCredSocket:
+    def getsockopt(self, level: int, optname: int, buflen: int) -> bytes:
+        return b"bad"
+
+
+class RaisingPeerCredSocket:
+    def getsockopt(self, level: int, optname: int, buflen: int) -> bytes:
+        raise OSError("unavailable")
+
+
+class GetPeerEidSocket:
+    def __init__(self, *, uid: int = 1001, gid: int = 1002, fail: bool = False) -> None:
+        self.uid = uid
+        self.gid = gid
+        self.fail = fail
+
+    def getpeereid(self) -> tuple[int, int]:
+        if self.fail:
+            raise OSError("unavailable")
+        return (self.uid, self.gid)
+
+
+@pytest.fixture(autouse=True)
+def restore_so_peercred(monkeypatch: pytest.MonkeyPatch):
+    original = attestor_module._SO_PEERCRED
+    yield
+    monkeypatch.setattr(attestor_module, "_SO_PEERCRED", original)
+
+
+def _policy(**overrides: object) -> PeerCredentialPolicy:
+    values = {
+        "uid_to_principal": {1001: "github:mjtrout"},
+        "allowed_gids": (1002,),
+        "transport": "unix_socket",
+        "credential_source_prefix": "kernel_peer_credential",
+    }
+    values.update(overrides)
+    return PeerCredentialPolicy(**values)
+
+
+def test_so_peercred_success_maps_uid_to_principal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(attestor_module, "_SO_PEERCRED", 17)
+    fake = FakePeerCredSocket()
+
+    result = KernelPeerCredentialAttestor(_policy()).attest(fake)
+
+    assert result.boundary_attested is True
+    assert result.peer_principal_id == "github:mjtrout"
+    assert PEER_CREDENTIAL_SOURCE_SO_PEERCRED in result.credential_source
+    assert "uid=1001" in result.credential_source
+    assert "gid=1002" in result.credential_source
+    assert fake.calls == [(attestor_module.socket.SOL_SOCKET, 17, struct.calcsize("3i"))]
+
+
+def test_getpeereid_fallback_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(attestor_module, "_SO_PEERCRED", None)
+
+    result = KernelPeerCredentialAttestor(_policy()).attest(GetPeerEidSocket())
+
+    assert result.boundary_attested is True
+    assert result.peer_principal_id == "github:mjtrout"
+    assert PEER_CREDENTIAL_SOURCE_GETPEEREID in result.credential_source
+    assert "pid=0" in result.credential_source
+
+
+def test_unsupported_platform_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(attestor_module, "_SO_PEERCRED", None)
+
+    result = KernelPeerCredentialAttestor(_policy()).attest(object())
+
+    assert result.boundary_attested is False
+    assert result.peer_principal_id == ""
+    assert result.credential_source == FAIL_PEER_CREDENTIAL_UNAVAILABLE
+
+
+def test_malformed_or_exception_credentials_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(attestor_module, "_SO_PEERCRED", 17)
+
+    short = KernelPeerCredentialAttestor(_policy()).attest(ShortPeerCredSocket())
+    raised = KernelPeerCredentialAttestor(_policy()).attest(RaisingPeerCredSocket())
+    negative = KernelPeerCredentialAttestor(_policy()).attest(FakePeerCredSocket(uid=-1))
+
+    assert short.boundary_attested is False
+    assert short.credential_source == FAIL_PEER_CREDENTIAL_UNAVAILABLE
+    assert raised.boundary_attested is False
+    assert raised.credential_source == FAIL_PEER_CREDENTIAL_UNAVAILABLE
+    assert negative.boundary_attested is False
+    assert negative.credential_source == FAIL_PEER_CREDENTIAL_MALFORMED
+
+
+def test_unmapped_uid_and_wrong_gid_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(attestor_module, "_SO_PEERCRED", 17)
+
+    uid = KernelPeerCredentialAttestor(_policy()).attest(FakePeerCredSocket(uid=2000))
+    gid = KernelPeerCredentialAttestor(_policy()).attest(FakePeerCredSocket(gid=3000))
+
+    assert uid.boundary_attested is False
+    assert uid.credential_source == FAIL_PEER_CREDENTIAL_UID_NOT_ALLOWED
+    assert gid.boundary_attested is False
+    assert gid.credential_source == FAIL_PEER_CREDENTIAL_GID_NOT_ALLOWED
+
+
+def test_policy_must_be_complete_ascii_and_non_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(attestor_module, "_SO_PEERCRED", 17)
+    cases = (
+        PeerCredentialPolicy({}),
+        PeerCredentialPolicy({1001: ""}),
+        PeerCredentialPolicy({1001: "github:\u2603"}),
+        PeerCredentialPolicy({-1: "github:mjtrout"}),
+        PeerCredentialPolicy({1001: "github:mjtrout"}, allowed_gids=(-1,)),
+        PeerCredentialPolicy({1001: "github:mjtrout"}, transport="sock-\u2603"),
+    )
+
+    for policy in cases:
+        result = KernelPeerCredentialAttestor(policy).attest(FakePeerCredSocket())
+        assert result.boundary_attested is False
+        assert result.credential_source == FAIL_PEER_CREDENTIAL_POLICY_INVALID
+
+
+def test_attestor_has_no_request_body_input() -> None:
+    import inspect
+
+    signature = inspect.signature(KernelPeerCredentialAttestor.attest)
+    assert list(signature.parameters) == ["self", "connection"]
+
+
+def test_module_has_no_shell_file_repo_openclaw_hermes_or_holoindex_surface() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "os",
+        "subprocess",
+        "pwd",
+        "grp",
+        "psutil",
+        "requests",
+        "urllib",
+        "http",
+        "git",
+        "holo_index",
+    }
+    banned_name_calls = {"eval", "exec", "compile", "__import__", "open"}
+    banned_attrs = {
+        "getenv",
+        "environ",
+        "system",
+        "popen",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "spawn",
+        "read_text",
+        "read_bytes",
+        "write_text",
+        "write_bytes",
+    }
+    banned_name_fragments = ("openclaw", "hermes", "worktree", "holoindex")
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+            assert not any(fragment in node.module.lower() for fragment in banned_name_fragments)
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_name_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs


### PR DESCRIPTION
## Summary

Adds `REDDOG_SIGNER_SOCKET_PEER_CREDENTIAL_ATTESTOR_PHASE1`, a fail-closed peer credential attestor for the isolated RedDog signer socket service.

The attestor maps kernel socket credentials to the existing `SignerPeerAttestation` using an injected signer-owned UID/GID policy:

- Linux `SO_PEERCRED` path
- `getpeereid` fallback where available
- explicit UID-to-principal mapping
- optional GID allowlist
- no request-body identity input
- fail-closed on unsupported platforms, malformed credentials, unmapped UID, wrong GID, or invalid policy

## Validation

- `pytest modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_peer_credential_attestor.py -q` -> 8 passed
- signer/socket band -> 40 passed, 3 skipped (Windows AF_UNIX live-socket skips)
- `git diff --check` -> clean (LF/CRLF warning only)
- New module/test: 0 non-ASCII, 0 NUL
- Diff additions: 0 non-ASCII
- `python -m py_compile` on new module/test -> pass

## HoloIndex

Read-only probe for `RedDog signer socket peer credential attestor SO_PEERCRED getpeereid` surfaced adjacent verifier/signing docs and credential surfaces, but not this new module before indexing.

Recorded INDEX_GAP: `HOLOINDEX_REDDOG_SIGNER_SOCKET_PEER_CREDENTIAL_ATTESTOR_INDEX_GAP_PHASE1`.

No runtime re-index is performed.

## Truth Boundary Checklist

- NO_REQUEST_BODY_IDENTITY_TRUSTED: PASS
- NO_OS_USER_LOOKUP: PASS
- NO_FILE_READ: PASS
- NO_SIGNER_LAUNCH: PASS
- NO_SOCKET_BINDING: PASS
- NO_SHELL_COMMAND: PASS
- NO_REPO_MUTATION: PASS
- NO_OPENCLAW_HERMES_WRE_WIRING: PASS
- NO_HOLOINDEX_REINDEX: PASS

## Residual SPECIFIED_NOT_IMPLEMENTED

- isolated signer process entrypoint
- production WSP71 vault resolver integration
- signer service runtime wiring
- live authority pilot