### PR TITLE
feat(reddog): durable resident AgentDB architect cycle

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,25 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_RESIDENT_ARCHITECT_DURABLE_AGENTDB_CYCLE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added a durable resident RedDog cycle runtime that persists
+  `reddog_intent.v1`, enqueues read-only audit tasks to AgentDB, resumes by
+  `intent_id`, handles duplicate/cancel/timeout states, and persists backend
+  architect determinations.
+- Added an OpenClaw-owned RedDog read-only audit claim seam so resident RedDog
+  no longer runs audit tasks through the previous inline E2E shortcut.
+- Updated the resident architect session bridge to call the durable AgentDB
+  cycle and surface cycle/task/claim status to the thin client.
+- Added tests for durable submission, OpenClaw claiming, report persistence,
+  architect determination, duplicate reconnect, missing governed
+  external-research retriever rejection, timeout, cancellation, and bridge
+  summarization.
+- Boundary remains read-only: no shell, repo mutation, HoloIndex re-index,
+  Hermes dispatch, worktree operation, PR creation, PatternMemory promotion,
+  or live FoundUp enqueue.
+
 ## 2026-07-16: REDDOG_RESIDENT_QUEUE_DRAFT_PR_PUBLISH_REQUEST_BINDING_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 22, 50, 97

--- a/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
@@ -36,6 +36,19 @@ from typing import Any, Callable, Deque, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
+READONLY_AUDIT_OPENCLAW_CLAIM_ACCEPT = "READONLY_AUDIT_OPENCLAW_CLAIM_ACCEPT"
+READONLY_AUDIT_OPENCLAW_CLAIM_IDLE = "READONLY_AUDIT_OPENCLAW_CLAIM_IDLE"
+READONLY_AUDIT_OPENCLAW_CLAIM_REJECT = "READONLY_AUDIT_OPENCLAW_CLAIM_REJECT"
+
+
+class ReadOnlyAuditOpenClawClaimReason:
+    NO_PENDING_TASK = "NO_PENDING_REDDOG_READONLY_AUDIT_TASK"
+    CLAIM_RACE_LOST = "REJECT_REDDOG_READONLY_AUDIT_CLAIM_RACE_LOST"
+    MALFORMED_CONTEXT = "REJECT_REDDOG_READONLY_AUDIT_MALFORMED_CONTEXT"
+    TASK_EXECUTION_REJECTED = "REJECT_REDDOG_READONLY_AUDIT_TASK_EXECUTION_REJECTED"
+    REPORT_PERSIST_REJECTED = "REJECT_REDDOG_READONLY_AUDIT_REPORT_PERSIST_REJECTED"
+    AGENTDB_FAILURE = "REJECT_REDDOG_READONLY_AUDIT_AGENTDB_FAILURE"
+
 
 @dataclass
 class SupervisorMetrics:
@@ -87,6 +100,215 @@ def _normalize_ai_analysis(analysis: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def claim_reddog_readonly_audit_task_once(
+    *,
+    repo_root: Path,
+    agent_id: str = "openclaw_supervisor",
+    agent_db_factory: Optional[Callable[[], Any]] = None,
+    report_store: Any | None = None,
+    audit_model_runner: Any | None = None,
+    holoindex_adapter: Any | None = None,
+    codeindex_adapter: Any | None = None,
+    external_research_retriever: Any | None = None,
+    timeout_seconds: int = 60,
+) -> Dict[str, Any]:
+    """Claim and execute one RedDog read-only audit AgentDB task.
+
+    This is the OpenClaw-owned execution seam for resident RedDog cycles. It
+    atomically claims a pending RedDog read-only audit task from AgentDB, runs
+    the existing read-only task executor, persists the report, and marks the
+    AgentDB task complete. It does not run shell commands, mutate repo files,
+    create worktrees, dispatch Hermes, create PRs, or re-index HoloIndex.
+    """
+
+    try:
+        from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
+            READONLY_AUDIT_TASK_SOURCE,
+        )
+        from modules.communication.moltbot_bridge.src.reddog_readonly_audit_report_collection import (
+            AgentDbReadOnlyAuditReportStore,
+            persist_reddog_readonly_audit_task_report,
+        )
+        from modules.communication.moltbot_bridge.src.reddog_readonly_audit_task_executor import (
+            execute_reddog_readonly_audit_task,
+        )
+        from modules.infrastructure.database.src.agent_db import AgentDB
+
+        factory = agent_db_factory or AgentDB
+        db = factory()
+        task = _claim_pending_reddog_readonly_audit_task(
+            db=db,
+            agent_id=agent_id,
+            source=READONLY_AUDIT_TASK_SOURCE,
+        )
+    except Exception as exc:
+        return _readonly_claim_result(
+            accepted=False,
+            status=READONLY_AUDIT_OPENCLAW_CLAIM_REJECT,
+            rejection_reasons=(ReadOnlyAuditOpenClawClaimReason.AGENTDB_FAILURE,),
+            detail=str(exc)[:300],
+        )
+
+    if task is None:
+        return _readonly_claim_result(
+            accepted=False,
+            status=READONLY_AUDIT_OPENCLAW_CLAIM_IDLE,
+            rejection_reasons=(ReadOnlyAuditOpenClawClaimReason.NO_PENDING_TASK,),
+        )
+    if task.get("claim_race_lost"):
+        return _readonly_claim_result(
+            accepted=False,
+            status=READONLY_AUDIT_OPENCLAW_CLAIM_REJECT,
+            task_id=str(task.get("task_id") or ""),
+            rejection_reasons=(ReadOnlyAuditOpenClawClaimReason.CLAIM_RACE_LOST,),
+        )
+
+    task_id = str(task.get("task_id") or "")
+    context = task.get("context")
+    if not isinstance(context, dict):
+        _mark_reddog_readonly_audit_task_failed(db, task_id)
+        return _readonly_claim_result(
+            accepted=False,
+            status=READONLY_AUDIT_OPENCLAW_CLAIM_REJECT,
+            task_id=task_id,
+            rejection_reasons=(ReadOnlyAuditOpenClawClaimReason.MALFORMED_CONTEXT,),
+        )
+
+    run_result = execute_reddog_readonly_audit_task(
+        task_context=context,
+        repo_root=repo_root,
+        task_id=task_id,
+        model_runner=audit_model_runner,
+        holoindex_adapter=holoindex_adapter,
+        codeindex_adapter=codeindex_adapter,
+        external_research_retriever=external_research_retriever,
+        timeout_seconds=timeout_seconds,
+    )
+    if not run_result.accepted:
+        _mark_reddog_readonly_audit_task_failed(db, task_id)
+        return _readonly_claim_result(
+            accepted=False,
+            status=READONLY_AUDIT_OPENCLAW_CLAIM_REJECT,
+            task_id=task_id,
+            assignment_id=_readonly_assignment_id(context),
+            rejection_reasons=(
+                ReadOnlyAuditOpenClawClaimReason.TASK_EXECUTION_REJECTED,
+                *run_result.rejection_reasons,
+            ),
+        )
+
+    store = report_store or AgentDbReadOnlyAuditReportStore(agent_db_factory=factory)
+    persist_result = persist_reddog_readonly_audit_task_report(
+        task_id=task_id,
+        task_context=context,
+        task_result={
+            "ok": True,
+            "executor": "openclaw_supervisor:reddog_readonly_audit",
+            "structured_result": run_result.to_dict(),
+        },
+        store=store,
+    )
+    if not persist_result.accepted:
+        _mark_reddog_readonly_audit_task_failed(db, task_id)
+        return _readonly_claim_result(
+            accepted=False,
+            status=READONLY_AUDIT_OPENCLAW_CLAIM_REJECT,
+            task_id=task_id,
+            assignment_id=_readonly_assignment_id(context),
+            rejection_reasons=(
+                ReadOnlyAuditOpenClawClaimReason.REPORT_PERSIST_REJECTED,
+                *persist_result.rejection_reasons,
+            ),
+        )
+
+    db.complete_autonomous_task(task_id)
+    report = run_result.report if isinstance(run_result.report, dict) else {}
+    return _readonly_claim_result(
+        accepted=True,
+        status=READONLY_AUDIT_OPENCLAW_CLAIM_ACCEPT,
+        task_id=task_id,
+        assignment_id=_readonly_assignment_id(context),
+        report_digest=str(report.get("report_digest") or ""),
+    )
+
+
+def _claim_pending_reddog_readonly_audit_task(*, db: Any, agent_id: str, source: str) -> Optional[Dict[str, Any]]:
+    with db.db.get_connection() as conn:
+        row = conn.execute(
+            """
+            SELECT task_id, context FROM agents_autonomous_tasks
+            WHERE status = 'pending' AND discovered_by = ?
+            ORDER BY priority_score DESC, discovered_at ASC
+            LIMIT 1
+            """,
+            (source,),
+        ).fetchone()
+        if not row:
+            return None
+        task_id = row["task_id"] if hasattr(row, "keys") else row[0]
+        updated = conn.execute(
+            """
+            UPDATE agents_autonomous_tasks
+            SET assigned_to = ?, assigned_at = CURRENT_TIMESTAMP, status = 'assigned'
+            WHERE task_id = ? AND status = 'pending' AND discovered_by = ?
+            """,
+            (agent_id, task_id, source),
+        ).rowcount
+        if updated != 1:
+            return {"task_id": task_id, "claim_race_lost": True}
+        raw_context = row["context"] if hasattr(row, "keys") else row[1]
+    try:
+        context = json.loads(raw_context) if isinstance(raw_context, str) else raw_context
+    except Exception:
+        context = None
+    return {"task_id": task_id, "context": context}
+
+
+def _mark_reddog_readonly_audit_task_failed(db: Any, task_id: str) -> None:
+    if not task_id:
+        return
+    try:
+        db.db.execute_write(
+            "UPDATE agents_autonomous_tasks SET status = 'failed', completed_at = CURRENT_TIMESTAMP WHERE task_id = ?",
+            (task_id,),
+        )
+    except Exception:
+        logger.debug("[SUPERVISOR] Failed to mark RedDog readonly audit task failed", exc_info=True)
+
+
+def _readonly_assignment_id(context: Dict[str, Any]) -> str:
+    assignment = context.get("assignment") if isinstance(context, dict) else {}
+    return str(assignment.get("assignment_id") or "") if isinstance(assignment, dict) else ""
+
+
+def _readonly_claim_result(
+    *,
+    accepted: bool,
+    status: str,
+    task_id: str | None = None,
+    assignment_id: str | None = None,
+    report_digest: str | None = None,
+    rejection_reasons=(),
+    detail: str = "",
+) -> Dict[str, Any]:
+    return {
+        "accepted": accepted,
+        "status": status,
+        "task_id": task_id,
+        "assignment_id": assignment_id,
+        "report_digest": report_digest,
+        "rejection_reasons": tuple(dict.fromkeys(str(reason) for reason in rejection_reasons if str(reason))),
+        "detail": detail,
+        "no_shell_command_executed": True,
+        "no_repo_mutation_performed": True,
+        "no_holoindex_reindex_performed": True,
+        "no_hermes_dispatch_performed": True,
+        "no_worktree_operation_performed": True,
+        "no_pr_created": True,
+        "no_live_foundup_enqueue_performed": True,
+    }
+
+
 class OpenClawSupervisor:
     """
     Canonical 0102 supervisor for the resident OpenClaw runtime.
@@ -130,6 +352,31 @@ class OpenClawSupervisor:
         self._libido_monitor: Any | None = None
         self._triage_queue: List[Dict[str, Any]] = []
         self._execution_results: List[Dict[str, Any]] = []
+
+    def claim_reddog_readonly_audit_task_once(
+        self,
+        *,
+        agent_db_factory: Optional[Callable[[], Any]] = None,
+        report_store: Any | None = None,
+        audit_model_runner: Any | None = None,
+        holoindex_adapter: Any | None = None,
+        codeindex_adapter: Any | None = None,
+        external_research_retriever: Any | None = None,
+        timeout_seconds: int = 60,
+    ) -> Dict[str, Any]:
+        """Claim one RedDog read-only audit task through OpenClaw."""
+
+        return claim_reddog_readonly_audit_task_once(
+            repo_root=self.repo_root,
+            agent_id="openclaw_supervisor",
+            agent_db_factory=agent_db_factory,
+            report_store=report_store,
+            audit_model_runner=audit_model_runner,
+            holoindex_adapter=holoindex_adapter,
+            codeindex_adapter=codeindex_adapter,
+            external_research_retriever=external_research_retriever,
+            timeout_seconds=timeout_seconds,
+        )
 
     def stop(self) -> None:
         self._stop_event.set()

--- a/modules/communication/moltbot_bridge/src/reddog_resident_architect_durable_agentdb_cycle.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_architect_durable_agentdb_cycle.py
@@ -1,0 +1,633 @@
+"""Durable AgentDB resident RedDog architect cycle.
+
+Slice: REDDOG_RESIDENT_ARCHITECT_DURABLE_AGENTDB_CYCLE_PHASE1
+
+This module turns the RedDog thin-client intent into a durable AgentDB cycle:
+intent submission, read-only audit task enqueue, OpenClaw-owned task claiming,
+read-only report persistence, backend architect determination, and status
+recovery by intent ID. It does not execute shell commands, mutate source files,
+create worktrees, dispatch Hermes, create PRs, promote PatternMemory, enqueue
+live FoundUp work, or re-index HoloIndex.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional, Protocol, Sequence
+
+from holo_index.freshness_receipt import HoloIndexFreshnessReceipt
+from modules.communication.moltbot_bridge.src.openclaw_supervisor import (
+    READONLY_AUDIT_OPENCLAW_CLAIM_ACCEPT,
+    READONLY_AUDIT_OPENCLAW_CLAIM_IDLE,
+    claim_reddog_readonly_audit_task_once,
+)
+from modules.communication.moltbot_bridge.src.reddog_backend_architect_determination_runtime import (
+    ArchitectDeterminationStore,
+    ArchitectModelRunner,
+)
+from modules.communication.moltbot_bridge.src.reddog_main_readonly_operational_bootstrap import (
+    DEFAULT_BOOTSTRAP_CHANGED_PATHS,
+    DEFAULT_BOOTSTRAP_READ_TARGETS,
+    REDDOG_MAIN_BOOTSTRAP_READY,
+    RedDogMainReadonlyBootstrapResult,
+    run_reddog_main_readonly_operational_bootstrap,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
+    AgentDbReadOnlyAuditTaskWriter,
+    READONLY_AUDIT_TASK_SOURCE,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_runtime import (
+    DEFAULT_AUDIT_LANES,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_0102_audit_worker_runtime import (
+    ExternalResearchRetriever,
+    ReadOnlyEvidenceQueryAdapter,
+    RepoAuditModelRunner,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_decision_persistence import (
+    ReadOnlyAuditDecisionStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_report_collection import (
+    AgentDbReadOnlyAuditReportStore,
+    ReadOnlyAuditReportStore,
+)
+
+
+REDDOG_RESIDENT_CYCLE_ACCEPT = "REDDOG_RESIDENT_CYCLE_ACCEPT"
+REDDOG_RESIDENT_CYCLE_REJECT = "REDDOG_RESIDENT_CYCLE_REJECT"
+
+STATUS_SUBMITTED = "SUBMITTED"
+STATUS_ENQUEUED = "ENQUEUED"
+STATUS_RUNNING = "RUNNING"
+STATUS_DETERMINED = "DETERMINED"
+STATUS_FAILED = "FAILED"
+STATUS_TIMED_OUT = "TIMED_OUT"
+STATUS_CANCELLED = "CANCELLED"
+
+TERMINAL_STATUSES = frozenset({STATUS_DETERMINED, STATUS_FAILED, STATUS_TIMED_OUT, STATUS_CANCELLED})
+
+
+class ResidentCycleReason:
+    INTENT_INVALID = "REJECT_RESIDENT_CYCLE_INTENT_INVALID"
+    EXECUTABLE_AUTHORITY_REQUESTED = "REJECT_RESIDENT_CYCLE_EXECUTABLE_AUTHORITY_REQUESTED"
+    EXTERNAL_RESEARCH_RETRIEVER_MISSING = "REJECT_RESIDENT_CYCLE_EXTERNAL_RESEARCH_RETRIEVER_MISSING"
+    BOOTSTRAP_REJECTED = "REJECT_RESIDENT_CYCLE_BOOTSTRAP_REJECTED"
+    TASK_ENQUEUE_REJECTED = "REJECT_RESIDENT_CYCLE_TASK_ENQUEUE_REJECTED"
+    NO_TASK_IDS = "REJECT_RESIDENT_CYCLE_NO_TASK_IDS"
+    OPENCLAW_CLAIM_REJECTED = "REJECT_RESIDENT_CYCLE_OPENCLAW_CLAIM_REJECTED"
+    TIMEOUT = "REJECT_RESIDENT_CYCLE_TIMEOUT"
+    FINAL_BOOTSTRAP_REJECTED = "REJECT_RESIDENT_CYCLE_FINAL_BOOTSTRAP_REJECTED"
+    ARCHITECT_DETERMINATION_MISSING = "REJECT_RESIDENT_CYCLE_ARCHITECT_DETERMINATION_MISSING"
+    DUPLICATE_ACTIVE_INTENT = "REJECT_RESIDENT_CYCLE_DUPLICATE_ACTIVE_INTENT"
+    RETRY_NOT_ALLOWED = "REJECT_RESIDENT_CYCLE_RETRY_NOT_ALLOWED"
+    CANCELLED = "REJECT_RESIDENT_CYCLE_CANCELLED"
+    STORE_REJECTED = "REJECT_RESIDENT_CYCLE_STORE_REJECTED"
+
+
+class ResidentArchitectCycleStore(Protocol):
+    def load_cycle_by_intent(self, intent_id: str) -> Optional[Mapping[str, Any]]: ...
+
+    def upsert_cycle(self, record: Mapping[str, Any]) -> Mapping[str, Any]: ...
+
+    def update_cycle(self, intent_id: str, updates: Mapping[str, Any]) -> Mapping[str, Any]: ...
+
+    def load_task_ids(self, determination_id: str) -> tuple[str, ...]: ...
+
+    def load_task_status_counts(self, task_ids: Sequence[str]) -> Mapping[str, int]: ...
+
+    def delete_cycle_tasks(self, task_ids: Sequence[str]) -> None: ...
+
+
+@dataclass(frozen=True)
+class RedDogResidentArchitectCycleResult:
+    accepted: bool
+    decision: str
+    status: str
+    intent_id: str
+    cycle_id: str
+    snapshot_id: Optional[str]
+    determination_id: Optional[str]
+    swarm_id: Optional[str]
+    task_ids: tuple[str, ...]
+    task_status_counts: Mapping[str, int]
+    openclaw_claims: tuple[Mapping[str, Any], ...]
+    final_bootstrap: Optional[RedDogMainReadonlyBootstrapResult]
+    architect_action: Optional[str]
+    architect_next_slice: Optional[str]
+    architect_determination_id: Optional[str]
+    queue_candidate_count: int
+    duplicate_intent_reused: bool
+    recovered_existing_cycle: bool
+    retry_count: int
+    rejection_reasons: tuple[str, ...]
+    no_shell_command_executed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_worktree_operation_performed: bool = True
+    no_pr_created: bool = True
+    no_pattern_memory_promotion_performed: bool = True
+    no_live_foundup_enqueue_performed: bool = True
+    read_only_authority_only: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["final_bootstrap"] = self.final_bootstrap.to_dict() if self.final_bootstrap else None
+        payload["task_status_counts"] = dict(self.task_status_counts)
+        payload["openclaw_claims"] = [dict(item) for item in self.openclaw_claims]
+        payload["rejection_reasons"] = list(self.rejection_reasons)
+        return payload
+
+
+class AgentDbResidentArchitectCycleStore:
+    """AgentDB-backed resident-cycle store."""
+
+    def __init__(self, agent_db_factory: Optional[Callable[[], Any]] = None) -> None:
+        self._agent_db_factory = agent_db_factory
+
+    def load_cycle_by_intent(self, intent_id: str) -> Optional[Mapping[str, Any]]:
+        db = self._agent_db()
+        self._ensure_table(db)
+        rows = db.db.execute_query(
+            "SELECT cycle_json FROM reddog_resident_architect_cycles WHERE intent_id = ?",
+            (intent_id,),
+        )
+        if not rows:
+            return None
+        value = rows[0]["cycle_json"] if isinstance(rows[0], Mapping) else rows[0][0]
+        return json.loads(value)
+
+    def upsert_cycle(self, record: Mapping[str, Any]) -> Mapping[str, Any]:
+        db = self._agent_db()
+        self._ensure_table(db)
+        payload = _canonical_json(record)
+        with db.db.get_connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO reddog_resident_architect_cycles
+                (intent_id, cycle_id, status, snapshot_id, determination_id, cycle_json, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(intent_id) DO UPDATE SET
+                    cycle_id = excluded.cycle_id,
+                    status = excluded.status,
+                    snapshot_id = excluded.snapshot_id,
+                    determination_id = excluded.determination_id,
+                    cycle_json = excluded.cycle_json,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    record.get("intent_id"),
+                    record.get("cycle_id"),
+                    record.get("status"),
+                    record.get("snapshot_id"),
+                    record.get("determination_id"),
+                    payload,
+                    _now_iso(),
+                ),
+            )
+        return {"ok": True, "stored": True}
+
+    def update_cycle(self, intent_id: str, updates: Mapping[str, Any]) -> Mapping[str, Any]:
+        current = self.load_cycle_by_intent(intent_id)
+        if current is None:
+            return {"ok": False, "reason": "missing_cycle"}
+        merged = dict(current)
+        merged.update(dict(updates))
+        return self.upsert_cycle(merged)
+
+    def load_task_ids(self, determination_id: str) -> tuple[str, ...]:
+        if not determination_id:
+            return ()
+        db = self._agent_db()
+        rows = db.db.execute_query(
+            """
+            SELECT task_id FROM agents_autonomous_tasks
+            WHERE discovered_by = ? AND origin_continuity_id = ?
+            ORDER BY priority_score DESC, discovered_at ASC
+            """,
+            (READONLY_AUDIT_TASK_SOURCE, determination_id),
+        )
+        return tuple(str(row["task_id"] if isinstance(row, Mapping) else row[0]) for row in rows)
+
+    def load_task_status_counts(self, task_ids: Sequence[str]) -> Mapping[str, int]:
+        if not task_ids:
+            return {}
+        db = self._agent_db()
+        counts: dict[str, int] = {}
+        for task_id in task_ids:
+            rows = db.db.execute_query(
+                "SELECT status FROM agents_autonomous_tasks WHERE task_id = ?",
+                (task_id,),
+            )
+            if rows and isinstance(rows[0], Mapping):
+                status = str(rows[0]["status"])
+            elif rows:
+                status = str(rows[0][0])
+            else:
+                status = "missing"
+            counts[status] = counts.get(status, 0) + 1
+        return counts
+
+    def delete_cycle_tasks(self, task_ids: Sequence[str]) -> None:
+        if not task_ids:
+            return
+        db = self._agent_db()
+        with db.db.get_connection() as conn:
+            for task_id in task_ids:
+                conn.execute(
+                    """
+                    DELETE FROM agents_autonomous_tasks
+                    WHERE task_id = ? AND discovered_by = ? AND status IN ('failed', 'pending', 'assigned')
+                    """,
+                    (task_id, READONLY_AUDIT_TASK_SOURCE),
+                )
+
+    def _agent_db(self) -> Any:
+        factory = self._agent_db_factory
+        if factory is None:
+            from modules.infrastructure.database.src.agent_db import AgentDB
+
+            factory = AgentDB
+        return factory()
+
+    @staticmethod
+    def _ensure_table(db: Any) -> None:
+        with db.db.get_connection() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS reddog_resident_architect_cycles (
+                    intent_id TEXT PRIMARY KEY,
+                    cycle_id TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    snapshot_id TEXT,
+                    determination_id TEXT,
+                    cycle_json TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_reddog_resident_architect_cycles_status
+                ON reddog_resident_architect_cycles(status)
+                """
+            )
+
+
+def run_reddog_resident_architect_durable_agentdb_cycle(
+    *,
+    repo_root: Path | str,
+    red_dog_intent: Mapping[str, Any],
+    work_state_path: Path | str | None = None,
+    holoindex_receipt_path: Path | str | None = None,
+    holoindex_ssd_path: Path | str | None = None,
+    changed_paths: Sequence[str] = DEFAULT_BOOTSTRAP_CHANGED_PATHS,
+    allowed_read_targets: Sequence[str] = DEFAULT_BOOTSTRAP_READ_TARGETS,
+    requested_operation: str = "extension_resident_architect_session",
+    prompt_text: str = "extension resident RedDog architect session",
+    now_iso: str | None = None,
+    repo_state_override: Mapping[str, Any] | None = None,
+    work_state_snapshot_override: Mapping[str, Any] | None = None,
+    holoindex_receipt_override: HoloIndexFreshnessReceipt | Mapping[str, Any] | None = None,
+    audit_lanes: Sequence[str] = DEFAULT_AUDIT_LANES,
+    cycle_store: ResidentArchitectCycleStore | None = None,
+    agent_db_factory: Optional[Callable[[], Any]] = None,
+    report_store: ReadOnlyAuditReportStore | None = None,
+    decision_store: ReadOnlyAuditDecisionStore | None = None,
+    architect_model_runner: ArchitectModelRunner | None = None,
+    architect_determination_store: ArchitectDeterminationStore | None = None,
+    audit_model_runner: RepoAuditModelRunner | None = None,
+    holoindex_adapter: ReadOnlyEvidenceQueryAdapter | None = None,
+    codeindex_adapter: ReadOnlyEvidenceQueryAdapter | None = None,
+    external_research_retriever: ExternalResearchRetriever | None = None,
+    openclaw_claim_runner: Optional[Callable[..., Mapping[str, Any]]] = None,
+    max_claims: int = 8,
+    timeout_seconds: int = 60,
+    cancel_requested: bool = False,
+    retry_requested: bool = False,
+) -> RedDogResidentArchitectCycleResult:
+    """Submit or resume one durable resident RedDog architect cycle."""
+
+    root = Path(repo_root).resolve()
+    store = cycle_store or AgentDbResidentArchitectCycleStore(agent_db_factory=agent_db_factory)
+    reasons = _validate_intent(red_dog_intent)
+    intent_id = str(red_dog_intent.get("intent_id") or "").strip()
+    existing = store.load_cycle_by_intent(intent_id) if intent_id and not reasons else None
+
+    if cancel_requested:
+        if existing is not None and str(existing.get("status")) not in TERMINAL_STATUSES:
+            store.update_cycle(intent_id, {"status": STATUS_CANCELLED, "cancelled_at": _now_iso()})
+        return _result_from_record(
+            record=store.load_cycle_by_intent(intent_id) or existing or _new_record(red_dog_intent, retry_count=0),
+            accepted=False,
+            rejection_reasons=(ResidentCycleReason.CANCELLED,),
+        )
+
+    if existing is not None and retry_requested:
+        status = str(existing.get("status") or "")
+        if status not in {STATUS_FAILED, STATUS_TIMED_OUT, STATUS_CANCELLED}:
+            return _result_from_record(
+                record=existing,
+                accepted=False,
+                rejection_reasons=(ResidentCycleReason.RETRY_NOT_ALLOWED,),
+            )
+        old_tasks = tuple(str(task_id) for task_id in existing.get("task_ids", ()) if str(task_id))
+        store.delete_cycle_tasks(old_tasks)
+        existing = None
+
+    if existing is not None and str(existing.get("status")) == STATUS_DETERMINED:
+        return _result_from_record(record=existing, accepted=True, duplicate_intent_reused=True)
+
+    if reasons:
+        return _reject(red_dog_intent, reasons)
+    if external_research_retriever is None:
+        return _reject(red_dog_intent, (ResidentCycleReason.EXTERNAL_RESEARCH_RETRIEVER_MISSING,))
+
+    if retry_requested:
+        retry_count = int(existing.get("retry_count", 0)) + 1 if existing else 1
+    elif existing:
+        retry_count = int(existing.get("retry_count", 0))
+    else:
+        retry_count = 0
+    record = dict(existing) if existing is not None else _new_record(red_dog_intent, retry_count=retry_count)
+    recovered = existing is not None
+
+    if existing is None:
+        initial = run_reddog_main_readonly_operational_bootstrap(
+            repo_root=root,
+            work_state_path=work_state_path,
+            holoindex_receipt_path=holoindex_receipt_path,
+            holoindex_ssd_path=holoindex_ssd_path,
+            changed_paths=changed_paths,
+            allowed_read_targets=allowed_read_targets,
+            requested_operation=requested_operation,
+            prompt_text=prompt_text,
+            now_iso=now_iso,
+            repo_state_override=repo_state_override,
+            work_state_snapshot_override=work_state_snapshot_override,
+            holoindex_receipt_override=holoindex_receipt_override,
+            audit_lanes=audit_lanes,
+            enqueue_readonly_audit_tasks=True,
+            enqueue_writer=AgentDbReadOnlyAuditTaskWriter(agent_db_factory=agent_db_factory),
+        )
+        if not initial.ready or initial.status != REDDOG_MAIN_BOOTSTRAP_READY:
+            record.update(
+                _failure_updates(
+                    STATUS_FAILED,
+                    (ResidentCycleReason.BOOTSTRAP_REJECTED, *initial.rejection_reasons),
+                )
+            )
+            store.upsert_cycle(record)
+            return _result_from_record(record=record, accepted=False)
+        if not initial.enqueue_attempted or initial.enqueue_task_count <= 0 or initial.enqueue_rejection_reasons:
+            record.update(
+                _failure_updates(
+                    STATUS_FAILED,
+                    (ResidentCycleReason.TASK_ENQUEUE_REJECTED, *initial.enqueue_rejection_reasons),
+                )
+            )
+            store.upsert_cycle(record)
+            return _result_from_record(record=record, accepted=False)
+        task_ids = store.load_task_ids(str(initial.determination_id or ""))
+        if not task_ids:
+            record.update(_failure_updates(STATUS_FAILED, (ResidentCycleReason.NO_TASK_IDS,)))
+            store.upsert_cycle(record)
+            return _result_from_record(record=record, accepted=False)
+        record.update(
+            {
+                "status": STATUS_ENQUEUED,
+                "snapshot_id": initial.snapshot_receipt_id,
+                "determination_id": initial.determination_id,
+                "swarm_id": initial.swarm_id,
+                "task_ids": list(task_ids),
+                "task_status_counts": dict(store.load_task_status_counts(task_ids)),
+                "initial_bootstrap": initial.to_dict(),
+                "updated_at": _now_iso(),
+            }
+        )
+        store.upsert_cycle(record)
+
+    task_ids = tuple(str(task_id) for task_id in record.get("task_ids", ()) if str(task_id))
+    claims: list[Mapping[str, Any]] = []
+    claim_runner = openclaw_claim_runner or claim_reddog_readonly_audit_task_once
+    for _ in range(max(0, int(max_claims))):
+        counts = dict(store.load_task_status_counts(task_ids))
+        if task_ids and counts.get("completed", 0) == len(task_ids):
+            break
+        claim = dict(
+            claim_runner(
+                repo_root=root,
+                agent_db_factory=agent_db_factory,
+                report_store=report_store or AgentDbReadOnlyAuditReportStore(agent_db_factory=agent_db_factory),
+                audit_model_runner=audit_model_runner,
+                holoindex_adapter=holoindex_adapter,
+                codeindex_adapter=codeindex_adapter,
+                external_research_retriever=external_research_retriever,
+                timeout_seconds=timeout_seconds,
+            )
+        )
+        claims.append(claim)
+        if claim.get("status") == READONLY_AUDIT_OPENCLAW_CLAIM_IDLE:
+            break
+        if claim.get("status") != READONLY_AUDIT_OPENCLAW_CLAIM_ACCEPT:
+            record.update(
+                _failure_updates(
+                    STATUS_FAILED,
+                    (ResidentCycleReason.OPENCLAW_CLAIM_REJECTED, *claim.get("rejection_reasons", ())),
+                )
+            )
+            record["openclaw_claims"] = [dict(item) for item in claims]
+            record["task_status_counts"] = dict(store.load_task_status_counts(task_ids))
+            store.upsert_cycle(record)
+            return _result_from_record(record=record, accepted=False, recovered_existing_cycle=recovered)
+
+    counts = dict(store.load_task_status_counts(task_ids))
+    record["task_status_counts"] = counts
+    record["openclaw_claims"] = [dict(item) for item in claims]
+    if not task_ids or counts.get("completed", 0) != len(task_ids):
+        record.update(_failure_updates(STATUS_TIMED_OUT, (ResidentCycleReason.TIMEOUT,)))
+        store.upsert_cycle(record)
+        return _result_from_record(record=record, accepted=False, recovered_existing_cycle=recovered)
+
+    final = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=root,
+        work_state_path=work_state_path,
+        holoindex_receipt_path=holoindex_receipt_path,
+        holoindex_ssd_path=holoindex_ssd_path,
+        changed_paths=changed_paths,
+        allowed_read_targets=allowed_read_targets,
+        requested_operation=requested_operation,
+        prompt_text=prompt_text,
+        now_iso=now_iso,
+        repo_state_override=repo_state_override,
+        work_state_snapshot_override=work_state_snapshot_override,
+        holoindex_receipt_override=holoindex_receipt_override,
+        audit_lanes=audit_lanes,
+        collect_readonly_audit_reports=True,
+        report_store=report_store or AgentDbReadOnlyAuditReportStore(agent_db_factory=agent_db_factory),
+        persist_readonly_audit_decision=True,
+        decision_store=decision_store,
+        run_backend_architect_determination=True,
+        architect_model_runner=architect_model_runner,
+        architect_determination_store=architect_determination_store,
+    )
+    if not final.ready:
+        record.update(
+            _failure_updates(
+                STATUS_FAILED,
+                (ResidentCycleReason.FINAL_BOOTSTRAP_REJECTED, *final.rejection_reasons),
+            )
+        )
+        record["final_bootstrap"] = final.to_dict()
+        store.upsert_cycle(record)
+        return _result_from_record(
+            record=record,
+            accepted=False,
+            final_bootstrap=final,
+            recovered_existing_cycle=recovered,
+        )
+    if not final.backend_architect_determination_id:
+        record.update(_failure_updates(STATUS_FAILED, (ResidentCycleReason.ARCHITECT_DETERMINATION_MISSING,)))
+        record["final_bootstrap"] = final.to_dict()
+        store.upsert_cycle(record)
+        return _result_from_record(
+            record=record,
+            accepted=False,
+            final_bootstrap=final,
+            recovered_existing_cycle=recovered,
+        )
+
+    record.update(
+        {
+            "status": STATUS_DETERMINED,
+            "rejection_reasons": [],
+            "final_bootstrap": final.to_dict(),
+            "architect_action": final.backend_architect_determination_action,
+            "architect_next_slice": final.backend_architect_determination_next_slice,
+            "architect_determination_id": final.backend_architect_determination_id,
+            "queue_candidate_count": final.backend_architect_determination_queue_candidate_count,
+            "updated_at": _now_iso(),
+        }
+    )
+    store.upsert_cycle(record)
+    return _result_from_record(record=record, accepted=True, final_bootstrap=final, recovered_existing_cycle=recovered)
+
+
+def _new_record(intent: Mapping[str, Any], *, retry_count: int) -> dict[str, Any]:
+    intent_id = str(intent.get("intent_id") or "").strip()
+    return {
+        "schema_version": "reddog_resident_architect_cycle.v1",
+        "intent_id": intent_id,
+        "cycle_id": _digest({"intent_id": intent_id, "retry_count": retry_count, "slice": "resident_agentdb_cycle"}),
+        "status": STATUS_SUBMITTED,
+        "intent": dict(intent),
+        "snapshot_id": None,
+        "determination_id": None,
+        "swarm_id": None,
+        "task_ids": [],
+        "task_status_counts": {},
+        "openclaw_claims": [],
+        "retry_count": retry_count,
+        "created_at": _now_iso(),
+        "updated_at": _now_iso(),
+        "rejection_reasons": [],
+        "read_only_authority_only": True,
+    }
+
+
+def _validate_intent(intent: Mapping[str, Any]) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if not isinstance(intent, Mapping) or intent.get("schema_version") != "reddog_intent.v1":
+        reasons.append(ResidentCycleReason.INTENT_INVALID)
+    if not str(intent.get("intent_id") or "").strip():
+        reasons.append(ResidentCycleReason.INTENT_INVALID)
+    if intent.get("submits_executable_authority") is not False:
+        reasons.append(ResidentCycleReason.EXECUTABLE_AUTHORITY_REQUESTED)
+    return tuple(dict.fromkeys(reasons))
+
+
+def _failure_updates(status: str, reasons: Sequence[str]) -> dict[str, Any]:
+    return {
+        "status": status,
+        "rejection_reasons": list(dict.fromkeys(str(reason) for reason in reasons if str(reason).strip())),
+        "updated_at": _now_iso(),
+    }
+
+
+def _reject(intent: Mapping[str, Any], reasons: Sequence[str]) -> RedDogResidentArchitectCycleResult:
+    record = _new_record(intent if isinstance(intent, Mapping) else {}, retry_count=0)
+    record.update(_failure_updates(STATUS_FAILED, reasons))
+    return _result_from_record(record=record, accepted=False)
+
+
+def _result_from_record(
+    *,
+    record: Mapping[str, Any],
+    accepted: bool,
+    rejection_reasons: Sequence[str] | None = None,
+    final_bootstrap: RedDogMainReadonlyBootstrapResult | None = None,
+    duplicate_intent_reused: bool = False,
+    recovered_existing_cycle: bool = False,
+) -> RedDogResidentArchitectCycleResult:
+    reasons = tuple(rejection_reasons) if rejection_reasons is not None else tuple(record.get("rejection_reasons", ()))
+    final = final_bootstrap
+    return RedDogResidentArchitectCycleResult(
+        accepted=accepted,
+        decision=REDDOG_RESIDENT_CYCLE_ACCEPT if accepted else REDDOG_RESIDENT_CYCLE_REJECT,
+        status=str(record.get("status") or STATUS_FAILED),
+        intent_id=str(record.get("intent_id") or ""),
+        cycle_id=str(record.get("cycle_id") or ""),
+        snapshot_id=_optional_string(record.get("snapshot_id")),
+        determination_id=_optional_string(record.get("determination_id")),
+        swarm_id=_optional_string(record.get("swarm_id")),
+        task_ids=tuple(str(task_id) for task_id in record.get("task_ids", ()) if str(task_id)),
+        task_status_counts=dict(record.get("task_status_counts") or {}),
+        openclaw_claims=tuple(dict(item) for item in record.get("openclaw_claims", ()) if isinstance(item, Mapping)),
+        final_bootstrap=final,
+        architect_action=_optional_string(record.get("architect_action")),
+        architect_next_slice=_optional_string(record.get("architect_next_slice")),
+        architect_determination_id=_optional_string(record.get("architect_determination_id")),
+        queue_candidate_count=int(record.get("queue_candidate_count") or 0),
+        duplicate_intent_reused=duplicate_intent_reused,
+        recovered_existing_cycle=recovered_existing_cycle,
+        retry_count=int(record.get("retry_count") or 0),
+        rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons if str(reason).strip())),
+    )
+
+
+def _optional_string(value: Any) -> Optional[str]:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _digest(payload: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def _canonical_json(payload: Any) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+__all__ = [
+    "AgentDbResidentArchitectCycleStore",
+    "REDDOG_RESIDENT_CYCLE_ACCEPT",
+    "REDDOG_RESIDENT_CYCLE_REJECT",
+    "RedDogResidentArchitectCycleResult",
+    "ResidentCycleReason",
+    "STATUS_CANCELLED",
+    "STATUS_DETERMINED",
+    "STATUS_ENQUEUED",
+    "STATUS_FAILED",
+    "STATUS_RUNNING",
+    "STATUS_SUBMITTED",
+    "STATUS_TIMED_OUT",
+    "run_reddog_resident_architect_durable_agentdb_cycle",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py
@@ -1,0 +1,344 @@
+"""Tests for REDDOG_RESIDENT_ARCHITECT_DURABLE_AGENTDB_CYCLE_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from holo_index.freshness_receipt import CollectionFreshness, HoloIndexFreshnessReceipt
+from modules.communication.moltbot_bridge.src.reddog_backend_architect_determination_runtime import (
+    ARCHITECT_DETERMINATION_ACCEPT,
+    ArchitectModelResult,
+    InMemoryArchitectDeterminationStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
+    READONLY_AUDIT_TASK_SOURCE,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_0102_audit_worker_runtime import (
+    RepoAuditModelResult,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle import (
+    REDDOG_RESIDENT_CYCLE_ACCEPT,
+    REDDOG_RESIDENT_CYCLE_REJECT,
+    STATUS_DETERMINED,
+    STATUS_TIMED_OUT,
+    AgentDbResidentArchitectCycleStore,
+    ResidentCycleReason,
+    run_reddog_resident_architect_durable_agentdb_cycle,
+)
+from modules.infrastructure.database.src.agent_db import AgentDB
+from modules.infrastructure.database.src.db_manager import DatabaseManager
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_resident_architect_durable_agentdb_cycle.py"
+)
+NOW = "2026-07-16T00:00:00+00:00"
+HEAD = "f9ac824d8"
+REVISION = "sha256:resident-work-state"
+
+
+@pytest.fixture(autouse=True)
+def isolated_agent_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("FOUNDUPS_DB_PATH", str(tmp_path / "foundups.db"))
+    DatabaseManager.reset_for_tests()
+    yield
+    DatabaseManager.reset_for_tests()
+
+
+def _intent() -> dict[str, object]:
+    return {
+        "schema_version": "reddog_intent.v1",
+        "intent_id": "sha256:intent-resident-cycle",
+        "origin": "extension",
+        "principal_ref": "012",
+        "work_focus": "resident RedDog architect audit",
+        "submits_executable_authority": False,
+    }
+
+
+def _repo_state() -> dict[str, object]:
+    return {
+        "head_sha": HEAD,
+        "dirty_paths": (),
+        "dirty_digest": "sha256:clean",
+        "worktree_digest": "sha256:worktrees",
+    }
+
+
+def _work_state() -> dict[str, object]:
+    return {
+        "schema_version": "reddog_authoritative_work_state.v1",
+        "revision": REVISION,
+        "selected_slice": "REDDOG_RESIDENT_ARCHITECT_DURABLE_AGENTDB_CYCLE_PHASE1",
+        "refresh_receipt_id": "sha256:refresh-resident",
+        "worker_claims": [
+            {
+                "claim_id": "claim-resident",
+                "slice_id": "REDDOG_RESIDENT_ARCHITECT_DURABLE_AGENTDB_CYCLE_PHASE1",
+            }
+        ],
+        "wre_queue_items": [{"queue_item_id": "queue-resident", "claim_id": "claim-resident"}],
+    }
+
+
+def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
+    return HoloIndexFreshnessReceipt(
+        schema_version="holoindex_freshness_receipt.v1",
+        generated_at=NOW,
+        repo_root=str(REPO_ROOT),
+        repo_head_sha=HEAD,
+        ssd_path="E:/HoloIndex",
+        source="ci_targeted_reindex",
+        generation_id="sha256:holo-generation-resident",
+        collections=[
+            CollectionFreshness(
+                name="navigation_work_ledger",
+                count=4,
+                status="indexed",
+                source="ci_targeted_reindex",
+                repo_head_sha=HEAD,
+                last_indexed_at=NOW,
+                source_manifest_digest="sha256:work-ledger-manifest",
+                indexed_paths_digest="sha256:work-ledger-paths",
+                verification="PASS",
+            ),
+            CollectionFreshness(
+                name="navigation_symbols",
+                count=9,
+                status="indexed",
+                source="ci_targeted_reindex",
+                repo_head_sha=HEAD,
+                last_indexed_at=NOW,
+                source_manifest_digest="sha256:symbols-manifest",
+                indexed_paths_digest="sha256:symbols-paths",
+                verification="PASS",
+            ),
+        ],
+    )
+
+
+class _FakeQueryAdapter:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def query(self, *, query: str, allowed_paths, limit: int):
+        self.calls.append({"query": query, "allowed_paths": tuple(allowed_paths), "limit": limit})
+        path = allowed_paths[0] if allowed_paths else "docs/0102_session_briefings/ACTIVE_SLICE_LEDGER.md"
+        return {
+            "ok": True,
+            "source": "fake",
+            "query": query,
+            "freshness": "FRESH",
+            "hits": [{"path": path, "title": "fake hit", "score": 0.99, "digest": "sha256:index-hit"}],
+            "error": "",
+            "freshness_generation_id": "sha256:holo-generation-resident",
+            "freshness_receipt_digest": "sha256:holo-receipt-resident",
+            "freshness_receipt_path": "E:/HoloIndex/indexes/holoindex_freshness_receipt.json",
+            "repo_head_sha": HEAD,
+        }
+
+
+class _FakeExternalResearchRetriever:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def fetch(self, target):
+        self.calls.append(dict(target))
+        return {
+            "source_url": str(target.get("url") or "https://github.com/FOUNDUPS/Foundups-Agent"),
+            "source_type": "github",
+            "fetched_at": 1000,
+            "content_sha256": "a" * 64,
+            "provenance_refs": ["github:FOUNDUPS/Foundups-Agent@main"],
+            "freshness_receipt_digest": "sha256:" + "b" * 64,
+            "finding_status": "candidate",
+            "content_text": "Repository metadata snapshot.",
+        }
+
+
+class _AuditModelRunner:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def run_repo_code_audit(self, *, prompt: str, context: str, binding, timeout_seconds: int):
+        self.calls.append({"prompt": prompt, "context": context, "binding": dict(binding)})
+        parsed_context = json.loads(context)
+        parsed_prompt = json.loads(prompt)
+        evidence_ref = parsed_context["untrusted_repository_evidence"][0]["evidence_ref"]
+        lane_id = parsed_prompt["assignment"]["lane_id"]
+        output = {
+            "summary": f"{lane_id} verified read-only resident-cycle evidence.",
+            "evidence_refs": [evidence_ref],
+            "findings": [
+                {
+                    "finding_id": f"{lane_id}:resident-cycle",
+                    "claim": f"{lane_id} supports continuing the resident AgentDB cycle.",
+                    "wsp97_label": "OBSERVED",
+                    "recommended_action": "FIX",
+                    "wsp15_priority": "P1",
+                    "severity": "MAJOR",
+                    "evidence_refs": [evidence_ref],
+                    "next_slice_name": "REDDOG_RESIDENT_RUNTIME_NEXT_PHASE1",
+                }
+            ],
+        }
+        return RepoAuditModelResult(
+            ok=True,
+            status="MODEL_OK",
+            content=json.dumps(output, sort_keys=True),
+            model_receipt_id=f"model-receipt-{lane_id}",
+            model_result_digest=f"sha256:model-result-{lane_id}",
+            made_network_call=True,
+        )
+
+
+class _ArchitectRunner:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def run_architect_determination(self, *, prompt: str, context: str, binding, timeout_seconds: int):
+        self.calls.append({"prompt": prompt, "context": context, "binding": dict(binding)})
+        parsed = json.loads(prompt)
+        evidence_ref = parsed["reports"][0]["evidence_refs"][0]
+        content = {
+            "action": "FIX",
+            "next_slice_name": "REDDOG_RESIDENT_RUNTIME_NEXT_PHASE1",
+            "summary": "Read-only OpenClaw audit reports support one next resident runtime slice.",
+            "decision_reasons": ["selected highest-priority verified report"],
+            "evidence_refs": [evidence_ref],
+            "wsp15_allocation_receipt_id": parsed["wsp15_allocation_receipt_id"],
+        }
+        return ArchitectModelResult(
+            ok=True,
+            status="MODEL_OK",
+            content=json.dumps(content, sort_keys=True),
+            model_receipt_id="architect-model-receipt-resident",
+            model_result_digest="sha256:architect-model-result-resident",
+            review_packet={"fusion_panel_quorum": {"passed": True}},
+            made_network_call=True,
+            rejection_reasons=(),
+        )
+
+
+def _runtime_kwargs(**overrides):
+    kwargs = {
+        "repo_root": REPO_ROOT,
+        "red_dog_intent": _intent(),
+        "repo_state_override": _repo_state(),
+        "work_state_snapshot_override": _work_state(),
+        "holoindex_receipt_override": _fresh_holo_receipt(),
+        "now_iso": NOW,
+        "architect_determination_store": InMemoryArchitectDeterminationStore(),
+        "audit_model_runner": _AuditModelRunner(),
+        "architect_model_runner": _ArchitectRunner(),
+        "holoindex_adapter": _FakeQueryAdapter(),
+        "codeindex_adapter": _FakeQueryAdapter(),
+        "external_research_retriever": _FakeExternalResearchRetriever(),
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+def test_durable_cycle_submits_agentdb_tasks_openclaw_claims_reports_and_determines() -> None:
+    result = run_reddog_resident_architect_durable_agentdb_cycle(**_runtime_kwargs())
+
+    assert result.accepted is True
+    assert result.decision == REDDOG_RESIDENT_CYCLE_ACCEPT
+    assert result.status == STATUS_DETERMINED
+    assert result.snapshot_id
+    assert result.determination_id
+    assert len(result.task_ids) == 5
+    assert result.task_status_counts == {"completed": 5}
+    assert len(result.openclaw_claims) == 5
+    assert all(claim["accepted"] is True for claim in result.openclaw_claims)
+    assert result.architect_determination_id
+    assert result.architect_action == "FIX"
+    assert result.queue_candidate_count == 1
+    assert result.read_only_authority_only is True
+    assert result.no_repo_mutation_performed is True
+    assert result.no_holoindex_reindex_performed is True
+
+    tasks = AgentDB().get_autonomous_tasks(status="completed", limit=10)
+    assert len([task for task in tasks if task["discovered_by"] == READONLY_AUDIT_TASK_SOURCE]) == 5
+
+
+def test_duplicate_intent_reconnects_to_persisted_cycle_without_new_claims() -> None:
+    first = run_reddog_resident_architect_durable_agentdb_cycle(**_runtime_kwargs())
+    assert first.accepted is True
+
+    second = run_reddog_resident_architect_durable_agentdb_cycle(**_runtime_kwargs())
+
+    assert second.accepted is True
+    assert second.status == STATUS_DETERMINED
+    assert second.cycle_id == first.cycle_id
+    assert second.duplicate_intent_reused is True
+    assert len(second.openclaw_claims) == len(first.openclaw_claims) == 5
+    assert tuple(claim["task_id"] for claim in second.openclaw_claims) == tuple(
+        claim["task_id"] for claim in first.openclaw_claims
+    )
+    assert AgentDB().get_autonomous_tasks(status="completed", limit=20)
+
+
+def test_missing_external_research_retriever_fails_before_agentdb_enqueue() -> None:
+    result = run_reddog_resident_architect_durable_agentdb_cycle(
+        **_runtime_kwargs(external_research_retriever=None)
+    )
+
+    assert result.accepted is False
+    assert result.decision == REDDOG_RESIDENT_CYCLE_REJECT
+    assert ResidentCycleReason.EXTERNAL_RESEARCH_RETRIEVER_MISSING in result.rejection_reasons
+    assert AgentDB().get_autonomous_tasks(status="pending", limit=10) == []
+
+
+def test_timeout_when_openclaw_does_not_claim_tasks() -> None:
+    result = run_reddog_resident_architect_durable_agentdb_cycle(
+        **_runtime_kwargs(max_claims=0)
+    )
+
+    assert result.accepted is False
+    assert result.status == STATUS_TIMED_OUT
+    assert ResidentCycleReason.TIMEOUT in result.rejection_reasons
+    assert result.task_status_counts == {"pending": 5}
+    assert result.architect_determination_id is None
+
+
+def test_cancel_unknown_intent_returns_cancelled_without_side_effects() -> None:
+    result = run_reddog_resident_architect_durable_agentdb_cycle(
+        **_runtime_kwargs(cancel_requested=True)
+    )
+
+    assert result.accepted is False
+    assert ResidentCycleReason.CANCELLED in result.rejection_reasons
+    assert AgentDB().get_autonomous_tasks(status="pending", limit=10) == []
+
+
+def test_runtime_module_has_no_shell_worktree_repo_mutation_or_reindex_imports() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imports = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+    assert "subprocess" not in imports
+    forbidden_text = (
+        "git push",
+        "gh pr",
+        "holo_index.py --index",
+        "hermes_job_executor",
+        "worktree add",
+        "PatternMemory.promote",
+    )
+    for text in forbidden_text:
+        assert text not in source

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_session_bridge.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_session_bridge.py
@@ -16,11 +16,6 @@ SPEC.loader.exec_module(bridge)
 
 
 def _accepted_result():
-    initial = SimpleNamespace(
-        status="READY",
-        snapshot_receipt_id="sha256:snapshot",
-        swarm_id="sha256:swarm",
-    )
     final = SimpleNamespace(
         status="READY",
         snapshot_receipt_id="sha256:final",
@@ -31,12 +26,21 @@ def _accepted_result():
     )
     return SimpleNamespace(
         accepted=True,
-        status="READONLY_AUDIT_RESEARCH_DECISION_E2E_ACCEPT",
-        initial_bootstrap=initial,
+        status="DETERMINED",
+        intent_id="sha256:intent",
+        cycle_id="sha256:cycle",
+        snapshot_id="sha256:snapshot",
+        swarm_id="sha256:swarm",
+        task_ids=("task-a", "task-b"),
+        task_status_counts={"completed": 2},
+        openclaw_claims=({"accepted": True}, {"accepted": True}),
+        duplicate_intent_reused=False,
+        recovered_existing_cycle=False,
         final_bootstrap=final,
-        task_runs=(SimpleNamespace(persist_accepted=True), SimpleNamespace(persist_accepted=True)),
-        readonly_audit_tasks_enqueued=True,
-        readonly_audit_tasks_executed=True,
+        architect_action="FIX",
+        architect_next_slice="REDDOG_NEXT_PHASE1",
+        architect_determination_id="sha256:architect",
+        queue_candidate_count=1,
         rejection_reasons=(),
         no_shell_command_executed=True,
         no_repo_mutation_performed=True,
@@ -46,7 +50,6 @@ def _accepted_result():
         no_pr_created=True,
         no_pattern_memory_promotion_performed=True,
         no_live_foundup_enqueue_performed=True,
-        coding_worker_spawned=False,
     )
 
 
@@ -60,17 +63,22 @@ def test_resident_architect_session_requires_explicit_request() -> None:
     assert result["no_holoindex_reindex_performed"] is True
 
 
-def test_resident_architect_session_summarizes_e2e_runtime(monkeypatch) -> None:
+def test_resident_architect_session_summarizes_durable_cycle_runtime(monkeypatch) -> None:
     calls = []
 
-    def fake_e2e(**kwargs):
+    def fake_cycle(**kwargs):
         calls.append(kwargs)
         return _accepted_result()
 
-    monkeypatch.setattr(bridge, "run_reddog_readonly_audit_research_decision_e2e", fake_e2e)
+    monkeypatch.setattr(bridge, "run_reddog_resident_architect_durable_agentdb_cycle", fake_cycle)
     result = bridge._result(
         {
             "explicit_resident_architect_session_requested": True,
+            "red_dog_intent": {
+                "schema_version": "reddog_intent.v1",
+                "intent_id": "sha256:intent",
+                "submits_executable_authority": False,
+            },
             "repo_root": ".",
             "work_focus": "audit resident loop",
             "work_state_path": "O:/state/work_state.json",
@@ -81,15 +89,19 @@ def test_resident_architect_session_summarizes_e2e_runtime(monkeypatch) -> None:
     )
 
     assert calls and calls[0]["requested_operation"] == "extension_resident_architect_session"
+    assert calls[0]["red_dog_intent"]["intent_id"] == "sha256:intent"
     assert calls[0]["prompt_text"] == "audit resident loop"
     assert calls[0]["timeout_seconds"] == 13
     assert result["decision"] == bridge.RESIDENT_ARCHITECT_SESSION_ACCEPT
     assert result["accepted"] is True
     assert result["resident_backend_invoked"] is True
+    assert result["durable_agentdb_cycle"] is True
+    assert result["cycle_id"] == "sha256:cycle"
     assert result["snapshot_id"] == "sha256:snapshot"
     assert result["swarm_id"] == "sha256:swarm"
     assert result["task_count"] == 2
     assert result["reports_persisted"] == 2
+    assert result["openclaw_claim_count"] == 2
     assert result["architect_action"] == "FIX"
     assert result["architect_next_slice"] == "REDDOG_NEXT_PHASE1"
     assert result["queue_candidate_count"] == 1
@@ -99,11 +111,20 @@ def test_resident_architect_session_summarizes_e2e_runtime(monkeypatch) -> None:
 
 
 def test_resident_architect_session_bridge_failure_fails_closed(monkeypatch) -> None:
-    def fail_e2e(**kwargs):
+    def fail_cycle(**kwargs):
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(bridge, "run_reddog_readonly_audit_research_decision_e2e", fail_e2e)
-    result = bridge._result({"explicit_resident_architect_session_requested": True})
+    monkeypatch.setattr(bridge, "run_reddog_resident_architect_durable_agentdb_cycle", fail_cycle)
+    result = bridge._result(
+        {
+            "explicit_resident_architect_session_requested": True,
+            "red_dog_intent": {
+                "schema_version": "reddog_intent.v1",
+                "intent_id": "sha256:intent",
+                "submits_executable_authority": False,
+            },
+        }
+    )
 
     assert result["decision"] == bridge.RESIDENT_ARCHITECT_SESSION_REJECT
     assert result["resident_backend_invoked"] is True

--- a/scripts/reddog_resident_architect_session_once.py
+++ b/scripts/reddog_resident_architect_session_once.py
@@ -1,12 +1,12 @@
-"""One-shot bridge for RedDog thin client -> resident architect session.
+"""One-shot bridge for RedDog thin client -> durable resident architect cycle.
 
 Slice: REDDOG_EXTENSION_TO_RESIDENT_ARCHITECT_SESSION_RUNTIME_PHASE1
 
 The editor runtime may call this script only when the resident architect
-session is explicitly enabled. It delegates to the read-only audit/research/
-decision E2E runtime and returns a bounded status packet. It does not perform
-source mutation, shell work, worktree creation, PR creation, HoloIndex re-index,
-Hermes dispatch, or live FoundUp enqueue.
+session is explicitly enabled. It delegates to the durable AgentDB resident
+cycle runtime and returns a bounded status packet. It does not perform source
+mutation, shell work, worktree creation, PR creation, HoloIndex re-index,
+Hermes dispatch, live FoundUp enqueue, or direct inline task execution.
 """
 
 from __future__ import annotations
@@ -21,8 +21,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from modules.communication.moltbot_bridge.src.reddog_readonly_audit_research_decision_e2e_runtime import (  # noqa: E402
-    run_reddog_readonly_audit_research_decision_e2e,
+from modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle import (  # noqa: E402
+    run_reddog_resident_architect_durable_agentdb_cycle,
 )
 
 RESIDENT_ARCHITECT_SESSION_ACCEPT = "RESIDENT_ARCHITECT_SESSION_ACCEPT"
@@ -81,38 +81,72 @@ def _reject(reason: str, *, bridge_error_class: str | None = None) -> Dict[str, 
     return output
 
 
+class _ConfiguredExternalResearchRetriever:
+    """File-backed approved external research snapshot retriever.
+
+    The resident bridge requires a configured retriever. A JSON snapshot file
+    path is supplied through REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH. The file is
+    treated as untrusted data by downstream grounding; this bridge only returns
+    it to the governed adapter.
+    """
+
+    def __init__(self, snapshot_path: Path) -> None:
+        self.snapshot_path = snapshot_path
+
+    def fetch(self, target: Mapping[str, Any]) -> Mapping[str, Any]:
+        try:
+            payload = json.loads(self.snapshot_path.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+        if isinstance(payload, dict) and isinstance(payload.get("snapshots"), list):
+            url = str(target.get("url") or target.get("target") or "")
+            for item in payload["snapshots"]:
+                if isinstance(item, dict) and str(item.get("source_url") or item.get("url") or "") == url:
+                    return item
+        return payload if isinstance(payload, dict) else {}
+
+
+def _external_retriever_from_env() -> Any | None:
+    raw_path = os.getenv("REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH", "").strip()
+    if not raw_path:
+        return None
+    path = Path(raw_path)
+    return _ConfiguredExternalResearchRetriever(path) if path.is_file() else None
+
+
 def _summarize_result(result: Any) -> Dict[str, Any]:
-    initial = result.initial_bootstrap
     final = result.final_bootstrap
     final_status = final.status if final else ""
-    reports_persisted = sum(1 for task in result.task_runs if task.persist_accepted)
     return {
         "decision": RESIDENT_ARCHITECT_SESSION_ACCEPT if result.accepted else RESIDENT_ARCHITECT_SESSION_REJECT,
         "accepted": bool(result.accepted),
         "status": str(result.status),
         "resident_backend_invoked": True,
         "red_dog_intent_submitted": True,
+        "durable_agentdb_cycle": True,
         "python_invocation_performed": True,
-        "snapshot_id": _string(getattr(initial, "snapshot_receipt_id", "")),
+        "snapshot_id": _string(result.snapshot_id),
         "final_snapshot_id": _string(getattr(final, "snapshot_receipt_id", "")) if final else "",
-        "swarm_id": _string(getattr(initial, "swarm_id", "")),
-        "cycle_id": _string(getattr(initial, "swarm_id", "")),
-        "initial_status": _string(getattr(initial, "status", "")),
+        "swarm_id": _string(result.swarm_id),
+        "cycle_id": _string(result.cycle_id),
+        "intent_id": _string(result.intent_id),
+        "initial_status": _string(result.status),
         "final_status": final_status,
-        "task_count": len(result.task_runs),
-        "reports_persisted": reports_persisted,
-        "readonly_audit_tasks_enqueued": bool(result.readonly_audit_tasks_enqueued),
-        "readonly_audit_tasks_executed": bool(result.readonly_audit_tasks_executed),
-        "architect_action": _string(getattr(final, "backend_architect_determination_action", "")) if final else "",
-        "architect_next_slice": (
-            _string(getattr(final, "backend_architect_determination_next_slice", "")) if final else ""
+        "task_count": len(result.task_ids),
+        "task_status_counts": dict(result.task_status_counts),
+        "reports_persisted": int(result.task_status_counts.get("completed", 0)),
+        "readonly_audit_tasks_enqueued": bool(result.task_ids),
+        "readonly_audit_tasks_executed": (
+            int(result.task_status_counts.get("completed", 0)) == len(result.task_ids)
+            and bool(result.task_ids)
         ),
-        "architect_determination_id": (
-            _string(getattr(final, "backend_architect_determination_id", "")) if final else ""
-        ),
-        "queue_candidate_count": int(
-            getattr(final, "backend_architect_determination_queue_candidate_count", 0) if final else 0
-        ),
+        "openclaw_claim_count": len(result.openclaw_claims),
+        "recovered_existing_cycle": bool(result.recovered_existing_cycle),
+        "duplicate_intent_reused": bool(result.duplicate_intent_reused),
+        "architect_action": _string(result.architect_action),
+        "architect_next_slice": _string(result.architect_next_slice),
+        "architect_determination_id": _string(result.architect_determination_id),
+        "queue_candidate_count": int(result.queue_candidate_count),
         "rejection_reasons": list(result.rejection_reasons),
         "no_shell_command_executed": bool(result.no_shell_command_executed),
         "no_repo_mutation_performed": bool(result.no_repo_mutation_performed),
@@ -122,13 +156,16 @@ def _summarize_result(result: Any) -> Dict[str, Any]:
         "no_pr_created": bool(result.no_pr_created),
         "no_pattern_memory_promotion_performed": bool(result.no_pattern_memory_promotion_performed),
         "no_live_foundup_enqueue_performed": bool(result.no_live_foundup_enqueue_performed),
-        "coding_worker_spawned": bool(result.coding_worker_spawned),
+        "coding_worker_spawned": False,
     }
 
 
 def _result(payload: Mapping[str, Any]) -> Dict[str, Any]:
     if payload.get("_bridge_error"):
-        return _reject(str(payload["_bridge_error"]), bridge_error_class=str(payload.get("_bridge_error_class") or "Error"))
+        return _reject(
+            str(payload["_bridge_error"]),
+            bridge_error_class=str(payload.get("_bridge_error_class") or "Error"),
+        )
     if payload.get("explicit_resident_architect_session_requested") is not True:
         return _reject("explicit_resident_architect_session_request_missing")
     intent = payload.get("red_dog_intent")
@@ -140,22 +177,26 @@ def _result(payload: Mapping[str, Any]) -> Dict[str, Any]:
     repo_root_text = payload.get("repo_root")
     repo_root = Path(str(repo_root_text)).resolve() if repo_root_text else REPO_ROOT
     try:
-        result = run_reddog_readonly_audit_research_decision_e2e(
+        result = run_reddog_resident_architect_durable_agentdb_cycle(
             repo_root=repo_root,
-            work_state_path=_string(payload.get("work_state_path") or os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", "")),
-            holoindex_receipt_path=_string(payload.get("holoindex_receipt_path") or os.getenv("HOLOINDEX_FRESHNESS_RECEIPT", "")),
+            red_dog_intent=intent,
+            work_state_path=_string(
+                payload.get("work_state_path") or os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", "")
+            ),
+            holoindex_receipt_path=_string(
+                payload.get("holoindex_receipt_path") or os.getenv("HOLOINDEX_FRESHNESS_RECEIPT", "")
+            ),
             holoindex_ssd_path=_string(payload.get("holoindex_ssd_path") or os.getenv("HOLOINDEX_SSD_PATH", "")),
             requested_operation="extension_resident_architect_session",
             prompt_text=_string(payload.get("work_focus") or "extension resident RedDog architect session"),
+            external_research_retriever=_external_retriever_from_env(),
             timeout_seconds=_int(payload.get("timeout_seconds"), 60),
         )
     except Exception as exc:
         output = _reject("resident_architect_session_bridge_failed", bridge_error_class=type(exc).__name__)
         output["resident_backend_invoked"] = True
         return output
-    summary = _summarize_result(result)
-    summary["intent_id"] = _string(payload.get("intent_id") or intent.get("intent_id"))
-    return summary
+    return _summarize_result(result)
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
- add a durable AgentDB-backed RedDog resident architect cycle for reddog_intent.v1 submission, recovery, duplicate handling, cancellation/timeout, and backend architect determination persistence
- add an OpenClaw-owned RedDog read-only audit claim seam so audit tasks are claimed from AgentDB instead of run through the prior inline E2E shortcut
- update the resident architect bridge to return cycle/task/claim progress from the durable runtime

## Validation
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_session_bridge.py -q
- python -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_enqueue.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_report_collection.py -q
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_backend_architect_determination_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_research_decision_e2e_runtime.py -q
- git diff --check
- python -m py_compile modules/communication/moltbot_bridge/src/reddog_resident_architect_durable_agentdb_cycle.py scripts/reddog_resident_architect_session_once.py

## Boundary
Read-only authority only. No shell execution, repo mutation, HoloIndex re-index, Hermes dispatch, worktree operation, PR publishing, PatternMemory promotion, or live FoundUp enqueue.