### PR TITLE
feat(reddog): signed authority worker dispatch dry-run

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,31 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-15: REDDOG_SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added a signed-authority worker-dispatch dry-run planner that consumes an
+  accepted queue authority verification result, the signed authority runtime
+  payload, and the authoritative WSP_15 allocation receipt.
+- The planner verifies that the signed work-authority allocation receipt id,
+  digest, priority, MPS total, and reasoning tier match the supplied WSP_15
+  allocation before emitting deterministic worker-dispatch intents.
+- WSP_15 worker-plan fields now produce dry-run intents for fusion lead,
+  critics, coding workers, independent verifier, and OpenClaw candidate review
+  without registering workers, mutating queues, spawning processes, or invoking
+  Hermes/OpenClaw.
+- The slice rejects post-signing allocation tamper, queue-mutation permission,
+  Hermes execution permission, malformed MPS/priority relationships, missing
+  explicit invoke, and unaccepted authority inputs.
+- No worker spawn, queue mutation, worktree creation, shell command, OpenClaw
+  enqueue, Hermes dispatch, repo mutation, PR creation, reward settlement,
+  PatternMemory write, or HoloIndex runtime re-index is added.
+- HoloIndex read-only probe for `RedDog signed authority worker dispatch
+  dryrun WSP15` returned adjacent RedDog governance assets but not this new
+  seam; recorded as
+  `HOLOINDEX_REDDOG_SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_INDEX_GAP_PHASE1`.
+  No runtime re-index is performed in this slice.
+
 ## 2026-07-15: REDDOG_SIGNED_AUTHORITY_WSP15_ALLOCATION_BINDING_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_signed_authority_worker_dispatch_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_authority_worker_dispatch_dryrun.py
@@ -1,0 +1,353 @@
+"""RedDog signed-authority worker dispatch dry-run planner.
+
+Slice: REDDOG_SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_PHASE1
+
+This module consumes an accepted queue authority verification result, the
+signed authority runtime payload, and the authoritative WSP15 allocation
+receipt. It emits deterministic worker-dispatch intents only. It does not
+register workers, spawn workers, enqueue OpenClaw, dispatch Hermes, run shell
+commands, mutate the repository, publish PRs, settle rewards, or re-index
+HoloIndex.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Mapping, Sequence, Tuple
+
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    AUTHORITY_ISSUED,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authority_runtime_invoke import (
+    QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authority_verification_invoke import (
+    QUEUE_AUTHORITY_VERIFICATION_INVOKE_ACCEPT,
+)
+
+
+SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_ACCEPT = (
+    "SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_ACCEPT"
+)
+SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_REJECT = (
+    "SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_REJECT"
+)
+
+
+class SignedAuthorityWorkerDispatchDryRunReason:
+    EXPLICIT_REQUEST_MISSING = "REJECT_EXPLICIT_SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_MISSING"
+    AUTHORITY_VERIFICATION_NOT_ACCEPTED = "REJECT_AUTHORITY_VERIFICATION_NOT_ACCEPTED"
+    AUTHORITY_RUNTIME_NOT_ACCEPTED = "REJECT_AUTHORITY_RUNTIME_NOT_ACCEPTED"
+    AUTHORITY_PAYLOAD_MISSING = "REJECT_AUTHORITY_PAYLOAD_MISSING"
+    WSP15_ALLOCATION_MISSING = "REJECT_WSP15_ALLOCATION_MISSING"
+    WSP15_ALLOCATION_MALFORMED = "REJECT_WSP15_ALLOCATION_MALFORMED"
+    WSP15_RECEIPT_ID_MISMATCH = "REJECT_WSP15_RECEIPT_ID_MISMATCH"
+    WSP15_DIGEST_MISMATCH = "REJECT_WSP15_DIGEST_MISMATCH"
+    WSP15_PRIORITY_MISMATCH = "REJECT_WSP15_PRIORITY_MISMATCH"
+    WSP15_MPS_TOTAL_MISMATCH = "REJECT_WSP15_MPS_TOTAL_MISMATCH"
+    WSP15_REASONING_TIER_MISMATCH = "REJECT_WSP15_REASONING_TIER_MISMATCH"
+    QUEUE_MUTATION_NOT_ALLOWED = "REJECT_QUEUE_MUTATION_NOT_ALLOWED"
+    HERMES_EXECUTION_NOT_ALLOWED = "REJECT_HERMES_EXECUTION_NOT_ALLOWED"
+    WORKER_PLAN_EMPTY = "REJECT_WORKER_PLAN_EMPTY"
+
+
+@dataclass(frozen=True)
+class WorkerDispatchIntent:
+    """One planned worker assignment intent. This is not a worker invocation."""
+
+    intent_id: str
+    role: str
+    worker_runtime: str
+    capability: str
+    work_order_id: str
+    foundup_id: str
+    requested_operation: str
+    wsp15_allocation_receipt_id: str
+    wsp15_allocation_digest: str
+    dry_run_only: bool = True
+    no_worker_spawn_performed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class SignedAuthorityWorkerDispatchDryRunReceipt:
+    receipt_id: str
+    work_order_id: str
+    foundup_id: str
+    requested_operation: str
+    wsp15_allocation_receipt_id: str
+    wsp15_allocation_digest: str
+    wsp15_priority: str
+    wsp15_mps_total: int
+    wsp15_reasoning_tier: str
+    dispatch_intent_count: int
+    dispatch_intents: Tuple[WorkerDispatchIntent, ...]
+    no_worker_spawn_performed: bool = True
+    no_queue_mutation_performed: bool = True
+    no_worktree_created: bool = True
+    no_shell_command_executed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pr_created: bool = True
+    no_reward_settlement_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["dispatch_intents"] = [intent.to_dict() for intent in self.dispatch_intents]
+        return payload
+
+
+@dataclass(frozen=True)
+class SignedAuthorityWorkerDispatchDryRunResult:
+    accepted: bool
+    decision: str
+    rejection_reasons: List[str] = field(default_factory=list)
+    receipt: SignedAuthorityWorkerDispatchDryRunReceipt | None = None
+    explicit_signed_authority_worker_dispatch_dryrun_requested: bool = False
+    no_worker_spawn_performed: bool = True
+    no_queue_mutation_performed: bool = True
+    no_worktree_created: bool = True
+    no_shell_command_executed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pr_created: bool = True
+    no_reward_settlement_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["receipt"] = self.receipt.to_dict() if self.receipt else None
+        return payload
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        return value.to_dict()
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _digest(value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _reject(
+    reasons: Sequence[str],
+    *,
+    explicit_requested: bool,
+) -> SignedAuthorityWorkerDispatchDryRunResult:
+    return SignedAuthorityWorkerDispatchDryRunResult(
+        accepted=False,
+        decision=SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_REJECT,
+        rejection_reasons=list(dict.fromkeys(reasons)),
+        receipt=None,
+        explicit_signed_authority_worker_dispatch_dryrun_requested=explicit_requested,
+    )
+
+
+def _valid_priority_for_mps(priority: str, mps_total: int) -> bool:
+    if mps_total >= 18:
+        return priority == "P0"
+    if mps_total >= 14:
+        return priority == "P1"
+    if mps_total >= 10:
+        return priority == "P2"
+    if mps_total >= 7:
+        return priority == "P3"
+    return priority == "P4"
+
+
+def _validate_allocation(allocation: Mapping[str, Any]) -> List[str]:
+    reasons: List[str] = []
+    if not allocation:
+        return [SignedAuthorityWorkerDispatchDryRunReason.WSP15_ALLOCATION_MISSING]
+    receipt_id = str(allocation.get("receipt_id") or "")
+    priority = str(allocation.get("priority") or "")
+    tier = str(allocation.get("reasoning_tier") or "")
+    total = allocation.get("mps_total")
+    worker_plan = _mapping(allocation.get("worker_plan"))
+    if (
+        not receipt_id.startswith("sha256:")
+        or priority not in {"P0", "P1", "P2", "P3", "P4"}
+        or tier not in {"REGULAR", "HIGH", "ULTRA"}
+        or type(total) is not int
+        or not _valid_priority_for_mps(priority, total)
+        or not worker_plan
+    ):
+        reasons.append(SignedAuthorityWorkerDispatchDryRunReason.WSP15_ALLOCATION_MALFORMED)
+    if worker_plan and worker_plan.get("queue_mutation_allowed") is not False:
+        reasons.append(SignedAuthorityWorkerDispatchDryRunReason.QUEUE_MUTATION_NOT_ALLOWED)
+    if worker_plan and worker_plan.get("hermes_execution_allowed") is not False:
+        reasons.append(SignedAuthorityWorkerDispatchDryRunReason.HERMES_EXECUTION_NOT_ALLOWED)
+    return reasons
+
+
+def _build_intents(
+    *,
+    work_authority: Mapping[str, Any],
+    allocation: Mapping[str, Any],
+) -> Tuple[WorkerDispatchIntent, ...]:
+    worker_plan = _mapping(allocation.get("worker_plan"))
+    intents: List[WorkerDispatchIntent] = []
+    base = {
+        "work_order_id": str(work_authority["work_order_id"]),
+        "foundup_id": str(work_authority["foundup_id"]),
+        "requested_operation": str(work_authority["requested_operation"]),
+        "wsp15_allocation_receipt_id": str(allocation["receipt_id"]),
+        "wsp15_allocation_digest": _digest(allocation),
+    }
+
+    roles: List[tuple[str, str, str]] = []
+    if worker_plan.get("fusion_required") is True:
+        roles.append(("fusion_lead", "0102", "architect_review"))
+    critic_count = int(worker_plan.get("critic_count") or 0)
+    for index in range(max(0, critic_count)):
+        roles.append((f"critic_{index + 1}", "0102", "adversarial_review"))
+    coding_count = int(worker_plan.get("coding_worker_count") or 0)
+    for index in range(max(0, coding_count)):
+        roles.append((f"coding_worker_{index + 1}", "0102", "bounded_code_change"))
+    if worker_plan.get("independent_verifier_required") is True:
+        roles.append(("independent_verifier", "0102", "diff_verification"))
+    if worker_plan.get("openclaw_candidate") is True:
+        roles.append(("openclaw_candidate", "openclaw", "candidate_queue_review"))
+
+    for role, runtime, capability in roles:
+        seed = {
+            **base,
+            "role": role,
+            "worker_runtime": runtime,
+            "capability": capability,
+        }
+        intents.append(
+            WorkerDispatchIntent(
+                intent_id="worker_dispatch_intent_" + _digest(seed).removeprefix("sha256:")[:16],
+                role=role,
+                worker_runtime=runtime,
+                capability=capability,
+                **base,
+            )
+        )
+    return tuple(intents)
+
+
+def plan_reddog_signed_authority_worker_dispatch_dry_run(
+    *,
+    explicit_signed_authority_worker_dispatch_dryrun_requested: bool,
+    queue_authority_verification_result: Mapping[str, Any],
+    queue_authority_runtime_result: Mapping[str, Any],
+    wsp15_allocation_receipt: Mapping[str, Any],
+) -> SignedAuthorityWorkerDispatchDryRunResult:
+    """Plan worker dispatch from accepted signed authority without dispatching workers."""
+
+    if explicit_signed_authority_worker_dispatch_dryrun_requested is not True:
+        return _reject(
+            [SignedAuthorityWorkerDispatchDryRunReason.EXPLICIT_REQUEST_MISSING],
+            explicit_requested=False,
+        )
+
+    verification = _mapping(queue_authority_verification_result)
+    verification_result = _mapping(verification.get("verification_result"))
+    if (
+        verification.get("decision") != QUEUE_AUTHORITY_VERIFICATION_INVOKE_ACCEPT
+        or verification_result.get("accepted") is not True
+    ):
+        return _reject(
+            [SignedAuthorityWorkerDispatchDryRunReason.AUTHORITY_VERIFICATION_NOT_ACCEPTED],
+            explicit_requested=True,
+        )
+
+    runtime = _mapping(queue_authority_runtime_result)
+    authority = _mapping(runtime.get("authority_result"))
+    receipt = _mapping(authority.get("receipt"))
+    if (
+        runtime.get("decision") != QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT
+        or authority.get("accepted") is not True
+        or receipt.get("status") != AUTHORITY_ISSUED
+    ):
+        return _reject(
+            [SignedAuthorityWorkerDispatchDryRunReason.AUTHORITY_RUNTIME_NOT_ACCEPTED],
+            explicit_requested=True,
+        )
+
+    work_authority = _mapping(authority.get("work_authority"))
+    if not work_authority:
+        return _reject(
+            [SignedAuthorityWorkerDispatchDryRunReason.AUTHORITY_PAYLOAD_MISSING],
+            explicit_requested=True,
+        )
+
+    allocation = _mapping(wsp15_allocation_receipt)
+    reasons = _validate_allocation(allocation)
+    if reasons:
+        return _reject(reasons, explicit_requested=True)
+
+    allocation_receipt_id = str(allocation["receipt_id"])
+    allocation_digest = _digest(allocation)
+    if str(work_authority.get("wsp15_allocation_receipt_id") or "") != allocation_receipt_id:
+        reasons.append(SignedAuthorityWorkerDispatchDryRunReason.WSP15_RECEIPT_ID_MISMATCH)
+    if str(work_authority.get("wsp15_allocation_digest") or "") != allocation_digest:
+        reasons.append(SignedAuthorityWorkerDispatchDryRunReason.WSP15_DIGEST_MISMATCH)
+    if str(work_authority.get("wsp15_priority") or "") != str(allocation["priority"]):
+        reasons.append(SignedAuthorityWorkerDispatchDryRunReason.WSP15_PRIORITY_MISMATCH)
+    if work_authority.get("wsp15_mps_total") != allocation["mps_total"]:
+        reasons.append(SignedAuthorityWorkerDispatchDryRunReason.WSP15_MPS_TOTAL_MISMATCH)
+    if str(work_authority.get("wsp15_reasoning_tier") or "") != str(allocation["reasoning_tier"]):
+        reasons.append(SignedAuthorityWorkerDispatchDryRunReason.WSP15_REASONING_TIER_MISMATCH)
+    if reasons:
+        return _reject(reasons, explicit_requested=True)
+
+    intents = _build_intents(work_authority=work_authority, allocation=allocation)
+    if not intents:
+        return _reject(
+            [SignedAuthorityWorkerDispatchDryRunReason.WORKER_PLAN_EMPTY],
+            explicit_requested=True,
+        )
+
+    receipt_seed = {
+        "work_order_id": work_authority["work_order_id"],
+        "wsp15_allocation_receipt_id": allocation_receipt_id,
+        "wsp15_allocation_digest": allocation_digest,
+        "dispatch_intent_ids": [intent.intent_id for intent in intents],
+    }
+    receipt = SignedAuthorityWorkerDispatchDryRunReceipt(
+        receipt_id="signed_authority_worker_dispatch_" + _digest(receipt_seed).removeprefix("sha256:")[:16],
+        work_order_id=str(work_authority["work_order_id"]),
+        foundup_id=str(work_authority["foundup_id"]),
+        requested_operation=str(work_authority["requested_operation"]),
+        wsp15_allocation_receipt_id=allocation_receipt_id,
+        wsp15_allocation_digest=allocation_digest,
+        wsp15_priority=str(allocation["priority"]),
+        wsp15_mps_total=int(allocation["mps_total"]),
+        wsp15_reasoning_tier=str(allocation["reasoning_tier"]),
+        dispatch_intent_count=len(intents),
+        dispatch_intents=intents,
+    )
+    return SignedAuthorityWorkerDispatchDryRunResult(
+        accepted=True,
+        decision=SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_ACCEPT,
+        rejection_reasons=[],
+        receipt=receipt,
+        explicit_signed_authority_worker_dispatch_dryrun_requested=True,
+    )
+
+
+__all__ = [
+    "SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_ACCEPT",
+    "SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_REJECT",
+    "SignedAuthorityWorkerDispatchDryRunReason",
+    "SignedAuthorityWorkerDispatchDryRunReceipt",
+    "SignedAuthorityWorkerDispatchDryRunResult",
+    "WorkerDispatchIntent",
+    "plan_reddog_signed_authority_worker_dispatch_dry_run",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_authority_worker_dispatch_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_authority_worker_dispatch_dryrun.py
@@ -1,0 +1,312 @@
+"""Tests for REDDOG_SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src import (
+    reddog_signed_authority_worker_dispatch_dryrun as dispatch,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    AUTHORITY_ISSUED,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authority_runtime_invoke import (
+    QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authority_verification_invoke import (
+    QUEUE_AUTHORITY_VERIFICATION_INVOKE_ACCEPT,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_signed_authority_worker_dispatch_dryrun.py"
+)
+
+
+def _digest(value: dict) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _allocation(**overrides):
+    payload = {
+        "schema_version": "reddog_wsp15_allocation_receipt.v1",
+        "receipt_id": "sha256:wsp15-allocation",
+        "mps_total": 20,
+        "priority": "P0",
+        "reasoning_tier": "ULTRA",
+        "worker_plan": {
+            "schema_version": "reddog_wsp15_worker_plan.v1",
+            "fusion_required": True,
+            "reasoning_tier": "ULTRA",
+            "critic_count": 2,
+            "coding_worker_count": 2,
+            "independent_verifier_required": True,
+            "openclaw_candidate": True,
+            "hermes_execution_allowed": False,
+            "queue_mutation_allowed": False,
+            "mode_selection_source": "reddog_wsp15_allocation_receipt.v1",
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _work_authority(allocation=None, **overrides):
+    allocation = allocation or _allocation()
+    payload = {
+        "work_order_id": "wo-1",
+        "principal_id": "github:mjtrout",
+        "reddog_id": "reddog:abc123",
+        "repo_full_name": "FOUNDUPS/Foundups-Agent",
+        "foundup_id": "paccess_001",
+        "allowed_paths": ["modules/foundups/paccess_001/src/app.py"],
+        "denied_paths": [],
+        "requested_operation": "create_foundup",
+        "permission_snapshot_digest": "sha256:permission-snapshot",
+        "wsp15_allocation_receipt_id": allocation["receipt_id"],
+        "wsp15_allocation_digest": _digest(allocation),
+        "wsp15_priority": allocation["priority"],
+        "wsp15_mps_total": allocation["mps_total"],
+        "wsp15_reasoning_tier": allocation["reasoning_tier"],
+        "nonce": "nonce-1",
+        "issued_at": 1000,
+        "expires_at": 1100,
+        "valve_state_required": "VALVE_OPEN_WORKTREE_CREATE",
+        "key_epoch": "epoch-1",
+        "signature": "sig-work",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _verification_result(**overrides):
+    payload = {
+        "decision": QUEUE_AUTHORITY_VERIFICATION_INVOKE_ACCEPT,
+        "verification_result": {
+            "accepted": True,
+            "reason_codes": [],
+            "work_order_id": "wo-1",
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _runtime_result(allocation=None, **overrides):
+    allocation = allocation or _allocation()
+    payload = {
+        "decision": QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT,
+        "authority_result": {
+            "accepted": True,
+            "receipt": {"status": AUTHORITY_ISSUED, "receipt_id": "auth-1"},
+            "work_authority": _work_authority(allocation),
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _plan(allocation=None, **overrides):
+    allocation = allocation or _allocation()
+    args = {
+        "explicit_signed_authority_worker_dispatch_dryrun_requested": True,
+        "queue_authority_verification_result": _verification_result(),
+        "queue_authority_runtime_result": _runtime_result(allocation),
+        "wsp15_allocation_receipt": allocation,
+    }
+    args.update(overrides)
+    return dispatch.plan_reddog_signed_authority_worker_dispatch_dry_run(**args)
+
+
+def test_accepts_verified_signed_authority_and_emits_wsp15_worker_intents() -> None:
+    result = _plan()
+
+    assert result.accepted is True
+    assert result.decision == dispatch.SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_ACCEPT
+    assert result.receipt is not None
+    assert result.receipt.dispatch_intent_count == 7
+    roles = [intent.role for intent in result.receipt.dispatch_intents]
+    assert roles == [
+        "fusion_lead",
+        "critic_1",
+        "critic_2",
+        "coding_worker_1",
+        "coding_worker_2",
+        "independent_verifier",
+        "openclaw_candidate",
+    ]
+    assert {intent.worker_runtime for intent in result.receipt.dispatch_intents} == {"0102", "openclaw"}
+    assert result.receipt.wsp15_allocation_digest == _digest(_allocation())
+    assert result.receipt.no_worker_spawn_performed is True
+    assert result.receipt.no_openclaw_enqueue_performed is True
+    assert result.receipt.no_hermes_dispatch_performed is True
+
+
+def test_explicit_request_is_required() -> None:
+    result = _plan(explicit_signed_authority_worker_dispatch_dryrun_requested=False)
+
+    assert result.accepted is False
+    assert dispatch.SignedAuthorityWorkerDispatchDryRunReason.EXPLICIT_REQUEST_MISSING in result.rejection_reasons
+
+
+def test_rejects_unaccepted_authority_verification() -> None:
+    result = _plan(
+        queue_authority_verification_result={
+            "decision": "QUEUE_AUTHORITY_VERIFICATION_INVOKE_REJECT",
+            "verification_result": {"accepted": False},
+        }
+    )
+
+    assert result.accepted is False
+    assert (
+        dispatch.SignedAuthorityWorkerDispatchDryRunReason.AUTHORITY_VERIFICATION_NOT_ACCEPTED
+        in result.rejection_reasons
+    )
+
+
+def test_rejects_unaccepted_authority_runtime() -> None:
+    result = _plan(queue_authority_runtime_result={"decision": "QUEUE_AUTHORITY_RUNTIME_INVOKE_REJECT"})
+
+    assert result.accepted is False
+    assert dispatch.SignedAuthorityWorkerDispatchDryRunReason.AUTHORITY_RUNTIME_NOT_ACCEPTED in result.rejection_reasons
+
+
+def test_rejects_missing_allocation() -> None:
+    result = _plan(wsp15_allocation_receipt={})
+
+    assert result.accepted is False
+    assert dispatch.SignedAuthorityWorkerDispatchDryRunReason.WSP15_ALLOCATION_MISSING in result.rejection_reasons
+
+
+def test_rejects_allocation_digest_tamper_after_signing() -> None:
+    allocation = _allocation()
+    runtime = _runtime_result(allocation)
+    tampered = _allocation()
+    tampered["mps_total"] = 19
+
+    result = _plan(
+        allocation=tampered,
+        queue_authority_runtime_result=runtime,
+        wsp15_allocation_receipt=tampered,
+    )
+
+    assert result.accepted is False
+    assert dispatch.SignedAuthorityWorkerDispatchDryRunReason.WSP15_DIGEST_MISMATCH in result.rejection_reasons
+    assert dispatch.SignedAuthorityWorkerDispatchDryRunReason.WSP15_MPS_TOTAL_MISMATCH in result.rejection_reasons
+
+
+def test_rejects_receipt_id_mismatch() -> None:
+    allocation = _allocation()
+    runtime = _runtime_result(allocation)
+    runtime["authority_result"]["work_authority"]["wsp15_allocation_receipt_id"] = "sha256:other"
+
+    result = _plan(queue_authority_runtime_result=runtime)
+
+    assert result.accepted is False
+    assert dispatch.SignedAuthorityWorkerDispatchDryRunReason.WSP15_RECEIPT_ID_MISMATCH in result.rejection_reasons
+
+
+def test_rejects_if_worker_plan_allows_hermes_execution() -> None:
+    allocation = _allocation()
+    allocation["worker_plan"] = dict(allocation["worker_plan"], hermes_execution_allowed=True)
+
+    result = _plan(allocation=allocation, queue_authority_runtime_result=_runtime_result(allocation))
+
+    assert result.accepted is False
+    assert dispatch.SignedAuthorityWorkerDispatchDryRunReason.HERMES_EXECUTION_NOT_ALLOWED in result.rejection_reasons
+
+
+def test_rejects_if_worker_plan_allows_queue_mutation() -> None:
+    allocation = _allocation()
+    allocation["worker_plan"] = dict(allocation["worker_plan"], queue_mutation_allowed=True)
+
+    result = _plan(allocation=allocation, queue_authority_runtime_result=_runtime_result(allocation))
+
+    assert result.accepted is False
+    assert dispatch.SignedAuthorityWorkerDispatchDryRunReason.QUEUE_MUTATION_NOT_ALLOWED in result.rejection_reasons
+
+
+def test_rejects_malformed_mps_priority_relationship() -> None:
+    allocation = _allocation(priority="P4")
+
+    result = _plan(allocation=allocation, queue_authority_runtime_result=_runtime_result(allocation))
+
+    assert result.accepted is False
+    assert dispatch.SignedAuthorityWorkerDispatchDryRunReason.WSP15_ALLOCATION_MALFORMED in result.rejection_reasons
+
+
+def test_rejects_empty_worker_plan() -> None:
+    allocation = _allocation()
+    allocation["worker_plan"] = {
+        "schema_version": "reddog_wsp15_worker_plan.v1",
+        "hermes_execution_allowed": False,
+        "queue_mutation_allowed": False,
+    }
+
+    result = _plan(allocation=allocation, queue_authority_runtime_result=_runtime_result(allocation))
+
+    assert result.accepted is False
+    assert dispatch.SignedAuthorityWorkerDispatchDryRunReason.WORKER_PLAN_EMPTY in result.rejection_reasons
+
+
+def test_result_is_json_serializable_and_truth_flags_are_false_for_side_effects() -> None:
+    payload = _plan().to_dict()
+
+    json.dumps(payload, sort_keys=True)
+    assert payload["no_worker_spawn_performed"] is True
+    assert payload["no_queue_mutation_performed"] is True
+    assert payload["no_worktree_created"] is True
+    assert payload["no_shell_command_executed"] is True
+    assert payload["no_openclaw_enqueue_performed"] is True
+    assert payload["no_hermes_dispatch_performed"] is True
+    assert payload["no_repo_mutation_performed"] is True
+    assert payload["no_holoindex_reindex_performed"] is True
+    assert payload["no_pr_created"] is True
+    assert payload["no_reward_settlement_performed"] is True
+
+
+def test_module_has_no_runtime_dispatch_or_execution_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "os",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "git",
+        "gh",
+    }
+    banned_import_fragments = {
+        "openclaw_supervisor",
+        "hermes_job_executor",
+        "worker_assignment_protocol",
+        "swarm_dispatch_integration",
+        "worktree_pr_runner",
+        "pattern_memory",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__", "open"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".")[0]
+                assert root not in banned_import_roots
+                assert not any(fragment in alias.name for fragment in banned_import_fragments)
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            root = module.split(".")[0]
+            assert root not in banned_import_roots
+            assert not any(fragment in module for fragment in banned_import_fragments)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls


### PR DESCRIPTION
## Summary

Implements REDDOG_SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_PHASE1.

This slice adds a RedDog-side dry-run planner that consumes:

- accepted queue authority verification result
- signed authority runtime payload
- authoritative WSP_15 allocation receipt

It validates the signed allocation receipt id, digest, priority, MPS total, and reasoning tier against the supplied WSP_15 allocation before emitting deterministic worker-dispatch intents.

## Boundary

No worker spawn, queue mutation, worktree creation, shell command, OpenClaw enqueue, Hermes dispatch, repo mutation, PR creation, reward settlement, PatternMemory write, or HoloIndex runtime re-index is added.

## Validation

- pytest -q modules/communication/moltbot_bridge/tests/test_reddog_signed_authority_worker_dispatch_dryrun.py -> 13 passed
- pytest -q modules/communication/moltbot_bridge/tests/test_reddog_wsp15_allocation_receipt.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_request_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_runtime_invoke.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_verification_invoke.py modules/communication/moltbot_bridge/tests/test_reddog_signed_authority_worker_dispatch_dryrun.py -> 61 passed
- python -m py_compile on new module/test -> pass
- git diff --check -> clean, except existing LF/CRLF informational warning on ModLog
- ASCII/NUL scan on new files -> 0 non-ASCII, 0 NUL

## HoloIndex

Read-only probe for RedDog signed authority worker dispatch dryrun WSP15 returned adjacent RedDog governance assets but not this new seam. Recorded as HOLOINDEX_REDDOG_SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_INDEX_GAP_PHASE1. No runtime re-index is performed.

## Truth boundary checklist

- NO_WORKER_SPAWN: PASS
- NO_QUEUE_MUTATION: PASS
- NO_WORKTREE_CREATE: PASS
- NO_SHELL_COMMAND: PASS
- NO_OPENCLAW_ENQUEUE: PASS
- NO_HERMES_DISPATCH: PASS
- NO_REPO_MUTATION: PASS
- NO_HOLOINDEX_REINDEX: PASS
- DRYRUN_ONLY: PASS
