### PR TITLE
feat(reddog): add WSP15 allocation receipt runtime

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,29 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-15: REDDOG_WSP15_ALLOCATION_RECEIPT_RUNTIME_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `src/reddog_wsp15_allocation_receipt.py`, a deterministic WSP_15
+  MPS allocation receipt for RedDog work-focus planning.
+- The receipt records complexity, importance, deferability, impact, total MPS,
+  P0-P4 priority, reasoning tier, and a worker-plan recommendation without
+  calling models, spawning workers, mutating queues, or re-indexing HoloIndex.
+- Threaded the allocation receipt into
+  `reddog_main_readonly_operational_bootstrap` ready and not-ready results so
+  downstream authority-profile materialization can bind to a real receipt
+  instead of hand-written WSP_15 fields.
+- Added tests for P0/ULTRA authority-sensitive RedDog runtime work, regular
+  low-priority prompts, deterministic JSON serialization, score bounds, static
+  execution/indexing import denial, and bootstrap result propagation.
+- No OpenClaw enqueue, Hermes dispatch, worktree creation, shell command,
+  draft PR, merge, reward settlement, PatternMemory write, or HoloIndex runtime
+  re-index is added.
+- HoloIndex read-only probe for `RedDog WSP15 allocation receipt MPS worker
+  plan` returned adjacent RedDog/WSP assets but not the new allocation module;
+  recorded as `HOLOINDEX_REDDOG_WSP15_ALLOCATION_RECEIPT_INDEX_GAP_PHASE1`.
+  No runtime re-index is performed in this slice.
+
 ## 2026-07-14: REDDOG_MAIN_RESIDENT_QUEUE_WORK_ORDER_MATERIALIZER_BOOTSTRAP_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 34, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
@@ -57,6 +57,9 @@ from modules.communication.moltbot_bridge.src.reddog_operational_context_snapsho
     load_existing_holoindex_receipt,
     observe_repo_state,
 )
+from modules.communication.moltbot_bridge.src.reddog_wsp15_allocation_receipt import (
+    allocate_reddog_wsp15_receipt,
+)
 
 
 REDDOG_MAIN_BOOTSTRAP_READY = "REDDOG_MAIN_BOOTSTRAP_READY"
@@ -90,6 +93,7 @@ class RedDogMainReadonlyBootstrapResult:
     rejection_reasons: tuple[str, ...]
     changed_paths: tuple[str, ...]
     allowed_read_targets: tuple[str, ...]
+    wsp15_allocation_receipt: Optional[Mapping[str, Any]] = None
     assignment_ids: tuple[str, ...] = ()
     report_collection_attempted: bool = False
     report_collection_status: Optional[str] = None
@@ -150,6 +154,12 @@ def run_reddog_main_readonly_operational_bootstrap(
 
     paths = _normalize_paths(changed_paths)
     targets = _normalize_paths(allowed_read_targets)
+    wsp15_allocation_receipt = allocate_reddog_wsp15_receipt(
+        requested_operation=requested_operation,
+        prompt_text=prompt_text,
+        changed_paths=paths,
+        allowed_read_targets=targets,
+    ).to_dict()
     reasons: list[str] = []
 
     work_state_snapshot = work_state_snapshot_override
@@ -187,6 +197,7 @@ def run_reddog_main_readonly_operational_bootstrap(
             reasons=reasons,
             changed_paths=paths,
             allowed_read_targets=targets,
+            wsp15_allocation_receipt=wsp15_allocation_receipt,
         )
 
     assert work_state_snapshot is not None
@@ -204,6 +215,7 @@ def run_reddog_main_readonly_operational_bootstrap(
             reasons=snapshot_result.rejection_reasons or ("snapshot_rejected",),
             changed_paths=paths,
             allowed_read_targets=targets,
+            wsp15_allocation_receipt=wsp15_allocation_receipt,
         )
 
     snapshot = snapshot_result.snapshot
@@ -225,6 +237,7 @@ def run_reddog_main_readonly_operational_bootstrap(
             reasons=gate.rejection_reasons or ("fusion_assignment_gate_rejected",),
             changed_paths=paths,
             allowed_read_targets=targets,
+            wsp15_allocation_receipt=wsp15_allocation_receipt,
             snapshot=snapshot,
             evidence_bundle=evidence_bundle,
             gate=gate,
@@ -243,6 +256,7 @@ def run_reddog_main_readonly_operational_bootstrap(
             reasons=plan.rejection_reasons or ("readonly_audit_swarm_rejected",),
             changed_paths=paths,
             allowed_read_targets=targets,
+            wsp15_allocation_receipt=wsp15_allocation_receipt,
             snapshot=snapshot,
             evidence_bundle=evidence_bundle,
             gate=gate,
@@ -266,6 +280,7 @@ def run_reddog_main_readonly_operational_bootstrap(
                     reasons=("readonly_audit_decision_report_load_failed",),
                     changed_paths=paths,
                     allowed_read_targets=targets,
+                    wsp15_allocation_receipt=wsp15_allocation_receipt,
                     snapshot=snapshot,
                     evidence_bundle=evidence_bundle,
                     gate=gate,
@@ -281,6 +296,7 @@ def run_reddog_main_readonly_operational_bootstrap(
                     reasons=("readonly_audit_decision_rejected", *decision_result.rejection_reasons),
                     changed_paths=paths,
                     allowed_read_targets=targets,
+                    wsp15_allocation_receipt=wsp15_allocation_receipt,
                     snapshot=snapshot,
                     evidence_bundle=evidence_bundle,
                     gate=gate,
@@ -303,6 +319,7 @@ def run_reddog_main_readonly_operational_bootstrap(
                         ),
                         changed_paths=paths,
                         allowed_read_targets=targets,
+                        wsp15_allocation_receipt=wsp15_allocation_receipt,
                         snapshot=snapshot,
                         evidence_bundle=evidence_bundle,
                         gate=gate,
@@ -319,6 +336,7 @@ def run_reddog_main_readonly_operational_bootstrap(
                 plan=plan,
                 changed_paths=paths,
                 allowed_read_targets=targets,
+                wsp15_allocation_receipt=wsp15_allocation_receipt,
                 collection_result=collection_result,
                 decision_result=decision_result,
                 decision_persist_result=decision_persist_result,
@@ -330,6 +348,7 @@ def run_reddog_main_readonly_operational_bootstrap(
                 reasons=("readonly_audit_report_collection_rejected", *collection_result.rejection_reasons),
                 changed_paths=paths,
                 allowed_read_targets=targets,
+                wsp15_allocation_receipt=wsp15_allocation_receipt,
                 snapshot=snapshot,
                 evidence_bundle=evidence_bundle,
                 gate=gate,
@@ -352,6 +371,7 @@ def run_reddog_main_readonly_operational_bootstrap(
                 reasons=("readonly_audit_enqueue_rejected", *enqueue_result.rejection_reasons),
                 changed_paths=paths,
                 allowed_read_targets=targets,
+                wsp15_allocation_receipt=wsp15_allocation_receipt,
                 snapshot=snapshot,
                 evidence_bundle=evidence_bundle,
                 gate=gate,
@@ -370,6 +390,7 @@ def run_reddog_main_readonly_operational_bootstrap(
         plan=plan,
         changed_paths=paths,
         allowed_read_targets=targets,
+        wsp15_allocation_receipt=wsp15_allocation_receipt,
         collection_result=collection_result,
         decision_result=decision_result,
         decision_persist_result=decision_persist_result,
@@ -387,6 +408,7 @@ def _ready(
     plan: ReadOnlyAuditSwarmPlan,
     changed_paths: Sequence[str],
     allowed_read_targets: Sequence[str],
+    wsp15_allocation_receipt: Mapping[str, Any],
     collection_result: ReadOnlyAuditReportCollectionResult | None,
     decision_result: ReadOnlyAuditDecisionReceipt | None,
     decision_persist_result: ReadOnlyAuditDecisionPersistResult | None,
@@ -401,6 +423,7 @@ def _ready(
         snapshot_receipt_id=snapshot.snapshot_receipt_id,
         context_view_id=context_view.context_view_id,
         evidence_bundle_id=evidence_bundle.evidence_bundle_id,
+        wsp15_allocation_receipt=wsp15_allocation_receipt,
         determination_id=gate.determination_binding.determination_id,
         swarm_id=plan.receipt.swarm_id,
         assignment_count=len(plan.assignments),
@@ -471,6 +494,7 @@ def _not_ready(
     reasons: Sequence[str],
     changed_paths: Sequence[str],
     allowed_read_targets: Sequence[str],
+    wsp15_allocation_receipt: Mapping[str, Any] | None = None,
     snapshot: OperationalContextSnapshot | None = None,
     evidence_bundle: EvidenceBundle | None = None,
     gate: FusionAssignmentGateDecision | None = None,
@@ -489,6 +513,7 @@ def _not_ready(
         snapshot_receipt_id=snapshot.snapshot_receipt_id if snapshot else None,
         context_view_id=gate.determination_binding.context_view_id if gate and gate.determination_binding else None,
         evidence_bundle_id=evidence_bundle.evidence_bundle_id if evidence_bundle else None,
+        wsp15_allocation_receipt=wsp15_allocation_receipt,
         determination_id=determination_id,
         swarm_id=swarm_plan.receipt.swarm_id if swarm_plan else None,
         assignment_count=len(swarm_plan.assignments) if swarm_plan else 0,

--- a/modules/communication/moltbot_bridge/src/reddog_wsp15_allocation_receipt.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wsp15_allocation_receipt.py
@@ -1,0 +1,338 @@
+"""Deterministic RedDog WSP 15 allocation receipts.
+
+This module converts a work focus into a WSP 15 MPS allocation receipt that
+downstream RedDog/OpenClaw planning can bind to without relying on hand-written
+priority fields. It performs no model calls, worker dispatch, queue mutation,
+shell execution, or HoloIndex indexing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA_VERSION = "reddog_wsp15_allocation_receipt.v1"
+
+PRIORITY_P0 = "P0"
+PRIORITY_P1 = "P1"
+PRIORITY_P2 = "P2"
+PRIORITY_P3 = "P3"
+PRIORITY_P4 = "P4"
+
+REASONING_REGULAR = "REGULAR"
+REASONING_HIGH = "HIGH"
+REASONING_ULTRA = "ULTRA"
+
+_ULTRA_KEYWORDS = (
+    "authority",
+    "auth",
+    "credential",
+    "hermes",
+    "live",
+    "main.py",
+    "merge",
+    "openclaw",
+    "redaction",
+    "reddog",
+    "security",
+    "signature",
+    "sovereign",
+    "token",
+    "valve",
+    "worktree",
+    "wre",
+)
+
+_URGENCY_KEYWORDS = (
+    "block",
+    "blocked",
+    "critical",
+    "fail",
+    "fix",
+    "main startup",
+    "operational",
+    "runtime",
+    "startup",
+)
+
+_SYSTEM_KEYWORDS = (
+    "agentdb",
+    "brain",
+    "breadcrumb",
+    "fusion",
+    "holoindex",
+    "main",
+    "queue",
+    "wsp",
+)
+
+
+@dataclass(frozen=True)
+class RedDogWSP15AllocationReceipt:
+    """WSP 15 allocation receipt for one RedDog work focus."""
+
+    schema_version: str
+    receipt_id: str
+    input_digest: str
+    requested_operation: str
+    prompt_digest: str
+    changed_paths: tuple[str, ...]
+    allowed_read_targets: tuple[str, ...]
+    complexity: int
+    importance: int
+    deferability: int
+    impact: int
+    mps_total: int
+    priority: str
+    reasoning_tier: str
+    worker_plan: Mapping[str, Any]
+    scoring_rationale: Mapping[str, str]
+    wsp_refs: tuple[str, ...] = ("WSP_15", "WSP_97")
+    wsp97_label: str = "INFERRED"
+    scoring_method: str = "deterministic_wsp15_runtime_heuristic"
+    no_model_call_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_queue_mutation_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def allocate_reddog_wsp15_receipt(
+    *,
+    requested_operation: str,
+    prompt_text: str,
+    changed_paths: Sequence[str] = (),
+    allowed_read_targets: Sequence[str] = (),
+) -> RedDogWSP15AllocationReceipt:
+    """Allocate a deterministic WSP 15 receipt for a RedDog work focus."""
+
+    paths = _normalize_paths(changed_paths)
+    targets = _normalize_paths(allowed_read_targets)
+    corpus = _corpus(
+        requested_operation=requested_operation,
+        prompt_text=prompt_text,
+        changed_paths=paths,
+        allowed_read_targets=targets,
+    )
+    path_count = len(tuple(dict.fromkeys((*paths, *targets))))
+    ultra_hit = _contains_any(corpus, _ULTRA_KEYWORDS)
+    urgency_hit = _contains_any(corpus, _URGENCY_KEYWORDS)
+    system_hit = _contains_any(corpus, _SYSTEM_KEYWORDS)
+
+    complexity = _score_complexity(path_count=path_count, corpus=corpus, ultra_hit=ultra_hit)
+    importance = _score_importance(ultra_hit=ultra_hit, system_hit=system_hit, path_count=path_count)
+    deferability = _score_deferability(ultra_hit=ultra_hit, urgency_hit=urgency_hit)
+    impact = _score_impact(ultra_hit=ultra_hit, system_hit=system_hit, urgency_hit=urgency_hit)
+    mps_total = complexity + importance + deferability + impact
+    priority = _priority_for_total(mps_total)
+    reasoning_tier = _reasoning_tier(priority=priority, ultra_hit=ultra_hit, path_count=path_count)
+    worker_plan = _worker_plan(priority=priority, reasoning_tier=reasoning_tier, ultra_hit=ultra_hit)
+    scoring_rationale = {
+        "complexity": _complexity_rationale(path_count=path_count, ultra_hit=ultra_hit),
+        "importance": _importance_rationale(ultra_hit=ultra_hit, system_hit=system_hit),
+        "deferability": _deferability_rationale(ultra_hit=ultra_hit, urgency_hit=urgency_hit),
+        "impact": _impact_rationale(ultra_hit=ultra_hit, system_hit=system_hit, urgency_hit=urgency_hit),
+    }
+    input_payload = {
+        "schema_version": SCHEMA_VERSION,
+        "requested_operation": str(requested_operation or ""),
+        "prompt_digest": _digest(str(prompt_text or "")),
+        "changed_paths": paths,
+        "allowed_read_targets": targets,
+        "complexity": complexity,
+        "importance": importance,
+        "deferability": deferability,
+        "impact": impact,
+        "mps_total": mps_total,
+        "priority": priority,
+        "reasoning_tier": reasoning_tier,
+        "worker_plan": worker_plan,
+        "scoring_method": "deterministic_wsp15_runtime_heuristic",
+    }
+    input_digest = _digest(input_payload)
+    return RedDogWSP15AllocationReceipt(
+        schema_version=SCHEMA_VERSION,
+        receipt_id=_digest({"receipt": input_digest, "type": SCHEMA_VERSION}),
+        input_digest=input_digest,
+        requested_operation=str(requested_operation or ""),
+        prompt_digest=_digest(str(prompt_text or "")),
+        changed_paths=paths,
+        allowed_read_targets=targets,
+        complexity=complexity,
+        importance=importance,
+        deferability=deferability,
+        impact=impact,
+        mps_total=mps_total,
+        priority=priority,
+        reasoning_tier=reasoning_tier,
+        worker_plan=worker_plan,
+        scoring_rationale=scoring_rationale,
+    )
+
+
+def _score_complexity(*, path_count: int, corpus: str, ultra_hit: bool) -> int:
+    if ultra_hit or "runtime" in corpus or "integration" in corpus:
+        return 5
+    if path_count >= 6:
+        return 4
+    if path_count >= 3:
+        return 3
+    if path_count >= 1:
+        return 2
+    return 1
+
+
+def _score_importance(*, ultra_hit: bool, system_hit: bool, path_count: int) -> int:
+    if ultra_hit:
+        return 5
+    if system_hit:
+        return 4
+    if path_count >= 1:
+        return 3
+    return 2
+
+
+def _score_deferability(*, ultra_hit: bool, urgency_hit: bool) -> int:
+    if ultra_hit and urgency_hit:
+        return 5
+    if ultra_hit or urgency_hit:
+        return 4
+    return 3
+
+
+def _score_impact(*, ultra_hit: bool, system_hit: bool, urgency_hit: bool) -> int:
+    if ultra_hit and (system_hit or urgency_hit):
+        return 5
+    if ultra_hit or system_hit:
+        return 4
+    return 3
+
+
+def _priority_for_total(total: int) -> str:
+    if total >= 16:
+        return PRIORITY_P0
+    if total >= 13:
+        return PRIORITY_P1
+    if total >= 10:
+        return PRIORITY_P2
+    if total >= 7:
+        return PRIORITY_P3
+    return PRIORITY_P4
+
+
+def _reasoning_tier(*, priority: str, ultra_hit: bool, path_count: int) -> str:
+    if priority == PRIORITY_P0 or ultra_hit:
+        return REASONING_ULTRA
+    if priority in {PRIORITY_P1, PRIORITY_P2} or path_count >= 3:
+        return REASONING_HIGH
+    return REASONING_REGULAR
+
+
+def _worker_plan(*, priority: str, reasoning_tier: str, ultra_hit: bool) -> Mapping[str, Any]:
+    critic_count = 0
+    if reasoning_tier == REASONING_ULTRA:
+        critic_count = 2
+    elif reasoning_tier == REASONING_HIGH:
+        critic_count = 1
+    return {
+        "schema_version": "reddog_wsp15_worker_plan.v1",
+        "fusion_required": reasoning_tier in {REASONING_HIGH, REASONING_ULTRA},
+        "reasoning_tier": reasoning_tier,
+        "critic_count": critic_count,
+        "coding_worker_count": 2 if priority == PRIORITY_P0 else (1 if priority in {PRIORITY_P1, PRIORITY_P2} else 0),
+        "independent_verifier_required": priority in {PRIORITY_P0, PRIORITY_P1} or ultra_hit,
+        "openclaw_candidate": priority in {PRIORITY_P0, PRIORITY_P1},
+        "hermes_execution_allowed": False,
+        "queue_mutation_allowed": False,
+        "mode_selection_source": SCHEMA_VERSION,
+    }
+
+
+def _complexity_rationale(*, path_count: int, ultra_hit: bool) -> str:
+    if ultra_hit:
+        return "Very high because the work focus touches RedDog/WRE/security/runtime authority terms."
+    return f"Derived from {path_count} unique repo targets and no authority-sensitive keyword hit."
+
+
+def _importance_rationale(*, ultra_hit: bool, system_hit: bool) -> str:
+    if ultra_hit:
+        return "Essential because authority-sensitive RedDog/WRE terms are present."
+    if system_hit:
+        return "Critical because system governance or memory terms are present."
+    return "Important but not core-authority-sensitive."
+
+
+def _deferability_rationale(*, ultra_hit: bool, urgency_hit: bool) -> str:
+    if ultra_hit and urgency_hit:
+        return "Cannot defer because authority-sensitive and blocking/operational terms are present."
+    if ultra_hit or urgency_hit:
+        return "Difficult to defer because either authority or urgency terms are present."
+    return "Moderate deferability."
+
+
+def _impact_rationale(*, ultra_hit: bool, system_hit: bool, urgency_hit: bool) -> str:
+    if ultra_hit and (system_hit or urgency_hit):
+        return "Transformative operational impact for RedDog/WRE governance."
+    if ultra_hit or system_hit:
+        return "Major system impact."
+    return "Moderate impact."
+
+
+def _contains_any(text: str, needles: Sequence[str]) -> bool:
+    return any(needle in text for needle in needles)
+
+
+def _corpus(
+    *,
+    requested_operation: str,
+    prompt_text: str,
+    changed_paths: Sequence[str],
+    allowed_read_targets: Sequence[str],
+) -> str:
+    return " ".join(
+        (
+            str(requested_operation or ""),
+            str(prompt_text or ""),
+            " ".join(str(path) for path in changed_paths),
+            " ".join(str(path) for path in allowed_read_targets),
+        )
+    ).lower()
+
+
+def _normalize_paths(paths: Sequence[str]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    for value in paths:
+        text = str(value or "").replace("\\", "/").strip()
+        while text.startswith("./"):
+            text = text[2:]
+        if text and not text.startswith("/") and not text.startswith("../") and "/../" not in text:
+            normalized.append(text)
+    return tuple(dict.fromkeys(normalized))
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def _digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "PRIORITY_P0",
+    "PRIORITY_P1",
+    "PRIORITY_P2",
+    "PRIORITY_P3",
+    "PRIORITY_P4",
+    "REASONING_HIGH",
+    "REASONING_REGULAR",
+    "REASONING_ULTRA",
+    "RedDogWSP15AllocationReceipt",
+    "allocate_reddog_wsp15_receipt",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -200,6 +200,13 @@ def test_bootstrap_plans_default_readonly_audit_swarm_from_fresh_context() -> No
     assert result.status == REDDOG_MAIN_BOOTSTRAP_READY
     assert result.snapshot_receipt_id and result.snapshot_receipt_id.startswith("sha256:")
     assert result.evidence_bundle_id and result.evidence_bundle_id.startswith("sha256:")
+    assert result.wsp15_allocation_receipt is not None
+    assert result.wsp15_allocation_receipt["receipt_id"].startswith("sha256:")
+    assert result.wsp15_allocation_receipt["mps_total"] >= 16
+    assert result.wsp15_allocation_receipt["priority"] == "P0"
+    assert result.wsp15_allocation_receipt["reasoning_tier"] == "ULTRA"
+    assert result.wsp15_allocation_receipt["worker_plan"]["fusion_required"] is True
+    assert result.wsp15_allocation_receipt["no_model_call_performed"] is True
     assert result.determination_id and result.determination_id.startswith("sha256:")
     assert result.swarm_id and result.swarm_id.startswith("sha256:")
     assert result.assignment_count == 5
@@ -452,6 +459,9 @@ def test_bootstrap_not_ready_without_authoritative_work_state_or_holoindex_recei
     assert "missing_authoritative_work_state_path" in result.rejection_reasons
     assert "missing_holoindex_freshness_receipt_path" in result.rejection_reasons
     assert result.assignment_count == 0
+    assert result.wsp15_allocation_receipt is not None
+    assert result.wsp15_allocation_receipt["priority"] == "P0"
+    assert result.wsp15_allocation_receipt["worker_plan"]["queue_mutation_allowed"] is False
     assert result.no_repo_mutation_performed is True
     assert result.no_holoindex_reindex_performed is True
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wsp15_allocation_receipt.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wsp15_allocation_receipt.py
@@ -1,0 +1,118 @@
+"""Tests for REDDOG_WSP15_ALLOCATION_RECEIPT_RUNTIME_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_wsp15_allocation_receipt import (
+    PRIORITY_P0,
+    PRIORITY_P3,
+    REASONING_REGULAR,
+    REASONING_ULTRA,
+    allocate_reddog_wsp15_receipt,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_wsp15_allocation_receipt.py"
+)
+
+
+def test_allocation_scores_reddog_runtime_authority_work_as_p0_ultra() -> None:
+    receipt = allocate_reddog_wsp15_receipt(
+        requested_operation="main_startup_readonly_operational_audit",
+        prompt_text="Make RedDog operational with WRE, OpenClaw, Hermes, valve, signature, and worktree safety.",
+        changed_paths=(
+            "main.py",
+            "modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py",
+            "modules/communication/moltbot_bridge/src/reddog_wre_execution_valve.py",
+        ),
+        allowed_read_targets=("docs/0102_session_briefings/ACTIVE_SLICE_LEDGER.md",),
+    )
+
+    assert receipt.schema_version == "reddog_wsp15_allocation_receipt.v1"
+    assert receipt.receipt_id.startswith("sha256:")
+    assert receipt.input_digest.startswith("sha256:")
+    assert receipt.priority == PRIORITY_P0
+    assert receipt.reasoning_tier == REASONING_ULTRA
+    assert receipt.complexity == 5
+    assert receipt.importance == 5
+    assert receipt.deferability == 5
+    assert receipt.impact == 5
+    assert receipt.mps_total == 20
+    assert receipt.worker_plan["fusion_required"] is True
+    assert receipt.worker_plan["independent_verifier_required"] is True
+    assert receipt.worker_plan["hermes_execution_allowed"] is False
+    assert receipt.no_model_call_performed is True
+    assert receipt.no_worker_spawn_performed is True
+    assert receipt.no_holoindex_reindex_performed is True
+
+
+def test_allocation_can_emit_regular_low_priority_receipt_for_simple_prompt() -> None:
+    receipt = allocate_reddog_wsp15_receipt(
+        requested_operation="answer_simple_question",
+        prompt_text="Say hello.",
+    )
+
+    assert receipt.priority == PRIORITY_P3
+    assert receipt.reasoning_tier == REASONING_REGULAR
+    assert receipt.worker_plan["fusion_required"] is False
+    assert receipt.worker_plan["coding_worker_count"] == 0
+
+
+def test_allocation_receipt_is_deterministic_and_json_serializable() -> None:
+    first = allocate_reddog_wsp15_receipt(
+        requested_operation="audit reddog runtime",
+        prompt_text="Audit RedDog operational runtime.",
+        changed_paths=("modules/communication/moltbot_bridge/src/reddog_main.py",),
+    )
+    second = allocate_reddog_wsp15_receipt(
+        requested_operation="audit reddog runtime",
+        prompt_text="Audit RedDog operational runtime.",
+        changed_paths=("./modules/communication/moltbot_bridge/src/reddog_main.py",),
+    )
+
+    assert first.receipt_id == second.receipt_id
+    encoded = json.dumps(first.to_dict(), sort_keys=True)
+    assert "reddog_wsp15_allocation_receipt.v1" in encoded
+
+
+def test_allocation_scores_stay_within_wsp15_ranges() -> None:
+    receipt = allocate_reddog_wsp15_receipt(
+        requested_operation="review docs",
+        prompt_text="Review a WSP doc and queue the finding.",
+        changed_paths=("WSP_framework/src/WSP_15_Module_Prioritization_Scoring_System.md",),
+    )
+
+    scores = (receipt.complexity, receipt.importance, receipt.deferability, receipt.impact)
+    assert all(1 <= score <= 5 for score in scores)
+    assert receipt.mps_total == sum(scores)
+    assert 4 <= receipt.mps_total <= 20
+
+
+def test_allocation_module_has_no_execution_or_indexing_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "holo_index",
+        "os",
+        "requests",
+        "socket",
+        "subprocess",
+        "urllib",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported = {alias.name.split(".")[0] for alias in node.names}
+            assert imported.isdisjoint(banned_import_roots)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".")[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in {"eval", "exec", "open"}


### PR DESCRIPTION
## Summary
- add deterministic RedDog WSP_15 MPS allocation receipt generation
- thread allocation receipts into read-only main bootstrap ready/not-ready results
- cover P0/ULTRA scoring, regular prompt scoring, deterministic JSON, score bounds, AST denylist, and bootstrap propagation

## WSP_97 Truth Boundary
- OBSERVED: receipt records complexity, importance, deferability, impact, MPS total, priority, reasoning tier, and worker-plan recommendation
- OBSERVED: read-only bootstrap now emits the receipt for downstream authority-profile binding
- SPECIFIED_NOT_IMPLEMENTED: no model call, worker spawn, queue mutation, OpenClaw enqueue, Hermes dispatch, worktree creation, shell command, PR publish, merge, reward settlement, PatternMemory write, or HoloIndex runtime re-index
- INDEX_GAP: HOLOINDEX_REDDOG_WSP15_ALLOCATION_RECEIPT_INDEX_GAP_PHASE1 recorded from read-only probe

## Validation
- pytest modules/communication/moltbot_bridge/tests/test_reddog_wsp15_allocation_receipt.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_request_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_verified_authority_work_order_invoke.py -q -> 97 passed
- python -m py_compile touched modules/tests -> pass
- git diff --check -> clean
- ASCII additions scan -> pass