### PR TITLE
fix(memex): harden multi-foundup current-state scoping

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,23 @@
 # HoloIndex Package ModLog
 
+## [2026-07-16] FOUNDUP_MEMEX_MULTI_FOUNDUP_SCOPE_HARDENING_PHASE1
+
+**Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice
+**WSP**: 00, 15, 22, 50, 60, 97
+
+- UPDATE `holo_index/memex_projection_integrity.py`: serialized Memex
+  projection records must now carry consistent operational snapshot
+  `metadata.snapshot_id` and `metadata.snapshot_content_digest` values across
+  every record.
+- ADD optional expected binding checks for operational snapshot id and content
+  digest so a later assignment-binding slice can pin the Memex projection to
+  the exact RedDog snapshot.
+- TEST `tests/test_holoindex_memex_projection_integrity.py`: mixed, missing,
+  and expected-mismatched operational snapshot metadata all fail closed.
+- Boundary: this remains integrity, not authentication. Runtime policy
+  issuance, assignment-bound authorization, content-bearing evidence, and typed
+  citation policy remain downstream.
+
 ## [2026-07-16] HOLOINDEX_MEMEX_ACCESS_POLICY_RECEIPT_PHASE1
 
 **Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice

--- a/holo_index/memex_projection_integrity.py
+++ b/holo_index/memex_projection_integrity.py
@@ -65,6 +65,8 @@ def verify_and_rehydrate_memex_projection(
     expected_source_revision: str | None = None,
     expected_access_policy_digest: str | None = None,
     expected_holoindex_generation_id: str | None = None,
+    expected_operational_snapshot_id: str | None = None,
+    expected_operational_snapshot_content_digest: str | None = None,
 ) -> MemexProjectionIntegrityResult:
     """Return a typed verified projection or fail closed.
 
@@ -143,6 +145,16 @@ def verify_and_rehydrate_memex_projection(
         for record in records
         if isinstance(record.metadata, Mapping)
     }
+    operational_snapshot_ids = {
+        str(record.metadata.get("snapshot_id") or "").strip()
+        for record in records
+        if isinstance(record.metadata, Mapping)
+    }
+    operational_snapshot_content_digests = {
+        str(record.metadata.get("snapshot_content_digest") or "").strip()
+        for record in records
+        if isinstance(record.metadata, Mapping)
+    }
 
     if len(foundup_ids) != 1:
         reasons.append("mixed_foundup_records")
@@ -156,6 +168,12 @@ def verify_and_rehydrate_memex_projection(
         policy_digests and next(iter(policy_digests)) != receipt.access_policy_digest
     ):
         reasons.append("mixed_policy_digests")
+    if len(operational_snapshot_ids) != 1 or not next(iter(operational_snapshot_ids or {""})):
+        reasons.append("mixed_operational_snapshot_ids")
+    if len(operational_snapshot_content_digests) != 1 or not next(
+        iter(operational_snapshot_content_digests or {""})
+    ):
+        reasons.append("mixed_operational_snapshot_content_digests")
 
     if expected_foundup_id and foundup_ids != {_clean(expected_foundup_id)}:
         reasons.append("expected_foundup_mismatch")
@@ -171,6 +189,14 @@ def verify_and_rehydrate_memex_projection(
         expected_holoindex_generation_id
     ):
         reasons.append("expected_generation_mismatch")
+    if expected_operational_snapshot_id and operational_snapshot_ids != {
+        _clean(expected_operational_snapshot_id)
+    }:
+        reasons.append("expected_operational_snapshot_id_mismatch")
+    if expected_operational_snapshot_content_digest and operational_snapshot_content_digests != {
+        _clean(expected_operational_snapshot_content_digest)
+    }:
+        reasons.append("expected_operational_snapshot_content_digest_mismatch")
 
     for record in records:
         reasons.extend(_record_integrity_reasons(record, receipt=receipt))
@@ -256,6 +282,10 @@ def _record_integrity_reasons(
         reasons.append("metadata_source_revision_mismatch")
     if record.metadata.get("access_policy_digest") != receipt.access_policy_digest:
         reasons.append("metadata_access_policy_mismatch")
+    if not str(record.metadata.get("snapshot_id") or "").strip():
+        reasons.append("metadata_snapshot_id_missing")
+    if not str(record.metadata.get("snapshot_content_digest") or "").strip():
+        reasons.append("metadata_snapshot_content_digest_missing")
     section = str(record.metadata.get("section") or "").strip()
     if not section:
         reasons.append("missing_record_section")

--- a/holo_index/tests/test_holoindex_memex_projection_integrity.py
+++ b/holo_index/tests/test_holoindex_memex_projection_integrity.py
@@ -138,6 +138,35 @@ def test_mixed_policy_digests_rejected() -> None:
     _assert_fail(projection, "mixed_policy_digests")
 
 
+def test_operational_snapshot_metadata_bindings_are_validated() -> None:
+    projection = _projection()
+    projection["records"][0]["metadata"] = dict(projection["records"][0]["metadata"])
+    projection["records"][0]["metadata"]["snapshot_id"] = "other-snapshot"
+
+    _assert_fail(projection, "mixed_operational_snapshot_ids")
+
+    digest_mismatch = _projection()
+    digest_mismatch["records"][0]["metadata"] = dict(digest_mismatch["records"][0]["metadata"])
+    digest_mismatch["records"][0]["metadata"]["snapshot_content_digest"] = "sha256:other-snapshot"
+    _assert_fail(digest_mismatch, "mixed_operational_snapshot_content_digests")
+
+    missing = _projection()
+    missing["records"][0]["metadata"] = dict(missing["records"][0]["metadata"])
+    missing["records"][0]["metadata"]["snapshot_id"] = ""
+    _assert_fail(missing, "metadata_snapshot_id_missing")
+
+    _assert_fail(
+        _projection(),
+        "expected_operational_snapshot_id_mismatch",
+        expected_operational_snapshot_id="other-snapshot",
+    )
+    _assert_fail(
+        _projection(),
+        "expected_operational_snapshot_content_digest_mismatch",
+        expected_operational_snapshot_content_digest="sha256:other-snapshot",
+    )
+
+
 def test_record_count_and_rejected_count_are_validated() -> None:
     projection = _projection()
     projection["receipt"]["records_indexed"] = 99

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,24 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: FOUNDUP_MEMEX_MULTI_FOUNDUP_SCOPE_HARDENING_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 60, 97
+
+- Hardened FoundUp Brain/Memex current-state assembly for resident
+  multi-FoundUp operation.
+- Resident mode now requires explicit FoundUp scoping across identity,
+  roadmap, outcomes, worker claims, queue items, and policy FoundUp scope.
+- Foreign worker claims and queue items are excluded with deterministic
+  count/digest accounting instead of leaking into the selected FoundUp or
+  rejecting the whole mixed snapshot.
+- Legacy single-FoundUp inference now requires explicit compatibility mode and
+  marks inferred records with `legacy_single_foundup_compatibility`.
+- Added an assembly receipt to the read-only view with included/excluded work
+  counts, excluded-record digest, policy scope, and no-write attestations.
+- Tests cover independent A/B FoundUp views from one mixed snapshot, resident
+  rejection of unscoped records, explicit compatibility mode, and policy-scope
+  mismatch.
+
 ## 2026-07-16: HOLOINDEX_MEMEX_PROJECTION_INTEGRITY_AND_REHYDRATION_GATE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 60, 97

--- a/modules/communication/moltbot_bridge/src/foundup_brain_current_state.py
+++ b/modules/communication/moltbot_bridge/src/foundup_brain_current_state.py
@@ -64,6 +64,7 @@ class FoundUpBrainView:
     verified_outcomes: tuple[dict[str, Any], ...]
     learning_candidates: tuple[dict[str, Any], ...] = ()
     roadmap_signals: tuple[dict[str, Any], ...] = ()
+    assembly_receipt: dict[str, Any] | None = None
     invariants: dict[str, bool] | None = None
 
     def to_dict(self) -> dict[str, Any]:
@@ -100,6 +101,9 @@ def assemble_foundup_brain_current_state(
     roadmap_state: Mapping[str, Any] | None = None,
     verified_outcomes: Sequence[Mapping[str, Any]] = (),
     now_iso: str | None = None,
+    resident_mode: bool = True,
+    legacy_single_foundup_compatibility: bool = False,
+    policy_foundup_scope: Sequence[str] | None = None,
 ) -> FoundUpBrainAssemblyResult:
     """Assemble one FoundUp's current cognition from existing receipts."""
 
@@ -129,28 +133,77 @@ def assemble_foundup_brain_current_state(
     identity_clean = _normalize_identity(identity)
     if not identity_clean.get("name"):
         reasons.append("missing_identity_name")
-    identity_foundup_id = str(identity_clean.get("foundup_id", normalized_foundup_id)).strip()
-    if identity_foundup_id and identity_foundup_id != normalized_foundup_id:
+    identity_foundup_id = str(identity_clean.get("foundup_id", "")).strip()
+    if not identity_foundup_id:
+        if resident_mode and not legacy_single_foundup_compatibility:
+            reasons.append("identity_missing_foundup_id")
+        elif legacy_single_foundup_compatibility:
+            identity_clean["scope_origin"] = "legacy_single_foundup_compatibility"
+    elif identity_foundup_id != normalized_foundup_id:
         reasons.append("identity_foundup_id_mismatch")
     identity_clean["foundup_id"] = normalized_foundup_id
 
-    roadmap_clean = _normalize_roadmap_state(roadmap_state, normalized_foundup_id, reasons)
+    policy_scope = tuple(str(item).strip() for item in (policy_foundup_scope or ()) if str(item).strip())
+    if resident_mode:
+        if policy_scope != (normalized_foundup_id,):
+            reasons.append("policy_foundup_scope_mismatch")
+
+    roadmap_clean = _normalize_roadmap_state(
+        roadmap_state,
+        normalized_foundup_id,
+        reasons,
+        resident_mode=resident_mode,
+        legacy_single_foundup_compatibility=legacy_single_foundup_compatibility,
+    )
     outcomes_clean = tuple(
-        _normalize_verified_outcome(outcome, normalized_foundup_id, reasons)
+        _normalize_verified_outcome(
+            outcome,
+            normalized_foundup_id,
+            reasons,
+            resident_mode=resident_mode,
+            legacy_single_foundup_compatibility=legacy_single_foundup_compatibility,
+        )
         for outcome in verified_outcomes
     )
-    active_work = _scope_work_records(
+    active_work, excluded_active_work = _scope_work_records(
         snapshot.work_state.get("worker_claims", ()),
         normalized_foundup_id,
         "worker_claim",
         reasons,
+        resident_mode=resident_mode,
+        legacy_single_foundup_compatibility=legacy_single_foundup_compatibility,
     )
-    queued_work = _scope_work_records(
+    queued_work, excluded_queued_work = _scope_work_records(
         snapshot.work_state.get("wre_queue_items", ()),
         normalized_foundup_id,
         "queue_item",
         reasons,
+        resident_mode=resident_mode,
+        legacy_single_foundup_compatibility=legacy_single_foundup_compatibility,
     )
+    excluded_records = excluded_active_work + excluded_queued_work
+    excluded_record_digest = _digest(excluded_records)
+    assembly_receipt_payload = {
+        "schema_version": "foundup_memex_assembly_receipt.v1",
+        "foundup_id": normalized_foundup_id,
+        "snapshot_id": snapshot.snapshot_receipt_id,
+        "snapshot_content_digest": snapshot.snapshot_content_digest,
+        "resident_mode": resident_mode is True,
+        "legacy_single_foundup_compatibility": legacy_single_foundup_compatibility is True,
+        "policy_foundup_scope": policy_scope,
+        "included_worker_claims": len(active_work),
+        "included_queue_items": len(queued_work),
+        "excluded_record_count": len(excluded_records),
+        "excluded_record_digest": excluded_record_digest,
+        "no_brain_write_performed": True,
+        "no_breadcrumb_write_performed": True,
+        "no_holoindex_mutation_performed": True,
+        "no_queue_mutation_performed": True,
+    }
+    assembly_receipt = {
+        **assembly_receipt_payload,
+        "receipt_id": _digest(assembly_receipt_payload),
+    }
 
     candidate_payload = {
         "identity": identity_clean,
@@ -195,6 +248,7 @@ def assemble_foundup_brain_current_state(
         "verified_outcomes": outcomes_clean,
         "learning_candidates": (),
         "roadmap_signals": (),
+        "assembly_receipt": assembly_receipt,
     }
     view_id = _digest(content)
     view = FoundUpBrainView(
@@ -218,6 +272,7 @@ def assemble_foundup_brain_current_state(
             "no_worker_spawn": True,
             "no_repo_mutation": True,
         },
+        assembly_receipt=assembly_receipt,
     )
     return FoundUpBrainAssemblyResult(
         accepted=True,
@@ -236,10 +291,19 @@ def _normalize_roadmap_state(
     roadmap_state: Mapping[str, Any] | None,
     foundup_id: str,
     reasons: list[str],
+    *,
+    resident_mode: bool,
+    legacy_single_foundup_compatibility: bool,
 ) -> dict[str, Any]:
     data = dict(roadmap_state or {})
-    scoped_id = str(data.get("foundup_id", foundup_id)).strip()
-    if scoped_id and scoped_id != foundup_id:
+    scoped_id = str(data.get("foundup_id", "")).strip()
+    scope_origin = ""
+    if not scoped_id:
+        if resident_mode and not legacy_single_foundup_compatibility:
+            reasons.append("roadmap_missing_foundup_id")
+        elif legacy_single_foundup_compatibility:
+            scope_origin = "legacy_single_foundup_compatibility"
+    elif scoped_id != foundup_id:
         reasons.append("roadmap_foundup_id_mismatch")
     roadmap_id = str(data.get("roadmap_id", "")).strip()
     version = str(data.get("version", "")).strip()
@@ -257,6 +321,7 @@ def _normalize_roadmap_state(
         "content_digest": content_digest,
         "active_item_ids": tuple(str(value) for value in data.get("active_item_ids", ())),
         "blocked_item_ids": tuple(str(value) for value in data.get("blocked_item_ids", ())),
+        "scope_origin": scope_origin,
     }
 
 
@@ -264,9 +329,18 @@ def _normalize_verified_outcome(
     outcome: Mapping[str, Any],
     foundup_id: str,
     reasons: list[str],
+    *,
+    resident_mode: bool,
+    legacy_single_foundup_compatibility: bool,
 ) -> dict[str, Any]:
-    scoped_id = str(outcome.get("foundup_id", foundup_id)).strip()
-    if scoped_id and scoped_id != foundup_id:
+    scoped_id = str(outcome.get("foundup_id", "")).strip()
+    scope_origin = ""
+    if not scoped_id:
+        if resident_mode and not legacy_single_foundup_compatibility:
+            reasons.append("verified_outcome_missing_foundup_id")
+        elif legacy_single_foundup_compatibility:
+            scope_origin = "legacy_single_foundup_compatibility"
+    elif scoped_id != foundup_id:
         reasons.append("verified_outcome_foundup_id_mismatch")
     accepted = bool(outcome.get("accepted", False))
     held_out_passed = bool(outcome.get("held_out_passed", False))
@@ -287,6 +361,7 @@ def _normalize_verified_outcome(
         **required_ids,
         "accepted": accepted,
         "held_out_passed": held_out_passed,
+        "scope_origin": scope_origin,
     }
 
 
@@ -295,19 +370,67 @@ def _scope_work_records(
     foundup_id: str,
     record_kind: str,
     reasons: list[str],
-) -> tuple[dict[str, Any], ...]:
+    *,
+    resident_mode: bool,
+    legacy_single_foundup_compatibility: bool,
+) -> tuple[tuple[dict[str, Any], ...], tuple[dict[str, Any], ...]]:
     scoped: list[dict[str, Any]] = []
-    for record in records:
+    excluded: list[dict[str, Any]] = []
+    for index, record in enumerate(records):
         data = dict(record)
         record_foundup_id = str(data.get("foundup_id", "")).strip()
         if record_foundup_id and record_foundup_id != foundup_id:
-            reasons.append(f"{record_kind}_foundup_id_mismatch")
+            excluded.append(
+                _excluded_record_summary(
+                    record_kind=record_kind,
+                    record=data,
+                    index=index,
+                    foundup_id=record_foundup_id,
+                    reason=f"{record_kind}_foundup_id_mismatch",
+                )
+            )
             continue
         if not record_foundup_id:
+            if resident_mode and not legacy_single_foundup_compatibility:
+                reasons.append(f"{record_kind}_missing_foundup_id")
+                excluded.append(
+                    _excluded_record_summary(
+                        record_kind=record_kind,
+                        record=data,
+                        index=index,
+                        foundup_id="",
+                        reason=f"{record_kind}_missing_foundup_id",
+                    )
+                )
+                continue
             data["foundup_id"] = foundup_id
-            data["scope_origin"] = "legacy_single_foundup_poc"
+            data["scope_origin"] = "legacy_single_foundup_compatibility"
         scoped.append(data)
-    return tuple(scoped)
+    return tuple(scoped), tuple(excluded)
+
+
+def _excluded_record_summary(
+    *,
+    record_kind: str,
+    record: Mapping[str, Any],
+    index: int,
+    foundup_id: str,
+    reason: str,
+) -> dict[str, Any]:
+    identifier = (
+        record.get("claim_id")
+        or record.get("queue_item_id")
+        or record.get("work_order_id")
+        or record.get("slice_name")
+        or record.get("selected_slice")
+        or f"{record_kind}:{index}"
+    )
+    return {
+        "record_kind": record_kind,
+        "record_ref": str(identifier),
+        "foundup_id": str(foundup_id),
+        "reason": reason,
+    }
 
 
 def _snapshot_expired(valid_until: str, now_iso: str) -> bool:

--- a/modules/communication/moltbot_bridge/src/foundup_memex_current_state.py
+++ b/modules/communication/moltbot_bridge/src/foundup_memex_current_state.py
@@ -42,6 +42,9 @@ def assemble_foundup_memex_current_state(
     roadmap_state: Mapping[str, Any] | None = None,
     verified_outcomes: Sequence[Mapping[str, Any]] = (),
     now_iso: str | None = None,
+    resident_mode: bool = True,
+    legacy_single_foundup_compatibility: bool = False,
+    policy_foundup_scope: Sequence[str] | None = None,
 ) -> FoundUpMemexAssemblyResult:
     """Assemble the read-only current-state Memex view for one FoundUp.
 
@@ -56,4 +59,7 @@ def assemble_foundup_memex_current_state(
         roadmap_state=roadmap_state,
         verified_outcomes=verified_outcomes,
         now_iso=now_iso,
+        resident_mode=resident_mode,
+        legacy_single_foundup_compatibility=legacy_single_foundup_compatibility,
+        policy_foundup_scope=policy_foundup_scope,
     )

--- a/modules/communication/moltbot_bridge/tests/test_foundup_brain_current_state.py
+++ b/modules/communication/moltbot_bridge/tests/test_foundup_brain_current_state.py
@@ -174,6 +174,7 @@ def _assemble(**overrides):
         "roadmap_state": _roadmap(),
         "verified_outcomes": [_verified_outcome()],
         "now_iso": VALID_NOW,
+        "policy_foundup_scope": (FOUNDUP_ID,),
     }
     kwargs.update(overrides)
     return assemble_foundup_brain_current_state(**kwargs)
@@ -195,6 +196,10 @@ def test_assembles_deterministic_read_only_foundup_brain_view() -> None:
     assert first.view.current_state["breadcrumb_scope"] == FOUNDUP_ID
     assert first.view.current_state["brain_signature_digest"] == "sha256:foundup-brain"
     assert first.view.current_state["active_work"][0]["foundup_id"] == FOUNDUP_ID
+    assert first.view.assembly_receipt is not None
+    assert first.view.assembly_receipt["policy_foundup_scope"] == (FOUNDUP_ID,)
+    assert first.view.assembly_receipt["excluded_record_count"] == 0
+    assert first.view.assembly_receipt["excluded_record_digest"].startswith("sha256:")
     assert first.view.learning_candidates == ()
     assert first.view.roadmap_signals == ()
     assert all(first.view.invariants.values())
@@ -220,23 +225,102 @@ def test_cross_foundup_identity_roadmap_and_outcome_are_rejected() -> None:
     assert "verified_outcome_foundup_id_mismatch" in result.rejection_reasons
 
 
-def test_cross_foundup_work_claim_and_queue_item_are_rejected() -> None:
+def test_cross_foundup_work_claim_and_queue_item_are_excluded_not_leaked() -> None:
     snapshot = _snapshot(
         worker_claims=[{"claim_id": "foreign-claim", "foundup_id": "other-foundup"}],
         queue_items=[{"queue_item_id": "foreign-queue", "foundup_id": "other-foundup"}],
     )
     result = _assemble(snapshot=snapshot, verified_outcomes=[])
-    assert result.accepted is False
-    assert "worker_claim_foundup_id_mismatch" in result.rejection_reasons
-    assert "queue_item_foundup_id_mismatch" in result.rejection_reasons
+    assert result.accepted is True
+    assert result.view is not None
+    assert result.view.current_state["active_work"] == ()
+    assert result.view.current_state["queued_work"] == ()
+    assert result.view.assembly_receipt is not None
+    assert result.view.assembly_receipt["excluded_record_count"] == 2
+    assert result.view.assembly_receipt["excluded_record_digest"].startswith("sha256:")
 
 
-def test_legacy_unscoped_work_record_is_visible_only_in_single_foundup_poc() -> None:
+def test_unscoped_work_record_fails_in_resident_mode() -> None:
     snapshot = _snapshot(worker_claims=[{"claim_id": "legacy-claim", "status": "ACTIVE"}])
     result = _assemble(snapshot=snapshot, verified_outcomes=[])
+    assert result.accepted is False
+    assert "worker_claim_missing_foundup_id" in result.rejection_reasons
+
+
+def test_legacy_unscoped_work_record_requires_explicit_compatibility_mode() -> None:
+    snapshot = _snapshot(worker_claims=[{"claim_id": "legacy-claim", "status": "ACTIVE"}])
+    result = _assemble(
+        snapshot=snapshot,
+        verified_outcomes=[],
+        legacy_single_foundup_compatibility=True,
+    )
     assert result.accepted is True
     assert result.view is not None
     assert result.view.current_state["active_work"][0]["claim_id"] == "legacy-claim"
+    assert (
+        result.view.current_state["active_work"][0]["scope_origin"]
+        == "legacy_single_foundup_compatibility"
+    )
+
+
+def test_mixed_foundup_snapshot_can_build_independent_views_without_leakage() -> None:
+    snapshot = _snapshot(
+        worker_claims=[
+            {"claim_id": "a-claim", "foundup_id": FOUNDUP_ID, "status": "ACTIVE"},
+            {"claim_id": "b-claim", "foundup_id": "foundup-b", "status": "ACTIVE"},
+        ],
+        queue_items=[
+            {"queue_item_id": "a-queue", "foundup_id": FOUNDUP_ID},
+            {"queue_item_id": "b-queue", "foundup_id": "foundup-b"},
+        ],
+    )
+
+    view_a = _assemble(snapshot=snapshot, verified_outcomes=[])
+    view_b = _assemble(
+        foundup_id="foundup-b",
+        snapshot=snapshot,
+        identity=_identity("foundup-b"),
+        roadmap_state=_roadmap("foundup-b"),
+        verified_outcomes=[],
+        policy_foundup_scope=("foundup-b",),
+    )
+
+    assert view_a.accepted is True and view_a.view is not None
+    assert view_b.accepted is True and view_b.view is not None
+    assert [item["claim_id"] for item in view_a.view.current_state["active_work"]] == ["a-claim"]
+    assert [item["queue_item_id"] for item in view_a.view.current_state["queued_work"]] == ["a-queue"]
+    assert [item["claim_id"] for item in view_b.view.current_state["active_work"]] == ["b-claim"]
+    assert [item["queue_item_id"] for item in view_b.view.current_state["queued_work"]] == ["b-queue"]
+    assert view_a.view.assembly_receipt["excluded_record_count"] == 2
+    assert view_b.view.assembly_receipt["excluded_record_count"] == 2
+
+
+def test_identity_roadmap_outcome_and_policy_scope_must_match_foundup() -> None:
+    result = _assemble(
+        identity={"name": "Foundups Agent"},
+        roadmap_state={
+            "roadmap_id": "foundups-agent-roadmap",
+            "version": "phase1",
+            "content_digest": "sha256:roadmap",
+        },
+        verified_outcomes=[
+            {
+                "outcome_id": "outcome-1",
+                "verification_receipt_id": "sha256:verification",
+                "held_out_receipt_id": "sha256:held-out",
+                "head_sha": HEAD,
+                "accepted": True,
+                "held_out_passed": True,
+                "content_digest": "sha256:outcome",
+            }
+        ],
+        policy_foundup_scope=("other-foundup",),
+    )
+    assert result.accepted is False
+    assert "identity_missing_foundup_id" in result.rejection_reasons
+    assert "roadmap_missing_foundup_id" in result.rejection_reasons
+    assert "verified_outcome_missing_foundup_id" in result.rejection_reasons
+    assert "policy_foundup_scope_mismatch" in result.rejection_reasons
 
 
 def test_missing_roadmap_binding_fails_closed() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_foundup_memex_current_state.py
+++ b/modules/communication/moltbot_bridge/tests/test_foundup_memex_current_state.py
@@ -49,6 +49,9 @@ def test_memex_adapter_delegates_exact_inputs_without_new_authority() -> None:
             roadmap_state=roadmap,
             verified_outcomes=outcomes,
             now_iso="2026-07-14T00:00:00+00:00",
+            resident_mode=True,
+            legacy_single_foundup_compatibility=False,
+            policy_foundup_scope=("foundups-agent",),
         )
 
     assert result is sentinel
@@ -59,6 +62,9 @@ def test_memex_adapter_delegates_exact_inputs_without_new_authority() -> None:
         roadmap_state=roadmap,
         verified_outcomes=outcomes,
         now_iso="2026-07-14T00:00:00+00:00",
+        resident_mode=True,
+        legacy_single_foundup_compatibility=False,
+        policy_foundup_scope=("foundups-agent",),
     )
 
 


### PR DESCRIPTION
## Summary
- harden FoundUp Brain/Memex current-state assembly for resident multi-FoundUp scoping
- require explicit FoundUp scope for identity, roadmap, outcomes, work records, queue items, and policy scope in resident mode
- exclude foreign work records with deterministic assembly-receipt count/digest instead of leaking them or rejecting a mixed snapshot
- add HoloIndex projection integrity checks for operational snapshot metadata consistency

## Truth boundary
- Integrity only, not authentication.
- No Memex supplier, content-bearing evidence, policy issuance, worker spawn, repo mutation, HoloIndex re-index, or authority promotion.

## Validation
- python -m pytest modules/communication/moltbot_bridge/tests/test_foundup_brain_current_state.py modules/communication/moltbot_bridge/tests/test_foundup_memex_current_state.py holo_index/tests/test_holoindex_memex_access_policy_receipt.py holo_index/tests/test_holoindex_memex_projection_adapter.py holo_index/tests/test_holoindex_memex_projection_integrity.py holo_index/tests/test_holoindex_memex_query_routing.py holo_index/tests/test_holoindex_query_receipt.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
- 85 passed
- git diff --check
- added ModLog lines ASCII-clean; historical ModLog non-ASCII unchanged