### PR TITLE
feat(reddog): backend architect determination runtime

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,28 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-15: REDDOG_BACKEND_ARCHITECT_DETERMINATION_RUNTIME_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97
+
+- Added `reddog_backend_architect_determination_runtime.py`, a real backend
+  architect determination runtime that consumes an accepted operational
+  snapshot, collected read-only audit reports, the Fusion assignment gate, and
+  a canonical WSP_15 allocation receipt.
+- The runtime calls an explicit RedDog/Fusion model runner, validates a strict
+  `FIX | RESEARCH_MORE | REVISE | STOP` JSON determination, requires Fusion
+  quorum and matching WSP_15 allocation receipt id, persists the determination,
+  and emits at most one candidate queue item for `FIX`.
+- Added an explicit opt-in path in `reddog_main_readonly_operational_bootstrap`
+  so main startup behavior remains unchanged unless backend architect
+  determination is requested.
+- No coding worker spawn, shell command, worktree operation, repo mutation,
+  OpenClaw enqueue, Hermes dispatch, PR creation, PatternMemory promotion, or
+  HoloIndex runtime re-index is added.
+- HoloIndex read-only probe for `RedDog backend architect determination
+  runtime` is treated as
+  `HOLOINDEX_REDDOG_BACKEND_ARCHITECT_DETERMINATION_RUNTIME_INDEX_GAP_PHASE1`
+  until the new runtime is indexed by the governed WRE/CI indexer.
+
 ## 2026-07-15: REDDOG_RESIDENT_QUEUE_WORKER_DISPATCH_DRYRUN_STAGE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py
@@ -1,0 +1,1188 @@
+"""Backend RedDog architect determination runtime.
+
+Slice: REDDOG_BACKEND_ARCHITECT_DETERMINATION_RUNTIME_PHASE1
+
+This module consumes an accepted operational snapshot plus collected read-only
+audit reports, calls a redaction-gated RedDog/Fusion model runner, validates a
+bounded architect determination, persists that determination, and emits at most
+one candidate WRE queue item for a FIX decision.
+
+It does not spawn workers, execute shell commands, mutate repository files,
+create worktrees, enqueue OpenClaw, dispatch Hermes, publish PRs, admit
+PatternMemory, settle rewards, or re-index HoloIndex.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Optional, Protocol, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_context_snapshot_fusion_assignment_gate import (
+    FUSION_ASSIGNMENT_GATE_PASSED,
+    FusionAssignmentGateDecision,
+)
+from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
+    ContextView,
+    EvidenceBundle,
+    OperationalContextSnapshot,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_report_collection import (
+    ReadOnlyAuditReportCollectionResult,
+)
+
+
+ARCHITECT_DETERMINATION_ACCEPT = "ARCHITECT_DETERMINATION_ACCEPT"
+ARCHITECT_DETERMINATION_REJECT = "ARCHITECT_DETERMINATION_REJECT"
+ARCHITECT_DETERMINATION_SCHEMA_VERSION = "reddog_architect_determination_receipt.v1"
+ARCHITECT_QUEUE_CANDIDATE_SCHEMA_VERSION = "reddog_architect_queue_candidate.v1"
+
+ACTION_FIX = "FIX"
+ACTION_RESEARCH_MORE = "RESEARCH_MORE"
+ACTION_REVISE = "REVISE"
+ACTION_STOP = "STOP"
+ALLOWED_ACTIONS = (ACTION_FIX, ACTION_RESEARCH_MORE, ACTION_REVISE, ACTION_STOP)
+
+ENV_ARCHITECT_RUNTIME_MODE = "REDDOG_BACKEND_ARCHITECT_RUNTIME_MODE"
+RUNTIME_MODE_FOUNDUPS_FUSION = "foundups_fusion"
+DEFAULT_MAX_PROMPT_CHARS = 24_000
+
+
+class ArchitectDeterminationReason:
+    MISSING_SNAPSHOT = "REJECT_ARCHITECT_DETERMINATION_MISSING_SNAPSHOT"
+    SNAPSHOT_REJECTED = "REJECT_ARCHITECT_DETERMINATION_SNAPSHOT_REJECTED"
+    SNAPSHOT_EXPIRED = "REJECT_ARCHITECT_DETERMINATION_SNAPSHOT_EXPIRED"
+    SNAPSHOT_HAS_CONFLICTS = "REJECT_ARCHITECT_DETERMINATION_SNAPSHOT_HAS_CONFLICTS"
+    MISSING_CONTEXT_VIEW = "REJECT_ARCHITECT_DETERMINATION_MISSING_CONTEXT_VIEW"
+    MISSING_EVIDENCE_BUNDLE = "REJECT_ARCHITECT_DETERMINATION_MISSING_EVIDENCE_BUNDLE"
+    FUSION_GATE_NOT_PASSED = "REJECT_ARCHITECT_DETERMINATION_FUSION_GATE_NOT_PASSED"
+    MISSING_DETERMINATION_BINDING = "REJECT_ARCHITECT_DETERMINATION_MISSING_BINDING"
+    REPORT_COLLECTION_NOT_ACCEPTED = "REJECT_ARCHITECT_DETERMINATION_REPORT_COLLECTION_NOT_ACCEPTED"
+    MISSING_AUDIT_REPORTS = "REJECT_ARCHITECT_DETERMINATION_MISSING_AUDIT_REPORTS"
+    REPORT_COUNT_MISMATCH = "REJECT_ARCHITECT_DETERMINATION_REPORT_COUNT_MISMATCH"
+    REPORT_MISSING_RECEIPT = "REJECT_ARCHITECT_DETERMINATION_REPORT_MISSING_RECEIPT"
+    REPORT_MISSING_EVIDENCE = "REJECT_ARCHITECT_DETERMINATION_REPORT_MISSING_EVIDENCE"
+    REPORT_CLAIMS_SIDE_EFFECT = "REJECT_ARCHITECT_DETERMINATION_REPORT_CLAIMS_SIDE_EFFECT"
+    MISSING_WSP15_ALLOCATION = "REJECT_ARCHITECT_DETERMINATION_MISSING_WSP15_ALLOCATION"
+    MALFORMED_WSP15_ALLOCATION = "REJECT_ARCHITECT_DETERMINATION_MALFORMED_WSP15_ALLOCATION"
+    DUPLICATE_CYCLE = "REJECT_ARCHITECT_DETERMINATION_DUPLICATE_CYCLE"
+    MODEL_FAILURE = "REJECT_ARCHITECT_DETERMINATION_MODEL_FAILURE"
+    MODEL_TIMEOUT = "REJECT_ARCHITECT_DETERMINATION_MODEL_TIMEOUT"
+    FUSION_QUORUM_NOT_PASSED = "REJECT_ARCHITECT_DETERMINATION_FUSION_QUORUM_NOT_PASSED"
+    INVALID_MODEL_OUTPUT = "REJECT_ARCHITECT_DETERMINATION_INVALID_MODEL_OUTPUT"
+    WSP15_RECEIPT_MISMATCH = "REJECT_ARCHITECT_DETERMINATION_WSP15_RECEIPT_MISMATCH"
+    STORE_REJECTED = "REJECT_ARCHITECT_DETERMINATION_STORE_REJECTED"
+
+
+@dataclass(frozen=True)
+class ArchitectModelResult:
+    """Result returned by a configured backend architect model runner."""
+
+    ok: bool
+    status: str
+    content: str
+    model_receipt_id: Optional[str]
+    model_result_digest: str
+    review_packet: Mapping[str, Any]
+    made_network_call: bool
+    rejection_reasons: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class ArchitectModelRunner(Protocol):
+    """Runtime model runner interface for backend architect determination."""
+
+    def run_architect_determination(
+        self,
+        *,
+        prompt: str,
+        context: str,
+        binding: Mapping[str, Any],
+        timeout_seconds: int,
+    ) -> ArchitectModelResult: ...
+
+
+@dataclass(frozen=True)
+class FoundupsFusionArchitectModelRunner:
+    """Production runner for the existing redaction-gated FoundUps Fusion bridge.
+
+    The runner is concrete, not a SPECIFIED_NOT_IMPLEMENTED placeholder. It is
+    explicit-mode only: callers must set REDDOG_BACKEND_ARCHITECT_RUNTIME_MODE
+    to ``foundups_fusion`` and provide OPENROUTER_API_KEY. Tests should inject a
+    fake runner instead of reaching the network.
+    """
+
+    lead_model: str = "z-ai/glm-5.2"
+    panel_models: tuple[str, ...] = ("deepseek/deepseek-v4-pro", "moonshotai/kimi-k2.7-code")
+    max_tokens: int = 1200
+    temperature: float = 0.0
+
+    def run_architect_determination(
+        self,
+        *,
+        prompt: str,
+        context: str,
+        binding: Mapping[str, Any],
+        timeout_seconds: int,
+    ) -> ArchitectModelResult:
+        if os.getenv(ENV_ARCHITECT_RUNTIME_MODE, "").strip() != RUNTIME_MODE_FOUNDUPS_FUSION:
+            return _model_result_reject("runtime_mode_not_enabled")
+        api_key = os.getenv("OPENROUTER_API_KEY")
+        if not api_key:
+            return _model_result_reject("missing_openrouter_api_key")
+        try:
+            from scripts.advisory_model_once import _run_foundups_fusion
+            from modules.communication.moltbot_bridge.src.fusion_redaction_gate import (
+                REDACTION_GATE_PASSED,
+                evaluate_redaction_gate,
+            )
+        except Exception:
+            return _model_result_reject("fusion_bridge_unavailable")
+
+        gate = evaluate_redaction_gate(prompt, context, audit_mode=True)
+        if gate.status != REDACTION_GATE_PASSED or not gate.redacted_prompt:
+            return _model_result_reject("redaction_blocked")
+        redacted_user = gate.redacted_prompt
+        if gate.redacted_context:
+            redacted_user = gate.redacted_prompt + "\n\n" + gate.redacted_context
+        payload = {
+            "mode": "foundups_fusion",
+            "lead_model": self.lead_model,
+            "panel_models": list(self.panel_models),
+            "max_tokens": self.max_tokens,
+            "temperature": self.temperature,
+            "timeout": timeout_seconds,
+            "_redacted_evidence_context": gate.redacted_context or "",
+            "bridge_meta": {"architect_binding": dict(binding)},
+        }
+        try:
+            result = _run_foundups_fusion(api_key, redacted_user, [], payload)
+        except TimeoutError:
+            return _model_result_reject(ArchitectDeterminationReason.MODEL_TIMEOUT)
+        except Exception:
+            return _model_result_reject("fusion_bridge_call_failed")
+        if not isinstance(result, Mapping) or result.get("ok") is not True:
+            return _model_result_reject(str(result.get("reason") if isinstance(result, Mapping) else "model_failed"))
+        content = str(result.get("content") or "")
+        review_packet = result.get("review_packet") if isinstance(result.get("review_packet"), Mapping) else {}
+        model_receipt_id = str(review_packet.get("receipt_id") or "").strip() or None
+        return ArchitectModelResult(
+            ok=True,
+            status="MODEL_OK",
+            content=content,
+            model_receipt_id=model_receipt_id,
+            model_result_digest=_digest({"content": content, "review_packet": review_packet}),
+            review_packet=dict(review_packet),
+            made_network_call=True,
+            rejection_reasons=(),
+        )
+
+
+@dataclass(frozen=True)
+class ArchitectQueueCandidate:
+    """Queue candidate emitted by a FIX determination."""
+
+    schema_version: str
+    queue_candidate_id: str
+    source_determination_receipt_id: str
+    slice_id: str
+    status: str
+    evidence_refs: tuple[str, ...]
+    wsp15_allocation_receipt: Mapping[str, Any]
+    no_queue_mutation_performed: bool = True
+    no_execution_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_repo_mutation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ArchitectDeterminationReceipt:
+    """Validated backend architect determination receipt."""
+
+    schema_version: str
+    determination_receipt_id: str
+    cycle_id: str
+    accepted: bool
+    status: str
+    action: str
+    next_slice_name: Optional[str]
+    summary: str
+    snapshot_receipt_id: Optional[str]
+    snapshot_content_digest: Optional[str]
+    context_view_id: Optional[str]
+    evidence_bundle_id: Optional[str]
+    report_bundle_id: Optional[str]
+    report_count: int
+    audit_report_digests: tuple[str, ...]
+    model_result_digest: Optional[str]
+    model_receipt_id: Optional[str]
+    fusion_quorum_passed: bool
+    wsp15_allocation_receipt_id: Optional[str]
+    wsp15_allocation_digest: Optional[str]
+    queue_candidate: Optional[ArchitectQueueCandidate]
+    decision_reasons: tuple[str, ...]
+    rejection_reasons: tuple[str, ...]
+    no_coding_worker_spawned: bool = True
+    no_shell_command_executed: bool = True
+    no_worktree_operation_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_pr_created: bool = True
+    no_pattern_memory_promotion_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["queue_candidate"] = self.queue_candidate.to_dict() if self.queue_candidate else None
+        return data
+
+
+@dataclass(frozen=True)
+class ArchitectDeterminationPersistResult:
+    """Persistence result for a backend architect determination."""
+
+    accepted: bool
+    status: str
+    determination_receipt_id: Optional[str]
+    cycle_id: Optional[str]
+    stored: bool
+    idempotent: bool
+    rejection_reasons: tuple[str, ...]
+    no_queue_mutation_performed: bool = True
+    no_execution_performed: bool = True
+    no_repo_mutation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class BackendArchitectDeterminationResult:
+    """Top-level runtime result."""
+
+    accepted: bool
+    status: str
+    receipt: ArchitectDeterminationReceipt
+    persist_result: ArchitectDeterminationPersistResult
+    queue_candidate_count: int
+    rejection_reasons: tuple[str, ...]
+    no_coding_worker_spawned: bool = True
+    no_shell_command_executed: bool = True
+    no_worktree_operation_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_pr_created: bool = True
+    no_pattern_memory_promotion_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "accepted": self.accepted,
+            "status": self.status,
+            "receipt": self.receipt.to_dict(),
+            "persist_result": self.persist_result.to_dict(),
+            "queue_candidate_count": self.queue_candidate_count,
+            "rejection_reasons": list(self.rejection_reasons),
+            "no_coding_worker_spawned": self.no_coding_worker_spawned,
+            "no_shell_command_executed": self.no_shell_command_executed,
+            "no_worktree_operation_performed": self.no_worktree_operation_performed,
+            "no_repo_mutation_performed": self.no_repo_mutation_performed,
+            "no_openclaw_enqueue_performed": self.no_openclaw_enqueue_performed,
+            "no_hermes_dispatch_performed": self.no_hermes_dispatch_performed,
+            "no_pr_created": self.no_pr_created,
+            "no_pattern_memory_promotion_performed": self.no_pattern_memory_promotion_performed,
+            "no_holoindex_reindex_performed": self.no_holoindex_reindex_performed,
+        }
+
+
+@dataclass(frozen=True)
+class ArchitectDeterminationRecord:
+    determination_receipt_id: str
+    cycle_id: str
+    action: str
+    next_slice_name: Optional[str]
+    determination: Mapping[str, Any]
+    stored_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class ArchitectDeterminationStore(Protocol):
+    def load_architect_determination_by_cycle(self, cycle_id: str) -> Optional[Mapping[str, Any]]: ...
+
+    def store_architect_determination(self, record: ArchitectDeterminationRecord) -> Mapping[str, Any]: ...
+
+
+class InMemoryArchitectDeterminationStore:
+    """Test/runtime helper with duplicate-cycle protection."""
+
+    def __init__(self, initial: Sequence[Mapping[str, Any]] = (), *, reject: bool = False) -> None:
+        self.reject = reject
+        self.records: list[ArchitectDeterminationRecord] = []
+        self._by_cycle: dict[str, Mapping[str, Any]] = {}
+        for item in initial:
+            cycle_id = str(item.get("cycle_id") or "")
+            if cycle_id:
+                self._by_cycle[cycle_id] = dict(item)
+
+    def load_architect_determination_by_cycle(self, cycle_id: str) -> Optional[Mapping[str, Any]]:
+        return self._by_cycle.get(cycle_id)
+
+    def store_architect_determination(self, record: ArchitectDeterminationRecord) -> Mapping[str, Any]:
+        if self.reject:
+            return {"ok": False, "reason": "store_rejected"}
+        existing = self._by_cycle.get(record.cycle_id)
+        payload = record.to_dict()
+        if existing is not None:
+            if _canonical_json(existing) == _canonical_json(payload):
+                return {"ok": True, "stored": False, "idempotent": True}
+            return {"ok": False, "reason": "duplicate_cycle"}
+        self.records.append(record)
+        self._by_cycle[record.cycle_id] = payload
+        return {"ok": True, "stored": True, "idempotent": False}
+
+
+class AgentDbArchitectDeterminationStore:
+    """AgentDB-backed store for backend architect determination receipts."""
+
+    def __init__(self, agent_db_factory: Optional[Any] = None) -> None:
+        self._agent_db_factory = agent_db_factory
+
+    def load_architect_determination_by_cycle(self, cycle_id: str) -> Optional[Mapping[str, Any]]:
+        db = self._agent_db()
+        self._ensure_table(db)
+        rows = db.db.execute_query(
+            """
+            SELECT determination_json FROM reddog_architect_determinations
+            WHERE cycle_id = ?
+            """,
+            (cycle_id,),
+        )
+        if not rows:
+            return None
+        value = rows[0]["determination_json"] if isinstance(rows[0], Mapping) else rows[0][0]
+        return json.loads(value)
+
+    def store_architect_determination(self, record: ArchitectDeterminationRecord) -> Mapping[str, Any]:
+        db = self._agent_db()
+        self._ensure_table(db)
+        determination_json = _canonical_json(record.determination)
+        with db.db.get_connection() as conn:
+            existing = conn.execute(
+                """
+                SELECT determination_json FROM reddog_architect_determinations
+                WHERE cycle_id = ?
+                """,
+                (record.cycle_id,),
+            ).fetchone()
+            if existing:
+                existing_json = existing["determination_json"] if hasattr(existing, "keys") else existing[0]
+                if existing_json == determination_json:
+                    return {"ok": True, "stored": False, "idempotent": True}
+                return {"ok": False, "reason": "duplicate_cycle"}
+            conn.execute(
+                """
+                INSERT INTO reddog_architect_determinations
+                (determination_receipt_id, cycle_id, action, next_slice_name, determination_json, stored_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.determination_receipt_id,
+                    record.cycle_id,
+                    record.action,
+                    record.next_slice_name,
+                    determination_json,
+                    record.stored_at,
+                ),
+            )
+        return {"ok": True, "stored": True, "idempotent": False}
+
+    def _agent_db(self) -> Any:
+        factory = self._agent_db_factory
+        if factory is None:
+            from modules.infrastructure.database.src.agent_db import AgentDB
+
+            factory = AgentDB
+        return factory()
+
+    @staticmethod
+    def _ensure_table(db: Any) -> None:
+        with db.db.get_connection() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS reddog_architect_determinations (
+                    determination_receipt_id TEXT PRIMARY KEY,
+                    cycle_id TEXT NOT NULL UNIQUE,
+                    action TEXT NOT NULL,
+                    next_slice_name TEXT,
+                    determination_json TEXT NOT NULL,
+                    stored_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_reddog_architect_determinations_action
+                ON reddog_architect_determinations(action)
+                """
+            )
+
+
+def run_reddog_backend_architect_determination_runtime(
+    *,
+    snapshot: OperationalContextSnapshot | None,
+    context_view: ContextView | None,
+    evidence_bundle: EvidenceBundle | None,
+    fusion_gate: FusionAssignmentGateDecision | None,
+    report_collection: ReadOnlyAuditReportCollectionResult | None,
+    reports: Sequence[Mapping[str, Any]],
+    wsp15_allocation_receipt: Mapping[str, Any],
+    store: ArchitectDeterminationStore | None = None,
+    model_runner: ArchitectModelRunner | None = None,
+    now_iso: str | None = None,
+    timeout_seconds: int = 60,
+) -> BackendArchitectDeterminationResult:
+    """Produce, persist, and queue-candidate one backend architect determination."""
+
+    observed_at = now_iso or datetime.now(timezone.utc).isoformat()
+    reasons: list[str] = []
+    model_result: ArchitectModelResult | None = None
+
+    _validate_static_inputs(
+        snapshot=snapshot,
+        context_view=context_view,
+        evidence_bundle=evidence_bundle,
+        fusion_gate=fusion_gate,
+        report_collection=report_collection,
+        reports=reports,
+        wsp15_allocation_receipt=wsp15_allocation_receipt,
+        now_iso=observed_at,
+        reasons=reasons,
+    )
+    report_bundle_id = _report_bundle_id(report_collection)
+    report_digests = _report_digests(reports)
+    allocation_receipt_id = str(wsp15_allocation_receipt.get("receipt_id") or "").strip() or None
+    allocation_digest = _digest(wsp15_allocation_receipt) if isinstance(wsp15_allocation_receipt, Mapping) else None
+    cycle_id = _cycle_id(
+        snapshot=snapshot,
+        report_bundle_id=report_bundle_id,
+        report_digests=report_digests,
+        wsp15_allocation_digest=allocation_digest,
+    )
+    writer = store if store is not None else AgentDbArchitectDeterminationStore()
+    if cycle_id and not reasons:
+        try:
+            if writer.load_architect_determination_by_cycle(cycle_id) is not None:
+                reasons.append(ArchitectDeterminationReason.DUPLICATE_CYCLE)
+        except Exception:
+            reasons.append(ArchitectDeterminationReason.STORE_REJECTED)
+
+    if reasons:
+        receipt = _receipt(
+            accepted=False,
+            action=ACTION_STOP,
+            next_slice_name=None,
+            summary="Backend architect determination rejected before model call.",
+            snapshot=snapshot,
+            context_view=context_view,
+            evidence_bundle=evidence_bundle,
+            report_bundle_id=report_bundle_id,
+            report_count=_report_count(report_collection),
+            report_digests=report_digests,
+            model_result=None,
+            allocation_receipt_id=allocation_receipt_id,
+            allocation_digest=allocation_digest,
+            cycle_id=cycle_id or "sha256:" + "0" * 64,
+            decision_reasons=(),
+            rejection_reasons=_dedupe(reasons),
+        )
+        persist_result = _persist_rejected(receipt)
+        return _result(receipt=receipt, persist_result=persist_result)
+
+    assert snapshot is not None
+    assert context_view is not None
+    assert evidence_bundle is not None
+    assert fusion_gate is not None
+    assert report_collection is not None
+    assert cycle_id is not None
+    runner = model_runner if model_runner is not None else FoundupsFusionArchitectModelRunner()
+    prompt = _build_architect_prompt(
+        snapshot=snapshot,
+        report_collection=report_collection,
+        reports=reports,
+        wsp15_allocation_receipt=wsp15_allocation_receipt,
+    )
+    context = _build_architect_context(
+        context_view=context_view,
+        evidence_bundle=evidence_bundle,
+        reports=reports,
+    )
+    binding = fusion_gate.determination_binding.to_dict() if fusion_gate.determination_binding else {}
+    try:
+        model_result = runner.run_architect_determination(
+            prompt=prompt,
+            context=context,
+            binding=binding,
+            timeout_seconds=timeout_seconds,
+        )
+    except TimeoutError:
+        reasons.append(ArchitectDeterminationReason.MODEL_TIMEOUT)
+        model_result = None
+    except Exception:
+        reasons.append(ArchitectDeterminationReason.MODEL_FAILURE)
+        model_result = None
+
+    if model_result is None:
+        receipt = _receipt(
+            accepted=False,
+            action=ACTION_STOP,
+            next_slice_name=None,
+            summary="Backend architect model call failed.",
+            snapshot=snapshot,
+            context_view=context_view,
+            evidence_bundle=evidence_bundle,
+            report_bundle_id=report_bundle_id,
+            report_count=_report_count(report_collection),
+            report_digests=report_digests,
+            model_result=None,
+            allocation_receipt_id=allocation_receipt_id,
+            allocation_digest=allocation_digest,
+            cycle_id=cycle_id,
+            decision_reasons=(),
+            rejection_reasons=_dedupe(reasons),
+        )
+        persist_result = _persist_rejected(receipt)
+        return _result(receipt=receipt, persist_result=persist_result)
+
+    if not model_result.ok:
+        reasons.append(ArchitectDeterminationReason.MODEL_FAILURE)
+        reasons.extend(model_result.rejection_reasons)
+    if not _fusion_quorum_passed(model_result.review_packet):
+        reasons.append(ArchitectDeterminationReason.FUSION_QUORUM_NOT_PASSED)
+
+    parsed = _parse_model_output(model_result.content)
+    output_reasons: list[str] = []
+    _validate_model_output(
+        parsed,
+        reports=reports,
+        wsp15_allocation_receipt_id=allocation_receipt_id,
+        output_reasons=output_reasons,
+    )
+    reasons.extend(output_reasons)
+    if reasons:
+        receipt = _receipt(
+            accepted=False,
+            action=ACTION_STOP,
+            next_slice_name=None,
+            summary="Backend architect determination rejected after model validation.",
+            snapshot=snapshot,
+            context_view=context_view,
+            evidence_bundle=evidence_bundle,
+            report_bundle_id=report_bundle_id,
+            report_count=_report_count(report_collection),
+            report_digests=report_digests,
+            model_result=model_result,
+            allocation_receipt_id=allocation_receipt_id,
+            allocation_digest=allocation_digest,
+            cycle_id=cycle_id,
+            decision_reasons=(),
+            rejection_reasons=_dedupe(reasons),
+        )
+        persist_result = _persist_rejected(receipt)
+        return _result(receipt=receipt, persist_result=persist_result)
+
+    action = str(parsed["action"]).upper()
+    next_slice_name = str(parsed.get("next_slice_name") or "").strip() or None
+    summary = str(parsed.get("summary") or "").strip()
+    decision_reasons = _normalize_text_list(parsed.get("decision_reasons"))
+    queue_candidate = None
+    receipt_stub_id = _digest(
+        {
+            "cycle_id": cycle_id,
+            "action": action,
+            "next_slice_name": next_slice_name,
+            "model_result_digest": model_result.model_result_digest,
+        }
+    )
+    if action == ACTION_FIX:
+        assert next_slice_name is not None
+        queue_candidate = _queue_candidate(
+            source_determination_receipt_id=receipt_stub_id,
+            next_slice_name=next_slice_name,
+            snapshot=snapshot,
+            report_bundle_id=report_bundle_id,
+            wsp15_allocation_receipt=wsp15_allocation_receipt,
+        )
+    receipt = _receipt(
+        accepted=True,
+        action=action,
+        next_slice_name=next_slice_name,
+        summary=summary,
+        snapshot=snapshot,
+        context_view=context_view,
+        evidence_bundle=evidence_bundle,
+        report_bundle_id=report_bundle_id,
+        report_count=_report_count(report_collection),
+        report_digests=report_digests,
+        model_result=model_result,
+        allocation_receipt_id=allocation_receipt_id,
+        allocation_digest=allocation_digest,
+        cycle_id=cycle_id,
+        decision_reasons=decision_reasons,
+        rejection_reasons=(),
+        queue_candidate=queue_candidate,
+        determination_receipt_id=receipt_stub_id,
+    )
+    persist_result = _persist_receipt(receipt, writer=writer, now_iso=observed_at)
+    if not persist_result.accepted:
+        failed = _receipt(
+            accepted=False,
+            action=ACTION_STOP,
+            next_slice_name=None,
+            summary="Backend architect determination persistence rejected.",
+            snapshot=snapshot,
+            context_view=context_view,
+            evidence_bundle=evidence_bundle,
+            report_bundle_id=report_bundle_id,
+            report_count=_report_count(report_collection),
+            report_digests=report_digests,
+            model_result=model_result,
+            allocation_receipt_id=allocation_receipt_id,
+            allocation_digest=allocation_digest,
+            cycle_id=cycle_id,
+            decision_reasons=decision_reasons,
+            rejection_reasons=(ArchitectDeterminationReason.STORE_REJECTED, *persist_result.rejection_reasons),
+        )
+        return _result(receipt=failed, persist_result=persist_result)
+    return _result(receipt=receipt, persist_result=persist_result)
+
+
+def _validate_static_inputs(
+    *,
+    snapshot: OperationalContextSnapshot | None,
+    context_view: ContextView | None,
+    evidence_bundle: EvidenceBundle | None,
+    fusion_gate: FusionAssignmentGateDecision | None,
+    report_collection: ReadOnlyAuditReportCollectionResult | None,
+    reports: Sequence[Mapping[str, Any]],
+    wsp15_allocation_receipt: Mapping[str, Any],
+    now_iso: str,
+    reasons: list[str],
+) -> None:
+    if snapshot is None:
+        reasons.append(ArchitectDeterminationReason.MISSING_SNAPSHOT)
+    else:
+        if snapshot.rejection_reasons:
+            reasons.append(ArchitectDeterminationReason.SNAPSHOT_REJECTED)
+        if snapshot.conflicts:
+            reasons.append(ArchitectDeterminationReason.SNAPSHOT_HAS_CONFLICTS)
+        if _snapshot_expired(snapshot.valid_until, now_iso):
+            reasons.append(ArchitectDeterminationReason.SNAPSHOT_EXPIRED)
+        if not snapshot.snapshot_receipt_id or not snapshot.snapshot_content_digest:
+            reasons.append(ArchitectDeterminationReason.MISSING_SNAPSHOT)
+    if context_view is None:
+        reasons.append(ArchitectDeterminationReason.MISSING_CONTEXT_VIEW)
+    if evidence_bundle is None:
+        reasons.append(ArchitectDeterminationReason.MISSING_EVIDENCE_BUNDLE)
+    if fusion_gate is None or not fusion_gate.accepted or fusion_gate.status != FUSION_ASSIGNMENT_GATE_PASSED:
+        reasons.append(ArchitectDeterminationReason.FUSION_GATE_NOT_PASSED)
+    elif fusion_gate.determination_binding is None:
+        reasons.append(ArchitectDeterminationReason.MISSING_DETERMINATION_BINDING)
+    if report_collection is None or not report_collection.accepted:
+        reasons.append(ArchitectDeterminationReason.REPORT_COLLECTION_NOT_ACCEPTED)
+    else:
+        if not report_collection.validation or not report_collection.validation.bundle:
+            reasons.append(ArchitectDeterminationReason.REPORT_COLLECTION_NOT_ACCEPTED)
+        if report_collection.report_count != len(reports):
+            reasons.append(ArchitectDeterminationReason.REPORT_COUNT_MISMATCH)
+    if not reports:
+        reasons.append(ArchitectDeterminationReason.MISSING_AUDIT_REPORTS)
+    for index, report in enumerate(reports):
+        if not isinstance(report, Mapping):
+            reasons.append(f"{ArchitectDeterminationReason.REPORT_MISSING_RECEIPT}:{index}")
+            continue
+        if not str(report.get("report_digest") or "").strip() or not str(report.get("assignment_id") or "").strip():
+            reasons.append(f"{ArchitectDeterminationReason.REPORT_MISSING_RECEIPT}:{index}")
+        evidence_refs = _normalize_text_list(report.get("evidence_refs"))
+        if not evidence_refs:
+            reasons.append(f"{ArchitectDeterminationReason.REPORT_MISSING_EVIDENCE}:{index}")
+        if (
+            report.get("repo_mutation_performed") is True
+            or report.get("execution_performed") is True
+            or report.get("openclaw_enqueue_performed") is True
+        ):
+            reasons.append(f"{ArchitectDeterminationReason.REPORT_CLAIMS_SIDE_EFFECT}:{index}")
+    _validate_wsp15_allocation(wsp15_allocation_receipt, reasons)
+
+
+def _validate_wsp15_allocation(allocation: Mapping[str, Any], reasons: list[str]) -> None:
+    if not isinstance(allocation, Mapping) or not allocation:
+        reasons.append(ArchitectDeterminationReason.MISSING_WSP15_ALLOCATION)
+        return
+    required = (
+        "receipt_id",
+        "complexity",
+        "importance",
+        "deferability",
+        "impact",
+        "mps_total",
+        "priority",
+        "reasoning_tier",
+        "worker_plan",
+    )
+    missing = [key for key in required if key not in allocation or allocation.get(key) in (None, "")]
+    if missing:
+        reasons.append(ArchitectDeterminationReason.MALFORMED_WSP15_ALLOCATION)
+        return
+    if not str(allocation.get("receipt_id") or "").startswith("sha256:"):
+        reasons.append(ArchitectDeterminationReason.MALFORMED_WSP15_ALLOCATION)
+    scores = [allocation.get(key) for key in ("complexity", "importance", "deferability", "impact")]
+    if not all(isinstance(value, int) and 1 <= value <= 5 for value in scores):
+        reasons.append(ArchitectDeterminationReason.MALFORMED_WSP15_ALLOCATION)
+    total = allocation.get("mps_total")
+    if not isinstance(total, int) or total != sum(scores):
+        reasons.append(ArchitectDeterminationReason.MALFORMED_WSP15_ALLOCATION)
+    priority = str(allocation.get("priority") or "")
+    if priority not in {"P0", "P1", "P2", "P3", "P4"}:
+        reasons.append(ArchitectDeterminationReason.MALFORMED_WSP15_ALLOCATION)
+    if not isinstance(allocation.get("worker_plan"), Mapping):
+        reasons.append(ArchitectDeterminationReason.MALFORMED_WSP15_ALLOCATION)
+
+
+def _parse_model_output(content: str) -> Mapping[str, Any]:
+    text = str(content or "").strip()
+    if not text:
+        return {}
+    candidates = [text]
+    if "```" in text:
+        parts = text.split("```")
+        for part in parts:
+            cleaned = part.strip()
+            if cleaned.lower().startswith("json"):
+                cleaned = cleaned[4:].strip()
+            if cleaned.startswith("{") and cleaned.endswith("}"):
+                candidates.insert(0, cleaned)
+    start = text.find("{")
+    end = text.rfind("}")
+    if start >= 0 and end > start:
+        candidates.append(text[start : end + 1])
+    for candidate in candidates:
+        try:
+            parsed = json.loads(candidate)
+        except Exception:
+            continue
+        if isinstance(parsed, Mapping):
+            return parsed
+    return {}
+
+
+def _validate_model_output(
+    output: Mapping[str, Any],
+    *,
+    reports: Sequence[Mapping[str, Any]],
+    wsp15_allocation_receipt_id: Optional[str],
+    output_reasons: list[str],
+) -> None:
+    if not output:
+        output_reasons.append(ArchitectDeterminationReason.INVALID_MODEL_OUTPUT)
+        return
+    action = str(output.get("action") or "").strip().upper()
+    next_slice = str(output.get("next_slice_name") or "").strip()
+    summary = str(output.get("summary") or "").strip()
+    evidence_refs = _normalize_text_list(output.get("evidence_refs"))
+    model_allocation_id = str(output.get("wsp15_allocation_receipt_id") or "").strip()
+    if action not in ALLOWED_ACTIONS:
+        output_reasons.append(ArchitectDeterminationReason.INVALID_MODEL_OUTPUT)
+    if action in {ACTION_FIX, ACTION_RESEARCH_MORE, ACTION_REVISE} and not _valid_slice_name(next_slice):
+        output_reasons.append(ArchitectDeterminationReason.INVALID_MODEL_OUTPUT)
+    if action == ACTION_STOP and next_slice:
+        output_reasons.append(ArchitectDeterminationReason.INVALID_MODEL_OUTPUT)
+    if not summary:
+        output_reasons.append(ArchitectDeterminationReason.INVALID_MODEL_OUTPUT)
+    if not evidence_refs:
+        output_reasons.append(ArchitectDeterminationReason.INVALID_MODEL_OUTPUT)
+    report_refs = set(_all_report_evidence_refs(reports))
+    if evidence_refs and not set(evidence_refs).issubset(report_refs):
+        output_reasons.append(ArchitectDeterminationReason.INVALID_MODEL_OUTPUT)
+    if not model_allocation_id or model_allocation_id != wsp15_allocation_receipt_id:
+        output_reasons.append(ArchitectDeterminationReason.WSP15_RECEIPT_MISMATCH)
+
+
+def _fusion_quorum_passed(review_packet: Mapping[str, Any]) -> bool:
+    quorum = review_packet.get("fusion_panel_quorum")
+    return isinstance(quorum, Mapping) and quorum.get("passed") is True
+
+
+def _build_architect_prompt(
+    *,
+    snapshot: OperationalContextSnapshot,
+    report_collection: ReadOnlyAuditReportCollectionResult,
+    reports: Sequence[Mapping[str, Any]],
+    wsp15_allocation_receipt: Mapping[str, Any],
+) -> str:
+    payload = {
+        "task": "Return one backend RedDog architect determination as strict JSON only.",
+        "allowed_actions": list(ALLOWED_ACTIONS),
+        "required_json_fields": [
+            "action",
+            "next_slice_name",
+            "summary",
+            "decision_reasons",
+            "evidence_refs",
+            "wsp15_allocation_receipt_id",
+        ],
+        "rules": [
+            "Use FIX only when exactly one next implementation slice should be queued.",
+            "Use RESEARCH_MORE when evidence is insufficient.",
+            "Use REVISE when prior work should be corrected before new implementation.",
+            "Use STOP when no next work should be queued.",
+            "Use only evidence_refs present in the supplied audit reports.",
+            "Echo the supplied WSP15 allocation receipt id exactly.",
+        ],
+        "snapshot_receipt_id": snapshot.snapshot_receipt_id,
+        "snapshot_content_digest": snapshot.snapshot_content_digest,
+        "report_collection": {
+            "status": report_collection.status,
+            "report_count": report_collection.report_count,
+            "bundle_id": _report_bundle_id(report_collection),
+        },
+        "wsp15_allocation_receipt_id": wsp15_allocation_receipt.get("receipt_id"),
+        "reports": [_report_prompt_view(report) for report in reports],
+    }
+    text = _canonical_json(payload)
+    return text[:DEFAULT_MAX_PROMPT_CHARS]
+
+
+def _build_architect_context(
+    *,
+    context_view: ContextView,
+    evidence_bundle: EvidenceBundle,
+    reports: Sequence[Mapping[str, Any]],
+) -> str:
+    payload = {
+        "context_view_id": context_view.context_view_id,
+        "snapshot_receipt_id": context_view.snapshot_receipt_id,
+        "evidence_bundle_id": evidence_bundle.evidence_bundle_id,
+        "context_view_text": context_view.text[:6000],
+        "audit_reports": [_report_prompt_view(report) for report in reports],
+    }
+    return _canonical_json(payload)[:DEFAULT_MAX_PROMPT_CHARS]
+
+
+def _report_prompt_view(report: Mapping[str, Any]) -> Mapping[str, Any]:
+    return {
+        "assignment_id": report.get("assignment_id"),
+        "lane_id": report.get("lane_id"),
+        "summary": str(report.get("summary") or "")[:1000],
+        "report_digest": report.get("report_digest"),
+        "evidence_refs": list(_normalize_text_list(report.get("evidence_refs"))),
+        "findings": report.get("findings") if isinstance(report.get("findings"), list) else [],
+    }
+
+
+def _queue_candidate(
+    *,
+    source_determination_receipt_id: str,
+    next_slice_name: str,
+    snapshot: OperationalContextSnapshot,
+    report_bundle_id: Optional[str],
+    wsp15_allocation_receipt: Mapping[str, Any],
+) -> ArchitectQueueCandidate:
+    payload = {
+        "source_determination_receipt_id": source_determination_receipt_id,
+        "slice_id": next_slice_name,
+        "snapshot_receipt_id": snapshot.snapshot_receipt_id,
+        "report_bundle_id": report_bundle_id,
+        "wsp15_allocation_receipt_id": wsp15_allocation_receipt.get("receipt_id"),
+    }
+    return ArchitectQueueCandidate(
+        schema_version=ARCHITECT_QUEUE_CANDIDATE_SCHEMA_VERSION,
+        queue_candidate_id=_digest(payload),
+        source_determination_receipt_id=source_determination_receipt_id,
+        slice_id=next_slice_name,
+        status="CANDIDATE",
+        evidence_refs=(
+            f"architect_determination:{source_determination_receipt_id}",
+            f"snapshot:{snapshot.snapshot_receipt_id}",
+            f"report_bundle:{report_bundle_id}",
+            f"wsp15_allocation:{wsp15_allocation_receipt.get('receipt_id')}",
+        ),
+        wsp15_allocation_receipt=dict(wsp15_allocation_receipt),
+    )
+
+
+def _receipt(
+    *,
+    accepted: bool,
+    action: str,
+    next_slice_name: Optional[str],
+    summary: str,
+    snapshot: OperationalContextSnapshot | None,
+    context_view: ContextView | None,
+    evidence_bundle: EvidenceBundle | None,
+    report_bundle_id: Optional[str],
+    report_count: int,
+    report_digests: Sequence[str],
+    model_result: ArchitectModelResult | None,
+    allocation_receipt_id: Optional[str],
+    allocation_digest: Optional[str],
+    cycle_id: str,
+    decision_reasons: Sequence[str],
+    rejection_reasons: Sequence[str],
+    queue_candidate: ArchitectQueueCandidate | None = None,
+    determination_receipt_id: Optional[str] = None,
+) -> ArchitectDeterminationReceipt:
+    payload = {
+        "schema_version": ARCHITECT_DETERMINATION_SCHEMA_VERSION,
+        "accepted": accepted,
+        "action": action,
+        "next_slice_name": next_slice_name,
+        "summary": summary,
+        "cycle_id": cycle_id,
+        "snapshot_receipt_id": snapshot.snapshot_receipt_id if snapshot else None,
+        "context_view_id": context_view.context_view_id if context_view else None,
+        "evidence_bundle_id": evidence_bundle.evidence_bundle_id if evidence_bundle else None,
+        "report_bundle_id": report_bundle_id,
+        "report_count": report_count,
+        "audit_report_digests": tuple(report_digests),
+        "model_result_digest": model_result.model_result_digest if model_result else None,
+        "model_receipt_id": model_result.model_receipt_id if model_result else None,
+        "fusion_quorum_passed": _fusion_quorum_passed(model_result.review_packet) if model_result else False,
+        "wsp15_allocation_receipt_id": allocation_receipt_id,
+        "wsp15_allocation_digest": allocation_digest,
+        "queue_candidate_id": queue_candidate.queue_candidate_id if queue_candidate else None,
+        "decision_reasons": tuple(decision_reasons),
+        "rejection_reasons": tuple(rejection_reasons),
+    }
+    receipt_id = determination_receipt_id or _digest(payload)
+    return ArchitectDeterminationReceipt(
+        schema_version=ARCHITECT_DETERMINATION_SCHEMA_VERSION,
+        determination_receipt_id=receipt_id,
+        cycle_id=cycle_id,
+        accepted=accepted,
+        status=ARCHITECT_DETERMINATION_ACCEPT if accepted else ARCHITECT_DETERMINATION_REJECT,
+        action=action,
+        next_slice_name=next_slice_name,
+        summary=summary,
+        snapshot_receipt_id=snapshot.snapshot_receipt_id if snapshot else None,
+        snapshot_content_digest=snapshot.snapshot_content_digest if snapshot else None,
+        context_view_id=context_view.context_view_id if context_view else None,
+        evidence_bundle_id=evidence_bundle.evidence_bundle_id if evidence_bundle else None,
+        report_bundle_id=report_bundle_id,
+        report_count=report_count,
+        audit_report_digests=tuple(report_digests),
+        model_result_digest=model_result.model_result_digest if model_result else None,
+        model_receipt_id=model_result.model_receipt_id if model_result else None,
+        fusion_quorum_passed=_fusion_quorum_passed(model_result.review_packet) if model_result else False,
+        wsp15_allocation_receipt_id=allocation_receipt_id,
+        wsp15_allocation_digest=allocation_digest,
+        queue_candidate=queue_candidate,
+        decision_reasons=tuple(decision_reasons),
+        rejection_reasons=tuple(rejection_reasons),
+    )
+
+
+def _persist_receipt(
+    receipt: ArchitectDeterminationReceipt,
+    *,
+    writer: ArchitectDeterminationStore,
+    now_iso: str,
+) -> ArchitectDeterminationPersistResult:
+    if not receipt.accepted:
+        return _persist_rejected(receipt)
+    record = ArchitectDeterminationRecord(
+        determination_receipt_id=receipt.determination_receipt_id,
+        cycle_id=receipt.cycle_id,
+        action=receipt.action,
+        next_slice_name=receipt.next_slice_name,
+        determination=receipt.to_dict(),
+        stored_at=now_iso,
+    )
+    try:
+        write = writer.store_architect_determination(record)
+    except Exception:
+        write = {"ok": False, "reason": "store_exception"}
+    if not isinstance(write, Mapping) or write.get("ok") is not True:
+        return ArchitectDeterminationPersistResult(
+            accepted=False,
+            status=ARCHITECT_DETERMINATION_REJECT,
+            determination_receipt_id=receipt.determination_receipt_id,
+            cycle_id=receipt.cycle_id,
+            stored=False,
+            idempotent=False,
+            rejection_reasons=(ArchitectDeterminationReason.STORE_REJECTED,),
+        )
+    return ArchitectDeterminationPersistResult(
+        accepted=True,
+        status=ARCHITECT_DETERMINATION_ACCEPT,
+        determination_receipt_id=receipt.determination_receipt_id,
+        cycle_id=receipt.cycle_id,
+        stored=bool(write.get("stored")),
+        idempotent=bool(write.get("idempotent")),
+        rejection_reasons=(),
+    )
+
+
+def _persist_rejected(receipt: ArchitectDeterminationReceipt) -> ArchitectDeterminationPersistResult:
+    return ArchitectDeterminationPersistResult(
+        accepted=False,
+        status=ARCHITECT_DETERMINATION_REJECT,
+        determination_receipt_id=receipt.determination_receipt_id,
+        cycle_id=receipt.cycle_id,
+        stored=False,
+        idempotent=False,
+        rejection_reasons=receipt.rejection_reasons,
+    )
+
+
+def _result(
+    *,
+    receipt: ArchitectDeterminationReceipt,
+    persist_result: ArchitectDeterminationPersistResult,
+) -> BackendArchitectDeterminationResult:
+    accepted = receipt.accepted and persist_result.accepted
+    reasons = receipt.rejection_reasons or persist_result.rejection_reasons
+    return BackendArchitectDeterminationResult(
+        accepted=accepted,
+        status=ARCHITECT_DETERMINATION_ACCEPT if accepted else ARCHITECT_DETERMINATION_REJECT,
+        receipt=receipt,
+        persist_result=persist_result,
+        queue_candidate_count=1 if receipt.queue_candidate else 0,
+        rejection_reasons=tuple(reasons),
+    )
+
+
+def _model_result_reject(reason: str) -> ArchitectModelResult:
+    normalized = str(reason or ArchitectDeterminationReason.MODEL_FAILURE)
+    return ArchitectModelResult(
+        ok=False,
+        status="MODEL_REJECT",
+        content="",
+        model_receipt_id=None,
+        model_result_digest=_digest({"ok": False, "reason": normalized}),
+        review_packet={},
+        made_network_call=False,
+        rejection_reasons=(normalized,),
+    )
+
+
+def _cycle_id(
+    *,
+    snapshot: OperationalContextSnapshot | None,
+    report_bundle_id: Optional[str],
+    report_digests: Sequence[str],
+    wsp15_allocation_digest: Optional[str],
+) -> Optional[str]:
+    if snapshot is None or not report_bundle_id or not wsp15_allocation_digest:
+        return None
+    return _digest(
+        {
+            "snapshot_receipt_id": snapshot.snapshot_receipt_id,
+            "snapshot_content_digest": snapshot.snapshot_content_digest,
+            "report_bundle_id": report_bundle_id,
+            "report_digests": tuple(report_digests),
+            "wsp15_allocation_digest": wsp15_allocation_digest,
+        }
+    )
+
+
+def _report_bundle_id(collection: ReadOnlyAuditReportCollectionResult | None) -> Optional[str]:
+    if not collection or not collection.validation or not collection.validation.bundle:
+        return None
+    return collection.validation.bundle.bundle_id
+
+
+def _report_count(collection: ReadOnlyAuditReportCollectionResult | None) -> int:
+    return int(collection.report_count) if collection else 0
+
+
+def _report_digests(reports: Sequence[Mapping[str, Any]]) -> tuple[str, ...]:
+    digests = []
+    for report in reports:
+        if isinstance(report, Mapping):
+            digest = str(report.get("report_digest") or "").strip()
+            digests.append(digest or _digest(report))
+    return tuple(sorted(digests))
+
+
+def _all_report_evidence_refs(reports: Sequence[Mapping[str, Any]]) -> tuple[str, ...]:
+    refs: list[str] = []
+    for report in reports:
+        if isinstance(report, Mapping):
+            refs.extend(_normalize_text_list(report.get("evidence_refs")))
+    return tuple(dict.fromkeys(refs))
+
+
+def _normalize_text_list(value: Any) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        return ()
+    return tuple(dict.fromkeys(str(item).strip() for item in value if str(item).strip()))
+
+
+def _dedupe(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(str(value) for value in values if str(value).strip()))
+
+
+def _valid_slice_name(value: str) -> bool:
+    text = str(value or "").strip()
+    return bool(text) and text == text.upper() and all(ch.isalnum() or ch == "_" for ch in text)
+
+
+def _snapshot_expired(valid_until: str, now_iso: str) -> bool:
+    try:
+        valid = datetime.fromisoformat(str(valid_until))
+        now = datetime.fromisoformat(str(now_iso))
+    except ValueError:
+        return True
+    if valid.tzinfo is None:
+        valid = valid.replace(tzinfo=timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    return valid <= now
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def _digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "ACTION_FIX",
+    "ACTION_RESEARCH_MORE",
+    "ACTION_REVISE",
+    "ACTION_STOP",
+    "ALLOWED_ACTIONS",
+    "ARCHITECT_DETERMINATION_ACCEPT",
+    "ARCHITECT_DETERMINATION_REJECT",
+    "ARCHITECT_DETERMINATION_SCHEMA_VERSION",
+    "ArchitectDeterminationPersistResult",
+    "ArchitectDeterminationReason",
+    "ArchitectDeterminationReceipt",
+    "ArchitectDeterminationStore",
+    "ArchitectModelResult",
+    "ArchitectModelRunner",
+    "ArchitectQueueCandidate",
+    "AgentDbArchitectDeterminationStore",
+    "BackendArchitectDeterminationResult",
+    "ENV_ARCHITECT_RUNTIME_MODE",
+    "FoundupsFusionArchitectModelRunner",
+    "InMemoryArchitectDeterminationStore",
+    "RUNTIME_MODE_FOUNDUPS_FUSION",
+    "run_reddog_backend_architect_determination_runtime",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
@@ -48,6 +48,13 @@ from modules.communication.moltbot_bridge.src.reddog_readonly_audit_decision_per
     ReadOnlyAuditDecisionStore,
     persist_reddog_readonly_audit_decision,
 )
+from modules.communication.moltbot_bridge.src.reddog_backend_architect_determination_runtime import (
+    AgentDbArchitectDeterminationStore,
+    ArchitectDeterminationStore,
+    ArchitectModelRunner,
+    BackendArchitectDeterminationResult,
+    run_reddog_backend_architect_determination_runtime,
+)
 from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
     EvidenceBundle,
     OperationalContextSnapshot,
@@ -110,6 +117,14 @@ class RedDogMainReadonlyBootstrapResult:
     readonly_audit_decision_persist_status: Optional[str] = None
     readonly_audit_decision_persist_stored: bool = False
     readonly_audit_decision_persist_rejection_reasons: tuple[str, ...] = ()
+    backend_architect_determination_attempted: bool = False
+    backend_architect_determination_status: Optional[str] = None
+    backend_architect_determination_action: Optional[str] = None
+    backend_architect_determination_id: Optional[str] = None
+    backend_architect_determination_next_slice: Optional[str] = None
+    backend_architect_determination_queue_candidate_count: int = 0
+    backend_architect_determination_persist_stored: bool = False
+    backend_architect_determination_rejection_reasons: tuple[str, ...] = ()
     enqueue_attempted: bool = False
     enqueue_decision: Optional[str] = None
     enqueue_receipt_id: Optional[str] = None
@@ -149,6 +164,9 @@ def run_reddog_main_readonly_operational_bootstrap(
     report_store: ReadOnlyAuditReportStore | None = None,
     persist_readonly_audit_decision: bool = False,
     decision_store: ReadOnlyAuditDecisionStore | None = None,
+    run_backend_architect_determination: bool = False,
+    architect_model_runner: ArchitectModelRunner | None = None,
+    architect_determination_store: ArchitectDeterminationStore | None = None,
 ) -> RedDogMainReadonlyBootstrapResult:
     """Build a read-only startup plan or explain why it is not ready."""
 
@@ -266,6 +284,7 @@ def run_reddog_main_readonly_operational_bootstrap(
     collection_result: ReadOnlyAuditReportCollectionResult | None = None
     decision_result: ReadOnlyAuditDecisionReceipt | None = None
     decision_persist_result: ReadOnlyAuditDecisionPersistResult | None = None
+    architect_result: BackendArchitectDeterminationResult | None = None
     if collect_readonly_audit_reports:
         reader = report_store if report_store is not None else AgentDbReadOnlyAuditReportStore()
         collection_result = collect_reddog_readonly_audit_report_bundle(
@@ -327,6 +346,43 @@ def run_reddog_main_readonly_operational_bootstrap(
                         collection_result=collection_result,
                         decision_result=decision_result,
                         decision_persist_result=decision_persist_result,
+                        architect_result=architect_result,
+                    )
+            if run_backend_architect_determination:
+                architect_store = (
+                    architect_determination_store
+                    if architect_determination_store is not None
+                    else AgentDbArchitectDeterminationStore()
+                )
+                architect_result = run_reddog_backend_architect_determination_runtime(
+                    snapshot=snapshot,
+                    context_view=context_view,
+                    evidence_bundle=evidence_bundle,
+                    fusion_gate=gate,
+                    report_collection=collection_result,
+                    reports=decision_reports,
+                    wsp15_allocation_receipt=wsp15_allocation_receipt,
+                    store=architect_store,
+                    model_runner=architect_model_runner,
+                    now_iso=now_iso,
+                )
+                if not architect_result.accepted:
+                    return _not_ready(
+                        reasons=(
+                            "backend_architect_determination_rejected",
+                            *architect_result.rejection_reasons,
+                        ),
+                        changed_paths=paths,
+                        allowed_read_targets=targets,
+                        wsp15_allocation_receipt=wsp15_allocation_receipt,
+                        snapshot=snapshot,
+                        evidence_bundle=evidence_bundle,
+                        gate=gate,
+                        swarm_plan=plan,
+                        collection_result=collection_result,
+                        decision_result=decision_result,
+                        decision_persist_result=decision_persist_result,
+                        architect_result=architect_result,
                     )
             return _ready(
                 snapshot=snapshot,
@@ -340,6 +396,7 @@ def run_reddog_main_readonly_operational_bootstrap(
                 collection_result=collection_result,
                 decision_result=decision_result,
                 decision_persist_result=decision_persist_result,
+                architect_result=architect_result,
                 enqueue_result=None,
                 enqueue_attempted=False,
             )
@@ -356,6 +413,7 @@ def run_reddog_main_readonly_operational_bootstrap(
                 collection_result=collection_result,
                 decision_result=decision_result,
                 decision_persist_result=decision_persist_result,
+                architect_result=architect_result,
             )
 
     enqueue_result: ReadOnlyAuditSwarmEnqueueResult | None = None
@@ -379,6 +437,7 @@ def run_reddog_main_readonly_operational_bootstrap(
                 collection_result=collection_result,
                 decision_result=decision_result,
                 decision_persist_result=decision_persist_result,
+                architect_result=architect_result,
                 enqueue_result=enqueue_result,
             )
 
@@ -394,6 +453,7 @@ def run_reddog_main_readonly_operational_bootstrap(
         collection_result=collection_result,
         decision_result=decision_result,
         decision_persist_result=decision_persist_result,
+        architect_result=architect_result,
         enqueue_result=enqueue_result,
         enqueue_attempted=enqueue_readonly_audit_tasks,
     )
@@ -412,6 +472,7 @@ def _ready(
     collection_result: ReadOnlyAuditReportCollectionResult | None,
     decision_result: ReadOnlyAuditDecisionReceipt | None,
     decision_persist_result: ReadOnlyAuditDecisionPersistResult | None,
+    architect_result: BackendArchitectDeterminationResult | None,
     enqueue_result: ReadOnlyAuditSwarmEnqueueResult | None,
     enqueue_attempted: bool,
 ) -> RedDogMainReadonlyBootstrapResult:
@@ -448,6 +509,24 @@ def _ready(
         readonly_audit_decision_persist_rejection_reasons=(
             decision_persist_result.rejection_reasons if decision_persist_result else ()
         ),
+        backend_architect_determination_attempted=architect_result is not None,
+        backend_architect_determination_status=architect_result.status if architect_result else None,
+        backend_architect_determination_action=architect_result.receipt.action if architect_result else None,
+        backend_architect_determination_id=(
+            architect_result.receipt.determination_receipt_id if architect_result else None
+        ),
+        backend_architect_determination_next_slice=(
+            architect_result.receipt.next_slice_name if architect_result else None
+        ),
+        backend_architect_determination_queue_candidate_count=(
+            architect_result.queue_candidate_count if architect_result else 0
+        ),
+        backend_architect_determination_persist_stored=(
+            architect_result.persist_result.stored if architect_result else False
+        ),
+        backend_architect_determination_rejection_reasons=(
+            architect_result.rejection_reasons if architect_result else ()
+        ),
         enqueue_attempted=enqueue_attempted,
         enqueue_decision=enqueue_result.decision if enqueue_result else None,
         enqueue_receipt_id=enqueue_result.receipt.enqueue_receipt_id if enqueue_result else None,
@@ -455,6 +534,9 @@ def _ready(
         enqueue_rejection_reasons=enqueue_result.rejection_reasons if enqueue_result else (),
         no_openclaw_enqueue_performed=not bool(enqueue_result and enqueue_result.accepted),
         no_queue_mutation_performed=not bool(enqueue_result and enqueue_result.accepted),
+        no_model_call_performed=not bool(
+            architect_result and architect_result.receipt.model_result_digest
+        ),
     )
 
 
@@ -502,6 +584,7 @@ def _not_ready(
     collection_result: ReadOnlyAuditReportCollectionResult | None = None,
     decision_result: ReadOnlyAuditDecisionReceipt | None = None,
     decision_persist_result: ReadOnlyAuditDecisionPersistResult | None = None,
+    architect_result: BackendArchitectDeterminationResult | None = None,
     enqueue_result: ReadOnlyAuditSwarmEnqueueResult | None = None,
 ) -> RedDogMainReadonlyBootstrapResult:
     determination_id = None
@@ -542,11 +625,32 @@ def _not_ready(
         readonly_audit_decision_persist_rejection_reasons=(
             decision_persist_result.rejection_reasons if decision_persist_result else ()
         ),
+        backend_architect_determination_attempted=architect_result is not None,
+        backend_architect_determination_status=architect_result.status if architect_result else None,
+        backend_architect_determination_action=architect_result.receipt.action if architect_result else None,
+        backend_architect_determination_id=(
+            architect_result.receipt.determination_receipt_id if architect_result else None
+        ),
+        backend_architect_determination_next_slice=(
+            architect_result.receipt.next_slice_name if architect_result else None
+        ),
+        backend_architect_determination_queue_candidate_count=(
+            architect_result.queue_candidate_count if architect_result else 0
+        ),
+        backend_architect_determination_persist_stored=(
+            architect_result.persist_result.stored if architect_result else False
+        ),
+        backend_architect_determination_rejection_reasons=(
+            architect_result.rejection_reasons if architect_result else ()
+        ),
         enqueue_attempted=enqueue_result is not None,
         enqueue_decision=enqueue_result.decision if enqueue_result else None,
         enqueue_receipt_id=enqueue_result.receipt.enqueue_receipt_id if enqueue_result else None,
         enqueue_task_count=len(enqueue_result.tasks) if enqueue_result and enqueue_result.accepted else 0,
         enqueue_rejection_reasons=enqueue_result.rejection_reasons if enqueue_result else (),
+        no_model_call_performed=not bool(
+            architect_result and architect_result.receipt.model_result_digest
+        ),
     )
 
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_backend_architect_determination_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_backend_architect_determination_runtime.py
@@ -1,0 +1,505 @@
+"""Tests for REDDOG_BACKEND_ARCHITECT_DETERMINATION_RUNTIME_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from holo_index.freshness_receipt import CollectionFreshness, HoloIndexFreshnessReceipt
+from modules.communication.moltbot_bridge.src.reddog_backend_architect_determination_runtime import (
+    ACTION_FIX,
+    ACTION_RESEARCH_MORE,
+    ARCHITECT_DETERMINATION_ACCEPT,
+    ARCHITECT_DETERMINATION_REJECT,
+    ArchitectDeterminationReason,
+    ArchitectModelResult,
+    FoundupsFusionArchitectModelRunner,
+    InMemoryArchitectDeterminationStore,
+    run_reddog_backend_architect_determination_runtime,
+)
+from modules.communication.moltbot_bridge.src.reddog_context_snapshot_fusion_assignment_gate import (
+    evaluate_context_snapshot_fusion_assignment_gate,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_runtime import (
+    DEFAULT_AUDIT_LANES,
+    READONLY_AUDIT_REPORTS_ACCEPTED,
+    validate_reddog_openclaw_readonly_audit_reports,
+    plan_reddog_openclaw_readonly_audit_swarm,
+)
+from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
+    build_evidence_bundle,
+    build_operational_context_snapshot,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_report_collection import (
+    READONLY_AUDIT_REPORT_COLLECTION_ACCEPT,
+    ReadOnlyAuditReportCollectionResult,
+)
+from modules.communication.moltbot_bridge.src.reddog_wsp15_allocation_receipt import (
+    allocate_reddog_wsp15_receipt,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_backend_architect_determination_runtime.py"
+)
+NOW = "2026-07-15T00:00:00+00:00"
+HEAD = "283d07ae4c7ed7bd1c8d9f9c7a112fd75ef00aaa"
+REVISION = "sha256:authoritative-work-state"
+
+
+class FakeArchitectRunner:
+    def __init__(
+        self,
+        output: Mapping[str, Any] | str,
+        *,
+        ok: bool = True,
+        quorum: bool = True,
+        raise_timeout: bool = False,
+    ) -> None:
+        self.output = output
+        self.ok = ok
+        self.quorum = quorum
+        self.raise_timeout = raise_timeout
+        self.calls: list[dict[str, Any]] = []
+
+    def run_architect_determination(self, *, prompt: str, context: str, binding: Mapping[str, Any], timeout_seconds: int):
+        self.calls.append(
+            {
+                "prompt": prompt,
+                "context": context,
+                "binding": dict(binding),
+                "timeout_seconds": timeout_seconds,
+            }
+        )
+        if self.raise_timeout:
+            raise TimeoutError("model timeout")
+        content = self.output if isinstance(self.output, str) else json.dumps(self.output, sort_keys=True)
+        return ArchitectModelResult(
+            ok=self.ok,
+            status="MODEL_OK" if self.ok else "MODEL_REJECT",
+            content=content,
+            model_receipt_id="model-receipt-1",
+            model_result_digest="sha256:model-result",
+            review_packet={"fusion_panel_quorum": {"passed": self.quorum}},
+            made_network_call=True,
+            rejection_reasons=() if self.ok else ("model_failed",),
+        )
+
+
+def _repo_state() -> dict[str, object]:
+    return {
+        "head_sha": HEAD,
+        "dirty_paths": (),
+        "dirty_digest": "sha256:clean",
+        "worktree_digest": "sha256:worktrees",
+    }
+
+
+def _work_state() -> dict[str, object]:
+    return {
+        "schema_version": "reddog_authoritative_work_state.v1",
+        "revision": REVISION,
+        "selected_slice": "REDDOG_BACKEND_ARCHITECT_DETERMINATION_RUNTIME_PHASE1",
+        "refresh_receipt_id": "sha256:refresh",
+        "worker_claims": [
+            {"claim_id": "claim-1", "slice_id": "REDDOG_BACKEND_ARCHITECT_DETERMINATION_RUNTIME_PHASE1"}
+        ],
+        "wre_queue_items": [{"queue_item_id": "queue-1", "claim_id": "claim-1"}],
+    }
+
+
+def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
+    return HoloIndexFreshnessReceipt(
+        schema_version="holoindex_freshness_receipt.v1",
+        generated_at=NOW,
+        repo_root=str(REPO_ROOT),
+        repo_head_sha=HEAD,
+        ssd_path="E:/HoloIndex",
+        source="ci_targeted_reindex",
+        collections=[
+            CollectionFreshness(
+                name="navigation_work_ledger",
+                count=4,
+                status="indexed",
+                source="ci_targeted_reindex",
+                repo_head_sha=HEAD,
+                last_indexed_at=NOW,
+            ),
+            CollectionFreshness(
+                name="navigation_symbols",
+                count=9,
+                status="indexed",
+                source="ci_targeted_reindex",
+                repo_head_sha=HEAD,
+                last_indexed_at=NOW,
+            ),
+        ],
+    )
+
+
+def _build_inputs(*, include_reports: bool = True):
+    snapshot_result = build_operational_context_snapshot(
+        repo_state=_repo_state(),
+        work_state_snapshot=_work_state(),
+        holoindex_receipt=_fresh_holo_receipt(),
+        changed_paths=("modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py",),
+        now_iso=NOW,
+        breadcrumb_scope="REDDOG_BACKEND_ARCHITECT_DETERMINATION_RUNTIME_PHASE1",
+    )
+    assert snapshot_result.accepted is True
+    snapshot = snapshot_result.snapshot
+    context_view = snapshot_result.context_view
+    assert snapshot is not None and context_view is not None
+    evidence_bundle = build_evidence_bundle(
+        snapshot=snapshot,
+        context_view=context_view,
+        report_digests=("sha256:source-receipts",),
+    )
+    fusion_gate = evaluate_context_snapshot_fusion_assignment_gate(
+        snapshot=snapshot,
+        context_view=context_view,
+        evidence_bundle=evidence_bundle,
+        current_repo_head_sha=HEAD,
+        current_work_state_revision=REVISION,
+        requested_operation="backend_architect_determination",
+        prompt_text="Produce backend architect determination",
+        now_iso=NOW,
+    )
+    assert fusion_gate.accepted is True
+    plan = plan_reddog_openclaw_readonly_audit_swarm(
+        snapshot=snapshot,
+        context_view=context_view,
+        evidence_bundle=evidence_bundle,
+        gate_decision=fusion_gate,
+        audit_lanes=DEFAULT_AUDIT_LANES,
+        allowed_read_targets=("modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py",),
+    )
+    assert plan.accepted is True
+    reports = _reports(plan) if include_reports else ()
+    validation = validate_reddog_openclaw_readonly_audit_reports(plan=plan, reports=reports)
+    collection = ReadOnlyAuditReportCollectionResult(
+        accepted=validation.accepted,
+        status=READONLY_AUDIT_REPORT_COLLECTION_ACCEPT if validation.accepted else "REJECT",
+        swarm_id=plan.receipt.swarm_id,
+        report_count=len(reports),
+        validation=validation,
+        rejection_reasons=validation.rejection_reasons,
+    )
+    allocation = allocate_reddog_wsp15_receipt(
+        requested_operation="backend_architect_determination",
+        prompt_text="RedDog backend architect determination runtime",
+        changed_paths=("modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py",),
+        allowed_read_targets=("modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py",),
+    ).to_dict()
+    return {
+        "snapshot": snapshot,
+        "context_view": context_view,
+        "evidence_bundle": evidence_bundle,
+        "fusion_gate": fusion_gate,
+        "report_collection": collection,
+        "reports": reports,
+        "allocation": allocation,
+    }
+
+
+def _reports(plan) -> tuple[dict[str, Any], ...]:
+    reports: list[dict[str, Any]] = []
+    for assignment in plan.assignments:
+        evidence_ref = f"file:docs/{assignment.lane_id}.md:sha256:{assignment.lane_id}:lines:1"
+        reports.append(
+            {
+                "assignment_id": assignment.assignment_id,
+                "lane_id": assignment.lane_id,
+                "snapshot_receipt_id": assignment.snapshot_receipt_id,
+                "summary": f"{assignment.lane_id} report supports backend architect determination.",
+                "evidence_refs": [evidence_ref],
+                "repo_mutation_performed": False,
+                "execution_performed": False,
+                "openclaw_enqueue_performed": False,
+                "readonly_audit_performed": True,
+                "report_digest": f"sha256:{assignment.lane_id}",
+                "findings": [
+                    {
+                        "finding_id": f"{assignment.lane_id}-finding",
+                        "claim": "Backend architect runtime needs one next implementation slice.",
+                        "wsp97_label": "OBSERVED",
+                        "recommended_action": "FIX",
+                        "wsp15_priority": "P0",
+                        "severity": "MAJOR",
+                        "evidence_refs": [evidence_ref],
+                        "next_slice_name": "REDDOG_NEXT_RUNTIME_SLICE_PHASE1",
+                    }
+                ],
+            }
+        )
+    return tuple(reports)
+
+
+def _model_output(allocation: Mapping[str, Any], evidence_ref: str, *, action: str = ACTION_FIX) -> dict[str, Any]:
+    return {
+        "action": action,
+        "next_slice_name": "REDDOG_NEXT_RUNTIME_SLICE_PHASE1" if action != "STOP" else None,
+        "summary": "Verified reports support one next backend runtime slice.",
+        "decision_reasons": ["selected verified P0 runtime gap"],
+        "evidence_refs": [evidence_ref],
+        "wsp15_allocation_receipt_id": allocation["receipt_id"],
+    }
+
+
+def _runtime_kwargs(inputs: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "snapshot": inputs["snapshot"],
+        "context_view": inputs["context_view"],
+        "evidence_bundle": inputs["evidence_bundle"],
+        "fusion_gate": inputs["fusion_gate"],
+        "report_collection": inputs["report_collection"],
+        "reports": inputs["reports"],
+    }
+
+
+def test_backend_architect_runtime_accepts_fix_persists_and_emits_one_queue_candidate() -> None:
+    inputs = _build_inputs()
+    evidence_ref = inputs["reports"][0]["evidence_refs"][0]
+    store = InMemoryArchitectDeterminationStore()
+    runner = FakeArchitectRunner(_model_output(inputs["allocation"], evidence_ref))
+
+    result = run_reddog_backend_architect_determination_runtime(
+        **_runtime_kwargs(inputs),
+        wsp15_allocation_receipt=inputs["allocation"],
+        store=store,
+        model_runner=runner,
+        now_iso=NOW,
+    )
+
+    assert result.accepted is True
+    assert result.status == ARCHITECT_DETERMINATION_ACCEPT
+    assert result.receipt.action == ACTION_FIX
+    assert result.receipt.fusion_quorum_passed is True
+    assert result.receipt.wsp15_allocation_receipt_id == inputs["allocation"]["receipt_id"]
+    assert result.receipt.queue_candidate is not None
+    assert result.queue_candidate_count == 1
+    assert result.receipt.queue_candidate.slice_id == "REDDOG_NEXT_RUNTIME_SLICE_PHASE1"
+    assert result.receipt.queue_candidate.status == "CANDIDATE"
+    assert result.persist_result.accepted is True
+    assert result.persist_result.stored is True
+    assert len(store.records) == 1
+    assert len(runner.calls) == 1
+    assert result.no_repo_mutation_performed is True
+    assert result.no_openclaw_enqueue_performed is True
+    assert result.no_hermes_dispatch_performed is True
+    assert result.no_holoindex_reindex_performed is True
+
+
+def test_research_more_persists_without_queue_candidate() -> None:
+    inputs = _build_inputs()
+    evidence_ref = inputs["reports"][0]["evidence_refs"][0]
+    output = _model_output(inputs["allocation"], evidence_ref, action=ACTION_RESEARCH_MORE)
+    runner = FakeArchitectRunner(output)
+
+    result = run_reddog_backend_architect_determination_runtime(
+        **_runtime_kwargs(inputs),
+        wsp15_allocation_receipt=inputs["allocation"],
+        store=InMemoryArchitectDeterminationStore(),
+        model_runner=runner,
+        now_iso=NOW,
+    )
+
+    assert result.accepted is True
+    assert result.receipt.action == ACTION_RESEARCH_MORE
+    assert result.receipt.queue_candidate is None
+    assert result.queue_candidate_count == 0
+
+
+def test_missing_reports_fail_before_model_call() -> None:
+    inputs = _build_inputs(include_reports=False)
+    runner = FakeArchitectRunner({})
+
+    result = run_reddog_backend_architect_determination_runtime(
+        **_runtime_kwargs(inputs),
+        wsp15_allocation_receipt=inputs["allocation"],
+        store=InMemoryArchitectDeterminationStore(),
+        model_runner=runner,
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert result.status == ARCHITECT_DETERMINATION_REJECT
+    assert ArchitectDeterminationReason.REPORT_COLLECTION_NOT_ACCEPTED in result.rejection_reasons
+    assert ArchitectDeterminationReason.MISSING_AUDIT_REPORTS in result.rejection_reasons
+    assert runner.calls == []
+
+
+def test_failed_fusion_quorum_rejects_after_model_call() -> None:
+    inputs = _build_inputs()
+    evidence_ref = inputs["reports"][0]["evidence_refs"][0]
+    runner = FakeArchitectRunner(_model_output(inputs["allocation"], evidence_ref), quorum=False)
+
+    result = run_reddog_backend_architect_determination_runtime(
+        **_runtime_kwargs(inputs),
+        wsp15_allocation_receipt=inputs["allocation"],
+        store=InMemoryArchitectDeterminationStore(),
+        model_runner=runner,
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert ArchitectDeterminationReason.FUSION_QUORUM_NOT_PASSED in result.rejection_reasons
+    assert result.persist_result.stored is False
+
+
+def test_invented_evidence_ref_rejects_invalid_output() -> None:
+    inputs = _build_inputs()
+    output = _model_output(inputs["allocation"], "file:not-in-report.md:1")
+    runner = FakeArchitectRunner(output)
+
+    result = run_reddog_backend_architect_determination_runtime(
+        **_runtime_kwargs(inputs),
+        wsp15_allocation_receipt=inputs["allocation"],
+        store=InMemoryArchitectDeterminationStore(),
+        model_runner=runner,
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert ArchitectDeterminationReason.INVALID_MODEL_OUTPUT in result.rejection_reasons
+
+
+def test_wsp15_receipt_mismatch_rejects() -> None:
+    inputs = _build_inputs()
+    evidence_ref = inputs["reports"][0]["evidence_refs"][0]
+    output = _model_output(inputs["allocation"], evidence_ref)
+    output["wsp15_allocation_receipt_id"] = "sha256:not-the-allocation"
+    runner = FakeArchitectRunner(output)
+
+    result = run_reddog_backend_architect_determination_runtime(
+        **_runtime_kwargs(inputs),
+        wsp15_allocation_receipt=inputs["allocation"],
+        store=InMemoryArchitectDeterminationStore(),
+        model_runner=runner,
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert ArchitectDeterminationReason.WSP15_RECEIPT_MISMATCH in result.rejection_reasons
+
+
+def test_duplicate_cycle_fails_closed_before_model_call() -> None:
+    inputs = _build_inputs()
+    evidence_ref = inputs["reports"][0]["evidence_refs"][0]
+    store = InMemoryArchitectDeterminationStore()
+
+    first = run_reddog_backend_architect_determination_runtime(
+        **_runtime_kwargs(inputs),
+        wsp15_allocation_receipt=inputs["allocation"],
+        store=store,
+        model_runner=FakeArchitectRunner(_model_output(inputs["allocation"], evidence_ref)),
+        now_iso=NOW,
+    )
+    assert first.accepted is True
+    second_runner = FakeArchitectRunner(_model_output(inputs["allocation"], evidence_ref))
+    second = run_reddog_backend_architect_determination_runtime(
+        **_runtime_kwargs(inputs),
+        wsp15_allocation_receipt=inputs["allocation"],
+        store=store,
+        model_runner=second_runner,
+        now_iso=NOW,
+    )
+
+    assert second.accepted is False
+    assert ArchitectDeterminationReason.DUPLICATE_CYCLE in second.rejection_reasons
+    assert second_runner.calls == []
+
+
+def test_expired_snapshot_fails_closed_before_model_call() -> None:
+    inputs = _build_inputs()
+    runner = FakeArchitectRunner({})
+
+    result = run_reddog_backend_architect_determination_runtime(
+        **_runtime_kwargs(inputs),
+        wsp15_allocation_receipt=inputs["allocation"],
+        store=InMemoryArchitectDeterminationStore(),
+        model_runner=runner,
+        now_iso="2026-07-15T01:00:00+00:00",
+    )
+
+    assert result.accepted is False
+    assert ArchitectDeterminationReason.SNAPSHOT_EXPIRED in result.rejection_reasons
+    assert runner.calls == []
+
+
+def test_model_timeout_rejects_without_persistence() -> None:
+    inputs = _build_inputs()
+    runner = FakeArchitectRunner({}, raise_timeout=True)
+
+    result = run_reddog_backend_architect_determination_runtime(
+        **_runtime_kwargs(inputs),
+        wsp15_allocation_receipt=inputs["allocation"],
+        store=InMemoryArchitectDeterminationStore(),
+        model_runner=runner,
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert ArchitectDeterminationReason.MODEL_TIMEOUT in result.rejection_reasons
+    assert result.persist_result.stored is False
+
+
+def test_model_failure_rejects_without_persistence() -> None:
+    inputs = _build_inputs()
+    evidence_ref = inputs["reports"][0]["evidence_refs"][0]
+    runner = FakeArchitectRunner(_model_output(inputs["allocation"], evidence_ref), ok=False)
+
+    result = run_reddog_backend_architect_determination_runtime(
+        **_runtime_kwargs(inputs),
+        wsp15_allocation_receipt=inputs["allocation"],
+        store=InMemoryArchitectDeterminationStore(),
+        model_runner=runner,
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert ArchitectDeterminationReason.MODEL_FAILURE in result.rejection_reasons
+    assert result.persist_result.stored is False
+
+
+def test_production_runner_is_explicit_mode_only_without_network(monkeypatch) -> None:
+    monkeypatch.delenv("REDDOG_BACKEND_ARCHITECT_RUNTIME_MODE", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    result = FoundupsFusionArchitectModelRunner().run_architect_determination(
+        prompt="Return JSON.",
+        context="{}",
+        binding={"binding": "test"},
+        timeout_seconds=1,
+    )
+
+    assert result.ok is False
+    assert result.made_network_call is False
+    assert result.rejection_reasons == ("runtime_mode_not_enabled",)
+
+
+def test_module_ast_denies_execution_and_mutation_surfaces() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_imports = {"subprocess", "shutil"}
+    banned_attrs = {
+        ("os", "system"),
+        ("os", "popen"),
+        ("os", "spawn"),
+        ("os", "replace"),
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name not in banned_imports
+        if isinstance(node, ast.ImportFrom):
+            assert (node.module or "").split(".")[0] not in banned_imports
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+            assert (node.value.id, node.attr) not in banned_attrs

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -37,6 +37,11 @@ from modules.communication.moltbot_bridge.src.reddog_readonly_audit_decision_run
     ACTION_RESEARCH_MORE,
     DEFAULT_SEMANTIC_FINDINGS_SLICE,
 )
+from modules.communication.moltbot_bridge.src.reddog_backend_architect_determination_runtime import (
+    ARCHITECT_DETERMINATION_ACCEPT,
+    ArchitectModelResult,
+    InMemoryArchitectDeterminationStore,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -144,6 +149,41 @@ class _FakeDecisionStore:
 
     def load_readonly_audit_decision(self, decision_id: str):
         return None
+
+
+class _FakeArchitectRunner:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def run_architect_determination(self, *, prompt: str, context: str, binding, timeout_seconds: int):
+        self.calls.append(
+            {
+                "prompt": prompt,
+                "context": context,
+                "binding": dict(binding),
+                "timeout_seconds": timeout_seconds,
+            }
+        )
+        prompt_payload = json.loads(prompt)
+        evidence_ref = prompt_payload["reports"][0]["evidence_refs"][0]
+        content = {
+            "action": ACTION_FIX,
+            "next_slice_name": "REDDOG_RUNTIME_RECONCILER_PHASE1",
+            "summary": "Collected read-only reports support one backend runtime fix.",
+            "decision_reasons": ["selected verified runtime reconciler gap"],
+            "evidence_refs": [evidence_ref],
+            "wsp15_allocation_receipt_id": prompt_payload["wsp15_allocation_receipt_id"],
+        }
+        return ArchitectModelResult(
+            ok=True,
+            status="MODEL_OK",
+            content=json.dumps(content, sort_keys=True),
+            model_receipt_id="model-receipt-bootstrap",
+            model_result_digest="sha256:model-result-bootstrap",
+            review_packet={"fusion_panel_quorum": {"passed": True}},
+            made_network_call=True,
+            rejection_reasons=(),
+        )
 
 
 def _reports_for_bootstrap_result(
@@ -323,6 +363,47 @@ def test_bootstrap_persists_accepted_next_action_decision_when_enabled() -> None
     assert result.readonly_audit_decision_persist_rejection_reasons == ()
     assert len(decision_store.records) == 1
     assert decision_store.records[0].action == ACTION_FIX
+
+
+def test_bootstrap_runs_backend_architect_determination_when_enabled() -> None:
+    baseline = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+    )
+    report_store = _FakeReportStore(_reports_for_bootstrap_result(baseline, include_findings=True))
+    architect_store = InMemoryArchitectDeterminationStore()
+    architect_runner = _FakeArchitectRunner()
+
+    result = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+        collect_readonly_audit_reports=True,
+        report_store=report_store,
+        run_backend_architect_determination=True,
+        architect_model_runner=architect_runner,
+        architect_determination_store=architect_store,
+    )
+
+    assert result.ready is True
+    assert result.backend_architect_determination_attempted is True
+    assert result.backend_architect_determination_status == ARCHITECT_DETERMINATION_ACCEPT
+    assert result.backend_architect_determination_action == ACTION_FIX
+    assert result.backend_architect_determination_next_slice == "REDDOG_RUNTIME_RECONCILER_PHASE1"
+    assert result.backend_architect_determination_id
+    assert result.backend_architect_determination_queue_candidate_count == 1
+    assert result.backend_architect_determination_persist_stored is True
+    assert result.backend_architect_determination_rejection_reasons == ()
+    assert result.no_model_call_performed is False
+    assert len(architect_runner.calls) == 1
+    assert len(architect_store.records) == 1
+    assert result.no_openclaw_enqueue_performed is True
+    assert result.no_queue_mutation_performed is True
 
 
 def test_bootstrap_fails_closed_when_decision_persistence_rejects() -> None:


### PR DESCRIPTION
## Summary

Implements `REDDOG_BACKEND_ARCHITECT_DETERMINATION_RUNTIME_PHASE1` as real backend runtime code.

- Adds `reddog_backend_architect_determination_runtime.py`.
- Consumes accepted operational snapshot, collected read-only audit reports, Fusion assignment gate, and canonical WSP_15 allocation receipt.
- Calls an explicit RedDog/Fusion architect model runner; tests inject a deterministic runner, production runner uses the existing redaction-gated `scripts/advisory_model_once` Fusion path only when explicitly configured.
- Validates strict `FIX | RESEARCH_MORE | REVISE | STOP` JSON output, Fusion quorum, evidence refs, and WSP_15 receipt binding.
- Persists `ArchitectDeterminationReceipt` and emits at most one candidate queue item for `FIX`.
- Adds explicit opt-in bootstrap wiring; default `main.py` read-only bootstrap behavior remains unchanged.

## WSP_97 Truth Boundary

OBSERVED:
- Runtime can produce, persist, and queue-candidate one backend architect determination with an injected runner.
- Production adapter is concrete and callable through explicit configured runtime mode.
- Duplicate cycle fails closed before model invocation.
- Missing reports, stale snapshot, invalid output, failed quorum, WSP_15 mismatch, model timeout/failure all reject.

NO:
- No coding worker spawn.
- No shell command.
- No worktree operation.
- No repo mutation.
- No OpenClaw enqueue.
- No Hermes dispatch.
- No PR creation.
- No PatternMemory promotion.
- No HoloIndex re-index.

## Validation

```text
pytest modules/communication/moltbot_bridge/tests/test_reddog_backend_architect_determination_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py -q --tb=short
34 passed

pytest modules/communication/moltbot_bridge/tests -q --tb=short -k "backend_architect or readonly_operational or resident_queue or wre_queue_authority or signed_authority or wsp15"
312 passed, 2743 deselected

python -m py_compile modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
passed

git diff --check
clean (only LF -> CRLF warnings)

ASCII/NUL scan
new files: 0 non-ASCII, 0 NUL
tracked diff additions: 0 non-ASCII, 0 NUL
```

## HoloIndex

Read-only probe for `RedDog backend architect determination runtime` returned adjacent assets but not the new runtime seam. Recorded as:

```text
HOLOINDEX_REDDOG_BACKEND_ARCHITECT_DETERMINATION_RUNTIME_INDEX_GAP_PHASE1
```

No runtime re-index was performed.

## Sequence Boundary

This PR stops after one real backend RedDog determination can be produced, persisted, and translated into one candidate queue item. The next slice remains the first actual OpenClaw-launched read-only 0102 audit worker.
