### PR TITLE
feat(ai-gateway): add model promotion gate

### DIFF
--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -117,6 +117,25 @@ the candidate panel. The harness does not call model providers, execute commands
 promote champions, persist PatternMemory, mutate HoloIndex, or bind RedDog
 runtime defaults.
 
+#### Champion/Challenger Promotion Gate
+
+```python
+evaluate_model_promotion_gate(...) -> ModelPromotionGateReceipt
+```
+
+`ModelPromotionPolicy` binds task family, candidate ID, minimum verifier pass
+rate, minimum sample count, required task-set digest, required held-out split
+digest, required verifier digest, and optional latency/cost ceilings.
+
+The gate validates a `ModelCombinationBenchmarkRunReceipt` and emits
+`PROMOTE_CHAMPION` only when benchmark evidence matches the policy and signed
+promotion authority is supplied. `KEEP_CHALLENGER` records below-threshold
+benchmark evidence without creating champion authority. Mismatched or tampered
+benchmark projections return `REJECT`.
+
+This API does not mutate model catalogs, write champion ledgers, call providers,
+or bind runtime RedDog model defaults.
+
 ## Configuration
 
 ### Environment Variables

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,40 @@
 # AI Gateway Module Change Log
 
+## [2026-07-16] - Champion/Challenger Promotion Gate
+
+**Who:** 0102 Codex
+**Type:** Runtime Foundation
+**Slice:** MODEL_CHAMPION_CHALLENGER_PROMOTION_GATE_PHASE1
+
+**What:** Added a fail-closed promotion gate over model benchmark evidence.
+
+**Why:** Benchmark evidence alone should not install production authority. RedDog
+needs a separate gate that validates task-set/verifier/topology evidence against
+explicit WSP_15 policy and requires signed promotion authority before a champion
+receipt exists.
+
+**Files:**
+- `src/model_promotion_gate.py` - promotion policy, gate receipt, evidence
+  consistency checks, challenger/hero threshold handling, and signed promotion
+  evidence emission.
+- `tests/test_model_promotion_gate.py` - signed authority, below-threshold
+  challenger, missing evidence, tampered benchmark projection, policy conflict,
+  threshold, deterministic digest, and no-network/no-command tests.
+- `README.md` and `INTERFACE.md` - API and truth-boundary notes.
+
+**Truth Boundary:**
+- IMPLEMENTED: matching benchmark evidence plus signed authority can produce a
+  `ModelPromotionEvidenceReceipt`.
+- IMPLEMENTED: below-threshold candidates remain challengers without champion
+  authority.
+- IMPLEMENTED: mismatched or tampered benchmark evidence fails closed.
+- NOT IMPLEMENTED: model catalog mutation, champion ledger persistence,
+  AutoResearch scheduling, provider calls, or RedDog dynamic runtime binding.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-16] - Model Combination Benchmark Harness
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -59,6 +59,17 @@ commands, promote champions, write PatternMemory, or bind RedDog runtime model
 defaults. Panel benchmark evidence remains panel evidence; a later promotion
 gate must decide how, or whether, panel combinations become production choices.
 
+## Champion/Challenger Promotion Gate
+
+`src/model_promotion_gate.py` validates benchmark-run evidence against an
+explicit promotion policy. It can emit a `ModelPromotionEvidenceReceipt` only
+when the benchmark evidence matches the policy and a signed promotion authority
+receipt is supplied.
+
+The gate does not mutate the catalog, write a champion ledger, call providers,
+or bind RedDog runtime defaults. Below-threshold candidates remain challengers;
+tampered or mismatched evidence fails closed.
+
 **Usage Examples**:
 ```python
 from modules.ai_intelligence.ai_gateway import AIGateway

--- a/modules/ai_intelligence/ai_gateway/src/model_promotion_gate.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_promotion_gate.py
@@ -1,0 +1,282 @@
+"""Champion/challenger promotion gate for model intelligence.
+
+The gate validates benchmark-run evidence and, only when signed promotion
+authority is supplied, emits a promotion evidence receipt. It does not mutate
+the model catalog, write a champion ledger, call providers, or bind RedDog
+runtime defaults.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any, Mapping
+
+from .model_combination_benchmark_harness import ModelCombinationBenchmarkRunReceipt
+from .model_intelligence_catalog import PromotionState
+from .model_intelligence_outcomes import (
+    ModelBenchmarkEvidenceReceipt,
+    ModelPromotionEvidenceReceipt,
+    build_model_promotion_evidence_receipt,
+)
+
+
+PROMOTION_GATE_SCHEMA_VERSION = "model_promotion_gate_receipt.v1"
+PROMOTION_POLICY_SCHEMA_VERSION = "model_promotion_policy.v1"
+
+
+class ModelPromotionGateDecision(str, Enum):
+    """Decision emitted by the benchmark promotion gate."""
+
+    PROMOTE_CHAMPION = "promote_champion"
+    KEEP_CHALLENGER = "keep_challenger"
+    REJECT = "reject"
+
+
+@dataclass(frozen=True)
+class ModelPromotionPolicy:
+    """Explicit policy for champion/challenger evaluation."""
+
+    task_family: str
+    candidate_id: str
+    min_verifier_pass_rate: float
+    min_sample_count: int
+    required_task_set_digest: str
+    required_held_out_split_digest: str
+    required_verifier_digest: str
+    max_latency_ms: int | None = None
+    max_cost_estimate_usd: float | None = None
+    schema_version: str = PROMOTION_POLICY_SCHEMA_VERSION
+
+    def normalized(self) -> "ModelPromotionPolicy":
+        return ModelPromotionPolicy(
+            task_family=_clean_token(_required("task_family", self.task_family)),
+            candidate_id=_required("candidate_id", self.candidate_id),
+            min_verifier_pass_rate=_threshold(self.min_verifier_pass_rate),
+            min_sample_count=_positive_int(self.min_sample_count, "min_sample_count"),
+            required_task_set_digest=_required("required_task_set_digest", self.required_task_set_digest),
+            required_held_out_split_digest=_required(
+                "required_held_out_split_digest",
+                self.required_held_out_split_digest,
+            ),
+            required_verifier_digest=_required("required_verifier_digest", self.required_verifier_digest),
+            max_latency_ms=_positive_int_or_none(self.max_latency_ms, "max_latency_ms"),
+            max_cost_estimate_usd=_positive_float_or_none(
+                self.max_cost_estimate_usd,
+                "max_cost_estimate_usd",
+            ),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        policy = self.normalized()
+        return {
+            "schema_version": policy.schema_version,
+            "task_family": policy.task_family,
+            "candidate_id": policy.candidate_id,
+            "min_verifier_pass_rate": policy.min_verifier_pass_rate,
+            "min_sample_count": policy.min_sample_count,
+            "required_task_set_digest": policy.required_task_set_digest,
+            "required_held_out_split_digest": policy.required_held_out_split_digest,
+            "required_verifier_digest": policy.required_verifier_digest,
+            "max_latency_ms": policy.max_latency_ms,
+            "max_cost_estimate_usd": policy.max_cost_estimate_usd,
+        }
+
+
+@dataclass(frozen=True)
+class ModelPromotionGateReceipt:
+    """Digest-bound promotion gate result."""
+
+    receipt_id: str
+    decision: ModelPromotionGateDecision
+    candidate_id: str
+    task_family: str
+    benchmark_run_receipt_id: str
+    benchmark_evidence_receipt_id: str | None
+    policy: ModelPromotionPolicy
+    promotion_evidence_receipt: ModelPromotionEvidenceReceipt | None = None
+    rejection_reasons: tuple[str, ...] = ()
+    schema_version: str = PROMOTION_GATE_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "receipt_id": self.receipt_id,
+            "decision": self.decision.value,
+            "candidate_id": self.candidate_id,
+            "task_family": self.task_family,
+            "benchmark_run_receipt_id": self.benchmark_run_receipt_id,
+            "benchmark_evidence_receipt_id": self.benchmark_evidence_receipt_id,
+            "policy": self.policy.to_dict(),
+            "promotion_evidence_receipt": (
+                self.promotion_evidence_receipt.to_dict() if self.promotion_evidence_receipt else None
+            ),
+            "rejection_reasons": list(self.rejection_reasons),
+        }
+
+
+def evaluate_model_promotion_gate(
+    *,
+    benchmark_run_receipt: ModelCombinationBenchmarkRunReceipt,
+    policy: ModelPromotionPolicy,
+    promotion_authority_receipt_id: str | None = None,
+    signed_promotion_receipt_id: str | None = None,
+) -> ModelPromotionGateReceipt:
+    """Evaluate one benchmark candidate for champion/challenger promotion."""
+
+    normalized_policy = policy.normalized()
+    benchmark_run_receipt_id = _digest_prefixed(
+        "model_combination_benchmark_run_projection",
+        _benchmark_run_projection(benchmark_run_receipt),
+    )
+    evidence = _find_candidate_evidence(benchmark_run_receipt, normalized_policy.candidate_id)
+    rejections = _evidence_rejections(benchmark_run_receipt, normalized_policy, evidence)
+    promotion_evidence: ModelPromotionEvidenceReceipt | None = None
+    decision = ModelPromotionGateDecision.REJECT
+    if evidence and not rejections:
+        if evidence.verifier_pass_rate < normalized_policy.min_verifier_pass_rate:
+            decision = ModelPromotionGateDecision.KEEP_CHALLENGER
+            rejections.append("verifier_pass_rate_below_champion_threshold")
+        elif not promotion_authority_receipt_id or not str(promotion_authority_receipt_id).strip():
+            rejections.append("missing_promotion_authority_receipt")
+        elif not signed_promotion_receipt_id or not str(signed_promotion_receipt_id).strip():
+            rejections.append("missing_signed_promotion_receipt")
+        else:
+            promotion_evidence = build_model_promotion_evidence_receipt(
+                benchmark_receipt=evidence,
+                promotion_state=PromotionState.CHAMPION,
+                promotion_authority_receipt_id=promotion_authority_receipt_id,
+                signed_promotion_receipt_id=signed_promotion_receipt_id,
+                min_verifier_pass_rate=normalized_policy.min_verifier_pass_rate,
+            )
+            decision = ModelPromotionGateDecision.PROMOTE_CHAMPION
+    body = {
+        "schema_version": PROMOTION_GATE_SCHEMA_VERSION,
+        "decision": decision.value,
+        "candidate_id": normalized_policy.candidate_id,
+        "task_family": normalized_policy.task_family,
+        "benchmark_run_receipt_id": benchmark_run_receipt_id,
+        "benchmark_evidence_receipt_id": evidence.receipt_id if evidence else None,
+        "policy": normalized_policy.to_dict(),
+        "promotion_evidence_receipt_id": promotion_evidence.receipt_id if promotion_evidence else None,
+        "rejection_reasons": sorted(set(rejections)),
+    }
+    return ModelPromotionGateReceipt(
+        receipt_id=_digest_prefixed("model_promotion_gate", body),
+        decision=decision,
+        candidate_id=normalized_policy.candidate_id,
+        task_family=normalized_policy.task_family,
+        benchmark_run_receipt_id=benchmark_run_receipt_id,
+        benchmark_evidence_receipt_id=evidence.receipt_id if evidence else None,
+        policy=normalized_policy,
+        promotion_evidence_receipt=promotion_evidence,
+        rejection_reasons=tuple(sorted(set(rejections))),
+    )
+
+
+def _find_candidate_evidence(
+    benchmark_run_receipt: ModelCombinationBenchmarkRunReceipt,
+    candidate_id: str,
+) -> ModelBenchmarkEvidenceReceipt | None:
+    matches = [
+        evidence for evidence in benchmark_run_receipt.benchmark_evidence_receipts if evidence.model_id == candidate_id
+    ]
+    if len(matches) != 1:
+        return None
+    return matches[0]
+
+
+def _evidence_rejections(
+    benchmark_run_receipt: ModelCombinationBenchmarkRunReceipt,
+    policy: ModelPromotionPolicy,
+    evidence: ModelBenchmarkEvidenceReceipt | None,
+) -> list[str]:
+    reasons: list[str] = []
+    if evidence is None:
+        return ["benchmark_evidence_missing_or_ambiguous"]
+    if benchmark_run_receipt.task_family != policy.task_family:
+        reasons.append("task_family_mismatch")
+    if benchmark_run_receipt.task_set_digest != policy.required_task_set_digest:
+        reasons.append("task_set_digest_mismatch")
+    if benchmark_run_receipt.held_out_split_digest != policy.required_held_out_split_digest:
+        reasons.append("held_out_split_digest_mismatch")
+    if benchmark_run_receipt.verifier_digest != policy.required_verifier_digest:
+        reasons.append("verifier_digest_mismatch")
+    if evidence.task_family != policy.task_family:
+        reasons.append("evidence_task_family_mismatch")
+    if evidence.task_set_digest != benchmark_run_receipt.task_set_digest:
+        reasons.append("evidence_task_set_digest_mismatch")
+    if evidence.held_out_split_digest != benchmark_run_receipt.held_out_split_digest:
+        reasons.append("evidence_held_out_split_digest_mismatch")
+    if evidence.verifier_digest != benchmark_run_receipt.verifier_digest:
+        reasons.append("evidence_verifier_digest_mismatch")
+    if evidence.sample_count < policy.min_sample_count:
+        reasons.append("sample_count_below_policy")
+    if policy.max_latency_ms is not None and evidence.metrics.latency_ms is not None:
+        if evidence.metrics.latency_ms > policy.max_latency_ms:
+            reasons.append("latency_above_policy")
+    if policy.max_cost_estimate_usd is not None and evidence.metrics.cost_estimate_usd is not None:
+        if evidence.metrics.cost_estimate_usd > policy.max_cost_estimate_usd:
+            reasons.append("cost_above_policy")
+    return reasons
+
+
+def _benchmark_run_projection(receipt: ModelCombinationBenchmarkRunReceipt) -> dict[str, Any]:
+    return {
+        "schema_version": receipt.schema_version,
+        "task_family": receipt.task_family,
+        "task_set_digest": receipt.task_set_digest,
+        "held_out_split_digest": receipt.held_out_split_digest,
+        "verifier_digest": receipt.verifier_digest,
+        "candidates": [candidate.to_dict() for candidate in receipt.candidates],
+        "benchmark_evidence_receipts": [
+            evidence.to_dict() for evidence in receipt.benchmark_evidence_receipts
+        ],
+    }
+
+
+def _required(name: str, value: Any) -> str:
+    cleaned = str(value).strip()
+    if not cleaned:
+        raise ValueError(f"missing_{name}")
+    return cleaned
+
+
+def _threshold(value: float) -> float:
+    parsed = float(value)
+    if parsed <= 0 or parsed > 1:
+        raise ValueError("invalid_verifier_threshold")
+    return parsed
+
+
+def _positive_int(value: int, name: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise ValueError(f"invalid_{name}")
+    return parsed
+
+
+def _positive_int_or_none(value: int | None, name: str) -> int | None:
+    if value is None:
+        return None
+    return _positive_int(value, name)
+
+
+def _positive_float_or_none(value: float | None, name: str) -> float | None:
+    if value is None:
+        return None
+    parsed = float(value)
+    if parsed <= 0:
+        raise ValueError(f"invalid_{name}")
+    return parsed
+
+
+def _clean_token(value: Any) -> str:
+    return str(value).strip().lower().replace(" ", "_")
+
+
+def _digest_prefixed(prefix: str, value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return f"{prefix}:{hashlib.sha256(encoded).hexdigest()}"

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_promotion_gate.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_promotion_gate.py
@@ -1,0 +1,277 @@
+"""Tests for model champion/challenger promotion gate."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import replace
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_combination_benchmark_harness import (
+    ModelBenchmarkRoleAssignment,
+    ModelBenchmarkTask,
+    ModelBenchmarkTaskOutput,
+    ModelBenchmarkVerifierResult,
+    build_model_benchmark_candidate,
+    run_model_combination_benchmark,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import (
+    ModelOutcomeMetrics,
+    VerifierDecision,
+)
+from modules.ai_intelligence.ai_gateway.src.model_promotion_gate import (
+    ModelPromotionGateDecision,
+    ModelPromotionPolicy,
+    evaluate_model_promotion_gate,
+)
+
+
+def _tasks():
+    return (
+        ModelBenchmarkTask(
+            task_id="task-001",
+            task_family="architecture",
+            prompt_digest="sha256:prompt-a",
+            expected_output_digest="sha256:expected-a",
+            verifier_contract_digest="sha256:verifier-contract",
+        ),
+        ModelBenchmarkTask(
+            task_id="task-002",
+            task_family="architecture",
+            prompt_digest="sha256:prompt-b",
+            expected_output_digest="sha256:expected-b",
+            verifier_contract_digest="sha256:verifier-contract",
+        ),
+    )
+
+
+def _candidate(model_id: str = "provider/model-a"):
+    return build_model_benchmark_candidate(
+        (ModelBenchmarkRoleAssignment(role="principal", model_id=model_id, provider="provider"),)
+    )
+
+
+def _runner(task, candidate):
+    return ModelBenchmarkTaskOutput(
+        output_digest=f"sha256:output:{candidate.candidate_id}:{task.task_id}",
+        runner_receipt_id=f"runner:{candidate.candidate_id}:{task.task_id}",
+        metrics=ModelOutcomeMetrics(latency_ms=100, input_tokens=10, output_tokens=5, cost_estimate_usd=0.01),
+    )
+
+
+def _accepting_verifier(task, candidate, output):
+    return ModelBenchmarkVerifierResult(
+        decision=VerifierDecision.ACCEPT,
+        verifier_receipt_id=f"verify:{candidate.candidate_id}:{task.task_id}",
+        evidence_correct=True,
+    )
+
+
+def _rejecting_verifier(task, candidate, output):
+    if task.task_id == "task-001":
+        return _accepting_verifier(task, candidate, output)
+    return ModelBenchmarkVerifierResult(
+        decision=VerifierDecision.REJECT,
+        verifier_receipt_id=f"verify:{candidate.candidate_id}:{task.task_id}",
+        evidence_correct=False,
+        rejection_reasons=("bad_claim",),
+    )
+
+
+def _benchmark(verifier=_accepting_verifier):
+    return run_model_combination_benchmark(
+        tasks=_tasks(),
+        candidates=(_candidate(),),
+        runner=_runner,
+        verifier=verifier,
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+    )
+
+
+def _policy(run):
+    return ModelPromotionPolicy(
+        task_family="architecture",
+        candidate_id="provider/model-a",
+        min_verifier_pass_rate=0.9,
+        min_sample_count=2,
+        required_task_set_digest=run.task_set_digest,
+        required_held_out_split_digest=run.held_out_split_digest,
+        required_verifier_digest=run.verifier_digest,
+        max_latency_ms=200,
+        max_cost_estimate_usd=1.0,
+    )
+
+
+def test_gate_promotes_champion_only_with_signed_authority_and_matching_benchmark():
+    run = _benchmark()
+    receipt = evaluate_model_promotion_gate(
+        benchmark_run_receipt=run,
+        policy=_policy(run),
+        promotion_authority_receipt_id="authority:1",
+        signed_promotion_receipt_id="signed:1",
+    )
+
+    assert receipt.decision == ModelPromotionGateDecision.PROMOTE_CHAMPION
+    assert receipt.rejection_reasons == ()
+    assert receipt.promotion_evidence_receipt is not None
+    assert receipt.promotion_evidence_receipt.model_id == "provider/model-a"
+    assert receipt.promotion_evidence_receipt.signed_promotion_receipt_id == "signed:1"
+    assert receipt.receipt_id.startswith("model_promotion_gate:")
+
+
+def test_gate_rejects_champion_when_signed_authority_is_missing():
+    run = _benchmark()
+
+    receipt = evaluate_model_promotion_gate(
+        benchmark_run_receipt=run,
+        policy=_policy(run),
+        promotion_authority_receipt_id="authority:1",
+    )
+
+    assert receipt.decision == ModelPromotionGateDecision.REJECT
+    assert receipt.promotion_evidence_receipt is None
+    assert receipt.rejection_reasons == ("missing_signed_promotion_receipt",)
+
+
+def test_gate_keeps_challenger_when_benchmark_is_below_threshold():
+    run = _benchmark(verifier=_rejecting_verifier)
+
+    receipt = evaluate_model_promotion_gate(
+        benchmark_run_receipt=run,
+        policy=_policy(run),
+        promotion_authority_receipt_id="authority:1",
+        signed_promotion_receipt_id="signed:1",
+    )
+
+    assert receipt.decision == ModelPromotionGateDecision.KEEP_CHALLENGER
+    assert receipt.promotion_evidence_receipt is None
+    assert receipt.rejection_reasons == ("verifier_pass_rate_below_champion_threshold",)
+
+
+def test_gate_rejects_missing_or_wrong_candidate_evidence():
+    run = _benchmark()
+    policy = ModelPromotionPolicy(
+        task_family="architecture",
+        candidate_id="provider/missing",
+        min_verifier_pass_rate=0.9,
+        min_sample_count=2,
+        required_task_set_digest=run.task_set_digest,
+        required_held_out_split_digest=run.held_out_split_digest,
+        required_verifier_digest=run.verifier_digest,
+    )
+
+    receipt = evaluate_model_promotion_gate(
+        benchmark_run_receipt=run,
+        policy=policy,
+        promotion_authority_receipt_id="authority:1",
+        signed_promotion_receipt_id="signed:1",
+    )
+
+    assert receipt.decision == ModelPromotionGateDecision.REJECT
+    assert receipt.rejection_reasons == ("benchmark_evidence_missing_or_ambiguous",)
+
+
+def test_gate_rejects_tampered_benchmark_projection():
+    run = _benchmark()
+    evidence = replace(run.benchmark_evidence_receipts[0], held_out_split_digest="held_out_split:tampered")
+    tampered = replace(run, benchmark_evidence_receipts=(evidence,))
+
+    receipt = evaluate_model_promotion_gate(
+        benchmark_run_receipt=tampered,
+        policy=_policy(run),
+        promotion_authority_receipt_id="authority:1",
+        signed_promotion_receipt_id="signed:1",
+    )
+
+    assert receipt.decision == ModelPromotionGateDecision.REJECT
+    assert "evidence_held_out_split_digest_mismatch" in receipt.rejection_reasons
+
+
+def test_gate_rejects_policy_digest_and_metric_conflicts():
+    run = _benchmark()
+    bad_policy = replace(
+        _policy(run),
+        required_task_set_digest="model_benchmark_task_set:wrong",
+        max_latency_ms=50,
+    )
+
+    receipt = evaluate_model_promotion_gate(
+        benchmark_run_receipt=run,
+        policy=bad_policy,
+        promotion_authority_receipt_id="authority:1",
+        signed_promotion_receipt_id="signed:1",
+    )
+
+    assert receipt.decision == ModelPromotionGateDecision.REJECT
+    assert "task_set_digest_mismatch" in receipt.rejection_reasons
+    assert "latency_above_policy" in receipt.rejection_reasons
+
+
+def test_gate_policy_requires_nonzero_threshold_and_sample_count():
+    run = _benchmark()
+    for kwargs, expected in (
+        ({"min_verifier_pass_rate": 0.0}, "invalid_verifier_threshold"),
+        ({"min_sample_count": 0}, "invalid_min_sample_count"),
+    ):
+        data = {
+            "task_family": "architecture",
+            "candidate_id": "provider/model-a",
+            "min_verifier_pass_rate": 0.9,
+            "min_sample_count": 2,
+            "required_task_set_digest": run.task_set_digest,
+            "required_held_out_split_digest": run.held_out_split_digest,
+            "required_verifier_digest": run.verifier_digest,
+        }
+        data.update(kwargs)
+        try:
+            ModelPromotionPolicy(**data).normalized()
+        except ValueError as exc:
+            assert str(exc) == expected
+        else:
+            raise AssertionError(f"expected {expected}")
+
+
+def test_gate_digest_is_stable_and_binds_signed_receipt():
+    run = _benchmark()
+    first = evaluate_model_promotion_gate(
+        benchmark_run_receipt=run,
+        policy=_policy(run),
+        promotion_authority_receipt_id="authority:1",
+        signed_promotion_receipt_id="signed:1",
+    )
+    second = evaluate_model_promotion_gate(
+        benchmark_run_receipt=run,
+        policy=_policy(run),
+        promotion_authority_receipt_id="authority:1",
+        signed_promotion_receipt_id="signed:1",
+    )
+    changed = evaluate_model_promotion_gate(
+        benchmark_run_receipt=run,
+        policy=_policy(run),
+        promotion_authority_receipt_id="authority:1",
+        signed_promotion_receipt_id="signed:2",
+    )
+
+    assert first.receipt_id == second.receipt_id
+    assert first.receipt_id != changed.receipt_id
+
+
+def test_promotion_gate_module_has_no_network_command_or_runtime_binding_imports():
+    source = Path("modules/ai_intelligence/ai_gateway/src/model_promotion_gate.py").read_text()
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            assert not (
+                isinstance(node.func.value, ast.Name)
+                and node.func.value.id in {"os", "subprocess", "requests", "urllib", "openai"}
+            )
+
+    assert "subprocess" not in imported
+    assert "requests" not in imported
+    assert "urllib" not in imported
+    assert "openai" not in imported


### PR DESCRIPTION
## Summary

Implements `MODEL_CHAMPION_CHALLENGER_PROMOTION_GATE_PHASE1`.

This adds a fail-closed promotion gate over model benchmark evidence. The gate validates a `ModelCombinationBenchmarkRunReceipt` against an explicit `ModelPromotionPolicy`, keeps below-threshold candidates as challengers, and only emits `ModelPromotionEvidenceReceipt` when matching benchmark evidence and signed promotion authority are both present.

## Truth Boundary

- IMPLEMENTED: matching benchmark evidence plus signed authority can produce a promotion evidence receipt.
- IMPLEMENTED: below-threshold candidates remain challengers without champion authority.
- IMPLEMENTED: tampered or mismatched benchmark evidence fails closed.
- NOT IMPLEMENTED: model catalog mutation, champion ledger persistence, AutoResearch scheduling, provider calls, PatternMemory writes, or RedDog dynamic runtime binding.

## Validation

- `python -m pytest modules/ai_intelligence/ai_gateway/tests -q` -> 43 passed
- `python -m py_compile modules/ai_intelligence/ai_gateway/src/model_intelligence_catalog.py modules/ai_intelligence/ai_gateway/src/model_intelligence_selection.py modules/ai_intelligence/ai_gateway/src/model_intelligence_outcomes.py modules/ai_intelligence/ai_gateway/src/model_combination_benchmark_harness.py modules/ai_intelligence/ai_gateway/src/model_promotion_gate.py` -> pass
- `git diff --check` -> pass (autocrlf warnings only)
- Added-line ASCII scan -> `added_line_non_ascii=0`

Worker-Lane: reddog-model-intelligence
Slice: MODEL_CHAMPION_CHALLENGER_PROMOTION_GATE_PHASE1
