### PR TITLE
feat(reddog): run readonly audit research decision e2e

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,23 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_READONLY_AUDIT_RESEARCH_DECISION_E2E_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 22, 50, 97
+
+- Added an explicit resident-cycle runtime that composes the existing RedDog
+  read-only operational bootstrap, read-only audit task enqueue seam, model
+  backed 0102 audit executor, report persistence, report collection, and
+  backend architect determination.
+- The cycle now proves the current operational loop can plan the five default
+  audit lanes, execute those read-only worker tasks with injected model/index
+  adapters, persist their reports, validate the report bundle, and emit one
+  backend architect queue candidate.
+- Added fail-closed coverage for task execution rejection and report
+  persistence rejection before any final architect determination.
+- Boundary remains read-only: no shell execution, repository mutation,
+  worktree operation, Hermes dispatch, live FoundUp enqueue, PR creation,
+  PatternMemory promotion, or HoloIndex re-index.
+
 ## 2026-07-16: REDDOG_EXTERNAL_RESEARCH_AUDIT_RUNTIME_CONSUMPTION_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 22, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
@@ -1314,16 +1314,7 @@ def _build_repo_audit_model_context(
     external_research_evidence_bundle: Mapping[str, Any] | None = None,
 ) -> str:
     payload = {
-        "untrusted_repository_evidence": [
-            {
-                "evidence_ref": _evidence_ref(item.evidence),
-                "path": item.evidence.path,
-                "digest": item.evidence.digest,
-                "truncated": item.evidence.truncated,
-                "text": item.text,
-            }
-            for item in snapshots
-        ],
+        "untrusted_repository_evidence": _bounded_repository_evidence(snapshots),
         "holoindex_query_receipt": holo_receipt,
         "codeindex_query_receipt": code_receipt,
         "index_query_errors": list(index_query_errors),
@@ -1338,6 +1329,29 @@ def _build_repo_audit_model_context(
     if external_research_evidence_bundle is not None:
         payload["untrusted_external_research_evidence"] = external_research_evidence_bundle
     return _budgeted_json(payload, MAX_MODEL_CONTEXT_CHARS)
+
+
+def _bounded_repository_evidence(
+    snapshots: Sequence[_ReadOnlyTargetSnapshot],
+) -> list[Mapping[str, Any]]:
+    """Pack repository evidence without dropping refs or exceeding context."""
+
+    count = max(1, len(snapshots))
+    text_budget = max(1200, min(6000, 24_000 // count))
+    packed: list[Mapping[str, Any]] = []
+    for item in snapshots:
+        text = _bound_text(item.text, text_budget)
+        packed.append(
+            {
+                "evidence_ref": _evidence_ref(item.evidence),
+                "path": item.evidence.path,
+                "digest": item.evidence.digest,
+                "truncated": item.evidence.truncated or len(text) < len(item.text),
+                "text_chars": len(text),
+                "text": text,
+            }
+        )
+    return packed
 
 
 def _parse_model_output(content: str) -> Mapping[str, Any]:

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_audit_research_decision_e2e_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_audit_research_decision_e2e_runtime.py
@@ -1,0 +1,451 @@
+"""End-to-end resident RedDog read-only audit and decision cycle.
+
+Slice: REDDOG_READONLY_AUDIT_RESEARCH_DECISION_E2E_PHASE1
+
+This module composes the existing read-only operational bootstrap, AgentDB
+task enqueue seam, read-only 0102 audit executor, report persistence,
+report collection, and backend architect determination runtime into one
+explicit resident-cycle call.
+
+It does not execute shell commands, mutate repository files, create worktrees,
+dispatch Hermes/WRE coding workers, create PRs, promote PatternMemory, or
+re-index HoloIndex. It may publish and execute read-only audit task records
+when the caller explicitly invokes this runtime.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional, Protocol, Sequence
+
+from holo_index.freshness_receipt import HoloIndexFreshnessReceipt
+from modules.communication.moltbot_bridge.src.reddog_backend_architect_determination_runtime import (
+    ArchitectDeterminationStore,
+    ArchitectModelRunner,
+    BackendArchitectDeterminationResult,
+)
+from modules.communication.moltbot_bridge.src.reddog_main_readonly_operational_bootstrap import (
+    DEFAULT_BOOTSTRAP_CHANGED_PATHS,
+    DEFAULT_BOOTSTRAP_READ_TARGETS,
+    REDDOG_MAIN_BOOTSTRAP_READY,
+    RedDogMainReadonlyBootstrapResult,
+    run_reddog_main_readonly_operational_bootstrap,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
+    AgentDbReadOnlyAuditTaskWriter,
+    ReadOnlyAuditSwarmEnqueueReceipt,
+    ReadOnlyAuditTaskSpec,
+    ReadOnlyAuditTaskWriter,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_runtime import (
+    DEFAULT_AUDIT_LANES,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_0102_audit_worker_runtime import (
+    ExternalResearchRetriever,
+    ReadOnlyEvidenceQueryAdapter,
+    RepoAuditModelRunner,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_decision_persistence import (
+    ReadOnlyAuditDecisionStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_report_collection import (
+    AgentDbReadOnlyAuditReportStore,
+    ReadOnlyAuditReportPersistResult,
+    ReadOnlyAuditReportStore,
+    persist_reddog_readonly_audit_task_report,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_task_executor import (
+    ReadOnlyAuditTaskExecutionResult,
+    execute_reddog_readonly_audit_task,
+)
+
+
+READONLY_AUDIT_RESEARCH_DECISION_E2E_ACCEPT = "READONLY_AUDIT_RESEARCH_DECISION_E2E_ACCEPT"
+READONLY_AUDIT_RESEARCH_DECISION_E2E_REJECT = "READONLY_AUDIT_RESEARCH_DECISION_E2E_REJECT"
+
+
+class ReadOnlyAuditResearchDecisionE2EReason:
+    BOOTSTRAP_REJECTED = "REJECT_E2E_BOOTSTRAP_REJECTED"
+    ENQUEUE_NOT_ACCEPTED = "REJECT_E2E_ENQUEUE_NOT_ACCEPTED"
+    NO_CAPTURED_TASKS = "REJECT_E2E_NO_CAPTURED_TASKS"
+    TASK_EXECUTION_REJECTED = "REJECT_E2E_TASK_EXECUTION_REJECTED"
+    REPORT_PERSIST_REJECTED = "REJECT_E2E_REPORT_PERSIST_REJECTED"
+    FINAL_BOOTSTRAP_REJECTED = "REJECT_E2E_FINAL_BOOTSTRAP_REJECTED"
+    FINAL_SWARM_MISMATCH = "REJECT_E2E_FINAL_SWARM_MISMATCH"
+    ARCHITECT_DETERMINATION_MISSING = "REJECT_E2E_ARCHITECT_DETERMINATION_MISSING"
+
+
+class ReadOnlyAuditTaskExecutor(Protocol):
+    def execute_readonly_audit_task(
+        self,
+        *,
+        task: ReadOnlyAuditTaskSpec,
+        repo_root: Path,
+        model_runner: RepoAuditModelRunner | None,
+        holoindex_adapter: ReadOnlyEvidenceQueryAdapter | None,
+        codeindex_adapter: ReadOnlyEvidenceQueryAdapter | None,
+        external_research_retriever: ExternalResearchRetriever | None,
+        timeout_seconds: int,
+    ) -> ReadOnlyAuditTaskExecutionResult: ...
+
+
+@dataclass(frozen=True)
+class DirectReadOnlyAuditTaskExecutor:
+    """In-process executor for already planned read-only audit tasks."""
+
+    def execute_readonly_audit_task(
+        self,
+        *,
+        task: ReadOnlyAuditTaskSpec,
+        repo_root: Path,
+        model_runner: RepoAuditModelRunner | None,
+        holoindex_adapter: ReadOnlyEvidenceQueryAdapter | None,
+        codeindex_adapter: ReadOnlyEvidenceQueryAdapter | None,
+        external_research_retriever: ExternalResearchRetriever | None,
+        timeout_seconds: int,
+    ) -> ReadOnlyAuditTaskExecutionResult:
+        return execute_reddog_readonly_audit_task(
+            task_context=task.context,
+            repo_root=repo_root,
+            task_id=task.task_id,
+            model_runner=model_runner,
+            holoindex_adapter=holoindex_adapter,
+            codeindex_adapter=codeindex_adapter,
+            external_research_retriever=external_research_retriever,
+            timeout_seconds=timeout_seconds,
+        )
+
+
+@dataclass(frozen=True)
+class ReadOnlyAuditTaskRunRecord:
+    task_id: str
+    assignment_id: str
+    lane_id: str
+    accepted: bool
+    report_digest: Optional[str]
+    persist_accepted: bool
+    rejection_reasons: tuple[str, ...]
+    persist_rejection_reasons: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RedDogReadonlyAuditResearchDecisionE2EResult:
+    accepted: bool
+    status: str
+    initial_bootstrap: RedDogMainReadonlyBootstrapResult
+    final_bootstrap: Optional[RedDogMainReadonlyBootstrapResult]
+    task_runs: tuple[ReadOnlyAuditTaskRunRecord, ...]
+    architect_result: Optional[BackendArchitectDeterminationResult]
+    rejection_reasons: tuple[str, ...]
+    no_shell_command_executed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_worktree_operation_performed: bool = True
+    no_pr_created: bool = True
+    no_pattern_memory_promotion_performed: bool = True
+    no_live_foundup_enqueue_performed: bool = True
+    coding_worker_spawned: bool = False
+    readonly_audit_tasks_enqueued: bool = False
+    readonly_audit_tasks_executed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "accepted": self.accepted,
+            "status": self.status,
+            "initial_bootstrap": self.initial_bootstrap.to_dict(),
+            "final_bootstrap": self.final_bootstrap.to_dict() if self.final_bootstrap else None,
+            "task_runs": [item.to_dict() for item in self.task_runs],
+            "architect_result": self.architect_result.to_dict() if self.architect_result else None,
+            "rejection_reasons": list(self.rejection_reasons),
+            "no_shell_command_executed": self.no_shell_command_executed,
+            "no_repo_mutation_performed": self.no_repo_mutation_performed,
+            "no_holoindex_reindex_performed": self.no_holoindex_reindex_performed,
+            "no_hermes_dispatch_performed": self.no_hermes_dispatch_performed,
+            "no_worktree_operation_performed": self.no_worktree_operation_performed,
+            "no_pr_created": self.no_pr_created,
+            "no_pattern_memory_promotion_performed": self.no_pattern_memory_promotion_performed,
+            "no_live_foundup_enqueue_performed": self.no_live_foundup_enqueue_performed,
+            "coding_worker_spawned": self.coding_worker_spawned,
+            "readonly_audit_tasks_enqueued": self.readonly_audit_tasks_enqueued,
+            "readonly_audit_tasks_executed": self.readonly_audit_tasks_executed,
+        }
+
+
+class _CapturingReadOnlyAuditTaskWriter:
+    def __init__(self, delegate: ReadOnlyAuditTaskWriter | None) -> None:
+        self.delegate = delegate
+        self.tasks: tuple[ReadOnlyAuditTaskSpec, ...] = ()
+        self.receipt: ReadOnlyAuditSwarmEnqueueReceipt | None = None
+
+    def enqueue_readonly_audit_tasks(
+        self,
+        tasks: Sequence[ReadOnlyAuditTaskSpec],
+        receipt: ReadOnlyAuditSwarmEnqueueReceipt,
+    ) -> Mapping[str, Any]:
+        self.tasks = tuple(tasks)
+        self.receipt = receipt
+        if self.delegate is None:
+            return {"ok": True, "created_task_ids": [task.task_id for task in self.tasks]}
+        return self.delegate.enqueue_readonly_audit_tasks(self.tasks, receipt)
+
+
+def run_reddog_readonly_audit_research_decision_e2e(
+    *,
+    repo_root: Path | str,
+    work_state_path: Path | str | None = None,
+    holoindex_receipt_path: Path | str | None = None,
+    holoindex_ssd_path: Path | str | None = None,
+    changed_paths: Sequence[str] = DEFAULT_BOOTSTRAP_CHANGED_PATHS,
+    allowed_read_targets: Sequence[str] = DEFAULT_BOOTSTRAP_READ_TARGETS,
+    requested_operation: str = "main_startup_readonly_operational_audit",
+    prompt_text: str = "main.py read-only RedDog operational bootstrap",
+    now_iso: str | None = None,
+    repo_state_override: Mapping[str, Any] | None = None,
+    work_state_snapshot_override: Mapping[str, Any] | None = None,
+    holoindex_receipt_override: HoloIndexFreshnessReceipt | Mapping[str, Any] | None = None,
+    audit_lanes: Sequence[str] = DEFAULT_AUDIT_LANES,
+    enqueue_writer: ReadOnlyAuditTaskWriter | None = None,
+    report_store: ReadOnlyAuditReportStore | None = None,
+    decision_store: ReadOnlyAuditDecisionStore | None = None,
+    architect_model_runner: ArchitectModelRunner | None = None,
+    architect_determination_store: ArchitectDeterminationStore | None = None,
+    audit_model_runner: RepoAuditModelRunner | None = None,
+    holoindex_adapter: ReadOnlyEvidenceQueryAdapter | None = None,
+    codeindex_adapter: ReadOnlyEvidenceQueryAdapter | None = None,
+    external_research_retriever: ExternalResearchRetriever | None = None,
+    task_executor: ReadOnlyAuditTaskExecutor | None = None,
+    timeout_seconds: int = 60,
+) -> RedDogReadonlyAuditResearchDecisionE2EResult:
+    """Run one explicit read-only audit -> research -> decision cycle."""
+
+    root = Path(repo_root).resolve()
+    report_writer = report_store if report_store is not None else AgentDbReadOnlyAuditReportStore()
+    delegate_writer = enqueue_writer if enqueue_writer is not None else AgentDbReadOnlyAuditTaskWriter()
+    capture_writer = _CapturingReadOnlyAuditTaskWriter(delegate_writer)
+    executor = task_executor if task_executor is not None else DirectReadOnlyAuditTaskExecutor()
+
+    initial = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=root,
+        work_state_path=work_state_path,
+        holoindex_receipt_path=holoindex_receipt_path,
+        holoindex_ssd_path=holoindex_ssd_path,
+        changed_paths=changed_paths,
+        allowed_read_targets=allowed_read_targets,
+        requested_operation=requested_operation,
+        prompt_text=prompt_text,
+        now_iso=now_iso,
+        repo_state_override=repo_state_override,
+        work_state_snapshot_override=work_state_snapshot_override,
+        holoindex_receipt_override=holoindex_receipt_override,
+        audit_lanes=audit_lanes,
+        enqueue_readonly_audit_tasks=True,
+        enqueue_writer=capture_writer,
+    )
+    if not initial.ready or initial.status != REDDOG_MAIN_BOOTSTRAP_READY:
+        return _result(
+            accepted=False,
+            initial=initial,
+            final=None,
+            task_runs=(),
+            architect_result=None,
+            reasons=(ReadOnlyAuditResearchDecisionE2EReason.BOOTSTRAP_REJECTED, *initial.rejection_reasons),
+        )
+    if initial.enqueue_decision is None or initial.enqueue_rejection_reasons:
+        return _result(
+            accepted=False,
+            initial=initial,
+            final=None,
+            task_runs=(),
+            architect_result=None,
+            reasons=(
+                ReadOnlyAuditResearchDecisionE2EReason.ENQUEUE_NOT_ACCEPTED,
+                *initial.enqueue_rejection_reasons,
+            ),
+        )
+    if not capture_writer.tasks:
+        return _result(
+            accepted=False,
+            initial=initial,
+            final=None,
+            task_runs=(),
+            architect_result=None,
+            reasons=(ReadOnlyAuditResearchDecisionE2EReason.NO_CAPTURED_TASKS,),
+        )
+
+    task_runs: list[ReadOnlyAuditTaskRunRecord] = []
+    for task in capture_writer.tasks:
+        run_result = executor.execute_readonly_audit_task(
+            task=task,
+            repo_root=root,
+            model_runner=audit_model_runner,
+            holoindex_adapter=holoindex_adapter,
+            codeindex_adapter=codeindex_adapter,
+            external_research_retriever=external_research_retriever,
+            timeout_seconds=timeout_seconds,
+        )
+        persist_result: ReadOnlyAuditReportPersistResult | None = None
+        if run_result.accepted:
+            persist_result = persist_reddog_readonly_audit_task_report(
+                task_id=task.task_id,
+                task_context=task.context,
+                task_result={
+                    "ok": True,
+                    "executor": "reddog:readonly_audit",
+                    "structured_result": run_result.to_dict(),
+                },
+                store=report_writer,
+            )
+        record = _task_record(task=task, run_result=run_result, persist_result=persist_result)
+        task_runs.append(record)
+        if not run_result.accepted:
+            return _result(
+                accepted=False,
+                initial=initial,
+                final=None,
+                task_runs=tuple(task_runs),
+                architect_result=None,
+                reasons=(
+                    ReadOnlyAuditResearchDecisionE2EReason.TASK_EXECUTION_REJECTED,
+                    *run_result.rejection_reasons,
+                ),
+            )
+        if persist_result is None or not persist_result.accepted:
+            return _result(
+                accepted=False,
+                initial=initial,
+                final=None,
+                task_runs=tuple(task_runs),
+                architect_result=None,
+                reasons=(
+                    ReadOnlyAuditResearchDecisionE2EReason.REPORT_PERSIST_REJECTED,
+                    *(persist_result.rejection_reasons if persist_result else ()),
+                ),
+            )
+
+    final = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=root,
+        work_state_path=work_state_path,
+        holoindex_receipt_path=holoindex_receipt_path,
+        holoindex_ssd_path=holoindex_ssd_path,
+        changed_paths=changed_paths,
+        allowed_read_targets=allowed_read_targets,
+        requested_operation=requested_operation,
+        prompt_text=prompt_text,
+        now_iso=now_iso,
+        repo_state_override=repo_state_override,
+        work_state_snapshot_override=work_state_snapshot_override,
+        holoindex_receipt_override=holoindex_receipt_override,
+        audit_lanes=audit_lanes,
+        collect_readonly_audit_reports=True,
+        report_store=report_writer,
+        persist_readonly_audit_decision=True,
+        decision_store=decision_store,
+        run_backend_architect_determination=True,
+        architect_model_runner=architect_model_runner,
+        architect_determination_store=architect_determination_store,
+    )
+    if final.swarm_id != initial.swarm_id:
+        return _result(
+            accepted=False,
+            initial=initial,
+            final=final,
+            task_runs=tuple(task_runs),
+            architect_result=None,
+            reasons=(ReadOnlyAuditResearchDecisionE2EReason.FINAL_SWARM_MISMATCH,),
+        )
+    if not final.ready:
+        return _result(
+            accepted=False,
+            initial=initial,
+            final=final,
+            task_runs=tuple(task_runs),
+            architect_result=None,
+            reasons=(ReadOnlyAuditResearchDecisionE2EReason.FINAL_BOOTSTRAP_REJECTED, *final.rejection_reasons),
+        )
+    if not final.backend_architect_determination_attempted or not final.backend_architect_determination_id:
+        return _result(
+            accepted=False,
+            initial=initial,
+            final=final,
+            task_runs=tuple(task_runs),
+            architect_result=None,
+            reasons=(ReadOnlyAuditResearchDecisionE2EReason.ARCHITECT_DETERMINATION_MISSING,),
+        )
+
+    architect_result = None
+    if final.backend_architect_determination_status:
+        # The bootstrap result intentionally exposes only safe summary fields.
+        # Preserve a None architect_result here rather than reloading store state.
+        architect_result = None
+
+    return _result(
+        accepted=True,
+        initial=initial,
+        final=final,
+        task_runs=tuple(task_runs),
+        architect_result=architect_result,
+        reasons=(),
+    )
+
+
+def _task_record(
+    *,
+    task: ReadOnlyAuditTaskSpec,
+    run_result: ReadOnlyAuditTaskExecutionResult,
+    persist_result: ReadOnlyAuditReportPersistResult | None,
+) -> ReadOnlyAuditTaskRunRecord:
+    assignment = task.context.get("assignment") if isinstance(task.context, Mapping) else {}
+    report = run_result.report if isinstance(run_result.report, Mapping) else {}
+    return ReadOnlyAuditTaskRunRecord(
+        task_id=task.task_id,
+        assignment_id=str(assignment.get("assignment_id") or ""),
+        lane_id=str(assignment.get("lane_id") or ""),
+        accepted=run_result.accepted,
+        report_digest=str(report.get("report_digest") or "").strip() or None,
+        persist_accepted=bool(persist_result and persist_result.accepted),
+        rejection_reasons=run_result.rejection_reasons,
+        persist_rejection_reasons=persist_result.rejection_reasons if persist_result else (),
+    )
+
+
+def _result(
+    *,
+    accepted: bool,
+    initial: RedDogMainReadonlyBootstrapResult,
+    final: RedDogMainReadonlyBootstrapResult | None,
+    task_runs: Sequence[ReadOnlyAuditTaskRunRecord],
+    architect_result: BackendArchitectDeterminationResult | None,
+    reasons: Sequence[str],
+) -> RedDogReadonlyAuditResearchDecisionE2EResult:
+    return RedDogReadonlyAuditResearchDecisionE2EResult(
+        accepted=accepted,
+        status=(
+            READONLY_AUDIT_RESEARCH_DECISION_E2E_ACCEPT
+            if accepted
+            else READONLY_AUDIT_RESEARCH_DECISION_E2E_REJECT
+        ),
+        initial_bootstrap=initial,
+        final_bootstrap=final,
+        task_runs=tuple(task_runs),
+        architect_result=architect_result,
+        rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons if str(reason).strip())),
+        readonly_audit_tasks_enqueued=initial.enqueue_task_count > 0,
+        readonly_audit_tasks_executed=bool(task_runs) and all(item.accepted for item in task_runs),
+    )
+
+
+__all__ = [
+    "READONLY_AUDIT_RESEARCH_DECISION_E2E_ACCEPT",
+    "READONLY_AUDIT_RESEARCH_DECISION_E2E_REJECT",
+    "DirectReadOnlyAuditTaskExecutor",
+    "ReadOnlyAuditResearchDecisionE2EReason",
+    "ReadOnlyAuditTaskExecutor",
+    "ReadOnlyAuditTaskRunRecord",
+    "RedDogReadonlyAuditResearchDecisionE2EResult",
+    "run_reddog_readonly_audit_research_decision_e2e",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_backend_architect_determination_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_backend_architect_determination_runtime.py
@@ -125,6 +125,7 @@ def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
         repo_head_sha=HEAD,
         ssd_path="E:/HoloIndex",
         source="ci_targeted_reindex",
+        generation_id="sha256:holo-generation",
         collections=[
             CollectionFreshness(
                 name="navigation_work_ledger",
@@ -133,6 +134,9 @@ def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
                 source="ci_targeted_reindex",
                 repo_head_sha=HEAD,
                 last_indexed_at=NOW,
+                source_manifest_digest="sha256:work-ledger-manifest",
+                indexed_paths_digest="sha256:work-ledger-paths",
+                verification="PASS",
             ),
             CollectionFreshness(
                 name="navigation_symbols",
@@ -141,6 +145,9 @@ def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
                 source="ci_targeted_reindex",
                 repo_head_sha=HEAD,
                 last_indexed_at=NOW,
+                source_manifest_digest="sha256:symbols-manifest",
+                indexed_paths_digest="sha256:symbols-paths",
+                verification="PASS",
             ),
         ],
     )

--- a/modules/communication/moltbot_bridge/tests/test_reddog_context_snapshot_fusion_assignment_gate.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_context_snapshot_fusion_assignment_gate.py
@@ -40,6 +40,7 @@ def _fresh_holo_receipt():
         repo_head_sha=HEAD,
         ssd_path="E:/HoloIndex",
         source="ci_targeted_reindex",
+        generation_id="sha256:holo-generation",
         collections=[
             CollectionFreshness(
                 name="navigation_work_ledger",
@@ -48,7 +49,21 @@ def _fresh_holo_receipt():
                 source="ci_targeted_reindex",
                 repo_head_sha=HEAD,
                 last_indexed_at=NOW,
-            )
+                source_manifest_digest="sha256:work-ledger-manifest",
+                indexed_paths_digest="sha256:work-ledger-paths",
+                verification="PASS",
+            ),
+            CollectionFreshness(
+                name="navigation_symbols",
+                count=3,
+                status="indexed",
+                source="ci_targeted_reindex",
+                repo_head_sha=HEAD,
+                last_indexed_at=NOW,
+                source_manifest_digest="sha256:symbols-manifest",
+                indexed_paths_digest="sha256:symbols-paths",
+                verification="PASS",
+            ),
         ],
     )
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_research_decision_e2e_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_research_decision_e2e_runtime.py
@@ -1,0 +1,387 @@
+"""Tests for REDDOG_READONLY_AUDIT_RESEARCH_DECISION_E2E_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from holo_index.freshness_receipt import CollectionFreshness, HoloIndexFreshnessReceipt
+from modules.communication.moltbot_bridge.src.reddog_backend_architect_determination_runtime import (
+    ARCHITECT_DETERMINATION_ACCEPT,
+    ArchitectModelResult,
+    InMemoryArchitectDeterminationStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_main_readonly_operational_bootstrap import (
+    DEFAULT_BOOTSTRAP_READ_TARGETS,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
+    READONLY_AUDIT_TASK_SOURCE,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_0102_audit_worker_runtime import (
+    RepoAuditModelResult,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_decision_persistence import (
+    READONLY_AUDIT_DECISION_PERSIST_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_research_decision_e2e_runtime import (
+    READONLY_AUDIT_RESEARCH_DECISION_E2E_ACCEPT,
+    READONLY_AUDIT_RESEARCH_DECISION_E2E_REJECT,
+    DirectReadOnlyAuditTaskExecutor,
+    ReadOnlyAuditResearchDecisionE2EReason,
+    run_reddog_readonly_audit_research_decision_e2e,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_report_collection import (
+    READONLY_AUDIT_REPORT_COLLECTION_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_task_executor import (
+    READONLY_AUDIT_TASK_REPORT_REJECT,
+    ReadOnlyAuditTaskExecutionResult,
+    ReadOnlyAuditTaskRejectReason,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_readonly_audit_research_decision_e2e_runtime.py"
+)
+NOW = "2026-07-16T00:00:00+00:00"
+HEAD = "da7bb6d20"
+REVISION = "sha256:e2e-work-state"
+
+
+def _repo_state() -> dict[str, object]:
+    return {
+        "head_sha": HEAD,
+        "dirty_paths": (),
+        "dirty_digest": "sha256:clean",
+        "worktree_digest": "sha256:worktrees",
+    }
+
+
+def _work_state() -> dict[str, object]:
+    return {
+        "schema_version": "reddog_authoritative_work_state.v1",
+        "revision": REVISION,
+        "selected_slice": "REDDOG_READONLY_AUDIT_RESEARCH_DECISION_E2E_PHASE1",
+        "refresh_receipt_id": "sha256:refresh",
+        "worker_claims": [
+            {
+                "claim_id": "claim-e2e",
+                "slice_id": "REDDOG_READONLY_AUDIT_RESEARCH_DECISION_E2E_PHASE1",
+            }
+        ],
+        "wre_queue_items": [{"queue_item_id": "queue-e2e", "claim_id": "claim-e2e"}],
+    }
+
+
+def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
+    return HoloIndexFreshnessReceipt(
+        schema_version="holoindex_freshness_receipt.v1",
+        generated_at=NOW,
+        repo_root=str(REPO_ROOT),
+        repo_head_sha=HEAD,
+        ssd_path="E:/HoloIndex",
+        source="ci_targeted_reindex",
+        generation_id="sha256:holo-generation-e2e",
+        collections=[
+            CollectionFreshness(
+                name="navigation_work_ledger",
+                count=4,
+                status="indexed",
+                source="ci_targeted_reindex",
+                repo_head_sha=HEAD,
+                last_indexed_at=NOW,
+                source_manifest_digest="sha256:work-ledger-manifest",
+                indexed_paths_digest="sha256:work-ledger-paths",
+                verification="PASS",
+            ),
+            CollectionFreshness(
+                name="navigation_symbols",
+                count=9,
+                status="indexed",
+                source="ci_targeted_reindex",
+                repo_head_sha=HEAD,
+                last_indexed_at=NOW,
+                source_manifest_digest="sha256:symbols-manifest",
+                indexed_paths_digest="sha256:symbols-paths",
+                verification="PASS",
+            ),
+        ],
+    )
+
+
+class _AcceptingTaskWriter:
+    def __init__(self) -> None:
+        self.tasks = []
+
+    def enqueue_readonly_audit_tasks(self, tasks, receipt):
+        self.tasks.append((tuple(tasks), receipt))
+        return {"ok": True, "created_task_ids": [task.task_id for task in tasks]}
+
+
+class _InMemoryReportStore:
+    def __init__(self, *, reject_store: bool = False) -> None:
+        self.reject_store = reject_store
+        self.records = []
+        self.load_calls = []
+
+    def store_readonly_audit_report(self, record):
+        if self.reject_store:
+            return {"ok": False, "reason": "forced_reject"}
+        self.records.append(record)
+        return {"ok": True, "stored": True}
+
+    def load_readonly_audit_reports(self, swarm_id: str):
+        self.load_calls.append(swarm_id)
+        return tuple(record.report for record in self.records if record.swarm_id == swarm_id)
+
+
+class _InMemoryDecisionStore:
+    def __init__(self) -> None:
+        self.records = []
+
+    def store_readonly_audit_decision(self, record):
+        self.records.append(record)
+        return {"ok": True, "stored": True, "idempotent": False}
+
+    def load_latest_readonly_audit_decision(self):
+        return None
+
+    def load_readonly_audit_decision(self, decision_id: str):
+        return None
+
+
+class _FakeQueryAdapter:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def query(self, *, query: str, allowed_paths, limit: int):
+        self.calls.append({"query": query, "allowed_paths": tuple(allowed_paths), "limit": limit})
+        path = allowed_paths[0] if allowed_paths else DEFAULT_BOOTSTRAP_READ_TARGETS[0]
+        return {
+            "ok": True,
+            "source": "fake",
+            "query": query,
+            "freshness": "FRESH",
+            "hits": [{"path": path, "title": "fake hit", "score": 0.99, "digest": "sha256:index-hit"}],
+            "error": "",
+            "freshness_generation_id": "sha256:holo-generation-e2e",
+            "freshness_receipt_digest": "sha256:holo-receipt-e2e",
+            "freshness_receipt_path": "E:/HoloIndex/indexes/holoindex_freshness_receipt.json",
+            "repo_head_sha": HEAD,
+        }
+
+
+class _AuditModelRunner:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def run_repo_code_audit(self, *, prompt: str, context: str, binding, timeout_seconds: int):
+        self.calls.append({"prompt": prompt, "context": context, "binding": dict(binding)})
+        parsed_context = json.loads(context)
+        parsed_prompt = json.loads(prompt)
+        evidence_ref = parsed_context["untrusted_repository_evidence"][0]["evidence_ref"]
+        lane_id = parsed_prompt["assignment"]["lane_id"]
+        output = {
+            "summary": f"{lane_id} verified current evidence and found one actionable runtime gap.",
+            "evidence_refs": [evidence_ref],
+            "findings": [
+                {
+                    "finding_id": f"{lane_id}:runtime-gap",
+                    "claim": f"{lane_id} supports continuing with the resident RedDog runtime path.",
+                    "wsp97_label": "OBSERVED",
+                    "recommended_action": "FIX",
+                    "wsp15_priority": "P1",
+                    "severity": "MAJOR",
+                    "evidence_refs": [evidence_ref],
+                    "next_slice_name": "REDDOG_RESIDENT_RUNTIME_NEXT_PHASE1",
+                }
+            ],
+        }
+        return RepoAuditModelResult(
+            ok=True,
+            status="MODEL_OK",
+            content=json.dumps(output, sort_keys=True),
+            model_receipt_id=f"model-receipt-{lane_id}",
+            model_result_digest=f"sha256:model-result-{lane_id}",
+            made_network_call=True,
+        )
+
+
+class _ArchitectRunner:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def run_architect_determination(self, *, prompt: str, context: str, binding, timeout_seconds: int):
+        self.calls.append({"prompt": prompt, "context": context, "binding": dict(binding)})
+        parsed = json.loads(prompt)
+        evidence_ref = parsed["reports"][0]["evidence_refs"][0]
+        content = {
+            "action": "FIX",
+            "next_slice_name": "REDDOG_RESIDENT_RUNTIME_NEXT_PHASE1",
+            "summary": "All read-only audit reports support one next resident runtime slice.",
+            "decision_reasons": ["selected highest priority verified read-only audit finding"],
+            "evidence_refs": [evidence_ref],
+            "wsp15_allocation_receipt_id": parsed["wsp15_allocation_receipt_id"],
+        }
+        return ArchitectModelResult(
+            ok=True,
+            status="MODEL_OK",
+            content=json.dumps(content, sort_keys=True),
+            model_receipt_id="architect-model-receipt-e2e",
+            model_result_digest="sha256:architect-model-result-e2e",
+            review_packet={"fusion_panel_quorum": {"passed": True}},
+            made_network_call=True,
+            rejection_reasons=(),
+        )
+
+
+class _RejectingTaskExecutor:
+    def execute_readonly_audit_task(self, **kwargs):
+        return ReadOnlyAuditTaskExecutionResult(
+            accepted=False,
+            decision=READONLY_AUDIT_TASK_REPORT_REJECT,
+            report=None,
+            evidence=(),
+            rejection_reasons=(ReadOnlyAuditTaskRejectReason.MODEL_FAILURE,),
+        )
+
+
+def test_e2e_runs_enqueued_readonly_tasks_persists_reports_and_architect_decides() -> None:
+    writer = _AcceptingTaskWriter()
+    report_store = _InMemoryReportStore()
+    decision_store = _InMemoryDecisionStore()
+    architect_store = InMemoryArchitectDeterminationStore()
+    audit_runner = _AuditModelRunner()
+    architect_runner = _ArchitectRunner()
+
+    result = run_reddog_readonly_audit_research_decision_e2e(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+        enqueue_writer=writer,
+        report_store=report_store,
+        decision_store=decision_store,
+        architect_determination_store=architect_store,
+        audit_model_runner=audit_runner,
+        architect_model_runner=architect_runner,
+        holoindex_adapter=_FakeQueryAdapter(),
+        codeindex_adapter=_FakeQueryAdapter(),
+    )
+
+    assert result.accepted is True
+    assert result.status == READONLY_AUDIT_RESEARCH_DECISION_E2E_ACCEPT
+    assert result.initial_bootstrap.enqueue_task_count == 5
+    assert result.initial_bootstrap.report_collection_attempted is False
+    assert result.final_bootstrap is not None
+    assert result.final_bootstrap.report_collection_status == READONLY_AUDIT_REPORT_COLLECTION_ACCEPT
+    assert result.final_bootstrap.report_collection_report_count == 5
+    assert result.final_bootstrap.readonly_audit_decision_persist_status == READONLY_AUDIT_DECISION_PERSIST_ACCEPT
+    assert result.final_bootstrap.backend_architect_determination_status == ARCHITECT_DETERMINATION_ACCEPT
+    assert result.final_bootstrap.backend_architect_determination_queue_candidate_count == 1
+    assert len(result.task_runs) == 5
+    assert all(item.accepted and item.persist_accepted for item in result.task_runs)
+    assert len(report_store.records) == 5
+    assert len(decision_store.records) == 1
+    assert len(architect_store.records) == 1
+    assert len(audit_runner.calls) == 5
+    assert len(architect_runner.calls) == 1
+    assert result.readonly_audit_tasks_enqueued is True
+    assert result.readonly_audit_tasks_executed is True
+    assert result.coding_worker_spawned is False
+    assert result.no_repo_mutation_performed is True
+    assert result.no_holoindex_reindex_performed is True
+    assert result.no_live_foundup_enqueue_performed is True
+
+
+def test_e2e_fails_closed_before_report_collection_when_task_execution_rejects() -> None:
+    result = run_reddog_readonly_audit_research_decision_e2e(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+        enqueue_writer=_AcceptingTaskWriter(),
+        report_store=_InMemoryReportStore(),
+        task_executor=_RejectingTaskExecutor(),
+    )
+
+    assert result.accepted is False
+    assert result.status == READONLY_AUDIT_RESEARCH_DECISION_E2E_REJECT
+    assert ReadOnlyAuditResearchDecisionE2EReason.TASK_EXECUTION_REJECTED in result.rejection_reasons
+    assert ReadOnlyAuditTaskRejectReason.MODEL_FAILURE in result.rejection_reasons
+    assert result.final_bootstrap is None
+    assert len(result.task_runs) == 1
+    assert result.task_runs[0].accepted is False
+
+
+def test_e2e_fails_closed_when_report_persistence_rejects() -> None:
+    result = run_reddog_readonly_audit_research_decision_e2e(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+        enqueue_writer=_AcceptingTaskWriter(),
+        report_store=_InMemoryReportStore(reject_store=True),
+        audit_model_runner=_AuditModelRunner(),
+        holoindex_adapter=_FakeQueryAdapter(),
+        codeindex_adapter=_FakeQueryAdapter(),
+    )
+
+    assert result.accepted is False
+    assert ReadOnlyAuditResearchDecisionE2EReason.REPORT_PERSIST_REJECTED in result.rejection_reasons
+    assert result.final_bootstrap is None
+    assert len(result.task_runs) == 1
+    assert result.task_runs[0].accepted is True
+    assert result.task_runs[0].persist_accepted is False
+
+
+def test_e2e_module_has_no_shell_worktree_repo_mutation_or_reindex_imports() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    forbidden_text = (
+        "subprocess",
+        "requests",
+        "httpx",
+        "socket",
+        "git push",
+        "gh pr",
+        "holo_index.py --index",
+        "hermes_job_executor",
+    )
+    for token in forbidden_text:
+        assert token not in source
+
+    forbidden_calls = {
+        "write_text",
+        "open",
+        "mkdir",
+        "unlink",
+        "rmdir",
+        "remove",
+        "system",
+        "popen",
+        "run",
+        "call",
+        "check_call",
+        "check_output",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".")[0] not in {"subprocess", "requests", "httpx", "socket"}
+        elif isinstance(node, ast.ImportFrom):
+            assert (node.module or "").split(".")[0] not in {"subprocess", "requests", "httpx", "socket"}
+        elif isinstance(node, ast.Call):
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else func.id if isinstance(func, ast.Name) else ""
+            assert name not in forbidden_calls


### PR DESCRIPTION
## Summary

Implements `REDDOG_READONLY_AUDIT_RESEARCH_DECISION_E2E_PHASE1` as an explicit resident read-only runtime cycle:

- bootstrap operational snapshot and read-only audit swarm plan
- enqueue the five default read-only audit lane tasks through the existing enqueue seam
- execute each read-only audit task with injected/read-only model and index adapters
- persist reports through the existing report collection store
- collect and validate the report bundle
- run backend architect determination and emit at most one queue candidate

Also fixes a runtime context-budget issue exposed by the E2E test: model-backed read-only audit workers now pack repository evidence into bounded per-target excerpts while preserving file evidence refs and digests.

## WSP_97 Truth Boundary

OBSERVED:
- The new E2E runtime composes existing runtime modules instead of duplicating validation rules.
- It fails closed on task execution rejection and report persistence rejection before final architect determination.
- It performs no shell execution, repository mutation, worktree operation, Hermes dispatch, live FoundUp enqueue, PR creation, PatternMemory promotion, or HoloIndex re-index.
- Stale HoloIndex freshness test fixtures are updated to current generation/manifest verification semantics.

SPECIFIED_NOT_IMPLEMENTED:
- Coding worker execution remains unimplemented here.
- Live enqueue/runtime mutation remains blocked.
- External production retriever/network policy is not added in this slice.

## Validation

Focused gate:

```text
pytest modules/communication/moltbot_bridge/tests/test_reddog_context_snapshot_fusion_assignment_gate.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_backend_architect_determination_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_report_collection.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_research_decision_e2e_runtime.py
=> 93 passed
```

Hygiene:

```text
git diff --cached --check
=> clean, CRLF warnings only
new files ASCII-clean
```

Non-gating broad-suite note:

```text
pytest modules/communication/moltbot_bridge/tests
=> not usable as this slice gate; unrelated OpenClaw/PFmall/ROC suites cascade into pytest capture teardown errors: ValueError: I/O operation on closed file.
```