### PR TITLE
feat(reddog): bind queue verifier to evidence producer

### DIFF
--- a/main.py
+++ b/main.py
@@ -1603,6 +1603,8 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
         REDDOG_ARTIFACT_CONTENTS_PATH                        Outside-repo artifact contents JSON
         REDDOG_HOLOINDEX_EVIDENCE_PATH                       Outside-repo HoloIndex evidence JSON
         REDDOG_SLICE_VERIFIER_REQUEST_PATH                   Outside-repo slice verifier request JSON
+        REDDOG_EVIDENCE_PRODUCER_REQUEST_PATH                Outside-repo evidence producer request JSON
+        REDDOG_EVIDENCE_COMMAND_RUNNER_MODE                  Optional `real` evidence command runner mode
         REDDOG_WRE_QUEUE_ITEM_ID                             Optional exact queue item id
         REDDOG_SIGNER_SOCKET_PATH                            Optional outside-repo isolated signer socket
         REDDOG_SIGNATURE_VERIFIER_BACKEND                    Optional verifier backend (`ed25519`)
@@ -1692,6 +1694,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             artifact_contents_path=os.getenv("REDDOG_ARTIFACT_CONTENTS_PATH", "") or None,
             holoindex_evidence_path=os.getenv("REDDOG_HOLOINDEX_EVIDENCE_PATH", "") or None,
             verifier_request_path=os.getenv("REDDOG_SLICE_VERIFIER_REQUEST_PATH", "") or None,
+            evidence_producer_request_path=os.getenv("REDDOG_EVIDENCE_PRODUCER_REQUEST_PATH", "") or None,
             publish_request_path=os.getenv("REDDOG_DRAFT_PR_PUBLISH_REQUEST_PATH", "") or None,
             ratchet_request_path=os.getenv("REDDOG_OUTCOME_RATCHET_REQUEST_PATH", "") or None,
             outcome_ratchet_store_path=os.getenv("REDDOG_OUTCOME_RATCHET_STORE_PATH", "") or None,
@@ -1706,6 +1709,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             signature_verifier_backend=os.getenv("REDDOG_SIGNATURE_VERIFIER_BACKEND", "") or None,
             worktree_runner_mode=os.getenv("REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE", "") or None,
             worktree_runner_timeout_s=worktree_runner_timeout_s,
+            evidence_command_runner_mode=os.getenv("REDDOG_EVIDENCE_COMMAND_RUNNER_MODE", "") or None,
             draft_pr_runner=draft_pr_runner,
             pattern_memory_admission_sink=pattern_memory_admission_sink,
             requested_queue_item_id=os.getenv("REDDOG_WRE_QUEUE_ITEM_ID", "") or None,

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,23 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: WRE_INDEPENDENT_EVIDENCE_PRODUCER_QUEUE_BINDING_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 22, 50, 97
+
+- Wired the resident queue `slice_verifier` stage to optionally produce
+  independent machine-derived diff/test evidence from the assigned isolated
+  worktree before invoking the existing queue-authorized autonomous slice
+  verifier.
+- Preserved the existing prebuilt verifier-request path. The new evidence path
+  requires an explicit evidence-producer request and an explicitly injected
+  command runner; default startup behavior remains unchanged.
+- Added `main.py` preflight environment plumbing for
+  `REDDOG_EVIDENCE_PRODUCER_REQUEST_PATH` and
+  `REDDOG_EVIDENCE_COMMAND_RUNNER_MODE`.
+- Boundary remains bounded and fail-closed: no GitHub call, draft PR publish,
+  merge, PatternMemory write, reward settlement, HoloIndex re-index, OpenClaw
+  enqueue, or Hermes dispatch.
+
 ## 2026-07-16: REDDOG_MAIN_READONLY_E2E_RUNTIME_CONSUMPTION_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 22, 50, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -131,6 +131,7 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
     artifact_contents_path: Path | str | None = None,
     holoindex_evidence_path: Path | str | None = None,
     verifier_request_path: Path | str | None = None,
+    evidence_producer_request_path: Path | str | None = None,
     publish_request_path: Path | str | None = None,
     ratchet_request_path: Path | str | None = None,
     outcome_ratchet_store_path: Path | str | None = None,
@@ -147,6 +148,8 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
     worktree_runner: Any = None,
     worktree_runner_mode: str | None = None,
     worktree_runner_timeout_s: int = 120,
+    evidence_command_runner: Any = None,
+    evidence_command_runner_mode: str | None = None,
     draft_pr_runner: Any = None,
     outcome_ratchet_store: Any = None,
     explicit_pattern_memory_write_requested: bool = False,
@@ -270,6 +273,17 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
     if verifier_request_reasons:
         return _not_ready(verifier_request_reasons, chain_results_path=None)
 
+    evidence_producer_request, evidence_producer_request_reasons = _read_json_outside_repo(
+        root,
+        evidence_producer_request_path,
+        missing_reason="missing_evidence_producer_request_path",
+        inside_reason="evidence_producer_request_path_inside_repo",
+        unreadable_reason="malformed_evidence_producer_request",
+        required=False,
+    )
+    if evidence_producer_request_reasons:
+        return _not_ready(evidence_producer_request_reasons, chain_results_path=None)
+
     publish_request, publish_request_reasons = _read_json_outside_repo(
         root,
         publish_request_path,
@@ -331,6 +345,13 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
     if runner_reasons:
         return _not_ready(runner_reasons, chain_results_path=None)
 
+    resolved_evidence_command_runner, evidence_runner_reasons = _build_evidence_command_runner(
+        injected_runner=evidence_command_runner,
+        mode=evidence_command_runner_mode,
+    )
+    if evidence_runner_reasons:
+        return _not_ready(evidence_runner_reasons, chain_results_path=None)
+
     dependency_bundle = load_reddog_main_resident_queue_runtime_dependency_bundle(
         repo_root=root,
         authority_state_path=authority_state_path,
@@ -378,6 +399,8 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
         artifact_contents=artifact_contents,
         holoindex_evidence=holoindex_evidence,
         verifier_request=verifier_request,
+        evidence_producer_request=evidence_producer_request,
+        evidence_command_runner=resolved_evidence_command_runner,
         publish_request=publish_request,
         draft_pr_runner=draft_pr_runner,
         ratchet_request=ratchet_request,
@@ -908,6 +931,25 @@ def _build_worktree_runner(
     )
 
     return RealRedDogWorktreeRunner(repo_root, timeout_s=int(timeout_s)), ()
+
+
+def _build_evidence_command_runner(
+    *,
+    injected_runner: Any,
+    mode: str | None,
+) -> tuple[Any, tuple[str, ...]]:
+    if injected_runner is not None:
+        return injected_runner, ()
+    normalized = str(mode or "").strip().lower()
+    if not normalized:
+        return None, ()
+    if normalized not in {"real", "subprocess"}:
+        return None, ("unsupported_evidence_command_runner_mode",)
+    from modules.infrastructure.wre_core.src.wre_independent_evidence_producer_runtime import (
+        SubprocessEvidenceCommandRunner,
+    )
+
+    return SubprocessEvidenceCommandRunner(), ()
 
 
 def _build_outcome_ratchet_store(

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_slice_verifier_handler.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_slice_verifier_handler.py
@@ -31,6 +31,9 @@ from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_slice_
     QUEUE_AUTHORIZED_SLICE_VERIFIER_INVOKE_REJECT,
     invoke_reddog_wre_queue_authorized_slice_verifier,
 )
+from modules.infrastructure.wre_core.src.wre_independent_evidence_producer_runtime import (
+    produce_independent_slice_evidence,
+)
 
 
 SLICE_VERIFIER_STAGE_KEY = "slice_verifier"
@@ -40,6 +43,8 @@ FAIL_DISPATCH_STAGE_MISMATCH = "FAIL_DISPATCH_STAGE_MISMATCH"
 FAIL_DISPATCH_NEXT_ACTION_MISMATCH = "FAIL_DISPATCH_NEXT_ACTION_MISMATCH"
 FAIL_BOUNDED_WORKER_PILOT_STAGE_MISSING = "FAIL_BOUNDED_WORKER_PILOT_STAGE_MISSING"
 FAIL_VERIFIER_REQUEST_MISSING = "FAIL_VERIFIER_REQUEST_MISSING"
+FAIL_EVIDENCE_COMMAND_RUNNER_MISSING = "FAIL_EVIDENCE_COMMAND_RUNNER_MISSING"
+FAIL_EVIDENCE_PRODUCER_REJECTED = "FAIL_EVIDENCE_PRODUCER_REJECTED"
 
 
 def _mapping(value: Any) -> Mapping[str, Any]:
@@ -49,6 +54,10 @@ def _mapping(value: Any) -> Mapping[str, Any]:
     if isinstance(value, Mapping):
         return value
     return {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
 
 
 def _stage_results(state: Mapping[str, Any]) -> Mapping[str, Mapping[str, Any]]:
@@ -79,7 +88,9 @@ class ResidentQueueSliceVerifierStageHandler:
     """Callable handler for the resident queue `slice_verifier` stage."""
 
     chain_results_store: ResidentQueueChainResultsStore
-    verifier_request: Mapping[str, Any]
+    verifier_request: Mapping[str, Any] | None = None
+    evidence_producer_request: Mapping[str, Any] | None = None
+    evidence_command_runner: Any = None
 
     def __call__(self, request: ResidentQueueStageDispatchRequest) -> Mapping[str, Any]:
         if request.stage_key != SLICE_VERIFIER_STAGE_KEY:
@@ -101,26 +112,89 @@ class ResidentQueueSliceVerifierStageHandler:
             return _reject(FAIL_BOUNDED_WORKER_PILOT_STAGE_MISSING)
 
         verifier_request = _mapping(self.verifier_request)
+        evidence_producer_result: Mapping[str, Any] | None = None
         if not verifier_request:
-            return _reject(FAIL_VERIFIER_REQUEST_MISSING)
+            evidence_producer_request = _mapping(self.evidence_producer_request)
+            if not evidence_producer_request:
+                return _reject(FAIL_VERIFIER_REQUEST_MISSING)
+            if self.evidence_command_runner is None:
+                return _reject(FAIL_EVIDENCE_COMMAND_RUNNER_MISSING)
+            produced = produce_independent_slice_evidence(
+                evidence_producer_request,
+                runner=self.evidence_command_runner,
+            )
+            evidence_producer_result = produced.to_dict()
+            if produced.accepted is not True:
+                rejected = _reject(FAIL_EVIDENCE_PRODUCER_REJECTED, *produced.rejection_reasons)
+                rejected["evidence_producer_result"] = evidence_producer_result
+                rejected["bounded_evidence_command_execution_performed"] = bool(produced.command_results)
+                rejected["no_shell_command_executed"] = True
+                return rejected
+            verifier_request = _verifier_request_from_evidence(
+                request=evidence_producer_request,
+                diff_evidence=produced.diff_evidence,
+                test_evidence=produced.test_evidence,
+            )
 
-        return invoke_reddog_wre_queue_authorized_slice_verifier(
+        result = invoke_reddog_wre_queue_authorized_slice_verifier(
             explicit_queue_authorized_slice_verifier_requested=True,
             queue_bounded_worker_pilot_result=bounded_worker_pilot,
             verifier_request=verifier_request,
         ).to_dict()
+        if evidence_producer_result is not None:
+            result["evidence_producer_result"] = evidence_producer_result
+            command_results = evidence_producer_result.get("command_results")
+            result["bounded_evidence_command_execution_performed"] = bool(command_results)
+            result["no_command_execution_performed"] = False
+            result["no_shell_command_executed"] = True
+        return result
+
+
+def _verifier_request_from_evidence(
+    *,
+    request: Mapping[str, Any],
+    diff_evidence: Mapping[str, Any],
+    test_evidence: Mapping[str, Any],
+) -> dict[str, Any]:
+    verifier_request = {
+        "work_order_id": str(request.get("work_order_id") or ""),
+        "slice_name": str(request.get("slice_name") or ""),
+        "worker_id": str(request.get("worker_id") or ""),
+        "verifier_id": str(request.get("verifier_id") or ""),
+        "base_sha": str(request.get("base_sha") or ""),
+        "head_sha": str(request.get("head_sha") or ""),
+        "allowed_path_patterns": list(_list(request.get("allowed_path_patterns"))),
+        "expected_changed_paths": list(_list(request.get("expected_changed_paths"))),
+        "forbidden_path_patterns": list(_list(request.get("forbidden_path_patterns"))),
+        "diff_evidence": dict(diff_evidence),
+        "test_evidence": dict(test_evidence),
+        "signed_authority": dict(_mapping(request.get("signed_authority"))),
+        "signed_receipt_chain": dict(_mapping(request.get("signed_receipt_chain"))),
+        "holoindex_evidence": dict(_mapping(request.get("holoindex_evidence"))),
+        "pattern_memory_write_performed": bool(request.get("pattern_memory_write_performed")),
+        "draft_pr_published": bool(request.get("draft_pr_published")),
+        "merge_performed": bool(request.get("merge_performed")),
+    }
+    for optional in ("protected_surface_authorization_digest", "consensus_receipt_digest"):
+        if request.get(optional):
+            verifier_request[optional] = request[optional]
+    return verifier_request
 
 
 def build_reddog_resident_queue_slice_verifier_stage_handler(
     *,
     chain_results_store: ResidentQueueChainResultsStore,
-    verifier_request: Mapping[str, Any],
+    verifier_request: Mapping[str, Any] | None = None,
+    evidence_producer_request: Mapping[str, Any] | None = None,
+    evidence_command_runner: Any = None,
 ) -> ResidentQueueSliceVerifierStageHandler:
     """Build the injected slice-verifier handler for the dispatcher."""
 
     return ResidentQueueSliceVerifierStageHandler(
         chain_results_store=chain_results_store,
         verifier_request=verifier_request,
+        evidence_producer_request=evidence_producer_request,
+        evidence_command_runner=evidence_command_runner,
     )
 
 
@@ -129,6 +203,8 @@ __all__ = [
     "FAIL_BOUNDED_WORKER_PILOT_STAGE_MISSING",
     "FAIL_DISPATCH_NEXT_ACTION_MISMATCH",
     "FAIL_DISPATCH_STAGE_MISMATCH",
+    "FAIL_EVIDENCE_COMMAND_RUNNER_MISSING",
+    "FAIL_EVIDENCE_PRODUCER_REJECTED",
     "FAIL_VERIFIER_REQUEST_MISSING",
     "ResidentQueueSliceVerifierStageHandler",
     "SLICE_VERIFIER_STAGE_KEY",

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_stage_handler_registry.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_stage_handler_registry.py
@@ -198,6 +198,8 @@ def build_reddog_resident_queue_stage_handler_registry(
     operation_cwd: Optional[Path] = None,
     holoindex_evidence: Optional[Mapping[str, Any]] = None,
     verifier_request: Optional[Mapping[str, Any]] = None,
+    evidence_producer_request: Optional[Mapping[str, Any]] = None,
+    evidence_command_runner: Any = None,
     publish_request: Optional[Mapping[str, Any]] = None,
     draft_pr_runner: Any = None,
     ratchet_request: Optional[Mapping[str, Any]] = None,
@@ -365,10 +367,16 @@ def build_reddog_resident_queue_stage_handler_registry(
         handlers,
         missing,
         SLICE_VERIFIER_STAGE_KEY,
-        _missing(("verifier_request", verifier_request)),
+        _slice_verifier_missing(
+            verifier_request=verifier_request,
+            evidence_producer_request=evidence_producer_request,
+            evidence_command_runner=evidence_command_runner,
+        ),
         lambda: build_reddog_resident_queue_slice_verifier_stage_handler(
             chain_results_store=chain_results_store,
-            verifier_request=verifier_request or {},
+            verifier_request=verifier_request,
+            evidence_producer_request=evidence_producer_request,
+            evidence_command_runner=evidence_command_runner,
         ),
     )
     _add_if_ready(
@@ -421,6 +429,26 @@ def build_reddog_resident_queue_stage_handler_registry(
         handlers=handlers,
         missing_stage_reasons=missing,
     )
+
+
+def _slice_verifier_missing(
+    *,
+    verifier_request: Optional[Mapping[str, Any]],
+    evidence_producer_request: Optional[Mapping[str, Any]],
+    evidence_command_runner: Any,
+) -> tuple[str, ...]:
+    if verifier_request:
+        return ()
+    if evidence_producer_request and evidence_command_runner is not None:
+        return ()
+    reasons: list[str] = []
+    if not verifier_request:
+        reasons.append("missing_dependency:verifier_request")
+    if not evidence_producer_request:
+        reasons.append("missing_dependency:evidence_producer_request")
+    if evidence_command_runner is None:
+        reasons.append("missing_dependency:evidence_command_runner")
+    return tuple(reasons)
 
 
 __all__ = [

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,21 @@
+## 2026-07-16: WRE_INDEPENDENT_EVIDENCE_PRODUCER_QUEUE_BINDING_PHASE1
+
+**Files**: `test_reddog_resident_queue_slice_verifier_handler.py`,
+`test_reddog_resident_queue_stage_handler_registry.py`,
+`test_reddog_main_resident_queue_serial_loop_bootstrap.py` (UPDATED)
+
+**Slice**: `WRE_INDEPENDENT_EVIDENCE_PRODUCER_QUEUE_BINDING_PHASE1` |
+**Predecessor**: #1119 independent evidence producer runtime
+
+Resident queue slice verifier can now either consume a prebuilt verifier
+request or explicitly produce diff/test evidence from the isolated worktree
+using an injected evidence command runner. Tests prove producer acceptance feeds
+the existing autonomous verifier, producer rejection blocks verification,
+registry dependencies fail closed, startup env plumbing forwards the request and
+runner mode, and unsupported evidence runner modes reject.
+
+**Run**: `pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_slice_verifier_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_stage_handler_registry.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/infrastructure/wre_core/tests/test_wre_independent_evidence_producer_runtime.py -q`
+
 ## 2026-07-11: REDDOG_OPENCLAW_LIVE_ENQUEUE_WRITER_ADAPTER_PHASE1
 
 **File**: `test_reddog_openclaw_live_enqueue_writer.py` (NEW - 6 tests)

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -62,6 +62,10 @@ from modules.infrastructure.wre_core.src.wre_autonomous_slice_verifier_runtime i
     AUTONOMOUS_SLICE_VERIFIER_ACCEPT,
     verify_autonomous_slice_runtime,
 )
+from modules.infrastructure.wre_core.src.wre_independent_evidence_producer_runtime import (
+    CommandResult,
+    EVIDENCE_PRODUCER_ACCEPT,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -446,6 +450,30 @@ def _slice_verifier_request() -> dict[str, object]:
     }
 
 
+def _evidence_producer_request(repo: Path, worktree: Path) -> dict[str, object]:
+    return {
+        **_slice_verifier_request(),
+        "explicit_evidence_production_requested": True,
+        "repo_root": str(repo),
+        "worktree_path": str(worktree),
+        "operation_cwd": str(worktree),
+        "required_checks": [
+            {
+                "name": "pytest",
+                "argv": [
+                    "python",
+                    "-m",
+                    "pytest",
+                    "modules/communication/moltbot_bridge/tests/"
+                    "test_reddog_main_resident_queue_serial_loop_bootstrap.py",
+                    "-q",
+                ],
+                "timeout_s": 30,
+            }
+        ],
+    }
+
+
 def _draft_pr_publish_request(worktree_path: Path) -> dict[str, object]:
     return {
         "work_order_id": WORK_ORDER_ID,
@@ -644,6 +672,31 @@ class _FakeWorktreeRunner:
     def cleanup_worktree(self, *, worktree_path: Path):
         self.calls.append(("cleanup_worktree", str(worktree_path), None, None))
         return {"ok": True, "returncode": 0, "stdout": "", "stderr": ""}
+
+
+class _FakeEvidenceRunner:
+    def __init__(self, *, head: str = "a" * 40) -> None:
+        self.head = head
+        self.calls: list[tuple[str, ...]] = []
+
+    def run(self, argv, *, cwd: Path, timeout_s: int) -> CommandResult:
+        _ = (cwd, timeout_s)
+        argv_tuple = tuple(argv)
+        self.calls.append(argv_tuple)
+        if argv_tuple == ("git", "rev-parse", "HEAD"):
+            return CommandResult(returncode=0, stdout=self.head + "\n")
+        if argv_tuple[:3] == ("git", "diff", "--name-only"):
+            return CommandResult(returncode=0, stdout=PILOT_ARTIFACT + "\n")
+        if argv_tuple[:3] == ("git", "diff", "--unified=0"):
+            return CommandResult(
+                returncode=0,
+                stdout=(
+                    f"diff --git a/{PILOT_ARTIFACT} b/{PILOT_ARTIFACT}\n"
+                    f"+++ b/{PILOT_ARTIFACT}\n"
+                    "+resident queue produced independent evidence\n"
+                ),
+            )
+        return CommandResult(returncode=0, stdout="ok\n")
 
 
 class _FakePatternMemoryAdmissionSink:
@@ -1519,6 +1572,115 @@ def test_bootstrap_serial_loop_reaches_slice_verifier_with_explicit_request(
     assert stage["no_pattern_memory_write_performed"] is True
     assert stage["no_reward_settlement_performed"] is True
     assert stage["no_holoindex_reindex_performed"] is True
+    assert (worktree / PILOT_ARTIFACT).exists()
+    assert not (repo / PILOT_ARTIFACT).exists()
+    assert "012-sovereign-worktree-token" not in json.dumps(stored, sort_keys=True)
+
+
+def test_bootstrap_serial_loop_produces_independent_evidence_for_slice_verifier(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    principal_public, reddog_public, connector = _ed25519_signing_material()
+    pilot_overrides = _pilot_path_overrides()
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(
+        tmp_path,
+        "profile.json",
+        _profile(
+            principal_public_key=principal_public,
+            reddog_public_key=reddog_public,
+            requested_operation=PILOT_OPERATION,
+            allowed_paths=_pilot_allowed_paths(),
+            denied_paths=pilot_overrides["denied_paths"],
+        ),
+    )
+    snapshots = _write_runtime_json(tmp_path, "snapshots.json", _snapshots())
+    principals = _write_runtime_json(tmp_path, "principals.json", _principals(principal_public))
+    work_order = _work_order(**pilot_overrides)
+    work_orders = _write_runtime_json(
+        tmp_path,
+        "work_orders.json",
+        {"work_orders": {WORK_ORDER_ID: work_order}},
+    )
+    valve_env = _write_runtime_json(tmp_path, "valve_env.json", _valve_environment())
+    chain = tmp_path / "runtime" / "chain_results.json"
+    authority_state = tmp_path / "runtime" / "authority_state.json"
+    socket_path = tmp_path / "runtime" / "signer.sock"
+    worktree_runner = _FakeWorktreeRunner()
+    evidence_runner = _FakeEvidenceRunner()
+    worktree = _pilot_worktree_path(repo, work_order)
+    pilot_payloads = _pilot_payloads(repo, worktree, work_order)
+    generic_writer = _write_runtime_json(
+        tmp_path,
+        "generic_writer.json",
+        pilot_payloads["generic_writer_dryrun_result"],
+    )
+    governed_shell = _write_runtime_json(
+        tmp_path,
+        "governed_shell.json",
+        pilot_payloads["governed_shell_dryrun_result"],
+    )
+    artifacts = _write_runtime_json(
+        tmp_path,
+        "artifact_contents.json",
+        pilot_payloads["artifact_contents"],
+    )
+    holoindex = _write_runtime_json(
+        tmp_path,
+        "holoindex_evidence.json",
+        pilot_payloads["holoindex_evidence"],
+    )
+    evidence_request = _write_runtime_json(
+        tmp_path,
+        "evidence_producer_request.json",
+        _evidence_producer_request(repo, worktree),
+    )
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        work_orders_path=work_orders,
+        valve_environment_path=valve_env,
+        generic_writer_dryrun_result_path=generic_writer,
+        governed_shell_dryrun_result_path=governed_shell,
+        artifact_contents_path=artifacts,
+        holoindex_evidence_path=holoindex,
+        evidence_producer_request_path=evidence_request,
+        evidence_command_runner=evidence_runner,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshots,
+        principal_authority_records_path=principals,
+        signer_socket_path=socket_path,
+        signer_socket_connector=connector,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        worktree_runner=worktree_runner,
+        now_iso=NOW,
+        now_epoch=1000,
+        requested_queue_item_id="queue-1",
+        max_steps=10,
+    )
+
+    assert result.accepted is True
+    assert result.steps_run == 10
+    assert result.dispatched_stages[-1] == "slice_verifier"
+    assert result.no_slice_verification_performed is False
+    stored = json.loads(chain.read_text(encoding="utf-8"))
+    stage = stored["stage_results"]["slice_verifier"]
+    assert stage["decision"] == "QUEUE_AUTHORIZED_SLICE_VERIFIER_INVOKE_ACCEPT"
+    assert stage["evidence_producer_result"]["decision"] == EVIDENCE_PRODUCER_ACCEPT
+    assert stage["verifier_result"]["decision"] == AUTONOMOUS_SLICE_VERIFIER_ACCEPT
+    assert stage["verifier_result"]["receipt"]["changed_paths"] == [PILOT_ARTIFACT]
+    assert stage["bounded_evidence_command_execution_performed"] is True
+    assert stage["no_command_execution_performed"] is False
+    assert stage["no_shell_command_executed"] is True
+    assert stage["no_github_call_performed"] is True
+    assert stage["no_pr_publish_performed"] is True
+    assert stage["no_merge_performed"] is True
+    assert stage["no_holoindex_reindex_performed"] is True
+    assert ("git", "rev-parse", "HEAD") in evidence_runner.calls
     assert (worktree / PILOT_ARTIFACT).exists()
     assert not (repo / PILOT_ARTIFACT).exists()
     assert "012-sovereign-worktree-token" not in json.dumps(stored, sort_keys=True)
@@ -2422,6 +2584,24 @@ def test_bootstrap_rejects_unsupported_worktree_runner_mode(tmp_path: Path) -> N
     assert "unsupported_worktree_runner_mode" in result.rejection_reasons
 
 
+def test_bootstrap_rejects_unsupported_evidence_command_runner_mode(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(tmp_path, "profile.json", _profile())
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=tmp_path / "runtime" / "chain_results.json",
+        authority_profile_path=profile,
+        evidence_command_runner_mode="shell",
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert "unsupported_evidence_command_runner_mode" in result.rejection_reasons
+
+
 def test_bootstrap_serial_loop_fails_closed_before_work_order_without_resolver(
     tmp_path: Path,
 ) -> None:
@@ -2811,6 +2991,10 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
                 "REDDOG_ARTIFACT_CONTENTS_PATH": str(tmp_path / "artifact_contents.json"),
                 "REDDOG_HOLOINDEX_EVIDENCE_PATH": str(tmp_path / "holoindex_evidence.json"),
                 "REDDOG_SLICE_VERIFIER_REQUEST_PATH": str(tmp_path / "verifier_request.json"),
+                "REDDOG_EVIDENCE_PRODUCER_REQUEST_PATH": str(
+                    tmp_path / "evidence_producer_request.json"
+                ),
+                "REDDOG_EVIDENCE_COMMAND_RUNNER_MODE": "real",
                 "REDDOG_DRAFT_PR_PUBLISH_REQUEST_PATH": str(tmp_path / "publish_request.json"),
                 "REDDOG_OUTCOME_RATCHET_REQUEST_PATH": str(tmp_path / "ratchet_request.json"),
                 "REDDOG_OUTCOME_RATCHET_STORE_PATH": str(tmp_path / "ratchet.jsonl"),
@@ -2860,6 +3044,10 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
     assert mocked.call_args.kwargs["verifier_request_path"] == str(
         tmp_path / "verifier_request.json"
     )
+    assert mocked.call_args.kwargs["evidence_producer_request_path"] == str(
+        tmp_path / "evidence_producer_request.json"
+    )
+    assert mocked.call_args.kwargs["evidence_command_runner_mode"] == "real"
     assert mocked.call_args.kwargs["publish_request_path"] == str(
         tmp_path / "publish_request.json"
     )

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_slice_verifier_handler.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_slice_verifier_handler.py
@@ -24,6 +24,8 @@ from modules.communication.moltbot_bridge.src.reddog_resident_queue_slice_verifi
     FAIL_BOUNDED_WORKER_PILOT_STAGE_MISSING,
     FAIL_DISPATCH_NEXT_ACTION_MISMATCH,
     FAIL_DISPATCH_STAGE_MISMATCH,
+    FAIL_EVIDENCE_COMMAND_RUNNER_MISSING,
+    FAIL_EVIDENCE_PRODUCER_REJECTED,
     FAIL_VERIFIER_REQUEST_MISSING,
     SLICE_VERIFIER_STAGE_KEY,
     build_reddog_resident_queue_slice_verifier_stage_handler,
@@ -68,6 +70,11 @@ from modules.communication.moltbot_bridge.tests.reddog_resident_queue_test_helpe
 )
 from modules.infrastructure.wre_core.src.wre_autonomous_slice_verifier_runtime import (
     AUTONOMOUS_SLICE_VERIFIER_ACCEPT,
+)
+from modules.infrastructure.wre_core.src.wre_independent_evidence_producer_runtime import (
+    CommandResult,
+    EVIDENCE_PRODUCER_ACCEPT,
+    FAIL_HOLOINDEX_EVIDENCE,
 )
 
 
@@ -142,11 +149,63 @@ def _handler(
     *,
     chain_store: InMemoryResidentQueueChainResultsStore,
     verifier_request: dict[str, object] | None = None,
+    evidence_producer_request: dict[str, object] | None = None,
+    evidence_command_runner: object | None = None,
 ):
     return build_reddog_resident_queue_slice_verifier_stage_handler(
         chain_results_store=chain_store,
         verifier_request=verifier_request if verifier_request is not None else _verifier_request(),
+        evidence_producer_request=evidence_producer_request,
+        evidence_command_runner=evidence_command_runner,
     )
+
+
+class _FakeEvidenceRunner:
+    def __init__(self, *, head: str = "a" * 40) -> None:
+        self.head = head
+        self.calls: list[tuple[str, ...]] = []
+
+    def run(self, argv, *, cwd: Path, timeout_s: int) -> CommandResult:
+        _ = (cwd, timeout_s)
+        argv_tuple = tuple(argv)
+        self.calls.append(argv_tuple)
+        if argv_tuple == ("git", "rev-parse", "HEAD"):
+            return CommandResult(returncode=0, stdout=self.head + "\n")
+        if argv_tuple[:3] == ("git", "diff", "--name-only"):
+            return CommandResult(returncode=0, stdout=ARTIFACT + "\n")
+        if argv_tuple[:3] == ("git", "diff", "--unified=0"):
+            return CommandResult(
+                returncode=0,
+                stdout=(
+                    f"diff --git a/{ARTIFACT} b/{ARTIFACT}\n"
+                    f"+++ b/{ARTIFACT}\n"
+                    "+resident queue produced evidence\n"
+                ),
+            )
+        return CommandResult(returncode=0, stdout="ok\n")
+
+
+def _evidence_producer_request(tmp_path: Path, **overrides: object) -> dict[str, object]:
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    repo.mkdir(exist_ok=True)
+    worktree.mkdir(exist_ok=True)
+    payload = {
+        **_verifier_request(),
+        "explicit_evidence_production_requested": True,
+        "repo_root": str(repo),
+        "worktree_path": str(worktree),
+        "operation_cwd": str(worktree),
+        "required_checks": [
+            {
+                "name": "pytest",
+                "argv": ["python", "-m", "pytest", "modules/communication/moltbot_bridge/tests", "-q"],
+                "timeout_s": 30,
+            }
+        ],
+    }
+    payload.update(overrides)
+    return payload
 
 
 def test_dispatcher_records_slice_verifier_and_advances_to_draft_pr_publish() -> None:
@@ -211,6 +270,98 @@ def test_missing_verifier_request_rejects_direct_handler_call() -> None:
 
     assert result["decision"] == QUEUE_AUTHORIZED_SLICE_VERIFIER_INVOKE_REJECT
     assert FAIL_VERIFIER_REQUEST_MISSING in result["rejection_reasons"]
+
+
+def test_dispatcher_produces_independent_evidence_before_slice_verifier(tmp_path: Path) -> None:
+    chain_store = _seeded_store()
+    runner = _FakeEvidenceRunner()
+
+    result = invoke_reddog_resident_queue_next_stage_dispatch(
+        explicit_resident_queue_stage_dispatch_requested=True,
+        work_state_snapshot=_snapshot(),
+        store=chain_store,
+        handlers={
+            SLICE_VERIFIER_STAGE_KEY: _handler(
+                chain_store=chain_store,
+                verifier_request={},
+                evidence_producer_request=_evidence_producer_request(tmp_path),
+                evidence_command_runner=runner,
+            )
+        },
+        now_iso=NOW_ISO,
+    )
+
+    assert result.accepted is True
+    assert result.dispatched_stage == SLICE_VERIFIER_STAGE_KEY
+    stage = chain_store.load()["stage_results"][SLICE_VERIFIER_STAGE_KEY]
+    assert stage["decision"] == QUEUE_AUTHORIZED_SLICE_VERIFIER_INVOKE_ACCEPT
+    assert stage["evidence_producer_result"]["decision"] == EVIDENCE_PRODUCER_ACCEPT
+    assert stage["verifier_result"]["decision"] == AUTONOMOUS_SLICE_VERIFIER_ACCEPT
+    assert stage["verifier_result"]["receipt"]["changed_paths"] == [ARTIFACT]
+    assert stage["bounded_evidence_command_execution_performed"] is True
+    assert stage["no_command_execution_performed"] is False
+    assert stage["no_shell_command_executed"] is True
+    assert stage["no_github_call_performed"] is True
+    assert stage["no_pr_publish_performed"] is True
+    assert stage["no_merge_performed"] is True
+    assert stage["no_pattern_memory_write_performed"] is True
+    assert stage["no_reward_settlement_performed"] is True
+    assert stage["no_holoindex_reindex_performed"] is True
+    assert ("git", "rev-parse", "HEAD") in runner.calls
+
+
+def test_rejected_evidence_producer_blocks_verifier(tmp_path: Path) -> None:
+    handler = _handler(
+        chain_store=_seeded_store(),
+        verifier_request={},
+        evidence_producer_request=_evidence_producer_request(
+            tmp_path,
+            holoindex_evidence={
+                "index_gap_detected": True,
+                "holoindex_freshness_receipt_digest": "sha256:" + "b" * 64,
+            },
+        ),
+        evidence_command_runner=_FakeEvidenceRunner(),
+    )
+    request = ResidentQueueStageDispatchRequest(
+        stage_key=SLICE_VERIFIER_STAGE_KEY,
+        next_action=NEXT_QUEUE_SLICE_VERIFIER_INVOKE,
+        queue_item_id="queue-1",
+        selected_slice="REDDOG_TEST_SLICE_PHASE1",
+        plan_id="plan-1",
+        accepted_stages=(),
+    )
+
+    result = dict(handler(request))
+
+    assert result["decision"] == QUEUE_AUTHORIZED_SLICE_VERIFIER_INVOKE_REJECT
+    assert FAIL_EVIDENCE_PRODUCER_REJECTED in result["rejection_reasons"]
+    assert FAIL_HOLOINDEX_EVIDENCE in result["rejection_reasons"]
+    assert result["verifier_result"] is None
+    assert result["evidence_producer_result"]["accepted"] is False
+
+
+def test_evidence_producer_request_requires_explicit_runner(tmp_path: Path) -> None:
+    handler = _handler(
+        chain_store=_seeded_store(),
+        verifier_request={},
+        evidence_producer_request=_evidence_producer_request(tmp_path),
+        evidence_command_runner=None,
+    )
+    request = ResidentQueueStageDispatchRequest(
+        stage_key=SLICE_VERIFIER_STAGE_KEY,
+        next_action=NEXT_QUEUE_SLICE_VERIFIER_INVOKE,
+        queue_item_id="queue-1",
+        selected_slice="REDDOG_TEST_SLICE_PHASE1",
+        plan_id="plan-1",
+        accepted_stages=(),
+    )
+
+    result = dict(handler(request))
+
+    assert result["decision"] == QUEUE_AUTHORIZED_SLICE_VERIFIER_INVOKE_REJECT
+    assert FAIL_EVIDENCE_COMMAND_RUNNER_MISSING in result["rejection_reasons"]
+    assert result["verifier_result"] is None
 
 
 def test_wrong_stage_rejects_direct_handler_call() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_stage_handler_registry.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_stage_handler_registry.py
@@ -161,6 +161,25 @@ def test_registry_rejects_empty_mapping_dependencies() -> None:
     assert "missing_dependency:authority_profile" in registry.missing_stage_reasons["authority_request"]
     assert "missing_dependency:generic_writer_dryrun_result" in registry.missing_stage_reasons["bounded_worker_pilot"]
     assert "missing_dependency:verifier_request" in registry.missing_stage_reasons["slice_verifier"]
+    assert "missing_dependency:evidence_producer_request" in registry.missing_stage_reasons["slice_verifier"]
+    assert "missing_dependency:evidence_command_runner" in registry.missing_stage_reasons["slice_verifier"]
+
+
+def test_registry_registers_slice_verifier_from_evidence_producer_dependencies(tmp_path: Path) -> None:
+    dummy = Dummy()
+    registry = build_reddog_resident_queue_stage_handler_registry(
+        work_state_snapshot=_snapshot(),
+        chain_results_store=_store(),
+        authority_profile={"principal_id": "github:mjtrout"},
+        repo_root=tmp_path,
+        evidence_producer_request={"explicit_evidence_production_requested": True},
+        evidence_command_runner=dummy,
+        now_iso=NOW_ISO,
+    )
+
+    assert "slice_verifier" in registry.registered_stage_keys
+    assert "slice_verifier" not in registry.missing_stage_reasons
+    assert registry.no_default_runner_created is True
 
 
 def test_registry_has_no_shell_network_holoindex_or_default_client_construction() -> None:


### PR DESCRIPTION
## Summary
- binds the resident queue `slice_verifier` stage to the independent evidence producer from #1119
- preserves the existing prebuilt verifier-request path while adding an explicit evidence-producer request + explicit command-runner path
- forwards `REDDOG_EVIDENCE_PRODUCER_REQUEST_PATH` and `REDDOG_EVIDENCE_COMMAND_RUNNER_MODE` through `main.py` resident queue preflight

## Boundary
- no GitHub call, PR publish, merge, PatternMemory write, reward settlement, OpenClaw enqueue, Hermes dispatch, or HoloIndex re-index
- no default evidence command runner is created by the registry or handler
- producer rejection stops before verifier invocation

## Validation
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_slice_verifier_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_stage_handler_registry.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/infrastructure/wre_core/tests/test_wre_independent_evidence_producer_runtime.py -q` -> 72 passed
- adjacent queue cluster -> 122 passed
- `python -m py_compile ...` -> pass
- `git diff --check` -> pass
- added-lines ASCII check -> pass