### PR TITLE
feat(wre): produce independent slice evidence

### DIFF
--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -2,6 +2,34 @@
 
 ## Chronological Change Log
 
+### [2026-07-16] - WRE_INDEPENDENT_EVIDENCE_PRODUCER_RUNTIME_PHASE1
+
+**WSP Protocol References**: WSP 00 (Operational Grounding), WSP 15
+(Priority), WSP 34 (Git Operations), WSP 50 (Pre-Action), WSP 97 (Truth
+Boundary), WSP 22 (ModLog)
+
+**Type**: Runtime evidence production for autonomous coding slices.
+
+**Deliverable**:
+- Added `src/wre_independent_evidence_producer_runtime.py`: explicit,
+  isolated-worktree evidence producer that computes machine-derived Git diff
+  evidence, runs allowlisted check argv, and emits verifier-compatible
+  `diff_evidence` / `test_evidence` plus a receipt.
+- Added `tests/test_wre_independent_evidence_producer_runtime.py`: proves the
+  produced evidence is accepted by the existing autonomous slice verifier and
+  fails closed on missing explicit request, shared-repo worktree, head mismatch,
+  scope/protected-path violations, secret-bearing diff, unsafe command argv,
+  failed tests, and HoloIndex gaps.
+
+**Boundary**: This slice does not edit files, create worktrees, publish PRs,
+merge, call GitHub, write PatternMemory, settle rewards, or re-index HoloIndex.
+Production command execution is limited to argv-only subprocess calls in the
+assigned isolated worktree; tests use an injected runner.
+
+**Verification**: Focused evidence/verifier/ratchet path tests passed locally.
+
+---
+
 ### [2026-07-14] - WRE_CODEACT_GIT_CWD_GUARD_INTEGRATION_PHASE1
 
 **WSP Protocol References**: WSP 00 (Operational Grounding), WSP 15

--- a/modules/infrastructure/wre_core/src/wre_independent_evidence_producer_runtime.py
+++ b/modules/infrastructure/wre_core/src/wre_independent_evidence_producer_runtime.py
@@ -1,0 +1,584 @@
+"""Independent evidence producer for bounded RedDog/WRE coding slices.
+
+Slice: WRE_INDEPENDENT_EVIDENCE_PRODUCER_RUNTIME_PHASE1
+
+This module produces machine-derived evidence for the existing autonomous slice
+verifier. It inspects an already-created isolated worktree, computes the real
+Git diff between an exact base/head pair, runs caller-declared allowlisted
+checks, and emits a verifier-compatible evidence packet.
+
+It does not edit files, create worktrees, call GitHub, publish PRs, merge,
+write PatternMemory, settle rewards, or re-index HoloIndex.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import json
+import re
+import subprocess
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Protocol, Sequence
+
+EVIDENCE_PRODUCER_ACCEPT = "INDEPENDENT_EVIDENCE_PRODUCER_ACCEPT"
+EVIDENCE_PRODUCER_REJECT = "INDEPENDENT_EVIDENCE_PRODUCER_REJECT"
+
+FAIL_EXPLICIT_REQUEST = "FAIL_EXPLICIT_EVIDENCE_PRODUCTION_REQUEST_MISSING"
+FAIL_REPO_ROOT = "FAIL_REPO_ROOT_INVALID"
+FAIL_WORKTREE = "FAIL_WORKTREE_INVALID"
+FAIL_WORKTREE_INSIDE_REPO = "FAIL_WORKTREE_INSIDE_REPO"
+FAIL_OPERATION_CWD = "FAIL_OPERATION_CWD_INVALID"
+FAIL_SHA = "FAIL_SHA_INVALID"
+FAIL_HEAD_MISMATCH = "FAIL_HEAD_SHA_MISMATCH"
+FAIL_DIFF_EVIDENCE = "FAIL_DIFF_EVIDENCE"
+FAIL_SCOPE_VIOLATION = "FAIL_SCOPE_VIOLATION"
+FAIL_PROTECTED_SURFACE = "FAIL_PROTECTED_SURFACE"
+FAIL_SECRET_IN_DIFF = "FAIL_SECRET_IN_DIFF"
+FAIL_REQUIRED_CHECKS = "FAIL_REQUIRED_CHECKS"
+FAIL_CHECK_COMMAND_REJECTED = "FAIL_CHECK_COMMAND_REJECTED"
+FAIL_CHECK_FAILED = "FAIL_CHECK_FAILED"
+FAIL_HOLOINDEX_EVIDENCE = "FAIL_HOLOINDEX_EVIDENCE"
+FAIL_RUNNER_EXCEPTION = "FAIL_RUNNER_EXCEPTION"
+
+HEAD_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+MAX_DIFF_SAMPLE_BYTES = 64 * 1024
+MAX_COMMAND_OUTPUT_BYTES = 32 * 1024
+MAX_CHECKS = 8
+MAX_ARGV = 24
+DEFAULT_TIMEOUT_S = 60
+
+PROTECTED_PATH_PREFIXES = (
+    ".github/workflows/",
+    "WSP_framework/",
+    "holo_index/",
+    "modules/infrastructure/wre_core/src/wre_autonomous_slice_verifier_runtime.py",
+    "modules/infrastructure/wre_core/src/wre_independent_evidence_producer_runtime.py",
+    "modules/communication/moltbot_bridge/src/reddog_wre_execution_valve.py",
+    "modules/communication/moltbot_bridge/src/reddog_work_order_signature_verifier.py",
+    "modules/communication/moltbot_bridge/src/reddog_signed_receipt_chain.py",
+)
+
+DENIED_PATH_FRAGMENTS = (
+    "/secrets/",
+    "/wallet/",
+    "/private_key",
+    "/nonce/",
+    "/permission/",
+)
+
+SECRET_MARKERS = (
+    "authorization:",
+    "bearer ",
+    "api_key",
+    "apikey",
+    "private_key",
+    "begin private key",
+    "secret=",
+    "token=",
+    "password=",
+)
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+    duration_ms: int = 0
+    timed_out: bool = False
+    stdout_truncated: bool = False
+    stderr_truncated: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class EvidenceCommandRunner(Protocol):
+    def run(self, argv: Sequence[str], *, cwd: Path, timeout_s: int) -> CommandResult:
+        ...
+
+
+class SubprocessEvidenceCommandRunner:
+    """Read-only command runner. Uses argv lists only; shell is never enabled."""
+
+    def run(self, argv: Sequence[str], *, cwd: Path, timeout_s: int) -> CommandResult:
+        start = time.perf_counter()
+        try:
+            completed = subprocess.run(
+                list(argv),
+                cwd=str(cwd),
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=timeout_s,
+                shell=False,
+                check=False,
+            )
+            stdout, stdout_truncated = _truncate_with_flag(completed.stdout, MAX_COMMAND_OUTPUT_BYTES)
+            stderr, stderr_truncated = _truncate_with_flag(completed.stderr, MAX_COMMAND_OUTPUT_BYTES)
+            return CommandResult(
+                returncode=int(completed.returncode),
+                stdout=stdout,
+                stderr=stderr,
+                duration_ms=int((time.perf_counter() - start) * 1000),
+                stdout_truncated=stdout_truncated,
+                stderr_truncated=stderr_truncated,
+            )
+        except subprocess.TimeoutExpired as exc:
+            stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+            stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+            stdout, stdout_truncated = _truncate_with_flag(stdout, MAX_COMMAND_OUTPUT_BYTES)
+            stderr, stderr_truncated = _truncate_with_flag(stderr, MAX_COMMAND_OUTPUT_BYTES)
+            return CommandResult(
+                returncode=124,
+                stdout=stdout,
+                stderr=stderr,
+                duration_ms=int((time.perf_counter() - start) * 1000),
+                timed_out=True,
+                stdout_truncated=stdout_truncated,
+                stderr_truncated=stderr_truncated,
+            )
+
+
+@dataclass(frozen=True)
+class EvidenceProducerReceipt:
+    receipt_id: str
+    work_order_id: str
+    slice_name: str
+    worker_id: str
+    verifier_id: str
+    base_sha: str
+    head_sha: str
+    changed_paths: List[str]
+    diff_digest: str
+    test_evidence_digest: str
+    check_count: int
+    rejection_reasons: List[str]
+    accepted: bool
+    no_file_edit_performed: bool = True
+    no_worktree_created: bool = True
+    no_github_call_performed: bool = True
+    no_pr_publish_performed: bool = True
+    no_merge_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_reward_settlement_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class IndependentEvidenceProducerResult:
+    decision: str
+    accepted: bool
+    rejection_reasons: List[str]
+    diff_evidence: Dict[str, Any]
+    test_evidence: Dict[str, Any]
+    receipt: EvidenceProducerReceipt
+    command_results: List[Dict[str, Any]] = field(default_factory=list)
+    no_file_edit_performed: bool = True
+    no_worktree_created: bool = True
+    no_github_call_performed: bool = True
+    no_pr_publish_performed: bool = True
+    no_merge_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_reward_settlement_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["receipt"] = self.receipt.to_dict()
+        return payload
+
+
+def produce_independent_slice_evidence(
+    request: Mapping[str, Any],
+    *,
+    runner: Optional[EvidenceCommandRunner] = None,
+) -> IndependentEvidenceProducerResult:
+    """Produce machine-derived evidence for one bounded worktree slice."""
+
+    req = request if isinstance(request, Mapping) else {}
+    reasons: List[str] = []
+    if req.get("explicit_evidence_production_requested") is not True:
+        reasons.append(FAIL_EXPLICIT_REQUEST)
+
+    repo_root = _resolve_path(req.get("repo_root"))
+    worktree_path = _resolve_path(req.get("worktree_path"))
+    operation_cwd = _resolve_path(req.get("operation_cwd") or req.get("worktree_path"))
+    if repo_root is None or not repo_root.exists() or not repo_root.is_dir():
+        reasons.append(FAIL_REPO_ROOT)
+    if worktree_path is None or not worktree_path.exists() or not worktree_path.is_dir():
+        reasons.append(FAIL_WORKTREE)
+    if repo_root and worktree_path and _is_inside(worktree_path, repo_root):
+        reasons.append(FAIL_WORKTREE_INSIDE_REPO)
+    if worktree_path and operation_cwd and not _is_inside(operation_cwd, worktree_path):
+        reasons.append(FAIL_OPERATION_CWD)
+
+    work_order_id = str(req.get("work_order_id") or "")
+    slice_name = str(req.get("slice_name") or "")
+    worker_id = str(req.get("worker_id") or "")
+    verifier_id = str(req.get("verifier_id") or "")
+    base_sha = str(req.get("base_sha") or "")
+    head_sha = str(req.get("head_sha") or "")
+    if not all([work_order_id, slice_name, worker_id, verifier_id]):
+        reasons.append(FAIL_DIFF_EVIDENCE)
+    if not _is_head_sha(base_sha) or not _is_head_sha(head_sha) or base_sha == head_sha:
+        reasons.append(FAIL_SHA)
+
+    holo = _mapping(req.get("holoindex_evidence"))
+    if holo.get("index_gap_detected") is True or str(holo.get("retrieval_quality") or "").upper() == "INDEX_GAP":
+        reasons.append(FAIL_HOLOINDEX_EVIDENCE)
+
+    command_runner = runner or SubprocessEvidenceCommandRunner()
+    command_results: List[Dict[str, Any]] = []
+    changed_paths: List[str] = []
+    diff_text = ""
+    added_lines: List[str] = []
+
+    if not reasons:
+        try:
+            assert worktree_path is not None
+            head = command_runner.run(("git", "rev-parse", "HEAD"), cwd=worktree_path, timeout_s=DEFAULT_TIMEOUT_S)
+            command_results.append(_command_record("git_rev_parse_head", ("git", "rev-parse", "HEAD"), head))
+            if head.returncode != 0 or head.stdout.strip() != head_sha:
+                reasons.append(FAIL_HEAD_MISMATCH)
+
+            if not reasons:
+                names = command_runner.run(
+                    ("git", "diff", "--name-only", base_sha, head_sha, "--"),
+                    cwd=worktree_path,
+                    timeout_s=DEFAULT_TIMEOUT_S,
+                )
+                command_results.append(
+                    _command_record("git_diff_name_only", ("git", "diff", "--name-only", base_sha, head_sha, "--"), names)
+                )
+                if names.returncode != 0:
+                    reasons.append(FAIL_DIFF_EVIDENCE)
+                changed_paths = _normalize_changed_paths(names.stdout)
+                if not changed_paths:
+                    reasons.append(FAIL_DIFF_EVIDENCE)
+
+            if changed_paths and not reasons:
+                diff = command_runner.run(
+                    ("git", "diff", "--unified=0", base_sha, head_sha, "--", *changed_paths),
+                    cwd=worktree_path,
+                    timeout_s=DEFAULT_TIMEOUT_S,
+                )
+                command_results.append(
+                    _command_record("git_diff_unified", ("git", "diff", "--unified=0", base_sha, head_sha, "--", *changed_paths), diff)
+                )
+                if diff.returncode != 0 or diff.stdout_truncated:
+                    reasons.append(FAIL_DIFF_EVIDENCE)
+                diff_text = diff.stdout
+                added_lines = _added_lines(diff_text)
+        except Exception:
+            reasons.append(FAIL_RUNNER_EXCEPTION)
+
+    if changed_paths:
+        path_reasons = _path_reasons(changed_paths, req)
+        reasons.extend(path_reasons)
+        if _diff_contains_secret(diff_text):
+            reasons.append(FAIL_SECRET_IN_DIFF)
+
+    checks = _list(req.get("required_checks"))
+    test_records: List[Dict[str, Any]] = []
+    if not checks:
+        reasons.append(FAIL_REQUIRED_CHECKS)
+    elif len(checks) > MAX_CHECKS:
+        reasons.append(FAIL_REQUIRED_CHECKS)
+    elif _terminal_reasons(reasons):
+        # Unsafe diff/path state: do not proceed to caller commands.
+        pass
+    else:
+        assert operation_cwd is not None
+        for check in checks:
+            check_map = _mapping(check)
+            name = str(check_map.get("name") or "")
+            argv = check_map.get("argv")
+            timeout_s = _bounded_timeout(check_map.get("timeout_s"))
+            if not _allowed_check_argv(argv):
+                reasons.append(FAIL_CHECK_COMMAND_REJECTED)
+                continue
+            argv_tuple = tuple(str(item) for item in argv)
+            try:
+                result = command_runner.run(argv_tuple, cwd=operation_cwd, timeout_s=timeout_s)
+            except Exception:
+                reasons.append(FAIL_RUNNER_EXCEPTION)
+                continue
+            command_results.append(_command_record(name or "required_check", argv_tuple, result))
+            conclusion = "success" if result.returncode == 0 and result.timed_out is False else "failure"
+            record = {
+                "name": name or argv_tuple[0],
+                "head_sha": head_sha,
+                "conclusion": conclusion,
+                "returncode": result.returncode,
+                "timed_out": result.timed_out,
+                "argv_digest": _digest(list(argv_tuple)),
+                "stdout_digest": _digest(result.stdout),
+                "stderr_digest": _digest(result.stderr),
+                "duration_ms": result.duration_ms,
+            }
+            test_records.append(record)
+            if conclusion != "success":
+                reasons.append(FAIL_CHECK_FAILED)
+
+    diff_digest = _digest(diff_text)
+    diff_evidence = {
+        "source": "machine_derived",
+        "red_dog_prose_source": False,
+        "base_sha": base_sha,
+        "head_sha": head_sha,
+        "diff_digest": diff_digest,
+        "changed_paths": changed_paths,
+        "added_lines": added_lines[:50],
+        "diff_text_sample": _truncate(diff_text, MAX_DIFF_SAMPLE_BYTES),
+    }
+    test_evidence_digest = _digest(test_records)
+    test_evidence = {
+        "head_sha": head_sha,
+        "test_evidence_digest": test_evidence_digest,
+        "required_checks": test_records,
+    }
+
+    deduped = _dedupe(reasons)
+    accepted = not deduped
+    receipt_seed = {
+        "work_order_id": work_order_id,
+        "slice_name": slice_name,
+        "worker_id": worker_id,
+        "verifier_id": verifier_id,
+        "base_sha": base_sha,
+        "head_sha": head_sha,
+        "changed_paths": changed_paths,
+        "diff_digest": diff_digest,
+        "test_evidence_digest": test_evidence_digest,
+        "rejection_reasons": deduped,
+    }
+    receipt = EvidenceProducerReceipt(
+        receipt_id="wre_evidence_" + _digest(receipt_seed).removeprefix("sha256:")[:16],
+        work_order_id=work_order_id,
+        slice_name=slice_name,
+        worker_id=worker_id,
+        verifier_id=verifier_id,
+        base_sha=base_sha,
+        head_sha=head_sha,
+        changed_paths=changed_paths,
+        diff_digest=diff_digest,
+        test_evidence_digest=test_evidence_digest,
+        check_count=len(test_records),
+        rejection_reasons=deduped,
+        accepted=accepted,
+    )
+    return IndependentEvidenceProducerResult(
+        decision=EVIDENCE_PRODUCER_ACCEPT if accepted else EVIDENCE_PRODUCER_REJECT,
+        accepted=accepted,
+        rejection_reasons=deduped,
+        diff_evidence=diff_evidence,
+        test_evidence=test_evidence,
+        receipt=receipt,
+        command_results=command_results,
+    )
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> List[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _resolve_path(value: Any) -> Optional[Path]:
+    if not isinstance(value, (str, Path)) or not str(value):
+        return None
+    return Path(value).resolve()
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+def _is_head_sha(value: str) -> bool:
+    return bool(HEAD_SHA_RE.fullmatch(str(value or "")))
+
+
+def _is_digest(value: Any) -> bool:
+    return isinstance(value, str) and bool(SHA256_RE.fullmatch(value))
+
+
+def _digest(payload: Any) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dedupe(values: Iterable[str]) -> List[str]:
+    seen: set[str] = set()
+    ordered: List[str] = []
+    for value in values:
+        text = str(value or "").strip()
+        if text and text not in seen:
+            seen.add(text)
+            ordered.append(text)
+    return ordered
+
+
+def _truncate(value: str, max_bytes: int) -> str:
+    return _truncate_with_flag(value, max_bytes)[0]
+
+
+def _truncate_with_flag(value: str, max_bytes: int) -> tuple[str, bool]:
+    data = str(value or "").encode("utf-8", errors="replace")
+    if len(data) <= max_bytes:
+        return str(value or ""), False
+    return data[:max_bytes].decode("utf-8", errors="replace"), True
+
+
+def _normalize_changed_paths(stdout: str) -> List[str]:
+    paths: List[str] = []
+    for raw in str(stdout or "").splitlines():
+        path = raw.replace("\\", "/").strip().strip("/")
+        if path and _safe_repo_path(path):
+            paths.append(path)
+    return _dedupe(paths)
+
+
+def _safe_repo_path(path: str) -> bool:
+    if not path or path.startswith("/") or ":" in path or "\x00" in path:
+        return False
+    parts = [part for part in path.split("/") if part]
+    return bool(parts) and ".." not in parts and all(part.strip(" .\t") for part in parts)
+
+
+def _matches_any(path: str, patterns: Sequence[str]) -> bool:
+    lowered = path.lower()
+    for pattern in patterns:
+        pat = str(pattern or "").replace("\\", "/").strip().lower()
+        if pat and fnmatch.fnmatch(lowered, pat):
+            return True
+    return False
+
+
+def _protected_path(path: str) -> bool:
+    lowered = path.lower()
+    basename = lowered.rsplit("/", 1)[-1]
+    if basename.startswith(".env"):
+        return True
+    if any(fragment in lowered for fragment in DENIED_PATH_FRAGMENTS):
+        return True
+    return any(lowered.startswith(prefix.lower()) for prefix in PROTECTED_PATH_PREFIXES)
+
+
+def _path_reasons(paths: Sequence[str], req: Mapping[str, Any]) -> List[str]:
+    reasons: List[str] = []
+    allowed = [str(item) for item in _list(req.get("allowed_path_patterns"))]
+    forbidden = [str(item) for item in _list(req.get("forbidden_path_patterns"))]
+    expected = {_normalize_expected_path(item) for item in _list(req.get("expected_changed_paths"))}
+    expected.discard("")
+    if expected and set(paths) != expected:
+        reasons.append(FAIL_SCOPE_VIOLATION)
+    for path in paths:
+        if not _safe_repo_path(path):
+            reasons.append(FAIL_SCOPE_VIOLATION)
+        if allowed and not _matches_any(path, allowed):
+            reasons.append(FAIL_SCOPE_VIOLATION)
+        if forbidden and _matches_any(path, forbidden):
+            reasons.append(FAIL_SCOPE_VIOLATION)
+        if _protected_path(path) and not (
+            _is_digest(req.get("protected_surface_authorization_digest"))
+            and _is_digest(req.get("consensus_receipt_digest"))
+        ):
+            reasons.append(FAIL_PROTECTED_SURFACE)
+    return reasons
+
+
+def _normalize_expected_path(value: Any) -> str:
+    return str(value or "").replace("\\", "/").strip().strip("/")
+
+
+def _diff_contains_secret(diff_text: str) -> bool:
+    lower = str(diff_text or "").lower()
+    return any(marker in lower for marker in SECRET_MARKERS)
+
+
+def _added_lines(diff_text: str) -> List[str]:
+    lines: List[str] = []
+    for line in str(diff_text or "").splitlines():
+        if line.startswith("+") and not line.startswith("+++"):
+            lines.append(line[1:])
+    return lines
+
+
+def _terminal_reasons(reasons: Sequence[str]) -> bool:
+    blocked = {
+        FAIL_EXPLICIT_REQUEST,
+        FAIL_REPO_ROOT,
+        FAIL_WORKTREE,
+        FAIL_WORKTREE_INSIDE_REPO,
+        FAIL_OPERATION_CWD,
+        FAIL_SHA,
+        FAIL_HEAD_MISMATCH,
+        FAIL_DIFF_EVIDENCE,
+        FAIL_SCOPE_VIOLATION,
+        FAIL_PROTECTED_SURFACE,
+        FAIL_SECRET_IN_DIFF,
+        FAIL_HOLOINDEX_EVIDENCE,
+        FAIL_RUNNER_EXCEPTION,
+    }
+    return any(reason in blocked for reason in reasons)
+
+
+def _bounded_timeout(value: Any) -> int:
+    try:
+        parsed = int(value)
+    except Exception:
+        parsed = DEFAULT_TIMEOUT_S
+    return max(1, min(parsed, 300))
+
+
+def _allowed_check_argv(value: Any) -> bool:
+    if not isinstance(value, list) or not value or len(value) > MAX_ARGV:
+        return False
+    argv = [str(item) for item in value]
+    if any((not item or "\x00" in item or "\n" in item or "\r" in item) for item in argv):
+        return False
+    first = argv[0].lower()
+    if first in {"python", "python3", "py"}:
+        return len(argv) >= 3 and argv[1] == "-m" and argv[2] in {"pytest", "ruff", "mypy"}
+    if first in {"pytest", "ruff", "mypy"}:
+        return True
+    return False
+
+
+def _command_record(name: str, argv: Sequence[str], result: CommandResult) -> Dict[str, Any]:
+    return {
+        "name": str(name or ""),
+        "argv_digest": _digest(list(argv)),
+        "returncode": result.returncode,
+        "stdout_digest": _digest(result.stdout),
+        "stderr_digest": _digest(result.stderr),
+        "duration_ms": result.duration_ms,
+        "timed_out": result.timed_out,
+        "stdout_truncated": result.stdout_truncated,
+        "stderr_truncated": result.stderr_truncated,
+    }
+
+
+__all__ = [
+    "CommandResult",
+    "EVIDENCE_PRODUCER_ACCEPT",
+    "EVIDENCE_PRODUCER_REJECT",
+    "EvidenceCommandRunner",
+    "IndependentEvidenceProducerResult",
+    "SubprocessEvidenceCommandRunner",
+    "produce_independent_slice_evidence",
+]

--- a/modules/infrastructure/wre_core/tests/TestModLog.md
+++ b/modules/infrastructure/wre_core/tests/TestModLog.md
@@ -1,5 +1,23 @@
 # TestModLog - wre_core/tests
 
+## 2026-07-16: WRE_INDEPENDENT_EVIDENCE_PRODUCER_RUNTIME_PHASE1
+
+**Slice**: `WRE_INDEPENDENT_EVIDENCE_PRODUCER_RUNTIME_PHASE1`
+
+**New** `test_wre_independent_evidence_producer_runtime.py` (11 tests):
+- Verifier-compatible happy path: injected machine-derived Git diff/test
+  evidence feeds `verify_autonomous_slice_runtime()` and is accepted.
+- Fail-closed guards: explicit request required, worktree inside repo rejected
+  before runner calls, head mismatch blocks required checks, scope/protected
+  path violations block tests, secret-bearing diff rejected, truncated diff
+  rejected, unsafe check argv rejected, failed checks rejected, and HoloIndex
+  gap rejects before runner use.
+- AST boundary: no GitHub, HoloIndex mutation, PatternMemory, PR publish, or
+  merge surfaces; production subprocess path is argv-only with `shell=False`.
+
+**Run**: focused new file + adjacent verifier/ratchet/handler path -> 102
+passed.
+
 ## 2026-06-04: HERMES_DELEGATE_IMPORT_PATH_REMEDIATION_PHASE1 (W6)
 
 **Slice**: `HERMES_DELEGATE_IMPORT_PATH_REMEDIATION_PHASE1` | **Predecessors**: #757 (HERMES_AGENT_RUNTIME_INSTALL_AND_PATH_AUDIT_PHASE1)

--- a/modules/infrastructure/wre_core/tests/test_wre_independent_evidence_producer_runtime.py
+++ b/modules/infrastructure/wre_core/tests/test_wre_independent_evidence_producer_runtime.py
@@ -1,0 +1,301 @@
+"""Tests for WRE_INDEPENDENT_EVIDENCE_PRODUCER_RUNTIME_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.infrastructure.wre_core.src import wre_independent_evidence_producer_runtime as ep
+from modules.infrastructure.wre_core.src.wre_autonomous_slice_verifier_runtime import (
+    AUTONOMOUS_SLICE_VERIFIER_ACCEPT,
+    verify_autonomous_slice_runtime,
+)
+from modules.infrastructure.wre_core.src.wre_independent_evidence_producer_runtime import (
+    EVIDENCE_PRODUCER_ACCEPT,
+    EVIDENCE_PRODUCER_REJECT,
+    FAIL_CHECK_COMMAND_REJECTED,
+    FAIL_CHECK_FAILED,
+    FAIL_EXPLICIT_REQUEST,
+    FAIL_HEAD_MISMATCH,
+    FAIL_HOLOINDEX_EVIDENCE,
+    FAIL_PROTECTED_SURFACE,
+    FAIL_SCOPE_VIOLATION,
+    FAIL_SECRET_IN_DIFF,
+    FAIL_WORKTREE_INSIDE_REPO,
+    CommandResult,
+    produce_independent_slice_evidence,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "infrastructure"
+    / "wre_core"
+    / "src"
+    / "wre_independent_evidence_producer_runtime.py"
+)
+
+BASE = "b" * 40
+HEAD = "a" * 40
+WORK_ORDER_ID = "wo-independent-evidence-001"
+SLICE_NAME = "WRE_INDEPENDENT_EVIDENCE_PRODUCER_RUNTIME_PHASE1"
+CHANGED = "modules/foundups/paccess_001/README.md"
+
+
+class FakeRunner:
+    def __init__(
+        self,
+        *,
+        head: str = HEAD,
+        changed_paths: str = CHANGED + "\n",
+        diff_text: str | None = None,
+        diff_truncated: bool = False,
+        check_returncode: int = 0,
+    ) -> None:
+        self.head = head
+        self.changed_paths = changed_paths
+        self.diff_text = diff_text if diff_text is not None else (
+            f"diff --git a/{CHANGED} b/{CHANGED}\n"
+            f"+++ b/{CHANGED}\n"
+            "+independent evidence producer fixture\n"
+        )
+        self.diff_truncated = diff_truncated
+        self.check_returncode = check_returncode
+        self.calls: list[tuple[str, ...]] = []
+
+    def run(self, argv, *, cwd: Path, timeout_s: int) -> CommandResult:
+        _ = (cwd, timeout_s)
+        argv_tuple = tuple(argv)
+        self.calls.append(argv_tuple)
+        if argv_tuple == ("git", "rev-parse", "HEAD"):
+            return CommandResult(returncode=0, stdout=self.head + "\n")
+        if argv_tuple[:3] == ("git", "diff", "--name-only"):
+            return CommandResult(returncode=0, stdout=self.changed_paths)
+        if argv_tuple[:3] == ("git", "diff", "--unified=0"):
+            return CommandResult(returncode=0, stdout=self.diff_text, stdout_truncated=self.diff_truncated)
+        return CommandResult(
+            returncode=self.check_returncode,
+            stdout="tests ok\n" if self.check_returncode == 0 else "",
+            stderr="" if self.check_returncode == 0 else "tests failed\n",
+        )
+
+
+def _request(tmp_path: Path, **overrides):
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    repo.mkdir(exist_ok=True)
+    worktree.mkdir(exist_ok=True)
+    payload = {
+        "explicit_evidence_production_requested": True,
+        "work_order_id": WORK_ORDER_ID,
+        "slice_name": SLICE_NAME,
+        "worker_id": "worker:author",
+        "verifier_id": "worker:verifier",
+        "repo_root": str(repo),
+        "worktree_path": str(worktree),
+        "operation_cwd": str(worktree),
+        "base_sha": BASE,
+        "head_sha": HEAD,
+        "allowed_path_patterns": ["modules/foundups/paccess_001/**"],
+        "forbidden_path_patterns": ["**/.env", "**/secrets/**"],
+        "expected_changed_paths": [CHANGED],
+        "required_checks": [
+            {
+                "name": "pytest",
+                "argv": ["python", "-m", "pytest", "modules/foundups/paccess_001/tests", "-q"],
+                "timeout_s": 30,
+            }
+        ],
+        "holoindex_evidence": {
+            "index_gap_detected": False,
+            "retrieval_quality": "HIGH",
+            "holoindex_freshness_receipt_digest": "sha256:" + "1" * 64,
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _verifier_request(produced):
+    return {
+        "work_order_id": WORK_ORDER_ID,
+        "slice_name": SLICE_NAME,
+        "worker_id": "worker:author",
+        "verifier_id": "worker:verifier",
+        "base_sha": BASE,
+        "head_sha": HEAD,
+        "allowed_path_patterns": ["modules/foundups/paccess_001/**"],
+        "expected_changed_paths": [CHANGED],
+        "forbidden_path_patterns": ["**/.env", "**/secrets/**"],
+        "diff_evidence": produced.diff_evidence,
+        "test_evidence": produced.test_evidence,
+        "signed_authority": {
+            "accepted": True,
+            "signature_gate_digest": "sha256:" + "2" * 64,
+        },
+        "signed_receipt_chain": {
+            "accepted": True,
+            "terminal_receipt_hash": "sha256:" + "3" * 64,
+        },
+        "worktree_receipt": {
+            "accepted": True,
+            "receipt_id": "sha256:" + "4" * 64,
+        },
+        "holoindex_evidence": {
+            "index_gap_detected": False,
+            "holoindex_freshness_receipt_digest": "sha256:" + "5" * 64,
+        },
+        "pattern_memory_write_performed": False,
+        "draft_pr_published": False,
+        "merge_performed": False,
+    }
+
+
+def test_produces_verifier_compatible_machine_evidence(tmp_path: Path) -> None:
+    runner = FakeRunner()
+    result = produce_independent_slice_evidence(_request(tmp_path), runner=runner)
+
+    assert result.accepted is True
+    assert result.decision == EVIDENCE_PRODUCER_ACCEPT
+    assert result.diff_evidence["source"] == "machine_derived"
+    assert result.diff_evidence["red_dog_prose_source"] is False
+    assert result.diff_evidence["changed_paths"] == [CHANGED]
+    assert result.test_evidence["required_checks"][0]["conclusion"] == "success"
+    assert result.receipt.no_holoindex_reindex_performed is True
+    assert ("git", "rev-parse", "HEAD") in runner.calls
+
+    verifier = verify_autonomous_slice_runtime(_verifier_request(result))
+    assert verifier.accepted is True
+    assert verifier.decision == AUTONOMOUS_SLICE_VERIFIER_ACCEPT
+
+
+def test_requires_explicit_request_before_runner_calls(tmp_path: Path) -> None:
+    runner = FakeRunner()
+    req = _request(tmp_path, explicit_evidence_production_requested=False)
+
+    result = produce_independent_slice_evidence(req, runner=runner)
+
+    assert result.accepted is False
+    assert result.decision == EVIDENCE_PRODUCER_REJECT
+    assert FAIL_EXPLICIT_REQUEST in result.rejection_reasons
+    assert runner.calls == []
+
+
+def test_rejects_worktree_inside_repo_before_runner_calls(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    worktree = repo / "nested-worktree"
+    worktree.mkdir(parents=True)
+    runner = FakeRunner()
+    req = _request(tmp_path, repo_root=str(repo), worktree_path=str(worktree), operation_cwd=str(worktree))
+
+    result = produce_independent_slice_evidence(req, runner=runner)
+
+    assert result.accepted is False
+    assert FAIL_WORKTREE_INSIDE_REPO in result.rejection_reasons
+    assert runner.calls == []
+
+
+def test_head_sha_mismatch_rejects_without_checks(tmp_path: Path) -> None:
+    runner = FakeRunner(head="c" * 40)
+
+    result = produce_independent_slice_evidence(_request(tmp_path), runner=runner)
+
+    assert result.accepted is False
+    assert FAIL_HEAD_MISMATCH in result.rejection_reasons
+    assert not any(call[0] == "python" for call in runner.calls)
+
+
+def test_scope_violation_blocks_test_execution(tmp_path: Path) -> None:
+    runner = FakeRunner(changed_paths=".github/workflows/deploy.yml\n")
+    req = _request(tmp_path, expected_changed_paths=[".github/workflows/deploy.yml"])
+
+    result = produce_independent_slice_evidence(req, runner=runner)
+
+    assert result.accepted is False
+    assert FAIL_SCOPE_VIOLATION in result.rejection_reasons
+    assert FAIL_PROTECTED_SURFACE in result.rejection_reasons
+    assert not any(call[0] == "python" for call in runner.calls)
+
+
+def test_secret_in_diff_rejects_and_blocks_test_execution(tmp_path: Path) -> None:
+    runner = FakeRunner(diff_text=f"+++ b/{CHANGED}\n+token=abc123\n")
+
+    result = produce_independent_slice_evidence(_request(tmp_path), runner=runner)
+
+    assert result.accepted is False
+    assert FAIL_SECRET_IN_DIFF in result.rejection_reasons
+    assert not any(call[0] == "python" for call in runner.calls)
+
+
+def test_truncated_diff_rejects_and_blocks_test_execution(tmp_path: Path) -> None:
+    runner = FakeRunner(diff_truncated=True)
+
+    result = produce_independent_slice_evidence(_request(tmp_path), runner=runner)
+
+    assert result.accepted is False
+    assert ep.FAIL_DIFF_EVIDENCE in result.rejection_reasons
+    assert not any(call[0] == "python" for call in runner.calls)
+
+
+def test_unknown_check_command_rejected(tmp_path: Path) -> None:
+    req = _request(
+        tmp_path,
+        required_checks=[{"name": "bad", "argv": ["powershell", "-Command", "Write-Host ok"]}],
+    )
+
+    result = produce_independent_slice_evidence(req, runner=FakeRunner())
+
+    assert result.accepted is False
+    assert FAIL_CHECK_COMMAND_REJECTED in result.rejection_reasons
+
+
+def test_failed_required_check_rejects(tmp_path: Path) -> None:
+    result = produce_independent_slice_evidence(_request(tmp_path), runner=FakeRunner(check_returncode=1))
+
+    assert result.accepted is False
+    assert FAIL_CHECK_FAILED in result.rejection_reasons
+    assert result.test_evidence["required_checks"][0]["conclusion"] == "failure"
+
+
+def test_holoindex_gap_rejects_before_runner_calls(tmp_path: Path) -> None:
+    runner = FakeRunner()
+    req = _request(
+        tmp_path,
+        holoindex_evidence={
+            "index_gap_detected": True,
+            "retrieval_quality": "INDEX_GAP",
+            "holoindex_freshness_receipt_digest": "sha256:" + "1" * 64,
+        },
+    )
+
+    result = produce_independent_slice_evidence(req, runner=runner)
+
+    assert result.accepted is False
+    assert FAIL_HOLOINDEX_EVIDENCE in result.rejection_reasons
+    assert runner.calls == []
+
+
+def test_ast_boundary_no_github_pr_merge_patternmemory_or_holoindex_writes() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {"requests", "urllib", "http", "socket", "github", "ghapi", "holo_index"}
+    banned_import_fragments = {"pattern_memory", "reddog_verified_draft_pr_publish"}
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    banned_attrs = {"unlink", "remove", "rmdir", "rename", "Popen", "check_call", "check_output"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+                assert all(fragment not in alias.name for fragment in banned_import_fragments)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+            assert all(fragment not in node.module for fragment in banned_import_fragments)
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    assert "shell=False" in src
+    assert "subprocess.run(" in src


### PR DESCRIPTION
## Summary
- Add `wre_independent_evidence_producer_runtime.py` for machine-derived diff/test evidence from an isolated worktree.
- Emit verifier-compatible `diff_evidence` and `test_evidence` with exact base/head binding.
- Fail closed on missing explicit request, shared-repo worktree, head mismatch, scope/protected-path violation, secret-bearing or truncated diff, unsafe check argv, failed checks, and HoloIndex gaps.

## WSP_97 Truth Boundary
- OBSERVED: the existing autonomous slice verifier consumes supplied evidence; this slice produces that evidence independently from the author worker.
- OBSERVED: no file edits, worktree creation, GitHub/PR calls, merge, PatternMemory write, reward settlement, or HoloIndex re-index are performed by this module.
- SPECIFIED_NOT_IMPLEMENTED: this does not create the Hermes model coding worker; it is the verifier-facing evidence producer needed before trusting a coding worker.

## Validation
- `pytest modules/infrastructure/wre_core/tests/test_wre_independent_evidence_producer_runtime.py modules/infrastructure/wre_core/tests/test_reddog_verified_outcome_ratchet.py modules/infrastructure/wre_core/tests/test_reddog_verified_draft_pr_publish.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_slice_verifier_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_verified_draft_pr_publish_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_verified_outcome_ratchet_handler.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q` -> 102 passed
- `python -m py_compile modules/infrastructure/wre_core/src/wre_independent_evidence_producer_runtime.py`
- `git diff --check`

## Boundary
- Draft PR only.
- No extension runtime changes.
- No resident-loop auto-wiring in this PR.