### PR TITLE
fix(holoindex): require collection freshness manifests

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,29 @@
 # HoloIndex Package ModLog
 
+## [2026-07-16] HOLOINDEX_COLLECTION_FRESHNESS_TRUTH_REPAIR_PHASE1
+
+**Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice
+**WSP**: 00, 15, 22, 50, 97
+
+- UPDATE `holo_index/freshness_receipt.py`: freshness receipts now carry
+  generation-bound per-collection manifest proof instead of treating nonzero
+  collection counts as authoritative freshness. Each collection records source
+  manifest digest, indexed-path digest, removed-path digest, embedding backend,
+  and verification status.
+- UPDATE `evaluate_freshness_for_paths`: write-sensitive freshness checks now
+  reject legacy/count-only receipts, missing generation IDs, missing collection
+  manifests, missing indexed-path digests, and non-PASS collection verification.
+- TEST `tests/test_holoindex_freshness_receipt.py`: regression coverage for
+  count-only overclaim rejection, legacy receipt rejection, generation ID
+  changes when collection manifests change, and code-only refreshes that cannot
+  mark Skillz fresh without a Skillz manifest.
+- TEST `tests/test_holoindex_ci_freshness_gate.py` and
+  `tests/test_holoindex_ci_main_freshness_gate.py`: CI fixtures upgraded to the
+  new receipt proof contract while preserving read-only/no-reindex guarantees.
+- Boundary: no HoloIndex re-index, no semantic-store mutation, no RedDog runtime
+  write path, no WRE enqueue. This repair changes receipt truth and validation
+  only.
+
 ## [2026-07-14] HOLOINDEX_CI_MAIN_FRESHNESS_GATE_PHASE1
 
 **Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice

--- a/holo_index/freshness_receipt.py
+++ b/holo_index/freshness_receipt.py
@@ -6,6 +6,7 @@ collection entries fail closed for write-sensitive RedDog/WRE gates.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -41,6 +42,12 @@ class CollectionFreshness:
     source: str
     repo_head_sha: str
     last_indexed_at: str
+    source_manifest_digest: str = ""
+    indexed_paths_digest: str = ""
+    removed_paths_digest: str = ""
+    schema_version: str = "holoindex_collection_freshness.v1"
+    embedding_backend: str = ""
+    verification: str = "UNKNOWN"
 
 
 @dataclass(frozen=True)
@@ -53,6 +60,8 @@ class HoloIndexFreshnessReceipt:
     repo_head_sha: str
     ssd_path: str
     source: str
+    generation_id: str = ""
+    base_generation_id: str = ""
     collections: list[CollectionFreshness] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
@@ -98,6 +107,93 @@ def _collection_status(collection: Any, count: int) -> str:
     if count <= 0:
         return "empty"
     return "indexed"
+
+
+def _digest(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _metadata_path(metadata: Any) -> str:
+    if not isinstance(metadata, Mapping):
+        return ""
+    for key in ("path", "file_path", "filepath", "source_path", "source"):
+        value = metadata.get(key)
+        if isinstance(value, str) and value.strip():
+            return _norm_path(value)
+    return ""
+
+
+def _collection_snapshot_manifest(
+    collection: Any,
+    *,
+    name: str,
+    count: int,
+) -> dict[str, str]:
+    """Return deterministic per-collection proof fields.
+
+    A count-only collection handle is not enough evidence that a collection was
+    refreshed. Consumers that depend on freshness require this manifest proof.
+    """
+
+    if collection is None:
+        return {
+            "source_manifest_digest": "",
+            "indexed_paths_digest": "",
+            "removed_paths_digest": _digest([]),
+            "embedding_backend": "",
+            "verification": "MISSING",
+        }
+    if count <= 0:
+        return {
+            "source_manifest_digest": _digest({"collection": name, "ids": [], "paths": []}),
+            "indexed_paths_digest": _digest([]),
+            "removed_paths_digest": _digest([]),
+            "embedding_backend": "",
+            "verification": "EMPTY",
+        }
+
+    try:
+        snapshot = collection.get(include=["metadatas"])
+    except Exception:
+        return {
+            "source_manifest_digest": "",
+            "indexed_paths_digest": "",
+            "removed_paths_digest": _digest([]),
+            "embedding_backend": "",
+            "verification": "UNVERIFIED",
+        }
+
+    ids = snapshot.get("ids", []) if isinstance(snapshot, Mapping) else []
+    metadatas = snapshot.get("metadatas", []) if isinstance(snapshot, Mapping) else []
+    if not isinstance(ids, list):
+        ids = []
+    if not isinstance(metadatas, list):
+        metadatas = []
+
+    indexed_paths = sorted(
+        path for path in (_metadata_path(metadata) for metadata in metadatas) if path
+    )
+    source_manifest = {
+        "collection": name,
+        "count": count,
+        "ids": sorted(str(item) for item in ids),
+        "paths": indexed_paths,
+    }
+    metadata = getattr(collection, "metadata", None)
+    embedding_backend = ""
+    if isinstance(metadata, Mapping):
+        raw_backend = metadata.get("embedding_backend") or metadata.get("embedding_model")
+        if isinstance(raw_backend, str):
+            embedding_backend = raw_backend
+
+    return {
+        "source_manifest_digest": _digest(source_manifest),
+        "indexed_paths_digest": _digest(indexed_paths),
+        "removed_paths_digest": _digest([]),
+        "embedding_backend": embedding_backend,
+        "verification": "PASS" if ids else "UNVERIFIED",
+    }
 
 
 def _resolve_git_dir(repo_root: Path) -> Path | None:
@@ -179,6 +275,7 @@ def build_freshness_receipt(
                 except Exception:
                     collection = None
         count = _safe_count(collection)
+        manifest = _collection_snapshot_manifest(collection, name=name, count=count)
         collections.append(
             CollectionFreshness(
                 name=name,
@@ -187,8 +284,32 @@ def build_freshness_receipt(
                 source=source,
                 repo_head_sha=head_sha,
                 last_indexed_at=generated,
+                source_manifest_digest=manifest["source_manifest_digest"],
+                indexed_paths_digest=manifest["indexed_paths_digest"],
+                removed_paths_digest=manifest["removed_paths_digest"],
+                embedding_backend=manifest["embedding_backend"],
+                verification=manifest["verification"],
             )
         )
+
+    generation_id = _digest(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "repo_head_sha": head_sha,
+            "collections": [
+                {
+                    "name": entry.name,
+                    "count": entry.count,
+                    "status": entry.status,
+                    "source_manifest_digest": entry.source_manifest_digest,
+                    "indexed_paths_digest": entry.indexed_paths_digest,
+                    "removed_paths_digest": entry.removed_paths_digest,
+                    "verification": entry.verification,
+                }
+                for entry in collections
+            ],
+        }
+    )
 
     return HoloIndexFreshnessReceipt(
         schema_version=SCHEMA_VERSION,
@@ -197,6 +318,8 @@ def build_freshness_receipt(
         repo_head_sha=head_sha,
         ssd_path=str(Path(ssd_path)),
         source=source,
+        generation_id=generation_id,
+        base_generation_id="",
         collections=collections,
     )
 
@@ -217,6 +340,8 @@ def load_freshness_receipt(path: Path | str) -> HoloIndexFreshnessReceipt:
         repo_head_sha=data.get("repo_head_sha", ""),
         ssd_path=data.get("ssd_path", ""),
         source=data.get("source", ""),
+        generation_id=data.get("generation_id", ""),
+        base_generation_id=data.get("base_generation_id", ""),
         collections=collections,
     )
 
@@ -290,6 +415,8 @@ def evaluate_freshness_for_paths(
                 repo_head_sha=str(receipt.get("repo_head_sha", "")),
                 ssd_path=str(receipt.get("ssd_path", "")),
                 source=str(receipt.get("source", "")),
+                generation_id=str(receipt.get("generation_id", "")),
+                base_generation_id=str(receipt.get("base_generation_id", "")),
                 collections=[
                     CollectionFreshness(**entry)
                     for entry in receipt.get("collections", [])
@@ -303,6 +430,9 @@ def evaluate_freshness_for_paths(
     stale: set[str] = set()
     if receipt.schema_version != SCHEMA_VERSION:
         reasons.append("unsupported_freshness_receipt_schema")
+        stale.update(required)
+    if required and not receipt.generation_id:
+        reasons.append("missing_holoindex_generation_id")
         stale.update(required)
     if expected_repo_head_sha and receipt.repo_head_sha != expected_repo_head_sha:
         reasons.append("stale_repo_head_sha")
@@ -318,6 +448,15 @@ def evaluate_freshness_for_paths(
         if entry.status != "indexed" or entry.count <= 0:
             stale.add(name)
             reasons.append(f"collection_not_indexed:{name}")
+        if entry.verification != "PASS":
+            stale.add(name)
+            reasons.append(f"collection_verification_not_pass:{name}")
+        if not entry.source_manifest_digest:
+            stale.add(name)
+            reasons.append(f"collection_manifest_missing:{name}")
+        if not entry.indexed_paths_digest:
+            stale.add(name)
+            reasons.append(f"collection_indexed_paths_missing:{name}")
         if expected_repo_head_sha and entry.repo_head_sha != expected_repo_head_sha:
             stale.add(name)
             reasons.append(f"stale_collection_sha:{name}")

--- a/holo_index/tests/test_holoindex_ci_freshness_gate.py
+++ b/holo_index/tests/test_holoindex_ci_freshness_gate.py
@@ -38,6 +38,25 @@ class CountCollection:
         return self._count
 
 
+class SnapshotCollection:
+    def __init__(self, name: str, count: int = 3):
+        self.name = name
+        self._count = count
+        self.metadata = {"embedding_backend": "ci-test"}
+
+    def count(self) -> int:
+        return self._count
+
+    def get(self, include=None):
+        return {
+            "ids": [f"{self.name}:{index}" for index in range(self._count)],
+            "metadatas": [
+                {"path": f"{self.name}/item_{index}.txt"}
+                for index in range(self._count)
+            ],
+        }
+
+
 def _holo(**counts: int):
     attr_map = {
         "navigation_code": "code_collection",
@@ -52,7 +71,7 @@ def _holo(**counts: int):
     }
     values = {}
     for collection_name, attr_name in attr_map.items():
-        values[attr_name] = CountCollection(counts.get(collection_name, 3))
+        values[attr_name] = SnapshotCollection(collection_name, counts.get(collection_name, 3))
     return SimpleNamespace(**values)
 
 

--- a/holo_index/tests/test_holoindex_ci_main_freshness_gate.py
+++ b/holo_index/tests/test_holoindex_ci_main_freshness_gate.py
@@ -27,6 +27,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 MODULE = REPO_ROOT / "holo_index" / "ci_main_freshness_gate.py"
 HEAD = "9c31512a8b4d6e1f0a2b3c4d5e6f708192a3b4c5"
 BASE = "7994990bcf1e2d3c4b5a69788776655443322110"
+DIGEST = "sha256:" + "0" * 64
 
 
 def _write_receipt(tmp_path: Path, *, head: str = HEAD) -> Path:
@@ -37,6 +38,7 @@ def _write_receipt(tmp_path: Path, *, head: str = HEAD) -> Path:
         repo_head_sha=head,
         ssd_path=str(tmp_path),
         source="ci_targeted_reindex",
+        generation_id=DIGEST,
         collections=[
             CollectionFreshness(
                 name="navigation_work_ledger",
@@ -45,6 +47,11 @@ def _write_receipt(tmp_path: Path, *, head: str = HEAD) -> Path:
                 source="ci_targeted_reindex",
                 repo_head_sha=head,
                 last_indexed_at="2026-07-14T00:00:00+00:00",
+                source_manifest_digest=DIGEST,
+                indexed_paths_digest=DIGEST,
+                removed_paths_digest=DIGEST,
+                embedding_backend="ci-test",
+                verification="PASS",
             )
         ],
     )

--- a/holo_index/tests/test_holoindex_freshness_receipt.py
+++ b/holo_index/tests/test_holoindex_freshness_receipt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -28,7 +29,44 @@ class CountCollection:
         return self._count
 
 
+class SnapshotCollection:
+    def __init__(self, name: str, count: int):
+        self.name = name
+        self._count = count
+        self.metadata = {"embedding_backend": "test-embedding"}
+
+    def count(self) -> int:
+        return self._count
+
+    def get(self, include=None):
+        return {
+            "ids": [f"{self.name}:{index}" for index in range(self._count)],
+            "metadatas": [
+                {"path": f"{self.name}/item_{index}.txt"}
+                for index in range(self._count)
+            ],
+        }
+
+
 def _holo(**counts: int):
+    attr_map = {
+        "navigation_code": "code_collection",
+        "navigation_wsp": "wsp_collection",
+        "navigation_tests": "test_collection",
+        "navigation_skills": "skill_collection",
+        "navigation_symbols": "symbol_collection",
+        "navigation_docs": "docs_collection",
+        "navigation_knowledge": "knowledge_collection",
+        "navigation_work_ledger": "work_ledger_collection",
+        "navigation_vocabulary": "vocabulary_collection",
+    }
+    values = {}
+    for collection_name, attr_name in attr_map.items():
+        values[attr_name] = SnapshotCollection(collection_name, counts.get(collection_name, 3))
+    return SimpleNamespace(**values)
+
+
+def _count_only_holo(**counts: int):
     attr_map = {
         "navigation_code": "code_collection",
         "navigation_wsp": "wsp_collection",
@@ -46,6 +84,10 @@ def _holo(**counts: int):
     return SimpleNamespace(**values)
 
 
+def _assert_sha256_digest(value: str) -> None:
+    assert re.fullmatch(r"sha256:[0-9a-f]{64}", value)
+
+
 def test_receipt_contains_all_expected_collections(tmp_path: Path) -> None:
     receipt = build_freshness_receipt(
         _holo(),
@@ -59,8 +101,15 @@ def test_receipt_contains_all_expected_collections(tmp_path: Path) -> None:
     assert receipt.schema_version == SCHEMA_VERSION
     assert receipt.repo_head_sha == "abc123"
     assert receipt.source == "manual_index"
+    _assert_sha256_digest(receipt.generation_id)
     assert [entry.name for entry in receipt.collections] == list(ALL_COLLECTIONS)
     assert all(entry.status == "indexed" for entry in receipt.collections)
+    assert all(entry.verification == "PASS" for entry in receipt.collections)
+    assert all(entry.embedding_backend == "test-embedding" for entry in receipt.collections)
+    for entry in receipt.collections:
+        _assert_sha256_digest(entry.source_manifest_digest)
+        _assert_sha256_digest(entry.indexed_paths_digest)
+        _assert_sha256_digest(entry.removed_paths_digest)
 
 
 def test_receipt_roundtrip_json(tmp_path: Path) -> None:
@@ -188,6 +237,113 @@ def test_empty_collection_fails_closed_when_path_requires_it(tmp_path: Path) -> 
     assert check.ok is False
     assert check.stale_collections == ["navigation_work_ledger"]
     assert "collection_not_indexed:navigation_work_ledger" in check.reasons
+    assert "collection_verification_not_pass:navigation_work_ledger" in check.reasons
+
+
+def test_count_only_collection_receipt_fails_closed_for_required_path(tmp_path: Path) -> None:
+    receipt = build_freshness_receipt(
+        _count_only_holo(),
+        ssd_path=tmp_path,
+        repo_root=REPO_ROOT,
+        source="manual_index",
+        generated_at="2026-07-12T00:00:00+00:00",
+        repo_head_sha="abc123",
+    )
+
+    check = evaluate_freshness_for_paths(
+        receipt,
+        ["modules/foundups/agent/src/create_foundup_dryrun.py"],
+        expected_repo_head_sha="abc123",
+    )
+
+    assert check.ok is False
+    assert check.stale_collections == ["navigation_symbols"]
+    assert "collection_verification_not_pass:navigation_symbols" in check.reasons
+    assert "collection_manifest_missing:navigation_symbols" in check.reasons
+    assert "collection_indexed_paths_missing:navigation_symbols" in check.reasons
+
+
+def test_legacy_count_only_mapping_fails_required_generation_and_manifest() -> None:
+    legacy = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": "2026-07-12T00:00:00+00:00",
+        "repo_root": str(REPO_ROOT),
+        "repo_head_sha": "abc123",
+        "ssd_path": "ssd",
+        "source": "legacy",
+        "collections": [
+            {
+                "name": "navigation_symbols",
+                "count": 1,
+                "status": "indexed",
+                "source": "legacy",
+                "repo_head_sha": "abc123",
+                "last_indexed_at": "2026-07-12T00:00:00+00:00",
+            }
+        ],
+    }
+
+    check = evaluate_freshness_for_paths(
+        legacy,
+        ["modules/foundups/agent/src/create_foundup_dryrun.py"],
+        expected_repo_head_sha="abc123",
+    )
+
+    assert check.ok is False
+    assert "missing_holoindex_generation_id" in check.reasons
+    assert "collection_verification_not_pass:navigation_symbols" in check.reasons
+    assert "collection_manifest_missing:navigation_symbols" in check.reasons
+
+
+def test_generation_id_changes_when_collection_manifest_changes(tmp_path: Path) -> None:
+    first = build_freshness_receipt(
+        _holo(),
+        ssd_path=tmp_path,
+        repo_root=REPO_ROOT,
+        source="manual_index",
+        generated_at="2026-07-12T00:00:00+00:00",
+        repo_head_sha="abc123",
+    )
+    second = build_freshness_receipt(
+        _holo(**{"navigation_symbols": 4}),
+        ssd_path=tmp_path,
+        repo_root=REPO_ROOT,
+        source="manual_index",
+        generated_at="2026-07-12T00:00:00+00:00",
+        repo_head_sha="abc123",
+    )
+
+    assert first.generation_id != second.generation_id
+
+
+def test_code_refresh_does_not_mark_skill_collection_fresh_without_skill_manifest(
+    tmp_path: Path,
+) -> None:
+    receipt = build_freshness_receipt(
+        _holo(**{"navigation_skills": 3}),
+        ssd_path=tmp_path,
+        repo_root=REPO_ROOT,
+        source="code_only_refresh",
+        generated_at="2026-07-12T00:00:00+00:00",
+        repo_head_sha="abc123",
+    )
+    data = receipt.to_dict()
+    for entry in data["collections"]:
+        if entry["name"] == "navigation_skills":
+            entry["source_manifest_digest"] = ""
+            entry["indexed_paths_digest"] = ""
+            entry["verification"] = "UNVERIFIED"
+
+    check = evaluate_freshness_for_paths(
+        data,
+        ["modules/foundups/agent/SKILLz.md"],
+        expected_repo_head_sha="abc123",
+    )
+
+    assert check.ok is False
+    assert check.stale_collections == ["navigation_skills"]
+    assert "collection_verification_not_pass:navigation_skills" in check.reasons
+    assert "collection_manifest_missing:navigation_skills" in check.reasons
 
 
 def test_cli_index_state_writer_emits_freshness_receipt_contract() -> None:


### PR DESCRIPTION
## Summary

Implements `HOLOINDEX_COLLECTION_FRESHNESS_TRUTH_REPAIR_PHASE1`.

This repair makes HoloIndex freshness receipts prove per-collection freshness with generation-bound manifest fields instead of allowing count-only freshness overclaims.

## Changes

- Adds receipt-level `generation_id` / `base_generation_id`.
- Adds per-collection manifest fields:
  - `source_manifest_digest`
  - `indexed_paths_digest`
  - `removed_paths_digest`
  - `embedding_backend`
  - `verification`
- Makes `evaluate_freshness_for_paths` fail closed when a required collection has:
  - no generation ID
  - non-PASS verification
  - missing source manifest digest
  - missing indexed-path digest
- Updates CI freshness fixtures to the new proof contract.
- Adds regression tests for count-only overclaim, legacy receipt rejection, generation changes, and code-only refreshes that cannot mark Skillz fresh.

## Validation

- `python -m py_compile holo_index/freshness_receipt.py holo_index/ci_freshness_gate.py holo_index/ci_main_freshness_gate.py`
- `pytest holo_index/tests/test_holoindex_freshness_receipt.py holo_index/tests/test_holoindex_ci_freshness_gate.py holo_index/tests/test_holoindex_ci_main_freshness_gate.py -q --tb=short` -> 32 passed
- `git diff --check` -> clean
- Diff additions ASCII/NUL scan -> PASS

## Broader suite note

`pytest holo_index/tests -q --tb=short` currently reports legacy/environment failures unrelated to this slice, including missing CLI executable paths, stale PatternCoach/HoloDAE API expectations, missing pytest fixture `client`, and existing recall/ranking expectations. The focused freshness/CI gate tests above pass.

## Boundary

No HoloIndex re-index, no semantic-store mutation, no RedDog runtime write path, no WRE enqueue, no runtime re-index.