### PR TITLE
feat(reddog): add isolated signer process entrypoint

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,27 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_ISOLATED_SIGNER_PROCESS_ENTRYPOINT_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 71, 95, 97
+
+- Added `src/reddog_isolated_signer_process_entrypoint.py`: a one-shot
+  composition function that wires the test-only signer key-provider dry-run,
+  kernel peer-credential attestor, and existing one-request signer socket
+  service through injected dependencies.
+- Added tests proving successful composition, key-provider rejection before
+  service invocation, peer-policy rejection before key-provider/service use,
+  invalid config rejection, service rejection/exception preservation, service
+  return-type validation, receipt non-leakage, and AST denial of env, shell,
+  file, repo, OpenClaw, Hermes, and HoloIndex runtime mutation surfaces.
+- Boundary: injectable process entrypoint only. No environment parsing, no
+  process spawn, no direct socket bind in this module, no file secret loading,
+  no repository mutation, no OpenClaw enqueue, no Hermes dispatch, no WRE queue
+  write, no reward settlement, and no HoloIndex runtime re-index.
+- HoloIndex read-only probe for `RedDog isolated signer process entrypoint key
+  provider peer credential service` is recorded as
+  `HOLOINDEX_REDDOG_ISOLATED_SIGNER_PROCESS_ENTRYPOINT_INDEX_GAP_PHASE1`; no
+  runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_SIGNER_SOCKET_PEER_CREDENTIAL_ATTESTOR_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 71, 95, 97

--- a/modules/communication/moltbot_bridge/src/reddog_isolated_signer_process_entrypoint.py
+++ b/modules/communication/moltbot_bridge/src/reddog_isolated_signer_process_entrypoint.py
@@ -1,0 +1,202 @@
+"""One-shot isolated RedDog signer process entrypoint composition.
+
+Slice: REDDOG_ISOLATED_SIGNER_PROCESS_ENTRYPOINT_PHASE1
+
+This module composes the signer key-provider dry-run, kernel peer-credential
+attestor, and one-request signer socket service. It does not parse environment
+variables, spawn a process, bind sockets directly, read files, mutate the
+repository, enqueue OpenClaw, dispatch Hermes, or re-index HoloIndex.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Callable, Optional, Protocol
+
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_service import (
+    DEFAULT_SIGNER_SOCKET_SERVICE_MAX_RESPONSE_BYTES,
+    DEFAULT_SIGNER_SOCKET_SERVICE_TIMEOUT_S,
+    SIGNER_SOCKET_SERVICE_SERVED,
+    IsolatedSignerSocketServiceResult,
+    serve_reddog_isolated_signer_socket_once,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
+    PROVIDER_MODE_TEST_ONLY_DRYRUN,
+    SignerKeyProviderProfile,
+    SignerKeyResolver,
+    build_test_only_signer_backend_from_provider,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_peer_credential_attestor import (
+    KernelPeerCredentialAttestor,
+    PeerCredentialPolicy,
+)
+
+
+SIGNER_PROCESS_ENTRYPOINT_SERVED = "SIGNER_PROCESS_ENTRYPOINT_SERVED"
+SIGNER_PROCESS_ENTRYPOINT_REJECT = "SIGNER_PROCESS_ENTRYPOINT_REJECT"
+
+FAIL_SIGNER_PROCESS_CONFIG_INVALID = "FAIL_SIGNER_PROCESS_CONFIG_INVALID"
+FAIL_SIGNER_PROCESS_PEER_POLICY_INVALID = "FAIL_SIGNER_PROCESS_PEER_POLICY_INVALID"
+FAIL_SIGNER_PROCESS_KEY_PROVIDER_REJECTED = "FAIL_SIGNER_PROCESS_KEY_PROVIDER_REJECTED"
+FAIL_SIGNER_PROCESS_SERVICE_REJECTED = "FAIL_SIGNER_PROCESS_SERVICE_REJECTED"
+FAIL_SIGNER_PROCESS_SERVICE_INVALID = "FAIL_SIGNER_PROCESS_SERVICE_INVALID"
+
+
+class ServeSignerSocketOnce(Protocol):
+    """Injected signer socket service callable."""
+
+    def __call__(
+        self,
+        *,
+        repo_root: Path | str,
+        socket_path: Path | str | None,
+        backend: Any,
+        peer_attestor: Any,
+        timeout_s: float,
+        max_request_bytes: int,
+        max_response_bytes: int,
+        ready_callback: Optional[Callable[[], None]] = None,
+    ) -> IsolatedSignerSocketServiceResult:
+        """Serve one signer request."""
+
+
+@dataclass(frozen=True)
+class IsolatedSignerProcessEntryPointConfig:
+    """Configuration supplied by the future isolated signer process owner."""
+
+    repo_root: Path | str
+    socket_path: Path | str | None
+    key_provider_profile: SignerKeyProviderProfile
+    peer_policy: PeerCredentialPolicy
+    provider_mode: str = PROVIDER_MODE_TEST_ONLY_DRYRUN
+    allow_test_only_key_material: bool = False
+    permission_snapshot_fresh: bool = False
+    timeout_s: float = DEFAULT_SIGNER_SOCKET_SERVICE_TIMEOUT_S
+    max_request_bytes: int = 16384
+    max_response_bytes: int = DEFAULT_SIGNER_SOCKET_SERVICE_MAX_RESPONSE_BYTES
+
+
+@dataclass(frozen=True)
+class IsolatedSignerProcessEntryPointResult:
+    """Audit-safe entrypoint result."""
+
+    accepted: bool
+    status: str
+    rejection_reasons: tuple[str, ...]
+    key_provider_receipt: dict[str, Any]
+    service_result: Optional[dict[str, Any]]
+    no_env_parsed: bool = True
+    no_process_spawned: bool = True
+    no_socket_bound_directly: bool = True
+    no_file_secret_loaded: bool = True
+    no_repo_mutation_performed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_wre_queue_write_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_secret_values_returned: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_isolated_signer_process_once(
+    config: IsolatedSignerProcessEntryPointConfig,
+    resolver: SignerKeyResolver,
+    *,
+    serve_once: ServeSignerSocketOnce = serve_reddog_isolated_signer_socket_once,
+    ready_callback: Optional[Callable[[], None]] = None,
+) -> IsolatedSignerProcessEntryPointResult:
+    """Compose the one-shot signer service with injected dry-run dependencies."""
+
+    if not isinstance(config, IsolatedSignerProcessEntryPointConfig):
+        return _reject(FAIL_SIGNER_PROCESS_CONFIG_INVALID)
+    if not _peer_policy_valid(config.peer_policy):
+        return _reject(FAIL_SIGNER_PROCESS_PEER_POLICY_INVALID)
+
+    key_result = build_test_only_signer_backend_from_provider(
+        config.key_provider_profile,
+        resolver,
+        provider_mode=config.provider_mode,
+        allow_test_only_key_material=config.allow_test_only_key_material,
+        permission_snapshot_fresh=config.permission_snapshot_fresh,
+    )
+    key_receipt = key_result.to_receipt()
+    if not key_result.ok or key_result.backend is None:
+        return _reject(FAIL_SIGNER_PROCESS_KEY_PROVIDER_REJECTED, key_provider_receipt=key_receipt)
+
+    try:
+        service_result = serve_once(
+            repo_root=config.repo_root,
+            socket_path=config.socket_path,
+            backend=key_result.backend,
+            peer_attestor=KernelPeerCredentialAttestor(config.peer_policy),
+            timeout_s=config.timeout_s,
+            max_request_bytes=config.max_request_bytes,
+            max_response_bytes=config.max_response_bytes,
+            ready_callback=ready_callback,
+        )
+    except Exception:
+        return _reject(FAIL_SIGNER_PROCESS_SERVICE_REJECTED, key_provider_receipt=key_receipt)
+    if not isinstance(service_result, IsolatedSignerSocketServiceResult):
+        return _reject(FAIL_SIGNER_PROCESS_SERVICE_INVALID, key_provider_receipt=key_receipt)
+    service_receipt = service_result.to_dict()
+    if service_result.accepted is not True or service_result.status != SIGNER_SOCKET_SERVICE_SERVED:
+        return _reject(
+            FAIL_SIGNER_PROCESS_SERVICE_REJECTED,
+            key_provider_receipt=key_receipt,
+            service_result=service_receipt,
+        )
+
+    return IsolatedSignerProcessEntryPointResult(
+        accepted=True,
+        status=SIGNER_PROCESS_ENTRYPOINT_SERVED,
+        rejection_reasons=(),
+        key_provider_receipt=key_receipt,
+        service_result=service_receipt,
+    )
+
+
+def _reject(
+    *reasons: str,
+    key_provider_receipt: Optional[dict[str, Any]] = None,
+    service_result: Optional[dict[str, Any]] = None,
+) -> IsolatedSignerProcessEntryPointResult:
+    return IsolatedSignerProcessEntryPointResult(
+        accepted=False,
+        status=SIGNER_PROCESS_ENTRYPOINT_REJECT,
+        rejection_reasons=tuple(str(reason) for reason in reasons if reason),
+        key_provider_receipt=key_provider_receipt or {},
+        service_result=service_result,
+    )
+
+
+def _peer_policy_valid(policy: PeerCredentialPolicy) -> bool:
+    if not isinstance(policy, PeerCredentialPolicy) or not policy.uid_to_principal:
+        return False
+    for uid, principal in policy.uid_to_principal.items():
+        if not isinstance(uid, int) or uid < 0:
+            return False
+        if not isinstance(principal, str) or not principal or not _is_ascii(principal):
+            return False
+    return all(isinstance(gid, int) and gid >= 0 for gid in policy.allowed_gids)
+
+
+def _is_ascii(value: str) -> bool:
+    return all(ord(char) < 128 for char in value)
+
+
+__all__ = [
+    "FAIL_SIGNER_PROCESS_CONFIG_INVALID",
+    "FAIL_SIGNER_PROCESS_KEY_PROVIDER_REJECTED",
+    "FAIL_SIGNER_PROCESS_PEER_POLICY_INVALID",
+    "FAIL_SIGNER_PROCESS_SERVICE_INVALID",
+    "FAIL_SIGNER_PROCESS_SERVICE_REJECTED",
+    "IsolatedSignerProcessEntryPointConfig",
+    "IsolatedSignerProcessEntryPointResult",
+    "SIGNER_PROCESS_ENTRYPOINT_REJECT",
+    "SIGNER_PROCESS_ENTRYPOINT_SERVED",
+    "ServeSignerSocketOnce",
+    "run_reddog_isolated_signer_process_once",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_isolated_signer_process_entrypoint.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_isolated_signer_process_entrypoint.py
@@ -1,0 +1,365 @@
+"""Tests for REDDOG_ISOLATED_SIGNER_PROCESS_ENTRYPOINT_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import base64
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    Ed25519SignatureVerifier,
+    encode_ed25519_public_key,
+)
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_process_entrypoint import (
+    FAIL_SIGNER_PROCESS_CONFIG_INVALID,
+    FAIL_SIGNER_PROCESS_KEY_PROVIDER_REJECTED,
+    FAIL_SIGNER_PROCESS_PEER_POLICY_INVALID,
+    FAIL_SIGNER_PROCESS_SERVICE_INVALID,
+    FAIL_SIGNER_PROCESS_SERVICE_REJECTED,
+    SIGNER_PROCESS_ENTRYPOINT_REJECT,
+    SIGNER_PROCESS_ENTRYPOINT_SERVED,
+    IsolatedSignerProcessEntryPointConfig,
+    run_reddog_isolated_signer_process_once,
+)
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_service import (
+    SIGNER_SOCKET_SERVICE_REJECT,
+    SIGNER_SOCKET_SERVICE_SERVED,
+    IsolatedSignerSocketServiceResult,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    SigningRequest,
+    public_key_fingerprint,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
+    AUDIT_KEY_PREFIX,
+    PROVIDER_MODE_TEST_ONLY_DRYRUN,
+    SIGNING_KEY_PREFIX,
+    SignerKeyProviderProfile,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_peer_credential_attestor import (
+    PeerCredentialPolicy,
+)
+from modules.infrastructure.secrets_mcp.src.vault_resolver import ResolveResult, hash_reference
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_isolated_signer_process_entrypoint.py"
+)
+
+
+pytest.importorskip("cryptography")
+
+
+class FakeResolver:
+    def __init__(self, values: dict[str, str], ttl: int = 60) -> None:
+        self.values = values
+        self.ttl = ttl
+
+    def resolve(self, reference: str, requester_id: str | None = None) -> ResolveResult:
+        value = self.values[reference]
+        return ResolveResult(
+            success=True,
+            reference=reference,
+            reference_hash=hash_reference(reference),
+            ttl_remaining=self.ttl,
+            session_id="test-session",
+            _secret_value=value,
+        )
+
+
+class CapturingService:
+    def __init__(self, result: IsolatedSignerSocketServiceResult | object | None = None) -> None:
+        self.result = result
+        self.calls: list[dict[str, object]] = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.result is not None:
+            return self.result
+        return IsolatedSignerSocketServiceResult(
+            accepted=True,
+            status=SIGNER_SOCKET_SERVICE_SERVED,
+            rejection_reasons=(),
+            socket_path=str(kwargs["socket_path"]),
+            request_handled=True,
+            socket_removed=True,
+        )
+
+
+class RaisingService:
+    def __call__(self, **kwargs):
+        raise RuntimeError("service failed")
+
+
+def _private_key():
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    return Ed25519PrivateKey.generate()
+
+
+def _private_key_secret(private_key) -> str:
+    from cryptography.hazmat.primitives import serialization
+
+    raw = private_key.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return SIGNING_KEY_PREFIX + base64.b64encode(raw).decode("ascii")
+
+
+def _public_text(private_key) -> str:
+    from cryptography.hazmat.primitives import serialization
+
+    public_bytes = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return encode_ed25519_public_key(public_bytes)
+
+
+def _audit_secret(raw: bytes = b"0123456789abcdef0123456789abcdef") -> str:
+    return AUDIT_KEY_PREFIX + base64.b64encode(raw).decode("ascii")
+
+
+def _resolver(private_key) -> FakeResolver:
+    return FakeResolver(
+        {
+            "op://test-vault/reddog-signing/private": _private_key_secret(private_key),
+            "op://test-vault/reddog-audit/mac": _audit_secret(),
+        }
+    )
+
+
+def _profile(public_key: str, **overrides: object) -> SignerKeyProviderProfile:
+    values = {
+        "signer_profile_id": "signer-profile-1",
+        "signer_agent_id": "signer:reddog-authority",
+        "signing_key_ref": "op://test-vault/reddog-signing/private",
+        "audit_mac_key_ref": "op://test-vault/reddog-audit/mac",
+        "expected_public_key": public_key,
+        "expected_key_fingerprint": public_key_fingerprint(public_key),
+        "expected_key_epoch": "epoch-1",
+        "permission_snapshot_digest": "sha256:permission",
+        "ttl_seconds": 60,
+    }
+    values.update(overrides)
+    return SignerKeyProviderProfile(**values)
+
+
+def _policy(**overrides: object) -> PeerCredentialPolicy:
+    values = {
+        "uid_to_principal": {1001: "github:mjtrout"},
+        "allowed_gids": (1002,),
+        "transport": "unix_socket",
+        "credential_source_prefix": "kernel_peer_credential",
+    }
+    values.update(overrides)
+    return PeerCredentialPolicy(**values)
+
+
+def _config(public_key: str, **overrides: object) -> IsolatedSignerProcessEntryPointConfig:
+    values = {
+        "repo_root": "O:/Foundups-Agent",
+        "socket_path": "O:/tmp/reddog-signer.sock",
+        "key_provider_profile": _profile(public_key),
+        "peer_policy": _policy(),
+        "provider_mode": PROVIDER_MODE_TEST_ONLY_DRYRUN,
+        "allow_test_only_key_material": True,
+        "permission_snapshot_fresh": True,
+    }
+    values.update(overrides)
+    return IsolatedSignerProcessEntryPointConfig(**values)
+
+
+def _request(public_key: str) -> SigningRequest:
+    return SigningRequest(
+        signing_input='reddog-workauth.v1.{"work_order_id":"wo-1"}',
+        payload_digest="sha256:payload",
+        signer_role="reddog",
+        signer_public_key=public_key,
+        requester_principal_id="github:mjtrout",
+        nonce="nonce-1",
+        key_epoch="epoch-1",
+        requested_operation="create_foundup",
+        authority_tier="HIGH",
+        consensus_receipt_digest="sha256:consensus",
+    )
+
+
+def test_entrypoint_composes_key_provider_attestor_and_service() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    service = CapturingService()
+
+    result = run_reddog_isolated_signer_process_once(
+        _config(public_key),
+        _resolver(private_key),
+        serve_once=service,
+    )
+
+    assert result.accepted is True
+    assert result.status == SIGNER_PROCESS_ENTRYPOINT_SERVED
+    assert result.key_provider_receipt["ok"] is True
+    assert result.service_result["status"] == SIGNER_SOCKET_SERVICE_SERVED
+    assert result.no_env_parsed is True
+    assert result.no_process_spawned is True
+    assert len(service.calls) == 1
+    backend = service.calls[0]["backend"]
+    response = backend.sign(_request(public_key), service.calls[0]["peer_attestor"].attest(_FakePeerCredSocket()))
+    assert response.accepted is True
+    assert Ed25519SignatureVerifier().verify(public_key, _request(public_key).signing_input, response.signature) is True
+
+
+class _FakePeerCredSocket:
+    def getsockopt(self, level: int, optname: int, buflen: int) -> bytes:
+        import struct
+
+        return struct.pack("3i", 123, 1001, 1002)
+
+
+def test_default_key_provider_mode_rejects_before_service_call() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    service = CapturingService()
+    config = _config(public_key, allow_test_only_key_material=False)
+
+    result = run_reddog_isolated_signer_process_once(config, _resolver(private_key), serve_once=service)
+
+    assert result.accepted is False
+    assert result.status == SIGNER_PROCESS_ENTRYPOINT_REJECT
+    assert FAIL_SIGNER_PROCESS_KEY_PROVIDER_REJECTED in result.rejection_reasons
+    assert service.calls == []
+
+
+def test_invalid_peer_policy_rejects_before_key_provider_or_service() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    service = CapturingService()
+    config = _config(public_key, peer_policy=PeerCredentialPolicy({}))
+
+    result = run_reddog_isolated_signer_process_once(config, _resolver(private_key), serve_once=service)
+
+    assert result.accepted is False
+    assert FAIL_SIGNER_PROCESS_PEER_POLICY_INVALID in result.rejection_reasons
+    assert result.key_provider_receipt == {}
+    assert service.calls == []
+
+
+def test_invalid_config_rejects() -> None:
+    result = run_reddog_isolated_signer_process_once("not-config", object())  # type: ignore[arg-type]
+
+    assert result.accepted is False
+    assert FAIL_SIGNER_PROCESS_CONFIG_INVALID in result.rejection_reasons
+
+
+def test_service_reject_or_exception_is_preserved() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    rejected_service = CapturingService(
+        IsolatedSignerSocketServiceResult(
+            accepted=False,
+            status=SIGNER_SOCKET_SERVICE_REJECT,
+            rejection_reasons=("FAIL_SOCKET",),
+        )
+    )
+
+    rejected = run_reddog_isolated_signer_process_once(
+        _config(public_key),
+        _resolver(private_key),
+        serve_once=rejected_service,
+    )
+    raised = run_reddog_isolated_signer_process_once(
+        _config(public_key),
+        _resolver(private_key),
+        serve_once=RaisingService(),
+    )
+
+    assert rejected.accepted is False
+    assert FAIL_SIGNER_PROCESS_SERVICE_REJECTED in rejected.rejection_reasons
+    assert rejected.service_result["status"] == SIGNER_SOCKET_SERVICE_REJECT
+    assert raised.accepted is False
+    assert FAIL_SIGNER_PROCESS_SERVICE_REJECTED in raised.rejection_reasons
+
+
+def test_service_return_type_must_be_service_result() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+
+    result = run_reddog_isolated_signer_process_once(
+        _config(public_key),
+        _resolver(private_key),
+        serve_once=CapturingService(result={"not": "service-result"}),
+    )
+
+    assert result.accepted is False
+    assert FAIL_SIGNER_PROCESS_SERVICE_INVALID in result.rejection_reasons
+
+
+def test_receipts_do_not_serialize_backend_or_secret_material() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+
+    result = run_reddog_isolated_signer_process_once(
+        _config(public_key),
+        _resolver(private_key),
+        serve_once=CapturingService(),
+    )
+    text = str(result.to_dict())
+
+    assert "backend" not in text
+    assert SIGNING_KEY_PREFIX not in text
+    assert AUDIT_KEY_PREFIX not in text
+    assert "0123456789abcdef" not in text
+
+
+def test_module_has_no_env_shell_file_repo_openclaw_hermes_or_holoindex_surface() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "os",
+        "subprocess",
+        "socket",
+        "requests",
+        "urllib",
+        "http",
+        "git",
+        "holo_index",
+    }
+    banned_name_calls = {"eval", "exec", "compile", "__import__", "open"}
+    banned_attrs = {
+        "getenv",
+        "environ",
+        "system",
+        "popen",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "spawn",
+        "read_text",
+        "read_bytes",
+        "write_text",
+        "write_bytes",
+    }
+    banned_name_fragments = ("openclaw", "hermes", "worktree", "holoindex")
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+            assert not any(fragment in node.module.lower() for fragment in banned_name_fragments)
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_name_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs


### PR DESCRIPTION
## Summary

Adds `REDDOG_ISOLATED_SIGNER_PROCESS_ENTRYPOINT_PHASE1`, a one-shot composition function that wires together the pieces now present in the signer lane:

- test-only signer key-provider dry-run
- kernel peer-credential attestor
- existing one-request signer socket service

This is not a daemon launcher and not `main.py` wiring. It is an injectable entrypoint for a future isolated signer process owner.

## Validation

- `pytest modules/communication/moltbot_bridge/tests/test_reddog_isolated_signer_process_entrypoint.py -q` -> 8 passed
- signer/key/attestor/service band -> 48 passed, 3 skipped (Windows AF_UNIX live-socket skips)
- `git diff --check` -> clean (LF/CRLF warning only)
- New module/test: 0 non-ASCII, 0 NUL
- Diff additions: 0 non-ASCII
- `python -m py_compile` on new module/test -> pass

## HoloIndex

Read-only probe for `RedDog isolated signer process entrypoint key provider peer credential service` surfaced adjacent signer isolation and credential surfaces, but not this new module before indexing.

Recorded INDEX_GAP: `HOLOINDEX_REDDOG_ISOLATED_SIGNER_PROCESS_ENTRYPOINT_INDEX_GAP_PHASE1`.

No runtime re-index is performed.

## Truth Boundary Checklist

- NO_ENV_PARSED: PASS
- NO_PROCESS_SPAWNED: PASS
- NO_DIRECT_SOCKET_BIND_IN_MODULE: PASS
- NO_FILE_SECRET_LOADING: PASS
- NO_REPO_MUTATION: PASS
- NO_OPENCLAW_HERMES_WRE_WIRING: PASS
- NO_HOLOINDEX_REINDEX: PASS
- INJECTED_SERVICE_AND_DEPENDENCIES_ONLY: PASS

## Residual SPECIFIED_NOT_IMPLEMENTED

- production WSP71 vault resolver integration
- signer service runtime wiring/lifecycle
- `main.py` resident loop connection to signer service
- live authority pilot