### PR TITLE
feat(reddog): bootstrap resident queue through valve

### DIFF
--- a/main.py
+++ b/main.py
@@ -1534,6 +1534,8 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
         REDDOG_AUTHORITATIVE_WORK_STATE_PATH                 Existing work-state snapshot
         REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH             Outside-repo chain-results JSON
         REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH         Outside-repo authority profile JSON
+        REDDOG_WORK_ORDERS_PATH                              Outside-repo work-order JSON snapshot
+        REDDOG_EXECUTION_VALVE_ENV_PATH                      Outside-repo valve environment JSON
         REDDOG_WRE_QUEUE_ITEM_ID                             Optional exact queue item id
         REDDOG_SIGNER_SOCKET_PATH                            Optional outside-repo isolated signer socket
         REDDOG_SIGNATURE_VERIFIER_BACKEND                    Optional verifier backend (`ed25519`)
@@ -1574,6 +1576,8 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             work_state_path=os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
             chain_results_path=os.getenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH", "") or None,
             authority_profile_path=os.getenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", "") or None,
+            work_orders_path=os.getenv("REDDOG_WORK_ORDERS_PATH", "") or None,
+            valve_environment_path=os.getenv("REDDOG_EXECUTION_VALVE_ENV_PATH", "") or None,
             authority_state_path=os.getenv("REDDOG_AUTHORITY_RUNTIME_STATE_PATH", "") or None,
             permission_snapshots_path=os.getenv("REDDOG_PERMISSION_SNAPSHOTS_PATH", "") or None,
             principal_authority_records_path=os.getenv("REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH", "") or None,

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,28 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_RESIDENT_QUEUE_PLAN_VALVE_BOOTSTRAP_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Extended `src/reddog_main_resident_queue_serial_loop_bootstrap.py` so an
+  explicitly enabled resident serial loop can load outside-repo work-order and
+  execution-valve environment snapshots, then reuse the existing
+  `work_order_invocation`, `executor_plan`, and `execution_valve` stage
+  handlers.
+- Added tests proving the startup loop can advance through signed authority,
+  verified work-order invocation, executor dry-run planning, and execution
+  valve evaluation, then stop before `worktree_create`.
+- Added fail-closed coverage for missing/malformed work-order inputs and
+  inside-repo valve environment paths, plus `main.py` env wiring for
+  `REDDOG_WORK_ORDERS_PATH` and `REDDOG_EXECUTION_VALVE_ENV_PATH`.
+- Boundary: no worker spawn, no worktree creation, no shell command, no
+  OpenClaw enqueue, no Hermes dispatch, no PR, no repository mutation, no
+  PatternMemory client, and no HoloIndex runtime re-index.
+- HoloIndex read-only probe for `RedDog resident queue plan valve bootstrap work
+  order invocation execution valve` did not rank the bootstrap module; recorded
+  as `HOLOINDEX_REDDOG_RESIDENT_QUEUE_PLAN_VALVE_BOOTSTRAP_INDEX_GAP_PHASE1`.
+  No runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_ISOLATED_SIGNER_PROCESS_ENTRYPOINT_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 71, 95, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -9,15 +9,17 @@ dependencies this bootstrap owns today, and advances through the serial loop up
 to a bounded max step count.
 
 This slice does not introduce a production signer, runner, PR, PatternMemory,
-OpenClaw, Hermes, or HoloIndex dependency. Public signature verification can be
-enabled only through the explicit runtime dependency bundle. Missing later-stage
-dependencies fail closed through the registry and dispatcher.
+OpenClaw, Hermes, or HoloIndex dependency. Work-order and valve artifacts are
+loaded only from outside-repo JSON snapshots. Public signature verification can
+be enabled only through the explicit runtime dependency bundle. Missing
+later-stage dependencies fail closed through the registry and dispatcher.
 """
 
 from __future__ import annotations
 
 import json
 from dataclasses import asdict, dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
@@ -79,12 +81,31 @@ class RedDogMainResidentQueueSerialLoopBootstrapResult:
         return asdict(self)
 
 
+class JsonResidentQueueWorkOrderResolver:
+    """Resolve queue-bound work orders from an outside-repo JSON snapshot."""
+
+    def __init__(self, work_orders: Mapping[str, Mapping[str, Any]]) -> None:
+        self._work_orders = {str(key): dict(value) for key, value in work_orders.items()}
+
+    def resolve(
+        self,
+        *,
+        work_order_id: str,
+        queue_item_id: Optional[str],
+        selected_slice: Optional[str],
+    ) -> Mapping[str, Any]:
+        _ = (queue_item_id, selected_slice)
+        return self._work_orders.get(str(work_order_id), {})
+
+
 def run_reddog_main_resident_queue_serial_loop_bootstrap(
     *,
     repo_root: Path | str,
     work_state_path: Path | str | None,
     chain_results_path: Path | str | None,
     authority_profile_path: Path | str | None,
+    work_orders_path: Path | str | None = None,
+    valve_environment_path: Path | str | None = None,
     authority_state_path: Path | str | None = None,
     permission_snapshots_path: Path | str | None = None,
     principal_authority_records_path: Path | str | None = None,
@@ -133,6 +154,21 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
         return _not_ready(chain_reasons, chain_results_path=None)
     assert chain_path is not None
 
+    work_orders, work_order_reasons = _load_work_orders(root, work_orders_path)
+    if work_order_reasons:
+        return _not_ready(work_order_reasons, chain_results_path=None)
+
+    valve_environment, valve_reasons = _read_json_outside_repo(
+        root,
+        valve_environment_path,
+        missing_reason="missing_valve_environment_path",
+        inside_reason="valve_environment_path_inside_repo",
+        unreadable_reason="malformed_valve_environment",
+        required=False,
+    )
+    if valve_reasons:
+        return _not_ready(valve_reasons, chain_results_path=None)
+
     dependency_bundle = load_reddog_main_resident_queue_runtime_dependency_bundle(
         repo_root=root,
         authority_state_path=authority_state_path,
@@ -154,6 +190,7 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
         )
 
     store = AtomicJsonResidentQueueChainResultsStore(chain_path)
+    run_now = _parse_datetime(now_iso) if now_iso else None
     registry = build_reddog_resident_queue_stage_handler_registry(
         work_state_snapshot=snapshot,
         chain_results_store=store,
@@ -168,6 +205,17 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
         principal_key_resolver=dependency_bundle.principal_key_resolver,
         nonce_store=dependency_bundle.nonce_store,
         revocation_oracle=dependency_bundle.revocation_oracle,
+        work_order_resolver=(
+            JsonResidentQueueWorkOrderResolver(work_orders) if work_orders is not None else None
+        ),
+        repo_root=root,
+        valve_environment=valve_environment,
+        now_datetime=run_now,
+        permission_expires_at=(
+            str(valve_environment.get("permission_expires_at"))
+            if isinstance(valve_environment, Mapping) and valve_environment.get("permission_expires_at")
+            else None
+        ),
     )
     loop = run_reddog_resident_queue_serial_loop(
         explicit_resident_queue_serial_loop_requested=True,
@@ -205,9 +253,10 @@ def _read_json_outside_repo(
     missing_reason: str,
     inside_reason: str,
     unreadable_reason: str,
+    required: bool = True,
 ) -> tuple[Optional[Mapping[str, Any]], tuple[str, ...]]:
     if not value:
-        return None, (missing_reason,)
+        return None, (missing_reason,) if required else ()
     path = Path(value)
     if not path.is_absolute():
         path = (repo_root / path).resolve()
@@ -224,6 +273,36 @@ def _read_json_outside_repo(
     if not isinstance(payload, Mapping):
         return None, (unreadable_reason,)
     return payload, ()
+
+
+def _load_work_orders(
+    repo_root: Path,
+    value: Path | str | None,
+) -> tuple[Optional[Mapping[str, Mapping[str, Any]]], tuple[str, ...]]:
+    payload, reasons = _read_json_outside_repo(
+        repo_root,
+        value,
+        missing_reason="missing_work_orders_path",
+        inside_reason="work_orders_path_inside_repo",
+        unreadable_reason="malformed_work_orders",
+        required=False,
+    )
+    if reasons:
+        return None, reasons
+    if payload is None:
+        return None, ()
+    raw = payload.get("work_orders")
+    if not isinstance(raw, Mapping):
+        return None, ("malformed_work_orders",)
+    work_orders: dict[str, Mapping[str, Any]] = {}
+    for key, item in raw.items():
+        if not isinstance(item, Mapping):
+            return None, ("malformed_work_orders",)
+        work_order_id = str(item.get("work_order_id") or "").strip()
+        if not work_order_id or str(key) != work_order_id:
+            return None, ("malformed_work_orders",)
+        work_orders[work_order_id] = dict(item)
+    return work_orders, ()
 
 
 def _resolve_output_outside_repo(
@@ -249,6 +328,18 @@ def _is_inside(child: Path, parent: Path) -> bool:
     child_r = child.resolve()
     parent_r = parent.resolve()
     return child_r == parent_r or parent_r in child_r.parents
+
+
+def _parse_datetime(value: str) -> Optional[datetime]:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
 
 
 def _not_ready(
@@ -305,6 +396,7 @@ def _from_loop(
 
 
 __all__ = [
+    "JsonResidentQueueWorkOrderResolver",
     "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED",
     "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_NOT_READY",
     "RedDogMainResidentQueueSerialLoopBootstrapResult",

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -46,6 +46,8 @@ MODULE_PATH = (
 )
 NOW = "2026-07-14T00:00:00+00:00"
 EXPIRES = "2026-07-14T01:00:00+00:00"
+WORK_ORDER_ID = "resident-queue-work-order-001"
+FOUNDUP_ID = "paccess_001"
 
 
 def _snapshot() -> dict[str, object]:
@@ -78,16 +80,17 @@ def _snapshot() -> dict[str, object]:
 
 def _profile(**overrides: object) -> dict[str, object]:
     profile = {
+        "work_order_id": WORK_ORDER_ID,
         "principal_id": "github:mjtrout",
         "principal_provider": "github",
         "principal_public_key": "pub:principal",
         "reddog_id": "reddog:abc123",
         "reddog_public_key": "pub:reddog",
         "repo_full_name": "FOUNDUPS/Foundups-Agent",
-        "foundup_id": "paccess_001",
-        "allowed_paths": ["modules/foundups/paccess_001/**"],
-        "denied_paths": ["modules/foundups/paccess_001/secrets/**"],
-        "requested_operation": "create_foundup",
+        "foundup_id": FOUNDUP_ID,
+        "allowed_paths": [f"modules/foundups/{FOUNDUP_ID}/**"],
+        "denied_paths": [f"modules/foundups/{FOUNDUP_ID}/secrets/**"],
+        "requested_operation": "feature_slice",
         "permission_snapshot_digest": "sha256:snap-1",
         "identity_nonce": "identity-nonce-0001",
         "work_authority_nonce": "workauth-nonce-0001",
@@ -101,6 +104,82 @@ def _profile(**overrides: object) -> dict[str, object]:
     }
     profile.update(overrides)
     return profile
+
+
+def _work_order(**overrides: object) -> dict[str, object]:
+    payload = {
+        "work_order_id": WORK_ORDER_ID,
+        "created_at": "2026-07-13T23:59:30+00:00",
+        "red_dog_instance_id": "reddog-main-bootstrap",
+        "authenticated_principal": "github:mjtrout",
+        "principal_provider": "github",
+        "repo_full_name": "FOUNDUPS/Foundups-Agent",
+        "repo_permission_snapshot": {
+            "permission_level": "write",
+            "captured_at": "2026-07-13T23:59:30+00:00",
+            "source": "test",
+            "digest": "sha256:snap-1",
+        },
+        "requested_operation": "feature_slice",
+        "authority_tier": "source",
+        "allowed_paths": [f"modules/foundups/{FOUNDUP_ID}/**"],
+        "denied_paths": [f"modules/foundups/{FOUNDUP_ID}/secrets/**"],
+        "branch_name": "feat/paccess-001-resident-queue",
+        "base_ref": "main",
+        "task_summary": "Resident queue startup reaches the execution valve only.",
+        "wsp_applicability": ["WSP_34", "WSP_50", "WSP_97"],
+        "holoindex_evidence_refs": [
+            "modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py"
+        ],
+        "skillz_candidates": [],
+        "required_tests": ["pytest modules/communication/moltbot_bridge/tests"],
+        "required_policy_gates": ["openclaw_policy_gate", "signed_work_order_authority"],
+        "required_reviewers": [],
+        "sentinel_checks": [],
+        "rollback_plan": "No live worktree created by this bootstrap slice.",
+        "expiry": EXPIRES,
+        "nonce": "resident-queue-work-order-nonce-001",
+        "evidence_digest": "sha256:" + ("a" * 64),
+        "advisory_only_source_packet": {
+            "work_focus_digest": "sha256:" + ("b" * 64),
+            "wsp_prompt_digest": "sha256:" + ("c" * 64),
+            "copy_md_run_trace_digest": "sha256:" + ("d" * 64),
+        },
+        "holoindex_evidence": {
+            "holoindex_query": "RedDog resident queue execution valve bootstrap",
+            "holoindex_status": "bundle_json_ok",
+            "code_hits": [
+                "modules/communication/moltbot_bridge/src/reddog_resident_queue_execution_valve_handler.py"
+            ],
+            "wsp_hits": ["WSP_framework/src/WSP_34_Git_Operations_Protocol.md"],
+            "skillz_hits": [],
+            "direct_read_fallback_used": True,
+            "index_gap_detected": False,
+            "applicable_wsps": ["WSP_34", "WSP_97"],
+            "evidence_refs": [
+                "modules/communication/moltbot_bridge/src/reddog_wre_execution_valve.py"
+            ],
+            "retrieval_quality": "HIGH",
+            "skillz_gap_detected": False,
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _work_orders(**overrides: object) -> dict[str, object]:
+    order = _work_order(**overrides)
+    return {"work_orders": {WORK_ORDER_ID: order}}
+
+
+def _valve_environment(**overrides: object) -> dict[str, object]:
+    env = {
+        "valve_worktree_create_enabled": True,
+        "sovereign_worktree_token": "012-sovereign-worktree-token",
+        "permission_expires_at": EXPIRES,
+    }
+    env.update(overrides)
+    return env
 
 
 def _snapshots() -> dict[str, object]:
@@ -422,6 +501,165 @@ def test_bootstrap_serial_loop_verifies_ed25519_authority_when_configured(tmp_pa
     assert authority["verified_work_authority_nonces"] == ["workauth-nonce-0001"]
 
 
+def test_bootstrap_serial_loop_reaches_execution_valve_with_explicit_work_order_inputs(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    principal_public, reddog_public, connector = _ed25519_signing_material()
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(
+        tmp_path,
+        "profile.json",
+        _profile(principal_public_key=principal_public, reddog_public_key=reddog_public),
+    )
+    snapshots = _write_runtime_json(tmp_path, "snapshots.json", _snapshots())
+    principals = _write_runtime_json(tmp_path, "principals.json", _principals(principal_public))
+    work_orders = _write_runtime_json(tmp_path, "work_orders.json", _work_orders())
+    valve_env = _write_runtime_json(tmp_path, "valve_env.json", _valve_environment())
+    chain = tmp_path / "runtime" / "chain_results.json"
+    authority_state = tmp_path / "runtime" / "authority_state.json"
+    socket_path = tmp_path / "runtime" / "signer.sock"
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        work_orders_path=work_orders,
+        valve_environment_path=valve_env,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshots,
+        principal_authority_records_path=principals,
+        signer_socket_path=socket_path,
+        signer_socket_connector=connector,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        now_iso=NOW,
+        now_epoch=1000,
+        requested_queue_item_id="queue-1",
+        max_steps=6,
+    )
+
+    assert result.accepted is True
+    assert result.status == REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED
+    assert result.steps_run == 6
+    assert result.dispatched_stages == (
+        "authority_request",
+        "authority_runtime",
+        "authority_verification",
+        "work_order_invocation",
+        "executor_plan",
+        "execution_valve",
+    )
+    assert result.next_action == "RUN_QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE"
+    assert result.no_signature_verification_performed is False
+    assert result.no_worker_spawn_performed is True
+    assert result.no_worktree_created is True
+    assert result.no_shell_command_executed is True
+    assert result.no_openclaw_enqueue_performed is True
+    assert result.no_hermes_dispatch_performed is True
+    assert result.no_repo_mutation_performed is True
+    assert result.no_holoindex_reindex_performed is True
+    assert result.no_pr_created is True
+
+    stored = json.loads(chain.read_text(encoding="utf-8"))
+    stage_results = stored["stage_results"]
+    assert stage_results["work_order_invocation"]["decision"] == "QUEUE_VERIFIED_AUTHORITY_WORK_ORDER_INVOKE_ACCEPT"
+    assert stage_results["executor_plan"]["decision"] == "QUEUE_AUTHORIZED_EXECUTOR_PLAN_DRYRUN_ACCEPT"
+    valve = stage_results["execution_valve"]
+    assert valve["decision"] == "QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_ACCEPT"
+    assert valve["valve_decision"]["valve_state"] == VALVE_OPEN_WORKTREE_CREATE
+    assert "012-sovereign-worktree-token" not in json.dumps(stored, sort_keys=True)
+
+
+def test_bootstrap_serial_loop_fails_closed_before_work_order_without_resolver(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    principal_public, reddog_public, connector = _ed25519_signing_material()
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(
+        tmp_path,
+        "profile.json",
+        _profile(principal_public_key=principal_public, reddog_public_key=reddog_public),
+    )
+    snapshots = _write_runtime_json(tmp_path, "snapshots.json", _snapshots())
+    principals = _write_runtime_json(tmp_path, "principals.json", _principals(principal_public))
+    valve_env = _write_runtime_json(tmp_path, "valve_env.json", _valve_environment())
+    chain = tmp_path / "runtime" / "chain_results.json"
+    authority_state = tmp_path / "runtime" / "authority_state.json"
+    socket_path = tmp_path / "runtime" / "signer.sock"
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        valve_environment_path=valve_env,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshots,
+        principal_authority_records_path=principals,
+        signer_socket_path=socket_path,
+        signer_socket_connector=connector,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        now_iso=NOW,
+        now_epoch=1000,
+        requested_queue_item_id="queue-1",
+        max_steps=4,
+    )
+
+    assert result.accepted is False
+    assert result.status == REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_NOT_READY
+    assert result.steps_run == 3
+    assert result.dispatched_stages == (
+        "authority_request",
+        "authority_runtime",
+        "authority_verification",
+    )
+    assert "FAIL_HANDLER_MISSING" in result.rejection_reasons
+    assert "stage:work_order_invocation" in result.rejection_reasons
+    assert result.no_worktree_created is True
+    assert result.no_shell_command_executed is True
+
+
+def test_bootstrap_rejects_malformed_work_orders(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(tmp_path, "profile.json", _profile())
+    work_orders = _write_runtime_json(tmp_path, "work_orders.json", {"work_orders": {"bad": {}}})
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=tmp_path / "runtime" / "chain_results.json",
+        authority_profile_path=profile,
+        work_orders_path=work_orders,
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert "malformed_work_orders" in result.rejection_reasons
+
+
+def test_bootstrap_rejects_valve_environment_inside_repo(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(tmp_path, "profile.json", _profile())
+    valve_env = repo / "valve_env.json"
+    valve_env.write_text(json.dumps(_valve_environment(), sort_keys=True), encoding="utf-8")
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=tmp_path / "runtime" / "chain_results.json",
+        authority_profile_path=profile,
+        valve_environment_path=valve_env,
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert "valve_environment_path_inside_repo" in result.rejection_reasons
+
+
 def test_bootstrap_rejects_missing_authority_profile(tmp_path: Path) -> None:
     repo = _repo(tmp_path)
     state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
@@ -492,6 +730,8 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
                 "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
                 "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
                 "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+                "REDDOG_WORK_ORDERS_PATH": str(tmp_path / "work_orders.json"),
+                "REDDOG_EXECUTION_VALVE_ENV_PATH": str(tmp_path / "valve_env.json"),
                 "REDDOG_AUTHORITY_RUNTIME_STATE_PATH": str(tmp_path / "authority_state.json"),
                 "REDDOG_PERMISSION_SNAPSHOTS_PATH": str(tmp_path / "snapshots.json"),
                 "REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH": str(tmp_path / "principals.json"),
@@ -509,6 +749,8 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
     assert mocked.call_args.kwargs["work_state_path"] == str(tmp_path / "state.json")
     assert mocked.call_args.kwargs["chain_results_path"] == str(tmp_path / "chain.json")
     assert mocked.call_args.kwargs["authority_profile_path"] == str(tmp_path / "profile.json")
+    assert mocked.call_args.kwargs["work_orders_path"] == str(tmp_path / "work_orders.json")
+    assert mocked.call_args.kwargs["valve_environment_path"] == str(tmp_path / "valve_env.json")
     assert mocked.call_args.kwargs["authority_state_path"] == str(tmp_path / "authority_state.json")
     assert mocked.call_args.kwargs["permission_snapshots_path"] == str(tmp_path / "snapshots.json")
     assert mocked.call_args.kwargs["principal_authority_records_path"] == str(tmp_path / "principals.json")


### PR DESCRIPTION
## Summary

- extend the explicit resident queue serial-loop bootstrap with outside-repo work-order and execution-valve environment snapshots
- reuse the existing work-order invocation, executor dry-run, and execution-valve stage handlers so startup can advance through the valve and stop before worktree creation
- add fail-closed tests for missing/malformed work-order inputs, inside-repo valve env paths, token non-leakage, and main.py env wiring

## Validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q` -> 15 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_stage_handler_registry.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_work_order_invocation_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_executor_plan_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_execution_valve_handler.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_verified_authority_work_order_invoke.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_executor_plan_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_execution_valve_invoke.py -q` -> 73 passed
- `git diff --check` -> clean (autocrlf warnings only)
- diff-added non-ASCII scan -> 0

## WSP_97 Truth Boundary

- No worker spawn
- No worktree creation
- No shell command execution
- No OpenClaw enqueue
- No Hermes dispatch
- No PR creation
- No repository mutation beyond this code slice
- No PatternMemory client
- No HoloIndex runtime re-index

## HoloIndex

Read-only probe for `RedDog resident queue plan valve bootstrap work order invocation execution valve` did not rank the bootstrap module. Recorded as `HOLOINDEX_REDDOG_RESIDENT_QUEUE_PLAN_VALVE_BOOTSTRAP_INDEX_GAP_PHASE1`; no runtime re-index performed.