### PR TITLE
feat(holoindex): route Memex projection query receipts

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,26 @@
 # HoloIndex Package ModLog
 
+## [2026-07-16] HOLOINDEX_MEMEX_QUERY_RECEIPT_ROUTING_PHASE1
+
+**Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice
+**WSP**: 00, 15, 22, 50, 60, 97
+
+- ADD `holo_index/memex_query_routing.py`: read-only deterministic query
+  receipts over already-projected Memex shadow records. Results use
+  `source_class=memex`, `memex://...` paths, evidence refs, projection receipt
+  digest binding, and the projection `holoindex_generation_id`.
+- ADD query semantics: misses return an empty successful Memex receipt rather
+  than a false index-gap claim; empty queries, missing projection receipts, and
+  rejected projections fail closed.
+- TEST `tests/test_holoindex_memex_query_routing.py`: source-class and
+  generation binding, plain-dict projection compatibility, miss behavior,
+  fail-closed malformed inputs, rejected projections, and AST no-write/no-exec
+  guards.
+- Boundary: no HoloIndex re-index, no Memex/HoloIndex write, no external
+  retrieval, no current-code proof, no authority promotion, and no runtime
+  RedDog wiring. This slice gives RedDog/WRE a receipt format for Memex
+  evidence; it does not decide work or mutate state.
+
 ## [2026-07-16] HOLOINDEX_MEMEX_GOVERNED_PROJECTION_ADAPTER_PHASE1
 
 **Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice

--- a/holo_index/memex_query_routing.py
+++ b/holo_index/memex_query_routing.py
@@ -1,0 +1,200 @@
+"""Read-only query receipts for governed Memex projection records.
+
+Memex projection records are historical memory evidence. They can support
+project continuity and prior-decision recall, but they cannot prove current code
+or authoritative work state. This module performs deterministic local matching
+over already-projected records and returns a generation-bound query receipt.
+It never mutates Memex or HoloIndex.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, is_dataclass
+from typing import Any, Mapping, Sequence
+
+from holo_index.memex_projection_adapter import (
+    MemexProjectionRecord,
+    MemexProjectionResult,
+    MemexSnapshotProjectionReceipt,
+)
+from holo_index.query_receipt import SOURCE_CLASS_MEMEX, build_query_receipt
+
+
+SCHEMA_VERSION = "holoindex_memex_query_routing.v1"
+MEMEX_QUERY_SOURCE = "memex_projection"
+
+_TERM_RE = re.compile(r"[A-Za-z0-9_]{2,}")
+
+
+def build_memex_projection_query_receipt(
+    *,
+    query: str,
+    projection: MemexProjectionResult | Mapping[str, Any],
+    limit: int = 8,
+) -> Mapping[str, Any]:
+    """Build a read-only query receipt from a Memex projection result."""
+
+    query_text = str(query or "").strip()
+    records, receipt, projection_ok, error = _normalize_projection(projection)
+    terms = _query_terms(query_text)
+    if not query_text or not terms:
+        projection_ok = False
+        error = error or "empty_memex_query"
+    if not receipt:
+        projection_ok = False
+        error = error or "missing_memex_projection_receipt"
+
+    hits = []
+    if projection_ok and receipt:
+        hits = _rank_records(records, terms=terms, limit=limit)
+
+    result = {
+        "ok": projection_ok,
+        "query": query_text,
+        "freshness": "CURRENT" if projection_ok else "UNKNOWN",
+        "hits": hits,
+        "error": error,
+    }
+    generation_binding = {
+        "freshness_generation_id": receipt.holoindex_generation_id if receipt else "",
+        "freshness_receipt_digest": receipt.receipt_id if receipt else "",
+        "freshness_receipt_path": "",
+        "repo_head_sha": receipt.source_revision if receipt else "",
+    }
+    return build_query_receipt(
+        source=MEMEX_QUERY_SOURCE,
+        source_class=SOURCE_CLASS_MEMEX,
+        query=query_text,
+        result=result,
+        require_generation=True,
+        generation_binding=generation_binding,
+    )
+
+
+def _normalize_projection(
+    projection: MemexProjectionResult | Mapping[str, Any],
+) -> tuple[tuple[MemexProjectionRecord, ...], MemexSnapshotProjectionReceipt | None, bool, str]:
+    if isinstance(projection, MemexProjectionResult):
+        return (
+            tuple(projection.records),
+            projection.receipt,
+            projection.accepted and projection.receipt is not None,
+            "" if projection.accepted else ",".join(projection.rejection_reasons),
+        )
+    if not isinstance(projection, Mapping):
+        return (), None, False, "projection_not_mapping"
+    raw_records = projection.get("records")
+    records = tuple(
+        record
+        for record in (_record_from_mapping(item) for item in raw_records or ())
+        if record is not None
+    )
+    receipt = _receipt_from_mapping(projection.get("receipt"))
+    accepted = projection.get("accepted") is True and receipt is not None
+    reasons = projection.get("rejection_reasons")
+    error = ",".join(str(item) for item in reasons) if isinstance(reasons, Sequence) else ""
+    return records, receipt, accepted, error
+
+
+def _record_from_mapping(value: Any) -> MemexProjectionRecord | None:
+    if isinstance(value, MemexProjectionRecord):
+        return value
+    if not isinstance(value, Mapping):
+        return None
+    try:
+        return MemexProjectionRecord(
+            record_id=str(value.get("record_id") or ""),
+            source_class=str(value.get("source_class") or ""),
+            foundup_id=str(value.get("foundup_id") or ""),
+            memex_snapshot_id=str(value.get("memex_snapshot_id") or ""),
+            source_scope=str(value.get("source_scope") or ""),
+            source_revision=str(value.get("source_revision") or ""),
+            title=str(value.get("title") or ""),
+            text=str(value.get("text") or ""),
+            metadata=dict(value.get("metadata") or {}),
+            content_digest=str(value.get("content_digest") or ""),
+        )
+    except Exception:
+        return None
+
+
+def _receipt_from_mapping(value: Any) -> MemexSnapshotProjectionReceipt | None:
+    if isinstance(value, MemexSnapshotProjectionReceipt):
+        return value
+    if not isinstance(value, Mapping):
+        return None
+    try:
+        return MemexSnapshotProjectionReceipt(
+            schema_version=str(value.get("schema_version") or ""),
+            memex_snapshot_id=str(value.get("memex_snapshot_id") or ""),
+            source_scope=str(value.get("source_scope") or ""),
+            source_revision=str(value.get("source_revision") or ""),
+            content_manifest_digest=str(value.get("content_manifest_digest") or ""),
+            created_at=str(value.get("created_at") or ""),
+            access_policy_digest=str(value.get("access_policy_digest") or ""),
+            records_indexed=int(value.get("records_indexed") or 0),
+            records_rejected=int(value.get("records_rejected") or 0),
+            holoindex_generation_id=str(value.get("holoindex_generation_id") or ""),
+            verification=str(value.get("verification") or ""),
+            rejected_reasons=tuple(value.get("rejected_reasons") or ()),
+            no_holoindex_write_performed=bool(value.get("no_holoindex_write_performed", True)),
+            no_memex_write_performed=bool(value.get("no_memex_write_performed", True)),
+            no_brain_write_performed=bool(value.get("no_brain_write_performed", True)),
+            no_breadcrumb_write_performed=bool(
+                value.get("no_breadcrumb_write_performed", True)
+            ),
+            receipt_id=str(value.get("receipt_id") or ""),
+        )
+    except Exception:
+        return None
+
+
+def _query_terms(query: str) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(match.group(0).lower() for match in _TERM_RE.finditer(query)))
+
+
+def _rank_records(
+    records: Sequence[MemexProjectionRecord],
+    *,
+    terms: Sequence[str],
+    limit: int,
+) -> list[dict[str, Any]]:
+    ranked = []
+    for record in records:
+        haystack = f"{record.title}\n{record.text}".lower()
+        matched = tuple(term for term in terms if term in haystack)
+        if not matched:
+            continue
+        score = len(matched) / max(1, len(terms))
+        ranked.append(
+            {
+                "path": f"memex://{record.memex_snapshot_id}/{record.record_id}",
+                "title": record.title,
+                "score": round(score, 6),
+                "digest": record.content_digest,
+                "evidence_ref": (
+                    f"memex:{record.memex_snapshot_id}:{record.record_id}:"
+                    f"{record.metadata.get('section', '')}"
+                ),
+            }
+        )
+    ranked.sort(key=lambda item: (-float(item["score"]), str(item["path"])))
+    return ranked[: max(0, int(limit or 0))]
+
+
+def projection_to_plain_dict(value: MemexProjectionResult) -> dict[str, Any]:
+    """Return a plain dict for callers that persist projection results."""
+
+    data = value.to_dict()
+    if value.receipt and is_dataclass(value.receipt):
+        data["receipt"] = asdict(value.receipt)
+    return data
+
+
+__all__ = [
+    "MEMEX_QUERY_SOURCE",
+    "SCHEMA_VERSION",
+    "build_memex_projection_query_receipt",
+    "projection_to_plain_dict",
+]

--- a/holo_index/tests/test_holoindex_memex_query_routing.py
+++ b/holo_index/tests/test_holoindex_memex_query_routing.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from holo_index.memex_projection_adapter import (
+    project_foundup_memex_to_holoindex_shadow,
+)
+from holo_index.memex_query_routing import (
+    MEMEX_QUERY_SOURCE,
+    build_memex_projection_query_receipt,
+    projection_to_plain_dict,
+)
+
+
+MODULE_PATH = Path(__file__).parents[1] / "memex_query_routing.py"
+FIXED_NOW = "2026-07-16T00:00:00+00:00"
+
+
+def _projection():
+    return project_foundup_memex_to_holoindex_shadow(
+        memex_view={
+            "schema_version": "foundup_brain_current_state.v1",
+            "foundup_brain_view_id": "sha256:brain-view",
+            "foundup_id": "foundups-agent",
+            "snapshot_id": "snapshot-1",
+            "snapshot_content_digest": "sha256:snapshot",
+            "identity": {
+                "foundup_id": "foundups-agent",
+                "name": "Foundups Agent",
+            },
+            "current_state": {
+                "selected_slice": "REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH_RUNTIME_PHASE1",
+                "runtime_gap": "authoritative work state reconciliation",
+            },
+            "roadmap_state": {
+                "roadmap_id": "r1",
+                "next_slice": "REDDOG_SIGNER_AND_DELEGATED_AUTHORITY_RUNTIME_PHASE1",
+            },
+            "verified_outcomes": [
+                {
+                    "outcome_id": "o1",
+                    "accepted": True,
+                    "finding": "Memex cannot prove current code without direct reads.",
+                }
+            ],
+        },
+        source_scope="foundup:foundups-agent",
+        source_revision="abc123",
+        allowed_foundup_ids=("foundups-agent",),
+        holoindex_generation_id="generation-1",
+        now_iso=FIXED_NOW,
+    )
+
+
+def test_memex_query_receipt_binds_projection_generation_and_source_class() -> None:
+    projection = _projection()
+    receipt = build_memex_projection_query_receipt(
+        query="authoritative work state reconciliation",
+        projection=projection,
+    )
+
+    assert receipt["source"] == MEMEX_QUERY_SOURCE
+    assert receipt["source_class"] == "memex"
+    assert receipt["ok"] is True
+    assert receipt["freshness"] == "CURRENT"
+    assert receipt["freshness_generation_id"] == "generation-1"
+    assert receipt["freshness_receipt_digest"] == projection.receipt.receipt_id
+    assert receipt["repo_head_sha"] == "abc123"
+    assert receipt["no_holoindex_reindex_performed"] is True
+    assert receipt["index_gap_detected"] is False
+    assert receipt["hits"]
+    assert receipt["hits"][0]["source_class"] == "memex"
+    assert receipt["hits"][0]["path"].startswith("memex://sha256:brain-view/")
+    assert receipt["hits"][0]["digest"].startswith("sha256:")
+    assert "current_state" in receipt["hits"][0]["evidence_ref"]
+
+
+def test_memex_query_receipt_accepts_plain_projection_dict() -> None:
+    projection = _projection()
+    receipt = build_memex_projection_query_receipt(
+        query="delegated authority",
+        projection=projection_to_plain_dict(projection),
+    )
+
+    assert receipt["ok"] is True
+    assert receipt["source_class"] == "memex"
+    assert receipt["hits"]
+    assert "roadmap_state" in receipt["hits"][0]["evidence_ref"]
+
+
+def test_memex_query_miss_is_not_a_generation_gap() -> None:
+    receipt = build_memex_projection_query_receipt(
+        query="nonexistent asteroid result",
+        projection=_projection(),
+    )
+
+    assert receipt["ok"] is True
+    assert receipt["hits"] == []
+    assert receipt["index_gap_detected"] is False
+    assert receipt["stale_reasons"] == []
+
+
+def test_memex_query_empty_query_fails_closed() -> None:
+    receipt = build_memex_projection_query_receipt(query="", projection=_projection())
+
+    assert receipt["ok"] is False
+    assert receipt["freshness"] == "UNKNOWN"
+    assert receipt["error"] == "empty_memex_query"
+    assert receipt["hits"] == []
+
+
+def test_memex_query_missing_projection_receipt_fails_closed() -> None:
+    projection = _projection().to_dict()
+    projection["receipt"] = None
+
+    receipt = build_memex_projection_query_receipt(
+        query="authoritative work state",
+        projection=projection,
+    )
+
+    assert receipt["ok"] is False
+    assert receipt["freshness"] == "UNKNOWN"
+    assert receipt["error"] == "missing_memex_projection_receipt"
+    assert receipt["freshness_generation_id"] == ""
+    assert receipt["index_gap_detected"] is False
+
+
+def test_memex_query_rejected_projection_fails_closed() -> None:
+    rejected = project_foundup_memex_to_holoindex_shadow(
+        memex_view={"foundup_id": "other"},
+        source_scope="foundup:foundups-agent",
+        source_revision="abc123",
+        allowed_foundup_ids=("foundups-agent",),
+        now_iso=FIXED_NOW,
+    )
+    receipt = build_memex_projection_query_receipt(
+        query="anything",
+        projection=rejected,
+    )
+
+    assert receipt["ok"] is False
+    assert "foundup_scope_not_authorized" in receipt["error"]
+    assert receipt["hits"] == []
+
+
+def test_memex_query_router_is_read_only_by_ast() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_imports = {
+        "subprocess",
+        "requests",
+        "httpx",
+        "sqlite3",
+        "chromadb",
+    }
+    banned_calls = {
+        "add",
+        "upsert",
+        "delete",
+        "reset",
+        "_reset_collection",
+        "write_text",
+        "write_bytes",
+        "open",
+    }
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_imports
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_imports
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_calls
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls


### PR DESCRIPTION
## Summary\n- add read-only query receipts over governed Memex projection records\n- bind Memex hits to source_class=memex, projection receipt digest, and HoloIndex generation id\n- fail closed on empty queries, missing projection receipts, and rejected projections\n\n## Tests\n- python -m py_compile holo_index\\memex_projection_adapter.py holo_index\\memex_query_routing.py\n- pytest holo_index/tests/test_holoindex_memex_query_routing.py holo_index/tests/test_holoindex_memex_projection_adapter.py holo_index/tests/test_holoindex_query_receipt.py modules/communication/moltbot_bridge/tests/test_foundup_memex_current_state.py modules/communication/moltbot_bridge/tests/test_foundup_brain_current_state.py modules/communication/moltbot_bridge/tests/test_reddog_operational_context_snapshot.py -q --tb=short\n- pytest holo_index/tests/test_holoindex_memex_query_routing.py holo_index/tests/test_holoindex_memex_projection_adapter.py holo_index/tests/test_holoindex_query_receipt.py holo_index/tests/test_holoindex_freshness_receipt.py holo_index/tests/test_holoindex_incremental_foundup_index.py holo_index/tests/test_holoindex_incremental_index_executor.py modules/communication/moltbot_bridge/tests/test_foundup_memex_current_state.py modules/communication/moltbot_bridge/tests/test_foundup_brain_current_state.py modules/communication/moltbot_bridge/tests/test_reddog_operational_context_snapshot.py -q --tb=short\n- git diff --cached --check\n- ASCII/NUL scan PASS on cached additions\n\n## Truth Boundary\n- No HoloIndex re-index\n- No Memex or HoloIndex write\n- No external retrieval\n- No current-code proof\n- No authority promotion\n- No RedDog runtime wiring