### PR TITLE
fix(reddog): enforce typed evidence citation policy

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,21 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_TYPED_EVIDENCE_CITATION_POLICY_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 60, 97
+
+- Added a typed citation policy for read-only RedDog audit output.
+- Repository `file:` evidence can support current implementation claims.
+  `memex:` evidence is allowed only as supplemental historical memory context
+  beside at least one current repository file evidence ref.
+- Wired the policy into model-backed repo-audit output validation so unknown
+  file refs, unknown Memex refs, and Memex-only findings fail closed.
+- Updated the model prompt rules to state that Memex evidence cannot replace
+  file evidence for repo-audit findings.
+- Boundary remains read-only: no authority promotion, worker spawn, OpenClaw
+  enqueue, Hermes dispatch, repo mutation, HoloIndex re-index, or PatternMemory
+  promotion.
+
 ## 2026-07-16: REDDOG_MEMEX_CONTENT_BEARING_EVIDENCE_BUNDLE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 60, 97

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
@@ -38,6 +38,9 @@ from modules.communication.moltbot_bridge.src.reddog_wsp15_allocation_receipt im
     canonical_reddog_wsp15_allocation_digest,
     validate_reddog_wsp15_allocation_receipt,
 )
+from modules.communication.moltbot_bridge.src.reddog_typed_evidence_citation_policy import (
+    validate_typed_evidence_citations,
+)
 from holo_index.query_receipt import (
     SOURCE_CLASS_CODEINDEX,
     SOURCE_CLASS_HOLOINDEX,
@@ -535,7 +538,11 @@ def execute_model_backed_repo_code_audit(
         return _reject(reasons)
 
     parsed = _parse_model_output(model_result.content)
-    output_reasons = _validate_repo_audit_model_output(parsed, allowed_evidence_refs=evidence_refs)
+    output_reasons = _validate_repo_audit_model_output(
+        parsed,
+        allowed_evidence_refs=evidence_refs,
+        allowed_memex_evidence_refs=_memex_evidence_refs(memex_evidence_bundle),
+    )
     if output_reasons:
         return _reject(output_reasons)
 
@@ -977,6 +984,7 @@ def _build_repo_audit_model_prompt(
             "Use only supplied evidence_refs.",
             "Every finding must cite at least one supplied file evidence_ref.",
             "Memex evidence is historical memory context, not current repository proof; do not cite it as file evidence.",
+            "Memex evidence_refs may supplement file evidence_refs but may never be the only citation for a finding.",
             "Use exactly the allowed enum strings; do not invent synonyms such as high, medium, proceed, or mitigate.",
             "If evidence is insufficient, report an OBSERVED gap instead of inventing facts.",
             "Do not claim repo mutation, shell execution, OpenClaw enqueue, Hermes dispatch, or re-indexing.",
@@ -1054,6 +1062,7 @@ def _validate_repo_audit_model_output(
     output: Mapping[str, Any],
     *,
     allowed_evidence_refs: Sequence[str],
+    allowed_memex_evidence_refs: Sequence[str] = (),
 ) -> tuple[str, ...]:
     reasons: list[str] = []
     if not output:
@@ -1066,9 +1075,13 @@ def _validate_repo_audit_model_output(
     findings = output.get("findings")
     if not summary or not evidence_refs or not isinstance(findings, list) or not findings:
         reasons.append(ReadOnlyAuditTaskRejectReason.MODEL_SCHEMA_FAILURE)
-    allowed = set(allowed_evidence_refs)
-    if evidence_refs and not set(evidence_refs).issubset(allowed):
-        reasons.append(ReadOnlyAuditTaskRejectReason.UNKNOWN_EVIDENCE_REF)
+    top_policy = validate_typed_evidence_citations(
+        refs=evidence_refs,
+        allowed_file_refs=allowed_evidence_refs,
+        allowed_memex_refs=allowed_memex_evidence_refs,
+    )
+    if not top_policy.accepted:
+        reasons.extend(_citation_policy_reasons(top_policy.rejection_reasons, prefix="top"))
     for index, finding in enumerate(findings if isinstance(findings, list) else []):
         if not isinstance(finding, Mapping):
             reasons.append(f"{ReadOnlyAuditTaskRejectReason.MODEL_SCHEMA_FAILURE}:{index}")
@@ -1097,9 +1110,39 @@ def _validate_repo_audit_model_output(
             reasons.append(f"{ReadOnlyAuditTaskRejectReason.MODEL_SCHEMA_FAILURE}:missing_next_slice:{index}")
         if action == "STOP" and next_slice:
             reasons.append(f"{ReadOnlyAuditTaskRejectReason.MODEL_SCHEMA_FAILURE}:stop_next_slice:{index}")
-        if refs and not set(refs).issubset(allowed):
-            reasons.append(f"{ReadOnlyAuditTaskRejectReason.UNKNOWN_EVIDENCE_REF}:{index}")
+        citation_policy = validate_typed_evidence_citations(
+            refs=refs,
+            allowed_file_refs=allowed_evidence_refs,
+            allowed_memex_refs=allowed_memex_evidence_refs,
+        )
+        if not citation_policy.accepted:
+            reasons.extend(_citation_policy_reasons(citation_policy.rejection_reasons, prefix=str(index)))
     return tuple(dict.fromkeys(reasons))
+
+
+def _citation_policy_reasons(reasons: Sequence[str], *, prefix: str) -> tuple[str, ...]:
+    mapped: list[str] = []
+    for reason in reasons:
+        if reason.startswith("unknown_"):
+            mapped.append(f"{ReadOnlyAuditTaskRejectReason.UNKNOWN_EVIDENCE_REF}:{prefix}:{reason}")
+        else:
+            mapped.append(f"{ReadOnlyAuditTaskRejectReason.MODEL_SCHEMA_FAILURE}:{prefix}:{reason}")
+    return tuple(mapped)
+
+
+def _memex_evidence_refs(bundle: Mapping[str, Any] | None) -> tuple[str, ...]:
+    if not isinstance(bundle, Mapping):
+        return ()
+    records = bundle.get("records")
+    if isinstance(records, (str, bytes)) or not isinstance(records, Sequence):
+        return ()
+    refs = []
+    for record in records:
+        if isinstance(record, Mapping):
+            ref = str(record.get("evidence_ref") or "").strip()
+            if ref:
+                refs.append(ref)
+    return tuple(dict.fromkeys(refs))
 
 
 def _build_model_report(

--- a/modules/communication/moltbot_bridge/src/reddog_typed_evidence_citation_policy.py
+++ b/modules/communication/moltbot_bridge/src/reddog_typed_evidence_citation_policy.py
@@ -1,0 +1,93 @@
+"""Typed evidence citation policy for RedDog read-only audit outputs.
+
+Repository file evidence can support current implementation claims. Memex
+evidence is historical memory context and can only supplement a finding that
+also cites current repository evidence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+
+SOURCE_CLASS_REPO_FILE = "repo_file"
+SOURCE_CLASS_MEMEX = "memex"
+SOURCE_CLASS_UNKNOWN = "unknown"
+
+TYPED_CITATION_ACCEPTED = "TYPED_EVIDENCE_CITATIONS_ACCEPTED"
+TYPED_CITATION_REJECTED = "TYPED_EVIDENCE_CITATIONS_REJECTED"
+
+
+@dataclass(frozen=True)
+class TypedCitationPolicyResult:
+    accepted: bool
+    status: str
+    rejection_reasons: tuple[str, ...]
+
+
+def classify_evidence_ref(ref: str) -> str:
+    text = str(ref or "").strip()
+    if text.startswith("file:"):
+        return SOURCE_CLASS_REPO_FILE
+    if text.startswith("memex:"):
+        return SOURCE_CLASS_MEMEX
+    return SOURCE_CLASS_UNKNOWN
+
+
+def validate_typed_evidence_citations(
+    *,
+    refs: Sequence[str],
+    allowed_file_refs: Sequence[str],
+    allowed_memex_refs: Sequence[str] = (),
+    require_file_evidence: bool = True,
+) -> TypedCitationPolicyResult:
+    """Validate that cited evidence refs match their typed authority boundary."""
+
+    normalized_refs = tuple(dict.fromkeys(str(ref).strip() for ref in refs if str(ref).strip()))
+    file_allowed = set(str(ref).strip() for ref in allowed_file_refs if str(ref).strip())
+    memex_allowed = set(str(ref).strip() for ref in allowed_memex_refs if str(ref).strip())
+    reasons: list[str] = []
+
+    if not normalized_refs:
+        reasons.append("missing_evidence_refs")
+
+    saw_file = False
+    for ref in normalized_refs:
+        source_class = classify_evidence_ref(ref)
+        if source_class == SOURCE_CLASS_REPO_FILE:
+            saw_file = True
+            if ref not in file_allowed:
+                reasons.append("unknown_file_evidence_ref")
+        elif source_class == SOURCE_CLASS_MEMEX:
+            if ref not in memex_allowed:
+                reasons.append("unknown_memex_evidence_ref")
+        else:
+            reasons.append("unknown_evidence_ref_type")
+
+    if require_file_evidence and normalized_refs and not saw_file:
+        reasons.append("memex_cannot_replace_repo_file_evidence")
+
+    if reasons:
+        return TypedCitationPolicyResult(
+            accepted=False,
+            status=TYPED_CITATION_REJECTED,
+            rejection_reasons=tuple(dict.fromkeys(reasons)),
+        )
+    return TypedCitationPolicyResult(
+        accepted=True,
+        status=TYPED_CITATION_ACCEPTED,
+        rejection_reasons=(),
+    )
+
+
+__all__ = [
+    "SOURCE_CLASS_MEMEX",
+    "SOURCE_CLASS_REPO_FILE",
+    "SOURCE_CLASS_UNKNOWN",
+    "TYPED_CITATION_ACCEPTED",
+    "TYPED_CITATION_REJECTED",
+    "TypedCitationPolicyResult",
+    "classify_evidence_ref",
+    "validate_typed_evidence_citations",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
@@ -127,8 +127,16 @@ def _patch_default_query_adapters(monkeypatch) -> None:
 
 
 class _EchoEvidenceModelRunner:
-    def __init__(self, *, unknown_ref: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        unknown_ref: bool = False,
+        include_memex_ref: bool = False,
+        memex_only_ref: bool = False,
+    ) -> None:
         self.unknown_ref = unknown_ref
+        self.include_memex_ref = include_memex_ref
+        self.memex_only_ref = memex_only_ref
         self.calls = []
 
     def run_repo_code_audit(self, *, prompt: str, context: str, binding, timeout_seconds: int):
@@ -137,9 +145,15 @@ class _EchoEvidenceModelRunner:
         evidence_ref = parsed["untrusted_repository_evidence"][0]["evidence_ref"]
         if self.unknown_ref:
             evidence_ref = "file:missing.py:sha256:missing:lines:1"
+        evidence_refs = [evidence_ref]
+        memex_records = parsed.get("memex_evidence_bundle", {}).get("records", [])
+        if self.include_memex_ref and memex_records:
+            evidence_refs.append(memex_records[0]["evidence_ref"])
+        if self.memex_only_ref and memex_records:
+            evidence_refs = [memex_records[0]["evidence_ref"]]
         output = {
             "summary": "Model-backed repo audit verified supplied evidence.",
-            "evidence_refs": [evidence_ref],
+            "evidence_refs": evidence_refs,
             "findings": [
                 {
                     "finding_id": "repo-code-audit-finding-1",
@@ -148,7 +162,7 @@ class _EchoEvidenceModelRunner:
                     "recommended_action": "FIX",
                     "wsp15_priority": "P1",
                     "severity": "MAJOR",
-                    "evidence_refs": [evidence_ref],
+                    "evidence_refs": evidence_refs,
                     "next_slice_name": "REDDOG_NEXT_RUNTIME_SLICE_PHASE1",
                 }
             ],
@@ -547,6 +561,56 @@ def test_model_backed_includes_optional_memex_query_receipt(tmp_path: Path) -> N
     assert worker_receipt["memex_query_receipt_id"] == memex_receipt["receipt_id"]
     assert worker_receipt["memex_evidence_bundle_id"] == memex_bundle["bundle_id"]
     assert worker_receipt["no_side_effect_attestations"]["no_holoindex_reindex_performed"] is True
+
+
+def test_model_backed_allows_memex_refs_only_as_supplemental_citations(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    runner = _EchoEvidenceModelRunner(include_memex_ref=True)
+    context = _model_context()
+    context["memex_access_policy_receipt"] = _memex_access_policy_receipt()
+    context["memex_projection"] = _memex_projection(
+        access_policy_receipt=context["memex_access_policy_receipt"]
+    )
+
+    result = execute_reddog_readonly_audit_task(
+        task_context=context,
+        repo_root=root,
+        task_id="task-1",
+        model_runner=runner,
+        holoindex_adapter=_FakeQueryAdapter(),
+        codeindex_adapter=_FakeQueryAdapter(),
+    )
+
+    assert result.accepted is True
+    assert result.report is not None
+    finding_refs = result.report["findings"][0]["evidence_refs"]
+    assert any(ref.startswith("file:") for ref in finding_refs)
+    assert any(ref.startswith("memex:") for ref in finding_refs)
+
+
+def test_model_backed_rejects_memex_only_citation_for_repo_audit_finding(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    runner = _EchoEvidenceModelRunner(memex_only_ref=True)
+    context = _model_context()
+    context["memex_access_policy_receipt"] = _memex_access_policy_receipt()
+    context["memex_projection"] = _memex_projection(
+        access_policy_receipt=context["memex_access_policy_receipt"]
+    )
+
+    result = execute_reddog_readonly_audit_task(
+        task_context=context,
+        repo_root=root,
+        task_id="task-1",
+        model_runner=runner,
+        holoindex_adapter=_FakeQueryAdapter(),
+        codeindex_adapter=_FakeQueryAdapter(),
+    )
+
+    assert result.accepted is False
+    assert any(
+        "memex_cannot_replace_repo_file_evidence" in reason
+        for reason in result.rejection_reasons
+    )
 
 
 def test_model_backed_rejects_invalid_supplied_memex_projection_before_model(tmp_path: Path) -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_typed_evidence_citation_policy.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_typed_evidence_citation_policy.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_typed_evidence_citation_policy import (
+    SOURCE_CLASS_MEMEX,
+    SOURCE_CLASS_REPO_FILE,
+    SOURCE_CLASS_UNKNOWN,
+    classify_evidence_ref,
+    validate_typed_evidence_citations,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_typed_evidence_citation_policy.py"
+)
+FILE_REF = "file:docs/work_ledger.schema.json:sha256:file:lines:1"
+MEMEX_REF = "memex:sha256:brain-view:sha256:record:current_state"
+
+
+def test_classifies_known_evidence_ref_types() -> None:
+    assert classify_evidence_ref(FILE_REF) == SOURCE_CLASS_REPO_FILE
+    assert classify_evidence_ref(MEMEX_REF) == SOURCE_CLASS_MEMEX
+    assert classify_evidence_ref("http://example.test") == SOURCE_CLASS_UNKNOWN
+
+
+def test_file_evidence_alone_is_valid_for_current_repo_claim() -> None:
+    result = validate_typed_evidence_citations(
+        refs=(FILE_REF,),
+        allowed_file_refs=(FILE_REF,),
+    )
+
+    assert result.accepted is True
+
+
+def test_memex_can_supplement_file_evidence() -> None:
+    result = validate_typed_evidence_citations(
+        refs=(FILE_REF, MEMEX_REF),
+        allowed_file_refs=(FILE_REF,),
+        allowed_memex_refs=(MEMEX_REF,),
+    )
+
+    assert result.accepted is True
+
+
+def test_memex_cannot_replace_file_evidence_for_repo_audit_finding() -> None:
+    result = validate_typed_evidence_citations(
+        refs=(MEMEX_REF,),
+        allowed_file_refs=(FILE_REF,),
+        allowed_memex_refs=(MEMEX_REF,),
+    )
+
+    assert result.accepted is False
+    assert "memex_cannot_replace_repo_file_evidence" in result.rejection_reasons
+
+
+def test_unknown_or_unallowed_refs_fail_closed() -> None:
+    result = validate_typed_evidence_citations(
+        refs=(FILE_REF, "memex:unknown:unknown:identity", "raw:unknown"),
+        allowed_file_refs=(FILE_REF,),
+        allowed_memex_refs=(MEMEX_REF,),
+    )
+
+    assert result.accepted is False
+    assert "unknown_memex_evidence_ref" in result.rejection_reasons
+    assert "unknown_evidence_ref_type" in result.rejection_reasons
+
+
+def test_typed_citation_policy_is_read_only_by_ast() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    forbidden_imports = {"subprocess", "requests", "httpx", "sqlite3", "os"}
+    forbidden_calls = {"open", "write_text", "write_bytes", "system", "popen"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in forbidden_imports
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in forbidden_imports
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in forbidden_calls
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in forbidden_calls


### PR DESCRIPTION
## Summary
- add typed evidence citation policy for RedDog read-only audit findings
- allow Memex refs only as supplemental historical context beside current repository file refs
- reject unknown file refs, unknown Memex refs, and Memex-only repo-audit findings before accepting model output
- update prompt rules to prevent Memex memory from replacing current-code evidence

## Truth boundary
- Citation policy only; Memex can supplement but not prove current implementation.
- No authority promotion, worker spawn, OpenClaw enqueue, Hermes dispatch, repo mutation, HoloIndex re-index, or PatternMemory promotion.

## Validation
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_typed_evidence_citation_policy.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
- 37 passed
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_typed_evidence_citation_policy.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py holo_index/tests/test_holoindex_memex_access_policy_receipt.py holo_index/tests/test_holoindex_memex_projection_adapter.py holo_index/tests/test_holoindex_memex_projection_integrity.py holo_index/tests/test_holoindex_memex_query_routing.py holo_index/tests/test_holoindex_memex_evidence_bundle.py holo_index/tests/test_holoindex_query_receipt.py
- 86 passed
- git diff --check
- added/new lines ASCII-clean; historical ModLog non-ASCII unchanged