### PR TITLE
feat(memex): add per-target retrieval verdicts

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,22 @@
 # HoloIndex Package ModLog
 
+## [2026-07-16] HOLOINDEX_MEMEX_PER_TARGET_RETRIEVAL_VERDICT_PHASE1
+
+**Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice
+**WSP**: 00, 15, 22, 50, 60, 97
+
+- UPDATE `holo_index/memex_query_routing.py`: Memex query receipts now expose
+  an overall `retrieval_verdict` and deterministic
+  `per_target_retrieval_verdicts` for every query term.
+- UPDATE `holo_index/query_receipt.py`: query receipts bind optional
+  retrieval verdict fields into the receipt digest instead of dropping them
+  during normalization.
+- TEST `tests/test_holoindex_memex_query_routing.py`: found and missed Memex
+  targets now report explicit per-target verdicts without creating index-gap
+  false positives.
+- Boundary: verdicts are read-only query metadata. No Memex supplier, external
+  retrieval, HoloIndex re-index, or evidence promotion is added.
+
 ## [2026-07-16] REDDOG_MEMEX_CONTENT_BEARING_EVIDENCE_BUNDLE_PHASE1
 
 **Agent**: 0102 (Codex) | Commander: 012 | Gate: implementation slice

--- a/holo_index/memex_query_routing.py
+++ b/holo_index/memex_query_routing.py
@@ -49,6 +49,7 @@ def build_memex_projection_query_receipt(
     hits = []
     if projection_ok and receipt:
         hits = _rank_records(records, terms=terms, limit=limit)
+    verdicts = _per_target_verdicts(records, terms=terms) if projection_ok else []
 
     result = {
         "ok": projection_ok,
@@ -56,6 +57,8 @@ def build_memex_projection_query_receipt(
         "freshness": "CURRENT" if projection_ok else "UNKNOWN",
         "hits": hits,
         "error": error,
+        "retrieval_verdict": "FOUND" if hits else "MISS",
+        "per_target_retrieval_verdicts": verdicts,
     }
     generation_binding = {
         "freshness_generation_id": receipt.holoindex_generation_id if receipt else "",
@@ -118,6 +121,37 @@ def _rank_records(
         )
     ranked.sort(key=lambda item: (-float(item["score"]), str(item["path"])))
     return ranked[: max(0, int(limit or 0))]
+
+
+def _per_target_verdicts(
+    records: Sequence[MemexProjectionRecord],
+    *,
+    terms: Sequence[str],
+) -> list[dict[str, Any]]:
+    verdicts = []
+    for term in terms:
+        matched_refs = []
+        for record in records:
+            haystack = f"{record.title}\n{record.text}".lower()
+            if term not in haystack:
+                continue
+            matched_refs.append(_record_evidence_ref(record))
+        verdicts.append(
+            {
+                "target": term,
+                "source_class": SOURCE_CLASS_MEMEX,
+                "verdict": "FOUND" if matched_refs else "MISS",
+                "matched_evidence_refs": matched_refs,
+            }
+        )
+    return verdicts
+
+
+def _record_evidence_ref(record: MemexProjectionRecord) -> str:
+    return (
+        f"memex:{record.memex_snapshot_id}:{record.record_id}:"
+        f"{record.metadata.get('section', '')}"
+    )
 
 
 def projection_to_plain_dict(value: MemexProjectionResult) -> dict[str, Any]:

--- a/holo_index/query_receipt.py
+++ b/holo_index/query_receipt.py
@@ -224,6 +224,29 @@ def build_query_receipt(
         "stale_reasons": stale_reasons,
         "no_holoindex_reindex_performed": True,
     }
+    retrieval_verdict = str(result.get("retrieval_verdict") or "").strip()
+    if retrieval_verdict:
+        payload["retrieval_verdict"] = retrieval_verdict
+    per_target = result.get("per_target_retrieval_verdicts")
+    if not isinstance(per_target, (str, bytes)) and isinstance(per_target, Sequence):
+        payload["per_target_retrieval_verdicts"] = [
+            {
+                "target": str(item.get("target") or ""),
+                "source_class": str(item.get("source_class") or ""),
+                "verdict": str(item.get("verdict") or ""),
+                "matched_evidence_refs": [
+                    str(ref)
+                    for ref in (
+                        item.get("matched_evidence_refs")
+                        if not isinstance(item.get("matched_evidence_refs"), (str, bytes))
+                        and isinstance(item.get("matched_evidence_refs"), Sequence)
+                        else ()
+                    )
+                ],
+            }
+            for item in per_target
+            if isinstance(item, Mapping)
+        ]
     return {**payload, "receipt_id": digest_json(payload)}
 
 

--- a/holo_index/tests/test_holoindex_memex_query_routing.py
+++ b/holo_index/tests/test_holoindex_memex_query_routing.py
@@ -74,6 +74,10 @@ def test_memex_query_receipt_binds_projection_generation_and_source_class() -> N
     assert receipt["hits"][0]["path"].startswith("memex://sha256:brain-view/")
     assert receipt["hits"][0]["digest"].startswith("sha256:")
     assert "current_state" in receipt["hits"][0]["evidence_ref"]
+    assert receipt["retrieval_verdict"] == "FOUND"
+    verdicts = {item["target"]: item for item in receipt["per_target_retrieval_verdicts"]}
+    assert verdicts["authoritative"]["verdict"] == "FOUND"
+    assert verdicts["reconciliation"]["matched_evidence_refs"]
 
 
 def test_memex_query_receipt_accepts_plain_projection_dict() -> None:
@@ -98,6 +102,11 @@ def test_memex_query_miss_is_not_a_generation_gap() -> None:
     assert receipt["ok"] is True
     assert receipt["hits"] == []
     assert receipt["index_gap_detected"] is False
+    assert receipt["retrieval_verdict"] == "MISS"
+    assert all(
+        item["verdict"] == "MISS"
+        for item in receipt["per_target_retrieval_verdicts"]
+    )
     assert receipt["stale_reasons"] == []
 
 


### PR DESCRIPTION
## Summary
- add etrieval_verdict and per_target_retrieval_verdicts to Memex query receipts
- bind optional retrieval verdict fields into the generic query receipt digest
- preserve Memex miss behavior without creating false HoloIndex index-gap claims

## Truth boundary
- Read-only query metadata only.
- No Memex supplier, external retrieval, HoloIndex re-index, evidence promotion, worker spawn, or authority change.

## Validation
- python -m pytest holo_index/tests/test_holoindex_memex_query_routing.py holo_index/tests/test_holoindex_memex_evidence_bundle.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
- 43 passed
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_typed_evidence_citation_policy.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py holo_index/tests/test_holoindex_memex_access_policy_receipt.py holo_index/tests/test_holoindex_memex_projection_adapter.py holo_index/tests/test_holoindex_memex_projection_integrity.py holo_index/tests/test_holoindex_memex_query_routing.py holo_index/tests/test_holoindex_memex_evidence_bundle.py holo_index/tests/test_holoindex_query_receipt.py
- 86 passed
- git diff --check
- added ModLog lines ASCII-clean; historical ModLog non-ASCII unchanged