### PR TITLE
fix(reddog): bind memex projections to audit assignments

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,23 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_MEMEX_SNAPSHOT_ASSIGNMENT_BINDING_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 60, 97
+
+- Hardened the model-backed read-only audit worker so supplied Memex
+  projections are assignment-bound before any model call.
+- Runtime Memex consumption now requires and revalidates an access-policy
+  receipt against principal, work order, FoundUp id, source scope, and expiry.
+- The projection integrity gate is invoked with expected FoundUp, source scope,
+  source revision, HoloIndex generation, operational snapshot id/content
+  digest, access-policy digest, replay state, and revocation state.
+- Missing policy receipts, mismatched policy work orders, mismatched projection
+  snapshot bindings, and replayed projection receipts fail closed before the
+  RedDog/Fusion model runner is called.
+- Boundary remains read-only: no Memex supplier, content-bearing citation
+  policy, worker spawn, OpenClaw enqueue, Hermes dispatch, repo mutation,
+  HoloIndex re-index, or authority promotion.
+
 ## 2026-07-16: FOUNDUP_MEMEX_MULTI_FOUNDUP_SCOPE_HARDENING_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 60, 97

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
@@ -44,6 +44,7 @@ from holo_index.query_receipt import (
     build_query_receipt,
     load_generation_binding,
 )
+from holo_index.memex_access_policy_receipt import validate_memex_access_policy_receipt
 from holo_index.memex_query_routing import build_memex_projection_query_receipt
 from holo_index.memex_projection_integrity import verify_and_rehydrate_memex_projection
 
@@ -598,37 +599,116 @@ def _optional_memex_query_receipt(
     if projection is None:
         return None
     try:
-        gate = verify_and_rehydrate_memex_projection(projection, runtime_mode=True)
-        if not gate.accepted or gate.projection is None:
-            return build_query_receipt(
-                source="memex_projection",
-                source_class="memex",
+        expected_foundup_id = _first_text(task_context, assignment, "foundup_id")
+        expected_source_scope = _first_text(task_context, assignment, "memex_source_scope")
+        expected_source_revision = _first_text(task_context, assignment, "memex_source_revision")
+        expected_generation_id = _first_text(task_context, assignment, "memex_holoindex_generation_id")
+        expected_principal_id = _first_text(task_context, assignment, "principal_id")
+        expected_work_order_id = (
+            _first_text(task_context, assignment, "work_order_id")
+            or str(assignment.get("assignment_id") or "").strip()
+        )
+        expected_snapshot_id = str(assignment.get("snapshot_receipt_id") or "").strip()
+        expected_snapshot_digest = str(assignment.get("snapshot_content_digest") or "").strip()
+        now_iso = _first_text(task_context, assignment, "memex_now_iso")
+
+        missing_binding = [
+            name
+            for name, value in (
+                ("foundup_id", expected_foundup_id),
+                ("memex_source_scope", expected_source_scope),
+                ("memex_holoindex_generation_id", expected_generation_id),
+                ("principal_id", expected_principal_id),
+                ("work_order_id", expected_work_order_id),
+                ("snapshot_receipt_id", expected_snapshot_id),
+                ("snapshot_content_digest", expected_snapshot_digest),
+            )
+            if not value
+        ]
+        if missing_binding:
+            return _memex_error_receipt(
                 query=query,
-                result={
-                    "ok": False,
-                    "query": query,
-                    "freshness": "UNKNOWN",
-                    "hits": [],
-                    "error": "memex_projection_integrity_failed:"
-                    + ",".join(gate.rejection_reasons),
-                },
-                require_generation=False,
+                error="memex_assignment_binding_failed:missing_" + ",".join(missing_binding),
+            )
+
+        policy_receipt = task_context.get("memex_access_policy_receipt")
+        if policy_receipt is None:
+            policy_receipt = assignment.get("memex_access_policy_receipt")
+        if policy_receipt is None:
+            return _memex_error_receipt(query=query, error="memex_access_policy_missing")
+
+        policy_validation = validate_memex_access_policy_receipt(
+            policy_receipt,
+            expected_foundup_id=expected_foundup_id,
+            expected_source_scope=expected_source_scope,
+            expected_principal_id=expected_principal_id,
+            expected_work_order_id=expected_work_order_id,
+            now_iso=now_iso or None,
+            seen_receipt_ids=_text_sequence(task_context.get("seen_memex_access_policy_receipt_ids"))
+            + _text_sequence(assignment.get("seen_memex_access_policy_receipt_ids")),
+            revoked_receipt_ids=_text_sequence(task_context.get("revoked_memex_access_policy_receipt_ids"))
+            + _text_sequence(assignment.get("revoked_memex_access_policy_receipt_ids")),
+        )
+        if not policy_validation.accepted or policy_validation.receipt is None:
+            return _memex_error_receipt(
+                query=query,
+                error="memex_access_policy_failed:" + ",".join(policy_validation.rejection_reasons),
+            )
+
+        gate = verify_and_rehydrate_memex_projection(
+            projection,
+            runtime_mode=True,
+            now_iso=now_iso or None,
+            seen_receipt_ids=_text_sequence(task_context.get("seen_memex_projection_receipt_ids"))
+            + _text_sequence(assignment.get("seen_memex_projection_receipt_ids")),
+            revoked_snapshot_ids=_text_sequence(task_context.get("revoked_memex_snapshot_ids"))
+            + _text_sequence(assignment.get("revoked_memex_snapshot_ids")),
+            expected_foundup_id=expected_foundup_id,
+            expected_source_scope=expected_source_scope,
+            expected_source_revision=expected_source_revision or None,
+            expected_access_policy_digest=policy_validation.receipt.receipt_id,
+            expected_holoindex_generation_id=expected_generation_id,
+            expected_operational_snapshot_id=expected_snapshot_id,
+            expected_operational_snapshot_content_digest=expected_snapshot_digest,
+        )
+        if not gate.accepted or gate.projection is None:
+            return _memex_error_receipt(
+                query=query,
+                error="memex_projection_integrity_failed:" + ",".join(gate.rejection_reasons),
             )
         return build_memex_projection_query_receipt(query=query, projection=gate.projection)
     except Exception as exc:
-        return build_query_receipt(
-            source="memex_projection",
-            source_class="memex",
-            query=query,
-            result={
-                "ok": False,
-                "query": query,
-                "freshness": "UNKNOWN",
-                "hits": [],
-                "error": f"memex_query_failed:{type(exc).__name__}",
-            },
-            require_generation=False,
-        )
+        return _memex_error_receipt(query=query, error=f"memex_query_failed:{type(exc).__name__}")
+
+
+def _memex_error_receipt(*, query: str, error: str) -> Mapping[str, Any]:
+    return build_query_receipt(
+        source="memex_projection",
+        source_class="memex",
+        query=query,
+        result={
+            "ok": False,
+            "query": query,
+            "freshness": "UNKNOWN",
+            "hits": [],
+            "error": error,
+        },
+        require_generation=False,
+    )
+
+
+def _first_text(
+    task_context: Mapping[str, Any],
+    assignment: Mapping[str, Any],
+    key: str,
+) -> str:
+    return str(task_context.get(key) or assignment.get(key) or "").strip()
+
+
+def _text_sequence(value: Any) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        return ()
+    return tuple(dict.fromkeys(str(item).strip() for item in value if str(item).strip()))
 
 
 def _query_rejection_reason(receipt: Mapping[str, Any]) -> str:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from holo_index.memex_access_policy_receipt import build_memex_access_policy_receipt
 from holo_index.memex_projection_adapter import project_foundup_memex_to_holoindex_shadow
 from modules.communication.moltbot_bridge.scripts.run_task import execute_task
 from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
@@ -56,6 +57,11 @@ MODEL_WORKER_MODULE_PATH = (
     / "src"
     / "reddog_readonly_0102_audit_worker_runtime.py"
 )
+MEMEX_FOUNDUP_ID = "foundups-agent"
+MEMEX_GENERATION_ID = "sha256:memex-generation"
+MEMEX_SOURCE_REVISION = "abc123"
+MEMEX_SOURCE_SCOPE = f"foundup:{MEMEX_FOUNDUP_ID}:lane:{REPO_CODE_AUDIT_LANE}"
+MEMEX_NOW = "2026-07-16T00:01:00+00:00"
 
 
 @pytest.fixture(autouse=True)
@@ -250,30 +256,57 @@ def _model_context(
         allowed_read_targets=context["assignment"]["allowed_read_targets"],
     ).to_dict()
     context["worker_mode"] = MODEL_WORKER_MODE
+    context["principal_id"] = "principal-012"
+    context["work_order_id"] = "assignment-1"
+    context["foundup_id"] = MEMEX_FOUNDUP_ID
+    context["memex_now_iso"] = MEMEX_NOW
     context["wsp15_allocation_receipt"] = allocation
     context["wsp15_allocation_receipt_id"] = allocation["receipt_id"]
     context["wsp15_allocation_digest"] = canonical_reddog_wsp15_allocation_digest(allocation)
     context["assignment"] = dict(context["assignment"])
     context["assignment"]["lane_id"] = REPO_CODE_AUDIT_LANE
+    context["assignment"]["foundup_id"] = MEMEX_FOUNDUP_ID
+    context["assignment"]["principal_id"] = "principal-012"
+    context["assignment"]["work_order_id"] = "assignment-1"
     context["assignment"]["snapshot_content_digest"] = "sha256:snapshot-content"
     context["assignment"]["context_view_id"] = "sha256:context-view"
     context["assignment"]["evidence_bundle_id"] = "sha256:evidence-bundle"
     context["assignment"]["determination_id"] = "sha256:determination"
     context["assignment"]["wsp15_allocation_receipt_id"] = allocation["receipt_id"]
     context["assignment"]["wsp15_allocation_digest"] = context["wsp15_allocation_digest"]
+    context["assignment"]["memex_source_scope"] = MEMEX_SOURCE_SCOPE
+    context["assignment"]["memex_source_revision"] = MEMEX_SOURCE_REVISION
+    context["assignment"]["memex_holoindex_generation_id"] = MEMEX_GENERATION_ID
     return context
 
 
-def _memex_projection() -> dict:
+def _memex_access_policy_receipt() -> dict:
+    result = build_memex_access_policy_receipt(
+        principal_id="principal-012",
+        work_order_id="assignment-1",
+        foundup_scope=(MEMEX_FOUNDUP_ID,),
+        source_scope=MEMEX_SOURCE_SCOPE,
+        sensitivity_classes=("internal",),
+        issued_at="2026-07-16T00:00:00+00:00",
+        expires_at="2026-07-16T01:00:00+00:00",
+        policy_generation_id="policy-generation-1",
+    )
+    assert result.accepted is True
+    assert result.receipt is not None
+    return result.receipt.to_dict()
+
+
+def _memex_projection(*, access_policy_receipt: dict | None = None) -> dict:
+    access_policy_receipt = access_policy_receipt or _memex_access_policy_receipt()
     result = project_foundup_memex_to_holoindex_shadow(
         memex_view={
             "schema_version": "foundup_brain_current_state.v1",
             "foundup_brain_view_id": "sha256:brain-view",
-            "foundup_id": "foundups-agent",
+            "foundup_id": MEMEX_FOUNDUP_ID,
             "snapshot_id": "snapshot-1",
-            "snapshot_content_digest": "sha256:snapshot",
+            "snapshot_content_digest": "sha256:snapshot-content",
             "identity": {
-                "foundup_id": "foundups-agent",
+                "foundup_id": MEMEX_FOUNDUP_ID,
                 "name": "Foundups Agent",
             },
             "current_state": {
@@ -284,12 +317,12 @@ def _memex_projection() -> dict:
                 "next_slice": "REDDOG_RUNTIME_NEXT_PHASE1",
             },
         },
-        source_scope="foundup:foundups-agent",
-        source_revision="abc123",
-        allowed_foundup_ids=("foundups-agent",),
-        access_policy_digest="sha256:" + "2" * 64,
-        holoindex_generation_id="sha256:memex-generation",
-        now_iso="2026-07-16T00:00:00+00:00",
+        source_scope=MEMEX_SOURCE_SCOPE,
+        source_revision=MEMEX_SOURCE_REVISION,
+        allowed_foundup_ids=(MEMEX_FOUNDUP_ID,),
+        access_policy_receipt=access_policy_receipt,
+        holoindex_generation_id=MEMEX_GENERATION_ID,
+        now_iso=MEMEX_NOW,
     )
     assert result.accepted is True
     return result.to_dict()
@@ -480,7 +513,10 @@ def test_model_backed_includes_optional_memex_query_receipt(tmp_path: Path) -> N
     root = _repo(tmp_path)
     runner = _EchoEvidenceModelRunner()
     context = _model_context()
-    context["memex_projection"] = _memex_projection()
+    context["memex_access_policy_receipt"] = _memex_access_policy_receipt()
+    context["memex_projection"] = _memex_projection(
+        access_policy_receipt=context["memex_access_policy_receipt"]
+    )
 
     result = execute_reddog_readonly_audit_task(
         task_context=context,
@@ -510,6 +546,7 @@ def test_model_backed_rejects_invalid_supplied_memex_projection_before_model(tmp
     root = _repo(tmp_path)
     runner = _EchoEvidenceModelRunner()
     context = _model_context()
+    context["memex_access_policy_receipt"] = _memex_access_policy_receipt()
     context["memex_projection"] = {"accepted": True, "records": [], "receipt": None}
 
     result = execute_reddog_readonly_audit_task(
@@ -530,9 +567,111 @@ def test_model_backed_rejects_tampered_memex_projection_before_model(tmp_path: P
     root = _repo(tmp_path)
     runner = _EchoEvidenceModelRunner()
     context = _model_context()
-    projection = _memex_projection()
+    context["memex_access_policy_receipt"] = _memex_access_policy_receipt()
+    projection = _memex_projection(access_policy_receipt=context["memex_access_policy_receipt"])
     projection["records"][0]["text"] = projection["records"][0]["text"] + " tampered"
     context["memex_projection"] = projection
+
+    result = execute_reddog_readonly_audit_task(
+        task_context=context,
+        repo_root=root,
+        task_id="task-1",
+        model_runner=runner,
+        holoindex_adapter=_FakeQueryAdapter(),
+        codeindex_adapter=_FakeQueryAdapter(),
+    )
+
+    assert result.accepted is False
+    assert ReadOnlyAuditTaskRejectReason.INDEX_QUERY_FAILED in result.rejection_reasons
+    assert not runner.calls
+
+
+def test_model_backed_rejects_memex_projection_without_policy_receipt(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    runner = _EchoEvidenceModelRunner()
+    context = _model_context()
+    context["memex_projection"] = _memex_projection()
+
+    result = execute_reddog_readonly_audit_task(
+        task_context=context,
+        repo_root=root,
+        task_id="task-1",
+        model_runner=runner,
+        holoindex_adapter=_FakeQueryAdapter(),
+        codeindex_adapter=_FakeQueryAdapter(),
+    )
+
+    assert result.accepted is False
+    assert ReadOnlyAuditTaskRejectReason.INDEX_QUERY_FAILED in result.rejection_reasons
+    assert not runner.calls
+
+
+def test_model_backed_rejects_memex_policy_work_order_mismatch(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    runner = _EchoEvidenceModelRunner()
+    context = _model_context()
+    bad_policy = build_memex_access_policy_receipt(
+        principal_id="principal-012",
+        work_order_id="other-assignment",
+        foundup_scope=(MEMEX_FOUNDUP_ID,),
+        source_scope=MEMEX_SOURCE_SCOPE,
+        sensitivity_classes=("internal",),
+        issued_at="2026-07-16T00:00:00+00:00",
+        expires_at="2026-07-16T01:00:00+00:00",
+        policy_generation_id="policy-generation-1",
+    )
+    assert bad_policy.accepted is True and bad_policy.receipt is not None
+    context["memex_access_policy_receipt"] = bad_policy.receipt.to_dict()
+    context["memex_projection"] = _memex_projection(
+        access_policy_receipt=context["memex_access_policy_receipt"]
+    )
+
+    result = execute_reddog_readonly_audit_task(
+        task_context=context,
+        repo_root=root,
+        task_id="task-1",
+        model_runner=runner,
+        holoindex_adapter=_FakeQueryAdapter(),
+        codeindex_adapter=_FakeQueryAdapter(),
+    )
+
+    assert result.accepted is False
+    assert ReadOnlyAuditTaskRejectReason.INDEX_QUERY_FAILED in result.rejection_reasons
+    assert not runner.calls
+
+
+def test_model_backed_rejects_memex_projection_snapshot_binding_mismatch(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    runner = _EchoEvidenceModelRunner()
+    context = _model_context()
+    context["memex_access_policy_receipt"] = _memex_access_policy_receipt()
+    projection = _memex_projection(access_policy_receipt=context["memex_access_policy_receipt"])
+    projection["records"][0]["metadata"] = dict(projection["records"][0]["metadata"])
+    projection["records"][0]["metadata"]["snapshot_content_digest"] = "sha256:other-snapshot"
+    context["memex_projection"] = projection
+
+    result = execute_reddog_readonly_audit_task(
+        task_context=context,
+        repo_root=root,
+        task_id="task-1",
+        model_runner=runner,
+        holoindex_adapter=_FakeQueryAdapter(),
+        codeindex_adapter=_FakeQueryAdapter(),
+    )
+
+    assert result.accepted is False
+    assert ReadOnlyAuditTaskRejectReason.INDEX_QUERY_FAILED in result.rejection_reasons
+    assert not runner.calls
+
+
+def test_model_backed_rejects_replayed_memex_projection_receipt(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    runner = _EchoEvidenceModelRunner()
+    context = _model_context()
+    context["memex_access_policy_receipt"] = _memex_access_policy_receipt()
+    projection = _memex_projection(access_policy_receipt=context["memex_access_policy_receipt"])
+    context["memex_projection"] = projection
+    context["seen_memex_projection_receipt_ids"] = [projection["receipt"]["receipt_id"]]
 
     result = execute_reddog_readonly_audit_task(
         task_context=context,


### PR DESCRIPTION
## Summary
- require a Memex access-policy receipt whenever a model-backed audit consumes a Memex projection
- revalidate the policy receipt at consumption time against principal, work order, FoundUp id, source scope, and expiry
- pass assignment-bound expected FoundUp/source/snapshot/generation/policy bindings into the Memex projection integrity gate
- fail closed before model invocation for missing policy, policy work-order mismatch, projection snapshot mismatch, or replayed projection receipt

## Truth boundary
- Integrity and assignment binding only, not authenticated policy issuance.
- No Memex supplier, content-bearing evidence, citation policy, worker spawn, OpenClaw enqueue, Hermes dispatch, repo mutation, HoloIndex re-index, or authority promotion.

## Validation
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
- 29 passed
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py holo_index/tests/test_holoindex_memex_access_policy_receipt.py holo_index/tests/test_holoindex_memex_projection_adapter.py holo_index/tests/test_holoindex_memex_projection_integrity.py holo_index/tests/test_holoindex_memex_query_routing.py holo_index/tests/test_holoindex_query_receipt.py
- 73 passed
- git diff --check
- added ModLog lines ASCII-clean; historical ModLog non-ASCII unchanged