### PR TITLE
feat(reddog): bind WSP15 allocation into WRE queue

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,26 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-15: REDDOG_AUTHORITATIVE_WORK_STATE_WSP15_QUEUE_BINDING_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Bound the deterministic WSP_15 allocation receipt into the authoritative
+  work-state runtime WRE queue item for the selected slice.
+- Queue items now include `wsp15_allocation_receipt` and an evidence ref of
+  `wsp15_allocation:<receipt_id>` alongside claim and freshness refs.
+- Updated the WRE queue consumer dry-run to fail closed when the WSP_15
+  allocation receipt is missing or not referenced, and to surface priority,
+  MPS total, and reasoning tier in the consumer receipt.
+- No queue mutation beyond the existing authoritative work-state atomic commit,
+  worker spawn, OpenClaw enqueue, Hermes dispatch, worktree creation, shell
+  command, repo mutation, reward settlement, PatternMemory write, or HoloIndex
+  runtime re-index is added.
+- HoloIndex read-only probe for `RedDog authoritative work state WSP15 queue
+  binding allocation receipt` returned adjacent RedDog/WSP assets but not this
+  binding seam; recorded as
+  `HOLOINDEX_REDDOG_AUTHORITATIVE_WORK_STATE_WSP15_QUEUE_BINDING_INDEX_GAP_PHASE1`.
+  No runtime re-index is performed in this slice.
+
 ## 2026-07-15: REDDOG_WSP15_ALLOCATION_RECEIPT_RUNTIME_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_authoritative_work_state_refresh_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_authoritative_work_state_refresh_runtime.py
@@ -34,6 +34,9 @@ from modules.communication.moltbot_bridge.src.reddog_lane_state_reconciler impor
     parse_work_ledger_json,
     reconcile_lane_sources,
 )
+from modules.communication.moltbot_bridge.src.reddog_wsp15_allocation_receipt import (
+    allocate_reddog_wsp15_receipt,
+)
 
 
 AUTHORITATIVE_REFRESH_APPLIED = "AUTHORITATIVE_REFRESH_APPLIED"
@@ -122,6 +125,7 @@ class WREQueueItem:
     status: str
     enqueued_at: str
     evidence_refs: Tuple[str, ...]
+    wsp15_allocation_receipt: Mapping[str, Any]
     no_execution_performed: bool = True
 
     def to_dict(self) -> Dict[str, Any]:
@@ -452,12 +456,49 @@ def _build_claim(
     )
 
 
-def _build_queue_item(claim: DurableWorkerClaim, *, now_iso: str) -> WREQueueItem:
+def _selected_record(report: LaneReconciliationReport, selected_slice: str) -> Optional[LaneSliceRecord]:
+    for record in _authoritative_records(report):
+        if record.slice_id == selected_slice:
+            return record
+    return None
+
+
+def _allocation_receipt_for_selected_slice(
+    *,
+    selected_slice: str,
+    record: Optional[LaneSliceRecord],
+) -> Mapping[str, Any]:
+    evidence_targets: tuple[str, ...] = ()
+    if record and record.evidence:
+        evidence_targets = tuple(ref.strip() for ref in record.evidence.split(";") if ref.strip())
+    prompt_parts = [selected_slice]
+    if record and record.priority:
+        prompt_parts.append(f"priority={record.priority}")
+    if record and record.wsp15_total is not None:
+        prompt_parts.append(f"source_wsp15_total={record.wsp15_total}")
+    if record and record.status:
+        prompt_parts.append(f"status={record.status}")
+    return allocate_reddog_wsp15_receipt(
+        requested_operation=f"authoritative_work_state_queue:{selected_slice}",
+        prompt_text=" ".join(prompt_parts),
+        changed_paths=evidence_targets,
+        allowed_read_targets=evidence_targets,
+    ).to_dict()
+
+
+def _build_queue_item(
+    claim: DurableWorkerClaim,
+    *,
+    now_iso: str,
+    wsp15_allocation_receipt: Mapping[str, Any],
+) -> WREQueueItem:
+    allocation_receipt_id = str(wsp15_allocation_receipt.get("receipt_id") or "")
     payload = {
         "slice_id": claim.slice_id,
         "claim_id": claim.claim_id,
         "worker_id": claim.worker_id,
         "enqueued_at": now_iso,
+        "wsp15_allocation_receipt_id": allocation_receipt_id,
     }
     return WREQueueItem(
         queue_item_id=_canonical_digest(payload),
@@ -466,7 +507,12 @@ def _build_queue_item(claim: DurableWorkerClaim, *, now_iso: str) -> WREQueueIte
         worker_id=claim.worker_id,
         status="QUEUED",
         enqueued_at=now_iso,
-        evidence_refs=(f"claim:{claim.claim_id}", f"freshness:{claim.freshness_receipt_id}"),
+        evidence_refs=(
+            f"claim:{claim.claim_id}",
+            f"freshness:{claim.freshness_receipt_id}",
+            f"wsp15_allocation:{allocation_receipt_id}",
+        ),
+        wsp15_allocation_receipt=dict(wsp15_allocation_receipt),
     )
 
 
@@ -622,7 +668,15 @@ def refresh_authoritative_work_state_runtime(
             report=report,
             freshness=freshness,
         )
-        queue_item = _build_queue_item(durable_claim, now_iso=now_iso)
+        allocation_receipt = _allocation_receipt_for_selected_slice(
+            selected_slice=selected,
+            record=_selected_record(report, selected),
+        )
+        queue_item = _build_queue_item(
+            durable_claim,
+            now_iso=now_iso,
+            wsp15_allocation_receipt=allocation_receipt,
+        )
         queue_items = (queue_item,)
         queue_sync = WREQueueSyncReceipt(
             sync_id=_canonical_digest(

--- a/modules/communication/moltbot_bridge/src/reddog_wre_queue_consumer_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_queue_consumer_dryrun.py
@@ -33,6 +33,7 @@ FAIL_CLAIM_STATUS = "FAIL_CLAIM_STATUS"
 FAIL_CLAIM_EXPIRED = "FAIL_CLAIM_EXPIRED"
 FAIL_FRESHNESS_RECEIPT = "FAIL_FRESHNESS_RECEIPT"
 FAIL_QUEUE_EVIDENCE_REFS = "FAIL_QUEUE_EVIDENCE_REFS"
+FAIL_WSP15_ALLOCATION_RECEIPT = "FAIL_WSP15_ALLOCATION_RECEIPT"
 FAIL_REQUESTED_QUEUE_NOT_FOUND = "FAIL_REQUESTED_QUEUE_NOT_FOUND"
 
 WORK_STATE_SCHEMA_VERSION = "reddog_authoritative_work_state.v1"
@@ -48,6 +49,10 @@ class WREQueueConsumerDryRunReceipt:
     claim_id: str
     worker_id: str
     freshness_receipt_id: str
+    wsp15_allocation_receipt_id: str
+    wsp15_priority: str
+    wsp15_mps_total: int
+    reasoning_tier: str
     next_required_gate: str
     execution_ready: bool = False
     no_queue_mutation_performed: bool = True
@@ -230,7 +235,26 @@ def plan_reddog_wre_queue_consumer_dry_run(
     if not freshness or freshness.get("fresh") is not True:
         reasons.append(FAIL_FRESHNESS_RECEIPT)
 
-    expected_refs = {f"claim:{claim_id}", f"freshness:{freshness_receipt_id}"}
+    wsp15_allocation = _mapping(selected.get("wsp15_allocation_receipt"))
+    allocation_receipt_id = str(wsp15_allocation.get("receipt_id") or "")
+    allocation_priority = str(wsp15_allocation.get("priority") or "")
+    allocation_tier = str(wsp15_allocation.get("reasoning_tier") or "")
+    allocation_total = wsp15_allocation.get("mps_total")
+    allocation_worker_plan = _mapping(wsp15_allocation.get("worker_plan"))
+    if (
+        not allocation_receipt_id.startswith("sha256:")
+        or not allocation_priority
+        or not allocation_tier
+        or not isinstance(allocation_total, int)
+        or not allocation_worker_plan
+    ):
+        reasons.append(FAIL_WSP15_ALLOCATION_RECEIPT)
+
+    expected_refs = {
+        f"claim:{claim_id}",
+        f"freshness:{freshness_receipt_id}",
+        f"wsp15_allocation:{allocation_receipt_id}",
+    }
     if not expected_refs.issubset(set(evidence_refs)):
         reasons.append(FAIL_QUEUE_EVIDENCE_REFS)
 
@@ -252,6 +276,10 @@ def plan_reddog_wre_queue_consumer_dry_run(
         "claim_id": claim_id,
         "worker_id": worker_id,
         "freshness_receipt_id": freshness_receipt_id,
+        "wsp15_allocation_receipt_id": allocation_receipt_id,
+        "wsp15_priority": allocation_priority,
+        "wsp15_mps_total": allocation_total,
+        "reasoning_tier": allocation_tier,
         "next_required_gate": NEXT_GATE_SIGNED_AUTHORITY_REQUIRED,
     }
     receipt = WREQueueConsumerDryRunReceipt(
@@ -261,6 +289,10 @@ def plan_reddog_wre_queue_consumer_dry_run(
         claim_id=claim_id,
         worker_id=worker_id,
         freshness_receipt_id=freshness_receipt_id,
+        wsp15_allocation_receipt_id=allocation_receipt_id,
+        wsp15_priority=allocation_priority,
+        wsp15_mps_total=allocation_total,
+        reasoning_tier=allocation_tier,
         next_required_gate=NEXT_GATE_SIGNED_AUTHORITY_REQUIRED,
     )
     return WREQueueConsumerDryRunResult(

--- a/modules/communication/moltbot_bridge/tests/test_reddog_authoritative_work_state_refresh_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_authoritative_work_state_refresh_runtime.py
@@ -136,6 +136,13 @@ def test_runtime_refresh_commits_authoritative_snapshot_claim_and_wre_queue_item
     assert snapshot["worker_claims"][0]["worker_id"] == "reddog-0102"
     assert snapshot["wre_queue_items"][0]["claim_id"] == snapshot["worker_claims"][0]["claim_id"]
     assert snapshot["wre_queue_items"][0]["no_execution_performed"] is True
+    allocation = snapshot["wre_queue_items"][0]["wsp15_allocation_receipt"]
+    assert allocation["schema_version"] == "reddog_wsp15_allocation_receipt.v1"
+    assert allocation["receipt_id"].startswith("sha256:")
+    assert allocation["mps_total"] >= 16
+    assert allocation["priority"] == "P0"
+    assert allocation["reasoning_tier"] == "ULTRA"
+    assert f"wsp15_allocation:{allocation['receipt_id']}" in snapshot["wre_queue_items"][0]["evidence_refs"]
     assert snapshot["no_holoindex_mutation_performed"] is True
     assert snapshot["no_worker_spawn_performed"] is True
     assert snapshot["no_execution_performed"] is True

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -81,7 +81,24 @@ PILOT_DOMAIN_ID = FOUNDUP_ID
 PILOT_ARTIFACT = f"modules/foundups/{PILOT_DOMAIN_ID}/README.md"
 
 
+def _queue_wsp15_allocation_receipt() -> dict[str, object]:
+    return {
+        "schema_version": "reddog_wsp15_allocation_receipt.v1",
+        "receipt_id": "sha256:wsp15-allocation-queue",
+        "mps_total": 20,
+        "priority": "P0",
+        "reasoning_tier": "ULTRA",
+        "worker_plan": {
+            "fusion_required": True,
+            "independent_verifier_required": True,
+            "queue_mutation_allowed": False,
+            "hermes_execution_allowed": False,
+        },
+    }
+
+
 def _snapshot() -> dict[str, object]:
+    allocation = _queue_wsp15_allocation_receipt()
     return {
         "schema_version": "reddog_authoritative_work_state.v1",
         "freshness_receipts": [{"receipt_id": "fresh-1", "fresh": True}],
@@ -102,7 +119,12 @@ def _snapshot() -> dict[str, object]:
                 "claim_id": "claim-1",
                 "worker_id": "reddog-0102",
                 "status": "QUEUED",
-                "evidence_refs": ["claim:claim-1", "freshness:fresh-1"],
+                "evidence_refs": [
+                    "claim:claim-1",
+                    "freshness:fresh-1",
+                    f"wsp15_allocation:{allocation['receipt_id']}",
+                ],
+                "wsp15_allocation_receipt": allocation,
                 "no_execution_performed": True,
             }
         ],

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py
@@ -36,9 +36,26 @@ BOOTSTRAP_PATH = (
 NOW = "2026-07-14T00:00:00+00:00"
 
 
+def _allocation_receipt():
+    return {
+        "schema_version": "reddog_wsp15_allocation_receipt.v1",
+        "receipt_id": "sha256:wsp15-allocation",
+        "mps_total": 18,
+        "priority": "P0",
+        "reasoning_tier": "ULTRA",
+        "worker_plan": {
+            "fusion_required": True,
+            "independent_verifier_required": True,
+            "queue_mutation_allowed": False,
+            "hermes_execution_allowed": False,
+        },
+    }
+
+
 def _snapshot(**overrides):
     claim_id = "claim-1"
     freshness_id = "fresh-1"
+    allocation = _allocation_receipt()
     base = {
         "schema_version": "reddog_authoritative_work_state.v1",
         "revision": "sha256:revision",
@@ -66,7 +83,12 @@ def _snapshot(**overrides):
                 "worker_id": "reddog-main-bootstrap",
                 "status": "QUEUED",
                 "enqueued_at": NOW,
-                "evidence_refs": [f"claim:{claim_id}", f"freshness:{freshness_id}"],
+                "evidence_refs": [
+                    f"claim:{claim_id}",
+                    f"freshness:{freshness_id}",
+                    f"wsp15_allocation:{allocation['receipt_id']}",
+                ],
+                "wsp15_allocation_receipt": allocation,
                 "no_execution_performed": True,
             }
         ],
@@ -88,6 +110,10 @@ def test_accepts_one_fresh_queued_item_without_execution() -> None:
     assert result.next_required_gate == consumer.NEXT_GATE_SIGNED_AUTHORITY_REQUIRED
     assert result.execution_ready is False
     assert result.receipt is not None
+    assert result.receipt.wsp15_allocation_receipt_id == "sha256:wsp15-allocation"
+    assert result.receipt.wsp15_priority == "P0"
+    assert result.receipt.wsp15_mps_total == 18
+    assert result.receipt.reasoning_tier == "ULTRA"
     assert result.receipt.no_queue_mutation_performed is True
     assert result.receipt.no_worker_spawn_performed is True
     assert result.receipt.no_worktree_created is True
@@ -192,6 +218,16 @@ def test_rejects_missing_queue_evidence_refs() -> None:
 
     assert result.accepted is False
     assert consumer.FAIL_QUEUE_EVIDENCE_REFS in result.rejection_reasons
+
+
+def test_rejects_missing_wsp15_allocation_receipt() -> None:
+    snapshot = _snapshot()
+    snapshot["wre_queue_items"][0].pop("wsp15_allocation_receipt")
+
+    result = consumer.plan_reddog_wre_queue_consumer_dry_run(snapshot, now_iso=NOW)
+
+    assert result.accepted is False
+    assert consumer.FAIL_WSP15_ALLOCATION_RECEIPT in result.rejection_reasons
 
 
 def test_bootstrap_loads_work_state_outside_repo(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- bind deterministic WSP_15 allocation receipts into authoritative WRE queue items
- require queue evidence refs to include the WSP_15 allocation receipt id
- surface priority, MPS total, and reasoning tier in WRE queue consumer receipts

## WSP_97 Truth Boundary
- OBSERVED: authoritative work-state runtime already atomically writes durable claims and WRE queue items
- OBSERVED: queue items now carry wsp15_allocation_receipt and wsp15_allocation:<receipt_id> evidence refs
- OBSERVED: WRE queue consumer rejects missing or unreferenced WSP_15 allocation evidence
- SPECIFIED_NOT_IMPLEMENTED: no worker spawn, OpenClaw enqueue, Hermes dispatch, worktree creation, shell command, repo mutation, reward settlement, PatternMemory write, or HoloIndex runtime re-index
- INDEX_GAP: HOLOINDEX_REDDOG_AUTHORITATIVE_WORK_STATE_WSP15_QUEUE_BINDING_INDEX_GAP_PHASE1 recorded from read-only probe

## Validation
- pytest modules/communication/moltbot_bridge/tests/test_reddog_wsp15_allocation_receipt.py modules/communication/moltbot_bridge/tests/test_reddog_authoritative_work_state_refresh_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_request_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_verified_authority_work_order_invoke.py -q -> 107 passed
- python -m py_compile touched modules/tests -> pass
- git diff --check -> clean
- ASCII additions scan -> pass