### PR TITLE
feat(reddog): supply assignment-bound memex projections

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,23 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_MEMEX_SNAPSHOT_PROJECTION_SUPPLIER_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 22, 50, 97
+
+- Added an assignment-bound Memex snapshot projection supplier for read-only
+  RedDog audit workers.
+- Runtime can now take an explicit `memex_view`, construct a matching access
+  policy receipt and HoloIndex shadow projection, then reuse the existing
+  integrity, query-receipt, evidence-bundle, and citation gates.
+- Missing assignment bindings, missing policy expiry, scope mismatch, snapshot
+  mismatch, projection tampering, replay, and policy failures reject before any
+  model call.
+- Boundary remains read-only: no HoloIndex re-index, Memex write, Brain write,
+  Breadcrumb write, repo mutation, shell execution, OpenClaw enqueue, Hermes
+  dispatch, worktree operation, PR, merge, or PatternMemory promotion.
+- Policy issuance is still deterministic integrity only; authenticated policy
+  authority remains outside this slice.
+
 ## 2026-07-16: REDDOG_TYPED_EVIDENCE_CITATION_POLICY_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 50, 60, 97

--- a/modules/communication/moltbot_bridge/src/reddog_memex_snapshot_projection_supplier.py
+++ b/modules/communication/moltbot_bridge/src/reddog_memex_snapshot_projection_supplier.py
@@ -1,0 +1,175 @@
+"""Assignment-bound Memex projection supplier for RedDog read-only workers.
+
+The supplier turns an already assembled Memex view into a governed HoloIndex
+shadow projection plus access-policy receipt. It performs no Memex write,
+HoloIndex write, re-index, worker spawn, shell, or repo mutation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from holo_index.memex_access_policy_receipt import (
+    MemexAccessPolicyReceipt,
+    build_memex_access_policy_receipt,
+)
+from holo_index.memex_projection_adapter import (
+    MemexProjectionResult,
+    project_foundup_memex_to_holoindex_shadow,
+)
+from holo_index.memex_projection_integrity import verify_and_rehydrate_memex_projection
+
+
+SUPPLIER_ACCEPTED = "MEMEX_SNAPSHOT_PROJECTION_SUPPLIED"
+SUPPLIER_REJECTED = "MEMEX_SNAPSHOT_PROJECTION_REJECTED"
+
+
+@dataclass(frozen=True)
+class MemexSnapshotProjectionSupplyResult:
+    accepted: bool
+    status: str
+    projection: MemexProjectionResult | None
+    access_policy_receipt: MemexAccessPolicyReceipt | None
+    rejection_reasons: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "accepted": self.accepted,
+            "status": self.status,
+            "projection": self.projection.to_dict() if self.projection else None,
+            "access_policy_receipt": (
+                self.access_policy_receipt.to_dict() if self.access_policy_receipt else None
+            ),
+            "rejection_reasons": list(self.rejection_reasons),
+        }
+
+
+def supply_assignment_bound_memex_projection(
+    *,
+    memex_view: Mapping[str, Any],
+    foundup_id: str,
+    principal_id: str,
+    work_order_id: str,
+    source_scope: str,
+    source_revision: str,
+    snapshot_receipt_id: str,
+    snapshot_content_digest: str,
+    holoindex_generation_id: str,
+    issued_at: str,
+    expires_at: str,
+    sensitivity_classes: Sequence[str] = ("internal",),
+    allowed_record_sections: Sequence[str] = (),
+    denied_record_sections: Sequence[str] = (),
+    max_records: int = 32,
+) -> MemexSnapshotProjectionSupplyResult:
+    """Supply a verified projection and policy receipt for one assignment."""
+
+    reasons: list[str] = []
+    if not isinstance(memex_view, Mapping):
+        return _reject("memex_view_not_mapping")
+
+    expected = {
+        "foundup_id": _clean(foundup_id),
+        "principal_id": _clean(principal_id),
+        "work_order_id": _clean(work_order_id),
+        "source_scope": _clean(source_scope),
+        "source_revision": _clean(source_revision),
+        "snapshot_receipt_id": _clean(snapshot_receipt_id),
+        "snapshot_content_digest": _clean(snapshot_content_digest),
+        "holoindex_generation_id": _clean(holoindex_generation_id),
+        "issued_at": _clean(issued_at),
+        "expires_at": _clean(expires_at),
+    }
+    for key, value in expected.items():
+        if not value:
+            reasons.append(f"missing_{key}")
+
+    if _clean(memex_view.get("foundup_id")) != expected["foundup_id"]:
+        reasons.append("memex_view_foundup_mismatch")
+    if _clean(memex_view.get("snapshot_id")) != expected["snapshot_receipt_id"]:
+        reasons.append("memex_view_snapshot_id_mismatch")
+    if _clean(memex_view.get("snapshot_content_digest")) != expected["snapshot_content_digest"]:
+        reasons.append("memex_view_snapshot_digest_mismatch")
+    if reasons:
+        return _reject(*reasons)
+
+    policy = build_memex_access_policy_receipt(
+        principal_id=expected["principal_id"],
+        work_order_id=expected["work_order_id"],
+        foundup_scope=(expected["foundup_id"],),
+        source_scope=expected["source_scope"],
+        sensitivity_classes=tuple(sensitivity_classes),
+        allowed_record_sections=tuple(allowed_record_sections) or (
+            "identity",
+            "current_state",
+            "roadmap_state",
+            "verified_outcome",
+        ),
+        denied_record_sections=tuple(denied_record_sections),
+        max_records=max_records,
+        issued_at=expected["issued_at"],
+        expires_at=expected["expires_at"],
+        policy_generation_id=f"{expected['holoindex_generation_id']}:memex-policy",
+    )
+    if not policy.accepted or policy.receipt is None:
+        return _reject(
+            *("access_policy:" + reason for reason in policy.rejection_reasons)
+        )
+
+    projection = project_foundup_memex_to_holoindex_shadow(
+        memex_view=memex_view,
+        source_scope=expected["source_scope"],
+        source_revision=expected["source_revision"],
+        allowed_foundup_ids=(expected["foundup_id"],),
+        access_policy_receipt=policy.receipt,
+        holoindex_generation_id=expected["holoindex_generation_id"],
+        now_iso=expected["issued_at"],
+    )
+    if not projection.accepted or projection.receipt is None:
+        return _reject(*("projection:" + reason for reason in projection.rejection_reasons))
+
+    gate = verify_and_rehydrate_memex_projection(
+        projection,
+        runtime_mode=True,
+        now_iso=expected["issued_at"],
+        expected_foundup_id=expected["foundup_id"],
+        expected_source_scope=expected["source_scope"],
+        expected_source_revision=expected["source_revision"],
+        expected_access_policy_digest=policy.receipt.receipt_id,
+        expected_holoindex_generation_id=expected["holoindex_generation_id"],
+        expected_operational_snapshot_id=expected["snapshot_receipt_id"],
+        expected_operational_snapshot_content_digest=expected["snapshot_content_digest"],
+    )
+    if not gate.accepted:
+        return _reject(*("integrity:" + reason for reason in gate.rejection_reasons))
+
+    return MemexSnapshotProjectionSupplyResult(
+        accepted=True,
+        status=SUPPLIER_ACCEPTED,
+        projection=projection,
+        access_policy_receipt=policy.receipt,
+        rejection_reasons=(),
+    )
+
+
+def _reject(*reasons: str) -> MemexSnapshotProjectionSupplyResult:
+    return MemexSnapshotProjectionSupplyResult(
+        accepted=False,
+        status=SUPPLIER_REJECTED,
+        projection=None,
+        access_policy_receipt=None,
+        rejection_reasons=tuple(dict.fromkeys(reason for reason in reasons if reason)),
+    )
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+__all__ = [
+    "MemexSnapshotProjectionSupplyResult",
+    "SUPPLIER_ACCEPTED",
+    "SUPPLIER_REJECTED",
+    "supply_assignment_bound_memex_projection",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
@@ -41,6 +41,9 @@ from modules.communication.moltbot_bridge.src.reddog_wsp15_allocation_receipt im
 from modules.communication.moltbot_bridge.src.reddog_typed_evidence_citation_policy import (
     validate_typed_evidence_citations,
 )
+from modules.communication.moltbot_bridge.src.reddog_memex_snapshot_projection_supplier import (
+    supply_assignment_bound_memex_projection,
+)
 from holo_index.query_receipt import (
     SOURCE_CLASS_CODEINDEX,
     SOURCE_CLASS_HOLOINDEX,
@@ -609,7 +612,10 @@ def _optional_memex_query_artifacts(
     projection = task_context.get("memex_projection")
     if projection is None:
         projection = assignment.get("memex_projection")
-    if projection is None:
+    memex_view = task_context.get("memex_view")
+    if memex_view is None:
+        memex_view = assignment.get("memex_view")
+    if projection is None and memex_view is None:
         return None
     try:
         expected_foundup_id = _first_text(task_context, assignment, "foundup_id")
@@ -650,6 +656,54 @@ def _optional_memex_query_artifacts(
         policy_receipt = task_context.get("memex_access_policy_receipt")
         if policy_receipt is None:
             policy_receipt = assignment.get("memex_access_policy_receipt")
+        if projection is None:
+            supplier_issued_at = (
+                _first_text(task_context, assignment, "memex_policy_issued_at")
+                or now_iso
+            )
+            supplier_expires_at = _first_text(task_context, assignment, "memex_policy_expires_at")
+            supplier_missing = [
+                name
+                for name, value in (
+                    ("memex_source_revision", expected_source_revision),
+                    ("memex_policy_issued_at", supplier_issued_at),
+                    ("memex_policy_expires_at", supplier_expires_at),
+                )
+                if not value
+            ]
+            if supplier_missing:
+                return (
+                    _memex_error_receipt(
+                        query=query,
+                        error="memex_projection_supplier_failed:missing_"
+                        + ",".join(supplier_missing),
+                    ),
+                    None,
+                )
+            supplier = supply_assignment_bound_memex_projection(
+                memex_view=memex_view,
+                foundup_id=expected_foundup_id,
+                principal_id=expected_principal_id,
+                work_order_id=expected_work_order_id,
+                source_scope=expected_source_scope,
+                source_revision=expected_source_revision,
+                snapshot_receipt_id=expected_snapshot_id,
+                snapshot_content_digest=expected_snapshot_digest,
+                holoindex_generation_id=expected_generation_id,
+                issued_at=supplier_issued_at,
+                expires_at=supplier_expires_at,
+            )
+            if not supplier.accepted or supplier.projection is None or supplier.access_policy_receipt is None:
+                return (
+                    _memex_error_receipt(
+                        query=query,
+                        error="memex_projection_supplier_failed:"
+                        + ",".join(supplier.rejection_reasons),
+                    ),
+                    None,
+                )
+            projection = supplier.projection
+            policy_receipt = supplier.access_policy_receipt.to_dict()
         if policy_receipt is None:
             return (_memex_error_receipt(query=query, error="memex_access_policy_missing"), None)
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_memex_snapshot_projection_supplier.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_memex_snapshot_projection_supplier.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_memex_snapshot_projection_supplier import (
+    supply_assignment_bound_memex_projection,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_memex_snapshot_projection_supplier.py"
+)
+
+
+def _memex_view() -> dict:
+    return {
+        "schema_version": "foundup_brain_current_state.v1",
+        "foundup_brain_view_id": "sha256:brain-view",
+        "foundup_id": "foundups-agent",
+        "snapshot_id": "snapshot-1",
+        "snapshot_content_digest": "sha256:snapshot-content",
+        "identity": {
+            "foundup_id": "foundups-agent",
+            "name": "Foundups Agent",
+        },
+        "current_state": {
+            "selected_slice": "REDDOG_MEMEX_SNAPSHOT_PROJECTION_SUPPLIER_PHASE1",
+            "runtime_gap": "projection supplier",
+        },
+        "roadmap_state": {
+            "next_slice": "REDDOG_OPERATIONAL_MEMORY_NEXT_PHASE1",
+        },
+    }
+
+
+def _supply(**overrides):
+    kwargs = {
+        "memex_view": _memex_view(),
+        "foundup_id": "foundups-agent",
+        "principal_id": "principal-012",
+        "work_order_id": "assignment-1",
+        "source_scope": "foundup:foundups-agent:lane:repo_code_audit",
+        "source_revision": "abc123",
+        "snapshot_receipt_id": "snapshot-1",
+        "snapshot_content_digest": "sha256:snapshot-content",
+        "holoindex_generation_id": "sha256:memex-generation",
+        "issued_at": "2026-07-16T00:00:00+00:00",
+        "expires_at": "2026-07-16T01:00:00+00:00",
+    }
+    kwargs.update(overrides)
+    return supply_assignment_bound_memex_projection(**kwargs)
+
+
+def test_supplies_assignment_bound_projection_and_policy_receipt() -> None:
+    result = _supply()
+
+    assert result.accepted is True
+    assert result.projection is not None
+    assert result.access_policy_receipt is not None
+    assert result.projection.receipt is not None
+    assert result.projection.receipt.access_policy_digest == result.access_policy_receipt.receipt_id
+    assert result.projection.receipt.holoindex_generation_id == "sha256:memex-generation"
+    assert result.projection.records
+    assert result.projection.records[0].metadata["snapshot_id"] == "snapshot-1"
+    assert result.projection.records[0].metadata["snapshot_content_digest"] == "sha256:snapshot-content"
+
+
+def test_rejects_memex_view_scope_or_snapshot_mismatch() -> None:
+    view = _memex_view()
+    view["foundup_id"] = "other-foundup"
+    result = _supply(memex_view=view)
+
+    assert result.accepted is False
+    assert "memex_view_foundup_mismatch" in result.rejection_reasons
+
+    snapshot_mismatch = _memex_view()
+    snapshot_mismatch["snapshot_content_digest"] = "sha256:other"
+    result = _supply(memex_view=snapshot_mismatch)
+    assert result.accepted is False
+    assert "memex_view_snapshot_digest_mismatch" in result.rejection_reasons
+
+
+def test_rejects_missing_assignment_bindings() -> None:
+    result = _supply(principal_id="", work_order_id="", holoindex_generation_id="")
+
+    assert result.accepted is False
+    assert "missing_principal_id" in result.rejection_reasons
+    assert "missing_work_order_id" in result.rejection_reasons
+    assert "missing_holoindex_generation_id" in result.rejection_reasons
+
+
+def test_supplier_is_read_only_by_ast() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    forbidden_imports = {"subprocess", "requests", "httpx", "sqlite3", "os"}
+    forbidden_calls = {"open", "write_text", "write_bytes", "system", "popen"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in forbidden_imports
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in forbidden_imports
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in forbidden_calls
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in forbidden_calls

--- a/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
@@ -62,6 +62,7 @@ MEMEX_GENERATION_ID = "sha256:memex-generation"
 MEMEX_SOURCE_REVISION = "abc123"
 MEMEX_SOURCE_SCOPE = f"foundup:{MEMEX_FOUNDUP_ID}:lane:{REPO_CODE_AUDIT_LANE}"
 MEMEX_NOW = "2026-07-16T00:01:00+00:00"
+MEMEX_POLICY_EXPIRES_AT = "2026-07-16T01:00:00+00:00"
 
 
 @pytest.fixture(autouse=True)
@@ -291,6 +292,7 @@ def _model_context(
     context["assignment"]["memex_source_scope"] = MEMEX_SOURCE_SCOPE
     context["assignment"]["memex_source_revision"] = MEMEX_SOURCE_REVISION
     context["assignment"]["memex_holoindex_generation_id"] = MEMEX_GENERATION_ID
+    context["assignment"]["memex_policy_expires_at"] = MEMEX_POLICY_EXPIRES_AT
     return context
 
 
@@ -302,7 +304,7 @@ def _memex_access_policy_receipt() -> dict:
         source_scope=MEMEX_SOURCE_SCOPE,
         sensitivity_classes=("internal",),
         issued_at="2026-07-16T00:00:00+00:00",
-        expires_at="2026-07-16T01:00:00+00:00",
+        expires_at=MEMEX_POLICY_EXPIRES_AT,
         policy_generation_id="policy-generation-1",
     )
     assert result.accepted is True
@@ -310,27 +312,31 @@ def _memex_access_policy_receipt() -> dict:
     return result.receipt.to_dict()
 
 
+def _memex_view() -> dict:
+    return {
+        "schema_version": "foundup_brain_current_state.v1",
+        "foundup_brain_view_id": "sha256:brain-view",
+        "foundup_id": MEMEX_FOUNDUP_ID,
+        "snapshot_id": "snapshot-1",
+        "snapshot_content_digest": "sha256:snapshot-content",
+        "identity": {
+            "foundup_id": MEMEX_FOUNDUP_ID,
+            "name": "Foundups Agent",
+        },
+        "current_state": {
+            "selected_slice": "REDDOG_MEMEX_QUERY_RECEIPT_RUNTIME_BINDING_PHASE1",
+            "evidence_path": "modules/communication/moltbot_bridge/src/sample.py",
+        },
+        "roadmap_state": {
+            "next_slice": "REDDOG_RUNTIME_NEXT_PHASE1",
+        },
+    }
+
+
 def _memex_projection(*, access_policy_receipt: dict | None = None) -> dict:
     access_policy_receipt = access_policy_receipt or _memex_access_policy_receipt()
     result = project_foundup_memex_to_holoindex_shadow(
-        memex_view={
-            "schema_version": "foundup_brain_current_state.v1",
-            "foundup_brain_view_id": "sha256:brain-view",
-            "foundup_id": MEMEX_FOUNDUP_ID,
-            "snapshot_id": "snapshot-1",
-            "snapshot_content_digest": "sha256:snapshot-content",
-            "identity": {
-                "foundup_id": MEMEX_FOUNDUP_ID,
-                "name": "Foundups Agent",
-            },
-            "current_state": {
-                "selected_slice": "REDDOG_MEMEX_QUERY_RECEIPT_RUNTIME_BINDING_PHASE1",
-                "evidence_path": "modules/communication/moltbot_bridge/src/sample.py",
-            },
-            "roadmap_state": {
-                "next_slice": "REDDOG_RUNTIME_NEXT_PHASE1",
-            },
-        },
+        memex_view=_memex_view(),
         source_scope=MEMEX_SOURCE_SCOPE,
         source_revision=MEMEX_SOURCE_REVISION,
         allowed_foundup_ids=(MEMEX_FOUNDUP_ID,),
@@ -561,6 +567,58 @@ def test_model_backed_includes_optional_memex_query_receipt(tmp_path: Path) -> N
     assert worker_receipt["memex_query_receipt_id"] == memex_receipt["receipt_id"]
     assert worker_receipt["memex_evidence_bundle_id"] == memex_bundle["bundle_id"]
     assert worker_receipt["no_side_effect_attestations"]["no_holoindex_reindex_performed"] is True
+
+
+def test_model_backed_supplies_assignment_bound_memex_projection_from_view(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    runner = _EchoEvidenceModelRunner()
+    context = _model_context()
+    context["memex_view"] = _memex_view()
+
+    result = execute_reddog_readonly_audit_task(
+        task_context=context,
+        repo_root=root,
+        task_id="task-1",
+        model_runner=runner,
+        holoindex_adapter=_FakeQueryAdapter(),
+        codeindex_adapter=_FakeQueryAdapter(),
+    )
+
+    assert result.accepted is True
+    assert runner.calls
+    model_context = json.loads(runner.calls[0]["context"])
+    memex_receipt = model_context["memex_query_receipt"]
+    memex_bundle = model_context["memex_evidence_bundle"]
+    assert memex_receipt["source_class"] == "memex"
+    assert memex_receipt["freshness_generation_id"] == MEMEX_GENERATION_ID
+    assert memex_bundle["records"]
+    assert result.report is not None
+    worker_receipt = result.report["worker_receipt"]
+    assert worker_receipt["memex_query_receipt_id"] == memex_receipt["receipt_id"]
+    assert worker_receipt["memex_evidence_bundle_id"] == memex_bundle["bundle_id"]
+    assert worker_receipt["no_side_effect_attestations"]["no_holoindex_reindex_performed"] is True
+
+
+def test_model_backed_rejects_memex_view_without_supplier_expiry_before_model(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    runner = _EchoEvidenceModelRunner()
+    context = _model_context()
+    context["assignment"] = dict(context["assignment"])
+    context["assignment"].pop("memex_policy_expires_at")
+    context["memex_view"] = _memex_view()
+
+    result = execute_reddog_readonly_audit_task(
+        task_context=context,
+        repo_root=root,
+        task_id="task-1",
+        model_runner=runner,
+        holoindex_adapter=_FakeQueryAdapter(),
+        codeindex_adapter=_FakeQueryAdapter(),
+    )
+
+    assert result.accepted is False
+    assert ReadOnlyAuditTaskRejectReason.INDEX_QUERY_FAILED in result.rejection_reasons
+    assert not runner.calls
 
 
 def test_model_backed_allows_memex_refs_only_as_supplemental_citations(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add an assignment-bound Memex projection supplier for read-only RedDog audit workers.
- Let the runtime consume an explicit memex_view and synthesize a matching access-policy receipt plus HoloIndex shadow projection.
- Reuse the existing integrity gate, query receipt, content evidence bundle, and typed citation policy before any model call.

## Validation
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_memex_snapshot_projection_supplier.py
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py -q
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_memex_snapshot_projection_supplier.py modules/communication/moltbot_bridge/tests/test_reddog_typed_evidence_citation_policy.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py holo_index/tests/test_holoindex_memex_access_policy_receipt.py holo_index/tests/test_holoindex_memex_projection_adapter.py holo_index/tests/test_holoindex_memex_projection_integrity.py holo_index/tests/test_holoindex_memex_query_routing.py holo_index/tests/test_holoindex_memex_evidence_bundle.py holo_index/tests/test_holoindex_query_receipt.py
- git diff --cached --check

## Truth Boundary
- No HoloIndex re-index, Memex write, Brain write, Breadcrumb write, repo mutation, shell execution, OpenClaw enqueue, Hermes dispatch, worktree operation, PR/merge automation, or PatternMemory promotion in runtime.
- Policy issuance remains deterministic integrity only, not authenticated authority.