### PR TITLE
fix(holoindex): consolidate resident HoloDAE runtime

### DIFF
--- a/holo_index/qwen_advisor/ModLog.md
+++ b/holo_index/qwen_advisor/ModLog.md
@@ -4,6 +4,28 @@
 This ModLog tracks all changes to the `holo_index/qwen_advisor/` module.
 Each entry must include WSP protocol references and impact analysis.
 
+## [2026-07-16] - HOLOINDEX_RESIDENT_DAE_RUNTIME_CONSOLIDATION_PHASE1
+**Agent**: 0102 (Codex)
+**Type**: Runtime consolidation repair
+**WSP Compliance**: WSP 00, WSP 15, WSP 50, WSP 80, WSP 97
+
+### Changes Implemented
+- Fixed `HoloDAECoordinator` initialization order so `_scan_for_gates()` cannot
+  log before `self.logger` and telemetry are initialized.
+- Added compatibility accessors for `monitoring_active`,
+  `last_monitoring_result`, and `run_monitoring_cycle()` while keeping the
+  monitoring loop as the state owner.
+- Updated request work-context derivation so HoloIndex returned files drive the
+  current work context before Qwen internal analysis files.
+- Synchronized coordinator, formatter, and monitoring-loop work context after
+  request handling and manual monitoring cycles.
+
+### Boundary
+- No re-index, no automatic HoloDAE launch, no semantic-store writes, no WRE
+  enqueue, and no RedDog runtime authority change.
+
+---
+
 ## [2025-11-30] - MAJOR: WSP 62 Coordinator Refactoring (Sprints H1-H6)
 **Agent**: 0102
 **Type**: Major Refactoring & WRE Integration

--- a/holo_index/qwen_advisor/holodae_coordinator.py
+++ b/holo_index/qwen_advisor/holodae_coordinator.py
@@ -97,6 +97,20 @@ class HoloDAECoordinator:
                 'priority': 'P2'
             }
         ]
+
+        # Logging must exist before any discovery hooks run. Gate scanning uses
+        # _detailed_log, so initialize this before _scan_for_gates().
+        self.holo_console_enabled = os.getenv("HOLO_SILENT", "0").lower() not in {"1", "true", "yes"}
+        self.verbose = os.getenv('HOLO_VERBOSE', '').lower() in {"1", "true", "yes"}
+        self.session_id = f"holo-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+        self.logger = logging.getLogger('holodae_activity')
+        self.telemetry_logger = TelemetryLogger(self.session_id)
+        self.telemetry_formatter = TelemetryFormatter(
+            telemetry_logger=self.telemetry_logger,
+            current_work_context=self.current_work_context,
+            logger=self.logger
+        )
+        self.holo_agent_id = self.telemetry_logger.session_id
         
         # Initialize doc tracking
         self.doc_only_modules: Set[str] = set()
@@ -108,21 +122,6 @@ class HoloDAECoordinator:
         self.detected_gates: Dict[str, Any] = {}
         self._scan_for_gates()
 
-        # Environment + logging context
-        self.holo_console_enabled = os.getenv("HOLO_SILENT", "0").lower() not in {"1", "true", "yes"}
-        self.verbose = os.getenv('HOLO_VERBOSE', '').lower() in {"1", "true", "yes"}
-        self.session_id = f"holo-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
-        
-        # Initialize Telemetry
-        self.logger = logging.getLogger('holodae_activity')
-        self.telemetry_logger = TelemetryLogger(self.session_id)
-        self.telemetry_formatter = TelemetryFormatter(
-            telemetry_logger=self.telemetry_logger,
-            current_work_context=self.current_work_context,
-            logger=self.logger
-        )
-        self.holo_agent_id = self.telemetry_logger.session_id
-        
         # Initialize breadcrumb tracer
         self.breadcrumb_tracer = get_tracer()
 
@@ -318,6 +317,27 @@ class HoloDAECoordinator:
 
         return None
 
+    def _extract_search_result_paths(self, search_results: dict) -> List[str]:
+        """Extract repository paths from HoloIndex result records."""
+        paths: List[str] = []
+        for section in ("code", "wsps", "wsp"):
+            for result in search_results.get(section, []) or []:
+                if isinstance(result, str):
+                    candidate = result
+                elif isinstance(result, dict):
+                    candidate = (
+                        result.get("location")
+                        or result.get("file")
+                        or result.get("path")
+                        or result.get("source")
+                        or ""
+                    )
+                else:
+                    candidate = ""
+                if candidate and candidate not in paths:
+                    paths.append(candidate)
+        return paths
+
     def handle_holoindex_request(self, query: str, search_results: dict) -> str:
         """Handle HoloIndex search request - Main orchestration entry point"""
         self._detailed_log(f"[HOLODAE-COORDINATOR] Processing query: '{query}'")
@@ -373,10 +393,17 @@ class HoloDAECoordinator:
         # Update work context
         analysis_context = self.qwen_orchestrator.get_recent_analysis_context()
         session_actions = [f"{decision.recommended_action.value}:{decision.description}" for decision in arbitration_decisions]
-        if analysis_context['files'] or session_actions:
-            self.current_work_context = self.context_analyzer.analyze_work_context(analysis_context['files'], session_actions)
+        result_files = self._extract_search_result_paths(filtered_results)
+        context_files = result_files or analysis_context['files']
+        if context_files or session_actions:
+            self.current_work_context = self.context_analyzer.analyze_work_context(context_files, session_actions)
+            if result_files:
+                first_result_module = self.context_analyzer._extract_module(result_files[0])
+                if first_result_module:
+                    self.current_work_context.primary_module = first_result_module
             # Update formatter's context reference
             self.telemetry_formatter.current_work_context = self.current_work_context
+            self.monitoring_loop.current_work_context = self.current_work_context
 
         search_summary = {
             'code': search_results.get('code', []),
@@ -468,6 +495,23 @@ class HoloDAECoordinator:
 
     def enable_monitoring(self) -> None:
         self.monitoring_loop.enable_monitoring()
+
+    @property
+    def monitoring_active(self) -> bool:
+        """Compatibility access to the broker-owned monitoring state."""
+        return self.monitoring_loop.monitoring_active
+
+    @property
+    def last_monitoring_result(self) -> Optional[MonitoringResult]:
+        """Compatibility access for status/report tests and legacy callers."""
+        return self.monitoring_loop.last_monitoring_result
+
+    def run_monitoring_cycle(self) -> MonitoringResult:
+        """Run one read-only HoloDAE monitoring cycle."""
+        result = self.monitoring_loop.run_monitoring_cycle()
+        self.current_work_context = self.monitoring_loop.current_work_context
+        self.telemetry_formatter.current_work_context = self.current_work_context
+        return result
 
     def get_status_summary(self) -> Dict[str, Any]:
         """Get comprehensive status summary"""

--- a/main.py
+++ b/main.py
@@ -1728,6 +1728,12 @@ def bootstrap_runtime_dae_launches() -> None:
             start_callable=run_holodae,
             stop_callable=stop_holodae,
             description="Code intelligence and search runtime.",
+            metadata={
+                "resident_owner": "dae_launch_broker",
+                "runtime_autostart": False,
+                "runtime_reindex_allowed": False,
+                "query_runtime": True,
+            },
         ),
         DAELaunchSpec(
             dae_id="git_push_dae",

--- a/modules/ai_intelligence/holo_dae/ModLog.md
+++ b/modules/ai_intelligence/holo_dae/ModLog.md
@@ -1,3 +1,12 @@
+## 2026-07-16: HOLOINDEX_RESIDENT_DAE_RUNTIME_CONSOLIDATION_PHASE1
+- Marked HoloDAE's main.py broker registration as `resident_owner=dae_launch_broker`,
+  `runtime_autostart=false`, `runtime_reindex_allowed=false`, and
+  `query_runtime=true`.
+- Added regression coverage that HoloDAE registers with a stop hook but does not
+  autostart during normal runtime bootstrap.
+- Boundary: no HoloIndex re-index, no automatic HoloDAE launch, no semantic-store
+  mutation, and no RedDog/OpenClaw execution wiring.
+
 ## 2026-03-18: Broker-managed HoloDAE stop hook
 - Added broker-visible lifecycle state to `scripts/launch.py`.
 - Added `stop_holodae()` so the runtime broker can stop HoloDAE instead of returning `stop_unsupported`.

--- a/tests/test_main_runtime_bootstrap.py
+++ b/tests/test_main_runtime_bootstrap.py
@@ -73,6 +73,10 @@ def test_bootstrap_runtime_dae_launches_registers_holodae_stop_hook(monkeypatch)
     holodae_specs = [spec for spec in specs if spec.dae_id == "holodae"]
     assert len(holodae_specs) == 1
     assert holodae_specs[0].stop_callable is main.stop_holodae
+    assert holodae_specs[0].metadata["resident_owner"] == "dae_launch_broker"
+    assert holodae_specs[0].metadata["runtime_autostart"] is False
+    assert holodae_specs[0].metadata["runtime_reindex_allowed"] is False
+    broker.start_dae.assert_not_called()
 
 
 def test_bootstrap_runtime_dae_launches_registers_git_push_and_social_stop_hooks(monkeypatch):


### PR DESCRIPTION
## Summary

Implements `HOLOINDEX_RESIDENT_DAE_RUNTIME_CONSOLIDATION_PHASE1`.

This consolidates HoloDAE as a broker-owned resident query runtime while fixing the current coordinator construction bug that prevented HoloDAE from being instantiated cleanly.

## Changes

- Fixes `HoloDAECoordinator` initialization order so gate scanning cannot log before `self.logger` / telemetry exist.
- Adds compatibility accessors for `monitoring_active`, `last_monitoring_result`, and `run_monitoring_cycle()` while preserving `MonitoringLoop` as state owner.
- Makes HoloIndex returned files authoritative for request work-context derivation before Qwen internal analysis files.
- Synchronizes coordinator, formatter, and monitoring-loop work context after request handling and manual monitoring cycles.
- Marks main.py HoloDAE broker registration as:
  - `resident_owner=dae_launch_broker`
  - `runtime_autostart=false`
  - `runtime_reindex_allowed=false`
  - `query_runtime=true`
- Adds regression coverage that HoloDAE registers with a stop hook and does not autostart from normal runtime bootstrap.

## Validation

- `python -m py_compile holo_index/qwen_advisor/holodae_coordinator.py main.py modules/ai_intelligence/holo_dae/scripts/launch.py`
- `pytest holo_index/tests/test_qwen_advisor_stub.py modules/ai_intelligence/holo_dae/tests/test_launch.py -q --tb=short` -> 4 passed
- `pytest tests/test_main_runtime_bootstrap.py -q --tb=short` -> 9 passed
- `git diff --check` -> clean
- Diff additions ASCII/NUL scan -> PASS

## Broader-test note

`holo_index/tests/test_holodae_coordinator.py holo_index/tests/test_phase3_wre_integration.py` still contain stale expectations unrelated to this slice: old output banners, missing legacy WRE helper methods, old MCP signature assumptions, and obsolete SkillExecutor helpers. This PR fixes the constructor/runtime-owner issue and validates the direct resident paths without bundling a broad legacy-test rewrite.

## Boundary

No HoloIndex re-index, no automatic HoloDAE launch, no semantic-store mutation, no WRE enqueue, and no RedDog/OpenClaw execution wiring.