### PR TITLE
feat(reddog): use queue WSP15 allocation in materializer

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,27 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-15: REDDOG_WORK_ORDER_MATERIALIZER_QUEUE_WSP15_BINDING_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Updated the resident queue work-order materializer to source WSP_15
+  allocation from the selected authoritative queue item. Authority-profile and
+  snapshot copies are consistency checks only and fail closed on conflict.
+- This keeps queue-bound WSP_15 evidence authoritative through queue consumer,
+  authority-request dry-run, and materialized work-order context binding.
+- Missing operational context receipts still fail closed; this slice removes
+  the need to duplicate WSP_15 allocation in the external authority profile
+  when the queue item already carries it, without allowing profile or snapshot
+  allocation to override the selected queue item.
+- No signing, worker spawn, OpenClaw enqueue, Hermes dispatch, worktree
+  creation, shell command, repo mutation, reward settlement, PatternMemory
+  write, or HoloIndex runtime re-index is added.
+- HoloIndex read-only probe for `RedDog work order materializer queue WSP15
+  allocation binding` returned adjacent queue/WSP assets but not this binding
+  seam; recorded as
+  `HOLOINDEX_REDDOG_WORK_ORDER_MATERIALIZER_QUEUE_WSP15_BINDING_INDEX_GAP_PHASE1`.
+  No runtime re-index is performed in this slice.
+
 ## 2026-07-15: REDDOG_AUTHORITY_REQUEST_WSP15_BINDING_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -546,6 +546,8 @@ def _materialize_work_orders_from_authority_profile(
         return None, ("work_order_materializer_missing_work_order_id",)
 
     queue_receipt = queue_result.receipt.to_dict() if queue_result.receipt is not None else {}
+    queue_item = _queue_item(snapshot=snapshot, queue_item_id=str(queue_receipt.get("queue_item_id") or ""))
+    queue_wsp15_allocation = _nested_mapping(queue_item, "wsp15_allocation_receipt")
     slice_id = str(queue_receipt.get("slice_id") or "")
     created_at = str(now_iso or _snapshot_timestamp(snapshot) or "1970-01-01T00:00:00+00:00")
     expiry = str(_claim_expiry(snapshot, queue_receipt) or authority_profile.get("expiry") or "")
@@ -555,6 +557,8 @@ def _materialize_work_orders_from_authority_profile(
     context_binding, binding_reasons = _operational_context_binding(
         authority_profile=authority_profile,
         snapshot=snapshot,
+        queue_wsp15_allocation=queue_wsp15_allocation,
+        queue_wsp15_allocation_receipt_id=str(queue_receipt.get("wsp15_allocation_receipt_id") or ""),
     )
     if binding_reasons:
         return None, binding_reasons
@@ -655,6 +659,16 @@ def _claim_expiry(snapshot: Mapping[str, Any], queue_receipt: Mapping[str, Any])
     return ""
 
 
+def _queue_item(*, snapshot: Mapping[str, Any], queue_item_id: str) -> Mapping[str, Any]:
+    items = snapshot.get("wre_queue_items")
+    if not isinstance(items, list):
+        return {}
+    for item in items:
+        if isinstance(item, Mapping) and str(item.get("queue_item_id") or "") == queue_item_id:
+            return item
+    return {}
+
+
 def _slug(value: str) -> str:
     chars: list[str] = []
     for char in value.lower():
@@ -723,10 +737,49 @@ def _lookup_mapping(
     return {}
 
 
+def _lookup_mapping_sources(
+    *,
+    authority_profile: Mapping[str, Any],
+    snapshot: Mapping[str, Any],
+    names: tuple[str, ...],
+) -> list[tuple[str, Mapping[str, Any]]]:
+    sources = (
+        ("authority_profile", authority_profile),
+        ("authority_profile.operational_context_binding", _nested_mapping(authority_profile, "operational_context_binding")),
+        ("snapshot", snapshot),
+        ("snapshot.operational_context_binding", _nested_mapping(snapshot, "operational_context_binding")),
+    )
+    found: list[tuple[str, Mapping[str, Any]]] = []
+    for label, source in sources:
+        for name in names:
+            value = source.get(name)
+            if isinstance(value, Mapping):
+                found.append((f"{label}.{name}", value))
+    return found
+
+
+def _wsp15_priority_for_total(total: int) -> str:
+    if total >= 16:
+        return "P0"
+    if total >= 13:
+        return "P1"
+    if total >= 10:
+        return "P2"
+    if total >= 7:
+        return "P3"
+    return "P4"
+
+
+def _valid_mps_score(value: Any) -> bool:
+    return type(value) is int and 1 <= value <= 5
+
+
 def _operational_context_binding(
     *,
     authority_profile: Mapping[str, Any],
     snapshot: Mapping[str, Any],
+    queue_wsp15_allocation: Mapping[str, Any],
+    queue_wsp15_allocation_receipt_id: str,
 ) -> tuple[Mapping[str, Any], tuple[str, ...]]:
     snapshot_receipt_id = _lookup_text(
         authority_profile=authority_profile,
@@ -748,11 +801,13 @@ def _operational_context_binding(
         snapshot=snapshot,
         names=("readonly_audit_decision_id", "decision_id", "determination_id", "latest_decision_id"),
     )
-    allocation = _lookup_mapping(
+    allocation_names = ("wsp15_allocation_receipt", "wsp_15_allocation_receipt", "wsp_15_allocation")
+    duplicate_allocations = _lookup_mapping_sources(
         authority_profile=authority_profile,
         snapshot=snapshot,
-        names=("wsp15_allocation_receipt", "wsp_15_allocation_receipt", "wsp_15_allocation"),
+        names=allocation_names,
     )
+    allocation = queue_wsp15_allocation
     reasons: list[str] = []
     required = {
         "snapshot_receipt_id": snapshot_receipt_id,
@@ -765,10 +820,38 @@ def _operational_context_binding(
             reasons.append(f"work_order_materializer_missing_context_binding:{name}")
     if not allocation:
         reasons.append("work_order_materializer_missing_wsp15_allocation_receipt")
-    else:
-        for field in ("mps_total", "priority", "reasoning_tier", "worker_plan"):
+    if not queue_wsp15_allocation_receipt_id:
+        reasons.append("work_order_materializer_missing_queue_wsp15_allocation_receipt_id")
+    if allocation:
+        for label, duplicate in duplicate_allocations:
+            if dict(duplicate) != dict(allocation):
+                reasons.append(f"work_order_materializer_conflicting_wsp15_allocation_receipt:{label}")
+        receipt_id = str(allocation.get("receipt_id") or "")
+        if queue_wsp15_allocation_receipt_id and receipt_id != queue_wsp15_allocation_receipt_id:
+            reasons.append("work_order_materializer_wsp15_allocation_receipt_id_mismatch")
+        for field in (
+            "receipt_id",
+            "complexity",
+            "importance",
+            "deferability",
+            "impact",
+            "mps_total",
+            "priority",
+            "reasoning_tier",
+            "worker_plan",
+        ):
             if field not in allocation or allocation.get(field) in (None, "", (), {}):
                 reasons.append(f"work_order_materializer_malformed_wsp15_allocation_receipt:{field}")
+        score_fields = ("complexity", "importance", "deferability", "impact")
+        if all(field in allocation for field in score_fields + ("mps_total",)):
+            scores = [allocation.get(field) for field in score_fields]
+            total = allocation.get("mps_total")
+            if not all(_valid_mps_score(score) for score in scores):
+                reasons.append("work_order_materializer_malformed_wsp15_allocation_receipt:mps_scores")
+            elif type(total) is not int or total != sum(scores):
+                reasons.append("work_order_materializer_malformed_wsp15_allocation_receipt:mps_total")
+            elif str(allocation.get("priority") or "") != _wsp15_priority_for_total(total):
+                reasons.append("work_order_materializer_malformed_wsp15_allocation_receipt:priority")
     if reasons:
         return {}, tuple(reasons)
     return {

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_loop_bootstrap import (
     REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED,
     REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_NOT_READY,
+    _operational_context_binding,
     run_reddog_main_resident_queue_serial_loop_bootstrap,
 )
 from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_runtime_dependency_bundle import (
@@ -85,14 +86,24 @@ def _queue_wsp15_allocation_receipt() -> dict[str, object]:
     return {
         "schema_version": "reddog_wsp15_allocation_receipt.v1",
         "receipt_id": "sha256:wsp15-allocation-queue",
+        "complexity": 5,
+        "importance": 5,
+        "deferability": 5,
+        "impact": 5,
         "mps_total": 20,
         "priority": "P0",
         "reasoning_tier": "ULTRA",
         "worker_plan": {
+            "schema_version": "reddog_wsp15_worker_plan.v1",
             "fusion_required": True,
+            "reasoning_tier": "ULTRA",
+            "critic_count": 2,
+            "coding_worker_count": 2,
             "independent_verifier_required": True,
+            "openclaw_candidate": True,
             "queue_mutation_allowed": False,
             "hermes_execution_allowed": False,
+            "mode_selection_source": "reddog_wsp15_allocation_receipt.v1",
         },
     }
 
@@ -158,20 +169,7 @@ def _profile(**overrides: object) -> dict[str, object]:
         "context_view_id": "sha256:context-view-1",
         "evidence_bundle_id": "sha256:evidence-bundle-1",
         "readonly_audit_decision_id": "sha256:decision-1",
-        "wsp15_allocation_receipt": {
-            "complexity": 5,
-            "importance": 5,
-            "deferability": 5,
-            "impact": 5,
-            "mps_total": 20,
-            "priority": "P0",
-            "reasoning_tier": "ULTRA",
-            "worker_plan": {
-                "fusion_required": True,
-                "coding_workers": 1,
-                "independent_verifier": True,
-            },
-        },
+        "wsp15_allocation_receipt": _queue_wsp15_allocation_receipt(),
         "holoindex_evidence": {
             "holoindex_query": "RedDog resident queue materialized work order",
             "holoindex_status": "bundle_json_ok",
@@ -2567,7 +2565,144 @@ def test_bootstrap_rejects_work_order_materializer_without_context_binding(
 
     assert result.accepted is False
     assert "work_order_materializer_missing_context_binding:snapshot_receipt_id" in result.rejection_reasons
-    assert "work_order_materializer_missing_wsp15_allocation_receipt" in result.rejection_reasons
+
+
+def test_bootstrap_materializer_uses_queue_wsp15_allocation_when_profile_omits_it(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile_payload = _profile()
+    profile_payload.pop("wsp15_allocation_receipt")
+    principal_public, reddog_public, connector = _ed25519_signing_material()
+    profile_payload["principal_public_key"] = principal_public
+    profile_payload["reddog_public_key"] = reddog_public
+    profile = _write_runtime_json(tmp_path, "profile.json", profile_payload)
+    snapshots = _write_runtime_json(tmp_path, "snapshots.json", _snapshots())
+    principals = _write_runtime_json(tmp_path, "principals.json", _principals(principal_public))
+    valve_env = _write_runtime_json(tmp_path, "valve_env.json", _valve_environment())
+    chain = tmp_path / "runtime" / "chain_results.json"
+    authority_state = tmp_path / "runtime" / "authority_state.json"
+    socket_path = tmp_path / "runtime" / "signer.sock"
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        work_order_materializer_mode="authority_profile",
+        valve_environment_path=valve_env,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshots,
+        principal_authority_records_path=principals,
+        signer_socket_path=socket_path,
+        signer_socket_connector=connector,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        now_iso=NOW,
+        now_epoch=1000,
+        requested_queue_item_id="queue-1",
+        max_steps=6,
+    )
+
+    assert result.accepted is True
+
+
+def test_materializer_context_binding_uses_queue_wsp15_allocation_as_authority() -> None:
+    profile = _profile()
+    profile.pop("wsp15_allocation_receipt")
+    allocation = _queue_wsp15_allocation_receipt()
+
+    binding, reasons = _operational_context_binding(
+        authority_profile=profile,
+        snapshot={},
+        queue_wsp15_allocation=allocation,
+        queue_wsp15_allocation_receipt_id=str(allocation["receipt_id"]),
+    )
+
+    assert reasons == ()
+    assert binding["wsp15_allocation_receipt"] == allocation
+
+
+def test_materializer_context_binding_rejects_conflicting_profile_wsp15_allocation() -> None:
+    allocation = _queue_wsp15_allocation_receipt()
+    conflicting = dict(allocation)
+    conflicting["priority"] = "P4"
+
+    _, reasons = _operational_context_binding(
+        authority_profile=_profile(wsp15_allocation_receipt=conflicting),
+        snapshot={},
+        queue_wsp15_allocation=allocation,
+        queue_wsp15_allocation_receipt_id=str(allocation["receipt_id"]),
+    )
+
+    assert (
+        "work_order_materializer_conflicting_wsp15_allocation_receipt:"
+        "authority_profile.wsp15_allocation_receipt"
+    ) in reasons
+
+
+def test_materializer_context_binding_rejects_conflicting_snapshot_wsp15_allocation() -> None:
+    allocation = _queue_wsp15_allocation_receipt()
+    conflicting = dict(allocation)
+    conflicting["mps_total"] = 19
+
+    _, reasons = _operational_context_binding(
+        authority_profile=_profile(),
+        snapshot={"wsp15_allocation_receipt": conflicting},
+        queue_wsp15_allocation=allocation,
+        queue_wsp15_allocation_receipt_id=str(allocation["receipt_id"]),
+    )
+
+    assert (
+        "work_order_materializer_conflicting_wsp15_allocation_receipt:"
+        "snapshot.wsp15_allocation_receipt"
+    ) in reasons
+
+
+def test_materializer_context_binding_rejects_queue_receipt_id_mismatch() -> None:
+    allocation = _queue_wsp15_allocation_receipt()
+
+    _, reasons = _operational_context_binding(
+        authority_profile=_profile(),
+        snapshot={},
+        queue_wsp15_allocation=allocation,
+        queue_wsp15_allocation_receipt_id="sha256:other-allocation",
+    )
+
+    assert "work_order_materializer_wsp15_allocation_receipt_id_mismatch" in reasons
+
+
+def test_materializer_context_binding_rejects_missing_queue_allocation_receipt_id() -> None:
+    profile = _profile()
+    profile.pop("wsp15_allocation_receipt")
+    allocation = _queue_wsp15_allocation_receipt()
+    allocation.pop("receipt_id")
+
+    _, reasons = _operational_context_binding(
+        authority_profile=profile,
+        snapshot={},
+        queue_wsp15_allocation=allocation,
+        queue_wsp15_allocation_receipt_id="",
+    )
+
+    assert "work_order_materializer_missing_queue_wsp15_allocation_receipt_id" in reasons
+    assert "work_order_materializer_malformed_wsp15_allocation_receipt:receipt_id" in reasons
+
+
+def test_materializer_context_binding_rejects_malformed_mps_priority_relationship() -> None:
+    profile = _profile()
+    profile.pop("wsp15_allocation_receipt")
+    allocation = _queue_wsp15_allocation_receipt()
+    allocation["priority"] = "P4"
+
+    _, reasons = _operational_context_binding(
+        authority_profile=profile,
+        snapshot={},
+        queue_wsp15_allocation=allocation,
+        queue_wsp15_allocation_receipt_id=str(allocation["receipt_id"]),
+    )
+
+    assert "work_order_materializer_malformed_wsp15_allocation_receipt:priority" in reasons
 
 
 def test_bootstrap_rejects_valve_environment_inside_repo(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- make the resident queue work-order materializer source WSP_15 allocation from the selected authoritative queue item
- treat authority-profile and snapshot WSP_15 allocation copies as consistency checks only; conflicting copies now fail closed
- require the queue consumer `wsp15_allocation_receipt_id` to match the selected queue item allocation `receipt_id`
- validate the full allocation shape: receipt_id, four MPS scores, mps_total, priority, reasoning_tier, and worker_plan
- prove profile WSP_15 duplication is no longer required when the queue item carries the allocation receipt

## WSP_97 Truth Boundary
- OBSERVED: authoritative queue items now carry WSP_15 allocation receipts
- OBSERVED: materializer now binds the selected queue item's allocation into operational_context_binding
- OBSERVED: profile/snapshot allocations cannot override the selected queue item; mismatch rejects
- SPECIFIED_NOT_IMPLEMENTED: no signing, worker spawn, OpenClaw enqueue, Hermes dispatch, worktree creation, shell command, repo mutation, reward settlement, PatternMemory write, or HoloIndex runtime re-index
- INDEX_GAP: HOLOINDEX_REDDOG_WORK_ORDER_MATERIALIZER_QUEUE_WSP15_BINDING_INDEX_GAP_PHASE1 recorded from read-only probe

## Validation
- pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q -> 43 passed
- pytest WSP15/authoritative queue/authority/materializer cross-stage suite -> 116 passed
- python -m py_compile touched module -> pass
- git diff --check -> clean
- ASCII additions scan -> pass