### PR TITLE
feat(ai-gateway): add canonical model catalog snapshots

### DIFF
--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -39,6 +39,25 @@ Convenience function for quick AI calls without creating a client instance.
 #### `test_gateway() -> bool`
 Test gateway connectivity and configuration.
 
+#### Model Intelligence Catalog
+
+```python
+normalize_static_registry_cards(...) -> tuple[ModelCapabilityCard, ...]
+normalize_openrouter_catalog(payload) -> tuple[tuple[ModelCapabilityCard, ...], tuple[ModelCatalogRejectedRecord, ...]]
+normalize_local_role_cards(selections) -> tuple[ModelCapabilityCard, ...]
+build_model_catalog_snapshot(cards, ...) -> ModelCatalogSnapshot
+build_canonical_model_catalog(...) -> ModelCatalogSnapshot
+```
+
+These functions produce immutable catalog evidence for downstream model
+selection. They do not call provider APIs, execute commands, compress output,
+benchmark models, or select a RedDog/Fusion panel.
+
+`ModelCapabilityCard` captures provider, canonical model ID, availability,
+context window, modalities, supported parameters, rough cost metadata, task
+families, and promotion state. `ModelCatalogSnapshot` binds cards and rejected
+records to a deterministic `snapshot_id`.
+
 ## Configuration
 
 ### Environment Variables

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,35 @@
 # AI Gateway Module Change Log
 
+## [2026-07-16] - Model Intelligence Canonical Catalog Runtime
+
+**Who:** 0102 Codex
+**Type:** Runtime Foundation
+**Slice:** MODEL_INTELLIGENCE_CANONICAL_CATALOG_RUNTIME_PHASE1
+
+**What:** Added a canonical model catalog snapshot layer for RedDog model intelligence.
+
+**Why:** RedDog must select models by measured task fitness, not by permanent hardcoded
+GLM/DeepSeek/Kimi or static gateway defaults. This slice creates the receipt-bound
+catalog evidence layer that later selection, benchmarking, and champion/challenger
+promotion can consume.
+
+**Files:**
+- `src/model_intelligence_catalog.py` - model capability cards, catalog snapshot receipts,
+  static registry normalization, OpenRouter-style catalog normalization, and local role
+  normalization.
+- `tests/test_model_intelligence_catalog.py` - deterministic digest, malformed record,
+  local path privacy, and no-network/no-command guard tests.
+
+**Truth Boundary:**
+- IMPLEMENTED: immutable catalog snapshot receipts and normalized capability cards.
+- IMPLEMENTED: "latest/provider catalog" evidence remains `candidate`, never `champion`.
+- NOT IMPLEMENTED: task selection receipts, benchmark harness, fusion panel optimization,
+  RedDog bridge binding, AutoResearch promotion, or provider network fetch.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-02-17] - Full Model Registry Refresh (Feb 2026 Current)
 
 **Who:** 0102

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -6,6 +6,18 @@
 
 **Dependencies**: requests>=2.25.0
 
+## Model Intelligence Catalog
+
+`src/model_intelligence_catalog.py` provides the runtime evidence layer for
+RedDog model intelligence. It normalizes static registry entries, provider
+catalog payloads, and local role-resolution results into immutable
+`ModelCatalogSnapshot` receipts.
+
+This layer does not choose a model, call a provider, run benchmarks, or promote
+any model to production. Provider catalog entries and `latest`-style aliases are
+eligible candidates only; later benchmark and verifier receipts must promote
+champion/challenger status.
+
 **Usage Examples**:
 ```python
 from modules.ai_intelligence.ai_gateway import AIGateway

--- a/modules/ai_intelligence/ai_gateway/src/model_intelligence_catalog.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_intelligence_catalog.py
@@ -1,0 +1,377 @@
+"""Canonical model catalog snapshots for RedDog model intelligence.
+
+This module is the first runtime layer for measured model selection. It does
+not choose a model, benchmark a model, call a provider, or trust "latest"
+aliases as production-ready. It converts provider/local/static evidence into
+immutable capability cards that later selection and benchmark slices can bind.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field, replace
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Iterable, Mapping, Sequence
+
+from .model_registry import ALL_MODELS, RECOMMENDED_MODELS, ModelStatus
+
+
+SCHEMA_VERSION = "model_catalog_snapshot.v1"
+CARD_SCHEMA_VERSION = "model_capability_card.v1"
+
+
+class Availability(str, Enum):
+    """Observed availability state for a model candidate."""
+
+    AVAILABLE = "available"
+    UNAVAILABLE = "unavailable"
+    UNKNOWN = "unknown"
+
+
+class PromotionState(str, Enum):
+    """Governance state for using a model in production paths."""
+
+    CANDIDATE = "candidate"
+    CHALLENGER = "challenger"
+    CHAMPION = "champion"
+    DEPRECATED = "deprecated"
+    BLOCKED = "blocked"
+
+
+@dataclass(frozen=True)
+class ModelCatalogRejectedRecord:
+    """A catalog source record that could not be normalized."""
+
+    source: str
+    reason: str
+    record_digest: str
+
+
+@dataclass(frozen=True)
+class ModelCapabilityCard:
+    """Normalized capability evidence for a single model candidate."""
+
+    provider: str
+    model_id: str
+    canonical_model_id: str
+    source: str
+    availability: Availability = Availability.UNKNOWN
+    freshness: str = "unknown"
+    promotion_state: PromotionState = PromotionState.CANDIDATE
+    task_families: tuple[str, ...] = ()
+    context_window: int | None = None
+    input_cost_per_million: float | None = None
+    output_cost_per_million: float | None = None
+    supports_tools: bool = False
+    supports_structured_output: bool = False
+    supports_reasoning: bool = False
+    modalities: tuple[str, ...] = ("text",)
+    supported_parameters: tuple[str, ...] = ()
+    privacy_policy: str = "unknown"
+    verifier_pass_rate: float | None = None
+    benchmark_scores: Mapping[str, float] = field(default_factory=dict)
+    schema_version: str = CARD_SCHEMA_VERSION
+
+    def normalized(self) -> "ModelCapabilityCard":
+        """Return a deterministic representation for hashing and snapshots."""
+
+        return replace(
+            self,
+            provider=_clean_token(self.provider),
+            model_id=str(self.model_id).strip(),
+            canonical_model_id=str(self.canonical_model_id).strip(),
+            source=_clean_token(self.source),
+            freshness=_clean_token(self.freshness),
+            task_families=tuple(sorted({_clean_token(v) for v in self.task_families if str(v).strip()})),
+            modalities=tuple(sorted({_clean_token(v) for v in self.modalities if str(v).strip()})) or ("text",),
+            supported_parameters=tuple(
+                sorted({_clean_token(v) for v in self.supported_parameters if str(v).strip()})
+            ),
+            benchmark_scores=dict(sorted((str(k), float(v)) for k, v in self.benchmark_scores.items())),
+        )
+
+
+@dataclass(frozen=True)
+class ModelCatalogSnapshot:
+    """Immutable catalog snapshot consumed by later selection/benchmark slices."""
+
+    snapshot_id: str
+    generated_at: str
+    cards: tuple[ModelCapabilityCard, ...]
+    source_receipts: tuple[str, ...] = ()
+    rejected_records: tuple[ModelCatalogRejectedRecord, ...] = ()
+    schema_version: str = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-ready representation."""
+
+        return {
+            "schema_version": self.schema_version,
+            "snapshot_id": self.snapshot_id,
+            "generated_at": self.generated_at,
+            "source_receipts": list(self.source_receipts),
+            "cards": [_card_to_json(card) for card in self.cards],
+            "rejected_records": [asdict(record) for record in self.rejected_records],
+        }
+
+
+def build_model_catalog_snapshot(
+    cards: Iterable[ModelCapabilityCard],
+    *,
+    source_receipts: Sequence[str] | None = None,
+    rejected_records: Sequence[ModelCatalogRejectedRecord] | None = None,
+    generated_at: str | None = None,
+) -> ModelCatalogSnapshot:
+    """Build a digest-bound catalog snapshot from normalized cards."""
+
+    generated = generated_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    normalized_cards = tuple(
+        sorted((card.normalized() for card in cards), key=lambda card: (card.provider, card.canonical_model_id))
+    )
+    normalized_receipts = tuple(sorted(str(v).strip() for v in (source_receipts or ()) if str(v).strip()))
+    normalized_rejections = tuple(rejected_records or ())
+    body = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": generated,
+        "source_receipts": list(normalized_receipts),
+        "cards": [_card_to_json(card) for card in normalized_cards],
+        "rejected_records": [asdict(record) for record in normalized_rejections],
+    }
+    snapshot_id = _digest_prefixed("model_catalog_snapshot", body)
+    return ModelCatalogSnapshot(
+        snapshot_id=snapshot_id,
+        generated_at=generated,
+        cards=normalized_cards,
+        source_receipts=normalized_receipts,
+        rejected_records=normalized_rejections,
+    )
+
+
+def normalize_static_registry_cards(
+    registry_models: Mapping[str, Any] | None = None,
+    recommended_models: Mapping[str, Sequence[str]] | None = None,
+) -> tuple[ModelCapabilityCard, ...]:
+    """Normalize the existing static registry into candidate cards.
+
+    Static registry entries are evidence, not proof of task fitness. Current
+    models become candidates; legacy models become challengers; deprecated and
+    sunset models are not eligible for production selection.
+    """
+
+    registry = registry_models or ALL_MODELS
+    task_index = _task_index(recommended_models or RECOMMENDED_MODELS)
+    cards: list[ModelCapabilityCard] = []
+    for model_id, info in registry.items():
+        status = getattr(info, "status", None)
+        status_value = getattr(status, "value", str(status or "unknown"))
+        cards.append(
+            ModelCapabilityCard(
+                provider=str(getattr(info, "provider", "unknown")),
+                model_id=str(getattr(info, "model_id", model_id)),
+                canonical_model_id=str(getattr(info, "model_id", model_id)),
+                source="static_model_registry",
+                availability=Availability.UNKNOWN,
+                freshness=status_value,
+                promotion_state=_promotion_from_registry_status(status),
+                task_families=tuple(task_index.get(str(getattr(info, "model_id", model_id)), ())),
+                privacy_policy="provider_policy_unknown",
+            ).normalized()
+        )
+    return tuple(sorted(cards, key=lambda card: (card.provider, card.canonical_model_id)))
+
+
+def normalize_openrouter_catalog(
+    catalog_payload: Mapping[str, Any],
+) -> tuple[tuple[ModelCapabilityCard, ...], tuple[ModelCatalogRejectedRecord, ...]]:
+    """Normalize an OpenRouter-style model catalog payload.
+
+    The OpenRouter catalog is provider evidence. Every normalized record starts
+    as a candidate and must be benchmarked before becoming a champion.
+    """
+
+    records = catalog_payload.get("data", [])
+    if not isinstance(records, list):
+        return (), (
+            ModelCatalogRejectedRecord(
+                source="openrouter_catalog",
+                reason="data_not_list",
+                record_digest=_digest_prefixed("rejected_record", catalog_payload),
+            ),
+        )
+
+    cards: list[ModelCapabilityCard] = []
+    rejected: list[ModelCatalogRejectedRecord] = []
+    for record in records:
+        if not isinstance(record, Mapping):
+            rejected.append(_reject_openrouter_record(record, "record_not_mapping"))
+            continue
+        model_id = str(record.get("id") or "").strip()
+        if not model_id:
+            rejected.append(_reject_openrouter_record(record, "missing_model_id"))
+            continue
+        architecture = record.get("architecture") if isinstance(record.get("architecture"), Mapping) else {}
+        pricing = record.get("pricing") if isinstance(record.get("pricing"), Mapping) else {}
+        supported_parameters = _string_tuple(record.get("supported_parameters"))
+        modalities = _modalities_from_openrouter(architecture)
+        provider = model_id.split("/", 1)[0] if "/" in model_id else "openrouter"
+        cards.append(
+            ModelCapabilityCard(
+                provider=provider,
+                model_id=model_id,
+                canonical_model_id=model_id,
+                source="openrouter_catalog",
+                availability=Availability.AVAILABLE,
+                freshness="provider_catalog",
+                promotion_state=PromotionState.CANDIDATE,
+                task_families=(),
+                context_window=_positive_int(record.get("context_length")),
+                input_cost_per_million=_per_million(pricing.get("prompt")),
+                output_cost_per_million=_per_million(pricing.get("completion")),
+                supports_tools=bool({"tools", "tool_choice"} & set(supported_parameters)),
+                supports_structured_output=bool({"response_format", "structured_outputs"} & set(supported_parameters)),
+                supports_reasoning="reasoning" in set(supported_parameters),
+                modalities=modalities,
+                supported_parameters=supported_parameters,
+                privacy_policy="openrouter_provider_policy",
+            ).normalized()
+        )
+    return tuple(sorted(cards, key=lambda card: card.canonical_model_id)), tuple(rejected)
+
+
+def normalize_local_role_cards(selections: Mapping[str, Any]) -> tuple[ModelCapabilityCard, ...]:
+    """Normalize local role resolution without leaking local filesystem paths."""
+
+    cards: list[ModelCapabilityCard] = []
+    for role, selection in selections.items():
+        exists = bool(_read_attr_or_key(selection, "exists", False))
+        source = str(_read_attr_or_key(selection, "source", "local_model_selection"))
+        canonical_id = f"local/{_clean_token(role)}"
+        cards.append(
+            ModelCapabilityCard(
+                provider="local",
+                model_id=canonical_id,
+                canonical_model_id=canonical_id,
+                source=source or "local_model_selection",
+                availability=Availability.AVAILABLE if exists else Availability.UNAVAILABLE,
+                freshness="local_probe",
+                promotion_state=PromotionState.CANDIDATE if exists else PromotionState.CHALLENGER,
+                task_families=(_clean_token(role),),
+                privacy_policy="local_runtime",
+            ).normalized()
+        )
+    return tuple(sorted(cards, key=lambda card: card.canonical_model_id))
+
+
+def build_canonical_model_catalog(
+    *,
+    static_registry: bool = True,
+    openrouter_payload: Mapping[str, Any] | None = None,
+    local_role_selections: Mapping[str, Any] | None = None,
+    source_receipts: Sequence[str] | None = None,
+    generated_at: str | None = None,
+) -> ModelCatalogSnapshot:
+    """Build a catalog snapshot from the supplied evidence sources."""
+
+    cards: list[ModelCapabilityCard] = []
+    rejected: list[ModelCatalogRejectedRecord] = []
+    if static_registry:
+        cards.extend(normalize_static_registry_cards())
+    if openrouter_payload is not None:
+        openrouter_cards, openrouter_rejected = normalize_openrouter_catalog(openrouter_payload)
+        cards.extend(openrouter_cards)
+        rejected.extend(openrouter_rejected)
+    if local_role_selections is not None:
+        cards.extend(normalize_local_role_cards(local_role_selections))
+    return build_model_catalog_snapshot(
+        cards,
+        source_receipts=source_receipts,
+        rejected_records=rejected,
+        generated_at=generated_at,
+    )
+
+
+def _task_index(recommended_models: Mapping[str, Sequence[str]]) -> dict[str, tuple[str, ...]]:
+    index: dict[str, set[str]] = {}
+    for task, model_ids in recommended_models.items():
+        for model_id in model_ids:
+            index.setdefault(str(model_id), set()).add(str(task))
+    return {model_id: tuple(sorted(tasks)) for model_id, tasks in index.items()}
+
+
+def _promotion_from_registry_status(status: Any) -> PromotionState:
+    if status == ModelStatus.CURRENT:
+        return PromotionState.CANDIDATE
+    if status == ModelStatus.LEGACY:
+        return PromotionState.CHALLENGER
+    if status == ModelStatus.DEPRECATED:
+        return PromotionState.DEPRECATED
+    if status == ModelStatus.SUNSET:
+        return PromotionState.BLOCKED
+    return PromotionState.CANDIDATE
+
+
+def _modalities_from_openrouter(architecture: Mapping[str, Any]) -> tuple[str, ...]:
+    values: list[str] = []
+    values.extend(_string_tuple(architecture.get("input_modalities")))
+    values.extend(_string_tuple(architecture.get("output_modalities")))
+    return tuple(sorted(set(values))) or ("text",)
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return ()
+    return tuple(str(item).strip() for item in value if str(item).strip())
+
+
+def _positive_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _per_million(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed < 0:
+        return None
+    return round(parsed * 1_000_000, 10)
+
+
+def _read_attr_or_key(value: Any, name: str, default: Any) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _clean_token(value: Any) -> str:
+    return str(value).strip().lower().replace(" ", "_")
+
+
+def _card_to_json(card: ModelCapabilityCard) -> dict[str, Any]:
+    data = asdict(card.normalized())
+    data["availability"] = card.availability.value
+    data["promotion_state"] = card.promotion_state.value
+    data["task_families"] = list(card.task_families)
+    data["modalities"] = list(card.modalities)
+    data["supported_parameters"] = list(card.supported_parameters)
+    data["benchmark_scores"] = dict(sorted(card.benchmark_scores.items()))
+    return data
+
+
+def _reject_openrouter_record(record: Any, reason: str) -> ModelCatalogRejectedRecord:
+    return ModelCatalogRejectedRecord(
+        source="openrouter_catalog",
+        reason=reason,
+        record_digest=_digest_prefixed("rejected_record", record),
+    )
+
+
+def _digest_prefixed(prefix: str, value: Any) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return f"{prefix}:{hashlib.sha256(encoded).hexdigest()}"

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_catalog.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_catalog.py
@@ -1,0 +1,167 @@
+"""Tests for canonical model intelligence catalog snapshots."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_catalog import (
+    Availability,
+    PromotionState,
+    build_canonical_model_catalog,
+    build_model_catalog_snapshot,
+    normalize_local_role_cards,
+    normalize_openrouter_catalog,
+    normalize_static_registry_cards,
+)
+from modules.ai_intelligence.ai_gateway.src.model_registry import ModelInfo, ModelStatus
+
+
+def test_static_registry_current_models_are_candidates_not_champions():
+    cards = normalize_static_registry_cards(
+        {
+            "frontier-x": ModelInfo(
+                model_id="frontier-x",
+                provider="test",
+                status=ModelStatus.CURRENT,
+            ),
+            "old-x": ModelInfo(
+                model_id="old-x",
+                provider="test",
+                status=ModelStatus.SUNSET,
+            ),
+        },
+        {"architecture": ["frontier-x"]},
+    )
+
+    by_id = {card.canonical_model_id: card for card in cards}
+    assert by_id["frontier-x"].promotion_state == PromotionState.CANDIDATE
+    assert by_id["frontier-x"].task_families == ("architecture",)
+    assert by_id["old-x"].promotion_state == PromotionState.BLOCKED
+    assert all(card.promotion_state != PromotionState.CHAMPION for card in cards)
+
+
+def test_openrouter_catalog_normalizes_capability_and_pricing_evidence():
+    cards, rejected = normalize_openrouter_catalog(
+        {
+            "data": [
+                {
+                    "id": "moonshotai/kimi-k2.7-code",
+                    "context_length": 262144,
+                    "pricing": {"prompt": "0.0000006", "completion": "0.0000025"},
+                    "architecture": {
+                        "input_modalities": ["text"],
+                        "output_modalities": ["text"],
+                    },
+                    "supported_parameters": ["tools", "response_format", "reasoning"],
+                }
+            ]
+        }
+    )
+
+    assert rejected == ()
+    assert len(cards) == 1
+    card = cards[0]
+    assert card.provider == "moonshotai"
+    assert card.canonical_model_id == "moonshotai/kimi-k2.7-code"
+    assert card.availability == Availability.AVAILABLE
+    assert card.promotion_state == PromotionState.CANDIDATE
+    assert card.context_window == 262144
+    assert card.input_cost_per_million == 0.6
+    assert card.output_cost_per_million == 2.5
+    assert card.supports_tools is True
+    assert card.supports_structured_output is True
+    assert card.supports_reasoning is True
+
+
+def test_openrouter_catalog_rejects_malformed_records_fail_closed():
+    cards, rejected = normalize_openrouter_catalog({"data": [{}, "bad"]})
+
+    assert cards == ()
+    assert [item.reason for item in rejected] == ["missing_model_id", "record_not_mapping"]
+    assert all(item.record_digest.startswith("rejected_record:") for item in rejected)
+
+
+@dataclass(frozen=True)
+class _LocalSelection:
+    exists: bool
+    source: str
+    path: Path
+
+
+def test_local_role_cards_do_not_leak_local_filesystem_paths():
+    cards = normalize_local_role_cards(
+        {
+            "code": _LocalSelection(
+                exists=True,
+                source="LOCAL_MODEL_CODE_PATH",
+                path=Path("C:/Users/user/private/model.gguf"),
+            )
+        }
+    )
+
+    snapshot = build_model_catalog_snapshot(cards, generated_at="2026-07-16T00:00:00+00:00")
+    as_text = str(snapshot.to_dict())
+    assert cards[0].canonical_model_id == "local/code"
+    assert cards[0].availability == Availability.AVAILABLE
+    assert "C:/Users/user/private" not in as_text
+    assert "model.gguf" not in as_text
+
+
+def test_snapshot_digest_is_deterministic_and_changes_when_card_changes():
+    cards, _rejected = normalize_openrouter_catalog(
+        {
+            "data": [
+                {"id": "provider/b", "context_length": 20},
+                {"id": "provider/a", "context_length": 10},
+            ]
+        }
+    )
+    first = build_model_catalog_snapshot(cards, generated_at="2026-07-16T00:00:00+00:00")
+    second = build_model_catalog_snapshot(reversed(cards), generated_at="2026-07-16T00:00:00+00:00")
+
+    assert first.snapshot_id == second.snapshot_id
+    assert [card.canonical_model_id for card in first.cards] == ["provider/a", "provider/b"]
+
+    changed_cards, _ = normalize_openrouter_catalog(
+        {"data": [{"id": "provider/a", "context_length": 999}, {"id": "provider/b", "context_length": 20}]}
+    )
+    changed = build_model_catalog_snapshot(changed_cards, generated_at="2026-07-16T00:00:00+00:00")
+    assert changed.snapshot_id != first.snapshot_id
+
+
+def test_build_canonical_catalog_combines_sources_and_keeps_rejections():
+    snapshot = build_canonical_model_catalog(
+        static_registry=False,
+        openrouter_payload={"data": [{"id": "openai/example"}, {}]},
+        local_role_selections={"triage": {"exists": False, "source": "test"}},
+        source_receipts=("provider_receipt:abc",),
+        generated_at="2026-07-16T00:00:00+00:00",
+    )
+
+    assert snapshot.snapshot_id.startswith("model_catalog_snapshot:")
+    assert snapshot.source_receipts == ("provider_receipt:abc",)
+    assert [card.canonical_model_id for card in snapshot.cards] == ["local/triage", "openai/example"]
+    assert snapshot.rejected_records[0].reason == "missing_model_id"
+    assert snapshot.cards[0].promotion_state == PromotionState.CHALLENGER
+
+
+def test_catalog_runtime_has_no_network_or_command_execution_imports():
+    source = Path("modules/ai_intelligence/ai_gateway/src/model_intelligence_catalog.py").read_text()
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            assert not (
+                isinstance(node.func.value, ast.Name)
+                and node.func.value.id in {"os", "subprocess", "requests", "urllib"}
+            )
+
+    assert "subprocess" not in imported
+    assert "requests" not in imported
+    assert "urllib" not in imported


### PR DESCRIPTION
﻿## Summary

Implements `MODEL_INTELLIGENCE_CANONICAL_CATALOG_RUNTIME_PHASE1` in `modules/ai_intelligence/ai_gateway`.

This is the first runtime foundation for measured RedDog model selection. It creates immutable model catalog snapshots and normalized capability cards from existing static registry evidence, OpenRouter-style provider catalog payloads, and local role-resolution evidence.

## What changed

- Added `src/model_intelligence_catalog.py`
  - `ModelCapabilityCard`
  - `ModelCatalogSnapshot`
  - `ModelCatalogRejectedRecord`
  - static registry normalization
  - OpenRouter-style catalog normalization
  - local role normalization without leaking local filesystem paths
  - deterministic snapshot receipts
- Added `tests/test_model_intelligence_catalog.py`
- Updated AI Gateway README, INTERFACE, and ModLog.

## WSP_97 truth boundary

OBSERVED / implemented:
- Catalog evidence can be normalized into deterministic, digest-bound snapshots.
- Provider catalog records become `candidate`, never `champion`.
- Deprecated/sunset static registry records are not promoted.
- Malformed provider records are rejected with digests.
- Local role cards do not leak local model file paths.
- No network calls, command execution, RTK, telemetry persistence, or RedDog bridge changes.

SPECIFIED_NOT_IMPLEMENTED:
- Task selection receipts.
- Dynamic RedDog/Fusion model binding.
- Benchmark harness and champion/challenger promotion.
- AutoResearch optimization loop.
- Provider catalog fetching.

## Validation

- `python -m pytest modules/ai_intelligence/ai_gateway/tests -q` -> 7 passed
- `python -m py_compile modules/ai_intelligence/ai_gateway/src/model_intelligence_catalog.py`
- `git diff --check`
- Added-line ASCII scan -> 0 non-ASCII
