### PR TITLE
feat(reddog): bootstrap resident draft PR publish

### DIFF
--- a/main.py
+++ b/main.py
@@ -1601,6 +1601,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             artifact_contents_path=os.getenv("REDDOG_ARTIFACT_CONTENTS_PATH", "") or None,
             holoindex_evidence_path=os.getenv("REDDOG_HOLOINDEX_EVIDENCE_PATH", "") or None,
             verifier_request_path=os.getenv("REDDOG_SLICE_VERIFIER_REQUEST_PATH", "") or None,
+            publish_request_path=os.getenv("REDDOG_DRAFT_PR_PUBLISH_REQUEST_PATH", "") or None,
             authority_state_path=os.getenv("REDDOG_AUTHORITY_RUNTIME_STATE_PATH", "") or None,
             permission_snapshots_path=os.getenv("REDDOG_PERMISSION_SNAPSHOTS_PATH", "") or None,
             principal_authority_records_path=os.getenv("REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH", "") or None,

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,32 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_VERIFIED_DRAFT_PR_PUBLISH_BOOTSTRAP_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 34, 50, 97
+
+- Extended `src/reddog_main_resident_queue_serial_loop_bootstrap.py` so an
+  explicitly enabled resident serial loop can load an outside-repo
+  `publish_request` JSON artifact and, with an explicitly injected draft-PR
+  runner, advance from `slice_verifier` to `verified_draft_pr_publish`.
+- Added `main.py` env wiring for `REDDOG_DRAFT_PR_PUBLISH_REQUEST_PATH`.
+  This slice does not construct a real PR runner from `main.py`; installed
+  runtime still fails closed at this stage unless a future explicit runner
+  bridge is added.
+- Added the `no_verified_draft_pr_publish_performed` result attestation and
+  wired `no_pr_created` to the verified draft-PR publish stage boundary.
+- Added tests proving the stage-10 happy path publishes only a draft PR through
+  an injected fake runner, advances to
+  `RUN_QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE`, and preserves
+  no-ready, no-merge, no-PatternMemory, no-reward, and no-HoloIndex-reindex
+  invariants.
+- Added fail-closed coverage proving a publish request without an injected
+  draft-PR runner stops the loop at `stage:verified_draft_pr_publish`.
+- HoloIndex read-only probe for `RedDog main resident queue verified draft PR
+  publish bootstrap publish request injected draft PR runner` returned adjacent
+  worktree PR runner and audit assets, but not this bootstrap seam; recorded as
+  `HOLOINDEX_REDDOG_MAIN_RESIDENT_QUEUE_VERIFIED_DRAFT_PR_PUBLISH_BOOTSTRAP_INDEX_GAP_PHASE1`.
+  No runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_SLICE_VERIFIER_BOOTSTRAP_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 34, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -71,6 +71,7 @@ class RedDogMainResidentQueueSerialLoopBootstrapResult:
     no_bounded_task_execution_performed: bool = True
     no_bounded_file_edit_performed: bool = True
     no_slice_verification_performed: bool = True
+    no_verified_draft_pr_publish_performed: bool = True
     no_shell_command_executed: bool = True
     no_openclaw_enqueue_performed: bool = True
     no_hermes_dispatch_performed: bool = True
@@ -114,6 +115,7 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
     artifact_contents_path: Path | str | None = None,
     holoindex_evidence_path: Path | str | None = None,
     verifier_request_path: Path | str | None = None,
+    publish_request_path: Path | str | None = None,
     authority_state_path: Path | str | None = None,
     permission_snapshots_path: Path | str | None = None,
     principal_authority_records_path: Path | str | None = None,
@@ -125,6 +127,7 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
     worktree_runner: Any = None,
     worktree_runner_mode: str | None = None,
     worktree_runner_timeout_s: int = 120,
+    draft_pr_runner: Any = None,
     requested_queue_item_id: str | None = None,
     now_iso: str | None = None,
     now_epoch: int | None = None,
@@ -235,6 +238,17 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
     if verifier_request_reasons:
         return _not_ready(verifier_request_reasons, chain_results_path=None)
 
+    publish_request, publish_request_reasons = _read_json_outside_repo(
+        root,
+        publish_request_path,
+        missing_reason="missing_publish_request_path",
+        inside_reason="publish_request_path_inside_repo",
+        unreadable_reason="malformed_publish_request",
+        required=False,
+    )
+    if publish_request_reasons:
+        return _not_ready(publish_request_reasons, chain_results_path=None)
+
     resolved_worktree_runner, runner_reasons = _build_worktree_runner(
         root,
         injected_runner=worktree_runner,
@@ -291,6 +305,8 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
         artifact_contents=artifact_contents,
         holoindex_evidence=holoindex_evidence,
         verifier_request=verifier_request,
+        publish_request=publish_request,
+        draft_pr_runner=draft_pr_runner,
         now_datetime=run_now,
         permission_expires_at=(
             str(valve_environment.get("permission_expires_at"))
@@ -500,9 +516,13 @@ def _from_loop(
         no_bounded_task_execution_performed="bounded_worker_pilot" not in loop.dispatched_stages,
         no_bounded_file_edit_performed="bounded_worker_pilot" not in loop.dispatched_stages,
         no_slice_verification_performed="slice_verifier" not in loop.dispatched_stages,
+        no_verified_draft_pr_publish_performed=(
+            "verified_draft_pr_publish" not in loop.dispatched_stages
+        ),
         no_repo_mutation_performed=not any(
             stage in loop.dispatched_stages for stage in ("worktree_create", "bounded_worker_pilot")
         ),
+        no_pr_created="verified_draft_pr_publish" not in loop.dispatched_stages,
     )
 
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -53,6 +53,9 @@ from modules.communication.moltbot_bridge.tests.test_reddog_wre_queue_authorized
     _signed_authority as _pilot_signed_authority,
     _valve as _pilot_valve,
 )
+from modules.communication.moltbot_bridge.tests.test_reddog_wre_queue_authorized_verified_draft_pr_publish_invoke import (
+    FakeDraftPrRunner,
+)
 from modules.infrastructure.wre_core.src.wre_autonomous_slice_verifier_runtime import (
     AUTONOMOUS_SLICE_VERIFIER_ACCEPT,
 )
@@ -382,6 +385,21 @@ def _slice_verifier_request() -> dict[str, object]:
         "pattern_memory_write_performed": False,
         "draft_pr_published": False,
         "merge_performed": False,
+    }
+
+
+def _draft_pr_publish_request(worktree_path: Path) -> dict[str, object]:
+    return {
+        "work_order_id": WORK_ORDER_ID,
+        "pre_publish_branch_head_sha": "a" * 40,
+        "branch_name": "feat/reddog-resident-queue-paccess-pilot",
+        "base_branch": "main",
+        "pr_title": "feat(reddog): resident queue paccess pilot",
+        "pr_body": "Verified by WRE autonomous slice verifier.",
+        "worktree_path": str(worktree_path),
+        "draft_pr_only": True,
+        "mark_ready": False,
+        "merge": False,
     }
 
 
@@ -1102,6 +1120,137 @@ def test_bootstrap_serial_loop_reaches_slice_verifier_with_explicit_request(
     assert "012-sovereign-worktree-token" not in json.dumps(stored, sort_keys=True)
 
 
+def test_bootstrap_serial_loop_reaches_verified_draft_pr_publish_with_injected_runner(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    principal_public, reddog_public, connector = _ed25519_signing_material()
+    pilot_overrides = _pilot_path_overrides()
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(
+        tmp_path,
+        "profile.json",
+        _profile(
+            principal_public_key=principal_public,
+            reddog_public_key=reddog_public,
+            requested_operation=PILOT_OPERATION,
+            allowed_paths=_pilot_allowed_paths(),
+            denied_paths=pilot_overrides["denied_paths"],
+        ),
+    )
+    snapshots = _write_runtime_json(tmp_path, "snapshots.json", _snapshots())
+    principals = _write_runtime_json(tmp_path, "principals.json", _principals(principal_public))
+    work_order = _work_order(**pilot_overrides)
+    work_orders = _write_runtime_json(
+        tmp_path,
+        "work_orders.json",
+        {"work_orders": {WORK_ORDER_ID: work_order}},
+    )
+    valve_env = _write_runtime_json(tmp_path, "valve_env.json", _valve_environment())
+    chain = tmp_path / "runtime" / "chain_results.json"
+    authority_state = tmp_path / "runtime" / "authority_state.json"
+    socket_path = tmp_path / "runtime" / "signer.sock"
+    worktree_runner = _FakeWorktreeRunner()
+    worktree = _pilot_worktree_path(repo, work_order)
+    pilot_payloads = _pilot_payloads(repo, worktree, work_order)
+    generic_writer = _write_runtime_json(
+        tmp_path,
+        "generic_writer.json",
+        pilot_payloads["generic_writer_dryrun_result"],
+    )
+    governed_shell = _write_runtime_json(
+        tmp_path,
+        "governed_shell.json",
+        pilot_payloads["governed_shell_dryrun_result"],
+    )
+    artifacts = _write_runtime_json(
+        tmp_path,
+        "artifact_contents.json",
+        pilot_payloads["artifact_contents"],
+    )
+    holoindex = _write_runtime_json(
+        tmp_path,
+        "holoindex_evidence.json",
+        pilot_payloads["holoindex_evidence"],
+    )
+    verifier = _write_runtime_json(
+        tmp_path,
+        "verifier_request.json",
+        _slice_verifier_request(),
+    )
+    publish_request = _write_runtime_json(
+        tmp_path,
+        "publish_request.json",
+        _draft_pr_publish_request(worktree),
+    )
+    draft_pr_runner = FakeDraftPrRunner()
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        work_orders_path=work_orders,
+        valve_environment_path=valve_env,
+        generic_writer_dryrun_result_path=generic_writer,
+        governed_shell_dryrun_result_path=governed_shell,
+        artifact_contents_path=artifacts,
+        holoindex_evidence_path=holoindex,
+        verifier_request_path=verifier,
+        publish_request_path=publish_request,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshots,
+        principal_authority_records_path=principals,
+        signer_socket_path=socket_path,
+        signer_socket_connector=connector,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        worktree_runner=worktree_runner,
+        draft_pr_runner=draft_pr_runner,
+        now_iso=NOW,
+        now_epoch=1000,
+        requested_queue_item_id="queue-1",
+        max_steps=10,
+    )
+
+    assert result.accepted is True
+    assert result.steps_run == 10
+    assert result.dispatched_stages == (
+        "authority_request",
+        "authority_runtime",
+        "authority_verification",
+        "work_order_invocation",
+        "executor_plan",
+        "execution_valve",
+        "worktree_create",
+        "bounded_worker_pilot",
+        "slice_verifier",
+        "verified_draft_pr_publish",
+    )
+    assert result.next_action == "RUN_QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE"
+    assert result.no_slice_verification_performed is False
+    assert result.no_verified_draft_pr_publish_performed is False
+    assert result.no_pr_created is False
+    assert result.no_shell_command_executed is True
+    assert result.no_openclaw_enqueue_performed is True
+    assert result.no_hermes_dispatch_performed is True
+    assert result.no_holoindex_reindex_performed is True
+
+    stored = json.loads(chain.read_text(encoding="utf-8"))
+    stage = stored["stage_results"]["verified_draft_pr_publish"]
+    assert stage["decision"] == "QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_ACCEPT"
+    assert stage["publish_result"]["decision"] == "VERIFIED_DRAFT_PR_PUBLISH_ACCEPT"
+    assert stage["publish_result"]["receipt"]["draft_pr_url"].endswith("/pull/2000")
+    assert stage["no_ready_performed"] is True
+    assert stage["no_merge_performed"] is True
+    assert stage["no_pattern_memory_write_performed"] is True
+    assert stage["no_reward_settlement_performed"] is True
+    assert stage["no_holoindex_reindex_performed"] is True
+    assert [call[0] for call in draft_pr_runner.calls] == ["push_branch", "create_draft_pr"]
+    assert (worktree / PILOT_ARTIFACT).exists()
+    assert not (repo / PILOT_ARTIFACT).exists()
+    assert "012-sovereign-worktree-token" not in json.dumps(stored, sort_keys=True)
+
+
 def test_bootstrap_serial_loop_fails_closed_at_bounded_worker_without_pilot_artifacts(
     tmp_path: Path,
 ) -> None:
@@ -1236,6 +1385,106 @@ def test_bootstrap_serial_loop_fails_closed_at_slice_verifier_without_request(
     assert "FAIL_HANDLER_MISSING" in result.rejection_reasons
     assert "stage:slice_verifier" in result.rejection_reasons
     assert result.no_slice_verification_performed is True
+    assert result.no_pr_created is True
+
+
+def test_bootstrap_serial_loop_fails_closed_at_verified_draft_pr_publish_without_runner(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    principal_public, reddog_public, connector = _ed25519_signing_material()
+    pilot_overrides = _pilot_path_overrides()
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(
+        tmp_path,
+        "profile.json",
+        _profile(
+            principal_public_key=principal_public,
+            reddog_public_key=reddog_public,
+            requested_operation=PILOT_OPERATION,
+            allowed_paths=_pilot_allowed_paths(),
+            denied_paths=pilot_overrides["denied_paths"],
+        ),
+    )
+    snapshots = _write_runtime_json(tmp_path, "snapshots.json", _snapshots())
+    principals = _write_runtime_json(tmp_path, "principals.json", _principals(principal_public))
+    work_order = _work_order(**pilot_overrides)
+    work_orders = _write_runtime_json(
+        tmp_path,
+        "work_orders.json",
+        {"work_orders": {WORK_ORDER_ID: work_order}},
+    )
+    valve_env = _write_runtime_json(tmp_path, "valve_env.json", _valve_environment())
+    chain = tmp_path / "runtime" / "chain_results.json"
+    authority_state = tmp_path / "runtime" / "authority_state.json"
+    socket_path = tmp_path / "runtime" / "signer.sock"
+    runner = _FakeWorktreeRunner()
+    worktree = _pilot_worktree_path(repo, work_order)
+    pilot_payloads = _pilot_payloads(repo, worktree, work_order)
+    generic_writer = _write_runtime_json(
+        tmp_path,
+        "generic_writer.json",
+        pilot_payloads["generic_writer_dryrun_result"],
+    )
+    governed_shell = _write_runtime_json(
+        tmp_path,
+        "governed_shell.json",
+        pilot_payloads["governed_shell_dryrun_result"],
+    )
+    artifacts = _write_runtime_json(
+        tmp_path,
+        "artifact_contents.json",
+        pilot_payloads["artifact_contents"],
+    )
+    holoindex = _write_runtime_json(
+        tmp_path,
+        "holoindex_evidence.json",
+        pilot_payloads["holoindex_evidence"],
+    )
+    verifier = _write_runtime_json(
+        tmp_path,
+        "verifier_request.json",
+        _slice_verifier_request(),
+    )
+    publish_request = _write_runtime_json(
+        tmp_path,
+        "publish_request.json",
+        _draft_pr_publish_request(worktree),
+    )
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        work_orders_path=work_orders,
+        valve_environment_path=valve_env,
+        generic_writer_dryrun_result_path=generic_writer,
+        governed_shell_dryrun_result_path=governed_shell,
+        artifact_contents_path=artifacts,
+        holoindex_evidence_path=holoindex,
+        verifier_request_path=verifier,
+        publish_request_path=publish_request,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshots,
+        principal_authority_records_path=principals,
+        signer_socket_path=socket_path,
+        signer_socket_connector=connector,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        worktree_runner=runner,
+        now_iso=NOW,
+        now_epoch=1000,
+        requested_queue_item_id="queue-1",
+        max_steps=10,
+    )
+
+    assert result.accepted is False
+    assert result.status == REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_NOT_READY
+    assert result.steps_run == 9
+    assert "FAIL_HANDLER_MISSING" in result.rejection_reasons
+    assert "stage:verified_draft_pr_publish" in result.rejection_reasons
+    assert result.no_slice_verification_performed is False
+    assert result.no_verified_draft_pr_publish_performed is True
     assert result.no_pr_created is True
 
 
@@ -1477,6 +1726,7 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
                 "REDDOG_ARTIFACT_CONTENTS_PATH": str(tmp_path / "artifact_contents.json"),
                 "REDDOG_HOLOINDEX_EVIDENCE_PATH": str(tmp_path / "holoindex_evidence.json"),
                 "REDDOG_SLICE_VERIFIER_REQUEST_PATH": str(tmp_path / "verifier_request.json"),
+                "REDDOG_DRAFT_PR_PUBLISH_REQUEST_PATH": str(tmp_path / "publish_request.json"),
                 "REDDOG_AUTHORITY_RUNTIME_STATE_PATH": str(tmp_path / "authority_state.json"),
                 "REDDOG_PERMISSION_SNAPSHOTS_PATH": str(tmp_path / "snapshots.json"),
                 "REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH": str(tmp_path / "principals.json"),
@@ -1512,6 +1762,9 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
     )
     assert mocked.call_args.kwargs["verifier_request_path"] == str(
         tmp_path / "verifier_request.json"
+    )
+    assert mocked.call_args.kwargs["publish_request_path"] == str(
+        tmp_path / "publish_request.json"
     )
     assert mocked.call_args.kwargs["authority_state_path"] == str(tmp_path / "authority_state.json")
     assert mocked.call_args.kwargs["permission_snapshots_path"] == str(tmp_path / "snapshots.json")


### PR DESCRIPTION
## Summary

REDDOG_MAIN_RESIDENT_QUEUE_VERIFIED_DRAFT_PR_PUBLISH_BOOTSTRAP_PHASE1

- Adds outside-repo publish request loading to the main resident serial-loop bootstrap.
- Threads REDDOG_DRAFT_PR_PUBLISH_REQUEST_PATH through main.py.
- Allows stage-10 progression from slice_verifier to erified_draft_pr_publish only when a draft PR runner is explicitly injected.
- Adds 
o_verified_draft_pr_publish_performed and updates 
o_pr_created to reflect the verified draft PR publish stage boundary.

## Boundary

- No real PR runner is constructed by main.py in this slice.
- No mark-ready, merge, PatternMemory write, reward settlement, OpenClaw enqueue, Hermes dispatch, shell command, or HoloIndex re-index.
- Installed runtime still fails closed at this stage without a future explicit runner bridge.

## Validation

- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -> 24 passed
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_verified_draft_pr_publish_handler.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_draft_pr_publish_invoke.py modules/infrastructure/wre_core/tests/test_reddog_verified_draft_pr_publish.py -> 29 passed
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_stage_handler_registry.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_serial_loop.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_orchestration_plan.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_next_stage_dispatch.py -> 34 passed
- combined publish/bootstrap run -> 53 passed
- git diff --check -> clean except autocrlf warnings
- HoloIndex read-only probe recorded HOLOINDEX_REDDOG_MAIN_RESIDENT_QUEUE_VERIFIED_DRAFT_PR_PUBLISH_BOOTSTRAP_INDEX_GAP_PHASE1

## WSP_97 Truth Boundary

- OBSERVED: injected fake runner can advance the resident loop through verified draft PR publish.
- OBSERVED: missing runner fails closed at stage:verified_draft_pr_publish.
- OBSERVED: no runtime HoloIndex re-index is performed.
- SPECIFIED_NOT_IMPLEMENTED: real draft PR runner wiring from main.py, verified outcome ratchet bootstrap, held-out regression gate bootstrap, PatternMemory admission bootstrap.
