### PR TITLE
feat(ai-gateway): bind model production selection to evidence receipts

### DIFF
--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -74,6 +74,31 @@ rejection reasons, catalog snapshot ID, and requirements. Evaluation mode may
 select candidates for benchmarking. Production mode requires measured champion
 evidence and fails closed for unbenchmarked candidates.
 
+Production model selection must pass `production_evidence` containing
+receipt-bound benchmark and promotion proof. Catalog fields alone do not satisfy
+production authority, even when `promotion_state == CHAMPION`.
+
+Panel mode emits role assignments and a topology digest. The candidate panel may
+include roles such as principal, researcher, critic and implementer; the verifier
+role is reserved for an independent verifier outside the candidate panel.
+
+#### Benchmark Evidence and Outcome Receipts
+
+```python
+build_model_benchmark_evidence_receipt(...) -> ModelBenchmarkEvidenceReceipt
+build_model_promotion_evidence_receipt(...) -> ModelPromotionEvidenceReceipt
+production_evidence_for_selection(...) -> dict[str, dict[str, Any]]
+build_model_selection_outcome_receipt(...) -> ModelSelectionOutcomeReceipt
+outcome_feedback_record(receipt) -> dict[str, Any]
+```
+
+Benchmark evidence binds the model, task family, task-set digest, held-out split
+digest, prompt/topology digest, verifier digest, verifier receipt, sample count,
+accepted count, cost and latency. Promotion evidence binds a signed authority
+receipt to that benchmark evidence. Outcome receipts are feedback-eligible only
+when the independent verifier accepts, task completion is true, evidence is
+verified, and no regression or unauthorized change is detected.
+
 ## Configuration
 
 ### Environment Variables

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,46 @@
 # AI Gateway Module Change Log
 
+## [2026-07-16] - Benchmark Evidence and Outcome Receipts
+
+**Who:** 0102 Codex
+**Type:** Runtime Foundation Hardening
+**Slice:** MODEL_BENCHMARK_EVIDENCE_AND_OUTCOME_RECEIPTS_PHASE1
+
+**What:** Hardened model-intelligence production selection with receipt-bound
+benchmark, verifier, promotion, topology, and outcome evidence.
+
+**Why:** #1129 introduced task-selection receipts, but production selection still
+depended on scalar catalog fields (`promotion_state`, `benchmark_scores`,
+`verifier_pass_rate`). Production binding must not trust those fields unless they
+are backed by measured held-out benchmark evidence and signed promotion authority.
+
+**Files:**
+- `src/model_intelligence_outcomes.py` - benchmark evidence receipts, signed
+  promotion evidence receipts, production evidence mapping, and fail-closed
+  outcome receipts.
+- `src/model_intelligence_selection.py` - production selection now requires
+  receipt-bound evidence and an explicit nonzero verifier threshold; panel
+  selection emits role assignments/topology digest and reserves verifier outside
+  the candidate panel.
+- `tests/test_model_intelligence_outcomes.py` and
+  `tests/test_model_intelligence_selection.py` - benchmark digest, held-out
+  split, verifier digest, signed promotion, threshold, panel-role, and no-network
+  guards.
+
+**Truth Boundary:**
+- IMPLEMENTED: evaluation selection behavior remains available for benchmarking.
+- IMPLEMENTED: production selection rejects catalog-only champions.
+- IMPLEMENTED: benchmark evidence binds model ID, task-set digest, held-out split,
+  prompt/topology digest, verifier digest, sample count, cost, and latency.
+- IMPLEMENTED: promotion evidence requires signed promotion authority.
+- NOT IMPLEMENTED: benchmark harness execution, champion/challenger ledger writes,
+  AutoResearch campaigns, RedDog dynamic runtime binding, provider calls, or
+  PatternMemory admission.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-16] - Model Intelligence Task Selection Receipts
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -32,6 +32,21 @@ Two purposes are supported:
 This keeps RedDog flexible without allowing a newly discovered model alias to
 become production authority before measured FoundUps performance exists.
 
+## Benchmark Evidence and Outcome Receipts
+
+`src/model_intelligence_outcomes.py` defines the receipt-bound evidence required
+before production model selection can trust a champion:
+
+- held-out benchmark evidence bound to model ID, task family, task-set digest,
+  held-out split digest, prompt/topology digest, verifier digest, sample count,
+  cost and latency
+- signed promotion evidence over the benchmark receipt
+- selection outcome receipts that become feedback-eligible only after independent
+  verifier acceptance and regression/unauthorized-change checks
+
+Catalog scalar fields remain useful for evaluation and ranking, but production
+selection rejects `CHAMPION` unless these evidence receipts are supplied.
+
 **Usage Examples**:
 ```python
 from modules.ai_intelligence.ai_gateway import AIGateway

--- a/modules/ai_intelligence/ai_gateway/src/model_intelligence_outcomes.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_intelligence_outcomes.py
@@ -1,0 +1,455 @@
+"""Benchmark evidence and outcome receipts for model intelligence.
+
+This module hardens model selection beyond scalar catalog fields. It defines the
+receipt-bound benchmark, promotion, and outcome evidence that production model
+selection must consume before RedDog can bind a model or Fusion panel.
+
+No function in this module calls a model, writes PatternMemory, promotes a model
+by itself, mutates HoloIndex, or executes commands.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any, Mapping
+
+from .model_intelligence_catalog import PromotionState
+from .model_intelligence_selection import ModelSelectionReceipt, SelectionDecision
+
+
+BENCHMARK_SCHEMA_VERSION = "model_benchmark_evidence_receipt.v1"
+PROMOTION_SCHEMA_VERSION = "model_promotion_evidence_receipt.v1"
+OUTCOME_SCHEMA_VERSION = "model_selection_outcome_receipt.v1"
+
+
+class VerifierDecision(str, Enum):
+    """Independent verifier verdict for the model-produced work."""
+
+    ACCEPT = "accept"
+    REJECT = "reject"
+    ERROR = "error"
+    SKIPPED = "skipped"
+
+
+class OutcomeDecision(str, Enum):
+    """Whether this outcome may feed benchmark/recursive learning."""
+
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+
+
+@dataclass(frozen=True)
+class ModelOutcomeMetrics:
+    """Bounded numeric measurements for one model or panel outcome."""
+
+    latency_ms: int | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cost_estimate_usd: float | None = None
+
+    def normalized(self) -> "ModelOutcomeMetrics":
+        return ModelOutcomeMetrics(
+            latency_ms=_non_negative_int_or_none(self.latency_ms),
+            input_tokens=_non_negative_int_or_none(self.input_tokens),
+            output_tokens=_non_negative_int_or_none(self.output_tokens),
+            cost_estimate_usd=_non_negative_float_or_none(self.cost_estimate_usd),
+        )
+
+
+@dataclass(frozen=True)
+class ModelBenchmarkEvidenceReceipt:
+    """Receipt for measured model performance on a held-out task set."""
+
+    receipt_id: str
+    model_id: str
+    task_family: str
+    task_set_digest: str
+    held_out_split_digest: str
+    prompt_topology_digest: str
+    verifier_digest: str
+    verifier_receipt_id: str
+    sample_count: int
+    accepted_count: int
+    verifier_pass_rate: float
+    metrics: ModelOutcomeMetrics
+    schema_version: str = BENCHMARK_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "receipt_id": self.receipt_id,
+            "model_id": self.model_id,
+            "task_family": self.task_family,
+            "task_set_digest": self.task_set_digest,
+            "held_out_split_digest": self.held_out_split_digest,
+            "prompt_topology_digest": self.prompt_topology_digest,
+            "verifier_digest": self.verifier_digest,
+            "verifier_receipt_id": self.verifier_receipt_id,
+            "sample_count": self.sample_count,
+            "accepted_count": self.accepted_count,
+            "verifier_pass_rate": self.verifier_pass_rate,
+            "metrics": asdict(self.metrics.normalized()),
+        }
+
+
+@dataclass(frozen=True)
+class ModelPromotionEvidenceReceipt:
+    """Receipt proving a model was authorized for a promotion state."""
+
+    receipt_id: str
+    model_id: str
+    task_family: str
+    benchmark_evidence_receipt_id: str
+    promotion_state: PromotionState
+    promotion_authority_receipt_id: str
+    signed_promotion_receipt_id: str
+    min_verifier_pass_rate: float
+    schema_version: str = PROMOTION_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "receipt_id": self.receipt_id,
+            "model_id": self.model_id,
+            "task_family": self.task_family,
+            "benchmark_evidence_receipt_id": self.benchmark_evidence_receipt_id,
+            "promotion_state": self.promotion_state.value,
+            "promotion_authority_receipt_id": self.promotion_authority_receipt_id,
+            "signed_promotion_receipt_id": self.signed_promotion_receipt_id,
+            "min_verifier_pass_rate": self.min_verifier_pass_rate,
+        }
+
+
+@dataclass(frozen=True)
+class ModelSelectionOutcomeReceipt:
+    """Digest-bound outcome for a model selection receipt."""
+
+    receipt_id: str
+    selection_receipt_id: str
+    catalog_snapshot_id: str
+    task_family: str
+    selected_model_ids: tuple[str, ...]
+    verifier_decision: VerifierDecision
+    verification_receipt_ids: tuple[str, ...]
+    outcome_decision: OutcomeDecision
+    feedback_eligible: bool
+    metrics: ModelOutcomeMetrics
+    rejection_reasons: tuple[str, ...] = ()
+    evidence_receipt_ids: tuple[str, ...] = ()
+    schema_version: str = OUTCOME_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "receipt_id": self.receipt_id,
+            "selection_receipt_id": self.selection_receipt_id,
+            "catalog_snapshot_id": self.catalog_snapshot_id,
+            "task_family": self.task_family,
+            "selected_model_ids": list(self.selected_model_ids),
+            "verifier_decision": self.verifier_decision.value,
+            "verification_receipt_ids": list(self.verification_receipt_ids),
+            "outcome_decision": self.outcome_decision.value,
+            "feedback_eligible": self.feedback_eligible,
+            "metrics": asdict(self.metrics.normalized()),
+            "rejection_reasons": list(self.rejection_reasons),
+            "evidence_receipt_ids": list(self.evidence_receipt_ids),
+        }
+
+
+def build_model_benchmark_evidence_receipt(
+    *,
+    model_id: str,
+    task_family: str,
+    task_set_digest: str,
+    held_out_split_digest: str,
+    prompt_topology_digest: str,
+    verifier_digest: str,
+    verifier_receipt_id: str,
+    sample_count: int,
+    accepted_count: int,
+    metrics: ModelOutcomeMetrics | None = None,
+) -> ModelBenchmarkEvidenceReceipt:
+    """Build a receipt for measured held-out benchmark evidence."""
+
+    normalized = {
+        "schema_version": BENCHMARK_SCHEMA_VERSION,
+        "model_id": _required("model_id", model_id),
+        "task_family": _clean_token(_required("task_family", task_family)),
+        "task_set_digest": _required("task_set_digest", task_set_digest),
+        "held_out_split_digest": _required("held_out_split_digest", held_out_split_digest),
+        "prompt_topology_digest": _required("prompt_topology_digest", prompt_topology_digest),
+        "verifier_digest": _required("verifier_digest", verifier_digest),
+        "verifier_receipt_id": _required("verifier_receipt_id", verifier_receipt_id),
+        "sample_count": _positive_int(sample_count, "sample_count"),
+        "accepted_count": _bounded_accepted_count(accepted_count, sample_count),
+        "metrics": asdict((metrics or ModelOutcomeMetrics()).normalized()),
+    }
+    pass_rate = round(normalized["accepted_count"] / normalized["sample_count"], 6)
+    body = {**normalized, "verifier_pass_rate": pass_rate}
+    return ModelBenchmarkEvidenceReceipt(
+        receipt_id=_digest_prefixed("model_benchmark_evidence", body),
+        model_id=normalized["model_id"],
+        task_family=normalized["task_family"],
+        task_set_digest=normalized["task_set_digest"],
+        held_out_split_digest=normalized["held_out_split_digest"],
+        prompt_topology_digest=normalized["prompt_topology_digest"],
+        verifier_digest=normalized["verifier_digest"],
+        verifier_receipt_id=normalized["verifier_receipt_id"],
+        sample_count=normalized["sample_count"],
+        accepted_count=normalized["accepted_count"],
+        verifier_pass_rate=pass_rate,
+        metrics=(metrics or ModelOutcomeMetrics()).normalized(),
+    )
+
+
+def build_model_promotion_evidence_receipt(
+    *,
+    benchmark_receipt: ModelBenchmarkEvidenceReceipt,
+    promotion_state: PromotionState,
+    promotion_authority_receipt_id: str,
+    signed_promotion_receipt_id: str,
+    min_verifier_pass_rate: float,
+) -> ModelPromotionEvidenceReceipt:
+    """Build a signed-authority promotion receipt over benchmark evidence."""
+
+    threshold = _threshold(min_verifier_pass_rate)
+    if promotion_state != PromotionState.CHAMPION:
+        raise ValueError("only_champion_promotion_supported")
+    if benchmark_receipt.verifier_pass_rate < threshold:
+        raise ValueError("benchmark_below_promotion_threshold")
+    body = {
+        "schema_version": PROMOTION_SCHEMA_VERSION,
+        "model_id": benchmark_receipt.model_id,
+        "task_family": benchmark_receipt.task_family,
+        "benchmark_evidence_receipt_id": benchmark_receipt.receipt_id,
+        "promotion_state": promotion_state.value,
+        "promotion_authority_receipt_id": _required("promotion_authority_receipt_id", promotion_authority_receipt_id),
+        "signed_promotion_receipt_id": _required("signed_promotion_receipt_id", signed_promotion_receipt_id),
+        "min_verifier_pass_rate": threshold,
+    }
+    return ModelPromotionEvidenceReceipt(
+        receipt_id=_digest_prefixed("model_promotion_evidence", body),
+        model_id=benchmark_receipt.model_id,
+        task_family=benchmark_receipt.task_family,
+        benchmark_evidence_receipt_id=benchmark_receipt.receipt_id,
+        promotion_state=promotion_state,
+        promotion_authority_receipt_id=body["promotion_authority_receipt_id"],
+        signed_promotion_receipt_id=body["signed_promotion_receipt_id"],
+        min_verifier_pass_rate=threshold,
+    )
+
+
+def production_evidence_for_selection(
+    benchmark_receipt: ModelBenchmarkEvidenceReceipt,
+    promotion_receipt: ModelPromotionEvidenceReceipt,
+) -> dict[str, dict[str, Any]]:
+    """Convert receipts into the evidence mapping consumed by selection."""
+
+    if promotion_receipt.benchmark_evidence_receipt_id != benchmark_receipt.receipt_id:
+        raise ValueError("promotion_benchmark_mismatch")
+    if promotion_receipt.model_id != benchmark_receipt.model_id:
+        raise ValueError("promotion_model_mismatch")
+    if promotion_receipt.task_family != benchmark_receipt.task_family:
+        raise ValueError("promotion_task_mismatch")
+    return {
+        benchmark_receipt.model_id: {
+            "model_id": benchmark_receipt.model_id,
+            "task_family": benchmark_receipt.task_family,
+            "benchmark_evidence_receipt_id": benchmark_receipt.receipt_id,
+            "promotion_receipt_id": promotion_receipt.receipt_id,
+            "signed_promotion_receipt_id": promotion_receipt.signed_promotion_receipt_id,
+            "task_set_digest": benchmark_receipt.task_set_digest,
+            "held_out_split_digest": benchmark_receipt.held_out_split_digest,
+            "prompt_topology_digest": benchmark_receipt.prompt_topology_digest,
+            "verifier_digest": benchmark_receipt.verifier_digest,
+            "sample_count": benchmark_receipt.sample_count,
+            "verifier_pass_rate": benchmark_receipt.verifier_pass_rate,
+            "promotion_state": promotion_receipt.promotion_state.value,
+        }
+    }
+
+
+def build_model_selection_outcome_receipt(
+    selection_receipt: ModelSelectionReceipt,
+    *,
+    verifier_decision: VerifierDecision | str,
+    verification_receipt_ids: tuple[str, ...] = (),
+    task_completed: bool = False,
+    evidence_correct: bool = False,
+    unauthorized_changes_detected: bool = False,
+    regression_detected: bool = False,
+    metrics: ModelOutcomeMetrics | None = None,
+    rejection_reasons: tuple[str, ...] = (),
+    evidence_receipt_ids: tuple[str, ...] = (),
+) -> ModelSelectionOutcomeReceipt:
+    """Build a fail-closed outcome receipt for a model selection result."""
+
+    verifier = _coerce_verifier_decision(verifier_decision)
+    normalized_verification_receipts = _normalize_receipts(verification_receipt_ids)
+    normalized_evidence_receipts = _normalize_receipts(evidence_receipt_ids)
+    normalized_rejections = tuple(sorted(_clean_reason(reason) for reason in rejection_reasons if str(reason).strip()))
+    metrics_value = (metrics or ModelOutcomeMetrics()).normalized()
+    automatic_rejections = _automatic_rejection_reasons(
+        selection_receipt=selection_receipt,
+        verifier_decision=verifier,
+        verification_receipt_ids=normalized_verification_receipts,
+        task_completed=task_completed,
+        evidence_correct=evidence_correct,
+        unauthorized_changes_detected=unauthorized_changes_detected,
+        regression_detected=regression_detected,
+    )
+    all_rejections = tuple(sorted(set(normalized_rejections + automatic_rejections)))
+    feedback_eligible = not all_rejections
+    outcome_decision = OutcomeDecision.ACCEPTED if feedback_eligible else OutcomeDecision.REJECTED
+    body = {
+        "schema_version": OUTCOME_SCHEMA_VERSION,
+        "selection_receipt_id": selection_receipt.receipt_id,
+        "catalog_snapshot_id": selection_receipt.catalog_snapshot_id,
+        "task_family": selection_receipt.requirements.task_family,
+        "selected_model_ids": list(selection_receipt.selected_model_ids),
+        "verifier_decision": verifier.value,
+        "verification_receipt_ids": list(normalized_verification_receipts),
+        "outcome_decision": outcome_decision.value,
+        "feedback_eligible": feedback_eligible,
+        "metrics": asdict(metrics_value),
+        "rejection_reasons": list(all_rejections),
+        "evidence_receipt_ids": list(normalized_evidence_receipts),
+    }
+    return ModelSelectionOutcomeReceipt(
+        receipt_id=_digest_prefixed("model_selection_outcome_receipt", body),
+        selection_receipt_id=selection_receipt.receipt_id,
+        catalog_snapshot_id=selection_receipt.catalog_snapshot_id,
+        task_family=selection_receipt.requirements.task_family,
+        selected_model_ids=selection_receipt.selected_model_ids,
+        verifier_decision=verifier,
+        verification_receipt_ids=normalized_verification_receipts,
+        outcome_decision=outcome_decision,
+        feedback_eligible=feedback_eligible,
+        metrics=metrics_value,
+        rejection_reasons=all_rejections,
+        evidence_receipt_ids=normalized_evidence_receipts,
+    )
+
+
+def outcome_feedback_record(receipt: ModelSelectionOutcomeReceipt) -> dict[str, Any]:
+    """Return the minimal record a downstream benchmark ledger may admit."""
+
+    if not receipt.feedback_eligible:
+        raise ValueError("outcome_not_feedback_eligible")
+    return {
+        "outcome_receipt_id": receipt.receipt_id,
+        "selection_receipt_id": receipt.selection_receipt_id,
+        "catalog_snapshot_id": receipt.catalog_snapshot_id,
+        "task_family": receipt.task_family,
+        "selected_model_ids": list(receipt.selected_model_ids),
+        "verification_receipt_ids": list(receipt.verification_receipt_ids),
+        "metrics": asdict(receipt.metrics.normalized()),
+    }
+
+
+def _automatic_rejection_reasons(
+    *,
+    selection_receipt: ModelSelectionReceipt,
+    verifier_decision: VerifierDecision,
+    verification_receipt_ids: tuple[str, ...],
+    task_completed: bool,
+    evidence_correct: bool,
+    unauthorized_changes_detected: bool,
+    regression_detected: bool,
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if selection_receipt.decision != SelectionDecision.SELECTED:
+        reasons.append("selection_not_selected")
+    if not selection_receipt.selected_model_ids:
+        reasons.append("missing_selected_models")
+    if verifier_decision != VerifierDecision.ACCEPT:
+        reasons.append("verifier_not_accept")
+    if not verification_receipt_ids:
+        reasons.append("missing_verification_receipts")
+    if not task_completed:
+        reasons.append("task_not_completed")
+    if not evidence_correct:
+        reasons.append("evidence_not_verified")
+    if unauthorized_changes_detected:
+        reasons.append("unauthorized_changes_detected")
+    if regression_detected:
+        reasons.append("regression_detected")
+    return tuple(sorted(set(reasons)))
+
+
+def _coerce_verifier_decision(value: VerifierDecision | str) -> VerifierDecision:
+    if isinstance(value, VerifierDecision):
+        return value
+    try:
+        return VerifierDecision(str(value).strip().lower())
+    except ValueError as exc:
+        raise ValueError("invalid_verifier_decision") from exc
+
+
+def _normalize_receipts(values: tuple[str, ...]) -> tuple[str, ...]:
+    normalized = tuple(sorted(str(value).strip() for value in values if str(value).strip()))
+    if len(set(normalized)) != len(normalized):
+        raise ValueError("duplicate_receipt_ids")
+    return normalized
+
+
+def _required(name: str, value: Any) -> str:
+    cleaned = str(value).strip()
+    if not cleaned:
+        raise ValueError(f"missing_{name}")
+    return cleaned
+
+
+def _positive_int(value: int, name: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise ValueError(f"invalid_{name}")
+    return parsed
+
+
+def _bounded_accepted_count(value: int, sample_count: int) -> int:
+    parsed = int(value)
+    if parsed < 0 or parsed > int(sample_count):
+        raise ValueError("invalid_accepted_count")
+    return parsed
+
+
+def _threshold(value: float) -> float:
+    parsed = float(value)
+    if parsed <= 0 or parsed > 1:
+        raise ValueError("invalid_verifier_threshold")
+    return parsed
+
+
+def _clean_reason(value: Any) -> str:
+    return str(value).strip().lower().replace(" ", "_")
+
+
+def _clean_token(value: Any) -> str:
+    return str(value).strip().lower().replace(" ", "_")
+
+
+def _non_negative_int_or_none(value: int | None) -> int | None:
+    if value is None:
+        return None
+    parsed = int(value)
+    if parsed < 0:
+        raise ValueError("negative_metric")
+    return parsed
+
+
+def _non_negative_float_or_none(value: float | None) -> float | None:
+    if value is None:
+        return None
+    parsed = float(value)
+    if parsed < 0:
+        raise ValueError("negative_metric")
+    return parsed
+
+
+def _digest_prefixed(prefix: str, value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return f"{prefix}:{hashlib.sha256(encoded).hexdigest()}"

--- a/modules/ai_intelligence/ai_gateway/src/model_intelligence_selection.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_intelligence_selection.py
@@ -24,6 +24,8 @@ from .model_intelligence_catalog import (
 
 
 SELECTION_SCHEMA_VERSION = "model_selection_receipt.v1"
+DEFAULT_PANEL_ROLES = ("principal", "researcher", "critic", "implementer")
+RESERVED_PANEL_ROLES = {"verifier"}
 
 
 class SelectionMode(str, Enum):
@@ -64,7 +66,9 @@ class ModelTaskRequirements:
     allowed_providers: tuple[str, ...] = ()
     denied_providers: tuple[str, ...] = ()
     max_candidates: int = 1
-    min_verifier_pass_rate: float = 0.0
+    min_verifier_pass_rate: float | None = None
+    panel_roles: tuple[str, ...] = ()
+    panel_topology_digest: str | None = None
 
     def normalized(self) -> "ModelTaskRequirements":
         max_candidates = max(1, min(int(self.max_candidates), 5))
@@ -85,7 +89,9 @@ class ModelTaskRequirements:
             allowed_providers=tuple(sorted({_clean_token(v) for v in self.allowed_providers if str(v).strip()})),
             denied_providers=tuple(sorted({_clean_token(v) for v in self.denied_providers if str(v).strip()})),
             max_candidates=max_candidates,
-            min_verifier_pass_rate=max(0.0, min(float(self.min_verifier_pass_rate), 1.0)),
+            min_verifier_pass_rate=_verifier_threshold_or_none(self.min_verifier_pass_rate),
+            panel_roles=_normalize_panel_roles(self.panel_roles, max_candidates, self.selection_mode),
+            panel_topology_digest=_clean_optional_digest(self.panel_topology_digest),
         )
 
 
@@ -100,6 +106,15 @@ class ModelCandidateRanking:
 
 
 @dataclass(frozen=True)
+class ModelPanelRoleAssignment:
+    """Role-to-model assignment for panel selection receipts."""
+
+    role: str
+    canonical_model_id: str
+    provider: str
+
+
+@dataclass(frozen=True)
 class ModelSelectionReceipt:
     """Digest-bound model selection result."""
 
@@ -109,6 +124,8 @@ class ModelSelectionReceipt:
     decision: SelectionDecision
     selected_model_ids: tuple[str, ...]
     rankings: tuple[ModelCandidateRanking, ...]
+    role_assignments: tuple[ModelPanelRoleAssignment, ...] = ()
+    panel_topology_digest: str | None = None
     rejection_reasons: tuple[str, ...] = ()
     schema_version: str = SELECTION_SCHEMA_VERSION
 
@@ -121,6 +138,8 @@ class ModelSelectionReceipt:
             "decision": self.decision.value,
             "selected_model_ids": list(self.selected_model_ids),
             "rankings": [asdict(ranking) for ranking in self.rankings],
+            "role_assignments": [asdict(assignment) for assignment in self.role_assignments],
+            "panel_topology_digest": self.panel_topology_digest,
             "rejection_reasons": list(self.rejection_reasons),
         }
 
@@ -128,6 +147,8 @@ class ModelSelectionReceipt:
 def select_models_for_task(
     snapshot: ModelCatalogSnapshot,
     requirements: ModelTaskRequirements,
+    *,
+    production_evidence: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> ModelSelectionReceipt:
     """Select eligible model candidates from a catalog snapshot."""
 
@@ -135,7 +156,7 @@ def select_models_for_task(
     ranked: list[ModelCandidateRanking] = []
     rejection_counts: dict[str, int] = {}
     for card in snapshot.cards:
-        ok, reasons = _eligible(card, normalized_requirements)
+        ok, reasons = _eligible(card, normalized_requirements, production_evidence or {})
         if not ok:
             for reason in reasons:
                 rejection_counts[reason] = rejection_counts.get(reason, 0) + 1
@@ -144,6 +165,7 @@ def select_models_for_task(
 
     ranked.sort(key=lambda item: (-item.score, item.provider, item.canonical_model_id))
     selected = _select_rankings(ranked, normalized_requirements)
+    role_assignments = _build_role_assignments(selected, normalized_requirements)
     decision = SelectionDecision.SELECTED if selected else SelectionDecision.REJECTED
     rejection_reasons = tuple(
         sorted(f"{reason}:{count}" for reason, count in rejection_counts.items())
@@ -155,6 +177,8 @@ def select_models_for_task(
         "decision": decision.value,
         "selected_model_ids": [item.canonical_model_id for item in selected],
         "rankings": [asdict(item) for item in ranked],
+        "role_assignments": [asdict(item) for item in role_assignments],
+        "panel_topology_digest": _panel_topology_digest(normalized_requirements, selected),
         "rejection_reasons": list(rejection_reasons),
     }
     receipt_id = _digest_prefixed("model_selection_receipt", body)
@@ -165,11 +189,17 @@ def select_models_for_task(
         decision=decision,
         selected_model_ids=tuple(item.canonical_model_id for item in selected),
         rankings=tuple(ranked),
+        role_assignments=role_assignments,
+        panel_topology_digest=_panel_topology_digest(normalized_requirements, selected),
         rejection_reasons=rejection_reasons,
     )
 
 
-def _eligible(card: ModelCapabilityCard, requirements: ModelTaskRequirements) -> tuple[bool, tuple[str, ...]]:
+def _eligible(
+    card: ModelCapabilityCard,
+    requirements: ModelTaskRequirements,
+    production_evidence: Mapping[str, Mapping[str, Any]],
+) -> tuple[bool, tuple[str, ...]]:
     reasons: list[str] = []
     provider = _clean_token(card.provider)
     if requirements.allowed_providers and provider not in requirements.allowed_providers:
@@ -200,14 +230,15 @@ def _eligible(card: ModelCapabilityCard, requirements: ModelTaskRequirements) ->
         if card.output_cost_per_million > requirements.max_output_cost_per_million:
             reasons.append("output_cost_too_high")
     if requirements.purpose == SelectionPurpose.PRODUCTION:
+        if requirements.min_verifier_pass_rate is None or requirements.min_verifier_pass_rate <= 0:
+            reasons.append("production_verifier_threshold_missing")
         if card.promotion_state != PromotionState.CHAMPION:
             reasons.append("not_production_champion")
-        if card.verifier_pass_rate is None:
-            reasons.append("missing_verifier_pass_rate")
-        elif card.verifier_pass_rate < requirements.min_verifier_pass_rate:
-            reasons.append("verifier_pass_rate_too_low")
-        if requirements.task_family not in set(card.benchmark_scores):
-            reasons.append("missing_task_benchmark")
+        evidence = production_evidence.get(card.canonical_model_id)
+        if not evidence:
+            reasons.append("missing_production_evidence")
+        else:
+            reasons.extend(_production_evidence_rejections(card, requirements, evidence))
     return not reasons, tuple(sorted(set(reasons)))
 
 
@@ -269,6 +300,77 @@ def _select_rankings(
     return tuple(selected)
 
 
+def _build_role_assignments(
+    selected: tuple[ModelCandidateRanking, ...],
+    requirements: ModelTaskRequirements,
+) -> tuple[ModelPanelRoleAssignment, ...]:
+    if not selected:
+        return ()
+    roles = ("principal",) if requirements.selection_mode == SelectionMode.SINGLE else requirements.panel_roles
+    return tuple(
+        ModelPanelRoleAssignment(
+            role=roles[index],
+            canonical_model_id=item.canonical_model_id,
+            provider=item.provider,
+        )
+        for index, item in enumerate(selected)
+        if index < len(roles)
+    )
+
+
+def _panel_topology_digest(
+    requirements: ModelTaskRequirements,
+    selected: tuple[ModelCandidateRanking, ...],
+) -> str | None:
+    if requirements.selection_mode != SelectionMode.PANEL:
+        return None
+    if requirements.panel_topology_digest:
+        return requirements.panel_topology_digest
+    body = {
+        "roles": list(requirements.panel_roles),
+        "selected_model_ids": [item.canonical_model_id for item in selected],
+        "providers": [item.provider for item in selected],
+    }
+    return _digest_prefixed("panel_topology", body)
+
+
+def _production_evidence_rejections(
+    card: ModelCapabilityCard,
+    requirements: ModelTaskRequirements,
+    evidence: Mapping[str, Any],
+) -> list[str]:
+    reasons: list[str] = []
+    if str(evidence.get("model_id") or "") != card.canonical_model_id:
+        reasons.append("evidence_model_mismatch")
+    if str(evidence.get("task_family") or "") != requirements.task_family:
+        reasons.append("evidence_task_mismatch")
+    if not evidence.get("benchmark_evidence_receipt_id"):
+        reasons.append("missing_benchmark_evidence_receipt")
+    if not evidence.get("promotion_receipt_id"):
+        reasons.append("missing_promotion_receipt")
+    if not evidence.get("signed_promotion_receipt_id"):
+        reasons.append("missing_signed_promotion_receipt")
+    if not evidence.get("task_set_digest"):
+        reasons.append("missing_task_set_digest")
+    if not evidence.get("held_out_split_digest"):
+        reasons.append("missing_held_out_split_digest")
+    if not evidence.get("verifier_digest"):
+        reasons.append("missing_verifier_digest")
+    if not evidence.get("prompt_topology_digest"):
+        reasons.append("missing_prompt_topology_digest")
+    sample_count = _non_negative_int_or_none(evidence.get("sample_count"))
+    if not sample_count:
+        reasons.append("missing_sample_count")
+    verifier_pass_rate = evidence.get("verifier_pass_rate")
+    if verifier_pass_rate is None:
+        reasons.append("missing_verifier_pass_rate")
+    elif requirements.min_verifier_pass_rate is not None and float(verifier_pass_rate) < requirements.min_verifier_pass_rate:
+        reasons.append("verifier_pass_rate_too_low")
+    if str(evidence.get("promotion_state") or "").lower() != PromotionState.CHAMPION.value:
+        reasons.append("promotion_receipt_not_champion")
+    return reasons
+
+
 def _cost_penalty(value: float | None) -> float:
     if value is None:
         return 0.0
@@ -292,7 +394,26 @@ def _requirements_to_json(requirements: ModelTaskRequirements) -> dict[str, Any]
         "denied_providers": list(normalized.denied_providers),
         "max_candidates": normalized.max_candidates,
         "min_verifier_pass_rate": normalized.min_verifier_pass_rate,
+        "panel_roles": list(normalized.panel_roles),
+        "panel_topology_digest": normalized.panel_topology_digest,
     }
+
+
+def _normalize_panel_roles(
+    value: tuple[str, ...],
+    max_candidates: int,
+    selection_mode: SelectionMode,
+) -> tuple[str, ...]:
+    if selection_mode == SelectionMode.SINGLE:
+        return ("principal",)
+    roles = tuple(_clean_token(role) for role in value if str(role).strip()) or DEFAULT_PANEL_ROLES
+    if any(role in RESERVED_PANEL_ROLES for role in roles):
+        raise ValueError("verifier_role_reserved_for_independent_verifier")
+    if len(set(roles)) != len(roles):
+        raise ValueError("duplicate_panel_roles")
+    if len(roles) < max_candidates:
+        raise ValueError("insufficient_panel_roles")
+    return roles[:max_candidates]
 
 
 def _non_negative_float_or_none(value: float | None) -> float | None:
@@ -300,6 +421,26 @@ def _non_negative_float_or_none(value: float | None) -> float | None:
         return None
     parsed = float(value)
     return parsed if parsed >= 0 else None
+
+
+def _non_negative_int_or_none(value: Any) -> int | None:
+    if value is None:
+        return None
+    parsed = int(value)
+    return parsed if parsed >= 0 else None
+
+
+def _verifier_threshold_or_none(value: float | None) -> float | None:
+    if value is None:
+        return None
+    return max(0.0, min(float(value), 1.0))
+
+
+def _clean_optional_digest(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = str(value).strip()
+    return cleaned or None
 
 
 def _clean_token(value: Any) -> str:

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_outcomes.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_outcomes.py
@@ -1,0 +1,239 @@
+"""Tests for model benchmark evidence and outcome receipts."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_catalog import (
+    ModelCapabilityCard,
+    PromotionState,
+    build_model_catalog_snapshot,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import (
+    ModelOutcomeMetrics,
+    OutcomeDecision,
+    VerifierDecision,
+    build_model_benchmark_evidence_receipt,
+    build_model_promotion_evidence_receipt,
+    build_model_selection_outcome_receipt,
+    outcome_feedback_record,
+    production_evidence_for_selection,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_selection import (
+    ModelTaskRequirements,
+    SelectionDecision,
+    SelectionPurpose,
+    select_models_for_task,
+)
+
+
+def _selected_receipt():
+    snapshot = build_model_catalog_snapshot(
+        (
+            ModelCapabilityCard(
+                provider="provider",
+                model_id="provider/model",
+                canonical_model_id="provider/model",
+                source="test",
+                promotion_state=PromotionState.CANDIDATE,
+                task_families=("architecture",),
+            ).normalized(),
+        ),
+        generated_at="2026-07-16T00:00:00+00:00",
+    )
+    receipt = select_models_for_task(snapshot, ModelTaskRequirements(task_family="architecture"))
+    assert receipt.decision == SelectionDecision.SELECTED
+    return receipt
+
+
+def test_benchmark_evidence_binds_held_out_task_set_verifier_topology_and_metrics():
+    receipt = build_model_benchmark_evidence_receipt(
+        model_id="provider/model",
+        task_family="architecture",
+        task_set_digest="sha256:taskset",
+        held_out_split_digest="sha256:heldout",
+        prompt_topology_digest="sha256:topology",
+        verifier_digest="sha256:verifier",
+        verifier_receipt_id="verifier:1",
+        sample_count=25,
+        accepted_count=23,
+        metrics=ModelOutcomeMetrics(latency_ms=1000, input_tokens=200, output_tokens=100, cost_estimate_usd=0.12),
+    )
+
+    assert receipt.receipt_id.startswith("model_benchmark_evidence:")
+    assert receipt.verifier_pass_rate == 0.92
+    assert receipt.task_set_digest == "sha256:taskset"
+    assert receipt.held_out_split_digest == "sha256:heldout"
+    assert receipt.prompt_topology_digest == "sha256:topology"
+    assert receipt.verifier_digest == "sha256:verifier"
+
+
+def test_benchmark_evidence_rejects_missing_digest_and_bad_sample_counts():
+    for kwargs in (
+        {"task_set_digest": ""},
+        {"sample_count": 0},
+        {"accepted_count": 6, "sample_count": 5},
+    ):
+        base = {
+            "model_id": "provider/model",
+            "task_family": "architecture",
+            "task_set_digest": "sha256:taskset",
+            "held_out_split_digest": "sha256:heldout",
+            "prompt_topology_digest": "sha256:topology",
+            "verifier_digest": "sha256:verifier",
+            "verifier_receipt_id": "verifier:1",
+            "sample_count": 5,
+            "accepted_count": 4,
+        }
+        base.update(kwargs)
+        try:
+            build_model_benchmark_evidence_receipt(**base)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"expected rejection for {kwargs}")
+
+
+def test_promotion_evidence_requires_signed_authority_and_threshold():
+    benchmark = build_model_benchmark_evidence_receipt(
+        model_id="provider/model",
+        task_family="architecture",
+        task_set_digest="sha256:taskset",
+        held_out_split_digest="sha256:heldout",
+        prompt_topology_digest="sha256:topology",
+        verifier_digest="sha256:verifier",
+        verifier_receipt_id="verifier:1",
+        sample_count=10,
+        accepted_count=10,
+    )
+
+    promotion = build_model_promotion_evidence_receipt(
+        benchmark_receipt=benchmark,
+        promotion_state=PromotionState.CHAMPION,
+        promotion_authority_receipt_id="authority:1",
+        signed_promotion_receipt_id="signature:1",
+        min_verifier_pass_rate=0.95,
+    )
+
+    assert promotion.receipt_id.startswith("model_promotion_evidence:")
+    assert promotion.signed_promotion_receipt_id == "signature:1"
+
+    try:
+        build_model_promotion_evidence_receipt(
+            benchmark_receipt=benchmark,
+            promotion_state=PromotionState.CHAMPION,
+            promotion_authority_receipt_id="authority:1",
+            signed_promotion_receipt_id="",
+            min_verifier_pass_rate=0.95,
+        )
+    except ValueError as exc:
+        assert str(exc) == "missing_signed_promotion_receipt_id"
+    else:
+        raise AssertionError("expected missing signature rejection")
+
+
+def test_production_evidence_map_feeds_hardened_selection():
+    benchmark = build_model_benchmark_evidence_receipt(
+        model_id="provider/model",
+        task_family="architecture",
+        task_set_digest="sha256:taskset",
+        held_out_split_digest="sha256:heldout",
+        prompt_topology_digest="sha256:topology",
+        verifier_digest="sha256:verifier",
+        verifier_receipt_id="verifier:1",
+        sample_count=10,
+        accepted_count=9,
+    )
+    promotion = build_model_promotion_evidence_receipt(
+        benchmark_receipt=benchmark,
+        promotion_state=PromotionState.CHAMPION,
+        promotion_authority_receipt_id="authority:1",
+        signed_promotion_receipt_id="signature:1",
+        min_verifier_pass_rate=0.9,
+    )
+    snapshot = build_model_catalog_snapshot(
+        (
+            ModelCapabilityCard(
+                provider="provider",
+                model_id="provider/model",
+                canonical_model_id="provider/model",
+                source="test",
+                promotion_state=PromotionState.CHAMPION,
+                task_families=("architecture",),
+            ).normalized(),
+        ),
+        generated_at="2026-07-16T00:00:00+00:00",
+    )
+
+    receipt = select_models_for_task(
+        snapshot,
+        ModelTaskRequirements(
+            task_family="architecture",
+            purpose=SelectionPurpose.PRODUCTION,
+            min_verifier_pass_rate=0.9,
+        ),
+        production_evidence=production_evidence_for_selection(benchmark, promotion),
+    )
+
+    assert receipt.selected_model_ids == ("provider/model",)
+
+
+def test_outcome_receipt_accepts_only_verified_complete_results():
+    selection = _selected_receipt()
+    receipt = build_model_selection_outcome_receipt(
+        selection,
+        verifier_decision=VerifierDecision.ACCEPT,
+        verification_receipt_ids=("verify:1",),
+        task_completed=True,
+        evidence_correct=True,
+        metrics=ModelOutcomeMetrics(latency_ms=100),
+    )
+
+    assert receipt.outcome_decision == OutcomeDecision.ACCEPTED
+    assert receipt.feedback_eligible is True
+    assert outcome_feedback_record(receipt)["outcome_receipt_id"] == receipt.receipt_id
+
+
+def test_outcome_receipt_rejects_unverified_or_regressed_results():
+    selection = _selected_receipt()
+    receipt = build_model_selection_outcome_receipt(
+        selection,
+        verifier_decision=VerifierDecision.REJECT,
+        verification_receipt_ids=("verify:1",),
+        task_completed=True,
+        evidence_correct=True,
+        regression_detected=True,
+    )
+
+    assert receipt.outcome_decision == OutcomeDecision.REJECTED
+    assert receipt.feedback_eligible is False
+    assert "verifier_not_accept" in receipt.rejection_reasons
+    assert "regression_detected" in receipt.rejection_reasons
+
+    try:
+        outcome_feedback_record(receipt)
+    except ValueError as exc:
+        assert str(exc) == "outcome_not_feedback_eligible"
+    else:
+        raise AssertionError("rejected outcome must not feed benchmark memory")
+
+
+def test_outcome_module_has_no_network_or_command_execution_imports():
+    source = Path("modules/ai_intelligence/ai_gateway/src/model_intelligence_outcomes.py").read_text()
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            assert not (
+                isinstance(node.func.value, ast.Name)
+                and node.func.value.id in {"os", "subprocess", "requests", "urllib"}
+            )
+
+    assert "subprocess" not in imported
+    assert "requests" not in imported
+    assert "urllib" not in imported

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_selection.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_selection.py
@@ -18,6 +18,12 @@ from modules.ai_intelligence.ai_gateway.src.model_intelligence_selection import 
     SelectionPurpose,
     select_models_for_task,
 )
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import (
+    ModelOutcomeMetrics,
+    build_model_benchmark_evidence_receipt,
+    build_model_promotion_evidence_receipt,
+    production_evidence_for_selection,
+)
 
 
 def _snapshot(*cards: ModelCapabilityCard):
@@ -84,17 +90,73 @@ def test_production_rejects_unbenchmarked_non_champion_candidate():
     assert receipt.decision == SelectionDecision.REJECTED
     assert receipt.selected_model_ids == ()
     assert "not_production_champion:1" in receipt.rejection_reasons
-    assert "missing_verifier_pass_rate:1" in receipt.rejection_reasons
-    assert "missing_task_benchmark:1" in receipt.rejection_reasons
+    assert "missing_production_evidence:1" in receipt.rejection_reasons
 
 
-def test_production_selects_measured_champion_over_weaker_candidate():
+def test_production_rejects_catalog_only_champion_without_receipt_bound_evidence():
     champion = _card(
         "provider/champion",
         provider="a",
         promotion_state=PromotionState.CHAMPION,
         verifier_pass_rate=0.96,
         benchmark_scores={"architecture": 0.88},
+    )
+    receipt = select_models_for_task(
+        _snapshot(champion),
+        ModelTaskRequirements(
+            task_family="architecture",
+            purpose=SelectionPurpose.PRODUCTION,
+            min_verifier_pass_rate=0.9,
+        ),
+    )
+
+    assert receipt.decision == SelectionDecision.REJECTED
+    assert receipt.selected_model_ids == ()
+    assert "missing_production_evidence:1" in receipt.rejection_reasons
+
+
+def test_production_requires_explicit_nonzero_verifier_threshold():
+    champion = _card(
+        "provider/champion",
+        promotion_state=PromotionState.CHAMPION,
+        verifier_pass_rate=0.99,
+        benchmark_scores={"architecture": 0.99},
+    )
+    receipt = select_models_for_task(
+        _snapshot(champion),
+        ModelTaskRequirements(
+            task_family="architecture",
+            purpose=SelectionPurpose.PRODUCTION,
+        ),
+        production_evidence={
+            "provider/champion": {
+                "model_id": "provider/champion",
+                "task_family": "architecture",
+                "benchmark_evidence_receipt_id": "benchmark:1",
+                "promotion_receipt_id": "promotion:1",
+                "signed_promotion_receipt_id": "signed:1",
+                "task_set_digest": "sha256:taskset",
+                "held_out_split_digest": "sha256:heldout",
+                "prompt_topology_digest": "sha256:topology",
+                "verifier_digest": "sha256:verifier",
+                "sample_count": 10,
+                "verifier_pass_rate": 0.99,
+                "promotion_state": "champion",
+            }
+        },
+    )
+
+    assert receipt.decision == SelectionDecision.REJECTED
+    assert "production_verifier_threshold_missing:1" in receipt.rejection_reasons
+
+
+def test_production_selects_champion_only_with_benchmark_and_signed_promotion_receipts():
+    champion = _card(
+        "provider/champion",
+        provider="a",
+        promotion_state=PromotionState.CHAMPION,
+        verifier_pass_rate=0.01,
+        benchmark_scores={},
     )
     candidate = _card(
         "provider/candidate",
@@ -103,6 +165,25 @@ def test_production_selects_measured_champion_over_weaker_candidate():
         verifier_pass_rate=0.99,
         benchmark_scores={"architecture": 0.99},
     )
+    benchmark = build_model_benchmark_evidence_receipt(
+        model_id="provider/champion",
+        task_family="architecture",
+        task_set_digest="sha256:task-set",
+        held_out_split_digest="sha256:held-out",
+        prompt_topology_digest="sha256:topology",
+        verifier_digest="sha256:verifier",
+        verifier_receipt_id="verifier_receipt:1",
+        sample_count=50,
+        accepted_count=47,
+        metrics=ModelOutcomeMetrics(latency_ms=1200, input_tokens=1000, output_tokens=500),
+    )
+    promotion = build_model_promotion_evidence_receipt(
+        benchmark_receipt=benchmark,
+        promotion_state=PromotionState.CHAMPION,
+        promotion_authority_receipt_id="promotion_authority:1",
+        signed_promotion_receipt_id="signed_promotion:1",
+        min_verifier_pass_rate=0.9,
+    )
     receipt = select_models_for_task(
         _snapshot(candidate, champion),
         ModelTaskRequirements(
@@ -110,6 +191,7 @@ def test_production_selects_measured_champion_over_weaker_candidate():
             purpose=SelectionPurpose.PRODUCTION,
             min_verifier_pass_rate=0.9,
         ),
+        production_evidence=production_evidence_for_selection(benchmark, promotion),
     )
 
     assert receipt.decision == SelectionDecision.SELECTED
@@ -169,10 +251,31 @@ def test_panel_selection_prefers_provider_diversity():
 
     assert receipt.decision == SelectionDecision.SELECTED
     assert len(receipt.selected_model_ids) == 2
+    assert receipt.panel_topology_digest
+    assert [assignment.role for assignment in receipt.role_assignments] == ["principal", "researcher"]
     selected_providers = {
         item.provider for item in receipt.rankings if item.canonical_model_id in receipt.selected_model_ids
     }
     assert selected_providers == {"a", "b"}
+
+
+def test_panel_selection_reserves_verifier_role_for_independent_verifier():
+    snapshot = _snapshot(_card("a/strong", provider="a"), _card("b/diverse", provider="b"))
+
+    try:
+        select_models_for_task(
+            snapshot,
+            ModelTaskRequirements(
+                task_family="architecture",
+                selection_mode=SelectionMode.PANEL,
+                max_candidates=2,
+                panel_roles=("principal", "verifier"),
+            ),
+        )
+    except ValueError as exc:
+        assert str(exc) == "verifier_role_reserved_for_independent_verifier"
+    else:
+        raise AssertionError("expected verifier role to be rejected")
 
 
 def test_blocked_and_unavailable_models_are_never_selected():


### PR DESCRIPTION
﻿## Summary

Implements `MODEL_BENCHMARK_EVIDENCE_AND_OUTCOME_RECEIPTS_PHASE1`.

This hardens #1129 additively. Evaluation selection remains available for benchmarking, but production selection can no longer trust scalar catalog fields such as `promotion_state`, `benchmark_scores`, or `verifier_pass_rate` by themselves.

## What changed

- Added `src/model_intelligence_outcomes.py`
  - `ModelBenchmarkEvidenceReceipt`
  - `ModelPromotionEvidenceReceipt`
  - `ModelSelectionOutcomeReceipt`
  - receipt mapping for production selection
  - fail-closed feedback record creation
- Hardened `src/model_intelligence_selection.py`
  - production requires receipt-bound benchmark + signed promotion evidence
  - production requires explicit nonzero verifier threshold
  - catalog-only `CHAMPION` is rejected
  - panel selection emits role assignments and topology digest
  - `verifier` role is reserved for the independent verifier outside the candidate panel
- Added/updated tests for benchmark digests, held-out split, verifier digest, signed promotion, outcome feedback, production threshold, and panel role boundaries.

## WSP_97 truth boundary

OBSERVED / implemented:
- Evaluation selection behavior is preserved for benchmark candidates.
- Production selection rejects unbenchmarked/non-receipt-bound champions.
- Benchmark evidence binds model ID, task-set digest, held-out split digest, prompt/topology digest, verifier digest, sample count, cost and latency.
- Promotion evidence requires signed promotion authority.
- Outcome receipts are feedback-eligible only after independent verifier acceptance and no regression/unauthorized-change flags.
- No provider calls, model calls, command execution, PatternMemory writes, HoloIndex re-index, RedDog runtime binding, or champion ledger mutation.

SPECIFIED_NOT_IMPLEMENTED:
- Benchmark harness execution.
- Champion/challenger promotion gate persistence.
- AutoResearch campaign loop.
- RedDog dynamic model runtime binding.

## Validation

- `python -m pytest modules/ai_intelligence/ai_gateway/tests -q` -> 25 passed
- `python -m py_compile modules/ai_intelligence/ai_gateway/src/model_intelligence_catalog.py modules/ai_intelligence/ai_gateway/src/model_intelligence_selection.py modules/ai_intelligence/ai_gateway/src/model_intelligence_outcomes.py`
- `git diff --check`
- Added-line ASCII scan -> 0 non-ASCII
