### PR TITLE
feat(ai-gateway): add task model selection receipts

### DIFF
--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -58,6 +58,22 @@ context window, modalities, supported parameters, rough cost metadata, task
 families, and promotion state. `ModelCatalogSnapshot` binds cards and rejected
 records to a deterministic `snapshot_id`.
 
+#### Model Intelligence Selection
+
+```python
+select_models_for_task(snapshot, requirements) -> ModelSelectionReceipt
+```
+
+`ModelTaskRequirements` describes task family, single/panel mode, evaluation vs
+production purpose, required modalities, context size, tool/structured/reasoning
+requirements, cost ceilings, provider allow/deny sets, candidate count, and
+minimum verifier pass rate.
+
+`ModelSelectionReceipt` binds the selected model IDs, ranked candidates,
+rejection reasons, catalog snapshot ID, and requirements. Evaluation mode may
+select candidates for benchmarking. Production mode requires measured champion
+evidence and fails closed for unbenchmarked candidates.
+
 ## Configuration
 
 ### Environment Variables

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,34 @@
 # AI Gateway Module Change Log
 
+## [2026-07-16] - Model Intelligence Task Selection Receipts
+
+**Who:** 0102 Codex
+**Type:** Runtime Foundation
+**Slice:** MODEL_INTELLIGENCE_TASK_SELECTION_RECEIPT_PHASE1
+
+**What:** Added task-scoped model selection receipts over canonical catalog snapshots.
+
+**Why:** RedDog should request capabilities, budget and WSP_15 task requirements, not
+hardcoded model names. This slice provides the deterministic receipt layer that later
+RedDog runtime binding and benchmark promotion can consume.
+
+**Files:**
+- `src/model_intelligence_selection.py` - model task requirements, single/panel
+  selection, production/evaluation modes, candidate rankings, digest-bound receipts.
+- `tests/test_model_intelligence_selection.py` - production fail-closed, panel
+  diversity, capability/cost filtering, digest, and no-network/no-command tests.
+
+**Truth Boundary:**
+- IMPLEMENTED: evaluation can select candidate models for benchmarking.
+- IMPLEMENTED: production rejects unbenchmarked non-champion candidates.
+- IMPLEMENTED: panel mode prefers provider diversity without hardcoded providers.
+- NOT IMPLEMENTED: RedDog bridge binding, benchmark ledger, champion/challenger
+  promotion writes, AutoResearch campaigns, or provider calls.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-16] - Model Intelligence Canonical Catalog Runtime
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -18,6 +18,20 @@ any model to production. Provider catalog entries and `latest`-style aliases are
 eligible candidates only; later benchmark and verifier receipts must promote
 champion/challenger status.
 
+## Model Selection Receipts
+
+`src/model_intelligence_selection.py` consumes a `ModelCatalogSnapshot` and
+`ModelTaskRequirements` to produce a deterministic `ModelSelectionReceipt`.
+
+Two purposes are supported:
+
+- `evaluation`: may select candidate models for benchmark or shadow testing.
+- `production`: requires champion promotion, task benchmark evidence, and verifier
+  pass-rate evidence.
+
+This keeps RedDog flexible without allowing a newly discovered model alias to
+become production authority before measured FoundUps performance exists.
+
 **Usage Examples**:
 ```python
 from modules.ai_intelligence.ai_gateway import AIGateway

--- a/modules/ai_intelligence/ai_gateway/src/model_intelligence_selection.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_intelligence_selection.py
@@ -1,0 +1,311 @@
+"""Task-scoped model selection receipts for RedDog model intelligence.
+
+The selector consumes a canonical model catalog snapshot and produces a
+digest-bound receipt. It does not call a provider, benchmark a model, mutate
+state, or bind RedDog runtime defaults. Production mode is intentionally stricter
+than evaluation mode: unbenchmarked provider-catalog candidates can be selected
+for evaluation, but not for production authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any, Iterable, Mapping
+
+from .model_intelligence_catalog import (
+    Availability,
+    ModelCapabilityCard,
+    ModelCatalogSnapshot,
+    PromotionState,
+)
+
+
+SELECTION_SCHEMA_VERSION = "model_selection_receipt.v1"
+
+
+class SelectionMode(str, Enum):
+    """Shape of requested model selection."""
+
+    SINGLE = "single"
+    PANEL = "panel"
+
+
+class SelectionPurpose(str, Enum):
+    """How the selected model(s) may be used."""
+
+    EVALUATION = "evaluation"
+    PRODUCTION = "production"
+
+
+class SelectionDecision(str, Enum):
+    """Selection result."""
+
+    SELECTED = "selected"
+    REJECTED = "rejected"
+
+
+@dataclass(frozen=True)
+class ModelTaskRequirements:
+    """Task requirements supplied by RedDog/WSP_15, not model names."""
+
+    task_family: str
+    selection_mode: SelectionMode = SelectionMode.SINGLE
+    purpose: SelectionPurpose = SelectionPurpose.EVALUATION
+    required_modalities: tuple[str, ...] = ("text",)
+    min_context_window: int | None = None
+    require_tools: bool = False
+    require_structured_output: bool = False
+    require_reasoning: bool = False
+    max_input_cost_per_million: float | None = None
+    max_output_cost_per_million: float | None = None
+    allowed_providers: tuple[str, ...] = ()
+    denied_providers: tuple[str, ...] = ()
+    max_candidates: int = 1
+    min_verifier_pass_rate: float = 0.0
+
+    def normalized(self) -> "ModelTaskRequirements":
+        max_candidates = max(1, min(int(self.max_candidates), 5))
+        if self.selection_mode == SelectionMode.SINGLE:
+            max_candidates = 1
+        return ModelTaskRequirements(
+            task_family=_clean_token(self.task_family),
+            selection_mode=self.selection_mode,
+            purpose=self.purpose,
+            required_modalities=tuple(sorted({_clean_token(v) for v in self.required_modalities if str(v).strip()}))
+            or ("text",),
+            min_context_window=self.min_context_window if self.min_context_window and self.min_context_window > 0 else None,
+            require_tools=bool(self.require_tools),
+            require_structured_output=bool(self.require_structured_output),
+            require_reasoning=bool(self.require_reasoning),
+            max_input_cost_per_million=_non_negative_float_or_none(self.max_input_cost_per_million),
+            max_output_cost_per_million=_non_negative_float_or_none(self.max_output_cost_per_million),
+            allowed_providers=tuple(sorted({_clean_token(v) for v in self.allowed_providers if str(v).strip()})),
+            denied_providers=tuple(sorted({_clean_token(v) for v in self.denied_providers if str(v).strip()})),
+            max_candidates=max_candidates,
+            min_verifier_pass_rate=max(0.0, min(float(self.min_verifier_pass_rate), 1.0)),
+        )
+
+
+@dataclass(frozen=True)
+class ModelCandidateRanking:
+    """Ranked candidate evidence included in the selection receipt."""
+
+    canonical_model_id: str
+    provider: str
+    score: float
+    reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ModelSelectionReceipt:
+    """Digest-bound model selection result."""
+
+    receipt_id: str
+    catalog_snapshot_id: str
+    requirements: ModelTaskRequirements
+    decision: SelectionDecision
+    selected_model_ids: tuple[str, ...]
+    rankings: tuple[ModelCandidateRanking, ...]
+    rejection_reasons: tuple[str, ...] = ()
+    schema_version: str = SELECTION_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "receipt_id": self.receipt_id,
+            "catalog_snapshot_id": self.catalog_snapshot_id,
+            "requirements": _requirements_to_json(self.requirements),
+            "decision": self.decision.value,
+            "selected_model_ids": list(self.selected_model_ids),
+            "rankings": [asdict(ranking) for ranking in self.rankings],
+            "rejection_reasons": list(self.rejection_reasons),
+        }
+
+
+def select_models_for_task(
+    snapshot: ModelCatalogSnapshot,
+    requirements: ModelTaskRequirements,
+) -> ModelSelectionReceipt:
+    """Select eligible model candidates from a catalog snapshot."""
+
+    normalized_requirements = requirements.normalized()
+    ranked: list[ModelCandidateRanking] = []
+    rejection_counts: dict[str, int] = {}
+    for card in snapshot.cards:
+        ok, reasons = _eligible(card, normalized_requirements)
+        if not ok:
+            for reason in reasons:
+                rejection_counts[reason] = rejection_counts.get(reason, 0) + 1
+            continue
+        ranked.append(_rank_candidate(card, normalized_requirements))
+
+    ranked.sort(key=lambda item: (-item.score, item.provider, item.canonical_model_id))
+    selected = _select_rankings(ranked, normalized_requirements)
+    decision = SelectionDecision.SELECTED if selected else SelectionDecision.REJECTED
+    rejection_reasons = tuple(
+        sorted(f"{reason}:{count}" for reason, count in rejection_counts.items())
+    ) if not selected else ()
+    body = {
+        "schema_version": SELECTION_SCHEMA_VERSION,
+        "catalog_snapshot_id": snapshot.snapshot_id,
+        "requirements": _requirements_to_json(normalized_requirements),
+        "decision": decision.value,
+        "selected_model_ids": [item.canonical_model_id for item in selected],
+        "rankings": [asdict(item) for item in ranked],
+        "rejection_reasons": list(rejection_reasons),
+    }
+    receipt_id = _digest_prefixed("model_selection_receipt", body)
+    return ModelSelectionReceipt(
+        receipt_id=receipt_id,
+        catalog_snapshot_id=snapshot.snapshot_id,
+        requirements=normalized_requirements,
+        decision=decision,
+        selected_model_ids=tuple(item.canonical_model_id for item in selected),
+        rankings=tuple(ranked),
+        rejection_reasons=rejection_reasons,
+    )
+
+
+def _eligible(card: ModelCapabilityCard, requirements: ModelTaskRequirements) -> tuple[bool, tuple[str, ...]]:
+    reasons: list[str] = []
+    provider = _clean_token(card.provider)
+    if requirements.allowed_providers and provider not in requirements.allowed_providers:
+        reasons.append("provider_not_allowed")
+    if provider in requirements.denied_providers:
+        reasons.append("provider_denied")
+    if card.promotion_state in {PromotionState.BLOCKED, PromotionState.DEPRECATED}:
+        reasons.append("promotion_state_not_eligible")
+    if card.availability == Availability.UNAVAILABLE:
+        reasons.append("unavailable")
+    if requirements.task_family not in set(card.task_families):
+        reasons.append("task_family_missing")
+    if not set(requirements.required_modalities).issubset(set(card.modalities)):
+        reasons.append("modality_missing")
+    if requirements.min_context_window is not None:
+        if card.context_window is None or card.context_window < requirements.min_context_window:
+            reasons.append("context_window_too_small")
+    if requirements.require_tools and not card.supports_tools:
+        reasons.append("tools_missing")
+    if requirements.require_structured_output and not card.supports_structured_output:
+        reasons.append("structured_output_missing")
+    if requirements.require_reasoning and not card.supports_reasoning:
+        reasons.append("reasoning_missing")
+    if requirements.max_input_cost_per_million is not None and card.input_cost_per_million is not None:
+        if card.input_cost_per_million > requirements.max_input_cost_per_million:
+            reasons.append("input_cost_too_high")
+    if requirements.max_output_cost_per_million is not None and card.output_cost_per_million is not None:
+        if card.output_cost_per_million > requirements.max_output_cost_per_million:
+            reasons.append("output_cost_too_high")
+    if requirements.purpose == SelectionPurpose.PRODUCTION:
+        if card.promotion_state != PromotionState.CHAMPION:
+            reasons.append("not_production_champion")
+        if card.verifier_pass_rate is None:
+            reasons.append("missing_verifier_pass_rate")
+        elif card.verifier_pass_rate < requirements.min_verifier_pass_rate:
+            reasons.append("verifier_pass_rate_too_low")
+        if requirements.task_family not in set(card.benchmark_scores):
+            reasons.append("missing_task_benchmark")
+    return not reasons, tuple(sorted(set(reasons)))
+
+
+def _rank_candidate(card: ModelCapabilityCard, requirements: ModelTaskRequirements) -> ModelCandidateRanking:
+    reasons: list[str] = []
+    score = 0.0
+    promotion_weight = {
+        PromotionState.CHAMPION: 100.0,
+        PromotionState.CANDIDATE: 50.0,
+        PromotionState.CHALLENGER: 25.0,
+    }.get(card.promotion_state, 0.0)
+    score += promotion_weight
+    reasons.append(f"promotion:{card.promotion_state.value}")
+
+    benchmark_score = float(card.benchmark_scores.get(requirements.task_family, 0.0))
+    if benchmark_score:
+        score += benchmark_score * 100.0
+        reasons.append("task_benchmark")
+    if card.verifier_pass_rate is not None:
+        score += float(card.verifier_pass_rate) * 50.0
+        reasons.append("verifier_pass_rate")
+    if card.availability == Availability.AVAILABLE:
+        score += 10.0
+        reasons.append("available")
+    if requirements.min_context_window and card.context_window:
+        score += min(card.context_window / requirements.min_context_window, 2.0)
+        reasons.append("context_fit")
+    score -= _cost_penalty(card.input_cost_per_million)
+    score -= _cost_penalty(card.output_cost_per_million)
+    return ModelCandidateRanking(
+        canonical_model_id=card.canonical_model_id,
+        provider=card.provider,
+        score=round(score, 6),
+        reasons=tuple(sorted(set(reasons))),
+    )
+
+
+def _select_rankings(
+    ranked: Sequence[ModelCandidateRanking],
+    requirements: ModelTaskRequirements,
+) -> tuple[ModelCandidateRanking, ...]:
+    if requirements.selection_mode == SelectionMode.SINGLE:
+        return tuple(ranked[:1])
+
+    selected: list[ModelCandidateRanking] = []
+    used_providers: set[str] = set()
+    for item in ranked:
+        if item.provider in used_providers and len(ranked) >= requirements.max_candidates:
+            continue
+        selected.append(item)
+        used_providers.add(item.provider)
+        if len(selected) >= requirements.max_candidates:
+            return tuple(selected)
+    for item in ranked:
+        if item not in selected:
+            selected.append(item)
+            if len(selected) >= requirements.max_candidates:
+                break
+    return tuple(selected)
+
+
+def _cost_penalty(value: float | None) -> float:
+    if value is None:
+        return 0.0
+    return min(max(value, 0.0), 100.0) / 100.0
+
+
+def _requirements_to_json(requirements: ModelTaskRequirements) -> dict[str, Any]:
+    normalized = requirements.normalized()
+    return {
+        "task_family": normalized.task_family,
+        "selection_mode": normalized.selection_mode.value,
+        "purpose": normalized.purpose.value,
+        "required_modalities": list(normalized.required_modalities),
+        "min_context_window": normalized.min_context_window,
+        "require_tools": normalized.require_tools,
+        "require_structured_output": normalized.require_structured_output,
+        "require_reasoning": normalized.require_reasoning,
+        "max_input_cost_per_million": normalized.max_input_cost_per_million,
+        "max_output_cost_per_million": normalized.max_output_cost_per_million,
+        "allowed_providers": list(normalized.allowed_providers),
+        "denied_providers": list(normalized.denied_providers),
+        "max_candidates": normalized.max_candidates,
+        "min_verifier_pass_rate": normalized.min_verifier_pass_rate,
+    }
+
+
+def _non_negative_float_or_none(value: float | None) -> float | None:
+    if value is None:
+        return None
+    parsed = float(value)
+    return parsed if parsed >= 0 else None
+
+
+def _clean_token(value: Any) -> str:
+    return str(value).strip().lower().replace(" ", "_")
+
+
+def _digest_prefixed(prefix: str, value: Any) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return f"{prefix}:{hashlib.sha256(encoded).hexdigest()}"

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_selection.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_selection.py
@@ -1,0 +1,222 @@
+"""Tests for task-scoped model selection receipts."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_catalog import (
+    Availability,
+    ModelCapabilityCard,
+    PromotionState,
+    build_model_catalog_snapshot,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_selection import (
+    ModelTaskRequirements,
+    SelectionDecision,
+    SelectionMode,
+    SelectionPurpose,
+    select_models_for_task,
+)
+
+
+def _snapshot(*cards: ModelCapabilityCard):
+    return build_model_catalog_snapshot(cards, generated_at="2026-07-16T00:00:00+00:00")
+
+
+def _card(
+    model_id: str,
+    *,
+    provider: str = "test",
+    promotion_state: PromotionState = PromotionState.CANDIDATE,
+    availability: Availability = Availability.AVAILABLE,
+    task_families: tuple[str, ...] = ("architecture",),
+    verifier_pass_rate: float | None = None,
+    benchmark_scores: dict[str, float] | None = None,
+    context_window: int | None = 128000,
+    supports_tools: bool = False,
+    supports_structured_output: bool = False,
+    supports_reasoning: bool = False,
+    input_cost_per_million: float | None = None,
+    output_cost_per_million: float | None = None,
+) -> ModelCapabilityCard:
+    return ModelCapabilityCard(
+        provider=provider,
+        model_id=model_id,
+        canonical_model_id=model_id,
+        source="test",
+        availability=availability,
+        freshness="test",
+        promotion_state=promotion_state,
+        task_families=task_families,
+        context_window=context_window,
+        supports_tools=supports_tools,
+        supports_structured_output=supports_structured_output,
+        supports_reasoning=supports_reasoning,
+        input_cost_per_million=input_cost_per_million,
+        output_cost_per_million=output_cost_per_million,
+        verifier_pass_rate=verifier_pass_rate,
+        benchmark_scores=benchmark_scores or {},
+    ).normalized()
+
+
+def test_evaluation_selects_candidate_for_benchmarking():
+    snapshot = _snapshot(_card("provider/candidate", benchmark_scores={}))
+    receipt = select_models_for_task(snapshot, ModelTaskRequirements(task_family="architecture"))
+
+    assert receipt.decision == SelectionDecision.SELECTED
+    assert receipt.selected_model_ids == ("provider/candidate",)
+    assert receipt.catalog_snapshot_id == snapshot.snapshot_id
+    assert receipt.receipt_id.startswith("model_selection_receipt:")
+
+
+def test_production_rejects_unbenchmarked_non_champion_candidate():
+    snapshot = _snapshot(_card("provider/candidate", benchmark_scores={}))
+    receipt = select_models_for_task(
+        snapshot,
+        ModelTaskRequirements(
+            task_family="architecture",
+            purpose=SelectionPurpose.PRODUCTION,
+            min_verifier_pass_rate=0.9,
+        ),
+    )
+
+    assert receipt.decision == SelectionDecision.REJECTED
+    assert receipt.selected_model_ids == ()
+    assert "not_production_champion:1" in receipt.rejection_reasons
+    assert "missing_verifier_pass_rate:1" in receipt.rejection_reasons
+    assert "missing_task_benchmark:1" in receipt.rejection_reasons
+
+
+def test_production_selects_measured_champion_over_weaker_candidate():
+    champion = _card(
+        "provider/champion",
+        provider="a",
+        promotion_state=PromotionState.CHAMPION,
+        verifier_pass_rate=0.96,
+        benchmark_scores={"architecture": 0.88},
+    )
+    candidate = _card(
+        "provider/candidate",
+        provider="b",
+        promotion_state=PromotionState.CANDIDATE,
+        verifier_pass_rate=0.99,
+        benchmark_scores={"architecture": 0.99},
+    )
+    receipt = select_models_for_task(
+        _snapshot(candidate, champion),
+        ModelTaskRequirements(
+            task_family="architecture",
+            purpose=SelectionPurpose.PRODUCTION,
+            min_verifier_pass_rate=0.9,
+        ),
+    )
+
+    assert receipt.decision == SelectionDecision.SELECTED
+    assert receipt.selected_model_ids == ("provider/champion",)
+    assert all(item.canonical_model_id != "provider/candidate" for item in receipt.rankings)
+
+
+def test_requirements_filter_context_tools_structured_reasoning_and_cost():
+    good = _card(
+        "provider/good",
+        supports_tools=True,
+        supports_structured_output=True,
+        supports_reasoning=True,
+        context_window=200000,
+        input_cost_per_million=1.0,
+        output_cost_per_million=2.0,
+    )
+    no_tools = _card("provider/no-tools", supports_tools=False)
+    costly = _card(
+        "provider/costly",
+        supports_tools=True,
+        supports_structured_output=True,
+        supports_reasoning=True,
+        context_window=200000,
+        input_cost_per_million=100.0,
+    )
+    receipt = select_models_for_task(
+        _snapshot(no_tools, costly, good),
+        ModelTaskRequirements(
+            task_family="architecture",
+            min_context_window=100000,
+            require_tools=True,
+            require_structured_output=True,
+            require_reasoning=True,
+            max_input_cost_per_million=10.0,
+        ),
+    )
+
+    assert receipt.selected_model_ids == ("provider/good",)
+    assert all(item.canonical_model_id == "provider/good" for item in receipt.rankings)
+
+
+def test_panel_selection_prefers_provider_diversity():
+    snapshot = _snapshot(
+        _card("a/strong", provider="a", benchmark_scores={"architecture": 0.9}),
+        _card("a/second", provider="a", benchmark_scores={"architecture": 0.8}),
+        _card("b/diverse", provider="b", benchmark_scores={"architecture": 0.7}),
+    )
+    receipt = select_models_for_task(
+        snapshot,
+        ModelTaskRequirements(
+            task_family="architecture",
+            selection_mode=SelectionMode.PANEL,
+            max_candidates=2,
+        ),
+    )
+
+    assert receipt.decision == SelectionDecision.SELECTED
+    assert len(receipt.selected_model_ids) == 2
+    selected_providers = {
+        item.provider for item in receipt.rankings if item.canonical_model_id in receipt.selected_model_ids
+    }
+    assert selected_providers == {"a", "b"}
+
+
+def test_blocked_and_unavailable_models_are_never_selected():
+    snapshot = _snapshot(
+        _card("provider/blocked", promotion_state=PromotionState.BLOCKED),
+        _card("provider/unavailable", availability=Availability.UNAVAILABLE),
+    )
+    receipt = select_models_for_task(snapshot, ModelTaskRequirements(task_family="architecture"))
+
+    assert receipt.decision == SelectionDecision.REJECTED
+    assert "promotion_state_not_eligible:1" in receipt.rejection_reasons
+    assert "unavailable:1" in receipt.rejection_reasons
+
+
+def test_receipt_digest_is_stable_and_binds_snapshot_id():
+    snapshot = _snapshot(_card("provider/a"), _card("provider/b"))
+    requirements = ModelTaskRequirements(task_family="architecture")
+
+    first = select_models_for_task(snapshot, requirements)
+    second = select_models_for_task(snapshot, requirements)
+
+    assert first.receipt_id == second.receipt_id
+    assert first.catalog_snapshot_id == snapshot.snapshot_id
+
+    changed_snapshot = _snapshot(_card("provider/a", benchmark_scores={"architecture": 0.9}))
+    changed = select_models_for_task(changed_snapshot, requirements)
+    assert changed.receipt_id != first.receipt_id
+
+
+def test_selector_has_no_network_or_command_execution_imports():
+    source = Path("modules/ai_intelligence/ai_gateway/src/model_intelligence_selection.py").read_text()
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            assert not (
+                isinstance(node.func.value, ast.Name)
+                and node.func.value.id in {"os", "subprocess", "requests", "urllib"}
+            )
+
+    assert "subprocess" not in imported
+    assert "requests" not in imported
+    assert "urllib" not in imported


### PR DESCRIPTION
﻿## Summary

Implements `MODEL_INTELLIGENCE_TASK_SELECTION_RECEIPT_PHASE1`.

This adds deterministic task-scoped model selection receipts over `ModelCatalogSnapshot`. RedDog can now express task requirements and panel shape without naming a permanent model stack. Evaluation mode can select candidates for benchmark/shadow testing; production mode fails closed unless a model has champion promotion, task benchmark evidence, and verifier pass-rate evidence.

## What changed

- Added `src/model_intelligence_selection.py`
  - `ModelTaskRequirements`
  - `ModelSelectionReceipt`
  - single-model and panel selection
  - evaluation vs production purpose
  - capability, context, cost, provider allow/deny, and verifier filters
- Added `tests/test_model_intelligence_selection.py`
- Updated AI Gateway README, INTERFACE, and ModLog.

## WSP_97 truth boundary

OBSERVED / implemented:
- Evaluation selection may choose candidates for benchmarking.
- Production selection rejects unbenchmarked non-champion candidates.
- Panel selection prefers provider diversity without hardcoded providers.
- Selection binds to the catalog snapshot ID and emits deterministic receipts.
- Blocked/deprecated/unavailable models are never selected.
- No provider calls, network fetch, command execution, RedDog bridge binding, or benchmark writes.

SPECIFIED_NOT_IMPLEMENTED:
- RedDog dynamic model binding.
- Benchmark ledger and champion/challenger promotion writes.
- Model-combination benchmark harness.
- AutoResearch campaign loop.

## Validation

- `python -m pytest modules/ai_intelligence/ai_gateway/tests -q` -> 15 passed
- `python -m py_compile modules/ai_intelligence/ai_gateway/src/model_intelligence_catalog.py modules/ai_intelligence/ai_gateway/src/model_intelligence_selection.py`
- `git diff --check`
- Added-line ASCII scan -> 0 non-ASCII
