### PR TITLE
fix(wre): enforce git cwd guard in CodeAct

### DIFF
--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -2,6 +2,34 @@
 
 ## Chronological Change Log
 
+### [2026-07-14] - WRE_CODEACT_GIT_CWD_GUARD_INTEGRATION_PHASE1
+
+**WSP Protocol References**: WSP 00 (Operational Grounding), WSP 15
+(Priority), WSP 34 (Git Operations), WSP 50 (Pre-Action), WSP 97 (Truth
+Boundary), WSP 22 (ModLog)
+
+**Type**: Worker execution-surface hardening. CodeAct git cwd guard wiring.
+
+**Deliverable**:
+- Updated `src/codeact_executor.py`: shell actions now pass parsed argv through
+  `validate_worker_git_operation_cwd` before subprocess execution. Read-only
+  git inspection remains allowed from the repository root. Mutating or unknown
+  git commands are blocked unless the executor was constructed with an isolated
+  `worker_worktree_path`, in which case the command cwd is that worktree.
+- Updated `tests/test_codeact_executor_hardening.py`: verifies read-only git
+  compatibility, shared-root `git add` rejection before subprocess, and
+  isolated-worktree `git add` execution cwd.
+
+**Boundary**: This slice grants no new command authority. CodeAct still requires
+existing allowlist/safety-gate checks before the cwd guard. It does not create a
+worktree, spawn workers, enqueue OpenClaw, dispatch Hermes, publish PRs, mutate
+HoloIndex, or merge code.
+
+**Verification**: Focused CodeAct and WRE git-cwd guard tests to be run before
+promotion.
+
+---
+
 ### [2026-07-14] - WRE_WORKER_GIT_CWD_GUARD_PHASE1
 
 **WSP Protocol References**: WSP 00 (Operational Grounding), WSP 15

--- a/modules/infrastructure/wre_core/src/codeact_executor.py
+++ b/modules/infrastructure/wre_core/src/codeact_executor.py
@@ -41,6 +41,10 @@ from typing import Dict, List, Optional, Any, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from modules.infrastructure.wre_core.src.wre_worker_git_cwd_guard import (
+    validate_worker_git_operation_cwd,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -137,7 +141,8 @@ class CodeActExecutor:
         self,
         repo_root: Path,
         llm_callback: Optional[Callable[[str], str]] = None,
-        confirmation_callback: Optional[Callable[[str], bool]] = None
+        confirmation_callback: Optional[Callable[[str], bool]] = None,
+        worker_worktree_path: Optional[Path] = None,
     ):
         """
         Initialize CodeAct executor.
@@ -147,9 +152,10 @@ class CodeActExecutor:
             llm_callback: Function(prompt) -> str for LLM generation
             confirmation_callback: Function(command) -> bool for confirmations
         """
-        self.repo_root = Path(repo_root)
+        self.repo_root = Path(repo_root).resolve()
         self.llm_callback = llm_callback
         self.confirmation_callback = confirmation_callback
+        self.worker_worktree_path = Path(worker_worktree_path).resolve() if worker_worktree_path else None
         self.strict_mode = os.getenv("WRE_CODEACT_STRICT", "1").strip() == "1"
 
     def execute(
@@ -378,13 +384,27 @@ class CodeActExecutor:
             if not cmd_parts:
                 return {"error": "Command parse failed: empty command"}
 
+            command_cwd = self.worker_worktree_path or self.repo_root
+            git_guard = validate_worker_git_operation_cwd(
+                repo_root=self.repo_root,
+                operation_cwd=command_cwd,
+                claimed_worktree_path=self.worker_worktree_path,
+                argv=cmd_parts,
+            )
+            if git_guard.ok is not True:
+                return {
+                    "error": f"Command blocked by worker git cwd guard: {git_guard.code}",
+                    "gate_triggered": f"git_cwd_guard:{git_guard.code}",
+                    "git_cwd_guard": git_guard.to_dict(),
+                }
+
             result = subprocess.run(
                 cmd_parts,
                 shell=False,
                 capture_output=True,
                 text=True,
                 timeout=gates.max_execution_time_ms / 1000,
-                cwd=str(self.repo_root)
+                cwd=str(command_cwd)
             )
 
             output = result.stdout

--- a/modules/infrastructure/wre_core/tests/test_codeact_executor_hardening.py
+++ b/modules/infrastructure/wre_core/tests/test_codeact_executor_hardening.py
@@ -51,6 +51,95 @@ def test_shell_execution_uses_shell_false():
     assert kwargs.get("shell") is False
 
 
+def test_readonly_git_command_still_runs_from_repo_root(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    executor = CodeActExecutor(repo_root=repo)
+    skill = {
+        "format": "codeact",
+        "code_section": {
+            "main_action": {"type": "shell", "command": "git status --short", "capture": "out"}
+        },
+        "safety_gates": {
+            "allowed_commands": ["git status *"],
+            "require_allowlist": True,
+            "forbid_shell_metacharacters": True,
+        },
+    }
+
+    with patch("modules.infrastructure.wre_core.src.codeact_executor.subprocess.run") as mock_run:
+        class _Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        mock_run.return_value = _Result()
+        result = executor.execute(skill, {})
+
+    assert result.success is True
+    assert mock_run.call_count == 1
+    _, kwargs = mock_run.call_args
+    assert kwargs.get("cwd") == str(repo.resolve())
+
+
+def test_mutating_git_command_from_shared_root_is_blocked_before_subprocess(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    executor = CodeActExecutor(repo_root=repo)
+    skill = {
+        "format": "codeact",
+        "code_section": {
+            "main_action": {"type": "shell", "command": "git add README.md", "capture": "out"}
+        },
+        "safety_gates": {
+            "allowed_commands": ["git *"],
+            "require_allowlist": True,
+            "forbid_shell_metacharacters": True,
+        },
+    }
+
+    with patch("modules.infrastructure.wre_core.src.codeact_executor.subprocess.run") as mock_run:
+        result = executor.execute(skill, {})
+
+    assert result.success is False
+    assert "worker git cwd guard" in (result.error or "")
+    assert "FAIL_CLAIMED_WORKTREE_MISSING" in (result.error or "")
+    assert mock_run.call_count == 0
+
+
+def test_mutating_git_command_runs_only_from_claimed_worktree(tmp_path: Path):
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worker-worktree"
+    repo.mkdir()
+    worktree.mkdir()
+    executor = CodeActExecutor(repo_root=repo, worker_worktree_path=worktree)
+    skill = {
+        "format": "codeact",
+        "code_section": {
+            "main_action": {"type": "shell", "command": "git add README.md", "capture": "out"}
+        },
+        "safety_gates": {
+            "allowed_commands": ["git *"],
+            "require_allowlist": True,
+            "forbid_shell_metacharacters": True,
+        },
+    }
+
+    with patch("modules.infrastructure.wre_core.src.codeact_executor.subprocess.run") as mock_run:
+        class _Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        mock_run.return_value = _Result()
+        result = executor.execute(skill, {})
+
+    assert result.success is True
+    assert mock_run.call_count == 1
+    _, kwargs = mock_run.call_args
+    assert kwargs.get("cwd") == str(worktree.resolve())
+
+
 def test_metacharacter_policy_blocks_command():
     executor = CodeActExecutor(repo_root=Path("."))
     skill = {
@@ -68,4 +157,3 @@ def test_metacharacter_policy_blocks_command():
     result = executor.execute(skill, {})
     assert result.success is False
     assert "metacharacter policy" in (result.error or "").lower()
-


### PR DESCRIPTION
## Summary

Consumes the new WRE worker git cwd guard inside `CodeActExecutor`, the live shell execution surface. Read-only git commands still run from the repo root, but mutating or unknown git commands are blocked before subprocess unless the executor is constructed with an isolated worker worktree path.

## WSP_97 Truth Boundary

OBSERVED:
- CodeAct still performs its existing allowlist/metacharacter/confirmation checks first.
- Parsed argv is passed to `validate_worker_git_operation_cwd` before subprocess execution.
- `git status --short` remains allowed from repo root.
- `git add README.md` from shared root is rejected before subprocess.
- With `worker_worktree_path`, mutating git runs with cwd set to the isolated worktree.

NOT IMPLEMENTED:
- No new worker launch wiring.
- No worktree creation.
- No OpenClaw/Hermes queue wiring.
- No merge/PR authority.
- No HoloIndex mutation.

## Verification

Local:
- `python -m pytest modules/infrastructure/wre_core/tests/test_codeact_executor_hardening.py modules/infrastructure/wre_core/tests/test_wre_worker_git_cwd_guard.py -q` -> 16 passed
- `python -m pytest modules/infrastructure/wre_core/tests/test_wre_auto_researcher.py modules/infrastructure/wre_core/tests/test_wre_autonomous_slice_verifier_runtime.py modules/infrastructure/wre_core/tests/test_reddog_verified_draft_pr_publish.py modules/infrastructure/wre_core/tests/test_git_main_merge_sentinel.py -q` -> 36 passed
- `git diff --check` -> clean
- ASCII/NUL scan -> 0 non-ASCII, 0 NUL on changed files

## HoloIndex

No runtime re-index. This is WRE execution-surface hardening; freshness/indexing remains owned by WRE/CI, not RedDog runtime.