### PR TITLE
feat(reddog): gate resident queue worktree bootstrap

### DIFF
--- a/main.py
+++ b/main.py
@@ -1539,6 +1539,8 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
         REDDOG_WRE_QUEUE_ITEM_ID                             Optional exact queue item id
         REDDOG_SIGNER_SOCKET_PATH                            Optional outside-repo isolated signer socket
         REDDOG_SIGNATURE_VERIFIER_BACKEND                    Optional verifier backend (`ed25519`)
+        REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE           Optional `real` runner mode
+        REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_TIMEOUT_S      Optional runner timeout
     """
 
     if os.getenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP", "0") == "0":
@@ -1565,6 +1567,11 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
         signer_socket_max_response_bytes = int(signer_socket_max_value) if signer_socket_max_value else 16384
     except ValueError:
         signer_socket_max_response_bytes = 0
+    try:
+        worktree_runner_timeout_value = os.getenv("REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_TIMEOUT_S", "")
+        worktree_runner_timeout_s = int(worktree_runner_timeout_value) if worktree_runner_timeout_value else 120
+    except ValueError:
+        worktree_runner_timeout_s = 0
 
     try:
         from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_loop_bootstrap import (
@@ -1585,6 +1592,8 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             signer_socket_timeout_s=signer_socket_timeout_s,
             signer_socket_max_response_bytes=signer_socket_max_response_bytes,
             signature_verifier_backend=os.getenv("REDDOG_SIGNATURE_VERIFIER_BACKEND", "") or None,
+            worktree_runner_mode=os.getenv("REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE", "") or None,
+            worktree_runner_timeout_s=worktree_runner_timeout_s,
             requested_queue_item_id=os.getenv("REDDOG_WRE_QUEUE_ITEM_ID", "") or None,
             now_epoch=now_epoch,
             max_steps=max_steps,

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,31 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_WORKTREE_CREATE_BOOTSTRAP_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 34, 50, 97
+
+- Extended `src/reddog_main_resident_queue_serial_loop_bootstrap.py` so an
+  explicitly enabled resident serial loop can inject a worktree runner and
+  advance one more stage from `execution_valve` to `worktree_create`.
+- Added `main.py` env wiring for
+  `REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE=real` and
+  `REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_TIMEOUT_S`; no runner is constructed
+  by default.
+- Added tests proving explicit fake-runner worktree creation, fail-closed
+  behavior without a runner, unsupported runner-mode rejection, token
+  non-leakage, and preserved no-worker/no-task/no-OpenClaw/no-Hermes/no-PR
+  boundaries.
+- Boundary: worktree creation only when the resident serial loop is explicitly
+  enabled, authority is signed and verified, the execution valve is open, and a
+  runner is explicitly injected/configured. No task execution, no file edits,
+  no OpenClaw enqueue, no Hermes dispatch, no PR, no reward settlement, no
+  PatternMemory client, and no HoloIndex runtime re-index.
+- HoloIndex read-only probe for `RedDog resident queue worktree create bootstrap
+  real runner main serial loop` ranked the existing worktree runner but did not
+  rank the bootstrap seam; recorded as
+  `HOLOINDEX_REDDOG_MAIN_RESIDENT_QUEUE_WORKTREE_CREATE_BOOTSTRAP_INDEX_GAP_PHASE1`.
+  No runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_RESIDENT_QUEUE_PLAN_VALVE_BOOTSTRAP_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -114,6 +114,9 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
     signer_socket_max_response_bytes: int = DEFAULT_SIGNER_SOCKET_MAX_RESPONSE_BYTES,
     signer_socket_connector: Optional[SignerSocketConnector] = None,
     signature_verifier_backend: str | None = None,
+    worktree_runner: Any = None,
+    worktree_runner_mode: str | None = None,
+    worktree_runner_timeout_s: int = 120,
     requested_queue_item_id: str | None = None,
     now_iso: str | None = None,
     now_epoch: int | None = None,
@@ -169,6 +172,15 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
     if valve_reasons:
         return _not_ready(valve_reasons, chain_results_path=None)
 
+    resolved_worktree_runner, runner_reasons = _build_worktree_runner(
+        root,
+        injected_runner=worktree_runner,
+        mode=worktree_runner_mode,
+        timeout_s=worktree_runner_timeout_s,
+    )
+    if runner_reasons:
+        return _not_ready(runner_reasons, chain_results_path=None)
+
     dependency_bundle = load_reddog_main_resident_queue_runtime_dependency_bundle(
         repo_root=root,
         authority_state_path=authority_state_path,
@@ -210,6 +222,7 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
         ),
         repo_root=root,
         valve_environment=valve_environment,
+        worktree_runner=resolved_worktree_runner,
         now_datetime=run_now,
         permission_expires_at=(
             str(valve_environment.get("permission_expires_at"))
@@ -305,6 +318,29 @@ def _load_work_orders(
     return work_orders, ()
 
 
+def _build_worktree_runner(
+    repo_root: Path,
+    *,
+    injected_runner: Any,
+    mode: str | None,
+    timeout_s: int,
+) -> tuple[Any, tuple[str, ...]]:
+    if injected_runner is not None:
+        return injected_runner, ()
+    normalized = str(mode or "").strip().lower()
+    if not normalized:
+        return None, ()
+    if normalized not in {"real", "git_worktree"}:
+        return None, ("unsupported_worktree_runner_mode",)
+    if int(timeout_s) <= 0:
+        return None, ("invalid_worktree_runner_timeout",)
+    from modules.communication.moltbot_bridge.src.reddog_wre_worktree_runner import (
+        RealRedDogWorktreeRunner,
+    )
+
+    return RealRedDogWorktreeRunner(repo_root, timeout_s=int(timeout_s)), ()
+
+
 def _resolve_output_outside_repo(
     repo_root: Path,
     value: Path | str | None,
@@ -392,6 +428,8 @@ def _from_loop(
         runtime_dependency_bundle_requested=runtime_dependency_bundle_requested,
         rejection_reasons=tuple(loop.rejection_reasons),
         no_signature_verification_performed="authority_verification" not in loop.dispatched_stages,
+        no_worktree_created="worktree_create" not in loop.dispatched_stages,
+        no_repo_mutation_performed="worktree_create" not in loop.dispatched_stages,
     )
 
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -251,6 +251,22 @@ class _AuditMacBuilder:
         return "audit:" + request.payload_digest
 
 
+class _FakeWorktreeRunner:
+    def __init__(self, *, ok: bool = True) -> None:
+        self.ok = ok
+        self.calls: list[tuple[str, str, str | None, str | None]] = []
+
+    def create_worktree(self, *, worktree_path: Path, branch_name: str, base_ref: str):
+        self.calls.append(("create_worktree", str(worktree_path), branch_name, base_ref))
+        if self.ok:
+            Path(worktree_path).mkdir(parents=True, exist_ok=True)
+        return {"ok": self.ok, "returncode": 0 if self.ok else 1, "stdout": "", "stderr": ""}
+
+    def cleanup_worktree(self, *, worktree_path: Path):
+        self.calls.append(("cleanup_worktree", str(worktree_path), None, None))
+        return {"ok": True, "returncode": 0, "stdout": "", "stderr": ""}
+
+
 def _ed25519_signing_material():
     from cryptography.hazmat.primitives import serialization
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -571,6 +587,152 @@ def test_bootstrap_serial_loop_reaches_execution_valve_with_explicit_work_order_
     assert "012-sovereign-worktree-token" not in json.dumps(stored, sort_keys=True)
 
 
+def test_bootstrap_serial_loop_creates_worktree_only_with_explicit_runner(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    principal_public, reddog_public, connector = _ed25519_signing_material()
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(
+        tmp_path,
+        "profile.json",
+        _profile(principal_public_key=principal_public, reddog_public_key=reddog_public),
+    )
+    snapshots = _write_runtime_json(tmp_path, "snapshots.json", _snapshots())
+    principals = _write_runtime_json(tmp_path, "principals.json", _principals(principal_public))
+    work_orders = _write_runtime_json(tmp_path, "work_orders.json", _work_orders())
+    valve_env = _write_runtime_json(tmp_path, "valve_env.json", _valve_environment())
+    chain = tmp_path / "runtime" / "chain_results.json"
+    authority_state = tmp_path / "runtime" / "authority_state.json"
+    socket_path = tmp_path / "runtime" / "signer.sock"
+    runner = _FakeWorktreeRunner()
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        work_orders_path=work_orders,
+        valve_environment_path=valve_env,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshots,
+        principal_authority_records_path=principals,
+        signer_socket_path=socket_path,
+        signer_socket_connector=connector,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        worktree_runner=runner,
+        now_iso=NOW,
+        now_epoch=1000,
+        requested_queue_item_id="queue-1",
+        max_steps=7,
+    )
+
+    assert result.accepted is True
+    assert result.status == REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED
+    assert result.steps_run == 7
+    assert result.dispatched_stages == (
+        "authority_request",
+        "authority_runtime",
+        "authority_verification",
+        "work_order_invocation",
+        "executor_plan",
+        "execution_valve",
+        "worktree_create",
+    )
+    assert result.next_action == "RUN_QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE"
+    assert result.no_worktree_created is False
+    assert result.no_repo_mutation_performed is False
+    assert result.no_worker_spawn_performed is True
+    assert result.no_shell_command_executed is True
+    assert result.no_openclaw_enqueue_performed is True
+    assert result.no_hermes_dispatch_performed is True
+    assert result.no_pr_created is True
+    assert [call[0] for call in runner.calls] == ["create_worktree"]
+
+    stored = json.loads(chain.read_text(encoding="utf-8"))
+    stage = stored["stage_results"]["worktree_create"]
+    assert stage["decision"] == "QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_ACCEPT"
+    assert stage["worktree_create_result"]["decision"] == "WORKTREE_CREATE_ACCEPT"
+    assert stage["worktree_create_result"]["no_task_execution_performed"] is True
+    assert stage["worktree_create_result"]["no_file_edit_performed"] is True
+    assert stage["no_openclaw_enqueue_performed"] is True
+    assert stage["no_hermes_dispatch_performed"] is True
+    assert Path(stage["worktree_create_result"]["worktree_path"]).exists()
+    assert "012-sovereign-worktree-token" not in json.dumps(stored, sort_keys=True)
+
+
+def test_bootstrap_serial_loop_fails_closed_at_worktree_without_runner(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    principal_public, reddog_public, connector = _ed25519_signing_material()
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(
+        tmp_path,
+        "profile.json",
+        _profile(principal_public_key=principal_public, reddog_public_key=reddog_public),
+    )
+    snapshots = _write_runtime_json(tmp_path, "snapshots.json", _snapshots())
+    principals = _write_runtime_json(tmp_path, "principals.json", _principals(principal_public))
+    work_orders = _write_runtime_json(tmp_path, "work_orders.json", _work_orders())
+    valve_env = _write_runtime_json(tmp_path, "valve_env.json", _valve_environment())
+    chain = tmp_path / "runtime" / "chain_results.json"
+    authority_state = tmp_path / "runtime" / "authority_state.json"
+    socket_path = tmp_path / "runtime" / "signer.sock"
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        work_orders_path=work_orders,
+        valve_environment_path=valve_env,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshots,
+        principal_authority_records_path=principals,
+        signer_socket_path=socket_path,
+        signer_socket_connector=connector,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        now_iso=NOW,
+        now_epoch=1000,
+        requested_queue_item_id="queue-1",
+        max_steps=7,
+    )
+
+    assert result.accepted is False
+    assert result.status == REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_NOT_READY
+    assert result.steps_run == 6
+    assert result.dispatched_stages == (
+        "authority_request",
+        "authority_runtime",
+        "authority_verification",
+        "work_order_invocation",
+        "executor_plan",
+        "execution_valve",
+    )
+    assert "FAIL_HANDLER_MISSING" in result.rejection_reasons
+    assert "stage:worktree_create" in result.rejection_reasons
+    assert result.no_worktree_created is True
+
+
+def test_bootstrap_rejects_unsupported_worktree_runner_mode(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(tmp_path, "profile.json", _profile())
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=tmp_path / "runtime" / "chain_results.json",
+        authority_profile_path=profile,
+        worktree_runner_mode="shell",
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert "unsupported_worktree_runner_mode" in result.rejection_reasons
+
+
 def test_bootstrap_serial_loop_fails_closed_before_work_order_without_resolver(
     tmp_path: Path,
 ) -> None:
@@ -739,6 +901,8 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
                 "REDDOG_SIGNER_SOCKET_TIMEOUT_S": "2.5",
                 "REDDOG_SIGNER_SOCKET_MAX_RESPONSE_BYTES": "8192",
                 "REDDOG_SIGNATURE_VERIFIER_BACKEND": REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+                "REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE": "real",
+                "REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_TIMEOUT_S": "77",
                 "REDDOG_RESIDENT_QUEUE_NOW_EPOCH": "1000",
                 "REDDOG_WRE_QUEUE_ITEM_ID": "queue-1",
             },
@@ -758,6 +922,8 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
     assert mocked.call_args.kwargs["signer_socket_timeout_s"] == 2.5
     assert mocked.call_args.kwargs["signer_socket_max_response_bytes"] == 8192
     assert mocked.call_args.kwargs["signature_verifier_backend"] == REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519
+    assert mocked.call_args.kwargs["worktree_runner_mode"] == "real"
+    assert mocked.call_args.kwargs["worktree_runner_timeout_s"] == 77
     assert mocked.call_args.kwargs["requested_queue_item_id"] == "queue-1"
     assert mocked.call_args.kwargs["now_epoch"] == 1000
     assert mocked.call_args.kwargs["max_steps"] == 1
@@ -796,7 +962,7 @@ def test_main_serial_loop_preflight_blocks_when_enforced() -> None:
             assert main.run_reddog_resident_queue_serial_loop_preflight(REPO_ROOT) is False
 
 
-def test_module_has_no_shell_network_holoindex_or_later_stage_imports() -> None:
+def test_module_has_no_shell_network_holoindex_or_worker_stage_imports() -> None:
     tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
     banned_import_roots = {
         "subprocess",
@@ -816,7 +982,6 @@ def test_module_has_no_shell_network_holoindex_or_later_stage_imports() -> None:
         "reddog_wre_queue_authority_verification_invoke",
         "reddog_wre_queue_authorized",
         "reddog_wre_queue_verified_authority_work_order_invoke",
-        "reddog_wre_worktree_runner",
         "worktree_pr_runner",
         "pattern_memory",
         "openclaw_supervisor",


### PR DESCRIPTION
## Summary

- add explicit resident serial-loop worktree runner injection behind `REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE=real`
- allow the loop to advance from `execution_valve` to `worktree_create` only when signed authority, valve-open state, work-order inputs, and a runner are all present
- keep default behavior fail-closed: no runner is constructed unless explicitly configured or injected in tests

## Validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q` -> 18 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_stage_handler_registry.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_worktree_create_handler.py modules/communication/moltbot_bridge/tests/test_reddog_wre_worktree_create.py modules/communication/moltbot_bridge/tests/test_reddog_wre_cwd_guard.py modules/infrastructure/wre_core/tests/test_wre_worker_git_cwd_guard.py modules/infrastructure/wre_core/tests/test_codeact_executor_hardening.py -q` -> 62 passed
- `git diff --check` -> clean (autocrlf warnings only)
- diff-added non-ASCII scan -> 0

## WSP_97 Truth Boundary

- Worktree creation only; no task execution
- No file edits by worker task
- No OpenClaw enqueue
- No Hermes dispatch
- No PR creation
- No reward settlement
- No PatternMemory client
- No HoloIndex runtime re-index
- Default serial loop remains OFF and no runner is built without explicit runner mode

## HoloIndex

Read-only probe for `RedDog resident queue worktree create bootstrap real runner main serial loop` ranked the existing worktree runner but did not rank the bootstrap seam. Recorded as `HOLOINDEX_REDDOG_MAIN_RESIDENT_QUEUE_WORKTREE_CREATE_BOOTSTRAP_INDEX_GAP_PHASE1`; no runtime re-index performed.