### PR TITLE
feat(reddog): bootstrap resident pattern memory admission

### DIFF
--- a/main.py
+++ b/main.py
@@ -1605,6 +1605,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             ratchet_request_path=os.getenv("REDDOG_OUTCOME_RATCHET_REQUEST_PATH", "") or None,
             outcome_ratchet_store_path=os.getenv("REDDOG_OUTCOME_RATCHET_STORE_PATH", "") or None,
             held_out_gate_request_path=os.getenv("REDDOG_HELD_OUT_GATE_REQUEST_PATH", "") or None,
+            admission_request_path=os.getenv("REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_PATH", "") or None,
             authority_state_path=os.getenv("REDDOG_AUTHORITY_RUNTIME_STATE_PATH", "") or None,
             permission_snapshots_path=os.getenv("REDDOG_PERMISSION_SNAPSHOTS_PATH", "") or None,
             principal_authority_records_path=os.getenv("REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH", "") or None,

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,32 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_PATTERN_MEMORY_ADMISSION_BOOTSTRAP_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 34, 50, 97
+
+- Extended `src/reddog_main_resident_queue_serial_loop_bootstrap.py` so an
+  explicitly enabled resident serial loop can load an outside-repo
+  `admission_request` JSON artifact and, only with an explicitly injected
+  PatternMemory admission sink, advance from `held_out_regression_gate` to
+  `pattern_memory_admission`.
+- Added `main.py` env wiring for `REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_PATH`.
+  This slice does not construct a PatternMemory sink from `main.py`; installed
+  runtime still fails closed at this stage unless a future explicit sink bridge
+  is added.
+- Added `no_pattern_memory_admission_performed` and
+  `no_pattern_memory_write_performed` result attestations.
+- Added tests proving the stage-13 happy path writes exactly through an
+  injected fake sink, completes the resident queue chain, and preserves
+  no-command, no-PR-publish, no-merge, no-reward, and no-HoloIndex-reindex
+  invariants.
+- Added fail-closed coverage proving an admission request without an injected
+  sink stops the loop at `stage:pattern_memory_admission`.
+- HoloIndex read-only probe for `RedDog main resident queue PatternMemory
+  admission bootstrap admission request injected sink` returned adjacent
+  live-enqueue, WSP, and audit assets, but not this bootstrap seam; recorded as
+  `HOLOINDEX_REDDOG_MAIN_RESIDENT_QUEUE_PATTERN_MEMORY_ADMISSION_BOOTSTRAP_INDEX_GAP_PHASE1`.
+  No runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_HELD_OUT_REGRESSION_GATE_BOOTSTRAP_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 34, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -77,6 +77,8 @@ class RedDogMainResidentQueueSerialLoopBootstrapResult:
     no_verified_draft_pr_publish_performed: bool = True
     no_verified_outcome_ratchet_performed: bool = True
     no_held_out_regression_gate_performed: bool = True
+    no_pattern_memory_admission_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
     no_shell_command_executed: bool = True
     no_openclaw_enqueue_performed: bool = True
     no_hermes_dispatch_performed: bool = True
@@ -124,6 +126,7 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
     ratchet_request_path: Path | str | None = None,
     outcome_ratchet_store_path: Path | str | None = None,
     held_out_gate_request_path: Path | str | None = None,
+    admission_request_path: Path | str | None = None,
     authority_state_path: Path | str | None = None,
     permission_snapshots_path: Path | str | None = None,
     principal_authority_records_path: Path | str | None = None,
@@ -139,6 +142,7 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
     outcome_ratchet_store: Any = None,
     explicit_pattern_memory_write_requested: bool = False,
     ratchet_pattern_memory_sink: Any = None,
+    pattern_memory_admission_sink: Any = None,
     requested_queue_item_id: str | None = None,
     now_iso: str | None = None,
     now_epoch: int | None = None,
@@ -282,6 +286,17 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
     if held_out_gate_request_reasons:
         return _not_ready(held_out_gate_request_reasons, chain_results_path=None)
 
+    admission_request, admission_request_reasons = _read_json_outside_repo(
+        root,
+        admission_request_path,
+        missing_reason="missing_admission_request_path",
+        inside_reason="admission_request_path_inside_repo",
+        unreadable_reason="malformed_admission_request",
+        required=False,
+    )
+    if admission_request_reasons:
+        return _not_ready(admission_request_reasons, chain_results_path=None)
+
     resolved_outcome_ratchet_store, ratchet_store_reasons = _build_outcome_ratchet_store(
         root,
         injected_store=outcome_ratchet_store,
@@ -353,6 +368,8 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
         held_out_gate_request=held_out_gate_request,
         explicit_pattern_memory_write_requested=explicit_pattern_memory_write_requested,
         ratchet_pattern_memory_sink=ratchet_pattern_memory_sink,
+        admission_request=admission_request,
+        pattern_memory_admission_sink=pattern_memory_admission_sink,
         now_datetime=run_now,
         permission_expires_at=(
             str(valve_environment.get("permission_expires_at"))
@@ -592,6 +609,12 @@ def _from_loop(
         ),
         no_held_out_regression_gate_performed=(
             "held_out_regression_gate" not in loop.dispatched_stages
+        ),
+        no_pattern_memory_admission_performed=(
+            "pattern_memory_admission" not in loop.dispatched_stages
+        ),
+        no_pattern_memory_write_performed=not (
+            accepted and "pattern_memory_admission" in loop.dispatched_stages
         ),
         no_repo_mutation_performed=not any(
             stage in loop.dispatched_stages for stage in ("worktree_create", "bounded_worker_pilot")

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -495,6 +495,16 @@ def _held_out_gate_request(
     }
 
 
+def _pattern_memory_admission_request() -> dict[str, object]:
+    return {
+        "work_order_id": WORK_ORDER_ID,
+        "admission_metadata": {
+            "source": "resident_queue_bootstrap",
+            "retention_policy": "verified_recursive_improvement_only",
+        },
+    }
+
+
 def _snapshots() -> dict[str, object]:
     return {
         "snapshots": {
@@ -578,6 +588,15 @@ class _FakeWorktreeRunner:
     def cleanup_worktree(self, *, worktree_path: Path):
         self.calls.append(("cleanup_worktree", str(worktree_path), None, None))
         return {"ok": True, "returncode": 0, "stdout": "", "stderr": ""}
+
+
+class _FakePatternMemoryAdmissionSink:
+    def __init__(self) -> None:
+        self.records: list[dict[str, object]] = []
+
+    def store_verified_outcome(self, record: Mapping[str, object]) -> str:
+        self.records.append(dict(record))
+        return "pattern-memory-record-1"
 
 
 def _ed25519_signing_material():
@@ -774,6 +793,32 @@ def _run_bootstrap_to_verified_outcome_ratchet(tmp_path: Path) -> dict[str, obje
         "chain": chain,
         "verifier_stage": verifier_stage,
     }
+
+
+def _run_bootstrap_to_held_out_regression_gate(tmp_path: Path) -> dict[str, object]:
+    ctx = _run_bootstrap_to_verified_outcome_ratchet(tmp_path)
+    verifier_stage = ctx["verifier_stage"]
+    held_out_request = _write_runtime_json(
+        tmp_path,
+        "held_out_gate_request.json",
+        _held_out_gate_request(verifier_stage["verifier_result"]),
+    )
+    gate_run = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=ctx["repo"],
+        work_state_path=ctx["state"],
+        chain_results_path=ctx["chain"],
+        authority_profile_path=ctx["profile"],
+        held_out_gate_request_path=held_out_request,
+        now_iso=NOW,
+        requested_queue_item_id="queue-1",
+        max_steps=1,
+    )
+    assert gate_run.accepted is True
+    stored = json.loads(Path(ctx["chain"]).read_text(encoding="utf-8"))
+    assert stored["stage_results"]["held_out_regression_gate"]["decision"] == (
+        "QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_ACCEPT"
+    )
+    return ctx
 
 
 def test_bootstrap_serial_loop_applies_one_stage_with_existing_dependencies(tmp_path: Path) -> None:
@@ -1722,6 +1767,86 @@ def test_bootstrap_serial_loop_fails_closed_at_held_out_without_gate_request(
     assert result.no_pattern_memory_client_created is True
 
 
+def test_bootstrap_serial_loop_reaches_pattern_memory_admission_with_injected_sink(
+    tmp_path: Path,
+) -> None:
+    ctx = _run_bootstrap_to_held_out_regression_gate(tmp_path)
+    admission_request = _write_runtime_json(
+        tmp_path,
+        "pattern_memory_admission_request.json",
+        _pattern_memory_admission_request(),
+    )
+    sink = _FakePatternMemoryAdmissionSink()
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=ctx["repo"],
+        work_state_path=ctx["state"],
+        chain_results_path=ctx["chain"],
+        authority_profile_path=ctx["profile"],
+        admission_request_path=admission_request,
+        pattern_memory_admission_sink=sink,
+        now_iso=NOW,
+        requested_queue_item_id="queue-1",
+        max_steps=1,
+    )
+
+    assert result.accepted is True
+    assert result.steps_run == 1
+    assert result.dispatched_stages == ("pattern_memory_admission",)
+    assert result.next_action == "STOP_QUEUE_CHAIN_COMPLETE"
+    assert result.no_pattern_memory_admission_performed is False
+    assert result.no_pattern_memory_write_performed is False
+    assert result.no_pattern_memory_client_created is True
+    assert result.no_reward_settlement_performed is True
+    assert result.no_holoindex_reindex_performed is True
+
+    stored = json.loads(Path(ctx["chain"]).read_text(encoding="utf-8"))
+    stage = stored["stage_results"]["pattern_memory_admission"]
+    assert stage["decision"] == "QUEUE_AUTHORIZED_PATTERN_MEMORY_ADMISSION_INVOKE_ACCEPT"
+    assert stage["pattern_memory_write_performed"] is True
+    assert stage["receipt"]["pattern_memory_record_id"] == "pattern-memory-record-1"
+    assert stage["no_command_execution_performed"] is True
+    assert stage["no_pr_publish_performed"] is True
+    assert stage["no_merge_performed"] is True
+    assert stage["no_reward_settlement_performed"] is True
+    assert stage["no_holoindex_reindex_performed"] is True
+    assert len(sink.records) == 1
+    assert sink.records[0]["record_type"] == "reddog_verified_recursive_improvement_outcome"
+    assert sink.records[0]["work_order_id"] == WORK_ORDER_ID
+
+
+def test_bootstrap_serial_loop_fails_closed_at_pattern_memory_without_injected_sink(
+    tmp_path: Path,
+) -> None:
+    ctx = _run_bootstrap_to_held_out_regression_gate(tmp_path)
+    admission_request = _write_runtime_json(
+        tmp_path,
+        "pattern_memory_admission_request.json",
+        _pattern_memory_admission_request(),
+    )
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=ctx["repo"],
+        work_state_path=ctx["state"],
+        chain_results_path=ctx["chain"],
+        authority_profile_path=ctx["profile"],
+        admission_request_path=admission_request,
+        now_iso=NOW,
+        requested_queue_item_id="queue-1",
+        max_steps=1,
+    )
+
+    assert result.accepted is False
+    assert result.status == REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_NOT_READY
+    assert result.steps_run == 0
+    assert result.dispatched_stages == ()
+    assert "FAIL_HANDLER_MISSING" in result.rejection_reasons
+    assert "stage:pattern_memory_admission" in result.rejection_reasons
+    assert result.no_pattern_memory_admission_performed is True
+    assert result.no_pattern_memory_write_performed is True
+    assert result.no_pattern_memory_client_created is True
+
+
 def test_bootstrap_serial_loop_fails_closed_at_bounded_worker_without_pilot_artifacts(
     tmp_path: Path,
 ) -> None:
@@ -2337,6 +2462,9 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
                 "REDDOG_OUTCOME_RATCHET_REQUEST_PATH": str(tmp_path / "ratchet_request.json"),
                 "REDDOG_OUTCOME_RATCHET_STORE_PATH": str(tmp_path / "ratchet.jsonl"),
                 "REDDOG_HELD_OUT_GATE_REQUEST_PATH": str(tmp_path / "held_out_gate_request.json"),
+                "REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_PATH": str(
+                    tmp_path / "pattern_memory_admission_request.json"
+                ),
                 "REDDOG_AUTHORITY_RUNTIME_STATE_PATH": str(tmp_path / "authority_state.json"),
                 "REDDOG_PERMISSION_SNAPSHOTS_PATH": str(tmp_path / "snapshots.json"),
                 "REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH": str(tmp_path / "principals.json"),
@@ -2384,6 +2512,9 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
     )
     assert mocked.call_args.kwargs["held_out_gate_request_path"] == str(
         tmp_path / "held_out_gate_request.json"
+    )
+    assert mocked.call_args.kwargs["admission_request_path"] == str(
+        tmp_path / "pattern_memory_admission_request.json"
     )
     assert mocked.call_args.kwargs["authority_state_path"] == str(tmp_path / "authority_state.json")
     assert mocked.call_args.kwargs["permission_snapshots_path"] == str(tmp_path / "snapshots.json")


### PR DESCRIPTION
## Summary

- Wires optional outside-repo REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_PATH into the resident queue bootstrap.
- Advances the persisted resident chain from held_out_regression_gate to pattern_memory_admission only when an explicit admission request and injected sink are supplied.
- Adds no_pattern_memory_admission_performed and no_pattern_memory_write_performed attestations.
- main.py passes only the request path; it does not construct a PatternMemory sink, so installed runtime remains fail-closed at this stage until a future explicit sink bridge exists.

## Validation

- bootstrap test file: 30 passed
- PatternMemory handler/invoke tests: 18 passed
- held-out handler/invoke tests: 17 passed
- registry/serial-loop/orchestration/dispatch tests: 34 passed
- py_compile on touched Python files: passed
- git diff --check: clean
- HoloIndex read-only probe: adjacent hits only; INDEX_GAP recorded in ModLog

## Truth Boundary

- No default PatternMemory client is created.
- PatternMemory write occurs only through an injected sink in tests/runtime caller injection.
- No HoloIndex runtime re-index is performed.
- No OpenClaw enqueue, Hermes dispatch, shell command, test command, PR publish, merge, or reward settlement is performed.
- Admission request without an injected sink fails closed at stage:pattern_memory_admission.
