### PR TITLE
feat(ai-gateway): add champion challenger autoresearch planner

### DIFF
--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -136,6 +136,22 @@ benchmark projections return `REJECT`.
 This API does not mutate model catalogs, write champion ledgers, call providers,
 or bind runtime RedDog model defaults.
 
+#### Champion/Challenger AutoResearch Planner
+
+```python
+plan_model_champion_challenger_autoresearch(...) -> ModelAutoResearchPlanReceipt
+```
+
+The planner consumes promotion-gate receipts, a candidate pool, and
+`ModelAutoResearchPolicy`. It emits a digest-bound plan containing
+`BENCHMARK_NEW_CANDIDATE`, `REBENCHMARK_CHALLENGER`, or `STOP` items.
+
+The policy binds task family, catalog snapshot ID, maximum campaign items,
+optional verifier digest, and a required cost-budget receipt. Missing source gate
+receipts, verifier mismatch, or missing budget evidence fails closed. The planner
+does not execute benchmarks, call providers, write PatternMemory, mutate
+catalogs, or bind runtime defaults.
+
 ## Configuration
 
 ### Environment Variables

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,41 @@
 # AI Gateway Module Change Log
 
+## [2026-07-16] - Champion/Challenger AutoResearch Planner
+
+**Who:** 0102 Codex
+**Type:** Runtime Foundation
+**Slice:** MODEL_CHAMPION_CHALLENGER_AUTORESEARCH_PHASE1
+
+**What:** Added a receipt-bound AutoResearch campaign planner for model
+champion/challenger evaluation.
+
+**Why:** After benchmark harness and promotion gate receipts exist, RedDog needs
+a governed way to decide which model or panel candidates should be benchmarked
+next without running providers, writing PatternMemory, or installing runtime
+defaults.
+
+**Files:**
+- `src/model_champion_challenger_autoresearch.py` - AutoResearch policy, campaign
+  items, plan receipts, gate/candidate binding, and fail-closed budget/verifier
+  checks.
+- `tests/test_model_champion_challenger_autoresearch.py` - new-candidate,
+  challenger-retest, stop, missing gate/budget, verifier mismatch, cap,
+  deterministic digest, and no-network/no-command tests.
+- `README.md` and `INTERFACE.md` - API and truth-boundary notes.
+
+**Truth Boundary:**
+- IMPLEMENTED: promotion-gate receipts can produce a deterministic benchmark
+  campaign plan.
+- IMPLEMENTED: untested candidates and challengers are routed separately.
+- IMPLEMENTED: missing gate receipts, verifier mismatch, and missing cost budget
+  fail closed.
+- NOT IMPLEMENTED: campaign execution, provider calls, PatternMemory writes,
+  champion ledger writes, AutoResearch git mutation, or RedDog runtime binding.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-16] - Champion/Challenger Promotion Gate
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -70,6 +70,17 @@ The gate does not mutate the catalog, write a champion ledger, call providers,
 or bind RedDog runtime defaults. Below-threshold candidates remain challengers;
 tampered or mismatched evidence fails closed.
 
+## Champion/Challenger AutoResearch Planner
+
+`src/model_champion_challenger_autoresearch.py` converts promotion-gate receipts
+and candidate pools into a digest-bound benchmark campaign plan. It can propose
+benchmarking untested candidates or rebenchmarking challengers, but it does not
+execute those campaigns.
+
+The planner requires source promotion-gate receipts and a cost-budget receipt.
+It does not call providers, run benchmarks, mutate catalogs, write
+PatternMemory, or bind RedDog runtime defaults.
+
 **Usage Examples**:
 ```python
 from modules.ai_intelligence.ai_gateway import AIGateway

--- a/modules/ai_intelligence/ai_gateway/src/model_champion_challenger_autoresearch.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_champion_challenger_autoresearch.py
@@ -1,0 +1,247 @@
+"""AutoResearch campaign planner for champion/challenger model intelligence.
+
+This module plans benchmark campaigns from promotion-gate receipts. It does not
+run benchmarks, call providers, mutate model catalogs, write PatternMemory, or
+bind RedDog runtime defaults.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+from .model_combination_benchmark_harness import ModelBenchmarkCandidate
+from .model_promotion_gate import ModelPromotionGateDecision, ModelPromotionGateReceipt
+
+
+AUTORESEARCH_SCHEMA_VERSION = "model_champion_challenger_autoresearch_plan.v1"
+AUTORESEARCH_POLICY_SCHEMA_VERSION = "model_autoresearch_policy.v1"
+
+
+class ModelAutoResearchAction(str, Enum):
+    """Action proposed by the model AutoResearch planner."""
+
+    BENCHMARK_NEW_CANDIDATE = "benchmark_new_candidate"
+    REBENCHMARK_CHALLENGER = "rebenchmark_challenger"
+    STOP = "stop"
+
+
+@dataclass(frozen=True)
+class ModelAutoResearchPolicy:
+    """Policy for selecting the next model benchmark campaigns."""
+
+    task_family: str
+    catalog_snapshot_id: str
+    max_campaign_items: int = 3
+    rebenchmark_challengers: bool = True
+    required_verifier_digest: str | None = None
+    cost_budget_receipt_id: str | None = None
+    schema_version: str = AUTORESEARCH_POLICY_SCHEMA_VERSION
+
+    def normalized(self) -> "ModelAutoResearchPolicy":
+        return ModelAutoResearchPolicy(
+            task_family=_clean_token(_required("task_family", self.task_family)),
+            catalog_snapshot_id=_required("catalog_snapshot_id", self.catalog_snapshot_id),
+            max_campaign_items=max(1, min(int(self.max_campaign_items), 10)),
+            rebenchmark_challengers=bool(self.rebenchmark_challengers),
+            required_verifier_digest=_optional(self.required_verifier_digest),
+            cost_budget_receipt_id=_optional(self.cost_budget_receipt_id),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        policy = self.normalized()
+        return {
+            "schema_version": policy.schema_version,
+            "task_family": policy.task_family,
+            "catalog_snapshot_id": policy.catalog_snapshot_id,
+            "max_campaign_items": policy.max_campaign_items,
+            "rebenchmark_challengers": policy.rebenchmark_challengers,
+            "required_verifier_digest": policy.required_verifier_digest,
+            "cost_budget_receipt_id": policy.cost_budget_receipt_id,
+        }
+
+
+@dataclass(frozen=True)
+class ModelAutoResearchCampaignItem:
+    """One proposed benchmark campaign item."""
+
+    candidate_id: str
+    action: ModelAutoResearchAction
+    priority: str
+    reason: str
+    source_gate_receipt_id: str | None = None
+    requires_independent_verifier: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "candidate_id": self.candidate_id,
+            "action": self.action.value,
+            "priority": self.priority,
+            "reason": self.reason,
+            "source_gate_receipt_id": self.source_gate_receipt_id,
+            "requires_independent_verifier": self.requires_independent_verifier,
+        }
+
+
+@dataclass(frozen=True)
+class ModelAutoResearchPlanReceipt:
+    """Digest-bound campaign plan for model AutoResearch."""
+
+    receipt_id: str
+    policy: ModelAutoResearchPolicy
+    source_gate_receipt_ids: tuple[str, ...]
+    candidate_pool_digest: str
+    campaign_items: tuple[ModelAutoResearchCampaignItem, ...]
+    rejection_reasons: tuple[str, ...] = ()
+    schema_version: str = AUTORESEARCH_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "receipt_id": self.receipt_id,
+            "policy": self.policy.to_dict(),
+            "source_gate_receipt_ids": list(self.source_gate_receipt_ids),
+            "candidate_pool_digest": self.candidate_pool_digest,
+            "campaign_items": [item.to_dict() for item in self.campaign_items],
+            "rejection_reasons": list(self.rejection_reasons),
+        }
+
+
+def plan_model_champion_challenger_autoresearch(
+    *,
+    promotion_gate_receipts: Sequence[ModelPromotionGateReceipt],
+    candidate_pool: Sequence[ModelBenchmarkCandidate],
+    policy: ModelAutoResearchPolicy,
+) -> ModelAutoResearchPlanReceipt:
+    """Plan the next benchmark campaigns from gate receipts and candidates."""
+
+    normalized_policy = policy.normalized()
+    normalized_candidates = _normalize_candidates(candidate_pool)
+    normalized_gates = _normalize_gate_receipts(promotion_gate_receipts, normalized_policy.task_family)
+    candidate_pool_digest = _digest_prefixed(
+        "model_autoresearch_candidate_pool",
+        {"candidates": [candidate.to_dict() for candidate in normalized_candidates]},
+    )
+    source_gate_ids = tuple(sorted(receipt.receipt_id for receipt in normalized_gates))
+    rejection_reasons = _policy_rejections(normalized_policy, normalized_gates)
+    campaign_items: list[ModelAutoResearchCampaignItem] = []
+    seen_gate_candidate_ids = {receipt.candidate_id for receipt in normalized_gates}
+
+    if not rejection_reasons:
+        for receipt in normalized_gates:
+            if (
+                receipt.decision == ModelPromotionGateDecision.KEEP_CHALLENGER
+                and normalized_policy.rebenchmark_challengers
+            ):
+                campaign_items.append(
+                    ModelAutoResearchCampaignItem(
+                        candidate_id=receipt.candidate_id,
+                        action=ModelAutoResearchAction.REBENCHMARK_CHALLENGER,
+                        priority="P2",
+                        reason="challenger_below_champion_threshold",
+                        source_gate_receipt_id=receipt.receipt_id,
+                    )
+                )
+        for candidate in normalized_candidates:
+            if candidate.candidate_id in seen_gate_candidate_ids:
+                continue
+            campaign_items.append(
+                ModelAutoResearchCampaignItem(
+                    candidate_id=candidate.candidate_id,
+                    action=ModelAutoResearchAction.BENCHMARK_NEW_CANDIDATE,
+                    priority="P1",
+                    reason="candidate_not_yet_benchmarked",
+                )
+            )
+        campaign_items = campaign_items[: normalized_policy.max_campaign_items]
+        if not campaign_items:
+            campaign_items.append(
+                ModelAutoResearchCampaignItem(
+                    candidate_id="none",
+                    action=ModelAutoResearchAction.STOP,
+                    priority="P3",
+                    reason="no_unbenchmarked_or_rebenchmarkable_candidates",
+                    requires_independent_verifier=False,
+                )
+            )
+    body = {
+        "schema_version": AUTORESEARCH_SCHEMA_VERSION,
+        "policy": normalized_policy.to_dict(),
+        "source_gate_receipt_ids": list(source_gate_ids),
+        "candidate_pool_digest": candidate_pool_digest,
+        "campaign_items": [item.to_dict() for item in campaign_items],
+        "rejection_reasons": sorted(set(rejection_reasons)),
+    }
+    return ModelAutoResearchPlanReceipt(
+        receipt_id=_digest_prefixed("model_autoresearch_plan", body),
+        policy=normalized_policy,
+        source_gate_receipt_ids=source_gate_ids,
+        candidate_pool_digest=candidate_pool_digest,
+        campaign_items=tuple(campaign_items),
+        rejection_reasons=tuple(sorted(set(rejection_reasons))),
+    )
+
+
+def _normalize_candidates(candidates: Sequence[ModelBenchmarkCandidate]) -> tuple[ModelBenchmarkCandidate, ...]:
+    normalized = tuple(candidates)
+    candidate_ids = [candidate.candidate_id for candidate in normalized]
+    if len(set(candidate_ids)) != len(candidate_ids):
+        raise ValueError("duplicate_autoresearch_candidates")
+    return tuple(sorted(normalized, key=lambda candidate: candidate.candidate_id))
+
+
+def _normalize_gate_receipts(
+    receipts: Sequence[ModelPromotionGateReceipt],
+    task_family: str,
+) -> tuple[ModelPromotionGateReceipt, ...]:
+    normalized = tuple(receipts)
+    receipt_ids = [receipt.receipt_id for receipt in normalized]
+    if len(set(receipt_ids)) != len(receipt_ids):
+        raise ValueError("duplicate_promotion_gate_receipts")
+    if any(receipt.task_family != task_family for receipt in normalized):
+        raise ValueError("promotion_gate_task_family_mismatch")
+    return tuple(sorted(normalized, key=lambda receipt: receipt.receipt_id))
+
+
+def _policy_rejections(
+    policy: ModelAutoResearchPolicy,
+    gate_receipts: tuple[ModelPromotionGateReceipt, ...],
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if not gate_receipts:
+        reasons.append("missing_promotion_gate_receipts")
+    if policy.required_verifier_digest:
+        for receipt in gate_receipts:
+            gate_verifier = receipt.policy.required_verifier_digest
+            if gate_verifier != policy.required_verifier_digest:
+                reasons.append("verifier_digest_mismatch")
+                break
+    if policy.cost_budget_receipt_id is None:
+        reasons.append("missing_cost_budget_receipt")
+    return tuple(sorted(set(reasons)))
+
+
+def _required(name: str, value: Any) -> str:
+    cleaned = str(value).strip()
+    if not cleaned:
+        raise ValueError(f"missing_{name}")
+    return cleaned
+
+
+def _optional(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = str(value).strip()
+    return cleaned or None
+
+
+def _clean_token(value: Any) -> str:
+    return str(value).strip().lower().replace(" ", "_")
+
+
+def _digest_prefixed(prefix: str, value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return f"{prefix}:{hashlib.sha256(encoded).hexdigest()}"

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_champion_challenger_autoresearch.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_champion_challenger_autoresearch.py
@@ -1,0 +1,261 @@
+"""Tests for model champion/challenger AutoResearch campaign planner."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_champion_challenger_autoresearch import (
+    ModelAutoResearchAction,
+    ModelAutoResearchPolicy,
+    plan_model_champion_challenger_autoresearch,
+)
+from modules.ai_intelligence.ai_gateway.src.model_combination_benchmark_harness import (
+    ModelBenchmarkRoleAssignment,
+    ModelBenchmarkTask,
+    ModelBenchmarkTaskOutput,
+    ModelBenchmarkVerifierResult,
+    build_model_benchmark_candidate,
+    run_model_combination_benchmark,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import (
+    ModelOutcomeMetrics,
+    VerifierDecision,
+)
+from modules.ai_intelligence.ai_gateway.src.model_promotion_gate import (
+    ModelPromotionGateDecision,
+    ModelPromotionPolicy,
+    evaluate_model_promotion_gate,
+)
+
+
+def _candidate(model_id: str):
+    return build_model_benchmark_candidate(
+        (ModelBenchmarkRoleAssignment(role="principal", model_id=model_id, provider="provider"),)
+    )
+
+
+def _tasks():
+    return (
+        ModelBenchmarkTask(
+            task_id="task-001",
+            task_family="architecture",
+            prompt_digest="sha256:prompt-a",
+            expected_output_digest="sha256:expected-a",
+            verifier_contract_digest="sha256:verifier-contract",
+        ),
+        ModelBenchmarkTask(
+            task_id="task-002",
+            task_family="architecture",
+            prompt_digest="sha256:prompt-b",
+            expected_output_digest="sha256:expected-b",
+            verifier_contract_digest="sha256:verifier-contract",
+        ),
+    )
+
+
+def _runner(task, candidate):
+    return ModelBenchmarkTaskOutput(
+        output_digest=f"sha256:output:{candidate.candidate_id}:{task.task_id}",
+        runner_receipt_id=f"runner:{candidate.candidate_id}:{task.task_id}",
+        metrics=ModelOutcomeMetrics(latency_ms=100, input_tokens=10, output_tokens=5, cost_estimate_usd=0.01),
+    )
+
+
+def _verifier(pass_all: bool):
+    def verifier(task, candidate, output):
+        if pass_all or task.task_id == "task-001":
+            return ModelBenchmarkVerifierResult(
+                decision=VerifierDecision.ACCEPT,
+                verifier_receipt_id=f"verify:{candidate.candidate_id}:{task.task_id}",
+                evidence_correct=True,
+            )
+        return ModelBenchmarkVerifierResult(
+            decision=VerifierDecision.REJECT,
+            verifier_receipt_id=f"verify:{candidate.candidate_id}:{task.task_id}",
+            evidence_correct=False,
+            rejection_reasons=("bad_claim",),
+        )
+
+    return verifier
+
+
+def _gate(candidate_id: str, *, pass_all: bool):
+    candidate = _candidate(candidate_id)
+    run = run_model_combination_benchmark(
+        tasks=_tasks(),
+        candidates=(candidate,),
+        runner=_runner,
+        verifier=_verifier(pass_all),
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+    )
+    policy = ModelPromotionPolicy(
+        task_family="architecture",
+        candidate_id=candidate_id,
+        min_verifier_pass_rate=0.9,
+        min_sample_count=2,
+        required_task_set_digest=run.task_set_digest,
+        required_held_out_split_digest=run.held_out_split_digest,
+        required_verifier_digest=run.verifier_digest,
+    )
+    return evaluate_model_promotion_gate(
+        benchmark_run_receipt=run,
+        policy=policy,
+        promotion_authority_receipt_id="authority:1",
+        signed_promotion_receipt_id="signed:1",
+    )
+
+
+def _policy():
+    return ModelAutoResearchPolicy(
+        task_family="architecture",
+        catalog_snapshot_id="model_catalog_snapshot:1",
+        max_campaign_items=3,
+        required_verifier_digest="sha256:verifier",
+        cost_budget_receipt_id="cost_budget:1",
+    )
+
+
+def test_autoresearch_plans_new_candidate_and_rebenchmark_challenger():
+    champion_gate = _gate("provider/champion", pass_all=True)
+    challenger_gate = _gate("provider/challenger", pass_all=False)
+    new_candidate = _candidate("provider/new")
+
+    receipt = plan_model_champion_challenger_autoresearch(
+        promotion_gate_receipts=(champion_gate, challenger_gate),
+        candidate_pool=(_candidate("provider/champion"), _candidate("provider/challenger"), new_candidate),
+        policy=_policy(),
+    )
+
+    assert champion_gate.decision == ModelPromotionGateDecision.PROMOTE_CHAMPION
+    assert receipt.rejection_reasons == ()
+    assert receipt.receipt_id.startswith("model_autoresearch_plan:")
+    assert [item.action for item in receipt.campaign_items] == [
+        ModelAutoResearchAction.REBENCHMARK_CHALLENGER,
+        ModelAutoResearchAction.BENCHMARK_NEW_CANDIDATE,
+    ]
+    assert [item.candidate_id for item in receipt.campaign_items] == [
+        "provider/challenger",
+        "provider/new",
+    ]
+    assert all(item.requires_independent_verifier for item in receipt.campaign_items)
+
+
+def test_autoresearch_stops_when_no_candidates_need_work():
+    champion_gate = _gate("provider/champion", pass_all=True)
+
+    receipt = plan_model_champion_challenger_autoresearch(
+        promotion_gate_receipts=(champion_gate,),
+        candidate_pool=(_candidate("provider/champion"),),
+        policy=_policy(),
+    )
+
+    assert receipt.rejection_reasons == ()
+    assert len(receipt.campaign_items) == 1
+    assert receipt.campaign_items[0].action == ModelAutoResearchAction.STOP
+    assert receipt.campaign_items[0].requires_independent_verifier is False
+
+
+def test_autoresearch_requires_gate_receipts_and_cost_budget():
+    receipt = plan_model_champion_challenger_autoresearch(
+        promotion_gate_receipts=(),
+        candidate_pool=(_candidate("provider/new"),),
+        policy=ModelAutoResearchPolicy(
+            task_family="architecture",
+            catalog_snapshot_id="model_catalog_snapshot:1",
+            required_verifier_digest="sha256:verifier",
+        ),
+    )
+
+    assert receipt.campaign_items == ()
+    assert receipt.rejection_reasons == (
+        "missing_cost_budget_receipt",
+        "missing_promotion_gate_receipts",
+    )
+
+
+def test_autoresearch_rejects_verifier_digest_mismatch():
+    champion_gate = _gate("provider/champion", pass_all=True)
+
+    receipt = plan_model_champion_challenger_autoresearch(
+        promotion_gate_receipts=(champion_gate,),
+        candidate_pool=(_candidate("provider/new"),),
+        policy=ModelAutoResearchPolicy(
+            task_family="architecture",
+            catalog_snapshot_id="model_catalog_snapshot:1",
+            required_verifier_digest="sha256:wrong",
+            cost_budget_receipt_id="cost_budget:1",
+        ),
+    )
+
+    assert receipt.campaign_items == ()
+    assert receipt.rejection_reasons == ("verifier_digest_mismatch",)
+
+
+def test_autoresearch_max_campaign_items_caps_output():
+    challenger = _gate("provider/challenger", pass_all=False)
+    receipt = plan_model_champion_challenger_autoresearch(
+        promotion_gate_receipts=(challenger,),
+        candidate_pool=(
+            _candidate("provider/a"),
+            _candidate("provider/b"),
+            _candidate("provider/c"),
+            _candidate("provider/challenger"),
+        ),
+        policy=ModelAutoResearchPolicy(
+            task_family="architecture",
+            catalog_snapshot_id="model_catalog_snapshot:1",
+            max_campaign_items=2,
+            required_verifier_digest="sha256:verifier",
+            cost_budget_receipt_id="cost_budget:1",
+        ),
+    )
+
+    assert len(receipt.campaign_items) == 2
+    assert receipt.campaign_items[0].action == ModelAutoResearchAction.REBENCHMARK_CHALLENGER
+
+
+def test_autoresearch_digest_is_stable_and_binds_candidate_pool():
+    champion_gate = _gate("provider/champion", pass_all=True)
+    first = plan_model_champion_challenger_autoresearch(
+        promotion_gate_receipts=(champion_gate,),
+        candidate_pool=(_candidate("provider/new"),),
+        policy=_policy(),
+    )
+    second = plan_model_champion_challenger_autoresearch(
+        promotion_gate_receipts=(champion_gate,),
+        candidate_pool=(_candidate("provider/new"),),
+        policy=_policy(),
+    )
+    changed = plan_model_champion_challenger_autoresearch(
+        promotion_gate_receipts=(champion_gate,),
+        candidate_pool=(_candidate("provider/other"),),
+        policy=_policy(),
+    )
+
+    assert first.receipt_id == second.receipt_id
+    assert first.receipt_id != changed.receipt_id
+
+
+def test_autoresearch_module_has_no_network_command_or_pattern_memory_imports():
+    source = Path(
+        "modules/ai_intelligence/ai_gateway/src/model_champion_challenger_autoresearch.py"
+    ).read_text()
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            assert not (
+                isinstance(node.func.value, ast.Name)
+                and node.func.value.id in {"os", "subprocess", "requests", "urllib", "openai"}
+            )
+
+    assert "subprocess" not in imported
+    assert "requests" not in imported
+    assert "urllib" not in imported
+    assert "openai" not in imported


### PR DESCRIPTION
## Summary

Implements `MODEL_CHAMPION_CHALLENGER_AUTORESEARCH_PHASE1`.

This adds a receipt-bound campaign planner that consumes promotion-gate receipts and a candidate pool to decide the next benchmark work: benchmark untested candidates, rebenchmark challengers, or stop when there is no useful campaign. It requires gate evidence and a cost-budget receipt before producing campaign items.

## Truth Boundary

- IMPLEMENTED: promotion-gate receipts can produce a deterministic benchmark campaign plan.
- IMPLEMENTED: untested candidates and challengers are routed separately.
- IMPLEMENTED: missing gate receipts, verifier mismatch, and missing cost budget fail closed.
- NOT IMPLEMENTED: campaign execution, provider calls, PatternMemory writes, champion ledger writes, AutoResearch git mutation, or RedDog runtime binding.

## Validation

- `python -m pytest modules/ai_intelligence/ai_gateway/tests -q` -> 50 passed
- `python -m py_compile modules/ai_intelligence/ai_gateway/src/model_intelligence_catalog.py modules/ai_intelligence/ai_gateway/src/model_intelligence_selection.py modules/ai_intelligence/ai_gateway/src/model_intelligence_outcomes.py modules/ai_intelligence/ai_gateway/src/model_combination_benchmark_harness.py modules/ai_intelligence/ai_gateway/src/model_promotion_gate.py modules/ai_intelligence/ai_gateway/src/model_champion_challenger_autoresearch.py` -> pass
- `git diff --check` -> pass (autocrlf warnings only)
- Added-line ASCII scan -> `added_line_non_ascii=0`

Worker-Lane: reddog-model-intelligence
Slice: MODEL_CHAMPION_CHALLENGER_AUTORESEARCH_PHASE1
