### PR TITLE
feat(ai-gateway): add model combination benchmark harness

### DIFF
--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -99,6 +99,24 @@ receipt to that benchmark evidence. Outcome receipts are feedback-eligible only
 when the independent verifier accepts, task completion is true, evidence is
 verified, and no regression or unauthorized change is detected.
 
+#### Model Combination Benchmark Harness
+
+```python
+build_model_benchmark_candidate(role_assignments) -> ModelBenchmarkCandidate
+run_model_combination_benchmark(...) -> ModelCombinationBenchmarkRunReceipt
+```
+
+The harness evaluates single-model or panel candidates against a held-out
+`ModelBenchmarkTask` set using injected runner and verifier callables. It
+produces per-candidate `ModelBenchmarkEvidenceReceipt` records and a digest-bound
+run receipt over task-set digest, held-out split digest, verifier digest,
+role/topology assignments, sample receipts, and benchmark evidence receipt IDs.
+
+The verifier role is reserved for an independent verifier and cannot be part of
+the candidate panel. The harness does not call model providers, execute commands,
+promote champions, persist PatternMemory, mutate HoloIndex, or bind RedDog
+runtime defaults.
+
 ## Configuration
 
 ### Environment Variables

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,43 @@
 # AI Gateway Module Change Log
 
+## [2026-07-16] - Model Combination Benchmark Harness
+
+**Who:** 0102 Codex
+**Type:** Runtime Foundation
+**Slice:** MODEL_COMBINATION_BENCHMARK_HARNESS_PHASE1
+
+**What:** Added a deterministic benchmark harness for single-model and Fusion
+panel candidates.
+
+**Why:** RedDog model selection must be driven by measured task fitness. After
+receipt-bound production evidence landed, the next missing layer was a governed
+way to produce benchmark evidence from held-out tasks without turning provider
+catalog claims or model self-reports into production authority.
+
+**Files:**
+- `src/model_combination_benchmark_harness.py` - held-out task and candidate
+  schemas, role/topology-bound candidate construction, injected runner/verifier
+  benchmark execution, fail-closed sample receipts, and benchmark run receipts.
+- `tests/test_model_combination_benchmark_harness.py` - single-model, panel,
+  verifier-role exclusion, runner/verifier failure, deterministic digest, task
+  validation, panel evidence boundary, and no-network/no-command tests.
+- `README.md` and `INTERFACE.md` - public truth boundary and API notes.
+
+**Truth Boundary:**
+- IMPLEMENTED: benchmark evidence can be produced for single-model and panel
+  candidates from injected runner/verifier seams.
+- IMPLEMENTED: task-set, held-out split, verifier, sample count, cost, latency,
+  and role/topology digests are bound into receipts.
+- IMPLEMENTED: runner/verifier failures produce rejected sample evidence rather
+  than promotion evidence by assertion.
+- NOT IMPLEMENTED: provider calls, benchmark scheduling, champion/challenger
+  promotion gates, PatternMemory writes, AutoResearch campaigns, or RedDog
+  dynamic runtime binding.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-16] - Benchmark Evidence and Outcome Receipts
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -47,6 +47,18 @@ before production model selection can trust a champion:
 Catalog scalar fields remain useful for evaluation and ranking, but production
 selection rejects `CHAMPION` unless these evidence receipts are supplied.
 
+## Model Combination Benchmark Harness
+
+`src/model_combination_benchmark_harness.py` runs deterministic held-out
+benchmarks for single-model and panel candidates through injected runner and
+verifier callables. It binds task-set, held-out split, verifier, role/topology
+and sample results into benchmark evidence receipts.
+
+This layer is still pre-production. It does not call providers, execute shell
+commands, promote champions, write PatternMemory, or bind RedDog runtime model
+defaults. Panel benchmark evidence remains panel evidence; a later promotion
+gate must decide how, or whether, panel combinations become production choices.
+
 **Usage Examples**:
 ```python
 from modules.ai_intelligence.ai_gateway import AIGateway

--- a/modules/ai_intelligence/ai_gateway/src/model_combination_benchmark_harness.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_combination_benchmark_harness.py
@@ -1,0 +1,446 @@
+"""Deterministic benchmark harness for model and panel candidates.
+
+The harness evaluates candidate model combinations against held-out tasks using
+injected runner and verifier callables. It does not call model providers,
+execute commands, promote champions, write PatternMemory, or bind RedDog
+runtime defaults.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any, Callable, Mapping, Sequence
+
+from .model_intelligence_outcomes import (
+    ModelBenchmarkEvidenceReceipt,
+    ModelOutcomeMetrics,
+    VerifierDecision,
+    build_model_benchmark_evidence_receipt,
+)
+from .model_intelligence_selection import RESERVED_PANEL_ROLES
+
+
+BENCHMARK_RUN_SCHEMA_VERSION = "model_combination_benchmark_run_receipt.v1"
+TASK_SCHEMA_VERSION = "model_benchmark_task.v1"
+CANDIDATE_SCHEMA_VERSION = "model_benchmark_candidate.v1"
+
+
+@dataclass(frozen=True)
+class ModelBenchmarkTask:
+    """One held-out benchmark task.
+
+    The prompt body is not stored here. The harness binds only deterministic
+    digests and task metadata so benchmark receipts can be audited without
+    leaking raw prompts into downstream promotion records.
+    """
+
+    task_id: str
+    task_family: str
+    prompt_digest: str
+    expected_output_digest: str
+    verifier_contract_digest: str
+    metadata: Mapping[str, str] = field(default_factory=dict)
+    schema_version: str = TASK_SCHEMA_VERSION
+
+    def normalized(self) -> "ModelBenchmarkTask":
+        return ModelBenchmarkTask(
+            task_id=_required("task_id", self.task_id),
+            task_family=_clean_token(_required("task_family", self.task_family)),
+            prompt_digest=_required("prompt_digest", self.prompt_digest),
+            expected_output_digest=_required("expected_output_digest", self.expected_output_digest),
+            verifier_contract_digest=_required("verifier_contract_digest", self.verifier_contract_digest),
+            metadata=dict(sorted((str(k), str(v)) for k, v in self.metadata.items())),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        task = self.normalized()
+        return {
+            "schema_version": task.schema_version,
+            "task_id": task.task_id,
+            "task_family": task.task_family,
+            "prompt_digest": task.prompt_digest,
+            "expected_output_digest": task.expected_output_digest,
+            "verifier_contract_digest": task.verifier_contract_digest,
+            "metadata": dict(task.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class ModelBenchmarkRoleAssignment:
+    """Role assignment for a benchmark candidate."""
+
+    role: str
+    model_id: str
+    provider: str
+
+    def normalized(self) -> "ModelBenchmarkRoleAssignment":
+        role = _clean_token(_required("role", self.role))
+        if role in RESERVED_PANEL_ROLES:
+            raise ValueError("verifier_role_reserved_for_independent_verifier")
+        return ModelBenchmarkRoleAssignment(
+            role=role,
+            model_id=_required("model_id", self.model_id),
+            provider=_clean_token(_required("provider", self.provider)),
+        )
+
+
+@dataclass(frozen=True)
+class ModelBenchmarkCandidate:
+    """Single-model or panel candidate to benchmark."""
+
+    candidate_id: str
+    role_assignments: tuple[ModelBenchmarkRoleAssignment, ...]
+    topology_digest: str
+    schema_version: str = CANDIDATE_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "candidate_id": self.candidate_id,
+            "topology_digest": self.topology_digest,
+            "role_assignments": [asdict(item.normalized()) for item in self.role_assignments],
+        }
+
+
+@dataclass(frozen=True)
+class ModelBenchmarkTaskOutput:
+    """Output receipt returned by an injected candidate runner."""
+
+    output_digest: str
+    runner_receipt_id: str
+    metrics: ModelOutcomeMetrics = field(default_factory=ModelOutcomeMetrics)
+
+    def normalized(self) -> "ModelBenchmarkTaskOutput":
+        return ModelBenchmarkTaskOutput(
+            output_digest=_required("output_digest", self.output_digest),
+            runner_receipt_id=_required("runner_receipt_id", self.runner_receipt_id),
+            metrics=self.metrics.normalized(),
+        )
+
+
+@dataclass(frozen=True)
+class ModelBenchmarkVerifierResult:
+    """Independent verifier result for one candidate/task output."""
+
+    decision: VerifierDecision
+    verifier_receipt_id: str
+    evidence_correct: bool
+    rejection_reasons: tuple[str, ...] = ()
+
+    def normalized(self) -> "ModelBenchmarkVerifierResult":
+        return ModelBenchmarkVerifierResult(
+            decision=_coerce_verifier_decision(self.decision),
+            verifier_receipt_id=_required("verifier_receipt_id", self.verifier_receipt_id),
+            evidence_correct=bool(self.evidence_correct),
+            rejection_reasons=tuple(sorted(_clean_token(v) for v in self.rejection_reasons if str(v).strip())),
+        )
+
+
+@dataclass(frozen=True)
+class ModelBenchmarkSampleReceipt:
+    """Fail-closed result for one candidate on one held-out task."""
+
+    task_id: str
+    candidate_id: str
+    decision: VerifierDecision
+    accepted: bool
+    output_digest: str | None = None
+    runner_receipt_id: str | None = None
+    verifier_receipt_id: str | None = None
+    metrics: ModelOutcomeMetrics = field(default_factory=ModelOutcomeMetrics)
+    rejection_reasons: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "candidate_id": self.candidate_id,
+            "decision": self.decision.value,
+            "accepted": self.accepted,
+            "output_digest": self.output_digest,
+            "runner_receipt_id": self.runner_receipt_id,
+            "verifier_receipt_id": self.verifier_receipt_id,
+            "metrics": asdict(self.metrics.normalized()),
+            "rejection_reasons": list(self.rejection_reasons),
+        }
+
+
+@dataclass(frozen=True)
+class ModelCombinationBenchmarkRunReceipt:
+    """Digest-bound benchmark run over one held-out task set."""
+
+    receipt_id: str
+    task_family: str
+    task_set_digest: str
+    held_out_split_digest: str
+    verifier_digest: str
+    candidates: tuple[ModelBenchmarkCandidate, ...]
+    samples: tuple[ModelBenchmarkSampleReceipt, ...]
+    benchmark_evidence_receipts: tuple[ModelBenchmarkEvidenceReceipt, ...]
+    schema_version: str = BENCHMARK_RUN_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "receipt_id": self.receipt_id,
+            "task_family": self.task_family,
+            "task_set_digest": self.task_set_digest,
+            "held_out_split_digest": self.held_out_split_digest,
+            "verifier_digest": self.verifier_digest,
+            "candidates": [candidate.to_dict() for candidate in self.candidates],
+            "samples": [sample.to_dict() for sample in self.samples],
+            "benchmark_evidence_receipts": [
+                receipt.to_dict() for receipt in self.benchmark_evidence_receipts
+            ],
+        }
+
+
+BenchmarkRunner = Callable[[ModelBenchmarkTask, ModelBenchmarkCandidate], ModelBenchmarkTaskOutput]
+BenchmarkVerifier = Callable[
+    [ModelBenchmarkTask, ModelBenchmarkCandidate, ModelBenchmarkTaskOutput],
+    ModelBenchmarkVerifierResult,
+]
+
+
+def build_model_benchmark_candidate(
+    role_assignments: Sequence[ModelBenchmarkRoleAssignment],
+) -> ModelBenchmarkCandidate:
+    """Build a deterministic single-model or panel benchmark candidate."""
+
+    normalized = tuple(item.normalized() for item in role_assignments)
+    if not normalized:
+        raise ValueError("missing_role_assignments")
+    roles = [item.role for item in normalized]
+    if len(set(roles)) != len(roles):
+        raise ValueError("duplicate_candidate_roles")
+    body = {
+        "schema_version": CANDIDATE_SCHEMA_VERSION,
+        "role_assignments": [asdict(item) for item in normalized],
+    }
+    topology_digest = _digest_prefixed("model_panel_topology", body)
+    if len(normalized) == 1 and normalized[0].role == "principal":
+        candidate_id = normalized[0].model_id
+    else:
+        candidate_id = _digest_prefixed("model_panel_candidate", body)
+    return ModelBenchmarkCandidate(
+        candidate_id=candidate_id,
+        role_assignments=normalized,
+        topology_digest=topology_digest,
+    )
+
+
+def run_model_combination_benchmark(
+    *,
+    tasks: Sequence[ModelBenchmarkTask],
+    candidates: Sequence[ModelBenchmarkCandidate],
+    runner: BenchmarkRunner,
+    verifier: BenchmarkVerifier,
+    verifier_digest: str,
+    held_out_split_id: str,
+) -> ModelCombinationBenchmarkRunReceipt:
+    """Run a deterministic benchmark over injected runner/verifier seams."""
+
+    normalized_tasks = _normalize_tasks(tasks)
+    normalized_candidates = _normalize_candidates(candidates)
+    verifier_digest_value = _required("verifier_digest", verifier_digest)
+    held_out_split_digest = _digest_prefixed(
+        "held_out_split",
+        {
+            "held_out_split_id": _required("held_out_split_id", held_out_split_id),
+            "task_ids": [task.task_id for task in normalized_tasks],
+            "prompt_digests": [task.prompt_digest for task in normalized_tasks],
+        },
+    )
+    task_set_digest = _digest_prefixed(
+        "model_benchmark_task_set",
+        {"tasks": [task.to_dict() for task in normalized_tasks]},
+    )
+    task_family = normalized_tasks[0].task_family
+    samples: list[ModelBenchmarkSampleReceipt] = []
+    benchmark_receipts: list[ModelBenchmarkEvidenceReceipt] = []
+    for candidate in normalized_candidates:
+        candidate_samples = [
+            _run_one_sample(
+                task=task,
+                candidate=candidate,
+                runner=runner,
+                verifier=verifier,
+            )
+            for task in normalized_tasks
+        ]
+        samples.extend(candidate_samples)
+        benchmark_receipts.append(
+            build_model_benchmark_evidence_receipt(
+                model_id=candidate.candidate_id,
+                task_family=task_family,
+                task_set_digest=task_set_digest,
+                held_out_split_digest=held_out_split_digest,
+                prompt_topology_digest=candidate.topology_digest,
+                verifier_digest=verifier_digest_value,
+                verifier_receipt_id=_digest_prefixed(
+                    "model_combination_verifier_receipts",
+                    {
+                        "candidate_id": candidate.candidate_id,
+                        "verifier_receipt_ids": [
+                            sample.verifier_receipt_id
+                            for sample in candidate_samples
+                            if sample.verifier_receipt_id
+                        ],
+                    },
+                ),
+                sample_count=len(candidate_samples),
+                accepted_count=sum(1 for sample in candidate_samples if sample.accepted),
+                metrics=_aggregate_metrics(tuple(sample.metrics for sample in candidate_samples)),
+            )
+        )
+    body = {
+        "schema_version": BENCHMARK_RUN_SCHEMA_VERSION,
+        "task_family": task_family,
+        "task_set_digest": task_set_digest,
+        "held_out_split_digest": held_out_split_digest,
+        "verifier_digest": verifier_digest_value,
+        "candidates": [candidate.to_dict() for candidate in normalized_candidates],
+        "samples": [sample.to_dict() for sample in samples],
+        "benchmark_evidence_receipt_ids": [receipt.receipt_id for receipt in benchmark_receipts],
+    }
+    return ModelCombinationBenchmarkRunReceipt(
+        receipt_id=_digest_prefixed("model_combination_benchmark_run", body),
+        task_family=task_family,
+        task_set_digest=task_set_digest,
+        held_out_split_digest=held_out_split_digest,
+        verifier_digest=verifier_digest_value,
+        candidates=normalized_candidates,
+        samples=tuple(samples),
+        benchmark_evidence_receipts=tuple(benchmark_receipts),
+    )
+
+
+def _run_one_sample(
+    *,
+    task: ModelBenchmarkTask,
+    candidate: ModelBenchmarkCandidate,
+    runner: BenchmarkRunner,
+    verifier: BenchmarkVerifier,
+) -> ModelBenchmarkSampleReceipt:
+    try:
+        output = runner(task, candidate).normalized()
+    except Exception:
+        return ModelBenchmarkSampleReceipt(
+            task_id=task.task_id,
+            candidate_id=candidate.candidate_id,
+            decision=VerifierDecision.ERROR,
+            accepted=False,
+            rejection_reasons=("runner_error",),
+        )
+    try:
+        verifier_result = verifier(task, candidate, output).normalized()
+    except Exception:
+        return ModelBenchmarkSampleReceipt(
+            task_id=task.task_id,
+            candidate_id=candidate.candidate_id,
+            decision=VerifierDecision.ERROR,
+            accepted=False,
+            output_digest=output.output_digest,
+            runner_receipt_id=output.runner_receipt_id,
+            metrics=output.metrics,
+            rejection_reasons=("verifier_error",),
+        )
+    accepted = verifier_result.decision == VerifierDecision.ACCEPT and verifier_result.evidence_correct
+    rejection_reasons = list(verifier_result.rejection_reasons)
+    if verifier_result.decision != VerifierDecision.ACCEPT:
+        rejection_reasons.append("verifier_not_accept")
+    if not verifier_result.evidence_correct:
+        rejection_reasons.append("evidence_not_verified")
+    return ModelBenchmarkSampleReceipt(
+        task_id=task.task_id,
+        candidate_id=candidate.candidate_id,
+        decision=verifier_result.decision,
+        accepted=accepted,
+        output_digest=output.output_digest,
+        runner_receipt_id=output.runner_receipt_id,
+        verifier_receipt_id=verifier_result.verifier_receipt_id,
+        metrics=output.metrics,
+        rejection_reasons=tuple(sorted(set(rejection_reasons))),
+    )
+
+
+def _normalize_tasks(tasks: Sequence[ModelBenchmarkTask]) -> tuple[ModelBenchmarkTask, ...]:
+    normalized = tuple(task.normalized() for task in tasks)
+    if not normalized:
+        raise ValueError("missing_benchmark_tasks")
+    task_ids = [task.task_id for task in normalized]
+    if len(set(task_ids)) != len(task_ids):
+        raise ValueError("duplicate_benchmark_task_ids")
+    task_families = {task.task_family for task in normalized}
+    if len(task_families) != 1:
+        raise ValueError("mixed_task_families")
+    return tuple(sorted(normalized, key=lambda task: task.task_id))
+
+
+def _normalize_candidates(candidates: Sequence[ModelBenchmarkCandidate]) -> tuple[ModelBenchmarkCandidate, ...]:
+    normalized = tuple(candidates)
+    if not normalized:
+        raise ValueError("missing_benchmark_candidates")
+    candidate_ids = [candidate.candidate_id for candidate in normalized]
+    if len(set(candidate_ids)) != len(candidate_ids):
+        raise ValueError("duplicate_benchmark_candidate_ids")
+    return tuple(sorted(normalized, key=lambda candidate: candidate.candidate_id))
+
+
+def _aggregate_metrics(metrics: tuple[ModelOutcomeMetrics, ...]) -> ModelOutcomeMetrics:
+    if not metrics:
+        return ModelOutcomeMetrics()
+    normalized = tuple(item.normalized() for item in metrics)
+    return ModelOutcomeMetrics(
+        latency_ms=_mean_int(item.latency_ms for item in normalized),
+        input_tokens=_sum_int(item.input_tokens for item in normalized),
+        output_tokens=_sum_int(item.output_tokens for item in normalized),
+        cost_estimate_usd=_sum_float(item.cost_estimate_usd for item in normalized),
+    )
+
+
+def _mean_int(values: Sequence[int | None]) -> int | None:
+    present = [value for value in values if value is not None]
+    if not present:
+        return None
+    return round(sum(present) / len(present))
+
+
+def _sum_int(values: Sequence[int | None]) -> int | None:
+    present = [value for value in values if value is not None]
+    if not present:
+        return None
+    return sum(present)
+
+
+def _sum_float(values: Sequence[float | None]) -> float | None:
+    present = [value for value in values if value is not None]
+    if not present:
+        return None
+    return round(sum(present), 8)
+
+
+def _coerce_verifier_decision(value: VerifierDecision | str) -> VerifierDecision:
+    if isinstance(value, VerifierDecision):
+        return value
+    try:
+        return VerifierDecision(str(value).strip().lower())
+    except ValueError as exc:
+        raise ValueError("invalid_verifier_decision") from exc
+
+
+def _required(name: str, value: Any) -> str:
+    cleaned = str(value).strip()
+    if not cleaned:
+        raise ValueError(f"missing_{name}")
+    return cleaned
+
+
+def _clean_token(value: Any) -> str:
+    return str(value).strip().lower().replace(" ", "_")
+
+
+def _digest_prefixed(prefix: str, value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return f"{prefix}:{hashlib.sha256(encoded).hexdigest()}"

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_combination_benchmark_harness.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_combination_benchmark_harness.py
@@ -1,0 +1,288 @@
+"""Tests for deterministic model-combination benchmark harness."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_combination_benchmark_harness import (
+    ModelBenchmarkRoleAssignment,
+    ModelBenchmarkTask,
+    ModelBenchmarkTaskOutput,
+    ModelBenchmarkVerifierResult,
+    build_model_benchmark_candidate,
+    run_model_combination_benchmark,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import (
+    ModelOutcomeMetrics,
+    VerifierDecision,
+    production_evidence_for_selection,
+)
+
+
+def _tasks():
+    return (
+        ModelBenchmarkTask(
+            task_id="task-001",
+            task_family="architecture",
+            prompt_digest="sha256:prompt-a",
+            expected_output_digest="sha256:expected-a",
+            verifier_contract_digest="sha256:verifier-contract",
+        ),
+        ModelBenchmarkTask(
+            task_id="task-002",
+            task_family="architecture",
+            prompt_digest="sha256:prompt-b",
+            expected_output_digest="sha256:expected-b",
+            verifier_contract_digest="sha256:verifier-contract",
+        ),
+    )
+
+
+def _single_candidate(model_id: str = "provider/model-a"):
+    return build_model_benchmark_candidate(
+        (ModelBenchmarkRoleAssignment(role="principal", model_id=model_id, provider="provider"),)
+    )
+
+
+def _accepting_runner(task, candidate):
+    return ModelBenchmarkTaskOutput(
+        output_digest=f"sha256:output:{candidate.candidate_id}:{task.task_id}",
+        runner_receipt_id=f"runner:{candidate.candidate_id}:{task.task_id}",
+        metrics=ModelOutcomeMetrics(latency_ms=100, input_tokens=10, output_tokens=5, cost_estimate_usd=0.01),
+    )
+
+
+def _accepting_verifier(task, candidate, output):
+    return ModelBenchmarkVerifierResult(
+        decision=VerifierDecision.ACCEPT,
+        verifier_receipt_id=f"verify:{candidate.candidate_id}:{task.task_id}",
+        evidence_correct=True,
+    )
+
+
+def test_single_model_benchmark_produces_evidence_receipt_bound_to_held_out_tasks():
+    candidate = _single_candidate()
+
+    receipt = run_model_combination_benchmark(
+        tasks=_tasks(),
+        candidates=(candidate,),
+        runner=_accepting_runner,
+        verifier=_accepting_verifier,
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+    )
+
+    evidence = receipt.benchmark_evidence_receipts[0]
+    assert receipt.receipt_id.startswith("model_combination_benchmark_run:")
+    assert receipt.task_set_digest.startswith("model_benchmark_task_set:")
+    assert receipt.held_out_split_digest.startswith("held_out_split:")
+    assert evidence.model_id == "provider/model-a"
+    assert evidence.sample_count == 2
+    assert evidence.accepted_count == 2
+    assert evidence.verifier_pass_rate == 1.0
+    assert evidence.task_set_digest == receipt.task_set_digest
+    assert evidence.held_out_split_digest == receipt.held_out_split_digest
+    assert evidence.prompt_topology_digest == candidate.topology_digest
+    assert evidence.metrics.input_tokens == 20
+    assert evidence.metrics.output_tokens == 10
+
+
+def test_panel_candidate_binds_role_topology_and_is_not_direct_model_id():
+    candidate = build_model_benchmark_candidate(
+        (
+            ModelBenchmarkRoleAssignment(role="principal", model_id="a/lead", provider="a"),
+            ModelBenchmarkRoleAssignment(role="critic", model_id="b/critic", provider="b"),
+        )
+    )
+
+    receipt = run_model_combination_benchmark(
+        tasks=_tasks(),
+        candidates=(candidate,),
+        runner=_accepting_runner,
+        verifier=_accepting_verifier,
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+    )
+
+    assert candidate.candidate_id.startswith("model_panel_candidate:")
+    assert candidate.topology_digest.startswith("model_panel_topology:")
+    assert receipt.benchmark_evidence_receipts[0].model_id == candidate.candidate_id
+    assert [assignment.role for assignment in candidate.role_assignments] == ["principal", "critic"]
+
+
+def test_candidate_rejects_verifier_role_inside_candidate_panel():
+    try:
+        build_model_benchmark_candidate(
+            (
+                ModelBenchmarkRoleAssignment(role="principal", model_id="a/lead", provider="a"),
+                ModelBenchmarkRoleAssignment(role="verifier", model_id="b/verify", provider="b"),
+            )
+        )
+    except ValueError as exc:
+        assert str(exc) == "verifier_role_reserved_for_independent_verifier"
+    else:
+        raise AssertionError("expected verifier role rejection")
+
+
+def test_runner_error_fails_closed_without_blocking_other_candidates():
+    good = _single_candidate("provider/good")
+    bad = _single_candidate("provider/bad")
+
+    def runner(task, candidate):
+        if candidate.candidate_id == "provider/bad":
+            raise RuntimeError("provider unavailable")
+        return _accepting_runner(task, candidate)
+
+    receipt = run_model_combination_benchmark(
+        tasks=_tasks(),
+        candidates=(bad, good),
+        runner=runner,
+        verifier=_accepting_verifier,
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+    )
+
+    by_model = {item.model_id: item for item in receipt.benchmark_evidence_receipts}
+    assert by_model["provider/good"].verifier_pass_rate == 1.0
+    assert by_model["provider/bad"].verifier_pass_rate == 0.0
+    bad_samples = [sample for sample in receipt.samples if sample.candidate_id == "provider/bad"]
+    assert all(sample.rejection_reasons == ("runner_error",) for sample in bad_samples)
+
+
+def test_verifier_rejection_and_bad_evidence_reduce_pass_rate():
+    candidate = _single_candidate()
+
+    def verifier(task, candidate, output):
+        if task.task_id == "task-001":
+            return _accepting_verifier(task, candidate, output)
+        return ModelBenchmarkVerifierResult(
+            decision=VerifierDecision.ACCEPT,
+            verifier_receipt_id=f"verify:{candidate.candidate_id}:{task.task_id}",
+            evidence_correct=False,
+            rejection_reasons=("wrong_file_line",),
+        )
+
+    receipt = run_model_combination_benchmark(
+        tasks=_tasks(),
+        candidates=(candidate,),
+        runner=_accepting_runner,
+        verifier=verifier,
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+    )
+
+    evidence = receipt.benchmark_evidence_receipts[0]
+    assert evidence.accepted_count == 1
+    assert evidence.verifier_pass_rate == 0.5
+    rejected = [sample for sample in receipt.samples if not sample.accepted]
+    assert rejected[0].rejection_reasons == ("evidence_not_verified", "wrong_file_line")
+
+
+def test_harness_digest_is_stable_and_changes_with_held_out_split():
+    candidate = _single_candidate()
+    first = run_model_combination_benchmark(
+        tasks=_tasks(),
+        candidates=(candidate,),
+        runner=_accepting_runner,
+        verifier=_accepting_verifier,
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+    )
+    second = run_model_combination_benchmark(
+        tasks=_tasks(),
+        candidates=(candidate,),
+        runner=_accepting_runner,
+        verifier=_accepting_verifier,
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+    )
+    changed = run_model_combination_benchmark(
+        tasks=_tasks(),
+        candidates=(candidate,),
+        runner=_accepting_runner,
+        verifier=_accepting_verifier,
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v2",
+    )
+
+    assert first.receipt_id == second.receipt_id
+    assert first.receipt_id != changed.receipt_id
+
+
+def test_harness_rejects_duplicate_or_mixed_task_sets():
+    candidate = _single_candidate()
+    duplicate = (_tasks()[0], _tasks()[0])
+    mixed = (
+        _tasks()[0],
+        ModelBenchmarkTask(
+            task_id="task-003",
+            task_family="coding",
+            prompt_digest="sha256:prompt-c",
+            expected_output_digest="sha256:expected-c",
+            verifier_contract_digest="sha256:verifier-contract",
+        ),
+    )
+
+    for tasks, expected in ((duplicate, "duplicate_benchmark_task_ids"), (mixed, "mixed_task_families")):
+        try:
+            run_model_combination_benchmark(
+                tasks=tasks,
+                candidates=(candidate,),
+                runner=_accepting_runner,
+                verifier=_accepting_verifier,
+                verifier_digest="sha256:verifier",
+                held_out_split_id="heldout-v1",
+            )
+        except ValueError as exc:
+            assert str(exc) == expected
+        else:
+            raise AssertionError(f"expected {expected}")
+
+
+def test_panel_benchmark_evidence_is_not_accidentally_accepted_as_single_model_production_evidence():
+    panel = build_model_benchmark_candidate(
+        (
+            ModelBenchmarkRoleAssignment(role="principal", model_id="a/lead", provider="a"),
+            ModelBenchmarkRoleAssignment(role="critic", model_id="b/critic", provider="b"),
+        )
+    )
+    receipt = run_model_combination_benchmark(
+        tasks=_tasks(),
+        candidates=(panel,),
+        runner=_accepting_runner,
+        verifier=_accepting_verifier,
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+    )
+
+    evidence = receipt.benchmark_evidence_receipts[0]
+    assert evidence.model_id == panel.candidate_id
+    assert evidence.model_id not in {"a/lead", "b/critic"}
+
+    # A later promotion gate may define panel production semantics. This harness
+    # only measures the panel and must not silently map it to an individual model.
+    assert production_evidence_for_selection
+
+
+def test_harness_module_has_no_network_command_or_provider_imports():
+    source = Path(
+        "modules/ai_intelligence/ai_gateway/src/model_combination_benchmark_harness.py"
+    ).read_text()
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            assert not (
+                isinstance(node.func.value, ast.Name)
+                and node.func.value.id in {"os", "subprocess", "requests", "urllib", "openai"}
+            )
+
+    assert "subprocess" not in imported
+    assert "requests" not in imported
+    assert "urllib" not in imported
+    assert "openai" not in imported


### PR DESCRIPTION
## Summary

Implements `MODEL_COMBINATION_BENCHMARK_HARNESS_PHASE1` for RedDog model intelligence.

This adds a deterministic held-out benchmark harness for single-model and panel candidates. The harness uses injected runner/verifier callables, emits fail-closed sample receipts, and produces `ModelBenchmarkEvidenceReceipt` records that bind task-set, held-out split, verifier, role/topology, sample count, cost and latency evidence.

## Truth Boundary

- IMPLEMENTED: single-model and panel candidate benchmark receipts.
- IMPLEMENTED: verifier role is reserved outside the candidate panel.
- IMPLEMENTED: runner/verifier errors produce rejected sample evidence.
- IMPLEMENTED: deterministic run receipt over task-set, held-out split, verifier and topology digests.
- NOT IMPLEMENTED: provider calls, benchmark scheduling, champion/challenger promotion gate, PatternMemory writes, AutoResearch campaigns, or RedDog dynamic runtime binding.

## Validation

- `python -m pytest modules/ai_intelligence/ai_gateway/tests -q` -> 34 passed
- `python -m py_compile modules/ai_intelligence/ai_gateway/src/model_intelligence_catalog.py modules/ai_intelligence/ai_gateway/src/model_intelligence_selection.py modules/ai_intelligence/ai_gateway/src/model_intelligence_outcomes.py modules/ai_intelligence/ai_gateway/src/model_combination_benchmark_harness.py` -> pass
- `git diff --check` -> pass (autocrlf warnings only)
- Added-line ASCII scan -> `added_line_non_ascii=0`

Worker-Lane: reddog-model-intelligence
Slice: MODEL_COMBINATION_BENCHMARK_HARNESS_PHASE1
