### PR TITLE
feat(reddog): run readonly E2E runtime from main preflight

### DIFF
--- a/main.py
+++ b/main.py
@@ -1193,6 +1193,8 @@ def run_reddog_readonly_operational_bootstrap_preflight(repo_root: Path) -> bool
         REDDOG_READONLY_AUDIT_REPORT_COLLECTION_ENABLED   Override audit report collection bridge
         REDDOG_READONLY_AUDIT_DECISION_PERSIST_ENABLED    Override audit decision persistence bridge
         REDDOG_READONLY_AUDIT_SWARM_ENQUEUE_ENABLED       Override audit task enqueue bridge
+        REDDOG_READONLY_AUDIT_RESEARCH_DECISION_E2E_ENABLED
+                                                            Run one explicit read-only audit/research/decision cycle
         OPENCLAW_AUTO_TASKS_ENABLED                       Enables audit task enqueue if no override
         REDDOG_AUTHORITATIVE_WORK_STATE_PATH              Existing work-state JSON
         HOLOINDEX_FRESHNESS_RECEIPT                       Existing HoloIndex receipt
@@ -1219,6 +1221,65 @@ def run_reddog_readonly_operational_bootstrap_preflight(repo_root: Path) -> bool
         decision_persist_requested = os.getenv("OPENCLAW_AUTO_TASKS_ENABLED", "0") != "0"
     else:
         decision_persist_requested = decision_persist_override != "0"
+    e2e_requested = os.getenv("REDDOG_READONLY_AUDIT_RESEARCH_DECISION_E2E_ENABLED", "0") != "0"
+
+    if e2e_requested:
+        try:
+            from modules.communication.moltbot_bridge.src.reddog_readonly_audit_research_decision_e2e_runtime import (
+                run_reddog_readonly_audit_research_decision_e2e,
+            )
+
+            e2e_result = run_reddog_readonly_audit_research_decision_e2e(
+                repo_root=repo_root,
+                work_state_path=os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
+                holoindex_receipt_path=os.getenv("HOLOINDEX_FRESHNESS_RECEIPT", ""),
+                holoindex_ssd_path=os.getenv("HOLOINDEX_SSD_PATH", ""),
+            )
+        except Exception as exc:
+            logger.error(f"[REDDOG-BOOTSTRAP-E2E] Startup runtime failed: {exc}")
+            if enforced:
+                print(f"[REDDOG-BOOTSTRAP-E2E] preflight=FAIL error={type(exc).__name__}")
+                return False
+            print(f"[REDDOG-BOOTSTRAP-E2E] preflight=WARN error={type(exc).__name__}")
+            return True
+
+        e2e_status = "PASS" if e2e_result.accepted else "WARN"
+        e2e_reasons = ",".join(e2e_result.rejection_reasons) if e2e_result.rejection_reasons else "(none)"
+        final_bootstrap = e2e_result.final_bootstrap
+        reports_persisted = sum(1 for task in e2e_result.task_runs if task.persist_accepted)
+        print(
+            f"[REDDOG-BOOTSTRAP-E2E] preflight={e2e_status} status={e2e_result.status} "
+            f"accepted={e2e_result.accepted} initial_status={e2e_result.initial_bootstrap.status} "
+            f"final_status={final_bootstrap.status if final_bootstrap else '(none)'} "
+            f"tasks={len(e2e_result.task_runs)} reports_persisted={reports_persisted} "
+            f"tasks_enqueued={e2e_result.readonly_audit_tasks_enqueued} "
+            f"tasks_executed={e2e_result.readonly_audit_tasks_executed} "
+            f"architect_action={(final_bootstrap.backend_architect_determination_action if final_bootstrap else None) or '(none)'} "
+            f"architect_next_slice={(final_bootstrap.backend_architect_determination_next_slice if final_bootstrap else None) or '(none)'} "
+            f"queue_candidates={(final_bootstrap.backend_architect_determination_queue_candidate_count if final_bootstrap else 0)} "
+            f"reasons={e2e_reasons}"
+        )
+        print(
+            "[REDDOG-BOOTSTRAP-E2E] "
+            f"no_shell={e2e_result.no_shell_command_executed} "
+            f"no_repo_mutation={e2e_result.no_repo_mutation_performed} "
+            f"no_holoindex_reindex={e2e_result.no_holoindex_reindex_performed} "
+            f"no_hermes_dispatch={e2e_result.no_hermes_dispatch_performed} "
+            f"no_worktree={e2e_result.no_worktree_operation_performed} "
+            f"no_pr={e2e_result.no_pr_created} "
+            f"no_pattern_memory={e2e_result.no_pattern_memory_promotion_performed} "
+            f"no_live_foundup_enqueue={e2e_result.no_live_foundup_enqueue_performed} "
+            f"coding_worker_spawned={e2e_result.coding_worker_spawned}"
+        )
+        if e2e_result.accepted:
+            return True
+        if enforced:
+            print(
+                "[REDDOG-BOOTSTRAP-E2E] Startup blocked by "
+                "REDDOG_READONLY_OPERATIONAL_BOOTSTRAP_ENFORCED=1"
+            )
+            return False
+        return True
 
     try:
         from modules.communication.moltbot_bridge.src.reddog_main_readonly_operational_bootstrap import (

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,20 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_MAIN_READONLY_E2E_RUNTIME_CONSUMPTION_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 22, 50, 97
+
+- Added an explicit `main.py` startup flag,
+  `REDDOG_READONLY_AUDIT_RESEARCH_DECISION_E2E_ENABLED`, that runs one
+  read-only audit -> research -> backend architect determination cycle through
+  the #1115 E2E runtime.
+- Kept the existing bootstrap/menu behavior unchanged by default. Rejected E2E
+  runs remain warning-only unless
+  `REDDOG_READONLY_OPERATIONAL_BOOTSTRAP_ENFORCED=1`.
+- Startup output now reports E2E task count, persisted report count,
+  architect action/next slice, queue-candidate count, and the no-mutation
+  attestation fields needed to verify this is not a coding worker path.
+
 ## 2026-07-16: REDDOG_READONLY_AUDIT_RESEARCH_DECISION_E2E_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 22, 50, 97

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from holo_index.freshness_receipt import CollectionFreshness, HoloIndexFreshnessReceipt
@@ -696,6 +697,117 @@ def test_main_preflight_reports_ready_without_blocking_menu(capsys) -> None:
     assert "decision_action=FIX" in output
     assert "decision_next_slice=REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1" in output
     assert "decision_persist_attempted=False" in output
+
+
+def _e2e_result(*, accepted: bool = True):
+    final_bootstrap = SimpleNamespace(
+        status=REDDOG_MAIN_BOOTSTRAP_READY if accepted else REDDOG_MAIN_BOOTSTRAP_NOT_READY,
+        backend_architect_determination_action=ACTION_FIX if accepted else None,
+        backend_architect_determination_next_slice="REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1" if accepted else None,
+        backend_architect_determination_queue_candidate_count=1 if accepted else 0,
+    )
+    return SimpleNamespace(
+        accepted=accepted,
+        status="ACCEPT" if accepted else "REJECT",
+        initial_bootstrap=SimpleNamespace(status=REDDOG_MAIN_BOOTSTRAP_READY),
+        final_bootstrap=final_bootstrap if accepted else None,
+        task_runs=(SimpleNamespace(persist_accepted=True),) if accepted else (),
+        rejection_reasons=() if accepted else ("forced_reject",),
+        no_shell_command_executed=True,
+        no_repo_mutation_performed=True,
+        no_holoindex_reindex_performed=True,
+        no_hermes_dispatch_performed=True,
+        no_worktree_operation_performed=True,
+        no_pr_created=True,
+        no_pattern_memory_promotion_performed=True,
+        no_live_foundup_enqueue_performed=True,
+        coding_worker_spawned=False,
+        readonly_audit_tasks_enqueued=accepted,
+        readonly_audit_tasks_executed=accepted,
+    )
+
+
+def test_main_preflight_runs_explicit_readonly_e2e_runtime(capsys) -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_readonly_audit_research_decision_e2e_runtime."
+        "run_reddog_readonly_audit_research_decision_e2e",
+        return_value=_e2e_result(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_READONLY_OPERATIONAL_BOOTSTRAP": "1",
+                "REDDOG_READONLY_AUDIT_RESEARCH_DECISION_E2E_ENABLED": "1",
+                "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": "O:/state/work_state.json",
+                "HOLOINDEX_FRESHNESS_RECEIPT": "O:/state/holo_receipt.json",
+                "HOLOINDEX_SSD_PATH": "E:/HoloIndex",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_readonly_operational_bootstrap_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["repo_root"] == REPO_ROOT
+    assert mocked.call_args.kwargs["work_state_path"] == "O:/state/work_state.json"
+    assert mocked.call_args.kwargs["holoindex_receipt_path"] == "O:/state/holo_receipt.json"
+    output = capsys.readouterr().out
+    assert "[REDDOG-BOOTSTRAP-E2E] preflight=PASS" in output
+    assert "tasks=1" in output
+    assert "reports_persisted=1" in output
+    assert "architect_action=FIX" in output
+    assert "queue_candidates=1" in output
+    assert "no_repo_mutation=True" in output
+    assert "no_holoindex_reindex=True" in output
+    assert "coding_worker_spawned=False" in output
+
+
+def test_main_preflight_e2e_runtime_reject_is_nonblocking_by_default(capsys) -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_readonly_audit_research_decision_e2e_runtime."
+        "run_reddog_readonly_audit_research_decision_e2e",
+        return_value=_e2e_result(accepted=False),
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_READONLY_OPERATIONAL_BOOTSTRAP": "1",
+                "REDDOG_READONLY_AUDIT_RESEARCH_DECISION_E2E_ENABLED": "1",
+                "REDDOG_READONLY_OPERATIONAL_BOOTSTRAP_ENFORCED": "0",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_readonly_operational_bootstrap_preflight(REPO_ROOT) is True
+
+    output = capsys.readouterr().out
+    assert "[REDDOG-BOOTSTRAP-E2E] preflight=WARN" in output
+    assert "reasons=forced_reject" in output
+
+
+def test_main_preflight_e2e_runtime_reject_blocks_when_enforced(capsys) -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_readonly_audit_research_decision_e2e_runtime."
+        "run_reddog_readonly_audit_research_decision_e2e",
+        return_value=_e2e_result(accepted=False),
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_READONLY_OPERATIONAL_BOOTSTRAP": "1",
+                "REDDOG_READONLY_AUDIT_RESEARCH_DECISION_E2E_ENABLED": "1",
+                "REDDOG_READONLY_OPERATIONAL_BOOTSTRAP_ENFORCED": "1",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_readonly_operational_bootstrap_preflight(REPO_ROOT) is False
+
+    output = capsys.readouterr().out
+    assert "[REDDOG-BOOTSTRAP-E2E] preflight=WARN" in output
+    assert "Startup blocked by REDDOG_READONLY_OPERATIONAL_BOOTSTRAP_ENFORCED=1" in output
 
 
 def test_main_preflight_enables_enqueue_when_openclaw_auto_tasks_enabled() -> None:


### PR DESCRIPTION
## Summary
- add explicit REDDOG_READONLY_AUDIT_RESEARCH_DECISION_E2E_ENABLED startup path in main.py
- run the existing #1115 read-only audit -> research -> backend architect determination cycle only when opted in
- print task/report/architect decision/queue-candidate status plus no-mutation attestations
- keep default bootstrap/menu behavior unchanged and keep rejection warning-only unless REDDOG_READONLY_OPERATIONAL_BOOTSTRAP_ENFORCED=1

## Validation
- pytest modules/communication/moltbot_bridge/tests/test_reddog_context_snapshot_fusion_assignment_gate.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_authoritative_work_state_refresh_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_backend_architect_determination_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_report_collection.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_decision_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_decision_persistence.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_research_decision_e2e_runtime.py -> 121 passed
- git diff --check
- python -m py_compile main.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py

## Boundary
- no coding worker
- no shell/worktree/repo mutation
- no Hermes/live FoundUp enqueue
- no PR creation
- no PatternMemory promotion
- no HoloIndex re-index
