### PR TITLE
feat(holoindex): add governed Memex projection adapter

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,26 @@
 # HoloIndex Package ModLog
 
+## [2026-07-16] HOLOINDEX_MEMEX_GOVERNED_PROJECTION_ADAPTER_PHASE1
+
+**Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice
+**WSP**: 00, 15, 22, 50, 60, 97
+
+- ADD `holo_index/memex_projection_adapter.py`: deterministic, read-only
+  projection from an accepted FoundUp Memex/Brain current-state view into
+  shadow HoloIndex records with `source_class=memex`, snapshot binding,
+  access-policy digest, content digests, and an immutable projection receipt.
+- ADD sensitivity filtering: secret-bearing Memex sections are rejected before
+  record creation while safe sibling sections survive with honest
+  `records_rejected` telemetry.
+- TEST `tests/test_holoindex_memex_projection_adapter.py`: scoped projection,
+  deterministic receipts, cross-FoundUp rejection, snapshot/source-policy
+  fail-closed behavior, secret filtering, and AST guards against execution,
+  database, HoloIndex collection, or filesystem write paths.
+- Boundary: no HoloIndex write, no Memex write, no Brain/Breadcrumb write, no
+  PatternMemory promotion, no queue/worker authority, no external retrieval,
+  and no runtime re-index. A later governed indexer may promote the shadow
+  records after verification; this adapter only prepares the projection.
+
 ## [2026-07-16] HOLOINDEX_QUERY_RECEIPT_AND_GENERATION_BINDING_PHASE1
 
 **Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice

--- a/holo_index/memex_projection_adapter.py
+++ b/holo_index/memex_projection_adapter.py
@@ -1,0 +1,304 @@
+"""Governed Memex projection records for HoloIndex.
+
+This adapter turns an accepted FoundUp Memex view into deterministic shadow
+records that a later governed indexer may promote into HoloIndex. It does not
+write HoloIndex, Memex, Brain, Breadcrumbs, repository state, or queues.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from holo_index.query_receipt import SOURCE_CLASS_MEMEX, digest_json
+
+
+SCHEMA_VERSION = "holoindex_memex_governed_projection_adapter.v1"
+RECEIPT_SCHEMA_VERSION = "holoindex_memex_snapshot_projection_receipt.v1"
+PROJECTION_ACCEPTED = "MEMEX_PROJECTION_READY"
+PROJECTION_REJECTED = "MEMEX_PROJECTION_REJECTED"
+DEFAULT_ACCESS_POLICY_DIGEST = (
+    "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+)
+
+_SECRET_RE = re.compile(
+    r"(?i)(api[_-]?key|secret|password|private[_-]?key|bearer\s+[A-Za-z0-9._-]+|sk-[A-Za-z0-9_-]+)"
+)
+
+
+@dataclass(frozen=True)
+class MemexProjectionRecord:
+    """One shadow HoloIndex record derived from a Memex view."""
+
+    record_id: str
+    source_class: str
+    foundup_id: str
+    memex_snapshot_id: str
+    source_scope: str
+    source_revision: str
+    title: str
+    text: str
+    metadata: dict[str, Any]
+    content_digest: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class MemexSnapshotProjectionReceipt:
+    """Immutable receipt for one governed Memex projection."""
+
+    schema_version: str
+    memex_snapshot_id: str
+    source_scope: str
+    source_revision: str
+    content_manifest_digest: str
+    created_at: str
+    access_policy_digest: str
+    records_indexed: int
+    records_rejected: int
+    holoindex_generation_id: str
+    verification: str
+    rejected_reasons: tuple[str, ...] = ()
+    no_holoindex_write_performed: bool = True
+    no_memex_write_performed: bool = True
+    no_brain_write_performed: bool = True
+    no_breadcrumb_write_performed: bool = True
+    receipt_id: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class MemexProjectionResult:
+    accepted: bool
+    status: str
+    records: tuple[MemexProjectionRecord, ...]
+    receipt: MemexSnapshotProjectionReceipt | None
+    rejection_reasons: tuple[str, ...]
+    no_holoindex_write_performed: bool = True
+    no_memex_write_performed: bool = True
+    no_brain_write_performed: bool = True
+    no_breadcrumb_write_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "accepted": self.accepted,
+            "status": self.status,
+            "records": [record.to_dict() for record in self.records],
+            "receipt": self.receipt.to_dict() if self.receipt else None,
+            "rejection_reasons": list(self.rejection_reasons),
+            "no_holoindex_write_performed": self.no_holoindex_write_performed,
+            "no_memex_write_performed": self.no_memex_write_performed,
+            "no_brain_write_performed": self.no_brain_write_performed,
+            "no_breadcrumb_write_performed": self.no_breadcrumb_write_performed,
+        }
+
+
+def project_foundup_memex_to_holoindex_shadow(
+    *,
+    memex_view: Mapping[str, Any],
+    source_scope: str,
+    source_revision: str,
+    allowed_foundup_ids: Sequence[str],
+    access_policy_digest: str = DEFAULT_ACCESS_POLICY_DIGEST,
+    holoindex_generation_id: str = "",
+    now_iso: str | None = None,
+) -> MemexProjectionResult:
+    """Build shadow HoloIndex records from an accepted FoundUp Memex view."""
+
+    reasons: list[str] = []
+    if not isinstance(memex_view, Mapping):
+        return _reject("memex_view_not_mapping")
+    foundup_id = _clean(memex_view.get("foundup_id"))
+    if not foundup_id:
+        reasons.append("missing_foundup_id")
+    allowed = {_clean(item) for item in allowed_foundup_ids if _clean(item)}
+    if foundup_id and foundup_id not in allowed:
+        reasons.append("foundup_scope_not_authorized")
+    memex_snapshot_id = _clean(
+        memex_view.get("foundup_memex_view_id")
+        or memex_view.get("foundup_brain_view_id")
+        or memex_view.get("snapshot_id")
+    )
+    snapshot_id = _clean(memex_view.get("snapshot_id"))
+    snapshot_digest = _clean(memex_view.get("snapshot_content_digest"))
+    if not memex_snapshot_id or not snapshot_id or not snapshot_digest:
+        reasons.append("missing_snapshot_binding")
+    if not _clean(source_scope):
+        reasons.append("missing_source_scope")
+    if not _clean(source_revision):
+        reasons.append("missing_source_revision")
+    if not _clean(access_policy_digest).startswith("sha256:"):
+        reasons.append("invalid_access_policy_digest")
+
+    candidate_sections = _candidate_sections(memex_view)
+    records: list[MemexProjectionRecord] = []
+    rejected: list[str] = []
+    for label, payload in candidate_sections:
+        if _contains_secret(payload):
+            rejected.append(f"secret_bearing_record:{label}")
+            continue
+        record = _record_from_section(
+            label=label,
+            payload=payload,
+            foundup_id=foundup_id,
+            memex_snapshot_id=memex_snapshot_id,
+            source_scope=_clean(source_scope),
+            source_revision=_clean(source_revision),
+            access_policy_digest=_clean(access_policy_digest),
+            snapshot_id=snapshot_id,
+            snapshot_digest=snapshot_digest,
+        )
+        records.append(record)
+
+    if not records:
+        reasons.append("no_projectable_memex_records")
+    if reasons:
+        return _reject(*reasons, *rejected)
+
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "records": [
+            {
+                "record_id": record.record_id,
+                "content_digest": record.content_digest,
+                "source_class": record.source_class,
+            }
+            for record in records
+        ],
+        "rejected": rejected,
+    }
+    content_manifest_digest = digest_json(manifest)
+    receipt_payload = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "memex_snapshot_id": memex_snapshot_id,
+        "source_scope": _clean(source_scope),
+        "source_revision": _clean(source_revision),
+        "content_manifest_digest": content_manifest_digest,
+        "created_at": now_iso or datetime.now(timezone.utc).isoformat(),
+        "access_policy_digest": _clean(access_policy_digest),
+        "records_indexed": len(records),
+        "records_rejected": len(rejected),
+        "holoindex_generation_id": _clean(holoindex_generation_id),
+        "verification": "PASS",
+        "rejected_reasons": tuple(rejected),
+        "no_holoindex_write_performed": True,
+        "no_memex_write_performed": True,
+        "no_brain_write_performed": True,
+        "no_breadcrumb_write_performed": True,
+    }
+    receipt = MemexSnapshotProjectionReceipt(
+        **receipt_payload,
+        receipt_id=digest_json(receipt_payload),
+    )
+    return MemexProjectionResult(
+        accepted=True,
+        status=PROJECTION_ACCEPTED,
+        records=tuple(records),
+        receipt=receipt,
+        rejection_reasons=(),
+    )
+
+
+def _candidate_sections(memex_view: Mapping[str, Any]) -> tuple[tuple[str, Any], ...]:
+    sections: list[tuple[str, Any]] = []
+    for key in ("identity", "current_state", "roadmap_state"):
+        value = memex_view.get(key)
+        if isinstance(value, Mapping) and value:
+            sections.append((key, dict(value)))
+    outcomes = memex_view.get("verified_outcomes")
+    if isinstance(outcomes, Sequence) and not isinstance(outcomes, (str, bytes)):
+        for index, outcome in enumerate(outcomes):
+            if isinstance(outcome, Mapping):
+                sections.append((f"verified_outcome:{index}", dict(outcome)))
+    return tuple(sections)
+
+
+def _record_from_section(
+    *,
+    label: str,
+    payload: Any,
+    foundup_id: str,
+    memex_snapshot_id: str,
+    source_scope: str,
+    source_revision: str,
+    access_policy_digest: str,
+    snapshot_id: str,
+    snapshot_digest: str,
+) -> MemexProjectionRecord:
+    text = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    content_digest = "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+    record_payload = {
+        "foundup_id": foundup_id,
+        "label": label,
+        "memex_snapshot_id": memex_snapshot_id,
+        "source_revision": source_revision,
+        "content_digest": content_digest,
+        "access_policy_digest": access_policy_digest,
+    }
+    record_id = digest_json(record_payload)
+    return MemexProjectionRecord(
+        record_id=record_id,
+        source_class=SOURCE_CLASS_MEMEX,
+        foundup_id=foundup_id,
+        memex_snapshot_id=memex_snapshot_id,
+        source_scope=source_scope,
+        source_revision=source_revision,
+        title=f"{foundup_id} memex {label}",
+        text=text,
+        metadata={
+            "source_class": SOURCE_CLASS_MEMEX,
+            "foundup_id": foundup_id,
+            "memex_snapshot_id": memex_snapshot_id,
+            "snapshot_id": snapshot_id,
+            "snapshot_content_digest": snapshot_digest,
+            "section": label,
+            "access_policy_digest": access_policy_digest,
+            "source_scope": source_scope,
+            "source_revision": source_revision,
+        },
+        content_digest=content_digest,
+    )
+
+
+def _reject(*reasons: str) -> MemexProjectionResult:
+    clean_reasons = tuple(dict.fromkeys(reason for reason in reasons if reason))
+    return MemexProjectionResult(
+        accepted=False,
+        status=PROJECTION_REJECTED,
+        records=(),
+        receipt=None,
+        rejection_reasons=clean_reasons,
+    )
+
+
+def _contains_secret(value: Any) -> bool:
+    if isinstance(value, Mapping):
+        return any(_contains_secret(key) or _contains_secret(item) for key, item in value.items())
+    if isinstance(value, (list, tuple)):
+        return any(_contains_secret(item) for item in value)
+    return bool(_SECRET_RE.search(str(value)))
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+__all__ = [
+    "DEFAULT_ACCESS_POLICY_DIGEST",
+    "MemexProjectionRecord",
+    "MemexProjectionResult",
+    "MemexSnapshotProjectionReceipt",
+    "PROJECTION_ACCEPTED",
+    "PROJECTION_REJECTED",
+    "RECEIPT_SCHEMA_VERSION",
+    "SCHEMA_VERSION",
+    "project_foundup_memex_to_holoindex_shadow",
+]

--- a/holo_index/tests/test_holoindex_memex_projection_adapter.py
+++ b/holo_index/tests/test_holoindex_memex_projection_adapter.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from holo_index.memex_projection_adapter import (
+    DEFAULT_ACCESS_POLICY_DIGEST,
+    PROJECTION_ACCEPTED,
+    PROJECTION_REJECTED,
+    RECEIPT_SCHEMA_VERSION,
+    SCHEMA_VERSION,
+    project_foundup_memex_to_holoindex_shadow,
+)
+
+
+MODULE_PATH = Path(__file__).parents[1] / "memex_projection_adapter.py"
+FIXED_NOW = "2026-07-16T00:00:00+00:00"
+
+
+def _memex_view() -> dict[str, object]:
+    return {
+        "schema_version": "foundup_brain_current_state.v1",
+        "foundup_brain_view_id": "sha256:brain-view",
+        "foundup_id": "foundups-agent",
+        "snapshot_id": "snapshot-1",
+        "snapshot_content_digest": "sha256:snapshot",
+        "identity": {
+            "foundup_id": "foundups-agent",
+            "name": "Foundups Agent",
+        },
+        "current_state": {
+            "repo_head_sha": "abc123",
+            "selected_slice": "HOLOINDEX_MEMEX_GOVERNED_PROJECTION_ADAPTER_PHASE1",
+        },
+        "roadmap_state": {
+            "roadmap_id": "r1",
+            "version": "v1",
+            "content_digest": "sha256:roadmap",
+        },
+        "verified_outcomes": [
+            {
+                "outcome_id": "o1",
+                "accepted": True,
+                "held_out_passed": True,
+                "content_digest": "sha256:outcome",
+            }
+        ],
+    }
+
+
+def _project(**overrides: object):
+    kwargs = {
+        "memex_view": _memex_view(),
+        "source_scope": "foundup:foundups-agent",
+        "source_revision": "abc123",
+        "allowed_foundup_ids": ("foundups-agent",),
+        "holoindex_generation_id": "generation-1",
+        "now_iso": FIXED_NOW,
+    }
+    kwargs.update(overrides)
+    return project_foundup_memex_to_holoindex_shadow(**kwargs)
+
+
+def test_memex_projection_builds_shadow_records_and_receipt() -> None:
+    result = _project()
+
+    assert result.accepted is True
+    assert result.status == PROJECTION_ACCEPTED
+    assert len(result.records) == 4
+    assert result.receipt is not None
+
+    receipt = result.receipt.to_dict()
+    assert receipt["schema_version"] == RECEIPT_SCHEMA_VERSION
+    assert receipt["memex_snapshot_id"] == "sha256:brain-view"
+    assert receipt["source_scope"] == "foundup:foundups-agent"
+    assert receipt["source_revision"] == "abc123"
+    assert receipt["created_at"] == FIXED_NOW
+    assert receipt["access_policy_digest"] == DEFAULT_ACCESS_POLICY_DIGEST
+    assert receipt["records_indexed"] == 4
+    assert receipt["records_rejected"] == 0
+    assert receipt["holoindex_generation_id"] == "generation-1"
+    assert receipt["verification"] == "PASS"
+    assert receipt["receipt_id"].startswith("sha256:")
+    assert receipt["no_holoindex_write_performed"] is True
+    assert receipt["no_memex_write_performed"] is True
+    assert receipt["no_brain_write_performed"] is True
+    assert receipt["no_breadcrumb_write_performed"] is True
+
+    for record in result.records:
+        record_dict = record.to_dict()
+        assert record_dict["source_class"] == "memex"
+        assert record_dict["foundup_id"] == "foundups-agent"
+        assert record_dict["memex_snapshot_id"] == "sha256:brain-view"
+        assert record_dict["source_scope"] == "foundup:foundups-agent"
+        assert record_dict["source_revision"] == "abc123"
+        assert record_dict["content_digest"].startswith("sha256:")
+        assert record_dict["metadata"]["source_class"] == "memex"
+        assert record_dict["metadata"]["snapshot_id"] == "snapshot-1"
+        assert record_dict["metadata"]["snapshot_content_digest"] == "sha256:snapshot"
+        assert record_dict["metadata"]["access_policy_digest"] == DEFAULT_ACCESS_POLICY_DIGEST
+
+
+def test_memex_projection_is_deterministic_for_same_snapshot() -> None:
+    first = _project()
+    second = _project()
+
+    assert first.to_dict() == second.to_dict()
+
+
+def test_memex_projection_rejects_cross_foundup_scope() -> None:
+    result = _project(allowed_foundup_ids=("other-foundup",))
+
+    assert result.accepted is False
+    assert result.status == PROJECTION_REJECTED
+    assert "foundup_scope_not_authorized" in result.rejection_reasons
+    assert result.records == ()
+    assert result.receipt is None
+
+
+def test_memex_projection_filters_secret_record_without_dropping_siblings() -> None:
+    view = _memex_view()
+    view["verified_outcomes"] = [
+        {"outcome_id": "safe", "content_digest": "sha256:safe"},
+        {"outcome_id": "unsafe", "api_key": "sk-testsecret"},
+    ]
+
+    result = _project(memex_view=view)
+
+    assert result.accepted is True
+    assert result.receipt is not None
+    assert result.receipt.records_indexed == 4
+    assert result.receipt.records_rejected == 1
+    assert result.receipt.rejected_reasons == ("secret_bearing_record:verified_outcome:1",)
+    joined_records = "\n".join(record.text for record in result.records)
+    assert "sk-testsecret" not in joined_records
+    assert "unsafe" not in joined_records
+
+
+def test_memex_projection_rejects_missing_snapshot_binding() -> None:
+    view = _memex_view()
+    view.pop("foundup_brain_view_id")
+    view.pop("snapshot_id")
+
+    result = _project(memex_view=view)
+
+    assert result.accepted is False
+    assert "missing_snapshot_binding" in result.rejection_reasons
+
+
+def test_memex_projection_rejects_missing_source_scope_and_revision() -> None:
+    result = _project(source_scope="", source_revision="")
+
+    assert result.accepted is False
+    assert "missing_source_scope" in result.rejection_reasons
+    assert "missing_source_revision" in result.rejection_reasons
+
+
+def test_memex_projection_rejects_invalid_access_policy_digest() -> None:
+    result = _project(access_policy_digest="policy-v1")
+
+    assert result.accepted is False
+    assert "invalid_access_policy_digest" in result.rejection_reasons
+
+
+def test_memex_projection_is_projection_only_by_ast() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_imports = {
+        "subprocess",
+        "requests",
+        "httpx",
+        "sqlite3",
+        "chromadb",
+    }
+    banned_calls = {
+        "add",
+        "upsert",
+        "delete",
+        "reset",
+        "_reset_collection",
+        "write_text",
+        "write_bytes",
+        "open",
+    }
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".", 1)[0]
+                assert root not in banned_imports
+        if isinstance(node, ast.ImportFrom) and node.module:
+            root = node.module.split(".", 1)[0]
+            assert root not in banned_imports
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Attribute):
+                assert func.attr not in banned_calls
+            if isinstance(func, ast.Name):
+                assert func.id not in banned_calls
+
+
+def test_memex_projection_exports_schema_version() -> None:
+    assert SCHEMA_VERSION == "holoindex_memex_governed_projection_adapter.v1"

--- a/modules/communication/moltbot_bridge/tests/test_foundup_brain_current_state.py
+++ b/modules/communication/moltbot_bridge/tests/test_foundup_brain_current_state.py
@@ -40,6 +40,9 @@ def _snapshot(*, brain_available: bool = True, worker_claims=None, queue_items=N
         repo_head_sha=HEAD,
         ssd_path="E:/HoloIndex",
         source="ci_targeted_reindex",
+        generation_id=(
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ),
         collections=[
             CollectionFreshness(
                 name="navigation_work_ledger",
@@ -48,6 +51,17 @@ def _snapshot(*, brain_available: bool = True, worker_claims=None, queue_items=N
                 source="ci_targeted_reindex",
                 repo_head_sha=HEAD,
                 last_indexed_at=NOW,
+                source_manifest_digest=(
+                    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                ),
+                indexed_paths_digest=(
+                    "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                ),
+                removed_paths_digest=(
+                    "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                ),
+                embedding_backend="test-embedding",
+                verification="PASS",
             ),
             CollectionFreshness(
                 name="navigation_symbols",
@@ -56,6 +70,17 @@ def _snapshot(*, brain_available: bool = True, worker_claims=None, queue_items=N
                 source="ci_targeted_reindex",
                 repo_head_sha=HEAD,
                 last_indexed_at=NOW,
+                source_manifest_digest=(
+                    "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+                ),
+                indexed_paths_digest=(
+                    "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                ),
+                removed_paths_digest=(
+                    "sha256:9999999999999999999999999999999999999999999999999999999999999999"
+                ),
+                embedding_backend="test-embedding",
+                verification="PASS",
             ),
         ],
     )

--- a/modules/communication/moltbot_bridge/tests/test_reddog_operational_context_snapshot.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_operational_context_snapshot.py
@@ -82,6 +82,9 @@ def _fresh_holo_receipt(head: str = HEAD):
         repo_head_sha=head,
         ssd_path="E:/HoloIndex",
         source="ci_targeted_reindex",
+        generation_id=(
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ),
         collections=[
             CollectionFreshness(
                 name="navigation_work_ledger",
@@ -90,6 +93,17 @@ def _fresh_holo_receipt(head: str = HEAD):
                 source="ci_targeted_reindex",
                 repo_head_sha=head,
                 last_indexed_at=NOW,
+                source_manifest_digest=(
+                    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                ),
+                indexed_paths_digest=(
+                    "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                ),
+                removed_paths_digest=(
+                    "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                ),
+                embedding_backend="test-embedding",
+                verification="PASS",
             ),
             CollectionFreshness(
                 name="navigation_symbols",
@@ -98,6 +112,17 @@ def _fresh_holo_receipt(head: str = HEAD):
                 source="ci_targeted_reindex",
                 repo_head_sha=head,
                 last_indexed_at=NOW,
+                source_manifest_digest=(
+                    "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+                ),
+                indexed_paths_digest=(
+                    "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                ),
+                removed_paths_digest=(
+                    "sha256:9999999999999999999999999999999999999999999999999999999999999999"
+                ),
+                embedding_backend="test-embedding",
+                verification="PASS",
             ),
         ],
     )


### PR DESCRIPTION
## Summary\n- add read-only Memex -> HoloIndex shadow projection adapter with source_class=memex\n- add immutable projection receipt with snapshot, access-policy, manifest, and no-write attestations\n- update Brain fixture freshness proof to current generation/collection-manifest contract\n\n## Tests\n- python -m py_compile holo_index\\memex_projection_adapter.py\n- pytest holo_index/tests/test_holoindex_memex_projection_adapter.py holo_index/tests/test_holoindex_query_receipt.py holo_index/tests/test_holoindex_freshness_receipt.py holo_index/tests/test_holoindex_incremental_foundup_index.py holo_index/tests/test_holoindex_incremental_index_executor.py modules/communication/moltbot_bridge/tests/test_foundup_memex_current_state.py modules/communication/moltbot_bridge/tests/test_foundup_brain_current_state.py -q --tb=short\n- git diff --cached --check\n- ASCII/NUL scan PASS on cached additions\n\n## Truth Boundary\n- No HoloIndex write\n- No Memex write\n- No Brain/Breadcrumb write\n- No PatternMemory promotion\n- No queue/worker authority\n- No external retrieval\n- No runtime re-index