### PR TITLE
feat(reddog): bridge verified outcomes into pattern memory

### DIFF
--- a/main.py
+++ b/main.py
@@ -1582,6 +1582,14 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
         from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_loop_bootstrap import (
             run_reddog_main_resident_queue_serial_loop_bootstrap,
         )
+        from modules.communication.moltbot_bridge.src.reddog_verified_pattern_memory_sink import (
+            build_reddog_verified_pattern_memory_sink,
+        )
+
+        pattern_memory_admission_sink = build_reddog_verified_pattern_memory_sink(
+            repo_root=repo_root,
+            db_path=os.getenv("REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH", "") or None,
+        )
 
         result = run_reddog_main_resident_queue_serial_loop_bootstrap(
             repo_root=repo_root,
@@ -1615,6 +1623,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             signature_verifier_backend=os.getenv("REDDOG_SIGNATURE_VERIFIER_BACKEND", "") or None,
             worktree_runner_mode=os.getenv("REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE", "") or None,
             worktree_runner_timeout_s=worktree_runner_timeout_s,
+            pattern_memory_admission_sink=pattern_memory_admission_sink,
             requested_queue_item_id=os.getenv("REDDOG_WRE_QUEUE_ITEM_ID", "") or None,
             now_epoch=now_epoch,
             max_steps=max_steps,

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,28 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_PATTERN_MEMORY_SINK_BRIDGE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 34, 50, 97
+
+- Added `src/reddog_verified_pattern_memory_sink.py`, an explicit outside-repo
+  PatternMemory sink adapter for already-verified resident queue outcomes.
+- Added `main.py` env wiring for `REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH`.
+  The sink is constructed only when this path is set and it is outside the
+  repository checkout.
+- The sink maps a verified recursive improvement outcome into a WRE
+  `SkillOutcome`, stores it through the existing `PatternMemory` API, rejects
+  secret-bearing records, and returns a deterministic record id.
+- Added tests proving outside-repo storage, inside-repo path rejection,
+  idempotent repeated store, secret rejection, AST denylist invariants, and
+  `main.py` pass-through into the resident queue bootstrap.
+- No OpenClaw enqueue, Hermes dispatch, shell command, PR publish, merge,
+  reward settlement, or HoloIndex re-index is performed by this bridge.
+- HoloIndex read-only probe for `RedDog verified PatternMemory sink bridge
+  resident queue outside repo database` returned adjacent guard, verifier, WSP,
+  and audit assets, but not this sink bridge; recorded as
+  `HOLOINDEX_REDDOG_MAIN_RESIDENT_QUEUE_PATTERN_MEMORY_SINK_BRIDGE_INDEX_GAP_PHASE1`.
+  No runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_PATTERN_MEMORY_ADMISSION_BOOTSTRAP_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 34, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_verified_pattern_memory_sink.py
+++ b/modules/communication/moltbot_bridge/src/reddog_verified_pattern_memory_sink.py
@@ -1,0 +1,159 @@
+"""PatternMemory sink adapter for verified RedDog resident-queue outcomes.
+
+Slice: REDDOG_MAIN_RESIDENT_QUEUE_PATTERN_MEMORY_SINK_BRIDGE_PHASE1
+
+This adapter implements the `store_verified_outcome(record) -> record_id`
+protocol required by the queue-authorized PatternMemory admission guard. It
+does not decide whether an outcome is eligible. The resident queue gate chain
+must already have accepted the held-out regression and PatternMemory admission
+stage before this sink is called.
+
+The sink requires an explicit SQLite database path outside the repository
+checkout. It never creates a default PatternMemory client, executes commands,
+enqueues OpenClaw, dispatches Hermes, settles rewards, merges PRs, or re-indexes
+HoloIndex.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from modules.infrastructure.wre_core.src.pattern_memory import PatternMemory, SkillOutcome
+
+
+REDDOG_VERIFIED_PATTERN_MEMORY_SINK_READY = "REDDOG_VERIFIED_PATTERN_MEMORY_SINK_READY"
+
+SECRET_MARKERS = (
+    "authorization:",
+    "bearer ",
+    "api_key",
+    "apikey",
+    "private_key",
+    "begin private key",
+    "secret=",
+    "token=",
+    "password=",
+)
+
+
+class PatternMemorySinkConfigurationError(ValueError):
+    """Raised when the sink cannot be constructed safely."""
+
+
+def _is_inside(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def _digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _contains_secret(value: Any) -> bool:
+    text = _canonical_json(value).lower()
+    return any(marker in text for marker in SECRET_MARKERS)
+
+
+def _record_id(record: Mapping[str, Any]) -> str:
+    return "reddog_verified_outcome_" + _digest(record).removeprefix("sha256:")[:16]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+@dataclass(frozen=True)
+class RedDogVerifiedPatternMemorySink:
+    """Store verified RedDog outcomes in an explicit PatternMemory database."""
+
+    db_path: Path
+    agent: str = "reddog"
+
+    @property
+    def status(self) -> str:
+        return REDDOG_VERIFIED_PATTERN_MEMORY_SINK_READY
+
+    def store_verified_outcome(self, record: Mapping[str, Any]) -> str:
+        payload = dict(record)
+        if payload.get("record_type") != "reddog_verified_recursive_improvement_outcome":
+            raise ValueError("unsupported_verified_outcome_record_type")
+        if _contains_secret(payload):
+            raise ValueError("secret_in_verified_outcome_record")
+
+        execution_id = _record_id(payload)
+        memory = PatternMemory(db_path=self.db_path)
+        try:
+            cursor = memory.conn.cursor()
+            cursor.execute(
+                "SELECT execution_id FROM skill_outcomes WHERE execution_id = ? LIMIT 1",
+                (execution_id,),
+            )
+            if cursor.fetchone() is not None:
+                return execution_id
+
+            outcome = SkillOutcome(
+                execution_id=execution_id,
+                skill_name=str(payload.get("slice_name") or "reddog_verified_outcome"),
+                agent=self.agent,
+                timestamp=_utc_now(),
+                input_context=_canonical_json(
+                    {
+                        "work_order_id": payload.get("work_order_id"),
+                        "gate_id": payload.get("gate_id"),
+                        "ratchet_id": payload.get("ratchet_id"),
+                        "verifier_receipt_id": payload.get("verifier_receipt_id"),
+                    }
+                ),
+                output_result=_canonical_json(payload),
+                success=True,
+                pattern_fidelity=1.0,
+                outcome_quality=1.0,
+                execution_time_ms=0,
+                step_count=0,
+                notes="RedDog verified recursive improvement outcome admitted after held-out gate.",
+            )
+            memory.store_outcome(outcome)
+            return execution_id
+        finally:
+            memory.close()
+
+
+def build_reddog_verified_pattern_memory_sink(
+    *,
+    repo_root: Path | str,
+    db_path: Path | str | None,
+    agent: str = "reddog",
+) -> Optional[RedDogVerifiedPatternMemorySink]:
+    """Build an explicit outside-repo PatternMemory sink, or None if disabled."""
+
+    if not db_path:
+        return None
+    root = Path(repo_root).resolve()
+    path = Path(db_path)
+    if not path.is_absolute():
+        path = (root / path).resolve()
+    else:
+        path = path.resolve()
+    if _is_inside(path, root):
+        raise PatternMemorySinkConfigurationError("pattern_memory_db_path_inside_repo")
+    return RedDogVerifiedPatternMemorySink(db_path=path, agent=agent)
+
+
+__all__ = [
+    "PatternMemorySinkConfigurationError",
+    "REDDOG_VERIFIED_PATTERN_MEMORY_SINK_READY",
+    "RedDogVerifiedPatternMemorySink",
+    "build_reddog_verified_pattern_memory_sink",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -2465,6 +2465,9 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
                 "REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_PATH": str(
                     tmp_path / "pattern_memory_admission_request.json"
                 ),
+                "REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH": str(
+                    tmp_path / "pattern_memory.db"
+                ),
                 "REDDOG_AUTHORITY_RUNTIME_STATE_PATH": str(tmp_path / "authority_state.json"),
                 "REDDOG_PERMISSION_SNAPSHOTS_PATH": str(tmp_path / "snapshots.json"),
                 "REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH": str(tmp_path / "principals.json"),
@@ -2515,6 +2518,10 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
     )
     assert mocked.call_args.kwargs["admission_request_path"] == str(
         tmp_path / "pattern_memory_admission_request.json"
+    )
+    assert mocked.call_args.kwargs["pattern_memory_admission_sink"] is not None
+    assert str(mocked.call_args.kwargs["pattern_memory_admission_sink"].db_path) == str(
+        tmp_path / "pattern_memory.db"
     )
     assert mocked.call_args.kwargs["authority_state_path"] == str(tmp_path / "authority_state.json")
     assert mocked.call_args.kwargs["permission_snapshots_path"] == str(tmp_path / "snapshots.json")

--- a/modules/communication/moltbot_bridge/tests/test_reddog_verified_pattern_memory_sink.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_verified_pattern_memory_sink.py
@@ -1,0 +1,170 @@
+"""Tests for REDDOG_MAIN_RESIDENT_QUEUE_PATTERN_MEMORY_SINK_BRIDGE_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_verified_pattern_memory_sink import (
+    REDDOG_VERIFIED_PATTERN_MEMORY_SINK_READY,
+    PatternMemorySinkConfigurationError,
+    build_reddog_verified_pattern_memory_sink,
+)
+from modules.infrastructure.wre_core.src.pattern_memory import PatternMemory
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_verified_pattern_memory_sink.py"
+)
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    return repo
+
+
+def _record(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "record_type": "reddog_verified_recursive_improvement_outcome",
+        "work_order_id": "resident-queue-work-order-001",
+        "slice_name": "REDDOG_TEST_SLICE_PHASE1",
+        "gate_id": "held_out_recursive_gate_1234",
+        "ratchet_id": "outcome_ratchet_1234",
+        "verifier_receipt_id": "wre_slice_verify_1234",
+        "improvement_job_id": "imp_resident_queue_heldout_1234",
+        "held_out_suite_id": "heldout-resident-queue-001",
+        "candidate_head_sha": "a" * 40,
+        "regression_test_count": 12,
+        "pattern_memory_admission_allowed": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_build_returns_none_when_sink_path_is_not_configured(tmp_path: Path) -> None:
+    assert build_reddog_verified_pattern_memory_sink(repo_root=_repo(tmp_path), db_path=None) is None
+
+
+def test_build_rejects_pattern_memory_database_inside_repo(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+
+    with pytest.raises(PatternMemorySinkConfigurationError) as excinfo:
+        build_reddog_verified_pattern_memory_sink(
+            repo_root=repo,
+            db_path=repo / "runtime" / "pattern_memory.db",
+        )
+
+    assert "pattern_memory_db_path_inside_repo" in str(excinfo.value)
+
+
+def test_sink_stores_verified_outcome_in_outside_repo_pattern_memory_db(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    db_path = tmp_path / "runtime" / "pattern_memory.db"
+    sink = build_reddog_verified_pattern_memory_sink(repo_root=repo, db_path=db_path)
+    assert sink is not None
+    assert sink.status == REDDOG_VERIFIED_PATTERN_MEMORY_SINK_READY
+
+    record_id = sink.store_verified_outcome(_record())
+
+    memory = PatternMemory(db_path=db_path)
+    try:
+        cursor = memory.conn.cursor()
+        cursor.execute("SELECT * FROM skill_outcomes WHERE execution_id = ?", (record_id,))
+        row = cursor.fetchone()
+    finally:
+        memory.close()
+
+    assert row is not None
+    assert row["skill_name"] == "REDDOG_TEST_SLICE_PHASE1"
+    assert row["agent"] == "reddog"
+    assert row["success"] == 1
+    assert row["pattern_fidelity"] == 1.0
+    assert json.loads(row["output_result"])["record_type"] == (
+        "reddog_verified_recursive_improvement_outcome"
+    )
+
+
+def test_sink_is_idempotent_for_same_verified_outcome_record(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    sink = build_reddog_verified_pattern_memory_sink(
+        repo_root=repo,
+        db_path=tmp_path / "runtime" / "pattern_memory.db",
+    )
+    assert sink is not None
+
+    first = sink.store_verified_outcome(_record())
+    second = sink.store_verified_outcome(_record())
+
+    assert second == first
+
+
+def test_sink_rejects_secret_bearing_verified_outcome_record(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    sink = build_reddog_verified_pattern_memory_sink(
+        repo_root=repo,
+        db_path=tmp_path / "runtime" / "pattern_memory.db",
+    )
+    assert sink is not None
+
+    with pytest.raises(ValueError) as excinfo:
+        sink.store_verified_outcome(_record(admission_metadata={"api_key": "secret"}))
+
+    assert "secret_in_verified_outcome_record" in str(excinfo.value)
+
+
+def test_sink_module_has_no_shell_network_holoindex_or_authority_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "holo_index",
+        "git",
+        "gh",
+    }
+    banned_import_fragments = {
+        "openclaw",
+        "hermes",
+        "worktree_pr_runner",
+        "reddog_main_resident_queue_serial_loop_bootstrap",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    banned_attrs = {
+        "system",
+        "popen",
+        "spawn",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "unlink",
+        "remove",
+        "rmdir",
+        "rename",
+    }
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+                assert all(fragment not in alias.name for fragment in banned_import_fragments)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+            assert all(fragment not in node.module for fragment in banned_import_fragments)
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs


### PR DESCRIPTION
## Summary

- Adds an explicit RedDog verified PatternMemory sink adapter for already-verified resident queue outcomes.
- Wires main.py to construct the sink only when REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH is explicitly set.
- Requires the PatternMemory database path to resolve outside the repo checkout.
- Stores verified recursive improvement outcomes through the existing WRE PatternMemory SkillOutcome API.
- Rejects secret-bearing records and is idempotent for repeated verified outcome records.

## Validation

- sink bridge tests: 6 passed
- bootstrap/main pass-through tests: 30 passed
- PatternMemory admission handler/invoke tests: 18 passed
- py_compile on touched Python files: passed
- git diff --check: clean
- HoloIndex read-only probe: adjacent hits only; INDEX_GAP recorded in ModLog

## Truth Boundary

- No default PatternMemory client is created.
- No PatternMemory sink exists unless REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH is explicitly configured.
- The DB path must be outside the repo checkout.
- No HoloIndex runtime re-index is performed.
- No OpenClaw enqueue, Hermes dispatch, shell command, PR publish, merge, or reward settlement is performed.
