### PR TITLE
feat(holoindex): verify Memex projection integrity before routing

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,28 @@
 # HoloIndex Package ModLog
 
+## [2026-07-16] HOLOINDEX_MEMEX_PROJECTION_INTEGRITY_AND_REHYDRATION_GATE_PHASE1
+
+**Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice
+**WSP**: 00, 15, 22, 50, 60, 97
+
+- ADD `holo_index/memex_projection_integrity.py`: read-only rehydration gate
+  for serialized Memex projections. It recomputes record content digests,
+  record ids, content-manifest digest, projection receipt id, schema/version
+  bindings, record counts, and FoundUp/snapshot/policy/generation consistency
+  before returning a typed `MemexProjectionResult`.
+- UPDATE `holo_index/memex_query_routing.py`: Memex query receipts now consume
+  only rehydrated projections and never trust serialized `accepted: true`.
+- ADD runtime hardening: runtime mode rejects placeholder access-policy
+  digests, replayed receipts, revoked snapshots, expired projections, and
+  caller/assignment binding mismatches.
+- TEST `tests/test_holoindex_memex_projection_integrity.py`: tampered record
+  text, digest, manifest, receipt id, schema, verification, mixed bindings,
+  expiry, replay/revocation, placeholder policy, valid round-trip
+  serialization, and AST no-write/no-exec guards.
+- Boundary: no Memex write, no HoloIndex write, no Brain/Breadcrumb write, no
+  external retrieval, no runtime re-index, and no content-bearing citation
+  policy. Snapshot supply and Memex citation/verdict policy remain downstream.
+
 ## [2026-07-16] HOLOINDEX_MEMEX_QUERY_RECEIPT_ROUTING_PHASE1
 
 **Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice

--- a/holo_index/memex_projection_integrity.py
+++ b/holo_index/memex_projection_integrity.py
@@ -1,0 +1,447 @@
+"""Integrity gate for serialized Memex projection receipts.
+
+This module rehydrates a caller-supplied Memex projection only after
+recomputing every digest and binding that the projection adapter emitted. It is
+read-only and never trusts an ``accepted: true`` field from serialized input.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from holo_index.memex_projection_adapter import (
+    DEFAULT_ACCESS_POLICY_DIGEST,
+    MemexProjectionRecord,
+    MemexProjectionResult,
+    MemexSnapshotProjectionReceipt,
+    PROJECTION_ACCEPTED,
+    PROJECTION_REJECTED,
+    RECEIPT_SCHEMA_VERSION,
+    SCHEMA_VERSION,
+)
+from holo_index.query_receipt import SOURCE_CLASS_MEMEX, digest_json
+
+
+INTEGRITY_GATE_SCHEMA_VERSION = "holoindex_memex_projection_integrity_gate.v1"
+DEFAULT_RUNTIME_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
+
+
+@dataclass(frozen=True)
+class MemexProjectionIntegrityResult:
+    """Result of rehydrating and verifying a Memex projection."""
+
+    accepted: bool
+    status: str
+    projection: MemexProjectionResult | None
+    rejection_reasons: tuple[str, ...]
+    receipt_id: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": INTEGRITY_GATE_SCHEMA_VERSION,
+            "accepted": self.accepted,
+            "status": self.status,
+            "projection": self.projection.to_dict() if self.projection else None,
+            "rejection_reasons": list(self.rejection_reasons),
+            "receipt_id": self.receipt_id,
+        }
+
+
+def verify_and_rehydrate_memex_projection(
+    projection: MemexProjectionResult | Mapping[str, Any],
+    *,
+    runtime_mode: bool = False,
+    now_iso: str | None = None,
+    max_age_seconds: int | None = None,
+    seen_receipt_ids: Sequence[str] = (),
+    revoked_snapshot_ids: Sequence[str] = (),
+    expected_foundup_id: str | None = None,
+    expected_memex_snapshot_id: str | None = None,
+    expected_source_scope: str | None = None,
+    expected_source_revision: str | None = None,
+    expected_access_policy_digest: str | None = None,
+    expected_holoindex_generation_id: str | None = None,
+) -> MemexProjectionIntegrityResult:
+    """Return a typed verified projection or fail closed.
+
+    ``runtime_mode`` adds operational checks that are too strict for static unit
+    fixtures: placeholder access policies are rejected, replay/revocation inputs
+    are honored, and receipt age is bounded.
+    """
+
+    raw = _projection_to_mapping(projection)
+    if raw is None:
+        return _reject("projection_not_mapping")
+    prior_reasons = _prior_rejection_reasons(raw)
+
+    records_value = raw.get("records")
+    if not isinstance(records_value, Sequence) or isinstance(records_value, (str, bytes)):
+        return _reject(*prior_reasons, "projection_records_not_sequence")
+    receipt_value = raw.get("receipt")
+    if not isinstance(receipt_value, Mapping):
+        return _reject(*prior_reasons, "missing_projection_receipt")
+
+    records: list[MemexProjectionRecord] = []
+    reasons: list[str] = []
+    for index, item in enumerate(records_value):
+        record, record_reasons = _record_from_mapping(item, index=index)
+        reasons.extend(record_reasons)
+        if record is not None:
+            records.append(record)
+
+    receipt, receipt_reasons = _receipt_from_mapping(receipt_value)
+    reasons.extend(receipt_reasons)
+    if receipt is None:
+        return _reject(*prior_reasons, *reasons, "malformed_projection_receipt")
+
+    if not records:
+        reasons.append("no_projection_records")
+    if receipt.schema_version != RECEIPT_SCHEMA_VERSION:
+        reasons.append("schema_version_mismatch")
+    if receipt.verification != "PASS":
+        reasons.append("projection_verification_not_pass")
+    if not receipt.holoindex_generation_id:
+        reasons.append("missing_holoindex_generation_id")
+
+    seen = {_clean(item) for item in seen_receipt_ids if _clean(item)}
+    revoked = {_clean(item) for item in revoked_snapshot_ids if _clean(item)}
+    if runtime_mode and receipt.receipt_id in seen:
+        reasons.append("projection_receipt_replayed")
+    if runtime_mode and receipt.memex_snapshot_id in revoked:
+        reasons.append("projection_snapshot_revoked")
+
+    if runtime_mode and receipt.access_policy_digest == DEFAULT_ACCESS_POLICY_DIGEST:
+        reasons.append("placeholder_access_policy_digest")
+    if not _is_sha256(receipt.access_policy_digest):
+        reasons.append("invalid_access_policy_digest")
+
+    age_reason = _expiry_reason(
+        created_at=receipt.created_at,
+        now_iso=now_iso,
+        max_age_seconds=max_age_seconds if max_age_seconds is not None else (
+            DEFAULT_RUNTIME_MAX_AGE_SECONDS if runtime_mode else None
+        ),
+    )
+    if age_reason:
+        reasons.append(age_reason)
+
+    if receipt.records_indexed != len(records):
+        reasons.append("records_indexed_count_mismatch")
+    if receipt.records_rejected != len(receipt.rejected_reasons):
+        reasons.append("records_rejected_count_mismatch")
+
+    foundup_ids = {record.foundup_id for record in records if record.foundup_id}
+    snapshot_ids = {record.memex_snapshot_id for record in records if record.memex_snapshot_id}
+    scopes = {record.source_scope for record in records if record.source_scope}
+    revisions = {record.source_revision for record in records if record.source_revision}
+    policy_digests = {
+        str(record.metadata.get("access_policy_digest") or "").strip()
+        for record in records
+        if isinstance(record.metadata, Mapping)
+    }
+
+    if len(foundup_ids) != 1:
+        reasons.append("mixed_foundup_records")
+    if len(snapshot_ids) != 1 or (snapshot_ids and next(iter(snapshot_ids)) != receipt.memex_snapshot_id):
+        reasons.append("mixed_snapshot_ids")
+    if len(scopes) != 1 or (scopes and next(iter(scopes)) != receipt.source_scope):
+        reasons.append("mixed_source_scope")
+    if len(revisions) != 1 or (revisions and next(iter(revisions)) != receipt.source_revision):
+        reasons.append("mixed_source_revision")
+    if len(policy_digests) != 1 or (
+        policy_digests and next(iter(policy_digests)) != receipt.access_policy_digest
+    ):
+        reasons.append("mixed_policy_digests")
+
+    if expected_foundup_id and foundup_ids != {_clean(expected_foundup_id)}:
+        reasons.append("expected_foundup_mismatch")
+    if expected_memex_snapshot_id and receipt.memex_snapshot_id != _clean(expected_memex_snapshot_id):
+        reasons.append("expected_snapshot_mismatch")
+    if expected_source_scope and receipt.source_scope != _clean(expected_source_scope):
+        reasons.append("expected_source_scope_mismatch")
+    if expected_source_revision and receipt.source_revision != _clean(expected_source_revision):
+        reasons.append("expected_source_revision_mismatch")
+    if expected_access_policy_digest and receipt.access_policy_digest != _clean(expected_access_policy_digest):
+        reasons.append("expected_access_policy_mismatch")
+    if expected_holoindex_generation_id and receipt.holoindex_generation_id != _clean(
+        expected_holoindex_generation_id
+    ):
+        reasons.append("expected_generation_mismatch")
+
+    for record in records:
+        reasons.extend(_record_integrity_reasons(record, receipt=receipt))
+
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "records": [
+            {
+                "record_id": record.record_id,
+                "content_digest": record.content_digest,
+                "source_class": record.source_class,
+            }
+            for record in records
+        ],
+        "rejected": list(receipt.rejected_reasons),
+    }
+    if digest_json(manifest) != receipt.content_manifest_digest:
+        reasons.append("content_manifest_digest_mismatch")
+
+    receipt_payload = {
+        "schema_version": receipt.schema_version,
+        "memex_snapshot_id": receipt.memex_snapshot_id,
+        "source_scope": receipt.source_scope,
+        "source_revision": receipt.source_revision,
+        "content_manifest_digest": receipt.content_manifest_digest,
+        "created_at": receipt.created_at,
+        "access_policy_digest": receipt.access_policy_digest,
+        "records_indexed": receipt.records_indexed,
+        "records_rejected": receipt.records_rejected,
+        "holoindex_generation_id": receipt.holoindex_generation_id,
+        "verification": receipt.verification,
+        "rejected_reasons": tuple(receipt.rejected_reasons),
+        "no_holoindex_write_performed": receipt.no_holoindex_write_performed,
+        "no_memex_write_performed": receipt.no_memex_write_performed,
+        "no_brain_write_performed": receipt.no_brain_write_performed,
+        "no_breadcrumb_write_performed": receipt.no_breadcrumb_write_performed,
+    }
+    if digest_json(receipt_payload) != receipt.receipt_id:
+        reasons.append("receipt_id_mismatch")
+
+    if reasons:
+        return _reject(*prior_reasons, *reasons)
+
+    verified = MemexProjectionResult(
+        accepted=True,
+        status=PROJECTION_ACCEPTED,
+        records=tuple(records),
+        receipt=receipt,
+        rejection_reasons=(),
+    )
+    gate_payload = {
+        "schema_version": INTEGRITY_GATE_SCHEMA_VERSION,
+        "projection_receipt_id": receipt.receipt_id,
+        "record_ids": [record.record_id for record in records],
+        "runtime_mode": runtime_mode is True,
+    }
+    return MemexProjectionIntegrityResult(
+        accepted=True,
+        status="MEMEX_PROJECTION_INTEGRITY_VERIFIED",
+        projection=verified,
+        rejection_reasons=(),
+        receipt_id=digest_json(gate_payload),
+    )
+
+
+def _record_integrity_reasons(
+    record: MemexProjectionRecord,
+    *,
+    receipt: MemexSnapshotProjectionReceipt,
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if record.source_class != SOURCE_CLASS_MEMEX:
+        reasons.append("record_source_class_not_memex")
+    if record.metadata.get("source_class") != SOURCE_CLASS_MEMEX:
+        reasons.append("metadata_source_class_not_memex")
+    if record.metadata.get("foundup_id") != record.foundup_id:
+        reasons.append("metadata_foundup_mismatch")
+    if record.metadata.get("memex_snapshot_id") != record.memex_snapshot_id:
+        reasons.append("metadata_snapshot_mismatch")
+    if record.metadata.get("source_scope") != record.source_scope:
+        reasons.append("metadata_source_scope_mismatch")
+    if record.metadata.get("source_revision") != record.source_revision:
+        reasons.append("metadata_source_revision_mismatch")
+    if record.metadata.get("access_policy_digest") != receipt.access_policy_digest:
+        reasons.append("metadata_access_policy_mismatch")
+    section = str(record.metadata.get("section") or "").strip()
+    if not section:
+        reasons.append("missing_record_section")
+    computed_digest = _content_digest(record.text)
+    if computed_digest != record.content_digest:
+        reasons.append("record_content_digest_mismatch")
+    record_payload = {
+        "foundup_id": record.foundup_id,
+        "label": section,
+        "memex_snapshot_id": record.memex_snapshot_id,
+        "source_revision": record.source_revision,
+        "content_digest": record.content_digest,
+        "access_policy_digest": receipt.access_policy_digest,
+    }
+    if digest_json(record_payload) != record.record_id:
+        reasons.append("record_id_mismatch")
+    return tuple(reasons)
+
+
+def _projection_to_mapping(value: MemexProjectionResult | Mapping[str, Any]) -> Mapping[str, Any] | None:
+    if isinstance(value, MemexProjectionResult):
+        return value.to_dict()
+    if isinstance(value, Mapping):
+        return value
+    return None
+
+
+def _prior_rejection_reasons(value: Mapping[str, Any]) -> tuple[str, ...]:
+    reasons = value.get("rejection_reasons")
+    if not isinstance(reasons, Sequence) or isinstance(reasons, (str, bytes)):
+        return ()
+    return tuple(_text(item) for item in reasons if _text(item))
+
+
+def _record_from_mapping(value: Any, *, index: int) -> tuple[MemexProjectionRecord | None, tuple[str, ...]]:
+    if isinstance(value, MemexProjectionRecord):
+        return value, ()
+    if not isinstance(value, Mapping):
+        return None, (f"record_not_mapping:{index}",)
+    try:
+        metadata = value.get("metadata")
+        if not isinstance(metadata, Mapping):
+            return None, (f"record_metadata_not_mapping:{index}",)
+        record = MemexProjectionRecord(
+            record_id=_clean(value.get("record_id")),
+            source_class=_clean(value.get("source_class")),
+            foundup_id=_clean(value.get("foundup_id")),
+            memex_snapshot_id=_clean(value.get("memex_snapshot_id")),
+            source_scope=_clean(value.get("source_scope")),
+            source_revision=_clean(value.get("source_revision")),
+            title=_clean(value.get("title")),
+            text=_text(value.get("text")),
+            metadata={str(key): item for key, item in dict(metadata).items()},
+            content_digest=_clean(value.get("content_digest")),
+        )
+    except Exception:
+        return None, (f"record_malformed:{index}",)
+    required = (
+        record.record_id,
+        record.source_class,
+        record.foundup_id,
+        record.memex_snapshot_id,
+        record.source_scope,
+        record.source_revision,
+        record.text,
+        record.content_digest,
+    )
+    if any(not item for item in required):
+        return record, (f"record_missing_required_field:{index}",)
+    return record, ()
+
+
+def _receipt_from_mapping(value: Mapping[str, Any]) -> tuple[MemexSnapshotProjectionReceipt | None, tuple[str, ...]]:
+    try:
+        receipt = MemexSnapshotProjectionReceipt(
+            schema_version=_clean(value.get("schema_version")),
+            memex_snapshot_id=_clean(value.get("memex_snapshot_id")),
+            source_scope=_clean(value.get("source_scope")),
+            source_revision=_clean(value.get("source_revision")),
+            content_manifest_digest=_clean(value.get("content_manifest_digest")),
+            created_at=_clean(value.get("created_at")),
+            access_policy_digest=_clean(value.get("access_policy_digest")),
+            records_indexed=int(value.get("records_indexed")),
+            records_rejected=int(value.get("records_rejected")),
+            holoindex_generation_id=_clean(value.get("holoindex_generation_id")),
+            verification=_clean(value.get("verification")),
+            rejected_reasons=tuple(_text(item) for item in value.get("rejected_reasons") or ()),
+            no_holoindex_write_performed=bool(value.get("no_holoindex_write_performed")),
+            no_memex_write_performed=bool(value.get("no_memex_write_performed")),
+            no_brain_write_performed=bool(value.get("no_brain_write_performed")),
+            no_breadcrumb_write_performed=bool(value.get("no_breadcrumb_write_performed")),
+            receipt_id=_clean(value.get("receipt_id")),
+        )
+    except Exception:
+        return None, ("receipt_malformed",)
+    required = (
+        receipt.schema_version,
+        receipt.memex_snapshot_id,
+        receipt.source_scope,
+        receipt.source_revision,
+        receipt.content_manifest_digest,
+        receipt.created_at,
+        receipt.access_policy_digest,
+        receipt.holoindex_generation_id,
+        receipt.verification,
+        receipt.receipt_id,
+    )
+    if any(not item for item in required):
+        return receipt, ("receipt_missing_required_field",)
+    if not (
+        receipt.no_holoindex_write_performed
+        and receipt.no_memex_write_performed
+        and receipt.no_brain_write_performed
+        and receipt.no_breadcrumb_write_performed
+    ):
+        return receipt, ("side_effect_attestation_missing",)
+    return receipt, ()
+
+
+def _expiry_reason(*, created_at: str, now_iso: str | None, max_age_seconds: int | None) -> str:
+    if max_age_seconds is None:
+        return ""
+    try:
+        created = _parse_time(created_at)
+        now = _parse_time(now_iso) if now_iso else datetime.now(timezone.utc)
+    except Exception:
+        return "projection_timestamp_malformed"
+    if created > now:
+        return "projection_created_in_future"
+    if (now - created).total_seconds() > int(max_age_seconds):
+        return "projection_expired"
+    return ""
+
+
+def _parse_time(value: str | None) -> datetime:
+    text = _clean(value)
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _content_digest(text: str) -> str:
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _is_sha256(value: str) -> bool:
+    text = _clean(value)
+    if not text.startswith("sha256:") or len(text) != 71:
+        return False
+    return all(char in "0123456789abcdef" for char in text.removeprefix("sha256:"))
+
+
+def _reject(*reasons: str) -> MemexProjectionIntegrityResult:
+    clean_reasons = tuple(dict.fromkeys(reason for reason in reasons if reason))
+    payload = {
+        "schema_version": INTEGRITY_GATE_SCHEMA_VERSION,
+        "accepted": False,
+        "rejection_reasons": clean_reasons,
+    }
+    return MemexProjectionIntegrityResult(
+        accepted=False,
+        status=PROJECTION_REJECTED,
+        projection=None,
+        rejection_reasons=clean_reasons,
+        receipt_id=digest_json(payload),
+    )
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+__all__ = [
+    "DEFAULT_RUNTIME_MAX_AGE_SECONDS",
+    "INTEGRITY_GATE_SCHEMA_VERSION",
+    "MemexProjectionIntegrityResult",
+    "verify_and_rehydrate_memex_projection",
+]

--- a/holo_index/memex_query_routing.py
+++ b/holo_index/memex_query_routing.py
@@ -18,6 +18,7 @@ from holo_index.memex_projection_adapter import (
     MemexProjectionResult,
     MemexSnapshotProjectionReceipt,
 )
+from holo_index.memex_projection_integrity import verify_and_rehydrate_memex_projection
 from holo_index.query_receipt import SOURCE_CLASS_MEMEX, build_query_receipt
 
 
@@ -75,79 +76,15 @@ def build_memex_projection_query_receipt(
 def _normalize_projection(
     projection: MemexProjectionResult | Mapping[str, Any],
 ) -> tuple[tuple[MemexProjectionRecord, ...], MemexSnapshotProjectionReceipt | None, bool, str]:
-    if isinstance(projection, MemexProjectionResult):
-        return (
-            tuple(projection.records),
-            projection.receipt,
-            projection.accepted and projection.receipt is not None,
-            "" if projection.accepted else ",".join(projection.rejection_reasons),
-        )
-    if not isinstance(projection, Mapping):
-        return (), None, False, "projection_not_mapping"
-    raw_records = projection.get("records")
-    records = tuple(
-        record
-        for record in (_record_from_mapping(item) for item in raw_records or ())
-        if record is not None
+    gate = verify_and_rehydrate_memex_projection(projection)
+    if not gate.accepted or gate.projection is None:
+        return (), None, False, ",".join(gate.rejection_reasons)
+    return (
+        tuple(gate.projection.records),
+        gate.projection.receipt,
+        gate.accepted and gate.projection.receipt is not None,
+        "",
     )
-    receipt = _receipt_from_mapping(projection.get("receipt"))
-    accepted = projection.get("accepted") is True and receipt is not None
-    reasons = projection.get("rejection_reasons")
-    error = ",".join(str(item) for item in reasons) if isinstance(reasons, Sequence) else ""
-    return records, receipt, accepted, error
-
-
-def _record_from_mapping(value: Any) -> MemexProjectionRecord | None:
-    if isinstance(value, MemexProjectionRecord):
-        return value
-    if not isinstance(value, Mapping):
-        return None
-    try:
-        return MemexProjectionRecord(
-            record_id=str(value.get("record_id") or ""),
-            source_class=str(value.get("source_class") or ""),
-            foundup_id=str(value.get("foundup_id") or ""),
-            memex_snapshot_id=str(value.get("memex_snapshot_id") or ""),
-            source_scope=str(value.get("source_scope") or ""),
-            source_revision=str(value.get("source_revision") or ""),
-            title=str(value.get("title") or ""),
-            text=str(value.get("text") or ""),
-            metadata=dict(value.get("metadata") or {}),
-            content_digest=str(value.get("content_digest") or ""),
-        )
-    except Exception:
-        return None
-
-
-def _receipt_from_mapping(value: Any) -> MemexSnapshotProjectionReceipt | None:
-    if isinstance(value, MemexSnapshotProjectionReceipt):
-        return value
-    if not isinstance(value, Mapping):
-        return None
-    try:
-        return MemexSnapshotProjectionReceipt(
-            schema_version=str(value.get("schema_version") or ""),
-            memex_snapshot_id=str(value.get("memex_snapshot_id") or ""),
-            source_scope=str(value.get("source_scope") or ""),
-            source_revision=str(value.get("source_revision") or ""),
-            content_manifest_digest=str(value.get("content_manifest_digest") or ""),
-            created_at=str(value.get("created_at") or ""),
-            access_policy_digest=str(value.get("access_policy_digest") or ""),
-            records_indexed=int(value.get("records_indexed") or 0),
-            records_rejected=int(value.get("records_rejected") or 0),
-            holoindex_generation_id=str(value.get("holoindex_generation_id") or ""),
-            verification=str(value.get("verification") or ""),
-            rejected_reasons=tuple(value.get("rejected_reasons") or ()),
-            no_holoindex_write_performed=bool(value.get("no_holoindex_write_performed", True)),
-            no_memex_write_performed=bool(value.get("no_memex_write_performed", True)),
-            no_brain_write_performed=bool(value.get("no_brain_write_performed", True)),
-            no_breadcrumb_write_performed=bool(
-                value.get("no_breadcrumb_write_performed", True)
-            ),
-            receipt_id=str(value.get("receipt_id") or ""),
-        )
-    except Exception:
-        return None
 
 
 def _query_terms(query: str) -> tuple[str, ...]:

--- a/holo_index/tests/test_holoindex_memex_projection_integrity.py
+++ b/holo_index/tests/test_holoindex_memex_projection_integrity.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import ast
+from copy import deepcopy
+from pathlib import Path
+
+from holo_index.memex_projection_adapter import project_foundup_memex_to_holoindex_shadow
+from holo_index.memex_projection_integrity import (
+    verify_and_rehydrate_memex_projection,
+)
+from holo_index.query_receipt import digest_json
+
+
+MODULE_PATH = Path(__file__).parents[1] / "memex_projection_integrity.py"
+FIXED_NOW = "2026-07-16T00:00:00+00:00"
+POLICY_DIGEST = "sha256:" + "2" * 64
+
+
+def _projection(*, access_policy_digest: str = POLICY_DIGEST) -> dict:
+    result = project_foundup_memex_to_holoindex_shadow(
+        memex_view={
+            "schema_version": "foundup_brain_current_state.v1",
+            "foundup_brain_view_id": "sha256:brain-view",
+            "foundup_id": "foundups-agent",
+            "snapshot_id": "snapshot-1",
+            "snapshot_content_digest": "sha256:snapshot",
+            "identity": {
+                "foundup_id": "foundups-agent",
+                "name": "Foundups Agent",
+            },
+            "current_state": {
+                "selected_slice": "HOLOINDEX_MEMEX_PROJECTION_INTEGRITY_AND_REHYDRATION_GATE_PHASE1",
+                "runtime_gap": "serialized projection integrity",
+            },
+            "roadmap_state": {
+                "next_slice": "REDDOG_MEMEX_SNAPSHOT_PROJECTION_SUPPLIER_PHASE1",
+            },
+            "verified_outcomes": [
+                {
+                    "outcome_id": "o1",
+                    "accepted": True,
+                    "finding": "Memex projection transport exists.",
+                }
+            ],
+        },
+        source_scope="foundup:foundups-agent",
+        source_revision="abc123",
+        allowed_foundup_ids=("foundups-agent",),
+        access_policy_digest=access_policy_digest,
+        holoindex_generation_id="generation-1",
+        now_iso=FIXED_NOW,
+    )
+    assert result.accepted is True
+    return result.to_dict()
+
+
+def _assert_fail(projection: dict, reason: str, **kwargs) -> None:
+    gate = verify_and_rehydrate_memex_projection(projection, **kwargs)
+
+    assert gate.accepted is False
+    assert gate.projection is None
+    assert reason in gate.rejection_reasons
+
+
+def test_valid_round_trip_serialization_rehydrates_projection() -> None:
+    projection = _projection()
+
+    gate = verify_and_rehydrate_memex_projection(projection, runtime_mode=True, now_iso=FIXED_NOW)
+
+    assert gate.accepted is True
+    assert gate.projection is not None
+    assert gate.projection.accepted is True
+    assert len(gate.projection.records) == 4
+    assert gate.projection.receipt is not None
+    assert gate.projection.receipt.receipt_id == projection["receipt"]["receipt_id"]
+    assert gate.receipt_id.startswith("sha256:")
+
+
+def test_changed_record_text_with_old_digest_fails() -> None:
+    projection = _projection()
+    projection["records"][0]["text"] = projection["records"][0]["text"] + " tampered"
+
+    _assert_fail(projection, "record_content_digest_mismatch")
+
+
+def test_changed_record_digest_with_old_record_id_fails() -> None:
+    projection = _projection()
+    projection["records"][0]["content_digest"] = "sha256:" + "3" * 64
+
+    _assert_fail(projection, "record_id_mismatch")
+
+
+def test_changed_manifest_with_old_receipt_id_fails() -> None:
+    projection = _projection()
+    projection["receipt"]["content_manifest_digest"] = "sha256:" + "4" * 64
+
+    gate = verify_and_rehydrate_memex_projection(projection)
+
+    assert gate.accepted is False
+    assert "content_manifest_digest_mismatch" in gate.rejection_reasons
+    assert "receipt_id_mismatch" in gate.rejection_reasons
+
+
+def test_verification_fail_is_rejected_even_if_accepted_true() -> None:
+    projection = _projection()
+    projection["accepted"] = True
+    projection["receipt"]["verification"] = "FAIL"
+
+    _assert_fail(projection, "projection_verification_not_pass")
+
+
+def test_wrong_schema_is_rejected() -> None:
+    projection = _projection()
+    projection["receipt"]["schema_version"] = "wrong.v1"
+
+    _assert_fail(projection, "schema_version_mismatch")
+
+
+def test_mixed_foundup_records_rejected() -> None:
+    projection = _projection()
+    projection["records"][0]["foundup_id"] = "other-foundup"
+
+    _assert_fail(projection, "mixed_foundup_records")
+
+
+def test_mixed_snapshot_ids_rejected() -> None:
+    projection = _projection()
+    projection["records"][0]["memex_snapshot_id"] = "sha256:other-snapshot"
+
+    _assert_fail(projection, "mixed_snapshot_ids")
+
+
+def test_mixed_policy_digests_rejected() -> None:
+    projection = _projection()
+    projection["records"][0]["metadata"] = dict(projection["records"][0]["metadata"])
+    projection["records"][0]["metadata"]["access_policy_digest"] = "sha256:" + "5" * 64
+
+    _assert_fail(projection, "mixed_policy_digests")
+
+
+def test_record_count_and_rejected_count_are_validated() -> None:
+    projection = _projection()
+    projection["receipt"]["records_indexed"] = 99
+
+    _assert_fail(projection, "records_indexed_count_mismatch")
+
+    rejected_mismatch = _projection()
+    rejected_mismatch["receipt"]["records_rejected"] = 1
+    _assert_fail(rejected_mismatch, "records_rejected_count_mismatch")
+
+
+def test_expired_snapshot_rejected_when_age_bound_supplied() -> None:
+    projection = _projection()
+
+    _assert_fail(
+        projection,
+        "projection_expired",
+        now_iso="2026-07-18T00:00:00+00:00",
+        max_age_seconds=60,
+    )
+
+
+def test_placeholder_policy_rejected_in_runtime_mode() -> None:
+    projection = _projection(access_policy_digest="sha256:" + "1" * 64)
+
+    _assert_fail(projection, "placeholder_access_policy_digest", runtime_mode=True, now_iso=FIXED_NOW)
+
+
+def test_replay_revocation_and_expected_binding_rejected() -> None:
+    projection = _projection()
+    receipt_id = projection["receipt"]["receipt_id"]
+
+    _assert_fail(projection, "projection_receipt_replayed", runtime_mode=True, seen_receipt_ids=(receipt_id,))
+    _assert_fail(
+        projection,
+        "projection_snapshot_revoked",
+        runtime_mode=True,
+        revoked_snapshot_ids=("sha256:brain-view",),
+    )
+    _assert_fail(projection, "expected_foundup_mismatch", expected_foundup_id="other")
+    _assert_fail(projection, "expected_generation_mismatch", expected_holoindex_generation_id="other")
+
+
+def test_content_manifest_recomputed_from_records_and_rejections() -> None:
+    projection = _projection()
+    receipt = deepcopy(projection["receipt"])
+    records = projection["records"]
+    manifest = {
+        "schema_version": "holoindex_memex_governed_projection_adapter.v1",
+        "records": [
+            {
+                "record_id": record["record_id"],
+                "content_digest": record["content_digest"],
+                "source_class": record["source_class"],
+            }
+            for record in records
+        ],
+        "rejected": list(receipt["rejected_reasons"]),
+    }
+
+    assert digest_json(manifest) == receipt["content_manifest_digest"]
+
+
+def test_integrity_gate_is_read_only_by_ast() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_imports = {
+        "subprocess",
+        "requests",
+        "httpx",
+        "sqlite3",
+        "chromadb",
+    }
+    banned_calls = {
+        "add",
+        "upsert",
+        "delete",
+        "reset",
+        "_reset_collection",
+        "write_text",
+        "write_bytes",
+        "open",
+    }
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_imports
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_imports
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_calls
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls

--- a/holo_index/tests/test_holoindex_memex_query_routing.py
+++ b/holo_index/tests/test_holoindex_memex_query_routing.py
@@ -121,7 +121,7 @@ def test_memex_query_missing_projection_receipt_fails_closed() -> None:
 
     assert receipt["ok"] is False
     assert receipt["freshness"] == "UNKNOWN"
-    assert receipt["error"] == "missing_memex_projection_receipt"
+    assert receipt["error"] == "missing_projection_receipt"
     assert receipt["freshness_generation_id"] == ""
     assert receipt["index_gap_detected"] is False
 

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: HOLOINDEX_MEMEX_PROJECTION_INTEGRITY_AND_REHYDRATION_GATE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 60, 97
+
+- Updated `reddog_readonly_0102_audit_worker_runtime.py` so optional Memex
+  projections are verified through the HoloIndex integrity/rehydration gate in
+  runtime mode before any Memex query receipt is built.
+- Runtime mode rejects placeholder access-policy digests and any tampered,
+  expired, replayed, revoked, or binding-mismatched serialized projection
+  before the RedDog/Fusion model call.
+- Added a regression proving a tampered Memex record body rejects before the
+  model runner is called. Existing no-Memex behavior remains optional and
+  unchanged.
+- No Memex supplier, content-bearing citation policy, worker spawn, OpenClaw
+  enqueue, Hermes dispatch, repo mutation, shell command, HoloIndex re-index,
+  or authority promotion is added.
+
 ## 2026-07-16: REDDOG_MEMEX_QUERY_RECEIPT_RUNTIME_BINDING_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 60, 97

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
@@ -45,6 +45,7 @@ from holo_index.query_receipt import (
     load_generation_binding,
 )
 from holo_index.memex_query_routing import build_memex_projection_query_receipt
+from holo_index.memex_projection_integrity import verify_and_rehydrate_memex_projection
 
 
 READONLY_0102_AUDIT_WORKER_RECEIPT_SCHEMA = "readonly_0102_audit_worker_receipt.v1"
@@ -597,7 +598,23 @@ def _optional_memex_query_receipt(
     if projection is None:
         return None
     try:
-        return build_memex_projection_query_receipt(query=query, projection=projection)
+        gate = verify_and_rehydrate_memex_projection(projection, runtime_mode=True)
+        if not gate.accepted or gate.projection is None:
+            return build_query_receipt(
+                source="memex_projection",
+                source_class="memex",
+                query=query,
+                result={
+                    "ok": False,
+                    "query": query,
+                    "freshness": "UNKNOWN",
+                    "hits": [],
+                    "error": "memex_projection_integrity_failed:"
+                    + ",".join(gate.rejection_reasons),
+                },
+                require_generation=False,
+            )
+        return build_memex_projection_query_receipt(query=query, projection=gate.projection)
     except Exception as exc:
         return build_query_receipt(
             source="memex_projection",

--- a/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
@@ -287,6 +287,7 @@ def _memex_projection() -> dict:
         source_scope="foundup:foundups-agent",
         source_revision="abc123",
         allowed_foundup_ids=("foundups-agent",),
+        access_policy_digest="sha256:" + "2" * 64,
         holoindex_generation_id="sha256:memex-generation",
         now_iso="2026-07-16T00:00:00+00:00",
     )
@@ -510,6 +511,28 @@ def test_model_backed_rejects_invalid_supplied_memex_projection_before_model(tmp
     runner = _EchoEvidenceModelRunner()
     context = _model_context()
     context["memex_projection"] = {"accepted": True, "records": [], "receipt": None}
+
+    result = execute_reddog_readonly_audit_task(
+        task_context=context,
+        repo_root=root,
+        task_id="task-1",
+        model_runner=runner,
+        holoindex_adapter=_FakeQueryAdapter(),
+        codeindex_adapter=_FakeQueryAdapter(),
+    )
+
+    assert result.accepted is False
+    assert ReadOnlyAuditTaskRejectReason.INDEX_QUERY_FAILED in result.rejection_reasons
+    assert not runner.calls
+
+
+def test_model_backed_rejects_tampered_memex_projection_before_model(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    runner = _EchoEvidenceModelRunner()
+    context = _model_context()
+    projection = _memex_projection()
+    projection["records"][0]["text"] = projection["records"][0]["text"] + " tampered"
+    context["memex_projection"] = projection
 
     result = execute_reddog_readonly_audit_task(
         task_context=context,


### PR DESCRIPTION
## Slice
HOLOINDEX_MEMEX_PROJECTION_INTEGRITY_AND_REHYDRATION_GATE_PHASE1

## WSP_97 truth boundary
- OBSERVED: #1102-#1104 provided projection/query/runtime transport, but serialized projection mappings could be trusted structurally without recomputing every identifier and digest.
- IMPLEMENTED: a read-only HoloIndex integrity gate rehydrates projections only after recomputing record content digests, record ids, content-manifest digest, receipt id, schema versions, count fields, and FoundUp/snapshot/policy/generation bindings.
- IMPLEMENTED: RedDog read-only audit runtime calls the gate in runtime mode before building Memex query receipts, so tampered projections fail closed before the model call.
- SPECIFIED_NOT_IMPLEMENTED: automatic Memex supplier, access-policy receipt, content-bearing Memex citation policy, per-target Memex verdicts, worker spawn, OpenClaw enqueue, Hermes dispatch, HoloIndex re-index, and authority promotion.

## Runtime hardening
- Never trusts serialized `accepted: true`.
- Rejects verification != PASS, wrong schema, digest/id mismatches, mixed FoundUp/snapshot/policy bindings, record-count mismatches, placeholder access-policy digests in runtime mode, expired projections, replayed receipts, revoked snapshots, and expected-binding mismatches.
- Query routing now uses the rehydrated typed projection and no longer keeps a weaker shallow mapping normalizer.

## Validation
```text
python -m pytest holo_index/tests/test_holoindex_memex_projection_adapter.py holo_index/tests/test_holoindex_memex_projection_integrity.py holo_index/tests/test_holoindex_memex_query_routing.py holo_index/tests/test_holoindex_query_receipt.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
60 passed

git diff --check
PASS

ASCII/NUL scan
ASCII_DIFF_ADDITIONS_PASS
```

## No-side-effect boundary
No Memex write, HoloIndex write, Brain/Breadcrumb write, runtime re-index, external retrieval, shell command, repo mutation, OpenClaw enqueue, Hermes dispatch, worktree operation, PR publish, or model authority promotion is added.