### PR TITLE
feat(reddog): bind WSP15 allocation into authority request

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,27 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-15: REDDOG_AUTHORITY_REQUEST_WSP15_BINDING_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Bound the WRE queue consumer's WSP_15 allocation receipt into the delegated
+  authority request dry-run receipt before any signer invocation can occur.
+- The authority-request planner now rejects queue consumer receipts missing
+  `wsp15_allocation_receipt_id`, `wsp15_priority`, `wsp15_mps_total`, or
+  `reasoning_tier`, and rejects an authority profile that contradicts the
+  queue allocation receipt.
+- The signed authority runtime request schema is not expanded in this slice;
+  the WSP_15 allocation remains pre-signing evidence in the queue-authority
+  dry-run receipt.
+- No signing, signature verification, worker spawn, OpenClaw enqueue, Hermes
+  dispatch, worktree creation, shell command, repo mutation, reward settlement,
+  PatternMemory write, or HoloIndex runtime re-index is added.
+- HoloIndex read-only probe for `RedDog authority request WSP15 allocation
+  binding queue consumer receipt` returned adjacent RedDog/WSP assets but not
+  this authority-request binding seam; recorded as
+  `HOLOINDEX_REDDOG_AUTHORITY_REQUEST_WSP15_BINDING_INDEX_GAP_PHASE1`. No
+  runtime re-index is performed in this slice.
+
 ## 2026-07-15: REDDOG_AUTHORITATIVE_WORK_STATE_WSP15_QUEUE_BINDING_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_wre_queue_authority_request_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_queue_authority_request_dryrun.py
@@ -38,6 +38,7 @@ FAIL_ALLOWED_PATH_SCOPE = "FAIL_ALLOWED_PATH_SCOPE"
 FAIL_DENIED_PATH_SCOPE = "FAIL_DENIED_PATH_SCOPE"
 FAIL_HIGH_AUTHORITY_COSIGN = "FAIL_HIGH_AUTHORITY_COSIGN"
 FAIL_UNSUPPORTED_REPO_WIDE_AUTHORITY = "FAIL_UNSUPPORTED_REPO_WIDE_AUTHORITY"
+FAIL_WSP15_ALLOCATION_BINDING = "FAIL_WSP15_ALLOCATION_BINDING"
 
 _REQUIRED_PROFILE_FIELDS = (
     "principal_id",
@@ -71,6 +72,10 @@ class QueueAuthorityRequestDryRunReceipt:
     foundup_id: str
     allowed_paths: Tuple[str, ...]
     denied_paths: Tuple[str, ...]
+    wsp15_allocation_receipt_id: str
+    wsp15_priority: str
+    wsp15_mps_total: int
+    reasoning_tier: str
     delegated_authority_request_digest: str
     signer_invoked: bool = False
     signature_verified: bool = False
@@ -160,6 +165,31 @@ def _string_tuple(value: Any) -> Tuple[str, ...]:
     return ()
 
 
+def _valid_queue_wsp15_binding(queue_receipt: Mapping[str, Any], profile: Mapping[str, Any]) -> bool:
+    receipt_id = str(queue_receipt.get("wsp15_allocation_receipt_id") or "")
+    priority = str(queue_receipt.get("wsp15_priority") or "")
+    tier = str(queue_receipt.get("reasoning_tier") or "")
+    mps_total = queue_receipt.get("wsp15_mps_total")
+    if not receipt_id.startswith("sha256:") or not priority or not tier or not isinstance(mps_total, int):
+        return False
+    profile_receipt = _mapping(profile.get("wsp15_allocation_receipt"))
+    if not profile_receipt:
+        return True
+    profile_receipt_id = str(profile_receipt.get("receipt_id") or "")
+    if profile_receipt_id and profile_receipt_id != receipt_id:
+        return False
+    profile_priority = str(profile_receipt.get("priority") or "")
+    if profile_priority and profile_priority != priority:
+        return False
+    profile_tier = str(profile_receipt.get("reasoning_tier") or "")
+    if profile_tier and profile_tier != tier:
+        return False
+    profile_total = profile_receipt.get("mps_total")
+    if isinstance(profile_total, int) and profile_total != mps_total:
+        return False
+    return True
+
+
 def _path_within_foundup(path: str, foundup_id: str) -> bool:
     if not path or "\\" in path or ":" in path or path.startswith("/") or "\x00" in path:
         return False
@@ -211,6 +241,9 @@ def plan_reddog_wre_queue_authority_request_dry_run(
         reasons.append(FAIL_PROFILE_MISSING)
     elif not _is_ascii_deep(profile):
         reasons.append(FAIL_PROFILE_NON_ASCII)
+
+    if queue_receipt and profile and not _valid_queue_wsp15_binding(queue_receipt, profile):
+        reasons.append(FAIL_WSP15_ALLOCATION_BINDING)
 
     missing = [field for field in _REQUIRED_PROFILE_FIELDS if field not in profile or profile.get(field) in (None, "", ())]
     if missing:
@@ -281,6 +314,10 @@ def plan_reddog_wre_queue_authority_request_dry_run(
         foundup_id=request.foundup_id,
         allowed_paths=request.allowed_paths,
         denied_paths=request.denied_paths,
+        wsp15_allocation_receipt_id=str(queue_receipt.get("wsp15_allocation_receipt_id") or ""),
+        wsp15_priority=str(queue_receipt.get("wsp15_priority") or ""),
+        wsp15_mps_total=int(queue_receipt.get("wsp15_mps_total")),
+        reasoning_tier=str(queue_receipt.get("reasoning_tier") or ""),
         delegated_authority_request_digest=request_digest,
     )
     return QueueAuthorityRequestDryRunResult(
@@ -302,6 +339,7 @@ __all__ = [
     "FAIL_QUEUE_CONSUMER_NOT_READY",
     "FAIL_REQUIRED_FIELD",
     "FAIL_UNSUPPORTED_REPO_WIDE_AUTHORITY",
+    "FAIL_WSP15_ALLOCATION_BINDING",
     "QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT",
     "QUEUE_AUTHORITY_REQUEST_DRYRUN_REJECT",
     "QueueAuthorityRequestDryRunReceipt",

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_request_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_request_dryrun.py
@@ -36,6 +36,10 @@ def _queue_result(**overrides):
         "claim_id": "claim-1",
         "worker_id": "reddog-main-bootstrap",
         "freshness_receipt_id": "fresh-1",
+        "wsp15_allocation_receipt_id": "sha256:wsp15-allocation",
+        "wsp15_priority": "P0",
+        "wsp15_mps_total": 18,
+        "reasoning_tier": "ULTRA",
         "next_required_gate": NEXT_GATE_SIGNED_AUTHORITY_REQUIRED,
         "execution_ready": False,
         "no_queue_mutation_performed": True,
@@ -76,6 +80,13 @@ def _profile(**overrides):
         "key_epoch": "epoch-1",
         "consensus_receipt_digest": "sha256:consensus",
         "sovereign_authorization_digest": "sha256:012-token",
+        "wsp15_allocation_receipt": {
+            "receipt_id": "sha256:wsp15-allocation",
+            "priority": "P0",
+            "mps_total": 18,
+            "reasoning_tier": "ULTRA",
+            "worker_plan": {"fusion_required": True},
+        },
     }
     profile.update(overrides)
     return profile
@@ -110,6 +121,10 @@ def test_builds_delegated_authority_runtime_request_without_signing() -> None:
     assert request["allowed_paths"] == ("modules/foundups/paccess_001/**",)
     assert request["requested_operation"] == "create_foundup"
     assert request["valve_state_required"] == VALVE_OPEN_WORKTREE_CREATE
+    assert result.receipt.wsp15_allocation_receipt_id == "sha256:wsp15-allocation"
+    assert result.receipt.wsp15_priority == "P0"
+    assert result.receipt.wsp15_mps_total == 18
+    assert result.receipt.reasoning_tier == "ULTRA"
     assert result.receipt.delegated_authority_request_digest.startswith("sha256:")
 
 
@@ -132,6 +147,36 @@ def test_rejects_missing_profile() -> None:
 
     assert result.accepted is False
     assert planner.FAIL_PROFILE_MISSING in result.rejection_reasons
+
+
+def test_rejects_queue_consumer_without_wsp15_allocation_binding() -> None:
+    queue = _queue_result()
+    queue["receipt"].pop("wsp15_allocation_receipt_id")
+
+    result = planner.plan_reddog_wre_queue_authority_request_dry_run(
+        queue_consumer_result=queue,
+        authority_profile=_profile(),
+    )
+
+    assert result.accepted is False
+    assert planner.FAIL_WSP15_ALLOCATION_BINDING in result.rejection_reasons
+
+
+def test_rejects_profile_wsp15_binding_that_conflicts_with_queue() -> None:
+    result = planner.plan_reddog_wre_queue_authority_request_dry_run(
+        queue_consumer_result=_queue_result(),
+        authority_profile=_profile(
+            wsp15_allocation_receipt={
+                "receipt_id": "sha256:other",
+                "priority": "P0",
+                "mps_total": 18,
+                "reasoning_tier": "ULTRA",
+            }
+        ),
+    )
+
+    assert result.accepted is False
+    assert planner.FAIL_WSP15_ALLOCATION_BINDING in result.rejection_reasons
 
 
 def test_rejects_missing_required_profile_field() -> None:


### PR DESCRIPTION
## Summary
- require WRE queue consumer receipts to carry WSP_15 allocation binding before delegated-authority request dry-run accepts
- reject authority profiles that contradict the queue allocation receipt
- surface WSP_15 allocation id, priority, MPS total, and reasoning tier on the authority-request dry-run receipt

## WSP_97 Truth Boundary
- OBSERVED: queue consumer receipt now carries WSP_15 allocation evidence from the authoritative queue item
- OBSERVED: authority-request planner rejects missing queue allocation binding and profile/queue allocation conflicts before producing a signer request
- SPECIFIED_NOT_IMPLEMENTED: signer request schema is not expanded; no signing, signature verification, worker spawn, OpenClaw enqueue, Hermes dispatch, worktree creation, shell command, repo mutation, reward settlement, PatternMemory write, or HoloIndex runtime re-index
- INDEX_GAP: HOLOINDEX_REDDOG_AUTHORITY_REQUEST_WSP15_BINDING_INDEX_GAP_PHASE1 recorded from read-only probe

## Validation
- pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_request_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q -> 49 passed
- pytest cross-stage RedDog WSP15/queue/authority suite -> 109 passed
- python -m py_compile touched module/tests -> pass
- git diff --check -> clean
- ASCII additions scan -> pass