### PR TITLE
feat(holoindex): bind query receipts to freshness generation

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,29 @@
 # HoloIndex Package ModLog
 
+## [2026-07-16] HOLOINDEX_QUERY_RECEIPT_AND_GENERATION_BINDING_PHASE1
+
+**Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice
+**WSP**: 00, 15, 22, 50, 97
+
+- ADD `holo_index/query_receipt.py`: deterministic, read-only query receipts
+  that bind query hits to a HoloIndex freshness generation, freshness receipt
+  digest/path, repo head, source class, stale reasons, and a no-reindex
+  attestation.
+- UPDATE RedDog read-only 0102 audit worker HoloIndex adapter: production
+  queries now load the configured freshness receipt, use `HOLOINDEX_SSD_PATH`
+  or the standard HoloIndex SSD, and return generation-bound metadata without
+  mutating HoloIndex.
+- UPDATE query normalization: HoloIndex results that claim `FRESH` or `CURRENT`
+  without a generation ID or freshness receipt digest are downgraded to stale
+  evidence before any model call.
+- TEST `tests/test_holoindex_query_receipt.py` and
+  `modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py`:
+  generation binding, stale missing-generation rejection, receipt propagation,
+  and read-only/no-reindex invariants.
+- Boundary: no HoloIndex re-index, no collection mutation, no RedDog action
+  authority, no shell command, and no Memex/Brain write path. This slice makes
+  query evidence truthier; it does not maintain the index.
+
 ## [2026-07-16] HOLOINDEX_EVENT_DRIVEN_INCREMENTAL_INDEX_EXECUTOR_PHASE1
 
 **Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice

--- a/holo_index/query_receipt.py
+++ b/holo_index/query_receipt.py
@@ -1,0 +1,246 @@
+"""Generation-bound HoloIndex query receipts.
+
+WSP 97: a query result is only freshness evidence when it is bound to the
+HoloIndex generation that served it. Query receipts are read-only artifacts;
+they never trigger re-indexing or mutate HoloIndex.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from holo_index.freshness_receipt import (
+    HoloIndexFreshnessReceipt,
+    freshness_receipt_path,
+    load_freshness_receipt,
+)
+
+
+SCHEMA_VERSION = "holoindex_query_receipt.v1"
+SOURCE_CLASS_HOLOINDEX = "holoindex"
+SOURCE_CLASS_CODEINDEX = "codeindex"
+SOURCE_CLASS_MEMEX = "memex"
+SOURCE_CLASS_BRAIN = "brain"
+SOURCE_CLASS_BREADCRUMB = "breadcrumb"
+FRESHNESS_STATES = frozenset({"CURRENT", "FRESH"})
+
+
+@dataclass(frozen=True)
+class HoloIndexQueryHit:
+    """Bounded query hit normalized for RedDog/WRE receipts."""
+
+    path: str
+    title: str = ""
+    score: Any = None
+    digest: str = ""
+    evidence_ref: str = ""
+    source_class: str = SOURCE_CLASS_HOLOINDEX
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class HoloIndexQueryReceipt:
+    """Read-only query receipt bound to a HoloIndex generation."""
+
+    schema_version: str
+    source: str
+    source_class: str
+    ok: bool
+    query: str
+    freshness: str
+    hits: list[HoloIndexQueryHit] = field(default_factory=list)
+    error: str = ""
+    freshness_generation_id: str = ""
+    freshness_receipt_digest: str = ""
+    freshness_receipt_path: str = ""
+    repo_head_sha: str = ""
+    index_gap_detected: bool = False
+    stale_reasons: list[str] = field(default_factory=list)
+    no_holoindex_reindex_performed: bool = True
+    receipt_id: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["hits"] = [hit.to_dict() for hit in self.hits]
+        return data
+
+
+def digest_json(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def file_digest(path: Path | str) -> str:
+    receipt_path = Path(path)
+    try:
+        return "sha256:" + hashlib.sha256(receipt_path.read_bytes()).hexdigest()
+    except Exception:
+        return ""
+
+
+def load_generation_binding(
+    *,
+    ssd_path: Path | str | None = None,
+    receipt_path: Path | str | None = None,
+) -> Mapping[str, str]:
+    """Load public freshness-generation fields without mutating HoloIndex."""
+
+    path = Path(receipt_path) if receipt_path else freshness_receipt_path(Path(ssd_path or "E:/HoloIndex"))
+    try:
+        receipt = load_freshness_receipt(path)
+    except Exception:
+        return {
+            "freshness_generation_id": "",
+            "freshness_receipt_digest": "",
+            "freshness_receipt_path": str(path),
+            "repo_head_sha": "",
+        }
+    return generation_binding_from_receipt(receipt, receipt_path=path)
+
+
+def generation_binding_from_receipt(
+    receipt: HoloIndexFreshnessReceipt | Mapping[str, Any] | None,
+    *,
+    receipt_path: Path | str | None = None,
+) -> Mapping[str, str]:
+    """Return generation fields from a loaded freshness receipt."""
+
+    if receipt is None:
+        return {
+            "freshness_generation_id": "",
+            "freshness_receipt_digest": "",
+            "freshness_receipt_path": str(receipt_path or ""),
+            "repo_head_sha": "",
+        }
+    if isinstance(receipt, HoloIndexFreshnessReceipt):
+        generation_id = receipt.generation_id
+        repo_head_sha = receipt.repo_head_sha
+        digest = digest_json(receipt.to_dict())
+    elif isinstance(receipt, Mapping):
+        generation_id = str(receipt.get("generation_id") or "")
+        repo_head_sha = str(receipt.get("repo_head_sha") or "")
+        digest = digest_json(receipt)
+    else:
+        generation_id = ""
+        repo_head_sha = ""
+        digest = ""
+    if receipt_path:
+        disk_digest = file_digest(receipt_path)
+        if disk_digest:
+            digest = disk_digest
+    return {
+        "freshness_generation_id": generation_id,
+        "freshness_receipt_digest": digest,
+        "freshness_receipt_path": str(receipt_path or ""),
+        "repo_head_sha": repo_head_sha,
+    }
+
+
+def normalize_query_hits(value: Any, *, source_class: str, limit: int = 8) -> list[HoloIndexQueryHit]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return []
+    hits: list[HoloIndexQueryHit] = []
+    for item in value[: max(0, int(limit or 0))]:
+        if not isinstance(item, Mapping):
+            continue
+        path = str(item.get("path") or item.get("file") or "").replace("\\", "/").strip()
+        digest = str(item.get("digest") or item.get("content_digest") or "").strip()
+        evidence_ref = str(item.get("evidence_ref") or "").strip()
+        hits.append(
+            HoloIndexQueryHit(
+                path=path[:240],
+                title=str(item.get("title") or "")[:160],
+                score=item.get("score"),
+                digest=digest[:96],
+                evidence_ref=evidence_ref[:320],
+                source_class=source_class,
+            )
+        )
+    return hits
+
+
+def build_query_receipt(
+    *,
+    source: str,
+    source_class: str,
+    query: str,
+    result: Mapping[str, Any],
+    require_generation: bool,
+    generation_binding: Mapping[str, Any] | None = None,
+) -> Mapping[str, Any]:
+    """Normalize a query result into a deterministic receipt.
+
+    If ``require_generation`` is true, any fresh/current success without a
+    generation id is downgraded to UNKNOWN and marked as an INDEX_GAP.
+    """
+
+    binding = dict(generation_binding or {})
+    if not binding:
+        binding = {
+            "freshness_generation_id": str(result.get("freshness_generation_id") or ""),
+            "freshness_receipt_digest": str(result.get("freshness_receipt_digest") or ""),
+            "freshness_receipt_path": str(result.get("freshness_receipt_path") or ""),
+            "repo_head_sha": str(result.get("repo_head_sha") or ""),
+        }
+    freshness = str(result.get("freshness") or "UNKNOWN").upper()
+    ok = result.get("ok") is True
+    error = str(result.get("error") or "")
+    stale_reasons: list[str] = []
+    generation_id = str(binding.get("freshness_generation_id") or "")
+    if require_generation and ok and freshness in FRESHNESS_STATES and not generation_id:
+        freshness = "UNKNOWN"
+        stale_reasons.append("missing_holoindex_generation_id")
+        error = error or "missing_holoindex_generation_id"
+    if (
+        require_generation
+        and ok
+        and freshness in FRESHNESS_STATES
+        and not str(binding.get("freshness_receipt_digest") or "")
+    ):
+        freshness = "UNKNOWN"
+        stale_reasons.append("missing_holoindex_freshness_receipt_digest")
+        error = error or "missing_holoindex_freshness_receipt_digest"
+    hits = normalize_query_hits(result.get("hits"), source_class=source_class)
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "source": str(source or ""),
+        "source_class": str(source_class or ""),
+        "ok": ok,
+        "query": str(result.get("query") or query),
+        "freshness": freshness,
+        "hits": [hit.to_dict() for hit in hits],
+        "error": error,
+        "freshness_generation_id": generation_id,
+        "freshness_receipt_digest": str(binding.get("freshness_receipt_digest") or ""),
+        "freshness_receipt_path": str(binding.get("freshness_receipt_path") or ""),
+        "repo_head_sha": str(binding.get("repo_head_sha") or ""),
+        "index_gap_detected": bool(stale_reasons or result.get("index_gap_detected") is True),
+        "stale_reasons": stale_reasons,
+        "no_holoindex_reindex_performed": True,
+    }
+    return {**payload, "receipt_id": digest_json(payload)}
+
+
+__all__ = [
+    "FRESHNESS_STATES",
+    "HoloIndexQueryHit",
+    "HoloIndexQueryReceipt",
+    "SCHEMA_VERSION",
+    "SOURCE_CLASS_BRAIN",
+    "SOURCE_CLASS_BREADCRUMB",
+    "SOURCE_CLASS_CODEINDEX",
+    "SOURCE_CLASS_HOLOINDEX",
+    "SOURCE_CLASS_MEMEX",
+    "build_query_receipt",
+    "digest_json",
+    "file_digest",
+    "generation_binding_from_receipt",
+    "load_generation_binding",
+    "normalize_query_hits",
+]

--- a/holo_index/tests/test_holoindex_query_receipt.py
+++ b/holo_index/tests/test_holoindex_query_receipt.py
@@ -1,0 +1,116 @@
+"""Tests for HOLOINDEX_QUERY_RECEIPT_AND_GENERATION_BINDING_PHASE1."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from holo_index.freshness_receipt import (
+    CollectionFreshness,
+    HoloIndexFreshnessReceipt,
+    write_freshness_receipt,
+)
+from holo_index.query_receipt import (
+    SCHEMA_VERSION,
+    SOURCE_CLASS_HOLOINDEX,
+    build_query_receipt,
+    load_generation_binding,
+)
+
+
+def _freshness_receipt() -> HoloIndexFreshnessReceipt:
+    return HoloIndexFreshnessReceipt(
+        schema_version="holoindex_freshness_receipt.v1",
+        generated_at="2026-07-16T00:00:00+00:00",
+        repo_root="O:/Foundups-Agent",
+        repo_head_sha="abc123",
+        ssd_path="E:/HoloIndex",
+        source="test",
+        generation_id="sha256:generation",
+        collections=[
+            CollectionFreshness(
+                name="navigation_code",
+                count=1,
+                status="indexed",
+                source="test",
+                repo_head_sha="abc123",
+                last_indexed_at="2026-07-16T00:00:00+00:00",
+                source_manifest_digest="sha256:manifest",
+                indexed_paths_digest="sha256:paths",
+                removed_paths_digest="sha256:removed",
+                verification="PASS",
+            )
+        ],
+    )
+
+
+def test_load_generation_binding_from_freshness_receipt(tmp_path: Path) -> None:
+    path = tmp_path / "indexes" / "holoindex_freshness_receipt.json"
+    write_freshness_receipt(_freshness_receipt(), path)
+
+    binding = load_generation_binding(receipt_path=path)
+
+    assert binding["freshness_generation_id"] == "sha256:generation"
+    assert binding["freshness_receipt_digest"].startswith("sha256:")
+    assert binding["freshness_receipt_path"] == str(path)
+    assert binding["repo_head_sha"] == "abc123"
+
+
+def test_query_receipt_binds_generation_and_hits() -> None:
+    receipt = build_query_receipt(
+        source="holoindex",
+        source_class=SOURCE_CLASS_HOLOINDEX,
+        query="RedDog operational loop",
+        result={
+            "ok": True,
+            "query": "RedDog operational loop",
+            "freshness": "CURRENT",
+            "hits": [{"path": "holo_index/query_receipt.py", "title": "query receipts", "score": 0.9}],
+        },
+        require_generation=True,
+        generation_binding={
+            "freshness_generation_id": "sha256:generation",
+            "freshness_receipt_digest": "sha256:freshness",
+            "freshness_receipt_path": "E:/HoloIndex/indexes/holoindex_freshness_receipt.json",
+            "repo_head_sha": "abc123",
+        },
+    )
+
+    assert receipt["schema_version"] == SCHEMA_VERSION
+    assert receipt["receipt_id"].startswith("sha256:")
+    assert receipt["freshness_generation_id"] == "sha256:generation"
+    assert receipt["hits"][0]["source_class"] == SOURCE_CLASS_HOLOINDEX
+    assert receipt["no_holoindex_reindex_performed"] is True
+
+
+def test_fresh_query_without_generation_is_stale_not_fresh() -> None:
+    receipt = build_query_receipt(
+        source="holoindex",
+        source_class=SOURCE_CLASS_HOLOINDEX,
+        query="RedDog operational loop",
+        result={
+            "ok": True,
+            "query": "RedDog operational loop",
+            "freshness": "CURRENT",
+            "hits": [{"path": "holo_index/query_receipt.py"}],
+        },
+        require_generation=True,
+    )
+
+    assert receipt["ok"] is True
+    assert receipt["freshness"] == "UNKNOWN"
+    assert receipt["index_gap_detected"] is True
+    assert "missing_holoindex_generation_id" in receipt["stale_reasons"]
+
+
+def test_query_receipt_does_not_claim_reindex_or_command_authority() -> None:
+    receipt = build_query_receipt(
+        source="holoindex",
+        source_class=SOURCE_CLASS_HOLOINDEX,
+        query="status",
+        result={"ok": False, "freshness": "UNKNOWN", "hits": [], "error": "offline"},
+        require_generation=True,
+    )
+
+    assert receipt["no_holoindex_reindex_performed"] is True
+    assert "command" not in receipt
+    assert "subprocess" not in receipt

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
@@ -38,6 +38,12 @@ from modules.communication.moltbot_bridge.src.reddog_wsp15_allocation_receipt im
     canonical_reddog_wsp15_allocation_digest,
     validate_reddog_wsp15_allocation_receipt,
 )
+from holo_index.query_receipt import (
+    SOURCE_CLASS_CODEINDEX,
+    SOURCE_CLASS_HOLOINDEX,
+    build_query_receipt,
+    load_generation_binding,
+)
 
 
 READONLY_0102_AUDIT_WORKER_RECEIPT_SCHEMA = "readonly_0102_audit_worker_receipt.v1"
@@ -126,18 +132,22 @@ class HoloIndexReadOnlyQueryAdapter:
     """Read-only HoloIndex discovery adapter for repo audit workers."""
 
     repo_root: Path
+    ssd_path: Path | str | None = None
+    freshness_receipt_path: Path | str | None = None
 
     def query(self, *, query: str, allowed_paths: Sequence[str], limit: int) -> Mapping[str, Any]:
         started = time.monotonic()
         previous_readonly = os.environ.get("HOLOINDEX_QUERY_READONLY")
         os.environ["HOLOINDEX_QUERY_READONLY"] = "1"
+        ssd_path = Path(self.ssd_path or os.getenv("HOLOINDEX_SSD_PATH") or "E:/HoloIndex")
+        binding = load_generation_binding(ssd_path=ssd_path, receipt_path=self.freshness_receipt_path)
         try:
             from holo_index.core.holo_index import HoloIndex
 
             original_logger = getattr(HoloIndex, "_log_agent_action", None)
             try:
                 setattr(HoloIndex, "_log_agent_action", lambda *args, **kwargs: None)
-                index = HoloIndex(str(self.repo_root), quiet=True)
+                index = HoloIndex(ssd_path=str(ssd_path), quiet=True)
                 result = index.search(str(query or ""), limit=max(1, min(int(limit or 8), 20)))
             finally:
                 if original_logger is not None:
@@ -152,6 +162,7 @@ class HoloIndexReadOnlyQueryAdapter:
                 "error": f"holoindex_query_failed:{type(exc).__name__}",
                 "latency_ms": int((time.monotonic() - started) * 1000),
                 "no_holoindex_reindex_performed": True,
+                **binding,
             }
         finally:
             if previous_readonly is None:
@@ -168,6 +179,7 @@ class HoloIndexReadOnlyQueryAdapter:
             "error": "",
             "latency_ms": int((time.monotonic() - started) * 1000),
             "no_holoindex_reindex_performed": True,
+            **binding,
         }
 
 
@@ -550,16 +562,14 @@ def _query_index(
         result = {"ok": False, "source": source, "query": query, "hits": [], "error": "query_exception"}
     if not isinstance(result, Mapping):
         result = {"ok": False, "source": source, "query": query, "hits": [], "error": "query_not_mapping"}
-    receipt = {
-        "source": source,
-        "ok": result.get("ok") is True,
-        "query": str(result.get("query") or query),
-        "freshness": str(result.get("freshness") or "UNKNOWN"),
-        "hits": _bounded_index_hits(result.get("hits")),
-        "error": str(result.get("error") or ""),
-        "no_holoindex_reindex_performed": True,
-    }
-    return {**receipt, "receipt_id": "sha256:" + _digest(receipt)}
+    source_class = SOURCE_CLASS_HOLOINDEX if source == "holoindex" else SOURCE_CLASS_CODEINDEX
+    return build_query_receipt(
+        source=source,
+        source_class=source_class,
+        query=query,
+        result=result,
+        require_generation=source == "holoindex",
+    )
 
 
 def _query_rejection_reason(receipt: Mapping[str, Any]) -> str:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
@@ -66,10 +66,20 @@ def isolated_agent_db(tmp_path, monkeypatch):
 
 
 class _FakeQueryAdapter:
-    def __init__(self, *, ok: bool = True, error: str = "", freshness: str = "FRESH") -> None:
+    def __init__(
+        self,
+        *,
+        ok: bool = True,
+        error: str = "",
+        freshness: str = "FRESH",
+        generation_id: str = "sha256:generation",
+        freshness_digest: str = "sha256:freshness",
+    ) -> None:
         self.ok = ok
         self.error = error
         self.freshness = freshness
+        self.generation_id = generation_id
+        self.freshness_digest = freshness_digest
         self.calls = []
 
     def query(self, *, query: str, allowed_paths, limit: int):
@@ -91,6 +101,10 @@ class _FakeQueryAdapter:
             if self.ok
             else [],
             "error": self.error,
+            "freshness_generation_id": self.generation_id,
+            "freshness_receipt_digest": self.freshness_digest,
+            "freshness_receipt_path": "E:/HoloIndex/indexes/holoindex_freshness_receipt.json",
+            "repo_head_sha": "abc123",
         }
 
 
@@ -388,6 +402,46 @@ def test_model_backed_rejects_holoindex_error_before_model_call(tmp_path: Path) 
     assert result.accepted is False
     assert ReadOnlyAuditTaskRejectReason.INDEX_QUERY_FAILED in result.rejection_reasons
     assert not runner.calls
+
+
+def test_model_backed_rejects_fresh_holoindex_without_generation_before_model_call(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    runner = _EchoEvidenceModelRunner()
+
+    result = execute_reddog_readonly_audit_task(
+        task_context=_model_context(),
+        repo_root=root,
+        task_id="task-1",
+        model_runner=runner,
+        holoindex_adapter=_FakeQueryAdapter(generation_id=""),
+        codeindex_adapter=_FakeQueryAdapter(),
+    )
+
+    assert result.accepted is False
+    assert ReadOnlyAuditTaskRejectReason.INDEX_QUERY_STALE in result.rejection_reasons
+    assert not runner.calls
+
+
+def test_model_backed_binds_holoindex_generation_into_worker_receipt(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+
+    result = execute_reddog_readonly_audit_task(
+        task_context=_model_context(),
+        repo_root=root,
+        task_id="task-1",
+        model_runner=_EchoEvidenceModelRunner(),
+        holoindex_adapter=_FakeQueryAdapter(generation_id="sha256:generation-123"),
+        codeindex_adapter=_FakeQueryAdapter(),
+    )
+
+    assert result.accepted is True
+    assert result.report is not None
+    receipt = result.report["worker_receipt"]["holoindex_query_receipt"]
+    assert receipt["schema_version"] == "holoindex_query_receipt.v1"
+    assert receipt["source_class"] == "holoindex"
+    assert receipt["freshness_generation_id"] == "sha256:generation-123"
+    assert receipt["freshness_receipt_digest"] == "sha256:freshness"
+    assert receipt["no_holoindex_reindex_performed"] is True
 
 
 def test_model_backed_rejects_wsp15_binding_digest_mismatch(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add `holo_index/query_receipt.py` for deterministic, generation-bound HoloIndex query receipts
- bind RedDog read-only 0102 audit HoloIndex queries to freshness generation metadata from the configured freshness receipt
- fail closed before model calls when HoloIndex claims fresh/current results without generation or freshness-receipt binding

## WSP_97 Truth Boundary
- OBSERVED: query receipts include source class, generation id, freshness receipt digest/path, repo head, stale reasons, and no-reindex attestation
- OBSERVED: RedDog read-only audit worker propagates the HoloIndex query receipt into worker receipts/model context
- SPECIFIED_NOT_IMPLEMENTED: HoloIndex maintenance/reindex, Memex projection, Brain/Breadcrumb query receipts, and external research promotion remain separate slices

## Validation
- `python -m py_compile holo_index\\query_receipt.py modules\\communication\\moltbot_bridge\\src\\reddog_readonly_0102_audit_worker_runtime.py`
- `pytest holo_index/tests/test_holoindex_query_receipt.py holo_index/tests/test_holoindex_freshness_receipt.py holo_index/tests/test_holoindex_incremental_foundup_index.py holo_index/tests/test_holoindex_incremental_index_executor.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py -q --tb=short` -> 58 passed
- `git diff --cached --check` -> clean
- cached diff additions ASCII/NUL scan -> PASS

## Boundary
No HoloIndex re-index, collection mutation, shell execution, RedDog action authority, OpenClaw enqueue, Hermes dispatch, worktree operation, or Memex/Brain write path.