### PR TITLE
feat(reddog): model-back all readonly audit lanes

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,23 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_READONLY_AUDIT_MULTI_LANE_MODEL_WORKERS_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 22, 50, 97
+
+- Updated read-only audit swarm enqueue so all default audit lanes are explicit
+  `model_backed_0102` worker tasks, not only `repo_code_audit`.
+- Generalized the guarded model-backed read-only audit path to accept any
+  explicit audit lane while preserving WSP_15 binding, HoloIndex/CodeIndex
+  query receipts, governed direct reads, Memex evidence, redaction-gated model
+  calls, strict JSON validation, and typed evidence citation policy.
+- Added a runtime-freshness lane regression proving a non-repo lane reaches the
+  same guarded model path and carries its lane in the prompt.
+- Updated the enqueue fixture to satisfy current HoloIndex freshness receipt
+  generation/manifest verification semantics.
+- Boundary remains read-only: no repository mutation, shell execution, worktree
+  operation, OpenClaw child enqueue, Hermes dispatch, HoloIndex re-index, PR
+  creation, merge authority, or PatternMemory promotion.
+
 ## 2026-07-16: REDDOG_MEMEX_SNAPSHOT_PROJECTION_SUPPLIER_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 22, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_openclaw_readonly_audit_swarm_enqueue.py
+++ b/modules/communication/moltbot_bridge/src/reddog_openclaw_readonly_audit_swarm_enqueue.py
@@ -316,7 +316,7 @@ def _build_task_spec(plan: ReadOnlyAuditSwarmPlan, assignment: ReadOnlyAuditAssi
     context = {
         "source": READONLY_AUDIT_TASK_SOURCE,
         "slice_name": "REDDOG_OPENCLAW_READONLY_AUDIT_SWARM_AGENTDB_ENQUEUE_PHASE1",
-        "worker_mode": "model_backed_0102" if assignment.lane_id == "repo_code_audit" else "deterministic_readonly",
+        "worker_mode": "model_backed_0102",
         "wsp15_allocation_receipt_id": assignment.wsp15_allocation_receipt_id,
         "wsp15_allocation_digest": assignment.wsp15_allocation_digest,
         "wsp15_allocation_receipt": dict(plan.receipt.wsp15_allocation_receipt),

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
@@ -1,12 +1,12 @@
-"""Model-backed 0102 worker for RedDog read-only repo audit tasks.
+"""Model-backed 0102 worker for RedDog read-only audit tasks.
 
 Slice: REDDOG_OPENCLAW_READONLY_0102_AUDIT_WORKER_RUNTIME_PHASE1
 
-This module owns the model-backed repo_code_audit path. It is only reached
-from read-only AgentDB task contexts that explicitly request the
-``model_backed_0102`` worker mode. It may call the configured RedDog/Fusion
-model path, but it does not mutate the repository, run shell commands, enqueue
-OpenClaw work, dispatch Hermes, create worktrees, or re-index HoloIndex.
+This module owns model-backed read-only audit lanes. It is only reached from
+read-only AgentDB task contexts that explicitly request the ``model_backed_0102``
+worker mode. It may call the configured RedDog/Fusion model path, but it does
+not mutate the repository, run shell commands, enqueue OpenClaw work, dispatch
+Hermes, create worktrees, or re-index HoloIndex.
 """
 
 from __future__ import annotations
@@ -944,8 +944,9 @@ def _module_roots_from_paths(paths: Sequence[str]) -> list[str]:
 
 
 def _repo_audit_query(*, assignment: Mapping[str, Any], seed_targets: Sequence[str]) -> str:
+    lane_id = str(assignment.get("lane_id") or "readonly_audit").strip()
     targets = " ".join(str(value).replace("/", " ") for value in (*tuple(seed_targets), *tuple(assignment.get("allowed_read_targets", ()))))
-    return f"RedDog repo code audit readonly evidence {targets}".strip()
+    return f"RedDog {lane_id} readonly audit evidence {targets}".strip()
 
 
 def _validate_wsp15_binding(
@@ -1014,8 +1015,9 @@ def _build_repo_audit_model_prompt(
     assignment: Mapping[str, Any],
     allocation: Mapping[str, Any],
 ) -> str:
+    lane_id = str(assignment.get("lane_id") or "readonly_audit").strip()
     payload = {
-        "task": "Return one strict JSON read-only repo_code_audit report.",
+        "task": f"Return one strict JSON read-only audit report for lane {lane_id}.",
         "required_json_fields": ["summary", "findings", "evidence_refs"],
         "finding_required_fields": [
             "finding_id",
@@ -1045,7 +1047,7 @@ def _build_repo_audit_model_prompt(
         ],
         "assignment": {
             "assignment_id": assignment.get("assignment_id"),
-            "lane_id": assignment.get("lane_id"),
+            "lane_id": lane_id,
             "snapshot_receipt_id": assignment.get("snapshot_receipt_id"),
             "allowed_read_targets": list(assignment.get("allowed_read_targets", ())),
         },

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_audit_task_executor.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_audit_task_executor.py
@@ -148,7 +148,7 @@ def execute_reddog_readonly_audit_task(
 
     root = Path(repo_root).resolve()
     lane_id = str(assignment.get("lane_id") or "")
-    if lane_id == "repo_code_audit" and task_context.get("worker_mode") == "model_backed_0102":
+    if task_context.get("worker_mode") == "model_backed_0102":
         from modules.communication.moltbot_bridge.src.reddog_readonly_0102_audit_worker_runtime import (
             execute_model_backed_repo_code_audit,
         )

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -86,6 +86,7 @@ def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
         repo_head_sha=HEAD,
         ssd_path="E:/HoloIndex",
         source="ci_targeted_reindex",
+        generation_id="sha256:holo-generation",
         collections=[
             CollectionFreshness(
                 name="navigation_work_ledger",
@@ -94,6 +95,9 @@ def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
                 source="ci_targeted_reindex",
                 repo_head_sha=HEAD,
                 last_indexed_at=NOW,
+                source_manifest_digest="sha256:work-ledger-manifest",
+                indexed_paths_digest="sha256:work-ledger-paths",
+                verification="PASS",
             ),
             CollectionFreshness(
                 name="navigation_symbols",
@@ -102,6 +106,9 @@ def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
                 source="ci_targeted_reindex",
                 repo_head_sha=HEAD,
                 last_indexed_at=NOW,
+                source_manifest_digest="sha256:symbols-manifest",
+                indexed_paths_digest="sha256:symbols-paths",
+                verification="PASS",
             ),
         ],
     )

--- a/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_enqueue.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_enqueue.py
@@ -84,6 +84,7 @@ def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
         repo_head_sha=HEAD,
         ssd_path="E:/HoloIndex",
         source="ci_targeted_reindex",
+        generation_id="sha256:holo-generation",
         collections=[
             CollectionFreshness(
                 name="navigation_work_ledger",
@@ -92,6 +93,9 @@ def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
                 source="ci_targeted_reindex",
                 repo_head_sha=HEAD,
                 last_indexed_at=NOW,
+                source_manifest_digest="sha256:work-ledger-manifest",
+                indexed_paths_digest="sha256:work-ledger-paths",
+                verification="PASS",
             ),
             CollectionFreshness(
                 name="navigation_symbols",
@@ -100,6 +104,9 @@ def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
                 source="ci_targeted_reindex",
                 repo_head_sha=HEAD,
                 last_indexed_at=NOW,
+                source_manifest_digest="sha256:symbols-manifest",
+                indexed_paths_digest="sha256:symbols-paths",
+                verification="PASS",
             ),
         ],
     )
@@ -190,10 +197,11 @@ def test_enqueue_accepts_plan_and_builds_pending_readonly_tasks() -> None:
     assert tuple(task.context["assignment"]["lane_id"] for task in result.tasks) == DEFAULT_AUDIT_LANES
     assert all(task.required_skills == (READONLY_AUDIT_TASK_SKILL,) for task in result.tasks)
     assert all(task.context["source"] == READONLY_AUDIT_TASK_SOURCE for task in result.tasks)
+    assert all(task.context["worker_mode"] == "model_backed_0102" for task in result.tasks)
     assert writer.calls and len(writer.calls[0][0]) == 5
 
 
-def test_enqueue_carries_wsp15_allocation_into_repo_code_task_context() -> None:
+def test_enqueue_carries_wsp15_allocation_into_every_task_context() -> None:
     allocation = allocate_reddog_wsp15_receipt(
         requested_operation="readonly_audit_swarm",
         prompt_text="audit current RedDog operational loop",
@@ -204,11 +212,12 @@ def test_enqueue_carries_wsp15_allocation_into_repo_code_task_context() -> None:
     result = enqueue_reddog_readonly_audit_swarm(plan=plan, writer=_FakeWriter())
 
     assert result.accepted is True
-    repo_task = next(task for task in result.tasks if task.context["assignment"]["lane_id"] == "repo_code_audit")
-    assert repo_task.context["worker_mode"] == "model_backed_0102"
-    assert repo_task.context["wsp15_allocation_receipt"]["receipt_id"] == allocation["receipt_id"]
-    assert repo_task.context["wsp15_allocation_receipt_id"] == allocation["receipt_id"]
-    assert repo_task.context["wsp15_allocation_digest"]
+    assert len(result.tasks) == len(DEFAULT_AUDIT_LANES)
+    for task in result.tasks:
+        assert task.context["worker_mode"] == "model_backed_0102"
+        assert task.context["wsp15_allocation_receipt"]["receipt_id"] == allocation["receipt_id"]
+        assert task.context["wsp15_allocation_receipt_id"] == allocation["receipt_id"]
+        assert task.context["wsp15_allocation_digest"]
 
 
 def test_rejects_rejected_plan_and_missing_writer_before_publication() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_runtime.py
@@ -51,6 +51,7 @@ def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
         repo_head_sha=HEAD,
         ssd_path="E:/HoloIndex",
         source="ci_targeted_reindex",
+        generation_id="sha256:holo-generation",
         collections=[
             CollectionFreshness(
                 name="navigation_work_ledger",
@@ -59,6 +60,9 @@ def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
                 source="ci_targeted_reindex",
                 repo_head_sha=HEAD,
                 last_indexed_at=NOW,
+                source_manifest_digest="sha256:work-ledger-manifest",
+                indexed_paths_digest="sha256:work-ledger-paths",
+                verification="PASS",
             ),
             CollectionFreshness(
                 name="navigation_symbols",
@@ -67,6 +71,9 @@ def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
                 source="ci_targeted_reindex",
                 repo_head_sha=HEAD,
                 last_indexed_at=NOW,
+                source_manifest_digest="sha256:symbols-manifest",
+                indexed_paths_digest="sha256:symbols-paths",
+                verification="PASS",
             ),
         ],
     )

--- a/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
@@ -258,6 +258,7 @@ def _context() -> dict:
 def _model_context(
     *,
     allowed_read_targets: tuple[str, ...] | None = None,
+    lane_id: str = REPO_CODE_AUDIT_LANE,
     requested_operation: str = "repo_code_audit",
     prompt_text: str = "Run model-backed RedDog repo code audit.",
 ) -> dict:
@@ -279,7 +280,7 @@ def _model_context(
     context["wsp15_allocation_receipt_id"] = allocation["receipt_id"]
     context["wsp15_allocation_digest"] = canonical_reddog_wsp15_allocation_digest(allocation)
     context["assignment"] = dict(context["assignment"])
-    context["assignment"]["lane_id"] = REPO_CODE_AUDIT_LANE
+    context["assignment"]["lane_id"] = lane_id
     context["assignment"]["foundup_id"] = MEMEX_FOUNDUP_ID
     context["assignment"]["principal_id"] = "principal-012"
     context["assignment"]["work_order_id"] = "assignment-1"
@@ -289,7 +290,7 @@ def _model_context(
     context["assignment"]["determination_id"] = "sha256:determination"
     context["assignment"]["wsp15_allocation_receipt_id"] = allocation["receipt_id"]
     context["assignment"]["wsp15_allocation_digest"] = context["wsp15_allocation_digest"]
-    context["assignment"]["memex_source_scope"] = MEMEX_SOURCE_SCOPE
+    context["assignment"]["memex_source_scope"] = f"foundup:{MEMEX_FOUNDUP_ID}:lane:{lane_id}"
     context["assignment"]["memex_source_revision"] = MEMEX_SOURCE_REVISION
     context["assignment"]["memex_holoindex_generation_id"] = MEMEX_GENERATION_ID
     context["assignment"]["memex_policy_expires_at"] = MEMEX_POLICY_EXPIRES_AT
@@ -411,6 +412,35 @@ def test_model_backed_repo_code_audit_accepts_strict_evidence_bound_report(tmp_p
     assert result.report["worker_receipt"]["model_receipt_id"] == "model-receipt-1"
     assert result.report["worker_receipt"]["model_route_receipt_id"].startswith("sha256:")
     assert result.report["findings"][0]["evidence_refs"][0] in result.report["evidence_refs"]
+
+
+def test_model_backed_runtime_freshness_lane_uses_same_guarded_path(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    runner = _EchoEvidenceModelRunner()
+    context = _model_context(
+        lane_id="runtime_freshness_audit",
+        requested_operation="runtime_freshness_audit",
+        prompt_text="Run model-backed runtime freshness audit.",
+    )
+
+    result = execute_reddog_readonly_audit_task(
+        task_context=context,
+        repo_root=root,
+        task_id="task-1",
+        model_runner=runner,
+        holoindex_adapter=_FakeQueryAdapter(),
+        codeindex_adapter=_FakeQueryAdapter(),
+    )
+
+    assert result.accepted is True
+    assert result.no_model_call_performed is False
+    assert runner.calls
+    assert result.report is not None
+    assert result.report["lane_id"] == "runtime_freshness_audit"
+    assert result.report["model_backed_0102_worker_performed"] is True
+    model_prompt = json.loads(runner.calls[0]["prompt"])
+    assert model_prompt["assignment"]["lane_id"] == "runtime_freshness_audit"
+    assert "runtime_freshness_audit" in model_prompt["task"]
 
 
 def test_model_backed_discovers_index_candidate_before_direct_read(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Enqueue every default RedDog read-only audit lane as model_backed_0102, not only repo_code_audit.
- Generalize the existing guarded model-backed read-only audit path so non-repo lanes use the same WSP_15 binding, HoloIndex/CodeIndex receipts, governed direct reads, optional Memex evidence, strict JSON validation, and typed citation policy.
- Keep the boundary read-only: no repo mutation, shell, worktree, OpenClaw child enqueue, Hermes dispatch, HoloIndex re-index, PR/merge authority, or PatternMemory promotion.

## Validation
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py -q
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_enqueue.py -q
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_enqueue.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_report_collection.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_decision_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_decision_persistence.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py -q
- git diff --cached --check

## WSP_97 Truth Boundary
OBSERVED: non-repo lane runtime_freshness_audit reaches the same guarded model-backed path and carries its lane into the model prompt.
OBSERVED: all enqueued default audit lanes now receive worker_mode=model_backed_0102.
SPECIFIED_NOT_IMPLEMENTED: external research retrieval, live coding workers, worktree mutation, signed authority runtime, and merge authority remain outside this PR.