### PR TITLE
feat(reddog): bind Memex query receipts into read-only audit

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,24 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_MEMEX_QUERY_RECEIPT_RUNTIME_BINDING_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 60, 97
+
+- Updated `reddog_readonly_0102_audit_worker_runtime.py` so a model-backed
+  read-only repo audit can optionally consume a caller-supplied governed Memex
+  projection and convert it into a `source_class=memex` query receipt before
+  the RedDog/Fusion model call.
+- The Memex receipt is included in the model context, model binding, and worker
+  receipt only when supplied; existing no-Memex task contexts remain unchanged.
+- Invalid supplied Memex projections fail closed before the model call. A
+  successful Memex query miss is not treated as a HoloIndex freshness gap.
+- Added tests proving Memex receipt propagation, generation binding,
+  pre-model rejection for malformed Memex projections, and preservation of the
+  read-only/no-reindex side-effect boundary.
+- No Memex write, Brain/Breadcrumb write, HoloIndex re-index, repo mutation,
+  worker spawn, OpenClaw enqueue, Hermes dispatch, PR creation, or authority
+  promotion is added.
+
 ## 2026-07-15: REDDOG_OPENCLAW_READONLY_0102_AUDIT_WORKER_RUNTIME_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
@@ -44,6 +44,7 @@ from holo_index.query_receipt import (
     build_query_receipt,
     load_generation_binding,
 )
+from holo_index.memex_query_routing import build_memex_projection_query_receipt
 
 
 READONLY_0102_AUDIT_WORKER_RECEIPT_SCHEMA = "readonly_0102_audit_worker_receipt.v1"
@@ -471,9 +472,18 @@ def execute_model_backed_repo_code_audit(
     code_reject = _query_rejection_reason(code_receipt)
     if code_reject:
         return _reject([code_reject])
+    memex_receipt = _optional_memex_query_receipt(
+        task_context=task_context,
+        assignment=assignment,
+        query=query,
+    )
+    memex_reject = _query_rejection_reason(memex_receipt) if memex_receipt else None
+    if memex_reject:
+        return _reject([memex_reject])
     index_query_errors = tuple(
         str(receipt.get("error") or "")
-        for receipt in (holo_receipt, code_receipt)
+        for receipt in (holo_receipt, code_receipt, memex_receipt)
+        if receipt is not None
         if receipt.get("ok") is not True and str(receipt.get("error") or "").strip()
     )
 
@@ -487,6 +497,7 @@ def execute_model_backed_repo_code_audit(
         snapshots=snapshots,
         holo_receipt=holo_receipt,
         code_receipt=code_receipt,
+        memex_receipt=memex_receipt,
     )
     try:
         prompt = _build_repo_audit_model_prompt(assignment=assignment, allocation=allocation)
@@ -495,6 +506,7 @@ def execute_model_backed_repo_code_audit(
             holo_receipt=holo_receipt,
             code_receipt=code_receipt,
             index_query_errors=index_query_errors,
+            memex_receipt=memex_receipt,
         )
     except ValueError:
         return _reject([ReadOnlyAuditTaskRejectReason.PROMPT_BUDGET_EXCEEDED])
@@ -530,6 +542,7 @@ def execute_model_backed_repo_code_audit(
         holo_receipt=holo_receipt,
         code_receipt=code_receipt,
         index_query_errors=index_query_errors,
+        memex_receipt=memex_receipt,
         task_id=task_id,
         repo_head=_observe_repo_head(repo_root),
     )
@@ -570,6 +583,35 @@ def _query_index(
         result=result,
         require_generation=source == "holoindex",
     )
+
+
+def _optional_memex_query_receipt(
+    *,
+    task_context: Mapping[str, Any],
+    assignment: Mapping[str, Any],
+    query: str,
+) -> Mapping[str, Any] | None:
+    projection = task_context.get("memex_projection")
+    if projection is None:
+        projection = assignment.get("memex_projection")
+    if projection is None:
+        return None
+    try:
+        return build_memex_projection_query_receipt(query=query, projection=projection)
+    except Exception as exc:
+        return build_query_receipt(
+            source="memex_projection",
+            source_class="memex",
+            query=query,
+            result={
+                "ok": False,
+                "query": query,
+                "freshness": "UNKNOWN",
+                "hits": [],
+                "error": f"memex_query_failed:{type(exc).__name__}",
+            },
+            require_generation=False,
+        )
 
 
 def _query_rejection_reason(receipt: Mapping[str, Any]) -> str:
@@ -746,8 +788,9 @@ def _model_binding(
     snapshots: Sequence[_ReadOnlyTargetSnapshot],
     holo_receipt: Mapping[str, Any],
     code_receipt: Mapping[str, Any],
+    memex_receipt: Mapping[str, Any] | None = None,
 ) -> Mapping[str, Any]:
-    return {
+    payload = {
         "schema_version": READONLY_0102_AUDIT_WORKER_RECEIPT_SCHEMA,
         "task_id": str(task_id or ""),
         "assignment_id": str(assignment.get("assignment_id") or ""),
@@ -767,6 +810,9 @@ def _model_binding(
         "holoindex_query_receipt_id": holo_receipt.get("receipt_id"),
         "codeindex_query_receipt_id": code_receipt.get("receipt_id"),
     }
+    if memex_receipt is not None:
+        payload["memex_query_receipt_id"] = memex_receipt.get("receipt_id")
+    return payload
 
 
 def _build_repo_audit_model_prompt(
@@ -818,6 +864,7 @@ def _build_repo_audit_model_context(
     holo_receipt: Mapping[str, Any],
     code_receipt: Mapping[str, Any],
     index_query_errors: Sequence[str],
+    memex_receipt: Mapping[str, Any] | None = None,
 ) -> str:
     payload = {
         "untrusted_repository_evidence": [
@@ -835,6 +882,8 @@ def _build_repo_audit_model_context(
         "index_query_errors": list(index_query_errors),
         "no_holoindex_reindex_performed": True,
     }
+    if memex_receipt is not None:
+        payload["memex_query_receipt"] = memex_receipt
     return _budgeted_json(payload, MAX_MODEL_CONTEXT_CHARS)
 
 
@@ -927,6 +976,7 @@ def _build_model_report(
     holo_receipt: Mapping[str, Any],
     code_receipt: Mapping[str, Any],
     index_query_errors: Sequence[str],
+    memex_receipt: Mapping[str, Any] | None,
     task_id: str | None,
     repo_head: str,
 ) -> Mapping[str, Any]:
@@ -968,6 +1018,9 @@ def _build_model_report(
             "no_worktree_operation_performed": True,
         },
     }
+    if memex_receipt is not None:
+        receipt_payload["memex_query_receipt"] = dict(memex_receipt)
+        receipt_payload["memex_query_receipt_id"] = memex_receipt.get("receipt_id")
     receipt = {**receipt_payload, "receipt_id": "sha256:" + _digest(receipt_payload)}
     report = {
         "assignment_id": str(assignment.get("assignment_id") or ""),

--- a/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from holo_index.memex_projection_adapter import project_foundup_memex_to_holoindex_shadow
 from modules.communication.moltbot_bridge.scripts.run_task import execute_task
 from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
     READONLY_AUDIT_TASK_SKILL,
@@ -263,6 +264,36 @@ def _model_context(
     return context
 
 
+def _memex_projection() -> dict:
+    result = project_foundup_memex_to_holoindex_shadow(
+        memex_view={
+            "schema_version": "foundup_brain_current_state.v1",
+            "foundup_brain_view_id": "sha256:brain-view",
+            "foundup_id": "foundups-agent",
+            "snapshot_id": "snapshot-1",
+            "snapshot_content_digest": "sha256:snapshot",
+            "identity": {
+                "foundup_id": "foundups-agent",
+                "name": "Foundups Agent",
+            },
+            "current_state": {
+                "selected_slice": "REDDOG_MEMEX_QUERY_RECEIPT_RUNTIME_BINDING_PHASE1",
+                "evidence_path": "modules/communication/moltbot_bridge/src/sample.py",
+            },
+            "roadmap_state": {
+                "next_slice": "REDDOG_RUNTIME_NEXT_PHASE1",
+            },
+        },
+        source_scope="foundup:foundups-agent",
+        source_revision="abc123",
+        allowed_foundup_ids=("foundups-agent",),
+        holoindex_generation_id="sha256:memex-generation",
+        now_iso="2026-07-16T00:00:00+00:00",
+    )
+    assert result.accepted is True
+    return result.to_dict()
+
+
 def _ledger_context() -> dict:
     context = _context()
     context["assignment"] = dict(context["assignment"])
@@ -442,6 +473,56 @@ def test_model_backed_binds_holoindex_generation_into_worker_receipt(tmp_path: P
     assert receipt["freshness_generation_id"] == "sha256:generation-123"
     assert receipt["freshness_receipt_digest"] == "sha256:freshness"
     assert receipt["no_holoindex_reindex_performed"] is True
+
+
+def test_model_backed_includes_optional_memex_query_receipt(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    runner = _EchoEvidenceModelRunner()
+    context = _model_context()
+    context["memex_projection"] = _memex_projection()
+
+    result = execute_reddog_readonly_audit_task(
+        task_context=context,
+        repo_root=root,
+        task_id="task-1",
+        model_runner=runner,
+        holoindex_adapter=_FakeQueryAdapter(),
+        codeindex_adapter=_FakeQueryAdapter(),
+    )
+
+    assert result.accepted is True
+    assert runner.calls
+    model_context = json.loads(runner.calls[0]["context"])
+    memex_receipt = model_context["memex_query_receipt"]
+    assert memex_receipt["source_class"] == "memex"
+    assert memex_receipt["freshness_generation_id"] == "sha256:memex-generation"
+    assert memex_receipt["hits"]
+    assert memex_receipt["hits"][0]["path"].startswith("memex://sha256:brain-view/")
+    assert result.report is not None
+    worker_receipt = result.report["worker_receipt"]
+    assert worker_receipt["memex_query_receipt"]["source_class"] == "memex"
+    assert worker_receipt["memex_query_receipt_id"] == memex_receipt["receipt_id"]
+    assert worker_receipt["no_side_effect_attestations"]["no_holoindex_reindex_performed"] is True
+
+
+def test_model_backed_rejects_invalid_supplied_memex_projection_before_model(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    runner = _EchoEvidenceModelRunner()
+    context = _model_context()
+    context["memex_projection"] = {"accepted": True, "records": [], "receipt": None}
+
+    result = execute_reddog_readonly_audit_task(
+        task_context=context,
+        repo_root=root,
+        task_id="task-1",
+        model_runner=runner,
+        holoindex_adapter=_FakeQueryAdapter(),
+        codeindex_adapter=_FakeQueryAdapter(),
+    )
+
+    assert result.accepted is False
+    assert ReadOnlyAuditTaskRejectReason.INDEX_QUERY_FAILED in result.rejection_reasons
+    assert not runner.calls
 
 
 def test_model_backed_rejects_wsp15_binding_digest_mismatch(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary\n- optionally convert supplied governed Memex projections into source_class=memex query receipts in the model-backed read-only audit path\n- include Memex receipts in model context, binding, and worker receipt only when supplied\n- fail closed before model call on malformed Memex projection input\n\n## Tests\n- python -m py_compile modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py holo_index/memex_query_routing.py holo_index/memex_projection_adapter.py\n- pytest modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py holo_index/tests/test_holoindex_memex_query_routing.py holo_index/tests/test_holoindex_memex_projection_adapter.py -q --tb=short\n- pytest modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py holo_index/tests/test_holoindex_memex_query_routing.py holo_index/tests/test_holoindex_memex_projection_adapter.py holo_index/tests/test_holoindex_query_receipt.py holo_index/tests/test_holoindex_freshness_receipt.py holo_index/tests/test_holoindex_incremental_foundup_index.py holo_index/tests/test_holoindex_incremental_index_executor.py modules/communication/moltbot_bridge/tests/test_foundup_memex_current_state.py modules/communication/moltbot_bridge/tests/test_foundup_brain_current_state.py modules/communication/moltbot_bridge/tests/test_reddog_operational_context_snapshot.py -q --tb=short\n- git diff --cached --check\n- ASCII/NUL scan PASS on cached additions\n\n## Truth Boundary\n- No Memex write\n- No Brain/Breadcrumb write\n- No HoloIndex re-index\n- No repo mutation\n- No worker spawn\n- No OpenClaw enqueue\n- No Hermes dispatch\n- No authority promotion