### PR TITLE
feat(reddog): supply operational memex snapshots to resident tasks

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,27 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_OPERATIONAL_MEMEX_SNAPSHOT_SUPPLIER_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added an operational Memex snapshot supplier wrapper for resident RedDog
+  read-only audit tasks. It assembles a FoundUp Memex view from the accepted
+  operational snapshot and injects assignment-bound Memex bindings into
+  AgentDB task context before OpenClaw workers claim the task.
+- Wired optional Memex supply through the main read-only bootstrap, durable
+  resident AgentDB cycle, and thin-client bridge payload while keeping the
+  default resident cycle unchanged.
+- Added a HoloIndex generation binding to operational snapshots so Memex
+  projections bind to the exact retrieval generation used by the resident
+  cycle.
+- Tightened worker model-context packing so Memex remains supplemental and
+  cannot crowd out current repository evidence; full Memex receipt IDs remain
+  bound in worker receipts.
+- Boundary remains read-only: no Memex write, Brain/Breadcrumb write,
+  HoloIndex re-index, shell, repo mutation, worker spawn expansion, Hermes
+  dispatch, worktree operation, PR, PatternMemory promotion, or live FoundUp
+  enqueue.
+
 ## 2026-07-16: REDDOG_RESIDENT_ARCHITECT_DURABLE_AGENTDB_CYCLE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
@@ -32,6 +32,11 @@ from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swa
     ReadOnlyAuditTaskWriter,
     enqueue_reddog_readonly_audit_swarm,
 )
+from modules.communication.moltbot_bridge.src.reddog_operational_memex_snapshot_supplier import (
+    OperationalMemexReadOnlyAuditTaskWriter,
+    OperationalMemexSnapshotSupplyConfig,
+    OperationalMemexTaskEnrichmentResult,
+)
 from modules.communication.moltbot_bridge.src.reddog_readonly_audit_report_collection import (
     AgentDbReadOnlyAuditReportStore,
     ReadOnlyAuditReportCollectionResult,
@@ -130,6 +135,10 @@ class RedDogMainReadonlyBootstrapResult:
     enqueue_receipt_id: Optional[str] = None
     enqueue_task_count: int = 0
     enqueue_rejection_reasons: tuple[str, ...] = ()
+    memex_snapshot_supply_attempted: bool = False
+    memex_snapshot_supply_status: Optional[str] = None
+    memex_snapshot_supply_view_id: Optional[str] = None
+    memex_snapshot_supply_rejection_reasons: tuple[str, ...] = ()
     no_model_call_performed: bool = True
     no_worker_spawn_performed: bool = True
     no_openclaw_enqueue_performed: bool = True
@@ -156,9 +165,14 @@ def run_reddog_main_readonly_operational_bootstrap(
     repo_state_override: Mapping[str, Any] | None = None,
     work_state_snapshot_override: Mapping[str, Any] | None = None,
     holoindex_receipt_override: HoloIndexFreshnessReceipt | Mapping[str, Any] | None = None,
+    breadcrumbs: Sequence[Mapping[str, Any]] = (),
+    brain_state: Mapping[str, Any] | None = None,
+    workspace_memory_notes: Sequence[Mapping[str, Any]] = (),
+    bootstrap_projection: Mapping[str, Any] | None = None,
     audit_lanes: Sequence[str] = DEFAULT_AUDIT_LANES,
     enqueue_readonly_audit_tasks: bool = False,
     enqueue_writer: ReadOnlyAuditTaskWriter | None = None,
+    memex_snapshot_supply_config: OperationalMemexSnapshotSupplyConfig | Mapping[str, Any] | None = None,
     seen_assignment_ids: Optional[set[str]] = None,
     collect_readonly_audit_reports: bool = False,
     report_store: ReadOnlyAuditReportStore | None = None,
@@ -227,6 +241,10 @@ def run_reddog_main_readonly_operational_bootstrap(
         changed_paths=paths,
         now_iso=now_iso,
         breadcrumb_scope=str(work_state_snapshot.get("selected_slice") or "main_startup"),
+        breadcrumbs=breadcrumbs,
+        brain_state=brain_state,
+        workspace_memory_notes=workspace_memory_notes,
+        bootstrap_projection=bootstrap_projection,
     )
     if not snapshot_result.accepted or snapshot_result.snapshot is None or snapshot_result.context_view is None:
         return _not_ready(
@@ -286,6 +304,7 @@ def run_reddog_main_readonly_operational_bootstrap(
     decision_result: ReadOnlyAuditDecisionReceipt | None = None
     decision_persist_result: ReadOnlyAuditDecisionPersistResult | None = None
     architect_result: BackendArchitectDeterminationResult | None = None
+    memex_supply_result: OperationalMemexTaskEnrichmentResult | None = None
     if collect_readonly_audit_reports:
         reader = report_store if report_store is not None else AgentDbReadOnlyAuditReportStore()
         collection_result = collect_reddog_readonly_audit_report_bundle(
@@ -420,11 +439,22 @@ def run_reddog_main_readonly_operational_bootstrap(
     enqueue_result: ReadOnlyAuditSwarmEnqueueResult | None = None
     if enqueue_readonly_audit_tasks:
         writer = enqueue_writer if enqueue_writer is not None else AgentDbReadOnlyAuditTaskWriter()
+        memex_writer: OperationalMemexReadOnlyAuditTaskWriter | None = None
+        if memex_snapshot_supply_config is not None:
+            memex_writer = OperationalMemexReadOnlyAuditTaskWriter(
+                delegate=writer,
+                snapshot=snapshot,
+                config=memex_snapshot_supply_config,
+                now_iso=now_iso,
+            )
+            writer = memex_writer
         enqueue_result = enqueue_reddog_readonly_audit_swarm(
             plan=plan,
             writer=writer,
             seen_assignment_ids=seen_assignment_ids,
         )
+        if memex_writer is not None:
+            memex_supply_result = memex_writer.last_result
         if not enqueue_result.accepted:
             return _not_ready(
                 reasons=("readonly_audit_enqueue_rejected", *enqueue_result.rejection_reasons),
@@ -440,6 +470,7 @@ def run_reddog_main_readonly_operational_bootstrap(
                 decision_persist_result=decision_persist_result,
                 architect_result=architect_result,
                 enqueue_result=enqueue_result,
+                memex_supply_result=memex_supply_result,
             )
 
     return _ready(
@@ -457,6 +488,7 @@ def run_reddog_main_readonly_operational_bootstrap(
         architect_result=architect_result,
         enqueue_result=enqueue_result,
         enqueue_attempted=enqueue_readonly_audit_tasks,
+        memex_supply_result=memex_supply_result,
     )
 
 
@@ -476,6 +508,7 @@ def _ready(
     architect_result: BackendArchitectDeterminationResult | None,
     enqueue_result: ReadOnlyAuditSwarmEnqueueResult | None,
     enqueue_attempted: bool,
+    memex_supply_result: OperationalMemexTaskEnrichmentResult | None = None,
 ) -> RedDogMainReadonlyBootstrapResult:
     assert gate.determination_binding is not None
     bundle = collection_result.validation.bundle if collection_result and collection_result.validation else None
@@ -533,6 +566,12 @@ def _ready(
         enqueue_receipt_id=enqueue_result.receipt.enqueue_receipt_id if enqueue_result else None,
         enqueue_task_count=len(enqueue_result.tasks) if enqueue_result else 0,
         enqueue_rejection_reasons=enqueue_result.rejection_reasons if enqueue_result else (),
+        memex_snapshot_supply_attempted=memex_supply_result is not None,
+        memex_snapshot_supply_status=memex_supply_result.status if memex_supply_result else None,
+        memex_snapshot_supply_view_id=memex_supply_result.memex_view_id if memex_supply_result else None,
+        memex_snapshot_supply_rejection_reasons=(
+            memex_supply_result.rejection_reasons if memex_supply_result else ()
+        ),
         no_openclaw_enqueue_performed=not bool(enqueue_result and enqueue_result.accepted),
         no_queue_mutation_performed=not bool(enqueue_result and enqueue_result.accepted),
         no_model_call_performed=not bool(
@@ -587,6 +626,7 @@ def _not_ready(
     decision_persist_result: ReadOnlyAuditDecisionPersistResult | None = None,
     architect_result: BackendArchitectDeterminationResult | None = None,
     enqueue_result: ReadOnlyAuditSwarmEnqueueResult | None = None,
+    memex_supply_result: OperationalMemexTaskEnrichmentResult | None = None,
 ) -> RedDogMainReadonlyBootstrapResult:
     determination_id = None
     if gate and gate.determination_binding:
@@ -649,6 +689,12 @@ def _not_ready(
         enqueue_receipt_id=enqueue_result.receipt.enqueue_receipt_id if enqueue_result else None,
         enqueue_task_count=len(enqueue_result.tasks) if enqueue_result and enqueue_result.accepted else 0,
         enqueue_rejection_reasons=enqueue_result.rejection_reasons if enqueue_result else (),
+        memex_snapshot_supply_attempted=memex_supply_result is not None,
+        memex_snapshot_supply_status=memex_supply_result.status if memex_supply_result else None,
+        memex_snapshot_supply_view_id=memex_supply_result.memex_view_id if memex_supply_result else None,
+        memex_snapshot_supply_rejection_reasons=(
+            memex_supply_result.rejection_reasons if memex_supply_result else ()
+        ),
         no_model_call_performed=not bool(
             architect_result and architect_result.receipt.model_result_digest
         ),

--- a/modules/communication/moltbot_bridge/src/reddog_operational_context_snapshot.py
+++ b/modules/communication/moltbot_bridge/src/reddog_operational_context_snapshot.py
@@ -552,12 +552,16 @@ def _normalize_holoindex_state(
     )
     receipt_digest = _digest(receipt.to_dict() if hasattr(receipt, "to_dict") else receipt or {})
     receipt_head = ""
+    generation_id = ""
     if isinstance(receipt, HoloIndexFreshnessReceipt):
         receipt_head = receipt.repo_head_sha
+        generation_id = receipt.generation_id
     elif isinstance(receipt, Mapping):
         receipt_head = str(receipt.get("repo_head_sha", ""))
+        generation_id = str(receipt.get("generation_id", ""))
     return {
         "receipt_digest": receipt_digest,
+        "generation_id": generation_id,
         "repo_head_sha": receipt_head,
         "freshness_ok": check.ok,
         "required_collections": tuple(check.required_collections),

--- a/modules/communication/moltbot_bridge/src/reddog_operational_memex_snapshot_supplier.py
+++ b/modules/communication/moltbot_bridge/src/reddog_operational_memex_snapshot_supplier.py
@@ -1,0 +1,330 @@
+"""Operational Memex snapshot supplier for resident RedDog audit tasks.
+
+Slice: REDDOG_OPERATIONAL_MEMEX_SNAPSHOT_SUPPLIER_PHASE1
+
+This module enriches already planned read-only audit task packets with an
+assignment-bound FoundUp Memex view. It does not project into HoloIndex, query
+HoloIndex, write Memex, write Brain/Breadcrumbs, re-index, execute shell, spawn
+workers, or mutate repository state. The worker runtime owns projection,
+integrity rehydration, query receipt creation, and citation policy.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field, replace
+from typing import Any, Mapping, Sequence
+
+from modules.communication.moltbot_bridge.src.foundup_memex_current_state import (
+    assemble_foundup_memex_current_state,
+)
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
+    ReadOnlyAuditSwarmEnqueueReceipt,
+    ReadOnlyAuditTaskSpec,
+    ReadOnlyAuditTaskWriter,
+)
+from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
+    OperationalContextSnapshot,
+)
+
+
+OPERATIONAL_MEMEX_SUPPLY_ACCEPT = "OPERATIONAL_MEMEX_SUPPLY_ACCEPT"
+OPERATIONAL_MEMEX_SUPPLY_REJECT = "OPERATIONAL_MEMEX_SUPPLY_REJECT"
+
+
+@dataclass(frozen=True)
+class OperationalMemexSnapshotSupplyConfig:
+    """Typed operator-approved Memex supply config for one resident cycle."""
+
+    foundup_id: str
+    principal_id: str
+    identity: Mapping[str, Any] = field(default_factory=dict)
+    roadmap_state: Mapping[str, Any] = field(default_factory=dict)
+    verified_outcomes: tuple[Mapping[str, Any], ...] = ()
+    policy_issued_at: str = ""
+    policy_expires_at: str = ""
+    holoindex_generation_id: str = ""
+    source_revision: str = ""
+    max_records: int = 32
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class OperationalMemexTaskEnrichmentResult:
+    """Result from adding operational Memex bindings to task contexts."""
+
+    accepted: bool
+    status: str
+    tasks: tuple[ReadOnlyAuditTaskSpec, ...]
+    memex_view_id: str | None
+    rejection_reasons: tuple[str, ...]
+    no_memex_write_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_shell_command_executed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "accepted": self.accepted,
+            "status": self.status,
+            "tasks": [task.to_dict() for task in self.tasks],
+            "memex_view_id": self.memex_view_id,
+            "rejection_reasons": list(self.rejection_reasons),
+            "no_memex_write_performed": self.no_memex_write_performed,
+            "no_holoindex_reindex_performed": self.no_holoindex_reindex_performed,
+            "no_repo_mutation_performed": self.no_repo_mutation_performed,
+            "no_worker_spawn_performed": self.no_worker_spawn_performed,
+            "no_shell_command_executed": self.no_shell_command_executed,
+        }
+
+
+class OperationalMemexReadOnlyAuditTaskWriter:
+    """Read-only writer wrapper that supplies Memex context before enqueue."""
+
+    def __init__(
+        self,
+        *,
+        delegate: ReadOnlyAuditTaskWriter,
+        snapshot: OperationalContextSnapshot,
+        config: OperationalMemexSnapshotSupplyConfig | Mapping[str, Any],
+        now_iso: str | None = None,
+    ) -> None:
+        self.delegate = delegate
+        self.snapshot = snapshot
+        self.config = normalize_operational_memex_supply_config(config)
+        self.now_iso = now_iso
+        self.last_result: OperationalMemexTaskEnrichmentResult | None = None
+
+    def enqueue_readonly_audit_tasks(
+        self,
+        tasks: Sequence[ReadOnlyAuditTaskSpec],
+        receipt: ReadOnlyAuditSwarmEnqueueReceipt,
+    ) -> Mapping[str, Any]:
+        result = enrich_readonly_audit_tasks_with_operational_memex(
+            tasks=tasks,
+            snapshot=self.snapshot,
+            config=self.config,
+            now_iso=self.now_iso,
+        )
+        self.last_result = result
+        if not result.accepted:
+            return {
+                "ok": False,
+                "reason": "operational_memex_supply_rejected",
+                "rejection_reasons": list(result.rejection_reasons),
+                "created_task_ids": [],
+            }
+        return self.delegate.enqueue_readonly_audit_tasks(result.tasks, receipt)
+
+
+def normalize_operational_memex_supply_config(
+    config: OperationalMemexSnapshotSupplyConfig | Mapping[str, Any],
+) -> OperationalMemexSnapshotSupplyConfig:
+    """Normalize a mapping into a typed supply config without guessing scope."""
+
+    if isinstance(config, OperationalMemexSnapshotSupplyConfig):
+        return config
+    data = dict(config or {})
+    outcomes = data.get("verified_outcomes") or ()
+    if isinstance(outcomes, Mapping):
+        outcomes = (outcomes,)
+    return OperationalMemexSnapshotSupplyConfig(
+        foundup_id=_clean(data.get("foundup_id")),
+        principal_id=_clean(data.get("principal_id")),
+        identity=dict(data.get("identity") or {}),
+        roadmap_state=dict(data.get("roadmap_state") or {}),
+        verified_outcomes=tuple(dict(item) for item in outcomes if isinstance(item, Mapping)),
+        policy_issued_at=_clean(data.get("policy_issued_at")),
+        policy_expires_at=_clean(data.get("policy_expires_at")),
+        holoindex_generation_id=_clean(data.get("holoindex_generation_id")),
+        source_revision=_clean(data.get("source_revision")),
+        max_records=_positive_int(data.get("max_records"), default=32),
+    )
+
+
+def enrich_readonly_audit_tasks_with_operational_memex(
+    *,
+    tasks: Sequence[ReadOnlyAuditTaskSpec],
+    snapshot: OperationalContextSnapshot,
+    config: OperationalMemexSnapshotSupplyConfig | Mapping[str, Any],
+    now_iso: str | None = None,
+) -> OperationalMemexTaskEnrichmentResult:
+    """Attach a snapshot-bound Memex view and assignment bindings to tasks."""
+
+    cfg = normalize_operational_memex_supply_config(config)
+    reasons = _validate_config(cfg)
+    if not isinstance(snapshot, OperationalContextSnapshot):
+        reasons.append("missing_operational_snapshot")
+    if not tasks:
+        reasons.append("missing_readonly_audit_tasks")
+    if isinstance(snapshot, OperationalContextSnapshot):
+        reasons.extend(_validate_snapshot_memory_sources(snapshot))
+    if reasons:
+        return _reject(reasons)
+
+    assert isinstance(snapshot, OperationalContextSnapshot)
+    issued_at = cfg.policy_issued_at or now_iso or snapshot.created_at
+    expires_at = cfg.policy_expires_at or snapshot.valid_until
+    generation_id = cfg.holoindex_generation_id or _clean(snapshot.holoindex_state.get("generation_id"))
+    source_revision = cfg.source_revision or _clean(snapshot.work_state.get("revision")) or snapshot.snapshot_content_digest
+    missing_runtime = [
+        name
+        for name, value in (
+            ("memex_policy_issued_at", issued_at),
+            ("memex_policy_expires_at", expires_at),
+            ("memex_holoindex_generation_id", generation_id),
+            ("memex_source_revision", source_revision),
+        )
+        if not value
+    ]
+    if missing_runtime:
+        return _reject(missing_runtime)
+
+    assembly = assemble_foundup_memex_current_state(
+        foundup_id=cfg.foundup_id,
+        snapshot=snapshot,
+        identity=cfg.identity,
+        roadmap_state=cfg.roadmap_state,
+        verified_outcomes=cfg.verified_outcomes,
+        now_iso=issued_at,
+        resident_mode=True,
+        legacy_single_foundup_compatibility=False,
+        policy_foundup_scope=(cfg.foundup_id,),
+    )
+    if not assembly.accepted or assembly.view is None:
+        return _reject("memex_view_assembly_failed:" + ",".join(assembly.rejection_reasons))
+
+    memex_view = assembly.view.to_dict()
+    view_id = _clean(memex_view.get("foundup_brain_view_id"))
+    enriched: list[ReadOnlyAuditTaskSpec] = []
+    for task in tasks:
+        context = dict(task.context)
+        assignment = dict(context.get("assignment") or {})
+        lane_id = _clean(assignment.get("lane_id")) or "unknown_lane"
+        assignment_id = _clean(assignment.get("assignment_id")) or task.task_id
+        binding = {
+            "foundup_id": cfg.foundup_id,
+            "principal_id": cfg.principal_id,
+            "work_order_id": assignment_id,
+            "memex_now_iso": issued_at,
+            "memex_policy_issued_at": issued_at,
+            "memex_policy_expires_at": expires_at,
+            "memex_source_scope": f"foundup:{cfg.foundup_id}:lane:{lane_id}",
+            "memex_source_revision": source_revision,
+            "memex_holoindex_generation_id": generation_id,
+        }
+        assignment.update(binding)
+        context.update(binding)
+        context["assignment"] = assignment
+        context["memex_view"] = memex_view
+        context["memex_snapshot_supply_receipt"] = {
+            "schema_version": "reddog_operational_memex_snapshot_supply_receipt.v1",
+            "foundup_id": cfg.foundup_id,
+            "principal_id": cfg.principal_id,
+            "snapshot_receipt_id": snapshot.snapshot_receipt_id,
+            "snapshot_content_digest": snapshot.snapshot_content_digest,
+            "memex_view_id": view_id,
+            "holoindex_generation_id": generation_id,
+            "source_revision": source_revision,
+            "policy_issued_at": issued_at,
+            "policy_expires_at": expires_at,
+            "assignment_id": assignment_id,
+            "lane_id": lane_id,
+            "receipt_id": _digest(
+                {
+                    "snapshot_receipt_id": snapshot.snapshot_receipt_id,
+                    "snapshot_content_digest": snapshot.snapshot_content_digest,
+                    "memex_view_id": view_id,
+                    "assignment_id": assignment_id,
+                    "lane_id": lane_id,
+                    "principal_id": cfg.principal_id,
+                    "foundup_id": cfg.foundup_id,
+                }
+            ),
+            "no_memex_write_performed": True,
+            "no_holoindex_reindex_performed": True,
+            "no_repo_mutation_performed": True,
+        }
+        enriched.append(replace(task, context=context))
+
+    return OperationalMemexTaskEnrichmentResult(
+        accepted=True,
+        status=OPERATIONAL_MEMEX_SUPPLY_ACCEPT,
+        tasks=tuple(enriched),
+        memex_view_id=view_id,
+        rejection_reasons=(),
+    )
+
+
+def _validate_config(config: OperationalMemexSnapshotSupplyConfig) -> list[str]:
+    reasons: list[str] = []
+    if not config.foundup_id:
+        reasons.append("missing_foundup_id")
+    if not config.principal_id:
+        reasons.append("missing_principal_id")
+    if not isinstance(config.identity, Mapping) or not config.identity:
+        reasons.append("missing_memex_identity")
+    if not isinstance(config.roadmap_state, Mapping) or not config.roadmap_state:
+        reasons.append("missing_memex_roadmap_state")
+    if config.max_records <= 0:
+        reasons.append("invalid_max_records")
+    return reasons
+
+
+def _validate_snapshot_memory_sources(snapshot: OperationalContextSnapshot) -> list[str]:
+    reasons: list[str] = []
+    if snapshot.brain_state.get("available") is not True:
+        reasons.append("brain_source_not_available")
+    if int(snapshot.brain_state.get("record_count") or 0) <= 0:
+        reasons.append("brain_source_empty")
+    if int(snapshot.breadcrumbs_state.get("record_count") or 0) <= 0:
+        reasons.append("breadcrumbs_source_empty")
+    return reasons
+
+
+def _reject(*reasons: Any) -> OperationalMemexTaskEnrichmentResult:
+    flattened: list[str] = []
+    for reason in reasons:
+        if isinstance(reason, (list, tuple)):
+            flattened.extend(str(item) for item in reason)
+        else:
+            flattened.append(str(reason))
+    return OperationalMemexTaskEnrichmentResult(
+        accepted=False,
+        status=OPERATIONAL_MEMEX_SUPPLY_REJECT,
+        tasks=(),
+        memex_view_id=None,
+        rejection_reasons=tuple(dict.fromkeys(item for item in flattened if item)),
+    )
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _positive_int(value: Any, *, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "OPERATIONAL_MEMEX_SUPPLY_ACCEPT",
+    "OPERATIONAL_MEMEX_SUPPLY_REJECT",
+    "OperationalMemexReadOnlyAuditTaskWriter",
+    "OperationalMemexSnapshotSupplyConfig",
+    "OperationalMemexTaskEnrichmentResult",
+    "enrich_readonly_audit_tasks_with_operational_memex",
+    "normalize_operational_memex_supply_config",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
@@ -69,6 +69,9 @@ RUNTIME_MODE_FOUNDUPS_FUSION = "foundups_fusion"
 
 MAX_MODEL_PROMPT_CHARS = 24_000
 MAX_MODEL_CONTEXT_CHARS = 36_000
+MAX_MEMEX_EVIDENCE_RECORD_CHARS = 1_200
+MAX_MODEL_MEMEX_RECORD_CHARS = 240
+MAX_MODEL_MEMEX_RECORDS = 1
 MAX_DISCOVERED_TARGETS = 16
 FRESH_INDEX_STATES = frozenset({"CURRENT", "FRESH"})
 
@@ -800,6 +803,7 @@ def _optional_memex_query_artifacts(
         bundle_result = build_memex_content_evidence_bundle(
             query_receipt=receipt,
             projection=gate.projection,
+            max_record_chars=MAX_MEMEX_EVIDENCE_RECORD_CHARS,
         )
         if not bundle_result.accepted or bundle_result.bundle is None:
             return (
@@ -1321,14 +1325,81 @@ def _build_repo_audit_model_context(
         "no_holoindex_reindex_performed": True,
     }
     if memex_receipt is not None:
-        payload["memex_query_receipt"] = memex_receipt
+        payload["memex_query_receipt"] = _compact_memex_query_receipt(memex_receipt)
     if memex_evidence_bundle is not None:
-        payload["memex_evidence_bundle"] = memex_evidence_bundle
+        payload["memex_evidence_bundle"] = _compact_memex_evidence_bundle(memex_evidence_bundle)
     if external_research_receipt is not None:
         payload["external_research_query_receipt"] = external_research_receipt
     if external_research_evidence_bundle is not None:
         payload["untrusted_external_research_evidence"] = external_research_evidence_bundle
-    return _budgeted_json(payload, MAX_MODEL_CONTEXT_CHARS)
+    try:
+        return _budgeted_json(payload, MAX_MODEL_CONTEXT_CHARS)
+    except ValueError:
+        if memex_evidence_bundle is not None:
+            payload["memex_evidence_bundle"] = _minimal_memex_evidence_bundle(memex_evidence_bundle)
+            return _budgeted_json(payload, MAX_MODEL_CONTEXT_CHARS)
+        raise
+
+
+def _compact_memex_query_receipt(receipt: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Keep model-visible Memex query receipts bounded.
+
+    The complete receipt remains available in the worker receipt. The model
+    context needs the generation binding, hits, and a small verdict sample only.
+    """
+
+    compact = dict(receipt)
+    verdicts = compact.get("per_target_retrieval_verdicts")
+    if not isinstance(verdicts, (str, bytes)) and isinstance(verdicts, Sequence):
+        compact["per_target_retrieval_verdicts"] = [
+            {
+                "target": _bound_text(item.get("target"), 80),
+                "source_class": _bound_text(item.get("source_class"), 32),
+                "verdict": _bound_text(item.get("verdict"), 32),
+            }
+            for item in verdicts[:8]
+            if isinstance(item, Mapping)
+        ]
+    return compact
+
+
+def _compact_memex_evidence_bundle(bundle: Mapping[str, Any]) -> Mapping[str, Any]:
+    compact = dict(bundle)
+    records = bundle.get("records")
+    if not isinstance(records, (str, bytes)) and isinstance(records, Sequence):
+        compact_records = []
+        for record in records[:MAX_MODEL_MEMEX_RECORDS]:
+            if not isinstance(record, Mapping):
+                continue
+            item = dict(record)
+            text = str(item.get("text") or "")
+            item["text"] = _bound_text(text, MAX_MODEL_MEMEX_RECORD_CHARS)
+            item["text_truncated"] = bool(item.get("text_truncated")) or len(text) > MAX_MODEL_MEMEX_RECORD_CHARS
+            compact_records.append(item)
+        compact["records"] = compact_records
+        compact["model_context_record_limit"] = MAX_MODEL_MEMEX_RECORDS
+        compact["model_context_record_chars"] = MAX_MODEL_MEMEX_RECORD_CHARS
+        compact["model_context_compacted"] = len(compact_records) != len(records) or any(
+            bool(record.get("text_truncated")) for record in compact_records if isinstance(record, Mapping)
+        )
+    return compact
+
+
+def _minimal_memex_evidence_bundle(bundle: Mapping[str, Any]) -> Mapping[str, Any]:
+    return {
+        "schema_version": str(bundle.get("schema_version") or ""),
+        "projection_receipt_id": str(bundle.get("projection_receipt_id") or ""),
+        "query_receipt_id": str(bundle.get("query_receipt_id") or ""),
+        "bundle_id": str(bundle.get("bundle_id") or ""),
+        "record_count": int(bundle.get("record_count") or 0),
+        "record_digests": list(bundle.get("record_digests") or ())[:8],
+        "records": [],
+        "model_context_omitted_reason": "memex_supplemental_budget_preserves_repository_evidence",
+        "no_memex_write_performed": True,
+        "no_holoindex_write_performed": True,
+        "no_brain_write_performed": True,
+        "no_breadcrumb_write_performed": True,
+    }
 
 
 def _bounded_repository_evidence(

--- a/modules/communication/moltbot_bridge/src/reddog_resident_architect_durable_agentdb_cycle.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_architect_durable_agentdb_cycle.py
@@ -40,6 +40,9 @@ from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swa
     AgentDbReadOnlyAuditTaskWriter,
     READONLY_AUDIT_TASK_SOURCE,
 )
+from modules.communication.moltbot_bridge.src.reddog_operational_memex_snapshot_supplier import (
+    OperationalMemexSnapshotSupplyConfig,
+)
 from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_runtime import (
     DEFAULT_AUDIT_LANES,
 )
@@ -293,6 +296,10 @@ def run_reddog_resident_architect_durable_agentdb_cycle(
     repo_state_override: Mapping[str, Any] | None = None,
     work_state_snapshot_override: Mapping[str, Any] | None = None,
     holoindex_receipt_override: HoloIndexFreshnessReceipt | Mapping[str, Any] | None = None,
+    breadcrumbs: Sequence[Mapping[str, Any]] = (),
+    brain_state: Mapping[str, Any] | None = None,
+    workspace_memory_notes: Sequence[Mapping[str, Any]] = (),
+    memex_snapshot_supply_config: OperationalMemexSnapshotSupplyConfig | Mapping[str, Any] | None = None,
     audit_lanes: Sequence[str] = DEFAULT_AUDIT_LANES,
     cycle_store: ResidentArchitectCycleStore | None = None,
     agent_db_factory: Optional[Callable[[], Any]] = None,
@@ -370,9 +377,16 @@ def run_reddog_resident_architect_durable_agentdb_cycle(
             repo_state_override=repo_state_override,
             work_state_snapshot_override=work_state_snapshot_override,
             holoindex_receipt_override=holoindex_receipt_override,
+            breadcrumbs=breadcrumbs,
+            brain_state=brain_state,
+            workspace_memory_notes=workspace_memory_notes,
             audit_lanes=audit_lanes,
             enqueue_readonly_audit_tasks=True,
             enqueue_writer=AgentDbReadOnlyAuditTaskWriter(agent_db_factory=agent_db_factory),
+            memex_snapshot_supply_config=_intent_bound_memex_config(
+                red_dog_intent=red_dog_intent,
+                config=memex_snapshot_supply_config,
+            ),
         )
         if not initial.ready or initial.status != REDDOG_MAIN_BOOTSTRAP_READY:
             record.update(
@@ -466,6 +480,9 @@ def run_reddog_resident_architect_durable_agentdb_cycle(
         repo_state_override=repo_state_override,
         work_state_snapshot_override=work_state_snapshot_override,
         holoindex_receipt_override=holoindex_receipt_override,
+        breadcrumbs=breadcrumbs,
+        brain_state=brain_state,
+        workspace_memory_notes=workspace_memory_notes,
         audit_lanes=audit_lanes,
         collect_readonly_audit_reports=True,
         report_store=report_store or AgentDbReadOnlyAuditReportStore(agent_db_factory=agent_db_factory),
@@ -548,6 +565,43 @@ def _validate_intent(intent: Mapping[str, Any]) -> tuple[str, ...]:
     if intent.get("submits_executable_authority") is not False:
         reasons.append(ResidentCycleReason.EXECUTABLE_AUTHORITY_REQUESTED)
     return tuple(dict.fromkeys(reasons))
+
+
+def _intent_bound_memex_config(
+    *,
+    red_dog_intent: Mapping[str, Any],
+    config: OperationalMemexSnapshotSupplyConfig | Mapping[str, Any] | None,
+) -> OperationalMemexSnapshotSupplyConfig | Mapping[str, Any] | None:
+    if config is None:
+        return None
+    if isinstance(config, OperationalMemexSnapshotSupplyConfig):
+        if config.principal_id:
+            return config
+        return OperationalMemexSnapshotSupplyConfig(
+            foundup_id=config.foundup_id,
+            principal_id=_principal_id(red_dog_intent),
+            identity=config.identity,
+            roadmap_state=config.roadmap_state,
+            verified_outcomes=config.verified_outcomes,
+            policy_issued_at=config.policy_issued_at,
+            policy_expires_at=config.policy_expires_at,
+            holoindex_generation_id=config.holoindex_generation_id,
+            source_revision=config.source_revision,
+            max_records=config.max_records,
+        )
+    data = dict(config)
+    data.setdefault("principal_id", _principal_id(red_dog_intent))
+    data.setdefault("foundup_id", str(red_dog_intent.get("foundup_id") or "").strip())
+    return data
+
+
+def _principal_id(intent: Mapping[str, Any]) -> str:
+    return str(
+        intent.get("principal_id")
+        or intent.get("principal_ref")
+        or intent.get("origin_principal")
+        or ""
+    ).strip()
 
 
 def _failure_updates(status: str, reasons: Sequence[str]) -> dict[str, Any]:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -515,6 +515,71 @@ def test_bootstrap_enqueue_opt_in_publishes_readonly_audit_tasks() -> None:
     assert result.no_queue_mutation_performed is False
 
 
+def test_bootstrap_memex_supply_enriches_enqueued_readonly_audit_tasks() -> None:
+    writer = _FakeEnqueueWriter()
+    work_state = dict(_work_state())
+    work_state["worker_claims"] = [
+        {
+            "claim_id": "claim-1",
+            "slice_id": "REDDOG_OPERATIONAL_MEMEX_SNAPSHOT_SUPPLIER_PHASE1",
+            "foundup_id": "foundups_agent",
+        }
+    ]
+    work_state["wre_queue_items"] = [
+        {"queue_item_id": "queue-1", "claim_id": "claim-1", "foundup_id": "foundups_agent"}
+    ]
+
+    result = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=work_state,
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+        breadcrumbs=[
+            {
+                "breadcrumb_id": "crumb-1",
+                "continuity_id": work_state["selected_slice"],
+                "task_id": "task-1",
+                "created_at": NOW,
+            }
+        ],
+        brain_state={
+            "available": True,
+            "signature_digest": "sha256:brain",
+            "summary_digest": "sha256:brain-summary",
+            "record_count": 5,
+        },
+        enqueue_readonly_audit_tasks=True,
+        enqueue_writer=writer,
+        memex_snapshot_supply_config={
+            "foundup_id": "foundups_agent",
+            "principal_id": "principal-012",
+            "identity": {"foundup_id": "foundups_agent", "name": "Foundups Agent"},
+            "roadmap_state": {
+                "foundup_id": "foundups_agent",
+                "roadmap_id": "resident-roadmap",
+                "version": "1",
+                "content_digest": "sha256:roadmap",
+            },
+        },
+    )
+
+    assert result.ready is True
+    assert result.memex_snapshot_supply_attempted is True
+    assert result.memex_snapshot_supply_status == "OPERATIONAL_MEMEX_SUPPLY_ACCEPT"
+    assert result.memex_snapshot_supply_view_id
+    assert result.memex_snapshot_supply_rejection_reasons == ()
+    task_context = writer.calls[0][0][0].context
+    assignment = task_context["assignment"]
+    assert task_context["memex_view"]["foundup_id"] == "foundups_agent"
+    assert task_context["memex_view"]["snapshot_id"] == result.snapshot_receipt_id
+    assert assignment["principal_id"] == "principal-012"
+    assert assignment["work_order_id"] == assignment["assignment_id"]
+    assert assignment["memex_holoindex_generation_id"] == "sha256:holo-generation"
+    assert assignment["memex_policy_expires_at"]
+    assert task_context["memex_snapshot_supply_receipt"]["no_holoindex_reindex_performed"] is True
+
+
 def test_bootstrap_enqueue_rejection_is_not_ready_without_spawning_workers() -> None:
     writer = _FakeEnqueueWriter(ok=False)
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_operational_memex_snapshot_supplier.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_operational_memex_snapshot_supplier.py
@@ -1,0 +1,270 @@
+"""Tests for REDDOG_OPERATIONAL_MEMEX_SNAPSHOT_SUPPLIER_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import replace
+from pathlib import Path
+
+from holo_index.freshness_receipt import CollectionFreshness, HoloIndexFreshnessReceipt
+from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
+    ReadOnlyAuditSwarmEnqueueReceipt,
+    ReadOnlyAuditTaskSpec,
+)
+from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
+    build_operational_context_snapshot,
+)
+from modules.communication.moltbot_bridge.src.reddog_operational_memex_snapshot_supplier import (
+    OPERATIONAL_MEMEX_SUPPLY_ACCEPT,
+    OPERATIONAL_MEMEX_SUPPLY_REJECT,
+    OperationalMemexReadOnlyAuditTaskWriter,
+    enrich_readonly_audit_tasks_with_operational_memex,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_operational_memex_snapshot_supplier.py"
+)
+NOW = "2026-07-16T00:00:00+00:00"
+HEAD = "06d823f52"
+REVISION = "sha256:work-state-memex"
+FOUNDUP_ID = "foundups_agent"
+GENERATION_ID = "sha256:holo-generation-memex"
+
+
+def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
+    return HoloIndexFreshnessReceipt(
+        schema_version="holoindex_freshness_receipt.v1",
+        generated_at=NOW,
+        repo_root=str(REPO_ROOT),
+        repo_head_sha=HEAD,
+        ssd_path="E:/HoloIndex",
+        source="ci_targeted_reindex",
+        generation_id=GENERATION_ID,
+        collections=[
+            CollectionFreshness(
+                name="navigation_work_ledger",
+                count=4,
+                status="indexed",
+                source="ci_targeted_reindex",
+                repo_head_sha=HEAD,
+                last_indexed_at=NOW,
+                source_manifest_digest="sha256:work-ledger-manifest",
+                indexed_paths_digest="sha256:work-ledger-paths",
+                verification="PASS",
+            ),
+            CollectionFreshness(
+                name="navigation_symbols",
+                count=9,
+                status="indexed",
+                source="ci_targeted_reindex",
+                repo_head_sha=HEAD,
+                last_indexed_at=NOW,
+                source_manifest_digest="sha256:symbols-manifest",
+                indexed_paths_digest="sha256:symbols-paths",
+                verification="PASS",
+            ),
+        ],
+    )
+
+
+def _snapshot(*, breadcrumbs=True, brain=True):
+    result = build_operational_context_snapshot(
+        repo_state={
+            "head_sha": HEAD,
+            "dirty_paths": (),
+            "dirty_digest": "sha256:clean",
+            "worktree_digest": "sha256:worktrees",
+        },
+        work_state_snapshot={
+            "schema_version": "reddog_authoritative_work_state.v1",
+            "revision": REVISION,
+            "selected_slice": "REDDOG_OPERATIONAL_MEMEX_SNAPSHOT_SUPPLIER_PHASE1",
+            "refresh_receipt_id": "sha256:refresh",
+            "worker_claims": [
+                {
+                    "claim_id": "claim-1",
+                    "slice_id": "REDDOG_OPERATIONAL_MEMEX_SNAPSHOT_SUPPLIER_PHASE1",
+                    "foundup_id": FOUNDUP_ID,
+                }
+            ],
+            "wre_queue_items": [
+                {"queue_item_id": "queue-1", "claim_id": "claim-1", "foundup_id": FOUNDUP_ID}
+            ],
+        },
+        holoindex_receipt=_fresh_holo_receipt(),
+        changed_paths=("docs/0102_session_briefings/ACTIVE_SLICE_LEDGER.md",),
+        now_iso=NOW,
+        breadcrumb_scope="REDDOG_OPERATIONAL_MEMEX_SNAPSHOT_SUPPLIER_PHASE1",
+        breadcrumbs=(
+            [
+                {
+                    "breadcrumb_id": "crumb-1",
+                    "continuity_id": "REDDOG_OPERATIONAL_MEMEX_SNAPSHOT_SUPPLIER_PHASE1",
+                    "task_id": "task-1",
+                    "created_at": NOW,
+                }
+            ]
+            if breadcrumbs
+            else ()
+        ),
+        brain_state=(
+            {
+                "available": True,
+                "signature_digest": "sha256:brain-signature",
+                "summary_digest": "sha256:brain-summary",
+                "record_count": 7,
+            }
+            if brain
+            else None
+        ),
+    )
+    assert result.accepted is True
+    assert result.snapshot is not None
+    return result.snapshot
+
+
+def _config(**overrides):
+    config = {
+        "foundup_id": FOUNDUP_ID,
+        "principal_id": "principal-012",
+        "identity": {"foundup_id": FOUNDUP_ID, "name": "Foundups Agent"},
+        "roadmap_state": {
+            "foundup_id": FOUNDUP_ID,
+            "roadmap_id": "resident-roadmap",
+            "version": "1",
+            "content_digest": "sha256:roadmap",
+        },
+        "verified_outcomes": (),
+    }
+    config.update(overrides)
+    return config
+
+
+def _task(lane_id: str = "repo_code_audit") -> ReadOnlyAuditTaskSpec:
+    assignment = {
+        "assignment_id": "assignment-1",
+        "lane_id": lane_id,
+        "snapshot_receipt_id": "placeholder",
+        "snapshot_content_digest": "placeholder",
+    }
+    return ReadOnlyAuditTaskSpec(
+        task_id="task-1",
+        description="RedDog read-only audit lane: repo_code_audit",
+        required_skills=("reddog_readonly_audit",),
+        estimated_complexity=0.35,
+        priority_score=0.85,
+        context={"assignment": assignment},
+        origin_continuity_id="determination-1",
+    )
+
+
+class _DelegateWriter:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def enqueue_readonly_audit_tasks(self, tasks, receipt):
+        self.calls.append((tuple(tasks), receipt))
+        return {"ok": True, "created_task_ids": [task.task_id for task in tasks]}
+
+
+def test_enriches_task_with_snapshot_bound_memex_view_and_worker_bindings() -> None:
+    snapshot = _snapshot()
+    task = _task()
+    task = replace(
+        task,
+        context={**task.context, "assignment": {
+            **task.context["assignment"],
+            "snapshot_receipt_id": snapshot.snapshot_receipt_id,
+            "snapshot_content_digest": snapshot.snapshot_content_digest,
+        }},
+    )
+
+    result = enrich_readonly_audit_tasks_with_operational_memex(
+        tasks=(task,),
+        snapshot=snapshot,
+        config=_config(),
+        now_iso=NOW,
+    )
+
+    assert result.accepted is True
+    assert result.status == OPERATIONAL_MEMEX_SUPPLY_ACCEPT
+    enriched = result.tasks[0].context
+    assignment = enriched["assignment"]
+    assert enriched["memex_view"]["foundup_id"] == FOUNDUP_ID
+    assert enriched["memex_view"]["snapshot_id"] == snapshot.snapshot_receipt_id
+    assert assignment["principal_id"] == "principal-012"
+    assert assignment["work_order_id"] == "assignment-1"
+    assert assignment["memex_source_scope"] == f"foundup:{FOUNDUP_ID}:lane:repo_code_audit"
+    assert assignment["memex_source_revision"] == REVISION
+    assert assignment["memex_holoindex_generation_id"] == GENERATION_ID
+    assert enriched["memex_snapshot_supply_receipt"]["no_holoindex_reindex_performed"] is True
+
+
+def test_rejects_before_enqueue_when_memex_sources_are_not_fresh() -> None:
+    snapshot = _snapshot(breadcrumbs=False)
+    task = _task()
+    delegate = _DelegateWriter()
+    writer = OperationalMemexReadOnlyAuditTaskWriter(
+        delegate=delegate,
+        snapshot=snapshot,
+        config=_config(),
+        now_iso=NOW,
+    )
+    receipt = ReadOnlyAuditSwarmEnqueueReceipt(
+        enqueue_receipt_id="receipt-1",
+        status="READONLY_AUDIT_SWARM_ENQUEUE_ACCEPT",
+        swarm_id="swarm-1",
+        snapshot_receipt_id=snapshot.snapshot_receipt_id,
+        determination_id="determination-1",
+        task_ids=("task-1",),
+        assignment_ids=("assignment-1",),
+        rejection_reasons=(),
+        created_at=NOW,
+        receipt_digest="sha256:receipt",
+    )
+
+    result = writer.enqueue_readonly_audit_tasks((task,), receipt)
+
+    assert result["ok"] is False
+    assert result["reason"] == "operational_memex_supply_rejected"
+    assert writer.last_result is not None
+    assert writer.last_result.status == OPERATIONAL_MEMEX_SUPPLY_REJECT
+    assert "breadcrumbs_source_empty" in writer.last_result.rejection_reasons
+    assert delegate.calls == []
+
+
+def test_rejects_missing_scope_without_guessing_foundup() -> None:
+    result = enrich_readonly_audit_tasks_with_operational_memex(
+        tasks=(_task(),),
+        snapshot=_snapshot(),
+        config=_config(foundup_id="", principal_id=""),
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert "missing_foundup_id" in result.rejection_reasons
+    assert "missing_principal_id" in result.rejection_reasons
+
+
+def test_supplier_module_is_read_only_by_ast() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    forbidden_imports = {"subprocess", "requests", "httpx", "sqlite3", "os"}
+    forbidden_calls = {"open", "write_text", "write_bytes", "system", "popen"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in forbidden_imports
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in forbidden_imports
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in forbidden_calls
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in forbidden_calls

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py
@@ -91,6 +91,21 @@ def _work_state() -> dict[str, object]:
     }
 
 
+def _foundup_work_state() -> dict[str, object]:
+    state = dict(_work_state())
+    state["worker_claims"] = [
+        {
+            "claim_id": "claim-resident",
+            "slice_id": "REDDOG_RESIDENT_ARCHITECT_DURABLE_AGENTDB_CYCLE_PHASE1",
+            "foundup_id": "foundups_agent",
+        }
+    ]
+    state["wre_queue_items"] = [
+        {"queue_item_id": "queue-resident", "claim_id": "claim-resident", "foundup_id": "foundups_agent"}
+    ]
+    return state
+
+
 def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
     return HoloIndexFreshnessReceipt(
         schema_version="holoindex_freshness_receipt.v1",
@@ -270,6 +285,63 @@ def test_durable_cycle_submits_agentdb_tasks_openclaw_claims_reports_and_determi
 
     tasks = AgentDB().get_autonomous_tasks(status="completed", limit=10)
     assert len([task for task in tasks if task["discovered_by"] == READONLY_AUDIT_TASK_SOURCE]) == 5
+
+
+def test_durable_cycle_supplies_operational_memex_to_openclaw_workers() -> None:
+    audit_runner = _AuditModelRunner()
+    intent = dict(_intent())
+    intent["principal_ref"] = "principal-012"
+
+    result = run_reddog_resident_architect_durable_agentdb_cycle(
+        **_runtime_kwargs(
+            red_dog_intent=intent,
+            work_state_snapshot_override=_foundup_work_state(),
+            breadcrumbs=[
+                {
+                    "breadcrumb_id": "crumb-resident",
+                    "continuity_id": "REDDOG_RESIDENT_ARCHITECT_DURABLE_AGENTDB_CYCLE_PHASE1",
+                    "task_id": "task-resident",
+                    "created_at": NOW,
+                }
+            ],
+            brain_state={
+                "available": True,
+                "signature_digest": "sha256:brain-resident",
+                "summary_digest": "sha256:brain-summary-resident",
+                "record_count": 9,
+            },
+            memex_snapshot_supply_config={
+                "foundup_id": "foundups_agent",
+                "identity": {"foundup_id": "foundups_agent", "name": "Foundups Agent"},
+                "roadmap_state": {
+                    "foundup_id": "foundups_agent",
+                    "roadmap_id": "resident-roadmap",
+                    "version": "1",
+                    "content_digest": "sha256:resident-roadmap",
+                },
+            },
+            audit_model_runner=audit_runner,
+        )
+    )
+
+    assert result.accepted is True
+    assert result.status == STATUS_DETERMINED
+    assert result.final_bootstrap is not None
+    assert result.final_bootstrap.memex_snapshot_supply_attempted is False
+    assert len(audit_runner.calls) == 5
+    contexts = [json.loads(call["context"]) for call in audit_runner.calls]
+    assert all(context["memex_query_receipt"]["source_class"] == "memex" for context in contexts)
+    assert all(context["memex_query_receipt"]["freshness_generation_id"] == "sha256:holo-generation-resident" for context in contexts)
+    assert all(context["memex_evidence_bundle"]["records"] for context in contexts)
+    completed = AgentDB().get_autonomous_tasks(status="completed", limit=10)
+    readonly_contexts = [
+        task["context"] if isinstance(task["context"], dict) else json.loads(task["context"])
+        for task in completed
+        if task["discovered_by"] == READONLY_AUDIT_TASK_SOURCE
+    ]
+    assert readonly_contexts
+    assert all(context["assignment"]["principal_id"] == "principal-012" for context in readonly_contexts)
+    assert all(context["assignment"]["memex_holoindex_generation_id"] == "sha256:holo-generation-resident" for context in readonly_contexts)
 
 
 def test_duplicate_intent_reconnects_to_persisted_cycle_without_new_claims() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_session_bridge.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_session_bridge.py
@@ -85,6 +85,14 @@ def test_resident_architect_session_summarizes_durable_cycle_runtime(monkeypatch
             "holoindex_receipt_path": "O:/state/holo.json",
             "holoindex_ssd_path": "E:/HoloIndex",
             "timeout_seconds": 13,
+            "breadcrumbs": [{"breadcrumb_id": "crumb-1"}],
+            "brain_state": {"available": True, "signature_digest": "sha256:brain"},
+            "workspace_memory_notes": [{"note_id": "note-1"}],
+            "memex_snapshot_supply": {
+                "foundup_id": "foundups_agent",
+                "identity": {"foundup_id": "foundups_agent", "name": "Foundups Agent"},
+                "roadmap_state": {"foundup_id": "foundups_agent", "roadmap_id": "r1"},
+            },
         }
     )
 
@@ -92,6 +100,10 @@ def test_resident_architect_session_summarizes_durable_cycle_runtime(monkeypatch
     assert calls[0]["red_dog_intent"]["intent_id"] == "sha256:intent"
     assert calls[0]["prompt_text"] == "audit resident loop"
     assert calls[0]["timeout_seconds"] == 13
+    assert calls[0]["breadcrumbs"] == ({"breadcrumb_id": "crumb-1"},)
+    assert calls[0]["brain_state"] == {"available": True, "signature_digest": "sha256:brain"}
+    assert calls[0]["workspace_memory_notes"] == ({"note_id": "note-1"},)
+    assert calls[0]["memex_snapshot_supply_config"]["foundup_id"] == "foundups_agent"
     assert result["decision"] == bridge.RESIDENT_ARCHITECT_SESSION_ACCEPT
     assert result["accepted"] is True
     assert result["resident_backend_invoked"] is True

--- a/scripts/reddog_resident_architect_session_once.py
+++ b/scripts/reddog_resident_architect_session_once.py
@@ -114,6 +114,16 @@ def _external_retriever_from_env() -> Any | None:
     return _ConfiguredExternalResearchRetriever(path) if path.is_file() else None
 
 
+def _mapping(value: Any) -> Mapping[str, Any] | None:
+    return value if isinstance(value, Mapping) else None
+
+
+def _sequence_of_mappings(value: Any) -> tuple[Mapping[str, Any], ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(item for item in value if isinstance(item, Mapping))
+
+
 def _summarize_result(result: Any) -> Dict[str, Any]:
     final = result.final_bootstrap
     final_status = final.status if final else ""
@@ -189,6 +199,10 @@ def _result(payload: Mapping[str, Any]) -> Dict[str, Any]:
             holoindex_ssd_path=_string(payload.get("holoindex_ssd_path") or os.getenv("HOLOINDEX_SSD_PATH", "")),
             requested_operation="extension_resident_architect_session",
             prompt_text=_string(payload.get("work_focus") or "extension resident RedDog architect session"),
+            breadcrumbs=_sequence_of_mappings(payload.get("breadcrumbs")),
+            brain_state=_mapping(payload.get("brain_state")),
+            workspace_memory_notes=_sequence_of_mappings(payload.get("workspace_memory_notes")),
+            memex_snapshot_supply_config=_mapping(payload.get("memex_snapshot_supply")),
             external_research_retriever=_external_retriever_from_env(),
             timeout_seconds=_int(payload.get("timeout_seconds"), 60),
         )


### PR DESCRIPTION
﻿## Summary

Implements `REDDOG_OPERATIONAL_MEMEX_SNAPSHOT_SUPPLIER_PHASE1` for the resident RedDog runtime.

This wires an operational Memex snapshot supply path into the durable AgentDB resident cycle so read-only OpenClaw audit tasks inherit an assignment-bound Memex view. The supplier derives the view from accepted operational snapshot inputs and existing Brain/Breadcrumb/ledger state, then attaches the required Memex bindings to task context for the worker runtime to project/query with its existing integrity gates.

## What Changed

- Added `reddog_operational_memex_snapshot_supplier.py` with a read-only supplier and task-writer wrapper.
- Threaded optional `breadcrumbs`, `brain_state`, `workspace_memory_notes`, and `memex_snapshot_supply_config` through:
  - backend bootstrap
  - durable resident cycle
  - session bridge JSON payload
- Included HoloIndex `generation_id` in operational context snapshot normalization.
- Kept Memex model context compact in read-only audit workers so current repo evidence remains dominant.
- Added focused tests for direct supplier behavior, bootstrap wiring, durable AgentDB cycle wiring, and session bridge payload handling.

## WSP_97 Truth Boundary

OBSERVED:
- Resident RedDog can now enrich read-only audit tasks with operational Memex assignment bindings.
- The worker runtime receives compact, citable Memex receipt/evidence metadata after the existing projection/integrity path.
- The implementation is read-only and does not write Memex, Brain, Breadcrumbs, HoloIndex, repo files, worktrees, PRs, or PatternMemory.

SPECIFIED_NOT_IMPLEMENTED:
- Runtime Memex snapshot supplier scheduling beyond explicit resident payload/config.
- Signed assignment authority for Memex policy issuance.
- Automatic HoloIndex re-indexing.
- Coding-worker execution or mutation.

## Validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_operational_memex_snapshot_supplier.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_session_bridge.py modules/communication/moltbot_bridge/tests/test_foundup_memex_current_state.py modules/communication/moltbot_bridge/tests/test_reddog_memex_snapshot_projection_supplier.py modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_enqueue.py modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_report_collection.py -q` -> 119 passed
- `python -m py_compile modules/communication/moltbot_bridge/src/reddog_operational_memex_snapshot_supplier.py modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py modules/communication/moltbot_bridge/src/reddog_resident_architect_durable_agentdb_cycle.py scripts/reddog_resident_architect_session_once.py`
- `git diff --check`
- Added-line ASCII scan -> 0 non-ASCII

Note: a broad `modules/communication/moltbot_bridge/tests` run was attempted earlier and produced many unrelated failures/errors with truncated output. This PR is validated against the resident runtime, OpenClaw task, and Memex projection regression set touched by the slice.
