### PR TITLE
feat(holoindex): add Memex access policy receipts

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,26 @@
 # HoloIndex Package ModLog
 
+## [2026-07-16] HOLOINDEX_MEMEX_ACCESS_POLICY_RECEIPT_PHASE1
+
+**Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice
+**WSP**: 00, 15, 22, 50, 60, 97
+
+- ADD `holo_index/memex_access_policy_receipt.py`: deterministic read-only
+  access-policy receipt for governed Memex projection. The receipt binds
+  principal, work order, FoundUp scope, source scope, sensitivity classes,
+  allowed/denied record sections, record cap, TTL, and policy generation.
+- UPDATE `holo_index/memex_projection_adapter.py`: optional
+  `access_policy_receipt` validation derives the projection
+  `access_policy_digest` from the receipt id, rejects tampered policy receipts,
+  and filters denied sections without dropping allowed siblings.
+- TEST `tests/test_holoindex_memex_access_policy_receipt.py` plus projection
+  adapter regressions: deterministic receipt, tamper, expiry, replay,
+  revocation, scope mismatch, unsupported sensitivity, section allow/deny,
+  policy-bound projection, and AST no-write/no-exec guards.
+- Boundary: no Memex write, no HoloIndex write, no Brain/Breadcrumb write, no
+  external retrieval, no runtime re-index, and no automatic snapshot supplier.
+  Multi-FoundUp hardening and assignment-bound supplier remain downstream.
+
 ## [2026-07-16] HOLOINDEX_MEMEX_PROJECTION_INTEGRITY_AND_REHYDRATION_GATE_PHASE1
 
 **Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice

--- a/holo_index/memex_access_policy_receipt.py
+++ b/holo_index/memex_access_policy_receipt.py
@@ -1,0 +1,332 @@
+"""Access-policy receipts for governed Memex projection.
+
+The receipt binds who may project which FoundUp memory scope into HoloIndex
+shadow records. It is deterministic, read-only, and carries no private data.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from holo_index.query_receipt import digest_json
+
+
+SCHEMA_VERSION = "holoindex_memex_access_policy_receipt.v1"
+POLICY_READY = "MEMEX_ACCESS_POLICY_READY"
+POLICY_REJECTED = "MEMEX_ACCESS_POLICY_REJECTED"
+VERIFICATION_PASS = "PASS"
+
+ALLOWED_SENSITIVITY_CLASSES = frozenset(
+    {
+        "public",
+        "internal",
+        "foundup_private",
+        "operator_private",
+    }
+)
+DEFAULT_ALLOWED_SECTIONS = (
+    "identity",
+    "current_state",
+    "roadmap_state",
+    "verified_outcome",
+)
+
+
+@dataclass(frozen=True)
+class MemexAccessPolicyReceipt:
+    schema_version: str
+    principal_id: str
+    work_order_id: str
+    foundup_scope: tuple[str, ...]
+    source_scope: str
+    sensitivity_classes: tuple[str, ...]
+    allowed_record_sections: tuple[str, ...]
+    denied_record_sections: tuple[str, ...]
+    max_records: int
+    issued_at: str
+    expires_at: str
+    policy_generation_id: str
+    verification: str
+    revoked: bool = False
+    no_memex_write_performed: bool = True
+    no_holoindex_write_performed: bool = True
+    no_brain_write_performed: bool = True
+    no_breadcrumb_write_performed: bool = True
+    receipt_id: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class MemexAccessPolicyValidationResult:
+    accepted: bool
+    status: str
+    receipt: MemexAccessPolicyReceipt | None
+    rejection_reasons: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "accepted": self.accepted,
+            "status": self.status,
+            "receipt": self.receipt.to_dict() if self.receipt else None,
+            "rejection_reasons": list(self.rejection_reasons),
+        }
+
+
+def build_memex_access_policy_receipt(
+    *,
+    principal_id: str,
+    work_order_id: str,
+    foundup_scope: Sequence[str],
+    source_scope: str,
+    sensitivity_classes: Sequence[str],
+    allowed_record_sections: Sequence[str] = DEFAULT_ALLOWED_SECTIONS,
+    denied_record_sections: Sequence[str] = (),
+    max_records: int = 32,
+    issued_at: str,
+    expires_at: str,
+    policy_generation_id: str,
+) -> MemexAccessPolicyValidationResult:
+    """Build and validate a deterministic access-policy receipt."""
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "principal_id": _clean(principal_id),
+        "work_order_id": _clean(work_order_id),
+        "foundup_scope": tuple(_unique_clean(foundup_scope)),
+        "source_scope": _clean(source_scope),
+        "sensitivity_classes": tuple(_unique_clean(sensitivity_classes)),
+        "allowed_record_sections": tuple(_unique_clean(allowed_record_sections)),
+        "denied_record_sections": tuple(_unique_clean(denied_record_sections)),
+        "max_records": int(max_records or 0),
+        "issued_at": _clean(issued_at),
+        "expires_at": _clean(expires_at),
+        "policy_generation_id": _clean(policy_generation_id),
+        "verification": VERIFICATION_PASS,
+        "revoked": False,
+        "no_memex_write_performed": True,
+        "no_holoindex_write_performed": True,
+        "no_brain_write_performed": True,
+        "no_breadcrumb_write_performed": True,
+    }
+    receipt = MemexAccessPolicyReceipt(**payload, receipt_id=digest_json(payload))
+    return validate_memex_access_policy_receipt(receipt, now_iso=issued_at)
+
+
+def validate_memex_access_policy_receipt(
+    receipt: MemexAccessPolicyReceipt | Mapping[str, Any],
+    *,
+    expected_foundup_id: str | None = None,
+    expected_source_scope: str | None = None,
+    expected_principal_id: str | None = None,
+    expected_work_order_id: str | None = None,
+    now_iso: str | None = None,
+    seen_receipt_ids: Sequence[str] = (),
+    revoked_receipt_ids: Sequence[str] = (),
+) -> MemexAccessPolicyValidationResult:
+    typed, reasons = _receipt_from_any(receipt)
+    if typed is None:
+        return _reject(*reasons, "access_policy_receipt_malformed")
+
+    if typed.schema_version != SCHEMA_VERSION:
+        reasons.append("schema_version_mismatch")
+    if typed.verification != VERIFICATION_PASS:
+        reasons.append("verification_not_pass")
+    if typed.revoked:
+        reasons.append("access_policy_revoked")
+    if typed.receipt_id in {_clean(item) for item in seen_receipt_ids if _clean(item)}:
+        reasons.append("access_policy_replayed")
+    if typed.receipt_id in {_clean(item) for item in revoked_receipt_ids if _clean(item)}:
+        reasons.append("access_policy_revoked")
+    if not typed.foundup_scope:
+        reasons.append("missing_foundup_scope")
+    if not typed.source_scope:
+        reasons.append("missing_source_scope")
+    if not typed.policy_generation_id:
+        reasons.append("missing_policy_generation_id")
+    if typed.max_records <= 0:
+        reasons.append("invalid_max_records")
+    if set(typed.sensitivity_classes) - ALLOWED_SENSITIVITY_CLASSES:
+        reasons.append("unsupported_sensitivity_class")
+    if not typed.allowed_record_sections:
+        reasons.append("missing_allowed_record_sections")
+    if not (
+        typed.no_memex_write_performed
+        and typed.no_holoindex_write_performed
+        and typed.no_brain_write_performed
+        and typed.no_breadcrumb_write_performed
+    ):
+        reasons.append("side_effect_attestation_missing")
+    time_reason = _time_reason(issued_at=typed.issued_at, expires_at=typed.expires_at, now_iso=now_iso)
+    if time_reason:
+        reasons.append(time_reason)
+    if expected_foundup_id and _clean(expected_foundup_id) not in typed.foundup_scope:
+        reasons.append("expected_foundup_not_in_scope")
+    if expected_source_scope and typed.source_scope != _clean(expected_source_scope):
+        reasons.append("expected_source_scope_mismatch")
+    if expected_principal_id and typed.principal_id != _clean(expected_principal_id):
+        reasons.append("expected_principal_mismatch")
+    if expected_work_order_id and typed.work_order_id != _clean(expected_work_order_id):
+        reasons.append("expected_work_order_mismatch")
+
+    payload = _receipt_payload(typed)
+    if digest_json(payload) != typed.receipt_id:
+        reasons.append("access_policy_receipt_id_mismatch")
+
+    if reasons:
+        return _reject(*reasons)
+    return MemexAccessPolicyValidationResult(
+        accepted=True,
+        status=POLICY_READY,
+        receipt=typed,
+        rejection_reasons=(),
+    )
+
+
+def section_allowed_by_policy(section: str, receipt: MemexAccessPolicyReceipt) -> bool:
+    """Return whether a projected record section is allowed by the receipt."""
+
+    normalized = _section_base(section)
+    allowed = {_section_base(item) for item in receipt.allowed_record_sections}
+    denied = {_section_base(item) for item in receipt.denied_record_sections}
+    return normalized in allowed and normalized not in denied
+
+
+def _receipt_payload(receipt: MemexAccessPolicyReceipt) -> dict[str, Any]:
+    return {
+        "schema_version": receipt.schema_version,
+        "principal_id": receipt.principal_id,
+        "work_order_id": receipt.work_order_id,
+        "foundup_scope": tuple(receipt.foundup_scope),
+        "source_scope": receipt.source_scope,
+        "sensitivity_classes": tuple(receipt.sensitivity_classes),
+        "allowed_record_sections": tuple(receipt.allowed_record_sections),
+        "denied_record_sections": tuple(receipt.denied_record_sections),
+        "max_records": receipt.max_records,
+        "issued_at": receipt.issued_at,
+        "expires_at": receipt.expires_at,
+        "policy_generation_id": receipt.policy_generation_id,
+        "verification": receipt.verification,
+        "revoked": receipt.revoked,
+        "no_memex_write_performed": receipt.no_memex_write_performed,
+        "no_holoindex_write_performed": receipt.no_holoindex_write_performed,
+        "no_brain_write_performed": receipt.no_brain_write_performed,
+        "no_breadcrumb_write_performed": receipt.no_breadcrumb_write_performed,
+    }
+
+
+def _receipt_from_any(value: MemexAccessPolicyReceipt | Mapping[str, Any]) -> tuple[
+    MemexAccessPolicyReceipt | None,
+    list[str],
+]:
+    if isinstance(value, MemexAccessPolicyReceipt):
+        return value, []
+    if not isinstance(value, Mapping):
+        return None, ["access_policy_not_mapping"]
+    try:
+        receipt = MemexAccessPolicyReceipt(
+            schema_version=_clean(value.get("schema_version")),
+            principal_id=_clean(value.get("principal_id")),
+            work_order_id=_clean(value.get("work_order_id")),
+            foundup_scope=tuple(_unique_clean(value.get("foundup_scope") or ())),
+            source_scope=_clean(value.get("source_scope")),
+            sensitivity_classes=tuple(_unique_clean(value.get("sensitivity_classes") or ())),
+            allowed_record_sections=tuple(_unique_clean(value.get("allowed_record_sections") or ())),
+            denied_record_sections=tuple(_unique_clean(value.get("denied_record_sections") or ())),
+            max_records=int(value.get("max_records") or 0),
+            issued_at=_clean(value.get("issued_at")),
+            expires_at=_clean(value.get("expires_at")),
+            policy_generation_id=_clean(value.get("policy_generation_id")),
+            verification=_clean(value.get("verification")),
+            revoked=bool(value.get("revoked")),
+            no_memex_write_performed=bool(value.get("no_memex_write_performed")),
+            no_holoindex_write_performed=bool(value.get("no_holoindex_write_performed")),
+            no_brain_write_performed=bool(value.get("no_brain_write_performed")),
+            no_breadcrumb_write_performed=bool(value.get("no_breadcrumb_write_performed")),
+            receipt_id=_clean(value.get("receipt_id")),
+        )
+    except Exception:
+        return None, ["access_policy_receipt_parse_failed"]
+    missing = []
+    for key in (
+        "schema_version",
+        "principal_id",
+        "work_order_id",
+        "source_scope",
+        "issued_at",
+        "expires_at",
+        "policy_generation_id",
+        "verification",
+        "receipt_id",
+    ):
+        if not _clean(getattr(receipt, key)):
+            missing.append(f"missing_{key}")
+    return receipt, missing
+
+
+def _time_reason(*, issued_at: str, expires_at: str, now_iso: str | None) -> str:
+    try:
+        issued = _parse_time(issued_at)
+        expires = _parse_time(expires_at)
+        now = _parse_time(now_iso) if now_iso else datetime.now(timezone.utc)
+    except Exception:
+        return "access_policy_time_malformed"
+    if expires <= issued:
+        return "access_policy_expiry_not_after_issue"
+    if now < issued:
+        return "access_policy_not_yet_valid"
+    if now > expires:
+        return "access_policy_expired"
+    return ""
+
+
+def _parse_time(value: str | None) -> datetime:
+    text = _clean(value)
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _section_base(value: str) -> str:
+    text = _clean(value)
+    if text.startswith("verified_outcome"):
+        return "verified_outcome"
+    return text
+
+
+def _unique_clean(values: Sequence[Any]) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)):
+        return (_clean(values),) if _clean(values) else ()
+    return tuple(dict.fromkeys(_clean(item) for item in values if _clean(item)))
+
+
+def _reject(*reasons: str) -> MemexAccessPolicyValidationResult:
+    return MemexAccessPolicyValidationResult(
+        accepted=False,
+        status=POLICY_REJECTED,
+        receipt=None,
+        rejection_reasons=tuple(dict.fromkeys(reason for reason in reasons if reason)),
+    )
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+__all__ = [
+    "DEFAULT_ALLOWED_SECTIONS",
+    "MemexAccessPolicyReceipt",
+    "MemexAccessPolicyValidationResult",
+    "POLICY_READY",
+    "POLICY_REJECTED",
+    "SCHEMA_VERSION",
+    "build_memex_access_policy_receipt",
+    "section_allowed_by_policy",
+    "validate_memex_access_policy_receipt",
+]

--- a/holo_index/memex_projection_adapter.py
+++ b/holo_index/memex_projection_adapter.py
@@ -14,6 +14,11 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Mapping, Sequence
 
+from holo_index.memex_access_policy_receipt import (
+    MemexAccessPolicyReceipt,
+    section_allowed_by_policy,
+    validate_memex_access_policy_receipt,
+)
 from holo_index.query_receipt import SOURCE_CLASS_MEMEX, digest_json
 
 
@@ -108,6 +113,7 @@ def project_foundup_memex_to_holoindex_shadow(
     source_revision: str,
     allowed_foundup_ids: Sequence[str],
     access_policy_digest: str = DEFAULT_ACCESS_POLICY_DIGEST,
+    access_policy_receipt: MemexAccessPolicyReceipt | Mapping[str, Any] | None = None,
     holoindex_generation_id: str = "",
     now_iso: str | None = None,
 ) -> MemexProjectionResult:
@@ -138,10 +144,38 @@ def project_foundup_memex_to_holoindex_shadow(
     if not _clean(access_policy_digest).startswith("sha256:"):
         reasons.append("invalid_access_policy_digest")
 
+    policy_receipt: MemexAccessPolicyReceipt | None = None
+    if access_policy_receipt is not None:
+        policy_validation = validate_memex_access_policy_receipt(
+            access_policy_receipt,
+            expected_foundup_id=foundup_id,
+            expected_source_scope=_clean(source_scope),
+            now_iso=now_iso,
+        )
+        if not policy_validation.accepted or policy_validation.receipt is None:
+            reasons.extend(
+                f"access_policy_receipt:{reason}"
+                for reason in policy_validation.rejection_reasons
+            )
+        else:
+            policy_receipt = policy_validation.receipt
+            if (
+                access_policy_digest != DEFAULT_ACCESS_POLICY_DIGEST
+                and _clean(access_policy_digest) != policy_receipt.receipt_id
+            ):
+                reasons.append("access_policy_digest_mismatch")
+            access_policy_digest = policy_receipt.receipt_id
+
     candidate_sections = _candidate_sections(memex_view)
     records: list[MemexProjectionRecord] = []
     rejected: list[str] = []
     for label, payload in candidate_sections:
+        if policy_receipt is not None and not section_allowed_by_policy(label, policy_receipt):
+            rejected.append(f"access_policy_denied_record:{label}")
+            continue
+        if policy_receipt is not None and len(records) >= policy_receipt.max_records:
+            rejected.append(f"access_policy_max_records:{label}")
+            continue
         if _contains_secret(payload):
             rejected.append(f"secret_bearing_record:{label}")
             continue

--- a/holo_index/tests/test_holoindex_memex_access_policy_receipt.py
+++ b/holo_index/tests/test_holoindex_memex_access_policy_receipt.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from holo_index.memex_access_policy_receipt import (
+    POLICY_READY,
+    build_memex_access_policy_receipt,
+    section_allowed_by_policy,
+    validate_memex_access_policy_receipt,
+)
+
+
+MODULE_PATH = Path(__file__).parents[1] / "memex_access_policy_receipt.py"
+ISSUED_AT = "2026-07-16T00:00:00+00:00"
+EXPIRES_AT = "2026-07-17T00:00:00+00:00"
+
+
+def _receipt() -> dict:
+    result = build_memex_access_policy_receipt(
+        principal_id="principal:012",
+        work_order_id="work-order-1",
+        foundup_scope=("foundups-agent",),
+        source_scope="foundup:foundups-agent",
+        sensitivity_classes=("internal",),
+        allowed_record_sections=("identity", "current_state", "roadmap_state"),
+        denied_record_sections=("verified_outcome",),
+        max_records=8,
+        issued_at=ISSUED_AT,
+        expires_at=EXPIRES_AT,
+        policy_generation_id="policy-generation-1",
+    )
+    assert result.accepted is True
+    assert result.receipt is not None
+    return result.receipt.to_dict()
+
+
+def test_access_policy_receipt_builds_deterministic_valid_receipt() -> None:
+    first = _receipt()
+    second = _receipt()
+
+    assert first == second
+    assert first["schema_version"] == "holoindex_memex_access_policy_receipt.v1"
+    assert first["receipt_id"].startswith("sha256:")
+    assert first["verification"] == "PASS"
+    assert first["no_memex_write_performed"] is True
+    assert first["no_holoindex_write_performed"] is True
+
+    validation = validate_memex_access_policy_receipt(
+        first,
+        expected_foundup_id="foundups-agent",
+        expected_source_scope="foundup:foundups-agent",
+        expected_principal_id="principal:012",
+        expected_work_order_id="work-order-1",
+        now_iso=ISSUED_AT,
+    )
+    assert validation.accepted is True
+    assert validation.status == POLICY_READY
+
+
+def test_access_policy_receipt_rejects_tampered_receipt_id() -> None:
+    receipt = _receipt()
+    receipt["principal_id"] = "principal:attacker"
+
+    validation = validate_memex_access_policy_receipt(receipt, now_iso=ISSUED_AT)
+
+    assert validation.accepted is False
+    assert "access_policy_receipt_id_mismatch" in validation.rejection_reasons
+
+
+def test_access_policy_receipt_rejects_expired_replayed_and_revoked() -> None:
+    receipt = _receipt()
+
+    expired = validate_memex_access_policy_receipt(receipt, now_iso="2026-07-18T00:00:00+00:00")
+    replayed = validate_memex_access_policy_receipt(
+        receipt,
+        now_iso=ISSUED_AT,
+        seen_receipt_ids=(receipt["receipt_id"],),
+    )
+    revoked = validate_memex_access_policy_receipt(
+        receipt,
+        now_iso=ISSUED_AT,
+        revoked_receipt_ids=(receipt["receipt_id"],),
+    )
+
+    assert expired.accepted is False
+    assert "access_policy_expired" in expired.rejection_reasons
+    assert replayed.accepted is False
+    assert "access_policy_replayed" in replayed.rejection_reasons
+    assert revoked.accepted is False
+    assert "access_policy_revoked" in revoked.rejection_reasons
+
+
+def test_access_policy_receipt_rejects_scope_mismatch_and_bad_sensitivity() -> None:
+    receipt = _receipt()
+    mismatch = validate_memex_access_policy_receipt(
+        receipt,
+        expected_foundup_id="other-foundup",
+        expected_source_scope="foundup:foundups-agent",
+        now_iso=ISSUED_AT,
+    )
+    bad_sensitivity = dict(receipt)
+    bad_sensitivity["sensitivity_classes"] = ["secret"]
+
+    bad = validate_memex_access_policy_receipt(bad_sensitivity, now_iso=ISSUED_AT)
+
+    assert mismatch.accepted is False
+    assert "expected_foundup_not_in_scope" in mismatch.rejection_reasons
+    assert bad.accepted is False
+    assert "unsupported_sensitivity_class" in bad.rejection_reasons
+
+
+def test_section_policy_allows_and_denies_expected_sections() -> None:
+    validation = validate_memex_access_policy_receipt(_receipt(), now_iso=ISSUED_AT)
+    assert validation.receipt is not None
+
+    assert section_allowed_by_policy("identity", validation.receipt) is True
+    assert section_allowed_by_policy("verified_outcome:0", validation.receipt) is False
+
+
+def test_access_policy_receipt_is_read_only_by_ast() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_imports = {
+        "subprocess",
+        "requests",
+        "httpx",
+        "sqlite3",
+        "chromadb",
+    }
+    banned_calls = {
+        "add",
+        "upsert",
+        "delete",
+        "reset",
+        "_reset_collection",
+        "write_text",
+        "write_bytes",
+        "open",
+    }
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_imports
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_imports
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_calls
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls

--- a/holo_index/tests/test_holoindex_memex_projection_adapter.py
+++ b/holo_index/tests/test_holoindex_memex_projection_adapter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+from holo_index.memex_access_policy_receipt import build_memex_access_policy_receipt
 from holo_index.memex_projection_adapter import (
     DEFAULT_ACCESS_POLICY_DIGEST,
     PROJECTION_ACCEPTED,
@@ -15,6 +16,7 @@ from holo_index.memex_projection_adapter import (
 
 MODULE_PATH = Path(__file__).parents[1] / "memex_projection_adapter.py"
 FIXED_NOW = "2026-07-16T00:00:00+00:00"
+POLICY_EXPIRES = "2026-07-17T00:00:00+00:00"
 
 
 def _memex_view() -> dict[str, object]:
@@ -59,6 +61,27 @@ def _project(**overrides: object):
     }
     kwargs.update(overrides)
     return project_foundup_memex_to_holoindex_shadow(**kwargs)
+
+
+def _policy_receipt(**overrides: object) -> dict:
+    kwargs = {
+        "principal_id": "principal:012",
+        "work_order_id": "work-order-1",
+        "foundup_scope": ("foundups-agent",),
+        "source_scope": "foundup:foundups-agent",
+        "sensitivity_classes": ("internal",),
+        "allowed_record_sections": ("identity", "current_state", "roadmap_state"),
+        "denied_record_sections": ("verified_outcome",),
+        "max_records": 8,
+        "issued_at": FIXED_NOW,
+        "expires_at": POLICY_EXPIRES,
+        "policy_generation_id": "policy-generation-1",
+    }
+    kwargs.update(overrides)
+    result = build_memex_access_policy_receipt(**kwargs)
+    assert result.accepted is True
+    assert result.receipt is not None
+    return result.receipt.to_dict()
 
 
 def test_memex_projection_builds_shadow_records_and_receipt() -> None:
@@ -160,6 +183,30 @@ def test_memex_projection_rejects_invalid_access_policy_digest() -> None:
 
     assert result.accepted is False
     assert "invalid_access_policy_digest" in result.rejection_reasons
+
+
+def test_memex_projection_binds_valid_access_policy_receipt() -> None:
+    policy = _policy_receipt()
+
+    result = _project(access_policy_receipt=policy)
+
+    assert result.accepted is True
+    assert result.receipt is not None
+    assert result.receipt.access_policy_digest == policy["receipt_id"]
+    assert result.receipt.records_indexed == 3
+    assert result.receipt.records_rejected == 1
+    assert result.receipt.rejected_reasons == ("access_policy_denied_record:verified_outcome:0",)
+    assert all(record.metadata["access_policy_digest"] == policy["receipt_id"] for record in result.records)
+
+
+def test_memex_projection_rejects_tampered_access_policy_receipt() -> None:
+    policy = _policy_receipt()
+    policy["principal_id"] = "principal:attacker"
+
+    result = _project(access_policy_receipt=policy)
+
+    assert result.accepted is False
+    assert "access_policy_receipt:access_policy_receipt_id_mismatch" in result.rejection_reasons
 
 
 def test_memex_projection_is_projection_only_by_ast() -> None:


### PR DESCRIPTION
## Slice
HOLOINDEX_MEMEX_ACCESS_POLICY_RECEIPT_PHASE1

## WSP_97 truth boundary
- OBSERVED: #1105 now rejects tampered serialized projections, but runtime projection still needed a real policy receipt instead of an opaque/placeholder policy digest.
- IMPLEMENTED: deterministic read-only Memex access-policy receipts binding principal, work order, FoundUp scope, source scope, sensitivity classes, allowed/denied sections, record cap, TTL, and policy generation.
- IMPLEMENTED: projection adapter optionally validates an access-policy receipt, derives `access_policy_digest` from the policy receipt id, rejects tampered policies, and filters denied sections without dropping allowed siblings.
- SPECIFIED_NOT_IMPLEMENTED: multi-FoundUp scope hardening, snapshot/assignment binding, content-bearing Memex evidence, citation policy, per-target Memex verdicts, and automatic snapshot projection supplier.

## Validation
```text
python -m pytest holo_index/tests/test_holoindex_memex_access_policy_receipt.py holo_index/tests/test_holoindex_memex_projection_adapter.py holo_index/tests/test_holoindex_memex_projection_integrity.py holo_index/tests/test_holoindex_memex_query_routing.py holo_index/tests/test_holoindex_query_receipt.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
68 passed

git diff --check
PASS

ASCII/NUL scan
ASCII_DIFF_ADDITIONS_PASS
```

## No-side-effect boundary
No Memex write, HoloIndex write, Brain/Breadcrumb write, runtime re-index, external retrieval, shell command, repo mutation, OpenClaw enqueue, Hermes dispatch, worktree operation, PR publish, or authority promotion is added.