### PR TITLE
feat(reddog): bridge draft PR runner into resident queue

### DIFF
--- a/main.py
+++ b/main.py
@@ -1546,6 +1546,8 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
         REDDOG_SIGNATURE_VERIFIER_BACKEND                    Optional verifier backend (`ed25519`)
         REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE           Optional `real` runner mode
         REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_TIMEOUT_S      Optional runner timeout
+        REDDOG_DRAFT_PR_RUNNER_MODE                          Optional `real` draft-PR runner mode
+        REDDOG_DRAFT_PR_RUNNER_TIMEOUT_S                     Optional draft-PR runner timeout
     """
 
     if os.getenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP", "0") == "0":
@@ -1577,6 +1579,11 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
         worktree_runner_timeout_s = int(worktree_runner_timeout_value) if worktree_runner_timeout_value else 120
     except ValueError:
         worktree_runner_timeout_s = 0
+    try:
+        draft_pr_runner_timeout_value = os.getenv("REDDOG_DRAFT_PR_RUNNER_TIMEOUT_S", "")
+        draft_pr_runner_timeout_s = int(draft_pr_runner_timeout_value) if draft_pr_runner_timeout_value else 120
+    except ValueError:
+        draft_pr_runner_timeout_s = 0
 
     try:
         from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_loop_bootstrap import (
@@ -1590,6 +1597,19 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             repo_root=repo_root,
             db_path=os.getenv("REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH", "") or None,
         )
+        draft_pr_runner = None
+        draft_pr_runner_mode = os.getenv("REDDOG_DRAFT_PR_RUNNER_MODE", "").strip().lower()
+        if draft_pr_runner_mode:
+            if draft_pr_runner_mode != "real":
+                raise ValueError("unsupported_draft_pr_runner_mode")
+            if draft_pr_runner_timeout_s <= 0:
+                raise ValueError("invalid_draft_pr_runner_timeout")
+            from modules.foundups.agent.src.worktree_pr_runner import RealWorktreeRunner
+
+            draft_pr_runner = RealWorktreeRunner(
+                repo_root=repo_root,
+                timeout_s=draft_pr_runner_timeout_s,
+            )
 
         result = run_reddog_main_resident_queue_serial_loop_bootstrap(
             repo_root=repo_root,
@@ -1623,6 +1643,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             signature_verifier_backend=os.getenv("REDDOG_SIGNATURE_VERIFIER_BACKEND", "") or None,
             worktree_runner_mode=os.getenv("REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE", "") or None,
             worktree_runner_timeout_s=worktree_runner_timeout_s,
+            draft_pr_runner=draft_pr_runner,
             pattern_memory_admission_sink=pattern_memory_admission_sink,
             requested_queue_item_id=os.getenv("REDDOG_WRE_QUEUE_ITEM_ID", "") or None,
             now_epoch=now_epoch,

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,31 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_DRAFT_PR_RUNNER_BRIDGE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added explicit `main.py` env wiring for `REDDOG_DRAFT_PR_RUNNER_MODE=real`
+  and `REDDOG_DRAFT_PR_RUNNER_TIMEOUT_S`.
+- The bridge constructs the existing approved
+  `modules.foundups.agent.src.worktree_pr_runner.RealWorktreeRunner` only when
+  explicitly requested, then injects it into the resident serial queue
+  `verified_draft_pr_publish` stage.
+- Default behavior remains fail-closed: no draft-PR runner is constructed and
+  the existing stage rejects with `FAIL_DRAFT_PR_RUNNER_MISSING`.
+- Unsupported runner modes or invalid timeouts reject before the resident queue
+  bootstrap runs when startup enforcement is enabled.
+- No PR is created by this bridge alone. The existing publish guard still
+  requires accepted slice-verifier evidence, exact-head metadata, branch policy,
+  and draft-only request fields before the injected runner can push or create a
+  draft PR. No ready, merge, reward settlement, PatternMemory write, Hermes
+  dispatch, OpenClaw enqueue, or HoloIndex runtime re-index is added.
+- HoloIndex read-only probe for `RedDog main resident queue draft PR runner
+  bridge verified draft PR publish RealWorktreeRunner` surfaced adjacent
+  worktree runner and governed work-order assets, but not this new bridge seam;
+  recorded as
+  `HOLOINDEX_REDDOG_MAIN_RESIDENT_QUEUE_DRAFT_PR_RUNNER_BRIDGE_INDEX_GAP_PHASE1`.
+  No runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_PATTERN_MEMORY_SINK_BRIDGE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 34, 50, 97

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -2477,6 +2477,8 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
                 "REDDOG_SIGNATURE_VERIFIER_BACKEND": REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
                 "REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE": "real",
                 "REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_TIMEOUT_S": "77",
+                "REDDOG_DRAFT_PR_RUNNER_MODE": "real",
+                "REDDOG_DRAFT_PR_RUNNER_TIMEOUT_S": "88",
                 "REDDOG_RESIDENT_QUEUE_NOW_EPOCH": "1000",
                 "REDDOG_WRE_QUEUE_ITEM_ID": "queue-1",
             },
@@ -2532,6 +2534,8 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
     assert mocked.call_args.kwargs["signature_verifier_backend"] == REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519
     assert mocked.call_args.kwargs["worktree_runner_mode"] == "real"
     assert mocked.call_args.kwargs["worktree_runner_timeout_s"] == 77
+    assert mocked.call_args.kwargs["draft_pr_runner"].__class__.__name__ == "RealWorktreeRunner"
+    assert mocked.call_args.kwargs["draft_pr_runner"].timeout_s == 88
     assert mocked.call_args.kwargs["requested_queue_item_id"] == "queue-1"
     assert mocked.call_args.kwargs["now_epoch"] == 1000
     assert mocked.call_args.kwargs["max_steps"] == 1
@@ -2564,6 +2568,25 @@ def test_main_serial_loop_preflight_blocks_when_enforced() -> None:
             {
                 "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP": "1",
                 "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_ENFORCED": "1",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_queue_serial_loop_preflight(REPO_ROOT) is False
+
+
+def test_main_serial_loop_preflight_rejects_unsupported_draft_pr_runner_mode_when_enforced() -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_loop_bootstrap.run_reddog_main_resident_queue_serial_loop_bootstrap",
+        side_effect=AssertionError("bootstrap must not run for unsupported draft PR runner mode"),
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP": "1",
+                "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_ENFORCED": "1",
+                "REDDOG_DRAFT_PR_RUNNER_MODE": "unsafe",
             },
             clear=True,
         ):


### PR DESCRIPTION
## Summary
- add explicit main.py env wiring for REDDOG_DRAFT_PR_RUNNER_MODE=real and REDDOG_DRAFT_PR_RUNNER_TIMEOUT_S
- inject the approved RealWorktreeRunner into the resident serial queue verified_draft_pr_publish stage only when explicitly requested
- preserve default fail-closed behavior and reject unsupported runner modes before bootstrap under enforcement

## Validation
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_verified_draft_pr_publish_handler.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_draft_pr_publish_invoke.py modules/infrastructure/wre_core/tests/test_reddog_verified_draft_pr_publish.py -> 60 passed
- python -m py_compile main.py modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py modules/foundups/agent/src/worktree_pr_runner.py
- git diff --check
- diff additions ASCII clean
- runner import smoke -> PASS

## Boundary
- no runner by default
- no PR creation by this bridge alone
- existing publish guard still requires accepted verifier evidence, exact-head metadata, branch policy, and draft-only request fields
- no ready, merge, reward settlement, PatternMemory write, Hermes dispatch, OpenClaw enqueue, or HoloIndex runtime re-index

## HoloIndex
- Read-only probe surfaced adjacent worktree runner assets but not this bridge seam.
- INDEX_GAP: HOLOINDEX_REDDOG_MAIN_RESIDENT_QUEUE_DRAFT_PR_RUNNER_BRIDGE_INDEX_GAP_PHASE1

Worker-Lane: resident-queue-runtime
Slice: REDDOG_MAIN_RESIDENT_QUEUE_DRAFT_PR_RUNNER_BRIDGE_PHASE1