### PR TITLE
feat(reddog): bootstrap resident outcome ratchet

### DIFF
--- a/main.py
+++ b/main.py
@@ -1602,6 +1602,8 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             holoindex_evidence_path=os.getenv("REDDOG_HOLOINDEX_EVIDENCE_PATH", "") or None,
             verifier_request_path=os.getenv("REDDOG_SLICE_VERIFIER_REQUEST_PATH", "") or None,
             publish_request_path=os.getenv("REDDOG_DRAFT_PR_PUBLISH_REQUEST_PATH", "") or None,
+            ratchet_request_path=os.getenv("REDDOG_OUTCOME_RATCHET_REQUEST_PATH", "") or None,
+            outcome_ratchet_store_path=os.getenv("REDDOG_OUTCOME_RATCHET_STORE_PATH", "") or None,
             authority_state_path=os.getenv("REDDOG_AUTHORITY_RUNTIME_STATE_PATH", "") or None,
             permission_snapshots_path=os.getenv("REDDOG_PERMISSION_SNAPSHOTS_PATH", "") or None,
             principal_authority_records_path=os.getenv("REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH", "") or None,

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,30 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_VERIFIED_OUTCOME_RATCHET_BOOTSTRAP_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 34, 50, 97
+
+- Extended `src/reddog_main_resident_queue_serial_loop_bootstrap.py` so an
+  explicitly enabled resident serial loop can load an outside-repo
+  `ratchet_request` JSON artifact and an outside-repo JSONL outcome-ratchet
+  store, then advance from `verified_draft_pr_publish` to
+  `verified_outcome_ratchet`.
+- Added `main.py` env wiring for `REDDOG_OUTCOME_RATCHET_REQUEST_PATH` and
+  `REDDOG_OUTCOME_RATCHET_STORE_PATH`.
+- Added the `no_verified_outcome_ratchet_performed` result attestation.
+- Added tests proving the stage-11 happy path records a verified outcome to an
+  outside-repo JSONL store, advances to
+  `RUN_QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE`, and preserves
+  no-command, no-PR-publish, no-ready, no-merge, no-reward, no-PatternMemory,
+  and no-HoloIndex-reindex invariants.
+- Added fail-closed coverage proving a ratchet request without an injected or
+  outside-repo outcome store stops the loop at `stage:verified_outcome_ratchet`.
+- HoloIndex read-only probe for `RedDog main resident queue verified outcome
+  ratchet bootstrap ratchet request JSONL store` returned adjacent wardrobe,
+  receipt, and contract assets, but not this bootstrap seam; recorded as
+  `HOLOINDEX_REDDOG_MAIN_RESIDENT_QUEUE_VERIFIED_OUTCOME_RATCHET_BOOTSTRAP_INDEX_GAP_PHASE1`.
+  No runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_VERIFIED_DRAFT_PR_PUBLISH_BOOTSTRAP_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 34, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -42,6 +42,9 @@ from modules.communication.moltbot_bridge.src.reddog_resident_queue_serial_loop 
 from modules.communication.moltbot_bridge.src.reddog_resident_queue_stage_handler_registry import (
     build_reddog_resident_queue_stage_handler_registry,
 )
+from modules.infrastructure.wre_core.src.reddog_verified_outcome_ratchet import (
+    JsonlOutcomeRatchetStore,
+)
 
 
 REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED = "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED"
@@ -72,6 +75,7 @@ class RedDogMainResidentQueueSerialLoopBootstrapResult:
     no_bounded_file_edit_performed: bool = True
     no_slice_verification_performed: bool = True
     no_verified_draft_pr_publish_performed: bool = True
+    no_verified_outcome_ratchet_performed: bool = True
     no_shell_command_executed: bool = True
     no_openclaw_enqueue_performed: bool = True
     no_hermes_dispatch_performed: bool = True
@@ -116,6 +120,8 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
     holoindex_evidence_path: Path | str | None = None,
     verifier_request_path: Path | str | None = None,
     publish_request_path: Path | str | None = None,
+    ratchet_request_path: Path | str | None = None,
+    outcome_ratchet_store_path: Path | str | None = None,
     authority_state_path: Path | str | None = None,
     permission_snapshots_path: Path | str | None = None,
     principal_authority_records_path: Path | str | None = None,
@@ -128,6 +134,9 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
     worktree_runner_mode: str | None = None,
     worktree_runner_timeout_s: int = 120,
     draft_pr_runner: Any = None,
+    outcome_ratchet_store: Any = None,
+    explicit_pattern_memory_write_requested: bool = False,
+    ratchet_pattern_memory_sink: Any = None,
     requested_queue_item_id: str | None = None,
     now_iso: str | None = None,
     now_epoch: int | None = None,
@@ -249,6 +258,25 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
     if publish_request_reasons:
         return _not_ready(publish_request_reasons, chain_results_path=None)
 
+    ratchet_request, ratchet_request_reasons = _read_json_outside_repo(
+        root,
+        ratchet_request_path,
+        missing_reason="missing_ratchet_request_path",
+        inside_reason="ratchet_request_path_inside_repo",
+        unreadable_reason="malformed_ratchet_request",
+        required=False,
+    )
+    if ratchet_request_reasons:
+        return _not_ready(ratchet_request_reasons, chain_results_path=None)
+
+    resolved_outcome_ratchet_store, ratchet_store_reasons = _build_outcome_ratchet_store(
+        root,
+        injected_store=outcome_ratchet_store,
+        store_path=outcome_ratchet_store_path,
+    )
+    if ratchet_store_reasons:
+        return _not_ready(ratchet_store_reasons, chain_results_path=None)
+
     resolved_worktree_runner, runner_reasons = _build_worktree_runner(
         root,
         injected_runner=worktree_runner,
@@ -307,6 +335,10 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
         verifier_request=verifier_request,
         publish_request=publish_request,
         draft_pr_runner=draft_pr_runner,
+        ratchet_request=ratchet_request,
+        outcome_ratchet_store=resolved_outcome_ratchet_store,
+        explicit_pattern_memory_write_requested=explicit_pattern_memory_write_requested,
+        ratchet_pattern_memory_sink=ratchet_pattern_memory_sink,
         now_datetime=run_now,
         permission_expires_at=(
             str(valve_environment.get("permission_expires_at"))
@@ -425,6 +457,28 @@ def _build_worktree_runner(
     return RealRedDogWorktreeRunner(repo_root, timeout_s=int(timeout_s)), ()
 
 
+def _build_outcome_ratchet_store(
+    repo_root: Path,
+    *,
+    injected_store: Any,
+    store_path: Path | str | None,
+) -> tuple[Any, tuple[str, ...]]:
+    if injected_store is not None:
+        return injected_store, ()
+    if not store_path:
+        return None, ()
+    path, reasons = _resolve_output_outside_repo(
+        repo_root,
+        store_path,
+        missing_reason="missing_outcome_ratchet_store_path",
+        inside_reason="outcome_ratchet_store_path_inside_repo",
+    )
+    if reasons:
+        return None, reasons
+    assert path is not None
+    return JsonlOutcomeRatchetStore(path), ()
+
+
 def _resolve_output_outside_repo(
     repo_root: Path,
     value: Path | str | None,
@@ -518,6 +572,9 @@ def _from_loop(
         no_slice_verification_performed="slice_verifier" not in loop.dispatched_stages,
         no_verified_draft_pr_publish_performed=(
             "verified_draft_pr_publish" not in loop.dispatched_stages
+        ),
+        no_verified_outcome_ratchet_performed=(
+            "verified_outcome_ratchet" not in loop.dispatched_stages
         ),
         no_repo_mutation_performed=not any(
             stage in loop.dispatched_stages for stage in ("worktree_create", "bounded_worker_pilot")

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -56,8 +56,10 @@ from modules.communication.moltbot_bridge.tests.test_reddog_wre_queue_authorized
 from modules.communication.moltbot_bridge.tests.test_reddog_wre_queue_authorized_verified_draft_pr_publish_invoke import (
     FakeDraftPrRunner,
 )
+from modules.infrastructure.wre_core.src import reddog_verified_outcome_ratchet as ratchet
 from modules.infrastructure.wre_core.src.wre_autonomous_slice_verifier_runtime import (
     AUTONOMOUS_SLICE_VERIFIER_ACCEPT,
+    verify_autonomous_slice_runtime,
 )
 
 
@@ -400,6 +402,54 @@ def _draft_pr_publish_request(worktree_path: Path) -> dict[str, object]:
         "draft_pr_only": True,
         "mark_ready": False,
         "merge": False,
+    }
+
+
+def _outcome_ratchet_request(
+    verification_result: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    verifier_result = dict(
+        verification_result or verify_autonomous_slice_runtime(_slice_verifier_request()).to_dict()
+    )
+    verifier_receipt = verifier_result["receipt"]
+    return {
+        "work_order_id": WORK_ORDER_ID,
+        "slice_name": verifier_receipt["slice_name"],
+        "outcome_status": "accepted",
+        "request_receipt": {
+            "request_id": "resident-queue-request-1",
+            "principal_id": "012",
+            "work_focus_digest": _digest("c"),
+        },
+        "execution_receipts": [
+            {"step": "worktree_created", "receipt_id": _digest("d")},
+            {"step": "bounded_worker_pilot", "receipt_id": _digest("e")},
+            {"step": "draft_pr_published", "receipt_id": "pending-publish-receipt"},
+        ],
+        "verification_result": verifier_result,
+        "publish_result": {
+            "accepted": False,
+            "decision": "VERIFIED_DRAFT_PR_PUBLISH_REJECT",
+            "receipt": {},
+        },
+        "cost_receipt": {
+            "total_tokens": 1234,
+            "estimated_cost_usd": 0.12,
+        },
+        "latency_receipt": {
+            "wall_time_ms": 1000,
+            "queue_time_ms": 10,
+        },
+        "acceptance_receipt": {
+            "accepted": True,
+            "reason": "queue verifier and draft PR publish accepted",
+        },
+        "failure_receipt": None,
+        "holoindex_evidence": {
+            "index_gap_detected": False,
+            "holoindex_freshness_receipt_digest": _digest("f"),
+        },
+        "enable_pattern_memory_write": False,
     }
 
 
@@ -1251,6 +1301,172 @@ def test_bootstrap_serial_loop_reaches_verified_draft_pr_publish_with_injected_r
     assert "012-sovereign-worktree-token" not in json.dumps(stored, sort_keys=True)
 
 
+def test_bootstrap_serial_loop_reaches_verified_outcome_ratchet_with_jsonl_store(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    principal_public, reddog_public, connector = _ed25519_signing_material()
+    pilot_overrides = _pilot_path_overrides()
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(
+        tmp_path,
+        "profile.json",
+        _profile(
+            principal_public_key=principal_public,
+            reddog_public_key=reddog_public,
+            requested_operation=PILOT_OPERATION,
+            allowed_paths=_pilot_allowed_paths(),
+            denied_paths=pilot_overrides["denied_paths"],
+        ),
+    )
+    snapshots = _write_runtime_json(tmp_path, "snapshots.json", _snapshots())
+    principals = _write_runtime_json(tmp_path, "principals.json", _principals(principal_public))
+    work_order = _work_order(**pilot_overrides)
+    work_orders = _write_runtime_json(
+        tmp_path,
+        "work_orders.json",
+        {"work_orders": {WORK_ORDER_ID: work_order}},
+    )
+    valve_env = _write_runtime_json(tmp_path, "valve_env.json", _valve_environment())
+    chain = tmp_path / "runtime" / "chain_results.json"
+    authority_state = tmp_path / "runtime" / "authority_state.json"
+    socket_path = tmp_path / "runtime" / "signer.sock"
+    worktree_runner = _FakeWorktreeRunner()
+    worktree = _pilot_worktree_path(repo, work_order)
+    pilot_payloads = _pilot_payloads(repo, worktree, work_order)
+    generic_writer = _write_runtime_json(
+        tmp_path,
+        "generic_writer.json",
+        pilot_payloads["generic_writer_dryrun_result"],
+    )
+    governed_shell = _write_runtime_json(
+        tmp_path,
+        "governed_shell.json",
+        pilot_payloads["governed_shell_dryrun_result"],
+    )
+    artifacts = _write_runtime_json(
+        tmp_path,
+        "artifact_contents.json",
+        pilot_payloads["artifact_contents"],
+    )
+    holoindex = _write_runtime_json(
+        tmp_path,
+        "holoindex_evidence.json",
+        pilot_payloads["holoindex_evidence"],
+    )
+    verifier = _write_runtime_json(
+        tmp_path,
+        "verifier_request.json",
+        _slice_verifier_request(),
+    )
+    publish_request = _write_runtime_json(
+        tmp_path,
+        "publish_request.json",
+        _draft_pr_publish_request(worktree),
+    )
+    outcome_store = tmp_path / "runtime" / "outcomes" / "ratchet.jsonl"
+    draft_pr_runner = FakeDraftPrRunner()
+
+    verifier_run = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        work_orders_path=work_orders,
+        valve_environment_path=valve_env,
+        generic_writer_dryrun_result_path=generic_writer,
+        governed_shell_dryrun_result_path=governed_shell,
+        artifact_contents_path=artifacts,
+        holoindex_evidence_path=holoindex,
+        verifier_request_path=verifier,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshots,
+        principal_authority_records_path=principals,
+        signer_socket_path=socket_path,
+        signer_socket_connector=connector,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        worktree_runner=worktree_runner,
+        now_iso=NOW,
+        now_epoch=1000,
+        requested_queue_item_id="queue-1",
+        max_steps=9,
+    )
+    assert verifier_run.accepted is True
+    verifier_stage = json.loads(chain.read_text(encoding="utf-8"))["stage_results"]["slice_verifier"]
+    ratchet_request = _write_runtime_json(
+        tmp_path,
+        "ratchet_request.json",
+        _outcome_ratchet_request(verifier_stage["verifier_result"]),
+    )
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        work_orders_path=work_orders,
+        valve_environment_path=valve_env,
+        generic_writer_dryrun_result_path=generic_writer,
+        governed_shell_dryrun_result_path=governed_shell,
+        artifact_contents_path=artifacts,
+        holoindex_evidence_path=holoindex,
+        verifier_request_path=verifier,
+        publish_request_path=publish_request,
+        ratchet_request_path=ratchet_request,
+        outcome_ratchet_store_path=outcome_store,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshots,
+        principal_authority_records_path=principals,
+        signer_socket_path=socket_path,
+        signer_socket_connector=connector,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        worktree_runner=worktree_runner,
+        draft_pr_runner=draft_pr_runner,
+        now_iso=NOW,
+        now_epoch=1000,
+        requested_queue_item_id="queue-1",
+        max_steps=2,
+    )
+
+    assert result.accepted is True
+    assert result.steps_run == 2
+    assert result.dispatched_stages == (
+        "verified_draft_pr_publish",
+        "verified_outcome_ratchet",
+    )
+    assert result.next_action == "RUN_QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE"
+    assert result.no_verified_draft_pr_publish_performed is False
+    assert result.no_verified_outcome_ratchet_performed is False
+    assert result.no_pr_created is False
+    assert result.no_pattern_memory_client_created is True
+    assert result.no_reward_settlement_performed is True
+    assert result.no_holoindex_reindex_performed is True
+
+    stored = json.loads(chain.read_text(encoding="utf-8"))
+    stage = stored["stage_results"]["verified_outcome_ratchet"]
+    assert stage["decision"] == "QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_ACCEPT"
+    assert stage["ratchet_result"]["decision"] == ratchet.OUTCOME_RATCHET_RECORDED
+    receipt = stage["ratchet_result"]["receipt"]
+    assert receipt["pattern_memory_eligible"] is True
+    assert receipt["pattern_memory_write_performed"] is False
+    assert stage["no_command_execution_performed"] is True
+    assert stage["no_pr_publish_performed"] is True
+    assert stage["no_ready_performed"] is True
+    assert stage["no_merge_performed"] is True
+    assert stage["no_reward_settlement_performed"] is True
+    assert stage["no_holoindex_reindex_performed"] is True
+
+    records = [
+        json.loads(line)
+        for line in outcome_store.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(records) == 1
+    assert records[0]["ratchet_receipt"]["work_order_id"] == WORK_ORDER_ID
+    assert records[0]["publish_result"]["decision"] == "VERIFIED_DRAFT_PR_PUBLISH_ACCEPT"
+    assert not (repo / "runtime" / "outcomes" / "ratchet.jsonl").exists()
+
+
 def test_bootstrap_serial_loop_fails_closed_at_bounded_worker_without_pilot_artifacts(
     tmp_path: Path,
 ) -> None:
@@ -1486,6 +1702,142 @@ def test_bootstrap_serial_loop_fails_closed_at_verified_draft_pr_publish_without
     assert result.no_slice_verification_performed is False
     assert result.no_verified_draft_pr_publish_performed is True
     assert result.no_pr_created is True
+
+
+def test_bootstrap_serial_loop_fails_closed_at_verified_outcome_ratchet_without_store(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    principal_public, reddog_public, connector = _ed25519_signing_material()
+    pilot_overrides = _pilot_path_overrides()
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(
+        tmp_path,
+        "profile.json",
+        _profile(
+            principal_public_key=principal_public,
+            reddog_public_key=reddog_public,
+            requested_operation=PILOT_OPERATION,
+            allowed_paths=_pilot_allowed_paths(),
+            denied_paths=pilot_overrides["denied_paths"],
+        ),
+    )
+    snapshots = _write_runtime_json(tmp_path, "snapshots.json", _snapshots())
+    principals = _write_runtime_json(tmp_path, "principals.json", _principals(principal_public))
+    work_order = _work_order(**pilot_overrides)
+    work_orders = _write_runtime_json(
+        tmp_path,
+        "work_orders.json",
+        {"work_orders": {WORK_ORDER_ID: work_order}},
+    )
+    valve_env = _write_runtime_json(tmp_path, "valve_env.json", _valve_environment())
+    chain = tmp_path / "runtime" / "chain_results.json"
+    authority_state = tmp_path / "runtime" / "authority_state.json"
+    socket_path = tmp_path / "runtime" / "signer.sock"
+    worktree_runner = _FakeWorktreeRunner()
+    worktree = _pilot_worktree_path(repo, work_order)
+    pilot_payloads = _pilot_payloads(repo, worktree, work_order)
+    generic_writer = _write_runtime_json(
+        tmp_path,
+        "generic_writer.json",
+        pilot_payloads["generic_writer_dryrun_result"],
+    )
+    governed_shell = _write_runtime_json(
+        tmp_path,
+        "governed_shell.json",
+        pilot_payloads["governed_shell_dryrun_result"],
+    )
+    artifacts = _write_runtime_json(
+        tmp_path,
+        "artifact_contents.json",
+        pilot_payloads["artifact_contents"],
+    )
+    holoindex = _write_runtime_json(
+        tmp_path,
+        "holoindex_evidence.json",
+        pilot_payloads["holoindex_evidence"],
+    )
+    verifier = _write_runtime_json(
+        tmp_path,
+        "verifier_request.json",
+        _slice_verifier_request(),
+    )
+    publish_request = _write_runtime_json(
+        tmp_path,
+        "publish_request.json",
+        _draft_pr_publish_request(worktree),
+    )
+    draft_pr_runner = FakeDraftPrRunner()
+
+    verifier_run = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        work_orders_path=work_orders,
+        valve_environment_path=valve_env,
+        generic_writer_dryrun_result_path=generic_writer,
+        governed_shell_dryrun_result_path=governed_shell,
+        artifact_contents_path=artifacts,
+        holoindex_evidence_path=holoindex,
+        verifier_request_path=verifier,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshots,
+        principal_authority_records_path=principals,
+        signer_socket_path=socket_path,
+        signer_socket_connector=connector,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        worktree_runner=worktree_runner,
+        now_iso=NOW,
+        now_epoch=1000,
+        requested_queue_item_id="queue-1",
+        max_steps=9,
+    )
+    assert verifier_run.accepted is True
+    verifier_stage = json.loads(chain.read_text(encoding="utf-8"))["stage_results"]["slice_verifier"]
+    ratchet_request = _write_runtime_json(
+        tmp_path,
+        "ratchet_request.json",
+        _outcome_ratchet_request(verifier_stage["verifier_result"]),
+    )
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        work_orders_path=work_orders,
+        valve_environment_path=valve_env,
+        generic_writer_dryrun_result_path=generic_writer,
+        governed_shell_dryrun_result_path=governed_shell,
+        artifact_contents_path=artifacts,
+        holoindex_evidence_path=holoindex,
+        verifier_request_path=verifier,
+        publish_request_path=publish_request,
+        ratchet_request_path=ratchet_request,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshots,
+        principal_authority_records_path=principals,
+        signer_socket_path=socket_path,
+        signer_socket_connector=connector,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        worktree_runner=worktree_runner,
+        draft_pr_runner=draft_pr_runner,
+        now_iso=NOW,
+        now_epoch=1000,
+        requested_queue_item_id="queue-1",
+        max_steps=2,
+    )
+
+    assert result.accepted is False
+    assert result.status == REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_NOT_READY
+    assert result.steps_run == 1
+    assert "FAIL_HANDLER_MISSING" in result.rejection_reasons
+    assert "stage:verified_outcome_ratchet" in result.rejection_reasons
+    assert result.no_verified_draft_pr_publish_performed is False
+    assert result.no_verified_outcome_ratchet_performed is True
+    assert result.no_pr_created is False
+    assert result.no_pattern_memory_client_created is True
 
 
 def test_bootstrap_serial_loop_fails_closed_at_worktree_without_runner(
@@ -1727,6 +2079,8 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
                 "REDDOG_HOLOINDEX_EVIDENCE_PATH": str(tmp_path / "holoindex_evidence.json"),
                 "REDDOG_SLICE_VERIFIER_REQUEST_PATH": str(tmp_path / "verifier_request.json"),
                 "REDDOG_DRAFT_PR_PUBLISH_REQUEST_PATH": str(tmp_path / "publish_request.json"),
+                "REDDOG_OUTCOME_RATCHET_REQUEST_PATH": str(tmp_path / "ratchet_request.json"),
+                "REDDOG_OUTCOME_RATCHET_STORE_PATH": str(tmp_path / "ratchet.jsonl"),
                 "REDDOG_AUTHORITY_RUNTIME_STATE_PATH": str(tmp_path / "authority_state.json"),
                 "REDDOG_PERMISSION_SNAPSHOTS_PATH": str(tmp_path / "snapshots.json"),
                 "REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH": str(tmp_path / "principals.json"),
@@ -1765,6 +2119,12 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
     )
     assert mocked.call_args.kwargs["publish_request_path"] == str(
         tmp_path / "publish_request.json"
+    )
+    assert mocked.call_args.kwargs["ratchet_request_path"] == str(
+        tmp_path / "ratchet_request.json"
+    )
+    assert mocked.call_args.kwargs["outcome_ratchet_store_path"] == str(
+        tmp_path / "ratchet.jsonl"
     )
     assert mocked.call_args.kwargs["authority_state_path"] == str(tmp_path / "authority_state.json")
     assert mocked.call_args.kwargs["permission_snapshots_path"] == str(tmp_path / "snapshots.json")


### PR DESCRIPTION
## Summary

REDDOG_MAIN_RESIDENT_QUEUE_VERIFIED_OUTCOME_RATCHET_BOOTSTRAP_PHASE1

- Adds outside-repo ratchet request loading to the main resident serial-loop bootstrap.
- Adds outside-repo JSONL outcome-ratchet store construction via REDDOG_OUTCOME_RATCHET_STORE_PATH.
- Threads REDDOG_OUTCOME_RATCHET_REQUEST_PATH and REDDOG_OUTCOME_RATCHET_STORE_PATH through main.py.
- Adds 
o_verified_outcome_ratchet_performed result attestation.

## Boundary

- Outcome ratchet writes only to the explicitly configured outside-repo JSONL store.
- No PatternMemory sink is constructed by main.py; PatternMemory remains disabled.
- No command execution, PR publish, mark-ready, merge, reward settlement, OpenClaw enqueue, Hermes dispatch, repo mutation, or HoloIndex re-index.

## Validation

- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -> 26 passed
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_verified_outcome_ratchet_handler.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_outcome_ratchet_invoke.py modules/infrastructure/wre_core/tests/test_reddog_verified_outcome_ratchet.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_verified_draft_pr_publish_handler.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_draft_pr_publish_invoke.py modules/infrastructure/wre_core/tests/test_reddog_verified_draft_pr_publish.py -> 62 passed
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_stage_handler_registry.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_serial_loop.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_orchestration_plan.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_next_stage_dispatch.py -> 34 passed
- python -m py_compile modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py -> pass
- git diff --check -> clean except autocrlf warnings
- HoloIndex read-only probe recorded HOLOINDEX_REDDOG_MAIN_RESIDENT_QUEUE_VERIFIED_OUTCOME_RATCHET_BOOTSTRAP_INDEX_GAP_PHASE1

## WSP_97 Truth Boundary

- OBSERVED: resident loop can resume after slice verification, publish through an injected fake runner, then record a verified outcome to an outside-repo JSONL store.
- OBSERVED: missing outcome store fails closed at stage:verified_outcome_ratchet.
- OBSERVED: PatternMemory is not wired or written in this bootstrap path.
- SPECIFIED_NOT_IMPLEMENTED: held-out regression gate bootstrap, PatternMemory admission bootstrap, real PatternMemory sink, reward settlement, HoloIndex re-index.
