### PR TITLE
feat(reddog): bridge extension to resident architect session

### DIFF
--- a/extensions/foundups_advisory_workers/ModLog.md
+++ b/extensions/foundups_advisory_workers/ModLog.md
@@ -2,6 +2,13 @@
 
 # ModLog - Foundups®Agent Extension
 
+## 2026-07-16 - REDDOG_EXTENSION_TO_RESIDENT_ARCHITECT_SESSION_RUNTIME_PHASE1 (resident backend session bridge, 0.3.68)
+
+- Added `scripts/reddog_resident_architect_session_once.py`, a JSON-in/JSON-out bridge that delegates to the resident read-only audit/research/backend-architect E2E runtime.
+- Added `foundupsFusion.enableResidentArchitectSession` (default false). When enabled and local runtime-consumption gates pass, the extension calls the resident backend and attaches snapshot/swarm/task/report/architect-decision telemetry to the review packet and Copy MD.
+- Boundary remains read-only: no shell, repo mutation, HoloIndex re-index, Hermes dispatch, worktree operation, PR creation, PatternMemory promotion, or live FoundUp enqueue.
+- Version 0.3.67 -> 0.3.68 (package.json + EXTENSION_VERSION + README + contract-test assertions).
+
 ## 2026-07-14 - REDDOG_EXTENSION_TO_OPENCLAW_LIVE_ENQUEUE_RUNTIME_BINDING_PHASE1 (guarded live-enqueue binding, 0.3.67)
 
 - Added a guarded extension runtime binding for `live_enqueue` wardrobe-selection receipts after grounding, fusion quorum, output validation, and runtime-consumption gates pass.

--- a/extensions/foundups_advisory_workers/README.md
+++ b/extensions/foundups_advisory_workers/README.md
@@ -1,6 +1,6 @@
 # Foundups®Agent
 
-Version: 0.3.67
+Version: 0.3.68
 
 This local Cursor/VS Code extension opens one RedDog Architect advisory worker as an editor webview tab, similar in ergonomics to `Claude Code: Open` but without repo, shell, browser, merge, CABR, or payout authority.
 
@@ -66,6 +66,7 @@ The extension is a bounded 0102 advisory surface:
 - Prompt-authoring override (v0.3.65): requests for worker/slice/M2M prompts override the DAEmon/log local diagnostic fast path, so pasted logs can be used as context for governed prompt generation instead of being answered instantly as non-actionable diagnostics.
 - Semantic grounding per-target proof (v0.3.66): semantic targets now require independent content-bearing HoloIndex evidence refs before Fusion or wardrobe selection may proceed. Aggregate `code_hits` / `wsp_hits` no longer satisfy unrelated semantic targets; missing, errored, or ref-less semantic evidence fails closed and is surfaced through `semantic_targets_required`, `semantic_targets_grounded`, `semantic_targets_missing`, and `semantic_target_coverage_digest` telemetry.
 - OpenClaw live-enqueue runtime binding (v0.3.67): after grounding, fusion quorum, output validation, wardrobe selection, and runtime-consumption gates pass, the extension may call the one-shot explicit live-enqueue invoke bridge for `live_enqueue` authority requests. This slice keeps `enableConcreteWriter=false`, so the editor subprocess can prove the guarded path is reachable but cannot perform a durable OpenClaw queue write.
+- Resident architect session bridge (v0.3.68): when `foundupsFusion.enableResidentArchitectSession=true` and local runtime-consumption gates pass, the extension may call the resident read-only RedDog audit -> research -> backend architect determination E2E runtime. The bridge returns snapshot/swarm/task/report/architect decision telemetry plus no-mutation attestations. It does not edit files, re-index HoloIndex, dispatch Hermes, create worktrees, enqueue live FoundUp work, create PRs, merge, or promote PatternMemory.
 
 The extension does not grant repo authority. **012 supplies work focus only**; 0102 assembles a WSP task prompt before the bridge runs. Work focus and bounded repo context are sent through `scripts/advisory_model_once.py`, which runs the landed Fusion redaction gate before making OpenRouter requests. The webview receives only advisory text and redacted local history.
 

--- a/extensions/foundups_advisory_workers/extension.js
+++ b/extensions/foundups_advisory_workers/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.3.67';
+const EXTENSION_VERSION = '0.3.68';
 const UNICODE_SURROGATE_PLACEHOLDER = '[MALFORMED_SURROGATE]';
 const TARGET_READ_BLOCKED_SEGMENTS = ['.git', 'node_modules', '__pycache__', '.venv'];
 const TARGET_READ_BLOCKED_BASENAMES = ['.env'];
@@ -38,11 +38,13 @@ const WRE_OPERATIONAL_SPINE_TARGET = 'reddog_wre_operational_spine';
 const WRE_OPERATIONAL_SPINE_CALL = 'modules/communication/moltbot_bridge/src/reddog_wre_operational_spine.py::run_reddog_wre_worktree_create_spine';
 const WRE_OPERATIONAL_SPINE_INVOKE_SCRIPT = 'scripts/reddog_extension_wre_spine_invoke_once.py';
 const REDDOG_EXTENSION_LIVE_ENQUEUE_INVOKE_SCRIPT = 'scripts/reddog_extension_live_enqueue_invoke_once.py';
+const REDDOG_RESIDENT_ARCHITECT_SESSION_SCRIPT = 'scripts/reddog_resident_architect_session_once.py';
 const REDDOG_OPERATOR_WARDROBE_SELECTION_SCRIPT = 'scripts/reddog_operator_wardrobe_selection_once.py';
 const REDDOG_GITHUB_PERMISSION_PROBE_SCRIPT = 'scripts/reddog_github_permission_probe_once.py';
 const WRE_OPERATIONAL_SPINE_INVOKE_MAX_BYTES = 262144;
 const WRE_OPERATIONAL_SPINE_REQUIRED_VALVE = 'VALVE_OPEN_WORKTREE_CREATE';
 const REDDOG_EXTENSION_OPENCLAW_LIVE_ENQUEUE_RUNTIME_BINDING_SLICE = 'REDDOG_EXTENSION_TO_OPENCLAW_LIVE_ENQUEUE_RUNTIME_BINDING_PHASE1';
+const REDDOG_RESIDENT_ARCHITECT_SESSION_RUNTIME_SLICE = 'REDDOG_EXTENSION_TO_RESIDENT_ARCHITECT_SESSION_RUNTIME_PHASE1';
 const REDDOG_OPENCLAW_LIVE_ENQUEUE_TARGET = 'reddog_openclaw_live_enqueue';
 const TRUSTED_PERMISSION_SNAPSHOT_SOURCES = new Set(['gh_cli', 'github_api', 'mock']);
 const MOJIBAKE_MARKERS = ['\u7aa6', '\u7aaa'];
@@ -3554,6 +3556,147 @@ function buildOpenClawLiveEnqueueRuntimeBindingSection(invokeResult) {
   ].join('\n');
 }
 
+function buildResidentArchitectSessionPayload(workFocus, options) {
+  const opts = options && typeof options === 'object' ? options : {};
+  if (opts.explicitResidentArchitectSessionRequested !== true) {
+    return {
+      ok: false,
+      rejection_reasons: ['explicit_resident_architect_session_request_missing'],
+      payload: null
+    };
+  }
+  return {
+    ok: true,
+    rejection_reasons: [],
+    payload: {
+      explicit_resident_architect_session_requested: true,
+      work_focus: String(workFocus || ''),
+      repo_root: opts.repoRoot ? String(opts.repoRoot) : undefined,
+      work_state_path: opts.workStatePath ? String(opts.workStatePath) : undefined,
+      holoindex_receipt_path: opts.holoindexReceiptPath ? String(opts.holoindexReceiptPath) : undefined,
+      holoindex_ssd_path: opts.holoindexSsdPath ? String(opts.holoindexSsdPath) : undefined,
+      timeout_seconds: Number(opts.timeoutSeconds || 60)
+    }
+  };
+}
+
+function buildResidentArchitectSessionResult(decision, fields) {
+  const payload = fields && typeof fields === 'object' ? fields : {};
+  return Object.assign({
+    slice_name: REDDOG_RESIDENT_ARCHITECT_SESSION_RUNTIME_SLICE,
+    decision: decision,
+    accepted: false,
+    resident_backend_invoked: false,
+    python_invocation_performed: false,
+    snapshot_id: '',
+    final_snapshot_id: '',
+    swarm_id: '',
+    initial_status: '',
+    final_status: '',
+    task_count: 0,
+    reports_persisted: 0,
+    readonly_audit_tasks_enqueued: false,
+    readonly_audit_tasks_executed: false,
+    architect_action: '',
+    architect_next_slice: '',
+    architect_determination_id: '',
+    queue_candidate_count: 0,
+    no_shell_command_executed: true,
+    no_repo_mutation_performed: true,
+    no_holoindex_reindex_performed: true,
+    no_hermes_dispatch_performed: true,
+    no_worktree_operation_performed: true,
+    no_pr_created: true,
+    no_pattern_memory_promotion_performed: true,
+    no_live_foundup_enqueue_performed: true,
+    coding_worker_spawned: false,
+    rejection_reasons: []
+  }, payload);
+}
+
+function runResidentArchitectSessionBridge(context, workFocus, options) {
+  const opts = options && typeof options === 'object' ? options : {};
+  const payloadResult = buildResidentArchitectSessionPayload(workFocus, opts);
+  if (!payloadResult.ok) {
+    return buildResidentArchitectSessionResult('RESIDENT_ARCHITECT_SESSION_SKIPPED', {
+      rejection_reasons: payloadResult.rejection_reasons,
+      not_invoked_reason: payloadResult.rejection_reasons[0] || 'resident_architect_session_not_enabled'
+    });
+  }
+  if (typeof opts.sessionRunner === 'function') {
+    const runnerResult = opts.sessionRunner(payloadResult.payload);
+    const parsed = typeof runnerResult === 'string' ? JSON.parse(runnerResult) : (runnerResult || {});
+    return buildResidentArchitectSessionResult(
+      parsed.decision || 'RESIDENT_ARCHITECT_SESSION_BRIDGE_RESULT',
+      parsed
+    );
+  }
+  const root = workspaceRoot();
+  const script = path.join(root, REDDOG_RESIDENT_ARCHITECT_SESSION_SCRIPT);
+  const config = vscode.workspace.getConfiguration('foundupsFusion');
+  const configuredPython = config.get('pythonPath') || 'python';
+  const interpreter = resolvePythonInterpreter(root, configuredPython);
+  try {
+    const stdout = cp.execFileSync(interpreter.path, ['-B', script], {
+      cwd: root,
+      input: JSON.stringify(payloadResult.payload),
+      encoding: 'utf8',
+      env: buildBridgePythonEnv(process.env),
+      windowsHide: true,
+      maxBuffer: WRE_OPERATIONAL_SPINE_INVOKE_MAX_BYTES
+    });
+    const parsed = JSON.parse(stdout);
+    return buildResidentArchitectSessionResult(
+      parsed.decision || 'RESIDENT_ARCHITECT_SESSION_BRIDGE_RESULT',
+      Object.assign({}, parsed, {
+        python_invocation_performed: true,
+        python_interpreter_source: interpreter.source
+      })
+    );
+  } catch (err) {
+    return buildResidentArchitectSessionResult('RESIDENT_ARCHITECT_SESSION_REJECT', {
+      python_invocation_performed: true,
+      resident_backend_invoked: false,
+      rejection_reasons: ['resident_architect_session_bridge_failed'],
+      bridge_error_class: err && err.code ? String(err.code) : (err && err.name ? String(err.name) : 'Error')
+    });
+  }
+}
+
+function buildResidentArchitectSessionSection(sessionResult) {
+  const r = sessionResult && typeof sessionResult === 'object' ? sessionResult : {};
+  return [
+    '## Resident RedDog Architect Session',
+    '- slice_name: ' + (r.slice_name || REDDOG_RESIDENT_ARCHITECT_SESSION_RUNTIME_SLICE) + ' [OBSERVED]',
+    '- decision: ' + (r.decision || 'unknown') + ' [OBSERVED]',
+    '- accepted: ' + (r.accepted === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- resident_backend_invoked: ' + (r.resident_backend_invoked === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- python_invocation_performed: ' + (r.python_invocation_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- snapshot_id: ' + (r.snapshot_id || 'unknown') + ' [OBSERVED]',
+    '- final_snapshot_id: ' + (r.final_snapshot_id || 'unknown') + ' [OBSERVED]',
+    '- swarm_id: ' + (r.swarm_id || 'unknown') + ' [OBSERVED]',
+    '- initial_status: ' + (r.initial_status || 'unknown') + ' [OBSERVED]',
+    '- final_status: ' + (r.final_status || 'unknown') + ' [OBSERVED]',
+    '- task_count: ' + Number(r.task_count || 0) + ' [OBSERVED]',
+    '- reports_persisted: ' + Number(r.reports_persisted || 0) + ' [OBSERVED]',
+    '- readonly_audit_tasks_enqueued: ' + (r.readonly_audit_tasks_enqueued === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- readonly_audit_tasks_executed: ' + (r.readonly_audit_tasks_executed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- architect_action: ' + (r.architect_action || 'unknown') + ' [OBSERVED]',
+    '- architect_next_slice: ' + (r.architect_next_slice || 'unknown') + ' [OBSERVED]',
+    '- architect_determination_id: ' + (r.architect_determination_id || 'unknown') + ' [OBSERVED]',
+    '- queue_candidate_count: ' + Number(r.queue_candidate_count || 0) + ' [OBSERVED]',
+    '- no_repo_mutation_performed: ' + (r.no_repo_mutation_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- no_holoindex_reindex_performed: ' + (r.no_holoindex_reindex_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- no_hermes_dispatch_performed: ' + (r.no_hermes_dispatch_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- no_worktree_operation_performed: ' + (r.no_worktree_operation_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- no_pr_created: ' + (r.no_pr_created === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- no_live_foundup_enqueue_performed: ' + (r.no_live_foundup_enqueue_performed === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- coding_worker_spawned: ' + (r.coding_worker_spawned === true ? 'true' : 'false') + ' [OBSERVED]',
+    '- rejection_reasons: ' + JSON.stringify(r.rejection_reasons || []) + ' [OBSERVED]',
+    '- not_invoked_reason: ' + (r.not_invoked_reason || 'none') + ' [OBSERVED]'
+  ].join('\n');
+}
+
 function buildCopyMarkdown(result, workerType, contextSummary, workTrail, holoScorecard, resolvedEffort, copyContext) {
   const packet = result && typeof result === 'object' ? result : {};
   const ctx = copyContext && typeof copyContext === 'object' ? copyContext : {};
@@ -3599,6 +3742,13 @@ function buildCopyMarkdown(result, workerType, contextSummary, workTrail, holoSc
     );
     if (liveEnqueueInvoke) {
       sections.push(buildOpenClawLiveEnqueueRuntimeBindingSection(liveEnqueueInvoke));
+    }
+    const residentSession = (
+      ctx.residentArchitectSessionResult
+      || packet.resident_architect_session_result
+    );
+    if (residentSession) {
+      sections.push(buildResidentArchitectSessionSection(residentSession));
     }
   }
   sections.push(buildContinuationTelemetrySection(ctx.continuationTelemetry || packet.continuation_telemetry));
@@ -5410,6 +5560,9 @@ function wireFusionWebview(context, webview, worker, state) {
     });
     const runtimeConsumptionGate = buildRuntimeConsumptionGate(result, validationState, mode, substantiveTask);
     const actionPlanningAllowed = runtimeConsumptionGate.passed === true;
+    const residentArchitectSessionEnabled = (
+      vscode.workspace.getConfiguration('foundupsFusion').get('enableResidentArchitectSession') === true
+    );
     const operatorWardrobeSelectionResult = actionPlanningAllowed
       ? runOperatorWardrobeSelectionBridge(context, workFocus, holoScorecard, promptConstruction, handoffRecommendation, {
         groundingPreflight: groundingPreflight
@@ -5448,6 +5601,11 @@ function wireFusionWebview(context, webview, worker, state) {
     ) {
       state.liveEnqueueKeys.add(String(openClawLiveEnqueueInvokeResult.live_enqueue_key));
     }
+    const residentArchitectSessionResult = (actionPlanningAllowed && residentArchitectSessionEnabled)
+      ? runResidentArchitectSessionBridge(context, workFocus, {
+        explicitResidentArchitectSessionRequested: true
+      })
+      : null;
     result.review_packet = attachOrchestratorMetadata(
       result.review_packet || {},
       classification,
@@ -5483,6 +5641,10 @@ function wireFusionWebview(context, webview, worker, state) {
     if (openClawLiveEnqueueInvokeResult) {
       result.openclaw_live_enqueue_runtime_binding_result = openClawLiveEnqueueInvokeResult;
       result.review_packet.openclaw_live_enqueue_runtime_binding_result = openClawLiveEnqueueInvokeResult;
+    }
+    if (residentArchitectSessionResult) {
+      result.resident_architect_session_result = residentArchitectSessionResult;
+      result.review_packet.resident_architect_session_result = residentArchitectSessionResult;
     }
     if (result.reason === 'redaction_blocked') {
       result.redaction_gate_report = buildRedactionGateReport(result, promptConstruction, contextMode);
@@ -5540,6 +5702,7 @@ function wireFusionWebview(context, webview, worker, state) {
       wreSpineDryRunPreview: wreSpineDryRunPreview,
       wreSpineInvokeResult: wreSpineInvokeResult,
       openClawLiveEnqueueInvokeResult: openClawLiveEnqueueInvokeResult,
+      residentArchitectSessionResult: residentArchitectSessionResult,
       continuationEnabled: continuationEnabled,
       continuationTelemetry: continuationTelemetry,
       // Only pass the summary for Copy MD inclusion when appended this run (fail-closed).
@@ -7495,6 +7658,9 @@ module.exports = {
   buildOpenClawLiveEnqueueRuntimeBindingPayload,
   invokeOpenClawLiveEnqueueRuntimeBindingBridge,
   buildOpenClawLiveEnqueueRuntimeBindingSection,
+  buildResidentArchitectSessionPayload,
+  runResidentArchitectSessionBridge,
+  buildResidentArchitectSessionSection,
   compositePayloadDigest,
   extractHoloIndexScorecard,
   formatHoloIndexScorecardLines,

--- a/extensions/foundups_advisory_workers/package.json
+++ b/extensions/foundups_advisory_workers/package.json
@@ -2,7 +2,7 @@
     "name":  "foundups-fusion-worker",
     "displayName":  "Foundups\u00aeAgent",
     "description":  "Open a WSP_00/WSP_97 RedDog Architect advisory worker in a Cursor editor webview tab.",
-    "version":  "0.3.67",
+    "version":  "0.3.68",
     "publisher":  "foundups",
     "icon":  "icon.png",
     "engines":  {
@@ -56,16 +56,21 @@
                                                                                                   "description":  "OpenRouter model slug for the principal/synthesis worker."
                                                                                               },
                                                                  "foundupsFusion.panelModels":  {
-                                                                                                    "type":  "array",
-                                                                                                    "default":  [
-                                                                                                                    "deepseek/deepseek-v4-pro",
-                                                                                                                    "moonshotai/kimi-k2.7-code"
-                                                                                                                ],
-                                                                                                    "items":  {
-                                                                                                                  "type":  "string"
-                                                                                                              },
-                                                                                                    "description":  "OpenRouter model slugs for panel critics. The extension uses up to four."
-                                                                                                }
+                                                                                                     "type":  "array",
+                                                                                                     "default":  [
+                                                                                                                     "deepseek/deepseek-v4-pro",
+                                                                                                                     "moonshotai/kimi-k2.7-code"
+                                                                                                                 ],
+                                                                                                     "items":  {
+                                                                                                                   "type":  "string"
+                                                                                                               },
+                                                                                                     "description":  "OpenRouter model slugs for panel critics. The extension uses up to four."
+                                                                                                },
+                                                                 "foundupsFusion.enableResidentArchitectSession":  {
+                                                                                                                       "type":  "boolean",
+                                                                                                                       "default":  false,
+                                                                                                                       "description":  "Explicitly run the resident RedDog read-only audit/research/architect decision cycle after local runtime gates pass. Default false."
+                                                                                                 }
                                                              }
                                           }
                     },

--- a/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
+++ b/extensions/foundups_advisory_workers/tests/verify_extension_contract.js
@@ -10,6 +10,7 @@ const root = path.resolve(__dirname, '..', '..', '..');
 const extDir = path.join(root, 'extensions', 'foundups_advisory_workers');
 const extensionJs = fs.readFileSync(path.join(extDir, 'extension.js'), 'utf8');
 const bridgePy = fs.readFileSync(path.join(root, 'scripts', 'advisory_model_once.py'), 'utf8');
+const residentArchitectBridgePy = fs.readFileSync(path.join(root, 'scripts', 'reddog_resident_architect_session_once.py'), 'utf8');
 const pkg = JSON.parse(fs.readFileSync(path.join(extDir, 'package.json'), 'utf8'));
 const readme = fs.readFileSync(path.join(extDir, 'README.md'), 'utf8');
 const iface = fs.readFileSync(path.join(extDir, 'INTERFACE.md'), 'utf8');
@@ -197,8 +198,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.3.67', 'package version must be 0.3.67');
-includes(extensionJs, "const EXTENSION_VERSION = '0.3.67'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.3.68', 'package version must be 0.3.68');
+includes(extensionJs, "const EXTENSION_VERSION = '0.3.68'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'foundups-fusion-worker', 'package id must remain stable in branding slice');
 assert.strictEqual(pkg.displayName, 'Foundups\u00aeAgent', 'display name must be Foundups\u00aeAgent');
 includes(JSON.stringify(pkg), 'Foundups\u00aeAgent: Open', 'command title must use Foundups\u00aeAgent');
@@ -215,7 +216,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.3.67', 'README version mismatch');
+includes(readme, 'Version: 0.3.68', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -1080,7 +1081,7 @@ assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
 assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
 assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
-assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.67', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.3.68', 'candidate must bind extension version');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
 assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [
@@ -2572,7 +2573,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.67'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.3.68'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -2586,7 +2587,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.3.67'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.3.68'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -2598,7 +2599,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.67'", 'bounded context must include source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.3.68'", 'bounded context must include source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');
@@ -3467,5 +3468,75 @@ const semanticExternalStillBlocked = orchestrator.buildTypedGroundingPreflight(t
 });
 assert.strictEqual(semanticExternalStillBlocked.passed, false, 'SGP-012: external research remains fail-closed even when semantic evidence exists');
 assert(semanticExternalStillBlocked.rejection_reasons.includes('external_research_retrieval_not_implemented'), 'SGP-012: external research fail-closed reason preserved');
+
+includes(extensionJs, 'REDDOG_RESIDENT_ARCHITECT_SESSION_SCRIPT', 'RAS-001: resident architect session script constant missing');
+includes(JSON.stringify(pkg), 'foundupsFusion.enableResidentArchitectSession', 'RAS-001: resident session setting missing');
+includes(extensionJs, "get('enableResidentArchitectSession')", 'RAS-001: resident session runtime setting read missing');
+includes(extensionJs, 'function runResidentArchitectSessionBridge', 'RAS-001: resident session extension bridge missing');
+includes(extensionJs, 'resident_architect_session_result', 'RAS-001: resident session result must attach to review packet');
+includes(extensionJs, 'buildResidentArchitectSessionSection', 'RAS-001: Copy MD resident session section missing');
+includes(residentArchitectBridgePy, 'run_reddog_readonly_audit_research_decision_e2e', 'RAS-002: bridge must delegate to resident E2E runtime');
+includes(residentArchitectBridgePy, 'explicit_resident_architect_session_requested', 'RAS-002: bridge must require explicit request');
+includes(residentArchitectBridgePy, 'no_holoindex_reindex_performed', 'RAS-002: bridge must surface no-reindex attestation');
+includes(residentArchitectBridgePy, 'no_repo_mutation_performed', 'RAS-002: bridge must surface no-repo-mutation attestation');
+
+const residentPayloadSkipped = orchestrator.buildResidentArchitectSessionPayload('work focus', {});
+assert.strictEqual(residentPayloadSkipped.ok, false, 'RAS-003: resident payload skips without explicit request');
+assert(residentPayloadSkipped.rejection_reasons.includes('explicit_resident_architect_session_request_missing'), 'RAS-003: missing explicit request reason');
+
+const residentPayload = orchestrator.buildResidentArchitectSessionPayload('audit work', {
+  explicitResidentArchitectSessionRequested: true,
+  repoRoot: 'O:/Foundups-Agent',
+  workStatePath: 'O:/state/work_state.json',
+  holoindexReceiptPath: 'O:/state/holo.json',
+  timeoutSeconds: 77
+});
+assert.strictEqual(residentPayload.ok, true, 'RAS-004: explicit request builds resident payload');
+assert.strictEqual(residentPayload.payload.work_focus, 'audit work', 'RAS-004: work focus preserved');
+assert.strictEqual(residentPayload.payload.repo_root, 'O:/Foundups-Agent', 'RAS-004: repo root preserved');
+assert.strictEqual(residentPayload.payload.timeout_seconds, 77, 'RAS-004: timeout preserved');
+
+let residentRunnerPayload = null;
+const residentBridgeResult = orchestrator.runResidentArchitectSessionBridge(null, 'audit work', {
+  explicitResidentArchitectSessionRequested: true,
+  sessionRunner: (payload) => {
+    residentRunnerPayload = payload;
+    return {
+      decision: 'RESIDENT_ARCHITECT_SESSION_ACCEPT',
+      accepted: true,
+      resident_backend_invoked: true,
+      python_invocation_performed: false,
+      snapshot_id: 'sha256:snapshot',
+      final_snapshot_id: 'sha256:final',
+      swarm_id: 'sha256:swarm',
+      initial_status: 'READY',
+      final_status: 'READY',
+      task_count: 5,
+      reports_persisted: 5,
+      readonly_audit_tasks_enqueued: true,
+      readonly_audit_tasks_executed: true,
+      architect_action: 'FIX',
+      architect_next_slice: 'REDDOG_NEXT_PHASE1',
+      architect_determination_id: 'sha256:architect',
+      queue_candidate_count: 1,
+      no_repo_mutation_performed: true,
+      no_holoindex_reindex_performed: true,
+      no_hermes_dispatch_performed: true,
+      no_worktree_operation_performed: true,
+      no_pr_created: true,
+      no_live_foundup_enqueue_performed: true,
+      coding_worker_spawned: false,
+      rejection_reasons: []
+    };
+  }
+});
+assert.strictEqual(residentRunnerPayload.explicit_resident_architect_session_requested, true, 'RAS-005: runner payload explicit flag');
+assert.strictEqual(residentBridgeResult.accepted, true, 'RAS-005: injected resident runner acceptance preserved');
+assert.strictEqual(residentBridgeResult.queue_candidate_count, 1, 'RAS-005: queue candidate count preserved');
+assert.strictEqual(residentBridgeResult.no_repo_mutation_performed, true, 'RAS-005: no repo mutation preserved');
+const residentSection = orchestrator.buildResidentArchitectSessionSection(residentBridgeResult);
+includes(residentSection, '- resident_backend_invoked: true', 'RAS-006: section reports backend invocation');
+includes(residentSection, '- architect_action: FIX', 'RAS-006: section reports architect action');
+includes(residentSection, '- no_holoindex_reindex_performed: true', 'RAS-006: section reports no reindex');
 
 console.log('Foundups\u00aeAgent extension contract checks passed.');

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_session_bridge.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_session_bridge.py
@@ -1,0 +1,111 @@
+"""Tests for REDDOG_EXTENSION_TO_RESIDENT_ARCHITECT_SESSION_RUNTIME_PHASE1."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+BRIDGE_PATH = REPO_ROOT / "scripts" / "reddog_resident_architect_session_once.py"
+SPEC = importlib.util.spec_from_file_location("reddog_resident_architect_session_once", BRIDGE_PATH)
+assert SPEC and SPEC.loader
+bridge = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(bridge)
+
+
+def _accepted_result():
+    initial = SimpleNamespace(
+        status="READY",
+        snapshot_receipt_id="sha256:snapshot",
+        swarm_id="sha256:swarm",
+    )
+    final = SimpleNamespace(
+        status="READY",
+        snapshot_receipt_id="sha256:final",
+        backend_architect_determination_action="FIX",
+        backend_architect_determination_next_slice="REDDOG_NEXT_PHASE1",
+        backend_architect_determination_id="sha256:architect",
+        backend_architect_determination_queue_candidate_count=1,
+    )
+    return SimpleNamespace(
+        accepted=True,
+        status="READONLY_AUDIT_RESEARCH_DECISION_E2E_ACCEPT",
+        initial_bootstrap=initial,
+        final_bootstrap=final,
+        task_runs=(SimpleNamespace(persist_accepted=True), SimpleNamespace(persist_accepted=True)),
+        readonly_audit_tasks_enqueued=True,
+        readonly_audit_tasks_executed=True,
+        rejection_reasons=(),
+        no_shell_command_executed=True,
+        no_repo_mutation_performed=True,
+        no_holoindex_reindex_performed=True,
+        no_hermes_dispatch_performed=True,
+        no_worktree_operation_performed=True,
+        no_pr_created=True,
+        no_pattern_memory_promotion_performed=True,
+        no_live_foundup_enqueue_performed=True,
+        coding_worker_spawned=False,
+    )
+
+
+def test_resident_architect_session_requires_explicit_request() -> None:
+    result = bridge._result({})
+
+    assert result["decision"] == bridge.RESIDENT_ARCHITECT_SESSION_REJECT
+    assert result["resident_backend_invoked"] is False
+    assert result["rejection_reasons"] == ["explicit_resident_architect_session_request_missing"]
+    assert result["no_repo_mutation_performed"] is True
+    assert result["no_holoindex_reindex_performed"] is True
+
+
+def test_resident_architect_session_summarizes_e2e_runtime(monkeypatch) -> None:
+    calls = []
+
+    def fake_e2e(**kwargs):
+        calls.append(kwargs)
+        return _accepted_result()
+
+    monkeypatch.setattr(bridge, "run_reddog_readonly_audit_research_decision_e2e", fake_e2e)
+    result = bridge._result(
+        {
+            "explicit_resident_architect_session_requested": True,
+            "repo_root": ".",
+            "work_focus": "audit resident loop",
+            "work_state_path": "O:/state/work_state.json",
+            "holoindex_receipt_path": "O:/state/holo.json",
+            "holoindex_ssd_path": "E:/HoloIndex",
+            "timeout_seconds": 13,
+        }
+    )
+
+    assert calls and calls[0]["requested_operation"] == "extension_resident_architect_session"
+    assert calls[0]["prompt_text"] == "audit resident loop"
+    assert calls[0]["timeout_seconds"] == 13
+    assert result["decision"] == bridge.RESIDENT_ARCHITECT_SESSION_ACCEPT
+    assert result["accepted"] is True
+    assert result["resident_backend_invoked"] is True
+    assert result["snapshot_id"] == "sha256:snapshot"
+    assert result["swarm_id"] == "sha256:swarm"
+    assert result["task_count"] == 2
+    assert result["reports_persisted"] == 2
+    assert result["architect_action"] == "FIX"
+    assert result["architect_next_slice"] == "REDDOG_NEXT_PHASE1"
+    assert result["queue_candidate_count"] == 1
+    assert result["no_repo_mutation_performed"] is True
+    assert result["no_holoindex_reindex_performed"] is True
+    assert result["coding_worker_spawned"] is False
+
+
+def test_resident_architect_session_bridge_failure_fails_closed(monkeypatch) -> None:
+    def fail_e2e(**kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(bridge, "run_reddog_readonly_audit_research_decision_e2e", fail_e2e)
+    result = bridge._result({"explicit_resident_architect_session_requested": True})
+
+    assert result["decision"] == bridge.RESIDENT_ARCHITECT_SESSION_REJECT
+    assert result["resident_backend_invoked"] is True
+    assert result["no_repo_mutation_performed"] is True
+    assert result["no_holoindex_reindex_performed"] is True

--- a/scripts/reddog_resident_architect_session_once.py
+++ b/scripts/reddog_resident_architect_session_once.py
@@ -1,0 +1,163 @@
+"""One-shot bridge for extension -> resident RedDog architect session.
+
+Slice: REDDOG_EXTENSION_TO_RESIDENT_ARCHITECT_SESSION_RUNTIME_PHASE1
+
+The editor runtime may call this script only when the resident architect
+session is explicitly enabled. It delegates to the read-only audit/research/
+decision E2E runtime and returns a bounded status packet. It does not perform
+source mutation, shell work, worktree creation, PR creation, HoloIndex re-index,
+Hermes dispatch, or live FoundUp enqueue.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_research_decision_e2e_runtime import (  # noqa: E402
+    run_reddog_readonly_audit_research_decision_e2e,
+)
+
+RESIDENT_ARCHITECT_SESSION_ACCEPT = "RESIDENT_ARCHITECT_SESSION_ACCEPT"
+RESIDENT_ARCHITECT_SESSION_REJECT = "RESIDENT_ARCHITECT_SESSION_REJECT"
+
+
+def _read_payload() -> Dict[str, Any]:
+    try:
+        raw = sys.stdin.buffer.read()
+        payload = json.loads(raw.decode("utf-8") if raw else "{}")
+    except Exception as exc:
+        return {"_bridge_error": "invalid_json", "_bridge_error_class": type(exc).__name__}
+    return payload if isinstance(payload, dict) else {"_bridge_error": "payload_not_object"}
+
+
+def _string(value: Any) -> str:
+    return str(value) if value is not None else ""
+
+
+def _int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _reject(reason: str, *, bridge_error_class: str | None = None) -> Dict[str, Any]:
+    output: Dict[str, Any] = {
+        "decision": RESIDENT_ARCHITECT_SESSION_REJECT,
+        "accepted": False,
+        "status": "REJECT",
+        "resident_backend_invoked": False,
+        "python_invocation_performed": True,
+        "snapshot_id": "",
+        "swarm_id": "",
+        "task_count": 0,
+        "reports_persisted": 0,
+        "architect_action": "",
+        "architect_next_slice": "",
+        "architect_determination_id": "",
+        "queue_candidate_count": 0,
+        "rejection_reasons": [reason],
+        "no_shell_command_executed": True,
+        "no_repo_mutation_performed": True,
+        "no_holoindex_reindex_performed": True,
+        "no_hermes_dispatch_performed": True,
+        "no_worktree_operation_performed": True,
+        "no_pr_created": True,
+        "no_pattern_memory_promotion_performed": True,
+        "no_live_foundup_enqueue_performed": True,
+        "coding_worker_spawned": False,
+    }
+    if bridge_error_class:
+        output["bridge_error_class"] = bridge_error_class
+    return output
+
+
+def _summarize_result(result: Any) -> Dict[str, Any]:
+    initial = result.initial_bootstrap
+    final = result.final_bootstrap
+    final_status = final.status if final else ""
+    reports_persisted = sum(1 for task in result.task_runs if task.persist_accepted)
+    return {
+        "decision": RESIDENT_ARCHITECT_SESSION_ACCEPT if result.accepted else RESIDENT_ARCHITECT_SESSION_REJECT,
+        "accepted": bool(result.accepted),
+        "status": str(result.status),
+        "resident_backend_invoked": True,
+        "python_invocation_performed": True,
+        "snapshot_id": _string(getattr(initial, "snapshot_receipt_id", "")),
+        "final_snapshot_id": _string(getattr(final, "snapshot_receipt_id", "")) if final else "",
+        "swarm_id": _string(getattr(initial, "swarm_id", "")),
+        "initial_status": _string(getattr(initial, "status", "")),
+        "final_status": final_status,
+        "task_count": len(result.task_runs),
+        "reports_persisted": reports_persisted,
+        "readonly_audit_tasks_enqueued": bool(result.readonly_audit_tasks_enqueued),
+        "readonly_audit_tasks_executed": bool(result.readonly_audit_tasks_executed),
+        "architect_action": _string(getattr(final, "backend_architect_determination_action", "")) if final else "",
+        "architect_next_slice": (
+            _string(getattr(final, "backend_architect_determination_next_slice", "")) if final else ""
+        ),
+        "architect_determination_id": (
+            _string(getattr(final, "backend_architect_determination_id", "")) if final else ""
+        ),
+        "queue_candidate_count": int(
+            getattr(final, "backend_architect_determination_queue_candidate_count", 0) if final else 0
+        ),
+        "rejection_reasons": list(result.rejection_reasons),
+        "no_shell_command_executed": bool(result.no_shell_command_executed),
+        "no_repo_mutation_performed": bool(result.no_repo_mutation_performed),
+        "no_holoindex_reindex_performed": bool(result.no_holoindex_reindex_performed),
+        "no_hermes_dispatch_performed": bool(result.no_hermes_dispatch_performed),
+        "no_worktree_operation_performed": bool(result.no_worktree_operation_performed),
+        "no_pr_created": bool(result.no_pr_created),
+        "no_pattern_memory_promotion_performed": bool(result.no_pattern_memory_promotion_performed),
+        "no_live_foundup_enqueue_performed": bool(result.no_live_foundup_enqueue_performed),
+        "coding_worker_spawned": bool(result.coding_worker_spawned),
+    }
+
+
+def _result(payload: Mapping[str, Any]) -> Dict[str, Any]:
+    if payload.get("_bridge_error"):
+        return _reject(str(payload["_bridge_error"]), bridge_error_class=str(payload.get("_bridge_error_class") or "Error"))
+    if payload.get("explicit_resident_architect_session_requested") is not True:
+        return _reject("explicit_resident_architect_session_request_missing")
+
+    repo_root_text = payload.get("repo_root")
+    repo_root = Path(str(repo_root_text)).resolve() if repo_root_text else REPO_ROOT
+    try:
+        result = run_reddog_readonly_audit_research_decision_e2e(
+            repo_root=repo_root,
+            work_state_path=_string(payload.get("work_state_path") or os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", "")),
+            holoindex_receipt_path=_string(payload.get("holoindex_receipt_path") or os.getenv("HOLOINDEX_FRESHNESS_RECEIPT", "")),
+            holoindex_ssd_path=_string(payload.get("holoindex_ssd_path") or os.getenv("HOLOINDEX_SSD_PATH", "")),
+            requested_operation="extension_resident_architect_session",
+            prompt_text=_string(payload.get("work_focus") or "extension resident RedDog architect session"),
+            timeout_seconds=_int(payload.get("timeout_seconds"), 60),
+        )
+    except Exception as exc:
+        output = _reject("resident_architect_session_bridge_failed", bridge_error_class=type(exc).__name__)
+        output["resident_backend_invoked"] = True
+        return output
+    return _summarize_result(result)
+
+
+def main() -> int:
+    try:
+        output = _result(_read_payload())
+    except Exception as exc:
+        output = _reject("resident_architect_session_bridge_failed", bridge_error_class=type(exc).__name__)
+        output["resident_backend_invoked"] = True
+    sys.stdout.write(json.dumps(output, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- bump Foundups Agent extension to 0.3.68
- add scripts/reddog_resident_architect_session_once.py, a JSON bridge to the resident read-only audit/research/backend-architect E2E runtime
- add oundupsFusion.enableResidentArchitectSession default false
- attach resident backend snapshot/swarm/task/report/architect decision telemetry to review packet and Copy MD when explicitly enabled and runtime gates pass

## Validation
- 
ode extensions/foundups_advisory_workers/tests/verify_extension_contract.js -> pass (with known spawned surrogate UnicodeEncodeError stderr noise)
- 
ode --check extensions/foundups_advisory_workers/extension.js
- python -m py_compile scripts/reddog_resident_architect_session_once.py modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_session_bridge.py
- pytest modules/communication/moltbot_bridge/tests/test_reddog_context_snapshot_fusion_assignment_gate.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_authoritative_work_state_refresh_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_backend_architect_determination_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_report_collection.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_decision_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_decision_persistence.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_research_decision_e2e_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_session_bridge.py -> 124 passed
- git diff --check

## Boundary
- default disabled
- no shell command execution
- no repo mutation
- no HoloIndex re-index
- no Hermes dispatch
- no worktree operation
- no PR creation
- no PatternMemory promotion
- no live FoundUp enqueue
- no coding worker spawned
