### PR TITLE
feat(holoindex): add event-driven incremental index executor

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,23 @@
 # HoloIndex Package ModLog
 
+## [2026-07-16] HOLOINDEX_EVENT_DRIVEN_INCREMENTAL_INDEX_EXECUTOR_PHASE1
+
+**Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice
+**WSP**: 00, 15, 22, 50, 97
+
+- ADD `holo_index/incremental_index_executor.py`: WRE/CI-owned executor for
+  applying a precomputed FoundUp-scoped incremental index plan to injected
+  collection handles. It supports stable-ID upserts, stable-ID deletes, scoped
+  source reads, deterministic execution receipts, and optional freshness receipt
+  writes from a supplied HoloIndex snapshot.
+- TEST `tests/test_holoindex_incremental_index_executor.py`: scoped upsert,
+  delete-without-source-read, rejected/noop plans, missing-source fail-closed,
+  freshness receipt emission, and AST guards against subprocess/full-reindex
+  calls.
+- Boundary: no full re-index, no `_reset_collection`, no HoloIndex runtime query
+  mutation, no RedDog runtime re-index, no subprocess, and no collection handle
+  discovery from this module. WRE/CI must inject the gateway and authorization.
+
 ## [2026-07-16] HOLOINDEX_COLLECTION_FRESHNESS_TRUTH_REPAIR_PHASE1
 
 **Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice

--- a/holo_index/incremental_index_executor.py
+++ b/holo_index/incremental_index_executor.py
@@ -1,0 +1,245 @@
+"""Event-driven incremental HoloIndex executor.
+
+This module executes a precomputed FoundUp-scoped incremental plan against
+injected collection handles. It is a WRE/CI maintenance primitive, not a RedDog
+runtime query primitive.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+from holo_index.freshness_receipt import (
+    HoloIndexFreshnessReceipt,
+    build_freshness_receipt,
+    write_freshness_receipt,
+)
+from holo_index.incremental_foundup_index import (
+    DECISION_NO_INDEXABLE_CHANGES,
+    DECISION_PLANNED,
+    DECISION_REJECTED,
+    OP_DELETE_PATH_ID,
+    OP_UPSERT_PATH,
+    IncrementalFoundUpIndexPlan,
+    path_is_under_foundup,
+)
+
+
+SCHEMA_VERSION = "holoindex_event_driven_incremental_index_executor.v1"
+
+DECISION_APPLIED = "APPLIED"
+DECISION_NOOP = "NOOP"
+DECISION_FAILED = "FAILED"
+
+
+class IncrementalCollectionGateway(Protocol):
+    """Injected collection and embedding adapter."""
+
+    def get_collection(self, name: str) -> Any:
+        """Return the mutable collection handle for a collection name."""
+
+    def embed(self, text: str) -> list[float]:
+        """Return an embedding for the provided text."""
+
+
+@dataclass(frozen=True)
+class IncrementalIndexExecutionReceipt:
+    """Receipt for one incremental execution attempt."""
+
+    schema_version: str
+    decision: str
+    plan_digest: str
+    foundup_id: str
+    foundup_root: str
+    target_collections: list[str] = field(default_factory=list)
+    operations_attempted: int = 0
+    operations_applied: int = 0
+    upserted_paths: list[str] = field(default_factory=list)
+    deleted_paths: list[str] = field(default_factory=list)
+    freshness_generation_id: str = ""
+    rejection_reasons: list[str] = field(default_factory=list)
+    no_full_reindex_performed: bool = True
+    no_runtime_reindex_performed: bool = True
+    collection_mutation_performed: bool = False
+    receipt_written: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def canonical_plan_digest(plan: IncrementalFoundUpIndexPlan) -> str:
+    payload = json.dumps(plan.to_dict(), sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _reject(
+    plan: IncrementalFoundUpIndexPlan,
+    reasons: list[str],
+) -> IncrementalIndexExecutionReceipt:
+    return IncrementalIndexExecutionReceipt(
+        schema_version=SCHEMA_VERSION,
+        decision=DECISION_FAILED,
+        plan_digest=canonical_plan_digest(plan),
+        foundup_id=plan.foundup_id,
+        foundup_root=plan.foundup_root,
+        target_collections=list(plan.target_collections),
+        operations_attempted=len(plan.operations),
+        rejection_reasons=reasons,
+    )
+
+
+def _resolve_repo_path(repo_root: Path, repo_relative_path: str) -> Path:
+    root = repo_root.resolve()
+    target = (root / repo_relative_path).resolve()
+    try:
+        target.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"path_outside_repo:{repo_relative_path}") from exc
+    return target
+
+
+def _read_indexable_file(path: Path, *, max_file_bytes: int) -> str:
+    if not path.exists() or not path.is_file():
+        raise ValueError(f"source_file_missing:{path}")
+    data = path.read_bytes()
+    if len(data) > max_file_bytes:
+        data = data[:max_file_bytes]
+    return data.decode("utf-8", errors="replace")
+
+
+def _collection_delete(collection: Any, stable_id: str) -> None:
+    collection.delete(ids=[stable_id])
+
+
+def _collection_add(
+    collection: Any,
+    *,
+    stable_id: str,
+    document: str,
+    metadata: dict[str, Any],
+    embedding: list[float],
+) -> None:
+    payload: dict[str, Any] = {
+        "ids": [stable_id],
+        "documents": [document],
+        "metadatas": [metadata],
+    }
+    if embedding:
+        payload["embeddings"] = [embedding]
+    collection.add(**payload)
+
+
+def execute_incremental_foundup_index_plan(
+    plan: IncrementalFoundUpIndexPlan,
+    *,
+    repo_root: Path | str,
+    gateway: IncrementalCollectionGateway,
+    holo_for_receipt: Any | None = None,
+    freshness_receipt_path: Path | str | None = None,
+    receipt_source: str = "wre_incremental_index",
+    max_file_bytes: int = 12000,
+) -> IncrementalIndexExecutionReceipt:
+    """Apply an already validated FoundUp-scoped incremental plan."""
+
+    if plan.schema_version != "holoindex_incremental_foundup_index.v1":
+        return _reject(plan, ["unsupported_plan_schema"])
+    if plan.decision == DECISION_REJECTED:
+        return _reject(plan, ["plan_rejected", *plan.rejection_reasons])
+    if plan.decision == DECISION_NO_INDEXABLE_CHANGES:
+        return IncrementalIndexExecutionReceipt(
+            schema_version=SCHEMA_VERSION,
+            decision=DECISION_NOOP,
+            plan_digest=canonical_plan_digest(plan),
+            foundup_id=plan.foundup_id,
+            foundup_root=plan.foundup_root,
+            target_collections=list(plan.target_collections),
+            rejection_reasons=["no_indexable_changes"],
+        )
+    if plan.decision != DECISION_PLANNED:
+        return _reject(plan, [f"unsupported_plan_decision:{plan.decision}"])
+    if not plan.operations:
+        return _reject(plan, ["planned_without_operations"])
+
+    root = Path(repo_root)
+    upserted: list[str] = []
+    deleted: list[str] = []
+    applied = 0
+    try:
+        for operation in plan.operations:
+            if not path_is_under_foundup(operation.repo_relative_path, plan.foundup_id):
+                raise ValueError(f"path_outside_foundup_scope:{operation.repo_relative_path}")
+            collection = gateway.get_collection(operation.collection)
+            if operation.operation == OP_UPSERT_PATH:
+                source_path = _resolve_repo_path(root, operation.repo_relative_path)
+                document = _read_indexable_file(source_path, max_file_bytes=max_file_bytes)
+                embedding = gateway.embed(document)
+                metadata = {
+                    "path": operation.repo_relative_path,
+                    "foundup_id": plan.foundup_id,
+                    "foundup_root": plan.foundup_root,
+                    "collection": operation.collection,
+                    "source": receipt_source,
+                }
+                _collection_delete(collection, operation.stable_id)
+                _collection_add(
+                    collection,
+                    stable_id=operation.stable_id,
+                    document=document,
+                    metadata=metadata,
+                    embedding=embedding,
+                )
+                upserted.append(operation.repo_relative_path)
+                applied += 1
+            elif operation.operation == OP_DELETE_PATH_ID:
+                _collection_delete(collection, operation.stable_id)
+                deleted.append(operation.repo_relative_path)
+                applied += 1
+            else:
+                raise ValueError(f"unsupported_operation:{operation.operation}")
+    except Exception as exc:
+        return _reject(plan, [str(exc)])
+
+    generation_id = ""
+    receipt_written = False
+    if holo_for_receipt is not None and freshness_receipt_path is not None:
+        receipt: HoloIndexFreshnessReceipt = build_freshness_receipt(
+            holo_for_receipt,
+            ssd_path=Path(freshness_receipt_path).parents[1],
+            repo_root=root,
+            source=receipt_source,
+        )
+        generation_id = receipt.generation_id
+        write_freshness_receipt(receipt, freshness_receipt_path)
+        receipt_written = True
+
+    return IncrementalIndexExecutionReceipt(
+        schema_version=SCHEMA_VERSION,
+        decision=DECISION_APPLIED,
+        plan_digest=canonical_plan_digest(plan),
+        foundup_id=plan.foundup_id,
+        foundup_root=plan.foundup_root,
+        target_collections=list(plan.target_collections),
+        operations_attempted=len(plan.operations),
+        operations_applied=applied,
+        upserted_paths=upserted,
+        deleted_paths=deleted,
+        freshness_generation_id=generation_id,
+        collection_mutation_performed=applied > 0,
+        receipt_written=receipt_written,
+    )
+
+
+__all__ = [
+    "DECISION_APPLIED",
+    "DECISION_FAILED",
+    "DECISION_NOOP",
+    "IncrementalCollectionGateway",
+    "IncrementalIndexExecutionReceipt",
+    "SCHEMA_VERSION",
+    "canonical_plan_digest",
+    "execute_incremental_foundup_index_plan",
+]

--- a/holo_index/tests/test_holoindex_incremental_index_executor.py
+++ b/holo_index/tests/test_holoindex_incremental_index_executor.py
@@ -1,0 +1,237 @@
+"""Tests for HOLOINDEX_EVENT_DRIVEN_INCREMENTAL_INDEX_EXECUTOR_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+from holo_index.freshness_receipt import freshness_receipt_path, load_freshness_receipt
+from holo_index.incremental_foundup_index import (
+    DECISION_NO_INDEXABLE_CHANGES,
+    DECISION_REJECTED,
+    IncrementalFoundUpIndexPlan,
+    plan_incremental_foundup_index,
+)
+from holo_index.incremental_index_executor import (
+    DECISION_APPLIED,
+    DECISION_FAILED,
+    DECISION_NOOP,
+    canonical_plan_digest,
+    execute_incremental_foundup_index_plan,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE = REPO_ROOT / "holo_index" / "incremental_index_executor.py"
+
+
+class FakeCollection:
+    def __init__(self, name: str):
+        self.name = name
+        self.metadata = {"embedding_backend": "fake"}
+        self.deleted: list[list[str]] = []
+        self.added: list[dict] = []
+
+    def delete(self, ids):
+        self.deleted.append(list(ids))
+
+    def add(self, **kwargs):
+        self.added.append(kwargs)
+
+    def count(self) -> int:
+        return len(self.added)
+
+    def get(self, include=None):
+        ids = []
+        metadatas = []
+        for payload in self.added:
+            ids.extend(payload.get("ids", []))
+            metadatas.extend(payload.get("metadatas", []))
+        return {"ids": ids, "metadatas": metadatas}
+
+
+class FakeGateway:
+    def __init__(self):
+        self.collections: dict[str, FakeCollection] = {}
+        self.embedded: list[str] = []
+
+    def get_collection(self, name: str):
+        return self.collections.setdefault(name, FakeCollection(name))
+
+    def embed(self, text: str):
+        self.embedded.append(text)
+        return [float(len(text))]
+
+
+def _holo_from_gateway(gateway: FakeGateway):
+    attr_map = {
+        "navigation_code": "code_collection",
+        "navigation_wsp": "wsp_collection",
+        "navigation_tests": "test_collection",
+        "navigation_skills": "skill_collection",
+        "navigation_symbols": "symbol_collection",
+        "navigation_docs": "docs_collection",
+        "navigation_knowledge": "knowledge_collection",
+        "navigation_work_ledger": "work_ledger_collection",
+        "navigation_vocabulary": "vocabulary_collection",
+    }
+    values = {}
+    for collection_name, attr_name in attr_map.items():
+        values[attr_name] = gateway.get_collection(collection_name)
+    return SimpleNamespace(**values)
+
+
+def _write_foundup_files(repo_root: Path) -> None:
+    foundup_root = repo_root / "modules" / "foundups" / "paccess_001"
+    (foundup_root / "src").mkdir(parents=True)
+    (foundup_root / "tests").mkdir(parents=True)
+    (foundup_root / "src" / "main.py").write_text("def create_foundup():\n    return True\n", encoding="utf-8")
+    (foundup_root / "README.md").write_text("# pAccess\n", encoding="utf-8")
+    (foundup_root / "tests" / "test_main.py").write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+
+
+def test_executor_applies_scoped_upsert_operations(tmp_path: Path) -> None:
+    _write_foundup_files(tmp_path)
+    gateway = FakeGateway()
+    plan = plan_incremental_foundup_index(
+        foundup_id="paccess_001",
+        changed_paths=[
+            "modules/foundups/paccess_001/src/main.py",
+            "modules/foundups/paccess_001/README.md",
+        ],
+    )
+
+    receipt = execute_incremental_foundup_index_plan(
+        plan,
+        repo_root=tmp_path,
+        gateway=gateway,
+    )
+
+    assert receipt.decision == DECISION_APPLIED
+    assert receipt.plan_digest == canonical_plan_digest(plan)
+    assert receipt.operations_attempted == 2
+    assert receipt.operations_applied == 2
+    assert receipt.collection_mutation_performed is True
+    assert receipt.no_full_reindex_performed is True
+    assert receipt.no_runtime_reindex_performed is True
+    assert set(receipt.upserted_paths) == {
+        "modules/foundups/paccess_001/src/main.py",
+        "modules/foundups/paccess_001/README.md",
+    }
+    symbol_collection = gateway.get_collection("navigation_symbols")
+    docs_collection = gateway.get_collection("navigation_docs")
+    assert len(symbol_collection.deleted) == 1
+    assert len(symbol_collection.added) == 1
+    assert symbol_collection.added[0]["metadatas"][0]["foundup_id"] == "paccess_001"
+    assert docs_collection.added[0]["metadatas"][0]["path"] == "modules/foundups/paccess_001/README.md"
+
+
+def test_executor_applies_delete_operations_without_reading_source(tmp_path: Path) -> None:
+    gateway = FakeGateway()
+    plan = plan_incremental_foundup_index(
+        foundup_id="paccess_001",
+        removed_paths=["modules/foundups/paccess_001/src/main.py"],
+    )
+
+    receipt = execute_incremental_foundup_index_plan(
+        plan,
+        repo_root=tmp_path,
+        gateway=gateway,
+    )
+
+    assert receipt.decision == DECISION_APPLIED
+    assert receipt.deleted_paths == ["modules/foundups/paccess_001/src/main.py"]
+    assert gateway.get_collection("navigation_symbols").deleted
+    assert gateway.embedded == []
+
+
+def test_executor_rejects_rejected_and_noop_plans(tmp_path: Path) -> None:
+    gateway = FakeGateway()
+    rejected = IncrementalFoundUpIndexPlan(
+        schema_version="holoindex_incremental_foundup_index.v1",
+        decision=DECISION_REJECTED,
+        foundup_id="bad",
+        foundup_root="",
+        rejection_reasons=["invalid_foundup_id"],
+    )
+    noop = IncrementalFoundUpIndexPlan(
+        schema_version="holoindex_incremental_foundup_index.v1",
+        decision=DECISION_NO_INDEXABLE_CHANGES,
+        foundup_id="paccess_001",
+        foundup_root="modules/foundups/paccess_001",
+    )
+
+    rejected_receipt = execute_incremental_foundup_index_plan(rejected, repo_root=tmp_path, gateway=gateway)
+    noop_receipt = execute_incremental_foundup_index_plan(noop, repo_root=tmp_path, gateway=gateway)
+
+    assert rejected_receipt.decision == DECISION_FAILED
+    assert "plan_rejected" in rejected_receipt.rejection_reasons
+    assert noop_receipt.decision == DECISION_NOOP
+    assert noop_receipt.collection_mutation_performed is False
+
+
+def test_executor_fails_closed_when_changed_source_is_missing(tmp_path: Path) -> None:
+    gateway = FakeGateway()
+    plan = plan_incremental_foundup_index(
+        foundup_id="paccess_001",
+        changed_paths=["modules/foundups/paccess_001/src/main.py"],
+    )
+
+    receipt = execute_incremental_foundup_index_plan(plan, repo_root=tmp_path, gateway=gateway)
+
+    assert receipt.decision == DECISION_FAILED
+    assert receipt.collection_mutation_performed is False
+    assert any(reason.startswith("source_file_missing:") for reason in receipt.rejection_reasons)
+
+
+def test_executor_writes_freshness_receipt_when_holo_snapshot_supplied(tmp_path: Path) -> None:
+    _write_foundup_files(tmp_path)
+    gateway = FakeGateway()
+    plan = plan_incremental_foundup_index(
+        foundup_id="paccess_001",
+        changed_paths=["modules/foundups/paccess_001/src/main.py"],
+    )
+    ssd_path = tmp_path / "ssd"
+    receipt_path = freshness_receipt_path(ssd_path)
+
+    receipt = execute_incremental_foundup_index_plan(
+        plan,
+        repo_root=tmp_path,
+        gateway=gateway,
+        holo_for_receipt=_holo_from_gateway(gateway),
+        freshness_receipt_path=receipt_path,
+    )
+    loaded = load_freshness_receipt(receipt_path)
+
+    assert receipt.decision == DECISION_APPLIED
+    assert receipt.receipt_written is True
+    assert receipt.freshness_generation_id == loaded.generation_id
+    assert loaded.source == "wre_incremental_index"
+
+
+def test_executor_module_has_no_full_reindex_or_subprocess_calls() -> None:
+    source = MODULE.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    banned_imports = {"subprocess", "requests", "holo_index.core.holo_index"}
+    banned_calls = {
+        "_reset_collection",
+        "delete_collection",
+        "index_code_entries",
+        "index_wsp_entries",
+        "index_docs_entries",
+        "index_symbol_entries",
+        "index_all",
+        "run",
+        "system",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name not in banned_imports
+        if isinstance(node, ast.ImportFrom):
+            assert (node.module or "") not in banned_imports
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            assert node.func.attr not in banned_calls
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls


### PR DESCRIPTION
## Summary

Implements `HOLOINDEX_EVENT_DRIVEN_INCREMENTAL_INDEX_EXECUTOR_PHASE1`.

Adds a WRE/CI-owned incremental executor for precomputed FoundUp-scoped HoloIndex plans. This closes the gap between the existing non-mutating planner and a controlled maintenance primitive without introducing RedDog runtime re-indexing.

## Changes

- Adds `holo_index/incremental_index_executor.py`.
- Executes only injected `IncrementalFoundUpIndexPlan` objects.
- Supports stable-ID upserts and stable-ID deletes against injected collection handles.
- Reads only scoped FoundUp source files for upsert operations.
- Emits deterministic execution receipts with plan digest and mutation summary.
- Optionally writes a HoloIndex freshness receipt from a supplied HoloIndex snapshot.
- Adds executor tests for scoped upsert, delete, rejected/noop plans, missing-source fail-closed, freshness receipt emission, and AST boundaries.

## Validation

- `python -m py_compile holo_index/incremental_index_executor.py holo_index/incremental_foundup_index.py holo_index/freshness_receipt.py`
- `pytest holo_index/tests/test_holoindex_incremental_index_executor.py holo_index/tests/test_holoindex_incremental_foundup_index.py holo_index/tests/test_holoindex_freshness_receipt.py holo_index/tests/test_holoindex_ci_freshness_gate.py holo_index/tests/test_holoindex_ci_main_freshness_gate.py -q --tb=short` -> 52 passed
- `git diff --check` -> clean
- Diff additions ASCII/NUL scan -> PASS

## Boundary

No full re-index, no `_reset_collection`, no HoloIndex runtime query mutation, no RedDog runtime re-index, no subprocess, no gateway discovery, and no authorization bypass. WRE/CI must inject the gateway and authorization.